### PR TITLE
fix(admin): preserve workspace add-block context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .pnpm-store/
 .turbo/
 .expo/
+.swc/
 .next/
 next-env.d.ts
 dist/

--- a/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
@@ -213,6 +213,8 @@ export default async function ExperienceEditorPage({
     notFound()
   }
 
+  const currentExperienceId = experience.id
+
   const owner = experience.ownerId
     ? await prisma.user.findUnique({
         where: { id: experience.ownerId },
@@ -396,6 +398,61 @@ export default async function ExperienceEditorPage({
     return { ok: true }
   }
 
+  async function createLocaleAction(formData: FormData) {
+    "use server"
+
+    const user = await requireSession()
+    const services = createServices(prisma)
+    const locale = String(formData.get("locale") ?? "").trim()
+    const blocksValue = String(formData.get("blocks") ?? "[]").trim() || "[]"
+
+    let blocks: unknown
+    try {
+      blocks = JSON.parse(blocksValue)
+    } catch {
+      return { ok: false, error: "Blocks JSON must be valid JSON." }
+    }
+
+    try {
+      const created = await services.experience.createLocale({
+        input: {
+          experienceId: currentExperienceId,
+          locale,
+          title: String(formData.get("title") ?? ""),
+          slug: String(formData.get("slug") ?? ""),
+          metaDescription: String(formData.get("metaDescription") ?? ""),
+          ogTitle: String(formData.get("ogTitle") ?? ""),
+          ogDescription: String(formData.get("ogDescription") ?? ""),
+          ogImageUrl: String(formData.get("ogImageUrl") ?? "").trim() || null,
+          pathSegment: String(formData.get("pathSegment") ?? "").trim() || null,
+          isHomepage: formData.get("isHomepage") === "on",
+          blocks,
+        },
+        user,
+      })
+
+      revalidatePath("/dashboard/experiences")
+      revalidatePath(`/dashboard/experiences/${id}`)
+      return {
+        ok: true,
+        href: `/dashboard/experiences/${currentExperienceId}?locale=${created.locale}`,
+      }
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        return {
+          ok: false,
+          error: "You do not have permission to add locales.",
+        }
+      }
+
+      if (error instanceof Error) {
+        return { ok: false, error: error.message }
+      }
+
+      return { ok: false, error: "Unable to add locale." }
+    }
+  }
+
   async function restoreRevisionAction(revisionId: string) {
     "use server"
 
@@ -460,6 +517,7 @@ export default async function ExperienceEditorPage({
         videoLibrary={videoLibrary}
         saveAction={saveLocaleAction}
         publishAction={publishLocaleAction}
+        createLocaleAction={createLocaleAction}
         restoreAction={restoreRevisionAction}
       />
     </div>

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
@@ -1,9 +1,14 @@
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it, vi } from "vitest"
-import { ExperienceEditor, cleanRoutePart } from "./experience-editor"
+import {
+  ExperienceEditor,
+  cleanLocaleCode,
+  cleanRoutePart,
+} from "./experience-editor"
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
+    push: vi.fn(),
     refresh: vi.fn(),
   }),
 }))
@@ -64,6 +69,7 @@ function renderEditor(
       }}
       saveAction={action}
       publishAction={action}
+      createLocaleAction={action}
       restoreAction={action}
     />,
   )
