### PR TITLE
chore(mobile-expo): CI lint, typecheck, and build for Expo app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     outputs:
       mobile_ios: ${{ steps.affected.outputs.mobile_ios }}
       mobile_android: ${{ steps.affected.outputs.mobile_android }}
+      mobile_expo: ${{ steps.affected.outputs.mobile_expo }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -58,9 +59,10 @@ jobs:
         run: |
           BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
           TURBO_OUT=$(TURBO_SCM_BASE="$BASE" pnpm turbo run lint --affected --dry-run=json 2>&1) || true
-          AFFECTED=$(echo "$TURBO_OUT" | jq -r '[.tasks[].package] | map(select(. == "@forge/mobile-ios" or . == "@forge/mobile-android")) | .[]' 2>&1 || echo "")
+          AFFECTED=$(echo "$TURBO_OUT" | jq -r '[.tasks[].package] | map(select(. == "@forge/mobile-ios" or . == "@forge/mobile-android" or . == "@forge/expo")) | .[]' 2>&1 || echo "")
           echo "mobile_ios=$(echo "$AFFECTED" | grep -q "@forge/mobile-ios" && echo "true" || echo "false")" >> $GITHUB_OUTPUT
           echo "mobile_android=$(echo "$AFFECTED" | grep -q "@forge/mobile-android" && echo "true" || echo "false")" >> $GITHUB_OUTPUT
+          echo "mobile_expo=$(echo "$AFFECTED" | grep -q "@forge/expo" && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
   generated-code:
     runs-on: ubuntu-latest
@@ -100,7 +102,7 @@ jobs:
       - name: Check format
         run: pnpm run format:check
       - name: Lint JS/TS
-        run: pnpm turbo run lint --filter='!@forge/mobile-*' --filter='!@forge/infra' -- --max-warnings=0
+        run: pnpm turbo run lint --filter='!@forge/mobile-*' --filter='!@forge/expo' --filter='!@forge/infra' -- --max-warnings=0
       - name: Test
         run: pnpm test
       - name: Build
@@ -141,3 +143,26 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: ktlint
         run: cd mobile/android && ./gradlew ktlintCheck
+
+  lint-expo:
+    runs-on: ubuntu-latest
+    needs: affected
+    if: needs.affected.outputs.mobile_expo == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm --filter @forge/expo run lint -- --max-warnings=0
+      - name: Typecheck
+        run: pnpm --filter @forge/expo run typecheck
+      - name: Build
+        run: pnpm --filter @forge/expo run build


### PR DESCRIPTION
## Summary

- Add dedicated `lint-expo` CI job that runs ESLint (`--max-warnings=0`), TypeScript typecheck (`tsc --noEmit`), and build validation for the Expo app (`mobile/expo`)
- Extend `affected` job to detect `@forge/expo` changes via Turbo affected analysis
- Exclude `@forge/expo` from main `build-and-test` lint step to avoid double-linting

Resolves #96

## Contracts Changed

No

## Regeneration Required

No

## Validation

- CI workflow YAML syntax validated
- New `lint-expo` job follows existing `lint-ios`/`lint-android` pattern
- Job is conditional on `@forge/expo` being affected (no wasted CI minutes)