### PR TITLE
chore(admin): run prisma migrate deploy before server start

### DIFF
--- a/apps/admin/railway.toml
+++ b/apps/admin/railway.toml
@@ -6,7 +6,20 @@ buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/admin... 
 # Railway's `[deploy.env]` block is unreliable for HOSTNAME (see
 # docs/solutions/deployment/nextjs-pnpm-monorepo-railway-standalone.md).
 # Set env vars in the Railway dashboard, not here.
-startCommand = "HOSTNAME=0.0.0.0 node apps/admin/.next/standalone/apps/admin/server.js"
+#
+# `prisma migrate deploy` runs before the server starts on every deploy.
+# Idempotent via the `_prisma_migrations` table — applied migrations are
+# no-ops on subsequent boots. If a migration fails, the start command
+# fails, Railway marks the deploy unhealthy and rolls back, which is the
+# intended fail-fast behavior (better than a running server against a
+# DB that's missing tables).
+#
+# Note: `CREATE EXTENSION vector` in 0001_init requires the DB role to
+# have superuser/owner privilege. Railway's managed Postgres pre-installs
+# pgvector on their plugin, so this should just work on a fresh service.
+# If it doesn't, run `CREATE EXTENSION vector;` once as the Railway DB
+# owner, then redeploy — subsequent migrate runs are no-ops.
+startCommand = "pnpm --filter @forge/admin db:migrate:deploy && HOSTNAME=0.0.0.0 node apps/admin/.next/standalone/apps/admin/server.js"
 healthcheckPath = "/api/health"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary

One-line change to `apps/admin/railway.toml`: prepend `pnpm --filter @forge/admin db:migrate:deploy` to the `startCommand` so Prisma migrations apply automatically on every Railway deploy.

Before:
\`\`\`
startCommand = \"HOSTNAME=0.0.0.0 node apps/admin/.next/standalone/apps/admin/server.js\"
\`\`\`

After:
\`\`\`
startCommand = \"pnpm --filter @forge/admin db:migrate:deploy && HOSTNAME=0.0.0.0 node apps/admin/.next/standalone/apps/admin/server.js\"
\`\`\`

Relevant because:
- Admin doesn't have a Railway service yet (tatai is provisioning). Wiring migrate-on-deploy now means he won't have to SSH in to run migrations by hand on first boot — just `git push` triggers it.
- \`_prisma_migrations\` table makes this idempotent; already-applied migrations are no-ops. Safe for existing deploys once admin is live.
- Fail-fast is the intended behavior per user discussion: a failed migration = failed start command = Railway marks the deploy unhealthy and rolls back. Better than a running server against a DB missing tables.

## Testing

- No code change; `railway.toml` only.
- Pair tested by reading the file and confirming the `db:migrate:deploy` script exists in `apps/admin/package.json` (it does, line 16).
- Actual verification lands when tatai provisions admin on Railway and the first deploy runs migrations 0001/0002/0003 cleanly.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - First-deploy logs: Railway \`forge-admin\` service — look for Prisma migrate output \`Applying migration '0001_init'\` / \`'0002_auth'\` / \`'0003_scene_embeddings'\`, then \`server.js\` boot log.
  - Subsequent deploys: look for \`No pending migrations to apply.\` before the server boots.
- **Expected healthy behavior**
  - First deploy: all three migrations apply, server boots, healthcheck at \`/api/health\` returns 200.
  - Normal deploys: zero pending migrations logged, server boots.
- **Failure signal(s) / rollback trigger**
  - Start command exits non-zero → Railway marks deploy unhealthy → previous version stays live.
  - Most likely cause on first deploy: \`CREATE EXTENSION vector\` requires DB superuser. If that fails, operator runs \`CREATE EXTENSION vector;\` once as the Railway DB owner, then retries the deploy.
- **Validation window & owner**
  - Window: first admin deploy (triggered by tatai standing up the service).
  - Owner: tatai (platform) + Nisal (migration author) on-call for the first deploy.
- **If no operational impact**
  - N/A — this is strictly an operational change, no runtime behavior changes for existing services (cms/manager/web/roadmap are untouched).

## Context

This is follow-up polish to PR #798 (R1 scene embeddings infrastructure). Keeps admin self-bootstrapping so the operator runbook for R1 backfill shrinks by one step.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>