### PR TITLE
chore(cms): rename transcript embeddings table

### DIFF
--- a/.context/compound-engineering/todos/024-ready-p2-rename-video-embeddings-to-transcript-embeddings.md
+++ b/.context/compound-engineering/todos/024-ready-p2-rename-video-embeddings-to-transcript-embeddings.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p2
 issue_id: "024"
 tags: [cms, embeddings, database, naming, transcript]
@@ -65,7 +65,7 @@ The current CMS table and code path use `video_embeddings` for transcript chunk 
 
 Do not fold the physical table rename into the current transcript sync PR. For the current PR, use Option 2 only where it reduces review ambiguity: keep `video_embeddings` as the physical table name, but make manager-facing copy/docs say "transcript embeddings" clearly.
 
-Implement Option 1 in a dedicated follow-up PR. Rename `video_embeddings` to `transcript_embeddings` across the CMS SQL/indexer path and manager-facing docs/copy, with a safe rename/create fallback for existing local/staging databases.
+Implement Option 1 in a dedicated follow-up PR. Rename `video_embeddings` to `transcript_embeddings` across the CMS SQL/indexer path and manager-facing docs/copy.
 
 ## Technical Details
 
@@ -83,8 +83,9 @@ Implement Option 1 in a dedicated follow-up PR. Rename `video_embeddings` to `tr
 
 **Database changes (if any):**
 
-- Add a safe table rename path from `video_embeddings` to `transcript_embeddings` if the old table exists.
-- Ensure indexes and foreign-key naming remain clear after the rename.
+- Rename the transcript chunk pgvector table definition to `transcript_embeddings`.
+- Rename the transcript HNSW index to `transcript_embeddings_embedding_idx`.
+- Update snapshot/import helpers and docs to use the new table name.
 
 ## Resources
 
@@ -94,11 +95,11 @@ Implement Option 1 in a dedicated follow-up PR. Rename `video_embeddings` to `tr
 
 ## Acceptance Criteria
 
-- [ ] The transcript chunk embedding table is named `transcript_embeddings`.
-- [ ] CMS indexing, summary, stats, and sync code no longer query `video_embeddings`.
-- [ ] Tests cover the renamed table path.
-- [ ] Docs/copy distinguish transcript embeddings from scene embeddings and future video profile embeddings.
-- [ ] Existing environments with `video_embeddings` can migrate safely.
+- [x] The transcript chunk embedding table is named `transcript_embeddings`.
+- [x] CMS indexing, summary, stats, and sync code no longer query `video_embeddings`.
+- [x] Tests cover the renamed table path.
+- [x] Docs/copy distinguish transcript embeddings from scene embeddings and future video profile embeddings.
+- [x] Snapshot/import/tooling references use `transcript_embeddings`.
 
 ## Work Log
 
