### PR TITLE
fix(web): reset demo-search session metrics on page refresh

### DIFF
--- a/apps/web/src/lib/demo-search-metrics.test.ts
+++ b/apps/web/src/lib/demo-search-metrics.test.ts
@@ -69,10 +69,7 @@ describe("demo-search-metrics", () => {
     expect(getStats()).toBe(afterRecord)
   })
 
-  it("degrades gracefully without window.sessionStorage", () => {
-    // Module is imported once — reset clears state, and because there is no
-    // window in the Node vitest env, hydrate() short-circuits. Recording a
-    // sample after reset must still work.
+  it("resets on module reset (fresh page-load semantics)", () => {
     recordQuery(42)
     expect(getStats().count).toBe(1)
   })

--- a/apps/web/src/lib/demo-search-metrics.ts
+++ b/apps/web/src/lib/demo-search-metrics.ts
@@ -1,20 +1,16 @@
-// Session-scoped metrics for the /demo-search showcase.
+// Page-scoped metrics for the /demo-search showcase.
 //
 // Records wall-clock round-trip for each semanticSearch query the demo page
 // fires client-side (initial page-load latency is server-side and not captured
-// here — see the demo page copy for the methodology note).
+// here — see the demo page copy for the methodology note). Counters reset on
+// every page load — the panel copy says "this session" meaning the current
+// visit, not a persistent tab session.
 //
 // Embedding cost assumption below tracks OpenAI text-embedding-3-small via
 // OpenRouter at ~20 tokens/query. Adjust both the constant and the demo panel
 // copy together if the embedding model changes.
 
 const EMBEDDING_COST_USD_PER_QUERY = 0.0000006
-
-const STORAGE_KEY = "demo-search-metrics:v1"
-
-type SerializedState = {
-  samples: number[]
-}
 
 export type DemoSearchStats = {
   count: number
@@ -25,46 +21,6 @@ export type DemoSearchStats = {
 
 const listeners = new Set<() => void>()
 let samples: number[] = []
-let hydrated = false
-
-function hasSessionStorage(): boolean {
-  try {
-    return (
-      typeof window !== "undefined" &&
-      typeof window.sessionStorage !== "undefined"
-    )
-  } catch {
-    return false
-  }
-}
-
-function hydrate() {
-  if (hydrated) return
-  hydrated = true
-  if (!hasSessionStorage()) return
-  try {
-    const raw = window.sessionStorage.getItem(STORAGE_KEY)
-    if (!raw) return
-    const parsed = JSON.parse(raw) as SerializedState
-    if (Array.isArray(parsed.samples)) {
-      samples = parsed.samples.filter(
-        (n) => typeof n === "number" && Number.isFinite(n) && n >= 0,
-      )
-    }
-  } catch {
-    // Corrupted storage — drop silently, start fresh.
-  }
-}
-
-function persist() {
-  if (!hasSessionStorage()) return
-  try {
-    const payload: SerializedState = { samples }
-    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
-  } catch {
-    // Quota exceeded or access denied — keep the in-memory copy.
-  }
-}
 
 function percentile(sorted: number[], p: number): number | null {
   if (sorted.length === 0) return null
@@ -89,15 +45,12 @@ function invalidateCache() {
 
 export function recordQuery(durationMs: number): void {
   if (!Number.isFinite(durationMs) || durationMs < 0) return
-  hydrate()
   samples.push(durationMs)
   invalidateCache()
-  persist()
   listeners.forEach((listener) => listener())
 }
 
 export function getStats(): DemoSearchStats {
-  hydrate()
   if (cachedStats !== null) return cachedStats
   if (samples.length === 0) {
     cachedStats = {
@@ -127,16 +80,8 @@ export function subscribe(listener: () => void): () => void {
 
 export function __resetForTests(): void {
   samples = []
-  hydrated = false
   listeners.clear()
   invalidateCache()
-  if (hasSessionStorage()) {
-    try {
-      window.sessionStorage.removeItem(STORAGE_KEY)
-    } catch {
-      // ignore
-    }
-  }
 }
 
 export { EMBEDDING_COST_USD_PER_QUERY }


### PR DESCRIPTION
## Summary

The Queries / Embedding-cost panel on `/demo-search` was persisting via `sessionStorage`, so a reload showed accumulated counts from the previous visit (e.g. `26 queries · \$0.000016`). The copy says "this session" meaning "this visit" — stakeholders expect a fresh zero on refresh.

Drop `sessionStorage` entirely. Metrics live in-memory only; reset happens naturally on each page load when the client module re-initializes.

## Changes

- Remove `hydrate`/`persist` + `STORAGE_KEY` + `hasSessionStorage` from `apps/web/src/lib/demo-search-metrics.ts`
- Update test that asserted sessionStorage-less degradation; behaviour is now the default path
- `__resetForTests()` no longer needs to clear storage

## Test plan

- [ ] Visit `/demo-search?q=X`, trigger a few "Load more" queries, refresh page
- [ ] Counters show `0 queries / \$0` after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)