### PR TITLE
docs(roadmap): add recommendation personalization tickets (feat-090–094)

### DIFF
--- a/docs/roadmap/content-discovery/feat-046-recommendations-demo-experience.md
+++ b/docs/roadmap/content-discovery/feat-046-recommendations-demo-experience.md
@@ -8,7 +8,8 @@ start_date: "2026-06-04"
 duration: 7
 depends_on:
   - "feat-044"
-blocks: []
+blocks:
+  - "feat-090"
 tags:
   - "web"
   - "cms"

--- a/docs/roadmap/content-discovery/feat-063-personalize-discovery-experiences.md
+++ b/docs/roadmap/content-discovery/feat-063-personalize-discovery-experiences.md
@@ -8,6 +8,7 @@ start_date: "2026-10-01"
 duration: 45
 depends_on:
   - "feat-058"
+  - "feat-090"
 blocks:
   - "feat-064"
 tags:

--- a/docs/roadmap/content-discovery/feat-090-watch-event-collection.md
+++ b/docs/roadmap/content-discovery/feat-090-watch-event-collection.md
@@ -1,0 +1,109 @@
+---
+id: "feat-090"
+title: "Watch Event Collection & Session Tracking"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-21"
+duration: 10
+depends_on:
+  - "feat-046"
+blocks:
+  - "feat-091"
+  - "feat-092"
+tags:
+  - "cms"
+  - "web"
+  - "infrastructure"
+  - "personalization"
+---
+
+## Problem
+
+The recommendation system returns identical results for every user watching the same video — pure cosine similarity with no learning from behavior. Before any personalization model can be trained (FPMC for "watch next", Two-Tower for home page), interaction data must be collected. No watch event infrastructure exists today.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/api/scene-embedding/services/recommender.ts` — current recommendation query that will eventually consume personalization signals
+2. `apps/cms/src/bootstrap/ensure-pgvector.ts` — pattern for bootstrap SQL table creation (same approach for `watch_events`)
+3. `apps/web/src/app/layout.tsx` — root layout where session cookie middleware would be wired
+4. `apps/web/src/components/VideoPlayer.tsx` or equivalent — video player component where watch events are emitted
+5. `docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md` — full requirements (R1-R3)
+
+## Grep These
+
+- `recommender` in `apps/cms/src/` — current recommendation path
+- `cookie` in `apps/web/src/` — any existing cookie patterns
+- `video.*player\|VideoPlayer` in `apps/web/src/` — video playback components
+- `ensure.*table\|CREATE TABLE` in `apps/cms/src/bootstrap/` — table creation pattern
+
+## What To Build
+
+### watch_events table (CMS PostgreSQL)
+
+```sql
+CREATE TABLE IF NOT EXISTS watch_events (
+  id              SERIAL PRIMARY KEY,
+  session_id      UUID NOT NULL,
+  video_id        INTEGER NOT NULL,
+  watch_duration  FLOAT NOT NULL,
+  video_duration  FLOAT NOT NULL,
+  completion      FLOAT GENERATED ALWAYS AS (
+    CASE WHEN video_duration > 0 THEN watch_duration / video_duration ELSE 0 END
+  ) STORED,
+  is_bounce       BOOLEAN GENERATED ALWAYS AS (
+    CASE WHEN video_duration > 0 THEN (watch_duration / video_duration) < 0.3 ELSE TRUE END
+  ) STORED,
+  geo_country     TEXT,
+  geo_region      TEXT,
+  device_type     TEXT,
+  browser_lang    TEXT,
+  referrer_type   TEXT,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS watch_events_session_id ON watch_events(session_id);
+CREATE INDEX IF NOT EXISTS watch_events_video_id ON watch_events(video_id);
+CREATE INDEX IF NOT EXISTS watch_events_created_at ON watch_events(created_at);
+CREATE INDEX IF NOT EXISTS watch_events_not_bounce
+  ON watch_events(video_id, session_id) WHERE NOT is_bounce;
+```
+
+### Session cookie (apps/web)
+
+- First-party UUID cookie set on first visit, persists across visits
+- `HttpOnly: false` (needs JS read for event emission), `SameSite: Lax`, `Secure: true`
+- Cookie name: `jfp_session`
+- Generate UUID client-side on first visit, store in cookie with 1-year expiry
+
+### Event emission (apps/web)
+
+- Emit watch events from the video player on: (a) video pause, (b) video end, (c) tab/page unload (`visibilitychange` or `beforeunload`)
+- POST to `POST /api/watch-events` with `{ sessionId, videoId, watchDuration, videoDuration }`
+- Use `navigator.sendBeacon` for unload events to avoid lost data
+- Debounce: don't emit more than once per 5 seconds for the same video
+
+### Watch event API (CMS)
+
+- `POST /api/watch-events` — accepts event payload, extracts geo/device/language from request headers
+- `auth: false` (public, matches search endpoint pattern)
+- Rate limited: 60/min per session ID
+- Validate: `videoId` exists, `watchDuration >= 0`, `videoDuration > 0`
+
+## Constraints
+
+- No login system. All identity is session/cookie-based.
+- No PII stored — session_id is a random UUID, not tied to any user account.
+- GDPR: cookie is functional (enables personalized recommendations), not tracking. May need consent banner for EU — defer legal review to implementation.
+- Do not modify the existing recommendation query in this ticket. Data collection only.
+- Web app first. Mobile instrumentation is a follow-up.
+
+## Verification
+
+1. Visit a video page → `jfp_session` cookie is set with a UUID value
+2. Watch a video for >30% → `watch_events` table has a row with `is_bounce = false`
+3. Watch <30% and navigate away → row exists with `is_bounce = true`
+4. `SELECT COUNT(*) FROM watch_events` grows as users interact
+5. `SELECT session_id, COUNT(*) FROM watch_events GROUP BY session_id HAVING COUNT(*) > 1` returns sessions with multiple videos (prerequisite for FPMC training)
+6. Geo/device/language columns populated from request headers
+7. `sendBeacon` fires on tab close — no lost events on navigation

--- a/docs/roadmap/content-discovery/feat-091-fpmc-video-page-recommendations.md
+++ b/docs/roadmap/content-discovery/feat-091-fpmc-video-page-recommendations.md
@@ -1,0 +1,80 @@
+---
+id: "feat-091"
+title: "FPMC Video Page Recommendations"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-05-01"
+duration: 14
+depends_on:
+  - "feat-090"
+blocks:
+  - "feat-094"
+tags:
+  - "cms"
+  - "web"
+  - "ai-pipeline"
+  - "personalization"
+---
+
+## Problem
+
+On video pages, "watch next" recommendations are pure cosine similarity — every user sees the same list. Factorized Personalized Markov Chains (FPMC) combine global transition patterns ("from video A, most users go to video B") with session preference patterns ("this session watches contemplative content") to predict the most likely next video for each session.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/api/scene-embedding/services/recommender.ts` — current cosine similarity recommendation query; blend logic will be added here
+2. `apps/cms/src/api/scene-embedding/services/recommender.ts:deduplicateResults` — 3-layer dedup that must work with blended scores
+3. `docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md` — R4-R6 (FPMC requirements)
+4. `watch_events` table (feat-090) — source data for training
+
+## Grep These
+
+- `queryPerVideo\|querySimilar` in `apps/cms/src/api/scene-embedding/` — recommendation entry points
+- `deduplicateResults` in `apps/cms/src/` — dedup that must handle blended scores
+- `watch_events` in `apps/cms/src/` — interaction data source
+
+## What To Build
+
+### Training pipeline (offline, Python)
+
+- Python script using PyTorch (or RecBole for experimentation)
+- Reads non-bounce `watch_events` grouped by `session_id`, ordered by `created_at`
+- Trains FPMC model: learns transition matrix (video A → video B) factorized with session latent factors
+- Exports transition factors to PostgreSQL tables:
+  - `fpmc_transitions(from_video_id, to_video_id, transition_score)` — global transition probabilities
+  - `fpmc_factors(video_id, factor_vector)` — latent factor embeddings for matrix factorization component
+- Training job runs as a Railway cron or GitHub Action (decide during planning)
+- Versioned model artifacts; rollback is a config change
+
+### Blend logic (CMS recommender.ts)
+
+- For each recommendation request on a video page:
+  1. Get cosine similarity candidates (existing path)
+  2. Get FPMC transition scores for the source video
+  3. Blend: `score = (1 - w) * cosine + w * fpmc` where `w` is a function of observation count
+  4. Blend weight ramp: start at `w=0.1` (90% content, 10% FPMC), shift toward `w=0.5` as transition observations grow
+- Accept optional `sessionId` parameter to incorporate session-specific factors when available
+
+### Progressive activation
+
+- Per-video activation threshold: only use FPMC scores when the source video has >= 20 observed transitions
+- Below threshold: pure cosine similarity (current behavior, invisible to user)
+- Activation check is a simple count query against `fpmc_transitions`
+
+## Constraints
+
+- Fallback must be invisible — when FPMC data is insufficient, users see the same results as today
+- Do not retrain on every request; models are batch-trained offline
+- Blend weight formula must be tunable without redeployment (configurable constant or env var)
+- Phase 1 languages only (en, es, fr)
+- Do not modify the search API — FPMC applies to video page recommendations only
+
+## Verification
+
+1. Two users watching the same video with different session histories see different "watch next" lists
+2. A video with 20+ transitions shows blended scores; a video with <20 transitions shows pure cosine
+3. Blend weight at 20 observations is ~0.1; at 200+ observations approaches 0.5
+4. Recommendation quality: for 50 seed videos with sufficient transitions, at least 30% of top-5 results differ from pure cosine baseline
+5. Training pipeline completes in <1 hour for current data volume
+6. Rollback: switching model version restores previous recommendation behavior

--- a/docs/roadmap/content-discovery/feat-092-two-tower-neural-recommendations.md
+++ b/docs/roadmap/content-discovery/feat-092-two-tower-neural-recommendations.md
@@ -1,0 +1,88 @@
+---
+id: "feat-092"
+title: "Two-Tower Neural Recommendation Model"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-05-15"
+duration: 21
+depends_on:
+  - "feat-090"
+blocks:
+  - "feat-093"
+  - "feat-094"
+tags:
+  - "cms"
+  - "web"
+  - "ai-pipeline"
+  - "personalization"
+  - "pgvector"
+---
+
+## Problem
+
+The home page and recommendation components need session-aware personalization beyond sequential "watch next" prediction. A Two-Tower neural model learns a shared embedding space where user sessions and video content can be compared via dot product, enabling personalized discovery based on the full session context — not just the last-watched video.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/api/scene-embedding/services/recommender.ts` — current recommendation query; Two-Tower results will be served alongside or instead of cosine similarity for home/recs surfaces
+2. `apps/cms/src/bootstrap/ensure-pgvector.ts` — pgvector table creation pattern for the 256-dim learned item embeddings
+3. `apps/cms/src/api/scene-embedding/services/indexer.ts` — existing embedding indexing pattern
+4. `docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md` — R7-R9 (Two-Tower requirements)
+
+## Grep These
+
+- `vector(1536)` in `apps/cms/src/` — existing embedding columns; the learned projection is `vector(256)`
+- `onnx\|onnxruntime` in `apps/cms/` — check if already a dependency
+- `recommender` in `apps/cms/src/api/scene-embedding/` — serving path
+- `watch_events` in `apps/cms/src/` — training data source
+
+## What To Build
+
+### Item tower (offline, pre-computed)
+
+- Linear projection: 1536-dim scene embeddings → 256-dim learned item embeddings
+- Projection matrix learned during training, applied to all scene embeddings
+- Store 256-dim embeddings in a new pgvector column or table alongside the 1536-dim originals
+- HNSW index on the 256-dim column for fast ANN retrieval
+
+### User tower (online, per-request)
+
+- Input: mean-pooled 256-dim embeddings of the session's watched videos + context features (geo region, device type, browser language, time of day)
+- Architecture: 2-layer MLP → 256-dim user embedding
+- Forward pass at request time via `onnxruntime-node` (~1ms)
+- Output: 256-dim user embedding → dot product against item embeddings in pgvector
+
+### Training pipeline (offline, Python)
+
+- PyTorch training job reading from `watch_events`
+- Contrastive learning: positive pairs from session co-occurrence, negatives sampled
+- Trains both the item projection matrix and user tower MLP jointly
+- Exports: item projection to PostgreSQL (bulk update 256-dim column), user tower to ONNX
+- Versioned artifacts; rollback via config pointing to previous version
+- Retraining cadence: weekly initially, increase as data grows
+
+### Serving (CMS)
+
+- `onnxruntime-node` dependency added to `apps/cms`
+- At request time: load ONNX model → compute user embedding → pgvector ANN query for nearest 256-dim items
+- Activate when total sessions with 2+ videos exceed 50K (global threshold)
+- Below threshold: fall back to existing cosine similarity on 1536-dim embeddings
+
+## Constraints
+
+- Frozen item tower: do not learn item embeddings from scratch; project existing scene embeddings
+- User tower model must be <10MB for reasonable `onnxruntime-node` memory footprint
+- Cold start (no session data) handled by feat-093, not this ticket — here, sessions with no history get existing cosine similarity
+- No real-time model updates; batch training only
+- Phase 1 languages only (en, es, fr)
+
+## Verification
+
+1. `onnxruntime-node` loads the ONNX model and produces a 256-dim vector in <5ms
+2. pgvector ANN query on 256-dim embeddings returns results in <50ms
+3. Two sessions with different watch histories produce different user embeddings
+4. Recommendations for a session that watched contemplative content skew toward contemplative videos
+5. A session below the 2-video threshold falls back to cosine similarity transparently
+6. Global activation: when `SELECT COUNT(DISTINCT session_id) FROM watch_events GROUP BY session_id HAVING COUNT(*) >= 2` exceeds 50K, Two-Tower activates
+7. Model rollback: changing the ONNX artifact version restores previous behavior

--- a/docs/roadmap/content-discovery/feat-093-cold-start-context-recommendations.md
+++ b/docs/roadmap/content-discovery/feat-093-cold-start-context-recommendations.md
@@ -1,0 +1,72 @@
+---
+id: "feat-093"
+title: "Cold Start Context-Based Recommendations"
+owner: "nisal"
+priority: "P2"
+status: "not-started"
+start_date: "2026-06-05"
+duration: 7
+depends_on:
+  - "feat-092"
+blocks: []
+tags:
+  - "web"
+  - "personalization"
+---
+
+## Problem
+
+When a user arrives with no session cookie (first visit, cleared cookies, incognito), the Two-Tower user tower has no watch history to work with. Without a cold-start strategy, these users fall back to non-personalized cosine similarity — the same experience as today. Context features available from the request (geo region, device type, browser language, time of day) carry meaningful signal about viewing tendencies that the user tower can exploit.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/api/scene-embedding/services/recommender.ts` — serving path where cold-start logic branches
+2. The Two-Tower user tower ONNX model (feat-092) — same model, different input: context features only, no watch history embeddings
+3. `apps/cms/src/middlewares/rate-limit.ts:resolveClientIp` — pattern for extracting request context (headers, geo)
+4. `docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md` — R8 (cold start)
+
+## Grep These
+
+- `resolveClientIp\|cf-connecting-ip\|x-forwarded-for` in `apps/cms/src/` — geo/header extraction patterns
+- `onnxruntime\|onnx` in `apps/cms/` — model serving path
+- `session_id\|sessionId\|jfp_session` in `apps/` — session detection
+
+## What To Build
+
+### Context feature extraction
+
+- Extract from request headers at recommendation time:
+  - Geo country/region: `cf-connecting-ip` → Cloudflare geo headers, or IP geolocation fallback
+  - Device type: `User-Agent` parsing (mobile/tablet/desktop/tv)
+  - Browser language: `Accept-Language` header
+  - Time of day: server-local hour bucket (0-5, 6-11, 12-17, 18-23)
+- Encode as feature vector matching the user tower's expected input format
+
+### Cold-start inference
+
+- When no session cookie exists (or session has 0 watch events):
+  1. Build context-only feature vector (zero-filled watch history, context features populated)
+  2. Forward pass through the same Two-Tower user tower ONNX model
+  3. Query pgvector with the resulting 256-dim user embedding
+- The model learns regional and device-based viewing tendencies during training (feat-092) — cold-start produces a broad, diverse set tuned to the user's context
+
+### Fallback chain
+
+1. Two-Tower with watch history (session has 2+ videos) → personalized
+2. Two-Tower with context only (no session / 0-1 videos) → context-personalized
+3. Pure cosine similarity (Two-Tower not activated globally) → baseline
+
+## Constraints
+
+- Same ONNX model as feat-092 — do not train a separate cold-start model
+- Context features must be extractable without additional network calls (headers only, no external geo API)
+- Output should be diverse (not all the same genre) — the model should learn this from training data distribution
+- No persistent user profiles — context is per-request, session is per-cookie
+
+## Verification
+
+1. A brand new user (no cookie) in Brazil on mobile sees different recommendations than a new user in Germany on desktop
+2. Two cold-start requests with identical context produce identical results (deterministic)
+3. Cold-start recommendations include videos from at least 3 different thematic clusters (diversity check)
+4. Latency: cold-start path adds <10ms over the baseline recommendation query
+5. Once the user watches 2+ videos, recommendations shift from cold-start to session-personalized

--- a/docs/roadmap/content-discovery/feat-094-recommendation-ab-comparison-logging.md
+++ b/docs/roadmap/content-discovery/feat-094-recommendation-ab-comparison-logging.md
@@ -1,0 +1,94 @@
+---
+id: "feat-094"
+title: "Recommendation A/B Comparison Logging"
+owner: "nisal"
+priority: "P2"
+status: "not-started"
+start_date: "2026-06-12"
+duration: 7
+depends_on:
+  - "feat-091"
+  - "feat-092"
+blocks: []
+tags:
+  - "cms"
+  - "web"
+  - "infrastructure"
+  - "personalization"
+---
+
+## Problem
+
+After FPMC (feat-091) and Two-Tower (feat-092) are live, there is no way to measure whether personalized recommendations actually improve user engagement compared to the content-similarity baseline. Without comparison data, model tuning is guesswork.
+
+## Entry Points — Read These First
+
+1. `apps/cms/src/api/scene-embedding/services/recommender.ts` — recommendation serving path where dual scores will be computed
+2. `watch_events` table (feat-090) — existing interaction logging; impression logging follows the same pattern
+3. `docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md` — R13-R14 (progressive rollout, A/B comparison)
+
+## Grep These
+
+- `queryPerVideo\|querySimilar` in `apps/cms/src/api/scene-embedding/` — recommendation endpoints
+- `watch_events` in `apps/cms/src/` — event logging pattern to mirror
+
+## What To Build
+
+### Dual-score response
+
+- Recommendation API returns both scores for each result:
+  - `contentScore`: pure cosine similarity (the baseline)
+  - `blendedScore`: model-blended score (FPMC or Two-Tower, depending on surface)
+- The ranked order uses `blendedScore`; `contentScore` is logged for comparison
+- Response shape is additive — existing consumers that don't read `contentScore` are unaffected
+
+### Impression logging
+
+New `recommendation_impressions` table:
+
+```sql
+CREATE TABLE IF NOT EXISTS recommendation_impressions (
+  id                SERIAL PRIMARY KEY,
+  session_id        UUID NOT NULL,
+  source_video_id   INTEGER,
+  surface           TEXT NOT NULL,
+  recommended_ids   INTEGER[] NOT NULL,
+  content_scores    FLOAT[] NOT NULL,
+  blended_scores    FLOAT[] NOT NULL,
+  model_version     TEXT NOT NULL,
+  created_at        TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS rec_impressions_session
+  ON recommendation_impressions(session_id);
+CREATE INDEX IF NOT EXISTS rec_impressions_created
+  ON recommendation_impressions(created_at);
+```
+
+- Logged on every recommendation response (server-side, no client instrumentation needed)
+- `surface`: `"video-page"` (FPMC) or `"home"` / `"component"` (Two-Tower)
+- Click-through is inferred by joining with `watch_events` — if a session watches a recommended video within the same session, that's a click-through
+
+### Comparison export
+
+- SQL queries or a simple script to compute:
+  - Click-through rate (CTR) by surface and model version
+  - Position-weighted CTR (clicks on rank-1 vs rank-5)
+  - Comparison: CTR of blended vs what CTR would have been if ranked by `contentScore`
+- No full A/B testing framework — manual analysis via SQL export
+
+## Constraints
+
+- No randomized A/B split in this ticket — all users see the blended ranking
+- Comparison is observational: "what would the baseline have shown?" computed from logged `contentScore` rankings
+- Impression logging must not add latency to the recommendation response (fire-and-forget insert)
+- No dashboarding UI — export to CSV/JSON for analysis
+- Impression data retention: 90 days rolling, then archive or delete
+
+## Verification
+
+1. Recommendation API response includes both `contentScore` and `blendedScore` for each result
+2. `recommendation_impressions` table populates on every recommendation request
+3. Click-through join query: `SELECT ... FROM recommendation_impressions ri JOIN watch_events we ON we.session_id = ri.session_id AND we.video_id = ANY(ri.recommended_ids)` returns matches
+4. Comparison query shows whether blended ranking produces higher CTR than content-only ranking would have
+5. Impression logging adds <5ms to recommendation response time


### PR DESCRIPTION
## Summary

Creates 5 roadmap tickets for the user-feedback-driven recommendation pipeline, based on the brainstorm at `docs/brainstorms/2026-04-12-user-feedback-driven-recommendations-requirements.md`.

- **feat-090** Watch Event Collection & Session Tracking (P1, 10 days)
- **feat-091** FPMC Video Page Recommendations (P1, 14 days)
- **feat-092** Two-Tower Neural Recommendation Model (P1, 21 days)
- **feat-093** Cold Start Context-Based Recommendations (P2, 7 days)
- **feat-094** Recommendation A/B Comparison Logging (P2, 7 days)

Dependency chain:
```
feat-046 (complete) → feat-090 → feat-091 → feat-094
                              → feat-092 → feat-093
                                         → feat-094
```

Also updates bidirectional deps:
- feat-046 `blocks: [feat-090]`
- feat-063 `depends_on: [..., feat-090]`

## Test plan

- [ ] Docs-only, no code changes
- [ ] Verify roadmap viewer renders the new tickets and dependency graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)