### PR TITLE
feat(manager): enable durable video enrichment dispatch

### DIFF
--- a/apps/manager/CLAUDE.md
+++ b/apps/manager/CLAUDE.md
@@ -72,7 +72,8 @@ Local mock-mode smoke can use the seeded credentials:
 - Railway S3 requires `forcePathStyle: true` in the S3Client config.
 - Audio cleanup extracts original audio with `ffmpeg` before calling ElevenLabs. The manager Railway service uses the repo-root `nixpacks.toml` to add `ffmpeg` to the NIXPACKS setup phase; the helper still throws a clear error if the binary is missing.
 - Job state is stored in Strapi as `EnrichmentJob` content type (with `enrichment.job-step` repeatable component). The `src/lib/state.ts` module provides the same `createJob`/`getJob`/`listJobs`/`updateJob`/`updateStepStatus` API backed by Strapi GraphQL mutations.
-- The `"use workflow"` and `"use step"` directives in `src/workflows/` are **inert** without the workflow SDK's build plugin configured in `next.config.ts`. Until the plugin is added and `WORKFLOW_API_KEY` is set, workflows run as plain async functions with no durability, retries, or checkpointing. See https://useworkflow.dev/.
+- Manager now enables the workflow SDK build plugin in `next.config.ts`, and enrichment entrypoints dispatch through `src/workflows/launchVideoEnrichment.ts` via `start()` from `workflow/api`. The workflow runtime is no longer inert.
+- Workflow-safe authoring still matters: keep Node-only imports and heavy service modules behind `"use step"` boundaries. A built app will reject workflow files that pull Node-only modules into the top-level workflow body. See https://useworkflow.dev/.
 
 ## Environment variables (Doppler project: forge-manager)
 

--- a/apps/manager/next.config.ts
+++ b/apps/manager/next.config.ts
@@ -1,10 +1,13 @@
 import type { NextConfig } from "next"
+import { withWorkflow } from "workflow/next"
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  experimental: {
-    typedRoutes: true,
-  },
+  typedRoutes: true,
 }
 
-export default nextConfig
+export default withWorkflow(nextConfig, {
+  workflows: {
+    dirs: ["src/workflows"],
+  },
+})

--- a/apps/manager/src/app/api/enrich/route.test.ts
+++ b/apps/manager/src/app/api/enrich/route.test.ts
@@ -387,6 +387,31 @@ describe("createEnrichmentJobs", () => {
     expect(dispatch.spy).toHaveBeenCalledTimes(1)
     expect(runVideoEnrichment).not.toHaveBeenCalled()
   })
