### PR TITLE
fix(infra): RDS postgres 16.4 invalid — use supported version

### DIFF
--- a/infra/aws/modules/cms/variables.tf
+++ b/infra/aws/modules/cms/variables.tf
@@ -41,7 +41,7 @@ variable "db_allocated_storage" {
 variable "db_engine_version" {
   description = "Postgres engine version."
   type        = string
-  default     = "16.4"
+  default     = "16.8"
 }
 
 variable "db_multi_az" {


### PR DESCRIPTION
Resolves #184

## Summary

RDS CreateDBInstance failed with `InvalidParameterCombination: Cannot find version 16.4 for postgres`. Default `db_engine_version` for CMS module updated from `16.4` to `16.8` (current RDS-supported PG 16 minor).

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed
- [x] Terraform plan reviewed (if infra change)