### PR TITLE
fix(infra): add ListVirtualMFADevices permission and moved block for tataihono user

### DIFF
--- a/infra/aws/github/terraform.tf
+++ b/infra/aws/github/terraform.tf
@@ -196,6 +196,17 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
   }
 
   statement {
+    sid    = "TerraformIamMfaCleanup"
+    effect = "Allow"
+    actions = [
+      "iam:ListVirtualMFADevices"
+    ]
+    resources = [
+      "arn:aws:iam::*:mfa/*"
+    ]
+  }
+
+  statement {
     sid    = "DenyIamCredentialMutation"
     effect = "Deny"
     actions = [

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -74,3 +74,8 @@ module "iam" {
   tags = var.tags
 }
 
+moved {
+  from = module.iam.module.users.module.tataihono.aws_iam_user.user
+  to   = module.iam[0].module.users.module.tataihono.aws_iam_user.user
+}
+


### PR DESCRIPTION
## Summary

Follow-up to #360. Two remaining blockers:

1. **`iam:ListVirtualMFADevices`** targets `arn:aws:iam::*:mfa/*`, not `user/*`. Added a separate statement with the correct resource scope.
2. **tataihono `DeleteConflict`**: The old state has `force_destroy = false`, so Terraform skips login profile cleanup before calling `DeleteUser`. Added a `moved` block so Terraform updates in-place (setting `force_destroy = true`) instead of destroy+recreate. The dev-secrets users are fine — they already had `force_destroy = true` in old state.

Resolves #359

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)