### PR TITLE
chore(devcontainer): provision Chromium for chrome-devtools MCP

### DIFF
--- a/.devcontainer.staged/Dockerfile
+++ b/.devcontainer.staged/Dockerfile
@@ -1,0 +1,140 @@
+# Claude Code Devcontainer
+# Based on Microsoft devcontainer image for better devcontainer integration
+ARG UV_VERSION=0.10.0
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}@sha256:78a7ff97cd27b7124a5f3c2aefe146170793c56a1e03321dd31a289f6d82a04f AS uv
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04@sha256:d94c97dd9cacf183d0a6fd12a8e87b526e9e928307674ae9c94139139c0c6eae
+
+ARG TZ
+ENV TZ="$TZ"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install additional system packages (base image already includes git, curl, sudo, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  # Sandboxing support for Claude Code
+  bubblewrap \
+  socat \
+  # Modern CLI tools
+  fd-find \
+  ripgrep \
+  tmux \
+  zsh \
+  # Build tools
+  build-essential \
+  # PostgreSQL client (server runs in sidecar container)
+  postgresql-client \
+  # Redis CLI client (server runs in sidecar container)
+  redis-tools \
+  # Utilities
+  jq \
+  nano \
+  unzip \
+  vim \
+  # Network tools (for security testing)
+  dnsutils \
+  ipset \
+  iptables \
+  iproute2 \
+  # Headless Chromium runtime deps (for chrome-devtools MCP). The browser
+  # binary itself is provisioned per-user in post_install.py via Playwright,
+  # which ships an arm64-native Chromium. These libs satisfy its runtime
+  # link requirements without needing snap or x86_64 multilib.
+  fonts-liberation \
+  libasound2t64 \
+  libatk-bridge2.0-0t64 \
+  libatk1.0-0t64 \
+  libcairo2 \
+  libcups2t64 \
+  libdrm2 \
+  libgbm1 \
+  libnss3 \
+  libpango-1.0-0 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxfixes3 \
+  libxkbcommon0 \
+  libxrandr2 \
+  libxss1 \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install git-delta
+ARG GIT_DELTA_VERSION=0.18.2
+RUN ARCH=$(dpkg --print-architecture) && \
+  curl -fsSL "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" -o /tmp/git-delta.deb && \
+  dpkg -i /tmp/git-delta.deb && \
+  rm /tmp/git-delta.deb
+
+# Install uv (Python package manager) via multi-stage copy
+COPY --from=uv /uv /usr/local/bin/uv
+
+# Install fzf from GitHub releases (newer than apt, includes built-in shell integration)
+ARG FZF_VERSION=0.67.0
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "${ARCH}" in \
+    amd64) FZF_ARCH="linux_amd64" ;; \
+    arm64) FZF_ARCH="linux_arm64" ;; \
+    *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+  esac && \
+  curl -fsSL "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-${FZF_ARCH}.tar.gz" | tar -xz -C /usr/local/bin
+
+# Install Doppler CLI (secrets management)
+RUN curl -fsSL --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh | sh
+
+# Create directories and set ownership (combined for fewer layers)
+RUN mkdir -p /commandhistory /workspace /home/vscode/.claude /home/vscode/.codex /opt && \
+  touch /commandhistory/.bash_history && \
+  touch /commandhistory/.zsh_history && \
+  chown -R vscode:vscode /commandhistory /workspace /home/vscode/.claude /home/vscode/.codex /opt
+
+# Set environment variables
+ENV DEVCONTAINER=true
+ENV SHELL=/bin/zsh
+ENV EDITOR=nano
+ENV VISUAL=nano
+
+WORKDIR /workspace
+
+# Switch to non-root user for remaining setup
+USER vscode
+
+# Set PATH early so claude and other user-installed binaries are available
+ENV PATH="/home/vscode/.local/bin:$PATH"
+
+# Install Claude Code natively with marketplace plugins
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+  claude plugin marketplace add anthropics/skills && \
+  claude plugin marketplace add trailofbits/skills && \
+  claude plugin marketplace add trailofbits/skills-curated
+
+# Install Python 3.13 via uv (fast binary download, not source compilation)
+RUN uv python install 3.13 --default
+
+# Install ast-grep (AST-based code search)
+RUN uv tool install ast-grep-cli
+
+# Install fnm (Fast Node Manager), Node 24, pnpm, and Codex CLI
+ARG NODE_VERSION=24
+ENV FNM_DIR="/home/vscode/.fnm"
+RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "$FNM_DIR" --skip-shell && \
+  export PATH="$FNM_DIR:$PATH" && \
+  eval "$(fnm env)" && \
+  fnm install ${NODE_VERSION} && \
+  fnm default ${NODE_VERSION} && \
+  corepack enable && \
+  corepack prepare pnpm@9.12.3 --activate && \
+  npm install -g @openai/codex@latest
+
+# Install Oh My Zsh
+ARG ZSH_IN_DOCKER_VERSION=1.2.1
+RUN sh -c "$(curl -fsSL https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
+  -p git \
+  -x
+
+# Copy zsh configuration
+COPY --chown=vscode:vscode .zshrc /home/vscode/.zshrc.custom
+
+# Append custom zshrc to the main one
+RUN echo 'source ~/.zshrc.custom' >> /home/vscode/.zshrc
+
+# Copy post_install script
+COPY --chown=vscode:vscode post_install.py /opt/post_install.py

