### PR TITLE
fix(cms): SES email provider export incompatible with Strapi require()

### DIFF
--- a/apps/cms/providers/strapi-provider-email-ses/index.ts
+++ b/apps/cms/providers/strapi-provider-email-ses/index.ts
@@ -24,40 +24,41 @@ function toArray(value: string | string[]): string[] {
   return Array.isArray(value) ? value : [value]
 }
 
-export default {
-  init(providerOptions: ProviderOptions = {}, settings: Settings = {}) {
-    const client = new SESv2Client({ region: providerOptions.region })
+export function init(
+  providerOptions: ProviderOptions = {},
+  settings: Settings = {},
+) {
+  const client = new SESv2Client({ region: providerOptions.region })
 
-    return {
-      async send(options: SendOptions) {
-        const from = options.from ?? settings.defaultFrom
-        const replyTo = options.replyTo ?? settings.defaultReplyTo
+  return {
+    async send(options: SendOptions) {
+      const from = options.from ?? settings.defaultFrom
+      const replyTo = options.replyTo ?? settings.defaultReplyTo
 
-        await client.send(
-          new SendEmailCommand({
-            FromEmailAddress: from,
-            Destination: {
-              ToAddresses: toArray(options.to),
-              ...(options.cc && { CcAddresses: toArray(options.cc) }),
-              ...(options.bcc && { BccAddresses: toArray(options.bcc) }),
-            },
-            Content: {
-              Simple: {
-                Subject: { Data: options.subject, Charset: "UTF-8" },
-                Body: {
-                  ...(options.text && {
-                    Text: { Data: options.text, Charset: "UTF-8" },
-                  }),
-                  ...(options.html && {
-                    Html: { Data: options.html, Charset: "UTF-8" },
-                  }),
-                },
+      await client.send(
+        new SendEmailCommand({
+          FromEmailAddress: from,
+          Destination: {
+            ToAddresses: toArray(options.to),
+            ...(options.cc && { CcAddresses: toArray(options.cc) }),
+            ...(options.bcc && { BccAddresses: toArray(options.bcc) }),
+          },
+          Content: {
+            Simple: {
+              Subject: { Data: options.subject, Charset: "UTF-8" },
+              Body: {
+                ...(options.text && {
+                  Text: { Data: options.text, Charset: "UTF-8" },
+                }),
+                ...(options.html && {
+                  Html: { Data: options.html, Charset: "UTF-8" },
+                }),
               },
             },
-            ...(replyTo && { ReplyToAddresses: [replyTo] }),
-          }),
-        )
-      },
-    }
-  },
+          },
+          ...(replyTo && { ReplyToAddresses: [replyTo] }),
+        }),
+      )
+    },
+  }
 }


### PR DESCRIPTION
## Summary

- Strapi's email bootstrap does `require(path).init()` but `export default { init }` compiles to CJS `exports.default = { init }`, making `provider.init` undefined
- Changed to named `export function init(...)` so `require()` returns `{ init }` directly

Resolves #447

## Contracts Changed

None

## Regeneration Required

No

## Validation

- CMS deploy should succeed without `provider.init is not a function` error

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the email provider's initialization structure for improved API consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->