### PR TITLE
fix(web): restore next binary in Railway deploy for @forge/web

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,12 +13,7 @@ node_modules
 apps/cms/.tmp
 apps/cms/.strapi-updater.json
 
-# Unneeded for CMS image (Dockerfile only copies root package files + apps/cms)
-apps/web
-apps/ai-orchestrator
-packages
-mobile
-infra
+# Keep monorepo workspaces in build context so any app service can build.
 
 # Env and logs (never in image)
 .env


### PR DESCRIPTION
## Summary

Remove CMS-specific workspace exclusions from root `.dockerignore` so Railway includes `apps/web` and `packages` in the build context. This fixes deploys where `pnpm --filter @forge/web build` fails with `next: not found` because web workspace dependencies are missing.

Resolves #474

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed

Notes:
- `pnpm --filter @forge/web build` now reaches Next build execution (no missing `next` binary), but local validation stops on required env vars not set for production build (`INTERNAL_GRAPHQL_URL`, `STRAPI_API_TOKEN`, `STRAPI_PREVIEW_SECRET`, `NEXT_PUBLIC_GRAPHQL_URL`).

Made with [Cursor](https://cursor.com)