### PR TITLE
fix(ci): capture format/validate failure output in Terraform plan/apply comments

### DIFF
--- a/.github/actions/terraform-apply-comment/action.yml
+++ b/.github/actions/terraform-apply-comment/action.yml
@@ -13,6 +13,10 @@ inputs:
   output_file:
     description: Path to apply log file from repo root (e.g. infra/aws/apply-aws.txt).
     required: true
+  fallback_log:
+    description: Optional path to pre-apply log (e.g. init) when apply output is missing.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -34,3 +38,4 @@ runs:
         INPUT_EXIT_CODE: ${{ inputs.exit_code }}
         INPUT_ENV: ${{ inputs.env }}
         INPUT_OUTPUT_FILE: ${{ inputs.output_file }}
+        INPUT_FALLBACK_LOG: ${{ inputs.fallback_log }}

--- a/.github/actions/terraform-apply-comment/comment.js
+++ b/.github/actions/terraform-apply-comment/comment.js
@@ -6,17 +6,45 @@ async function main({ github, context, core, fs, path }) {
     process.env.GITHUB_WORKSPACE || ".",
     core.getInput("output_file", { required: true }),
   )
-
-  const status = exitCode === 0 ? "Applied" : "Apply failed"
-  const icon = exitCode === 0 ? "✅" : "❌"
-  const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+  const fallbackPathRaw = (core.getInput("fallback_log") || "").trim()
+  const fallbackPath = fallbackPathRaw
+    ? path.join(process.env.GITHUB_WORKSPACE || ".", fallbackPathRaw)
+    : ""
 
   let applyOutput = ""
+  let usedFallback = false
   try {
     applyOutput = fs.readFileSync(outputPath, "utf8")
   } catch (e) {
-    applyOutput = `Unable to read apply output: ${e.message}`
+    if (fallbackPath) {
+      try {
+        applyOutput = fs.readFileSync(fallbackPath, "utf8")
+        usedFallback = true
+      } catch (e2) {
+        applyOutput = `Unable to read apply output: ${e.message}. Fallback: ${e2.message}`
+      }
+    } else {
+      applyOutput = `Unable to read apply output: ${e.message}`
+    }
   }
