### PR TITLE
fix(infra): kms:ResourceAliases condition missing ForAnyValue set operator

### DIFF
--- a/infra/aws/iam/groups/dev_secrets/main.tf
+++ b/infra/aws/iam/groups/dev_secrets/main.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "dev_secrets" {
     resources = ["*"]
 
     condition {
-      test     = "StringLike"
+      test     = "ForAnyValue:StringLike"
       variable = "kms:ResourceAliases"
       values = [
         "alias/forge-cms-dev-ssm",


### PR DESCRIPTION
## Summary

`kms:ResourceAliases` is a multi-valued condition key that requires a `ForAnyValue:` or `ForAllValues:` set operator prefix. The dev-secrets IAM group policy used plain `StringLike`, which silently fails to match, so `kms:Decrypt` is never allowed and `pnpm fetch-secrets --with-decryption` fails with `AccessDeniedException`.

Changed `StringLike` → `ForAnyValue:StringLike` in the `DecryptStageCmsSsm` statement.

Resolves #424

## Contracts Changed

- [x] no

## Regeneration Required

- [x] no

## Validation

- [x] Terraform plan reviewed (if infra change)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IAM policy configuration to improve security credential access evaluation methods. Internal infrastructure enhancement with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->