### PR TITLE
fix(web): replace demo-search Server Action with Route Handler

### DIFF
--- a/apps/web/src/app/api/demo-search/generate/route.ts
+++ b/apps/web/src/app/api/demo-search/generate/route.ts
@@ -1,5 +1,4 @@
-"use server"
-
+import { NextResponse } from "next/server"
 import {
   ExperienceGeneratorError,
   generateExperience,
@@ -22,31 +21,53 @@ const USER_MESSAGES: Record<ExperienceGeneratorErrorCode, string> = {
     "The model couldn't find enough in-catalog videos for this query. Try a broader query or different phrasing.",
 }
 
-export async function generateExperienceAction(input: {
-  query: string
-  results: CompactResult[]
-}): Promise<GenerateExperienceResult> {
+export async function POST(req: Request) {
+  let body: { query?: string; results?: CompactResult[] }
   try {
-    const { experience, latencyMs } = await generateExperience(
-      input.query,
-      input.results,
+    body = await req.json()
+  } catch {
+    return NextResponse.json<GenerateExperienceResult>(
+      {
+        ok: false,
+        code: "SCHEMA_MISMATCH",
+        message: USER_MESSAGES.SCHEMA_MISMATCH,
+      },
+      { status: 400 },
     )
-    return { ok: true, experience, latencyMs }
+  }
+
+  const { query, results } = body
+  if (typeof query !== "string" || !Array.isArray(results)) {
+    return NextResponse.json<GenerateExperienceResult>(
+      {
+        ok: false,
+        code: "SCHEMA_MISMATCH",
+        message: USER_MESSAGES.SCHEMA_MISMATCH,
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const { experience, latencyMs } = await generateExperience(query, results)
+    return NextResponse.json<GenerateExperienceResult>({
+      ok: true,
+      experience,
+      latencyMs,
+    })
   } catch (err) {
     if (err instanceof ExperienceGeneratorError) {
-      return {
+      return NextResponse.json<GenerateExperienceResult>({
         ok: false,
         code: err.code,
         message: USER_MESSAGES[err.code],
-      }
+      })
     }
-    // Unknown error — log server-side so it's grep-able in Railway instead
-    // of collapsing invisibly to a generic user message.
-    console.error("[generateExperienceAction] unexpected error", err)
-    return {
+    console.error("[generate route] unexpected error", err)
+    return NextResponse.json<GenerateExperienceResult>({
       ok: false,
       code: "UPSTREAM_ERROR",
       message: USER_MESSAGES.UPSTREAM_ERROR,
-    }
+    })
   }
 }

--- a/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
+++ b/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState, useTransition } from "react"
-import { generateExperienceAction } from "@/app/demo-search/actions"
+import { useEffect, useMemo, useRef, useState } from "react"
+import type { GenerateExperienceResult } from "@/app/api/demo-search/generate/route"
 import {
   getGeneratePending,
   setGeneratePending,
@@ -54,7 +54,7 @@ export function AiExperienceGeneratorDemo({
   results,
 }: AiExperienceGeneratorDemoProps) {
   const [state, setState] = useState<GenState>({ status: "idle" })
-  const [isPending, startTransition] = useTransition()
+  const [isPending, setIsPending] = useState(false)
   // `run` captures current query + results in a closure, so we hold the
   // latest copy in a ref for the bus subscription (which is set up once
   // on mount).
@@ -65,22 +65,25 @@ export function AiExperienceGeneratorDemo({
     [results],
   )
 
-  function run() {
+  async function run() {
     // Synchronous guard via the shared bus — isPending is closure-captured
     // and can be stale between two rapid requestGenerate() calls (shortcut
     // button + Enter key). getGeneratePending() reads the latest value.
     if (getGeneratePending()) return
     setGeneratePending(true)
+    setIsPending(true)
     const compact = results.slice(0, MAX_RESULTS_FOR_PROMPT).map((r) => ({
       slug: r.slug,
       title: r.title ?? r.slug,
       snippet: r.snippet ?? "",
     }))
-    startTransition(async () => {
-      const outcome = await generateExperienceAction({
-        query,
-        results: compact,
+    try {
+      const res = await fetch("/api/demo-search/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query, results: compact }),
       })
+      const outcome = (await res.json()) as GenerateExperienceResult
       if (outcome.ok) {
         setState({
           status: "success",
@@ -94,7 +97,16 @@ export function AiExperienceGeneratorDemo({
           message: outcome.message,
         })
       }
-    })
+    } catch {
+      setState({
+        status: "error",
+        code: "UPSTREAM_ERROR",
+        message:
+          "The AI generation service is unavailable right now. Give it a moment and try again.",
+      })
+    } finally {
+      setIsPending(false)
+    }
   }
   useEffect(() => {
     runRef.current = run


### PR DESCRIPTION
## Summary

- Each Generate click on `/demo-search` was triggering Next.js 16's RSC auto-revalidation, which re-streamed the Suspense children and appended a fresh `DemoSearchResults` subtree instead of reconciling — users saw the 8-card grid duplicate with every click (2 clicks → 24 tiles, 3 clicks → 32 tiles).
- Moved the experience-generator call from a `"use server"` Server Action to a plain `POST /api/demo-search/generate` Route Handler. No RSC revalidation, no reconciliation bug.
- Also unblocks independent rate-limiting on the endpoint (ce:review follow-up from #809).

## Changes

- **Added** `apps/web/src/app/api/demo-search/generate/route.ts` — POST handler with the same `GenerateExperienceResult` contract and `USER_MESSAGES` mapping.
- **Deleted** `apps/web/src/app/demo-search/actions.ts` (replaced).
- **Updated** `AiExperienceGeneratorDemo.tsx` — `fetch('/api/demo-search/generate', …)` with plain `useState`, no `useTransition`.

## Also in this deploy

- `OPENROUTER_API_KEY` set on `@forge/web` production via Railway GraphQL API (copied from `@forge/cms`), fixing the `NOT_CONFIGURED` → "AI generation is temporarily unavailable" error.

## Test plan

- [ ] Visit `https://watch.jesusfilm.org/watch/demo-search?q=evidence+of+the+resurrection`
- [ ] Confirm 8 result tiles render (no duplicates)
- [ ] Click **Generate** → experience renders, only 8 tiles still visible
- [ ] Click **Regenerate** → still 8 tiles
- [ ] Type a new query, press Enter → 8 fresh tiles, click **Generate** → 8 tiles + experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)