### PR TITLE
fix(admin): fetch coreId mapping from Railway S3

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -386,15 +386,17 @@ scale.
 
 **Operational runbook:**
 
-1. Dump the coreId → cms video id mapping from cms:
-   `pnpm --filter @forge/cms dump:core-id-mapping > .tmp/core-id-mapping.json`.
-   Re-dump when cms's catalog grows (Strapi SERIAL ids don't change, so
-   existing entries stay valid).
+1. Refresh the coreId → cms video id mapping into the shared Railway S3
+   bucket: `pnpm --filter @forge/admin refresh:core-id-mapping`. The
+   CLI dumps from cms and uploads to
+   `admin-migrations/core-id-mapping.json`. Re-run when cms's catalog
+   grows (Strapi SERIAL ids don't change, so existing entries stay
+   valid).
 2. Ensure `OPENROUTER_API_KEY` or `OPENAI_API_KEY` is set on the
    `forge-admin` Railway service.
-3. Invoke `triggerSceneEmbeddingBackfill` via GraphQL with
-   `mappingPath` pointing at the dump. Restrict with `coreIds` or
-   `locales` for dry runs.
+3. Invoke `triggerSceneEmbeddingBackfill` via GraphQL. `mappingS3Key`
+   defaults to `admin-migrations/core-id-mapping.json`; override for
+   dry runs or ad-hoc snapshots. Restrict with `coreIds` or `locales`.
 4. Verify: `SELECT COUNT(*) FROM video_scene_locale WHERE embedding IS NOT NULL`
    grows as expected; `SELECT DISTINCT video_edition_id FROM video_scene`
    enumerates the indexed editions.

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -15,7 +15,8 @@
     "db:generate": "prisma generate",
     "db:migrate:dev": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "refresh:core-id-mapping": "tsx src/scripts/refresh-core-id-mapping.ts"
   },
   "dependencies": {
     "@better-auth/prisma-adapter": "1.6.2",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -53,6 +53,8 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "3.1030.0",
+    "@smithy/node-http-handler": "4.4.14",
+    "@types/node": "^22",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "eslint": "^9.0.0",

--- a/apps/admin/src/graphql/mutations/scene-embedding.test.ts
+++ b/apps/admin/src/graphql/mutations/scene-embedding.test.ts
@@ -41,14 +41,14 @@ describe("dispatchSceneEmbeddingBackfill", () => {
     dispatch.mockReturnValue(BASE_REPORT)
 
     const report = await dispatchSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       coreIds: ["core-1"],
       locales: ["en"],
     })
 
     dispatch.expectDispatched(runSceneEmbeddingBackfill, [
       {
-        mappingPath: "/tmp/mapping.json",
+        mappingS3Key: "admin-migrations/core-id-mapping.json",
         coreIds: ["core-1"],
         locales: ["en"],
       },
@@ -60,11 +60,11 @@ describe("dispatchSceneEmbeddingBackfill", () => {
     dispatch.mockReturnValue(BASE_REPORT)
 
     await dispatchSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
     })
 
     dispatch.expectDispatched(runSceneEmbeddingBackfill, [
-      { mappingPath: "/tmp/mapping.json" },
+      { mappingS3Key: "admin-migrations/core-id-mapping.json" },
     ])
   })
 
@@ -73,14 +73,18 @@ describe("dispatchSceneEmbeddingBackfill", () => {
     dispatch.mockRejection(boom)
 
     await expect(
-      dispatchSceneEmbeddingBackfill({ mappingPath: "/tmp/missing.json" }),
+      dispatchSceneEmbeddingBackfill({
+        mappingS3Key: "admin-migrations/missing.json",
+      }),
     ).rejects.toBe(boom)
   })
 
   it("invokes start() exactly once per dispatch call", async () => {
     dispatch.mockReturnValue(BASE_REPORT)
 
-    await dispatchSceneEmbeddingBackfill({ mappingPath: "/tmp/mapping.json" })
+    await dispatchSceneEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
 
     expect(dispatch.spy).toHaveBeenCalledTimes(1)
   })

--- a/apps/admin/src/graphql/mutations/scene-embedding.ts
+++ b/apps/admin/src/graphql/mutations/scene-embedding.ts
@@ -15,14 +15,12 @@
 
 import { start } from "workflow/api"
 import { builder } from "@/graphql/builder"
+import { DEFAULT_CORE_ID_MAPPING_S3_KEY } from "@/services/core-id-mapping.service"
 import {
   runSceneEmbeddingBackfill,
   type SceneEmbeddingBackfillInput,
   type SceneEmbeddingBackfillReport,
 } from "@/workflows/sceneEmbeddingBackfill"
-
-export const DEFAULT_CORE_ID_MAPPING_S3_KEY =
-  "admin-migrations/core-id-mapping.json"
 
 /**
  * Dispatch the scene-embedding backfill workflow via the useworkflow

--- a/apps/admin/src/graphql/mutations/scene-embedding.ts
+++ b/apps/admin/src/graphql/mutations/scene-embedding.ts
@@ -21,6 +21,9 @@ import {
   type SceneEmbeddingBackfillReport,
 } from "@/workflows/sceneEmbeddingBackfill"
 
+export const DEFAULT_CORE_ID_MAPPING_S3_KEY =
+  "admin-migrations/core-id-mapping.json"
+
 /**
  * Dispatch the scene-embedding backfill workflow via the useworkflow
  * runtime and await the final report. Exported separately from the
@@ -41,10 +44,11 @@ builder.mutationFields((t) => ({
     description:
       "Enqueue the scene-embedding backfill workflow. Re-indexes apps/manager's scene-analysis artifacts into VideoScene + VideoSceneLocale. ADMIN-only.",
     args: {
-      mappingPath: t.arg.string({
-        required: true,
+      mappingS3Key: t.arg.string({
+        required: false,
+        defaultValue: DEFAULT_CORE_ID_MAPPING_S3_KEY,
         description:
-          "Absolute path to the coreId → cms video id mapping JSON (dumped via `pnpm --filter @forge/cms dump:core-id-mapping`).",
+          "S3 key of the coreId → cms video id mapping snapshot (uploaded via `pnpm --filter @forge/admin refresh:core-id-mapping`). Defaults to admin-migrations/core-id-mapping.json.",
       }),
       coreIds: t.arg.stringList({
         required: false,
@@ -59,7 +63,7 @@ builder.mutationFields((t) => ({
       // JSON scalar accepts any serializable shape; the return type
       // stays fully typed internally via SceneEmbeddingBackfillReport.
       return dispatchSceneEmbeddingBackfill({
-        mappingPath: args.mappingPath,
+        mappingS3Key: args.mappingS3Key ?? DEFAULT_CORE_ID_MAPPING_S3_KEY,
         coreIds: args.coreIds ?? undefined,
         locales: args.locales ?? undefined,
       })

--- a/apps/admin/src/graphql/schema.test.ts
+++ b/apps/admin/src/graphql/schema.test.ts
@@ -69,6 +69,17 @@ describe("GraphQL schema — Unit 4 content types", () => {
     const fields = mutation!.getFields()
     expect(fields.triggerSceneEmbeddingBackfill).toBeDefined()
   })
+
+  it("triggerSceneEmbeddingBackfill.mappingS3Key is optional with the canonical default", () => {
+    const mutation = schema.getMutationType()!
+    const field = mutation.getFields().triggerSceneEmbeddingBackfill!
+    const arg = field.args.find((a) => a.name === "mappingS3Key")
+    expect(arg).toBeDefined()
+    // Nullable (String, not String!) so clients may omit or pass null;
+    // defaultValue holds the canonical admin-migrations/ snapshot.
+    expect(String(arg!.type)).toBe("String")
+    expect(arg!.defaultValue).toBe("admin-migrations/core-id-mapping.json")
+  })
 })
 
 describe("VideoScene and VideoSceneLocale types", () => {

--- a/apps/admin/src/scripts/refresh-core-id-mapping.test.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.test.ts
@@ -20,7 +20,8 @@ const { spawn: realSpawn } =
     "node:child_process",
   )
 
-const { runDumpCommand } = await import("./refresh-core-id-mapping")
+const { runDumpCommand, parseTimeoutMs } =
+  await import("./refresh-core-id-mapping")
 
 function spawnQuickChild(code: string): ChildProcess {
   return realSpawn(process.execPath, ["-e", code], { stdio: "ignore" })
@@ -57,5 +58,44 @@ describe("runDumpCommand", () => {
     await expect(runDumpCommand("/tmp/ignored")).rejects.toThrow(
       /cms dump exited with signal SIGKILL/,
     )
+  })
+})
+
+describe("parseTimeoutMs", () => {
+  it("returns the default when the env var is undefined", () => {
+    expect(parseTimeoutMs(undefined)).toBe(10 * 60 * 1000)
+  })
+
+  it("accepts a valid numeric string", () => {
+    expect(parseTimeoutMs("30000")).toBe(30_000)
+  })
+
+  it("falls back to default + warns on non-numeric input (e.g. '10m')", () => {
+    // Prior implementation used Number('10m') === NaN, which setTimeout
+    // coerces to ~1ms, causing the child to SIGTERM almost instantly with
+    // a confusing 'exceeded NaNms' message. Regression guard.
+    const warn = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true)
+    try {
+      expect(parseTimeoutMs("10m")).toBe(10 * 60 * 1000)
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("ignoring non-numeric DUMP_TIMEOUT_MS"),
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it("falls back on zero or negative overrides", () => {
+    const warn = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true)
+    try {
+      expect(parseTimeoutMs("0")).toBe(10 * 60 * 1000)
+      expect(parseTimeoutMs("-100")).toBe(10 * 60 * 1000)
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/apps/admin/src/scripts/refresh-core-id-mapping.test.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the refresh CLI child-process orchestration.
+ *
+ * Exercises runDumpCommand against a tiny in-process node subprocess rather
+ * than mocking the full spawn protocol, so the exit/error event wiring and
+ * signal cleanup are covered end-to-end.
+ */
+
+import type { ChildProcess } from "node:child_process"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const { spawn } = vi.hoisted(() => ({ spawn: vi.fn() }))
+
+vi.mock("node:child_process", () => ({ spawn }))
+
+// Reach past the vi.mock hoist for an unmocked spawn so tests can drive
+// real (but trivial) subprocesses.
+const { spawn: realSpawn } =
+  await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  )
+
+const { runDumpCommand } = await import("./refresh-core-id-mapping")
+
+function spawnQuickChild(code: string): ChildProcess {
+  return realSpawn(process.execPath, ["-e", code], { stdio: "ignore" })
+}
+
+describe("runDumpCommand", () => {
+  beforeEach(() => {
+    spawn.mockReset()
+  })
+
+  it("resolves when the child exits with code 0", async () => {
+    spawn.mockImplementationOnce(() => spawnQuickChild("process.exit(0)"))
+
+    await expect(runDumpCommand("/tmp/ignored")).resolves.toBeUndefined()
+  })
+
+  it("rejects with a clear message when the child exits non-zero", async () => {
+    spawn.mockImplementationOnce(() => spawnQuickChild("process.exit(3)"))
+
+    await expect(runDumpCommand("/tmp/ignored")).rejects.toThrow(
+      /cms dump exited with code 3/,
+    )
+  })
+
+  it("rejects with the signal name when the child is killed by a signal", async () => {
+    spawn.mockImplementationOnce(() => {
+      const child = spawnQuickChild("setTimeout(() => {}, 60000)")
+      // Schedule kill after spawn returns so runDumpCommand's listeners
+      // are attached first.
+      setImmediate(() => child.kill("SIGKILL"))
+      return child
+    })
+
+    await expect(runDumpCommand("/tmp/ignored")).rejects.toThrow(
+      /cms dump exited with signal SIGKILL/,
+    )
+  })
+})

--- a/apps/admin/src/scripts/refresh-core-id-mapping.timeout.test.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.timeout.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Timeout-path test for runDumpCommand.
+ *
+ * Runs in a separate file so DUMP_TIMEOUT_MS can be overridden at import
+ * time (the CLI reads process.env.DUMP_TIMEOUT_MS once when the module is
+ * evaluated; vitest's per-file module-graph isolation gives us a clean
+ * slate here).
+ */
+
+import type { ChildProcess } from "node:child_process"
+import { describe, expect, it, vi } from "vitest"
+
+// Force a short timeout BEFORE the dynamic import so the module evaluates
+// its DUMP_TIMEOUT_MS closure with this value.
+process.env.DUMP_TIMEOUT_MS = "50"
+
+const { spawn } = vi.hoisted(() => ({ spawn: vi.fn() }))
+vi.mock("node:child_process", () => ({ spawn }))
+
+const { spawn: realSpawn } =
+  await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  )
+
+const { runDumpCommand } = await import("./refresh-core-id-mapping")
+
+describe("runDumpCommand — timeout path", () => {
+  it("rejects with a SIGTERM-exceeded message when the child ignores SIGTERM past DUMP_TIMEOUT_MS", async () => {
+    spawn.mockImplementationOnce(
+      (): ChildProcess =>
+        // Long-running child with a SIGTERM handler that does nothing so
+        // the timeout path has to fire. The child will eventually be
+        // SIGKILLed after the 5s escalation, but the outer promise rejects
+        // on SIGTERM-dispatch so the test doesn't wait that long.
+        realSpawn(
+          process.execPath,
+          [
+            "-e",
+            "process.on('SIGTERM', () => {}); setTimeout(() => {}, 60000)",
+          ],
+          { stdio: "ignore" },
+        ),
+    )
+
+    await expect(runDumpCommand("/tmp/ignored")).rejects.toThrow(
+      /cms dump exceeded 50ms; sent SIGTERM/,
+    )
+  })
+})

--- a/apps/admin/src/scripts/refresh-core-id-mapping.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.ts
@@ -29,23 +29,73 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 
-const DEFAULT_S3_KEY = "admin-migrations/core-id-mapping.json"
+import { DEFAULT_CORE_ID_MAPPING_S3_KEY } from "@/services/core-id-mapping.service"
 
