### PR TITLE
[codex] Polish CMS admin branding

### DIFF
--- a/apps/cms/src/admin/styles/admin.css
+++ b/apps/cms/src/admin/styles/admin.css
@@ -32,6 +32,10 @@ nav:has(img[alt="Application logo"]) > :has(img[alt="Application logo"]) img {
   border-radius: 0 !important;
 }
 
+main img[aria-hidden="true"][alt=""] {
+  height: 5.4rem !important;
+}
+
 nav[aria-label="Content Manager"] {
   border-right: none !important;
 }
@@ -78,7 +82,8 @@ nav[aria-label="Pagination"] a[aria-current]:hover {
   box-shadow: none !important;
 }
 
-img[src*="%234945FF"] {
+img[src*="%234945FF"],
+[role="alert"][aria-live="assertive"] > img[aria-hidden="true"] {
   filter: invert(32%) sepia(94%) saturate(4457%) hue-rotate(336deg)
     brightness(98%) contrast(91%) !important;
 }

--- a/docs/roadmap/platform/feat-078-cms-admin-loader-brand-red.md
+++ b/docs/roadmap/platform/feat-078-cms-admin-loader-brand-red.md
@@ -1,0 +1,49 @@
+---
+id: "feat-078"
+title: "CMS Admin Loader Brand Red"
+owner: "vlad"
+priority: "P2"
+status: "complete"
+start_date: "2026-04-10"
+duration: 1
+depends_on:
+  - "feat-047"
+blocks: []
+tags:
+  - "cms"
+  - "branding"
+---
+
+## Problem
+
+The Strapi CMS admin loading indicator still renders in the default Strapi purple/blue even though the admin shell already uses Jesus Film brand tokens. Editors should see the same `#EF3340` brand red during CMS loading states.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/admin/styles/admin.css` — existing CMS admin CSS overrides for Strapi default visuals
+2. `apps/cms/src/admin/app.tsx` — current Strapi admin theme configuration, already using `#EF3340` for primary tokens
+3. `docs/roadmap/platform/feat-047-cms-admin-branding-refresh.md` — prior CMS admin branding work this follows
+
+## Grep These
+
+- `img[src*="%234945FF"]` in `apps/cms/src/admin/styles/admin.css` — existing image filter for Strapi purple assets
+- `role="alert"` and `aria-live="assertive"` in Strapi design-system Loader markup — loader structure to target
+- `primary500` in `apps/cms/src/admin/app.tsx` — existing brand red theme token override
+
+## What To Build
+
+1. Add a targeted CSS selector for the Strapi design-system Loader image in `apps/cms/src/admin/styles/admin.css`.
+2. Reuse the existing red filter that maps Strapi purple assets to Jesus Film brand red.
+3. Leave `apps/cms/src/admin/app.tsx` unchanged because the theme tokens already use `#EF3340`.
+
+## Constraints
+
+- Do NOT replace Strapi package assets.
+- Do NOT change CMS content types, GraphQL schema, or editor workflows.
+- Do NOT broaden this into a redesign of CMS admin chrome or layout.
+
+## Verification
+
+- `cd apps/cms && pnpm build`
+- `cd apps/cms && pnpm lint`
+- Manually verify the CMS admin loader is brand red `#EF3340`, not Strapi purple/blue.

--- a/docs/roadmap/platform/feat-079-cms-auth-logo-size.md
+++ b/docs/roadmap/platform/feat-079-cms-auth-logo-size.md
@@ -1,0 +1,43 @@
+---
+id: "feat-079"
+title: "CMS Auth Logo Size"
+owner: "vlad"
+priority: "P2"
+status: "complete"
+start_date: "2026-04-10"
+duration: 1
+depends_on:
+  - "feat-047"
+blocks: []
+tags:
+  - "cms"
+  - "branding"
+---
+
+## Problem
+
+The Jesus Film logo on Strapi CMS unauthenticated pages is too large for the login layout. It should be 25% smaller while preserving the existing CMS branding and layout.
+
+## Entry Points - Read These First
+
+1. `apps/cms/src/admin/styles/admin.css` — existing CMS admin styling overrides
+2. `apps/cms/src/admin/app.tsx` — current Strapi admin auth logo configuration
+3. `@strapi/admin` `UnauthenticatedLogo` component — renders the auth logo at `7.2rem` high
+
+## What To Build
+
+1. Add a targeted CSS override for the Strapi unauthenticated auth logo.
+2. Reduce the logo height from `7.2rem` to `5.4rem`, making it 25% smaller.
+3. Keep the menu/sidebar logo size unchanged.
+
+## Constraints
+
+- Do NOT replace logo assets.
+- Do NOT change CMS content types, GraphQL schema, or editor workflows.
+- Do NOT redesign the login form or surrounding auth layout.
+
+## Verification
+
+- `cd apps/cms && pnpm build`
+- `cd apps/cms && pnpm lint`
+- Verify `/admin/auth/login` shows the auth logo 25% smaller and the CMS menu logo remains unchanged.


### PR DESCRIPTION
## Summary
- change the Strapi admin loader from the default purple to Jesus Film brand red
- reduce the unauthenticated CMS auth logo by 25% on login pages without affecting the sidebar logo
- add roadmap tickets for both CMS admin branding adjustments and mark them complete

## Why
Strapi's admin loader ships with a hard-coded SVG color, so the existing theme token override was not enough to brand the loading state. The auth logo also rendered larger than desired on login pages.

## Validation
- cd apps/cms && pnpm build
- cd apps/cms && pnpm lint
- confirmed the compiled admin CSS includes the loader override and 5.4rem auth logo height
- verified the local CMS admin responds at http://localhost:1537/admin
