### PR TITLE
fix: correct Doppler project name in mobile fetch-secrets

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,7 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "fetch-secrets": "rm -f .env && doppler secrets download --project forge-mobile-v2 --config dev --format env --no-file > .env.local.tmp && mv .env.local.tmp .env.local",
+    "fetch-secrets": "rm -f .env && doppler secrets download --project forge-mobile --config dev --format env --no-file > .env.local.tmp && mv .env.local.tmp .env.local",
     "lint": "eslint .",
     "test": "jest --passWithNoTests",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

- Fix `fetch-secrets` script in `apps/mobile/package.json`: change `--project forge-mobile-v2` to `--project forge-mobile`
- The Doppler project was always `forge-mobile` — the mobile-v2 app had the wrong project name, causing `pnpm fetch-secrets` to fail

## Context

Follow-up to #762 (rename mobile-v2 to mobile). The `forge-mobile-v2` Doppler project doesn't exist — this was the root cause of the `fetch-secrets` failure reported when both `apps/mobile` and `apps/mobile-v2` existed.

## Test plan

- [x] `pnpm fetch-secrets` completes successfully (all 4 tasks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)