### PR TITLE
fix(infra): terraform apply IAM permissions for groups, users, and autoscaling

### DIFF
--- a/infra/aws/github/terraform.tf
+++ b/infra/aws/github/terraform.tf
@@ -64,7 +64,8 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
       "route53:*",
       "s3:*",
       "ssm:*",
-      "wafv2:*"
+      "wafv2:*",
+      "application-autoscaling:*"
     ]
     resources = ["*"]
   }
@@ -139,27 +140,56 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
   }
 
   statement {
-    sid    = "DenyIamUserAndGroupMutation"
-    effect = "Deny"
+    sid    = "TerraformIamGroupManagement"
+    effect = "Allow"
     actions = [
-      "iam:AddUserToGroup",
       "iam:AttachGroupPolicy",
-      "iam:AttachUserPolicy",
-      "iam:CreateAccessKey",
       "iam:CreateGroup",
-      "iam:CreateLoginProfile",
-      "iam:CreateUser",
-      "iam:DeleteAccessKey",
       "iam:DeleteGroup",
       "iam:DeleteGroupPolicy",
-      "iam:DeleteLoginProfile",
-      "iam:DeleteUser",
-      "iam:DeleteUserPolicy",
       "iam:DetachGroupPolicy",
-      "iam:DetachUserPolicy",
-      "iam:PutGroupPolicy",
-      "iam:PutUserPolicy",
+      "iam:GetGroup",
+      "iam:GetGroupPolicy",
+      "iam:ListAttachedGroupPolicies",
+      "iam:ListGroupPolicies",
+      "iam:PutGroupPolicy"
+    ]
+    resources = [
+      "arn:aws:iam::*:group/forge-*"
+    ]
+  }
+
+  statement {
+    sid    = "TerraformIamUserManagement"
+    effect = "Allow"
+    actions = [
+      "iam:AddUserToGroup",
+      "iam:CreateUser",
+      "iam:DeleteUser",
+      "iam:GetUser",
+      "iam:ListGroupsForUser",
+      "iam:ListUserTags",
       "iam:RemoveUserFromGroup",
+      "iam:TagUser",
+      "iam:UntagUser"
+    ]
+    resources = [
+      "arn:aws:iam::*:user/*"
+    ]
+  }
+
+  statement {
+    sid    = "DenyIamCredentialMutation"
+    effect = "Deny"
+    actions = [
+      "iam:AttachUserPolicy",
+      "iam:CreateAccessKey",
+      "iam:CreateLoginProfile",
+      "iam:DeleteAccessKey",
+      "iam:DeleteLoginProfile",
+      "iam:DeleteUserPolicy",
+      "iam:DetachUserPolicy",
+      "iam:PutUserPolicy",
       "iam:UpdateLoginProfile"
     ]
     resources = ["*"]


### PR DESCRIPTION
## Summary

The `terraform-apply` workflow fails on `main` due to two missing permissions on the `forge-github-actions-terraform-apply-prod` role:

1. **`application-autoscaling:*`** — not in the service allow list, blocking ECS autoscaling target creation
2. **`iam:CreateGroup` / user ops** — blanket denied by `DenyIamUserAndGroupMutation`, blocking the new IAM module

This PR:
- Adds `application-autoscaling:*` to `TerraformAwsServiceManagement`
- Splits the old deny into scoped allows (`TerraformIamGroupManagement` on `forge-*` groups, `TerraformIamUserManagement` on users)
- Retains a narrower `DenyIamCredentialMutation` guardrail (access keys, login profiles, inline user policies)

Failing run: https://github.com/JesusFilm/forge/actions/runs/22925832670/job/66535976097

Resolves #338

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

**Note:** This is a chicken-and-egg scenario — the policy update and the new IAM resources are in the same `terraform apply`. The policy change (update to existing resource) should apply before the new creates, but if it races, a re-run will succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Updated AWS IAM policies to support expanded service integrations with more granular access controls for infrastructure operations.
  * Refined permission structure for team and user management with improved resource-specific scoping.
  * Strengthened security controls through refined restrictions on sensitive credential operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->