### PR TITLE
[codex] Sync translated subtitles back to Mux

### DIFF
--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -1337,6 +1337,7 @@ enum ENUM_COMPONENTENRICHMENTJOBSTEP_NAME {
   chapters
   embeddings
   metadata
+  mux_upload
   transcription
   translation
 }

--- a/apps/cms/src/components/enrichment/job-step.json
+++ b/apps/cms/src/components/enrichment/job-step.json
@@ -12,7 +12,8 @@
         "translation",
         "chapters",
         "metadata",
-        "embeddings"
+        "embeddings",
+        "mux_upload"
       ],
       "required": true
     },

--- a/apps/manager/src/app/api/jobs/[id]/artifacts/[artifact]/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/artifacts/[artifact]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { authenticateRequest } from "@/lib/auth"
 import { resolveJobArtifactDescriptor } from "@/lib/job-artifacts"
+import { hasValidMuxArtifactAccessSignature } from "@/lib/mux-artifact-access"
 import { getJob } from "@/lib/state"
 import { readArtifact } from "@/services/storage"
 
@@ -8,17 +9,27 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string; artifact: string }> },
 ) {
-  const authError = await authenticateRequest(request)
-  if (authError) return authError
-
   const { id, artifact } = await params
+  const logicalKey = decodeURIComponent(artifact)
+  const url = new URL(request.url)
+  const hasMuxSignature = hasValidMuxArtifactAccessSignature({
+    jobId: id,
+    artifactKey: logicalKey,
+    expiresAt: url.searchParams.get("muxExpiresAt"),
+    signature: url.searchParams.get("muxSignature"),
+  })
+
+  if (!hasMuxSignature) {
+    const authError = await authenticateRequest(request)
+    if (authError) return authError
+  }
+
   const job = await getJob(id)
 
   if (!job) {
     return NextResponse.json({ error: "Job not found" }, { status: 404 })
   }
 
-  const logicalKey = decodeURIComponent(artifact)
   const entry = job.artifacts[logicalKey]
   if (!entry || entry.kind !== "downloadable") {
     return NextResponse.json({ error: "Artifact not found" }, { status: 404 })
@@ -44,7 +55,9 @@ export async function GET(
     headers: {
       "Content-Type": descriptor.contentType,
       "Content-Disposition": `inline; filename="${logicalKey}.${descriptor.ext}"`,
-      "Cache-Control": "private, no-store",
+      "Cache-Control": hasMuxSignature
+        ? "private, max-age=60"
+        : "private, no-store",
     },
   })
 }

--- a/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.test.ts
@@ -251,6 +251,182 @@ describe("POST /api/jobs/[id]/mux-sync/override", () => {
     expect(applySubtitleOverrideMock).not.toHaveBeenCalled()
   })
 
