### PR TITLE
chore(cms): remove stale TODO

### DIFF
--- a/apps/cms/src/index.ts
+++ b/apps/cms/src/index.ts
@@ -12,9 +12,7 @@ export default {
       process.env.REVALIDATION_WEBHOOK_URL,
       process.env.REVALIDATION_SECRET,
     )
-    // Easter seed disabled — videos now come from gateway sync.
-    // TODO: rewrite seed to reference synced videos by gatewayId
-    // instead of creating its own.
+    // Easter seed removed — videos come from gateway sync.
   },
 
   destroy(/* { strapi }: { strapi: Core.Strapi } */) {},


### PR DESCRIPTION
## Summary

- Remove stale TODO comment about easter seed rewrite — gateway sync permanently replaced it

Trivial cleanup to trigger a fresh Railway deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)