### PR TITLE
fix(admin): isolate refresh CLI from @/config/env transitive import

### DIFF
--- a/apps/admin/src/scripts/refresh-core-id-mapping.import-isolation.test.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.import-isolation.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression test: the refresh CLI must NOT transitively import
+ * `@/config/env` or `@/storage/s3`. The CLI deliberately bypasses the
+ * admin env validator so operators can run it with only the
+ * RAILWAY_S3_* vars populated (not DATABASE_URL, BETTER_AUTH_SECRET,
+ * etc.). A transitive pull would force the operator's terminal to
+ * carry admin's full env matrix just to upload a JSON blob.
+ *
+ * Context: the sibling-call-site / transitive-import pattern captured
+ * in docs/solutions/best-practices/review-fix-round-2-sibling-call-site-regressions-20260421.md.
+ */
+
+import { readFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const FORBIDDEN_TRANSITIVES = [
+  "@/config/env",
+  "@/storage/s3",
+  "@/services/core-id-mapping.service",
+]
+
+async function readModule(relative: string): Promise<string> {
+  return readFile(resolve(__dirname, relative), "utf8")
+}
+
+describe("refresh-core-id-mapping CLI import isolation", () => {
+  it("does not import @/config/env, @/storage/s3, or the service file directly", async () => {
+    const cli = await readModule("./refresh-core-id-mapping.ts")
+    for (const bad of FORBIDDEN_TRANSITIVES) {
+      expect(cli).not.toMatch(new RegExp(`from\\s+["']${bad}["']`))
+    }
+  })
+
+  it("imports only from the constants module (no transitive env.ts pull)", async () => {
+    const constants = await readModule(
+      "../services/core-id-mapping.constants.ts",
+    )
+    // The constants module must itself be env-free.
+    for (const bad of FORBIDDEN_TRANSITIVES) {
+      expect(constants).not.toMatch(new RegExp(`from\\s+["']${bad}["']`))
+    }
+    expect(constants).not.toMatch(/from\s+["']@\/config\/env["']/)
+    // And it must actually export the constant the CLI needs.
+    expect(constants).toMatch(/export\s+const\s+DEFAULT_CORE_ID_MAPPING_S3_KEY/)
+  })
+})
+
+describe("core-id-mapping.service re-exports constants for backward compat", () => {
+  it("still exports DEFAULT_CORE_ID_MAPPING_S3_KEY and ADMIN_MIGRATIONS_S3_PREFIX", async () => {
+    const mod = await import("@/services/core-id-mapping.service")
+    expect(mod.DEFAULT_CORE_ID_MAPPING_S3_KEY).toBe(
+      "admin-migrations/core-id-mapping.json",
+    )
+    expect(mod.ADMIN_MIGRATIONS_S3_PREFIX).toBe("admin-migrations/")
+  })
+})
+
+describe("core-id-mapping.constants is env-validator-free", () => {
+  it("can be imported without any process.env populated", async () => {
+    // If the constants file accidentally imports @/config/env again,
+    // this dynamic import would throw during env validation (CI=1 in
+    // the test env suppresses the t3-env throw, so the stronger static
+    // assertion is the source-level regex above — this test is a
+    // runtime smoke).
+    const mod = await import("@/services/core-id-mapping.constants")
+    expect(mod.DEFAULT_CORE_ID_MAPPING_S3_KEY).toBeTruthy()
+    expect(mod.ADMIN_MIGRATIONS_S3_PREFIX).toBeTruthy()
+  })
+})

--- a/apps/admin/src/scripts/refresh-core-id-mapping.ts
+++ b/apps/admin/src/scripts/refresh-core-id-mapping.ts
@@ -29,7 +29,12 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 
-import { DEFAULT_CORE_ID_MAPPING_S3_KEY } from "@/services/core-id-mapping.service"
+// Import the constant from the standalone constants module — NOT from
+// core-id-mapping.service.ts — so the CLI doesn't transitively pull in
+// @/storage/s3 → @/config/env and trip the admin env validator
+// (DATABASE_URL etc.) on operator-run invocations that only have the
+// RAILWAY_S3_* vars populated.
+import { DEFAULT_CORE_ID_MAPPING_S3_KEY } from "@/services/core-id-mapping.constants"
 
 // Ceiling for the cms dump child. A healthy dump of the whole catalog takes
 // seconds; anything over 10 minutes is almost certainly a wedge (DB hang,

--- a/apps/admin/src/services/core-id-mapping.constants.ts
+++ b/apps/admin/src/services/core-id-mapping.constants.ts
@@ -1,0 +1,27 @@
+// Standalone constants for the coreId mapping flow.
+//
+// Extracted from core-id-mapping.service.ts so that the refresh CLI
+// (apps/admin/src/scripts/refresh-core-id-mapping.ts) can import them
+// without pulling in @/storage/s3 → @/config/env. The CLI deliberately
+// bypasses the admin env validator so it can run with only the
+// RAILWAY_S3_* vars populated — not the full server env matrix
+// (DATABASE_URL, BETTER_AUTH_SECRET, etc.). A transitive import of
+// env.ts from the service file broke that contract.
+
+/**
+ * Canonical S3 key for the coreId → cms video id snapshot that the admin
+ * refresh CLI uploads. Consumed by (a) the `triggerSceneEmbeddingBackfill`
+ * Pothos defaultValue, (b) the refresh CLI's upload target, and (c) the
+ * operator runbook.
+ */
+export const DEFAULT_CORE_ID_MAPPING_S3_KEY =
+  "admin-migrations/core-id-mapping.json"
+
+/**
+ * Any S3 key handed to the mutation must live under this prefix. The
+ * bucket is shared across services (manager writes
+ * `{assetId}/scene-analysis.json` etc.); confining ADMIN-supplied keys
+ * to the admin namespace stops a compromised ADMIN session from using
+ * the mutation to enumerate other apps' objects via error-code timing.
+ */
+export const ADMIN_MIGRATIONS_S3_PREFIX = "admin-migrations/"

--- a/apps/admin/src/services/core-id-mapping.service.ts
+++ b/apps/admin/src/services/core-id-mapping.service.ts
@@ -15,24 +15,15 @@
 import { z } from "zod"
 import { readObject } from "@/storage/s3"
 
-/**
- * Canonical S3 key for the coreId → cms video id snapshot that the admin
- * refresh CLI uploads. Consumed by (a) the `triggerSceneEmbeddingBackfill`
- * Pothos defaultValue, (b) the refresh CLI's upload target, and (c) the
- * operator runbook. Keep one source of truth so the CLI and mutation can
- * never silently target different keys.
- */
-export const DEFAULT_CORE_ID_MAPPING_S3_KEY =
-  "admin-migrations/core-id-mapping.json"
-
-/**
- * Any S3 key handed to the mutation must live under this prefix. The bucket
- * is shared across services (manager writes `{assetId}/scene-analysis.json`
- * etc.); confining ADMIN-supplied keys to the admin namespace stops a
- * compromised ADMIN session from using the mutation to enumerate other
- * apps' objects via error-code timing.
- */
-export const ADMIN_MIGRATIONS_S3_PREFIX = "admin-migrations/"
+// Re-export the canonical constants so existing consumers that import
+// from the service module keep working. The refresh CLI imports from
+// `./core-id-mapping.constants` directly to avoid pulling @/storage/s3
+// → @/config/env into the CLI's runtime env matrix.
+import {
+  ADMIN_MIGRATIONS_S3_PREFIX,
+  DEFAULT_CORE_ID_MAPPING_S3_KEY,
+} from "./core-id-mapping.constants"
+export { ADMIN_MIGRATIONS_S3_PREFIX, DEFAULT_CORE_ID_MAPPING_S3_KEY }
 
 export const CoreIdMappingRowSchema = z.object({
   coreId: z.string().min(1),


### PR DESCRIPTION
## Summary

The refresh CLI's \"runs with only RAILWAY_S3_* populated\" invariant was broken by a transitive import introduced in PR #819. Discovered the moment the CLI was first run on main: it crashes at module load with `Invalid environment variables: DATABASE_URL` because importing from `core-id-mapping.service.ts` drags in `storage/s3.ts` → `config/env.ts`.

Fix:
- New leaf module `services/core-id-mapping.constants.ts` holds the two canonical constants with no storage/env imports.
- Service re-exports both for backward compat; CLI imports from the constants module directly.
- Regression test (`refresh-core-id-mapping.import-isolation.test.ts`) fails loudly if the CLI ever re-imports the env or storage modules.

## Test plan

- [x] `pnpm --filter @forge/admin test` — 547 tests green (+1 new isolation test)
- [x] `pnpm --filter @forge/admin typecheck`
- [x] `pnpm --filter @forge/admin lint`
- [x] `env -i PATH=... pnpm --filter @forge/admin refresh:core-id-mapping` runs end-to-end (dumped 2113 rows from local cms, landed local fallback)

## Why it matters

This is exactly the transitive-import / sibling-call-site class flagged in `docs/solutions/best-practices/review-fix-round-2-sibling-call-site-regressions-20260421.md` (shipped with PR #819). The import-isolation test is the branch-coverage pin that doc's checklist point (b) prescribes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)