### PR TITLE
fix(infra): enforce prod deployment approval gates

### DIFF
--- a/infra/github/environments.tf
+++ b/infra/github/environments.tf
@@ -1,14 +1,29 @@
 # Deployment environments (protection rules, env-specific vars).
 # aws-*: terraform-apply; aws-plan-*: terraform-plan; cms-*: cms-deploy; vercel/github: separate plan/apply roles.
 
+data "github_user" "prod_environment_reviewer" {
+  username = "tataihono"
+}
+
 resource "github_repository_environment" "aws_stage" {
   repository  = github_repository.forge.name
   environment = "aws-stage"
 }
 
 resource "github_repository_environment" "aws_prod" {
-  repository  = github_repository.forge.name
-  environment = "aws-prod"
+  repository          = github_repository.forge.name
+  environment         = "aws-prod"
+  can_admins_bypass   = false
+  prevent_self_review = true
+
+  deployment_branch_policy {
+    protected_branches     = true
+    custom_branch_policies = false
+  }
+
+  reviewers {
+    users = [data.github_user.prod_environment_reviewer.id]
+  }
 }
 
 resource "github_repository_environment" "aws_plan_stage" {
@@ -27,8 +42,19 @@ resource "github_repository_environment" "cms_stage" {
 }
 
 resource "github_repository_environment" "cms_prod" {
-  repository  = github_repository.forge.name
-  environment = "cms-prod"
+  repository          = github_repository.forge.name
+  environment         = "cms-prod"
+  can_admins_bypass   = false
+  prevent_self_review = true
+
+  deployment_branch_policy {
+    protected_branches     = true
+    custom_branch_policies = false
+  }
+
+  reviewers {
+    users = [data.github_user.prod_environment_reviewer.id]
+  }
 }
 
 resource "github_repository_environment" "vercel_plan" {


### PR DESCRIPTION
## Summary
- enforce Terraform-managed approval gates on `aws-prod` and `cms-prod` GitHub environments
- require explicit reviewer approval, prevent self-review/admin bypass, and limit deployments to protected branches
- codify this in `infra/github/environments.tf` so prod gating is no longer manual drift

## Contracts Changed
- [ ] yes
- [x] no

## Regeneration Required
- [ ] yes
- [x] no

## Validation
- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

Resolves #67

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced production deployment safeguards by implementing mandatory reviewer approval requirements, protecting deployment branches, and preventing self-review and admin override on AWS and CMS production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->