### PR TITLE
feat(mobile-expo): adaptive text colors for dark section backgrounds

### DIFF
--- a/mobile/expo/src/components/sections/BibleQuotesCarouselRenderer.tsx
+++ b/mobile/expo/src/components/sections/BibleQuotesCarouselRenderer.tsx
@@ -12,6 +12,7 @@ import type {
   BibleQuoteItem,
   BibleQuotesCarouselSection,
 } from "../../lib/sectionModels"
+import { useSectionColorScheme } from "./SectionColorSchemeContext"
 
 export interface BibleQuotesCarouselRendererProps {
   section: BibleQuotesCarouselSection
@@ -83,13 +84,18 @@ export function BibleQuotesCarouselRenderer({
   section,
 }: BibleQuotesCarouselRendererProps) {
   const { heading, quotes } = section
+  const colorScheme = useSectionColorScheme()
+  const isOnDark = colorScheme === "light"
 
   return (
     // @ts-expect-error React 19 vs RN component types
     <View style={styles.container}>
       {heading != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.heading} accessibilityRole="header">
+        <Text
+          style={[styles.heading, isOnDark && styles.headingLight]}
+          accessibilityRole="header"
+        >
           {heading}
         </Text>
       )}
@@ -124,6 +130,9 @@ const styles = StyleSheet.create({
     color: "#1a1a1a",
     paddingHorizontal: 24,
     marginBottom: 16,
+  },
+  headingLight: {
+    color: "#ffffff",
   },
   scrollContent: {
     paddingHorizontal: 16,

--- a/mobile/expo/src/components/sections/CTARenderer.tsx
+++ b/mobile/expo/src/components/sections/CTARenderer.tsx
@@ -1,6 +1,7 @@
 import { Linking, Pressable, StyleSheet, Text, View } from "react-native"
 
 import type { CTASection } from "../../lib/sectionModels"
+import { useSectionColorScheme } from "./SectionColorSchemeContext"
 
 export interface CTARendererProps {
   section: CTASection
@@ -8,6 +9,8 @@ export interface CTARendererProps {
 
 export function CTARenderer({ section }: CTARendererProps) {
   const { heading, body, buttonLabel, buttonLink, variant } = section
+  const colorScheme = useSectionColorScheme()
+  const isOnDark = colorScheme === "light"
   const isPrimary = variant !== "secondary"
   const isDisabled = buttonLink == null
 
@@ -25,13 +28,16 @@ export function CTARenderer({ section }: CTARendererProps) {
     <View style={styles.container}>
       {heading != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.heading} accessibilityRole="header">
+        <Text
+          style={[styles.heading, isOnDark && styles.headingLight]}
+          accessibilityRole="header"
+        >
           {heading}
         </Text>
       )}
       {body != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.body}>{body}</Text>
+        <Text style={[styles.body, isOnDark && styles.bodyLight]}>{body}</Text>
       )}
       {/* @ts-expect-error React 19 vs RN component types */}
       <Pressable
@@ -76,12 +82,18 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginBottom: 8,
   },
+  headingLight: {
+    color: "#ffffff",
+  },
   body: {
     fontSize: 16,
     color: "#4a4a4a",
     textAlign: "center",
     lineHeight: 24,
     marginBottom: 16,
+  },
+  bodyLight: {
+    color: "rgba(255, 255, 255, 0.85)",
   },
   button: {
     paddingHorizontal: 28,

--- a/mobile/expo/src/components/sections/MediaCollectionRenderer.tsx
+++ b/mobile/expo/src/components/sections/MediaCollectionRenderer.tsx
@@ -13,6 +13,7 @@ import type {
   MediaCollectionItem,
   MediaCollectionSection,
 } from "../../lib/sectionModels"
+import { useSectionColorScheme } from "./SectionColorSchemeContext"
 
 export interface MediaCollectionRendererProps {
   section: MediaCollectionSection
@@ -23,11 +24,13 @@ function MediaItemCard({
   index,
   showNumber,
   large,
+  isOnDark,
 }: {
   item: MediaCollectionItem
   index: number
   showNumber: boolean
   large?: boolean
+  isOnDark?: boolean
 }) {
   const thumbnailUrl = item.imageOverride?.url ?? item.video?.image?.url ?? null
   const thumbnailAlt =
@@ -73,12 +76,18 @@ function MediaItemCard({
         )}
       </View>
       {/* @ts-expect-error RN Text vs React 19 ReactNode */}
-      <Text style={styles.itemTitle} numberOfLines={2}>
+      <Text
+        style={[styles.itemTitle, isOnDark && styles.itemTitleLight]}
+        numberOfLines={2}
+      >
         {title}
       </Text>
       {subtitle != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.itemSubtitle} numberOfLines={1}>
+        <Text
+          style={[styles.itemSubtitle, isOnDark && styles.itemSubtitleLight]}
+          numberOfLines={1}
+        >
           {subtitle}
         </Text>
       )}
@@ -105,6 +114,8 @@ export function MediaCollectionRenderer({
     items,
   } = section
 
+  const colorScheme = useSectionColorScheme()
+  const isOnDark = colorScheme === "light"
   const showNumbers = showItemNumbers === true
 
   const handleCtaPress = async () => {
@@ -121,24 +132,35 @@ export function MediaCollectionRenderer({
     <View style={styles.container}>
       {categoryLabel != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.categoryLabel}>{categoryLabel}</Text>
+        <Text
+          style={[styles.categoryLabel, isOnDark && styles.categoryLabelLight]}
+        >
+          {categoryLabel}
+        </Text>
       )}
       {title != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.title} accessibilityRole="header">
+        <Text
+          style={[styles.title, isOnDark && styles.titleLight]}
+          accessibilityRole="header"
+        >
           {title}
         </Text>
       )}
       {subtitle != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.subtitle}>{subtitle}</Text>
+        <Text style={[styles.subtitle, isOnDark && styles.subtitleLight]}>
+          {subtitle}
+        </Text>
       )}
       {description != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.description}>{description}</Text>
+        <Text style={[styles.description, isOnDark && styles.descriptionLight]}>
+          {description}
+        </Text>
       )}
 
