### PR TITLE
fix(tooling): skip commitlint for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   commits:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Resolves #16

## Summary

Skip the commits (commitlint) job for Dependabot PRs. Dependabot uses a fixed commit format that fails commitlint (subject-case, body-max-line-length). Human-authored PRs still run commitlint.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated (N/A)
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to exclude Dependabot PRs from the commits job verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->