### PR TITLE
feat(admin): split S3 client — read manager artifacts from manager's bucket

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -391,14 +391,20 @@ scale.
 
 **Operational runbook:**
 
-1. Refresh the coreId → cms video id mapping into the shared Railway S3
-   bucket: `pnpm --filter @forge/admin refresh:core-id-mapping`. The
-   CLI dumps from cms and uploads to
+1. Refresh the coreId → cms video id mapping into admin's own Railway
+   S3 bucket (the one wired to `RAILWAY_S3_*`):
+   `pnpm --filter @forge/admin refresh:core-id-mapping`. The CLI
+   dumps from cms and uploads to
    `admin-migrations/core-id-mapping.json`. Re-run when cms's catalog
    grows (Strapi SERIAL ids don't change, so existing entries stay
    valid).
-2. Ensure `OPENROUTER_API_KEY` or `OPENAI_API_KEY` is set on the
-   `forge-admin` Railway service.
+2. Ensure both S3 env blocks are set on the `forge-admin` Railway
+   service: `RAILWAY_S3_*` (admin's write bucket — coreId mapping,
+   admin-migrations/) and `MANAGER_ARTIFACTS_S3_*` (manager's
+   bucket — read-only, where admin reads `{assetId}/scene-analysis.json`
+   and `{assetId}/embeddings.json`). Also ensure `OPENROUTER_API_KEY`
+   or `OPENAI_API_KEY` is set so admin can re-embed scene
+   descriptions.
 3. Invoke `triggerSceneEmbeddingBackfill` via GraphQL. `mappingS3Key`
    defaults to `admin-migrations/core-id-mapping.json`; override for
    dry runs or ad-hoc snapshots. Omitted `locales` means "every
@@ -468,8 +474,13 @@ manager's stamp). See
    `pnpm --filter @forge/admin refresh:core-id-mapping`.
    Same CLI R1 uses; same snapshot consumed by both workflows.
 2. No API keys required for R2 backfill (vectors come from the
-   artifact). `RAILWAY_S3_*` and `REDIS_*` must be set on the
-   `forge-admin` Railway service (pre-existing from R1 prod).
+   artifact). `RAILWAY_S3_*` (admin's own write bucket — used by the
+   refresh CLI for `admin-migrations/core-id-mapping.json`),
+   `MANAGER_ARTIFACTS_S3_*` (manager's bucket — where admin reads
+   `{assetId}/embeddings.json` and `{assetId}/scene-analysis.json`
+   from), and `REDIS_*` must be set on the `forge-admin` Railway
+   service. The two S3 env blocks point at _different_ buckets — see
+   `src/storage/s3.ts` for the split.
 3. Invoke `triggerTranscriptEmbeddingBackfill` via GraphQL.
    `mappingS3Key` defaults to `admin-migrations/core-id-mapping.json`.
    Omitted `languages` means "every BCP-47 that exists across the

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -399,12 +399,19 @@ scale.
    grows (Strapi SERIAL ids don't change, so existing entries stay
    valid).
 2. Ensure both S3 env blocks are set on the `forge-admin` Railway
-   service: `RAILWAY_S3_*` (admin's write bucket — coreId mapping,
-   admin-migrations/) and `MANAGER_ARTIFACTS_S3_*` (manager's
-   bucket — read-only, where admin reads `{assetId}/scene-analysis.json`
-   and `{assetId}/embeddings.json`). Also ensure `OPENROUTER_API_KEY`
-   or `OPENAI_API_KEY` is set so admin can re-embed scene
-   descriptions.
+   service:
+   - `RAILWAY_S3_*` → admin's write bucket
+     (`cms-storage-jbpuckp0lmqap`, Railway bucket resource
+     `17368fd5-23e7-45bb-b007-e3f843b3d710`). Used for the coreId
+     mapping snapshot and any other `admin-migrations/*` writes.
+   - `MANAGER_ARTIFACTS_S3_*` → manager's bucket
+     (`forgemanagerartifacts-xtgld8`, Railway bucket resource
+     `b1c705c6-5add-48a0-a153-5ef40f876a4f`). Read-only;
+     `{assetId}/scene-analysis.json` + `{assetId}/embeddings.json`.
+
+   Also ensure `OPENROUTER_API_KEY` or `OPENAI_API_KEY` is set so
+   admin can re-embed scene descriptions.
+
 3. Invoke `triggerSceneEmbeddingBackfill` via GraphQL. `mappingS3Key`
    defaults to `admin-migrations/core-id-mapping.json`; override for
    dry runs or ad-hoc snapshots. Omitted `locales` means "every
@@ -469,8 +476,8 @@ manager's stamp). See
 
 **Operational runbook** (shares the R1 mapping snapshot):
 
