### PR TITLE
fix(infra): skip IAM module on stage terraform apply

### DIFF
--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -68,6 +68,7 @@ module "platform" {
 }
 
 module "iam" {
+  count  = var.environment == "prod" ? 1 : 0
   source = "./iam"
 
   tags = var.tags


### PR DESCRIPTION
## Summary

Stage `terraform-apply` fails with `EntityAlreadyExists` for all IAM groups and the MFA policy because IAM resources are global and already managed by the prod state. This adds `count = var.environment == "prod" ? 1 : 0` to `module "iam"` so it only runs on prod.

Resolves #349

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [x] Terraform plan reviewed (if infra change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure deployment logic to optimize resource provisioning based on environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->