### PR TITLE
chore(devcontainer): add Redis sidecar service

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   # PostgreSQL client (server runs in sidecar container)
   postgresql-client \
+  # Redis CLI client (server runs in sidecar container)
+  redis-tools \
   # Utilities
   jq \
   nano \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,8 @@
     "NPM_CONFIG_MINIMUM_RELEASE_AGE": "1440",
     "PYTHONDONTWRITEBYTECODE": "1",
     "PIP_DISABLE_PIP_VERSION_CHECK": "1",
-    "DATABASE_URL": "postgresql://forge:forge@db:5432/forge"
+    "DATABASE_URL": "postgresql://forge:forge@db:5432/forge",
+    "REDIS_URL": "redis://redis:6379"
   },
   "initializeCommand": "test -f \"$HOME/.gitconfig\" || touch \"$HOME/.gitconfig\"",
   "workspaceFolder": "/workspace",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     # Keep the container alive for VS Code to attach
     command: sleep infinity
 
@@ -41,8 +43,22 @@ services:
       timeout: 3s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
 volumes:
   pgdata:
+  redisdata:
   claude-code-bashhistory:
   claude-code-config:
   claude-code-gh:


### PR DESCRIPTION
## Summary
- Adds Redis 7 Alpine as a sidecar service in docker-compose with healthcheck and persistent volume
- Installs `redis-tools` CLI client in the Dockerfile
- Adds `REDIS_URL=redis://redis:6379` environment variable

## Test plan
- [ ] Rebuild devcontainer and verify Redis starts healthy
- [ ] Run `redis-cli ping` from inside the container — should return `PONG`
- [ ] Verify `REDIS_URL` env var is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)