### PR TITLE
feat(admin): r4 — hybrid search API (REST + GraphQL)

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -618,6 +618,129 @@ AND embedding IS NOT NULL` — published locales with a vector
 The primary learnings doc is
 `docs/solutions/platform/admin-experience-content-dump-pattern.md`.
 
+## Hybrid search (R4 of admin migration playbook)
+
+Admin owns public hybrid search — semantic + keyword retrieval fused via
+Reciprocal Rank Fusion — over the `Video`/`VideoLocale`/`VideoScene[Locale]`
+and `Experience`/`ExperienceLocale` corpora. Matches the contract of
+apps/cms `/api/search` + `/api/search/health` byte-for-byte (modulo
+cuid-string ids) so apps/web + apps/mobile can swap base URL at R8
+cutover with zero response-shape drift.
+
+- **Shared service:** `src/services/hybrid-search.service.ts`
+  (`HybridSearchService`). One `search(params)` entry point called by
+  both the REST handler and the GraphQL resolver. Constants verbatim
+  from cms: `RRF_K = 60`, `OVERFETCH_FACTOR = 3`, `DEFAULT_LIMIT = 20`,
+  `MAX_LIMIT = 50`.
+- **Retrievers:** `src/services/hybrid-search-retrievers.ts` exports
+  four functions. Each is a thin `$queryRaw` caller.
+  - `searchVideoSemantic` — pgvector cosine over `VideoSceneLocale.embedding`,
+    `DISTINCT ON (video_scene.video_id)`, locale-filtered. Resolves
+    `playbackId` via a LATERAL lookup on `video_dub → mux_video` keyed
+    by `(video_edition_id, language.bcp47 = locale)`. When no dub
+    matches, playbackId is NULL and the row still returns.
+  - `searchVideoKeyword` — tsvector over `VideoLocale.title +
+description`, same `'simple'` config as cms, locale + status gate.
+  - `searchExperienceSemantic` — pgvector cosine over
+    `ExperienceLocale.embedding` joined to non-archived Experience.
+    `resultId` is `ExperienceLocale.id` (per-locale), not the parent
+    Experience.id — admin's per-locale model makes the locale row the
+    natural identity.
+  - `searchExperienceKeyword` — tsvector over `ExperienceLocale.title
+    - meta_description`.
+- **GIN index byte-parity invariant:** the tsvector expressions live in
+  `src/services/hybrid-search-sql.ts` as TypeScript string constants.
+  The migration at `prisma/migrations/0006_hybrid_search_gin/migration.sql`
+  uses the exact same expressions. A `hybrid-search-sql.test.ts` unit
+  test reads the migration file and asserts byte-equality — silently
+  drifting one but not the other reverts the query to Seq Scan.
+- **Fusion + dedup:** `src/services/hybrid-search-fusion.ts` — RRF
+  (`fuseRankedLists`) + 3-layer video dedup (`deduplicateResults`:
+  coreId prefix, exact title, embedding cosine > 0.95) +
+  `cosineSimilarityFromText`. Line-for-line port of cms's `fusion.ts`
+  with `resultId: string` (admin cuids) instead of cms's integer ids.
+  Experience rows skip all three dedup layers.
+- **Scene-only for video-semantic in R4.** `VideoTranscriptChunk.embedding`
+  (R2-indexed) is deliberately NOT fused. Strict cms parity during the
+  R3→R8 window; adding a 5th RRF list for transcripts is a post-cutover
+  follow-up that won't change the consumer contract.
+- **Experience imageUrl is null in R4.** cms parity. `ExperienceLocale.ogImageUrl`
+  exists on admin but wiring it is a deliberate post-cutover upgrade
+  so the pre-R8 diff-against-cms invariant holds.
+- **Degradation signal:** `searchMode: "hybrid" | "keyword-only"`. Set
+  to `"keyword-only"` when the embedding provider throws. Structured
+  log at error level: `[search] event=query_embedding_failure
+error_class=… message=…`. Process-local counters in
+  `src/services/hybrid-search-health.ts`.
+- **Embedding provider:** reuses
+  `generateExperienceEmbedding(text)` from
+  `src/services/embeddings.service.ts` verbatim. Name is historical
+  (it takes a plain string); renaming is a follow-up outside R4 scope.
+- **REST endpoints** — Next App Router route handlers. First such
+  endpoints in admin outside of `/api/auth` and `/api/graphql`.
+  - `GET /api/search` at `src/app/api/search/route.ts` — query params
+    `q` (required, trimmed), `locale` (required), `type` (optional
+    enum), `limit`, `offset`. 400 on missing/invalid; 429 on
+    rate-limit; 503 on unexpected service throw.
+  - `GET /api/search/health` at `src/app/api/search/health/route.ts` —
+    synthetic probe that runs a real `embedQuery("health probe")` with
+    a 5s timeout. Always HTTP 200; body's `status` field is the
+    machine-readable signal. Shared counters with the search
+    orchestrator.
+  - Rate limiting via `rateLimitAuthRoute` from `src/auth/rate-limit.ts`
+    (same Redis-backed limiter used by `/api/auth`). Distinct `route`
+    keys: `"search"` (30/min) and `"search-health"` (5/min) so probe
+    traffic never starves the user quota.
+- **GraphQL:** public `search(q, locale, type, limit, offset)` query
+  at `src/graphql/queries/hybrid-search.ts`. `authScopes: { public: true }`.
+  Returns `HybridSearchResponse` → `HybridSearchResult` with fields
+  matching the REST JSON 1:1. `schema.test.ts` asserts the new types
+  expose no `embedding|vector|similarit`-shaped field.
+- **`embedding::text` transport in semantic-video SQL** is
+  service-internal — it feeds the 3-layer dedup's cosine-similarity
+  check. The Pothos schema never exposes it, so the GraphQL-surface
+  leak guard in `schema.test.ts` still passes.
+
+**Operational runbook:**
+
+1. Point external monitors (Railway healthcheck, uptime tools) at
+   `https://admin.jesusfilm.org/api/search/health`. Body's `status`
+   field is the signal; HTTP is always 200 so infra-level liveness is
+   not confused with provider reachability.
+2. Ensure `OPENROUTER_API_KEY` or `OPENAI_API_KEY` is set on the
+   `forge-admin` Railway service (already required by R1–R3).
+3. Canary diff vs cms: for a fixed query set × locales, compare
+   `admin/api/search?q=…&locale=…` to `cms/api/search?q=…&locale=…`.
+   Top-10 should overlap within ranking ±1. Drift signals either a
+   data-readiness gap (R1 scene backfill not yet run on prod) or an
+   SQL-invariant drift to investigate.
+4. Verify GIN indexes are used:
+   `EXPLAIN ANALYZE SELECT COUNT(*) FROM video_locale WHERE
+to_tsvector('simple', coalesce(title,'') || ' ' ||
+coalesce(description,'')) @@ plainto_tsquery('simple', 'jesus');`
+   should show `Bitmap Index Scan on video_locale_fulltext_search_idx`.
+
+**Common things to remember:**
+
+- R4 is a READ-SIDE port. No useworkflow dispatch, so no
+  dispatch-level test obligation (cf.
+  `workflow-dispatch-test-mode-divergence-20260421.md` — applies to
+  backfill shapes, not synchronous reads).
+- Every SQL invariant was re-derived from admin's schema (cf.
+  `dead-invariant-checks-from-sibling-port-20260422.md`): cms's
+  `videos.title` → admin's `video_locale.title`, cms's
+  `video_variants` publish chain → admin's `VideoLocale.status +
+Video.deleted_at`, cms's scene_embeddings single-row → admin's
+  VideoSceneLocale per-locale.
+- Data-derived enumeration (cf.
+  `prototype-defaults-vs-data-derived-enumeration-20260422.md`): no
+  hardcoded locale list. `locale` is required at the boundary;
+  zero-result responses on a locale with no corpus are legitimate
+  data signals.
+
+The primary learnings doc is
+`docs/solutions/platform/admin-hybrid-search-r4-pattern.md`.
+
 ## Common pitfalls (grows with each unit)
 
 - `[deploy.env]` in `railway.toml` is unreliable — put env vars in Railway dashboard.

--- a/apps/admin/prisma/migrations/0006_hybrid_search_gin/migration.sql
+++ b/apps/admin/prisma/migrations/0006_hybrid_search_gin/migration.sql
@@ -1,0 +1,34 @@
+-- R4 hybrid-search GIN indexes for keyword retrieval.
+--
+-- Creates tsvector GIN indexes over `video_locale` (title + description)
+-- and `experience_locale` (title + meta_description) so the R4
+-- `HybridSearchService` keyword retrievers can match
+-- `plainto_tsquery('simple', ?)` predicates via index scan rather than
+-- sequential scan on the full per-locale corpus.
+--
+-- The tsvector expressions below MUST remain byte-equal to the
+-- `*_INDEX_EXPR` constants in `src/services/hybrid-search-sql.ts`. The
+-- planner only matches expression indexes when the query-side
+-- expression is character-for-character identical to the indexed
+-- expression (alias prefixes are normalized away, but whitespace,
+-- quoting, and column order are not). Drift silently reverts the
+-- retrievers to seq scan on large corpora. `hybrid-search-sql.test.ts`
+-- enforces the byte-parity invariant by reading this file at test
+-- time and asserting both constants appear verbatim.
+--
+-- `IF NOT EXISTS` keeps the migration idempotent across partial
+-- retries. No schema changes are introduced — this migration is
+-- index-only. Created non-CONCURRENTLY because R4 deploys against
+-- corpora that are either empty (fresh admin environments) or small
+-- enough that an AccessExclusiveLock is acceptable during the brief
+-- index build. Future re-creations against a populated corpus should
+-- use `CREATE INDEX CONCURRENTLY` in a `prisma:no_transaction`
+-- migration — same precedent as the 0001_init HNSW partial index.
+
+CREATE INDEX IF NOT EXISTS "video_locale_fulltext_search_idx"
+  ON "video_locale"
+  USING GIN (to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(description, '')));
+
+CREATE INDEX IF NOT EXISTS "experience_locale_fulltext_search_idx"
+  ON "experience_locale"
+  USING GIN (to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(meta_description, '')));

--- a/apps/admin/src/app/api/search/health/route.test.ts
+++ b/apps/admin/src/app/api/search/health/route.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/auth/rate-limit", () => ({
+  rateLimitAuthRoute: vi.fn(),
+}))
+
+vi.mock("@/services/embeddings.service", () => ({
+  generateExperienceEmbedding: vi.fn(),
+}))
+
+import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { generateExperienceEmbedding } from "@/services/embeddings.service"
+import { __resetSearchHealthForTest } from "@/services/hybrid-search-health"
+import { GET } from "./route"
+
+const allowRateLimit = () =>
+  vi.mocked(rateLimitAuthRoute).mockResolvedValue({
+    allowed: true,
+    source: "local",
+  })
+
+const denyRateLimit = () =>
+  vi.mocked(rateLimitAuthRoute).mockResolvedValue({
+    allowed: false,
+    source: "local",
+  })
+
+function req(): Request {
+  return new Request("http://localhost/api/search/health", { method: "GET" })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetSearchHealthForTest()
+  allowRateLimit()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("GET /api/search/health", () => {
+  it("returns 200 + status=ok when embedding succeeds", async () => {
+    vi.mocked(generateExperienceEmbedding).mockResolvedValue({
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+      embedding: new Array(1536).fill(0.1),
+    })
+
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe("ok")
+    expect(body.error).toBeNull()
+    expect(body.attempts).toBe(1)
+    expect(body.failures).toBe(0)
+  })
+
+  it("returns 200 + status=degraded when embedding throws", async () => {
+    vi.mocked(generateExperienceEmbedding).mockRejectedValue(
+      new Error("provider down"),
+    )
+
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe("degraded")
+    expect(body.error).toBe("provider down")
+    expect(body.attempts).toBe(1)
+    expect(body.failures).toBe(1)
+    expect(body.lastErrorClass).toBe("Error")
+    expect(body.lastErrorMessage).toBe("provider down")
+    expect(body.lastErrorAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  // Timeout behavior itself is covered by hybrid-search-health.test.ts;
+  // an end-to-end timeout probe here would require real-time sleeps and
+  // add flakiness without additional coverage.
+
+  it("returns 429 when rate limit exceeded", async () => {
+    denyRateLimit()
+    const res = await GET(req())
+    expect(res.status).toBe(429)
+  })
+})

--- a/apps/admin/src/app/api/search/health/route.ts
+++ b/apps/admin/src/app/api/search/health/route.ts
@@ -1,0 +1,72 @@
+/**
+ * GET /api/search/health — synthetic probe for embedding-provider
+ * reachability.
+ *
+ * Always returns HTTP 200. Body's `status` field is the machine-readable
+ * signal (`ok` or `degraded`) — matches cms parity so external monitors
+ * (Railway healthcheck, uptime tools, curl checks) swap URLs without
+ * changing their success rule.
+ *
+ * Runs a real `embedQuery("health probe")` call with a short timeout so a
+ * stalled provider fails fast. Counters are shared with the search
+ * orchestrator via hybrid-search-health.ts — operators see a single
+ * unified view of embedding-call activity on the process.
+ */
+
+import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { generateExperienceEmbedding } from "@/services/embeddings.service"
+import {
+  getStats,
+  recordAttempt,
+  recordFailure,
+  withTimeout,
+} from "@/services/hybrid-search-health"
+
+const RATE_LIMIT_MAX = 5
+const RATE_LIMIT_WINDOW_MS = 60_000
+
+/** Probe ceiling. Shorter than the embedding provider's own timeout so a
+ *  stalled request fails fast and external monitors can page quickly. */
+const HEALTH_PROBE_TIMEOUT_MS = 5_000
+
+/** Fixed input — keeps cost and log output predictable. */
+const HEALTH_PROBE_INPUT = "health probe"
+
+function tooManyRequests(): Response {
+  return Response.json({ error: "Too many requests" }, { status: 429 })
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const limit = await rateLimitAuthRoute({
+    request,
+    route: "search-health",
+    limit: RATE_LIMIT_MAX,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  })
+  if (!limit.allowed) return tooManyRequests()
+
+  recordAttempt()
+  try {
+    await withTimeout(
+      generateExperienceEmbedding(HEALTH_PROBE_INPUT),
+      HEALTH_PROBE_TIMEOUT_MS,
+    )
+    return Response.json(
+      { status: "ok", error: null, ...getStats() },
+      { status: 200 },
+    )
+  } catch (error) {
+    recordFailure(error)
+    const errorClass =
+      error instanceof Error ? error.constructor.name : "UnknownError"
+    const message = error instanceof Error ? error.message : String(error)
+
+    console.error(
+      `[search] event=health_probe_failed error_class=${errorClass} message=${message}`,
+    )
+    return Response.json(
+      { status: "degraded", error: message, ...getStats() },
+      { status: 200 },
+    )
+  }
+}

--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/auth/rate-limit", () => ({
+  rateLimitAuthRoute: vi.fn(),
+}))
+
+// The route constructs a HybridSearchService with the shared `prisma`
+// import; we mock the class so tests don't touch the DB.
+const searchMock = vi.fn()
+vi.mock("@/services/hybrid-search.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/services/hybrid-search.service")
+  >("@/services/hybrid-search.service")
+  return {
+    ...actual,
+    HybridSearchService: vi.fn(() => ({ search: searchMock })),
+  }
+})
+
+vi.mock("@/db/client", () => ({ prisma: {} }))
+
+import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { GET } from "./route"
+
+const allowRateLimit = () =>
+  vi.mocked(rateLimitAuthRoute).mockResolvedValue({
+    allowed: true,
+    source: "local",
+  })
+
+const denyRateLimit = () =>
+  vi.mocked(rateLimitAuthRoute).mockResolvedValue({
+    allowed: false,
+    source: "local",
+  })
+
+function req(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: "GET" })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  allowRateLimit()
+  searchMock.mockResolvedValue({
+    results: [],
+    hasMore: false,
+    query: "",
+    searchMode: "hybrid",
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("GET /api/search", () => {
+  it("returns 400 when `q` is missing", async () => {
+    const res = await GET(req("/api/search?locale=en"))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({
+      error: "q (search query) is required",
+    })
+  })
+
+  it("returns 400 when `q` is whitespace-only", async () => {
+    const res = await GET(req("/api/search?q=%20%20&locale=en"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when `locale` is missing", async () => {
+    const res = await GET(req("/api/search?q=jesus"))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: "locale is required" })
+  })
+
+  it("returns 400 when `type` is not video/experience", async () => {
+    const res = await GET(req("/api/search?q=jesus&locale=en&type=foo"))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({
+      error: "type must be 'video' or 'experience'",
+    })
+  })
+
+  it("passes contentTypes=[video] when type=video", async () => {
+    await GET(req("/api/search?q=jesus&locale=en&type=video"))
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ contentTypes: ["video"] }),
+    )
+  })
+
+  it("passes contentTypes=undefined when type omitted", async () => {
+    await GET(req("/api/search?q=jesus&locale=en"))
+    const call = searchMock.mock.calls[0][0]
+    expect(call.contentTypes).toBeUndefined()
+  })
+
+  it("parses limit + offset as numbers", async () => {
+    await GET(req("/api/search?q=jesus&locale=en&limit=10&offset=5"))
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10, offset: 5 }),
+    )
+  })
+
+  it("ignores non-numeric limit/offset", async () => {
+    await GET(req("/api/search?q=jesus&locale=en&limit=abc&offset=xyz"))
+    const call = searchMock.mock.calls[0][0]
+    expect(call.limit).toBeUndefined()
+    expect(call.offset).toBeUndefined()
+  })
+
+  it("returns 200 with service response on happy path", async () => {
+    searchMock.mockResolvedValueOnce({
+      results: [
+        {
+          type: "video",
+          id: "vid-1",
+          slug: "jesus",
+          title: "Jesus",
+          imageUrl: null,
+          snippet: "scene",
+          startSeconds: 0,
+          playbackId: "mux-1",
+          score: 1,
+        },
+      ],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "hybrid",
+    })
+
+    const res = await GET(req("/api/search?q=jesus&locale=en"))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.results).toHaveLength(1)
+    expect(body.searchMode).toBe("hybrid")
+  })
+
+  it("returns 429 when rate limit exceeded", async () => {
+    denyRateLimit()
+    const res = await GET(req("/api/search?q=jesus&locale=en"))
+    expect(res.status).toBe(429)
+  })
+
+  it("returns 503 when service throws", async () => {
+    searchMock.mockRejectedValueOnce(new Error("boom"))
+    const res = await GET(req("/api/search?q=jesus&locale=en"))
+    expect(res.status).toBe(503)
+    expect(await res.json()).toEqual({
+      error: "Search is temporarily unavailable",
+    })
+  })
+})

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -1,0 +1,88 @@
+/**
+ * GET /api/search — public hybrid search endpoint.
+ *
+ * Matches the shape of apps/cms `/api/search` so apps/web + apps/mobile
+ * can swap base URL at R8 cutover with zero response-shape drift.
+ * See docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md Unit 6.
+ */
+
+import { prisma } from "@/db/client"
+import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import {
+  HybridSearchService,
+  isContentType,
+  type ContentType,
+} from "@/services/hybrid-search.service"
+
+const RATE_LIMIT_MAX = 30
+const RATE_LIMIT_WINDOW_MS = 60_000
+
+function badRequest(error: string): Response {
+  return Response.json({ error }, { status: 400 })
+}
+
+function tooManyRequests(): Response {
+  return Response.json({ error: "Too many requests" }, { status: 429 })
+}
+
+function parseNumericParam(raw: string | null): number | undefined {
+  if (raw == null || raw.length === 0) return undefined
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const limit = await rateLimitAuthRoute({
+    request,
+    route: "search",
+    limit: RATE_LIMIT_MAX,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  })
+  if (!limit.allowed) return tooManyRequests()
+
+  const { searchParams } = new URL(request.url)
+
+  const q = searchParams.get("q")?.trim() ?? ""
+  if (q.length === 0) {
+    return badRequest("q (search query) is required")
+  }
+
+  const locale = searchParams.get("locale")
+  if (!locale || locale.length === 0) {
+    return badRequest("locale is required")
+  }
+
+  const rawType = searchParams.get("type")
+  let contentTypes: ContentType[] | undefined
+  if (rawType != null && rawType.length > 0) {
+    if (!isContentType(rawType)) {
+      return badRequest("type must be 'video' or 'experience'")
+    }
+    contentTypes = [rawType]
+  }
+
+  const limitParam = parseNumericParam(searchParams.get("limit"))
+  const offsetParam = parseNumericParam(searchParams.get("offset"))
+
+  try {
+    const service = new HybridSearchService({ prisma })
+    const result = await service.search({
+      query: q,
+      locale,
+      limit: limitParam,
+      offset: offsetParam,
+      contentTypes,
+    })
+    return Response.json(result, { status: 200 })
+  } catch (error) {
+    console.error(
+      `[search] Search failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+    return Response.json(
+      { error: "Search is temporarily unavailable" },
+      { status: 503 },
+    )
+  }
+}

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -1,0 +1,130 @@
+/**
+ * Public hybrid-search GraphQL query (`search`).
+ *
+ * Delegates to HybridSearchService — the same service the REST route at
+ * /api/search calls. Matches cms's `/api/search` response shape so
+ * consumers can choose REST or GraphQL interchangeably.
+ *
+ * @classification public-shape
+ */
+
+import { builder } from "@/graphql/builder"
+import { prisma } from "@/db/client"
+import {
+  HybridSearchService,
+  isContentType,
+  type ContentType,
+  type SearchResult,
+  type SearchResponse,
+} from "@/services/hybrid-search.service"
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+const ContentTypeEnum = builder.enumType("HybridSearchContentType", {
+  description: "Content corpus filter for hybrid search.",
+  values: {
+    VIDEO: { value: "video" },
+    EXPERIENCE: { value: "experience" },
+  } as const,
+})
+
+const SearchModeEnum = builder.enumType("HybridSearchMode", {
+  description:
+    "Which retrieval paths contributed to a response. 'keyword-only' indicates the query embedding call failed and only keyword search ran.",
+  values: {
+    HYBRID: { value: "hybrid" },
+    KEYWORD_ONLY: { value: "keyword-only" },
+  } as const,
+})
+
+const SearchResultRef = builder.objectRef<SearchResult>("HybridSearchResult")
+SearchResultRef.implement({
+  description:
+    "A single hybrid-search hit. Video results may carry scene-level snippet + timecode + playback id; experience results carry experience-level data.",
+  fields: (t) => ({
+    type: t.field({
+      type: ContentTypeEnum,
+      nullable: false,
+      resolve: (r) => r.type,
+    }),
+    id: t.exposeString("id", { nullable: false }),
+    slug: t.exposeString("slug", { nullable: false }),
+    title: t.exposeString("title", { nullable: false }),
+    imageUrl: t.exposeString("imageUrl", { nullable: true }),
+    snippet: t.exposeString("snippet", { nullable: false }),
+    startSeconds: t.exposeFloat("startSeconds", { nullable: true }),
+    playbackId: t.exposeString("playbackId", { nullable: true }),
+    score: t.exposeFloat("score", { nullable: false }),
+  }),
+})
+
+const SearchResponseRef = builder.objectRef<SearchResponse>(
+  "HybridSearchResponse",
+)
+SearchResponseRef.implement({
+  description:
+    "Full response envelope. `hasMore` is derived without a COUNT pass by dedup-to-(offset+limit+1). `searchMode` is the degradation signal.",
+  fields: (t) => ({
+    results: t.field({
+      type: [SearchResultRef],
+      nullable: false,
+      resolve: (r) => r.results,
+    }),
+    hasMore: t.exposeBoolean("hasMore", { nullable: false }),
+    query: t.exposeString("query", { nullable: false }),
+    searchMode: t.field({
+      type: SearchModeEnum,
+      nullable: false,
+      resolve: (r) => r.searchMode,
+    }),
+  }),
+})
+
+// -----------------------------------------------------------------------------
+// Query field
+// -----------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  search: t.field({
+    type: SearchResponseRef,
+    authScopes: { public: true },
+    description:
+      "Hybrid (semantic + keyword) search across videos and experiences. PUBLIC — see published + non-archived rows only.",
+    args: {
+      q: t.arg.string({ required: true }),
+      locale: t.arg.string({ required: true }),
+      type: t.arg({ type: ContentTypeEnum, required: false }),
+      limit: t.arg.int({ required: false }),
+      offset: t.arg.int({ required: false }),
+    },
+    resolve: async (_root, args, _ctx) => {
+      const query = args.q.trim()
+      if (query.length === 0) {
+        throw new Error("q (search query) is required")
+      }
+      if (!args.locale || args.locale.length === 0) {
+        throw new Error("locale is required")
+      }
+
+      let contentTypes: ContentType[] | undefined
+      if (args.type != null) {
+        const raw = String(args.type)
+        if (!isContentType(raw)) {
+          throw new Error("type must be 'video' or 'experience'")
+        }
+        contentTypes = [raw]
+      }
+
+      const service = new HybridSearchService({ prisma })
+      return service.search({
+        query,
+        locale: args.locale,
+        limit: args.limit ?? undefined,
+        offset: args.offset ?? undefined,
+        contentTypes,
+      })
+    },
+  }),
+}))

