### PR TITLE
feat(secrets): integrate doppler project cms for stage/prod

### DIFF
--- a/.github/workflows/cms-secrets-sync.yml
+++ b/.github/workflows/cms-secrets-sync.yml
@@ -1,0 +1,110 @@
+name: cms-secrets-sync
+
+on:
+  push:
+    branches:
+      - stage
+      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - stage
+          - prod
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: cms-secrets-sync-${{ github.event_name == 'workflow_dispatch' && inputs.environment || (github.ref_name == 'main' && 'prod' || 'stage') }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-east-2
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || (github.ref_name == 'main' && 'prod' || 'stage') }}
+    steps:
+      - name: Determine target environment
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DEPLOY_ENV="${{ inputs.environment }}"
+          elif [ "${{ github.ref_name }}" = "main" ]; then
+            DEPLOY_ENV="prod"
+          else
+            DEPLOY_ENV="stage"
+          fi
+
+          echo "deploy_env=$DEPLOY_ENV" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        if: steps.target.outputs.deploy_env == 'stage'
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_CMS_STAGE }}
+
+      - name: Configure AWS credentials (prod)
+        if: steps.target.outputs.deploy_env == 'prod'
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_CMS_PROD }}
+
+      - name: Install Doppler CLI
+        run: curl -Ls --tlsv1.2 --proto "=https" https://cli.doppler.com/install.sh | sudo sh
+
+      - name: Sync Doppler cms secrets to SSM
+        if: steps.target.outputs.deploy_env == 'stage'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CMS_STAGE }}
+          DOPPLER_PROJECT: cms
+          DOPPLER_CONFIG: ${{ steps.target.outputs.deploy_env }}
+          PARAMETER_PREFIX: /forge/cms/${{ steps.target.outputs.deploy_env }}
+        run: |
+          set -euo pipefail
+          KEYS=(APP_KEYS ADMIN_JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SALT ENCRYPTION_KEY)
+          for key in "${KEYS[@]}"; do
+            value="$(doppler secrets get "$key" --plain --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG")"
+            aws ssm put-parameter \
+              --name "$PARAMETER_PREFIX/$key" \
+              --value "$value" \
+              --type SecureString \
+              --overwrite
+          done
+
+      - name: Sync Doppler cms secrets to SSM (prod)
+        if: steps.target.outputs.deploy_env == 'prod'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CMS_PROD }}
+          DOPPLER_PROJECT: cms
+          DOPPLER_CONFIG: ${{ steps.target.outputs.deploy_env }}
+          PARAMETER_PREFIX: /forge/cms/${{ steps.target.outputs.deploy_env }}
+        run: |
+          set -euo pipefail
+          KEYS=(APP_KEYS ADMIN_JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SALT ENCRYPTION_KEY)
+          for key in "${KEYS[@]}"; do
+            value="$(doppler secrets get "$key" --plain --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG")"
+            aws ssm put-parameter \
+              --name "$PARAMETER_PREFIX/$key" \
+              --value "$value" \
+              --type SecureString \
+              --overwrite
+          done
+
+      - name: Force ECS rollout to load fresh parameters
+        env:
+          DEPLOY_ENV: ${{ steps.target.outputs.deploy_env }}
+        run: |
+          set -euo pipefail
+          cluster="forge-cms-$DEPLOY_ENV"
+          service="forge-cms-$DEPLOY_ENV-service"
+          aws ecs update-service --cluster "$cluster" --service "$service" --force-new-deployment >/dev/null
+          aws ecs wait services-stable --cluster "$cluster" --services "$service"

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -10,3 +10,20 @@ Terraform source for AWS stacks.
 ## Rule
 
 No manual console configuration.
+
+## CMS secrets sync
+
+- CMS runtime secrets are sourced from Doppler project `cms` (`stage`/`prod`) and synced into SSM Parameter Store paths:
+  - `/forge/cms/stage/APP_KEYS`
+  - `/forge/cms/stage/ADMIN_JWT_SECRET`
+  - `/forge/cms/stage/API_TOKEN_SALT`
+  - `/forge/cms/stage/TRANSFER_TOKEN_SALT`
+  - `/forge/cms/stage/ENCRYPTION_KEY`
+  - same keys under `/forge/cms/prod/*` for production.
+- ECS task definition reads those SSM parameters as container secrets.
+- Workflow `.github/workflows/cms-secrets-sync.yml` performs sync and forces ECS rolling deployment so fresh values are loaded immediately.
+- Required GitHub secrets:
+  - `DOPPLER_TOKEN_CMS_STAGE`
+  - `DOPPLER_TOKEN_CMS_PROD`
+  - `AWS_ROLE_ARN_CMS_STAGE`
+  - `AWS_ROLE_ARN_CMS_PROD`

--- a/infra/aws/modules/cms/main.tf
+++ b/infra/aws/modules/cms/main.tf
@@ -1,16 +1,20 @@
 locals {
-  name_prefix     = "forge-cms-${var.environment}"
-  container_image = "strapi/strapi:latest"
-  container_port  = 1337
-  desired_count   = 1
-  task_cpu        = 512
-  task_memory     = 1024
+  name_prefix                = "forge-cms-${var.environment}"
+  container_image            = "strapi/strapi:latest"
+  container_port             = 1337
+  desired_count              = 1
+  task_cpu                   = 512
+  task_memory                = 1024
+  ssm_parameter_path_prefix  = coalesce(var.ssm_parameter_path_prefix, "/forge/cms/${var.environment}")
+  cms_secret_parameter_names = ["APP_KEYS", "ADMIN_JWT_SECRET", "API_TOKEN_SALT", "TRANSFER_TOKEN_SALT", "ENCRYPTION_KEY"]
   tags = merge(var.tags, {
     Environment = var.environment
     ManagedBy   = "terraform"
     Service     = "cms"
   })
 }
