### PR TITLE
feat(manager): sync scene embeddings from enrichment pipeline

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -24,7 +24,7 @@ jobs:
             if (!match) return;
             const [, type, scope] = match;
             const validTypes = ['feat', 'fix', 'chore', 'docs'];
-            const validScopes = ['web', 'cms', 'mobile', 'graphql', 'tooling'];
+            const validScopes = ['web', 'cms', 'manager', 'mobile', 'graphql', 'tooling'];
             if (!validTypes.includes(type) || !validScopes.includes(scope)) return;
             const labelsToAdd = [type, scope];
             const issue = context.payload.issue;
@@ -53,7 +53,7 @@ jobs:
             if (!match) return;
             const [, type, scope] = match;
             const validTypes = ['feat', 'fix', 'chore', 'docs'];
-            const validScopes = ['web', 'cms', 'mobile', 'graphql', 'tooling'];
+            const validScopes = ['web', 'cms', 'manager', 'mobile', 'graphql', 'tooling'];
             if (!validTypes.includes(type) || !validScopes.includes(scope)) return;
             const labelsToAdd = [type, scope];
             const pr = context.payload.pull_request;

--- a/apps/cms/src/api/scene-embedding/controllers/scene-embedding.test.ts
+++ b/apps/cms/src/api/scene-embedding/controllers/scene-embedding.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  getProcessedVideoIdsMock,
+  getRecommendationsMock,
+  getSceneEmbeddingStatsMock,
+  indexSceneEmbeddingsMock,
+} = vi.hoisted(() => ({
+  getProcessedVideoIdsMock: vi.fn(),
+  getRecommendationsMock: vi.fn(),
+  getSceneEmbeddingStatsMock: vi.fn(),
+  indexSceneEmbeddingsMock: vi.fn(),
+}))
+
+vi.mock("../services/indexer", async () => {
+  const actual = await vi.importActual<typeof import("../services/indexer")>(
+    "../services/indexer",
+  )
+
+  return {
+    ...actual,
+    indexSceneEmbeddings: indexSceneEmbeddingsMock,
+    getSceneEmbeddingStats: getSceneEmbeddingStatsMock,
+    getProcessedVideoIds: getProcessedVideoIdsMock,
+  }
+})
+
+vi.mock("../services/recommender", () => ({
+  VideoNotFoundError: class VideoNotFoundError extends Error {},
+  getRecommendations: getRecommendationsMock,
+}))
+
+import sceneEmbeddingController, {
+  EXPECTED_DIMS,
+  MAX_SCENES,
+} from "./scene-embedding"
+import { SceneEmbeddingIndexError } from "../services/indexer"
+
+function buildContext(body: Record<string, unknown>) {
+  return {
+    status: 0,
+    body: undefined as unknown,
+    request: {
+      body,
+      query: undefined,
+    },
+  }
+}
+
+describe("scene-embedding controller", () => {
+  const strapi = {
+    log: {
+      error: vi.fn(),
+    },
+  } as unknown as Parameters<typeof sceneEmbeddingController>[0]["strapi"]
+
+  beforeEach(() => {
+    indexSceneEmbeddingsMock.mockReset()
+    getSceneEmbeddingStatsMock.mockReset()
+    getProcessedVideoIdsMock.mockReset()
+    getRecommendationsMock.mockReset()
+  })
+
+  it("accepts request-level videoDocumentId targets for scene indexing", async () => {
+    indexSceneEmbeddingsMock.mockResolvedValue({
+      scenesIndexed: 1,
+      resolvedVideoId: 42,
+      videoDocumentId: "video-doc-1",
+    })
+    const controller = sceneEmbeddingController({ strapi })
+    const ctx = buildContext({
+      videoDocumentId: "video-doc-1",
+      scenes: [
+        {
+          muxAssetId: "mux-1",
+          playbackId: "play-1",
+          sceneIndex: 0,
+          startSeconds: 0,
+          description: "Themes: hope.",
+          embedding: Array.from({ length: EXPECTED_DIMS }, () => 1),
+        },
+      ],
+    })
+
+    await controller.index(ctx)
+
+    expect(indexSceneEmbeddingsMock).toHaveBeenCalledWith(
+      strapi,
+      {
+        videoId: undefined,
+        videoDocumentId: "video-doc-1",
+        scenes: [
+          expect.objectContaining({
+            muxAssetId: "mux-1",
+            sceneIndex: 0,
+          }),
+        ],
+      },
+      { skipDelete: false },
+    )
+    expect(ctx.status).toBe(200)
+    expect(ctx.body).toEqual({
+      scenesIndexed: 1,
+      resolvedVideoId: 42,
+      videoDocumentId: "video-doc-1",
+    })
+  })
+
+  it("requires row-level videoId when no request target is provided", async () => {
+    const controller = sceneEmbeddingController({ strapi })
+    const ctx = buildContext({
+      scenes: [
+        {
+          muxAssetId: "mux-1",
+          playbackId: "play-1",
+          sceneIndex: 0,
+          startSeconds: 0,
+          description: "Themes: hope.",
+          embedding: Array.from({ length: EXPECTED_DIMS }, () => 1),
+        },
+      ],
+    })
+
+    await controller.index(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({
+      error: "scenes[0]: videoId must be a number",
+    })
+  })
+
+  it("rejects requests above the scene limit", async () => {
+    const controller = sceneEmbeddingController({ strapi })
+    const ctx = buildContext({
+      videoDocumentId: "video-doc-1",
+      scenes: Array.from({ length: MAX_SCENES + 1 }, (_, index) => ({
+        muxAssetId: "mux-1",
+        playbackId: "play-1",
+        sceneIndex: index,
+        startSeconds: index,
+        description: `Scene ${index}`,
+        embedding: Array.from({ length: EXPECTED_DIMS }, () => 1),
+      })),
+    })
+
+    await controller.index(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({
+      error: `Maximum ${MAX_SCENES} scenes per request`,
+    })
+  })
+
+  it("surfaces structured scene target errors from the service", async () => {
+    indexSceneEmbeddingsMock.mockRejectedValue(
+      new SceneEmbeddingIndexError(400, "conflicting_video_id"),
+    )
+    const controller = sceneEmbeddingController({ strapi })
+    const ctx = buildContext({
+      videoDocumentId: "video-doc-1",
+      scenes: [
+        {
+          videoId: 99,
+          muxAssetId: "mux-1",
+          playbackId: "play-1",
+          sceneIndex: 0,
+          startSeconds: 0,
+          description: "Themes: hope.",
+          embedding: Array.from({ length: EXPECTED_DIMS }, () => 1),
+        },
+      ],
+    })
+
+    await controller.index(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: "conflicting_video_id" })
+  })
+})

--- a/apps/cms/src/api/scene-embedding/controllers/scene-embedding.ts
+++ b/apps/cms/src/api/scene-embedding/controllers/scene-embedding.ts
@@ -1,20 +1,23 @@
 import type { Core } from "@strapi/strapi"
 import type { SceneEmbeddingInput } from "../services/indexer"
 import {
+  SceneEmbeddingIndexError,
   indexSceneEmbeddings,
   getSceneEmbeddingStats,
   getProcessedVideoIds,
 } from "../services/indexer"
 import { getRecommendations, VideoNotFoundError } from "../services/recommender"
 
-const EXPECTED_DIMS = 1536
-const MAX_SCENES = 500
+export const EXPECTED_DIMS = 1536
+export const MAX_SCENES = 500
 
 type StrapiContext = {
   status: number
   body: unknown
   request: {
     body?: {
+      videoId?: number
+      videoDocumentId?: string
       scenes?: SceneEmbeddingInput[]
       skipDelete?: boolean
     }
@@ -22,11 +25,20 @@ type StrapiContext = {
   }
 }
 
+function isFiniteSceneVector(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length === EXPECTED_DIMS &&
+    value.every((entry) => Number.isFinite(entry))
+  )
+}
+
 function validateScene(
   scene: SceneEmbeddingInput,
   index: number,
+  options: { requestTargetProvided: boolean },
 ): string | null {
-  if (typeof scene.videoId !== "number") {
+  if (!options.requestTargetProvided && typeof scene.videoId !== "number") {
     return `scenes[${index}]: videoId must be a number`
   }
   if (typeof scene.muxAssetId !== "string" || !scene.muxAssetId) {
@@ -44,11 +56,7 @@ function validateScene(
   if (typeof scene.description !== "string" || !scene.description) {
     return `scenes[${index}]: description is required`
   }
-  if (
-    !Array.isArray(scene.embedding) ||
-    scene.embedding.length !== EXPECTED_DIMS ||
-    !scene.embedding.every((v) => Number.isFinite(v))
-  ) {
+  if (!isFiniteSceneVector(scene.embedding)) {
     return `scenes[${index}]: embedding must be ${EXPECTED_DIMS} finite numbers`
   }
   return null
@@ -56,7 +64,11 @@ function validateScene(
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async index(ctx: StrapiContext) {
-    const { scenes, skipDelete } = ctx.request.body ?? {}
+    const { videoId, videoDocumentId, scenes, skipDelete } =
+      ctx.request.body ?? {}
+    const requestTargetProvided =
+      typeof videoId === "number" ||
+      (typeof videoDocumentId === "string" && videoDocumentId.trim().length > 0)
 
     if (!Array.isArray(scenes) || scenes.length === 0) {
       ctx.status = 400
@@ -70,47 +82,53 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       return
     }
 
-    const seen = new Set<string>()
-    for (let i = 0; i < scenes.length; i++) {
-      const scene = scenes[i]
+    for (let index = 0; index < scenes.length; index += 1) {
+      const scene = scenes[index]
       if (!scene) {
         ctx.status = 400
-        ctx.body = { error: `scenes[${i}] is null or undefined` }
+        ctx.body = { error: `scenes[${index}] is null or undefined` }
         return
       }
-      const err = validateScene(scene, i)
-      if (err) {
+
+      const error = validateScene(scene, index, { requestTargetProvided })
+      if (error) {
         ctx.status = 400
-        ctx.body = { error: err }
+        ctx.body = { error }
         return
       }
-      const key = `${scene.videoId}:${scene.sceneIndex}`
-      if (seen.has(key)) {
-        ctx.status = 400
-        ctx.body = {
-          error: `Duplicate (videoId, sceneIndex) at scenes[${i}]: ${key}`,
-        }
-        return
-      }
-      seen.add(key)
     }
 
     try {
-      const result = await indexSceneEmbeddings(strapi, scenes, {
-        skipDelete: skipDelete === true,
-      })
+      const result = await indexSceneEmbeddings(
+        strapi,
+        {
+          videoId,
+          videoDocumentId,
+          scenes,
+        },
+        {
+          skipDelete: skipDelete === true,
+        },
+      )
       ctx.status = 200
       ctx.body = result
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+    } catch (error) {
+      if (error instanceof SceneEmbeddingIndexError) {
+        ctx.status = error.status
+        ctx.body = { error: error.code }
+        return
+      }
+
+      const message = error instanceof Error ? error.message : String(error)
       if (message.includes("violates foreign key")) {
         ctx.status = 404
-        ctx.body = { error: "One or more video IDs not found" }
-      } else {
-        strapi.log.error(`[scene-embedding] Index failed: ${message}`)
-        ctx.status = 500
-        ctx.body = { error: "Failed to index scene embeddings" }
+        ctx.body = { error: "video_not_found" }
+        return
       }
+
+      strapi.log.error(`[scene-embedding] Index failed: ${message}`)
+      ctx.status = 500
+      ctx.body = { error: "Failed to index scene embeddings" }
     }
   },
 
@@ -139,7 +157,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async recommendations(ctx: StrapiContext) {
     const query = ctx.request.query ?? {}
 
-    // Validate required params
     const videoIdRaw = query.videoId
     if (!videoIdRaw || isNaN(Number(videoIdRaw))) {
       ctx.status = 400
@@ -156,7 +173,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
     const videoId = Number(videoIdRaw)
 
-    // Optional: sceneIndex
     let sceneIndex: number | undefined
     if (query.sceneIndex !== undefined) {
       sceneIndex = Number(query.sceneIndex)
@@ -167,7 +183,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       }
     }
 
-    // Optional: limit (service layer enforces default 10, max 50)
     const limit = query.limit ? Number(query.limit) || undefined : undefined
 
     try {
@@ -179,13 +194,15 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       })
       ctx.status = 200
       ctx.body = { recommendations: results }
-    } catch (err) {
-      if (err instanceof VideoNotFoundError) {
+    } catch (error) {
+      if (error instanceof VideoNotFoundError) {
         ctx.status = 404
-        ctx.body = { error: err.message }
+        ctx.body = { error: error.message }
       } else {
         strapi.log.error(
-          `[scene-embedding] Recommendations failed: ${err instanceof Error ? err.message : String(err)}`,
+          `[scene-embedding] Recommendations failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
         )
         ctx.status = 503
         ctx.body = { error: "Scene embedding features not available" }

--- a/apps/cms/src/api/scene-embedding/services/indexer.test.ts
+++ b/apps/cms/src/api/scene-embedding/services/indexer.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest"
+import { indexSceneEmbeddings, SceneEmbeddingIndexError } from "./indexer"
+
+function buildScene(videoId?: number) {
+  return {
+    ...(videoId != null ? { videoId } : {}),
+    muxAssetId: "mux-1",
+    playbackId: "play-1",
+    sceneIndex: 0,
+    startSeconds: 0,
+    endSeconds: 30,
+    description: "Themes: hope.",
+    themes: ["hope"],
+    bibleVerses: [],
+    demographics: [],
+    spiritualContext: [],
+    chapterTitle: "Intro",
+    embedding: Array.from({ length: 1536 }, () => 1),
+    model: "text-embedding-3-small",
+    language: "en",
+  }
+}
+
+function createStrapiForDocumentIdTarget() {
+  const connectionRaw = vi.fn(async (sql: string, bindings?: unknown[]) => {
+    if (sql.includes("FROM videos") && sql.includes("document_id")) {
+      expect(bindings).toEqual(["video-doc-1"])
+      return {
+        rows: [
+          { id: 42, document_id: "video-doc-1", published_at: "2026-04-10" },
+        ],
+      }
+    }
+
+    throw new Error(`Unexpected connection raw query: ${sql}`)
+  })
+
+  const transactionRaw = vi.fn(async (sql: string, bindings?: unknown[]) => {
+    const normalized = sql.replace(/\s+/g, " ").trim()
+
+    if (normalized.startsWith("DELETE FROM scene_embeddings")) {
+      expect(bindings).toEqual([42])
+      return { rows: [] }
+    }
+
+    if (normalized.startsWith("INSERT INTO scene_embeddings")) {
+      expect(bindings?.[0]).toBe(42)
+      return { rows: [] }
+    }
+
+    throw new Error(`Unexpected transaction raw query: ${sql}`)
+  })
+
+  const trx = { raw: transactionRaw }
+  const transaction = vi.fn(
+    async (callback: (trx: typeof trx) => Promise<unknown>) => callback(trx),
+  )
+
+  return {
+    strapi: {
+      db: {
+        connection: {
+          raw: connectionRaw,
+          transaction,
+        },
+      },
+      log: {
+        info: vi.fn(),
+      },
+    },
+    transactionRaw,
+  }
+}
+
+describe("indexSceneEmbeddings", () => {
+  it("resolves request-level videoDocumentId to the published numeric video row", async () => {
+    const { strapi, transactionRaw } = createStrapiForDocumentIdTarget()
+
+    const result = await indexSceneEmbeddings(
+      strapi as Parameters<typeof indexSceneEmbeddings>[0],
+      {
+        videoDocumentId: "video-doc-1",
+        scenes: [buildScene()],
+      },
+    )
+
+    expect(result).toEqual({
+      scenesIndexed: 1,
+      resolvedVideoId: 42,
+      videoDocumentId: "video-doc-1",
+    })
+    expect(transactionRaw).toHaveBeenCalledTimes(2)
+  })
+
+  it("rejects conflicting row-level videoId when a request target is provided", async () => {
+    const { strapi } = createStrapiForDocumentIdTarget()
+
+    await expect(
+      indexSceneEmbeddings(
+        strapi as Parameters<typeof indexSceneEmbeddings>[0],
+        {
+          videoDocumentId: "video-doc-1",
+          scenes: [buildScene(99)],
+        },
+      ),
+    ).rejects.toMatchObject<SceneEmbeddingIndexError>({
+      status: 400,
+      code: "conflicting_video_id",
+    })
+  })
+
+  it("rejects multi-video row payloads without a request-level target", async () => {
+    const { strapi } = createStrapiForDocumentIdTarget()
+
+    await expect(
+      indexSceneEmbeddings(
+        strapi as Parameters<typeof indexSceneEmbeddings>[0],
+        {
+          scenes: [
+            buildScene(41),
+            {
+              ...buildScene(42),
+              sceneIndex: 1,
+            },
+          ],
+        },
+      ),
+    ).rejects.toMatchObject<SceneEmbeddingIndexError>({
+      status: 400,
+      code: "multi_video_request",
+    })
+  })
+})

--- a/apps/cms/src/api/scene-embedding/services/indexer.test.ts
+++ b/apps/cms/src/api/scene-embedding/services/indexer.test.ts
@@ -72,6 +72,69 @@ function createStrapiForDocumentIdTarget() {
   }
 }
 
+function createStrapiForNumericTargets() {
+  const connectionRaw = vi.fn(async (sql: string, bindings?: unknown[]) => {
+    if (sql.includes("FROM videos") && sql.includes("WHERE id = ?")) {
+      const videoId = bindings?.[0]
+
+      if (videoId === 41) {
+        return {
+          rows: [
+            { id: 41, document_id: "video-doc-41", published_at: "2026-04-10" },
+          ],
+        }
+      }
+
+      if (videoId === 42) {
+        return {
+          rows: [
+            { id: 42, document_id: "video-doc-42", published_at: "2026-04-10" },
+          ],
+        }
+      }
+    }
+
+    throw new Error(`Unexpected connection raw query: ${sql}`)
+  })
+
+  const transactionRaw = vi.fn(async (sql: string, bindings?: unknown[]) => {
+    const normalized = sql.replace(/\s+/g, " ").trim()
+
+    if (normalized.startsWith("DELETE FROM scene_embeddings")) {
+      expect(bindings).toEqual([[41, 42]])
+      return { rows: [] }
+    }
+
+    if (normalized.startsWith("INSERT INTO scene_embeddings")) {
+      expect(bindings?.[0]).toBe(41)
+      expect(bindings?.[16]).toBe(42)
+      return { rows: [] }
+    }
+
+    throw new Error(`Unexpected transaction raw query: ${sql}`)
+  })
+
+  const trx = { raw: transactionRaw }
+  const transaction = vi.fn(
+    async (callback: (trx: typeof trx) => Promise<unknown>) => callback(trx),
+  )
+
+  return {
+    strapi: {
+      db: {
+        connection: {
+          raw: connectionRaw,
+          transaction,
+        },
+      },
+      log: {
+        info: vi.fn(),
+      },
+    },
+    transactionRaw,
+  }
+}
+
 describe("indexSceneEmbeddings", () => {
   it("resolves request-level videoDocumentId to the published numeric video row", async () => {
     const { strapi, transactionRaw } = createStrapiForDocumentIdTarget()
@@ -109,25 +172,26 @@ describe("indexSceneEmbeddings", () => {
     })
   })
 
-  it("rejects multi-video row payloads without a request-level target", async () => {
-    const { strapi } = createStrapiForDocumentIdTarget()
+  it("preserves legacy multi-video row payloads without a request-level target", async () => {
+    const { strapi, transactionRaw } = createStrapiForNumericTargets()
 
-    await expect(
-      indexSceneEmbeddings(
-        strapi as Parameters<typeof indexSceneEmbeddings>[0],
-        {
-          scenes: [
-            buildScene(41),
-            {
-              ...buildScene(42),
-              sceneIndex: 1,
-            },
-          ],
-        },
-      ),
-    ).rejects.toMatchObject<SceneEmbeddingIndexError>({
-      status: 400,
-      code: "multi_video_request",
+    const result = await indexSceneEmbeddings(
+      strapi as Parameters<typeof indexSceneEmbeddings>[0],
+      {
+        scenes: [
+          buildScene(41),
+          {
+            ...buildScene(42),
+            sceneIndex: 1,
+          },
+        ],
+      },
+    )
+
+    expect(result).toEqual({
+      scenesIndexed: 2,
+      resolvedVideoIds: [41, 42],
     })
+    expect(transactionRaw).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/cms/src/api/scene-embedding/services/indexer.ts
+++ b/apps/cms/src/api/scene-embedding/services/indexer.ts
@@ -1,7 +1,7 @@
 import type { Core } from "@strapi/strapi"
 
 export type SceneEmbeddingInput = {
-  videoId: number
+  videoId?: number
   coreId?: string
   muxAssetId: string
   playbackId: string
@@ -19,11 +19,53 @@ export type SceneEmbeddingInput = {
   language?: string
 }
 
+export type SyncSceneEmbeddingsInput = {
+  videoId?: number
+  videoDocumentId?: string
+  scenes: SceneEmbeddingInput[]
+}
+
+export type SceneEmbeddingIndexResult = {
+  scenesIndexed: number
+  resolvedVideoId: number
+  videoDocumentId?: string
+}
+
+type ResolvedSceneTarget = {
+  resolvedVideoId: number
+  videoDocumentId?: string
+}
+
+type ResolvedSceneEmbeddingInput = SceneEmbeddingInput & {
+  videoId: number
+}
+
+type VideoRow = {
+  id: number | string
+  document_id?: string | null
+  published_at?: string | null
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type KnexInstance = any
 
-// 16 bindings per row → 30 rows = 480 params (well within PG's 65535 limit)
+// 16 bindings per row -> 30 rows = 480 params (well within PG's 65535 limit)
 const BATCH_SIZE = 30
+
+export class SceneEmbeddingIndexError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message = code,
+  ) {
+    super(message)
+    this.name = "SceneEmbeddingIndexError"
+  }
+}
+
+function toNumber(value: number | string | undefined | null): number {
+  return typeof value === "number" ? value : Number(value ?? 0)
+}
 
 /** Convert a string array to a PostgreSQL array literal: {val1,val2} */
 function toPgArray(arr: string[]): string {
@@ -37,27 +79,181 @@ function toPgArray(arr: string[]): string {
   )
 }
 
+async function readVideoRowsByDocumentId(
+  strapi: Core.Strapi,
+  videoDocumentId: string,
+): Promise<VideoRow[]> {
+  const knex: KnexInstance = strapi.db.connection
+  const result: { rows: VideoRow[] } = await knex.raw(
+    `
+      SELECT id, document_id, published_at
+      FROM videos
+      WHERE document_id = ?
+      ORDER BY CASE WHEN published_at IS NOT NULL THEN 0 ELSE 1 END, id DESC
+    `,
+    [videoDocumentId],
+  )
+  return result.rows ?? []
+}
+
+async function readVideoRowById(
+  strapi: Core.Strapi,
+  videoId: number,
+): Promise<VideoRow | null> {
+  const knex: KnexInstance = strapi.db.connection
+  const result: { rows: VideoRow[] } = await knex.raw(
+    `
+      SELECT id, document_id, published_at
+      FROM videos
+      WHERE id = ?
+      LIMIT 1
+    `,
+    [videoId],
+  )
+  return result.rows[0] ?? null
+}
+
+async function resolveSceneTarget(
+  strapi: Core.Strapi,
+  input: Pick<SyncSceneEmbeddingsInput, "videoId" | "videoDocumentId">,
+): Promise<ResolvedSceneTarget> {
+  if (typeof input.videoId === "number") {
+    const row = await readVideoRowById(strapi, input.videoId)
+    if (!row) {
+      throw new SceneEmbeddingIndexError(404, "video_not_found")
+    }
+
+    if (row.published_at == null) {
+      throw new SceneEmbeddingIndexError(409, "unpublished_video")
+    }
+
+    return {
+      resolvedVideoId: toNumber(row.id),
+      ...(row.document_id ? { videoDocumentId: row.document_id } : {}),
+    }
+  }
+
+  if (
+    typeof input.videoDocumentId === "string" &&
+    input.videoDocumentId.trim().length > 0
+  ) {
+    const rows = await readVideoRowsByDocumentId(strapi, input.videoDocumentId)
+    if (rows.length === 0) {
+      throw new SceneEmbeddingIndexError(404, "video_not_found")
+    }
+
+    const publishedRow = rows.find((row) => row.published_at != null)
+    if (!publishedRow) {
+      throw new SceneEmbeddingIndexError(409, "unpublished_video")
+    }
+
+    return {
+      resolvedVideoId: toNumber(publishedRow.id),
+      videoDocumentId: publishedRow.document_id ?? input.videoDocumentId,
+    }
+  }
+
+  throw new SceneEmbeddingIndexError(
+    400,
+    "invalid_video_target",
+    "videoId or videoDocumentId is required",
+  )
+}
+
+async function resolveScenesForWrite(
+  strapi: Core.Strapi,
+  input: SyncSceneEmbeddingsInput,
+): Promise<{
+  target: ResolvedSceneTarget
+  scenes: ResolvedSceneEmbeddingInput[]
+}> {
+  const requestTargetProvided =
+    typeof input.videoId === "number" ||
+    (typeof input.videoDocumentId === "string" &&
+      input.videoDocumentId.trim().length > 0)
+
+  if (requestTargetProvided) {
+    const target = await resolveSceneTarget(strapi, input)
+    const conflictingRow = input.scenes.find(
+      (scene) =>
+        typeof scene.videoId === "number" &&
+        scene.videoId !== target.resolvedVideoId,
+    )
+
+    if (conflictingRow) {
+      throw new SceneEmbeddingIndexError(400, "conflicting_video_id")
+    }
+
+    return {
+      target,
+      scenes: input.scenes.map((scene) => ({
+        ...scene,
+        videoId: target.resolvedVideoId,
+      })),
+    }
+  }
+
+  const rowVideoIds = [
+    ...new Set(
+      input.scenes
+        .map((scene) => scene.videoId)
+        .filter((videoId): videoId is number => typeof videoId === "number"),
+    ),
+  ]
+
+  if (rowVideoIds.length === 0) {
+    throw new SceneEmbeddingIndexError(400, "invalid_video_target")
+  }
+
+  if (rowVideoIds.length > 1) {
+    throw new SceneEmbeddingIndexError(400, "multi_video_request")
+  }
+
+  const target = await resolveSceneTarget(strapi, { videoId: rowVideoIds[0] })
+  return {
+    target,
+    scenes: input.scenes.map((scene) => ({
+      ...scene,
+      videoId: target.resolvedVideoId,
+    })),
+  }
+}
+
+function assertNoDuplicateSceneIndexes(
+  scenes: ResolvedSceneEmbeddingInput[],
+): void {
+  const seen = new Set<string>()
+
+  for (const scene of scenes) {
+    const key = `${scene.videoId}:${scene.sceneIndex}`
+    if (seen.has(key)) {
+      throw new SceneEmbeddingIndexError(400, "duplicate_scene_index")
+    }
+    seen.add(key)
+  }
+}
+
 export async function indexSceneEmbeddings(
   strapi: Core.Strapi,
-  scenes: SceneEmbeddingInput[],
+  input: SyncSceneEmbeddingsInput,
   options?: { skipDelete?: boolean },
-): Promise<{ scenesIndexed: number }> {
-  if (scenes.length === 0) return { scenesIndexed: 0 }
+): Promise<SceneEmbeddingIndexResult> {
+  if (input.scenes.length === 0) {
+    throw new SceneEmbeddingIndexError(400, "scenes_required")
+  }
+
+  const { target, scenes } = await resolveScenesForWrite(strapi, input)
+  assertNoDuplicateSceneIndexes(scenes)
 
   const knex: KnexInstance = strapi.db.connection
 
-  const videoIds = [...new Set(scenes.map((s) => s.videoId))]
-
   await knex.transaction(async (trx: KnexInstance) => {
     if (!options?.skipDelete) {
-      // Batch delete all affected videos in one statement
-      await trx.raw(
-        "DELETE FROM scene_embeddings WHERE video_id = ANY(?::int[])",
-        [videoIds],
-      )
+      await trx.raw("DELETE FROM scene_embeddings WHERE video_id = ?", [
+        target.resolvedVideoId,
+      ])
     }
 
-    // Batch insert
     for (let offset = 0; offset < scenes.length; offset += BATCH_SIZE) {
       const batch = scenes.slice(offset, offset + BATCH_SIZE)
       const placeholders: string[] = []
@@ -99,10 +295,16 @@ export async function indexSceneEmbeddings(
   })
 
   strapi.log.info(
-    `[scene-embedding] Indexed ${scenes.length} scenes for ${videoIds.length} video(s)`,
+    `[scene-embedding] Indexed ${scenes.length} scenes for video ${target.resolvedVideoId}`,
   )
 
-  return { scenesIndexed: scenes.length }
+  return {
+    scenesIndexed: scenes.length,
+    resolvedVideoId: target.resolvedVideoId,
+    ...(target.videoDocumentId
+      ? { videoDocumentId: target.videoDocumentId }
+      : {}),
+  }
 }
 
 export async function getProcessedVideoIds(

--- a/apps/cms/src/api/scene-embedding/services/indexer.ts
+++ b/apps/cms/src/api/scene-embedding/services/indexer.ts
@@ -27,7 +27,8 @@ export type SyncSceneEmbeddingsInput = {
 
 export type SceneEmbeddingIndexResult = {
   scenesIndexed: number
-  resolvedVideoId: number
+  resolvedVideoId?: number
+  resolvedVideoIds?: number[]
   videoDocumentId?: string
 }
 
@@ -164,7 +165,8 @@ async function resolveScenesForWrite(
   strapi: Core.Strapi,
   input: SyncSceneEmbeddingsInput,
 ): Promise<{
-  target: ResolvedSceneTarget
+  responseTarget?: ResolvedSceneTarget
+  resolvedVideoIds: number[]
   scenes: ResolvedSceneEmbeddingInput[]
 }> {
   const requestTargetProvided =
@@ -185,7 +187,8 @@ async function resolveScenesForWrite(
     }
 
     return {
-      target,
+      responseTarget: target,
+      resolvedVideoIds: [target.resolvedVideoId],
       scenes: input.scenes.map((scene) => ({
         ...scene,
         videoId: target.resolvedVideoId,
@@ -205,17 +208,45 @@ async function resolveScenesForWrite(
     throw new SceneEmbeddingIndexError(400, "invalid_video_target")
   }
 
-  if (rowVideoIds.length > 1) {
-    throw new SceneEmbeddingIndexError(400, "multi_video_request")
-  }
+  const targets = new Map<number, ResolvedSceneTarget>(
+    await Promise.all(
+      rowVideoIds.map(
+        async (videoId): Promise<readonly [number, ResolvedSceneTarget]> => [
+          videoId,
+          await resolveSceneTarget(strapi, { videoId }),
+        ],
+      ),
+    ),
+  )
 
-  const target = await resolveSceneTarget(strapi, { videoId: rowVideoIds[0] })
+  const resolvedVideoIds = [
+    ...new Set(
+      rowVideoIds.map(
+        (videoId) => targets.get(videoId)?.resolvedVideoId ?? videoId,
+      ),
+    ),
+  ]
+
   return {
-    target,
-    scenes: input.scenes.map((scene) => ({
-      ...scene,
-      videoId: target.resolvedVideoId,
-    })),
+    ...(rowVideoIds.length === 1
+      ? { responseTarget: targets.get(rowVideoIds[0]) }
+      : {}),
+    resolvedVideoIds,
+    scenes: input.scenes.map((scene) => {
+      if (typeof scene.videoId !== "number") {
+        throw new SceneEmbeddingIndexError(400, "invalid_video_target")
+      }
+
+      const target = targets.get(scene.videoId)
+      if (!target) {
+        throw new SceneEmbeddingIndexError(400, "invalid_video_target")
+      }
+
+      return {
+        ...scene,
+        videoId: target.resolvedVideoId,
+      }
+    }),
   }
 }
 
@@ -242,16 +273,24 @@ export async function indexSceneEmbeddings(
     throw new SceneEmbeddingIndexError(400, "scenes_required")
   }
 
-  const { target, scenes } = await resolveScenesForWrite(strapi, input)
+  const { responseTarget, resolvedVideoIds, scenes } =
+    await resolveScenesForWrite(strapi, input)
   assertNoDuplicateSceneIndexes(scenes)
 
   const knex: KnexInstance = strapi.db.connection
 
   await knex.transaction(async (trx: KnexInstance) => {
     if (!options?.skipDelete) {
-      await trx.raw("DELETE FROM scene_embeddings WHERE video_id = ?", [
-        target.resolvedVideoId,
-      ])
+      if (resolvedVideoIds.length === 1) {
+        await trx.raw("DELETE FROM scene_embeddings WHERE video_id = ?", [
+          resolvedVideoIds[0],
+        ])
+      } else {
+        await trx.raw(
+          "DELETE FROM scene_embeddings WHERE video_id = ANY(?::int[])",
+          [resolvedVideoIds],
+        )
+      }
     }
 
     for (let offset = 0; offset < scenes.length; offset += BATCH_SIZE) {
@@ -295,15 +334,24 @@ export async function indexSceneEmbeddings(
   })
 
   strapi.log.info(
-    `[scene-embedding] Indexed ${scenes.length} scenes for video ${target.resolvedVideoId}`,
+    `[scene-embedding] Indexed ${scenes.length} scenes for ${
+      resolvedVideoIds.length === 1
+        ? `video ${resolvedVideoIds[0]}`
+        : `${resolvedVideoIds.length} videos`
+    }`,
   )
 
   return {
     scenesIndexed: scenes.length,
-    resolvedVideoId: target.resolvedVideoId,
-    ...(target.videoDocumentId
-      ? { videoDocumentId: target.videoDocumentId }
+    ...(responseTarget
+      ? {
+          resolvedVideoId: responseTarget.resolvedVideoId,
+          ...(responseTarget.videoDocumentId
+            ? { videoDocumentId: responseTarget.videoDocumentId }
+            : {}),
+        }
       : {}),
+    ...(resolvedVideoIds.length > 1 ? { resolvedVideoIds } : {}),
   }
 }
 

--- a/apps/manager/src/features/jobs/live-job-steps-table.tsx
+++ b/apps/manager/src/features/jobs/live-job-steps-table.tsx
@@ -15,6 +15,7 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { getEmbeddingSyncReport } from "@/lib/embedding-sync-report"
+import { getSceneEmbeddingSyncReport } from "@/lib/scene-embedding-sync-report"
 import { formatStepName } from "@/lib/workflow-steps"
 import { canRetryMuxSyncOverride } from "@/lib/mux-sync-override"
 import type {
@@ -33,6 +34,11 @@ import {
   EmbeddingSyncInlineDetails,
   shouldExpandEmbeddingSyncByDefault,
 } from "./embedding-sync-card"
+import {
+  hasSceneEmbeddingSyncIssue,
+  SceneEmbeddingSyncInlineDetails,
+  shouldExpandSceneEmbeddingSyncByDefault,
+} from "./scene-embedding-sync-card"
 import { getPresentedMuxSyncComparisons } from "@/features/jobs/mux-sync-presenter"
 
 type RunPollOptions = {
@@ -225,10 +231,18 @@ export function LiveJobStepsTable({
     () => getEmbeddingSyncReport(job.artifacts),
     [job.artifacts],
   )
-  const [isEmbeddingSyncExpanded, setIsEmbeddingSyncExpanded] = useState(() =>
-    shouldExpandEmbeddingSyncByDefault(
-      getEmbeddingSyncReport(initialJob.artifacts),
-    ),
+  const sceneEmbeddingSyncReport = useMemo(
+    () => getSceneEmbeddingSyncReport(job.artifacts),
+    [job.artifacts],
+  )
+  const [isEmbeddingSyncExpanded, setIsEmbeddingSyncExpanded] = useState(
+    () =>
+      shouldExpandEmbeddingSyncByDefault(
+        getEmbeddingSyncReport(initialJob.artifacts),
+      ) ||
+      shouldExpandSceneEmbeddingSyncByDefault(
+        getSceneEmbeddingSyncReport(initialJob.artifacts),
+      ),
   )
   const [overrideArtifactKey, setOverrideArtifactKey] = useState<string | null>(
     null,
@@ -350,15 +364,21 @@ export function LiveJobStepsTable({
   )
 
   useEffect(() => {
-    if (shouldExpandEmbeddingSyncByDefault(embeddingSyncReport)) {
+    if (
+      shouldExpandEmbeddingSyncByDefault(embeddingSyncReport) ||
+      shouldExpandSceneEmbeddingSyncByDefault(sceneEmbeddingSyncReport)
+    ) {
       setIsEmbeddingSyncExpanded(true)
       return
     }
 
-    if (!embeddingSyncReport) {
+    if (
+      !embeddingSyncReport &&
+      !hasSceneEmbeddingSyncIssue(sceneEmbeddingSyncReport)
+    ) {
       setIsEmbeddingSyncExpanded(false)
     }
-  }, [embeddingSyncReport])
+  }, [embeddingSyncReport, sceneEmbeddingSyncReport])
 
   const handleSubtitleOverride = useCallback(
     async (comparison: MuxSyncComparison) => {
@@ -479,16 +499,21 @@ export function LiveJobStepsTable({
               const inlineError = step.error ?? null
               const translationFailures = getTranslationFailureDetails(step)
               const isEmbeddingsStep = step.name === "embeddings"
+              const hasSceneEmbeddingDetails = hasSceneEmbeddingSyncIssue(
+                sceneEmbeddingSyncReport,
+              )
               const isEmbeddingRowExpandable =
-                isEmbeddingsStep && embeddingSyncReport != null
+                isEmbeddingsStep &&
+                (embeddingSyncReport != null || hasSceneEmbeddingDetails)
               const showEmbeddingSyncInlineDetails =
                 isEmbeddingsStep &&
-                embeddingSyncReport != null &&
+                (embeddingSyncReport != null || hasSceneEmbeddingDetails) &&
                 isEmbeddingSyncExpanded
               const showInlineEmbeddingSummary =
                 isEmbeddingsStep &&
-                embeddingSyncReport != null &&
-                embeddingSyncReport.status === "failed"
+                ((embeddingSyncReport != null &&
+                  embeddingSyncReport.status === "failed") ||
+                  hasSceneEmbeddingDetails)
               const toggleEmbeddingSyncExpanded = () => {
                 if (!isEmbeddingRowExpandable) {
                   return
@@ -554,6 +579,12 @@ export function LiveJobStepsTable({
                             <span className="jobs-step-inline-summary">
                               <span className="jobs-step-inline-summary-text">
                                 CMS sync needs attention.
+                              </span>
+                            </span>
+                          ) : showInlineEmbeddingSummary ? (
+                            <span className="jobs-step-inline-summary">
+                              <span className="jobs-step-inline-summary-text">
+                                Scene sync needs attention.
                               </span>
                             </span>
                           ) : null}
@@ -679,10 +710,15 @@ export function LiveJobStepsTable({
                   {showEmbeddingSyncInlineDetails && (
                     <tr className="jobs-step-detail-row jobs-embedding-sync-detail-row">
                       <td colSpan={4}>
-                        <EmbeddingSyncInlineDetails
-                          job={job}
-                          onJobUpdate={handleJobUpdate}
-                        />
+                        {embeddingSyncReport ? (
+                          <EmbeddingSyncInlineDetails
+                            job={job}
+                            onJobUpdate={handleJobUpdate}
+                          />
+                        ) : null}
+                        {hasSceneEmbeddingDetails ? (
+                          <SceneEmbeddingSyncInlineDetails job={job} />
+                        ) : null}
                       </td>
                     </tr>
                   )}

--- a/apps/manager/src/features/jobs/scene-embedding-sync-card.tsx
+++ b/apps/manager/src/features/jobs/scene-embedding-sync-card.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import React from "react"
+import { getSceneEmbeddingSyncReport } from "@/lib/scene-embedding-sync-report"
+import type { JobRecord, SceneEmbeddingSyncReport } from "@/types/job"
+
+type SceneEmbeddingSyncCardProps = {
+  job: JobRecord
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="jobs-embedding-sync-row">
+      <span className="jobs-embedding-sync-label">{label}</span>
+      <span className="jobs-embedding-sync-value">{value}</span>
+    </div>
+  )
+}
+
+export function hasSceneEmbeddingSyncIssue(
+  report: SceneEmbeddingSyncReport | undefined,
+): report is SceneEmbeddingSyncReport {
+  return Boolean(
+    report && report.status !== "indexed" && report.status !== "skipped_empty",
+  )
+}
+
+export function shouldExpandSceneEmbeddingSyncByDefault(
+  report: SceneEmbeddingSyncReport | undefined,
+): boolean {
+  return hasSceneEmbeddingSyncIssue(report)
+}
+
+export function getSceneEmbeddingSyncExplanation(
+  report: SceneEmbeddingSyncReport,
+): string {
+  switch (report.status) {
+    case "indexed":
+      return "Scene embeddings were indexed into CMS."
+    case "skipped_empty":
+      return "Scene analysis completed, but no indexable scene descriptions were produced."
+    case "unsupported":
+      return "This workflow run does not have a CMS video target for scene embedding sync."
+    case "failed":
+      if (report.reason === "video_not_found") {
+        return "The target CMS video could not be found when scene sync ran."
+      }
+      if (report.reason === "unpublished_video") {
+        return "Only published CMS videos are indexed in v1, so draft-only content was not synced."
+      }
+      if (report.reason === "artifact_missing") {
+        return "The scene analysis artifact could not be read back for scene embedding sync."
+      }
+      return "Scene analysis succeeded, but the scene embedding sync subphase did not."
+  }
+}
+
+export function SceneEmbeddingSyncInlineDetails({
+  job,
+}: SceneEmbeddingSyncCardProps) {
+  const report = getSceneEmbeddingSyncReport(job.artifacts)
+  if (!hasSceneEmbeddingSyncIssue(report)) {
+    return null
+  }
+
+  const checkedReport = report
+
+  return (
+    <section className="jobs-embedding-sync-inline">
+      <div className="jobs-embedding-sync-inline-header">
+        <h4 className="jobs-embedding-sync-inline-title">
+          Scene Embeddings CMS Sync
+        </h4>
+        <p className="jobs-embedding-sync-inline-summary">
+          {getSceneEmbeddingSyncExplanation(checkedReport)}
+        </p>
+      </div>
+
+      <div className="jobs-embedding-sync-grid">
+        <div className="jobs-embedding-sync-panel">
+          <h4 className="jobs-embedding-sync-heading">
+            Generated Scene Analysis
+          </h4>
+          <SummaryRow
+            label="Scenes generated"
+            value={String(checkedReport.generatedSceneCount)}
+          />
+          <SummaryRow
+            label="Scenes indexable"
+            value={String(checkedReport.indexableSceneCount)}
+          />
+          <SummaryRow
+            label="Skipped empties"
+            value={String(checkedReport.skippedEmptySceneIndexes?.length ?? 0)}
+          />
+        </div>
+
+        <div className="jobs-embedding-sync-panel">
+          <h4 className="jobs-embedding-sync-heading">
+            CMS Scene Vector Index
+          </h4>
+          <SummaryRow
+            label="Resolved video ID"
+            value={String(checkedReport.resolvedVideoId ?? "–")}
+          />
+          <SummaryRow
+            label="Rows indexed"
+            value={String(checkedReport.indexedSceneCount ?? 0)}
+          />
+          <SummaryRow label="Model" value={checkedReport.model ?? "–"} />
+          <SummaryRow
+            label="Embedding tokens"
+            value={String(checkedReport.embeddingTokens ?? 0)}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/manager/src/lib/scene-embedding-sync-report.ts
+++ b/apps/manager/src/lib/scene-embedding-sync-report.ts
@@ -1,0 +1,115 @@
+import type {
+  JobArtifactManifest,
+  SceneEmbeddingSyncReport,
+  SceneEmbeddingSyncStatus,
+} from "@/types/job"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value)
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function readNumberArray(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const numbers = value.filter(
+    (entry): entry is number =>
+      typeof entry === "number" && Number.isFinite(entry),
+  )
+
+  return numbers.length === value.length ? numbers : undefined
+}
+
+function isSceneEmbeddingSyncStatus(
+  value: unknown,
+): value is SceneEmbeddingSyncStatus {
+  return (
+    value === "indexed" ||
+    value === "skipped_empty" ||
+    value === "failed" ||
+    value === "unsupported"
+  )
+}
+
+export function normalizeSceneEmbeddingSyncReport(
+  value: unknown,
+): SceneEmbeddingSyncReport | undefined {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  const generatedSceneCount = readNumber(value.generatedSceneCount)
+  const indexableSceneCount = readNumber(value.indexableSceneCount)
+  if (
+    value.domain !== "scene_embeddings" ||
+    !isSceneEmbeddingSyncStatus(value.status) ||
+    generatedSceneCount == null ||
+    indexableSceneCount == null
+  ) {
+    return undefined
+  }
+
+  return {
+    domain: "scene_embeddings",
+    status: value.status,
+    generatedSceneCount,
+    indexableSceneCount,
+    ...(readString(value.videoDocumentId)
+      ? { videoDocumentId: readString(value.videoDocumentId) }
+      : {}),
+    ...(readNumber(value.resolvedVideoId) != null
+      ? { resolvedVideoId: readNumber(value.resolvedVideoId) }
+      : {}),
+    ...(readString(value.reason) ? { reason: readString(value.reason) } : {}),
+    ...(readString(value.model) ? { model: readString(value.model) } : {}),
+    ...(readNumber(value.dimensions) != null
+      ? { dimensions: readNumber(value.dimensions) }
+      : {}),
+    ...(readNumber(value.indexedSceneCount) != null
+      ? { indexedSceneCount: readNumber(value.indexedSceneCount) }
+      : {}),
+    ...(readNumber(value.embeddingTokens) != null
+      ? { embeddingTokens: readNumber(value.embeddingTokens) }
+      : {}),
+    ...(readNumberArray(value.skippedEmptySceneIndexes)
+      ? {
+          skippedEmptySceneIndexes: readNumberArray(
+            value.skippedEmptySceneIndexes,
+          ),
+        }
+      : {}),
+  }
+}
+
+export function getSceneEmbeddingSyncReport(
+  artifacts: JobArtifactManifest,
+): SceneEmbeddingSyncReport | undefined {
+  const artifact = artifacts.sceneEmbeddingSync
+  if (artifact?.kind !== "metadata") {
+    return undefined
+  }
+
+  return normalizeSceneEmbeddingSyncReport(artifact.data)
+}
+
+export function buildSceneEmbeddingSyncArtifact(
+  report: SceneEmbeddingSyncReport,
+): JobArtifactManifest {
+  return {
+    sceneEmbeddingSync: {
+      kind: "metadata",
+      data: report as unknown as Record<string, unknown>,
+    },
+  }
+}

--- a/apps/manager/src/services/embeddings.ts
+++ b/apps/manager/src/services/embeddings.ts
@@ -5,7 +5,7 @@ import type { VideoMetadata } from "@/services/metadata"
 import { getOpenrouter } from "@/services/openrouter"
 import { writeArtifact } from "@/services/storage"
 
-const EMBEDDING_MODEL = "openai/text-embedding-3-small"
+export const EMBEDDING_MODEL = "openai/text-embedding-3-small"
 const DEFAULT_MAX_CHUNK_TOKENS = 500
 const DEFAULT_OVERLAP_TOKENS = 100
 const DEFAULT_MAX_BATCH_CHUNKS = 8
@@ -493,14 +493,14 @@ function createBatches(
   return batches
 }
 
-async function requestEmbeddingVectors(
+export async function requestEmbeddingVectors(
   input: string[],
   options: {
     expectedDimensions: number | null
     context: string
     itemLabel: string
   },
-): Promise<{ embeddings: number[][]; dimensions: number }> {
+): Promise<{ embeddings: number[][]; dimensions: number; tokenCount: number }> {
   const response = await getOpenrouter().embeddings.create({
     model: EMBEDDING_MODEL,
     input,
@@ -564,6 +564,7 @@ async function requestEmbeddingVectors(
 
   return {
     dimensions,
+    tokenCount: response.usage?.total_tokens ?? 0,
     embeddings: input.map((_, index) => {
       const embedding = embeddingsByIndex.get(index)
       if (!embedding) {

--- a/apps/manager/src/services/sceneEmbedder.test.ts
+++ b/apps/manager/src/services/sceneEmbedder.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  readArtifactMock,
+  runSceneAnalysisPipelineMock,
+  syncSceneAnalysisEmbeddingsMock,
+} = vi.hoisted(() => ({
+  readArtifactMock: vi.fn(),
+  runSceneAnalysisPipelineMock: vi.fn(),
+  syncSceneAnalysisEmbeddingsMock: vi.fn(),
+}))
+
+vi.mock("@/services/storage", () => ({
+  readArtifact: readArtifactMock,
+}))
+
+vi.mock("@/workflows/sceneAnalysisPipeline", () => ({
+  runSceneAnalysisPipeline: runSceneAnalysisPipelineMock,
+}))
+
+vi.mock("@/services/sceneEmbeddingSync", () => ({
+  syncSceneAnalysisEmbeddings: syncSceneAnalysisEmbeddingsMock,
+}))
+
+import { processVideoForBackfill } from "@/services/sceneEmbedder"
+
+function buildSceneAnalysisBody(): Uint8Array {
+  return new TextEncoder().encode(
+    JSON.stringify({
+      scenes: [
+        {
+          sceneIndex: 0,
+          startSeconds: 0,
+          endSeconds: 25,
+          chapterTitle: "Intro",
+          description: "Themes: hope.",
+          themes: ["hope"],
+          bibleVerses: [],
+          demographics: [],
+          spiritualContext: [],
+        },
+      ],
+      totalInputTokens: 11,
+      totalOutputTokens: 7,
+    }),
+  )
+}
+
+describe("processVideoForBackfill", () => {
+  beforeEach(() => {
+    readArtifactMock.mockReset()
+    runSceneAnalysisPipelineMock.mockReset()
+    syncSceneAnalysisEmbeddingsMock.mockReset()
+  })
+
+  it("reuses the shared sync service and preserves backfill metrics", async () => {
+    runSceneAnalysisPipelineMock.mockResolvedValue({
+      totalInputTokens: 101,
+      totalOutputTokens: 42,
+    })
+    readArtifactMock.mockResolvedValue(buildSceneAnalysisBody())
+    syncSceneAnalysisEmbeddingsMock.mockResolvedValue({
+      domain: "scene_embeddings",
+      status: "indexed",
+      resolvedVideoId: 42,
+      generatedSceneCount: 1,
+      indexableSceneCount: 1,
+      indexedSceneCount: 1,
+      embeddingTokens: 77,
+    })
+
+    const result = await processVideoForBackfill({
+      videoId: 42,
+      title: "Backfill Video",
+      subtitleUrl: "https://example.com/subtitles.vtt",
+      subtitleLanguage: "en",
+      muxAssetId: "mux-1",
+      playbackId: "play-1",
+      coreId: "core-1",
+      label: "segment",
+    })
+
+    expect(syncSceneAnalysisEmbeddingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: "42",
+        videoId: 42,
+        coreId: "core-1",
+        muxAssetId: "mux-1",
+        playbackId: "play-1",
+        language: "en",
+        analysisResult: expect.objectContaining({
+          scenes: [expect.objectContaining({ sceneIndex: 0 })],
+        }),
+      }),
+    )
+    expect(result).toMatchObject({
+      videoId: 42,
+      sceneCount: 1,
+      totalInputTokens: 101,
+      totalOutputTokens: 42,
+      embeddingTokens: 77,
+    })
+  })
+
+  it("throws when the shared sync path reports a failed scene embedding sync", async () => {
+    runSceneAnalysisPipelineMock.mockResolvedValue({
+      totalInputTokens: 101,
+      totalOutputTokens: 42,
+    })
+    readArtifactMock.mockResolvedValue(buildSceneAnalysisBody())
+    syncSceneAnalysisEmbeddingsMock.mockResolvedValue({
+      domain: "scene_embeddings",
+      status: "failed",
+      reason: "video_not_found",
+      generatedSceneCount: 1,
+      indexableSceneCount: 1,
+    })
+
+    await expect(
+      processVideoForBackfill({
+        videoId: 42,
+        title: "Backfill Video",
+        subtitleUrl: "https://example.com/subtitles.vtt",
+        subtitleLanguage: "en",
+        muxAssetId: "mux-1",
+        playbackId: "play-1",
+        coreId: "core-1",
+        label: "segment",
+      }),
+    ).rejects.toThrow("video_not_found")
+  })
+})

--- a/apps/manager/src/services/sceneEmbedder.ts
+++ b/apps/manager/src/services/sceneEmbedder.ts
@@ -1,9 +1,8 @@
 // Scene embedder — bridges scene analysis pipeline to CMS embedding indexer.
 // Per-video: run pipeline -> embed descriptions -> POST to CMS indexer.
 
-import { getOpenrouter } from "@/services/openrouter"
 import { readArtifact } from "@/services/storage"
-import { cmsPost } from "@/services/cmsClient"
+import { syncSceneAnalysisEmbeddings } from "@/services/sceneEmbeddingSync"
 import { runSceneAnalysisPipeline } from "@/workflows/sceneAnalysisPipeline"
 import type { SceneAnalysisResult } from "@/services/sceneAnalysis"
 import type { BackfillVideo } from "@/services/backfillQueue"
@@ -51,226 +50,30 @@ export async function processVideoForBackfill(
       durationMs: Date.now() - start,
     }
   }
-
-  // Filter out scenes with empty descriptions — the embedding API rejects empty
-  // strings (returns {error} instead of {data}). Empty descriptions mean the LLM
-  // failed to extract any signals for that scene, so there's nothing to embed.
-  const indexableScenes = analysisResult.scenes.filter(
-    (s) => s.description.trim().length > 0,
-  )
-
-  if (indexableScenes.length === 0) {
-    console.warn(
-      JSON.stringify({
-        event: "backfill_no_indexable_scenes",
-        videoId: video.videoId,
-        title: video.title,
-        totalScenes: analysisResult.scenes.length,
-      }),
-    )
-    return {
-      videoId: video.videoId,
-      sceneCount: 0,
-      totalInputTokens: pipelineResult.totalInputTokens,
-      totalOutputTokens: pipelineResult.totalOutputTokens,
-      embeddingTokens: 0,
-      durationMs: Date.now() - start,
-    }
-  }
-
-  if (indexableScenes.length < analysisResult.scenes.length) {
-    console.warn(
-      JSON.stringify({
-        event: "backfill_skipped_empty_scenes",
-        videoId: video.videoId,
-        title: video.title,
-        totalScenes: analysisResult.scenes.length,
-        indexableScenes: indexableScenes.length,
-        skippedIndexes: analysisResult.scenes
-          .filter((s) => s.description.trim().length === 0)
-          .map((s) => s.sceneIndex),
-      }),
-    )
-  }
-
-  // Step 3: Generate embeddings for all scene descriptions in one batch.
-  // OpenRouter occasionally returns a response without .data — retry up to 3 times.
-  const descriptions = indexableScenes.map((s) => s.description)
-  const MAX_EMBED_RETRIES = 3
-
-  let embeddingResponse: Awaited<
-    ReturnType<ReturnType<typeof getOpenrouter>["embeddings"]["create"]>
-  > | null = null
-
-  const attemptErrors: string[] = []
-
-  for (let attempt = 1; attempt <= MAX_EMBED_RETRIES; attempt++) {
-    try {
-      const response = await getOpenrouter().embeddings.create({
-        model: "openai/text-embedding-3-small",
-        input: descriptions,
-      })
-
-      if (response.data?.length === descriptions.length) {
-        embeddingResponse = response
-        break
-      }
-
-      const detail = `attempt ${attempt}: malformed response (got ${response.data?.length ?? 0} embeddings, expected ${descriptions.length})`
-      attemptErrors.push(detail)
-
-      console.warn(
-        JSON.stringify({
-          event: "embedding_retry",
-          videoId: video.videoId,
-          title: video.title,
-          attempt,
-          reason: "malformed_response",
-          expected: descriptions.length,
-          got: response.data?.length ?? 0,
-          rawKeys: response ? Object.keys(response) : [],
-        }),
-      )
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      const detail = `attempt ${attempt}: ${msg}`
-      attemptErrors.push(detail)
-
-      console.warn(
-        JSON.stringify({
-          event: "embedding_retry",
-          videoId: video.videoId,
-          title: video.title,
-          attempt,
-          reason: "thrown_error",
-          error: msg,
-          errorType: err instanceof Error ? err.constructor.name : typeof err,
-        }),
-      )
-    }
-
-    if (attempt < MAX_EMBED_RETRIES) {
-      await new Promise((r) => setTimeout(r, 3000 * attempt))
-    }
-  }
-
-  // Fallback: if batch embedding failed, try one-at-a-time
-  if (!embeddingResponse) {
-    console.warn(
-      JSON.stringify({
-        event: "embedding_batch_failed_falling_back_to_single",
-        videoId: video.videoId,
-        title: video.title,
-        sceneCount: descriptions.length,
-        batchAttempts: attemptErrors,
-      }),
-    )
-
-    const singleEmbeddings: number[][] = []
-    let singleTokens = 0
-
-    for (let i = 0; i < descriptions.length; i++) {
-      // Pace single-item calls to avoid hammering a rate-limited API
-      if (i > 0) await new Promise((r) => setTimeout(r, 500))
-
-      try {
-        const singleResponse = await getOpenrouter().embeddings.create({
-          model: "openai/text-embedding-3-small",
-          input: [descriptions[i]!],
-        })
-
-        if (!singleResponse.data?.[0]?.embedding) {
-          throw new Error(`Single-mode returned no embedding for scene ${i}`)
-        }
-
-        singleEmbeddings.push(singleResponse.data[0].embedding)
-        singleTokens += singleResponse.usage?.total_tokens ?? 0
-      } catch (err) {
-        throw new Error(
-          `Embedding failed for video ${video.videoId} (${video.title}), ` +
-            `scene ${i}/${descriptions.length} in single mode: ` +
-            `${err instanceof Error ? err.message : String(err)}. ` +
-            `Batch attempts: [${attemptErrors.join(" | ")}]. ` +
-            `Re-running the backfill will retry this video.`,
-        )
-      }
-    }
-
-    // Build a synthetic response matching the batch shape
-    embeddingResponse = {
-      data: singleEmbeddings.map((embedding, index) => ({
-        embedding,
-        index,
-        object: "embedding" as const,
-      })),
-      model: "openai/text-embedding-3-small",
-      object: "list" as const,
-      usage: { prompt_tokens: singleTokens, total_tokens: singleTokens },
-    }
-  }
-
-  const embeddingTokens = embeddingResponse.usage?.total_tokens ?? 0
-
-  // Step 4: Build SceneEmbeddingInput array and POST to CMS indexer
-  const scenes = indexableScenes.map((scene, i) => ({
+  const syncReport = await syncSceneAnalysisEmbeddings({
+    assetId: String(video.videoId),
     videoId: video.videoId,
-    coreId: video.coreId ?? undefined,
+    coreId: video.coreId,
     muxAssetId: video.muxAssetId,
     playbackId: video.playbackId,
-    sceneIndex: scene.sceneIndex,
-    startSeconds: scene.startSeconds,
-    endSeconds: scene.endSeconds ?? undefined,
-    description: scene.description,
-    themes: scene.themes,
-    bibleVerses: scene.bibleVerses,
-    demographics: scene.demographics,
-    spiritualContext: scene.spiritualContext,
-    chapterTitle: scene.chapterTitle ?? undefined,
-    embedding: embeddingResponse.data[i]!.embedding,
-    model: "text-embedding-3-small",
     language: video.subtitleLanguage,
-  }))
+    analysisResult,
+  })
 
-  // POST scenes to CMS in chunks to avoid 413 Payload Too Large.
-  // Each scene has a 1536-dim embedding (~12KB as JSON), so 20 scenes ≈ 240KB.
-  const INDEX_CHUNK_SIZE = 20
-  const MAX_INDEX_RETRIES = 3
-
-  for (let offset = 0; offset < scenes.length; offset += INDEX_CHUNK_SIZE) {
-    const chunk = scenes.slice(offset, offset + INDEX_CHUNK_SIZE)
-    const isFirstChunk = offset === 0
-
-    for (let attempt = 1; attempt <= MAX_INDEX_RETRIES; attempt++) {
-      try {
-        await cmsPost<{ scenesIndexed: number }>("/scene-embedding/index", {
-          scenes: chunk,
-          // First chunk deletes existing data; subsequent chunks append
-          ...(isFirstChunk ? {} : { skipDelete: true }),
-        })
-        break
-      } catch (err) {
-        if (attempt === MAX_INDEX_RETRIES) throw err
-        console.warn(
-          JSON.stringify({
-            event: "index_retry",
-            videoId: video.videoId,
-            title: video.title,
-            attempt,
-            chunk: `${offset}-${offset + chunk.length}/${scenes.length}`,
-            error: err instanceof Error ? err.message : String(err),
-          }),
-        )
-        await new Promise((r) => setTimeout(r, 3000 * attempt))
-      }
-    }
+  if (syncReport.status === "failed" || syncReport.status === "unsupported") {
+    throw new Error(
+      `Scene embedding sync failed for video ${video.videoId} (${video.title}): ${
+        syncReport.reason ?? syncReport.status
+      }`,
+    )
   }
 
   return {
     videoId: video.videoId,
-    sceneCount: indexableScenes.length,
+    sceneCount: syncReport.indexedSceneCount ?? 0,
     totalInputTokens: pipelineResult.totalInputTokens,
     totalOutputTokens: pipelineResult.totalOutputTokens,
-    embeddingTokens,
+    embeddingTokens: syncReport.embeddingTokens ?? 0,
     durationMs: Date.now() - start,
   }
 }

--- a/apps/manager/src/services/sceneEmbeddingSync.test.ts
+++ b/apps/manager/src/services/sceneEmbeddingSync.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { cmsPostMock, readArtifactMock, requestEmbeddingVectorsMock } =
+  vi.hoisted(() => ({
+    cmsPostMock: vi.fn(),
+    readArtifactMock: vi.fn(),
+    requestEmbeddingVectorsMock: vi.fn(),
+  }))
+
+vi.mock("@/services/cmsClient", () => ({
+  CmsHttpError: class CmsHttpError extends Error {
+    constructor(
+      readonly method: "GET" | "POST",
+      readonly path: string,
+      readonly status: number,
+      readonly bodyText: string,
+      readonly responseData?: unknown,
+    ) {
+      super(`CMS ${method} ${path} returned ${status}: ${bodyText}`)
+      this.name = "CmsHttpError"
+    }
+  },
+  cmsPost: cmsPostMock,
+}))
+
+vi.mock("@/services/storage", () => ({
+  readArtifact: readArtifactMock,
+}))
+
+vi.mock("@/services/embeddings", () => ({
+  EMBEDDING_MODEL: "openai/text-embedding-3-small",
+  requestEmbeddingVectors: requestEmbeddingVectorsMock,
+}))
+
+import { CmsHttpError } from "@/services/cmsClient"
+import { syncSceneAnalysisEmbeddings } from "@/services/sceneEmbeddingSync"
+
+function buildVector(seed: number): number[] {
+  return Array.from({ length: 1536 }, () => seed)
+}
+
+describe("syncSceneAnalysisEmbeddings", () => {
+  beforeEach(() => {
+    cmsPostMock.mockReset()
+    readArtifactMock.mockReset()
+    requestEmbeddingVectorsMock.mockReset()
+  })
+
+  it("indexes scene descriptions through the CMS videoDocumentId boundary", async () => {
+    requestEmbeddingVectorsMock.mockResolvedValue({
+      embeddings: [buildVector(1), buildVector(2)],
+      dimensions: 1536,
+      tokenCount: 88,
+    })
+    cmsPostMock.mockResolvedValue({
+      scenesIndexed: 2,
+      resolvedVideoId: 42,
+      videoDocumentId: "video-doc-1",
+    })
+
+    const report = await syncSceneAnalysisEmbeddings({
+      assetId: "asset-1",
+      videoDocumentId: "video-doc-1",
+      muxAssetId: "mux-1",
+      playbackId: "play-1",
+      language: "en",
+      analysisResult: {
+        scenes: [
+          {
+            sceneIndex: 0,
+            startSeconds: 0,
+            endSeconds: 30,
+            chapterTitle: "Intro",
+            description: "Themes: hope.\nContent: An opening scene.",
+            themes: ["hope"],
+            bibleVerses: [],
+            demographics: [],
+            spiritualContext: [],
+          },
+          {
+            sceneIndex: 1,
+            startSeconds: 30,
+            endSeconds: 60,
+            chapterTitle: "Middle",
+            description: "",
+            themes: [],
+            bibleVerses: [],
+            demographics: [],
+            spiritualContext: [],
+          },
+          {
+            sceneIndex: 2,
+            startSeconds: 60,
+            endSeconds: null,
+            chapterTitle: "End",
+            description: "Themes: courage.\nContent: A closing scene.",
+            themes: ["courage"],
+            bibleVerses: [],
+            demographics: [],
+            spiritualContext: [],
+          },
+        ],
+        totalInputTokens: 10,
+        totalOutputTokens: 4,
+      },
+    })
+
+    expect(requestEmbeddingVectorsMock).toHaveBeenCalledWith(
+      [
+        "Themes: hope.\nContent: An opening scene.",
+        "Themes: courage.\nContent: A closing scene.",
+      ],
+      expect.objectContaining({
+        expectedDimensions: null,
+      }),
+    )
+    expect(cmsPostMock).toHaveBeenCalledWith(
+      "/scene-embedding/index",
+      expect.objectContaining({
+        videoDocumentId: "video-doc-1",
+        scenes: [
+          expect.objectContaining({
+            sceneIndex: 0,
+            muxAssetId: "mux-1",
+            playbackId: "play-1",
+            language: "en",
+          }),
+          expect.objectContaining({
+            sceneIndex: 2,
+            muxAssetId: "mux-1",
+            playbackId: "play-1",
+            language: "en",
+          }),
+        ],
+      }),
+    )
+    expect(report).toMatchObject({
+      domain: "scene_embeddings",
+      status: "indexed",
+      videoDocumentId: "video-doc-1",
+      resolvedVideoId: 42,
+      generatedSceneCount: 3,
+      indexableSceneCount: 2,
+      indexedSceneCount: 2,
+      dimensions: 1536,
+      embeddingTokens: 88,
+      skippedEmptySceneIndexes: [1],
+    })
+  })
+
+  it("returns unsupported when enrichment has no CMS video target", async () => {
+    const report = await syncSceneAnalysisEmbeddings({
+      assetId: "asset-1",
+      muxAssetId: "mux-1",
+      playbackId: "play-1",
+      analysisResult: {
+        scenes: [
+          {
+            sceneIndex: 0,
+            startSeconds: 0,
+            endSeconds: null,
+            chapterTitle: null,
+            description: "Themes: hope.",
+            themes: ["hope"],
+            bibleVerses: [],
+            demographics: [],
+            spiritualContext: [],
+          },
+        ],
+        totalInputTokens: 1,
+        totalOutputTokens: 1,
+      },
+    })
+
+    expect(report.status).toBe("unsupported")
+    expect(report.reason).toBe("no_video_target")
+    expect(requestEmbeddingVectorsMock).not.toHaveBeenCalled()
+    expect(cmsPostMock).not.toHaveBeenCalled()
+  })
+
+  it("returns failed when the CMS request comes back with a scene target error", async () => {
+    vi.useFakeTimers()
+    try {
+      requestEmbeddingVectorsMock.mockResolvedValue({
+        embeddings: [buildVector(1)],
+        dimensions: 1536,
+        tokenCount: 21,
+      })
+      cmsPostMock.mockRejectedValue(
+        new CmsHttpError(
+          "POST",
+          "/scene-embedding/index",
+          404,
+          '{"error":"video_not_found"}',
+          { error: "video_not_found" },
+        ),
+      )
+
+      const reportPromise = syncSceneAnalysisEmbeddings({
+        assetId: "asset-1",
+        videoDocumentId: "video-doc-1",
+        muxAssetId: "mux-1",
+        playbackId: "play-1",
+        analysisResult: {
+          scenes: [
+            {
+              sceneIndex: 0,
+              startSeconds: 0,
+              endSeconds: null,
+              chapterTitle: null,
+              description: "Themes: hope.",
+              themes: ["hope"],
+              bibleVerses: [],
+              demographics: [],
+              spiritualContext: [],
+            },
+          ],
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+        },
+      })
+      await vi.runAllTimersAsync()
+      const report = await reportPromise
+
+      expect(report.status).toBe("failed")
+      expect(report.reason).toBe("video_not_found")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/manager/src/services/sceneEmbeddingSync.ts
+++ b/apps/manager/src/services/sceneEmbeddingSync.ts
@@ -1,0 +1,444 @@
+import { CmsHttpError, cmsPost } from "@/services/cmsClient"
+import { EMBEDDING_MODEL, requestEmbeddingVectors } from "@/services/embeddings"
+import type {
+  SceneAnalysis,
+  SceneAnalysisResult,
+} from "@/services/sceneAnalysis"
+import { readArtifact } from "@/services/storage"
+import type { SceneEmbeddingSyncReport } from "@/types/job"
+
+type SceneEmbeddingIndexSceneInput = {
+  videoId?: number
+  coreId?: string
+  muxAssetId: string
+  playbackId: string
+  sceneIndex: number
+  startSeconds: number
+  endSeconds?: number
+  description: string
+  themes?: string[]
+  bibleVerses?: string[]
+  demographics?: string[]
+  spiritualContext?: string[]
+  chapterTitle?: string
+  embedding: number[]
+  model?: string
+  language?: string
+}
+
+type CmsSceneIndexResponse = {
+  scenesIndexed: number
+  resolvedVideoId: number
+  videoDocumentId?: string
+}
+
+export type SyncSceneAnalysisInput = {
+  assetId: string
+  videoId?: number
+  videoDocumentId?: string
+  coreId?: string | null
+  muxAssetId: string
+  playbackId: string
+  language?: string
+  analysisResult?: SceneAnalysisResult
+}
+
+const MAX_EMBED_RETRIES = 3
+const MAX_INDEX_RETRIES = 3
+const INDEX_CHUNK_SIZE = 20
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value)
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  )
+}
+
+function normalizeSceneAnalysis(value: unknown): SceneAnalysis | undefined {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  if (
+    typeof value.sceneIndex !== "number" ||
+    !Number.isFinite(value.sceneIndex) ||
+    typeof value.startSeconds !== "number" ||
+    !Number.isFinite(value.startSeconds) ||
+    (value.endSeconds != null &&
+      (typeof value.endSeconds !== "number" ||
+        !Number.isFinite(value.endSeconds))) ||
+    (value.chapterTitle != null && typeof value.chapterTitle !== "string") ||
+    typeof value.description !== "string" ||
+    !isStringArray(value.themes) ||
+    !isStringArray(value.bibleVerses) ||
+    !isStringArray(value.demographics) ||
+    !isStringArray(value.spiritualContext)
+  ) {
+    return undefined
+  }
+
+  return {
+    sceneIndex: value.sceneIndex,
+    startSeconds: value.startSeconds,
+    endSeconds: value.endSeconds ?? null,
+    chapterTitle: value.chapterTitle ?? null,
+    description: value.description,
+    themes: value.themes,
+    bibleVerses: value.bibleVerses,
+    demographics: value.demographics,
+    spiritualContext: value.spiritualContext,
+  }
+}
+
+function normalizeSceneAnalysisResult(
+  value: unknown,
+): SceneAnalysisResult | undefined {
+  if (!isRecord(value) || !Array.isArray(value.scenes)) {
+    return undefined
+  }
+
+  const scenes = value.scenes.map((scene) => normalizeSceneAnalysis(scene))
+  if (scenes.some((scene) => scene == null)) {
+    return undefined
+  }
+
+  const totalInputTokens =
+    typeof value.totalInputTokens === "number" &&
+    Number.isFinite(value.totalInputTokens)
+      ? value.totalInputTokens
+      : 0
+  const totalOutputTokens =
+    typeof value.totalOutputTokens === "number" &&
+    Number.isFinite(value.totalOutputTokens)
+      ? value.totalOutputTokens
+      : 0
+
+  return {
+    scenes: scenes as SceneAnalysis[],
+    totalInputTokens,
+    totalOutputTokens,
+  }
+}
+
+async function loadSceneAnalysisResult(
+  input: SyncSceneAnalysisInput,
+): Promise<
+  { ok: true; result: SceneAnalysisResult } | { ok: false; reason: string }
+> {
+  if (input.analysisResult) {
+    return { ok: true, result: input.analysisResult }
+  }
+
+  try {
+    const bytes = await readArtifact(input.assetId, "scene-analysis", "json")
+    const parsed = normalizeSceneAnalysisResult(
+      JSON.parse(new TextDecoder().decode(bytes)) as unknown,
+    )
+    if (!parsed) {
+      return { ok: false, reason: "artifact_invalid" }
+    }
+
+    return { ok: true, result: parsed }
+  } catch (error) {
+    return {
+      ok: false,
+      reason:
+        error instanceof Error &&
+        /not found|missing|no such key|ENOENT/i.test(error.message)
+          ? "artifact_missing"
+          : "artifact_invalid",
+    }
+  }
+}
+
+function readCmsErrorCode(error: CmsHttpError): string | undefined {
+  if (
+    isRecord(error.responseData) &&
+    typeof error.responseData.error === "string"
+  ) {
+    return error.responseData.error
+  }
+
+  return undefined
+}
+
+function buildBaseReport(
+  input: SyncSceneAnalysisInput,
+  options: {
+    status: SceneEmbeddingSyncReport["status"]
+    generatedSceneCount: number
+    indexableSceneCount: number
+    skippedEmptySceneIndexes?: number[]
+    resolvedVideoId?: number
+    reason?: string
+    dimensions?: number
+    embeddingTokens?: number
+    indexedSceneCount?: number
+  },
+): SceneEmbeddingSyncReport {
+  return {
+    domain: "scene_embeddings",
+    status: options.status,
+    generatedSceneCount: options.generatedSceneCount,
+    indexableSceneCount: options.indexableSceneCount,
+    ...(input.videoDocumentId
+      ? { videoDocumentId: input.videoDocumentId }
+      : {}),
+    ...(options.resolvedVideoId != null
+      ? { resolvedVideoId: options.resolvedVideoId }
+      : {}),
+    ...(options.reason ? { reason: options.reason } : {}),
+    ...(options.dimensions != null ? { dimensions: options.dimensions } : {}),
+    ...(options.embeddingTokens != null
+      ? { embeddingTokens: options.embeddingTokens }
+      : {}),
+    ...(options.indexedSceneCount != null
+      ? { indexedSceneCount: options.indexedSceneCount }
+      : {}),
+    ...(options.skippedEmptySceneIndexes &&
+    options.skippedEmptySceneIndexes.length > 0
+      ? { skippedEmptySceneIndexes: options.skippedEmptySceneIndexes }
+      : {}),
+    ...(options.status === "indexed"
+      ? { model: EMBEDDING_MODEL.replace("openai/", "") }
+      : {}),
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function generateSceneEmbeddings(descriptions: string[]): Promise<{
+  embeddings: number[][]
+  dimensions: number
+  embeddingTokens: number
+}> {
+  const attemptErrors: string[] = []
+
+  for (let attempt = 1; attempt <= MAX_EMBED_RETRIES; attempt += 1) {
+    try {
+      const response = await requestEmbeddingVectors(descriptions, {
+        expectedDimensions: null,
+        context: `Scene embedding batch ${attempt}/${MAX_EMBED_RETRIES}`,
+        itemLabel: "scene descriptions",
+      })
+
+      return {
+        embeddings: response.embeddings,
+        dimensions: response.dimensions,
+        embeddingTokens: response.tokenCount,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      attemptErrors.push(`attempt ${attempt}: ${message}`)
+
+      console.warn(
+        JSON.stringify({
+          event: "scene_embedding_retry",
+          attempt,
+          reason: message,
+          sceneCount: descriptions.length,
+        }),
+      )
+
+      if (attempt < MAX_EMBED_RETRIES) {
+        await sleep(3000 * attempt)
+      }
+    }
+  }
+
+  console.warn(
+    JSON.stringify({
+      event: "scene_embedding_batch_failed_falling_back_to_single",
+      sceneCount: descriptions.length,
+      attempts: attemptErrors,
+    }),
+  )
+
+  const embeddings: number[][] = []
+  let dimensions: number | null = null
+  let embeddingTokens = 0
+
+  for (let index = 0; index < descriptions.length; index += 1) {
+    if (index > 0) {
+      await sleep(500)
+    }
+
+    const response = await requestEmbeddingVectors([descriptions[index]!], {
+      expectedDimensions: dimensions,
+      context: `Scene embedding ${index + 1}/${descriptions.length}`,
+      itemLabel: "scene descriptions",
+    })
+
+    dimensions = response.dimensions
+    embeddingTokens += response.tokenCount
+    embeddings.push(response.embeddings[0]!)
+  }
+
+  if (dimensions == null) {
+    throw new Error("scene_embedding_missing_dimensions")
+  }
+
+  return { embeddings, dimensions, embeddingTokens }
+}
+
+function buildSceneRows(
+  input: SyncSceneAnalysisInput,
+  scenes: SceneAnalysis[],
+  embeddings: number[][],
+): SceneEmbeddingIndexSceneInput[] {
+  return scenes.map((scene, index) => ({
+    coreId: input.coreId ?? undefined,
+    muxAssetId: input.muxAssetId,
+    playbackId: input.playbackId,
+    sceneIndex: scene.sceneIndex,
+    startSeconds: scene.startSeconds,
+    endSeconds: scene.endSeconds ?? undefined,
+    description: scene.description,
+    themes: scene.themes,
+    bibleVerses: scene.bibleVerses,
+    demographics: scene.demographics,
+    spiritualContext: scene.spiritualContext,
+    chapterTitle: scene.chapterTitle ?? undefined,
+    embedding: embeddings[index]!,
+    model: EMBEDDING_MODEL.replace("openai/", ""),
+    language: input.language ?? "en",
+  }))
+}
+
+export async function syncSceneAnalysisEmbeddings(
+  input: SyncSceneAnalysisInput,
+): Promise<SceneEmbeddingSyncReport> {
+  const analysis = await loadSceneAnalysisResult(input)
+  if (!analysis.ok) {
+    return buildBaseReport(input, {
+      status: "failed",
+      reason: analysis.reason,
+      generatedSceneCount: 0,
+      indexableSceneCount: 0,
+    })
+  }
+
+  const generatedSceneCount = analysis.result.scenes.length
+  const skippedEmptySceneIndexes = analysis.result.scenes
+    .filter((scene) => scene.description.trim().length === 0)
+    .map((scene) => scene.sceneIndex)
+  const indexableScenes = analysis.result.scenes.filter(
+    (scene) => scene.description.trim().length > 0,
+  )
+
+  if (input.videoId == null && !input.videoDocumentId) {
+    return buildBaseReport(input, {
+      status: "unsupported",
+      reason: "no_video_target",
+      generatedSceneCount,
+      indexableSceneCount: indexableScenes.length,
+      skippedEmptySceneIndexes,
+    })
+  }
+
+  if (indexableScenes.length === 0) {
+    return buildBaseReport(input, {
+      status: "skipped_empty",
+      generatedSceneCount,
+      indexableSceneCount: 0,
+      skippedEmptySceneIndexes,
+    })
+  }
+
+  let dimensions: number | undefined
+  let embeddingTokens = 0
+
+  try {
+    const embeddingResult = await generateSceneEmbeddings(
+      indexableScenes.map((scene) => scene.description),
+    )
+    dimensions = embeddingResult.dimensions
+    embeddingTokens = embeddingResult.embeddingTokens
+
+    const scenes = buildSceneRows(
+      input,
+      indexableScenes,
+      embeddingResult.embeddings,
+    )
+
+    let resolvedVideoId: number | undefined
+    let videoDocumentId = input.videoDocumentId
+    let indexedSceneCount = 0
+
+    for (let offset = 0; offset < scenes.length; offset += INDEX_CHUNK_SIZE) {
+      const chunk = scenes.slice(offset, offset + INDEX_CHUNK_SIZE)
+      const isFirstChunk = offset === 0
+
+      for (let attempt = 1; attempt <= MAX_INDEX_RETRIES; attempt += 1) {
+        try {
+          const response = await cmsPost<CmsSceneIndexResponse>(
+            "/scene-embedding/index",
+            {
+              ...(input.videoId != null ? { videoId: input.videoId } : {}),
+              ...(videoDocumentId ? { videoDocumentId } : {}),
+              scenes: chunk,
+              ...(isFirstChunk ? {} : { skipDelete: true }),
+            },
+          )
+
+          resolvedVideoId = response.resolvedVideoId
+          videoDocumentId = response.videoDocumentId ?? videoDocumentId
+          indexedSceneCount += response.scenesIndexed
+          break
+        } catch (error) {
+          if (attempt === MAX_INDEX_RETRIES) {
+            throw error
+          }
+
+          console.warn(
+            JSON.stringify({
+              event: "scene_embedding_index_retry",
+              attempt,
+              chunkStart: offset,
+              chunkSize: chunk.length,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          )
+
+          await sleep(3000 * attempt)
+        }
+      }
+    }
+
+    return {
+      ...buildBaseReport(input, {
+        status: "indexed",
+        generatedSceneCount,
+        indexableSceneCount: indexableScenes.length,
+        resolvedVideoId,
+        skippedEmptySceneIndexes,
+        dimensions,
+        embeddingTokens,
+        indexedSceneCount,
+      }),
+      ...(videoDocumentId ? { videoDocumentId } : {}),
+    }
+  } catch (error) {
+    const reason =
+      error instanceof CmsHttpError
+        ? (readCmsErrorCode(error) ?? "cms_request_failed")
+        : error instanceof Error
+          ? error.message
+          : "scene_embedding_failed"
+
+    return buildBaseReport(input, {
+      status: "failed",
+      reason,
+      generatedSceneCount,
+      indexableSceneCount: indexableScenes.length,
+      skippedEmptySceneIndexes,
+      dimensions,
+      embeddingTokens,
+    })
+  }
+}

--- a/apps/manager/src/types/job.ts
+++ b/apps/manager/src/types/job.ts
@@ -78,6 +78,27 @@ export type EmbeddingSyncReport = {
   override?: EmbeddingSyncOverrideSummary
 }
 
+export type SceneEmbeddingSyncStatus =
+  | "indexed"
+  | "skipped_empty"
+  | "failed"
+  | "unsupported"
+
+export type SceneEmbeddingSyncReport = {
+  domain: "scene_embeddings"
+  videoDocumentId?: string
+  resolvedVideoId?: number
+  status: SceneEmbeddingSyncStatus
+  reason?: string
+  model?: string
+  dimensions?: number
+  generatedSceneCount: number
+  indexableSceneCount: number
+  indexedSceneCount?: number
+  skippedEmptySceneIndexes?: number[]
+  embeddingTokens?: number
+}
+
 export type MuxSyncStatus =
   | "synced"
   | "skipped_existing_mux_data"

--- a/apps/manager/src/workflows/videoEnrichment.test.ts
+++ b/apps/manager/src/workflows/videoEnrichment.test.ts
@@ -4,9 +4,13 @@ const {
   chaptersMock,
   embeddingSyncMock,
   embeddingsMock,
+  extractAndStoreSceneBoundariesMock,
+  getMuxAssetMock,
   getJobMock,
   mergeJobArtifactsMock,
   metadataMock,
+  sceneEmbeddingSyncMock,
+  analyzeAllScenesMock,
   persistedJobArtifacts,
   subtitleTranslationMock,
   syncTranslatedSubtitlesToMuxMock,
@@ -17,9 +21,13 @@ const {
   chaptersMock: vi.fn(),
   embeddingSyncMock: vi.fn(),
   embeddingsMock: vi.fn(),
+  extractAndStoreSceneBoundariesMock: vi.fn(),
+  getMuxAssetMock: vi.fn(),
   getJobMock: vi.fn(),
   mergeJobArtifactsMock: vi.fn(),
   metadataMock: vi.fn(),
+  sceneEmbeddingSyncMock: vi.fn(),
+  analyzeAllScenesMock: vi.fn(),
   persistedJobArtifacts: {} as Record<string, unknown>,
   subtitleTranslationMock: vi.fn(),
   syncTranslatedSubtitlesToMuxMock: vi.fn(),
@@ -56,6 +64,22 @@ vi.mock("@/services/mux-sync", () => ({
   syncTranslatedSubtitlesToMux: syncTranslatedSubtitlesToMuxMock,
 }))
 
+vi.mock("@/services/sceneBoundaries", () => ({
+  extractAndStoreSceneBoundaries: extractAndStoreSceneBoundariesMock,
+}))
+
+vi.mock("@/services/sceneAnalysis", () => ({
+  analyzeAllScenes: analyzeAllScenesMock,
+}))
+
+vi.mock("@/services/sceneEmbeddingSync", () => ({
+  syncSceneAnalysisEmbeddings: sceneEmbeddingSyncMock,
+}))
+
+vi.mock("@/services/mux", () => ({
+  getMuxAsset: getMuxAssetMock,
+}))
+
 vi.mock("@/lib/state", async () => {
   const actual =
     await vi.importActual<typeof import("@/lib/state")>("@/lib/state")
@@ -76,9 +100,13 @@ describe("runVideoEnrichment", () => {
     chaptersMock.mockReset()
     embeddingSyncMock.mockReset()
     embeddingsMock.mockReset()
+    extractAndStoreSceneBoundariesMock.mockReset()
+    getMuxAssetMock.mockReset()
     getJobMock.mockReset()
     mergeJobArtifactsMock.mockReset()
     metadataMock.mockReset()
+    sceneEmbeddingSyncMock.mockReset()
+    analyzeAllScenesMock.mockReset()
     subtitleTranslationMock.mockReset()
     syncTranslatedSubtitlesToMuxMock.mockReset()
     transcribeMock.mockReset()
@@ -95,6 +123,49 @@ describe("runVideoEnrichment", () => {
         contentFingerprint: "sha256:generated",
         hasMetadataEmbedding: false,
       },
+    })
+    extractAndStoreSceneBoundariesMock.mockResolvedValue({
+      scenes: [
+        {
+          sceneIndex: 0,
+          startSeconds: 0,
+          endSeconds: 30,
+          chapterTitle: "Intro",
+          transcript: "Opening scene transcript",
+        },
+      ],
+    })
+    getMuxAssetMock.mockResolvedValue({
+      playbackId: "play-1",
+    })
+    analyzeAllScenesMock.mockResolvedValue({
+      scenes: [
+        {
+          sceneIndex: 0,
+          startSeconds: 0,
+          endSeconds: 30,
+          chapterTitle: "Intro",
+          description: "Themes: hope.",
+          themes: ["hope"],
+          bibleVerses: [],
+          demographics: [],
+          spiritualContext: [],
+        },
+      ],
+      totalInputTokens: 12,
+      totalOutputTokens: 4,
+    })
+    sceneEmbeddingSyncMock.mockResolvedValue({
+      domain: "scene_embeddings",
+      status: "indexed",
+      resolvedVideoId: 42,
+      videoDocumentId: "video-doc-1",
+      generatedSceneCount: 1,
+      indexableSceneCount: 1,
+      indexedSceneCount: 1,
+      embeddingTokens: 21,
+      model: "text-embedding-3-small",
+      dimensions: 1536,
     })
 
     for (const key of Object.keys(persistedJobArtifacts)) {
@@ -547,6 +618,170 @@ describe("runVideoEnrichment", () => {
       "embeddings",
       "failed",
       "video_not_found",
+    ])
+  })
+
+  it("persists scene embedding sync metadata when optional scene analysis is enabled", async () => {
+    transcribeMock.mockResolvedValue({
+      text: "hello world",
+      segments: [],
+      language: "en",
+      artifactKeys: ["transcript", "subtitles"],
+    })
+    subtitleTranslationMock.mockResolvedValue([
+      { lang: "en", status: "completed" },
+    ])
+    chaptersMock.mockResolvedValue({
+      chapters: [
+        { title: "Intro", startSeconds: 0, endSeconds: 30, summary: "" },
+      ],
+      artifactKeys: ["chapters"],
+    })
+    metadataMock.mockResolvedValue({
+      title: "Title",
+      description: "Description",
+      topics: [],
+      speakers: [],
+      tags: ["tag-1"],
+      language: "en",
+      artifactKeys: ["metadata"],
+    })
+    embeddingsMock.mockResolvedValue({
+      model: "openai/text-embedding-3-small",
+      dimensions: 3,
+      chunks: [{ text: "chunk 1" }],
+      metadata: { generatedAt: "2026-04-10T00:00:00.000Z" },
+      artifactKeys: ["embeddings"],
+    })
+
+    await expect(
+      runVideoEnrichment({
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        language: "en",
+        translateTo: ["en"],
+        runSceneAnalysis: true,
+        videoDocumentId: "video-doc-1",
+      }),
+    ).resolves.toMatchObject({
+      assetId: "asset-1",
+      language: "en",
+    })
+
+    expect(extractAndStoreSceneBoundariesMock).toHaveBeenCalledWith(
+      "asset-1",
+      [{ title: "Intro", startSeconds: 0, endSeconds: 30, summary: "" }],
+      "hello world",
+    )
+    expect(analyzeAllScenesMock).toHaveBeenCalledWith(
+      "asset-1",
+      "play-1",
+      expect.any(Array),
+      expect.objectContaining({
+        videoLabel: "unknown",
+      }),
+    )
+    expect(sceneEmbeddingSyncMock).toHaveBeenCalledWith({
+      assetId: "asset-1",
+      videoDocumentId: "video-doc-1",
+      muxAssetId: "mux-1",
+      playbackId: "play-1",
+      language: "en",
+      analysisResult: expect.objectContaining({
+        scenes: [expect.objectContaining({ sceneIndex: 0 })],
+      }),
+    })
+    expect(mergeJobArtifactsMock.mock.calls).toContainEqual([
+      "job-1",
+      {
+        sceneEmbeddingSync: {
+          kind: "metadata",
+          data: expect.objectContaining({
+            domain: "scene_embeddings",
+            status: "indexed",
+            resolvedVideoId: 42,
+          }),
+        },
+      },
+    ])
+  })
+
+  it("records failed scene embedding sync reports without failing the enrichment job", async () => {
+    transcribeMock.mockResolvedValue({
+      text: "hello world",
+      segments: [],
+      language: "en",
+      artifactKeys: ["transcript", "subtitles"],
+    })
+    subtitleTranslationMock.mockResolvedValue([
+      { lang: "en", status: "completed" },
+    ])
+    chaptersMock.mockResolvedValue({
+      chapters: [
+        { title: "Intro", startSeconds: 0, endSeconds: 30, summary: "" },
+      ],
+      artifactKeys: ["chapters"],
+    })
+    metadataMock.mockResolvedValue({
+      title: "Title",
+      description: "Description",
+      topics: [],
+      speakers: [],
+      tags: ["tag-1"],
+      language: "en",
+      artifactKeys: ["metadata"],
+    })
+    embeddingsMock.mockResolvedValue({
+      model: "openai/text-embedding-3-small",
+      dimensions: 3,
+      chunks: [{ text: "chunk 1" }],
+      metadata: { generatedAt: "2026-04-10T00:00:00.000Z" },
+      artifactKeys: ["embeddings"],
+    })
+    sceneEmbeddingSyncMock.mockResolvedValue({
+      domain: "scene_embeddings",
+      status: "failed",
+      reason: "video_not_found",
+      generatedSceneCount: 1,
+      indexableSceneCount: 1,
+      videoDocumentId: "video-doc-1",
+    })
+
+    await expect(
+      runVideoEnrichment({
+        jobId: "job-1",
+        assetId: "asset-1",
+        muxAssetId: "mux-1",
+        language: "en",
+        translateTo: ["en"],
+        runSceneAnalysis: true,
+        videoDocumentId: "video-doc-1",
+      }),
+    ).resolves.toMatchObject({
+      assetId: "asset-1",
+      language: "en",
+    })
+
+    expect(mergeJobArtifactsMock.mock.calls).toContainEqual([
+      "job-1",
+      {
+        sceneEmbeddingSync: {
+          kind: "metadata",
+          data: expect.objectContaining({
+            domain: "scene_embeddings",
+            status: "failed",
+            reason: "video_not_found",
+          }),
+        },
+      },
+    ])
+    expect(updateJobMock.mock.calls).toContainEqual([
+      "job-1",
+      expect.objectContaining({
+        status: "completed",
+        currentStep: undefined,
+      }),
     ])
   })
 

--- a/apps/manager/src/workflows/videoEnrichment.ts
+++ b/apps/manager/src/workflows/videoEnrichment.ts
@@ -14,6 +14,7 @@
 import { createHash } from "node:crypto"
 import { buildDownloadableArtifactManifest } from "@/lib/job-artifacts"
 import { buildEmbeddingSyncArtifact } from "@/lib/embedding-sync-report"
+import { buildSceneEmbeddingSyncArtifact } from "@/lib/scene-embedding-sync-report"
 import { getMuxSyncReport, setMuxSyncReport } from "@/lib/mux-sync-report"
 import {
   getJob,
@@ -411,6 +412,8 @@ export async function runVideoEnrichment(
         const { extractAndStoreSceneBoundaries } =
           await import("@/services/sceneBoundaries")
         const { analyzeAllScenes } = await import("@/services/sceneAnalysis")
+        const { syncSceneAnalysisEmbeddings } =
+          await import("@/services/sceneEmbeddingSync")
         const { getMuxAsset } = await import("@/services/mux")
 
         const boundaries = await extractAndStoreSceneBoundaries(
@@ -420,7 +423,7 @@ export async function runVideoEnrichment(
         )
 
         const muxAsset = await getMuxAsset(input.muxAssetId)
-        await analyzeAllScenes(
+        const analysisResult = await analyzeAllScenes(
           input.assetId,
           muxAsset.playbackId,
           boundaries.scenes,
@@ -428,6 +431,34 @@ export async function runVideoEnrichment(
             videoLabel: input.videoLabel ?? "unknown",
             bibleVerses: input.bibleVerses,
           },
+        )
+
+        const sceneEmbeddingSyncReport = await syncSceneAnalysisEmbeddings({
+          assetId: input.assetId,
+          videoDocumentId: input.videoDocumentId,
+          muxAssetId: input.muxAssetId,
+          playbackId: muxAsset.playbackId,
+          language: transcription.language,
+          analysisResult,
+        })
+
+        if (
+          sceneEmbeddingSyncReport.status === "failed" ||
+          sceneEmbeddingSyncReport.status === "unsupported"
+        ) {
+          console.error(
+            JSON.stringify({
+              event: "scene_embedding_sync_issue_in_enrichment",
+              jobId: input.jobId,
+              status: sceneEmbeddingSyncReport.status,
+              reason: sceneEmbeddingSyncReport.reason ?? "unknown",
+            }),
+          )
+        }
+
+        await persistMergedArtifacts(
+          input.jobId,
+          buildSceneEmbeddingSyncArtifact(sceneEmbeddingSyncReport),
         )
       } catch (sceneError) {
         console.error(

--- a/docs/brainstorms/2026-04-10-scene-embeddings-from-enrichment-pipeline-requirements.md
+++ b/docs/brainstorms/2026-04-10-scene-embeddings-from-enrichment-pipeline-requirements.md
@@ -1,0 +1,44 @@
+---
+date: 2026-04-10
+topic: scene-embeddings-from-enrichment-pipeline
+related:
+  - docs/roadmap/content-discovery/feat-045-pipeline-integration.md
+  - docs/plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md
+---
+
+# Scene Embeddings from Enrichment Pipeline
+
+## What We're Building
+
+Add scene embedding sync to the existing optional enrichment scene-analysis path so a completed enrichment job can produce CMS `scene_embeddings` from the transcript it just generated. This closes the gap where enrichment can already create scene analysis artifacts but stops short of indexing the scenes that power recommendations.
+
+Keep `scene_embeddings` unchanged on the CMS side: rows still store numeric `video_id` and remain compatible with the current recommendation query model. The external manager-to-CMS boundary should accept `videoDocumentId`, then CMS resolves that to the published numeric video row before delete-and-replace indexing.
+
+## Why This Approach
+
+We considered three shapes:
+
+- Shared manager sync service plus CMS `videoDocumentId` resolution
+- Manager-side numeric ID resolution before CMS POST
+- Rekeying `scene_embeddings` around `videoDocumentId`
+
+The chosen approach is the first one. It keeps catalog backfill and enrichment as separate entry points, which still matches the real data sources, while extracting only the shared embed-and-index work. It also follows the existing transcript embedding sync pattern, where manager sends a stable document identifier and CMS owns the lookup to its internal row ID.
+
+## Key Decisions
+
+- Shared manager service: extract the embed-and-index logic from `apps/manager/src/services/sceneEmbedder.ts` into a reusable `sceneEmbeddingSync` service that both backfill and enrichment call.
+- CMS boundary takes `videoDocumentId`: extend `/scene-embedding/index` so enrichment can target a video by `videoDocumentId` without learning Strapi numeric IDs.
+- Keep numeric internal keying: do not change `scene_embeddings.video_id`; recommendation queries and relational joins already depend on numeric video IDs.
+- Enrichment uses in-memory scene analysis: after `analyzeAllScenes()` succeeds in `videoEnrichment.ts`, call the shared sync service with the computed analysis result instead of re-reading artifacts.
+- Overwrite on enrichment rerun: scene sync should replace existing rows for that video, not skip when rows already exist. Scene analysis output can legitimately change across reruns, and the current scene indexer already uses delete-and-reinsert semantics.
+- Failure stays optional: a scene embedding sync failure should be recorded and logged, but it must not fail the overall enrichment job.
+
+## Open Questions
+
+- No product-level blockers remain for planning.
+- Planning should decide the smallest useful sync report shape for job artifacts and job UI.
+- Planning should confirm whether language gating belongs in enrichment wiring, shared sync, or both.
+
+## Next Steps
+
+Proceed to planning with Approach A and overwrite semantics as the chosen design.

--- a/docs/plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md
+++ b/docs/plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md
@@ -251,14 +251,14 @@ Expected outcome: backfill behavior remains compatible while sharing the indexin
 
 ## Acceptance Criteria
 
-- [ ] Enrichment jobs with `runSceneAnalysis: true` index scene embeddings into CMS after scene analysis succeeds.
-- [ ] Enrichment scene embedding indexing uses the generated enrichment transcript path, not `subtitleUrl`.
-- [ ] Backfill still processes existing subtitle-backed videos and indexes scene embeddings.
-- [ ] Shared manager scene embedding sync logic handles empty scene descriptions, batch embedding failures, single-item fallback, chunked CMS index posts, and structured reports.
-- [ ] CMS `/scene-embedding/index` supports `videoDocumentId` resolution to a published video while preserving existing numeric `videoId` callers.
-- [ ] Scene embedding failures in enrichment are persisted and logged but do not fail the core enrichment job.
-- [ ] No duplicate or conflicting `(video, sceneIndex)` rows are inserted during a chunked CMS upload.
-- [ ] Tests cover enrichment success, enrichment scene-embedding failure, backfill reuse, CMS `videoDocumentId` resolution, and CMS validation failures.
+- [x] Enrichment jobs with `runSceneAnalysis: true` index scene embeddings into CMS after scene analysis succeeds.
+- [x] Enrichment scene embedding indexing uses the generated enrichment transcript path, not `subtitleUrl`.
+- [x] Backfill still processes existing subtitle-backed videos and indexes scene embeddings.
+- [x] Shared manager scene embedding sync logic handles empty scene descriptions, batch embedding failures, single-item fallback, chunked CMS index posts, and structured reports.
+- [x] CMS `/scene-embedding/index` supports `videoDocumentId` resolution to a published video while preserving existing numeric `videoId` callers.
+- [x] Scene embedding failures in enrichment are persisted and logged but do not fail the core enrichment job.
+- [x] No duplicate or conflicting `(video, sceneIndex)` rows are inserted during a chunked CMS upload.
+- [x] Tests cover enrichment success, enrichment scene-embedding failure, backfill reuse, CMS `videoDocumentId` resolution, and CMS validation failures.
 
 ## Non-Goals
 

--- a/docs/roadmap/content-discovery/feat-045-pipeline-integration.md
+++ b/docs/roadmap/content-discovery/feat-045-pipeline-integration.md
@@ -3,7 +3,7 @@ id: "feat-045"
 title: "Video Vectorization — Pipeline Integration"
 owner: "nisal"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-06-04"
 duration: 7
 depends_on:

--- a/docs/solutions/integration-issues/cms-scene-embedding-indexer-multi-video-api-compatibility.md
+++ b/docs/solutions/integration-issues/cms-scene-embedding-indexer-multi-video-api-compatibility.md
@@ -1,0 +1,269 @@
+---
+title: "CMS scene embedding indexer: preserve legacy multi-video API compatibility"
+category: integration-issues
+module: CMS
+date: 2026-04-11
+problem_type: integration_issue
+component: service_object
+symptoms:
+  - "Legacy `/scene-embedding/index` requests with row-level numeric `videoId` values for more than one video started failing with `multi_video_request`"
+  - "The new request-level `videoDocumentId` path worked, but it accidentally narrowed the older numeric request shape instead of extending it additively"
+  - "Existing scene embedding callers could no longer replace rows for multiple videos in one request"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - cms
+  - scene-embeddings
+  - video-document-id
+  - api-compatibility
+  - backward-compatibility
+  - pgvector
+affected_components:
+  - apps/cms/src/api/scene-embedding/services/indexer.ts
+  - apps/cms/src/api/scene-embedding/services/indexer.test.ts
+related_docs:
+  - docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md
+  - docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md
+  - docs/solutions/platform/backfill-worker-pattern-manager-20260407.md
+  - docs/solutions/best-practices/pgvector-recommendation-query-locale-graphql-strapi-v5.md
+  - docs/plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md
+  - docs/plans/2026-04-09-feat-sync-enrichment-embeddings-into-cms-vector-index-plan.md
+  - docs/brainstorms/2026-04-10-scene-embeddings-from-enrichment-pipeline-requirements.md
+  - docs/roadmap/content-discovery/feat-045-pipeline-integration.md
+---
+
+# CMS scene embedding indexer: preserve legacy multi-video API compatibility
+
+## Problem
+
+The scene embedding PR that added request-level `videoDocumentId` support to
+`/scene-embedding/index` also introduced a compatibility regression in the CMS
+write path.
+
+Before the refactor, callers could send a request like this with no request-level
+target:
+
+```ts
+await indexSceneEmbeddings(strapi, {
+  scenes: [
+    { ...sceneFields, videoId: 41, sceneIndex: 0 },
+    { ...sceneFields, videoId: 42, sceneIndex: 1 },
+  ],
+})
+```
+
+That shape was valid. The service deleted stale rows for both videos and wrote
+the replacement scene rows in one request.
+
+During the `videoDocumentId` refactor, the no-request-target path was narrowed to
+a single resolved target, so the same payload started failing with
+`SceneEmbeddingIndexError(400, "multi_video_request")`.
+
+## Reproduction
+
+The regression showed up in PR review rather than in the enrichment flow itself:
+
+1. add request-level `videoDocumentId` support for enrichment-driven scene sync
+2. keep request-level targets single-video, published-only, and conflict-checked
+3. accidentally apply that same single-target assumption to the legacy
+   row-level numeric path
+
+The broken condition was simple:
+
+- no request-level `videoId`
+- no request-level `videoDocumentId`
+- at least two distinct row-level numeric `scenes[].videoId` values
+
+## Root Cause
+
+`resolveScenesForWrite()` was refactored around one resolved `target`.
+
+That was correct for the new request-level target mode, but the same invariant
+was then applied to the older row-level numeric mode. In practice, the service
+went from:
+
+- request-level target: single resolved video
+- row-level numeric target: one or more videos
+
+to:
+
+- request-level target: single resolved video
+- row-level numeric target: also forced to one video
+
+That was an API-contract regression, not a database or recommendation-model
+change. The broader scene embedding design still wanted numeric `video_id`
+internally. The mistake was collapsing an additive boundary change into a
+narrower accepted request shape.
+
+## Solution
+
+The fix kept the new request-level path and restored the old row-level numeric
+behavior.
+
+### 1. Keep request-level targets single-video
+
+When the request includes `videoId` or `videoDocumentId`, the service still:
+
+- resolves one published target
+- rejects conflicting row-level `videoId`s with `conflicting_video_id`
+- normalizes every scene row onto that one resolved numeric video id
+
+That preserves the enrichment contract.
+
+### 2. Restore row-level numeric multi-video mode
+
+When the request has no request-level target, the service now:
+
+- collects every distinct row-level numeric `videoId`
+- resolves each one through the published-video guard
+- remaps each scene row to its resolved numeric video id
+- returns `resolvedVideoIds` when more than one video was written
+
+The key split now looks like this:
+
+```ts
+if (requestTargetProvided) {
+  const target = await resolveSceneTarget(strapi, input)
+
+  return {
+    responseTarget: target,
+    resolvedVideoIds: [target.resolvedVideoId],
+    scenes: input.scenes.map((scene) => ({
+      ...scene,
+      videoId: target.resolvedVideoId,
+    })),
+  }
+}
+
+const targets = new Map(
+  await Promise.all(
+    rowVideoIds.map(async (videoId) => [
+      videoId,
+      await resolveSceneTarget(strapi, { videoId }),
+    ]),
+  ),
+)
+```
+
+### 3. Delete stale rows for every affected legacy target
+
+The write path now keeps the single-video delete for request-targeted or
+single-row-target requests, but restores the old multi-video delete for legacy
+row-level batches:
+
+```ts
+if (!options?.skipDelete) {
+  if (resolvedVideoIds.length === 1) {
+    await trx.raw("DELETE FROM scene_embeddings WHERE video_id = ?", [
+      resolvedVideoIds[0],
+    ])
+  } else {
+    await trx.raw(
+      "DELETE FROM scene_embeddings WHERE video_id = ANY(?::int[])",
+      [resolvedVideoIds],
+    )
+  }
+}
+```
+
+That preserves the original replace-in-one-request behavior instead of forcing
+callers to split the batch themselves.
+
+### 4. Add a characterization-style regression test
+
+The most important test change was flipping the old failing expectation into a
+compatibility assertion:
+
+- a two-video numeric row-level payload succeeds
+- delete bindings include both video ids
+- insert bindings contain both resolved ids
+- the result reports `resolvedVideoIds: [41, 42]`
+
+This makes the old accepted request shape explicit in the test suite so a future
+refactor cannot quietly narrow it again.
+
+## Why This Works
+
+The fix restores the correct boundary split:
+
+1. `videoDocumentId` is an additive API convenience for manager-to-CMS calls.
+2. Numeric `video_id` remains the internal storage key for
+   `scene_embeddings`.
+3. Legacy row-level numeric callers are still valid even when they touch more
+   than one video in one request.
+
+That matters because the rest of the scene embedding system still depends on the
+numeric key:
+
+- pgvector write-side indexing
+- recommendation SQL joins through Strapi link tables
+- backfill progress tracking through `scene_embeddings`
+
+So the right move was not to rewrite the storage model. It was to keep the new
+request-level target mode scoped to the new enrichment use case and preserve the
+older multi-video numeric contract beside it.
+
+## Verification
+
+Automated checks run after the fix:
+
+- `cd apps/cms && pnpm test -- src/api/scene-embedding/services/indexer.test.ts src/api/scene-embedding/controllers/scene-embedding.test.ts`
+- `cd apps/cms && pnpm typecheck`
+- `cd apps/cms && pnpm exec eslint src/api/scene-embedding/services/indexer.ts src/api/scene-embedding/services/indexer.test.ts src/api/scene-embedding/controllers/scene-embedding.test.ts`
+
+Review result:
+
+- PR #717 review finding closed by commit `31bf194`
+- request-level `videoDocumentId` indexing still returns a single
+  `resolvedVideoId`
+- legacy row-level numeric multi-video payloads succeed again and return
+  `resolvedVideoIds`
+
+## Prevention
+
+1. Treat `videoDocumentId` support as additive API-boundary behavior. Do not
+   collapse the existing row-level numeric `videoId` contract into the new
+   request-level target path.
+2. Keep target resolution split into explicit modes:
+   - request-level `videoId` / `videoDocumentId`: single target
+   - row-level `videoId` only: legacy multi-video batch mode
+3. Before refactoring an existing endpoint contract, add characterization tests
+   for the accepted payload shapes on `main`.
+4. When stricter validation rejects payloads that used to work, either preserve
+   the old behavior or document the breaking change explicitly.
+5. Review endpoint changes for API shape drift, not only for current in-repo
+   caller usage. "No caller currently does this" is not enough when a custom
+   internal endpoint already accepted the shape.
+
+## Operational Checks
+
+- After deploy, run or inspect one legacy numeric multi-video scene indexing
+  request and confirm it no longer returns `multi_video_request`.
+- Watch CMS logs for spikes in:
+  - `multi_video_request`
+  - `invalid_video_target`
+  - `conflicting_video_id`
+- Spot-check that `scene_embeddings` rows exist for every video id referenced by
+  a legacy numeric multi-video payload.
+
+Healthy behavior:
+
+- legacy row-level numeric multi-video requests succeed
+- request-level `videoDocumentId` syncs still resolve one published CMS video
+  and index rows normally
+
+Failure signal:
+
+- 400 responses for previously accepted row-level numeric multi-video requests
+
+## Related References
+
+- [Vector embedding storage scope and PR sequencing](../best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md)
+- [pgvector embedding indexing in Strapi v5](../best-practices/pgvector-embedding-indexing-strapi-v5.md)
+- [Backfill worker pattern: Next.js manager with CMS queue](../platform/backfill-worker-pattern-manager-20260407.md)
+- [pgvector recommendation query with locale-aware joins](../best-practices/pgvector-recommendation-query-locale-graphql-strapi-v5.md)
+- [Plan: integrate scene embeddings into enrichment pipeline](../../plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md)
+- [Plan: sync enrichment embeddings into CMS vector index](../../plans/2026-04-09-feat-sync-enrichment-embeddings-into-cms-vector-index-plan.md)
+- [Brainstorm: scene embeddings from enrichment pipeline](../../brainstorms/2026-04-10-scene-embeddings-from-enrichment-pipeline-requirements.md)
+- [Roadmap: video vectorization pipeline integration](../../roadmap/content-discovery/feat-045-pipeline-integration.md)


### PR DESCRIPTION
## Summary

- add a shared manager-side `sceneEmbeddingSync` service that reuses the existing scene embedding indexing flow for enrichment-generated scene analysis
- accept `videoDocumentId` at the CMS scene-embedding API boundary while keeping `scene_embeddings` keyed by numeric `video_id`
- preserve legacy row-level multi-video numeric scene index requests alongside the new single-target request-level path
- persist `sceneEmbeddingSync` metadata on enrichment jobs and surface scene-sync issues inline in the manager job detail UI

## Work Loop

- [x] `ce:plan` done
- [x] `ce:work` done
- [x] `ce:review` done
- [x] `ce:compound` done

## Testing

- `cd apps/manager && pnpm test -- src/services/sceneEmbeddingSync.test.ts src/services/sceneEmbedder.test.ts src/workflows/videoEnrichment.test.ts`
- `cd apps/cms && pnpm test -- src/api/scene-embedding/controllers/scene-embedding.test.ts src/api/scene-embedding/services/indexer.test.ts`
- `cd apps/manager && pnpm typecheck`
- `cd apps/cms && pnpm typecheck`
- `cd apps/cms && pnpm exec eslint src/api/scene-embedding/services/indexer.ts src/api/scene-embedding/services/indexer.test.ts src/api/scene-embedding/controllers/scene-embedding.test.ts`
- headless browser smoke on manager jobs list and job detail
- manual local verification that `scene_embeddings` rows were written for `video_id = 1607` and `sceneEmbeddingSync` was persisted on job `jy4isqi0y8wyercn4kkc2epe`

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs:
    - Search CMS logs for `[scene-embedding] Index failed`
    - Search manager and CMS logs for `multi_video_request`, `video_not_found`, and `unpublished_video`
  - Metrics/Dashboards:
    - Watch scene embedding indexing success/failure counts if available in existing job or API dashboards
- **Validation checks (queries/commands)**
  - Trigger or inspect a legacy numeric scene-index request that includes more than one `videoId` and confirm it no longer returns `400 multi_video_request`
  - Re-run a request-level `videoDocumentId` scene sync and confirm the response still includes a single `resolvedVideoId`
- **Expected healthy behavior**
  - Legacy row-level numeric multi-video requests succeed again
  - Enrichment-driven request-level scene sync still resolves one published CMS video and indexes rows normally
- **Failure signal(s) / rollback trigger**
  - Any renewed `multi_video_request` failures for row-level numeric batches
  - Request-level `videoDocumentId` syncs stop returning a `resolvedVideoId` or start failing with target-resolution errors
  - Immediate action: revert to the previous commit on this branch or disable the narrowed indexer change before the feature ships
- **Validation window & owner**
  - Window: first deploy including this PR and the next backfill/enrichment runs that touch scene indexing
  - Owner: PR author / content-discovery on-call

## Notes

- Plan: `docs/plans/2026-04-11-feat-integrate-scene-embeddings-into-enrichment-plan.md`
- Brainstorm: `docs/brainstorms/2026-04-10-scene-embeddings-from-enrichment-pipeline-requirements.md`
- Roadmap: `docs/roadmap/content-discovery/feat-045-pipeline-integration.md`
- Solution doc: `docs/solutions/integration-issues/cms-scene-embedding-indexer-multi-video-api-compatibility.md`