### PR TITLE
fix(manager): remove review player card hover cursor

### DIFF
--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -3962,6 +3962,14 @@ body.jobs-standalone .jobs-step-job-id {
 .jobs-review-card {
   margin-top: 18px;
   padding: 24px;
+  cursor: default;
+}
+
+.jobs-review-card:hover,
+.jobs-review-card:focus-visible {
+  border-color: #d6cec1;
+  box-shadow: 0 10px 22px rgba(12, 17, 29, 0.06);
+  outline: none;
 }
 
 .jobs-review-summary {


### PR DESCRIPTION
## Summary

Fixes the manager job detail Review Player card so the card itself no longer behaves like an interactive collection card on hover. The underlying shared `.collection-card` style sets `cursor: pointer` and hover elevation for expandable collection cards; this PR opts the non-clickable review player card back into a default cursor while preserving pointer affordances on the actual controls inside it.

## Work Loop

- [ ] `ce:plan` done
- [x] `ce:work` done
- [x] `ce:review` done
- [ ] `ce:compound` done

## Notes

Validation run:

- `git diff --check`
- `pnpm run format:check`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager test`
- `CI=1 pnpm --filter @forge/manager build`

Local-only note: `pnpm --filter @forge/manager build` without `CI=1` fails because manager runtime secrets are not present locally; the repo's manager env config skips validation under GitHub Actions CI.
