### PR TITLE
docs(infra): update dev-secrets onboarding to use direct security credentials path

### DIFF
--- a/infra/aws/iam/users/dev_secrets/README.md
+++ b/infra/aws/iam/users/dev_secrets/README.md
@@ -64,7 +64,7 @@ MFA-gated permissions only take effect after re-authenticating. Sign out, then s
 3. Verify credentials work (should print your ARN and account ID, press `q` to exit):
    - `aws sts get-caller-identity --profile forge-dev-secrets`
 4. Fetch secrets (from repo root):
-   - `AWS_PROFILE=forge-dev-secrets pnpm fetch-secrets`
+   - `pnpm fetch-secrets`
 
 ## For Admins
 

--- a/scripts/fetch-secrets.ts
+++ b/scripts/fetch-secrets.ts
@@ -19,6 +19,8 @@ type SsmGetParametersByPathResponse = {
   NextToken?: string
 }
 
+const AWS_PROFILE = "forge-dev-secrets"
+
 const PROJECT_CONFIG: Record<Project, ProjectConfig> = {
   cms: {
     defaultPath: "/forge/aws/cms/dev/",
@@ -48,6 +50,8 @@ function fetchAllByPath(ssmPath: string): SsmParameter[] {
 
   do {
     const args = [
+      "--profile",
+      AWS_PROFILE,
       "ssm",
       "get-parameters-by-path",
       "--path",

--- a/turbo.json
+++ b/turbo.json
@@ -28,13 +28,6 @@
     },
     "fetch-secrets": {
       "cache": false,
-      "passThroughEnv": [
-        "AWS_PROFILE",
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_SESSION_TOKEN",
-        "AWS_DEFAULT_REGION"
-      ],
       "outputs": [".env.development.local"]
     },
     "generate": {


### PR DESCRIPTION
## Summary

Updates dev-secrets onboarding README to direct users to **account menu → Security credentials** instead of IAM → Users, which requires `iam:ListUsers` (denied before MFA is enrolled).

Follow-up to #403.

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [x] Reviewed content for accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated MFA setup instructions with revised navigation path
  * Added clarification on access restrictions until MFA is activated
  * Reorganized steps for access key creation and CLI configuration
  * Documented sign-out/sign-in requirement after enabling MFA

<!-- end of auto-generated comment: release notes by coderabbit.ai -->