### PR TITLE
fix(infra): grant CMS ECS execution role Secrets Manager access for RDS secret

### DIFF
--- a/infra/aws/modules/cms/main.tf
+++ b/infra/aws/modules/cms/main.tf
@@ -43,6 +43,24 @@ resource "aws_iam_role_policy_attachment" "ecs_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+data "aws_iam_policy_document" "ecs_execution_secrets" {
+  statement {
+    sid    = "ReadRdsSecretForInjection"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret"
+    ]
+    resources = [aws_db_instance.cms.master_user_secret[0].secret_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_execution_secrets" {
+  name   = "${local.name_prefix}-execution-secrets"
+  role   = aws_iam_role.ecs_execution.id
+  policy = data.aws_iam_policy_document.ecs_execution_secrets.json
+}
+
 resource "aws_iam_role" "ecs_task" {
   name = "${local.name_prefix}-task-role"
   assume_role_policy = jsonencode({


### PR DESCRIPTION
Resolves #198

## Summary

CMS ECS tasks were failing with `AccessDeniedException` on `secretsmanager:GetSecretValue` for the RDS master user secret. ECS injects container `secrets` using the **execution role**; only the task role had that permission. This PR adds an IAM policy to the CMS ECS execution role allowing `GetSecretValue` and `DescribeSecret` on the RDS secret ARN.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure permissions to enable secure database secret access, enhancing system reliability and security compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->