### PR TITLE
feat(tv): add TV app prototype for Apple TV and Android TV

### DIFF
--- a/apps/tv/.gitignore
+++ b/apps/tv/.gitignore
@@ -1,0 +1,5 @@
+.expo/
+ios/
+android/
+.env.local
+node_modules/

--- a/apps/tv/CLAUDE.md
+++ b/apps/tv/CLAUDE.md
@@ -1,0 +1,70 @@
+# apps/tv — Expo TV App (Apple TV + Android TV)
+
+## Stack
+
+- React Native with Expo (SDK 54, managed workflow)
+- react-native-tvos (aliased as react-native) for TV platform support
+- @react-native-tvos/config-tv Expo plugin with EXPO_TV=1
+- Expo Router for file-based navigation (stack only, no tabs)
+- @forge/graphql with gql.tada for typed GraphQL operations
+- Apollo Client for GraphQL data fetching
+- expo-video for HLS playback
+- expo-image for optimized image loading
+
+## Architecture
+
+This is a TV adaptation of the Server-Driven UI (SDUI) app. Same pipeline
+as mobile-v2, different renderers optimized for 10-foot UI and D-pad navigation.
+
+### SDUI Pipeline
+
+```
+Strapi GraphQL → gql.tada typed query → normalizer (adds `kind`) → dispatcher → TV renderers
+```
+
+- **Queries**: Imported from mobile-v2 or copied with sync comment
+- **Normalizer**: Copied from mobile-v2 (identical logic)
+- **Dispatcher**: TV version with subset of block kinds
+- **Renderers**: All new, designed for 10-foot UI with D-pad focus
+
+## Design System: The Crimson Gallery
+
+All UI follows the Crimson Gallery design system from the Stitch mockups:
+
+- Background: `#161311` (warm stone, never pure black)
+- Surface container: `#221F1D`
+- Surface container high: `#2D2927`
+- Primary accent: `#CB333B` (Crimson Red — sparingly, for CTAs and focus rings)
+- Text: `#F5F5F4`
+- Muted: `#A8A29E`
+- Font: System (SF Pro on tvOS, Roboto on Android TV)
+- No 1px borders — use background color shifts
+- 16px border radius on cards
+- Focus state: 1.05x scale + crimson glow
+
+## Conventions
+
+- Build with `EXPO_TV=1 npx expo prebuild --clean` before running.
+- Dev-client builds only (no Expo Go on TV).
+- System font (`fontFamily: 'System'`) for platform-native typography.
+- `hexToRgba(color, 0)` for gradient stops — never `"transparent"`.
+- Validate all CMS-sourced URLs via `validateUrl.ts` before use.
+- Composite React keys: `key={\`${item.kind}-${item.id}-${index}\`}`.
+- Hardcoded English locale: `{ locale: "en" }` for all GraphQL queries.
+
+## TV-Specific Patterns
+
+- Every interactive element must be focusable via D-pad.
+- Visible focus ring (crimson glow) on focused elements.
+- `TVFocusGuideView` to constrain focus within horizontal rails.
+- `hasTVPreferredFocus` for initial focus control and back-navigation focus restore.
+- Stack navigation only: Home → Experience Detail → Video Playback.
+- Menu/Back button pops navigation stack.
+
+## Common Pitfalls
+
+- Android TV VideoView z-order: renders on top of all RN Views.
+- Focus lost on back-navigation (react-native-tvos #852): workaround with `hasTVPreferredFocus` in `useEffect`.
+- Lazy Apollo Client init: never module-scope. Use `getApolloClient()` getter.
+- `Math.round()` all scaled font sizes on Android (sub-pixel = blurry).
+- Must run `EXPO_TV=1 npx expo prebuild --clean` when switching between TV and phone targets.

--- a/apps/tv/app.json
+++ b/apps/tv/app.json
@@ -1,0 +1,47 @@
+{
+  "expo": {
+    "name": "forge-tv",
+    "slug": "jesus-film-forge-tv",
+    "version": "1.0.0",
+    "orientation": "landscape",
+    "userInterfaceStyle": "dark",
+    "newArchEnabled": false,
+    "splash": {
+      "resizeMode": "contain",
+      "backgroundColor": "#161311"
+    },
+    "ios": {
+      "bundleIdentifier": "org.jesusfilm.forgetv",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSAppTransportSecurity": {
+          "NSAllowsLocalNetworking": true
+        }
+      }
+    },
+    "android": {
+      "package": "org.jesusfilm.forgetv"
+    },
+    "plugins": [
+      "expo-router",
+      [
+        "@react-native-tvos/config-tv",
+        {
+          "isTV": true,
+          "tvosDeploymentTarget": "16.0"
+        }
+      ],
+      [
+        "expo-video",
+        {
+          "supportsBackgroundPlayback": false
+        }
+      ]
+    ],
+    "extra": {
+      "router": {
+        "origin": false
+      }
+    }
+  }
+}

--- a/apps/tv/app/_layout.tsx
+++ b/apps/tv/app/_layout.tsx
@@ -1,0 +1,176 @@
+import { Component, useRef } from "react"
+import { ScrollView, Text, View } from "react-native"
+import type { ErrorInfo, ReactNode } from "react"
+
+import {
+  VideoPlayerProvider,
+  useVideoPlayerContext,
+} from "../src/contexts/VideoPlayerContext"
+import { VideoPlayer } from "../src/components/VideoPlayer"
+
+/** Background color from Crimson Gallery design system */
+const BG_COLOR = "#161311"
+
+let moduleError: string | null = null
+
+let Stack: typeof import("expo-router").Stack
+let StatusBar: typeof import("expo-status-bar").StatusBar
+let ApolloProvider: typeof import("@apollo/client/react").ApolloProvider
+let getApolloClient: typeof import("../src/lib/apolloClient").getApolloClient
+
+// require() is intentional — static imports cause silent white screens when
+// module-level throws (e.g., env validation) crash the entire module graph.
+/* eslint-disable @typescript-eslint/no-require-imports */
+try {
+  Stack = require("expo-router").Stack
+  StatusBar = require("expo-status-bar").StatusBar
+  ApolloProvider = require("@apollo/client/react").ApolloProvider
+  getApolloClient = require("../src/lib/apolloClient").getApolloClient
+} catch (e: unknown) {
+  const err = e instanceof Error ? e : new Error(String(e))
+  moduleError = `${err.message}\n\n${err.stack ?? ""}`
+}
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+/** Renders the full-screen video player overlay when a video is active. */
+function VideoPlayerOverlay() {
+  const { state, dismissVideo } = useVideoPlayerContext()
+
+  if (!state.isVisible || state.currentUrl == null) {
+    return null
+  }
+
+  return (
+    <VideoPlayer
+      streamingUrl={state.currentUrl}
+      title={state.currentTitle ?? undefined}
+      subtitle={state.currentSubtitle ?? undefined}
+      onDismiss={dismissVideo}
+    />
+  )
+}
+
+class ErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null; errorInfo: ErrorInfo | null }
+> {
+  state: { error: Error | null; errorInfo: ErrorInfo | null } = {
+    error: null,
+    errorInfo: null,
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ errorInfo })
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: BG_COLOR,
+            padding: 80,
+          }}
+        >
+          <Text
+            style={{
+              color: "#ef4444",
+              fontSize: 28,
+              fontWeight: "bold",
+              marginBottom: 16,
+            }}
+          >
+            App Error
+          </Text>
+          <ScrollView>
+            <Text
+              style={{
+                color: "#fbbf24",
+                fontSize: 18,
+                fontFamily: "monospace",
+              }}
+              selectable
+            >
+              {this.state.error.message}
+            </Text>
+            {this.state.errorInfo?.componentStack && (
+              <Text
+                style={{
+                  color: "#a8a29e",
+                  fontSize: 14,
+                  fontFamily: "monospace",
+                  marginTop: 16,
+                }}
+                selectable
+              >
+                {this.state.errorInfo.componentStack}
+              </Text>
+            )}
+          </ScrollView>
+        </View>
+      )
+    }
+    return this.props.children
+  }
+}
+
+export default function RootLayout() {
+  const clientRef = useRef(moduleError == null ? getApolloClient() : null)
+
+  if (moduleError) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: BG_COLOR,
+          padding: 80,
+        }}
+      >
+        <Text
+          style={{
+            color: "#ef4444",
+            fontSize: 28,
+            fontWeight: "bold",
+            marginBottom: 16,
+          }}
+        >
+          Startup Error
+        </Text>
+        <ScrollView>
+          <Text
+            style={{
+              color: "#fbbf24",
+              fontSize: 18,
+              fontFamily: "monospace",
+            }}
+            selectable
+          >
+            {moduleError}
+          </Text>
+        </ScrollView>
+      </View>
+    )
+  }
+
+  return (
+    <ErrorBoundary>
+      <ApolloProvider client={clientRef.current!}>
+        <VideoPlayerProvider>
+          <StatusBar style="light" />
+          <Stack
+            screenOptions={{
+              headerShown: false,
+              contentStyle: { backgroundColor: BG_COLOR },
+            }}
+          />
+          <VideoPlayerOverlay />
+        </VideoPlayerProvider>
+      </ApolloProvider>
+    </ErrorBoundary>
+  )
+}

--- a/apps/tv/app/experience/[slug].tsx
+++ b/apps/tv/app/experience/[slug].tsx
@@ -1,0 +1,160 @@
+import { useQuery } from "@apollo/client/react"
+import { useLocalSearchParams } from "expo-router"
+import { useMemo, useState } from "react"
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native"
+
+import { SectionDispatcher } from "../../src/components/sections/SectionDispatcher"
+import { ExperienceProvider } from "../../src/contexts/ExperienceProvider"
+import { normalizeExperience } from "../../src/lib/normalizer"
+import { GET_WATCH_EXPERIENCE } from "../../src/lib/queries"
+
+export default function ExperienceDetailScreen() {
+  const { slug } = useLocalSearchParams<{ slug: string }>()
+  const decodedSlug = decodeURIComponent(slug ?? "")
+
+  const { data, loading, error, refetch } = useQuery(GET_WATCH_EXPERIENCE, {
+    variables: {
+      locale: "en",
+      filters: { slug: { eq: decodedSlug } },
+    },
+    skip: !decodedSlug,
+  })
+
+  const rawExperience = data?.experiences?.[0]
+
+  const experience = useMemo(() => {
+    if (!rawExperience) return null
+    return normalizeExperience(rawExperience as Record<string, unknown>)
+  }, [rawExperience])
+
+  const errorMessage = error?.message ?? null
+
+  const handleRefetch = useMemo(() => () => void refetch(), [refetch])
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#CB333B" />
+      </View>
+    )
+  }
+
+  if (errorMessage) {
+    return <ErrorState message={errorMessage} onRetry={handleRefetch} />
+  }
+
+  if (!experience || experience.sections.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyText}>No content available</Text>
+      </View>
+    )
+  }
+
+  return (
+    <ExperienceProvider
+      experience={experience}
+      loading={loading}
+      error={errorMessage}
+      refetch={handleRefetch}
+    >
+      <ScrollView
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+      >
+        {experience.sections.map((section, index) => (
+          <View key={`${section.kind}-${section.id}-${index}`}>
+            <SectionDispatcher section={section} />
+          </View>
+        ))}
+      </ScrollView>
+    </ExperienceProvider>
+  )
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string
+  onRetry: () => void
+}) {
+  const [focused, setFocused] = useState(false)
+
+  return (
+    <View style={styles.centered}>
+      <Text style={styles.errorText}>{message}</Text>
+      <Pressable
+        onPress={onRetry}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        hasTVPreferredFocus
+        style={[styles.retryButton, focused && styles.retryButtonFocused]}
+      >
+        <Text style={styles.retryButtonText}>Try Again</Text>
+      </Pressable>
+      <Text style={styles.backHint}>Press menu to go back</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#161311",
+  },
+  list: {
+    flex: 1,
+    backgroundColor: "#161311",
+  },
+  listContent: {
+    paddingBottom: 80,
+  },
+  emptyText: {
+    color: "#F5F5F4",
+    fontSize: 20,
+    fontFamily: "System",
+  },
+  errorText: {
+    color: "#F5F5F4",
+    fontSize: 20,
+    fontFamily: "System",
+    marginBottom: 24,
+    textAlign: "center",
+    paddingHorizontal: 40,
+  },
+  retryButton: {
+    backgroundColor: "#CB333B",
+    paddingHorizontal: 32,
+    paddingVertical: 12,
+    borderRadius: 24,
+  },
+  retryButtonFocused: {
+    shadowColor: "#CB333B",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.8,
+    shadowRadius: 12,
+    elevation: 8,
+  },
+  retryButtonText: {
+    color: "#F5F5F4",
+    fontSize: 18,
+    fontFamily: "System",
+    fontWeight: "600",
+  },
+  backHint: {
+    color: "#A8A29E",
+    fontSize: 14,
+    fontFamily: "System",
+    marginTop: 16,
+  },
+})

--- a/apps/tv/app/index.tsx
+++ b/apps/tv/app/index.tsx
@@ -1,0 +1,261 @@
+import { useQuery } from "@apollo/client/react"
+import { Image } from "expo-image"
+import { useRouter } from "expo-router"
+import { useState } from "react"
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native"
+
+import { ContentRail } from "../src/components/ContentRail"
+import { FocusableCard } from "../src/components/FocusableCard"
+import { HomeHero } from "../src/components/HomeHero"
+import { resolveImageUrl } from "../src/lib/resolveImageUrl"
+import { LIST_EXPERIENCES, GET_WATCH_EXPERIENCE } from "../src/lib/queries"
+
+/** Crimson Gallery design tokens */
+const COLORS = {
+  surface: "#161311",
+  surfaceContainer: "#221F1D",
+  primary: "#CB333B",
+  text: "#F5F5F4",
+  muted: "#A8A29E",
+} as const
+
+const CARD_WIDTH = 280
+const CARD_IMAGE_HEIGHT = 158
+
+export default function HomeScreen() {
+  const router = useRouter()
+  const [retryFocused, setRetryFocused] = useState(false)
+
+  const {
+    data: listData,
+    loading: listLoading,
+    error: listError,
+    refetch: listRefetch,
+  } = useQuery(LIST_EXPERIENCES, { variables: { locale: "en" } })
+
+  const experiences = (listData?.experiences ?? []).filter(
+    (e): e is NonNullable<typeof e> => e != null,
+  )
+  const homepageExperience = experiences.find((e) => e.isHomepage)
+
+  const { data: heroData, loading: heroLoading } = useQuery(
+    GET_WATCH_EXPERIENCE,
+    {
+      variables: {
+        locale: "en",
+        filters: { slug: { eq: homepageExperience?.slug ?? "" } },
+      },
+      skip: !homepageExperience?.slug,
+    },
+  )
+
+  // Extract hero image from the homepage experience's first videoHero block
+  const heroExperience = heroData?.experiences?.[0]
+  const heroBlocks = (heroExperience?.blocks ?? []).filter(
+    (b): b is NonNullable<typeof b> => b != null,
+  )
+  const heroBlock = heroBlocks.find(
+    (b) => b.__typename === "ComponentSectionsVideoHero",
+  )
+  const heroVideoStill = (() => {
+    if (
+      heroBlock == null ||
+      heroBlock.__typename !== "ComponentSectionsVideoHero"
+    )
+      return null
+    const images = heroBlock.video?.images
+    if (!Array.isArray(images) || images.length === 0) return null
+    const first = images[0]
+    return first?.videoStill ?? null
+  })()
+
+  // Fallback to ogImage if no videoHero image
+  const finalHeroImage =
+    resolveImageUrl(heroVideoStill) ??
+    resolveImageUrl(homepageExperience?.ogImage?.url ?? null)
+
+  const isLoading = listLoading || heroLoading
+
+  // ── Loading state ──
+  if (isLoading && !listData) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={COLORS.primary} />
+      </View>
+    )
+  }
+
+  // ── Error state ──
+  if (listError) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>Something went wrong</Text>
+        <Text style={styles.errorDetail}>{listError.message}</Text>
+        <Pressable
+          onFocus={() => setRetryFocused(true)}
+          onBlur={() => setRetryFocused(false)}
+          style={[
+            styles.retryButton,
+            retryFocused && styles.retryButtonFocused,
+          ]}
+          onPress={() => void listRefetch()}
+          hasTVPreferredFocus
+        >
+          <Text style={styles.retryText}>Try Again</Text>
+        </Pressable>
+      </View>
+    )
+  }
+
+  // ── Empty state ──
+  if (experiences.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyText}>No experiences available</Text>
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.scrollContent}
+    >
+      {/* Hero area */}
+      {homepageExperience ? (
+        <HomeHero
+          title={homepageExperience.title ?? ""}
+          subtitle={homepageExperience.metaDescription ?? undefined}
+          imageUrl={finalHeroImage}
+        />
+      ) : null}
+
+      {/* Experiences rail */}
+      <View style={styles.railContainer}>
+        <ContentRail
+          title="Experiences"
+          railId="home-experiences"
+          data={experiences}
+          keyExtractor={(item) => item.documentId}
+          renderItem={(item) => {
+            const imageUrl = resolveImageUrl(item.ogImage?.url ?? null)
+            return (
+              <FocusableCard
+                onPress={() => {
+                  router.push(`/experience/${encodeURIComponent(item.slug)}`)
+                }}
+                style={styles.card}
+              >
+                {imageUrl ? (
+                  <Image
+                    source={{ uri: imageUrl }}
+                    style={styles.cardImage}
+                    contentFit="cover"
+                    recyclingKey={`card-${item.documentId}`}
+                  />
+                ) : (
+                  <View style={[styles.cardImage, styles.cardImageFallback]} />
+                )}
+                <View style={styles.cardTextContainer}>
+                  <Text style={styles.cardTitle} numberOfLines={2}>
+                    {item.title ?? "Untitled"}
+                  </Text>
+                </View>
+              </FocusableCard>
+            )
+          }}
+        />
+      </View>
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: COLORS.surface,
+  },
+  scrollContent: {
+    paddingBottom: 80,
+  },
+  centered: {
+    flex: 1,
+    backgroundColor: COLORS.surface,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 80,
+  },
+  railContainer: {
+    marginTop: 24,
+  },
+  // ── Error state ──
+  errorText: {
+    fontFamily: "System",
+    fontSize: 28,
+    fontWeight: "bold",
+    color: COLORS.text,
+    marginBottom: 8,
+  },
+  errorDetail: {
+    fontFamily: "System",
+    fontSize: 18,
+    color: COLORS.muted,
+    marginBottom: 32,
+    textAlign: "center",
+  },
+  retryButton: {
+    paddingHorizontal: 40,
+    paddingVertical: 16,
+    borderRadius: 28,
+    backgroundColor: COLORS.primary,
+  },
+  retryButtonFocused: {
+    transform: [{ scale: 1.05 }],
+    shadowColor: COLORS.primary,
+    shadowRadius: 20,
+    shadowOpacity: 0.5,
+    shadowOffset: { width: 0, height: 0 },
+  },
+  retryText: {
+    fontFamily: "System",
+    fontSize: 20,
+    fontWeight: "600",
+    color: COLORS.text,
+  },
+  // ── Empty state ──
+  emptyText: {
+    fontFamily: "System",
+    fontSize: 24,
+    color: COLORS.muted,
+  },
+  // ── Card styles ──
+  card: {
+    width: CARD_WIDTH,
+    overflow: "hidden",
+  },
+  cardImage: {
+    width: CARD_WIDTH,
+    height: CARD_IMAGE_HEIGHT,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  cardImageFallback: {
+    backgroundColor: COLORS.surfaceContainer,
+  },
+  cardTextContainer: {
+    padding: 12,
+  },
+  cardTitle: {
+    fontFamily: "System",
+    fontSize: 16,
+    fontWeight: "600",
+    color: COLORS.text,
+  },
+})

