### PR TITLE
fix(infra): import IAM groups and policy orphaned by partial state migration

### DIFF
--- a/infra/aws/import-iam.tf
+++ b/infra/aws/import-iam.tf
@@ -1,0 +1,28 @@
+# Temporary imports: groups/policy exist in AWS but were removed from state
+# during the partial module.iam → module.iam[0] migration.
+# Remove this file after a successful apply.
+
+import {
+  to = module.iam[0].module.groups.module.admin_readonly.aws_iam_group.admin_readonly
+  id = "forge-admin-readonly"
+}
+
+import {
+  to = module.iam[0].module.groups.module.billing.aws_iam_group.billing
+  id = "forge-billing"
+}
+
+import {
+  to = module.iam[0].module.groups.module.dev_secrets.aws_iam_group.dev_secrets
+  id = "forge-dev-secrets"
+}
+
+import {
+  to = module.iam[0].module.groups.module.login_profile.aws_iam_group.login_profile
+  id = "forge-iam-login-profile"
+}
+
+import {
+  to = module.iam[0].module.groups.module.require_mfa.aws_iam_policy.require_mfa
+  id = "arn:aws:iam::031374266475:policy/forge-require-mfa"
+}


### PR DESCRIPTION
## Summary

Follow-up to #362. The partial destroy removed IAM groups and the require-mfa policy from Terraform state, but they still exist in AWS (user deletion failed, which blocked actual group deletion). Now Terraform tries to create them at the new `module.iam[0]` address and gets `EntityAlreadyExists`.

Adds `import` blocks to adopt these 5 existing AWS resources into the new state addresses:
- `forge-admin-readonly` group
- `forge-billing` group
- `forge-dev-secrets` group
- `forge-iam-login-profile` group
- `forge-require-mfa` policy

**Note:** `import-iam.tf` should be deleted after a successful apply.

Resolves #359

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added AWS IAM import configuration as part of infrastructure state management updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->