### PR TITLE
fix(cms): add JWT_SECRET for users-permissions plugin

### DIFF
--- a/apps/cms/.env.example
+++ b/apps/cms/.env.example
@@ -3,6 +3,8 @@ HOST=0.0.0.0
 PORT=1337
 APP_KEYS=key1,key2,key3,key4
 ADMIN_JWT_SECRET=
+# Users & Permissions plugin (API auth); set in ECS task def for prod
+JWT_SECRET=
 API_TOKEN_SALT=
 TRANSFER_TOKEN_SALT=
 ENCRYPTION_KEY=

--- a/apps/cms/config/plugins.ts
+++ b/apps/cms/config/plugins.ts
@@ -4,6 +4,11 @@ import type { Core } from "@strapi/strapi"
 const config = ({
   env,
 }: Core.Config.Shared.ConfigParams): Core.Config.Plugin => ({
+  "users-permissions": {
+    config: {
+      jwtSecret: env("JWT_SECRET"),
+    },
+  },
   graphql: {
     config: {
       endpoint: "/graphql",

--- a/infra/aws/modules/cms/main.tf
+++ b/infra/aws/modules/cms/main.tf
@@ -67,6 +67,11 @@ ephemeral "random_password" "admin_jwt_secret" {
   special = false
 }
 
+ephemeral "random_password" "jwt_secret" {
+  length  = 64
+  special = false
+}
+
 ephemeral "random_password" "api_token_salt" {
   length  = 64
   special = false
@@ -101,6 +106,15 @@ resource "aws_ssm_parameter" "admin_jwt_secret" {
   type             = "SecureString"
   key_id           = aws_kms_key.cms_ssm.arn
   value_wo         = ephemeral.random_password.admin_jwt_secret.result
+  value_wo_version = var.ssm_secret_version
+  tags             = local.tags
+}
+
+resource "aws_ssm_parameter" "jwt_secret" {
+  name             = "${local.ssm_parameter_prefix}/JWT_SECRET"
+  type             = "SecureString"
+  key_id           = aws_kms_key.cms_ssm.arn
+  value_wo         = ephemeral.random_password.jwt_secret.result
   value_wo_version = var.ssm_secret_version
   tags             = local.tags
 }
@@ -184,6 +198,7 @@ data "aws_iam_policy_document" "ecs_execution_secrets" {
     resources = [
       aws_ssm_parameter.app_keys.arn,
       aws_ssm_parameter.admin_jwt_secret.arn,
+      aws_ssm_parameter.jwt_secret.arn,
       aws_ssm_parameter.api_token_salt.arn,
       aws_ssm_parameter.transfer_token_salt.arn,
       aws_ssm_parameter.encryption_key.arn,
@@ -336,6 +351,10 @@ resource "aws_ecs_task_definition" "cms" {
       {
         name      = "ADMIN_JWT_SECRET"
         valueFrom = aws_ssm_parameter.admin_jwt_secret.arn
+      },
+      {
+        name      = "JWT_SECRET"
+        valueFrom = aws_ssm_parameter.jwt_secret.arn
       },
       {
         name      = "API_TOKEN_SALT"


### PR DESCRIPTION
## Summary

Strapi users-permissions plugin requires `jwtSecret` in plugin config. ECS tasks were failing with "Missing jwtSecret". This adds JWT_SECRET (separate from ADMIN_JWT_SECRET): app reads it from env; Terraform creates SSM parameter from ephemeral random and injects it into the ECS task definition.

Resolves #260

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured the Users & Permissions plugin with JWT-based authentication support.
  * Added secure JWT secret provisioning and management in the production environment using AWS infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->