### PR TITLE
docs: make repo instructions tool-agnostic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,52 @@
 # Forge Agent Guide
 
-This file is the quick execution map. `CLAUDE.md` is the full source of truth; keep both aligned.
+Use this file as the quick execution map. `CLAUDE.md` holds the detailed repo conventions; keep the two aligned.
 
 ## Core model
 
 - Canonical content lives in Strapi.
 - `apps/cms` GraphQL schema drives contracts.
 - `packages/graphql` is the typed client layer.
-- `apps/web` and `apps/mobile` consume `packages/graphql`.
+- `apps/web` and `apps/mobile-v2` consume `packages/graphql`.
+- `apps/mobile/` is deprecated. Do not modify or reference it for new work.
 - Deploy on Railway with Cloudflare edge controls.
 
-## Roadmap
+## Execution checklist
 
-Work is tracked in `docs/roadmap/` as markdown files with YAML frontmatter. Always check for a relevant ticket before starting work.
+- Check `docs/roadmap/` for a relevant ticket before starting.
+- If a ticket exists, set `status: "in-progress"` before making changes.
+- If no ticket exists, create one in the correct lane using the next sequential `feat-NNN` ID and the format defined in `CLAUDE.md`.
+- Check `docs/solutions/` for prior patterns and `todos/` for unresolved findings when they apply to your scope.
+- Read the package-local guide for the area you are changing before editing.
+- Before pushing or opening/updating a PR, run PR-focused validation for the touched scope, including format and CI-sensitive checks.
+- When the work is done, update the roadmap ticket to `status: "complete"`. Create a follow-up `feat-NNN` ticket if additional work is discovered.
 
-- **Before work**: find the ticket in `docs/roadmap/`, set `status: "in-progress"`.
-- **After work**: set `status: "complete"`. If follow-up work is needed, create a new `feat-NNN` file.
-- **New work**: create a ticket in the appropriate lane directory. Use the next sequential `feat-NNN` ID. Follow the format in `CLAUDE.md` exactly — agent-optimized body with entry points, grep patterns, types, constraints, and verification.
-- **Dependencies**: if your feature depends on another, add it to `depends_on` and add your ID to the other feature's `blocks`.
-- **Brainstorm**: run `/ce:brainstorm docs/roadmap/{lane}/feat-NNN-{slug}.md` to start work on a ticket.
+## Compound Engineering
 
-## Compound workflow
+- Follow the Compound Engineering loop: `ce:plan` -> `ce:work` -> `ce:review` -> `ce:compound`.
+- Start with explicit scope in `docs/plans/` or `docs/<scope>/plans/` when planning is needed.
+- Use Compound Engineering to brainstorm against the roadmap ticket before implementation when that workflow is available in your environment.
+- After completion, compound durable learnings back into docs or rules.
 
-Use the loop: `ce:plan` -> `ce:work` -> `ce:review` -> `ce:compound`.
+## Roadmap rules
 
-- Start with explicit scope in plan docs under `docs/plans/` or `docs/<scope>/plans/`.
-- Check `docs/roadmap/` for the relevant feature ticket.
-- Check `docs/solutions/` before implementing.
-- Check `todos/` for unresolved findings.
-- Before pushing or opening/updating a PR, run PR-focused validation for the touched scope. Always include format/CI-sensitive checks that can fail the PR even when package-local lint/typecheck/test pass.
-- After completion, compound learnings back into docs/rules.
-- Update the roadmap ticket status to `complete`.
+- Keep roadmap files in `docs/roadmap/` with YAML frontmatter.
+- Keep dependencies bidirectional: if a feature `depends_on` another feature, add the reverse entry to `blocks`.
+- Keep feature bodies agent-optimized: exact file paths, grep patterns, types, constraints, and verification.
 
 ## Boundaries
 
 - One PR should stay within one scope unless explicitly broadened.
 - No cross-imports between app contexts.
 - Never hand-edit generated GraphQL env/types outputs.
-- If CMS schema changes, regenerate GraphQL types in the same PR.
+- If the CMS schema changes, regenerate GraphQL types in the same PR.
 
 ## Package guidance
 
-Also read package-local guides before edits:
-
 - `apps/web/AGENTS.md` + `apps/web/CLAUDE.md`
-- `apps/mobile/AGENTS.md` + `apps/mobile/CLAUDE.md`
 - `apps/cms/AGENTS.md` + `apps/cms/CLAUDE.md`
+- `apps/manager/AGENTS.md` + `apps/manager/CLAUDE.md`
+- `apps/admin/AGENTS.md` + `apps/admin/CLAUDE.md`
+- `apps/mobile-v2/CLAUDE.md`
 - `apps/roadmap/CLAUDE.md`
 - `packages/graphql/AGENTS.md` + `packages/graphql/CLAUDE.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Cursor does not load this file automatically. Keep `.cursor/rules/project-contex
 - Server Actions for mutations. No API routes unless needed for webhooks.
 - Use `next/image` and `next/font` — no raw `<img>` tags.
 
