### PR TITLE
feat(web): add semantic search UI with overlay and site header (feat-011)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -170,3 +170,66 @@
     background-position: 0% 50%;
   }
 }
+
+/* Search overlay animations */
+@keyframes overlay-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes overlay-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes card-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.97);
+  }
+}
+
+/* Search overlay scrollbar */
+.search-overlay-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+.search-overlay-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.search-overlay-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+}
+.search-overlay-scroll:hover::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+}
+.search-overlay-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+.search-overlay-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+.search-overlay-scroll:hover {
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 import localFont from "next/font/local"
 import "./globals.css"
 import { cn } from "@/lib/utils"
+import { SiteHeader } from "@/components/SiteHeader"
 
 const apercuPro = localFont({
   src: [
@@ -26,7 +27,10 @@ const apercuPro = localFont({
 export default function RootLayout(props: { children: ReactNode }) {
   return (
     <html lang="en" className={cn("font-sans", apercuPro.variable)}>
-      <body className="bg-stone-900">{props.children}</body>
+      <body className="bg-stone-900">
+        <SiteHeader />
+        <div className="pt-16">{props.children}</div>
+      </body>
     </html>
   )
 }

--- a/apps/web/src/app/search/error.tsx
+++ b/apps/web/src/app/search/error.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+export default function SearchError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center px-4 text-center">
+      <h2 className="text-lg font-semibold text-stone-100">
+        Something went wrong
+      </h2>
+      <p className="mt-2 text-sm text-stone-400">
+        {error.message || "An unexpected error occurred while searching."}
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 rounded-lg bg-stone-800 px-6 py-3 text-sm font-medium text-stone-200 transition hover:bg-stone-700"
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/app/search/loading.tsx
+++ b/apps/web/src/app/search/loading.tsx
@@ -1,0 +1,32 @@
+import { CONTENT_WIDTH_CLASSES } from "@/lib/content-width"
+
+function CardSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-stone-800">
+      <div className="aspect-video w-full animate-pulse bg-stone-700" />
+      <div className="flex flex-col gap-2 p-3">
+        <div className="h-4 w-3/4 animate-pulse rounded bg-stone-700" />
+        <div className="h-3 w-full animate-pulse rounded bg-stone-700" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-stone-700" />
+      </div>
+    </div>
+  )
+}
+
+export default function SearchLoading() {
+  return (
+    <main className="min-h-screen bg-stone-900">
+      <div className={`${CONTENT_WIDTH_CLASSES} py-8`}>
+        {/* Search input skeleton */}
+        <div className="mb-8 h-12 w-full animate-pulse rounded-xl bg-stone-800" />
+
+        {/* Grid of card skeletons */}
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 8 }, (_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next"
+import { Suspense } from "react"
+import { CONTENT_WIDTH_CLASSES } from "@/lib/content-width"
+import { searchVideos, type SearchError } from "@/lib/search"
+import { SearchInput } from "@/components/search/SearchInput"
+import { SearchResults } from "@/components/search/SearchResults"
+
+type PageProps = {
+  searchParams: Promise<{ q?: string }>
+}
+
+export async function generateMetadata({
+  searchParams,
+}: PageProps): Promise<Metadata> {
+  const { q } = await searchParams
+  return {
+    title: q ? `Search: ${q}` : "Search",
+  }
+}
+
+export default async function SearchPage({ searchParams }: PageProps) {
+  const { q } = await searchParams
+  const query = q?.trim() ?? ""
+
+  return (
+    <main className="min-h-screen bg-stone-900">
+      <div className={`${CONTENT_WIDTH_CLASSES} py-8`}>
+        <SearchInput defaultValue={query} />
+
+        <div className="mt-8">
+          {query ? (
+            <Suspense
+              fallback={
+                <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {Array.from({ length: 8 }, (_, i) => (
+                    <div
+                      key={i}
+                      className="overflow-hidden rounded-2xl bg-stone-800"
+                    >
+                      <div className="aspect-video w-full animate-pulse bg-stone-700" />
+                      <div className="flex flex-col gap-2 p-3">
+                        <div className="h-4 w-3/4 animate-pulse rounded bg-stone-700" />
+                        <div className="h-3 w-full animate-pulse rounded bg-stone-700" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              }
+            >
+              <SearchResultsLoader query={query} />
+            </Suspense>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-24 text-center">
+              <svg
+                className="mb-4 h-16 w-16 text-stone-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <p className="text-lg text-stone-400">
+                Search for videos about any topic
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}
+
+async function SearchResultsLoader({ query }: { query: string }) {
+  try {
+    const { results, hasMore } = await searchVideos(query)
+
+    return (
+      <SearchResults
+        key={query}
+        initialResults={results}
+        initialHasMore={hasMore}
+        query={query}
+      />
+    )
+  } catch (err) {
+    const error = err as SearchError
+    return (
+      <div className="py-16 text-center">
+        <p className="text-lg font-semibold text-red-400">
+          {error.message ?? "Something went wrong"}
+        </p>
+        <p className="mt-2 text-sm text-stone-400">
+          Please try again later
+          {error.retryAfterSeconds != null &&
+            ` (retry in ${error.retryAfterSeconds}s)`}
+        </p>
+      </div>
+    )
+  }
+}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -77,30 +77,31 @@ export default async function SearchPage({ searchParams }: PageProps) {
 }
 
 async function SearchResultsLoader({ query }: { query: string }) {
-  try {
-    const { results, hasMore } = await searchVideos(query)
+  const data = await searchVideos(query).catch((err) => ({
+    error: err as SearchError,
+  }))
 
-    return (
-      <SearchResults
-        key={query}
-        initialResults={results}
-        initialHasMore={hasMore}
-        query={query}
-      />
-    )
-  } catch (err) {
-    const error = err as SearchError
+  if ("error" in data) {
     return (
       <div className="py-16 text-center">
         <p className="text-lg font-semibold text-red-400">
-          {error.message ?? "Something went wrong"}
+          {data.error.message ?? "Something went wrong"}
         </p>
         <p className="mt-2 text-sm text-stone-400">
           Please try again later
-          {error.retryAfterSeconds != null &&
-            ` (retry in ${error.retryAfterSeconds}s)`}
+          {data.error.retryAfterSeconds != null &&
+            ` (retry in ${data.error.retryAfterSeconds}s)`}
         </p>
       </div>
     )
   }
+
+  return (
+    <SearchResults
+      key={query}
+      initialResults={data.results}
+      initialHasMore={data.hasMore}
+      query={query}
+    />
+  )
 }

--- a/apps/web/src/components/SearchOverlay.tsx
+++ b/apps/web/src/components/SearchOverlay.tsx
@@ -1,0 +1,356 @@
+"use client"
+
+import { useRef, useState, useEffect, useCallback } from "react"
+import client from "@/lib/client"
+import { SEMANTIC_SEARCH, type SearchResult } from "@/lib/search"
+import { VideoCard } from "./search/VideoCard"
+
+type SearchOverlayProps = {
+  open: boolean
+  onClose: () => void
+  closing?: boolean
+}
+
+export function SearchOverlay({ open, onClose, closing }: SearchOverlayProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const requestIdRef = useRef(0)
+  const [query, setQuery] = useState("")
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [displayResults, setDisplayResults] = useState<SearchResult[]>([])
+  const [exiting, setExiting] = useState(false)
+  const [resultsKey, setResultsKey] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [showSkeleton, setShowSkeleton] = useState(false)
+  const skeletonTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [searched, setSearched] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      const t = setTimeout(() => inputRef.current?.focus(), 100)
+      return () => clearTimeout(t)
+    }
+    setQuery("")
+    setResults([])
+    setDisplayResults([])
+    setExiting(false)
+    setHasMore(false)
+    setError(null)
+    setSearched(false)
+    setShowSkeleton(false)
+    if (skeletonTimerRef.current) clearTimeout(skeletonTimerRef.current)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden"
+      return () => {
+        document.body.style.overflow = ""
+      }
+    }
+  }, [open])
+
+  const search = useCallback(
+    async (q: string) => {
+      const trimmed = q.trim()
+      if (!trimmed) {
+        if (displayResults.length > 0) {
+          setExiting(true)
+          await new Promise((r) => setTimeout(r, 200))
+          setExiting(false)
+        }
+        setResults([])
+        setDisplayResults([])
+        setHasMore(false)
+        setSearched(false)
+        return
+      }
+
+      // Animate out existing results if any
+      if (displayResults.length > 0) {
+        setExiting(true)
+        await new Promise((r) => setTimeout(r, 200))
+        setExiting(false)
+        setDisplayResults([])
+      }
+
+      const thisRequest = ++requestIdRef.current
+      setLoading(true)
+      setError(null)
+      setSearched(true)
+      if (skeletonTimerRef.current) clearTimeout(skeletonTimerRef.current)
+      skeletonTimerRef.current = setTimeout(() => setShowSkeleton(true), 500)
+
+      try {
+        const result = await client.query({
+          query: SEMANTIC_SEARCH,
+          variables: {
+            query: trimmed.slice(0, 200),
+            locale: "en",
+            limit: 20,
+            offset: 0,
+          },
+          fetchPolicy: "no-cache",
+        })
+
+        // Discard stale response if a newer search was triggered
+        if (requestIdRef.current !== thisRequest) return
+
+        const data = result.data?.semanticSearch
+        const newResults = data?.results ?? []
+        setResults(newResults)
+        setDisplayResults(newResults)
+        setResultsKey((k) => k + 1)
+        setHasMore(data?.hasMore ?? false)
+      } catch {
+        setError("Search failed. Please try again.")
+      } finally {
+        if (skeletonTimerRef.current) clearTimeout(skeletonTimerRef.current)
+        setShowSkeleton(false)
+        setLoading(false)
+      }
+    },
+    [displayResults.length],
+  )
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newValue = e.target.value
+    setQuery(newValue)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => search(newValue), 300)
+  }
+
+  async function loadMore() {
+    setLoadingMore(true)
+    setError(null)
+
+    try {
+      const result = await client.query({
+        query: SEMANTIC_SEARCH,
+        variables: {
+          query: query.trim().slice(0, 200),
+          locale: "en",
+          limit: 20,
+          offset: results.length,
+        },
+        fetchPolicy: "no-cache",
+      })
+
+      const data = result.data?.semanticSearch
+      if (data) {
+        setResults((prev) => [...prev, ...data.results])
+        setDisplayResults((prev) => [...prev, ...data.results])
+        setHasMore(data.hasMore)
+      }
+    } catch {
+      setError("Failed to load more results.")
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 9999,
+        backgroundColor: "rgba(0, 0, 0, 0.75)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        display: "flex",
+        flexDirection: "column",
+        animation: closing
+          ? "overlay-fade-out 200ms ease-out forwards"
+          : "overlay-fade-in 200ms ease-out forwards",
+      }}
+    >
+      {/* Top bar: search input centered, X on right */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          padding: "20px 24px 0",
+          gap: "16px",
+          flexShrink: 0,
+        }}
+      >
+        <div style={{ flex: 1 }} />
+        <div style={{ width: "100%", maxWidth: "480px" }}>
+          <div className="relative">
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+              <svg
+                className="h-4 w-4 text-stone-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+            </div>
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={handleChange}
+              placeholder="Search videos by keyword..."
+              className="w-full rounded-full border border-stone-700 bg-stone-900/80 py-2.5 pl-11 pr-4 text-sm text-stone-100 placeholder-stone-500 outline-none transition focus:border-stone-500"
+            />
+          </div>
+        </div>
+        <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-stone-400 transition hover:text-white"
+            aria-label="Close search"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-5 w-5"
+              aria-hidden="true"
+            >
+              <line x1={18} y1={6} x2={6} y2={18} />
+              <line x1={6} y1={6} x2={18} y2={18} />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Scrollable results */}
+      <div
+        className="search-overlay-scroll"
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          padding: "24px 24px 32px",
+          minHeight: 0,
+        }}
+      >
+        <div style={{ maxWidth: "1400px", margin: "0 auto" }}>
+          {loading && showSkeleton && (
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: 8 }, (_, i) => (
+                <div key={i} className="overflow-hidden rounded-2xl bg-white/5">
+                  <div className="aspect-video w-full animate-pulse bg-white/10" />
+                  <div className="flex flex-col gap-2 p-3">
+                    <div className="h-4 w-3/4 animate-pulse rounded bg-white/10" />
+                    <div className="h-3 w-full animate-pulse rounded bg-white/10" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!loading && searched && results.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <h2 className="text-lg font-semibold text-stone-200">
+                No results for &apos;{query.trim()}&apos;
+              </h2>
+              <p className="mt-2 text-sm text-stone-500">
+                Try different keywords or browse experiences
+              </p>
+            </div>
+          )}
+
+          {displayResults.length > 0 && (
+            <>
+              <div
+                key={resultsKey}
+                className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                style={
+                  exiting
+                    ? { animation: "card-exit 200ms ease-in forwards" }
+                    : undefined
+                }
+              >
+                {displayResults.map((result, index) => (
+                  <div key={`${result.id}-${index}`} onClick={onClose}>
+                    <VideoCard result={result} index={exiting ? 0 : index} />
+                  </div>
+                ))}
+              </div>
+
+              {error && (
+                <div className="mt-6 text-center">
+                  <p className="text-sm text-red-400">{error}</p>
+                  <button
+                    type="button"
+                    onClick={loadMore}
+                    className="mt-2 rounded-lg bg-stone-700 px-4 py-2 text-sm text-stone-200 transition hover:bg-stone-600"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+
+              {hasMore && !error && (
+                <div className="mt-8 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={loadMore}
+                    disabled={loadingMore}
+                    className="flex items-center gap-2 rounded-lg bg-white/10 px-6 py-3 text-sm font-medium text-stone-300 transition hover:bg-white/15 disabled:opacity-50"
+                  >
+                    {loadingMore && (
+                      <svg
+                        className="h-4 w-4 animate-spin"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        aria-hidden="true"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                        />
+                      </svg>
+                    )}
+                    {loadingMore ? "Loading..." : "Load more"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/SearchToggle.tsx
+++ b/apps/web/src/components/SearchToggle.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState, useCallback, useRef } from "react"
+import { createPortal } from "react-dom"
+import { SearchOverlay } from "./SearchOverlay"
+
+export function SearchToggle() {
+  const [open, setOpen] = useState(false)
+  const [closing, setClosing] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleClose = useCallback(() => {
+    setClosing(true)
+    timerRef.current = setTimeout(() => {
+      setOpen(false)
+      setClosing(false)
+    }, 200)
+  }, [])
+
+  const handleOpen = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setClosing(false)
+    setOpen(true)
+  }, [])
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="rounded-lg p-2 text-stone-300 transition hover:bg-stone-800 hover:text-white"
+        aria-label="Search"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-5 w-5"
+          aria-hidden="true"
+        >
+          <circle cx={11} cy={11} r={8} />
+          <line x1={21} y1={21} x2={16.65} y2={16.65} />
+        </svg>
+      </button>
+
+      {open &&
+        createPortal(
+          <SearchOverlay open={open} onClose={handleClose} closing={closing} />,
+          document.body,
+        )}
+    </>
+  )
+}

--- a/apps/web/src/components/SiteHeader.tsx
+++ b/apps/web/src/components/SiteHeader.tsx
@@ -1,9 +1,8 @@
+import Image from "next/image"
 import Link from "next/link"
 import type { Route } from "next"
 import { CONTENT_WIDTH_CLASSES } from "@/lib/content-width"
 import { SearchToggle } from "./SearchToggle"
-
-const BASE_PATH = "/watch"
 
 export function SiteHeader() {
   return (
@@ -12,11 +11,12 @@ export function SiteHeader() {
         className={`${CONTENT_WIDTH_CLASSES} flex h-full items-center justify-between`}
       >
         <Link href={"/" as Route} className="flex items-center">
-          <img
-            src={`${BASE_PATH}/images/jesusfilm-sign.svg`}
+          <Image
+            src="/images/jesusfilm-sign.svg"
             alt="JesusFilm"
             width={32}
             height={24}
+            unoptimized
           />
         </Link>
 

--- a/apps/web/src/components/SiteHeader.tsx
+++ b/apps/web/src/components/SiteHeader.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link"
+import type { Route } from "next"
+import { CONTENT_WIDTH_CLASSES } from "@/lib/content-width"
+import { SearchToggle } from "./SearchToggle"
+
+const BASE_PATH = "/watch"
+
+export function SiteHeader() {
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 h-16 bg-stone-900/80 backdrop-blur-sm">
+      <div
+        className={`${CONTENT_WIDTH_CLASSES} flex h-full items-center justify-between`}
+      >
+        <Link href={"/" as Route} className="flex items-center">
+          <img
+            src={`${BASE_PATH}/images/jesusfilm-sign.svg`}
+            alt="JesusFilm"
+            width={32}
+            height={24}
+          />
+        </Link>
+
+        <SearchToggle />
+      </div>
+    </header>
+  )
+}

--- a/apps/web/src/components/search/SearchInput.tsx
+++ b/apps/web/src/components/search/SearchInput.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useRef, useState, useEffect, useCallback } from "react"
+import { useRouter } from "next/navigation"
+
+type SearchInputProps = {
+  defaultValue?: string
+}
+
+export function SearchInput({ defaultValue = "" }: SearchInputProps) {
+  const router = useRouter()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [value, setValue] = useState(defaultValue)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const debouncedNavigate = useCallback(
+    (query: string) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+      timerRef.current = setTimeout(() => {
+        if (query.trim()) {
+          router.replace(`/search?q=${encodeURIComponent(query.trim())}`)
+        } else {
+          router.replace("/search")
+        }
+      }, 300)
+    },
+    [router],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newValue = e.target.value
+    setValue(newValue)
+    debouncedNavigate(newValue)
+  }
+
+  return (
+    <div className="relative w-full">
+      <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+        <svg
+          className="h-5 w-5 text-stone-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+      </div>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={handleChange}
+        placeholder="Search for videos..."
+        className="w-full rounded-xl bg-stone-800 py-3 pl-12 pr-4 text-stone-100 placeholder-stone-500 outline-none ring-stone-600 transition focus:ring-2"
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/search/SearchResults.tsx
+++ b/apps/web/src/components/search/SearchResults.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useState } from "react"
+import client from "@/lib/client"
+import { SEMANTIC_SEARCH, type SearchResult } from "@/lib/search"
+import { VideoCard } from "./VideoCard"
+
+type SearchResultsProps = {
+  initialResults: SearchResult[]
+  initialHasMore: boolean
+  query: string
+}
+
+export function SearchResults({
+  initialResults,
+  initialHasMore,
+  query,
+}: SearchResultsProps) {
+  const [results, setResults] = useState(initialResults)
+  const [hasMore, setHasMore] = useState(initialHasMore)
+  const [offset, setOffset] = useState(initialResults.length)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (initialResults.length === 0) {
+    return (
+      <div className="py-16 text-center">
+        <h2 className="text-lg font-semibold text-stone-100">
+          No results for &apos;{query}&apos;
+        </h2>
+        <p className="mt-2 text-sm text-stone-400">
+          Try different keywords or browse experiences
+        </p>
+      </div>
+    )
+  }
+
+  async function loadMore() {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await client.query({
+        query: SEMANTIC_SEARCH,
+        variables: {
+          query,
+          locale: "en",
+          limit: 20,
+          offset,
+        },
+        fetchPolicy: "no-cache",
+      })
+
+      if (result.error) {
+        throw new Error(result.error.message || "Failed to load more results")
+      }
+
+      const data = result.data?.semanticSearch
+      if (data) {
+        setResults((prev) => [...prev, ...data.results])
+        setHasMore(data.hasMore)
+        setOffset((prev) => prev + data.results.length)
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load more results",
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {results.map((result, index) => (
+          <VideoCard
+            key={`${result.id}-${index}`}
+            result={result}
+            index={index}
+          />
+        ))}
+      </div>
+
+      {error && (
+        <div className="mt-6 text-center">
+          <p className="text-sm text-red-400">{error}</p>
+          <button
+            type="button"
+            onClick={loadMore}
+            className="mt-2 rounded-lg bg-stone-700 px-4 py-2 text-sm text-stone-200 transition hover:bg-stone-600"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {hasMore && !error && (
+        <div className="mt-8 flex justify-center">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loading}
+            className="flex items-center gap-2 rounded-lg bg-stone-800 px-6 py-3 text-sm font-medium text-stone-200 transition hover:bg-stone-700 disabled:opacity-50"
+          >
+            {loading && (
+              <svg
+                className="h-4 w-4 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+            )}
+            {loading ? "Loading..." : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/search/VideoCard.tsx
+++ b/apps/web/src/components/search/VideoCard.tsx
@@ -1,0 +1,55 @@
+import Image from "next/image"
+import Link from "next/link"
+import type { Route } from "next"
+import type { SearchResult } from "@/lib/search"
+
+type VideoCardProps = {
+  result: SearchResult
+  index?: number
+}
+
+export function VideoCard({ result, index = 0 }: VideoCardProps) {
+  return (
+    <Link
+      href={`/${result.slug}/en` as Route}
+      className="group flex flex-col overflow-hidden rounded-2xl bg-stone-800 transition hover:brightness-110"
+      style={{
+        animation: `card-enter 300ms ease-out ${index * 50}ms both`,
+      }}
+    >
+      <div className="relative aspect-video w-full overflow-hidden bg-stone-700">
+        {result.imageUrl ? (
+          <Image
+            src={result.imageUrl}
+            alt={result.title ?? "Video thumbnail"}
+            fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
+            className="object-cover transition group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-stone-500">
+            <svg
+              className="h-12 w-12"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col gap-1.5 p-3">
+        <h3 className="line-clamp-1 text-sm font-semibold text-stone-100">
+          {result.title}
+        </h3>
+        {result.snippet && (
+          <p className="line-clamp-2 text-xs leading-relaxed text-stone-400">
+            {result.snippet}
+          </p>
+        )}
+      </div>
+    </Link>
+  )
+}

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,0 +1,107 @@
+import { graphql, type ResultOf } from "@forge/graphql"
+import client from "@/lib/client"
+
+export const SEMANTIC_SEARCH = graphql(`
+  query SemanticSearch(
+    $query: String!
+    $locale: String!
+    $limit: Int
+    $offset: Int
+  ) {
+    semanticSearch(
+      query: $query
+      locale: $locale
+      limit: $limit
+      offset: $offset
+    ) {
+      query
+      hasMore
+      results {
+        type
+        id
+        slug
+        title
+        imageUrl
+        snippet
+        startSeconds
+        playbackId
+        score
+      }
+    }
+  }
+`)
+
+export type SearchResult = ResultOf<
+  typeof SEMANTIC_SEARCH
+>["semanticSearch"]["results"][number]
+
+type SearchResponse = ResultOf<typeof SEMANTIC_SEARCH>["semanticSearch"]
+
+export type SearchError = {
+  code: string
+  message: string
+  retryAfterSeconds?: number
+}
+
+const MAX_QUERY_LENGTH = 200
+
+export async function searchVideos(
+  query: string,
+  limit = 20,
+  offset = 0,
+): Promise<{ results: SearchResult[]; hasMore: boolean; query: string }> {
+  const truncatedQuery = query.slice(0, MAX_QUERY_LENGTH)
+
+  const result = await client.query({
+    query: SEMANTIC_SEARCH,
+    variables: {
+      query: truncatedQuery,
+      locale: "en",
+      limit,
+      offset,
+    },
+    fetchPolicy: "no-cache",
+  })
+
+  if (result.error) {
+    // Apollo's ErrorLike type is minimal but the runtime object may carry
+    // graphQLErrors with extensions from the server response.
+    const gqlErrors = (
+      result.error as unknown as {
+        graphQLErrors?: {
+          message: string
+          extensions?: Record<string, unknown>
+        }[]
+      }
+    ).graphQLErrors
+
+    if (gqlErrors?.length) {
+      const firstError = gqlErrors[0]
+      const code =
+        (firstError.extensions?.code as string) ?? "UNKNOWN_SEARCH_ERROR"
+      const message = firstError.message ?? "Search request failed"
+      const retryAfterSeconds = firstError.extensions?.retryAfterSeconds as
+        | number
+        | undefined
+
+      const searchError: SearchError = { code, message }
+      if (retryAfterSeconds != null) {
+        searchError.retryAfterSeconds = retryAfterSeconds
+      }
+      throw searchError
+    }
+
+    throw {
+      code: "NETWORK_ERROR",
+      message: result.error.message || "Search request failed",
+    } satisfies SearchError
+  }
+
+  const data = result.data?.semanticSearch as SearchResponse | undefined
+
+  return {
+    results: data?.results ?? [],
+    hasMore: data?.hasMore ?? false,
+    query: data?.query ?? truncatedQuery,
+  }
+}

--- a/docs/brainstorms/2026-04-15-search-ui-web-mobile-requirements.md
+++ b/docs/brainstorms/2026-04-15-search-ui-web-mobile-requirements.md
@@ -1,0 +1,103 @@
+---
+date: 2026-04-15
+topic: search-ui-web-mobile
+---
+
+# Search UI — Web & Mobile
+
+## Problem Frame
+
+955+ JesusFilm videos are semantically indexed (feat-010, complete), but users have no way to search for content. The `semanticSearch` GraphQL query is live — hybrid semantic + keyword search with RRF fusion — but no UI consumes it. Users currently browse only through curated experience pages.
+
+## Decisions
+
+- **Two separate PRs**: Web (feat-011) ships independently from Mobile (feat-012). Shared GraphQL query definition in `packages/graphql` lands with the first PR.
+- **Web entry point**: Minimal site header with logo and search icon, visible on all pages. Search icon navigates to `/search`.
+- **Mobile entry point**: Search icon in the Discover tab header bar (enable `headerShown: true`). Tapping pushes SearchScreen onto the navigation stack.
+- **Mobile result navigation**: New `/experience/[slug]` route that loads an experience by slug (existing routes use `sectionKey` which search results don't provide).
+- **Pagination**: Explicit "Load More" button (not infinite scroll). Uses `offset` param. Default page size: 20 results (`limit=20` for initial and subsequent loads).
+- **Result tap action**: Navigate to the experience page (`/[slug]/[locale]` on web, `/experience/[slug]` on mobile). No timestamp seeking in v1.
+- **Locale**: Hardcoded `en` for v1.
+- **No search frameworks**: No Algolia, no ElasticSearch UI, no third-party search components.
+- **No score indicator**: Results are sorted by relevance — position communicates rank. Score field is not rendered.
+- **Data fetching**: GraphQL via `packages/graphql` only (not REST). Consistent with CLAUDE.md rule: "apps never call Strapi REST."
+- **Web architecture**: Server Component page with Suspense boundary for SearchResults. Initial results server-rendered. "Load More" is a client component that fetches additional pages client-side.
+
+## API Contract (Locked — feat-010)
+
+```graphql
+semanticSearch(query: String!, locale: String!, limit: Int, offset: Int): SearchResponse!
+
+type SearchResponse {
+  results: [SearchResult!]!
+  hasMore: Boolean!
+  query: String!
+}
+
+type SearchResult {
+  type: String!          # "video" in v1
+  id: Int!
+  slug: String!
+  title: String!
+  imageUrl: String       # nullable
+  snippet: String!
+  startSeconds: Float    # nullable (keyword-only matches)
+  playbackId: String     # nullable (keyword-only matches)
+  score: Float!          # 0-1 RRF-normalized
+}
+```
+
+Error codes: `BAD_USER_INPUT`, `RATE_LIMITED` (with `retryAfterSeconds`), `SERVICE_UNAVAILABLE`.
+
+## Requirements — Web (feat-011)
+
+- W1. `/search` route as a Server Component reading `?q=` from `searchParams`. Wrap SearchResults in a `<Suspense>` boundary with a loading fallback. Add `loading.tsx` for route-level loading state.
+- W2. `SearchInput` client component: text input with 300ms debounce, updates URL via `router.replace` on keystroke (not `useEffect` fetch). Autofocuses on mount.
+- W3. `SearchResults`: initial results server-rendered inside Suspense boundary. "Load More" is a client component that fetches additional pages client-side and appends to the list. Button shows loading spinner and is disabled while fetching. On pagination error, show inline error below existing results with retry action.
+- W4. `VideoCard` component: thumbnail via `next/image` (fallback for null `imageUrl`), title, snippet (truncated to 2 lines).
+- W5. `searchVideos()` data fetcher in `apps/web/src/lib/content.ts` using the `semanticSearch` GraphQL query (not REST).
+- W6. Minimal site header: logo + search icon. Fixed position, visible on all pages. Search icon navigates to `/search`.
+- W7. Empty states: initial state (no query — centered search prompt: "Search for videos about any topic"), no results state (heading: "No results for '[query]'", body: "Try different keywords or browse experiences"), loading state via Suspense fallback.
+- W8. Shareable URLs: refreshing `/search?q=forgiveness` re-runs the search with the same query.
+- W9. Error handling: display user-friendly message for rate limiting (with retry hint) and service errors.
+- W10. All `semanticSearch` calls pass `locale: "en"` hardcoded. No runtime locale switching in v1.
+
+## Requirements — Mobile (feat-012)
+
+- M1. `SearchScreen` with `TextInput` at top, 300ms debounce, `FlatList` for results.
+- M2. `SearchResultCard` component: thumbnail (via `expo-image`, fallback for null `imageUrl`), title, snippet (truncated to 2 lines via `numberOfLines={2}`).
+- M3. Search icon in Discover tab header bar. Enable `headerShown: true` on the Discover tab and add search icon via `headerRight`. Pushes SearchScreen onto stack.
+- M4. Apollo Client `useLazyQuery` for data fetching with the `semanticSearch` query. Triggered on debounced input change.
+- M5. "Load More" button in `FlatList` footer when `hasMore` is true. Button shows loading spinner and is disabled while fetching. On pagination error, show inline error below existing results with retry action. Existing results remain visible during pagination.
+- M6. Empty states: initial state (no query entered — centered search prompt: "Search for videos about any topic"), no results state (query entered but zero results — heading: "No results for '[query]'", body: "Try different keywords or browse experiences"), loading spinner.
+- M7. Keyboard dismisses on scroll (`keyboardDismissMode="on-drag"`).
+- M8. New `/experience/[slug]` route: loads an experience by slug and renders it. Tapping a search result navigates to this route using the result's `slug`.
+- M9. Error handling: display user-friendly message for rate limiting and service errors.
+- M10. All `semanticSearch` calls pass `locale: "en"` hardcoded. No runtime locale switching in v1.
+
+## Shared (packages/graphql)
+
+- S1. Define the `semanticSearch` query operation using `graphql()` from `@forge/graphql` with a `SearchResultFragment`. Fragment selects all SearchResult fields.
+- S2. Export typed result types for consuming apps.
+
+## Scope Boundaries
+
+- No personalization or search history.
+- No filters (by type, date, etc.) — v1 returns all matching videos.
+- No timestamp seeking on result tap.
+- No analytics/tracking for search queries in v1.
+- No voice search.
+- English locale only.
+- No score indicator on result cards.
+- TV app (apps/tv) excluded from this feature.
+
+## Success Criteria
+
+- Typing a query on web navigates to `/search?q=...` and displays ranked results from the semantic search API.
+- Refreshing the URL re-runs the search with the same results.
+- On mobile, tapping the search icon opens a search screen; typing shows debounced results.
+- Tapping a mobile search result navigates to the new experience route and renders the experience.
+- "Load More" fetches the next page on both platforms.
+- Empty, loading, no-results, and error states all render appropriately.
+- When the API returns `RATE_LIMITED`, the UI shows a retry message with the wait time. When the API returns `SERVICE_UNAVAILABLE`, the UI shows a service error message.
+- No regressions to existing experience pages or navigation.

--- a/docs/plans/2026-04-15-001-feat-search-ui-web-mobile-plan.md
+++ b/docs/plans/2026-04-15-001-feat-search-ui-web-mobile-plan.md
@@ -1,0 +1,508 @@
+---
+title: "feat: Add search UI for web and mobile"
+type: feat
+status: active
+date: 2026-04-15
+origin: docs/brainstorms/2026-04-15-search-ui-web-mobile-requirements.md
+---
+
+# feat: Add search UI for web and mobile
+
+## Overview
+
+Add search interfaces to both the web (Next.js) and mobile (Expo) apps, consuming the existing `semanticSearch` GraphQL query (feat-010, complete). Two separate PRs: web ships first with the shared query definition, mobile follows.
+
+## Problem Frame
+
+955+ JesusFilm videos are semantically indexed with hybrid search (pgvector + FTS + RRF fusion), but no UI exists to search them. Users can only browse curated experience pages. (see origin: `docs/brainstorms/2026-04-15-search-ui-web-mobile-requirements.md`)
+
+## Requirements Trace
+
+- W1–W10: Web search requirements (Server Component page, SearchInput, SearchResults, VideoCard, data fetcher, site header, empty/error states, shareable URLs, locale)
+- M1–M10: Mobile search requirements (SearchScreen, SearchResultCard, Discover tab entry, Apollo fetching, Load More, empty/error states, keyboard dismiss, experience route, locale)
+- S1–S2: Shared GraphQL query and typed exports
+
+## Scope Boundaries
+
+- No personalization, search history, or filters
+- No timestamp seeking on result tap
+- No analytics/tracking in v1
+- No voice search
+- English locale only (`locale: "en"` hardcoded)
+- No score indicator on cards
+- TV app excluded
+
+### Deferred to Separate Tasks
+
+- Accessibility audit (ARIA roles, screen reader labels, focus management): separate follow-up PR
+- Grid responsive breakpoint polish: can be refined post-launch
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Web:**
+
+- `apps/web/src/lib/content.ts` — data fetching: `graphql()` query → Apollo `client.query()` → wrapped in `unstable_cache()` + React `cache()`
+- `apps/web/src/lib/client.ts` — Apollo Client singleton, server uses `INTERNAL_GRAPHQL_URL` with Bearer token
+- `apps/web/src/lib/recommendations.ts` — precedent for custom GraphQL extension queries. Uses raw `gql` tag, but `SearchResult`/`SearchResponse` types ARE in `graphql-env.d.ts` so `graphql()` should work
+- `apps/web/src/components/sections/VideoRecommendations.tsx` — closest card grid pattern (dark theme, `next/image`, `Link`, `bg-stone-800`, `rounded-lg`)
+- `apps/web/src/lib/content-width.ts` — `CONTENT_WIDTH_CLASSES` for layout alignment
+- `apps/web/src/app/layout.tsx` — bare layout with no header, just font loading + `bg-stone-900` body
+
+**Mobile:**
+
+- `apps/mobile/src/lib/queries.ts` — query + fragment definitions using `graphql()` from `@forge/graphql`
+- `apps/mobile/src/lib/apolloClient.ts` — lazy singleton via `getApolloClient()`
+- `apps/mobile/src/lib/color.ts` — warm stone palette (`BG_COLOR`, `SURFACE_COLOR`, `TEXT_PRIMARY`, `TEXT_SECONDARY`, `ACCENT`)
+- `apps/mobile/app/(tabs)/_layout.tsx` — 4 tabs, `headerShown: false` globally
+- `apps/mobile/app/(tabs)/watch.tsx` — Discover tab, currently a `PlaceholderScreen`
+- `apps/mobile/app/video/[sectionKey].tsx` — detail screen pattern (uses `useSectionByKey()` from ExperienceProvider)
+- `apps/mobile/src/hooks/useExperience.ts` — loads experience by slug via Apollo `useQuery`
+- `apps/mobile/src/contexts/ExperienceProvider.tsx` — wraps subtree with experience data + sectionMap
+
+**Shared:**
+
+- `packages/graphql/src/graphql-env.d.ts` — introspection types include `SearchResult`, `SearchResponse`
+- `apps/cms/schema.graphql` line 2796 — `semanticSearch` query definition
+
+### Institutional Learnings
+
+- **Codegen strips optional variables** (`docs/solutions/cms/codegen-strips-optional-graphql-variables.md`): `optimizeDocumentNode: false` must be set. Without it, optional `limit`/`offset` vars get silently stripped from the DocumentNode AST — pagination silently breaks.
+- **Strapi v5 error extensions** (`docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md`): Error codes (`RATE_LIMITED`, etc.) are in `errors[0].extensions.code`. Check `extensions.code`, never message strings. Watch for duplicate `graphql` package versions.
+- **Server-side GraphQL in Next.js** (`docs/solutions/graphql/server-side-strapi-queries-nextjs.md`): Use `fetchPolicy: "no-cache"` in Server Components. Let Next.js handle caching.
+- **ISR + headers() trap** (`docs/solutions/web/nextjs16-cachecomponents-isr.md`): `headers()` anywhere in page route forces dynamic rendering. Search pages are dynamic anyway (user-driven queries), so this is fine.
+- **Expo Router slugs with slashes** (`docs/solutions/mobile/expo-router-slash-in-dynamic-route-params.md`): `encodeURIComponent()` at navigation time, `decodeURIComponent()` on receiving screen, wrap in try/catch.
+- **Gradient banding** (`docs/solutions/mobile/linear-gradient-dark-banding-transparent-keyword.md`): Use `hexToRgba(color, 0)`, never `"transparent"`.
+- **Mobile Apollo patterns** (`docs/solutions/mobile/mobile-v2-sdui-app-scaffold-and-review-findings.md`): Use `cache-and-network` fetch policy. Lazy init via `getApolloClient()`.
+
+## Key Technical Decisions
+
+- **Query definition location**: Define in each consuming app using `graphql()` from `@forge/graphql` (consistent with existing patterns in `content.ts` and `queries.ts`). Not in `packages/graphql` package itself per mobile CLAUDE.md rule.
+- **Web search page rendering**: Dynamic rendering (not ISR). Search queries are user-driven — no point caching. Use `fetchPolicy: "no-cache"` for initial server fetch. Do NOT wrap in `unstable_cache()`.
+- **Web Load More architecture**: Initial results server-rendered via RSC. "Load More" is a client component that receives `initialResults` + `initialHasMore` as props, then fetches subsequent pages client-side via Apollo Client (using `NEXT_PUBLIC_GRAPHQL_URL`).
+- **Mobile experience loading for search results**: Reuse `useExperience({ slug })` hook (which already loads by slug via Apollo `useQuery`) inside a new `/experience/[slug]` route. No need to build new data fetching — just a new route that wraps ExperienceProvider + renders sections.
+- **Error handling approach**: Parse `errors[0].extensions.code` from GraphQL response. For `RATE_LIMITED`, show static "Please wait N seconds" message (not a countdown timer). For `SERVICE_UNAVAILABLE`, show generic error with retry button.
+- **No `gql` fallback needed**: `SearchResult` and `SearchResponse` types ARE in `graphql-env.d.ts`, confirming gql.tada introspection picks them up. Use `graphql()` (not raw `gql` tag).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to define the query?**: In each consuming app (web: `content.ts`, mobile: `queries.ts`), not in `packages/graphql`. This follows the established pattern.
+- **How does mobile load an experience by slug?**: `useExperience({ slug })` already exists and fetches by slug. Wrap it in a new route.
+- **Should search use ISR?**: No. User-driven queries are inherently dynamic. Skip `unstable_cache()`.
+
+### Deferred to Implementation
+
+- **Exact header layout dimensions**: Height, logo sizing, breakpoint behavior — resolve during implementation with visual feedback.
+- **Fallback image for null `imageUrl`**: Use a branded placeholder or `bg-stone-700` color fill — decide during VideoCard implementation.
+- **Whether `NEXT_PUBLIC_GRAPHQL_URL` already exists**: Check `apps/web/src/env.ts`. If not, add it for client-side Load More fetches.
+
+## Implementation Units
+
+### PR 1: Web Search (feat-011)
+
+- [ ] **Unit 1: Search query definition + data fetcher**
+
+**Goal:** Define the `semanticSearch` GraphQL query and a `searchVideos()` fetcher function.
+
+**Requirements:** W5, W10, S1
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `apps/web/src/lib/search.ts` (query definition + server fetcher — separate from `content.ts` because `content.ts` imports `unstable_cache` from `next/cache` which is server-only and would break client-side imports of the query constant)
+- Test: `apps/web/src/lib/__tests__/search.test.ts`
+
+**Approach:**
+
+- Define `SEMANTIC_SEARCH` query using `graphql()` from `@forge/graphql` selecting all `SearchResult` fields. **Note:** `semanticSearch` uses `locale: String!` (not `I18NLocaleCode!` as in standard Strapi queries) — define the variable as `$locale: String!`
+- Export the `SEMANTIC_SEARCH` query constant so both server-side `searchVideos()` and client-side `SearchResults.tsx` can import it
+- Create `searchVideos(query: string, limit?: number, offset?: number)` async function
+- Use `client.query()` with `fetchPolicy: "no-cache"` — no `unstable_cache()` wrapping (dynamic user queries)
+- Hardcode `locale: "en"`
+- Add max query length check (200 characters) — truncate before sending to API
+- Return typed `{ results, hasMore, query }` or throw typed error with parsed `extensions.code`
+- Verify `optimizeDocumentNode: false` is set in codegen config to prevent `limit`/`offset` variable stripping
+
+**Patterns to follow:**
+
+- `apps/web/src/lib/content.ts` existing query patterns (fragment composition, type extraction)
+- `apps/web/src/lib/recommendations.ts` for custom extension query precedent
+
+**Test scenarios:**
+
+- Happy path: `searchVideos("forgiveness")` returns typed results with all fields
+- Edge case: empty results array with `hasMore: false`
+- Error path: function throws with parsed error code when API returns `RATE_LIMITED`
+- Error path: function throws with parsed error code for `SERVICE_UNAVAILABLE`
+- Edge case: `limit` and `offset` variables are present in the sent query (codegen stripping guard)
+
+**Verification:**
+
+- `searchVideos()` compiles with full type safety via gql.tada
+- Calling with query string returns structured results
+
+---
+
+- [ ] **Unit 2: /search page + SearchInput component**
+
+**Goal:** Create the search route and debounced input component.
+
+**Requirements:** W1, W2, W7 (initial empty state), W8
+
+**Dependencies:** Unit 1
+
+**Files:**
+
+- Create: `apps/web/src/app/search/page.tsx`
+- Create: `apps/web/src/app/search/loading.tsx`
+- Create: `apps/web/src/components/search/SearchInput.tsx`
+
+**Approach:**
+
+- `page.tsx`: Server Component. `searchParams` is a `Promise<{ q?: string }>` in Next.js 16 — must `await` before reading `.q` (per existing `[slug]/[locale]/page.tsx` pattern). If no query, render initial empty state ("Search for videos about any topic"). If query present, call `searchVideos()` inside an async RSC wrapped in `<Suspense>` with loading fallback.
+- `loading.tsx`: Route-level loading skeleton (grid of placeholder cards).
+- `SearchInput.tsx`: `'use client'` component. Controlled input with 300ms debounce via `setTimeout`/`clearTimeout`. Updates URL via `router.replace(`/search?q=${encoded}`)` on debounce fire. Reads initial value from `searchParams.q` prop. Autofocuses on mount via `useRef` + `useEffect`.
+- Use `CONTENT_WIDTH_CLASSES` from `content-width.ts` for page layout alignment.
+
+**Patterns to follow:**
+
+- `apps/web/src/app/[slug]/[locale]/page.tsx` for dynamic route + async data fetching pattern
+
+**Test scenarios:**
+
+- Happy path: navigating to `/search?q=forgiveness` renders search results
+- Happy path: refreshing the page with `?q=` preserves the query and re-fetches
+- Edge case: navigating to `/search` with no query shows initial empty state
+- Edge case: typing updates URL via `router.replace` (not `router.push`) after 300ms
+- Integration: SearchInput reads initial query from URL and populates the input field
+
+**Verification:**
+
+- `/search` renders without errors
+- `/search?q=test` triggers data fetch and displays results
+- Browser back button works correctly (no history pollution from debounce)
+
+---
+
+- [ ] **Unit 3: VideoCard + SearchResults with Load More**
+
+**Goal:** Build the result card and paginated results list.
+
+**Requirements:** W3, W4
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+
+- Create: `apps/web/src/components/search/VideoCard.tsx`
+- Create: `apps/web/src/components/search/SearchResults.tsx`
+
+**Approach:**
+
+- `VideoCard.tsx`: Server component. `next/image` for thumbnail (aspect-ratio container, `fill` + `sizes`). Fallback for null `imageUrl` (stone-colored placeholder). Title (truncated 1 line), snippet (truncated 2 lines via `line-clamp-2`). Wrapped in `<Link href={/${slug}/en}>`. Dark theme: `bg-stone-800 rounded-2xl` matching VideoRecommendations pattern.
+- `SearchResults.tsx`: `'use client'` component. Receives `initialResults`, `initialHasMore`, and `query` as props from the server-rendered page. Manages offset state. "Load More" button at bottom when `hasMore` is true. On click: fetches next page via Apollo Client (client-side), appends to results array. Button shows spinner while loading, disabled during fetch. On error: inline error message below results with retry button.
+- Responsive grid: `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6`.
+- No-results state when query exists but results are empty: heading "No results for '[query]'", body "Try different keywords or browse experiences".
+
+**Patterns to follow:**
+
+- `apps/web/src/components/sections/VideoRecommendations.tsx` for dark card grid, `next/image` with `fill`, Link wrapping
+
+**Test scenarios:**
+
+- Happy path: renders grid of VideoCards from results array
+- Happy path: "Load More" button appears when `hasMore` is true, hidden when false
+- Happy path: clicking "Load More" fetches next page and appends results
+- Edge case: null `imageUrl` renders placeholder instead of broken image
+- Edge case: long snippet truncated to 2 lines
+- Error path: pagination fetch error shows inline error with retry button
+- Edge case: no results for query shows "No results for '[query]'" message
+
+**Verification:**
+
+- Results display in responsive grid
+- Load More fetches and appends without losing existing results
+- Card links navigate to correct experience page
+
+---
+
+- [ ] **Unit 4: Minimal site header**
+
+**Goal:** Add a fixed site header with logo and search icon to all pages.
+
+**Requirements:** W6
+
+**Dependencies:** None (can be built in parallel with Units 1-3)
+
+**Files:**
+
+- Create: `apps/web/src/components/SiteHeader.tsx`
+- Modify: `apps/web/src/app/layout.tsx`
+
+**Approach:**
+
+- `SiteHeader.tsx`: Fixed-position header, `h-16` (64px). Logo (JesusFilm logo or text mark) on left, search icon (magnifying glass) on right. `bg-stone-900/80 backdrop-blur-sm` for subtle transparency. `z-50` to float above content. `CONTENT_WIDTH_CLASSES` for inner alignment. Search icon is a `<Link href="/search">`.
+- `layout.tsx`: Add `<SiteHeader />` inside `<body>` before `{children}`. Add `pt-16` to body or a wrapper to prevent content from being hidden behind the 64px fixed header.
+- Keep it minimal — no navigation links, no dropdown menus. Just logo + search icon.
+
+**Patterns to follow:**
+
+- `apps/web/src/lib/content-width.ts` for `CONTENT_WIDTH_CLASSES`
+- Existing `bg-stone-900` dark theme from `layout.tsx`
+
+**Test scenarios:**
+
+- Happy path: header visible on homepage
+- Happy path: header visible on `/search` page
+- Happy path: search icon navigates to `/search`
+- Edge case: header stays fixed on scroll
+- Integration: existing experience pages (`/[slug]/[locale]`) render correctly with header (no layout regressions)
+
+**Verification:**
+
+- Header renders on all pages
+- Search icon navigates to `/search`
+- No layout shifts or regressions on existing pages
+
+---
+
+- [ ] **Unit 5: Error handling**
+
+**Goal:** Handle API errors gracefully with user-friendly messages.
+
+**Requirements:** W9
+
+**Dependencies:** Unit 2, Unit 3
+
+**Files:**
+
+- Create: `apps/web/src/app/search/error.tsx`
+- Modify: `apps/web/src/components/search/SearchResults.tsx`
+
+**Approach:**
+
+- `error.tsx`: Route-level error boundary for unexpected errors. Shows "Something went wrong" with retry button.
+- In `searchVideos()`: parse GraphQL `errors[0].extensions.code` and throw typed errors.
+- In `SearchResults.tsx` (client component): catch pagination errors. Extract error codes via Apollo Client v4 path: `(error as ApolloError).graphQLErrors?.[0]?.extensions?.code` and `retryAfterSeconds` via `graphQLErrors?.[0]?.extensions?.retryAfterSeconds`. For `RATE_LIMITED`, show "Too many requests. Please wait N seconds." For `SERVICE_UNAVAILABLE`, show "Search is temporarily unavailable. Please try again."
+- In the server-rendered initial fetch: try/catch around `searchVideos()`. On error, render error state inline (not throw to error boundary) so SearchInput remains usable.
+
+**Patterns to follow:**
+
+- `docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md` for error code parsing
+
+**Test scenarios:**
+
+- Error path: rate-limited response shows message with wait time
+- Error path: service unavailable shows generic error with retry
+- Error path: server-side fetch error renders inline error without breaking the page
+- Happy path: error boundary catches unexpected errors with retry action
+
+**Verification:**
+
+- Error states render correctly for each error code
+- SearchInput remains functional even when results error
+
+---
+
+### PR 2: Mobile Search (feat-012)
+
+- [ ] **Unit 6: /experience/[slug] route**
+
+**Goal:** Create a new route that loads an experience by slug, enabling search result navigation.
+
+**Requirements:** M8
+
+**Dependencies:** None (prerequisite for search navigation)
+
+**Files:**
+
+- Create: `apps/mobile/app/experience/[slug].tsx`
+- Modify: `apps/mobile/app/_layout.tsx` (add screen to Stack)
+
+**Approach:**
+
+- New route file at `apps/mobile/app/experience/[slug].tsx`.
+- Read `slug` from `useLocalSearchParams()`. Apply `decodeURIComponent()` wrapped in try/catch (per Expo Router slug learning).
+- Use existing `useExperience({ slug })` hook to load the experience by slug.
+- Wrap content in `ExperienceProvider` with the loaded experience data.
+- Render experience sections using the existing `SectionDispatcher` pattern.
+- In `_layout.tsx`: add `<Stack.Screen name="experience/[slug]" options={{ headerShown: true, headerTitle: "" }} />`.
+- Loading state: full-screen spinner. Error state: error message with back button.
+
+**Patterns to follow:**
+
+- `apps/mobile/app/video/[sectionKey].tsx` for detail screen pattern (params, layout, back button)
+- `apps/mobile/src/hooks/useExperience.ts` for experience loading by slug
+- `apps/mobile/src/contexts/ExperienceProvider.tsx` for wrapping with experience context
+
+**Test scenarios:**
+
+- Happy path: navigating to `/experience/easter` loads and renders the Easter experience
+- Edge case: slug with special characters decoded correctly
+- Error path: invalid slug shows error state
+- Edge case: back button returns to previous screen
+- Integration: experience sections render correctly with SectionDispatcher
+
+**Verification:**
+
+- Route loads experiences by slug
+- Sections render identically to how they render on the Home tab
+
+---
+
+- [ ] **Unit 7: Search query + SearchScreen + SearchResultCard**
+
+**Goal:** Build the core search screen with input, results list, and result cards.
+
+**Requirements:** M1, M2, M4, M7, M10
+
+**Dependencies:** Unit 6
+
+**Files:**
+
+- Create: `apps/mobile/src/screens/SearchScreen.tsx`
+- Create: `apps/mobile/src/components/SearchResultCard.tsx`
+- Modify: `apps/mobile/src/lib/queries.ts` (add search query + fragment)
+- Create: `apps/mobile/app/search.tsx` (route file)
+- Modify: `apps/mobile/app/_layout.tsx` (add search screen to Stack)
+
+**Approach:**
+
+- Define `SEMANTIC_SEARCH_QUERY` in `queries.ts` using `graphql()` from `@forge/graphql` with a `SearchResultFragment` selecting all fields. Hardcode `locale: "en"`.
+- `SearchScreen.tsx`: `TextInput` at top with 300ms debounce. `useLazyQuery` with `fetchPolicy: "network-only"` for data fetching (search results are ephemeral user-driven queries — do not cache). Triggered on debounced input change. `FlatList` for results with `keyboardDismissMode="on-drag"`. Composite keys: `` `search-${item.id}-${index}` ``.
+- `SearchResultCard.tsx`: `Pressable` wrapping horizontal card layout. Thumbnail via `expo-image` with `recyclingKey` (fallback for null `imageUrl`: stone-colored `View`). Title (1 line, `numberOfLines={1}`). Snippet (2 lines, `numberOfLines={2}`). On press: `router.push(`/experience/${encodeURIComponent(slug)}`)`.
+- Colors: `BG_COLOR` background, `SURFACE_COLOR` card background, `TEXT_PRIMARY`/`TEXT_SECONDARY` for text, `ACCENT` for focus states.
+- `Math.round()` all computed font sizes (Android sub-pixel blurring).
+
+**Patterns to follow:**
+
+- `apps/mobile/src/lib/queries.ts` for fragment + query definition patterns
+- `apps/mobile/src/lib/color.ts` for color tokens
+- `apps/mobile/app/video/[sectionKey].tsx` for screen layout patterns
+
+**Test scenarios:**
+
+- Happy path: typing "forgiveness" shows debounced results after 300ms
+- Happy path: tapping a result navigates to `/experience/[slug]`
+- Edge case: empty input shows initial state ("Search for videos about any topic")
+- Edge case: null `imageUrl` shows placeholder instead of broken image
+- Edge case: keyboard dismisses on scroll
+- Edge case: slug with slashes encoded correctly in navigation
+
+**Verification:**
+
+- Search screen shows results from the GraphQL API
+- Results navigate to experience route correctly
+
+---
+
+- [ ] **Unit 8: Discover tab search icon**
+
+**Goal:** Add search entry point to the Discover tab header.
+
+**Requirements:** M3
+
+**Dependencies:** Unit 7
+
+**Files:**
+
+- Modify: `apps/mobile/app/(tabs)/_layout.tsx`
+- Modify: `apps/mobile/app/(tabs)/watch.tsx`
+
+**Approach:**
+
+- In `_layout.tsx`: enable `headerShown: true` for the Discover tab screen. Add `headerRight` option with a search icon (`Ionicons search` in `ACCENT` color). On press: `router.push("/search")`.
+- Style header: `headerStyle: { backgroundColor: BG_COLOR }`, `headerTintColor: TEXT_PRIMARY`, `headerShadowVisible: false`.
+- `watch.tsx`: remains a placeholder for now. The Discover tab shows its placeholder content; the search icon in the header is the entry point to search.
+
+**Patterns to follow:**
+
+- `apps/mobile/app/(tabs)/_layout.tsx` existing tab configuration
+- `apps/mobile/app/_layout.tsx` for `headerRight` pattern with Pressable + Ionicons
+
+**Test scenarios:**
+
+- Happy path: Discover tab shows header with search icon
+- Happy path: tapping search icon navigates to SearchScreen
+- Edge case: other tabs unaffected by header change
+- Integration: back navigation from SearchScreen returns to Discover tab
+
+**Verification:**
+
+- Search icon visible in Discover tab header
+- Tapping navigates to search screen
+- No regression on other tabs
+
+---
+
+- [ ] **Unit 9: Load More + empty states + error handling**
+
+**Goal:** Complete the search experience with pagination, empty states, and error handling.
+
+**Requirements:** M5, M6, M9
+
+**Dependencies:** Unit 7
+
+**Files:**
+
+- Modify: `apps/mobile/src/screens/SearchScreen.tsx`
+- Create: `apps/mobile/src/components/LoadMoreButton.tsx`
+
+**Approach:**
+
+- `LoadMoreButton.tsx`: renders in `FlatList` `ListFooterComponent` when `hasMore` is true. Shows `ActivityIndicator` while loading, disabled during fetch. On pagination error: inline error text + retry button below existing results.
+- Pagination: track `offset` state in SearchScreen. On "Load More" press: call `fetchMore()` with `offset: results.length`. Merge new results into existing array.
+- Empty states: initial (no query) — centered illustration-free prompt "Search for videos about any topic". No results — "No results for '[query]'" + "Try different keywords or browse experiences".
+- Error handling: parse `errors[0].extensions.code`. For `RATE_LIMITED`: "Too many requests. Please wait N seconds." For `SERVICE_UNAVAILABLE`: "Search is temporarily unavailable. Please try again."
+
+**Patterns to follow:**
+
+- `apps/mobile/src/components/ui/` for UI component patterns
+- `docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md` for error code parsing
+
+**Test scenarios:**
+
+- Happy path: "Load More" button appears when `hasMore` is true
+- Happy path: tapping "Load More" appends next page of results
+- Edge case: "Load More" shows spinner during fetch, disabled state
+- Error path: pagination error shows inline error with retry, existing results preserved
+- Error path: rate-limited shows wait time message
+- Error path: service unavailable shows generic error
+- Edge case: initial state (no query) shows prompt
+- Edge case: query with zero results shows no-results message
+
+**Verification:**
+
+- Pagination works and results accumulate
+- All empty/error states render correctly
+
+## System-Wide Impact
+
+- **Interaction graph:** Web header added to root layout affects all pages. Mobile Discover tab header visibility changes. New mobile Stack screen added.
+- **Error propagation:** GraphQL errors parsed at the data-fetching layer and surfaced as typed errors to UI components. Rate-limit errors from shared bucket (30 req/min/IP) affect both search and any other search consumers.
+- **State lifecycle risks:** Web Load More state is client-side — navigating away and back resets to server-rendered initial page (correct behavior for URL-driven search). Mobile FlatList state lost on screen unmount (acceptable for search).
+- **API surface parity:** `semanticSearch` query defined independently in web and mobile — ensure both select the same fields.
+- **Unchanged invariants:** Existing `/[slug]/[locale]` routes, experience pages, SDUI pipeline, and recommendations remain unchanged. The site header is additive only.
+
+## Risks & Dependencies
+
+| Risk                                                             | Mitigation                                                                                                                           |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `graphql()` fails for `semanticSearch` types (custom extension)  | Types confirmed in `graphql-env.d.ts`. If it fails, fall back to raw `gql` tag per `recommendations.ts` pattern                      |
+| Codegen strips `limit`/`offset` optional variables               | Verify `optimizeDocumentNode: false` in codegen config. Test that pagination variables reach the API                                 |
+| `NEXT_PUBLIC_GRAPHQL_URL` not configured for client-side fetches | Check `apps/web/src/env.ts`. Add if missing — needed for Load More client-side fetching                                              |
+| Mobile experience route doesn't render all section types         | Reuse exact same ExperienceProvider + SectionDispatcher. If a section type fails, it's a pre-existing renderer gap, not a search bug |
+| Site header breaks existing full-bleed experience pages          | Use `fixed` positioning with `z-50`. Add body padding-top. Test against existing pages                                               |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-15-search-ui-web-mobile-requirements.md](docs/brainstorms/2026-04-15-search-ui-web-mobile-requirements.md)
+- Related roadmap: `docs/roadmap/content-discovery/feat-011-search-ui-web.md`, `docs/roadmap/content-discovery/feat-012-search-ui-mobile.md`
+- CMS search API: `apps/cms/src/api/search/`, `apps/cms/src/graphql/search.ts`
+- Error handling learning: `docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md`
+- Codegen learning: `docs/solutions/cms/codegen-strips-optional-graphql-variables.md`
+- Slug encoding learning: `docs/solutions/mobile/expo-router-slash-in-dynamic-route-params.md`

--- a/docs/solutions/best-practices/nextjs-search-overlay-ui-patterns-20260415.md
+++ b/docs/solutions/best-practices/nextjs-search-overlay-ui-patterns-20260415.md
@@ -1,0 +1,166 @@
+---
+title: "Next.js Search Overlay UI — Patterns and Pitfalls"
+date: 2026-04-15
+category: best-practices
+module: web
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Building a search overlay or modal in a Next.js App Router app
+  - Consuming a GraphQL API from both Server and Client Components
+  - Using Apollo Client with gql.tada in a basePath-configured app
+  - Adding debounced async search with client-side state management
+tags:
+  - nextjs
+  - react
+  - search
+  - overlay
+  - portal
+  - server-components
+  - client-components
+  - apollo
+  - debounce
+  - race-condition
+---
+
+# Next.js Search Overlay UI — Patterns and Pitfalls
+
+## Context
+
+Building a semantic search overlay for the JesusFilm web app (`apps/web/`) surfaced eight patterns and pitfalls at the intersection of Next.js 16 App Router, Apollo Client, CSS stacking contexts, and React component boundaries. Each issue was non-obvious, produced silent failures or cryptic errors, and is likely to recur in any feature that mixes Server Components with interactive client overlays.
+
+## Guidance
+
+### 1. Separate query definitions from server-only modules
+
+**Problem:** `content.ts` imports `unstable_cache` from `next/cache` (server-only). Placing a GraphQL query constant there means any `'use client'` component that imports the query will fail to bundle — the server-only import poisons the entire file.
+
+**Fix:** Create a dedicated file (e.g., `search.ts`) with no server-only imports. Both Server Components and Client Components can safely import from it.
+
+```ts
+// BAD: content.ts — has unstable_cache, breaks client imports
+import { unstable_cache } from 'next/cache'
+export const SEARCH_QUERY = graphql(`...`)
+
+// GOOD: search.ts — no server-only imports
+import { graphql } from '@forge/graphql'
+export const SEARCH_QUERY = graphql(`...`)
+export async function searchVideos(query: string) { ... }
+```
+
+Common server-only offenders: `next/cache`, `next/headers`, `server-only`.
+
+### 2. Use createPortal for overlays inside stacking contexts
+
+**Problem:** A `position: fixed; inset: 0` overlay rendered inside a `<header>` with `backdrop-filter: blur()` gets clipped. The `backdrop-filter` creates a new CSS stacking context that constrains fixed-position descendants — z-index escalation has no effect.
+
+**Fix:** Render the overlay via `createPortal` to `document.body`.
+
+```tsx
+import { createPortal } from "react-dom"
+
+// In SearchToggle.tsx
+{
+  open &&
+    createPortal(
+      <SearchOverlay open={open} onClose={handleClose} />,
+      document.body,
+    )
+}
+```
+
+Properties that create stacking contexts (silently): `backdrop-filter`, `transform`, `opacity < 1`, `will-change`, `isolation: isolate`, `filter`.
+
+### 3. Await searchParams in Next.js 16
+
+**Problem:** In Next.js 16, `searchParams` is `Promise<{ [key: string]: string | undefined }>`. Accessing properties synchronously causes TypeScript errors and runtime failures.
+
+```tsx
+type Props = { searchParams: Promise<{ q?: string }> }
+
+export default async function SearchPage({ searchParams }: Props) {
+  const { q } = await searchParams // MUST await
+}
+```
+
+### 4. basePath is not auto-applied to next/image for local files
+
+**Problem:** With `basePath: "/watch"`, `<Image src="/images/logo.svg" />` renders `src="/images/logo.svg"` but the file is served at `/watch/images/logo.svg`. The image 404s silently.
+
+**Fix:** Use `unoptimized` with a manually prefixed path, or use the codebase `BASE_PATH` constant pattern (seen in `MediaCollection.tsx`, `DynamicBackground.tsx`).
+
+### 5. Define keyframes in globals.css, not styled-jsx
+
+**Problem:** `<style jsx global>` blocks pass the project's main TypeScript lint but fail under `lint-staged`'s stricter ESLint invocation (`Definition for rule not found`). Worse, keyframes defined in the overlay's scope are unavailable to components rendered on the `/search` page route — cards get `opacity: 0` (the animation start state) with no keyframe to animate from, making them invisible.
+
+**Fix:** Define all `@keyframes`, scrollbar styles, and global CSS in `apps/web/src/app/globals.css`.
+
+### 6. Guard debounced async search against race conditions
+
+**Problem:** A 300ms debounce fires search queries. If the user types faster than the network round-trip, an older response can resolve after a newer one and overwrite fresh results with stale data. (session history)
+
+**Fix:** Use a request ID counter ref. Each search call increments it and captures the value; after the response, check that the captured ID still matches before writing state.
+
+```ts
+const requestIdRef = useRef(0)
+
+const search = useCallback(async (q: string) => {
+  const thisRequest = ++requestIdRef.current
+  const data = await client.query({ ... })
+  if (requestIdRef.current !== thisRequest) return // stale
+  setResults(data)
+}, [])
+```
+
+### 7. Avoid JSX inside try/catch — use .catch() pattern
+
+**Problem:** The `react-hooks/error-boundaries` ESLint rule forbids JSX inside try/catch blocks. React doesn't render JSX immediately, so try/catch won't actually catch rendering errors.
+
+**Fix:** Use `.catch()` to convert errors into a data structure, then render conditionally.
+
+```ts
+// BAD — lint error
+try {
+  const data = await fetchData()
+  return <Results data={data} />
+} catch (e) {
+  return <ErrorState />
+}
+
+// GOOD
+const result = await fetchData().catch((e) => ({ error: e }))
+if ('error' in result) return <ErrorState />
+return <Results data={result} />
+```
+
+### 8. Custom GraphQL extensions use String!, not I18NLocaleCode!
+
+**Problem:** Standard Strapi content queries use `I18NLocaleCode!` for locale. Custom GraphQL resolver extensions (like `semanticSearch`) use `String!`. Copying the locale variable type from an existing query causes a GraphQL type mismatch at the schema layer — gql.tada catches this at compile time, but the error is confusing.
+
+**Fix:** Always check the schema definition for the specific operation. Don't copy-paste locale types across queries.
+
+## Why This Matters
+
+Each of these issues produces silent failures, invisible UI bugs, or CI-only errors that are difficult to diagnose without prior knowledge. Server-only import poisoning and stacking context clipping are particularly insidious — they produce no console errors and no build-time warnings. Documenting these patterns prevents repeat investigation time.
+
+## When to Apply
+
+- Building any overlay, modal, or drawer in a Next.js App Router app with `backdrop-filter` on parent elements
+- Consuming GraphQL queries from both Server and Client Components
+- Adding debounced search or autocomplete with async data fetching
+- Working with `basePath` configuration and local image assets
+- Adding custom GraphQL resolver extensions alongside Strapi's generated schema
+
+## Examples
+
+See `apps/web/src/components/SearchOverlay.tsx` for the complete implementation showing all eight patterns applied together: portal rendering, request ID guard, `.catch()` error handling, and `globals.css` keyframe references.
+
+See `apps/web/src/lib/search.ts` for the query definition separation pattern — a standalone file with no server-only imports, exportable to both RSC and client contexts.
+
+## Related
+
+- `docs/solutions/web/nextjs16-cachecomponents-isr.md` — Apollo + Next.js 16 caching patterns (same data-fetching context)
+- `docs/solutions/graphql/server-side-strapi-queries-nextjs.md` — Server Component GraphQL fetching (the "server owns the call" pattern this doc extends)
+- `docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md` — CMS backend counterpart to this UI doc
+- `docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md` — Error extension handling for search API errors


### PR DESCRIPTION
## Summary

- Add search overlay UI to the web app, consuming the existing `semanticSearch` GraphQL API (feat-010)
- New site header with JesusFilm logo and search icon on all pages
- Search overlay with debounced input, animated video card grid, Load More pagination, and error handling
- Fallback `/search` page for direct URL access and shareable search links

## What's included

| Component | Description |
|-----------|-------------|
| `SiteHeader` | Fixed header with logo + search icon |
| `SearchOverlay` | Full-screen semi-transparent overlay with blur, rendered via portal |
| `SearchInput` | Debounced input (300ms) using `router.replace` |
| `VideoCard` | Result card with `next/image`, staggered fade-up entrance animation |
| `SearchResults` | Paginated results with Load More (client-side Apollo fetch) |
| `search.ts` | GraphQL query + `searchVideos()` fetcher with typed error handling |

## Key decisions

- **Overlay UX** over full-page navigation — preserves user context while searching
- **Server Component page** at `/search` as fallback for direct URL access
- **`locale: String!`** (not `I18NLocaleCode!`) — matches the custom search extension's schema
- **Separate `search.ts`** from `content.ts` — avoids `unstable_cache` server-only import breaking client components
- **Race condition guard** via request counter ref to discard stale search responses

## Test plan

- [ ] Open any experience page, verify site header with logo + search icon renders
- [ ] Click search icon, verify overlay opens with fade-in animation
- [ ] Type a query, verify debounced results appear with staggered card animations
- [ ] Click X or press Escape, verify overlay closes with fade-out
- [ ] Clear search input, verify results animate out
- [ ] Click "Load More" when available, verify next page appends
- [ ] Navigate to `/watch/search?q=christmas` directly, verify server-rendered results
- [ ] Verify existing experience pages are not affected by the header addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)