### PR TITLE
chore(android): externalize Strapi API key (#113)

### DIFF
--- a/mobile/android/AGENTS.md
+++ b/mobile/android/AGENTS.md
@@ -2,6 +2,63 @@
 
 Scope: `mobile/android`.
 
+## Rules
+
 - Kotlin + Compose only.
-- Integrate via ContentClient adapter; Kotlin client generation deferred.
 - Keep platform-specific code isolated.
+- Operations are NOT shared with iOS — each platform owns its `.graphql` files.
+
+## Before every task
+
+1. **Fetch and rebase** — `git fetch origin && git rebase origin/main`.
+   The CMS schema (`apps/cms/schema.graphql`) changes frequently because it is
+   shared across web, Android, and iOS. Always start from the latest `main`.
+2. **Run the build** — `cd mobile/android && ./gradlew assembleDebug`.
+   This triggers Apollo codegen. If `compileDebugKotlin` fails, the generated
+   types have changed and Kotlin source files need updating.
+3. **Create your feature branch** only after the build passes on latest `main`.
+
+## Git setup in containers
+
+If `ssh` is not available but `gh` CLI is authenticated:
+
+```bash
+gh auth setup-git
+git config --global url."https://github.com/".insteadOf "git@github.com:"
+```
+
+## GraphQL / Apollo 4
+
+- Schema source: `apps/cms/schema.graphql` (read directly, not copied).
+- Generated package: `com.forge.mobile.graphql`.
+- Apollo 4 uses **composition, not inheritance** for inline fragments.
+  Access fragment fields via nullable properties on the wrapper:
+
+  ```kotlin
+  // Correct
+  section?.onComponentSectionsCta?.heading
+
+  // Wrong — no such subtype exists
+  section is ExperienceBySlugQuery.ComponentSectionsCtaSections
+  ```
+
+- When the schema adds/removes/renames fields or changes nullability, update
+  Kotlin call sites to match the regenerated types in
+  `app/build/generated/source/apollo/forge/com/forge/mobile/graphql/`.
+
+## Configuration
+
+`GRAPHQL_ENDPOINT` and `GRAPHQL_TOKEN` resolve via:
+`local.properties` → env var (`STRAPI_GRAPHQL_ENDPOINT` / `STRAPI_GRAPHQL_TOKEN`) → default.
+
+Never hardcode tokens in tracked files. See `local.properties.example`.
+
+## Common pitfalls
+
+| Issue                                     | Fix                                                                                   |
+| ----------------------------------------- | ------------------------------------------------------------------------------------- |
+| `~/.gradle` owned by root                 | `export GRADLE_USER_HOME=/tmp/.gradle` or fix ownership                               |
+| `~/.config` owned by root                 | `export XDG_CONFIG_HOME=/tmp/.config`                                                 |
+| Port 1337 already in use                  | `lsof -ti:1337 \| xargs kill` then retry                                              |
+| `gradle.properties` missing               | Must contain `android.useAndroidX=true` at minimum                                    |
+| Apollo types mismatch after schema change | Read generated types in `app/build/generated/source/apollo/` and update Kotlin source |

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -38,18 +38,68 @@ cd mobile/android
 
 ### Configuration
 
-Create `mobile/android/local.properties` (git-ignored) and add your token:
+The build resolves `GRAPHQL_ENDPOINT` and `GRAPHQL_TOKEN` using a three-tier
+fallback chain:
 
-```properties
-graphql.token=your-token-here
+1. **`local.properties`** — `graphql.endpoint` / `graphql.token` (gitignored, never committed)
+2. **Environment variables** — `STRAPI_GRAPHQL_ENDPOINT` / `STRAPI_GRAPHQL_TOKEN` (CI / containers)
+3. **Defaults** — `https://cms.forge.dev/graphql` / empty string
+
+Copy the example file to get started:
+
+```bash
+cp local.properties.example local.properties
+# then edit local.properties with your values
 ```
 
-The build reads `graphql.token` at compile time via `local.properties` so the
-token is never committed to version control. Note: it is compiled into
-`BuildConfig` and therefore exists in the APK binary — do not use a
-long-lived privileged token here; prefer a short-lived or scoped one. The
-endpoint is hardcoded to `https://cms.forge.dev/graphql`; override it in
-`app/build.gradle.kts` if needed.
+Note: the token is compiled into `BuildConfig` and therefore exists in the APK
+binary — do not use a long-lived privileged token here; prefer a short-lived
+or scoped one.
+
+## Pre-task workflow
+
+The CMS schema is shared across web, Android, and iOS and changes frequently.
+**Before starting any task**, run through these steps:
+
+```bash
+# 1. Fetch latest and rebase your branch
+git fetch origin
+git rebase origin/main
+
+# 2. Rebuild to run Apollo codegen against the latest schema
+cd mobile/android
+./gradlew assembleDebug
+
+# 3. If build fails at compileDebugKotlin, check generated types
+#    Generated types live in:
+#    app/build/generated/source/apollo/forge/com/forge/mobile/graphql/
+#
+#    Compare against Kotlin source files that reference them
+#    (e.g. GraphQLContentClient.kt) and fix mismatches.
+```
+
+### Common schema-change breakages
+
+- **Renamed/removed fields** — Apollo codegen drops them from generated classes;
+  Kotlin code referencing old names won't compile.
+- **Nullability changes** — A field changing from `String` to `String?` (or vice
+  versa) requires updating call sites with safe calls (`?.`) or removing them.
+- **New union/dynamic-zone members** — `Section` gains a new
+  `onComponentSections*` field; existing `when`/`mapNotNull` blocks may need a
+  new branch.
+
+### Apollo 4 type pattern
+
+Apollo 4 does **not** generate sealed class subtypes for inline fragments.
+Instead it generates a wrapper with nullable fields:
+
+```kotlin
+// CORRECT — use nullable field access
+section?.onComponentSectionsCta?.heading
+
+// WRONG — there is no subtype to cast to
+section is ExperienceBySlugQuery.ComponentSectionsCtaSections
+```
 
 ## Parity checklist (Android ↔ iOS)
 

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -19,8 +19,20 @@ apollo {
 val localProperties =
   Properties().apply {
     val f = rootProject.file("local.properties")
-    if (f.exists()) load(f.inputStream())
+    if (f.exists()) {
+      f.inputStream().use { load(it) }
+    }
   }
+
+val graphqlEndpoint =
+  localProperties.getProperty("graphql.endpoint")?.takeIf { it.isNotBlank() }
+    ?: System.getenv("STRAPI_GRAPHQL_ENDPOINT")?.takeIf { it.isNotBlank() }
+    ?: "https://cms.forge.dev/graphql"
+
+val graphqlToken =
+  localProperties.getProperty("graphql.token")?.takeIf { it.isNotBlank() }
+    ?: System.getenv("STRAPI_GRAPHQL_TOKEN")?.takeIf { it.isNotBlank() }
+    ?: ""
 
 android {
   namespace = "com.forge.mobile"
@@ -33,12 +45,8 @@ android {
     versionCode = 1
     versionName = "0.0.1"
 
-    buildConfigField("String", "GRAPHQL_ENDPOINT", "\"https://cms.forge.dev/graphql\"")
-    buildConfigField(
-      "String",
-      "GRAPHQL_TOKEN",
-      "\"${localProperties.getProperty("graphql.token", "")}\"",
-    )
+    buildConfigField("String", "GRAPHQL_ENDPOINT", "\"$graphqlEndpoint\"")
+    buildConfigField("String", "GRAPHQL_TOKEN", "\"$graphqlToken\"")
   }
 
   buildFeatures {

--- a/mobile/android/app/src/main/kotlin/com/forge/mobile/GraphQLContentClient.kt
+++ b/mobile/android/app/src/main/kotlin/com/forge/mobile/GraphQLContentClient.kt
@@ -43,15 +43,12 @@ class GraphQLContentClient(
     }
     val experience = experiences.firstOrNull() ?: return null
 
-    // Build a summary body from the first CTA or PromoBanner heading
+    // Build a summary body from the first CTA or PromoBanner section
     val body =
       experience.sections?.mapNotNull { section ->
-        when (section) {
-          is ExperienceBySlugQuery.ComponentSectionsCtaSections -> section.body
-          is ExperienceBySlugQuery.ComponentSectionsPromoBannerSections -> section.description
-          is ExperienceBySlugQuery.ComponentSectionsInfoBlocksSections -> section.description ?: section.heading
-          else -> null
-        }
+        section?.onComponentSectionsCta?.body
+          ?: section?.onComponentSectionsPromoBanner?.description
+          ?: section?.onComponentSectionsInfoBlocks?.let { it.description ?: it.heading }
       }?.firstOrNull() ?: ""
 
     return MobileContentItem(
@@ -60,12 +57,9 @@ class GraphQLContentClient(
       locale = experience.locale ?: locale,
       title =
         experience.sections?.mapNotNull { section ->
-          when (section) {
-            is ExperienceBySlugQuery.ComponentSectionsCtaSections -> section.heading
-            is ExperienceBySlugQuery.ComponentSectionsPromoBannerSections -> section.heading
-            is ExperienceBySlugQuery.ComponentSectionsInfoBlocksSections -> section.heading
-            else -> null
-          }
+          section?.onComponentSectionsCta?.heading
+            ?: section?.onComponentSectionsPromoBanner?.heading
+            ?: section?.onComponentSectionsInfoBlocks?.heading
         }?.firstOrNull() ?: experience.slug,
       body = body,
       state = if (experience.publishedAt != null) "published" else "draft",
@@ -80,6 +74,9 @@ class GraphQLContentClient(
     page: Int = 1,
     pageSize: Int = 25,
   ): List<MobileContentItem> {
+    require(page > 0) { "page must be >= 1" }
+    require(pageSize > 0) { "pageSize must be > 0" }
+
     val response =
       apolloClient
         .query(
@@ -94,7 +91,8 @@ class GraphQLContentClient(
       throw IllegalStateException("Experiences failed: ${errors.joinToString { it.message }}")
     }
 
-    return response.data?.experiences?.map { experience ->
+    return response.data?.experiences?.mapNotNull { experience ->
+      experience ?: return@mapNotNull null
       MobileContentItem(
         id = experience.documentId,
         slug = experience.slug,

--- a/mobile/android/local.properties.example
+++ b/mobile/android/local.properties.example
@@ -1,0 +1,4 @@
+# Strapi CMS GraphQL — copy this file to local.properties and fill in values.
+# local.properties is gitignored and must never be committed.
+graphql.endpoint=http://localhost:1337/graphql
+graphql.token=your-strapi-api-token


### PR DESCRIPTION
## Summary

- Replace hardcoded `GRAPHQL_ENDPOINT` and local-only `GRAPHQL_TOKEN` with a three-tier fallback chain: `local.properties` → env var (`STRAPI_GRAPHQL_ENDPOINT` / `STRAPI_GRAPHQL_TOKEN`) → safe default
- Fix `GraphQLContentClient.kt` to use Apollo 4 composition pattern (nullable fields on wrapper) instead of non-existent sealed subtypes
- Add pre-task workflow documentation (fetch/rebase/rebuild before every task) to README and AGENTS.md
- Create `local.properties.example` template

## Test plan

- [x] `./gradlew assembleDebug` passes with no `local.properties` values (safe defaults)
- [x] `generateDebugBuildConfig` produces correct `BuildConfig` fields
- [x] `compileDebugKotlin` passes after Apollo 4 type access fix
- [ ] Verify env var injection works in CI
- [ ] Verify `local.properties` override works locally

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apollo-based GraphQL integration with token-authenticated requests, content fetching, and paginated listings.
  * Exposed configurable GRAPHQL endpoint and token for local and CI builds.

* **Documentation**
  * Expanded Android setup with end-to-end GraphQL workflow, codegen/config guidance, pre-task checklist, common pitfalls, and parity notes vs iOS.
  * Added example local properties and environment fallback instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->