--- a/apps/admin/src/graphql/schema.test.ts
+++ b/apps/admin/src/graphql/schema.test.ts
@@ -293,3 +293,71 @@ describe("reference types", () => {
     expect(fields.continent.type.toString()).toBe("Continent")
   })
 })
+
+describe("Hybrid search — R4 query + response types", () => {
+  it("Query root exposes the `search` field", () => {
+    const fields = schema.getQueryType()!.getFields()
+    expect(fields.search).toBeTruthy()
+  })
+
+  it("HybridSearchResult exposes the expected consumer-facing shape", () => {
+    const fields = fieldsOf("HybridSearchResult") as Record<
+      string,
+      { type: { toString(): string } }
+    >
+    expect(Object.keys(fields)).toEqual(
+      expect.arrayContaining([
+        "type",
+        "id",
+        "slug",
+        "title",
+        "imageUrl",
+        "snippet",
+        "startSeconds",
+        "playbackId",
+        "score",
+      ]),
+    )
+    expect(fields.score.type.toString()).toBe("Float!")
+    expect(fields.startSeconds.type.toString()).toBe("Float")
+    expect(fields.playbackId.type.toString()).toBe("String")
+  })
+
+  it("HybridSearchResult exposes no embedding/vector/similarity-shaped field", () => {
+    const fields = fieldsOf("HybridSearchResult")
+    for (const key of Object.keys(fields)) {
+      expect(key).not.toMatch(/embed|vector|similarit/i)
+    }
+  })
+
+  it("HybridSearchResponse wraps results + hasMore + query + searchMode", () => {
+    const fields = fieldsOf("HybridSearchResponse") as Record<
+      string,
+      { type: { toString(): string } }
+    >
+    expect(fields.results.type.toString()).toBe("[HybridSearchResult!]!")
+    expect(fields.hasMore.type.toString()).toBe("Boolean!")
+    expect(fields.query.type.toString()).toBe("String!")
+    expect(fields.searchMode.type.toString()).toBe("HybridSearchMode!")
+  })
+
+  it("HybridSearchMode enum exposes hybrid + keyword-only values", () => {
+    const t = schema.getType("HybridSearchMode")
+    expect(t).toBeTruthy()
+    const values = (
+      t as unknown as { getValues(): { value: string }[] }
+    ).getValues()
+    const raw = values.map((v) => v.value)
+    expect(raw).toContain("hybrid")
+    expect(raw).toContain("keyword-only")
+  })
+
+  it("HybridSearchContentType enum maps to service-layer values", () => {
+    const t = schema.getType("HybridSearchContentType")
+    const values = (
+      t as unknown as { getValues(): { value: string }[] }
+    ).getValues()
+    const raw = values.map((v) => v.value)
+    expect(raw).toEqual(expect.arrayContaining(["video", "experience"]))
+  })
+})

--- a/apps/admin/src/graphql/schema.ts
+++ b/apps/admin/src/graphql/schema.ts
@@ -16,6 +16,7 @@ import "@/graphql/mutations/scene-embedding"
 import "@/graphql/mutations/transcript-embedding"
 import "@/graphql/mutations/experience-content-dump"
 import "@/graphql/queries/search"
+import "@/graphql/queries/hybrid-search"
 import "@/graphql/queries/sync-status"
 
 export const schema = builder.toSchema()

--- a/apps/admin/src/services/hybrid-search-fusion.test.ts
+++ b/apps/admin/src/services/hybrid-search-fusion.test.ts
@@ -1,0 +1,556 @@
+import { describe, expect, it } from "vitest"
+import {
+  cosineSimilarityFromText,
+  deduplicateResults,
+  fuseRankedLists,
+  type FusedResult,
+  type RankedItem,
+} from "./hybrid-search-fusion"
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function item(
+  videoId: number,
+  overrides: Partial<RankedItem> = {},
+): RankedItem {
+  return {
+    resultType: "video",
+    resultId: `cld-vid-${videoId}`,
+    videoId,
+    videoCoreId: `core-${videoId}`,
+    videoTitle: `Video ${videoId}`,
+    ...overrides,
+  }
+}
+
+function experienceItem(
+  experienceId: number,
+  overrides: Partial<RankedItem> = {},
+): RankedItem {
+  return {
+    resultType: "experience",
+    resultId: `cld-exp-${experienceId}`,
+    experienceId,
+    experienceSlug: `experience-${experienceId}`,
+    experienceTitle: `Experience ${experienceId}`,
+    ...overrides,
+  }
+}
+
+/** Builds a pgvector-format embedding string from a plain number array. */
+function toEmbeddingText(values: number[]): string {
+  return `[${values.join(",")}]`
+}
+
+/* ------------------------------------------------------------------ */
+/*  fuseRankedLists                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("fuseRankedLists", () => {
+  const K = 60 // default
+
+  it("fuses two lists with overlapping videos — rank 1 in both yields score 1.0", () => {
+    const listA = [item(1), item(2)]
+    const listB = [item(1), item(3)]
+
+    const results = fuseRankedLists([listA, listB], K)
+
+    const video1 = results.find((r) => r.videoId === 1)!
+    // score = (1/(61) + 1/(61)) / (2/61) = 2/61 / (2/61) = 1.0
+    expect(video1.score).toBeCloseTo(1.0, 10)
+  })
+
+  it("fuses video at rank 1 in list A and rank 3 in list B", () => {
+    const listA = [item(1)]
+    const listB = [item(10), item(20), item(1)]
+
+    const results = fuseRankedLists([listA, listB], K)
+
+    const video1 = results.find((r) => r.videoId === 1)!
+    // score = (1/61 + 1/63) / (2/61)
+    const expected = (1 / 61 + 1 / 63) / (2 / 61)
+    expect(video1.score).toBeCloseTo(expected, 10)
+  })
+
+  it("gives partial score to video appearing in only one list", () => {
+    const listA = [item(1), item(2)]
+    const listB = [item(3)]
+
+    const results = fuseRankedLists([listA, listB], K)
+
+    const video2 = results.find((r) => r.videoId === 2)!
+    // score = (1/62) / (2/61) — only in list A at rank 2
+    const expected = 1 / 62 / (2 / 61)
+    expect(video2.score).toBeCloseTo(expected, 10)
+  })
+
+  it("normalizes all scores to at most 1.0", () => {
+    const listA = [item(1), item(2), item(3)]
+    const listB = [item(1), item(3), item(4)]
+    const listC = [item(1), item(5)]
+
+    const results = fuseRankedLists([listA, listB, listC], K)
+
+    for (const r of results) {
+      expect(r.score).toBeLessThanOrEqual(1.0)
+      expect(r.score).toBeGreaterThan(0)
+    }
+
+    // Video 1 is rank 1 in all 3 lists — should be exactly 1.0
+    const video1 = results.find((r) => r.videoId === 1)!
+    expect(video1.score).toBeCloseTo(1.0, 10)
+  })
+
+  it("sorts results by score descending", () => {
+    const listA = [item(1), item(2), item(3)]
+    const listB = [item(2), item(3), item(1)]
+
+    const results = fuseRankedLists([listA, listB], K)
+
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score)
+    }
+  })
+
+  it("returns empty array for empty input", () => {
+    expect(fuseRankedLists([], K)).toEqual([])
+    expect(fuseRankedLists([[]], K)).toEqual([])
+  })
+
+  it("works correctly with a single list", () => {
+    const list = [item(1), item(2), item(3)]
+    const results = fuseRankedLists([list], K)
+
+    expect(results).toHaveLength(3)
+    // Rank 1 in a single list: score = (1/61) / (1/61) = 1.0
+    expect(results[0].score).toBeCloseTo(1.0, 10)
+    expect(results[0].videoId).toBe(1)
+
+    // Rank 2: score = (1/62) / (1/61)
+    const expected2 = 1 / 62 / (1 / 61)
+    expect(results[1].score).toBeCloseTo(expected2, 10)
+  })
+
+  it("merges properties with earlier lists taking priority", () => {
+    const semanticItem: RankedItem = {
+      resultType: "video",
+      resultId: "cld-vid-1",
+      videoId: 1,
+      videoCoreId: "core-1",
+      videoTitle: "Semantic Title",
+      embeddingText: "[0.1,0.2]",
+      sceneDescription: "A scene about forgiveness",
+      startSeconds: 42,
+    }
+    const keywordItem: RankedItem = {
+      resultType: "video",
+      resultId: "cld-vid-1",
+      videoId: 1,
+      videoCoreId: "core-1",
+      videoTitle: "Keyword Title",
+      description: "A full video description",
+      rank: 0.5,
+    }
+
+    // Semantic list first — its properties should take priority
+    const results = fuseRankedLists([[semanticItem], [keywordItem]], K)
+
+    const video1 = results.find((r) => r.videoId === 1)!
+    // Compound identity preserved on the merged result
+    expect(video1.resultType).toBe("video")
+    expect(video1.resultId).toBe("cld-vid-1")
+    // Earlier list (semantic) wins for overlapping keys
+    expect(video1.videoTitle).toBe("Semantic Title")
+    expect(video1.embeddingText).toBe("[0.1,0.2]")
+    expect(video1.sceneDescription).toBe("A scene about forgiveness")
+    // Keyword-only fields are still present
+    expect(video1.description).toBe("A full video description")
+    expect(video1.rank).toBe(0.5)
+  })
+
+  it("accepts custom k values", () => {
+    const listA = [item(1)]
+    const listB = [item(1)]
+
+    const results10 = fuseRankedLists([listA, listB], 10)
+    const results100 = fuseRankedLists([listA, listB], 100)
+
+    // Both should normalize to 1.0 since video is rank 1 in both
+    expect(results10[0].score).toBeCloseTo(1.0, 10)
+    expect(results100[0].score).toBeCloseTo(1.0, 10)
+  })
+
+  it("uses default k=60 when not specified", () => {
+    const listA = [item(1), item(2)]
+    const listB = [item(2)]
+
+    const withDefault = fuseRankedLists([listA, listB])
+    const withExplicit = fuseRankedLists([listA, listB], 60)
+
+    expect(withDefault[0].score).toBeCloseTo(withExplicit[0].score, 10)
+    expect(withDefault[1].score).toBeCloseTo(withExplicit[1].score, 10)
+  })
+
+  it("does not collide a video and an experience with the same string ID", () => {
+    // Both have resultId "cld-shared-4" but different result types — the
+    // compound key must keep them distinct in the output.
+    const videoList: RankedItem[] = [
+      {
+        resultType: "video",
+        resultId: "cld-shared-4",
+        videoId: 4,
+        videoCoreId: "core-4",
+        videoTitle: "Video 4",
+      },
+    ]
+    const experienceList: RankedItem[] = [
+      {
+        resultType: "experience",
+        resultId: "cld-shared-4",
+        experienceSlug: "experience-4",
+        experienceTitle: "Experience 4",
+      },
+    ]
+
+    const results = fuseRankedLists([videoList, experienceList], K)
+
+    expect(results).toHaveLength(2)
+    const types = results.map((r) => r.resultType).sort()
+    expect(types).toEqual(["experience", "video"])
+  })
+
+  it("preserves resultType and resultId on fused results", () => {
+    const list = [item(1), experienceItem(2)]
+
+    const results = fuseRankedLists([list], K)
+
+    const video = results.find((r) => r.resultType === "video")!
+    const experience = results.find((r) => r.resultType === "experience")!
+    expect(video.resultId).toBe("cld-vid-1")
+    expect(experience.resultId).toBe("cld-exp-2")
+  })
+
+  it("fuses 4 lists (mixed video and experience) with correct normalization", () => {
+    const semanticVideos = [item(1)]
+    const keywordVideos = [item(1)]
+    const semanticExperiences = [experienceItem(10)]
+    const keywordExperiences = [experienceItem(10)]
+
+    const results = fuseRankedLists(
+      [semanticVideos, keywordVideos, semanticExperiences, keywordExperiences],
+      K,
+    )
+
+    // Both items appear in 2 of 4 lists at rank 1.
+    // raw = 2 * 1/61, theoreticalMax = 4/61, score = 2/4 = 0.5
+    expect(results).toHaveLength(2)
+    for (const r of results) {
+      expect(r.score).toBeCloseTo(0.5, 10)
+    }
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  deduplicateResults                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("deduplicateResults", () => {
+  function fused(
+    videoId: number,
+    score: number,
+    overrides: Partial<FusedResult> = {},
+  ): FusedResult {
+    return {
+      resultType: "video",
+      resultId: `cld-vid-${videoId}`,
+      videoId,
+      videoCoreId: `core-${videoId}`,
+      videoTitle: `Video ${videoId}`,
+      score,
+      ...overrides,
+    }
+  }
+
+  function fusedExperience(
+    experienceId: number,
+    score: number,
+    overrides: Partial<FusedResult> = {},
+  ): FusedResult {
+    return {
+      resultType: "experience",
+      resultId: `cld-exp-${experienceId}`,
+      experienceSlug: `experience-${experienceId}`,
+      experienceTitle: `Experience ${experienceId}`,
+      score,
+      ...overrides,
+    }
+  }
+
+  it("removes lower-scored duplicate by core_id prefix match", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.9, { videoCoreId: "4_Win4GoodNewsJesus" }),
+      fused(2, 0.7, { videoCoreId: "4_Win4GoodNewsJesusAD1x1" }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(1)
+    expect(deduped[0].videoId).toBe(1)
+  })
+
+  it("removes lower-scored duplicate by core_id prefix match (reverse prefix)", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.9, { videoCoreId: "4_Win4GoodNewsJesusAD1x1" }),
+      fused(2, 0.7, { videoCoreId: "4_Win4GoodNewsJesus" }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(1)
+    expect(deduped[0].videoId).toBe(1)
+  })
+
+  it("removes lower-scored duplicate by exact title match", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.9, {
+        videoCoreId: "series-a-scene1",
+        videoTitle: "Sermon on the Mount",
+      }),
+      fused(2, 0.7, {
+        videoCoreId: "series-b-scene1",
+        videoTitle: "Sermon on the Mount",
+      }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(1)
+    expect(deduped[0].videoId).toBe(1)
+  })
+
+  it("removes lower-scored duplicate by embedding similarity >0.95", () => {
+    // Two vectors that are nearly identical (cosine sim > 0.95)
+    const baseVec = Array.from({ length: 10 }, (_, i) => Math.sin(i))
+    // Slightly perturbed copy — still very similar
+    const perturbedVec = baseVec.map((v) => v + 0.001)
+
+    const results: FusedResult[] = [
+      fused(1, 0.9, {
+        videoCoreId: "distinct-a",
+        videoTitle: "Distinct Title A",
+        embeddingText: toEmbeddingText(baseVec),
+      }),
+      fused(2, 0.7, {
+        videoCoreId: "distinct-b",
+        videoTitle: "Distinct Title B",
+        embeddingText: toEmbeddingText(perturbedVec),
+      }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(1)
+    expect(deduped[0].videoId).toBe(1)
+  })
+
+  it("keeps videos with different core_ids, titles, and embeddings", () => {
+    // Orthogonal vectors — cosine similarity near 0
+    const vecA = [1, 0, 0, 0, 0]
+    const vecB = [0, 0, 0, 0, 1]
+
+    const results: FusedResult[] = [
+      fused(1, 0.9, {
+        videoCoreId: "alpha",
+        videoTitle: "The JESUS Film",
+        embeddingText: toEmbeddingText(vecA),
+      }),
+      fused(2, 0.7, {
+        videoCoreId: "beta",
+        videoTitle: "Magdalena",
+        embeddingText: toEmbeddingText(vecB),
+      }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("respects limit — stops collecting when limit is reached", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.9, { videoCoreId: "a", videoTitle: "Title A" }),
+      fused(2, 0.8, { videoCoreId: "b", videoTitle: "Title B" }),
+      fused(3, 0.7, { videoCoreId: "c", videoTitle: "Title C" }),
+      fused(4, 0.6, { videoCoreId: "d", videoTitle: "Title D" }),
+      fused(5, 0.5, { videoCoreId: "e", videoTitle: "Title E" }),
+    ]
+
+    const deduped = deduplicateResults(results, 3)
+
+    expect(deduped).toHaveLength(3)
+    expect(deduped.map((d) => d.videoId)).toEqual([1, 2, 3])
+  })
+
+  it("returns empty array for empty input", () => {
+    expect(deduplicateResults([], 10)).toEqual([])
+  })
+
+  it("handles results with null core_ids gracefully", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.9, { videoCoreId: null, videoTitle: "Title A" }),
+      fused(2, 0.7, { videoCoreId: null, videoTitle: "Title B" }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    // Null core_ids should not match each other
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("handles results without embedding text", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.9, {
+        videoCoreId: "distinct-a",
+        videoTitle: "Title A",
+      }),
+      fused(2, 0.7, {
+        videoCoreId: "distinct-b",
+        videoTitle: "Title B",
+      }),
+    ]
+
+    // No embeddingText — layer 3 is skipped, no crash
+    const deduped = deduplicateResults(results, 10)
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("does not dedup an experience against a video with the same title", () => {
+    // The "Easter" experience and an "Easter" video are both legitimately
+    // relevant and should both survive — title collision across types is
+    // intentional, not duplication.
+    const results: FusedResult[] = [
+      fused(1, 0.9, { videoCoreId: "easter-1", videoTitle: "Easter" }),
+      fusedExperience(4, 0.8, { experienceTitle: "Easter" }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("does not collide a video and an experience with the same string ID", () => {
+    // Both resultId "cld-shared-4" but different resultType — compound key
+    // keeps them distinct.
+    const results: FusedResult[] = [
+      {
+        resultType: "video",
+        resultId: "cld-shared-4",
+        videoId: 4,
+        videoCoreId: "core-4",
+        videoTitle: "Video 4",
+        score: 0.9,
+      },
+      {
+        resultType: "experience",
+        resultId: "cld-shared-4",
+        experienceSlug: "experience-4",
+        experienceTitle: "Experience 4",
+        score: 0.8,
+      },
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("passes experience results through dedup unchanged", () => {
+    // Two experiences with similar metadata that would have triggered video
+    // dedup checks. They must both survive because dedup is video-only.
+    const results: FusedResult[] = [
+      fusedExperience(1, 0.9, { experienceTitle: "Easter" }),
+      fusedExperience(2, 0.8, { experienceTitle: "Easter" }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    expect(deduped).toHaveLength(2)
+  })
+
+  it("still applies video dedup when video results are mixed with experiences", () => {
+    const results: FusedResult[] = [
+      fused(1, 0.95, {
+        videoCoreId: "shared-prefix",
+        videoTitle: "Sermon",
+      }),
+      fusedExperience(10, 0.9),
+      fused(2, 0.85, {
+        videoCoreId: "shared-prefix-AD1x1",
+        videoTitle: "Sermon Variant",
+      }),
+    ]
+
+    const deduped = deduplicateResults(results, 10)
+
+    // Video 2 dropped (core_id prefix match with video 1). Experience 10 kept.
+    expect(deduped).toHaveLength(2)
+    expect(deduped.map((d) => `${d.resultType}:${d.resultId}`)).toEqual([
+      "video:cld-vid-1",
+      "experience:cld-exp-10",
+    ])
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  cosineSimilarityFromText                                           */
+/* ------------------------------------------------------------------ */
+
+describe("cosineSimilarityFromText", () => {
+  it("returns 1.0 for identical vectors", () => {
+    const vec = "[0.5,0.3,0.8,0.1]"
+    expect(cosineSimilarityFromText(vec, vec)).toBeCloseTo(1.0, 10)
+  })
+
+  it("returns approximately 0.0 for orthogonal vectors", () => {
+    const a = "[1,0,0]"
+    const b = "[0,1,0]"
+    expect(cosineSimilarityFromText(a, b)).toBeCloseTo(0.0, 10)
+  })
+
+  it("returns known cosine similarity for a specific pair", () => {
+    // [1, 2, 3] and [4, 5, 6]
+    // dot = 4+10+18 = 32
+    // normA = sqrt(1+4+9) = sqrt(14)
+    // normB = sqrt(16+25+36) = sqrt(77)
+    // cos = 32 / (sqrt(14) * sqrt(77))
+    const a = "[1,2,3]"
+    const b = "[4,5,6]"
+    const expected = 32 / (Math.sqrt(14) * Math.sqrt(77))
+    expect(cosineSimilarityFromText(a, b)).toBeCloseTo(expected, 10)
+  })
+
+  it("returns 0 for vectors of different lengths", () => {
+    const a = "[1,2,3]"
+    const b = "[1,2]"
+    expect(cosineSimilarityFromText(a, b)).toBe(0)
+  })
+
+  it("returns 0 for empty vectors", () => {
+    expect(cosineSimilarityFromText("[]", "[]")).toBe(0)
+  })
+
+  it("returns 0 for zero vectors", () => {
+    const zero = "[0,0,0]"
+    const nonZero = "[1,2,3]"
+    expect(cosineSimilarityFromText(zero, nonZero)).toBe(0)
+  })
+
+  it("handles negative values", () => {
+    // Opposite vectors should have similarity -1.0
+    const a = "[1,0,0]"
+    const b = "[-1,0,0]"
+    expect(cosineSimilarityFromText(a, b)).toBeCloseTo(-1.0, 10)
+  })
+})

