### PR TITLE
fix(cms): gate easter seed to doppler prd

### DIFF
--- a/apps/cms/src/index.ts
+++ b/apps/cms/src/index.ts
@@ -7,9 +7,14 @@ export default {
 
   async bootstrap({ strapi }: { strapi: Core.Strapi }) {
     await ensureInternalApiToken(strapi, process.env.STRAPI_INTERNAL_API_TOKEN)
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.DOPPLER_CONFIG === "prd") {
       await seedEaster(strapi)
+      return
     }
+
+    strapi.log.info(
+      `[seed-easter] Skipped because DOPPLER_CONFIG is "${process.env.DOPPLER_CONFIG ?? "undefined"}", expected "prd".`,
+    )
   },
 
   destroy(/* { strapi }: { strapi: Core.Strapi } */) {},


### PR DESCRIPTION
## Summary

- Run Easter seeding only when `DOPPLER_CONFIG` is exactly `prd`.
- Remove dependency on `NODE_ENV` for this seed gate so stage-like prod env values do not trigger seeding.
- Add a skip log with current `DOPPLER_CONFIG` for traceability.

Resolves #487

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration logic to use DOPPLER_CONFIG instead of NODE_ENV for controlling initialization behavior. The system now performs seeding only when DOPPLER_CONFIG is set to "prd" and logs a skip notification for other configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->