### PR TITLE
fix(manager): login fails — Strapi v5 strips populate=role

### DIFF
--- a/apps/manager/src/app/api/auth/login/route.ts
+++ b/apps/manager/src/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers"
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { env } from "@/config/env"
+import { verifyStrapiJwtWithRole } from "@/lib/auth"
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -10,13 +11,6 @@ const loginSchema = z.object({
 
 const authResponseSchema = z.object({
   jwt: z.string().min(1),
-  user: z.unknown(),
-})
-
-const meResponseSchema = z.object({
-  id: z.number(),
-  email: z.string(),
-  role: z.object({ name: z.string() }).optional(),
 })
 
 export async function POST(request: Request) {
@@ -42,6 +36,7 @@ export async function POST(request: Request) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ identifier: email, password }),
+    signal: AbortSignal.timeout(5000),
   })
 
   if (!res.ok) {
@@ -57,28 +52,17 @@ export async function POST(request: Request) {
   }
   const { jwt } = authParsed.data
 
-  // Verify the user has the Manager role
-  const meRes = await fetch(`${env.STRAPI_URL}/api/users/me?populate=role`, {
-    headers: { Authorization: `Bearer ${jwt}` },
-  })
+  // Verify JWT and fetch user with role (uses admin API token internally)
+  const user = await verifyStrapiJwtWithRole(jwt)
 
-  if (!meRes.ok) {
+  if (!user) {
     return NextResponse.json(
       { error: "Failed to fetch user profile from upstream" },
       { status: 502 },
     )
   }
 
-  const meParsed = meResponseSchema.safeParse(await meRes.json())
-  if (!meParsed.success) {
-    return NextResponse.json(
-      { error: "Unexpected user response from upstream" },
-      { status: 502 },
-    )
-  }
-  const me = meParsed.data
-
-  if (me.role?.name !== "Manager") {
+  if (user.role?.name !== "Manager") {
     return NextResponse.json({ error: "Unauthorized role" }, { status: 403 })
   }
 
@@ -92,6 +76,6 @@ export async function POST(request: Request) {
   })
 
   return NextResponse.json({
-    user: { id: me.id, email: me.email, role: me.role?.name },
+    user: { id: user.id, email: user.email, role: user.role?.name },
   })
 }

--- a/apps/manager/src/lib/auth.ts
+++ b/apps/manager/src/lib/auth.ts
@@ -19,16 +19,16 @@ type StrapiUser = {
 }
 
 /**
- * Validates a Strapi JWT by calling /api/users/me and confirms the user
- * holds the "Manager" role. Returns the user on success, null on failure.
+ * Fetches a Strapi user by ID with role populated using the admin API token.
+ * Private — callers must only pass IDs obtained from a verified source
+ * (JWT-validated /api/users/me or /api/auth/local response).
  */
-async function validateStrapiJwt(jwt: string): Promise<StrapiUser | null> {
+async function fetchUserWithRole(userId: number): Promise<StrapiUser | null> {
   try {
     const response = await fetch(
-      `${env.STRAPI_URL}/api/users/me?populate=role`,
+      `${env.STRAPI_URL}/api/users/${userId}?populate=role`,
       {
-        headers: { Authorization: `Bearer ${jwt}` },
-        // Short timeout to avoid blocking API routes if Strapi is slow
+        headers: { Authorization: `Bearer ${env.STRAPI_API_TOKEN}` },
         signal: AbortSignal.timeout(5000),
       },
     )
@@ -37,14 +37,35 @@ async function validateStrapiJwt(jwt: string): Promise<StrapiUser | null> {
       return null
     }
 
-    const user = (await response.json()) as StrapiUser
+    return (await response.json()) as StrapiUser
+  } catch {
+    return null
+  }
+}
 
-    // Confirm user has the Manager role
-    if (!user.role || user.role.name !== "Manager") {
+/**
+ * Verifies a Strapi JWT and returns the user with role populated.
+ * First validates the JWT via /api/users/me to get the trusted user ID,
+ * then fetches the role via admin API token (bypasses content API sanitization).
+ */
+export async function verifyStrapiJwtWithRole(
+  jwt: string,
+): Promise<StrapiUser | null> {
+  try {
+    // Verify JWT is valid and get user ID
+    const meResponse = await fetch(`${env.STRAPI_URL}/api/users/me`, {
+      headers: { Authorization: `Bearer ${jwt}` },
+      signal: AbortSignal.timeout(5000),
+    })
+
+    if (!meResponse.ok) {
       return null
     }
 
-    return user
+    const me = (await meResponse.json()) as { id: number }
+
+    // Fetch full user with role using admin API token
+    return await fetchUserWithRole(me.id)
   } catch {
     return null
   }
@@ -73,8 +94,8 @@ export async function authenticateRequest(
   const cookieHeader = request.headers.get("cookie") ?? ""
   const jwtMatch = cookieHeader.match(/strapi-jwt=([^;]+)/)
   if (jwtMatch?.[1]) {
-    const user = await validateStrapiJwt(jwtMatch[1])
-    if (user) {
+    const user = await verifyStrapiJwtWithRole(jwtMatch[1])
+    if (user?.role?.name === "Manager") {
       return null // Authenticated via validated Strapi session
     }
     return NextResponse.json(

--- a/docs/solutions/cms/strapi-v5-populate-role-sanitization.md
+++ b/docs/solutions/cms/strapi-v5-populate-role-sanitization.md
@@ -1,0 +1,66 @@
+---
+title: "Strapi v5 content API sanitization strips populate=role from /api/users/me"
+category: cms
+date: 2026-03-18
+tags:
+  - strapi-v5
+  - users-permissions
+  - authentication
+  - manager
+---
+
+# Strapi v5 content API sanitization strips `populate=role`
+
+## Problem
+
+The manager app's login flow called `/api/users/me?populate=role` using the user's own JWT. Strapi v5's `contentAPI.sanitize.query()` stripped the `populate=role` parameter because the user's role lacked permission to read the `users-permissions.role` content type via the REST API. The role was never returned, so `auth.ts` saw `user.role === undefined` and rejected every login as "Invalid or expired token".
+
+## Root Cause
+
+In Strapi v5, the `/api/users/me` controller runs the query through `contentAPI.sanitize.query()` (line 214 of the plugin's `controllers/user.js`). This sanitizer checks if the authenticated user's role has permission to populate the requested relation. If the role doesn't have "find" permission on `plugin::users-permissions.role`, the populate parameter is silently dropped.
+
+This differs from `fetchAuthenticatedUser()` (used internally by Strapi middleware for JWT validation), which hard-codes `populate: ['role']` and bypasses content API sanitization.
+
+## Solution
+
+Use the admin-level `STRAPI_API_TOKEN` to fetch user details with role, instead of the user's own JWT:
+
+1. Verify the JWT is valid via `/api/users/me` (no populate) — this confirms identity and returns the user ID
+2. Fetch `/api/users/{id}?populate=role` with `Authorization: Bearer ${STRAPI_API_TOKEN}` — the API token has full access and bypasses per-role sanitization
+
+The fetcher function (`fetchUserWithRole`) is kept private to prevent IDOR — only the public `verifyStrapiJwtWithRole(jwt)` function is exported, which binds the user ID to a verified JWT.
+
+## Key Pattern
+
+```typescript
+// Private — only accepts IDs from verified sources
+async function fetchUserWithRole(userId: number): Promise<StrapiUser | null> {
+  const response = await fetch(
+    `${env.STRAPI_URL}/api/users/${userId}?populate=role`,
+    { headers: { Authorization: `Bearer ${env.STRAPI_API_TOKEN}` } },
+  )
+  return (await response.json()) as StrapiUser
+}
+
+// Public — JWT-verified path is the only way to get a user with role
+export async function verifyStrapiJwtWithRole(
+  jwt: string,
+): Promise<StrapiUser | null> {
+  const meResponse = await fetch(`${env.STRAPI_URL}/api/users/me`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  })
+  const me = (await meResponse.json()) as { id: number }
+  return await fetchUserWithRole(me.id)
+}
+```
+
+## Alternatives Considered
+
+- **Grant the Manager role permission to read `users-permissions.role` via Strapi admin** — works but fragile; any future role changes could break login again.
+- **Use GraphQL `/graphql` with a `me` query** — returns role correctly but adds unnecessary complexity for a simple auth check.
+
+## Files
+
+- `apps/manager/src/lib/auth.ts` — `fetchUserWithRole` (private) + `verifyStrapiJwtWithRole` (public)
+- `apps/manager/src/app/api/auth/login/route.ts` — uses `verifyStrapiJwtWithRole(jwt)`
+- `apps/cms/node_modules/@strapi/plugin-users-permissions/server/controllers/user.js` — the sanitization source (line 214)


### PR DESCRIPTION
## Summary

- Strapi v5's `contentAPI.sanitize.query()` strips `?populate=role` from `/api/users/me` when the user's role lacks read permission on `users-permissions.role`
- This caused all manager logins to fail with "Invalid or expired token" because the role was never returned
- Fix: verify JWT via `/api/users/me` (identity only), then fetch user with role using `STRAPI_API_TOKEN` which bypasses per-role sanitization
- `fetchUserWithRole()` is private to prevent IDOR; only `verifyStrapiJwtWithRole(jwt)` is exported
- Added 5s timeout on `/api/auth/local` fetch (was missing)

## Test plan

- [ ] Login with a Strapi user that has the "Manager" role — should succeed
- [ ] Login with a user that has a different role — should get 403 "Unauthorized role"
- [ ] Login with invalid credentials — should get 401
- [ ] Verify subsequent authenticated API calls work (JWT cookie validated correctly)
- [ ] Typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)