@@ -129,3 +130,17 @@ Implement Option 1 in a dedicated follow-up PR. Rename `video_embeddings` to `tr
 **Learnings:**
 
 - The safest sequence is scope clarity first, database rename second, scene-enrichment integration third.
+
+### 2026-04-10 - Completed
+
+**By:** Codex
+
+**Actions:**
+
+- Renamed the CMS transcript chunk pgvector table references from `video_embeddings` to `transcript_embeddings`.
+- Updated CMS bootstrap SQL, transcript embedding indexer queries, snapshot/import helpers, roadmap docs, and best-practice docs.
+- Added focused CMS bootstrap coverage for the renamed table and reran the transcript embedding/controller/bootstrap tests with `pnpm dlx vitest@2.1.9`.
+
+**Learnings:**
+
+- The rename is mechanically small in code, but the semantic-search and roadmap docs need to move with it or they keep reintroducing the old mental model.

--- a/apps/cms/src/api/coverage-snapshot/services/coverage-snapshot.ts
+++ b/apps/cms/src/api/coverage-snapshot/services/coverage-snapshot.ts
@@ -36,6 +36,19 @@ type SnapshotData = {
   languageCoverage: LanguageCoverageEntry[]
 }
 
+type CoverageSnapshotDocument = {
+  documentId: string
+  date?: string
+}
+
+type CoverageSnapshotDocumentService = {
+  findFirst: (
+    params: Record<string, unknown>,
+  ) => Promise<CoverageSnapshotDocument | null>
+  update: (params: Record<string, unknown>) => Promise<CoverageSnapshotDocument>
+  create: (params: Record<string, unknown>) => Promise<CoverageSnapshotDocument>
+}
+
 type MediaCoverageRow = {
   language_id: number
   language_core_id: string
@@ -141,6 +154,14 @@ async function queryMediaCoverage(
   }
 }
 
+function coverageSnapshotDocs(
+  strapi: Core.Strapi,
+): CoverageSnapshotDocumentService {
+  return strapi.documents(
+    "api::coverage-snapshot.coverage-snapshot" as never,
+  ) as unknown as CoverageSnapshotDocumentService
+}
+
 async function computeSnapshot(strapi: Core.Strapi): Promise<SnapshotData> {
   const knex = strapi.db.connection
 
@@ -231,7 +252,7 @@ async function createSnapshot(strapi: Core.Strapi): Promise<void> {
   )
 
   // Idempotent upsert: find existing snapshot for today, update or create
-  const docs = strapi.documents("api::coverage-snapshot.coverage-snapshot")
+  const docs = coverageSnapshotDocs(strapi)
   const existing = await docs.findFirst({
     filters: { date: todayStr },
   })

--- a/apps/cms/src/api/data-snapshot/services/snapshot-tables.ts
+++ b/apps/cms/src/api/data-snapshot/services/snapshot-tables.ts
@@ -32,7 +32,7 @@ export const SNAPSHOT_TABLES = [
   "coverage_snapshots",
   // pgvector embedding tables (feat-041, feat-044)
   "scene_embeddings",
-  "video_embeddings",
+  "transcript_embeddings",
   // Strapi component tables (used by content types above)
   "components_video_cloudflare_images",
   "components_video_variant_downloads",

--- a/apps/cms/src/api/embedding/services/indexer.test.ts
+++ b/apps/cms/src/api/embedding/services/indexer.test.ts
@@ -57,13 +57,13 @@ function createStrapiForIfMissingTest(options: {
     }
 
     if (
-      normalized.includes("FROM video_embeddings") &&
+      normalized.includes("FROM transcript_embeddings") &&
       normalized.includes("ORDER BY chunk_index ASC")
     ) {
       expect(bindings).toEqual([42])
 
       const selectCount = queryLog.filter((entry) =>
-        entry.includes("FROM video_embeddings"),
+        entry.includes("FROM transcript_embeddings"),
       ).length
 
       if (selectCount === 1) {
@@ -73,12 +73,12 @@ function createStrapiForIfMissingTest(options: {
       return { rows: options.appliedRowsAfterWrite ?? [] }
     }
 
-    if (normalized.startsWith("DELETE FROM video_embeddings")) {
+    if (normalized.startsWith("DELETE FROM transcript_embeddings")) {
       expect(bindings).toEqual([42])
       return { rows: [] }
     }
 
-    if (normalized.startsWith("INSERT INTO video_embeddings")) {
+    if (normalized.startsWith("INSERT INTO transcript_embeddings")) {
       return { rows: [] }
     }
 
@@ -150,13 +150,13 @@ function createStrapiForOverrideTest(options: {
     }
 
     if (
-      normalized.includes("FROM video_embeddings") &&
+      normalized.includes("FROM transcript_embeddings") &&
       normalized.includes("ORDER BY chunk_index ASC")
     ) {
       expect(bindings).toEqual([42])
 
       const selectCount = queryLog.filter((entry) =>
-        entry.includes("FROM video_embeddings"),
+        entry.includes("FROM transcript_embeddings"),
       ).length
 
       if (selectCount === 1) {
@@ -166,12 +166,12 @@ function createStrapiForOverrideTest(options: {
       return { rows: options.appliedRowsAfterWrite }
     }
 
-    if (normalized.startsWith("DELETE FROM video_embeddings")) {
+    if (normalized.startsWith("DELETE FROM transcript_embeddings")) {
       expect(bindings).toEqual([42])
       return { rows: [] }
     }
 
-    if (normalized.startsWith("INSERT INTO video_embeddings")) {
+    if (normalized.startsWith("INSERT INTO transcript_embeddings")) {
       return { rows: [] }
     }
 
@@ -246,10 +246,10 @@ describe("syncVideoEmbeddings if_missing", () => {
     })
     expect(queryLog).toEqual([
       "SELECT id FROM videos WHERE id = ? FOR UPDATE",
-      "SELECT chunk_index, chunk_text, model FROM video_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
-      "DELETE FROM video_embeddings WHERE video_id = ?",
-      "INSERT INTO video_embeddings (video_id, chunk_index, chunk_text, embedding, model) VALUES (?, ?, ?, ?::vector, ?), (?, ?, ?, ?::vector, ?)",
-      "SELECT chunk_index, chunk_text, model FROM video_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
+      "SELECT chunk_index, chunk_text, model FROM transcript_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
+      "DELETE FROM transcript_embeddings WHERE video_id = ?",
+      "INSERT INTO transcript_embeddings (video_id, chunk_index, chunk_text, embedding, model) VALUES (?, ?, ?, ?::vector, ?), (?, ?, ?, ?::vector, ?)",
+      "SELECT chunk_index, chunk_text, model FROM transcript_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
     ])
   })
 
@@ -289,7 +289,7 @@ describe("syncVideoEmbeddings if_missing", () => {
     })
     expect(queryLog).toEqual([
       "SELECT id FROM videos WHERE id = ? FOR UPDATE",
-      "SELECT chunk_index, chunk_text, model FROM video_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
+      "SELECT chunk_index, chunk_text, model FROM transcript_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
     ])
   })
 })
@@ -393,10 +393,10 @@ describe("syncVideoEmbeddings override", () => {
     })
     expect(queryLog).toEqual([
       "SELECT id FROM videos WHERE id = ? FOR UPDATE",
-      "SELECT chunk_index, chunk_text, model FROM video_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
-      "DELETE FROM video_embeddings WHERE video_id = ?",
-      "INSERT INTO video_embeddings (video_id, chunk_index, chunk_text, embedding, model) VALUES (?, ?, ?, ?::vector, ?), (?, ?, ?, ?::vector, ?)",
-      "SELECT chunk_index, chunk_text, model FROM video_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
+      "SELECT chunk_index, chunk_text, model FROM transcript_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
+      "DELETE FROM transcript_embeddings WHERE video_id = ?",
+      "INSERT INTO transcript_embeddings (video_id, chunk_index, chunk_text, embedding, model) VALUES (?, ?, ?, ?::vector, ?), (?, ?, ?, ?::vector, ?)",
+      "SELECT chunk_index, chunk_text, model FROM transcript_embeddings WHERE video_id = ? ORDER BY chunk_index ASC",
     ])
   })
 })

--- a/apps/cms/src/api/embedding/services/indexer.ts
+++ b/apps/cms/src/api/embedding/services/indexer.ts
@@ -236,7 +236,7 @@ async function readVideoEmbeddingRowsFromExecutor(
   const result = (await executor.raw(
     `
       SELECT chunk_index, chunk_text, model
-      FROM video_embeddings
+      FROM transcript_embeddings
       WHERE video_id = ?
       ORDER BY chunk_index ASC
     `,
@@ -297,7 +297,7 @@ async function replaceVideoEmbeddings(
   chunks: ChunkInput[],
   model: string,
 ): Promise<void> {
-  await executor.raw("DELETE FROM video_embeddings WHERE video_id = ?", [
+  await executor.raw("DELETE FROM transcript_embeddings WHERE video_id = ?", [
     videoId,
   ])
 
@@ -319,7 +319,7 @@ async function replaceVideoEmbeddings(
     }
 
     await executor.raw(
-      `INSERT INTO video_embeddings (video_id, chunk_index, chunk_text, embedding, model)
+      `INSERT INTO transcript_embeddings (video_id, chunk_index, chunk_text, embedding, model)
        VALUES ${placeholders.join(", ")}`,
       bindings,
     )
