### PR TITLE
feat(cms): add experiences to search results (feat-086)

### DIFF
--- a/apps/cms/config/database.ts
+++ b/apps/cms/config/database.ts
@@ -38,6 +38,18 @@ const config = ({
         max: env.int("DATABASE_POOL_MAX", 25),
         // Set per-connection statement_timeout and idle_in_transaction timeout
         // so slow or abandoned queries release connections back to the pool.
+        //
+        // Also enable pgvector's HNSW iterative scan so filtered nearest-
+        // neighbour queries (e.g. `WHERE locale = ? ORDER BY embedding <=> ?`)
+        // can keep fetching from the partial HNSW index until LIMIT is
+        // satisfied, instead of stopping at the default ef_search window of
+        // 40 candidates. Combined with the per-locale partial indexes
+        // created in `bootstrap/ensure-pgvector.ts`, this is what makes
+        // experience semantic search use the index at scale.
+        // `relaxed_order` allows pgvector to return rows out of strict
+        // distance order during iteration, which is fine because the
+        // outer ORDER BY in our queries re-sorts the result. SET commands
+        // are quietly ignored if the pgvector extension is missing.
         afterCreate(
           conn: { query: (sql: string, cb: () => void) => void },
           cb: () => void,
@@ -48,7 +60,10 @@ const config = ({
             60000,
           )
           conn.query(
-            `SET statement_timeout = ${statementTimeout}; SET idle_in_transaction_session_timeout = ${idleTxTimeout};`,
+            `SET statement_timeout = ${statementTimeout};
+             SET idle_in_transaction_session_timeout = ${idleTxTimeout};
+             SET hnsw.iterative_scan = relaxed_order;
+             SET hnsw.max_scan_tuples = 20000;`,
             cb,
           )
         },

--- a/apps/cms/src/api/search/controllers/search.test.ts
+++ b/apps/cms/src/api/search/controllers/search.test.ts
@@ -91,6 +91,7 @@ describe("search controller", () => {
       locale: "en",
       limit: undefined,
       offset: undefined,
+      contentTypes: undefined,
     })
   })
 
@@ -150,5 +151,74 @@ describe("search controller", () => {
 
     expect(ctx.status).toBe(400)
     expect(ctx.body).toEqual({ error: "q (search query) is required" })
+  })
+
+  describe("type filter", () => {
+    beforeEach(() => {
+      vi.mocked(search).mockResolvedValue({
+        results: [],
+        hasMore: false,
+        query: "test",
+      })
+    })
+
+    it("passes contentTypes=['video'] when type=video", async () => {
+      const ctx = makeCtx({ q: "test", locale: "en", type: "video" })
+      await controller.search(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(search).toHaveBeenCalledWith(
+        mockStrapi,
+        expect.objectContaining({ contentTypes: ["video"] }),
+      )
+    })
+
+    it("passes contentTypes=['experience'] when type=experience", async () => {
+      const ctx = makeCtx({ q: "test", locale: "en", type: "experience" })
+      await controller.search(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(search).toHaveBeenCalledWith(
+        mockStrapi,
+        expect.objectContaining({ contentTypes: ["experience"] }),
+      )
+    })
+
+    it("passes contentTypes=undefined when type is omitted", async () => {
+      const ctx = makeCtx({ q: "test", locale: "en" })
+      await controller.search(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(search).toHaveBeenCalledWith(
+        mockStrapi,
+        expect.objectContaining({ contentTypes: undefined }),
+      )
+    })
+
+    it("returns 400 when type is invalid", async () => {
+      const ctx = makeCtx({ q: "test", locale: "en", type: "invalid" })
+      await controller.search(ctx)
+
+      expect(ctx.status).toBe(400)
+      expect(ctx.body).toEqual({
+        error: "type must be 'video' or 'experience'",
+      })
+      expect(search).not.toHaveBeenCalled()
+    })
+
+    it("returns 400 for an empty type rather than treating it as missing", async () => {
+      // An explicit empty string is not the same as omitting the param.
+      // Treat it as omitted (default to both) so callers building URLs with
+      // optional values do not get spurious 400s.
+      const ctx = makeCtx({ q: "test", locale: "en", type: "" })
+      await controller.search(ctx)
+
+      // Empty string falls through to the default — both content types.
+      expect(ctx.status).toBe(200)
+      expect(search).toHaveBeenCalledWith(
+        mockStrapi,
+        expect.objectContaining({ contentTypes: undefined }),
+      )
+    })
   })
 })

--- a/apps/cms/src/api/search/controllers/search.test.ts
+++ b/apps/cms/src/api/search/controllers/search.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-vi.mock("../services/search", () => ({
-  search: vi.fn(),
-}))
+vi.mock("../services/search", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/search")>()
+  return {
+    ...actual,
+    search: vi.fn(),
+  }
+})
 
 import { search } from "../services/search"
 import searchControllerFactory from "./search"
@@ -206,10 +210,9 @@ describe("search controller", () => {
       expect(search).not.toHaveBeenCalled()
     })
 
-    it("returns 400 for an empty type rather than treating it as missing", async () => {
-      // An explicit empty string is not the same as omitting the param.
-      // Treat it as omitted (default to both) so callers building URLs with
-      // optional values do not get spurious 400s.
+    it("treats an explicit empty-string type as omitted (defaults to both)", async () => {
+      // An explicit empty string is treated the same as omitting the param.
+      // Callers building URLs with optional values shouldn't get spurious 400s.
       const ctx = makeCtx({ q: "test", locale: "en", type: "" })
       await controller.search(ctx)
 

--- a/apps/cms/src/api/search/controllers/search.ts
+++ b/apps/cms/src/api/search/controllers/search.ts
@@ -1,5 +1,5 @@
 import type { Core } from "@strapi/strapi"
-import { search, type ContentType } from "../services/search"
+import { search, isContentType, type ContentType } from "../services/search"
 
 type StrapiContext = {
   status: number
@@ -7,12 +7,6 @@ type StrapiContext = {
   request: {
     query?: Record<string, string | undefined>
   }
-}
-
-const VALID_TYPES: readonly ContentType[] = ["video", "experience"]
-
-function isContentType(value: string): value is ContentType {
-  return (VALID_TYPES as readonly string[]).includes(value)
 }
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({

--- a/apps/cms/src/api/search/controllers/search.ts
+++ b/apps/cms/src/api/search/controllers/search.ts
@@ -1,5 +1,5 @@
 import type { Core } from "@strapi/strapi"
-import { search } from "../services/search"
+import { search, type ContentType } from "../services/search"
 
 type StrapiContext = {
   status: number
@@ -7,6 +7,12 @@ type StrapiContext = {
   request: {
     query?: Record<string, string | undefined>
   }
+}
+
+const VALID_TYPES: readonly ContentType[] = ["video", "experience"]
+
+function isContentType(value: string): value is ContentType {
+  return (VALID_TYPES as readonly string[]).includes(value)
 }
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
@@ -27,6 +33,19 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       return
     }
 
+    // Optional type filter — restricts results to the given content type.
+    // Omitting it returns both videos and experiences (the default).
+    let contentTypes: ContentType[] | undefined
+    const rawType = query.type
+    if (rawType != null && rawType.length > 0) {
+      if (!isContentType(rawType)) {
+        ctx.status = 400
+        ctx.body = { error: "type must be 'video' or 'experience'" }
+        return
+      }
+      contentTypes = [rawType]
+    }
+
     const limit = query.limit ? Number(query.limit) || undefined : undefined
     const offset = query.offset ? Number(query.offset) || undefined : undefined
 
@@ -36,6 +55,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
         locale,
         limit,
         offset,
+        contentTypes,
       })
       ctx.status = 200
       ctx.body = result

--- a/apps/cms/src/api/search/services/experience-keyword-search.test.ts
+++ b/apps/cms/src/api/search/services/experience-keyword-search.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from "vitest"
+import { searchByExperienceKeyword } from "./experience-keyword-search"
+
+/**
+ * Creates a mock knex instance whose `.raw()` records calls and returns
+ * the provided rows.
+ */
+function createMockKnex(rows: Record<string, unknown>[] = []) {
+  const raw = vi.fn(async () => ({ rows }))
+  return { raw, knex: { raw } }
+}
+
+function buildRow(overrides: Record<string, unknown> = {}) {
+  return {
+    experience_id: 1,
+    slug: "easter",
+    title: "Easter",
+    meta_description: "Discover the true meaning of Easter.",
+    rank: 0.5,
+    ...overrides,
+  }
+}
+
+describe("searchByExperienceKeyword", () => {
+  it("returns results ordered by rank descending", async () => {
+    const rows = [
+      buildRow({ experience_id: 1, title: "Easter", rank: 0.8 }),
+      buildRow({ experience_id: 2, title: "Christmas", rank: 0.4 }),
+      buildRow({ experience_id: 3, title: "Advent", rank: 0.2 }),
+    ]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "Easter",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toHaveLength(3)
+    expect(results[0]!.experienceTitle).toBe("Easter")
+    expect(results[0]!.rank).toBe(0.8)
+    expect(results[1]!.experienceTitle).toBe("Christmas")
+    expect(results[1]!.rank).toBe(0.4)
+  })
+
+  it("tags every result with resultType=experience and resultId=experienceId", async () => {
+    const rows = [buildRow({ experience_id: 7 })]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "anything",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results[0]!.resultType).toBe("experience")
+    expect(results[0]!.resultId).toBe(7)
+    expect(results[0]!.experienceId).toBe(7)
+  })
+
+  it("returns empty array for empty query", async () => {
+    const { knex, raw } = createMockKnex()
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toEqual([])
+    expect(raw).not.toHaveBeenCalled()
+  })
+
+  it("returns empty array for whitespace-only query", async () => {
+    const { knex, raw } = createMockKnex()
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "   ",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toEqual([])
+    expect(raw).not.toHaveBeenCalled()
+  })
+
+  it("passes correct SQL parameters to knex.raw", async () => {
+    const { knex, raw } = createMockKnex([])
+
+    await searchByExperienceKeyword(knex, {
+      query: "Easter",
+      locale: "es",
+      limit: 20,
+    })
+
+    expect(raw).toHaveBeenCalledTimes(1)
+    const [sql, bindings] = raw.mock.calls[0]
+
+    // SQL should reference the experiences table, locale filter, and the
+    // tsvector expression matching the GIN index.
+    expect(sql).toContain("experiences")
+    expect(sql).toContain("to_tsvector")
+    expect(sql).toContain("plainto_tsquery")
+    expect(sql).toContain("ts_rank")
+    expect(sql).toContain("e.locale = ?")
+    expect(sql).toContain("published_at IS NOT NULL")
+
+    // Bindings: [query (ts_rank), query (WHERE @@), locale, limit]
+    expect(bindings).toEqual(["Easter", "Easter", "es", 20])
+  })
+
+  it("trims the query before binding to SQL", async () => {
+    const { knex, raw } = createMockKnex([])
+
+    await searchByExperienceKeyword(knex, {
+      query: "  Easter  ",
+      locale: "en",
+      limit: 10,
+    })
+
+    const [, bindings] = raw.mock.calls[0]
+    expect(bindings[0]).toBe("Easter")
+    expect(bindings[1]).toBe("Easter")
+  })
+
+  it("maps row fields to camelCase result properties", async () => {
+    const rows = [
+      buildRow({
+        experience_id: 42,
+        slug: "sermon-on-the-mount",
+        title: "Sermon on the Mount",
+        meta_description: "An experience about Jesus's teachings.",
+        rank: 0.75,
+      }),
+    ]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "sermon",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toHaveLength(1)
+    const result = results[0]!
+    expect(result.experienceId).toBe(42)
+    expect(result.experienceSlug).toBe("sermon-on-the-mount")
+    expect(result.experienceTitle).toBe("Sermon on the Mount")
+    expect(result.experienceMetaDescription).toBe(
+      "An experience about Jesus's teachings.",
+    )
+    expect(result.rank).toBe(0.75)
+  })
+
+  it("handles null optional fields gracefully", async () => {
+    const rows = [
+      buildRow({
+        title: null,
+        meta_description: null,
+      }),
+    ]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "test",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toHaveLength(1)
+    const result = results[0]!
+    expect(result.experienceTitle).toBe("")
+    expect(result.experienceMetaDescription).toBeNull()
+  })
+
+  it("returns null for imageUrl in v1 (og_image join deferred)", async () => {
+    const { knex } = createMockKnex([buildRow()])
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "easter",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results[0]!.imageUrl).toBeNull()
+  })
+
+  it("returns empty array when no rows match", async () => {
+    const { knex } = createMockKnex([])
+
+    const results = await searchByExperienceKeyword(knex, {
+      query: "nonexistent",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toEqual([])
+  })
+})

--- a/apps/cms/src/api/search/services/experience-keyword-search.ts
+++ b/apps/cms/src/api/search/services/experience-keyword-search.ts
@@ -1,0 +1,98 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type KnexInstance = any
+
+export type ExperienceKeywordSearchParams = {
+  query: string
+  locale: string
+  limit: number
+}
+
+export type ExperienceKeywordResult = {
+  resultType: "experience"
+  resultId: number
+  experienceId: number
+  experienceSlug: string
+  experienceTitle: string
+  experienceMetaDescription: string | null
+  imageUrl: string | null
+  rank: number
+}
+
+type ExperienceKeywordRow = {
+  experience_id: number
+  slug: string
+  title: string | null
+  meta_description: string | null
+  rank: number
+}
+
+/**
+ * Full-text keyword search on experiences.title + meta_description using
+ * PostgreSQL tsvector/tsquery with locale-aware filtering.
+ *
+ * The tsvector expression matches the GIN index `experiences_fulltext_search_idx`
+ * created in `bootstrap/ensure-pgvector.ts`. Any change to the expression
+ * here must be mirrored there or the index will not be used.
+ *
+ * Experiences are localized entities — the `experiences.locale` column is a
+ * direct filter, no link-table chain. The `UNIQUE(experience_id, locale)`
+ * constraint on `experiences` (via Strapi i18n) means no DISTINCT ON is
+ * needed — at most one row per experience per locale.
+ *
+ * Image URL is `null` in v1 — see experience-semantic-search.ts for context.
+ */
+const EXPERIENCE_KEYWORD_SEARCH_SQL = `
+  SELECT
+    e.id AS experience_id,
+    e.slug,
+    e.title,
+    e.meta_description,
+    ts_rank(
+      to_tsvector('simple', coalesce(e.title, '') || ' ' || coalesce(e.meta_description, '')),
+      plainto_tsquery('simple', ?)
+    ) AS rank
+  FROM experiences e
+  WHERE to_tsvector('simple', coalesce(e.title, '') || ' ' || coalesce(e.meta_description, ''))
+    @@ plainto_tsquery('simple', ?)
+    AND e.locale = ?
+    AND e.published_at IS NOT NULL
+  ORDER BY rank DESC
+  LIMIT ?
+`
+
+function mapRow(row: ExperienceKeywordRow): ExperienceKeywordResult {
+  return {
+    resultType: "experience",
+    resultId: row.experience_id,
+    experienceId: row.experience_id,
+    experienceSlug: row.slug ?? "",
+    experienceTitle: row.title ?? "",
+    experienceMetaDescription: row.meta_description ?? null,
+    imageUrl: null,
+    rank: Number(row.rank),
+  }
+}
+
+/**
+ * Searches experiences by keyword using PostgreSQL full-text search.
+ *
+ * Returns an empty array for empty/whitespace-only queries (plainto_tsquery
+ * would produce an empty tsquery which matches nothing, but we short-circuit
+ * to avoid the round-trip).
+ */
+export async function searchByExperienceKeyword(
+  knex: KnexInstance,
+  params: ExperienceKeywordSearchParams,
+): Promise<ExperienceKeywordResult[]> {
+  const trimmed = params.query.trim()
+  if (trimmed.length === 0) {
+    return []
+  }
+
+  const result: { rows: ExperienceKeywordRow[] } = await knex.raw(
+    EXPERIENCE_KEYWORD_SEARCH_SQL,
+    [trimmed, trimmed, params.locale, params.limit],
+  )
+
+  return result.rows.map(mapRow)
+}

--- a/apps/cms/src/api/search/services/experience-keyword-search.ts
+++ b/apps/cms/src/api/search/services/experience-keyword-search.ts
@@ -35,9 +35,10 @@ type ExperienceKeywordRow = {
  * here must be mirrored there or the index will not be used.
  *
  * Experiences are localized entities — the `experiences.locale` column is a
- * direct filter, no link-table chain. The `UNIQUE(experience_id, locale)`
- * constraint on `experiences` (via Strapi i18n) means no DISTINCT ON is
- * needed — at most one row per experience per locale.
+ * direct filter, no link-table chain. Strapi i18n stores each locale of an
+ * experience as a separate row in `experiences` with a unique `id`, so at
+ * most one row per (logical experience, locale) is returned. No DISTINCT ON
+ * is needed.
  *
  * Image URL is `null` in v1 — see experience-semantic-search.ts for context.
  */

--- a/apps/cms/src/api/search/services/experience-semantic-search.test.ts
+++ b/apps/cms/src/api/search/services/experience-semantic-search.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest"
+import { searchByExperienceSemantic } from "./experience-semantic-search"
+
+/**
+ * Creates a mock knex instance whose `.raw()` records calls and returns
+ * the provided rows.
+ */
+function createMockKnex(rows: Record<string, unknown>[] = []) {
+  const raw = vi.fn(async () => ({ rows }))
+  return { raw, knex: { raw } }
+}
+
+function buildRow(overrides: Record<string, unknown> = {}) {
+  return {
+    experience_id: 1,
+    slug: "easter",
+    title: "Easter",
+    meta_description:
+      "Discover the true meaning of Easter through story and scripture.",
+    similarity: 0.9,
+    ...overrides,
+  }
+}
+
+const QUERY_EMBEDDING = "[0.1,0.2,0.3,0.4]"
+
+describe("searchByExperienceSemantic", () => {
+  it("returns mapped results from raw query", async () => {
+    const rows = [
+      buildRow({ experience_id: 1, title: "Easter", similarity: 0.95 }),
+      buildRow({ experience_id: 2, title: "Christmas", similarity: 0.7 }),
+    ]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toHaveLength(2)
+    expect(results[0]!.experienceTitle).toBe("Easter")
+    expect(results[0]!.similarity).toBe(0.95)
+    expect(results[1]!.experienceTitle).toBe("Christmas")
+    expect(results[1]!.similarity).toBe(0.7)
+  })
+
+  it("tags every result with resultType=experience and resultId=experienceId", async () => {
+    const rows = [buildRow({ experience_id: 7 })]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results[0]!.resultType).toBe("experience")
+    expect(results[0]!.resultId).toBe(7)
+    expect(results[0]!.experienceId).toBe(7)
+  })
+
+  it("passes correct parameters to knex.raw (embedding, locale, embedding, limit)", async () => {
+    const { knex, raw } = createMockKnex([])
+
+    await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "es",
+      limit: 25,
+    })
+
+    expect(raw).toHaveBeenCalledTimes(1)
+    const [sql, bindings] = raw.mock.calls[0]
+
+    // SQL should reference experience_embeddings, locale filter, and ?::vector.
+    expect(sql).toContain("experience_embeddings")
+    expect(sql).toContain("?::vector")
+    expect(sql).toContain("ee.locale = ?")
+    expect(sql).toContain("published_at IS NOT NULL")
+
+    // Bindings: [queryEmbedding, locale, queryEmbedding, limit]
+    // queryEmbedding appears twice (once for similarity calc, once for ORDER BY).
+    expect(bindings).toEqual([QUERY_EMBEDDING, "es", QUERY_EMBEDDING, 25])
+  })
+
+  it("returns empty array when no rows match", async () => {
+    const { knex } = createMockKnex([])
+
+    const results = await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toEqual([])
+  })
+
+  it("maps row fields correctly from snake_case to camelCase", async () => {
+    const rows = [
+      buildRow({
+        experience_id: 42,
+        slug: "sermon-on-the-mount",
+        title: "Sermon on the Mount",
+        meta_description: "An experience about the teachings of Jesus.",
+        similarity: 0.82,
+      }),
+    ]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toHaveLength(1)
+    const result = results[0]!
+    expect(result.experienceId).toBe(42)
+    expect(result.experienceSlug).toBe("sermon-on-the-mount")
+    expect(result.experienceTitle).toBe("Sermon on the Mount")
+    expect(result.experienceMetaDescription).toBe(
+      "An experience about the teachings of Jesus.",
+    )
+    expect(result.similarity).toBe(0.82)
+  })
+
+  it("handles null optional fields gracefully", async () => {
+    const rows = [
+      buildRow({
+        title: null,
+        meta_description: null,
+      }),
+    ]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results).toHaveLength(1)
+    const result = results[0]!
+    expect(result.experienceTitle).toBe("")
+    expect(result.experienceMetaDescription).toBeNull()
+  })
+
+  it("returns null for imageUrl in v1 (og_image join deferred)", async () => {
+    const { knex } = createMockKnex([buildRow()])
+
+    const results = await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(results[0]!.imageUrl).toBeNull()
+  })
+
+  it("converts similarity to number even if returned as string", async () => {
+    const rows = [
+      buildRow({
+        // PostgreSQL sometimes returns numeric types as strings via knex
+        similarity: "0.7531" as unknown as number,
+      }),
+    ]
+    const { knex } = createMockKnex(rows)
+
+    const results = await searchByExperienceSemantic(knex, {
+      queryEmbedding: QUERY_EMBEDDING,
+      locale: "en",
+      limit: 5,
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]!.similarity).toBe(0.7531)
+    expect(typeof results[0]!.similarity).toBe("number")
+  })
+})

--- a/apps/cms/src/api/search/services/experience-semantic-search.test.ts
+++ b/apps/cms/src/api/search/services/experience-semantic-search.test.ts
@@ -157,6 +157,22 @@ describe("searchByExperienceSemantic", () => {
     expect(results[0]!.imageUrl).toBeNull()
   })
 
+  it("propagates knex.raw rejections to the caller (no internal swallow)", async () => {
+    // The orchestrator wraps this in Promise.allSettled — the search
+    // function itself must let DB errors surface so they can be logged
+    // with the correct retrieval label.
+    const dbError = new Error("relation experience_embeddings does not exist")
+    const knex = { raw: vi.fn().mockRejectedValue(dbError) }
+
+    await expect(
+      searchByExperienceSemantic(knex, {
+        queryEmbedding: QUERY_EMBEDDING,
+        locale: "en",
+        limit: 10,
+      }),
+    ).rejects.toThrow("relation experience_embeddings does not exist")
+  })
+
   it("converts similarity to number even if returned as string", async () => {
     const rows = [
       buildRow({

--- a/apps/cms/src/api/search/services/experience-semantic-search.ts
+++ b/apps/cms/src/api/search/services/experience-semantic-search.ts
@@ -1,0 +1,91 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type KnexInstance = any
+
+export type ExperienceSemanticSearchParams = {
+  queryEmbedding: string // pgvector text format "[0.1,0.2,...]"
+  locale: string
+  limit: number
+}
+
+export type ExperienceSemanticResult = {
+  resultType: "experience"
+  resultId: number
+  experienceId: number
+  experienceSlug: string
+  experienceTitle: string
+  experienceMetaDescription: string | null
+  imageUrl: string | null
+  similarity: number
+}
+
+type ExperienceSemanticRow = {
+  experience_id: number
+  slug: string
+  title: string | null
+  meta_description: string | null
+  similarity: number
+}
+
+/**
+ * Per-query semantic similarity over experience-level embeddings.
+ *
+ * Unlike video semantic search, experiences are localized entities — the
+ * `experience_embeddings` table stores `locale` directly on the row, so
+ * locale filtering is a simple WHERE clause with no link-table chain.
+ *
+ * The `UNIQUE(experience_id, locale)` constraint on `experience_embeddings`
+ * guarantees one row per experience per locale, so no DISTINCT ON is needed.
+ *
+ * Image URL is `null` in v1 — the experience `og_image` field is a Strapi
+ * media relation requiring a multi-table join (`files_related_morphs` →
+ * `files`). Deferred to a follow-up if downstream consumers need it.
+ */
+const EXPERIENCE_SEMANTIC_SQL = `
+  SELECT
+    ee.experience_id,
+    e.slug,
+    e.title,
+    e.meta_description,
+    1 - (ee.embedding <=> ?::vector) AS similarity
+  FROM experience_embeddings ee
+  JOIN experiences e ON e.id = ee.experience_id
+    AND e.published_at IS NOT NULL
+  WHERE ee.locale = ?
+  ORDER BY ee.embedding <=> ?::vector
+  LIMIT ?
+`
+
+function mapRow(row: ExperienceSemanticRow): ExperienceSemanticResult {
+  return {
+    resultType: "experience",
+    resultId: row.experience_id,
+    experienceId: row.experience_id,
+    experienceSlug: row.slug ?? "",
+    experienceTitle: row.title ?? "",
+    experienceMetaDescription: row.meta_description ?? null,
+    imageUrl: null,
+    similarity: Number(row.similarity),
+  }
+}
+
+/**
+ * Queries experience_embeddings with a pre-computed query embedding vector
+ * via pgvector cosine similarity, returning the best-matching experiences
+ * for the requested locale.
+ *
+ * @param knex                    - Knex database connection instance
+ * @param params.queryEmbedding   - Embedding vector in pgvector text format "[0.1,0.2,...]"
+ * @param params.locale           - Locale code matching experience_embeddings.locale
+ * @param params.limit            - Maximum number of results to return
+ */
+export async function searchByExperienceSemantic(
+  knex: KnexInstance,
+  params: ExperienceSemanticSearchParams,
+): Promise<ExperienceSemanticResult[]> {
+  const result: { rows: ExperienceSemanticRow[] } = await knex.raw(
+    EXPERIENCE_SEMANTIC_SQL,
+    [params.queryEmbedding, params.locale, params.queryEmbedding, params.limit],
+  )
+
+  return result.rows.map(mapRow)
+}

--- a/apps/cms/src/api/search/services/experience-semantic-search.ts
+++ b/apps/cms/src/api/search/services/experience-semantic-search.ts
@@ -36,6 +36,16 @@ type ExperienceSemanticRow = {
  * The `UNIQUE(experience_id, locale)` constraint on `experience_embeddings`
  * guarantees one row per experience per locale, so no DISTINCT ON is needed.
  *
+ * Index strategy: per-locale partial HNSW indexes (created in
+ * `bootstrap/ensure-pgvector.ts`) are what make this query use HNSW instead
+ * of falling back to Seq Scan. The planner picks the partial index for the
+ * matching locale automatically — no SQL hints required. Connection-level
+ * `hnsw.iterative_scan = relaxed_order` (set in `config/database.ts`)
+ * lets the index return enough candidates to satisfy LIMIT past the default
+ * ef_search window. For locales without a partial index, the query falls
+ * back to the global HNSW (or Seq Scan if pgvector's planner cost model
+ * disagrees) — still functionally correct, just slower at scale.
+ *
  * Image URL is `null` in v1 — the experience `og_image` field is a Strapi
  * media relation requiring a multi-table join (`files_related_morphs` →
  * `files`). Deferred to a follow-up if downstream consumers need it.

--- a/apps/cms/src/api/search/services/fusion.test.ts
+++ b/apps/cms/src/api/search/services/fusion.test.ts
@@ -135,6 +135,8 @@ describe("fuseRankedLists", () => {
 
   it("merges properties with earlier lists taking priority", () => {
     const semanticItem: RankedItem = {
+      resultType: "video",
+      resultId: 1,
       videoId: 1,
       videoCoreId: "core-1",
       videoTitle: "Semantic Title",
@@ -143,6 +145,8 @@ describe("fuseRankedLists", () => {
       startSeconds: 42,
     }
     const keywordItem: RankedItem = {
+      resultType: "video",
+      resultId: 1,
       videoId: 1,
       videoCoreId: "core-1",
       videoTitle: "Keyword Title",
@@ -154,6 +158,9 @@ describe("fuseRankedLists", () => {
     const results = fuseRankedLists([[semanticItem], [keywordItem]], K)
 
     const video1 = results.find((r) => r.videoId === 1)!
+    // Compound identity preserved on the merged result
+    expect(video1.resultType).toBe("video")
+    expect(video1.resultId).toBe(1)
     // Earlier list (semantic) wins for overlapping keys
     expect(video1.videoTitle).toBe("Semantic Title")
     expect(video1.embeddingText).toBe("[0.1,0.2]")

--- a/apps/cms/src/api/search/services/fusion.test.ts
+++ b/apps/cms/src/api/search/services/fusion.test.ts
@@ -16,9 +16,25 @@ function item(
   overrides: Partial<RankedItem> = {},
 ): RankedItem {
   return {
+    resultType: "video",
+    resultId: videoId,
     videoId,
     videoCoreId: `core-${videoId}`,
     videoTitle: `Video ${videoId}`,
+    ...overrides,
+  }
+}
+
+function experienceItem(
+  experienceId: number,
+  overrides: Partial<RankedItem> = {},
+): RankedItem {
+  return {
+    resultType: "experience",
+    resultId: experienceId,
+    experienceId,
+    experienceSlug: `experience-${experienceId}`,
+    experienceTitle: `Experience ${experienceId}`,
     ...overrides,
   }
 }
@@ -169,6 +185,49 @@ describe("fuseRankedLists", () => {
     expect(withDefault[0].score).toBeCloseTo(withExplicit[0].score, 10)
     expect(withDefault[1].score).toBeCloseTo(withExplicit[1].score, 10)
   })
+
+  it("does not collide a video and an experience with the same integer ID", () => {
+    // Both have id=4 but different result types — the compound key must
+    // keep them distinct in the output.
+    const videoList = [item(4)]
+    const experienceList = [experienceItem(4)]
+
+    const results = fuseRankedLists([videoList, experienceList], K)
+
+    expect(results).toHaveLength(2)
+    const types = results.map((r) => r.resultType).sort()
+    expect(types).toEqual(["experience", "video"])
+  })
+
+  it("preserves resultType and resultId on fused results", () => {
+    const list = [item(1), experienceItem(2)]
+
+    const results = fuseRankedLists([list], K)
+
+    const video = results.find((r) => r.resultType === "video")!
+    const experience = results.find((r) => r.resultType === "experience")!
+    expect(video.resultId).toBe(1)
+    expect(experience.resultId).toBe(2)
+  })
+
+  it("fuses 4 lists (mixed video and experience) with correct normalization", () => {
+    const semanticVideos = [item(1)]
+    const keywordVideos = [item(1)]
+    const semanticExperiences = [experienceItem(10)]
+    const keywordExperiences = [experienceItem(10)]
+
+    const results = fuseRankedLists(
+      [semanticVideos, keywordVideos, semanticExperiences, keywordExperiences],
+      K,
+    )
+
+    // Both items appear in 2 of 4 lists at rank 1.
+    // raw = 2 * 1/61, theoreticalMax = 4/61, score = 2/4 = 0.5
+    expect(results).toHaveLength(2)
+    for (const r of results) {
+      expect(r.score).toBeCloseTo(0.5, 10)
+    }
+  })
 })
 
 /* ------------------------------------------------------------------ */
@@ -182,9 +241,27 @@ describe("deduplicateResults", () => {
     overrides: Partial<FusedResult> = {},
   ): FusedResult {
     return {
+      resultType: "video",
+      resultId: videoId,
       videoId,
       videoCoreId: `core-${videoId}`,
       videoTitle: `Video ${videoId}`,
+      score,
+      ...overrides,
+    }
+  }
+
+  function fusedExperience(
+    experienceId: number,
+    score: number,
+    overrides: Partial<FusedResult> = {},
+  ): FusedResult {
+    return {
+      resultType: "experience",
+      resultId: experienceId,
+      experienceId,
+      experienceSlug: `experience-${experienceId}`,
+      experienceTitle: `Experience ${experienceId}`,
       score,
       ...overrides,
     }
@@ -326,6 +403,64 @@ describe("deduplicateResults", () => {
     // No embeddingText — layer 3 is skipped, no crash
     const deduped = deduplicateResults(results, 10)
     expect(deduped).toHaveLength(2)
+  })
+
+  it("does not dedup an experience against a video with the same title", () => {
+    // The "Easter" experience and an "Easter" video are both legitimately
+    // relevant and should both survive — title collision across types is
+    // intentional, not duplication.
+    const results: FusedResult[] = [
+      fused(1, 0.9, { videoCoreId: "easter-1", videoTitle: "Easter" }),
+      fusedExperience(4, 0.8, { experienceTitle: "Easter" }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("does not collide a video and an experience with the same integer ID", () => {
+    const results: FusedResult[] = [fused(4, 0.9), fusedExperience(4, 0.8)]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("passes experience results through dedup unchanged", () => {
+    // Two experiences with similar metadata that would have triggered video
+    // dedup checks. They must both survive because dedup is video-only.
+    const results: FusedResult[] = [
+      fusedExperience(1, 0.9, { experienceTitle: "Easter" }),
+      fusedExperience(2, 0.8, { experienceTitle: "Easter" }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("still applies video dedup when video results are mixed with experiences", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.95, {
+        videoCoreId: "shared-prefix",
+        videoTitle: "Sermon",
+      }),
+      fusedExperience(10, 0.9),
+      fused(2, 0.85, {
+        videoCoreId: "shared-prefix-AD1x1",
+        videoTitle: "Sermon Variant",
+      }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    // Video 2 dropped (core_id prefix match with video 1). Experience 10 kept.
+    expect(deduped).toHaveLength(2)
+    expect(deduped.map((d) => `${d.resultType}:${d.resultId}`)).toEqual([
+      "video:1",
+      "experience:10",
+    ])
   })
 })
 

--- a/apps/cms/src/api/search/services/fusion.ts
+++ b/apps/cms/src/api/search/services/fusion.ts
@@ -1,16 +1,22 @@
 /**
  * Reciprocal Rank Fusion (RRF) and deduplication for hybrid search.
  *
- * RRF merges N ranked lists (semantic, keyword, and future personalization)
- * into a single scored list. The 3-layer dedup strategy is adapted from
- * the recommender service (core_id prefix, exact title, embedding cosine
- * similarity) to remove duplicate videos before pagination.
+ * RRF merges N ranked lists (video semantic, video keyword, experience
+ * semantic, experience keyword, and future personalization) into a single
+ * scored list. Items are identified by a compound `${resultType}:${resultId}`
+ * key so heterogeneous result types do not collide on shared integer IDs.
+ *
+ * The 3-layer dedup strategy is adapted from the recommender service
+ * (core_id prefix, exact title, embedding cosine similarity) and applies
+ * only to video results. Non-video results pass through unchanged.
  */
 
 export type RankedItem = {
-  videoId: number
-  videoCoreId: string | null
-  videoTitle: string
+  resultType: "video" | "experience"
+  resultId: number
+  videoId?: number
+  videoCoreId?: string | null
+  videoTitle?: string
   embeddingText?: string
   [key: string]: unknown
 }
@@ -45,25 +51,24 @@ export function fuseRankedLists(
 ): FusedResult[] {
   if (lists.length === 0) return []
 
-  // Accumulate RRF scores and collect properties per video
-  const scoreMap = new Map<number, number>()
-  const propsMap = new Map<number, RankedItem>()
+  // Accumulate RRF scores and collect properties per result.
+  // Compound key prevents cross-type ID collision (e.g. video 4 vs experience 4).
+  const scoreMap = new Map<string, number>()
+  const propsMap = new Map<string, RankedItem>()
 
   for (const list of lists) {
     for (let rank = 0; rank < list.length; rank++) {
       const item = list[rank]
+      const key = `${item.resultType}:${item.resultId}`
       const rank1Based = rank + 1
       const contribution = 1 / (k + rank1Based)
 
-      scoreMap.set(
-        item.videoId,
-        (scoreMap.get(item.videoId) ?? 0) + contribution,
-      )
+      scoreMap.set(key, (scoreMap.get(key) ?? 0) + contribution)
 
       // Merge properties — earlier lists take priority for overlapping keys
-      const existing = propsMap.get(item.videoId)
+      const existing = propsMap.get(key)
       if (existing == null) {
-        propsMap.set(item.videoId, { ...item })
+        propsMap.set(key, { ...item })
       } else {
         // Add keys from this item that don't already exist on the merged object
         for (const key of Object.keys(item)) {
@@ -79,11 +84,10 @@ export function fuseRankedLists(
   const theoreticalMax = lists.length / (k + 1)
 
   const results: FusedResult[] = []
-  scoreMap.forEach((rawScore, videoId) => {
-    const props = propsMap.get(videoId)!
+  scoreMap.forEach((rawScore, key) => {
+    const props = propsMap.get(key)!
     results.push({
       ...props,
-      videoId,
       score: theoreticalMax > 0 ? rawScore / theoreticalMax : 0,
     })
   })
@@ -107,6 +111,13 @@ export function fuseRankedLists(
  *    scene exists in multiple film series with different core_ids.
  * 3. Embedding similarity >0.95 — safety net for unlabeled near-duplicates.
  *
+ * All three strategies are video-specific. Non-video results (e.g.
+ * experiences) skip these checks and pass through unchanged — experiences
+ * have no `core_id`, cross-type title collisions are intentional ("Easter"
+ * the experience and "Easter" the video are both legitimately relevant),
+ * and cross-type embedding similarity is not a dedup concern. Within-type
+ * dedup for non-video result types can be added if future volume warrants.
+ *
  * The higher-scored result is always kept; the lower-scored duplicate is
  * discarded. Stops collecting once `limit` unique results are found.
  *
@@ -123,36 +134,43 @@ export function deduplicateResults(
     if (deduped.length >= limit) break
 
     let isDuplicate = false
-    for (const kept of deduped) {
-      // Check 1: core_id prefix match (ad-format variants)
-      if (candidate.videoCoreId && kept.videoCoreId) {
-        const a = candidate.videoCoreId
-        const b = kept.videoCoreId
-        if (a.startsWith(b) || b.startsWith(a)) {
+
+    // Video-specific dedup. Non-video results (e.g. experiences) skip the
+    // 3 checks below and only obey the limit cap.
+    if (candidate.resultType === "video") {
+      for (const kept of deduped) {
+        if (kept.resultType !== "video") continue
+
+        // Check 1: core_id prefix match (ad-format variants)
+        if (candidate.videoCoreId && kept.videoCoreId) {
+          const a = candidate.videoCoreId
+          const b = kept.videoCoreId
+          if (a.startsWith(b) || b.startsWith(a)) {
+            isDuplicate = true
+            break
+          }
+        }
+
+        // Check 2: exact title match (cross-series same scene)
+        if (
+          candidate.videoTitle &&
+          kept.videoTitle &&
+          candidate.videoTitle === kept.videoTitle
+        ) {
           isDuplicate = true
           break
         }
-      }
 
-      // Check 2: exact title match (cross-series same scene)
-      if (
-        candidate.videoTitle &&
-        kept.videoTitle &&
-        candidate.videoTitle === kept.videoTitle
-      ) {
-        isDuplicate = true
-        break
-      }
-
-      // Check 3: embedding similarity (safety net for unlabeled duplicates)
-      if (candidate.embeddingText && kept.embeddingText) {
-        const sim = cosineSimilarityFromText(
-          candidate.embeddingText,
-          kept.embeddingText,
-        )
-        if (sim > 0.95) {
-          isDuplicate = true
-          break
+        // Check 3: embedding similarity (safety net for unlabeled duplicates)
+        if (candidate.embeddingText && kept.embeddingText) {
+          const sim = cosineSimilarityFromText(
+            candidate.embeddingText,
+            kept.embeddingText,
+          )
+          if (sim > 0.95) {
+            isDuplicate = true
+            break
+          }
         }
       }
     }

--- a/apps/cms/src/api/search/services/fusion.ts
+++ b/apps/cms/src/api/search/services/fusion.ts
@@ -70,10 +70,11 @@ export function fuseRankedLists(
       if (existing == null) {
         propsMap.set(key, { ...item })
       } else {
-        // Add keys from this item that don't already exist on the merged object
-        for (const key of Object.keys(item)) {
-          if (!(key in existing) || existing[key] == null) {
-            existing[key] = item[key]
+        // Add keys from this item that don't already exist on the merged object.
+        // Use `propKey` to avoid shadowing the outer compound `key` variable.
+        for (const propKey of Object.keys(item)) {
+          if (!(propKey in existing) || existing[propKey] == null) {
+            existing[propKey] = item[propKey]
           }
         }
       }

--- a/apps/cms/src/api/search/services/search.test.ts
+++ b/apps/cms/src/api/search/services/search.test.ts
@@ -12,6 +12,14 @@ vi.mock("./keyword-search", () => ({
   searchByKeyword: vi.fn(),
 }))
 
+vi.mock("./experience-semantic-search", () => ({
+  searchByExperienceSemantic: vi.fn(),
+}))
+
+vi.mock("./experience-keyword-search", () => ({
+  searchByExperienceKeyword: vi.fn(),
+}))
+
 vi.mock("./fusion", () => ({
   fuseRankedLists: vi.fn(),
   deduplicateResults: vi.fn(),
@@ -20,6 +28,8 @@ vi.mock("./fusion", () => ({
 import { embedQuery } from "../../../lib/openrouter"
 import { searchBySemantic } from "./semantic-search"
 import { searchByKeyword } from "./keyword-search"
+import { searchByExperienceSemantic } from "./experience-semantic-search"
+import { searchByExperienceKeyword } from "./experience-keyword-search"
 import { fuseRankedLists, deduplicateResults } from "./fusion"
 import { search } from "./search"
 
@@ -32,6 +42,21 @@ const mockStrapi = {
   db: { connection: mockKnex },
   log: { warn: logWarn, error: logError },
 } as unknown as Parameters<typeof search>[0]
+
+/**
+ * Default empty-mock setup for all retrievals + fusion + dedup. Tests that
+ * exercise just one slice of the pipeline can call this and only override
+ * the mocks they care about.
+ */
+function setupDefaultMocks() {
+  vi.mocked(embedQuery).mockResolvedValue([0.1])
+  vi.mocked(searchBySemantic).mockResolvedValue([])
+  vi.mocked(searchByKeyword).mockResolvedValue([])
+  vi.mocked(searchByExperienceSemantic).mockResolvedValue([])
+  vi.mocked(searchByExperienceKeyword).mockResolvedValue([])
+  vi.mocked(fuseRankedLists).mockReturnValue([])
+  vi.mocked(deduplicateResults).mockReturnValue([])
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -68,8 +93,12 @@ describe("search", () => {
         rank: 0.5,
       },
     ])
+    vi.mocked(searchByExperienceSemantic).mockResolvedValue([])
+    vi.mocked(searchByExperienceKeyword).mockResolvedValue([])
     vi.mocked(fuseRankedLists).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 1,
         videoId: 1,
         videoSlug: "video-one",
         videoTitle: "Video One",
@@ -82,6 +111,8 @@ describe("search", () => {
         score: 0.95,
       },
       {
+        resultType: "video",
+        resultId: 2,
         videoId: 2,
         videoSlug: "video-two",
         videoTitle: "Video Two",
@@ -93,6 +124,8 @@ describe("search", () => {
     ])
     vi.mocked(deduplicateResults).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 1,
         videoId: 1,
         videoSlug: "video-one",
         videoTitle: "Video One",
@@ -105,6 +138,8 @@ describe("search", () => {
         score: 0.95,
       },
       {
+        resultType: "video",
+        resultId: 2,
         videoId: 2,
         videoSlug: "video-two",
         videoTitle: "Video Two",
@@ -123,7 +158,7 @@ describe("search", () => {
     // Verify embedding was generated
     expect(embedQuery).toHaveBeenCalledWith("forgiveness")
 
-    // Verify both retrievals were called with overfetch (20 * 3 = 60)
+    // Verify both video retrievals were called with overfetch (20 * 3 = 60)
     expect(searchBySemantic).toHaveBeenCalledWith(mockKnex, {
       queryEmbedding: "[0.1,0.2,0.3]",
       locale: "en",
@@ -135,11 +170,9 @@ describe("search", () => {
       limit: 60,
     })
 
-    // Verify fusion was called with both result lists
-    expect(fuseRankedLists).toHaveBeenCalledWith(
-      [expect.any(Array), expect.any(Array)],
-      60,
-    )
+    // Default contentTypes also fires experience retrievals
+    expect(searchByExperienceSemantic).toHaveBeenCalled()
+    expect(searchByExperienceKeyword).toHaveBeenCalled()
 
     // Verify dedup was called with offset + limit + 1 (extra for hasMore)
     expect(deduplicateResults).toHaveBeenCalledWith(expect.any(Array), 21)
@@ -162,11 +195,7 @@ describe("search", () => {
   })
 
   it("clamps limit to MAX_LIMIT (50)", async () => {
-    vi.mocked(embedQuery).mockResolvedValue([0.1])
-    vi.mocked(searchBySemantic).mockResolvedValue([])
-    vi.mocked(searchByKeyword).mockResolvedValue([])
-    vi.mocked(fuseRankedLists).mockReturnValue([])
-    vi.mocked(deduplicateResults).mockReturnValue([])
+    setupDefaultMocks()
 
     await search(mockStrapi, {
       query: "test",
@@ -182,11 +211,7 @@ describe("search", () => {
   })
 
   it("clamps limit minimum to 1", async () => {
-    vi.mocked(embedQuery).mockResolvedValue([0.1])
-    vi.mocked(searchBySemantic).mockResolvedValue([])
-    vi.mocked(searchByKeyword).mockResolvedValue([])
-    vi.mocked(fuseRankedLists).mockReturnValue([])
-    vi.mocked(deduplicateResults).mockReturnValue([])
+    setupDefaultMocks()
 
     await search(mockStrapi, {
       query: "test",
@@ -202,24 +227,27 @@ describe("search", () => {
   })
 
   it("applies offset for pagination", async () => {
-    vi.mocked(embedQuery).mockResolvedValue([0.1])
-    vi.mocked(searchBySemantic).mockResolvedValue([])
-    vi.mocked(searchByKeyword).mockResolvedValue([])
-    vi.mocked(fuseRankedLists).mockReturnValue([])
+    setupDefaultMocks()
     vi.mocked(deduplicateResults).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 1,
         videoId: 1,
         videoTitle: "A",
         videoCoreId: null,
         score: 0.9,
       },
       {
+        resultType: "video",
+        resultId: 2,
         videoId: 2,
         videoTitle: "B",
         videoCoreId: null,
         score: 0.8,
       },
       {
+        resultType: "video",
+        resultId: 3,
         videoId: 3,
         videoTitle: "C",
         videoCoreId: null,
@@ -246,16 +274,33 @@ describe("search", () => {
   })
 
   it("sets hasMore when dedup returns more than offset + limit", async () => {
-    vi.mocked(embedQuery).mockResolvedValue([0.1])
-    vi.mocked(searchBySemantic).mockResolvedValue([])
-    vi.mocked(searchByKeyword).mockResolvedValue([])
-    vi.mocked(fuseRankedLists).mockReturnValue([])
+    setupDefaultMocks()
     // Dedup returns 3 items when we asked for offset+limit+1 = 3 (limit=2, offset=0)
-    // Actually the dedup limit is 3, so if it returns exactly 3 we know there's more
     vi.mocked(deduplicateResults).mockReturnValue([
-      { videoId: 1, videoTitle: "A", videoCoreId: null, score: 0.9 },
-      { videoId: 2, videoTitle: "B", videoCoreId: null, score: 0.8 },
-      { videoId: 3, videoTitle: "C", videoCoreId: null, score: 0.7 },
+      {
+        resultType: "video",
+        resultId: 1,
+        videoId: 1,
+        videoTitle: "A",
+        videoCoreId: null,
+        score: 0.9,
+      },
+      {
+        resultType: "video",
+        resultId: 2,
+        videoId: 2,
+        videoTitle: "B",
+        videoCoreId: null,
+        score: 0.8,
+      },
+      {
+        resultType: "video",
+        resultId: 3,
+        videoId: 3,
+        videoTitle: "C",
+        videoCoreId: null,
+        score: 0.7,
+      },
     ])
 
     const result = await search(mockStrapi, {
@@ -270,11 +315,7 @@ describe("search", () => {
   })
 
   it("returns empty results when both retrievals return nothing", async () => {
-    vi.mocked(embedQuery).mockResolvedValue([0.1])
-    vi.mocked(searchBySemantic).mockResolvedValue([])
-    vi.mocked(searchByKeyword).mockResolvedValue([])
-    vi.mocked(fuseRankedLists).mockReturnValue([])
-    vi.mocked(deduplicateResults).mockReturnValue([])
+    setupDefaultMocks()
 
     const result = await search(mockStrapi, {
       query: "nonexistent",
@@ -290,6 +331,7 @@ describe("search", () => {
     vi.mocked(embedQuery).mockRejectedValue(
       new Error("OPENROUTER_API_KEY is not set"),
     )
+    vi.mocked(searchBySemantic).mockResolvedValue([])
     vi.mocked(searchByKeyword).mockResolvedValue([
       {
         videoId: 10,
@@ -301,8 +343,12 @@ describe("search", () => {
         rank: 0.5,
       },
     ])
+    vi.mocked(searchByExperienceSemantic).mockResolvedValue([])
+    vi.mocked(searchByExperienceKeyword).mockResolvedValue([])
     vi.mocked(fuseRankedLists).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 10,
         videoId: 10,
         videoSlug: "found",
         videoTitle: "Found",
@@ -314,6 +360,8 @@ describe("search", () => {
     ])
     vi.mocked(deduplicateResults).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 10,
         videoId: 10,
         videoSlug: "found",
         videoTitle: "Found",
@@ -328,8 +376,11 @@ describe("search", () => {
 
     // Keyword search still ran
     expect(searchByKeyword).toHaveBeenCalled()
-    // Semantic search was skipped (no embedding available)
+    // Semantic searches were skipped (no embedding available)
     expect(searchBySemantic).not.toHaveBeenCalled()
+    expect(searchByExperienceSemantic).not.toHaveBeenCalled()
+    // Experience keyword search still ran (no embedding dependency)
+    expect(searchByExperienceKeyword).toHaveBeenCalled()
     // Results still returned
     expect(result.results).toHaveLength(1)
     expect(result.results[0]!.id).toBe(10)
@@ -349,8 +400,12 @@ describe("search", () => {
         rank: 0.4,
       },
     ])
+    vi.mocked(searchByExperienceSemantic).mockResolvedValue([])
+    vi.mocked(searchByExperienceKeyword).mockResolvedValue([])
     vi.mocked(fuseRankedLists).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 20,
         videoId: 20,
         videoSlug: "keyword-only",
         videoTitle: "Keyword Only",
@@ -362,6 +417,8 @@ describe("search", () => {
     ])
     vi.mocked(deduplicateResults).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 20,
         videoId: 20,
         videoSlug: "keyword-only",
         videoTitle: "Keyword Only",
@@ -379,10 +436,16 @@ describe("search", () => {
     expect(result.results[0]!.id).toBe(20)
   })
 
-  it("returns empty results gracefully when both retrievals reject", async () => {
+  it("returns empty results gracefully when all retrievals reject", async () => {
     vi.mocked(embedQuery).mockResolvedValue([0.1])
     vi.mocked(searchBySemantic).mockRejectedValue(new Error("pgvector down"))
     vi.mocked(searchByKeyword).mockRejectedValue(
+      new Error("connection pool exhausted"),
+    )
+    vi.mocked(searchByExperienceSemantic).mockRejectedValue(
+      new Error("pgvector down"),
+    )
+    vi.mocked(searchByExperienceKeyword).mockRejectedValue(
       new Error("connection pool exhausted"),
     )
     vi.mocked(fuseRankedLists).mockReturnValue([])
@@ -393,18 +456,17 @@ describe("search", () => {
     // Total failure doesn't throw — degrades to empty result set
     expect(result.results).toEqual([])
     expect(result.hasMore).toBe(false)
-    // Both failures are logged for operational visibility
-    expect(logError.mock.calls.length).toBeGreaterThanOrEqual(2)
+    // All four failures are logged for operational visibility
+    expect(logError.mock.calls.length).toBeGreaterThanOrEqual(4)
   })
 
   it("maps keyword-only results with null startSeconds and playbackId", async () => {
-    vi.mocked(embedQuery).mockResolvedValue([0.1])
-    vi.mocked(searchBySemantic).mockResolvedValue([])
-    vi.mocked(searchByKeyword).mockResolvedValue([])
-    vi.mocked(fuseRankedLists).mockReturnValue([])
+    setupDefaultMocks()
     // A keyword-only result has no startSeconds or playbackId
     vi.mocked(deduplicateResults).mockReturnValue([
       {
+        resultType: "video",
+        resultId: 30,
         videoId: 30,
         videoSlug: "keyword-video",
         videoTitle: "Keyword Video",
@@ -420,5 +482,273 @@ describe("search", () => {
     // Null signals "no scene-level match" — client must handle missing data
     expect(result.results[0]!.startSeconds).toBeNull()
     expect(result.results[0]!.playbackId).toBeNull()
+  })
+
+  /* ---------------------------------------------------------------- */
+  /*  Content type filter                                              */
+  /* ---------------------------------------------------------------- */
+
+  describe("contentTypes filter", () => {
+    it("fires only video retrievals when contentTypes=['video']", async () => {
+      setupDefaultMocks()
+
+      await search(mockStrapi, {
+        query: "test",
+        locale: "en",
+        contentTypes: ["video"],
+      })
+
+      expect(searchBySemantic).toHaveBeenCalled()
+      expect(searchByKeyword).toHaveBeenCalled()
+      expect(searchByExperienceSemantic).not.toHaveBeenCalled()
+      expect(searchByExperienceKeyword).not.toHaveBeenCalled()
+    })
+
+    it("fires only experience retrievals when contentTypes=['experience']", async () => {
+      setupDefaultMocks()
+
+      await search(mockStrapi, {
+        query: "test",
+        locale: "en",
+        contentTypes: ["experience"],
+      })
+
+      expect(searchBySemantic).not.toHaveBeenCalled()
+      expect(searchByKeyword).not.toHaveBeenCalled()
+      expect(searchByExperienceSemantic).toHaveBeenCalled()
+      expect(searchByExperienceKeyword).toHaveBeenCalled()
+    })
+
+    it("fires all four retrievals when contentTypes is omitted", async () => {
+      setupDefaultMocks()
+
+      await search(mockStrapi, { query: "test", locale: "en" })
+
+      expect(searchBySemantic).toHaveBeenCalled()
+      expect(searchByKeyword).toHaveBeenCalled()
+      expect(searchByExperienceSemantic).toHaveBeenCalled()
+      expect(searchByExperienceKeyword).toHaveBeenCalled()
+    })
+
+    it("fires all four retrievals when contentTypes=['video','experience']", async () => {
+      setupDefaultMocks()
+
+      await search(mockStrapi, {
+        query: "test",
+        locale: "en",
+        contentTypes: ["video", "experience"],
+      })
+
+      expect(searchBySemantic).toHaveBeenCalled()
+      expect(searchByKeyword).toHaveBeenCalled()
+      expect(searchByExperienceSemantic).toHaveBeenCalled()
+      expect(searchByExperienceKeyword).toHaveBeenCalled()
+    })
+
+    it("falls back to all types when contentTypes is an empty array", async () => {
+      setupDefaultMocks()
+
+      await search(mockStrapi, {
+        query: "test",
+        locale: "en",
+        contentTypes: [],
+      })
+
+      expect(searchBySemantic).toHaveBeenCalled()
+      expect(searchByExperienceSemantic).toHaveBeenCalled()
+    })
+  })
+
+  /* ---------------------------------------------------------------- */
+  /*  RRF score dilution prevention                                    */
+  /* ---------------------------------------------------------------- */
+
+  describe("empty list filtering before fusion", () => {
+    it("does not pass empty result lists to fuseRankedLists", async () => {
+      vi.mocked(embedQuery).mockResolvedValue([0.1])
+      vi.mocked(searchBySemantic).mockResolvedValue([
+        {
+          videoId: 1,
+          videoSlug: "v",
+          videoTitle: "V",
+          videoCoreId: null,
+          imageUrl: null,
+          sceneIndex: 0,
+          description: "d",
+          startSeconds: 0,
+          playbackId: "p",
+          similarity: 0.9,
+          embeddingText: "[0.1]",
+        },
+      ])
+      vi.mocked(searchByKeyword).mockResolvedValue([])
+      vi.mocked(searchByExperienceSemantic).mockResolvedValue([])
+      vi.mocked(searchByExperienceKeyword).mockResolvedValue([])
+      vi.mocked(fuseRankedLists).mockReturnValue([])
+      vi.mocked(deduplicateResults).mockReturnValue([])
+
+      await search(mockStrapi, { query: "test", locale: "en" })
+
+      // Only the non-empty list should reach fusion. RRF normalization
+      // divides by the input list count, so feeding empty lists would
+      // dilute the score from the one list that did contribute.
+      expect(fuseRankedLists).toHaveBeenCalledWith(
+        [expect.arrayContaining([expect.objectContaining({ videoId: 1 })])],
+        60,
+      )
+      const passedLists = vi.mocked(fuseRankedLists).mock.calls[0]![0]
+      expect(passedLists).toHaveLength(1)
+    })
+  })
+
+  /* ---------------------------------------------------------------- */
+  /*  Mixed video + experience results                                 */
+  /* ---------------------------------------------------------------- */
+
+  describe("mixed result types", () => {
+    it("annotates video results with resultType/resultId before fusion", async () => {
+      setupDefaultMocks()
+      vi.mocked(searchBySemantic).mockResolvedValue([
+        {
+          videoId: 99,
+          videoSlug: "v99",
+          videoTitle: "V99",
+          videoCoreId: "c99",
+          imageUrl: null,
+          sceneIndex: 0,
+          description: "d",
+          startSeconds: 0,
+          playbackId: "p",
+          similarity: 0.9,
+          embeddingText: "[0.1]",
+        },
+      ])
+
+      await search(mockStrapi, {
+        query: "test",
+        locale: "en",
+        contentTypes: ["video"],
+      })
+
+      const passedLists = vi.mocked(fuseRankedLists).mock.calls[0]![0]
+      const semanticList = passedLists[0]!
+      expect(semanticList[0]).toMatchObject({
+        resultType: "video",
+        resultId: 99,
+        videoId: 99,
+      })
+    })
+
+    it("maps experience results to the SearchResult contract", async () => {
+      setupDefaultMocks()
+      vi.mocked(deduplicateResults).mockReturnValue([
+        {
+          resultType: "experience",
+          resultId: 4,
+          experienceId: 4,
+          experienceSlug: "easter",
+          experienceTitle: "Easter",
+          experienceMetaDescription:
+            "Discover the meaning of Easter through scripture.",
+          imageUrl: null,
+          score: 0.92,
+        },
+      ])
+
+      const result = await search(mockStrapi, {
+        query: "Easter",
+        locale: "en",
+      })
+
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]).toEqual({
+        type: "experience",
+        id: 4,
+        slug: "easter",
+        title: "Easter",
+        imageUrl: null,
+        snippet: "Discover the meaning of Easter through scripture.",
+        startSeconds: null,
+        playbackId: null,
+        score: 0.92,
+      })
+    })
+
+    it("returns mixed video and experience results in score order", async () => {
+      setupDefaultMocks()
+      vi.mocked(deduplicateResults).mockReturnValue([
+        {
+          resultType: "experience",
+          resultId: 4,
+          experienceId: 4,
+          experienceSlug: "easter",
+          experienceTitle: "Easter",
+          experienceMetaDescription: "Easter snippet",
+          imageUrl: null,
+          score: 0.96,
+        },
+        {
+          resultType: "video",
+          resultId: 7,
+          videoId: 7,
+          videoSlug: "easter-video",
+          videoTitle: "Easter Video",
+          videoCoreId: "ev",
+          imageUrl: null,
+          description: "video snippet",
+          startSeconds: 12,
+          playbackId: "px",
+          score: 0.81,
+        },
+      ])
+
+      const result = await search(mockStrapi, {
+        query: "Easter",
+        locale: "en",
+      })
+
+      expect(result.results.map((r) => r.type)).toEqual(["experience", "video"])
+      expect(result.results[0]!.id).toBe(4)
+      expect(result.results[1]!.id).toBe(7)
+    })
+
+    it("preserves both results when video id and experience id collide", async () => {
+      setupDefaultMocks()
+      // Same integer id on both — the orchestrator must not collapse them.
+      vi.mocked(deduplicateResults).mockReturnValue([
+        {
+          resultType: "video",
+          resultId: 4,
+          videoId: 4,
+          videoSlug: "v4",
+          videoTitle: "Video 4",
+          videoCoreId: "c4",
+          imageUrl: null,
+          description: "video 4",
+          startSeconds: 0,
+          playbackId: "p4",
+          score: 0.9,
+        },
+        {
+          resultType: "experience",
+          resultId: 4,
+          experienceId: 4,
+          experienceSlug: "exp-4",
+          experienceTitle: "Experience 4",
+          experienceMetaDescription: "experience 4",
+          imageUrl: null,
+          score: 0.85,
+        },
+      ])
+
+      const result = await search(mockStrapi, {
+        query: "test",
+        locale: "en",
+      })
+
+      expect(result.results).toHaveLength(2)
+      expect(result.results[0]).toMatchObject({ type: "video", id: 4 })
+      expect(result.results[1]).toMatchObject({ type: "experience", id: 4 })
+    })
   })
 })

--- a/apps/cms/src/api/search/services/search.test.ts
+++ b/apps/cms/src/api/search/services/search.test.ts
@@ -557,6 +557,70 @@ describe("search", () => {
       expect(searchBySemantic).toHaveBeenCalled()
       expect(searchByExperienceSemantic).toHaveBeenCalled()
     })
+
+    it("with contentTypes=['experience'] and embedQuery failure, only experience keyword runs", async () => {
+      // Combined degradation: experience-only filter + OpenRouter outage.
+      // Should fall back to a single experience-keyword retrieval. Fusion
+      // receives exactly one non-empty list.
+      vi.mocked(embedQuery).mockRejectedValue(new Error("OpenRouter down"))
+      vi.mocked(searchByExperienceKeyword).mockResolvedValue([
+        {
+          resultType: "experience",
+          resultId: 4,
+          experienceId: 4,
+          experienceSlug: "easter",
+          experienceTitle: "Easter",
+          experienceMetaDescription: "Easter snippet",
+          imageUrl: null,
+          rank: 0.5,
+        },
+      ])
+      vi.mocked(fuseRankedLists).mockReturnValue([
+        {
+          resultType: "experience",
+          resultId: 4,
+          experienceId: 4,
+          experienceSlug: "easter",
+          experienceTitle: "Easter",
+          experienceMetaDescription: "Easter snippet",
+          imageUrl: null,
+          score: 1.0,
+        },
+      ])
+      vi.mocked(deduplicateResults).mockReturnValue([
+        {
+          resultType: "experience",
+          resultId: 4,
+          experienceId: 4,
+          experienceSlug: "easter",
+          experienceTitle: "Easter",
+          experienceMetaDescription: "Easter snippet",
+          imageUrl: null,
+          score: 1.0,
+        },
+      ])
+
+      const result = await search(mockStrapi, {
+        query: "Easter",
+        locale: "en",
+        contentTypes: ["experience"],
+      })
+
+      // Only experience keyword fired
+      expect(searchByExperienceKeyword).toHaveBeenCalled()
+      expect(searchByExperienceSemantic).not.toHaveBeenCalled()
+      expect(searchBySemantic).not.toHaveBeenCalled()
+      expect(searchByKeyword).not.toHaveBeenCalled()
+
+      // Fusion received exactly one non-empty list
+      const passedLists = vi.mocked(fuseRankedLists).mock.calls[0]![0]
+      expect(passedLists).toHaveLength(1)
+
+      // Result reaches the client
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]!.type).toBe("experience")
+      expect(result.results[0]!.id).toBe(4)
+    })
   })
 
   /* ---------------------------------------------------------------- */
@@ -641,6 +705,8 @@ describe("search", () => {
 
     it("maps experience results to the SearchResult contract", async () => {
       setupDefaultMocks()
+      // Use a score that exercises the 3-decimal rounding in
+      // mapToSearchResult — proves the round() isn't accidentally a no-op.
       vi.mocked(deduplicateResults).mockReturnValue([
         {
           resultType: "experience",
@@ -651,7 +717,7 @@ describe("search", () => {
           experienceMetaDescription:
             "Discover the meaning of Easter through scripture.",
           imageUrl: null,
-          score: 0.92,
+          score: 0.9234567,
         },
       ])
 
@@ -670,7 +736,7 @@ describe("search", () => {
         snippet: "Discover the meaning of Easter through scripture.",
         startSeconds: null,
         playbackId: null,
-        score: 0.92,
+        score: 0.923,
       })
     })
 

--- a/apps/cms/src/api/search/services/search.ts
+++ b/apps/cms/src/api/search/services/search.ts
@@ -17,7 +17,17 @@ const RRF_K = 60
 
 export type ContentType = "video" | "experience"
 
-const ALL_CONTENT_TYPES: readonly ContentType[] = ["video", "experience"]
+export const ALL_CONTENT_TYPES: readonly ContentType[] = ["video", "experience"]
+
+/**
+ * Type guard for the optional `type` query/argument value at the API
+ * boundary. Lives here (alongside `ContentType`) so REST and GraphQL share
+ * a single source of truth — adding a new content type only requires
+ * updating the union and this array.
+ */
+export function isContentType(value: string): value is ContentType {
+  return (ALL_CONTENT_TYPES as readonly string[]).includes(value)
+}
 
 export type SearchParams = {
   query: string

--- a/apps/cms/src/api/search/services/search.ts
+++ b/apps/cms/src/api/search/services/search.ts
@@ -1,9 +1,11 @@
 import type { Core } from "@strapi/strapi"
 import { embedQuery } from "../../../lib/openrouter"
+import { searchByExperienceKeyword } from "./experience-keyword-search"
+import { searchByExperienceSemantic } from "./experience-semantic-search"
 import { searchByKeyword } from "./keyword-search"
 import { searchBySemantic } from "./semantic-search"
 import { fuseRankedLists, deduplicateResults } from "./fusion"
-import type { FusedResult } from "./fusion"
+import type { FusedResult, RankedItem } from "./fusion"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type KnexInstance = any
@@ -13,23 +15,33 @@ const DEFAULT_LIMIT = 20
 const OVERFETCH_FACTOR = 3
 const RRF_K = 60
 
+export type ContentType = "video" | "experience"
+
+const ALL_CONTENT_TYPES: readonly ContentType[] = ["video", "experience"]
+
 export type SearchParams = {
   query: string
   locale: string
   limit?: number
   offset?: number
+  /**
+   * Restrict results to the given content types. Omit (or pass undefined)
+   * to search both videos and experiences. Passing an empty array also
+   * defaults to both, since "no results" is rarely the caller's intent.
+   */
+  contentTypes?: ContentType[]
 }
 
 export type SearchResult = {
-  type: "video"
+  type: ContentType
   id: number
   slug: string
   title: string
   imageUrl: string | null
   snippet: string
-  /** null when the match is keyword-only (no scene-level timestamp) */
+  /** null when the match is keyword-only or for non-video results */
   startSeconds: number | null
-  /** null when the match is keyword-only (no scene-level Mux asset) */
+  /** null when the match is keyword-only or for non-video results */
   playbackId: string | null
   score: number
 }
@@ -51,18 +63,33 @@ function toPgvectorText(embedding: number[]): string {
 /**
  * Maps a fused result to the API response contract.
  *
- * Semantic results carry scene-level data (description as snippet,
- * startSeconds, playbackId). Keyword-only results fall back to the
- * video description for snippet and return null for startSeconds and
- * playbackId — clients must check for null before constructing a Mux
- * deep-link URL or rendering a scene thumbnail.
+ * Video results carry scene-level data (description as snippet, startSeconds,
+ * playbackId for semantic matches; nullable for keyword-only matches).
+ * Experience results carry experience-level data (meta_description as
+ * snippet) and always have null startSeconds/playbackId. Clients must
+ * check for null before constructing a Mux deep-link URL or rendering a
+ * scene thumbnail.
  */
 function mapToSearchResult(result: FusedResult): SearchResult {
+  if (result.resultType === "experience") {
+    return {
+      type: "experience",
+      id: result.resultId,
+      slug: (result.experienceSlug as string) ?? "",
+      title: (result.experienceTitle as string) ?? "",
+      imageUrl: (result.imageUrl as string | null) ?? null,
+      snippet: (result.experienceMetaDescription as string | null) ?? "",
+      startSeconds: null,
+      playbackId: null,
+      score: Math.round(result.score * 1000) / 1000,
+    }
+  }
+
   const startSeconds = result.startSeconds
   const playbackId = result.playbackId
   return {
     type: "video",
-    id: result.videoId,
+    id: result.resultId,
     slug: (result.videoSlug as string) ?? "",
     title: result.videoTitle ?? "",
     imageUrl: (result.imageUrl as string | null) ?? null,
@@ -76,17 +103,33 @@ function mapToSearchResult(result: FusedResult): SearchResult {
 }
 
 /**
+ * Annotates a video search result (from semantic-search.ts or keyword-search.ts)
+ * with the compound identity key required by the fusion layer. This keeps
+ * the existing video search functions agnostic of the multi-type result
+ * model — the orchestrator owns the wiring.
+ */
+function annotateVideo<T extends { videoId: number }>(item: T): T & RankedItem {
+  return {
+    ...item,
+    resultType: "video",
+    resultId: item.videoId,
+  }
+}
+
+/**
  * Hybrid search orchestrator.
  *
  * 1. Embed the user's query via OpenRouter. On failure, degrade to
  *    keyword-only search instead of returning 503 — keyword search has
  *    no external dependencies and is valuable on its own.
- * 2. Run semantic (pgvector) and keyword (tsvector) retrieval in parallel
- *    with Promise.allSettled so one retrieval failing does not discard
- *    the other's successful results.
- * 3. Merge via Reciprocal Rank Fusion (single-list fusion if semantic
- *    degraded to empty).
- * 4. Deduplicate (3-layer: core_id, title, embedding similarity).
+ * 2. Run retrieval in parallel based on `contentTypes` — up to 4 lists
+ *    (video semantic, video keyword, experience semantic, experience
+ *    keyword) via Promise.allSettled, so one retrieval failing does not
+ *    discard the others.
+ * 3. Merge via Reciprocal Rank Fusion. Empty result lists are filtered
+ *    out before fusion — passing them dilutes the RRF normalization
+ *    (which divides by N for N input lists).
+ * 4. Deduplicate (3-layer for videos; experiences pass through).
  * 5. Paginate with hasMore signal (dedup one extra to detect overflow).
  */
 export async function search(
@@ -98,6 +141,15 @@ export async function search(
   const offset = Math.max(0, params.offset ?? 0)
   const knex: KnexInstance = strapi.db.connection
   const overfetchLimit = limit * OVERFETCH_FACTOR
+
+  // Resolve which content types to search. Empty array falls back to all
+  // types (no caller realistically wants "search nothing").
+  const requested =
+    params.contentTypes != null && params.contentTypes.length > 0
+      ? params.contentTypes
+      : ALL_CONTENT_TYPES
+  const wantsVideos = requested.includes("video")
+  const wantsExperiences = requested.includes("experience")
 
   // Step 1: Embed the user's query. Degrade gracefully if OpenRouter is
   // unavailable — keyword search alone still returns useful results.
@@ -115,26 +167,68 @@ export async function search(
 
   // Step 2: Run retrieval in parallel. allSettled keeps partial results
   // when one retrieval fails (e.g., pgvector timeout but keyword succeeds).
-  const [semanticOutcome, keywordOutcome] = await Promise.allSettled([
-    queryEmbedding != null
-      ? searchBySemantic(knex, {
-          queryEmbedding,
-          locale,
-          limit: overfetchLimit,
-        })
-      : Promise.resolve([]),
-    searchByKeyword(knex, {
-      query,
-      locale,
-      limit: overfetchLimit,
-    }),
-  ])
+  // Each retrieval is paired with a label so we can map outcomes back to
+  // their source for logging.
+  type Retrieval = {
+    label: string
+    promise: Promise<RankedItem[]>
+  }
+  const retrievals: Retrieval[] = []
 
-  const semanticResults = unwrapOutcome(strapi, semanticOutcome, "semantic")
-  const keywordResults = unwrapOutcome(strapi, keywordOutcome, "keyword")
+  if (wantsVideos) {
+    retrievals.push({
+      label: "semantic-video",
+      promise:
+        queryEmbedding != null
+          ? searchBySemantic(knex, {
+              queryEmbedding,
+              locale,
+              limit: overfetchLimit,
+            }).then((rows) => rows.map(annotateVideo))
+          : Promise.resolve([]),
+    })
+    retrievals.push({
+      label: "keyword-video",
+      promise: searchByKeyword(knex, {
+        query,
+        locale,
+        limit: overfetchLimit,
+      }).then((rows) => rows.map(annotateVideo)),
+    })
+  }
 
-  // Step 3: Fuse ranked lists via RRF
-  const fused = fuseRankedLists([semanticResults, keywordResults], RRF_K)
+  if (wantsExperiences) {
+    retrievals.push({
+      label: "semantic-experience",
+      promise:
+        queryEmbedding != null
+          ? searchByExperienceSemantic(knex, {
+              queryEmbedding,
+              locale,
+              limit: overfetchLimit,
+            })
+          : Promise.resolve([]),
+    })
+    retrievals.push({
+      label: "keyword-experience",
+      promise: searchByExperienceKeyword(knex, {
+        query,
+        locale,
+        limit: overfetchLimit,
+      }),
+    })
+  }
+
+  const outcomes = await Promise.allSettled(retrievals.map((r) => r.promise))
+  const lists = outcomes.map((outcome, i) =>
+    unwrapOutcome(strapi, outcome, retrievals[i]!.label),
+  )
+
+  // Step 3: Fuse ranked lists via RRF. Drop empty lists first — RRF
+  // normalizes by dividing by the number of input lists, so feeding empty
+  // ones dilutes scores from the lists that did contribute.
+  const nonEmptyLists = lists.filter((list) => list.length > 0)
+  const fused = fuseRankedLists(nonEmptyLists, RRF_K)
 
   // Step 4: Dedup one extra result beyond the page window so we know
   // whether more results exist (drives hasMore without a full count pass).

--- a/apps/cms/src/bootstrap/ensure-pgvector.ts
+++ b/apps/cms/src/bootstrap/ensure-pgvector.ts
@@ -118,10 +118,38 @@ export async function ensurePgvector(strapi: Core.Strapi): Promise<void> {
       )
     `)
 
+    // Per-locale partial HNSW indexes for `experience_embeddings`.
+    //
+    // The naive index `CREATE INDEX ... USING hnsw (embedding ...)` works for
+    // unfiltered nearest-neighbour queries, but `WHERE locale = ? ORDER BY
+    // embedding <=> ?` defeats it: pgvector's planner cost model for
+    // HNSW-with-WHERE is too pessimistic, so the planner picks `Seq Scan +
+    // Top-N Sort` even when HNSW would be ~10× faster (verified locally on a
+    // 10K-row synthetic table — 19.8ms seq scan vs 1.5ms HNSW).
+    //
+    // Partial indexes keyed on locale match the `WHERE locale = ?` predicate
+    // exactly, so the planner picks them naturally. The `hnsw.iterative_scan`
+    // GUC (set at connection time in `config/database.ts`) lets the index
+    // continue searching past the default `ef_search` window when the LIMIT
+    // requires more candidates.
+    //
+    // The non-partial index below is kept as a fallback for unknown locales
+    // (queries with `WHERE locale = 'jp'` would still seq-scan, but the
+    // global index covers any future unfiltered query that might appear).
+    //
+    // To support a new locale efficiently, add another partial index here.
     await knex.raw(`
       CREATE INDEX IF NOT EXISTS experience_embeddings_hnsw
         ON experience_embeddings USING hnsw (embedding vector_cosine_ops)
     `)
+
+    for (const locale of ["en", "es", "fr"] as const) {
+      await knex.raw(
+        `CREATE INDEX IF NOT EXISTS experience_embeddings_hnsw_${locale}
+           ON experience_embeddings USING hnsw (embedding vector_cosine_ops)
+           WHERE locale = '${locale}'`,
+      )
+    }
 
     // Note: UNIQUE(experience_id, locale) already creates a B-tree index.
     // No explicit index needed for that column pair.

--- a/apps/cms/src/graphql/search.test.ts
+++ b/apps/cms/src/graphql/search.test.ts
@@ -30,6 +30,7 @@ type ExtensionFactory = () => {
             locale: string
             limit?: number
             offset?: number
+            type?: string
           },
           context: unknown,
         ) => Promise<unknown>
@@ -102,6 +103,7 @@ describe("registerSearchExtension", () => {
       locale: "en",
       limit: 10,
       offset: 0,
+      contentTypes: undefined,
     })
   })
 
@@ -301,5 +303,86 @@ describe("registerSearchExtension", () => {
       expect.any(Number),
       expect.any(Number),
     )
+  })
+
+  describe("type argument", () => {
+    beforeEach(() => {
+      vi.mocked(search).mockResolvedValue({
+        results: [],
+        hasMore: false,
+        query: "test",
+      })
+    })
+
+    it("declares optional type argument on the semanticSearch query", () => {
+      const { config } = buildExtension()
+      expect(config.typeDefs).toContain("type: String")
+    })
+
+    it("forwards contentTypes=['video'] when type=video", async () => {
+      const { config } = buildExtension()
+      await config.resolvers.Query.semanticSearch.resolve(
+        null,
+        { query: "test", locale: "en", type: "video" },
+        { koaContext: { ip: "127.0.0.1" } },
+      )
+
+      expect(search).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ contentTypes: ["video"] }),
+      )
+    })
+
+    it("forwards contentTypes=['experience'] when type=experience", async () => {
+      const { config } = buildExtension()
+      await config.resolvers.Query.semanticSearch.resolve(
+        null,
+        { query: "test", locale: "en", type: "experience" },
+        { koaContext: { ip: "127.0.0.1" } },
+      )
+
+      expect(search).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ contentTypes: ["experience"] }),
+      )
+    })
+
+    it("forwards contentTypes=undefined when type is omitted", async () => {
+      const { config } = buildExtension()
+      await config.resolvers.Query.semanticSearch.resolve(
+        null,
+        { query: "test", locale: "en" },
+        { koaContext: { ip: "127.0.0.1" } },
+      )
+
+      expect(search).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ contentTypes: undefined }),
+      )
+    })
+
+    it("throws GraphQLError with BAD_USER_INPUT when type is invalid", async () => {
+      const { config } = buildExtension()
+
+      let caught: unknown = null
+      try {
+        await config.resolvers.Query.semanticSearch.resolve(
+          null,
+          { query: "test", locale: "en", type: "invalid" },
+          { koaContext: { ip: "127.0.0.1" } },
+        )
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeInstanceOf(GraphQLError)
+      expect((caught as GraphQLError).message).toBe(
+        "type must be 'video' or 'experience'",
+      )
+      expect((caught as GraphQLError).extensions).toEqual({
+        code: "BAD_USER_INPUT",
+      })
+      expect(search).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/cms/src/graphql/search.test.ts
+++ b/apps/cms/src/graphql/search.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { GraphQLError } from "graphql"
 
-vi.mock("../api/search/services/search", () => ({
-  search: vi.fn(),
-}))
+vi.mock("../api/search/services/search", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../api/search/services/search")>()
+  return {
+    ...actual,
+    search: vi.fn(),
+  }
+})
 
 vi.mock("../lib/rate-limit-bucket", async (importOriginal) => {
   const actual =
@@ -352,6 +357,22 @@ describe("registerSearchExtension", () => {
       await config.resolvers.Query.semanticSearch.resolve(
         null,
         { query: "test", locale: "en" },
+        { koaContext: { ip: "127.0.0.1" } },
+      )
+
+      expect(search).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ contentTypes: undefined }),
+      )
+    })
+
+    it("treats an explicit empty-string type as omitted (defaults to both)", async () => {
+      // Mirrors REST behavior so a GraphQL client sending an unset variable
+      // as "" doesn't get a spurious BAD_USER_INPUT.
+      const { config } = buildExtension()
+      await config.resolvers.Query.semanticSearch.resolve(
+        null,
+        { query: "test", locale: "en", type: "" },
         { koaContext: { ip: "127.0.0.1" } },
       )
 

--- a/apps/cms/src/graphql/search.ts
+++ b/apps/cms/src/graphql/search.ts
@@ -1,17 +1,15 @@
 import type { Core } from "@strapi/strapi"
 import { GraphQLError } from "graphql"
-import { search, type ContentType } from "../api/search/services/search"
+import {
+  search,
+  isContentType,
+  type ContentType,
+} from "../api/search/services/search"
 import {
   SEARCH_RATE_LIMIT,
   checkRateLimit,
   resolveClientIp,
 } from "../lib/rate-limit-bucket"
-
-const VALID_CONTENT_TYPES: readonly ContentType[] = ["video", "experience"]
-
-function isContentType(value: string): value is ContentType {
-  return (VALID_CONTENT_TYPES as readonly string[]).includes(value)
-}
 
 type GraphQLResolverContext = {
   koaContext?: {

--- a/apps/cms/src/graphql/search.ts
+++ b/apps/cms/src/graphql/search.ts
@@ -1,11 +1,17 @@
 import type { Core } from "@strapi/strapi"
 import { GraphQLError } from "graphql"
-import { search } from "../api/search/services/search"
+import { search, type ContentType } from "../api/search/services/search"
 import {
   SEARCH_RATE_LIMIT,
   checkRateLimit,
   resolveClientIp,
 } from "../lib/rate-limit-bucket"
+
+const VALID_CONTENT_TYPES: readonly ContentType[] = ["video", "experience"]
+
+function isContentType(value: string): value is ContentType {
+  return (VALID_CONTENT_TYPES as readonly string[]).includes(value)
+}
 
 type GraphQLResolverContext = {
   koaContext?: {
@@ -47,15 +53,16 @@ export function registerSearchExtension(strapi: Core.Strapi) {
   extensionService.use(() => ({
     typeDefs: `
       type SearchResult {
+        "Discriminator: 'video' or 'experience'."
         type: String!
         id: Int!
         slug: String!
         title: String!
         imageUrl: String
         snippet: String!
-        "Null when the match is keyword-only (no scene-level timestamp)."
+        "Null for experience results, and for keyword-only video matches that have no scene-level timestamp."
         startSeconds: Float
-        "Null when the match is keyword-only (no scene-level Mux asset)."
+        "Null for experience results, and for keyword-only video matches that have no scene-level Mux asset."
         playbackId: String
         score: Float!
       }
@@ -73,6 +80,8 @@ export function registerSearchExtension(strapi: Core.Strapi) {
           locale: String!
           limit: Int
           offset: Int
+          "Restrict results to a single content type ('video' or 'experience'). Omit to return both."
+          type: String
         ): SearchResponse!
       }
     `,
@@ -86,6 +95,7 @@ export function registerSearchExtension(strapi: Core.Strapi) {
               locale: string
               limit?: number
               offset?: number
+              type?: string
             },
             context: unknown,
           ) => {
@@ -95,6 +105,18 @@ export function registerSearchExtension(strapi: Core.Strapi) {
               throw new GraphQLError("query must not be empty", {
                 extensions: { code: "BAD_USER_INPUT" },
               })
+            }
+
+            // Validate optional type filter at the GraphQL boundary so
+            // invalid values fail fast with a structured error code.
+            let contentTypes: ContentType[] | undefined
+            if (args.type != null && args.type.length > 0) {
+              if (!isContentType(args.type)) {
+                throw new GraphQLError("type must be 'video' or 'experience'", {
+                  extensions: { code: "BAD_USER_INPUT" },
+                })
+              }
+              contentTypes = [args.type]
             }
 
             // Share the SEARCH_RATE_LIMIT.key bucket with the REST middleware
@@ -126,6 +148,7 @@ export function registerSearchExtension(strapi: Core.Strapi) {
                 locale: args.locale,
                 limit: args.limit,
                 offset: args.offset,
+                contentTypes,
               })
             } catch (err) {
               strapi.log.error(

--- a/docs/plans/2026-04-15-001-feat-experience-search-integration-plan.md
+++ b/docs/plans/2026-04-15-001-feat-experience-search-integration-plan.md
@@ -1,0 +1,315 @@
+---
+title: "feat: Add experiences to search results (feat-086)"
+type: feat
+status: completed
+date: 2026-04-15
+origin: docs/brainstorms/2026-04-13-semantic-search-api-requirements.md
+---
+
+# feat: Add experiences to search results (feat-086)
+
+## Overview
+
+Extend the hybrid search API to return experience results alongside video results. The search orchestrator currently fires 2 retrievals (video semantic + video keyword), fuses via RRF, and returns `type: "video"` results. This adds 2 experience retrievals, updates the fusion identity key to prevent cross-type collisions, and exposes a `type` filter parameter so consumers can request videos only, experiences only, or both.
+
+## Problem Frame
+
+Users searching "Easter" get videos about Easter bunnies but miss the dedicated Easter experience page — a curated landing page designed to drive engagement. The `experience_embeddings` table is populated (feat-095/096), the fusion function already accepts N ranked lists, and the `type` discriminator was designed for this extension. This is a thin integration layer, not a new subsystem.
+
+(see origin: `docs/brainstorms/2026-04-13-semantic-search-api-requirements.md` — scope boundaries explicitly deferred experiences to post-v1)
+
+## Requirements Trace
+
+- R1. Experience semantic search: query `experience_embeddings` by cosine similarity, filter by locale and published_at
+- R2. Experience keyword search: `ts_rank` over `experiences_fulltext_search_idx` GIN index
+- R3. Mixed fusion: 4 ranked lists (video semantic, video keyword, experience semantic, experience keyword) merged via RRF without cross-type ID collision
+- R4. Type filter: optional `?type=video|experience` on REST, optional `type` argument on GraphQL. Omitted = both. Invalid = 400
+- R5. Backward compatibility: existing consumers see no breaking changes. `startSeconds` and `playbackId` already nullable
+- R6. Response time <500ms (parallel retrievals via `Promise.allSettled`)
+- R7. Dedup: video-specific 3-layer dedup skipped for experience results
+
+## Scope Boundaries
+
+- No experience embedding pipeline changes (feat-095)
+- No backfill changes (feat-096)
+- No personalization signals (feat-091+)
+- No scene-level experience results (whole-experience granularity only)
+- No cross-type semantic similarity or recommendations
+- No experience image URL in v1 if the Strapi media join is complex — return `null` and iterate
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Orchestrator** `apps/cms/src/api/search/services/search.ts`: 5-step pipeline (embed → retrieve → fuse → dedup → paginate). `SearchResult.type` hardcoded to `"video"`. `mapToSearchResult()` reads video-specific fields from `FusedResult`. `unwrapOutcome()` extracts `Promise.allSettled` results.
+- **Fusion** `apps/cms/src/api/search/services/fusion.ts`: `fuseRankedLists()` uses `item.videoId` (number) as Map key — collision risk. `RankedItem` has `videoId`, `videoCoreId`, `videoTitle` as required fields plus open `[key: string]: unknown`. `deduplicateResults()` has 3 video-specific checks.
+- **Video semantic** `apps/cms/src/api/search/services/semantic-search.ts`: `DISTINCT ON (se.video_id)` + subquery pattern. 4-table locale join chain. Returns `SemanticResult` with `videoId`, scene-level fields.
+- **Video keyword** `apps/cms/src/api/search/services/keyword-search.ts`: `ts_rank` on `to_tsvector('simple', title || description)`. Same locale join chain. Returns `KeywordResult` with `videoId`.
+- **Controller** `apps/cms/src/api/search/controllers/search.ts`: Validates `q` and `locale`, parses `limit`/`offset`. No `type` parsing yet.
+- **GraphQL** `apps/cms/src/graphql/search.ts`: `registerSearchExtension()` defines `SearchResult` type and `semanticSearch` query. Resolver validates empty query, checks rate limit, calls `search()`.
+- **DB schema**: `experience_embeddings` table with `HNSW` index on `embedding`, `UNIQUE(experience_id, locale)`. `experiences_fulltext_search_idx` GIN index on `to_tsvector('simple', title || meta_description)`. Both created by feat-095 bootstrap.
+- **Experience schema**: `experiences` table has `slug`, `title`, `meta_description`, `locale`, `published_at`, `og_image` (media relation). Locale is a direct column — no link-table chain needed.
+- **Test pattern**: Colocated sibling files. `createMockKnex()` factory, `buildRow()` with overrides, `vi.mock()` at module level, `vi.mocked()` for type-safe assertions.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md` — the architecture being extended. RRF handles N lists natively. `Promise.allSettled` for graceful degradation. Nullable scene fields for non-video result types.
+- `docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md` — `experience_embeddings` schema. Locale is on the row (no join chain). `slug` stored on embedding row.
+- `docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md` — use `GraphQLError` directly, never custom Error subclasses.
+- `docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md` — separate table per retrieval grain. Merge at fusion layer, not storage layer.
+- Strapi v5 raw SQL: field names are snake_case in DB (`metaDescription` → `meta_description`). Always verify with `\d tablename`.
+
+## Key Technical Decisions
+
+- **Compound identity key in fusion**: Change `fuseRankedLists` Map key from `item.videoId` (number) to `${item.resultType}:${item.resultId}` (string). This prevents video id=4 and experience id=4 from colliding. The `scoreMap` and `propsMap` both change from `Map<number, ...>` to `Map<string, ...>`.
+
+- **RankedItem type evolution**: Add `resultType: "video" | "experience"` and `resultId: number` as required fields. Make `videoId`, `videoCoreId`, `videoTitle` optional (they are only meaningful for video results). Experience results carry their own fields (`experienceSlug`, `experienceTitle`, etc.) via the existing open index signature. Video search functions continue returning their current shapes; the orchestrator annotates with `resultType`/`resultId` before passing to fusion.
+
+- **Empty list filtering before fusion**: When `type=video`, only fire video retrievals. When `type=experience`, only fire experience retrievals. Before calling `fuseRankedLists`, filter out empty arrays. Passing empty lists dilutes RRF scores because the theoretical maximum assumes all lists contribute.
+
+- **Dedup type guard**: `deduplicateResults` skips all 3 video-specific checks (core_id prefix, title match, embedding similarity) when `candidate.resultType !== "video"`. Experiences pass through with only the limit cap applied.
+
+- **Experience image URL**: The `experiences.og_image` field is a Strapi media relation requiring a multi-table join through `files_related_morphs` → `files`. If this join is straightforward, include it. If complex, return `imageUrl: null` for experiences in v1 and iterate — the search result contract already has `imageUrl` as nullable.
+
+- **No `DISTINCT ON` needed for experiences**: Unlike videos (which can have multiple variants per locale), `experience_embeddings` has a `UNIQUE(experience_id, locale)` constraint. One row per experience per locale — no dedup at the SQL level needed.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **RRF score normalization with variable list count**: When `type=video` sends 2 lists and `type` omitted sends 4 lists, the `theoreticalMax` normalization (`lists.length / (k + 1)`) naturally adjusts. Scores are always [0,1] regardless of list count. No change needed to the normalization logic.
+- **Experience `locale` column name**: Strapi v5 i18n stores locale directly on the content table. The column is `locale` (not snake-cased from something else). Confirmed in the experience embeddings pipeline.
+- **Test file location**: Tests are colocated siblings in `apps/cms/src/api/search/services/`, not in a `__tests__/` subdirectory.
+
+### Deferred to Implementation
+
+- **Exact experience image join SQL**: Whether to join `files_related_morphs` → `files` for `og_image` or return `null`. Depends on verifying the Strapi v5 media link table structure at implementation time.
+- **Experience `embeddingText` for cross-experience dedup**: v1 skips dedup for experiences entirely. If future experience volume warrants it, `embeddingText` can be carried through from `experience_embeddings.embedding::text` and a within-type dedup layer added.
+
+## Implementation Units
+
+- [x] **Unit 1: Extend fusion identity key and RankedItem type**
+
+  **Goal:** Make `fuseRankedLists` and `deduplicateResults` work with heterogeneous result types without cross-type ID collision.
+
+  **Requirements:** R3, R7
+
+  **Dependencies:** None — this is the foundation other units build on.
+
+  **Files:**
+  - Modify: `apps/cms/src/api/search/services/fusion.ts`
+  - Test: `apps/cms/src/api/search/services/fusion.test.ts`
+
+  **Approach:**
+  - Add `resultType: "video" | "experience"` and `resultId: number` to `RankedItem`. Make `videoId` optional (existing video code still sets it).
+  - Change `scoreMap` and `propsMap` from `Map<number, ...>` to `Map<string, ...>` keyed by `${resultType}:${resultId}`.
+  - In `deduplicateResults`, wrap the 3 video-specific checks in a `resultType === "video"` guard. Non-video results only check the limit cap.
+  - Update the `forEach` callback that builds `FusedResult[]` to spread `resultType` and `resultId` from `propsMap`.
+
+  **Patterns to follow:**
+  - Existing `fuseRankedLists` structure — accumulate scores, merge properties, normalize, sort.
+  - Existing `deduplicateResults` structure — iterate candidates, check against kept list.
+
+  **Test scenarios:**
+  - Video-only lists: behavior identical to current (regression)
+  - Mixed lists: video id=4 and experience id=4 both survive as distinct results
+  - Experience results skip all 3 dedup checks
+  - Property merge priority preserved across types (semantic list takes priority over keyword list)
+  - Score normalization correct with 2 lists and 4 lists
+
+  **Verification:**
+  - All existing `fusion.test.ts` tests pass with minimal updates (adding `resultType`/`resultId` to test data)
+  - New compound key tests pass
+
+- [x] **Unit 2: Experience semantic search**
+
+  **Goal:** Query `experience_embeddings` by cosine similarity with locale filtering and published_at check.
+
+  **Requirements:** R1
+
+  **Dependencies:** Unit 1 (return type must include `resultType`/`resultId`)
+
+  **Files:**
+  - Create: `apps/cms/src/api/search/services/experience-semantic-search.ts`
+  - Test: `apps/cms/src/api/search/services/experience-semantic-search.test.ts`
+
+  **Approach:**
+  - Mirror the structure of `semantic-search.ts` but much simpler SQL:
+    - No `DISTINCT ON` (unique constraint handles it)
+    - No locale join chain (direct `WHERE ee.locale = ?`)
+    - Join `experience_embeddings ee` → `experiences e` on `e.id = ee.experience_id AND e.published_at IS NOT NULL`
+  - Select: `ee.experience_id`, `e.slug`, `e.title`, `e.meta_description`, `1 - (ee.embedding <=> ?::vector) AS similarity`
+  - Return type includes `resultType: "experience"`, `resultId: experienceId`
+  - Same `mapRow` pattern (snake_case → camelCase)
+
+  **Patterns to follow:**
+  - `apps/cms/src/api/search/services/semantic-search.ts` — SQL structure, `mapRow`, export signature
+  - `createMockKnex()` + `buildRow()` test pattern from `semantic-search.test.ts`
+
+  **Test scenarios:**
+  - Returns mapped results with correct field names
+  - Passes correct bindings to `knex.raw` (embedding, locale, embedding, limit)
+  - Returns empty array when no matches
+  - Filters out unpublished experiences (`published_at IS NULL`)
+  - Locale filtering works (only returns matching locale)
+
+  **Verification:**
+  - Tests pass. Function can be imported and called from the orchestrator.
+
+- [x] **Unit 3: Experience keyword search**
+
+  **Goal:** Full-text keyword search on `experiences.title + meta_description` using the existing GIN index.
+
+  **Requirements:** R2
+
+  **Dependencies:** Unit 1 (return type must include `resultType`/`resultId`)
+
+  **Files:**
+  - Create: `apps/cms/src/api/search/services/experience-keyword-search.ts`
+  - Test: `apps/cms/src/api/search/services/experience-keyword-search.test.ts`
+
+  **Approach:**
+  - Mirror `keyword-search.ts` structure but against `experiences` table directly
+  - SQL uses `ts_rank(to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(meta_description, '')), plainto_tsquery('simple', ?))` — matches the GIN index expression
+  - Filter: `WHERE ... @@ ... AND locale = ? AND published_at IS NOT NULL`
+  - No `DISTINCT ON` needed (one row per experience per locale in the `experiences` table via i18n)
+  - Short-circuit on empty/whitespace query (same as video keyword)
+  - Return type includes `resultType: "experience"`, `resultId: experienceId`
+
+  **Patterns to follow:**
+  - `apps/cms/src/api/search/services/keyword-search.ts` — SQL structure, empty query short-circuit, `mapRow`
+  - `createMockKnex()` + `buildRow()` test pattern from `keyword-search.test.ts`
+
+  **Test scenarios:**
+  - Returns results ordered by rank descending
+  - Returns empty array for empty/whitespace query without hitting DB
+  - Passes correct bindings (query, locale, query, limit)
+  - Filters by locale and published_at
+  - Field mapping correctness (snake_case → camelCase)
+
+  **Verification:**
+  - Tests pass. Function can be imported and called from the orchestrator.
+
+- [x] **Unit 4: Update orchestrator with type filter and 4-list fusion**
+
+  **Goal:** Wire experience retrievals into the search pipeline, add `contentTypes` parameter, filter empty lists before fusion.
+
+  **Requirements:** R3, R4, R5, R6
+
+  **Dependencies:** Units 1, 2, 3
+
+  **Files:**
+  - Modify: `apps/cms/src/api/search/services/search.ts`
+  - Test: `apps/cms/src/api/search/services/search.test.ts`
+
+  **Approach:**
+  - Add `contentTypes?: ("video" | "experience")[]` to `SearchParams`. Default to `["video", "experience"]` when omitted.
+  - Conditionally launch retrievals based on `contentTypes`: if only `"video"`, fire 2 video retrievals. If only `"experience"`, fire 2 experience retrievals. If both, fire all 4 via `Promise.allSettled`.
+  - Collect results, filter out empty arrays, pass non-empty lists to `fuseRankedLists`.
+  - Update `mapToSearchResult` to handle both types: check `resultType` to determine field mapping. Video results use `videoId`/`videoSlug`/`videoTitle`/`description`/`startSeconds`/`playbackId`. Experience results use `experienceId`/`experienceSlug`/`experienceTitle`/`experienceMetaDescription`. Both map to the same `SearchResult` shape.
+  - Update `SearchResult.type` from `"video"` to `"video" | "experience"`.
+
+  **Patterns to follow:**
+  - Existing `Promise.allSettled` + `unwrapOutcome` pattern
+  - Existing `mapToSearchResult` field-reading pattern
+
+  **Test scenarios:**
+  - Default (no contentTypes): 4 retrievals fired, mixed results returned
+  - `contentTypes: ["video"]`: only 2 video retrievals, no experience search functions called
+  - `contentTypes: ["experience"]`: only 2 experience retrievals, no video search functions called
+  - Graceful degradation: experience semantic fails, video results still returned
+  - Experience results have `type: "experience"`, `startSeconds: null`, `playbackId: null`
+  - Empty retrieval lists filtered before fusion (verify `fuseRankedLists` not called with empty arrays)
+  - Regression: video-only query returns identical results to pre-change behavior
+
+  **Verification:**
+  - All existing `search.test.ts` tests pass (with mock updates for new imports)
+  - New type filter tests pass
+
+- [x] **Unit 5: Update controller and GraphQL for type filter**
+
+  **Goal:** Expose the `type` filter parameter on REST and GraphQL endpoints with validation.
+
+  **Requirements:** R4, R5
+
+  **Dependencies:** Unit 4
+
+  **Files:**
+  - Modify: `apps/cms/src/api/search/controllers/search.ts`
+  - Modify: `apps/cms/src/graphql/search.ts`
+
+  **Approach:**
+  - **Controller**: Parse `query.type`. Valid values: `"video"`, `"experience"`, or absent. Invalid → 400 with `{ error: "type must be 'video' or 'experience'" }`. Convert to `contentTypes` array and pass to `search()`.
+  - **GraphQL**: Add optional `type: String` argument to `semanticSearch` query. Validate in resolver — invalid values throw `GraphQLError` with `BAD_USER_INPUT` code. Convert to `contentTypes` and pass to `search()`.
+  - **GraphQL typeDefs**: Update `SearchResult.startSeconds` and `SearchResult.playbackId` descriptions to note that null also applies to experience results, not just keyword-only matches.
+
+  **Patterns to follow:**
+  - Existing controller validation pattern (`q` and `locale` checks)
+  - Existing GraphQL resolver validation pattern (empty query → `BAD_USER_INPUT`)
+  - `GraphQLError` with `extensions.code` (per `strapi-v5-graphql-error-extensions-stripping` learning)
+
+  **Test scenarios:**
+  - REST: `?type=video` passes `contentTypes: ["video"]` to search
+  - REST: `?type=experience` passes `contentTypes: ["experience"]` to search
+  - REST: no `type` param passes default (both)
+  - REST: `?type=invalid` returns 400
+  - GraphQL: `type: "video"` works
+  - GraphQL: `type: "invalid"` returns `BAD_USER_INPUT` error
+  - GraphQL: `type` omitted defaults to both
+
+  **Verification:**
+  - Controller and GraphQL resolver correctly route the type parameter
+  - Invalid type values rejected at the boundary
+
+- [x] **Unit 6: Integration tests for mixed results**
+
+  **Goal:** Verify the full pipeline produces correct mixed results end-to-end within the test suite.
+
+  **Requirements:** R1, R2, R3, R4, R5, R7
+
+  **Dependencies:** Units 1–5
+
+  **Files:**
+  - Modify: `apps/cms/src/api/search/services/search.test.ts`
+  - Modify: `apps/cms/src/api/search/services/fusion.test.ts`
+
+  **Approach:**
+  - Add orchestrator test cases that exercise the full 4-list flow with mocked dependencies returning both video and experience results.
+  - Add fusion test cases for compound key correctness with heterogeneous types.
+  - Verify collision resistance: video id=4 and experience id=4 both appear in output.
+  - Verify dedup: experiences pass through unchanged while video dedup still functions.
+
+  **Test scenarios:**
+  - Mixed results: experience ranked above video by RRF score
+  - Collision case: same integer ID, different types, both survive
+  - Video dedup still works within video results
+  - Experience results untouched by dedup
+  - Pagination with mixed types: `offset`/`limit` slicing works correctly
+  - `hasMore` signal correct with mixed result set
+
+  **Verification:**
+  - Full test suite passes: `pnpm --filter cms test`
+  - No regressions in existing video-only test cases
+
+## System-Wide Impact
+
+- **API surface parity**: Both REST (`GET /api/search`) and GraphQL (`semanticSearch`) get the `type` filter. Both call the same `search()` service — no divergence risk.
+- **Error propagation**: `Promise.allSettled` ensures experience retrieval failures degrade gracefully. Same pattern as existing video graceful degradation.
+- **State lifecycle risks**: None — search is stateless read-only. No writes, no cache invalidation concerns.
+- **Interaction graph**: No callbacks, middleware, or observers affected. The rate-limit middleware and shared bucket are unchanged.
+- **Integration coverage**: Unit tests with mocked knex cover orchestration logic. Live verification against production data confirms SQL correctness and real response times.
+
+## Risks & Dependencies
+
+- **Data dependency**: `experience_embeddings` must be populated (feat-095 pipeline + feat-096 backfill). Without data, experience search returns empty results (safe but invisible).
+- **Experience schema field names**: Raw SQL uses snake_case (`meta_description`, `published_at`). Verify column names against the actual DB before finalizing SQL. The Strapi v5 snake-case convention is documented but has caused bugs before (e.g., `bcp47` → `bcp_47`).
+- **RRF score comparability**: Video semantic scores and experience semantic scores are both cosine similarity from the same embedding model (`text-embedding-3-small`), so they're comparable. Keyword scores use `ts_rank` which has different scale characteristics — but RRF is rank-based, not score-based, so this is fine by design.
+
+## Sources & References
+
+- **Origin document**: [docs/brainstorms/2026-04-13-semantic-search-api-requirements.md](docs/brainstorms/2026-04-13-semantic-search-api-requirements.md)
+- **Feature ticket**: [docs/roadmap/content-discovery/feat-086-experience-search-integration.md](docs/roadmap/content-discovery/feat-086-experience-search-integration.md)
+- **v1 search plan**: [docs/plans/2026-04-13-003-feat-semantic-search-api-plan.md](docs/plans/2026-04-13-003-feat-semantic-search-api-plan.md)
+- **Search architecture learning**: [docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md](docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md)
+- **Experience embedding pipeline learning**: [docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md](docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md)
+- **GraphQL error pattern**: [docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md](docs/solutions/integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md)

--- a/docs/roadmap/content-discovery/feat-086-experience-search-integration.md
+++ b/docs/roadmap/content-discovery/feat-086-experience-search-integration.md
@@ -3,7 +3,7 @@ id: "feat-086"
 title: "Search Extension — Add Experiences to Results"
 owner: "nisal"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-23"
 duration: 5
 depends_on:

--- a/docs/roadmap/content-discovery/feat-097-investigate-prod-query-embedding.md
+++ b/docs/roadmap/content-discovery/feat-097-investigate-prod-query-embedding.md
@@ -1,0 +1,172 @@
+---
+id: "feat-097"
+title: "Investigate Production Query Embedding Degradation"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-16"
+duration: 2
+depends_on: []
+blocks: []
+tags:
+  - "cms"
+  - "search"
+  - "ai-pipeline"
+---
+
+## Problem
+
+Production semantic search is silently degraded — the OpenRouter query-embedding call appears to fail or return non-overlapping results, leaving keyword search as the only contributing retrieval. The orchestrator's graceful-degradation `try/catch` around `embedQuery` swallows the failure, so the API still returns 200s with results. There is no visible 503 or error surfaced to consumers, but **the hybrid search promise is not being delivered**.
+
+This is invisible in CI (tests mock `embedQuery`), invisible to the API contract (results still return), and invisible to monitoring (no error logs unless someone reads them). It only surfaces by inspecting RRF scores, which all carry the unmistakable signature of single-list fusion when 2-list fusion was attempted.
+
+## Evidence
+
+Discovered while validating feat-086 against production on 2026-04-15 (`https://cms.jesusfilm.org/api/search?q=...&locale=en`):
+
+| Query                        | Top score | Has scene-level data? | Notes                                                   |
+| ---------------------------- | --------- | --------------------- | ------------------------------------------------------- |
+| `Easter`                     | **0.500** | No                    | All 5 results: `startSeconds: null`, `playbackId: null` |
+| `forgiveness`                | **0.500** | No                    | Same pattern                                            |
+| `Jesus heals`                | **0.500** | No                    | Same pattern                                            |
+| `resurrection`               | **0.500** | No                    | Same pattern                                            |
+| `centurion at the cross`     | empty     | N/A                   | Should hit scene embeddings; returns nothing            |
+| `feeling alone in suffering` | empty     | N/A                   | Pure thematic; returns nothing                          |
+
+The score `0.500` is mathematically the **exact** value for a result ranked #1 in keyword search and absent from semantic search, when 2 lists are passed to RRF:
+
+```
+score = (1/(k+1)) / (lists.length / (k+1))
+      = (1/61)   / (2/61)
+      = 0.500
+```
+
+Every "rank-2 score = 0.492", "rank-3 score = 0.484" pattern follows the same formula precisely (`(1/62) / (2/61) = 0.4918`, `(1/63) / (2/61) = 0.4836`).
+
+If semantic search were contributing AND ranked the same items at rank-1, the scores would be `1.000`. They are not.
+
+If semantic search were contributing AND ranked **different** items than keyword, those different items would appear in the top-5 with scores around `0.500` from the semantic side. They do not — top-5 is dominated entirely by keyword hits.
+
+The **empty results** for thematic-only queries (`"feeling alone in suffering"`) are damning: keyword search legitimately returns nothing for that phrase, so the response should be filled by semantic. It isn't, which means semantic returned nothing too.
+
+For comparison, the **same code paths run against a local DB return rich semantic results**. Local `Easter` query (with this PR's changes applied) returned scene-level data: themes (`new life, awe, meaning`), bible verses (`2 Corinthians 5:17, Revelation 21:5`), demographics (`adult, young adult`), spiritual context. Production returns none of this. The code is identical — the difference is the runtime environment.
+
+## Hypotheses (Ranked by Likelihood)
+
+1. **`OPENROUTER_API_KEY` env var missing or invalid in Railway.** The `try/catch` in `apps/cms/src/api/search/services/search.ts:154-166` swallows the failure with `strapi.log.warn(...)`. If Railway's env var is unset, every query embedding call rejects with `OPENROUTER_API_KEY is not set` (per `apps/cms/src/lib/openrouter.ts`). Most likely root cause.
+2. **OpenRouter API outage or throttling on the production IP.** Less likely (we'd see intermittent rather than uniform degradation across all queries).
+3. **Model deprecation or rename.** `text-embedding-3-small` could have been renamed/removed on OpenRouter.
+4. **Network egress blocked from Railway → OpenRouter.** Possible but would manifest as timeouts in logs.
+5. **Cold-start cache / instance restart loop** preventing the embedding client from initializing.
+6. **Semantic search returning data, but for completely different videos** that never make top-5 because keyword consistently ranks higher. Unlikely given the empty-result thematic queries.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/api/search/services/search.ts:154-166` — the `try/catch` that hides the failure. Notice it logs `strapi.log.warn` (not `error`), which may be filtered out of production log retention.
+2. `apps/cms/src/lib/openrouter.ts` — the `embedQuery` function and its env validation.
+3. `apps/cms/src/api/search/services/fusion.ts` — confirm the RRF score math matches the observed evidence.
+4. Railway dashboard → `forge-cms` service → Logs tab → search for `[search]` and `Query embedding failed`.
+5. Railway dashboard → `forge-cms` service → Variables tab → confirm `OPENROUTER_API_KEY` is present and non-empty.
+
+## Grep These
+
+- `OPENROUTER_API_KEY` in `apps/cms/src/lib/`
+- `embedQuery` in `apps/cms/src/`
+- `Query embedding failed` in `apps/cms/src/api/search/`
+- `[search]` log prefixes (the orchestrator uses these as a namespace)
+
+## What To Build (Investigation Plan)
+
+### Step 1: Confirm the diagnosis from logs
+
+```bash
+# Tail Railway logs for the embedding warning
+railway logs --service forge-cms | grep -E "(embedding failed|OPENROUTER|\[search\])"
+```
+
+If the warning `[search] Query embedding failed, falling back to keyword-only: ...` appears every time a query is made, the hypothesis is confirmed. The error message will indicate the root cause (missing key, network error, HTTP status).
+
+### Step 2: Fix the underlying issue
+
+Most likely path:
+
+```bash
+# Verify the env var is set in Railway
+railway variables --service forge-cms | grep OPENROUTER
+
+# If missing, set it from Doppler:
+railway variables --set OPENROUTER_API_KEY=<value-from-doppler>
+
+# If present, validate the key works against OpenRouter:
+curl -X POST https://openrouter.ai/api/v1/embeddings \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": "test", "model": "text-embedding-3-small"}'
+```
+
+### Step 3: Make the failure visible going forward
+
+The current `try/catch` is too quiet. It should still degrade gracefully (don't break the API) but should also:
+
+- Log at `error` level, not `warn`, so it surfaces in default log retention.
+- Increment a metric (e.g., `search_query_embedding_failures_total`) so degraded operation triggers alerts before someone notices missing scene data.
+- Optionally surface a non-blocking signal in the API response (`degraded: true` flag in the response envelope, or an `X-Search-Mode: keyword-only` header) so consumers can render a banner like "advanced semantic search temporarily unavailable."
+
+### Step 4: Add a synthetic health check
+
+Add a startup or periodic job that runs a single test query embedding and reports failure to operational metrics. Catches the regression before it hits real users.
+
+```ts
+// e.g., in apps/cms/src/bootstrap/probe-openrouter.ts
+async function probeOpenRouter(strapi: Core.Strapi): Promise<void> {
+  try {
+    await embedQuery("health-check probe")
+    strapi.log.info("[probe] OpenRouter embedding healthy")
+  } catch (err) {
+    strapi.log.error(`[probe] OpenRouter embedding FAILED: ${err}`)
+    // Optionally: emit to InfluxDB / monitoring
+  }
+}
+```
+
+## Constraints
+
+- **Do not break the graceful degradation path.** Search must keep returning 200 with keyword results even when semantic fails. The `try/catch` stays — what changes is the noise level and visibility.
+- **Don't add a hard 503 on embedding failure.** That would regress consumer behavior.
+- **Don't modify the RRF algorithm.** The math is correct; the input is the problem.
+- **No personalization or model swap.** Out of scope.
+
+## Verification
+
+After fix:
+
+```bash
+curl 'https://cms.jesusfilm.org/api/search?q=feeling%20alone%20in%20suffering&locale=en' \
+  | jq '.results | length'
+# Expect: > 0 (semantic returns thematically relevant scenes)
+
+curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en' \
+  | jq '.results[0]'
+# Expect: startSeconds and playbackId are non-null on the top result
+# Expect: snippet contains scene-level themes/bible-verses prose
+
+curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en' \
+  | jq '.results[0].score'
+# Expect: ~1.0 if rank-1 in both lists, or ~0.95+ for rank-1 in one and rank-2 in the other.
+# Should NOT be exactly 0.500 anymore.
+```
+
+Run a few thematic queries and confirm scene-level data appears (`startSeconds`, `playbackId`, themes/bible-verses in snippet).
+
+## Out of Scope
+
+- Replacing OpenRouter with a different embedding provider — that's a separate evaluation.
+- Switching embedding model — `text-embedding-3-small` is fine if it works.
+- Changing RRF k constant — orthogonal concern.
+- Adding personalization signals to ranking (feat-091+).
+
+## Related
+
+- **feat-010** — original semantic search API. The graceful-degradation pattern was intentional but the silence is a known trade-off.
+- **feat-086** (PR #777) — adds experiences to search. Will exhibit the same degraded behavior in production until this is fixed (experience semantic also depends on `embedQuery`).
+- `docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md` — documents the degradation strategy.

--- a/docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md
+++ b/docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md
@@ -34,6 +34,9 @@ related:
   - "docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md"
   - "docs/solutions/cms/strapi-v5-blurhash-generation-multi-path-pattern.md"
   - "docs/solutions/platform/multimodal-scene-analysis-pipeline.md"
+  - "docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md"
+  - "docs/solutions/best-practices/rrf-fusion-heterogeneous-content-types-20260415.md"
+last_updated: "2026-04-15"
 ---
 
 ## Problem
@@ -129,6 +132,8 @@ CREATE TABLE IF NOT EXISTS experience_embeddings (
 ```
 
 Plus HNSW index for ANN queries and GIN FTS index on the `experiences` table for keyword search. No explicit B-tree index needed — the UNIQUE constraint provides it.
+
+**For locale-filtered semantic search at scale**: the global HNSW above is sufficient for the write side, but query-side filtering on `WHERE locale = ?` causes the planner to bypass HNSW entirely (it picks Seq Scan + Top-N Sort). The search integration in feat-086 added per-locale partial HNSW indexes on top of this base — see [pgvector HNSW index bypassed by planner when WHERE filter on indexed table](../performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md). When this pipeline lights up a new locale, add a matching partial index in `ensure-pgvector.ts`.
 
 ### 2. Recursive text flattener for dynamic zone blocks
 

--- a/docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md
+++ b/docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md
@@ -30,6 +30,8 @@ related_files:
 github_prs:
   - "#744"
   - "#747"
+  - "#777"
+last_updated: "2026-04-15"
 ---
 
 ## When to Use This Pattern
@@ -145,6 +147,8 @@ JOIN languages l ON l.id = vll.language_id AND l.bcp_47 = ?
 ```
 
 Strapi snake-cases field names (`bcp47` → `bcp_47`). The chain is non-obvious — reuse this exact pattern across any query that needs locale filtering. Reference: `apps/cms/src/api/scene-embedding/services/recommender.ts`.
+
+**Why the JOIN chain matters for HNSW performance.** Filtering locale via the JOIN keeps the WHERE clause off the embedding table, so pgvector's HNSW scan stays unconstrained — the planner picks the index. When feat-086 added `experience_embeddings`, the table stores `locale` directly on the row, so `WHERE ee.locale = ?` defeats the planner's HNSW cost model and silently picks Seq Scan. The mitigation is per-locale partial HNSW indexes plus the `hnsw.iterative_scan` GUC. See [pgvector HNSW index bypassed by planner when WHERE filter on indexed table](../performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md). When extending this search pattern to a new content type, prefer keeping the locale filter on a _joined_ table when possible; if the new table has locale on the row, plan for partial indexes.
 
 ### 5. `DISTINCT ON` + over-fetch + dedupe
 
@@ -336,7 +340,9 @@ curl -s -X POST http://localhost:1337/graphql \
 - [Strapi v5: Custom Error subclasses lose extensions](../integration-issues/strapi-v5-graphql-error-extensions-stripping-20260413.md) — critical companion doc for the error contract
 - [pgvector embedding indexing in Strapi v5](./pgvector-embedding-indexing-strapi-v5.md) — the storage layer this search queries
 - [pgvector recommendation query + locale + GraphQL in Strapi v5](./pgvector-recommendation-query-locale-graphql-strapi-v5.md) — the sibling recommendation API that this search borrows its locale join chain and dedup strategy from
+- [Composing N-way RRF safely with heterogeneous content types](./rrf-fusion-heterogeneous-content-types-20260415.md) — feat-086 extended the fusion to mixed video/experience results; documents the compound identity key + empty-list filtering patterns
+- [pgvector HNSW index bypassed by planner when WHERE filter on indexed table](../performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md) — operational concern when extending search to a content type with locale on the row
 - [feat-010 Semantic Search API](../../roadmap/content-discovery/feat-010-semantic-search-api.md) — the feature ticket
 - [feat-086 Experience Search Integration](../../roadmap/content-discovery/feat-086-experience-search-integration.md) — extends this pattern with a new content type
 - [2026-04-13 Semantic Search API brainstorm](../../brainstorms/2026-04-13-semantic-search-api-requirements.md) — the requirements + industry research that drove these decisions
-- PRs #744 (initial implementation) and #747 (hardening from 4-pass review)
+- PRs #744 (initial implementation), #747 (hardening from 4-pass review), and #777 (feat-086 + this perf fix)

--- a/docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md
+++ b/docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md
@@ -33,6 +33,8 @@ related:
   - "docs/solutions/platform/multimodal-scene-analysis-pipeline.md"
   - "docs/solutions/best-practices/pgvector-recommendation-query-locale-graphql-strapi-v5.md"
   - "docs/solutions/best-practices/vector-embedding-storage-scope-sequencing-2026-04-11.md"
+  - "docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md"
+last_updated: "2026-04-15"
 ---
 
 ## Problem
@@ -194,6 +196,8 @@ Controllers should reject invalid data before touching the database. Check: embe
 ### 5. Use HNSW over IVFFlat for incremental inserts
 
 HNSW doesn't require periodic rebuilds. IVFFlat index quality degrades as data is added without rebuilding.
+
+**Caveat — filtered queries**: a global HNSW index works only for _unfiltered_ nearest-neighbour queries. The moment you add `WHERE column = ?` on the indexed table (e.g., `WHERE locale = ?`), pgvector's planner cost model gets the answer wrong and silently picks Seq Scan + Top-N Sort instead of HNSW. The fix is per-locale (or per-filter-value) **partial HNSW indexes** plus the `hnsw.iterative_scan = relaxed_order` GUC at connection level. See [pgvector HNSW index bypassed by planner when WHERE filter on indexed table](../performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md) for the empirical comparison and the production fix shipped in PR #777.
 
 ### 6. Both embedding tables need FK CASCADE
 

--- a/docs/solutions/best-practices/pgvector-recommendation-query-locale-graphql-strapi-v5.md
+++ b/docs/solutions/best-practices/pgvector-recommendation-query-locale-graphql-strapi-v5.md
@@ -33,6 +33,8 @@ related:
   - "docs/solutions/platform/backfill-worker-pattern-manager-20260407.md"
   - "docs/solutions/performance-issues/manager-video-coverage-sql-aggregation-20260402.md"
   - "docs/solutions/platform/multimodal-scene-analysis-pipeline.md"
+  - "docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md"
+last_updated: "2026-04-15"
 ---
 
 ## Problem
@@ -206,7 +208,9 @@ Transport adapters handle only request parsing and error response formatting.
 2. **`DISTINCT ON` + subquery** is the canonical PostgreSQL pattern for "best row per group with global ordering."
 3. **Parent-child exclusion prevents content cannibalization** — JESUS film's 61 child segments are literally the same content cut into clips. Without exclusion, recommendations are useless.
 4. **`register()` timing** is required because Strapi compiles the GraphQL schema after `register()` but before `bootstrap()`. Extensions added in `bootstrap()` are silently ignored.
-5. **Performance verified**: 45ms execution time for top-10 query against 1,965 scenes. HNSW index handles the cosine similarity search efficiently.
+5. **Performance verified**: 45ms execution time for top-10 query against 1,965 scenes. HNSW index handles the cosine similarity search efficiently because the locale filter lives on a _joined_ table (`languages.bcp_47`), not on `scene_embeddings` itself — the HNSW scan stays unconstrained.
+
+   ⚠️ **Watch out at scale or with different schemas.** If a future query puts the filter directly on the embedding table (`WHERE column = ? ORDER BY embedding <=> ?`), pgvector's planner cost model is too pessimistic and silently picks Seq Scan over HNSW. Verify with `EXPLAIN ANALYZE` once `scene_embeddings` grows past ~5K rows or whenever a new filter column is added. The fix is per-locale partial HNSW indexes plus `hnsw.iterative_scan = relaxed_order`. See [pgvector HNSW index bypassed by planner when WHERE filter on indexed table](../performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md).
 
 ## Prevention
 

--- a/docs/solutions/best-practices/rrf-fusion-heterogeneous-content-types-20260415.md
+++ b/docs/solutions/best-practices/rrf-fusion-heterogeneous-content-types-20260415.md
@@ -1,0 +1,187 @@
+---
+title: "Composing N-way RRF safely with heterogeneous content types"
+category: "best-practices"
+problem_type: "best_practice"
+component: "service_object"
+root_cause: "missing_validation"
+resolution_type: "code_fix"
+severity: "medium"
+module: "apps/cms"
+tags:
+  - rrf
+  - reciprocal-rank-fusion
+  - search
+  - hybrid-search
+  - ranking
+  - typescript
+  - strapi
+  - cms
+date: "2026-04-15"
+related_prs:
+  - "JesusFilm/forge#777"
+related_docs:
+  - "docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md"
+  - "docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md"
+---
+
+# Composing N-way RRF safely with heterogeneous content types
+
+When extending a Reciprocal Rank Fusion search from one content type to many (e.g. videos + experiences + future personalization signals), two non-obvious traps surface that don't matter in the single-type case. Both produce **silent ranking bugs** rather than errors — tests that only assert "results are returned" will pass while the relevance contract quietly breaks.
+
+## Problem
+
+RRF is famously simple: `score = sum(1 / (k + rank_i))` for each list a result appears in, normalized by `lists.length / (k + 1)`. The contract is "give me N ranked lists, get back one fused list." This works perfectly when every list ranks items from the same identity space (one type of content) and every list is non-empty.
+
+When you fuse heterogeneous content types (video + experience + ...) the implementation has to handle two quiet failure modes that the math glosses over.
+
+## Failure mode 1: integer ID collision across content types
+
+Most fusion implementations use the result's identity (`videoId`, `productId`, etc.) as the Map key. With one content type this is fine — IDs are unique within the type. With multiple types, **ID 4 in the video table and ID 4 in the experience table collide on the same Map key**.
+
+Symptom: the higher-scoring result silently overwrites the lower-scoring one, or property merging produces a Frankenstein object with fields from both types. No error, just the wrong result set.
+
+## Failure mode 2: empty input lists dilute the normalization
+
+RRF normalizes scores by `theoreticalMax = lists.length / (k + 1)`. Pass 4 lists where 2 are empty (because semantic embedding failed, or because no keyword match exists for the locale): `lists.length` is still 4, so a result that's rank-1 in both _contributing_ lists scores `(2/(k+1)) / (4/(k+1)) = 0.5` instead of the intended `1.0`.
+
+Symptom: scores compress toward zero. If any downstream consumer thresholds on score (e.g., "only show results > 0.7"), the threshold is never met. Ranking order is preserved but absolute values lie.
+
+## Solution
+
+### 1. Compound identity key for the fusion Map
+
+Don't key the fusion accumulator by the bare result ID. Key it by `${resultType}:${resultId}`:
+
+```typescript
+// fusion.ts
+export type RankedItem = {
+  resultType: "video" | "experience"
+  resultId: number
+  // ...other fields, kept in an open index signature for now
+  [key: string]: unknown
+}
+
+export function fuseRankedLists(
+  lists: RankedItem[][],
+  k: number = 60,
+): FusedResult[] {
+  const scoreMap = new Map<string, number>() // <-- string, not number
+  const propsMap = new Map<string, RankedItem>()
+
+  for (const list of lists) {
+    for (let rank = 0; rank < list.length; rank++) {
+      const item = list[rank]
+      const key = `${item.resultType}:${item.resultId}` // <-- compound
+      const contribution = 1 / (k + rank + 1)
+      scoreMap.set(key, (scoreMap.get(key) ?? 0) + contribution)
+      // ...property merge
+    }
+  }
+  // ...normalize and sort
+}
+```
+
+This costs nothing — Map<string> performs identically to Map<number> for this access pattern — and eliminates the entire collision class.
+
+The same compound-key discipline extends to dedup. If your dedup logic is type-specific (e.g., "two videos with prefix-matching `core_id` are duplicates"), guard it with a type check so it doesn't accidentally merge across types:
+
+```typescript
+function deduplicateResults(results: FusedResult[]): FusedResult[] {
+  // ...
+  for (const candidate of results) {
+    if (candidate.resultType === "video") {
+      // video-specific dedup checks (core_id prefix, title match, embedding similarity)
+    }
+    // experiences pass through unchanged — their dedup story is different
+  }
+}
+```
+
+The orchestrator owns the wiring — search functions stay agnostic of the multi-type model:
+
+```typescript
+// search.ts orchestrator
+function annotateVideo<T extends { videoId: number }>(item: T): T & RankedItem {
+  return { ...item, resultType: "video", resultId: item.videoId }
+}
+
+const videoResults = await searchBySemantic(...)  // returns SemanticResult, no resultType
+const tagged = videoResults.map(annotateVideo)    // adds compound identity
+fuseRankedLists([tagged, ...otherLists], 60)
+```
+
+This keeps the existing video search functions backward-compatible. They never had to know about the fusion contract.
+
+### 2. Filter empty lists before passing them to RRF
+
+```typescript
+// orchestrator
+const lists = outcomes.map((o) => unwrapOutcome(o)) // may produce []
+const nonEmpty = lists.filter((list) => list.length > 0)
+const fused = fuseRankedLists(nonEmpty, RRF_K) // accurate normalization
+```
+
+Two situations make this load-bearing:
+
+- **Conditional retrievals**: a `?type=video` API filter fires only video retrievals; the unfired experience retrievals shouldn't appear as empty placeholders in the fusion call.
+- **Graceful degradation**: when one retrieval fails (semantic embedding service down, pgvector timeout) and `Promise.allSettled` returns it as `[]`, the score normalization should reflect what actually contributed.
+
+The combined effect: a result ranked #1 in the only contributing list scores `1.0` (correct), not `1/N` where N counts empty lists.
+
+## Why this works
+
+**Compound key**: RRF's identity contract is "two items in different lists with the same key are the same item." That contract only holds within a single identity namespace. Adding a type prefix creates a wider namespace where each `(resultType, resultId)` pair is a unique anchor. Cross-type collisions become impossible by construction.
+
+**Empty filtering**: RRF's normalization assumes every input list is a real opinion about ranking. An empty list isn't an opinion — it's the absence of one. Including it in the divisor punishes lists that did contribute, in a way that compounds with `lists.length`. Filtering is the simplest way to make `theoreticalMax` reflect actual signal.
+
+## Prevention
+
+### Tests that catch these bugs
+
+Both failures are silent. Add tests that assert on values, not just shapes:
+
+```typescript
+// Compound key collision test
+it("does not collide a video and an experience with the same integer ID", () => {
+  const results = fuseRankedLists(
+    [
+      [{ resultType: "video", resultId: 4 }],
+      [{ resultType: "experience", resultId: 4 }],
+    ],
+    60,
+  )
+  expect(results).toHaveLength(2) // both survive
+})
+
+// Empty-list filtering test
+it("does not pass empty lists into fusion", async () => {
+  // Mock 1 retrieval to return data, 3 to return empty
+  await search(strapi, { query: "test", locale: "en" })
+  const passedLists = vi.mocked(fuseRankedLists).mock.calls[0][0]
+  expect(passedLists).toHaveLength(1) // not 4
+})
+
+// Score normalization test (verifies the math, not just the order)
+it("rank-1 in the only contributing list scores 1.0, not 0.25", () => {
+  // Without empty-list filtering this test fails with score ≈ 0.25
+})
+```
+
+The score-value test is the canary. If a refactor accidentally re-introduces empty-list passing, the order tests still pass but the value test fails.
+
+### Where to look in code review
+
+- Any `Map<number, ...>` or `Record<number, ...>` in a fusion / dedup / merge layer where multiple result types are in play.
+- Any `Promise.allSettled([...])` followed directly by a fusion call without a length filter.
+- Any switch/branch on `result.type` (or equivalent discriminator) that doesn't have a default branch — ID-collision bugs often manifest as missing default handling.
+
+### Generalizes beyond RRF
+
+The same two patterns apply to any N-way ranking aggregator that accumulates per-item scores across lists:
+
+- Borda count
+- Comb-SUM / Comb-MNZ
+- Weighted blending
+- Custom "boost on appearance in any list" logic
+
+If you're combining scores from heterogeneous sources, key by `(type, id)` and ignore empty inputs.

--- a/docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md
+++ b/docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md
@@ -1,0 +1,239 @@
+---
+title: "pgvector HNSW index bypassed by planner when WHERE filter on indexed table"
+category: "performance-issues"
+problem_type: "performance_issue"
+component: "database"
+root_cause: "missing_index"
+resolution_type: "code_fix"
+severity: "medium"
+module: "apps/cms"
+tags:
+  - pgvector
+  - hnsw
+  - postgresql
+  - query-planner
+  - partial-index
+  - semantic-search
+  - experience-embeddings
+  - cms
+date: "2026-04-15"
+related_prs:
+  - "JesusFilm/forge#777"
+related_docs:
+  - "docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md"
+  - "docs/solutions/best-practices/pgvector-recommendation-query-locale-graphql-strapi-v5.md"
+  - "docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md"
+  - "docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md"
+---
+
+# pgvector HNSW index bypassed by planner when WHERE filter on indexed table
+
+## Problem
+
+PostgreSQL's query planner silently bypasses pgvector HNSW indexes when a `WHERE` clause filters on a column belonging to the same indexed table. The planner's cost model for HNSW + post-filter is too pessimistic, so it chooses `Seq Scan + Top-N Sort` even when HNSW would be 5–10× faster — and at scale, **94× faster**.
+
+## Symptoms
+
+- Query latency **178ms** with JOIN at 10K rows (seqscan + nested loop), vs **19.8ms** without JOIN.
+- `EXPLAIN ANALYZE` shows the planner choosing a sequential scan with post-filter instead of the HNSW index:
+
+```
+Seq Scan on experience_embeddings ee
+  Filter: ((locale)::text = 'en'::text)
+  Rows Removed by Filter: 8000
+  ->  Sort Method: top-N heapsort  Memory: 32kB
+```
+
+Instead of the expected:
+
+```
+Index Scan using experience_embeddings_hnsw on experience_embeddings ee
+  Order By: (embedding <=> $1)
+```
+
+The problematic query in `apps/cms/src/api/search/services/experience-semantic-search.ts`:
+
+```sql
+SELECT ee.experience_id, e.slug, e.title, e.meta_description,
+  1 - (ee.embedding <=> ?::vector) AS similarity
+FROM experience_embeddings ee
+JOIN experiences e ON e.id = ee.experience_id AND e.published_at IS NOT NULL
+WHERE ee.locale = ?
+ORDER BY ee.embedding <=> ?::vector
+LIMIT ?
+```
+
+The HNSW index `experience_embeddings_hnsw` exists. The planner just refuses to use it because of the `WHERE locale = ?` predicate.
+
+## What Didn't Work
+
+Five strategies tested locally with `EXPLAIN ANALYZE` on a 10K-row synthetic table (pgvector 0.8.2, PostgreSQL 16):
+
+| #   | Strategy                                                         | Result                                                                                                              | Time     |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
+| 1   | `SET hnsw.iterative_scan = relaxed_order` alone                  | Planner still picked Seq Scan — GUC only affects HNSW scans _when chosen_, doesn't influence the planner's decision | 13ms     |
+| 2   | Subquery wrapping (HNSW in inner SELECT, locale filter in outer) | Worked standalone (7.35ms) but JOIN to `experiences` flattened the planner's view; `MATERIALIZED` CTE also failed   | 76–178ms |
+| 3   | `SET hnsw.ef_search = 500` (bigger search window)                | Still Seq Scan — same root cause as #1                                                                              | 16ms     |
+| 4   | `SET enable_seqscan = off`                                       | Forced HNSW (20ms with JOIN) but heavy-handed escape hatch affecting all queries on the connection                  | 20ms     |
+| 5   | Multi-locale partial index (`WHERE locale IN ('en','es','fr')`)  | Worked (1.91ms) but a REINDEX is needed whenever locales evolve                                                     | 1.91ms   |
+
+The recurring lesson: **the GUCs (`iterative_scan`, `ef_search`) only modulate HNSW scans the planner has already chosen.** They do not change the planner's choice. Restructuring the SQL helps when standalone but the planner re-flattens it as soon as a JOIN appears downstream.
+
+## Solution
+
+Two coordinated changes — **no SQL changes in the search service itself**:
+
+### 1. Per-locale partial HNSW indexes
+
+File: `apps/cms/src/bootstrap/ensure-pgvector.ts`
+
+```sql
+-- Keep the global HNSW as a fallback for unknown locales
+CREATE INDEX IF NOT EXISTS experience_embeddings_hnsw
+  ON experience_embeddings USING hnsw (embedding vector_cosine_ops);
+
+-- Add a partial HNSW per Phase 1 locale
+CREATE INDEX IF NOT EXISTS experience_embeddings_hnsw_en
+  ON experience_embeddings USING hnsw (embedding vector_cosine_ops)
+  WHERE locale = 'en';
+
+CREATE INDEX IF NOT EXISTS experience_embeddings_hnsw_es
+  ON experience_embeddings USING hnsw (embedding vector_cosine_ops)
+  WHERE locale = 'es';
+
+CREATE INDEX IF NOT EXISTS experience_embeddings_hnsw_fr
+  ON experience_embeddings USING hnsw (embedding vector_cosine_ops)
+  WHERE locale = 'fr';
+```
+
+The global HNSW index is kept as a fallback for unknown locales — queries with `WHERE locale = 'xx'` (no partial match) fall back to seqscan, still functional, just slower at scale. Adding a new locale = single `CREATE INDEX` line.
+
+### 2. Connection-level GUCs for iterative scan
+
+File: `apps/cms/config/database.ts` — extend the existing `afterCreate` hook:
+
+```typescript
+afterCreate(
+  conn: { query: (sql: string, cb: () => void) => void },
+  cb: () => void,
+) {
+  const statementTimeout = env.int("DATABASE_STATEMENT_TIMEOUT", 30000)
+  const idleTxTimeout = env.int("DATABASE_IDLE_IN_TRANSACTION_TIMEOUT", 60000)
+  conn.query(
+    `SET statement_timeout = ${statementTimeout};
+     SET idle_in_transaction_session_timeout = ${idleTxTimeout};
+     SET hnsw.iterative_scan = relaxed_order;
+     SET hnsw.max_scan_tuples = 20000;`,
+    cb,
+  )
+}
+```
+
+- `hnsw.iterative_scan = relaxed_order` lets the partial index keep fetching past the default `ef_search = 40` window when LIMIT requires more candidates.
+- `relaxed_order` allows HNSW to return rows out of strict distance order during iteration — safe because the outer `ORDER BY` re-sorts.
+- `hnsw.max_scan_tuples = 20000` caps the iterative scan so it cannot run away on pathological queries.
+
+Set once per connection in the pool's `afterCreate` hook → **zero per-query overhead**.
+
+### Verification
+
+Production-shaped query (`JOIN + LIMIT 60`) on a 10K-row synthetic `experience_embeddings`:
+
+| Locale                  | Plan                                         | Time       |
+| ----------------------- | -------------------------------------------- | ---------- |
+| `en` (partial index)    | `Index Scan using ..._hnsw_en` + Nested Loop | **1.90ms** |
+| `de` (no partial index) | Seq Scan + Hash Join (graceful fallback)     | 17.55ms    |
+| baseline (before fix)   | Seq Scan + Sort + Nested Loop                | 178ms      |
+
+**94× faster** for indexed locales.
+
+## Why This Works
+
+The root cause is pgvector's broken cost model for HNSW + post-filter. When the planner sees:
+
+```
+WHERE ee.locale = 'en' ORDER BY ee.embedding <=> ? LIMIT 60
+```
+
+it estimates the cost of scanning the HNSW index _and then_ discarding rows that fail the locale predicate. Because HNSW doesn't natively understand locale, the planner assumes it may need to scan many index entries to find enough matching rows — and its cost estimate balloons past the seqscan alternative.
+
+Partial indexes sidestep this entirely:
+
+1. The index definition `WHERE locale = 'en'` means **every row in the index already satisfies the locale predicate**. There is no post-filter.
+2. PostgreSQL's planner sees `WHERE locale = 'en'` in the query and recognizes that the partial index `..._hnsw_en WHERE locale = 'en'` covers exactly the matching rows. The locale filter is "free."
+3. The cost model is never asked the pessimistic question — the answer is implicitly "all rows in this index match."
+4. The `Index Scan` returns rows directly from the partial HNSW in approximate distance order; the outer `ORDER BY` does a final sort on a small result set.
+
+`iterative_scan` is the second half: even with a matching partial index, default HNSW returns at most `ef_search = 40` candidates per pass. Without it, `LIMIT 60` would only see 40 results. With `iterative_scan = relaxed_order`, HNSW keeps fetching until the LIMIT (capped by `max_scan_tuples`) is satisfied.
+
+## Prevention
+
+### When to reach for partial indexes with pgvector
+
+- **Any time you combine `WHERE column = ?` with `ORDER BY embedding <=> ?` on the same table.** If the filtered column is not part of the HNSW index, the planner will likely bypass it.
+- **Cardinality matters.** Partial indexes work best for low-cardinality filter columns (locales, content types, status flags). High-cardinality columns (user IDs, slugs) would create too many indexes — use a different approach (e.g., a covering composite index, or pre-filter via a separate query).
+- **Existing scene_embeddings query is unaffected** because its locale filter lives on a JOINed table (`languages.bcp_47`), not on `scene_embeddings` itself. The HNSW index on `scene_embeddings.embedding` is unconstrained by JOINs to other tables.
+
+### Signs of the seqscan problem in EXPLAIN ANALYZE
+
+Look for these red flags:
+
+```
+Seq Scan on <table_with_embedding>
+  Filter: (<non-embedding_column> = ...)
+  Rows Removed by Filter: <large number>
+```
+
+```
+Sort Method: top-N heapsort
+  Sort Key: (embedding <=> ...)
+```
+
+If you see `Sort Method: top-N heapsort` on an embedding distance, the HNSW index was **not used**. A working HNSW query shows `Index Scan using <hnsw_index_name>` with `Order By: (embedding <=> ...)`.
+
+### What to grep for in future pgvector code
+
+```bash
+# Embedding queries with WHERE — likely candidates for partial indexes
+grep -rn 'ORDER BY.*<=>\|ORDER BY.*<#>\|ORDER BY.*<->' apps/cms/src/
+
+# Audit existing HNSW index definitions
+grep -rn 'USING hnsw' apps/cms/src/
+```
+
+For every match of the first pattern, ask: "Does the WHERE clause filter the same table the HNSW index lives on?" If yes, the partial-index pattern is needed.
+
+### Suggested EXPLAIN-based regression test
+
+Add an integration test that verifies the planner picks the HNSW index. Catches regressions from schema changes, pgvector upgrades, or PostgreSQL version bumps:
+
+```typescript
+it("uses HNSW partial index for locale-filtered similarity search", async () => {
+  const result = await knex.raw(
+    `EXPLAIN (FORMAT JSON)
+     SELECT ee.experience_id,
+       1 - (ee.embedding <=> ?::vector) AS similarity
+     FROM experience_embeddings ee
+     WHERE ee.locale = ?
+     ORDER BY ee.embedding <=> ?::vector
+     LIMIT 60`,
+    [testEmbedding, "en", testEmbedding],
+  )
+
+  const plan = JSON.stringify(result.rows[0])
+  expect(plan).toContain("Index Scan")
+  expect(plan).toContain("experience_embeddings_hnsw_en")
+  expect(plan).not.toContain("Seq Scan")
+})
+```
+
+`EXPLAIN` (not `EXPLAIN ANALYZE`) only inspects the plan without executing — fast and safe for CI. If pgvector or PostgreSQL ever changes the planner behavior, this test fails before latency regresses in production.
+
+### Documentation hygiene
+
+Cross-reference this doc from any pgvector-related learning that recommends an HNSW index without discussing filter degradation. The four most relevant existing docs to refresh:
+
+- `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md` — section 5 ("Use HNSW over IVFFlat") should add a caveat about WHERE filter degradation.
+- `docs/solutions/best-practices/pgvector-recommendation-query-locale-graphql-strapi-v5.md` — the "45ms execution time...HNSW handles it efficiently" claim is true at 1,965 rows but degrades at scale.
+- `docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md` — the experience_embeddings table doc should reference the partial-index strategy.
+- `docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md` — the architectural search doc should mention HNSW filter performance as a known operational concern.


### PR DESCRIPTION
## Summary

Extends the hybrid search API to return experience results alongside videos. Searching `Easter` no longer just returns videos about Easter bunnies — the dedicated Easter experience page surfaces too.

- **4-list RRF fusion**: orchestrator runs up to 4 parallel retrievals (video semantic, video keyword, experience semantic, experience keyword) via `Promise.allSettled`. Empty lists are filtered before fusion so RRF normalization stays accurate.
- **Compound identity key**: `fuseRankedLists` now keys by `\${resultType}:\${resultId}` instead of `videoId`, so a video with id=4 and an experience with id=4 no longer collide.
- **Type guard on dedup**: the 3-layer video dedup (core_id prefix, title match, embedding similarity) skips non-video results — experiences pass through untouched.
- **Type filter parameter** on REST (`?type=video|experience`) and GraphQL (`semanticSearch(type: ...)`). Omitted = both. Invalid = 400 / `BAD_USER_INPUT`. When a single type is requested only its retrievals fire.
- **No backward-compat breakage**: existing consumers see no breaking changes. `startSeconds` and `playbackId` were already nullable on `SearchResult`.

Plan: [docs/plans/2026-04-15-001-feat-experience-search-integration-plan.md](docs/plans/2026-04-15-001-feat-experience-search-integration-plan.md)
Roadmap: [feat-086](docs/roadmap/content-discovery/feat-086-experience-search-integration.md) (status → complete)

## Testing

- 113 search-related tests pass (33 fusion + 20 orchestrator + 8 experience-semantic + 10 experience-keyword + 13 controller + 16 GraphQL + 7 video keyword + 6 video semantic)
- Full CMS suite: **284/284 passing** — no regressions
- TypeScript: clean
- ESLint: clean

Key new test coverage:
- `fusion.test.ts`: compound key prevents video↔experience id collision; dedup type guard preserves experiences with shared titles; mixed video+experience dedup still drops video duplicates
- `search.test.ts`: \`contentTypes\` filter (video-only, experience-only, both, empty array fallback); empty lists filtered before fusion; mixed result mapping; collision case
- `controllers/search.test.ts`: \`?type=video\`, \`?type=experience\`, omitted, invalid (400), empty string (defaults)
- `graphql/search.test.ts`: \`type\` argument forwarded; invalid type throws \`GraphQLError\` with \`BAD_USER_INPUT\`

## Manual verification (post-deploy)

\`\`\`bash
# Both content types (default)
curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en'

# Videos only — backward-compatible behavior matches v1
curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en&type=video'

# Experiences only
curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en&type=experience'

# Invalid type — should return 400
curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en&type=invalid'

# GraphQL
curl -X POST https://cms.jesusfilm.org/graphql -H 'Content-Type: application/json' \\
  -d '{\"query\":\"{ semanticSearch(query:\\\"Easter\\\", locale:\\\"en\\\", type:\\\"experience\\\") { results { type id slug title } } }\"}'
\`\`\`

Expected: experience search returns the \`easter\` and \`christmas\` experiences (the two embedded by feat-095/096) when the query is thematically relevant; videos still return as before; mixed results interleave by RRF score.

## Out of scope

- Experience image URL is \`null\` in v1 — \`og_image\` is a Strapi media relation requiring a multi-table join through \`files_related_morphs\`. Plan defers this; downstream consumers can treat \`imageUrl\` as nullable as already documented in the contract.
- Within-experience dedup (currently skipped — only 2 experiences exist; revisit if volume grows)
- \`schema.graphql\` is auto-generated by Strapi at build time and will reflect the new \`type\` argument and updated \`SearchResult\` descriptions on next deploy. Not committed here because regeneration requires a live DB connection.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: \`[search]\` prefixed log lines in CMS Railway logs. Watch for \`semantic-experience\` and \`keyword-experience\` retrieval failures.
  - Metrics/Dashboards: CMS request latency for \`/api/search\` (p95 < 500ms target).
- **Validation checks (queries/commands)**
  - \`curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en'\` — should include \`type: \"experience\"\` results
  - \`curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en&type=video'\` — should be byte-equivalent to pre-merge response
  - \`curl 'https://cms.jesusfilm.org/api/search?q=Easter&locale=en&type=invalid'\` — should return 400
- **Expected healthy behavior**
  - \"Easter\" / \"Christmas\" queries return the corresponding experience as a top result alongside thematically relevant videos
  - Response time p95 stays < 500ms (4 parallel queries should not exceed 2-query baseline by much; experience SQL is simpler than video SQL)
  - \`type=video\` returns identical results to pre-feat-086 (regression check)
- **Failure signal(s) / rollback trigger**
  - p95 latency > 1s sustained for 5+ minutes → rollback
  - \`semantic-experience\` or \`keyword-experience\` retrieval failure rate > 5% over 10 minutes → investigate (may indicate \`experience_embeddings\` table missing or pgvector index issue)
- **Validation window & owner**
  - Window: 24h post-deploy
  - Owner: nisal

---

[![Compound Engineering v2.52.0](https://img.shields.io/badge/Compound_Engineering-v2.52.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)