### PR TITLE
fix(infra): ECS CMS task health status unknown

### DIFF
--- a/infra/aws/modules/cms/main.tf
+++ b/infra/aws/modules/cms/main.tf
@@ -335,6 +335,13 @@ resource "aws_ecs_task_definition" "cms" {
       hostPort      = 1337
       protocol      = "tcp"
     }]
+    healthCheck = {
+      command     = ["CMD-SHELL", "wget -q -O - http://localhost:1337/_health || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 60
+    }
     logConfiguration = {
       logDriver = "awslogs"
       options = {


### PR DESCRIPTION
Resolves #266

## Summary

ECS Tasks showed "Health status: Unknown" because the task definition had no container health check. Added a container `healthCheck` in the CMS task definition that hits `/_health` (wget), so ECS console reports Healthy/Unhealthy. ALB target group already had the same path; this only populates the ECS UI column.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated health monitoring for the CMS service with periodic status checks to ensure continuous availability and improve system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->