### PR TITLE
chore: gitignore forge.code-workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ mobile/ios/App/ForgeApp/Generated/
 # Compound engineering working files
 todos/*.md
 !todos/.gitkeep
+forge.code-workspace


### PR DESCRIPTION
## Summary
- Adds `forge.code-workspace` to `.gitignore` to keep editor config out of version control

## Test plan
- [x] Verify file no longer shows as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)