### PR TITLE
chore(infra): remove CMS module defaults; platform owns policy

### DIFF
--- a/infra/aws/modules/cms/variables.tf
+++ b/infra/aws/modules/cms/variables.tf
@@ -11,55 +11,46 @@ variable "aws_region" {
 variable "tags" {
   description = "Common tags applied to all resources."
   type        = map(string)
-  default     = {}
 }
 
 variable "db_name" {
   description = "Database name for the CMS Postgres instance."
   type        = string
-  default     = "cms"
 }
 
 variable "db_username" {
   description = "Master username for the CMS Postgres instance."
   type        = string
-  default     = "cms"
 }
 
 variable "db_instance_class" {
   description = "RDS instance class for CMS Postgres."
   type        = string
-  default     = "db.t4g.micro"
 }
 
 variable "db_allocated_storage" {
   description = "Allocated storage size (GiB) for CMS Postgres."
   type        = number
-  default     = 20
 }
 
 variable "db_engine_version" {
   description = "Postgres engine version."
   type        = string
-  default     = "16.8"
 }
 
 variable "db_multi_az" {
   description = "Enable Multi-AZ deployment for the RDS instance."
   type        = bool
-  default     = false
 }
 
 variable "db_backup_retention_period" {
   description = "Number of days to retain automated RDS backups."
   type        = number
-  default     = 7
 }
 
 variable "db_enabled_cloudwatch_logs_exports" {
   description = "PostgreSQL log types exported from RDS to CloudWatch Logs."
   type        = list(string)
-  default     = ["postgresql", "upgrade"]
 }
 
 variable "route53_zone_id" {


### PR DESCRIPTION
Resolves #192

## Summary

CMS module is only consumed by platform; duplicate defaults caused drift and duplicated policy. Removed defaults for all variables that platform passes (tags, db_name, db_username, db_instance_class, db_allocated_storage, db_engine_version, db_multi_az, db_backup_retention_period, db_enabled_cloudwatch_logs_exports). Kept `default = null` for optional `db_master_user_secret_kms_key_id`. Platform remains single source of truth.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure configuration updated to require explicit values for database and infrastructure parameters. Database name, credentials, instance class, storage allocation, version, availability settings, backup retention, and logging exports now require explicit configuration during deployment rather than using defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->