-1. Refresh the coreId → cms video id mapping into the shared Railway
-   S3 bucket:
+1. Refresh the coreId → cms video id mapping into admin's own Railway
+   S3 bucket (the one wired to `RAILWAY_S3_*`):
    `pnpm --filter @forge/admin refresh:core-id-mapping`.
    Same CLI R1 uses; same snapshot consumed by both workflows.
 2. No API keys required for R2 backfill (vectors come from the

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -57,6 +57,18 @@ export const env = createEnv({
     RAILWAY_S3_BUCKET: z.string().min(1).optional(),
     RAILWAY_S3_ACCESS_KEY_ID: z.string().min(1).optional(),
     RAILWAY_S3_SECRET_ACCESS_KEY: z.string().min(1).optional(),
+    // Manager artifacts bucket — admin reads {assetId}/scene-analysis.json
+    // and {assetId}/embeddings.json from apps/manager's S3 bucket via
+    // readManagerArtifact() in src/storage/s3.ts. Distinct from
+    // RAILWAY_S3_*, which is admin's own write bucket (cms-storage,
+    // used for admin-migrations/core-id-mapping.json etc.). Read-only
+    // at the code layer: src/storage/s3.ts intentionally exposes no
+    // writeManagerArtifact helper.
+    MANAGER_ARTIFACTS_S3_ENDPOINT: z.string().url().optional(),
+    MANAGER_ARTIFACTS_S3_REGION: z.string().min(1).optional(),
+    MANAGER_ARTIFACTS_S3_BUCKET: z.string().min(1).optional(),
+    MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID: z.string().min(1).optional(),
+    MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY: z.string().min(1).optional(),
     // R3 — read-only Postgres URL for cms (Strapi v5). Optional at boot
     // so admin still starts in environments without the dump enabled.
     // The cms-pg singleton (`src/db/cms-pg.ts`) throws a clean
@@ -116,6 +128,21 @@ export const env = createEnv({
     ),
     RAILWAY_S3_SECRET_ACCESS_KEY: emptyToUndefined(
       process.env.RAILWAY_S3_SECRET_ACCESS_KEY,
+    ),
+    MANAGER_ARTIFACTS_S3_ENDPOINT: emptyToUndefined(
+      process.env.MANAGER_ARTIFACTS_S3_ENDPOINT,
+    ),
+    MANAGER_ARTIFACTS_S3_REGION: emptyToUndefined(
+      process.env.MANAGER_ARTIFACTS_S3_REGION,
+    ),
+    MANAGER_ARTIFACTS_S3_BUCKET: emptyToUndefined(
+      process.env.MANAGER_ARTIFACTS_S3_BUCKET,
+    ),
+    MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID: emptyToUndefined(
+      process.env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID,
+    ),
+    MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY: emptyToUndefined(
+      process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY,
     ),
     CMS_DATABASE_URL: emptyToUndefined(process.env.CMS_DATABASE_URL),
     NODE_ENV: emptyToUndefined(process.env.NODE_ENV),

--- a/apps/admin/src/services/manager-artifacts.service.test.ts
+++ b/apps/admin/src/services/manager-artifacts.service.test.ts
@@ -359,4 +359,34 @@ describe("readEmbeddingsArtifact", () => {
       errorSpy.mockRestore()
     }
   })
+
+  // Misclassification guard. The S3 production fail-fast in
+  // `src/storage/s3.ts::assertManagerArtifactsConfiguredForProduction`
+  // throws "MANAGER_ARTIFACTS_S3_BUCKET is not set ..." synchronously
+  // inside the async readManagerArtifact. The classifier regex in
+  // readEmbeddingsArtifact / readSceneAnalysisArtifact
+  // (`/not found|missing|no such key|ENOENT|NoSuchKey/i`) must NOT
+  // match this string — otherwise a misconfigured prod deploy would
+  // silently classify every target as `artifact_missing` (skipped),
+  // hiding the config error as "manager hasn't produced this yet."
+  // Lock in the classifier behavior against that exact message.
+  it("classifies the prod-guard error string as artifact_read_failed (not artifact_missing)", async () => {
+    readArtifactSpy.mockRejectedValueOnce(
+      new Error(
+        "MANAGER_ARTIFACTS_S3_BUCKET is not set — admin cannot read manager artifacts via local fallback in production",
+      ),
+    )
+    const error = await readEmbeddingsArtifact("1").catch((e) => e)
+    expect((error as { code: string }).code).toBe("artifact_read_failed")
+  })
+
+  it("classifies the missing-credentials error string as artifact_read_failed (not artifact_missing)", async () => {
+    readArtifactSpy.mockRejectedValueOnce(
+      new Error(
+        "MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID and MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY are required when MANAGER_ARTIFACTS_S3_BUCKET is set",
+      ),
+    )
+    const error = await readEmbeddingsArtifact("1").catch((e) => e)
+    expect((error as { code: string }).code).toBe("artifact_read_failed")
+  })
 })

--- a/apps/admin/src/services/manager-artifacts.service.test.ts
+++ b/apps/admin/src/services/manager-artifacts.service.test.ts
@@ -173,14 +173,14 @@ function stubArtifactBytes(body: unknown): Uint8Array {
 }
 
 describe("readEmbeddingsArtifact", () => {
-  // Spy on readArtifact so these tests don't rely on the shared
-  // `.tmp/artifacts/` directory (which `src/storage/s3.test.ts`
+  // Spy on readManagerArtifact so these tests don't rely on the
+  // shared `.tmp/artifacts/` directory (which `src/storage/s3.test.ts`
   // wipes in its own afterEach, racing with any file-based fixture).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let readArtifactSpy: any
 
   beforeEach(() => {
-    readArtifactSpy = vi.spyOn(s3, "readArtifact")
+    readArtifactSpy = vi.spyOn(s3, "readManagerArtifact")
   })
 
   afterEach(() => {

--- a/apps/admin/src/services/manager-artifacts.service.ts
+++ b/apps/admin/src/services/manager-artifacts.service.ts
@@ -1,7 +1,7 @@
 // Manager artifact reader — downloads scene-analysis.json and
-// embeddings.json (and future manager-produced artifacts) from the
-// shared Railway S3 bucket and Zod-validates against the expected
-// shape before returning.
+// embeddings.json (and future manager-produced artifacts) from
+// manager's Railway S3 bucket (MANAGER_ARTIFACTS_S3_*) and
+// Zod-validates against the expected shape before returning.
 //
 // R1 (scene embeddings) reads `{assetId}/scene-analysis.json` and
 // regenerates vectors in admin.
@@ -17,7 +17,7 @@
 //     EmbeddingsResult is the canonical shape for readEmbeddingsArtifact).
 
 import { z } from "zod"
-import { readArtifact } from "@/storage/s3"
+import { readManagerArtifact } from "@/storage/s3"
 
 export const SceneAnalysisSchema = z
   .object({
@@ -59,9 +59,10 @@ export class ManagerArtifactError extends Error {
 }
 
 /**
- * Read a scene-analysis artifact from the shared Railway S3 bucket or
- * local `.tmp/artifacts/{assetId}/scene-analysis.json` fallback and
- * return the parsed, Zod-validated result.
+ * Read a scene-analysis artifact from manager's Railway S3 bucket
+ * (MANAGER_ARTIFACTS_S3_*) or local
+ * `.tmp/artifacts/{assetId}/scene-analysis.json` fallback and return
+ * the parsed, Zod-validated result.
  *
  * @param assetId  The integer cms video id as a string — this is the
  *                 key manager used when writing the artifact. Admin's
@@ -73,7 +74,7 @@ export async function readSceneAnalysisArtifact(
 ): Promise<SceneAnalysisResult> {
   let bytes: Uint8Array
   try {
-    bytes = await readArtifact(assetId, "scene-analysis", "json")
+    bytes = await readManagerArtifact(assetId, "scene-analysis", "json")
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     if (/not found|missing|no such key|ENOENT|NoSuchKey/i.test(message)) {
@@ -185,9 +186,10 @@ export type EmbeddingsChunk = z.infer<typeof EmbeddingsChunkSchema>
 export type EmbeddingsResult = z.infer<typeof EmbeddingsResultSchema>
 
 /**
- * Read an embeddings artifact from the shared Railway S3 bucket or
- * local `.tmp/artifacts/{assetId}/embeddings.json` fallback and
- * return the parsed, Zod-validated result. Vectors inside
+ * Read an embeddings artifact from manager's Railway S3 bucket
+ * (MANAGER_ARTIFACTS_S3_*) or local
+ * `.tmp/artifacts/{assetId}/embeddings.json` fallback and return
+ * the parsed, Zod-validated result. Vectors inside
  * `chunks[].embedding` are the authoritative source that R2's
  * transcript-embedding indexer copies into admin's Postgres — no
  * provider call is made during R2 backfill.
@@ -202,7 +204,7 @@ export async function readEmbeddingsArtifact(
 ): Promise<EmbeddingsResult> {
   let bytes: Uint8Array
   try {
-    bytes = await readArtifact(assetId, "embeddings", "json")
+    bytes = await readManagerArtifact(assetId, "embeddings", "json")
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     if (/not found|missing|no such key|ENOENT|NoSuchKey/i.test(message)) {

--- a/apps/admin/src/storage/s3.manager-artifacts-backend.test.ts
+++ b/apps/admin/src/storage/s3.manager-artifacts-backend.test.ts
@@ -1,0 +1,124 @@
+/**
+ * S3-backend tests for `readManagerArtifact` in storage/s3.ts.
+ *
+ * Lives in a separate file so the env-driven
+ * `useManagerArtifactsS3 = Boolean(env.MANAGER_ARTIFACTS_S3_BUCKET)`
+ * flag can be flipped on at module import time without affecting the
+ * other s3.ts test files (which intentionally test the unset-bucket
+ * shape).
+ *
+ * The key assertion: this helper resolves Bucket/creds from the
+ * MANAGER_ARTIFACTS_S3_* env block — NOT from RAILWAY_S3_*. This
+ * locks in the two-bucket separation introduced when admin moved its
+ * artifact reads off the cms-storage bucket and onto manager's bucket.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { s3Send, GetObjectCommand, capturedClientConfigs } = vi.hoisted(() => ({
+  s3Send: vi.fn(),
+  GetObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
+    __command: "GetObject",
+    input,
+  })),
+  capturedClientConfigs: [] as Array<Record<string, unknown>>,
+}))
+
+class StubS3Client {
+  constructor(public readonly config: Record<string, unknown>) {
+    capturedClientConfigs.push(config)
+  }
+  send(...args: unknown[]) {
+    return s3Send(...args)
+  }
+}
+
+class StubNodeHttpHandler {
+  constructor(public readonly config: Record<string, unknown>) {}
+}
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: StubS3Client,
+  PutObjectCommand: vi.fn(),
+  GetObjectCommand,
+}))
+
+vi.mock("@smithy/node-http-handler", () => ({
+  NodeHttpHandler: StubNodeHttpHandler,
+}))
+
+// Set distinct values on each env block so the test can prove which one
+// the helper read. RAILWAY_S3_* would route to "wrong-bucket" if the
+// helper accidentally fell through to the primary client.
+process.env.RAILWAY_S3_BUCKET = "wrong-bucket"
+process.env.RAILWAY_S3_ENDPOINT = "https://wrong.example.com"
+process.env.RAILWAY_S3_REGION = "wrong-region"
+process.env.RAILWAY_S3_ACCESS_KEY_ID = "WRONG_AKIA"
+process.env.RAILWAY_S3_SECRET_ACCESS_KEY = "wrong-secret"
+
+process.env.MANAGER_ARTIFACTS_S3_BUCKET = "manager-bucket"
+process.env.MANAGER_ARTIFACTS_S3_ENDPOINT = "https://manager.example.com"
+process.env.MANAGER_ARTIFACTS_S3_REGION = "sjc"
+process.env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID = "MANAGER_AKIA"
+process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY = "manager-secret"
+
+const { readManagerArtifact } = await import("./s3")
+
+describe("storage — readManagerArtifact (S3 backend)", () => {
+  beforeEach(() => {
+    s3Send.mockReset()
+    GetObjectCommand.mockClear()
+  })
+
+  afterEach(() => {
+    s3Send.mockReset()
+  })
+
+  it("issues GetObjectCommand against MANAGER_ARTIFACTS_S3_BUCKET (not RAILWAY_S3_BUCKET)", async () => {
+    const bytes = new TextEncoder().encode('{"scenes":[]}')
+    s3Send.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => bytes },
+    })
+
+    const result = await readManagerArtifact("1502", "scene-analysis", "json")
+
+    expect(GetObjectCommand).toHaveBeenCalledWith({
+      Bucket: "manager-bucket",
+      Key: "1502/scene-analysis.json",
+    })
+    expect(GetObjectCommand).not.toHaveBeenCalledWith(
+      expect.objectContaining({ Bucket: "wrong-bucket" }),
+    )
+    expect(new TextDecoder().decode(result)).toBe('{"scenes":[]}')
+  })
+
+  it("constructs an S3Client with MANAGER_ARTIFACTS_S3_* endpoint, region, and credentials", async () => {
+    s3Send.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => new Uint8Array() },
+    })
+    await readManagerArtifact("1502", "embeddings", "json").catch(() => {})
+
+    // The manager-artifacts client is the only S3Client this test file
+    // constructs; assert against the most recent capture.
+    const config = capturedClientConfigs[capturedClientConfigs.length - 1]
+    expect(config?.endpoint).toBe("https://manager.example.com")
+    expect(config?.region).toBe("sjc")
+    expect(config?.credentials).toEqual({
+      accessKeyId: "MANAGER_AKIA",
+      secretAccessKey: "manager-secret",
+    })
+    expect(config?.requestHandler).toBeInstanceOf(StubNodeHttpHandler)
+    expect((config!.requestHandler as StubNodeHttpHandler).config).toEqual({
+      connectionTimeout: 5_000,
+      requestTimeout: 30_000,
+    })
+  })
+
+  it("throws a clear error when the response Body is missing", async () => {
+    s3Send.mockResolvedValueOnce({})
+
+    await expect(
+      readManagerArtifact("1502", "scene-analysis", "json"),
+    ).rejects.toThrow("Empty body for 1502/scene-analysis.json")
+  })
+})

--- a/apps/admin/src/storage/s3.manager-artifacts-backend.test.ts
+++ b/apps/admin/src/storage/s3.manager-artifacts-backend.test.ts
@@ -7,6 +7,12 @@
  * other s3.ts test files (which intentionally test the unset-bucket
  * shape).
  *
+ * MUST run with vitest's default `isolate: true` worker model — the
+ * module-load env mutations below are visible to anything that
+ * imports `./s3` from the same worker. Adding a sibling test that
+ * shares this file's worker would silently inherit the env state
+ * captured at our `await import("./s3")` line.
+ *
  * The key assertion: this helper resolves Bucket/creds from the
  * MANAGER_ARTIFACTS_S3_* env block — NOT from RAILWAY_S3_*. This
  * locks in the two-bucket separation introduced when admin moved its
@@ -47,9 +53,9 @@ vi.mock("@smithy/node-http-handler", () => ({
   NodeHttpHandler: StubNodeHttpHandler,
 }))
 
-// Set distinct values on each env block so the test can prove which one
-// the helper read. RAILWAY_S3_* would route to "wrong-bucket" if the
-// helper accidentally fell through to the primary client.
+// Set distinct values on each env block so a regression that aliased
+// the two clients would route to the WRONG bucket name and fail
+// loudly rather than passing because both pointed at the same place.
 process.env.RAILWAY_S3_BUCKET = "wrong-bucket"
 process.env.RAILWAY_S3_ENDPOINT = "https://wrong.example.com"
 process.env.RAILWAY_S3_REGION = "wrong-region"
@@ -62,12 +68,19 @@ process.env.MANAGER_ARTIFACTS_S3_REGION = "sjc"
 process.env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID = "MANAGER_AKIA"
 process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY = "manager-secret"
 
-const { readManagerArtifact } = await import("./s3")
+const storage = await import("./s3")
+const { readManagerArtifact, readArtifact } = storage
 
 describe("storage — readManagerArtifact (S3 backend)", () => {
   beforeEach(() => {
     s3Send.mockReset()
     GetObjectCommand.mockClear()
+    // capturedClientConfigs is intentionally NOT reset between tests —
+    // the s3 module memoizes both clients at module scope, so only the
+    // first test that triggers each lazy init appends a config. Tests
+    // below find their target client by endpoint string match rather
+    // than positional index, which is robust to test ordering and
+    // future additions.
   })
 
   afterEach(() => {
@@ -86,9 +99,6 @@ describe("storage — readManagerArtifact (S3 backend)", () => {
       Bucket: "manager-bucket",
       Key: "1502/scene-analysis.json",
     })
-    expect(GetObjectCommand).not.toHaveBeenCalledWith(
-      expect.objectContaining({ Bucket: "wrong-bucket" }),
-    )
     expect(new TextDecoder().decode(result)).toBe('{"scenes":[]}')
   })
 
@@ -98,17 +108,26 @@ describe("storage — readManagerArtifact (S3 backend)", () => {
     })
     await readManagerArtifact("1502", "embeddings", "json").catch(() => {})
 
-    // The manager-artifacts client is the only S3Client this test file
-    // constructs; assert against the most recent capture.
-    const config = capturedClientConfigs[capturedClientConfigs.length - 1]
-    expect(config?.endpoint).toBe("https://manager.example.com")
-    expect(config?.region).toBe("sjc")
-    expect(config?.credentials).toEqual({
+    // Find the manager-artifacts client by endpoint rather than by
+    // positional index — robust to test ordering and to the cross-route
+    // test below which also constructs the primary client.
+    const config = capturedClientConfigs.find(
+      (c) => c.endpoint === "https://manager.example.com",
+    )
+    if (!config) {
+      throw new Error(
+        "expected the manager-artifacts S3Client to have been constructed by this point",
+      )
+    }
+    expect(config.region).toBe("sjc")
+    expect(config.credentials).toEqual({
       accessKeyId: "MANAGER_AKIA",
       secretAccessKey: "manager-secret",
     })
-    expect(config?.requestHandler).toBeInstanceOf(StubNodeHttpHandler)
-    expect((config!.requestHandler as StubNodeHttpHandler).config).toEqual({
+    if (!(config.requestHandler instanceof StubNodeHttpHandler)) {
+      throw new Error("expected requestHandler to be a StubNodeHttpHandler")
+    }
+    expect(config.requestHandler.config).toEqual({
       connectionTimeout: 5_000,
       requestTimeout: 30_000,
     })
@@ -120,5 +139,67 @@ describe("storage — readManagerArtifact (S3 backend)", () => {
     await expect(
       readManagerArtifact("1502", "scene-analysis", "json"),
     ).rejects.toThrow("Empty body for 1502/scene-analysis.json")
+  })
+
+  it("readArtifact and readManagerArtifact route to different buckets when both env blocks are set", async () => {
+    // Cross-route lock-in: prove the two helpers don't accidentally
+    // alias to the same bucket. A regression that pointed both at
+    // RAILWAY_S3_BUCKET (the original bug this PR fixes) would land
+    // both calls on Bucket: "wrong-bucket" and fail this test loudly.
+    const bytes = new TextEncoder().encode("{}")
+    s3Send.mockResolvedValue({
+      Body: { transformToByteArray: async () => bytes },
+    })
+
+    await readManagerArtifact("1502", "scene-analysis", "json")
+    await readArtifact("1502", "scene-analysis", "json")
+
+    expect(GetObjectCommand).toHaveBeenCalledWith({
+      Bucket: "manager-bucket",
+      Key: "1502/scene-analysis.json",
+    })
+    expect(GetObjectCommand).toHaveBeenCalledWith({
+      Bucket: "wrong-bucket",
+      Key: "1502/scene-analysis.json",
+    })
+  })
+
+  it("does not export getManagerArtifactsS3 or _s3ManagerArtifacts (read-only-by-omission contract)", () => {
+    // The "read-only" guarantee on manager's bucket is enforced by code
+    // surface only — Railway buckets don't expose separate read-only
+    // IAM. If a future PR exports the S3 client factory or the
+    // singleton, callers could send PutObjectCommand directly. Lock the
+    // surface here.
+    const exports = storage as Record<string, unknown>
+    expect("readManagerArtifact" in exports).toBe(true)
+    expect("getManagerArtifactsS3" in exports).toBe(false)
+    expect("_s3ManagerArtifacts" in exports).toBe(false)
+    expect("writeManagerArtifact" in exports).toBe(false)
+  })
+
+  it("throws a clear error when MANAGER_ARTIFACTS_S3_BUCKET is set but credentials are unset", async () => {
+    // Misconfiguration scenario: bucket env wired, but creds typo'd or
+    // forgotten. The s3 module's lazy-init must reject before any S3
+    // request, with a message that names BOTH missing vars.
+    //
+    // We mutate creds in-place, then force a fresh module instance so
+    // useManagerArtifactsS3 + the lazy singleton observe the new state.
+    vi.resetModules()
+    delete process.env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID
+    delete process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY
+    try {
+      const fresh = await import("./s3")
+      await expect(
+        fresh.readManagerArtifact("1502", "scene-analysis", "json"),
+      ).rejects.toThrow(
+        /MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID and MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY are required/,
+      )
+    } finally {
+      // Restore for any later tests in the same worker (currently none,
+      // but defensive against future additions).
+      process.env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID = "MANAGER_AKIA"
+      process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY = "manager-secret"
+      vi.resetModules()
+    }
   })
 })

--- a/apps/admin/src/storage/s3.manager-artifacts-prod-guard.test.ts
+++ b/apps/admin/src/storage/s3.manager-artifacts-prod-guard.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Fail-fast test for the production-requires-manager-bucket guard.
+ *
+ * Mirrors `s3.prod-guard.test.ts` for the new `readManagerArtifact`
+ * helper. Runs in a separate file so NODE_ENV can be flipped to
+ * "production" at module import time without contaminating other
+ * test files' module-cached `useManagerArtifactsS3` flag.
+ */
+
+import { describe, expect, it, vi } from "vitest"
+;(process.env as Record<string, string | undefined>).NODE_ENV = "production"
+delete process.env.MANAGER_ARTIFACTS_S3_BUCKET
+// Keep RAILWAY_S3_BUCKET set so the primary client's prod guard does
+// NOT trip — we want to isolate the manager-artifacts guard here.
+process.env.RAILWAY_S3_BUCKET = "irrelevant-primary-bucket"
+process.env.RAILWAY_S3_ENDPOINT = "https://primary.example.com"
+process.env.RAILWAY_S3_REGION = "auto"
+process.env.RAILWAY_S3_ACCESS_KEY_ID = "PRIMARY_AKIA"
+process.env.RAILWAY_S3_SECRET_ACCESS_KEY = "primary-secret"
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class {},
+  PutObjectCommand: class {},
+  GetObjectCommand: class {},
+}))
+vi.mock("@smithy/node-http-handler", () => ({
+  NodeHttpHandler: class {},
+}))
+
+const { readManagerArtifact } = await import("./s3")
+
+describe("storage — readManagerArtifact production fail-fast", () => {
+  it("rejects loudly when MANAGER_ARTIFACTS_S3_BUCKET is unset in production", async () => {
+    await expect(
+      readManagerArtifact("1502", "scene-analysis", "json"),
+    ).rejects.toThrow(/MANAGER_ARTIFACTS_S3_BUCKET is not set/)
+  })
+})

--- a/apps/admin/src/storage/s3.ts
+++ b/apps/admin/src/storage/s3.ts
@@ -195,6 +195,111 @@ export async function readArtifact(
 }
 
 // ---------------------------------------------------------------------------
+// Manager artifacts S3 backend — read-only by design.
+//
+// Admin's R1 (scene embeddings) and R2 (transcript embeddings) backfills
+// re-index `{assetId}/scene-analysis.json` and `{assetId}/embeddings.json`
+// produced by apps/manager. Those artifacts live in manager's own
+// Railway bucket, NOT admin's RAILWAY_S3_* (cms-storage) bucket — admin's
+// reads must be routed there.
+//
+// Distinct env block (MANAGER_ARTIFACTS_S3_*) so admin's writes (which
+// continue to land in RAILWAY_S3_BUCKET) never mix with manager's bucket.
+// No writeManagerArtifact helper exists: read-only is enforced at the
+// code layer because Railway's bucket resources don't expose a
+// separate read-only credential.
+// ---------------------------------------------------------------------------
+
+const useManagerArtifactsS3 = Boolean(env.MANAGER_ARTIFACTS_S3_BUCKET)
+
+function assertManagerArtifactsConfiguredForProduction(): void {
+  if (!useManagerArtifactsS3 && env.NODE_ENV === "production") {
+    throw new Error(
+      "MANAGER_ARTIFACTS_S3_BUCKET is not set — admin cannot read manager artifacts via local fallback in production",
+    )
+  }
+}
+
+let _s3ManagerArtifacts:
+  | InstanceType<typeof import("@aws-sdk/client-s3").S3Client>
+  | undefined
+
+async function getManagerArtifactsS3() {
+  if (!_s3ManagerArtifacts) {
+    if (
+      !env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID ||
+      !env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY
+    ) {
+      throw new Error(
+        "MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID and MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY are required when MANAGER_ARTIFACTS_S3_BUCKET is set",
+      )
+    }
+    const [{ S3Client }, { NodeHttpHandler }] = await Promise.all([
+      import("@aws-sdk/client-s3"),
+      import("@smithy/node-http-handler"),
+    ])
+    if (!_s3ManagerArtifacts) {
+      _s3ManagerArtifacts = new S3Client({
+        endpoint: env.MANAGER_ARTIFACTS_S3_ENDPOINT,
+        region: env.MANAGER_ARTIFACTS_S3_REGION ?? "auto",
+        credentials: {
+          accessKeyId: env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID,
+          secretAccessKey: env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY,
+        },
+        forcePathStyle: true,
+        // Same timeout discipline as the primary client — a stalled
+        // manager-bucket endpoint must not hold the workflow runtime
+        // hostage.
+        requestHandler: new NodeHttpHandler({
+          connectionTimeout: 5_000,
+          requestTimeout: 30_000,
+        }),
+      })
+    }
+  }
+  return _s3ManagerArtifacts
+}
+
+/**
+ * Read a manager-produced artifact from manager's S3 bucket.
+ *
+ * Mirrors `readArtifact` but resolves bucket + creds from the
+ * MANAGER_ARTIFACTS_S3_* env block. Falls back to the same local
+ * `.tmp/artifacts/{assetId}/{artifactType}.{ext}` path as
+ * `readArtifact` when MANAGER_ARTIFACTS_S3_BUCKET is unset (dev
+ * convenience — both helpers point at the same on-disk fixtures).
+ *
+ * Production guard: if MANAGER_ARTIFACTS_S3_BUCKET is unset and
+ * NODE_ENV === "production", throws — the local fallback would
+ * silently miss every artifact and downstream consumers would
+ * misclassify the resulting ENOENT as "manager hasn't produced this
+ * yet."
+ */
+export async function readManagerArtifact(
+  assetId: string,
+  artifactType: string,
+  ext: string,
+): Promise<Uint8Array> {
+  assertManagerArtifactsConfiguredForProduction()
+
+  if (!useManagerArtifactsS3) return localRead(assetId, artifactType, ext)
+
+  const { GetObjectCommand } = await import("@aws-sdk/client-s3")
+  const key = artifactKey(assetId, artifactType, ext)
+  const s3 = await getManagerArtifactsS3()
+
+  const response = await s3.send(
+    new GetObjectCommand({
+      Bucket: env.MANAGER_ARTIFACTS_S3_BUCKET,
+      Key: key,
+    }),
+  )
+
+  if (!response.Body) throw new Error(`Empty body for ${key}`)
+  return new Uint8Array(await response.Body.transformToByteArray())
+}
+
+// ---------------------------------------------------------------------------
 // Object-key API — reads/writes to an arbitrary S3 key (slash-separated
 // path segments), rather than the `{assetId}/{artifactType}.{ext}` shape.
 // Used for admin-scoped resources like the coreId mapping snapshot.

--- a/apps/admin/src/storage/s3.ts
+++ b/apps/admin/src/storage/s3.ts
@@ -172,6 +172,20 @@ export async function writeArtifact(
   return key
 }
 
+/**
+ * Read a `{assetId}/{artifactType}.{ext}` artifact from admin's OWN
+ * Railway S3 bucket (`RAILWAY_S3_*`).
+ *
+ * Today this has no production caller in admin — admin doesn't write
+ * artifacts in this key shape; it only writes object-key resources
+ * (admin-migrations/...) via {@link writeObject}. The function is
+ * retained as the symmetric pair to {@link writeArtifact} for any
+ * future intra-admin artifact use case.
+ *
+ * **Do NOT use this helper to read manager-produced artifacts** —
+ * scene-analysis.json and embeddings.json live in manager's bucket,
+ * not admin's. Use {@link readManagerArtifact} for those.
+ */
 export async function readArtifact(
   assetId: string,
   artifactType: string,


### PR DESCRIPTION
## Summary

Admin's prod `RAILWAY_S3_*` env points at the **cms-storage** bucket (`cms-storage-jbpuckp0lmqap`, Railway resource `17368fd5-…`) and is used for admin's own writes — `admin-migrations/core-id-mapping.json` plus periodic cms snapshots.

The R1 (scene embeddings) and R2 (transcript embeddings) backfill code in `apps/admin/src/services/manager-artifacts.service.ts` was using the same env block to read `{assetId}/scene-analysis.json` and `{assetId}/embeddings.json` — but those artifacts only ever land in **manager's** bucket (`forgemanagerartifacts-xtgld8`, Railway resource `b1c705c6-…`). manager's bucket is the source of truth: only `apps/manager/src/services/sceneAnalysis.ts` and `apps/manager/src/services/embeddings.ts` write these files, and they write to manager's own `RAILWAY_S3_BUCKET`.

Surfaced during the R1 prod smoke this afternoon: refresh CLI succeeded (2,139 mapping rows uploaded), but `triggerSceneEmbeddingBackfill` would have returned `artifact_missing` for every target. Smoke pulled up before invoking the mutation.

This PR splits the S3 client so admin writes its own artifacts to its own bucket, and reads manager's artifacts from manager's bucket.

### What changed

- **`src/config/env.ts`** — adds 5 new optional vars: `MANAGER_ARTIFACTS_S3_BUCKET`, `_ENDPOINT`, `_REGION`, `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY`. Same `emptyToUndefined` + `.optional()` shape as the existing `RAILWAY_S3_*` block.
- **`src/storage/s3.ts`** — adds a sibling lazy `_s3ManagerArtifacts` client and `readManagerArtifact(assetId, artifactType, ext)`. Same `SAFE_KEY_PATTERN`, same `NodeHttpHandler` 5s/30s timeout discipline, same local-fallback path (`.tmp/artifacts/{assetId}/...`) as the existing read helper. **No `writeManagerArtifact`** — read-only at the code layer because Railway's bucket resources don't expose a separate read-only credential.
- **`src/services/manager-artifacts.service.ts`** — swaps the two `readArtifact()` call sites (`readSceneAnalysisArtifact`, `readEmbeddingsArtifact`) for `readManagerArtifact()`. Header comments updated; behaviour unchanged.
- **Tests:**
  - `s3.manager-artifacts-backend.test.ts` (new) — locks in that `readManagerArtifact` resolves Bucket/creds from `MANAGER_ARTIFACTS_S3_*`, never `RAILWAY_S3_*`. Sets distinct values on each env block so a regression that fell back to the primary client would route to a `wrong-bucket` value the assertion catches.
  - `s3.manager-artifacts-prod-guard.test.ts` (new) — pins the prod fail-fast: `NODE_ENV=production` + unset `MANAGER_ARTIFACTS_S3_BUCKET` throws loudly. Keeps `RAILWAY_S3_BUCKET` set so this test isolates the new guard from the existing one.
  - `manager-artifacts.service.test.ts` (existing) — spy target updated from `readArtifact` to `readManagerArtifact`. All 16 existing tests continue to pass with no behaviour change.
- **`apps/admin/CLAUDE.md`** — R1 + R2 runbooks updated to reference both env blocks and explain the two-bucket model.

### Why this design (not a single shared bucket)

The earlier R1 design assumed admin and manager share one bucket. They don't: admin/cms share one bucket (cms-storage), manager owns a different bucket. The user explicitly chose the two-env-blocks split (per discussion in [link to handoff thread]) over repointing admin's `RAILWAY_S3_*` at manager's bucket, so admin's writes stay isolated from manager's data.

## Testing

- `pnpm --filter @forge/admin typecheck` — clean.
- `pnpm --filter @forge/admin test` — 67 files / 928 tests pass (1 todo, pre-existing). The 4 new test cases cover env routing + prod guard.
- `pnpm --filter @forge/admin lint` — clean.

Tests run with no manager bucket env set, so they exercise the local-fallback branch except for the two new tests that explicitly stub envs.

## Refs

- `docs/handoffs/2026-04-21-admin-migration-r1-smoke-and-r2-handoff.md` — the R1 smoke handoff that surfaced this gap. Next person picking up R1 should read this PR's commit message before re-running the smoke.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: `service=forge-admin event=storage.write` (admin's own writes to RAILWAY_S3_* should still land — no change). No new structured log event on the read path; failures surface as `ManagerArtifactError(code=artifact_missing|artifact_read_failed)` from the workflow's per-target outcome list.
  - Metrics/Dashboards: existing useworkflow run-completion dashboards for `sceneEmbeddingBackfill` / `transcriptEmbeddingBackfill`.
- **Validation checks (post-env-wire)**
  - After wiring `MANAGER_ARTIFACTS_S3_*` on the forge-admin prod service:
    - `triggerSceneEmbeddingBackfill(coreIds: ["<one with manager artifacts>"], locales: ["en"])` → expect `succeeded: 1, failed: 0` and `outcomes[0].action !== "artifact_missing"`.
    - `SELECT COUNT(*) FROM video_scene_locale WHERE embedding IS NOT NULL` should grow by the artifact's scene count.
- **Expected healthy behavior**
  - Existing R1 + R2 mutations behave identically to today against local dev (local fallback path unchanged).
  - In prod, before `MANAGER_ARTIFACTS_S3_*` is wired, every backfill target returns `failed { reason: "artifact_read_failed", message: "MANAGER_ARTIFACTS_S3_BUCKET is not set ..." }` — clean fail-loud signal, no silent degradation.
  - Once env wired, mutations behave as designed.
- **Failure signal / rollback trigger**
  - If the deploy itself fails to boot (env validation), Railway healthcheck fails — rollback the deploy. The new env vars are all `.optional()`, so this should not regress boot.
  - If `writeArtifact` / `writeObject` / `refresh:core-id-mapping` regresses (admin's own writes), revert this PR — those code paths were not modified but a regression there would affect the migration mapping flow.
- **Validation window & owner**
  - Window: ~10 min after deploy, then again immediately after `MANAGER_ARTIFACTS_S3_*` env vars are added on the forge-admin Railway service.
  - Owner: Nisal — this PR is a prerequisite for completing the R1 prod smoke (that work continues in the linked handoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context) via Compound Engineering ce:work