### PR TITLE
fix(ci): handle non-workspace changes in cms deploy affected detection

### DIFF
--- a/.github/workflows/cms-deploy.yml
+++ b/.github/workflows/cms-deploy.yml
@@ -51,14 +51,18 @@ jobs:
             exit 0
           fi
 
-          if ! TURBO_OUT=$(TURBO_SCM_BASE="$BASE" pnpm turbo run lint --affected --dry-run=json 2>&1); then
+          TURBO_STDERR=$(mktemp)
+          if ! TURBO_OUT=$(TURBO_SCM_BASE="$BASE" pnpm turbo run lint --affected --dry-run=json 2>"$TURBO_STDERR"); then
+            cat "$TURBO_STDERR" >&2
             echo "$TURBO_OUT" >&2
+            rm -f "$TURBO_STDERR"
             echo "Affected detection failed; forcing deploy to avoid false negative." >&2
             echo "cms=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          CMS_AFFECTED=$(echo "$TURBO_OUT" | jq -r 'try ([.tasks[]?.package] | any(. == "@forge/cms")) catch "true"')
+          CMS_AFFECTED=$(echo "$TURBO_OUT" | jq -r 'try ([.tasks[]?.package] | any(. == "@forge/cms")) catch "true"' 2>/dev/null || echo "true")
+          rm -f "$TURBO_STDERR"
           echo "cms=$CMS_AFFECTED" >> "$GITHUB_OUTPUT"
 
   deploy:


### PR DESCRIPTION
## Summary

Prevent `cms-deploy` affected detection from failing when Turbo writes non-JSON output to stderr. Capture stderr separately, parse only JSON stdout with `jq`, and keep the existing safe fallback to `cms=true` if detection or parsing fails.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)

Resolves #241.

Made with [Cursor](https://cursor.com)