### PR TITLE
docs(roadmap): split experience search into pipeline + backfill + integration

### DIFF
--- a/docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md
+++ b/docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md
@@ -109,13 +109,15 @@ This brainstorm supersedes the deferred R4b ("User-driven scoring") from the [Vi
 
 Proposed new roadmap tickets (content-discovery lane, owner: nisal):
 
+_Updated 2026-04-13: IDs renumbered from the original feat-084–088 because those IDs were taken by unrelated Manager/Platform tickets between when this brainstorm was written and when the roadmap work started. feat-086 is also already taken by "Search Extension — Experience Embeddings & Indexing." Next free block is feat-090 onward._
+
 | ID       | Title                                     | Depends On         | Priority |
 | -------- | ----------------------------------------- | ------------------ | -------- |
-| feat-084 | Watch Event Collection & Session Tracking | feat-046           | P1       |
-| feat-085 | FPMC Video Page Recommendations           | feat-084           | P1       |
-| feat-086 | Two-Tower Neural Recommendation Model     | feat-084           | P1       |
-| feat-087 | Cold Start Context-Based Recommendations  | feat-086           | P2       |
-| feat-088 | Recommendation A/B Comparison Logging     | feat-085, feat-086 | P2       |
+| feat-090 | Watch Event Collection & Session Tracking | feat-046           | P1       |
+| feat-091 | FPMC Video Page Recommendations           | feat-090           | P1       |
+| feat-092 | Two-Tower Neural Recommendation Model     | feat-090           | P1       |
+| feat-093 | Cold Start Context-Based Recommendations  | feat-092           | P2       |
+| feat-094 | Recommendation A/B Comparison Logging     | feat-091, feat-092 | P2       |
 
 ## Next Steps
 
@@ -135,50 +137,50 @@ docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md
 
 Create these tickets in docs/roadmap/content-discovery/:
 
-1. feat-084-watch-event-collection.md
+1. feat-090-watch-event-collection.md
    - owner: nisal, priority: P1, status: not-started
    - start_date: 2026-04-21, duration: 10
    - depends_on: [feat-046]
-   - blocks: [feat-085, feat-086]
+   - blocks: [feat-091, feat-092]
    - tags: [cms, web, infrastructure, personalization]
    - Scope: watch_events table in CMS PostgreSQL, session cookie middleware
      in apps/web, event emission from video player (view, progress, complete),
      detractor threshold filtering, geo/device/language context capture.
 
-2. feat-085-fpmc-video-page-recommendations.md
+2. feat-091-fpmc-video-page-recommendations.md
    - owner: nisal, priority: P1, status: not-started
    - start_date: 2026-05-01, duration: 14
-   - depends_on: [feat-084]
-   - blocks: [feat-088]
+   - depends_on: [feat-090]
+   - blocks: [feat-094]
    - tags: [cms, web, ai-pipeline, personalization]
    - Scope: FPMC model training pipeline (Python/PyTorch/RecBole), transition
      factor storage in PostgreSQL, blend logic in recommender.ts (cosine +
      FPMC weighted by observation count), progressive per-video activation.
 
-3. feat-086-two-tower-neural-recommendations.md
+3. feat-092-two-tower-neural-recommendations.md
    - owner: nisal, priority: P1, status: not-started
    - start_date: 2026-05-15, duration: 21
-   - depends_on: [feat-084]
-   - blocks: [feat-087, feat-088]
+   - depends_on: [feat-090]
+   - blocks: [feat-093, feat-094]
    - tags: [cms, web, ai-pipeline, personalization, pgvector]
    - Scope: Two-Tower model (frozen item tower from scene embeddings, learned
      user tower from session sequences + context), PyTorch training pipeline,
      ONNX export, onnxruntime-node serving in Strapi, 256-dim learned item
      embeddings in pgvector, home page and recommendation component integration.
 
-4. feat-087-cold-start-context-recommendations.md
+4. feat-093-cold-start-context-recommendations.md
    - owner: nisal, priority: P2, status: not-started
    - start_date: 2026-06-05, duration: 7
-   - depends_on: [feat-086]
+   - depends_on: [feat-092]
    - tags: [web, personalization]
    - Scope: Context-only user tower inference for sessions with no cookie.
      Geo region, device type, browser language, time of day as input features.
      Broad diverse video spread as output. Graceful fallback to popular/trending.
 
-5. feat-088-recommendation-ab-comparison-logging.md
+5. feat-094-recommendation-ab-comparison-logging.md
    - owner: nisal, priority: P2, status: not-started
    - start_date: 2026-06-12, duration: 7
-   - depends_on: [feat-085, feat-086]
+   - depends_on: [feat-091, feat-092]
    - tags: [cms, web, infrastructure, personalization]
    - Scope: Dual-score response from recommendation API (content-similarity
      score + model-blended score). Impression logging (which recommendations
@@ -186,8 +188,8 @@ Create these tickets in docs/roadmap/content-discovery/:
      manual analysis.
 
 Also update:
-- feat-063: add depends_on feat-084 (watch events are prerequisite for personalization)
-- docs/roadmap/README.md: add new tickets to the content-discovery section
+- feat-063: add depends_on feat-090 (watch events are prerequisite for personalization)
+- docs/roadmap/README.md: regenerate via apps/roadmap/scripts/generate-roadmap-readme.js
 
 Ensure bidirectional dependency linking (depends_on ↔ blocks).
 ```

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,10 +6,10 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (April 13, 2026)
 
-- **Total tickets:** 84
-- **Complete:** 29
+- **Total tickets:** 88
+- **Complete:** 31
 - **In progress:** 3
-- **Not started:** 16
+- **Not started:** 18
 - **Blocked:** 36
 - **Overdue and not complete:** 2
 
@@ -20,11 +20,14 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | ID                                                                             | Feature                                                  | Owner     | Priority | Start      | Days | Due        | Status      |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
 | [feat-009](content-discovery/feat-009-pgvector-embedding-indexing.md)          | pgvector Setup and Embedding Indexing                    | nisal     | P0       | 2026-04-07 | 14   | 2026-04-20 | complete    |
-| [feat-010](content-discovery/feat-010-semantic-search-api.md)                  | Semantic Search API (Hybrid: pgvector + keyword + RRF)   | nisal     | P0       | 2026-04-14 | 21   | 2026-05-04 | not-started |
-| [feat-011](content-discovery/feat-011-search-ui-web.md)                        | Search UI — Web                                          | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | blocked     |
-| [feat-012](content-discovery/feat-012-search-ui-mobile.md)                     | Search UI — Mobile                                       | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | blocked     |
+| [feat-010](content-discovery/feat-010-semantic-search-api.md)                  | Semantic Search API                                      | nisal     | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
+| [feat-011](content-discovery/feat-011-search-ui-web.md)                        | Search UI — Web                                          | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | not-started |
+| [feat-012](content-discovery/feat-012-search-ui-mobile.md)                     | Search UI — Mobile                                       | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | not-started |
+| [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)        | Experience Embedding Pipeline                            | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | not-started |
 | [feat-037](content-discovery/feat-037-video-content-vectorization.md)          | Video Content Vectorization for Recommendations          | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | blocked     |
 | [feat-038](content-discovery/feat-038-video-vectorization-data-audit.md)       | Video Vectorization — Data Audit                         | nisal     | P1       | 2026-04-21 | 3    | 2026-04-23 | complete    |
+| [feat-096](content-discovery/feat-096-experience-embeddings-backfill.md)       | Experience Embeddings Backfill                           | nisal     | P1       | 2026-04-21 | 2    | 2026-04-22 | blocked     |
+| [feat-086](content-discovery/feat-086-experience-search-integration.md)        | Search Extension — Add Experiences to Results            | nisal     | P1       | 2026-04-23 | 5    | 2026-04-27 | blocked     |
 | [feat-039](content-discovery/feat-039-chapter-based-scene-boundaries.md)       | Video Vectorization — Chapter-Based Scene Boundaries     | nisal     | P1       | 2026-04-24 | 7    | 2026-04-30 | complete    |
 | [feat-040](content-discovery/feat-040-multimodal-scene-descriptions.md)        | Video Vectorization — Multimodal Scene Analysis          | nisal     | P1       | 2026-05-01 | 10   | 2026-05-10 | complete    |
 | [feat-041](content-discovery/feat-041-scene-embeddings-table.md)               | Video Vectorization — Scene Embeddings Table + Indexing  | nisal     | P1       | 2026-05-11 | 7    | 2026-05-17 | complete    |
@@ -80,6 +83,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-077](platform/feat-077-roadmap-operations-and-owner-hygiene.md)            | Roadmap Operations and Owner Hygiene               | josh      | P1       | 2026-04-10 | 14   | 2026-04-23 | in-progress |
 | [feat-051](platform/feat-051-public-report-role.md)                              | Public Report Role                                 | vlad      | P1       | 2026-04-13 | 14   | 2026-04-26 | not-started |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                            | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |
+| [feat-089](platform/feat-089-agent-agnostic-repo-instructions.md)                | Agent-Agnostic Repo Instructions                   | josh      | P2       | 2026-04-13 | 1    | 2026-04-13 | complete    |
 | [feat-068](platform/feat-068-partner-publishing-and-user-accounts.md)            | Partner Publishing and User Accounts               | tataihono | P2       | 2026-10-01 | 61   | 2026-11-30 | blocked     |
 | [feat-066](platform/feat-066-llm-steering-system-rag-and-guardrails.md)          | LLM Steering System (RAG + Guardrails)             | tataihono | P2       | 2026-10-15 | 78   | 2026-12-31 | blocked     |
 | [feat-064](platform/feat-064-optimize-through-data-driven-insights.md)           | Optimize Through Data-Driven Insights              | tataihono | P2       | 2026-11-15 | 46   | 2026-12-30 | blocked     |

--- a/docs/roadmap/content-discovery/feat-086-experience-search-integration.md
+++ b/docs/roadmap/content-discovery/feat-086-experience-search-integration.md
@@ -1,146 +1,149 @@
 ---
 id: "feat-086"
-title: "Search Extension — Experience Embeddings & Indexing"
+title: "Search Extension — Add Experiences to Results"
 owner: "nisal"
 priority: "P1"
 status: "not-started"
-start_date: "2026-05-05"
-duration: 10
+start_date: "2026-04-23"
+duration: 5
 depends_on:
   - "feat-010"
+  - "feat-095"
+  - "feat-096"
 blocks: []
 tags:
   - "cms"
   - "search"
   - "pgvector"
-  - "ai-pipeline"
 ---
 
 ## Problem
 
 The Semantic Search API (feat-010) returns only `type: "video"` results. Experiences — like the `easter` landing page with curated content blocks — are invisible to search. A user querying "Easter" gets videos about Easter bunnies but misses the dedicated Easter experience page that is specifically designed to drive engagement around that topic.
 
-The existing search API was designed with this extension in mind: the `type` field on results is always `"video"` in v1, the fusion function already accepts N ranked lists, and experiences are a logical second content type. This ticket adds experience embeddings, an indexing pipeline, and wires them into the search orchestrator.
+The search API was designed with this extension in mind: the `type` field on each result is a discriminator, the fusion function already accepts N ranked lists, and experiences are a logical second content type. With feat-095 (pipeline) and feat-096 (backfill) shipping the `experience_embeddings` table populated with data, this ticket is the thin integration layer: query experiences alongside videos, fuse all four ranked lists, update the `SearchResult` contract.
 
 Unblocks richer discovery — searching for "Christmas" or "Easter" should surface both topical videos AND the experience landing pages that package them.
 
 ## Entry Points — Read These First
 
 1. `apps/cms/src/api/search/services/search.ts` — the orchestrator. Will add experience retrieval as a third and fourth ranked list before fusion.
-2. `apps/cms/src/api/search/services/fusion.ts` — `fuseRankedLists(lists, k)` already generic over N lists. Verify `RankedItem` type works for experiences without changes.
-3. `apps/cms/src/api/search/services/semantic-search.ts` and `keyword-search.ts` — patterns to mirror for experience variants.
-4. `apps/cms/src/api/scene-embedding/services/indexer.ts` — existing scene-embedding indexer. The experience indexer follows the same idempotent upsert pattern.
-5. `apps/cms/src/bootstrap/ensure-pgvector.ts` — where the new `experience_embeddings` table must be added idempotently.
-6. `apps/cms/src/api/experience/content-types/experience/schema.json` — the Experience content type. Note the localized `title`, `metaDescription`, `ogTitle`, `ogDescription`, `pathSegment`, and the `experiences_cmps` dynamic zone with content blocks.
-7. `apps/cms/src/api/experience/content-types/experience/lifecycles.js` — where to hook embedding regeneration on publish/update.
-8. `apps/manager/src/services/embeddings.ts` — `openai/text-embedding-3-small` (1536-dim) model. Experiences must use the same model as scene_embeddings so vectors are comparable in the same space.
-9. `docs/plans/2026-04-13-003-feat-semantic-search-api-plan.md` — the v1 search plan. Read the Scope Boundaries section — this ticket moves experiences out of "future" into "supported".
+2. `apps/cms/src/api/search/services/fusion.ts` — `fuseRankedLists(lists, k)` already generic over N lists. Verify `RankedItem` identity key handles heterogeneous result types.
+3. `apps/cms/src/api/search/services/semantic-search.ts` and `keyword-search.ts` — the existing video retrieval patterns to mirror.
+4. `apps/cms/src/api/search/services/experience-embedder.ts` (from feat-095) — the pipeline that populated `experience_embeddings`.
+5. `apps/cms/src/bootstrap/ensure-pgvector.ts` — verify the `experience_embeddings` table and GIN FTS index on `experiences` were created by feat-095.
+6. `apps/cms/src/graphql/search.ts` — where the `SearchResult` GraphQL type is defined. Needs update for optional fields.
+7. `docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md` — the architectural pattern this extends.
+8. `docs/plans/2026-04-13-003-feat-semantic-search-api-plan.md` — the original v1 search plan. Read the Scope Boundaries section — this ticket moves experiences out of "future" into "supported".
 
 ## Grep These
 
-- `registerSearchExtension` in `apps/cms/src/graphql/` — where the `SearchResult` GraphQL type is defined. Needs update for optional fields.
-- `experiences_cmps` in `apps/cms/src/` — the dynamic content blocks join table. Need to understand structure to extract embeddable text.
-- `lifecycle` in `apps/cms/src/api/experience/` — publish/update hooks.
-- `scene_embeddings` in `apps/cms/src/` — the existing pgvector table pattern.
-- `tsvector` in `apps/cms/src/` — the GIN index pattern to mirror.
+- `registerSearchExtension` in `apps/cms/src/graphql/` — where `SearchResult` GraphQL type is defined.
+- `experience_embeddings` in `apps/cms/src/` — the table created by feat-095.
+- `videos_fulltext_search_idx` in `apps/cms/src/` — the GIN FTS pattern feat-095 mirrored for experiences.
+- `fuseRankedLists` in `apps/cms/src/api/search/` — the RRF function. Confirm it handles 4 lists without contract changes.
+- `RankedItem` in `apps/cms/src/api/search/services/fusion.ts` — the identity type that needs to handle video vs experience without collision.
 
 ## What To Build
 
-### 1. New `experience_embeddings` table (bootstrap)
-
-Add to `ensure-pgvector.ts` alongside `scene_embeddings`:
-
-```sql
-CREATE TABLE IF NOT EXISTS experience_embeddings (
-  id                SERIAL PRIMARY KEY,
-  experience_id     INTEGER NOT NULL REFERENCES experiences(id) ON DELETE CASCADE,
-  locale            TEXT NOT NULL,
-  slug              TEXT NOT NULL,
-  source_text       TEXT NOT NULL,
-  embedding         vector(1536) NOT NULL,
-  model             TEXT NOT NULL DEFAULT 'text-embedding-3-small',
-  created_at        TIMESTAMPTZ DEFAULT NOW(),
-  updated_at        TIMESTAMPTZ DEFAULT NOW(),
-  UNIQUE(experience_id, locale)
-)
-```
-
-Plus HNSW index (`embedding vector_cosine_ops`), btree on `(experience_id, locale)`, and a GIN index on `to_tsvector('simple', title + meta_description)` for keyword search (mirrors the `videos_fulltext_search_idx` pattern).
-
-### 2. Experience embedding indexer
-
-`apps/cms/src/api/experience/services/experience-embedder.ts`:
-
-- `buildExperienceText(experience, locale)` — flattens the experience into an embeddable document: `title`, `metaDescription`, `ogTitle`, `ogDescription`, plus text content from each component in `experiences_cmps` (section headers, paragraph blocks, captions — NOT raw HTML)
-- `indexExperience(strapi, experienceId, locale)` — builds the text, calls `embedQuery()` (lift and rename the existing embed function if needed, or extract to a shared `embedText()`), upserts into `experience_embeddings` by `(experience_id, locale)`
-- `deleteExperienceEmbedding(strapi, experienceId, locale)` — called when unpublished or deleted
-
-### 3. Lifecycle hooks on the Experience content type
-
-Modify `apps/cms/src/api/experience/content-types/experience/lifecycles.js`:
-
-- `afterUpdate`: if `published_at` transitioned to non-null OR experience content changed, enqueue `indexExperience()` for each locale
-- `afterPublish`: enqueue `indexExperience()`
-- `afterUnpublish` / `afterDelete`: call `deleteExperienceEmbedding()`
-
-All calls are fire-and-forget with error logging — experience save must never fail because embedding generation failed.
-
-### 4. Experience search services
+### 1. Experience semantic retrieval
 
 `apps/cms/src/api/search/services/experience-semantic-search.ts`:
 
-- Query `experience_embeddings` with query embedding, filter by `locale`, order by cosine similarity, LIMIT 3x overfetch
-- Join to `experiences` for `title`, `slug`, `meta_description`
-- Return `ExperienceSemanticResult[]` shaped to merge into the fusion `RankedItem` type (`videoId` becomes a shared numeric ID field; use `id` + `type` discriminator instead — see below)
+- Query `experience_embeddings` by cosine similarity on the query embedding
+- Filter by `locale`
+- Join to `experiences` for `title`, `slug`, `meta_description`, `image_url` (or equivalent)
+- Only return rows where `experiences.published_at IS NOT NULL`
+- Return `ExperienceSemanticResult[]` shaped for fusion
+
+```sql
+SELECT
+  ee.experience_id AS id,
+  e.slug,
+  e.title,
+  e.meta_description AS snippet,
+  -- image source depending on experience schema
+  1 - (ee.embedding <=> ?::vector) AS similarity
+FROM experience_embeddings ee
+JOIN experiences e ON e.id = ee.experience_id
+  AND e.published_at IS NOT NULL
+WHERE ee.locale = ?
+ORDER BY ee.embedding <=> ?::vector
+LIMIT ?
+```
+
+### 2. Experience keyword retrieval
 
 `apps/cms/src/api/search/services/experience-keyword-search.ts`:
 
-- tsvector on `experiences.title + meta_description` with `ts_rank`
-- Locale filter via `experiences.locale = $locale` (experiences are localized entities, no link table chain needed — see schema)
+- `ts_rank` over the `videos_fulltext_search_idx`-style GIN index on `experiences.title + meta_description` (created by feat-095)
+- Locale filter via `experiences.locale = $locale`
 - Published filter
 
-### 5. Extend the `RankedItem` contract
+Mirrors `keyword-search.ts` for videos but against `experiences` directly (experiences are localized entities — no link-table chain).
 
-Currently `RankedItem` assumes `videoId: number` as the identity. Change fusion to use a compound key:
+### 3. Extend the `RankedItem` identity key
 
-```typescript
+`fuseRankedLists` currently keys the Map by `videoId`. For mixed video + experience results, video id=4 and experience id=4 would collide. Use a compound key:
+
+```ts
 type RankedItem = {
   resultType: "video" | "experience"
   resultId: number
-  // ... rest of properties
+  // ...rest
 }
+
+// In fusion:
+const key = `${item.resultType}:${item.resultId}`
 ```
 
-The fusion Map key becomes `${resultType}:${resultId}`. This lets videos and experiences coexist in the same ranked list without ID collision.
+Or keep `videoId` but add `experienceId` as a separate field — whichever keeps the video code path untouched for backward compatibility with feat-011/012 consumers mid-flight.
 
-Alternatively, add a second retrieval call pair (experience-semantic + experience-keyword) that runs alongside the existing two, and fuses all four lists together. The fusion is already N-list capable; only the dedup key needs to be compound.
-
-### 6. Update the orchestrator
+### 4. Update the orchestrator
 
 In `apps/cms/src/api/search/services/search.ts`:
 
-```typescript
+```ts
 const [semanticVideos, keywordVideos, semanticExperiences, keywordExperiences] =
-  await Promise.all([
-    searchBySemantic(...),
-    searchByKeyword(...),
-    searchByExperienceSemantic(...),
-    searchByExperienceKeyword(...),
+  await Promise.allSettled([
+    searchBySemantic(knex, { queryEmbedding, locale, limit: overfetchLimit }),
+    searchByKeyword(knex, { query, locale, limit: overfetchLimit }),
+    searchByExperienceSemantic(knex, {
+      queryEmbedding,
+      locale,
+      limit: overfetchLimit,
+    }),
+    searchByExperienceKeyword(knex, { query, locale, limit: overfetchLimit }),
   ])
 
 const fused = fuseRankedLists(
-  [semanticVideos, keywordVideos, semanticExperiences, keywordExperiences],
+  [
+    unwrapOutcome(strapi, semanticVideos, "semantic-video"),
+    unwrapOutcome(strapi, keywordVideos, "keyword-video"),
+    unwrapOutcome(strapi, semanticExperiences, "semantic-experience"),
+    unwrapOutcome(strapi, keywordExperiences, "keyword-experience"),
+  ],
   RRF_K,
 )
 ```
 
-Dedup logic: the 3-layer video dedup doesn't apply to experiences. Skip dedup checks when `resultType !== "video"` (or add type-aware checks — experiences have no core_id or embedding near-duplicate problem).
+Four lists via `Promise.allSettled` maintains the graceful-degradation guarantee from v1: if any one retrieval fails, others survive.
 
-### 7. Update the `SearchResult` type + GraphQL schema
+### 5. Dedup behavior
 
-The plan's API contract already has `type: "video"` — extend to `type: "video" | "experience"`. Fields that only apply to videos become nullable:
+The 3-layer video dedup (core_id prefix, title match, embedding similarity) doesn't apply to experiences:
 
-```typescript
+- Experiences have no `core_id`
+- Title collisions across types are usually meaningful ("Easter" the experience vs "Easter" a video are both legitimately relevant)
+- Cross-type embedding similarity is not a dedup concern — these are different content types
+
+Update `deduplicateResults()` to skip the video-specific dedup checks when `resultType !== "video"`. Experiences pass through unchanged.
+
+### 6. Update `SearchResult` TS type + GraphQL schema
+
+Extend the discriminator:
+
+```ts
 type SearchResult = {
   type: "video" | "experience"
   id: number
@@ -148,39 +151,34 @@ type SearchResult = {
   title: string
   imageUrl: string | null
   snippet: string
-  startSeconds: number | null // null for experiences
-  playbackId: string | null // null for experiences
+  startSeconds: number | null // null for experiences (already nullable since feat-010 P1 fix)
+  playbackId: string | null // null for experiences (same)
   score: number
 }
 ```
 
-Update `apps/cms/src/graphql/search.ts` GraphQL type definitions to match: `startSeconds: Float`, `playbackId: String` (both nullable now).
+`startSeconds` and `playbackId` are already nullable since feat-010's post-review hardening. No breaking change — just documenting that experiences also produce null for these fields.
 
-**Urim-facing API change:** `startSeconds` and `playbackId` may now be null. The mobile/web UIs must handle this when rendering experience results (show experience card without timestamp/play button).
+Update `apps/cms/src/graphql/search.ts` GraphQL typeDefs comment text to reflect that null also means "this is an experience, not a video", not only "keyword-only video match".
 
-### 8. Backfill script
+### 7. Tests
 
-`apps/cms/src/scripts/backfill-experience-embeddings.ts`:
-
-- Iterate all published experiences across all locales
-- Call `indexExperience()` for each
-- Idempotent — safe to rerun
-- One-time run after deployment + whenever embedding model changes
-
-### 9. Tests
-
-- `experience-embedder.test.ts` — verifies text flattening correctly pulls title, meta_description, and content block text
-- `experience-semantic-search.test.ts` and `experience-keyword-search.test.ts` — mirror the patterns from the video services
-- `search.test.ts` — update to cover 4-list fusion with both video and experience results
-- `fusion.test.ts` — verify compound `resultType:resultId` keys prevent collisions between a video with id=4 and an experience with id=4
+- `experience-semantic-search.test.ts` and `experience-keyword-search.test.ts` — mirror the existing `semantic-search.test.ts` / `keyword-search.test.ts` patterns.
+- `search.test.ts` — update to cover 4-list fusion. Add cases:
+  - Only experience results (no video match)
+  - Only video results (no experience match)
+  - Mixed results — experience ranked above video
+  - Collision case: video id=4 and experience id=4 both appear, both survive (compound key works)
+- `fusion.test.ts` — verify compound key handling.
+- End-to-end smoke: publish an experience, embed via feat-095 lifecycle, `curl /api/search?q=<experience-title>` returns it.
 
 ## API Contract Extension
 
 ```typescript
-// Unchanged
+// Request unchanged:
 GET /api/search?q=Easter&locale=en
 
-// New response shape
+// Response now includes experiences:
 {
   "results": [
     {
@@ -213,31 +211,30 @@ GET /api/search?q=Easter&locale=en
 
 ## Constraints
 
-- **Same embedding model as scene_embeddings** (`openai/text-embedding-3-small`, 1536-dim). Vectors must be comparable in the same space if we ever add cross-type semantic similarity later.
-- **No new external service** — reuse OpenRouter client from `apps/cms/src/lib/openrouter.ts`.
-- **Lifecycle hooks must not block writes.** Experience save/publish must never fail because embedding generation failed. Log and continue.
-- **Backwards compatible API.** Existing v1 consumers (Urim's search UIs in feat-011/feat-012) must not break. The `type` field was already present. `startSeconds` and `playbackId` become nullable — coordinate with Urim if feat-011/012 have already shipped.
-- **Locale handling differs from videos.** Videos are non-localized entities joined to `video_variants.language`. Experiences are themselves localized (one row per locale with `locale` column). The join chain is simpler for experiences.
-- **Response time budget unchanged**: <500ms. Adding two more parallel retrievals should not blow the budget since they all run in `Promise.all`.
-- **No personalization** in this ticket. That's feat-084+.
+- **Pipeline + backfill must ship first.** This ticket assumes `experience_embeddings` is populated. Without data, the joins return zero rows and experiences are still invisible.
+- **Backwards compatible API.** Existing v1 consumers (Urim's feat-011/feat-012) must not break. The `type` field was already present since v1; `startSeconds` / `playbackId` already nullable. The only change on the wire is that `type: "experience"` starts appearing in result sets.
+- **Response time budget unchanged**: <500ms. Adding two more parallel retrievals should not blow the budget since they all run in `Promise.allSettled` with the same over-fetch factor.
+- **Locale handling differs from videos.** Experiences are localized entities (one row per locale with a `locale` column). Videos go through `video_variants → languages`. Simpler join for experiences.
+- **Rate limit contract unchanged.** Same 30/min/IP shared bucket.
+- **No personalization.** That's feat-091+ (FPMC, Two-Tower).
 
 ## Verification
 
-- Apply migrations → `\dt experience_embeddings` shows the table, `\di` shows HNSW + GIN indexes
-- `pnpm --filter @forge/cms dev` boots without errors
-- Publishing an experience in Strapi admin fires the lifecycle hook and inserts a row in `experience_embeddings`
-- `curl "localhost:1337/api/search?q=Easter&locale=en"` returns BOTH videos AND the `easter` experience, with `type` correctly set on each
-- Experience result has `startSeconds: null` and `playbackId: null`
-- Semantic search for "find God's purpose in suffering" returns thematically relevant experiences, not just videos
-- Spanish query with `locale=es` returns only experiences with a Spanish localization
-- GraphQL `{ semanticSearch(...) { results { type id title } } }` works for both types
-- Backfill script populates `experience_embeddings` for all published experiences
-- No regression: video-only queries (e.g., "forgiveness" which has no matching experience) return the same videos as before with the same scores
-- Unit test: fusion correctly handles a video with id=4 and an experience with id=4 without collapsing them
+- `curl "localhost:1337/api/search?q=Easter&locale=en"` returns BOTH videos AND the `easter` experience, with `type` correctly set on each.
+- Experience result has `startSeconds: null` and `playbackId: null`.
+- Semantic query like "find meaning in suffering" returns thematically relevant experiences alongside videos.
+- Spanish query with `locale=es` returns only experiences with a Spanish locale row in `experience_embeddings`.
+- GraphQL: `{ semanticSearch(query: "Easter", locale: "en") { results { type id title } } }` returns mixed types.
+- Query where experience and video share an integer ID (e.g., video 4 and experience 4) returns both as distinct results.
+- Regression: video-only queries (e.g., "forgiveness" with no matching experience) return identical results to pre-feat-086 with identical scores.
+- Response time stays <500ms p95 under realistic load.
+- Rate limit still fires at 30 req/min/IP with `Retry-After` header.
 
 ## Out of Scope
 
-- Personalization signals (feat-084+)
-- Scene-level experience results (e.g., matching a specific section within an experience) — whole-experience granularity only in v1
-- Cross-type semantic similarity (suggesting videos based on an experience's embedding) — recommendation API, not search
-- Experience admin UI showing "search-ready" badge
+- **Experience embedding pipeline** (feat-095).
+- **Experience backfill** (feat-096).
+- **Personalization signals** (feat-091+).
+- **Scene-level experience results** (matching a specific content block within an experience) — whole-experience granularity only in v1.
+- **Cross-type semantic similarity** (recommending videos based on an experience's embedding) — recommendation API, not search.
+- **Experience admin UI** showing "search-ready" or embedding status badge.

--- a/docs/roadmap/content-discovery/feat-095-experience-embedding-pipeline.md
+++ b/docs/roadmap/content-discovery/feat-095-experience-embedding-pipeline.md
@@ -1,0 +1,184 @@
+---
+id: "feat-095"
+title: "Experience Embedding Pipeline"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-16"
+duration: 5
+depends_on:
+  - "feat-010"
+blocks:
+  - "feat-086"
+  - "feat-096"
+tags:
+  - "cms"
+  - "pgvector"
+  - "ai-pipeline"
+  - "experiences"
+---
+
+## Problem
+
+Experiences (the `easter` landing page, `christmas`, topic hubs) are currently invisible to semantic search because we have no embeddings for them. Before feat-086 can wire experiences into search results, we need the underlying pipeline: a `experience_embeddings` table, a text-flattening indexer that embeds the right parts of an experience, and lifecycle hooks so newly created/updated experiences automatically get embedded.
+
+This mirrors the scene-embedding pipeline (feat-041) — storage + indexer + lifecycle — but for a different content type.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/bootstrap/ensure-pgvector.ts` — where `scene_embeddings` + HNSW + GIN indexes are declared idempotently. Add `experience_embeddings` here.
+2. `apps/cms/src/api/scene-embedding/services/indexer.ts` — existing scene-embedding indexer. The experience indexer follows the same idempotent upsert pattern but with different source text.
+3. `apps/cms/src/api/experience/content-types/experience/schema.json` — the Experience content type. Note the localized `title`, `metaDescription`, `ogTitle`, `ogDescription`, `pathSegment`, and the `experiences_cmps` dynamic zone with content blocks.
+4. `apps/cms/src/api/experience/content-types/experience/lifecycles.js` — where to hook embedding regeneration on publish/update.
+5. `apps/cms/src/lib/openrouter.ts` — `embedQuery()` client for `openai/text-embedding-3-small` (1536-dim). Lift or rename to a shared `embedText()` if it helps clarity.
+6. `docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md` — the architectural pattern this pipeline feeds into.
+7. `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md` — existing pattern for pgvector columns in Strapi v5.
+
+## Grep These
+
+- `scene_embeddings` in `apps/cms/src/` — pattern for pgvector-backed tables.
+- `experiences_cmps` in `apps/cms/src/` — dynamic content blocks join table. Understand structure to extract embeddable text.
+- `lifecycle` in `apps/cms/src/api/experience/` — publish/update hooks on the Experience content type.
+- `ensurePgvector` in `apps/cms/src/bootstrap/` — idempotent table creation pattern.
+
+## What To Build
+
+### 1. `experience_embeddings` table (bootstrap)
+
+Add to `apps/cms/src/bootstrap/ensure-pgvector.ts` alongside `scene_embeddings`:
+
+```sql
+CREATE TABLE IF NOT EXISTS experience_embeddings (
+  id                SERIAL PRIMARY KEY,
+  experience_id     INTEGER NOT NULL REFERENCES experiences(id) ON DELETE CASCADE,
+  locale            TEXT NOT NULL,
+  slug              TEXT NOT NULL,
+  source_text       TEXT NOT NULL,
+  embedding         vector(1536) NOT NULL,
+  model             TEXT NOT NULL DEFAULT 'text-embedding-3-small',
+  created_at        TIMESTAMPTZ DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(experience_id, locale)
+)
+```
+
+Plus:
+
+- HNSW index on `(embedding vector_cosine_ops)` for fast ANN queries
+- B-tree index on `(experience_id, locale)` for lookup
+- GIN index on `to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(meta_description, ''))` over the `experiences` table — **mirrors** the `videos_fulltext_search_idx` pattern from feat-010 so keyword search reuses the same approach
+
+All statements idempotent (`IF NOT EXISTS`).
+
+### 2. Embeddable-text flattener
+
+`apps/cms/src/api/experience/services/experience-embedder.ts`:
+
+```ts
+export function buildExperienceText(experience, locale: string): string {
+  // Concatenate in priority order so OpenRouter weighting gives us
+  // what matters most. Strip HTML, skip asset URLs and raw markup.
+  const parts = [
+    experience.title,
+    experience.metaDescription,
+    experience.ogTitle !== experience.title ? experience.ogTitle : null,
+    experience.ogDescription !== experience.metaDescription
+      ? experience.ogDescription
+      : null,
+    ...flattenContentBlocks(experience.experiences_cmps ?? []),
+  ]
+  return parts.filter(Boolean).join("\n\n")
+}
+```
+
+`flattenContentBlocks` pulls section headers, paragraph text, captions — **NOT** HTML markup, not asset URLs, not button link targets. One line per block.
+
+### 3. Indexer service
+
+```ts
+export async function indexExperience(
+  strapi: Core.Strapi,
+  experienceId: number,
+  locale: string,
+): Promise<void> {
+  const experience = await readExperience(strapi, experienceId, locale)
+  if (!experience || experience.published_at == null) {
+    // Unpublished → remove any existing embedding
+    await deleteExperienceEmbedding(strapi, experienceId, locale)
+    return
+  }
+
+  const sourceText = buildExperienceText(experience, locale)
+  const embedding = await embedText(sourceText)
+  const embeddingVector = toPgvectorText(embedding)
+
+  await knex.raw(
+    `INSERT INTO experience_embeddings
+       (experience_id, locale, slug, source_text, embedding)
+     VALUES (?, ?, ?, ?, ?::vector)
+     ON CONFLICT (experience_id, locale) DO UPDATE
+       SET slug = EXCLUDED.slug,
+           source_text = EXCLUDED.source_text,
+           embedding = EXCLUDED.embedding,
+           updated_at = NOW()`,
+    [experienceId, locale, experience.slug, sourceText, embeddingVector],
+  )
+}
+
+export async function deleteExperienceEmbedding(
+  strapi: Core.Strapi,
+  experienceId: number,
+  locale: string,
+): Promise<void>
+```
+
+### 4. Lifecycle hooks
+
+Modify `apps/cms/src/api/experience/content-types/experience/lifecycles.js` (or `.ts` if the file is converted):
+
+- `afterUpdate`: if `published_at` transitioned non-null OR content-bearing fields changed, enqueue `indexExperience()` for the experience's locale. Fire-and-forget with `strapi.log.error()` on failure.
+- `afterCreate` (with publication): same as afterUpdate.
+- `beforeDelete` / `afterUnpublish`: call `deleteExperienceEmbedding()`.
+
+**Critical:** lifecycle hooks must not block the save. If `embedText()` throws (OpenRouter down), log the error and continue. The save succeeds; backfill (feat-096) will pick up anything that failed.
+
+### 5. Shared `embedText` helper (if not already extracted)
+
+`apps/cms/src/lib/openrouter.ts` currently exports `embedQuery(text)`. Rename or alias to `embedText(text)` since it's now used for indexing too, not just search queries. Keep `embedQuery` as a re-export for backward compatibility.
+
+### 6. Tests
+
+- `experience-embedder.test.ts`:
+  - `buildExperienceText()` correctly flattens title + meta + content blocks
+  - Skips unpublished-only fields, HTML markup, and empty optional fields
+  - Handles locale-specific fields correctly
+- `indexer.test.ts`:
+  - Upsert behavior: inserts new, updates existing on same `(experience_id, locale)`
+  - Delete on unpublish
+  - Lifecycle hook fires on update but doesn't block on embedding failure
+
+## Constraints
+
+- **Same model as scene_embeddings** (`openai/text-embedding-3-small`, 1536-dim). Vectors must be comparable in the same embedding space if we ever add cross-type semantic similarity later.
+- **No new external dependencies** — reuse `apps/cms/src/lib/openrouter.ts`.
+- **Lifecycle hooks must never block writes.** Experience save/publish must always succeed even if embedding fails. Log and continue.
+- **Strapi v5 raw SQL conventions:** column names are snake_cased (`published_at`, not `publishedAt`). The bootstrap file uses raw SQL; reuse `knex.raw()` via `strapi.db.connection`.
+- **Locale differs from videos.** Videos are joined to `video_variants.language` through link tables. Experiences are themselves localized — one row per locale with a `locale` column directly on the entity. Simpler join chain.
+- **Does NOT add experiences to search results.** That's feat-086. This ticket only builds the pipeline; the resulting embeddings just sit in the table until feat-086 queries them.
+
+## Verification
+
+- `pnpm --filter @forge/cms dev` boots cleanly; logs show `[pgvector] experience_embeddings table ready`.
+- `psql $DATABASE_URL -c "\d experience_embeddings"` shows the table + all indexes.
+- Publish an experience in the Strapi admin → `SELECT count(*) FROM experience_embeddings` increments.
+- Update an experience's title → `SELECT source_text FROM experience_embeddings WHERE experience_id = X` reflects the change after `updated_at` advances.
+- Unpublish an experience → its row is deleted.
+- Kill OpenRouter (unset API key) → saving an experience still succeeds, `strapi.log.error` logs the embedding failure, row is not created.
+- Unit tests pass; typecheck + lint clean.
+
+## Out of Scope
+
+- **Backfill** of existing experiences (that's feat-096).
+- **Search integration** — wiring experiences into `/api/search` results (that's feat-086, now rescoped).
+- **Dynamic re-embedding** when the embedding model version changes — one-shot backfill in feat-096 handles model upgrades.
+- **Cross-type similarity** (experience → videos recommendation) — separate future work.

--- a/docs/roadmap/content-discovery/feat-096-experience-embeddings-backfill.md
+++ b/docs/roadmap/content-discovery/feat-096-experience-embeddings-backfill.md
@@ -1,0 +1,166 @@
+---
+id: "feat-096"
+title: "Experience Embeddings Backfill"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-21"
+duration: 2
+depends_on:
+  - "feat-095"
+blocks:
+  - "feat-086"
+tags:
+  - "cms"
+  - "pgvector"
+  - "backfill"
+  - "experiences"
+---
+
+## Problem
+
+Once the experience embedding pipeline (feat-095) ships, only newly-published or updated experiences get embeddings. Every existing published experience in the CMS is still invisible to semantic search until we backfill. Without this backfill, feat-086 (search integration) would launch with zero experiences indexed — the feature would appear broken.
+
+This ticket is the one-shot bulk-embedding operation for existing content, analogous to feat-042 (Scene Embeddings Backfill Worker) but for experiences. Experiences are a much smaller catalog than videos (tens of experiences vs thousands of scenes), so a simple synchronous script is sufficient — no queue, no worker service.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/api/experience/services/experience-embedder.ts` — the `indexExperience()` function from feat-095. The backfill just calls this in a loop.
+2. `apps/cms/src/scripts/` — existing one-shot script patterns (e.g., `data-import-utils.ts`). The backfill script lives here.
+3. `apps/cms/src/api/scene-embedding/services/indexer.ts` — the scene-embedding analog. Study the error-handling and progress-logging pattern.
+4. `docs/roadmap/content-discovery/feat-042-backfill-worker.md` — the scene backfill ticket. Many of the same principles apply (idempotency, resumability) but at much smaller scale.
+5. `apps/cms/src/api/experience/content-types/experience/schema.json` — to understand what "all published experiences across all locales" means.
+
+## Grep These
+
+- `data-import-utils` in `apps/cms/src/scripts/` — existing one-shot script patterns.
+- `strapi.db.connection.raw` in `apps/cms/src/` — raw SQL patterns.
+- `published_at IS NOT NULL` in `apps/cms/src/` — Strapi v5 published-content filter.
+
+## What To Build
+
+### 1. Backfill script
+
+`apps/cms/src/scripts/backfill-experience-embeddings.ts`:
+
+```ts
+import { indexExperience } from "../api/experience/services/experience-embedder"
+
+async function main() {
+  const strapi = await bootStrapi()
+  const knex = strapi.db.connection
+
+  const rows = await knex.raw(`
+    SELECT id, locale, slug
+    FROM experiences
+    WHERE published_at IS NOT NULL
+    ORDER BY id, locale
+  `)
+  const experiences = rows.rows
+
+  strapi.log.info(
+    `[backfill-experience] starting: ${experiences.length} experiences to embed`,
+  )
+
+  let success = 0
+  let failure = 0
+  for (const { id, locale, slug } of experiences) {
+    try {
+      await indexExperience(strapi, id, locale)
+      success += 1
+      if (success % 10 === 0) {
+        strapi.log.info(
+          `[backfill-experience] progress: ${success}/${experiences.length}`,
+        )
+      }
+    } catch (err) {
+      failure += 1
+      strapi.log.error(
+        `[backfill-experience] failed id=${id} locale=${locale} slug=${slug}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      )
+    }
+  }
+
+  strapi.log.info(
+    `[backfill-experience] done: ${success} succeeded, ${failure} failed`,
+  )
+  process.exit(failure > 0 ? 1 : 0)
+}
+```
+
+### 2. Package.json script
+
+Add to `apps/cms/package.json`:
+
+```json
+{
+  "scripts": {
+    "backfill:experience-embeddings": "tsx src/scripts/backfill-experience-embeddings.ts"
+  }
+}
+```
+
+### 3. Idempotency + resumability
+
+- **Idempotent:** safe to re-run. Each call to `indexExperience()` is an UPSERT (feat-095 guarantees this), so repeats just update `updated_at` with the same content.
+- **Resumable:** if the script crashes halfway, rerun it. Already-embedded experiences get their rows updated with the same content (no harm); missing ones get created.
+- **No progress checkpoint file.** The catalog is small enough that a restart re-runs everything in under a minute. No need for the complexity of `feat-042`-style checkpointing.
+
+### 4. Cost + runtime guardrails
+
+Before running, log an estimate:
+
+```ts
+const estimatedTokens = experiences.length * 1500 // rough average per experience
+const estimatedCost = (estimatedTokens * 0.00002) / 1000 // text-embedding-3-small rate
+strapi.log.info(
+  `[backfill-experience] estimated ${estimatedTokens} tokens, ~$${estimatedCost.toFixed(4)}`,
+)
+```
+
+Abort early if:
+
+- `experiences.length > 10_000` (sanity check — unexpected catalog size)
+- `estimatedCost > 5.00` (runaway guardrail)
+
+Override with `--force` flag if the operator genuinely wants to proceed.
+
+### 5. Dry-run mode
+
+`--dry-run` flag: logs every experience it would embed (id + locale + slug + text length) but skips the actual OpenRouter call and DB write. Operator can review which experiences will be processed before spending money.
+
+### 6. Tests
+
+- `backfill-experience-embeddings.test.ts`:
+  - Builds the expected query against a test DB
+  - Handles `indexExperience()` failures gracefully (continues, counts failures)
+  - Returns exit code 0 on all success, 1 on any failure
+  - `--dry-run` doesn't call `indexExperience()`
+
+## Constraints
+
+- **No queue, no worker service.** Experiences are a small catalog (<100 items expected for Phase 1). A simple `for await` loop in a script is sufficient. Resist the urge to over-engineer.
+- **Reuse `indexExperience()`.** This script is a thin driver; all the embedding logic lives in feat-095. If the pipeline changes, the backfill picks up the change automatically.
+- **OpenRouter rate limit** is not a concern at this scale (maybe 100 experiences × 3 locales = 300 calls). If it ever becomes one, add a `pLimit(5)` concurrency cap.
+- **Does NOT run automatically.** This is an operator-triggered script, not a cron job or deploy hook. Ongoing embedding maintenance is handled by the feat-095 lifecycle hooks.
+
+## Verification
+
+- `pnpm --filter @forge/cms backfill:experience-embeddings --dry-run` logs every experience that would be embedded, no DB writes, no OpenRouter calls. Exit 0.
+- `pnpm --filter @forge/cms backfill:experience-embeddings` runs end-to-end:
+  - Log estimated cost before starting
+  - Progress every 10 experiences
+  - Final summary: N succeeded, 0 failed
+  - `SELECT count(*) FROM experience_embeddings` equals the number of published experiences × locales
+- Re-run the same script → log shows every experience processed again (successfully), `updated_at` advances, `created_at` unchanged. Idempotent.
+- Simulate a failure (break one experience's content temporarily) → script continues past it, final summary shows 1 failure with logged details, exit code 1.
+- After backfill completes: `curl "localhost:1337/api/search?q=Easter&locale=en"` (once feat-086 lands) returns the `easter` experience in results.
+
+## Out of Scope
+
+- **Incremental re-embedding** on model version changes. This is a one-shot script, but if the embedding model changes, we simply re-run it. No partial-update logic needed because upserts are cheap.
+- **Scheduling.** This script is run manually after deploys, or when the operator chooses. No cron needed given the catalog size.
+- **Progress UI or dashboard.** Logs in Railway are sufficient.
+- **Model comparison or A/B.** Single model (`text-embedding-3-small`) matching scene_embeddings.


### PR DESCRIPTION
## Summary

Splits the 10-day `feat-086` experience-search ticket into three focused tickets matching the pattern used by the video vectorization work (feat-041 storage, feat-042 backfill, feat-044 query).

### New tickets

- **feat-095 — Experience Embedding Pipeline** (5d, starts 2026-04-16)
  Table + HNSW/GIN indexes + lifecycle hooks + text flattener + indexer service. Mirrors the scene-embedding pipeline but for experiences (simpler join chain since experiences are localized entities).

- **feat-096 — Experience Embeddings Backfill** (2d, starts 2026-04-21, depends_on feat-095)
  One-shot script to embed all existing published experiences across locales. Small catalog so no queue/worker — just a for-loop with `--dry-run`, cost guardrails, idempotent upsert via feat-095.

### Rescoped

- **feat-086 — "Search Extension — Add Experiences to Results"** (5d, starts 2026-04-23, depends_on feat-010 + feat-095 + feat-096)
  Now just the search integration: orchestrator updates, 4-list RRF fusion, compound identity key for video vs experience collision, `SearchResult` contract extension. Was 10 days, now 5.

### Also in this PR

- Renumbered the proposed personalization tickets in `docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md` from `feat-084`–`088` to `feat-090`–`094` because the original IDs collided with existing Manager/Platform tickets and our own `feat-086`.
- Regenerated `docs/roadmap/README.md` to reflect feat-010 as complete (PR #747 merged) and feat-011/012 unblocked.

## Test plan

- [x] Bidirectional dependency links (each `depends_on` has a matching `blocks` in the upstream ticket)
- [x] `node apps/roadmap/scripts/generate-roadmap-readme.js` produces a clean README with correct auto-computed statuses
- [x] No collision between new IDs (feat-095, feat-096) and existing tickets
- [ ] Team review of scope: does feat-095's 5-day estimate feel right? Does feat-096 need a queue or is the simple script enough?

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)