### PR TITLE
docs(solutions): compound meta-pattern — verify infra writes via independent read path

### DIFF
--- a/docs/solutions/best-practices/verify-infra-writes-via-independent-read-path-20260420.md
+++ b/docs/solutions/best-practices/verify-infra-writes-via-independent-read-path-20260420.md
@@ -1,0 +1,200 @@
+---
+title: When a write tool says "applied," verify via an independent read path before iterating on failure
+date: 2026-04-20
+category: best-practices
+problem_type: best_practice
+component: tooling
+root_cause: inadequate_documentation
+resolution_type: workflow_improvement
+severity: medium
+tags: [agentic, mcp, infrastructure, debugging, verification, railway]
+---
+
+## Problem
+
+When an infra-facing tool (MCP, CLI, API) returns a success-shaped
+response — `applied`, `staged`, `ok` — the ACK confirms **the write
+call was accepted**, not that **the downstream state changed in the
+way you expect**. Conflating the two is how an agent burns a
+deploy-wastes-an-hour spiral without realizing the failure is their
+own making.
+
+Observed 2026-04-20 during feat-104 (admin Railway provisioning):
+five consecutive deployments failed with `Error creating build plan
+with Railpack: No start command detected`. Each failure, I called
+the MCP's `updateServiceTool` to "re-apply" `startCommand`. Each
+call returned:
+
+```json
+{
+  "status": "applied",
+  "message": "Service has been updated and changes are staged for deployment."
+}
+```
+
+I also called `getServiceConfigTool` between retries — it reported
+the values as set. Both signals pointed at success. But every
+deployment snapshot showed `startCommand: null`. I blew an hour
+chasing hypotheses (compound-command parsing, region mismatch,
+Railpack vs NIXPACKS builder) before Nisal pushed me to stop and
+investigate the root cause directly.
+
+The fix was one tool call: `mcp__railway__accept-deploy` instead of
+the agent's internal `deployServiceTool`. `updateServiceTool` stages
+edits into a buffer; `accept-deploy` flushes that buffer into the
+canonical `serviceInstance` row AND triggers a deploy. Using
+`deployServiceTool` alone skipped the flush. The MCP wasn't broken —
+my mental model of "applied = live" was.
+
+## Symptoms
+
+- Write tool returns a success shape.
+- Read tool reports the write "took."
+- Downstream consumer (build, deployment, query engine) behaves as
+  if the write never happened.
+- Repeating the same write + retry loop produces the same outcome.
+- The agent keeps generating new hypotheses for why the write is
+  being "ignored" — compound-command parsing, length limits, region
+  mismatches, builder auto-detection — instead of questioning whether
+  the write is actually live.
+
+## What Didn't Work
+
+- **Re-calling the write with a simpler shape.** I assumed Railway
+  was rejecting a compound `startCommand` with `&&` and env var
+  prefixes, so I reduced it to `pnpm --filter X start`. Same
+  outcome. The shape wasn't the problem.
+- **Re-deploying with `deployServiceTool` after each write.** That
+  tool snapshots the live `serviceInstance` (which was unchanged)
+  and deploys from the unchanged state. It does not flush staged
+  patches.
+- **Trusting `getServiceConfigTool` as a read oracle.** It reads
+  the staged-merged view — so values appear "set" even though the
+  canonical row they'll be snapshotted from is empty. Two tools can
+  agree and both be lying by omission.
+
+## Solution
+
+**The specific Railway fix** (captured in depth in
+[`platform/railway-mcp-staged-config-never-commits-20260420.md`](../platform/railway-mcp-staged-config-never-commits-20260420.md)):
+after `updateServiceTool`, always call `mcp__railway__accept-deploy`
+on the environment. Don't call `deployServiceTool` and expect
+staged patches to flush.
+
+**The general rule — the actual learning worth compounding:**
+
+> When a write tool returns success but the observed downstream
+> behavior says the write didn't land, stop iterating on new hypotheses
+> about WHY the write is being ignored. Query the canonical stored
+> state via an independent read path — a different API, a different
+> endpoint, a direct SQL query, anything not sharing machinery with
+> the write tool. Confirm "the write actually took" before you propose
+> "why the downstream disagrees."
+
+Concretely, before the second retry of any failing infra write:
+
+1. **Identify the layered storage.** Most infra tools have staging,
+   canonical, and derived layers. Know which your write targets
+   and which your downstream reads.
+2. **Find an independent read path.** If the write is via MCP, query
+   via raw GraphQL / REST / SQL. If it's via a CLI, query via the
+   underlying API. Never use the SAME tool's read endpoint — it may
+   read the same buffer it wrote to.
+3. **Compare write-side ACK against canonical state.** If they
+   disagree, the write didn't land — stop iterating on downstream
+   hypotheses and fix the staging→canonical flush.
+4. **Only after the write's canonical effect is verified**, start
+   proposing theories for why the downstream isn't honoring it.
+
+## Why This Works
+
+Write-side success is necessary but not sufficient evidence of a
+state change. The tool owns the write path; its success signal
+reflects only that path. Any layer between the tool and the
+eventual consumer (staging buffers, caches, CDNs, async
+replication, transactional outboxes) can swallow the write
+silently.
+
+An independent read — especially one owned by the consumer — is
+the only thing that proves the write survived all layers. It's
+the engineering equivalent of read-after-write consistency
+testing: you can't assume it; you verify.
+
+## Prevention
+
+### Baseline habits
+
+- **Map your tool's layers before trusting it.** The first time you
+  use a new infra MCP / CLI / API for writes, answer these before
+  building automation on top of it:
+  1. Where does a write physically land (staging / canonical /
+     derived)?
+  2. What flushes staging → canonical (a follow-up call? a timer?
+     nothing automatic)?
+  3. Which read tool reads from which layer?
+  4. Which layer does the downstream consumer snapshot from?
+- **Keep a separate read path ready for every infra write.** For
+  Railway, that's raw GraphQL via `Project-Access-Token`. For cloud
+  providers it's usually the underlying API, not the wrapper CLI.
+- **Budget a hard retry cap.** Before the **third** consecutive
+  retry of the same write-that-claimed-success, hand off to the
+  verification path. Three strikes is a mandatory stop.
+
+### Red flags that trigger immediate verification
+
+- Any response that says "staged," "queued," "pending," "scheduled,"
+  "will apply" — these are future-tense. Treat as unverified until
+  confirmed flushed.
+- Downstream consumer behaves exactly as if your write never
+  happened (not "partial effect" — literally no effect).
+- Your read tool matches the write tool's claim, but the real system
+  diverges. Suspect both of reading the same staged buffer.
+
+### Code / operations shape
+
+```python
+# Bad: treat write ACK as done
+result = mcp.update_service(startCommand="...")
+assert result.status == "applied"  # misleading success signal
+mcp.deploy_service(...)             # may snapshot unchanged state
+
+# Good: verify canonical state via independent read before the next step
+mcp.update_service(startCommand="...")
+live = graphql.query(
+    "service(id).serviceInstances.edges[0].node.startCommand"
+)
+if live != expected:
+    raise RuntimeError(
+        "Write reported applied but canonical state unchanged. "
+        "Check for staged→canonical flush step."
+    )
+mcp.accept_deploy(environmentId=...)  # explicit flush, then deploy
+```
+
+### Retrospective prompt for post-incident review
+
+When an agent-driven session burns multiple retries on an infra
+operation that should have been one call:
+
+- Did we have an independent read path? If not, why was that okay?
+- At what retry number should we have stopped and verified
+  canonical state? (The answer should almost never be > 3.)
+- Was there a success signal we trusted that reflected write-side
+  ACK, not downstream state?
+
+## Why This Entry Exists Even Though the Railway-Specific Doc Exists
+
+The Railway doc at
+`docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md`
+tells future readers how to use Railway's MCP correctly. This doc
+tells them how to **avoid the shape of failure in the first place**
+for any infra tool they adopt — Kubernetes, Cloudflare, Terraform
+Cloud, Vercel, AWS, anything with a staging layer.
+
+The Railway finding is specific. The meta-pattern compounds.
+
+## Related
+
+- [`platform/railway-mcp-staged-config-never-commits-20260420.md`](../platform/railway-mcp-staged-config-never-commits-20260420.md) — the Railway-specific fix.
+- PR #804 — feat-104 admin Railway provisioning (where this surfaced).
+- PR #807 — feat-105 SSO ticket + the Railway-specific solution doc.


