### PR TITLE
chore(roadmap): mark completed tickets and cancel feat-003

### DIFF
--- a/docs/roadmap/content-discovery/feat-037-video-content-vectorization.md
+++ b/docs/roadmap/content-discovery/feat-037-video-content-vectorization.md
@@ -3,7 +3,7 @@ id: "feat-037"
 title: "Video Content Vectorization for Recommendations"
 owner: "nisal"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-21"
 duration: 42
 depends_on:

--- a/docs/roadmap/content-discovery/feat-071-recommendation-content-deduplication.md
+++ b/docs/roadmap/content-discovery/feat-071-recommendation-content-deduplication.md
@@ -3,7 +3,7 @@ id: "feat-071"
 title: "Recommendation Content Deduplication"
 owner: "nisal"
 priority: "P2"
-status: "not-started"
+status: "complete"
 start_date: "2026-06-15"
 duration: 5
 depends_on:

--- a/docs/roadmap/content-discovery/feat-095-experience-embedding-pipeline.md
+++ b/docs/roadmap/content-discovery/feat-095-experience-embedding-pipeline.md
@@ -3,7 +3,7 @@ id: "feat-095"
 title: "Experience Embedding Pipeline"
 owner: "nisal"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-04-16"
 duration: 5
 depends_on:

--- a/docs/roadmap/content-discovery/feat-096-experience-embeddings-backfill.md
+++ b/docs/roadmap/content-discovery/feat-096-experience-embeddings-backfill.md
@@ -3,7 +3,7 @@ id: "feat-096"
 title: "Experience Embeddings Backfill"
 owner: "nisal"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-04-21"
 duration: 2
 depends_on:

--- a/docs/roadmap/content-discovery/feat-097-investigate-prod-query-embedding.md
+++ b/docs/roadmap/content-discovery/feat-097-investigate-prod-query-embedding.md
@@ -3,7 +3,7 @@ id: "feat-097"
 title: "Investigate Production Query Embedding Degradation"
 owner: "nisal"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-04-15"
 duration: 2
 depends_on: []

--- a/docs/roadmap/topic-experiences/feat-003-topic-content-type.md
+++ b/docs/roadmap/topic-experiences/feat-003-topic-content-type.md
@@ -3,7 +3,7 @@ id: "feat-003"
 title: "Topic Content Type in Strapi"
 owner: "nisal"
 priority: "P0"
-status: "not-started"
+status: "cancelled"
 start_date: "2026-04-01"
 duration: 14
 depends_on:


### PR DESCRIPTION
## Summary

Housekeeping pass on roadmap ticket statuses after the search/embedding work shipped.

- **feat-037** → `complete` — all 8 sub-tickets (038–042, 044–046) already marked complete; parent was missed
- **feat-071** → `complete` — 3-layer dedup (core_id prefix, title match, cosine >0.95) is live in both `recommender.ts` and `fusion.ts`
- **feat-095** → `complete` — experience embedding pipeline shipped in PR #771
- **feat-096** → `complete` — experience embeddings backfill shipped in PR #771
- **feat-097** → `complete` — production fix live + hardening PR #780 merged
- **feat-003** → `cancelled` — Topic Content Type dropped from roadmap

## Test plan

- [ ] Docs-only change, no code affected
- [ ] Verify roadmap viewer renders updated statuses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)