### PR TITLE
fix(manager): add language-first coverage empty state

### DIFF
--- a/apps/manager/AGENTS.md
+++ b/apps/manager/AGENTS.md
@@ -19,6 +19,10 @@ This app orchestrates AI video enrichment pipelines. Agents working here should 
 - If this app needs new CMS data: add content type in `apps/cms`, run codegen in `packages/graphql`, then use typed op here.
 - If enrichment results should be stored in Strapi: define a mutation in `packages/graphql`.
 
+## UI styling
+
+- Reuse existing app colors for manager UI work. Do not introduce new hex values, palette tokens, or one-off color variants unless the user explicitly approves a new color.
+
 ## Workflow steps checklist (when adding a new enrichment step)
 
 1. Add service client in `src/services/`

--- a/apps/manager/src/app/dashboard/coverage/page.tsx
+++ b/apps/manager/src/app/dashboard/coverage/page.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next"
 import { CoverageReportClient } from "@/features/coverage/coverage-report-client"
+import {
+  resolveRequestedLanguageIds,
+  type CoverageLanguageSearchParams,
+} from "@/features/coverage/language-selection"
 
 export const dynamic = "force-dynamic"
 
@@ -7,32 +11,13 @@ export const metadata: Metadata = {
   title: "Coverage -- Forge Manager",
 }
 
-type CoveragePageSearchParams = {
-  languageId?: string
-  languageIds?: string
-}
-
-function parseRequestedLanguageIds(raw: string | undefined): string[] {
-  if (!raw) return []
-  return [
-    ...new Set(
-      raw
-        .split(",")
-        .map((value) => value.trim())
-        .filter(Boolean),
-    ),
-  ]
-}
-
 export default async function CoveragePage({
   searchParams,
 }: {
-  searchParams?: Promise<CoveragePageSearchParams | undefined>
+  searchParams?: Promise<CoverageLanguageSearchParams | undefined>
 }) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined
