### PR TITLE
feat(web): configure base path /watch

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: "/watch",
   experimental: {
     typedRoutes: true
   }


### PR DESCRIPTION
## Summary

Add `basePath: "/watch"` to Next.js config so the app is served under `/watch`. Next.js automatically prefixes `Link` and `router` with the base path; `assetPrefix` not needed for default static assets.

Resolves #28

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)