### PR TITLE
fix(web): prefix demo-search Route Handler fetch with /watch basePath

### DIFF
--- a/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
+++ b/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
@@ -78,7 +78,7 @@ export function AiExperienceGeneratorDemo({
       snippet: r.snippet ?? "",
     }))
     try {
-      const res = await fetch("/api/demo-search/generate", {
+      const res = await fetch("/watch/api/demo-search/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ query, results: compact }),


### PR DESCRIPTION
## Summary

Follow-up to #813. `next.config` sets `basePath: "/watch"`, but `fetch()` calls do **not** auto-prefix basePath the way `<Link>` / `router.push` do. The client was hitting `/api/demo-search/generate` → 404 → caught as `UPSTREAM_ERROR` → rendered as "AI generation service is unavailable right now."

One-line fix: hardcode the full path `/watch/api/demo-search/generate`.

Also explains the lingering tile duplication report after #813 merged — the request was never reaching the server, but the user's browser was still on the old cached bundle that invoked the now-deleted Server Action.

## Test plan

- [ ] After deploy, hard-refresh `https://watch.jesusfilm.org/watch/demo-search?q=evidence+of+the+resurrection`
- [ ] Click Generate → experience renders, 8 tiles still visible (no duplication)
- [ ] Click Regenerate → still 8 tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)