--- a/apps/tv/babel.config.js
+++ b/apps/tv/babel.config.js
@@ -1,0 +1,7 @@
+/* global module */
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ["babel-preset-expo"],
+  }
+}

--- a/apps/tv/metro.config.js
+++ b/apps/tv/metro.config.js
@@ -1,0 +1,65 @@
+/* global require, module */
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { getDefaultConfig } = require("expo/metro-config")
+const path = require("path")
+
+const projectRoot = __dirname
+const monorepoRoot = path.resolve(projectRoot, "../..")
+
+const config = getDefaultConfig(projectRoot)
+
+// Watch the monorepo root for workspace package changes,
+// preserving Expo's default watchFolders (required by expo-doctor).
+config.watchFolders = [...(config.watchFolders || []), monorepoRoot]
+
+// Resolve packages from the monorepo root
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, "node_modules"),
+  path.resolve(monorepoRoot, "node_modules"),
+]
+
+// Apollo Client v4 can ship .cjs; ensure Metro resolves them
+config.resolver.sourceExts.push("cjs")
+
+// In a pnpm monorepo Metro can follow symlinks into .pnpm and resolve a
+// different copy of react (18.x from cms, 19.x from web's react-dom, etc).
+// Force every import of these packages to the single copy this app owns.
+// Note: react-native resolves to react-native-tvos via the npm alias.
+const singletonPkgs = {
+  react: path.resolve(projectRoot, "node_modules/react"),
+  "react-native": path.resolve(projectRoot, "node_modules/react-native"),
+}
+
+config.resolver.extraNodeModules = singletonPkgs
+
+function resolveFromProjectRoot(context, moduleName, platform) {
+  return context.resolveRequest(
+    {
+      ...context,
+      resolveRequest: undefined,
+      originModulePath: path.join(projectRoot, "package.json"),
+    },
+    moduleName,
+    platform,
+  )
+}
+
+const defaultResolveRequest = config.resolver.resolveRequest
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  // Exact match (e.g. "react") or deep import (e.g. "react/jsx-runtime")
+  const isSingleton =
+    singletonPkgs[moduleName] ||
+    Object.keys(singletonPkgs).some((pkg) => moduleName.startsWith(pkg + "/"))
+
+  if (isSingleton) {
+    return resolveFromProjectRoot(context, moduleName, platform)
+  }
+
+  // Fall through to any prior resolver, or Metro's built-in default
+  if (defaultResolveRequest) {
+    return defaultResolveRequest(context, moduleName, platform)
+  }
+  return context.resolveRequest(context, moduleName, platform)
+}
+
+module.exports = config

--- a/apps/tv/package.json
+++ b/apps/tv/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@forge/tv",
+  "version": "1.0.0",
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "EXPO_TV=1 expo start",
+    "ios": "EXPO_TV=1 expo run:ios",
+    "android": "EXPO_TV=1 expo run:android",
+    "prebuild": "EXPO_TV=1 npx expo prebuild --clean",
+    "lint": "eslint .",
+    "test": "jest --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "build": "echo 'Expo TV app has no production bundle step; use EAS when needed.'"
+  },
+  "dependencies": {
+    "@apollo/client": "^4.1.4",
+    "@forge/graphql": "workspace:*",
+    "@react-native-tvos/config-tv": "^0.0.13",
+    "@t3-oss/env-core": "^0.13.11",
+    "expo": "~54.0.33",
+    "expo-constants": "~18.0.13",
+    "expo-dev-client": "~6.0.20",
+    "expo-image": "~3.0.11",
+    "expo-linking": "~8.0.11",
+    "expo-router": "~6.0.23",
+    "expo-status-bar": "~3.0.9",
+    "expo-video": "~3.0.16",
+    "graphql": "16.13.1",
+    "react": "19.1.0",
+    "react-native": "npm:react-native-tvos@0.81-stable",
+    "react-native-screens": "~4.16.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@babel/runtime": "^7.28.0",
+    "@types/jest": "^29.5.0",
+    "@types/react": "~19.1.17",
+    "babel-preset-expo": "^54.0.10",
+    "eslint": ">=8.10",
+    "eslint-config-expo": "~10.0.0",
+    "jest": "^29.7.0",
+    "jest-expo": "~54.0.0",
+    "typescript": "~5.9.2"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|react-navigation|@react-navigation|@t3-oss|zod))"
+    ]
+  },
+  "private": true
+}

--- a/apps/tv/src/components/ContentRail.tsx
+++ b/apps/tv/src/components/ContentRail.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback, useRef, type ReactNode } from "react"
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+  // @ts-expect-error TVFocusGuideView is provided by react-native-tvos but not in base RN types
+  TVFocusGuideView,
+} from "react-native"
+
+/** Module-level focus memory: railId -> last focused index */
+const focusMemory = new Map<string, number>()
+
+type ContentRailProps<T> = {
+  title: string
+  data: T[]
+  renderItem: (item: T, index: number) => ReactNode
+  railId: string
+  keyExtractor: (item: T) => string
+}
+
+export function ContentRail<T>({
+  title,
+  data,
+  renderItem,
+  railId,
+  keyExtractor,
+}: ContentRailProps<T>) {
+  const listRef = useRef<FlatList<T>>(null)
+
+  const handleItemFocus = useCallback(
+    (index: number) => {
+      focusMemory.set(railId, index)
+    },
+    [railId],
+  )
+
+  if (data.length === 0) {
+    return null
+  }
+
+  const savedIndex = focusMemory.get(railId)
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      <TVFocusGuideView autoFocus>
+        <FlatList
+          ref={listRef}
+          data={data}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+          initialScrollIndex={savedIndex}
+          keyExtractor={keyExtractor}
+          getItemLayout={undefined}
+          renderItem={({ item, index }) => (
+            <View
+              style={index < data.length - 1 ? styles.itemWithGap : undefined}
+              onFocus={() => handleItemFocus(index)}
+            >
+              {renderItem(item, index)}
+            </View>
+          )}
+        />
+      </TVFocusGuideView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 32,
+  },
+  title: {
+    fontFamily: "System",
+    fontSize: 20,
+    color: "#A8A29E",
+    letterSpacing: 0.5,
+    marginBottom: 12,
+    paddingHorizontal: 80,
+  },
+  listContent: {
+    paddingHorizontal: 80,
+  },
+  itemWithGap: {
+    marginRight: 24,
+  },
+})

--- a/apps/tv/src/components/FocusableCard.tsx
+++ b/apps/tv/src/components/FocusableCard.tsx
@@ -1,0 +1,54 @@
+import { useState, type ReactNode } from "react"
+import { Pressable, StyleSheet, type ViewStyle } from "react-native"
+
+type FocusableCardProps = {
+  onPress: () => void
+  onFocus?: () => void
+  onBlur?: () => void
+  hasTVPreferredFocus?: boolean
+  style?: ViewStyle
+  children: ReactNode
+}
+
+export function FocusableCard({
+  onPress,
+  onFocus,
+  onBlur,
+  hasTVPreferredFocus,
+  style,
+  children,
+}: FocusableCardProps) {
+  const [isFocused, setIsFocused] = useState(false)
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onFocus={() => {
+        setIsFocused(true)
+        onFocus?.()
+      }}
+      onBlur={() => {
+        setIsFocused(false)
+        onBlur?.()
+      }}
+      hasTVPreferredFocus={hasTVPreferredFocus}
+      style={[styles.card, isFocused && styles.cardFocused, style]}
+    >
+      {children}
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#2D2927",
+    borderRadius: 16,
+  },
+  cardFocused: {
+    transform: [{ scale: 1.05 }],
+    shadowColor: "#CB333B",
+    shadowRadius: 20,
+    shadowOpacity: 0.5,
+    shadowOffset: { width: 0, height: 0 },
+  },
+})

--- a/apps/tv/src/components/HomeHero.tsx
+++ b/apps/tv/src/components/HomeHero.tsx
@@ -1,0 +1,105 @@
+import { Dimensions, StyleSheet, Text, View } from "react-native"
+import { Image } from "expo-image"
+
+const { height: SCREEN_HEIGHT } = Dimensions.get("window")
+const HERO_HEIGHT = SCREEN_HEIGHT * 0.55
+
+/** Crimson Gallery design tokens */
+const COLORS = {
+  surface: "#161311",
+  surfaceContainer: "#221F1D",
+  text: "#F5F5F4",
+  muted: "#A8A29E",
+} as const
+
+type HomeHeroProps = {
+  title: string
+  subtitle?: string
+  imageUrl?: string | null
+}
+
+export function HomeHero({ title, subtitle, imageUrl }: HomeHeroProps) {
+  return (
+    <View style={styles.container}>
+      {imageUrl ? (
+        <Image
+          source={{ uri: imageUrl }}
+          style={StyleSheet.absoluteFill}
+          contentFit="cover"
+          recyclingKey={`hero-${imageUrl}`}
+        />
+      ) : (
+        <View style={[StyleSheet.absoluteFill, styles.fallbackBg]} />
+      )}
+
+      {/* Gradient overlay: only show over images, not fallback */}
+      {imageUrl != null && (
+        <>
+          <View style={styles.gradientTop} />
+          <View style={styles.gradientBottom} />
+        </>
+      )}
+
+      {/* Text overlay */}
+      <View style={styles.textContainer}>
+        <Text style={styles.title} numberOfLines={2}>
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text style={styles.subtitle} numberOfLines={2}>
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+    height: HERO_HEIGHT,
+    position: "relative",
+    overflow: "hidden",
+  },
+  fallbackBg: {
+    backgroundColor: COLORS.surfaceContainer,
+  },
+  gradientTop: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: HERO_HEIGHT * 0.4,
+    height: HERO_HEIGHT * 0.3,
+    backgroundColor: COLORS.surface,
+    opacity: 0.3,
+  },
+  gradientBottom: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: HERO_HEIGHT * 0.5,
+    backgroundColor: COLORS.surface,
+    opacity: 0.85,
+  },
+  textContainer: {
+    position: "absolute",
+    bottom: 48,
+    left: 80,
+    right: 80,
+  },
+  title: {
+    fontFamily: "System",
+    fontSize: 44,
+    fontWeight: "bold",
+    color: COLORS.text,
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontFamily: "System",
+    fontSize: 20,
+    color: COLORS.muted,
+    marginTop: 8,
+  },
+})

