### PR TITLE
feat(admin): port keyword-first lexical search to admin (R4 extension)

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -784,6 +784,177 @@ Note: the 3-layer video dedup + `cosineSimilarityFromText` live in
 recommendations consume one implementation. `deduplicateResults` below
 is a thin `FusedResult`-typed wrapper.
 
+## Hybrid search keyword-first mode (R4 extension)
+
+Opt-in `mode="keyword-first"` argument on the same `HybridSearchService`
+that R4 ships. Adds three lexical retrievers + a post-fusion semantic-
+dilution cap + an origin-gated debug payload. Default behavior stays
+byte-identical to R4 main when `mode` is unset / null / `""` / `"hybrid"`
+/ unknown — locked in by `src/services/hybrid-search.regression.test.ts`.
+
+This is an **extension of R4**, not a new R-stage. The cms-side
+`feat-109` work (apps/cms PR #852) lives on cms during the R3 → R8
+window; admin's surface matches the cms-side contract by R8 cutover.
+
+- **Schema:** Migration `0009_keyword_first_lexical/migration.sql`
+  provisions `pg_trgm`, two STORED generated tsvector columns on
+  `video_locale` (`title_tsv`, `description_tsv`), a weighted GIN
+  index over `(setweight(title_tsv,'A') || setweight(description_tsv,'B'))`,
+  and a trigram GIN index on `title gin_trgm_ops`. Generated columns
+  - GIN indexes attach to `VideoLocale`, NOT `Video` (per-locale
+    attachment per admin's data model). The legacy R4
+    `video_locale_fulltext_search_idx` from `0006` is untouched —
+    hybrid mode keeps reading it via `searchVideoKeyword`.
+
+- **Byte-parity invariant:** `WEIGHTED_TSV_INDEX_EXPR` /
+  `WEIGHTED_TSV_QUERY_EXPR` / `TITLE_TSV_GENERATED_EXPR` /
+  `DESCRIPTION_TSV_GENERATED_EXPR` in `src/services/hybrid-search-sql.ts`
+  must stay byte-equal to the migration. `hybrid-search-sql.test.ts`
+  reads the migration and asserts. The trigram path uses operator-class
+  GIN (`gin_trgm_ops`) — no expression byte-parity guard needed; index
+  selection happens via the `%>` operator. Per
+  `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md`.
+
+- **Generated-column drift trap:** Postgres has no `ALTER COLUMN ...
+GENERATED` editor for stored expressions. Any future rewrite of
+  `*_GENERATED_EXPR` requires a coordinated `DROP COLUMN ... CASCADE +
+ADD COLUMN ... GENERATED ALWAYS AS (...)` migration. Per
+  `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`.
+
+- **Three new lexical retrievers** in
+  `src/services/hybrid-search-keyword-first-retrievers.ts`:
+  - `searchByKeywordWeighted` — phrase-aware
+    `websearch_to_tsquery('simple', q)`, ranked by `ts_rank_cd`
+    against the weighted tsvector. `Prisma.raw(WEIGHTED_TSV_QUERY_EXPR)`
+    for the unbindable expression fragment.
+  - `searchByTrigram` — `vl.title %> q` with `similarity(vl.title, q)`
+    ranking. Title-only (description trigram index would balloon).
+  - `searchByExactTitle` — dynamic AND-chain of `vl.title ILIKE ?`
+    via `Prisma.join`, ranked `LENGTH(title) ASC`. Tokenization is
+    Unicode letter / digit split, lowercased, deduped, **capped at
+    `MAX_EXACT_TITLE_TOKENS = 16`** (DoS guard from cms-side fix).
+    All three honor R4's locale + status + `deleted_at IS NULL` chain.
+
+- **Branched orchestrator:** Single `HybridSearchService.search()`
+  branches once on `pipelineMode === "keyword-first"`. Hybrid path
+  is UNTOUCHED. Keyword-first dispatches: semantic-video (shared) +
+  keyword-weighted-video + trigram-video + exact-title-video. The
+  R4 `searchVideoKeyword` is NOT called on the keyword-first branch.
+  Per `docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md`.
+
+- **Mode normalization:** `normalizeMode(raw, logger)` decodes the
+  free-form public arg to a closed `SearchPipelineMode` set. Unknown
+  values warn-and-fall-back to hybrid via a single sanitized log line
+  (`[search] event=search_unknown_mode mode=… falling_back=hybrid`)
+  — never throws. CR/LF/TAB stripped, length clamped to 64. Per
+  `docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md`.
+
+- **Semantic-dilution cap:** Active only in keyword-first mode and
+  only when at least one exact-title result's lowercased title
+  contains every query token. When triggered, semantic-only fused
+  results whose `videoCoreId` is null OR not present in the top-3
+  keyword-side core_ids get `score *= 0.5` and the list re-sorts.
+  `applyDilutionCap` is exported for unit testing. Gated by
+  `SEARCH_DILUTION_CAP_ENABLED` (default `true`; only literal
+  `"false"` disables — tolerant parser is a documented follow-up).
+
+- **Origin-gated `debug` payload:** `isDebugAllowedForOrigin` in
+  `src/services/hybrid-search-debug-allowlist.ts` is the soft gate.
+  Boundary (REST + GraphQL) consults the allowlist; the service
+  trusts the boolean. Fail-closed on `Origin: undefined`. Allowlist:
+  `SEARCH_DEBUG_ALLOWED_ORIGINS` CSV; otherwise any origin in
+  non-production. Threat model is "soft feature flag, not auth" —
+  Origin headers are forgeable from non-browser clients. The payload
+  carries no PII / credentials, only retriever ranks + fused score
+  - cap state. Per
+    `docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md`.
+
+- **GraphQL types:** `HybridSearchResult.debug` is a nullable
+  `HybridSearchResultDebug` (`retrieverRanks`, `fusedScore`,
+  `dilutionCapApplied`). `HybridSearchRetrieverRank.label` is
+  explicitly **UNSTABLE** in the schema description — operators
+  inspecting payloads are the audience; do NOT branch on those
+  strings in production code. `schema.test.ts` asserts no
+  `embed|vector|similarit` field leaks on either new type.
+
+- **REST endpoint:** Same `GET /api/search` extends with `mode` +
+  `debug` query params. `mode=` (empty) is forwarded as undefined to
+  avoid polluting the warn log. `debug=true` is the only opt-in
+  spelling — `debug=1` and other truthy values are treated as off
+  (debug is a deliberate developer affordance, not a fuzzy toggle).
+
+- **Endpoints + acceptance:**
+  - `GET /api/search?q=…&locale=…&mode=keyword-first&debug=true`
+  - GraphQL: `Query.search(q, locale, type?, limit?, offset?, mode?, debug?)`
+  - Bible Project headline test
+    (`src/services/hybrid-search.bible-project.test.ts`) asserts top-3
+    are all `/bible\s*project/i` titles for `q="the bible project"`.
+
+- **Test-first regression gate:**
+  `src/services/hybrid-search.regression.test.ts` asserts byte-identity
+  across `mode ∈ {undefined, null, "", "hybrid", "garbage"}` against
+  deterministic mocked retrievers. Adding a new retriever / debug
+  field / cap parameter is allowed only as long as that test stays
+  green. Per
+  `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`.
+
+**Operational runbook:**
+
+1. Apply migration `0009_keyword_first_lexical` in any environment
+   that wants keyword-first available. `prisma migrate dev` /
+   `prisma migrate deploy` is idempotent. The two new GIN indexes
+   add disk + write amplification proportional to corpus size; cost
+   is negligible at admin's current zero-row prod data and grows
+   when R0 backfills.
+2. Confirm `pg_trgm` extension permission on the prod DB role.
+   First migration that needs it; older R0–R5 migrations don't.
+3. To opt in via REST, append `?mode=keyword-first`. To opt in via
+   GraphQL, pass `mode: "keyword-first"`. Default behavior is
+   byte-identical to R4.
+4. To inspect scoring on a dev / preview environment: append
+   `&debug=true` AND make the request from an allowlisted origin
+   (any origin in non-production by default; explicit
+   `SEARCH_DEBUG_ALLOWED_ORIGINS` CSV overrides). Curl needs an
+   explicit `-H "Origin: <allowlisted>"` header.
+5. Verify GIN indexes are used. Probe SQL:
+   `EXPLAIN ANALYZE SELECT v.id FROM video_locale vl JOIN video v ON
+v.id = vl.video_id WHERE setweight(vl.title_tsv,'A') ||
+setweight(vl.description_tsv,'B') @@
+websearch_to_tsquery('simple', 'jesus') AND vl.locale = 'en'
+LIMIT 10;`
+   should show `Bitmap Index Scan on
+video_locale_lexical_weighted_idx`. Trigram probe:
+   `… WHERE vl.title %> 'jesus' …` should show
+   `video_locale_title_trgm_idx`.
+6. R0 dependency: admin's `video` / `video_locale` tables are 0 rows
+   in prod. Real-DB integration tests (canary diff vs cms keyword-first,
+   EXPLAIN-based GIN verification) are deferred to R0 readiness.
+
+**Common things to remember:**
+
+- The hybrid path is byte-identical to R4. Touching it without
+  updating `hybrid-search.regression.test.ts` is the definition of a
+  regression. Per `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md`.
+- `searchMode` (response field) ≠ `mode` (input arg). The response
+  reports embedding-degradation; the input selects the pipeline.
+  GraphQL schema description on `Query.search.mode` explicitly
+  disambiguates.
+- Retriever labels in the debug payload are UNSTABLE — never branch
+  on them in production code.
+- `Prisma.raw(EXPR)` is reserved for the unbindable weighted tsvector
+  fragment. Bound parameters interpolate via `${expr}` in the
+  template literal. `searchByExactTitle` uses `Prisma.join` to
+  compose the variable-length AND-chain so the placeholder count
+  always matches the bound-value count (Postgres rejects unbound
+  placeholders at parse time, which is the safe failure mode).
+- The dilution cap is invisible on thematic queries
+  (`q="hope when life is hard"`) — those have no exact-title trigger,
+  so the cap silently does nothing. Hard filtering is intentionally
+  NOT used.
+
+The primary learnings doc is
+`docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.
+
 ## Scene recommendations (R5 of admin migration playbook)
 
 Admin owns public scene-similarity recommendations — given a seed video

--- a/apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql
+++ b/apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql
@@ -1,0 +1,65 @@
+-- R4-extension: keyword-first lexical search infrastructure.
+--
+-- Provisions the DB shape both modes can sit on while staying dormant
+-- on the hybrid path. The legacy `video_locale_fulltext_search_idx`
+-- from `0006_hybrid_search_gin/migration.sql` is intentionally untouched
+-- — `searchVideoKeyword` (R4) keeps reading it.
+--
+-- Three pieces:
+--   1. `pg_trgm` extension (idempotent; first migration that needs it).
+--   2. Two STORED generated tsvector columns on `video_locale`:
+--      `title_tsv` and `description_tsv`. They derive from the canonical
+--      `title` / `description` columns; rewriting either canonical field
+--      automatically refreshes its tsvector.
+--   3. Two GIN indexes:
+--      - `video_locale_lexical_weighted_idx` over the per-field weighted
+--        tsvector `(setweight(title_tsv,'A') || setweight(description_tsv,'B'))`.
+--        Backs the `searchByKeywordWeighted` retriever in keyword-first
+--        mode. Title-tier weight (A) outranks description-tier weight (B)
+--        so a query word that lands in the title beats the same word in
+--        the description.
+--      - `video_locale_title_trgm_idx` over `title` with `gin_trgm_ops`.
+--        Backs the `searchByTrigram` retriever for typo-tolerant lookup.
+--
+-- Byte-parity invariant: the generated-column expressions and the
+-- weighted GIN index expression below MUST stay byte-equal to the
+-- corresponding `*_GENERATED_EXPR` and `WEIGHTED_TSV_INDEX_EXPR`
+-- constants in `src/services/hybrid-search-sql.ts`. The planner only
+-- matches expression-based GIN indexes when the query-side expression
+-- is character-for-character identical to the indexed expression.
+-- `hybrid-search-sql.test.ts` enforces this by reading this file at
+-- test time.
+--
+-- The trigram path uses operator-class GIN (`gin_trgm_ops`) and does
+-- NOT need a TS shared constant — operator-class indexes are selected
+-- by the operator (`%>`) regardless of alias prefixes. Per
+-- docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md.
+--
+-- Generated-column drift trap: any future change to the
+-- `*_GENERATED_EXPR` constants requires a coordinated
+-- `DROP COLUMN ... CASCADE + ADD COLUMN ... GENERATED ALWAYS AS (...)`
+-- migration. ALTER COLUMN cannot edit a generated expression in place.
+-- Per docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md.
+--
+-- Created non-CONCURRENTLY for the same reason as `0006_hybrid_search_gin`:
+-- admin deploys against a near-empty corpus today and the AccessExclusiveLock
+-- is acceptable. Future re-creations against a populated corpus should
+-- use `CREATE INDEX CONCURRENTLY` in a `prisma:no_transaction` migration.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+ALTER TABLE "video_locale"
+  ADD COLUMN IF NOT EXISTS "title_tsv" tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', coalesce(title, ''))) STORED;
+
+ALTER TABLE "video_locale"
+  ADD COLUMN IF NOT EXISTS "description_tsv" tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', coalesce(description, ''))) STORED;
+
+CREATE INDEX IF NOT EXISTS "video_locale_lexical_weighted_idx"
+  ON "video_locale"
+  USING GIN ((setweight(title_tsv, 'A') || setweight(description_tsv, 'B')));
+
+CREATE INDEX IF NOT EXISTS "video_locale_title_trgm_idx"
+  ON "video_locale"
+  USING GIN (title gin_trgm_ops);

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -620,19 +620,31 @@ model Video {
 /// Per-locale Video content. Editors curate localized title / description /
 /// snippet / imageAlt and publish them independently of other locales.
 model VideoLocale {
-  id          String       @id @default(cuid())
-  videoId     String       @map("video_id")
-  video       Video        @relation(fields: [videoId], references: [id], onDelete: Cascade)
+  id             String                       @id @default(cuid())
+  videoId        String                       @map("video_id")
+  video          Video                        @relation(fields: [videoId], references: [id], onDelete: Cascade)
   /// IETF BCP-47 locale code, e.g. "en", "fr", "es-419".
-  locale      String
-  title       String?
-  description String?
-  snippet     String?
-  imageAlt    String?      @map("image_alt")
-  status      LocaleStatus @default(DRAFT)
-  publishedAt DateTime?    @map("published_at")
-  createdAt   DateTime     @default(now()) @map("created_at")
-  updatedAt   DateTime     @updatedAt @map("updated_at")
+  locale         String
+  title          String?
+  description    String?
+  snippet        String?
+  imageAlt       String?                      @map("image_alt")
+  status         LocaleStatus                 @default(DRAFT)
+  publishedAt    DateTime?                    @map("published_at")
+  createdAt      DateTime                     @default(now()) @map("created_at")
+  updatedAt      DateTime                     @updatedAt @map("updated_at")
+  /// STORED generated tsvector columns — derived from `title` /
+  /// `description` by `0009_keyword_first_lexical/migration.sql`. Backed by
+  /// `video_locale_lexical_weighted_idx` (GIN over the per-field weighted
+  /// expression). Service code reads these via `Prisma.raw` only — Prisma
+  /// has no first-class generated-tsvector column type, so we expose the
+  /// columns to introspection through `Unsupported(...)?` placeholders to
+  /// keep `prisma migrate dev` from offering to drop them. Any change to
+  /// the generated expression requires a coordinated DROP CASCADE + ADD
+  /// COLUMN migration (Postgres has no in-place editor for stored
+  /// generated expressions).
+  titleTsv       Unsupported("tsvector")?     @map("title_tsv")
+  descriptionTsv Unsupported("tsvector")?     @map("description_tsv")
 
   @@unique([videoId, locale])
   @@index([locale])

--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -19,7 +19,12 @@ vi.mock("@/services/hybrid-search.service", async () => {
 
 vi.mock("@/db/client", () => ({ prisma: {} }))
 
+vi.mock("@/services/hybrid-search-debug-allowlist", () => ({
+  isDebugAllowedForOrigin: vi.fn(),
+}))
+
 import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
 import { GET } from "./route"
 
 const allowRateLimit = () =>
@@ -38,9 +43,18 @@ function req(path: string): Request {
   return new Request(`http://localhost${path}`, { method: "GET" })
 }
 
+function reqWithOrigin(path: string, origin: string): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "GET",
+    headers: { origin },
+  })
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   allowRateLimit()
+  // Default: deny debug. Individual tests opt in.
+  vi.mocked(isDebugAllowedForOrigin).mockReturnValue(false)
   searchMock.mockResolvedValue({
     results: [],
     hasMore: false,
@@ -165,6 +179,64 @@ describe("GET /api/search", () => {
     await GET(req("/api/search?q=jesus&locale=en"))
     const call = searchMock.mock.calls[0][0]
     expect(call.mode).toBeUndefined()
+  })
+
+  it("debug=true with allowlisted origin → service called with debug:true", async () => {
+    vi.mocked(isDebugAllowedForOrigin).mockReturnValue(true)
+    await GET(
+      reqWithOrigin(
+        "/api/search?q=jesus&locale=en&debug=true",
+        "http://localhost:3003",
+      ),
+    )
+    expect(isDebugAllowedForOrigin).toHaveBeenCalledWith(
+      "http://localhost:3003",
+    )
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: true }),
+    )
+  })
+
+  it("debug=true with disallowed origin → service called with debug:false", async () => {
+    vi.mocked(isDebugAllowedForOrigin).mockReturnValue(false)
+    await GET(
+      reqWithOrigin(
+        "/api/search?q=jesus&locale=en&debug=true",
+        "https://attacker.test",
+      ),
+    )
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false }),
+    )
+  })
+
+  it("debug=true without Origin header → fails closed (debug:false)", async () => {
+    // No Origin header at all.
+    await GET(req("/api/search?q=jesus&locale=en&debug=true"))
+    expect(isDebugAllowedForOrigin).toHaveBeenCalledWith(undefined)
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false }),
+    )
+  })
+
+  it("debug omitted → service called with debug:false (no allowlist consultation needed)", async () => {
+    await GET(req("/api/search?q=jesus&locale=en"))
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false }),
+    )
+  })
+
+  it("debug=1 (truthy non-'true' value) is treated as opt-out", async () => {
+    vi.mocked(isDebugAllowedForOrigin).mockReturnValue(true)
+    await GET(
+      reqWithOrigin(
+        "/api/search?q=jesus&locale=en&debug=1",
+        "http://localhost:3003",
+      ),
+    )
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false }),
+    )
   })
 
   it("returns 503 when service throws", async () => {

--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -141,6 +141,32 @@ describe("GET /api/search", () => {
     expect(res.status).toBe(429)
   })
 
+  it("forwards mode='keyword-first' to the service", async () => {
+    await GET(req("/api/search?q=jesus&locale=en&mode=keyword-first"))
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "keyword-first" }),
+    )
+  })
+
+  it("forwards arbitrary mode values verbatim (service warn-and-falls-back)", async () => {
+    await GET(req("/api/search?q=jesus&locale=en&mode=garbage"))
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "garbage" }),
+    )
+  })
+
+  it("treats empty mode (?mode=) as undefined to avoid polluting the warn log", async () => {
+    await GET(req("/api/search?q=jesus&locale=en&mode="))
+    const call = searchMock.mock.calls[0][0]
+    expect(call.mode).toBeUndefined()
+  })
+
+  it("treats omitted mode as undefined", async () => {
+    await GET(req("/api/search?q=jesus&locale=en"))
+    const call = searchMock.mock.calls[0][0]
+    expect(call.mode).toBeUndefined()
+  })
+
   it("returns 503 when service throws", async () => {
     searchMock.mockRejectedValueOnce(new Error("boom"))
     const res = await GET(req("/api/search?q=jesus&locale=en"))

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -18,6 +18,20 @@ import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlis
 const RATE_LIMIT_MAX = 30
 const RATE_LIMIT_WINDOW_MS = 60_000
 
+/**
+ * Hard upper bound on the trimmed `q` parameter length. Above this the
+ * request is rejected at the boundary instead of being passed through to
+ * `websearch_to_tsquery` / `similarity()` (the keyword-first retrievers)
+ * or to the embedding provider (semantic). 1024 chars is well above any
+ * natural-language search query (the longest known song title is ~70
+ * characters; a paragraph is ~500) and well below the regimes where the
+ * Postgres tsquery parser starts spending meaningful CPU. The matching
+ * per-token cap (`MAX_EXACT_TITLE_TOKENS = 16`) lives inside
+ * `searchByExactTitle`; the length cap covers the other two retrievers
+ * + the embedding provider input.
+ */
+const MAX_QUERY_LENGTH = 1024
+
 function badRequest(error: string): Response {
   return Response.json({ error }, { status: 400 })
 }
@@ -46,6 +60,9 @@ export async function GET(request: Request): Promise<Response> {
   const q = searchParams.get("q")?.trim() ?? ""
   if (q.length === 0) {
     return badRequest("q (search query) is required")
+  }
+  if (q.length > MAX_QUERY_LENGTH) {
+    return badRequest(`q must be at most ${MAX_QUERY_LENGTH} characters`)
   }
 
   const locale = searchParams.get("locale")

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -13,6 +13,7 @@ import {
   isContentType,
   type ContentType,
 } from "@/services/hybrid-search.service"
+import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
 
 const RATE_LIMIT_MAX = 30
 const RATE_LIMIT_WINDOW_MS = 60_000
@@ -71,6 +72,17 @@ export async function GET(request: Request): Promise<Response> {
   const rawMode = searchParams.get("mode")
   const mode = rawMode != null && rawMode.length > 0 ? rawMode : undefined
 
+  // `debug=true` opts into the per-result internal scoring payload.
+  // Origin-gated at the boundary (the service trusts the boolean):
+  // a curl-from-prod with no `Origin` header is fail-closed; a
+  // browser request from a non-allowlisted origin is also rejected.
+  // Any other truthy value (e.g. `?debug=1`) is intentionally treated
+  // as "off" — debug is a deliberate developer affordance, not a
+  // pattern-matching toggle.
+  const debugRequested = searchParams.get("debug") === "true"
+  const origin = request.headers.get("origin") ?? undefined
+  const debug = debugRequested && isDebugAllowedForOrigin(origin)
+
   try {
     const service = new HybridSearchService({ prisma })
     const result = await service.search({
@@ -80,6 +92,7 @@ export async function GET(request: Request): Promise<Response> {
       offset: offsetParam,
       contentTypes,
       mode,
+      debug,
     })
     return Response.json(result, { status: 200 })
   } catch (error) {

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -64,6 +64,13 @@ export async function GET(request: Request): Promise<Response> {
   const limitParam = parseNumericParam(searchParams.get("limit"))
   const offsetParam = parseNumericParam(searchParams.get("offset"))
 
+  // `mode` is a free-form string at the boundary so future modes can
+  // ship without REST schema changes. The service's `normalizeMode`
+  // warn-and-falls-back on unknown values; we forward the empty string
+  // as undefined so logs aren't polluted on bare `?mode=`.
+  const rawMode = searchParams.get("mode")
+  const mode = rawMode != null && rawMode.length > 0 ? rawMode : undefined
+
   try {
     const service = new HybridSearchService({ prisma })
     const result = await service.search({
@@ -72,6 +79,7 @@ export async function GET(request: Request): Promise<Response> {
       limit: limitParam,
       offset: offsetParam,
       contentTypes,
+      mode,
     })
     return Response.json(result, { status: 200 })
   } catch (error) {

--- a/apps/admin/src/graphql/queries/hybrid-search.test.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.test.ts
@@ -23,7 +23,12 @@ vi.mock("@/services/hybrid-search.service", async () => {
 
 vi.mock("@/db/client", () => ({ prisma: {} }))
 
+vi.mock("@/services/hybrid-search-debug-allowlist", () => ({
+  isDebugAllowedForOrigin: vi.fn(),
+}))
+
 import { schema } from "@/graphql/schema"
+import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
 
 type ResolverArgs = {
   q: string
@@ -32,13 +37,23 @@ type ResolverArgs = {
   limit?: number
   offset?: number
   mode?: string | null
+  debug?: boolean | null
+}
+
+type ResolverCtx = {
+  request?: { headers?: Headers | { get(name: string): string | null } }
+}
+
+function ctxWithOrigin(origin: string | undefined): ResolverCtx {
+  if (origin == null) return { request: { headers: new Headers() } }
+  return { request: { headers: new Headers({ origin }) } }
 }
 
 type FieldWithResolve = {
   resolve: (
     root: unknown,
     args: ResolverArgs,
-    ctx: unknown,
+    ctx: ResolverCtx,
     info: unknown,
   ) => unknown
 }
@@ -49,13 +64,17 @@ function getResolver(): FieldWithResolve["resolve"] {
   return field.resolve
 }
 
-async function invoke(args: ResolverArgs) {
+async function invoke(
+  args: ResolverArgs,
+  ctx: ResolverCtx = ctxWithOrigin(undefined),
+) {
   const resolve = getResolver()
-  return resolve(null, args, {}, {})
+  return resolve(null, args, ctx, {})
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(isDebugAllowedForOrigin).mockReturnValue(false)
   searchMock.mockResolvedValue({
     results: [],
     hasMore: false,
@@ -139,6 +158,51 @@ describe("Query.search resolver", () => {
         limit: 5,
         offset: 10,
       }),
+    )
+  })
+})
+
+describe("Query.search debug arg + origin gating", () => {
+  it("debug=true with allowlisted origin → service called with debug:true", async () => {
+    vi.mocked(isDebugAllowedForOrigin).mockReturnValue(true)
+    await invoke(
+      { q: "jesus", locale: "en", debug: true },
+      ctxWithOrigin("http://localhost:3003"),
+    )
+    expect(isDebugAllowedForOrigin).toHaveBeenCalledWith(
+      "http://localhost:3003",
+    )
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: true }),
+    )
+  })
+
+  it("debug=true with disallowed origin → service called with debug:false", async () => {
+    vi.mocked(isDebugAllowedForOrigin).mockReturnValue(false)
+    await invoke(
+      { q: "jesus", locale: "en", debug: true },
+      ctxWithOrigin("https://attacker.test"),
+    )
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false }),
+    )
+  })
+
+  it("debug=true without Origin header → fails closed (debug:false)", async () => {
+    await invoke(
+      { q: "jesus", locale: "en", debug: true },
+      ctxWithOrigin(undefined),
+    )
+    expect(isDebugAllowedForOrigin).toHaveBeenCalledWith(undefined)
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false }),
+    )
+  })
+
+  it("debug omitted → service called with debug:false", async () => {
+    await invoke({ q: "jesus", locale: "en" })
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: false }),
     )
   })
 })

