### PR TITLE
fix(cms-deploy): improve deploy rollout diagnostics

### DIFF
--- a/.github/workflows/cms-deploy.yml
+++ b/.github/workflows/cms-deploy.yml
@@ -139,12 +139,40 @@ jobs:
           SERVICE_NAME: ${{ steps.vars.outputs.service_name }}
           IMAGE_URI: ${{ steps.image.outputs.image_uri }}
         run: |
+          set -o pipefail
+
+          print_service_snapshot() {
+            local service_json="$1"
+            echo "Service status:"
+            echo "$service_json" | jq -r '
+              .services[0] as $service
+              | "service=\($service.serviceName) status=\($service.status) desired=\($service.desiredCount) running=\($service.runningCount) pending=\($service.pendingCount)"
+            '
+            echo "Deployments:"
+            echo "$service_json" | jq -r '
+              .services[0].deployments[]?
+              | "- status=\(.status) rollout=\(.rolloutState // "n/a") reason=\(.rolloutStateReason // "n/a") desired=\(.desiredCount) running=\(.runningCount) pending=\(.pendingCount) taskDef=\(.taskDefinition)"
+            '
+          }
+
+          print_recent_events() {
+            local service_json="$1"
+            echo "Recent ECS service events:"
+            echo "$service_json" | jq -r '
+              .services[0].events[:5][]?
+              | "- [\(.createdAt)] \(.message)"
+            '
+          }
+
+          echo "Describing ECS service: $SERVICE_NAME"
           SERVICE_JSON=$(aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME")
           if [ "$(echo "$SERVICE_JSON" | jq -r '.failures | length')" -gt 0 ] || \
              [ "$(echo "$SERVICE_JSON" | jq -r '.services | length')" -eq 0 ]; then
             echo "ECS service not found or not describable: $SERVICE_NAME" >&2
             exit 1
           fi
+
+          print_service_snapshot "$SERVICE_JSON"
 
           TASK_DEFINITION_ARN=$(echo "$SERVICE_JSON" | jq -r '.services[0].taskDefinition')
           if [ -z "$TASK_DEFINITION_ARN" ] || [ "$TASK_DEFINITION_ARN" = "null" ]; then
@@ -188,21 +216,59 @@ jobs:
             | with_entries(select(.value != null))
           ')
 
+          echo "Registering new task definition for image: $IMAGE_URI"
           NEW_TASK_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_TASK" | jq -r '.taskDefinition.taskDefinitionArn')
+          echo "Registered ECS task definition ARN: $NEW_TASK_ARN"
 
+          echo "Updating ECS service to task definition: $NEW_TASK_ARN"
           aws ecs update-service \
             --cluster "$CLUSTER_NAME" \
             --service "$SERVICE_NAME" \
             --task-definition "$NEW_TASK_ARN" \
             --force-new-deployment >/dev/null
 
-          aws ecs wait services-stable --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME"
+          MAX_ATTEMPTS=60
+          SLEEP_SECONDS=10
 
-          ROLLOUT_STATE=$(aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME" | jq -r '.services[0].deployments[] | select(.status=="PRIMARY") | .rolloutState')
-          if [ "$ROLLOUT_STATE" != "COMPLETED" ]; then
-            echo "Primary deployment rollout did not complete: $ROLLOUT_STATE" >&2
-            exit 1
-          fi
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "Rollout poll $attempt/$MAX_ATTEMPTS"
+            SERVICE_JSON=$(aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME")
+            print_service_snapshot "$SERVICE_JSON"
+
+            ROLLOUT_STATE=$(echo "$SERVICE_JSON" | jq -r '.services[0].deployments[] | select(.status=="PRIMARY") | .rolloutState // empty')
+            ROLLOUT_REASON=$(echo "$SERVICE_JSON" | jq -r '.services[0].deployments[] | select(.status=="PRIMARY") | .rolloutStateReason // empty')
+            DESIRED_COUNT=$(echo "$SERVICE_JSON" | jq -r '.services[0].desiredCount')
+            RUNNING_COUNT=$(echo "$SERVICE_JSON" | jq -r '.services[0].runningCount')
+            PENDING_COUNT=$(echo "$SERVICE_JSON" | jq -r '.services[0].pendingCount')
+            DEPLOYMENT_COUNT=$(echo "$SERVICE_JSON" | jq -r '.services[0].deployments | length')
+
+            if [ "$ROLLOUT_STATE" = "COMPLETED" ] && \
+               [ "$RUNNING_COUNT" = "$DESIRED_COUNT" ] && \
+               [ "$PENDING_COUNT" = "0" ] && \
+               [ "$DEPLOYMENT_COUNT" = "1" ]; then
+              echo "ECS rollout completed successfully."
+              break
+            fi
+
+            if [ "$ROLLOUT_STATE" = "FAILED" ]; then
+              echo "Primary deployment rollout failed: ${ROLLOUT_REASON:-no reason provided}" >&2
+              print_recent_events "$SERVICE_JSON"
+              exit 1
+            fi
+
+            if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+              echo "Primary deployment rollout did not complete within $((MAX_ATTEMPTS * SLEEP_SECONDS)) seconds." >&2
+              echo "Final rollout state: ${ROLLOUT_STATE:-unknown}" >&2
+              if [ -n "$ROLLOUT_REASON" ]; then
+                echo "Final rollout reason: $ROLLOUT_REASON" >&2
+              fi
+              print_recent_events "$SERVICE_JSON"
+              exit 1
+            fi
+
+            print_recent_events "$SERVICE_JSON"
+            sleep "$SLEEP_SECONDS"
+          done
 
           echo "task_definition_arn=$NEW_TASK_ARN" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

The ECS rollout step previously used `aws ecs wait services-stable` followed by a single rollout-state read. When the rollout was still `IN_PROGRESS` at that instant the job failed with no context about *why* (task health, image pull errors, etc.).

This replaces that with a bounded polling loop (up to 10 min) that on every iteration logs:
- Service status (desired/running/pending counts)
- All active deployments with rollout state and reason
- Last 5 ECS service events

On failure or timeout the same diagnostic snapshot is printed to stderr so the next failure is immediately actionable.

Note: no `/_health` endpoint was needed — Strapi v5 ships a built-in `/_health` route that returns `204`. The ALB target group already points at that path.

Resolves #253

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced ECS deployment process with improved rollout monitoring and failure detection.
  * Added comprehensive status reporting and diagnostic logging during deployment rollout phases.
  * Increased visibility into deployment health with better error tracking and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->