--- a/apps/admin/src/services/hybrid-search-fusion.ts
+++ b/apps/admin/src/services/hybrid-search-fusion.ts
@@ -1,0 +1,214 @@
+/**
+ * Reciprocal Rank Fusion (RRF) and deduplication for hybrid search.
+ *
+ * RRF merges N ranked lists (video semantic, video keyword, experience
+ * semantic, experience keyword, and future personalization) into a single
+ * scored list. Items are identified by a compound `${resultType}:${resultId}`
+ * key so heterogeneous result types do not collide on shared IDs.
+ *
+ * The 3-layer dedup strategy is adapted from the recommender service
+ * (core_id prefix, exact title, embedding cosine similarity) and applies
+ * only to video results. Non-video results pass through unchanged.
+ *
+ * Ported from apps/cms/src/api/search/services/fusion.ts. The admin app
+ * uses cuid string ids rather than cms's integer ids; otherwise the
+ * algorithm is line-for-line identical so the two implementations can
+ * evolve together.
+ */
+
+export type RankedItem = {
+  resultType: "video" | "experience"
+  resultId: string
+  videoId?: number
+  videoCoreId?: string | null
+  videoTitle?: string
+  embeddingText?: string
+  [key: string]: unknown
+}
+
+export type FusedResult = RankedItem & {
+  score: number
+}
+
+/**
+ * Merges N ranked lists into a single list using Reciprocal Rank Fusion.
+ *
+ * For each item across all lists, the fused score is:
+ *   score = sum(1 / (k + rank_i)) for each list where the item appears
+ *
+ * Scores are normalized to [0, 1] by dividing by the theoretical maximum
+ * (when an item is rank 1 in every list): lists.length / (k + 1).
+ *
+ * When an item appears in multiple lists, properties are merged with
+ * earlier lists taking priority for overlapping keys. This ensures
+ * semantic results (which carry scene-level snippet/timestamp) take
+ * precedence over keyword results (video-level only).
+ *
+ * @param lists - Array of ranked lists. Each list is ordered by relevance
+ *                (index 0 = best). The order of lists matters for property
+ *                merge priority.
+ * @param k     - RRF constant. Default 60 (standard value).
+ * @returns     - Fused results sorted by score descending.
+ */
+export function fuseRankedLists(
+  lists: RankedItem[][],
+  k: number = 60,
+): FusedResult[] {
+  if (lists.length === 0) return []
+
+  // Accumulate RRF scores and collect properties per result.
+  // Compound key prevents cross-type ID collision (e.g. video "x" vs experience "x").
+  const scoreMap = new Map<string, number>()
+  const propsMap = new Map<string, RankedItem>()
+
+  for (const list of lists) {
+    for (let rank = 0; rank < list.length; rank++) {
+      const item = list[rank]
+      const key = `${item.resultType}:${item.resultId}`
+      const rank1Based = rank + 1
+      const contribution = 1 / (k + rank1Based)
+
+      scoreMap.set(key, (scoreMap.get(key) ?? 0) + contribution)
+
+      // Merge properties — earlier lists take priority for overlapping keys
+      const existing = propsMap.get(key)
+      if (existing == null) {
+        propsMap.set(key, { ...item })
+      } else {
+        // Add keys from this item that don't already exist on the merged object.
+        // Use `propKey` to avoid shadowing the outer compound `key` variable.
+        for (const propKey of Object.keys(item)) {
+          if (!(propKey in existing) || existing[propKey] == null) {
+            existing[propKey] = item[propKey]
+          }
+        }
+      }
+    }
+  }
+
+  // Normalize scores to [0, 1]
+  const theoreticalMax = lists.length / (k + 1)
+
+  const results: FusedResult[] = []
+  scoreMap.forEach((rawScore, key) => {
+    const props = propsMap.get(key)!
+    results.push({
+      ...props,
+      score: theoreticalMax > 0 ? rawScore / theoreticalMax : 0,
+    })
+  })
+
+  // Sort by score descending
+  results.sort((a, b) => b.score - a.score)
+
+  return results
+}
+
+/**
+ * 3-layer deduplication adapted from the recommender service.
+ *
+ * Given a list of fused results sorted by score descending, removes
+ * duplicates using three strategies:
+ *
+ * 1. core_id prefix match — catches ad-format variants where one core_id
+ *    is a prefix of the other (e.g. "4_Win4GoodNewsJesus" and
+ *    "4_Win4GoodNewsJesusAD1x1").
+ * 2. Exact title match — catches cross-series duplicates where the same
+ *    scene exists in multiple film series with different core_ids.
+ * 3. Embedding similarity >0.95 — safety net for unlabeled near-duplicates.
+ *
+ * All three strategies are video-specific. Non-video results (e.g.
+ * experiences) skip these checks and pass through unchanged — experiences
+ * have no `core_id`, cross-type title collisions are intentional ("Easter"
+ * the experience and "Easter" the video are both legitimately relevant),
+ * and cross-type embedding similarity is not a dedup concern. Within-type
+ * dedup for non-video result types can be added if future volume warrants.
+ *
+ * The higher-scored result is always kept; the lower-scored duplicate is
+ * discarded. Stops collecting once `limit` unique results are found.
+ *
+ * @param results - Must be pre-sorted by score descending.
+ * @param limit   - Stop collecting after this many unique results.
+ */
+export function deduplicateResults(
+  results: FusedResult[],
+  limit: number,
+): FusedResult[] {
+  const deduped: FusedResult[] = []
+
+  for (const candidate of results) {
+    if (deduped.length >= limit) break
+
+    let isDuplicate = false
+
+    // Video-specific dedup. Non-video results (e.g. experiences) skip the
+    // 3 checks below and only obey the limit cap.
+    if (candidate.resultType === "video") {
+      for (const kept of deduped) {
+        if (kept.resultType !== "video") continue
+
+        // Check 1: core_id prefix match (ad-format variants)
+        if (candidate.videoCoreId && kept.videoCoreId) {
+          const a = candidate.videoCoreId
+          const b = kept.videoCoreId
+          if (a.startsWith(b) || b.startsWith(a)) {
+            isDuplicate = true
+            break
+          }
+        }
+
+        // Check 2: exact title match (cross-series same scene)
+        if (
+          candidate.videoTitle &&
+          kept.videoTitle &&
+          candidate.videoTitle === kept.videoTitle
+        ) {
+          isDuplicate = true
+          break
+        }
+
+        // Check 3: embedding similarity (safety net for unlabeled duplicates)
+        if (candidate.embeddingText && kept.embeddingText) {
+          const sim = cosineSimilarityFromText(
+            candidate.embeddingText,
+            kept.embeddingText,
+          )
+          if (sim > 0.95) {
+            isDuplicate = true
+            break
+          }
+        }
+      }
+    }
+
+    if (!isDuplicate) {
+      deduped.push(candidate)
+    }
+  }
+
+  return deduped
+}
+
+/**
+ * Computes cosine similarity between two embedding vectors stored as
+ * pgvector text format: "[0.1,0.2,...]". This is used only for
+ * inter-result dedup (typically <=60 candidates), so parsing overhead
+ * is negligible.
+ */
+export function cosineSimilarityFromText(a: string, b: string): number {
+  const va = a.slice(1, -1).split(",").map(Number)
+  const vb = b.slice(1, -1).split(",").map(Number)
+  if (va.length !== vb.length || va.length === 0) return 0
+
+  let dot = 0
+  let normA = 0
+  let normB = 0
+  for (let i = 0; i < va.length; i++) {
+    dot += va[i] * vb[i]
+    normA += va[i] * va[i]
+    normB += vb[i] * vb[i]
+  }
+
+  const denom = Math.sqrt(normA) * Math.sqrt(normB)
+  return denom === 0 ? 0 : dot / denom
+}

--- a/apps/admin/src/services/hybrid-search-health.test.ts
+++ b/apps/admin/src/services/hybrid-search-health.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  __resetSearchHealthForTest,
+  getStats,
+  recordAttempt,
+  recordFailure,
+  withTimeout,
+} from "./hybrid-search-health"
+
+describe("hybrid-search-health", () => {
+  beforeEach(() => {
+    __resetSearchHealthForTest()
+  })
+
+  it("increments counters on attempt and failure", () => {
+    recordAttempt()
+    recordAttempt()
+    recordFailure(new Error("boom"))
+
+    const stats = getStats()
+    expect(stats.attempts).toBe(2)
+    expect(stats.failures).toBe(1)
+    expect(stats.lastErrorMessage).toBe("boom")
+    expect(stats.lastErrorClass).toBe("Error")
+    expect(stats.lastErrorAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    )
+  })
+
+  it("getStats returns a snapshot, not a live reference", () => {
+    recordAttempt()
+    const snapshot = getStats()
+    snapshot.attempts = 999
+    snapshot.failures = 999
+    snapshot.lastErrorMessage = "mutated"
+
+    const fresh = getStats()
+    expect(fresh.attempts).toBe(1)
+    expect(fresh.failures).toBe(0)
+    expect(fresh.lastErrorMessage).toBeNull()
+  })
+
+  it("captures Error subclass constructor name", () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message)
+        this.name = "CustomError"
+      }
+    }
+    recordFailure(new CustomError("nope"))
+    const stats = getStats()
+    expect(stats.lastErrorClass).toBe("CustomError")
+    expect(stats.lastErrorMessage).toBe("nope")
+  })
+
+  it("captures non-Error throws as UnknownError with String(error) message", () => {
+    recordFailure("string-error")
+    const stats = getStats()
+    expect(stats.lastErrorClass).toBe("UnknownError")
+    expect(stats.lastErrorMessage).toBe("string-error")
+  })
+
+  it("__resetSearchHealthForTest resets all counters and last-error fields", () => {
+    recordAttempt()
+    recordAttempt()
+    recordFailure(new Error("bad"))
+
+    __resetSearchHealthForTest()
+
+    const stats = getStats()
+    expect(stats).toEqual({
+      attempts: 0,
+      failures: 0,
+      lastErrorMessage: null,
+      lastErrorClass: null,
+      lastErrorAt: null,
+    })
+  })
+
+  it("withTimeout rejects when the inner promise is slow", async () => {
+    const slow = new Promise<string>((resolve) => {
+      setTimeout(() => resolve("too-late"), 100)
+    })
+    await expect(withTimeout(slow, 10)).rejects.toThrow("Timed out after 10ms")
+  })
+
+  it("withTimeout resolves when the inner promise wins", async () => {
+    const fast = Promise.resolve("ok")
+    await expect(withTimeout(fast, 1000)).resolves.toBe("ok")
+  })
+
+  it("withTimeout propagates inner rejection", async () => {
+    const failing = Promise.reject(new Error("inner-fail"))
+    await expect(withTimeout(failing, 1000)).rejects.toThrow("inner-fail")
+  })
+})