--- a/apps/admin/src/graphql/queries/hybrid-search.test.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Execution tests for the public `search` GraphQL query resolver.
+ *
+ * Invokes the resolver function directly via `schema.getFields()` to
+ * dodge vitest's transitive-graphql double-instance issue (same
+ * pattern used by `scene-recommendations.test.ts`). Mocks
+ * HybridSearchService so we verify resolver wiring + arg validation
+ * + mode plumbing without touching the DB or the embedding provider.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const searchMock = vi.fn()
+vi.mock("@/services/hybrid-search.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/services/hybrid-search.service")
+  >("@/services/hybrid-search.service")
+  return {
+    ...actual,
+    HybridSearchService: vi.fn(() => ({ search: searchMock })),
+  }
+})
+
+vi.mock("@/db/client", () => ({ prisma: {} }))
+
+import { schema } from "@/graphql/schema"
+
+type ResolverArgs = {
+  q: string
+  locale: string
+  type?: "video" | "experience"
+  limit?: number
+  offset?: number
+  mode?: string | null
+}
+
+type FieldWithResolve = {
+  resolve: (
+    root: unknown,
+    args: ResolverArgs,
+    ctx: unknown,
+    info: unknown,
+  ) => unknown
+}
+
+function getResolver(): FieldWithResolve["resolve"] {
+  const fields = schema.getQueryType()!.getFields()
+  const field = fields.search as unknown as FieldWithResolve
+  return field.resolve
+}
+
+async function invoke(args: ResolverArgs) {
+  const resolve = getResolver()
+  return resolve(null, args, {}, {})
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  searchMock.mockResolvedValue({
+    results: [],
+    hasMore: false,
+    query: "",
+    searchMode: "hybrid",
+  })
+})
+
+describe("Query.search resolver", () => {
+  it("rejects empty / whitespace-only q", async () => {
+    await expect(invoke({ q: "   ", locale: "en" })).rejects.toThrow(/q/)
+    expect(searchMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects empty locale", async () => {
+    await expect(invoke({ q: "jesus", locale: "" })).rejects.toThrow(/locale/)
+  })
+
+  it("rejects unknown content type", async () => {
+    // Pothos enum normally rejects this at parse time; the resolver also
+    // guards in case a caller passes a raw string through a custom client.
+    await expect(
+      invoke({
+        q: "jesus",
+        locale: "en",
+        type: "foo" as unknown as "video",
+      }),
+    ).rejects.toThrow(/type/)
+  })
+
+  it("forwards canonical mode='keyword-first' to the service", async () => {
+    await invoke({ q: "jesus", locale: "en", mode: "keyword-first" })
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "keyword-first" }),
+    )
+  })
+
+  it("forwards mode='hybrid' explicitly", async () => {
+    await invoke({ q: "jesus", locale: "en", mode: "hybrid" })
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "hybrid" }),
+    )
+  })
+
+  it("forwards arbitrary mode values verbatim (service warn-and-falls-back)", async () => {
+    await invoke({ q: "jesus", locale: "en", mode: "garbage" })
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "garbage" }),
+    )
+  })
+
+  it("treats empty mode (mode: '') as undefined", async () => {
+    await invoke({ q: "jesus", locale: "en", mode: "" })
+    const call = searchMock.mock.calls[0]![0]
+    expect(call.mode).toBeUndefined()
+  })
+
+  it("treats null mode as undefined", async () => {
+    await invoke({ q: "jesus", locale: "en", mode: null })
+    const call = searchMock.mock.calls[0]![0]
+    expect(call.mode).toBeUndefined()
+  })
+
+  it("treats missing mode as undefined", async () => {
+    await invoke({ q: "jesus", locale: "en" })
+    const call = searchMock.mock.calls[0]![0]
+    expect(call.mode).toBeUndefined()
+  })
+
+  it("forwards trimmed q + locale + limit + offset to the service", async () => {
+    await invoke({
+      q: "  jesus  ",
+      locale: "es",
+      limit: 5,
+      offset: 10,
+    })
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "jesus",
+        locale: "es",
+        limit: 5,
+        offset: 10,
+      }),
+    )
+  })
+})
+
+describe("schema description on Query.search.mode arg", () => {
+  it("disambiguates from the searchMode response field", () => {
+    const field = schema.getQueryType()!.getFields().search!
+    const modeArg = field.args.find((a) => a.name === "mode")
+    expect(modeArg).toBeDefined()
+    const description = modeArg!.description ?? ""
+    expect(description).toMatch(/searchMode/)
+    expect(description.toLowerCase()).toMatch(/orthogonal/)
+  })
+})

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -98,6 +98,11 @@ builder.queryFields((t) => ({
       type: t.arg({ type: ContentTypeEnum, required: false }),
       limit: t.arg.int({ required: false }),
       offset: t.arg.int({ required: false }),
+      mode: t.arg.string({
+        required: false,
+        description:
+          "Selects the retrieval pipeline. Default: 'hybrid' (the R4 baseline). Currently accepts 'hybrid' and 'keyword-first'. Unknown values fall back to 'hybrid' with a server-side warn log; never throws. Kept as a nullable String (not an enum) so future modes ship without GraphQL schema changes. ORTHOGONAL to the response field `searchMode`, which reports the embedding-degradation signal ('hybrid' | 'keyword-only') based on whether semantic retrieval ran — these two share a name but answer different questions.",
+      }),
     },
     resolve: async (_root, args, _ctx) => {
       const query = args.q.trim()
@@ -117,6 +122,13 @@ builder.queryFields((t) => ({
         contentTypes = [raw]
       }
 
+      // `mode` stays a free-form string at the boundary; the service's
+      // `normalizeMode` warn-and-falls-back on unknown values. Empty
+      // string is forwarded as undefined so an explicit `mode: ""` from
+      // a client doesn't pollute the warn log.
+      const rawMode = args.mode ?? undefined
+      const mode = rawMode != null && rawMode.length > 0 ? rawMode : undefined
+
       const service = new HybridSearchService({ prisma })
       return service.search({
         query,
@@ -124,6 +136,7 @@ builder.queryFields((t) => ({
         limit: args.limit ?? undefined,
         offset: args.offset ?? undefined,
         contentTypes,
+        mode,
       })
     },
   }),

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -86,6 +86,8 @@ SearchResponseRef.implement({
     searchMode: t.field({
       type: SearchModeEnum,
       nullable: false,
+      description:
+        "Embedding-degradation signal — 'hybrid' when semantic retrieval ran, 'keyword-only' when the embedding provider failed. ORTHOGONAL to the input arg `mode`, which selects the retrieval pipeline. Same name, different concern.",
       resolve: (r) => r.searchMode,
     }),
   }),
@@ -123,6 +125,14 @@ builder.queryFields((t) => ({
       if (query.length === 0) {
         throw new Error("q (search query) is required")
       }
+      // Length cap mirrors the REST handler (`MAX_QUERY_LENGTH = 1024`).
+      // Bounds the input that flows into `websearch_to_tsquery`,
+      // `similarity()`, and the embedding provider — the per-token
+      // `MAX_EXACT_TITLE_TOKENS = 16` cap inside `searchByExactTitle`
+      // covers a different scenario.
+      if (query.length > 1024) {
+        throw new Error("q must be at most 1024 characters")
+      }
       if (!args.locale || args.locale.length === 0) {
         throw new Error("locale is required")
       }
@@ -148,7 +158,8 @@ builder.queryFields((t) => ({
       // closed. The service trusts the boolean — this is the only
       // place that consults the allowlist.
       const debugRequested = args.debug === true
-      const origin = ctx.request?.headers?.get("origin") ?? undefined
+      // ContextShape.request is non-nullable Request; same for Headers.
+      const origin = ctx.request.headers.get("origin") ?? undefined
       const debug = debugRequested && isDebugAllowedForOrigin(origin)
 
       const service = new HybridSearchService({ prisma })

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -17,6 +17,8 @@ import {
   type SearchResult,
   type SearchResponse,
 } from "@/services/hybrid-search.service"
+import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
+import { SearchResultDebugRef } from "@/graphql/types/hybrid-search-debug"
 
 // -----------------------------------------------------------------------------
 // Types
@@ -57,6 +59,13 @@ SearchResultRef.implement({
     startSeconds: t.exposeFloat("startSeconds", { nullable: true }),
     playbackId: t.exposeString("playbackId", { nullable: true }),
     score: t.exposeFloat("score", { nullable: false }),
+    debug: t.field({
+      type: SearchResultDebugRef,
+      nullable: true,
+      description:
+        "Internal scoring detail. Present only when the caller passed `debug: true` AND the request origin is on the debug allowlist. Origin-gating happens at the resolver boundary; the service trusts the boolean.",
+      resolve: (r) => r.debug ?? null,
+    }),
   }),
 })
 
@@ -103,8 +112,13 @@ builder.queryFields((t) => ({
         description:
           "Selects the retrieval pipeline. Default: 'hybrid' (the R4 baseline). Currently accepts 'hybrid' and 'keyword-first'. Unknown values fall back to 'hybrid' with a server-side warn log; never throws. Kept as a nullable String (not an enum) so future modes ship without GraphQL schema changes. ORTHOGONAL to the response field `searchMode`, which reports the embedding-degradation signal ('hybrid' | 'keyword-only') based on whether semantic retrieval ran — these two share a name but answer different questions.",
       }),
+      debug: t.arg.boolean({
+        required: false,
+        description:
+          "When true, attaches internal scoring detail under `result.debug` (per-retriever ranks, fused score, dilution-cap state). Origin-gated at the resolver: requests from non-allowlisted origins (production browsers) silently get the payload stripped. Treat this as a soft feature flag — Origin headers are NOT an authentication mechanism.",
+      }),
     },
-    resolve: async (_root, args, _ctx) => {
+    resolve: async (_root, args, ctx) => {
       const query = args.q.trim()
       if (query.length === 0) {
         throw new Error("q (search query) is required")
@@ -129,6 +143,14 @@ builder.queryFields((t) => ({
       const rawMode = args.mode ?? undefined
       const mode = rawMode != null && rawMode.length > 0 ? rawMode : undefined
 
+      // `debug` is origin-gated. Yoga sets `Origin` from the underlying
+      // Request; if absent (server-to-server, curl) the gate fails
+      // closed. The service trusts the boolean — this is the only
+      // place that consults the allowlist.
+      const debugRequested = args.debug === true
+      const origin = ctx.request?.headers?.get("origin") ?? undefined
+      const debug = debugRequested && isDebugAllowedForOrigin(origin)
+
       const service = new HybridSearchService({ prisma })
       return service.search({
         query,
@@ -137,6 +159,7 @@ builder.queryFields((t) => ({
         offset: args.offset ?? undefined,
         contentTypes,
         mode,
+        debug,
       })
     },
   }),

--- a/apps/admin/src/graphql/schema.test.ts
+++ b/apps/admin/src/graphql/schema.test.ts
@@ -370,6 +370,49 @@ describe("Hybrid search — R4 query + response types", () => {
     }
   })
 
+  it("HybridSearchResultDebug exposes ranks + fusedScore + dilutionCapApplied (no embedding leak)", () => {
+    const fields = fieldsOf("HybridSearchResultDebug") as Record<
+      string,
+      { type: { toString(): string } }
+    >
+    expect(Object.keys(fields)).toEqual(
+      expect.arrayContaining([
+        "retrieverRanks",
+        "fusedScore",
+        "dilutionCapApplied",
+      ]),
+    )
+    for (const key of Object.keys(fields)) {
+      expect(key).not.toMatch(/embed|vector|similarit/i)
+    }
+    expect(fields.fusedScore.type.toString()).toBe("Float!")
+    expect(fields.dilutionCapApplied.type.toString()).toBe("Boolean!")
+    expect(fields.retrieverRanks.type.toString()).toBe(
+      "[HybridSearchRetrieverRank!]!",
+    )
+  })
+
+  it("HybridSearchRetrieverRank carries label + rank only (no embedding leak)", () => {
+    const fields = fieldsOf("HybridSearchRetrieverRank") as Record<
+      string,
+      { type: { toString(): string } }
+    >
+    expect(Object.keys(fields).sort()).toEqual(["label", "rank"])
+    for (const key of Object.keys(fields)) {
+      expect(key).not.toMatch(/embed|vector|similarit/i)
+    }
+    expect(fields.label.type.toString()).toBe("String!")
+    expect(fields.rank.type.toString()).toBe("Int!")
+  })
+
+  it("HybridSearchResult exposes a nullable debug field gated at the resolver", () => {
+    const fields = fieldsOf("HybridSearchResult") as Record<
+      string,
+      { type: { toString(): string } }
+    >
+    expect(fields.debug.type.toString()).toBe("HybridSearchResultDebug")
+  })
+
   it("HybridSearchResponse wraps results + hasMore + query + searchMode", () => {
     const fields = fieldsOf("HybridSearchResponse") as Record<
       string,

--- a/apps/admin/src/graphql/schema.ts
+++ b/apps/admin/src/graphql/schema.ts
@@ -16,6 +16,9 @@ import "@/graphql/mutations/scene-embedding"
 import "@/graphql/mutations/transcript-embedding"
 import "@/graphql/mutations/experience-content-dump"
 import "@/graphql/queries/search"
+// Debug-payload types must register before the hybrid-search query
+// references them via SearchResultDebugRef.
+import "@/graphql/types/hybrid-search-debug"
 import "@/graphql/queries/hybrid-search"
 import "@/graphql/queries/scene-recommendations"
 import "@/graphql/queries/sync-status"

--- a/apps/admin/src/graphql/types/hybrid-search-debug.ts
+++ b/apps/admin/src/graphql/types/hybrid-search-debug.ts
@@ -1,0 +1,44 @@
+/**
+ * Pothos types for the optional `debug` payload on `HybridSearchResult`.
+ *
+ * Surfaced only when the caller passed `debug: true` AND the request
+ * origin is on the debug allowlist. Stripped silently otherwise.
+ *
+ * @classification public-shape
+ */
+
+import { builder } from "@/graphql/builder"
+import type { SearchResultDebug } from "@/services/hybrid-search.service"
+
+const SearchRetrieverRankRef = builder.objectRef<
+  SearchResultDebug["retrieverRanks"][number]
+>("HybridSearchRetrieverRank")
+
+SearchRetrieverRankRef.implement({
+  description:
+    "One contributing retriever's rank for a single fused result. The `label` is an UNSTABLE internal name (e.g. 'semantic-video', 'keyword-weighted-video', 'trigram-video', 'exact-title-video') — it MAY be renamed without a breaking-change marker. Operators inspecting the payload during triage are the intended audience; do NOT branch on these strings in production code.",
+  fields: (t) => ({
+    label: t.exposeString("label", { nullable: false }),
+    rank: t.exposeInt("rank", { nullable: false }),
+  }),
+})
+
+export const SearchResultDebugRef = builder.objectRef<SearchResultDebug>(
+  "HybridSearchResultDebug",
+)
+
+SearchResultDebugRef.implement({
+  description:
+    "Per-result internal scoring detail. Origin-gated at the boundary; absent when the caller didn't request `debug` or the origin isn't on the allowlist. Carries no embedding vectors, no PII, and no credentials — only the per-retriever ranks that produced this hit, the fused RRF score, and whether the keyword-first dilution cap down-weighted the row.",
+  fields: (t) => ({
+    retrieverRanks: t.field({
+      type: [SearchRetrieverRankRef],
+      nullable: false,
+      resolve: (r) => r.retrieverRanks,
+    }),
+    fusedScore: t.exposeFloat("fusedScore", { nullable: false }),
+    dilutionCapApplied: t.exposeBoolean("dilutionCapApplied", {
+      nullable: false,
+    }),
+  }),
+})

--- a/apps/admin/src/graphql/types/hybrid-search-debug.ts
+++ b/apps/admin/src/graphql/types/hybrid-search-debug.ts
@@ -34,11 +34,19 @@ SearchResultDebugRef.implement({
     retrieverRanks: t.field({
       type: [SearchRetrieverRankRef],
       nullable: false,
+      description:
+        "Per-list contributions that produced this fused result, in dispatch order (semantic-video, keyword-* / lexical retrievers, semantic-experience, keyword-experience). Each entry's `rank` is 1-based.",
       resolve: (r) => r.retrieverRanks,
     }),
-    fusedScore: t.exposeFloat("fusedScore", { nullable: false }),
+    fusedScore: t.exposeFloat("fusedScore", {
+      nullable: false,
+      description:
+        "Reciprocal Rank Fusion score BEFORE the keyword-first dilution cap. The visible `score` field on `HybridSearchResult` reflects the post-cap value; comparing the two reveals exactly how much the cap down-weighted this row (0.5× when `dilutionCapApplied` is true, identical otherwise).",
+    }),
     dilutionCapApplied: t.exposeBoolean("dilutionCapApplied", {
       nullable: false,
+      description:
+        "Whether the keyword-first semantic-dilution cap halved this row's score. The cap only runs in `mode=\"keyword-first\"` when an exact-title hit covered every query token. In hybrid mode the cap never runs — the field reads `false` because 'cap was not applicable on this code path', NOT because 'cap considered this row and chose not to'. Use `mode` alongside this flag to interpret it correctly.",
     }),
   }),
 })

--- a/apps/admin/src/services/hybrid-search-debug-allowlist.test.ts
+++ b/apps/admin/src/services/hybrid-search-debug-allowlist.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { isDebugAllowedForOrigin } from "./hybrid-search-debug-allowlist"
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
+const ORIGINAL_ALLOWLIST = process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV
+  if (ORIGINAL_ALLOWLIST != null) {
+    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS = ORIGINAL_ALLOWLIST
+  } else {
+    delete process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
+  }
+})
+
+describe("isDebugAllowedForOrigin", () => {
+  it("fails closed when origin is undefined", () => {
+    expect(isDebugAllowedForOrigin(undefined)).toBe(false)
+  })
+
+  it("fails closed when origin is empty string", () => {
+    expect(isDebugAllowedForOrigin("")).toBe(false)
+  })
+
+  it("uses explicit allowlist when SEARCH_DEBUG_ALLOWED_ORIGINS is set (production)", () => {
+    process.env.NODE_ENV = "production"
+    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS =
+      "https://staging.admin.jesusfilm.org, https://debug.admin.jesusfilm.org"
+    expect(isDebugAllowedForOrigin("https://staging.admin.jesusfilm.org")).toBe(
+      true,
+    )
+    expect(isDebugAllowedForOrigin("https://admin.jesusfilm.org")).toBe(false)
+    expect(isDebugAllowedForOrigin("https://attacker.test")).toBe(false)
+  })
+
+  it("rejects all origins when explicit allowlist is set but does not include the origin (non-prod)", () => {
+    process.env.NODE_ENV = "development"
+    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS = "https://staging.example"
+    expect(isDebugAllowedForOrigin("http://localhost:3003")).toBe(false)
+    expect(isDebugAllowedForOrigin("https://staging.example")).toBe(true)
+  })
+
+  it("falls back to non-production heuristic when allowlist env is unset", () => {
+    delete process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
+    process.env.NODE_ENV = "development"
+    expect(isDebugAllowedForOrigin("http://localhost:3003")).toBe(true)
+    expect(isDebugAllowedForOrigin("https://preview.example")).toBe(true)
+  })
+
+  it("denies all origins in production when allowlist env is unset", () => {
+    delete process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
+    process.env.NODE_ENV = "production"
+    expect(isDebugAllowedForOrigin("https://admin.jesusfilm.org")).toBe(false)
+  })
+
+  it("treats whitespace-only allowlist as if unset (falls back to NODE_ENV)", () => {
+    process.env.NODE_ENV = "development"
+    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS = "   "
+    expect(isDebugAllowedForOrigin("http://localhost:3003")).toBe(true)
+  })
+
+  it("trims allowlist entries", () => {
+    process.env.NODE_ENV = "production"
+    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS =
+      "  https://staging.example  ,  https://debug.example  "
+    expect(isDebugAllowedForOrigin("https://staging.example")).toBe(true)
+    expect(isDebugAllowedForOrigin("https://debug.example")).toBe(true)
+  })
+})

--- a/apps/admin/src/services/hybrid-search-debug-allowlist.test.ts
+++ b/apps/admin/src/services/hybrid-search-debug-allowlist.test.ts
@@ -1,19 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { isDebugAllowedForOrigin } from "./hybrid-search-debug-allowlist"
 
-const ORIGINAL_NODE_ENV = process.env.NODE_ENV
-const ORIGINAL_ALLOWLIST = process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
+// `env.NODE_ENV` is readonly under Next.js's TS lib, but the
+// runtime allows mutation. Cast through `Record<string,string|undefined>`
+// to mutate without losing the readonly guard elsewhere.
+const env = process.env as Record<string, string | undefined>
+
+const ORIGINAL_NODE_ENV = env.NODE_ENV
+const ORIGINAL_ALLOWLIST = env.SEARCH_DEBUG_ALLOWED_ORIGINS
 
 beforeEach(() => {
   vi.resetModules()
 })
 
 afterEach(() => {
-  process.env.NODE_ENV = ORIGINAL_NODE_ENV
+  env.NODE_ENV = ORIGINAL_NODE_ENV
   if (ORIGINAL_ALLOWLIST != null) {
-    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS = ORIGINAL_ALLOWLIST
+    env.SEARCH_DEBUG_ALLOWED_ORIGINS = ORIGINAL_ALLOWLIST
   } else {
-    delete process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
+    delete env.SEARCH_DEBUG_ALLOWED_ORIGINS
   }
 })
 
@@ -27,8 +32,8 @@ describe("isDebugAllowedForOrigin", () => {
   })
 
   it("uses explicit allowlist when SEARCH_DEBUG_ALLOWED_ORIGINS is set (production)", () => {
-    process.env.NODE_ENV = "production"
-    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS =
+    env.NODE_ENV = "production"
+    env.SEARCH_DEBUG_ALLOWED_ORIGINS =
       "https://staging.admin.jesusfilm.org, https://debug.admin.jesusfilm.org"
     expect(isDebugAllowedForOrigin("https://staging.admin.jesusfilm.org")).toBe(
       true,
@@ -38,34 +43,34 @@ describe("isDebugAllowedForOrigin", () => {
   })
 
   it("rejects all origins when explicit allowlist is set but does not include the origin (non-prod)", () => {
-    process.env.NODE_ENV = "development"
-    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS = "https://staging.example"
+    env.NODE_ENV = "development"
+    env.SEARCH_DEBUG_ALLOWED_ORIGINS = "https://staging.example"
     expect(isDebugAllowedForOrigin("http://localhost:3003")).toBe(false)
     expect(isDebugAllowedForOrigin("https://staging.example")).toBe(true)
   })
 
   it("falls back to non-production heuristic when allowlist env is unset", () => {
-    delete process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
-    process.env.NODE_ENV = "development"
+    delete env.SEARCH_DEBUG_ALLOWED_ORIGINS
+    env.NODE_ENV = "development"
     expect(isDebugAllowedForOrigin("http://localhost:3003")).toBe(true)
     expect(isDebugAllowedForOrigin("https://preview.example")).toBe(true)
   })
 
   it("denies all origins in production when allowlist env is unset", () => {
-    delete process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
-    process.env.NODE_ENV = "production"
+    delete env.SEARCH_DEBUG_ALLOWED_ORIGINS
+    env.NODE_ENV = "production"
     expect(isDebugAllowedForOrigin("https://admin.jesusfilm.org")).toBe(false)
   })
 
   it("treats whitespace-only allowlist as if unset (falls back to NODE_ENV)", () => {
-    process.env.NODE_ENV = "development"
-    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS = "   "
+    env.NODE_ENV = "development"
+    env.SEARCH_DEBUG_ALLOWED_ORIGINS = "   "
     expect(isDebugAllowedForOrigin("http://localhost:3003")).toBe(true)
   })
 
   it("trims allowlist entries", () => {
-    process.env.NODE_ENV = "production"
-    process.env.SEARCH_DEBUG_ALLOWED_ORIGINS =
+    env.NODE_ENV = "production"
+    env.SEARCH_DEBUG_ALLOWED_ORIGINS =
       "  https://staging.example  ,  https://debug.example  "
     expect(isDebugAllowedForOrigin("https://staging.example")).toBe(true)
     expect(isDebugAllowedForOrigin("https://debug.example")).toBe(true)

--- a/apps/admin/src/services/hybrid-search-debug-allowlist.ts
+++ b/apps/admin/src/services/hybrid-search-debug-allowlist.ts
@@ -1,0 +1,62 @@
+/**
+ * Origin gating for the optional `debug` response payload on hybrid
+ * search (R4-extension keyword-first mode).
+ *
+ * The `debug=true` query param surfaces internal scoring detail
+ * (per-retriever ranks, fused score, dilution-cap application) per
+ * result. Production consumers must NOT see this payload — it leaks
+ * implementation detail and would tempt clients to depend on internal
+ * scoring constants. Dev / Railway-preview origins ARE allowed to see
+ * it for operator inspection.
+ *
+ * Allowlist resolution:
+ *  - `SEARCH_DEBUG_ALLOWED_ORIGINS` env (CSV) — explicit allowlist.
+ *    When set, only origins in this list are allowed.
+ *  - Otherwise: allowed iff `NODE_ENV !== "production"`. Conservative
+ *    default — debug works in dev and Railway preview deployments,
+ *    and is automatically stripped in production.
+ *
+ * Fail-closed semantics:
+ *  - `origin` undefined → false (non-browser clients with no Origin
+ *    header don't get debug, which protects against curl-from-prod
+ *    accidentally exposing scoring internals to log scrapers). Mirrors
+ *    the yoga-cors institutional learning.
+ *
+ * **Threat model — the Origin header is NOT an authentication
+ *  mechanism.** Browsers set `Origin` automatically and forbid
+ *  client-side override, but any non-browser HTTP client (curl,
+ *  server-to-server, MCP tool, attacker with `nc`) can send
+ *  `Origin: <any-allowlisted-host>` and unlock the debug payload.
+ *  Treat this gate as a *soft feature flag* that prevents accidental
+ *  browser-based exposure, not as a security boundary. The payload
+ *  reveals scoring internals but no secrets, PII, or credentials. If
+ *  that risk model ever changes — e.g. the payload starts carrying
+ *  user-scoped data — replace this gate with a server-side
+ *  authenticated check (signed token, allowlisted IP range,
+ *  internal-only network path) before relying on it. Per
+ *  docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md.
+ *
+ * **Agent access trade-off.** Because the gate fails closed on
+ *  `Origin === undefined`, agent clients (CLI bots, MCP tools,
+ *  server-to-server callers) on a deployed dev/staging environment
+ *  cannot see the debug payload without explicitly setting an
+ *  `Origin` header to an allowlisted value. This is a deliberate
+ *  consequence of fail-closed semantics, not an oversight: agents
+ *  that need debug on a deployed environment should set
+ *  `Origin: <allowlisted-origin>` on their request, or the operator
+ *  should add a token-based debug gate as a follow-up.
+ */
+export function isDebugAllowedForOrigin(origin: string | undefined): boolean {
+  if (origin == null || origin.length === 0) return false
+
+  const raw = process.env.SEARCH_DEBUG_ALLOWED_ORIGINS
+  if (raw != null && raw.trim().length > 0) {
+    const allowlist = raw
+      .split(",")
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0)
+    return allowlist.includes(origin)
+  }
+
+  return process.env.NODE_ENV !== "production"
+}

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Unit tests for the keyword-first lexical retrievers.
+ *
+ * Mirrors `hybrid-search-retrievers.test.ts` shape: mocks
+ * `prisma.$queryRaw` and asserts the row-mapping + short-circuit
+ * + DoS-cap contracts without touching Postgres. Real-DB EXPLAIN +
+ * Bible Project headline tests are deferred to R0 readiness, same
+ * posture as R4 + R5.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  MAX_EXACT_TITLE_TOKENS,
+  searchByExactTitle,
+  searchByKeywordWeighted,
+  searchByTrigram,
+  tokenizeForExactTitle,
+} from "./hybrid-search-keyword-first-retrievers"
+
+function mockPrisma() {
+  const $queryRaw = vi.fn()
+  return {
+    $queryRaw,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+describe("tokenizeForExactTitle", () => {
+  it("splits on Unicode non-letter / non-digit boundaries", () => {
+    expect(tokenizeForExactTitle("The Bible Project")).toEqual([
+      "the",
+      "bible",
+      "project",
+    ])
+  })
+
+  it("lowercases and drops punctuation runs", () => {
+    expect(tokenizeForExactTitle("Jesus, the Christ!")).toEqual([
+      "jesus",
+      "the",
+      "christ",
+    ])
+  })
+
+  it("returns [] for empty / whitespace / pure-punctuation input", () => {
+    expect(tokenizeForExactTitle("")).toEqual([])
+    expect(tokenizeForExactTitle("   ")).toEqual([])
+    expect(tokenizeForExactTitle("!!!,..??")).toEqual([])
+  })
+
+  it("caps at MAX_EXACT_TITLE_TOKENS = 16 (DoS guard)", () => {
+    const long = Array.from({ length: 100 }, (_, i) => `word${i}`).join(" ")
+    const tokens = tokenizeForExactTitle(long)
+    expect(tokens).toHaveLength(MAX_EXACT_TITLE_TOKENS)
+    expect(tokens[0]).toBe("word0")
+    expect(tokens[15]).toBe("word15")
+  })
+
+  it("handles Unicode letters (non-ASCII)", () => {
+    expect(tokenizeForExactTitle("Yésus Christós")).toEqual([
+      "yésus",
+      "christós",
+    ])
+  })
+
+  it("handles digits as token characters", () => {
+    expect(tokenizeForExactTitle("Genesis 1:1")).toEqual(["genesis", "1", "1"])
+  })
+})
+
+describe("searchByKeywordWeighted", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("returns a RankedItem-shaped row per DB row", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-1",
+        video_core_id: "1_BibleProject",
+        video_slug: "bible-project",
+        video_title: "The Bible Project",
+        description: "Animated bible overview",
+        rank: 0.42,
+      },
+    ])
+
+    const rows = await searchByKeywordWeighted(prisma, {
+      query: "bible project",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      resultType: "video",
+      resultId: "vid-1",
+      videoCoreId: "1_BibleProject",
+      videoSlug: "bible-project",
+      videoTitle: "The Bible Project",
+      imageUrl: null,
+      description: "Animated bible overview",
+      rank: 0.42,
+    })
+  })
+
+  it("short-circuits to [] on empty / whitespace input without a DB call", async () => {
+    expect(
+      await searchByKeywordWeighted(prisma, {
+        query: "",
+        locale: "en",
+        limit: 10,
+      }),
+    ).toEqual([])
+    expect(
+      await searchByKeywordWeighted(prisma, {
+        query: "   ",
+        locale: "en",
+        limit: 10,
+      }),
+    ).toEqual([])
+    expect(prisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it("tolerates null video_core_id and null description", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-2",
+        video_core_id: null,
+        video_slug: "x",
+        video_title: "X",
+        description: null,
+        rank: 0.1,
+      },
+    ])
+
+    const [row] = await searchByKeywordWeighted(prisma, {
+      query: "x",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(row).toMatchObject({
+      videoCoreId: null,
+      description: null,
+    })
+  })
+
+  it("interpolates websearch_to_tsquery + WEIGHTED_TSV_QUERY_EXPR into the SQL", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchByKeywordWeighted(prisma, {
+      query: "bible",
+      locale: "en",
+      limit: 10,
+    })
+    // Tagged-template form — Prisma builds a `Sql` envelope, the first
+    // arg is the cooked-string array. Smoke-check the SQL skeleton.
+    const [strings] = prisma.$queryRaw.mock.calls[0] as [TemplateStringsArray]
+    const joined = strings.join("?")
+    expect(joined).toMatch(/websearch_to_tsquery\('simple',\s*\?\)/)
+    expect(joined).toMatch(/ts_rank_cd/)
+    expect(joined).toMatch(/vl\.locale\s*=\s*\?/)
+    expect(joined).toMatch(/vl\.status\s*=\s*'published'/)
+    expect(joined).toMatch(/v\.deleted_at IS NULL/)
+  })
+})
+
+describe("searchByTrigram", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("returns a RankedItem-shaped row per DB row", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-1",
+        video_core_id: "1_BibleProject",
+        video_slug: "bible-project",
+        video_title: "Bible Project",
+        description: "desc",
+        similarity: 0.55,
+      },
+    ])
+
+    const rows = await searchByTrigram(prisma, {
+      query: "bibel project",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows[0]).toMatchObject({
+      resultType: "video",
+      resultId: "vid-1",
+      videoTitle: "Bible Project",
+      similarity: 0.55,
+    })
+  })
+
+  it("short-circuits to [] on empty input", async () => {
+    expect(
+      await searchByTrigram(prisma, { query: "", locale: "en", limit: 10 }),
+    ).toEqual([])
+    expect(prisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it("uses %> operator (operator-class trigram GIN selection)", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchByTrigram(prisma, {
+      query: "bible",
+      locale: "en",
+      limit: 10,
+    })
+    const [strings] = prisma.$queryRaw.mock.calls[0] as [TemplateStringsArray]
+    const joined = strings.join("?")
+    expect(joined).toMatch(/vl\.title\s*%>\s*\?/)
+    expect(joined).toMatch(/similarity\(vl\.title,\s*\?\)/)
+  })
+})
+
+describe("searchByExactTitle", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("returns a RankedItem-shaped row per DB row", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-1",
+        video_core_id: "1_BibleProject",
+        video_slug: "bible-project",
+        video_title: "The Bible Project",
+        description: "desc",
+        title_length: 17,
+      },
+    ])
+
+    const rows = await searchByExactTitle(prisma, {
+      query: "the bible project",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows[0]).toMatchObject({
+      resultType: "video",
+      resultId: "vid-1",
+      videoTitle: "The Bible Project",
+      titleLength: 17,
+    })
+  })
+
+  it("short-circuits to [] on empty / pure-punctuation queries", async () => {
+    expect(
+      await searchByExactTitle(prisma, {
+        query: "",
+        locale: "en",
+        limit: 10,
+      }),
+    ).toEqual([])
+    expect(
+      await searchByExactTitle(prisma, {
+        query: "!!!",
+        locale: "en",
+        limit: 10,
+      }),
+    ).toEqual([])
+    expect(prisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it("caps the AND-chain at 16 ILIKE clauses for pathological queries", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const longQuery = Array.from({ length: 1000 }, (_, i) => `word${i}`).join(
+      " ",
+    )
+    await searchByExactTitle(prisma, {
+      query: longQuery,
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(prisma.$queryRaw).toHaveBeenCalledOnce()
+    // Tagged-template `prisma.$queryRaw\`...\`` passes the cooked
+    // strings as the 0th arg and bound values as positional args after.
+    // Our query has three positional bindings:
+    //   ${ilikeChain}  ${locale}  ${limit}
+    // — `Prisma.join` collapses the 16 ILIKE clauses into one bound
+    // expression. So the call should have 1 + 3 args total.
+    const callArgs = prisma.$queryRaw.mock.calls[0]
+    expect(callArgs.length - 1).toBe(3)
+    // The first bound positional is the `Prisma.Sql` from `Prisma.join`,
+    // which exposes the constituent values. Each of those is one wrapped
+    // ILIKE pattern. Cap holds: exactly 16 entries.
+    const ilikeChain = callArgs[1] as { values: string[] }
+    expect(ilikeChain.values).toHaveLength(MAX_EXACT_TITLE_TOKENS)
+    for (const value of ilikeChain.values) {
+      expect(value.startsWith("%")).toBe(true)
+      expect(value.endsWith("%")).toBe(true)
+    }
+    expect(ilikeChain.values[0]).toBe("%word0%")
+    expect(ilikeChain.values[MAX_EXACT_TITLE_TOKENS - 1]).toBe("%word15%")
+  })
+
+  it("emits exactly N ILIKE clauses for an N-token query", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchByExactTitle(prisma, {
+      query: "the bible",
+      locale: "en",
+      limit: 10,
+    })
+    const callArgs = prisma.$queryRaw.mock.calls[0]
+    const ilikeChain = callArgs[1] as { values: string[] }
+    expect(ilikeChain.values).toEqual(["%the%", "%bible%"])
+  })
+})

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
@@ -63,8 +63,35 @@ describe("tokenizeForExactTitle", () => {
     ])
   })
 
-  it("handles digits as token characters", () => {
-    expect(tokenizeForExactTitle("Genesis 1:1")).toEqual(["genesis", "1", "1"])
+  it("handles digits as token characters and dedupes repeated tokens", () => {
+    // "Genesis 1:1" tokenizes to ['genesis', '1', '1']; dedup collapses
+    // the repeated '1' so the AND-chain doesn't carry redundant
+    // predicates.
+    expect(tokenizeForExactTitle("Genesis 1:1")).toEqual(["genesis", "1"])
+  })
+
+  it("dedupes repeated whole-word tokens before applying the cap", () => {
+    // 100 repeats of the same word collapse to one — the cap is a
+    // distinct-token cap, not a slice of the raw split.
+    const repeated = Array.from({ length: 100 }, () => "jesus").join(" ")
+    expect(tokenizeForExactTitle(repeated)).toEqual(["jesus"])
+  })
+
+  it("preserves order of first occurrence when deduping", () => {
+    // Token 'jesus' first appears before 'christ' even though 'jesus'
+    // appears multiple times.
+    expect(tokenizeForExactTitle("jesus christ jesus")).toEqual([
+      "jesus",
+      "christ",
+    ])
+  })
+
+  it("dedup happens before the 16-token cap (leading duplicates don't push later uniques out)", () => {
+    // 17 leading 'a's followed by 'b'. Without dedup-before-cap, the
+    // 'b' would never enter (slice(0,16) of 17 'a's). With the new
+    // logic, dedup collapses 'a's first, so the result is ['a','b'].
+    const input = "a a a a a a a a a a a a a a a a a b"
+    expect(tokenizeForExactTitle(input)).toEqual(["a", "b"])
   })
 })
 

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
@@ -1,0 +1,328 @@
+/**
+ * Three lexical retrievers that feed the keyword-first branch of the
+ * hybrid-search RRF orchestrator. Sibling of `hybrid-search-retrievers.ts`
+ * (R4) — same shape contract (`RankedItem`-conformant rows, no
+ * `annotateVideo` step), different SQL.
+ *
+ * Schema attachment: title + description live on `VideoLocale` in admin
+ * (per-locale rows), so the new GIN indexes provisioned by
+ * `0009_keyword_first_lexical/migration.sql` attach to `video_locale`,
+ * not `video`. Locale filter is `vl.locale = ?` (direct column) — admin
+ * does NOT use a `bcp_47` link-table chain like cms's link tables.
+ *
+ * Consumer visibility gate is identical to R4's `searchVideoKeyword`:
+ *   - `v.deleted_at IS NULL` (Video tombstone)
+ *   - `vl.status = 'published'` (per-locale publish state)
+ *
+ * Re-derived from cms's keyword-weighted, trigram, and exact-title
+ * retrievers; SQL shape ports, column names + locale filter do not.
+ * Per docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md.
+ */
+
+import { Prisma, type PrismaClient } from "@prisma/client"
+import { WEIGHTED_TSV_QUERY_EXPR } from "./hybrid-search-sql"
+import type { RankedItem } from "./hybrid-search-fusion"
+
+// -----------------------------------------------------------------------------
+// Shared parameter shapes
+// -----------------------------------------------------------------------------
+
+export type KeywordWeightedSearchParams = {
+  query: string
+  locale: string
+  limit: number
+}
+
+export type TrigramSearchParams = {
+  query: string
+  locale: string
+  limit: number
+}
+
+export type ExactTitleSearchParams = {
+  query: string
+  locale: string
+  limit: number
+}
+
+// -----------------------------------------------------------------------------
+// Return shapes — all three carry the same row contract as R4's
+// `searchVideoKeyword`, plus a retriever-specific score field
+// (`rank` for tsvector retrievers, `similarity` for trigram,
+// `titleLength` for exact-title). Keeps the orchestrator's
+// `mapToSearchResult` keyword-row branch untouched.
+// -----------------------------------------------------------------------------
+
+type VideoKeywordRowShape = RankedItem & {
+  resultType: "video"
+  resultId: string
+  videoCoreId: string | null
+  videoSlug: string
+  videoTitle: string
+  imageUrl: null
+  description: string | null
+}
+
+export type KeywordWeightedResult = VideoKeywordRowShape & { rank: number }
+export type TrigramResult = VideoKeywordRowShape & { similarity: number }
+export type ExactTitleResult = VideoKeywordRowShape & { titleLength: number }
+
+// -----------------------------------------------------------------------------
+// Internal raw-row shapes
+// -----------------------------------------------------------------------------
+
+type KeywordWeightedRow = {
+  video_id: string
+  video_core_id: string | null
+  video_slug: string | null
+  video_title: string | null
+  description: string | null
+  rank: number
+}
+
+type TrigramRow = {
+  video_id: string
+  video_core_id: string | null
+  video_slug: string | null
+  video_title: string | null
+  description: string | null
+  similarity: number
+}
+
+type ExactTitleRow = {
+  video_id: string
+  video_core_id: string | null
+  video_slug: string | null
+  video_title: string | null
+  description: string | null
+  title_length: number
+}
+
+// -----------------------------------------------------------------------------
+// Exact-title tokenizer + DoS cap
+// -----------------------------------------------------------------------------
+
+const PUNCTUATION_RE = /[^\p{L}\p{N}]+/u
+
+/**
+ * Maximum query tokens fed into the AND-chain of `vl.title ILIKE ?`
+ * clauses. Caps planner stack growth from a pathological pasted query
+ * (a 1MB clipboard accident shouldn't widen the WHERE clause to a
+ * thousand predicates). 16 is well above any natural-language search
+ * title; longer queries are truncated rather than rejected so users
+ * see results instead of a 4xx.
+ *
+ * Carried over verbatim from cms feat-109's `MAX_EXACT_TITLE_TOKENS`.
+ */
+export const MAX_EXACT_TITLE_TOKENS = 16
+
+/**
+ * Tokenize a query into "all-tokens-must-appear-in-title" parts.
+ *
+ * Splits on Unicode non-letter / non-digit boundaries, lowercases,
+ * drops empties, then caps at `MAX_EXACT_TITLE_TOKENS` to bound the
+ * predicate count. Whitespace + punctuation stripping in one pass.
+ */
+export function tokenizeForExactTitle(query: string): string[] {
+  const tokens = query
+    .toLowerCase()
+    .split(PUNCTUATION_RE)
+    .filter((token) => token.length > 0)
+  return tokens.slice(0, MAX_EXACT_TITLE_TOKENS)
+}
+
+// -----------------------------------------------------------------------------
+// Retrievers
+// -----------------------------------------------------------------------------
+
+/**
+ * Phrase-aware, per-field weighted full-text retrieval.
+ *
+ * `websearch_to_tsquery('simple', ?)` accepts user-typed double-quotes
+ * as exact phrases (Algolia-like). Ranking uses `ts_rank_cd` against
+ * the per-field weighted tsvector
+ * `(setweight(vl.title_tsv,'A') || setweight(vl.description_tsv,'B'))`
+ * so a query word in the title outranks the same word in the
+ * description. The expression is sourced from `WEIGHTED_TSV_QUERY_EXPR`
+ * in `hybrid-search-sql.ts` so it stays byte-equal to the GIN index
+ * created by `0009_keyword_first_lexical/migration.sql`. Drift =
+ * silent Seq Scan.
+ *
+ * Empty / whitespace input short-circuits to `[]`.
+ */
+export async function searchByKeywordWeighted(
+  prisma: PrismaClient,
+  params: KeywordWeightedSearchParams,
+): Promise<KeywordWeightedResult[]> {
+  const trimmed = params.query.trim()
+  if (trimmed.length === 0) return []
+
+  const { locale, limit } = params
+  const tsvector = Prisma.raw(WEIGHTED_TSV_QUERY_EXPR)
+
+  const rows = await prisma.$queryRaw<KeywordWeightedRow[]>`
+    SELECT * FROM (
+      SELECT DISTINCT ON (v.id)
+        v.id           AS video_id,
+        v.core_id      AS video_core_id,
+        v.slug         AS video_slug,
+        vl.title       AS video_title,
+        vl.description AS description,
+        ts_rank_cd(
+          ${tsvector},
+          websearch_to_tsquery('simple', ${trimmed})
+        ) AS rank
+      FROM video_locale vl
+      JOIN video v ON v.id = vl.video_id
+        AND v.deleted_at IS NULL
+      WHERE ${tsvector} @@ websearch_to_tsquery('simple', ${trimmed})
+        AND vl.locale = ${locale}
+        AND vl.status = 'published'
+      ORDER BY v.id, rank DESC
+    ) sub
+    ORDER BY sub.rank DESC
+    LIMIT ${limit}
+  `
+
+  return rows.map((row) => ({
+    resultType: "video" as const,
+    resultId: row.video_id,
+    videoCoreId: row.video_core_id,
+    videoSlug: row.video_slug ?? "",
+    videoTitle: row.video_title ?? "",
+    imageUrl: null,
+    description: row.description,
+    rank: Number(row.rank),
+  }))
+}
+
+/**
+ * Trigram word-similarity retrieval over `video_locale.title`.
+ *
+ * Closes the typo / partial-prefix gap that `websearch_to_tsquery`
+ * misses: `q="bibel project"` won't match a tsvector lemma but will
+ * still score highly here, because pg_trgm computes character-trigram
+ * overlap.
+ *
+ * Uses the `%>` operator ("word similar to") rather than `%`, which
+ * tends to overmatch on long descriptions. Title-only — the
+ * description trigram index would balloon without meaningful gain.
+ *
+ * Index selection happens via the `%>` operator against the
+ * `video_locale_title_trgm_idx` GIN trigram index (operator-class
+ * `gin_trgm_ops`); no expression byte-parity guard needed.
+ *
+ * Empty input short-circuits to `[]`.
+ */
+export async function searchByTrigram(
+  prisma: PrismaClient,
+  params: TrigramSearchParams,
+): Promise<TrigramResult[]> {
+  const trimmed = params.query.trim()
+  if (trimmed.length === 0) return []
+
+  const { locale, limit } = params
+
+  const rows = await prisma.$queryRaw<TrigramRow[]>`
+    SELECT * FROM (
+      SELECT DISTINCT ON (v.id)
+        v.id           AS video_id,
+        v.core_id      AS video_core_id,
+        v.slug         AS video_slug,
+        vl.title       AS video_title,
+        vl.description AS description,
+        similarity(vl.title, ${trimmed}) AS similarity
+      FROM video_locale vl
+      JOIN video v ON v.id = vl.video_id
+        AND v.deleted_at IS NULL
+      WHERE vl.title %> ${trimmed}
+        AND vl.locale = ${locale}
+        AND vl.status = 'published'
+      ORDER BY v.id, similarity DESC
+    ) sub
+    ORDER BY sub.similarity DESC
+    LIMIT ${limit}
+  `
+
+  return rows.map((row) => ({
+    resultType: "video" as const,
+    resultId: row.video_id,
+    videoCoreId: row.video_core_id,
+    videoSlug: row.video_slug ?? "",
+    videoTitle: row.video_title ?? "",
+    imageUrl: null,
+    description: row.description,
+    similarity: Number(row.similarity),
+  }))
+}
+
+/**
+ * Exact-token-in-title retriever.
+ *
+ * Returns videos whose title contains EVERY query token (case-
+ * insensitive, punctuation-stripped). Ranked shortest-title first —
+ * the shorter the title, the tighter the match (a 3-word title that
+ * contains all 3 tokens wins over a 12-word title that contains all 3
+ * plus 9 unrelated words).
+ *
+ * Wired into RRF as the 4th list in keyword-first mode. Together with
+ * `searchByKeywordWeighted` and `searchByTrigram`, it produces the
+ * "every query token must appear in the most-important attribute"
+ * Algolia-like behavior the keyword-first plan calls for.
+ *
+ * Token count is capped at `MAX_EXACT_TITLE_TOKENS` (16) — see
+ * `tokenizeForExactTitle`. Empty / whitespace-only / all-punctuation
+ * queries short-circuit to `[]`.
+ *
+ * Dynamic AND-chain composed via `Prisma.join` so the bound parameter
+ * count exactly matches the token count. Postgres rejects unbound
+ * placeholders at parse time, which is the safe failure mode.
+ */
+export async function searchByExactTitle(
+  prisma: PrismaClient,
+  params: ExactTitleSearchParams,
+): Promise<ExactTitleResult[]> {
+  const tokens = tokenizeForExactTitle(params.query)
+  if (tokens.length === 0) return []
+
+  const { locale, limit } = params
+
+  // One ILIKE per token, ANDed. Each bound to its own parameter via
+  // `Prisma.sql` template fragment; `Prisma.join` composes them.
+  const ilikeChain = Prisma.join(
+    tokens.map((token) => Prisma.sql`vl.title ILIKE ${`%${token}%`}`),
+    " AND ",
+  )
+
+  const rows = await prisma.$queryRaw<ExactTitleRow[]>`
+    SELECT * FROM (
+      SELECT DISTINCT ON (v.id)
+        v.id            AS video_id,
+        v.core_id       AS video_core_id,
+        v.slug          AS video_slug,
+        vl.title        AS video_title,
+        vl.description  AS description,
+        LENGTH(vl.title) AS title_length
+      FROM video_locale vl
+      JOIN video v ON v.id = vl.video_id
+        AND v.deleted_at IS NULL
+      WHERE ${ilikeChain}
+        AND vl.locale = ${locale}
+        AND vl.status = 'published'
+      ORDER BY v.id, title_length ASC
+    ) sub
+    ORDER BY sub.title_length ASC
+    LIMIT ${limit}
+  `
+
+  return rows.map((row) => ({
+    resultType: "video" as const,
+    resultId: row.video_id,
+    videoCoreId: row.video_core_id,
+    videoSlug: row.video_slug ?? "",
+    videoTitle: row.video_title ?? "",
+    imageUrl: null,
+    description: row.description,
+    titleLength: Number(row.title_length),
+  }))
+}

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
@@ -120,15 +120,24 @@ export const MAX_EXACT_TITLE_TOKENS = 16
  * Tokenize a query into "all-tokens-must-appear-in-title" parts.
  *
  * Splits on Unicode non-letter / non-digit boundaries, lowercases,
- * drops empties, then caps at `MAX_EXACT_TITLE_TOKENS` to bound the
- * predicate count. Whitespace + punctuation stripping in one pass.
+ * drops empties, **deduplicates** (so a 16-repeat-of-one-token query
+ * doesn't burn the cap on identical predicates), then caps at
+ * `MAX_EXACT_TITLE_TOKENS` to bound the planner stack. Whitespace +
+ * punctuation stripping in one pass.
+ *
+ * Dedup happens BEFORE the cap so leading duplicates can't push later
+ * unique tokens out of the window.
  */
 export function tokenizeForExactTitle(query: string): string[] {
-  const tokens = query
-    .toLowerCase()
-    .split(PUNCTUATION_RE)
-    .filter((token) => token.length > 0)
-  return tokens.slice(0, MAX_EXACT_TITLE_TOKENS)
+  const seen = new Set<string>()
+  const tokens: string[] = []
+  for (const part of query.toLowerCase().split(PUNCTUATION_RE)) {
+    if (part.length === 0 || seen.has(part)) continue
+    seen.add(part)
+    tokens.push(part)
+    if (tokens.length === MAX_EXACT_TITLE_TOKENS) break
+  }
+  return tokens
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/admin/src/services/hybrid-search-sql.test.ts
+++ b/apps/admin/src/services/hybrid-search-sql.test.ts
@@ -4,8 +4,13 @@ import { resolve } from "node:path"
 import { describe, expect, it } from "vitest"
 
 import {
+  DESCRIPTION_TSV_GENERATED_EXPR,
   EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR,
+  TITLE_TSV_GENERATED_EXPR,
+  VIDEO_LOCALE_LEXICAL_WEIGHTED_INDEX_NAME,
+  VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME,
   VIDEO_LOCALE_TSVECTOR_INDEX_EXPR,
+  WEIGHTED_TSV_INDEX_EXPR,
 } from "./hybrid-search-sql"
 
 /**
@@ -38,5 +43,74 @@ describe("hybrid-search-sql byte-parity with GIN migration", () => {
 
   it("contains the experience-locale tsvector INDEX expression verbatim", () => {
     expect(migrationSql).toContain(EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR)
+  })
+})
+
+/**
+ * Byte-parity invariant for R4-extension keyword-first lexical search.
+ *
+ * The generated-column expressions and weighted GIN index expression
+ * MUST appear byte-equal inside `0009_keyword_first_lexical/migration.sql`.
+ * Drift on the generated columns means a future migration would
+ * compute different tsvectors than the live data carries; drift on
+ * the weighted index expression silently reverts the
+ * `searchByKeywordWeighted` retriever to seq scan.
+ *
+ * The trigram retriever uses operator-class GIN (`gin_trgm_ops`) and
+ * has no expression byte-parity to enforce — only the index name is
+ * cross-checked here so a future rename can't go un-noticed.
+ */
+describe("hybrid-search-sql byte-parity with keyword-first migration", () => {
+  const keywordFirstMigrationSql = readFileSync(
+    resolve(
+      __dirname,
+      "..",
+      "..",
+      "prisma",
+      "migrations",
+      "0009_keyword_first_lexical",
+      "migration.sql",
+    ),
+    "utf8",
+  )
+
+  it("contains the title generated-column expression verbatim", () => {
+    expect(keywordFirstMigrationSql).toContain(TITLE_TSV_GENERATED_EXPR)
+  })
+
+  it("contains the description generated-column expression verbatim", () => {
+    expect(keywordFirstMigrationSql).toContain(DESCRIPTION_TSV_GENERATED_EXPR)
+  })
+
+  it("contains the weighted tsvector INDEX expression verbatim", () => {
+    expect(keywordFirstMigrationSql).toContain(WEIGHTED_TSV_INDEX_EXPR)
+  })
+
+  it("creates the weighted GIN index under the canonical name", () => {
+    expect(keywordFirstMigrationSql).toContain(
+      VIDEO_LOCALE_LEXICAL_WEIGHTED_INDEX_NAME,
+    )
+  })
+
+  it("creates the trigram GIN index under the canonical name", () => {
+    expect(keywordFirstMigrationSql).toContain(
+      VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME,
+    )
+  })
+
+  it("provisions pg_trgm idempotently", () => {
+    expect(keywordFirstMigrationSql).toMatch(
+      /CREATE EXTENSION IF NOT EXISTS pg_trgm/i,
+    )
+  })
+
+  it("leaves the legacy R4 GIN index untouched", () => {
+    // Sanity: nothing in the keyword-first migration drops or alters
+    // R4's index. The R4 keyword retriever still reads it on the
+    // hybrid path. The migration is allowed to *mention* the legacy
+    // index in comments — what matters is no DDL touches it.
+    expect(keywordFirstMigrationSql).not.toMatch(
+      /\b(DROP|ALTER)\s+INDEX[^\n]*video_locale_fulltext_search_idx/i,
+    )
   })
 })

--- a/apps/admin/src/services/hybrid-search-sql.ts
+++ b/apps/admin/src/services/hybrid-search-sql.ts
@@ -1,5 +1,17 @@
 /**
- * Shared SQL fragments for admin's R4 hybrid-search keyword retrievers.
+ * Shared SQL fragments for admin's hybrid-search keyword retrievers.
+ *
+ * Two sections:
+ *  1. R4 baseline — `*_TSVECTOR_*_EXPR` constants for the concatenated
+ *     tsvector retrievers backed by `video_locale_fulltext_search_idx` /
+ *     `experience_locale_fulltext_search_idx` from
+ *     `0006_hybrid_search_gin/migration.sql`.
+ *  2. R4-extension keyword-first — `*_TSV_GENERATED_EXPR`,
+ *     `WEIGHTED_TSV_*_EXPR`, and index-name constants for the per-field
+ *     weighted GIN + trigram retrievers backed by
+ *     `0009_keyword_first_lexical/migration.sql`. Touching either
+ *     section can drift byte-parity for the other; both are guarded by
+ *     `hybrid-search-sql.test.ts`.
  *
  * Keyword search in Postgres uses a `to_tsvector(...)` expression evaluated
  * on `video_locale` and `experience_locale`. A GIN index over the SAME

--- a/apps/admin/src/services/hybrid-search-sql.ts
+++ b/apps/admin/src/services/hybrid-search-sql.ts
@@ -80,3 +80,92 @@ export const EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR =
  */
 export const EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR =
   "to_tsvector('simple', coalesce(el.title, '') || ' ' || coalesce(el.meta_description, ''))"
+
+// -----------------------------------------------------------------------------
+// R4-extension: keyword-first lexical search expressions.
+//
+// The keyword-first mode adds three lexical retrievers on top of R4's
+// hybrid foundation. Two of them — `searchByKeywordWeighted` and the
+// generated-column expressions that back it — share the same byte-parity
+// discipline as R4's `*_TSVECTOR_*_EXPR` pair: a GIN index in
+// `0009_keyword_first_lexical/migration.sql` is created over the
+// expression below, so any drift between the constants here and the
+// migration silently reverts the retriever to seq scan.
+//
+// The trigram retriever (`searchByTrigram`) uses operator-class GIN
+// (`gin_trgm_ops`) and does NOT need a shared constant — index
+// selection happens via the operator (`%>`), not the expression. Per
+// docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md.
+//
+// The generated-column expressions (`*_GENERATED_EXPR`) cannot be
+// changed via `ALTER COLUMN ... GENERATED` — Postgres has no
+// in-place editor for stored generated expressions. Any future
+// rewrite requires a coordinated `DROP COLUMN ... CASCADE + ADD
+// COLUMN ... GENERATED ALWAYS AS (...)` migration. Per
+// docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md.
+// -----------------------------------------------------------------------------
+
+/**
+ * Generated-column expression for `video_locale.title_tsv`.
+ *
+ * Used by `prisma/migrations/0009_keyword_first_lexical/migration.sql`
+ * inside `ALTER TABLE video_locale ADD COLUMN title_tsv tsvector
+ * GENERATED ALWAYS AS (<expr>) STORED`. Must appear byte-equal in the
+ * migration. Service code never references this expression directly —
+ * the column it produces (`title_tsv`) is what queries read.
+ */
+export const TITLE_TSV_GENERATED_EXPR =
+  "to_tsvector('simple', coalesce(title, ''))"
+
+/**
+ * Generated-column expression for `video_locale.description_tsv`.
+ *
+ * Same byte-parity contract as `TITLE_TSV_GENERATED_EXPR`. Service
+ * code reads the resulting `description_tsv` column rather than
+ * recomputing the expression.
+ */
+export const DESCRIPTION_TSV_GENERATED_EXPR =
+  "to_tsvector('simple', coalesce(description, ''))"
+
+/**
+ * Per-field weighted tsvector expression, INDEX form (bare columns).
+ *
+ * Used by `prisma/migrations/0009_keyword_first_lexical/migration.sql`
+ * to create `video_locale_lexical_weighted_idx`. Title (`A`) outranks
+ * description (`B`) so a query word in the title beats the same word
+ * in the description on `ts_rank_cd`.
+ *
+ * Must appear byte-equal in the migration.
+ */
+export const WEIGHTED_TSV_INDEX_EXPR =
+  "setweight(title_tsv, 'A') || setweight(description_tsv, 'B')"
+
+/**
+ * Per-field weighted tsvector expression, QUERY form (aliased columns).
+ *
+ * Intended for service-layer SQL where `video_locale` is joined as
+ * `vl`. Postgres's planner strips alias prefixes before matching the
+ * expression against `video_locale_lexical_weighted_idx`, so the
+ * INDEX form and QUERY form are equivalent for index selection — the
+ * same property R4's `*_TSVECTOR_*_EXPR` pair already relies on.
+ */
+export const WEIGHTED_TSV_QUERY_EXPR =
+  "setweight(vl.title_tsv, 'A') || setweight(vl.description_tsv, 'B')"
+
+/**
+ * Index name for the weighted GIN index on `video_locale`.
+ *
+ * Centralized so tests, migration assertions, and `EXPLAIN ANALYZE`
+ * runbooks reference one canonical string.
+ */
+export const VIDEO_LOCALE_LEXICAL_WEIGHTED_INDEX_NAME =
+  "video_locale_lexical_weighted_idx"
+
+/**
+ * Index name for the trigram GIN index on `video_locale.title`.
+ *
+ * Trigram path uses `gin_trgm_ops` operator-class — no expression
+ * byte-parity guard needed; this constant exists only so tests and
+ * runbooks share one canonical name.
+ */
+export const VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME = "video_locale_title_trgm_idx"

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -290,17 +290,19 @@ describe("Bible Project headline (keyword-first mode)", () => {
     const top5BpCount = titles.slice(0, 5).filter(bibleProjectMatches).length
     expect(top5BpCount).toBeGreaterThanOrEqual(4)
 
-    // 3) No result whose title lacks both "bible" AND "project" ranks
-    //    above any result whose title contains both. Anchor: the
-    //    earliest BP rank in the list bounds the latest non-BP rank.
-    const firstBpRank = titles.findIndex(bibleProjectMatches)
-    expect(firstBpRank).toBeGreaterThanOrEqual(0)
-    const lastNonBpRank = titles
-      .map((t, i) => (bibleProjectMatches(t) ? -1 : i))
+    // 3) No interleaving — every BP result outranks every non-BP result.
+    //    Anchor: the LAST BP rank in the list must come before the FIRST
+    //    non-BP rank. (Earlier framing — `firstBpRank < lastNonBpRank+1`
+    //    — was vacuously true given the top-3 check above; the
+    //    interleaving guard is the assertion that actually fires when
+    //    the cap or the rank fusion regresses.)
+    const lastBpRank = titles
+      .map((t, i) => (bibleProjectMatches(t) ? i : -1))
       .reduce((max, i) => Math.max(max, i), -1)
-    expect(firstBpRank).toBeLessThan(
-      lastNonBpRank === -1 ? Infinity : lastNonBpRank + 1,
-    )
+    const firstNonBpRank = titles.findIndex((t) => !bibleProjectMatches(t))
+    if (firstNonBpRank !== -1 && lastBpRank !== -1) {
+      expect(lastBpRank).toBeLessThan(firstNonBpRank)
+    }
   })
 
   it("hybrid mode (mode=undefined) does NOT call the lexical retrievers — locked in by Unit 2 regression", async () => {

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Bible Project headline acceptance test for admin keyword-first mode.
+ *
+ * The user-facing acceptance criterion: typing `"the bible project"`
+ * should surface Bible Project videos in the top-N — not random
+ * "project" or "bible" videos that happened to score high on
+ * semantic similarity. This is the headline win of keyword-first mode
+ * over R4 hybrid.
+ *
+ * Implemented as an orchestrator-level test against mocked retrievers
+ * (matches cms feat-109's `search.bible-project.test.ts` pattern). Real-DB
+ * verification against seeded fixtures is deferred to R0 readiness, same
+ * posture as R4 + R5.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./hybrid-search-retrievers", () => ({
+  searchVideoSemantic: vi.fn(),
+  searchVideoKeyword: vi.fn(),
+  searchExperienceSemantic: vi.fn(),
+  searchExperienceKeyword: vi.fn(),
+}))
+
+vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
+  searchByKeywordWeighted: vi.fn(),
+  searchByTrigram: vi.fn(),
+  searchByExactTitle: vi.fn(),
+  MAX_EXACT_TITLE_TOKENS: 16,
+  tokenizeForExactTitle: (q: string) =>
+    q
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter((t) => t.length > 0),
+}))
+
+import {
+  searchVideoSemantic,
+  searchVideoKeyword,
+  searchExperienceSemantic,
+  searchExperienceKeyword,
+} from "./hybrid-search-retrievers"
+import {
+  searchByKeywordWeighted,
+  searchByTrigram,
+  searchByExactTitle,
+} from "./hybrid-search-keyword-first-retrievers"
+import { __resetSearchHealthForTest } from "./hybrid-search-health"
+import {
+  HybridSearchService,
+  type QueryEmbedder,
+} from "./hybrid-search.service"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = {} as any
+const successEmbedder = (): QueryEmbedder =>
+  vi.fn().mockResolvedValue([0.1, 0.2, 0.3])
+
+/**
+ * Fixture set: 5 Bible Project videos, 3 unrelated "project" videos,
+ * and 3 Bible-themed videos with the word "bible" only in description.
+ *
+ * Hybrid mode (concatenated tsvector) lets all 11 jockey on equal
+ * tsvector footing; semantic similarity shuffles the order. The
+ * dilution cap kicks in for keyword-first because there's a clear
+ * lexical winner — "The Bible Project" titles satisfy
+ * `tokenizeForExactTitle("the bible project")`.
+ */
+
+type Fixture = {
+  resultId: string
+  videoCoreId: string
+  videoSlug: string
+  videoTitle: string
+  description: string
+}
+
+const BIBLE_PROJECT_VIDEOS: Fixture[] = [
+  {
+    resultId: "bp-1",
+    videoCoreId: "bp-1-core",
+    videoSlug: "bp-genesis",
+    videoTitle: "The Bible Project: Genesis Overview",
+    description: "Animated overview of Genesis",
+  },
+  {
+    resultId: "bp-2",
+    videoCoreId: "bp-2-core",
+    videoSlug: "bp-exodus",
+    videoTitle: "The Bible Project: Exodus Overview",
+    description: "Animated overview of Exodus",
+  },
+  {
+    resultId: "bp-3",
+    videoCoreId: "bp-3-core",
+    videoSlug: "bp-gospel",
+    videoTitle: "The Bible Project: Gospel of Mark",
+    description: "Animated overview of Mark",
+  },
+  {
+    resultId: "bp-4",
+    videoCoreId: "bp-4-core",
+    videoSlug: "bp-john",
+    videoTitle: "The Bible Project: Gospel of John",
+    description: "Animated overview of John",
+  },
+  {
+    resultId: "bp-5",
+    videoCoreId: "bp-5-core",
+    videoSlug: "bp-romans",
+    videoTitle: "The Bible Project: Romans",
+    description: "Animated overview of Romans",
+  },
+]
+
+const PROJECT_VIDEOS: Fixture[] = [
+  {
+    resultId: "pj-1",
+    videoCoreId: "pj-1-core",
+    videoSlug: "school-project",
+    videoTitle: "School Project Tips",
+    description: "How to do a school project",
+  },
+  {
+    resultId: "pj-2",
+    videoCoreId: "pj-2-core",
+    videoSlug: "code-project",
+    videoTitle: "Code Project Walkthrough",
+    description: "Walking through a code project",
+  },
+  {
+    resultId: "pj-3",
+    videoCoreId: "pj-3-core",
+    videoSlug: "art-project",
+    videoTitle: "Art Project Showcase",
+    description: "Showcasing student art projects",
+  },
+]
+
+const BIBLE_DESC_ONLY: Fixture[] = [
+  {
+    resultId: "bd-1",
+    videoCoreId: "bd-1-core",
+    videoSlug: "story-time",
+    videoTitle: "Story Time",
+    description: "A bible story for kids",
+  },
+  {
+    resultId: "bd-2",
+    videoCoreId: "bd-2-core",
+    videoSlug: "lessons",
+    videoTitle: "Sunday School Lessons",
+    description: "Bible lessons for Sunday school",
+  },
+  {
+    resultId: "bd-3",
+    videoCoreId: "bd-3-core",
+    videoSlug: "history",
+    videoTitle: "Ancient History",
+    description: "Ancient bible-era history overview",
+  },
+]
+
+const ALL_FIXTURES = [
+  ...BIBLE_PROJECT_VIDEOS,
+  ...PROJECT_VIDEOS,
+  ...BIBLE_DESC_ONLY,
+]
+
+function asKeywordWeighted(f: Fixture, rank: number) {
+  return {
+    resultType: "video" as const,
+    resultId: f.resultId,
+    videoCoreId: f.videoCoreId,
+    videoSlug: f.videoSlug,
+    videoTitle: f.videoTitle,
+    imageUrl: null,
+    description: f.description,
+    rank,
+  }
+}
+
+function asTrigram(f: Fixture, similarity: number) {
+  return {
+    resultType: "video" as const,
+    resultId: f.resultId,
+    videoCoreId: f.videoCoreId,
+    videoSlug: f.videoSlug,
+    videoTitle: f.videoTitle,
+    imageUrl: null,
+    description: f.description,
+    similarity,
+  }
+}
+
+function asExactTitle(f: Fixture, titleLength: number) {
+  return {
+    resultType: "video" as const,
+    resultId: f.resultId,
+    videoCoreId: f.videoCoreId,
+    videoSlug: f.videoSlug,
+    videoTitle: f.videoTitle,
+    imageUrl: null,
+    description: f.description,
+    titleLength,
+  }
+}
+
+function asSemantic(f: Fixture, similarity: number) {
+  return {
+    resultType: "video" as const,
+    resultId: f.resultId,
+    videoCoreId: f.videoCoreId,
+    videoSlug: f.videoSlug,
+    videoTitle: f.videoTitle,
+    imageUrl: null,
+    sceneDescription: `scene from ${f.videoTitle}`,
+    startSeconds: 0,
+    playbackId: `mux-${f.resultId}`,
+    similarity,
+    embeddingText: `[${Array.from({ length: 32 }, (_, j) =>
+      f.resultId.charCodeAt(0) + j === j ? 1 : 0,
+    ).join(",")}]`,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetSearchHealthForTest()
+  vi.mocked(searchExperienceSemantic).mockResolvedValue([])
+  vi.mocked(searchExperienceKeyword).mockResolvedValue([])
+})
+
+describe("Bible Project headline (keyword-first mode)", () => {
+  it("returns Bible Project videos in the top results for q='the bible project'", async () => {
+    // Semantic-video: noisy ranking — bible-desc-only and project-only
+    // videos score reasonably alongside Bible Project videos.
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      asSemantic(BIBLE_DESC_ONLY[0]!, 0.88),
+      asSemantic(PROJECT_VIDEOS[0]!, 0.85),
+      asSemantic(BIBLE_PROJECT_VIDEOS[0]!, 0.82),
+      asSemantic(BIBLE_PROJECT_VIDEOS[1]!, 0.81),
+      asSemantic(BIBLE_DESC_ONLY[1]!, 0.79),
+      asSemantic(BIBLE_PROJECT_VIDEOS[2]!, 0.78),
+      asSemantic(PROJECT_VIDEOS[1]!, 0.76),
+    ])
+    // Keyword-weighted (websearch_to_tsquery + weighted tsvector):
+    // Bible Project videos clearly outrank because all three tokens
+    // hit title (weight A) on every BP entry.
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue(
+      BIBLE_PROJECT_VIDEOS.map((f, i) => asKeywordWeighted(f, 1 - i * 0.05)),
+    )
+    // Trigram (vl.title %>): same ranking — all BP titles share trigrams
+    // with "the bible project".
+    vi.mocked(searchByTrigram).mockResolvedValue(
+      BIBLE_PROJECT_VIDEOS.map((f, i) => asTrigram(f, 0.6 - i * 0.05)),
+    )
+    // Exact title (tokens-in-title): only Bible Project rows satisfy
+    // "the AND bible AND project" all in title.
+    vi.mocked(searchByExactTitle).mockResolvedValue(
+      BIBLE_PROJECT_VIDEOS.map((f, i) =>
+        asExactTitle(f, f.videoTitle.length + i),
+      ),
+    )
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+      contentTypes: ["video"],
+      limit: 10,
+    })
+
+    const titles = result.results.map((r) => r.title)
+
+    // 1) The top 3 results are all Bible Project videos.
+    const bibleProjectMatches = (title: string) =>
+      /bible\s*project/i.test(title)
+    expect(titles.slice(0, 3).every(bibleProjectMatches)).toBe(true)
+
+    // 2) At least 4 of the first 5 results are Bible Project videos
+    //    (some semantic-only Bible-themed videos may surface in the
+    //    list but should not crowd out the lexical winners).
+    const top5BpCount = titles.slice(0, 5).filter(bibleProjectMatches).length
+    expect(top5BpCount).toBeGreaterThanOrEqual(4)
+
+    // 3) No result whose title lacks both "bible" AND "project" ranks
+    //    above any result whose title contains both. Anchor: the
+    //    earliest BP rank in the list bounds the latest non-BP rank.
+    const firstBpRank = titles.findIndex(bibleProjectMatches)
+    expect(firstBpRank).toBeGreaterThanOrEqual(0)
+    const lastNonBpRank = titles
+      .map((t, i) => (bibleProjectMatches(t) ? -1 : i))
+      .reduce((max, i) => Math.max(max, i), -1)
+    expect(firstBpRank).toBeLessThan(
+      lastNonBpRank === -1 ? Infinity : lastNonBpRank + 1,
+    )
+  })
+
+  it("hybrid mode (mode=undefined) does NOT call the lexical retrievers — locked in by Unit 2 regression", async () => {
+    vi.mocked(searchVideoSemantic).mockResolvedValue([])
+    vi.mocked(searchVideoKeyword).mockResolvedValue([])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "the bible project",
+      locale: "en",
+      contentTypes: ["video"],
+      limit: 10,
+    })
+
+    expect(searchVideoKeyword).toHaveBeenCalledTimes(1)
+    expect(searchByKeywordWeighted).not.toHaveBeenCalled()
+    expect(searchByTrigram).not.toHaveBeenCalled()
+    expect(searchByExactTitle).not.toHaveBeenCalled()
+  })
+
+  it("preserves searchMode='hybrid' even on the keyword-first branch when embedding succeeds", async () => {
+    vi.mocked(searchVideoSemantic).mockResolvedValue([])
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([])
+    vi.mocked(searchByTrigram).mockResolvedValue([])
+    vi.mocked(searchByExactTitle).mockResolvedValue([])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+    })
+
+    expect(result.searchMode).toBe("hybrid")
+  })
+
+  // Reference fixture coverage marker so unused-export linting flags
+  // don't fire on intentionally-shared fixtures.
+  it("fixture coverage sanity — every fixture is reachable by ID", () => {
+    const ids = new Set(ALL_FIXTURES.map((f) => f.resultId))
+    expect(ids.size).toBe(ALL_FIXTURES.length)
+  })
+})

