### PR TITLE
feat(cms): database export/import for non-production environments

### DIFF
--- a/.github/workflows/cms-db-export.yml
+++ b/.github/workflows/cms-db-export.yml
@@ -1,0 +1,135 @@
+# Nightly export of the production CMS database to Railway S3.
+# Dev/staging environments consume this backup via `pnpm data-import` in apps/cms
+# instead of running the gateway sync.
+
+name: cms-db-export
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # daily at 04:00 UTC
+  workflow_dispatch: {} # manual trigger via GitHub UI
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cms-db-export
+  cancel-in-progress: false # let a running export finish
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      DATABASE_URL: ${{ secrets.CMS_DATABASE_URL }}
+      RAILWAY_S3_ENDPOINT: ${{ secrets.RAILWAY_S3_ENDPOINT }}
+      RAILWAY_S3_REGION: ${{ secrets.RAILWAY_S3_REGION }}
+      RAILWAY_S3_BUCKET: ${{ secrets.RAILWAY_S3_BUCKET }}
+      RAILWAY_S3_ACCESS_KEY_ID: ${{ secrets.RAILWAY_S3_ACCESS_KEY_ID }}
+      RAILWAY_S3_SECRET_ACCESS_KEY: ${{ secrets.RAILWAY_S3_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Validate secrets
+        run: |
+          missing=()
+          [ -z "$DATABASE_URL" ] && missing+=("CMS_DATABASE_URL")
+          [ -z "$RAILWAY_S3_ENDPOINT" ] && missing+=("RAILWAY_S3_ENDPOINT")
+          [ -z "$RAILWAY_S3_BUCKET" ] && missing+=("RAILWAY_S3_BUCKET")
+          [ -z "$RAILWAY_S3_ACCESS_KEY_ID" ] && missing+=("RAILWAY_S3_ACCESS_KEY_ID")
+          [ -z "$RAILWAY_S3_SECRET_ACCESS_KEY" ] && missing+=("RAILWAY_S3_SECRET_ACCESS_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+
+      - name: Export database
+        run: |
+          set -euo pipefail
+
+          # Tables to exclude from the export — admin, auth, system, and media tables
+          # that are environment-specific or bootstrapped on startup.
+          EXCLUDE_TABLES=(
+            admin_users
+            admin_roles
+            admin_permissions
+            admin_users_roles_lnk
+            admin_permissions_role_lnk
+            strapi_api_tokens
+            strapi_api_token_permissions
+            strapi_api_token_permissions_token_lnk
+            strapi_transfer_tokens
+            strapi_transfer_token_permissions
+            strapi_transfer_token_permissions_token_lnk
+            strapi_webhooks
+            strapi_webhooks_events
+            upload_files
+            upload_files_folder_lnk
+            upload_files_related_mph
+            upload_folders
+            upload_folders_parent_lnk
+            strapi_migrations
+            strapi_migrations_internal
+          )
+
+          EXCLUDE_ARGS=""
+          for table in "${EXCLUDE_TABLES[@]}"; do
+            EXCLUDE_ARGS="$EXCLUDE_ARGS --exclude-table=public.$table"
+          done
+
+          echo "::group::Running pg_dump"
+          pg_dump "$DATABASE_URL" \
+            --format=plain \
+            --inserts \
+            --no-owner \
+            --no-privileges \
+            --schema=public \
+            $EXCLUDE_ARGS \
+            | gzip > /tmp/cms-backup.sql.gz
+
+          SIZE=$(stat --format=%s /tmp/cms-backup.sql.gz)
+          echo "Backup size: $((SIZE / 1024 / 1024)) MB (compressed)"
+          echo "::endgroup::"
+
+      - name: Upload to Railway S3
+        run: |
+          set -euo pipefail
+
+          # Install AWS CLI v2 (pre-installed on ubuntu-latest, but ensure it's available)
+          aws --version
+
+          export AWS_ACCESS_KEY_ID="$RAILWAY_S3_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$RAILWAY_S3_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="${RAILWAY_S3_REGION:-auto}"
+
+          S3_URL="$RAILWAY_S3_ENDPOINT"
+          BUCKET="$RAILWAY_S3_BUCKET"
+          KEY="backups/cms-backup.sql.gz"
+          BAK_KEY="backups/cms-backup.sql.gz.bak"
+
+          echo "::group::Rotating previous backup"
+          # Move current backup to .bak (ignore error if it doesn't exist yet)
+          aws s3 mv "s3://$BUCKET/$KEY" "s3://$BUCKET/$BAK_KEY" \
+            --endpoint-url "$S3_URL" 2>/dev/null || echo "No previous backup to rotate"
+          echo "::endgroup::"
+
+          echo "::group::Uploading new backup"
+          aws s3 cp /tmp/cms-backup.sql.gz "s3://$BUCKET/$KEY" \
+            --endpoint-url "$S3_URL" \
+            --content-type "application/gzip"
+          echo "Upload complete: $KEY"
+          echo "::endgroup::"
+
+      - name: Summary
+        run: |
+          SIZE=$(stat --format=%s /tmp/cms-backup.sql.gz)
+          echo "## CMS Database Export" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Size:** $((SIZE / 1024 / 1024)) MB (compressed)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Location:** backups/cms-backup.sql.gz" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Timestamp:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/cms/.gitignore
+++ b/apps/cms/.gitignore
@@ -6,3 +6,4 @@ dist/
 types/
 public/uploads/*
 !public/uploads/.gitkeep
+imports/

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -11,10 +11,12 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "codegen": "graphql-codegen --config codegen.ts",
-    "test": "echo \"no test configured\""
+    "test": "vitest run",
+    "data-import": "tsx src/scripts/data-import.ts"
   },
   "dependencies": {
     "@apollo/client": "^4.1.4",
+    "@aws-sdk/client-s3": "^3.0.0",
     "@strapi/plugin-graphql": "5.36.0",
     "@strapi/plugin-users-permissions": "5.36.0",
     "@strapi/provider-upload-aws-s3": "5.36.0",
@@ -40,7 +42,8 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "graphql": "16.13.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "2.1.9"
   },
   "engines": {
     "node": "24"

--- a/apps/cms/src/scripts/data-import-utils.test.ts
+++ b/apps/cms/src/scripts/data-import-utils.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  formatBytes,
+  parseConnectionString,
+  shouldKeepLine,
+} from "./data-import-utils"
+
+// ---------------------------------------------------------------------------
+// parseConnectionString
+// ---------------------------------------------------------------------------
+
+describe("parseConnectionString", () => {
+  it("parses a full connection string", () => {
+    const result = parseConnectionString(
+      "postgres://admin:s3cret@db.railway.app:5432/strapi_prod?sslmode=require",
+    )
+    expect(result).toEqual({
+      host: "db.railway.app",
+      port: "5432",
+      user: "admin",
+      database: "strapi_prod",
+      password: "s3cret",
+      sslmode: "require",
+    })
+  })
+
+  it("defaults port to 5432 when omitted", () => {
+    const result = parseConnectionString("postgres://user:pass@host/mydb")
+    expect(result.port).toBe("5432")
+  })
+
+  it("defaults sslmode to prefer when omitted", () => {
+    const result = parseConnectionString("postgres://user:pass@host:5432/mydb")
+    expect(result.sslmode).toBe("prefer")
+  })
+
+  it("handles URL-encoded password characters", () => {
+    const result = parseConnectionString(
+      "postgres://user:p%40ss%23word@host:5432/db",
+    )
+    expect(result.password).toBe("p@ss#word")
+  })
+
+  it("decodes URL-encoded username", () => {
+    const result = parseConnectionString(
+      "postgres://user%40org:pass@host:5432/db",
+    )
+    expect(result.user).toBe("user@org")
+  })
+
+  it("handles empty password", () => {
+    const result = parseConnectionString("postgres://user:@host:5432/db")
+    expect(result.password).toBe("")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// shouldKeepLine
+// ---------------------------------------------------------------------------
+
+describe("shouldKeepLine", () => {
+  describe("keeps normal SQL", () => {
+    it("keeps INSERT statements", () => {
+      expect(
+        shouldKeepLine("INSERT INTO videos (id, title) VALUES (1, 'test');"),
+      ).toBe(true)
+    })
+
+    it("keeps CREATE TABLE statements", () => {
+      expect(
+        shouldKeepLine("CREATE TABLE videos (id serial PRIMARY KEY);"),
+      ).toBe(true)
+    })
+
+    it("keeps SELECT statements", () => {
+      expect(shouldKeepLine("SELECT 1;")).toBe(true)
+    })
+
+    it("keeps SET statements", () => {
+      expect(shouldKeepLine("SET search_path = public;")).toBe(true)
+    })
+
+    it("keeps empty lines", () => {
+      expect(shouldKeepLine("")).toBe(true)
+    })
+
+    it("keeps SQL comments", () => {
+      expect(shouldKeepLine("-- This is a comment")).toBe(true)
+    })
+
+    it("keeps ALTER TABLE statements", () => {
+      expect(shouldKeepLine("ALTER TABLE videos ADD COLUMN slug text;")).toBe(
+        true,
+      )
+    })
+  })
+
+  describe("strips CREATE PUBLICATION", () => {
+    it("strips basic CREATE PUBLICATION", () => {
+      expect(shouldKeepLine("CREATE PUBLICATION my_pub FOR ALL TABLES;")).toBe(
+        false,
+      )
+    })
+
+    it("strips with leading whitespace", () => {
+      expect(
+        shouldKeepLine("  CREATE PUBLICATION my_pub FOR TABLE videos;"),
+      ).toBe(false)
+    })
+
+    it("strips case-insensitively", () => {
+      expect(shouldKeepLine("create publication my_pub FOR ALL TABLES;")).toBe(
+        false,
+      )
+    })
+  })
+
+  describe("strips ALTER PUBLICATION", () => {
+    it("strips ALTER PUBLICATION", () => {
+      expect(shouldKeepLine("ALTER PUBLICATION my_pub ADD TABLE videos;")).toBe(
+        false,
+      )
+    })
+
+    it("strips case-insensitively", () => {
+      expect(shouldKeepLine("alter publication my_pub SET TABLE videos;")).toBe(
+        false,
+      )
+    })
+  })
+
+  describe("strips psql meta-commands", () => {
+    it("strips \\connect", () => {
+      expect(shouldKeepLine("\\connect mydb")).toBe(false)
+    })
+
+    it("strips \\set", () => {
+      expect(shouldKeepLine("\\set ON_ERROR_STOP on")).toBe(false)
+    })
+
+    it("strips \\encoding", () => {
+      expect(shouldKeepLine("\\encoding UTF8")).toBe(false)
+    })
+  })
+
+  describe("keeps allowed meta-commands", () => {
+    it("keeps \\. (COPY terminator)", () => {
+      expect(shouldKeepLine("\\.")).toBe(true)
+    })
+
+    it("keeps \\copy", () => {
+      expect(shouldKeepLine("\\copy videos FROM stdin;")).toBe(true)
+    })
+
+    it("keeps \\COPY (case-insensitive)", () => {
+      expect(shouldKeepLine("\\COPY videos FROM stdin;")).toBe(true)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatBytes
+// ---------------------------------------------------------------------------
+
+describe("formatBytes", () => {
+  it("formats 0 bytes", () => {
+    expect(formatBytes(0)).toBe("0 B")
+  })
+
+  it("formats bytes", () => {
+    expect(formatBytes(500)).toBe("500 B")
+  })
+
+  it("formats kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB")
+  })
+
+  it("formats megabytes", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB")
+  })
+
+  it("formats gigabytes", () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0 GB")
+  })
+
+  it("formats fractional values", () => {
+    expect(formatBytes(1536)).toBe("1.5 KB")
+  })
+
+  it("formats large values with decimals", () => {
+    const size = 52.7 * 1024 * 1024
+    expect(formatBytes(size)).toBe("52.7 MB")
+  })
+})

--- a/apps/cms/src/scripts/data-import-utils.ts
+++ b/apps/cms/src/scripts/data-import-utils.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure utility functions for the CMS data-import pipeline.
+ * Extracted for testability — no side effects, no process.exit, no I/O.
+ */
+
+// ---------------------------------------------------------------------------
+// Connection string parsing
+// ---------------------------------------------------------------------------
+
+export type DbConfig = {
+  host: string
+  port: string
+  user: string
+  database: string
+  password: string
+  sslmode: string
+}
+
+export function parseConnectionString(url: string): DbConfig {
+  const parsed = new URL(url)
+  return {
+    host: parsed.hostname,
+    port: parsed.port || "5432",
+    user: decodeURIComponent(parsed.username),
+    database: parsed.pathname.replace(/^\//, ""),
+    password: decodeURIComponent(parsed.password),
+    sslmode: parsed.searchParams.get("sslmode") ?? "prefer",
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SQL preprocessing
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the SQL line should be kept (not stripped).
+ *
+ * Strips:
+ * - CREATE PUBLICATION statements (replication config from production)
+ * - ALTER PUBLICATION statements
+ * - psql meta-commands (lines starting with \) except \. (COPY terminator) and \copy
+ */
+export function shouldKeepLine(line: string): boolean {
+  // Strip CREATE PUBLICATION statements
+  if (/^\s*CREATE\s+PUBLICATION\s/i.test(line)) return false
+
+  // Strip ALTER PUBLICATION statements
+  if (/^\s*ALTER\s+PUBLICATION\s/i.test(line)) return false
+
+  // Strip psql meta-commands except \. (COPY terminator) and \copy
+  if (/^\\/.test(line) && !/^\\\./.test(line) && !/^\\copy/i.test(line)) {
+    return false
+  }
+
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Byte formatting
+// ---------------------------------------------------------------------------
+
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B"
+  const units = ["B", "KB", "MB", "GB"]
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  )
+  const value = bytes / Math.pow(1024, i)
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}

--- a/apps/cms/src/scripts/data-import.ts
+++ b/apps/cms/src/scripts/data-import.ts
@@ -1,0 +1,362 @@
+/**
+ * CMS Data Import
+ *
+ * Downloads the nightly production database backup from Railway S3 and restores
+ * it into the local/staging PostgreSQL instance. Replaces the gateway sync for
+ * non-production environments.
+ *
+ * Usage:
+ *   pnpm data-import
+ *
+ * Required env vars:
+ *   DATABASE_URL                  — PostgreSQL connection string
+ *   RAILWAY_S3_ENDPOINT           — S3-compatible endpoint
+ *   RAILWAY_S3_REGION             — S3 region (default: "auto")
+ *   RAILWAY_S3_BUCKET             — S3 bucket name
+ *   RAILWAY_S3_ACCESS_KEY_ID      — S3 access key
+ *   RAILWAY_S3_SECRET_ACCESS_KEY  — S3 secret key
+ */
+
+import { spawn } from "node:child_process"
+import { createReadStream, createWriteStream } from "node:fs"
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { createGunzip } from "node:zlib"
+import { createInterface } from "node:readline"
+import { pipeline } from "node:stream/promises"
+import { Readable, Transform } from "node:stream"
+
+import {
+  type DbConfig,
+  formatBytes,
+  parseConnectionString,
+  shouldKeepLine,
+} from "./data-import-utils"
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const BACKUP_KEY = "backups/cms-backup.sql.gz"
+const IMPORTS_DIR = "./imports"
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`)
+  }
+  return value
+}
+
+function assertNotProduction(): void {
+  const nodeEnv = process.env["NODE_ENV"]
+  if (nodeEnv === "production") {
+    throw new Error(
+      "Refusing to run data-import with NODE_ENV=production. " +
+        "This script runs DROP SCHEMA CASCADE and is only safe for dev/staging.",
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// S3 Download
+// ---------------------------------------------------------------------------
+
+async function downloadBackup(destPath: string): Promise<void> {
+  const { S3Client, GetObjectCommand } = await import("@aws-sdk/client-s3")
+
+  const s3 = new S3Client({
+    endpoint: requiredEnv("RAILWAY_S3_ENDPOINT"),
+    region: process.env["RAILWAY_S3_REGION"] ?? "auto",
+    credentials: {
+      accessKeyId: requiredEnv("RAILWAY_S3_ACCESS_KEY_ID"),
+      secretAccessKey: requiredEnv("RAILWAY_S3_SECRET_ACCESS_KEY"),
+    },
+    forcePathStyle: true,
+  })
+
+  const bucket = requiredEnv("RAILWAY_S3_BUCKET")
+
+  console.log(`[data-import] Downloading s3://${bucket}/${BACKUP_KEY}`)
+  const startTime = Date.now()
+
+  const response = await s3.send(
+    new GetObjectCommand({ Bucket: bucket, Key: BACKUP_KEY }),
+  )
+
+  if (!response.Body) {
+    throw new Error("S3 response body is empty")
+  }
+
+  const contentLength = response.ContentLength ?? 0
+  let bytesReceived = 0
+
+  // Progress tracking transform
+  const progress = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      bytesReceived += chunk.length
+      if (contentLength > 0) {
+        const pct = ((bytesReceived / contentLength) * 100).toFixed(1)
+        process.stdout.write(
+          `\r[data-import] Download progress: ${pct}% (${formatBytes(bytesReceived)} / ${formatBytes(contentLength)})`,
+        )
+      } else {
+        process.stdout.write(
+          `\r[data-import] Downloaded: ${formatBytes(bytesReceived)}`,
+        )
+      }
+      callback(null, chunk)
+    },
+  })
+
+  const bodyStream =
+    response.Body instanceof Readable
+      ? response.Body
+      : Readable.fromWeb(response.Body as ReadableStream)
+
+  const dest = createWriteStream(destPath)
+  await pipeline(bodyStream, progress, dest)
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+  console.log(
+    `\n[data-import] Download complete: ${formatBytes(bytesReceived)} in ${elapsed}s`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Decompress
+// ---------------------------------------------------------------------------
+
+async function decompress(gzPath: string, outPath: string): Promise<void> {
+  console.log(`[data-import] Decompressing ${gzPath}`)
+  const startTime = Date.now()
+
+  const gunzip = createGunzip()
+  const source = createReadStream(gzPath)
+  const dest = createWriteStream(outPath)
+
+  await pipeline(source, gunzip, dest)
+
+  const gzSize = (await stat(gzPath)).size
+  const rawSize = (await stat(outPath)).size
+  const ratio = rawSize > 0 ? ((gzSize / rawSize) * 100).toFixed(1) : "N/A"
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+
+  console.log(
+    `[data-import] Decompressed: ${formatBytes(gzSize)} → ${formatBytes(rawSize)} (${ratio}% compression ratio) in ${elapsed}s`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Preprocess SQL
+// ---------------------------------------------------------------------------
+
+async function preprocessSql(
+  inputPath: string,
+  outputPath: string,
+): Promise<void> {
+  console.log(`[data-import] Preprocessing SQL`)
+  const startTime = Date.now()
+
+  const input = createReadStream(inputPath, { encoding: "utf-8" })
+  const output = createWriteStream(outputPath, { encoding: "utf-8" })
+  const rl = createInterface({ input, crlfDelay: Infinity })
+
+  // Prepend DROP/CREATE SCHEMA inside the file so that --single-transaction
+  // wraps everything atomically. If the restore fails, the DROP rolls back too.
+  output.write("DROP SCHEMA public CASCADE;\n")
+  output.write("CREATE SCHEMA public;\n\n")
+
+  let linesRead = 0
+  let linesStripped = 0
+
+  for await (const line of rl) {
+    linesRead++
+
+    if (shouldKeepLine(line)) {
+      output.write(line + "\n")
+    } else {
+      linesStripped++
+    }
+  }
+
+  output.end()
+
+  // Wait for output to finish flushing
+  await new Promise<void>((resolve, reject) => {
+    output.on("finish", resolve)
+    output.on("error", reject)
+  })
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+  console.log(
+    `[data-import] Preprocessed: ${linesRead} lines read, ${linesStripped} stripped in ${elapsed}s`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// psql Restore
+// ---------------------------------------------------------------------------
+
+async function psqlRestore(db: DbConfig, sqlPath: string): Promise<void> {
+  console.log(`[data-import] Restoring: ${sqlPath}`)
+
+  const args: string[] = [
+    "-h",
+    db.host,
+    "-p",
+    db.port,
+    "-U",
+    db.user,
+    "-d",
+    db.database,
+    "-v",
+    "ON_ERROR_STOP=1",
+    "--single-transaction",
+    "-f",
+    sqlPath,
+  ]
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PGPASSWORD: db.password,
+    PGSSLMODE: db.sslmode,
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn("psql", args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    let stderr = ""
+    proc.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString()
+    })
+
+    proc.stdout.on("data", (data: Buffer) => {
+      process.stdout.write(data)
+    })
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        console.error(`[data-import] psql exited with code ${code}`)
+        if (stderr) console.error(`[data-import] stderr:\n${stderr}`)
+        reject(new Error(`psql restore failed with exit code ${code}`))
+      } else {
+        console.log(`[data-import] Restore complete`)
+        resolve()
+      }
+    })
+
+    proc.on("error", (err) => {
+      reject(new Error(`Failed to spawn psql: ${err.message}`))
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp tracking
+// ---------------------------------------------------------------------------
+
+const TIMESTAMP_FILE = "./imports/.last-import"
+
+async function recordTimestamp(): Promise<void> {
+  const now = new Date().toISOString()
+  await writeFile(TIMESTAMP_FILE, now, "utf-8")
+  console.log(`[data-import] Import timestamp recorded: ${now}`)
+}
+
+async function getLastImport(): Promise<string | null> {
+  try {
+    return (await readFile(TIMESTAMP_FILE, "utf-8")).trim()
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+async function cleanup(): Promise<void> {
+  const files = [
+    `${IMPORTS_DIR}/cms-backup.sql.gz`,
+    `${IMPORTS_DIR}/cms-backup.sql`,
+    `${IMPORTS_DIR}/cms-backup-processed.sql`,
+  ]
+
+  for (const file of files) {
+    try {
+      await rm(file, { force: true })
+    } catch {
+      // ignore missing files
+    }
+  }
+
+  console.log(`[data-import] Temp files cleaned up`)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  assertNotProduction()
+
+  console.log("[data-import] Starting CMS database import")
+  console.log("─".repeat(60))
+
+  const lastImport = await getLastImport()
+  if (lastImport) {
+    console.log(`[data-import] Last import: ${lastImport}`)
+  }
+
+  const databaseUrl = requiredEnv("DATABASE_URL")
+  const db = parseConnectionString(databaseUrl)
+
+  console.log(
+    `[data-import] Target database: ${db.host}:${db.port}/${db.database}`,
+  )
+  console.log("─".repeat(60))
+
+  // Ensure imports directory exists
+  await mkdir(IMPORTS_DIR, { recursive: true })
+
+  const gzPath = `${IMPORTS_DIR}/cms-backup.sql.gz`
+  const sqlPath = `${IMPORTS_DIR}/cms-backup.sql`
+  const processedPath = `${IMPORTS_DIR}/cms-backup-processed.sql`
+
+  try {
+    // Step 1: Download
+    console.log("\n[Step 1/5] Downloading backup from S3")
+    await downloadBackup(gzPath)
+
+    // Step 2: Decompress
+    console.log("\n[Step 2/5] Decompressing")
+    await decompress(gzPath, sqlPath)
+
+    // Step 3: Preprocess
+    console.log("\n[Step 3/5] Preprocessing SQL")
+    await preprocessSql(sqlPath, processedPath)
+
+    // Step 4: Restore
+    console.log("\n[Step 4/5] Restoring database")
+    await psqlRestore(db, processedPath)
+
+    // Step 5: Record timestamp
+    console.log("\n[Step 5/5] Recording timestamp")
+    await recordTimestamp()
+  } finally {
+    // Always clean up temp files
+    console.log("\n[Cleanup] Removing temp files")
+    await cleanup()
+  }
+
+  console.log("\n" + "─".repeat(60))
+  console.log("[data-import] Import completed successfully")
+}
+
+main().catch((err: unknown) => {
+  console.error("[data-import] Fatal error:", err)
+  process.exit(1)
+})

--- a/apps/cms/vitest.config.ts
+++ b/apps/cms/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+})

--- a/docs/solutions/cms/database-export-import.md
+++ b/docs/solutions/cms/database-export-import.md
@@ -1,0 +1,151 @@
+---
+title: CMS Database Export/Import Pipeline
+category: cms
+date: 2026-03-23
+tags:
+  - database
+  - backup
+  - restore
+  - pg_dump
+  - railway-s3
+  - github-actions
+  - strapi-v5
+---
+
+# CMS Database Export/Import
+
+## Problem
+
+Non-production environments (dev/staging) need production content data without running the full gateway sync, which is slow, requires gateway API access, and duplicates production work.
+
+## Root Cause
+
+The gateway sync (`apps/cms/src/api/gateway-sync/`) pulls data via paginated GraphQL queries and upserts records one-by-one through Strapi's document service. This is correct for production but unnecessarily slow for seeding dev/staging — a full database clone is faster and more reliable.
+
+## Solution
+
+Two-sided backup/restore pipeline:
+
+1. **Export** — GitHub Actions cron (`cms-db-export.yml`) runs `pg_dump` against production PostgreSQL nightly at 04:00 UTC, uploads gzipped SQL to Railway S3 at `backups/cms-backup.sql.gz`.
+
+2. **Import** — `apps/cms/src/scripts/data-import.ts` downloads from S3, decompresses, preprocesses (strips replication/publication statements), and restores via `psql --single-transaction`.
+
+### Architecture
+
+```
+GitHub Actions (daily cron at 04:00 UTC)
+  ├─ pg_dump production Strapi DB (--inserts --no-owner)
+  ├─ Exclude admin/system/upload/migration tables
+  ├─ gzip
+  └─ Upload to Railway S3: backups/cms-backup.sql.gz
+
+Dev/Staging (manual: pnpm data-import)
+  ├─ Download from Railway S3
+  ├─ Decompress (createGunzip stream)
+  ├─ Preprocess SQL:
+  │   ├─ Prepend DROP SCHEMA + CREATE SCHEMA (inside transaction)
+  │   ├─ Strip CREATE/ALTER PUBLICATION statements
+  │   └─ Strip psql meta-commands (except \. and \copy)
+  ├─ psql restore (--single-transaction, ON_ERROR_STOP=1)
+  ├─ Record import timestamp
+  └─ Cleanup temp files
+```
+
+### Key Files
+
+| File                                             | Purpose                                         |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `.github/workflows/cms-db-export.yml`            | Nightly export cron + manual dispatch           |
+| `apps/cms/src/scripts/data-import.ts`            | Import orchestrator (I/O, S3, psql)             |
+| `apps/cms/src/scripts/data-import-utils.ts`      | Pure functions (parsing, filtering, formatting) |
+| `apps/cms/src/scripts/data-import-utils.test.ts` | 31 unit tests                                   |
+
+## Excluded Tables
+
+Admin, auth, system, upload, and migration tables are excluded from the export because they are environment-specific or bootstrapped on startup:
+
+- `admin_users`, `admin_roles`, `admin_permissions` (and junction tables `_lnk`)
+- `strapi_api_tokens`, `strapi_api_token_permissions` (and junction tables)
+- `strapi_transfer_tokens`, `strapi_transfer_token_permissions` (and junction tables)
+- `strapi_webhooks`, `strapi_webhooks_events`
+- `upload_files`, `upload_folders` (and junction tables `_lnk`, `_mph`)
+- `strapi_migrations`, `strapi_migrations_internal`
+
+**Known limitation:** Content types with media fields (e.g., `experience.ogImage`) will have dangling references to `upload_files` after import. Media must be re-uploaded on dev/staging if needed.
+
+**Investigate:** `strapi_core_store_settings` and `strapi_database_schema` may also need exclusion to prevent schema sync drift between environments.
+
+## Required GitHub Secrets
+
+- `CMS_DATABASE_URL` — production PostgreSQL connection string (prefer read-only user)
+- `RAILWAY_S3_ENDPOINT`, `RAILWAY_S3_REGION`, `RAILWAY_S3_BUCKET`
+- `RAILWAY_S3_ACCESS_KEY_ID`, `RAILWAY_S3_SECRET_ACCESS_KEY`
+
+## Usage
+
+```bash
+# Run import on dev/staging
+cd apps/cms
+pnpm data-import
+```
+
+## Safety Guards
+
+- **Production safeguard:** The import script refuses to run when `NODE_ENV=production`.
+- **Atomic restore:** `DROP SCHEMA CASCADE` and the restore SQL are both inside `--single-transaction`. If the restore fails, the DROP rolls back too — the database is left unchanged.
+- **Concurrency control:** The export workflow uses `cancel-in-progress: false` to prevent overlapping exports.
+- **Secret validation:** The workflow validates all secrets before proceeding (unattended cron failures would otherwise be silent).
+
+## Key Decisions
+
+- Railway S3 chosen over Cloudflare R2 because the bucket is already provisioned and configured across the monorepo.
+- GitHub Actions cron chosen over Railway cron to avoid consuming Railway compute for a batch job.
+- `--inserts` format used instead of `COPY` for portability across PostgreSQL versions. May need revisiting if restore times exceed 10 minutes at scale.
+- Preprocessing strips `CREATE PUBLICATION` and psql meta-commands that fail in non-production environments.
+- Pure logic extracted to `data-import-utils.ts` for testability — side-effectful code stays in `data-import.ts`.
+
+## Learnings
+
+### Critical: psql `-c` runs outside `--single-transaction` when combined with `-f`
+
+When psql receives both `-c "DROP SCHEMA..."` and `-f restore.sql`, the `-c` command runs as a separate operation **before** the `-f` file's transaction begins. If the restore fails, the DROP has already committed and the database is empty with no rollback.
+
+**Fix:** Prepend the `DROP SCHEMA` / `CREATE SCHEMA` statements into the processed SQL file itself during preprocessing. This way, `--single-transaction` wraps everything atomically.
+
+### Node `URL` class does not auto-decode credentials
+
+`URL.password` and `URL.username` return percent-encoded strings (e.g., `p%40ss` instead of `p@ss`). Must wrap with `decodeURIComponent()` when parsing PostgreSQL connection strings. Caught by tests.
+
+### Vitest version must match Vite major
+
+Vitest 4.x requires Vite 6+. This repo pins Vite 5.x, so use `vitest@^2` for compatibility. Vitest 2.1.9 confirmed working with `vite@5`.
+
+### Railway S3 requires `forcePathStyle: true`
+
+Same pattern as `apps/manager/src/services/storage.ts`. Without this, the AWS SDK constructs virtual-hosted-style URLs that Railway's S3-compatible storage doesn't support.
+
+### Strapi v5 junction table naming
+
+Follows the pattern `{table}_{relation}_lnk` — these must be excluded alongside their parent tables in the pg_dump, or the restore will fail with FK constraint errors. Upload-related morphic tables use `_mph` suffix.
+
+### GitHub Actions cron needs explicit secret validation
+
+Cron workflows run unattended at night. A missing secret would cause a silent failure. Always validate secrets as the first step before doing any work.
+
+### Always add production safeguards to destructive scripts
+
+Any script that runs `DROP SCHEMA CASCADE` must check `NODE_ENV` and refuse to run in production. A single `DATABASE_URL` misconfiguration would be catastrophic.
+
+## Prevention
+
+- Run `pnpm test` in `apps/cms` to verify preprocessing and parsing logic (31 unit tests).
+- After first deploy, manually trigger the workflow via `gh workflow run cms-db-export.yml` and verify the backup in S3 before waiting for the cron.
+- Monitor the GitHub Actions workflow for failures — consider adding Slack notifications for cron job failures.
+
+## Cross-References
+
+- `apps/cms/src/api/gateway-sync/` — Production-only sync (GraphQL pull from upstream gateway)
+- `apps/manager/src/services/storage.ts` — Established Railway S3 pattern
+- `docs/solutions/platform/optional-railway-s3-local-fallback.md` — S3 toggle convention
+- `docs/solutions/cms/strapi-v5-bootstrap-webhook-seeding.md` — Confirms webhooks are bootstrapped (correctly excluded from export)
+- `docs/solutions/cms/strapi-v5-populate-role-sanitization.md` — Confirms API tokens are environment-specific (correctly excluded)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@apollo/client':
         specifier: ^4.1.4
         version: 4.1.4(graphql-ws@6.0.7(graphql@16.13.1)(ws@8.19.0))(graphql@16.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)
+      '@aws-sdk/client-s3':
+        specifier: ^3.0.0
+        version: 3.975.0
       '@strapi/plugin-graphql':
         specifier: 5.36.0
         version: 5.36.0(nnmr5n6ayliyzemffutcj7luzy)
@@ -127,6 +130,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: 2.1.9
+        version: 2.1.9(@types/node@20.19.33)(jsdom@20.0.3)(lightningcss@1.30.2)(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(terser@5.46.0)
 
   apps/manager:
     dependencies:
@@ -5649,6 +5655,35 @@ packages:
     peerDependencies:
       vite: ^4 || ^5
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -6158,6 +6193,10 @@ packages:
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -6496,6 +6535,10 @@ packages:
       magicast:
         optional: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
     engines: {node: '>= 6.0.0'}
@@ -6569,6 +6612,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -6619,6 +6666,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -7218,6 +7269,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
 
@@ -7562,6 +7617,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -7865,6 +7923,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -10006,6 +10068,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
 
@@ -11172,8 +11237,15 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
@@ -12307,6 +12379,9 @@ packages:
   sift@16.0.1:
     resolution: {integrity: sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -12465,6 +12540,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -12489,6 +12567,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -12868,6 +12949,12 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -12875,6 +12962,18 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
@@ -13429,6 +13528,11 @@ packages:
   videojs-vtt.js@0.15.5:
     resolution: {integrity: sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -13458,6 +13562,31 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vlq@1.0.1:
@@ -13604,6 +13733,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@3.1.0:
@@ -20990,6 +21124,47 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(vite@5.4.21(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@20.19.33)(typescript@5.9.3)
+      vite: 5.4.21(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -21756,6 +21931,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
@@ -22190,6 +22367,8 @@ snapshots:
       pkg-types: 2.3.0
       rc9: 2.1.2
 
+  cac@6.7.14: {}
+
   cache-content-type@1.0.1:
     dependencies:
       mime-types: 2.1.35
@@ -22281,6 +22460,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -22344,6 +22531,8 @@ snapshots:
   chardet@0.7.0: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -22932,6 +23121,8 @@ snapshots:
     optionalDependencies:
       babel-plugin-macros: 3.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-equal@1.0.1: {}
 
   deep-extend@0.6.0: {}
@@ -23301,6 +23492,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -23448,9 +23641,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
@@ -23465,8 +23658,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -23492,7 +23685,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -23503,7 +23696,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -23514,7 +23707,7 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -23527,7 +23720,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -23767,6 +23960,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -26402,6 +26597,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lower-case-first@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -27265,6 +27462,32 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@20.19.33)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.1
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.4.4
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@25.2.3)
@@ -27940,7 +28163,11 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pause@0.0.1: {}
 
@@ -29430,6 +29657,8 @@ snapshots:
 
   sift@16.0.1: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -29585,6 +29814,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   stacktrace-gps@3.1.2:
@@ -29607,6 +29838,8 @@ snapshots:
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -30037,12 +30270,22 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   title-case@3.0.3:
     dependencies:
@@ -30601,6 +30844,24 @@ snapshots:
     dependencies:
       global: 4.4.0
 
+  vite-node@2.1.9(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0):
     dependencies:
       esbuild: 0.21.5
@@ -30611,6 +30872,42 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.2
       terser: 5.46.0
+
+  vitest@2.1.9(@types/node@20.19.33)(jsdom@20.0.3)(lightningcss@1.30.2)(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(terser@5.46.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(vite@5.4.21(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@8.1.1)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@20.19.33)(lightningcss@1.30.2)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.33
+      jsdom: 20.0.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vlq@1.0.1: {}
 
@@ -30807,6 +31104,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a nightly GitHub Actions cron workflow that `pg_dump`s the production CMS database (excluding admin, auth, upload, and migration tables), gzips the output, and uploads to Railway S3
- Adds a `pnpm data-import` script in `apps/cms` that downloads the backup, decompresses, preprocesses SQL, and restores into a target PostgreSQL database via `psql`
- Replaces the gateway GraphQL sync for dev/staging environments — production continues using the existing gateway sync

## Key design decisions

- **Atomic restore**: DROP SCHEMA + restore SQL are both inside `--single-transaction` — if restore fails, the DROP rolls back
- **Production safeguard**: Import script refuses to run when `NODE_ENV=production`
- **Railway S3**: Uses the existing S3 bucket and `RAILWAY_S3_*` env var pattern (same as `apps/manager`)
- **GitHub Actions cron**: Runs at 04:00 UTC daily + manual `workflow_dispatch` trigger
- **Pure logic extracted**: `data-import-utils.ts` for testability, 31 unit tests

## Required GitHub Secrets

Before this workflow can run, add these secrets in the repo settings:

- `CMS_DATABASE_URL` — production PostgreSQL connection string
- `RAILWAY_S3_ENDPOINT`, `RAILWAY_S3_REGION`, `RAILWAY_S3_BUCKET`
- `RAILWAY_S3_ACCESS_KEY_ID`, `RAILWAY_S3_SECRET_ACCESS_KEY`

## Test plan

- [x] `pnpm test` passes in `apps/cms` (31/31 tests)
- [x] `tsc --noEmit` passes (0 errors)
- [x] Pre-commit hooks (prettier) pass
- [ ] Add GitHub secrets to repo settings
- [ ] Manually trigger workflow via `gh workflow run cms-db-export.yml`
- [ ] Verify backup appears in S3 at `backups/cms-backup.sql.gz`
- [ ] Run `pnpm data-import` against a dev/staging database
- [ ] Verify content data is present after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)