### PR TITLE
fix(mobile-ios): cta button orange-red gradient, remove section background

### DIFF
--- a/mobile/ios/Sources/ForgeMobile/Views/Sections/CTAView.swift
+++ b/mobile/ios/Sources/ForgeMobile/Views/Sections/CTAView.swift
@@ -55,7 +55,7 @@ struct CTAView: View {
       .foregroundStyle(.white)
       .frame(minWidth: 120)
       .padding(.horizontal, 24)
-      .padding(.vertical, 14)
+      .padding(.vertical, 20)
       .background(
         LinearGradient(
           colors: gradientColors,
@@ -63,7 +63,7 @@ struct CTAView: View {
           endPoint: .trailing
         )
       )
-      .clipShape(Capsule())
+      .clipShape(RoundedRectangle(cornerRadius: 12))
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace system `.borderedProminent`/`.bordered` button styles with a custom orange-to-red `LinearGradient` capsule button to match the reference website design
- Remove `systemGroupedBackground` from the CTA section so it has no background color
- Secondary variant uses a subtler orange gradient; primary uses orange → red

Resolves #458
Parent: #100

## Test plan

- [ ] Build and run on iOS Simulator — verify CTA button renders with orange-red gradient
- [ ] Confirm section has no background color (transparent)
- [ ] Verify primary and secondary variants show distinct gradient styles
- [ ] Test VoiceOver accessibility on CTA button
- [ ] Compare visually against reference: https://www.jesusfilm.org/watch/easter.html/english.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CTA buttons with gradient backgrounds for a more modern appearance.
  * Unified button styling across primary and secondary variants, ensuring consistent visual presentation.
  * Refined button design with improved visual hierarchy and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->