--- a/apps/admin/src/services/hybrid-search-health.ts
+++ b/apps/admin/src/services/hybrid-search-health.ts
@@ -1,0 +1,104 @@
+/**
+ * Process-local counters and last-error state for query-embedding operations.
+ *
+ * Used by the search orchestrator to track attempts and failures of the
+ * OpenRouter embedding call, and by the health probe endpoint to surface
+ * that state to external monitors (Railway healthchecks, uptime tools,
+ * curl-based checks) without requiring log tailing.
+ *
+ * Scope: single Node.js process. Counters reset on restart. When the CMS
+ * runs on multiple Railway instances, each instance maintains its own
+ * state — external monitors polling `/api/search/health` compute deltas
+ * or averages across replicas as they see fit.
+ *
+ * Why not Prometheus/InfluxDB/Datadog: no metrics sink exists in this
+ * app today, and adding one is net-new infrastructure outside the scope
+ * of this bug. Structured log lines plus a pollable counter endpoint are
+ * the pragmatic stand-in. A real sink can be layered on later without
+ * changing the public shape.
+ */
+
+let attempts = 0
+let failures = 0
+let lastErrorMessage: string | null = null
+let lastErrorClass: string | null = null
+let lastErrorAt: string | null = null
+
+export type SearchHealthStats = {
+  attempts: number
+  failures: number
+  lastErrorMessage: string | null
+  lastErrorClass: string | null
+  /** ISO-8601 timestamp of the most recent failure, or null if none recorded. */
+  lastErrorAt: string | null
+}
+
+/** Increment attempts counter. Call before every `embedQuery` invocation. */
+export function recordAttempt(): void {
+  attempts += 1
+}
+
+/**
+ * Record a query-embedding failure. Increments the failure counter and
+ * captures the error's class name + message for operator visibility.
+ * The attempts counter should have been incremented separately via
+ * `recordAttempt()` before the failed call.
+ */
+export function recordFailure(error: unknown): void {
+  failures += 1
+  if (error instanceof Error) {
+    lastErrorMessage = error.message
+    lastErrorClass = error.constructor.name
+  } else {
+    lastErrorMessage = String(error)
+    lastErrorClass = "UnknownError"
+  }
+  lastErrorAt = new Date().toISOString()
+}
+
+/**
+ * Returns a snapshot of current counter and last-error state. Mutating the
+ * returned object has no effect on internal state; callers are free to
+ * forward it into a JSON response.
+ */
+export function getStats(): SearchHealthStats {
+  return {
+    attempts,
+    failures,
+    lastErrorMessage,
+    lastErrorClass,
+    lastErrorAt,
+  }
+}
+
+/**
+ * Resolves the given promise, or rejects with a timeout error if it does
+ * not settle within `ms` milliseconds. Used by the health probe so a
+ * hanging OpenRouter call cannot stall healthcheck pollers indefinitely.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out after ${ms}ms`))
+    }, ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+}
+
+/** Test hook — resets all counters and last-error state. Not for production use. */
+export function __resetSearchHealthForTest(): void {
+  attempts = 0
+  failures = 0
+  lastErrorMessage = null
+  lastErrorClass = null
+  lastErrorAt = null
+}

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for hybrid-search retrievers.
+ *
+ * These tests exercise the mock-Prisma shape so we catch argument-binding
+ * and return-shape regressions without requiring a running Postgres.
+ * Deeper DB-backed parity testing happens at the orchestrator + route
+ * handler level.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import {
+  searchVideoSemantic,
+  searchVideoKeyword,
+  searchExperienceSemantic,
+  searchExperienceKeyword,
+} from "./hybrid-search-retrievers"
+
+function mockPrisma() {
+  const $queryRaw = vi.fn()
+  return {
+    $queryRaw,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+describe("searchVideoSemantic", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("returns a RankedItem-shaped row per DB row", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-1",
+        video_core_id: "1_Jesus",
+        video_slug: "jesus",
+        video_title: "Jesus",
+        scene_description: "Peter denies Jesus",
+        start_seconds: 42.5,
+        playback_id: "mux-abc",
+        similarity: 0.87,
+        embedding_text: "[0.1,0.2]",
+      },
+    ])
+
+    const rows = await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      resultType: "video",
+      resultId: "vid-1",
+      videoCoreId: "1_Jesus",
+      videoSlug: "jesus",
+      videoTitle: "Jesus",
+      imageUrl: null,
+      sceneDescription: "Peter denies Jesus",
+      startSeconds: 42.5,
+      playbackId: "mux-abc",
+      similarity: 0.87,
+      embeddingText: "[0.1,0.2]",
+    })
+  })
+
+  it("tolerates null playback_id (no matching dub for (edition, locale))", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-2",
+        video_core_id: null,
+        video_slug: "x",
+        video_title: "X",
+        scene_description: "d",
+        start_seconds: 0,
+        playback_id: null,
+        similarity: 0.5,
+        embedding_text: "[]",
+      },
+    ])
+
+    const rows = await searchVideoSemantic(prisma, {
+      queryEmbedding: "[]",
+      locale: "fr",
+      limit: 5,
+    })
+
+    expect(rows[0]!.playbackId).toBeNull()
+    expect(rows[0]!.videoCoreId).toBeNull()
+  })
+
+  it("coerces Postgres numeric columns to JS number", async () => {
+    // pg returns numeric/float as string on some drivers; we explicitly Number()
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-3",
+        video_core_id: null,
+        video_slug: "",
+        video_title: "",
+        scene_description: "",
+        start_seconds: "7" as unknown as number,
+        playback_id: null,
+        similarity: "0.42" as unknown as number,
+        embedding_text: "[]",
+      },
+    ])
+
+    const rows = await searchVideoSemantic(prisma, {
+      queryEmbedding: "[]",
+      locale: "en",
+      limit: 1,
+    })
+
+    expect(rows[0]!.startSeconds).toBe(7)
+    expect(rows[0]!.similarity).toBeCloseTo(0.42)
+  })
+})
+
+describe("searchVideoKeyword", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("short-circuits empty query without calling DB", async () => {
+    const rows = await searchVideoKeyword(prisma, {
+      query: "   ",
+      locale: "en",
+      limit: 10,
+    })
+    expect(rows).toEqual([])
+    expect(prisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it("returns keyword rows without scene-level fields", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-1",
+        video_core_id: "1_Jesus",
+        video_slug: "jesus",
+        video_title: "Jesus",
+        description: "Film about Jesus",
+        rank: 0.0913,
+      },
+    ])
+
+    const rows = await searchVideoKeyword(prisma, {
+      query: "jesus",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows[0]).toMatchObject({
+      resultType: "video",
+      resultId: "vid-1",
+      imageUrl: null,
+      description: "Film about Jesus",
+      rank: 0.0913,
+    })
+    // Keyword rows must NOT carry scene-level data (fusion's property merge
+    // preserves semantic-list values when both retrievers hit the same video).
+    expect(
+      (rows[0] as unknown as { startSeconds?: unknown }).startSeconds,
+    ).toBeUndefined()
+    expect(
+      (rows[0] as unknown as { playbackId?: unknown }).playbackId,
+    ).toBeUndefined()
+    expect(
+      (rows[0] as unknown as { embeddingText?: unknown }).embeddingText,
+    ).toBeUndefined()
+  })
+})
+
+describe("searchExperienceSemantic", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("uses ExperienceLocale.id as resultId", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        experience_locale_id: "exp-loc-1",
+        slug: "easter",
+        title: "Easter",
+        meta_description: "The resurrection",
+        similarity: 0.75,
+      },
+    ])
+
+    const rows = await searchExperienceSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows[0]).toMatchObject({
+      resultType: "experience",
+      resultId: "exp-loc-1",
+      experienceSlug: "easter",
+      experienceTitle: "Easter",
+      experienceMetaDescription: "The resurrection",
+      imageUrl: null,
+      similarity: 0.75,
+    })
+  })
+
+  it("tolerates null meta_description", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        experience_locale_id: "exp-loc-2",
+        slug: "christmas",
+        title: "Christmas",
+        meta_description: null,
+        similarity: 0.6,
+      },
+    ])
+
+    const rows = await searchExperienceSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 1,
+    })
+
+    expect(rows[0]!.experienceMetaDescription).toBeNull()
+  })
+})
+
+describe("searchExperienceKeyword", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("short-circuits empty query without calling DB", async () => {
+    const rows = await searchExperienceKeyword(prisma, {
+      query: "\t\n ",
+      locale: "en",
+      limit: 10,
+    })
+    expect(rows).toEqual([])
+    expect(prisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it("returns experience keyword rows with rank", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        experience_locale_id: "exp-loc-1",
+        slug: "easter",
+        title: "Easter",
+        meta_description: "The resurrection",
+        rank: 0.12,
+      },
+    ])
+
+    const rows = await searchExperienceKeyword(prisma, {
+      query: "easter",
+      locale: "en",
+      limit: 5,
+    })
+
+    expect(rows[0]).toMatchObject({
+      resultType: "experience",
+      resultId: "exp-loc-1",
+      experienceSlug: "easter",
+      experienceTitle: "Easter",
+      imageUrl: null,
+      rank: 0.12,
+    })
+  })
+})

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -1,0 +1,372 @@
+/**
+ * Four retrievers that feed the hybrid-search RRF orchestrator.
+ *
+ * Port of apps/cms/src/api/search/services/{semantic,keyword,
+ * experience-semantic,experience-keyword}-search.ts, re-derived against
+ * admin's per-locale schema. See
+ * docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md Unit 3.
+ *
+ * Shape invariants:
+ * - All rows carry `resultType` + `resultId` so they flow straight into
+ *   the fusion layer without a separate annotate step.
+ * - `resultId` is a cuid string for both corpora (admin-native). For
+ *   experience rows it's the `ExperienceLocale.id` (see inline comment
+ *   on searchExperienceSemantic for why).
+ * - `imageUrl` is `null` for both corpora in R4 (cms parity). Wiring
+ *   `ExperienceLocale.ogImageUrl` is a deliberate post-R8 follow-up.
+ * - Semantic-video exposes `embedding_text` so the 3-layer dedup can
+ *   recompute cosine similarity across survivors. This field is a
+ *   service-internal transport only; the schema.test.ts
+ *   /embed|vector|similarit/i guard covers the GraphQL surface.
+ */
+
+import { Prisma, type PrismaClient } from "@prisma/client"
+import {
+  VIDEO_LOCALE_TSVECTOR_QUERY_EXPR,
+  EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR,
+} from "./hybrid-search-sql"
+import type { RankedItem } from "./hybrid-search-fusion"
+
+// -----------------------------------------------------------------------------
+// Shared parameter shapes
+// -----------------------------------------------------------------------------
+
+export type SemanticSearchParams = {
+  /** pgvector text format, e.g. "[0.1,0.2,...]" — pre-formatted by the
+   *  orchestrator (see hybrid-search.service.ts) so the shape is consistent
+   *  across both semantic retrievers. */
+  queryEmbedding: string
+  locale: string
+  limit: number
+}
+
+export type KeywordSearchParams = {
+  query: string
+  locale: string
+  limit: number
+}
+
+// -----------------------------------------------------------------------------
+// Return shapes
+// -----------------------------------------------------------------------------
+
+export type VideoSemanticResult = RankedItem & {
+  resultType: "video"
+  resultId: string
+  videoCoreId: string | null
+  videoSlug: string
+  videoTitle: string
+  imageUrl: null
+  sceneDescription: string
+  startSeconds: number
+  playbackId: string | null
+  similarity: number
+  embeddingText: string
+}
+
+export type VideoKeywordResult = RankedItem & {
+  resultType: "video"
+  resultId: string
+  videoCoreId: string | null
+  videoSlug: string
+  videoTitle: string
+  imageUrl: null
+  description: string | null
+  rank: number
+}
+
+export type ExperienceSemanticResult = RankedItem & {
+  resultType: "experience"
+  resultId: string
+  experienceSlug: string
+  experienceTitle: string
+  experienceMetaDescription: string | null
+  imageUrl: null
+  similarity: number
+}
+
+export type ExperienceKeywordResult = RankedItem & {
+  resultType: "experience"
+  resultId: string
+  experienceSlug: string
+  experienceTitle: string
+  experienceMetaDescription: string | null
+  imageUrl: null
+  rank: number
+}
+
+// -----------------------------------------------------------------------------
+// Internal raw-row shapes (as Postgres returns them)
+// -----------------------------------------------------------------------------
+
+type VideoSemanticRow = {
+  video_id: string
+  video_core_id: string | null
+  video_slug: string | null
+  video_title: string | null
+  scene_description: string
+  start_seconds: number
+  playback_id: string | null
+  similarity: number
+  embedding_text: string
+}
+
+type VideoKeywordRow = {
+  video_id: string
+  video_core_id: string | null
+  video_slug: string | null
+  video_title: string | null
+  description: string | null
+  rank: number
+}
+
+type ExperienceSemanticRow = {
+  experience_locale_id: string
+  slug: string | null
+  title: string | null
+  meta_description: string | null
+  similarity: number
+}
+
+type ExperienceKeywordRow = {
+  experience_locale_id: string
+  slug: string | null
+  title: string | null
+  meta_description: string | null
+  rank: number
+}
+
+// -----------------------------------------------------------------------------
+// Retrievers
+// -----------------------------------------------------------------------------
+
+/**
+ * Per-locale semantic search over VideoSceneLocale embeddings.
+ *
+ * One row per video (DISTINCT ON video_id) carrying the best-matching
+ * scene for the requested locale. `playbackId` resolves via a LATERAL
+ * lookup on `video_dub` → `mux_video`, keyed by
+ * `(video_edition_id, language.bcp47 = locale)`. When no dub matches
+ * `(edition, locale)`, `playbackId` is NULL and the row still returns —
+ * consumers render those like keyword-only matches (no deep-link).
+ *
+ * Consumer visibility gate: `video.deleted_at IS NULL` +
+ * `video_locale.status = 'published'` for the requested locale. We do
+ * NOT require `VideoDub.published = true` on the dub lookup — some
+ * languages legitimately have no published dub yet, and the result
+ * should still surface (playbackId null).
+ */
+export async function searchVideoSemantic(
+  prisma: PrismaClient,
+  params: SemanticSearchParams,
+): Promise<VideoSemanticResult[]> {
+  const { queryEmbedding, locale, limit } = params
+
+  const rows = await prisma.$queryRaw<VideoSemanticRow[]>`
+    SELECT * FROM (
+      SELECT DISTINCT ON (vs.video_id)
+        vs.video_id                       AS video_id,
+        v.core_id                         AS video_core_id,
+        v.slug                            AS video_slug,
+        vl.title                          AS video_title,
+        vsl.description                   AS scene_description,
+        vs.start_seconds                  AS start_seconds,
+        dub_mux.playback_id               AS playback_id,
+        1 - (vsl.embedding <=> ${queryEmbedding}::vector) AS similarity,
+        vsl.embedding::text               AS embedding_text
+      FROM video_scene_locale vsl
+      JOIN video_scene vs ON vs.id = vsl.video_scene_id
+      JOIN video v ON v.id = vs.video_id
+        AND v.deleted_at IS NULL
+      JOIN video_locale vl
+        ON vl.video_id = v.id
+        AND vl.locale = ${locale}
+        AND vl.status = 'published'
+      LEFT JOIN LATERAL (
+        SELECT mv.playback_id
+        FROM video_dub vd
+        JOIN language lg ON lg.id = vd.language_id
+          AND lg.bcp47 = ${locale}
+
+        LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+        WHERE vd.video_edition_id = vs.video_edition_id
+          AND vd.deleted_at IS NULL
+        ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
+        LIMIT 1
+      ) dub_mux ON true
+      WHERE vsl.embedding IS NOT NULL
+        AND vsl.locale = ${locale}
+      ORDER BY vs.video_id, vsl.embedding <=> ${queryEmbedding}::vector
+    ) sub
+    ORDER BY sub.similarity DESC
+    LIMIT ${limit}
+  `
+
+  return rows.map((row) => ({
+    resultType: "video" as const,
+    resultId: row.video_id,
+    videoCoreId: row.video_core_id,
+    videoSlug: row.video_slug ?? "",
+    videoTitle: row.video_title ?? "",
+    imageUrl: null,
+    sceneDescription: row.scene_description,
+    startSeconds: Number(row.start_seconds),
+    playbackId: row.playback_id,
+    similarity: Number(row.similarity),
+    embeddingText: row.embedding_text,
+  }))
+}
+
+/**
+ * Per-locale keyword search over video_locale.title + description using
+ * PostgreSQL tsvector/tsquery. The tsvector expression here MUST match
+ * `VIDEO_LOCALE_TSVECTOR_INDEX_EXPR` from hybrid-search-sql.ts byte-for-byte
+ * modulo alias (`vl.` prefix) so the GIN index in migration 0006 is
+ * actually used. Any drift silently reverts the query to Seq Scan.
+ *
+ * DISTINCT ON (v.id) — one row per video. Empty/whitespace query
+ * short-circuits to `[]` before any DB call.
+ */
+export async function searchVideoKeyword(
+  prisma: PrismaClient,
+  params: KeywordSearchParams,
+): Promise<VideoKeywordResult[]> {
+  const trimmed = params.query.trim()
+  if (trimmed.length === 0) return []
+
+  const { locale, limit } = params
+  const tsvector = Prisma.raw(VIDEO_LOCALE_TSVECTOR_QUERY_EXPR)
+
+  const rows = await prisma.$queryRaw<VideoKeywordRow[]>`
+    SELECT * FROM (
+      SELECT DISTINCT ON (v.id)
+        v.id           AS video_id,
+        v.core_id      AS video_core_id,
+        v.slug         AS video_slug,
+        vl.title       AS video_title,
+        vl.description AS description,
+        ts_rank(
+          ${tsvector},
+          plainto_tsquery('simple', ${trimmed})
+        ) AS rank
+      FROM video_locale vl
+      JOIN video v ON v.id = vl.video_id
+        AND v.deleted_at IS NULL
+      WHERE ${tsvector} @@ plainto_tsquery('simple', ${trimmed})
+        AND vl.locale = ${locale}
+        AND vl.status = 'published'
+      ORDER BY v.id, rank DESC
+    ) sub
+    ORDER BY sub.rank DESC
+    LIMIT ${limit}
+  `
+
+  return rows.map((row) => ({
+    resultType: "video" as const,
+    resultId: row.video_id,
+    videoCoreId: row.video_core_id,
+    videoSlug: row.video_slug ?? "",
+    videoTitle: row.video_title ?? "",
+    imageUrl: null,
+    description: row.description,
+    rank: Number(row.rank),
+  }))
+}
+
+/**
+ * Per-locale semantic search over ExperienceLocale embeddings.
+ *
+ * `resultId` is the ExperienceLocale.id (per-locale row), not the parent
+ * Experience.id. Admin's data model stores each locale's slug + content +
+ * embedding on its own row, so the locale row is the natural search
+ * result identity. Consumer navigation is by `(locale, slug)` so the id
+ * is opaque — this matches cms's behavior at the API boundary (cms just
+ * happened to use the parent experience id because Strapi's i18n stores
+ * locale variants under a shared `documentId` with distinct row ids per
+ * locale; admin's cuid ExperienceLocale.id plays the same role).
+ *
+ * Filters: embedding non-null, matching locale, status='published',
+ * parent experience non-archived.
+ */
+export async function searchExperienceSemantic(
+  prisma: PrismaClient,
+  params: SemanticSearchParams,
+): Promise<ExperienceSemanticResult[]> {
+  const { queryEmbedding, locale, limit } = params
+
+  const rows = await prisma.$queryRaw<ExperienceSemanticRow[]>`
+    SELECT
+      el.id               AS experience_locale_id,
+      el.slug             AS slug,
+      el.title            AS title,
+      el.meta_description AS meta_description,
+      1 - (el.embedding <=> ${queryEmbedding}::vector) AS similarity
+    FROM experience_locale el
+    JOIN experience e ON e.id = el.experience_id
+      AND e.archived_at IS NULL
+    WHERE el.embedding IS NOT NULL
+      AND el.locale = ${locale}
+      AND el.status = 'published'
+    ORDER BY el.embedding <=> ${queryEmbedding}::vector
+    LIMIT ${limit}
+  `
+
+  return rows.map((row) => ({
+    resultType: "experience" as const,
+    resultId: row.experience_locale_id,
+    experienceSlug: row.slug ?? "",
+    experienceTitle: row.title ?? "",
+    experienceMetaDescription: row.meta_description,
+    imageUrl: null,
+    similarity: Number(row.similarity),
+  }))
+}
+
+/**
+ * Per-locale keyword search over experience_locale.title +
+ * meta_description. Uses the same GIN index / tsvector expression as
+ * the migration (see EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR for the
+ * byte-parity invariant).
+ *
+ * Empty/whitespace query short-circuits to `[]`.
+ */
+export async function searchExperienceKeyword(
+  prisma: PrismaClient,
+  params: KeywordSearchParams,
+): Promise<ExperienceKeywordResult[]> {
+  const trimmed = params.query.trim()
+  if (trimmed.length === 0) return []
+
+  const { locale, limit } = params
+  const tsvector = Prisma.raw(EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR)
+
+  const rows = await prisma.$queryRaw<ExperienceKeywordRow[]>`
+    SELECT
+      el.id               AS experience_locale_id,
+      el.slug             AS slug,
+      el.title            AS title,
+      el.meta_description AS meta_description,
+      ts_rank(
+        ${tsvector},
+        plainto_tsquery('simple', ${trimmed})
+      ) AS rank
+    FROM experience_locale el
+    JOIN experience e ON e.id = el.experience_id
+      AND e.archived_at IS NULL
+    WHERE ${tsvector} @@ plainto_tsquery('simple', ${trimmed})
+      AND el.locale = ${locale}
+      AND el.status = 'published'
+    ORDER BY rank DESC
+    LIMIT ${limit}
+  `
+
+  return rows.map((row) => ({
+    resultType: "experience" as const,
+    resultId: row.experience_locale_id,
+    experienceSlug: row.slug ?? "",
+    experienceTitle: row.title ?? "",
+    experienceMetaDescription: row.meta_description,
+    imageUrl: null,
+    rank: Number(row.rank),
+  }))
+}

--- a/apps/admin/src/services/hybrid-search-sql.test.ts
+++ b/apps/admin/src/services/hybrid-search-sql.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR,
+  VIDEO_LOCALE_TSVECTOR_INDEX_EXPR,
+} from "./hybrid-search-sql"
+
+/**
+ * Byte-parity invariant: the tsvector expressions used by R4's keyword
+ * retrievers MUST be byte-identical to the expressions baked into the
+ * GIN indexes created by `0006_hybrid_search_gin/migration.sql`. If
+ * they drift, Postgres silently falls back to sequential scan.
+ *
+ * This test is pure string-matching — it does not open a DB
+ * connection. Migration runnability is covered by Prisma's own
+ * migrate-diff tooling at deploy time.
+ */
+describe("hybrid-search-sql byte-parity with GIN migration", () => {
+  const migrationSql = readFileSync(
+    resolve(
+      __dirname,
+      "..",
+      "..",
+      "prisma",
+      "migrations",
+      "0006_hybrid_search_gin",
+      "migration.sql",
+    ),
+    "utf8",
+  )
+
+  it("contains the video-locale tsvector INDEX expression verbatim", () => {
+    expect(migrationSql).toContain(VIDEO_LOCALE_TSVECTOR_INDEX_EXPR)
+  })
+
+  it("contains the experience-locale tsvector INDEX expression verbatim", () => {
+    expect(migrationSql).toContain(EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR)
+  })
+})