+
+  it("reports per-video launch failures as batch errors", async () => {
+    startMock.mockReset()
+    startMock.mockRejectedValueOnce(new Error("workflow offline"))
+
+    const result = await createEnrichmentJobs({
+      videoIds: ["video-1"],
+      targetLanguageIds: ["6414"],
+    })
+
+    expect(result).toMatchObject({
+      created: 0,
+      failed: 1,
+      jobs: [],
+      errors: [
+        {
+          videoId: "video-1",
+          error: "Failed to launch enrichment workflow.",
+        },
+      ],
+    })
+    expect(updateJobMock).toHaveBeenCalledWith("job-1", { status: "failed" })
+    expect(startMock).toHaveBeenCalledTimes(1)
+    expect(runVideoEnrichment).not.toHaveBeenCalled()
+  })
 })
 
 describe("POST /api/enrich", () => {
@@ -427,5 +452,119 @@ describe("POST /api/enrich", () => {
     expect(response.status).toBe(400)
     dispatch.expectNotDispatched()
     expect(createJobMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps a batch 201 response while surfacing per-video launch failures", async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({
+        data: {
+          videos: [
+            {
+              documentId: "video-doc-1",
+              coreId: "video-1",
+              title: "Video 1",
+              primaryLanguage: {
+                coreId: "529",
+                bcp47: "en",
+                iso3: "eng",
+              },
+              variants: [],
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          languages: [
+            {
+              coreId: "6414",
+              bcp47: "fr",
+              iso3: "fra",
+            },
+          ],
+        },
+      })
+    materializeEnrichmentTargetForJobMock.mockResolvedValueOnce({
+      status: "ready",
+      materializationMode: "direct_mux_asset_reuse",
+      sourceVideoCoreId: "video-1",
+      sourceLanguage: { coreId: "529", bcp47: "en", iso3: "eng" },
+      sourceLanguageCode: "en",
+      sourceMuxAssetId: "mux-source-1",
+      sourceMuxPlaybackId: "mux-source-playback-1",
+      sourceInputType: "mux_asset",
+      sourceSelectionReason: "fallback-en",
+      sourceSelectionAttemptedCodes: ["fr", "en"],
+      targetMuxAssetId: "mux-target-1",
+      targetMuxPlaybackId: "mux-target-playback-1",
+    })
+    ensureGeneratedSubtitlesForAssetMock.mockResolvedValueOnce(undefined)
+    isAudioCleanupConfiguredMock.mockReturnValueOnce(true)
+    createJobMock.mockResolvedValueOnce({
+      id: "job-1",
+      muxAssetId: "mux-target-1",
+      muxPlaybackId: "mux-target-playback-1",
+      languages: ["fr"],
+      options: {},
+      status: "pending",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        transcriptionRouting: {
+          kind: "metadata",
+          data: { attempts: [] },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+    updateJobMock.mockImplementation(async (_id, updates) => ({
+      id: "job-1",
+      muxAssetId: "mux-target-1",
+      muxPlaybackId: "mux-target-playback-1",
+      languages: ["fr"],
+      options: {},
+      status: updates.status ?? "pending",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        transcriptionRouting: {
+          kind: "metadata",
+          data: { attempts: [] },
+        },
+        ...(updates.artifacts ?? {}),
+      },
+      steps: [],
+      errors: [],
+    }))
+    startMock.mockRejectedValueOnce(new Error("workflow offline"))
+
+    const response = await POST(
+      new Request("https://manager.test/api/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          videoIds: ["video-1"],
+          targetLanguageIds: ["6414"],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toMatchObject({
+      created: 0,
+      failed: 1,
+      jobs: [],
+      errors: [
+        {
+          videoId: "video-1",
+          error: "Failed to launch enrichment workflow.",
+        },
+      ],
+    })
+    expect(updateJobMock).toHaveBeenCalledWith("job-1", { status: "failed" })
+    expect(startMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/manager/src/app/api/enrich/route.test.ts
+++ b/apps/manager/src/app/api/enrich/route.test.ts
@@ -1,10 +1,83 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  afterMock,
+  authenticateRequestMock,
+  clientQueryMock,
+  createJobMock,
+  ensureGeneratedSubtitlesForAssetMock,
+  isAudioCleanupConfiguredMock,
+  materializeEnrichmentTargetForJobMock,
+  runVideoEnrichmentMock,
+  startMock,
+  updateJobMock,
+} = vi.hoisted(() => ({
+  afterMock: vi.fn(),
+  authenticateRequestMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  createJobMock: vi.fn(),
+  ensureGeneratedSubtitlesForAssetMock: vi.fn(),
+  isAudioCleanupConfiguredMock: vi.fn(),
+  materializeEnrichmentTargetForJobMock: vi.fn(),
+  runVideoEnrichmentMock: vi.fn(),
+  startMock: vi.fn(),
+  updateJobMock: vi.fn(),
+}))
+
+vi.mock("next/server", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/server")>("next/server")
+
+  return {
+    ...actual,
+    after: afterMock,
+  }
+})
+
+vi.mock("workflow/api", () => ({
+  start: startMock,
+}))
+
+vi.mock("@/lib/auth", () => ({
+  authenticateRequest: authenticateRequestMock,
+}))
+
+vi.mock("@/cms/client", () => ({
+  default: () => ({
+    query: clientQueryMock,
+  }),
+}))
+
+vi.mock("@/lib/state", () => ({
+  createJob: createJobMock,
+  updateJob: updateJobMock,
+}))
+
+vi.mock("@/services/mux", () => ({
+  ensureGeneratedSubtitlesForAsset: ensureGeneratedSubtitlesForAssetMock,
+}))
+
+vi.mock("@/services/audioCleanup", () => ({
+  isAudioCleanupConfigured: isAudioCleanupConfiguredMock,
+}))
+
+vi.mock("@/services/stageClone", () => ({
+  materializeEnrichmentTargetForJob: materializeEnrichmentTargetForJobMock,
+}))
+
+vi.mock("@/workflows/videoEnrichment", () => ({
+  runVideoEnrichment: runVideoEnrichmentMock,
+}))
 import {
+  POST,
   buildMaterializationMetadata,
+  createEnrichmentJobs,
   ENRICH_CREATE_CONCURRENCY,
   GET_VIDEOS_WITH_MUX,
   mapWithConcurrencyLimit,
 } from "@/app/api/enrich/route"
+import { wrapStartSpy } from "@/test-helpers/workflow-dispatch"
+import { runVideoEnrichment } from "@/workflows/videoEnrichment"
 
 type QueryNode = {
   kind?: string
@@ -181,5 +254,178 @@ describe("buildMaterializationMetadata", () => {
     })
     expect(metadata).not.toHaveProperty("sourceInputHost")
     expect(metadata).not.toHaveProperty("stageMuxAssetId")
+  })
+})
+
+describe("createEnrichmentJobs", () => {
+  const dispatch = wrapStartSpy(startMock)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    authenticateRequestMock.mockResolvedValue(null)
+    afterMock.mockImplementation(async (callback: () => Promise<void>) => {
+      await callback()
+    })
+    isAudioCleanupConfiguredMock.mockReturnValue(true)
+    clientQueryMock
+      .mockResolvedValueOnce({
+        data: {
+          videos: [
+            {
+              documentId: "video-doc-1",
+              coreId: "video-1",
+              title: "Video 1",
+              primaryLanguage: {
+                coreId: "529",
+                bcp47: "en",
+                iso3: "eng",
+              },
+              variants: [],
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          languages: [
+            {
+              coreId: "6414",
+              bcp47: "fr",
+              iso3: "fra",
+            },
+          ],
+        },
+      })
+    materializeEnrichmentTargetForJobMock.mockResolvedValue({
+      status: "ready",
+      materializationMode: "direct_mux_asset_reuse",
+      sourceVideoCoreId: "video-1",
+      sourceLanguage: { coreId: "529", bcp47: "en", iso3: "eng" },
+      sourceLanguageCode: "en",
+      sourceMuxAssetId: "mux-source-1",
+      sourceMuxPlaybackId: "mux-source-playback-1",
+      sourceInputType: "mux_asset",
+      sourceSelectionReason: "fallback-en",
+      sourceSelectionAttemptedCodes: ["fr", "en"],
+      targetMuxAssetId: "mux-target-1",
+      targetMuxPlaybackId: "mux-target-playback-1",
+    })
+    ensureGeneratedSubtitlesForAssetMock.mockResolvedValue(undefined)
+    createJobMock.mockResolvedValue({
+      id: "job-1",
+      muxAssetId: "mux-target-1",
+      muxPlaybackId: "mux-target-playback-1",
+      languages: ["fr"],
+      options: {},
+      status: "pending",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        transcriptionRouting: {
+          kind: "metadata",
+          data: { attempts: [] },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+    updateJobMock.mockImplementation(async (_id, updates) => ({
+      id: "job-1",
+      muxAssetId: "mux-target-1",
+      muxPlaybackId: "mux-target-playback-1",
+      languages: ["fr"],
+      options: {},
+      status: "pending",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        transcriptionRouting: {
+          kind: "metadata",
+          data: { attempts: [] },
+        },
+        ...(updates.artifacts ?? {}),
+      },
+      steps: [],
+      errors: [],
+    }))
+    dispatch.mockReturnValue({
+      assetId: "mux-target-1",
+      transcript: "Transcript",
+      language: "en",
+      chapters: [],
+      tags: [],
+    })
+  })
+
+  it("dispatches enrichment jobs through workflow start()", async () => {
+    const result = await createEnrichmentJobs({
+      videoIds: ["video-1"],
+      targetLanguageIds: ["6414"],
+    })
+
+    expect(result).toMatchObject({
+      created: 1,
+      failed: 0,
+      jobs: [{ videoId: "video-1", jobId: "job-1" }],
+    })
+    dispatch.expectDispatched(runVideoEnrichment, [
+      expect.objectContaining({
+        jobId: "job-1",
+        assetId: "mux-target-1",
+        muxAssetId: "mux-target-1",
+        playbackId: "mux-target-playback-1",
+        language: "en",
+        translateTo: ["fr"],
+        runAudioCleanup: true,
+        videoDocumentId: "video-doc-1",
+        requestedTranscriptionProvider: "automatic",
+      }),
+    ])
+    expect(dispatch.spy).toHaveBeenCalledTimes(1)
+    expect(runVideoEnrichment).not.toHaveBeenCalled()
+  })
+})
+
+describe("POST /api/enrich", () => {
+  const dispatch = wrapStartSpy(startMock)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authenticateRequestMock.mockResolvedValue(null)
+  })
+
+  it("rejects unauthorized requests before dispatch", async () => {
+    authenticateRequestMock.mockResolvedValueOnce(
+      Response.json({ error: "Unauthorized" }, { status: 401 }),
+    )
+
+    const response = await POST(
+      new Request("https://manager.test/api/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ videoIds: ["video-1"] }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    dispatch.expectNotDispatched()
+    expect(createJobMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 400 for invalid payloads without dispatching", async () => {
+    const response = await POST(
+      new Request("https://manager.test/api/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ videoIds: [] }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    dispatch.expectNotDispatched()
+    expect(createJobMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/manager/src/app/api/enrich/route.ts
+++ b/apps/manager/src/app/api/enrich/route.ts
@@ -3,7 +3,6 @@
 // coverage UI. The route derives the source audio language per video from CMS
 // metadata, then normalizes only real language codes into the workflow.
 
-import { after } from "next/server"
 import { NextResponse } from "next/server"
 import pLimit from "p-limit"
 import { z } from "zod"
@@ -30,7 +29,7 @@ import {
   materializeEnrichmentTargetForJob,
   type MaterializeEnrichmentTargetResult,
 } from "@/services/stageClone"
-import { runVideoEnrichment } from "@/workflows/videoEnrichment"
+import { launchVideoEnrichment } from "@/workflows/launchVideoEnrichment"
 import getClient from "@/cms/client"
 import type { JobArtifactManifest } from "@/types/job"
 
@@ -435,26 +434,23 @@ export async function createEnrichmentJobs(
           },
         })
 
-        // Run enrichment in the background after the response is sent
-        after(async () => {
-          try {
-            await runVideoEnrichment({
-              jobId: job.id,
-              assetId: job.muxAssetId,
-              muxAssetId: materialization.targetMuxAssetId,
-              playbackId: materialization.targetMuxPlaybackId,
-              language: materialization.sourceLanguageCode,
-              translateTo: normalizedTargets.targetLanguageCodes,
-              runAudioCleanup: isAudioCleanupConfigured(),
-              initialArtifacts: updatedJob?.artifacts ?? job.artifacts,
-              videoDocumentId: video.documentId,
-              requestedTranscriptionProvider: "automatic",
-            })
-          } catch (err: unknown) {
-            console.error(`Enrichment failed for job ${job.id}:`, err)
-            await updateJob(job.id, { status: "failed" }).catch(console.error)
-          }
-        })
+        try {
+          await launchVideoEnrichment({
+            jobId: job.id,
+            assetId: job.muxAssetId,
+            muxAssetId: materialization.targetMuxAssetId,
+            playbackId: materialization.targetMuxPlaybackId,
+            language: materialization.sourceLanguageCode,
+            translateTo: normalizedTargets.targetLanguageCodes,
+            runAudioCleanup: isAudioCleanupConfigured(),
+            initialArtifacts: updatedJob?.artifacts ?? job.artifacts,
+            videoDocumentId: video.documentId,
+            requestedTranscriptionProvider: "automatic",
+          })
+        } catch (err: unknown) {
+          console.error(`Enrichment failed for job ${job.id}:`, err)
+          await updateJob(job.id, { status: "failed" }).catch(console.error)
+        }
 
         return { videoId: coreId, jobId: job.id }
       } catch (err) {

--- a/apps/manager/src/app/api/enrich/route.ts
+++ b/apps/manager/src/app/api/enrich/route.ts
@@ -450,6 +450,11 @@ export async function createEnrichmentJobs(
         } catch (err: unknown) {
           console.error(`Enrichment failed for job ${job.id}:`, err)
           await updateJob(job.id, { status: "failed" }).catch(console.error)
+
+          return {
+            videoId: coreId,
+            error: "Failed to launch enrichment workflow.",
+          }
         }
 
         return { videoId: coreId, jobId: job.id }

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
@@ -219,6 +219,70 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
     expect(runVideoEnrichment).not.toHaveBeenCalled()
   })
 
+  it("returns a failed job payload when workflow dispatch fails", async () => {
+    startMock.mockReset()
+    startMock.mockRejectedValueOnce(new Error("workflow offline"))
+    updateJobMock
+      .mockImplementationOnce(async (_id, updates) => ({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: updates.status ?? "pending",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: updates.artifacts ?? {},
+        steps: updates.steps ?? [],
+        errors: updates.errors ?? [],
+        currentStep: updates.currentStep,
+      }))
+      .mockImplementationOnce(async (_id, updates) => ({
+        id: "job-1",
+        muxAssetId: "mux-1",
+        muxPlaybackId: "play-1",
+        languages: ["fr"],
+        options: {},
+        status: updates.status ?? "failed",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: {},
+        steps: [],
+        errors: [],
+        currentStep: updates.currentStep,
+      }))
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/transcription/rerun", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "mux" }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to relaunch enrichment workflow.",
+      job: expect.objectContaining({
+        id: "job-1",
+        status: "failed",
+      }),
+    })
+    expect(updateJobMock).toHaveBeenNthCalledWith(
+      2,
+      "job-1",
+      expect.objectContaining({
+        status: "failed",
+        currentStep: undefined,
+      }),
+    )
+    expect(startMock).toHaveBeenCalledTimes(1)
+    expect(runVideoEnrichment).not.toHaveBeenCalled()
+  })
+
   it("rejects reruns while transcription is already active", async () => {
     getJobMock.mockResolvedValueOnce({
       id: "job-1",

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
@@ -5,12 +5,14 @@ const {
   afterMock,
   getJobMock,
   runVideoEnrichmentMock,
+  startMock,
   updateJobMock,
 } = vi.hoisted(() => ({
   authenticateRequestMock: vi.fn(),
   afterMock: vi.fn(),
   getJobMock: vi.fn(),
   runVideoEnrichmentMock: vi.fn(),
+  startMock: vi.fn(),
   updateJobMock: vi.fn(),
 }))
 
@@ -28,6 +30,10 @@ vi.mock("@/lib/auth", () => ({
   authenticateRequest: authenticateRequestMock,
 }))
 
+vi.mock("workflow/api", () => ({
+  start: startMock,
+}))
+
 vi.mock("@/lib/state", () => ({
   getJob: getJobMock,
   updateJob: updateJobMock,
@@ -38,20 +44,27 @@ vi.mock("@/workflows/videoEnrichment", () => ({
 }))
 
 import { POST } from "@/app/api/jobs/[id]/transcription/rerun/route"
+import { wrapStartSpy } from "@/test-helpers/workflow-dispatch"
+import { runVideoEnrichment } from "@/workflows/videoEnrichment"
 
 describe("POST /api/jobs/[id]/transcription/rerun", () => {
+  const dispatch = wrapStartSpy(startMock)
+
   beforeEach(() => {
-    authenticateRequestMock.mockReset()
-    afterMock.mockReset()
-    getJobMock.mockReset()
-    runVideoEnrichmentMock.mockReset()
-    updateJobMock.mockReset()
+    vi.clearAllMocks()
 
     authenticateRequestMock.mockResolvedValue(null)
     afterMock.mockImplementation(async (callback: () => Promise<void>) => {
       await callback()
     })
     runVideoEnrichmentMock.mockResolvedValue(undefined)
+    dispatch.mockReturnValue({
+      assetId: "mux-1",
+      transcript: "Transcript",
+      language: "en",
+      chapters: [],
+      tags: [],
+    })
     getJobMock.mockResolvedValue({
       id: "job-1",
       muxAssetId: "mux-1",
@@ -191,7 +204,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
       }),
     )
 
-    expect(runVideoEnrichmentMock).toHaveBeenCalledWith(
+    dispatch.expectDispatched(runVideoEnrichment, [
       expect.objectContaining({
         jobId: "job-1",
         assetId: "mux-1",
@@ -201,7 +214,9 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
         }),
         requestedTranscriptionProvider: "elevenlabs",
       }),
-    )
+    ])
+    expect(dispatch.spy).toHaveBeenCalledTimes(1)
+    expect(runVideoEnrichment).not.toHaveBeenCalled()
   })
 
   it("rejects reruns while transcription is already active", async () => {
@@ -232,6 +247,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
 
     expect(response.status).toBe(409)
     expect(updateJobMock).not.toHaveBeenCalled()
+    dispatch.expectNotDispatched()
   })
 
   it("rejects forced ElevenLabs reruns when no original source url is available", async () => {
@@ -267,7 +283,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
     )
 
     expect(response.status).toBe(409)
-    expect(runVideoEnrichmentMock).not.toHaveBeenCalled()
+    dispatch.expectNotDispatched()
   })
 
   it("rejects forced ElevenLabs reruns when the source language is unresolved", async () => {
@@ -306,7 +322,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
 
     expect(response.status).toBe(409)
     expect(updateJobMock).not.toHaveBeenCalled()
-    expect(runVideoEnrichmentMock).not.toHaveBeenCalled()
+    dispatch.expectNotDispatched()
   })
 
   it("rejects forced ElevenLabs reruns when the source language is unsupported", async () => {
@@ -345,7 +361,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
 
     expect(response.status).toBe(409)
     expect(updateJobMock).not.toHaveBeenCalled()
-    expect(runVideoEnrichmentMock).not.toHaveBeenCalled()
+    dispatch.expectNotDispatched()
   })
 
   it("returns 400 for invalid JSON", async () => {
@@ -360,6 +376,6 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
 
     expect(response.status).toBe(400)
     expect(updateJobMock).not.toHaveBeenCalled()
-    expect(runVideoEnrichmentMock).not.toHaveBeenCalled()
+    dispatch.expectNotDispatched()
   })
 })

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
@@ -211,10 +211,20 @@ export async function POST(
     })
   } catch (error) {
     console.error(`Transcription rerun failed for job ${updatedJob.id}:`, error)
-    await updateJob(updatedJob.id, {
+    const failedJob = await updateJob(updatedJob.id, {
       status: "failed",
       currentStep: undefined,
     }).catch(console.error)
+
+    return NextResponse.json(
+      {
+        error: "Failed to relaunch enrichment workflow.",
+        details: error instanceof Error ? error.message : undefined,
+        code: "workflow_launch_failed",
+        job: failedJob ?? undefined,
+      },
+      { status: 502 },
+    )
   }
 
   return NextResponse.json({ job: updatedJob }, { status: 202 })

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto"
-import { after, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 import { z } from "zod"
 import { authenticateRequest } from "@/lib/auth"
 import {
@@ -17,7 +17,7 @@ import type {
 } from "@/types/job"
 import { isSupportedElevenLabsLanguage } from "@/services/elevenlabs-transcription"
 import { normalizeSourceLanguageCode } from "@/services/transcription"
-import { runVideoEnrichment } from "@/workflows/videoEnrichment"
+import { launchVideoEnrichment } from "@/workflows/launchVideoEnrichment"
 
 const requestBodySchema = z.object({
   provider: z.enum(["elevenlabs", "mux"]),
@@ -196,31 +196,26 @@ export async function POST(
     )
   }
 
-  after(async () => {
-    try {
-      await runVideoEnrichment({
-        jobId: updatedJob.id,
-        assetId: updatedJob.muxAssetId,
-        muxAssetId: updatedJob.muxAssetId,
-        language:
-          existingRoutingReport?.finalSourceLanguageCode ??
-          job.sourceLanguageCode ??
-          "auto",
-        translateTo: job.languages,
-        initialArtifacts: updatedJob.artifacts,
-        requestedTranscriptionProvider: provider,
-      })
-    } catch (error) {
-      console.error(
-        `Transcription rerun failed for job ${updatedJob.id}:`,
-        error,
-      )
-      await updateJob(updatedJob.id, {
-        status: "failed",
-        currentStep: undefined,
-      }).catch(console.error)
-    }
-  })
+  try {
+    await launchVideoEnrichment({
+      jobId: updatedJob.id,
+      assetId: updatedJob.muxAssetId,
+      muxAssetId: updatedJob.muxAssetId,
+      language:
+        existingRoutingReport?.finalSourceLanguageCode ??
+        job.sourceLanguageCode ??
+        "auto",
+      translateTo: job.languages,
+      initialArtifacts: updatedJob.artifacts,
+      requestedTranscriptionProvider: provider,
+    })
+  } catch (error) {
+    console.error(`Transcription rerun failed for job ${updatedJob.id}:`, error)
+    await updateJob(updatedJob.id, {
+      status: "failed",
+      currentStep: undefined,
+    }).catch(console.error)
+  }
 
   return NextResponse.json({ job: updatedJob }, { status: 202 })
 }

--- a/apps/manager/src/app/api/jobs/route.test.ts
+++ b/apps/manager/src/app/api/jobs/route.test.ts
@@ -2,16 +2,32 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
   authenticateRequestMock,
+  countJobsMock,
   createJobMock,
   createMuxAssetMock,
   getCmsGatewayMock,
+  isAudioCleanupConfiguredMock,
+  listJobSummariesMock,
+  listJobsMock,
   runVideoEnrichmentMock,
+  startMock,
+  updateJobMock,
 } = vi.hoisted(() => ({
   authenticateRequestMock: vi.fn(),
+  countJobsMock: vi.fn(),
   createJobMock: vi.fn(),
   createMuxAssetMock: vi.fn(),
   getCmsGatewayMock: vi.fn(),
+  isAudioCleanupConfiguredMock: vi.fn(),
+  listJobSummariesMock: vi.fn(),
+  listJobsMock: vi.fn(),
   runVideoEnrichmentMock: vi.fn(),
+  startMock: vi.fn(),
+  updateJobMock: vi.fn(),
+}))
+
+vi.mock("workflow/api", () => ({
+  start: startMock,
 }))
 
 vi.mock("@/lib/auth", () => ({
@@ -28,36 +44,77 @@ vi.mock("@/cms/gateway", async () => {
 })
 
 vi.mock("@/lib/state", () => ({
-  countJobs: vi.fn(),
+  countJobs: countJobsMock,
   createJob: createJobMock,
-  listJobSummaries: vi.fn(),
-  listJobs: vi.fn(),
-  updateJob: vi.fn(),
+  listJobSummaries: listJobSummariesMock,
+  listJobs: listJobsMock,
+  updateJob: updateJobMock,
 }))
 
 vi.mock("@/services/mux", () => ({
   createMuxAsset: createMuxAssetMock,
 }))
 
+vi.mock("@/services/audioCleanup", () => ({
+  isAudioCleanupConfigured: isAudioCleanupConfiguredMock,
+}))
+
 vi.mock("@/workflows/videoEnrichment", () => ({
   runVideoEnrichment: runVideoEnrichmentMock,
 }))
 
-import { POST } from "./route"
+import { POST } from "@/app/api/jobs/route"
+import { wrapStartSpy } from "@/test-helpers/workflow-dispatch"
+import { runVideoEnrichment } from "@/workflows/videoEnrichment"
 
-describe("POST /api/jobs in mock mode", () => {
+describe("POST /api/jobs", () => {
+  const dispatch = wrapStartSpy(startMock)
+
   beforeEach(() => {
-    authenticateRequestMock.mockReset()
-    createJobMock.mockReset()
-    createMuxAssetMock.mockReset()
-    getCmsGatewayMock.mockReset()
-    runVideoEnrichmentMock.mockReset()
+    vi.clearAllMocks()
+
     authenticateRequestMock.mockResolvedValue(null)
-    getCmsGatewayMock.mockReturnValue({ mode: "mock" })
+    getCmsGatewayMock.mockReturnValue({ mode: "live" })
+    isAudioCleanupConfiguredMock.mockReturnValue(true)
+    createMuxAssetMock.mockResolvedValue({
+      assetId: "mux-asset-1",
+      playbackId: "mux-playback-1",
+    })
+    createJobMock.mockResolvedValue({
+      id: "job-1",
+      muxAssetId: "mux-asset-1",
+      muxPlaybackId: "mux-playback-1",
+      languages: ["fr"],
+      options: {},
+      status: "pending",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      artifacts: {
+        transcriptionRouting: {
+          kind: "metadata",
+          data: {
+            attempts: [],
+            sourceInputUrl: "https://cdn.example.com/video.mp4",
+          },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+    updateJobMock.mockResolvedValue(null)
+    dispatch.mockReturnValue({
+      assetId: "mux-asset-1",
+      transcript: "Transcript",
+      language: "en",
+      chapters: [],
+      tags: [],
+    })
   })
 
-  it("creates a demo job without Mux ingestion or workflow dispatch", async () => {
-    createJobMock.mockResolvedValue({
+  it("creates a demo job in mock mode without Mux ingestion or workflow dispatch", async () => {
+    getCmsGatewayMock.mockReturnValueOnce({ mode: "mock" })
+    createJobMock.mockResolvedValueOnce({
       id: "mock-job-3",
       muxAssetId: "mock-upload-asset",
       muxPlaybackId: "mock-upload-playback",
@@ -73,7 +130,7 @@ describe("POST /api/jobs in mock mode", () => {
     })
 
     const response = await POST(
-      new Request("http://example.test/api/jobs", {
+      new Request("https://manager.test/api/jobs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -89,6 +146,103 @@ describe("POST /api/jobs in mock mode", () => {
       note: "Created in mock mode without Mux ingestion or workflow dispatch.",
     })
     expect(createMuxAssetMock).not.toHaveBeenCalled()
-    expect(runVideoEnrichmentMock).not.toHaveBeenCalled()
+    dispatch.expectNotDispatched()
+    expect(runVideoEnrichment).not.toHaveBeenCalled()
+  })
+
+  it("rejects unauthorized requests before dispatch", async () => {
+    authenticateRequestMock.mockResolvedValueOnce(
+      Response.json({ error: "Unauthorized" }, { status: 401 }),
+    )
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          inputUrl: "https://cdn.example.com/video.mp4",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    dispatch.expectNotDispatched()
+    expect(createMuxAssetMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 400 for invalid payloads without dispatching", async () => {
+    const response = await POST(
+      new Request("https://manager.test/api/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          inputUrl: "http://cdn.example.com/video.mp4",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    dispatch.expectNotDispatched()
+    expect(createMuxAssetMock).not.toHaveBeenCalled()
+  })
+
+  it("dispatches enrichment through workflow start()", async () => {
+    const response = await POST(
+      new Request("https://manager.test/api/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          inputUrl: "https://cdn.example.com/video.mp4",
+          language: "en",
+          translateTo: ["fr"],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    dispatch.expectDispatched(runVideoEnrichment, [
+      expect.objectContaining({
+        jobId: "job-1",
+        assetId: "mux-asset-1",
+        muxAssetId: "mux-asset-1",
+        playbackId: "mux-playback-1",
+        language: "en",
+        translateTo: ["fr"],
+        runAudioCleanup: true,
+        initialArtifacts: expect.objectContaining({
+          transcriptionRouting: expect.any(Object),
+        }),
+        requestedTranscriptionProvider: "automatic",
+      }),
+    ])
+    expect(dispatch.spy).toHaveBeenCalledTimes(1)
+    expect(runVideoEnrichment).not.toHaveBeenCalled()
+  })
+
+  it("returns a launch failure response when workflow dispatch fails", async () => {
+    startMock.mockReset()
+    startMock.mockRejectedValueOnce(new Error("workflow offline"))
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          inputUrl: "https://cdn.example.com/video.mp4",
+          language: "en",
+          translateTo: ["fr"],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to launch enrichment workflow.",
+      code: "workflow_launch_failed",
+      details: "workflow offline",
+    })
+    expect(updateJobMock).toHaveBeenCalledWith("job-1", { status: "failed" })
+    expect(startMock).toHaveBeenCalledTimes(1)
+    expect(runVideoEnrichment).not.toHaveBeenCalled()
   })
 })

--- a/apps/manager/src/app/api/jobs/route.ts
+++ b/apps/manager/src/app/api/jobs/route.ts
@@ -158,6 +158,15 @@ export async function POST(request: Request) {
   } catch (error: unknown) {
     console.error(`Enrichment failed for job ${job.id}:`, error)
     await updateJob(job.id, { status: "failed" }).catch(console.error)
+
+    return NextResponse.json(
+      {
+        error: "Failed to launch enrichment workflow.",
+        details: error instanceof Error ? error.message : undefined,
+        code: "workflow_launch_failed",
+      },
+      { status: 502 },
+    )
   }
 
   return NextResponse.json({ job, jobId: job.id }, { status: 201 })

--- a/apps/manager/src/app/api/jobs/route.ts
+++ b/apps/manager/src/app/api/jobs/route.ts
@@ -1,4 +1,3 @@
-import { after } from "next/server"
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { authenticateRequest } from "@/lib/auth"
@@ -13,7 +12,7 @@ import {
 } from "@/lib/state"
 import { createMuxAsset } from "@/services/mux"
 import { isAudioCleanupConfigured } from "@/services/audioCleanup"
-import { runVideoEnrichment } from "@/workflows/videoEnrichment"
+import { launchVideoEnrichment } from "@/workflows/launchVideoEnrichment"
 
 const createJobSchema = z.object({
   inputUrl: z
@@ -144,26 +143,22 @@ export async function POST(request: Request) {
     },
   )
 
-  // Run enrichment after the response is sent.
-  // after() tells the runtime to keep the function alive for background work.
-  after(async () => {
-    try {
-      await runVideoEnrichment({
-        jobId: job.id,
-        assetId: job.muxAssetId,
-        muxAssetId: muxAsset.assetId,
-        playbackId: muxAsset.playbackId,
-        language: body.language,
-        translateTo: body.translateTo,
-        runAudioCleanup: isAudioCleanupConfigured(),
-        initialArtifacts: job.artifacts,
-        requestedTranscriptionProvider: "automatic",
-      })
-    } catch (error: unknown) {
-      console.error(`Enrichment failed for job ${job.id}:`, error)
-      await updateJob(job.id, { status: "failed" }).catch(console.error)
-    }
-  })
+  try {
+    await launchVideoEnrichment({
+      jobId: job.id,
+      assetId: job.muxAssetId,
+      muxAssetId: muxAsset.assetId,
+      playbackId: muxAsset.playbackId,
+      language: body.language,
+      translateTo: body.translateTo,
+      runAudioCleanup: isAudioCleanupConfigured(),
+      initialArtifacts: job.artifacts,
+      requestedTranscriptionProvider: "automatic",
+    })
+  } catch (error: unknown) {
+    console.error(`Enrichment failed for job ${job.id}:`, error)
+    await updateJob(job.id, { status: "failed" }).catch(console.error)
+  }
 
   return NextResponse.json({ job, jobId: job.id }, { status: 201 })
 }

--- a/apps/manager/src/test-helpers/workflow-dispatch.ts
+++ b/apps/manager/src/test-helpers/workflow-dispatch.ts
@@ -1,0 +1,40 @@
+import { expect, type Mock } from "vitest"
+
+export type MockRun<TResult> = {
+  runId: string
+  returnValue: Promise<TResult>
+}
+
+export type WorkflowDispatchSpy<TResult> = {
+  mockReturnValue(value: TResult): void
+  mockRejection(err: Error): void
+  expectDispatched(workflow: unknown, args: unknown[]): void
+  expectNotDispatched(): void
+  readonly spy: Mock
+}
+
+export function wrapStartSpy<TResult>(
+  start: Mock,
+): WorkflowDispatchSpy<TResult> {
+  return {
+    mockReturnValue(value) {
+      start.mockResolvedValueOnce({
+        runId: `test-run-${Math.random().toString(36).slice(2, 10)}`,
+        returnValue: Promise.resolve(value),
+      } satisfies MockRun<TResult>)
+    },
+    mockRejection(err) {
+      start.mockResolvedValueOnce({
+        runId: "test-run-err",
+        returnValue: Promise.reject(err),
+      } satisfies MockRun<TResult>)
+    },
+    expectDispatched(workflow, args) {
+      expect(start).toHaveBeenCalledWith(workflow, args)
+    },
+    expectNotDispatched() {
+      expect(start).not.toHaveBeenCalled()
+    },
+    spy: start,
+  }
+}

--- a/apps/manager/src/workflows/jobStateSteps.ts
+++ b/apps/manager/src/workflows/jobStateSteps.ts
@@ -1,0 +1,62 @@
+import type { WorkflowStepName } from "@/types/job"
+import type {
+  JobArtifactManifest,
+  JobRecord,
+  JobStepDetails,
+} from "@/types/job"
+
+export async function stepGetJob(jobId: string): Promise<JobRecord | null> {
+  "use step"
+  const { getJob } = await import("@/lib/state")
+  return getJob(jobId)
+}
+
+export async function stepUpdateJob(
+  jobId: string,
+  updates: Partial<
+    Pick<
+      JobRecord,
+      | "status"
+      | "currentStep"
+      | "artifacts"
+      | "errors"
+      | "startedAt"
+      | "completedAt"
+      | "retries"
+      | "steps"
+    >
+  >,
+): Promise<JobRecord | null> {
+  "use step"
+  const { updateJob } = await import("@/lib/state")
+  return updateJob(jobId, updates)
+}
+
+export async function stepMergeJobArtifacts(
+  jobId: string,
+  artifacts: JobArtifactManifest,
+): Promise<JobRecord | null> {
+  "use step"
+  const { mergeJobArtifacts } = await import("@/lib/state")
+  return mergeJobArtifacts(jobId, artifacts)
+}
+
+export async function stepUpdateStepStatus(
+  jobId: string,
+  stepName: WorkflowStepName,
+  status: "pending" | "running" | "completed" | "failed" | "skipped",
+  error?: string,
+  details?: JobStepDetails,
+): Promise<JobRecord | null> {
+  "use step"
+  const { updateStepStatus } = await import("@/lib/state")
+  if (details !== undefined) {
+    return updateStepStatus(jobId, stepName, status, error, details)
+  }
+
+  if (error !== undefined) {
+    return updateStepStatus(jobId, stepName, status, error)
+  }
+
+  return updateStepStatus(jobId, stepName, status)
+}

--- a/apps/manager/src/workflows/launchVideoEnrichment.ts
+++ b/apps/manager/src/workflows/launchVideoEnrichment.ts
@@ -1,0 +1,9 @@
+import { start } from "workflow/api"
+import {
+  runVideoEnrichment,
+  type VideoEnrichmentInput,
+} from "@/workflows/videoEnrichment"
+
+export async function launchVideoEnrichment(input: VideoEnrichmentInput) {
+  return start(runVideoEnrichment, [input])
+}

--- a/apps/manager/src/workflows/videoEnrichment.test.ts
+++ b/apps/manager/src/workflows/videoEnrichment.test.ts
@@ -91,18 +91,12 @@ vi.mock("@/services/mux", () => ({
     `https://stream.mux.com/${playbackId}.m3u8`,
 }))
 
-vi.mock("@/lib/state", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/lib/state")>("@/lib/state")
-
-  return {
-    ...actual,
-    getJob: getJobMock,
-    mergeJobArtifacts: mergeJobArtifactsMock,
-    updateJob: updateJobMock,
-    updateStepStatus: updateStepStatusMock,
-  }
-})
+vi.mock("@/workflows/jobStateSteps", () => ({
+  stepGetJob: getJobMock,
+  stepMergeJobArtifacts: mergeJobArtifactsMock,
+  stepUpdateJob: updateJobMock,
+  stepUpdateStepStatus: updateStepStatusMock,
+}))
 
 import { runVideoEnrichment } from "@/workflows/videoEnrichment"
 

--- a/apps/manager/src/workflows/videoEnrichment.ts
+++ b/apps/manager/src/workflows/videoEnrichment.ts
@@ -16,13 +16,6 @@ import { buildEmbeddingSyncArtifact } from "@/lib/embedding-sync-report"
 import { buildSceneEmbeddingSyncArtifact } from "@/lib/scene-embedding-sync-report"
 import { getMuxSyncReport, setMuxSyncReport } from "@/lib/mux-sync-report"
 import { setTranscriptionRoutingReport } from "@/lib/transcription-routing-report"
-import {
-  getJob,
-  mergeArtifactEntries,
-  mergeJobArtifacts,
-  updateJob,
-  updateStepStatus,
-} from "@/lib/state"
 import type { WorkflowStepName } from "@/types/job"
 import type {
   EmbeddingSyncReport,
@@ -37,6 +30,12 @@ import type { EmbeddingTranscriptInput } from "@/services/embeddings"
 import type { Chapter, GenerateChaptersInput } from "@/services/chapters"
 import type { VideoMetadata } from "@/services/metadata"
 import type { LanguageResult } from "@/services/subtitleTranslation/types"
+import {
+  stepGetJob,
+  stepMergeJobArtifacts,
+  stepUpdateJob,
+  stepUpdateStepStatus,
+} from "@/workflows/jobStateSteps"
 
 function getRoutingReportFromError(error: unknown): JobArtifactManifest | null {
   if (
@@ -71,6 +70,16 @@ export type VideoEnrichmentInput = {
   requestedTranscriptionProvider?: RequestedTranscriptionProvider
 }
 
+function mergeArtifactEntries(
+  existing: JobArtifactManifest,
+  incoming: JobArtifactManifest,
+): JobArtifactManifest {
+  return {
+    ...existing,
+    ...incoming,
+  }
+}
+
 export type VideoEnrichmentOutput = {
   assetId: string
   transcript: string
@@ -80,8 +89,8 @@ export type VideoEnrichmentOutput = {
 }
 
 async function markStepRunning(jobId: string, step: WorkflowStepName) {
-  await updateStepStatus(jobId, step, "running")
-  await updateJob(jobId, { status: "running", currentStep: step })
+  await stepUpdateStepStatus(jobId, step, "running")
+  await stepUpdateJob(jobId, { status: "running", currentStep: step })
 }
 
 async function markStepComplete(
@@ -90,11 +99,11 @@ async function markStepComplete(
   details?: JobStepDetails,
 ) {
   if (details === undefined) {
-    await updateStepStatus(jobId, step, "completed")
+    await stepUpdateStepStatus(jobId, step, "completed")
     return
   }
 
-  await updateStepStatus(jobId, step, "completed", undefined, details)
+  await stepUpdateStepStatus(jobId, step, "completed", undefined, details)
 }
 
 async function markStepFailed(
@@ -102,11 +111,11 @@ async function markStepFailed(
   step: WorkflowStepName,
   error: string,
 ) {
-  await updateStepStatus(jobId, step, "failed", error)
+  await stepUpdateStepStatus(jobId, step, "failed", error)
 }
 
 async function markStepSkipped(jobId: string, step: WorkflowStepName) {
-  await updateStepStatus(jobId, step, "skipped")
+  await stepUpdateStepStatus(jobId, step, "skipped")
 }
 
 function getPersistedAudioCleanupArtifactKeys(error: unknown): string[] {
@@ -132,7 +141,7 @@ async function persistArtifacts(
   jobId: string,
   artifacts: JobArtifactManifest,
 ): Promise<void> {
-  const updated = await updateJob(jobId, { artifacts })
+  const updated = await stepUpdateJob(jobId, { artifacts })
   if (!updated) {
     throw new Error(`Failed to persist artifact manifest for job ${jobId}`)
   }
@@ -146,7 +155,7 @@ async function persistMergedArtifacts(
     return
   }
 
-  const updated = await mergeJobArtifacts(jobId, artifacts)
+  const updated = await stepMergeJobArtifacts(jobId, artifacts)
   if (!updated) {
     throw new Error(`Failed to persist artifact manifest for job ${jobId}`)
   }
@@ -198,7 +207,7 @@ export async function runVideoEnrichment(
     }),
   )
 
-  await updateJob(input.jobId, {
+  await stepUpdateJob(input.jobId, {
     status: "running",
     startedAt: new Date().toISOString(),
   })
@@ -450,7 +459,7 @@ export async function runVideoEnrichment(
 
     await markStepRunning(input.jobId, "mux_upload")
     try {
-      const currentJob = await getJob(input.jobId)
+      const currentJob = await stepGetJob(input.jobId)
       if (!currentJob) {
         throw new Error(`Job ${input.jobId} not found while preparing Mux sync`)
       }
@@ -463,7 +472,7 @@ export async function runVideoEnrichment(
         previousReport: getMuxSyncReport(currentJob.artifacts),
       })
 
-      const persisted = await updateJob(input.jobId, {
+      const persisted = await stepUpdateJob(input.jobId, {
         artifacts: setMuxSyncReport(currentJob.artifacts, muxSyncReport),
       })
       if (!persisted) {
@@ -546,7 +555,7 @@ export async function runVideoEnrichment(
     }
 
     // Mark job complete
-    await updateJob(input.jobId, {
+    await stepUpdateJob(input.jobId, {
       status: "completed",
       currentStep: undefined,
       completedAt: new Date().toISOString(),
@@ -582,7 +591,7 @@ export async function runVideoEnrichment(
 
     // Individual parallel steps mark themselves as failed via runParallelStep.
     // Just mark the overall job as failed here.
-    await updateJob(input.jobId, {
+    await stepUpdateJob(input.jobId, {
       status: "failed",
       currentStep: undefined,
     })

--- a/apps/manager/src/workflows/videoEnrichment.ts
+++ b/apps/manager/src/workflows/videoEnrichment.ts
@@ -11,7 +11,6 @@
 // Uses the `workflow` package ("use workflow" / "use step" directives)
 // for durable execution. Each step is idempotent.
 
-import { createHash } from "node:crypto"
 import { buildDownloadableArtifactManifest } from "@/lib/job-artifacts"
 import { buildEmbeddingSyncArtifact } from "@/lib/embedding-sync-report"
 import { buildSceneEmbeddingSyncArtifact } from "@/lib/scene-embedding-sync-report"
@@ -35,7 +34,7 @@ import type {
   TranslationLanguageResult,
 } from "@/types/job"
 import type { EmbeddingTranscriptInput } from "@/services/embeddings"
-import type { GenerateChaptersInput } from "@/services/chapters"
+import type { Chapter, GenerateChaptersInput } from "@/services/chapters"
 import type { VideoMetadata } from "@/services/metadata"
 import type { LanguageResult } from "@/services/subtitleTranslation/types"
 
@@ -183,49 +182,6 @@ function getTranslationStepDetails(
   return { languageResults }
 }
 
-function buildGeneratedEmbeddingContentFingerprint(
-  model: string,
-  chunks: Array<{ text: string }>,
-): string {
-  return `sha256:${createHash("sha256")
-    .update(
-      JSON.stringify({
-        model,
-        chunks: chunks.map((chunk, index) => ({
-          index,
-          text: chunk.text,
-        })),
-      }),
-    )
-    .digest("hex")}`
-}
-
-function buildFallbackEmbeddingSyncReport(
-  result: Awaited<ReturnType<typeof stepEmbeddings>>,
-  videoDocumentId: string | undefined,
-  reason: string,
-): EmbeddingSyncReport {
-  return {
-    domain: "embeddings",
-    status: "failed",
-    ...(videoDocumentId ? { videoDocumentId } : {}),
-    reason,
-    generated: {
-      model: result.model,
-      dimensions: result.dimensions,
-      chunkCount: result.chunks.length,
-      contentFingerprint: buildGeneratedEmbeddingContentFingerprint(
-        result.model,
-        result.chunks,
-      ),
-      hasMetadataEmbedding: result.metadataEmbedding != null,
-      ...(typeof result.metadata.generatedAt === "string"
-        ? { generatedAt: result.metadata.generatedAt }
-        : {}),
-    },
-  }
-}
-
 export async function runVideoEnrichment(
   input: VideoEnrichmentInput,
 ): Promise<VideoEnrichmentOutput> {
@@ -325,13 +281,10 @@ export async function runVideoEnrichment(
     async function runAudioCleanupStep(): Promise<void> {
       try {
         await markStepRunning(input.jobId, "audio_cleanup")
-        const { runAudioCleanup } = await import("@/services/audioCleanup")
-        const { getMuxAsset, getPlaybackUrl } = await import("@/services/mux")
-        const playbackId =
-          input.playbackId ?? (await getMuxAsset(input.muxAssetId)).playbackId
-        const audioCleanupResult = await runAudioCleanup({
+        const audioCleanupResult = await stepAudioCleanup({
           assetId: input.assetId,
-          sourceVideoUrl: getPlaybackUrl(playbackId),
+          muxAssetId: input.muxAssetId,
+          playbackId: input.playbackId,
         })
         await persistMergedArtifacts(
           input.jobId,
@@ -438,21 +391,20 @@ export async function runVideoEnrichment(
           buildDownloadableArtifactManifest(result.artifactKeys),
         )
 
-        let syncReport: EmbeddingSyncReport
-        try {
-          const { syncEmbeddingArtifact } =
-            await import("@/services/embeddingSync")
-          syncReport = await syncEmbeddingArtifact({
-            assetId: input.assetId,
-            videoDocumentId: input.videoDocumentId,
-          })
-        } catch (error) {
-          syncReport = buildFallbackEmbeddingSyncReport(
-            result,
-            input.videoDocumentId,
-            error instanceof Error ? error.message : "embedding_sync_failed",
-          )
-        }
+        const syncReport = await stepEmbeddingSync({
+          assetId: input.assetId,
+          videoDocumentId: input.videoDocumentId,
+          generated: {
+            model: result.model,
+            dimensions: result.dimensions,
+            chunks: result.chunks,
+            metadataGeneratedAt:
+              typeof result.metadata?.generatedAt === "string"
+                ? result.metadata.generatedAt
+                : undefined,
+            hasMetadataEmbedding: result.metadataEmbedding != null,
+          },
+        })
 
         await persistMergedArtifacts(
           input.jobId,
@@ -550,37 +502,15 @@ export async function runVideoEnrichment(
     // Error-isolated: scene analysis failure does not block core enrichment.
     if (input.runSceneAnalysis) {
       try {
-        const { extractAndStoreSceneBoundaries } =
-          await import("@/services/sceneBoundaries")
-        const { analyzeAllScenes } = await import("@/services/sceneAnalysis")
-        const { syncSceneAnalysisEmbeddings } =
-          await import("@/services/sceneEmbeddingSync")
-        const { getMuxAsset } = await import("@/services/mux")
-
-        const boundaries = await extractAndStoreSceneBoundaries(
-          input.assetId,
-          chaptersResult.value.result.chapters,
-          transcription.text,
-        )
-
-        const muxAsset = await getMuxAsset(input.muxAssetId)
-        const analysisResult = await analyzeAllScenes(
-          input.assetId,
-          muxAsset.playbackId,
-          boundaries.scenes,
-          {
-            videoLabel: input.videoLabel ?? "unknown",
-            bibleVerses: input.bibleVerses,
-          },
-        )
-
-        const sceneEmbeddingSyncReport = await syncSceneAnalysisEmbeddings({
+        const sceneEmbeddingSyncReport = await stepSceneAnalysisAndSync({
           assetId: input.assetId,
           videoDocumentId: input.videoDocumentId,
           muxAssetId: input.muxAssetId,
-          playbackId: muxAsset.playbackId,
           language: transcription.language,
-          analysisResult,
+          transcript: transcription.text,
+          chapters: chaptersResult.value.result.chapters,
+          videoLabel: input.videoLabel ?? "unknown",
+          bibleVerses: input.bibleVerses,
         })
 
         if (
@@ -725,4 +655,120 @@ async function stepMuxUpload(input: {
   "use step"
   const { syncTranslatedSubtitlesToMux } = await import("@/services/mux-sync")
   return syncTranslatedSubtitlesToMux(input)
+}
+
+async function stepAudioCleanup(input: {
+  assetId: string
+  muxAssetId: string
+  playbackId?: string
+}) {
+  "use step"
+  const { runAudioCleanup } = await import("@/services/audioCleanup")
+  const { getMuxAsset, getPlaybackUrl } = await import("@/services/mux")
+  const playbackId =
+    input.playbackId ?? (await getMuxAsset(input.muxAssetId)).playbackId
+
+  return runAudioCleanup({
+    assetId: input.assetId,
+    sourceVideoUrl: getPlaybackUrl(playbackId),
+  })
+}
+
+async function stepEmbeddingSync(input: {
+  assetId: string
+  videoDocumentId?: string
+  generated: {
+    model: string
+    dimensions: number
+    chunks: Array<{ text: string }>
+    metadataGeneratedAt?: string
+    hasMetadataEmbedding: boolean
+  }
+}): Promise<EmbeddingSyncReport> {
+  "use step"
+
+  try {
+    const { syncEmbeddingArtifact } = await import("@/services/embeddingSync")
+    return await syncEmbeddingArtifact({
+      assetId: input.assetId,
+      videoDocumentId: input.videoDocumentId,
+    })
+  } catch (error) {
+    const { createHash } = await import("node:crypto")
+
+    return {
+      domain: "embeddings",
+      status: "failed",
+      ...(input.videoDocumentId
+        ? { videoDocumentId: input.videoDocumentId }
+        : {}),
+      reason: error instanceof Error ? error.message : "embedding_sync_failed",
+      generated: {
+        model: input.generated.model,
+        dimensions: input.generated.dimensions,
+        chunkCount: input.generated.chunks.length,
+        contentFingerprint: `sha256:${createHash("sha256")
+          .update(
+            JSON.stringify({
+              model: input.generated.model,
+              chunks: input.generated.chunks.map((chunk, index) => ({
+                index,
+                text: chunk.text,
+              })),
+            }),
+          )
+          .digest("hex")}`,
+        hasMetadataEmbedding: input.generated.hasMetadataEmbedding,
+        ...(input.generated.metadataGeneratedAt
+          ? { generatedAt: input.generated.metadataGeneratedAt }
+          : {}),
+      },
+    }
+  }
+}
+
+async function stepSceneAnalysisAndSync(input: {
+  assetId: string
+  videoDocumentId?: string
+  muxAssetId: string
+  language: string
+  transcript: string
+  chapters: Chapter[]
+  videoLabel: string
+  bibleVerses?: string[]
+}) {
+  "use step"
+
+  const { extractAndStoreSceneBoundaries } =
+    await import("@/services/sceneBoundaries")
+  const { analyzeAllScenes } = await import("@/services/sceneAnalysis")
+  const { syncSceneAnalysisEmbeddings } =
+    await import("@/services/sceneEmbeddingSync")
+  const { getMuxAsset } = await import("@/services/mux")
+
+  const boundaries = await extractAndStoreSceneBoundaries(
+    input.assetId,
+    input.chapters,
+    input.transcript,
+  )
+
+  const muxAsset = await getMuxAsset(input.muxAssetId)
+  const analysisResult = await analyzeAllScenes(
+    input.assetId,
+    muxAsset.playbackId,
+    boundaries.scenes,
+    {
+      videoLabel: input.videoLabel,
+      bibleVerses: input.bibleVerses,
+    },
+  )
+
+  return syncSceneAnalysisEmbeddings({
+    assetId: input.assetId,
+    videoDocumentId: input.videoDocumentId,
+    muxAssetId: input.muxAssetId,
+    playbackId: muxAsset.playbackId,
+    language: input.language,
+    analysisResult,
+  })
 }

--- a/docs/plans/2026-04-22-001-feat-031-manager-workflow-durability-plan.md
+++ b/docs/plans/2026-04-22-001-feat-031-manager-workflow-durability-plan.md
@@ -1,0 +1,226 @@
+---
+title: "feat: Make the manager video enrichment workflow actually durable"
+type: feat
+status: active
+date: 2026-04-22
+origin: docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md
+---
+
+# feat: Make the manager video enrichment workflow actually durable
+
+## Overview
+
+Plan the next narrow slice for `feat-031`: wire the existing `apps/manager` video enrichment pipeline into a real workflow runtime so `runVideoEnrichment()` is no longer just a plain async function launched from a request handler. This slice is about durable execution for the current five-step pipeline, not about adding new enrichment capabilities.
+
+## Problem Frame
+
+`feat-031` is marked `in-progress`, and the current manager app already contains step orchestration for transcription, translation, chapters, metadata, and embeddings. But the code explicitly says the `"use workflow"` / `"use step"` directives are inert because `apps/manager/next.config.ts` does not enable the workflow build plugin, and both API entrypoints still launch the full pipeline via `after(async () => runVideoEnrichment(...))`.
+
+That means the pipeline currently behaves like best-effort background work tied to the request lifecycle instead of a durable workflow. A restart, deployment, or runtime interruption can strand jobs mid-run even though operator-visible job state already lives in Strapi. This leaves a core part of `feat-031` incomplete. (see origin: `docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md`)
+
+## Requirements Trace
+
+- R1. The existing enrichment pipeline in `apps/manager` must execute through real workflow-runtime semantics rather than direct inline async work.
+- R2. Keep the implementation bounded to the current five-step pipeline: transcription, translation, chapters, metadata, embeddings.
+- R3. Preserve Strapi-backed `EnrichmentJob` records in `apps/manager/src/lib/state.ts` as the operator-facing source of truth.
+- R4. Both `POST /api/jobs` and `POST /api/enrich` must launch work through the same shared path.
+- R5. Verification must prove the runtime launch path works without regressing job-state updates or route behavior.
+
+## Scope Boundaries
+
+- No voiceover/TTS work. That belongs to `feat-014` even though older manager docs mention it in the broader pipeline vision.
+- No new dashboard surface beyond whatever existing job-state fields already show.
+- No new CMS schema or GraphQL codegen work unless runtime integration proves an unavoidable persistence gap.
+- No rewrite of the enrichment services themselves.
+- No new queueing system beyond the workflow runtime already intended for this app.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/manager/src/workflows/videoEnrichment.ts`
+  The orchestration logic already exists, but the file header documents that durability is disabled until the workflow plugin is configured.
+- `apps/manager/src/app/api/jobs/route.ts`
+  Creates a Mux asset and then runs the entire enrichment pipeline inside `after(...)`.
+- `apps/manager/src/app/api/enrich/route.ts`
+  Creates batch jobs from CMS videos and duplicates the same direct `after(...)` launch pattern.
+- `apps/manager/next.config.ts`
+  Still exports a minimal Next config with no workflow build plugin.
+- `apps/manager/src/config/env.ts`
+  Already defines `WORKFLOW_API_KEY`, so the app has started the env contract for durable execution.
+- `apps/manager/src/lib/state.ts`
+  Job progress already persists in Strapi and should remain the canonical operator view during this slice.
+- `docs/solutions/platform/videoforge-manager-integration.md`
+  Records the intended durable-workflow architecture and confirms this was part of the original manager direction, even though the current code has not fully closed the loop.
+- `docs/plans/2026-03-17-001-feat-videoforge-manager-full-port-plan.md`
+  Older broad manager plan. Useful for context, but too wide to drive the next safe step on `feat-031`.
+
+### Institutional Learnings
+
+- The manager app already treats workflow steps as idempotent; that should remain the contract once the runtime is actually enabled.
+- `after()` is acceptable for post-response launch bookkeeping, but it is not a substitute for durable orchestration.
+- The repo already prefers keeping operator-visible truth in existing persisted state rather than inventing a second shadow status store.
+
+## Key Technical Decisions
+
+- **Create one shared launcher abstraction.**
+  Add `apps/manager/src/workflows/launchVideoEnrichment.ts` as the only place API routes trigger the workflow runtime. This removes duplicated launch logic from the routes and isolates SDK-specific wiring to one module.
+
+- **Enable the workflow plugin in `apps/manager/next.config.ts`.**
+  This slice should turn on the build/runtime path that makes `"use workflow"` and `"use step"` real. Leaving durability behind a silent missing-plugin state would keep `feat-031` misleadingly "in progress" without closing the core gap.
+
+- **Keep Strapi `EnrichmentJob` as the canonical job record.**
+  Do not add a second durable-job table in this slice. The runtime handles execution durability; Strapi remains the UI-facing state and audit surface.
+
+- **Retain the existing five workflow steps.**
+  Do not add `voiceover`, `mux_upload`, or `cms_notify` while enabling durability. Finishing execution semantics is already enough scope for one PR-sized slice.
+
+- **Use an explicit local-fallback policy instead of accidental direct execution.**
+  The implementation should not silently fall back to inline async work just because runtime wiring is missing. If local development needs a non-durable path, make that choice explicit in the launcher and document it clearly. Production/staging should fail loudly when durability is expected but unavailable.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this slice include voiceover because older manager docs mention it?**
+  No. `feat-014` exists as a separate roadmap ticket, and this run should not merge ticket scope.
+
+- **Should both API routes keep their own launch logic?**
+  No. They should converge on a single launcher helper so the runtime integration, error handling, and fallback policy live in one place.
+
+- **Should this slice add new CMS fields for workflow-run identifiers?**
+  Not initially. The smallest safe slice is to enable durable execution while continuing to use the existing `EnrichmentJob` record.
+
+### Deferred To Implementation
+
+- **Exact SDK hook-up details for `workflow@4.2.0-beta.70`.**
+  Confirm the concrete plugin and launcher API from the installed package while implementing, but keep that uncertainty boxed inside `launchVideoEnrichment.ts` and `next.config.ts`.
+
+- **Whether the current parallel `Promise.all(...)` block should remain a single orchestration segment or be broken into smaller runtime-managed units.**
+  Start by preserving the current step boundaries. If the SDK makes that pattern awkward, treat finer-grained fan-out as follow-up work rather than broadening this slice.
+
+## Implementation Units
+
+- [ ] **Unit 1: Enable the workflow runtime in the manager build**
+
+  **Goal:** Make the manager app compile the enrichment workflow through the intended workflow runtime instead of leaving directive strings inert.
+
+  **Requirements:** R1, R5
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `apps/manager/next.config.ts`
+  - Modify: `apps/manager/src/config/env.ts` (only if the SDK requires additional env wiring beyond `WORKFLOW_API_KEY`)
+
+  **Approach:**
+  - Add the workflow build plugin to the Next.js config for `apps/manager`
+  - Keep the config change isolated to manager; do not change root monorepo build settings
+  - Preserve existing `output: "standalone"` and `typedRoutes` behavior
+  - Make missing runtime configuration explicit instead of silently leaving the workflow as plain async code
+
+  **Verification:**
+  - `pnpm --filter @forge/manager typecheck`
+  - `pnpm --filter @forge/manager build`
+  - Build output no longer relies on the "plugin missing" condition described in `videoEnrichment.ts`
+
+- [ ] **Unit 2: Centralize workflow launching behind one shared helper**
+
+  **Goal:** Replace duplicated direct invocation logic with a single launch path that can own runtime integration, local fallback policy, and launch-time error handling.
+
+  **Requirements:** R1, R3, R4
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `apps/manager/src/workflows/launchVideoEnrichment.ts`
+  - Modify: `apps/manager/src/workflows/videoEnrichment.ts`
+
+  **Approach:**
+  - Define a shared launcher function that accepts the existing `VideoEnrichmentInput`
+  - Keep `runVideoEnrichment()` responsible for orchestration logic only
+  - Move runtime-specific trigger code out of route handlers and into the launcher
+  - Normalize launch failures so callers can mark jobs failed or surface an actionable operator error without duplicating that logic
+  - If a direct local-development fallback is retained, make the mode explicit in code and logs
+
+  **Verification:**
+  - `apps/manager/src/workflows/videoEnrichment.ts` no longer has to double as both runtime entrypoint and route-launch surface
+  - Launcher compiles cleanly and is the only workflow trigger path used by routes
+
+- [ ] **Unit 3: Switch both API entrypoints to the shared launcher**
+
+  **Goal:** Ensure every enrichment job enters the durable runtime the same way, whether it starts from a raw input URL or a CMS video selection.
+
+  **Requirements:** R3, R4, R5
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `apps/manager/src/app/api/jobs/route.ts`
+  - Modify: `apps/manager/src/app/api/enrich/route.ts`
+
+  **Approach:**
+  - Replace direct `after(async () => runVideoEnrichment(...))` calls with the launcher helper
+  - Keep route handlers focused on auth, validation, lookup/ingest, and job creation
+  - If `after()` is still needed, use it only to enqueue/trigger the runtime launch, not to host the entire pipeline body
+  - Keep job creation semantics unchanged so the dashboard and existing polling behavior continue to work
+
+  **Verification:**
+  - Both endpoints compile and call the same launcher
+  - Launch-time failures produce a clear job failure path instead of leaving a silently pending job
+  - Existing response shapes stay stable
+
+- [ ] **Unit 4: Align manager docs with the post-change runtime truth**
+
+  **Goal:** Remove the current mismatch where manager docs describe durable workflows while the code comments still say the runtime is inert.
+
+  **Requirements:** R5
+
+  **Dependencies:** Unit 3
+
+  **Files:**
+  - Modify: `apps/manager/CLAUDE.md`
+  - Modify: `docs/solutions/platform/videoforge-manager-integration.md`
+
+  **Approach:**
+  - Update manager guidance to state the actual runtime requirement and launch path after implementation lands
+  - Keep the solution doc honest about what is now durable versus what remains future work
+
+  **Verification:**
+  - Repo docs no longer contradict the implementation state of `feat-031`
+
+## System-Wide Impact
+
+- Primary impact is limited to `apps/manager`
+- No expected `apps/cms` or `packages/graphql` changes in the first slice
+- Railway manager deploys will need the runtime env configuration to stay valid once durability is enabled for real
+
+## Risks & Mitigations
+
+- **Workflow SDK API drift or unclear package ergonomics**
+  Keep all SDK-specific code inside the launcher helper and `next.config.ts` so the rest of the manager code stays stable.
+
+- **Build/runtime surprises after enabling the plugin**
+  Validate with a real manager build in the implementation phase instead of relying on typecheck alone.
+
+- **Silent local fallback reintroduces the same durability gap**
+  Make any fallback explicit and development-only. Production/staging should fail closed if runtime configuration is missing.
+
+- **Current parallel step fan-out may not map perfectly to runtime checkpoints**
+  Preserve the current shape first. If finer-grained runtime fan-out is needed, capture it as a follow-up instead of expanding this ticket slice mid-run.
+
+## Verification Strategy
+
+- `pnpm --filter @forge/manager typecheck`
+- `pnpm --filter @forge/manager build`
+- Manual smoke test against manager:
+  - create a job through `POST /api/jobs` or `POST /api/enrich`
+  - confirm the route returns quickly after job creation
+  - confirm the job enters the shared launch path
+  - confirm Strapi-backed step state still transitions through running/completed or failed
+
+## Sources & References
+
+- Origin ticket: `docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md`
+- Existing manager plan: `docs/plans/2026-03-17-001-feat-videoforge-manager-full-port-plan.md`
+- Existing manager solution doc: `docs/solutions/platform/videoforge-manager-integration.md`

--- a/docs/plans/2026-04-22-001-feat-031-manager-workflow-durability-plan.md
+++ b/docs/plans/2026-04-22-001-feat-031-manager-workflow-durability-plan.md
@@ -3,6 +3,7 @@ title: "feat: Make the manager video enrichment workflow actually durable"
 type: feat
 status: active
 date: 2026-04-22
+deepened: 2026-04-22
 origin: docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md
 ---
 
@@ -14,17 +15,21 @@ Plan the next narrow slice for `feat-031`: wire the existing `apps/manager` vide
 
 ## Problem Frame
 
-`feat-031` is marked `in-progress`, and the current manager app already contains step orchestration for transcription, translation, chapters, metadata, and embeddings. But the code explicitly says the `"use workflow"` / `"use step"` directives are inert because `apps/manager/next.config.ts` does not enable the workflow build plugin, and both API entrypoints still launch the full pipeline via `after(async () => runVideoEnrichment(...))`.
+`feat-031` is marked `in-progress`, and the current manager app already contains step orchestration for transcription, translation, chapters, metadata, embeddings, mux sync, and related artifact persistence. `origin/main` also now has substantial workflow-body and route-level test coverage. But the code still explicitly says the `"use workflow"` / `"use step"` directives are inert because `apps/manager/next.config.ts` does not enable the workflow build plugin, and the enrichment workflow is still launched directly from route handlers instead of via `start()` from `workflow/api`.
 
-That means the pipeline currently behaves like best-effort background work tied to the request lifecycle instead of a durable workflow. A restart, deployment, or runtime interruption can strand jobs mid-run even though operator-visible job state already lives in Strapi. This leaves a core part of `feat-031` incomplete. (see origin: `docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md`)
+Today, `POST /api/jobs`, `POST /api/enrich`, and `POST /api/jobs/[id]/transcription/rerun` all still end up calling `runVideoEnrichment(...)` from inside `after(...)`. That means the pipeline behaves like best-effort background work tied to the request lifecycle instead of a durable workflow. A restart, deployment, or runtime interruption can strand jobs mid-run even though operator-visible job state already lives in Strapi. This leaves a core part of `feat-031` incomplete. (see origin: `docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md`)
 
 ## Requirements Trace
 
 - R1. The existing enrichment pipeline in `apps/manager` must execute through real workflow-runtime semantics rather than direct inline async work.
 - R2. Keep the implementation bounded to the current five-step pipeline: transcription, translation, chapters, metadata, embeddings.
 - R3. Preserve Strapi-backed `EnrichmentJob` records in `apps/manager/src/lib/state.ts` as the operator-facing source of truth.
-- R4. Both `POST /api/jobs` and `POST /api/enrich` must launch work through the same shared path.
-- R5. Verification must prove the runtime launch path works without regressing job-state updates or route behavior.
+- R4. All enrichment launch entrypoints must dispatch through the same shared runtime path: `POST /api/jobs`, `POST /api/enrich`, and `POST /api/jobs/[id]/transcription/rerun`.
+- R5. Red/Green TDD is required. The plan must use dispatch-level tests in addition to existing workflow-body tests.
+- R6. A user smoke test is required against a built manager runtime, not only Vitest or `pnpm dev`.
+- R7. Verification must prove the runtime launch path works without regressing job-state updates or route behavior.
+- R8. Work must follow repo branch/PR conventions: canonical branch `feat/031-ai-video-enrichment-pipeline`, PR target `main`, and no skipped pre-commit hooks.
+- R9. This slice must not rename or reorder the persisted manager workflow step inventory unless a deliberate follow-up ticket expands scope.
 
 ## Scope Boundaries
 
@@ -33,6 +38,7 @@ That means the pipeline currently behaves like best-effort background work tied 
 - No new CMS schema or GraphQL codegen work unless runtime integration proves an unavoidable persistence gap.
 - No rewrite of the enrichment services themselves.
 - No new queueing system beyond the workflow runtime already intended for this app.
+- No renaming or reordering of `FORGE_WORKFLOW_STEPS`; coverage reporting, CMS enums, and generated GraphQL contracts already depend on that inventory.
 
 ## Context & Research
 
@@ -44,22 +50,45 @@ That means the pipeline currently behaves like best-effort background work tied 
   Creates a Mux asset and then runs the entire enrichment pipeline inside `after(...)`.
 - `apps/manager/src/app/api/enrich/route.ts`
   Creates batch jobs from CMS videos and duplicates the same direct `after(...)` launch pattern.
+- `apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts`
+  Requeues transcription reruns but still launches `runVideoEnrichment(...)` directly inside `after(...)`.
 - `apps/manager/next.config.ts`
   Still exports a minimal Next config with no workflow build plugin.
 - `apps/manager/src/config/env.ts`
   Already defines `WORKFLOW_API_KEY`, so the app has started the env contract for durable execution.
 - `apps/manager/src/lib/state.ts`
-  Job progress already persists in Strapi and should remain the canonical operator view during this slice.
+  Job progress already persists in Strapi and should remain the canonical operator view during this slice. This is more trustworthy than the stale "file-backed" wording still present in `apps/manager/AGENTS.md`.
+- `apps/manager/src/lib/workflow-steps.ts`
+  Canonical persisted step inventory for manager jobs.
+- `apps/manager/src/lib/workflow-steps.test.ts`
+  Locks the manager step inventory to the CMS enum and generated GraphQL types, so durability work should not casually change step order or names.
+- `apps/manager/src/features/coverage/coverage-report-model.ts`
+  Coverage/completeness logic derives from persisted manager workflow steps, so step-contract drift would leak into operator-facing reporting immediately.
+- `apps/manager/src/workflows/videoEnrichment.test.ts`
+  `origin/main` already has substantial workflow-body coverage, so the plan should extend tests rather than acting as if the harness is missing.
+- `apps/manager/src/app/api/enrich/route.test.ts`
+  Existing route-test pattern for enrich helpers.
+- `apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts`
+  Existing route-test pattern already mocking `after(...)` and `runVideoEnrichment(...)`; this should evolve into dispatch assertions once the launcher changes.
 - `docs/solutions/platform/videoforge-manager-integration.md`
   Records the intended durable-workflow architecture and confirms this was part of the original manager direction, even though the current code has not fully closed the loop.
 - `docs/plans/2026-03-17-001-feat-videoforge-manager-full-port-plan.md`
   Older broad manager plan. Useful for context, but too wide to drive the next safe step on `feat-031`.
+- `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md`
+  Strongest local learning for this slice: workflow-body tests are insufficient once `withWorkflow` is enabled; dispatch sites must be tested directly.
+- `docs/plans/2026-04-21-002-fix-admin-workflow-dispatch-plan.md`
+  Best local implementation precedent for enabling real workflow dispatch in this monorepo.
+- `apps/admin/src/test-helpers/workflow-dispatch.ts`
+  Existing helper pattern for asserting `start()` dispatches correctly.
+- Official Workflow DevKit docs:
+  `withWorkflow(...)` is the actual Next.js boundary that transforms `"use workflow"` / `"use step"` directives, and `start()` is the runtime API for enqueueing workflow runs from API routes. The local world is bundled automatically for local development, and the vendor's own compatibility tests run against a built Next.js app started with `next start`.
 
 ### Institutional Learnings
 
 - The manager app already treats workflow steps as idempotent; that should remain the contract once the runtime is actually enabled.
 - `after()` is acceptable for post-response launch bookkeeping, but it is not a substitute for durable orchestration.
 - The repo already prefers keeping operator-visible truth in existing persisted state rather than inventing a second shadow status store.
+- useworkflow has a proven repo-local trap: `"use workflow"` functions can still pass unit tests while crashing in a real built runtime if callers forget to dispatch via `start()`.
 
 ## Key Technical Decisions
 
@@ -69,14 +98,32 @@ That means the pipeline currently behaves like best-effort background work tied 
 - **Enable the workflow plugin in `apps/manager/next.config.ts`.**
   This slice should turn on the build/runtime path that makes `"use workflow"` and `"use step"` real. Leaving durability behind a silent missing-plugin state would keep `feat-031` misleadingly "in progress" without closing the core gap.
 
+- **Mirror the admin app's bounded workflow scan.**
+  The manager app should follow `apps/admin/next.config.ts` and restrict workflow scanning to `src/workflows`. That keeps plugin scope tight and avoids reintroducing the wide directory scan risk already documented in the admin precedent.
+
+- **Use the admin dispatch pattern as the runtime reference, not manager's current behavior.**
+  `apps/admin` is now the only app in the monorepo with a live workflow dispatch pattern. Manager should follow that precedent for plugin wiring and dispatch tests rather than treating its existing direct invocation as a reference.
+
+- **Dispatch directly from the request path; do not keep `after()` as the primary launch boundary.**
+  Official Workflow docs describe `start()` as the runtime API for API routes and note that it returns immediately after enqueueing a run. For manager's enrichment routes, the target state should therefore be: persist the job, call `start()` exactly once, then return the normal 201/202 response. Keeping the enqueue itself inside `after()` should be treated as a fallback only if implementation uncovers a concrete incompatibility.
+
 - **Keep Strapi `EnrichmentJob` as the canonical job record.**
   Do not add a second durable-job table in this slice. The runtime handles execution durability; Strapi remains the UI-facing state and audit surface.
 
 - **Retain the existing five workflow steps.**
   Do not add `voiceover`, `mux_upload`, or `cms_notify` while enabling durability. Finishing execution semantics is already enough scope for one PR-sized slice.
 
-- **Use an explicit local-fallback policy instead of accidental direct execution.**
-  The implementation should not silently fall back to inline async work just because runtime wiring is missing. If local development needs a non-durable path, make that choice explicit in the launcher and document it clearly. Production/staging should fail loudly when durability is expected but unavailable.
+- **Cover every workflow launch surface in one slice.**
+  The shared launcher must replace direct calls in `POST /api/jobs`, `POST /api/enrich`, and `POST /api/jobs/[id]/transcription/rerun`. Fixing only two of the three would leave the same production crash class behind.
+
+- **Red/Green TDD must focus on dispatch, not just workflow internals.**
+  Existing `videoEnrichment.test.ts` cases remain valuable, but the required new red tests should assert dispatch through `start()` from `workflow/api` at the call sites. That is the only test layer that catches the built-runtime failure class documented on 2026-04-21.
+
+- **The user smoke test must exercise a built runtime.**
+  Because directives can remain inert in test/dev execution paths, smoke must run against the built manager runtime, then invoke a real enrichment path and confirm durable dispatch/job progression. This is also consistent with Workflow DevKit's own published local-world compatibility testing, which validates built Next.js apps started in production mode.
+
+- **The execution plan should follow the repo's canonical branch and PR path.**
+  The implementation branch for this ticket remains `feat/031-ai-video-enrichment-pipeline`, the PR should target `main`, and the plan should call out that pre-commit hooks must not be bypassed.
 
 ## Open Questions
 
@@ -88,26 +135,59 @@ That means the pipeline currently behaves like best-effort background work tied 
 - **Should both API routes keep their own launch logic?**
   No. They should converge on a single launcher helper so the runtime integration, error handling, and fallback policy live in one place.
 
+- **Should transcription rerun be part of this slice?**
+  Yes. `origin/main` shows it dispatching the same workflow directly, so leaving it out would preserve the same non-durable path in production.
+
 - **Should this slice add new CMS fields for workflow-run identifiers?**
   Not initially. The smallest safe slice is to enable durable execution while continuing to use the existing `EnrichmentJob` record.
 
 ### Deferred To Implementation
 
-- **Exact SDK hook-up details for `workflow@4.2.0-beta.70`.**
-  Confirm the concrete plugin and launcher API from the installed package while implementing, but keep that uncertainty boxed inside `launchVideoEnrichment.ts` and `next.config.ts`.
+- **Exact SDK hook-up details for `workflow@4.2.2`.**
+  Confirm the concrete `withWorkflow(...)` and `start(...)` usage from the installed package while implementing, but keep that uncertainty boxed inside `launchVideoEnrichment.ts`, route tests, and `next.config.ts`.
+
+- **Whether any manager route truly still needs `after()` once dispatch is durable.**
+  The default plan assumption is "no" because `start()` already enqueues without waiting for workflow completion. If one route still needs `after()`, implementation should document why that route is exceptional.
 
 - **Whether the current parallel `Promise.all(...)` block should remain a single orchestration segment or be broken into smaller runtime-managed units.**
   Start by preserving the current step boundaries. If the SDK makes that pattern awkward, treat finer-grained fan-out as follow-up work rather than broadening this slice.
 
+- **Whether manager should copy the admin test helper directly or create a manager-local equivalent.**
+  Decide during implementation based on import-path ergonomics and whether the helper belongs in a shared package. The important requirement is dispatch-level coverage, not where the helper lives.
+
 ## Implementation Units
 
-- [ ] **Unit 1: Enable the workflow runtime in the manager build**
+- [x] **Unit 1: Red phase — add dispatch-focused tests for every enrichment launch surface**
+
+  **Goal:** Prove the current `origin/main` dispatch boundary is wrong before implementation, and establish regression coverage for the built-runtime failure class.
+
+  **Requirements:** R4, R5, R7
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `apps/manager/src/app/api/jobs/route.test.ts`
+  - Modify: `apps/manager/src/app/api/enrich/route.test.ts`
+  - Modify: `apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts`
+  - Modify or Create: a manager dispatch test helper if reusing the admin helper directly is not appropriate
+
+  **Approach:**
+  - Mock `start()` from `workflow/api` and assert each entrypoint dispatches the workflow with the expected function reference and args tuple
+  - Follow the local dispatch-test learning from `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md`
+  - Preserve existing route-level auth and validation assertions
+  - Assert exactly one dispatch per request path so the slice catches accidental double-dispatch regressions during the move away from `after(...)`
+  - Do not treat current `videoEnrichment.test.ts` coverage as sufficient for this slice; those tests are workflow-body coverage, not dispatch coverage
+
+  **Verification:**
+  - The new/updated tests fail red on current `origin/main` because entrypoints still call `runVideoEnrichment(...)` directly
+
+- [x] **Unit 2: Enable the workflow runtime in the manager build**
 
   **Goal:** Make the manager app compile the enrichment workflow through the intended workflow runtime instead of leaving directive strings inert.
 
-  **Requirements:** R1, R5
+  **Requirements:** R1, R7
 
-  **Dependencies:** None
+  **Dependencies:** Unit 1
 
   **Files:**
   - Modify: `apps/manager/next.config.ts`
@@ -115,6 +195,7 @@ That means the pipeline currently behaves like best-effort background work tied 
 
   **Approach:**
   - Add the workflow build plugin to the Next.js config for `apps/manager`
+  - Mirror admin's bounded `workflows.dirs = [\"src/workflows\"]` pattern unless manager's file layout proves that restriction is insufficient
   - Keep the config change isolated to manager; do not change root monorepo build settings
   - Preserve existing `output: "standalone"` and `typedRoutes` behavior
   - Make missing runtime configuration explicit instead of silently leaving the workflow as plain async code
@@ -124,13 +205,13 @@ That means the pipeline currently behaves like best-effort background work tied 
   - `pnpm --filter @forge/manager build`
   - Build output no longer relies on the "plugin missing" condition described in `videoEnrichment.ts`
 
-- [ ] **Unit 2: Centralize workflow launching behind one shared helper**
+- [x] **Unit 3: Centralize workflow launching behind one shared helper**
 
   **Goal:** Replace duplicated direct invocation logic with a single launch path that can own runtime integration, local fallback policy, and launch-time error handling.
 
-  **Requirements:** R1, R3, R4
+  **Requirements:** R1, R3, R4, R7
 
-  **Dependencies:** Unit 1
+  **Dependencies:** Unit 2
 
   **Files:**
   - Create: `apps/manager/src/workflows/launchVideoEnrichment.ts`
@@ -140,47 +221,92 @@ That means the pipeline currently behaves like best-effort background work tied 
   - Define a shared launcher function that accepts the existing `VideoEnrichmentInput`
   - Keep `runVideoEnrichment()` responsible for orchestration logic only
   - Move runtime-specific trigger code out of route handlers and into the launcher
+  - Make the launcher's default contract "dispatch exactly once and return enqueue metadata", not "wait for workflow completion"
   - Normalize launch failures so callers can mark jobs failed or surface an actionable operator error without duplicating that logic
-  - If a direct local-development fallback is retained, make the mode explicit in code and logs
+  - If a direct local-development fallback is retained, make the mode explicit in code and logs rather than silently reintroducing non-durable behavior
 
   **Verification:**
   - `apps/manager/src/workflows/videoEnrichment.ts` no longer has to double as both runtime entrypoint and route-launch surface
   - Launcher compiles cleanly and is the only workflow trigger path used by routes
 
-- [ ] **Unit 3: Switch both API entrypoints to the shared launcher**
+- [x] **Unit 4: Switch all enrichment entrypoints to the shared launcher**
 
-  **Goal:** Ensure every enrichment job enters the durable runtime the same way, whether it starts from a raw input URL or a CMS video selection.
+  **Goal:** Ensure every enrichment job enters the durable runtime the same way, whether it starts from a raw input URL, a CMS video selection, or a transcription rerun.
 
-  **Requirements:** R3, R4, R5
-
-  **Dependencies:** Unit 2
-
-  **Files:**
-  - Modify: `apps/manager/src/app/api/jobs/route.ts`
-  - Modify: `apps/manager/src/app/api/enrich/route.ts`
-
-  **Approach:**
-  - Replace direct `after(async () => runVideoEnrichment(...))` calls with the launcher helper
-  - Keep route handlers focused on auth, validation, lookup/ingest, and job creation
-  - If `after()` is still needed, use it only to enqueue/trigger the runtime launch, not to host the entire pipeline body
-  - Keep job creation semantics unchanged so the dashboard and existing polling behavior continue to work
-
-  **Verification:**
-  - Both endpoints compile and call the same launcher
-  - Launch-time failures produce a clear job failure path instead of leaving a silently pending job
-  - Existing response shapes stay stable
-
-- [ ] **Unit 4: Align manager docs with the post-change runtime truth**
-
-  **Goal:** Remove the current mismatch where manager docs describe durable workflows while the code comments still say the runtime is inert.
-
-  **Requirements:** R5
+  **Requirements:** R3, R4, R5, R7
 
   **Dependencies:** Unit 3
 
   **Files:**
+  - Modify: `apps/manager/src/app/api/jobs/route.ts`
+  - Modify: `apps/manager/src/app/api/enrich/route.ts`
+  - Modify: `apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts`
+
+  **Approach:**
+  - Replace direct workflow calls with the launcher helper and `start(...)` dispatch path
+  - Keep route handlers focused on auth, validation, lookup/ingest, and job creation
+  - Prefer direct dispatch from the request path; only keep `after()` if implementation proves one route needs post-response enqueue semantics
+  - Keep job creation semantics unchanged so the dashboard and existing polling behavior continue to work
+
+  **Verification:**
+  - All three entrypoints compile and call the same launcher
+  - No entrypoint both dispatches inline and enqueues a second run via `after()`
+  - Launch-time failures produce a clear job failure path instead of leaving a silently pending job
+  - Existing response shapes stay stable
+
+## High-Level Technical Design
+
+This diagram is directional planning guidance, not implementation specification.
+
+```mermaid
+flowchart TD
+  A["Manager API route\njobs / enrich / transcription rerun"] --> B["Validate request + persist EnrichmentJob in Strapi"]
+  B --> C["launchVideoEnrichment(input)"]
+  C --> D["start(runVideoEnrichment, [input])\nfrom workflow/api"]
+  D --> E["Immediate 201/202 response\nexisting route contract preserved"]
+  D --> F["Workflow runtime executes steps\ntranscription -> translation -> chapters -> metadata -> embeddings"]
+  F --> G["updateJob / updateStepStatus\npersist progress in Strapi"]
+  G --> H["Manager UI polls job state\nfrom persisted CMS-backed records"]
+```
+
+Design implications:
+
+- The route owns validation, job creation, and one-time dispatch.
+- The workflow function owns orchestration and step-level persistence.
+- Strapi remains the operator-facing source of truth; workflow runtime durability is execution infrastructure, not a replacement job store.
+- Because `start()` already enqueues asynchronously, the route should not need to wait for workflow completion or wrap the whole workflow body in `after()`.
+
+- [x] **Unit 5: Green phase — keep workflow-body coverage honest and aligned**
+
+  **Goal:** Preserve and extend the existing manager workflow-body tests so dispatch wiring does not hide real orchestration regressions.
+
+  **Requirements:** R5, R7
+
+  **Dependencies:** Unit 4
+
+  **Files:**
+  - Modify: `apps/manager/src/workflows/videoEnrichment.test.ts`
+
+  **Approach:**
+  - Keep existing body-level tests intact; only adjust them where plugin/runtime integration changes helper boundaries or import paths
+  - Add one focused case if needed to ensure the launcher/runtime integration does not change the current workflow contract unexpectedly
+  - Avoid replacing body coverage with dispatch coverage; both layers are needed
+
+  **Verification:**
+  - `pnpm --filter @forge/manager test -- src/workflows/videoEnrichment.test.ts`
+
+- [x] **Unit 6: Align manager docs with the post-change runtime truth**
+
+  **Goal:** Remove the current mismatch where manager docs describe durable workflows while the code comments still say the runtime is inert.
+
+  **Requirements:** R7, R8
+
+  **Dependencies:** Unit 5
+
+  **Files:**
   - Modify: `apps/manager/CLAUDE.md`
   - Modify: `docs/solutions/platform/videoforge-manager-integration.md`
+  - Consider Modify: `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md` only if the manager implementation adds a reusable nuance worth compounding
 
   **Approach:**
   - Update manager guidance to state the actual runtime requirement and launch path after implementation lands
@@ -189,34 +315,117 @@ That means the pipeline currently behaves like best-effort background work tied 
   **Verification:**
   - Repo docs no longer contradict the implementation state of `feat-031`
 
+- [ ] **Unit 7: Run required user smoke test against the built runtime**
+
+  **Goal:** Prove the new dispatch path works in the only environment that matters for this bug class: the compiled manager runtime.
+
+  **Requirements:** R6, R7
+
+  **Dependencies:** Unit 6
+
+  **Files:**
+  - No required source changes
+  - Capture evidence in the PR description or follow-up compound doc if the repo's normal workflow expects it
+
+  **Approach:**
+  - Run `pnpm --filter @forge/manager build`
+  - Start the built manager app with `pnpm --filter @forge/manager start`
+  - Trigger a real enrichment path through one of the operator entrypoints
+  - Confirm the route returns quickly, the workflow dispatch succeeds, and job state advances through the persisted Strapi surface
+  - Prefer a user-visible smoke that proves the feature end-to-end rather than relying only on logs
+
+  **Verification:**
+  - Smoke is performed against the built runtime, not only `pnpm dev`
+  - Evidence shows dispatch succeeds without the direct-call runtime error
+  - Current run completed a production-mode boot smoke (`next build`, `next start`, `GET /login`, `GET /api/health`) with placeholder env values, but did not exercise a real enrichment job because live Strapi/Mux/OpenRouter credentials were not present in this environment
+
+## Red/Green TDD Plan
+
+This slice requires explicit Red/Green TDD.
+
+### Red
+
+1. Add dispatch tests around:
+   - `apps/manager/src/app/api/jobs/route.ts`
+   - `apps/manager/src/app/api/enrich/route.ts`
+   - `apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts`
+2. Mock `start()` from `workflow/api` and assert the correct workflow function + args tuple are dispatched.
+3. Confirm those tests fail against the current direct-call implementation.
+
+### Green
+
+1. Wire `withWorkflow(...)` into `apps/manager/next.config.ts`.
+2. Introduce `apps/manager/src/workflows/launchVideoEnrichment.ts`.
+3. Update all three route entrypoints to dispatch via the launcher instead of calling `runVideoEnrichment(...)` directly.
+4. Update/repair existing `videoEnrichment.test.ts` cases only as needed to preserve workflow-body coverage.
+
+### Smoke
+
+1. Build manager with `pnpm --filter @forge/manager build`.
+2. Start the built app with `pnpm --filter @forge/manager start`.
+3. Trigger a real enrichment launch and confirm durable dispatch plus persisted job progression.
+
+## Repo Workflow Requirements
+
+- Use the canonical ticket branch: `feat/031-ai-video-enrichment-pipeline`
+- Keep the work in one PR-sized slice
+- Target PRs to `main`
+- Use conventional commits
+- Do not skip pre-commit hooks with `--no-verify`
+- Before opening or updating the PR, run the touched-scope validation and include the required red/green test evidence plus the built-runtime smoke result
+
 ## System-Wide Impact
 
 - Primary impact is limited to `apps/manager`
 - No expected `apps/cms` or `packages/graphql` changes in the first slice
-- Railway manager deploys will need the runtime env configuration to stay valid once durability is enabled for real
+- Manager build behavior changes materially: `next.config.ts` will now transform workflow directives and should mirror the admin app's bounded workflow directory configuration
+- API semantics stay intentionally stable at the surface level (201/202 job creation responses), but the internal execution boundary changes from in-process async work to dispatched workflow runs
+- Strapi job persistence remains on the critical path for operator truth; dispatch durability reduces execution fragility but does not remove the need for step-level write correctness
+- Coverage/reporting contracts should remain unchanged because persisted workflow step names and order are explicitly out of scope for this slice
+- Local smoke likely exercises Workflow's bundled local world rather than an external service, so runtime verification should be framed as "built manager runtime + persisted job progression", not as an infrastructure migration
 
 ## Risks & Mitigations
 
 - **Workflow SDK API drift or unclear package ergonomics**
   Keep all SDK-specific code inside the launcher helper and `next.config.ts` so the rest of the manager code stays stable.
 
+- **Dispatch tests are skipped in favor of body tests**
+  Treat that as a plan failure, not an implementation shortcut. The admin dispatch learning shows body tests alone will miss the production regression class.
+
 - **Build/runtime surprises after enabling the plugin**
   Validate with a real manager build in the implementation phase instead of relying on typecheck alone.
 
+- **Direct-route dispatch accidentally changes request timing or response shape**
+  Keep the route contract explicit: dispatch once, return the existing job payload, and do not await workflow completion.
+
+- **Double-dispatch during the transition from `after()` to `start()`**
+  Add red tests that assert one dispatch per request path, then remove `after()` from the happy path unless a route proves it is strictly necessary.
+
 - **Silent local fallback reintroduces the same durability gap**
-  Make any fallback explicit and development-only. Production/staging should fail closed if runtime configuration is missing.
+  Avoid fallback-by-default. Production/staging should fail closed if runtime configuration is missing.
 
 - **Current parallel step fan-out may not map perfectly to runtime checkpoints**
   Preserve the current shape first. If finer-grained runtime fan-out is needed, capture it as a follow-up instead of expanding this ticket slice mid-run.
 
+- **Plugin scan scope grows too wide and slows or destabilizes builds**
+  Start with the admin precedent of `workflows.dirs = [\"src/workflows\"]` and only widen the scope if manager's workflow layout truly requires it.
+
+- **Smoke passes in dev but not in the built runtime**
+  Treat `pnpm dev` as insufficient proof for this feature. The required smoke must run against the compiled app.
+
 ## Verification Strategy
 
+- Red TDD:
+  - `pnpm --filter @forge/manager test -- src/app/api/enrich/route.test.ts 'src/app/api/jobs/[id]/transcription/rerun/route.test.ts'`
+  - plus the new `src/app/api/jobs/route.test.ts`
 - `pnpm --filter @forge/manager typecheck`
+- `pnpm --filter @forge/manager test -- src/workflows/videoEnrichment.test.ts`
 - `pnpm --filter @forge/manager build`
-- Manual smoke test against manager:
+- User smoke test against the built manager runtime:
   - create a job through `POST /api/jobs` or `POST /api/enrich`
+  - optionally verify rerun dispatch through `POST /api/jobs/[id]/transcription/rerun`
   - confirm the route returns quickly after job creation
-  - confirm the job enters the shared launch path
+  - confirm the job enters the shared launch path via workflow dispatch
   - confirm Strapi-backed step state still transitions through running/completed or failed
 
 ## Sources & References
@@ -224,3 +433,9 @@ That means the pipeline currently behaves like best-effort background work tied 
 - Origin ticket: `docs/roadmap/media-generation/feat-031-ai-video-enrichment-pipeline.md`
 - Existing manager plan: `docs/plans/2026-03-17-001-feat-videoforge-manager-full-port-plan.md`
 - Existing manager solution doc: `docs/solutions/platform/videoforge-manager-integration.md`
+- Dispatch test learning: `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md`
+- Admin workflow-dispatch precedent: `docs/plans/2026-04-21-002-fix-admin-workflow-dispatch-plan.md`
+- Official Workflow DevKit docs:
+  - [withWorkflow API](https://useworkflow.dev/docs/api-reference/workflow-next/with-workflow)
+  - [start API](https://useworkflow.dev/docs/api-reference/workflow-api/start)
+  - [Local World](https://workflow-sdk.dev/worlds/local)

--- a/docs/solutions/platform/videoforge-manager-integration.md
+++ b/docs/solutions/platform/videoforge-manager-integration.md
@@ -38,9 +38,11 @@ Ported VideoForge as `apps/manager` (`@forge/manager`) — a Next.js App Router 
 
 3. **Zod validation at all boundaries**: Request bodies, JSON-shaped LLM output (via shared `createStructuredOpenrouterOutput(...)` in `src/services/openrouter.ts`), env vars (via `@t3-oss/env-nextjs`).
 
-4. **`after()` for background workflow**: Next.js `after()` API keeps the runtime alive after the response, replacing the original fire-and-forget detached promise.
+4. **Shared launcher + `start()` for workflow dispatch**: manager routes now dispatch through `src/workflows/launchVideoEnrichment.ts`, which calls `start(runVideoEnrichment, [input])` from `workflow/api`. The workflow runtime owns execution durability; the route keeps ownership of validation, job creation, and the immediate 201/202 response.
 
-5. **Mux transcription only** (no OpenRouter fallback): OpenRouter doesn't expose Whisper. The original fallback asked an LLM to "generate a transcript" with no audio — producing hallucinated text. Replaced with actual VTT parsing from Mux subtitle tracks.
+5. **Workflow-safe import boundaries matter once durability is real**: enabling `withWorkflow(...)` in `next.config.ts` makes `"use workflow"` / `"use step"` real, but it also means the build rejects Node-only imports pulled into the workflow body. Manager's workflow-safe pattern is: keep orchestration/state updates in the workflow, and move Mux/audio cleanup/storage/embedding-sync/scene-analysis work behind explicit `"use step"` helpers.
+
+6. **Mux transcription only** (no OpenRouter fallback): OpenRouter doesn't expose Whisper. The original fallback asked an LLM to "generate a transcript" with no audio — producing hallucinated text. Replaced with actual VTT parsing from Mux subtitle tracks.
 
 ### Code Review Findings (14 issues found, 13 fixed)
 
@@ -70,16 +72,18 @@ The multi-agent review (`/ce:review`) caught critical issues before deployment:
 
 4. **Strapi Users & Permissions JWTs don't expire by default.** Configure `plugins.js` → `users-permissions.config.jwt.expiresIn` if needed.
 
-5. **`after()` import** is from `next/server` (not `next/headers`). Available in Next.js 15+.
+5. **`withWorkflow(...)` is required** for durable execution. Without the build plugin, `"use workflow"` / `"use step"` are just inert string directives.
 
-6. **No root config changes needed** for new apps — `apps/*` workspace glob covers it automatically.
+6. **Dispatch via `start()` from `workflow/api`** — not by calling the workflow function directly. Body-only tests won't catch this; dispatch-site tests are required.
+
+7. **No root config changes needed** for new apps — `apps/*` workspace glob covers it automatically.
 
 ## Prevention
 
 - Always validate external data (request bodies, LLM output, file-based state) with Zod — it's already a dependency via `@t3-oss/env-nextjs`.
 - Use a shared client module for any SDK instantiated in multiple services (OpenAI, Mux, S3).
 - Run `/ce:review` before `/ce:compound` to catch issues while context is fresh.
-- For background work in Next.js route handlers, use `after()` — never fire-and-forget promises.
+- For workflow-backed background work in Next.js route handlers, dispatch through `start()` from `workflow/api` and keep Node-only service imports inside `"use step"` functions.
 - When adding a new app, follow `docs/solutions/platform/adding-new-apps.md`.
 
 ## Cross-References


### PR DESCRIPTION
## Summary
- enable the manager workflow runtime with `withWorkflow(...)` scoped to `src/workflows`
- dispatch `/api/jobs`, `/api/enrich`, and transcription reruns through `start()` via a shared launcher
- return honest launch-failure responses now that dispatch happens in-request (`502` JSON for single-job + rerun, batch `errors` for `/api/enrich`)
- keep the enrichment workflow build-safe by moving Node-dependent work behind explicit `"use step"` boundaries
- add dispatch-focused route tests and update manager docs/plan state to match the shipped runtime behavior

## Testing
- `pnpm --filter @forge/manager test -- src/workflows/videoEnrichment.test.ts src/lib/workflow-steps.test.ts src/app/api/jobs/route.test.ts src/app/api/enrich/route.test.ts 'src/app/api/jobs/[id]/transcription/rerun/route.test.ts'`
- `pnpm --filter @forge/manager typecheck`
- `pnpm exec eslint next.config.ts src/workflows/videoEnrichment.ts src/workflows/launchVideoEnrichment.ts src/test-helpers/workflow-dispatch.ts src/app/api/jobs/route.ts src/app/api/jobs/route.test.ts src/app/api/enrich/route.ts src/app/api/enrich/route.test.ts 'src/app/api/jobs/[id]/transcription/rerun/route.ts' 'src/app/api/jobs/[id]/transcription/rerun/route.test.ts'`
- `env MUX_TOKEN_ID=test MUX_TOKEN_SECRET=test OPENROUTER_API_KEY=test STRAPI_URL=http://127.0.0.1:1337 STRAPI_API_TOKEN=test pnpm --filter @forge/manager build`

## Smoke
- production-mode smoke with placeholder env: built manager successfully booted from the standalone server bundle
- verified `GET /login` returned `200 OK`
- verified `GET /api/health` returned `200 OK` with `{"status":"ok"}`
- full live enrichment smoke was not run because this environment did not include working Strapi, Mux, or OpenRouter credentials

## Post-Deploy Monitoring & Validation
- Log queries/search terms: `workflow_start`, `workflow_complete`, `workflow_error`, `audio_cleanup_failed_in_enrichment`, `scene_embedding_sync_issue_in_enrichment`, `Transcription rerun failed for job`, `Enrichment failed for job`
- Metrics or dashboards to watch: manager service deploy/build logs, workflow manifest generation during build, `/api/jobs` and `/api/enrich` 5xx rate, job status distribution in manager dashboard/Strapi-backed `EnrichmentJob` records
- Expected healthy signals: manager build emits workflow manifest without node-module plugin failures; successful job creation routes return their usual `201/202`; synchronous launch failures surface as explicit `502` JSON or batch `errors`; persisted jobs advance from `pending` to running/completed with step updates
- Failure signals and rollback/mitigation trigger: any deploy-time workflow plugin error, repeated unexpected route 500s/502s on launch surfaces, or jobs stuck `pending` without step progress after dispatch; rollback to previous manager release if dispatch cannot start new jobs
- Validation window and owner: first deploy window after merge; owner `vlad`
