### PR TITLE
fix(infra): allow access-key programmatic access without MFA

### DIFF
--- a/infra/aws/iam/groups/require_mfa/main.tf
+++ b/infra/aws/iam/groups/require_mfa/main.tf
@@ -3,7 +3,9 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "require_mfa" {
-  # Deny all when MFA not present (BoolIfExists so long-term keys are also denied).
+  # Deny when MFA not present on console sessions. Access-key requests (where
+  # aws:MultiFactorAuthPresent is absent) are allowed through — Bool only
+  # matches when the key exists and equals "false".
   statement {
     sid    = "DenyAllUnlessMFAPresent"
     effect = "Deny"
@@ -21,7 +23,7 @@ data "aws_iam_policy_document" "require_mfa" {
     resources = ["*"]
 
     condition {
-      test     = "BoolIfExists"
+      test     = "Bool"
       variable = "aws:MultiFactorAuthPresent"
       values   = ["false"]
     }
@@ -53,7 +55,7 @@ data "aws_iam_policy_document" "require_mfa" {
 resource "aws_iam_policy" "require_mfa" {
   name        = "forge-require-mfa"
   path        = "/"
-  description = "Requires MFA for all actions; allows MFA setup and self-service so users can enroll on first sign-in."
+  description = "Requires MFA for console sessions; allows access-key programmatic access and MFA self-service."
   policy      = data.aws_iam_policy_document.require_mfa.json
   tags = merge(var.tags, {
     ManagedBy = "terraform"


### PR DESCRIPTION
## Summary

Change the `forge-require-mfa` policy condition from `BoolIfExists` to `Bool` for `aws:MultiFactorAuthPresent`.

- `BoolIfExists` denies when the key is `false` **or absent** — blocks both console-without-MFA and access-key sessions
- `Bool` denies only when the key **exists** and is `false` — blocks console-without-MFA but allows access-key programmatic requests through

Console sessions still require MFA. `pnpm fetch-secrets` works with access keys.

Resolves #405

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [ ] Terraform plan reviewed (if infra change)