@@ -444,7 +444,7 @@ export async function getVideoEmbeddingStats(
     SELECT
       COUNT(DISTINCT video_id)::text AS total_videos,
       COUNT(*)::text AS total_chunks
-    FROM video_embeddings
+    FROM transcript_embeddings
   `)
   const row = result.rows[0]
   return {

--- a/apps/cms/src/bootstrap/ensure-pgvector.test.ts
+++ b/apps/cms/src/bootstrap/ensure-pgvector.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ensurePgvector } from "./ensure-pgvector"
+
+function createStrapi(rawImpl?: (sql: string) => Promise<unknown>) {
+  const raw = vi.fn(
+    rawImpl ??
+      (async () => {
+        return undefined
+      }),
+  )
+
+  return {
+    strapi: {
+      db: {
+        connection: {
+          raw,
+        },
+      },
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+    raw,
+  }
+}
+
+describe("ensurePgvector", () => {
+  it("creates transcript embeddings tables and indexes", async () => {
+    const { strapi, raw } = createStrapi()
+
+    await ensurePgvector(strapi as Parameters<typeof ensurePgvector>[0])
+
+    const queries = raw.mock.calls.map(([sql]) =>
+      sql.replace(/\s+/g, " ").trim(),
+    )
+
+    expect(queries[0]).toBe("CREATE EXTENSION IF NOT EXISTS vector")
+    expect(queries).toContain(
+      "CREATE TABLE IF NOT EXISTS transcript_embeddings ( id SERIAL PRIMARY KEY, video_id INTEGER NOT NULL REFERENCES videos(id) ON DELETE CASCADE, chunk_index INTEGER NOT NULL, chunk_text TEXT NOT NULL, embedding vector(1536) NOT NULL, model VARCHAR(100) NOT NULL DEFAULT 'text-embedding-3-small', created_at TIMESTAMP DEFAULT NOW(), UNIQUE(video_id, chunk_index) )",
+    )
+    expect(queries).toContain(
+      "CREATE INDEX IF NOT EXISTS transcript_embeddings_embedding_idx ON transcript_embeddings USING hnsw (embedding vector_cosine_ops)",
+    )
+    expect(queries.some((query) => query.includes("video_embeddings"))).toBe(
+      false,
+    )
+  })
+
+  it("returns early when pgvector extension is unavailable", async () => {
+    const extensionError = new Error("extension unavailable")
+    const { strapi, raw } = createStrapi(async () => {
+      throw extensionError
+    })
+
+    await ensurePgvector(strapi as Parameters<typeof ensurePgvector>[0])
+
+    expect(raw).toHaveBeenCalledTimes(1)
+    expect(strapi.log.warn).toHaveBeenCalledWith(
+      "[pgvector] Extension not available, embedding features disabled: extension unavailable",
+    )
+    expect(strapi.log.info).not.toHaveBeenCalled()
+  })
+})

--- a/apps/cms/src/bootstrap/ensure-pgvector.ts
+++ b/apps/cms/src/bootstrap/ensure-pgvector.ts
@@ -28,9 +28,9 @@ export async function ensurePgvector(strapi: Core.Strapi): Promise<void> {
   strapi.log.info("[pgvector] Extension enabled")
 
   try {
-    // 2. video_embeddings — transcript chunk embeddings (feat-009)
+    // 2. transcript_embeddings — transcript chunk embeddings (feat-009)
     await knex.raw(`
-      CREATE TABLE IF NOT EXISTS video_embeddings (
+      CREATE TABLE IF NOT EXISTS transcript_embeddings (
         id          SERIAL PRIMARY KEY,
         video_id    INTEGER NOT NULL REFERENCES videos(id) ON DELETE CASCADE,
         chunk_index INTEGER NOT NULL,
@@ -43,8 +43,8 @@ export async function ensurePgvector(strapi: Core.Strapi): Promise<void> {
     `)
 
     await knex.raw(`
-      CREATE INDEX IF NOT EXISTS video_embeddings_embedding_idx
-        ON video_embeddings USING hnsw (embedding vector_cosine_ops)
+      CREATE INDEX IF NOT EXISTS transcript_embeddings_embedding_idx
+        ON transcript_embeddings USING hnsw (embedding vector_cosine_ops)
     `)
 
     // 3. scene_embeddings — multimodal scene analysis embeddings (feat-041)

--- a/apps/cms/src/scripts/data-import.ts
+++ b/apps/cms/src/scripts/data-import.ts
@@ -170,7 +170,7 @@ async function decompress(gzPath: string, outPath: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /** Embedding tables that require pgvector to restore. */
-const PGVECTOR_TABLES = new Set(["scene_embeddings", "video_embeddings"])
+const PGVECTOR_TABLES = new Set(["scene_embeddings", "transcript_embeddings"])
 
 /**
  * Checks if the local PostgreSQL instance supports pgvector.

--- a/docs/plans/2026-04-09-feat-sync-enrichment-embeddings-into-cms-vector-index-plan.md
+++ b/docs/plans/2026-04-09-feat-sync-enrichment-embeddings-into-cms-vector-index-plan.md
@@ -13,7 +13,7 @@ roadmap:
 
 ## Overview
 
-Sync completed enrichment-job transcript embeddings into the CMS-owned `video_embeddings` pgvector index, using the same product policy we want for broader CMS sync. In this slice, `video_embeddings` remains the physical table name, but the domain concept is transcript chunk embeddings:
+Sync completed enrichment-job transcript embeddings into the CMS-owned `transcript_embeddings` pgvector index, using the same product policy we want for broader CMS sync. In this slice, `transcript_embeddings` remains the physical table name, but the domain concept is transcript chunk embeddings:
 
 - automatically index only when CMS is missing transcript embeddings for the video
 - never overwrite an existing CMS transcript vector index automatically
@@ -33,14 +33,14 @@ The manager enrichment pipeline now produces a richer `embeddings.json` artifact
 
 But the transcript chunk vectors still stop at artifact storage. The CMS already has the correct persistence layer for transcript search:
 
-- `video_embeddings`
+- `transcript_embeddings`
 - the `embedding/index` CMS endpoint
 - `feat-010` semantic search plans that query transcript chunks from pgvector
 
 Without a sync path:
 
 1. newly enriched videos are not searchable through the CMS transcript vector index
-2. the existing `video_embeddings` infrastructure and `feat-010` remain disconnected from manager enrich jobs
+2. the existing `transcript_embeddings` infrastructure and `feat-010` remain disconnected from manager enrich jobs
 3. operators cannot tell whether CMS is already indexed, newly indexed, or skipped for safety
 
 ## Found Brainstorm
@@ -78,7 +78,7 @@ The artifact is already strong enough to drive CMS transcript indexing without r
 
 [indexer.ts](/Users/o/.codex/worktrees/8e02/forge/apps/cms/src/api/embedding/services/indexer.ts) and [embedding.ts](/Users/o/.codex/worktrees/8e02/forge/apps/cms/src/api/embedding/controllers/embedding.ts) already provide:
 
-- `video_embeddings` table
+- `transcript_embeddings` table
 - delete-then-insert transactional indexing
 - validation for 1536-dimension chunk vectors
 - `POST /api/embedding/index`
@@ -98,12 +98,12 @@ This is the correct CMS home for transcript embeddings today.
 
 [feat-010-semantic-search-api.md](/Users/o/.codex/worktrees/8e02/forge/docs/roadmap/content-discovery/feat-010-semantic-search-api.md) assumes:
 
-- `video_embeddings` contains transcript chunk rows
+- `transcript_embeddings` contains transcript chunk rows
 - `chunk_text` is returned as the user-facing search snippet
 
 That makes two constraints explicit:
 
-1. we should not change `video_embeddings` away from transcript chunks in this slice
+1. we should not change `transcript_embeddings` away from transcript chunks in this slice
 2. we should not stuff `metadataEmbedding` into this same table just to say it is “synced”
 
 ### Manager-to-CMS integration path already exists
@@ -143,7 +143,7 @@ Use one canonical resolver everywhere in this slice:
 
 ### 1. Sync transcript chunk embeddings only in v1
 
-This plan syncs only `EmbeddingsResult.chunks[]` into `video_embeddings`.
+This plan syncs only `EmbeddingsResult.chunks[]` into `transcript_embeddings`.
 
 It does **not** sync:
 
@@ -459,7 +459,7 @@ Red:
 Green:
 
 - implement video resolution by `documentId`
-- return compact index summaries from `video_embeddings` in the `POST /api/embedding/index` response
+- return compact index summaries from `transcript_embeddings` in the `POST /api/embedding/index` response
 - return `hasEmbeddings`, not ambiguous `exists`
 - compute and return `contentFingerprint`
 - use the published-only resolver consistently
@@ -580,13 +580,13 @@ Refactor:
   - trigger a stale compare (for example by changing CMS rows before override) and confirm the route returns `409 stale_compare`
   - if a transcript exceeds 500 chunks, confirm the job records `unsupported` with `chunk_limit_exceeded`
 - DB verification:
-  - `video_embeddings` row count increases for the first run
+  - `transcript_embeddings` row count increases for the first run
   - chunk text remains searchable and aligned with the generated artifact
 
 ## Out of Scope
 
 - syncing `metadataEmbedding` into CMS
-- redesigning `video_embeddings` to hold multiple embedding kinds
+- redesigning `transcript_embeddings` to hold multiple embedding kinds
 - syncing scene embeddings as part of the enrichment-job flow
 - exposing raw vector values in the manager UI
 - changing the `feat-010` semantic search query contract in this slice
@@ -595,7 +595,7 @@ Refactor:
 
 If this lands cleanly, the next likely follow-ups are:
 
-1. rename `video_embeddings` to `transcript_embeddings` in a dedicated database/copy cleanup PR
+1. rename the transcript chunk table to `transcript_embeddings` in a dedicated database/copy cleanup PR
 2. integrate scene embedding indexing into the enrichment scene-analysis path
 3. design a CMS home for future video profile / metadata-derived embeddings only after the retrieval strategy is clear
 4. add a bulk-ingest story if transcript chunk counts above 500 become common in production

--- a/docs/plans/2026-04-09-feat-sync-enrichment-results-into-cms-models-plan.md
+++ b/docs/plans/2026-04-09-feat-sync-enrichment-results-into-cms-models-plan.md
@@ -71,7 +71,7 @@ The repo also already has a CMS-owned persistence layer for embeddings, but it i
 - [pgvector best-practice doc](/Users/o/.codex/worktrees/1ec2/forge/docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md)
 - [embedding indexer](/Users/o/.codex/worktrees/1ec2/forge/apps/cms/src/api/embedding/services/indexer.ts)
 
-That matters because “the right CMS destination” for embeddings is the existing `video_embeddings` table, not a new Strapi collection type.
+That matters because “the right CMS destination” for embeddings is the existing `transcript_embeddings` table, not a new Strapi collection type.
 
 ### Current enrichment result shapes
 
@@ -94,14 +94,14 @@ That matters because “the right CMS destination” for embeddings is the exist
 
 ### The right CMS home for each job outcome
 
-| Job outcome                             | Right CMS destination                                       | Existing or new                                        | Why                                                                    |
-| --------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
-| Source subtitles / translated subtitles | `VideoSubtitle` + optional `CloudflareR2` asset relation    | Existing                                               | Subtitle tracks already have a publishable CMS model                   |
-| Plain transcript JSON                   | **No new content type**; keep as job artifact               | No new type                                            | It duplicates the subtitle cue model and is mainly workflow/debug data |
-| Metadata title / description            | `Video`                                                     | Existing                                               | These fields already exist and are editorially meaningful              |
-| Topics / tags / speakers                | `Keyword` with `type` discriminator                         | Extend existing                                        | Avoids creating three premature content types                          |
-| Chapters                                | `VideoChapter`                                              | **New**                                                | No current chapter model exists                                        |
-| Embeddings                              | `video_embeddings` pgvector table via CMS embedding service | Existing CMS-owned persistence, **not** a content type | This is already the correct storage shape                              |
+| Job outcome                             | Right CMS destination                                            | Existing or new                                        | Why                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Source subtitles / translated subtitles | `VideoSubtitle` + optional `CloudflareR2` asset relation         | Existing                                               | Subtitle tracks already have a publishable CMS model                   |
+| Plain transcript JSON                   | **No new content type**; keep as job artifact                    | No new type                                            | It duplicates the subtitle cue model and is mainly workflow/debug data |
+| Metadata title / description            | `Video`                                                          | Existing                                               | These fields already exist and are editorially meaningful              |
+| Topics / tags / speakers                | `Keyword` with `type` discriminator                              | Extend existing                                        | Avoids creating three premature content types                          |
+| Chapters                                | `VideoChapter`                                                   | **New**                                                | No current chapter model exists                                        |
+| Embeddings                              | `transcript_embeddings` pgvector table via CMS embedding service | Existing CMS-owned persistence, **not** a content type | This is already the correct storage shape                              |
 
 ### Important explicit non-goals
 
@@ -283,7 +283,7 @@ If CMS already has data:
 
 **Missing-only auto-apply**
 
-- If no `video_embeddings` rows exist for the target video, index generated chunk embeddings
+- If no `transcript_embeddings` rows exist for the target video, index generated chunk embeddings
 
 **Skip if existing**
 

--- a/docs/plans/2026-04-10-refactor-rename-video-embeddings-to-transcript-embeddings-plan.md
+++ b/docs/plans/2026-04-10-refactor-rename-video-embeddings-to-transcript-embeddings-plan.md
@@ -1,0 +1,270 @@
+---
+title: "refactor: Rename video_embeddings to transcript_embeddings"
+type: refactor
+status: completed
+date: 2026-04-10
+origin: .context/compound-engineering/todos/024-ready-p2-rename-video-embeddings-to-transcript-embeddings.md
+related:
+  - docs/brainstorms/2026-04-02-video-content-vectorization-requirements.md
+  - docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md
+  - docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md
+  - docs/plans/2026-04-09-feat-sync-enrichment-embeddings-into-cms-vector-index-plan.md
+  - docs/plans/2026-04-09-feat-sync-enrichment-results-into-cms-models-plan.md
+  - docs/roadmap/content-discovery/feat-009-pgvector-embedding-indexing.md
+  - docs/roadmap/content-discovery/feat-010-semantic-search-api.md
+---
+
+# refactor: Rename video_embeddings to transcript_embeddings
+
+## Overview
+
+Rename the CMS pgvector transcript chunk table from `video_embeddings` to `transcript_embeddings`, and update the code/docs that refer to the physical table name.
+
+This is a naming and model-clarity cleanup. The table row shape remains transcript-specific:
+
+```sql
+video_id
+chunk_index
+chunk_text
+embedding
+model
+```
+
+The PR should not redesign embedding storage, add scene embedding sync, store metadata/profile vectors, or change the manager artifact contract. It should make the existing transcript chunk vector store accurately named before semantic search and future video-profile work deepen the confusion.
+
+## Problem Statement
+
+`video_embeddings` sounds like the canonical table for every video-related vector, but the current table stores transcript chunks only. That conflicts with the system's emerging retrieval grains:
+
+- transcript embeddings answer "where in the spoken transcript does this query match?"
+- scene embeddings answer "which visually and thematically analyzed scenes are similar?"
+- future video profile embeddings may answer "what is this video broadly about?"
+
+The current physical name forces docs and code to explain that "video" means "transcript chunk". Renaming now keeps the transcript sync PR sequence clean while the table is still young.
+
+## Found Context
+
+Found brainstorm from 2026-04-02: `video-content-vectorization`. Using as context for planning because it explicitly separates transcript embeddings from scene embeddings.
+
+Found ready todo: `.context/compound-engineering/todos/024-ready-p2-rename-video-embeddings-to-transcript-embeddings.md`.
+
+Key decisions carried forward:
+
+- implement the physical table rename in its own PR
+- preserve transcript chunk semantics
+- keep `scene_embeddings` separate
+- leave `metadataEmbedding` artifact-only until a retrieval strategy justifies CMS storage
+- keep this PR focused on naming/model clarity, not broad embedding redesign
+
+## Research Summary
+
+External research skipped. This is a repo-internal Strapi/PostgreSQL rename with strong local guidance in `docs/solutions/`.
+
+Relevant files:
+
+- `apps/cms/src/bootstrap/ensure-pgvector.ts` creates `video_embeddings` and `scene_embeddings` on boot.
+- `apps/cms/src/api/embedding/services/indexer.ts` reads, deletes, inserts, summarizes, and stats-queries `video_embeddings`.
+- `apps/cms/src/api/embedding/services/indexer.test.ts` asserts the current SQL strings.
+- `apps/cms/src/api/embedding/controllers/embedding.test.ts` covers the API-mode behavior around the indexer service.
+- `apps/cms/src/api/data-snapshot/services/snapshot-tables.ts` includes `video_embeddings` in snapshot exports.
+- `apps/cms/src/scripts/data-import.ts` treats `video_embeddings` as a pgvector table to skip when local pgvector is unavailable.
+- `docs/roadmap/content-discovery/feat-010-semantic-search-api.md` still uses `video_embeddings` in semantic-search SQL.
+- `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md` documents `video_embeddings` as the transcript table.
+
+Relevant learnings:
+
+- `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md`: use raw SQL for pgvector, parameterized vector casts, HNSW indexes, FK cascade, and graceful bootstrap failure when pgvector or dependent tables are unavailable.
+- `docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md`: name vector stores by retrieval grain and do this rename as a focused follow-up PR, not as part of scene/profile embedding design.
+
+No `docs/solutions/patterns/critical-patterns.md` file exists in this repo.
+
+## Proposed Solution
+
+Rename the physical table and all direct table-name references to `transcript_embeddings`.
+
+Keep these public/domain surfaces stable unless a direct table-name string forces a change:
+
+- `POST /api/embedding/index`
+- `GET /api/embedding/stats`
+- manager artifact key `artifacts.embeddingSync`
+- response fields like `hasEmbeddings`, `chunkCount`, and `contentFingerprint`
+- exported CMS service names such as `syncVideoEmbeddings` unless the implementation diff stays small and tests show no callsite churn
+
+Reason: this PR is the physical storage vocabulary cleanup, not an API contract rename.
+
+## Technical Approach
+
+### 1. CMS bootstrap SQL
+
+Modify `apps/cms/src/bootstrap/ensure-pgvector.ts`.
+
+Tasks:
+
+- Change transcript table DDL from `video_embeddings` to `transcript_embeddings`.
+- Change HNSW index name to `transcript_embeddings_embedding_idx`.
+- Preserve the current graceful degradation: if `CREATE EXTENSION IF NOT EXISTS vector` fails, Strapi still boots without embedding features.
+- Preserve existing `scene_embeddings` DDL and migrations.
+- Add or update bootstrap tests for fresh DB creation and extension failure.
+
+### 2. CMS embedding indexer queries
+
+Modify `apps/cms/src/api/embedding/services/indexer.ts`.
+
+Tasks:
+
+- Update all direct SQL references from `video_embeddings` to `transcript_embeddings`.
+- Cover read summary, delete-then-insert, `if_missing`, override, and stats queries.
+- Keep the transaction and row-locking behavior unchanged.
+- Keep chunk indexing order and generated content fingerprint behavior unchanged.
+- Prefer a small local table-name constant only if it makes the repeated raw SQL safer without obscuring the SQL.
+
+### 3. CMS tests
+
+Modify `apps/cms/src/api/embedding/services/indexer.test.ts`.
+
+Tasks:
+
+- Update SQL string assertions and raw-query mocks to expect `transcript_embeddings`.
+- Keep existing behavior assertions intact for:
+  - lock before missing check
+  - skip when existing rows appear after lock
+  - override stale-compare protection
+  - draft-only target rejection
+
+Modify `apps/cms/src/api/embedding/controllers/embedding.test.ts` only if the indexer mock names or stats payloads change. Do not change controller behavior just to rename the table.
+
+Add `apps/cms/src/bootstrap/ensure-pgvector.test.ts` if the repo does not already have bootstrap test coverage.
+
+### 4. Snapshot and import lists
+
+Modify `apps/cms/src/api/data-snapshot/services/snapshot-tables.ts`.
+
+Tasks:
+
+- Replace `video_embeddings` with `transcript_embeddings` in `SNAPSHOT_TABLES`.
+- Keep `scene_embeddings` unchanged.
+
+Modify `apps/cms/src/scripts/data-import.ts` and possibly `apps/cms/src/scripts/data-import-utils.ts`.
+
+Tasks:
+
+- Update pgvector skip handling and snapshot/export lists to use `transcript_embeddings`.
+- Add tests only if these helpers already have coverage or the change introduces new branching.
+
+### 5. Docs and roadmap references
+
+Update durable implementation docs:
+
+- `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md`
+- `docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md`
+- `docs/roadmap/content-discovery/feat-009-pgvector-embedding-indexing.md`
+- `docs/roadmap/content-discovery/feat-010-semantic-search-api.md`
+- `docs/roadmap/content-discovery/feat-037-video-content-vectorization.md`
+- `docs/roadmap/content-discovery/feat-041-scene-embeddings-table.md`
+- `docs/plans/2026-04-09-feat-sync-enrichment-embeddings-into-cms-vector-index-plan.md`
+- `docs/plans/2026-04-09-feat-sync-enrichment-results-into-cms-models-plan.md`
+
+Recommended wording:
+
+- Use `transcript_embeddings` for the transcript chunk table.
+- Keep `scene_embeddings` as the multimodal scene table.
+- Keep future video-level/profile vectors separate.
+- Where a document is historical, add a short "renamed later" note instead of rewriting the past in a confusing way.
+
+### 6. Todo status
+
+After implementation and verification, update `.context/compound-engineering/todos/024-ready-p2-rename-video-embeddings-to-transcript-embeddings.md` from `ready` to `complete` with a work-log note.
+
+Do not mark it complete during planning.
+
+## Flow Analysis
+
+### Flow 1: Fresh CMS bootstrap
+
+Entry point: Strapi boot calls `ensurePgvector()`.
+
+Expected outcome:
+
+- pgvector extension is enabled
+- `transcript_embeddings` is created
+- `transcript_embeddings_embedding_idx` is created
+- no `video_embeddings` table is created
+
+### Flow 2: Local data import without pgvector
+
+Entry point: `pnpm --filter @forge/cms data-import`.
+
+Expected outcome:
+
+- import strips pgvector blocks for `transcript_embeddings`
+- non-embedding CMS tables restore successfully
+- Strapi can boot without embedding features, matching current behavior
+
+### Flow 3: Semantic search implementation after rename
+
+Entry point: future `feat-010` work reads roadmap docs.
+
+Expected outcome:
+
+- planned SQL queries `transcript_embeddings`
+- aliases make transcript scope clear, for example `FROM transcript_embeddings te`
+- snippets still come from `chunk_text`
+
+## Acceptance Criteria
+
+- [x] `ensurePgvector` creates `transcript_embeddings` for fresh databases.
+- [x] CMS embedding indexer read/write/stats queries use `transcript_embeddings`.
+- [x] CMS indexer tests assert the new table name and keep behavior coverage for missing-only and override flows.
+- [x] Snapshot export includes `transcript_embeddings`.
+- [x] Data import pgvector filtering handles `transcript_embeddings`.
+- [x] Semantic-search docs query `transcript_embeddings` and continue returning `chunk_text` snippets.
+- [x] Docs distinguish transcript embeddings from `scene_embeddings` and future video profile embeddings.
+- [x] No manager artifact, endpoint, or response contract is renamed unless required by a direct table-name reference.
+
+## Quality Gates
+
+Run focused checks:
+
+```bash
+pnpm --filter @forge/cms test -- src/api/embedding/services/indexer.test.ts src/api/embedding/controllers/embedding.test.ts
+pnpm --filter @forge/cms test -- src/bootstrap/ensure-pgvector.test.ts
+pnpm --filter @forge/cms test -- src/scripts/data-import-utils.test.ts
+pnpm --filter @forge/cms typecheck
+```
+
+If no bootstrap or import-utils test is added, replace that command with the actual focused test file that covers the touched helper.
+
+Manual SQL checks against a disposable local or staging database:
+
+```sql
+SELECT to_regclass('public.transcript_embeddings');
+\d transcript_embeddings
+SELECT COUNT(*) FROM transcript_embeddings;
+```
+
+## Non-Goals
+
+- Do not add scene embedding indexing to enrichment.
+- Do not design or create `video_profile_embeddings`.
+- Do not store `metadataEmbedding` in the transcript table.
+- Do not change the shape of `embeddings.json`.
+- Do not rename manager `artifacts.embeddingSync`.
+- Do not introduce a Strapi content type for pgvector data.
+- Do not require GraphQL codegen; this raw SQL table is not a GraphQL content type.
+
+## Risks
+
+- **Missed table-name reference**: one lingering SQL/doc string could keep pointing at `video_embeddings`. Mitigation: repo-wide search and focused CMS tests.
+- **Snapshot/import drift**: local tooling may still export or skip the old name. Mitigation: update the snapshot allowlist and pgvector table set in the same PR.
+- **Historical docs become misleading**: future implementers may copy old SQL. Mitigation: update durable docs and active roadmap instructions; add historical notes where needed.
+
+## References
+
+- `.context/compound-engineering/todos/024-ready-p2-rename-video-embeddings-to-transcript-embeddings.md`
+- `docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md`
+- `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md`
+- `apps/cms/src/bootstrap/ensure-pgvector.ts`
+- `apps/cms/src/api/embedding/services/indexer.ts`
+- `apps/cms/src/api/data-snapshot/services/snapshot-tables.ts`
+- `apps/cms/src/scripts/data-import.ts`
+- `docs/roadmap/content-discovery/feat-010-semantic-search-api.md`

--- a/docs/plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md
+++ b/docs/plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md
@@ -262,7 +262,7 @@ Expected outcome: backfill behavior remains compatible while sharing the indexin
 
 ## Non-Goals
 
-- Do not rename `video_embeddings` to `transcript_embeddings` in this slice. That is tracked separately in `.context/compound-engineering/todos/024-ready-p2-rename-video-embeddings-to-transcript-embeddings.md`.
+- Do not mix transcript table naming cleanup into this slice. That work is tracked separately under `docs/roadmap/content-discovery/feat-080-transcript-embedding-table-rename.md`.
 - Do not merge transcript chunk embeddings and scene embeddings into one table.
 - Do not build the final recommendation UI.
 - Do not require scene embedding for every enrichment job unless the caller enables scene analysis.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (April 10, 2026)
 
-- **Total tickets:** 80
-- **Complete:** 22
+- **Total tickets:** 81
+- **Complete:** 23
 - **In progress:** 3
 - **Not started:** 55
 - **Blocked:** 0
@@ -37,6 +37,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)  | Deploy Semantic Search Architecture                      | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-063](content-discovery/feat-063-personalize-discovery-experiences.md)    | Personalize Discovery Experiences                        | tataihono | P2       | 2026-10-01 | 45   | 2026-11-14 | not-started |
 | [feat-071](content-discovery/feat-071-recommendation-content-deduplication.md) | Recommendation Content Deduplication                     | nisal     | P2       | 2026-06-15 | 5    | 2026-06-19 | not-started |
+| [feat-080](content-discovery/feat-080-transcript-embedding-table-rename.md)    | Transcript Embedding Table Rename                        | nisal     | P2       | 2026-04-10 | 2    | 2026-04-12 | complete    |
 
 ### Media Generation
 

--- a/docs/roadmap/content-discovery/feat-009-pgvector-embedding-indexing.md
+++ b/docs/roadmap/content-discovery/feat-009-pgvector-embedding-indexing.md
@@ -43,7 +43,7 @@ tags:
 2. Create embeddings table via bootstrap SQL (not a Strapi content type — vector columns aren't supported by Strapi's ORM):
 
    ```sql
-   CREATE TABLE IF NOT EXISTS video_embeddings (
+   CREATE TABLE IF NOT EXISTS transcript_embeddings (
      id SERIAL PRIMARY KEY,
      video_id INTEGER NOT NULL REFERENCES videos(id) ON DELETE CASCADE,
      chunk_index INTEGER NOT NULL,
@@ -54,8 +54,8 @@ tags:
      UNIQUE(video_id, chunk_index)
    );
 
-   CREATE INDEX IF NOT EXISTS video_embeddings_embedding_idx
-     ON video_embeddings USING hnsw (embedding vector_cosine_ops);
+   CREATE INDEX IF NOT EXISTS transcript_embeddings_embedding_idx
+     ON transcript_embeddings USING hnsw (embedding vector_cosine_ops);
    ```
 
 3. Indexing service — new file: `apps/cms/src/api/embedding/services/indexer.ts`
@@ -68,7 +68,7 @@ tags:
    ```
 
    - Download `embeddings.json` from S3 for the given asset
-   - Upsert rows into `video_embeddings` (delete existing + insert, within a transaction)
+   - Upsert rows into `transcript_embeddings` (delete existing + insert, within a transaction)
    - Return chunk count
 
 4. Batch indexing endpoint — `POST /api/embeddings/index-all` that iterates all videos with enrichment artifacts and indexes them. For initial backfill.
@@ -86,11 +86,11 @@ tags:
 ## Verification
 
 - `SELECT * FROM pg_extension WHERE extname = 'vector'` → returns vector extension
-- `\d video_embeddings` → shows table with vector(1536) column
+- `\d transcript_embeddings` → shows table with vector(1536) column
 - Run `indexVideoEmbeddings(videoId, assetId)` for a test video → rows inserted
 - ```sql
   SELECT v.id, ve.chunk_text, ve.embedding <=> '[query_vector]' AS distance
-  FROM video_embeddings ve JOIN videos v ON v.id = ve.video_id
+  FROM transcript_embeddings ve JOIN videos v ON v.id = ve.video_id
   ORDER BY distance LIMIT 5;
   ```
   → returns 5 nearest chunks

--- a/docs/roadmap/content-discovery/feat-010-semantic-search-api.md
+++ b/docs/roadmap/content-discovery/feat-010-semantic-search-api.md
@@ -22,7 +22,7 @@ tags:
 1. `apps/cms/src/api/core-sync/controllers/` — pattern for custom Strapi controllers
 2. `apps/cms/src/api/core-sync/routes/` — pattern for custom routes
 3. `apps/manager/src/lib/openrouter.ts` — OpenRouter client for generating query embeddings (you'll need this or a copy in CMS)
-4. Feature 2 above — the `video_embeddings` table you just built
+4. Feature 2 above — the `transcript_embeddings` table you just built
 
 ## Grep These
 
@@ -75,7 +75,7 @@ tags:
        v.id, v.title, v.description, v.slug,
        ve.chunk_text AS snippet,
        1 - (ve.embedding <=> $1::vector) AS score
-     FROM video_embeddings ve
+     FROM transcript_embeddings ve
      JOIN videos v ON v.id = ve.video_id
      LEFT JOIN topics_videos_lnk tvl ON tvl.video_id = v.id
      LEFT JOIN topics t ON t.id = tvl.topic_id

--- a/docs/roadmap/content-discovery/feat-037-video-content-vectorization.md
+++ b/docs/roadmap/content-discovery/feat-037-video-content-vectorization.md
@@ -215,7 +215,7 @@ Add scene vectorization to `videoEnrichment.ts` as an independent branch:
 - **No locale bleed** — recommendations are locale-aware. A user's locale determines which results they see. Never recommend the same video in a different language.
 - **No human tags** — existing CMS tags are unreliable. All semantic signal comes from LLM extraction against actual video segments + transcript.
 - **Pure vector similarity scoring** — no user feedback loop in Phase 1. API accepts optional `rerank` parameter (no-op) to prepare for user-driven scoring in Phase 2.
-- **Separate table from `video_embeddings`** — different columns, different query patterns. Do not extend feat-009's table.
+- **Separate table from `transcript_embeddings`** — different columns, different query patterns. Do not extend feat-009's table.
 - **Do NOT use a Strapi content type** for scene embeddings — pgvector columns don't work with Strapi ORM. Use raw SQL (same pattern as feat-009).
 - **Embed once per Video, not per VideoVariant** — language variants share visual content. Dedup by `video_id`.
 - **Cost cap** — backfill worker must auto-pause if cumulative cost exceeds configurable threshold.

--- a/docs/roadmap/content-discovery/feat-041-scene-embeddings-table.md
+++ b/docs/roadmap/content-discovery/feat-041-scene-embeddings-table.md
@@ -20,7 +20,7 @@ tags:
 
 ## Problem
 
-Scene descriptions need to be embedded and stored in pgvector for similarity queries. This requires a new `scene_embeddings` table (separate from feat-009's `video_embeddings`) and an indexing service.
+Scene descriptions need to be embedded and stored in pgvector for similarity queries. This requires a new `scene_embeddings` table (separate from feat-009's `transcript_embeddings`) and an indexing service.
 
 ## Entry Points — Read These First
 
@@ -30,7 +30,7 @@ Scene descriptions need to be embedded and stored in pgvector for similarity que
 
 ## Grep These
 
-- `video_embeddings` in `apps/cms/src/` — feat-009 table creation pattern to follow
+- `transcript_embeddings` in `apps/cms/src/` — feat-009 table creation pattern to follow
 - `strapi.db.connection.raw` in `apps/cms/src/` — raw SQL execution pattern
 
 ## What To Build

--- a/docs/roadmap/content-discovery/feat-080-transcript-embedding-table-rename.md
+++ b/docs/roadmap/content-discovery/feat-080-transcript-embedding-table-rename.md
@@ -1,0 +1,62 @@
+---
+id: "feat-080"
+title: "Transcript Embedding Table Rename"
+owner: "nisal"
+priority: "P2"
+status: "complete"
+start_date: "2026-04-10"
+duration: 2
+depends_on:
+  - "feat-009"
+blocks: []
+tags:
+  - "cms"
+  - "pgvector"
+  - "search"
+---
+
+## Problem
+
+The CMS transcript chunk vector table is named `video_embeddings`, which is broader than the data it actually stores. That makes the storage model harder to reason about now that the system also has `scene_embeddings` and is likely to grow future video-level/profile vector stores.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/bootstrap/ensure-pgvector.ts` — creates pgvector tables and indexes on boot.
+2. `apps/cms/src/api/embedding/services/indexer.ts` — transcript embedding read/write/stats queries.
+3. `apps/cms/src/api/embedding/services/indexer.test.ts` — SQL assertions around transcript embedding flows.
+4. `apps/cms/src/api/data-snapshot/services/snapshot-tables.ts` — snapshot export allowlist.
+5. `apps/cms/src/scripts/data-import.ts` — local import pgvector table filtering.
+6. `docs/plans/2026-04-10-refactor-rename-video-embeddings-to-transcript-embeddings-plan.md` — execution plan and scope guardrails.
+
+## Grep These
+
+- `video_embeddings` in `apps/cms/src/`
+- `video_embeddings` in `docs/roadmap/`
+- `video_embeddings` in `docs/solutions/`
+- `embedding/index` in `apps/cms/src/`
+- `SNAPSHOT_TABLES` in `apps/cms/src/`
+
+## What To Build
+
+1. Rename the transcript chunk pgvector table from `video_embeddings` to `transcript_embeddings` in CMS bootstrap SQL.
+2. Rename the transcript embedding HNSW index to `transcript_embeddings_embedding_idx`.
+3. Update transcript embedding indexer SQL to read/write/stats-query `transcript_embeddings`.
+4. Update focused CMS tests to assert the renamed table.
+5. Update snapshot/import helpers to use `transcript_embeddings`.
+6. Update roadmap/plan/solution docs that still describe transcript chunks as `video_embeddings`.
+
+## Constraints
+
+- Keep this as a naming/model-clarity change. Do not redesign embedding storage.
+- Do not combine transcript rows with `scene_embeddings`, `metadataEmbedding`, or future profile vectors.
+- Do not rename API routes like `POST /api/embedding/index`.
+- Do not change the manager artifact contract or `artifacts.embeddingSync`.
+- Do not introduce a Strapi content type for pgvector tables.
+
+## Verification
+
+- `pnpm --filter @forge/cms test -- src/api/embedding/services/indexer.test.ts src/api/embedding/controllers/embedding.test.ts`
+- `pnpm --filter @forge/cms typecheck`
+- `rg -n "video_embeddings" apps/cms/src docs/roadmap docs/solutions docs/plans`
+- `SELECT to_regclass('public.transcript_embeddings');`
+- `\d transcript_embeddings`

--- a/docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md
+++ b/docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md
@@ -37,7 +37,7 @@ related:
 
 ## Problem
 
-Strapi v5's ORM does not support pgvector's `vector(1536)` column type, but the video content vectorization pipeline requires storing and querying high-dimensional embeddings in PostgreSQL with HNSW indexes. Two tables are needed: `video_embeddings` (transcript chunks) and `scene_embeddings` (multimodal scene analysis with metadata arrays).
+Strapi v5's ORM does not support pgvector's `vector(1536)` column type, but the video content vectorization pipeline requires storing and querying high-dimensional embeddings in PostgreSQL with HNSW indexes. Two tables are needed: `transcript_embeddings` (transcript chunks) and `scene_embeddings` (multimodal scene analysis with metadata arrays).
 
 ## What Didn't Work
 
@@ -59,7 +59,7 @@ One INSERT per row, one round-trip per iteration:
 ```typescript
 // WRONG — 500 round-trips for 500 chunks
 for (const chunk of chunks) {
-  await trx.raw(`INSERT INTO video_embeddings ... VALUES (?, ?, ?)`, [...])
+  await trx.raw(`INSERT INTO transcript_embeddings ... VALUES (?, ?, ?)`, [...])
 }
 ```
 
@@ -88,7 +88,7 @@ try {
 }
 
 try {
-  await knex.raw(`CREATE TABLE IF NOT EXISTS video_embeddings (...)`)
+  await knex.raw(`CREATE TABLE IF NOT EXISTS transcript_embeddings (...)`)
   await knex.raw(`CREATE TABLE IF NOT EXISTS scene_embeddings (...)`)
   // HNSW indexes, B-tree indexes
 } catch (err) {
@@ -128,7 +128,7 @@ for (let offset = 0; offset < chunks.length; offset += BATCH_SIZE) {
   }
 
   await trx.raw(
-    `INSERT INTO video_embeddings (...) VALUES ${placeholders.join(", ")}`,
+    `INSERT INTO transcript_embeddings (...) VALUES ${placeholders.join(", ")}`,
     bindings,
   )
 }

--- a/docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md
+++ b/docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md
@@ -25,6 +25,8 @@ tags:
 
 # Vector embedding storage scope and PR sequencing
 
+Update (2026-04-10): the dedicated follow-up rename landed, so the transcript chunk table now uses `transcript_embeddings`. The sequencing guidance below remains as the decision record for why that rename was split from the earlier transcript sync work.
+
 ## Problem
 
 The enrichment transcript sync PR made generated transcript chunks durable in the CMS pgvector index, but it surfaced a naming and scope problem: the physical CMS table is called `video_embeddings`, while the data being synced is specifically transcript chunks.


### PR DESCRIPTION
## Summary
- rename the CMS transcript chunk pgvector table references from video_embeddings to transcript_embeddings
- update bootstrap SQL, embedding indexer queries, snapshot/import helpers, and focused roadmap/plan/solution docs
- add bootstrap coverage for the renamed table and close out the related roadmap ticket, plan, and compound todo
- narrow coverage snapshot document-service typing so CMS typecheck passes cleanly on this branch

## Testing
- pnpm dlx vitest@2.1.9 run src/api/embedding/services/indexer.test.ts src/api/embedding/controllers/embedding.test.ts src/bootstrap/ensure-pgvector.test.ts
- pnpm --filter @forge/cms typecheck

## Post-Deploy Monitoring & Validation
- What to monitor/search
  - Logs: search CMS logs for [pgvector] and embedding
  - Metrics/Dashboards: none beyond standard CMS error monitoring
- Validation checks (queries/commands)
  - SELECT to_regclass('public.transcript_embeddings');
  - SELECT COUNT(*) FROM transcript_embeddings;
  - GET /api/embedding/stats returns normal transcript counts
- Expected healthy behavior
  - CMS boots without pgvector table creation warnings
  - transcript embedding stats and sync flows continue to work under the renamed table
- Failure signals / rollback trigger
  - embedding/index or embedding/stats errors due to missing table references
  - bootstrap warnings about failed embedding table creation after deploy
- Validation window & owner
  - Window: first deploy of this branch to a CMS environment
  - Owner: repo maintainer merging the PR

## Before / After Screenshots
No UI changes.

## Figma Design
N/A

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
