### PR TITLE
[codex] add mux environment labels to job detail

### DIFF
--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -3813,11 +3813,16 @@ body.jobs-standalone .jobs-step-job-id {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 10px;
   border-radius: 999px;
   border: 1px solid transparent;
   cursor: help;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
   transition:
     transform 120ms ease,
     box-shadow 120ms ease,
@@ -3851,6 +3856,10 @@ body.jobs-standalone .jobs-step-job-id {
 .jobs-mux-environment-indicator--production:hover,
 .jobs-mux-environment-indicator--production:focus-visible {
   border-color: #c98d86;
+}
+
+.jobs-mux-environment-indicator__label {
+  text-transform: lowercase;
 }
 
 .jobs-error-header {

--- a/apps/manager/src/features/jobs/live-job-detail-header.tsx
+++ b/apps/manager/src/features/jobs/live-job-detail-header.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import {
   getJobMuxEnvironment,
+  getMuxEnvironmentLabel,
   getMuxEnvironmentTooltip,
 } from "@/lib/mux-environment"
 import type { JobRecord } from "@/types/job"
@@ -145,6 +146,10 @@ export function LiveJobDetailHeader({
     () => getMuxEnvironmentTooltip(muxEnvironment),
     [muxEnvironment],
   )
+  const muxEnvironmentLabel = useMemo(
+    () => getMuxEnvironmentLabel(muxEnvironment),
+    [muxEnvironment],
+  )
   const MuxEnvironmentIcon =
     muxEnvironment === "staging" ? FlaskConical : TriangleAlert
 
@@ -237,10 +242,12 @@ export function LiveJobDetailHeader({
                       className={`jobs-mux-environment-indicator jobs-mux-environment-indicator--${muxEnvironment}`}
                       title={muxEnvironmentTooltip}
                       aria-label={muxEnvironmentTooltip}
-                      role="img"
                       tabIndex={0}
                     >
                       <MuxEnvironmentIcon size={14} aria-hidden="true" />
+                      <span className="jobs-mux-environment-indicator__label">
+                        {muxEnvironmentLabel}
+                      </span>
                     </span>
                   </>
                 ) : null}

--- a/apps/manager/src/lib/mux-environment.test.ts
+++ b/apps/manager/src/lib/mux-environment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   getJobMuxEnvironment,
+  getMuxEnvironmentLabel,
   getMuxEnvironmentTooltip,
 } from "@/lib/mux-environment"
 import type { JobArtifactManifest } from "@/types/job"
@@ -60,5 +61,15 @@ describe("getMuxEnvironmentTooltip", () => {
     expect(getMuxEnvironmentTooltip("production")).toBe(
       "Production Mux environment",
     )
+  })
+})
+
+describe("getMuxEnvironmentLabel", () => {
+  it("returns the staging badge label", () => {
+    expect(getMuxEnvironmentLabel("staging")).toBe("stage")
+  })
+
+  it("returns the production badge label", () => {
+    expect(getMuxEnvironmentLabel("production")).toBe("prod")
   })
 })

--- a/apps/manager/src/lib/mux-environment.ts
+++ b/apps/manager/src/lib/mux-environment.ts
@@ -41,3 +41,7 @@ export function getMuxEnvironmentTooltip(environment: MuxEnvironment): string {
     ? "Staging Mux environment"
     : "Production Mux environment"
 }
+
+export function getMuxEnvironmentLabel(environment: MuxEnvironment): string {
+  return environment === "staging" ? "stage" : "prod"
+}


### PR DESCRIPTION
## What changed
- added short Mux environment labels to the job detail indicator pill
- kept the existing staging/production icon and tooltip behavior
- added unit coverage for the new label helper

## Why
The existing icon-only indicator required operators to infer the destination environment from color and icon alone. Adding `stage` and `prod` makes the target environment explicit during QA and review.

## Impact
Job detail pages in manager now show a compact labeled environment badge next to `Watch on Mux`, reducing ambiguity when switching between staging and production assets.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @forge/manager test -- src/lib/mux-environment.test.ts`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
