### PR TITLE
fix(web): use INTERNAL_GRAPHQL_URL for server traffic

### DIFF
--- a/apps/web/.env.ci
+++ b/apps/web/.env.ci
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_GRAPHQL_URL=http://localhost:1337/graphql
+INTERNAL_GRAPHQL_URL=http://localhost:1337/graphql
 STRAPI_API_TOKEN=ci-placeholder
 STRAPI_PREVIEW_SECRET=ci-placeholder

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,6 @@
 # GraphQL endpoint (Strapi)
 NEXT_PUBLIC_GRAPHQL_URL=http://localhost:1337/graphql
+INTERNAL_GRAPHQL_URL=http://localhost:1337/graphql
 
 # Production CMS image hostname (e.g. api.example.com)
 NEXT_PUBLIC_CMS_HOSTNAME=

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 export const env = createEnv({
   server: {
+    INTERNAL_GRAPHQL_URL: z.url(),
     STRAPI_API_TOKEN: z.string(),
     STRAPI_PREVIEW_SECRET: z.string(),
   },
@@ -10,6 +11,7 @@ export const env = createEnv({
     NEXT_PUBLIC_GRAPHQL_URL: z.url(),
   },
   runtimeEnv: {
+    INTERNAL_GRAPHQL_URL: process.env.INTERNAL_GRAPHQL_URL,
     STRAPI_API_TOKEN: process.env.STRAPI_API_TOKEN,
     STRAPI_PREVIEW_SECRET: process.env.STRAPI_PREVIEW_SECRET,
     NEXT_PUBLIC_GRAPHQL_URL: process.env.NEXT_PUBLIC_GRAPHQL_URL,

--- a/apps/web/src/lib/client.ts
+++ b/apps/web/src/lib/client.ts
@@ -1,11 +1,13 @@
-import "server-only"
 import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client"
 import { env } from "@/env"
 
-const uri = env.NEXT_PUBLIC_GRAPHQL_URL
-const headers: Record<string, string> = {
-  Authorization: `Bearer ${env.STRAPI_API_TOKEN}`,
-}
+const isServer = typeof window === "undefined"
+const uri = isServer ? env.INTERNAL_GRAPHQL_URL : env.NEXT_PUBLIC_GRAPHQL_URL
+const headers: Record<string, string> = isServer
+  ? {
+      Authorization: `Bearer ${env.STRAPI_API_TOKEN}`,
+    }
+  : {}
 const client = new ApolloClient({
   link: new HttpLink({ uri, headers }),
   cache: new InMemoryCache(),


### PR DESCRIPTION
## Summary

Update web GraphQL client URL selection by runtime: browser uses `NEXT_PUBLIC_GRAPHQL_URL`, server uses `INTERNAL_GRAPHQL_URL`.
Update web env configuration/docs (`src/env.ts`, `.env.example`, `.env.ci`) to use the new server-side variable name.

Resolves #471

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [x] Generated code verified (no manual edits)
- [x] Tests and build passed

Made with [Cursor](https://cursor.com)