--- a/.devcontainer.staged/post_install.py
+++ b/.devcontainer.staged/post_install.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Post-install configuration for AI-enabled devcontainer.
+
+Runs on container creation to set up:
+- Claude settings (bypassPermissions mode)
+- Codex settings (danger-full-access with no approval prompts)
+- Tmux configuration (200k history, mouse support)
+- Directory ownership fixes for mounted volumes
+- Chromium binary + stable symlink for chrome-devtools MCP
+"""
+
+import contextlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def setup_claude_settings():
+    """Configure Claude Code with bypassPermissions enabled."""
+    claude_dir = Path.home() / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    settings_file = claude_dir / "settings.json"
+
+    # Load existing settings or start fresh
+    settings = {}
+    if settings_file.exists():
+        with contextlib.suppress(json.JSONDecodeError):
+            settings = json.loads(settings_file.read_text())
+
+    # Set bypassPermissions mode
+    if "permissions" not in settings:
+        settings["permissions"] = {}
+    settings["permissions"]["defaultMode"] = "bypassPermissions"
+
+    settings_file.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    print(f"[post_install] Claude settings configured: {settings_file}", file=sys.stderr)
+
+
+def setup_codex_settings():
+    """Configure Codex with full access inside the devcontainer VM."""
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    codex_home.mkdir(parents=True, exist_ok=True)
+
+    config_file = codex_home / "config.toml"
+    desired_lines = [
+        'approval_policy = "never"',
+        'sandbox_mode = "danger-full-access"',
+    ]
+    desired_keys = ("approval_policy", "sandbox_mode")
+
+    existing_lines: list[str] = []
+    if config_file.exists():
+        existing_lines = config_file.read_text(encoding="utf-8").splitlines()
+
+    filtered_lines = [
+        line
+        for line in existing_lines
+        if not any(line.strip().startswith(f"{key} =") for key in desired_keys)
+    ]
+
+    config_lines = [*desired_lines]
+    if filtered_lines:
+        config_lines.append("")
+        config_lines.extend(filtered_lines)
+
+    config_file.write_text("\n".join(config_lines) + "\n", encoding="utf-8")
+    print(f"[post_install] Codex settings configured: {config_file}", file=sys.stderr)
+
+
+def setup_tmux_config():
+    """Configure tmux with 200k history, mouse support, and vi keys."""
+    tmux_conf = Path.home() / ".tmux.conf"
+
+    if tmux_conf.exists():
+        print("[post_install] Tmux config exists, skipping", file=sys.stderr)
+        return
+
+    config = """\
+# 200k line scrollback history
+set-option -g history-limit 200000
+
+# Enable mouse support
+set -g mouse on
+
+# Use vi keys in copy mode
+setw -g mode-keys vi
+
+# Start windows and panes at 1, not 0
+set -g base-index 1
+setw -g pane-base-index 1
+
+# Renumber windows when one is closed
+set -g renumber-windows on
+
+# Faster escape time for vim
+set -sg escape-time 10
+
+# True color support
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+
+# Terminal features (ghostty, cursor shape in vim)
+set -as terminal-features ",xterm-ghostty:RGB"
+set -as terminal-features ",xterm*:RGB"
+set -ga terminal-overrides ",xterm*:colors=256"
+set -ga terminal-overrides '*:Ss=\\E[%p1%d q:Se=\\E[ q'
+
+# Status bar
+set -g status-style 'bg=#333333 fg=#ffffff'
+set -g status-left '[#S] '
+set -g status-right '%Y-%m-%d %H:%M'
+"""
+    tmux_conf.write_text(config, encoding="utf-8")
+    print(f"[post_install] Tmux configured: {tmux_conf}", file=sys.stderr)
+
+
+def fix_directory_ownership():
+    """Fix ownership of mounted volumes that may have root ownership."""
+    uid = os.getuid()
+    gid = os.getgid()
+
+    dirs_to_fix = [
+        Path.home() / ".claude",
+        Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")),
+        Path("/commandhistory"),
+        Path.home() / ".config" / "gh",
+    ]
+
+    for dir_path in dirs_to_fix:
+        if dir_path.exists():
+            try:
+                # Use sudo to fix ownership if needed
+                stat_info = dir_path.stat()
+                if stat_info.st_uid != uid:
+                    subprocess.run(
+                        ["sudo", "chown", "-R", f"{uid}:{gid}", str(dir_path)],
+                        check=True,
+                        capture_output=True,
+                    )
+                    print(f"[post_install] Fixed ownership: {dir_path}", file=sys.stderr)
+            except (PermissionError, subprocess.CalledProcessError) as e:
+                print(
+                    f"[post_install] Warning: Could not fix ownership of {dir_path}: {e}",
+                    file=sys.stderr,
+                )
+
+
+def setup_global_gitignore():
+    """Set up global gitignore and local git config.
+
+    Since ~/.gitconfig is mounted read-only from host, we create a local
+    config file that includes the host config and adds container-specific
+    settings like core.excludesfile and delta configuration.
+
+    GIT_CONFIG_GLOBAL env var (set in devcontainer.json) points git to this
+    local config as the "global" config.
+    """
+    home = Path.home()
+    gitignore = home / ".gitignore_global"
+    local_gitconfig = home / ".gitconfig.local"
+    host_gitconfig = home / ".gitconfig"
+
+    # Create global gitignore with common patterns
+    patterns = """\
+# Claude Code
+.claude/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+
+# Python
+*.pyc
+*.pyo
+__pycache__/
+*.egg-info/
+.eggs/
+*.egg
+.venv/
+venv/
+.mypy_cache/
+.ruff_cache/
+
+# Node
+node_modules/
+.npm/
+
+# Editors
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+*.sublime-*
+
+# Misc
+*.log
+.env.local
+.env.*.local
+"""
+    gitignore.write_text(patterns, encoding="utf-8")
+    print(f"[post_install] Global gitignore created: {gitignore}", file=sys.stderr)
+
+    # Create local git config that includes host config and sets excludesfile + delta
+    # Delta config is included here so it works even if host doesn't have it configured
+    local_config = f"""\
+# Container-local git config
+# Includes host config (mounted read-only) and adds container settings
+
+[include]
+    path = {host_gitconfig}
+
+[core]
+    excludesfile = {gitignore}
+    pager = delta
+
+[interactive]
+    diffFilter = delta --color-only
+
+[delta]
+    navigate = true
+    light = false
+    line-numbers = true
+    side-by-side = false
+
+[merge]
+    conflictstyle = diff3
+
+[diff]
+    colorMoved = default
+
+[gpg "ssh"]
+    program = /usr/bin/ssh-keygen
+"""
+    local_gitconfig.write_text(local_config, encoding="utf-8")
+    print(f"[post_install] Local git config created: {local_gitconfig}", file=sys.stderr)
+
+
+def setup_chrome_devtools_mcp():
+    """Provision Chromium for chrome-devtools MCP.
+
+    Uses Playwright's installer because it ships an arm64-native Chromium for
+    Linux — Google's Chrome-for-Testing builds are x86_64 only and Rosetta
+    inside the container can't satisfy the cross-arch glibc / GTK chain.
+
+    Creates a stable symlink at ~/.cache/chrome-devtools-mcp/chromium-bin
+    so the repo's `.mcp.json` does not need to chase Playwright revision
+    bumps. The target is the highest-versioned `chromium-*/chrome-linux/chrome`
+    under ~/.cache/ms-playwright/. The symlink name avoids `chrome` because
+    chrome-devtools-mcp uses a sibling `chrome-profile/` directory at the
+    same parent and we don't want to risk a collision. Idempotent: re-running
+    on an existing container skips the download and refreshes the symlink to
+    whatever is current.
+    """
+    home = Path.home()
+    fnm_bin = home / ".fnm" / "fnm"
+    if not fnm_bin.exists():
+        print(
+            "[post_install] fnm not found, skipping chrome-devtools MCP setup",
+            file=sys.stderr,
+        )
+        return
+
+    # Run `pnpm dlx playwright install chromium` through a login-style bash
+    # invocation so fnm exposes node + pnpm on PATH.
+    install_cmd = (
+        f'eval "$({fnm_bin} env)" && pnpm dlx playwright@latest install chromium'
+    )
+    try:
+        subprocess.run(
+            ["bash", "-c", install_cmd],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(
+            "[post_install] Warning: Playwright chromium install failed; "
+            f"chrome-devtools MCP will not work until resolved. {exc.stderr}",
+            file=sys.stderr,
+        )
+        return
+
+    pw_cache = home / ".cache" / "ms-playwright"
+    candidates = sorted(
+        pw_cache.glob("chromium-*/chrome-linux/chrome"),
+        key=lambda p: p.parent.parent.name,
+        reverse=True,
+    )
+    chrome_bin = next((p for p in candidates if p.is_file()), None)
+    if chrome_bin is None:
+        print(
+            "[post_install] Warning: Playwright reported success but no "
+            "chromium binary was found under ~/.cache/ms-playwright/",
+            file=sys.stderr,
+        )
+        return
+
+    link_dir = home / ".cache" / "chrome-devtools-mcp"
+    link_dir.mkdir(parents=True, exist_ok=True)
+    link = link_dir / "chromium-bin"
+    if link.is_symlink() or link.is_file():
+        link.unlink()
+    elif link.exists():
+        # A directory at this path is unexpected — bail rather than rm -rf it.
+        print(
+            f"[post_install] Warning: {link} exists and is not a file/symlink; "
+            "leaving alone. Remove it manually to enable chrome-devtools MCP.",
+            file=sys.stderr,
+        )
+        return
+    link.symlink_to(chrome_bin)
+    print(
+        f"[post_install] chrome-devtools MCP chromium ready: {link} -> {chrome_bin}",
+        file=sys.stderr,
+    )
+
+
+def main():
+    """Run all post-install configuration."""
+    print("[post_install] Starting post-install configuration...", file=sys.stderr)
+
+    setup_claude_settings()
+    setup_codex_settings()
+    setup_tmux_config()
+    fix_directory_ownership()
+    setup_global_gitignore()
+    setup_chrome_devtools_mcp()
+
+    print("[post_install] Configuration complete!", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,19 @@
     "railway": {
       "type": "http",
       "url": "https://mcp.railway.com"
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@latest",
+        "--executablePath",
+        "/home/vscode/.cache/chrome-devtools-mcp/chromium-bin",
+        "--headless",
+        "--isolated",
+        "--chromeArg=--no-sandbox",
+        "--chromeArg=--disable-gpu",
+        "--chromeArg=--disable-dev-shm-usage"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Makes the `chrome-devtools` MCP server work for every dev the moment their container finishes provisioning — no manual apt / Playwright / symlink steps.

**What's wired up:**
- **Dockerfile:** adds the headless-Chromium runtime deps (`libnss3`, `libgbm1`, `libasound2t64`, `libatk1.0-0t64`, …). The browser binary itself is installed per-user, not baked into the image.
- **post_install.py:** new `setup_chrome_devtools_mcp()` runs on container create. Downloads an arm64-native Chromium via `pnpm dlx playwright install chromium` (Google's Chrome-for-Testing is x86_64 only and Rosetta can't satisfy the cross-arch glibc chain), then creates a stable symlink at `~/.cache/chrome-devtools-mcp/chromium-bin` pointed at it. Idempotent.
- **`.mcp.json`:** the `chrome-devtools` entry now points `--executablePath` at the stable symlink and passes `--headless --isolated --no-sandbox --disable-gpu --disable-dev-shm-usage` so Chromium runs cleanly in a sandboxed devcontainer (no DBus, no X, no /dev/shm).

**Why Playwright-bundled Chromium vs Chrome-for-Testing:** tried both. Chrome-for-Testing ships only x86_64 Linux; the container is arm64 with Rosetta available but the x86_64 userland (libc, libdl, libglib, GTK/X11 stack) is not on the apt-ports arm64 mirror. Playwright ships an arm64-native Chromium as a single self-contained tarball — exactly what we need.

## Testing

Ran the updated `post_install.py` end-to-end in this container:

```
[post_install] chrome-devtools MCP chromium ready: /home/vscode/.cache/chrome-devtools-mcp/chromium-bin -> /home/vscode/.cache/ms-playwright/chromium-1217/chrome-linux/chrome
```

Smoke:
- `~/.cache/chrome-devtools-mcp/chromium-bin --version` → `Chromium 147.0.7727.0`
- `~/.cache/chrome-devtools-mcp/chromium-bin --headless --no-sandbox --disable-gpu --dump-dom https://example.com | grep h1` → `<h1>Example Domain</h1>`
- Idempotency: ran `post_install.py` twice in a row, second run was a Playwright cache hit (~2s, no re-download), symlink refreshed.

## Reviewer — one manual apply step required

The agent that authored this PR couldn't edit `.devcontainer/` directly because that path is a read-only `fakeowner` mount inside the running container (a security boundary — agents inside the container can't modify devcontainer config). The new Dockerfile + post_install.py are staged under `.devcontainer.staged/`. **Please run from your host before merging:**

```bash
git checkout chore/devcontainer-chrome-devtools-mcp
git pull
cp .devcontainer.staged/Dockerfile .devcontainer.staged/post_install.py .devcontainer/
git rm -rf .devcontainer.staged
git add -A && git commit --amend --no-edit && git push --force-with-lease
```

That keeps the final merged diff clean (only `.devcontainer/Dockerfile`, `.devcontainer/post_install.py`, `.mcp.json`).

## Post-Deploy Monitoring & Validation

- **What to monitor/search:** team Slack / issues for anyone rebuilding their container after this merges. Watch for post_install warnings from the `[post_install] Warning: Playwright chromium install failed` line if Playwright's install endpoint is unreachable.
- **Validation checks:**
  - After container rebuild: `ls -l ~/.cache/chrome-devtools-mcp/chromium-bin` (must be a symlink into `~/.cache/ms-playwright/chromium-*/chrome-linux/chrome`)
  - `~/.cache/chrome-devtools-mcp/chromium-bin --version` (must print `Chromium …`)
  - Claude Code restart → chrome-devtools MCP tools listed (e.g. `mcp__chrome-devtools__navigate_page`)
- **Expected healthy:** symlink present, Chromium runs, MCP tools available in Claude Code.
- **Failure signal / rollback trigger:** `setup_chrome_devtools_mcp` warning in `postCreateCommand` output, or chrome-devtools MCP fails to connect on first `navigate_page`. Rollback: revert this PR — nothing in the codebase depends on the MCP working; developers just lose the agent-driven browser verification they had before.
- **Validation window & owner:** first 48h of devs rebuilding their container, Nisal.

---

[![Compound Engineering v2.52.0](https://img.shields.io/badge/Compound_Engineering-v2.52.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)