### PR TITLE
chore(roadmap): mark search UI and TV app features as complete

### DIFF
--- a/docs/roadmap/content-discovery/feat-011-search-ui-web.md
+++ b/docs/roadmap/content-discovery/feat-011-search-ui-web.md
@@ -3,7 +3,7 @@ id: "feat-011"
 title: "Search UI — Web"
 owner: "urim"
 priority: "P0"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-14"
 duration: 21
 depends_on:

--- a/docs/roadmap/content-discovery/feat-012-search-ui-mobile.md
+++ b/docs/roadmap/content-discovery/feat-012-search-ui-mobile.md
@@ -3,7 +3,7 @@ id: "feat-012"
 title: "Search UI — Mobile"
 owner: "urim"
 priority: "P0"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-14"
 duration: 21
 depends_on:

--- a/docs/roadmap/topic-experiences/feat-072-tv-app-spike.md
+++ b/docs/roadmap/topic-experiences/feat-072-tv-app-spike.md
@@ -3,7 +3,7 @@ id: "feat-072"
 title: "TV App — Expo TV Toolchain Spike"
 owner: "urim"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-10"
 duration: 2
 depends_on: []

--- a/docs/roadmap/topic-experiences/feat-073-tv-app-scaffolding.md
+++ b/docs/roadmap/topic-experiences/feat-073-tv-app-scaffolding.md
@@ -3,7 +3,7 @@ id: "feat-073"
 title: "TV App — Scaffolding + GraphQL Wiring"
 owner: "urim"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-12"
 duration: 3
 depends_on:

--- a/docs/roadmap/topic-experiences/feat-074-tv-app-home-screen.md
+++ b/docs/roadmap/topic-experiences/feat-074-tv-app-home-screen.md
@@ -3,7 +3,7 @@ id: "feat-074"
 title: "TV App — Home Screen (Hero + Experiences Rail)"
 owner: "urim"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-15"
 duration: 5
 depends_on:

--- a/docs/roadmap/topic-experiences/feat-075-tv-app-experience-screen.md
+++ b/docs/roadmap/topic-experiences/feat-075-tv-app-experience-screen.md
@@ -3,7 +3,7 @@ id: "feat-075"
 title: "TV App — Experience Detail Screen (SDUI Renderers)"
 owner: "urim"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-04-15"
 duration: 7
 depends_on:

--- a/docs/roadmap/topic-experiences/feat-076-tv-app-video-playback.md
+++ b/docs/roadmap/topic-experiences/feat-076-tv-app-video-playback.md
@@ -3,7 +3,7 @@ id: "feat-076"
 title: "TV App — Video Playback + Polish"
 owner: "urim"
 priority: "P1"
-status: "not-started"
+status: "in-progress"
 start_date: "2026-04-22"
 duration: 7
 depends_on:


### PR DESCRIPTION
## Summary
- Update roadmap status for 7 features assigned to urim that were implemented but still marked as `not-started`
- feat-011, feat-012 (Search UI Web/Mobile) → `complete`
- feat-072 through feat-075 (TV App Spike, Scaffolding, Home Screen, Experience Screen) → `complete`
- feat-076 (TV App Video Playback + Polish) → `in-progress`

## Test plan
- [ ] Verify roadmap dashboard at https://ds-ai.jesusfilm.org/roadmap reflects updated statuses
- [ ] Confirm no other frontmatter fields were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)