-### React Native (apps/mobile)
+### React Native (apps/mobile-v2)
 
 - Expo managed workflow. Eject only if absolutely necessary.
 - EAS Build for CI/CD. Test builds with `eas build --profile preview`.
@@ -81,7 +81,7 @@ Cursor does not load this file automatically. Keep `.cursor/rules/project-contex
 - Strapi v5 with GraphQL plugin enabled.
 - Content types defined in the admin UI.
 - API tokens seeded via bootstrap lifecycle using HMAC-SHA512 hashing.
-- GraphQL schema is the contract — apps/web and apps/mobile never call Strapi REST.
+- GraphQL schema is the contract — apps/web and apps/mobile-v2 never call Strapi REST.
 
 ### Deployment
 
@@ -201,7 +201,7 @@ This repo uses the compound engineering workflow. After completing work:
 
 ### Before Starting Work
 
-1. Check `docs/roadmap/` for a relevant feature ticket. If one exists, use `/ce:brainstorm` with it.
+1. Check `docs/roadmap/` for a relevant feature ticket. If one exists, use Compound Engineering to brainstorm against that ticket before implementation.
 2. Run `ce:plan` with explicit scope: "Add X, affecting `apps/web` and `packages/graphql`"
 3. Reference `docs/solutions/` for past patterns relevant to the task.
 4. Check `todos/` for related outstanding findings.
@@ -215,7 +215,7 @@ This is the most common cross-package workflow. Every agent should know it:
 2. Run Strapi locally so the GraphQL schema is available
 3. Run codegen in `packages/graphql/` to regenerate typed operations
 4. Update or add queries/mutations/fragments in `packages/graphql/`
-5. Update consuming code in `apps/web/` and/or `apps/mobile/`
+5. Update consuming code in `apps/web/` and/or `apps/mobile-v2/`
 6. Commit generated files alongside source changes
 
 Never skip step 3. Stale types are the #1 source of runtime GraphQL errors.

--- a/compound-engineering.local.md
+++ b/compound-engineering.local.md
@@ -59,18 +59,18 @@ apps/cms (Strapi v5)
 packages/graphql (gql.tada typed client)
   -> consumed by
 apps/web (Next.js)
-apps/mobile (Expo)
+apps/mobile-v2 (Expo)
 ```
 
 This is a linear dependency chain. Changes flow downstream:
-Strapi schema -> packages/graphql codegen -> web + mobile queries.
+Strapi schema -> packages/graphql codegen -> web + mobile-v2 queries.
 
 ### Cross-Package Review Checklist
 
-- If `apps/cms/` content types change: run codegen in `packages/graphql/`, then check `apps/web/` and `apps/mobile/` for broken queries
-- If `packages/graphql/` changes: check both `apps/web/` and `apps/mobile/` for type compatibility
+- If `apps/cms/` content types change: run codegen in `packages/graphql/`, then check `apps/web/` and `apps/mobile-v2/` for broken queries
+- If `packages/graphql/` changes: check both `apps/web/` and `apps/mobile-v2/` for type compatibility
 - If `packages/graphql/` codegen config changes: verify output types still match Strapi's actual GraphQL schema
-- If `apps/web/` or `apps/mobile/` add new GraphQL operations: verify the fields exist in the Strapi schema and are typed in `packages/graphql/`
+- If `apps/web/` or `apps/mobile-v2/` add new GraphQL operations: verify the fields exist in the Strapi schema and are typed in `packages/graphql/`
 
 ## Solution Categories
 

