### PR TITLE
feat(tv): conform Bible Quotes carousel cards to mobile/web visual pattern

### DIFF
--- a/apps/tv/src/components/LinkModal.tsx
+++ b/apps/tv/src/components/LinkModal.tsx
@@ -1,0 +1,306 @@
+import { useCallback, useMemo, useState } from "react"
+import {
+  ActivityIndicator,
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native"
+
+import { FocusableCard } from "./FocusableCard"
+import { COLORS, hexToRgba } from "../lib/colors"
+import { scale } from "../lib/scale"
+
+// ── Platform detection ─────────────────────────────────────────────────────
+
+const isTvOS = Platform.isTV && Platform.OS === "ios"
+
+// ── WebView (Android TV only) ──────────────────────────────────────────────
+// Dynamic require — tvOS ships no WebKit, so the RNCWebViewModule native
+// module is absent on Apple TV. A static `import` would trigger TurboModule
+// registration at module load and redbox on tvOS before any component mounts.
+// The conditional require skips the evaluation entirely on tvOS.
+type WebViewComponent = typeof import("react-native-webview").WebView
+const WebView: WebViewComponent | null =
+  Platform.OS === "android"
+    ? // eslint-disable-next-line @typescript-eslint/no-require-imports -- Deliberate platform-conditional require. A static import would fail at module load on tvOS (see comment above).
+      (require("react-native-webview") as typeof import("react-native-webview"))
+        .WebView
+    : null
+
+// ── QR code (tvOS only) ────────────────────────────────────────────────────
+import qrcode from "qrcode-generator"
+
+// ── QR Matrix Component (tvOS) ─────────────────────────────────────────────
+
+function QrMatrix({ url }: { url: string }) {
+  const matrix = useMemo(() => {
+    const qr = qrcode(0, "L")
+    qr.addData(url)
+    qr.make()
+    const n = qr.getModuleCount()
+    // 8 = 4 cells quiet-zone on each side
+    const cellSize = Math.round(480 / (n + 8))
+    const quietZone = 4 * cellSize
+    const gridSize = n * cellSize
+    const totalSize = gridSize + quietZone * 2
+
+    const rows: boolean[][] = []
+    for (let r = 0; r < n; r++) {
+      const row: boolean[] = []
+      for (let c = 0; c < n; c++) {
+        row.push(qr.isDark(r, c))
+      }
+      rows.push(row)
+    }
+
+    return { rows, n, cellSize, quietZone, totalSize }
+  }, [url])
+
+  return (
+    <View
+      style={[
+        styles.qrOuter,
+        {
+          width: matrix.totalSize,
+          height: matrix.totalSize,
+          padding: matrix.quietZone,
+          backgroundColor: "#FFFFFF",
+          borderRadius: 16,
+        },
+      ]}
+    >
+      {matrix.rows.map((row, r) => (
+        <View key={`qr-row-${r}`} style={styles.qrRow}>
+          {row.map((isDark, c) => (
+            <View
+              key={`qr-${r}-${c}`}
+              style={{
+                width: matrix.cellSize,
+                height: matrix.cellSize,
+                backgroundColor: isDark ? "#000000" : "#FFFFFF",
+              }}
+            />
+          ))}
+        </View>
+      ))}
+    </View>
+  )
+}
+
+// ── Android TV WebView Modal Content ───────────────────────────────────────
+
+type WebViewState = "loading" | "loaded" | "errored"
+
+function AndroidTvWebViewContent({
+  url,
+  urlValidator,
+  errorText,
+}: {
+  url: string
+  urlValidator: (url: string) => boolean
+  errorText: string
+}) {
+  const [state, setState] = useState<WebViewState>("loading")
+
+  const handleLoadEnd = useCallback(() => {
+    setState((prev) => (prev === "loading" ? "loaded" : prev))
+  }, [])
+
+  const handleError = useCallback(() => {
+    setState("errored")
+  }, [])
+
+  const handleNavigationRequest = useCallback(
+    (request: { url: string }) => urlValidator(request.url),
+    [urlValidator],
+  )
+
+  if (state === "errored" || WebView == null) {
+    return (
+      <View style={styles.centeredContent}>
+        <Text style={styles.errorText}>{errorText}</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.webViewContainer}>
+      {state === "loading" && (
+        <View style={styles.centeredOverlay}>
+          <ActivityIndicator size="large" color="#ffffff" />
+        </View>
+      )}
+      <WebView
+        source={{ uri: url }}
+        originWhitelist={["https://*"]}
+        onShouldStartLoadWithRequest={handleNavigationRequest}
+        style={[styles.webView, state === "loading" && styles.webViewHidden]}
+        javaScriptEnabled
+        domStorageEnabled
+        allowFileAccess={false}
+        allowFileAccessFromFileURLs={false}
+        allowUniversalAccessFromFileURLs={false}
+        javaScriptCanOpenWindowsAutomatically={false}
+        mixedContentMode="never"
+        thirdPartyCookiesEnabled={false}
+        mediaPlaybackRequiresUserAction
+        onLoadEnd={handleLoadEnd}
+        onError={handleError}
+      />
+    </View>
+  )
+}
+
+// ── tvOS QR Modal Content ──────────────────────────────────────────────────
+
+function TvOSQrContent({ url, qrHeading }: { url: string; qrHeading: string }) {
+  return (
+    <View style={styles.centeredContent}>
+      <View style={styles.qrCard}>
+        <Text style={styles.qrHeading}>{qrHeading}</Text>
+        <QrMatrix url={url} />
+        <Text style={styles.qrUrlText} numberOfLines={1} ellipsizeMode="middle">
+          {url}
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+// ── LinkModal ──────────────────────────────────────────────────────────────
+
+type LinkModalProps = {
+  url: string
+  visible: boolean
+  onClose: () => void
+  urlValidator: (url: string) => boolean
+  errorText?: string
+  qrHeading?: string
+}
+
+export function LinkModal({
+  url,
+  visible,
+  onClose,
+  urlValidator,
+  errorText = "Couldn't load the page.",
+  qrHeading = "Scan to continue on your phone",
+}: LinkModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      animationType="fade"
+      transparent
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalOverlay}>
+        {/* Close button in normal flow so tvOS focus engine can reach it */}
+        <View style={styles.closeRow}>
+          <FocusableCard
+            onPress={onClose}
+            hasTVPreferredFocus
+            style={styles.closeButton}
+          >
+            <Text style={styles.closeIcon}>{"\u2715"}</Text>
+          </FocusableCard>
+        </View>
+
+        {isTvOS ? (
+          <TvOSQrContent url={url} qrHeading={qrHeading} />
+        ) : (
+          <AndroidTvWebViewContent
+            url={url}
+            urlValidator={urlValidator}
+            errorText={errorText}
+          />
+        )}
+      </View>
+    </Modal>
+  )
+}
+
+// ── Styles ─────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  // Modal
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.9)",
+  },
+  closeRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingTop: scale(40),
+    paddingRight: scale(40),
+  },
+  closeButton: {
+    width: scale(56),
+    height: scale(56),
+    borderRadius: scale(28),
+    backgroundColor: "rgba(255,255,255,0.15)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  closeIcon: {
+    color: "#ffffff",
+    fontSize: scale(22),
+    fontFamily: "System",
+  },
+  // Android TV WebView
+  webViewContainer: {
+    flex: 1,
+    marginTop: scale(100),
+  },
+  webView: {
+    flex: 1,
+    backgroundColor: hexToRgba(COLORS.surface, 0),
+  },
+  webViewHidden: {
+    opacity: 0,
+  },
+  centeredOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  // tvOS QR
+  centeredContent: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  qrCard: {
+    backgroundColor: COLORS.surfaceContainerHigh,
+    borderRadius: scale(24),
+    padding: scale(48),
+    alignItems: "center",
+  },
+  qrHeading: {
+    color: COLORS.text,
+    fontSize: scale(32),
+    fontWeight: "700",
+    fontFamily: "System",
+    marginBottom: scale(32),
+  },
+  qrOuter: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  qrRow: {
+    flexDirection: "row",
+  },
+  qrUrlText: {
+    color: COLORS.muted,
+    fontSize: scale(18),
+    fontFamily: "System",
+    marginTop: scale(24),
+    maxWidth: scale(400),
+  },
+  errorText: {
+    color: COLORS.muted,
+    fontSize: scale(24),
+    fontFamily: "System",
+  },
+})

