### PR TITLE
fix(cms): bind knex client methods to preserve `this` context

### DIFF
--- a/apps/cms/src/internal-api-token.ts
+++ b/apps/cms/src/internal-api-token.ts
@@ -35,11 +35,11 @@ async function withTokenBootstrapLock(
     return
   }
 
-  const acquireConnection = connection.client?.acquireConnection
-  const releaseConnection = connection.client?.releaseConnection
+  const client = connection?.client
   if (
-    typeof acquireConnection !== "function" ||
-    typeof releaseConnection !== "function"
+    !client ||
+    typeof client.acquireConnection !== "function" ||
+    typeof client.releaseConnection !== "function"
   ) {
     await raw("SELECT pg_advisory_lock(?)", [TOKEN_BOOTSTRAP_LOCK_ID])
     try {
@@ -50,7 +50,7 @@ async function withTokenBootstrapLock(
     return
   }
 
-  const session = await acquireConnection()
+  const session = await client.acquireConnection()
   try {
     if (typeof session.query !== "function") {
       throw new Error("Postgres advisory lock session does not expose query().")
@@ -67,7 +67,7 @@ async function withTokenBootstrapLock(
         ])
       }
     } finally {
-      await releaseConnection(session)
+      await client.releaseConnection(session)
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes CMS crash-loop on startup: `TypeError: Cannot read properties of undefined (reading 'pool')`.

`acquireConnection` and `releaseConnection` were extracted as standalone function references from the knex client, losing their `this` binding. When knex's `acquireConnection()` ran, `this` was `undefined`, so `this.pool` threw. Fix keeps a `client` reference and calls methods on it directly.

Resolves #392

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code refactoring with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->