--- a/apps/admin/src/services/hybrid-search.debug.test.ts
+++ b/apps/admin/src/services/hybrid-search.debug.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Service-level tests for the origin-gated `debug` payload.
+ *
+ * Origin gating happens at the REST + GraphQL boundary; the service
+ * trusts the boolean. These tests cover the orchestrator's contract
+ * with that boolean: when `debug: true`, every returned result carries
+ * a `debug` payload with the per-retriever ranks + fused score +
+ * cap state; when omitted/false, the field is absent.
+ *
+ * Boundary-level origin gating (REST + GraphQL) is covered in
+ * `app/api/search/route.test.ts` and `graphql/queries/hybrid-search.test.ts`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./hybrid-search-retrievers", () => ({
+  searchVideoSemantic: vi.fn(),
+  searchVideoKeyword: vi.fn(),
+  searchExperienceSemantic: vi.fn(),
+  searchExperienceKeyword: vi.fn(),
+}))
+
+vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
+  searchByKeywordWeighted: vi.fn(),
+  searchByTrigram: vi.fn(),
+  searchByExactTitle: vi.fn(),
+  MAX_EXACT_TITLE_TOKENS: 16,
+  tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
+}))
+
+import {
+  searchVideoSemantic,
+  searchVideoKeyword,
+  searchExperienceSemantic,
+  searchExperienceKeyword,
+} from "./hybrid-search-retrievers"
+import {
+  searchByKeywordWeighted,
+  searchByTrigram,
+  searchByExactTitle,
+} from "./hybrid-search-keyword-first-retrievers"
+import { __resetSearchHealthForTest } from "./hybrid-search-health"
+import {
+  HybridSearchService,
+  type QueryEmbedder,
+} from "./hybrid-search.service"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = {} as any
+const successEmbedder = (): QueryEmbedder =>
+  vi.fn().mockResolvedValue([0.1, 0.2, 0.3])
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetSearchHealthForTest()
+  vi.mocked(searchVideoSemantic).mockResolvedValue([])
+  vi.mocked(searchExperienceSemantic).mockResolvedValue([])
+  vi.mocked(searchExperienceKeyword).mockResolvedValue([])
+  vi.mocked(searchByKeywordWeighted).mockResolvedValue([])
+  vi.mocked(searchByTrigram).mockResolvedValue([])
+  vi.mocked(searchByExactTitle).mockResolvedValue([])
+  vi.mocked(searchVideoKeyword).mockResolvedValue([
+    {
+      resultType: "video",
+      resultId: "vid-1",
+      videoCoreId: "core-1",
+      videoSlug: "x",
+      videoTitle: "X",
+      imageUrl: null,
+      description: "d",
+      rank: 0.5,
+    },
+  ])
+})
+
+describe("HybridSearchService debug payload routing", () => {
+  it("attaches debug to every result when params.debug=true", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "x",
+      locale: "en",
+      debug: true,
+    })
+
+    expect(result.results).toHaveLength(1)
+    const debug = result.results[0]!.debug
+    expect(debug).toBeDefined()
+    expect(debug!.retrieverRanks).toEqual([{ label: "keyword-video", rank: 1 }])
+    expect(typeof debug!.fusedScore).toBe("number")
+    expect(debug!.dilutionCapApplied).toBe(false)
+  })
+
+  it("strips debug when params.debug omitted", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({ query: "x", locale: "en" })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0]!.debug).toBeUndefined()
+  })
+
+  it("strips debug when params.debug=false", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "x",
+      locale: "en",
+      debug: false,
+    })
+
+    expect(result.results[0]!.debug).toBeUndefined()
+  })
+
+  it("debug payload aggregates ranks across multiple lists when a result hits more than one", async () => {
+    // Same resultId appears in semantic-video AND keyword-video.
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-shared",
+        videoCoreId: "core-S",
+        videoSlug: "shared",
+        videoTitle: "Shared",
+        imageUrl: null,
+        sceneDescription: "desc",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 0.9,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+    vi.mocked(searchVideoKeyword).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-shared",
+        videoCoreId: "core-S",
+        videoSlug: "shared",
+        videoTitle: "Shared",
+        imageUrl: null,
+        description: "d",
+        rank: 0.5,
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "shared",
+      locale: "en",
+      debug: true,
+    })
+
+    const debug = result.results[0]!.debug!
+    const labels = debug.retrieverRanks.map((r) => r.label).sort()
+    expect(labels).toEqual(["keyword-video", "semantic-video"])
+  })
+
+  it("dilutionCapApplied reflects the cap's per-result decision in keyword-first mode", async () => {
+    // Bring up a keyword-first scenario where the cap fires on a
+    // semantic-only row.
+    vi.mocked(searchVideoKeyword).mockResolvedValue([])
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-sem-only",
+        videoCoreId: "core-OUT",
+        videoSlug: "out",
+        videoTitle: "Out of allowlist",
+        imageUrl: null,
+        sceneDescription: "scene",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 0.85,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+    vi.mocked(searchByExactTitle).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-exact",
+        videoCoreId: "core-IN",
+        videoSlug: "exact",
+        videoTitle: "The Bible Project",
+        imageUrl: null,
+        description: "",
+        titleLength: 17,
+      },
+    ])
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-kw",
+        videoCoreId: "core-IN",
+        videoSlug: "kw",
+        videoTitle: "The Bible Project",
+        imageUrl: null,
+        description: "",
+        rank: 0.5,
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+      debug: true,
+    })
+
+    const semOnly = result.results.find((r) => r.id === "vid-sem-only")
+    expect(semOnly).toBeDefined()
+    expect(semOnly!.debug!.dilutionCapApplied).toBe(true)
+    // Keyword-side rows (vid-kw / vid-exact) survive dedup as a single
+    // entry because they share videoCoreId + title; the survivor's
+    // dilutionCapApplied is false (it was never semantic-only).
+    const keywordSurvivor = result.results.find(
+      (r) => r.id === "vid-kw" || r.id === "vid-exact",
+    )
+    expect(keywordSurvivor).toBeDefined()
+    expect(keywordSurvivor!.debug!.dilutionCapApplied).toBe(false)
+  })
+})

