### PR TITLE
feat(android): scaffold buildable app shell with Compose startup screen

### DIFF
--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -3,3 +3,24 @@
 Native Kotlin + Jetpack Compose app. Outside Turborepo graph.
 
 Integrates via ContentClient; implement using `packages/graphql` GraphQL types.
+
+## Prerequisites
+
+- Java 17+
+- Android SDK with compileSdk 34
+
+## Build
+
+```sh
+# Debug APK
+./gradlew :app:assembleDebug
+
+# Run on connected device/emulator
+./gradlew :app:installDebug
+```
+
+## Lint
+
+```sh
+./gradlew ktlintCheck
+```

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -14,10 +14,29 @@ android {
     versionCode = 1
     versionName = "0.0.1"
   }
+
+  buildFeatures {
+    compose = true
+  }
+
+  composeOptions {
+    kotlinCompilerExtensionVersion = "1.5.14"
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
 }
 
 dependencies {
+  implementation(platform("androidx.compose:compose-bom:2024.09.02"))
   implementation("androidx.core:core-ktx:1.13.1")
   implementation("androidx.activity:activity-compose:1.9.2")
-  implementation("androidx.compose.ui:ui:1.7.2")
+  implementation("androidx.compose.ui:ui")
+  implementation("androidx.compose.material3:material3")
 }

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <application
+    android:allowBackup="false"
+    android:label="@string/app_name"
+    android:supportsRtl="true"
+    android:theme="@style/Theme.Forge">
+    <activity
+      android:name=".MainActivity"
+      android:exported="true"
+      android:theme="@style/Theme.Forge">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+
+</manifest>

--- a/mobile/android/app/src/main/kotlin/com/forge/mobile/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/com/forge/mobile/MainActivity.kt
@@ -1,0 +1,36 @@
+package com.forge.mobile
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+class MainActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      MaterialTheme {
+        Surface(
+          modifier = Modifier.fillMaxSize(),
+          color = MaterialTheme.colorScheme.background,
+        ) {
+          Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize(),
+          ) {
+            Text(
+              text = "Forge Android",
+              style = MaterialTheme.typography.headlineMedium,
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/mobile/android/app/src/main/res/values/strings.xml
+++ b/mobile/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name">Forge</string>
+</resources>

--- a/mobile/android/app/src/main/res/values/themes.xml
+++ b/mobile/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="Theme.Forge" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.application") version "8.5.2" apply false
-  id("org.jetbrains.kotlin.android") version "1.9.25" apply false
+  id("org.jetbrains.kotlin.android") version "1.9.24" apply false
   id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
 }
 

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+kotlin.code.style=official


### PR DESCRIPTION
## Summary
- Add AndroidManifest.xml, MainActivity with Material3 Compose UI, and string/theme resources
- Configure Compose compiler (BOM 2024.09.02, compiler extension 1.5.14) with JVM 17 target
- Downgrade Kotlin 1.9.25 → 1.9.24 for Compose compiler compatibility
- Document local build commands (`assembleDebug`, `installDebug`, `ktlintCheck`) in README

## Test plan
- [ ] `./gradlew :app:assembleDebug` builds successfully
- [ ] `./gradlew ktlintCheck` passes with no violations
- [ ] App launches on emulator/device showing "Forge Android" centered text

Resolves #80 (Android portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prerequisites, build instructions, and linting guidelines for Android development.

* **New Features**
  * Initialized Android application with Material Design 3 support and Jetpack Compose framework.

* **Chores**
  * Configured Java 17 compatibility and updated build system dependencies for Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->