### PR TITLE
fix(infra): platform db_engine_version default to 16.8

### DIFF
--- a/infra/aws/modules/platform/variables.tf
+++ b/infra/aws/modules/platform/variables.tf
@@ -41,7 +41,7 @@ variable "db_allocated_storage" {
 variable "db_engine_version" {
   description = "Postgres engine version."
   type        = string
-  default     = "16.4"
+  default     = "16.8"
 }
 
 variable "db_multi_az" {


### PR DESCRIPTION
Resolves #194

Platform had missed the 16.4→16.8 update; RDS doesn't support 16.4. Single default change in `modules/platform/variables.tf`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database engine version from 16.4 to 16.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->