### PR TITLE
chore(mobile-expo): unit tests for data layer and critical hooks

### DIFF
--- a/mobile/expo/README.md
+++ b/mobile/expo/README.md
@@ -84,6 +84,27 @@ All `.env` files (except `.env.example`) are gitignored. Never commit real endpo
 - **Optional auth:** If Strapi requires a token for read, set `EXPO_PUBLIC_STRAPI_TOKEN`. The client adds `Authorization: Bearer <token>` when present. **Warning:** `EXPO_PUBLIC_STRAPI_TOKEN` is embedded in the client bundle at build time. Do not use production secrets; use a read-only token with minimal scope, or avoid token auth in public builds.
 - **Codegen:** Types and operations come from the shared package `@forge/graphql` (schema: `apps/cms/schema.graphql`). When the Strapi schema changes, run from the **repo root**: `pnpm run codegen`. That regenerates `packages/graphql`; do not hand-edit generated files under `packages/graphql/src/graphql-env.d.ts`.
 
+## Testing
+
+Tests use [Jest](https://jestjs.io/) with the `jest-expo` preset. Test files are colocated with their source (e.g. `Foo.test.tsx` next to `Foo.tsx`).
+
+```bash
+# Run all tests
+pnpm --filter @forge/expo test
+
+# Run a specific test file
+pnpm --filter @forge/expo test -- sectionMapper
+
+# Run in watch mode
+pnpm --filter @forge/expo test -- --watch
+```
+
+Test conventions:
+
+- Use `createElement` for component smoke tests (no full render needed).
+- Mock external modules (`experienceService`, `apolloClient`, `expo-video`) at the top of the test file.
+- Keep tests deterministic — no network calls, no timers, no device state.
+
 ## No shared logic with native apps
 
 This app does not share UI or business logic with `mobile/ios` or `mobile/android`. It consumes Strapi/GraphQL only (see sub-issues #91+).

--- a/mobile/expo/src/hooks/useExperience.test.ts
+++ b/mobile/expo/src/hooks/useExperience.test.ts
@@ -1,0 +1,182 @@
+import type { ApolloClient } from "@apollo/client"
+
+import {
+  getWatchHome,
+  getExperienceBySlug,
+  type ExperienceResult,
+} from "../lib/experienceService"
+import { loadExperience } from "./useExperience"
+
+// -- Mocks -------------------------------------------------------------------
+// jest.mock is hoisted by babel-jest, so the mock is in place before imports run.
+
+jest.mock("../lib/experienceService", () => ({
+  getWatchHome: jest.fn(),
+  getExperienceBySlug: jest.fn(),
+}))
+
+const mockGetWatchHome = getWatchHome as jest.MockedFunction<
+  typeof getWatchHome
+>
+const mockGetBySlug = getExperienceBySlug as jest.MockedFunction<
+  typeof getExperienceBySlug
+>
+
+const fakeClient = {} as ApolloClient
+
+const successResult: ExperienceResult = {
+  data: { documentId: "doc-1", slug: "easter", sections: [] },
+  error: null,
+}
+
+const errorResult: ExperienceResult = {
+  data: null,
+  error: new Error("No experience found"),
+}
+
+// -- Tests -------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+describe("loadExperience", () => {
+  describe("routing to correct fetch function", () => {
+    it("calls getWatchHome when no slug is provided", async () => {
+      mockGetWatchHome.mockResolvedValue(successResult)
+
+      const result = await loadExperience(fakeClient, { locale: "en" })
+
+      expect(mockGetWatchHome).toHaveBeenCalledWith(fakeClient, "en")
+      expect(mockGetBySlug).not.toHaveBeenCalled()
+      expect(result).toEqual(successResult)
+    })
+
+    it("calls getExperienceBySlug when slug is provided", async () => {
+      mockGetBySlug.mockResolvedValue(successResult)
+
+      const result = await loadExperience(fakeClient, {
+        slug: "easter",
+        locale: "en",
+      })
+
+      expect(mockGetBySlug).toHaveBeenCalledWith(fakeClient, "easter", "en")
+      expect(mockGetWatchHome).not.toHaveBeenCalled()
+      expect(result).toEqual(successResult)
+    })
+
+    it("passes locale through to the service", async () => {
+      mockGetBySlug.mockResolvedValue(successResult)
+
+      await loadExperience(fakeClient, { slug: "test", locale: "es" })
+
+      expect(mockGetBySlug).toHaveBeenCalledWith(fakeClient, "test", "es")
+    })
+  })
+
+  describe("fallback logic", () => {
+    it("skips fallback when primary succeeds", async () => {
+      mockGetWatchHome.mockResolvedValue(successResult)
+
+      const result = await loadExperience(fakeClient, {
+        fallbackSlug: "easter",
+        locale: "en",
+      })
+
+      expect(mockGetWatchHome).toHaveBeenCalledTimes(1)
+      expect(mockGetBySlug).not.toHaveBeenCalled()
+      expect(result.data).toBeTruthy()
+    })
+
+    it("tries fallback slug when primary returns no data", async () => {
+      mockGetWatchHome.mockResolvedValue(errorResult)
+      mockGetBySlug.mockResolvedValue(successResult)
+
+      const result = await loadExperience(fakeClient, {
+        fallbackSlug: "easter",
+        locale: "en",
+      })
+
+      expect(mockGetWatchHome).toHaveBeenCalledWith(fakeClient, "en")
+      expect(mockGetBySlug).toHaveBeenCalledWith(fakeClient, "easter", "en")
+      expect(result).toEqual(successResult)
+    })
+
+    it("returns primary error when no fallback slug is specified", async () => {
+      mockGetWatchHome.mockResolvedValue(errorResult)
+
+      const result = await loadExperience(fakeClient, { locale: "en" })
+
+      expect(result).toEqual(errorResult)
+      expect(mockGetBySlug).not.toHaveBeenCalled()
+    })
+
+    it("returns primary error when both primary and fallback fail", async () => {
+      const fallbackError: ExperienceResult = {
+        data: null,
+        error: new Error("Fallback also failed"),
+      }
+      mockGetWatchHome.mockResolvedValue(errorResult)
+      mockGetBySlug.mockResolvedValue(fallbackError)
+
+      const result = await loadExperience(fakeClient, {
+        fallbackSlug: "easter",
+        locale: "en",
+      })
+
+      // Returns the original primary error, not the fallback error
+      expect(result).toEqual(errorResult)
+    })
+
+    it("uses fallback with slug-based primary too", async () => {
+      mockGetBySlug
+        .mockResolvedValueOnce(errorResult) // primary by slug
+        .mockResolvedValueOnce(successResult) // fallback
+
+      const result = await loadExperience(fakeClient, {
+        slug: "nonexistent",
+        fallbackSlug: "easter",
+        locale: "en",
+      })
+
+      expect(mockGetBySlug).toHaveBeenCalledTimes(2)
+      expect(mockGetBySlug).toHaveBeenNthCalledWith(
+        1,
+        fakeClient,
+        "nonexistent",
+        "en",
+      )
+      expect(mockGetBySlug).toHaveBeenNthCalledWith(
+        2,
+        fakeClient,
+        "easter",
+        "en",
+      )
+      expect(result).toEqual(successResult)
+    })
+  })
+
+  describe("error propagation", () => {
+    it("propagates service errors in the result", async () => {
+      const apolloError = { message: "GraphQL error", graphQLErrors: [] }
+      const resultWithError: ExperienceResult = {
+        data: null,
+        error: apolloError as any,
+      }
+      mockGetWatchHome.mockResolvedValue(resultWithError)
+
+      const result = await loadExperience(fakeClient, { locale: "en" })
+
+      expect(result.error).toEqual(apolloError)
+      expect(result.data).toBeNull()
+    })
+
+    it("throws when the service throws (not caught in loadExperience)", async () => {
+      mockGetWatchHome.mockRejectedValue(new Error("Network failure"))
+
+      await expect(
+        loadExperience(fakeClient, { locale: "en" }),
+      ).rejects.toThrow("Network failure")
+    })
+  })
+})

