### PR TITLE
fix(infra): ECS CMS task health check failing

### DIFF
--- a/infra/aws/modules/cms/main.tf
+++ b/infra/aws/modules/cms/main.tf
@@ -336,7 +336,7 @@ resource "aws_ecs_task_definition" "cms" {
       protocol      = "tcp"
     }]
     healthCheck = {
-      command     = ["CMD-SHELL", "wget -q -O - http://localhost:1337/_health || exit 1"]
+      command     = ["CMD-SHELL", "wget -q -O - http://0.0.0.0:1337/_health || exit 1"]
       interval    = 30
       timeout     = 5
       retries     = 3


### PR DESCRIPTION
Resolves #271

## Summary

ECS CMS container health check was failing. Updated the task definition health check URL from `http://localhost:1337/_health` to `http://0.0.0.0:1337/_health` to align with `HOST=0.0.0.0` in the container.

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated (none changed)
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed (CI)
- [x] Terraform plan reviewed (if infra change)