### PR TITLE
fix(infra): allow cms deploy role to register task definitions

### DIFF
--- a/infra/aws/github/cms.tf
+++ b/infra/aws/github/cms.tf
@@ -77,12 +77,20 @@ data "aws_iam_policy_document" "github_actions_cms_deploy" {
   }
 
   statement {
+    sid    = "EcsTaskDefinitionReadWrite"
+    effect = "Allow"
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
     sid    = "EcsDeploy"
     effect = "Allow"
     actions = [
       "ecs:DescribeServices",
-      "ecs:DescribeTaskDefinition",
-      "ecs:RegisterTaskDefinition",
       "ecs:UpdateService",
       "ecs:TagResource"
     ]


### PR DESCRIPTION
## Summary

Align CMS deploy ECS IAM scopes with AWS action behavior:

- grant `ecs:DescribeTaskDefinition` and `ecs:RegisterTaskDefinition` with `Resource: *`
- keep `ecs:DescribeServices`, `ecs:UpdateService`, and `ecs:TagResource` scoped to CMS cluster/service/task-definition ARNs

Resolves #247.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)