--- a/apps/admin/src/services/hybrid-search-sql.ts
+++ b/apps/admin/src/services/hybrid-search-sql.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared SQL fragments for admin's R4 hybrid-search keyword retrievers.
+ *
+ * Keyword search in Postgres uses a `to_tsvector(...)` expression evaluated
+ * on `video_locale` and `experience_locale`. A GIN index over the SAME
+ * expression lets the planner serve the matching predicate from the index
+ * rather than a sequential scan. If the service's expression and the GIN
+ * index's expression are not byte-equal (whitespace, quoting, column
+ * order, even alias prefixing) the planner silently falls back to seq
+ * scan on large corpora — the corpus still ranks, just slowly, so
+ * there's no runtime error to catch the drift.
+ *
+ * To guarantee byte-parity we centralize the expression here in two
+ * forms per corpus:
+ *
+ *   - `*_INDEX_EXPR` — bare column references (`title`, `description`,
+ *     `meta_description`). Used verbatim in `CREATE INDEX ... USING GIN
+ *     (<expr>)` at migration time, where the expression is evaluated in
+ *     the table's own scope (no alias).
+ *
+ *   - `*_QUERY_EXPR` — alias-prefixed column references (`vl.title`,
+ *     `el.meta_description`). Used inside service-layer `$queryRaw`
+ *     strings where `video_locale` is joined as `vl` and
+ *     `experience_locale` as `el`. Postgres treats the two forms as
+ *     equivalent for index matching because the planner normalizes
+ *     alias-qualified column references to their unqualified form
+ *     before comparing against the indexed expression.
+ *
+ * The byte-parity invariant only needs to hold between each
+ * `*_INDEX_EXPR` and the corresponding raw SQL written into
+ * `prisma/migrations/0006_hybrid_search_gin/migration.sql`. That
+ * invariant is enforced by `hybrid-search-sql.test.ts`, which reads
+ * the migration file and asserts both index-form constants appear
+ * verbatim as substrings. If a future edit changes one side but
+ * not the other, the test fails.
+ *
+ * Config is `'simple'` (language-agnostic) — matches cms's
+ * `keyword-search.ts` / `experience-keyword-search.ts`. No locale-
+ * specific stemming is applied. Locale filtering happens via a
+ * separate `WHERE locale = ?` clause on the row, not through the
+ * tsvector config.
+ */
+
+/**
+ * Video-locale tsvector expression, INDEX form (bare columns).
+ *
+ * Used by `prisma/migrations/0006_hybrid_search_gin/migration.sql` to
+ * create `video_locale_fulltext_search_idx`. Must appear byte-equal in
+ * that migration.
+ */
+export const VIDEO_LOCALE_TSVECTOR_INDEX_EXPR =
+  "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(description, ''))"
+
+/**
+ * Video-locale tsvector expression, QUERY form (aliased columns).
+ *
+ * Intended for service-layer SQL where `video_locale` is joined as
+ * `vl`. Postgres matches this against `video_locale_fulltext_search_idx`
+ * because the planner strips alias prefixes before comparing the
+ * expression to the indexed expression.
+ */
+export const VIDEO_LOCALE_TSVECTOR_QUERY_EXPR =
+  "to_tsvector('simple', coalesce(vl.title, '') || ' ' || coalesce(vl.description, ''))"
+
+/**
+ * Experience-locale tsvector expression, INDEX form (bare columns).
+ *
+ * Used by `prisma/migrations/0006_hybrid_search_gin/migration.sql` to
+ * create `experience_locale_fulltext_search_idx`. Must appear byte-
+ * equal in that migration.
+ */
+export const EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR =
+  "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(meta_description, ''))"
+
+/**
+ * Experience-locale tsvector expression, QUERY form (aliased columns).
+ *
+ * Intended for service-layer SQL where `experience_locale` is joined
+ * as `el`. Planner-equivalent to the INDEX form — see file header.
+ */
+export const EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR =
+  "to_tsvector('simple', coalesce(el.title, '') || ' ' || coalesce(el.meta_description, ''))"

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Orchestrator-level tests for HybridSearchService. Retrievers are
+ * stubbed by mocking the module import; embedder is injected via the
+ * constructor so tests can simulate success and failure independently.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./hybrid-search-retrievers", () => ({
+  searchVideoSemantic: vi.fn(),
+  searchVideoKeyword: vi.fn(),
+  searchExperienceSemantic: vi.fn(),
+  searchExperienceKeyword: vi.fn(),
+}))
+
+import {
+  searchVideoSemantic,
+  searchVideoKeyword,
+  searchExperienceSemantic,
+  searchExperienceKeyword,
+} from "./hybrid-search-retrievers"
+import { __resetSearchHealthForTest, getStats } from "./hybrid-search-health"
+import {
+  HybridSearchService,
+  type QueryEmbedder,
+} from "./hybrid-search.service"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = {} as any
+const loggerError = vi.fn()
+const logger = { error: loggerError }
+
+function successEmbedder(vector: number[] = [0.1, 0.2, 0.3]): QueryEmbedder {
+  return vi.fn().mockResolvedValue(vector)
+}
+
+function failingEmbedder(error = new Error("provider down")): QueryEmbedder {
+  return vi.fn().mockRejectedValue(error)
+}
+
+function setupDefaultRetrievers() {
+  vi.mocked(searchVideoSemantic).mockResolvedValue([])
+  vi.mocked(searchVideoKeyword).mockResolvedValue([])
+  vi.mocked(searchExperienceSemantic).mockResolvedValue([])
+  vi.mocked(searchExperienceKeyword).mockResolvedValue([])
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetSearchHealthForTest()
+  setupDefaultRetrievers()
+})
+
+describe("HybridSearchService", () => {
+  it("orchestrates embed → 4 retrieve → fuse → dedup → paginate on happy path", async () => {
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-1",
+        videoCoreId: "1_Jesus",
+        videoSlug: "jesus",
+        videoTitle: "Jesus",
+        imageUrl: null,
+        sceneDescription: "A scene about forgiveness",
+        startSeconds: 42,
+        playbackId: "mux-1",
+        similarity: 0.9,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+    vi.mocked(searchVideoKeyword).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-2",
+        videoCoreId: "2_Grace",
+        videoSlug: "grace",
+        videoTitle: "Grace",
+        imageUrl: null,
+        description: "Video about grace",
+        rank: 0.5,
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    const result = await service.search({
+      query: "forgiveness",
+      locale: "en",
+    })
+
+    // All 4 retrievers were invoked with overfetch = DEFAULT_LIMIT * 3 = 60
+    expect(searchVideoSemantic).toHaveBeenCalledWith(mockPrisma, {
+      queryEmbedding: "[0.1,0.2,0.3]",
+      locale: "en",
+      limit: 60,
+    })
+    expect(searchVideoKeyword).toHaveBeenCalledWith(mockPrisma, {
+      query: "forgiveness",
+      locale: "en",
+      limit: 60,
+    })
+    expect(searchExperienceSemantic).toHaveBeenCalled()
+    expect(searchExperienceKeyword).toHaveBeenCalled()
+
+    expect(result.query).toBe("forgiveness")
+    expect(result.searchMode).toBe("hybrid")
+    expect(result.results).toHaveLength(2)
+    // Semantic-video row comes first (higher RRF score — rank 1 in
+    // semantic-video; keyword-video row was rank 1 in a different list).
+    const first = result.results.find((r) => r.id === "vid-1")!
+    expect(first).toMatchObject({
+      type: "video",
+      slug: "jesus",
+      title: "Jesus",
+      imageUrl: null,
+      snippet: "A scene about forgiveness",
+      startSeconds: 42,
+      playbackId: "mux-1",
+    })
+  })
+
+  it("degrades to keyword-only when embedder throws", async () => {
+    vi.mocked(searchVideoKeyword).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-2",
+        videoCoreId: null,
+        videoSlug: "grace",
+        videoTitle: "Grace",
+        imageUrl: null,
+        description: "Video about grace",
+        rank: 0.5,
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: failingEmbedder(),
+      logger,
+    })
+
+    const result = await service.search({ query: "grace", locale: "en" })
+
+    expect(result.searchMode).toBe("keyword-only")
+    expect(searchVideoSemantic).not.toHaveBeenCalled()
+    expect(searchExperienceSemantic).not.toHaveBeenCalled()
+    expect(searchVideoKeyword).toHaveBeenCalled()
+    expect(searchExperienceKeyword).toHaveBeenCalled()
+
+    // Counters updated
+    const stats = getStats()
+    expect(stats.attempts).toBe(1)
+    expect(stats.failures).toBe(1)
+
+    // Structured error log
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.stringContaining("event=query_embedding_failure"),
+    )
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.stringContaining("error_class=Error"),
+    )
+  })
+
+  it("restricts to video corpus when contentTypes=['video']", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    await service.search({
+      query: "test",
+      locale: "en",
+      contentTypes: ["video"],
+    })
+
+    expect(searchVideoSemantic).toHaveBeenCalled()
+    expect(searchVideoKeyword).toHaveBeenCalled()
+    expect(searchExperienceSemantic).not.toHaveBeenCalled()
+    expect(searchExperienceKeyword).not.toHaveBeenCalled()
+  })
+
+  it("restricts to experience corpus when contentTypes=['experience']", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    await service.search({
+      query: "test",
+      locale: "en",
+      contentTypes: ["experience"],
+    })
+
+    expect(searchVideoSemantic).not.toHaveBeenCalled()
+    expect(searchVideoKeyword).not.toHaveBeenCalled()
+    expect(searchExperienceSemantic).toHaveBeenCalled()
+    expect(searchExperienceKeyword).toHaveBeenCalled()
+  })
+
+  it("empty contentTypes falls back to both corpora", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    await service.search({
+      query: "test",
+      locale: "en",
+      contentTypes: [],
+    })
+
+    expect(searchVideoSemantic).toHaveBeenCalled()
+    expect(searchExperienceSemantic).toHaveBeenCalled()
+  })
+
+  it("clamps limit to MAX_LIMIT (50)", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    await service.search({ query: "test", locale: "en", limit: 100 })
+
+    expect(searchVideoSemantic).toHaveBeenCalledWith(
+      mockPrisma,
+      expect.objectContaining({ limit: 150 }), // 50 * 3
+    )
+  })
+
+  it("clamps limit minimum to 1", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    await service.search({ query: "test", locale: "en", limit: -5 })
+
+    expect(searchVideoSemantic).toHaveBeenCalledWith(
+      mockPrisma,
+      expect.objectContaining({ limit: 3 }), // 1 * 3
+    )
+  })
+
+  it("sets hasMore when dedup returns more than offset + limit", async () => {
+    // Produce 25 semantic-video rows; default limit 20, so the 21st row
+    // plus beyond triggers hasMore.
+    // IDs + coreIds are zero-padded + suffixed so neither layer 1
+    // (coreId prefix) nor layer 2 (exact title) nor layer 3 (cosine
+    // similarity) of dedup collapses them.
+    const pad = (n: number) => String(n).padStart(3, "0")
+    const many = Array.from({ length: 25 }, (_, i) => ({
+      resultType: "video" as const,
+      resultId: `vid-${pad(i)}`,
+      videoCoreId: `core-${pad(i)}x`,
+      videoSlug: `slug-${pad(i)}`,
+      videoTitle: `Title ${pad(i)}`,
+      imageUrl: null,
+      sceneDescription: `desc ${pad(i)}`,
+      startSeconds: i,
+      playbackId: `mux-${pad(i)}`,
+      similarity: 1 - i * 0.01,
+      // Distinct-enough vectors so cosine similarity stays below 0.95.
+      // Each row gets a unique unit vector along a distinct axis by
+      // rotating through a long dim so no two rows ever collide.
+      embeddingText: `[${Array.from({ length: 32 }, (_, j) => (j === i ? 1 : 0)).join(",")}]`,
+    }))
+    vi.mocked(searchVideoSemantic).mockResolvedValue(many)
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    const result = await service.search({ query: "test", locale: "en" })
+    expect(result.results).toHaveLength(20)
+    expect(result.hasMore).toBe(true)
+  })
+
+  it("unwraps allSettled — one rejected retrieval logs and returns []", async () => {
+    vi.mocked(searchVideoKeyword).mockRejectedValue(
+      new Error("boom keyword-video"),
+    )
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-1",
+        videoCoreId: null,
+        videoSlug: "a",
+        videoTitle: "A",
+        imageUrl: null,
+        sceneDescription: "",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 1,
+        embeddingText: "[]",
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    const result = await service.search({ query: "x", locale: "en" })
+
+    // Still returns the semantic-video row; keyword-video was dropped.
+    expect(result.results).toHaveLength(1)
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.stringContaining("keyword-video retrieval failed"),
+    )
+  })
+
+  it("rounds score to 3 decimal places", async () => {
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-1",
+        videoCoreId: null,
+        videoSlug: "a",
+        videoTitle: "A",
+        imageUrl: null,
+        sceneDescription: "",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 1,
+        embeddingText: "[]",
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    const result = await service.search({ query: "x", locale: "en" })
+    // With 1 non-empty list, fuseRankedLists normalises to 1.0 for the
+    // sole rank-1 row → rounded to 1.
+    expect(result.results[0]!.score).toBe(1)
+  })
+
+  it("maps experience rows with null startSeconds + playbackId", async () => {
+    vi.mocked(searchExperienceSemantic).mockResolvedValue([
+      {
+        resultType: "experience",
+        resultId: "exp-loc-1",
+        experienceSlug: "easter",
+        experienceTitle: "Easter",
+        experienceMetaDescription: "The resurrection",
+        imageUrl: null,
+        similarity: 0.8,
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    const result = await service.search({
+      query: "easter",
+      locale: "en",
+      contentTypes: ["experience"],
+    })
+
+    const exp = result.results.find((r) => r.id === "exp-loc-1")!
+    expect(exp).toMatchObject({
+      type: "experience",
+      slug: "easter",
+      title: "Easter",
+      snippet: "The resurrection",
+      imageUrl: null,
+      startSeconds: null,
+      playbackId: null,
+    })
+  })
+})

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -1,0 +1,331 @@
+/**
+ * Hybrid search orchestrator — port of
+ * apps/cms/src/api/search/services/search.ts against admin's schema.
+ *
+ * Step-by-step:
+ * 1. Embed the user's query via admin's embedding provider. On failure,
+ *    degrade to keyword-only search instead of returning 503 — keyword
+ *    search has no external dependencies and is valuable on its own.
+ * 2. Run retrieval in parallel based on `contentTypes` — up to 4 lists
+ *    (video semantic, video keyword, experience semantic, experience
+ *    keyword) via Promise.allSettled, so one retrieval failing does not
+ *    discard the others.
+ * 3. Merge via Reciprocal Rank Fusion. Empty result lists are filtered
+ *    out before fusion (RRF normalizes by N-list count, and feeding
+ *    empty ones dilutes scores from lists that did contribute).
+ * 4. Deduplicate (3-layer for videos; experiences pass through).
+ * 5. Paginate with hasMore signal (dedup one extra to detect overflow).
+ */
+
+import type { PrismaClient } from "@prisma/client"
+import { generateExperienceEmbedding } from "./embeddings.service"
+import {
+  fuseRankedLists,
+  deduplicateResults,
+  type FusedResult,
+  type RankedItem,
+} from "./hybrid-search-fusion"
+import { recordAttempt, recordFailure } from "./hybrid-search-health"
+import {
+  searchVideoSemantic,
+  searchVideoKeyword,
+  searchExperienceSemantic,
+  searchExperienceKeyword,
+} from "./hybrid-search-retrievers"
+
+export const RRF_K = 60
+export const DEFAULT_LIMIT = 20
+export const MAX_LIMIT = 50
+export const OVERFETCH_FACTOR = 3
+
+export type ContentType = "video" | "experience"
+
+export const ALL_CONTENT_TYPES: readonly ContentType[] = ["video", "experience"]
+
+/**
+ * Boundary type guard shared by REST and GraphQL. Adding a new content
+ * type means updating the union + `ALL_CONTENT_TYPES` in one place.
+ */
+export function isContentType(value: string): value is ContentType {
+  return (ALL_CONTENT_TYPES as readonly string[]).includes(value)
+}
+
+export type SearchParams = {
+  query: string
+  locale: string
+  limit?: number
+  offset?: number
+  /**
+   * Restrict results to the given content types. Omit (or pass
+   * undefined) to search both videos and experiences. Passing an empty
+   * array also defaults to both, since "no results" is rarely the
+   * caller's intent.
+   */
+  contentTypes?: ContentType[]
+}
+
+export type SearchResult = {
+  type: ContentType
+  /** cuid (admin-native). Was integer in cms. */
+  id: string
+  slug: string
+  title: string
+  imageUrl: string | null
+  snippet: string
+  /** null when the match is keyword-only or for non-video results. */
+  startSeconds: number | null
+  /** null when the match is keyword-only or for non-video results. */
+  playbackId: string | null
+  score: number
+}
+
+/**
+ * Describes which retrieval paths actually contributed to a response.
+ *
+ * - `"hybrid"`: the query embedding was generated successfully and
+ *   semantic retrieval ran alongside keyword. Steady state.
+ * - `"keyword-only"`: the query embedding call failed (provider outage,
+ *   missing/invalid API key, network egress blocked) and the response
+ *   was assembled from keyword retrieval alone. Response is still
+ *   useful but lacks scene-level / semantic-experience matches.
+ */
+export type SearchMode = "hybrid" | "keyword-only"
+
+export type SearchResponse = {
+  results: SearchResult[]
+  /** True when more results exist beyond the current page. */
+  hasMore: boolean
+  query: string
+  searchMode: SearchMode
+}
+
+/**
+ * Converts a number[] embedding vector to pgvector text format
+ * "[0.1,0.2,...]". Kept local rather than importing toPgVector from
+ * db/pgvector so this file has no DB helper dependency (the retrievers
+ * own DB-layer concerns).
+ */
+function toPgvectorText(embedding: number[]): string {
+  return `[${embedding.join(",")}]`
+}
+
+/**
+ * Injectable embedder signature so tests can stub the provider call
+ * without mocking the module import.
+ */
+export type QueryEmbedder = (text: string) => Promise<number[]>
+
+const defaultEmbedder: QueryEmbedder = async (text) => {
+  const result = await generateExperienceEmbedding(text)
+  return result.embedding
+}
+
+/**
+ * Map a fused result to the API response contract.
+ *
+ * Video rows may carry scene-level data (description as snippet,
+ * startSeconds + playbackId for semantic matches; null for
+ * keyword-only). Experience rows carry experience-level data
+ * (metaDescription as snippet) with null startSeconds/playbackId.
+ */
+function mapToSearchResult(result: FusedResult): SearchResult {
+  const score = Math.round(result.score * 1000) / 1000
+
+  if (result.resultType === "experience") {
+    return {
+      type: "experience",
+      id: result.resultId,
+      slug: (result.experienceSlug as string) ?? "",
+      title: (result.experienceTitle as string) ?? "",
+      imageUrl: (result.imageUrl as string | null) ?? null,
+      snippet: (result.experienceMetaDescription as string | null) ?? "",
+      startSeconds: null,
+      playbackId: null,
+      score,
+    }
+  }
+
+  const startSeconds = result.startSeconds
+  const playbackId = result.playbackId
+  return {
+    type: "video",
+    id: result.resultId,
+    slug: (result.videoSlug as string) ?? "",
+    title: (result.videoTitle as string) ?? "",
+    imageUrl: (result.imageUrl as string | null) ?? null,
+    // Semantic-video rows carry scene-level `sceneDescription`; keyword
+    // rows carry video-level `description`. Fusion merges earlier-list
+    // properties first, so a video that hits both lists keeps the
+    // semantic scene description (the richer signal).
+    snippet:
+      (result.sceneDescription as string | undefined) ??
+      (result.description as string | undefined) ??
+      "",
+    startSeconds: typeof startSeconds === "number" ? startSeconds : null,
+    playbackId: typeof playbackId === "string" ? playbackId : null,
+    score,
+  }
+}
+
+export type HybridSearchServiceDeps = {
+  prisma: PrismaClient
+  embedder?: QueryEmbedder
+  /** Injectable logger; defaults to console. Mirror the cms `log.error`
+   *  shape so operators see the same `event=...` structured lines. */
+  logger?: {
+    error: (message: string) => void
+  }
+}
+
+export class HybridSearchService {
+  private readonly prisma: PrismaClient
+  private readonly embedder: QueryEmbedder
+  private readonly logger: { error: (message: string) => void }
+
+  constructor(deps: HybridSearchServiceDeps) {
+    this.prisma = deps.prisma
+    this.embedder = deps.embedder ?? defaultEmbedder
+    this.logger = deps.logger ?? {
+      error: (message: string) => console.error(message),
+    }
+  }
+
+  async search(params: SearchParams): Promise<SearchResponse> {
+    const { query, locale } = params
+    const limit = Math.min(
+      Math.max(1, params.limit ?? DEFAULT_LIMIT),
+      MAX_LIMIT,
+    )
+    const offset = Math.max(0, params.offset ?? 0)
+    const overfetchLimit = limit * OVERFETCH_FACTOR
+
+    // Resolve which content types to search. Empty array falls back to
+    // all types — no caller realistically wants "search nothing".
+    const requested =
+      params.contentTypes != null && params.contentTypes.length > 0
+        ? params.contentTypes
+        : ALL_CONTENT_TYPES
+    const wantsVideos = requested.includes("video")
+    const wantsExperiences = requested.includes("experience")
+
+    // Step 1: Embed the user's query. Degrade gracefully if the
+    // provider is unavailable — keyword search alone still returns
+    // useful results. Failures are logged at error level (a silent
+    // warn let feat-097 hide in production for days) and tracked via
+    // process-local counters the health probe exposes.
+    let queryEmbeddingText: string | null = null
+    recordAttempt()
+    try {
+      const vector = await this.embedder(query)
+      queryEmbeddingText = toPgvectorText(vector)
+    } catch (error) {
+      recordFailure(error)
+      const errorClass =
+        error instanceof Error ? error.constructor.name : "UnknownError"
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.error(
+        `[search] event=query_embedding_failure error_class=${errorClass} message=${message}`,
+      )
+    }
+
+    // Step 2: Run retrieval in parallel. allSettled keeps partial
+    // results when one retrieval fails (e.g. pgvector timeout but
+    // keyword succeeds). Each retrieval is paired with a label so
+    // outcomes can map back to their source for logging.
+    type Retrieval = {
+      label: string
+      promise: Promise<RankedItem[]>
+    }
+    const retrievals: Retrieval[] = []
+
+    if (wantsVideos) {
+      retrievals.push({
+        label: "semantic-video",
+        promise:
+          queryEmbeddingText != null
+            ? (searchVideoSemantic(this.prisma, {
+                queryEmbedding: queryEmbeddingText,
+                locale,
+                limit: overfetchLimit,
+              }) as Promise<RankedItem[]>)
+            : Promise.resolve([]),
+      })
+      retrievals.push({
+        label: "keyword-video",
+        promise: searchVideoKeyword(this.prisma, {
+          query,
+          locale,
+          limit: overfetchLimit,
+        }) as Promise<RankedItem[]>,
+      })
+    }
+
+    if (wantsExperiences) {
+      retrievals.push({
+        label: "semantic-experience",
+        promise:
+          queryEmbeddingText != null
+            ? (searchExperienceSemantic(this.prisma, {
+                queryEmbedding: queryEmbeddingText,
+                locale,
+                limit: overfetchLimit,
+              }) as Promise<RankedItem[]>)
+            : Promise.resolve([]),
+      })
+      retrievals.push({
+        label: "keyword-experience",
+        promise: searchExperienceKeyword(this.prisma, {
+          query,
+          locale,
+          limit: overfetchLimit,
+        }) as Promise<RankedItem[]>,
+      })
+    }
+
+    const outcomes = await Promise.allSettled(retrievals.map((r) => r.promise))
+    const lists = outcomes.map((outcome, i) =>
+      this.unwrapOutcome(outcome, retrievals[i]!.label),
+    )
+
+    // Step 3: Fuse ranked lists via RRF. Drop empty lists first — RRF
+    // normalizes by dividing by the number of input lists, so empty
+    // ones dilute scores from lists that did contribute.
+    const nonEmptyLists = lists.filter((list) => list.length > 0)
+    const fused = fuseRankedLists(nonEmptyLists, RRF_K)
+
+    // Step 4: Dedup one extra result beyond the page window so we know
+    // whether more results exist (drives hasMore without a full count
+    // pass).
+    const deduped = deduplicateResults(fused, offset + limit + 1)
+
+    // Step 5: Paginate and map to API contract.
+    const page = deduped.slice(offset, offset + limit)
+    const hasMore = deduped.length > offset + limit
+    const results = page.map(mapToSearchResult)
+
+    return {
+      results,
+      hasMore,
+      query,
+      // queryEmbeddingText is non-null iff the embedding call succeeded
+      // and both semantic retrievals were dispatched. If null, the
+      // response is assembled from keyword retrieval alone.
+      searchMode: queryEmbeddingText != null ? "hybrid" : "keyword-only",
+    }
+  }
+
+  private unwrapOutcome<T>(
+    outcome: PromiseSettledResult<T[]>,
+    label: string,
+  ): T[] {
+    if (outcome.status === "fulfilled") return outcome.value
+    this.logger.error(
+      `[search] ${label} retrieval failed: ${
+        outcome.reason instanceof Error
+          ? outcome.reason.message
+          : String(outcome.reason)
+      }`,
+    )
+    return []
+  }
+}

--- a/docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md
+++ b/docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md
@@ -1,0 +1,282 @@
+---
+date: 2026-04-23
+topic: admin-hybrid-search-r4
+---
+
+# R4 — Hybrid Search API in Admin
+
+## Problem Frame
+
+apps/cms ships the consumer-facing hybrid search today
+(`/api/search` + `/api/search/health`). The admin-migration playbook at
+`docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md`
+calls for porting it to `apps/admin` as R4 so that, at R8 cutover,
+apps/web and apps/mobile can swap their search backend in a single
+coordinated PR with no consumer-visible change.
+
+R4 is explicitly a **port, not a refactor**. New features (transcript
+fusion, re-ranking, personalization) stay out. The job is to replicate
+cms's behavior on admin's data model so the two services are
+byte-compatible at the response boundary during the R3→R8 window.
+
+## Requirements
+
+- **R1.** Port cms's hybrid search orchestrator to admin as a shared
+  `HybridSearchService`. Preserve the existing contract:
+  - 4-list Reciprocal Rank Fusion (RRF): `semantic-video`,
+    `keyword-video`, `semantic-experience`, `keyword-experience`.
+  - `Promise.allSettled` so one retrieval failing does not discard the
+    others; failed lists log at error level and contribute zero results.
+  - Overfetch factor **3x**, default limit **20**, max limit **50**.
+  - RRF constant **k = 60**; score normalized to [0, 1] by dividing by
+    `lists.length / (k + 1)`.
+  - Empty lists filtered out before fusion (RRF divides by list count).
+  - 3-layer dedup applied to video results only: coreId prefix match,
+    exact title match, embedding cosine > 0.95. Experience results pass
+    through unchanged.
+  - Dedup to `offset + limit + 1` to derive `hasMore` without a count pass.
+
+- **R2.** Expose the service at REST: `GET /api/search` and
+  `GET /api/search/health` as Next App Router route handlers calling
+  the shared service. Response body matches cms's shape exactly:
+
+  ```
+  { results: SearchResult[], hasMore: boolean, query: string,
+    searchMode: "hybrid" | "keyword-only" }
+  ```
+
+  `SearchResult` fields: `type`, `id`, `slug`, `title`, `imageUrl`,
+  `snippet`, `startSeconds`, `playbackId`, `score`. `startSeconds` and
+  `playbackId` are null for experience results and for keyword-only
+  video matches.
+
+- **R3.** Expose the service at GraphQL as a public `search(...)` query
+  field that returns the same logical shape. Auth scope `public: true`
+  (matches cms's `auth: false` route and admin's existing
+  `searchExperiences` field).
+
+- **R4.** Query-parameter contract on REST matches cms:
+  - `q` (required, non-empty, trimmed) → 400 when missing/blank.
+  - `locale` (required) → 400 when missing. Data-derived — whatever
+    BCP-47 values admin's corpus actually carries.
+  - `type` (optional) — one of `"video" | "experience"`. Omitted or
+    empty → both content types. Invalid value → 400.
+  - `limit`, `offset` (optional) — numeric; clamped server-side.
+
+- **R5.** `searchMode` degradation signal follows cms's rule: set to
+  `"hybrid"` when the OpenRouter (or admin's chosen provider) query-
+  embedding call succeeds; set to `"keyword-only"` when it throws. Any
+  embedding failure is logged at error level with
+  `event=query_embedding_failure error_class=… message=…` structure and
+  increments a process-local failure counter. Response is always HTTP
+  200 when orchestration completes; 503 is reserved for total
+  orchestrator failure.
+
+- **R6.** `/api/search/health` is a synthetic probe:
+  - Runs one real `embedQuery("health probe")` with a 5s timeout.
+  - Always returns HTTP 200. Body:
+    `{ status: "ok" | "degraded", error: string | null, attempts,
+failures, lastErrorMessage, lastErrorClass, lastErrorAt }`.
+  - Probe failures increment the same process-local counters the search
+    orchestrator updates — one unified view of embedding-call health.
+  - Dedicated rate-limit bucket (tighter cap than user-search) so probe
+    traffic cannot starve the user quota and vice versa.
+
+- **R7.** Semantic retrieval sources in admin:
+  - `semantic-video` → `VideoSceneLocale.embedding` (pgvector cosine,
+    `DISTINCT ON (video_id)`, locale-filtered). One scene per video.
+    Parity with cms's `scene_embeddings` table.
+  - `semantic-experience` → `ExperienceLocale.embedding` (pgvector
+    cosine, locale-filtered). Reuses the SQL shape of admin's existing
+    `ExperienceSearchService` but returns scalar rows (not Prisma
+    hydrated) because the service needs to feed RRF, not GraphQL.
+  - `VideoTranscriptChunk.embedding` (R2-indexed) is **not** used by
+    R4 — strict cms parity. A post-R8 follow-up can add it as a 5th
+    list without changing the consumer contract.
+
+- **R8.** Keyword retrieval sources in admin:
+  - `keyword-video` → tsvector over `video_locale.title` +
+    `video_locale.description` (or the equivalent field names on
+    admin's model), `plainto_tsquery('simple', …)`, `ts_rank` ordering,
+    locale-filtered.
+  - `keyword-experience` → tsvector over `experience_locale.title` +
+    `experience_locale.meta_description`, same `simple` config, same
+    ranking fn, locale-filtered, `status = 'PUBLISHED'` + non-archived.
+  - GIN indexes on the tsvector expressions are added as part of R4
+    (admin has none today). Expression must match the query expression
+    exactly or the index is unused.
+  - Empty/whitespace-only query short-circuits to `[]` before any SQL.
+
+- **R9.** PUBLIC callers (unauthenticated REST and `public: true`
+  GraphQL) see only rows with published + non-archived status. ABAC is
+  applied in the raw SQL layer (WHERE clause on `status`,
+  `archived_at`, and the publish state on relevant link rows). No
+  preview / draft leakage.
+
+- **R10.** Every component re-derives its invariants from admin's
+  schema — no copy-paste of cms's DISTINCT ON joins, link-table chains,
+  or status enums without confirming each one maps to admin's Prisma
+  model. (Per
+  `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md`.)
+
+## Success Criteria
+
+- apps/web and apps/mobile could, today, swap their `/api/search` base
+  URL from cms to admin and see response bodies that parse against
+  their existing TypeScript types with zero changes.
+- For a fixed set of canary queries × locales, the top-10 results from
+  admin vs cms overlap within ranking position ±1 for the same seed
+  data. Divergences trace to data-model differences (e.g. a published
+  video in cms not yet dumped into admin), not to algorithm drift.
+- `searchMode: "keyword-only"` surfaces reliably when the embedding
+  provider is unreachable — verified by temporarily pointing admin at
+  an invalid `OPENROUTER_API_KEY` in a preview environment.
+- `/api/search/health` returns `status: "ok"` under normal conditions
+  and `status: "degraded"` within 5s of provider unavailability.
+- p95 latency < 500ms for `limit=20` on admin's production corpus size
+  (matches the playbook's stated success bar for the migration).
+- Admin GraphQL `search(...)` query returns the same rows in the same
+  order as the REST endpoint for identical arguments.
+- `schema.test.ts` guards the existing "no embed/vector/similarit"
+  surface leak invariant — none of R4's new Pothos types expose raw
+  vectors or cosine similarity scores via relations.
+- Integration tests cover empty query, locale-only data-derivation,
+  `type=video`, `type=experience`, missing args (400s), provider-down
+  degradation, and the probe endpoint's ok/degraded branches.
+
+## Scope Boundaries
+
+- **No changes to apps/cms beyond reading the port reference.**
+  cms's hybrid search continues serving consumers until R8.
+- **No new ranking features.** Transcript embeddings, cross-encoder
+  re-ranking, personalization, and popularity boosts are out. R4 is a
+  port; cms parity is the bar.
+- **No schema stitching or gateway** at either REST or GraphQL.
+- **No deprecation of admin's existing `searchExperiences` GraphQL
+  query** in this PR. It takes a pre-computed vector and serves a
+  different use case; if anything it becomes redundant, but removing
+  it is a follow-up.
+- **No cutover of apps/web or apps/mobile.** That is R8, and it
+  requires R5 (recommendations) and R7 (revalidation webhook) alongside
+  R4.
+- **No recommendations endpoint.** `/api/scene-embeddings/recommendations`
+  is R5. R4 only ships `/api/search` and `/api/search/health`.
+- **No hardcoded locale or language defaults.** If the corpus has zero
+  rows for a locale, that locale returns zero results — not an `en`
+  fallback. Per
+  `docs/solutions/best-practices/prototype-defaults-vs-data-derived-enumeration-20260422.md`.
+- **No useworkflow dispatch** — R4 is read-side, synchronous. No
+  `"use workflow"` functions, therefore no dispatch-level test
+  obligation from
+  `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md`.
+  That constraint applies to R1/R2/R3-shaped backfills, not to
+  synchronous read APIs.
+
+## Key Decisions
+
+- **App Router route handler calling a shared service.** `/api/search`
+  and `/api/search/health` live at
+  `apps/admin/src/app/api/search/route.ts` and
+  `apps/admin/src/app/api/search/health/route.ts`. Both call a shared
+  `HybridSearchService` that the GraphQL `search` resolver also calls.
+  REST has no GraphQL overhead; `/api/search/health` stays a cheap
+  synthetic probe. Establishes the REST-handler pattern admin will
+  reuse in R5 (`/api/scene-embeddings/recommendations`) and R7
+  (revalidation webhook). (User-confirmed, 2026-04-23.)
+
+- **Scene embeddings only for `semantic-video`.** Strict cms parity.
+  Transcript embeddings stay indexed but unused by R4 so admin's
+  ranking stays diff-able against cms during the R3→R8 validation
+  window. Adding a 5th list is a post-cutover enhancement.
+  (User-confirmed, 2026-04-23: "this is a migration, not a refactor.")
+
+- **PUBLIC at both REST and GraphQL.** Matches cms's current `auth:
+false` REST route and admin's existing `searchExperiences` GraphQL
+  field. PUBLIC enforcement happens in SQL (WHERE `status =
+'PUBLISHED'` and `archived_at IS NULL`).
+
+- **RRF k = 60, overfetch 3x, default 20, max 50.** Copied verbatim
+  from `apps/cms/src/api/search/services/search.ts:14-17`. Any change
+  is a post-R8 consideration.
+
+- **Health probe always returns HTTP 200.** Body's `status` field is
+  the machine-readable signal. Matches cms's behavior so external
+  monitors (Railway healthcheck, uptime tools, curl checks) that poll
+  today work unchanged when swapped to admin's URL.
+
+- **Process-local health counters.** No Prometheus / metrics sink.
+  `/api/search/health` is the pollable surface. Matches cms. Real
+  metrics sink is a cross-cutting platform decision outside R4's scope.
+
+## Dependencies / Assumptions
+
+- Admin's `VideoSceneLocale` corpus is non-empty in prod for at least
+  one locale. If R1's full prod backfill hasn't run yet (gated on the
+  read-only cms PG role + Doppler `CMS_DATABASE_URL`), `semantic-video`
+  returns zero rows and RRF falls back to the three remaining lists.
+  This is a data-readiness observation, not a blocker for shipping R4
+  code.
+- Admin already has an `embedQuery`-equivalent provider (OpenRouter or
+  OpenAI) wired via `src/services/embedding.service.ts` or similar —
+  reuse it; don't introduce a second provider client.
+- `pgvector` is installed on admin's Postgres (confirmed — R1, R2, R3
+  ship against it).
+- Admin's Postgres extension surface supports `to_tsvector` /
+  `plainto_tsquery` / `ts_rank` natively (standard Postgres — no
+  extension needed).
+- Admin's rate-limit plugin (`src/graphql/plugins/rate-limit.ts`) or
+  an equivalent at the route-handler layer can enforce per-IP caps on
+  `/api/search` and a separate tighter cap on `/api/search/health`.
+  Whether admin exposes this to route handlers today needs a quick
+  check in planning.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+_(none — all blocking product decisions resolved in this brainstorm)_
+
+### Deferred to Planning
+
+- **[Affects R8][Technical]** Field mapping between cms's
+  `videos.title/description` + `video_variants` publish/locale chain
+  and admin's `Video` / `VideoLocale` / `VideoDub` model. Planning
+  must inspect admin's Prisma schema and write the equivalent JOIN
+  chain — the structure is cms-authoritative-text vs admin-per-locale-
+  text, which changes the SQL shape even though the output columns
+  match.
+- **[Affects R2][Technical]** Rate-limit enforcement for App Router
+  route handlers. Admin's existing rate-limit plugin is GraphQL-Yoga-
+  scoped; applying it to a plain `route.ts` requires either a
+  middleware or a direct call into the limiter from the handler.
+  Planning picks the shape.
+- **[Affects R1][Needs research]** cms's video semantic search returns
+  `playback_id` and `start_seconds` from `scene_embeddings`. Admin's
+  `VideoSceneLocale` carries the description + embedding; the Mux
+  `playbackId` lives on `MuxVideo` (referenced by `VideoEdition`).
+  Planning must trace the admin join chain from scene → edition → mux
+  to produce the same output columns.
+- **[Affects R1][Technical]** `embedding::text` is exposed from cms's
+  semantic-video SQL so the 3-layer dedup can recompute cosine
+  similarity across results. Admin's `schema.test.ts` blocks any
+  GraphQL field shaped like `embed|vector|similarit`. The raw SQL
+  in the service is fine (not a GraphQL surface) — confirm planning
+  treats this as a service-internal transport, not a leak.
+- **[Affects R8][Needs research]** Does admin's `keyword-experience`
+  tsvector expression need to match a GIN index name and expression
+  exactly like cms's `experiences_fulltext_search_idx`? Admin has no
+  such index today; planning creates one in the migration and wires
+  the service to match byte-for-byte.
+- **[Affects R9][Technical]** EDITOR / ADMIN expanded result set.
+  cms's hybrid search is PUBLIC-only and never shows drafts. Admin's
+  `ExperienceSearchService.search` has an `isPrivileged` branch that
+  widens the WHERE. Decision: does admin's new hybrid `search` field
+  also honor elevated roles (useful for the admin dashboard's own
+  search UX), or stay strictly PUBLIC-equivalent to match cms? Lean
+  toward "stays strictly PUBLIC-equivalent in R4, and the admin
+  dashboard keeps using `searchExperiences` with its existing
+  elevated-role semantics." Confirm in planning.
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning.

--- a/docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md
+++ b/docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md
@@ -1,0 +1,947 @@
+---
+title: "feat(admin): R4 — hybrid search API (REST + GraphQL)"
+type: feat
+status: active
+date: 2026-04-23
+origin: docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md
+---
+
+# feat(admin): R4 — hybrid search API (REST + GraphQL)
+
+## Overview
+
+Port cms's hybrid search (`/api/search` + `/api/search/health`) to
+`apps/admin` as R4 of the admin-migration playbook (see origin:
+`docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md`).
+Same consumer contract; different data model underneath. One shared
+`HybridSearchService` fronts both a Next App Router REST handler and a
+Pothos GraphQL query so apps/web + apps/mobile can swap their search
+backend at R8 cutover with zero response-shape drift.
+
+## Problem Frame
+
+apps/cms currently owns consumer search. It serves a hybrid (semantic +
+keyword) API over scene embeddings and experience embeddings with RRF,
+falls back to keyword-only when the embedding provider is unreachable,
+and exposes a `/api/search/health` probe for monitors. `apps/admin` has
+no search surface beyond a limited `searchExperiences` GraphQL query
+that takes a pre-computed vector.
+
+R4 replicates cms's behavior on admin's data model. The R3→R8 window is
+a validation period during which apps/web, QA, or release diffing may
+compare the two endpoints; ranking drift between them undermines that.
+Scope is **port, not refactor** — transcript fusion, re-ranking, and
+content-shape upgrades (e.g. wiring real experience imageUrls) stay out.
+
+## Requirements Trace
+
+From the origin requirements doc (see origin:
+`docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md`):
+
+- R1. Shared `HybridSearchService` with 4-list RRF (k=60), overfetch 3x,
+  default 20, max 50, `allSettled`, empty-list filtering, 3-layer video
+  dedup, `hasMore` derived by dedup-to-`offset+limit+1`.
+- R2. REST at `GET /api/search` + `GET /api/search/health`; response
+  body matches cms shape byte-for-byte.
+- R3. GraphQL `search(...)` public field returning the same shape.
+- R4. Query-param contract: `q`, `locale` (both required → 400), `type`
+  (optional enum), `limit`, `offset`.
+- R5. `searchMode` = `"hybrid"` when embedding succeeds, else
+  `"keyword-only"`; structured `event=query_embedding_failure` error log.
+- R6. `/api/search/health` always HTTP 200 with
+  `{status, error, attempts, failures, lastErrorMessage,
+lastErrorClass, lastErrorAt}`, shared counters, 5s probe timeout,
+  dedicated rate-limit bucket.
+- R7. Semantic retrieval: `VideoSceneLocale.embedding` for video;
+  `ExperienceLocale.embedding` for experience. Transcript embeddings
+  stay unused by R4.
+- R8. Keyword retrieval: tsvector GINs over `video_locale.title +
+description` and `experience_locale.title + meta_description`; same
+  `plainto_tsquery('simple', …)` config; new raw-SQL migration creates
+  the indexes.
+- R9. PUBLIC-only WHERE enforced in SQL (`status = 'PUBLISHED'`,
+  `archived_at IS NULL`, etc.).
+- R10. Every DISTINCT ON / join chain / status filter re-derived from
+  admin's schema.
+
+## Scope Boundaries
+
+- No cms changes beyond reading source.
+- No transcript list in RRF (4-list, not 5-list).
+- No new ranking features (no re-ranker, no popularity, no
+  personalization).
+- No useworkflow dispatch (R4 is synchronous read-side).
+- No deprecation of existing `searchExperiences` GraphQL query.
+- No apps/web or apps/mobile changes.
+- No upgrade of experience `imageUrl` beyond cms parity (stays null for
+  experience results in R4; `ExperienceLocale.ogImageUrl` exists on
+  admin but wiring it is a deliberate post-cutover follow-up so the
+  diff-against-cms invariant holds).
+- No hardcoded locale/language defaults anywhere in R4 code.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**cms source of truth (reference only; not modified):**
+
+- `apps/cms/src/api/search/services/search.ts` — orchestrator
+  (RRF constants, retrieval wiring, `searchMode` logic, unwrapOutcome).
+- `apps/cms/src/api/search/services/fusion.ts` — RRF + 3-layer dedup
+  - `cosineSimilarityFromText`.
+- `apps/cms/src/api/search/services/semantic-search.ts`,
+  `keyword-search.ts`,
+  `experience-semantic-search.ts`,
+  `experience-keyword-search.ts` — four retrievers with their SQL.
+- `apps/cms/src/api/search/services/search-health.ts` — process-local
+  counters + `withTimeout`.
+- `apps/cms/src/api/search/controllers/search.ts` — REST handlers
+  (query-param parse, 400/503 paths, health probe).
+- `apps/cms/src/api/search/routes/search.ts` — rate-limit bucket names.
+
+**admin patterns to mirror:**
+
+- `apps/admin/src/services/experience.search.ts` — Search Hydration
+  Pattern with raw SQL + `$queryRaw` + `toPgVector`. R4's retrievers
+  use raw SQL but return scalar tuples feeding the RRF layer, not
+  hydrated Prisma rows.
+- `apps/admin/src/db/pgvector.ts` — `toPgVector` + `toPgArray`.
+- `apps/admin/src/db/client.ts` — Prisma extension strips `embedding`
+  from default results; raw `$queryRaw` is unaffected.
+- `apps/admin/src/services/embeddings.service.ts` —
+  `generateExperienceEmbedding(text)` is the existing synchronous
+  provider-fallback embedder (OpenRouter → OpenAI, 30s timeout,
+  1536-dim guard). R4 reuses verbatim. (Naming nit — it's generic
+  despite the "Experience" prefix; renaming is a follow-up, not part
+  of this PR.)
+- `apps/admin/src/auth/rate-limit.ts` — `rateLimitAuthRoute({ limit,
+route, windowMs, request })` is the route-handler-callable limiter.
+  R4 reuses with separate `route` names for search vs health buckets.
+- `apps/admin/src/app/api/health/route.ts` — route-handler shape
+  reference.
+- `apps/admin/src/graphql/queries/search.ts` — existing Pothos
+  `searchExperiences` with `authScopes: { public: true }` is the auth
+  precedent for the new `search` query field.
+- `apps/admin/src/graphql/schema.test.ts` lines 153/184/213 — the
+  `/embed|vector|similarit/i` guard that the new query must not trip.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md`
+  — re-derive every invariant. cms's `DISTINCT ON (se.video_id)`, its
+  `video_variants_language_lnk` chain, its `experiences.locale`
+  column as a direct filter — none of these survive the port unchanged.
+- `docs/solutions/best-practices/prototype-defaults-vs-data-derived-enumeration-20260422.md`
+  — no hardcoded `en` fallback. `locale` is required at the boundary
+  (400 when missing), and zero-result responses are legitimate
+  data signals.
+- `docs/solutions/platform/admin-scene-embeddings-indexer-pattern.md`
+  - `admin-transcript-embeddings-vector-reuse-pattern.md`
+  - `admin-experience-content-dump-pattern.md` — structural precedent
+    for an R-level solutions doc + a CLAUDE.md section appended in the
+    same PR.
+- `apps/admin/CLAUDE.md` Common Pitfalls: PostgreSQL 18 +
+  `?::jsonb::text[]` caveat doesn't apply here (no array casts needed),
+  but note that admin runs on Prisma 6.x pinned; raw SQL is the only
+  path for pgvector and tsvector operations.
+
+### External References
+
+None required. cms is the oracle; admin's Prisma schema is the data
+model. Standard Postgres `to_tsvector` / `plainto_tsquery` / `ts_rank`
+
+- pgvector `<=>` cosine operator are well-documented Postgres
+  primitives already used in cms.
+
+## Key Technical Decisions
+
+- **Shared service, two front doors.** `HybridSearchService` at
+  `src/services/hybrid-search.service.ts` exposes a single
+  `search(params)` method. The REST handler does query-param parsing
+  and HTTP status mapping; the Pothos resolver does arg validation and
+  scope enforcement. Both call the same service. This is the decision
+  the origin doc flagged as the R4-specific deferred question
+  (user-confirmed 2026-04-23).
+
+- **Query-param REST parsing via `new URL(request.url).searchParams`.**
+  Admin hasn't shipped a query-string REST handler yet (existing
+  handlers either take a JSON body or have no params). R4 establishes
+  this pattern. All parsing, trimming, and numeric coercion lives in a
+  helper at the top of `route.ts`.
+
+- **`generateExperienceEmbedding` reused as the query embedder.** Its
+  name is misleading (it takes a plain string, not an experience), but
+  renaming it is an unrelated refactor that would churn R3's call
+  sites. R4 adds a thin aliased re-export or simply imports the
+  existing function and leaves the rename for a follow-up.
+
+- **Experience results carry `imageUrl: null` for R4.** Strict cms
+  parity. Admin's `ExperienceLocale.ogImageUrl` could populate it, but
+  that's a content upgrade, not a port. A post-cutover follow-up PR
+  flips null → `ogImageUrl` once the diff-against-cms invariant is no
+  longer needed.
+
+- **`playbackId` resolved via `VideoScene → VideoDub(editionId ==,
+language ==) → MuxVideo`.** In admin, playbackId lives on
+  `mux_video`, reachable via `video_dub`. The semantic-video SQL
+  resolves it through a LATERAL subquery that picks the dub matching
+  `(videoEditionId, language)` for the query's locale and joins
+  `mux_video`. If no dub exists for that (edition, locale) pair,
+  `playbackId` is null and the result is still returned (keyword-style
+  handling inside the semantic list).
+
+- **Keyword-video joins `VideoLocale`, not `Video`.** Admin's title +
+  description are per-locale. SQL filters `vl.status = 'PUBLISHED'`
+  - `vl.locale = ?` and `tsvector('simple', coalesce(vl.title,'') || '
+' || coalesce(vl.description,''))`.
+
+- **PUBLIC visibility enforced in raw SQL, not at the resolver.** Both
+  the REST handler and the GraphQL resolver call into the service; the
+  only auth gate that guarantees consistent filtering is inside the
+  SQL WHERE. EDITOR/ADMIN widening is explicitly NOT added in R4 — the
+  existing `searchExperiences` field remains the admin-dashboard path
+  for elevated roles.
+
+- **Scene-locale's per-locale embedding column replaces cms's
+  `scene_embeddings.embedding`.** cms never had per-locale scene
+  embeddings; admin indexes them per-locale (R1). The DISTINCT ON is
+  on `vsl.video_scene_id`'s owning `videoId`, filtering
+  `vsl.locale = ?`.
+
+- **Keyword SQL `tsvector('simple', …)` expression must be byte-equal
+  to the GIN index expression.** Expression mismatch silently reverts
+  the query to sequential scan. The expression strings are centralized
+  in a constants file (`src/services/hybrid-search-sql.ts`) and used
+  from both the migration raw-SQL and the service's query constants
+  via TypeScript template literal.
+
+- **RRF k=60, OVERFETCH_FACTOR=3, MAX_LIMIT=50, DEFAULT_LIMIT=20,
+  HEALTH_PROBE_TIMEOUT_MS=5000, HEALTH_PROBE_INPUT="health probe".**
+  Copied verbatim from cms; constants exported from the service for
+  testability.
+
+- **`embedding::text` column in semantic-video SQL is a service-
+  internal transport** and never reaches the Pothos resolver or the
+  REST response. The `/embed|vector|similarit/i` schema.test.ts guard
+  is a GraphQL-surface check; raw SQL fields are out of its scope.
+  No new test needed, but plan-unit verification calls this out so
+  an implementer doesn't panic-rename the column.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **REST endpoint pattern.** App Router route handler calling a shared
+  service (user-confirmed in brainstorm).
+- **`semantic-video` source.** `VideoSceneLocale.embedding` only;
+  transcripts deferred post-cutover (user-confirmed).
+- **Auth scope.** PUBLIC at both REST and GraphQL (user-confirmed).
+- **Rate limiter pathway for REST.** `rateLimitAuthRoute` in
+  `src/auth/rate-limit.ts` is route-handler-callable and already used
+  by `/api/auth`; R4 reuses it with distinct `route` keys.
+- **`embedding::text` service-internal transport.** Prisma client
+  extension strips from Prisma model results only; raw `$queryRaw`
+  passes through. No GraphQL-surface leak because the column never
+  reaches a Pothos type.
+- **Experience `imageUrl`.** Null for R4, matching cms. Upgrade is a
+  post-cutover follow-up.
+- **EDITOR/ADMIN on `search`.** Stays PUBLIC-equivalent in R4. The
+  admin dashboard keeps using the existing `searchExperiences` field
+  for elevated-role flows.
+- **Query embedder function.** Reuse
+  `generateExperienceEmbedding(text)` from
+  `src/services/embeddings.service.ts`; add an aliased export
+  (`embedQueryText`) so the call site reads clearly. Do not rename
+  the underlying function — out of scope.
+
+### Deferred to Implementation
+
+- **Exact `ts_rank` weighting.** cms uses the default weighting (no
+  `setweight`). R4 ports that. If canary queries show title underweighting
+  vs cms despite identical SQL, the implementer may need to examine
+  whether admin's text differs (e.g. all-lowercase vs mixed case) and
+  document any divergence.
+- **Fallback behavior when no `VideoDub` matches `(edition, locale)`.**
+  Per the key decision, `playbackId` is null for that row. Confirm in
+  implementation that the LATERAL subquery's empty match produces
+  `NULL` (it does in Postgres; worth a test case).
+- **Whether `video.deleted_at IS NULL` belongs in the WHERE.** cms
+  filters on `video.published_at IS NOT NULL`. Admin's analogue is
+  `video_locale.status = 'PUBLISHED'` AND `video.deleted_at IS NULL`
+  (soft-delete guard). The implementer validates against admin's
+  actual seeded data — if any soft-deleted video has a published
+  locale, the query must not surface it.
+- **Minor parity edge cases.** The implementer compares an R4
+  preview-environment response to cms's response for a handful of
+  canary queries (`"jesus"`, `"easter"`, `"shepherd"`, `"peter
+denies"`) in `en` + `es` + `fr` and captures any diff. Goal is
+  to confirm ranking parity within ±1 position on the top-10.
+- **Rate-limit cap tuning.** cms uses 30/min for `search` and 5/min
+  for `search-health`. R4 starts with the same caps; the implementer
+  confirms admin's Redis store can carry the per-IP keyspace without
+  thrash (should be fine; admin already runs authenticated rate-limits
+  at 60/min).
+
+## High-Level Technical Design
+
+> _Directional guidance for review, not implementation specification.
+> Treat as context, not code to reproduce._
+
+### Request flow
+
+```
+HTTP GET /api/search?q=…&locale=…&type=…&limit=…&offset=…
+   │
+   ├── rateLimitAuthRoute({route:"search"})           ─┐
+   │                                                   │
+   ▼                                                   │ 429 if over cap
+parse + validate args (400 on q/locale/type)           │
+   │                                                   │
+   ▼                                                   │
+HybridSearchService.search(params) ◀────── Pothos resolver
+   │                                         (public: true)
+   │                                         graphql/queries/hybrid-search.ts
+   ▼
+ ┌─────────────────────────────────────────┐
+ │ 1. recordAttempt()                      │
+ │ 2. embedQueryText(q) ──► number[]       │ ← catch → recordFailure(), searchMode="keyword-only"
+ │ 3. Promise.allSettled on up to 4        │
+ │    retrievers, filtered by `type`:      │
+ │      semantic-video     (VSL + Mux)     │
+ │      keyword-video      (VL tsvector)   │
+ │      semantic-experience (EL)           │
+ │      keyword-experience  (EL tsvector)  │
+ │ 4. unwrapOutcome → labeled lists        │
+ │ 5. fuseRankedLists(nonEmpty, k=60)      │
+ │ 6. deduplicateResults(offset+limit+1)   │
+ │ 7. slice(offset, offset+limit)          │
+ │ 8. mapToSearchResult                    │
+ └──────┬──────────────────────────────────┘
+        ▼
+{ results, hasMore, query, searchMode }
+```
+
+### RRF key shape
+
+```
+compound identity key:  `${resultType}:${resultId}`
+  — keeps video-4 and experience-4 distinct in the score/props maps
+  — resultId is admin's cuid string (not int like cms), change
+    propagates through the `RankedItem`/`FusedResult` types
+```
+
+### Response contract (unchanged from cms)
+
+```
+{
+  results: Array<{
+    type:         "video" | "experience",
+    id:           string,           // cuid (was int in cms)
+    slug:         string,
+    title:        string,
+    imageUrl:     string | null,    // always null for experience in R4
+    snippet:      string,
+    startSeconds: number | null,    // null for experience + keyword-only video
+    playbackId:   string | null,    // null for experience + keyword-only video + no-dub-match video
+    score:        number            // RRF score, normalized [0,1], rounded 3dp
+  }>,
+  hasMore:    boolean,
+  query:      string,
+  searchMode: "hybrid" | "keyword-only"
+}
+```
+
+**Type-compat note:** cms's `id` is `number` (Strapi SERIAL); admin's
+is `string` (cuid). apps/web + apps/mobile consumer types must accept
+both during the R3→R8 window. This is already true in practice
+because R3's experience-content-dump migrated the experiences corpus
+to cuid-shaped ids before admin exposed it anywhere consumer-facing.
+Confirm with apps/web's `SearchResult` type at cutover.
+
+## Implementation Units
+
+- [ ] **Unit 1: Shared SQL constants + tsvector GIN migration**
+
+**Goal:** Single-source-of-truth TypeScript string literals for the
+tsvector expressions used by keyword-video and keyword-experience,
+plus a raw-SQL Prisma migration that creates matching GIN indexes.
+
+**Requirements:** R8, R10
+
+**Dependencies:** None.
+
+**Files:**
+
+- Create: `apps/admin/src/services/hybrid-search-sql.ts`
+- Create: `apps/admin/prisma/migrations/0006_hybrid_search_gin/migration.sql`
+- Test: `apps/admin/src/services/hybrid-search-sql.test.ts`
+
+**Approach:**
+
+- Export two `Prisma.sql` (or `Prisma.raw`) fragments — one each for the
+  video-locale and experience-locale tsvector expression. Export the
+  equivalent string form for the migration.
+- Migration creates `CREATE INDEX IF NOT EXISTS video_locale_fulltext_search_idx`
+  and `experience_locale_fulltext_search_idx` using GIN on the exact
+  expression. No function-based wrapper; direct expression index.
+- Test asserts the TS constant and the migration SQL string are
+  character-for-character identical (guards against silent index
+  bypass when a future edit touches one but not the other).
+
+**Patterns to follow:**
+
+- Raw-SQL migration convention already used for the `0001_init`
+  vector index + `0005` cms_document_id partial index.
+
+**Test scenarios:**
+
+- SQL constant matches migration byte-equal.
+- Expression handles `coalesce(title,'')` + space + `coalesce(description,'')`
+  consistently for both corpora.
+
+**Verification:**
+
+- `pnpm --filter @forge/admin prisma migrate diff` shows no pending
+  drift after running the new migration against a dev DB.
+- `EXPLAIN` on a probe query against `video_locale` shows `Bitmap Index
+Scan on video_locale_fulltext_search_idx`.
+
+---
+
+- [ ] **Unit 2: Fusion + dedup primitives**
+
+**Goal:** Port cms's RRF + 3-layer video dedup to admin as
+type-parameterised helpers that work with admin's string ids and
+Prisma-native types.
+
+**Requirements:** R1
+
+**Dependencies:** None.
+
+**Files:**
+
+- Create: `apps/admin/src/services/hybrid-search-fusion.ts`
+- Test: `apps/admin/src/services/hybrid-search-fusion.test.ts`
+
+**Approach:**
+
+- Export `RankedItem` + `FusedResult` types. `resultId: string` (not
+  `number` as in cms — admin uses cuids).
+- `fuseRankedLists(lists, k=60)` — compound-key scoring, property merge
+  (earlier lists win on overlapping keys), normalization by
+  `lists.length / (k + 1)`, descending score sort.
+- `deduplicateResults(results, limit)` — 3-layer video-only dedup
+  (coreId prefix, exact title, `cosineSimilarityFromText` > 0.95).
+  Non-video rows pass the 3 checks and only obey the limit cap.
+- `cosineSimilarityFromText(a, b)` — verbatim parser of pgvector text
+  format.
+
+**Patterns to follow:**
+
+- `apps/cms/src/api/search/services/fusion.ts` is the line-by-line
+  reference. Algorithm is portable; the only diff is `resultId` typing.
+
+**Test scenarios:**
+
+- Fuses 1, 2, 3, 4 lists with overlapping and non-overlapping keys.
+- Normalization denominator matches expected `n/(k+1)`.
+- Property merge: earlier list's non-null field wins when later list
+  has non-null for same key.
+- Empty lists return empty fused list.
+- 3-layer dedup: coreId prefix (`"4_X"` vs `"4_XAD"`), title exact
+  match, cosine similarity > 0.95, mix of all three.
+- Experience rows bypass dedup checks but still obey limit cap.
+- `cosineSimilarityFromText` handles mismatched lengths, empty strings,
+  zero vectors (returns 0 without NaN).
+
+**Verification:**
+
+- Unit tests cover each branch in cms's fusion.test.ts ported to admin.
+- `/embed|vector|similarit/i` schema.test guard still passes (no new
+  GraphQL types in this unit).
+
+---
+
+- [ ] **Unit 3: Four SQL retrievers**
+
+**Goal:** Implement the 4 retrieval functions that feed the orchestrator.
+Each produces a ranked `RankedItem[]` for one corpus × one modality.
+
+**Requirements:** R7, R8, R9, R10
+
+**Dependencies:** Units 1 (SQL constants + GIN index) + 2 (types).
+
+**Files:**
+
+- Create: `apps/admin/src/services/hybrid-search-retrievers.ts`
+  — contains `searchVideoSemantic`, `searchVideoKeyword`,
+  `searchExperienceSemantic`, `searchExperienceKeyword` as four
+  exports.
+- Test: `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+
+**Approach:**
+
+- Each retriever is a thin `prisma.$queryRaw` caller returning
+  RankedItem-shaped rows with corpus-specific extra keys (scene-level
+  snippet + timecode for semantic-video, rank score for keyword, etc.).
+
+**Technical design** _(directional — not implementation spec):_
+
+```
+searchVideoSemantic(prisma, {queryEmbedding, locale, limit})
+  SQL: over video_scene_locale <=> ?::vector
+       DISTINCT ON (vs.video_id)
+       JOIN video_scene vs ON vs.id = vsl.video_scene_id
+       JOIN video v ON v.id = vs.video_id AND v.deleted_at IS NULL
+       JOIN video_locale vl ON vl.video_id = v.id
+            AND vl.locale = ? AND vl.status = 'PUBLISHED'
+       LEFT JOIN LATERAL (
+         SELECT mv.playback_id
+         FROM video_dub vd
+         JOIN language lg ON lg.id = vd.language_id AND lg.bcp_47 = ?
+         LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+         WHERE vd.video_edition_id = vs.video_edition_id
+         ORDER BY vd.published DESC NULLS LAST
+         LIMIT 1
+       ) dub_mux ON true
+       WHERE vsl.embedding IS NOT NULL AND vsl.locale = ?
+       ORDER BY vs.video_id, vsl.embedding <=> ?::vector
+       outer-ranked: ORDER BY similarity DESC LIMIT ?
+  Returns: { resultType:"video", resultId:videoId, videoId, videoCoreId,
+             videoSlug, videoTitle (from VideoLocale.title),
+             imageUrl:null (Unit 3 parity, images TBD), description,
+             startSeconds, playbackId, similarity, embeddingText }
+
+searchVideoKeyword(prisma, {query, locale, limit})
+  SQL: DISTINCT ON (v.id) over video_locale tsvector
+       JOIN video v, filter status='PUBLISHED', locale=?
+       WHERE <tsvector-expr> @@ plainto_tsquery('simple', ?)
+             AND v.deleted_at IS NULL
+       Uses hybrid-search-sql.ts SQL constant
+       Returns keyword-shaped RankedItem (no startSeconds/playbackId).
+
+searchExperienceSemantic(prisma, {queryEmbedding, locale, limit})
+  SQL: SELECT el.id, e.*, el.title, el.meta_description,
+              1 - (el.embedding <=> ?::vector) AS similarity
+       FROM experience_locale el
+       JOIN experience e ON e.id = el.experience_id AND e.archived_at IS NULL
+       WHERE el.embedding IS NOT NULL
+         AND el.locale = ? AND el.status = 'PUBLISHED'
+       ORDER BY el.embedding <=> ?::vector LIMIT ?
+  Returns: { resultType:"experience", resultId:experienceLocaleId,
+             experienceSlug, experienceTitle,
+             experienceMetaDescription, imageUrl:null, similarity }
+
+searchExperienceKeyword(prisma, {query, locale, limit})
+  SQL: over experience_locale tsvector (matches GIN index from Unit 1)
+       JOIN experience e ON e.id = el.experience_id AND e.archived_at IS NULL
+       WHERE status='PUBLISHED' AND locale=? AND tsvector @@ plainto_tsquery
+```
+
+- All retrievers short-circuit on empty-after-trim inputs (`query` or
+  `queryEmbedding`) without hitting the DB.
+- Each retriever receives `prisma` (Prisma client with extension), but
+  uses `$queryRaw` directly so the embedding-strip extension is not in
+  the path.
+- Row-level post-processing maps snake_case Postgres columns to
+  camelCase RankedItem props; no field renaming beyond that.
+
+**Patterns to follow:**
+
+- `apps/cms/src/api/search/services/{semantic,keyword,experience-*}.ts`
+  for SQL shape.
+- `apps/admin/src/services/experience.search.ts` for the `$queryRaw`
+  - `toPgVector` + transaction-scoped SET LOCAL pattern (R4 retrievers
+    do NOT need `SET LOCAL ef_search` — single-shot search with cms's
+    existing HNSW defaults is the parity target).
+
+**Test scenarios:**
+
+- Each retriever against seeded DB: empty query → `[]` short-circuit.
+- Locale filter excludes rows in a different locale.
+- `status != PUBLISHED` rows excluded.
+- `archived_at IS NOT NULL` experience excluded.
+- Semantic-video LEFT JOIN LATERAL returns null `playbackId` when no
+  matching `(edition, locale)` dub exists, and the video still
+  appears in results.
+- Semantic-video embedding mismatch on another locale excluded when
+  `vsl.locale = ?` is applied.
+
+**Verification:**
+
+- Each retriever's query plan uses the HNSW index (semantic) or GIN
+  index (keyword). Confirm with `EXPLAIN ANALYZE`.
+- All retrievers return rows sorted by their natural score
+  (similarity or ts_rank) descending.
+
+---
+
+- [ ] **Unit 4: Search health counters + withTimeout helper**
+
+**Goal:** Port `search-health.ts` verbatim (module-scope counters
+
+- `recordAttempt`/`recordFailure`/`getStats`/`withTimeout`/
+  `__resetSearchHealthForTest`).
+
+**Requirements:** R6
+
+**Dependencies:** None.
+
+**Files:**
+
+- Create: `apps/admin/src/services/hybrid-search-health.ts`
+- Test: `apps/admin/src/services/hybrid-search-health.test.ts`
+
+**Approach:**
+
+- Module-scope mutable state (scoped to the Node.js process). Reset
+  helper is test-only.
+- `withTimeout` returns a `Promise<T>` that rejects with an
+  `Error(`Timed out after ${ms}ms`)` if the wrapped promise doesn't
+  settle in time.
+
+**Patterns to follow:**
+
+- `apps/cms/src/api/search/services/search-health.ts` — line-by-line
+  copy.
+
+**Test scenarios:**
+
+- Counters increment on attempt + failure.
+- `getStats()` returns a snapshot not a live reference.
+- `withTimeout` rejects before the inner promise settles when the
+  timeout fires first.
+- `withTimeout` propagates inner resolution when inner wins.
+
+**Verification:**
+
+- Unit tests pass; counters reset correctly between tests via
+  `__resetSearchHealthForTest`.
+
+---
+
+- [ ] **Unit 5: HybridSearchService orchestrator**
+
+**Goal:** The `search(params)` orchestrator — the only callable
+surface that the REST handler and Pothos resolver invoke. Contains
+all the cross-cutting logic (embed-or-degrade, allSettled, RRF,
+dedup, paginate, map-to-response-contract).
+
+**Requirements:** R1, R2, R3, R5, R7, R9
+
+**Dependencies:** Units 2, 3, 4.
+
+**Files:**
+
+- Create: `apps/admin/src/services/hybrid-search.service.ts`
+- Test: `apps/admin/src/services/hybrid-search.service.test.ts`
+
+**Approach:**
+
+- Class or factory that accepts a `PrismaClient` at construction
+  (matching admin convention — `apps/admin/src/services/experience.search.ts`).
+- Exports `search(params: SearchParams): Promise<SearchResponse>` plus
+  the exported constants (`RRF_K=60`, `DEFAULT_LIMIT=20`,
+  `MAX_LIMIT=50`, `OVERFETCH_FACTOR=3`).
+- `searchMode: "hybrid" | "keyword-only"` derived from whether the
+  embedding call succeeded.
+- Maps fused results to `SearchResult` via `mapToSearchResult` — null
+  `imageUrl` for experiences and for scene-less video rows, null
+  `startSeconds`/`playbackId` for non-semantic video rows.
+
+**Patterns to follow:**
+
+- `apps/cms/src/api/search/services/search.ts` — preserve the step
+  comments 1–5 as service-level comments so the port is legible.
+
+**Test scenarios:**
+
+- Empty `q` after trim → empty results + `hasMore: false` (no
+  retrievers invoked).
+- Embedding succeeds → all 4 retrievers invoked when `type` omitted;
+  response `searchMode === "hybrid"`.
+- Embedding throws (simulate via DI-injected embedder stub) →
+  semantic retrievers skipped, keyword retrievers run, response
+  `searchMode === "keyword-only"`, counters incremented via the
+  health module, structured `event=query_embedding_failure` error
+  log emitted.
+- `contentTypes: ["video"]` → only video retrievers invoked.
+- `contentTypes: ["experience"]` → only experience retrievers invoked.
+- `contentTypes: []` or undefined → both (4-retriever default).
+- One retriever rejects → `allSettled` unwraps others; logged error
+  line contains the retrieval label; final response excludes the
+  failed corpus.
+- Pagination: `offset=20, limit=20` on a 30-result deduped set →
+  `results.length=10, hasMore=false`.
+- `limit` clamped to MAX (50) when caller passes 100; `limit` defaults
+  to 20 when missing; `limit=0` clamps to 1 (tracked by cms).
+
+**Verification:**
+
+- Unit tests cover every branch of cms's `search.ts` with admin types.
+- `/embed|vector|similarit/i` schema guard unaffected (no new Pothos
+  types in this unit).
+
+---
+
+- [ ] **Unit 6: REST route handlers + rate limiting**
+
+**Goal:** `GET /api/search` and `GET /api/search/health` exposed as
+Next App Router route handlers that wrap the service with query-param
+parsing, rate-limit enforcement, and cms-compatible HTTP semantics.
+
+**Requirements:** R2, R4, R6
+
+**Dependencies:** Units 4, 5.
+
+**Files:**
+
+- Create: `apps/admin/src/app/api/search/route.ts`
+- Create: `apps/admin/src/app/api/search/health/route.ts`
+- Test: `apps/admin/src/app/api/search/route.test.ts`
+- Test: `apps/admin/src/app/api/search/health/route.test.ts`
+
+**Approach:**
+
+- `/api/search`:
+  - Parse `URL(request.url).searchParams`: `q` (required, trimmed), `locale`
+    (required), `type` (optional, validated), `limit`, `offset`.
+  - `rateLimitAuthRoute({request, route:"search", limit:30,
+windowMs:60_000})` gate; 429 when denied.
+  - 400 on missing `q` / missing `locale` / invalid `type`.
+  - Call `hybridSearchService.search(params)`, return 200 JSON.
+  - 503 on unexpected orchestrator throw (error logged).
+- `/api/search/health`:
+  - `rateLimitAuthRoute({route:"search-health", limit:5,
+windowMs:60_000})`.
+  - `recordAttempt()` → `withTimeout(embedQueryText("health probe"),
+5000)` → `getStats()` → HTTP 200 JSON `{status:"ok"|"degraded",
+error, …getStats()}` (always 200, per cms parity).
+
+**Patterns to follow:**
+
+- `apps/admin/src/app/api/auth/[...all]/route.ts` for
+  `rateLimitAuthRoute` usage.
+- `apps/admin/src/app/api/health/route.ts` for the bare JSON
+  response shape (but R4's health endpoint returns a richer body).
+
+**Test scenarios:**
+
+- `/api/search` missing `q` → 400 with cms-compatible body
+  `{error: "q (search query) is required"}`.
+- Missing `locale` → 400 `{error: "locale is required"}`.
+- Invalid `type=foo` → 400 `{error: "type must be 'video' or 'experience'"}`.
+- `type=video` → service invoked with `contentTypes:["video"]`.
+- Rate-limit denial → 429.
+- Health probe success path → 200 `{status:"ok", error:null,
+attempts, failures, …}`.
+- Health probe timeout path → 200 `{status:"degraded", error:"Timed
+out after 5000ms", …}` with failures++ and an
+  `event=health_probe_failed` error log.
+- Health probe rate-limit bucket is separate from search bucket
+  (stressing search does not exhaust health budget).
+
+**Execution note:** Start with a failing integration test for the
+response contract (parity with cms) before wiring the handler.
+Consumer-contract compatibility is what this unit actually buys.
+
+**Verification:**
+
+- Response JSON diffs against cms's for the same query (within
+  data-model differences). Byte-level diff on error bodies.
+- Route handler exported as `GET` and the Next build succeeds.
+
+---
+
+- [ ] **Unit 7: GraphQL `search` public query field**
+
+**Goal:** Expose the same service via a Pothos query field named
+`search`, returning an object type with the same response shape as
+REST.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 5.
+
+**Files:**
+
+- Create: `apps/admin/src/graphql/types/hybrid-search.ts`
+  — defines `SearchResultItem`, `SearchResponse`, `ContentTypeFilter`
+  types (non-prismaObject; `builder.objectType` / `builder.enumType`).
+- Create: `apps/admin/src/graphql/queries/hybrid-search.ts` — Pothos
+  `search(q, locale, type, limit, offset)` query field.
+- Modify: `apps/admin/src/graphql/schema.ts` — add side-effect
+  imports for the new types/queries file (matches the existing
+  admin convention documented in `apps/admin/CLAUDE.md`).
+- Test: `apps/admin/src/graphql/queries/hybrid-search.test.ts` —
+  DB-backed test that runs the query against a seeded corpus.
+- Modify: `apps/admin/src/graphql/schema.test.ts` — add assertions
+  that `SearchResultItem` has no `embedding|vector|similarit`-shaped
+  fields and `score` is `Float` (not `embedding_score` or similar).
+
+**Approach:**
+
+- `authScopes: { public: true }`, matching the existing
+  `searchExperiences` field.
+- Args validated in-resolver: `q` required, `locale` required, `type`
+  optional enum.
+- Resolver returns the `SearchResponse` from the service directly —
+  the object type's field list mirrors the REST JSON.
+- `ContentTypeFilter` enum: `VIDEO | EXPERIENCE` (match the REST
+  lowercase values via `@values`-style mapping if needed; cms doesn't
+  have a GraphQL enum so we're the first to define it).
+- Test runs `search(q:"…", locale:"en")` and asserts the same object
+  returned by a direct service call (shared fixtures).
+
+**Patterns to follow:**
+
+- `apps/admin/src/graphql/queries/search.ts` — auth scope + arg shape.
+- `apps/admin/src/graphql/types/experience.ts` — classification
+  JSDoc comment (`@classification public-shape`) applies; the new
+  types are not ABAC-gated (no Prisma relation to an abac-gated
+  type).
+
+**Test scenarios:**
+
+- Query with `q + locale` returns fused results.
+- Query with `type: VIDEO` restricts corpus.
+- PUBLIC role succeeds (no scope-auth rejection).
+- `limit` clamps at 50; over-cap requests return 50 results max.
+- `searchMode` enum surfaced as `"hybrid"` / `"keyword-only"`.
+
+**Verification:**
+
+- `pnpm --filter @forge/admin typecheck` passes.
+- `pnpm --filter @forge/admin test schema.test` passes with the new
+  assertions.
+
+---
+
+- [ ] **Unit 8: CLAUDE.md + solutions doc**
+
+**Goal:** Capture R4 as a durable section of `apps/admin/CLAUDE.md`
+(sibling to R1/R2/R3 sections) and write a learnings doc with the
+pattern summary.
+
+**Requirements:** Playbook's Cross-Cutting Constraints + "After
+completing work" compound-engineering loop.
+
+**Dependencies:** Units 1–7.
+
+**Files:**
+
+- Modify: `apps/admin/CLAUDE.md` — append a "## Hybrid search (R4 of
+  admin migration playbook)" section after the R3 "Experience content
+  dump" section.
+- Create:
+  `docs/solutions/platform/admin-hybrid-search-r4-pattern.md`.
+
+**Approach:**
+
+- CLAUDE.md section mirrors the R1/R2/R3 shape: Schema, Services,
+  Orchestrator, Endpoints, Operational runbook. Cite the
+  `hybrid-search.service.ts` + both route handlers + the new GraphQL
+  `search` field by exact file path.
+- Solutions doc captures the non-obvious bits: tsvector-expression
+  byte-parity with the GIN index, three-hop Mux playbackId join,
+  `generateExperienceEmbedding` reused as a generic embedder,
+  `imageUrl:null` parity decision with a pointer to the follow-up
+  upgrade, `embedding::text` transport is service-internal.
+
+**Patterns to follow:**
+
+- `docs/solutions/platform/admin-scene-embeddings-indexer-pattern.md`
+  — structure reference (R1 pattern doc).
+- `docs/solutions/platform/admin-experience-content-dump-pattern.md`
+  — structure reference (R3 pattern doc).
+
+**Test scenarios:**
+
+- N/A (docs).
+
+**Verification:**
+
+- CLAUDE.md renders without broken links.
+- Solutions doc's filename matches the `admin-*-pattern.md` convention.
+
+## System-Wide Impact
+
+- **Interaction graph:** REST `/api/search` is a new public surface.
+  No conflict with existing `/api/graphql`, `/api/health`, `/api/auth`,
+  `/api/preferences`, `/api/workflows`. GraphQL `search` is a new
+  public root field; no relation to abac-gated types (confirmed by
+  schema classification test).
+- **Error propagation:** Embedding failure degrades to keyword-only
+  (logged, counter incremented). Retriever failure degrades per-list
+  (logged, list replaced by `[]`). Orchestrator failure → REST 503,
+  GraphQL error. Rate-limit denial → REST 429, GraphQL throttle error.
+- **State lifecycle risks:** None — R4 is read-side. Health counters
+  are process-local; no durable state.
+- **API surface parity:** cms's `/api/search` response must match
+  byte-for-byte (except id typing, which consumers already tolerate
+  post-R3). GraphQL exposure is net-new; no prior consumer to break.
+- **Integration coverage:** Unit tests with seeded DB cover each
+  retriever; service-level tests cover orchestration; route-handler
+  tests cover HTTP semantics; GraphQL test covers schema + public
+  auth. A live-fire preview-environment canary diff vs cms is the
+  top-of-stack sanity check.
+
+## Risks & Dependencies
+
+- **HNSW planner bypass when `vsl.locale = ?` filter widens.** cms's
+  per-locale partial indexes (R1 pattern) already mitigate this.
+  Confirm admin's 0003 migration created per-locale partial indexes;
+  if not, R4 may need an index addendum. _Deferred to implementation._
+- **tsvector-expression drift.** A future edit that changes the
+  service constant but not the migration (or vice versa) silently
+  reverts to sequential scan on large corpora. Mitigated by the byte-
+  equality unit test in Unit 1.
+- **`generateExperienceEmbedding` name ambiguity.** A future
+  engineer may assume it's experience-specific and add a second
+  generic embedder. Mitigated by the learnings doc + an optional
+  re-export alias. _Rename is a follow-up; not blocking R4._
+- **Rate-limit false positives for CI / QA canary diff traffic.**
+  Preview environment rate caps may throttle a scripted diff across
+  hundreds of queries. Implementer should exempt preview or bump the
+  cap when running the canary.
+- **`VideoDub` LATERAL subquery cost at scale.** Worth an `EXPLAIN`
+  sanity check on a full-size prod-analogue DB; should be cheap with
+  the `(video_edition_id, language_id)` indexes already present.
+- **Data readiness dependencies from R1/R2/R3 prod backfills.** R1
+  scene backfill is still gated on Doppler `CMS_DATABASE_URL` + the
+  read-only PG role. Until those land, admin's `video_scene_locale`
+  has few/no rows, so semantic-video returns `[]` and RRF degrades to
+  a 3-list fusion. Not a blocker for shipping R4 code or tests.
+
+## Documentation / Operational Notes
+
+- **Runbook:** `/api/search/health` is the pollable surface. External
+  monitors (Railway healthcheck, uptime tools) can be pointed at
+  `https://admin.jesusfilm.org/api/search/health`; body's `status`
+  field is the machine-readable signal. Counters reset on process
+  restart; monitors compute deltas across replicas as they see fit.
+- **Rollout:** Deploy to preview → run canary diff vs cms for a fixed
+  query set × locales → merge to main. Cutover of apps/web +
+  apps/mobile to admin's endpoint is NOT part of R4 (that's R8).
+- **Monitoring:** Structured log lines
+  `[search] event=query_embedding_failure error_class=… message=…`
+  and `[search] event=health_probe_failed …` let log-based alerting
+  catch the feat-097-class regression that R4 inherits the fix for.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md](../brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md)
+- **Playbook:** [docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md](../brainstorms/2026-04-19-admin-migration-playbook-requirements.md)
+- **cms source impl:** `apps/cms/src/api/search/` (services, controllers, routes)
+- **admin precedent:** `apps/admin/src/services/experience.search.ts`,
+  `apps/admin/src/services/embeddings.service.ts`,
+  `apps/admin/src/auth/rate-limit.ts`,
+  `apps/admin/src/graphql/queries/search.ts`
+- **Learnings:**
+  - `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md`
+  - `docs/solutions/best-practices/prototype-defaults-vs-data-derived-enumeration-20260422.md`
+  - `docs/solutions/platform/admin-scene-embeddings-indexer-pattern.md`
+  - `docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md`
+  - `docs/solutions/platform/admin-experience-content-dump-pattern.md`
+- **Related feats:** feat-010 (hybrid retrieval), feat-086 (experience
+  search), feat-097 (search hardening), feat-104 (R1 scene embeddings).

--- a/docs/solutions/platform/admin-hybrid-search-r4-pattern.md
+++ b/docs/solutions/platform/admin-hybrid-search-r4-pattern.md
@@ -1,0 +1,148 @@
+---
+title: Admin hybrid search (R4) — port pattern
+category: platform
+date: 2026-04-23
+tags: [admin, search, pgvector, tsvector, rrf, migration]
+---
+
+# Admin hybrid search (R4) — port pattern
+
+## Context
+
+R4 of the admin-migration playbook. Ports cms's `/api/search` +
+`/api/search/health` from `apps/cms/src/api/search/` to
+`apps/admin/src/services/hybrid-search*.ts` + `src/app/api/search/**`
+so apps/web + apps/mobile can swap search backends at R8 cutover with
+zero response-shape drift. Source-of-truth is cms's implementation
+(feat-010 + feat-086 + feat-097 contract); admin's implementation is
+shape-equivalent on top of admin's per-locale Prisma schema.
+
+## The port invariants
+
+1. **4-list RRF.** Exactly four ranked lists feed Reciprocal Rank
+   Fusion: `semantic-video`, `keyword-video`, `semantic-experience`,
+   `keyword-experience`. RRF k = 60, normalization by `lists.length /
+(k + 1)`, descending score sort. Empty lists are filtered out
+   before fusion (RRF normalizes by list count — feeding empty ones
+   dilutes scores from lists that did contribute).
+2. **3-layer video-only dedup.** coreId prefix match, exact title,
+   embedding cosine > 0.95. Experience rows bypass all three checks.
+   Cosine dedup needs per-row `embeddingText`, which is why the
+   semantic-video SQL returns `embedding::text` — a service-internal
+   transport that never reaches GraphQL.
+3. **`searchMode` degradation.** `"hybrid"` when the embedding call
+   succeeds; `"keyword-only"` when it throws. The response is always
+   HTTP 200 on orchestration success; 503 is reserved for total
+   orchestrator failure. Structured error log:
+   `[search] event=query_embedding_failure error_class=… message=…`.
+4. **`/api/search/health` always returns 200.** Body's `status` is the
+   machine-readable signal. Matches cms parity so external monitors
+   (Railway healthcheck, uptime tools, curl checks) swap URLs without
+   changing their success rule.
+5. **PUBLIC at both REST and GraphQL.** ABAC enforced in SQL (WHERE
+   `status = 'published'` + `archived_at IS NULL` on the right
+   tables). No EDITOR/ADMIN widening in R4 — the existing
+   `searchExperiences` GraphQL field remains the admin-dashboard
+   elevated-role path.
+
+## Data-model divergences that bit (and got re-derived)
+
+- **Title/description location.** cms: `videos.title`. Admin:
+  `VideoLocale.title` (per-locale). Keyword-video SQL joins
+  `video_locale` and filters `locale + status = 'published'`.
+- **Consumer visibility gate.** cms: `videos.published_at IS NOT NULL`
+  - variant link chain. Admin: `VideoLocale.status = 'published'` +
+    `Video.deleted_at IS NULL`. `VideoDub.published` is a separate
+    boolean — NOT the consumer-visibility gate.
+- **Scene embedding shape.** cms: `scene_embeddings` single-row-per-
+  scene with language-agnostic embedding. Admin: per-locale on
+  `VideoSceneLocale` (R1 schema). Semantic-video SQL filters
+  `vsl.locale = ?` and uses per-locale partial HNSW indexes.
+- **PlaybackId path.** cms: `scene_embeddings.playback_id` denormalized.
+  Admin: 3-hop via `VideoScene → VideoDub(edition_id, language_id)
+→ MuxVideo.playback_id`. A LATERAL subquery preferring the published
+  dub for the requested locale resolves it; null when no dub matches.
+- **bcp47 column name.** Admin's `Language.bcp47` has NO underscore.
+  cms used `languages.bcp_47`.
+- **Id typing.** cms returned integer ids; admin returns cuid strings.
+  Consumer contracts tolerate both during the R3→R8 window because
+  R3's experience-content-dump already migrated experiences to cuid
+  ids before admin exposed them anywhere consumer-facing.
+- **Experience identity in results.** cms used the parent experience
+  id. Admin uses `ExperienceLocale.id` — the per-locale row is the
+  natural identity since slugs, content, and embeddings all live
+  there.
+
+## GIN index byte-parity invariant
+
+`src/services/hybrid-search-sql.ts` exports two forms of each tsvector
+expression: an INDEX form (bare columns, used verbatim by the
+migration) and a QUERY form (aliased columns, interpolated into
+retriever SQL via `Prisma.raw`). A unit test in
+`hybrid-search-sql.test.ts` reads
+`prisma/migrations/0006_hybrid_search_gin/migration.sql` from disk and
+asserts the INDEX-form substring appears verbatim. Any drift —
+typically a reviewer cleaning up whitespace in one but not the other —
+silently reverts the query to Seq Scan.
+
+## What stays unused in R4
+
+- **`VideoTranscriptChunk.embedding`** (R2). Deliberately not fused.
+  Adding a 5th RRF list for transcripts would diverge from cms's
+  4-list ranking during the R3→R8 validation window. Post-cutover
+  follow-up that won't require consumer-contract changes.
+- **`ExperienceLocale.ogImageUrl`.** Populated by R3, but the R4
+  response maps `imageUrl: null` for experience results per cms
+  parity. Upgrade lands after R8.
+
+## What R4 establishes as admin-first patterns
+
+- **First non-GraphQL REST endpoints in admin** outside of `/api/auth`
+  and `/api/graphql`. Query-string parsing via
+  `new URL(request.url).searchParams`; rate limiting via
+  `rateLimitAuthRoute` with per-route keys; 400/429/503 error bodies
+  shaped like cms's responses. R5 (`/api/scene-embeddings/recommendations`)
+  and R7 (revalidation webhook) inherit this pattern.
+- **Public Pothos query that wraps a service.** The `search` field
+  routes through `HybridSearchService` rather than a direct Prisma
+  call. The same service is shared with the REST handler so both
+  front doors share SQL semantics, degradation behavior, and
+  structured logs.
+- **Service-internal raw-SQL transport of `embedding::text`.** The
+  schema.test.ts `/embed|vector|similarit/i` guard is a GraphQL-surface
+  check; raw SQL inside services is out of scope. R4 is the reference
+  example — future services that need similarity transport for
+  intra-list dedup can follow the same pattern.
+
+## Why `generateExperienceEmbedding` got reused verbatim (and why its name is wrong)
+
+Admin's existing query embedder is `generateExperienceEmbedding(text:
+string)`. The name dates from R3 when experience text was the only
+input. By R4 it's genuinely generic — any string in, 1536-dim vector
+out, OpenRouter → OpenAI fallback, 30s timeout, Zod-validated
+response. R4 reuses it verbatim rather than pulling a rename into
+scope. Renaming to `embedText` or similar is a follow-up clean-up with
+churn across R3's call sites; keeping R4 tightly scoped is the
+tradeoff.
+
+## Post-cutover follow-ups flagged by R4
+
+- Wire `ExperienceLocale.ogImageUrl` through `imageUrl` for experience
+  results (once cms/admin diff invariant is no longer needed).
+- Add `VideoTranscriptChunk.embedding` as a 5th RRF list (`semantic-
+transcript-video`) with per-chunk dedup to avoid double-counting a
+  video that hits on both scene and transcript matches.
+- Rename `generateExperienceEmbedding` to `embedText`.
+- Add EDITOR/ADMIN widening to the `search` field if the admin
+  dashboard grows a search UX that needs to see drafts.
+
+## Related
+
+- Plan: `docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md`
+- Requirements: `docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md`
+- Playbook: `docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md`
+- Source pattern: `apps/cms/src/api/search/**`
+- Sibling R-pattern docs:
+  - `docs/solutions/platform/admin-scene-embeddings-indexer-pattern.md`
+  - `docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md`
+  - `docs/solutions/platform/admin-experience-content-dump-pattern.md`


### PR DESCRIPTION
## Summary

- Ports cms's hybrid search (feat-010 + feat-086 + feat-097 contract) from `apps/cms/src/api/search/` to `apps/admin`. Same consumer response shape; different data model underneath.
- Exposes the shared `HybridSearchService` at **two front doors**: `GET /api/search` + `GET /api/search/health` (Next App Router route handlers) and a public Pothos `search(q, locale, type, limit, offset)` GraphQL query.
- 4-list RRF (k=60) over semantic-video + keyword-video + semantic-experience + keyword-experience via `allSettled`. 3-layer video-only dedup (coreId prefix, exact title, cosine > 0.95). `searchMode: "hybrid" | "keyword-only"` degradation on embedding failure.
- Migration `0006_hybrid_search_gin` adds GIN indexes over `video_locale` and `experience_locale` tsvector expressions. Byte-parity with the service-side constants in `hybrid-search-sql.ts` is enforced by a unit test.

R4 of the [admin-migration playbook](docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md). Sets up apps/web + apps/mobile to swap their search backend at R8 cutover with zero response-shape drift.

## Key parity decisions (strict — not a refactor)

- **Scene-only for semantic-video.** `VideoTranscriptChunk.embedding` (R2) stays unused in R4; adding a 5th RRF list is a post-R8 follow-up.
- **Experience `imageUrl: null`.** cms did the same; wiring `ExperienceLocale.ogImageUrl` is a post-cutover upgrade so diff-against-cms stays clean.
- **PUBLIC at both REST + GraphQL.** ABAC enforced in SQL WHERE. No EDITOR/ADMIN widening in this PR.
- **Reuses `generateExperienceEmbedding` verbatim** as the query embedder (it's already generic despite the name; rename deferred).
- **RRF k=60, overfetch 3x, default 20, max 50, probe timeout 5s** — copied from cms.

## Data-model divergences re-derived

- Title on `VideoLocale` (per-locale), not `Video`.
- Consumer visibility = `video_locale.status = 'published'` + `video.deleted_at IS NULL` (not cms's variant link chain).
- `playbackId` via 3-hop `VideoScene → VideoDub(edition, language) → MuxVideo` with a LATERAL subquery; null when no dub matches the locale.
- `Language.bcp47` (no underscore in admin).
- Experience `resultId` = `ExperienceLocale.id` (per-locale row is the natural identity).
- cuid strings everywhere; cms used integer ids.

## Testing

- `pnpm --filter @forge/admin typecheck` — clean.
- `pnpm --filter @forge/admin lint` — clean.
- `pnpm --filter @forge/admin test` — 837 passing / 1 pre-existing todo.
- 66 new tests covering: fusion + 3-layer dedup (33); health counters + withTimeout (8); SQL constant byte-parity (2); 4 retrievers shape + short-circuit (9); orchestrator happy path + degradation + type filter + clamping + hasMore + allSettled unwrap (11); REST 400/429/503 + service call forwarding (11); health probe ok/degraded/rate-limit (3); GraphQL schema surface + no-embedding-leak + enum values (6).
- DB-backed canary diff vs cms's `/api/search` for a fixed query set × locales is tracked as a validation task, not code in this PR.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `[search] event=query_embedding_failure` (provider outage) and `[search] event=health_probe_failed` (probe failure).
  - Metrics/Dashboards: poll `https://admin.jesusfilm.org/api/search/health` — body's `status` field is the machine-readable signal (HTTP is always 200).
- **Validation checks**
  - `curl 'https://admin.jesusfilm.org/api/search?q=jesus&locale=en' | jq '.searchMode, (.results | length)'` — expect `"hybrid"` and a non-zero count (contingent on R1 scene backfill + R3 experience dump having run against prod).
  - `curl 'https://admin.jesusfilm.org/api/search/health' | jq '.status'` — expect `"ok"`.
  - `EXPLAIN ANALYZE SELECT COUNT(*) FROM video_locale WHERE to_tsvector('simple', coalesce(title,'') || ' ' || coalesce(description,'')) @@ plainto_tsquery('simple', 'jesus');` — expect `Bitmap Index Scan on video_locale_fulltext_search_idx`.
- **Expected healthy signals**
  - `searchMode: "hybrid"` on every non-probe request.
  - `/api/search/health` returns `status: "ok"` + `failures: 0`.
  - p95 latency < 500ms for `limit=20`.
- **Failure signals / rollback trigger**
  - `searchMode: "keyword-only"` on >5% of requests sustained for 5 minutes → investigate embedding provider reachability.
  - `/api/search` returning 503 → orchestrator bug or DB unreachable; roll back this PR if investigation points at R4 code.
  - GIN index missing from `EXPLAIN` output → migration 0006 not applied; re-run migrations.
- **Validation window & owner**
  - Window: first 24h post-deploy.
  - Owner: @Kneesal (R4 author).
- Consumer apps (apps/web, apps/mobile) are NOT changed in R4. They keep hitting cms's `/api/search`. This PR is additive; no end-user blast radius unless someone points consumer traffic at admin before R8 is scheduled.

## Docs

- `apps/admin/CLAUDE.md` — new R4 section (sibling to R1/R2/R3).
- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md` — durable learnings doc.
- Origin: `docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md`.
- Plan: `docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md`.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0