### PR TITLE
chore(tooling): add start task to turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,10 @@
       "cache": false,
       "persistent": true
     },
+    "start": {
+      "cache": false,
+      "persistent": true
+    },
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
## Summary

Add `start` task to turbo.json with `cache: false` and `persistent: true` so `turbo run start` works correctly for long-running production servers.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)

Resolves #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new "start" command configuration for running the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->