### PR TITLE
docs(roadmap): TV app prototype tickets and requirements (feat-072–076)

### DIFF
--- a/docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md
+++ b/docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md
@@ -1,0 +1,174 @@
+---
+date: 2026-04-10
+topic: tv-app-prototype
+---
+
+# TV App Prototype — Apple TV & Android TV
+
+## Problem Frame
+
+Urim's roadmap items (feat-011, 012, 017, 018) are blocked on upstream search and topic infrastructure. Rather than idle, this time should go toward standing up a TV app — the third rendering target for the existing CMS-driven Experience pipeline.
+
+JesusFilm's SDUI architecture (Strapi → GraphQL → normalizer → dispatcher → renderers) was designed for exactly this: same content, multiple surfaces. A TV app adds reach to living rooms using existing CMS content and GraphQL API. The prototype validates that the pipeline works on TV and establishes the foundation for a production app.
+
+This work is **AI-driven** — Claude agents execute implementation, Urim reviews plans and PRs. It runs **in parallel with feat-004 (Web App Onboarding)**.
+
+## Users
+
+- People who watch faith-based video content on their TV
+- Families exploring JesusFilm Experiences together on a big screen
+- Not power users — expect low technical confidence with remote controls
+
+## Design Philosophy
+
+- **Effortless discovery**: Users should find interesting content within seconds, not hunt for it. The UI must guide, not overwhelm.
+- **10-foot UI**: Everything readable from a couch. Large text, high contrast, generous spacing. No small tap targets — focus rings and D-pad are the interaction model.
+- **Curated rails, not infinite scroll**: Horizontal content rails (Netflix/YouTube TV pattern) organized by Experience or category. Proven for TV because it works perfectly with D-pad left/right/up/down.
+- **Dive deeper on select**: Pressing select on a rail item opens the full Experience view — the section-by-section journey, adapted for TV.
+- **Video-first**: On TV, video is the primary medium. Full-screen playback on select. Minimize text-heavy screens.
+
+## Scope — Working Prototype
+
+### In Scope
+
+1. **Day-1 spike**: Verify Expo TV toolchain — get a minimal "hello world" app building and running on Apple TV Simulator using `@react-native-tvos/config-tv` + `EXPO_TV=1`. Confirm expo-video plays an HLS stream on tvOS. Go/no-go gate before further work.
+2. **App scaffolding**: New `apps/tv/` Expo app using `react-native-tvos` (aliased via npm as `react-native`), `@react-native-tvos/config-tv` plugin, CNG/prebuild with `EXPO_TV=1`. Dev-client builds only (no Expo Go on TV).
+3. **GraphQL wiring**: Apollo Client + `@forge/graphql` fetching Experiences from CMS
+4. **SDUI pipeline**: Normalizer and dispatcher ported from mobile-v2, adapted for TV renderers
+5. **Home screen**: Featured hero from the `isHomepage` Experience (VideoHero block) at the top. Below: an "Experiences" rail showing all Experiences as cards (`LIST_EXPERIENCES` → ogImage + title). Select opens Experience detail.
+6. **Experience screen**: Vertical section feed rendering the blocks for a selected Experience. Renderers: VideoHero, SectionWrapper, Container, Video, Text, BibleQuotesCarousel. Unhandled block types display a PlaceholderRenderer (dev log + skip).
+7. **Video playback**: expo-video playing HLS streams, full-screen on select
+8. **Focus management**: TVFocusGuideView for reliable D-pad navigation between and within rails
+9. **Loading/error states**: Loading spinner while fetching, error screen with focusable retry button (D-pad must always have a focus target). Empty state if no Experiences returned.
+
+### Out of Scope (for prototype)
+
+- Search functionality (blocked upstream anyway)
+- Topic browsing (blocked upstream)
+- Deep linking / universal links
+- Analytics / tracking
+- Offline support / caching beyond Apollo defaults
+- Localization (English only for prototype)
+- Production EAS build profiles (development/preview only)
+- App Store / Play Store submission
+- MediaCollection, quiz, NavigationCarousel, VideoCarousel, EasterDates, and other non-core renderers (deferred — PlaceholderRenderer handles these gracefully)
+- Auto-preview on focus (deferred — prototype shows static thumbnails; auto-preview adds debounce/mute/abort complexity better suited for a follow-up)
+
+## Architecture
+
+```
+apps/tv/                          # New Expo TV app
+├── app/
+│   ├── _layout.tsx               # Root layout + ExperienceProvider + Apollo
+│   ├── index.tsx                 # Home screen (content rails)
+│   └── experience/[slug].tsx     # Experience detail screen
+├── src/
+│   ├── lib/
+│   │   ├── queries.ts            # Import/re-export from mobile-v2 or duplicate
+│   │   ├── normalizer.ts         # Port from mobile-v2 (identical logic)
+│   │   └── apolloClient.ts        # Apollo Client setup for TV (follows mobile-v2 lazy-init pattern)
+│   └── components/
+│       ├── sections/
+│       │   ├── SectionDispatcher.tsx
+│       │   ├── VideoHeroRenderer.tsx     # TV-adapted (auto-preview, focus ring)
+│       │   ├── VideoCardRenderer.tsx     # Landscape card for rails
+│       │   ├── TextRenderer.tsx          # Large readable text
+│       │   ├── BibleQuotesCarouselRenderer.tsx
+│       │   ├── SectionWrapperRenderer.tsx   # Structural wrapper (most blocks are nested inside these)
+│       │   ├── ContainerRenderer.tsx        # Container wrapper for Text + RelatedQuestions
+│       │   └── PlaceholderRenderer.tsx      # Fallback for unhandled block types (logs + skips)
+│       ├── ContentRail.tsx               # Horizontal scrolling rail with focus
+│       ├── FocusableCard.tsx             # Base focusable element with ring
+│       └── VideoPlayer.tsx               # Full-screen TV video player
+```
+
+### Code Sharing Strategy
+
+- **Direct reuse**: `@forge/graphql` package (types, `graphql()` function) — already shared
+- **Import directly**: `normalizer.ts` and `queries.ts` — import from `apps/mobile-v2/src/lib/` via pnpm workspace path (e.g., add `mobile-v2` as a workspace dependency, or use TypeScript path aliases). Avoids copy-and-drift. Both files depend on `@forge/graphql` types which are already shared. Note: normalizer uses RN `__DEV__` global (available in react-native-tvos).
+- **Rewrite for TV**: All renderers — same data shapes but entirely different visual treatment for 10-foot UI and focus navigation
+- **ExperienceProvider**: Port from `apps/mobile-v2/src/contexts/ExperienceProvider.tsx` — provides normalized Experience data to screens. Import directly or copy if the provider needs TV-specific adaptations.
+- **Not extracted to shared package yet**: If the TV app proves out, extract normalizer + queries + ExperienceProvider into `packages/experience-sdui` as a follow-up.
+
+## TV-Specific UX Patterns
+
+### Focus Management
+
+- Every interactive element must be focusable via D-pad
+- Visible focus ring (high-contrast border or glow) on the currently focused element
+- Focus memory (in-memory, per-session only): returning to the home screen from an Experience detail remembers which rail card was last focused. No persistence across app restarts.
+- TVFocusGuideView to constrain focus within rails (prevent diagonal jumps)
+
+### Home Screen Layout
+
+- **Hero area (top)**: The `isHomepage` Experience's VideoHero block, rendered full-width at top of screen. Shows thumbnail (no auto-preview in prototype). Title + subtitle overlay.
+- **Experiences rail (below hero)**: Horizontal rail of all Experiences from `LIST_EXPERIENCES`. Each card shows ogImage + title. D-pad left/right scrolls the rail. Select navigates to that Experience's detail screen.
+- D-pad up focuses hero, down focuses rail
+- Focused card scales up slightly (1.05x) with focus ring
+- Rail title visible above the rail (e.g., "Explore Experiences")
+
+### Video Behavior
+
+- On focus (in a rail): show static thumbnail (auto-preview deferred to follow-up)
+- On select from rail: navigate to Experience detail screen
+- On select on a video block in Experience screen: enter full-screen playback
+- Playback controls: play/pause (center button), seek ±10s (left/right), back to Experience (menu button)
+- End of video: return to Experience screen, focus on the video block that was playing
+
+### Navigation
+
+- No tab bar — Expo Router stack navigation (home → experience detail → video fullscreen)
+- Select on home rail card: push to `experience/[slug]` screen
+- Back button (menu on Apple TV remote, back on Android TV): pops navigation stack
+- Home screen is the root — back from home exits app
+- Transitions: use Expo Router's default push animation (known to work on TV per ExpoRouterTV demo)
+
+## Success Criteria
+
+### Technical (binary pass/fail)
+
+1. `apps/tv/` builds and runs on Apple TV Simulator and Android TV Emulator via `EXPO_TV=1 npx expo prebuild --clean && npx expo run:ios` (or Android equivalent)
+2. Home screen renders hero + Experiences rail populated from CMS via GraphQL
+3. D-pad navigation works: move between hero and rail, scroll within rail, select items
+4. Selecting an Experience opens the Experience detail screen (vertical section feed of blocks)
+5. Video playback works full-screen with play/pause and ±10s seek
+6. Focus rings are visible and follow D-pad movement consistently
+7. Loading spinner shows during data fetch; error screen with retry button shows on failure
+
+### Qualitative (go/no-go for production app)
+
+8. Focus navigation feels responsive (no perceptible lag between D-pad press and focus move)
+9. Video playback quality is acceptable on a TV-sized display (no buffering on reasonable connection)
+10. The Experience detail screen is readable and navigable — content doesn't feel like a stretched phone app
+
+## Platform Validation (Resolved)
+
+Research confirms Expo SDK 54 supports TV targets:
+
+- `react-native-tvos@0.81-stable` installed as npm alias for `react-native`
+- `@react-native-tvos/config-tv` Expo config plugin handles native setup
+- `EXPO_TV=1` + `npx expo prebuild --clean` generates TV-targeted native projects
+- expo-video has tvOS support (expo/expo PR #29560, merged June 2024)
+- Expo Router works on TV (confirmed by ExpoRouterTV demo project)
+- Dev-client builds only (no Expo Go on TV)
+- Day-1 spike (In Scope item #1) validates this end-to-end before further work
+
+## Risks & Open Questions
+
+1. **Focus management complexity**: D-pad focus can be finicky, especially with nested scrollable containers. May need custom focus engine. Known issue: focus lost on back-navigation (react-native-tvos issue #852).
+2. **Image aspect ratios**: Mobile queries use `mobileCinematicHigh` (portrait-optimized). TV is landscape-native. Prototype uses `ogImage` for home rail and `videoStill` for Experience blocks — both are landscape-friendly. If quality is insufficient, TV-specific CMS image fields may be needed later.
+3. **Content volume**: If the CMS has fewer than ~5 Experiences, the home screen rail will look sparse. The prototype's visual quality depends on having enough content to demonstrate the browsing experience.
+4. **pnpm workspace import**: Importing normalizer/queries directly from mobile-v2 may need Metro bundler configuration to resolve cross-app imports. If this causes issues, fall back to copying the files.
+
+## Roadmap Fit
+
+- **Timeline**: Prototype during blocked period (April 10 – April 30, 2026). If upstream items unblock mid-prototype, TV work continues at lower priority — the AI agents can sustain progress with lighter review cadence.
+- **Parallel with**: feat-004 (Web App Onboarding). Both are AI-driven with Urim reviewing PRs. Expect ~2-3 PRs/day across both tracks during active periods.
+- **No upstream dependencies**: Uses existing CMS content and GraphQL API
+- **Follow-up ticket**: If prototype succeeds (meets qualitative criteria #8-10), create a proper roadmap feature for production TV app
+
+## Non-Goals
+
+- This is not a production app. No App Store polish, no crash reporting, no performance optimization.
+- Not extracting shared SDUI packages yet. Prove the concept first, refactor second.
+- Not building custom navigation patterns. Use proven TV patterns (rails, focus rings, back = pop).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,10 +6,10 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (April 7, 2026)
 
-- **Total tickets:** 70
+- **Total tickets:** 75
 - **Complete:** 12
 - **In progress:** 3
-- **Not started:** 11
+- **Not started:** 16
 - **Blocked:** 44
 - **Overdue and not complete:** 2
 
@@ -82,25 +82,30 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ### Topic Experiences
 
-| ID                                                                                    | Feature                                      | Owner     | Priority | Start      | Days | Due        | Status      |
-| ------------------------------------------------------------------------------------- | -------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
-| [feat-023](topic-experiences/feat-023-web-experience-pages.md)                        | Web Experience Pages                         | nisal     | P0       | 2026-02-17 | 31   | 2026-03-19 | complete    |
-| [feat-025](topic-experiences/feat-025-mobile-app-ios-native.md)                       | Mobile App — iOS Native                      | urim      | P0       | 2026-02-25 | 16   | 2026-03-12 | complete    |
-| [feat-024](topic-experiences/feat-024-mobile-app-expo.md)                             | Mobile App — Expo                            | ekkasit   | P0       | 2026-03-02 | 28   | 2026-03-29 | complete    |
-| [feat-029](topic-experiences/feat-029-easter-experience.md)                           | Easter Experience (First Production Launch)  | nisal     | P0       | 2026-03-10 | 21   | 2026-03-30 | complete    |
-| [feat-034](topic-experiences/feat-034-ai-christmas-experience.md)                     | AI-Generated Christmas Experience            | ekkasit   | P0       | 2026-03-25 | 7    | 2026-03-31 | in-progress |
-| [feat-001](topic-experiences/feat-001-architecture-contracts.md)                      | Architecture Contracts                       | tataihono | P0       | 2026-04-01 | 7    | 2026-04-07 | not-started |
-| [feat-002](topic-experiences/feat-002-wire-enrichment-metadata-to-cms.md)             | Wire Enrichment Metadata Back to CMS         | vlad      | P0       | 2026-04-01 | 14   | 2026-04-14 | not-started |
-| [feat-003](topic-experiences/feat-003-topic-content-type.md)                          | Topic Content Type in Strapi                 | nisal     | P0       | 2026-04-01 | 14   | 2026-04-14 | blocked     |
-| [feat-007](topic-experiences/feat-007-topic-clustering.md)                            | Topic Clustering from Enriched Metadata      | ekkasit   | P0       | 2026-04-01 | 21   | 2026-04-21 | blocked     |
-| [feat-008](topic-experiences/feat-008-experience-block-templates.md)                  | Experience Block Template System             | ekkasit   | P0       | 2026-04-07 | 21   | 2026-04-27 | blocked     |
-| [feat-013](topic-experiences/feat-013-bulk-experience-generation.md)                  | Bulk Experience Generation Pipeline          | ekkasit   | P0       | 2026-04-14 | 42   | 2026-05-25 | blocked     |
-| [feat-015](topic-experiences/feat-015-bulk-experience-write-api.md)                   | Bulk Experience Write API                    | nisal     | P1       | 2026-04-14 | 21   | 2026-05-04 | blocked     |
-| [feat-017](topic-experiences/feat-017-topic-browsing-web.md)                          | Topic Browsing — Web                         | urim      | P1       | 2026-04-21 | 28   | 2026-05-18 | blocked     |
-| [feat-016](topic-experiences/feat-016-topic-experience-graphql.md)                    | Topic / Experience GraphQL Wiring            | nisal     | P1       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
-| [feat-018](topic-experiences/feat-018-topic-browsing-mobile.md)                       | Topic Browsing — Mobile                      | urim      | P1       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
-| [feat-061](topic-experiences/feat-061-watch-platform-upgrade-bible-verse-visuals.md)  | Watch Platform Upgrade (Bible Verse Visuals) | tataihono | P1       | 2026-07-15 | 48   | 2026-08-31 | blocked     |
-| [feat-059](topic-experiences/feat-059-ai-assisted-topic-page-generation-and-flows.md) | AI-Assisted Topic Page Generation and Flows  | tataihono | P1       | 2026-08-01 | 45   | 2026-09-14 | blocked     |
-| [feat-020](topic-experiences/feat-020-ai-topic-content-generation.md)                 | AI Topic Content Generation Service          | vlad      | P2       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
-| [feat-021](topic-experiences/feat-021-generation-quality-monitoring.md)               | Generation Quality & Monitoring Dashboard    | ekkasit   | P2       | 2026-05-05 | 21   | 2026-05-25 | blocked     |
-| [feat-069](topic-experiences/feat-069-validated-topic-pages.md)                       | Validated Topic Pages                        | tataihono | P2       | 2026-11-01 | 61   | 2026-12-31 | blocked     |
+| ID                                                                                    | Feature                                        | Owner     | Priority | Start      | Days | Due        | Status      |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
+| [feat-023](topic-experiences/feat-023-web-experience-pages.md)                        | Web Experience Pages                           | nisal     | P0       | 2026-02-17 | 31   | 2026-03-19 | complete    |
+| [feat-025](topic-experiences/feat-025-mobile-app-ios-native.md)                       | Mobile App — iOS Native                        | urim      | P0       | 2026-02-25 | 16   | 2026-03-12 | complete    |
+| [feat-024](topic-experiences/feat-024-mobile-app-expo.md)                             | Mobile App — Expo                              | ekkasit   | P0       | 2026-03-02 | 28   | 2026-03-29 | complete    |
+| [feat-029](topic-experiences/feat-029-easter-experience.md)                           | Easter Experience (First Production Launch)    | nisal     | P0       | 2026-03-10 | 21   | 2026-03-30 | complete    |
+| [feat-034](topic-experiences/feat-034-ai-christmas-experience.md)                     | AI-Generated Christmas Experience              | ekkasit   | P0       | 2026-03-25 | 7    | 2026-03-31 | in-progress |
+| [feat-001](topic-experiences/feat-001-architecture-contracts.md)                      | Architecture Contracts                         | tataihono | P0       | 2026-04-01 | 7    | 2026-04-07 | not-started |
+| [feat-002](topic-experiences/feat-002-wire-enrichment-metadata-to-cms.md)             | Wire Enrichment Metadata Back to CMS           | vlad      | P0       | 2026-04-01 | 14   | 2026-04-14 | not-started |
+| [feat-003](topic-experiences/feat-003-topic-content-type.md)                          | Topic Content Type in Strapi                   | nisal     | P0       | 2026-04-01 | 14   | 2026-04-14 | blocked     |
+| [feat-007](topic-experiences/feat-007-topic-clustering.md)                            | Topic Clustering from Enriched Metadata        | ekkasit   | P0       | 2026-04-01 | 21   | 2026-04-21 | blocked     |
+| [feat-008](topic-experiences/feat-008-experience-block-templates.md)                  | Experience Block Template System               | ekkasit   | P0       | 2026-04-07 | 21   | 2026-04-27 | blocked     |
+| [feat-013](topic-experiences/feat-013-bulk-experience-generation.md)                  | Bulk Experience Generation Pipeline            | ekkasit   | P0       | 2026-04-14 | 42   | 2026-05-25 | blocked     |
+| [feat-015](topic-experiences/feat-015-bulk-experience-write-api.md)                   | Bulk Experience Write API                      | nisal     | P1       | 2026-04-14 | 21   | 2026-05-04 | blocked     |
+| [feat-017](topic-experiences/feat-017-topic-browsing-web.md)                          | Topic Browsing — Web                           | urim      | P1       | 2026-04-21 | 28   | 2026-05-18 | blocked     |
+| [feat-016](topic-experiences/feat-016-topic-experience-graphql.md)                    | Topic / Experience GraphQL Wiring              | nisal     | P1       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
+| [feat-018](topic-experiences/feat-018-topic-browsing-mobile.md)                       | Topic Browsing — Mobile                        | urim      | P1       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
+| [feat-061](topic-experiences/feat-061-watch-platform-upgrade-bible-verse-visuals.md)  | Watch Platform Upgrade (Bible Verse Visuals)   | tataihono | P1       | 2026-07-15 | 48   | 2026-08-31 | blocked     |
+| [feat-059](topic-experiences/feat-059-ai-assisted-topic-page-generation-and-flows.md) | AI-Assisted Topic Page Generation and Flows    | tataihono | P1       | 2026-08-01 | 45   | 2026-09-14 | blocked     |
+| [feat-020](topic-experiences/feat-020-ai-topic-content-generation.md)                 | AI Topic Content Generation Service            | vlad      | P2       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
+| [feat-021](topic-experiences/feat-021-generation-quality-monitoring.md)               | Generation Quality & Monitoring Dashboard      | ekkasit   | P2       | 2026-05-05 | 21   | 2026-05-25 | blocked     |
+| [feat-069](topic-experiences/feat-069-validated-topic-pages.md)                       | Validated Topic Pages                          | tataihono | P2       | 2026-11-01 | 61   | 2026-12-31 | blocked     |
+| [feat-072](topic-experiences/feat-072-tv-app-spike.md)                                | TV App — Expo TV Toolchain Spike               | urim      | P1       | 2026-04-10 | 2    | 2026-04-11 | not-started |
+| [feat-073](topic-experiences/feat-073-tv-app-scaffolding.md)                          | TV App — Scaffolding + GraphQL Wiring          | urim      | P1       | 2026-04-12 | 3    | 2026-04-14 | not-started |
+| [feat-074](topic-experiences/feat-074-tv-app-home-screen.md)                          | TV App — Home Screen (Hero + Experiences Rail) | urim      | P1       | 2026-04-15 | 5    | 2026-04-19 | not-started |
+| [feat-075](topic-experiences/feat-075-tv-app-experience-screen.md)                    | TV App — Experience Detail Screen              | urim      | P1       | 2026-04-15 | 7    | 2026-04-21 | not-started |
+| [feat-076](topic-experiences/feat-076-tv-app-video-playback.md)                       | TV App — Video Playback + Polish               | urim      | P1       | 2026-04-22 | 7    | 2026-04-28 | not-started |

--- a/docs/roadmap/topic-experiences/feat-072-tv-app-spike.md
+++ b/docs/roadmap/topic-experiences/feat-072-tv-app-spike.md
@@ -1,0 +1,56 @@
+---
+id: "feat-072"
+title: "TV App — Expo TV Toolchain Spike"
+owner: "urim"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-10"
+duration: 2
+depends_on: []
+blocks:
+  - "feat-073"
+tags:
+  - "tv"
+  - "mobile"
+---
+
+## Problem
+
+Before investing in a TV app prototype, we need to verify that the Expo SDK 54 TV toolchain works end-to-end: building for Apple TV Simulator, running expo-video on tvOS, and confirming Expo Router navigates correctly with D-pad input.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md` — full requirements and Platform Validation section
+2. `apps/mobile-v2/package.json` — current Expo SDK version and dependencies to match
+3. `apps/mobile-v2/app.json` — Expo config structure to base TV config on
+
+## Grep These
+
+- `react-native-tvos` on npm — verify `0.81-stable` release exists
+- `@react-native-tvos/config-tv` on npm — verify plugin exists and supports SDK 54
+- `expo-video` in `apps/mobile-v2/` — current video configuration to replicate
+
+## What To Build
+
+1. Create minimal `apps/tv-spike/` Expo app (throwaway, not production scaffolding)
+2. Install `react-native-tvos@0.81-stable` as npm alias for `react-native`
+3. Add `@react-native-tvos/config-tv` plugin to `app.json`
+4. Run `EXPO_TV=1 npx expo prebuild --clean` — verify native project generates
+5. Run on Apple TV Simulator — verify app launches
+6. Add a single expo-video component playing an HLS stream — verify playback works
+7. Add two screens with Expo Router — verify D-pad navigation and back button work
+8. Document any issues, workarounds, or version pins needed
+
+## Constraints
+
+- This is a throwaway spike — do NOT invest in architecture, styling, or code quality
+- Do NOT add to the monorepo's CI pipeline
+- If the spike fails (Expo TV doesn't work with SDK 54), document why and stop
+
+## Verification
+
+- Apple TV Simulator shows the spike app running
+- expo-video plays an HLS stream on tvOS
+- D-pad navigates between two Expo Router screens
+- Back button (menu) pops the navigation stack
+- Document: go/no-go decision with any required version pins or workarounds

--- a/docs/roadmap/topic-experiences/feat-073-tv-app-scaffolding.md
+++ b/docs/roadmap/topic-experiences/feat-073-tv-app-scaffolding.md
@@ -1,0 +1,60 @@
+---
+id: "feat-073"
+title: "TV App — Scaffolding + GraphQL Wiring"
+owner: "urim"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-12"
+duration: 3
+depends_on:
+  - "feat-072"
+blocks:
+  - "feat-074"
+  - "feat-075"
+tags:
+  - "tv"
+  - "graphql"
+---
+
+## Problem
+
+With the Expo TV toolchain validated (feat-072), set up the production TV app scaffolding: proper Expo project, Apollo Client wiring, and the SDUI pipeline (normalizer + dispatcher) imported from mobile-v2.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md` — Architecture and Code Sharing Strategy sections
+2. `apps/mobile-v2/src/lib/apolloClient.ts` — Apollo Client lazy-init pattern to replicate
+3. `apps/mobile-v2/src/lib/normalizer.ts` — normalizer to import directly
+4. `apps/mobile-v2/src/lib/queries.ts` — queries to import directly
+5. `apps/mobile-v2/src/contexts/ExperienceProvider.tsx` — context provider to port
+6. `packages/graphql/` — shared typed GraphQL client
+
+## Grep These
+
+- `getApolloClient` in `apps/mobile-v2/src/` — lazy Apollo Client init pattern
+- `NormalizedBlock` in `apps/mobile-v2/src/` — normalizer output type usage
+- `ExperienceProvider` in `apps/mobile-v2/src/` — context usage pattern
+
+## What To Build
+
+1. Create `apps/tv/` with proper Expo TV config (react-native-tvos alias, config-tv plugin, EXPO_TV=1)
+2. Add `apps/tv/` to pnpm workspace and turborepo pipeline
+3. Wire Apollo Client (`apolloClient.ts`) following mobile-v2's lazy-init pattern
+4. Import `normalizer.ts` and `queries.ts` from mobile-v2 via pnpm workspace path or TypeScript path aliases. If Metro can't resolve cross-app imports, copy the files.
+5. Port `ExperienceProvider` — adapt if needed for TV (e.g., no ExperienceSelectionProvider if TV always shows all Experiences)
+6. Create `SectionDispatcher.tsx` with PlaceholderRenderer for unhandled blocks
+7. Set up Expo Router with two routes: `app/index.tsx` (home) and `app/experience/[slug].tsx` (detail)
+8. Verify: app builds, connects to CMS GraphQL, and fetches Experience data
+
+## Constraints
+
+- Do NOT build any UI beyond placeholder screens that log fetched data
+- Do NOT add linting/CI yet — that's a follow-up after the prototype is proven
+- Import from mobile-v2 first; only copy files if the import approach fails
+
+## Verification
+
+- `cd apps/tv && EXPO_TV=1 npx expo prebuild --clean && npx expo run:ios` succeeds
+- Console logs show Experience data fetched from CMS
+- Expo Router navigates between home and detail screens via D-pad
+- `pnpm build --filter=tv` runs without errors in turborepo

--- a/docs/roadmap/topic-experiences/feat-074-tv-app-home-screen.md
+++ b/docs/roadmap/topic-experiences/feat-074-tv-app-home-screen.md
@@ -1,0 +1,59 @@
+---
+id: "feat-074"
+title: "TV App — Home Screen (Hero + Experiences Rail)"
+owner: "urim"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-15"
+duration: 5
+depends_on:
+  - "feat-073"
+blocks:
+  - "feat-076"
+tags:
+  - "tv"
+---
+
+## Problem
+
+The TV app needs a home screen that lets users discover and browse Experiences using D-pad navigation. The home screen uses a featured hero at the top (from the `isHomepage` Experience) and a horizontal rail of all available Experiences below.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md` — Home Screen Layout section
+2. `apps/mobile-v2/src/lib/queries.ts` — `LIST_EXPERIENCES` and `GET_WATCH_EXPERIENCE` queries
+3. `apps/mobile-v2/src/components/sections/VideoHeroRenderer.tsx` — hero renderer to adapt for TV
+4. `apps/tv/app/index.tsx` — home screen route (from feat-073 scaffolding)
+
+## Grep These
+
+- `LIST_EXPERIENCES` in `apps/mobile-v2/src/` — how the Experience list is fetched
+- `isHomepage` in `apps/mobile-v2/src/` — how the homepage Experience is identified
+- `TVFocusGuideView` in react-native-tvos docs — focus containment API
+- `hasTVPreferredFocus` — initial focus control
+
+## What To Build
+
+1. **FocusableCard component**: Base pressable element with visible focus ring (border glow), 1.05x scale-up on focus, `onPress` handler. Uses `hasTVPreferredFocus` for initial focus.
+2. **ContentRail component**: Horizontal FlatList of FocusableCards, wrapped in TVFocusGuideView to constrain D-pad left/right within the rail. Rail title label above.
+3. **Home screen hero**: Fetch `isHomepage` Experience via `GET_WATCH_EXPERIENCE`, extract VideoHero block. Render as a full-width static thumbnail with title/subtitle overlay. No auto-preview (deferred).
+4. **Experiences rail**: Fetch all Experiences via `LIST_EXPERIENCES`. Render as FocusableCards showing ogImage + title. Select pushes to `experience/[slug]`.
+5. **Focus navigation**: D-pad up/down moves between hero and rail. Focus memory (in-memory ref) remembers last-focused rail card.
+6. **Loading state**: Centered spinner while fetching.
+7. **Error state**: Error message with focusable "Retry" button.
+8. **Empty state**: "No Experiences available" message.
+
+## Constraints
+
+- Use `ogImage` from `LIST_EXPERIENCES` for rail card thumbnails — do NOT add new CMS image fields
+- Static thumbnails only — no auto-preview on focus
+- 10-foot UI: minimum text size ~24sp, generous card spacing, high-contrast focus ring
+
+## Verification
+
+- Home screen shows hero area with the homepage Experience's VideoHero image
+- Experiences rail shows cards for all Experiences from CMS
+- D-pad left/right scrolls rail, up/down moves between hero and rail
+- Focus ring is clearly visible on the currently focused card
+- Select on a card navigates to the Experience detail route
+- Loading spinner shows during fetch, error screen with retry on failure

--- a/docs/roadmap/topic-experiences/feat-075-tv-app-experience-screen.md
+++ b/docs/roadmap/topic-experiences/feat-075-tv-app-experience-screen.md
@@ -1,0 +1,70 @@
+---
+id: "feat-075"
+title: "TV App — Experience Detail Screen (SDUI Renderers)"
+owner: "urim"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-15"
+duration: 7
+depends_on:
+  - "feat-073"
+blocks:
+  - "feat-076"
+tags:
+  - "tv"
+---
+
+## Problem
+
+When a user selects an Experience from the home screen rail, the TV app needs to render that Experience's content blocks in a vertical, D-pad-navigable feed. This requires TV-adapted renderers for the core block types.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md` — Experience screen and renderer sections
+2. `apps/mobile-v2/src/components/sections/SectionDispatcher.tsx` — mobile dispatcher to adapt
+3. `apps/mobile-v2/src/components/sections/SectionWrapperRenderer.tsx` — structural wrapper pattern
+4. `apps/mobile-v2/src/components/sections/ContainerRenderer.tsx` — container wrapper
+5. `apps/mobile-v2/src/components/sections/VideoCardRenderer.tsx` — video block renderer
+6. `apps/mobile-v2/src/components/sections/TextRenderer.tsx` — text block renderer
+7. `apps/mobile-v2/src/components/sections/BibleQuotesCarouselRenderer.tsx` — carousel renderer
+8. `apps/mobile-v2/src/lib/normalizer.ts` — block type mapping (18 types)
+
+## Grep These
+
+- `kind === ` in `apps/mobile-v2/src/components/sections/SectionDispatcher.tsx` — all handled block types
+- `NormalizedBlock` in `apps/mobile-v2/src/` — type shape used by renderers
+- `contentParagraphs` in `apps/mobile-v2/src/` — how JSON text arrays are rendered
+
+## What To Build
+
+### Renderers (TV-adapted, 10-foot UI)
+
+1. **SectionWrapperRenderer**: Recursively renders child blocks with optional background color. Structural pass-through — required because most blocks are nested inside these.
+2. **ContainerRenderer**: Renders child Text + RelatedQuestions blocks. Layout wrapper.
+3. **VideoHeroRenderer**: Full-width hero with static thumbnail, title overlay. Select enters full-screen playback (connects to feat-076).
+4. **VideoCardRenderer**: Landscape video card with thumbnail + title. Focusable. Select enters playback.
+5. **TextRenderer**: Large readable text (min ~24sp heading, ~18sp body). Max line width ~80 characters for readability at 10 feet.
+6. **BibleQuotesCarouselRenderer**: Horizontal D-pad-navigable carousel of quote cards. Each card shows reference + text. TVFocusGuideView to contain horizontal focus.
+7. **PlaceholderRenderer**: Logs unhandled block type in dev, renders nothing. Prevents crashes from unrecognized blocks.
+
+### Screen
+
+8. **Experience detail screen** (`app/experience/[slug].tsx`): Fetch Experience via `GET_WATCH_EXPERIENCE`, normalize blocks, render via SectionDispatcher in a vertical FlatList. D-pad up/down scrolls between sections. First focusable element receives initial focus.
+9. **Loading/error/empty states**: Same pattern as home screen.
+
+## Constraints
+
+- Renderers receive the same `NormalizedBlock` types as mobile-v2 — do NOT create parallel type hierarchies
+- 10-foot UI: all text readable from couch distance. Use generous padding and spacing.
+- Back button (menu) returns to home screen
+- Do NOT implement NavigationCarousel, VideoCarousel, MediaCollection, QuizButton, EasterDates — PlaceholderRenderer handles these
+
+## Verification
+
+- Navigating to an Experience from home shows its blocks rendered vertically
+- SectionWrapper/Container correctly render nested child blocks
+- Video blocks show thumbnails and are focusable
+- Text blocks are large and readable
+- BibleQuotes carousel navigates horizontally with D-pad
+- Unhandled block types silently skip (no crash, dev log only)
+- Back button returns to home screen with focus memory preserved

--- a/docs/roadmap/topic-experiences/feat-076-tv-app-video-playback.md
+++ b/docs/roadmap/topic-experiences/feat-076-tv-app-video-playback.md
@@ -1,0 +1,75 @@
+---
+id: "feat-076"
+title: "TV App — Video Playback + Polish"
+owner: "urim"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-22"
+duration: 7
+depends_on:
+  - "feat-074"
+  - "feat-075"
+blocks: []
+tags:
+  - "tv"
+---
+
+## Problem
+
+The TV app needs full-screen video playback with TV remote controls, and an overall polish pass to ensure the prototype meets the qualitative go/no-go criteria for a production TV app decision.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md` — Video Behavior and Success Criteria sections
+2. `apps/mobile-v2/app.json` — expo-video plugin config (`supportsBackgroundPlayback`)
+3. `apps/tv/src/components/sections/VideoHeroRenderer.tsx` — hero renderer (from feat-075)
+4. `apps/tv/src/components/sections/VideoCardRenderer.tsx` — video card renderer (from feat-075)
+
+## Grep These
+
+- `expo-video` in `apps/mobile-v2/` — current video implementation
+- `useVideoPlayer` in `apps/mobile-v2/src/` — video player hook usage
+- `streamingUrl` in `apps/mobile-v2/src/` — HLS URL extraction from Experience data
+
+## What To Build
+
+### Video Playback
+
+1. **VideoPlayer component**: Full-screen expo-video player for TV
+   - Play/pause: center button (Apple TV remote select / Android TV center)
+   - Seek: ±10 seconds on left/right D-pad
+   - Back: menu button returns to Experience detail screen
+   - Simple progress bar overlay (show on any button press, auto-hide after 3s)
+2. **Integration**: VideoHeroRenderer and VideoCardRenderer `onSelect` triggers full-screen playback with the block's `streamingUrl`
+3. **End of playback**: Return to Experience detail screen, restore focus to the video block that was playing
+
+### Polish Pass
+
+4. **Focus ring consistency**: Audit all focusable elements — ensure visible focus ring on every interactive item across all screens
+5. **Focus responsiveness**: Test rapid D-pad input — ensure no perceptible lag
+6. **Content readability**: Verify all text is readable at 10-foot distance on a 1080p display
+7. **Navigation flow**: Verify complete flow: home → rail select → experience detail → video block select → fullscreen playback → back → experience → back → home (with focus memory)
+
+## Constraints
+
+- Use expo-video (validated in feat-072 spike). Only switch to react-native-video if expo-video has a blocking TV issue discovered during implementation.
+- No scrubber/seek bar UI beyond basic progress indicator
+- No resume-from-position — always starts from beginning (prototype scope)
+- No background playback or PiP
+
+## Verification
+
+### Technical
+
+- Select on a video block enters full-screen playback
+- Center button toggles play/pause
+- Left/right D-pad seeks ±10 seconds
+- Menu button exits playback and returns to Experience screen
+- End of video returns to Experience screen automatically
+
+### Qualitative (go/no-go for production)
+
+- Focus navigation feels responsive (no perceptible lag)
+- Video playback quality acceptable on TV display
+- Experience detail screen is readable and navigable — doesn't feel like a stretched phone app
+- Complete home → experience → video → back flow works smoothly

--- a/docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md
+++ b/docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md
@@ -1,0 +1,218 @@
+---
+title: "Expo TV Platform Setup in an SDUI Monorepo"
+date: "2026-04-10"
+category: best-practices
+module: tv-app
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - "Adding Apple TV or Android TV to a monorepo with an existing Expo/React Native SDUI pipeline"
+  - "Porting an SDUI dispatcher to a 10-foot UI (TV, kiosk, car)"
+  - "Designing a TV home screen against a CMS modeled for single-Experience deep-links"
+tags:
+  - expo
+  - tv
+  - react-native
+  - sdui
+  - monorepo
+  - focus-management
+  - architecture
+---
+
+# Expo TV Platform Setup in an SDUI Monorepo
+
+## Context
+
+A monorepo has a working mobile Expo app (SDK 54, React Native 0.81.5) and a web Next.js app, both consuming a Server-Driven UI pipeline: Strapi CMS -> GraphQL -> gql.tada -> normalizer -> dispatcher -> renderers. The team wanted to add Apple TV and Android TV support without duplicating SDUI logic or diverging from the existing content model.
+
+The key challenge was uncertainty about whether Expo SDK 54 supported TV targets at all, combined with the architectural question of how to share the SDUI pipeline across a fundamentally different interaction model (D-pad focus vs touch).
+
+## Guidance
+
+### 1. Expo SDK 54 TV Toolchain
+
+Expo SDK 54 supports TV via `react-native-tvos` and the `@react-native-tvos/config-tv` plugin. No ejection required.
+
+Install `react-native-tvos` as an npm alias:
+
+```jsonc
+// apps/tv/package.json
+{
+  "dependencies": {
+    "react-native": "npm:react-native-tvos@0.81-stable",
+  },
+}
+```
+
+Add the config plugin:
+
+```jsonc
+// apps/tv/app.json
+{
+  "expo": {
+    "plugins": [["@react-native-tvos/config-tv", { "isTV": true }]],
+  },
+}
+```
+
+Build for TV:
+
+```bash
+EXPO_TV=1 npx expo prebuild --clean
+```
+
+Key facts:
+
+- expo-video has tvOS support (expo/expo PR #29560, merged June 2024)
+- Expo Router works on TV (confirmed by ExpoRouterTV demo project)
+- No Expo Go on TV -- dev-client builds only
+- TV-specific file extensions supported: `*.tv.tsx`, `*.ios.tv.tsx`, `*.android.tv.tsx`
+- `npx expo prebuild --clean` is required when switching between phone and TV targets
+
+### 2. Separate App, Shared Logic
+
+Create `apps/tv/` as a new Expo app -- do NOT add TV as a platform target inside the mobile app. Touch UX assumptions (gestures, small screen, portrait) conflict with 10-foot TV UX (D-pad, focus rings, landscape).
+
+```
+apps/
+  mobile-v2/    # touch app -- do not modify for TV
+  tv/           # new Expo app for Apple TV + Android TV
+packages/
+  graphql/      # shared typed GraphQL client (already exists)
+```
+
+Import normalizer and queries from mobile-v2 via pnpm workspace paths. Avoids copy-and-drift -- a CMS schema change propagates automatically after codegen. Renderers are rewritten from scratch for TV.
+
+### 3. Home Screen Data Model
+
+Mobile SDUI apps load one Experience at a time. A TV home screen needs multiple Experiences as a browsable rail. Use existing queries:
+
+- **Hero**: Fetch the `isHomepage` Experience via `GET_WATCH_EXPERIENCE`, render its `VideoHero` block full-width at the top
+- **Rail**: Fetch all Experiences via `LIST_EXPERIENCES` (returns ogImage + title), render as horizontal cards
+
+No new CMS queries or content types needed.
+
+### 4. Structural Renderers Are Mandatory
+
+Most CMS blocks are nested inside structural wrappers (`SectionWrapper`, `Container`). If these aren't handled in the dispatcher, nested content silently disappears -- no error, just blank space.
+
+Always implement:
+
+- `SectionWrapperRenderer` -- renders children, passes layout props
+- `ContainerRenderer` -- renders children, passes width/padding props
+- `PlaceholderRenderer` -- logs unhandled block types in dev, returns null
+
+```typescript
+// PlaceholderRenderer.tsx
+export function PlaceholderRenderer({ block }: BlockProps) {
+  if (__DEV__) {
+    console.warn(`[TV] Unhandled block type: ${block.kind}`)
+  }
+  return null
+}
+```
+
+### 5. Day-1 Spike Pattern
+
+Before building any features, validate the toolchain end-to-end with a throwaway spike:
+
+1. Minimal Expo TV app (single screen)
+2. Build for Apple TV Simulator
+3. Confirm expo-video plays an HLS stream
+4. Confirm D-pad reaches a focusable element
+5. Go/no-go gate -- only proceed if all pass
+
+This catches blocking platform issues before any UI or data layer investment.
+
+### 6. Focus Management
+
+Focus management is the defining TV UX challenge.
+
+**Constrain D-pad navigation within rails:**
+
+```tsx
+import { TVFocusGuideView } from 'react-native';
+
+<TVFocusGuideView>
+  <FlatList horizontal data={items} renderItem={...} />
+</TVFocusGuideView>
+```
+
+**Per-session focus memory (in-memory only):**
+
+```typescript
+const focusMemory = new Map<string, number>() // railId -> itemIndex
+```
+
+**Every interactive element needs a visible focus ring** -- the default highlight is insufficient at 10-foot viewing distance.
+
+**Known issue:** Focus lost on back-navigation (react-native-tvos issue #852). Workaround: restore focus via `hasTVPreferredFocus` in a `useEffect` on screen focus.
+
+## Why This Matters
+
+- **Prevents copy-and-drift**: Sharing normalizer/queries via workspace paths means CMS changes propagate automatically
+- **Prevents silent content gaps**: Missing structural renderers cause sections to vanish without errors -- the hardest SDUI bug class to diagnose
+- **Prevents wasted effort**: Day-1 spike surfaces platform blockers in hours, not weeks
+- **Focus bugs are invisible in desktop testing**: Must test on TV Simulator with simulated remote
+
+## When to Apply
+
+- Adding any new platform (TV, kiosk, car) to a monorepo with an existing SDUI pipeline
+- Expo SDK 54+ with react-native-tvos 0.81-stable
+- Porting an SDUI dispatcher to a 10-foot or non-touch UI
+- Designing a TV home screen against a CMS modeled for single-Experience views
+
+## Examples
+
+**Correct monorepo structure:**
+
+```
+apps/mobile-v2/   # untouched
+apps/tv/          # new app -- shares logic, rewrites renderers
+  app/
+    _layout.tsx
+    index.tsx                 # home: hero + experiences rail
+    experience/[slug].tsx     # detail: vertical section feed
+  src/
+    components/sections/      # all new TV renderers
+    lib/                      # imports normalizer + queries from mobile-v2
+```
+
+**Incorrect approach -- do not add TV target to mobile app:**
+
+```jsonc
+// apps/mobile-v2/app.json -- DO NOT DO THIS
+{
+  "expo": {
+    "platforms": ["ios", "android", "tvos"],
+  },
+}
+```
+
+**Home screen composition using existing queries:**
+
+```typescript
+const { data: homepage } = useExperience("homepage")
+const { data: experiences } = useListExperiences()
+
+const heroBlock = homepage?.blocks.find((b) => b.kind === "videoHero")
+const rail = experiences.map((e) => ({
+  title: e.title,
+  image: e.ogImage,
+  slug: e.slug,
+}))
+```
+
+## Related
+
+- `docs/solutions/mobile/mobile-v2-sdui-app-scaffold-and-review-findings.md` -- baseline SDUI scaffold pattern (mobile-v2); TV diverges with react-native-tvos alias and EXPO_TV=1
+- `docs/solutions/mobile/metro-pnpm-symlink-react-duplicate-resolution.md` -- Metro/pnpm singleton resolution required for apps/tv from day one
+- `docs/solutions/build-errors/expo-doctor-sdk54-health-checks-mobile-v2-20260409.md` -- Expo SDK 54 health checks apply verbatim to TV builds
+- `docs/solutions/mobile/sdui-experience-provider-block-index-parent-child-loss.md` -- ExperienceProvider `siblingContent` propagation must be preserved in TV port
+- `docs/solutions/mobile/experience-selection-provider-library-tab-pattern-2026-04-08.md` -- `isHomepage` resolution pattern used for TV home screen hero
+- `docs/solutions/best-practices/playlist-video-player-sdui-mobile-20260409.md` -- `useVideoPlayer` stability patterns; TV adds remote control event mapping
+- `docs/solutions/platform/adding-new-apps.md` -- monorepo scaffold checklist; TV uses EAS Build instead of Railway
+- `docs/solutions/mobile/expo-router-slash-in-dynamic-route-params.md` -- `encodeURIComponent` for `experience/[slug]` route params
+- `docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md` -- full requirements document for the TV prototype
+- Roadmap: feat-072 through feat-076 -- implementation tickets


### PR DESCRIPTION
## Summary
- Add 5 roadmap tickets (feat-072 through feat-076) for a TV app prototype targeting Apple TV and Android TV
- Add brainstorm requirements doc with validated Expo TV platform approach
- Add compound engineering solution doc for reusable TV/SDUI patterns
- Update roadmap README with new ticket entries

## Context
Urim's roadmap items are blocked on upstream search/topic infrastructure. This TV app prototype uses the blocked time productively — it's a third rendering target for the existing SDUI pipeline (Strapi → GraphQL → normalizer → dispatcher → renderers) with zero backend changes.

## Tickets Created
| ID | Feature | Days | Dates |
|---|---|---|---|
| feat-072 | Expo TV Toolchain Spike (go/no-go) | 2 | Apr 10–11 |
| feat-073 | Scaffolding + GraphQL Wiring | 3 | Apr 12–14 |
| feat-074 | Home Screen (Hero + Rail) | 5 | Apr 15–19 |
| feat-075 | Experience Detail Screen | 7 | Apr 15–21 |
| feat-076 | Video Playback + Polish | 7 | Apr 22–28 |

## Test plan
- [ ] Verify roadmap dashboard renders new tickets at `localhost:3100`
- [ ] Verify feat-072–076 dependency chain is correct (072 blocks 073, 073 blocks 074+075, both block 076)
- [ ] Review requirements doc for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)