### PR TITLE
fix(infra): enable SSL for CMS ECS → RDS connection

### DIFF
--- a/infra/aws/modules/cms/main.tf
+++ b/infra/aws/modules/cms/main.tf
@@ -319,7 +319,8 @@ resource "aws_ecs_task_definition" "cms" {
       { name = "DATABASE_PORT", value = tostring(aws_db_instance.cms.port) },
       { name = "DATABASE_NAME", value = var.db_name },
       { name = "DATABASE_USERNAME", value = var.db_username },
-      { name = "DATABASE_SSL", value = "false" },
+      { name = "DATABASE_SSL", value = "true" },
+      { name = "DATABASE_SSL_REJECT_UNAUTHORIZED", value = "false" },
       { name = "AWS_REGION", value = var.aws_region },
       { name = "AWS_S3_BUCKET", value = var.assets_bucket_name },
     ]


### PR DESCRIPTION
Resolves #255

## Summary

CMS ECS tasks were failing on deploy with `no pg_hba.conf entry for host "...", user "cms", database "cms", no encryption`. RDS Postgres requires SSL; the task definition had `DATABASE_SSL=false`. Enable TLS for the CMS → RDS connection and set `DATABASE_SSL_REJECT_UNAUTHORIZED=false` so RDS cert is accepted without bundling the CA in the image.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection security configuration to enable SSL encryption for improved connection security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->