-  const requestedLanguageIds = parseRequestedLanguageIds(
-    resolvedSearchParams?.languageIds ?? resolvedSearchParams?.languageId,
-  )
+  const requestedLanguageIds = resolveRequestedLanguageIds(resolvedSearchParams)
 
   return (
     <CoverageReportClient

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -2207,6 +2207,23 @@ html[data-coverage-loading="true"] .collections::after {
   outline: none;
 }
 
+.collection-empty-browse {
+  border: none;
+  background: transparent;
+  color: #756f63;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 4px 0;
+  transition: color 150ms ease;
+}
+
+.collection-empty-browse:hover,
+.collection-empty-browse:focus-visible {
+  color: #2a241b;
+  outline: none;
+}
+
 .tile {
   width: 22px;
   height: 22px;

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -1406,7 +1406,8 @@ body.jobs-standalone code {
   flex: 1;
 }
 
-.collections:has(.collection-empty--no-data) {
+.collections:has(.collection-empty--no-data),
+.collections:has(.collection-empty--language-required) {
   justify-content: center;
   align-items: center;
 }
@@ -2139,21 +2140,71 @@ html[data-coverage-loading="true"] .collections::after {
   gap: 8px;
 }
 
+.collection-empty--language-required {
+  width: 100%;
+  text-align: center;
+  padding: 72px 24px;
+  max-width: 560px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
 .collection-empty-title {
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--color-ink, #1e293b);
+  color: #2a241b;
 }
 
 .collection-empty-hint {
   font-size: 0.9rem;
-  color: var(--color-muted, #94a3b8);
+  color: #b0a496;
   max-width: 300px;
 }
 
 .collection-empty-icon {
   color: #c4b8ac;
   margin-bottom: 4px;
+}
+
+.collection-empty-icon--large {
+  color: #c4b8ac;
+  margin-bottom: 10px;
+}
+
+.collection-empty-presets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.collection-empty-preset {
+  border: 1px solid #d8cfbf;
+  background: #f8f4ee;
+  color: #3a342b;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 150ms ease,
+    border-color 150ms ease,
+    background 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.collection-empty-preset:hover,
+.collection-empty-preset:focus-visible {
+  background: #efe6d8;
+  border-color: #c9bea9;
+  box-shadow: 0 8px 18px rgba(12, 17, 29, 0.1);
+  transform: translateY(-1px);
+  outline: none;
 }
 
 .tile {

--- a/apps/manager/src/features/coverage/LanguageGeoSelector.tsx
+++ b/apps/manager/src/features/coverage/LanguageGeoSelector.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import { Languages, XCircle } from "lucide-react"
+import { normalizeCoverageLanguageSearchParams } from "./language-selection"
 import { apiFetch } from "@/lib/api-fetch"
 
 type LanguageOption = {
@@ -43,6 +44,7 @@ interface LanguageGeoSelectorProps {
   className?: string
   attentionRequired?: boolean
   attentionRequestKey?: number
+  openRequestKey?: number
 }
 
 function normalizeText(value: string): string {
@@ -95,6 +97,7 @@ export function LanguageGeoSelector({
   className,
   attentionRequired = false,
   attentionRequestKey = 0,
+  openRequestKey = 0,
 }: LanguageGeoSelectorProps) {
   const pathname = usePathname()
   const router = useRouter()
@@ -458,14 +461,10 @@ export function LanguageGeoSelector({
 
   const applyUrlParams = (nextLanguageIds: string[]) => {
     const currentQuery = searchParams?.toString() ?? ""
-    const nextParams = new URLSearchParams(currentQuery)
-    nextParams.delete("refresh")
-
-    if (nextLanguageIds.length > 0) {
-      nextParams.set("languageId", nextLanguageIds.join(","))
-    } else {
-      nextParams.delete("languageId")
-    }
+    const nextParams = normalizeCoverageLanguageSearchParams(
+      currentQuery,
+      nextLanguageIds,
+    )
 
     const queryString = nextParams.toString()
     const nextUrl = queryString ? `${pathname}?${queryString}` : pathname
@@ -555,6 +554,19 @@ export function LanguageGeoSelector({
       })
     }
   }, [attentionRequired, attentionRequestKey, isPickerExpanded])
+
+  useEffect(() => {
+    if (openRequestKey <= 0) return
+
+    setIsPickerExpanded(true)
+    window.requestAnimationFrame(() => {
+      primaryActionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      })
+      searchInputRef.current?.focus()
+    })
+  }, [openRequestKey])
 
   const hasLanguageData =
     options.length > 0 || (geoData?.languages.length ?? 0) > 0

--- a/apps/manager/src/features/coverage/coverage-empty-state.test.ts
+++ b/apps/manager/src/features/coverage/coverage-empty-state.test.ts
@@ -1,0 +1,26 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+import { LanguageSelectionEmptyState } from "@/features/coverage/coverage-empty-state"
+
+describe("coverage-empty-state", () => {
+  it("keeps a general language-browsing action alongside presets", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(LanguageSelectionEmptyState, {
+        reportLabel: "Subtitles",
+        presets: [
+          { id: "lang-en", label: "English" },
+          { id: "lang-fr", label: "French" },
+        ],
+        onSelectPreset: vi.fn(),
+        onBrowseAllLanguages: vi.fn(),
+      }),
+    )
+
+    expect(markup).toContain("Select a language to begin")
+    expect(markup).toContain("Browse all languages")
+    expect(markup).toContain("English")
+    expect(markup).toContain("French")
+  })
+})

--- a/apps/manager/src/features/coverage/coverage-empty-state.tsx
+++ b/apps/manager/src/features/coverage/coverage-empty-state.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { Languages } from "lucide-react"
+
+import type { LanguagePreset } from "./language-selection"
+
+export function LanguageSelectionEmptyState({
+  reportLabel,
+  presets,
+  onSelectPreset,
+  onBrowseAllLanguages,
+}: {
+  reportLabel: string
+  presets: LanguagePreset[]
+  onSelectPreset: (languageId: string) => void
+  onBrowseAllLanguages: () => void
+}) {
+  return (
+    <div className="collection-empty collection-empty--language-required">
+      <Languages
+        size={64}
+        strokeWidth={1.5}
+        aria-hidden="true"
+        className="collection-empty-icon collection-empty-icon--large"
+      />
+      <span className="collection-empty-title">Select a language to begin</span>
+      <span className="collection-empty-hint">
+        Choose a language to view {reportLabel.toLowerCase()} coverage across
+        the media library.
+      </span>
+      {presets.length > 0 ? (
+        <div className="collection-empty-presets" aria-label="Language presets">
+          {presets.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              className="collection-empty-preset"
+              onClick={() => onSelectPreset(preset.id)}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        className="collection-empty-browse"
+        onClick={onBrowseAllLanguages}
+      >
+        Browse all languages
+      </button>
+    </div>
+  )
+}

--- a/apps/manager/src/features/coverage/coverage-report-client.tsx
+++ b/apps/manager/src/features/coverage/coverage-report-client.tsx
@@ -9,10 +9,16 @@ import React, {
   useState,
 } from "react"
 import { createPortal } from "react-dom"
-import { ServerOff } from "lucide-react"
+import { Languages, ServerOff } from "lucide-react"
 import { useRouter } from "next/navigation"
 
 import { LanguageGeoSelector } from "./LanguageGeoSelector"
+import {
+  hasSelectedLanguages as hasSelectedLanguagesInSelection,
+  resolveLanguagePresets,
+  type LanguageOption,
+  type LanguagePreset,
+} from "./language-selection"
 import {
   getVideoQaSelectionDisabledReason,
   isEnrichActionReady,
@@ -85,12 +91,6 @@ type ClientCollection = {
   label: string
   labelDisplay: string
   videos: ClientVideo[]
-}
-
-type LanguageOption = {
-  id: string
-  englishLabel: string
-  nativeLabel: string
 }
 
 // ---------------------------------------------------------------------------
@@ -802,6 +802,46 @@ function ReportTypeSelector({
   )
 }
 
+function LanguageSelectionEmptyState({
+  reportLabel,
+  presets,
+  onSelectPreset,
+}: {
+  reportLabel: string
+  presets: LanguagePreset[]
+  onSelectPreset: (languageId: string) => void
+}) {
+  return (
+    <div className="collection-empty collection-empty--language-required">
+      <Languages
+        size={64}
+        strokeWidth={1.5}
+        aria-hidden="true"
+        className="collection-empty-icon collection-empty-icon--large"
+      />
+      <span className="collection-empty-title">Select a language to begin</span>
+      <span className="collection-empty-hint">
+        Choose a language to view {reportLabel.toLowerCase()} coverage across
+        the media library.
+      </span>
+      {presets.length > 0 ? (
+        <div className="collection-empty-presets" aria-label="Language presets">
+          {presets.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              className="collection-empty-preset"
+              onClick={() => onSelectPreset(preset.id)}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Collection card
 // ---------------------------------------------------------------------------
@@ -1164,6 +1204,7 @@ export function CoverageReportClient({
   }, [videoCollections, initialJobs, reportType])
   const selectedLanguageIds = initialSelectedLanguageIds
   const languageOptions = initialLanguages
+  const [languageCatalog, setLanguageCatalog] = useState<LanguageOption[]>([])
   const [languageNameMap, setLanguageNameMap] = useState<Map<string, string>>(
     new Map(),
   )
@@ -1174,12 +1215,13 @@ export function CoverageReportClient({
         const response = await apiFetch("/api/languages")
         if (!response.ok) return
         const payload = (await response.json()) as {
-          languages: Array<{ id: string; englishLabel: string }>
+          languages: LanguageOption[]
         }
         const map = new Map<string, string>()
         for (const lang of payload.languages ?? []) {
           map.set(lang.id, lang.englishLabel)
         }
+        setLanguageCatalog(payload.languages ?? [])
         setLanguageNameMap(map)
       } catch {
         // ignore — will fall back to IDs
@@ -1208,6 +1250,8 @@ export function CoverageReportClient({
   const [searchQuery, setSearchQuery] = useState("")
   const [typeFilter, setTypeFilter] = useState("all")
   const [interactionMode, setInteractionMode] = useSessionMode("explore")
+  const hasSelectedLanguages =
+    hasSelectedLanguagesInSelection(selectedLanguageIds)
   const isSelectMode = interactionMode === "select"
   const selectableVideoIds = useMemo(
     () =>
@@ -1281,6 +1325,13 @@ export function CoverageReportClient({
 
   // Fetch video coverage data from proxy API when languages change
   useEffect(() => {
+    if (!hasSelectedLanguages) {
+      setVideoCollections([])
+      setVideoCollectionsLoadFailed(false)
+      setIsLoadingVideos(false)
+      return
+    }
+
     const controller = new AbortController()
     setIsLoadingVideos(true)
     setVideoCollectionsLoadFailed(false)
@@ -1329,7 +1380,7 @@ export function CoverageReportClient({
     })()
 
     return () => controller.abort()
-  }, [selectedLanguageIds])
+  }, [hasSelectedLanguages, selectedLanguageIds])
 
   // Fetch latest coverage snapshot once on mount for instant header bar
   useEffect(() => {
@@ -1491,6 +1542,36 @@ export function CoverageReportClient({
   const totalCollections = visibleCollections.length
   const showCoverageControls =
     gatewayConfigured && !errorMessage && !videoCollectionsLoadFailed
+  const showCollectionControls = showCoverageControls && hasSelectedLanguages
+
+  const presetLanguages = useMemo<LanguagePreset[]>(
+    () => resolveLanguagePresets(languageCatalog),
+    [languageCatalog],
+  )
+
+  const applySelectedLanguages = useCallback(
+    (languageIds: string[]) => {
+      const nextParams = new URLSearchParams(
+        typeof window === "undefined" ? "" : window.location.search,
+      )
+      nextParams.delete("refresh")
+
+      if (languageIds.length > 0) {
+        nextParams.set("languageId", languageIds.join(","))
+      } else {
+        nextParams.delete("languageId")
+      }
+
+      const queryString = nextParams.toString()
+      const nextUrl = queryString
+        ? `/dashboard/coverage?${queryString}`
+        : "/dashboard/coverage"
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- typed routes does not accept dynamic query strings here
+      router.push(nextUrl as any)
+    },
+    [router],
+  )
 
   const headerSlot = hydrated
     ? document.getElementById("report-header-slot")
@@ -1553,7 +1634,7 @@ export function CoverageReportClient({
         </section>
       )}
 
-      {showCoverageControls && (
+      {showCollectionControls && (
         <section className="mode-panel">
           {hydrated && (
             <ModeToggle
@@ -1570,7 +1651,7 @@ export function CoverageReportClient({
         </section>
       )}
 
-      {showCoverageControls && (
+      {showCollectionControls && (
         <section className="search-filter-card">
           <div className="search-filter-row">
             <div className="collection-search-shell">
@@ -1658,6 +1739,16 @@ export function CoverageReportClient({
         </div>
       ) : errorMessage ? (
         <div className="report-error">{errorMessage}</div>
+      ) : !hasSelectedLanguages ? (
+        <div className="collections">
+          <LanguageSelectionEmptyState
+            reportLabel={reportConfig.label}
+            presets={presetLanguages}
+            onSelectPreset={(languageId) =>
+              applySelectedLanguages([languageId])
+            }
+          />
+        </div>
       ) : videoCollectionsLoadFailed ? (
         <div className="collections">
           <div className="collection-empty collection-empty--no-data">

--- a/apps/manager/src/features/coverage/coverage-report-client.tsx
+++ b/apps/manager/src/features/coverage/coverage-report-client.tsx
@@ -9,12 +9,14 @@ import React, {
   useState,
 } from "react"
 import { createPortal } from "react-dom"
-import { Languages, ServerOff } from "lucide-react"
+import { ServerOff } from "lucide-react"
 import { useRouter } from "next/navigation"
 
+import { LanguageSelectionEmptyState } from "./coverage-empty-state"
 import { LanguageGeoSelector } from "./LanguageGeoSelector"
 import {
   hasSelectedLanguages as hasSelectedLanguagesInSelection,
+  normalizeCoverageLanguageSearchParams,
   resolveLanguagePresets,
   type LanguageOption,
   type LanguagePreset,
@@ -802,46 +804,6 @@ function ReportTypeSelector({
   )
 }
 
-function LanguageSelectionEmptyState({
-  reportLabel,
-  presets,
-  onSelectPreset,
-}: {
-  reportLabel: string
-  presets: LanguagePreset[]
-  onSelectPreset: (languageId: string) => void
-}) {
-  return (
-    <div className="collection-empty collection-empty--language-required">
-      <Languages
-        size={64}
-        strokeWidth={1.5}
-        aria-hidden="true"
-        className="collection-empty-icon collection-empty-icon--large"
-      />
-      <span className="collection-empty-title">Select a language to begin</span>
-      <span className="collection-empty-hint">
-        Choose a language to view {reportLabel.toLowerCase()} coverage across
-        the media library.
-      </span>
-      {presets.length > 0 ? (
-        <div className="collection-empty-presets" aria-label="Language presets">
-          {presets.map((preset) => (
-            <button
-              key={preset.id}
-              type="button"
-              className="collection-empty-preset"
-              onClick={() => onSelectPreset(preset.id)}
-            >
-              {preset.label}
-            </button>
-          ))}
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
 // ---------------------------------------------------------------------------
 // Collection card
 // ---------------------------------------------------------------------------
@@ -1245,6 +1207,10 @@ export function CoverageReportClient({
     languageSelectorFocusRequestCount,
     setLanguageSelectorFocusRequestCount,
   ] = useState(0)
+  const [
+    languageSelectorOpenRequestCount,
+    setLanguageSelectorOpenRequestCount,
+  ] = useState(0)
   const hydrated = useHydrated()
   const reportConfig = REPORT_CONFIG[reportType]
   const [searchQuery, setSearchQuery] = useState("")
@@ -1551,16 +1517,10 @@ export function CoverageReportClient({
 
   const applySelectedLanguages = useCallback(
     (languageIds: string[]) => {
-      const nextParams = new URLSearchParams(
+      const nextParams = normalizeCoverageLanguageSearchParams(
         typeof window === "undefined" ? "" : window.location.search,
+        languageIds,
       )
-      nextParams.delete("refresh")
-
-      if (languageIds.length > 0) {
-        nextParams.set("languageId", languageIds.join(","))
-      } else {
-        nextParams.delete("languageId")
-      }
 
       const queryString = nextParams.toString()
       const nextUrl = queryString
@@ -1629,6 +1589,7 @@ export function CoverageReportClient({
               options={languageOptions}
               attentionRequired={languageSelectionRequired}
               attentionRequestKey={languageSelectorFocusRequestCount}
+              openRequestKey={languageSelectorOpenRequestCount}
             />
           </div>
         </section>
@@ -1746,6 +1707,9 @@ export function CoverageReportClient({
             presets={presetLanguages}
             onSelectPreset={(languageId) =>
               applySelectedLanguages([languageId])
+            }
+            onBrowseAllLanguages={() =>
+              setLanguageSelectorOpenRequestCount((prev) => prev + 1)
             }
           />
         </div>

--- a/apps/manager/src/features/coverage/language-selection.test.ts
+++ b/apps/manager/src/features/coverage/language-selection.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest"
 
 import {
   hasSelectedLanguages,
+  normalizeCoverageLanguageSearchParams,
+  parseRequestedLanguageIds,
   resolveLanguagePresets,
+  resolveRequestedLanguageIds,
   type LanguageOption,
 } from "@/features/coverage/language-selection"
 
@@ -38,5 +41,50 @@ describe("language-selection", () => {
     expect(resolveLanguagePresets(languages)).toEqual([
       { id: "lang-en", label: "English" },
     ])
+  })
+
+  it("parses and deduplicates requested language ids", () => {
+    expect(parseRequestedLanguageIds(" lang-en,lang-fr,lang-en ,, ")).toEqual([
+      "lang-en",
+      "lang-fr",
+    ])
+  })
+
+  it("prefers the canonical languageId param while still supporting legacy languageIds", () => {
+    expect(
+      resolveRequestedLanguageIds({
+        languageId: "lang-es",
+        languageIds: "lang-fr,lang-ar",
+      }),
+    ).toEqual(["lang-es"])
+
+    expect(
+      resolveRequestedLanguageIds({
+        languageIds: "lang-fr,lang-ar",
+      }),
+    ).toEqual(["lang-fr", "lang-ar"])
+  })
+
+  it("normalizes coverage language query params to the canonical singular key", () => {
+    const normalized = normalizeCoverageLanguageSearchParams(
+      "origin=collection&refresh=1&languageIds=lang-fr&languageId=lang-ar",
+      ["lang-en", "lang-es"],
+    )
+
+    expect(normalized.get("origin")).toBe("collection")
+    expect(normalized.get("refresh")).toBeNull()
+    expect(normalized.get("languageIds")).toBeNull()
+    expect(normalized.get("languageId")).toBe("lang-en,lang-es")
+  })
+
+  it("removes both language query keys when the selection is cleared", () => {
+    const normalized = normalizeCoverageLanguageSearchParams(
+      "languageIds=lang-fr&languageId=lang-ar&mediaType=series",
+      [],
+    )
+
+    expect(normalized.get("mediaType")).toBe("series")
+    expect(normalized.get("languageIds")).toBeNull()
+    expect(normalized.get("languageId")).toBeNull()
   })
 })

--- a/apps/manager/src/features/coverage/language-selection.test.ts
+++ b/apps/manager/src/features/coverage/language-selection.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  hasSelectedLanguages,
+  resolveLanguagePresets,
+  type LanguageOption,
+} from "@/features/coverage/language-selection"
+
+describe("language-selection", () => {
+  it("treats an empty language selection as the empty state trigger", () => {
+    expect(hasSelectedLanguages([])).toBe(false)
+    expect(hasSelectedLanguages(["lang-en"])).toBe(true)
+  })
+
+  it("resolves the coverage language presets from available languages", () => {
+    const languages: LanguageOption[] = [
+      { id: "lang-ar", englishLabel: "Arabic", nativeLabel: "العربية" },
+      { id: "lang-en", englishLabel: "English", nativeLabel: "English" },
+      { id: "lang-es", englishLabel: "Spanish", nativeLabel: "Español" },
+      { id: "lang-fr", englishLabel: "French", nativeLabel: "Français" },
+      { id: "lang-pt", englishLabel: "Portuguese", nativeLabel: "Português" },
+    ]
+
+    expect(resolveLanguagePresets(languages)).toEqual([
+      { id: "lang-en", label: "English" },
+      { id: "lang-fr", label: "French" },
+      { id: "lang-es", label: "Spanish" },
+      { id: "lang-ar", label: "Modern Standard Arabic" },
+    ])
+  })
+
+  it("skips presets that are not present in the fetched language catalog", () => {
+    const languages: LanguageOption[] = [
+      { id: "lang-en", englishLabel: "English", nativeLabel: "English" },
+      { id: "lang-sw", englishLabel: "Swahili", nativeLabel: "Kiswahili" },
+    ]
+
+    expect(resolveLanguagePresets(languages)).toEqual([
+      { id: "lang-en", label: "English" },
+    ])
+  })
+})

--- a/apps/manager/src/features/coverage/language-selection.ts
+++ b/apps/manager/src/features/coverage/language-selection.ts
@@ -9,6 +9,11 @@ export type LanguagePreset = {
   label: string
 }
 
+export type CoverageLanguageSearchParams = {
+  languageId?: string
+  languageIds?: string
+}
+
 const LANGUAGE_PRESET_DEFINITIONS: Array<{
   label: string
   aliases: string[]
@@ -38,6 +43,44 @@ const LANGUAGE_PRESET_DEFINITIONS: Array<{
 
 export function hasSelectedLanguages(languageIds: string[]): boolean {
   return languageIds.length > 0
+}
+
+export function parseRequestedLanguageIds(raw: string | undefined): string[] {
+  if (!raw) return []
+
+  return [
+    ...new Set(
+      raw
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  ]
+}
+
+export function resolveRequestedLanguageIds(
+  searchParams: CoverageLanguageSearchParams | undefined,
+): string[] {
+  return parseRequestedLanguageIds(
+    searchParams?.languageId ?? searchParams?.languageIds,
+  )
+}
+
+export function normalizeCoverageLanguageSearchParams(
+  currentQuery: string,
+  languageIds: string[],
+): URLSearchParams {
+  const nextParams = new URLSearchParams(currentQuery)
+
+  nextParams.delete("refresh")
+  nextParams.delete("languageId")
+  nextParams.delete("languageIds")
+
+  if (languageIds.length > 0) {
+    nextParams.set("languageId", languageIds.join(","))
+  }
+
+  return nextParams
 }
 
 export function resolveLanguagePresets(

--- a/apps/manager/src/features/coverage/language-selection.ts
+++ b/apps/manager/src/features/coverage/language-selection.ts
@@ -1,0 +1,60 @@
+export type LanguageOption = {
+  id: string
+  englishLabel: string
+  nativeLabel: string
+}
+
+export type LanguagePreset = {
+  id: string
+  label: string
+}
+
+const LANGUAGE_PRESET_DEFINITIONS: Array<{
+  label: string
+  aliases: string[]
+}> = [
+  {
+    label: "English",
+    aliases: ["english"],
+  },
+  {
+    label: "French",
+    aliases: ["french"],
+  },
+  {
+    label: "Spanish",
+    aliases: ["spanish", "castilian"],
+  },
+  {
+    label: "Modern Standard Arabic",
+    aliases: [
+      "modern standard arabic",
+      "arabic standard",
+      "standard arabic",
+      "arabic",
+    ],
+  },
+] as const
+
+export function hasSelectedLanguages(languageIds: string[]): boolean {
+  return languageIds.length > 0
+}
+
+export function resolveLanguagePresets(
+  languages: LanguageOption[],
+): LanguagePreset[] {
+  const normalizedOptions = languages.map((language) => ({
+    ...language,
+    normalizedLabel: language.englishLabel.trim().toLowerCase(),
+  }))
+
+  const presets = LANGUAGE_PRESET_DEFINITIONS.map((preset) => {
+    const match = normalizedOptions.find((language) =>
+      preset.aliases.includes(language.normalizedLabel),
+    )
+
+    return match ? { id: match.id, label: preset.label } : null
+  })
+
+  return presets.filter((preset): preset is LanguagePreset => preset != null)
+}

--- a/docs/solutions/integration-issues/manager-coverage-language-first-empty-state-20260410.md
+++ b/docs/solutions/integration-issues/manager-coverage-language-first-empty-state-20260410.md
@@ -1,0 +1,72 @@
+---
+title: "Manager Coverage Language-First Empty State"
+category: integration-issues
+date: 2026-04-10
+severity: medium
+tags:
+  - manager
+  - coverage
+  - empty-state
+  - query-params
+  - language-selection
+affected_components:
+  - apps/manager/src/app/dashboard/coverage/page.tsx
+  - apps/manager/src/features/coverage/LanguageGeoSelector.tsx
+  - apps/manager/src/features/coverage/coverage-empty-state.tsx
+  - apps/manager/src/features/coverage/coverage-report-client.tsx
+  - apps/manager/src/features/coverage/language-selection.ts
+related_docs:
+  - docs/solutions/integration-issues/manager-coverage-dashboard-review-regression-cleanup.md
+  - docs/solutions/platform/restoring-upstream-ui-verbatim.md
+---
+
+# Manager Coverage Language-First Empty State
+
+## Problem
+
+The coverage dashboard rendered the full collection list even when no language was selected, which made the page feel broken and diluted the point of the report. After introducing preset language actions, a second regression appeared: legacy URLs using `languageIds` could override new preset clicks that wrote `languageId`.
+
+## Root Cause
+
+Two small mismatches compounded:
+
+1. The page had no dedicated "choose a language first" state, so the default view looked like empty or irrelevant report data instead of an intentional entry point.
+2. Coverage routing accepted both `languageId` and `languageIds`, but new navigation paths only wrote the singular key while some reads still preferred the plural key.
+
+## Solution
+
+### Add a real language-first entry state
+
+Render a dedicated empty state when no language is selected:
+
+- hide collection cards and collection filters until the user chooses a language
+- offer preset shortcuts for English, French, Spanish, and Modern Standard Arabic
+- keep a "Browse all languages" action that opens the existing selector instead of trapping the user in presets only
+- reuse existing app palette values rather than introducing one-off colors
+
+### Normalize coverage language query params
+
+Move the parsing and write logic into shared helpers:
+
+- parse incoming language ids once
+- prefer `languageId` as the canonical query param
+- still accept legacy `languageIds` links
+- delete both keys before writing the next selection so stale params cannot win
+
+## Prevention
+
+1. When a report depends on required context, give it an explicit first-run state instead of rendering partial report chrome with misleading data.
+2. If old and new query params must coexist temporarily, centralize parsing and normalization in one helper used by every read and write path.
+3. For parity work, reuse existing palette tokens or established literal colors already present in the app unless product explicitly asks for a new color.
+
+## Verification
+
+- `pnpm --filter @forge/manager lint`
+- `pnpm --filter @forge/manager typecheck`
+- `pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts src/features/coverage/coverage-empty-state.test.ts`
+
+## Related References
+
+- `apps/manager/src/features/coverage/coverage-empty-state.tsx`
+- `apps/manager/src/features/coverage/language-selection.ts`
+- `apps/manager/src/features/coverage/LanguageGeoSelector.tsx`


### PR DESCRIPTION
## Summary

Add a language-first empty state to the manager coverage dashboard so collections and filters stay hidden until a language is selected. This also adds preset shortcuts, preserves access to the full language picker, reuses existing palette colors, and normalizes legacy `languageIds` URLs so preset clicks cannot be overridden by stale query params.

## Work Loop

- [ ] `ce:plan` done
- [x] `ce:work` done
- [x] `ce:review` done
- [x] `ce:compound` done

## Notes

- Compound note: `docs/solutions/integration-issues/manager-coverage-language-first-empty-state-20260410.md`
- Verification:
  - `pnpm --filter @forge/manager lint`
  - `pnpm --filter @forge/manager typecheck`
  - `pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts src/features/coverage/coverage-empty-state.test.ts`
