### PR TITLE
chore: wire Railway remote MCP server into .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "railway": {
+      "type": "http",
+      "url": "https://mcp.railway.com"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds project-scoped \`.mcp.json\` pointing Claude Code at Railway's remote MCP server (\`https://mcp.railway.com\`).

Why: we're about to provision \`@forge/admin\` on Railway as part of R1 operational rollout. Typed MCP tools (service create, variable set, template deploy, logs) beat hand-crafted GraphQL curls for both reliability and auditability.

## How it works

- **Remote MCP, not local** (\`@railway/mcp-server\` npm package). No Railway CLI install, no token env var, no Dockerfile changes.
- Auth is OAuth on first use — Railway opens a browser window and scopes access to workspaces/projects the user already has via their Railway login.
- Project-scoped so the whole team picks it up on pull + Claude Code restart.

Reference: https://docs.railway.com/ai/remote-mcp-server

## Testing

- \`.mcp.json\` syntax validates (\`type: \"http\"\` + \`url\`).
- Actual verification: pull the branch, restart Claude Code, make a Railway request (e.g. \"list services in the forge project\"), approve the OAuth prompt. Works for me → good to merge.

## First-use UX

Each teammate will see:
1. Claude Code prompt: \"This repo's .mcp.json adds a server. Approve?\" (one-time).
2. First Railway tool call: browser window to Railway asking to approve scopes (one-time per workspace).

No ongoing friction after that.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a dev-tooling config only. No runtime code paths touched, no CI behavior changes. If the MCP endpoint is down, Claude Code falls back to whatever existing workflow each session was already using.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>