-async function runDumpCommand(outPath: string): Promise<void> {
+const DEFAULT_S3_KEY = DEFAULT_CORE_ID_MAPPING_S3_KEY
+
+// Ceiling for the cms dump child. A healthy dump of the whole catalog takes
+// seconds; anything over 10 minutes is almost certainly a wedge (DB hang,
+// stale pnpm store lock) that an operator would rather see as a clear
+// timeout than an indefinite stall. Override with DUMP_TIMEOUT_MS for
+// exceptional cases.
+const DUMP_TIMEOUT_MS = Number(process.env.DUMP_TIMEOUT_MS ?? 10 * 60 * 1000)
+
+export async function runDumpCommand(outPath: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn(
       "pnpm",
       ["--filter", "@forge/cms", "dump:core-id-mapping", "--out", outPath],
       { stdio: "inherit" },
     )
-    child.on("error", reject)
-    child.on("exit", (code) => {
-      if (code === 0) return resolve()
-      reject(
-        new Error(
-          `cms dump exited with code ${code ?? "null"} (signal-based exit)`,
-        ),
-      )
+
+    let settled = false
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      fn()
+    }
+
+    const timeout = setTimeout(() => {
+      settle(() => {
+        child.kill("SIGTERM")
+        setTimeout(() => child.kill("SIGKILL"), 5_000).unref()
+        reject(
+          new Error(`cms dump exceeded ${DUMP_TIMEOUT_MS}ms; sent SIGTERM`),
+        )
+      })
+    }, DUMP_TIMEOUT_MS)
+    timeout.unref()
+
+    const forwardSignal = (signal: NodeJS.Signals) => {
+      // Operator hit Ctrl-C — propagate so the child exits cleanly and
+      // doesn't leak a DB connection to cms.
+      if (!child.killed) child.kill(signal)
+    }
+    process.once("SIGINT", forwardSignal)
+    process.once("SIGTERM", forwardSignal)
+
+    const cleanup = () => {
+      clearTimeout(timeout)
+      process.off("SIGINT", forwardSignal)
+      process.off("SIGTERM", forwardSignal)
+    }
+
+    child.on("error", (err: Error) => {
+      settle(() => {
+        cleanup()
+        reject(err)
+      })
+    })
+    child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+      settle(() => {
+        cleanup()
+        if (code === 0) return resolve()
+        reject(
+          new Error(
+            `cms dump exited with ${signal ? `signal ${signal}` : `code ${code ?? "null"}`}`,
+          ),
+        )
+      })
     })
   })
 }
@@ -98,7 +148,7 @@ async function uploadToS3(bytes: Buffer): Promise<void> {
   )
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const tmp = await mkdtemp(join(tmpdir(), "refresh-core-id-mapping-"))
   const outPath = join(tmp, "core-id-mapping.json")
 
@@ -115,13 +165,29 @@ async function main(): Promise<void> {
       `[refresh:core-id-mapping] uploaded ${bytes.byteLength} bytes to s3 key ${DEFAULT_S3_KEY}\n`,
     )
   } finally {
-    await rm(tmp, { recursive: true, force: true }).catch(() => {})
+    await rm(tmp, { recursive: true, force: true }).catch((err) => {
+      // rm with force:true already swallows ENOENT; anything reaching here
+      // is an unexpected condition (EACCES, EBUSY). Surface it so the
+      // operator sees the leaked tmp dir — cleanup failure shouldn't mask
+      // upload success but should at least be observable.
+      process.stderr.write(
+        `[refresh:core-id-mapping] warning: failed to clean tmp dir ${tmp}: ${err instanceof Error ? err.message : String(err)}\n`,
+      )
+    })
   }
 }
 
