### PR TITLE
fix(infra): add SES permissions to terraform apply IAM role

### DIFF
--- a/infra/aws/github/terraform.tf
+++ b/infra/aws/github/terraform.tf
@@ -63,6 +63,7 @@ data "aws_iam_policy_document" "github_actions_terraform_apply" {
       "rds:*",
       "route53:*",
       "s3:*",
+      "ses:*",
       "ssm:*",
       "wafv2:*",
       "application-autoscaling:*"


### PR DESCRIPTION
## Summary

Add `ses:*` to the `TerraformAwsServiceManagement` statement in the GitHub Actions terraform-apply IAM policy. The role was missing SES permissions, causing `AccessDenied` on `ses:VerifyDomainIdentity` when deploying SES resources from #400.

Resolves #407

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [x] Terraform plan reviewed (if infra change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure permissions to grant expanded email service access to the deployment automation pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->