### PR TITLE
fix(cms): Dockerfile missing provider directory causes pnpm install ENOENT

### DIFF
--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /workspace
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/cms/package.json apps/cms/package.json
+COPY apps/cms/providers/strapi-provider-email-ses/package.json apps/cms/providers/strapi-provider-email-ses/package.json
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --filter @forge/cms...


### PR DESCRIPTION
## Summary

The CMS `package.json` declares a `file:` dependency on `providers/strapi-provider-email-ses`, but the Dockerfile only copied `apps/cms/package.json` before `pnpm install`. This caused `ENOENT` because the provider directory didn't exist yet. Fixed by copying the provider's `package.json` before install.

Resolves #411

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)