### PR DESCRIPTION
## Summary

Compounds a meta-pattern that bit me hard during feat-104 (admin Railway provisioning, PR #804 / #807):

> When a write tool returns success but the downstream consumer behaves as if the write didn't land, **stop iterating on new hypotheses**. Query the canonical stored state via a read path that does NOT share machinery with the write tool.

I burned 5 failed deploys cycling new theories (compound-command parsing, region mismatch, Railpack vs NIXPACKS) because the MCP said `"applied"` and the MCP's own read tool agreed. Neither reflected the canonical `serviceInstance` state. One tool call — `accept-deploy` instead of `deployServiceTool` — was the actual fix, and I'd have gotten there in one retry instead of five if I'd verified via independent read after the first failure.

## Why this is separate from PR #807

- **PR #807** carries the Railway-specific doc (`docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md`) — how to use Railway's MCP correctly.
- **This PR** carries the general pattern (`docs/solutions/best-practices/verify-infra-writes-via-independent-read-path-20260420.md`) — applies to any infra tool with staging/canonical/derived layers (Kubernetes, Cloudflare, Terraform Cloud, Vercel, cloud CLIs).

Nisal asked for them in separate PRs so the meta-learning has its own review surface.

## What the doc captures

- The failure mode and symptoms (write-ACK vs canonical-state divergence)
- What didn't work (retrying the write with a simpler shape, trusting the MCP's own read oracle)
- The specific Railway fix + the general rule
- Prevention: baseline habits for adopting any infra tool, red flags, retry cap, code-shape pattern, retrospective prompts

## Test plan

- [ ] Review the meta-pattern claims against the observed symptoms (five failed deploys documented with timestamps in the conversation log)
- [ ] Cross-check links to the Railway-specific doc resolve once PR #807 merges
- [ ] Sanity-check the prevention-habits list against teammates' mental models of when they'd actually reach for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)