--- a/apps/tv/src/components/VideoPlayer.tsx
+++ b/apps/tv/src/components/VideoPlayer.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useRef, useState } from "react"
+import { Pressable, StyleSheet, Text, View } from "react-native"
+import { useVideoPlayer, VideoView } from "expo-video"
+
+// ── Design System ───────────────────────────────────────────────────────────
+
+const COLORS = {
+  surface: "#161311",
+  surfaceContainerGlass: "rgba(34, 31, 29, 0.7)",
+  crimson: "#CB333B",
+  text: "#F5F5F4",
+  muted: "#A8A29E",
+} as const
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface VideoPlayerProps {
+  streamingUrl: string
+  title?: string
+  subtitle?: string
+  onDismiss: () => void
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export function VideoPlayer({
+  streamingUrl,
+  title,
+  subtitle,
+  onDismiss,
+}: VideoPlayerProps) {
+  const [isPaused, setIsPaused] = useState(false)
+  const [isPlayPauseFocused, setIsPlayPauseFocused] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+
+  // Keep source reference stable per the institutional learning:
+  // useVideoPlayer(source) — source must be stable.
+  const sourceRef = useRef(streamingUrl)
+  sourceRef.current = streamingUrl
+
+  const player = useVideoPlayer(sourceRef.current, (p) => {
+    p.timeUpdateEventInterval = 1
+  })
+
+  // Auto-play on mount
+  useEffect(() => {
+    player.play()
+  }, [player])
+
+  // Listen to playToEnd for auto-dismiss
+  useEffect(() => {
+    const subscription = player.addListener("playToEnd", () => {
+      onDismiss()
+    })
+    return () => {
+      subscription.remove()
+    }
+  }, [player, onDismiss])
+
+  // Track playing state changes
+  useEffect(() => {
+    const subscription = player.addListener(
+      "playingChange",
+      ({ isPlaying }) => {
+        setIsPaused(!isPlaying)
+      },
+    )
+    return () => {
+      subscription.remove()
+    }
+  }, [player])
+
+  // Track time updates
+  useEffect(() => {
+    const subscription = player.addListener("timeUpdate", (payload) => {
+      setCurrentTime(payload.currentTime)
+    })
+    return () => {
+      subscription.remove()
+    }
+  }, [player])
+
+  // Track duration from sourceLoad
+  useEffect(() => {
+    const subscription = player.addListener("sourceLoad", (payload) => {
+      setDuration(payload.duration)
+    })
+    return () => {
+      subscription.remove()
+    }
+  }, [player])
+
+  // Pause on unmount
+  useEffect(() => {
+    return () => {
+      player.pause()
+    }
+  }, [player])
+
+  const togglePlayPause = () => {
+    if (player.playing) {
+      player.pause()
+    } else {
+      player.play()
+    }
+  }
+
+  return (
+    <View style={styles.overlay}>
+      <VideoView
+        style={StyleSheet.absoluteFill}
+        player={player}
+        nativeControls={false}
+        contentFit="contain"
+      />
+
+      {/* Back hint — top left */}
+      <View style={styles.backHintContainer}>
+        <Pressable onPress={onDismiss} style={styles.backButton}>
+          <Text style={styles.backHintText}>{"← Back"}</Text>
+        </Pressable>
+      </View>
+
+      {/* Transport controls — bottom glassmorphism bar */}
+      <View style={styles.transportBar}>
+        {/* Left: title + subtitle */}
+        <View style={styles.transportLeft}>
+          {title != null && (
+            <Text style={styles.transportTitle} numberOfLines={1}>
+              {title}
+            </Text>
+          )}
+          {subtitle != null && (
+            <Text style={styles.transportSubtitle} numberOfLines={1}>
+              {subtitle}
+            </Text>
+          )}
+        </View>
+
+        {/* Center: play/pause */}
+        <Pressable
+          onPress={togglePlayPause}
+          onFocus={() => setIsPlayPauseFocused(true)}
+          onBlur={() => setIsPlayPauseFocused(false)}
+          style={[
+            styles.playPauseButton,
+            isPlayPauseFocused && styles.playPauseButtonFocused,
+          ]}
+          hasTVPreferredFocus
+        >
+          <Text style={styles.playPauseText}>{isPaused ? "▶" : "⏸"}</Text>
+        </Pressable>
+
+        {/* Right: time display */}
+        <View style={styles.transportRight}>
+          <Text style={styles.timeText}>
+            {formatTime(currentTime)}
+            {duration > 0 ? ` / ${formatTime(duration)}` : ""}
+          </Text>
+        </View>
+      </View>
+
+      {/* NOTE: Seek controls (rewind/fast-forward via TV remote) are deferred.
+          Implementing seek requires native TV remote event listeners (e.g.,
+          TVEventHandler or platform-specific swipe gestures) which adds
+          complexity beyond the prototype scope. */}
+    </View>
+  )
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}:${secs.toString().padStart(2, "0")}`
+}
+
+// ── Styles ──────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: COLORS.surface,
+    zIndex: 1000,
+  },
+  backHintContainer: {
+    position: "absolute",
+    top: 40,
+    left: 48,
+    zIndex: 1001,
+  },
+  backButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  backHintText: {
+    fontFamily: "System",
+    fontSize: 16,
+    color: COLORS.muted,
+  },
+  transportBar: {
+    position: "absolute",
+    bottom: 40,
+    left: 48,
+    right: 48,
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: COLORS.surfaceContainerGlass,
+    borderRadius: 16,
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+    zIndex: 1001,
+  },
+  transportLeft: {
+    flex: 1,
+    marginRight: 16,
+  },
+  transportTitle: {
+    fontFamily: "System",
+    fontSize: 18,
+    fontWeight: "500",
+    color: COLORS.text,
+  },
+  transportSubtitle: {
+    fontFamily: "System",
+    fontSize: 14,
+    color: COLORS.muted,
+    marginTop: 2,
+  },
+  playPauseButton: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  playPauseButtonFocused: {
+    backgroundColor: COLORS.crimson,
+    shadowColor: COLORS.crimson,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.6,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  playPauseText: {
+    fontSize: 24,
+    color: COLORS.text,
+  },
+  transportRight: {
+    flex: 1,
+    alignItems: "flex-end",
+    marginLeft: 16,
+  },
+  timeText: {
+    fontFamily: "System",
+    fontSize: 14,
+    color: COLORS.muted,
+    fontVariant: ["tabular-nums"],
+  },
+})

--- a/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
+++ b/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
@@ -1,0 +1,142 @@
+import React, { useCallback } from "react"
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+  // @ts-expect-error TVFocusGuideView is provided by react-native-tvos but not in base RN types
+  TVFocusGuideView,
+} from "react-native"
+
+import type { NormalizedBlock } from "../../lib/normalizer"
+import { FocusableCard } from "../FocusableCard"
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const CARD_WIDTH = 400
+const CARD_GAP = 24
+
+const COLORS = {
+  surfaceContainer: "#221F1D",
+  crimson: "#CB333B",
+  text: "#F5F5F4",
+  muted: "#A8A29E",
+} as const
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type QuoteItem = {
+  id: string
+  reference: string
+  text: string
+  attribution?: string | null
+}
+
+export interface BibleQuotesCarouselRendererProps {
+  section: NormalizedBlock
+}
+
+// ── QuoteCard ────────────────────────────────────────────────────────────────
+
+function QuoteCard({ quote }: { quote: QuoteItem }) {
+  return (
+    <FocusableCard
+      onPress={() => {
+        console.log("[BibleQuotesCarousel] Selected:", quote.reference)
+      }}
+      style={styles.card}
+    >
+      <Text style={styles.reference}>{quote.reference}</Text>
+      <Text style={styles.quoteText}>{quote.text}</Text>
+    </FocusableCard>
+  )
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function BibleQuotesCarouselRenderer({
+  section,
+}: BibleQuotesCarouselRendererProps) {
+  const heading = section.bqcHeading as string | null
+  const quotes = (section.quotes as QuoteItem[] | undefined) ?? []
+
+  const renderItem = useCallback(
+    ({ item }: { item: QuoteItem }) => <QuoteCard quote={item} />,
+    [],
+  )
+
+  const keyExtractor = useCallback(
+    (item: QuoteItem, index: number) => `bqc-${item.id}-${index}`,
+    [],
+  )
+
+  if (quotes.length === 0) return null
+
+  return (
+    <View style={styles.container}>
+      {heading != null && (
+        <Text style={styles.heading} accessibilityRole="header">
+          {heading}
+        </Text>
+      )}
+      <TVFocusGuideView autoFocus>
+        <FlatList
+          data={quotes}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+          ItemSeparatorComponent={Separator}
+        />
+      </TVFocusGuideView>
+    </View>
+  )
+}
+
+function Separator() {
+  return <View style={styles.separator} />
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 32,
+  },
+  heading: {
+    fontFamily: "System",
+    fontSize: 20,
+    fontWeight: "600",
+    color: COLORS.muted,
+    letterSpacing: 0.5,
+    marginBottom: 12,
+    paddingHorizontal: 80,
+  },
+  listContent: {
+    paddingHorizontal: 80,
+  },
+  separator: {
+    width: CARD_GAP,
+  },
+  card: {
+    width: CARD_WIDTH,
+    backgroundColor: COLORS.surfaceContainer,
+    borderRadius: 16,
+    padding: 24,
+  },
+  reference: {
+    fontFamily: "System",
+    fontSize: 18,
+    fontWeight: "500",
+    color: COLORS.crimson,
+    marginBottom: 12,
+  },
+  quoteText: {
+    fontFamily: "System",
+    fontSize: 20,
+    fontWeight: "400",
+    color: COLORS.text,
+    lineHeight: 30,
+  },
+})

--- a/apps/tv/src/components/sections/ContainerRenderer.tsx
+++ b/apps/tv/src/components/sections/ContainerRenderer.tsx
@@ -1,0 +1,56 @@
+import { StyleSheet, View } from "react-native"
+
+import type { NormalizedBlock } from "../../lib/normalizer"
+import { SectionDispatcher } from "./SectionDispatcher"
+
+type Slot = {
+  id: string
+  gridSpan: number
+  slotContent?: NormalizedBlock[]
+}
+
+export interface ContainerRendererProps {
+  section: NormalizedBlock
+}
+
+export function ContainerRenderer({ section }: ContainerRendererProps) {
+  const slots = (section.slots as Slot[] | undefined) ?? []
+
+  if (slots.length === 0) return null
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        {slots.map((slot) => {
+          const content = slot.slotContent ?? []
+          return (
+            <View
+              key={`container-slot-${slot.id}`}
+              style={[styles.slot, { flex: slot.gridSpan }]}
+            >
+              {content.map((child, index) => (
+                <SectionDispatcher
+                  key={`${child.kind}-${child.id}-${index}`}
+                  section={child}
+                />
+              ))}
+            </View>
+          )
+        })}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 80,
+    paddingVertical: 24,
+  },
+  row: {
+    flexDirection: "row",
+  },
+  slot: {
+    minWidth: 0,
+  },
+})

--- a/apps/tv/src/components/sections/PlaceholderRenderer.tsx
+++ b/apps/tv/src/components/sections/PlaceholderRenderer.tsx
@@ -1,0 +1,16 @@
+import type { NormalizedBlock } from "../../lib/normalizer"
+
+export interface PlaceholderRendererProps {
+  section: NormalizedBlock
+}
+
+/**
+ * Fallback renderer for unimplemented block types.
+ * Logs a warning in dev and renders nothing.
+ */
+export function PlaceholderRenderer({ section }: PlaceholderRendererProps) {
+  if (__DEV__) {
+    console.warn(`[TV] Unhandled block type: ${section.kind}`)
+  }
+  return null
+}

--- a/apps/tv/src/components/sections/SectionDispatcher.tsx
+++ b/apps/tv/src/components/sections/SectionDispatcher.tsx
@@ -1,0 +1,33 @@
+import type { NormalizedBlock } from "../../lib/normalizer"
+import { SectionWrapperRenderer } from "./SectionWrapperRenderer"
+import { ContainerRenderer } from "./ContainerRenderer"
+import { VideoHeroRenderer } from "./VideoHeroRenderer"
+import { VideoCardRenderer } from "./VideoCardRenderer"
+import { TextRenderer } from "./TextRenderer"
+import { BibleQuotesCarouselRenderer } from "./BibleQuotesCarouselRenderer"
+import { PlaceholderRenderer } from "./PlaceholderRenderer"
+
+export interface SectionDispatcherProps {
+  section: NormalizedBlock
+}
+
+export function SectionDispatcher({ section }: SectionDispatcherProps) {
+  const { kind } = section
+
+  switch (kind) {
+    case "sectionWrapper":
+      return <SectionWrapperRenderer section={section} />
+    case "container":
+      return <ContainerRenderer section={section} />
+    case "videoHero":
+      return <VideoHeroRenderer section={section} />
+    case "video":
+      return <VideoCardRenderer section={section} />
+    case "text":
+      return <TextRenderer section={section} />
+    case "bibleQuotesCarousel":
+      return <BibleQuotesCarouselRenderer section={section} />
+    default:
+      return <PlaceholderRenderer section={section} />
+  }
+}

--- a/apps/tv/src/components/sections/SectionWrapperRenderer.tsx
+++ b/apps/tv/src/components/sections/SectionWrapperRenderer.tsx
@@ -1,0 +1,34 @@
+import { StyleSheet, View } from "react-native"
+
+import type { NormalizedBlock } from "../../lib/normalizer"
+import { SectionDispatcher } from "./SectionDispatcher"
+
+export interface SectionWrapperRendererProps {
+  section: NormalizedBlock
+}
+
+export function SectionWrapperRenderer({
+  section,
+}: SectionWrapperRendererProps) {
+  const content =
+    (section.sectionContent as NormalizedBlock[] | undefined) ?? []
+
+  if (content.length === 0) return null
+
+  return (
+    <View style={styles.wrapper}>
+      {content.map((child, index) => (
+        <SectionDispatcher
+          key={`${child.kind}-${child.id}-${index}`}
+          section={child}
+        />
+      ))}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    paddingVertical: 24,
+  },
+})

--- a/apps/tv/src/components/sections/TextRenderer.tsx
+++ b/apps/tv/src/components/sections/TextRenderer.tsx
@@ -1,0 +1,75 @@
+import { StyleSheet, Text, View } from "react-native"
+
+import type { NormalizedBlock } from "../../lib/normalizer"
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const COLORS = {
+  text: "#F5F5F4",
+  muted: "#A8A29E",
+} as const
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface TextRendererProps {
+  section: NormalizedBlock
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function TextRenderer({ section }: TextRendererProps) {
+  const heading = section.textHeading as string | null
+  const rawParagraphs = section.contentParagraphs
+
+  // contentParagraphs is a Strapi JSON field that should be string[]
+  const paragraphs: string[] = Array.isArray(rawParagraphs)
+    ? (rawParagraphs as string[])
+    : []
+
+  return (
+    <View style={styles.container}>
+      {heading != null && (
+        <Text style={styles.heading} accessibilityRole="header">
+          {heading}
+        </Text>
+      )}
+      {paragraphs.map((paragraph, index) => (
+        <Text
+          key={`text-p-${index}`}
+          style={[
+            styles.paragraph,
+            index < paragraphs.length - 1 && styles.paragraphSpacing,
+          ]}
+        >
+          {paragraph}
+        </Text>
+      ))}
+    </View>
+  )
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 80,
+    paddingVertical: 32,
+  },
+  heading: {
+    fontFamily: "System",
+    fontSize: 28,
+    fontWeight: "bold",
+    color: COLORS.text,
+    marginBottom: 16,
+  },
+  paragraph: {
+    fontFamily: "System",
+    fontSize: 22,
+    fontWeight: "400",
+    color: COLORS.muted,
+    lineHeight: 33,
+  },
+  paragraphSpacing: {
+    marginBottom: 16,
+  },
+})

--- a/apps/tv/src/components/sections/VideoCardRenderer.tsx
+++ b/apps/tv/src/components/sections/VideoCardRenderer.tsx
@@ -1,0 +1,120 @@
+import { StyleSheet, Text, View } from "react-native"
+import { Image } from "expo-image"
+
+import type { NormalizedBlock } from "../../lib/normalizer"
+import { resolveImageUrl } from "../../lib/resolveImageUrl"
+import { FocusableCard } from "../FocusableCard"
+import { useVideoPlayerContext } from "../../contexts/VideoPlayerContext"
+import { validateStreamingUrl } from "../../lib/validateUrl"
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const CARD_WIDTH = 320
+const THUMBNAIL_HEIGHT = 180
+
+const COLORS = {
+  surfaceContainerHigh: "#2D2927",
+  text: "#F5F5F4",
+  muted: "#A8A29E",
+  surfaceContainerHighest: "#383432",
+} as const
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface VideoCardRendererProps {
+  section: NormalizedBlock
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function VideoCardRenderer({ section }: VideoCardRendererProps) {
+  const { playVideo } = useVideoPlayerContext()
+  const streamingUrl = section.streamingUrl as string | null | undefined
+
+  const video = section.videoRef as
+    | {
+        documentId?: string
+        title?: string
+        slug?: string
+        images?: {
+          url?: string
+          videoStill?: string
+        }[]
+      }
+    | null
+    | undefined
+
+  const videoStill = video?.images?.[0]?.videoStill ?? null
+  const ogImage = video?.images?.[0]?.url ?? null
+  const imageSource = resolveImageUrl(videoStill) ?? resolveImageUrl(ogImage)
+
+  // Title: prefer video title, fall back to section heading
+  const title = video?.title ?? (section.videoTitle as string | null) ?? null
+
+  return (
+    <FocusableCard
+      onPress={() => {
+        if (validateStreamingUrl(streamingUrl)) {
+          playVideo(streamingUrl!, title ?? undefined)
+        } else {
+          console.log(
+            "[VideoCardRenderer] No streamingUrl for:",
+            title ?? video?.slug,
+          )
+        }
+      }}
+      style={styles.card}
+    >
+      <View style={styles.thumbnailContainer}>
+        {imageSource != null ? (
+          <Image
+            source={imageSource}
+            style={styles.thumbnail}
+            contentFit="cover"
+            recyclingKey={`video-card-${section.kind}-${String(video?.documentId ?? "unknown")}`}
+            accessibilityLabel={title ?? "Video thumbnail"}
+          />
+        ) : (
+          <View style={[styles.thumbnail, styles.thumbnailFallback]} />
+        )}
+      </View>
+      {title != null && (
+        <Text style={styles.title} numberOfLines={2}>
+          {title}
+        </Text>
+      )}
+    </FocusableCard>
+  )
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  card: {
+    width: CARD_WIDTH,
+    backgroundColor: COLORS.surfaceContainerHigh,
+    borderRadius: 16,
+    overflow: "hidden",
+  },
+  thumbnailContainer: {
+    width: CARD_WIDTH,
+    height: THUMBNAIL_HEIGHT,
+    position: "relative",
+  },
+  thumbnail: {
+    width: CARD_WIDTH,
+    height: THUMBNAIL_HEIGHT,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  thumbnailFallback: {
+    backgroundColor: COLORS.surfaceContainerHighest,
+  },
+  title: {
+    fontFamily: "System",
+    fontSize: 16,
+    fontWeight: "600",
+    color: COLORS.text,
+    padding: 12,
+  },
+})

--- a/apps/tv/src/components/sections/VideoHeroRenderer.tsx
+++ b/apps/tv/src/components/sections/VideoHeroRenderer.tsx
@@ -1,0 +1,157 @@
+import { Dimensions, Pressable, StyleSheet, Text, View } from "react-native"
+import { Image } from "expo-image"
+
+import type { NormalizedBlock } from "../../lib/normalizer"
+import { resolveImageUrl } from "../../lib/resolveImageUrl"
+import { useVideoPlayerContext } from "../../contexts/VideoPlayerContext"
+import { validateStreamingUrl } from "../../lib/validateUrl"
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const { height: SCREEN_HEIGHT } = Dimensions.get("window")
+const HERO_HEIGHT = SCREEN_HEIGHT * 0.55
+
+const COLORS = {
+  surface: "#161311",
+  surfaceContainer: "#221F1D",
+  text: "#F5F5F4",
+  muted: "#A8A29E",
+} as const
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface VideoHeroRendererProps {
+  section: NormalizedBlock
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function VideoHeroRenderer({ section }: VideoHeroRendererProps) {
+  const { playVideo } = useVideoPlayerContext()
+  const heading = section.heading as string | null
+  const subheading = section.subheading as string | null
+  const streamingUrl = section.streamingUrl as string | null | undefined
+
+  const video = section.video as
+    | {
+        documentId?: string
+        title?: string
+        slug?: string
+        images?: {
+          url?: string
+          mobileCinematicHigh?: string
+          videoStill?: string
+        }[]
+      }
+    | null
+    | undefined
+
+  const videoStill = video?.images?.[0]?.videoStill ?? null
+  const ogImage = video?.images?.[0]?.url ?? null
+  const imageSource = resolveImageUrl(videoStill) ?? resolveImageUrl(ogImage)
+
+  return (
+    <Pressable
+      style={styles.container}
+      onPress={() => {
+        if (validateStreamingUrl(streamingUrl)) {
+          playVideo(
+            streamingUrl!,
+            heading ?? video?.title ?? undefined,
+            subheading ?? undefined,
+          )
+        } else {
+          console.log(
+            "[VideoHeroRenderer] No streamingUrl for:",
+            heading ?? video?.slug,
+          )
+        }
+      }}
+    >
+      {imageSource != null ? (
+        <Image
+          source={imageSource}
+          style={StyleSheet.absoluteFill}
+          contentFit="cover"
+          recyclingKey={`video-hero-${section.kind}-${String(video?.documentId ?? "unknown")}`}
+          accessibilityLabel={video?.title ?? heading ?? "Video hero image"}
+        />
+      ) : (
+        <View style={[StyleSheet.absoluteFill, styles.fallbackBg]} />
+      )}
+
+      {/* Gradient overlay: only show over images, not fallback */}
+      {imageSource != null && (
+        <>
+          <View style={styles.gradientTop} />
+          <View style={styles.gradientBottom} />
+        </>
+      )}
+
+      {/* Text overlay — always visible, positioned above gradients */}
+      <View style={styles.textContainer}>
+        {heading != null && (
+          <Text style={styles.title} numberOfLines={2}>
+            {heading}
+          </Text>
+        )}
+        {subheading != null && (
+          <Text style={styles.subtitle} numberOfLines={2}>
+            {subheading}
+          </Text>
+        )}
+      </View>
+    </Pressable>
+  )
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+    height: HERO_HEIGHT,
+    overflow: "hidden",
+  },
+  fallbackBg: {
+    backgroundColor: COLORS.surfaceContainer,
+  },
+  gradientTop: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: HERO_HEIGHT * 0.4,
+    height: HERO_HEIGHT * 0.3,
+    backgroundColor: COLORS.surface,
+    opacity: 0.3,
+  },
+  gradientBottom: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: HERO_HEIGHT * 0.5,
+    backgroundColor: COLORS.surface,
+    opacity: 0.85,
+  },
+  textContainer: {
+    position: "absolute",
+    bottom: 48,
+    left: 80,
+    right: 80,
+  },
+  title: {
+    fontFamily: "System",
+    fontSize: 40,
+    fontWeight: "bold",
+    color: COLORS.text,
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontFamily: "System",
+    fontSize: 20,
+    fontWeight: "400",
+    color: COLORS.muted,
+    marginTop: 8,
+  },
+})

--- a/apps/tv/src/contexts/ExperienceProvider.tsx
+++ b/apps/tv/src/contexts/ExperienceProvider.tsx
@@ -1,0 +1,109 @@
+// SYNC: keep in sync with apps/mobile-v2/src/contexts/ExperienceProvider.tsx
+
+import { createContext, useContext, useMemo, type ReactNode } from "react"
+import type { NormalizedBlock, NormalizedExperience } from "../lib/normalizer"
+
+type ExperienceContextValue = {
+  experience: NormalizedExperience | null
+  loading: boolean
+  error: string | null
+  /** O(1) lookup of a section by its sectionKey */
+  getSectionByKey: (key: string) => NormalizedBlock | undefined
+  refetch: () => void
+}
+
+const ExperienceContext = createContext<ExperienceContextValue>({
+  experience: null,
+  loading: true,
+  error: null,
+  getSectionByKey: () => undefined,
+  refetch: () => {},
+})
+
+export function ExperienceProvider({
+  children,
+  experience,
+  loading,
+  error,
+  refetch,
+}: {
+  children: ReactNode
+  experience: NormalizedExperience | null
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}) {
+  // Build a Map keyed by sectionKey for O(1) lookups from the detail screen
+  const sectionMap = useMemo(() => {
+    const map = new Map<string, NormalizedBlock>()
+    if (!experience) return map
+
+    function indexBlock(
+      block: NormalizedBlock,
+      siblingContent?: NormalizedBlock[],
+    ) {
+      const key =
+        (block.sectionKey as string | undefined) ??
+        (block.id as string | undefined)
+      if (key) {
+        map.set(key, siblingContent ? { ...block, siblingContent } : block)
+      }
+
+      // Index nested content in sectionWrapper
+      if (
+        block.kind === "sectionWrapper" &&
+        Array.isArray(block.sectionContent)
+      ) {
+        const children = block.sectionContent as NormalizedBlock[]
+        for (const child of children) {
+          indexBlock(child, children)
+        }
+      }
+
+      // Index nested content in container slots.
+      // Containers are structural wrappers — their children see the
+      // enclosing sectionWrapper's content, not the slot's own content.
+      if (block.kind === "container" && Array.isArray(block.slots)) {
+        for (const slot of block.slots as Array<{
+          slotContent?: NormalizedBlock[]
+        }>) {
+          if (Array.isArray(slot.slotContent)) {
+            for (const child of slot.slotContent) {
+              indexBlock(child, siblingContent)
+            }
+          }
+        }
+      }
+    }
+
+    for (const section of experience.sections) {
+      indexBlock(section)
+    }
+    return map
+  }, [experience])
+
+  const getSectionByKey = useMemo(
+    () => (key: string) => sectionMap.get(key),
+    [sectionMap],
+  )
+
+  const contextValue = useMemo(
+    () => ({ experience, loading, error, getSectionByKey, refetch }),
+    [experience, loading, error, getSectionByKey, refetch],
+  )
+
+  return (
+    <ExperienceContext.Provider value={contextValue}>
+      {children}
+    </ExperienceContext.Provider>
+  )
+}
+
+export function useExperienceContext() {
+  return useContext(ExperienceContext)
+}
+
+export function useSectionByKey(key: string): NormalizedBlock | undefined {
+  const { getSectionByKey } = useExperienceContext()
+  return getSectionByKey(key)
+}

--- a/apps/tv/src/contexts/VideoPlayerContext.tsx
+++ b/apps/tv/src/contexts/VideoPlayerContext.tsx
@@ -1,0 +1,83 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react"
+import type { ReactNode } from "react"
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+type VideoPlayerState = {
+  currentUrl: string | null
+  currentTitle: string | null
+  currentSubtitle: string | null
+  isVisible: boolean
+}
+
+type VideoPlayerContextValue = {
+  playVideo: (streamingUrl: string, title?: string, subtitle?: string) => void
+  dismissVideo: () => void
+  state: VideoPlayerState
+}
+
+// ── Context ─────────────────────────────────────────────────────────────────
+
+const VideoPlayerContext = createContext<VideoPlayerContextValue | null>(null)
+
+const INITIAL_STATE: VideoPlayerState = {
+  currentUrl: null,
+  currentTitle: null,
+  currentSubtitle: null,
+  isVisible: false,
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+export function VideoPlayerProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<VideoPlayerState>(INITIAL_STATE)
+
+  const playVideo = useCallback(
+    (streamingUrl: string, title?: string, subtitle?: string) => {
+      setState({
+        currentUrl: streamingUrl,
+        currentTitle: title ?? null,
+        currentSubtitle: subtitle ?? null,
+        isVisible: true,
+      })
+    },
+    [],
+  )
+
+  const dismissVideo = useCallback(() => {
+    setState(INITIAL_STATE)
+  }, [])
+
+  const value = useMemo<VideoPlayerContextValue>(
+    () => ({
+      playVideo,
+      dismissVideo,
+      state,
+    }),
+    [playVideo, dismissVideo, state],
+  )
+
+  return (
+    <VideoPlayerContext.Provider value={value}>
+      {children}
+    </VideoPlayerContext.Provider>
+  )
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+export function useVideoPlayerContext(): VideoPlayerContextValue {
+  const ctx = useContext(VideoPlayerContext)
+  if (ctx == null) {
+    throw new Error(
+      "useVideoPlayerContext must be used within a VideoPlayerProvider",
+    )
+  }
+  return ctx
+}

--- a/apps/tv/src/env.ts
+++ b/apps/tv/src/env.ts
@@ -1,0 +1,40 @@
+import { createEnv } from "@t3-oss/env-core"
+import { z } from "zod"
+
+// Metro only reliably inlines process.env.EXPO_PUBLIC_* at module scope.
+// References nested inside createEnv() arguments are not consistently
+// replaced during eas update bundling. These top-level reads ensure the
+// values are inlined and the error message surfaces them if validation fails.
+const _inlined = {
+  url: process.env.EXPO_PUBLIC_GRAPHQL_URL,
+  token: process.env.EXPO_PUBLIC_STRAPI_TOKEN,
+}
+void _inlined
+
+const createAppEnv = () =>
+  createEnv({
+    clientPrefix: "EXPO_PUBLIC_",
+    client: {
+      EXPO_PUBLIC_GRAPHQL_URL: z.string().url(),
+      EXPO_PUBLIC_STRAPI_TOKEN: z.string().optional(),
+    },
+    runtimeEnvStrict: {
+      EXPO_PUBLIC_GRAPHQL_URL: process.env.EXPO_PUBLIC_GRAPHQL_URL,
+      EXPO_PUBLIC_STRAPI_TOKEN: process.env.EXPO_PUBLIC_STRAPI_TOKEN,
+    },
+    isServer: false,
+    emptyStringAsUndefined: true,
+    skipValidation: !!process.env.CI && !process.env.EAS_BUILD,
+  })
+
+let env: ReturnType<typeof createAppEnv>
+try {
+  env = createAppEnv()
+} catch (e) {
+  throw new Error(
+    `Env validation failed. Inlined: URL="${_inlined.url}" TOKEN=${_inlined.token ? "set" : "MISSING"}. Original: ${e instanceof Error ? e.message : e}`,
+    { cause: e },
+  )
+}
+
+export { env }

--- a/apps/tv/src/lib/apolloClient.ts
+++ b/apps/tv/src/lib/apolloClient.ts
@@ -1,0 +1,56 @@
+import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client"
+import { getGraphQLUrl, getApiToken } from "./config"
+
+const REQUEST_TIMEOUT_MS = 15_000
+
+const fetchWithTimeout = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> => {
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  if (init?.signal) {
+    init.signal.addEventListener("abort", () => controller.abort(), {
+      once: true,
+    })
+  }
+
+  return fetch(input, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(id),
+  )
+}
+
+let _client: ApolloClient | undefined
+
+/**
+ * Lazy singleton Apollo Client.
+ * Never instantiate at module scope — crashes imports when env vars are missing in CI.
+ */
+export function getApolloClient(): ApolloClient {
+  if (_client) return _client
+
+  const headers: Record<string, string> = {}
+  const token = getApiToken()
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  const link = new HttpLink({
+    uri: getGraphQLUrl(),
+    headers,
+    fetch: fetchWithTimeout,
+  })
+
+  _client = new ApolloClient({
+    link,
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: "cache-and-network",
+      },
+    },
+  })
+
+  return _client
+}

--- a/apps/tv/src/lib/config.ts
+++ b/apps/tv/src/lib/config.ts
@@ -1,0 +1,20 @@
+import { Platform } from "react-native"
+import { env } from "../env"
+
+export function getGraphQLUrl(): string {
+  const url = env.EXPO_PUBLIC_GRAPHQL_URL
+  // Android emulator can't reach host via localhost — swap to 10.0.2.2
+  if (__DEV__ && Platform.OS === "android" && url.includes("localhost")) {
+    return url.replace("localhost", "10.0.2.2")
+  }
+  return url
+}
+
+export function getApiToken(): string | undefined {
+  return env.EXPO_PUBLIC_STRAPI_TOKEN
+}
+
+/** Hardcoded English locale for the TV prototype. */
+export function getLocale(): string {
+  return "en"
+}

--- a/apps/tv/src/lib/normalizer.ts
+++ b/apps/tv/src/lib/normalizer.ts
@@ -1,0 +1,118 @@
+// SYNC: keep in sync with apps/mobile-v2/src/lib/normalizer.ts
+
+/**
+ * Thin normalizer: maps __typename strings to clean `kind` discriminants.
+ * Does NOT create a parallel type hierarchy — renderers receive gql.tada
+ * ResultOf types with `kind` added for dispatch.
+ */
+
+const TYPENAME_TO_KIND = {
+  ComponentSectionsVideoHero: "videoHero",
+  ComponentSectionsSection: "sectionWrapper",
+  ComponentSectionsVideo: "video",
+  ComponentSectionsText: "text",
+  ComponentSectionsRelatedQuestions: "relatedQuestions",
+  ComponentSectionsBibleQuotesCarousel: "bibleQuotesCarousel",
+  ComponentSectionsContainer: "container",
+  ComponentSectionsMediaCollection: "mediaCollection",
+  ComponentSectionsNavigationCarousel: "navigationCarousel",
+  ComponentSectionsVideoCarousel: "videoCarousel",
+  ComponentSectionsQuizButton: "quizButton",
+  ComponentSectionsEasterDates: "easterDates",
+  ComponentSectionsAdventCountdown: "adventCountdown",
+  ComponentSectionsCta: "cta",
+  ComponentSectionsCard: "card",
+  ComponentSectionsPromoBanner: "promoBanner",
+  ComponentSectionsInfoBlocks: "infoBlocks",
+} as const satisfies Record<string, string>
+
+export type SectionKind =
+  (typeof TYPENAME_TO_KIND)[keyof typeof TYPENAME_TO_KIND]
+
+export type NormalizedBlock = {
+  kind: SectionKind
+  __typename: string
+  [key: string]: unknown
+}
+
+export type NormalizedExperience = {
+  documentId: string
+  slug: string
+  title: string | null
+  sections: NormalizedBlock[]
+}
+
+/**
+ * Normalize a single block by adding `kind` from its __typename.
+ * Returns null for unknown types (logged in dev).
+ */
+function normalizeBlock(
+  block: Record<string, unknown>,
+): NormalizedBlock | null {
+  const typename = block.__typename as string | undefined
+  if (!typename) return null
+
+  const kind = (TYPENAME_TO_KIND as Record<string, string>)[typename]
+  if (!kind) {
+    if (__DEV__) {
+      console.warn(`[normalizer] Unknown block type: ${typename}`)
+    }
+    return null
+  }
+
+  // For sectionWrapper, recursively normalize nested content
+  if (kind === "sectionWrapper" && Array.isArray(block.sectionContent)) {
+    return {
+      ...block,
+      kind,
+      sectionContent: normalizeContentArray(
+        block.sectionContent as Record<string, unknown>[],
+      ),
+    } as unknown as NormalizedBlock
+  }
+
+  // For container, recursively normalize slot content
+  if (kind === "container" && Array.isArray(block.slots)) {
+    return {
+      ...block,
+      kind,
+      slots: (block.slots as Record<string, unknown>[]).map((slot) => ({
+        ...slot,
+        slotContent: Array.isArray(slot.slotContent)
+          ? normalizeContentArray(slot.slotContent as Record<string, unknown>[])
+          : slot.slotContent,
+      })),
+    } as unknown as NormalizedBlock
+  }
+
+  return { ...block, kind } as NormalizedBlock
+}
+
+/**
+ * Normalize an array of nested content blocks (used in Section and Container).
+ */
+function normalizeContentArray(
+  items: Record<string, unknown>[],
+): NormalizedBlock[] {
+  return items
+    .map((item) => normalizeBlock(item))
+    .filter((item): item is NormalizedBlock => item !== null)
+}
+
+/**
+ * Normalize a full Experience response into typed sections.
+ */
+export function normalizeExperience(
+  experience: Record<string, unknown>,
+): NormalizedExperience {
+  const blocks = (experience.blocks ?? []) as Record<string, unknown>[]
+
+  return {
+    documentId: experience.documentId as string,
+    slug: experience.slug as string,
+    title: (experience.title as string) ?? null,
+    sections: blocks
+      .map((block) => normalizeBlock(block))
+      .filter((block): block is NormalizedBlock => block !== null),
+  }
+}

--- a/apps/tv/src/lib/queries.ts
+++ b/apps/tv/src/lib/queries.ts
@@ -1,0 +1,444 @@
+// SYNC: keep in sync with apps/mobile-v2/src/lib/queries.ts
+
+/**
+ * gql.tada typed GraphQL query and fragments for Experience blocks.
+ *
+ * Defined here in apps/tv/ per convention:
+ * "Operations are defined in apps using graphql() from this package."
+ *
+ * Uses @_unmask to make fragment fields directly accessible on parent results.
+ */
+import { graphql } from "@forge/graphql"
+
+// ── Leaf fragments ──────────────────────────────────────────────────
+
+export const VideoHeroFragment = graphql(`
+  fragment VideoHeroFields on ComponentSectionsVideoHero @_unmask {
+    id
+    sectionKey
+    heading
+    subheading
+    ctaLabel
+    ctaLink
+    streamingUrl
+    video {
+      documentId
+      title
+      slug
+      images {
+        url
+        mobileCinematicHigh
+        videoStill
+      }
+    }
+  }
+`)
+
+export const TextSectionFragment = graphql(`
+  fragment TextSectionFields on ComponentSectionsText @_unmask {
+    id
+    sectionKey
+    textHeading: heading
+    headingLevel
+    subtitle
+    contentParagraphs
+    textVariant: variant
+  }
+`)
+
+export const RelatedQuestionsFragment = graphql(`
+  fragment RelatedQuestionsFields on ComponentSectionsRelatedQuestions
+  @_unmask {
+    id
+    sectionKey
+    rqHeading: heading
+    ctaLabel
+    ctaLink
+    questions {
+      id
+      question
+      answer
+    }
+  }
+`)
+
+export const BibleQuotesCarouselFragment = graphql(`
+  fragment BibleQuotesCarouselFields on ComponentSectionsBibleQuotesCarousel
+  @_unmask {
+    id
+    sectionKey
+    bqcHeading: heading
+    quotes {
+      id
+      reference
+      text
+      attribution
+      imageUrl
+      backgroundColor
+      ctaLabel
+      ctaLink
+    }
+  }
+`)
+
+export const EasterDatesFragment = graphql(`
+  fragment EasterDatesFields on ComponentSectionsEasterDates @_unmask {
+    id
+    sectionKey
+    easterDatesTitle
+    westernEasterLabel
+    orthodoxEasterLabel
+    passoverLabel
+    locale
+  }
+`)
+
+export const AdventCountdownFragment = graphql(`
+  fragment AdventCountdownFields on ComponentSectionsAdventCountdown @_unmask {
+    id
+    sectionKey
+    adventTitle: title
+    scripture
+    scriptureReference
+    locale
+  }
+`)
+
+export const CTASectionFragment = graphql(`
+  fragment CTASectionFields on ComponentSectionsCta @_unmask {
+    id
+    sectionKey
+    ctaHeading: heading
+    body
+    buttonLabel
+    buttonLink
+    ctaVariant: variant
+  }
+`)
+
+export const VideoSectionFragment = graphql(`
+  fragment VideoSectionFields on ComponentSectionsVideo @_unmask {
+    id
+    sectionKey
+    streamingUrl
+    videoTitle: title
+    videoSubtitle: subtitle
+    media {
+      url
+    }
+    videoRef: video {
+      documentId
+      title
+      slug
+      imageAlt
+      images {
+        url
+        mobileCinematicHigh
+        videoStill
+      }
+    }
+  }
+`)
+
+export const NavigationCarouselFragment = graphql(`
+  fragment NavigationCarouselFields on ComponentSectionsNavigationCarousel
+  @_unmask {
+    id
+    sectionKey
+    items {
+      id
+      contentId
+      title
+      category
+      imageUrl
+      backgroundColor
+    }
+  }
+`)
+
+export const MediaCollectionFragment = graphql(`
+  fragment MediaCollectionFields on ComponentSectionsMediaCollection @_unmask {
+    id
+    sectionKey
+    mcTitle: title
+    mcSubtitle: subtitle
+    mcDescription: description
+    categoryLabel
+    mcCtaLink: ctaLink
+    mcCtaLabel: ctaLabel
+    showItemNumbers
+    mcVariant: variant
+    footerText
+    items {
+      id
+      titleOverride
+      subtitleOverride
+      labelOverride
+      collectionSize
+      imageUrl
+      linkToSectionKey
+      video {
+        documentId
+        title
+        slug
+        imageAlt
+        images {
+          url
+          mobileCinematicHigh
+          videoStill
+        }
+      }
+    }
+  }
+`)
+
+export const VideoCarouselFragment = graphql(`
+  fragment VideoCarouselFields on ComponentSectionsVideoCarousel @_unmask {
+    id
+    sectionKey
+    vcTitle: title
+    vcSubtitle: subtitle
+    vcDescription: description
+    items {
+      id
+      streamingUrl
+      imageUrl
+      titleOverride
+      backgroundColor
+      video {
+        documentId
+        title
+        slug
+        imageAlt
+        images {
+          url
+          mobileCinematicHigh
+          videoStill
+        }
+      }
+    }
+  }
+`)
+
+export const QuizButtonFragment = graphql(`
+  fragment QuizButtonFields on ComponentSectionsQuizButton @_unmask {
+    id
+    buttonText
+    iframeSrc
+  }
+`)
+
+// ── Composite fragments (nested content) ────────────────────────────
+
+// ContainerSlotContentDynamicZone members (from schema.graphql):
+// AdventCountdown, BibleQuotesCarousel, Card, Cta, EasterDates,
+// MediaCollection, RelatedQuestions, Text, Video
+// NOTE: Container, NavigationCarousel, VideoCarousel, QuizButton are NOT in this union
+export const ContainerFragment = graphql(
+  `
+    fragment ContainerFields on ComponentSectionsContainer @_unmask {
+      id
+      sectionKey
+      slots {
+        id
+        gridSpan
+        slotContent: content {
+          __typename
+          ... on ComponentSectionsText {
+            ...TextSectionFields
+          }
+          ... on ComponentSectionsEasterDates {
+            ...EasterDatesFields
+          }
+          ... on ComponentSectionsAdventCountdown {
+            ...AdventCountdownFields
+          }
+          ... on ComponentSectionsCta {
+            ...CTASectionFields
+          }
+          ... on ComponentSectionsVideo {
+            ...VideoSectionFields
+          }
+          ... on ComponentSectionsRelatedQuestions {
+            ...RelatedQuestionsFields
+          }
+          ... on ComponentSectionsBibleQuotesCarousel {
+            ...BibleQuotesCarouselFields
+          }
+          ... on ComponentSectionsMediaCollection {
+            ...MediaCollectionFields
+          }
+        }
+      }
+    }
+  `,
+  [
+    TextSectionFragment,
+    EasterDatesFragment,
+    AdventCountdownFragment,
+    CTASectionFragment,
+    VideoSectionFragment,
+    RelatedQuestionsFragment,
+    BibleQuotesCarouselFragment,
+    MediaCollectionFragment,
+  ],
+)
+
+// SectionContentDynamicZone members (from schema.graphql):
+// BibleQuotesCarousel, Card, Container, Cta, InfoBlocks, MediaCollection,
+// NavigationCarousel, PromoBanner, QuizButton, RelatedQuestions, Text, Video, VideoCarousel
+// NOTE: EasterDates and AdventCountdown are NOT in this union (only in ContainerSlotContentDynamicZone)
+export const SectionFragment = graphql(
+  `
+    fragment SectionFields on ComponentSectionsSection @_unmask {
+      id
+      sectionKey
+      backgroundColor
+      backgroundOpacity
+      dynamicBackgroundImage
+      staticOverlay
+      blurHash
+      sectionContent: content {
+        __typename
+        ... on ComponentSectionsContainer {
+          ...ContainerFields
+        }
+        ... on ComponentSectionsVideo {
+          ...VideoSectionFields
+        }
+        ... on ComponentSectionsRelatedQuestions {
+          ...RelatedQuestionsFields
+        }
+        ... on ComponentSectionsBibleQuotesCarousel {
+          ...BibleQuotesCarouselFields
+        }
+        ... on ComponentSectionsMediaCollection {
+          ...MediaCollectionFields
+        }
+        ... on ComponentSectionsQuizButton {
+          ...QuizButtonFields
+        }
+        ... on ComponentSectionsVideoCarousel {
+          ...VideoCarouselFields
+        }
+        ... on ComponentSectionsNavigationCarousel {
+          ...NavigationCarouselFields
+        }
+        ... on ComponentSectionsText {
+          ...TextSectionFields
+        }
+        ... on ComponentSectionsCta {
+          ...CTASectionFields
+        }
+      }
+    }
+  `,
+  [
+    ContainerFragment,
+    VideoSectionFragment,
+    RelatedQuestionsFragment,
+    BibleQuotesCarouselFragment,
+    MediaCollectionFragment,
+    QuizButtonFragment,
+    VideoCarouselFragment,
+    NavigationCarouselFragment,
+    TextSectionFragment,
+    CTASectionFragment,
+  ],
+)
+
+// ── Main query ──────────────────────────────────────────────────────
+
+export const GET_WATCH_EXPERIENCE = graphql(
+  `
+    query GetWatchExperience(
+      $locale: I18NLocaleCode!
+      $filters: ExperienceFiltersInput!
+    ) {
+      experiences(filters: $filters, locale: $locale) {
+        documentId
+        slug
+        title
+        blocks {
+          __typename
+          ... on ComponentSectionsVideoHero {
+            ...VideoHeroFields
+          }
+          ... on ComponentSectionsSection {
+            ...SectionFields
+          }
+          ... on ComponentSectionsVideoCarousel {
+            ...VideoCarouselFields
+          }
+          ... on ComponentSectionsMediaCollection {
+            ...MediaCollectionFields
+          }
+          ... on ComponentSectionsNavigationCarousel {
+            ...NavigationCarouselFields
+          }
+          ... on ComponentSectionsText {
+            ...TextSectionFields
+          }
+          ... on ComponentSectionsEasterDates {
+            ...EasterDatesFields
+          }
+          ... on ComponentSectionsAdventCountdown {
+            ...AdventCountdownFields
+          }
+          ... on ComponentSectionsBibleQuotesCarousel {
+            ...BibleQuotesCarouselFields
+          }
+          ... on ComponentSectionsCta {
+            ...CTASectionFields
+          }
+          ... on ComponentSectionsRelatedQuestions {
+            ...RelatedQuestionsFields
+          }
+          ... on ComponentSectionsContainer {
+            ...ContainerFields
+          }
+          ... on ComponentSectionsVideo {
+            ...VideoSectionFields
+          }
+        }
+      }
+    }
+  `,
+  [
+    VideoHeroFragment,
+    SectionFragment,
+    VideoCarouselFragment,
+    MediaCollectionFragment,
+    NavigationCarouselFragment,
+    TextSectionFragment,
+    EasterDatesFragment,
+    AdventCountdownFragment,
+    BibleQuotesCarouselFragment,
+    CTASectionFragment,
+    RelatedQuestionsFragment,
+    ContainerFragment,
+    VideoSectionFragment,
+  ],
+)
+
+// ── Lightweight listing query (no blocks) ─────────────────────────
+
+export const LIST_EXPERIENCES = graphql(`
+  query ListExperiences($locale: I18NLocaleCode!) {
+    experiences(locale: $locale) {
+      documentId
+      slug
+      title
+      metaDescription
+      isHomepage
+      ogImage {
+        url
+        alternativeText
+        width
+        height
+      }
+    }
+  }
+`)
+
+// Type is inferred by gql.tada at compile time via ResultOf<typeof GET_WATCH_EXPERIENCE>

--- a/apps/tv/src/lib/resolveImageUrl.ts
+++ b/apps/tv/src/lib/resolveImageUrl.ts
@@ -1,0 +1,47 @@
+// SYNC: keep in sync with apps/mobile-v2/src/lib/resolveImageUrl.ts
+
+import { Platform } from "react-native"
+
+/**
+ * In dev, relative paths resolve to the local Next.js server which serves
+ * apps/web/public/ directly. In production, the web app sits behind Cloudflare
+ * routing that intercepts static file paths, so we resolve to the GitHub raw
+ * URL for the same files in apps/web/public/.
+ */
+const STATIC_BASE_URL = __DEV__
+  ? Platform.OS === "android"
+    ? "http://10.0.2.2:3000/watch"
+    : "http://localhost:3000/watch"
+  : "https://raw.githubusercontent.com/JesusFilm/forge/main/apps/web/public"
+
+/**
+ * Resolve and validate an image URL from CMS content.
+ *
+ * - **Relative paths** (e.g. /images/thumbnails/...): Prefixed with the
+ *   appropriate static base URL for the current environment.
+ * - **Absolute URLs**: Must use https (or http in dev). Passed through as-is.
+ * - **Invalid/dangerous schemes**: Returns null.
+ */
+export function resolveImageUrl(url: string | null | undefined): string | null {
+  if (!url) return null
+
+  // Relative paths — static assets from apps/web/public/
+  if (url.startsWith("/") && !url.startsWith("//")) {
+    return `${STATIC_BASE_URL}${url}`
+  }
+
+  try {
+    const parsed = new URL(url)
+
+    if (parsed.protocol === "http:" && !__DEV__) {
+      return null
+    }
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return null
+    }
+
+    return url
+  } catch {
+    return null
+  }
+}

--- a/apps/tv/src/lib/types.ts
+++ b/apps/tv/src/lib/types.ts
@@ -1,0 +1,41 @@
+// SYNC: keep in sync with apps/mobile-v2/src/lib/types.ts
+
+/** Shape of a single video image entry from the CMS. */
+export type VideoImage = {
+  url?: string | null
+  mobileCinematicHigh?: string | null
+  videoStill?: string | null
+}
+
+/** Shared shape for a video reference resolved from CMS data. */
+export type VideoRef = {
+  documentId?: string
+  title?: string
+  slug?: string
+  imageAlt?: string
+  images?: VideoImage[]
+}
+
+/**
+ * Pick the best thumbnail URL from a video's images.
+ * Accepts either an array (runtime shape from GraphQL) or a single object
+ * (gql.tada inferred shape), since Strapi returns images as a collection.
+ * Prefers mobileCinematicHigh, falls back to videoStill, then url.
+ */
+export function pickThumbnailUrl(
+  images: VideoImage | VideoImage[] | null | undefined,
+): string | null {
+  if (!images) return null
+  const list = Array.isArray(images) ? images : [images]
+  if (list.length === 0) return null
+  for (const img of list) {
+    if (img.mobileCinematicHigh) return img.mobileCinematicHigh
+  }
+  for (const img of list) {
+    if (img.videoStill) return img.videoStill
+  }
+  for (const img of list) {
+    if (img.url) return img.url
+  }
+  return null
+}

--- a/apps/tv/src/lib/validateUrl.ts
+++ b/apps/tv/src/lib/validateUrl.ts
@@ -1,0 +1,48 @@
+// SYNC: keep in sync with apps/mobile-v2/src/lib/validateUrl.ts
+
+const ALLOWED_STREAMING_HOSTS = new Set(["stream.mux.com"])
+
+const BLOCKED_SCHEMES = new Set([
+  "javascript:",
+  "data:",
+  "tel:",
+  "sms:",
+  "file:",
+  "ftp:",
+])
+
+/**
+ * Validate a streaming URL before passing to useVideoPlayer().
+ * Only allows Mux streaming domains.
+ */
+export function validateStreamingUrl(url: string | null | undefined): boolean {
+  if (!url) return false
+  try {
+    const parsed = new URL(url)
+    return ALLOWED_STREAMING_HOSTS.has(parsed.hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Validate a CMS-sourced action URL before opening with Linking.openURL().
+ * Requires https: protocol. Rejects dangerous schemes.
+ */
+export function validateActionUrl(url: string | null | undefined): boolean {
+  if (!url) return false
+  try {
+    const parsed = new URL(url)
+
+    // Block dangerous schemes
+    if (BLOCKED_SCHEMES.has(parsed.protocol)) return false
+
+    // Require https (allow http only in dev)
+    if (parsed.protocol === "https:") return true
+    if (__DEV__ && parsed.protocol === "http:") return true
+
+    return false
+  } catch {
+    return false
+  }
+}

--- a/apps/tv/src/types/env.d.ts
+++ b/apps/tv/src/types/env.d.ts
@@ -1,0 +1,9 @@
+/** Metro inlines process.env.EXPO_PUBLIC_* at build time. */
+declare const process: {
+  env: Record<string, string | undefined> & {
+    EXPO_PUBLIC_GRAPHQL_URL?: string
+    EXPO_PUBLIC_STRAPI_TOKEN?: string
+    CI?: string
+    EAS_BUILD?: string
+  }
+}

--- a/apps/tv/tsconfig.json
+++ b/apps/tv/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": ["./src/*"],
+      "react": ["./node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime.d.ts"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/docs/plans/2026-04-13-001-feat-tv-app-prototype-plan.md
+++ b/docs/plans/2026-04-13-001-feat-tv-app-prototype-plan.md
@@ -1,0 +1,561 @@
+---
+title: "feat: TV App Prototype — Apple TV & Android TV"
+type: feat
+status: active
+date: 2026-04-13
+origin: docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md
+deepened: 2026-04-13
+---
+
+# feat: TV App Prototype — Apple TV & Android TV
+
+## Overview
+
+Add a TV app (`apps/tv/`) to the Forge monorepo that renders the existing CMS-driven Experience pipeline on Apple TV and Android TV. The app reuses the SDUI pipeline logic (normalizer, queries, ExperienceProvider) from `apps/mobile-v2/` and rewrites all renderers for 10-foot UI with D-pad focus navigation.
+
+This is a working prototype, not a production app. It validates that the SDUI architecture works on TV and establishes the foundation for a production decision.
+
+## Problem Frame
+
+Urim's roadmap items are blocked on upstream search and topic infrastructure. This time goes toward the TV app — the third rendering target for the SDUI pipeline. The architecture (Strapi → GraphQL → normalizer → dispatcher → renderers) was designed for multi-surface delivery. A TV app validates this with existing CMS content, adding reach to living rooms. (see origin: `docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md`)
+
+## Requirements Trace
+
+- R1. App builds and runs on Apple TV Simulator and Android TV Emulator
+- R2. Home screen renders hero (from `isHomepage` Experience) + Experiences rail from CMS via GraphQL
+- R3. D-pad navigation works: move between hero and rail, scroll within rail, select items
+- R4. Selecting an Experience opens the detail screen (vertical section feed of blocks)
+- R5. Video playback works full-screen with play/pause and ±10s seek via remote
+- R6. Focus rings visible and follow D-pad movement consistently
+- R7. Loading spinner during fetch; error screen with focusable retry button on failure
+- R8. Focus navigation feels responsive (no perceptible lag)
+- R9. Video playback quality acceptable on TV display
+- R10. Experience detail screen is readable — doesn't feel like a stretched phone app
+
+## Scope Boundaries
+
+- No search, topic browsing, deep linking, analytics, offline, localization, or store submission
+- No auto-preview on focus (static thumbnails only)
+- Non-core renderers (MediaCollection, Quiz, NavigationCarousel, VideoCarousel, EasterDates) handled by PlaceholderRenderer
+- No shared package extraction — copy files for now, extract later if a third consumer appears
+- Development/preview EAS build profiles only
+
+### Deferred to Separate Tasks
+
+- Production EAS build profiles and App Store / Play Store submission: separate roadmap item after prototype succeeds
+- `packages/sdui/` shared package extraction: follow-up if TV prototype validates and a third consumer appears
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/mobile-v2/src/lib/normalizer.ts` — `TYPENAME_TO_KIND` map, `normalizeExperience()`, `NormalizedBlock` type. ~100 LOC, pure logic, fully reusable.
+- `apps/mobile-v2/src/lib/queries.ts` — 13 fragments + `GET_WATCH_EXPERIENCE` + `LIST_EXPERIENCES`. gql.tada typed, no UI code. Fully reusable.
+- `apps/mobile-v2/src/contexts/ExperienceProvider.tsx` — React context with O(1) `getSectionByKey` lookup, recursive indexing of sectionWrapper/container children. Pure React, fully reusable.
+- `apps/mobile-v2/src/components/sections/SectionDispatcher.tsx` — switch on `kind` with `classifySection()` for videoCard classification. Pattern reusable; renderer imports are the replacement surface.
+- `apps/mobile-v2/src/lib/apolloClient.ts` — lazy singleton `getApolloClient()` with `HttpLink`, 15s timeout, bearer token.
+- `apps/mobile-v2/src/lib/config.ts` — `getGraphQLUrl()` per-platform URL, `getApiToken()`.
+- `apps/mobile-v2/src/env.ts` — `@t3-oss/env-core` with module-scope `_inlined` trick for Metro EAS Update inlining.
+- `apps/mobile-v2/metro.config.js` — pnpm singleton resolver for `react`/`react-native`, monorepo watchFolders, `.cjs` ext.
+- `apps/mobile-v2/src/lib/types.ts`, `parseSectionKey.ts`, `resolveImageUrl.ts`, `validateUrl.ts` — utility modules.
+
+### Institutional Learnings
+
+- **Metro pnpm singleton resolution** (critical): Must configure custom `resolveRequest` in `metro.config.js` from day one. `extraNodeModules` alone is not sufficient. For TV, the singleton map keys `react-native` to the `react-native-tvos` alias path. (`docs/solutions/mobile/metro-pnpm-symlink-react-duplicate-resolution.md`)
+- **Structural renderers are mandatory**: Missing `SectionWrapperRenderer`/`ContainerRenderer` causes nested content to silently vanish. (`docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md`)
+- **EAS Update env var inlining bug**: Module-scope `_inlined` references required. (`docs/solutions/runtime-errors/metro-env-inlining-eas-update-white-screen-20260410.md`)
+- **ExperienceProvider siblingContent propagation**: Must preserve recursive indexing of sectionWrapper and container children. (`docs/solutions/mobile/sdui-experience-provider-block-index-parent-child-loss.md`)
+- **expo-video stability**: `useVideoPlayer(source)` — source must be stable `useRef`, not state. Use `replaceAsync()` for source swapping. (`docs/solutions/best-practices/playlist-video-player-sdui-mobile-20260409.md`)
+- **Fragment spread validation**: Wrong dynamic zone union causes entire query rejection (blank screen). Verify against `apps/cms/schema.graphql`. (`docs/solutions/integration-issues/expo-graphql-schema-drift-and-fragment-validation.md`)
+- **Back-navigation focus loss**: react-native-tvos issue #852. Workaround: restore focus via `hasTVPreferredFocus` in `useEffect` on screen focus.
+- **Expo SDK 54 health**: Run `npx expo install --check` and `npx expo-doctor` after scaffold. (`docs/solutions/build-errors/expo-doctor-sdk54-health-checks-mobile-v2-20260409.md`)
+
+## Key Technical Decisions
+
+- **Separate app at `apps/tv/`**: TV UX (D-pad, landscape, 10-foot) conflicts fundamentally with touch UX (gestures, portrait, small screen). Do not add TV as a platform target inside mobile-v2.
+- **Import queries from mobile-v2, copy the rest**: `queries.ts` (443 LOC of GraphQL fragments) must stay as a single source of truth — CMS schema changes would silently break a copy. Import it from `apps/mobile-v2/src/lib/queries.ts` via pnpm workspace dependency. The remaining pipeline files (normalizer, ExperienceProvider, types, utilities — ~220 LOC combined) are pure logic with no `react-native` dependency and are safe to copy. If Metro cross-app import of queries causes bundler issues, fall back to copying with a `// SYNC: keep in sync with apps/mobile-v2/src/lib/queries.ts` comment.
+- **`react-native-tvos` via npm alias**: `"react-native": "npm:react-native-tvos@0.81-stable"` — standard approach, confirmed working with Expo SDK 54.
+- **Stack navigation only, no tab bar**: Home → Experience detail → Video fullscreen. Proven TV pattern.
+- **Single GraphQL URL env var**: TV platforms don't have the iOS/Android localhost emulator split that mobile-v2 handles. Simplify to `EXPO_PUBLIC_GRAPHQL_URL`.
+- **Hardcoded English locale**: All GraphQL queries requiring `$locale` use `"en"`. Localization is out of scope for prototype.
+- **`cache-and-network` fetch policy**: Avoid loading flash on subsequent visits, matches mobile-v2 pattern.
+- **`@forge/graphql` workspace protocol**: TV app pins `"@forge/graphql": "workspace:*"` to ensure same gql.tada types as mobile-v2.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Import vs copy SDUI files**: Import `queries.ts` from mobile-v2 (443 LOC of GraphQL fragments that must stay in sync with CMS schema). Copy normalizer, ExperienceProvider, and utilities (~220 LOC of pure logic with no react-native dependency). If Metro cross-app import fails, fall back to copy with sync comment.
+- **Separate iOS/Android env vars for GraphQL**: No. TV doesn't have the localhost split. Use a single `EXPO_PUBLIC_GRAPHQL_URL`.
+- **Locale handling**: Hardcode `"en"` for all queries requiring `$locale`. Localization is out of scope.
+- **Focus memory implementation**: In-memory `Map<string, number>` per session. No persistence needed for prototype.
+- **Multiple `isHomepage` experiences**: Use `Array.find()` (first match). CMS should enforce single homepage. Add defensive handling if none found.
+
+### Deferred to Implementation
+
+- **Exact `react-native-tvos@0.81-stable` compatibility**: Day-1 spike validates this before further work. If it fails, stop.
+- **expo-video remote control event mapping on TV**: Known to work per PR #29560, but exact API surface TBD during implementation.
+- **TVFocusGuideView nesting behavior**: May need experimentation to prevent diagonal focus jumps in nested scroll containers.
+
+## Output Structure
+
+```
+apps/tv/
+├── app/
+│   ├── _layout.tsx                     # Root layout + Apollo + providers
+│   ├── index.tsx                       # Home screen (hero + experiences rail)
+│   └── experience/[slug].tsx           # Experience detail screen
+├── src/
+│   ├── env.ts                          # t3-oss env (single GraphQL URL)
+│   ├── lib/
+│   │   ├── apolloClient.ts             # Lazy singleton Apollo Client
+│   │   ├── config.ts                   # GraphQL URL + token + locale helpers
+│   │   ├── normalizer.ts               # Copied from mobile-v2
+│   │   ├── queries.ts                  # Imported from mobile-v2 via workspace (or copied as fallback)
+│   │   ├── types.ts                    # Copied from mobile-v2
+│   │   ├── resolveImageUrl.ts          # Copied from mobile-v2
+│   │   └── validateUrl.ts              # Copied from mobile-v2
+│   ├── contexts/
+│   │   └── ExperienceProvider.tsx       # Copied from mobile-v2
+│   └── components/
+│       ├── sections/
+│       │   ├── SectionDispatcher.tsx    # TV version (subset of kinds)
+│       │   ├── VideoHeroRenderer.tsx    # TV-adapted hero
+│       │   ├── VideoCardRenderer.tsx    # Landscape video card for rails
+│       │   ├── TextRenderer.tsx         # Large readable text
+│       │   ├── BibleQuotesCarouselRenderer.tsx  # Horizontal D-pad carousel
+│       │   ├── SectionWrapperRenderer.tsx  # Structural wrapper
+│       │   ├── ContainerRenderer.tsx       # Structural wrapper
+│       │   └── PlaceholderRenderer.tsx     # Fallback for unhandled types
+│       ├── ContentRail.tsx             # Horizontal FlatList with TVFocusGuideView
+│       ├── FocusableCard.tsx           # Base focusable element with focus ring
+│       └── VideoPlayer.tsx             # Full-screen TV video player
+├── assets/                             # Icon, splash (TV-sized)
+├── app.json                            # Expo config with config-tv plugin
+├── babel.config.js                     # babel-preset-expo
+├── metro.config.js                     # Singleton resolver (react-native-tvos)
+├── tsconfig.json
+├── package.json                        # @forge/tv
+├── .env.local                          # Dev env vars (gitignored)
+└── CLAUDE.md                           # TV app conventions
+```
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+graph TD
+    subgraph "CMS (existing)"
+        Strapi["Strapi v5 GraphQL API"]
+    end
+
+    subgraph "Shared Package (existing)"
+        GQL["@forge/graphql<br/>gql.tada types"]
+    end
+
+    subgraph "apps/tv/ (new)"
+        ENV["env.ts<br/>EXPO_PUBLIC_GRAPHQL_URL"]
+        Apollo["apolloClient.ts<br/>lazy singleton"]
+        Queries["queries.ts<br/>copied from mobile-v2"]
+        Norm["normalizer.ts<br/>copied from mobile-v2"]
+        ExpProv["ExperienceProvider<br/>copied from mobile-v2"]
+
+        subgraph "Screens"
+            Home["index.tsx<br/>Hero + Rail"]
+            Detail["experience/[slug].tsx<br/>Section feed"]
+            Video["VideoPlayer.tsx<br/>Full-screen playback"]
+        end
+
+        subgraph "TV Renderers (new)"
+            Dispatch["SectionDispatcher"]
+            Hero["VideoHeroRenderer"]
+            VCard["VideoCardRenderer"]
+            Text["TextRenderer"]
+            Bible["BibleQuotesCarousel"]
+            SW["SectionWrapper"]
+            Cont["Container"]
+            PH["Placeholder"]
+        end
+
+        subgraph "TV Components (new)"
+            Rail["ContentRail<br/>TVFocusGuideView"]
+            FC["FocusableCard<br/>Focus ring + scale"]
+        end
+    end
+
+    Strapi --> Apollo
+    GQL --> Queries
+    ENV --> Apollo
+    Apollo --> Home
+    Apollo --> Detail
+    Queries --> Norm
+    Norm --> ExpProv
+    ExpProv --> Home
+    ExpProv --> Detail
+    Home --> Rail
+    Rail --> FC
+    Detail --> Dispatch
+    Dispatch --> Hero & VCard & Text & Bible & SW & Cont & PH
+    VCard --> Video
+    Hero --> Video
+```
+
+**Data flow for home screen:**
+
+1. `LIST_EXPERIENCES` → experience metadata (ogImage, title, slug, isHomepage)
+2. `GET_WATCH_EXPERIENCE` with `isHomepage` slug → full block data for hero
+3. Normalize hero blocks → render `VideoHeroRenderer` at top
+4. Map experiences list → `ContentRail` of `FocusableCard` items
+
+**Data flow for experience detail:**
+
+1. `GET_WATCH_EXPERIENCE` with selected slug → full block data
+2. `normalizeExperience()` → `ExperienceProvider` context
+3. Vertical FlatList → `SectionDispatcher` per block → TV renderers
+
+**Navigation:**
+
+- Home (index.tsx) → push `experience/[slug]` on card select
+- Experience detail → push full-screen VideoPlayer on video select
+- Menu/Back button → pop stack at each level
+
+## Implementation Units
+
+- [ ] **Unit 1: Expo TV Scaffolding**
+
+  **Goal:** Create `apps/tv/` with working Expo TV build for Apple TV Simulator — the go/no-go gate.
+
+  **Requirements:** R1
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `apps/tv/package.json`
+  - Create: `apps/tv/app.json`
+  - Create: `apps/tv/babel.config.js`
+  - Create: `apps/tv/metro.config.js`
+  - Create: `apps/tv/tsconfig.json`
+  - Create: `apps/tv/app/_layout.tsx`
+  - Create: `apps/tv/app/index.tsx` (minimal "Hello TV" screen)
+  - Create: `apps/tv/CLAUDE.md`
+
+  **Approach:**
+  - `package.json`: name `@forge/tv`, `"react-native": "npm:react-native-tvos@0.81-stable"`, match Expo SDK 54 deps from mobile-v2 using `npx expo install --check`
+  - `app.json`: `@react-native-tvos/config-tv` plugin with `{ "isTV": true }`, landscape orientation, dark background
+  - `metro.config.js`: Copy singleton resolver pattern from `apps/mobile-v2/metro.config.js`. Singleton map must include both `react` and `react-native` (the latter resolving to `react-native-tvos` alias). Missing `react` singleton causes "Invalid hook call" from duplicate React copies.
+  - `babel.config.js`: `babel-preset-expo` (required for Expo Router)
+  - Run `pnpm install` then `EXPO_TV=1 npx expo prebuild --clean` then build for Apple TV Simulator
+  - Minimal `index.tsx` with a `Text` + `Pressable` element to verify D-pad focus works
+
+  **Patterns to follow:**
+  - `apps/mobile-v2/metro.config.js` — singleton resolver
+  - `apps/mobile-v2/package.json` — dependency versions
+  - `docs/solutions/platform/adding-new-apps.md` — scaffold checklist
+
+  **Test scenarios:**
+  - Test expectation: none — pure scaffolding. Validation is build + Simulator launch.
+
+  **Verification:**
+  - `EXPO_TV=1 npx expo prebuild --clean` succeeds
+  - App launches on Apple TV Simulator
+  - App launches on Android TV Emulator (both platforms required for go/no-go)
+  - D-pad focuses the Pressable element with visible highlight
+  - `npx expo-doctor` passes
+  - `pnpm typecheck --filter=@forge/tv` passes
+
+- [ ] **Unit 2: Environment, Apollo Client, and SDUI Pipeline**
+
+  **Goal:** Wire up env vars, Apollo Client, and copy the SDUI pipeline files so the TV app can fetch and normalize Experience data from the CMS.
+
+  **Requirements:** R2 (data layer)
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `apps/tv/src/env.ts`
+  - Create: `apps/tv/src/lib/config.ts`
+  - Create: `apps/tv/src/lib/apolloClient.ts`
+  - Copy: `apps/tv/src/lib/normalizer.ts` (from `apps/mobile-v2/src/lib/normalizer.ts`)
+  - Import or copy: `apps/tv/src/lib/queries.ts` (prefer re-export from `apps/mobile-v2/src/lib/queries.ts` via workspace dep; copy as fallback)
+  - Copy: `apps/tv/src/lib/types.ts` (from `apps/mobile-v2/src/lib/types.ts`)
+  - Copy: `apps/tv/src/lib/resolveImageUrl.ts` (from `apps/mobile-v2/src/lib/resolveImageUrl.ts`)
+  - Copy: `apps/tv/src/lib/validateUrl.ts` (from `apps/mobile-v2/src/lib/validateUrl.ts`)
+  - Copy: `apps/tv/src/contexts/ExperienceProvider.tsx` (from `apps/mobile-v2/src/contexts/ExperienceProvider.tsx`)
+  - Modify: `apps/tv/app/_layout.tsx` (add ApolloProvider)
+  - Create: `apps/tv/.env.local`
+
+  **Approach:**
+  - `env.ts`: Simplify to single `EXPO_PUBLIC_GRAPHQL_URL` (no iOS/Android split). Keep module-scope `_inlined` pattern for EAS Update safety.
+  - `config.ts`: `getGraphQLUrl()` returns the single URL. `getApiToken()` same pattern. Add `getLocale()` returning `"en"` (hardcoded for prototype).
+  - `apolloClient.ts`: Copy lazy singleton pattern. Use `cache-and-network` default fetch policy.
+  - `package.json`: Add `"@forge/graphql": "workspace:*"` and `"@forge/mobile-v2": "workspace:*"` (for queries import). If mobile-v2 workspace import causes Metro issues, fall back to copying queries.ts with sync comment.
+  - Copied files: verify import paths resolve correctly after copy. Adjust any mobile-v2-specific imports to local paths.
+  - Root `_layout.tsx`: wrap children in `ApolloProvider` using `getApolloClient()`.
+
+  **Patterns to follow:**
+  - `apps/mobile-v2/src/env.ts` — env validation with inlining trick
+  - `apps/mobile-v2/src/lib/apolloClient.ts` — lazy singleton
+  - `docs/solutions/runtime-errors/metro-env-inlining-eas-update-white-screen-20260410.md`
+
+  **Test scenarios:**
+  - Happy path: Apollo Client fetches `LIST_EXPERIENCES` and returns experience data
+  - Error path: Network failure shows error state (verify via Apollo `error` field)
+  - Edge case: Missing `EXPO_PUBLIC_STRAPI_TOKEN` — app still starts (token is optional)
+
+  **Verification:**
+  - `console.log` in root layout confirms Apollo Client instantiated and GraphQL query returns data
+  - TypeScript compiles with no errors (`pnpm typecheck --filter=@forge/tv`)
+
+- [ ] **Unit 3: FocusableCard and ContentRail Components**
+
+  **Goal:** Build the two foundational TV UI components: a card that responds to D-pad focus with visual feedback, and a horizontal rail that constrains focus navigation.
+
+  **Requirements:** R3, R6, R8
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `apps/tv/src/components/FocusableCard.tsx`
+  - Create: `apps/tv/src/components/ContentRail.tsx`
+
+  **Approach:**
+  - **FocusableCard**: Pressable with `onFocus`/`onBlur` state. Focused state: 1.05x scale + high-contrast border glow. Accept `hasTVPreferredFocus` prop for initial focus control. `onPress` callback for selection.
+  - **ContentRail**: Horizontal FlatList wrapped in `TVFocusGuideView` to constrain D-pad left/right within the rail. Title label above. Accept `data`, `renderItem`, `title` props. Per-session focus memory via in-memory Map (rail ID → item index) to restore position on back-navigation.
+
+  **Patterns to follow:**
+  - `docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md` — TVFocusGuideView + focus ring patterns
+
+  **Test scenarios:**
+  - Happy path: FocusableCard shows focus ring when focused, hides when blurred
+  - Happy path: FocusableCard scales to 1.05x on focus
+  - Happy path: ContentRail constrains D-pad left/right within rail items
+  - Edge case: Single-item rail — focus stays on the single card, no crash
+  - Edge case: Empty rail — renders nothing or title only, no crash
+  - Integration: Back-navigation restores last focused item index in rail
+
+  **Verification:**
+  - On Apple TV Simulator: D-pad moves focus between cards in a rail with visible focus ring
+  - D-pad up/down exits the rail (not trapped)
+  - Focus memory works after navigating away and back
+
+- [ ] **Unit 4: Home Screen**
+
+  **Goal:** Render the TV home screen with a hero area (from `isHomepage` Experience) and an Experiences content rail below.
+
+  **Requirements:** R2, R3, R7
+
+  **Dependencies:** Units 2, 3
+
+  **Files:**
+  - Modify: `apps/tv/app/index.tsx`
+  - Create: `apps/tv/src/components/HomeHero.tsx` (simplified inline hero for home screen — not the full renderer)
+
+  **Approach:**
+  - Fetch `LIST_EXPERIENCES` with `variables: { locale: "en" }` for rail data and `GET_WATCH_EXPERIENCE` for homepage hero
+  - Find `isHomepage` Experience from list (first match via `Array.find()`), use its slug for the full experience query. If none found, skip hero.
+  - Hero: Full-width at top via `HomeHero` component (not the full `VideoHeroRenderer` — that is built in Unit 6 for the experience detail context). Shows `videoStill` or `ogImage` via expo-image, title + subtitle overlay. Static thumbnail only (no auto-preview).
+  - Rail below: `ContentRail` of `FocusableCard` items, each showing `ogImage` + title. `onPress` navigates to `experience/[slug]`.
+  - D-pad up → hero, down → rail
+  - Loading: centered spinner. Error: message + focusable retry button.
+
+  **Patterns to follow:**
+  - `apps/mobile-v2/src/contexts/ExperienceShell.tsx` — `LIST_EXPERIENCES` usage pattern
+  - `docs/solutions/mobile/experience-selection-provider-library-tab-pattern-2026-04-08.md` — `isHomepage` resolution
+
+  **Test scenarios:**
+  - Happy path: Home screen shows hero with title/image + Experiences rail with cards
+  - Happy path: Selecting a rail card navigates to `experience/[slug]`
+  - Happy path: D-pad moves focus between hero and rail
+  - Error path: GraphQL fetch failure shows error screen with focusable retry button
+  - Edge case: CMS returns zero Experiences — shows empty state message
+  - Edge case: No `isHomepage` Experience — hero area hidden, rail still renders
+  - Edge case: `isHomepage` slug resolves from LIST but GET_WATCH_EXPERIENCE returns null — falls back to rail-only view
+  - Edge case: Experience in rail has null `ogImage` — card renders with placeholder or title only
+
+  **Verification:**
+  - Home screen renders on Apple TV Simulator with real CMS data
+  - D-pad navigates between hero and rail cards
+  - Selecting a card pushes to experience detail route
+
+- [ ] **Unit 5: Structural Renderers and SectionDispatcher**
+
+  **Goal:** Implement the structural renderers (SectionWrapper, Container, Placeholder) and the TV SectionDispatcher so the experience detail screen can render block trees correctly.
+
+  **Requirements:** R4
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Create: `apps/tv/src/components/sections/SectionDispatcher.tsx`
+  - Create: `apps/tv/src/components/sections/SectionWrapperRenderer.tsx`
+  - Create: `apps/tv/src/components/sections/ContainerRenderer.tsx`
+  - Create: `apps/tv/src/components/sections/PlaceholderRenderer.tsx`
+
+  **Approach:**
+  - **SectionDispatcher**: Switch on `kind`. Subset of mobile-v2 kinds: `videoHero`, `sectionWrapper`, `video`, `text`, `bibleQuotesCarousel`, `container`. All others → PlaceholderRenderer. Initially, unimplemented renderer cases (videoHero, video, text, bibleQuotesCarousel) also fall through to PlaceholderRenderer — Unit 6 replaces these with real renderers.
+  - **SectionWrapperRenderer**: Renders children from `sectionContent` array via SectionDispatcher recursion. Passes layout props (padding, background).
+  - **ContainerRenderer**: Renders slot children via SectionDispatcher recursion. TV-adapted spacing.
+  - **PlaceholderRenderer**: `__DEV__` console.warn with block kind, returns null in production.
+
+  **Patterns to follow:**
+  - `apps/mobile-v2/src/components/sections/SectionDispatcher.tsx` — dispatch pattern
+  - `apps/mobile-v2/src/components/sections/SectionWrapperRenderer.tsx` — recursive child rendering
+  - `docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md` — structural renderers are mandatory
+
+  **Test scenarios:**
+  - Happy path: SectionDispatcher routes `sectionWrapper` kind to SectionWrapperRenderer
+  - Happy path: SectionWrapperRenderer recursively renders nested children
+  - Happy path: ContainerRenderer renders slot children
+  - Happy path: Unknown kind renders PlaceholderRenderer (logs in dev, returns null)
+  - Integration: Nested structure (sectionWrapper → container → text) renders full depth
+
+  **Verification:**
+  - A real Experience with nested blocks renders correctly — no silently missing sections
+  - Dev console shows warnings for unhandled block types
+
+- [ ] **Unit 6: Content Renderers**
+
+  **Goal:** Implement the TV-adapted visual renderers for core block types: VideoHero (experience detail version), VideoCard, Text, and BibleQuotesCarousel.
+
+  **Requirements:** R4, R6, R10
+
+  **Dependencies:** Units 3, 5
+
+  **Files:**
+  - Create: `apps/tv/src/components/sections/VideoHeroRenderer.tsx`
+  - Create: `apps/tv/src/components/sections/VideoCardRenderer.tsx`
+  - Create: `apps/tv/src/components/sections/TextRenderer.tsx`
+  - Create: `apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx`
+
+  **Approach:**
+  - **VideoHeroRenderer**: Full-width hero for the experience detail section feed. Shows `videoStill` via expo-image, title + subtitle overlay. Focusable — select enters video playback. (Home screen uses a separate `HomeHero` component from Unit 4, not this renderer.)
+  - **VideoCardRenderer**: Landscape card showing `videoStill` thumbnail + title. Focusable. Select enters video playback. Used in experience detail section feed.
+  - **TextRenderer**: Large readable text for 10-foot UI. `contentParagraphs` validated with `Array.isArray()`. System font, high contrast, generous line spacing.
+  - **BibleQuotesCarouselRenderer**: Horizontal D-pad-navigable carousel of quote cards. Each card shows reference + text. Wrap in `TVFocusGuideView` to contain horizontal focus.
+  - All renderers: expo-image with `recyclingKey`, `hexToRgba()` for gradient stops (never `"transparent"`), composite React keys.
+
+  **Patterns to follow:**
+  - `apps/mobile-v2/src/components/sections/VideoHeroRenderer.tsx` — data shape and field access
+  - `apps/mobile-v2/src/components/sections/TextRenderer.tsx` — paragraph parsing
+  - `apps/mobile-v2/src/components/sections/BibleQuotesCarouselRenderer.tsx` — carousel data shape
+
+  **Test scenarios:**
+  - Happy path: VideoHeroRenderer shows image, title, subtitle from Experience data
+  - Happy path: VideoCardRenderer shows thumbnail and title, is focusable
+  - Happy path: TextRenderer renders paragraphs with readable font size
+  - Happy path: BibleQuotesCarousel shows quote cards navigable with D-pad left/right
+  - Edge case: `contentParagraphs` is not an array — renders gracefully (no crash)
+  - Edge case: Missing `videoStill` image — falls back to `ogImage` or placeholder
+  - Edge case: Long title text — truncates with ellipsis, doesn't overflow
+
+  **Verification:**
+  - Real Experience blocks render on TV Simulator with correct data
+  - All interactive renderers show focus rings on D-pad focus
+  - Text is readable at 10-foot viewing distance (large font, high contrast)
+
+- [ ] **Unit 7: Experience Detail Screen**
+
+  **Goal:** Wire up the experience detail route to fetch, normalize, and render a full Experience as a vertical section feed using the TV renderers.
+
+  **Requirements:** R4, R7, R10
+
+  **Dependencies:** Units 2, 5, 6
+
+  **Files:**
+  - Create: `apps/tv/app/experience/[slug].tsx`
+
+  **Approach:**
+  - Route receives `slug` param via Expo Router `useLocalSearchParams()`
+  - Decode with `decodeURIComponent()` (slugs may contain `/`)
+  - Fetch `GET_WATCH_EXPERIENCE` with `variables: { slug, locale: "en" }`, normalize with `normalizeExperience()`
+  - Wrap content in `ExperienceProvider`
+  - Render vertical FlatList of sections via `SectionDispatcher`
+  - Loading: centered spinner. Error: message + focusable retry button.
+  - Back button (menu) pops to home screen. Focus should restore on the card that was selected (via ContentRail focus memory from Unit 3).
+
+  **Patterns to follow:**
+  - `apps/mobile-v2/app/(tabs)/index.tsx` — experience fetching pattern
+  - `docs/solutions/mobile/expo-router-slash-in-dynamic-route-params.md` — `encodeURIComponent` for slug params
+
+  **Test scenarios:**
+  - Happy path: Navigating to `experience/[slug]` renders that Experience's blocks in a vertical feed
+  - Happy path: D-pad navigates between focusable sections in the feed
+  - Happy path: Back button returns to home screen
+  - Error path: Invalid slug — shows error screen with retry
+  - Edge case: Experience with only unhandled block types — shows PlaceholderRenderer warnings, screen not blank (at minimum shows loading → empty state)
+
+  **Verification:**
+  - Select a card on home → experience detail renders with real blocks
+  - Back button returns to home, focus restores on the previously selected card
+  - Multiple experiences navigate correctly
+
+- [ ] **Unit 8: Video Playback**
+
+  **Goal:** Implement full-screen video playback with TV remote controls (play/pause, seek, back).
+
+  **Requirements:** R5, R9
+
+  **Dependencies:** Units 6, 7
+
+  **Files:**
+  - Create: `apps/tv/src/components/VideoPlayer.tsx`
+  - Modify: `apps/tv/src/components/sections/VideoHeroRenderer.tsx` (wire up video launch)
+  - Modify: `apps/tv/src/components/sections/VideoCardRenderer.tsx` (wire up video launch)
+
+  **Approach:**
+  - **VideoPlayer**: Full-screen expo-video player as a modal/overlay component (not a separate route — avoids URL-encoding long HLS URLs in route params). Receives `streamingUrl` via React context or callback prop.
+  - Remote controls: play/pause (center/select button), seek ±10s (left/right on remote), back to experience (menu button).
+  - Use stable `useRef` for video source (not state) per institutional learning.
+  - Pause on screen blur via navigation listener.
+  - End of video: dismiss overlay, focus returns to the video block that was playing.
+
+  **Patterns to follow:**
+  - `apps/mobile-v2/src/components/sections/VideoHeroRenderer.tsx` — video launch pattern
+  - `docs/solutions/best-practices/playlist-video-player-sdui-mobile-20260409.md` — `useVideoPlayer` stability patterns
+
+  **Test scenarios:**
+  - Happy path: Selecting a video block enters full-screen playback of HLS stream
+  - Happy path: Center button toggles play/pause
+  - Happy path: Left/right seeks ±10s
+  - Happy path: Menu button exits playback, returns to experience screen
+  - Happy path: Video end returns to experience screen
+  - Edge case: Invalid or unavailable stream URL — shows error, back button still works
+  - Edge case: Rapid play/pause — no crash or inconsistent state
+
+  **Verification:**
+  - HLS video plays full-screen on Apple TV Simulator
+  - Remote controls work as specified
+  - Navigation back from video restores experience screen with correct focus
+
+## System-Wide Impact
+
+- **Interaction graph:** The TV app is a new, independent consumer of the Strapi GraphQL API. It does not affect existing mobile-v2 or web apps. The only shared surface is the `@forge/graphql` package (read-only dependency) and the CMS content.
+- **Error propagation:** GraphQL errors surface via Apollo Client's `error` field → each screen shows error state with retry. No cross-app error propagation.
+- **State lifecycle risks:** Apollo `InMemoryCache` is per-session only (no persistence). No risk of stale cache across app restarts.
+- **API surface parity:** The TV app uses existing GraphQL queries (`GET_WATCH_EXPERIENCE`, `LIST_EXPERIENCES`). No new API surface created.
+- **Integration coverage:** End-to-end flow (CMS → GraphQL → normalize → dispatch → render) on TV should be validated with real CMS data, not mocks.
+- **Unchanged invariants:** `apps/mobile-v2/`, `apps/web/`, `packages/graphql/`, and `apps/cms/` are not modified by this plan.
+
+## Risks & Dependencies
+
+| Risk                                                          | Mitigation                                                                                                                                          |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Expo SDK 54 + react-native-tvos incompatibility               | Unit 1 is a go/no-go gate. If it fails, stop.                                                                                                       |
+| expo-video doesn't work on tvOS                               | Validated by expo/expo PR #29560, but confirmed by Unit 1 spike.                                                                                    |
+| Focus management complexity with nested scrollable containers | Start simple (one rail, one hero). TVFocusGuideView constrains focus. Known back-nav bug has documented workaround.                                 |
+| Metro bundler issues with react-native-tvos alias             | Singleton resolver pattern from mobile-v2 addresses this. Adjust `react-native` path in singleton map.                                              |
+| Sparse CMS content makes home screen look empty               | Prototype quality depends on content. Not a blocker but affects qualitative assessment.                                                             |
+| Copied SDUI files drift from mobile-v2                        | Low risk — files only change with CMS schema changes, which force both apps to update. Monitor and extract to shared package if drift becomes real. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md](docs/brainstorms/2026-04-10-tv-app-prototype-requirements.md)
+- Best practices: [docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md](docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md)
+- Metro resolution: [docs/solutions/mobile/metro-pnpm-symlink-react-duplicate-resolution.md](docs/solutions/mobile/metro-pnpm-symlink-react-duplicate-resolution.md)
+- SDUI scaffold: [docs/solutions/mobile/mobile-v2-sdui-app-scaffold-and-review-findings.md](docs/solutions/mobile/mobile-v2-sdui-app-scaffold-and-review-findings.md)
+- Env inlining: [docs/solutions/runtime-errors/metro-env-inlining-eas-update-white-screen-20260410.md](docs/solutions/runtime-errors/metro-env-inlining-eas-update-white-screen-20260410.md)
+- Video patterns: [docs/solutions/best-practices/playlist-video-player-sdui-mobile-20260409.md](docs/solutions/best-practices/playlist-video-player-sdui-mobile-20260409.md)
+- ExperienceProvider: [docs/solutions/mobile/sdui-experience-provider-block-index-parent-child-loss.md](docs/solutions/mobile/sdui-experience-provider-block-index-parent-child-loss.md)
+- Adding apps: [docs/solutions/platform/adding-new-apps.md](docs/solutions/platform/adding-new-apps.md)
+- Roadmap: feat-072 through feat-076 in `docs/roadmap/topic-experiences/`

--- a/docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md
+++ b/docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md
@@ -10,6 +10,10 @@ applies_when:
   - "Adding Apple TV or Android TV to a monorepo with an existing Expo/React Native SDUI pipeline"
   - "Porting an SDUI dispatcher to a 10-foot UI (TV, kiosk, car)"
   - "Designing a TV home screen against a CMS modeled for single-Experience deep-links"
+  - "Debugging New Architecture crashes on tvOS with react-native-tvos"
+  - "FlatList rendering zero-height items on tvOS"
+  - "Android TV emulator can't reach host localhost"
+last_updated: "2026-04-13"
 tags:
   - expo
   - tv
@@ -18,6 +22,8 @@ tags:
   - monorepo
   - focus-management
   - architecture
+  - new-architecture
+  - android-tv
 ---
 
 # Expo TV Platform Setup in an SDUI Monorepo
@@ -69,6 +75,88 @@ Key facts:
 - No Expo Go on TV -- dev-client builds only
 - TV-specific file extensions supported: `*.tv.tsx`, `*.ios.tv.tsx`, `*.android.tv.tsx`
 - `npx expo prebuild --clean` is required when switching between phone and TV targets
+
+**tvOS deployment target:** The `@react-native-tvos/config-tv` plugin defaults to tvOS 13.4, but Expo SDK 54 modules require tvOS 15.1+. Set `tvosDeploymentTarget` explicitly:
+
+```jsonc
+// apps/tv/app.json
+{
+  "plugins": [
+    [
+      "@react-native-tvos/config-tv",
+      { "isTV": true, "tvosDeploymentTarget": "16.0" },
+    ],
+  ],
+}
+```
+
+Without this, the build fails with: `compiling for tvOS 13.4, but module 'Expo' has a minimum deployment target of tvOS 15.1`.
+
+### 1b. Disable New Architecture on tvOS
+
+React Native's New Architecture (`newArchEnabled: true`) causes a hard crash on tvOS with react-native-tvos 0.81:
+
+```
+Failed to call into JavaScript module method RCTEventEmitter.receiveEvent().
+Module has not been registered as callable.
+```
+
+This is a known incompatibility. Disable it in `app.json`:
+
+```jsonc
+// apps/tv/app.json
+{
+  "expo": {
+    "newArchEnabled": false,
+  },
+}
+```
+
+Do not debug the event emitter error — it is not fixable without upstream react-native-tvos changes. The Legacy Architecture works correctly for TV.
+
+### 1c. Expo Dev Client on TV Simulator
+
+`expo run:ios` builds the app successfully but fails to detect the installed app on the TV Simulator:
+
+```
+CommandError: No development build (org.jesusfilm.forgetv) for this project is installed.
+```
+
+The app IS installed — the Expo CLI's tvOS Simulator detection is broken. Use a two-terminal workaround:
+
+**Terminal 1** — start Metro bundler:
+
+```bash
+EXPO_TV=1 npx expo start --clear
+```
+
+**Terminal 2** — launch via deep link:
+
+```bash
+xcrun simctl openurl <simulator-id> \
+  "exp+<slug>://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
+```
+
+Get the simulator ID from `xcrun simctl list devices | grep "Apple TV"`. The first launch shows an "Open in forge-tv?" dialog — accept it once, subsequent launches auto-connect.
+
+### 1d. Android TV Localhost Resolution
+
+The Android emulator cannot reach the host machine's `localhost`. Detect the platform and swap:
+
+```typescript
+// apps/tv/src/lib/config.ts
+import { Platform } from "react-native"
+
+export function getGraphQLUrl(): string {
+  const url = env.EXPO_PUBLIC_GRAPHQL_URL
+  if (__DEV__ && Platform.OS === "android" && url.includes("localhost")) {
+    return url.replace("localhost", "10.0.2.2")
+  }
+  return url
+}
+```
+
+This is a known Android emulator behavior — `10.0.2.2` maps to the host machine's loopback interface.
 
 ### 2. Separate App, Shared Logic
 
@@ -149,12 +237,60 @@ const focusMemory = new Map<string, number>() // railId -> itemIndex
 
 **Known issue:** Focus lost on back-navigation (react-native-tvos issue #852). Workaround: restore focus via `hasTVPreferredFocus` in a `useEffect` on screen focus.
 
+### 7. FlatList Zero-Height Items on tvOS
+
+FlatList with complex SDUI block content may render all items at zero height, producing a completely blank screen despite correct data. This is a tvOS-specific layout measurement issue with dynamically sized items.
+
+**Workaround:** Use `ScrollView` with mapped items instead of FlatList for the experience detail feed:
+
+```tsx
+// Instead of FlatList (blank screen on tvOS):
+<FlatList data={sections} renderItem={({ item }) => <SectionDispatcher section={item} />} />
+
+// Use ScrollView (works reliably):
+<ScrollView>
+  {sections.map((section, index) => (
+    <View key={`${section.kind}-${section.id}-${index}`}>
+      <SectionDispatcher section={section} />
+    </View>
+  ))}
+</ScrollView>
+```
+
+Horizontal FlatList (used in ContentRail) works correctly — the issue is specific to vertical FlatList with variable-height SDUI content.
+
+### 8. GraphQL Fragment Alias Pitfalls
+
+When gql.tada fragments use field aliases (e.g., `videoRef: video`), the normalized SDUI block carries the **aliased** name. Renderers must read the alias, not the original field name:
+
+```typescript
+// Fragment in queries.ts
+fragment VideoSectionFields on ComponentSectionsVideo {
+  videoRef: video { documentId title images { videoStill } }
+  videoTitle: title
+}
+
+// Renderer — CORRECT: use aliased names
+const video = section.videoRef   // ✓
+const title = section.videoTitle // ✓
+
+// Renderer — WRONG: original names are undefined
+const video = section.video      // ✗ undefined at runtime
+const title = section.title      // ✗ undefined at runtime
+```
+
+This is silent — TypeScript doesn't catch it because `NormalizedBlock` uses `[key: string]: unknown`. The only symptom is blank rendering with no errors. Verify field names against the actual fragment definitions in `queries.ts`.
+
 ## Why This Matters
 
 - **Prevents copy-and-drift**: Sharing normalizer/queries via workspace paths means CMS changes propagate automatically
 - **Prevents silent content gaps**: Missing structural renderers cause sections to vanish without errors -- the hardest SDUI bug class to diagnose
 - **Prevents wasted effort**: Day-1 spike surfaces platform blockers in hours, not weeks
 - **Focus bugs are invisible in desktop testing**: Must test on TV Simulator with simulated remote
+- **New Arch crash is a dead end**: The `RCTEventEmitter.receiveEvent()` error has no workaround — only disabling New Architecture resolves it. Without this knowledge, debugging takes days
+- **tvOS deployment target is a build blocker**: The default (13.4) fails silently deep in the Xcode build — not obvious from the error output
+- **GraphQL alias mismatch is silent**: Renders blank content with no errors or warnings — only discoverable by comparing fragment definitions against renderer field access
+- **Validates the SDUI architecture**: The same CMS content, GraphQL fragments, and normalizer serve mobile, web, and TV with shared pipeline code
 
 ## When to Apply
 
@@ -162,6 +298,10 @@ const focusMemory = new Map<string, number>() // railId -> itemIndex
 - Expo SDK 54+ with react-native-tvos 0.81-stable
 - Porting an SDUI dispatcher to a 10-foot or non-touch UI
 - Designing a TV home screen against a CMS modeled for single-Experience views
+- Debugging "RCTEventEmitter.receiveEvent() not registered" on tvOS — disable New Architecture
+- Debugging blank screens on tvOS after data loads successfully — check FlatList vs ScrollView
+- Android TV emulator returning "Network request failed" — swap localhost to 10.0.2.2
+- SDUI renderer showing blank content with no errors — check GraphQL fragment alias names
 
 ## Examples
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,10 +307,10 @@ importers:
         version: 10.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
       jest-expo:
         specifier: ~54.0.0
-        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -465,6 +465,88 @@ importers:
         version: 4.1.18
       typescript:
         specifier: ^5.8.3
+        version: 5.9.3
+
+  apps/tv:
+    dependencies:
+      '@apollo/client':
+        specifier: ^4.1.4
+        version: 4.1.4(graphql-ws@6.0.7(graphql@16.13.1)(ws@8.19.0))(graphql@16.13.1)(react-dom@19.2.4(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)
+      '@forge/graphql':
+        specifier: workspace:*
+        version: link:../../packages/graphql
+      '@react-native-tvos/config-tv':
+        specifier: ^0.0.13
+        version: 0.0.13(expo@54.0.33)
+      '@t3-oss/env-core':
+        specifier: ^0.13.11
+        version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
+      expo:
+        specifier: ~54.0.33
+        version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      expo-constants:
+        specifier: ~18.0.13
+        version: 18.0.13(expo@54.0.33)(react-native-tvos@0.81.5-2)
+      expo-dev-client:
+        specifier: ~6.0.20
+        version: 6.0.20(expo@54.0.33)
+      expo-image:
+        specifier: ~3.0.11
+        version: 3.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      expo-linking:
+        specifier: ~8.0.11
+        version: 8.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      expo-router:
+        specifier: ~6.0.23
+        version: 6.0.23(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      expo-status-bar:
+        specifier: ~3.0.9
+        version: 3.0.9(react-native-tvos@0.81.5-2)(react@19.1.0)
+      expo-video:
+        specifier: ~3.0.16
+        version: 3.0.16(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      graphql:
+        specifier: 16.13.1
+        version: 16.13.1
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-native:
+        specifier: npm:react-native-tvos@0.81-stable
+        version: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-screens:
+        specifier: ~4.16.0
+        version: 4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@babel/runtime':
+        specifier: ^7.28.0
+        version: 7.28.6
+      '@types/jest':
+        specifier: ^29.5.0
+        version: 29.5.14
+      '@types/react':
+        specifier: ~19.1.17
+        version: 19.1.17
+      babel-preset-expo:
+        specifier: ^54.0.10
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33)(react-refresh@0.14.2)
+      eslint:
+        specifier: '>=8.10'
+        version: 9.39.2(jiti@2.6.1)
+      eslint-config-expo:
+        specifier: ~10.0.0
+        version: 10.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
+      jest-expo:
+        specifier: ~54.0.0
+        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      typescript:
+        specifier: ~5.9.2
         version: 5.9.3
 
   apps/web:
@@ -2492,10 +2574,6 @@ packages:
   '@expo/env@2.0.8':
     resolution: {integrity: sha512-5VQD6GT8HIMRaSaB5JFtOXuvfDVU80YtZIuUT/GDhUF782usIXY13Tn3IdDz1Tm/lqA9qnRZQ1BF4t7LlvdJPA==}
 
-  '@expo/env@2.1.1':
-    resolution: {integrity: sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==}
-    engines: {node: '>=20.12.0'}
-
   '@expo/fingerprint@0.15.4':
     resolution: {integrity: sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==}
     hasBin: true
@@ -2505,9 +2583,6 @@ packages:
 
   '@expo/json-file@10.0.12':
     resolution: {integrity: sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==}
-
-  '@expo/json-file@10.0.8':
-    resolution: {integrity: sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==}
 
   '@expo/metro-config@54.0.14':
     resolution: {integrity: sha512-hxpLyDfOR4L23tJ9W1IbJJsG7k4lv2sotohBm/kTYyiG+pe1SYCAWsRmgk+H42o/wWf/HQjE5k45S5TomGLxNA==}
@@ -4675,6 +4750,22 @@ packages:
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.65 <1.0
+
+  '@react-native-tvos/config-tv@0.0.13':
+    resolution: {integrity: sha512-I7HEAVzkVDR4ou7AWVCLIeFydu9gIMlE6o0dAckTeb8kLeOGNtHAoLmqwN5geoNfZor9FRs/cV4bfol45mcK2g==}
+    peerDependencies:
+      expo: ^51
+
+  '@react-native-tvos/virtualized-lists@0.81.5-2':
+    resolution: {integrity: sha512-i5L6sJ8Dae5JUWhfb5w/RgZUm3CYRFhV5/PB/xu3ASxFyHjfO0kQAqcU3ySNAOR0HfmaXK8R4OC0h07zoUWKrQ==}
+    engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@types/react': ^19.1.0
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@react-native/assets-registry@0.81.5':
     resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
@@ -8800,11 +8891,25 @@ packages:
       expo: '*'
       react-native: '*'
 
-  expo-constants@55.0.9:
-    resolution: {integrity: sha512-iBiXjZeuU5S/8docQeNzsVvtDy4w0zlmXBpFEi1ypwugceEpdQQab65TVRbusXAcwpNVxCPMpNlDssYp0Pli2g==}
+  expo-dev-client@6.0.20:
+    resolution: {integrity: sha512-5XjoVlj1OxakNxy55j/AUaGPrDOlQlB6XdHLLWAw61w5ffSpUDHDnuZzKzs9xY1eIaogOqTOQaAzZ2ddBkdXLA==}
     peerDependencies:
       expo: '*'
-      react-native: '*'
+
+  expo-dev-launcher@6.0.20:
+    resolution: {integrity: sha512-a04zHEeT9sB0L5EB38fz7sNnUKJ2Ar1pXpcyl60Ki8bXPNCs9rjY7NuYrDkP/irM8+1DklMBqHpyHiLyJ/R+EA==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu-interface@2.0.0:
+    resolution: {integrity: sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu@7.0.18:
+    resolution: {integrity: sha512-4kTdlHrnZCAWCT6tZRQHSSjZ7vECFisL4T+nsG/GJDo/jcHNaOVGV5qPV9wzlTxyMk3YOPggRw4+g7Ownrg5eA==}
+    peerDependencies:
+      expo: '*'
 
   expo-eas-client@1.0.8:
     resolution: {integrity: sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA==}
@@ -8866,12 +8971,6 @@ packages:
     resolution: {integrity: sha512-nCMgZXcHesnFslH1TUFMdqlDiE4jYTTTSHb97g1jq1gyGX2xDEOyqBxQJmiIVGrZJ+kTWH6RljJ5tYyva9mrAg==}
     peerDependencies:
       expo: '*'
-      react: '*'
-      react-native: '*'
-
-  expo-linking@55.0.9:
-    resolution: {integrity: sha512-QWEefQZUu7PuJzye19Hr6msqpO4VB4TiY4T/6AkISJzZnoZGxWg16s3JTZS7D/b3VMm8VQfhw9I5NF/7f8EPcA==}
-    peerDependencies:
       react: '*'
       react-native: '*'
 
@@ -9441,6 +9540,10 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  getenv@1.0.0:
+    resolution: {integrity: sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==}
+    engines: {node: '>=6'}
 
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
@@ -12821,6 +12924,17 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-tvos@0.81.5-2:
+    resolution: {integrity: sha512-y/V8iFZGNXQq6b+X9VBQG19PaBpAXQHhv2vhcCMe2gEePqI2Uu8n3ClqglBn8u+Fl/GXCMcFdnJ0v0nRyxJ5TA==}
+    engines: {node: '>= 20.19.4'}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^19.1.0
+      react: ^19.1.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-native-webview@13.15.0:
     resolution: {integrity: sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==}
@@ -17658,6 +17772,81 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(graphql@16.13.1)(react-native-tvos@0.81.5-2)':
+    dependencies:
+      '@0no-co/graphql.web': 1.2.0(graphql@16.13.1)
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/devcert': 1.2.1
+      '@expo/env': 2.0.8
+      '@expo/image-utils': 0.8.8
+      '@expo/json-file': 10.0.12
+      '@expo/metro': 54.2.0
+      '@expo/metro-config': 54.0.14(expo@54.0.33)
+      '@expo/osascript': 2.3.8
+      '@expo/package-manager': 1.9.10
+      '@expo/plist': 0.4.8
+      '@expo/prebuild-config': 54.0.8(expo@54.0.33)
+      '@expo/schema-utils': 0.1.8
+      '@expo/spawn-async': 1.7.2
+      '@expo/ws-tunnel': 1.0.6
+      '@expo/xcpretty': 4.4.1
+      '@react-native/dev-middleware': 0.81.5
+      '@urql/core': 5.2.0(graphql@16.13.1)
+      '@urql/exchange-retry': 1.3.2(@urql/core@5.2.0(graphql@16.13.1))
+      accepts: 1.3.8
+      arg: 5.0.2
+      better-opn: 3.0.2
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      compression: 1.8.1
+      connect: 3.7.0
+      debug: 4.4.3(supports-color@8.1.1)
+      env-editor: 0.4.2
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      expo-server: 1.0.5
+      freeport-async: 2.0.0
+      getenv: 2.0.0
+      glob: 13.0.6
+      lan-network: 0.1.7
+      minimatch: 9.0.5
+      node-forge: 1.3.3
+      npm-package-arg: 11.0.3
+      ora: 3.4.0
+      picomatch: 3.0.1
+      pretty-bytes: 5.6.0
+      pretty-format: 29.7.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      qrcode-terminal: 0.11.0
+      require-from-string: 2.0.2
+      requireg: 0.2.2
+      resolve: 1.22.11
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      semver: 7.7.4
+      send: 0.19.2
+      slugify: 1.6.6
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      tar: 7.5.9
+      terminal-link: 2.1.1
+      undici: 6.23.0
+      wrap-ansi: 7.0.0
+      ws: 8.19.0
+    optionalDependencies:
+      expo-router: 6.0.23(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+
   '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(graphql@16.13.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))':
     dependencies:
       '@0no-co/graphql.web': 1.2.0(graphql@16.13.1)
@@ -17667,7 +17856,7 @@ snapshots:
       '@expo/devcert': 1.2.1
       '@expo/env': 2.0.8
       '@expo/image-utils': 0.8.8
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       '@expo/metro': 54.2.0
       '@expo/metro-config': 54.0.14(expo@54.0.33)
       '@expo/osascript': 2.3.8
@@ -17725,7 +17914,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0
     optionalDependencies:
-      expo-router: 6.0.23(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@55.0.9)(expo-linking@55.0.9)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-router: 6.0.23(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -17740,7 +17929,7 @@ snapshots:
   '@expo/config-plugins@54.0.4':
     dependencies:
       '@expo/config-types': 54.0.10
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       '@expo/plist': 0.4.8
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
@@ -17783,7 +17972,7 @@ snapshots:
       '@babel/code-frame': 7.10.4
       '@expo/config-plugins': 54.0.4
       '@expo/config-types': 54.0.10
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       deepmerge: 4.3.1
       getenv: 2.0.0
       glob: 13.0.6
@@ -17820,6 +18009,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/devtools@0.1.8(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      chalk: 4.1.2
+    optionalDependencies:
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       chalk: 4.1.2
@@ -17836,15 +18032,6 @@ snapshots:
       getenv: 2.0.0
     transitivePeerDependencies:
       - supports-color
-
-  '@expo/env@2.1.1':
-    dependencies:
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      getenv: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@expo/fingerprint@0.15.4':
     dependencies:
@@ -17880,11 +18067,6 @@ snapshots:
       '@babel/code-frame': 7.29.0
       json5: 2.2.3
 
-  '@expo/json-file@10.0.8':
-    dependencies:
-      '@babel/code-frame': 7.10.4
-      json5: 2.2.3
-
   '@expo/metro-config@54.0.14(expo@54.0.33)':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -17892,7 +18074,7 @@ snapshots:
       '@babel/generator': 7.29.1
       '@expo/config': 12.0.13
       '@expo/env': 2.0.8
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       '@expo/metro': 54.2.0
       '@expo/spawn-async': 1.7.2
       browserslist: 4.28.1
@@ -17909,11 +18091,15 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2)':
+    dependencies:
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
 
   '@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))':
     dependencies:
@@ -17947,7 +18133,7 @@ snapshots:
 
   '@expo/package-manager@1.9.10':
     dependencies:
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       '@expo/spawn-async': 1.7.2
       chalk: 4.1.2
       npm-package-arg: 11.0.3
@@ -17972,10 +18158,10 @@ snapshots:
       '@expo/config-plugins': 54.0.4
       '@expo/config-types': 54.0.10
       '@expo/image-utils': 0.8.8
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3(supports-color@8.1.1)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -18001,6 +18187,12 @@ snapshots:
       cross-spawn: 7.0.6
 
   '@expo/sudo-prompt@9.3.2': {}
+
+  '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      expo-font: 14.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
 
   '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -18936,14 +19128,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -19082,7 +19274,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -20437,6 +20629,20 @@ snapshots:
       merge-options: 3.0.4
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
+  '@react-native-tvos/config-tv@0.0.13(expo@54.0.33)':
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      getenv: 1.0.0
+
+  '@react-native-tvos/virtualized-lists@0.81.5-2(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+
   '@react-native/assets-registry@0.81.5': {}
 
   '@react-native/babel-plugin-codegen@0.81.5(@babel/core@7.29.0)':
@@ -20566,6 +20772,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
+  '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      '@react-navigation/native': 7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-safe-area-context: 5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-screens: 4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      sf-symbols-typescript: 2.2.0
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+
   '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@react-navigation/elements': 2.9.14(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -20605,6 +20824,16 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
 
+  '@react-navigation/elements@2.9.10(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      '@react-navigation/native': 7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-safe-area-context: 5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      use-latest-callback: 0.2.6(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
+
   '@react-navigation/elements@2.9.10(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@react-navigation/native': 7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -20622,6 +20851,16 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
       react-native-safe-area-context: 5.7.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      use-latest-callback: 0.2.6(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
+
+  '@react-navigation/elements@2.9.14(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      '@react-navigation/native': 7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-safe-area-context: 5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0)
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
 
@@ -20645,6 +20884,20 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
     optional: true
+
+  '@react-navigation/native-stack@7.14.4(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.10(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      '@react-navigation/native': 7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-safe-area-context: 5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-screens: 4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      sf-symbols-typescript: 2.2.0
+      warn-once: 0.1.1
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
 
   '@react-navigation/native-stack@7.14.4(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -20673,6 +20926,16 @@ snapshots:
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
+
+  '@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0)':
+    dependencies:
+      '@react-navigation/core': 7.16.1(react@19.1.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.11
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      use-latest-callback: 0.2.6(react@19.1.0)
 
   '@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -22924,7 +23187,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -23184,7 +23447,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -24447,7 +24710,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.6
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -25275,13 +25538,13 @@ snapshots:
     dependencies:
       buffer: 5.7.1
 
-  create-jest@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0):
+  create-jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -26031,7 +26294,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -26072,7 +26335,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -26092,6 +26355,35 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -26103,7 +26395,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -26341,6 +26633,16 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  expo-asset@12.0.12(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      '@expo/image-utils': 0.8.8
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native-tvos@0.81.5-2)
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/image-utils': 0.8.8
@@ -26357,6 +26659,15 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
+  expo-constants@18.0.13(expo@54.0.33)(react-native-tvos@0.81.5-2):
+    dependencies:
+      '@expo/config': 12.0.13
+      '@expo/env': 2.0.8
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-constants@18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
@@ -26366,25 +26677,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@55.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3):
+  expo-dev-client@6.0.20(expo@54.0.33):
     dependencies:
-      '@expo/config': 55.0.11(typescript@5.9.3)
-      '@expo/env': 2.1.1
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      expo-dev-launcher: 6.0.20(expo@54.0.33)
+      expo-dev-menu: 7.0.18(expo@54.0.33)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.33)
+      expo-manifests: 1.0.10(expo@54.0.33)
+      expo-updates-interface: 2.0.0(expo@54.0.33)
     transitivePeerDependencies:
       - supports-color
-      - typescript
-    optional: true
+
+  expo-dev-launcher@6.0.20(expo@54.0.33):
+    dependencies:
+      ajv: 8.18.0
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      expo-dev-menu: 7.0.18(expo@54.0.33)
+      expo-manifests: 1.0.10(expo@54.0.33)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-dev-menu-interface@2.0.0(expo@54.0.33):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+
+  expo-dev-menu@7.0.18(expo@54.0.33):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.33)
 
   expo-eas-client@1.0.8: {}
 
   expo-eas-client@55.0.3: {}
 
+  expo-file-system@19.0.21(expo@54.0.33)(react-native-tvos@0.81.5-2):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  expo-font@14.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      fontfaceobserver: 2.3.0
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
 
   expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -26399,6 +26740,12 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
+  expo-image@3.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   expo-image@3.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -26411,7 +26758,7 @@ snapshots:
 
   expo-keep-awake@15.0.8(expo@54.0.33)(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
   expo-linear-gradient@15.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
@@ -26426,17 +26773,15 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
-  expo-linking@55.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-linking@8.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0):
     dependencies:
-      expo-constants: 55.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native-tvos@0.81.5-2)
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
     transitivePeerDependencies:
       - expo
       - supports-color
-      - typescript
-    optional: true
 
   expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -26451,7 +26796,7 @@ snapshots:
   expo-manifests@1.0.10(expo@54.0.33):
     dependencies:
       '@expo/config': 12.0.13
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
       expo-json-utils: 0.15.0
     transitivePeerDependencies:
       - supports-color
@@ -26473,11 +26818,57 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
+  expo-modules-core@3.0.29(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   expo-modules-core@3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  expo-router@6.0.23(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      '@expo/metro-runtime': 5.0.4(react-native-tvos@0.81.5-2)
+      '@expo/schema-utils': 0.1.8
+      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.2.4(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs': 7.15.9(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      '@react-navigation/native': 7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0)
+      '@react-navigation/native-stack': 7.14.4(@react-navigation/native@7.1.33(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      client-only: 0.0.1
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native-tvos@0.81.5-2)
+      expo-linking: 8.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      expo-server: 1.0.5
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 19.1.0
+      react-fast-compare: 3.2.2
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.2.1(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-safe-area-context: 5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-screens: 4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.6(react@19.1.0)
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.2.4(react@19.1.0))(react@19.1.0)
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.1.0)
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
 
   expo-router@6.0.23(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -26519,7 +26910,7 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  expo-router@6.0.23(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@55.0.9)(expo-linking@55.0.9)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-router@6.0.23(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.7.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/metro-runtime': 5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       '@expo/schema-utils': 0.1.8
@@ -26532,8 +26923,8 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-constants: 55.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
-      expo-linking: 55.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
+      expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.5
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
@@ -26562,6 +26953,12 @@ snapshots:
 
   expo-server@1.0.5: {}
 
+  expo-status-bar@3.0.9(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.2.1(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -26574,7 +26971,7 @@ snapshots:
 
   expo-updates-interface@2.0.0(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
 
   expo-updates-interface@55.1.3(expo@54.0.33):
     dependencies:
@@ -26625,11 +27022,53 @@ snapshots:
       - supports-color
       - typescript
 
+  expo-video@3.0.16(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   expo-video@3.0.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@expo/cli': 54.0.23(expo-router@6.0.23)(expo@54.0.33)(graphql@16.13.1)(react-native-tvos@0.81.5-2)
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/devtools': 0.1.8(react-native-tvos@0.81.5-2)(react@19.1.0)
+      '@expo/fingerprint': 0.15.4
+      '@expo/metro': 54.2.0
+      '@expo/metro-config': 54.0.14(expo@54.0.33)
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+      '@ungap/structured-clone': 1.3.0
+      babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33)(react-refresh@0.14.2)
+      expo-asset: 12.0.12(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native-tvos@0.81.5-2)
+      expo-file-system: 19.0.21(expo@54.0.33)(react-native-tvos@0.81.5-2)
+      expo-font: 14.0.11(expo@54.0.33)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      expo-keep-awake: 15.0.8(expo@54.0.33)(react@19.1.0)
+      expo-modules-autolinking: 3.0.24
+      expo-modules-core: 3.0.29(react-native-tvos@0.81.5-2)(react@19.1.0)
+      pretty-format: 29.7.0
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-refresh: 0.14.2
+      whatwg-url-without-unicode: 8.0.0-3
+    optionalDependencies:
+      '@expo/metro-runtime': 5.0.4(react-native-tvos@0.81.5-2)
+      react-native-webview: 13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - expo-router
+      - graphql
+      - supports-color
+      - utf-8-validate
 
   expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -27227,6 +27666,8 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  getenv@1.0.0: {}
 
   getenv@2.0.0: {}
 
@@ -28261,16 +28702,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0):
+  jest-cli@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)
+      create-jest: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -28299,7 +28740,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0):
+  jest-config@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -28324,7 +28765,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -28384,7 +28825,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -28398,25 +28839,25 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0):
     dependencies:
       '@expo/config': 12.0.13
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)))(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@5.0.4(react-native-tvos@0.81.5-2))(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))
       json5: 2.2.3
       lodash: 4.17.23
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
       react-test-renderer: 19.1.0(react@19.1.0)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -28432,7 +28873,7 @@ snapshots:
   jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/config': 12.0.13
-      '@expo/json-file': 10.0.8
+      '@expo/json-file': 10.0.12
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
@@ -28631,11 +29072,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)
+      jest: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -28677,12 +29118,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0):
+  jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.33)(babel-plugin-macros@3.1.0)
+      jest-cli: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -31553,6 +31994,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-native-is-edge-to-edge@1.2.1(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   react-native-is-edge-to-edge@1.2.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -31563,10 +32009,23 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
+  react-native-safe-area-context@5.7.0(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+
   react-native-safe-area-context@5.7.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  react-native-screens@4.16.0(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-freeze: 1.0.4(react@19.1.0)
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.2.1(react-native-tvos@0.81.5-2)(react@19.1.0)
+      warn-once: 0.1.1
 
   react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -31583,6 +32042,62 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
       warn-once: 0.1.1
+
+  react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-tvos/virtualized-lists': 0.81.5-2(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      '@react-native/assets-registry': 0.81.5
+      '@react-native/codegen': 0.81.5(@babel/core@7.29.0)
+      '@react-native/community-cli-plugin': 0.81.5
+      '@react-native/gradle-plugin': 0.81.5
+      '@react-native/js-polyfills': 0.81.5
+      '@react-native/normalize-colors': 0.81.5
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      base64-js: 1.5.1
+      commander: 12.1.0
+      flow-enums-runtime: 0.0.6
+      glob: 7.2.3
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.83.4
+      metro-source-map: 0.83.4
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 19.1.0
+      react-devtools-core: 6.1.5
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.26.0
+      semver: 7.7.4
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 19.1.17
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - '@react-native/metro-config'
+      - bufferutil
+      - react-native
+      - supports-color
+      - utf-8-validate
+
+  react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0):
+    dependencies:
+      escape-string-regexp: 4.0.0
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+    optional: true
 
   react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -33506,7 +34021,7 @@ snapshots:
 
   unctx@2.5.0:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
       unplugin: 2.3.11
@@ -33595,7 +34110,7 @@ snapshots:
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      acorn: 8.15.0
+      acorn: 8.16.0
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 


### PR DESCRIPTION
## Summary

Adds `apps/tv/` — a new Expo TV app that brings the CMS-driven Experience pipeline to Apple TV and Android TV. The existing SDUI architecture (Strapi → GraphQL → normalizer → dispatcher → renderers) now serves three platforms from the same CMS content, validating the multi-surface design.

The app reuses the shared pipeline logic from mobile-v2 (normalizer, queries, ExperienceProvider) and rewrites all renderers for 10-foot UI with D-pad focus navigation using the Crimson Gallery design system.

## What's included

**Scaffolding & toolchain**
- Expo SDK 54 with `react-native-tvos` (aliased as `react-native`)
- `@react-native-tvos/config-tv` plugin with tvOS 16.0 deployment target
- Metro pnpm singleton resolver for both `react` and `react-native`
- Dev client workflow for TV Simulator (Expo Go unavailable on TV)

**Home screen**
- Hero area from the `isHomepage` Experience (title, subtitle, thumbnail)
- Horizontal Experiences rail with D-pad-focusable cards
- Loading spinner, error state with retry, empty state

**Experience detail**
- Vertical section feed rendering CMS blocks via SectionDispatcher
- TV renderers: VideoHero, VideoCard, Text, BibleQuotesCarousel, SectionWrapper, Container
- PlaceholderRenderer for unimplemented block types (logs in dev, skips in prod)

**Video playback**
- Full-screen expo-video player as a modal overlay
- Play/pause via remote, glassmorphism transport controls
- VideoPlayerContext wired into hero and video card renderers

**Design system: The Crimson Gallery**
- Dark warm stone background (`#161311`), crimson accent (`#CB333B`)
- Focus state: 1.05x scale + crimson glow on D-pad focus
- No 1px borders — tonal depth via surface color shifts

## Key technical decisions

- **Separate app, not a TV target inside mobile-v2**: touch UX conflicts fundamentally with D-pad/10-foot UI
- **New Architecture disabled**: `newArchEnabled: false` — New Arch causes `RCTEventEmitter.receiveEvent()` crash on tvOS with react-native-tvos 0.81
- **ScrollView over FlatList for detail feed**: FlatList renders zero-height items on tvOS with complex SDUI content
- **Android TV localhost swap**: `10.0.2.2` replaces `localhost` in dev config for Android emulator

## Test plan

- [x] Apple TV Simulator: home screen renders hero + rail, experience detail renders blocks
- [x] Android TV Emulator: home screen renders, experience detail renders with text and quotes
- [x] TypeScript compiles clean (`pnpm typecheck`)
- [x] ESLint passes (`pnpm lint`)
- [ ] D-pad focus ring visibility (manual verification)
- [ ] Video playback on TV (requires CMS content with streaming URLs + images)

## Roadmap

Implements feat-072 (spike) through feat-076 (playback) from `docs/roadmap/topic-experiences/`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M_context)-D97757?logo=claude&logoColor=white)