+  if (!usedFallback && applyOutput.trim() === "" && fallbackPath) {
+    try {
+      applyOutput = fs.readFileSync(fallbackPath, "utf8")
+      usedFallback = true
+    } catch (e2) {
+      applyOutput = "Apply output empty and no fallback log available."
+    }
+  } else if (applyOutput.trim() === "") {
+    applyOutput = "Apply output empty."
+  }
+
+  const status = usedFallback
+    ? "Pre-apply step failed (init)"
+    : exitCode === 0
+      ? "Applied"
+      : "Apply failed"
+  const icon = usedFallback || exitCode !== 0 ? "❌" : "✅"
+  const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
 
   const summaryMatch = applyOutput.match(
     /Apply complete!\s+Resources:\s+(\d+)\s+added,\s+(\d+)\s+changed,\s+(\d+)\s+destroyed\./,

--- a/.github/actions/terraform-plan-comment/action.yml
+++ b/.github/actions/terraform-plan-comment/action.yml
@@ -14,6 +14,10 @@ inputs:
   output_file:
     description: Path to plan log file from repo root (e.g. infra/aws/plan-stage.txt).
     required: true
+  fallback_log:
+    description: Optional path to pre-plan log (format/validate/init) when plan file is missing.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -35,3 +39,4 @@ runs:
         INPUT_ENV: ${{ inputs.env }}
         INPUT_EXIT_CODE: ${{ inputs.exit_code }}
         INPUT_OUTPUT_FILE: ${{ inputs.output_file }}
+        INPUT_FALLBACK_LOG: ${{ inputs.fallback_log }}

--- a/.github/actions/terraform-plan-comment/comment.js
+++ b/.github/actions/terraform-plan-comment/comment.js
@@ -11,6 +11,10 @@ async function main({ github, context, core, fs, path }) {
     process.env.GITHUB_WORKSPACE || ".",
     core.getInput("output_file", { required: true }),
   )
+  const fallbackPathRaw = (core.getInput("fallback_log") || "").trim()
+  const fallbackPath = fallbackPathRaw
+    ? path.join(process.env.GITHUB_WORKSPACE || ".", fallbackPathRaw)
+    : ""
   const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
 
   const marker = env
@@ -19,10 +23,32 @@ async function main({ github, context, core, fs, path }) {
   const envLabel = env ? `/${env}` : ""
 
   let plan = ""
+  let usedFallback = false
   try {
     plan = fs.readFileSync(outputPath, "utf8")
   } catch (e) {
-    plan = `Unable to read ${outputPath}: ${e.message}`
+    if (fallbackPath) {
+      try {
+        plan = fs.readFileSync(fallbackPath, "utf8")
+        usedFallback = true
+      } catch (e2) {
+        plan = `Unable to read plan output: ${e.message}. Fallback log: ${e2.message}`
+      }
+    } else {
+      plan = `Unable to read ${outputPath}: ${e.message}`
+    }
+  }
+  if (!usedFallback && plan.trim() === "") {
+    if (fallbackPath) {
+      try {
+        plan = fs.readFileSync(fallbackPath, "utf8")
+        usedFallback = true
+      } catch (e2) {
+        plan = "Plan output empty and no fallback log available."
+      }
+    } else if (plan.trim() === "") {
+      plan = "Plan output empty."
+    }
   }
 
   const summaryMatch = plan.match(
@@ -32,8 +58,9 @@ async function main({ github, context, core, fs, path }) {
   const changeCount = summaryMatch ? Number(summaryMatch[2]) : 0
   const destroyCount = summaryMatch ? Number(summaryMatch[3]) : 0
   const totalChanges = addCount + changeCount + destroyCount
-  const status =
-    exitCode === 1
+  const status = usedFallback
+    ? "Pre-plan step failed (format/validate/init)"
+    : exitCode === 1
       ? "Plan failed"
       : summaryMatch
         ? totalChanges > 0
@@ -42,8 +69,9 @@ async function main({ github, context, core, fs, path }) {
         : exitCode === 2
           ? "Changes detected"
           : "No changes"
-  const icon =
-    exitCode === 1
+  const icon = usedFallback
+    ? "❌"
+    : exitCode === 1
       ? "❌"
       : summaryMatch
         ? totalChanges > 0

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -80,8 +80,13 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TERRAFORM_APPLY_ROLE_ARN }}
           aws-region: us-east-2
+      - name: Prepare job log
+        run: printf "" > job-log.txt
       - name: Terraform init
-        run: terraform init -backend-config=../backend-config/shared.hcl -backend-config=${{ steps.vars.outputs.backend }} -reconfigure -input=false
+        run: |
+          echo "=== Init ===" >> job-log.txt
+          terraform init -backend-config=../backend-config/shared.hcl -backend-config=${{ steps.vars.outputs.backend }} -reconfigure -input=false 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Terraform apply
         id: apply_aws
         continue-on-error: true
@@ -99,6 +104,7 @@ jobs:
           exit_code: ${{ steps.apply_aws.outputs.exit_code || '1' }}
           env: ${{ steps.vars.outputs.deploy_env }}
           output_file: infra/aws/apply-aws.txt
+          fallback_log: infra/aws/job-log.txt
       - name: Fail job if apply failed
         if: ${{ steps.apply_aws.outputs.exit_code != '0' }}
         run: exit 1
@@ -137,8 +143,13 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.11.0
+      - name: Prepare job log
+        run: printf "" > job-log.txt
       - name: Terraform init
-        run: terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false
+        run: |
+          echo "=== Init ===" >> job-log.txt
+          terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Terraform apply
         id: apply_vercel
         continue-on-error: true
@@ -156,6 +167,7 @@ jobs:
           exit_code: ${{ steps.apply_vercel.outputs.exit_code || '1' }}
           env: ${{ steps.vars.outputs.deploy_env }}
           output_file: infra/vercel/apply-vercel.txt
+          fallback_log: infra/vercel/job-log.txt
       - name: Fail job if apply failed
         if: ${{ steps.apply_vercel.outputs.exit_code != '0' }}
         run: exit 1
@@ -191,8 +203,13 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.11.0
+      - name: Prepare job log
+        run: printf "" > job-log.txt
       - name: Terraform init
-        run: terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false
+        run: |
+          echo "=== Init ===" >> job-log.txt
+          terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Terraform apply
         id: apply_github
         continue-on-error: true
@@ -210,6 +227,7 @@ jobs:
           exit_code: ${{ steps.apply_github.outputs.exit_code || '1' }}
           env: prod
           output_file: infra/github/apply-github.txt
+          fallback_log: infra/github/job-log.txt
       - name: Fail job if apply failed
         if: ${{ steps.apply_github.outputs.exit_code != '0' }}
         run: exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -114,12 +114,23 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.11.0
+      - name: Prepare job log
+        run: printf "" > job-log.txt
       - name: Format check
-        run: terraform fmt -check -recursive
+        run: |
+          echo "=== Format check ===" >> job-log.txt
+          terraform fmt -check -recursive 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Init
-        run: terraform init -backend-config=../backend-config/shared.hcl -backend-config=${{ steps.vars.outputs.backend }} -reconfigure -input=false
+        run: |
+          echo "=== Init ===" >> job-log.txt
+          terraform init -backend-config=../backend-config/shared.hcl -backend-config=${{ steps.vars.outputs.backend }} -reconfigure -input=false 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Validate
-        run: terraform validate
+        run: |
+          echo "=== Validate ===" >> job-log.txt
+          terraform validate 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Plan ${{ matrix.environment }}
         id: plan
         continue-on-error: true
@@ -138,6 +149,7 @@ jobs:
           env: ${{ matrix.environment }}
           exit_code: ${{ steps.plan.outputs.exit_code || '1' }}
           output_file: infra/aws/plan-${{ matrix.environment }}.txt
+          fallback_log: infra/aws/job-log.txt
       - name: Fail job if plan errored
         if: ${{ steps.plan.outputs.exit_code == '1' }}
         run: |
@@ -175,12 +187,23 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.11.0
+      - name: Prepare job log
+        run: printf "" > job-log.txt
       - name: Format check
-        run: terraform fmt -check -recursive
+        run: |
+          echo "=== Format check ===" >> job-log.txt
+          terraform fmt -check -recursive 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Init
-        run: terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false
+        run: |
+          echo "=== Init ===" >> job-log.txt
+          terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Validate
-        run: terraform validate
+        run: |
+          echo "=== Validate ===" >> job-log.txt
+          terraform validate 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Plan
         id: plan_vercel
         continue-on-error: true
@@ -199,6 +222,7 @@ jobs:
           env: ""
           exit_code: ${{ steps.plan_vercel.outputs.exit_code || '1' }}
           output_file: infra/vercel/plan-vercel.txt
+          fallback_log: infra/vercel/job-log.txt
       - name: Fail job if plan errored
         if: ${{ steps.plan_vercel.outputs.exit_code == '1' }}
         run: |
@@ -236,12 +260,23 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.11.0
+      - name: Prepare job log
+        run: printf "" > job-log.txt
       - name: Format check
-        run: terraform fmt -check -recursive
+        run: |
+          echo "=== Format check ===" >> job-log.txt
+          terraform fmt -check -recursive 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Init
-        run: terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false
+        run: |
+          echo "=== Init ===" >> job-log.txt
+          terraform init -backend-config=../backend-config/shared.hcl -backend-config=backend-config.hcl -reconfigure -input=false 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Validate
-        run: terraform validate
+        run: |
+          echo "=== Validate ===" >> job-log.txt
+          terraform validate 2>&1 | tee -a job-log.txt
+          exit ${PIPESTATUS[0]}
       - name: Plan
         id: plan_github
         continue-on-error: true
@@ -260,6 +295,7 @@ jobs:
           env: prod
           exit_code: ${{ steps.plan_github.outputs.exit_code || '1' }}
           output_file: infra/github/plan-github.txt
+          fallback_log: infra/github/job-log.txt
       - name: Fail job if plan errored
         if: ${{ steps.plan_github.outputs.exit_code == '1' }}
         run: |


### PR DESCRIPTION
Resolves #279

## Summary

When plan/apply fails on format check, validate, or init, the comment step still runs but the plan/apply output file was never written, so the comment showed only "Unable to read ... ENOENT". This change captures pre-step output into a job log and passes it to the comment action as `fallback_log`; when the main output is missing or empty, the comment shows the actual failure log with status "Pre-plan step failed (format/validate/init)" or "Pre-apply step failed (init)".

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)

Made with [Cursor](https://cursor.com)