### PR TITLE
docs(infra): clarify dev-secrets onboarding apply job

### DIFF
--- a/infra/aws/iam/users/dev_secrets/README.md
+++ b/infra/aws/iam/users/dev_secrets/README.md
@@ -18,7 +18,7 @@ This access is managed by Terraform via PRs (no manual Terraform runs).
    - no `@`
 3. Open PR.
 4. Merge PR to `main`.
-5. Wait for `github-prod` to successfully deploy from `main` (infra CI apply), which creates your IAM user.
+5. Wait for the `aws-prod` job to successfully apply from `main`, which creates your IAM user.
 6. Let an admin know your account now needs console sign-in setup.
 
 ### 2) Sign in (IAM user, not root)
@@ -51,7 +51,7 @@ This access is managed by Terraform via PRs (no manual Terraform runs).
 
 ## For Admins
 
-After the PR is merged and `github-prod` successfully deploys:
+After the PR is merged and the `aws-prod` job successfully applies:
 
 1. Go to **IAM** -> **Users** -> `<github-handle>-dev-secrets`.
 2. Open **Security credentials**.


### PR DESCRIPTION
## Summary

Update `infra/aws/iam/users/dev_secrets/README.md` to clarify that IAM user creation depends on the `aws-prod` apply job from `main` (not `github-prod` deployment).

Resolves #343

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

Made with [Cursor](https://cursor.com)