-main().catch((err) => {
-  process.stderr.write(
-    `[refresh:core-id-mapping] failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
-  )
-  process.exit(1)
-})
+// Only run main() when this module is invoked directly (via tsx). Skip the
+// side-effect when imported by tests so the test can exercise runDumpCommand
+// without triggering the full CLI orchestration.
+if (
+  typeof process.argv[1] === "string" &&
+  import.meta.url === `file://${process.argv[1]}`
+) {
+  main().catch((err) => {
+    process.stderr.write(
+      `[refresh:core-id-mapping] failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    )
+    process.exit(1)
+  })
+}

--- a/apps/admin/src/scripts/refresh-core-id-mapping.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.ts
@@ -31,14 +31,27 @@ import { dirname, join } from "node:path"
 
 import { DEFAULT_CORE_ID_MAPPING_S3_KEY } from "@/services/core-id-mapping.service"
 
-const DEFAULT_S3_KEY = DEFAULT_CORE_ID_MAPPING_S3_KEY
-
 // Ceiling for the cms dump child. A healthy dump of the whole catalog takes
 // seconds; anything over 10 minutes is almost certainly a wedge (DB hang,
 // stale pnpm store lock) that an operator would rather see as a clear
-// timeout than an indefinite stall. Override with DUMP_TIMEOUT_MS for
-// exceptional cases.
-const DUMP_TIMEOUT_MS = Number(process.env.DUMP_TIMEOUT_MS ?? 10 * 60 * 1000)
+// timeout than an indefinite stall. Override with DUMP_TIMEOUT_MS=<ms> for
+// exceptional cases; a non-numeric override (e.g. the intuitive `10m`)
+// falls back to the default and warns, so setTimeout doesn't collapse to
+// ~1ms on `Number("10m") === NaN`.
+export function parseTimeoutMs(raw: string | undefined): number {
+  const fallback = 10 * 60 * 1000
+  if (raw === undefined) return fallback
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    process.stderr.write(
+      `[refresh:core-id-mapping] ignoring non-numeric DUMP_TIMEOUT_MS=${JSON.stringify(raw)}; falling back to ${fallback}ms\n`,
+    )
+    return fallback
+  }
+  return parsed
+}
+
+const DUMP_TIMEOUT_MS = parseTimeoutMs(process.env.DUMP_TIMEOUT_MS)
 
 export async function runDumpCommand(outPath: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
@@ -55,10 +68,17 @@ export async function runDumpCommand(outPath: string): Promise<void> {
       fn()
     }
 
+    // SIGKILL escalation timer is captured so cleanup() can cancel it when
+    // the child exits cleanly in response to SIGTERM — otherwise the killer
+    // fires at a dead pid (no-op but leaks a closure for 5s).
+    let killTimer: NodeJS.Timeout | undefined
+
     const timeout = setTimeout(() => {
       settle(() => {
         child.kill("SIGTERM")
-        setTimeout(() => child.kill("SIGKILL"), 5_000).unref()
+        killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000)
+        killTimer.unref()
+        cleanup()
         reject(
           new Error(`cms dump exceeded ${DUMP_TIMEOUT_MS}ms; sent SIGTERM`),
         )
@@ -68,7 +88,10 @@ export async function runDumpCommand(outPath: string): Promise<void> {
 
     const forwardSignal = (signal: NodeJS.Signals) => {
       // Operator hit Ctrl-C — propagate so the child exits cleanly and
-      // doesn't leak a DB connection to cms.
+      // doesn't leak a DB connection to cms. With stdio:"inherit" the
+      // terminal already delivers SIGINT to the whole foreground group, so
+      // this is primarily for programmatic SIGTERM (Railway/orchestrator)
+      // and for test environments where the child isn't terminal-bound.
       if (!child.killed) child.kill(signal)
     }
     process.once("SIGINT", forwardSignal)
@@ -76,17 +99,18 @@ export async function runDumpCommand(outPath: string): Promise<void> {
 
     const cleanup = () => {
       clearTimeout(timeout)
+      if (killTimer !== undefined) clearTimeout(killTimer)
       process.off("SIGINT", forwardSignal)
       process.off("SIGTERM", forwardSignal)
     }
 
-    child.on("error", (err: Error) => {
+    child.on("error", (err) => {
       settle(() => {
         cleanup()
         reject(err)
       })
     })
-    child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+    child.on("exit", (code, signal) => {
       settle(() => {
         cleanup()
         if (code === 0) return resolve()
@@ -112,7 +136,12 @@ async function uploadToS3(bytes: Buffer): Promise<void> {
   if (!RAILWAY_S3_BUCKET) {
     // Local fallback — mirrors storage/s3.ts's LOCAL_OBJECT_DIR layout so
     // dev runs can exercise the rest of the pipeline without real S3.
-    const localPath = join(process.cwd(), ".tmp", "objects", DEFAULT_S3_KEY)
+    const localPath = join(
+      process.cwd(),
+      ".tmp",
+      "objects",
+      DEFAULT_CORE_ID_MAPPING_S3_KEY,
+    )
     await mkdir(dirname(localPath), { recursive: true })
     await writeFile(localPath, bytes)
     process.stdout.write(
@@ -127,7 +156,11 @@ async function uploadToS3(bytes: Buffer): Promise<void> {
     )
   }
 
-  const { S3Client, PutObjectCommand } = await import("@aws-sdk/client-s3")
+  const [{ S3Client, PutObjectCommand }, { NodeHttpHandler }] =
+    await Promise.all([
+      import("@aws-sdk/client-s3"),
+      import("@smithy/node-http-handler"),
+    ])
   const s3 = new S3Client({
     endpoint: RAILWAY_S3_ENDPOINT,
     region: RAILWAY_S3_REGION ?? "auto",
@@ -136,12 +169,18 @@ async function uploadToS3(bytes: Buffer): Promise<void> {
       secretAccessKey: RAILWAY_S3_SECRET_ACCESS_KEY,
     },
     forcePathStyle: true,
+    // Match the timeouts on storage/s3.ts's shared client so a stalled
+    // Railway endpoint can't hang the operator CLI indefinitely.
+    requestHandler: new NodeHttpHandler({
+      connectionTimeout: 5_000,
+      requestTimeout: 30_000,
+    }),
   })
 
   await s3.send(
     new PutObjectCommand({
       Bucket: RAILWAY_S3_BUCKET,
-      Key: DEFAULT_S3_KEY,
+      Key: DEFAULT_CORE_ID_MAPPING_S3_KEY,
       Body: bytes,
       ContentType: "application/json",
     }),
@@ -162,7 +201,7 @@ export async function main(): Promise<void> {
     await uploadToS3(bytes)
 
     process.stdout.write(
-      `[refresh:core-id-mapping] uploaded ${bytes.byteLength} bytes to s3 key ${DEFAULT_S3_KEY}\n`,
+      `[refresh:core-id-mapping] uploaded ${bytes.byteLength} bytes to s3 key ${DEFAULT_CORE_ID_MAPPING_S3_KEY}\n`,
     )
   } finally {
     await rm(tmp, { recursive: true, force: true }).catch((err) => {

--- a/apps/admin/src/scripts/refresh-core-id-mapping.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.ts
@@ -1,0 +1,127 @@
+/**
+ * Refresh the admin coreId → cms video id mapping snapshot.
+ *
+ * Dumps from cms via `pnpm --filter @forge/cms dump:core-id-mapping` and
+ * uploads the resulting JSON to the shared Railway S3 bucket at
+ * `admin-migrations/core-id-mapping.json`. That key is the default
+ * consumed by `triggerSceneEmbeddingBackfill` (and future admin-migration
+ * mutations).
+ *
+ * Usage:
+ *   pnpm --filter @forge/admin refresh:core-id-mapping
+ *
+ * Env:
+ *   RAILWAY_S3_BUCKET, RAILWAY_S3_ENDPOINT, RAILWAY_S3_REGION,
+ *   RAILWAY_S3_ACCESS_KEY_ID, RAILWAY_S3_SECRET_ACCESS_KEY must point
+ *   at the shared bucket. Local fallback (no bucket) writes to
+ *   `apps/admin/.tmp/objects/admin-migrations/core-id-mapping.json`.
+ *
+ * The cms dump inherits apps/cms/.env for its DATABASE_URL — point
+ * that at prod cms when refreshing the prod snapshot.
+ *
+ * Reads env directly from process.env rather than @/config/env so the
+ * CLI can run without admin's full env matrix populated (e.g. DATABASE_URL
+ * is not required to upload a mapping file).
+ */
+
+import { spawn } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+const DEFAULT_S3_KEY = "admin-migrations/core-id-mapping.json"
+
+async function runDumpCommand(outPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      "pnpm",
+      ["--filter", "@forge/cms", "dump:core-id-mapping", "--out", outPath],
+      { stdio: "inherit" },
+    )
+    child.on("error", reject)
+    child.on("exit", (code) => {
+      if (code === 0) return resolve()
+      reject(
+        new Error(
+          `cms dump exited with code ${code ?? "null"} (signal-based exit)`,
+        ),
+      )
+    })
+  })
+}
+
+async function uploadToS3(bytes: Buffer): Promise<void> {
+  const {
+    RAILWAY_S3_BUCKET,
+    RAILWAY_S3_ENDPOINT,
+    RAILWAY_S3_REGION,
+    RAILWAY_S3_ACCESS_KEY_ID,
+    RAILWAY_S3_SECRET_ACCESS_KEY,
+  } = process.env
+
+  if (!RAILWAY_S3_BUCKET) {
+    // Local fallback — mirrors storage/s3.ts's LOCAL_OBJECT_DIR layout so
+    // dev runs can exercise the rest of the pipeline without real S3.
+    const localPath = join(process.cwd(), ".tmp", "objects", DEFAULT_S3_KEY)
+    await mkdir(dirname(localPath), { recursive: true })
+    await writeFile(localPath, bytes)
+    process.stdout.write(
+      `[refresh:core-id-mapping] RAILWAY_S3_BUCKET not set; wrote local fallback to ${localPath}\n`,
+    )
+    return
+  }
+
+  if (!RAILWAY_S3_ACCESS_KEY_ID || !RAILWAY_S3_SECRET_ACCESS_KEY) {
+    throw new Error(
+      "RAILWAY_S3_ACCESS_KEY_ID and RAILWAY_S3_SECRET_ACCESS_KEY are required when RAILWAY_S3_BUCKET is set",
+    )
+  }
+
+  const { S3Client, PutObjectCommand } = await import("@aws-sdk/client-s3")
+  const s3 = new S3Client({
+    endpoint: RAILWAY_S3_ENDPOINT,
+    region: RAILWAY_S3_REGION ?? "auto",
+    credentials: {
+      accessKeyId: RAILWAY_S3_ACCESS_KEY_ID,
+      secretAccessKey: RAILWAY_S3_SECRET_ACCESS_KEY,
+    },
+    forcePathStyle: true,
+  })
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: RAILWAY_S3_BUCKET,
+      Key: DEFAULT_S3_KEY,
+      Body: bytes,
+      ContentType: "application/json",
+    }),
+  )
+}
+
+async function main(): Promise<void> {
+  const tmp = await mkdtemp(join(tmpdir(), "refresh-core-id-mapping-"))
+  const outPath = join(tmp, "core-id-mapping.json")
+
+  try {
+    process.stdout.write(
+      `[refresh:core-id-mapping] dumping mapping from cms → ${outPath}\n`,
+    )
+    await runDumpCommand(outPath)
+
+    const bytes = await readFile(outPath)
+    await uploadToS3(bytes)
+
+    process.stdout.write(
+      `[refresh:core-id-mapping] uploaded ${bytes.byteLength} bytes to s3 key ${DEFAULT_S3_KEY}\n`,
+    )
+  } finally {
+    await rm(tmp, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `[refresh:core-id-mapping] failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+  )
+  process.exit(1)
+})

--- a/apps/admin/src/services/core-id-mapping.service.test.ts
+++ b/apps/admin/src/services/core-id-mapping.service.test.ts
@@ -4,7 +4,11 @@ const { readObject } = vi.hoisted(() => ({ readObject: vi.fn() }))
 
 vi.mock("@/storage/s3", () => ({ readObject }))
 
-import { loadCoreIdMapping } from "./core-id-mapping.service"
+import {
+  DEFAULT_CORE_ID_MAPPING_S3_KEY,
+  assertMappingS3KeyAllowed,
+  loadCoreIdMapping,
+} from "./core-id-mapping.service"
 
 function encode(value: unknown): Uint8Array {
   const body = typeof value === "string" ? value : JSON.stringify(value)
@@ -57,10 +61,15 @@ describe("loadCoreIdMapping", () => {
     expect(mapping.byCoreId.size).toBe(0)
   })
 
-  it("throws mapping_missing when S3 surfaces a NoSuchKey error", async () => {
-    readObject.mockRejectedValueOnce(
-      new Error("NoSuchKey: the specified key does not exist"),
-    )
+  it("throws mapping_missing for a real @aws-sdk/client-s3 NoSuchKey shape", async () => {
+    // Mirrors the typed SDK error: name discriminant + server message that
+    // does NOT contain any 'not found / missing' substring. The prior
+    // message-regex classifier would have misclassified this as read_failed.
+    const err = Object.assign(new Error("The specified key does not exist."), {
+      name: "NoSuchKey",
+      $metadata: { httpStatusCode: 404 },
+    })
+    readObject.mockRejectedValueOnce(err)
 
     await expect(
       loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
@@ -68,6 +77,17 @@ describe("loadCoreIdMapping", () => {
       name: "CoreIdMappingError",
       code: "mapping_missing",
     })
+  })
+
+  it("throws mapping_missing for a 404 shape without the NoSuchKey name", async () => {
+    const err = Object.assign(new Error("Not Found"), {
+      $metadata: { httpStatusCode: 404 },
+    })
+    readObject.mockRejectedValueOnce(err)
+
+    await expect(
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
+    ).rejects.toMatchObject({ code: "mapping_missing" })
   })
 
   it("throws mapping_missing when the local fallback file does not exist", async () => {
@@ -91,6 +111,38 @@ describe("loadCoreIdMapping", () => {
     ).rejects.toMatchObject({
       code: "mapping_read_failed",
     })
+  })
+
+  it("rejects S3 keys outside admin-migrations/ before any read", async () => {
+    await expect(
+      loadCoreIdMapping("other-app/secret.json"),
+    ).rejects.toMatchObject({ code: "mapping_key_rejected" })
+    expect(readObject).not.toHaveBeenCalled()
+  })
+
+  it("exposes the canonical default S3 key constant", () => {
+    expect(DEFAULT_CORE_ID_MAPPING_S3_KEY).toMatch(/^admin-migrations\//)
+    expect(() =>
+      assertMappingS3KeyAllowed(DEFAULT_CORE_ID_MAPPING_S3_KEY),
+    ).not.toThrow()
+    expect(() => assertMappingS3KeyAllowed("../escape.json")).toThrow(
+      /must live under admin-migrations\//,
+    )
+  })
+
+  it("does not misclassify credential errors whose message contains 'missing' or 'not found'", async () => {
+    // Prior regex matched 'missing' and 'not found' as substrings, so a
+    // CredentialsProviderError or DNS 'host not found' would silently be
+    // demoted to mapping_missing. Pin them to mapping_read_failed.
+    readObject.mockRejectedValueOnce(
+      new Error(
+        "CredentialsProviderError: could not load credentials, profile not found",
+      ),
+    )
+
+    await expect(
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
+    ).rejects.toMatchObject({ code: "mapping_read_failed" })
   })
 
   it("throws mapping_invalid on malformed JSON", async () => {

--- a/apps/admin/src/services/core-id-mapping.service.test.ts
+++ b/apps/admin/src/services/core-id-mapping.service.test.ts
@@ -79,15 +79,31 @@ describe("loadCoreIdMapping", () => {
     })
   })
 
-  it("throws mapping_missing for a 404 shape without the NoSuchKey name", async () => {
-    const err = Object.assign(new Error("Not Found"), {
-      $metadata: { httpStatusCode: 404 },
-    })
+  it("throws mapping_missing for the typed NotFound error name", async () => {
+    // NotFound is @aws-sdk/client-s3's typed error class for HEAD-style
+    // missing-object responses. Typed-name discriminant lets us classify
+    // without leaning on HTTP status codes (which also appear on config
+    // errors like NoSuchBucket).
+    const err = Object.assign(new Error("Not Found"), { name: "NotFound" })
     readObject.mockRejectedValueOnce(err)
 
     await expect(
       loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
     ).rejects.toMatchObject({ code: "mapping_missing" })
+  })
+
+  it("does NOT misclassify NoSuchBucket (404 config error) as mapping_missing", async () => {
+    // Railway S3 + a wrong RAILWAY_S3_BUCKET env lands here. Operator
+    // needs to see this as a config failure, not as "run the refresh CLI".
+    const err = Object.assign(
+      new Error("The specified bucket does not exist."),
+      { name: "NoSuchBucket", $metadata: { httpStatusCode: 404 } },
+    )
+    readObject.mockRejectedValueOnce(err)
+
+    await expect(
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
+    ).rejects.toMatchObject({ code: "mapping_read_failed" })
   })
 
   it("throws mapping_missing when the local fallback file does not exist", async () => {
@@ -120,12 +136,38 @@ describe("loadCoreIdMapping", () => {
     expect(readObject).not.toHaveBeenCalled()
   })
 
+  it("rejects admin-migrations-adjacent prefixes (near-miss)", async () => {
+    // 'admin-migrations-other/...' shouldn't pass — exact prefix with
+    // trailing slash is load-bearing. Pinning in case someone removes
+    // the slash thinking it's cosmetic.
+    await expect(
+      loadCoreIdMapping("admin-migrations-other/mapping.json"),
+    ).rejects.toMatchObject({ code: "mapping_key_rejected" })
+  })
+
+  it("rejects path-traversal keys even if they start with the prefix", async () => {
+    // `admin-migrations/../escape.json` passes the prefix check but is a
+    // traversal attempt — the segment regex should catch it as
+    // mapping_key_rejected rather than flowing through to readObject's
+    // generic validateObjectKey (which would surface as mapping_read_failed).
+    await expect(
+      loadCoreIdMapping("admin-migrations/../escape.json"),
+    ).rejects.toMatchObject({ code: "mapping_key_rejected" })
+    expect(readObject).not.toHaveBeenCalled()
+  })
+
   it("exposes the canonical default S3 key constant", () => {
     expect(DEFAULT_CORE_ID_MAPPING_S3_KEY).toMatch(/^admin-migrations\//)
     expect(() =>
       assertMappingS3KeyAllowed(DEFAULT_CORE_ID_MAPPING_S3_KEY),
     ).not.toThrow()
+    // `../escape.json` fails the segment regex first — it's a malformed
+    // path rather than a wrong-namespace one. Both errors are
+    // mapping_key_rejected; the distinction is only in the message.
     expect(() => assertMappingS3KeyAllowed("../escape.json")).toThrow(
+      /not a well-formed path/,
+    )
+    expect(() => assertMappingS3KeyAllowed("other-app/secret.json")).toThrow(
       /must live under admin-migrations\//,
     )
   })

--- a/apps/admin/src/services/core-id-mapping.service.test.ts
+++ b/apps/admin/src/services/core-id-mapping.service.test.ts
@@ -1,61 +1,41 @@
-import { mkdir, rm, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { readObject } = vi.hoisted(() => ({ readObject: vi.fn() }))
+
+vi.mock("@/storage/s3", () => ({ readObject }))
+
 import { loadCoreIdMapping } from "./core-id-mapping.service"
 
-const FIXTURE_DIR = join(tmpdir(), "admin-core-id-mapping-test")
-const ORIGINAL_ARTIFACT_DIR = process.env.ADMIN_ARTIFACT_DIR
-
-async function writeFixture(name: string, body: unknown): Promise<string> {
-  const path = join(FIXTURE_DIR, name)
-  await writeFile(path, typeof body === "string" ? body : JSON.stringify(body))
-  return path
+function encode(value: unknown): Uint8Array {
+  const body = typeof value === "string" ? value : JSON.stringify(value)
+  return new TextEncoder().encode(body)
 }
 
 describe("loadCoreIdMapping", () => {
-  beforeAll(async () => {
-    await mkdir(FIXTURE_DIR, { recursive: true })
-  })
-
-  afterAll(async () => {
-    await rm(FIXTURE_DIR, { recursive: true, force: true })
-  })
-
   beforeEach(() => {
-    // Tests write fixtures under the OS temp dir; point the allowlist
-    // there so the path-traversal guard doesn't reject them.
-    process.env.ADMIN_ARTIFACT_DIR = FIXTURE_DIR
-  })
-
-  afterEach(() => {
-    if (ORIGINAL_ARTIFACT_DIR === undefined) {
-      delete process.env.ADMIN_ARTIFACT_DIR
-    } else {
-      process.env.ADMIN_ARTIFACT_DIR = ORIGINAL_ARTIFACT_DIR
-    }
+    readObject.mockReset()
   })
 
   it("loads a valid mapping into a Map keyed by coreId", async () => {
-    const path = await writeFixture("valid.json", {
-      generatedAt: "2026-04-19T00:00:00.000Z",
-      count: 3,
-      rows: [
-        { coreId: "core-a", cmsVideoId: 1 },
-        { coreId: "core-b", cmsVideoId: 22 },
-        { coreId: "core-c", cmsVideoId: 333 },
-      ],
-    })
+    readObject.mockResolvedValueOnce(
+      encode({
+        generatedAt: "2026-04-19T00:00:00.000Z",
+        count: 3,
+        rows: [
+          { coreId: "core-a", cmsVideoId: 1 },
+          { coreId: "core-b", cmsVideoId: 22 },
+          { coreId: "core-c", cmsVideoId: 333 },
+        ],
+      }),
+    )
 
-    const mapping = await loadCoreIdMapping(path)
+    const mapping = await loadCoreIdMapping(
+      "admin-migrations/core-id-mapping.json",
+    )
+
+    expect(readObject).toHaveBeenCalledWith(
+      "admin-migrations/core-id-mapping.json",
+    )
     expect(mapping.byCoreId.size).toBe(3)
     expect(mapping.byCoreId.get("core-a")).toBe(1)
     expect(mapping.byCoreId.get("core-c")).toBe(333)
@@ -63,68 +43,75 @@ describe("loadCoreIdMapping", () => {
   })
 
   it("handles an empty rows array", async () => {
-    const path = await writeFixture("empty.json", {
-      generatedAt: "2026-04-19T00:00:00.000Z",
-      count: 0,
-      rows: [],
-    })
+    readObject.mockResolvedValueOnce(
+      encode({
+        generatedAt: "2026-04-19T00:00:00.000Z",
+        count: 0,
+        rows: [],
+      }),
+    )
 
-    const mapping = await loadCoreIdMapping(path)
+    const mapping = await loadCoreIdMapping(
+      "admin-migrations/core-id-mapping.json",
+    )
     expect(mapping.byCoreId.size).toBe(0)
   })
 
-  it("throws mapping_missing when the file does not exist", async () => {
+  it("throws mapping_missing when S3 surfaces a NoSuchKey error", async () => {
+    readObject.mockRejectedValueOnce(
+      new Error("NoSuchKey: the specified key does not exist"),
+    )
+
     await expect(
-      loadCoreIdMapping(join(FIXTURE_DIR, "no-such-file.json")),
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
     ).rejects.toMatchObject({
       name: "CoreIdMappingError",
       code: "mapping_missing",
     })
   })
 
-  it("throws mapping_invalid on malformed JSON", async () => {
-    const path = await writeFixture("bad.json", "{not json")
-    await expect(loadCoreIdMapping(path)).rejects.toMatchObject({
-      code: "mapping_invalid",
+  it("throws mapping_missing when the local fallback file does not exist", async () => {
+    const err = Object.assign(new Error("ENOENT: no such file or directory"), {
+      code: "ENOENT",
     })
+    readObject.mockRejectedValueOnce(err)
+
+    await expect(
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
+    ).rejects.toMatchObject({
+      code: "mapping_missing",
+    })
+  })
+
+  it("throws mapping_read_failed on unexpected S3 errors", async () => {
+    readObject.mockRejectedValueOnce(new Error("network is unreachable"))
+
+    await expect(
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
+    ).rejects.toMatchObject({
+      code: "mapping_read_failed",
+    })
+  })
+
+  it("throws mapping_invalid on malformed JSON", async () => {
+    readObject.mockResolvedValueOnce(encode("{not json"))
+
+    await expect(
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
+    ).rejects.toMatchObject({ code: "mapping_invalid" })
   })
 
   it("throws mapping_invalid when a row has the wrong shape", async () => {
-    const path = await writeFixture("wrong-shape.json", {
-      generatedAt: "x",
-      count: 1,
-      rows: [{ coreId: "core-a", cmsVideoId: "not-a-number" }],
-    })
-    await expect(loadCoreIdMapping(path)).rejects.toMatchObject({
-      code: "mapping_invalid",
-    })
-  })
-
-  it("rejects paths outside ADMIN_ARTIFACT_DIR with mapping_path_rejected", async () => {
-    // Write a file OUTSIDE the allowed root (by temporarily pointing
-    // ADMIN_ARTIFACT_DIR at an unrelated directory).
-    const outsideFixture = await writeFixture("valid-outside.json", {
-      generatedAt: "x",
-      count: 0,
-      rows: [],
-    })
-    const bogusRoot = join(tmpdir(), "admin-core-id-mapping-test-bogus-root")
-    await mkdir(bogusRoot, { recursive: true })
-    process.env.ADMIN_ARTIFACT_DIR = bogusRoot
-    try {
-      await expect(loadCoreIdMapping(outsideFixture)).rejects.toMatchObject({
-        code: "mapping_path_rejected",
-      })
-    } finally {
-      await rm(bogusRoot, { recursive: true, force: true })
-    }
-  })
-
-  it("rejects relative paths with mapping_path_rejected", async () => {
-    await expect(loadCoreIdMapping("relative/path.json")).rejects.toMatchObject(
-      {
-        code: "mapping_path_rejected",
-      },
+    readObject.mockResolvedValueOnce(
+      encode({
+        generatedAt: "x",
+        count: 1,
+        rows: [{ coreId: "core-a", cmsVideoId: "not-a-number" }],
+      }),
     )
+
+    await expect(
+      loadCoreIdMapping("admin-migrations/core-id-mapping.json"),
+    ).rejects.toMatchObject({ code: "mapping_invalid" })
   })
 })

--- a/apps/admin/src/services/core-id-mapping.service.ts
+++ b/apps/admin/src/services/core-id-mapping.service.ts
@@ -63,7 +63,23 @@ export class CoreIdMappingError extends Error {
   }
 }
 
+// Each path segment must begin with a non-dot character, matching the
+// shape storage/s3.ts's SAFE_OBJECT_KEY_PATTERN enforces. Running this
+// check inside assertMappingS3KeyAllowed means a key like
+// `admin-migrations/../escape.json` is reported as mapping_key_rejected
+// (operator intent clear) rather than as mapping_read_failed (storage
+// validateObjectKey throws a plain Error and loadCoreIdMapping wraps it
+// in the wrong CoreIdMappingError.code).
+const SAFE_MAPPING_KEY_PATTERN =
+  /^[a-zA-Z0-9_-][a-zA-Z0-9._-]*(\/[a-zA-Z0-9_-][a-zA-Z0-9._-]*)*$/
+
 export function assertMappingS3KeyAllowed(s3Key: string): void {
+  if (!SAFE_MAPPING_KEY_PATTERN.test(s3Key)) {
+    throw new CoreIdMappingError(
+      "mapping_key_rejected",
+      `Core-ID mapping s3 key is not a well-formed path (each segment must start with a letter, digit, '-', or '_')`,
+    )
+  }
   if (!s3Key.startsWith(ADMIN_MIGRATIONS_S3_PREFIX)) {
     throw new CoreIdMappingError(
       "mapping_key_rejected",
@@ -80,23 +96,25 @@ export type CoreIdMapping = {
 
 /**
  * Classify a storage read error as "the thing isn't there" vs "something is
- * broken". Checks typed discriminants — `@aws-sdk/client-s3`'s `NoSuchKey`
- * exports `name: "NoSuchKey"`, local fs misses carry `code: "ENOENT"` — so
- * operator diagnostics stay deterministic across SDK message rewordings.
+ * broken". Checks typed discriminants — `@aws-sdk/client-s3` exports
+ * `NoSuchKey` and `NotFound` classes whose `name` is a literal string
+ * constant, and local fs misses carry `code: "ENOENT"`. We deliberately do
+ * NOT treat a bare HTTP 404 as "missing": `NoSuchBucket` / `AccessDenied`
+ * can also surface as 404 depending on bucket policy, and those are
+ * configuration failures the operator should see as `mapping_read_failed`,
+ * not `mapping_missing` (which reads as "re-run the refresh CLI").
  */
 function isStorageMissingError(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false
   const err = error as {
     name?: unknown
     code?: unknown
-    $metadata?: { httpStatusCode?: unknown }
   }
   return (
     err.name === "NoSuchKey" ||
     err.name === "NotFound" ||
     err.code === "NoSuchKey" ||
-    err.code === "ENOENT" ||
-    err.$metadata?.httpStatusCode === 404
+    err.code === "ENOENT"
   )
 }
 

--- a/apps/admin/src/services/core-id-mapping.service.ts
+++ b/apps/admin/src/services/core-id-mapping.service.ts
@@ -3,16 +3,17 @@
 // admin and cms run on separate Postgres databases. During scene-embedding
 // backfill (R1), admin needs to translate its `Video.coreId` into the
 // integer `videos.id` used by cms as the S3 key prefix for manager's
-// scene-analysis artifacts. That mapping is dumped one-shot from cms via
-// `pnpm --filter @forge/cms dump:core-id-mapping` and loaded here.
+// scene-analysis artifacts. That mapping is dumped from cms via
+// `pnpm --filter @forge/cms dump:core-id-mapping`, uploaded to the
+// shared Railway S3 bucket, and loaded here.
 //
 // Snapshot semantics: Strapi SERIAL ids don't change, so a stale mapping
-// only misses newly added videos. Re-dump between backfills when the cms
+// only misses newly added videos. Re-run the admin refresh CLI
+// (`pnpm --filter @forge/admin refresh:core-id-mapping`) whenever cms's
 // catalog has grown.
 
-import { readFile, realpath } from "node:fs/promises"
-import { isAbsolute, resolve, sep } from "node:path"
 import { z } from "zod"
+import { readObject } from "@/storage/s3"
 
 export const CoreIdMappingRowSchema = z.object({
   coreId: z.string().min(1),
@@ -33,8 +34,7 @@ export class CoreIdMappingError extends Error {
     readonly code:
       | "mapping_missing"
       | "mapping_invalid"
-      | "mapping_read_failed"
-      | "mapping_path_rejected",
+      | "mapping_read_failed",
     message: string,
     readonly cause?: unknown,
   ) {
@@ -43,90 +43,35 @@ export class CoreIdMappingError extends Error {
   }
 }
 
-/**
- * Default allowed root for mapping files: `<cwd>/.tmp`. Callers (operators
- * or the workflow trigger) must supply a path whose real-path resolves
- * inside this root. Configurable via the `ADMIN_ARTIFACT_DIR` env (not
- * yet declared; reads `process.env` as a fallback until env.ts carries
- * the key so that ops can redirect locally without a code change).
- */
-function getAllowedRoot(): string {
-  const fromEnv = process.env.ADMIN_ARTIFACT_DIR
-  const candidate = fromEnv ?? resolve(process.cwd(), ".tmp")
-  return resolve(candidate)
-}
-
-async function assertPathWithinAllowedRoot(path: string): Promise<string> {
-  if (!isAbsolute(path)) {
-    throw new CoreIdMappingError(
-      "mapping_path_rejected",
-      `Core-ID mapping path must be absolute, got ${JSON.stringify(path)}`,
-    )
-  }
-  const root = getAllowedRoot()
-  let resolved: string
-  try {
-    resolved = await realpath(path)
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    if (/ENOENT|no such file|not found/i.test(message)) {
-      throw new CoreIdMappingError(
-        "mapping_missing",
-        `Core-ID mapping file not found at ${path}`,
-        error,
-      )
-    }
-    throw new CoreIdMappingError(
-      "mapping_read_failed",
-      `Failed to resolve Core-ID mapping path: ${message}`,
-      error,
-    )
-  }
-  const rootWithSep = root.endsWith(sep) ? root : root + sep
-  if (resolved !== root && !resolved.startsWith(rootWithSep)) {
-    throw new CoreIdMappingError(
-      "mapping_path_rejected",
-      `Core-ID mapping path must resolve inside ${root}`,
-    )
-  }
-  return resolved
-}
-
 /** Resolved mapping surface — a Map for O(1) lookup + the source metadata. */
 export type CoreIdMapping = {
   generatedAt: string
   byCoreId: ReadonlyMap<string, number>
 }
 
-export async function loadCoreIdMapping(path: string): Promise<CoreIdMapping> {
-  // Reject paths that would escape the configured artifact root before we
-  // touch the filesystem at the user-supplied path. The ADMIN-only GraphQL
-  // mutation hands this value in directly; without this gate a compromised
-  // ADMIN session becomes an arbitrary-file-read primitive.
-  const resolvedPath = await assertPathWithinAllowedRoot(path)
-
-  let raw: string
+export async function loadCoreIdMapping(s3Key: string): Promise<CoreIdMapping> {
+  let bytes: Uint8Array
   try {
-    raw = await readFile(resolvedPath, "utf8")
+    bytes = await readObject(s3Key)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    if (/ENOENT|no such file|not found/i.test(message)) {
+    if (/not found|missing|no such key|ENOENT|NoSuchKey/i.test(message)) {
       throw new CoreIdMappingError(
         "mapping_missing",
-        `Core-ID mapping file not found`,
+        `Core-ID mapping not found at s3 key ${s3Key}`,
         error,
       )
     }
     throw new CoreIdMappingError(
       "mapping_read_failed",
-      `Failed to read Core-ID mapping: ${message}`,
+      `Failed to read Core-ID mapping from s3 key ${s3Key}: ${message}`,
       error,
     )
   }
 
   let parsed: unknown
   try {
-    parsed = JSON.parse(raw)
+    parsed = JSON.parse(new TextDecoder().decode(bytes))
   } catch (error) {
     throw new CoreIdMappingError(
       "mapping_invalid",
@@ -142,7 +87,7 @@ export async function loadCoreIdMapping(path: string): Promise<CoreIdMapping> {
     console.error(
       JSON.stringify({
         event: "core_id_mapping_invalid",
-        path: resolvedPath,
+        s3Key,
         zodMessage: validated.error.message,
       }),
     )

--- a/apps/admin/src/services/core-id-mapping.service.ts
+++ b/apps/admin/src/services/core-id-mapping.service.ts
@@ -15,6 +15,25 @@
 import { z } from "zod"
 import { readObject } from "@/storage/s3"
 
+/**
+ * Canonical S3 key for the coreId → cms video id snapshot that the admin
+ * refresh CLI uploads. Consumed by (a) the `triggerSceneEmbeddingBackfill`
+ * Pothos defaultValue, (b) the refresh CLI's upload target, and (c) the
+ * operator runbook. Keep one source of truth so the CLI and mutation can
+ * never silently target different keys.
+ */
+export const DEFAULT_CORE_ID_MAPPING_S3_KEY =
+  "admin-migrations/core-id-mapping.json"
+
+/**
+ * Any S3 key handed to the mutation must live under this prefix. The bucket
+ * is shared across services (manager writes `{assetId}/scene-analysis.json`
+ * etc.); confining ADMIN-supplied keys to the admin namespace stops a
+ * compromised ADMIN session from using the mutation to enumerate other
+ * apps' objects via error-code timing.
+ */
+export const ADMIN_MIGRATIONS_S3_PREFIX = "admin-migrations/"
+
 export const CoreIdMappingRowSchema = z.object({
   coreId: z.string().min(1),
   cmsVideoId: z.number().int().positive(),
@@ -34,12 +53,22 @@ export class CoreIdMappingError extends Error {
     readonly code:
       | "mapping_missing"
       | "mapping_invalid"
-      | "mapping_read_failed",
+      | "mapping_read_failed"
+      | "mapping_key_rejected",
     message: string,
     readonly cause?: unknown,
   ) {
     super(message)
     this.name = "CoreIdMappingError"
+  }
+}
+
+export function assertMappingS3KeyAllowed(s3Key: string): void {
+  if (!s3Key.startsWith(ADMIN_MIGRATIONS_S3_PREFIX)) {
+    throw new CoreIdMappingError(
+      "mapping_key_rejected",
+      `Core-ID mapping s3 key must live under ${ADMIN_MIGRATIONS_S3_PREFIX}`,
+    )
   }
 }
 
@@ -49,19 +78,43 @@ export type CoreIdMapping = {
   byCoreId: ReadonlyMap<string, number>
 }
 
+/**
+ * Classify a storage read error as "the thing isn't there" vs "something is
+ * broken". Checks typed discriminants — `@aws-sdk/client-s3`'s `NoSuchKey`
+ * exports `name: "NoSuchKey"`, local fs misses carry `code: "ENOENT"` — so
+ * operator diagnostics stay deterministic across SDK message rewordings.
+ */
+function isStorageMissingError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false
+  const err = error as {
+    name?: unknown
+    code?: unknown
+    $metadata?: { httpStatusCode?: unknown }
+  }
+  return (
+    err.name === "NoSuchKey" ||
+    err.name === "NotFound" ||
+    err.code === "NoSuchKey" ||
+    err.code === "ENOENT" ||
+    err.$metadata?.httpStatusCode === 404
+  )
+}
+
 export async function loadCoreIdMapping(s3Key: string): Promise<CoreIdMapping> {
+  assertMappingS3KeyAllowed(s3Key)
+
   let bytes: Uint8Array
   try {
     bytes = await readObject(s3Key)
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    if (/not found|missing|no such key|ENOENT|NoSuchKey/i.test(message)) {
+    if (isStorageMissingError(error)) {
       throw new CoreIdMappingError(
         "mapping_missing",
         `Core-ID mapping not found at s3 key ${s3Key}`,
         error,
       )
     }
+    const message = error instanceof Error ? error.message : String(error)
     throw new CoreIdMappingError(
       "mapping_read_failed",
       `Failed to read Core-ID mapping from s3 key ${s3Key}: ${message}`,

--- a/apps/admin/src/storage/s3.prod-guard.test.ts
+++ b/apps/admin/src/storage/s3.prod-guard.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Fail-fast test for the production-requires-S3 guard in storage/s3.ts.
+ *
+ * Runs in a separate test file so NODE_ENV can be flipped to "production"
+ * at module import time, which is the only moment `useS3` and the prod
+ * guard read their inputs.
+ */
+
+import { describe, expect, it, vi } from "vitest"
+
+// Flip env BEFORE the dynamic import so env.ts + s3.ts see the production
+// shape. Leave RAILWAY_S3_BUCKET unset — that's the misconfigured state
+// the guard is meant to surface. NODE_ENV is `Readonly<string>` under
+// `@types/node`, so we assign via a pass-through cast.
+;(process.env as Record<string, string | undefined>).NODE_ENV = "production"
+delete process.env.RAILWAY_S3_BUCKET
+
+// @aws-sdk/client-s3 and @smithy/node-http-handler are imported lazily
+// inside getS3(), but the assertStorageConfiguredForProduction guard
+// runs BEFORE that path. Still, mock them defensively so any accidental
+// client-construction attempt fails loudly rather than reaching the
+// network.
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class {},
+  PutObjectCommand: class {},
+  GetObjectCommand: class {},
+}))
+vi.mock("@smithy/node-http-handler", () => ({
+  NodeHttpHandler: class {},
+}))
+
+const { writeObject, readObject } = await import("./s3")
+
+describe("storage — production fail-fast", () => {
+  it("writeObject rejects loudly when RAILWAY_S3_BUCKET is unset in production", async () => {
+    await expect(
+      writeObject("admin-migrations/x.json", "payload"),
+    ).rejects.toThrow(/RAILWAY_S3_BUCKET is not set/)
+  })
+
+  it("readObject rejects loudly when RAILWAY_S3_BUCKET is unset in production", async () => {
+    await expect(readObject("admin-migrations/x.json")).rejects.toThrow(
+      /RAILWAY_S3_BUCKET is not set/,
+    )
+  })
+})

--- a/apps/admin/src/storage/s3.s3-backend.test.ts
+++ b/apps/admin/src/storage/s3.s3-backend.test.ts
@@ -1,0 +1,104 @@
+/**
+ * S3-backend tests for storage/s3.ts.
+ *
+ * Runs in a separate file so the env-driven `useS3 = Boolean(env.RAILWAY_S3_BUCKET)`
+ * flag can be flipped on at module import time without affecting the
+ * local-fallback tests in s3.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { s3Send, PutObjectCommand, GetObjectCommand } = vi.hoisted(() => ({
+  s3Send: vi.fn(),
+  PutObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
+    __command: "PutObject",
+    input,
+  })),
+  GetObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
+    __command: "GetObject",
+    input,
+  })),
+}))
+
+class StubS3Client {
+  constructor(public readonly config: unknown) {}
+  send(...args: unknown[]) {
+    return s3Send(...args)
+  }
+}
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: StubS3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+}))
+
+vi.mock("@smithy/node-http-handler", () => ({
+  NodeHttpHandler: class {
+    constructor(public readonly config: unknown) {}
+  },
+}))
+
+// Set env before importing the module under test — `useS3` is computed at
+// import time and cached at module scope.
+process.env.RAILWAY_S3_BUCKET = "test-bucket"
+process.env.RAILWAY_S3_ENDPOINT = "https://s3.example.com"
+process.env.RAILWAY_S3_REGION = "auto"
+process.env.RAILWAY_S3_ACCESS_KEY_ID = "AKIA_TEST"
+process.env.RAILWAY_S3_SECRET_ACCESS_KEY = "secret"
+
+const { writeObject, readObject } = await import("./s3")
+
+describe("storage — object-key API (S3 backend)", () => {
+  beforeEach(() => {
+    s3Send.mockReset()
+    PutObjectCommand.mockClear()
+    GetObjectCommand.mockClear()
+  })
+
+  afterEach(() => {
+    s3Send.mockReset()
+  })
+
+  it("writeObject issues a PutObjectCommand with the expected bucket, key, body, and content-type", async () => {
+    s3Send.mockResolvedValueOnce({})
+
+    const key = await writeObject(
+      "admin-migrations/core-id-mapping.json",
+      '{"ok":true}',
+      "application/json",
+    )
+
+    expect(key).toBe("admin-migrations/core-id-mapping.json")
+    expect(PutObjectCommand).toHaveBeenCalledWith({
+      Bucket: "test-bucket",
+      Key: "admin-migrations/core-id-mapping.json",
+      Body: '{"ok":true}',
+      ContentType: "application/json",
+    })
+    expect(s3Send).toHaveBeenCalledTimes(1)
+  })
+
+  it("readObject issues a GetObjectCommand and returns the response body as bytes", async () => {
+    const bodyBytes = new TextEncoder().encode('{"rows":[]}')
+    s3Send.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => bodyBytes },
+    })
+
+    const bytes = await readObject("admin-migrations/core-id-mapping.json")
+
+    expect(GetObjectCommand).toHaveBeenCalledWith({
+      Bucket: "test-bucket",
+      Key: "admin-migrations/core-id-mapping.json",
+    })
+    expect(new TextDecoder().decode(bytes)).toBe('{"rows":[]}')
+  })
+
+  it("readObject throws a clear error when the response Body is missing", async () => {
+    s3Send.mockResolvedValueOnce({})
+
+    await expect(readObject("admin-migrations/empty.json")).rejects.toThrow(
+      "Empty body for admin-migrations/empty.json",
+    )
+  })
+})

--- a/apps/admin/src/storage/s3.s3-backend.test.ts
+++ b/apps/admin/src/storage/s3.s3-backend.test.ts
@@ -8,23 +8,31 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const { s3Send, PutObjectCommand, GetObjectCommand } = vi.hoisted(() => ({
-  s3Send: vi.fn(),
-  PutObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
-    __command: "PutObject",
-    input,
-  })),
-  GetObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
-    __command: "GetObject",
-    input,
-  })),
-}))
+const { s3Send, PutObjectCommand, GetObjectCommand, capturedS3Config } =
+  vi.hoisted(() => ({
+    s3Send: vi.fn(),
+    PutObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
+      __command: "PutObject",
+      input,
+    })),
+    GetObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
+      __command: "GetObject",
+      input,
+    })),
+    capturedS3Config: { last: undefined as unknown },
+  }))
 
 class StubS3Client {
-  constructor(public readonly config: unknown) {}
+  constructor(public readonly config: Record<string, unknown>) {
+    capturedS3Config.last = config
+  }
   send(...args: unknown[]) {
     return s3Send(...args)
   }
+}
+
+class StubNodeHttpHandler {
+  constructor(public readonly config: Record<string, unknown>) {}
 }
 
 vi.mock("@aws-sdk/client-s3", () => ({
@@ -34,9 +42,7 @@ vi.mock("@aws-sdk/client-s3", () => ({
 }))
 
 vi.mock("@smithy/node-http-handler", () => ({
-  NodeHttpHandler: class {
-    constructor(public readonly config: unknown) {}
-  },
+  NodeHttpHandler: StubNodeHttpHandler,
 }))
 
 // Set env before importing the module under test — `useS3` is computed at
@@ -100,5 +106,25 @@ describe("storage — object-key API (S3 backend)", () => {
     await expect(readObject("admin-migrations/empty.json")).rejects.toThrow(
       "Empty body for admin-migrations/empty.json",
     )
+  })
+
+  it("constructs the S3Client with a NodeHttpHandler carrying connect + request timeouts", async () => {
+    // F29: round-1 added @smithy/node-http-handler as the whole reason
+    // for the dep. If a regression drops `requestHandler` (or reverts to
+    // unbounded defaults), stepLoadMapping can hang for minutes on a
+    // stalled Railway endpoint. Lock the config in.
+    s3Send.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => new Uint8Array() },
+    })
+    await readObject("admin-migrations/core-id-mapping.json").catch(() => {})
+
+    const config = capturedS3Config.last as
+      | { requestHandler?: StubNodeHttpHandler }
+      | undefined
+    expect(config?.requestHandler).toBeInstanceOf(StubNodeHttpHandler)
+    expect(config!.requestHandler!.config).toEqual({
+      connectionTimeout: 5_000,
+      requestTimeout: 30_000,
+    })
   })
 })

--- a/apps/admin/src/storage/s3.test.ts
+++ b/apps/admin/src/storage/s3.test.ts
@@ -80,9 +80,23 @@ describe("storage — object-key API (local fallback)", () => {
     )
   })
 
-  it("rejects empty or leading-slash keys", async () => {
+  it("rejects empty, leading-slash, or trailing-slash keys", async () => {
     await expect(writeObject("", "x")).rejects.toThrow("Invalid object key")
     await expect(writeObject("/leading/slash.json", "x")).rejects.toThrow(
+      "Invalid object key",
+    )
+    await expect(writeObject("trailing/slash/", "x")).rejects.toThrow(
+      "Invalid object key",
+    )
+  })
+
+  it("rejects bare-dot segments like 'a/./b' and '.' / '..' ", async () => {
+    await expect(writeObject("admin/./b.json", "x")).rejects.toThrow(
+      "Invalid object key",
+    )
+    await expect(writeObject(".", "x")).rejects.toThrow("Invalid object key")
+    await expect(writeObject("..", "x")).rejects.toThrow("Invalid object key")
+    await expect(writeObject("admin/..", "x")).rejects.toThrow(
       "Invalid object key",
     )
   })

--- a/apps/admin/src/storage/s3.test.ts
+++ b/apps/admin/src/storage/s3.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, afterEach } from "vitest"
-import { writeArtifact, readArtifact } from "./s3"
+import { writeArtifact, readArtifact, writeObject, readObject } from "./s3"
 import { rm } from "node:fs/promises"
 import { join } from "node:path"
 
 // Tests use the local fallback (RAILWAY_S3_BUCKET is not set in test env)
 
 const LOCAL_DIR = join(process.cwd(), ".tmp", "artifacts")
+const LOCAL_OBJECT_DIR = join(process.cwd(), ".tmp", "objects")
 
 afterEach(async () => {
   await rm(LOCAL_DIR, { recursive: true, force: true })
+  await rm(LOCAL_OBJECT_DIR, { recursive: true, force: true })
 })
 
 describe("storage — local fallback", () => {
@@ -46,5 +48,42 @@ describe("storage — local fallback", () => {
         body: "x",
       }),
     ).rejects.toThrow("Invalid ext")
+  })
+})
+
+describe("storage — object-key API (local fallback)", () => {
+  it("writes and reads an object at an arbitrary slash-separated key", async () => {
+    const key = await writeObject(
+      "admin-migrations/core-id-mapping.json",
+      '{"ok":true}',
+      "application/json",
+    )
+
+    expect(key).toBe("admin-migrations/core-id-mapping.json")
+
+    const bytes = await readObject("admin-migrations/core-id-mapping.json")
+    expect(new TextDecoder().decode(bytes)).toBe('{"ok":true}')
+  })
+
+  it("throws on a missing object in local fallback", async () => {
+    await expect(
+      readObject("admin-migrations/does-not-exist.json"),
+    ).rejects.toThrow(/ENOENT/)
+  })
+
+  it("rejects traversal attempts in object keys", async () => {
+    await expect(
+      writeObject("admin-migrations/../escape.json", "x"),
+    ).rejects.toThrow("Invalid object key")
+    await expect(readObject("../escape.json")).rejects.toThrow(
+      "Invalid object key",
+    )
+  })
+
+  it("rejects empty or leading-slash keys", async () => {
+    await expect(writeObject("", "x")).rejects.toThrow("Invalid object key")
+    await expect(writeObject("/leading/slash.json", "x")).rejects.toThrow(
+      "Invalid object key",
+    )
   })
 })

--- a/apps/admin/src/storage/s3.ts
+++ b/apps/admin/src/storage/s3.ts
@@ -14,6 +14,21 @@ import { env } from "@/config/env"
 
 const useS3 = Boolean(env.RAILWAY_S3_BUCKET)
 
+/**
+ * In production, RAILWAY_S3_BUCKET absence is a fatal misconfiguration —
+ * the local fallback would silently read from an ephemeral container's
+ * `.tmp/objects/...` which doesn't exist, and downstream consumers would
+ * misclassify the resulting ENOENT as "object not uploaded yet". Fail
+ * loudly here so the operator sees a specific configuration error.
+ */
+function assertStorageConfiguredForProduction(): void {
+  if (!useS3 && env.NODE_ENV === "production") {
+    throw new Error(
+      "RAILWAY_S3_BUCKET is not set — admin storage cannot use local fallback in production",
+    )
+  }
+}
+
 export type WriteArtifactOptions = {
   assetId: string
   artifactType: string
@@ -25,10 +40,11 @@ export type WriteArtifactOptions = {
 const SAFE_KEY_PATTERN = /^[a-zA-Z0-9_-]+$/
 
 // Object-key pattern for arbitrary S3 keys (e.g. admin-migrations/core-id-mapping.json).
-// Allows path segments, digits, letters, dots, dashes, underscores. Disallows ".." and
-// leading/trailing slashes to keep the bucket namespace tidy and avoid traversal shapes
-// in the local fallback.
-const SAFE_OBJECT_KEY_PATTERN = /^[a-zA-Z0-9._-]+(\/[a-zA-Z0-9._-]+)*$/
+// Each segment must contain at least one non-dot character, which rules out bare
+// `..` and `.` segments (traversal / cwd-ref shapes) at the regex layer. Leading
+// and trailing slashes are not allowed.
+const SAFE_OBJECT_KEY_PATTERN =
+  /^[a-zA-Z0-9_-][a-zA-Z0-9._-]*(\/[a-zA-Z0-9_-][a-zA-Z0-9._-]*)*$/
 
 function validateKeyComponent(value: string, name: string): void {
   if (!SAFE_KEY_PATTERN.test(value)) {
@@ -39,9 +55,9 @@ function validateKeyComponent(value: string, name: string): void {
 }
 
 function validateObjectKey(key: string): void {
-  if (!SAFE_OBJECT_KEY_PATTERN.test(key) || key.includes("..")) {
+  if (!SAFE_OBJECT_KEY_PATTERN.test(key)) {
     throw new Error(
-      `Invalid object key: must be slash-separated alphanumeric segments (letters, digits, '.', '-', '_')`,
+      `Invalid object key: must be slash-separated segments of letters, digits, '.', '-', '_' with each segment starting with a non-dot character`,
     )
   }
 }
@@ -72,7 +88,10 @@ async function getS3() {
         "RAILWAY_S3_ACCESS_KEY_ID and RAILWAY_S3_SECRET_ACCESS_KEY are required when RAILWAY_S3_BUCKET is set",
       )
     }
-    const { S3Client } = await import("@aws-sdk/client-s3")
+    const [{ S3Client }, { NodeHttpHandler }] = await Promise.all([
+      import("@aws-sdk/client-s3"),
+      import("@smithy/node-http-handler"),
+    ])
     if (!_s3) {
       _s3 = new S3Client({
         endpoint: env.RAILWAY_S3_ENDPOINT,
@@ -82,6 +101,13 @@ async function getS3() {
           secretAccessKey: env.RAILWAY_S3_SECRET_ACCESS_KEY,
         },
         forcePathStyle: true,
+        // Bound every request so a stalled Railway S3 endpoint doesn't hold
+        // the workflow runtime hostage. Defaults are "no timeout", which
+        // means stepLoadMapping can wait minutes on a TCP half-open.
+        requestHandler: new NodeHttpHandler({
+          connectionTimeout: 5_000,
+          requestTimeout: 30_000,
+        }),
       })
     }
   }
@@ -180,6 +206,7 @@ export async function writeObject(
   contentType?: string,
 ): Promise<string> {
   validateObjectKey(key)
+  assertStorageConfiguredForProduction()
 
   if (!useS3) {
     const filePath = join(LOCAL_OBJECT_DIR, key)
@@ -213,6 +240,7 @@ export async function writeObject(
 
 export async function readObject(key: string): Promise<Uint8Array> {
   validateObjectKey(key)
+  assertStorageConfiguredForProduction()
 
   if (!useS3) {
     return readFile(join(LOCAL_OBJECT_DIR, key))

--- a/apps/admin/src/storage/s3.ts
+++ b/apps/admin/src/storage/s3.ts
@@ -9,7 +9,7 @@
 // Per Unit 11 of docs/plans/2026-04-13-002-feat-admin-app-graphql-postgres-plan.md.
 
 import { mkdir, readFile, writeFile } from "node:fs/promises"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { env } from "@/config/env"
 
 const useS3 = Boolean(env.RAILWAY_S3_BUCKET)
@@ -24,10 +24,24 @@ export type WriteArtifactOptions = {
 
 const SAFE_KEY_PATTERN = /^[a-zA-Z0-9_-]+$/
 
+// Object-key pattern for arbitrary S3 keys (e.g. admin-migrations/core-id-mapping.json).
+// Allows path segments, digits, letters, dots, dashes, underscores. Disallows ".." and
+// leading/trailing slashes to keep the bucket namespace tidy and avoid traversal shapes
+// in the local fallback.
+const SAFE_OBJECT_KEY_PATTERN = /^[a-zA-Z0-9._-]+(\/[a-zA-Z0-9._-]+)*$/
+
 function validateKeyComponent(value: string, name: string): void {
   if (!SAFE_KEY_PATTERN.test(value)) {
     throw new Error(
       `Invalid ${name}: must contain only alphanumeric characters, hyphens, and underscores`,
+    )
+  }
+}
+
+function validateObjectKey(key: string): void {
+  if (!SAFE_OBJECT_KEY_PATTERN.test(key) || key.includes("..")) {
+    throw new Error(
+      `Invalid object key: must be slash-separated alphanumeric segments (letters, digits, '.', '-', '_')`,
     )
   }
 }
@@ -79,6 +93,7 @@ async function getS3() {
 // ---------------------------------------------------------------------------
 
 const LOCAL_DIR = join(process.cwd(), ".tmp", "artifacts")
+const LOCAL_OBJECT_DIR = join(process.cwd(), ".tmp", "objects")
 
 async function localWrite(options: WriteArtifactOptions): Promise<string> {
   const key = artifactKey(options.assetId, options.artifactType, options.ext)
@@ -140,6 +155,70 @@ export async function readArtifact(
 
   const { GetObjectCommand } = await import("@aws-sdk/client-s3")
   const key = artifactKey(assetId, artifactType, ext)
+  const s3 = await getS3()
+
+  const response = await s3.send(
+    new GetObjectCommand({
+      Bucket: env.RAILWAY_S3_BUCKET,
+      Key: key,
+    }),
+  )
+
+  if (!response.Body) throw new Error(`Empty body for ${key}`)
+  return new Uint8Array(await response.Body.transformToByteArray())
+}
+
+// ---------------------------------------------------------------------------
+// Object-key API — reads/writes to an arbitrary S3 key (slash-separated
+// path segments), rather than the `{assetId}/{artifactType}.{ext}` shape.
+// Used for admin-scoped resources like the coreId mapping snapshot.
+// ---------------------------------------------------------------------------
+
+export async function writeObject(
+  key: string,
+  body: Buffer | Uint8Array | string,
+  contentType?: string,
+): Promise<string> {
+  validateObjectKey(key)
+
+  if (!useS3) {
+    const filePath = join(LOCAL_OBJECT_DIR, key)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, body)
+    return key
+  }
+
+  const { PutObjectCommand } = await import("@aws-sdk/client-s3")
+  const s3 = await getS3()
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: env.RAILWAY_S3_BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    }),
+  )
+
+  console.log(
+    JSON.stringify({
+      event: "storage.write",
+      key,
+      backend: "s3",
+      service: "forge-admin",
+    }),
+  )
+  return key
+}
+
+export async function readObject(key: string): Promise<Uint8Array> {
+  validateObjectKey(key)
+
+  if (!useS3) {
+    return readFile(join(LOCAL_OBJECT_DIR, key))
+  }
+
+  const { GetObjectCommand } = await import("@aws-sdk/client-s3")
   const s3 = await getS3()
 
   const response = await s3.send(

--- a/apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts
@@ -53,7 +53,7 @@ describe("runSceneEmbeddingBackfill", () => {
     ])
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       locales: ["en", "es"],
     })
 
@@ -81,7 +81,7 @@ describe("runSceneEmbeddingBackfill", () => {
     ])
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       coreIds: ["core-b"],
       locales: ["en"],
     })
@@ -101,7 +101,7 @@ describe("runSceneEmbeddingBackfill", () => {
     ])
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       locales: ["en"],
     })
 
@@ -121,7 +121,7 @@ describe("runSceneEmbeddingBackfill", () => {
     )
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       locales: ["en"],
     })
 
@@ -144,7 +144,7 @@ describe("runSceneEmbeddingBackfill", () => {
     )
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       locales: ["en"],
     })
 
@@ -171,7 +171,7 @@ describe("runSceneEmbeddingBackfill", () => {
       })
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       locales: ["en"],
     })
 
@@ -187,7 +187,7 @@ describe("runSceneEmbeddingBackfill", () => {
     ])
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       coreIds: [],
       locales: ["en"],
     })
@@ -201,7 +201,7 @@ describe("runSceneEmbeddingBackfill", () => {
     ])
 
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       locales: [],
     })
 
@@ -213,7 +213,7 @@ describe("runSceneEmbeddingBackfill", () => {
   it("returns an empty report when the DB has no editions", async () => {
     ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([])
     const report = await runSceneEmbeddingBackfill({
-      mappingPath: "/tmp/mapping.json",
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
       locales: ["en"],
     })
     expect(report.totalTargets).toBe(0)

--- a/apps/admin/src/workflows/sceneEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/sceneEmbeddingBackfill.ts
@@ -33,8 +33,8 @@ const SYSTEM_PRINCIPAL = {
 const DEFAULT_LOCALES = ["en", "es", "fr"] as const
 
 export type SceneEmbeddingBackfillInput = {
-  /** Absolute path to the JSON mapping file dumped from cms. */
-  mappingPath: string
+  /** S3 key of the JSON mapping snapshot uploaded via the admin refresh CLI. */
+  mappingS3Key: string
   /** Restrict to these coreIds. Omitted = all mapped videos. */
   coreIds?: readonly string[]
   /** Restrict to these locales. Omitted = en/es/fr. */
@@ -87,7 +87,7 @@ export async function runSceneEmbeddingBackfill(
 ): Promise<SceneEmbeddingBackfillReport> {
   "use workflow"
 
-  const mapping = await stepLoadMapping(input.mappingPath)
+  const mapping = await stepLoadMapping(input.mappingS3Key)
   // Treat length-0 arrays as "omitted" so a GraphQL caller who accidentally
   // passes `coreIds: []` / `locales: []` doesn't silently run zero work with
   // a success-shaped report. Matches the mutation description's "Omitted =
@@ -115,9 +115,9 @@ export async function runSceneEmbeddingBackfill(
   })
 }
 
-async function stepLoadMapping(path: string): Promise<CoreIdMapping> {
+async function stepLoadMapping(s3Key: string): Promise<CoreIdMapping> {
   "use step"
-  return loadCoreIdMapping(path)
+  return loadCoreIdMapping(s3Key)
 }
 
 async function stepEnumerateTargets(

--- a/docs/handoffs/2026-04-20-admin-railway-provisioning-handoff.md
+++ b/docs/handoffs/2026-04-20-admin-railway-provisioning-handoff.md
@@ -223,24 +223,18 @@ elsewhere (build hook instead of start command), follow his guidance.
 
 ### Step 6 — Smoke-test R1
 
-1. From local dev, dump the cms mapping:
-   `pnpm --filter @forge/cms dump:core-id-mapping > .tmp/core-id-mapping.json`
-2. Upload to admin's artifact dir OR keep local if invoking backfill
-   from a shell on the admin instance (deferred: the mutation accepts
-   an absolute path, so whichever matches `ADMIN_ARTIFACT_DIR`).
-3. Authenticate as an ADMIN principal (Better Auth login as an admin
+1. Refresh the coreId mapping into shared Railway S3:
+   `pnpm --filter @forge/admin refresh:core-id-mapping`. The CLI dumps
+   from cms and uploads to `admin-migrations/core-id-mapping.json`.
+2. Authenticate as an ADMIN principal (Better Auth login as an admin
    user; seed one if none exists).
-4. Invoke:
+3. Invoke (mappingS3Key defaults to the canonical snapshot):
    ```graphql
    mutation {
-     triggerSceneEmbeddingBackfill(
-       mappingPath: "/tmp/core-id-mapping/core-id-mapping.json"
-       coreIds: ["<pick one>"]
-       locales: ["en"]
-     )
+     triggerSceneEmbeddingBackfill(coreIds: ["<pick one>"], locales: ["en"])
    }
    ```
-5. Confirm:
+4. Confirm:
    - Response JSON shows `succeeded: 1`, `failed: 0`.
    - `SELECT COUNT(*) FROM video_scene_locale WHERE embedding IS NOT NULL`
      matches the scene count from that video's artifact.

--- a/docs/plans/2026-04-21-002-fix-admin-workflow-dispatch-plan.md
+++ b/docs/plans/2026-04-21-002-fix-admin-workflow-dispatch-plan.md
@@ -200,7 +200,7 @@ unit tests.
   - Existing mutation shape and permission gating in `apps/admin/src/graphql/mutations/scene-embedding.ts`.
 
   **Test scenarios:**
-  - Dispatch happy path: `start` is called exactly once with `runSceneEmbeddingBackfill` (identity reference) and an args array whose first element matches `{mappingPath, coreIds?, locales?}`. The mocked `Run.returnValue` resolves to a stub report; the resolver returns that report verbatim.
+  - Dispatch happy path: `start` is called exactly once with `runSceneEmbeddingBackfill` (identity reference) and an args array whose first element matches `{mappingS3Key, coreIds?, locales?}`. The mocked `Run.returnValue` resolves to a stub report; the resolver returns that report verbatim.
   - Arg pass-through for optional fields: null/undefined `coreIds` / `locales` collapse to `undefined` in the forwarded args (matches existing behavior).
   - Workflow rejection: `run.returnValue` rejects with a synthetic error → resolver propagates (GraphQL Yoga masks in prod; test just asserts rejection, not masked string).
   - ADMIN-only gating: unauthenticated / non-ADMIN caller fails before `start` is invoked (mock not called).

--- a/docs/roadmap/platform/feat-104-admin-railway-provisioning.md
+++ b/docs/roadmap/platform/feat-104-admin-railway-provisioning.md
@@ -122,26 +122,23 @@ guidance.
 
 ### R1 smoke test
 
-1. Dump cms mapping locally:
+1. Refresh the coreId mapping into the shared Railway S3 bucket:
    ```
-   pnpm --filter @forge/cms dump:core-id-mapping > .tmp/core-id-mapping.json
+   pnpm --filter @forge/admin refresh:core-id-mapping
    ```
-2. Upload mapping to admin's `ADMIN_ARTIFACT_DIR` (or invoke from a
-   shell on the admin instance with the local absolute path).
-3. Authenticate as an ADMIN principal (Better Auth login; seed via
+   The CLI dumps from cms and uploads the snapshot to
+   `admin-migrations/core-id-mapping.json`.
+2. Authenticate as an ADMIN principal (Better Auth login; seed via
    `UPDATE user SET role = 'ADMIN' WHERE email = '...'` if no admin
    exists).
-4. Invoke:
+3. Invoke (mappingS3Key defaults to the canonical snapshot — omit unless
+   running a dry run with an alt snapshot):
    ```graphql
    mutation {
-     triggerSceneEmbeddingBackfill(
-       mappingPath: "/tmp/core-id-mapping/core-id-mapping.json"
-       coreIds: ["<pick one>"]
-       locales: ["en"]
-     )
+     triggerSceneEmbeddingBackfill(coreIds: ["<pick one>"], locales: ["en"])
    }
    ```
-5. Confirm:
+4. Confirm:
    - Response shows `succeeded: 1`, `failed: 0`.
    - `SELECT COUNT(*) FROM video_scene_locale WHERE embedding IS NOT NULL`
      equals the scene count from that video's artifact.

--- a/docs/solutions/best-practices/review-fix-round-2-sibling-call-site-regressions-20260421.md
+++ b/docs/solutions/best-practices/review-fix-round-2-sibling-call-site-regressions-20260421.md
@@ -1,0 +1,220 @@
+---
+title: Round 2 of ce:review catches sibling-call-site regressions and self-coverage gaps that round-1 fixes leave behind
+date: 2026-04-21
+category: best-practices
+problem_type: best_practice
+component: development_workflow
+root_cause: missing_workflow_step
+resolution_type: workflow_improvement
+severity: medium
+tags:
+  [
+    ce-review,
+    review-fix-loop,
+    sibling-call-sites,
+    regression-prevention,
+    test-coverage,
+    compound-engineering,
+  ]
+---
+
+## Problem
+
+When a code-review round fixes a bug **class** — "unbounded timeout on
+the S3 client", "misclassify config errors as operator-fault", "unguarded
+`Number(process.env...)` parse" — the same class usually recurs at
+sibling call sites the reviewer never cited, and the fix itself typically
+adds new branches that no test exercises. A single-round review declares
+victory when CI goes green, even though both regressions and coverage
+gaps cluster exactly in the just-changed code.
+
+## Symptoms
+
+- CI is green after round-1 fixes land; reviewers mark findings
+  "applied".
+- Round 2 (or worse, production) surfaces the **same** bug class at a
+  sibling site.
+- The fix commit's new branches (prod fail-fast, new env parse, new SDK
+  handler wiring) have zero tests pinning them.
+
+Concrete example from PR #819 (JesusFilm/forge, 2026-04-21):
+
+| Round 1 fix                                                                                                                                | Round 2 found                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| F17: added `NodeHttpHandler({ connectionTimeout: 5_000, requestTimeout: 30_000 })` to `apps/admin/src/storage/s3.ts::getS3()`.             | F20: `apps/admin/src/scripts/refresh-core-id-mapping.ts::uploadToS3` constructs its own inline `new S3Client({ ... })` with no `requestHandler`. Operator-run CLI pointed at a stalled Railway endpoint would hang indefinitely.                                                                                                     |
+| F1: replaced a brittle message regex in `isStorageMissingError` with typed `name` / `code` checks PLUS `$metadata.httpStatusCode === 404`. | F22: the bare-404 check matches `NoSuchBucket` (config error) as well as `NoSuchKey` (really missing). A misconfigured bucket gets reported as `mapping_missing`, telling the operator "re-run the refresh CLI" instead of "page platform". Same class of "misclassify config error as operator-fault" bug round 1 was meant to fix. |
+| F2: added `const DUMP_TIMEOUT_MS = Number(process.env.DUMP_TIMEOUT_MS ?? 10 * 60 * 1000)` + SIGTERM / SIGKILL escalation.                  | F21: `Number("10m") === NaN`, and `setTimeout(NaN)` coerces to ~1ms. Every dump SIGTERMs instantly with "cms dump exceeded NaNms; sent SIGTERM".                                                                                                                                                                                     |
+| F17 + F2 + F4 added new branches (timeouts, prod fail-fast, escalation timer).                                                             | F23 / F24 / F29: none of the new branches had dedicated tests — the fix existed but was not pinned.                                                                                                                                                                                                                                  |
+
+## What Didn't Work
+
+- **Single-round review with the always-on personas.** Round 1 cited
+  the sites it saw; it did not rescan the diff for new-branch coverage
+  or for sibling construction sites.
+- **Relying on TypeScript to catch omissions.** Both S3 clients
+  type-check fine — `requestHandler` is optional. Omitting it is a
+  runtime / operational bug invisible to the compiler. Same for
+  `Number("10m")` returning `NaN`: the type is still `number`.
+- **Searching by file path only.** F17 was identified as a
+  `storage/s3.ts` problem, so the fix stayed there. The sibling in
+  `scripts/refresh-core-id-mapping.ts` only surfaces when you search by
+  **pattern** (`new S3Client(`), not by file.
+- **Re-running the same round-1 reviewer prompt over the full PR.** It
+  re-finds the originals and misses the regressions that were
+  introduced **by** the fixes.
+
+## Solution
+
+Two-part process addition. Adopt both; either alone misses the other
+class of gap.
+
+### (1) Before marking any round-1 finding "applied": grep for sibling call sites of the pattern
+
+The reviewer cites one site. The fix belongs at every site of that
+pattern. A few seconds of `rg` catches what the reviewer's scope didn't.
+
+```bash
+# Before calling F17 "applied", search for every S3Client construction:
+rg -n 'new S3Client\(' apps/ packages/
+# Would have caught apps/admin/src/scripts/refresh-core-id-mapping.ts::uploadToS3.
+
+# Before calling F1 "applied", search for every HTTP-status classifier:
+rg -n 'httpStatusCode\s*===\s*404|statusCode\s*===\s*404' apps/ packages/
+
+# Before calling the DUMP_TIMEOUT_MS fix "applied", search for other
+# bare Number(process.env...) parses that could hit the same NaN trap:
+rg -n 'Number\(process\.env\.' apps/ packages/
+
+# General "timeout wired at construction" sites:
+rg -n 'setTimeout\([^,]+,\s*[A-Z_]+\)' apps/ packages/
+```
+
+If a sibling turns up, fix it in the same commit as the primary finding,
+or open an explicit sibling-finding in the review report. PR #819's
+round-2 report did this with F20, F21, F22.
+
+### (2) After round-1 fixes land: run round 2 scoped to the fix-commit diff, not the full PR
+
+```bash
+# round1_commit = commit before fixes were applied (e.g. 19c82e8 for PR #819)
+# fix_commit    = HEAD after round-1 fixes landed (e.g. 93cb17b for PR #819)
+git diff -U10 ${round1_commit}..${fix_commit} -- 'apps/admin/**' \
+  > /tmp/round2-scope.diff
+wc -l /tmp/round2-scope.diff
+```
+
+Feed that narrower diff to the round-2 reviewers with a prompt that
+explicitly reframes the question:
+
+```
+Round 2 review of PR #XXX. Scope is ONLY the diff between the round-1
+commit <SHA_A> and the fix commit <SHA_B>, at /tmp/round2-scope.diff.
+
+Focus on:
+- Does every new branch in this diff have a test that exercises it?
+- Does the pattern fixed here recur at any sibling site outside this diff?
+- Did the fix itself introduce a new bug class (NaN env parse, overly
+  broad classifier, missing timeout on a sibling client)?
+```
+
+This is exactly what PR #819 round 2 did. Five reviewers scoped to the
+round-1 fix diff (~1000 lines) produced F20 / F21 / F22 plus
+coverage-gap findings F23 / F24 / F29 — each one a regression or
+coverage hole introduced **by** the round-1 fixes, not present in the
+original PR.
+
+## Why This Works
+
+- **Cheap.** A scoped round 2 is an hour or two; a full-PR re-review is
+  half a day and produces noise from re-finding round-1 originals.
+- **High signal.** The diff is exactly where new bugs were introduced.
+  Everything outside it was already reviewed in round 1.
+- **Maps to the skill's conventions.** `ce:review` already ships with
+  `max_rounds: 2`; this gives round 2 a concrete scope and prompt
+  instead of "run it again and see".
+- **Catches both failure modes in one pass.** Sibling-site regressions
+  (F20, F22) and self-coverage gaps (F23, F24, F29) cluster in the same
+  place: the fix diff and its immediate neighbors.
+
+## Prevention
+
+### Checklist when applying any review finding
+
+Before marking a finding "applied":
+
+- **(a) Grep for sibling call sites of the pattern.** Examples adjusted
+  per finding:
+
+  ```bash
+  rg -n 'new S3Client\('                       # client-construction siblings
+  rg -n 'httpStatusCode\s*===\s*\d{3}'          # status-code classifiers
+  rg -n 'Number\(process\.env\.'                # unguarded env-number parses
+  rg -n 'setTimeout\([^,]+,\s*[A-Z_]+\)'        # timeout wiring sites
+  ```
+
+  If a sibling matches, fix it or explicitly defer it in the same PR.
+
+- **(b) Verify the fix has a test that exercises its own new branch.**
+  Not the scenario that motivated the fix — the **branch** the fix
+  added. Examples from PR #819 round 2:
+  - F17 added `NodeHttpHandler` wiring → new test asserts the handler
+    is constructed with `{ connectionTimeout: 5_000, requestTimeout:
+30_000 }` and that the `S3Client` config carries it.
+  - `parseTimeoutMs` → test feeds `"10m"`, asserts fallback + stderr
+    warning.
+  - `isStorageMissingError` tightening → test pins `NoSuchBucket`
+    (404 + `name: "NoSuchBucket"`) as `mapping_read_failed`, not
+    `mapping_missing`.
+
+- **(c) Run round 2 scoped to the fix-commit diff, not the full PR.**
+
+  ```bash
+  git diff -U10 ${round1_commit}..${fix_commit} -- 'apps/admin/**' \
+    | tee /tmp/round2-scope.diff
+  ```
+
+  Give the reviewer prompt the scope explicitly, and ask the
+  narrow-question set from Solution (2) above — not the broad "review
+  this PR" prompt that re-finds round-1 originals.
+
+### Why we don't try to catch this statically
+
+We could add a codegen step or a structural lint to detect "two
+`S3Client` constructions in one app", but (a) the pattern is
+finding-specific (today S3 clients, tomorrow something else), and
+(b) the fix is cheap: a few `rg` lines per finding plus a scoped
+round-2 diff. Investment in tooling only pays off once the same class
+of miss happens a third time.
+
+### Carry-forward
+
+- The review-fix preference in `~/.claude/projects/-workspace/memory/feedback_review_fix_loop.md`
+  (auto memory [claude]) — "apply gated_auto fixes when verifiable" —
+  still holds. The round-2 additions here are complementary: round 1
+  applies the verifiable fixes aggressively; round 2 verifies that the
+  fixes themselves didn't regress.
+- The `ce:review` skill's persona selection for round 2 should narrow
+  to reviewers whose bar is most relevant to the round-1 fix diff
+  (correctness, testing, reliability, the stack-specific persona, plus
+  security if any boundary shifted). Agent-native, maintainability,
+  api-contract, learnings-researcher usually do not need to re-run on a
+  fix diff — their round-1 output is still valid for the broader PR.
+
+## Related
+
+- `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md`
+  — nearest prevention primitive (its "Grep check" step lists every
+  consumer of a `"use workflow"` function before shipping). Different
+  root cause (directive inert in tests), same shape of "find every site
+  of the pattern before declaring the fix done".
+- `docs/solutions/best-practices/verify-infra-writes-via-independent-read-path-20260420.md`
+  — meta-pattern about ACK-looks-green-but-prod-disagrees. The
+  round-2-scoped review is the code-review analogue of
+  verify-via-independent-read.
+- `docs/solutions/developer-experience/env-matrix-drift-from-runtime-requirements-20260421.md`
+  — same incident family (plan / review didn't catch what prod did),
+  different remedy (derive env from code).
+- `docs/solutions/best-practices/parallel-workflow-error-robustness-20260420.md`
+  — another learning surfaced during an earlier `ce:review` loop on
+  R1; scoped to typed-error classification, not the review process.
+- PR #819 round-1 fix commit `93cb17b`, round-2 fix commit `4724707`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,7 +156,7 @@ importers:
         version: 4.2.2
       better-auth:
         specifier: 1.6.2
-        version: 1.6.2(@opentelemetry/api@1.9.0)(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@6.19.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.6.2(@opentelemetry/api@1.9.0)(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@6.19.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       dataloader:
         specifier: 2.2.3
         version: 2.2.3
@@ -200,6 +200,12 @@ importers:
       '@aws-sdk/client-s3':
         specifier: 3.1030.0
         version: 3.1030.0
+      '@smithy/node-http-handler':
+        specifier: 4.4.14
+        version: 4.4.14
+      '@types/node':
+        specifier: ^22
+        version: 22.19.15
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -217,7 +223,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/cms:
     dependencies:
@@ -5208,10 +5214,6 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@smithy/abort-controller@4.2.11':
-    resolution: {integrity: sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/abort-controller@4.2.12':
     resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
     engines: {node: '>=18.0.0'}
@@ -5476,10 +5478,6 @@ packages:
     resolution: {integrity: sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.5.0':
-    resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.5.2':
     resolution: {integrity: sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==}
     engines: {node: '>=18.0.0'}
@@ -5506,14 +5504,6 @@ packages:
 
   '@smithy/protocol-http@5.3.13':
     resolution: {integrity: sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.2.11':
-    resolution: {integrity: sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.2.12':
-    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-builder@4.2.13':
@@ -16023,7 +16013,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.15
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.5.0
+      '@smithy/node-http-handler': 4.5.2
       '@smithy/protocol-http': 5.3.12
       '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
@@ -16203,7 +16193,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.17
       '@smithy/middleware-stack': 4.2.13
       '@smithy/node-config-provider': 4.3.13
-      '@smithy/node-http-handler': 4.5.2
+      '@smithy/node-http-handler': 4.4.14
       '@smithy/protocol-http': 5.3.13
       '@smithy/smithy-client': 4.12.9
       '@smithy/types': 4.14.0
@@ -16246,10 +16236,10 @@ snapshots:
       '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.11
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/signature-v4': 5.3.11
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-utf8': 4.2.2
@@ -16262,10 +16252,10 @@ snapshots:
       '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/signature-v4': 5.3.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-utf8': 4.2.2
@@ -16289,12 +16279,12 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.4':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/crc64-nvme@3.972.6':
@@ -16307,7 +16297,7 @@ snapshots:
       '@aws-sdk/core': 3.973.24
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.22':
@@ -16315,7 +16305,7 @@ snapshots:
       '@aws-sdk/core': 3.973.24
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.25':
@@ -16331,11 +16321,11 @@ snapshots:
       '@aws-sdk/core': 3.973.24
       '@aws-sdk/types': 3.973.7
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.0
+      '@smithy/node-http-handler': 4.4.14
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
@@ -16344,11 +16334,11 @@ snapshots:
       '@aws-sdk/core': 3.973.24
       '@aws-sdk/types': 3.973.7
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.0
+      '@smithy/node-http-handler': 4.5.2
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
@@ -16379,7 +16369,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16398,7 +16388,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16473,7 +16463,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.11
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16490,7 +16480,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16518,7 +16508,7 @@ snapshots:
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.22':
@@ -16527,7 +16517,7 @@ snapshots:
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.25':
@@ -16547,7 +16537,7 @@ snapshots:
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16560,7 +16550,7 @@ snapshots:
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16597,7 +16587,7 @@ snapshots:
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16609,7 +16599,7 @@ snapshots:
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16642,8 +16632,8 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
@@ -16652,8 +16642,8 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
@@ -16670,15 +16660,15 @@ snapshots:
   '@aws-sdk/middleware-expect-continue@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-expect-continue@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-expect-continue@3.972.9':
@@ -16698,8 +16688,8 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
@@ -16715,8 +16705,8 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
@@ -16742,15 +16732,15 @@ snapshots:
   '@aws-sdk/middleware-host-header@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.9':
@@ -16763,13 +16753,13 @@ snapshots:
   '@aws-sdk/middleware-location-constraint@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-location-constraint@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-location-constraint@3.972.9':
@@ -16781,13 +16771,13 @@ snapshots:
   '@aws-sdk/middleware-logger@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.9':
@@ -16808,16 +16798,16 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@aws/lambda-invoke-store': 0.2.3
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@aws/lambda-invoke-store': 0.2.3
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.0':
@@ -16827,10 +16817,10 @@ snapshots:
       '@aws-sdk/util-arn-parser': 3.972.0
       '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/signature-v4': 5.3.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.20
@@ -16844,10 +16834,10 @@ snapshots:
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/signature-v4': 5.3.11
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.20
@@ -16861,10 +16851,10 @@ snapshots:
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/signature-v4': 5.3.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.20
@@ -16891,13 +16881,13 @@ snapshots:
   '@aws-sdk/middleware-ssec@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-ssec@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-ssec@3.972.9':
@@ -16912,8 +16902,8 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@smithy/core': 3.23.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.25':
@@ -16922,8 +16912,8 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@smithy/core': 3.23.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
@@ -17049,7 +17039,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.17
       '@smithy/middleware-stack': 4.2.13
       '@smithy/node-config-provider': 4.3.13
-      '@smithy/node-http-handler': 4.5.2
+      '@smithy/node-http-handler': 4.4.14
       '@smithy/protocol-http': 5.3.13
       '@smithy/smithy-client': 4.12.9
       '@smithy/types': 4.14.0
@@ -17080,7 +17070,7 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/config-resolver': 4.4.13
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.972.9':
@@ -17088,7 +17078,7 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/config-resolver': 4.4.13
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/s3-request-presigner@3.1015.0':
@@ -17117,9 +17107,9 @@ snapshots:
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.0
       '@aws-sdk/types': 3.972.0
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/signature-v4': 5.3.11
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.995.0':
@@ -17135,9 +17125,9 @@ snapshots:
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.24
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/signature-v4': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.16':
@@ -17187,7 +17177,7 @@ snapshots:
 
   '@aws-sdk/types@3.972.0':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.1':
@@ -17197,12 +17187,12 @@ snapshots:
 
   '@aws-sdk/types@3.973.5':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.6':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.7':
@@ -17221,7 +17211,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.972.0':
     dependencies:
       '@aws-sdk/types': 3.972.0
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.12
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
@@ -17237,7 +17227,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.996.5':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.12
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
@@ -17253,8 +17243,8 @@ snapshots:
   '@aws-sdk/util-format-url@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -17264,14 +17254,14 @@ snapshots:
   '@aws-sdk/util-user-agent-browser@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       bowser: 2.14.1
       tslib: 2.8.1
 
@@ -17287,7 +17277,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.972.25
       '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
@@ -17305,7 +17295,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.972.25
       '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.0':
@@ -17316,13 +17306,13 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.10':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       fast-xml-parser: 5.5.7
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.15':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       fast-xml-parser: 5.5.7
       tslib: 2.8.1
 
@@ -19853,6 +19843,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.33
 
+  '@inquirer/confirm@5.1.21(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+    optional: true
+
   '@inquirer/confirm@5.1.21(@types/node@25.2.3)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.2.3)
@@ -19872,6 +19870,20 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 20.19.33
+
+  '@inquirer/core@10.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+    optional: true
 
   '@inquirer/core@10.3.2(@types/node@25.2.3)':
     dependencies:
@@ -19978,6 +19990,11 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@20.19.33)':
     optionalDependencies:
       '@types/node': 20.19.33
+
+  '@inquirer/type@3.0.10(@types/node@22.19.15)':
+    optionalDependencies:
+      '@types/node': 22.19.15
+    optional: true
 
   '@inquirer/type@3.0.10(@types/node@25.2.3)':
     optionalDependencies:
@@ -22017,14 +22034,9 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@smithy/abort-controller@4.2.11':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/abort-controller@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/chunked-blob-reader-native@4.2.3':
@@ -22039,7 +22051,7 @@ snapshots:
   '@smithy/config-resolver@4.4.10':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
@@ -22048,7 +22060,7 @@ snapshots:
   '@smithy/config-resolver@4.4.13':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
@@ -22065,8 +22077,8 @@ snapshots:
 
   '@smithy/core@3.23.12':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -22092,8 +22104,8 @@ snapshots:
   '@smithy/core@3.23.8':
     dependencies:
       '@smithy/middleware-serde': 4.2.15
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-middleware': 4.2.12
@@ -22106,7 +22118,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.12
       tslib: 2.8.1
 
@@ -22114,7 +22126,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.12
       tslib: 2.8.1
 
@@ -22150,13 +22162,13 @@ snapshots:
   '@smithy/eventstream-serde-browser@4.2.11':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.11
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.2.12':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.2.13':
@@ -22167,12 +22179,12 @@ snapshots:
 
   '@smithy/eventstream-serde-config-resolver@4.3.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-config-resolver@4.3.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-config-resolver@4.3.13':
@@ -22183,13 +22195,13 @@ snapshots:
   '@smithy/eventstream-serde-node@4.2.11':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.11
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-node@4.2.12':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-node@4.2.13':
@@ -22201,13 +22213,13 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.2.11':
     dependencies:
       '@smithy/eventstream-codec': 4.2.11
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-universal@4.2.12':
     dependencies:
       '@smithy/eventstream-codec': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-universal@4.2.13':
@@ -22218,17 +22230,17 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.3.13':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.11
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.15':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
@@ -22244,14 +22256,14 @@ snapshots:
     dependencies:
       '@smithy/chunked-blob-reader': 5.2.2
       '@smithy/chunked-blob-reader-native': 4.2.3
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.13':
     dependencies:
       '@smithy/chunked-blob-reader': 5.2.2
       '@smithy/chunked-blob-reader-native': 4.2.3
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.14':
@@ -22263,14 +22275,14 @@ snapshots:
 
   '@smithy/hash-node@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/hash-node@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
@@ -22284,13 +22296,13 @@ snapshots:
 
   '@smithy/hash-stream-node@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/hash-stream-node@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -22302,12 +22314,12 @@ snapshots:
 
   '@smithy/invalid-dependency@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.13':
@@ -22325,13 +22337,13 @@ snapshots:
 
   '@smithy/md5-js@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/md5-js@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -22343,14 +22355,14 @@ snapshots:
 
   '@smithy/middleware-content-length@4.2.11':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.12':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.13':
@@ -22365,7 +22377,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.15
       '@smithy/node-config-provider': 4.3.12
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.12
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
@@ -22376,7 +22388,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.15
       '@smithy/node-config-provider': 4.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.12
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
@@ -22395,10 +22407,10 @@ snapshots:
   '@smithy/middleware-retry@4.4.39':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/service-error-classification': 4.2.11
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.12
       '@smithy/uuid': 1.1.2
@@ -22407,10 +22419,10 @@ snapshots:
   '@smithy/middleware-retry@4.4.44':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.13
       '@smithy/service-error-classification': 4.2.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.12
       '@smithy/uuid': 1.1.2
@@ -22431,15 +22443,15 @@ snapshots:
 
   '@smithy/middleware-serde@4.2.12':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.15':
     dependencies:
       '@smithy/core': 3.23.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.17':
@@ -22451,12 +22463,12 @@ snapshots:
 
   '@smithy/middleware-stack@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.13':
@@ -22468,14 +22480,14 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.12':
     dependencies:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.13':
@@ -22487,18 +22499,10 @@ snapshots:
 
   '@smithy/node-http-handler@4.4.14':
     dependencies:
-      '@smithy/abort-controller': 4.2.11
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.11
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.5.0':
-    dependencies:
       '@smithy/abort-controller': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.5.2':
@@ -22510,12 +22514,12 @@ snapshots:
 
   '@smithy/property-provider@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/property-provider@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/property-provider@4.2.13':
@@ -22525,29 +22529,17 @@ snapshots:
 
   '@smithy/protocol-http@5.3.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.13':
     dependencies:
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.11':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-uri-escape': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.13':
@@ -22558,12 +22550,12 @@ snapshots:
 
   '@smithy/querystring-parser@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.13':
@@ -22573,11 +22565,11 @@ snapshots:
 
   '@smithy/service-error-classification@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
 
   '@smithy/service-error-classification@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
 
   '@smithy/service-error-classification@4.2.13':
     dependencies:
@@ -22585,12 +22577,12 @@ snapshots:
 
   '@smithy/shared-ini-file-loader@4.4.6':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.7':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.8':
@@ -22601,8 +22593,8 @@ snapshots:
   '@smithy/signature-v4@5.3.11':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-uri-escape': 4.2.2
@@ -22612,8 +22604,8 @@ snapshots:
   '@smithy/signature-v4@5.3.12':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-uri-escape': 4.2.2
@@ -22636,8 +22628,8 @@ snapshots:
       '@smithy/core': 3.23.12
       '@smithy/middleware-endpoint': 4.4.27
       '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
@@ -22646,8 +22638,8 @@ snapshots:
       '@smithy/core': 3.23.12
       '@smithy/middleware-endpoint': 4.4.27
       '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
@@ -22676,13 +22668,13 @@ snapshots:
   '@smithy/url-parser@4.2.11':
     dependencies:
       '@smithy/querystring-parser': 4.2.11
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/url-parser@4.2.12':
     dependencies:
       '@smithy/querystring-parser': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/url-parser@4.2.13':
@@ -22723,14 +22715,14 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.11
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.43':
     dependencies:
       '@smithy/property-provider': 4.2.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.45':
@@ -22747,7 +22739,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.11
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.47':
@@ -22757,7 +22749,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.50':
@@ -22773,13 +22765,13 @@ snapshots:
   '@smithy/util-endpoints@3.3.2':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.3.3':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.4.0':
@@ -22794,12 +22786,12 @@ snapshots:
 
   '@smithy/util-middleware@4.2.11':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-middleware@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-middleware@4.2.13':
@@ -22810,13 +22802,13 @@ snapshots:
   '@smithy/util-retry@4.2.11':
     dependencies:
       '@smithy/service-error-classification': 4.2.11
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-retry@4.2.12':
     dependencies:
       '@smithy/service-error-classification': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-retry@4.3.1':
@@ -22828,8 +22820,8 @@ snapshots:
   '@smithy/util-stream@4.5.17':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.0
-      '@smithy/types': 4.13.1
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -22839,8 +22831,8 @@ snapshots:
   '@smithy/util-stream@4.5.20':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.0
-      '@smithy/types': 4.13.1
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -22874,14 +22866,14 @@ snapshots:
 
   '@smithy/util-waiter@4.2.11':
     dependencies:
-      '@smithy/abort-controller': 4.2.11
-      '@smithy/types': 4.13.1
+      '@smithy/abort-controller': 4.2.12
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-waiter@4.2.13':
     dependencies:
       '@smithy/abort-controller': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-waiter@4.2.15':
@@ -22913,7 +22905,7 @@ snapshots:
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.14)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.42.1
-      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.42.1
       '@strapi/utils': 5.42.1
       '@testing-library/dom': 10.4.1
@@ -23112,7 +23104,7 @@ snapshots:
       '@strapi/database': 5.42.1(@types/node@20.19.33)(pg@8.18.0)
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.14)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/utils': 5.42.1
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -23213,7 +23205,7 @@ snapshots:
       '@strapi/generators': 5.42.1(@types/node@20.19.33)
       '@strapi/logger': 5.42.1
       '@strapi/permissions': 5.42.1
-      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.42.1
       '@strapi/utils': 5.42.1
       '@vercel/stega': 0.1.2
@@ -23670,7 +23662,7 @@ snapshots:
       '@strapi/openapi': 5.42.1
       '@strapi/permissions': 5.42.1
       '@strapi/review-workflows': 5.42.1(agzlmvar2icootkpsj6id3d3cq)
-      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.42.1
       '@strapi/upload': 5.42.1(rihswvylh7zb5l23z2knuzrf3i)
       '@strapi/utils': 5.42.1
@@ -23774,36 +23766,6 @@ snapshots:
       - webpack-dev-server
       - webpack-plugin-serve
       - yaml
-
-  '@strapi/types@5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.4.4)':
-    dependencies:
-      '@casl/ability': 6.7.5
-      '@koa/cors': 5.0.0
-      '@koa/router': 12.0.2
-      '@strapi/database': 5.42.1(@types/node@20.19.33)(pg@8.18.0)
-      '@strapi/logger': 5.42.1
-      '@strapi/permissions': 5.42.1
-      '@strapi/utils': 5.42.1
-      commander: 8.3.0
-      json-logic-js: 2.0.5
-      koa: 2.16.4
-      koa-body: 6.0.1
-      node-schedule: 2.1.1
-      typedoc: 0.25.10(typescript@5.4.4)
-      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
-      zod: 3.25.67
-    transitivePeerDependencies:
-      - '@types/node'
-      - better-sqlite3
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-      - typescript
 
   '@strapi/types@5.42.1(@types/node@20.19.33)(pg@8.18.0)(typescript@5.9.3)':
     dependencies:
@@ -24952,6 +24914,15 @@ snapshots:
       msw: 2.12.10(@types/node@20.19.33)(typescript@5.9.3)
       vite: 6.4.2(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@22.19.15)(typescript@5.9.3)
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@6.4.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -26002,7 +25973,7 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
-  better-auth@1.6.2(@opentelemetry/api@1.9.0)(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@6.19.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+  better-auth@1.6.2(@opentelemetry/api@1.9.0)(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@6.19.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
@@ -26028,7 +25999,7 @@ snapshots:
       prisma: 6.19.3(typescript@5.9.3)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -27497,7 +27468,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
@@ -27513,7 +27484,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -27550,7 +27521,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -27574,7 +27545,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -31996,6 +31967,32 @@ snapshots:
       - '@types/node'
     optional: true
 
+  msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.15)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.1
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.4.4
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@25.2.3)
@@ -35147,14 +35144,6 @@ snapshots:
       handlebars: 4.7.9
       typedoc: 0.25.10(typescript@5.9.3)
 
-  typedoc@0.25.10(typescript@5.4.4):
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.7
-      shiki: 0.14.7
-      typescript: 5.4.4
-
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:
       lunr: 2.3.9
@@ -35533,6 +35522,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
@@ -35564,6 +35574,23 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.33
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      terser: 5.46.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rollup: 4.60.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -35616,6 +35643,49 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.33
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.19.15
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Summary

Unblocks R1 scene-embedding full smoke on Railway. The prior `mappingPath: String!` input to `triggerSceneEmbeddingBackfill` assumed a filesystem file lived beside the running instance — fine for local dev, impossible on ephemeral Railway containers.

- `core-id-mapping.service.ts` now reads from S3 via a new `storage/s3.ts` `readObject(key)` helper (sibling to the existing artifact API). Removes the `ADMIN_ARTIFACT_DIR` allowlist and `mapping_path_rejected` error code — bucket scope is the new boundary.
- `triggerSceneEmbeddingBackfill` arg becomes `mappingS3Key: String = "admin-migrations/core-id-mapping.json"` — common invocation is now zero-arg.
- `pnpm --filter @forge/admin refresh:core-id-mapping` dumps from cms (via the existing cms script) and uploads the snapshot to S3, so post-refresh is one command.

## Test plan

- [x] `pnpm --filter @forge/admin test` — 519 tests green (incl. new S3 object-key coverage + NoSuchKey path in the mapping loader)
- [x] `pnpm --filter @forge/admin typecheck`
- [x] `pnpm --filter @forge/admin lint`
- [x] Dispatch test (`wrapStartSpy<T>()`) still guards the mutation
- [ ] Post-merge: run `pnpm --filter @forge/admin refresh:core-id-mapping` locally against prod creds, then invoke `triggerSceneEmbeddingBackfill(coreIds: ["<one>"], locales: ["en"])` and verify `video_scene_locale.embedding` row count matches the artifact's scene count.

## Notes

- The default `mappingS3Key` is the same string a cms-grown-catalog refresh will overwrite, so a manual override is only needed for dry runs or alt-snapshots.
- The refresh CLI reads `RAILWAY_S3_*` directly from `process.env` rather than going through `@/config/env` — deliberate, so the CLI doesn't need admin's full env matrix (DATABASE_URL etc) populated just to upload a JSON blob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)