### PR TITLE
fix(cms): disable default Strapi auth on core-sync routes

### DIFF
--- a/apps/cms/src/api/core-sync/routes/core-sync.ts
+++ b/apps/cms/src/api/core-sync/routes/core-sync.ts
@@ -5,6 +5,7 @@ export default {
       path: "/core-sync/trigger",
       handler: "core-sync.trigger",
       config: {
+        auth: false,
         policies: [],
         middlewares: ["global::admin-auth"],
       },
@@ -14,6 +15,7 @@ export default {
       path: "/core-sync/status",
       handler: "core-sync.status",
       config: {
+        auth: false,
         policies: [],
         middlewares: ["global::admin-auth"],
       },


### PR DESCRIPTION
## Summary
- Strapi v5's built-in content-API auth runs before route-level middlewares and rejects admin JWTs (expects API tokens), returning 401 "Missing or invalid credentials"
- Adding `auth: false` to both core-sync routes disables the default auth layer so our custom `admin-auth` middleware handles authentication instead

## Test plan
- [ ] POST `/api/core-sync/trigger` with admin JWT should return 202
- [ ] GET `/api/core-sync/status` with admin JWT should return sync status
- [ ] Requests without a valid admin JWT should still return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)