### PR TITLE
fix(cms): run easter seed only outside doppler prd

### DIFF
--- a/apps/cms/src/index.ts
+++ b/apps/cms/src/index.ts
@@ -7,14 +7,12 @@ export default {
 
   async bootstrap({ strapi }: { strapi: Core.Strapi }) {
     await ensureInternalApiToken(strapi, process.env.STRAPI_INTERNAL_API_TOKEN)
-    if (process.env.DOPPLER_CONFIG === "prd") {
+    if (process.env.DOPPLER_CONFIG !== "prd") {
       await seedEaster(strapi)
       return
     }
 
-    strapi.log.info(
-      `[seed-easter] Skipped because DOPPLER_CONFIG is "${process.env.DOPPLER_CONFIG ?? "undefined"}", expected "prd".`,
-    )
+    strapi.log.info(`[seed-easter] Skipped because DOPPLER_CONFIG is "prd".`)
   },
 
   destroy(/* { strapi }: { strapi: Core.Strapi } */) {},


### PR DESCRIPTION
## Summary

- Invert Easter seed gating to run only when `DOPPLER_CONFIG !== prd`.
- Skip seeding when `DOPPLER_CONFIG` is `prd`.
- Keep bootstrap behavior explicit via skip logging.

Resolves #491

## Contracts Changed

- [ ] yes
- [x] no

## Regeneration Required

- [ ] yes
- [x] no

## Validation

- [ ] Contracts validated
- [ ] Generated code verified (no manual edits)
- [ ] Tests and build passed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed environment-specific initialization behavior to correctly skip certain operations in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->