### PR TITLE
fix(scripts): use dynamic placeholders for EasterDates labels

### DIFF
--- a/scripts/seed-easter.mjs
+++ b/scripts/seed-easter.mjs
@@ -313,11 +313,10 @@ async function main() {
     {
       __typename: "ComponentSectionsEasterDates",
       sectionKey: "easter-dates",
-      easterDatesTitle: "When is Easter celebrated in 2026?",
-      westernEasterLabel:
-        "Western Easter (Catholic/Protestant): Sunday, April 5, 2026",
-      orthodoxEasterLabel: "Orthodox: Sunday, April 12, 2026",
-      passoverLabel: "Jewish Passover: Saturday, April 4, 2026",
+      easterDatesTitle: "When is Easter celebrated in {year}?",
+      westernEasterLabel: "Western Easter (Catholic/Protestant)",
+      orthodoxEasterLabel: "Orthodox",
+      passoverLabel: "Jewish Passover",
     },
 
     // ═══ BLOCK 3: Featured Videos Collection ═══


### PR DESCRIPTION
## Summary

- Replace hardcoded year `2026` with `{year}` placeholder in `easterDatesTitle`
- Strip date strings from labels — renderer calculates dates dynamically via Computus algorithm
- Before: `"Orthodox: Sunday, April 12, 2026"` → After: `"Orthodox"`

This was lost during merge conflict resolution in PR #410.

## Contracts Changed

No

## Regeneration Required

No

## Validation

- [ ] Run seed script and verify EasterDates accordion shows correct labels + calculated dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)