### PR TITLE
Make admin experience cards visual

### DIFF
--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -23,12 +23,12 @@ vi.mock("@/app/dashboard/live-data", () => ({
       key: "exp_1",
       locale: "en",
       title: "Stories of Forgiveness",
-      slug: "/exp/forgiveness-v4-global",
-      owner: "M. Rodriguez",
+      slug: "/watch/forgiveness-v4-global",
       statusLabel: "PUBLISHED",
       statusTone: "success",
-      embedding: "READY",
-      updated: "10/24/2023, 14:02",
+      preview: {
+        imageUrl: "https://images.example.com/forgiveness.jpg",
+      },
     },
   ]),
   loadVideoRows: vi.fn(async () => [
@@ -305,7 +305,14 @@ describe("dashboard UI routes", () => {
     const html = await htmlFrom(ExperiencesPage())
     expect(html).toContain(uiMessages.pages.experiences.title)
     expect(html).toContain(uiMessages.pages.experiences.actions.primary)
-    expect(html).toContain(uiMessages.common.operatorNotes)
+    expect(html).toContain("https://images.example.com/forgiveness.jpg")
+    expect(html).toContain("/watch/forgiveness-v4-global")
+    expect(html).not.toContain("/exp/forgiveness-v4-global")
+    expect(html).not.toContain(uiMessages.common.operatorNotes)
+    expect(html).not.toContain("Editorial Signals")
+    expect(html).not.toContain("Embedding")
+    expect(html).not.toContain("M. Rodriguez")
+    expect(html).not.toContain("10/24/2023, 14:02")
   })
 
   it("renders videos page with localized info strip and actions", async () => {

--- a/apps/admin/src/app/dashboard/experiences/page.tsx
+++ b/apps/admin/src/app/dashboard/experiences/page.tsx
@@ -1,15 +1,8 @@
-import { Filter, Layers3 } from "lucide-react"
+import { ImageIcon } from "lucide-react"
 import type { Route } from "next"
 import Link from "next/link"
 import { revalidatePath } from "next/cache"
-import {
-  DashboardPageHeader,
-  DataTable,
-  InsightGrid,
-  OperatorRail,
-  PageSection,
-  StatusPill,
-} from "@/components/admin-ui"
+import { DashboardPageHeader, StatusPill } from "@/components/admin-ui"
 import { ExperiencesActions } from "@/app/dashboard/experiences/experiences-actions"
 import { hasPermission } from "@/auth/permissions"
 import { requireSession } from "@/auth/session"
@@ -96,78 +89,66 @@ export default async function ExperiencesPage() {
         }
       />
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(340px,0.75fr)]">
-        <div className="flex flex-col gap-6">
-          <PageSection
-            title={page.table.title}
-            meta={page.table.meta}
-            actions={
-              <Layers3 className="h-4 w-4 text-[var(--color-text-muted)]" />
-            }
-          >
-            <DataTable
-              columns={page.table.columns}
-              selectedRow={experienceRows.length > 0 ? 0 : undefined}
-              rows={experienceRows.map((row) => [
-                <div key={`${row.slug}-title`}>
-                  <Link
-                    href={
-                      `/dashboard/experiences/${row.key}?locale=${row.locale}` as Route
-                    }
-                    className="block"
-                  >
-                    <div className="text-[13px] font-medium text-[var(--color-text-primary)] underline-offset-2 transition-all duration-[120ms] ease-out hover:underline">
+      <section aria-label={page.title}>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {experienceRows.map((row) => (
+            <Link
+              key={`${row.key}-${row.locale}`}
+              href={
+                `/dashboard/experiences/${row.key}?locale=${row.locale}` as Route
+              }
+              className="group overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-overlay)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
+            >
+              <article>
+                <div className="relative aspect-[4/3] overflow-hidden bg-[var(--color-surface)]">
+                  {row.preview.imageUrl ? (
+                    <div
+                      className="h-full w-full bg-cover bg-center"
+                      style={{
+                        backgroundImage: `url(${JSON.stringify(row.preview.imageUrl)})`,
+                      }}
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center bg-[var(--color-surface)]">
+                      <ImageIcon
+                        className="h-6 w-6 text-[var(--color-text-disabled)]"
+                        strokeWidth={1.5}
+                      />
+                    </div>
+                  )}
+
+                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/35 to-transparent p-4 pt-12">
+                    <h3 className="line-clamp-2 text-[15px] font-semibold leading-5 text-white underline-offset-2 group-hover:underline">
                       {row.title}
-                    </div>
-                    <div className="mono-meta text-[var(--color-text-muted)]">
-                      {row.slug}
-                    </div>
-                  </Link>
-                </div>,
-                <span key={`${row.slug}-owner`} className="text-[13px]">
-                  {row.owner}
-                </span>,
-                <StatusPill key={`${row.slug}-status`} tone={row.statusTone}>
-                  {row.statusLabel}
-                </StatusPill>,
-                <div
-                  key={`${row.slug}-embedding`}
-                  className="flex items-center gap-2"
-                >
-                  <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
-                  <span className="mono-meta text-[var(--color-text-secondary)]">
-                    {row.embedding}
-                  </span>
-                </div>,
-                <span
-                  key={`${row.slug}-updated`}
-                  className="mono-meta text-[var(--color-text-muted)]"
-                >
-                  {row.updated}
-                </span>,
-              ])}
-            />
-          </PageSection>
+                    </h3>
+                  </div>
+                </div>
 
-          <PageSection title={page.signals.title} meta={page.signals.meta}>
-            <div className="p-4">
-              <InsightGrid
-                items={page.signals.insights.map((item, index) => ({
-                  ...item,
-                  icon: index % 2 === 0 ? Layers3 : Filter,
-                }))}
-              />
+                <div className="flex items-center justify-between gap-3 px-4 py-3">
+                  <div className="mono-meta min-w-0 truncate text-[var(--color-text-muted)]">
+                    {row.slug}
+                  </div>
+                  <StatusPill tone={row.statusTone}>
+                    {row.statusLabel}
+                  </StatusPill>
+                </div>
+              </article>
+            </Link>
+          ))}
+
+          {experienceRows.length === 0 ? (
+            <div className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] p-6 text-center">
+              <div className="text-[14px] font-semibold">
+                {page.empty.title}
+              </div>
+              <div className="mx-auto mt-1 max-w-md text-[13px] leading-6 text-[var(--color-text-muted)]">
+                {page.empty.description}
+              </div>
             </div>
-          </PageSection>
+          ) : null}
         </div>
-
-        <OperatorRail
-          title={messages.common.operatorNotes}
-          meta={messages.common.fieldGuide}
-          notes={page.rail.notes}
-          chips={page.rail.chips}
-        />
-      </div>
+      </section>
     </div>
   )
 }

