### PR TITLE
fix(cms-deploy): use environment deploy role secret

### DIFF
--- a/.github/workflows/cms-deploy.yml
+++ b/.github/workflows/cms-deploy.yml
@@ -67,6 +67,7 @@ jobs:
       contents: write
     needs: affected
     if: needs.affected.outputs.cms == 'true'
+    environment: ${{ github.ref_name == 'main' && 'cms-prod' || 'cms-stage' }}
     runs-on: ubuntu-latest
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-2' }}
@@ -79,15 +80,14 @@ jobs:
         run: |
           if [ "${GITHUB_REF_NAME}" = "main" ]; then
             DEPLOY_ENV="prod"
-            echo "role_arn=${{ secrets.AWS_DEPLOY_ROLE_ARN_PROD || secrets.AWS_DEPLOY_ROLE_ARN }}" >> "$GITHUB_OUTPUT"
           elif [ "${GITHUB_REF_NAME}" = "stage" ]; then
             DEPLOY_ENV="stage"
-            echo "role_arn=${{ secrets.AWS_DEPLOY_ROLE_ARN_STAGE || secrets.AWS_DEPLOY_ROLE_ARN }}" >> "$GITHUB_OUTPUT"
           else
             echo "Unsupported branch: ${GITHUB_REF_NAME}" >&2
             exit 1
           fi
 
+          echo "role_arn=${{ secrets.CMS_DEPLOY_ROLE_ARN }}" >> "$GITHUB_OUTPUT"
           echo "deploy_env=$DEPLOY_ENV" >> "$GITHUB_OUTPUT"
           echo "ecr_repository=forge-cms-$DEPLOY_ENV" >> "$GITHUB_OUTPUT"
           echo "image_tag=${GITHUB_REF_NAME}-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
@@ -97,7 +97,7 @@ jobs:
       - name: Validate role ARN is configured
         if: steps.vars.outputs.role_arn == ''
         run: |
-          echo "Missing AWS deploy role secret for ${GITHUB_REF_NAME}" >&2
+          echo "Missing CMS_DEPLOY_ROLE_ARN secret for ${GITHUB_JOB} environment on ${GITHUB_REF_NAME}" >&2
           exit 1
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary

Bind `cms-deploy` to the `cms-stage` and `cms-prod` GitHub environments so the job can access the provisioned environment-scoped deploy secret.
Switch the workflow to read `CMS_DEPLOY_ROLE_ARN` and fail with a clearer message when the environment secret is missing.

Resolves #226

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)
- [x] Workflow YAML parsed locally
- [x] IDE diagnostics clean for touched file

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflow configuration to streamline environment-specific deployments and credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->