+  it("rejects a fresh pending override while another request is still in progress", async () => {
+    getJobMock.mockResolvedValueOnce({
+      id: "job-1",
+      muxAssetId: "mux-1",
+      muxPlaybackId: "play-1",
+      languages: ["fr"],
+      options: {},
+      status: "completed",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        muxSync: {
+          kind: "metadata",
+          data: {
+            comparisons: [
+              {
+                artifactKey: "subtitles-fr",
+                targetLanguage: "fr",
+                muxTargetType: "text_track",
+                muxTargetKey: "fr",
+                status: "override_pending",
+                explanation:
+                  "Override requested for fr subtitles. Waiting for Mux confirmation.",
+                canOverride: false,
+                updatedAt: "2026-04-10T12:00:30.000Z",
+              },
+            ],
+            updatedAt: "2026-04-10T12:00:30.000Z",
+          },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-10T12:00:45.000Z"))
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/mux-sync/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+        }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({
+      error: "Subtitle override is already in progress",
+    })
+    expect(applySubtitleOverrideMock).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it("allows retrying a stale pending override", async () => {
+    getJobMock.mockResolvedValueOnce({
+      id: "job-1",
+      muxAssetId: "mux-1",
+      muxPlaybackId: "play-1",
+      languages: ["fr"],
+      options: {},
+      status: "completed",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        muxSync: {
+          kind: "metadata",
+          data: {
+            comparisons: [
+              {
+                artifactKey: "subtitles-fr",
+                targetLanguage: "fr",
+                muxTargetType: "text_track",
+                muxTargetKey: "fr",
+                status: "override_pending",
+                explanation:
+                  "Override requested for fr subtitles. Waiting for Mux confirmation.",
+                muxTrackId: "track-fr",
+                canOverride: false,
+                updatedAt: "2026-04-10T12:00:00.000Z",
+              },
+            ],
+            updatedAt: "2026-04-10T12:00:00.000Z",
+          },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-10T12:01:05.000Z"))
+    updateJobMock.mockReset()
+    updateJobMock
+      .mockResolvedValueOnce({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {
+          muxSync: {
+            kind: "metadata",
+            data: {
+              comparisons: [
+                {
+                  artifactKey: "subtitles-fr",
+                  targetLanguage: "fr",
+                  muxTargetType: "text_track",
+                  muxTargetKey: "fr",
+                  status: "override_pending",
+                  explanation:
+                    "Resuming interrupted override for fr subtitles. Waiting for Mux confirmation.",
+                  muxTrackId: "track-fr",
+                  canOverride: false,
+                  updatedAt: "2026-04-10T12:01:05.000Z",
+                },
+              ],
+              updatedAt: "2026-04-10T12:01:05.000Z",
+            },
+          },
+        },
+        steps: [],
+        errors: [],
+      })
+      .mockResolvedValueOnce({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {},
+        steps: [],
+        errors: [],
+      })
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/mux-sync/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+        }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(applySubtitleOverrideMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousReport: expect.objectContaining({
+          comparisons: [
+            expect.objectContaining({
+              status: "override_pending",
+              muxTrackId: "track-fr",
+            }),
+          ],
+        }),
+      }),
+    )
+    vi.useRealTimers()
+  })
+
   it("does not mutate Mux if the pending override state cannot be persisted", async () => {
     updateJobMock.mockReset()
     updateJobMock.mockResolvedValueOnce(null)

--- a/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.test.ts
@@ -89,20 +89,54 @@ describe("POST /api/jobs/[id]/mux-sync/override", () => {
       ],
       updatedAt: "2026-04-10T12:30:00.000Z",
     })
-    updateJobMock.mockResolvedValue({
-      id: "job-1",
-      muxAssetId: "mux-1",
-      muxPlaybackId: "play-1",
-      languages: ["fr"],
-      options: {},
-      status: "completed",
-      retries: 0,
-      createdAt: "",
-      updatedAt: "",
-      artifacts: {},
-      steps: [],
-      errors: [],
-    })
+    updateJobMock
+      .mockResolvedValueOnce({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {
+          muxSync: {
+            kind: "metadata",
+            data: {
+              comparisons: [
+                {
+                  artifactKey: "subtitles-fr",
+                  targetLanguage: "fr",
+                  muxTargetType: "text_track",
+                  muxTargetKey: "fr",
+                  status: "override_pending",
+                  explanation:
+                    "Override requested for fr subtitles. Waiting for Mux confirmation.",
+                  canOverride: false,
+                },
+              ],
+              updatedAt: "2026-04-10T12:15:00.000Z",
+            },
+          },
+        },
+        steps: [],
+        errors: [],
+      })
+      .mockResolvedValue({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {},
+        steps: [],
+        errors: [],
+      })
   })
 
   it("applies an authorized subtitle override and persists the updated report", async () => {
@@ -124,9 +158,38 @@ describe("POST /api/jobs/[id]/mux-sync/override", () => {
         jobId: "job-1",
         artifactKey: "subtitles-fr",
         targetLanguage: "fr",
+        previousReport: expect.objectContaining({
+          comparisons: [
+            expect.objectContaining({
+              artifactKey: "subtitles-fr",
+              status: "override_pending",
+              canOverride: false,
+            }),
+          ],
+        }),
       }),
     )
-    expect(updateJobMock).toHaveBeenCalledWith(
+    expect(updateJobMock).toHaveBeenNthCalledWith(
+      1,
+      "job-1",
+      expect.objectContaining({
+        artifacts: expect.objectContaining({
+          muxSync: expect.objectContaining({
+            kind: "metadata",
+            data: expect.objectContaining({
+              comparisons: [
+                expect.objectContaining({
+                  artifactKey: "subtitles-fr",
+                  status: "override_pending",
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+    )
+    expect(updateJobMock).toHaveBeenNthCalledWith(
+      2,
       "job-1",
       expect.objectContaining({
         artifacts: expect.objectContaining({
@@ -186,5 +249,235 @@ describe("POST /api/jobs/[id]/mux-sync/override", () => {
 
     expect(response.status).toBe(409)
     expect(applySubtitleOverrideMock).not.toHaveBeenCalled()
+  })
+
+  it("does not mutate Mux if the pending override state cannot be persisted", async () => {
+    updateJobMock.mockReset()
+    updateJobMock.mockResolvedValueOnce(null)
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/mux-sync/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+        }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({
+      error: "Failed to persist subtitle override request",
+    })
+    expect(applySubtitleOverrideMock).not.toHaveBeenCalled()
+  })
+
+  it("returns a reconciliation-required state when Mux changes but final persistence fails", async () => {
+    updateJobMock.mockReset()
+    updateJobMock
+      .mockResolvedValueOnce({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {
+          muxSync: {
+            kind: "metadata",
+            data: {
+              comparisons: [
+                {
+                  artifactKey: "subtitles-fr",
+                  targetLanguage: "fr",
+                  muxTargetType: "text_track",
+                  muxTargetKey: "fr",
+                  status: "override_pending",
+                  explanation:
+                    "Override requested for fr subtitles. Waiting for Mux confirmation.",
+                  canOverride: false,
+                },
+              ],
+              updatedAt: "2026-04-10T12:15:00.000Z",
+            },
+          },
+        },
+        steps: [],
+        errors: [],
+      })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {
+          muxSync: {
+            kind: "metadata",
+            data: {
+              comparisons: [
+                {
+                  artifactKey: "subtitles-fr",
+                  targetLanguage: "fr",
+                  muxTargetType: "text_track",
+                  muxTargetKey: "fr",
+                  status: "reconciliation_required",
+                  explanation:
+                    "Mux subtitles were replaced, but the job report could not be finalized. Re-run the override or reconcile this job manually.",
+                  canOverride: true,
+                },
+              ],
+              updatedAt: "2026-04-10T12:31:00.000Z",
+            },
+          },
+        },
+        steps: [],
+        errors: [],
+      })
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/mux-sync/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+        }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({
+      error:
+        "Subtitle override applied on Mux, but the job report needs reconciliation",
+      reconciliationRequired: true,
+      job: expect.objectContaining({
+        artifacts: expect.objectContaining({
+          muxSync: expect.objectContaining({
+            data: expect.objectContaining({
+              comparisons: [
+                expect.objectContaining({
+                  status: "reconciliation_required",
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+    })
+  })
+
+  it("records a failed override state when the Mux mutation throws", async () => {
+    updateJobMock.mockReset()
+    updateJobMock
+      .mockResolvedValueOnce({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {
+          muxSync: {
+            kind: "metadata",
+            data: {
+              comparisons: [
+                {
+                  artifactKey: "subtitles-fr",
+                  targetLanguage: "fr",
+                  muxTargetType: "text_track",
+                  muxTargetKey: "fr",
+                  status: "override_pending",
+                  explanation:
+                    "Override requested for fr subtitles. Waiting for Mux confirmation.",
+                  canOverride: false,
+                },
+              ],
+              updatedAt: "2026-04-10T12:15:00.000Z",
+            },
+          },
+        },
+        steps: [],
+        errors: [],
+      })
+      .mockResolvedValueOnce({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: "completed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {
+          muxSync: {
+            kind: "metadata",
+            data: {
+              comparisons: [
+                {
+                  artifactKey: "subtitles-fr",
+                  targetLanguage: "fr",
+                  muxTargetType: "text_track",
+                  muxTargetKey: "fr",
+                  status: "failed",
+                  explanation: "Subtitle override failed: Mux fetch failed",
+                  canOverride: true,
+                },
+              ],
+              updatedAt: "2026-04-10T12:16:00.000Z",
+            },
+          },
+        },
+        steps: [],
+        errors: [],
+      })
+    applySubtitleOverrideMock.mockRejectedValueOnce(
+      new Error("Mux fetch failed"),
+    )
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/mux-sync/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+        }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({
+      error: "Mux fetch failed",
+      job: expect.objectContaining({
+        artifacts: expect.objectContaining({
+          muxSync: expect.objectContaining({
+            data: expect.objectContaining({
+              comparisons: [
+                expect.objectContaining({
+                  status: "failed",
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+    })
   })
 })

--- a/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  applySubtitleOverrideMock,
+  authenticateRequestMock,
+  getJobMock,
+  updateJobMock,
+} = vi.hoisted(() => ({
+  applySubtitleOverrideMock: vi.fn(),
+  authenticateRequestMock: vi.fn(),
+  getJobMock: vi.fn(),
+  updateJobMock: vi.fn(),
+}))
+
+vi.mock("@/lib/auth", () => ({
+  authenticateRequest: authenticateRequestMock,
+}))
+
+vi.mock("@/lib/state", () => ({
+  getJob: getJobMock,
+  updateJob: updateJobMock,
+}))
+
+vi.mock("@/services/mux-sync", () => ({
+  applySubtitleOverride: applySubtitleOverrideMock,
+}))
+
+import { POST } from "@/app/api/jobs/[id]/mux-sync/override/route"
+
+describe("POST /api/jobs/[id]/mux-sync/override", () => {
+  beforeEach(() => {
+    authenticateRequestMock.mockReset()
+    getJobMock.mockReset()
+    updateJobMock.mockReset()
+    applySubtitleOverrideMock.mockReset()
+
+    authenticateRequestMock.mockResolvedValue(null)
+    getJobMock.mockResolvedValue({
+      id: "job-1",
+      muxAssetId: "mux-1",
+      muxPlaybackId: "play-1",
+      languages: ["fr"],
+      options: {},
+      status: "completed",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        muxSync: {
+          kind: "metadata",
+          data: {
+            comparisons: [
+              {
+                artifactKey: "subtitles-fr",
+                targetLanguage: "fr",
+                muxTargetType: "text_track",
+                muxTargetKey: "fr",
+                status: "skipped_existing_mux_data",
+                explanation: "Mux already has fr subtitles",
+                muxTrackId: "track-fr",
+                canOverride: true,
+              },
+            ],
+            updatedAt: "2026-04-10T12:00:00.000Z",
+          },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+    applySubtitleOverrideMock.mockResolvedValue({
+      comparisons: [
+        {
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+          muxTargetType: "text_track",
+          muxTargetKey: "fr",
+          status: "override_applied",
+          explanation: "Replaced existing fr subtitles on Mux",
+        },
+      ],
+      overrideHistory: [
+        {
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+          at: "2026-04-10T12:30:00.000Z",
+          action: "override_subtitle_track",
+        },
+      ],
+      updatedAt: "2026-04-10T12:30:00.000Z",
+    })
+    updateJobMock.mockResolvedValue({
+      id: "job-1",
+      muxAssetId: "mux-1",
+      muxPlaybackId: "play-1",
+      languages: ["fr"],
+      options: {},
+      status: "completed",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {},
+      steps: [],
+      errors: [],
+    })
+  })
+
+  it("applies an authorized subtitle override and persists the updated report", async () => {
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/mux-sync/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+        }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(applySubtitleOverrideMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        artifactKey: "subtitles-fr",
+        targetLanguage: "fr",
+      }),
+    )
+    expect(updateJobMock).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({
+        artifacts: expect.objectContaining({
+          muxSync: expect.objectContaining({
+            kind: "metadata",
+          }),
+        }),
+      }),
+    )
+  })
+
+  it("rejects non-overrideable subtitle targets", async () => {
+    getJobMock.mockResolvedValueOnce({
+      id: "job-1",
+      muxAssetId: "mux-1",
+      muxPlaybackId: "play-1",
+      languages: ["fr"],
+      options: {},
+      status: "completed",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        muxSync: {
+          kind: "metadata",
+          data: {
+            comparisons: [
+              {
+                artifactKey: "subtitles-fr",
+                targetLanguage: "fr",
+                muxTargetType: "text_track",
+                muxTargetKey: "fr",
+                status: "synced",
+                explanation: "Synced fr subtitles to Mux",
+                canOverride: false,
+              },
+            ],
+            updatedAt: "2026-04-10T12:00:00.000Z",
+          },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/mux-sync/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+        }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(409)
+    expect(applySubtitleOverrideMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { authenticateRequest } from "@/lib/auth"
+import { getMuxSyncReport, setMuxSyncReport } from "@/lib/mux-sync-report"
+import { getJob, updateJob } from "@/lib/state"
+import { applySubtitleOverride } from "@/services/mux-sync"
+
+const requestBodySchema = z.object({
+  artifactKey: z.string().min(1).startsWith("subtitles-"),
+  targetLanguage: z.string().min(1),
+})
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authError = await authenticateRequest(request)
+  if (authError) return authError
+
+  const { id } = await params
+  const job = await getJob(id)
+
+  if (!job) {
+    return NextResponse.json({ error: "Job not found" }, { status: 404 })
+  }
+
+  const parsedBody = requestBodySchema.safeParse(await request.json())
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: "Invalid override request" },
+      { status: 400 },
+    )
+  }
+
+  const previousReport = getMuxSyncReport(job.artifacts)
+  const existingComparison = previousReport?.comparisons.find(
+    (comparison) =>
+      comparison.artifactKey === parsedBody.data.artifactKey &&
+      comparison.targetLanguage === parsedBody.data.targetLanguage,
+  )
+
+  if (!existingComparison || existingComparison.canOverride !== true) {
+    return NextResponse.json(
+      { error: "Subtitle track is not overrideable" },
+      { status: 409 },
+    )
+  }
+
+  try {
+    const nextReport = await applySubtitleOverride({
+      jobId: job.id,
+      assetId: job.muxAssetId,
+      muxAssetId: job.muxAssetId,
+      artifactKey: parsedBody.data.artifactKey,
+      targetLanguage: parsedBody.data.targetLanguage,
+      previousReport,
+    })
+
+    const updatedJob = await updateJob(job.id, {
+      artifacts: setMuxSyncReport(job.artifacts, nextReport),
+    })
+
+    if (!updatedJob) {
+      return NextResponse.json(
+        { error: "Failed to persist subtitle override" },
+        { status: 500 },
+      )
+    }
+
+    return NextResponse.json({
+      job: updatedJob,
+      report: nextReport,
+    })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to override subtitle track",
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.ts
@@ -4,11 +4,57 @@ import { authenticateRequest } from "@/lib/auth"
 import { getMuxSyncReport, setMuxSyncReport } from "@/lib/mux-sync-report"
 import { getJob, updateJob } from "@/lib/state"
 import { applySubtitleOverride } from "@/services/mux-sync"
+import type { MuxSyncComparison, MuxSyncReport } from "@/types/job"
 
 const requestBodySchema = z.object({
   artifactKey: z.string().min(1).startsWith("subtitles-"),
   targetLanguage: z.string().min(1),
 })
+
+function sortComparisons(
+  left: MuxSyncComparison,
+  right: MuxSyncComparison,
+): number {
+  if (left.targetLanguage === right.targetLanguage) {
+    return left.artifactKey.localeCompare(right.artifactKey)
+  }
+
+  return left.targetLanguage.localeCompare(right.targetLanguage)
+}
+
+function buildOverrideComparisonReport(
+  report: MuxSyncReport,
+  comparison: MuxSyncComparison,
+  input: {
+    status: MuxSyncComparison["status"]
+    explanation: string
+    canOverride: boolean
+  },
+): MuxSyncReport {
+  const updatedAt = new Date().toISOString()
+  const nextComparison: MuxSyncComparison = {
+    ...comparison,
+    status: input.status,
+    explanation: input.explanation,
+    canOverride: input.canOverride,
+    updatedAt,
+  }
+
+  return {
+    comparisons: [
+      ...report.comparisons.filter(
+        (candidate) =>
+          !(
+            candidate.artifactKey === comparison.artifactKey &&
+            candidate.targetLanguage === comparison.targetLanguage
+          ),
+      ),
+      nextComparison,
+    ].sort(sortComparisons),
+    overrideHistory: report.overrideHistory ?? [],
+    updatedAt,
+  }
+}
 
 export async function POST(
   request: Request,
@@ -39,30 +85,82 @@ export async function POST(
       comparison.targetLanguage === parsedBody.data.targetLanguage,
   )
 
-  if (!existingComparison || existingComparison.canOverride !== true) {
+  if (
+    !previousReport ||
+    !existingComparison ||
+    existingComparison.canOverride !== true
+  ) {
     return NextResponse.json(
       { error: "Subtitle track is not overrideable" },
       { status: 409 },
     )
   }
 
+  const currentReport = previousReport
+
   try {
+    const pendingReport = buildOverrideComparisonReport(
+      currentReport,
+      existingComparison,
+      {
+        status: "override_pending",
+        explanation: `Override requested for ${parsedBody.data.targetLanguage} subtitles. Waiting for Mux confirmation.`,
+        canOverride: false,
+      },
+    )
+    const pendingJob = await updateJob(job.id, {
+      artifacts: setMuxSyncReport(job.artifacts, pendingReport),
+    })
+
+    if (!pendingJob) {
+      return NextResponse.json(
+        { error: "Failed to persist subtitle override request" },
+        { status: 500 },
+      )
+    }
+
     const nextReport = await applySubtitleOverride({
       jobId: job.id,
       assetId: job.muxAssetId,
       muxAssetId: job.muxAssetId,
       artifactKey: parsedBody.data.artifactKey,
       targetLanguage: parsedBody.data.targetLanguage,
-      previousReport,
+      previousReport: pendingReport,
     })
 
     const updatedJob = await updateJob(job.id, {
-      artifacts: setMuxSyncReport(job.artifacts, nextReport),
+      artifacts: setMuxSyncReport(pendingJob.artifacts, nextReport),
     })
 
     if (!updatedJob) {
+      const updatedComparison =
+        nextReport.comparisons.find(
+          (comparison) =>
+            comparison.artifactKey === parsedBody.data.artifactKey &&
+            comparison.targetLanguage === parsedBody.data.targetLanguage,
+        ) ?? existingComparison
+      const reconciliationReport = buildOverrideComparisonReport(
+        nextReport,
+        updatedComparison,
+        {
+          status: "reconciliation_required",
+          explanation:
+            "Mux subtitles were replaced, but the job report could not be finalized. Re-run the override or reconcile this job manually.",
+          canOverride: true,
+        },
+      )
+      const reconciliationJob = await updateJob(job.id, {
+        artifacts: setMuxSyncReport(pendingJob.artifacts, reconciliationReport),
+      })
+
       return NextResponse.json(
-        { error: "Failed to persist subtitle override" },
+        {
+          error:
+            "Subtitle override applied on Mux, but the job report needs reconciliation",
+          job: reconciliationJob ?? pendingJob,
+          report: reconciliationJob ? reconciliationReport : pendingReport,
+          reconciliationRequired: true,
+        },
         { status: 500 },
       )
     }
@@ -72,12 +170,28 @@ export async function POST(
       report: nextReport,
     })
   } catch (error) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : "Failed to override subtitle track"
+    const failedReport = buildOverrideComparisonReport(
+      currentReport,
+      existingComparison,
+      {
+        status: "failed",
+        explanation: `Subtitle override failed: ${errorMessage}`,
+        canOverride: true,
+      },
+    )
+    const failedJob = await updateJob(job.id, {
+      artifacts: setMuxSyncReport(job.artifacts, failedReport),
+    })
+
     return NextResponse.json(
       {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to override subtitle track",
+        error: errorMessage,
+        job: failedJob ?? undefined,
+        report: failedJob ? failedReport : undefined,
       },
       { status: 500 },
     )

--- a/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/mux-sync/override/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { authenticateRequest } from "@/lib/auth"
+import {
+  canRetryMuxSyncOverride,
+  isStaleOverridePending,
+} from "@/lib/mux-sync-override"
 import { getMuxSyncReport, setMuxSyncReport } from "@/lib/mux-sync-report"
 import { getJob, updateJob } from "@/lib/state"
 import { applySubtitleOverride } from "@/services/mux-sync"
@@ -84,12 +88,26 @@ export async function POST(
       comparison.artifactKey === parsedBody.data.artifactKey &&
       comparison.targetLanguage === parsedBody.data.targetLanguage,
   )
+  const now = Date.now()
+
+  if (!previousReport || !existingComparison) {
+    return NextResponse.json(
+      { error: "Subtitle track is not overrideable" },
+      { status: 409 },
+    )
+  }
 
   if (
-    !previousReport ||
-    !existingComparison ||
-    existingComparison.canOverride !== true
+    existingComparison.status === "override_pending" &&
+    !isStaleOverridePending(existingComparison, now)
   ) {
+    return NextResponse.json(
+      { error: "Subtitle override is already in progress" },
+      { status: 409 },
+    )
+  }
+
+  if (!canRetryMuxSyncOverride(existingComparison, now)) {
     return NextResponse.json(
       { error: "Subtitle track is not overrideable" },
       { status: 409 },
@@ -97,19 +115,25 @@ export async function POST(
   }
 
   const currentReport = previousReport
+  let persistedArtifacts = job.artifacts
+  let workingReport = currentReport
+  let workingComparison = existingComparison
 
   try {
     const pendingReport = buildOverrideComparisonReport(
-      currentReport,
-      existingComparison,
+      workingReport,
+      workingComparison,
       {
         status: "override_pending",
-        explanation: `Override requested for ${parsedBody.data.targetLanguage} subtitles. Waiting for Mux confirmation.`,
+        explanation:
+          existingComparison.status === "override_pending"
+            ? `Resuming interrupted override for ${parsedBody.data.targetLanguage} subtitles. Waiting for Mux confirmation.`
+            : `Override requested for ${parsedBody.data.targetLanguage} subtitles. Waiting for Mux confirmation.`,
         canOverride: false,
       },
     )
     const pendingJob = await updateJob(job.id, {
-      artifacts: setMuxSyncReport(job.artifacts, pendingReport),
+      artifacts: setMuxSyncReport(persistedArtifacts, pendingReport),
     })
 
     if (!pendingJob) {
@@ -118,6 +142,14 @@ export async function POST(
         { status: 500 },
       )
     }
+    persistedArtifacts = pendingJob.artifacts
+    workingReport = pendingReport
+    workingComparison =
+      pendingReport.comparisons.find(
+        (comparison) =>
+          comparison.artifactKey === parsedBody.data.artifactKey &&
+          comparison.targetLanguage === parsedBody.data.targetLanguage,
+      ) ?? workingComparison
 
     const nextReport = await applySubtitleOverride({
       jobId: job.id,
@@ -129,7 +161,7 @@ export async function POST(
     })
 
     const updatedJob = await updateJob(job.id, {
-      artifacts: setMuxSyncReport(pendingJob.artifacts, nextReport),
+      artifacts: setMuxSyncReport(persistedArtifacts, nextReport),
     })
 
     if (!updatedJob) {
@@ -150,7 +182,7 @@ export async function POST(
         },
       )
       const reconciliationJob = await updateJob(job.id, {
-        artifacts: setMuxSyncReport(pendingJob.artifacts, reconciliationReport),
+        artifacts: setMuxSyncReport(persistedArtifacts, reconciliationReport),
       })
 
       return NextResponse.json(
@@ -175,8 +207,8 @@ export async function POST(
         ? error.message
         : "Failed to override subtitle track"
     const failedReport = buildOverrideComparisonReport(
-      currentReport,
-      existingComparison,
+      workingReport,
+      workingComparison,
       {
         status: "failed",
         explanation: `Subtitle override failed: ${errorMessage}`,
@@ -184,7 +216,7 @@ export async function POST(
       },
     )
     const failedJob = await updateJob(job.id, {
-      artifacts: setMuxSyncReport(job.artifacts, failedReport),
+      artifacts: setMuxSyncReport(persistedArtifacts, failedReport),
     })
 
     return NextResponse.json(

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -4102,6 +4102,65 @@ body.jobs-standalone .jobs-step-job-id {
   margin-top: 0.18rem;
 }
 
+.jobs-mux-sync-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.65rem;
+}
+
+.jobs-mux-sync-card {
+  border: 1px solid rgba(95, 87, 76, 0.18);
+  border-radius: 12px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.jobs-mux-sync-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.jobs-mux-sync-explanation {
+  margin: 0.45rem 0 0;
+  color: rgba(50, 40, 32, 0.82);
+}
+
+.jobs-mux-sync-previews {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.65rem;
+}
+
+.jobs-mux-sync-preview {
+  margin: 0.25rem 0 0;
+  white-space: pre-wrap;
+  font: inherit;
+  color: rgba(50, 40, 32, 0.82);
+  background: rgba(122, 114, 103, 0.08);
+  border-radius: 10px;
+  padding: 0.65rem;
+}
+
+.jobs-mux-sync-override {
+  margin-top: 0.75rem;
+  border: 1px solid rgba(79, 72, 62, 0.22);
+  border-radius: 999px;
+  background: #ffffff;
+  color: #4f483e;
+  padding: 0.45rem 0.85rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.jobs-mux-sync-override:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
 .jobs-step-retry-pill {
   display: inline-flex;
   align-items: center;

--- a/apps/manager/src/features/jobs/live-job-steps-table.tsx
+++ b/apps/manager/src/features/jobs/live-job-steps-table.tsx
@@ -349,14 +349,20 @@ export function LiveJobStepsTable({
           error?: string
           job?: JobRecord
         }
-        if (!response.ok || !payload.job) {
+        if (payload.job) {
+          setJob(payload.job)
+          onJobUpdate?.(payload.job)
+          latestStatusRef.current = payload.job.status
+        }
+
+        if (!response.ok) {
           setOverrideError(payload.error ?? "Failed to override subtitle track")
           return
         }
 
-        setJob(payload.job)
-        onJobUpdate?.(payload.job)
-        latestStatusRef.current = payload.job.status
+        if (!payload.job) {
+          setOverrideError("Failed to override subtitle track")
+        }
       } catch {
         setOverrideError("Failed to override subtitle track")
       } finally {

--- a/apps/manager/src/features/jobs/live-job-steps-table.tsx
+++ b/apps/manager/src/features/jobs/live-job-steps-table.tsx
@@ -14,6 +14,7 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { formatStepName } from "@/lib/workflow-steps"
+import { canRetryMuxSyncOverride } from "@/lib/mux-sync-override"
 import type {
   JobRecord,
   MuxSyncComparison,
@@ -559,54 +560,62 @@ export function LiveJobStepsTable({
                             <p className="jobs-error-text">{overrideError}</p>
                           ) : null}
                           <div className="jobs-mux-sync-list">
-                            {muxSyncStepComparisons.map((comparison) => (
-                              <article
-                                key={`${step.name}-${comparison.artifactKey}`}
-                                className="jobs-mux-sync-card"
-                              >
-                                <div className="jobs-mux-sync-card-header">
-                                  <strong>{comparison.targetLanguage}</strong>
-                                  <span className="jobs-step-retry-pill">
-                                    {comparison.status}
-                                  </span>
-                                </div>
-                                <p className="jobs-mux-sync-explanation">
-                                  {comparison.explanation}
-                                </p>
-                                <div className="jobs-mux-sync-previews">
-                                  <div>
-                                    <div className="small">Generated</div>
-                                    <pre className="jobs-mux-sync-preview">
-                                      {comparison.generatedPreview ?? "–"}
-                                    </pre>
+                            {muxSyncStepComparisons.map((comparison) => {
+                              const canOverride =
+                                canRetryMuxSyncOverride(comparison)
+
+                              return (
+                                <article
+                                  key={`${step.name}-${comparison.artifactKey}`}
+                                  className="jobs-mux-sync-card"
+                                >
+                                  <div className="jobs-mux-sync-card-header">
+                                    <strong>{comparison.targetLanguage}</strong>
+                                    <span className="jobs-step-retry-pill">
+                                      {comparison.status}
+                                    </span>
                                   </div>
-                                  <div>
-                                    <div className="small">Mux</div>
-                                    <pre className="jobs-mux-sync-preview">
-                                      {comparison.muxPreview ?? "–"}
-                                    </pre>
+                                  <p className="jobs-mux-sync-explanation">
+                                    {comparison.explanation}
+                                  </p>
+                                  <div className="jobs-mux-sync-previews">
+                                    <div>
+                                      <div className="small">Generated</div>
+                                      <pre className="jobs-mux-sync-preview">
+                                        {comparison.generatedPreview ?? "–"}
+                                      </pre>
+                                    </div>
+                                    <div>
+                                      <div className="small">Mux</div>
+                                      <pre className="jobs-mux-sync-preview">
+                                        {comparison.muxPreview ?? "–"}
+                                      </pre>
+                                    </div>
                                   </div>
-                                </div>
-                                {comparison.canOverride ? (
-                                  <button
-                                    type="button"
-                                    className="jobs-mux-sync-override"
-                                    onClick={() =>
-                                      void handleSubtitleOverride(comparison)
-                                    }
-                                    disabled={
-                                      overrideArtifactKey ===
+                                  {canOverride ? (
+                                    <button
+                                      type="button"
+                                      className="jobs-mux-sync-override"
+                                      onClick={() =>
+                                        void handleSubtitleOverride(comparison)
+                                      }
+                                      disabled={
+                                        overrideArtifactKey ===
+                                        comparison.artifactKey
+                                      }
+                                    >
+                                      {overrideArtifactKey ===
                                       comparison.artifactKey
-                                    }
-                                  >
-                                    {overrideArtifactKey ===
-                                    comparison.artifactKey
-                                      ? "Overriding…"
-                                      : "Override Mux data"}
-                                  </button>
-                                ) : null}
-                              </article>
-                            ))}
+                                        ? "Overriding…"
+                                        : comparison.status ===
+                                            "override_pending"
+                                          ? "Resume override"
+                                          : "Override Mux data"}
+                                    </button>
+                                  ) : null}
+                                </article>
+                              )
+                            })}
                           </div>
                         </td>
                       </tr>

--- a/apps/manager/src/features/jobs/live-job-steps-table.tsx
+++ b/apps/manager/src/features/jobs/live-job-steps-table.tsx
@@ -14,13 +14,19 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { formatStepName } from "@/lib/workflow-steps"
-import type { JobRecord, StepStatus, WorkflowStepName } from "@/types/job"
+import type {
+  JobRecord,
+  MuxSyncComparison,
+  StepStatus,
+  WorkflowStepName,
+} from "@/types/job"
 import {
   FOREGROUND_POLL_DELAY_MS,
   getNextPollDelayMs,
   shouldApplyPollResult,
 } from "./live-jobs-polling"
 import { getArtifactsForStep } from "@/lib/job-artifacts"
+import { getPresentedMuxSyncComparisons } from "@/features/jobs/mux-sync-presenter"
 
 type RunPollOptions = {
   scheduleNext: boolean
@@ -49,7 +55,7 @@ const STEP_DESCRIPTION_BY_NAME: Record<WorkflowStepName, string> = {
   translation: "Translates transcript content into target languages.",
   voiceover: "Synthesizes voiceover audio from generated text.",
   artifact_upload: "Uploads generated artifacts and writes the manifest.",
-  mux_upload: "Publishes output assets to Mux for playback.",
+  mux_upload: "Publishes translated subtitle tracks to Mux when needed.",
   cms_notify: "Notifies downstream CMS integrations of completion.",
 }
 
@@ -208,6 +214,10 @@ export function LiveJobStepsTable({
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [isPollingError, setIsPollingError] = useState(false)
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null)
+  const [overrideArtifactKey, setOverrideArtifactKey] = useState<string | null>(
+    null,
+  )
+  const [overrideError, setOverrideError] = useState<string | null>(null)
 
   const requestSeqRef = useRef(0)
   const latestStatusRef = useRef<JobRecord["status"]>(initialJob.status)
@@ -315,6 +325,47 @@ export function LiveJobStepsTable({
     void runPoll({ scheduleNext: true })
   }, [])
 
+  const handleSubtitleOverride = useCallback(
+    async (comparison: MuxSyncComparison) => {
+      setOverrideArtifactKey(comparison.artifactKey)
+      setOverrideError(null)
+
+      try {
+        const response = await fetch(
+          `/api/jobs/${encodeURIComponent(job.id)}/mux-sync/override`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              artifactKey: comparison.artifactKey,
+              targetLanguage: comparison.targetLanguage,
+            }),
+          },
+        )
+
+        const payload = (await response.json()) as {
+          error?: string
+          job?: JobRecord
+        }
+        if (!response.ok || !payload.job) {
+          setOverrideError(payload.error ?? "Failed to override subtitle track")
+          return
+        }
+
+        setJob(payload.job)
+        onJobUpdate?.(payload.job)
+        latestStatusRef.current = payload.job.status
+      } catch {
+        setOverrideError("Failed to override subtitle track")
+      } finally {
+        setOverrideArtifactKey(null)
+      }
+    },
+    [job.id, onJobUpdate],
+  )
+
   const liveStatus = useMemo(() => {
     if (isRefreshing) {
       return "Updating job..."
@@ -330,6 +381,11 @@ export function LiveJobStepsTable({
     }
     return `Auto-updating every ${Math.floor(FOREGROUND_POLL_DELAY_MS / 1000)}s`
   }, [isPollingError, isRefreshing, job.status, lastUpdatedAt])
+
+  const muxSyncComparisons = useMemo(
+    () => getPresentedMuxSyncComparisons(job),
+    [job],
+  )
 
   return (
     <section className="collection-card jobs-card">
@@ -371,6 +427,8 @@ export function LiveJobStepsTable({
           </thead>
           <tbody>
             {job.steps.map((step) => {
+              const muxSyncStepComparisons =
+                step.name === "mux_upload" ? muxSyncComparisons : []
               const stepArtifacts = getArtifactsForStep(
                 step.name,
                 job.id,
@@ -484,6 +542,69 @@ export function LiveJobStepsTable({
                       </td>
                     </tr>
                   )}
+                  {step.name === "mux_upload" &&
+                    (muxSyncStepComparisons.length > 0 || overrideError) && (
+                      <tr className="jobs-step-detail-row">
+                        <td colSpan={4}>
+                          <p className="jobs-step-detail-summary">
+                            Subtitle sync results
+                          </p>
+                          {overrideError ? (
+                            <p className="jobs-error-text">{overrideError}</p>
+                          ) : null}
+                          <div className="jobs-mux-sync-list">
+                            {muxSyncStepComparisons.map((comparison) => (
+                              <article
+                                key={`${step.name}-${comparison.artifactKey}`}
+                                className="jobs-mux-sync-card"
+                              >
+                                <div className="jobs-mux-sync-card-header">
+                                  <strong>{comparison.targetLanguage}</strong>
+                                  <span className="jobs-step-retry-pill">
+                                    {comparison.status}
+                                  </span>
+                                </div>
+                                <p className="jobs-mux-sync-explanation">
+                                  {comparison.explanation}
+                                </p>
+                                <div className="jobs-mux-sync-previews">
+                                  <div>
+                                    <div className="small">Generated</div>
+                                    <pre className="jobs-mux-sync-preview">
+                                      {comparison.generatedPreview ?? "–"}
+                                    </pre>
+                                  </div>
+                                  <div>
+                                    <div className="small">Mux</div>
+                                    <pre className="jobs-mux-sync-preview">
+                                      {comparison.muxPreview ?? "–"}
+                                    </pre>
+                                  </div>
+                                </div>
+                                {comparison.canOverride ? (
+                                  <button
+                                    type="button"
+                                    className="jobs-mux-sync-override"
+                                    onClick={() =>
+                                      void handleSubtitleOverride(comparison)
+                                    }
+                                    disabled={
+                                      overrideArtifactKey ===
+                                      comparison.artifactKey
+                                    }
+                                  >
+                                    {overrideArtifactKey ===
+                                    comparison.artifactKey
+                                      ? "Overriding…"
+                                      : "Override Mux data"}
+                                  </button>
+                                ) : null}
+                              </article>
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
                 </React.Fragment>
               )
             })}

--- a/apps/manager/src/features/jobs/mux-sync-presenter.test.ts
+++ b/apps/manager/src/features/jobs/mux-sync-presenter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import {
+  getPresentedMuxSyncComparison,
+  getPresentedMuxSyncComparisons,
+} from "@/features/jobs/mux-sync-presenter"
+import type { JobRecord } from "@/types/job"
+
+function buildJobRecord(overrides: Partial<JobRecord> = {}): JobRecord {
+  return {
+    id: "job-1",
+    muxAssetId: "mux-1",
+    muxPlaybackId: "play-1",
+    languages: [],
+    options: {},
+    status: "completed",
+    retries: 0,
+    createdAt: "2026-04-10T00:00:00.000Z",
+    updatedAt: "2026-04-10T00:00:00.000Z",
+    artifacts: {},
+    steps: [],
+    errors: [],
+    ...overrides,
+  }
+}
+
+describe("mux-sync-presenter", () => {
+  it("sorts mux sync comparisons by language", () => {
+    const job = buildJobRecord({
+      artifacts: {
+        muxSync: {
+          kind: "metadata",
+          data: {
+            comparisons: [
+              {
+                artifactKey: "subtitles-fr",
+                targetLanguage: "fr",
+                muxTargetType: "text_track",
+                muxTargetKey: "fr",
+                status: "synced",
+                explanation: "Synced fr subtitles to Mux",
+              },
+              {
+                artifactKey: "subtitles-en",
+                targetLanguage: "en",
+                muxTargetType: "text_track",
+                muxTargetKey: "en",
+                status: "skipped_existing_mux_data",
+                explanation: "Mux already has en subtitles",
+              },
+            ],
+            updatedAt: "2026-04-10T12:00:00.000Z",
+          },
+        },
+      },
+    })
+
+    expect(
+      getPresentedMuxSyncComparisons(job).map((entry) => entry.artifactKey),
+    ).toEqual(["subtitles-en", "subtitles-fr"])
+  })
+
+  it("returns a single comparison by artifact key", () => {
+    const job = buildJobRecord({
+      artifacts: {
+        muxSync: {
+          kind: "metadata",
+          data: {
+            comparisons: [
+              {
+                artifactKey: "subtitles-es",
+                targetLanguage: "es",
+                muxTargetType: "text_track",
+                muxTargetKey: "es",
+                status: "override_applied",
+                explanation: "Replaced existing es subtitles on Mux",
+              },
+            ],
+            updatedAt: "2026-04-10T12:00:00.000Z",
+          },
+        },
+      },
+    })
+
+    expect(getPresentedMuxSyncComparison(job, "subtitles-es")).toMatchObject({
+      targetLanguage: "es",
+      status: "override_applied",
+    })
+  })
+})

--- a/apps/manager/src/features/jobs/mux-sync-presenter.ts
+++ b/apps/manager/src/features/jobs/mux-sync-presenter.ts
@@ -1,0 +1,27 @@
+import { getMuxSyncReport } from "@/lib/mux-sync-report"
+import type { JobRecord, MuxSyncComparison } from "@/types/job"
+
+export function getPresentedMuxSyncComparisons(
+  job: JobRecord,
+): MuxSyncComparison[] {
+  const report = getMuxSyncReport(job.artifacts)
+  if (!report) {
+    return []
+  }
+
+  return [...report.comparisons].sort((left, right) => {
+    if (left.targetLanguage === right.targetLanguage) {
+      return left.artifactKey.localeCompare(right.artifactKey)
+    }
+    return left.targetLanguage.localeCompare(right.targetLanguage)
+  })
+}
+
+export function getPresentedMuxSyncComparison(
+  job: JobRecord,
+  artifactKey: string,
+): MuxSyncComparison | undefined {
+  return getPresentedMuxSyncComparisons(job).find(
+    (comparison) => comparison.artifactKey === artifactKey,
+  )
+}

--- a/apps/manager/src/lib/mux-artifact-access.ts
+++ b/apps/manager/src/lib/mux-artifact-access.ts
@@ -1,0 +1,105 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+import { env } from "@/config/env"
+
+const MUX_ARTIFACT_TOKEN_TTL_MS = 15 * 60 * 1000
+
+function getArtifactAccessSecret(): string {
+  return env.MANAGER_API_KEY ?? env.STRAPI_API_TOKEN
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}
+
+function buildSignaturePayload(
+  jobId: string,
+  artifactKey: string,
+  expiresAt: string,
+): string {
+  return `${jobId}:${artifactKey}:${expiresAt}`
+}
+
+function signPayload(payload: string): string {
+  return createHmac("sha256", getArtifactAccessSecret())
+    .update(payload)
+    .digest("hex")
+}
+
+export function resolveManagerPublicBaseUrl(): string {
+  const explicitBaseUrl =
+    process.env.MANAGER_PUBLIC_URL ??
+    process.env.NEXT_PUBLIC_MANAGER_URL ??
+    process.env.APP_URL
+
+  if (explicitBaseUrl) {
+    return trimTrailingSlash(explicitBaseUrl)
+  }
+
+  if (process.env.RAILWAY_PUBLIC_DOMAIN) {
+    return `https://${trimTrailingSlash(process.env.RAILWAY_PUBLIC_DOMAIN)}`
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${trimTrailingSlash(process.env.VERCEL_URL)}`
+  }
+
+  throw new Error(
+    "Manager public base URL is not configured for Mux subtitle sync",
+  )
+}
+
+export function buildMuxArtifactAccessUrl(input: {
+  jobId: string
+  artifactKey: string
+  now?: number
+  baseUrl?: string
+}): string {
+  const expiresAt = String(
+    (input.now ?? Date.now()) + MUX_ARTIFACT_TOKEN_TTL_MS,
+  )
+  const payload = buildSignaturePayload(
+    input.jobId,
+    input.artifactKey,
+    expiresAt,
+  )
+  const signature = signPayload(payload)
+  const baseUrl = input.baseUrl ?? resolveManagerPublicBaseUrl()
+
+  const url = new URL(
+    `${baseUrl}/api/jobs/${encodeURIComponent(input.jobId)}/artifacts/${encodeURIComponent(input.artifactKey)}`,
+  )
+  url.searchParams.set("muxExpiresAt", expiresAt)
+  url.searchParams.set("muxSignature", signature)
+  return url.toString()
+}
+
+export function hasValidMuxArtifactAccessSignature(input: {
+  jobId: string
+  artifactKey: string
+  expiresAt: string | null
+  signature: string | null
+  now?: number
+}): boolean {
+  if (!input.expiresAt || !input.signature) {
+    return false
+  }
+
+  const expiresAtMs = Number(input.expiresAt)
+  if (
+    !Number.isFinite(expiresAtMs) ||
+    expiresAtMs < (input.now ?? Date.now())
+  ) {
+    return false
+  }
+
+  const expected = signPayload(
+    buildSignaturePayload(input.jobId, input.artifactKey, input.expiresAt),
+  )
+
+  const providedBuffer = Buffer.from(input.signature)
+  const expectedBuffer = Buffer.from(expected)
+  return (
+    providedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(providedBuffer, expectedBuffer)
+  )
+}

--- a/apps/manager/src/lib/mux-sync-override.test.ts
+++ b/apps/manager/src/lib/mux-sync-override.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import {
+  canRetryMuxSyncOverride,
+  isStaleOverridePending,
+  MUX_OVERRIDE_RESUME_AFTER_MS,
+} from "@/lib/mux-sync-override"
+import type { MuxSyncComparison } from "@/types/job"
+
+function buildComparison(
+  overrides: Partial<MuxSyncComparison> = {},
+): MuxSyncComparison {
+  return {
+    artifactKey: "subtitles-fr",
+    targetLanguage: "fr",
+    muxTargetType: "text_track",
+    muxTargetKey: "fr",
+    status: "skipped_existing_mux_data",
+    explanation: "Mux already has fr subtitles",
+    canOverride: true,
+    updatedAt: "2026-04-10T12:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("mux-sync-override helpers", () => {
+  it("treats fresh override_pending entries as non-retryable", () => {
+    const comparison = buildComparison({
+      status: "override_pending",
+      canOverride: false,
+    })
+
+    expect(
+      isStaleOverridePending(
+        comparison,
+        Date.parse("2026-04-10T12:00:00.000Z") +
+          MUX_OVERRIDE_RESUME_AFTER_MS -
+          1,
+      ),
+    ).toBe(false)
+    expect(
+      canRetryMuxSyncOverride(
+        comparison,
+        Date.parse("2026-04-10T12:00:00.000Z") +
+          MUX_OVERRIDE_RESUME_AFTER_MS -
+          1,
+      ),
+    ).toBe(false)
+  })
+
+  it("allows retrying stale override_pending entries", () => {
+    const comparison = buildComparison({
+      status: "override_pending",
+      canOverride: false,
+    })
+
+    expect(
+      isStaleOverridePending(
+        comparison,
+        Date.parse("2026-04-10T12:00:00.000Z") + MUX_OVERRIDE_RESUME_AFTER_MS,
+      ),
+    ).toBe(true)
+    expect(
+      canRetryMuxSyncOverride(
+        comparison,
+        Date.parse("2026-04-10T12:00:00.000Z") + MUX_OVERRIDE_RESUME_AFTER_MS,
+      ),
+    ).toBe(true)
+  })
+})

--- a/apps/manager/src/lib/mux-sync-override.ts
+++ b/apps/manager/src/lib/mux-sync-override.ts
@@ -1,0 +1,31 @@
+import type { MuxSyncComparison } from "@/types/job"
+
+export const MUX_OVERRIDE_RESUME_AFTER_MS = 60_000
+
+export function isStaleOverridePending(
+  comparison: MuxSyncComparison,
+  now: number = Date.now(),
+): boolean {
+  if (comparison.status !== "override_pending") {
+    return false
+  }
+
+  const updatedAtMs =
+    typeof comparison.updatedAt === "string"
+      ? Date.parse(comparison.updatedAt)
+      : Number.NaN
+
+  return (
+    Number.isFinite(updatedAtMs) &&
+    now - updatedAtMs >= MUX_OVERRIDE_RESUME_AFTER_MS
+  )
+}
+
+export function canRetryMuxSyncOverride(
+  comparison: MuxSyncComparison,
+  now: number = Date.now(),
+): boolean {
+  return (
+    comparison.canOverride === true || isStaleOverridePending(comparison, now)
+  )
+}

--- a/apps/manager/src/lib/mux-sync-report.test.ts
+++ b/apps/manager/src/lib/mux-sync-report.test.ts
@@ -69,4 +69,46 @@ describe("mux-sync-report helpers", () => {
       },
     })
   })
+
+  it("keeps pending and reconciliation comparison states when reading persisted metadata", () => {
+    const report = getMuxSyncReport({
+      muxSync: {
+        kind: "metadata",
+        data: {
+          comparisons: [
+            {
+              artifactKey: "subtitles-fr",
+              targetLanguage: "fr",
+              muxTargetType: "text_track",
+              muxTargetKey: "fr",
+              status: "override_pending",
+              explanation: "Override requested for fr subtitles.",
+            },
+            {
+              artifactKey: "subtitles-es",
+              targetLanguage: "es",
+              muxTargetType: "text_track",
+              muxTargetKey: "es",
+              status: "reconciliation_required",
+              explanation: "Mux changed but the report needs reconciliation.",
+            },
+          ],
+          updatedAt: "2026-04-10T12:05:00.000Z",
+        },
+      },
+    } satisfies JobArtifactManifest)
+
+    expect(report?.comparisons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          artifactKey: "subtitles-fr",
+          status: "override_pending",
+        }),
+        expect.objectContaining({
+          artifactKey: "subtitles-es",
+          status: "reconciliation_required",
+        }),
+      ]),
+    )
+  })
 })

--- a/apps/manager/src/lib/mux-sync-report.test.ts
+++ b/apps/manager/src/lib/mux-sync-report.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import { getMuxSyncReport, setMuxSyncReport } from "@/lib/mux-sync-report"
+import type { JobArtifactManifest, MuxSyncReport } from "@/types/job"
+
+describe("mux-sync-report helpers", () => {
+  it("reads a persisted muxSync metadata artifact", () => {
+    const report = getMuxSyncReport({
+      muxSync: {
+        kind: "metadata",
+        data: {
+          comparisons: [
+            {
+              artifactKey: "subtitles-fr",
+              targetLanguage: "fr",
+              muxTargetType: "text_track",
+              muxTargetKey: "fr",
+              status: "skipped_existing_mux_data",
+              explanation: "Mux already has fr subtitles",
+              canOverride: true,
+            },
+          ],
+          updatedAt: "2026-04-10T12:00:00.000Z",
+        },
+      },
+    } satisfies JobArtifactManifest)
+
+    expect(report).toEqual({
+      comparisons: [
+        expect.objectContaining({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+          status: "skipped_existing_mux_data",
+          canOverride: true,
+        }),
+      ],
+      overrideHistory: [],
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    })
+  })
+
+  it("writes a muxSync report back into artifacts without dropping existing entries", () => {
+    const report: MuxSyncReport = {
+      comparisons: [
+        {
+          artifactKey: "subtitles-es",
+          targetLanguage: "es",
+          muxTargetType: "text_track",
+          muxTargetKey: "es",
+          status: "synced",
+          explanation: "Synced es subtitles to Mux",
+        },
+      ],
+      overrideHistory: [],
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    }
+
+    expect(
+      setMuxSyncReport(
+        {
+          transcript: { kind: "downloadable" },
+        },
+        report,
+      ),
+    ).toEqual({
+      transcript: { kind: "downloadable" },
+      muxSync: {
+        kind: "metadata",
+        data: report,
+      },
+    })
+  })
+})

--- a/apps/manager/src/lib/mux-sync-report.ts
+++ b/apps/manager/src/lib/mux-sync-report.ts
@@ -15,7 +15,9 @@ function isMuxSyncStatus(value: unknown): value is MuxSyncStatus {
     value === "synced" ||
     value === "skipped_existing_mux_data" ||
     value === "skipped_missing_generated_data" ||
+    value === "override_pending" ||
     value === "override_applied" ||
+    value === "reconciliation_required" ||
     value === "failed"
   )
 }

--- a/apps/manager/src/lib/mux-sync-report.ts
+++ b/apps/manager/src/lib/mux-sync-report.ts
@@ -1,0 +1,138 @@
+import type {
+  JobArtifactManifest,
+  MuxSyncComparison,
+  MuxSyncOverrideAuditEntry,
+  MuxSyncReport,
+  MuxSyncStatus,
+} from "@/types/job"
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value)
+}
+
+function isMuxSyncStatus(value: unknown): value is MuxSyncStatus {
+  return (
+    value === "synced" ||
+    value === "skipped_existing_mux_data" ||
+    value === "skipped_missing_generated_data" ||
+    value === "override_applied" ||
+    value === "failed"
+  )
+}
+
+function normalizeMuxSyncComparison(raw: unknown): MuxSyncComparison | null {
+  if (!isObjectRecord(raw)) {
+    return null
+  }
+
+  const artifactKey =
+    typeof raw.artifactKey === "string" ? raw.artifactKey : null
+  const targetLanguage =
+    typeof raw.targetLanguage === "string" ? raw.targetLanguage : null
+  const muxTargetType = raw.muxTargetType === "text_track" ? "text_track" : null
+  const muxTargetKey =
+    typeof raw.muxTargetKey === "string" ? raw.muxTargetKey : null
+  const status = isMuxSyncStatus(raw.status) ? raw.status : null
+  const explanation =
+    typeof raw.explanation === "string" ? raw.explanation : null
+
+  if (
+    artifactKey == null ||
+    targetLanguage == null ||
+    muxTargetType == null ||
+    muxTargetKey == null ||
+    status == null ||
+    explanation == null
+  ) {
+    return null
+  }
+
+  return {
+    artifactKey,
+    targetLanguage,
+    muxTargetType,
+    muxTargetKey,
+    status,
+    explanation,
+    generatedPreview:
+      typeof raw.generatedPreview === "string"
+        ? raw.generatedPreview
+        : undefined,
+    muxPreview: typeof raw.muxPreview === "string" ? raw.muxPreview : undefined,
+    muxTrackId: typeof raw.muxTrackId === "string" ? raw.muxTrackId : undefined,
+    canOverride:
+      typeof raw.canOverride === "boolean" ? raw.canOverride : undefined,
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : undefined,
+  }
+}
+
+function normalizeOverrideAuditEntry(
+  raw: unknown,
+): MuxSyncOverrideAuditEntry | null {
+  if (!isObjectRecord(raw)) {
+    return null
+  }
+
+  if (
+    typeof raw.artifactKey !== "string" ||
+    typeof raw.targetLanguage !== "string" ||
+    typeof raw.at !== "string" ||
+    raw.action !== "override_subtitle_track"
+  ) {
+    return null
+  }
+
+  return {
+    artifactKey: raw.artifactKey,
+    targetLanguage: raw.targetLanguage,
+    at: raw.at,
+    action: "override_subtitle_track",
+  }
+}
+
+export function getMuxSyncReport(
+  artifacts: JobArtifactManifest,
+): MuxSyncReport | undefined {
+  const raw = artifacts.muxSync
+  if (!raw || raw.kind !== "metadata" || !isObjectRecord(raw.data)) {
+    return undefined
+  }
+
+  const comparisons = Array.isArray(raw.data.comparisons)
+    ? raw.data.comparisons
+        .map(normalizeMuxSyncComparison)
+        .filter((entry): entry is MuxSyncComparison => entry != null)
+    : []
+
+  if (comparisons.length === 0) {
+    return undefined
+  }
+
+  const overrideHistory = Array.isArray(raw.data.overrideHistory)
+    ? raw.data.overrideHistory
+        .map(normalizeOverrideAuditEntry)
+        .filter((entry): entry is MuxSyncOverrideAuditEntry => entry != null)
+    : []
+
+  return {
+    comparisons,
+    overrideHistory,
+    updatedAt:
+      typeof raw.data.updatedAt === "string"
+        ? raw.data.updatedAt
+        : new Date(0).toISOString(),
+  }
+}
+
+export function setMuxSyncReport(
+  artifacts: JobArtifactManifest,
+  report: MuxSyncReport,
+): JobArtifactManifest {
+  return {
+    ...artifacts,
+    muxSync: {
+      kind: "metadata",
+      data: report as unknown as Record<string, unknown>,
+    },
+  }
+}

--- a/apps/manager/src/lib/workflow-steps.test.ts
+++ b/apps/manager/src/lib/workflow-steps.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest"
+import { buildInitialSteps } from "@/lib/workflow-steps"
+
+describe("buildInitialSteps", () => {
+  it("includes mux_upload in the persisted job steps", () => {
+    expect(buildInitialSteps().map((step) => step.name)).toContain("mux_upload")
+  })
+})

--- a/apps/manager/src/lib/workflow-steps.ts
+++ b/apps/manager/src/lib/workflow-steps.ts
@@ -9,6 +9,7 @@ const FORGE_STEPS: WorkflowStepName[] = [
   "chapters",
   "metadata",
   "embeddings",
+  "mux_upload",
 ]
 
 export function buildInitialSteps(): JobStepState[] {

--- a/apps/manager/src/services/mux-sync/index.test.ts
+++ b/apps/manager/src/services/mux-sync/index.test.ts
@@ -150,6 +150,7 @@ describe("applySubtitleOverride", () => {
     }
 
     const deleteTrack = vi.fn().mockResolvedValue(undefined)
+    const updateTrack = vi.fn().mockResolvedValue(undefined)
     const createTrack = vi.fn().mockResolvedValue({ id: "track-new" })
 
     const report = await applySubtitleOverride(
@@ -175,6 +176,7 @@ describe("applySubtitleOverride", () => {
           ],
         }),
         deleteTrack,
+        updateTrack,
         createTrack,
         readArtifactText: vi
           .fn()
@@ -195,12 +197,19 @@ describe("applySubtitleOverride", () => {
       },
     )
 
-    expect(deleteTrack).toHaveBeenCalledWith("mux-1", "track-old")
     expect(createTrack).toHaveBeenCalledWith("mux-1", {
       languageCode: "it",
       url: "https://manager.example/api/jobs/job-1/artifacts/subtitles-it",
+      name: "IT subtitles (override job-1)",
+    })
+    expect(deleteTrack).toHaveBeenCalledWith("mux-1", "track-old")
+    expect(updateTrack).toHaveBeenCalledWith("mux-1", "track-new", {
+      languageCode: "it",
       name: "IT subtitles",
     })
+    expect(createTrack.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteTrack.mock.invocationCallOrder[0],
+    )
     expect(report.comparisons).toEqual([
       expect.objectContaining({
         artifactKey: "subtitles-it",
@@ -217,6 +226,144 @@ describe("applySubtitleOverride", () => {
         at: "2026-04-10T12:30:00.000Z",
         action: "override_subtitle_track",
       },
+    ])
+  })
+
+  it("does not delete the original subtitle when replacement creation fails", async () => {
+    const deleteTrack = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      applySubtitleOverride(
+        {
+          jobId: "job-1",
+          assetId: "asset-1",
+          muxAssetId: "mux-1",
+          artifactKey: "subtitles-it",
+          targetLanguage: "it",
+          previousReport: {
+            comparisons: [
+              {
+                artifactKey: "subtitles-it",
+                targetLanguage: "it",
+                muxTargetType: "text_track",
+                muxTargetKey: "it",
+                status: "override_pending",
+                explanation: "Override requested for it subtitles.",
+                muxTrackId: "track-old",
+                canOverride: false,
+                updatedAt: "2026-04-10T12:00:00.000Z",
+              },
+            ],
+            overrideHistory: [],
+            updatedAt: "2026-04-10T12:00:00.000Z",
+          },
+        },
+        {
+          retrieveAsset: vi.fn().mockResolvedValue({
+            tracks: [
+              {
+                id: "track-old",
+                type: "text",
+                text_type: "subtitles",
+                language_code: "it",
+                status: "ready",
+                url: "https://stream.mux.com/text-it.vtt",
+              },
+            ],
+          }),
+          createTrack: vi
+            .fn()
+            .mockRejectedValue(new Error("Mux create failed")),
+          deleteTrack,
+          buildArtifactUrl: vi
+            .fn()
+            .mockReturnValue(
+              "https://manager.example/api/jobs/job-1/artifacts/subtitles-it",
+            ),
+          readArtifactText: vi
+            .fn()
+            .mockResolvedValue(
+              "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nCiao da Forge",
+            ),
+        },
+      ),
+    ).rejects.toThrow("Mux create failed")
+
+    expect(deleteTrack).not.toHaveBeenCalled()
+  })
+
+  it("resumes an interrupted override by finishing the pending replacement", async () => {
+    const deleteTrack = vi.fn().mockResolvedValue(undefined)
+    const updateTrack = vi.fn().mockResolvedValue(undefined)
+
+    const report = await applySubtitleOverride(
+      {
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        artifactKey: "subtitles-it",
+        targetLanguage: "it",
+        previousReport: {
+          comparisons: [
+            {
+              artifactKey: "subtitles-it",
+              targetLanguage: "it",
+              muxTargetType: "text_track",
+              muxTargetKey: "it",
+              status: "override_pending",
+              explanation: "Override requested for it subtitles.",
+              muxTrackId: "track-old",
+              muxPreview: "Ciao da Mux",
+              canOverride: false,
+              updatedAt: "2026-04-10T12:00:00.000Z",
+            },
+          ],
+          overrideHistory: [],
+          updatedAt: "2026-04-10T12:00:00.000Z",
+        },
+      },
+      {
+        retrieveAsset: vi.fn().mockResolvedValue({
+          tracks: [
+            {
+              id: "track-temp",
+              type: "text",
+              text_type: "subtitles",
+              language_code: "it",
+              status: "ready",
+              name: "IT subtitles (override job-1)",
+              url: "https://stream.mux.com/text-it-new.vtt",
+            },
+          ],
+        }),
+        createTrack: vi.fn(),
+        deleteTrack,
+        updateTrack,
+        buildArtifactUrl: vi
+          .fn()
+          .mockReturnValue(
+            "https://manager.example/api/jobs/job-1/artifacts/subtitles-it",
+          ),
+        readArtifactText: vi
+          .fn()
+          .mockResolvedValue(
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nCiao da Forge",
+          ),
+        now: () => "2026-04-10T12:30:00.000Z",
+      },
+    )
+
+    expect(deleteTrack).not.toHaveBeenCalled()
+    expect(updateTrack).toHaveBeenCalledWith("mux-1", "track-temp", {
+      languageCode: "it",
+      name: "IT subtitles",
+    })
+    expect(report.comparisons).toEqual([
+      expect.objectContaining({
+        artifactKey: "subtitles-it",
+        status: "override_applied",
+        muxTrackId: "track-temp",
+      }),
     ])
   })
 })

--- a/apps/manager/src/services/mux-sync/index.test.ts
+++ b/apps/manager/src/services/mux-sync/index.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  applySubtitleOverride,
+  syncTranslatedSubtitlesToMux,
+} from "@/services/mux-sync"
+import type { MuxSyncReport } from "@/types/job"
+
+describe("syncTranslatedSubtitlesToMux", () => {
+  it("creates a synced report entry when Mux is missing the target subtitle track", async () => {
+    const createTrack = vi.fn().mockResolvedValue({ id: "track-new" })
+
+    const report = await syncTranslatedSubtitlesToMux(
+      {
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        translationResults: [{ lang: "fr", status: "completed" }],
+      },
+      {
+        retrieveAsset: vi.fn().mockResolvedValue({ tracks: [] }),
+        createTrack,
+        readArtifactText: vi
+          .fn()
+          .mockResolvedValue(
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nBonjour tout le monde",
+          ),
+        buildArtifactUrl: vi
+          .fn()
+          .mockReturnValue(
+            "https://manager.example/api/jobs/job-1/artifacts/subtitles-fr",
+          ),
+        now: () => "2026-04-10T12:00:00.000Z",
+      },
+    )
+
+    expect(createTrack).toHaveBeenCalledWith("mux-1", {
+      languageCode: "fr",
+      url: "https://manager.example/api/jobs/job-1/artifacts/subtitles-fr",
+      name: "FR subtitles",
+    })
+    expect(report).toEqual({
+      comparisons: [
+        expect.objectContaining({
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+          status: "synced",
+          muxTrackId: "track-new",
+          generatedPreview: "Bonjour tout le monde",
+        }),
+      ],
+      overrideHistory: [],
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    })
+  })
+
+  it("skips syncing and includes generated-vs-mux previews when a language already exists", async () => {
+    const report = await syncTranslatedSubtitlesToMux(
+      {
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        translationResults: [{ lang: "es", status: "completed" }],
+      },
+      {
+        retrieveAsset: vi.fn().mockResolvedValue({
+          tracks: [
+            {
+              id: "track-es",
+              type: "text",
+              text_type: "subtitles",
+              language_code: "es",
+              status: "ready",
+              url: "https://stream.mux.com/text-es.vtt",
+            },
+          ],
+        }),
+        createTrack: vi.fn(),
+        readArtifactText: vi
+          .fn()
+          .mockResolvedValue(
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nHola desde Forge",
+          ),
+        readTrackText: vi
+          .fn()
+          .mockResolvedValue(
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nHola desde Mux",
+          ),
+        now: () => "2026-04-10T12:00:00.000Z",
+      },
+    )
+
+    expect(report.comparisons).toEqual([
+      expect.objectContaining({
+        artifactKey: "subtitles-es",
+        targetLanguage: "es",
+        status: "skipped_existing_mux_data",
+        muxTrackId: "track-es",
+        canOverride: true,
+        generatedPreview: "Hola desde Forge",
+        muxPreview: "Hola desde Mux",
+      }),
+    ])
+  })
+
+  it("reports skipped_missing_generated_data when translation output is unavailable", async () => {
+    const report = await syncTranslatedSubtitlesToMux(
+      {
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        translationResults: [
+          { lang: "de", status: "failed", error: "translator failed" },
+        ],
+      },
+      {
+        retrieveAsset: vi.fn().mockResolvedValue({ tracks: [] }),
+        now: () => "2026-04-10T12:00:00.000Z",
+      },
+    )
+
+    expect(report.comparisons).toEqual([
+      expect.objectContaining({
+        artifactKey: "subtitles-de",
+        status: "skipped_missing_generated_data",
+        explanation:
+          "Generated subtitle artifact is unavailable: translator failed",
+      }),
+    ])
+  })
+})
+
+describe("applySubtitleOverride", () => {
+  it("replaces an existing subtitle track and appends an audit entry", async () => {
+    const previousReport: MuxSyncReport = {
+      comparisons: [
+        {
+          artifactKey: "subtitles-it",
+          targetLanguage: "it",
+          muxTargetType: "text_track",
+          muxTargetKey: "it",
+          status: "skipped_existing_mux_data",
+          explanation: "Mux already has it subtitles",
+          muxTrackId: "track-old",
+          canOverride: true,
+          updatedAt: "2026-04-10T11:00:00.000Z",
+        },
+      ],
+      overrideHistory: [],
+      updatedAt: "2026-04-10T11:00:00.000Z",
+    }
+
+    const deleteTrack = vi.fn().mockResolvedValue(undefined)
+    const createTrack = vi.fn().mockResolvedValue({ id: "track-new" })
+
+    const report = await applySubtitleOverride(
+      {
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        artifactKey: "subtitles-it",
+        targetLanguage: "it",
+        previousReport,
+      },
+      {
+        retrieveAsset: vi.fn().mockResolvedValue({
+          tracks: [
+            {
+              id: "track-old",
+              type: "text",
+              text_type: "subtitles",
+              language_code: "it",
+              status: "ready",
+              url: "https://stream.mux.com/text-it.vtt",
+            },
+          ],
+        }),
+        deleteTrack,
+        createTrack,
+        readArtifactText: vi
+          .fn()
+          .mockResolvedValue(
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nCiao da Forge",
+          ),
+        readTrackText: vi
+          .fn()
+          .mockResolvedValue(
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nCiao da Mux",
+          ),
+        buildArtifactUrl: vi
+          .fn()
+          .mockReturnValue(
+            "https://manager.example/api/jobs/job-1/artifacts/subtitles-it",
+          ),
+        now: () => "2026-04-10T12:30:00.000Z",
+      },
+    )
+
+    expect(deleteTrack).toHaveBeenCalledWith("mux-1", "track-old")
+    expect(createTrack).toHaveBeenCalledWith("mux-1", {
+      languageCode: "it",
+      url: "https://manager.example/api/jobs/job-1/artifacts/subtitles-it",
+      name: "IT subtitles",
+    })
+    expect(report.comparisons).toEqual([
+      expect.objectContaining({
+        artifactKey: "subtitles-it",
+        status: "override_applied",
+        muxTrackId: "track-new",
+        generatedPreview: "Ciao da Forge",
+        muxPreview: "Ciao da Mux",
+      }),
+    ])
+    expect(report.overrideHistory).toEqual([
+      {
+        artifactKey: "subtitles-it",
+        targetLanguage: "it",
+        at: "2026-04-10T12:30:00.000Z",
+        action: "override_subtitle_track",
+      },
+    ])
+  })
+})

--- a/apps/manager/src/services/mux-sync/index.ts
+++ b/apps/manager/src/services/mux-sync/index.ts
@@ -36,6 +36,11 @@ type SyncSubtitlesToMuxDeps = {
     assetId: string,
     input: { languageCode: string; url: string; name: string },
   ) => Promise<{ id?: string | null }>
+  updateTrack?: (
+    assetId: string,
+    trackId: string,
+    input: { languageCode: string; name: string },
+  ) => Promise<void>
   deleteTrack?: (assetId: string, trackId: string) => Promise<void>
   readArtifactText?: (assetId: string, artifactKey: string) => Promise<string>
   readTrackText?: (trackUrl: string) => Promise<string>
@@ -101,6 +106,24 @@ function findSubtitleTrackByLanguage(
   return tracks.find((track) => track.languageCode === normalizedLanguage)
 }
 
+function findSubtitleTrackById(
+  tracks: MuxSubtitleTrack[],
+  trackId?: string,
+): MuxSubtitleTrack | undefined {
+  if (!trackId) {
+    return undefined
+  }
+
+  return tracks.find((track) => track.id === trackId)
+}
+
+function findSubtitleTrackByName(
+  tracks: MuxSubtitleTrack[],
+  name: string,
+): MuxSubtitleTrack | undefined {
+  return tracks.find((track) => track.name === name)
+}
+
 function buildPreview(raw: string): string {
   return raw
     .split(/\r?\n/)
@@ -118,6 +141,13 @@ function buildPreview(raw: string): string {
 
 function buildTrackName(languageCode: string): string {
   return `${languageCode.toUpperCase()} subtitles`
+}
+
+function buildPendingOverrideTrackName(
+  languageCode: string,
+  jobId: string,
+): string {
+  return `${buildTrackName(languageCode)} (override ${jobId.slice(0, 8)})`
 }
 
 function buildExplanationForExistingTrack(targetLanguage: string): string {
@@ -207,6 +237,23 @@ async function defaultDeleteTrack(
     `/video/v1/assets/${encodeURIComponent(assetId)}/tracks/${encodeURIComponent(trackId)}`,
     {
       method: "DELETE",
+    },
+  )
+}
+
+async function defaultUpdateTrack(
+  assetId: string,
+  trackId: string,
+  input: { languageCode: string; name: string },
+): Promise<void> {
+  await muxApiRequest(
+    `/video/v1/assets/${encodeURIComponent(assetId)}/tracks/${encodeURIComponent(trackId)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({
+        language_code: input.languageCode,
+        name: input.name,
+      }),
     },
   )
 }
@@ -383,6 +430,7 @@ export async function applySubtitleOverride(
 ): Promise<MuxSyncReport> {
   const retrieveAsset = deps.retrieveAsset ?? defaultRetrieveAsset
   const createTrack = deps.createTrack ?? defaultCreateTrack
+  const updateTrack = deps.updateTrack ?? defaultUpdateTrack
   const deleteTrack = deps.deleteTrack ?? defaultDeleteTrack
   const readArtifactText = deps.readArtifactText ?? defaultReadArtifactText
   const readTrackText = deps.readTrackText ?? defaultReadTrackText
@@ -393,35 +441,86 @@ export async function applySubtitleOverride(
   const now = deps.now?.() ?? new Date().toISOString()
 
   const targetLanguage = normalizeLanguageCode(input.targetLanguage)
+  const canonicalTrackName = buildTrackName(targetLanguage)
+  const pendingTrackName = buildPendingOverrideTrackName(
+    targetLanguage,
+    input.jobId,
+  )
   const generatedText = await readArtifactText(input.assetId, input.artifactKey)
   const generatedPreview = buildPreview(generatedText)
+  const previousComparison = input.previousReport?.comparisons.find(
+    (comparison) =>
+      comparison.artifactKey === input.artifactKey &&
+      comparison.targetLanguage === targetLanguage,
+  )
 
   const asset = await retrieveAsset(input.muxAssetId)
-  const tracks = getSubtitleTracks(asset)
-  const existingTrack = findSubtitleTrackByLanguage(tracks, targetLanguage)
-
-  if (!existingTrack) {
-    throw new Error(`Mux has no existing subtitle track for ${targetLanguage}`)
-  }
+  const tracks = getSubtitleTracks(asset).filter(
+    (track) => track.languageCode === targetLanguage,
+  )
+  const existingTrack =
+    previousComparison?.muxTrackId != null
+      ? findSubtitleTrackById(tracks, previousComparison.muxTrackId)
+      : findSubtitleTrackByLanguage(tracks, targetLanguage)
+  const pendingReplacementTrack = findSubtitleTrackByName(
+    tracks,
+    pendingTrackName,
+  )
+  const canonicalReplacementTrack = tracks.find(
+    (track) =>
+      track.id !== existingTrack?.id && track.name === canonicalTrackName,
+  )
+  let replacementTrack =
+    pendingReplacementTrack ?? canonicalReplacementTrack ?? undefined
 
   let muxPreview: string | undefined
-  if (existingTrack.url) {
+  if (existingTrack?.url) {
     try {
       muxPreview = buildPreview(await readTrackText(existingTrack.url))
     } catch {
       muxPreview = undefined
     }
   }
+  if (!muxPreview) {
+    muxPreview = previousComparison?.muxPreview
+  }
 
-  await deleteTrack(input.muxAssetId, existingTrack.id)
-  const createdTrack = await createTrack(input.muxAssetId, {
-    languageCode: targetLanguage,
-    url: buildArtifactUrl({
-      jobId: input.jobId,
-      artifactKey: input.artifactKey,
-    }),
-    name: buildTrackName(targetLanguage),
-  })
+  if (!replacementTrack) {
+    const replacementName =
+      existingTrack != null ? pendingTrackName : canonicalTrackName
+    const createdTrack = await createTrack(input.muxAssetId, {
+      languageCode: targetLanguage,
+      url: buildArtifactUrl({
+        jobId: input.jobId,
+        artifactKey: input.artifactKey,
+      }),
+      name: replacementName,
+    })
+    replacementTrack = {
+      id:
+        typeof createdTrack.id === "string" ? createdTrack.id : "pending-track",
+      languageCode: targetLanguage,
+      status: "unknown",
+      name: replacementName,
+    }
+  }
+
+  if (existingTrack && existingTrack.id !== replacementTrack.id) {
+    await deleteTrack(input.muxAssetId, existingTrack.id)
+  }
+
+  if (replacementTrack.name !== canonicalTrackName) {
+    if (!replacementTrack.id || replacementTrack.id === "pending-track") {
+      throw new Error(
+        `Mux replacement subtitle track is missing an id for ${targetLanguage}`,
+      )
+    }
+
+    await updateTrack(input.muxAssetId, replacementTrack.id, {
+      languageCode: targetLanguage,
+      name: canonicalTrackName,
+    })
+  }
 
   const nextComparison: MuxSyncComparison = {
     artifactKey: input.artifactKey,
@@ -432,8 +531,7 @@ export async function applySubtitleOverride(
     explanation: `Replaced existing ${targetLanguage} subtitles on Mux`,
     generatedPreview,
     muxPreview,
-    muxTrackId:
-      typeof createdTrack.id === "string" ? createdTrack.id : undefined,
+    muxTrackId: replacementTrack.id,
     canOverride: true,
     updatedAt: now,
   }

--- a/apps/manager/src/services/mux-sync/index.ts
+++ b/apps/manager/src/services/mux-sync/index.ts
@@ -1,0 +1,470 @@
+import { env } from "@/config/env"
+import { buildMuxArtifactAccessUrl } from "@/lib/mux-artifact-access"
+import type {
+  MuxSyncComparison,
+  MuxSyncOverrideAuditEntry,
+  MuxSyncReport,
+} from "@/types/job"
+import type { LanguageResult } from "@/services/subtitleTranslation/types"
+import { readArtifact } from "@/services/storage"
+
+type MuxTrackInfo = {
+  id?: string | null
+  type?: "video" | "audio" | "text" | null
+  text_type?: "subtitles" | "captions" | null
+  language_code?: string | null
+  status?: "preparing" | "ready" | "errored" | "deleted" | null
+  name?: string | null
+  url?: string | null
+}
+
+type MuxAssetPayload = {
+  tracks?: MuxTrackInfo[] | null
+}
+
+export type MuxSubtitleTrack = {
+  id: string
+  languageCode: string
+  status: "preparing" | "ready" | "errored" | "deleted" | "unknown"
+  name?: string
+  url?: string
+}
+
+type SyncSubtitlesToMuxDeps = {
+  retrieveAsset?: (assetId: string) => Promise<MuxAssetPayload>
+  createTrack?: (
+    assetId: string,
+    input: { languageCode: string; url: string; name: string },
+  ) => Promise<{ id?: string | null }>
+  deleteTrack?: (assetId: string, trackId: string) => Promise<void>
+  readArtifactText?: (assetId: string, artifactKey: string) => Promise<string>
+  readTrackText?: (trackUrl: string) => Promise<string>
+  buildArtifactUrl?: (input: { jobId: string; artifactKey: string }) => string
+  now?: () => string
+}
+
+function normalizeLanguageCode(language: string): string {
+  return (
+    language.trim().toLowerCase().split(/[-_]/)[0] ??
+    language.trim().toLowerCase()
+  )
+}
+
+function isSubtitleTrack(
+  track: MuxTrackInfo,
+): track is MuxTrackInfo & { id: string } {
+  return (
+    track.type === "text" &&
+    track.text_type === "subtitles" &&
+    Boolean(track.id)
+  )
+}
+
+function normalizeTrack(
+  track: MuxTrackInfo & { id: string },
+): MuxSubtitleTrack | null {
+  const languageCode =
+    typeof track.language_code === "string"
+      ? normalizeLanguageCode(track.language_code)
+      : null
+  if (!languageCode) {
+    return null
+  }
+
+  return {
+    id: track.id,
+    languageCode,
+    status:
+      track.status === "preparing" ||
+      track.status === "ready" ||
+      track.status === "errored" ||
+      track.status === "deleted"
+        ? track.status
+        : "unknown",
+    name: typeof track.name === "string" ? track.name : undefined,
+    url: typeof track.url === "string" ? track.url : undefined,
+  }
+}
+
+function getSubtitleTracks(asset: MuxAssetPayload): MuxSubtitleTrack[] {
+  return (asset.tracks ?? [])
+    .filter(isSubtitleTrack)
+    .map(normalizeTrack)
+    .filter((track): track is MuxSubtitleTrack => track != null)
+}
+
+function findSubtitleTrackByLanguage(
+  tracks: MuxSubtitleTrack[],
+  targetLanguage: string,
+): MuxSubtitleTrack | undefined {
+  const normalizedLanguage = normalizeLanguageCode(targetLanguage)
+  return tracks.find((track) => track.languageCode === normalizedLanguage)
+}
+
+function buildPreview(raw: string): string {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line.length > 0 &&
+        line !== "WEBVTT" &&
+        !line.includes("-->") &&
+        !/^\d+$/.test(line),
+    )
+    .join(" ")
+    .slice(0, 280)
+}
+
+function buildTrackName(languageCode: string): string {
+  return `${languageCode.toUpperCase()} subtitles`
+}
+
+function buildExplanationForExistingTrack(targetLanguage: string): string {
+  return `Mux already has ${targetLanguage} subtitles`
+}
+
+async function defaultReadArtifactText(
+  assetId: string,
+  artifactKey: string,
+): Promise<string> {
+  const body = await readArtifact(assetId, artifactKey, "vtt")
+  return new TextDecoder().decode(body)
+}
+
+async function defaultReadTrackText(trackUrl: string): Promise<string> {
+  const response = await fetch(trackUrl, {
+    method: "GET",
+    cache: "no-store",
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Mux subtitle track preview (${response.status})`,
+    )
+  }
+
+  return response.text()
+}
+
+function getMuxAuthHeader(): string {
+  return `Basic ${Buffer.from(`${env.MUX_TOKEN_ID}:${env.MUX_TOKEN_SECRET}`).toString("base64")}`
+}
+
+async function muxApiRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`https://api.mux.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: getMuxAuthHeader(),
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    cache: "no-store",
+  })
+
+  if (!response.ok) {
+    throw new Error(`Mux API request failed (${response.status})`)
+  }
+
+  return (await response.json()) as T
+}
+
+async function defaultRetrieveAsset(assetId: string): Promise<MuxAssetPayload> {
+  const response = await muxApiRequest<{ data?: MuxAssetPayload }>(
+    `/video/v1/assets/${encodeURIComponent(assetId)}`,
+    { method: "GET" },
+  )
+
+  return response.data ?? {}
+}
+
+async function defaultCreateTrack(
+  assetId: string,
+  input: { languageCode: string; url: string; name: string },
+): Promise<{ id?: string | null }> {
+  const response = await muxApiRequest<{ data?: { id?: string | null } }>(
+    `/video/v1/assets/${encodeURIComponent(assetId)}/tracks`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        url: input.url,
+        type: "text",
+        text_type: "subtitles",
+        language_code: input.languageCode,
+        name: input.name,
+      }),
+    },
+  )
+
+  return response.data ?? {}
+}
+
+async function defaultDeleteTrack(
+  assetId: string,
+  trackId: string,
+): Promise<void> {
+  await muxApiRequest(
+    `/video/v1/assets/${encodeURIComponent(assetId)}/tracks/${encodeURIComponent(trackId)}`,
+    {
+      method: "DELETE",
+    },
+  )
+}
+
+function createFailedComparison(input: {
+  artifactKey: string
+  targetLanguage: string
+  explanation: string
+  generatedPreview?: string
+  muxPreview?: string
+  muxTrackId?: string
+  canOverride?: boolean
+  now: string
+}): MuxSyncComparison {
+  return {
+    artifactKey: input.artifactKey,
+    targetLanguage: input.targetLanguage,
+    muxTargetType: "text_track",
+    muxTargetKey: input.targetLanguage,
+    status: "failed",
+    explanation: input.explanation,
+    generatedPreview: input.generatedPreview,
+    muxPreview: input.muxPreview,
+    muxTrackId: input.muxTrackId,
+    canOverride: input.canOverride,
+    updatedAt: input.now,
+  }
+}
+
+export async function syncTranslatedSubtitlesToMux(
+  input: {
+    jobId: string
+    assetId: string
+    muxAssetId: string
+    translationResults: LanguageResult[]
+    previousReport?: MuxSyncReport
+  },
+  deps: SyncSubtitlesToMuxDeps = {},
+): Promise<MuxSyncReport> {
+  const retrieveAsset = deps.retrieveAsset ?? defaultRetrieveAsset
+  const createTrack = deps.createTrack ?? defaultCreateTrack
+  const readArtifactText = deps.readArtifactText ?? defaultReadArtifactText
+  const readTrackText = deps.readTrackText ?? defaultReadTrackText
+  const buildArtifactUrl =
+    deps.buildArtifactUrl ??
+    ((params: { jobId: string; artifactKey: string }) =>
+      buildMuxArtifactAccessUrl(params))
+  const now = deps.now?.() ?? new Date().toISOString()
+
+  const asset = await retrieveAsset(input.muxAssetId)
+  const tracks = getSubtitleTracks(asset)
+  const comparisons: MuxSyncComparison[] = []
+
+  for (const result of input.translationResults) {
+    const artifactKey = `subtitles-${result.lang}`
+    const targetLanguage = normalizeLanguageCode(result.lang)
+
+    if (result.status !== "completed") {
+      comparisons.push({
+        artifactKey,
+        targetLanguage,
+        muxTargetType: "text_track",
+        muxTargetKey: targetLanguage,
+        status: "skipped_missing_generated_data",
+        explanation:
+          result.error != null
+            ? `Generated subtitle artifact is unavailable: ${result.error}`
+            : "Generated subtitle artifact is unavailable",
+        updatedAt: now,
+      })
+      continue
+    }
+
+    let generatedText: string
+    try {
+      generatedText = await readArtifactText(input.assetId, artifactKey)
+    } catch {
+      comparisons.push({
+        artifactKey,
+        targetLanguage,
+        muxTargetType: "text_track",
+        muxTargetKey: targetLanguage,
+        status: "skipped_missing_generated_data",
+        explanation: "Generated subtitle artifact is unavailable",
+        updatedAt: now,
+      })
+      continue
+    }
+
+    const generatedPreview = buildPreview(generatedText)
+    const existingTrack = findSubtitleTrackByLanguage(tracks, targetLanguage)
+
+    if (existingTrack) {
+      let muxPreview: string | undefined
+      if (existingTrack.url) {
+        try {
+          muxPreview = buildPreview(await readTrackText(existingTrack.url))
+        } catch {
+          muxPreview = undefined
+        }
+      }
+
+      comparisons.push({
+        artifactKey,
+        targetLanguage,
+        muxTargetType: "text_track",
+        muxTargetKey: targetLanguage,
+        status: "skipped_existing_mux_data",
+        explanation: buildExplanationForExistingTrack(targetLanguage),
+        generatedPreview,
+        muxPreview,
+        muxTrackId: existingTrack.id,
+        canOverride: existingTrack.status !== "deleted",
+        updatedAt: now,
+      })
+      continue
+    }
+
+    try {
+      const createdTrack = await createTrack(input.muxAssetId, {
+        languageCode: targetLanguage,
+        url: buildArtifactUrl({
+          jobId: input.jobId,
+          artifactKey,
+        }),
+        name: buildTrackName(targetLanguage),
+      })
+
+      comparisons.push({
+        artifactKey,
+        targetLanguage,
+        muxTargetType: "text_track",
+        muxTargetKey: targetLanguage,
+        status: "synced",
+        explanation: `Synced ${targetLanguage} subtitles to Mux`,
+        generatedPreview,
+        muxTrackId:
+          typeof createdTrack.id === "string" ? createdTrack.id : undefined,
+        updatedAt: now,
+      })
+    } catch (error) {
+      comparisons.push(
+        createFailedComparison({
+          artifactKey,
+          targetLanguage,
+          explanation:
+            error instanceof Error
+              ? error.message
+              : "Failed to sync subtitle track to Mux",
+          generatedPreview,
+          now,
+        }),
+      )
+    }
+  }
+
+  return {
+    comparisons,
+    overrideHistory: input.previousReport?.overrideHistory ?? [],
+    updatedAt: now,
+  }
+}
+
+export async function applySubtitleOverride(
+  input: {
+    jobId: string
+    assetId: string
+    muxAssetId: string
+    artifactKey: string
+    targetLanguage: string
+    previousReport?: MuxSyncReport
+  },
+  deps: SyncSubtitlesToMuxDeps = {},
+): Promise<MuxSyncReport> {
+  const retrieveAsset = deps.retrieveAsset ?? defaultRetrieveAsset
+  const createTrack = deps.createTrack ?? defaultCreateTrack
+  const deleteTrack = deps.deleteTrack ?? defaultDeleteTrack
+  const readArtifactText = deps.readArtifactText ?? defaultReadArtifactText
+  const readTrackText = deps.readTrackText ?? defaultReadTrackText
+  const buildArtifactUrl =
+    deps.buildArtifactUrl ??
+    ((params: { jobId: string; artifactKey: string }) =>
+      buildMuxArtifactAccessUrl(params))
+  const now = deps.now?.() ?? new Date().toISOString()
+
+  const targetLanguage = normalizeLanguageCode(input.targetLanguage)
+  const generatedText = await readArtifactText(input.assetId, input.artifactKey)
+  const generatedPreview = buildPreview(generatedText)
+
+  const asset = await retrieveAsset(input.muxAssetId)
+  const tracks = getSubtitleTracks(asset)
+  const existingTrack = findSubtitleTrackByLanguage(tracks, targetLanguage)
+
+  if (!existingTrack) {
+    throw new Error(`Mux has no existing subtitle track for ${targetLanguage}`)
+  }
+
+  let muxPreview: string | undefined
+  if (existingTrack.url) {
+    try {
+      muxPreview = buildPreview(await readTrackText(existingTrack.url))
+    } catch {
+      muxPreview = undefined
+    }
+  }
+
+  await deleteTrack(input.muxAssetId, existingTrack.id)
+  const createdTrack = await createTrack(input.muxAssetId, {
+    languageCode: targetLanguage,
+    url: buildArtifactUrl({
+      jobId: input.jobId,
+      artifactKey: input.artifactKey,
+    }),
+    name: buildTrackName(targetLanguage),
+  })
+
+  const nextComparison: MuxSyncComparison = {
+    artifactKey: input.artifactKey,
+    targetLanguage,
+    muxTargetType: "text_track",
+    muxTargetKey: targetLanguage,
+    status: "override_applied",
+    explanation: `Replaced existing ${targetLanguage} subtitles on Mux`,
+    generatedPreview,
+    muxPreview,
+    muxTrackId:
+      typeof createdTrack.id === "string" ? createdTrack.id : undefined,
+    canOverride: true,
+    updatedAt: now,
+  }
+
+  const priorComparisons = input.previousReport?.comparisons ?? []
+  const comparisons = [
+    ...priorComparisons.filter(
+      (comparison) =>
+        !(
+          comparison.artifactKey === input.artifactKey &&
+          comparison.targetLanguage === targetLanguage
+        ),
+    ),
+    nextComparison,
+  ].sort((left, right) =>
+    left.targetLanguage.localeCompare(right.targetLanguage),
+  )
+
+  const overrideHistory: MuxSyncOverrideAuditEntry[] = [
+    ...(input.previousReport?.overrideHistory ?? []),
+    {
+      artifactKey: input.artifactKey,
+      targetLanguage,
+      at: now,
+      action: "override_subtitle_track",
+    },
+  ]
+
+  return {
+    comparisons,
+    overrideHistory,
+    updatedAt: now,
+  }
+}

--- a/apps/manager/src/types/job.ts
+++ b/apps/manager/src/types/job.ts
@@ -43,7 +43,9 @@ export type MuxSyncStatus =
   | "synced"
   | "skipped_existing_mux_data"
   | "skipped_missing_generated_data"
+  | "override_pending"
   | "override_applied"
+  | "reconciliation_required"
   | "failed"
 
 export type MuxSyncComparison = {

--- a/apps/manager/src/types/job.ts
+++ b/apps/manager/src/types/job.ts
@@ -39,6 +39,40 @@ export type TranslationLanguageResult = {
   error?: string
 }
 
+export type MuxSyncStatus =
+  | "synced"
+  | "skipped_existing_mux_data"
+  | "skipped_missing_generated_data"
+  | "override_applied"
+  | "failed"
+
+export type MuxSyncComparison = {
+  artifactKey: string
+  targetLanguage: string
+  muxTargetType: "text_track"
+  muxTargetKey: string
+  status: MuxSyncStatus
+  explanation: string
+  generatedPreview?: string
+  muxPreview?: string
+  muxTrackId?: string
+  canOverride?: boolean
+  updatedAt?: string
+}
+
+export type MuxSyncOverrideAuditEntry = {
+  artifactKey: string
+  targetLanguage: string
+  at: string
+  action: "override_subtitle_track"
+}
+
+export type MuxSyncReport = {
+  comparisons: MuxSyncComparison[]
+  overrideHistory?: MuxSyncOverrideAuditEntry[]
+  updatedAt: string
+}
+
 export type JobStepDetails = {
   languageResults?: TranslationLanguageResult[]
 }

--- a/apps/manager/src/workflows/videoEnrichment.test.ts
+++ b/apps/manager/src/workflows/videoEnrichment.test.ts
@@ -3,18 +3,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const {
   chaptersMock,
   embeddingsMock,
+  getJobMock,
   mergeJobArtifactsMock,
   metadataMock,
+  persistedJobArtifacts,
   subtitleTranslationMock,
+  syncTranslatedSubtitlesToMuxMock,
   transcribeMock,
   updateJobMock,
   updateStepStatusMock,
 } = vi.hoisted(() => ({
   chaptersMock: vi.fn(),
   embeddingsMock: vi.fn(),
+  getJobMock: vi.fn(),
   mergeJobArtifactsMock: vi.fn(),
   metadataMock: vi.fn(),
+  persistedJobArtifacts: {} as Record<string, unknown>,
   subtitleTranslationMock: vi.fn(),
+  syncTranslatedSubtitlesToMuxMock: vi.fn(),
   transcribeMock: vi.fn(),
   updateJobMock: vi.fn(),
   updateStepStatusMock: vi.fn(),
@@ -40,12 +46,17 @@ vi.mock("@/services/subtitleTranslation", () => ({
   translateSubtitles: subtitleTranslationMock,
 }))
 
+vi.mock("@/services/mux-sync", () => ({
+  syncTranslatedSubtitlesToMux: syncTranslatedSubtitlesToMuxMock,
+}))
+
 vi.mock("@/lib/state", async () => {
   const actual =
     await vi.importActual<typeof import("@/lib/state")>("@/lib/state")
 
   return {
     ...actual,
+    getJob: getJobMock,
     mergeJobArtifacts: mergeJobArtifactsMock,
     updateJob: updateJobMock,
     updateStepStatus: updateStepStatusMock,
@@ -58,44 +69,52 @@ describe("runVideoEnrichment", () => {
   beforeEach(() => {
     chaptersMock.mockReset()
     embeddingsMock.mockReset()
+    getJobMock.mockReset()
     mergeJobArtifactsMock.mockReset()
     metadataMock.mockReset()
     subtitleTranslationMock.mockReset()
+    syncTranslatedSubtitlesToMuxMock.mockReset()
     transcribeMock.mockReset()
     updateJobMock.mockReset()
     updateStepStatusMock.mockReset()
+    for (const key of Object.keys(persistedJobArtifacts)) {
+      delete persistedJobArtifacts[key]
+    }
 
-    updateJobMock.mockImplementation(async (_id, updates) => ({
+    const buildJobRecord = (updates: Record<string, unknown> = {}) => ({
       id: "job-1",
       muxAssetId: "mux-1",
       muxPlaybackId: "play-1",
       languages: ["en"],
       options: {},
-      status: updates.status ?? "running",
+      status: (updates.status as string | undefined) ?? "running",
       retries: 0,
       createdAt: "",
       updatedAt: "",
-      artifacts: updates.artifacts ?? {},
+      artifacts: { ...persistedJobArtifacts },
       steps: [],
       errors: [],
-      currentStep: updates.currentStep,
-      startedAt: updates.startedAt,
-      completedAt: updates.completedAt,
-    }))
-    mergeJobArtifactsMock.mockImplementation(async (_id, artifacts) => ({
-      id: "job-1",
-      muxAssetId: "mux-1",
-      muxPlaybackId: "play-1",
-      languages: ["en"],
-      options: {},
-      status: "running",
-      retries: 0,
-      createdAt: "",
-      updatedAt: "",
-      artifacts,
-      steps: [],
-      errors: [],
-    }))
+      currentStep: updates.currentStep as string | undefined,
+      startedAt: updates.startedAt as string | undefined,
+      completedAt: updates.completedAt as string | undefined,
+    })
+
+    updateJobMock.mockImplementation(async (_id, updates) => {
+      if (updates.artifacts && typeof updates.artifacts === "object") {
+        Object.assign(persistedJobArtifacts, updates.artifacts)
+      }
+      return buildJobRecord(updates)
+    })
+    mergeJobArtifactsMock.mockImplementation(async (_id, artifacts) => {
+      Object.assign(persistedJobArtifacts, artifacts)
+      return buildJobRecord()
+    })
+    getJobMock.mockImplementation(async () => buildJobRecord())
+    syncTranslatedSubtitlesToMuxMock.mockResolvedValue({
+      comparisons: [],
+      overrideHistory: [],
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    })
     updateStepStatusMock.mockResolvedValue(null)
   })
 
@@ -134,6 +153,31 @@ describe("runVideoEnrichment", () => {
       chunks: [],
       artifactKeys: ["embeddings"],
     })
+    syncTranslatedSubtitlesToMuxMock.mockResolvedValue({
+      comparisons: [
+        {
+          artifactKey: "subtitles-en",
+          targetLanguage: "en",
+          muxTargetType: "text_track",
+          muxTargetKey: "en",
+          status: "synced",
+          explanation: "Synced en subtitles to Mux",
+          updatedAt: "2026-04-10T12:00:00.000Z",
+        },
+        {
+          artifactKey: "subtitles-fr",
+          targetLanguage: "fr",
+          muxTargetType: "text_track",
+          muxTargetKey: "fr",
+          status: "skipped_missing_generated_data",
+          explanation:
+            "Generated subtitle artifact is unavailable: bad glossary",
+          updatedAt: "2026-04-10T12:00:00.000Z",
+        },
+      ],
+      overrideHistory: [],
+      updatedAt: "2026-04-10T12:00:00.000Z",
+    })
 
     await expect(
       runVideoEnrichment({
@@ -165,13 +209,7 @@ describe("runVideoEnrichment", () => {
           startedAt: expect.any(String),
         }),
       ],
-      [
-        "job-1",
-        {
-          status: "running",
-          currentStep: "transcription",
-        },
-      ],
+      ["job-1", { status: "running", currentStep: "transcription" }],
       [
         "job-1",
         {
@@ -185,32 +223,33 @@ describe("runVideoEnrichment", () => {
           },
         },
       ],
+      ["job-1", { status: "running", currentStep: "translation" }],
+      ["job-1", { status: "running", currentStep: "chapters" }],
+      ["job-1", { status: "running", currentStep: "metadata" }],
+      ["job-1", { status: "running", currentStep: "embeddings" }],
+      ["job-1", { status: "running", currentStep: "mux_upload" }],
       [
         "job-1",
         {
-          status: "running",
-          currentStep: "translation",
-        },
-      ],
-      [
-        "job-1",
-        {
-          status: "running",
-          currentStep: "chapters",
-        },
-      ],
-      [
-        "job-1",
-        {
-          status: "running",
-          currentStep: "metadata",
-        },
-      ],
-      [
-        "job-1",
-        {
-          status: "running",
-          currentStep: "embeddings",
+          artifacts: expect.objectContaining({
+            materialization: {
+              kind: "metadata",
+              data: { sourceVideoCoreId: "video-1" },
+            },
+            transcript: { kind: "downloadable" },
+            subtitles: { kind: "downloadable" },
+            "subtitles-en": { kind: "downloadable" },
+            chapters: { kind: "downloadable" },
+            metadata: { kind: "downloadable" },
+            embeddings: { kind: "downloadable" },
+            muxSync: {
+              kind: "metadata",
+              data: expect.objectContaining({
+                comparisons: expect.any(Array),
+                updatedAt: "2026-04-10T12:00:00.000Z",
+              }),
+            },
+          }),
         },
       ],
       [
@@ -263,6 +302,27 @@ describe("runVideoEnrichment", () => {
         ],
       },
     ])
+    expect(updateStepStatusMock.mock.calls).toContainEqual([
+      "job-1",
+      "mux_upload",
+      "running",
+    ])
+    expect(updateStepStatusMock.mock.calls).toContainEqual([
+      "job-1",
+      "mux_upload",
+      "completed",
+    ])
+    expect(syncTranslatedSubtitlesToMuxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        translationResults: [
+          { lang: "en", status: "completed" },
+          { lang: "fr", status: "failed", error: "bad glossary" },
+        ],
+      }),
+    )
     expect(embeddingsMock).toHaveBeenCalledWith(
       "asset-1",
       expect.objectContaining({

--- a/apps/manager/src/workflows/videoEnrichment.ts
+++ b/apps/manager/src/workflows/videoEnrichment.ts
@@ -12,7 +12,9 @@
 // for durable execution. Each step is idempotent.
 
 import { buildDownloadableArtifactManifest } from "@/lib/job-artifacts"
+import { getMuxSyncReport, setMuxSyncReport } from "@/lib/mux-sync-report"
 import {
+  getJob,
   mergeArtifactEntries,
   mergeJobArtifacts,
   updateJob,
@@ -22,6 +24,7 @@ import type { WorkflowStepName } from "@/types/job"
 import type {
   JobArtifactManifest,
   JobStepDetails,
+  MuxSyncReport,
   TranslationLanguageResult,
 } from "@/types/job"
 import type { EmbeddingTranscriptInput } from "@/services/embeddings"
@@ -271,6 +274,48 @@ export async function runVideoEnrichment(
       throw embeddingsResult.reason
     }
 
+    await markStepRunning(input.jobId, "mux_upload")
+    try {
+      const currentJob = await getJob(input.jobId)
+      if (!currentJob) {
+        throw new Error(`Job ${input.jobId} not found while preparing Mux sync`)
+      }
+
+      const muxSyncReport = await stepMuxUpload({
+        jobId: input.jobId,
+        assetId: input.assetId,
+        muxAssetId: input.muxAssetId,
+        translationResults: translationResult.value.result,
+        previousReport: getMuxSyncReport(currentJob.artifacts),
+      })
+
+      const persisted = await updateJob(input.jobId, {
+        artifacts: setMuxSyncReport(currentJob.artifacts, muxSyncReport),
+      })
+      if (!persisted) {
+        throw new Error(
+          `Failed to persist Mux sync report for job ${input.jobId}`,
+        )
+      }
+
+      const failedComparisons = muxSyncReport.comparisons.filter(
+        (comparison) => comparison.status === "failed",
+      )
+      if (failedComparisons.length > 0) {
+        throw new Error(
+          failedComparisons
+            .map((comparison) => comparison.explanation)
+            .join("; "),
+        )
+      }
+
+      await markStepComplete(input.jobId, "mux_upload")
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error"
+      await markStepFailed(input.jobId, "mux_upload", msg)
+      throw err
+    }
+
     // Optional: Scene analysis (chapters → scene boundaries → OpenRouter + stills)
     // Uses the transcript already produced by enrichment, not a VTT fetch.
     // Error-isolated: scene analysis failure does not block core enrichment.
@@ -400,4 +445,16 @@ async function stepEmbeddings(
   "use step"
   const { generateEmbeddings } = await import("@/services/embeddings")
   return generateEmbeddings(assetId, transcript, { metadata })
+}
+
+async function stepMuxUpload(input: {
+  jobId: string
+  assetId: string
+  muxAssetId: string
+  translationResults: LanguageResult[]
+  previousReport?: MuxSyncReport
+}) {
+  "use step"
+  const { syncTranslatedSubtitlesToMux } = await import("@/services/mux-sync")
+  return syncTranslatedSubtitlesToMux(input)
 }

--- a/docs/plans/2026-04-09-feat-mux-sync-for-enrichment-outputs-plan.md
+++ b/docs/plans/2026-04-09-feat-mux-sync-for-enrichment-outputs-plan.md
@@ -1,50 +1,38 @@
 ---
-title: "feat: Sync enrichment outputs back to Mux when appropriate"
+title: "feat: Sync translated subtitles back to Mux"
 type: feat
-status: active
+status: completed
 date: 2026-04-09
 roadmap:
   - /docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md
 ---
 
-# feat: Sync enrichment outputs back to Mux when appropriate
+# feat: Sync translated subtitles back to Mux
 
 ## Overview
 
 Add a post-enrichment Mux sync phase that:
 
 - pushes generated translated subtitles into Mux as first-class text tracks when that language is missing on the target asset
-- pushes generated AI metadata into Mux only where Mux has a real first-class metadata field
-- explains in the job details when Forge did not sync because Mux already had data, or because Mux has no first-class sink for that artifact type
-- shows generated output side by side with the current Mux-side data when a sync was skipped because data already exists
-- allows an operator to override the Mux-side data with the newly generated data for supported artifact types
+- explains in the job details when Forge did not sync because Mux already had a subtitle track for that language
+- shows generated subtitle output side by side with the current Mux subtitle track when sync was skipped because data already exists
+- allows an operator to override an existing Mux subtitle track with the newly generated subtitle
 
-This plan is intentionally capability-aware. Based on current Mux docs and the current branch:
-
-- translated subtitles map cleanly to Mux text tracks
-- asset metadata maps only partially to Mux asset `meta`
-- chapters are supported by Mux Player at playback time, but are not stored as first-class asset-side records in the Video API
-- embeddings do not have a Mux-native first-class storage target
-
-So the implementation must separate:
-
-- artifacts that can be truly synced into Mux
-- artifacts that can only be explained, compared, and retained in Forge-managed storage
+This plan is intentionally subtitles-only. It does not sync metadata, chapters, embeddings, or any other enrichment artifact back to Mux.
 
 ## Problem Frame
 
-Today Forge creates and uses a stage Mux asset, but finished enrichment outputs remain Forge-managed artifacts:
+Today Forge creates and uses a stage Mux asset, but translated subtitle outputs remain Forge-managed artifacts:
 
 - translated subtitles are written to Forge artifact storage, not to Mux text tracks
-- metadata is written to Forge artifacts, not to Mux asset metadata
-- chapters are written to Forge artifacts and rendered from the job page only
-- embeddings are written to Forge artifacts only
+- when Mux already has a subtitle track for the same language, Forge does not persist comparison state explaining why sync was skipped
+- there is no operator flow to review generated subtitle output against the current Mux subtitle track and intentionally replace it
 
-That leaves three operator problems:
+The product outcome for this work is operational parity between Forge-generated translated subtitles and the Mux asset surface that playback and delivery tooling already reads. In v1, that means:
 
-1. Enrichment results are not reflected in Mux even when Mux has a native destination.
-2. When Mux already has data, Forge has no durable comparison state explaining why sync was skipped.
-3. There is no operator affordance to review generated output against current Mux-side state and force an overwrite when desired.
+- translated subtitle tracks become visible in Mux without a second manual upload path
+- operators can see exactly why Forge did or did not sync a subtitle track
+- operators can intentionally replace an existing Mux subtitle track after review
 
 ## Capability Reality
 
@@ -52,99 +40,78 @@ That leaves three operator problems:
 
 Relevant current code:
 
-- [mux.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/services/mux.ts)
-- [transcription.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/services/transcription.ts)
-- [subtitleTranslation/index.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/services/subtitleTranslation/index.ts)
-- [storage.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/services/storage.ts)
-- [videoEnrichment.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/workflows/videoEnrichment.ts)
-- [live-job-steps-table.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
+- [mux.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/services/mux.ts)
+- [transcription.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/services/transcription.ts)
+- [subtitleTranslation/index.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/services/subtitleTranslation/index.ts)
+- [storage.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/services/storage.ts)
+- [videoEnrichment.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/workflows/videoEnrichment.ts)
+- [live-job-steps-table.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
 
 Current behavior:
 
 - Forge creates a Mux asset and may request generated source subtitles
-- Forge stores generated artifacts locally or in Railway S3-compatible storage
-- the `mux_upload` workflow step exists in the job vocabulary and UI copy, but this branch does not yet implement a real sync phase for enrichment outputs
+- Forge stores generated subtitle artifacts locally or in Railway S3-compatible storage
+- the `mux_upload` workflow step exists in the job vocabulary and UI copy, but this branch does not yet implement a real sync phase for translated subtitles
 
 ### Current Mux capability constraints
 
 Current official Mux docs support:
 
 - subtitle tracks as asset text tracks via create-asset input or create-asset-track API
-- asset metadata fields `title`, `creator_id`, and `external_id`
-- chapters as Mux Player input, not as first-class asset-side persisted records
-- AI chaptering and embeddings workflows via `@mux/ai`, but not a first-class Mux Video write target for embeddings
+- track inspection on the asset so Forge can determine whether a target language already exists
 
 Sources:
 
 - [Add subtitles/captions to videos | Mux](https://support-agent.mux.com/docs/guides/add-subtitles-to-your-videos)
-- [Add metadata to your videos | Mux](https://www.mux.com/docs/guides/add-metadata-to-your-videos)
-- [Advanced usage of Mux Player | Mux](https://www.mux.com/docs/guides/player-advanced-usage)
-- [AI-generated chapters for your videos with Mux Player | Mux](https://www.mux.com/blog/ai-generated-chapters-for-your-videos-with-mux-player/)
-- [Use Mux in AI Workflows | Mux](https://www.mux.com/docs/integrations/ai-workflows)
 
 ### Implication
 
-The user-facing feature request needs one strategic adjustment:
+This plan only addresses the one enrichment artifact type that maps cleanly to a first-class Mux Video write target:
 
 - **Subtitles:** true native Mux sync
-- **Metadata:** partial native Mux sync only for fields Mux actually stores
-- **Chapters:** no true Mux asset-side sync today; compare/explain only unless product later accepts a Forge-managed playback layer
-- **Embeddings:** no Mux-native sync target; compare/explain only
 
-The plan below treats that as a product truth to surface clearly in the job UI, not something to hide.
+Everything else stays out of scope for this plan.
 
 ## Requirements Trace
 
-- R1. After enrichment completes, Forge must inspect the target Mux asset before attempting any write.
+- R1. After enrichment completes, Forge must inspect the target Mux asset before attempting any subtitle write.
 - R2. Forge must sync translated subtitle tracks into Mux only when the target language is missing on Mux.
-- R3. Forge must sync metadata only for fields that map to real Mux asset metadata fields.
-- R4. When Mux already has a supported destination populated, Forge must skip the write, persist the reason, and expose generated-vs-existing comparison data in the job details.
-- R5. Job details must include an explicit operator action to override Mux-side data with newly generated Forge data for supported artifact types.
-- R6. For artifact types that Mux does not support as first-class persisted asset data, job details must explain that no native sync target exists.
-- R7. The sync decision and comparison result must be durable in job state so the page does not recompute everything ad hoc on each refresh.
-- R8. The workflow and UI must distinguish:
+- R3. When Mux already has a subtitle track for that language, Forge must skip the write, persist the reason, and expose generated-vs-existing comparison data in the job details.
+- R4. Job details must include an explicit operator action to override an existing Mux subtitle track with the newly generated subtitle.
+- R5. The subtitle sync decision and comparison result must be durable in job state so the page does not recompute everything ad hoc on each refresh.
+- R6. The workflow and UI must distinguish:
   - `synced`
   - `skipped_missing_generated_data`
   - `skipped_existing_mux_data`
-  - `unsupported_mux_target`
   - `override_applied`
   - `failed`
-- R9. All new behavior must be added with red/green tests before implementation.
+- R7. All new behavior must be added with red/green tests before implementation.
 
 ## Scope Boundaries
 
 In scope:
 
-- a real post-enrichment `mux_upload` step
-- Mux asset inspection and sync decision logic
-- durable sync/comparison state on jobs
-- job details UI for explanation, side-by-side comparison, and override actions
+- a real post-enrichment `mux_upload` step for translated subtitles
+- Mux asset inspection and subtitle sync decision logic
+- durable subtitle sync/comparison state on jobs
+- job details UI for explanation, side-by-side subtitle comparison, and subtitle override actions
 - translated subtitle sync into Mux text tracks
-- mapped metadata sync into Mux asset metadata
-
-In scope with explicit limitation:
-
-- metadata only where the field has a real Mux destination
-- chapters and embeddings explanation/comparison state, not a fake native sync
 
 Out of scope:
 
-- redefining Mux’s API surface
-- pretending chapters or embeddings are first-class Mux asset records when they are not
+- metadata sync of any kind
+- chapters sync of any kind
+- embeddings sync of any kind
+- any generic “sync all enrichment outputs” abstraction
 - replacing Forge artifact storage as the system of record
 - adopting `@mux/ai` as part of this plan
 - CMS write-back or player-side rollout outside the manager job detail flow
 
 ## Product Decisions
 
-### 1. Treat syncability per artifact type, not as one global yes/no
+### 1. Subtitle sync is the only supported artifact type
 
-The job UI and workflow should not say “uploaded to Mux” as a blanket claim. It should report per artifact type:
-
-- what Forge generated
-- whether Mux has a native destination
-- whether Mux already had data
-- whether Forge synced it
+The job UI and workflow should not imply broader Mux sync coverage. This plan is only about translated subtitle tracks.
 
 ### 2. Subtitle sync is the first-class happy path
 
@@ -154,41 +121,9 @@ For each generated `subtitles-<lang>` artifact:
 - if Mux already has a track for that language, skip and persist comparison state
 - operator can force an override later
 
-### 3. Metadata sync is field-mapped, not artifact-shaped
+### 3. Existing Mux subtitle data wins by default
 
-Forge metadata artifacts currently contain richer structure than Mux asset metadata supports. Current Mux asset metadata fields are:
-
-- `title`
-- `creator_id`
-- `external_id`
-
-So this feature must decide an explicit mapping policy. Recommended initial policy:
-
-- sync generated `title` into Mux `meta.title`
-- do **not** overwrite `creator_id` or `external_id` with AI-generated content
-- treat generated `description`, `topics`, `speakers`, and `tags` as Forge-only for now, with an explanation that Mux has no equivalent first-class asset metadata field
-
-This keeps the sync honest and avoids abusing `creator_id` or `external_id`.
-
-### 4. Chapters are compare-only unless product later accepts a Forge playback layer
-
-Mux Player supports chapters passed into the player, but Mux Video does not expose a first-class asset-side persisted chapter record comparable to text tracks or asset meta.
-
-So for this plan:
-
-- show generated chapters in the job
-- show explanation that Mux has no first-class persisted chapter target on the asset
-- do not implement a fake “sync to Mux” step for chapters
-- do not expose an override button for chapters in v1
-
-### 5. Embeddings are compare/explain only
-
-Embeddings remain Forge-managed and should continue to live outside Mux.
-
-For this plan:
-
-- explain that Mux has no first-class embedding storage target
-- do not expose override-to-Mux for embeddings in v1
+Automatic sync should never overwrite an existing Mux subtitle track. Replacement requires an explicit operator action after review.
 
 ## Proposed User Flow
 
@@ -213,34 +148,24 @@ For this plan:
    - current Mux subtitle preview
 7. Operator can click `Override Mux data` to replace the existing French track.
 
-### Unsupported target path
-
-1. Workflow generates chapters and embeddings.
-2. `mux_upload` evaluates these artifact types.
-3. Forge marks them as `unsupported_mux_target`.
-4. Job details explain:
-   - chapters: `Mux Player supports chapters at playback time, but Mux Video has no first-class persisted chapter record on the asset`
-   - embeddings: `Mux has no native embedding storage target`
-
 ## Technical Approach
 
 ## Durable sync model
 
-Add a dedicated metadata artifact or expanded job-step details object to persist a `muxSyncReport`, for example:
+Persist a single canonical `muxSyncReport` in job artifacts, for example:
 
 ```ts
 type MuxSyncStatus =
   | "synced"
   | "skipped_existing_mux_data"
   | "skipped_missing_generated_data"
-  | "unsupported_mux_target"
   | "override_applied"
   | "failed"
 
 type MuxSyncComparison = {
   artifactKey: string
-  muxTargetType: "text_track" | "asset_meta_field" | "unsupported"
-  muxTargetKey?: string
+  muxTargetType: "text_track"
+  muxTargetKey: string
   status: MuxSyncStatus
   explanation: string
   generatedPreview?: unknown
@@ -251,39 +176,41 @@ type MuxSyncComparison = {
 
 Recommended storage location:
 
-- new `artifacts.muxSync` metadata entry for the cross-artifact report
-- additive `details` on the `mux_upload` step for high-level summary counts
+- `artifacts.muxSync` metadata entry as the canonical durable report
+- `mux_upload.details` may contain a derived summary only if the UI truly needs it, but it must be treated as a projection, not a second source of truth
 
 This keeps:
 
 - the full compare data durable and queryable
-- the step table concise
+- the step table concise without creating persistence drift
+
+Preview payload rules:
+
+- persist truncated subtitle previews only, never full subtitle bodies
+- preview payloads must be safe for the existing manager job-detail audience
+- if a preview cannot be safely truncated, persist a lightweight summary plus a link to the existing subtitle artifact instead
 
 ## Service boundaries
 
-Recommended new service layers:
+Recommended v1 service shape:
 
-- `services/mux-sync/read.ts`
-  - inspect current Mux text tracks and asset metadata
-- `services/mux-sync/plan.ts`
-  - compare generated artifacts against current Mux state
-  - produce the durable sync plan/report
-- `services/mux-sync/write.ts`
-  - apply missing writes
-  - apply override writes
-- `services/mux-sync/preview.ts`
-  - produce safe UI preview payloads for side-by-side compare
+- `services/mux-sync/index.ts`
+  - read current Mux subtitle tracks
+  - compare generated subtitle artifacts against current Mux state
+  - produce the canonical sync report
+  - apply missing subtitle writes and subtitle override writes
+- optional small helpers only where they clearly reduce duplication, for example preview shaping or Mux track normalization
 
-This avoids burying comparison logic directly inside [videoEnrichment.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/workflows/videoEnrichment.ts).
+This keeps v1 implementation right-sized while still avoiding burying comparison logic directly inside [videoEnrichment.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/workflows/videoEnrichment.ts).
 
 ## Job detail UI changes
 
 Recommended UI additions:
 
 - extend the step table or job detail page with a dedicated `Mux Sync` section
-- render per-artifact cards showing:
+- render compare cards for translated subtitle tracks that have generated-vs-Mux comparison data:
   - artifact name
-  - target type
+  - language
   - sync status
   - explanation
   - generated preview
@@ -292,126 +219,124 @@ Recommended UI additions:
 
 Likely entry points:
 
-- [live-job-detail-header.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/features/jobs/live-job-detail-header.tsx)
-- [live-job-steps-table.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
-- [app/dashboard/jobs/[id]/page.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/app/dashboard/jobs/[id]/page.tsx)
+- [live-job-detail-header.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/features/jobs/live-job-detail-header.tsx)
+- [live-job-steps-table.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
+- [app/dashboard/jobs/[id]/page.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/app/dashboard/jobs/[id]/page.tsx)
 
 ## Override action
 
 Recommended operator flow:
 
-- add a protected manager API endpoint to apply an override for a single supported target
-- require job id + artifact key + target descriptor
+- add a protected manager API endpoint to apply an override for a single subtitle target
+- require job id + artifact key + target language
+- authorize the endpoint to a narrow manager role that already has access to mutate enrichment outcomes
+- verify tenant/job ownership server-side before writing to Mux
 - endpoint re-reads Mux state before writing to avoid stale compare decisions
-- endpoint updates `muxSync` metadata and the `mux_upload` step details afterward
+- endpoint records an audit event for each override attempt
+- endpoint updates the canonical `muxSync` artifact report afterward
 
 Supported v1 override targets:
 
 - subtitle text tracks by language
-- `meta.title`
-
-Not supported in v1:
-
-- chapters
-- embeddings
-- AI-generated `description`, `topics`, `speakers`, `tags` into Mux, because there is no first-class destination
 
 ## Red/Green TDD Units
 
-- [ ] **Unit 1: Model current Mux state and sync decisions**
+- [x] **Unit 1: Model current Mux subtitle state and sync decisions**
 
-  **Goal:** Build a deterministic comparison layer before writing any Mux data.
+  **Goal:** Build a deterministic subtitle comparison layer before writing any Mux data.
 
   **Files:**
-  - Add: [apps/manager/src/services/mux-sync/read.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/services/mux-sync/read.ts)
-  - Add: [apps/manager/src/services/mux-sync/plan.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/services/mux-sync/plan.ts)
-  - Add tests for both
+  - Add: [apps/manager/src/services/mux-sync/index.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/services/mux-sync/index.ts)
+  - Add tests
 
   **Red**
   - failing tests for subtitle-track comparison:
     - missing track -> `synced` candidate
     - existing track -> `skipped_existing_mux_data`
-  - failing tests for metadata-field comparison:
-    - missing title -> `synced` candidate
-    - existing title -> `skipped_existing_mux_data`
-  - failing tests for chapters and embeddings:
-    - always `unsupported_mux_target`
+  - failing tests for missing generated subtitle data:
+    - missing artifact -> `skipped_missing_generated_data`
+  - failing tests proving preview payloads are truncated before persistence
 
   **Green**
-  - implement Mux-state reader and sync planner
-  - normalize Mux asset tracks and asset metadata into a stable compare model
+  - implement Mux subtitle-track reading, comparison, and report shaping
+  - normalize Mux subtitle track data into a stable compare model
 
   **Refactor**
   - keep comparison payloads compact enough for durable job storage
 
-- [ ] **Unit 2: Persist sync report into job state**
+- [x] **Unit 2: Persist subtitle sync report into job state**
 
-  **Goal:** Make sync decisions durable and visible on refresh.
+  **Goal:** Make subtitle sync decisions durable and visible on refresh.
 
   **Files:**
-  - [apps/manager/src/types/job.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/types/job.ts)
-  - [apps/manager/src/lib/state.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/lib/state.ts)
+  - [apps/manager/src/types/job.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/types/job.ts)
+  - [apps/manager/src/lib/state.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/lib/state.ts)
   - job/state tests
 
   **Red**
   - failing tests proving `muxSync` report round-trips through job reads
-  - failing tests proving `mux_upload` step details can summarize per-artifact results
+  - failing tests proving any derived `mux_upload` summary is computed from the canonical artifact report
+  - failing tests proving non-translation step details do not get dropped during hydration
 
   **Green**
-  - add durable job metadata shape and hydration
+  - add durable job metadata shape and hydration for `artifacts.muxSync`
+  - widen `JobStepDetails` only if a derived summary is required by the current UI
   - keep backwards compatibility for existing jobs without sync data
 
   **Refactor**
   - centralize the promoted fields so read-model drift does not recur
 
-- [ ] **Unit 3: Implement workflow-side sync for supported targets**
+- [x] **Unit 3: Implement workflow-side subtitle sync**
 
-  **Goal:** Make `mux_upload` a real workflow phase.
+  **Goal:** Make `mux_upload` a real subtitle workflow phase.
 
   **Files:**
-  - [apps/manager/src/workflows/videoEnrichment.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/workflows/videoEnrichment.ts)
-  - Add: `apps/manager/src/services/mux-sync/write.ts`
+  - [apps/cms/src/components/enrichment/job-step.json](/Users/o/.codex/worktrees/f618/forge/apps/cms/src/components/enrichment/job-step.json)
+  - regenerated GraphQL artifacts for the added CMS step enum
+  - [apps/manager/src/lib/workflow-steps.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/lib/workflow-steps.ts)
+  - [apps/manager/src/workflows/videoEnrichment.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/workflows/videoEnrichment.ts)
+  - [apps/manager/src/services/mux-sync/index.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/services/mux-sync/index.ts)
   - workflow tests
 
   **Red**
+  - failing test proving `mux_upload` exists as a persisted CMS-backed step for new jobs
   - failing workflow test for missing subtitle track leading to Mux write
   - failing workflow test for existing subtitle track leading to skip + explanation
-  - failing workflow test for metadata title sync
-  - failing workflow test for unsupported chapter/embedding targets producing explanations instead of fake writes
+  - failing workflow test for missing generated subtitle artifact leading to `skipped_missing_generated_data`
 
   **Green**
-  - insert `mux_upload` after artifact generation
+  - insert `mux_upload` after subtitle artifact generation
   - persist compare report before and after writes
   - mark step `completed` only after report persistence succeeds
 
   **Refactor**
   - keep sync behavior idempotent so reruns do not duplicate text tracks
 
-- [ ] **Unit 4: Add job detail compare UI**
+- [x] **Unit 4: Add job detail subtitle compare UI**
 
-  **Goal:** Let operators understand why data was or was not synced.
+  **Goal:** Let operators understand why subtitle data was or was not synced.
 
   **Files:**
-  - [apps/manager/src/features/jobs/live-job-detail-header.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/features/jobs/live-job-detail-header.tsx)
-  - [apps/manager/src/features/jobs/live-job-steps-table.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
-  - [apps/manager/src/app/globals.css](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/app/globals.css)
+  - [apps/manager/src/features/jobs/live-job-detail-header.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/features/jobs/live-job-detail-header.tsx)
+  - [apps/manager/src/features/jobs/live-job-steps-table.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
+  - [apps/manager/src/app/globals.css](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/app/globals.css)
   - UI tests
 
   **Red**
   - failing test for existing-data explanation rendering
-  - failing test for generated-vs-mux side-by-side preview rendering
-  - failing test that unsupported targets show explanation and no override button
+  - failing test for generated-vs-mux side-by-side subtitle preview rendering
+  - failing test that override appears only for subtitle tracks with replaceable Mux data
 
   **Green**
-  - render the compare cards and status copy
-  - wire download/view affordances for generated artifacts
+  - render compare cards for translated subtitle tracks
+  - wire download/view affordances for generated subtitle artifacts
 
   **Refactor**
   - keep the section readable on both small and wide layouts
 
-- [ ] **Unit 5: Add override action for supported targets**
+- [x] **Unit 5: Add subtitle override action**
 
-  **Goal:** Allow an operator to replace Mux-side data after review.
+  **Goal:** Allow an operator to replace a Mux subtitle track after review.
 
   **Files:**
   - Add manager override route, likely under `/api/jobs/:id/mux-sync/override`
@@ -420,8 +345,8 @@ Not supported in v1:
 
   **Red**
   - failing test for overriding an existing subtitle text track
-  - failing test for overriding `meta.title`
-  - failing test proving unsupported targets cannot be overridden
+  - failing test proving unauthorized roles cannot invoke override
+  - failing test proving override events are audited
 
   **Green**
   - implement override endpoint
@@ -433,37 +358,27 @@ Not supported in v1:
 
 ## Risks and Mitigations
 
-- **Risk: product language says “sync everything to Mux” but Mux does not support that uniformly.**
-  - Mitigation: encode per-artifact capability and explanation in the job model and UI.
-
-- **Risk: metadata sync silently abuses `creator_id` or `external_id`.**
-  - Mitigation: restrict v1 sync to `meta.title` unless a separate product decision explicitly redefines those fields.
-
 - **Risk: subtitle override duplicates tracks instead of replacing the intended one.**
   - Mitigation: implement explicit target selection and replacement semantics in the writer layer; do not rely on naive append-only behavior.
 
 - **Risk: compare payload becomes too large for durable job state.**
-  - Mitigation: persist compact previews only, not full artifact bodies; rely on existing artifact endpoints for the full generated output.
+  - Mitigation: persist compact previews only, not full subtitle bodies; rely on existing artifact endpoints for the full generated output.
 
-- **Risk: UI claims chapters or embeddings are “on Mux” when they are not.**
-  - Mitigation: require exact target-type labels and unsupported copy in tests.
+- **Risk: override writes expand the mutation surface without clear access control.**
+  - Mitigation: require narrow role-based authorization, tenant/job ownership checks, and audit logging for every override attempt.
 
 ## Acceptance Criteria
 
-- [ ] Enrichment jobs run a real `mux_upload` phase after artifact generation.
-- [ ] Missing translated subtitle tracks are pushed into Mux as text tracks.
-- [ ] Existing translated subtitle tracks are not overwritten automatically.
-- [ ] Job details explain when subtitle sync was skipped because Mux already had data.
-- [ ] Job details show generated subtitle preview side by side with current Mux subtitle preview before override.
-- [ ] Operators can override an existing Mux subtitle track with the newly generated subtitle.
-- [ ] Generated metadata sync only writes to fields that Mux natively supports.
-- [ ] Existing Mux metadata fields are not overwritten automatically.
-- [ ] Job details explain which metadata fields were syncable and which were Forge-only because Mux has no equivalent field.
-- [ ] Chapters are explicitly marked as having no first-class Mux asset sync target.
-- [ ] Embeddings are explicitly marked as having no first-class Mux sync target.
-- [ ] Unsupported targets do not show misleading override affordances.
-- [ ] Sync decisions survive page refresh and job polling because they are persisted in job state.
-- [ ] All new sync behavior is covered with red/green tests before implementation.
+- [x] Enrichment jobs run a real `mux_upload` phase after subtitle artifact generation.
+- [x] Missing translated subtitle tracks are pushed into Mux as text tracks.
+- [x] Existing translated subtitle tracks are not overwritten automatically.
+- [x] Missing generated subtitle artifacts are reported as `skipped_missing_generated_data`.
+- [x] Job details explain when subtitle sync was skipped because Mux already had data.
+- [x] Job details show generated subtitle preview side by side with current Mux subtitle preview before override.
+- [x] Operators can override an existing Mux subtitle track with the newly generated subtitle when authorized.
+- [x] Override writes require explicit authorization and are audit logged.
+- [x] Sync decisions survive page refresh and job polling because they are persisted in job state.
+- [x] All new subtitle sync behavior is covered with red/green tests before implementation.
 
 ## Verification
 
@@ -482,19 +397,15 @@ Focused manual QA:
 4. Run the same language again.
 5. Confirm the second job shows `skipped_existing_mux_data` with side-by-side comparison and no automatic overwrite.
 6. Trigger override and confirm the Mux-side track updates.
-7. Run a job with generated metadata where Mux has no title.
-8. Confirm `meta.title` syncs and Forge-only metadata fields are clearly labeled as unsupported by Mux.
-9. Confirm chapters and embeddings always show explanation-only state, never fake sync success.
+7. Run a job where the translated subtitle artifact is missing and confirm the job records `skipped_missing_generated_data`.
+8. Confirm an unauthorized operator cannot invoke override.
+9. Confirm successful override attempts are audit logged.
 
 ## References
 
-- [feat-031 AI Video Enrichment Pipeline](/Users/o/.codex/worktrees/1ec2/forge/docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md)
-- [mux.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/services/mux.ts)
-- [videoEnrichment.ts](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/workflows/videoEnrichment.ts)
-- [live-job-steps-table.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
-- [live-job-detail-header.tsx](/Users/o/.codex/worktrees/1ec2/forge/apps/manager/src/features/jobs/live-job-detail-header.tsx)
+- [feat-031 AI Video Enrichment Pipeline](/Users/o/.codex/worktrees/f618/forge/docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md)
+- [mux.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/services/mux.ts)
+- [videoEnrichment.ts](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/workflows/videoEnrichment.ts)
+- [live-job-steps-table.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/features/jobs/live-job-steps-table.tsx)
+- [live-job-detail-header.tsx](/Users/o/.codex/worktrees/f618/forge/apps/manager/src/features/jobs/live-job-detail-header.tsx)
 - [Add subtitles/captions to videos | Mux](https://support-agent.mux.com/docs/guides/add-subtitles-to-your-videos)
-- [Add metadata to your videos | Mux](https://www.mux.com/docs/guides/add-metadata-to-your-videos)
-- [Advanced usage of Mux Player | Mux](https://www.mux.com/docs/guides/player-advanced-usage)
-- [AI-generated chapters for your videos with Mux Player | Mux](https://www.mux.com/blog/ai-generated-chapters-for-your-videos-with-mux-player/)
-- [Use Mux in AI Workflows | Mux](https://www.mux.com/docs/integrations/ai-workflows)

--- a/packages/graphql/src/graphql-env.d.ts
+++ b/packages/graphql/src/graphql-env.d.ts
@@ -138,7 +138,7 @@ export type introspection_types = {
     'ENUM_BIBLEBOOK_SOURCE': { name: 'ENUM_BIBLEBOOK_SOURCE'; enumValues: 'core' | 'manager'; };
     'ENUM_BIBLECITATION_SOURCE': { name: 'ENUM_BIBLECITATION_SOURCE'; enumValues: 'core' | 'manager'; };
     'ENUM_CLOUDFLARER2_SOURCE': { name: 'ENUM_CLOUDFLARER2_SOURCE'; enumValues: 'core' | 'manager'; };
-    'ENUM_COMPONENTENRICHMENTJOBSTEP_NAME': { name: 'ENUM_COMPONENTENRICHMENTJOBSTEP_NAME'; enumValues: 'chapters' | 'embeddings' | 'metadata' | 'transcription' | 'translation'; };
+    'ENUM_COMPONENTENRICHMENTJOBSTEP_NAME': { name: 'ENUM_COMPONENTENRICHMENTJOBSTEP_NAME'; enumValues: 'chapters' | 'embeddings' | 'metadata' | 'mux_upload' | 'transcription' | 'translation'; };
     'ENUM_COMPONENTENRICHMENTJOBSTEP_STATUS': { name: 'ENUM_COMPONENTENRICHMENTJOBSTEP_STATUS'; enumValues: 'completed' | 'failed' | 'pending' | 'running' | 'skipped'; };
     'ENUM_COMPONENTSECTIONSCARD_VARIANT': { name: 'ENUM_COMPONENTSECTIONSCARD_VARIANT'; enumValues: 'default' | 'featured'; };
     'ENUM_COMPONENTSECTIONSCTA_VARIANT': { name: 'ENUM_COMPONENTSECTIONSCTA_VARIANT'; enumValues: 'primary' | 'secondary'; };


### PR DESCRIPTION
## What changed

This PR implements subtitle-only sync from enrichment outputs back into Mux.

It adds a real `mux_upload` workflow step that runs after subtitle generation, compares generated subtitle artifacts against existing Mux subtitle tracks, uploads missing translated subtitle tracks to Mux, and stores the canonical sync report in `artifacts.muxSync`.

It also adds:
- a signed artifact access path so Mux can fetch generated VTT files from manager
- a manual override API for replacing an existing Mux subtitle track with the generated one
- job detail UI for subtitle sync results, including generated/Mux previews and override actions
- resumable, non-destructive override handling so interrupted requests can be safely resumed
- the generated Strapi and GraphQL contract updates for the new `mux_upload` step enum value

## Why

The manager pipeline already produced translated subtitle artifacts, but there was no real sync phase to publish those translated subtitles back to Mux. Operators also needed visibility into what was synced and a safe manual path to override an existing Mux subtitle track when necessary.

## Impact

Users can now:
- finish an enrichment job and have translated subtitle tracks uploaded to Mux automatically when a target language is missing
- see per-language subtitle sync results in the job detail page
- manually override an existing Mux subtitle track with the generated subtitle artifact when the comparison allows it
- resume an interrupted override after the pending state becomes stale, without deleting the existing subtitle first

Scope is intentionally limited to subtitles only. No chapters, metadata, embeddings, or other artifacts are synced back to Mux in this PR.

## Validation

Automated:
- `pnpm --filter @forge/manager test`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/graphql generate`
- `pnpm --filter @forge/graphql typecheck`

Manual QA:
- ran a same-branch CMS + manager setup locally
- verified a real enrichment job completed with `mux_upload` as `completed`
- verified `artifacts.muxSync` recorded a `synced` result for `ru`
- verified manager served the signed subtitle artifact URL to Mux successfully
- verified the stage Mux asset contained the uploaded RU subtitle track
- verified the job detail UI rendered the `Mux Upload` step and `Subtitle sync results` with `Synced ru subtitles to Mux`

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Logs: search manager logs for `mux_upload`, `Subtitle override is already in progress`, `Subtitle override failed`, and `Mux API request failed`
  - Metrics/Dashboards: manager 5xx rate and enrichment-job failures involving `mux_upload`
- **Validation checks (queries/commands)**
  - Trigger a staging override on a job with `skipped_existing_mux_data` and confirm the report transitions to `override_applied`
  - If an override is intentionally interrupted after entering `override_pending`, confirm the button reappears after the stale window and the retry finishes successfully
- **Expected healthy behavior**
  - New subtitle uploads complete without duplicate lingering tracks
  - Override retries either finish the in-flight replacement or leave the original subtitle intact on failure
- **Failure signal(s) / rollback trigger**
  - Repeated `override_pending` entries that never recover, or assets left with missing subtitle tracks after a failed override
  - Immediate action: stop using manual override in production and revert the PR if overrides cannot be resumed safely
- **Validation window & owner**
  - Window: first staging verification after deploy, then first production operator use
  - Owner: manager / media-generation oncall

## Notes

True local end-to-end QA for this feature requires a public HTTPS manager URL so Mux can fetch the generated subtitle artifact.