--- a/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
+++ b/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
@@ -190,7 +190,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: scale(80),
   },
   listContent: {
-    paddingHorizontal: scale(80),
+    flexGrow: 1,
+    justifyContent: "center",
   },
   cardWrapper: {
     paddingVertical: scale(40),

--- a/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
+++ b/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
@@ -44,17 +44,15 @@ export interface BibleQuotesCarouselRendererProps {
 
 function QuoteCard({
   quote,
+  ctaLabel,
   onPress,
 }: {
   quote: QuoteItem
+  ctaLabel: string | null
   onPress: () => void
 }) {
   const imageSource = resolveImageUrl(quote.imageUrl ?? null)
   const bgColor = quote.backgroundColor ?? "#292524"
-  const hasValidCta =
-    quote.ctaLabel != null &&
-    quote.ctaLink != null &&
-    validateActionUrl(quote.ctaLink)
 
   return (
     <FocusableCard
@@ -88,9 +86,9 @@ function QuoteCard({
         <Text style={styles.quoteText} numberOfLines={6}>
           {quote.text}
         </Text>
-        {hasValidCta && (
+        {ctaLabel != null && (
           <View style={styles.ctaButton}>
-            <Text style={styles.ctaText}>{quote.ctaLabel}</Text>
+            <Text style={styles.ctaText}>{ctaLabel}</Text>
           </View>
         )}
       </View>
@@ -108,22 +106,21 @@ export function BibleQuotesCarouselRenderer({
   const [selectedCtaUrl, setSelectedCtaUrl] = useState<string | null>(null)
 
   const renderItem = useCallback(({ item }: { item: QuoteItem }) => {
-    const validCtaLink =
+    const hasValidCta =
       item.ctaLabel != null &&
       item.ctaLink != null &&
       validateActionUrl(item.ctaLink)
-        ? item.ctaLink
-        : null
+    const validCtaLink = hasValidCta ? item.ctaLink : null
+    const validCtaLabel = hasValidCta ? (item.ctaLabel ?? null) : null
 
     return (
       <View style={styles.cardWrapper}>
         <QuoteCard
           quote={item}
+          ctaLabel={validCtaLabel}
           onPress={() => {
             if (validCtaLink != null) {
               setSelectedCtaUrl(validCtaLink)
-            } else {
-              console.log("[BibleQuotesCarousel] Selected:", item.reference)
             }
           }}
         />

--- a/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
+++ b/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
@@ -7,22 +7,19 @@ import {
   // @ts-expect-error TVFocusGuideView is provided by react-native-tvos but not in base RN types
   TVFocusGuideView,
 } from "react-native"
+import { Image } from "expo-image"
+import { LinearGradient } from "expo-linear-gradient"
 
 import type { NormalizedBlock } from "../../lib/normalizer"
+import { COLORS, hexToRgba } from "../../lib/colors"
 import { scale } from "../../lib/scale"
+import { resolveImageUrl } from "../../lib/resolveImageUrl"
 import { FocusableCard } from "../FocusableCard"
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-const CARD_WIDTH = scale(400)
+const CARD_SIZE = scale(340)
 const CARD_GAP = scale(24)
-
-const COLORS = {
-  surfaceContainer: "#221F1D",
-  crimson: "#CB333B",
-  text: "#F5F5F4",
-  muted: "#A8A29E",
-} as const
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -31,6 +28,10 @@ type QuoteItem = {
   reference: string
   text: string
   attribution?: string | null
+  imageUrl?: string | null
+  backgroundColor?: string | null
+  ctaLabel?: string | null
+  ctaLink?: string | null
 }
 
 export interface BibleQuotesCarouselRendererProps {
@@ -40,15 +41,44 @@ export interface BibleQuotesCarouselRendererProps {
 // ── QuoteCard ────────────────────────────────────────────────────────────────
 
 function QuoteCard({ quote }: { quote: QuoteItem }) {
+  const imageSource = resolveImageUrl(quote.imageUrl ?? null)
+  const bgColor = quote.backgroundColor ?? "#292524"
+
   return (
     <FocusableCard
       onPress={() => {
         console.log("[BibleQuotesCarousel] Selected:", quote.reference)
       }}
-      style={styles.card}
+      style={{ ...styles.card, backgroundColor: bgColor }}
+      accessibilityLabel={`${quote.reference}: ${quote.text}`}
     >
-      <Text style={styles.reference}>{quote.reference}</Text>
-      <Text style={styles.quoteText}>{quote.text}</Text>
+      {imageSource != null && (
+        <Image
+          source={imageSource}
+          style={StyleSheet.absoluteFill}
+          contentFit="cover"
+          recyclingKey={`bqc-${quote.id}`}
+        />
+      )}
+      <LinearGradient
+        colors={[hexToRgba(bgColor, 0), bgColor]}
+        locations={[0, 0.6]}
+        style={StyleSheet.absoluteFill}
+        pointerEvents="none"
+      />
+      <View style={styles.cardContent}>
+        {quote.attribution != null && quote.attribution.length > 0 && (
+          <Text style={styles.attribution} numberOfLines={1}>
+            {quote.attribution.toUpperCase()}
+          </Text>
+        )}
+        <Text style={styles.reference} numberOfLines={1}>
+          {quote.reference.toUpperCase()}
+        </Text>
+        <Text style={styles.quoteText} numberOfLines={6}>
+          {quote.text}
+        </Text>
+      </View>
     </FocusableCard>
   )
 }
@@ -128,23 +158,38 @@ const styles = StyleSheet.create({
     width: CARD_GAP,
   },
   card: {
-    width: CARD_WIDTH,
-    backgroundColor: COLORS.surfaceContainer,
+    width: CARD_SIZE,
+    height: CARD_SIZE,
     borderRadius: scale(16),
-    padding: scale(24),
+    overflow: "hidden",
+  },
+  cardContent: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "flex-end",
+    padding: scale(20),
+  },
+  attribution: {
+    fontFamily: "System",
+    fontSize: scale(14),
+    fontWeight: "800",
+    color: "rgba(255,255,255,0.9)",
+    letterSpacing: 0.8,
+    marginBottom: scale(2),
   },
   reference: {
     fontFamily: "System",
-    fontSize: scale(18),
-    fontWeight: "500",
-    color: COLORS.crimson,
-    marginBottom: scale(12),
+    fontSize: scale(16),
+    fontWeight: "800",
+    color: "rgba(255,255,255,0.7)",
+    letterSpacing: 1.5,
+    marginBottom: scale(6),
   },
   quoteText: {
     fontFamily: "System",
-    fontSize: scale(20),
+    fontSize: scale(18),
     fontWeight: "400",
-    color: COLORS.text,
-    lineHeight: scale(30),
+    fontStyle: "italic",
+    color: "rgba(255,255,255,0.9)",
+    lineHeight: scale(26),
   },
 })

--- a/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
+++ b/apps/tv/src/components/sections/BibleQuotesCarouselRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react"
+import React, { useCallback, useState } from "react"
 import {
   FlatList,
   StyleSheet,
@@ -14,7 +14,9 @@ import type { NormalizedBlock } from "../../lib/normalizer"
 import { COLORS, hexToRgba } from "../../lib/colors"
 import { scale } from "../../lib/scale"
 import { resolveImageUrl } from "../../lib/resolveImageUrl"
+import { validateActionUrl } from "../../lib/validateUrl"
 import { FocusableCard } from "../FocusableCard"
+import { LinkModal } from "../LinkModal"
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -40,15 +42,23 @@ export interface BibleQuotesCarouselRendererProps {
 
 // ── QuoteCard ────────────────────────────────────────────────────────────────
 
-function QuoteCard({ quote }: { quote: QuoteItem }) {
+function QuoteCard({
+  quote,
+  onPress,
+}: {
+  quote: QuoteItem
+  onPress: () => void
+}) {
   const imageSource = resolveImageUrl(quote.imageUrl ?? null)
   const bgColor = quote.backgroundColor ?? "#292524"
+  const hasValidCta =
+    quote.ctaLabel != null &&
+    quote.ctaLink != null &&
+    validateActionUrl(quote.ctaLink)
 
   return (
     <FocusableCard
-      onPress={() => {
-        console.log("[BibleQuotesCarousel] Selected:", quote.reference)
-      }}
+      onPress={onPress}
       style={{ ...styles.card, backgroundColor: bgColor }}
       accessibilityLabel={`${quote.reference}: ${quote.text}`}
     >
@@ -78,6 +88,11 @@ function QuoteCard({ quote }: { quote: QuoteItem }) {
         <Text style={styles.quoteText} numberOfLines={6}>
           {quote.text}
         </Text>
+        {hasValidCta && (
+          <View style={styles.ctaButton}>
+            <Text style={styles.ctaText}>{quote.ctaLabel}</Text>
+          </View>
+        )}
       </View>
     </FocusableCard>
   )
@@ -90,15 +105,31 @@ export function BibleQuotesCarouselRenderer({
 }: BibleQuotesCarouselRendererProps) {
   const heading = section.bqcHeading as string | null
   const quotes = (section.quotes as QuoteItem[] | undefined) ?? []
+  const [selectedCtaUrl, setSelectedCtaUrl] = useState<string | null>(null)
 
-  const renderItem = useCallback(
-    ({ item }: { item: QuoteItem }) => (
+  const renderItem = useCallback(({ item }: { item: QuoteItem }) => {
+    const validCtaLink =
+      item.ctaLabel != null &&
+      item.ctaLink != null &&
+      validateActionUrl(item.ctaLink)
+        ? item.ctaLink
+        : null
+
+    return (
       <View style={styles.cardWrapper}>
-        <QuoteCard quote={item} />
+        <QuoteCard
+          quote={item}
+          onPress={() => {
+            if (validCtaLink != null) {
+              setSelectedCtaUrl(validCtaLink)
+            } else {
+              console.log("[BibleQuotesCarousel] Selected:", item.reference)
+            }
+          }}
+        />
       </View>
-    ),
-    [],
-  )
+    )
+  }, [])
 
   const keyExtractor = useCallback(
     (item: QuoteItem, index: number) => `bqc-${item.id}-${index}`,
@@ -125,6 +156,16 @@ export function BibleQuotesCarouselRenderer({
           ItemSeparatorComponent={Separator}
         />
       </TVFocusGuideView>
+      {selectedCtaUrl != null && (
+        <LinkModal
+          url={selectedCtaUrl}
+          visible
+          onClose={() => setSelectedCtaUrl(null)}
+          urlValidator={validateActionUrl}
+          errorText="Couldn't load the page."
+          qrHeading="Scan to visit on your phone"
+        />
+      )}
     </View>
   )
 }
@@ -191,5 +232,19 @@ const styles = StyleSheet.create({
     fontStyle: "italic",
     color: "rgba(255,255,255,0.9)",
     lineHeight: scale(26),
+  },
+  ctaButton: {
+    marginTop: scale(12),
+    alignSelf: "flex-start",
+    paddingHorizontal: scale(16),
+    paddingVertical: scale(8),
+    borderRadius: scale(20),
+    backgroundColor: "rgba(255,255,255,0.2)",
+  },
+  ctaText: {
+    fontFamily: "System",
+    fontSize: scale(14),
+    fontWeight: "600",
+    color: "rgba(255,255,255,0.9)",
   },
 })

--- a/apps/tv/src/components/sections/QuizButtonRenderer.tsx
+++ b/apps/tv/src/components/sections/QuizButtonRenderer.tsx
@@ -1,172 +1,17 @@
-import { useCallback, useMemo, useState } from "react"
-import {
-  ActivityIndicator,
-  Modal,
-  Platform,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native"
+import { useState } from "react"
+import { StyleSheet, Text, View } from "react-native"
 import { LinearGradient } from "expo-linear-gradient"
 
 import { FocusableCard } from "../FocusableCard"
+import { LinkModal } from "../LinkModal"
 import { COLORS, hexToRgba } from "../../lib/colors"
 import { scale } from "../../lib/scale"
 import type { NormalizedBlock } from "../../lib/normalizer"
 import { isAllowedQuizUrl } from "../../lib/validateUrl"
 
-// ── Platform detection ─────────────────────────────────────────────────────
-
-const isTvOS = Platform.isTV && Platform.OS === "ios"
-
-// ── WebView (Android TV only) ──────────────────────────────────────────────
-// Dynamic require — tvOS ships no WebKit, so the RNCWebViewModule native
-// module is absent on Apple TV. A static `import` would trigger TurboModule
-// registration at module load and redbox on tvOS before any component mounts.
-// The conditional require skips the evaluation entirely on tvOS.
-type WebViewComponent = typeof import("react-native-webview").WebView
-const WebView: WebViewComponent | null =
-  Platform.OS === "android"
-    ? // eslint-disable-next-line @typescript-eslint/no-require-imports -- Deliberate platform-conditional require. A static import would fail at module load on tvOS (see comment above).
-      (require("react-native-webview") as typeof import("react-native-webview"))
-        .WebView
-    : null
-
-// ── QR code (tvOS only) ────────────────────────────────────────────────────
-import qrcode from "qrcode-generator"
-
 // ── Quiz gradient (from mobile src/lib/color.ts) ───────────────────────
 
 const QUIZ_GRADIENT: readonly [string, string] = ["#E8891C", "#CB333B"]
-
-// ── QR Matrix Component (tvOS) ─────────────────────────────────────────────
-
-function QrMatrix({ url }: { url: string }) {
-  const matrix = useMemo(() => {
-    const qr = qrcode(0, "L")
-    qr.addData(url)
-    qr.make()
-    const n = qr.getModuleCount()
-    // 8 = 4 cells quiet-zone on each side
-    const cellSize = Math.round(480 / (n + 8))
-    const quietZone = 4 * cellSize
-    const gridSize = n * cellSize
-    const totalSize = gridSize + quietZone * 2
-
-    const rows: boolean[][] = []
-    for (let r = 0; r < n; r++) {
-      const row: boolean[] = []
-      for (let c = 0; c < n; c++) {
-        row.push(qr.isDark(r, c))
-      }
-      rows.push(row)
-    }
-
-    return { rows, n, cellSize, quietZone, totalSize }
-  }, [url])
-
-  return (
-    <View
-      style={[
-        styles.qrOuter,
-        {
-          width: matrix.totalSize,
-          height: matrix.totalSize,
-          padding: matrix.quietZone,
-          backgroundColor: "#FFFFFF",
-          borderRadius: 16,
-        },
-      ]}
-    >
-      {matrix.rows.map((row, r) => (
-        <View key={`qr-row-${r}`} style={styles.qrRow}>
-          {row.map((isDark, c) => (
-            <View
-              key={`qr-${r}-${c}`}
-              style={{
-                width: matrix.cellSize,
-                height: matrix.cellSize,
-                backgroundColor: isDark ? "#000000" : "#FFFFFF",
-              }}
-            />
-          ))}
-        </View>
-      ))}
-    </View>
-  )
-}
-
-// ── Android TV WebView Modal Content ───────────────────────────────────────
-
-type WebViewState = "loading" | "loaded" | "errored"
-
-function AndroidTvWebViewContent({ url }: { url: string }) {
-  const [state, setState] = useState<WebViewState>("loading")
-
-  const handleLoadEnd = useCallback(() => {
-    setState((prev) => (prev === "loading" ? "loaded" : prev))
-  }, [])
-
-  const handleError = useCallback(() => {
-    setState("errored")
-  }, [])
-
-  const handleNavigationRequest = useCallback(
-    (request: { url: string }) => isAllowedQuizUrl(request.url),
-    [],
-  )
-
-  if (state === "errored" || WebView == null) {
-    return (
-      <View style={styles.centeredContent}>
-        <Text style={styles.errorText}>Couldn't load the quiz.</Text>
-      </View>
-    )
-  }
-
-  return (
-    <View style={styles.webViewContainer}>
-      {state === "loading" && (
-        <View style={styles.centeredOverlay}>
-          <ActivityIndicator size="large" color="#ffffff" />
-        </View>
-      )}
-      <WebView
-        source={{ uri: url }}
-        originWhitelist={["https://*"]}
-        onShouldStartLoadWithRequest={handleNavigationRequest}
-        style={[styles.webView, state === "loading" && styles.webViewHidden]}
-        javaScriptEnabled
-        domStorageEnabled
-        allowFileAccess={false}
-        allowFileAccessFromFileURLs={false}
-        allowUniversalAccessFromFileURLs={false}
-        javaScriptCanOpenWindowsAutomatically={false}
-        mixedContentMode="never"
-        thirdPartyCookiesEnabled={false}
-        mediaPlaybackRequiresUserAction
-        onLoadEnd={handleLoadEnd}
-        onError={handleError}
-      />
-    </View>
-  )
-}
-
-// ── tvOS QR Modal Content ──────────────────────────────────────────────────
-
-function TvOSQrContent({ url }: { url: string }) {
-  return (
-    <View style={styles.centeredContent}>
-      <View style={styles.qrCard}>
-        <Text style={styles.qrHeading}>Scan to continue on your phone</Text>
-        <QrMatrix url={url} />
-        <Text style={styles.qrUrlText} numberOfLines={1} ellipsizeMode="middle">
-          {url}
-        </Text>
-      </View>
-    </View>
-  )
-}
 
 // ── QuizButtonRenderer ─────────────────────────────────────────────────────
 
@@ -205,31 +50,13 @@ export function QuizButtonRenderer({ section }: { section: NormalizedBlock }) {
         </FocusableCard>
       </View>
 
-      <Modal
+      <LinkModal
+        url={iframeSrc}
         visible={modalVisible}
-        animationType="fade"
-        transparent
-        onRequestClose={closeModal}
-      >
-        <View style={styles.modalOverlay}>
-          {/* Close button in normal flow so tvOS focus engine can reach it */}
-          <View style={styles.closeRow}>
-            <FocusableCard
-              onPress={closeModal}
-              hasTVPreferredFocus
-              style={styles.closeButton}
-            >
-              <Text style={styles.closeIcon}>{"\u2715"}</Text>
-            </FocusableCard>
-          </View>
-
-          {isTvOS ? (
-            <TvOSQrContent url={iframeSrc} />
-          ) : (
-            <AndroidTvWebViewContent url={iframeSrc} />
-          )}
-        </View>
-      </Modal>
+        onClose={closeModal}
+        urlValidator={isAllowedQuizUrl}
+        errorText="Couldn't load the quiz."
+      />
     </>
   )
 }
@@ -282,84 +109,5 @@ const styles = StyleSheet.create({
     color: "#ffffff",
     fontSize: scale(28),
     marginLeft: scale(16),
-  },
-  // Modal
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.9)",
-  },
-  closeRow: {
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    paddingTop: scale(40),
-    paddingRight: scale(40),
-  },
-  closeButton: {
-    width: scale(56),
-    height: scale(56),
-    borderRadius: scale(28),
-    backgroundColor: "rgba(255,255,255,0.15)",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  closeIcon: {
-    color: "#ffffff",
-    fontSize: scale(22),
-    fontFamily: "System",
-  },
-  // Android TV WebView
-  webViewContainer: {
-    flex: 1,
-    marginTop: scale(100),
-  },
-  webView: {
-    flex: 1,
-    backgroundColor: hexToRgba(COLORS.surface, 0),
-  },
-  webViewHidden: {
-    opacity: 0,
-  },
-  centeredOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  // tvOS QR
-  centeredContent: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  qrCard: {
-    backgroundColor: COLORS.surfaceContainerHigh,
-    borderRadius: scale(24),
-    padding: scale(48),
-    alignItems: "center",
-  },
-  qrHeading: {
-    color: COLORS.text,
-    fontSize: scale(32),
-    fontWeight: "700",
-    fontFamily: "System",
-    marginBottom: scale(32),
-  },
-  qrOuter: {
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  qrRow: {
-    flexDirection: "row",
-  },
-  qrUrlText: {
-    color: COLORS.muted,
-    fontSize: scale(18),
-    fontFamily: "System",
-    marginTop: scale(24),
-    maxWidth: scale(400),
-  },
-  errorText: {
-    color: COLORS.muted,
-    fontSize: scale(24),
-    fontFamily: "System",
   },
 })

--- a/docs/solutions/best-practices/tv-carousel-card-conformance-pattern-20260416.md
+++ b/docs/solutions/best-practices/tv-carousel-card-conformance-pattern-20260416.md
@@ -1,0 +1,161 @@
+---
+title: "TV Carousel Card Conformance — Matching Mobile/Web Visual Patterns"
+date: 2026-04-16
+category: best-practices
+module: apps/tv
+problem_type: best_practice
+component: frontend_stimulus
+severity: medium
+applies_when:
+  - "Adding a new SDUI carousel renderer to the TV app"
+  - "Upgrading a text-only TV card to a rich image card"
+  - "Adding CTA (call-to-action) support to a TV carousel card"
+  - "Extracting a shared modal component for reuse across renderers"
+tags:
+  - tv
+  - carousel
+  - sdui
+  - react-native-tvos
+  - expo-image
+  - linear-gradient
+  - webview
+  - cta
+---
+
+# TV Carousel Card Conformance — Matching Mobile/Web Visual Patterns
+
+## Context
+
+The TV app's SDUI pipeline renders the same content as mobile and web but with TV-optimized renderers. When Bible Quotes carousel cards were initially implemented for TV, they used plain text on a flat dark surface — while mobile and web showed rich square cards with background images, gradient overlays, italic quotes, and CTA buttons. This visual inconsistency made the TV experience feel incomplete. The conformance work established repeatable patterns for upgrading any TV carousel card to match the cross-platform visual standard.
+
+A first implementation attempt jumped straight to code before brainstorming — it was reverted and redone properly through the brainstorm/plan/work pipeline. (session history)
+
+## Guidance
+
+### 1. Image + Gradient + Text Overlay Card Pattern
+
+Follow `NavigationCarouselRenderer` as the canonical reference for any carousel card with a background image:
+
+- **Square geometry**: `CARD_SIZE = scale(340)` for both width and height
+- **Background image**: `expo-image` with `StyleSheet.absoluteFill`, `contentFit="cover"`, and `recyclingKey`. Always validate URLs through `resolveImageUrl()` — condition rendering on the resolved value, not the raw CMS field
+- **Gradient overlay**: `LinearGradient` with `colors={[hexToRgba(bgColor, 0), bgColor]}` and `locations={[0, 0.6]}`. Never use the string `"transparent"` — it resolves to `rgba(0,0,0,0)` on Android, creating dark banding
+- **Bottom-anchored text**: Content `View` with `StyleSheet.absoluteFillObject`, `justifyContent: "flex-end"`, `padding: scale(20)`
+- **Per-card backgroundColor**: Source from CMS data with fallback (`#292524`)
+- **Accessibility**: `accessibilityLabel` on the outer `FocusableCard`
+
+### 2. Shared Modal Extraction
+
+When a modal component has only 2-3 parametric differences between usages, extract it rather than duplicate:
+
+- `LinkModal` accepts: `url`, `visible`, `onClose`, `urlValidator: (url: string) => boolean`, `errorText?`, `qrHeading?`
+- Keep all WebView security hardening inside the shared component (`allowFileAccess={false}`, `mixedContentMode="never"`, `thirdPartyCookiesEnabled={false}`, etc.)
+- Keep platform branching inside the shared component — the conditional `require()` for WebView on tvOS prevents TurboModule registration crashes
+- Only mount the modal when a valid URL is selected (`selectedCtaUrl != null`) — never pass an empty string URL to WebView
+
+### 3. Single CTA Validation Site
+
+Validate CTA URLs once in the parent (`renderItem`), pass the validated result as a prop to the child:
+
+```
+// In renderItem — single validation site
+const hasValidCta = item.ctaLabel != null && item.ctaLink != null && validateActionUrl(item.ctaLink)
+const validCtaLink = hasValidCta ? item.ctaLink : null
+const validCtaLabel = hasValidCta ? (item.ctaLabel ?? null) : null
+
+// Child receives pre-validated props — no re-validation
+<QuoteCard ctaLabel={validCtaLabel} onPress={...} />
+```
+
+Duplicate validation in parent and child was caught during code review as a P1 issue — the two guards can theoretically diverge if the validator signature changes.
+
+### 4. Carousel Center Alignment
+
+For carousels where the total card width may not fill the screen:
+
+```
+contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }}
+```
+
+Note: this defeats FlatList virtualization since all items must render to measure total width. Acceptable for small lists (Bible quotes typically have 4-6 items) but avoid for lists with 20+ items.
+
+## Why This Matters
+
+- **Visual consistency**: Users moving between mobile, web, and TV see the same card metaphor. Image cards with gradient overlays are the established cross-platform pattern.
+- **No dark banding**: `hexToRgba(color, 0)` is enforced in the TV CLAUDE.md. String `"transparent"` causes visible black bands on Android TV gradient interpolation.
+- **tvOS TurboModule safety**: `react-native-webview` is not available on tvOS. A top-level `import` crashes the app before any component mounts. Conditional `require()` inside the shared modal is the only safe pattern.
+- **DRY security hardening**: WebView security config is non-trivial (~10 props). Centralizing it in `LinkModal` means security fixes propagate to all consumers automatically.
+- **FocusableCard two-layer architecture**: The outer `Animated.View` (`overflow: "visible"`) handles scale animation and crimson glow shadow. The inner `View` (`overflow: "hidden"`, `collapsable={false}`) clips content to border radius. This split is load-bearing for all image cards — `expo-image` with `absoluteFill` inside a single `overflow: "hidden"` View is invisible on Android TV. (session history)
+
+## When to Apply
+
+- **New carousel renderer**: Any new SDUI block renderer (e.g., `TestimonialsCarouselRenderer`) should follow the image + gradient pattern from `NavigationCarouselRenderer`
+- **Text-to-image card upgrade**: When upgrading a text-only card to show CMS images, follow the `BibleQuotesCarouselRenderer` transformation as a reference
+- **Adding CTA to a card**: Use `LinkModal` with `validateActionUrl` for general HTTPS links, `isAllowedQuizUrl` for quiz-specific domains
+- **Any `LinearGradient` in TV app**: Always use `hexToRgba()` for gradient stops — no exceptions
+- **Any WebView usage in TV app**: Gate the `require()` behind `Platform.OS === "android"` at module level
+
+## Examples
+
+### Before: Plain text card
+
+```
+const CARD_WIDTH = scale(400)
+
+<FocusableCard style={{ width: CARD_WIDTH, backgroundColor: "#221F1D", padding: scale(24) }}>
+  <Text style={{ color: "#CB333B" }}>{quote.reference}</Text>
+  <Text style={{ color: "#F5F5F4" }}>{quote.text}</Text>
+</FocusableCard>
+```
+
+### After: Square image card with gradient overlay
+
+```
+const CARD_SIZE = scale(340)
+
+<FocusableCard
+  style={{ ...styles.card, backgroundColor: bgColor }}
+  accessibilityLabel={`${quote.reference}: ${quote.text}`}
+>
+  {imageSource != null && (
+    <Image source={imageSource} style={StyleSheet.absoluteFill} contentFit="cover" />
+  )}
+  <LinearGradient
+    colors={[hexToRgba(bgColor, 0), bgColor]}
+    locations={[0, 0.6]}
+    style={StyleSheet.absoluteFill}
+    pointerEvents="none"
+  />
+  <View style={{ ...StyleSheet.absoluteFillObject, justifyContent: "flex-end", padding: scale(20) }}>
+    <Text style={{ fontWeight: "800", letterSpacing: 1.5 }}>{quote.reference.toUpperCase()}</Text>
+    <Text style={{ fontStyle: "italic" }}>{quote.text}</Text>
+    {ctaLabel != null && (
+      <View style={{ borderRadius: scale(20), backgroundColor: "rgba(255,255,255,0.2)" }}>
+        <Text>{ctaLabel}</Text>
+      </View>
+    )}
+  </View>
+</FocusableCard>
+```
+
+### Before: 130 lines of WebView/QR modal inline in QuizButtonRenderer
+
+### After: Shared LinkModal with parameterized props
+
+```
+// QuizButtonRenderer — quiz-specific validator
+<LinkModal url={iframeSrc} urlValidator={isAllowedQuizUrl} errorText="Couldn't load the quiz." />
+
+// BibleQuotesCarouselRenderer — general HTTPS validator
+{selectedCtaUrl != null && (
+  <LinkModal url={selectedCtaUrl} urlValidator={validateActionUrl} errorText="Couldn't load the page." />
+)}
+```
+
+## Related
+
+- `docs/solutions/ui-bugs/tv-carousel-card-focus-animation-overflow-20260416.md` — FocusableCard two-layer architecture, crimson glow, FlatList item padding
+- `docs/solutions/ui-bugs/android-tv-density-scaling-and-native-view-clipping-20260416.md` — `scale()` utility, `expo-image` inside `overflow: "hidden"` on Android TV
+- `docs/solutions/mobile/linear-gradient-dark-banding-transparent-keyword.md` — `hexToRgba()` origin and the `"transparent"` keyword ban
+- `docs/solutions/best-practices/react-native-tvos-porting-pitfalls-20260414.md` — WebView conditional require, absolute positioning focus issues
+- `docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md` — SDUI pipeline architecture, TVFocusGuideView patterns
+- PR: https://github.com/JesusFilm/forge/pull/792


### PR DESCRIPTION
## Summary

- Extract shared `LinkModal` (WebView/QR) from `QuizButtonRenderer` into a reusable component with parameterized URL validator, error text, and QR heading
- Transform Bible Quotes cards from plain text to square image cards with gradient overlays, bottom-anchored italic text, per-card `backgroundColor`, and CTA button support
- Wire CTA card press to `LinkModal` — opens WebView on Android TV, QR code on tvOS
- Center-align carousel when cards don't fill screen width

## Test plan

- [x] TypeScript type-check passes with zero errors
- [x] ESLint and Prettier pass via pre-commit hooks
- [x] Verified on Apple TV 4K (1080p) simulator — square cards, gradient overlays, CTA pill, centered layout
- [ ] Verify on Android TV emulator
- [ ] Verify QuizButtonRenderer still functions identically after LinkModal extraction
- [ ] Verify CTA press opens WebView modal (Android TV) / QR code (tvOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)