--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -1,6 +1,12 @@
 import type { LocaleStatus, VideoDub } from "@prisma/client"
 import type { Principal } from "@/auth/principal"
 import { prisma } from "@/db/client"
+import {
+  BlocksSchema,
+  type Block,
+  type ContainerContentBlock,
+  type SectionContentBlock,
+} from "@/domain/blocks"
 import { getAdminLocale } from "@/i18n/server"
 import { createServices } from "@/services"
 
@@ -17,7 +23,10 @@ type ExperienceLocaleRow = {
   experienceId: string
   locale: string
   slug: string
+  pathSegment: string | null
   title: string | null
+  ogImageUrl: string | null
+  blocks: unknown
   status: LocaleStatus
   updatedAt: Date
 }
@@ -99,6 +108,171 @@ function statusTone(status: LocaleStatus): "success" | "warning" | "danger" {
   if (status === "PUBLISHED") return "success"
   if (status === "ARCHIVED") return "danger"
   return "warning"
+}
+
+function compactText(value: string | null | undefined) {
+  return value?.replace(/\s+/g, " ").trim() || null
+}
+
+function directUrl(value: object, fields: readonly string[]): string | null {
+  for (const field of fields) {
+    if (field in value) {
+      const fieldValue = (value as Record<string, unknown>)[field]
+      if (typeof fieldValue === "string" && fieldValue.trim()) {
+        return fieldValue.trim()
+      }
+    }
+  }
+  return null
+}
+
+type PreviewBlock = Block | SectionContentBlock | ContainerContentBlock
+
+function addVideoId(ids: Set<string>, value: string | null | undefined) {
+  const id = compactText(value)
+  if (id) ids.add(id)
+}
+
+function collectVideoIdsFromBlock(block: PreviewBlock, ids: Set<string>) {
+  if (block.t === "video" || block.t === "videoHero") {
+    addVideoId(ids, block.videoId)
+  }
+
+  if (block.t === "mediaCollection" || block.t === "videoCarousel") {
+    for (const item of block.items) {
+      addVideoId(ids, item.videoId)
+    }
+  }
+
+  if (block.t === "section") {
+    for (const item of block.content) {
+      collectVideoIdsFromBlock(item, ids)
+    }
+  }
+
+  if (block.t === "container") {
+    for (const item of block.content) {
+      collectVideoIdsFromBlock(item, ids)
+    }
+  }
+}
+
+function videoIdsFromBlocks(blocks: readonly Block[]) {
+  const ids = new Set<string>()
+  for (const block of blocks) {
+    collectVideoIdsFromBlock(block, ids)
+  }
+  return Array.from(ids)
+}
+
+function parsedExperienceBlocks(locale: Pick<ExperienceLocaleRow, "blocks">) {
+  const parsed = BlocksSchema.safeParse(locale.blocks)
+  return parsed.success ? parsed.data : []
+}
+
+function previewImageForVideo(
+  videoId: string | null | undefined,
+  videoImagesByVideoId: Map<string, VideoImageRow[]>,
+) {
+  const id = compactText(videoId)
+  return id ? preferredVideoImage(videoImagesByVideoId.get(id) ?? []) : null
+}
+
+function previewImageFromBlock(
+  block: PreviewBlock,
+  videoImagesByVideoId: Map<string, VideoImageRow[]>,
+): string | null {
+  const direct = directUrl(block, [
+    "imageUrl",
+    "backgroundImageUrl",
+    "mediaUrl",
+  ])
+  if (direct) return direct
+
+  if (block.t === "video" || block.t === "videoHero") {
+    return previewImageForVideo(block.videoId, videoImagesByVideoId)
+  }
+
+  if (block.t === "mediaCollection") {
+    for (const item of block.items) {
+      const itemImage =
+        item.imageOverrideUrl ??
+        item.imageUrl ??
+        previewImageForVideo(item.videoId, videoImagesByVideoId)
+      if (itemImage) return itemImage
+    }
+  }
+
+  if (block.t === "videoCarousel") {
+    for (const item of block.items) {
+      const itemImage =
+        item.imageOverrideUrl ??
+        item.imageUrl ??
+        previewImageForVideo(item.videoId, videoImagesByVideoId)
+      if (itemImage) return itemImage
+    }
+  }
+
+  if (block.t === "navigationCarousel") {
+    for (const item of block.items) {
+      if (item.imageUrl) return item.imageUrl
+    }
+  }
+
+  if (block.t === "bibleQuotesCarousel") {
+    for (const quote of block.quotes) {
+      const quoteImage = quote.backgroundImageUrl ?? quote.imageUrl
+      if (quoteImage) return quoteImage
+    }
+  }
+
+  if (block.t === "section") {
+    for (const item of block.content) {
+      const itemImage = previewImageFromBlock(item, videoImagesByVideoId)
+      if (itemImage) return itemImage
+    }
+  }
+
+  if (block.t === "container") {
+    for (const item of block.content) {
+      const itemImage = previewImageFromBlock(item, videoImagesByVideoId)
+      if (itemImage) return itemImage
+    }
+  }
+
+  return null
+}
+
+function previewForExperienceLocale(
+  locale: ExperienceLocaleRow,
+  videoImagesByVideoId: Map<string, VideoImageRow[]>,
+) {
+  const blocks = parsedExperienceBlocks(locale)
+  const imageUrl =
+    compactText(locale.ogImageUrl) ??
+    blocks
+      .map((block) => previewImageFromBlock(block, videoImagesByVideoId))
+      .find((url): url is string => !!url) ??
+    null
+
+  return {
+    imageUrl,
+  }
+}
+
+function normalizePathPart(value: string | null | undefined) {
+  return value?.trim().replace(/^\/+|\/+$/g, "") ?? ""
+}
+
+function experiencePath(
+  locale: Pick<ExperienceLocaleRow, "pathSegment" | "slug">,
+) {
+  const parts = [
+    normalizePathPart(locale.pathSegment),
+    normalizePathPart(locale.slug),
+  ].filter(Boolean)
+
+  return `/${parts.join("/")}`
 }
 
 function sourceLabel(
@@ -216,7 +390,10 @@ export async function loadExperienceRows(principal: Principal) {
         experienceId: true,
         locale: true,
         slug: true,
+        pathSegment: true,
         title: true,
+        ogImageUrl: true,
+        blocks: true,
         status: true,
         updatedAt: true,
       },
@@ -236,24 +413,64 @@ export async function loadExperienceRows(principal: Principal) {
     localesByExperience.set(item.experienceId, current)
   }
 
+  const videoIds = Array.from(
+    new Set(
+      locales.flatMap((item) =>
+        videoIdsFromBlocks(parsedExperienceBlocks(item)),
+      ),
+    ),
+  )
+  let videoImages: VideoImageRow[] = []
+  if (videoIds.length > 0) {
+    try {
+      videoImages = await prisma.videoImage.findMany({
+        where: { videoId: { in: videoIds } },
+        select: {
+          videoId: true,
+          url: true,
+          kind: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "asc" },
+      })
+    } catch (error) {
+      if (isMissingTableError(error)) {
+        videoImages = []
+      } else {
+        throw error
+      }
+    }
+  }
+
+  const videoImagesByVideoId = new Map<string, VideoImageRow[]>()
+  for (const item of videoImages) {
+    const current = videoImagesByVideoId.get(item.videoId) ?? []
+    current.push(item)
+    videoImagesByVideoId.set(item.videoId, current)
+  }
+
   return experiences.map((experience) => {
     const experienceLocales = localesByExperience.get(experience.id) ?? []
     const localeRow = choosePreferredLocale(experienceLocales, locale)
     const title = localeRow?.title?.trim() || "Untitled Experience"
-    const slug = localeRow?.slug ?? experience.id
+    const path = localeRow
+      ? experiencePath(localeRow)
+      : `/${normalizePathPart(experience.id)}`
     const status = localeRow?.status ?? "DRAFT"
-    const owner = experience.ownerId?.slice(0, 8) ?? "SYSTEM"
+    const preview = localeRow
+      ? previewForExperienceLocale(localeRow, videoImagesByVideoId)
+      : {
+          imageUrl: null,
+        }
 
     return {
       key: experience.id,
       locale: localeRow?.locale ?? locale,
       title,
-      slug: `/exp/${slug}`,
-      owner,
+      slug: path,
       statusLabel: status,
       statusTone: statusTone(status),
-      embedding: status === "PUBLISHED" ? "READY" : "PENDING",
-      updated: formatDateTime(experience.updatedAt),
+      preview,
     }
   })
 }

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -332,102 +332,10 @@ export const adminMessages = {
             "You do not have permission to create experiences. Contact an administrator to grant access.",
           createFailed: "Unable to create experience. Please try again.",
         },
