### PR TITLE
fix(cms): use correct JWT field for admin auth in core-sync

### DIFF
--- a/apps/cms/src/middlewares/admin-auth.ts
+++ b/apps/cms/src/middlewares/admin-auth.ts
@@ -34,7 +34,7 @@ export default (_config: unknown, { strapi }: { strapi: Core.Strapi }) => {
       // Verify the admin user still exists and is active
       const admin = await strapi.db
         .query("admin::user")
-        .findOne({ where: { id: payload.id, isActive: true } })
+        .findOne({ where: { id: payload.userId, isActive: true } })
 
       if (!admin) {
         ctx.status = 401


### PR DESCRIPTION
## Summary
- Strapi v5 session tokens use `userId` in the JWT payload, but the `admin-auth` middleware was reading `payload.id` (which is `undefined`), causing all requests to `/api/core-sync/trigger` to fail with 401.
- One-line fix: `payload.id` → `payload.userId`

## Test plan
- [ ] Trigger core sync from the admin dashboard at `/admin/settings/core-sync-status` — should return 202 instead of 401
- [ ] Verify sync status endpoint also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)