### PR TITLE
docs(tooling): add agent safeguards for PR formatting and merged branches

### DIFF
--- a/.cursor/rules/gh-workflow.mdc
+++ b/.cursor/rules/gh-workflow.mdc
@@ -60,9 +60,25 @@ Make changes within the bounded context of the issue. When contracts change: run
 
 Produce a series of commits—one per small block of work. Each commit must use conventional format (`feat:`, `fix:`, `chore:`, `docs:` etc.). Atomic and reviewable.
 
+**Before committing**, verify the current branch's PR is not already merged:
+```
+gh pr list --repo JesusFilm/forge --head "$(git branch --show-current)" --state merged --json number
+```
+If the result is non-empty, **stop** — do not commit or push. Create a new branch from `main` instead.
+
 ## 6. PR
 
 Open PR targeting `main`. Use same title format as issue: `type(scope): description`. Fill PR template (Summary, Contracts Changed, Regeneration Required, Validation). Include `Resolves #123` in description.
+
+**Creating/updating PRs and issues with multiline bodies:** Never pass `\n` escape sequences in MCP tool string parameters — they render as literal text. Always use `gh` CLI with a HEREDOC:
+```
+gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
+## Summary
+...
+EOF
+)"
+```
+Same applies to `gh issue create`, `gh pr edit`, and `gh issue edit`.
 
 ## Resolving merge conflicts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,30 @@ Read AGENTS.md before doing any work. It is the single source of truth for workf
 - **Auto commit and push**: Do not ask whether to commit or push after requested changes. Commit and push automatically with a conventional commit message.
 - **Shared rules and skills**: When creating or updating rules or skills, make them available to both Claude and Cursor.
 
+## Merged-branch guard
+
+Before committing, verify the current branch's PR is not already merged:
+
+```
+gh pr list --repo JesusFilm/forge --head "$(git branch --show-current)" --state merged --json number
+```
+
+If non-empty, **stop** — create a new branch from `main` instead.
+
+## Creating PRs and issues
+
+Never pass `\n` escape sequences in API tool string parameters — they render as literal text. Always use `gh` CLI with a HEREDOC for multiline bodies:
+
+```
+gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
+## Summary
+...
+EOF
+)"
+```
+
+Same applies to `gh issue create`, `gh pr edit`, and `gh issue edit`.
+
 ## CI checks (use `gh` CLI)
 
 - Verify PR status: `gh pr checks <PR> --repo JesusFilm/forge`


### PR DESCRIPTION
## Summary

Adds two agent workflow safeguards:
1. **HEREDOC for multiline bodies** — MCP tool string parameters render `\n` as literal text, producing broken PR/issue markdown. Requires `gh` CLI with HEREDOC instead.
2. **Merged-branch guard** — agents must check `gh pr list --state merged` before committing to prevent pushing orphaned changes to already-merged branches.

Mirrored in both `.cursor/rules/gh-workflow.mdc` and `CLAUDE.md`.

Resolves #420

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [x] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed
- [ ] Terraform plan reviewed (if infra change)

Made with [Cursor](https://cursor.com)