### PR TITLE
fix(ci): allow manual cms deploy without affected gate

### DIFF
--- a/.github/workflows/cms-deploy.yml
+++ b/.github/workflows/cms-deploy.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - stage
       - main
+  workflow_dispatch:
 
 jobs:
   affected:
@@ -41,6 +42,11 @@ jobs:
       - id: affected
         name: Detect affected CMS package
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "cms=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           BASE="${{ github.event.before }}"
           if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
             BASE=$(git rev-parse HEAD^ 2>/dev/null || true)


### PR DESCRIPTION
Resolves #243

## Summary

Allow `cms-deploy` to be started manually from GitHub Actions and bypass affected detection for manual runs so operator-triggered deploys are not blocked.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)


Made with [Cursor](https://cursor.com)