### PR TITLE
fix(infra): add missing IAM list permissions for user deletion

### DIFF
--- a/infra/aws/github/terraform.tf
+++ b/infra/aws/github/terraform.tf
@@ -168,7 +168,9 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
       "iam:CreateUser",
       "iam:DeleteUser",
       "iam:GetUser",
+      "iam:ListAttachedUserPolicies",
       "iam:ListGroupsForUser",
+      "iam:ListUserPolicies",
       "iam:ListUserTags",
       "iam:TagUser",
       "iam:UntagUser"


### PR DESCRIPTION
## Summary

Adds `iam:ListUserPolicies` and `iam:ListAttachedUserPolicies` to the `TerraformIamUserManagement` statement in the GitHub Actions terraform-apply role. Terraform's AWS provider calls these when force-destroying IAM users to enumerate policies before deletion — without them, deleting `*-dev-secrets` users fails with 403.

Resolves #352

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [x] Terraform plan reviewed (if infra change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IAM policy permissions to enable additional user policy listing capabilities for the Terraform infrastructure management role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->