### PR TITLE
chore(tooling): add cross-platform demo checklist rule for AI agents

### DIFF
--- a/.cursor/rules/cross-platform-demo.mdc
+++ b/.cursor/rules/cross-platform-demo.mdc
@@ -1,0 +1,39 @@
+---
+description: Required steps when asked to demo the cross-platform mobile Expo app
+alwaysApply: true
+---
+
+# Cross-Platform Demo Checklist
+
+When asked to demo, run, or show the mobile Expo app, complete **all** of the following steps. Do not skip any platform.
+
+## 1. Strapi (data backend)
+
+- Check if Strapi is running on `localhost:1337` (`lsof -i :1337`).
+- If not running, start it: `pnpm --filter @forge/cms develop` (from repo root).
+- Check if Easter experience data is seeded: query Strapi GraphQL or check the response.
+- If not seeded, run: `node scripts/seed-easter.mjs` (from repo root).
+
+## 2. Metro bundler
+
+- Check if Metro is running on `localhost:8081` (`lsof -i :8081`).
+- If not running, start it: `cd mobile/expo && npx expo start --clear`.
+
+## 3. iOS simulator
+
+- Boot iPhone 17 Pro simulator if not already booted: `xcrun simctl boot A92DB15F-BD8B-4A07-A011-D3C52B18298A`.
+- Build and run: `cd mobile/expo && npx expo run:ios --device "A92DB15F-BD8B-4A07-A011-D3C52B18298A"`.
+
+## 4. Android emulator
+
+- Set `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"` (no system Java installed).
+- Start Pixel 9a emulator if not running: `$ANDROID_HOME/emulator/emulator -avd Pixel_9a -no-snapshot-load &`.
+- Wait for boot: `adb wait-for-device && adb shell getprop sys.boot_completed`.
+- Build and run: `cd mobile/expo && JAVA_HOME="..." npx expo run:android`.
+
+## 5. Visual verification
+
+- After both apps launch, capture screenshots from both simulators.
+- iOS: `xcrun simctl io <UDID> screenshot /tmp/ios-demo.png`.
+- Android: `adb exec-out screencap -p > /tmp/android-demo.png`.
+- Review the screenshots to confirm the app loaded correctly and data is displayed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,16 @@ Shared files (`pnpm-lock.yaml`, root `package.json`, root configs) are allowed a
    - Inform the human programmer and **wait for confirmation** before proceeding.
 5. **Pre-commit check** — before committing, review all staged files. If any file falls outside allowed folders, unstage it and follow rule 4.
 
+## Cross-platform demo checklist
+
+When asked to demo, run, or show the mobile Expo app, complete **all** steps. Do not skip any platform.
+
+1. **Strapi** — check if running on `localhost:1337`; if not, start with `pnpm --filter @forge/cms develop`. Check if Easter data is seeded; if not, run `node scripts/seed-easter.mjs`.
+2. **Metro** — check if running on `localhost:8081`; if not, start with `cd mobile/expo && npx expo start --clear`.
+3. **iOS** — boot iPhone 17 Pro simulator if needed, build and run with `npx expo run:ios`.
+4. **Android** — set `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`, start Pixel 9a emulator, build and run with `npx expo run:android`.
+5. **Screenshots** — capture screenshots from both simulators (`xcrun simctl io` for iOS, `adb exec-out screencap` for Android) and verify the app loaded correctly with data displayed.
+
 ## Scoped AGENTS.md files
 
 Each bounded context has its own AGENTS.md with scope-specific rules:


### PR DESCRIPTION
## Summary

- Adds a rule requiring AI agents to follow a complete checklist when asked to demo the mobile Expo app
- Checklist: start Strapi (seed if needed) → Metro → iOS build → Android build → capture screenshots for verification
- Rule added to both Claude Code (`CLAUDE.md`) and Cursor (`.cursor/rules/cross-platform-demo.mdc`)

**Motivation:** When demoing the cross-platform app, agents would sometimes skip starting Strapi (no data), skip one platform, or skip visual verification. This rule ensures consistent, complete demos every time.

## Contracts changed

No

## Regeneration required

No

## Validation

- Both files contain the same 5-step checklist
- Only markdown/config files changed — no code impact

Resolves #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cross-platform mobile app demo checklist with detailed setup and verification steps, covering backend configuration, build tools, simulators, emulators, and visual validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->