+
+data "aws_caller_identity" "current" {}
 
 resource "aws_cloudwatch_log_group" "cms" {
   name              = "/ecs/${local.name_prefix}"
@@ -68,12 +72,43 @@ data "aws_iam_policy_document" "ecs_task_secrets" {
     ]
     resources = [aws_db_instance.cms.master_user_secret[0].secret_arn]
   }
+
 }
 
 resource "aws_iam_role_policy" "ecs_task_secrets" {
   name   = "${local.name_prefix}-task-secrets"
   role   = aws_iam_role.ecs_task.id
   policy = data.aws_iam_policy_document.ecs_task_secrets.json
+}
+
+data "aws_iam_policy_document" "ecs_execution_ssm_parameters" {
+  statement {
+    sid    = "ReadCmsSsmParameters"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath"
+    ]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_parameter_path_prefix}/*"
+    ]
+  }
+
+  statement {
+    sid    = "DecryptSsmParameters"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_execution_ssm_parameters" {
+  name   = "${local.name_prefix}-execution-ssm-parameters"
+  role   = aws_iam_role.ecs_execution.id
+  policy = data.aws_iam_policy_document.ecs_execution_ssm_parameters.json
 }
 
 resource "aws_lb_target_group" "cms" {
@@ -142,12 +177,51 @@ resource "aws_ecs_task_definition" "cms" {
         awslogs-stream-prefix = "cms"
       }
     }
-    secrets = [
+    environment = [
+      {
+        name  = "HOST"
+        value = "0.0.0.0"
+      },
+      {
+        name  = "PORT"
+        value = tostring(local.container_port)
+      },
+      {
+        name  = "DATABASE_CLIENT"
+        value = "postgres"
+      },
+      {
+        name  = "DATABASE_HOST"
+        value = aws_db_instance.cms.address
+      },
+      {
+        name  = "DATABASE_PORT"
+        value = "5432"
+      },
+      {
+        name  = "DATABASE_NAME"
+        value = var.db_name
+      },
+      {
+        name  = "DATABASE_USERNAME"
+        value = var.db_username
+      },
+      {
+        name  = "DATABASE_SSL"
+        value = "true"
+      }
+    ]
+    secrets = concat([
+      for parameter_name in local.cms_secret_parameter_names : {
+        name      = parameter_name
+        valueFrom = "${local.ssm_parameter_path_prefix}/${parameter_name}"
+      }
+      ], [
       {
         name      = "DATABASE_PASSWORD"
         valueFrom = "${aws_db_instance.cms.master_user_secret[0].secret_arn}:password::"
       }
-    ]
+    ])
   }])
 
   tags = local.tags

--- a/infra/aws/modules/cms/outputs.tf
+++ b/infra/aws/modules/cms/outputs.tf
@@ -42,3 +42,8 @@ output "alb_certificate_arn" {
   description = "Validated ACM certificate ARN for the CMS ALB hostname."
   value       = aws_acm_certificate_validation.alb.certificate_arn
 }
+
+output "ssm_parameter_path_prefix" {
+  description = "SSM Parameter Store path prefix used for CMS runtime secrets."
+  value       = local.ssm_parameter_path_prefix
+}

--- a/infra/aws/modules/cms/variables.tf
+++ b/infra/aws/modules/cms/variables.tf
@@ -117,3 +117,9 @@ variable "rds_security_group_id" {
   description = "Security group ID attached to the CMS RDS instance."
   type        = string
 }
+
+variable "ssm_parameter_path_prefix" {
+  description = "Optional SSM Parameter Store path prefix for CMS runtime secrets."
+  type        = string
+  default     = null
+}

--- a/infra/aws/modules/platform/outputs.tf
+++ b/infra/aws/modules/platform/outputs.tf
@@ -52,3 +52,8 @@ output "private_subnet_ids" {
   description = "Private subnet IDs used by internal CMS resources."
   value       = [for subnet in aws_subnet.private : subnet.id]
 }
+
+output "cms_ssm_parameter_path_prefix" {
+  description = "SSM Parameter Store path prefix used for CMS runtime secrets."
+  value       = module.application.ssm_parameter_path_prefix
+}

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -43,6 +43,11 @@ output "db_master_secret_arns" {
   value       = { for env, module_instance in module.platform : env => module_instance.db_master_secret_arn }
 }
 
+output "cms_ssm_parameter_path_prefixes" {
+  description = "SSM Parameter Store path prefix by environment for CMS runtime secrets."
+  value       = { for env, module_instance in module.platform : env => module_instance.cms_ssm_parameter_path_prefix }
+}
+
 output "forge_delegated_zone_name" {
   description = "Delegated Route53 hosted zone name for this infrastructure."
   value       = aws_route53_zone.forge.name


### PR DESCRIPTION
## Summary

Implement Doppler-to-SSM sync for CMS stage/prod secrets and make them available to ECS tasks immediately.

- Add `.github/workflows/cms-secrets-sync.yml` to sync `cms` Doppler secrets to `/forge/cms/{env}/*` and force ECS rollout.
- Wire ECS task definition and execution-role IAM in `infra/aws/modules/cms` to read runtime secrets from SSM Parameter Store.
- Expose SSM path outputs in AWS Terraform outputs and document required GitHub secret inputs for the workflow.

Resolves #71

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

Made with [Cursor](https://cursor.com)