-        table: {
-          title: "Experience Index",
-          meta: "SELECTED_ROW reflects active editorial attention",
-          columns: [
-            "Title / Identifier",
-            "Owner",
-            "Status",
-            "Embedding",
-            "Updated",
-          ],
-          rows: [
-            {
-              title: "Stories of Forgiveness",
-              slug: "/exp/forgiveness-v4-global",
-              owner: "M. Rodriguez",
-              statusLabel: "Published",
-              statusTone: "success",
-              embedding: "JS SDK v2.1",
-              updated: "2023.10.24 14:02",
-            },
-            {
-              title: "The Jesus Film: Director's Cut",
-              slug: "/exp/jfilm-remastered",
-              owner: "A. Thompson",
-              statusLabel: "Draft",
-              statusTone: "warning",
-              embedding: "Native iOS",
-              updated: "2023.10.23 09:45",
-            },
-            {
-              title: "Walking Through Galilee",
-              slug: "/exp/galilee-vr-360",
-              owner: "S. Chen",
-              statusLabel: "Published",
-              statusTone: "success",
-              embedding: "WebXR / Aframe",
-              updated: "2023.10.22 18:20",
-            },
-            {
-              title: "Parables of the Kingdom",
-              slug: "/exp/parables-animated",
-              owner: "K. Williams",
-              statusLabel: "Failed",
-              statusTone: "danger",
-              embedding: "IFrame Bridge",
-              updated: "2023.10.20 11:30",
-            },
-            {
-              title: "Impact Maps: Asia Basin",
-              slug: "/exp/impact-asia-interactive",
-              owner: "D. Kim",
-              statusLabel: "Published",
-              statusTone: "success",
-              embedding: "Mapbox GL",
-              updated: "2023.10.18 08:15",
-            },
-          ],
-        },
-        signals: {
-          title: "Editorial Signals",
-          meta: "INDEX_HEALTH",
-          insights: [
-            {
-              label: "Published Mix",
-              value: "72%",
-              detail:
-                "Published experiences outnumber drafts without crowding review capacity.",
-            },
-            {
-              label: "Failed Builds",
-              value: "1",
-              detail:
-                "Only one experience currently needs pipeline intervention.",
-            },
-            {
-              label: "Embedding Freshness",
-              value: "98.6%",
-              detail:
-                "Most locales are within the current embedding freshness threshold.",
-            },
-            {
-              label: "Owner Load",
-              value: "6.4",
-              detail:
-                "Average active experiences per editor across the current board.",
-            },
-          ],
-        },
-        rail: {
-          notes:
-            "The experience index now uses a single shared table framework with selected-row treatment, mono identifiers, and the same structural chrome as the rest of the dashboard.",
-          chips: [
-            { label: "Source", value: "EXPERIENCES_FINAL" },
-            { label: "Density", value: "52PX_ACTIVE_ROWS" },
-            { label: "Action", value: "NEW_EXPERIENCE" },
-          ],
+        empty: {
+          title: "No experiences yet",
+          description:
+            "Create the first draft experience to start building locale content.",
         },
       },
       videos: {

--- a/docs/roadmap/platform/feat-108-admin-experiences-dashboard-card-refinement.md
+++ b/docs/roadmap/platform/feat-108-admin-experiences-dashboard-card-refinement.md
@@ -1,0 +1,65 @@
+---
+id: "feat-108"
+title: "Admin Experiences Dashboard Card Refinement"
+owner: "tataihono"
+priority: "P2"
+status: "complete"
+start_date: "2026-04-23"
+duration: 1
+depends_on:
+  - "feat-091"
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "ui"
+  - "experience"
+---
+
+## Problem
+
+The admin experiences index overweights internal operational concepts for the
+first editorial pass. Operator notes, editorial signals, and embedding status
+make the page feel busier than the work requires. Editors need a more direct
+way to scan each experience row and open the record.
+
+## Entry Points - Read These First
+
+1. `apps/admin/AGENTS.md`
+2. `apps/admin/CLAUDE.md`
+3. `apps/admin/src/app/dashboard/experiences/page.tsx`
+4. `apps/admin/src/app/dashboard/live-data.ts`
+5. `apps/admin/src/i18n/messages.ts`
+
+## Grep These
+
+- `Editorial Signals` in `apps/admin/src/app/dashboard/experiences/page.tsx`
+- `OperatorRail` in `apps/admin/src/app/dashboard/experiences/page.tsx`
+- `embedding` in `apps/admin/src/app/dashboard/live-data.ts`
+- `pages.experiences` in `apps/admin/src/i18n/messages.ts`
+
+## What To Build
+
+1. Replace the experiences table with a card-style list where each experience
+   row is a single clickable card.
+2. Add visual previews derived from `ExperienceLocale.ogImageUrl` and block
+   media fields, with a graceful fallback when no image exists.
+3. Keep each card visually led: title, status, and root-level route only.
+4. Let the card grid sit directly under the page header without an extra
+   section heading.
+5. Remove the operator notes rail from the experiences index.
+6. Remove the editorial signals section from the experiences index.
+7. Remove embedding status from the experiences index read model and UI.
+8. Keep the create-experience action and existing route targets unchanged.
+
+## Constraints
+
+- Keep scope inside `apps/admin` and this roadmap ticket.
+- Do not change Prisma schema, GraphQL schema, or service-layer write behavior.
+- Reuse existing Forge admin tokens and components; do not introduce new colors.
+- Preserve the authenticated page requirements and permissions for creation.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`
+- `pnpm --filter @forge/admin typecheck`

--- a/docs/solutions/best-practices/admin-experience-preview-cards-video-reference-images-20260423.md
+++ b/docs/solutions/best-practices/admin-experience-preview-cards-video-reference-images-20260423.md
@@ -1,0 +1,95 @@
+---
+title: "Admin experience preview cards should hydrate referenced video images"
+date: 2026-04-23
+category: best-practices
+module: apps/admin
+problem_type: best_practice
+component: tooling
+severity: low
+applies_when:
+  - Building index cards from ExperienceLocale block JSON
+  - Rendering visual previews for blocks that reference videos by id
+  - Simplifying editorial dashboards around visual scanability
+tags:
+  - admin
+  - experiences
+  - preview-cards
+  - video-hero
+  - video-images
+  - dashboard
+---
+
+# Admin experience preview cards should hydrate referenced video images
+
+## Context
+
+The admin experiences index moved from a text-heavy table to visual cards. The
+first pass could show images from `ExperienceLocale.ogImageUrl` and direct media
+fields inside block JSON, but `videoHero` cards still rendered blank when the
+hero block only contained a `videoId`.
+
+That is expected from the data model: video stills and posters live on
+`VideoImage`, not inside the `videoHero` block.
+
+## Guidance
+
+When deriving visual previews from experience blocks, treat direct block media
+as the first layer and referenced content as the second layer.
+
+For `apps/admin/src/app/dashboard/live-data.ts`, the useful order is:
+
+1. Use `ExperienceLocale.ogImageUrl` when present.
+2. Scan top-level and nested blocks for direct image fields such as `imageUrl`,
+   `backgroundImageUrl`, `mediaUrl`, `imageOverrideUrl`, and quote images.
+3. Collect referenced `videoId` values from `videoHero`, `video`,
+   `mediaCollection.items`, and `videoCarousel.items`.
+4. Fetch matching `VideoImage` rows in one query and apply the same image
+   priority used by the video library: `videoStill`, `mobileCinematicHigh`,
+   `poster`, `still`, then any URL.
+
+Keep the UI card itself lean. The index should help editors recognize and open
+the experience; details such as owner, updated time, block counts, and locale
+coverage belong inside the record view.
+
+## Why This Matters
+
+Experience blocks often describe relationships rather than duplicating media
+URLs. A visual dashboard that only reads the block JSON will underrepresent
+pages built from videos, especially video-led pages where `videoHero` is the
+primary visual signal.
+
+Hydrating referenced video images keeps the card preview aligned with the
+experience a viewer will actually see while avoiding duplicated image fields in
+the block payload.
+
+## When to Apply
+
+- An index card needs a visual preview for an experience, playlist, or route
+  assembled from blocks.
+- A block contains an entity reference such as `videoId` instead of a direct
+  image URL.
+- The referenced entity already has an ordered image/still/poster table.
+
+## Examples
+
+```ts
+const videoIds = locales.flatMap((locale) =>
+  videoIdsFromBlocks(parsedExperienceBlocks(locale)),
+)
+
+const videoImages = await prisma.videoImage.findMany({
+  where: { videoId: { in: videoIds } },
+  select: { videoId: true, url: true, kind: true, createdAt: true },
+  orderBy: { createdAt: "asc" },
+})
+```
+
+Then pass a `Map<videoId, VideoImageRow[]>` into the preview resolver so
+`videoHero.videoId` can resolve to the preferred still/poster without making
+per-card queries.
+
+## Related
+
+- `apps/admin/src/app/dashboard/live-data.ts`
+- `apps/admin/src/app/dashboard/experiences/page.tsx`
+- `apps/admin/src/domain/blocks.ts`


### PR DESCRIPTION
## Summary
- Replace the admin experiences table with lean visual preview cards
- Resolve previews from OG images, direct block media, and referenced video stills/posters
- Remove operator notes, editorial signals, owner/updated metadata, embedding status, and extra section chrome
- Document the preview-card video image hydration pattern

## Review
- Manual review completed for the intended diff; no blocking findings found
- Full typecheck remains blocked by pre-existing VideoTranscript Prisma/Pothos drift outside this branch

## Validation
- pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx
- pnpm --filter @forge/admin exec eslint src/app/dashboard/experiences/page.tsx src/app/dashboard/live-data.ts src/app/dashboard/dashboard-ui.test.tsx src/i18n/messages.ts