--- a/mobile/expo/src/hooks/useExperience.ts
+++ b/mobile/expo/src/hooks/useExperience.ts
@@ -1,9 +1,11 @@
+import type { ApolloClient } from "@apollo/client"
 import { useEffect, useState } from "react"
 
 import { apolloClient } from "../lib/apolloClient"
 import {
   getExperienceBySlug,
   getWatchHome,
+  type ExperienceResult,
   type MappedExperience,
 } from "../lib/experienceService"
 
@@ -12,10 +14,34 @@ type ExperienceStatus =
   | { status: "error"; message: string }
   | { status: "success"; data: MappedExperience }
 
-interface UseExperienceOptions {
+export interface UseExperienceOptions {
   slug?: string
   fallbackSlug?: string
   locale: string
+}
+
+/**
+ * Loads an experience with optional fallback.
+ * Extracted for testability — the hook wraps this in useState/useEffect.
+ */
+export async function loadExperience(
+  client: ApolloClient,
+  { slug, fallbackSlug, locale }: UseExperienceOptions,
+): Promise<ExperienceResult> {
+  const primary = slug
+    ? getExperienceBySlug(client, slug, locale)
+    : getWatchHome(client, locale)
+
+  const result = await primary
+  if (result.data) return result
+
+  // Try fallback slug if primary failed
+  if (fallbackSlug) {
+    const fallback = await getExperienceBySlug(client, fallbackSlug, locale)
+    if (fallback.data) return fallback
+  }
+
+  return result
 }
 
 export function useExperience({
@@ -29,28 +55,7 @@ export function useExperience({
     let cancelled = false
     setState({ status: "loading" })
 
-    async function load() {
-      const primary = slug
-        ? getExperienceBySlug(apolloClient, slug, locale)
-        : getWatchHome(apolloClient, locale)
-
-      const result = await primary
-      if (result.data) return result
-
-      // Try fallback slug if primary failed
-      if (fallbackSlug) {
-        const fallback = await getExperienceBySlug(
-          apolloClient,
-          fallbackSlug,
-          locale,
-        )
-        if (fallback.data) return fallback
-      }
-
-      return result
-    }
-
-    load()
+    loadExperience(apolloClient, { slug, fallbackSlug, locale })
       .then((result) => {
         if (cancelled) return
         if (result.error) {


### PR DESCRIPTION
## Summary

- Extract `loadExperience` from `useExperience` hook for direct testability (no rendering library needed)
- Add 10 tests covering fetch routing (watchHome vs by-slug), fallback logic, and error propagation
- Add Testing section to README with commands and conventions
- All acceptance criteria from #97 verified (14 test suites, 107 tests)

Resolves #97

## Acceptance criteria checklist

- [x] Data layer tests: fetch paths covered (`experienceService.test.ts` — 8 tests)
- [x] Mapping tests for all 10 section types (`sectionMapper.test.ts` — 17 tests)
- [x] Nested content tests: Section→content, Container→slots→content (`sectionMapper.test.ts`)
- [x] MediaCollection variant tests (all 5) (`MediaCollectionRenderer.test.tsx`)
- [x] SectionDispatcher dispatch tests (`SectionDispatcher.test.tsx` — 11 tests)
- [x] `useExperience` load logic tests (`useExperience.test.ts` — 10 tests)
- [x] Tests run in CI (jest via `pnpm test`)
- [x] README updated with how to run tests

## Contracts Changed

No

## Regeneration Required

No

## Validation

```
Test Suites: 14 passed, 14 total
Tests:       107 passed, 107 total
Lint:        0 warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)