--- a/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
+++ b/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Unit + orchestrator tests for the keyword-first semantic-dilution cap.
+ *
+ * The cap activates only in keyword-first mode, and only when the
+ * exact-title list returned a result whose lowercased title contains
+ * every query token. When triggered, semantic-only fused results whose
+ * `videoCoreId` is null OR not present in the top-N keyword-side
+ * core_ids are down-weighted by `DILUTION_CAP_DOWNWEIGHT` (0.5).
+ *
+ * Real-DB integration verification (canary diff vs cms keyword-first
+ * across a fixed query set × locales) is deferred to R0 readiness;
+ * algorithmic correctness is locked in here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  applyDilutionCap,
+  DILUTION_CAP_DOWNWEIGHT,
+  type SearchResultDebug,
+} from "./hybrid-search.service"
+import type { FusedResult, RankedItem } from "./hybrid-search-fusion"
+
+const ORIGINAL_FLAG = process.env.SEARCH_DILUTION_CAP_ENABLED
+
+afterEach(() => {
+  if (ORIGINAL_FLAG != null) {
+    process.env.SEARCH_DILUTION_CAP_ENABLED = ORIGINAL_FLAG
+  } else {
+    delete process.env.SEARCH_DILUTION_CAP_ENABLED
+  }
+})
+
+function makeFused(
+  resultId: string,
+  videoCoreId: string | null,
+  score: number,
+  videoTitle = "",
+): FusedResult {
+  return {
+    resultType: "video",
+    resultId,
+    videoCoreId,
+    videoTitle,
+    score,
+  }
+}
+
+function makeRanked(
+  resultId: string,
+  videoCoreId: string | null,
+  videoTitle = "",
+): RankedItem {
+  return {
+    resultType: "video",
+    resultId,
+    videoCoreId,
+    videoTitle,
+  }
+}
+
+function buildDebugByKey(
+  labeledLists: Array<{ label: string; list: RankedItem[] }>,
+): Map<string, SearchResultDebug> {
+  const map = new Map<string, SearchResultDebug>()
+  for (const { label, list } of labeledLists) {
+    for (let i = 0; i < list.length; i++) {
+      const item = list[i]!
+      const key = `${item.resultType}:${item.resultId}`
+      const existing = map.get(key)
+      if (existing == null) {
+        map.set(key, {
+          retrieverRanks: [{ label, rank: i + 1 }],
+          fusedScore: 0,
+          dilutionCapApplied: false,
+        })
+      } else {
+        existing.retrieverRanks.push({ label, rank: i + 1 })
+      }
+    }
+  }
+  return map
+}
+
+describe("applyDilutionCap", () => {
+  it("does NOT trigger when no exact-title hit covers every query token", () => {
+    // Query: "the bible project". Exact-title list has one item but its
+    // title doesn't contain "project" → cap is silent.
+    const labeledLists = [
+      {
+        label: "semantic-video",
+        list: [makeRanked("vid-sem-1", "core-A", "Bible Stories")],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-B", "Bible Stories")],
+      },
+    ]
+    const fused = [makeFused("vid-sem-1", "core-A", 0.8)]
+    const debugByKey = buildDebugByKey(labeledLists)
+
+    applyDilutionCap(fused, labeledLists, "the bible project", debugByKey)
+
+    expect(fused[0]!.score).toBe(0.8)
+    expect(debugByKey.get("video:vid-sem-1")!.dilutionCapApplied).toBe(false)
+  })
+
+  it("triggers when exact-title list contains a row with every token", () => {
+    const labeledLists = [
+      {
+        label: "semantic-video",
+        list: [makeRanked("vid-sem-1", "core-OUT", "Random Themes Video")],
+      },
+      {
+        label: "keyword-weighted-video",
+        list: [makeRanked("vid-kw-1", "core-IN", "The Bible Project")],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-IN", "The Bible Project")],
+      },
+    ]
+    const fused = [
+      makeFused("vid-sem-1", "core-OUT", 0.6, "Random Themes Video"),
+      makeFused("vid-kw-1", "core-IN", 0.5, "The Bible Project"),
+      makeFused("vid-ex-1", "core-IN", 0.4, "The Bible Project"),
+    ]
+    const debugByKey = buildDebugByKey(labeledLists)
+
+    applyDilutionCap(fused, labeledLists, "the bible project", debugByKey)
+
+    // vid-sem-1 (semantic-only, core_id NOT in top-N) → down-weighted.
+    const semOnly = fused.find((r) => r.resultId === "vid-sem-1")!
+    expect(semOnly.score).toBeCloseTo(0.6 * DILUTION_CAP_DOWNWEIGHT)
+    expect(debugByKey.get("video:vid-sem-1")!.dilutionCapApplied).toBe(true)
+
+    // vid-kw-1 (in keyword-side, NOT semantic-only) → unchanged.
+    const kw = fused.find((r) => r.resultId === "vid-kw-1")!
+    expect(kw.score).toBe(0.5)
+    expect(debugByKey.get("video:vid-kw-1")!.dilutionCapApplied).toBe(false)
+  })
+
+  it("treats null videoCoreId as 'outside top-N' (down-weighted)", () => {
+    const labeledLists = [
+      {
+        label: "semantic-video",
+        list: [makeRanked("vid-sem-null", null, "Some Other Video")],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-IN", "The Bible Project")],
+      },
+    ]
+    const fused = [makeFused("vid-sem-null", null, 0.7)]
+    const debugByKey = buildDebugByKey(labeledLists)
+
+    applyDilutionCap(fused, labeledLists, "the bible project", debugByKey)
+
+    expect(fused[0]!.score).toBeCloseTo(0.7 * DILUTION_CAP_DOWNWEIGHT)
+    expect(debugByKey.get("video:vid-sem-null")!.dilutionCapApplied).toBe(true)
+  })
+
+  it("exempts semantic-only rows whose videoCoreId IS in the top-N keyword-side allowlist", () => {
+    // Same core_id surfaces in semantic-video AND keyword-weighted-video
+    // but the fused result is only attributed to semantic-video (rare
+    // but possible after dedup). The cap exempts it because the entity
+    // is genuinely a keyword winner.
+    const labeledLists = [
+      {
+        label: "semantic-video",
+        list: [makeRanked("vid-sem-1", "core-IN", "")],
+      },
+      {
+        label: "trigram-video",
+        list: [makeRanked("vid-other", "core-IN", "")],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-X", "The Bible Project")],
+      },
+    ]
+    const fused = [makeFused("vid-sem-1", "core-IN", 0.7)]
+    const debugByKey = buildDebugByKey(labeledLists)
+    // Force semantic-only attribution on vid-sem-1 (it's only on the
+    // semantic-video list above, so this is correct).
+
+    applyDilutionCap(fused, labeledLists, "the bible project", debugByKey)
+
+    expect(fused[0]!.score).toBe(0.7)
+    expect(debugByKey.get("video:vid-sem-1")!.dilutionCapApplied).toBe(false)
+  })
+
+  it("re-sorts after down-weighting", () => {
+    const labeledLists = [
+      {
+        label: "semantic-video",
+        list: [makeRanked("vid-sem-high", "core-OUT", "")],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-IN", "The Bible Project")],
+      },
+    ]
+    const fused = [
+      makeFused("vid-sem-high", "core-OUT", 0.9), // semantic-only, will be halved → 0.45
+      makeFused("vid-ex-1", "core-IN", 0.6, "The Bible Project"), // 0.6
+    ]
+    const debugByKey = buildDebugByKey(labeledLists)
+
+    applyDilutionCap(fused, labeledLists, "the bible project", debugByKey)
+
+    expect(fused.map((r) => r.resultId)).toEqual(["vid-ex-1", "vid-sem-high"])
+  })
+
+  it("only DILUTION_CAP_TOP_N=3 keyword-side rows per list contribute to the allowlist", () => {
+    const labeledLists = [
+      {
+        label: "semantic-video",
+        list: [makeRanked("vid-sem-1", "core-INDEX-4", "")], // 4th in trigram → NOT in top-N
+      },
+      {
+        label: "trigram-video",
+        list: [
+          makeRanked("vid-t1", "core-INDEX-1", ""),
+          makeRanked("vid-t2", "core-INDEX-2", ""),
+          makeRanked("vid-t3", "core-INDEX-3", ""),
+          makeRanked("vid-t4", "core-INDEX-4", ""),
+        ],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-X", "The Bible Project")],
+      },
+    ]
+    const fused = [makeFused("vid-sem-1", "core-INDEX-4", 0.8)]
+    const debugByKey = buildDebugByKey(labeledLists)
+
+    applyDilutionCap(fused, labeledLists, "the bible project", debugByKey)
+
+    // core-INDEX-4 is the 4th in trigram-video — outside top-3 — so the
+    // semantic-only row gets down-weighted.
+    expect(fused[0]!.score).toBeCloseTo(0.8 * DILUTION_CAP_DOWNWEIGHT)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Orchestrator-level: env flag wiring + skip-on-hybrid-mode invariant.
+// -----------------------------------------------------------------------------
+
+describe("orchestrator: dilution cap respects SEARCH_DILUTION_CAP_ENABLED", () => {
+  vi.mock("./hybrid-search-retrievers", () => ({
+    searchVideoSemantic: vi.fn().mockResolvedValue([]),
+    searchVideoKeyword: vi.fn().mockResolvedValue([]),
+    searchExperienceSemantic: vi.fn().mockResolvedValue([]),
+    searchExperienceKeyword: vi.fn().mockResolvedValue([]),
+  }))
+
+  vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
+    searchByKeywordWeighted: vi.fn(),
+    searchByTrigram: vi.fn(),
+    searchByExactTitle: vi.fn(),
+    MAX_EXACT_TITLE_TOKENS: 16,
+    tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
+  }))
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("env=undefined → cap enabled", async () => {
+    delete process.env.SEARCH_DILUTION_CAP_ENABLED
+    const { isDilutionCapEnabled } = await import("./hybrid-search.service")
+    expect(isDilutionCapEnabled()).toBe(true)
+  })
+
+  it("env='false' → cap disabled", async () => {
+    process.env.SEARCH_DILUTION_CAP_ENABLED = "false"
+    const { isDilutionCapEnabled } = await import("./hybrid-search.service")
+    expect(isDilutionCapEnabled()).toBe(false)
+  })
+
+  it("env='0' or 'off' (typo'd off-values) → cap STAYS enabled (documented quirk)", async () => {
+    // Per cms-side decision: only the literal string "false" disables.
+    // A tolerant parser is a documented follow-up; today this is the
+    // safe direction (cap is on by default; an operator typing "0"
+    // gets cap-on, not cap-off, until they type "false").
+    process.env.SEARCH_DILUTION_CAP_ENABLED = "0"
+    const { isDilutionCapEnabled } = await import("./hybrid-search.service")
+    expect(isDilutionCapEnabled()).toBe(true)
+    process.env.SEARCH_DILUTION_CAP_ENABLED = "off"
+    expect(isDilutionCapEnabled()).toBe(true)
+  })
+})

--- a/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
+++ b/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
@@ -212,6 +212,67 @@ describe("applyDilutionCap", () => {
     expect(fused.map((r) => r.resultId)).toEqual(["vid-ex-1", "vid-sem-high"])
   })
 
+  it("returns silently when query yields zero tokens (pure punctuation)", () => {
+    // Note: vid-sem-1 isn't on any labeled list (semantic-video would
+    // contribute it normally; here we just construct the fused result
+    // directly to exercise the early-return path). Its score must not
+    // change when applyDilutionCap short-circuits on zero tokens.
+    const labeledLists = [
+      {
+        label: "semantic-video",
+        list: [makeRanked("vid-sem-1", "core-OUT", "")],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-X", "The Bible Project")],
+      },
+    ]
+    const fused = [makeFused("vid-sem-1", "core-OUT", 0.7)]
+    const debugByKey = buildDebugByKey(labeledLists)
+
+    // Zero-token query short-circuits before the trigger check —
+    // pure-punctuation input cannot satisfy "every token in title".
+    applyDilutionCap(fused, labeledLists, "!!!", debugByKey)
+
+    expect(fused[0]!.score).toBe(0.7)
+    expect(debugByKey.get("video:vid-sem-1")?.dilutionCapApplied).toBe(false)
+  })
+
+  it("never down-weights non-video result types (experience rows pass through)", () => {
+    const labeledLists = [
+      {
+        label: "semantic-experience",
+        list: [
+          {
+            resultType: "experience" as const,
+            resultId: "exp-1",
+            videoCoreId: null,
+          },
+        ],
+      },
+      {
+        label: "exact-title-video",
+        list: [makeRanked("vid-ex-1", "core-X", "The Bible Project")],
+      },
+    ]
+    const fused: FusedResult[] = [
+      {
+        resultType: "experience",
+        resultId: "exp-1",
+        videoCoreId: null,
+        score: 0.9,
+      },
+    ]
+    const debugByKey = buildDebugByKey(labeledLists)
+
+    applyDilutionCap(fused, labeledLists, "the bible project", debugByKey)
+
+    // Experience rows must NEVER be touched by the video-side cap, even
+    // when an exact-title trigger fires.
+    expect(fused[0]!.score).toBe(0.9)
+    expect(debugByKey.get("experience:exp-1")?.dilutionCapApplied).toBe(false)
+  })
+
   it("only DILUTION_CAP_TOP_N=3 keyword-side rows per list contribute to the allowlist", () => {
     const labeledLists = [
       {
@@ -244,25 +305,31 @@ describe("applyDilutionCap", () => {
 })
 
 // -----------------------------------------------------------------------------
-// Orchestrator-level: env flag wiring + skip-on-hybrid-mode invariant.
+// Env-flag parsing for SEARCH_DILUTION_CAP_ENABLED (no orchestrator —
+// see the next describe block for the orchestrator-level skip
+// behavior).
 // -----------------------------------------------------------------------------
 
-describe("orchestrator: dilution cap respects SEARCH_DILUTION_CAP_ENABLED", () => {
-  vi.mock("./hybrid-search-retrievers", () => ({
-    searchVideoSemantic: vi.fn().mockResolvedValue([]),
-    searchVideoKeyword: vi.fn().mockResolvedValue([]),
-    searchExperienceSemantic: vi.fn().mockResolvedValue([]),
-    searchExperienceKeyword: vi.fn().mockResolvedValue([]),
-  }))
+vi.mock("./hybrid-search-retrievers", () => ({
+  searchVideoSemantic: vi.fn(),
+  searchVideoKeyword: vi.fn(),
+  searchExperienceSemantic: vi.fn(),
+  searchExperienceKeyword: vi.fn(),
+}))
 
-  vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
-    searchByKeywordWeighted: vi.fn(),
-    searchByTrigram: vi.fn(),
-    searchByExactTitle: vi.fn(),
-    MAX_EXACT_TITLE_TOKENS: 16,
-    tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
-  }))
+vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
+  searchByKeywordWeighted: vi.fn(),
+  searchByTrigram: vi.fn(),
+  searchByExactTitle: vi.fn(),
+  MAX_EXACT_TITLE_TOKENS: 16,
+  tokenizeForExactTitle: (q: string) =>
+    q
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter((t) => t.length > 0),
+}))
 
+describe("isDilutionCapEnabled (SEARCH_DILUTION_CAP_ENABLED parser)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -289,5 +356,155 @@ describe("orchestrator: dilution cap respects SEARCH_DILUTION_CAP_ENABLED", () =
     expect(isDilutionCapEnabled()).toBe(true)
     process.env.SEARCH_DILUTION_CAP_ENABLED = "off"
     expect(isDilutionCapEnabled()).toBe(true)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Orchestrator-level: SEARCH_DILUTION_CAP_ENABLED='false' actually
+// short-circuits applyDilutionCap when keyword-first mode + exact-title
+// trigger are both present.
+// -----------------------------------------------------------------------------
+
+describe("HybridSearchService skips dilution cap when SEARCH_DILUTION_CAP_ENABLED='false'", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // Default every retriever to [] — individual tests override the
+    // ones whose return values they care about.
+    const {
+      searchVideoSemantic,
+      searchVideoKeyword,
+      searchExperienceSemantic,
+      searchExperienceKeyword,
+    } = await import("./hybrid-search-retrievers")
+    const { searchByKeywordWeighted, searchByTrigram, searchByExactTitle } =
+      await import("./hybrid-search-keyword-first-retrievers")
+    vi.mocked(searchVideoSemantic).mockResolvedValue([])
+    vi.mocked(searchVideoKeyword).mockResolvedValue([])
+    vi.mocked(searchExperienceSemantic).mockResolvedValue([])
+    vi.mocked(searchExperienceKeyword).mockResolvedValue([])
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([])
+    vi.mocked(searchByTrigram).mockResolvedValue([])
+    vi.mocked(searchByExactTitle).mockResolvedValue([])
+  })
+
+  it("env='false' + keyword-first + exact-title trigger → semantic-only score is NOT halved", async () => {
+    const { searchVideoSemantic, searchVideoKeyword } =
+      await import("./hybrid-search-retrievers")
+    const { searchByKeywordWeighted, searchByTrigram, searchByExactTitle } =
+      await import("./hybrid-search-keyword-first-retrievers")
+    const { HybridSearchService } = await import("./hybrid-search.service")
+
+    vi.mocked(searchVideoKeyword).mockResolvedValue([])
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-sem-only",
+        videoCoreId: "core-OUT",
+        videoSlug: "out",
+        videoTitle: "Out of allowlist",
+        imageUrl: null,
+        sceneDescription: "scene",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 0.85,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+    vi.mocked(searchByExactTitle).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-exact",
+        videoCoreId: "core-IN",
+        videoSlug: "exact",
+        videoTitle: "The Bible Project",
+        imageUrl: null,
+        description: "",
+        titleLength: 17,
+      },
+    ])
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([])
+    vi.mocked(searchByTrigram).mockResolvedValue([])
+
+    process.env.SEARCH_DILUTION_CAP_ENABLED = "false"
+
+    const service = new HybridSearchService({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: {} as any,
+      embedder: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+    const result = await service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+      debug: true,
+    })
+
+    const semOnly = result.results.find((r) => r.id === "vid-sem-only")
+    expect(semOnly).toBeDefined()
+    // dilutionCapApplied stays false because the cap never ran.
+    expect(semOnly!.debug!.dilutionCapApplied).toBe(false)
+    // pre-cap fusedScore equals visible score (within rounding) because
+    // the cap didn't mutate score.
+    expect(semOnly!.score).toBeCloseTo(semOnly!.debug!.fusedScore, 2)
+  })
+
+  it("env unset + keyword-first + exact-title trigger → semantic-only IS halved", async () => {
+    const { searchVideoSemantic, searchVideoKeyword } =
+      await import("./hybrid-search-retrievers")
+    const { searchByKeywordWeighted, searchByTrigram, searchByExactTitle } =
+      await import("./hybrid-search-keyword-first-retrievers")
+    const { HybridSearchService } = await import("./hybrid-search.service")
+
+    vi.mocked(searchVideoKeyword).mockResolvedValue([])
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-sem-only",
+        videoCoreId: "core-OUT",
+        videoSlug: "out",
+        videoTitle: "Out of allowlist",
+        imageUrl: null,
+        sceneDescription: "scene",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 0.85,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+    vi.mocked(searchByExactTitle).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-exact",
+        videoCoreId: "core-IN",
+        videoSlug: "exact",
+        videoTitle: "The Bible Project",
+        imageUrl: null,
+        description: "",
+        titleLength: 17,
+      },
+    ])
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([])
+    vi.mocked(searchByTrigram).mockResolvedValue([])
+
+    delete process.env.SEARCH_DILUTION_CAP_ENABLED
+
+    const service = new HybridSearchService({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: {} as any,
+      embedder: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+    const result = await service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+      debug: true,
+    })
+
+    const semOnly = result.results.find((r) => r.id === "vid-sem-only")
+    expect(semOnly!.debug!.dilutionCapApplied).toBe(true)
+    // visible score is half the pre-cap fusedScore.
+    expect(semOnly!.score).toBeCloseTo(semOnly!.debug!.fusedScore * 0.5, 2)
   })
 })

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Orchestrator-level tests for the `mode="keyword-first"` branch.
+ *
+ * Verifies that:
+ *   1. The hybrid path is left UNTOUCHED — `searchVideoKeyword` (R4) is
+ *      called, the three keyword-first retrievers are NOT.
+ *   2. The keyword-first path swaps `searchVideoKeyword` for the three
+ *      new retrievers (semantic-video stays shared between both modes).
+ *   3. Empty-list filtering before fusion is preserved.
+ *   4. Per-retriever failures via `Promise.allSettled` keep the rest
+ *      of the response intact.
+ *
+ * Real-DB integration tests (Bible Project headline against seeded
+ * data, EXPLAIN-based GIN verification) are deferred to R0 readiness,
+ * same posture as R4 + R5.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./hybrid-search-retrievers", () => ({
+  searchVideoSemantic: vi.fn(),
+  searchVideoKeyword: vi.fn(),
+  searchExperienceSemantic: vi.fn(),
+  searchExperienceKeyword: vi.fn(),
+}))
+
+vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
+  searchByKeywordWeighted: vi.fn(),
+  searchByTrigram: vi.fn(),
+  searchByExactTitle: vi.fn(),
+  MAX_EXACT_TITLE_TOKENS: 16,
+  tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
+}))
+
+import {
+  searchVideoSemantic,
+  searchVideoKeyword,
+  searchExperienceSemantic,
+  searchExperienceKeyword,
+} from "./hybrid-search-retrievers"
+import {
+  searchByKeywordWeighted,
+  searchByTrigram,
+  searchByExactTitle,
+} from "./hybrid-search-keyword-first-retrievers"
+import { __resetSearchHealthForTest } from "./hybrid-search-health"
+import {
+  HybridSearchService,
+  type QueryEmbedder,
+} from "./hybrid-search.service"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = {} as any
+
+const successEmbedder = (): QueryEmbedder =>
+  vi.fn().mockResolvedValue([0.1, 0.2, 0.3])
+
+function setupAllRetrieversEmpty() {
+  vi.mocked(searchVideoSemantic).mockResolvedValue([])
+  vi.mocked(searchVideoKeyword).mockResolvedValue([])
+  vi.mocked(searchExperienceSemantic).mockResolvedValue([])
+  vi.mocked(searchExperienceKeyword).mockResolvedValue([])
+  vi.mocked(searchByKeywordWeighted).mockResolvedValue([])
+  vi.mocked(searchByTrigram).mockResolvedValue([])
+  vi.mocked(searchByExactTitle).mockResolvedValue([])
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetSearchHealthForTest()
+  setupAllRetrieversEmpty()
+})
+
+describe("HybridSearchService keyword-first branch", () => {
+  it("dispatches the three lexical retrievers when mode='keyword-first'", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+    })
+
+    expect(searchByKeywordWeighted).toHaveBeenCalledWith(mockPrisma, {
+      query: "the bible project",
+      locale: "en",
+      limit: 60,
+    })
+    expect(searchByTrigram).toHaveBeenCalledWith(mockPrisma, {
+      query: "the bible project",
+      locale: "en",
+      limit: 60,
+    })
+    expect(searchByExactTitle).toHaveBeenCalledWith(mockPrisma, {
+      query: "the bible project",
+      locale: "en",
+      limit: 60,
+    })
+  })
+
+  it("does NOT dispatch the legacy R4 video keyword retriever in keyword-first mode", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "keyword-first",
+    })
+
+    expect(searchVideoKeyword).not.toHaveBeenCalled()
+  })
+
+  it("still shares semantic-video and both experience retrievers across modes", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "keyword-first",
+    })
+
+    expect(searchVideoSemantic).toHaveBeenCalled()
+    expect(searchExperienceSemantic).toHaveBeenCalled()
+    expect(searchExperienceKeyword).toHaveBeenCalled()
+  })
+
+  it("hybrid mode untouched — calls R4 retrievers, NOT keyword-first ones", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "hybrid",
+    })
+
+    expect(searchVideoKeyword).toHaveBeenCalledTimes(1)
+    expect(searchByKeywordWeighted).not.toHaveBeenCalled()
+    expect(searchByTrigram).not.toHaveBeenCalled()
+    expect(searchByExactTitle).not.toHaveBeenCalled()
+  })
+
+  it("isolates per-retriever failures via Promise.allSettled (one rejected list = empty list, response still returns)", async () => {
+    const loggerError = vi.fn()
+    vi.mocked(searchByTrigram).mockRejectedValue(new Error("boom trigram"))
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-1",
+        videoCoreId: null,
+        videoSlug: "a",
+        videoTitle: "A",
+        imageUrl: null,
+        description: "kw weighted survivor",
+        rank: 0.7,
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: loggerError },
+    })
+
+    const result = await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "keyword-first",
+    })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0]!.id).toBe("vid-1")
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.stringContaining("trigram-video retrieval failed"),
+    )
+  })
+
+  it("video-only contentTypes still routes through the keyword-first stack (no experience dispatch)", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "keyword-first",
+      contentTypes: ["video"],
+    })
+
+    expect(searchByKeywordWeighted).toHaveBeenCalled()
+    expect(searchByTrigram).toHaveBeenCalled()
+    expect(searchByExactTitle).toHaveBeenCalled()
+    expect(searchExperienceSemantic).not.toHaveBeenCalled()
+    expect(searchExperienceKeyword).not.toHaveBeenCalled()
+  })
+
+  it("preserves the searchMode='hybrid'/'keyword-only' degradation signal independently of input mode", async () => {
+    const failingEmbedder: QueryEmbedder = vi
+      .fn()
+      .mockRejectedValue(new Error("provider down"))
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: failingEmbedder,
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "keyword-first",
+    })
+
+    expect(result.searchMode).toBe("keyword-only")
+    // Semantic-video is gated behind embedding success — same as hybrid.
+    expect(searchVideoSemantic).not.toHaveBeenCalled()
+    // The three lexical retrievers DO run regardless (they don't need
+    // an embedding).
+    expect(searchByKeywordWeighted).toHaveBeenCalled()
+    expect(searchByTrigram).toHaveBeenCalled()
+    expect(searchByExactTitle).toHaveBeenCalled()
+  })
+})

--- a/apps/admin/src/services/hybrid-search.regression.test.ts
+++ b/apps/admin/src/services/hybrid-search.regression.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Default-mode regression snapshot — the byte-identity gate for the
+ * R4 → keyword-first port.
+ *
+ * The contract this test locks in: when the public `mode` argument is
+ * unset, null, empty string, `"hybrid"`, or any unknown value, the
+ * orchestrator's response MUST be byte-equal to R4's mode-less
+ * baseline. Adding new retrievers, dilution caps, or debug payloads
+ * to the keyword-first branch (Units 3+) is allowed only as long as
+ * THIS test stays green.
+ *
+ * The snapshot is captured *across modes within a single test run*
+ * against deterministic mocked retrievers — the byte-identity is the
+ * relative invariant (mode A == mode B == mode C == ...). A future
+ * R-stage that legitimately changes R4's hybrid response shape will
+ * fail this test on principle, which is the point: such a change must
+ * be a deliberate, reviewed update to the snapshot, not silent drift.
+ *
+ * Behavioral cross-check: keyword-first retrievers are mocked in Unit 3
+ * onward and asserted NEVER-CALLED on the default path. Until those
+ * retrievers exist we assert via the four R4 retrievers that they ARE
+ * all called regardless of `mode` value (since hybrid is the universal
+ * fallback in this unit).
+ *
+ * Per docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./hybrid-search-retrievers", () => ({
+  searchVideoSemantic: vi.fn(),
+  searchVideoKeyword: vi.fn(),
+  searchExperienceSemantic: vi.fn(),
+  searchExperienceKeyword: vi.fn(),
+}))
+
+import {
+  searchVideoSemantic,
+  searchVideoKeyword,
+  searchExperienceSemantic,
+  searchExperienceKeyword,
+} from "./hybrid-search-retrievers"
+import { __resetSearchHealthForTest } from "./hybrid-search-health"
+import {
+  HybridSearchService,
+  type QueryEmbedder,
+  type SearchParams,
+} from "./hybrid-search.service"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = {} as any
+
+const successEmbedder = (): QueryEmbedder =>
+  vi.fn().mockResolvedValue([0.1, 0.2, 0.3])
+
+/**
+ * Deterministic fixtures across all modes. The exact rows don't matter
+ * — what matters is that the same fixtures produce byte-identical
+ * responses regardless of the `mode` value.
+ */
+function setupRetrieverFixtures() {
+  vi.mocked(searchVideoSemantic).mockResolvedValue([
+    {
+      resultType: "video",
+      resultId: "vid-sem-1",
+      videoCoreId: "1_RegressionVideo",
+      videoSlug: "regression-video",
+      videoTitle: "Regression Video",
+      imageUrl: null,
+      sceneDescription: "Regression scene",
+      startSeconds: 12,
+      playbackId: "mux-regression-1",
+      similarity: 0.91,
+      embeddingText: "[0.1,0.2,0.3]",
+    },
+  ])
+  vi.mocked(searchVideoKeyword).mockResolvedValue([
+    {
+      resultType: "video",
+      resultId: "vid-kw-1",
+      videoCoreId: "2_KeywordVideo",
+      videoSlug: "keyword-video",
+      videoTitle: "Keyword Video",
+      imageUrl: null,
+      description: "Keyword description",
+      rank: 0.42,
+    },
+  ])
+  vi.mocked(searchExperienceSemantic).mockResolvedValue([
+    {
+      resultType: "experience",
+      resultId: "exp-sem-1",
+      experienceSlug: "regression-experience",
+      experienceTitle: "Regression Experience",
+      experienceMetaDescription: "Regression meta",
+      imageUrl: null,
+      similarity: 0.77,
+    },
+  ])
+  vi.mocked(searchExperienceKeyword).mockResolvedValue([
+    {
+      resultType: "experience",
+      resultId: "exp-kw-1",
+      experienceSlug: "keyword-experience",
+      experienceTitle: "Keyword Experience",
+      experienceMetaDescription: "Keyword meta",
+      imageUrl: null,
+      rank: 0.33,
+    },
+  ])
+}
+
+/** Five representative queries × 5 mode values. Keep this list stable — re-snapshotting on a whim defeats the point. */
+const REGRESSION_QUERIES = [
+  "the bible project",
+  "jesus heals",
+  "easter resurrection",
+  "forgiveness",
+  "hope when life is hard",
+]
+
+const DEFAULT_EQUIVALENT_MODES: Array<{
+  label: string
+  mode: SearchParams["mode"]
+}> = [
+  { label: "undefined", mode: undefined },
+  { label: "null", mode: null },
+  { label: "empty string", mode: "" },
+  { label: "'hybrid'", mode: "hybrid" },
+  { label: "'garbage' (unknown)", mode: "garbage" },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetSearchHealthForTest()
+  setupRetrieverFixtures()
+})
+
+describe("HybridSearchService default-mode regression snapshot", () => {
+  it.each(REGRESSION_QUERIES)(
+    "produces byte-identical responses across hybrid-equivalent modes for q=%s",
+    async (query) => {
+      const responses: string[] = []
+      for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
+        const warn = vi.fn()
+        const error = vi.fn()
+        const service = new HybridSearchService({
+          prisma: mockPrisma,
+          embedder: successEmbedder(),
+          logger: { warn, error },
+        })
+        const result = await service.search({ query, locale: "en", mode })
+        responses.push(JSON.stringify(result))
+      }
+      const [first, ...rest] = responses
+      for (const r of rest) {
+        expect(r).toBe(first)
+      }
+    },
+  )
+
+  it("calls every R4 retriever exactly once on the default path regardless of mode", async () => {
+    for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
+      vi.clearAllMocks()
+      setupRetrieverFixtures()
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: successEmbedder(),
+        logger: { warn: vi.fn(), error: vi.fn() },
+      })
+      await service.search({ query: "jesus", locale: "en", mode })
+      expect(searchVideoSemantic).toHaveBeenCalledTimes(1)
+      expect(searchVideoKeyword).toHaveBeenCalledTimes(1)
+      expect(searchExperienceSemantic).toHaveBeenCalledTimes(1)
+      expect(searchExperienceKeyword).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it("emits exactly one sanitized warn log on unknown mode and never throws", async () => {
+    const warn = vi.fn()
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn, error: vi.fn() },
+    })
+
+    await service.search({ query: "jesus", locale: "en", mode: "garbage" })
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    const line = warn.mock.calls[0]![0] as string
+    expect(line).toContain("event=search_unknown_mode")
+    expect(line).toContain("mode=garbage")
+    expect(line).toContain("falling_back=hybrid")
+  })
+
+  it("strips CR/LF/TAB from sanitized mode value to prevent log injection", async () => {
+    const warn = vi.fn()
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn, error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "garbage\r\nevent=injected",
+    })
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    const line = warn.mock.calls[0]![0] as string
+    // Newlines / tabs have been replaced with spaces. The sanitized
+    // payload still contains the literal substring `event=injected`
+    // (clamped + space-replaced), but no NEW log line was started, so
+    // a downstream log shipper sees one record, not two.
+    expect(line).not.toMatch(/[\r\n\t]/)
+    expect(line.split("\n").length).toBe(1)
+    expect(line).toContain("event=search_unknown_mode")
+    // `\r\n` becomes two spaces (no whitespace collapsing — keeps the
+    // sanitizer minimal and predictable).
+    expect(line).toContain("mode=garbage  event=injected")
+  })
+
+  it("does NOT warn when mode is unset / null / empty / 'hybrid'", async () => {
+    for (const mode of [undefined, null, "", "hybrid"] as const) {
+      const warn = vi.fn()
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: successEmbedder(),
+        logger: { warn, error: vi.fn() },
+      })
+      await service.search({ query: "jesus", locale: "en", mode })
+      expect(warn).not.toHaveBeenCalled()
+    }
+  })
+
+  it("does NOT warn when mode is the canonical 'keyword-first' value (recognized)", async () => {
+    const warn = vi.fn()
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn, error: vi.fn() },
+    })
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "keyword-first",
+    })
+    // Wired but not branched on in Unit 2 — the orchestrator's response
+    // is still hybrid-shaped. No warn should fire because the value is
+    // recognized.
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it("preserves searchMode='hybrid' when embedding succeeds — orthogonal to input mode", async () => {
+    for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: successEmbedder(),
+        logger: { warn: vi.fn(), error: vi.fn() },
+      })
+      const result = await service.search({
+        query: "jesus",
+        locale: "en",
+        mode,
+      })
+      expect(result.searchMode).toBe("hybrid")
+    }
+  })
+
+  it("preserves searchMode='keyword-only' when embedding fails — orthogonal to input mode", async () => {
+    const failingEmbedder: QueryEmbedder = vi
+      .fn()
+      .mockRejectedValue(new Error("provider down"))
+    for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: failingEmbedder,
+        logger: { warn: vi.fn(), error: vi.fn() },
+      })
+      const result = await service.search({
+        query: "jesus",
+        locale: "en",
+        mode,
+      })
+      expect(result.searchMode).toBe("keyword-only")
+    }
+  })
+})

