### PR TITLE
feat(web): demo-search Enter-to-regenerate + loading states

### DIFF
--- a/apps/web/src/app/demo-search/page.tsx
+++ b/apps/web/src/app/demo-search/page.tsx
@@ -68,6 +68,7 @@ export default async function DemoSearchPage({ searchParams }: PageProps) {
 
         <div className="mt-8">
           <Suspense
+            key={query}
             fallback={
               <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {Array.from({ length: 8 }, (_, i) => (

--- a/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
+++ b/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
@@ -1,12 +1,22 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react"
+import { useSearchParams } from "next/navigation"
 import type { GenerateExperienceResult } from "@/app/api/demo-search/generate/route"
 import {
-  getGeneratePending,
+  getSearchPending,
   setGeneratePending,
+  setSearchPending,
   subscribeToGenerateRequests,
+  subscribeToSearchPending,
 } from "@/lib/demo-generate-bus"
+import { DEMO_SEARCH_INPUT_ID } from "./DemoSearchInput"
 import type {
   Experience,
   ExperienceGeneratorErrorCode,
@@ -15,6 +25,7 @@ import type { SearchResult } from "@/lib/search"
 import { GeneratedSection } from "./GeneratedSections"
 
 const SCROLL_TARGET_ID = "ai-generated-stats"
+const AUTOGEN_QUERY_PARAM = "ag"
 
 type AiExperienceGeneratorDemoProps = {
   query: string
@@ -59,6 +70,18 @@ export function AiExperienceGeneratorDemo({
   // latest copy in a ref for the bus subscription (which is set up once
   // on mount).
   const runRef = useRef<() => void>(() => {})
+  // Guards the autogen-on-mount effect against React Strict Mode's
+  // double-invocation (dev-only) so we don't fire run() twice.
+  const autogenFiredRef = useRef(false)
+
+  const searchParams = useSearchParams()
+  const shouldAutogen = searchParams.get(AUTOGEN_QUERY_PARAM) === "1"
+
+  const searching = useSyncExternalStore(
+    subscribeToSearchPending,
+    getSearchPending,
+    () => false,
+  )
 
   const resultsBySlug = useMemo(
     () => new Map(results.map((r) => [r.slug, r])),
@@ -66,10 +89,10 @@ export function AiExperienceGeneratorDemo({
   )
 
   async function run() {
-    // Synchronous guard via the shared bus — isPending is closure-captured
-    // and can be stale between two rapid requestGenerate() calls (shortcut
-    // button + Enter key). getGeneratePending() reads the latest value.
-    if (getGeneratePending()) return
+    // Guard on local state — the shared bus's pending flag is also set by
+    // DemoSearchInput at Enter time purely for UI spinner purposes, so we
+    // can't rely on it as a re-entrancy guard here.
+    if (isPending) return
     setGeneratePending(true)
     setIsPending(true)
     const compact = results.slice(0, MAX_RESULTS_FOR_PROMPT).map((r) => ({
@@ -106,6 +129,7 @@ export function AiExperienceGeneratorDemo({
       })
     } finally {
       setIsPending(false)
+      setGeneratePending(false)
     }
   }
   useEffect(() => {
@@ -116,13 +140,33 @@ export function AiExperienceGeneratorDemo({
     return subscribeToGenerateRequests(() => runRef.current())
   }, [])
 
+  // This component only mounts once the Suspense boundary for the new query
+  // has resolved, so our mount is a reliable signal that "search is done".
   useEffect(() => {
-    setGeneratePending(isPending)
-    // Guarantee the shared bus never stays stuck at "Composing…" if this
-    // component unmounts while a transition is in flight (route change,
-    // parent re-key, etc.).
+    setSearchPending(false)
+  }, [])
+
+  // Auto-fire on mount when the URL carries ?ag=1 (set by DemoSearchInput
+  // on Enter). Strip the param with history.replaceState so a page reload
+  // doesn't re-fire — this is a silent URL update, no RSC round-trip.
+  useEffect(() => {
+    if (!shouldAutogen) return
+    if (autogenFiredRef.current) return
+    autogenFiredRef.current = true
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href)
+      url.searchParams.delete(AUTOGEN_QUERY_PARAM)
+      window.history.replaceState(null, "", url.toString())
+    }
+    runRef.current()
+  }, [shouldAutogen])
+
+  // If this component unmounts mid-fetch (route change, parent re-key) the
+  // shared bus would otherwise stay stuck at "Composing…" indefinitely.
+  // Clear it on unmount only if our own run is still pending.
+  useEffect(() => {
     return () => {
-      setGeneratePending(false)
+      if (isPending) setGeneratePending(false)
     }
   }, [isPending])
 
@@ -142,11 +186,31 @@ export function AiExperienceGeneratorDemo({
     return () => window.clearTimeout(timer)
   }, [state])
 
+  const isSuccess = state.status === "success"
   const buttonLabel = isPending
     ? "Composing…"
-    : state.status === "success"
-      ? "Regenerate"
-      : "Generate experience with AI"
+    : searching
+      ? "Waiting for search to finish…"
+      : isSuccess
+        ? "Try another prompt!"
+        : "Generate experience with AI"
+  const buttonDisabled = isPending || searching
+
+  function handleButtonClick() {
+    if (buttonDisabled) return
+    if (isSuccess) {
+      // "Try another prompt!" — scroll the user back to the hero search bar
+      // and focus its input. No generation run.
+      const node = document.getElementById(DEMO_SEARCH_INPUT_ID)
+      node?.scrollIntoView({ behavior: "smooth", block: "start" })
+      const input = node?.querySelector<HTMLInputElement>('input[type="text"]')
+      // Focus after the smooth-scroll animation has started so mobile
+      // keyboards don't jump the viewport.
+      window.setTimeout(() => input?.focus(), 350)
+      return
+    }
+    run()
+  }
 
   return (
     <section
@@ -173,11 +237,11 @@ export function AiExperienceGeneratorDemo({
       <div className="mt-6 mb-4 flex flex-col items-center gap-2">
         <button
           type="button"
-          onClick={run}
-          disabled={isPending}
+          onClick={handleButtonClick}
+          disabled={buttonDisabled}
           className="inline-flex items-center gap-2 rounded-lg bg-amber-500 px-6 py-3 text-sm font-semibold text-stone-950 transition hover:bg-amber-400 disabled:cursor-wait disabled:opacity-70"
         >
-          {isPending && (
+          {buttonDisabled && (
             <svg
               className="h-4 w-4 animate-spin"
               viewBox="0 0 24 24"

--- a/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
+++ b/apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
@@ -10,6 +10,7 @@ import {
 import { useSearchParams } from "next/navigation"
 import type { GenerateExperienceResult } from "@/app/api/demo-search/generate/route"
 import {
+  getGeneratePending,
   getSearchPending,
   setGeneratePending,
   setSearchPending,
@@ -146,14 +147,17 @@ export function AiExperienceGeneratorDemo({
     setSearchPending(false)
   }, [])
 
-  // Auto-fire on mount when the URL carries ?ag=1 (set by DemoSearchInput
-  // on Enter). Strip the param with history.replaceState so a page reload
-  // doesn't re-fire — this is a silent URL update, no RSC round-trip.
+  // Auto-fire on mount when either (a) the URL carries ?ag=1 (Enter-key
+  // flow) or (b) the bus pending flag is raised (Generate button was
+  // clicked during the search fetch — subscriber was unmounted in the
+  // Suspense fallback at the time, so we pick it up here). Strip ?ag=1
+  // via history.replaceState so a page reload doesn't re-fire.
   useEffect(() => {
-    if (!shouldAutogen) return
     if (autogenFiredRef.current) return
+    const hasQueuedTrigger = getGeneratePending()
+    if (!shouldAutogen && !hasQueuedTrigger) return
     autogenFiredRef.current = true
-    if (typeof window !== "undefined") {
+    if (shouldAutogen && typeof window !== "undefined") {
       const url = new URL(window.location.href)
       url.searchParams.delete(AUTOGEN_QUERY_PARAM)
       window.history.replaceState(null, "", url.toString())

--- a/apps/web/src/components/demo-search/DemoSearchInput.tsx
+++ b/apps/web/src/components/demo-search/DemoSearchInput.tsx
@@ -2,8 +2,17 @@
 
 import { useState } from "react"
 import { SearchInput } from "@/components/search/SearchInput"
-import { requestGenerate } from "@/lib/demo-generate-bus"
+import { setGeneratePending, setSearchPending } from "@/lib/demo-generate-bus"
 import { GenerateShortcutButton } from "./GenerateShortcutButton"
+
+// URL flag appended on Enter submit. AiExperienceGeneratorDemo reads it on
+// mount and auto-runs (then strips it), so Enter always regenerates even
+// after the navigation re-keys the component.
+const AUTOGEN_QUERY_PARAM = "ag"
+
+// DOM id on the hero bar container — scroll target for the "Try another
+// prompt!" button after a successful generation.
+export const DEMO_SEARCH_INPUT_ID = "demo-search-input"
 
 const MAX_QUERY_LENGTH = 200
 
@@ -17,7 +26,7 @@ export function DemoSearchInput({ defaultValue = "" }: DemoSearchInputProps) {
   const [length, setLength] = useState(defaultValue.length)
 
   return (
-    <div>
+    <div id={DEMO_SEARCH_INPUT_ID} className="scroll-mt-24">
       <div
         className="flex flex-col gap-3 rounded-3xl border border-stone-800 bg-stone-900/50 p-3 shadow-2xl shadow-black/40 md:flex-row md:items-center"
         onInput={(event) => {
@@ -30,7 +39,15 @@ export function DemoSearchInput({ defaultValue = "" }: DemoSearchInputProps) {
             defaultValue={defaultValue}
             searchPath="/demo-search"
             maxLength={MAX_QUERY_LENGTH}
-            onSubmit={requestGenerate}
+            // Flip both spinners on the instant Enter is pressed. The
+            // search spinner is cleared once the new
+            // AiExperienceGeneratorDemo mounts (Suspense resolved); the
+            // generate spinner is cleared when its autogen run finishes.
+            onSubmit={() => {
+              setSearchPending(true)
+              setGeneratePending(true)
+            }}
+            extraQueryOnSubmit={`${AUTOGEN_QUERY_PARAM}=1`}
             size="lg"
           />
         </div>

--- a/apps/web/src/components/demo-search/DemoSearchInput.tsx
+++ b/apps/web/src/components/demo-search/DemoSearchInput.tsx
@@ -39,14 +39,15 @@ export function DemoSearchInput({ defaultValue = "" }: DemoSearchInputProps) {
             defaultValue={defaultValue}
             searchPath="/demo-search"
             maxLength={MAX_QUERY_LENGTH}
-            // Flip both spinners on the instant Enter is pressed. The
-            // search spinner is cleared once the new
-            // AiExperienceGeneratorDemo mounts (Suspense resolved); the
-            // generate spinner is cleared when its autogen run finishes.
-            onSubmit={() => {
-              setSearchPending(true)
-              setGeneratePending(true)
-            }}
+            // onBeforeNavigate fires for BOTH debounced typing and Enter,
+            // so the shortcut-button "Waiting for search to finish…" label
+            // is correct whether the user typed or submitted. Cleared when
+            // AiExperienceGeneratorDemo mounts (Suspense resolved).
+            onBeforeNavigate={() => setSearchPending(true)}
+            // onSubmit only fires on Enter — we raise generate-pending
+            // then so the Enter-key flow always auto-regenerates after
+            // the search resolves.
+            onSubmit={() => setGeneratePending(true)}
             extraQueryOnSubmit={`${AUTOGEN_QUERY_PARAM}=1`}
             size="lg"
           />

--- a/apps/web/src/components/demo-search/GenerateShortcutButton.tsx
+++ b/apps/web/src/components/demo-search/GenerateShortcutButton.tsx
@@ -3,8 +3,10 @@
 import { useSyncExternalStore } from "react"
 import {
   getGeneratePending,
+  getSearchPending,
   requestGenerate,
   subscribeToGeneratePending,
+  subscribeToSearchPending,
 } from "@/lib/demo-generate-bus"
 
 // Rendered inline next to the big search input as the page's hero CTA.
@@ -19,15 +21,26 @@ export function GenerateShortcutButton() {
     getGeneratePending,
     () => false,
   )
+  const searching = useSyncExternalStore(
+    subscribeToSearchPending,
+    getSearchPending,
+    () => false,
+  )
+  const disabled = pending || searching
+  const label = searching
+    ? "Waiting for search to finish…"
+    : pending
+      ? "Composing…"
+      : "Generate"
 
   return (
     <button
       type="button"
       onClick={requestGenerate}
-      disabled={pending}
+      disabled={disabled}
       className="inline-flex items-center justify-center gap-2 rounded-2xl bg-amber-500 px-6 py-4 text-base font-semibold text-stone-950 shadow-lg shadow-amber-500/20 transition hover:bg-amber-400 hover:shadow-amber-500/40 disabled:cursor-wait disabled:opacity-70"
     >
-      {pending ? (
+      {disabled ? (
         <svg
           className="h-5 w-5 animate-spin"
           viewBox="0 0 24 24"
@@ -62,7 +75,7 @@ export function GenerateShortcutButton() {
           <path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z" />
         </svg>
       )}
-      {pending ? "Composing…" : "Generate"}
+      {label}
     </button>
   )
 }

--- a/apps/web/src/components/demo-search/GenerateShortcutButton.tsx
+++ b/apps/web/src/components/demo-search/GenerateShortcutButton.tsx
@@ -5,6 +5,7 @@ import {
   getGeneratePending,
   getSearchPending,
   requestGenerate,
+  setGeneratePending,
   subscribeToGeneratePending,
   subscribeToSearchPending,
 } from "@/lib/demo-generate-bus"
@@ -26,17 +27,30 @@ export function GenerateShortcutButton() {
     getSearchPending,
     () => false,
   )
-  const disabled = pending || searching
-  const label = searching
-    ? "Waiting for search to finish…"
-    : pending
-      ? "Composing…"
-      : "Generate"
+  // Clickable as long as no generate is already in flight/queued. During
+  // search the click just raises the pending flag; when the new
+  // AiExperienceGeneratorDemo mounts (Suspense resolved) it auto-fires.
+  const disabled = pending
+  const label = pending
+    ? searching
+      ? "Waiting for search to finish…"
+      : "Composing…"
+    : "Generate"
+
+  function handleClick() {
+    if (searching) {
+      // Subscriber is currently unmounted inside the Suspense fallback —
+      // just queue by raising the pending flag. New mount will pick it up.
+      setGeneratePending(true)
+      return
+    }
+    requestGenerate()
+  }
 
   return (
     <button
       type="button"
-      onClick={requestGenerate}
+      onClick={handleClick}
       disabled={disabled}
       className="inline-flex items-center justify-center gap-2 rounded-2xl bg-amber-500 px-6 py-4 text-base font-semibold text-stone-950 shadow-lg shadow-amber-500/20 transition hover:bg-amber-400 hover:shadow-amber-500/40 disabled:cursor-wait disabled:opacity-70"
     >

--- a/apps/web/src/components/search/SearchInput.tsx
+++ b/apps/web/src/components/search/SearchInput.tsx
@@ -13,6 +13,10 @@ type SearchInputProps = {
   // URL. Useful when the submitting page wants to signal a one-shot action
   // (like "auto-generate on the next mount") via the URL itself.
   extraQueryOnSubmit?: string
+  // Fired synchronously right before every navigation this input triggers
+  // (both debounced typing and Enter). Use to flip a parent-scoped
+  // "searching" UI flag before the RSC fetch starts.
+  onBeforeNavigate?: () => void
   size?: "default" | "lg"
 }
 
@@ -22,6 +26,7 @@ export function SearchInput({
   maxLength,
   onSubmit,
   extraQueryOnSubmit,
+  onBeforeNavigate,
   size = "default",
 }: SearchInputProps) {
   const router = useRouter()
@@ -39,6 +44,7 @@ export function SearchInput({
         clearTimeout(timerRef.current)
       }
       timerRef.current = setTimeout(() => {
+        onBeforeNavigate?.()
         if (query.trim()) {
           router.replace(
             `${searchPath}?q=${encodeURIComponent(query.trim())}` as Route,
@@ -48,7 +54,7 @@ export function SearchInput({
         }
       }, 300)
     },
-    [router, searchPath],
+    [router, searchPath, onBeforeNavigate],
   )
 
   useEffect(() => {
@@ -77,6 +83,7 @@ export function SearchInput({
       }
       const trimmed = value.trim()
       const suffix = extraQueryOnSubmit ? `&${extraQueryOnSubmit}` : ""
+      onBeforeNavigate?.()
       if (trimmed) {
         router.replace(
           `${searchPath}?q=${encodeURIComponent(trimmed)}${suffix}` as Route,

--- a/apps/web/src/components/search/SearchInput.tsx
+++ b/apps/web/src/components/search/SearchInput.tsx
@@ -9,6 +9,10 @@ type SearchInputProps = {
   searchPath?: string
   maxLength?: number
   onSubmit?: () => void
+  // Additional query-string (e.g. "ag=1") appended to the Enter-key navigation
+  // URL. Useful when the submitting page wants to signal a one-shot action
+  // (like "auto-generate on the next mount") via the URL itself.
+  extraQueryOnSubmit?: string
   size?: "default" | "lg"
 }
 
@@ -17,6 +21,7 @@ export function SearchInput({
   searchPath = "/search",
   maxLength,
   onSubmit,
+  extraQueryOnSubmit,
   size = "default",
 }: SearchInputProps) {
   const router = useRouter()
@@ -71,12 +76,17 @@ export function SearchInput({
         timerRef.current = null
       }
       const trimmed = value.trim()
+      const suffix = extraQueryOnSubmit ? `&${extraQueryOnSubmit}` : ""
       if (trimmed) {
         router.replace(
-          `${searchPath}?q=${encodeURIComponent(trimmed)}` as Route,
+          `${searchPath}?q=${encodeURIComponent(trimmed)}${suffix}` as Route,
         )
       } else {
-        router.replace(searchPath as Route)
+        router.replace(
+          (suffix
+            ? `${searchPath}?${extraQueryOnSubmit}`
+            : searchPath) as Route,
+        )
       }
       onSubmit()
     }

--- a/apps/web/src/lib/demo-generate-bus.ts
+++ b/apps/web/src/lib/demo-generate-bus.ts
@@ -11,7 +11,9 @@
 
 const triggerListeners = new Set<() => void>()
 const pendingListeners = new Set<() => void>()
+const searchPendingListeners = new Set<() => void>()
 let pending = false
+let searchPending = false
 
 export function requestGenerate(): void {
   triggerListeners.forEach((listener) => listener())
@@ -38,5 +40,27 @@ export function subscribeToGeneratePending(listener: () => void): () => void {
   pendingListeners.add(listener)
   return () => {
     pendingListeners.delete(listener)
+  }
+}
+
+// "Search pending" = the RSC navigation for a new query is in flight. Set
+// true when the user submits the hero-bar query and cleared once the new
+// AiExperienceGeneratorDemo has mounted (i.e. the Suspense boundary has
+// resolved with the new query's data). Drives the "Waiting for search to
+// finish" button state.
+export function setSearchPending(next: boolean): void {
+  if (searchPending === next) return
+  searchPending = next
+  searchPendingListeners.forEach((listener) => listener())
+}
+
+export function getSearchPending(): boolean {
+  return searchPending
+}
+
+export function subscribeToSearchPending(listener: () => void): () => void {
+  searchPendingListeners.add(listener)
+  return () => {
+    searchPendingListeners.delete(listener)
   }
 }

--- a/docs/solutions/best-practices/nextjs-cross-suspense-action-queue-with-url-params-20260421.md
+++ b/docs/solutions/best-practices/nextjs-cross-suspense-action-queue-with-url-params-20260421.md
@@ -1,0 +1,183 @@
+---
+title: "Queueing a user action across a Suspense boundary re-key in Next.js App Router"
+date: "2026-04-21"
+category: best-practices
+module: apps/web
+problem_type: ui_bug
+component: web
+severity: medium
+root_cause: framework_misuse
+resolution_type: code_fix
+related_components:
+  - apps/web/src/app/demo-search/page.tsx
+  - apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx
+  - apps/web/src/components/demo-search/DemoSearchInput.tsx
+  - apps/web/src/components/demo-search/GenerateShortcutButton.tsx
+  - apps/web/src/components/search/SearchInput.tsx
+  - apps/web/src/lib/demo-generate-bus.ts
+github_prs:
+  - "#815"
+  - "#816"
+  - "#817"
+related_docs:
+  - "docs/solutions/ui-bugs/react-duplicate-sibling-keys-append-on-rerender-20260421.md"
+  - "docs/solutions/best-practices/nextjs-server-action-llm-structured-output-pattern-2026-04-21.md"
+tags:
+  - react
+  - nextjs
+  - app-router
+  - suspense
+  - react-strict-mode
+  - client-state
+  - url-params
+  - usesync-external-store
+  - demo-search
+---
+
+# Queueing a user action across a Suspense boundary re-key in Next.js App Router
+
+## Problem
+
+`/demo-search` has a hero-bar search input and two "Generate" buttons (a shortcut next to the input, plus one inside a downstream `AiExperienceGeneratorDemo` component). The AI component sits inside a Suspense boundary keyed by the current query — `<Suspense key={query} fallback={skeleton}>` — so every query change unmounts it and re-renders the skeleton while the new RSC streams in.
+
+Two UX asks that look trivial but fight the framework:
+
+1. **"Enter + Generate should auto-regenerate."** User types a new query, presses Enter. URL updates, search refetches, skeleton shows, new cards arrive, _and_ the AI preview should generate against the new results — without a second click.
+2. **"Click during loading should queue."** User clicks Generate while the Suspense fallback is showing. The AI component is unmounted at that instant. Button should immediately show "Waiting for search to finish…", and once the component mounts, the generation should fire automatically.
+
+Both require a signal to cross a Suspense boundary re-key, which tears down the subscriber before the new one exists.
+
+## Symptoms
+
+- Enter + type a query: results update, AI preview stays on the old result. User has to click Generate again.
+- Click Generate mid-fallback: button does nothing. No network activity. No "loading" feedback.
+- After a fix attempt via a module-level bus with `queueMicrotask` + TTL: intermittent, reliable-looking in prod but silent in dev under React Strict Mode (the double-invocation of `useEffect` consumed the queued trigger on the first invocation, leaving the second real listener empty).
+
+## What Didn't Work
+
+1. **Firing existing bus subscribers at the moment of Enter.** The old component is still mounted when `router.replace` kicks off, so it catches the fire, starts a fetch closure-captured to the **old** query, and then gets unmounted mid-flight. The request is orphaned; the new component never sees the intent.
+
+2. **Module-level `queuedTriggerAt` + `queueMicrotask` on subscribe.** Mechanically sound but React Strict Mode's dev-only double-invocation of effects means the **first** subscribe consumes the queue and schedules the microtask against a listener that is immediately torn down by strict-mode cleanup; the **second** (real) subscribe sees an empty queue. Works in prod, broken in dev — a trap that shows up only when someone else debugs locally. Reject.
+
+3. **Making the button "disabled" during search.** Blocks the "queue on click" intent entirely. User sees a dead button with no feedback.
+
+4. **Relying on a single `generatePending` flag.** Conflates "generation is queued / UI wants to show a spinner" with "fetch is in flight". Breaks when the queued state needs to survive an unmount (the local `isPending` is gone but the bus still needs to say "Waiting…").
+
+## Solution
+
+Three cooperating mechanisms, layered by durability:
+
+### 1. URL param as the cross-Suspense trigger (Enter-key path)
+
+The Enter-key handler appends `?ag=1` to the navigation URL. On the _next_ mount — regardless of Strict Mode double-invocation, hydration races, or React 19 streaming order — the new `AiExperienceGeneratorDemo` reads `useSearchParams().get("ag")`, auto-fires its generation, and strips the param via `history.replaceState` (silent, no RSC round-trip, so reloading won't re-fire).
+
+```tsx
+// AiExperienceGeneratorDemo.tsx
+const searchParams = useSearchParams()
+const shouldAutogen = searchParams.get(AUTOGEN_QUERY_PARAM) === "1"
+const autogenFiredRef = useRef(false)
+
+useEffect(() => {
+  if (autogenFiredRef.current) return
+  const queued = getGeneratePending()
+  if (!shouldAutogen && !queued) return
+  autogenFiredRef.current = true
+  if (shouldAutogen && typeof window !== "undefined") {
+    const url = new URL(window.location.href)
+    url.searchParams.delete(AUTOGEN_QUERY_PARAM)
+    window.history.replaceState(null, "", url.toString())
+  }
+  runRef.current()
+}, [shouldAutogen])
+```
+
+The `autogenFiredRef` is the Strict-Mode defense: refs survive the double-invocation, so the first effect commit can set `fired=true` and the second is a no-op.
+
+### 2. Module-level "pending" flag for the click-during-loading path
+
+Clicking Generate while the subscriber is unmounted can't use the pub/sub listener path — there's nothing to fire. Instead we have a second, simpler channel: a shared `generatePending` boolean. Clicking while `searchPending` is true just _raises the flag_. The autogen effect above checks both `?ag=1` **and** `getGeneratePending()`, so a click-queue picks the trigger up on the next mount.
+
+```tsx
+// GenerateShortcutButton.tsx
+function handleClick() {
+  if (searching) {
+    setGeneratePending(true) // queue; no-op otherwise
+    return
+  }
+  requestGenerate() // fires live subscriber
+}
+```
+
+Unlike the microtask-queue approach, this has no "when was it queued / has TTL expired" logic — the component either mounts and finds the flag raised, or it doesn't. Deterministic.
+
+### 3. `onBeforeNavigate` hook so typing + Enter behave identically
+
+The original `SearchInput` fired its parent callback (`onSubmit`) only on Enter. Typing triggered a 300 ms-debounced `router.replace` that set **nothing** — so the shortcut button during typed-query loading still read "Generate", clicking it took the wrong branch (saw `searching=false`), and the click silently no-op'd.
+
+Fixed with a new `onBeforeNavigate?: () => void` prop fired synchronously in _both_ the Enter handler and the debounced navigator. `DemoSearchInput` wires it to `setSearchPending(true)` so the button label is correct no matter how navigation was triggered.
+
+```tsx
+// SearchInput.tsx (excerpt)
+timerRef.current = setTimeout(() => {
+  onBeforeNavigate?.()
+  router.replace(...)
+}, 300)
+
+// later, Enter path:
+onBeforeNavigate?.()
+router.replace(...)
+onSubmit?.()
+```
+
+### 4. Two orthogonal pending flags, not one
+
+Split the UI state cleanly:
+
+| Flag              | Semantic                       | Raised by                                                         | Cleared by                                  |
+| ----------------- | ------------------------------ | ----------------------------------------------------------------- | ------------------------------------------- |
+| `searchPending`   | RSC nav in flight              | `onBeforeNavigate` (typing + Enter)                               | `AiExperienceGeneratorDemo` mount useEffect |
+| `generatePending` | Generation queued or in flight | `onSubmit` (Enter), `handleClick` during search, or `run()` start | `run()` finally block                       |
+
+Button labels derive from both:
+
+```
+pending=false, searching=?     → "Generate"                (clickable)
+pending=true,  searching=true  → "Waiting for search to finish…" (disabled)
+pending=true,  searching=false → "Composing…"              (disabled)
+```
+
+## Why This Works
+
+**URL params survive Strict Mode.** React Strict Mode's effect double-invocation is designed to trip up any cleanup that assumes single-run. Module-level state that gets consumed in an effect is a direct hit. URL state is part of the render environment, not the effect lifecycle, so it's read fresh on every mount.
+
+**`history.replaceState` strips without re-render.** `router.replace` would start a fresh RSC navigation, causing a render loop. `history.replaceState` only mutates `window.location` + browser history — no React, no Next router, no RSC fetch. Exactly what "silent URL cleanup" needs.
+
+**Refs are the Strict-Mode escape hatch.** `useRef` survives double-invocation because it's not part of the render value. Any "did we already consume this intent" check belongs in a ref, not in module-level state and not in `useState`.
+
+**Two pending flags separate responsibility.** `searchPending` is owned by the nav layer (`SearchInput` → bus). `generatePending` is owned by the generation layer (button click + autogen effect + run). Combining them into one flag forces one subsystem to know about the other's lifecycle.
+
+**Clickable-while-busy with a queued intent** is the right UX primitive for "I want to do X when the thing blocking X finishes." Disabling the button would force users to wait-watch-click; queueing lets them fire-and-forget. The key is that the queued intent must be _durable across the unmount that ends the blocking state_ — hence the shared flag rather than component-local state.
+
+## Prevention
+
+**When a UI intent must cross a Suspense boundary re-key, don't use pub/sub.** The subscriber count is 0 at exactly the moment you need it to be >0. Options in order of robustness:
+
+1. **URL query param + `useSearchParams` + `history.replaceState`** — best for "one-shot, ship-and-forget" intents like "auto-run on next mount."
+2. **Shared module-level flag + ref-guarded mount effect** — good for stateless queued intents. Guard with `useRef`, not `useState`, so Strict Mode doesn't consume it twice.
+3. **Pub/sub `queueMicrotask`** — **avoid**. Looks clean, breaks silently under Strict Mode.
+
+**Test dev flows in Strict Mode before shipping.** React Strict Mode is on by default in Next.js and is the truth bar. A module-level queue that works in prod builds but fails in `next dev` is a broken queue — the prod behavior just happens to hide the bug.
+
+**Diagnose with headless Chromium against `localhost`.** Every theory in this investigation was wrong until I ran `puppeteer-core` against `localhost:3000`, clicked the button, and observed the mutation sequence. One real DOM assertion is worth ten correct-sounding hypotheses.
+
+**Check button-enabled semantics during async transitions.** If the button exists during the loading state, it should be clickable — either to fire immediately or to queue. A disabled button during loading tells the user "go away," which is almost never what you want.
+
+**`onBeforeNavigate` is a reusable pattern for any search-as-you-type UI.** If the parent needs to flip a "navigating…" flag, firing it on debounced-typing as well as Enter keeps the UI consistent regardless of how the user triggered it.
+
+## Related Documentation
+
+- [React duplicate sibling keys append on re-render](../ui-bugs/react-duplicate-sibling-keys-append-on-rerender-20260421.md) — the prior bug in this same component tree. Lesson: investigate with headless Chromium, not theory.
+- [Next.js Server Action + LLM structured output pattern](nextjs-server-action-llm-structured-output-pattern-2026-04-21.md) — the underlying generation primitive this UI wraps.
+- PR #815 — duplicate-key fix.
+- PR #816 — metrics reset on page refresh.
+- PR #817 — Enter + queue-on-click + two-flag loading states.


### PR DESCRIPTION
## Summary

Polish pass on `/demo-search` from stakeholder-demo feedback.

### Enter now regenerates reliably

Before: pressing Enter on the hero bar updated the search results but the AI preview didn't regenerate — the pub/sub bus couldn't survive the router navigation (the subscriber was torn down before the new one mounted).

After: Enter appends `?ag=1` to the URL; `AiExperienceGeneratorDemo` reads it on mount, auto-runs, and strips it with `history.replaceState` (silent, no RSC round-trip). Deterministic across navigation and React Strict Mode double-invocation.

### Loading states

Both generate buttons now reflect what's happening:

- During search (RSC navigation in flight) → "**Waiting for search to finish…**" + spinner
- During AI gen (POST in flight) → "**Composing…**" + spinner
- Cards show skeleton state on query change (added `key={query}` on the `<Suspense>` boundary so it re-mounts and re-shows the fallback)

### "Try another prompt!" after success

Bottom button after a successful generation now reads "**Try another prompt!**" and smooth-scrolls back to the hero bar + focuses the input on click. The intent is that stakeholders try different queries, not iterate on the same one.

## Changes

- `apps/web/src/components/search/SearchInput.tsx` — new `extraQueryOnSubmit` prop to append to the Enter-navigation URL
- `apps/web/src/components/demo-search/DemoSearchInput.tsx` — passes `extraQueryOnSubmit="ag=1"`; sets `searchPending` + `generatePending` on submit; exports `DEMO_SEARCH_INPUT_ID` (scroll target)
- `apps/web/src/components/demo-search/AiExperienceGeneratorDemo.tsx` — `useSearchParams` + autogen-on-mount effect; clears `searchPending` on mount; new "Try another prompt!" button in success state
- `apps/web/src/components/demo-search/GenerateShortcutButton.tsx` — subscribes to `searchPending`, labels + spinner reflect both states
- `apps/web/src/lib/demo-generate-bus.ts` — `setSearchPending` / `getSearchPending` / `subscribeToSearchPending`
- `apps/web/src/app/demo-search/page.tsx` — `key={query}` on the `<Suspense>` boundary

## Test plan

- [ ] Hard-refresh `/watch/demo-search?q=evidence+of+the+resurrection`
- [ ] Type a new query → press Enter → both buttons flip to "Waiting for search to finish…" → skeleton cards render → real cards → "Composing…" → experience
- [ ] After success, bottom button reads "Try another prompt!" → clicking smooth-scrolls to search bar and focuses input
- [ ] Manual click of the bottom Generate button (no Enter) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)