### PR TITLE
fix(ci): add action run link to terraform plan comment

### DIFF
--- a/.github/actions/terraform-plan-comment/comment.js
+++ b/.github/actions/terraform-plan-comment/comment.js
@@ -11,6 +11,7 @@ async function main({ github, context, core, fs, path }) {
     process.env.GITHUB_WORKSPACE || ".",
     core.getInput("output_file", { required: true }),
   )
+  const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
 
   const marker = env
     ? `<!-- terraform-plan-${stack}:${env} -->`
@@ -83,6 +84,8 @@ async function main({ github, context, core, fs, path }) {
     `**Changes:** ${changeSummary}`,
     "**Time:**",
     timeTable,
+    "",
+    `Run: ${runUrl}`,
     "",
     "```",
     plan,


### PR DESCRIPTION
## Summary

Add the GitHub Actions run link to the Terraform plan PR comment so reviewers can jump straight from the summary comment to the workflow run. Mirrors the existing apply comment behavior without changing plan parsing or comment update logic.

Resolves #239

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terraform plan comments now include a direct link to the GitHub Actions run, enabling users to quickly navigate to the specific workflow execution associated with each plan. This enhancement improves overall traceability, streamlines access to build and deployment details, and provides better visibility across your entire CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->