### PR TITLE
feat(ci): add native mobile build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-${{ hashFiles('mobile/ios/Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-
       - name: Build iOS (Simulator)
         run: >
           xcodebuild


### PR DESCRIPTION
## Summary

- Add conditional `build-ios` CI job that compiles the iOS app for Simulator when mobile iOS changes are detected
- Add conditional `build-android` CI job that assembles the Android debug APK when mobile Android changes are detected
- Both jobs reuse existing `affected` job outputs and run in parallel with lint jobs

Resolves #82

## Contracts Changed

No

## Regeneration Required

No

## Validation

- [x] YAML validated (8 jobs: commits, affected, generated-code, build-and-test, lint-ios, build-ios, lint-android, build-android)
- [x] Existing lint-ios and lint-android jobs unchanged
- [x] Build jobs conditional on affected detection (same pattern as lint jobs)
- [x] Build failures will block merge via standard CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now performs platform-specific builds for iOS and Android (including platform setup and caching) in addition to existing checks, expanding automated build coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->