-      {items.length > 0 && renderItems(variant, items, showNumbers)}
+      {items.length > 0 && renderItems(variant, items, showNumbers, isOnDark)}
 
       {ctaLink != null && (
         // @ts-expect-error React 19 vs RN component types
@@ -164,6 +186,7 @@ function renderItems(
   variant: MediaCollectionSection["variant"],
   items: MediaCollectionItem[],
   showNumbers: boolean,
+  isOnDark?: boolean,
 ): React.ReactNode {
   switch (variant) {
     case "carousel":
@@ -178,7 +201,12 @@ function renderItems(
           {items.map((item, i) => (
             // @ts-expect-error React 19 vs RN component types
             <View key={item.id} style={styles.carouselItem}>
-              <MediaItemCard item={item} index={i} showNumber={showNumbers} />
+              <MediaItemCard
+                item={item}
+                index={i}
+                showNumber={showNumbers}
+                isOnDark={isOnDark}
+              />
             </View>
           ))}
         </ScrollView>
@@ -206,6 +234,7 @@ function renderItems(
                 item={item}
                 index={index}
                 showNumber={showNumbers}
+                isOnDark={isOnDark}
               />
             </View>
           )}
@@ -214,12 +243,24 @@ function renderItems(
 
     case "hero":
       return (
-        <MediaItemCard item={items[0]} index={0} showNumber={false} large />
+        <MediaItemCard
+          item={items[0]}
+          index={0}
+          showNumber={false}
+          large
+          isOnDark={isOnDark}
+        />
       )
 
     case "player":
       return (
-        <MediaItemCard item={items[0]} index={0} showNumber={false} large />
+        <MediaItemCard
+          item={items[0]}
+          index={0}
+          showNumber={false}
+          large
+          isOnDark={isOnDark}
+        />
       )
 
     case "collection":
@@ -230,7 +271,12 @@ function renderItems(
           {items.map((item, i) => (
             // @ts-expect-error React 19 vs RN component types
             <View key={item.id} style={styles.collectionItem}>
-              <MediaItemCard item={item} index={i} showNumber={showNumbers} />
+              <MediaItemCard
+                item={item}
+                index={i}
+                showNumber={showNumbers}
+                isOnDark={isOnDark}
+              />
             </View>
           ))}
         </View>
@@ -254,6 +300,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     marginBottom: 4,
   },
+  categoryLabelLight: {
+    color: "rgba(255, 255, 255, 0.7)",
+  },
   title: {
     fontSize: 24,
     fontWeight: "700",
@@ -261,11 +310,17 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     marginBottom: 4,
   },
+  titleLight: {
+    color: "#ffffff",
+  },
   subtitle: {
     fontSize: 16,
     color: "#666666",
     paddingHorizontal: 24,
     marginBottom: 4,
+  },
+  subtitleLight: {
+    color: "rgba(255, 255, 255, 0.7)",
   },
   description: {
     fontSize: 14,
@@ -273,6 +328,9 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     paddingHorizontal: 24,
     marginBottom: 12,
+  },
+  descriptionLight: {
+    color: "rgba(255, 255, 255, 0.85)",
   },
   // Carousel
   carouselContent: {
@@ -358,10 +416,16 @@ const styles = StyleSheet.create({
     color: "#1a1a1a",
     marginTop: 8,
   },
+  itemTitleLight: {
+    color: "#ffffff",
+  },
   itemSubtitle: {
     fontSize: 12,
     color: "#666666",
     marginTop: 2,
+  },
+  itemSubtitleLight: {
+    color: "rgba(255, 255, 255, 0.7)",
   },
   ctaLink: {
     paddingHorizontal: 24,

--- a/mobile/expo/src/components/sections/RelatedQuestionsRenderer.tsx
+++ b/mobile/expo/src/components/sections/RelatedQuestionsRenderer.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { Pressable, StyleSheet, Text, View } from "react-native"
 
 import type { RelatedQuestionsSection } from "../../lib/sectionModels"
+import { useSectionColorScheme } from "./SectionColorSchemeContext"
 
 export interface RelatedQuestionsRendererProps {
   section: RelatedQuestionsSection
@@ -12,6 +13,8 @@ export function RelatedQuestionsRenderer({
 }: RelatedQuestionsRendererProps) {
   const { heading, questions } = section
   const [expandedId, setExpandedId] = useState<string | null>(null)
+  const colorScheme = useSectionColorScheme()
+  const isOnDark = colorScheme === "light"
 
   const toggle = (id: string) => {
     setExpandedId((prev) => (prev === id ? null : id))
@@ -22,7 +25,10 @@ export function RelatedQuestionsRenderer({
     <View style={styles.container}>
       {heading != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.heading} accessibilityRole="header">
+        <Text
+          style={[styles.heading, isOnDark && styles.headingLight]}
+          accessibilityRole="header"
+        >
           {heading}
         </Text>
       )}
@@ -30,7 +36,10 @@ export function RelatedQuestionsRenderer({
         const isExpanded = expandedId === item.id
         return (
           // @ts-expect-error React 19 vs RN component types
-          <View key={item.id} style={styles.item}>
+          <View
+            key={item.id}
+            style={[styles.item, isOnDark && styles.itemLight]}
+          >
             {/* @ts-expect-error React 19 vs RN component types */}
             <Pressable
               style={styles.questionRow}
@@ -40,15 +49,27 @@ export function RelatedQuestionsRenderer({
               accessibilityState={{ expanded: isExpanded }}
             >
               {/* @ts-expect-error RN Text vs React 19 ReactNode */}
-              <Text style={styles.questionText} numberOfLines={3}>
+              <Text
+                style={[
+                  styles.questionText,
+                  isOnDark && styles.questionTextLight,
+                ]}
+                numberOfLines={3}
+              >
                 {item.question}
               </Text>
               {/* @ts-expect-error RN Text vs React 19 ReactNode */}
-              <Text style={styles.chevron}>{isExpanded ? "▾" : "▸"}</Text>
+              <Text style={[styles.chevron, isOnDark && styles.chevronLight]}>
+                {isExpanded ? "▾" : "▸"}
+              </Text>
             </Pressable>
             {isExpanded && (
               // @ts-expect-error RN Text vs React 19 ReactNode
-              <Text style={styles.answerText}>{item.answer}</Text>
+              <Text
+                style={[styles.answerText, isOnDark && styles.answerTextLight]}
+              >
+                {item.answer}
+              </Text>
             )}
           </View>
         )
@@ -68,9 +89,15 @@ const styles = StyleSheet.create({
     color: "#1a1a1a",
     marginBottom: 16,
   },
+  headingLight: {
+    color: "#ffffff",
+  },
   item: {
     borderBottomWidth: 1,
     borderBottomColor: "#e5e5e5",
+  },
+  itemLight: {
+    borderBottomColor: "rgba(255, 255, 255, 0.2)",
   },
   questionRow: {
     flexDirection: "row",
@@ -84,14 +111,23 @@ const styles = StyleSheet.create({
     color: "#1a1a1a",
     marginRight: 12,
   },
+  questionTextLight: {
+    color: "#ffffff",
+  },
   chevron: {
     fontSize: 18,
     color: "#666666",
+  },
+  chevronLight: {
+    color: "rgba(255, 255, 255, 0.7)",
   },
   answerText: {
     fontSize: 15,
     color: "#4a4a4a",
     lineHeight: 22,
     paddingBottom: 16,
+  },
+  answerTextLight: {
+    color: "rgba(255, 255, 255, 0.85)",
   },
 })

--- a/mobile/expo/src/components/sections/SectionColorSchemeContext.test.ts
+++ b/mobile/expo/src/components/sections/SectionColorSchemeContext.test.ts
@@ -1,0 +1,26 @@
+import {
+  SectionColorSchemeContext,
+  useSectionColorScheme,
+  type ColorScheme,
+} from "./SectionColorSchemeContext"
+
+describe("SectionColorSchemeContext", () => {
+  it("exports the context with 'dark' as default value", () => {
+    // The context's default value is used when no Provider is above
+    // We verify the exported default matches our expectation
+    const ctx = SectionColorSchemeContext as { _currentValue: ColorScheme }
+    const defaultValue: ColorScheme = ctx._currentValue
+    expect(defaultValue).toBe("dark")
+  })
+
+  it("exports useSectionColorScheme hook as a function", () => {
+    expect(typeof useSectionColorScheme).toBe("function")
+  })
+
+  it("ColorScheme type accepts valid values", () => {
+    const light: ColorScheme = "light"
+    const dark: ColorScheme = "dark"
+    expect(light).toBe("light")
+    expect(dark).toBe("dark")
+  })
+})

--- a/mobile/expo/src/components/sections/SectionColorSchemeContext.ts
+++ b/mobile/expo/src/components/sections/SectionColorSchemeContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react"
+
+/**
+ * Color scheme for section content, derived from the parent SectionWrapper's
+ * background color.
+ *
+ * - `'dark'` → dark text on light background (default)
+ * - `'light'` → light text on dark background
+ */
+export type ColorScheme = "light" | "dark"
+
+export const SectionColorSchemeContext = createContext<ColorScheme>("dark")
+
+export function useSectionColorScheme(): ColorScheme {
+  return useContext(SectionColorSchemeContext)
+}

--- a/mobile/expo/src/components/sections/SectionWrapperRenderer.tsx
+++ b/mobile/expo/src/components/sections/SectionWrapperRenderer.tsx
@@ -4,6 +4,10 @@ import type {
   SectionBackgroundColor,
   SectionWrapperSection,
 } from "../../lib/sectionModels"
+import {
+  SectionColorSchemeContext,
+  type ColorScheme,
+} from "./SectionColorSchemeContext"
 import { ContentDispatcher } from "./SectionDispatcher"
 
 export interface SectionWrapperRendererProps {
@@ -17,6 +21,13 @@ const backgroundColors: Record<SectionBackgroundColor, string> = {
   primary: "#CB333B",
 }
 
+const colorSchemes: Record<SectionBackgroundColor, ColorScheme> = {
+  default: "dark",
+  light: "dark",
+  dark: "light",
+  primary: "light",
+}
+
 export function SectionWrapperRenderer({
   section,
 }: SectionWrapperRendererProps) {
@@ -27,6 +38,8 @@ export function SectionWrapperRenderer({
     ? backgroundColors[backgroundColor]
     : undefined
 
+  const colorScheme = backgroundColor ? colorSchemes[backgroundColor] : "dark"
+
   return (
     // @ts-expect-error React 19 vs RN component types
     <View
@@ -35,7 +48,9 @@ export function SectionWrapperRenderer({
         bgColor != null && { backgroundColor: bgColor },
       ]}
     >
-      {content.length > 0 && <ContentDispatcher content={content} />}
+      <SectionColorSchemeContext.Provider value={colorScheme}>
+        {content.length > 0 && <ContentDispatcher content={content} />}
+      </SectionColorSchemeContext.Provider>
     </View>
   )
 }

--- a/mobile/expo/src/components/sections/TextRenderer.tsx
+++ b/mobile/expo/src/components/sections/TextRenderer.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, View } from "react-native"
 
 import type { TextHeadingLevel, TextSection } from "../../lib/sectionModels"
+import { useSectionColorScheme } from "./SectionColorSchemeContext"
 
 export interface TextRendererProps {
   section: TextSection
@@ -17,6 +18,8 @@ const headingFontSizes: Record<TextHeadingLevel, number> = {
 
 export function TextRenderer({ section }: TextRendererProps) {
   const { heading, headingLevel, subtitle, content, variant } = section
+  const colorScheme = useSectionColorScheme()
+  const isOnDark = colorScheme === "light"
 
   const isLead = variant === "lead"
   const isSmall = variant === "small"
@@ -35,7 +38,11 @@ export function TextRenderer({ section }: TextRendererProps) {
       {heading != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
         <Text
-          style={[styles.heading, { fontSize: headingSize }]}
+          style={[
+            styles.heading,
+            { fontSize: headingSize },
+            isOnDark && styles.headingLight,
+          ]}
           accessibilityRole="header"
         >
           {heading}
@@ -43,7 +50,9 @@ export function TextRenderer({ section }: TextRendererProps) {
       )}
       {subtitle != null && (
         // @ts-expect-error RN Text vs React 19 ReactNode
-        <Text style={styles.subtitle}>{subtitle}</Text>
+        <Text style={[styles.subtitle, isOnDark && styles.subtitleLight]}>
+          {subtitle}
+        </Text>
       )}
       {/* @ts-expect-error RN Text vs React 19 ReactNode */}
       <Text
@@ -51,6 +60,7 @@ export function TextRenderer({ section }: TextRendererProps) {
           styles.content,
           isLead && styles.contentLead,
           isSmall && styles.contentSmall,
+          isOnDark && styles.contentLight,
         ]}
       >
         {content}
@@ -75,16 +85,25 @@ const styles = StyleSheet.create({
     color: "#1a1a1a",
     marginBottom: 8,
   },
+  headingLight: {
+    color: "#ffffff",
+  },
   subtitle: {
     fontSize: 16,
     fontWeight: "500",
     color: "#666666",
     marginBottom: 12,
   },
+  subtitleLight: {
+    color: "rgba(255, 255, 255, 0.7)",
+  },
   content: {
     fontSize: 16,
     color: "#333333",
     lineHeight: 24,
+  },
+  contentLight: {
+    color: "rgba(255, 255, 255, 0.85)",
   },
   contentLead: {
     fontSize: 20,


### PR DESCRIPTION
## Summary
- Add `SectionColorSchemeContext` (React Context) to propagate `'light'` | `'dark'` color scheme from `SectionWrapperRenderer` to nested child renderers
- `dark` and `primary` backgrounds → light text scheme (white headings, semi-transparent body/subtitle)
- `default` and `light` backgrounds → dark text scheme (existing behavior unchanged)
- Updated 5 leaf renderers: `TextRenderer`, `CTARenderer`, `MediaCollectionRenderer`, `RelatedQuestionsRenderer`, `BibleQuotesCarouselRenderer`

Resolves #368

## Contracts Changed
No

## Regeneration Required
No

## Validation
- [x] `pnpm --filter @forge/expo lint` — 0 warnings
- [x] `pnpm --filter @forge/expo test` — 110 tests pass (15 suites)
- [x] New unit tests for `SectionColorSchemeContext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced dynamic theme support for UI sections, enabling proper styling adjustments based on background context to improve readability and visual consistency across light and dark themed interfaces.

* **Tests**
  * Added test coverage for the new theme context functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->