### PR TITLE
docs(roadmap): add TV app search UI ticket (feat-106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ depends_on:                   # Feature IDs this depends on
   - "feat-001"
 blocks:                       # Feature IDs this blocks
   - "feat-010"
-tags:                         # Searchable: cms, manager, web, mobile, graphql, ai-pipeline, search, pgvector, infrastructure
+tags:                         # Searchable: cms, manager, web, mobile, tv, graphql, ai-pipeline, search, pgvector, infrastructure, i18n
   - "cms"
 ---
 

--- a/docs/roadmap/content-discovery/feat-010-semantic-search-api.md
+++ b/docs/roadmap/content-discovery/feat-010-semantic-search-api.md
@@ -13,6 +13,7 @@ blocks:
   - "feat-011"
   - "feat-012"
   - "feat-086"
+  - "feat-106"
 tags:
   - "cms"
   - "search"

--- a/docs/roadmap/topic-experiences/feat-074-tv-app-home-screen.md
+++ b/docs/roadmap/topic-experiences/feat-074-tv-app-home-screen.md
@@ -10,6 +10,7 @@ depends_on:
   - "feat-073"
 blocks:
   - "feat-076"
+  - "feat-106"
 tags:
   - "tv"
 ---

--- a/docs/roadmap/topic-experiences/feat-106-tv-app-search-ui.md
+++ b/docs/roadmap/topic-experiences/feat-106-tv-app-search-ui.md
@@ -1,0 +1,134 @@
+---
+id: "feat-106"
+title: "TV App — Search UI"
+owner: "urim"
+priority: "P1"
+status: "not-started"
+start_date: "2026-04-24"
+duration: 2
+depends_on:
+  - "feat-074"
+  - "feat-010"
+blocks: []
+tags:
+  - "tv"
+  - "search"
+---
+
+## Problem
+
+The TV app currently has no way to search for content. Users can only discover Experiences through the home rail (feat-074). We need a D-pad-navigable search surface that hits the same semantic search backend the web and mobile apps use (feat-010), so a user can jump from the home screen into a query-driven results grid and then into playback.
+
+## Entry Points — Read These First
+
+1. `apps/tv/app/index.tsx` — home screen; search entry point attaches here (focusable tile in header row or first rail)
+2. `apps/tv/app/_layout.tsx` — expo-router Stack; add `search` route alongside `index` and `experience/[slug]`
+3. `apps/tv/src/components/FocusableCard.tsx` — focus / D-pad pattern every TV control must follow
+4. `apps/tv/src/components/ContentRail.tsx` — horizontal rail scrolling/focus behavior (reuse layout for results)
+5. `apps/tv/src/lib/queries.ts` — add `SEMANTIC_SEARCH` GraphQL operation here (mirror the mobile/web shape)
+6. `apps/web/src/components/FloatingSearchBar.tsx` and `apps/web/src/components/search/SearchInput.tsx` — reference for query lifecycle (debounce, submit, locale)
+7. `docs/roadmap/content-discovery/feat-010-semantic-search-api.md` — response shape (`semanticSearch` → `{ results: [{ type, id, slug, title, imageUrl, snippet, startSeconds, playbackId, score }], hasMore, query }`)
+
+## Grep These
+
+- `useFocusable\|onFocus\|TVFocusGuideView` in `apps/tv/src/` — focus primitives to reuse
+- `useRouter` in `apps/tv/app/` — expo-router navigation pattern
+- `semanticSearch` in `packages/graphql/` and `apps/web/src/` — GraphQL operation shape
+- `scale(` in `apps/tv/src/` — 10-foot-UI sizing helper; use for all dimensions
+- `COLORS` in `apps/tv/src/lib/colors.ts` — do not hardcode hex values
+
+## What To Build
+
+1. Route: `apps/tv/app/search.tsx` (expo-router screen)
+
+   ```typescript
+   // Full-screen search surface.
+   // Top: on-screen keyboard + query input (D-pad friendly).
+   // Below: results grid that auto-focuses once results land.
+   export default function SearchScreen() { ... }
+   ```
+
+2. Component: `apps/tv/src/components/SearchKeyboard.tsx`
+
+   ```typescript
+   // A-Z + 0-9 + space + delete, laid out in a focusable grid.
+   // Each key is a FocusableCard. Pressing a key appends to the query.
+   // D-pad up/down/left/right moves between keys; center press triggers.
+   // Also wire hardware keyboard (Bluetooth) via onKeyPress for QA speed.
+   type Props = {
+     value: string
+     onChange: (next: string) => void
+     onSubmit: () => void
+   }
+   ```
+
+3. Component: `apps/tv/src/components/SearchResultsGrid.tsx`
+
+   ```typescript
+   // Grid of VideoCardRenderer-style tiles (reuse visual language).
+   // First result auto-focuses after submit so D-pad down from keyboard lands there.
+   // Empty state: "No results for \"<query>\"". Loading state: ActivityIndicator.
+   type Result = {
+     id: number
+     slug: string
+     title: string
+     imageUrl: string | null
+     snippet: string
+     startSeconds: number | null
+     playbackId: string | null
+   }
+   ```
+
+4. Entry point on home: add a Search tile at the start of the home rail or as a header focusable.
+   In `apps/tv/app/index.tsx`, add a `FocusableCard` with a magnifying-glass glyph and `onPress={() => router.push('/search')}`.
+
+5. GraphQL operation in `apps/tv/src/lib/queries.ts`:
+
+   ```typescript
+   export const SEMANTIC_SEARCH = graphql(`
+     query SemanticSearch($query: String!, $locale: String!, $limit: Int) {
+       semanticSearch(query: $query, locale: $locale, limit: $limit) {
+         results {
+           type
+           id
+           slug
+           title
+           imageUrl
+           snippet
+           startSeconds
+           playbackId
+           score
+         }
+         hasMore
+         query
+       }
+     }
+   `)
+   ```
+
+   Use `useLazyQuery` so the query only fires on submit, not on every keystroke.
+
+6. Debounce: submit fires on keyboard "Search" key press OR after 600ms of no input (longer than web's 300ms — TV input is slower and we want fewer network round-trips). Cancel any in-flight query on new submit.
+
+7. Selecting a result: `router.push(\`/experience/\${slug}\`)`. If `playbackId`is present and the result is an in-scene match, open playback and seek to`startSeconds` (reuse the VideoPlayer seek prop from feat-076).
+
+## Constraints
+
+- Every control must be focusable via D-pad. No hover-only, no mouse-only.
+- Use `scale()` for every dimension; no raw pixels. TV viewports are 1080p/4K — hardcoded web sizes will look tiny.
+- Do NOT import from `apps/web/src/` or `apps/mobile/src/`. Copy what you need and adapt.
+- Use `getLocale()` from `apps/tv/src/lib/config.ts` for the locale variable — do NOT hardcode `"en"`. feat-109 will swap this to a dynamic value; this ticket must already read from the helper.
+- No text-input `<TextInput>` fallback. The on-screen keyboard IS the input. A real `<TextInput>` on tvOS is unreliable across remotes — skip it.
+- Do NOT add search history/suggestions yet. Ship the minimal submit-and-render flow first; history is a follow-up.
+
+## Verification
+
+- Launch the TV app on Apple TV Simulator. From home, D-pad up/left to the Search tile, press center → navigates to `/search`.
+- On the search screen, type a query using only the remote (no keyboard) → query appears in the input field.
+- Press "Search" key → results grid populates; focus moves to the first result.
+- D-pad to a result, press center → navigates to the experience screen and (if scene-level) begins playback near `startSeconds`.
+- Submit an empty query → nothing happens (no network call).
+- Submit a query with no matches → "No results" message renders; focus returns to keyboard.
+- `pnpm --filter tv typecheck` passes.
+- `pnpm --filter tv test` passes (add a unit test for `SearchResultsGrid` empty/loading/populated states).
+- Confirm the GraphQL operation's `$locale` variable is declared as `String!` and NOT `I18NLocaleCode!`. Strapi's generated queries use `I18NLocaleCode!`, but `semanticSearch` is a custom resolver that expects `String!`. The wrong type causes a gql.tada compile-time mismatch with a confusing error. Verify against `packages/graphql/graphql-env.d.ts` after `pnpm --filter graphql codegen`. Reference: `docs/solutions/best-practices/nextjs-search-overlay-ui-patterns-20260415.md`.

--- a/docs/solutions/developer-experience/pr-extraction-stash-collision-20260424.md
+++ b/docs/solutions/developer-experience/pr-extraction-stash-collision-20260424.md
@@ -1,0 +1,188 @@
+---
+title: "Focused PR extraction corrupts worktree when stash-pop crosses branches with divergent files"
+date: "2026-04-24"
+category: "developer-experience"
+module: "git-workflow"
+problem_type: "workflow_issue"
+component: "development_workflow"
+severity: "medium"
+root_cause: "missing_workflow_step"
+resolution_type: "workflow_improvement"
+applies_when:
+  - "Shipping a focused PR from a feature branch that has pre-existing uncommitted edits"
+  - "Source branch differs from target base on any tracked file outside the intended PR scope"
+  - "Using `/pr`, `/ce-commit-push-pr`, or any flow that stashes, branches from `origin/main`, then pops"
+  - "The dirty file is `apps/cms/schema.graphql` or any other Strapi/codegen artifact that drifts per-branch"
+tags:
+  - "git"
+  - "git-stash"
+  - "git-worktree"
+  - "git-cherry-pick"
+  - "pr-workflow"
+  - "ce-pr"
+  - "schema-graphql"
+---
+
+# Focused PR extraction corrupts worktree when stash-pop crosses branches with divergent files
+
+## Context
+
+The `/pr` skill needed to ship a focused 4-file subset (new `feat-106` TV search ticket, two reverse-dependency edits, one `CLAUDE.md` tag-list edit) from a busy feature branch (`feat/web-floating-search-redesign`). The branch had pre-existing uncommitted modifications to `apps/cms/schema.graphql` and `apps/roadmap/tsconfig.json` plus several untracked brainstorm/plan files — none of which belonged in the focused PR.
+
+The natural instinct — `git stash push -u` → `git checkout -b new-branch origin/main` → `git stash pop` → stage only the 4 intended files → commit — contains a silent landmine when the source branch and the target base disagree about a tracked file's committed content.
+
+**This is not hypothetical in this repo.** `apps/cms/schema.graphql` drifts per-branch whenever anyone touches a Strapi content type. It was the collision file on 2026-04-20 (during a `git pull`), on 2026-04-23 (during a `git checkout`), and on 2026-04-24 (during the `/pr` stash-pop). Session history confirmed the recurring pattern (session history).
+
+## Guidance
+
+**Do not use `git stash push -u` + rebranch + `git stash pop`** to extract a focused PR from a dirty feature branch when the source branch differs from the target base on any tracked file. The stash records diffs against the source branch's HEAD; popping onto a branch with a different HEAD silently three-way-merges those diffs against the _wrong parent_, producing a worktree that matches neither branch.
+
+Prefer one of the following, in order of preference:
+
+### 1. Cherry-pick path (most reliable — recommended default)
+
+```bash
+# On feat/<branch> with dirty worktree:
+git add <focused files only>
+git commit -m "<focused commit message>"
+FOCUSED_SHA=$(git rev-parse HEAD)
+
+git checkout -b <topic-branch> origin/main
+git cherry-pick "$FOCUSED_SHA"
+git push -u origin HEAD
+gh pr create ...
+
+# Optional: if the commit should not live on the feature branch:
+git checkout feat/<branch>
+git reset --soft HEAD~1    # un-commits, preserves the dirty worktree intact
+```
+
+The commit is a self-contained diff. `cherry-pick` applies it against the target branch's HEAD with proper three-way context, not against stash metadata.
+
+### 2. Worktree path (best when the feature branch must stay untouched)
+
+```bash
+git worktree add ../forge-pr origin/main -b <topic-branch>
+cd ../forge-pr
+# Author the focused changes here, or copy blobs from the sibling worktree.
+git add <files> && git commit -m "<message>"
+git push -u origin HEAD
+gh pr create ...
+cd - && git worktree remove ../forge-pr
+```
+
+The original worktree's dirty state is never touched. No stash, no branch switch on the source, no collision surface. Recommended when the dirty state is long-running work you don't want to commit yet.
+
+### 3. Scoped-pathspec stash (fallback — only when the stash must travel)
+
+If you must carry an uncommitted change across branches, scope the stash to specific paths and do **not** pop it on a branch where the target file differs:
+
+```bash
+# Stash only the specific paths you want to carry:
+git stash push -m "pre-<target>-checkout" -- <path1> <path2>
+git checkout <target-branch>
+# DO NOT pop here if <target-branch>'s committed content for <pathN> differs.
+# Pop later, only on a branch where the parent matches.
+```
+
+This is the pattern that worked correctly in a prior session when the same `apps/cms/schema.graphql` collision was anticipated (session history — session `0ecf19bb`, 2026-04-23).
+
+### 4. Pre-flight check (when you cannot avoid the unscoped stash-pop)
+
+Before popping, verify the stash's tracked paths are disjoint from files that differ between source and target:
+
+```bash
+BASE_DIFF=$(git diff --name-only origin/main...HEAD)
+STASH_DIFF=$(git diff --name-only HEAD)
+comm -12 <(echo "$BASE_DIFF" | sort) <(echo "$STASH_DIFF" | sort)
+```
+
+Non-empty intersection ⇒ stash-pop will mis-merge those files. Bail and use path 1 or 2.
+
+## Why This Matters
+
+The failure mode is **silent**:
+
+- `git stash pop` onto a divergent base does _not_ report a conflict when the three-way merge resolves cleanly. The resulting worktree contains a ghost version of the file — content that matches neither branch's committed state.
+- If the operator then stages only the intentionally-focused files, the ghost content sits undetected in the worktree and later blocks checkout:
+  ```
+  error: Your local changes to apps/cms/schema.graphql would be overwritten by checkout.
+  Aborting
+  ```
+- Recovery requires knowing that `git stash pop` does not auto-drop the stash entry when the worktree is left in a merge-adjacent state — the original stash is still at `stash@{0}`, which is the rescue hatch.
+
+On today's run the PR itself shipped clean (only the 4 intended files were staged; PR #841 opened with all CI green). But on a less careful run, the ghost content could have been staged and a regression shipped. On a repeat of this pattern against `apps/cms/schema.graphql`, a subtly-wrong schema could escape to CI and cause downstream codegen failures.
+
+**`apps/cms/schema.graphql` is the canonical recurring trigger in this repo.** Strapi regenerates it per-branch whenever anyone touches a content type. Any `/pr` or `/ce-work` flow extracting a focused subset from a branch with uncommitted Strapi work will hit this unless the flow uses one of the safer paths above.
+
+## When to Apply
+
+- Shipping a focused subset PR (docs, roadmap tickets, config tweaks) from a feature branch with unrelated pre-existing modifications
+- Running `/pr` or `/ce-commit-push-pr` from a dirty feature branch
+- Any time `git diff origin/main...HEAD` and `git diff HEAD` share at least one path
+- Especially when the overlap includes `apps/cms/schema.graphql` or other codegen-derived artifacts
+
+Skip this guidance (unscoped stash-pop is fine) only when the source branch is already at `origin/main` (no divergence) or the stash touches only files that are identical between source and target base.
+
+## Examples
+
+**Before (what broke on 2026-04-24):**
+
+```bash
+# On feat/web-floating-search-redesign with dirty worktree:
+git stash push -u -m "ce-pr-roadmap-separator"
+git checkout -b docs/roadmap-tv-search-ticket origin/main
+git stash pop
+# Silent mis-merge of apps/cms/schema.graphql against main's version.
+
+git add CLAUDE.md docs/roadmap/content-discovery/feat-010-*.md \
+        docs/roadmap/topic-experiences/feat-074-*.md \
+        docs/roadmap/topic-experiences/feat-106-*.md
+git commit -m "docs(roadmap): add TV search ticket"
+# PR ships clean (only the 4 intended files were staged).
+
+git checkout feat/web-floating-search-redesign
+# error: Your local changes to apps/cms/schema.graphql would be overwritten by checkout.
+```
+
+Recovery that day: instead of force-checking out, the pristine pre-session state was preserved in `stash@{0}` (the original full stash that `git stash pop` did not auto-drop), and the user was handed manual recovery steps (`git checkout -- apps/cms/schema.graphql` + `git checkout feat/<branch>` + `git stash pop stash@{0}`).
+
+**After (cherry-pick path):**
+
+```bash
+# On feat/web-floating-search-redesign with dirty worktree:
+git add CLAUDE.md docs/roadmap/content-discovery/feat-010-*.md \
+        docs/roadmap/topic-experiences/feat-074-*.md \
+        docs/roadmap/topic-experiences/feat-106-*.md
+git commit -m "docs(roadmap): add TV search ticket + reverse deps"
+SHA=$(git rev-parse HEAD)
+
+git checkout -b docs/roadmap-tv-search-ticket origin/main
+git cherry-pick "$SHA"
+git push -u origin HEAD
+gh pr create ...
+
+# Dirty worktree on feat/web-floating-search-redesign is untouched.
+# If the commit shouldn't live on feat:
+git checkout feat/web-floating-search-redesign
+git reset --soft HEAD~1
+```
+
+**After (worktree path):**
+
+```bash
+git worktree add ../forge-pr origin/main -b docs/roadmap-tv-search-ticket
+cd ../forge-pr
+# Author the 4 files fresh, or copy specific blobs from the sibling worktree.
+git add CLAUDE.md docs/roadmap/...
+git commit -m "docs(roadmap): add TV search ticket + reverse deps"
+git push -u origin HEAD
+gh pr create ...
+cd - && git worktree remove ../forge-pr
+```
+
+## Related
+
+- Session history: same `apps/cms/schema.graphql` collision handled correctly on 2026-04-23 via scoped-pathspec stash in session `0ecf19bb`; same file surfaced as a cross-branch-divergence signal during a `git pull` on 2026-04-20 in session `5afc6d7b` (session history)
+- `/pr` skill default flow at `/Users/urimchae/.claude/commands/pr.md` — the specific trigger surface; step 1 uses the unscoped stash-rebranch-pop pattern
+- No prior entries in `docs/solutions/` cover git stash/cherry-pick/worktree patterns — this seeds the cluster


### PR DESCRIPTION
## Summary

- New ticket `feat-106` — TV App Search UI (D-pad navigable keyboard + semantic search via the existing GraphQL backend). Owned by urim, scheduled 2026-04-24 (2 days).
- Bidirectional graph edges added: `feat-010` (Semantic Search API) and `feat-074` (TV Home Screen) now list `feat-106` in their `blocks` arrays.
- `CLAUDE.md` roadmap tag allowlist extended with `tv` and `i18n`. `tv` is already in active use across feat-072..feat-076 + feat-106; `i18n` was added defensively for a localization cluster that has since been deferred (see Context).

## Context

Originally scoped alongside three localization tickets (web/mobile/TV) and a shared-locale-package follow-up, but the localization cluster was dropped after realizing locales should be CMS-driven (Strapi i18n plugin exposes `i18NLocales`) rather than hardcoded in three parallel allowlists. The `i18n` tag is kept in CLAUDE.md so a future CMS-driven localization ticket can use it without another doc PR.

## Test plan

- [ ] Roadmap viewer at `apps/roadmap` renders `feat-106` under `topic-experiences` without frontmatter errors
- [ ] `feat-074` and `feat-010` correctly show `feat-106` as a downstream block in the viewer
- [ ] No duplicate IDs introduced (highest pre-existing was `feat-105`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)