### PR TITLE
fix(infra): exempt cross-service calls from MFA deny policy

### DIFF
--- a/infra/aws/iam/groups/require_mfa/main.tf
+++ b/infra/aws/iam/groups/require_mfa/main.tf
@@ -3,9 +3,11 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "require_mfa" {
-  # Deny when MFA not present on console sessions. Access-key requests (where
-  # aws:MultiFactorAuthPresent is absent) are allowed through — Bool only
-  # matches when the key exists and equals "false".
+  # Deny when MFA not present on console sessions. Both conditions must be true
+  # (AND): Bool only matches when aws:MultiFactorAuthPresent exists and equals
+  # "false" (access-key requests omit the key entirely). BoolIfExists on
+  # aws:ViaAWSService treats an absent key as matching, so direct calls are
+  # denied while cross-service calls (e.g. SSM → KMS Decrypt) pass through.
   statement {
     sid    = "DenyAllUnlessMFAPresent"
     effect = "Deny"
@@ -25,6 +27,12 @@ data "aws_iam_policy_document" "require_mfa" {
     condition {
       test     = "Bool"
       variable = "aws:MultiFactorAuthPresent"
+      values   = ["false"]
+    }
+
+    condition {
+      test     = "BoolIfExists"
+      variable = "aws:ViaAWSService"
       values   = ["false"]
     }
   }


### PR DESCRIPTION
## Summary

The `Bool` vs `BoolIfExists` fix (#406) resolved direct SSM access-key calls but `kms:Decrypt` is still explicitly denied by `forge-require-mfa` when SSM invokes KMS as a cross-service request with `--with-decryption`. The KMS request context includes `aws:MultiFactorAuthPresent=false` even for long-term access keys, causing the deny to fire.

Adds `BoolIfExists` condition on `aws:ViaAWSService` so the deny only fires on **direct** calls (console without MFA) and not on cross-service calls (SSM → KMS Decrypt). MFA enforcement is retained for all groups including dev-secrets.

Resolves #405

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed
- [x] Terraform plan reviewed (if infra change)