### PR TITLE
fix(terraform): allow CreateServiceLinkedRole for RDS and ELB

### DIFF
--- a/infra/aws/github/terraform.tf
+++ b/infra/aws/github/terraform.tf
@@ -152,6 +152,17 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
   }
 
   statement {
+    sid    = "AllowCreateServiceLinkedRoles"
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole"
+    ]
+    resources = [
+      "arn:aws:iam::*:role/aws-service-role/*"
+    ]
+  }
+
+  statement {
     sid    = "DenyIamUserAndGroupMutation"
     effect = "Deny"
     actions = [


### PR DESCRIPTION
Resolves #182

## Summary

Terraform apply (aws/prod) fails when creating RDS or ALB because the apply role cannot create AWS service-linked roles (e.g. `AWSServiceRoleForElasticLoadBalancing`). Added `AllowCreateServiceLinkedRoles` statement: allow `iam:CreateServiceLinkedRole` on `arn:aws:iam::*:role/aws-service-role/*` only.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Terraform plan reviewed (single new IAM allow statement, scoped to SLR ARNs)
- [ ] CI checks pass (terraform-apply apply-aws after merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal infrastructure improvements to expand deployment permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->