### PR TITLE
fix(infra): grant Terraform apply role Secrets Manager permissions for RDS

### DIFF
--- a/infra/aws/github/terraform.tf
+++ b/infra/aws/github/terraform.tf
@@ -95,6 +95,7 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
       "kms:*",
       "logs:*",
       "rds:*",
+      "secretsmanager:*",
       "route53:*",
       "s3:*",
       "wafv2:*"


### PR DESCRIPTION
Resolves #196

## Summary

Terraform apply was failing when creating RDS with `manage_master_user_password = true` because RDS creates the master password secret in AWS Secrets Manager using the caller's credentials. The GitHub Actions Terraform apply role had `rds:*` but no `secretsmanager:*`. Add `secretsmanager:*` to the apply policy so RDS-managed secrets can be created.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)