### PR TITLE
chore: update mobile QR code to mobile-v2 and add /pr command

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -8,6 +8,6 @@ Move current changes to a new branch, commit, push, and open a PR. Then wait for
 
 3. **Push** — Push the new branch to origin with `-u` to set upstream tracking.
 
-4. **Open PR** — Create a pull request targeting `main` using `gh pr create`. Include a concise title and description summarizing the changes.
+4. **Open PR** — Create a pull request targeting `main` using `gh pr create`. Before writing the title, run `gh pr list --state all --limit 20` to see recent PR naming conventions and match that format consistently. Include a concise description summarizing the changes.
 
 5. **Wait for CI** — Monitor CI status using `gh pr checks` until all checks complete. Report the final result (pass/fail) with a link to the PR.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,13 @@
+Move current changes to a new branch, commit, push, and open a PR. Then wait for CI to finish.
+
+## Steps
+
+1. **Branch** — Create a new branch from the current branch using conventional naming (`feat/`, `fix/`, `chore/`, `docs/`) based on the nature of the changes. If `$ARGUMENTS` is provided, use it to inform the branch name.
+
+2. **Stage & Commit** — Stage all relevant changed files and create a commit following conventional commits (`feat:`, `fix:`, `chore:`, `docs:`). Write a clear commit message summarizing the changes.
+
+3. **Push** — Push the new branch to origin with `-u` to set upstream tracking.
+
+4. **Open PR** — Create a pull request targeting `main` using `gh pr create`. Include a concise title and description summarizing the changes.
+
+5. **Wait for CI** — Monitor CI status using `gh pr checks` until all checks complete. Report the final result (pass/fail) with a link to the PR.

--- a/apps/roadmap/lib/experiments.ts
+++ b/apps/roadmap/lib/experiments.ts
@@ -63,7 +63,7 @@ export const EXPERIMENTS: Experiment[] = [
     team: ["urim"],
     links: [],
     preview: {
-      expoProjectId: "7759da20-79e5-4d06-bb88-0a7474617676",
+      expoProjectId: "e8e41dde-3482-4571-a499-3b82673cdb39",
       channel: "preview",
     },
     accent: "text-amber-400",


### PR DESCRIPTION
## Summary
- Switch the experiments page QR code from the legacy mobile app to mobile-v2 so stakeholders scan into the latest EAS Update preview
- Add `/ship` custom Claude Code command for branch → commit → push → PR → CI wait workflow

## Test plan
- [ ] Visit https://ds-ai.jesusfilm.org/experiments, expand the Mobile App card, and verify the QR code opens mobile-v2 in Expo Go
- [ ] Verify `/ship` appears in Claude Code slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)