### PR TITLE
fix(cms): make categoryLabel optional in MediaCollection

### DIFF
--- a/apps/cms/src/components/sections/media-collection.json
+++ b/apps/cms/src/components/sections/media-collection.json
@@ -9,7 +9,7 @@
   "attributes": {
     "categoryLabel": {
       "type": "string",
-      "required": true
+      "required": false
     },
     "variant": {
       "type": "enumeration",


### PR DESCRIPTION
Resolves #45

## Summary

Make `categoryLabel` optional in MediaCollection section component. Not all variants (e.g. hero, player) need a category label.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)