### PR TITLE
fix(infra): MFA deny policy blocks password change on first login

### DIFF
--- a/infra/aws/iam/groups/require_mfa/main.tf
+++ b/infra/aws/iam/groups/require_mfa/main.tf
@@ -5,9 +5,19 @@ data "aws_caller_identity" "current" {}
 data "aws_iam_policy_document" "require_mfa" {
   # Deny all when MFA not present (BoolIfExists so long-term keys are also denied).
   statement {
-    sid       = "DenyAllUnlessMFAPresent"
-    effect    = "Deny"
-    actions   = ["*"]
+    sid    = "DenyAllUnlessMFAPresent"
+    effect = "Deny"
+    not_actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:DeleteVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+      "iam:ResyncMFADevice",
+      "iam:GetUser",
+      "iam:GetAccountPasswordPolicy",
+      "iam:ChangePassword",
+    ]
     resources = ["*"]
 
     condition {


### PR DESCRIPTION
## Summary

The `forge-require-mfa` IAM policy's Deny statement used `actions = ["*"]`, which in IAM evaluation always overrides any Allow — including the Allow for `iam:ChangePassword`. This blocked dev-secrets users from changing their password on first console login.

Switches the Deny to use `NotAction` (Terraform `not_actions`) so MFA setup and password self-service actions are excluded from the deny, allowing first-login flows to work.

Resolves #402

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [ ] Terraform plan reviewed (if infra change)