### PR TITLE
chore(tooling): add bounded context folder guard rule for AI agents

### DIFF
--- a/.cursor/rules/bounded-context-folder-guard.mdc
+++ b/.cursor/rules/bounded-context-folder-guard.mdc
@@ -1,0 +1,38 @@
+---
+description: Enforce file changes stay within the bounded context folder of the active issue/epic
+alwaysApply: true
+---
+
+# Bounded Context Folder Guard
+
+Before making any file changes, check the active issue and its parent epic to determine the bounded context. File changes must stay within that context's folder.
+
+## Context-to-folder mapping
+
+| Scope (from issue/epic title) | Allowed folders |
+|-------------------------------|-----------------|
+| `mobile-expo` | `mobile/expo/` |
+| `mobile-ios` | `mobile/ios/` |
+| `mobile-android` | `mobile/android/` |
+| `web` | `apps/web/` |
+| `cms` | `apps/cms/` |
+| `ai-orchestrator` | `apps/ai-orchestrator/` |
+| `graphql` | `packages/graphql/` |
+| `content-models` | `packages/content-models/` |
+| `ai-config` | `packages/ai-config/` |
+| `infra` | `infra/` |
+
+**Shared files** (`pnpm-lock.yaml`, root `package.json`, root config files) are allowed when they are a side effect of dependency changes within the bounded context.
+
+## Rules
+
+1. **Check scope first**: Read the active issue title and its parent epic. The `scope` in `type(scope): description` determines which folder you may modify.
+2. **No cross-platform changes**: A mobile-expo issue must not modify `apps/web/`, `apps/cms/`, or `mobile/ios/` files. A cms issue must not modify `apps/web/` or `mobile/` files. Same for every other context.
+3. **Shared packages require justification**: Changes to `packages/graphql/` or `packages/content-models/` are only allowed if the issue explicitly requires a contract or schema change. Regenerated code (codegen output) is permitted as a side effect.
+4. **If another platform needs changes — stop and escalate**:
+   - Do NOT silently modify files outside the bounded context.
+   - Create a new GitHub issue (or find an existing one) for the other platform's work.
+   - Link it to the current epic if one exists.
+   - Inform the human programmer and wait for confirmation before proceeding.
+   - Example: working on `mobile-expo` issue and discover `apps/cms/` schema needs a new field → create a `cms` issue, tell the programmer, wait.
+5. **Pre-commit check**: Before committing, review all staged files. If any file falls outside the allowed folders, unstage it and follow rule 4.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,39 @@ Same applies to `gh issue create`, `gh pr edit`, and `gh issue edit`.
 - Read failed logs: `gh run view <RUN_ID> --log-failed`
 - View PR reviews: `gh api repos/JesusFilm/forge/pulls/<PR>/comments`
 
+## Bounded context folder guard
+
+Before making any file changes, check the active issue and its parent epic to determine the bounded context. File changes must stay within that context's folder.
+
+**Context-to-folder mapping:**
+
+| Scope             | Allowed folders            |
+| ----------------- | -------------------------- |
+| `mobile-expo`     | `mobile/expo/`             |
+| `mobile-ios`      | `mobile/ios/`              |
+| `mobile-android`  | `mobile/android/`          |
+| `web`             | `apps/web/`                |
+| `cms`             | `apps/cms/`                |
+| `ai-orchestrator` | `apps/ai-orchestrator/`    |
+| `graphql`         | `packages/graphql/`        |
+| `content-models`  | `packages/content-models/` |
+| `ai-config`       | `packages/ai-config/`      |
+| `infra`           | `infra/`                   |
+
+Shared files (`pnpm-lock.yaml`, root `package.json`, root configs) are allowed as side effects of dependency changes within the context.
+
+**Rules:**
+
+1. **Check scope first** — read the active issue title and parent epic. The `scope` in `type(scope): description` determines which folder you may modify.
+2. **No cross-platform changes** — a mobile-expo issue must not modify `apps/web/`, `apps/cms/`, or `mobile/ios/` files. Same for every other context.
+3. **Shared packages require justification** — changes to `packages/graphql/` or `packages/content-models/` only if the issue explicitly requires a contract/schema change. Codegen output is permitted as a side effect.
+4. **If another platform needs changes — stop and escalate:**
+   - Do NOT silently modify files outside the bounded context.
+   - Create a new GitHub issue (or find an existing one) for the other platform's work.
+   - Link it to the current epic if one exists.
+   - Inform the human programmer and **wait for confirmation** before proceeding.
+5. **Pre-commit check** — before committing, review all staged files. If any file falls outside allowed folders, unstage it and follow rule 4.
+
 ## Scoped AGENTS.md files
 
 Each bounded context has its own AGENTS.md with scope-specific rules:


### PR DESCRIPTION
## Summary

- Adds a new enforced rule that maps issue scopes to allowed folders, preventing AI agents from modifying files outside the bounded context of the active issue
- Adds escalation procedure: when cross-context changes are needed, agents must create a separate issue, link to the epic, and wait for human confirmation
- Rule added to both Claude Code (`CLAUDE.md`) and Cursor (`.cursor/rules/bounded-context-folder-guard.mdc`)

**Motivation:** PR #384 demonstrated a dangerous pattern where a mobile-expo branch accidentally reverted web changes from PR #365 during a merge-then-revert. This rule prevents such cross-context side effects.

## Contracts changed

No

## Regeneration required

No

## Validation

- Both files contain identical context-to-folder mapping table (10 scopes)
- Both files contain identical 5 enforcement rules
- `pnpm lint` — pre-existing iOS lint failure only (unrelated)

Resolves #445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a bounded context folder guard policy to enforce code changes within designated project boundaries.
  * Updated documentation with context-to-folder mapping guidance for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->