### PR TITLE
fix(infra): terraform apply role missing IAM permissions for user deletion

### DIFF
--- a/infra/aws/github/terraform.tf
+++ b/infra/aws/github/terraform.tf
@@ -166,8 +166,11 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
     effect = "Allow"
     actions = [
       "iam:CreateUser",
+      "iam:DeleteAccessKey",
+      "iam:DeleteLoginProfile",
       "iam:DeleteUser",
       "iam:GetUser",
+      "iam:ListAccessKeys",
       "iam:ListAttachedUserPolicies",
       "iam:ListGroupsForUser",
       "iam:ListUserPolicies",
@@ -187,8 +190,6 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
       "iam:AttachUserPolicy",
       "iam:CreateAccessKey",
       "iam:CreateLoginProfile",
-      "iam:DeleteAccessKey",
-      "iam:DeleteLoginProfile",
       "iam:DeleteUserPolicy",
       "iam:DetachUserPolicy",
       "iam:PutUserPolicy",

--- a/infra/aws/iam/users/tataihono/main.tf
+++ b/infra/aws/iam/users/tataihono/main.tf
@@ -13,8 +13,9 @@ data "aws_iam_group" "login_profile" {
 }
 
 resource "aws_iam_user" "user" {
-  name = "tataihono.nikora@jesusfilm.org"
-  path = "/"
+  name          = "tataihono.nikora@jesusfilm.org"
+  path          = "/"
+  force_destroy = true
   tags = merge(var.tags, {
     ManagedBy = "terraform"
     Role      = "admin-readonly-billing"


### PR DESCRIPTION
## Summary

The `forge-github-actions-terraform-apply-prod` role could not delete IAM users because `DenyIamCredentialMutation` blocked `iam:DeleteAccessKey` and `iam:DeleteLoginProfile`, and `TerraformIamUserManagement` was missing `iam:ListAccessKeys`.

Changes:
- Removed `iam:DeleteAccessKey` and `iam:DeleteLoginProfile` from the deny statement (needed for `force_destroy` cleanup)
- Added `iam:ListAccessKeys`, `iam:DeleteAccessKey`, `iam:DeleteLoginProfile` to the user management allow statement
- Added `force_destroy = true` to the `tataihono.nikora@jesusfilm.org` user resource

The deny still blocks privilege-escalation actions: `CreateAccessKey`, `CreateLoginProfile`, `AttachUserPolicy`, `PutUserPolicy`, `UpdateLoginProfile`.

Resolves #356

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)