@@ -78,6 +84,12 @@ describe("ExperienceEditor", () => {
     expect(cleanRoutePart("sermon///notes")).toBe("sermonnotes")
     expect(cleanRoutePart("Palm_Sunday:Global!")).toBe("palmsundayglobal")
     expect(cleanRoutePart("alpha   beta---gamma")).toBe("alpha-beta-gamma")
+  })
+
+  it("normalizes locale codes for add-locale drafts", () => {
+    expect(cleanLocaleCode("  ES 419  ", true)).toBe("es-419")
+    expect(cleanLocaleCode("pt_BR")).toBe("pt-br")
+    expect(cleanLocaleCode("fr///CA")).toBe("frca")
   })
 
   it("renders container layout as a visual responsive grid editor", () => {

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
@@ -21,6 +21,7 @@ import {
 } from "@dnd-kit/core"
 import { arrayMove } from "@dnd-kit/sortable"
 import { HDate, months } from "@hebcal/hdate"
+import type { Route as NextRoute } from "next"
 import { useRouter } from "next/navigation"
 import {
   CalendarDays,
@@ -123,6 +124,10 @@ import { ContainerWorkspace } from "./experience-editor/container-workspace"
 type EditorActionResult = {
   ok: boolean
   error?: string
+}
+
+type CreateLocaleActionResult = EditorActionResult & {
+  href?: string
 }
 
 type RevisionEntry = {
@@ -670,6 +675,18 @@ export function cleanRoutePart(value: string, trimTrailing = false) {
   return trimTrailing ? cleaned.replace(/-+$/g, "") : cleaned
 }
 
+export function cleanLocaleCode(value: string, trimTrailing = false) {
+  const cleaned = value
+    .toLowerCase()
+    .replace(/_/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+/g, "")
+
+  return trimTrailing ? cleaned.replace(/-+$/g, "") : cleaned
+}
+
 function switchTrackClass(checked: boolean) {
   return checked
     ? "justify-end border-[var(--color-brand)] bg-[color-mix(in_oklab,var(--color-brand)_28%,black)]"
@@ -839,6 +856,7 @@ export function ExperienceEditor({
   initialValues,
   saveAction,
   publishAction,
+  createLocaleAction,
   restoreAction,
 }: {
   canPublish: boolean
@@ -862,6 +880,7 @@ export function ExperienceEditor({
   }
   saveAction: (formData: FormData) => Promise<EditorActionResult>
   publishAction: (localeId: string) => Promise<EditorActionResult>
+  createLocaleAction: (formData: FormData) => Promise<CreateLocaleActionResult>
   restoreAction: (revisionId: string) => Promise<EditorActionResult>
 }) {
   const router = useRouter()
@@ -894,6 +913,9 @@ export function ExperienceEditor({
   const [inlineBlockLibraryOpen, setInlineBlockLibraryOpen] = useState(false)
   const [revisionHistoryOpen, setRevisionHistoryOpen] = useState(false)
   const [localeDrawerOpen, setLocaleDrawerOpen] = useState(false)
+  const [newLocaleCode, setNewLocaleCode] = useState("")
+  const [newLocaleError, setNewLocaleError] = useState("")
+  const [isCreatingLocale, setIsCreatingLocale] = useState(false)
   const [blockSearchQuery, setBlockSearchQuery] = useState("")
   const [blockCategoryFilter, setBlockCategoryFilter] =
     useState<BlockCategoryFilter>("All")
@@ -1174,6 +1196,10 @@ export function ExperienceEditor({
       ? `Pick a video to add it to this ${videoPickerBlockLabel}.`
       : `No video currently attached to this ${videoPickerBlockLabel}.`
   const activeLocaleEntry = localeEntries.find((entry) => entry.active)
+  const cleanedNewLocaleCode = cleanLocaleCode(newLocaleCode, true)
+  const newLocaleAlreadyExists = localeEntries.some(
+    (entry) => entry.code.toLowerCase() === cleanedNewLocaleCode,
+  )
   const currentLocaleCode = activeLocaleEntry?.code ?? "en"
   const normalizedVideoLibraryQuery = videoLibraryQuery.trim().toLowerCase()
   const filteredVideoLibrary = [...videoLibrary]
@@ -2086,6 +2112,77 @@ export function ExperienceEditor({
     setInlineBlockLibraryOpen(true)
   }
 
+  function containerAddTargetChildIndex(content: unknown[], slotIndex: number) {
+    const markers = containerSlotMarkerIndexes(content)
+    const markerIndex = markers[slotIndex]
+    if (markerIndex === undefined) return null
+
+    const nextMarkerIndex = markers[slotIndex + 1] ?? content.length
+    let targetChildIndex = markerIndex
+    for (
+      let childIndex = markerIndex + 1;
+      childIndex < nextMarkerIndex;
+      childIndex += 1
+    ) {
+      if (!isContainerSlotBlock(content[childIndex])) {
+        targetChildIndex = childIndex
+      }
+    }
+
+    return targetChildIndex
+  }
+
+  function openToolbarAddBlockPicker() {
+    setRevisionHistoryOpen(false)
+    setLocaleDrawerOpen(false)
+
+    if (
+      isSectionWorkspaceOpen &&
+      focusedSectionIndex !== null &&
+      focusedSectionRecord
+    ) {
+      setPendingInsertIndex(asArray(focusedSectionRecord.content).length)
+      setInlineBlockLibraryOpen(true)
+      return
+    }
+
+    if (
+      isContainerWorkspaceOpen &&
+      focusedContainerIndex !== null &&
+      focusedContainerRecord
+    ) {
+      const content = readContainerContent(focusedContainerRecord)
+      const markers = containerSlotMarkerIndexes(content)
+      if (markers.length === 0) {
+        pushToast("Choose a slot layout before adding blocks.", "error")
+        return
+      }
+
+      const slotIndex = Math.min(
+        Math.max(focusedContainerSlotIndex ?? 0, 0),
+        markers.length - 1,
+      )
+      const targetChildIndex = containerAddTargetChildIndex(content, slotIndex)
+      if (targetChildIndex === null) return
+
+      setFocusedContainerSlotIndex(slotIndex)
+      setPendingInsertIndex(
+        nestedCanvasBlockIndex({
+          kind: "container",
+          containerIndex: focusedContainerIndex,
+          childIndex: targetChildIndex,
+        }),
+      )
+      setInlineBlockLibraryOpen(true)
+      return
+    }
+
+    setFocusedContainerIndex(null)
+    setFocusedSectionIndex(null)
+    setFocusedContainerSlotIndex(null)
+    openAddBlockPicker(parsedBlocks.length)
+  }
+
   function renderPendingInsertMarker() {
     return (
       <div className="flex h-full w-full animate-[pendingInsertIn_180ms_cubic-bezier(0.22,1,0.36,1)_both] items-center rounded-sm border border-dashed border-[var(--color-hairline-strong)] bg-[color-mix(in_oklab,var(--color-surface)_88%,black)] px-4 py-3 shadow-[0_12px_28px_rgba(0,0,0,0.24)]">
@@ -2311,6 +2408,42 @@ export function ExperienceEditor({
     )
   }
 
+  async function handleCreateLocale(formData: FormData) {
+    const locale = cleanLocaleCode(String(formData.get("locale") ?? ""), true)
+    if (!locale) {
+      setNewLocaleError("Enter a locale code.")
+      return
+    }
+    if (localeEntries.some((entry) => entry.code.toLowerCase() === locale)) {
+      setNewLocaleError("That locale already exists.")
+      return
+    }
+
+    formData.set("locale", locale)
+    setNewLocaleError("")
+    setIsCreatingLocale(true)
+
+    try {
+      const result = await createLocaleAction(formData)
+      if (!result.ok) {
+        setNewLocaleError(result.error ?? "Unable to add locale.")
+        return
+      }
+
+      setNewLocaleCode("")
+      setLocaleDrawerOpen(false)
+      pushToast(`Locale ${locale} added.`, "success")
+      if (result.href) {
+        router.push(result.href as NextRoute)
+      }
+      startTransition(() => {
+        router.refresh()
+      })
+    } finally {
+      setIsCreatingLocale(false)
+    }
+  }
+
   function renderLocaleDrawer() {
     return (
       <div
@@ -2343,6 +2476,67 @@ export function ExperienceEditor({
             </button>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-4 [scrollbar-color:rgba(255,255,255,0.12)_transparent] [scrollbar-width:thin]">
+            <form
+              action={handleCreateLocale}
+              className="mb-4 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] p-3"
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  name="locale"
+                  value={newLocaleCode}
+                  onChange={(event) => {
+                    setNewLocaleCode(cleanLocaleCode(event.target.value))
+                    setNewLocaleError("")
+                  }}
+                  onBlur={() => setNewLocaleCode(cleanedNewLocaleCode)}
+                  placeholder="Add locale"
+                  aria-label="New locale code"
+                  className="h-9 min-w-0 flex-1 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none transition-all duration-[120ms] ease-out placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-hairline-strong)]"
+                />
+                <button
+                  type="submit"
+                  disabled={
+                    isCreatingLocale ||
+                    !cleanedNewLocaleCode ||
+                    newLocaleAlreadyExists
+                  }
+                  className="inline-flex h-9 shrink-0 cursor-pointer items-center gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 text-[12px] font-medium text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface)] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Plus className="h-3.5 w-3.5" strokeWidth={1.5} />
+                  Add
+                </button>
+              </div>
+              <input type="hidden" name="title" value={title} />
+              <input type="hidden" name="slug" value={slug} />
+              <input type="hidden" name="pathSegment" value={pathSegment} />
+              <input
+                type="hidden"
+                name="metaDescription"
+                value={metaDescription}
+              />
+              <input type="hidden" name="ogTitle" value={ogTitle} />
+              <input type="hidden" name="ogDescription" value={ogDescription} />
+              <input type="hidden" name="ogImageUrl" value={ogImageUrl} />
+              <input
+                type="hidden"
+                name="isHomepage"
+                value={isHomepage ? "on" : ""}
+              />
+              <input
+                type="hidden"
+                name="blocks"
+                value={JSON.stringify(normalizedParsedBlocks, null, 2)}
+              />
+              {newLocaleError ? (
+                <div className="mt-2 text-[12px] text-[var(--color-danger)]">
+                  {newLocaleError}
+                </div>
+              ) : (
+                <div className="mt-2 text-[12px] text-[var(--color-text-muted)]">
+                  Starts from the current locale.
+                </div>
+              )}
+            </form>
             <div className="overflow-hidden rounded-sm border border-[var(--color-hairline)]">
               {localeEntries.map((locale) => (
                 <a
@@ -8727,14 +8921,7 @@ export function ExperienceEditor({
           <div className="pointer-events-auto flex items-center justify-between gap-2 rounded-sm border border-[var(--color-hairline)] bg-[color-mix(in_oklab,var(--color-surface)_94%,black)] p-1.5 shadow-[0_18px_56px_rgba(0,0,0,0.36)]">
             <button
               type="button"
-              onClick={() => {
-                setFocusedContainerIndex(null)
-                setFocusedSectionIndex(null)
-                setFocusedContainerSlotIndex(null)
-                setRevisionHistoryOpen(false)
-                setLocaleDrawerOpen(false)
-                openAddBlockPicker(parsedBlocks.length)
-              }}
+              onClick={openToolbarAddBlockPicker}
               className="inline-flex h-9 cursor-pointer items-center justify-center gap-2 rounded-[2px] px-3 text-[12px] font-medium text-[var(--color-text-primary)] transition-colors duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
             >
               <Plus className="h-4 w-4" strokeWidth={1.5} />

--- a/apps/admin/src/services/experience.schemas.ts
+++ b/apps/admin/src/services/experience.schemas.ts
@@ -15,6 +15,23 @@ export const CreateExperienceInput = z.object({
 })
 export type CreateExperienceInput = z.infer<typeof CreateExperienceInput>
 
+export const CreateExperienceLocaleInput = z.object({
+  experienceId: z.string().min(1),
+  locale: z.string().min(1).max(35),
+  slug: z.string().min(1).max(200),
+  title: z.string().max(500).optional(),
+  metaDescription: z.string().max(1000).optional(),
+  ogTitle: z.string().max(200).optional(),
+  ogDescription: z.string().max(500).optional(),
+  ogImageUrl: z.string().url().optional().nullable(),
+  isHomepage: z.boolean().optional(),
+  pathSegment: z.string().max(200).optional().nullable(),
+  blocks: BlocksSchema.optional().default([]),
+})
+export type CreateExperienceLocaleInput = z.infer<
+  typeof CreateExperienceLocaleInput
+>
+
 export const UpdateExperienceLocaleInput = z.object({
   id: z.string().min(1),
   slug: z.string().min(1).max(200).optional(),

--- a/apps/admin/src/services/experience.service.test.ts
+++ b/apps/admin/src/services/experience.service.test.ts
@@ -10,6 +10,7 @@ function mockPrisma() {
     update: vi.fn(),
   }
   const experienceLocale = {
+    create: vi.fn(),
     findFirst: vi.fn(),
     findUniqueOrThrow: vi.fn(),
     update: vi.fn(),
@@ -17,6 +18,7 @@ function mockPrisma() {
   const experience = {
     create: vi.fn(),
     findFirst: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
     findMany: vi.fn(),
     update: vi.fn(),
   }
@@ -140,6 +142,62 @@ describe("ExperienceService", () => {
           user: ADMIN,
         }),
       ).rejects.toThrow()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // createLocale
+  // ---------------------------------------------------------------------------
+
+  describe("createLocale", () => {
+    const input = {
+      experienceId: "exp-1",
+      locale: "es",
+      slug: "hello-world",
+      title: "Hello",
+      metaDescription: "Meta",
+      blocks: [{ t: "text", heading: "Hello" }],
+    }
+
+    it("EDITOR can add a draft locale to an owned experience", async () => {
+      prisma.experience.findUniqueOrThrow.mockResolvedValueOnce({
+        ownerId: "alice",
+        archivedAt: null,
+      })
+      prisma.experienceLocale.create.mockResolvedValueOnce({
+        id: "loc-es",
+        ...input,
+        status: "DRAFT",
+      })
+
+      const result = await service.createLocale({
+        input,
+        user: EDITOR_ALICE,
+      })
+
+      expect(result.id).toBe("loc-es")
+      expect(prisma.experienceLocale.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          locale: "es",
+          slug: "hello-world",
+          blocks: input.blocks,
+          experience: { connect: { id: "exp-1" } },
+        }),
+      })
+    })
+
+    it("EDITOR cannot add a locale to another editor's experience", async () => {
+      prisma.experience.findUniqueOrThrow.mockResolvedValueOnce({
+        ownerId: "alice",
+        archivedAt: null,
+      })
+
+      await expect(
+        service.createLocale({
+          input,
+          user: EDITOR_BOB,
+        }),
+      ).rejects.toThrow("Forbidden")
     })
   })
 

--- a/apps/admin/src/services/experience.service.ts
+++ b/apps/admin/src/services/experience.service.ts
@@ -17,6 +17,7 @@ import { ForbiddenError, NotFoundError } from "./errors"
 import { runExperienceEmbedding } from "@/workflows/experienceEmbedding"
 import {
   CreateExperienceInput,
+  CreateExperienceLocaleInput,
   UpdateExperienceLocaleInput,
   PublishExperienceLocaleInput,
   RestoreExperienceLocaleRevisionInput,
@@ -107,6 +108,40 @@ export class ExperienceService {
         },
       },
       include: { locales: true },
+    })
+  }
+
+  async createLocale({
+    input: raw,
+    user,
+  }: {
+    input: unknown
+    user: Principal | null
+  }) {
+    const input = CreateExperienceLocaleInput.parse(raw)
+
+    const experience = await this.prisma.experience.findUniqueOrThrow({
+      where: { id: input.experienceId },
+      select: { ownerId: true, archivedAt: true },
+    })
+
+    if (
+      !canEditExperienceLocale(user, {
+        status: "DRAFT",
+        experience,
+      })
+    ) {
+      throw new ForbiddenError()
+    }
+
+    const { experienceId, ...data } = input
+    return this.prisma.experienceLocale.create({
+      data: {
+        ...data,
+        experience: {
+          connect: { id: experienceId },
+        },
+      },
     })
   }
 


### PR DESCRIPTION
## Summary
- route the experience editor toolbar add-block action through the active section/container workspace context
- add an admin create-locale action so editors can add locale drafts from the current locale state
- ignore SWC cache output so local validation does not dirty the worktree

## Review
- CE review pass run locally with correctness/adversarial checks for the service mutation and editor state flow
- Review fix applied: add .swc/ to .gitignore for generated cache hygiene

## Validation
- pnpm --filter @forge/admin lint
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin test
- pnpm --filter @forge/admin build
- git diff --check