### PR TITLE
fix(cms): fix status dashboard not updating after sync trigger

### DIFF
--- a/apps/cms/src/admin/pages/SystemStatus.tsx
+++ b/apps/cms/src/admin/pages/SystemStatus.tsx
@@ -322,16 +322,12 @@ export default function SystemStatusPage() {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const fetchStatuses = useCallback(async () => {
-    try {
-      const [syncRes, snapRes] = await Promise.all([
-        get<SyncStatus>("/api/core-sync/status"),
-        get<SnapshotStatus>("/api/data-snapshot/admin/status"),
-      ])
-      setSyncStatus(syncRes.data)
-      setSnapshotStatus(snapRes.data)
-    } catch {
-      // Silently fail on poll — avoids toast spam
-    }
+    const [syncRes, snapRes] = await Promise.allSettled([
+      get<SyncStatus>("/api/core-sync/status"),
+      get<SnapshotStatus>("/api/data-snapshot/admin/status"),
+    ])
+    if (syncRes.status === "fulfilled") setSyncStatus(syncRes.value.data)
+    if (snapRes.status === "fulfilled") setSnapshotStatus(snapRes.value.data)
   }, [get])
 
   const fetchDownloadUrl = useCallback(async () => {

--- a/apps/cms/src/api/data-snapshot/routes/data-snapshot.ts
+++ b/apps/cms/src/api/data-snapshot/routes/data-snapshot.ts
@@ -33,6 +33,7 @@ export default {
       path: "/data-snapshot/admin/trigger",
       handler: "data-snapshot.trigger",
       config: {
+        auth: false,
         policies: [],
         middlewares: ["global::admin-auth"],
       },
@@ -42,6 +43,7 @@ export default {
       path: "/data-snapshot/admin/download",
       handler: "data-snapshot.download",
       config: {
+        auth: false,
         policies: [],
         middlewares: ["global::admin-auth"],
       },
@@ -51,6 +53,7 @@ export default {
       path: "/data-snapshot/admin/status",
       handler: "data-snapshot.status",
       config: {
+        auth: false,
         policies: [],
         middlewares: ["global::admin-auth"],
       },


### PR DESCRIPTION
## Summary
- Data-snapshot admin routes were missing `auth: false`, so Strapi's default content-API auth rejected admin session tokens before our `admin-auth` middleware could run
- `fetchStatuses` used `Promise.all` — a 401 on the data-snapshot endpoint silently prevented **both** sync and snapshot statuses from updating
- Switched to `Promise.allSettled` so each endpoint updates independently

## Test plan
- [ ] Click "Sync Now" — UI should show running state with phase progress
- [ ] Status should poll and update every 3s while sync is in progress
- [ ] Snapshot card should also show correct status independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)