--- a/docs/roadmap/platform/feat-089-agent-agnostic-repo-instructions.md
+++ b/docs/roadmap/platform/feat-089-agent-agnostic-repo-instructions.md
@@ -1,0 +1,60 @@
+---
+id: "feat-089"
+title: "Agent-Agnostic Repo Instructions"
+owner: "josh"
+priority: "P2"
+status: "complete"
+start_date: "2026-04-13"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "tooling"
+  - "documentation"
+  - "operations"
+---
+
+## Problem
+
+The root instruction files mix stable repo policy with assistant-specific wording and outdated package references. That creates avoidable ambiguity for engineers and agents working outside the original Claude/Cursor context, especially around Compound Engineering workflow hooks and the deprecated `apps/mobile/` package.
+
+## Entry Points — Read These First
+
+1. `AGENTS.md` — quick execution map that should stay short, enforceable, and tool-agnostic.
+2. `CLAUDE.md` — detailed repo conventions that `AGENTS.md` points to for deeper guidance.
+3. `apps/web/AGENTS.md` — example of a concise package-level guide that separates scope from deeper detail.
+4. `apps/mobile-v2/CLAUDE.md` — active mobile target that root docs should reference instead of deprecated `apps/mobile/`.
+
+## Grep These
+
+- `rg -n "/ce:|apps/mobile/|apps/mobile\b|CLAUDE.md is the full source of truth|full source of truth" AGENTS.md CLAUDE.md`
+- `rg -n "mobile-v2|Compound Engineering|ce:plan|ce:review|ce:compound" AGENTS.md CLAUDE.md`
+
+## What To Build
+
+1. Rewrite `AGENTS.md` so it is a repo execution guide rather than a Claude-specific shim.
+   - Keep it brief.
+   - Separate required repo policy from recommended workflow.
+   - Replace slash-command examples like `/ce:brainstorm ...` with tool-agnostic guidance such as "use Compound Engineering to brainstorm the ticket".
+2. Correct stale package references.
+   - Treat `apps/mobile-v2/` as the active mobile app.
+   - Explicitly mark `apps/mobile/` as deprecated in the quick guide where relevant.
+3. Align `CLAUDE.md` with the same neutral wording where the current text implies one assistant UI.
+   - Keep CE command names if they are real workflow concepts.
+   - Remove UI-specific slash command assumptions.
+4. Preserve actual repo policy.
+   - Do not weaken roadmap status rules, validation expectations, generated-file rules, or package boundary guidance.
+
+## Constraints
+
+- Keep the changes scoped to root documentation and roadmap metadata.
+- Do not rename `CLAUDE.md` in this ticket.
+- Do not rewrite package-local guides unless a root reference would otherwise be incorrect.
+- Preserve the short-form purpose of `AGENTS.md`; avoid turning it into a duplicate of `CLAUDE.md`.
+
+## Verification
+
+- `AGENTS.md` reads as agent-agnostic repo guidance and no longer requires Claude-specific slash command syntax.
+- Root docs reference `apps/mobile-v2/` as the active mobile app.
+- `CLAUDE.md` still captures the same repo policy, but with less assistant-specific wording.
+- `git diff -- AGENTS.md CLAUDE.md docs/roadmap/platform/feat-089-agent-agnostic-repo-instructions.md` shows only the intended documentation changes.

--- a/docs/solutions/platform/agent-instructions-should-stay-tool-agnostic-and-current.md
+++ b/docs/solutions/platform/agent-instructions-should-stay-tool-agnostic-and-current.md
@@ -1,0 +1,33 @@
+---
+title: "Agent instructions should stay tool-agnostic and current"
+category: platform
+date: 2026-04-13
+tags:
+  - documentation
+  - agent-workflows
+  - compound-engineering
+  - mobile-v2
+---
+
+# Agent instructions should stay tool-agnostic and current
+
+## Problem
+
+Root execution guides can drift into assistant-specific wording and stale package references. When that happens, the repo rules become harder to apply outside one chat surface, and active package targets like `apps/mobile-v2/` can diverge from the instructions agents actually read first.
+
+## Solution
+
+Keep active instruction files focused on repo policy, not one assistant UI:
+
+1. Put the short execution checklist in `AGENTS.md`.
+2. Keep detailed conventions in `CLAUDE.md` or the package-local guide it points to.
+3. Prefer workflow wording like "use Compound Engineering to brainstorm this ticket" over hard-coding one slash-command surface.
+4. Update active instruction files together when package ownership changes, especially for deprecated paths like `apps/mobile/` and current targets like `apps/mobile-v2/`.
+5. Review adjacent workflow config such as `compound-engineering.local.md` when changing root instructions so the dependency map and review checklist stay aligned.
+
+## Files
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `compound-engineering.local.md`
+- `docs/roadmap/platform/feat-089-agent-agnostic-repo-instructions.md`


### PR DESCRIPTION
## Summary
- rewrite the root `AGENTS.md` as an agent-agnostic execution checklist
- align root `CLAUDE.md` and `compound-engineering.local.md` with `apps/mobile-v2` and neutral Compound Engineering wording
- add roadmap ticket `feat-089` plus a platform solution note to capture the durable documentation pattern

## Review
- reviewed the docs diff in the isolated worktree and fixed the remaining stale mobile references in active CE guidance
- confirmed the new roadmap ticket owner is valid in the roadmap app owner registry

## Validation
- `pnpm exec prettier --check AGENTS.md CLAUDE.md compound-engineering.local.md docs/roadmap/platform/feat-089-agent-agnostic-repo-instructions.md docs/solutions/platform/agent-instructions-should-stay-tool-agnostic-and-current.md`

## Notes
- Compound Engineering is documented in this repo as workflow/UI commands rather than shell executables in this environment, so the durable outputs were captured directly in repo docs and `docs/solutions/`.