--- a/apps/admin/src/services/hybrid-search.regression.test.ts
+++ b/apps/admin/src/services/hybrid-search.regression.test.ts
@@ -34,12 +34,25 @@ vi.mock("./hybrid-search-retrievers", () => ({
   searchExperienceKeyword: vi.fn(),
 }))
 
+vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
+  searchByKeywordWeighted: vi.fn().mockResolvedValue([]),
+  searchByTrigram: vi.fn().mockResolvedValue([]),
+  searchByExactTitle: vi.fn().mockResolvedValue([]),
+  MAX_EXACT_TITLE_TOKENS: 16,
+  tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
+}))
+
 import {
   searchVideoSemantic,
   searchVideoKeyword,
   searchExperienceSemantic,
   searchExperienceKeyword,
 } from "./hybrid-search-retrievers"
+import {
+  searchByKeywordWeighted,
+  searchByTrigram,
+  searchByExactTitle,
+} from "./hybrid-search-keyword-first-retrievers"
 import { __resetSearchHealthForTest } from "./hybrid-search-health"
 import {
   HybridSearchService,
@@ -173,6 +186,22 @@ describe("HybridSearchService default-mode regression snapshot", () => {
       expect(searchVideoKeyword).toHaveBeenCalledTimes(1)
       expect(searchExperienceSemantic).toHaveBeenCalledTimes(1)
       expect(searchExperienceKeyword).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it("NEVER calls keyword-first retrievers on the default path", async () => {
+    for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
+      vi.clearAllMocks()
+      setupRetrieverFixtures()
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: successEmbedder(),
+        logger: { warn: vi.fn(), error: vi.fn() },
+      })
+      await service.search({ query: "jesus", locale: "en", mode })
+      expect(searchByKeywordWeighted).not.toHaveBeenCalled()
+      expect(searchByTrigram).not.toHaveBeenCalled()
+      expect(searchByExactTitle).not.toHaveBeenCalled()
     }
   })
 

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -22,6 +22,8 @@ import {
 import { __resetSearchHealthForTest, getStats } from "./hybrid-search-health"
 import {
   HybridSearchService,
+  normalizeMode,
+  sanitizeForLog,
   type QueryEmbedder,
 } from "./hybrid-search.service"
 
@@ -386,5 +388,89 @@ describe("HybridSearchService", () => {
       startSeconds: null,
       playbackId: null,
     })
+  })
+})
+
+describe("normalizeMode", () => {
+  it("treats null / undefined / '' / 'hybrid' as the canonical hybrid value", () => {
+    const warn = vi.fn()
+    expect(normalizeMode(undefined, { warn })).toBe("hybrid")
+    expect(normalizeMode(null, { warn })).toBe("hybrid")
+    expect(normalizeMode("", { warn })).toBe("hybrid")
+    expect(normalizeMode("hybrid", { warn })).toBe("hybrid")
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it("recognizes 'keyword-first' verbatim (no warn)", () => {
+    const warn = vi.fn()
+    expect(normalizeMode("keyword-first", { warn })).toBe("keyword-first")
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it("is case-sensitive — 'HYBRID' / 'Keyword-First' are unknown", () => {
+    const warn = vi.fn()
+    expect(normalizeMode("HYBRID", { warn })).toBe("hybrid")
+    expect(normalizeMode("Keyword-First", { warn })).toBe("hybrid")
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
+  it("rejects whitespace-padded values as unknown", () => {
+    const warn = vi.fn()
+    // The contract is explicit recognition by literal match — leading
+    // / trailing whitespace at the boundary is the caller's
+    // responsibility to trim. The empty-string carve-out covers the
+    // common `?mode=` shape; anything else warns.
+    expect(normalizeMode(" hybrid", { warn })).toBe("hybrid")
+    expect(normalizeMode("keyword-first ", { warn })).toBe("hybrid")
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
+  it("emits exactly one structured warn line on unknown values", () => {
+    const warn = vi.fn()
+    normalizeMode("garbage", { warn })
+    expect(warn).toHaveBeenCalledTimes(1)
+    const line = warn.mock.calls[0]![0] as string
+    expect(line).toContain("event=search_unknown_mode")
+    expect(line).toContain("mode=garbage")
+    expect(line).toContain("falling_back=hybrid")
+  })
+
+  it("never throws on weird inputs", () => {
+    const warn = vi.fn()
+    // Type-system says string|null|undefined; runtime can still see
+    // anything if a caller bypasses the boundary.
+    expect(() =>
+      normalizeMode(123 as unknown as string, { warn }),
+    ).not.toThrow()
+    expect(() => normalizeMode({} as unknown as string, { warn })).not.toThrow()
+  })
+})
+
+describe("sanitizeForLog", () => {
+  it("strips CR, LF, and TAB to single spaces", () => {
+    expect(sanitizeForLog("a\rb\nc\td")).toBe("a b c d")
+  })
+
+  it("does NOT collapse runs of whitespace (`\\r\\n` becomes two spaces)", () => {
+    expect(sanitizeForLog("a\r\nb")).toBe("a  b")
+  })
+
+  it("clamps to 64 characters", () => {
+    const input = "x".repeat(100)
+    const result = sanitizeForLog(input)
+    expect(result).toHaveLength(64)
+    expect(result).toBe("x".repeat(64))
+  })
+
+  it("preserves input that fits within the budget", () => {
+    expect(sanitizeForLog("hybrid")).toBe("hybrid")
+    expect(sanitizeForLog("a".repeat(64))).toBe("a".repeat(64))
+  })
+
+  it("coerces non-string input via String(...)", () => {
+    expect(sanitizeForLog(123)).toBe("123")
+    expect(sanitizeForLog(null)).toBe("null")
+    expect(sanitizeForLog(undefined)).toBe("undefined")
+    expect(sanitizeForLog({})).toBe("[object Object]")
   })
 })

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -28,7 +28,8 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockPrisma = {} as any
 const loggerError = vi.fn()
-const logger = { error: loggerError }
+const loggerWarn = vi.fn()
+const logger = { error: loggerError, warn: loggerWarn }
 
 function successEmbedder(vector: number[] = [0.1, 0.2, 0.3]): QueryEmbedder {
   return vi.fn().mockResolvedValue(vector)

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -32,6 +32,11 @@ import {
   searchExperienceSemantic,
   searchExperienceKeyword,
 } from "./hybrid-search-retrievers"
+import {
+  searchByKeywordWeighted,
+  searchByTrigram,
+  searchByExactTitle,
+} from "./hybrid-search-keyword-first-retrievers"
 
 export const RRF_K = 60
 export const DEFAULT_LIMIT = 20
@@ -261,10 +266,8 @@ export class HybridSearchService {
     // Decode the opt-in pipeline mode. Unknown values warn-and-fall-back
     // to "hybrid" without throwing — same contract REST + GraphQL
     // surface to clients. Computed once per call so the warn log fires
-    // at most once. Wired but not branched on in this unit; Unit 3
-    // adds the `mode === "keyword-first"` retrieval branch.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _pipelineMode = normalizeMode(params.mode, this.logger)
+    // at most once.
+    const pipelineMode = normalizeMode(params.mode, this.logger)
     const limit = Math.min(
       Math.max(1, params.limit ?? DEFAULT_LIMIT),
       MAX_LIMIT,
@@ -312,6 +315,8 @@ export class HybridSearchService {
     const retrievals: Retrieval[] = []
 
     if (wantsVideos) {
+      // Semantic-video is shared between hybrid and keyword-first —
+      // both pipelines benefit from scene-level vector matches.
       retrievals.push({
         label: "semantic-video",
         promise:
@@ -323,14 +328,49 @@ export class HybridSearchService {
               }) as Promise<RankedItem[]>)
             : Promise.resolve([]),
       })
-      retrievals.push({
-        label: "keyword-video",
-        promise: searchVideoKeyword(this.prisma, {
-          query,
-          locale,
-          limit: overfetchLimit,
-        }) as Promise<RankedItem[]>,
-      })
+
+      if (pipelineMode === "keyword-first") {
+        // Three-list lexical stack: phrase-aware weighted tsvector,
+        // typo-tolerant trigram on title, and exact-token-in-title
+        // (Algolia-like). The legacy R4 `searchVideoKeyword` is NOT
+        // dispatched on this branch — its concatenated tsvector is
+        // strictly weaker than the weighted one for this workload.
+        retrievals.push({
+          label: "keyword-weighted-video",
+          promise: searchByKeywordWeighted(this.prisma, {
+            query,
+            locale,
+            limit: overfetchLimit,
+          }) as Promise<RankedItem[]>,
+        })
+        retrievals.push({
+          label: "trigram-video",
+          promise: searchByTrigram(this.prisma, {
+            query,
+            locale,
+            limit: overfetchLimit,
+          }) as Promise<RankedItem[]>,
+        })
+        retrievals.push({
+          label: "exact-title-video",
+          promise: searchByExactTitle(this.prisma, {
+            query,
+            locale,
+            limit: overfetchLimit,
+          }) as Promise<RankedItem[]>,
+        })
+      } else {
+        // Hybrid path — UNCHANGED from R4. Byte-identity locked in by
+        // hybrid-search.regression.test.ts.
+        retrievals.push({
+          label: "keyword-video",
+          promise: searchVideoKeyword(this.prisma, {
+            query,
+            locale,
+            limit: overfetchLimit,
+          }) as Promise<RankedItem[]>,
+        })
+      }
     }
 
     if (wantsExperiences) {

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -62,6 +62,64 @@ export type SearchParams = {
    * caller's intent.
    */
   contentTypes?: ContentType[]
+  /**
+   * Opt-in retrieval pipeline selector. Defaults to `"hybrid"` (the R4
+   * baseline). `"keyword-first"` activates the lexical retriever stack
+   * (Unit 3 onward). Unknown values warn-and-fall-back to `"hybrid"`;
+   * never throws. Stays a nullable string at the type level (and at
+   * the REST/GraphQL boundaries) so future modes can ship without
+   * schema changes — `normalizeMode()` is the canonical decoder.
+   *
+   * Orthogonal to the `searchMode` *response* field, which is the
+   * embedding-degradation signal (`"hybrid"|"keyword-only"`).
+   */
+  mode?: string | null
+}
+
+/**
+ * Closed set of canonical retrieval pipelines after `normalizeMode`.
+ *
+ * Internal type — do NOT use as a GraphQL/REST input type. The boundary
+ * stays a nullable string so `normalizeMode` can warn-and-fall-back on
+ * unknown values without breaking clients on rollouts of new modes.
+ */
+export type SearchPipelineMode = "hybrid" | "keyword-first"
+
+/**
+ * Sanitizer for user-supplied values that get interpolated into
+ * structured log lines. Strips CR/LF/TAB so an attacker cannot inject
+ * synthetic `event=...` tokens via the request, and clamps length so
+ * a 1MB pasted string cannot bloat log shipping.
+ *
+ * Per docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md.
+ */
+export function sanitizeForLog(raw: unknown): string {
+  return String(raw)
+    .replace(/[\r\n\t]/g, " ")
+    .slice(0, 64)
+}
+
+/**
+ * Decodes the public `mode` argument to a canonical pipeline mode.
+ *
+ * `unset | null | "" | "hybrid"` → `"hybrid"`.
+ * `"keyword-first"` → `"keyword-first"`.
+ * anything else → `"hybrid"`, with a single structured warn log
+ * carrying the sanitized raw value.
+ *
+ * Never throws. The warn line is fire-once-per-call (callers invoke
+ * this exactly once at request entry).
+ */
+export function normalizeMode(
+  raw: string | null | undefined,
+  logger: { warn: (message: string) => void },
+): SearchPipelineMode {
+  if (raw == null || raw === "" || raw === "hybrid") return "hybrid"
+  if (raw === "keyword-first") return "keyword-first"
+  logger.warn(
+    `[search] event=search_unknown_mode mode=${sanitizeForLog(raw)} falling_back=hybrid`,
+  )
+  return "hybrid"
 }
 
 export type SearchResult = {
@@ -171,27 +229,42 @@ export type HybridSearchServiceDeps = {
   prisma: PrismaClient
   embedder?: QueryEmbedder
   /** Injectable logger; defaults to console. Mirror the cms `log.error`
-   *  shape so operators see the same `event=...` structured lines. */
+   *  / `log.warn` shape so operators see the same `event=...` structured
+   *  lines across the cms→admin migration window. `warn` is consulted
+   *  for unknown-mode fallback; `error` for embedding/retrieval failures. */
   logger?: {
     error: (message: string) => void
+    warn: (message: string) => void
   }
 }
 
 export class HybridSearchService {
   private readonly prisma: PrismaClient
   private readonly embedder: QueryEmbedder
-  private readonly logger: { error: (message: string) => void }
+  private readonly logger: {
+    error: (message: string) => void
+    warn: (message: string) => void
+  }
 
   constructor(deps: HybridSearchServiceDeps) {
     this.prisma = deps.prisma
     this.embedder = deps.embedder ?? defaultEmbedder
     this.logger = deps.logger ?? {
       error: (message: string) => console.error(message),
+      warn: (message: string) => console.warn(message),
     }
   }
 
   async search(params: SearchParams): Promise<SearchResponse> {
     const { query, locale } = params
+
+    // Decode the opt-in pipeline mode. Unknown values warn-and-fall-back
+    // to "hybrid" without throwing — same contract REST + GraphQL
+    // surface to clients. Computed once per call so the warn log fires
+    // at most once. Wired but not branched on in this unit; Unit 3
+    // adds the `mode === "keyword-first"` retrieval branch.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _pipelineMode = normalizeMode(params.mode, this.logger)
     const limit = Math.min(
       Math.max(1, params.limit ?? DEFAULT_LIMIT),
       MAX_LIMIT,

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -36,12 +36,36 @@ import {
   searchByKeywordWeighted,
   searchByTrigram,
   searchByExactTitle,
+  tokenizeForExactTitle,
 } from "./hybrid-search-keyword-first-retrievers"
 
 export const RRF_K = 60
 export const DEFAULT_LIMIT = 20
 export const MAX_LIMIT = 50
 export const OVERFETCH_FACTOR = 3
+
+/**
+ * Top-N keyword-side window used by the dilution cap. Plan-default 3.
+ * Higher widens the "this result genuinely shares an entity with the
+ * keyword winner" allowlist; lower bites harder.
+ */
+export const DILUTION_CAP_TOP_N = 3
+
+/** Down-weight applied by the dilution cap to semantic-only results
+ *  with no keyword-side core_id overlap. Plan-default 0.5. */
+export const DILUTION_CAP_DOWNWEIGHT = 0.5
+
+/**
+ * Read the dilution cap toggle. Default `true` (cap is active in
+ * keyword-first mode unless explicitly disabled by setting the env
+ * var to `"false"`). Hybrid mode never reaches the cap step regardless.
+ *
+ * Tolerant parser (e.g. accepting `"0"`, `"off"`) is a documented
+ * follow-up; today only the literal string `"false"` disables the cap.
+ */
+export function isDilutionCapEnabled(): boolean {
+  return process.env.SEARCH_DILUTION_CAP_ENABLED !== "false"
+}
 
 export type ContentType = "video" | "experience"
 
@@ -79,6 +103,28 @@ export type SearchParams = {
    * embedding-degradation signal (`"hybrid"|"keyword-only"`).
    */
   mode?: string | null
+  /**
+   * When true, the orchestrator attaches per-result internal scoring
+   * detail under `result.debug` (per-retriever ranks, fused score,
+   * dilution-cap state). The boundary is responsible for origin-gating
+   * via `isDebugAllowedForOrigin`; the service trusts the boolean.
+   */
+  debug?: boolean
+}
+
+/**
+ * Per-result debug payload. Surfaces internal scoring detail for
+ * operator inspection; origin-gated at the REST + GraphQL boundary.
+ *
+ * **Retriever labels are UNSTABLE** — they're internal implementation
+ * names and may be renamed without a breaking-change marker. Operators
+ * inspecting a payload for triage are the intended audience; do not
+ * branch on these strings in production code.
+ */
+export type SearchResultDebug = {
+  retrieverRanks: Array<{ label: string; rank: number }>
+  fusedScore: number
+  dilutionCapApplied: boolean
 }
 
 /**
@@ -140,6 +186,13 @@ export type SearchResult = {
   /** null when the match is keyword-only or for non-video results. */
   playbackId: string | null
   score: number
+  /**
+   * Internal scoring detail. Present only when the caller passed
+   * `debug: true` AND the request origin is on the debug allowlist
+   * (origin gating is the boundary's responsibility). Stripped
+   * silently otherwise.
+   */
+  debug?: SearchResultDebug
 }
 
 /**
@@ -400,11 +453,56 @@ export class HybridSearchService {
       this.unwrapOutcome(outcome, retrievals[i]!.label),
     )
 
+    // (label, list) pairs for downstream origin tracking. Used by both
+    // the dilution cap and the debug payload.
+    const labeledLists = retrievals.map((r, i) => ({
+      label: r.label,
+      list: lists[i] ?? [],
+    }))
+
+    // Per-key origin + rank map. Built unconditionally because the cap
+    // logic also reads it — even when the user didn't pass `debug:true`.
+    // Stripping happens at the response-mapping step below.
+    const debugByKey = new Map<string, SearchResultDebug>()
+    for (const { label, list } of labeledLists) {
+      for (let i = 0; i < list.length; i++) {
+        const item = list[i]!
+        const key = `${item.resultType}:${item.resultId}`
+        const existing = debugByKey.get(key)
+        if (existing == null) {
+          debugByKey.set(key, {
+            retrieverRanks: [{ label, rank: i + 1 }],
+            fusedScore: 0,
+            dilutionCapApplied: false,
+          })
+        } else {
+          existing.retrieverRanks.push({ label, rank: i + 1 })
+        }
+      }
+    }
+
     // Step 3: Fuse ranked lists via RRF. Drop empty lists first — RRF
     // normalizes by dividing by the number of input lists, so empty
     // ones dilute scores from lists that did contribute.
     const nonEmptyLists = lists.filter((list) => list.length > 0)
     const fused = fuseRankedLists(nonEmptyLists, RRF_K)
+
+    // Snapshot pre-cap fused scores so the debug payload can surface
+    // both numbers (the cap mutates `result.score` in place).
+    for (const result of fused) {
+      const key = `${result.resultType}:${result.resultId}`
+      const trace = debugByKey.get(key)
+      if (trace != null) trace.fusedScore = result.score
+    }
+
+    // Step 3b: Semantic-dilution cap. Active only in keyword-first mode
+    // and only when an exact-title hit exists. Halves the score of any
+    // fused result whose ONLY contributing list was semantic AND whose
+    // video core_id is not represented in the top-N keyword-side
+    // core_ids. Hybrid mode never reaches this step.
+    if (pipelineMode === "keyword-first" && isDilutionCapEnabled()) {
+      applyDilutionCap(fused, labeledLists, query, debugByKey)
+    }
 
     // Step 4: Dedup one extra result beyond the page window so we know
     // whether more results exist (drives hasMore without a full count
@@ -414,7 +512,14 @@ export class HybridSearchService {
     // Step 5: Paginate and map to API contract.
     const page = deduped.slice(offset, offset + limit)
     const hasMore = deduped.length > offset + limit
-    const results = page.map(mapToSearchResult)
+    const results = page.map((result) => {
+      const base = mapToSearchResult(result)
+      if (params.debug !== true) return base
+      const key = `${result.resultType}:${result.resultId}`
+      const trace = debugByKey.get(key)
+      if (trace == null) return base
+      return { ...base, debug: trace }
+    })
 
     return {
       results,
@@ -441,4 +546,80 @@ export class HybridSearchService {
     )
     return []
   }
+}
+
+/**
+ * Apply the keyword-first semantic-dilution cap.
+ *
+ * Triggers iff the exact-title list returned at least one result whose
+ * title (lowercased + tokenized) contains every query token — i.e. the
+ * user typed something with a clear lexical winner.
+ *
+ * When triggered, any fused result whose ONLY contributing list was
+ * `"semantic-video"` AND whose `videoCoreId` is null OR not in the
+ * top-N (default 3) of the three keyword-side lists' core_ids gets
+ * `score *= DILUTION_CAP_DOWNWEIGHT`. The list is then re-sorted.
+ *
+ * Mutates `fused` in place. Records cap application on `debugByKey`
+ * so the optional debug payload can surface it.
+ *
+ * Hard filtering is intentionally NOT used: thematic queries
+ * ("hope when life is hard") have no exact-title trigger, so the cap
+ * silently does nothing on them.
+ *
+ * Exported for unit-level testing.
+ */
+export function applyDilutionCap(
+  fused: FusedResult[],
+  labeledLists: Array<{ label: string; list: RankedItem[] }>,
+  query: string,
+  debugByKey: Map<string, SearchResultDebug>,
+): void {
+  const exactTitleList =
+    labeledLists.find((ll) => ll.label === "exact-title-video")?.list ?? []
+
+  const tokens = tokenizeForExactTitle(query)
+  if (tokens.length === 0) return
+
+  const triggered = exactTitleList.some((item) => {
+    const title = ((item.videoTitle as string | undefined) ?? "").toLowerCase()
+    return tokens.every((t) => title.includes(t))
+  })
+  if (!triggered) return
+
+  // Top-N keyword-side core_ids — the "this entity is genuinely a
+  // keyword winner" allowlist. Aggregated across the three lexical
+  // retrievers; a result represented in any of them is exempt.
+  const topNCoreIds = new Set<string>()
+  for (const label of [
+    "keyword-weighted-video",
+    "trigram-video",
+    "exact-title-video",
+  ]) {
+    const list = labeledLists.find((ll) => ll.label === label)?.list ?? []
+    for (let i = 0; i < Math.min(DILUTION_CAP_TOP_N, list.length); i++) {
+      const cid = (list[i]!.videoCoreId as string | null | undefined) ?? null
+      if (cid != null && cid.length > 0) topNCoreIds.add(cid)
+    }
+  }
+
+  for (const result of fused) {
+    if (result.resultType !== "video") continue
+
+    const key = `${result.resultType}:${result.resultId}`
+    const trace = debugByKey.get(key)
+    const origins = new Set((trace?.retrieverRanks ?? []).map((r) => r.label))
+    const onlySemantic = origins.size === 1 && origins.has("semantic-video")
+    if (!onlySemantic) continue
+
+    const cid = (result.videoCoreId as string | null | undefined) ?? null
+    const sharesKeywordCoreId =
+      cid != null && cid.length > 0 && topNCoreIds.has(cid)
+    if (sharesKeywordCoreId) continue
+
+    result.score *= DILUTION_CAP_DOWNWEIGHT
+    if (trace != null) trace.dilutionCapApplied = true
+  }
+
+  fused.sort((a, b) => b.score - a.score)
 }

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -582,7 +582,7 @@ export function applyDilutionCap(
   if (tokens.length === 0) return
 
   const triggered = exactTitleList.some((item) => {
-    const title = ((item.videoTitle as string | undefined) ?? "").toLowerCase()
+    const title = (item.videoTitle ?? "").toLowerCase()
     return tokens.every((t) => title.includes(t))
   })
   if (!triggered) return
@@ -598,7 +598,7 @@ export function applyDilutionCap(
   ]) {
     const list = labeledLists.find((ll) => ll.label === label)?.list ?? []
     for (let i = 0; i < Math.min(DILUTION_CAP_TOP_N, list.length); i++) {
-      const cid = (list[i]!.videoCoreId as string | null | undefined) ?? null
+      const cid = list[i]!.videoCoreId ?? null
       if (cid != null && cid.length > 0) topNCoreIds.add(cid)
     }
   }
@@ -612,7 +612,7 @@ export function applyDilutionCap(
     const onlySemantic = origins.size === 1 && origins.has("semantic-video")
     if (!onlySemantic) continue
 
-    const cid = (result.videoCoreId as string | null | undefined) ?? null
+    const cid = result.videoCoreId ?? null
     const sharesKeywordCoreId =
       cid != null && cid.length > 0 && topNCoreIds.has(cid)
     if (sharesKeywordCoreId) continue

--- a/docs/plans/2026-04-29-002-feat-search-cms-to-admin-keyword-first-port-plan.md
+++ b/docs/plans/2026-04-29-002-feat-search-cms-to-admin-keyword-first-port-plan.md
@@ -1,0 +1,1120 @@
+---
+title: "feat(admin): port keyword-first lexical search to admin (R4 extension)"
+type: feat
+status: active
+date: 2026-04-29
+origin: docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md
+predecessors:
+  - docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md
+  - docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md
+---
+
+# feat(admin): port keyword-first lexical search to admin (R4 extension)
+
+## Overview
+
+Port the keyword-first lexical search capability that shipped to
+`apps/cms` in PR #852 onto `apps/admin`'s R4 hybrid search foundation.
+Same opt-in `mode="keyword-first"` contract, same byte-identical-default
+invariant, same dilution cap and origin-gated debug payload — implemented
+against admin's Prisma schema (per-locale `VideoLocale` rows, cuid ids,
+Prisma migrations) instead of cms's Strapi v5 link-table model.
+
+This is **an extension of R4**, not a new R-stage. R4's
+`HybridSearchService` is the orchestrator we extend; the four R4
+retrievers stay untouched on the hybrid path; the keyword-first branch
+adds three new retrievers + the post-fusion cap. After R8 consumer
+cutover, cms's keyword-first work is deprecated alongside the rest of
+cms search.
+
+## Problem Frame
+
+The keyword-first capability was built on cms (PR #852, merged) when it
+should have extended admin's R4 (PR #837, merged 2026-04-23). The miss
+is documented in
+`docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md`
+and `docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md`.
+
+Per the migration playbook
+(`docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md`),
+all new search work belongs on admin. cms is the source side; admin is
+the destination. R4 is the right foundation for any new search
+capability.
+
+The recovery path is to port keyword-first to admin so admin's search
+surface matches the cms-side contract by R8 cutover. Until R8, both
+surfaces coexist (cms serves consumers; admin is canary).
+
+## Inherited Assumptions to Challenge
+
+Per the new compound learning
+(`docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md`),
+every load-bearing decision from the predecessor plan
+(`docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md`) is
+re-derived against admin's repo state below. Empty re-derivation cells
+would be a blocking review comment.
+
+| Inherited assumption (from cms feat-109)                                                      | Re-derived against admin                                                                                                                                                                                          | Still valid?                                              |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `mode` is a nullable String, not a closed enum                                                | Future modes (`"instant"`, `"persona-aware"`) ship without GraphQL schema changes. Pothos accepts nullable `String` args; warn-and-fall-back semantics work the same.                                             | **Yes**                                                   |
+| Single branched orchestrator, not twin functions                                              | Admin's `HybridSearchService.search()` is the natural branch point. R4 already centralizes embed → retrieve → fuse → dedup → paginate. Same shape.                                                                | **Yes**                                                   |
+| Default behavior MUST stay byte-identical to main when `mode` is unset/null/""/hybrid/garbage | R4's response contract is the new baseline. Test-first regression snapshot lands before any keyword-first code.                                                                                                   | **Yes — same posture, snapshot is against R4's behavior** |
+| Dilution cap default 0.5×, top-N=3                                                            | No reason to change. R4's RRF is verbatim port of cms (k=60, OVERFETCH_FACTOR=3).                                                                                                                                 | **Yes — same starting values**                            |
+| Origin-as-soft-gate for `debug` payload (not auth)                                            | Same threat model. Admin's CORS allowlist is configurable via env. Fail-closed on undefined origin still applies. Per `docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md`. | **Yes — same posture**                                    |
+| Bootstrap-on-every-boot pattern (idempotent DDL) via `ensure-search-lexical.ts`               | **NO — flips.** Admin uses Prisma migrations (`prisma/migrations/0009_*/migration.sql`), append-only. Same idempotency property at the migration layer.                                                           | **No — Prisma migration replaces on-boot DDL**            |
+| Strapi v5 raw SQL (snake_case, `knex.raw`)                                                    | **NO — translates.** Admin uses Prisma `$queryRaw` template literals + `Prisma.raw(EXPR)` for unbindable fragments. R4 already established the pattern.                                                           | **No — translates to Prisma idioms**                      |
+| Locale filter via `bcp_47` link tables (`languages.bcp_47 = ?`)                               | **NO — flips.** Admin filters via `vl.locale = ?` (column on `VideoLocale`). The `Language.bcp47` field is only consulted in semantic-video's `VideoDub` LATERAL lookup.                                          | **No — direct column filter**                             |
+| Single-row `videos.title` / `videos.description`                                              | **NO — flips.** Admin's title/description live on `VideoLocale` (per-locale rows). The new generated columns and GIN indexes are on `VideoLocale`, not `Video`.                                                   | **No — schema attachment changes**                        |
+| Retrievers return rows that need `annotateVideo()` to inject `resultType`/`resultId`          | **NO — already adopted.** R4 retrievers return `RankedItem`-shaped rows directly. The new keyword-first retrievers should match this.                                                                             | **No — stronger pattern, no annotate step**               |
+| `MAX_EXACT_TITLE_TOKENS = 16` token cap (DoS guard)                                           | Same DoS guard rationale. Admin doesn't loosen any input bounds vs cms.                                                                                                                                           | **Yes**                                                   |
+| Log-injection sanitizer on user-supplied `mode` value                                         | Same threat. Admin uses Pino-equivalent logging; same `replace(/[\r\n\t]/g, " ").slice(0, 64)` sanitizer applies. Confirm logger surface during implementation.                                                   | **Yes — apply with admin's logger**                       |
+| Six cms-paths solution docs                                                                   | **NO — extend.** The six docs need cross-references to admin paths (or new admin-side companion docs). The R4-extension solutions doc is the natural anchor.                                                      | **No — solution docs need admin-side cross-refs**         |
+| `searchMode` (response field) vs `mode` (input arg) naming collision                          | Same trap on admin (R4 already exposes `searchMode: "hybrid" \| "keyword-only"`). GraphQL schema description must explicitly disambiguate.                                                                        | **Yes — same disambiguation discipline**                  |
+
+## Requirements Trace
+
+From the playbook (R4 contract) and the cms feat-109 origin:
+
+- **R1.** Add a nullable `mode` argument (REST query param + GraphQL
+  nullable `String` arg) on admin's existing search surface. Accepts
+  `"hybrid"` (default) and `"keyword-first"`. Unknown values fall back
+  to hybrid with a structured warn log; never error.
+- **R2.** Default behavior is byte-identical to admin's R4 main when
+  `mode` is unset or `"hybrid"`. Locked in by a snapshot test that
+  runs throughout the PR.
+- **R3.** `mode="keyword-first"` activates the new video lexical stack
+  on admin's data model: phrase-aware tsquery (`websearch_to_tsquery`),
+  per-field weighted tsvector (`title_tsv` weight A, `description_tsv`
+  weight B) on `VideoLocale`, trigram matching on `VideoLocale.title`,
+  exact-token-in-title retriever as the 4th RRF list. Experience
+  retrievals (semantic + keyword) stay unchanged in either mode.
+- **R4.** DB infrastructure (`pg_trgm` extension, weighted generated
+  columns on `VideoLocale`, GIN indexes) lands in a Prisma migration.
+  Dormant on the hybrid path; the legacy R4 keyword retriever
+  (`searchVideoKeyword` against the existing
+  `video_locale_fulltext_search_idx`) stays untouched.
+- **R5.** Optional `debug=true` (REST query param + GraphQL arg)
+  surfaces per-retriever ranks + fused score + dilution-cap state per
+  result. Origin-gated at the boundary (REST controller + GraphQL
+  resolver); service trusts the boolean.
+- **R6.** `searchMode` response field semantics (`"hybrid" |
+"keyword-only"` — degradation signal) preserved verbatim. The new
+  input `mode` is orthogonal; documented disambiguation in the
+  GraphQL schema description.
+- **R7.** Strapi-v5 conventions DO NOT apply on admin. All raw SQL is
+  Prisma `$queryRaw` template literals; column names map to
+  snake_case in DB but `Prisma.raw(...)` is reserved for unbindable
+  expression fragments (per R4's established pattern).
+- **R8.** Admin's R0 (Core sync entity coverage) is upstream-blocked.
+  This plan ships code that's correct against admin's schema; data
+  lands when R0 runs. Real-DB integration tests are a deferred
+  follow-up gated on R0, same posture as R4 + R5.
+
+## Scope Boundaries
+
+**In scope:**
+
+- Prisma migration `0009_keyword_first_lexical/migration.sql`: pg_trgm
+  extension; generated `title_tsv` (A) + `description_tsv` (B) columns
+  on `VideoLocale`; weighted GIN index; GIN trigram index on
+  `VideoLocale.title`.
+- Shared SQL constants in
+  `apps/admin/src/services/hybrid-search-sql.ts` (the existing R4
+  module, extended). Per `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md`,
+  byte-parity guards apply only to the expression-based weighted GIN —
+  the trigram path uses operator-class indexing and needs no shared
+  constant.
+- Three new retrievers in
+  `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts`
+  (sibling to the R4 retriever module): `searchByKeywordWeighted`,
+  `searchByTrigram`, `searchByExactTitle`.
+- Branched orchestrator: `mode` plumbed through
+  `apps/admin/src/services/hybrid-search.service.ts`, REST handler at
+  `apps/admin/src/app/api/search/route.ts`, and GraphQL resolver at
+  `apps/admin/src/graphql/queries/hybrid-search.ts`.
+- Semantic-dilution cap behind `SEARCH_DILUTION_CAP_ENABLED` (default
+  on for keyword-first; no-op for hybrid).
+- Origin-gated `debug` field via a new
+  `apps/admin/src/services/hybrid-search-debug-allowlist.ts`. GraphQL
+  surface adds `SearchResultDebug` + `SearchRetrieverRank` types with
+  retriever labels marked UNSTABLE in schema descriptions.
+- Default-mode regression snapshot test (gating, test-first).
+- Bible Project headline acceptance test (orchestrator-level, mocked
+  retrievers).
+- Updated `apps/admin/CLAUDE.md` "Hybrid search keyword-first mode"
+  section appended after the R4 section.
+- New solution doc:
+  `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.
+- Cross-links to the admin-side from the six existing cms-paths
+  solution docs from feat-109.
+
+**Out of scope (deferred follow-ups):**
+
+- **Consumer cutover (R8).** apps/web / mobile / tv keep calling cms's
+  search endpoints during the R3→R8 window. R8 is a separate
+  one-shot.
+- **Deprecating cms keyword-first.** Happens at R8 alongside the rest
+  of cms search deprecation. This plan does NOT delete cms code.
+- **R0 Core sync.** Tracked as
+  `docs/roadmap/platform/feat-109-admin-core-sync-entity-coverage.md`.
+  The keyword-first port ships code that's correct against the
+  schema; meaningful prod data depends on R0.
+- **Real-DB integration tests** (`EXPLAIN`-based GIN-index
+  verification, Bible Project headline against seeded fixtures,
+  canary diff vs cms across a fixed query set × locales). Same
+  posture as R4 + R5: deferred until R0 lands. Captured here as
+  the explicit follow-up gate.
+- **`statement_timeout` for SQL retrievers.** Pre-existing
+  cross-cutting concern (R4 doesn't have it either). Broader-scope
+  follow-up; not introduced in this PR.
+- **Token-based debug auth.** Origin gate is the soft feature flag
+  posture inherited from cms; replacing with auth happens only if
+  the debug payload starts carrying user-scoped data.
+- **Tolerant parser for `SEARCH_DILUTION_CAP_ENABLED`** (currently
+  only literal `"false"` disables). Quality-of-life improvement;
+  follow-up.
+- **Apply lexical stack to `experiences`.** R4 covers experience
+  semantic + keyword. Adding keyword-first to experience-locale is a
+  separate ticket; videos-only this round.
+- **`apps/cms` ID collision cleanup.** `feat-109` is duplicated
+  between content-discovery and platform tickets. Out of scope here;
+  flag as a roadmap-hygiene follow-up.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Admin (target — extend these):**
+
+- `apps/admin/src/services/hybrid-search.service.ts` —
+  `HybridSearchService` orchestrator. Add `mode` parameter; branch the
+  video retrieval set on `mode === "keyword-first"`; insert the
+  dilution-cap step between fusion and dedup.
+- `apps/admin/src/services/hybrid-search-sql.ts` — extend with
+  `WEIGHTED_TSV_INDEX_EXPR` / `WEIGHTED_TSV_QUERY_EXPR` constants for
+  the new lexical stack. Existing four constants stay untouched.
+- `apps/admin/src/services/hybrid-search-retrievers.ts` — UNTOUCHED
+  on hybrid path. Continues to host the four R4 retrievers.
+- `apps/admin/src/services/hybrid-search-fusion.ts` — RRF + dedup;
+  unchanged. The dilution cap operates on its output, not on the
+  fusion algorithm.
+- `apps/admin/src/services/hybrid-search-health.ts` — unchanged.
+- `apps/admin/src/app/api/search/route.ts` — REST handler. Extend
+  with `mode` and `debug` query-param parsing; pass `debug:
+isDebugAllowedForOrigin(...)` to the service.
+- `apps/admin/src/graphql/queries/hybrid-search.ts` — Pothos resolver
+  - types. Extend with `mode: String` arg, `debug: Boolean` arg, and
+    `debug: SearchResultDebug` field on the result type.
+- `apps/admin/src/graphql/types/` — add `hybrid-search-debug.ts` for
+  `SearchResultDebug` + `SearchRetrieverRank` types.
+- `apps/admin/src/auth/rate-limit.ts` — `rateLimitAuthRoute` already
+  used by R4 search endpoints. No change.
+- `apps/admin/prisma/migrations/0009_keyword_first_lexical/` — new
+  migration directory.
+
+**Admin precedent (the R4 plan that this extends):**
+
+- `docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md` —
+  full structural reference. R4 went through 8 units; this extension
+  is 5 units because R4 is the foundation.
+- `apps/admin/CLAUDE.md` "Hybrid search (R4 of admin migration
+  playbook)" section — reference for the keyword-first extension's
+  CLAUDE.md addition.
+
+**cms source (the work to port — read for behavior, NOT to copy):**
+
+- `apps/cms/src/api/search/services/lexical-sql.ts` — shared constants
+  module. Translate to admin's `hybrid-search-sql.ts` extension.
+- `apps/cms/src/api/search/services/keyword-weighted-search.ts`,
+  `trigram-search.ts`, `exact-title-search.ts` — three retrievers.
+  SQL shape ports; column names + join chain re-derive.
+- `apps/cms/src/api/search/services/search.ts` — branched orchestrator
+  - `applyDilutionCap`. Logic ports verbatim; SQL doesn't.
+- `apps/cms/src/api/search/services/debug-allowlist.ts` — origin gate.
+  Ports verbatim (no admin-specific divergence).
+- `apps/cms/src/api/search/services/search.regression.test.ts`,
+  `search.keyword-first.test.ts`, `search.dilution-cap.test.ts`,
+  `search.bible-project.test.ts` — test patterns. Port the assertions
+  - behaviors; admin's mock harness differs.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md`
+  — the workflow miss this plan corrects. Documents why this work
+  belongs on admin.
+- `docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md`
+  — the inherited-assumptions audit pattern. The "Inherited
+  Assumptions to Challenge" section above is the discipline.
+- `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md`
+  — distinguishes byte-parity-guarded expression GIN from
+  operator-class GIN. Explains why the trigram path needs no shared
+  constant.
+- `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`
+  — generated-column drift trap. Less relevant on admin (Prisma
+  migrations don't use `IF NOT EXISTS`-keyed boot guards), but the
+  rule "any change to a generated expression requires an explicit
+  drop-and-recreate migration" still applies.
+- `docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md`
+  — threat model for the debug origin gate.
+- `docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md`
+  — sanitizer for the unknown-mode warn log.
+- `docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md`
+  — the branched-orchestrator design. Confirms the single-function-
+  with-`if`-branch shape over twin functions or strategy-pattern
+  abstraction.
+- `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`
+  — the test-first regression snapshot pattern. Adopted as the
+  gating test for this PR.
+- `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md`
+  — re-derive every invariant from cms's port. Already explicit in
+  this plan's "Inherited Assumptions" table.
+- `docs/solutions/best-practices/prototype-defaults-vs-data-derived-enumeration-20260422.md`
+  — no hardcoded `en` fallback. Locale required at boundary; zero
+  results on a locale with no corpus is a legitimate signal.
+- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md` — the
+  R4 pattern doc. The new keyword-first solution doc is its sibling,
+  not a replacement.
+
+### External References
+
+Skipped — Postgres `pg_trgm`, `websearch_to_tsquery`, weighted
+tsvector, RRF, and Prisma `$queryRaw` are well-established and
+documented in admin's R4 + R5 work. Local patterns are sufficient.
+
+## Key Technical Decisions
+
+- **Extend R4, do not fork.** Single `HybridSearchService` with one
+  branch on `mode === "keyword-first"`. Per
+  `docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md`.
+
+- **Generated columns + GIN indexes attach to `VideoLocale`, not
+  `Video`.** Admin's localized title/description live on
+  `VideoLocale` rows. cms's single-row attachment translates to a
+  per-locale attachment here.
+
+- **Per-locale partial GIN indexes are NOT needed.** Unlike pgvector
+  HNSW (which has the `pgvector-hnsw-index-bypass-with-where-filter`
+  planner trap), GIN indexes support lossy WHERE filtering and do not
+  need per-locale partials. Confirmed by R4's existing GIN posture
+  (one global GIN index, locale filter via `vl.locale = ?`).
+
+- **Migration `0009`, append-only.** Per admin's migration convention
+  (collapsed `0001_init`; append from there). The migration runs
+  idempotently in dev/preview and once in prod. No on-boot DDL.
+
+- **`searchByKeywordWeighted` SQL filters by locale via `vl.locale =
+?`.** Same as R4's `searchVideoKeyword`. The weighted tsvector
+  expression is alias-prefixed for the query (`vl.title_tsv`,
+  `vl.description_tsv`); the planner strips alias prefixes before
+  comparing to the indexed expression, so byte-parity holds with
+  the migration's bare-column index expression.
+
+- **`searchByTrigram` uses `videos_locale.title %> ?` with the
+  GIN trigram index on `VideoLocale.title gin_trgm_ops`.** Per
+  `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md`,
+  the trigram path uses operator-class indexing — no shared TS
+  constant needed; alias differences are irrelevant to index
+  selection.
+
+- **`searchByExactTitle` ports the 16-token cap.** `MAX_EXACT_TITLE_TOKENS
+= 16` from the cms-side fix. Tokenization (Unicode letter/digit
+  split, lowercase, deduplicate) ports verbatim.
+
+- **All keyword-first retrievers use `Prisma.raw(EXPR)` for the
+  weighted tsvector fragment.** Per R4's established pattern in
+  `searchVideoKeyword`. User input is bound via template-literal
+  interpolation (`${trimmed}`); only the unbindable expression
+  fragment uses `Prisma.raw`.
+
+- **`searchByExactTitle`'s dynamic ILIKE chain uses positional
+  binding.** N tokens → N `vl.title ILIKE ?` clauses joined with
+  `AND`. Bindings array is `[locale, ...tokens.map(t => '%${t}%'),
+limit]`. Postgres rejects unbound placeholder mismatches at parse
+  time — the safe failure mode.
+
+- **`mode` is a nullable String at both REST and GraphQL boundaries.**
+  Future modes ship as new values without schema changes. Unknown
+  values warn-and-fall-back via `normalizeMode(logger, raw)` — same
+  shape as cms.
+
+- **Log-injection sanitizer in `normalizeMode`.** `replace(/[\r\n\t]/g,
+" ").slice(0, 64)` before interpolating into the warn line. Per
+  `docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md`.
+
+- **Origin-gated `debug` payload via
+  `isDebugAllowedForOrigin(origin)`.** Fail closed on `undefined` /
+  empty origin. Default allowlist: any origin in non-production;
+  explicit `SEARCH_DEBUG_ALLOWED_ORIGINS` CSV overrides. Per
+  `docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md`.
+
+- **Dilution cap defaults: `top-N=3`, `downweight=0.5×`,
+  `SEARCH_DILUTION_CAP_ENABLED` default true on keyword-first.**
+  Same starting values as cms. Tunable post-launch.
+
+- **GraphQL retriever-rank labels marked UNSTABLE in schema
+  description.** `SearchRetrieverRank.label: String!` carries internal
+  retriever names. Renaming a retriever later is a soft contract
+  break for any consumer that depends on the literal strings; the
+  schema description must explicitly say "UNSTABLE — implementation
+  labels, do not branch on them in production code." Per the
+  cms-side fix from PR #852.
+
+- **Default-mode regression test is the gate.** Test-first sequencing
+  per
+  `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`.
+  Lands as the FIRST commit; held green through every subsequent
+  unit. Pairs JSON-equality with `not.toHaveBeenCalled()` behavioral
+  assertions for each new retriever.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does this work belong?** Admin, as an R4 extension. Per
+  the migration playbook + the workflow-miss compound docs.
+- **R-stage or extension?** R4 extension. The playbook says R4 covers
+  "the full feat-010 + feat-086 + feat-097 contract" — keyword-first
+  is net-new beyond that contract but doesn't warrant a new R-stage.
+- **Migration sequence number?** `0009_keyword_first_lexical`
+  (verified — `0007_admin_core_sync_coverage` and
+  `0008_reference_locale_rows` already exist).
+- **Generated-column attachment?** `VideoLocale` (per-locale title +
+  description live there).
+- **Per-locale partial GIN indexes?** No — GIN doesn't have HNSW's
+  WHERE-filter bypass.
+- **Trigger byte-parity guard for trigram?** No — operator-class GIN
+  doesn't need it.
+- **One file or sibling files for the three new retrievers?** Sibling
+  module (`hybrid-search-keyword-first-retrievers.ts`) separate from
+  R4's `hybrid-search-retrievers.ts`. Keeps the R4 file untouched on
+  the hybrid path; mirrors the cms-side per-retriever-file shape.
+- **Embedding provider?** Reuse R4's `generateExperienceEmbedding`
+  (the historical-name embedder). No change.
+- **Search REST contract.** Same shape as R4 — extend with `mode` and
+  `debug` query params. 400/429/503 semantics unchanged.
+
+### Deferred to Implementation
+
+- **Final `top-N` window for the dilution-cap trigger.** Plan-default
+  3; tune against canary set once R0 backfills admin data.
+- **Final dilution-cap downweight constant.** Plan-default 0.5×;
+  tune against the same canary set.
+- **Whether `Video.deleted_at IS NULL` belongs in every keyword-first
+  retriever's WHERE.** R4 retrievers carry it. The keyword-first
+  retrievers should mirror — confirm against current `hybrid-search-retrievers.ts`
+  shape during implementation.
+- **Logger sanitization point.** Admin's logger surface (Pino via
+  Yoga? Strapi-style? `console.log` wrapper?) — confirm at
+  implementation; apply the strip+truncate sanitizer at the
+  `strapi.log.warn`-equivalent call site.
+- **GraphQL `SearchResultDebug` type registration.** Add a side-effect
+  import in `src/graphql/schema.ts` per admin's "adding a new Pothos
+  type requires three steps" rule. Confirm the existing search
+  query's type-file imports the new type before `builder.toSchema()`.
+- **Whether to register `searchByExactTitle` as a fifth RRF input or
+  as a tied 4-list (matching cms).** cms has 4 lists in keyword-first
+  (semantic + 3 lexical retrievers). Plan-default: same.
+- **Ports of the six cms-side solution docs.** Implementation-time
+  decision: append admin paths to the existing docs vs. write a new
+  R4-extension-pattern doc + cross-link. Plan-default: a new
+  R4-extension pattern doc, with cross-links from the six.
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance
+> for review, not implementation specification. The implementing
+> agent should treat it as context, not code to reproduce._
+
+The orchestrator branches on `mode` once, around the **video** retrieval
+block. Embedding, experience retrievals, fusion, dedup, and pagination
+are shared.
+
+```
+HybridSearchService.search({ query, locale, mode?, debug?, contentTypes?, limit?, offset? })
+  │
+  ├── normalize mode:  unset|"hybrid" → hybrid
+  │                    "keyword-first" → keyword-first
+  │                    else → log structured warn (with sanitizer), fallback to hybrid
+  │
+  ├── embed(query)  // unchanged from R4; failure → keyword-only degradation
+  │
+  ├── build retrievals[]:
+  │     if wantsVideos and mode == hybrid:                ← UNCHANGED FROM R4
+  │       L_v_sem  = searchVideoSemantic(...)
+  │       L_v_kw   = searchVideoKeyword(...)
+  │     if wantsVideos and mode == keyword-first:         ← NEW
+  │       L_v_sem  = searchVideoSemantic(...)             // shared with hybrid
+  │       L_v_kwW  = searchByKeywordWeighted(...)         // weighted tsv on VideoLocale
+  │       L_v_trg  = searchByTrigram(...)                 // VideoLocale.title %> q
+  │       L_v_exct = searchByExactTitle(...)              // every token in title
+  │     if wantsExperiences:                              ← UNCHANGED in either mode
+  │       L_e_sem  = searchExperienceSemantic(...)
+  │       L_e_kw   = searchExperienceKeyword(...)
+  │
+  ├── allSettled, drop empty lists, fuseRankedLists(k=60)
+  │
+  ├── if mode == keyword-first and SEARCH_DILUTION_CAP_ENABLED
+  │      and exact-title list has at least one full-token-match hit:
+  │        topN_kw_core_ids = ∪ core_ids of top-N from L_v_kwW, L_v_trg, L_v_exct
+  │        for each fused result that contributed only via L_v_sem
+  │            and result.videoCoreId ∉ topN_kw_core_ids:
+  │              result.score *= 0.5
+  │        re-sort
+  │
+  ├── deduplicateResults(...)  // unchanged 3-layer
+  ├── paginate(limit, offset)
+  ├── if debug allowed → attach { retrieverRanks, fusedScore, dilutionCapApplied } per result
+  └── return { results, hasMore, query, searchMode }
+                                          ↑
+                            unchanged degradation signal
+                            ("hybrid"/"keyword-only")
+```
+
+The hybrid branch reads no new columns and gains no new dependencies.
+The two paths share `embed()`, `fuseRankedLists()`, `deduplicateResults()`,
+and the pagination tail.
+
+### Schema delta (Prisma migration `0009_keyword_first_lexical`)
+
+```sql
+-- pseudocode; final SQL lives in
+-- apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+ALTER TABLE video_locale
+  ADD COLUMN title_tsv tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', coalesce(title, ''))) STORED;
+
+ALTER TABLE video_locale
+  ADD COLUMN description_tsv tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', coalesce(description, ''))) STORED;
+
+CREATE INDEX video_locale_lexical_weighted_idx
+  ON video_locale USING gin (
+    (setweight(title_tsv, 'A') || setweight(description_tsv, 'B'))
+  );
+
+CREATE INDEX video_locale_title_trgm_idx
+  ON video_locale USING gin (title gin_trgm_ops);
+```
+
+The expression in the weighted GIN index must appear byte-equal in
+`hybrid-search-sql.ts` (extending the R4 byte-parity test pattern).
+
+## Implementation Units
+
+> **Sequencing.** Five units, each its own commit. Unit 2 is the
+> regression test (test-first); Units 3–5 must keep it green.
+
+### Unit 1: Migration `0009` + lexical SQL constants
+
+**Goal:** Provision the DB infrastructure both modes can sit on. Append
+the byte-parity-guarded weighted-tsvector constants to admin's existing
+shared SQL module.
+
+**Requirements:** R3, R4, R7
+
+**Dependencies:** None (R4 + R5 already shipped; their constants stay
+untouched).
+
+**Files:**
+
+- Create: `apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql`
+- Modify: `apps/admin/src/services/hybrid-search-sql.ts` — add four new
+  constants (`TITLE_TSV_GENERATED_EXPR`, `DESCRIPTION_TSV_GENERATED_EXPR`,
+  `WEIGHTED_TSV_INDEX_EXPR`, `WEIGHTED_TSV_QUERY_EXPR`) plus index-name
+  constants (`VIDEO_LOCALE_LEXICAL_WEIGHTED_INDEX_NAME`,
+  `VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME`).
+- Test: `apps/admin/src/services/hybrid-search-sql.test.ts` — extend
+  the existing R4 byte-equality test to also assert the new
+  `WEIGHTED_TSV_INDEX_EXPR` appears byte-equal in the migration SQL,
+  and that the legacy `VIDEO_LOCALE_TSVECTOR_INDEX_EXPR` is untouched.
+
+**Approach:**
+
+- Migration provisions: `pg_trgm` extension (idempotent), two STORED
+  generated columns on `video_locale` (`title_tsv`, `description_tsv`),
+  weighted GIN index over `(setweight(title_tsv,'A') ||
+setweight(description_tsv,'B'))`, GIN trigram index on `videos_locale.title`
+  with `gin_trgm_ops`.
+- The legacy `video_locale_fulltext_search_idx` from `0006` is left
+  untouched — hybrid mode keeps reading it via `searchVideoKeyword`.
+- The `*_QUERY_EXPR` constants alias-prefix columns (`vl.title_tsv`,
+  `vl.description_tsv`) for use inside `$queryRaw` template literals
+  where `video_locale` is joined as `vl`. Postgres planner strips
+  alias prefixes before matching the indexed expression — same
+  property R4 already relies on.
+- No shared constant for the trigram operator (`%>`); per
+  `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md`,
+  operator-class GIN doesn't need byte-parity guards. The retriever
+  inlines `vl.title %> ?` directly.
+
+**Patterns to follow:**
+
+- `apps/admin/prisma/migrations/0006_hybrid_search_gin/migration.sql`
+  — R4's GIN migration; same shape (raw SQL, no-DSL).
+- `apps/admin/src/services/hybrid-search-sql.ts` — R4's existing
+  byte-parity constants and the test that locks them in.
+
+**Test scenarios:**
+
+- `hybrid-search-sql.test.ts` reads the migration file and asserts
+  the new `WEIGHTED_TSV_INDEX_EXPR` substring is present byte-equal.
+- Legacy `VIDEO_LOCALE_TSVECTOR_INDEX_EXPR` is still asserted (no
+  regression on R4's invariant).
+- Schema-level assertion: the migration SQL contains
+  `CREATE EXTENSION IF NOT EXISTS pg_trgm`, two `ADD COLUMN`
+  statements with `GENERATED ALWAYS AS` + `STORED`, two `CREATE
+INDEX` statements for the new GIN indexes.
+
+**Verification:**
+
+- `pnpm --filter @forge/admin prisma migrate diff` reports no drift
+  between the migration and the schema after running the migration
+  against a dev DB.
+- `EXPLAIN ANALYZE` on a probe query against `video_locale` using
+  `WEIGHTED_TSV_QUERY_EXPR @@ websearch_to_tsquery('simple', ?)`
+  shows `Bitmap Index Scan on video_locale_lexical_weighted_idx`.
+- `EXPLAIN ANALYZE` on `videos_locale.title %> ?` shows `Bitmap
+Index Scan on video_locale_title_trgm_idx`.
+- Running R4's existing search against the migrated DB returns the
+  same response as before — the new columns and indexes are dormant
+  on the hybrid path.
+
+---
+
+### Unit 2: `mode` argument plumbing + default-mode regression test (test-first)
+
+**Goal:** Plumb the `mode` argument from REST + GraphQL through
+`HybridSearchService.search()`, with hybrid as the default. Lock in
+byte-identical default behavior with a snapshot test that runs from
+this point through every subsequent unit.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** Unit 1 (so the migration is buildable end-to-end).
+
+**Files:**
+
+- Create: `apps/admin/src/services/hybrid-search.regression.test.ts` —
+  the snapshot test. Lands FIRST as the gate.
+- Modify: `apps/admin/src/services/hybrid-search.service.ts` — extend
+  `SearchParams` with `mode?: string | null`. Add `normalizeMode()`
+  helper with log-injection sanitizer. In this unit, `mode` is
+  computed but doesn't change retrieval — only the warn-fallback for
+  unknown values is wired.
+- Modify: `apps/admin/src/app/api/search/route.ts` — accept and
+  validate `mode` query param. Empty string treated as omitted.
+- Modify: `apps/admin/src/graphql/queries/hybrid-search.ts` — add
+  `mode: String` arg with description disambiguating from
+  `searchMode` response field.
+- Test: `apps/admin/src/app/api/search/route.test.ts` — extend with
+  `mode` parsing cases.
+- Test: `apps/admin/src/graphql/queries/hybrid-search.test.ts` —
+  extend with GraphQL `mode` arg cases.
+
+**Execution note:** Test-first. The regression snapshot test is the
+**first commit** of this unit and is captured by running it once
+against `origin/main` before any other change. Subsequent commits
+must keep that snapshot green.
+
+**Approach:**
+
+- Default `"hybrid"` when `mode` is unset, null, or `""`.
+- Unknown values: log structured warning (`[search]
+event=search_unknown_mode mode=<sanitized> falling_back=hybrid`)
+  exactly once per call. Sanitizer: `String(raw).replace(/[\r\n\t]/g,
+" ").slice(0, 64)`. Never throw.
+- Regression test asserts `JSON.stringify(response)` byte-identity for
+  `mode ∈ {undefined, null, "", "hybrid", "garbage"}` against a fixed
+  retriever fixture. Behavioral assertion: keyword-first retrievers
+  (mocked from Unit 3 onward) NEVER called on the default path.
+- GraphQL schema description on `mode`: explicitly disambiguate from
+  `searchMode` response field (orthogonal — input selects pipeline,
+  output reflects what ran).
+
+**Patterns to follow:**
+
+- `apps/cms/src/api/search/services/search.regression.test.ts` — the
+  cms test pattern. Port to admin's mock harness.
+- R4's existing `mode`-less request path. The test snapshot is
+  effectively R4's response for the fixed query set.
+- `apps/admin/src/app/api/search/route.ts` — existing query-param
+  parsing pattern (`type` arg).
+
+**Test scenarios:**
+
+- `mode` unset → byte-identical response to R4 for the regression
+  query set (5 representative queries + their `mode ∈ {null, "",
+hybrid, garbage}` siblings).
+- `mode="garbage"` → byte-identical response + exactly one warn log
+  with the sanitized structured shape.
+- `mode="garbage\r\nevent=injected"` → log contains `mode=garbage
+event=injected` (newlines stripped to spaces, no synthetic event
+  injection).
+- REST `?mode=keyword-first` parses and forwards (returns hybrid
+  behavior in this unit; keyword-first wiring lands in Unit 3).
+- GraphQL `mode: null` and missing `mode` arg both default to hybrid.
+- `searchMode` response field still reports `"hybrid"|"keyword-only"`
+  based solely on embedding success/failure (orthogonal to input
+  `mode`) — pinned by an explicit cross-check.
+
+**Verification:**
+
+- Regression test passes on this branch.
+- Regression test would also pass on `origin/main` if the test file
+  alone were copied in — the snapshot is the pre-change baseline.
+
+---
+
+### Unit 3: Three keyword-first retrievers + branched orchestrator
+
+**Goal:** Implement the new lexical retrievers and wire the keyword-first
+video-retrieval branch into `HybridSearchService`. Hybrid path remains
+untouched.
+
+**Requirements:** R3, R4, R7
+
+**Dependencies:** Unit 1 (DB infra), Unit 2 (`mode` plumbing + regression
+test).
+
+**Files:**
+
+- Create:
+  `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts` —
+  exports `searchByKeywordWeighted`, `searchByTrigram`,
+  `searchByExactTitle` plus shared types (`KeywordWeightedSearchParams`,
+  `TrigramSearchParams`, `ExactTitleSearchParams`, the `MAX_EXACT_TITLE_TOKENS`
+  constant, `tokenizeForExactTitle` helper).
+- Create:
+  `apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts`.
+- Modify: `apps/admin/src/services/hybrid-search.service.ts` — in the
+  `wantsVideos && mode === "keyword-first"` branch, push 3 new
+  retrievals (semantic stays from the hybrid branch). Empty-list
+  filtering before fusion is preserved.
+- Test: `apps/admin/src/services/hybrid-search.keyword-first.test.ts` —
+  orchestrator-level test for the new branch.
+
+**Approach:**
+
+- All three new retrievers honor the same locale + status filtering as
+  R4's `searchVideoKeyword` (DISTINCT ON `v.id`, JOIN to `Video` with
+  `deleted_at IS NULL`, WHERE `vl.locale = ? AND vl.status = 'PUBLISHED'`).
+- All three honor the orchestrator's `OVERFETCH_FACTOR=3` via the
+  `limit` param.
+- `searchByKeywordWeighted`:
+  - WHERE: `${WEIGHTED_TSV_QUERY_EXPR} @@ websearch_to_tsquery('simple', ${trimmed})`.
+  - rank: `ts_rank_cd(${WEIGHTED_TSV_QUERY_EXPR}, websearch_to_tsquery('simple', ${trimmed}))`.
+  - `Prisma.raw(WEIGHTED_TSV_QUERY_EXPR)` per R4 pattern.
+  - Empty/whitespace input → `[]` short-circuit.
+- `searchByTrigram`:
+  - WHERE: `vl.title %> ${trimmed}`.
+  - rank: `similarity(vl.title, ${trimmed})` DESC.
+  - Empty input → `[]`.
+- `searchByExactTitle`:
+  - Tokenize via `tokenizeForExactTitle(query)` — Unicode letter/digit
+    split, lowercase, dedup. **Cap at `MAX_EXACT_TITLE_TOKENS = 16`**
+    (DoS guard from cms-side fix).
+  - WHERE: dynamic AND-chain of `vl.title ILIKE ?` (one per token);
+    `vl.locale = ?`; `vl.status = 'PUBLISHED'`; `v.deleted_at IS NULL`.
+  - rank: `LENGTH(vl.title) ASC` (tighter match wins).
+  - Bindings array: `[locale, ...tokens.map(t => '%${t}%'), limit]`.
+  - 0 tokens → `[]`.
+- All three return `RankedItem`-shaped rows directly (no `annotateVideo`
+  step — matches R4 retriever convention).
+- In the orchestrator's keyword-first branch, push retrievals with
+  labels `keyword-weighted-video`, `trigram-video`, `exact-title-video`.
+  Existing `Promise.allSettled` + `unwrapOutcome` envelope handles
+  per-retriever failures.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/hybrid-search-retrievers.ts:searchVideoKeyword`
+  — locale + status + deleted_at join chain; `Prisma.raw(EXPR)` for
+  the tsvector fragment; empty-input short-circuit.
+- `apps/cms/src/api/search/services/keyword-weighted-search.ts`,
+  `trigram-search.ts`, `exact-title-search.ts` — SQL behavior reference
+  (translate columns + locale).
+- `apps/admin/src/db/pgvector.ts` — `Prisma.raw` patterns.
+
+**Test scenarios:**
+
+- Per-retriever: each returns expected ordered IDs against a seeded
+  fixture for `q="the Bible project"` (orchestrator-level mocking
+  matches cms-side test pattern; real-DB test is a deferred follow-up).
+- Trigram: `q="bibel project"` (typo) returns Bible Project videos.
+- Exact-title: `q="bible"` returns every title containing "bible";
+  `q="the bible project"` returns only titles with all three tokens.
+- Exact-title: 1000-character pasted query → 16-token cap holds; SQL
+  has exactly 16 ILIKE clauses; bindings array length = 18 (1 locale
+  - 16 patterns + 1 limit).
+- Locale: a Bible Project VideoLocale published only in `es` does not
+  appear for `locale="en"`.
+- Empty / whitespace-only `q` → all three return `[]` without DB call.
+- Orchestrator: in keyword-first mode, fused list draws from 4 ranked-list
+  contributions; `searchMode` response field still reflects embedding
+  success/failure only.
+- Hybrid path: regression snapshot from Unit 2 still passes
+  byte-identically; `searchByKeywordWeighted/Trigram/ExactTitle` NOT
+  called; `searchVideoKeyword` (R4 legacy) IS called.
+
+**Verification:**
+
+- `EXPLAIN ANALYZE` on each new retriever's SQL shows `Bitmap Index
+Scan` on the appropriate index (deferred to real-DB integration).
+- All three new retriever modules export the same `(prisma, params) =>
+Promise<RankedItem[]>` signature shape.
+- Regression snapshot from Unit 2 holds.
+
+---
+
+### Unit 4: Semantic-dilution cap + origin-gated `debug` field
+
+**Goal:** Add the post-fusion semantic-dilution cap (flag-gated) and
+expose per-retriever scores via `debug`, origin-gated.
+
+**Requirements:** R5, R6
+
+**Dependencies:** Unit 3.
+
+**Files:**
+
+- Modify: `apps/admin/src/services/hybrid-search.service.ts` — insert
+  cap step between `fuseRankedLists` and `deduplicateResults` in the
+  keyword-first branch only. Build per-key origin map from labeled
+  lists. Thread `debug` through to response mapping.
+- Modify: `apps/admin/src/services/hybrid-search-fusion.ts` (if
+  needed) — retain per-result list-of-origin trace if not already
+  available. Keep changes additive.
+- Create: `apps/admin/src/services/hybrid-search-debug-allowlist.ts` —
+  port of cms `debug-allowlist.ts`.
+- Create: `apps/admin/src/services/hybrid-search-debug-allowlist.test.ts`.
+- Modify: `apps/admin/src/graphql/types/hybrid-search.ts` — add
+  `SearchResultDebug` + `SearchRetrieverRank` types. Mark labels
+  UNSTABLE in description. Side-effect import in
+  `apps/admin/src/graphql/schema.ts`.
+- Modify: `apps/admin/src/graphql/queries/hybrid-search.ts` — add
+  `debug: Boolean` arg; gate via `isDebugAllowedForOrigin` from the
+  Yoga context; thread `debug` boolean to service.
+- Modify: `apps/admin/src/app/api/search/route.ts` — parse `debug=true`
+  query param; gate via `isDebugAllowedForOrigin(headers.origin)`;
+  thread to service.
+- Modify: `apps/admin/src/graphql/schema.test.ts` — assert no
+  `embedding|vector|similarit` field leaks on the new types.
+- Create: `apps/admin/src/services/hybrid-search.dilution-cap.test.ts`
+  — covers cap on/off and trigger condition.
+- Create: `apps/admin/src/services/hybrid-search.debug.test.ts` —
+  covers origin-gated debug field.
+
+**Approach:**
+
+- **Cap activation:**
+  - Compute `topN_kw_core_ids` = union of `videoCoreId`s from the top-N
+    (default 3) results of `keyword-weighted-video`, `trigram-video`,
+    and `exact-title-video` lists.
+  - Cap _triggers_ iff `exact-title-video` returned at least one
+    result whose `videoTitle`, lowercased and whitespace-collapsed,
+    contains every query token.
+  - When triggered: any fused result whose only contributing list was
+    `semantic-video` AND whose `videoCoreId` is null or not in
+    `topN_kw_core_ids` gets `score *= 0.5`. Re-sort.
+- `SEARCH_DILUTION_CAP_ENABLED` defaults `true` in keyword-first;
+  unreached on hybrid. Read once per request at orchestrator entry.
+- **`debug` gating:** reuse admin's CORS allowlist source where
+  feasible. Default behavior: any origin in non-production; explicit
+  `SEARCH_DEBUG_ALLOWED_ORIGINS` CSV overrides. **Fail closed when
+  `Origin` is `undefined`** (yoga-cors learning). Origin extraction:
+  REST via `request.headers.get("origin")`; GraphQL via
+  `koaContext.request?.headers?.origin` (or Yoga's request-context
+  equivalent — confirm during implementation).
+- `debug` payload shape per result: `{ retrieverRanks: Array<{ label,
+rank }>, fusedScore, dilutionCapApplied }`. In hybrid mode, `debug`
+  arg can still be passed; the `dilutionCapApplied` flag is always
+  `false` (cap unreached).
+
+**Patterns to follow:**
+
+- `apps/cms/src/api/search/services/search.ts:applyDilutionCap` — the
+  cap algorithm. Ports verbatim modulo `cuid` ids vs cms's int ids.
+- `apps/cms/src/api/search/services/debug-allowlist.ts` — origin gate.
+  Ports verbatim.
+- `apps/admin/src/graphql/types/experience.ts` — Pothos type
+  registration pattern; `@classification public-shape` JSDoc.
+- `apps/admin/src/graphql/schema.test.ts` —
+  `/embed|vector|similarit/i` guard pattern.
+
+**Test scenarios:**
+
+- Cap enabled + exact-title hit exists: a seeded semantic-only video
+  with `videoCoreId` outside the keyword top-N has `score *= 0.5`;
+  one whose `videoCoreId` is inside the top-N is not down-weighted;
+  one with `videoCoreId === null` is treated as outside (down-weighted).
+- Cap enabled + no exact-title hit (e.g., `q="hope when life is
+hard"`): no down-weights; result order matches no-cap output ±1.
+- `SEARCH_DILUTION_CAP_ENABLED=false`: no down-weights regardless.
+- `SEARCH_DILUTION_CAP_ENABLED="0"` (typo'd off-value): cap stays ON
+  per cms-side decision; this is documented quirk, not bug.
+- `debug=true` from allowed origin: payload present; `dilutionCapApplied`
+  is `true` for the correct result(s).
+- `debug=true` from disallowed origin: payload stripped.
+- `debug=true` from request with `Origin: undefined`: payload stripped
+  (fail closed).
+- GraphQL: `SearchResultDebug` field absent (not null) in response when
+  `debug` arg unset — pin via schema-level test.
+- Default-mode regression snapshot still passes.
+
+**Verification:**
+
+- All cap test scenarios pass.
+- `debug` payload presence is governed strictly by `(debug=true) AND
+(origin in allowlist)`.
+- `schema.test.ts` `/embed|vector|similarit/i` guard still passes
+  (the new `SearchResultDebug` type has only `retrieverRanks`,
+  `fusedScore`, `dilutionCapApplied` — no `embedding|vector|similarity`).
+
+---
+
+### Unit 5: Bible Project headline acceptance test + CLAUDE.md update + solutions doc
+
+**Goal:** Lock in the user-facing acceptance criterion for keyword-first
+mode on admin. Document the R4 extension pattern in admin's CLAUDE.md
+and as a sibling of the R4 pattern doc in `docs/solutions/`.
+
+**Requirements:** R1–R6
+
+**Dependencies:** Unit 4.
+
+**Files:**
+
+- Create: `apps/admin/src/services/hybrid-search.bible-project.test.ts`
+  — orchestrator-level acceptance test with mocked retrievers.
+- Modify: `apps/admin/CLAUDE.md` — append a "## Hybrid search keyword-first
+  mode (R4 extension)" section after the R4 section. Cross-link to
+  the R4 section so future readers see the lineage.
+- Create:
+  `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
+  — sibling to
+  `docs/solutions/platform/admin-hybrid-search-r4-pattern.md`.
+- Modify: each of the six cms-side feat-109 solution docs at
+  `docs/solutions/{database-issues,best-practices,security-issues,design-patterns,workflow-issues}/`
+  to cross-link the new admin paths.
+
+**Approach:**
+
+- Acceptance test:
+  - Seed fixtures (orchestrator-level mocks): 5 Bible Project
+    `VideoLocale` rows in `en` + 3 unrelated "project" videos + 3
+    bible-description-only videos. Same fixture set as cms.
+  - Test calls `HybridSearchService.search()` with `q="the Bible
+project"`, `locale="en"`, `limit=10`, `mode="keyword-first"`,
+    `contentTypes=["video"]`.
+  - Assertions: at least 8 of 10 result titles match
+    `/bible\s*project/i`; no result whose title lacks both "bible"
+    AND "project" ranks above any result whose title contains both;
+    top 3 are all Bible Project videos.
+  - Same query with `mode` unset must still return the legacy
+    R4 diluted set (covered by Unit 2's regression snapshot — assert
+    here too as a cross-check).
+  - Real-DB integration version is documented as a follow-up gated on
+    R0 backfilling admin video data.
+- CLAUDE.md section follows the R1/R2/R3/R4/R5 shape: Schema,
+  Services, Orchestrator, Endpoints, Operational runbook. Cite
+  `hybrid-search-keyword-first-retrievers.ts`, the migration, the
+  service modifications, the GraphQL types/queries, and the new
+  debug-allowlist module by exact file path.
+- Solution doc captures the R4-extension-specific bits: branched
+  orchestrator on R4's `HybridSearchService`, dilution cap with
+  origin-tracking via labeled lists, debug allowlist as a soft gate
+  (not auth — link to the security-issues doc), Prisma migration
+  vs cms's bootstrap-on-boot.
+
+**Patterns to follow:**
+
+- `apps/admin/CLAUDE.md` "Hybrid search (R4 of admin migration
+  playbook)" section — structure reference for the new section.
+- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md` —
+  structure reference for the new solutions doc.
+- `apps/cms/src/api/search/services/search.bible-project.test.ts` —
+  acceptance test pattern.
+
+**Test scenarios:**
+
+- Headline assertion (above) passes.
+- Headline assertion fails on R4 main (no keyword-first mode exists)
+  — verified by hand at PR-open time.
+- Same query with `mode` unset returns R4's hybrid result set.
+- `searchMode` response field reports `"hybrid"` when embedding
+  succeeded (pinned cross-check).
+
+**Verification:**
+
+- Acceptance test passes on this branch.
+- Regression snapshot from Unit 2 passes byte-identically.
+- CLAUDE.md renders without broken links; new section appears after
+  R4 section, before "Common pitfalls".
+- Solution doc filename matches the `admin-*-pattern.md` convention.
+
+## System-Wide Impact
+
+- **Interaction graph:** `mode` and `debug` are strict additive args.
+  No callbacks, middleware, or observers change shape. R4 consumers
+  that don't pass `mode` see no change. Existing `searchMode` response
+  field (degradation signal) preserved verbatim.
+- **Error propagation:** Unknown `mode` warns and falls back, never
+  errors. Cap and debug failures (if any) are isolated to the
+  keyword-first branch and the response-decoration tail; cannot affect
+  hybrid responses. New retrievers wrapped by R4's existing
+  `Promise.allSettled` / `unwrapOutcome` — single retriever failure
+  returns `[]` for that list.
+- **State lifecycle risks:** None. New generated columns derive from
+  existing canonical fields (`VideoLocale.title`, `VideoLocale.description`).
+  `pg_trgm` is idempotent and shared with no other code path. No write
+  paths change.
+- **API surface parity:** `mode` and `debug` land on both REST
+  (`GET /api/search`) and GraphQL (`Query.search`). Both surfaces stay
+  in lock-step through `HybridSearchService`.
+- **Integration coverage:** Unit 2's regression snapshot is the gate —
+  any unit-level pass that breaks it is a bug, not a feature. Unit 5's
+  acceptance test exercises the full orchestrator under the new mode.
+  Real-DB integration is the explicit follow-up gated on R0.
+- **Affected stakeholders:**
+  - **Consumers (apps/web, apps/mobile, apps/tv):** No change. Still
+    on cms's search until R8.
+  - **Operators:** Two new GIN indexes + one new extension + two new
+    generated columns on `VideoLocale`. Index sizes documented in
+    PR description.
+  - **Future R4 work:** R4 + R5 carry on unchanged. The
+    keyword-first extension is opt-in.
+
+## Risks & Dependencies
+
+- **GIN byte-parity drift on the weighted expression.** A future edit
+  to `WEIGHTED_TSV_INDEX_EXPR` without a coordinated migration update
+  silently reverts queries to Seq Scan. Mitigated by Unit 1's
+  byte-equality test, mirroring R4's existing pattern.
+- **Generated-column expression drift.** Per
+  `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`,
+  any change to `TITLE_TSV_GENERATED_EXPR` or `DESCRIPTION_TSV_GENERATED_EXPR`
+  requires a coordinated `DROP COLUMN ... CASCADE + ADD COLUMN`
+  migration step. Less acute on admin (Prisma migrations don't auto-skip
+  via `IF NOT EXISTS`), but the rule still applies. Document inline
+  in `hybrid-search-sql.ts`.
+- **Snapshot test brittleness.** If R4's response shape changes between
+  snapshot capture and PR merge (R5 wouldn't but a future R-stage
+  might), the regression test will spuriously fail. Mitigated by
+  capturing the snapshot on the branch tip and only against
+  deterministic mocked retrievers.
+- **`pg_trgm` extension privilege.** Admin's prod DB role may need
+  explicit `CREATE EXTENSION` grant. Migration `0006` (R4 GIN) didn't
+  need pg_trgm; this is the first one that does. Confirm at
+  preview-environment deploy time.
+- **Origin gating false positives.** Admin's CORS may differ from cms;
+  preview environments may not set `Origin` correctly for legitimate
+  agent clients. Documented in
+  `docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md`
+  — fail-closed is intentional.
+- **R0 dependency for prod usefulness.** Admin's `video` /
+  `video_locale` tables are 0 rows in prod. The keyword-first port
+  ships code that's correct against the schema; meaningful prod data
+  awaits R0. Real-DB integration tests are explicitly deferred to R0
+  readiness.
+- **Index growth.** Two new GIN indexes on `video_locale`. At admin's
+  current zero-row prod data the cost is nil; once R0 backfills, the
+  indexes grow proportionally to the corpus. Report
+  `pg_size_pretty(pg_total_relation_size())` for both new indexes in
+  PR description after preview-environment deploy.
+- **Naming collision (`mode` input vs `searchMode` output).** Same
+  trap as cms-side. GraphQL schema description on `mode` explicitly
+  disambiguates; regression test asserts `searchMode` semantics are
+  unchanged in either input mode.
+
+## Documentation / Operational Notes
+
+- After Unit 2 lands, `apps/admin/CLAUDE.md`'s R4 section gains a
+  cross-reference to the new keyword-first section. After Unit 5
+  lands, the new section follows R4's section directly.
+- After Unit 5, the six cms-side solution docs from feat-109 get
+  admin-side cross-references. The new R4-extension pattern doc is
+  a sibling of `admin-hybrid-search-r4-pattern.md`.
+- PR description records:
+  - Final `SEARCH_DILUTION_CAP_ENABLED` default and downweight
+    constant.
+  - Final top-N window for the cap trigger.
+  - `pg_size_pretty(pg_total_relation_size())` output for both new
+    GIN indexes (preview environment, since prod data is empty).
+  - `EXPLAIN ANALYZE` output showing `Bitmap Index Scan` on the new
+    indexes for representative queries (preview environment).
+  - Whether `mode="garbage"` warn-log shape was confirmed sanitized.
+  - 24h passive canary diff (admin keyword-first vs cms keyword-first
+    once cms keyword-first is consumer-reachable in some surface) —
+    deferred until consumer surface lands; not blocking R4-extension
+    merge.
+- Roadmap: open a new ticket
+  `docs/roadmap/content-discovery/feat-NNN-search-keyword-first-mode-admin-port.md`
+  pointing to this plan; flip `feat-109-search-keyword-first-mode.md`
+  status note to mention the admin port is in flight.
+
+### Out-of-scope follow-ups (PR description should list these)
+
+- **Real-DB integration tests** gated on R0: EXPLAIN-based GIN
+  verification + Bible Project headline against seeded admin video
+  data + canary diff vs cms keyword-first.
+- **`statement_timeout` for SQL retrievers** (pre-existing R4 concern;
+  cross-cutting).
+- **Extract shared retriever join-chain helper** (R4's keyword
+  retriever + the three new retrievers all share locale + status +
+  deleted_at filtering).
+- **Split `hybrid-search.service.ts`** into orchestrator +
+  dilution-cap + debug-trace modules if it grows further.
+- **Tolerant parser for `SEARCH_DILUTION_CAP_ENABLED`** (currently
+  only literal `"false"` disables).
+- **Token-based debug auth** (current Origin gate is a soft feature
+  flag, not auth).
+- **Apply lexical stack to experiences** (videos-only this round).
+- **Roadmap `feat-109` ID collision cleanup** (content-discovery vs
+  platform tickets share the ID).
+- **R8 cutover deletes cms keyword-first** (separate ticket alongside
+  the rest of cms search deprecation).
+
+## Sources & References
+
+- **Origin (playbook):**
+  `docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md`
+- **Predecessor plans:**
+  - `docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md`
+  - `docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md`
+- **The miss this plan corrects:**
+  - `docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md`
+  - `docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md`
+- **Related PRs:**
+  - `JesusFilm/forge#852` (cms-side keyword-first; the work being
+    ported)
+  - `JesusFilm/forge#837` (admin R4 hybrid search; the foundation
+    being extended)
+  - `JesusFilm/forge#838` (admin R5 scene recommendations; pattern
+    sibling)
+- **Admin code (target):**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search-retrievers.ts`
+  - `apps/admin/src/services/hybrid-search-sql.ts`
+  - `apps/admin/src/services/hybrid-search-fusion.ts`
+  - `apps/admin/src/services/hybrid-search-health.ts`
+  - `apps/admin/src/app/api/search/route.ts`
+  - `apps/admin/src/graphql/queries/hybrid-search.ts`
+- **cms source (port from):**
+  - `apps/cms/src/api/search/services/{lexical-sql,keyword-weighted-search,trigram-search,exact-title-search,debug-allowlist,search}.ts`
+  - `apps/cms/src/bootstrap/ensure-search-lexical.ts` (translate to
+    Prisma migration)
+- **Institutional learnings cited:**
+  - `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md`
+  - `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`
+  - `docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md`
+  - `docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md`
+  - `docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md`
+  - `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`
+  - `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md`
+  - `docs/solutions/best-practices/prototype-defaults-vs-data-derived-enumeration-20260422.md`
+  - `docs/solutions/platform/admin-hybrid-search-r4-pattern.md`
+- **Origin research (still relevant):**
+  `docs/research/semantic-search-report.md` §4 / §6 / §7

--- a/docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md
+++ b/docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md
@@ -1,0 +1,172 @@
+---
+title: "Challenge predecessor-plan framing; treat MEMORY.md entries as forced-read pointers"
+category: "best-practices"
+problem_type: "best_practice"
+component: "development_workflow"
+root_cause: "missing_workflow_step"
+resolution_type: "workflow_improvement"
+severity: "medium"
+module: "compound-engineering"
+tags:
+  - ce-plan
+  - planning-hygiene
+  - predecessor-plan
+  - memory-md
+  - inherited-framing
+  - workflow
+date: "2026-04-29"
+related_prs:
+  - "JesusFilm/forge#849"
+  - "JesusFilm/forge#852"
+related_docs:
+  - "docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md"
+---
+
+## Problem
+
+`/ce:plan` runs that build on a predecessor plan can silently inherit
+the predecessor's framing — including decisions that were correct at
+the time but are wrong now, or that were never deeply justified. The
+new plan reads the old one for context, copies its scope/sequencing
+language, and the inherited framing reaches review unexamined. Compounding
+the trap: `MEMORY.md` entries that name a doc by path (a playbook, a
+runbook, a migration plan) are sometimes treated as summaries rather
+than as _pointers_ — the planner reads the memory blurb and skips
+the referenced source, missing facts that would change the plan.
+
+## Symptoms
+
+- A new plan reuses the predecessor plan's "ships to X first, port to
+  Y later" justification verbatim. The justification was never
+  re-derived from current repo state.
+- Reviewer asks: "the predecessor plan was 2 weeks ago — has anything
+  changed? Has the destination shipped any of the migration stages
+  since then?" Plan author can't answer without re-reading.
+- A `MEMORY.md` entry says `project_admin_migration_status.md` —
+  "R4 (hybrid search API) shipped PR #837, merged 2026-04-23. Awaiting
+  R0 (Core sync) before R1 produces work in prod." The planner reads
+  this summary and proceeds; the named playbook
+  (`docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md`)
+  is never opened.
+- Plan ships, work merges, then a reviewer asks: "if R4 already shipped,
+  why didn't we build on top of that?" Recovery is a port plus a
+  deprecation.
+
+## What Didn't Work
+
+- **Trusting the predecessor plan's "Decisions" section as load-bearing.**
+  Decisions sections record what was decided then, not whether the
+  decision still holds. Repo state moves; plans rarely get rewritten.
+- **Treating MEMORY.md entries as compressed truth.** Memory entries
+  are summaries cached at write-time. The body of a playbook can change
+  in ways the summary doesn't reflect. A summary saying "R4 shipped"
+  doesn't tell you whether feat-109's work belongs _on_ R4.
+- **Reading the predecessor plan thoroughly without an explicit
+  challenge phase.** Comprehension isn't critique. Without a
+  structured prompt to falsify each inherited assumption, the planner
+  defaults to confirmation.
+
+## Solution
+
+Add two workflow rules to `/ce:plan` (and any planning workflow that
+references prior artifacts):
+
+### 1. "Inherited assumptions to challenge" section in the new plan
+
+Every plan that builds on a predecessor plan MUST include a section
+named exactly `## Inherited assumptions to challenge`, listing each
+load-bearing assumption from the predecessor and the result of
+re-deriving it from current state. Template:
+
+```markdown
+## Inherited assumptions to challenge
+
+| Inherited assumption                                 | Predecessor source                       | Re-derived from current state                                                                                                                        | Still valid?                     |
+| ---------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| "Ships to apps/cms first; admin port is a follow-up" | `docs/plans/2026-04-28-001-...md` §Notes | Admin R4 shipped PR #837 on 2026-04-23. Schema and dev fixtures present. Empty prod tables are a deploy-timing concern, not a code-location concern. | **No** — should ship to admin R4 |
+| "<other inherited claim>"                            | <ref>                                    | <re-derivation>                                                                                                                                      | yes/no                           |
+```
+
+Empty re-derivation cells = blocking review comment. The discipline
+is filling the table, not its contents — an honest "still valid"
+answer beats no table at all.
+
+### 2. Memory-pointer escalation rule
+
+When a `MEMORY.md` entry's body names a doc by path (any reference of
+the form "see `<path>`", "captured in `<path>`", "tracked in `<path>`"),
+`/ce:plan` MUST open `<path>` before drafting. Memory entries are
+_pointers_, not _summaries_. Cache-warm context is not a substitute
+for the source of truth.
+
+Concretely, in the `/ce:plan` Phase 1 research:
+
+```bash
+# Walk MEMORY.md entries; extract any referenced doc paths.
+for md in $(grep -rE '`docs/[^`]+\.md`' "$MEMORY_DIR/MEMORY.md" \
+            "$MEMORY_DIR"/*.md 2>/dev/null \
+            | grep -oE 'docs/[^` ]+\.md' | sort -u); do
+  if [ -f "$md" ]; then
+    echo "Memory references $md — reading before plan drafting:"
+    # Open and incorporate into research context.
+  fi
+done
+```
+
+The memory-walk should run BEFORE the parallel research subagents are
+spawned, so the planner's prompt to those subagents already includes
+the named-pointer content rather than the memory blurb.
+
+## Why This Works
+
+The two rules attack two different failure modes that share a root
+cause: **comprehension by reference, not by reading**. The planner
+reads the predecessor plan's table of contents and assumes the
+decisions are good. The planner reads the memory entry and assumes
+the summary is the doc.
+
+The "Inherited assumptions" table forces an explicit comprehension
+audit per assumption — you can't fill a re-derivation cell without
+actually re-deriving. The memory-pointer rule replaces the summary
+with the source: by the time the planner reasons about the work, it
+has the playbook in front of it, not just a one-line note saying the
+playbook exists.
+
+## Prevention
+
+1. **`/ce:plan` template change.** Add the "Inherited assumptions to
+   challenge" section as a default for any plan that has an `origin:`,
+   `supersedes:`, or `predecessor:` frontmatter field, or that
+   references a prior plan in the body.
+2. **`/ce:plan` Phase 1 step.** Walk `MEMORY.md` entries for path
+   references; open any referenced docs before drafting.
+3. **`ce:review` lint.** Persona reviewers (correctness, maintainability)
+   should flag: a plan that names a predecessor without an "Inherited
+   assumptions to challenge" section is incomplete.
+4. **MEMORY.md authoring rule.** When writing a memory entry that
+   summarizes a longer doc, explicitly mark it as a pointer (e.g.,
+   "Pointer to `docs/path/...`. Read the doc; this entry is a
+   navigation aid, not a substitute"). Authors of memory entries
+   share responsibility for whether they're treated as summaries or
+   pointers.
+
+## Triggers — when this rule fires
+
+- Any plan that supersedes another plan
+- Any plan whose `origin:` field points at another plan or brainstorm
+- Any plan whose body says "extends", "ports", "follows", "follow-up to"
+- Any plan that runs `/ce:plan` against a feature ticket whose
+  description references prior work
+- Any planning context that loads a `MEMORY.md` entry naming a
+  migration / playbook / runbook / architecture doc by path
+
+## Related
+
+- `docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md` —
+  the playbook-discovery learning that triggered this sibling. Both
+  apply to `/ce:plan`; this one generalizes beyond migrations.
+- `docs/plans/2026-04-28-001-feat-search-keyword-first-mode-plan.md` —
+  the predecessor whose framing was inherited unchallenged.
+- `docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md` —
+  the new plan that should have run the "Inherited assumptions"
+  audit and the memory-pointer escalation.

--- a/docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md
+++ b/docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md
@@ -128,3 +128,19 @@ guard that's only meaningful for the expression case.
   the trigram GIN.
 - `apps/cms/src/api/search/services/keyword-weighted-search.ts` /
   `trigram-search.ts` — the two retrievers that exercise the distinction.
+
+## Admin-side counterpart
+
+The same distinction applies to admin's R4-extension keyword-first port:
+
+- `apps/admin/src/services/hybrid-search-sql.ts` — `WEIGHTED_TSV_INDEX_EXPR`
+  / `WEIGHTED_TSV_QUERY_EXPR` are byte-parity-guarded against
+  `prisma/migrations/0009_keyword_first_lexical/migration.sql`. No
+  shared constant for the trigram path — operator-class GIN
+  (`gin_trgm_ops`) selects via the `%>` operator.
+- `apps/admin/src/services/hybrid-search-sql.test.ts` — extended
+  byte-parity test asserts both invariants.
+- `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts` —
+  `searchByKeywordWeighted` (expression GIN) vs `searchByTrigram`
+  (operator-class GIN) showing the pattern in admin idiom.
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.

--- a/docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md
+++ b/docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md
@@ -153,3 +153,14 @@ it("default-mode aliases never invoke any keyword-first retriever", async () => 
   test gates.
 - `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`
   — analogous "lock in invariants at test-time" pattern for raw SQL.
+
+## Admin-side counterpart
+
+- `apps/admin/src/services/hybrid-search.regression.test.ts` —
+  admin's R4-extension regression snapshot. Same five-mode byte-
+  identity assertion + behavioral assertion that the new
+  keyword-first retrievers are NEVER called on the default path.
+  Held green through every commit in the keyword-first port.
+- `apps/admin/src/services/hybrid-search.service.ts` — the
+  orchestrator the admin-side test gates.
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.

--- a/docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md
+++ b/docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md
@@ -126,3 +126,19 @@ The drift is invisible because:
 - `apps/cms/src/bootstrap/ensure-pgvector.ts` — same idempotent pattern
   applied to pgvector tables (no generated columns; not affected by this
   trap, but the same IF NOT EXISTS posture).
+
+## Admin-side counterpart
+
+Admin uses Prisma migrations rather than on-boot DDL, but the rule
+holds — ALTER COLUMN cannot edit a generated expression in place:
+
+- `apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql`
+  — provisions `title_tsv` + `description_tsv` STORED generated
+  columns. Inline comment cites this trap. Future rewrites of the
+  generated expression require a coordinated `DROP COLUMN ... CASCADE +
+ADD COLUMN ... GENERATED ALWAYS AS (...)` migration.
+- `apps/admin/src/services/hybrid-search-sql.ts` — the
+  `*_GENERATED_EXPR` constants whose drift would silently break
+  byte-parity. The test in `hybrid-search-sql.test.ts` asserts the
+  migration text contains them verbatim.
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.

--- a/docs/solutions/database-issues/prisma-unsupported-placeholder-for-raw-sql-generated-columns-20260429.md
+++ b/docs/solutions/database-issues/prisma-unsupported-placeholder-for-raw-sql-generated-columns-20260429.md
@@ -1,0 +1,154 @@
+---
+title: "Prisma `Unsupported(...)?` placeholders for raw-SQL-managed generated columns"
+category: "database-issues"
+problem_type: "database_issue"
+component: "database"
+root_cause: "incomplete_setup"
+resolution_type: "code_fix"
+severity: "medium"
+module: "apps/admin"
+tags:
+  - prisma
+  - schema-drift
+  - generated-columns
+  - tsvector
+  - migrate-dev
+  - postgres
+date: "2026-04-29"
+related_prs:
+  - "JesusFilm/forge#feat-109-admin-port"
+---
+
+## Problem
+
+A Prisma migration adds a Postgres generated column (e.g.
+`title_tsv tsvector GENERATED ALWAYS AS (...) STORED`) and a GIN index
+over it. Both are managed exclusively via raw SQL — Prisma has no
+first-class type for stored generated tsvector columns. Because the
+column never appears in `prisma/schema.prisma`, the next engineer to
+run `pnpm prisma migrate dev` is prompted with a destructive plan:
+
+> ⚠️ The following column(s) will be dropped: `title_tsv`,
+> `description_tsv`. Continue?
+
+If the engineer accepts (or auto-approves on a CI/dev container), the
+column is dropped, the dependent GIN index is `CASCADE`-dropped
+silently, and the keyword-first retriever reverts to seq scan with no
+test or runtime signal.
+
+## Symptoms
+
+- `prisma migrate dev` shows `[+] Drop column "title_tsv"` in its diff
+  proposal, even though the column was added intentionally by an
+  earlier migration.
+- After accepting the prompt, `EXPLAIN ANALYZE` of the search retriever
+  drops from `Bitmap Index Scan` to `Seq Scan`.
+- No type error or test fail at compile time — the retriever's `Prisma.raw`
+  expression doesn't reference the column through Prisma's type system.
+
+## What Didn't Work
+
+- **Relying on `IF NOT EXISTS` in the migration.** Idempotency at apply
+  time doesn't help — `migrate dev` compares schema.prisma against the
+  introspected DB and offers to roll back any column it doesn't see in
+  the schema, regardless of how the column was originally created.
+- **Comments in the migration.** Future engineers don't see them
+  during the `migrate dev` prompt.
+- **Skipping `migrate dev` in favor of `migrate deploy`.** Works on
+  CI/prod but not in local dev where `migrate dev` is the canonical
+  workflow.
+
+## Solution
+
+Declare the raw-SQL-managed columns as `Unsupported("...")?`
+placeholders in `schema.prisma`. Prisma treats `Unsupported(...)`
+fields as opaque (cannot be selected via the typed client, cannot be
+written via standard CRUD) but recognizes their existence in
+introspection — `migrate dev` no longer proposes to drop them.
+
+```prisma
+model VideoLocale {
+  id          String       @id @default(cuid())
+  videoId     String       @map("video_id")
+  // ... existing fields ...
+
+  /// STORED generated tsvector columns — derived from `title` /
+  /// `description` by `0009_keyword_first_lexical/migration.sql`.
+  /// Service code reads these via `Prisma.raw` only — Prisma has no
+  /// first-class generated-tsvector column type, so we expose them
+  /// to introspection through Unsupported(...)? placeholders to keep
+  /// `prisma migrate dev` from offering to drop them.
+  titleTsv       Unsupported("tsvector")? @map("title_tsv")
+  descriptionTsv Unsupported("tsvector")? @map("description_tsv")
+
+  @@map("video_locale")
+}
+```
+
+The migration that creates the column stays unchanged. The schema
+declaration is purely defensive against `migrate dev` drift.
+
+## Why This Works
+
+`Unsupported(...)` is Prisma's official escape hatch for column types
+the generator doesn't model (geographic types, vectors, tsvector,
+hstore, custom domains). The runtime client cannot read or write the
+field, but the introspector reconciles its existence with the live
+DB. This is the same pattern already used for pgvector embedding
+columns elsewhere in admin's schema (`embedding Unsupported("vector(1536)")?`).
+
+The `?` (nullable) is required because `Unsupported(...)` columns
+must be nullable to compile — the typed client cannot construct a
+non-null value for an opaque type at insert time. For STORED
+generated columns this is purely cosmetic: the DB always populates
+the value from the generation expression and never accepts a NULL.
+
+The pairing is:
+
+1. **Migration** — creates the column with the generated expression
+   and any associated indexes (GIN, btree, etc).
+2. **Schema declaration** — placeholder so `migrate dev` doesn't drop
+   it.
+3. **Service code** — reads the column via `Prisma.raw(...)` inside
+   `$queryRaw` template literals (the typed client cannot select it).
+
+## Prevention
+
+1. **Whenever a migration adds a column that doesn't fit Prisma's
+   typed model — generated columns, vectors, tsvector, geographic
+   types, custom domains — pair it with a schema.prisma
+   `Unsupported(...)?` placeholder in the same PR.** This is the
+   safest default; the cost is one line per column.
+2. **Test asserts schema/migration alignment.** A test that reads the
+   migration file and the schema and asserts every column declared in
+   one appears in the other catches the drift at PR time:
+   ```ts
+   it("declares title_tsv / description_tsv on VideoLocale", () => {
+     const schema = readFileSync("prisma/schema.prisma", "utf8")
+     expect(schema).toMatch(/title_tsv.*Unsupported\("tsvector"\)\?/)
+     expect(schema).toMatch(/description_tsv.*Unsupported\("tsvector"\)\?/)
+   })
+   ```
+3. **Document inline.** A comment near the placeholder pointing to the
+   migration that owns the column makes the indirect ownership
+   explicit for future readers.
+4. **Generated-expression edits require coordinated DDL.** Postgres
+   has no in-place editor for stored generated expressions — any
+   change requires `DROP COLUMN ... CASCADE + ADD COLUMN ...` in a
+   single migration, which also rebuilds dependent indexes. See
+   `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`
+   for the full drift trap.
+
+## Related
+
+- `apps/admin/prisma/schema.prisma:622-651` — `VideoLocale.titleTsv` /
+  `descriptionTsv` placeholders.
+- `apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql`
+  — the migration that creates the columns.
+- `apps/admin/prisma/schema.prisma` `embedding Unsupported("vector(1536)")?`
+  precedent on `ExperienceLocale`, `VideoSceneLocale`,
+  `VideoTranscriptChunk` — same pattern applied to pgvector columns.
+- `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`
+  — the broader generated-column drift trap (sibling concern).
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
+  — the R4-extension that surfaced this learning during ce:review.

--- a/docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md
+++ b/docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md
@@ -167,3 +167,15 @@ type SearchResponse = { pipelineHealth: "ok" | "degraded-keyword-only" }
   orchestrator.
 - `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md` —
   the test pattern that gates this approach.
+
+## Admin-side counterpart
+
+- `apps/admin/src/services/hybrid-search.service.ts` — admin's
+  R4-extension `HybridSearchService.search()` with the same single-
+  branch shape (`if (pipelineMode === "keyword-first") …` around
+  the video retrieval block; semantic-video is shared, hybrid path
+  untouched).
+- `apps/admin/src/services/hybrid-search.regression.test.ts` —
+  byte-identity snapshot across `mode ∈ {undefined,null,"",hybrid,garbage}`
+  that gates Units 3-5 of the port.
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.

--- a/docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md
+++ b/docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md
@@ -1,0 +1,259 @@
+---
+title: Admin hybrid search keyword-first mode — R4 extension pattern
+category: platform
+date: 2026-04-29
+tags:
+  [
+    admin,
+    search,
+    keyword-first,
+    lexical,
+    tsvector,
+    trigram,
+    rrf,
+    dilution-cap,
+    debug,
+    migration,
+  ]
+---
+
+# Admin hybrid search keyword-first mode — R4 extension pattern
+
+## Context
+
+Sibling of `admin-hybrid-search-r4-pattern.md`. Captures the structural
+shape of the keyword-first mode that extends R4's `HybridSearchService`,
+shipped to admin in feat-109's destination-side port (apps/cms PR #852
+was the source-side; admin is the canonical surface from R8 forward).
+
+The cms-side feat-109 work is a one-shot port to admin's per-locale
+Prisma schema. Same opt-in `mode="keyword-first"` contract, same
+byte-identical-default invariant, same dilution cap and origin-gated
+debug payload — implemented against admin's idioms (Prisma migrations,
+`$queryRaw` template literals, `VideoLocale` per-locale rows) instead
+of cms's Strapi v5 link-table model.
+
+## The R4-extension invariants
+
+1. **Byte-identical default.** `mode` unset / null / `""` / `"hybrid"`
+   / unknown ⇒ R4 hybrid response, byte-identical. Locked in by
+   `apps/admin/src/services/hybrid-search.regression.test.ts`. The test
+   asserts `JSON.stringify(response)` equality across all five mode
+   values against deterministic mocked retrievers.
+
+2. **Single branched orchestrator.** One `HybridSearchService.search()`,
+   one `if (pipelineMode === "keyword-first")` branch around the
+   video-retrieval block. No twin functions, no strategy pattern.
+   Per `docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md`.
+
+3. **Hybrid path is UNTOUCHED.** R4's `searchVideoKeyword` (against
+   `video_locale_fulltext_search_idx`) keeps running in hybrid mode.
+   Keyword-first mode does NOT call it.
+
+4. **`searchMode` (response) ⊥ `mode` (input).** Response `searchMode`
+   is the embedding-degradation signal (`"hybrid"|"keyword-only"`).
+   Input `mode` selects the pipeline. Same name, different concern.
+   GraphQL schema description on `Query.search.mode` disambiguates
+   explicitly.
+
+5. **`mode` is a nullable String at the boundary, NOT an enum.**
+   Future modes (`"instant"`, `"persona-aware"`) ship without
+   GraphQL/REST schema changes. Unknown values warn-and-fall-back
+   via a single sanitized log line; never throw.
+
+## Schema delta — `0009_keyword_first_lexical`
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+ALTER TABLE "video_locale"
+  ADD COLUMN IF NOT EXISTS "title_tsv" tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', coalesce(title, ''))) STORED;
+
+ALTER TABLE "video_locale"
+  ADD COLUMN IF NOT EXISTS "description_tsv" tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', coalesce(description, ''))) STORED;
+
+CREATE INDEX IF NOT EXISTS "video_locale_lexical_weighted_idx"
+  ON "video_locale"
+  USING GIN ((setweight(title_tsv, 'A') || setweight(description_tsv, 'B')));
+
+CREATE INDEX IF NOT EXISTS "video_locale_title_trgm_idx"
+  ON "video_locale"
+  USING GIN (title gin_trgm_ops);
+```
+
+The byte-parity-guarded constants live in
+`apps/admin/src/services/hybrid-search-sql.ts`:
+`TITLE_TSV_GENERATED_EXPR`, `DESCRIPTION_TSV_GENERATED_EXPR`,
+`WEIGHTED_TSV_INDEX_EXPR`, `WEIGHTED_TSV_QUERY_EXPR`. The trigram path
+uses operator-class GIN — no shared constant; index selection by
+operator (`%>`).
+
+## Data-model divergences from cms feat-109
+
+- **Title/description location.** cms: `videos.title` + `videos.description`
+  (single-row). Admin: `VideoLocale.title` + `VideoLocale.description`
+  (per-locale). New generated columns + GIN indexes attach to
+  `video_locale`, not `video`.
+- **Locale filter.** cms: `languages.bcp_47 = ?` via
+  `video_variants_video_lnk → video_variants → video_variants_language_lnk → languages`
+  link chain. Admin: `vl.locale = ?` (direct column on `video_locale`).
+- **Migration mechanism.** cms: `ensure-search-lexical.ts` bootstrap
+  hook with idempotent DDL on every boot. Admin: append-only Prisma
+  migration `0009_keyword_first_lexical/migration.sql`. Same idempotency
+  property at the migration layer.
+- **Raw SQL idiom.** cms: `knex.raw(sql, [bindings])` with `?`
+  placeholders + the cms `lexical-sql.ts` shared module. Admin: Prisma
+  `$queryRaw` template literals + `Prisma.raw(EXPR)` for unbindable
+  fragments. `Prisma.join` composes the variable-length ILIKE chain
+  in `searchByExactTitle`.
+- **Row return shape.** cms: rows mapped through `annotateVideo()` to
+  inject `resultType`/`resultId`. Admin: retrievers return `RankedItem`-
+  shaped rows directly (R4 already adopted this stronger pattern).
+
+## Three keyword-first retrievers
+
+`apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts`:
+
+- **`searchByKeywordWeighted`** — `websearch_to_tsquery('simple', q)`
+  for phrase-aware tsquery, ranked by `ts_rank_cd` over the per-field
+  weighted tsvector. Title (weight A) outranks description (weight B).
+  `Prisma.raw(WEIGHTED_TSV_QUERY_EXPR)` for the unbindable expression.
+
+- **`searchByTrigram`** — `vl.title %> q` with `similarity(vl.title, q)`
+  ranking. Title-only — description trigram index would balloon. Closes
+  the typo / partial-prefix gap that `websearch_to_tsquery` misses.
+
+- **`searchByExactTitle`** — dynamic AND-chain of `vl.title ILIKE ?`
+  (one per token) composed via `Prisma.join`, ranked `LENGTH(title) ASC`.
+  `MAX_EXACT_TITLE_TOKENS = 16` caps planner stack growth from
+  pathological pasted queries (DoS guard from cms-side fix).
+  `tokenizeForExactTitle` is Unicode-letter / digit split, lowercased,
+  deduped.
+
+All three honor R4's locale + status + `deleted_at IS NULL` chain
+(`vl.locale = ? AND vl.status = 'published' AND v.deleted_at IS NULL`).
+All three short-circuit to `[]` on empty / whitespace input without a
+DB call. All three honor `OVERFETCH_FACTOR = 3` via the `limit` param.
+
+## Branched orchestrator — `HybridSearchService.search()`
+
+```
+embed(query)
+  ↓
+build retrievals[]:
+  if wantsVideos:
+    push semantic-video                         (shared)
+    if mode === "keyword-first":
+      push keyword-weighted-video
+      push trigram-video
+      push exact-title-video
+    else:                                        (hybrid path UNCHANGED)
+      push keyword-video                         (R4)
+  if wantsExperiences:
+    push semantic-experience + keyword-experience  (shared, both modes)
+allSettled → drop empty → fuseRankedLists(k=60)
+  ↓ snapshot pre-cap fused scores into debugByKey
+  ↓ if mode === "keyword-first" and SEARCH_DILUTION_CAP_ENABLED:
+       applyDilutionCap(fused, labeledLists, query, debugByKey)
+  ↓
+deduplicateResults → paginate → mapToSearchResult
+  ↓ if params.debug === true: attach debugByKey trace per result
+return { results, hasMore, query, searchMode }
+                                       ↑
+                              UNCHANGED degradation signal
+```
+
+## Semantic-dilution cap
+
+Activates only in keyword-first mode AND only when at least one
+exact-title row's lowercased title contains every query token. When
+triggered:
+
+- Aggregate top-3 (DILUTION_CAP_TOP_N) keyword-side `videoCoreId`s
+  across `keyword-weighted-video`, `trigram-video`, `exact-title-video`
+  → "this entity is genuinely a keyword winner" allowlist.
+- For each fused result whose ONLY contributing list was
+  `semantic-video` AND whose `videoCoreId` is null OR not in the
+  allowlist: `score *= DILUTION_CAP_DOWNWEIGHT` (0.5). Re-sort.
+
+Hard filtering is intentionally NOT used: thematic queries
+(`q="hope when life is hard"`) have no exact-title trigger, so the
+cap silently does nothing.
+
+`SEARCH_DILUTION_CAP_ENABLED` defaults `true`. Only the literal string
+`"false"` disables. Tolerant parser is a documented follow-up.
+
+## Origin-gated debug payload
+
+`apps/admin/src/services/hybrid-search-debug-allowlist.ts` is the soft
+gate:
+
+- `Origin: undefined` → fail closed.
+- `SEARCH_DEBUG_ALLOWED_ORIGINS` CSV present → only listed origins.
+- Otherwise → allowed iff `NODE_ENV !== "production"`.
+
+Threat model: this is a soft feature flag, not auth. Origins are
+forgeable from non-browser clients. The payload carries retriever
+ranks + fused score + cap state — no PII, no credentials. Replace with
+a token-based check before adding user-scoped data to the payload. Per
+`docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md`.
+
+GraphQL types: `HybridSearchResultDebug` carries `retrieverRanks`
+(an array of `HybridSearchRetrieverRank{ label, rank }`), `fusedScore`,
+and `dilutionCapApplied`. The retriever labels are explicitly
+**UNSTABLE** in the schema description — operators are the audience.
+
+## Test gates
+
+- **`hybrid-search-sql.test.ts`** — byte-parity vs migration `0009`.
+  Generated-column expressions, weighted index expression, index
+  names. Plus the legacy R4 `*_TSVECTOR_INDEX_EXPR` invariants.
+- **`hybrid-search.regression.test.ts`** — gating snapshot. Five mode
+  values, byte-identity, behavioral assertion that keyword-first
+  retrievers are NEVER called on the default path. Test-first per
+  `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`.
+- **`hybrid-search-keyword-first-retrievers.test.ts`** — per-retriever
+  shape + short-circuit + 16-token cap.
+- **`hybrid-search.keyword-first.test.ts`** — orchestrator branch
+  wiring, allSettled-isolated failures.
+- **`hybrid-search.dilution-cap.test.ts`** — cap on/off, trigger
+  condition, top-N exemption, null `videoCoreId` treated as outside,
+  re-sort after down-weighting.
+- **`hybrid-search.debug.test.ts`** — debug payload routing
+  (params.debug true/false), per-result rank aggregation across
+  multiple lists, dilutionCapApplied reflection.
+- **`hybrid-search-debug-allowlist.test.ts`** — origin gate behavior
+  across env + allowlist combinations.
+- **`hybrid-search.bible-project.test.ts`** — headline acceptance
+  test: top-3 are Bible Project for `q="the bible project"`.
+- **REST `route.test.ts` + GraphQL `hybrid-search.test.ts`** — boundary
+  origin gating, mode forwarding, `debug=true` only opt-in.
+
+## Out-of-scope follow-ups
+
+- **Real-DB integration tests** gated on R0 (Core sync entity coverage):
+  EXPLAIN-based GIN verification, Bible Project headline against seeded
+  data, canary diff vs cms keyword-first.
+- **R8 cutover** — apps/web / mobile / tv keep calling cms's search
+  during the R3 → R8 window. R8 is a separate one-shot.
+- **Deprecating cms keyword-first** — happens at R8 alongside the rest
+  of cms search deprecation. This work does NOT delete cms code.
+- **`statement_timeout` for SQL retrievers** — pre-existing R4 concern;
+  cross-cutting follow-up.
+- **Tolerant parser for `SEARCH_DILUTION_CAP_ENABLED`** — currently
+  only literal `"false"` disables.
+- **Token-based debug auth** — current Origin gate is a soft feature
+  flag. Replace if the payload starts carrying user-scoped data.
+- **Apply lexical stack to experiences** — videos-only this round.
+
+## See also
+
+- `apps/cms` source-side: feat-109 (PR #852).
+- Plan: `docs/plans/2026-04-29-002-feat-search-cms-to-admin-keyword-first-port-plan.md`.
+- R4 sibling: `docs/solutions/platform/admin-hybrid-search-r4-pattern.md`.
+- Workflow miss this corrects:
+  `docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md`.
+- Inherited-assumption discipline:
+  `docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md`.

--- a/docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md
+++ b/docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md
@@ -129,3 +129,13 @@ strapi.log.warn(
 - The same pattern should be audited on any other `log.warn`/`log.error`
   call that interpolates query-string or GraphQL-arg values across the
   cms / admin / manager codebases.
+
+## Admin-side counterpart
+
+- `apps/admin/src/services/hybrid-search.service.ts` — `sanitizeForLog`
+  - `normalizeMode` apply the same `replace(/[\r\n\t]/g, " ").slice(0, 64)`
+    pattern at the warn call site for unknown `mode` values.
+- `apps/admin/src/services/hybrid-search.regression.test.ts` — pins
+  the sanitizer against `mode="garbage\r\nevent=injected"` (one log
+  record, no synthetic event injection).
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.

--- a/docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md
+++ b/docs/solutions/security-issues/origin-header-soft-gate-not-security-boundary-20260429.md
@@ -131,3 +131,14 @@ attacker from requesting this."
   origin gate with the threat-model docstring.
 - `docs/solutions/security-issues/yoga-cors-origin-undefined-allows-all-origins.md` —
   the upstream yoga-cors gotcha and the fail-closed fix it prescribes.
+
+## Admin-side counterpart
+
+- `apps/admin/src/services/hybrid-search-debug-allowlist.ts` — verbatim
+  port of the cms gate to admin's R4-extension keyword-first surface.
+  Same threat model docstring; same fail-closed-on-undefined posture.
+- `apps/admin/src/services/hybrid-search-debug-allowlist.test.ts` —
+  origin-gate behavior across env + allowlist combinations.
+- `apps/admin/src/app/api/search/route.ts` + `apps/admin/src/graphql/queries/hybrid-search.ts`
+  — the two boundary integrations consulting the gate.
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.

--- a/docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md
+++ b/docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md
@@ -1,0 +1,166 @@
+---
+title: "Check the migration playbook before extending source-side capability that's destined for the destination"
+category: "workflow-issues"
+problem_type: "workflow_issue"
+component: "development_workflow"
+root_cause: "missing_workflow_step"
+resolution_type: "workflow_improvement"
+severity: "high"
+module: "compound-engineering"
+tags:
+  - workflow
+  - migration-playbook
+  - ce-plan
+  - architecture
+  - duplication-cost
+  - feat-109
+  - admin-migration
+date: "2026-04-29"
+related_prs:
+  - "JesusFilm/forge#849"
+  - "JesusFilm/forge#852"
+related_docs:
+  - "docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md"
+  - "docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md"
+---
+
+## Problem
+
+When an active migration playbook is in flight (cms → admin in this
+repo), and a request comes in to extend functionality that's
+mid-migration, the right question is **"which side of the migration
+does this work belong on?"** — not "which side has data today?" We
+asked the second question, got "cms has data," and shipped the wrong
+side. Six commits, six solution docs, and a merged PR later, all of
+it has to be ported.
+
+## Symptoms
+
+- Predecessor plan (PR #849) said "ships to cms first; admin R4 port
+  is a mechanical follow-up once Core-sync data-model reshape lands."
+- The `apps/admin/src/services/hybrid-search-sql.ts` (R4 byte-parity
+  reference, shipped 2026-04-23 in PR #837) was copied **into cms** as
+  the canonical pattern source for the GIN byte-parity invariant.
+- The `/ce:plan` repo-grounding scan reported file paths, retriever
+  conventions, naming collisions — but didn't reach for
+  `docs/brainstorms/*-playbook-*.md`.
+- `MEMORY.md` had `project_admin_migration_status.md` loaded, with R4
+  shipping explicitly noted, and the agent read past it.
+- Reviewer: "If R4 hybrid search already shipped to admin, why didn't
+  we build on top of that?"
+
+## What Didn't Work
+
+- **Inheriting the predecessor plan's framing without challenge.** PR
+  #849's "while we wait" justification ("admin's prod tables have 0
+  rows, so build on cms first") sounded reasonable in isolation. It's
+  a prod-data problem, not a code-location problem — admin has the
+  schema, the dev/staging fixtures, the R4 code; empty prod tables
+  don't block development.
+- **`/ce:plan`'s default research checks.** Local research covered
+  files, conventions, recent changes. It did NOT include "is there a
+  migration playbook that already says where new work belongs?"
+- **Treating the destination's pattern as a _reference_ instead of a
+  _target_.** When you're copying admin's pattern into cms, that's a
+  duplication signal: the work probably belongs on admin.
+
+## Solution
+
+Add a **migration-playbook check** as a default first-step in
+`/ce:plan` (and any other planning workflow) when the repo has an
+active migration in flight:
+
+1. **Discover playbooks.** Glob `docs/brainstorms/**/*-playbook-*.md`
+   and `docs/brainstorms/**/*-migration-*.md`. If results exist,
+   read them.
+2. **Check applicability.** Ask: "does the requested work touch a
+   capability that's mid-migration in this playbook? Is there an
+   R-stage for it?"
+3. **Default to the destination side.** If the work is in scope of
+   an R-stage that's already shipped, **extend that R-stage on the
+   destination**. If the R-stage hasn't shipped, the work is the
+   R-stage. If the work is genuinely net-new (not in any R-stage),
+   pick the destination unless there's a hard data/runtime reason
+   not to.
+4. **"Hard data/runtime reason" is narrow.** Empty tables in prod
+   are not it (build code, data lands later). Examples that ARE hard
+   reasons: dev environment can't run the destination, the
+   destination's schema doesn't exist yet, the destination is
+   fundamentally a different runtime (different language, different
+   process model).
+5. **If extending the source anyway, surface the duplication cost
+   explicitly.** Force the planner to write down: "this will be
+   ported to <destination> at <stage>; the cost is N commits ported
+   plus a deprecation."
+
+```ts
+// /ce:plan local research, additional default check:
+const playbooks = await glob([
+  "docs/brainstorms/**/*-playbook-*.md",
+  "docs/brainstorms/**/*-migration-*.md",
+])
+if (playbooks.length > 0) {
+  // Read each. For each R-stage / migration phase, ask:
+  // "Is the requested work in scope of an R-stage?"
+  // If yes, default destination side, document why if not.
+}
+```
+
+## Why This Works
+
+The structural problem is that migration playbooks live in
+`docs/brainstorms/` (long-form requirements docs), not in
+`docs/plans/` or `docs/roadmap/`. The default `/ce:plan` research
+agents look at code, recent commits, and roadmap tickets — none of
+which surface a brainstorm-style document. Adding the playbook glob
+as a default check catches the case before the planner reasons in
+isolation.
+
+The "default to destination, narrow exception list" rule short-
+circuits the most common failure mode: `inheriting "ship on the
+source side" framing because the source has data today`. Data is
+deployable; architecture is not. Building net-new capability on the
+side that's being deprecated produces drift, double work, and a
+broken cutover unless someone manually ports each addition.
+
+## Prevention
+
+1. **`/ce:plan` skill update.** Add a Phase 1 step: discover and
+   read any migration playbook, check whether the work is in scope of
+   an R-stage. If yes, prefer the destination side.
+2. **Code-review checklist for plan docs.** When reviewing a plan that
+   says "ships to source first; destination port is a follow-up," ask:
+   "is the destination unable to host this work today, or is it
+   inconvenient?" Inconvenient is not enough.
+3. **Duplication-signal heuristic for reviewers.** If the plan
+   imports a pattern reference from the destination side into the
+   source side, treat it as a tell that the work probably belongs on
+   the destination. Make the planner justify the inversion explicitly.
+4. **Memory hygiene.** When `MEMORY.md` references a migration
+   playbook by name, the planner should read the named playbook, not
+   skim the memory entry. The memory entry is a pointer; the playbook
+   is the source of truth.
+
+## Compounding cost incurred (this round)
+
+- **cms keyword-first** shipped in PR #852 (6 commits, ~5,400 LOC,
+  399 tests). Solid work, wrong side.
+- **Six `docs/solutions/` docs** authored against cms paths. They
+  carry over conceptually but every code reference will need an
+  admin equivalent.
+- **R4 admin keyword-first port** is now a separate ticket (TBD).
+- **Cleanup at R8 consumer cutover**: cms keyword-first is removed
+  alongside the rest of cms search. Net: same end-state, ~2× the
+  work to get there.
+
+## Related
+
+- `docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md` —
+  the playbook this learning was triggered by.
+- `docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md` —
+  the plan that should have caught this.
+- `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md` —
+  unrelated but a sibling pattern that also originated in feat-109.
+- `apps/admin/src/services/hybrid-search-sql.ts` — the R4 byte-parity
+  reference. Should have been the _target_ to extend, not the
+  _pattern_ to copy.

--- a/docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md
+++ b/docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md
@@ -15,12 +15,21 @@ tags:
   - duplication-cost
   - feat-109
   - admin-migration
+  - duplication-signal
+  - predecessor-plan-inheritance
 date: "2026-04-29"
+last_updated: "2026-04-29"
 related_prs:
-  - "JesusFilm/forge#849"
-  - "JesusFilm/forge#852"
+  - "JesusFilm/forge#852" # feat-109 keyword-first shipped to cms (the miss)
+  - "JesusFilm/forge#849" # predecessor cms-first plan whose framing was inherited
+  - "JesusFilm/forge#837" # R4 admin hybrid search — should have been the target
+  - "JesusFilm/forge#818" # R1 scene embeddings — admin migration playbook anchor
 related_docs:
   - "docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md"
+  - "docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md"
+  - "docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md"
+  - "docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md"
+  - "docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md"
   - "docs/solutions/design-patterns/branched-orchestrator-opt-in-mode-pattern-20260429.md"
 ---
 
@@ -38,14 +47,27 @@ it has to be ported.
 
 - Predecessor plan (PR #849) said "ships to cms first; admin R4 port
   is a mechanical follow-up once Core-sync data-model reshape lands."
+  The new plan inherited that sentence verbatim and never challenged
+  it — there was no "Inherited assumptions to challenge" section in
+  the new plan because that section did not exist.
+- **Cross-app create/reference split in the plan itself.** The plan's
+  "Files to create" list targeted `apps/cms/src/api/search/...` while
+  the plan's "Pattern reference" / "Byte-parity invariant source"
+  list cited `apps/admin/src/services/hybrid-search-sql.ts`. Whenever
+  a plan creates files in `apps/X/` and references patterns in
+  `apps/Y/` (X ≠ Y), that's a duplication tell — a mechanical lint a
+  reviewer (or `ce:review`) can run on the plan markdown without
+  domain knowledge.
 - The `apps/admin/src/services/hybrid-search-sql.ts` (R4 byte-parity
   reference, shipped 2026-04-23 in PR #837) was copied **into cms** as
   the canonical pattern source for the GIN byte-parity invariant.
 - The `/ce:plan` repo-grounding scan reported file paths, retriever
   conventions, naming collisions — but didn't reach for
-  `docs/brainstorms/*-playbook-*.md`.
+  `docs/brainstorms/*-playbook-*.md` or
+  `docs/brainstorms/*migration-playbook*.md`.
 - `MEMORY.md` had `project_admin_migration_status.md` loaded, with R4
-  shipping explicitly noted, and the agent read past it.
+  shipping explicitly noted (auto memory [claude]), and the agent read
+  past it.
 - Reviewer: "If R4 hybrid search already shipped to admin, why didn't
   we build on top of that?"
 
@@ -93,17 +115,28 @@ active migration in flight:
    ported to <destination> at <stage>; the cost is N commits ported
    plus a deprecation."
 
-```ts
-// /ce:plan local research, additional default check:
-const playbooks = await glob([
-  "docs/brainstorms/**/*-playbook-*.md",
-  "docs/brainstorms/**/*-migration-*.md",
-])
-if (playbooks.length > 0) {
-  // Read each. For each R-stage / migration phase, ask:
-  // "Is the requested work in scope of an R-stage?"
-  // If yes, default destination side, document why if not.
-}
+Concretely, as a shell-level check the `/ce:plan` skill harness can
+invoke during local research (the third name pattern catches the actual
+filename in this repo, which the bare `-playbook-` substring matches
+only incidentally):
+
+```bash
+# /ce:plan Phase 1 addendum — migration playbook discovery
+PLAYBOOKS=$(find docs/brainstorms -type f \( \
+  -name '*-playbook-*.md' -o \
+  -name '*-migration-*.md' -o \
+  -name '*migration-playbook*.md' \) 2>/dev/null)
+
+if [ -n "$PLAYBOOKS" ]; then
+  echo "Active migration playbooks found — read before planning:"
+  echo "$PLAYBOOKS"
+  # The planner MUST answer in the plan doc:
+  #   1. Is the requested work in scope of any R-stage?
+  #   2. Has that R-stage shipped on the destination?
+  #   3. If shipping to source anyway, what is the documented hard
+  #      data/runtime reason? (Empty prod tables are NOT a hard
+  #      reason — that's a deploy-timing concern.)
+fi
 ```
 
 ## Why This Works
@@ -126,20 +159,34 @@ broken cutover unless someone manually ports each addition.
 ## Prevention
 
 1. **`/ce:plan` skill update.** Add a Phase 1 step: discover and
-   read any migration playbook, check whether the work is in scope of
-   an R-stage. If yes, prefer the destination side.
-2. **Code-review checklist for plan docs.** When reviewing a plan that
+   read any migration playbook (use the `find` snippet above), check
+   whether the work is in scope of an R-stage. If yes, prefer the
+   destination side.
+2. **`/ce:plan` template addition: "Inherited assumptions to challenge."**
+   Every plan that builds on a predecessor plan must include this
+   section and re-derive the "which side / which app / which layer"
+   question from current repo state. The predecessor's framing is a
+   hypothesis to falsify, not a premise to inherit. See
+   `docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md`.
+3. **Lint: cross-app pattern import (mechanical reviewer rule).** If
+   a plan's "Files to create" list targets `apps/X/` and its "Pattern
+   reference" / "Byte-parity invariant source" cites `apps/Y/` where
+   X ≠ Y, the plan must contain a paragraph titled `Why X, not Y` with
+   a hard data/runtime reason. Absence of that paragraph = blocking
+   review comment. This is checkable without domain knowledge — `ce:review`
+   personas can apply it mechanically against the plan markdown.
+4. **Code-review checklist for plan docs.** When reviewing a plan that
    says "ships to source first; destination port is a follow-up," ask:
    "is the destination unable to host this work today, or is it
    inconvenient?" Inconvenient is not enough.
-3. **Duplication-signal heuristic for reviewers.** If the plan
-   imports a pattern reference from the destination side into the
-   source side, treat it as a tell that the work probably belongs on
-   the destination. Make the planner justify the inversion explicitly.
-4. **Memory hygiene.** When `MEMORY.md` references a migration
-   playbook by name, the planner should read the named playbook, not
-   skim the memory entry. The memory entry is a pointer; the playbook
-   is the source of truth.
+5. **Memory-pointer escalation rule.** When `MEMORY.md` contains an
+   entry whose body names a playbook, runbook, or migration doc by
+   path (e.g. `project_admin_migration_status.md` referencing
+   `apps/admin/CLAUDE.md` R1 runbook (auto memory [claude])),
+   `/ce:plan` MUST open the referenced doc before drafting. Treat
+   memory entries as forced-read pointers, not summaries. A
+   cache-warm summary is not a substitute for the source of truth —
+   memory entries go stale faster than their referents.
 
 ## Compounding cost incurred (this round)
 
@@ -157,10 +204,19 @@ broken cutover unless someone manually ports each addition.
 
 - `docs/brainstorms/2026-04-19-admin-migration-playbook-requirements.md` —
   the playbook this learning was triggered by.
+- `docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md` —
+  the destination-side plan that already shipped (PR #837); the
+  target this new work should have extended.
 - `docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md` —
   the plan that should have caught this.
+- `docs/solutions/best-practices/challenge-predecessor-plan-framing-and-read-named-memory-pointers-20260429.md` —
+  sibling learning: when `/ce:plan` builds on a predecessor plan,
+  challenge the inherited framing; treat MEMORY.md pointers as
+  forced-read references.
+- `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md` —
+  sibling-port theme reinforces the duplication-cost prevention rule.
 - `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md` —
-  unrelated but a sibling pattern that also originated in feat-109.
+  unrelated pattern that also originated in feat-109.
 - `apps/admin/src/services/hybrid-search-sql.ts` — the R4 byte-parity
   reference. Should have been the _target_ to extend, not the
   _pattern_ to copy.


### PR DESCRIPTION
## Summary

Ports the keyword-first lexical search capability shipped to `apps/cms` in [PR #852](https://github.com/JesusFilm/forge/pull/852) onto `apps/admin`'s R4 hybrid search foundation ([PR #837](https://github.com/JesusFilm/forge/pull/837)). Same opt-in `mode="keyword-first"` contract, same byte-identical-default invariant, same dilution cap and origin-gated debug payload — re-derived against admin's per-locale `VideoLocale` schema, Prisma migrations, and `$queryRaw` idioms.

This is an **R4 extension**, not a new R-stage. The plan is `docs/plans/2026-04-29-002-feat-search-cms-to-admin-keyword-first-port-plan.md` (in tree). Five implementation units shipped as five commits; each held the `hybrid-search.regression.test.ts` byte-identity gate green throughout.

### What's in scope

- **Unit 1** — Migration `0009_keyword_first_lexical/migration.sql`: `pg_trgm` extension, two STORED generated tsvector columns on `video_locale` (`title_tsv` weight A, `description_tsv` weight B), weighted GIN index, trigram GIN index on `title gin_trgm_ops`. Byte-parity-guarded SQL constants in `hybrid-search-sql.ts`.
- **Unit 2** — `mode` argument plumbing through REST + GraphQL with `normalizeMode()` warn-and-fall-back (sanitized log line, never throws). Default-mode regression test asserts byte-identity across `mode ∈ {undefined, null, "", "hybrid", "garbage"}`.
- **Unit 3** — Three new lexical retrievers in `hybrid-search-keyword-first-retrievers.ts`: `searchByKeywordWeighted` (phrase-aware `websearch_to_tsquery` + `ts_rank_cd`), `searchByTrigram` (`vl.title %> q`), `searchByExactTitle` (dynamic AND-chain of ILIKE clauses, `MAX_EXACT_TITLE_TOKENS = 16` DoS cap). Branched orchestrator on `HybridSearchService.search()`; hybrid path UNTOUCHED.
- **Unit 4** — Post-fusion semantic-dilution cap (gated by `SEARCH_DILUTION_CAP_ENABLED`, default true). Origin-gated `debug` payload via new `hybrid-search-debug-allowlist.ts`. New Pothos types `HybridSearchResultDebug` + `HybridSearchRetrieverRank` (labels marked UNSTABLE).
- **Unit 5** — Bible Project headline acceptance test. CLAUDE.md update. New solution doc + cross-links from the six cms-side feat-109 solution docs.

### Hard invariants this PR locks in

- Default behavior is byte-identical to R4 main when `mode` is unset / null / `""` / `"hybrid"` / unknown. Locked by `hybrid-search.regression.test.ts`.
- `searchMode` (response) is the embedding-degradation signal; orthogonal to input `mode` arg. GraphQL schema description disambiguates explicitly.
- Hybrid path's `searchVideoKeyword` (R4 legacy) is NEVER called in keyword-first mode. Asserted in the regression test.
- Generated-column expressions and weighted GIN expression byte-equal to migration. Trigram path uses operator-class GIN — no shared constant needed.
- Origin gate is a soft feature flag, not auth. Fail-closed on `Origin: undefined`. Threat model documented inline.

## Testing

- 1196 admin tests + 1 todo passing
- Lint clean
- Typecheck clean
- 13 new test files / extensions: `hybrid-search.regression.test.ts`, `hybrid-search-keyword-first-retrievers.test.ts`, `hybrid-search.keyword-first.test.ts`, `hybrid-search.dilution-cap.test.ts`, `hybrid-search.debug.test.ts`, `hybrid-search.bible-project.test.ts`, `hybrid-search-debug-allowlist.test.ts`, plus boundary tests in `app/api/search/route.test.ts` and `graphql/queries/hybrid-search.test.ts` + schema assertions in `graphql/schema.test.ts`.
- Real-DB integration tests (canary diff vs cms keyword-first, EXPLAIN-based GIN verification) are deferred to R0 readiness, same posture as R4 + R5.

## ce:review + ce:compound

- 7 reviewer personas dispatched in parallel (correctness, security, data-migrations, testing, maintainability, kieran-typescript, api-contract). 13 `safe_auto` findings applied in commit `598db797`. Residuals listed below.
- One new compound learning captured: `docs/solutions/database-issues/prisma-unsupported-placeholder-for-raw-sql-generated-columns-20260429.md` (commit `61d876c9`).

## Post-Deploy Monitoring & Validation

### Pre-deploy checks

- [ ] **`pg_trgm` extension privilege** on the `forge-admin` Railway prod DB role. First admin migration that needs it; older R0–R5 didn't. Verify before deploy:
      ```sql
      SELECT has_database_privilege(current_user, current_database(), 'CREATE');
      SELECT * FROM pg_available_extensions WHERE name = 'pg_trgm';
      ```
      If the role is locked down, have the platform team pre-create the extension out-of-band so the migration's `IF NOT EXISTS` is a no-op.
- [ ] **`video_locale` is empty in the target environment.** This migration's STORED-column rewrite + non-CONCURRENT GIN builds hold an AccessExclusiveLock for the duration. Safe at 0 rows; risky at backfill scale. R0 hasn't run yet, so prod and preview should both be 0 rows. Confirm:
      ```sql
      SELECT COUNT(*) FROM video_locale;
      ```

### What to monitor / search

- **Logs:**
  - `[search] event=search_unknown_mode` — operator typo or client bug (sanitized warn, ≤64 chars). Should be near-zero in steady state.
  - `[search] event=query_embedding_failure` — embedding provider degradation (existing R4 signal). Triggers `searchMode: "keyword-only"`.
  - `[search] keyword-weighted-video / trigram-video / exact-title-video retrieval failed` — per-retriever isolation working. Single failure shouldn't fail the response.
- **Metrics / dashboards:**
  - Existing `/api/search` rate-limit bucket (`"search"`, 30/min). Same bucket as R4.
  - Postgres planner: `EXPLAIN ANALYZE` should show `Bitmap Index Scan on video_locale_lexical_weighted_idx` and `…title_trgm_idx` once `video_locale` has rows.

### Validation queries

```sql
-- Generated columns + indexes exist
\d+ video_locale
-- expect: title_tsv (generated), description_tsv (generated)
\di video_locale_lexical_weighted_idx video_locale_title_trgm_idx
-- expect: both present, GIN, on video_locale

-- Index size baseline (capture for post-R0 comparison)
SELECT pg_size_pretty(pg_total_relation_size('video_locale_lexical_weighted_idx')) AS weighted_size,
       pg_size_pretty(pg_total_relation_size('video_locale_title_trgm_idx')) AS trgm_size;

-- Planner uses the indexes (after R0 backfill — meaningless at 0 rows)
EXPLAIN ANALYZE
SELECT v.id FROM video_locale vl
  JOIN video v ON v.id = vl.video_id
WHERE setweight(vl.title_tsv, 'A') || setweight(vl.description_tsv, 'B')
      @@ websearch_to_tsquery('simple', 'jesus')
  AND vl.locale = 'en' LIMIT 10;

EXPLAIN ANALYZE
SELECT v.id FROM video_locale vl
  JOIN video v ON v.id = vl.video_id
WHERE vl.title %> 'jesus' AND vl.locale = 'en' LIMIT 10;
```

### Expected healthy behavior

- `?mode=keyword-first` returns 200 with `searchMode: "hybrid"` (or `"keyword-only"` on embedding failure) and `query` echo.
- `?mode=keyword-first&debug=true` from a non-allowlisted origin (e.g. browser at production hostname) returns the response but with `result.debug` stripped.
- Default `?` (no mode) returns the same response shape as before this PR — verifiable by the byte-identity regression test running in CI.
- Bible Project headline test: `?q=the+bible+project&mode=keyword-first` produces all-Bible-Project top-3 once R0 has backfilled real data.

### Failure signals / rollback triggers

- Any `[search] event=…` log spike that wasn't there before.
- `pg_trgm` extension absent post-deploy → migration aborted, all 0009 DDL rolled back. Investigate role privileges.
- `EXPLAIN ANALYZE` showing `Seq Scan` instead of `Bitmap Index Scan` after R0 lands data → byte-parity drift; check `hybrid-search-sql.ts` constants vs migration text. The byte-parity test should have caught this in CI; a runtime regression here is a real bug.
- **Rollback path:** revert the merge commit + `prisma migrate resolve --rolled-back 0009_keyword_first_lexical`, then drop the two GIN indexes and the two generated columns. Migration is forward-only by Prisma convention; `IF NOT EXISTS` makes the re-apply safe.

### Validation window & owner

- **Window:** 24h post-merge for log-shape regressions; longer for data-dependent canary (waits on R0).
- **Owner:** keyword-first port shepherd (this PR's author + reviewer) for the immediate window; admin-platform for the canary once R0 is ready.

## Residual / deferred follow-ups (NOT in this PR)

- Real-DB integration tests gated on R0: EXPLAIN-based GIN verification, Bible Project headline against seeded admin video data, canary diff vs cms keyword-first across a fixed query × locales set.
- R8 consumer cutover — apps/web / mobile / tv stay on cms's search until R8.
- Deprecating cms's keyword-first — happens at R8 alongside the rest of cms search deprecation.
- `CREATE INDEX CONCURRENTLY` + `prisma:no_transaction` follow-up if 0009 ever needs to re-run against a populated environment.
- `statement_timeout` for SQL retrievers (pre-existing R4 concern; cross-cutting).
- Tolerant parser for `SEARCH_DILUTION_CAP_ENABLED` (today only the literal string `"false"` disables).
- Token-based debug auth (current Origin gate is a soft feature flag).
- Apply lexical stack to experiences (videos-only this round).
- Per-locale tsvector configs for multilingual lexical recall — `'simple'` matches cms parity but degrades on CJK / diacritics-heavy locales; semantic-video carries those today.
- Roadmap hygiene: `feat-109` ID duplicated between `content-discovery/` and `platform/`.

## Sources

- Plan: `docs/plans/2026-04-29-002-feat-search-cms-to-admin-keyword-first-port-plan.md`
- Predecessor plans: `docs/plans/2026-04-23-002-feat-admin-r4-hybrid-search-plan.md`, `docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md`
- Pattern doc: `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
- Eight cited solution docs from feat-109 in `docs/solutions/{best-practices,security-issues,database-issues,design-patterns,workflow-issues}/*-20260429.md`
- New compound learning: `docs/solutions/database-issues/prisma-unsupported-placeholder-for-raw-sql-generated-columns-20260429.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7, 1M context) via Compound Engineering v2.52.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>