### PR TITLE
docs(research): add Bible Project worked example to semantic-search report

### DIFF
--- a/docs/research/semantic-search-report.md
+++ b/docs/research/semantic-search-report.md
@@ -130,6 +130,18 @@ Experience embeddings are page-level (one vector per experience), which is why e
 
 These are the gaps that show up when comparing to an "Algolia-quality" experience.
 
+### Worked example — `"the Bible project"`
+
+A user searching `"the Bible project"` (a well-known video series) gets a mix of Bible Project videos and unrelated videos containing the word "project." Algolia, configured against the same catalog, would return a clean Bible Project set on page 1. Three of the gaps below combine to cause this:
+
+- `plainto_tsquery('simple', 'the Bible project')` flattens to `bible & project` — phrase adjacency is lost, so any video whose title or description contains both words anywhere ranks.
+- The keyword tsvector is `to_tsvector('simple', title || ' ' || description)` — a description hit on "project" weighs the same as a title hit on "Bible project."
+- The semantic retriever has no notion of phrases — for `"the Bible project"` it pulls in videos thematically near "bible" + "ministry" + "project," not just The Bible Project series. RRF then fuses the diluted lists and the tail leaks into the top results.
+
+**The "Algolia-quality" target for this query is concrete:** every result on page 1 is from the Bible Project series, and no non-matching title outranks a matching one. This is the canonical failure mode the §6 work is designed to close.
+
+### The full gap list
+
 - **No typo tolerance.** "frgive" returns nothing. Postgres FTS doesn't fuzzy-match and we don't run `pg_trgm`.
 - **No prefix matching.** "for" doesn't match "forgiveness" — kills the as-you-type feel.
 - **Title is invisible to the embedding.** Proper-noun queries ("Zacchaeus", a film name) rely entirely on the keyword path; if the keyword path doesn't match exactly, the result is buried.
@@ -183,6 +195,8 @@ The current `demographics` and `spiritual_context` columns are flat `text[]`s �
 ## 6. Adding Algolia-like Functionality
 
 Two questions to separate: **does it return Algolia-quality results?** and **does it look like Algolia to clients?** This section covers both, but the _result quality_ changes are where the real wins are.
+
+The operational definition of "Algolia-like" we're targeting is the worked example in §4: when a user types a known title — `"the Bible project"` is the canonical case — every result on page 1 should be from that series, and no non-matching title should outrank a matching one. Each subsection below addresses one piece of that gap.
 
 ### 6.1 Result quality (the changes that actually matter)
 


### PR DESCRIPTION
## Summary

- Adds a concrete failure case to **§4 What the Current Search Does Poorly**: `q="the Bible project"` returns a diluted mix instead of the Bible Project series. Walks through the three gaps (`plainto_tsquery` flattening, unweighted tsvector, semantic-side phrase blindness) that combine to produce it.
- Uses the same example in **§6 Adding Algolia-like Functionality** as the operational definition of "Algolia-like": every page-1 result is from the named series, no non-matching title outranks a matching one.

## Why

The report's gap list (§4) and recommendations (§6) are correct — this PR doesn't change them. It only adds a single canonical worked example so that:

- The "Algolia-like" framing has a concrete, falsifiable target rather than a vibe
- Plans that cite this report (specifically [feat-109 / PR #849](https://github.com/JesusFilm/forge/pull/849)) can lock acceptance criteria against the same example without restating the failure mode
- Reviewers reading §4 see the user-visible symptom before the abstract gap list

## Scope

- 14 lines added, 0 removed
- Recommendations, ordering, sequencing in §6.3 unchanged
- §5 (personas), §7 (extend-don't-fork), §9 (multilingual) unchanged

## Test plan

- [ ] §4 reads cleanly: failure mode is concrete and grounded before the abstract gap list
- [ ] §6 intro ties back to §4 without restating the example
- [ ] No drift from the recommendations already merged in #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)