### PR TITLE
fix(infra): allow cms deploy role to describe task definitions

### DIFF
--- a/infra/aws/github/cms.tf
+++ b/infra/aws/github/cms.tf
@@ -77,11 +77,19 @@ data "aws_iam_policy_document" "github_actions_cms_deploy" {
   }
 
   statement {
+    sid    = "EcsDescribeTaskDefinitions"
+    effect = "Allow"
+    actions = [
+      "ecs:DescribeTaskDefinition"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
     sid    = "EcsDeploy"
     effect = "Allow"
     actions = [
       "ecs:DescribeServices",
-      "ecs:DescribeTaskDefinition",
       "ecs:RegisterTaskDefinition",
       "ecs:UpdateService",
       "ecs:TagResource"


### PR DESCRIPTION
## Summary

Fix the CMS deploy IAM policy so the GitHub Actions deploy role can call `ecs:DescribeTaskDefinition` with the resource scope AWS requires.

Resolves #245.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS infrastructure configuration to reorganize IAM permissions related to task definition management. This change restructures how permissions are granted while maintaining service functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->