### PR TITLE
feat(roadmap): add planned roadmap and tasks views

### DIFF
--- a/apps/roadmap/app/(dashboard)/contributions/page.tsx
+++ b/apps/roadmap/app/(dashboard)/contributions/page.tsx
@@ -1,0 +1,183 @@
+import Link from "next/link"
+import {
+  getAllFeatures,
+  getStatusCounts,
+  ALL_LANES,
+  getAllOwners,
+  getLaneLabel,
+  getOwnerProfile,
+  type Lane,
+} from "@/lib/features"
+import ContributionsTimelinePanel from "@/components/ContributionsTimelinePanel"
+
+function formatRoadmapRange(
+  features: ReturnType<typeof getAllFeatures>,
+): string {
+  const datedFeatures = features.filter((feature) => feature.start_date)
+  if (datedFeatures.length === 0) return "No scheduled range"
+
+  let minDate = new Date(datedFeatures[0].start_date + "T00:00:00")
+  let maxDate = new Date(
+    minDate.getTime() + (datedFeatures[0].duration - 1) * 86400000,
+  )
+
+  for (const feature of datedFeatures) {
+    const start = new Date(feature.start_date + "T00:00:00")
+    const end = new Date(start.getTime() + (feature.duration - 1) * 86400000)
+    if (start < minDate) minDate = start
+    if (end > maxDate) maxDate = end
+  }
+
+  const sameYear = minDate.getFullYear() === maxDate.getFullYear()
+  const sameMonth = sameYear && minDate.getMonth() === maxDate.getMonth()
+
+  if (sameMonth) {
+    return minDate.toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+    })
+  }
+
+  if (sameYear) {
+    return `${minDate.toLocaleDateString("en-US", {
+      month: "long",
+    })} – ${maxDate.toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+    })}`
+  }
+
+  return `${minDate.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  })} – ${maxDate.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  })}`
+}
+
+export default function ContributionsPage() {
+  const features = getAllFeatures()
+  const totals = getStatusCounts(features)
+  const owners = getAllOwners()
+  const roadmapRange = formatRoadmapRange(features)
+  const laneLabels = Object.fromEntries(
+    ALL_LANES.map((l) => [l, getLaneLabel(l)]),
+  ) as Record<Lane, string>
+  const ownerAvatars = Object.fromEntries(
+    owners.map((o) => [o, getOwnerProfile(o)?.avatar ?? null]),
+  )
+
+  return (
+    <div className="space-y-6">
+      <section className="flex flex-col gap-6 pb-2 pt-8 lg:flex-row lg:justify-between">
+        <div className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-widest text-stone-500">
+            Work Tracking
+          </p>
+          <h1 className="text-4xl font-bold leading-tight tracking-tight sm:text-5xl">
+            Tasks
+          </h1>
+          <p className="max-w-2xl text-lg leading-relaxed text-stone-400">
+            {roadmapRange} · {features.length} features
+          </p>
+        </div>
+
+        <div className="self-start lg:self-center lg:text-right">
+          <Link
+            href="/roadmap"
+            className="inline-flex items-center gap-2 rounded-xl border border-stone-700 bg-stone-900 px-3.5 py-2.5 text-base font-semibold text-white transition-colors hover:border-stone-500 hover:bg-stone-800"
+          >
+            <svg
+              className="h-3.5 w-3.5 text-stone-300"
+              viewBox="0 0 20 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                d="M3.5 15.5V6.5M8.25 15.5V9.5M13 15.5V4.5M17 15.5H3"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span>Open Roadmap View</span>
+          </Link>
+          <p className="mt-2 max-w-[240px] text-sm leading-snug text-stone-500/80 lg:ml-auto">
+            See the strategic roadmap and phased release plan
+          </p>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard
+          label="Not Started"
+          count={totals["not-started"]}
+          color="text-stone-400"
+        />
+        <StatCard
+          label="In Progress"
+          count={totals["in-progress"]}
+          color="text-blue-400"
+        />
+        <StatCard
+          label="Complete"
+          count={totals.complete}
+          color="text-green-400"
+        />
+        <StatCard label="Blocked" count={totals.blocked} color="text-red-400" />
+      </div>
+
+      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-stone-400">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-stone-400" />{" "}
+          Not Started
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-blue-400" /> In
+          Progress
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-green-400" />{" "}
+          Complete
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-red-400" />{" "}
+          Blocked
+        </span>
+        <span className="flex items-center gap-2 border-l border-stone-700 pl-3">
+          <span className="border-l-2 border-l-red-500 pl-1">P0</span>
+          <span className="border-l-2 border-l-yellow-500 pl-1">P1</span>
+          <span className="border-l-2 border-l-stone-500 pl-1">P2</span>
+        </span>
+      </div>
+
+      <ContributionsTimelinePanel
+        features={features}
+        lanes={ALL_LANES}
+        owners={owners}
+        laneLabels={laneLabels}
+        ownerAvatars={ownerAvatars}
+      />
+    </div>
+  )
+}
+
+function StatCard({
+  label,
+  count,
+  color,
+}: {
+  label: string
+  count: number
+  color: string
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-3 sm:p-4">
+      <div className={`text-2xl font-bold sm:text-3xl ${color}`}>{count}</div>
+      <div className="mt-1 text-xs text-stone-400 sm:text-sm">{label}</div>
+    </div>
+  )
+}

--- a/apps/roadmap/app/(dashboard)/layout.tsx
+++ b/apps/roadmap/app/(dashboard)/layout.tsx
@@ -1,4 +1,4 @@
-import Sidebar from "@/components/Sidebar"
+import DashboardShell from "@/components/DashboardShell"
 import { getAllOwners, getOwnerProfile } from "@/lib/features"
 
 export default function DashboardLayout({
@@ -12,11 +12,8 @@ export default function DashboardLayout({
   )
 
   return (
-    <>
-      <Sidebar owners={owners} ownerAvatars={ownerAvatars} />
-      <main className="min-h-screen pt-12 md:ml-56 md:pt-0">
-        <div className="p-4 md:p-8">{children}</div>
-      </main>
-    </>
+    <DashboardShell owners={owners} ownerAvatars={ownerAvatars}>
+      {children}
+    </DashboardShell>
   )
 }

--- a/apps/roadmap/app/(dashboard)/roadmap/page.tsx
+++ b/apps/roadmap/app/(dashboard)/roadmap/page.tsx
@@ -1,151 +1,56 @@
-import {
-  getAllFeatures,
-  getStatusCounts,
-  ALL_LANES,
-  getAllOwners,
-  getLaneLabel,
-  getOwnerProfile,
-  type Lane,
-} from "@/lib/features"
-import RoadmapTimeline from "@/components/RoadmapTimeline"
-
-function formatRoadmapRange(
-  features: ReturnType<typeof getAllFeatures>,
-): string {
-  const datedFeatures = features.filter((feature) => feature.start_date)
-  if (datedFeatures.length === 0) return "No scheduled range"
-
-  let minDate = new Date(datedFeatures[0].start_date + "T00:00:00")
-  let maxDate = new Date(
-    minDate.getTime() + (datedFeatures[0].duration - 1) * 86400000,
-  )
-
-  for (const feature of datedFeatures) {
-    const start = new Date(feature.start_date + "T00:00:00")
-    const end = new Date(start.getTime() + (feature.duration - 1) * 86400000)
-    if (start < minDate) minDate = start
-    if (end > maxDate) maxDate = end
-  }
-
-  const sameYear = minDate.getFullYear() === maxDate.getFullYear()
-  const sameMonth = sameYear && minDate.getMonth() === maxDate.getMonth()
-
-  if (sameMonth) {
-    return minDate.toLocaleDateString("en-US", {
-      month: "long",
-      year: "numeric",
-    })
-  }
-
-  if (sameYear) {
-    return `${minDate.toLocaleDateString("en-US", {
-      month: "long",
-    })} – ${maxDate.toLocaleDateString("en-US", {
-      month: "long",
-      year: "numeric",
-    })}`
-  }
-
-  return `${minDate.toLocaleDateString("en-US", {
-    month: "long",
-    year: "numeric",
-  })} – ${maxDate.toLocaleDateString("en-US", {
-    month: "long",
-    year: "numeric",
-  })}`
-}
+import Link from "next/link"
+import PlannedRoadmapTimeline from "@/components/PlannedRoadmapTimeline"
 
 export default function DashboardPage() {
-  const features = getAllFeatures()
-  const totals = getStatusCounts(features)
-  const owners = getAllOwners()
-  const roadmapRange = formatRoadmapRange(features)
-  const laneLabels = Object.fromEntries(
-    ALL_LANES.map((l) => [l, getLaneLabel(l)]),
-  ) as Record<Lane, string>
-  const ownerAvatars = Object.fromEntries(
-    owners.map((o) => [o, getOwnerProfile(o)?.avatar ?? null]),
-  )
-
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Roadmap</h1>
-        <p className="mt-1 text-sm text-stone-400">
-          {roadmapRange} · {features.length} features
-        </p>
+      <div className="space-y-6">
+        <section className="flex flex-col gap-6 pb-2 pt-8 lg:flex-row lg:justify-between">
+          <div className="space-y-4">
+            <p className="text-xs font-semibold uppercase tracking-widest text-stone-500">
+              AI Delivery
+            </p>
+            <h1 className="text-4xl font-bold leading-tight tracking-tight sm:text-5xl">
+              Roadmap
+            </h1>
+            <p className="max-w-2xl text-lg leading-relaxed text-stone-400">
+              Our AI development strategy uses weekly releases to incorporate AI
+              features into existing products where they matter most.
+            </p>
+          </div>
+
+          <div className="self-start lg:self-center lg:text-right">
+            <Link
+              href="/contributions"
+              className="inline-flex items-center gap-2 rounded-xl border border-stone-700 bg-stone-900 px-3.5 py-2.5 text-base font-semibold text-white transition-colors hover:border-stone-500 hover:bg-stone-800"
+            >
+              <svg
+                className="h-3.5 w-3.5 text-stone-300"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M7 5.5H15M7 10H15M7 14.5H15M4.5 5.5H4.51M4.5 10H4.51M4.5 14.5H4.51"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <span>Open Task View</span>
+            </Link>
+            <p className="mt-2 max-w-[240px] text-sm leading-snug text-stone-500/80 lg:ml-auto">
+              See detailed breakdown of the work by person and late
+            </p>
+          </div>
+        </section>
       </div>
 
-      {/* Stats */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <StatCard
-          label="Not Started"
-          count={totals["not-started"]}
-          color="text-stone-400"
-        />
-        <StatCard
-          label="In Progress"
-          count={totals["in-progress"]}
-          color="text-blue-400"
-        />
-        <StatCard
-          label="Complete"
-          count={totals.complete}
-          color="text-green-400"
-        />
-        <StatCard label="Blocked" count={totals.blocked} color="text-red-400" />
+      <div className="relative left-1/2 w-screen max-w-[1800px] -translate-x-1/2 px-4 md:px-8">
+        <PlannedRoadmapTimeline />
       </div>
-
-      {/* Legend */}
-      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-stone-400">
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block h-2 w-2 rounded-full bg-stone-400" />{" "}
-          Not Started
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block h-2 w-2 rounded-full bg-blue-400" /> In
-          Progress
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block h-2 w-2 rounded-full bg-green-400" />{" "}
-          Complete
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="inline-block h-2 w-2 rounded-full bg-red-400" />{" "}
-          Blocked
-        </span>
-        <span className="flex items-center gap-2 border-l border-stone-700 pl-3">
-          <span className="border-l-2 border-l-red-500 pl-1">P0</span>
-          <span className="border-l-2 border-l-yellow-500 pl-1">P1</span>
-          <span className="border-l-2 border-l-stone-500 pl-1">P2</span>
-        </span>
-      </div>
-
-      {/* Roadmap timeline with toggle */}
-      <RoadmapTimeline
-        features={features}
-        lanes={ALL_LANES}
-        owners={owners}
-        laneLabels={laneLabels}
-        ownerAvatars={ownerAvatars}
-      />
-    </div>
-  )
-}
-
-function StatCard({
-  label,
-  count,
-  color,
-}: {
-  label: string
-  count: number
-  color: string
-}) {
-  return (
-    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-3 sm:p-4">
-      <div className={`text-2xl font-bold sm:text-3xl ${color}`}>{count}</div>
-      <div className="mt-1 text-xs text-stone-400 sm:text-sm">{label}</div>
     </div>
   )
 }

--- a/apps/roadmap/app/(public)/about/page.tsx
+++ b/apps/roadmap/app/(public)/about/page.tsx
@@ -64,7 +64,7 @@ const PRINCIPLES = [
 
 export default function AboutPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-20 pb-20">
+    <div className="space-y-20 pb-20">
       {/* Hero */}
       <section className="space-y-6 pt-8 text-center">
         <img

--- a/apps/roadmap/app/(public)/experiments/page.tsx
+++ b/apps/roadmap/app/(public)/experiments/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function ExperimentsPage() {
   return (
-    <div className="mx-auto max-w-4xl pb-20">
+    <div className="pb-20">
       {/* Hero */}
       <section className="space-y-4 pb-12 pt-8">
         <p className="text-xs font-semibold uppercase tracking-widest text-stone-500">

--- a/apps/roadmap/app/globals.css
+++ b/apps/roadmap/app/globals.css
@@ -32,3 +32,12 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+.roadmap-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.roadmap-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/apps/roadmap/components/ContributionsTimelinePanel.tsx
+++ b/apps/roadmap/components/ContributionsTimelinePanel.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState } from "react"
+import type { Feature, Lane } from "@/lib/features"
+import RoadmapTimeline, { type GroupByMode } from "./RoadmapTimeline"
+
+export default function ContributionsTimelinePanel({
+  features,
+  lanes,
+  owners,
+  laneLabels,
+  ownerAvatars,
+}: {
+  features: Feature[]
+  lanes: Lane[]
+  owners: string[]
+  laneLabels: Record<Lane, string>
+  ownerAvatars: Record<string, string | null>
+}) {
+  const [groupBy, setGroupBy] = useState<GroupByMode>("lane")
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+            Tasks view
+          </div>
+          <p className="mt-1 text-sm text-stone-400">
+            Live contribution schedule from docs/roadmap.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex w-fit items-center gap-1 rounded-lg bg-stone-800 p-1">
+            <button
+              onClick={() => setGroupBy("lane")}
+              className={`cursor-pointer rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                groupBy === "lane"
+                  ? "bg-stone-700 text-white"
+                  : "text-stone-400 hover:text-white"
+              }`}
+            >
+              By Lane
+            </button>
+            <button
+              onClick={() => setGroupBy("person")}
+              className={`cursor-pointer rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                groupBy === "person"
+                  ? "bg-stone-700 text-white"
+                  : "text-stone-400 hover:text-white"
+              }`}
+            >
+              By Person
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <RoadmapTimeline
+        features={features}
+        lanes={lanes}
+        owners={owners}
+        laneLabels={laneLabels}
+        ownerAvatars={ownerAvatars}
+        groupBy={groupBy}
+      />
+    </div>
+  )
+}

--- a/apps/roadmap/components/DashboardShell.tsx
+++ b/apps/roadmap/components/DashboardShell.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import Sidebar from "@/components/Sidebar"
+import TopNav from "@/components/TopNav"
+
+export default function DashboardShell({
+  owners,
+  ownerAvatars,
+  children,
+}: {
+  owners: string[]
+  ownerAvatars: Record<string, string | null>
+  children: React.ReactNode
+}) {
+  const pathname = usePathname()
+  const usesTopNav = pathname === "/roadmap" || pathname === "/contributions"
+
+  if (usesTopNav) {
+    return (
+      <>
+        <TopNav />
+        <main className="min-h-screen">
+          <div className="mx-auto max-w-5xl px-4 py-6 md:px-8 md:py-8">
+            {children}
+          </div>
+        </main>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Sidebar owners={owners} ownerAvatars={ownerAvatars} />
+      <main className="min-h-screen pt-12 md:ml-56 md:pt-0">
+        <div className="p-4 md:p-8">{children}</div>
+      </main>
+    </>
+  )
+}

--- a/apps/roadmap/components/PlannedRoadmapTimeline.tsx
+++ b/apps/roadmap/components/PlannedRoadmapTimeline.tsx
@@ -1,0 +1,593 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import {
+  PLANNED_MILESTONES,
+  PLANNED_PHASES,
+  PLANNED_START_ISO,
+  PLANNED_TIMELINE_ROWS,
+  PLANNED_TRACK_BARS,
+  PLANNED_TRACKS,
+  PLANNED_WEEK_COUNT,
+  PLANNED_WEEKS,
+  type PlannedMilestone,
+  type PlannedPhase,
+  type PlannedTrackId,
+  type PlannedTimelineRow,
+  type PlannedTone,
+  type PlannedTrackBar,
+} from "@/lib/plannedRoadmap"
+
+const DAY_MS = 86400000
+const TRACK_LABEL_WIDTH_PX = 220
+const WEEK_WIDTH_PX = 132
+const TIMELINE_MARKER_LABEL_BAND_PX = 0
+const TIMELINE_HEADER_MARKER_BAND_PX = 18
+const TIMELINE_BAR_GAP_PX = 8
+const TRACK_ROW_VERTICAL_INSET_PX = 10
+const TRACK_SUBLANE_GAP_PX = 8
+const TRACK_ROW_HEIGHT_PX = 116
+const STACKED_TRACK_ROW_HEIGHT_PX = 168
+
+const TONE_STYLES: Record<
+  PlannedTone,
+  {
+    bar: string
+    badge: string
+    marker: string
+    markerLabel: string
+    card: string
+    accent: string
+  }
+> = {
+  stone: {
+    bar: "bg-gradient-to-r from-stone-500/14 via-stone-400/10 to-stone-300/8 text-stone-100",
+    badge: "bg-stone-100/10 text-stone-200",
+    marker: "border-stone-400/50 bg-stone-300 text-stone-950",
+    markerLabel: "bg-stone-300 text-stone-950",
+    card: "border-stone-700/80 bg-stone-950/50",
+    accent: "text-stone-200",
+  },
+  amber: {
+    bar: "bg-gradient-to-r from-amber-500/18 via-amber-400/14 to-amber-300/10 text-amber-50",
+    badge: "bg-amber-500/15 text-amber-200",
+    marker: "border-amber-400/50 bg-amber-300 text-amber-950",
+    markerLabel: "bg-amber-400 text-amber-950",
+    card: "border-amber-500/30 bg-amber-500/8",
+    accent: "text-amber-200",
+  },
+  sky: {
+    bar: "bg-gradient-to-r from-sky-500/18 via-sky-400/14 to-sky-300/10 text-sky-50",
+    badge: "bg-sky-500/15 text-sky-200",
+    marker: "border-sky-400/50 bg-sky-300 text-sky-950",
+    markerLabel: "bg-sky-400 text-sky-950",
+    card: "border-sky-500/30 bg-sky-500/8",
+    accent: "text-sky-200",
+  },
+  emerald: {
+    bar: "bg-gradient-to-r from-emerald-500/16 via-emerald-400/12 to-emerald-300/8 text-emerald-50",
+    badge: "bg-emerald-500/15 text-emerald-200",
+    marker: "border-emerald-400/50 bg-emerald-300 text-emerald-950",
+    markerLabel: "bg-emerald-400 text-emerald-950",
+    card: "border-emerald-500/30 bg-emerald-500/8",
+    accent: "text-emerald-200",
+  },
+  lime: {
+    bar: "bg-gradient-to-r from-lime-500/16 via-lime-400/12 to-lime-300/8 text-lime-50",
+    badge: "bg-lime-500/15 text-lime-200",
+    marker: "border-lime-400/50 bg-lime-300 text-lime-950",
+    markerLabel: "bg-lime-400 text-lime-950",
+    card: "border-lime-500/30 bg-lime-500/8",
+    accent: "text-lime-200",
+  },
+  rose: {
+    bar: "bg-gradient-to-r from-rose-500/16 via-rose-400/12 to-rose-300/8 text-rose-50",
+    badge: "bg-rose-500/15 text-rose-200",
+    marker: "border-rose-400/50 bg-rose-300 text-rose-950",
+    markerLabel: "bg-rose-500 text-white",
+    card: "border-rose-500/30 bg-rose-500/8",
+    accent: "text-rose-200",
+  },
+  red: {
+    bar: "bg-gradient-to-r from-red-500/16 via-red-400/12 to-red-300/8 text-red-50",
+    badge: "bg-red-500/15 text-red-200",
+    marker: "border-red-400/50 bg-red-300 text-red-950",
+    markerLabel: "bg-red-500 text-white",
+    card: "border-red-500/30 bg-red-500/8",
+    accent: "text-red-200",
+  },
+}
+
+function dateToPct(date: string): number {
+  const start = new Date(`${PLANNED_START_ISO}T00:00:00`)
+  const target = new Date(`${date}T00:00:00`)
+  const totalDays = PLANNED_WEEK_COUNT * 7
+  const offsetDays = (target.getTime() - start.getTime()) / DAY_MS
+  return (offsetDays / totalDays) * 100
+}
+
+function weekLeftPct(startWeek: number): number {
+  return (startWeek / PLANNED_WEEK_COUNT) * 100
+}
+
+function weekWidthPct(spanWeeks: number): number {
+  return (spanWeeks / PLANNED_WEEK_COUNT) * 100
+}
+
+function formatCalendarRange(startIsoDate: string, endIsoDate: string): string {
+  const startDate = new Date(`${startIsoDate}T00:00:00`)
+  const endDate = new Date(`${endIsoDate}T00:00:00`)
+  const startMonth = startDate.toLocaleDateString("en-US", { month: "short" })
+  const startDay = startDate.toLocaleDateString("en-US", { day: "numeric" })
+  const endMonth = endDate.toLocaleDateString("en-US", { month: "short" })
+  const endDay = endDate.toLocaleDateString("en-US", { day: "numeric" })
+
+  if (startMonth === endMonth) {
+    return `${startMonth} ${startDay} - ${endDay}`
+  }
+
+  return `${startMonth} ${startDay} - ${endMonth} ${endDay}`
+}
+
+function getPhaseCalendarRangeLabel(phase: PlannedPhase): string {
+  const startWeek = PLANNED_WEEKS[phase.startWeek]
+  const endWeek = PLANNED_WEEKS[phase.startWeek + phase.spanWeeks - 1]
+
+  if (!startWeek || !endWeek) {
+    return phase.rangeLabel
+  }
+
+  const endDate = new Date(`${endWeek.isoDate}T00:00:00`)
+  endDate.setDate(endDate.getDate() + 6)
+
+  return `${phase.badge} | ${formatCalendarRange(
+    startWeek.isoDate,
+    endDate.toISOString().slice(0, 10),
+  )}`
+}
+
+function renderWeekGuides() {
+  return PLANNED_WEEKS.map((week) => {
+    const leftPct = (week.index / PLANNED_WEEK_COUNT) * 100
+    return (
+      <div
+        key={week.isoDate}
+        className="absolute top-0 bottom-0 w-px border-r border-stone-800"
+        style={{ left: `${leftPct}%` }}
+      />
+    )
+  })
+}
+
+function isPlannedPhase(
+  item: PlannedPhase | PlannedTrackBar,
+): item is PlannedPhase {
+  return "sections" in item
+}
+
+function getPhaseSectionId(phaseId: string) {
+  return `planned-phase-${phaseId}`
+}
+
+function getTrackSectionId(trackBarId: string) {
+  return `planned-track-${trackBarId}`
+}
+
+function getTimelineTargetId(item: PlannedPhase | PlannedTrackBar) {
+  return isPlannedPhase(item)
+    ? getPhaseSectionId(item.id)
+    : getTrackSectionId(item.id)
+}
+
+function TimelineBar({
+  item,
+  topPx,
+  heightPx,
+}: {
+  item: PlannedPhase | PlannedTrackBar
+  topPx: number
+  heightPx: number
+}) {
+  const tone = TONE_STYLES[item.tone]
+  const leftPct = weekLeftPct(item.startWeek)
+  const widthPct = Math.max(weekWidthPct(item.spanWeeks), 8)
+  const isCompact = heightPx <= 52
+  const showBadge = Boolean(item.badge) && !isCompact
+  const targetId = getTimelineTargetId(item)
+  return (
+    <a
+      href={`#${targetId}`}
+      className={`absolute overflow-hidden rounded-xl shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-sm transition-[transform,filter,box-shadow] duration-150 hover:-translate-y-0.5 hover:brightness-125 hover:saturate-140 hover:shadow-[0_16px_34px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.1)] focus:outline-none focus:ring-2 focus:ring-white/30 ${tone.bar} ${
+        isCompact ? "px-4 py-1.5" : "px-3 py-2"
+      }`}
+      style={{
+        left: `calc(${leftPct}% + ${TIMELINE_BAR_GAP_PX / 2}px)`,
+        width: `calc(${widthPct}% - ${TIMELINE_BAR_GAP_PX}px)`,
+        top: `${topPx}px`,
+        height: `${heightPx}px`,
+      }}
+      aria-label={`Jump to ${item.title} details`}
+    >
+      <div className="pointer-events-none absolute inset-x-4 top-0 h-px bg-white/6" />
+      {showBadge && (
+        <div className="flex items-center gap-2">
+          <span
+            className={`rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${tone.badge}`}
+          >
+            {item.badge}
+          </span>
+        </div>
+      )}
+      <div
+        className={`truncate font-semibold text-white ${
+          isCompact ? "text-[13px] leading-4" : "mt-1 text-sm leading-5"
+        }`}
+      >
+        {item.title}
+      </div>
+      <div
+        className={`text-stone-300 ${
+          isCompact
+            ? "mt-0.5 line-clamp-2 text-[10px] leading-3.5"
+            : "line-clamp-2 text-[11px] leading-4"
+        }`}
+      >
+        {item.summary}
+      </div>
+    </a>
+  )
+}
+
+function MilestoneMarker({ milestone }: { milestone: PlannedMilestone }) {
+  return (
+    <div className="group relative">
+      <div
+        className="pointer-events-auto whitespace-nowrap rounded bg-red-500 px-1 py-px text-[9px] font-medium text-white"
+        tabIndex={0}
+      >
+        {milestone.label}
+      </div>
+      <div className="pointer-events-none absolute left-1/2 top-14 z-40 hidden w-72 -translate-x-1/2 rounded-xl border border-stone-700 bg-stone-950/96 p-3 text-left shadow-2xl group-hover:block group-focus-within:block">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+          {milestone.dateLabel}
+        </div>
+        <div className="mt-2 text-sm font-semibold text-white">
+          {milestone.label}
+        </div>
+        <p className="mt-2 text-sm leading-relaxed text-stone-300">
+          {milestone.description}
+        </p>
+        {milestone.items && milestone.items.length > 0 && (
+          <>
+            <div className="mt-3 text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+              Show only
+            </div>
+            <ul className="mt-2 space-y-1.5 text-sm text-stone-300">
+              {milestone.items.map((item) => (
+                <li key={`${milestone.id}-${item}`}>- {item}</li>
+              ))}
+            </ul>
+          </>
+        )}
+        {milestone.quote && (
+          <div className="mt-3 text-sm text-rose-100">"{milestone.quote}"</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function getBarsForTrackIds(trackIds: PlannedTrackId[]) {
+  return [
+    ...PLANNED_PHASES.filter((phase) => trackIds.includes(phase.track)),
+    ...PLANNED_TRACK_BARS.filter((bar) => trackIds.includes(bar.track)),
+  ]
+}
+
+function TrackRow({
+  row,
+  showTopBorder = true,
+}: {
+  row: PlannedTimelineRow
+  showTopBorder?: boolean
+}) {
+  const lanes = row.sublanes
+    ? row.sublanes.map((sublane) => ({
+        id: sublane.id,
+        bars: getBarsForTrackIds(sublane.trackIds),
+      }))
+    : [{ id: row.id, bars: getBarsForTrackIds(row.trackIds) }]
+  const rowHeightPx =
+    lanes.length > 1 ? STACKED_TRACK_ROW_HEIGHT_PX : TRACK_ROW_HEIGHT_PX
+  const laneHeightPx =
+    (rowHeightPx -
+      TRACK_ROW_VERTICAL_INSET_PX * 2 -
+      TRACK_SUBLANE_GAP_PX * (lanes.length - 1)) /
+    lanes.length
+
+  return (
+    <div
+      className={`grid ${showTopBorder ? "border-t border-stone-800" : ""}`}
+      style={{
+        gridTemplateColumns: `${TRACK_LABEL_WIDTH_PX}px minmax(0, 1fr)`,
+      }}
+    >
+      <div className="flex items-center gap-3 px-4 py-4">
+        <div>
+          <div className="text-sm font-semibold text-white">{row.label}</div>
+          <div className="text-xs text-stone-500">{row.description}</div>
+        </div>
+      </div>
+      <div className="relative" style={{ height: `${rowHeightPx}px` }}>
+        <div className="absolute inset-0">{renderWeekGuides()}</div>
+        <div className="absolute top-0 right-0 bottom-0 border-r border-stone-800" />
+        {lanes.length > 1 &&
+          lanes.slice(0, -1).map((lane, index) => (
+            <div
+              key={`${row.id}-${lane.id}-divider`}
+              className="absolute left-0 right-0 border-t border-stone-800/80"
+              style={{
+                top: `${TRACK_ROW_VERTICAL_INSET_PX + (index + 1) * laneHeightPx + index * TRACK_SUBLANE_GAP_PX + TRACK_SUBLANE_GAP_PX / 2}px`,
+              }}
+            />
+          ))}
+        {lanes.map((lane, index) => {
+          const laneTopPx =
+            TRACK_ROW_VERTICAL_INSET_PX +
+            index * (laneHeightPx + TRACK_SUBLANE_GAP_PX)
+
+          return lane.bars.map((bar) => (
+            <TimelineBar
+              key={`${row.id}-${lane.id}-${bar.id}`}
+              item={bar}
+              topPx={laneTopPx}
+              heightPx={laneHeightPx}
+            />
+          ))
+        })}
+      </div>
+    </div>
+  )
+}
+
+function PhaseCard({ phase }: { phase: PlannedPhase }) {
+  const tone = TONE_STYLES[phase.tone]
+  const track = PLANNED_TRACKS.find((candidate) => candidate.id === phase.track)
+  const calendarRangeLabel = getPhaseCalendarRangeLabel(phase)
+
+  return (
+    <div
+      id={getPhaseSectionId(phase.id)}
+      className={`scroll-mt-24 rounded-2xl border p-4 ${tone.card}`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${tone.badge}`}
+        >
+          {phase.badge}
+        </span>
+        {track && (
+          <span className="text-[11px] text-stone-500">{track.label}</span>
+        )}
+      </div>
+      <h3 className="mt-3 text-base font-semibold text-white">{phase.title}</h3>
+      <p className="mt-1 text-sm text-stone-300">{phase.summary}</p>
+      <p className={`mt-2 text-xs ${tone.accent}`}>{calendarRangeLabel}</p>
+
+      <div className="mt-4 space-y-4">
+        {phase.sections.map((section) => (
+          <div key={`${phase.id}-${section.label}`}>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+              {section.label}
+            </div>
+            <ul className="mt-2 space-y-1.5 text-sm text-stone-300">
+              {section.items.map((item) => (
+                <li key={`${phase.id}-${section.label}-${item}`}>- {item}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TrackBarCard({ bar }: { bar: PlannedTrackBar }) {
+  const tone = TONE_STYLES[bar.tone]
+  const track = PLANNED_TRACKS.find((candidate) => candidate.id === bar.track)
+
+  return (
+    <div
+      id={getTrackSectionId(bar.id)}
+      className={`scroll-mt-24 rounded-2xl border p-4 ${tone.card}`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        {track && (
+          <span className="text-[11px] text-stone-500">{track.label}</span>
+        )}
+      </div>
+      <h3 className="mt-3 text-base font-semibold text-white">{bar.title}</h3>
+      <p className="mt-1 text-sm text-stone-300">{bar.summary}</p>
+      {bar.details && bar.details.length > 0 && (
+        <ul className="mt-4 space-y-1.5 text-sm text-stone-300">
+          {bar.details.map((detail) => (
+            <li key={`${bar.id}-${detail}`}>- {detail}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default function PlannedRoadmapTimeline() {
+  const minWidthPx = TRACK_LABEL_WIDTH_PX + PLANNED_WEEK_COUNT * WEEK_WIDTH_PX
+  const [todayPct, setTodayPct] = useState<number | null>(null)
+
+  useEffect(() => {
+    const plannedStartDate = new Date(`${PLANNED_START_ISO}T00:00:00`)
+    const today = new Date()
+    const normalizedToday = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+    )
+    const todayOffsetDays =
+      (normalizedToday.getTime() - plannedStartDate.getTime()) / DAY_MS
+    const nextTodayPct = Math.max(
+      0,
+      Math.min(100, (todayOffsetDays / (PLANNED_WEEK_COUNT * 7)) * 100),
+    )
+
+    setTodayPct(nextTodayPct)
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      <div className="pr-0">
+        <div className="-mr-4 overflow-hidden md:-mr-8">
+          <div className="-mb-6 overflow-x-auto pb-6">
+            <div
+              className="relative"
+              style={{
+                minWidth: `${minWidthPx}px`,
+                paddingTop: `${TIMELINE_HEADER_MARKER_BAND_PX}px`,
+              }}
+            >
+              <div
+                className="pointer-events-none absolute right-0 z-30"
+                style={{
+                  left: `${TRACK_LABEL_WIDTH_PX}px`,
+                  top: "0px",
+                  bottom: "0px",
+                }}
+              >
+                {todayPct !== null && (
+                  <div
+                    className="absolute inset-y-0 z-30 w-px bg-red-500/70"
+                    style={{ left: `${todayPct}%` }}
+                  >
+                    <div className="absolute left-1/2 top-0 -translate-x-1/2 rounded bg-red-500 px-1 py-px text-[9px] font-medium whitespace-nowrap text-white">
+                      Today
+                    </div>
+                    <div
+                      className="absolute left-1/2 w-px -translate-x-1/2 bg-red-500/70"
+                      style={{
+                        top: `${TIMELINE_HEADER_MARKER_BAND_PX - 2}px`,
+                        bottom: "0px",
+                      }}
+                    />
+                  </div>
+                )}
+                {PLANNED_MILESTONES.map((milestone) => (
+                  <div
+                    key={`header-${milestone.id}`}
+                    className="absolute inset-y-0 z-20 w-px"
+                    style={{ left: `${dateToPct(milestone.date)}%` }}
+                  >
+                    <div
+                      className="absolute left-1/2 w-px -translate-x-1/2 bg-red-500/70"
+                      style={{
+                        top: `${TIMELINE_HEADER_MARKER_BAND_PX - 2}px`,
+                        bottom: "0px",
+                      }}
+                    />
+                    <div className="absolute left-1/2 top-0 -translate-x-1/2">
+                      <MilestoneMarker milestone={milestone} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div
+                className="grid"
+                style={{
+                  gridTemplateColumns: `${TRACK_LABEL_WIDTH_PX}px repeat(${PLANNED_WEEK_COUNT}, minmax(${WEEK_WIDTH_PX}px, 1fr))`,
+                }}
+              >
+                <div className="px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+                  Track
+                </div>
+                {PLANNED_WEEKS.map((week) => (
+                  <div
+                    key={week.isoDate}
+                    className="flex flex-col items-center justify-center gap-0.5 px-1 py-3 text-center text-[11px] text-stone-500"
+                  >
+                    <div className="font-semibold text-stone-300">
+                      {week.shortLabel}
+                    </div>
+                    <div className="text-[10px] text-stone-400">
+                      {week.dateLabel}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div
+                className="relative"
+                style={{ paddingTop: `${TIMELINE_MARKER_LABEL_BAND_PX}px` }}
+              >
+                {PLANNED_TIMELINE_ROWS.map((row, index) => (
+                  <TrackRow
+                    key={row.id}
+                    row={row}
+                    showTopBorder={index !== 0}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-5xl px-4 md:px-8">
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-stone-400">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-stone-300" />{" "}
+            Foundation
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-amber-400" />{" "}
+            Player / Experiences / Homepage
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-sky-400" />{" "}
+            Search
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />{" "}
+            Agentic Framework
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2 w-2 rounded-full bg-lime-400" />{" "}
+            Mobile + TV
+          </span>
+          <span className="flex items-center gap-2 border-l border-stone-700 pl-3">
+            <span className="inline-block h-2 w-2 rounded-full bg-rose-500" />
+            Important events
+          </span>
+          <span className="flex items-center gap-2">
+            <span className="h-3 border-l-2 border-l-red-500" />
+            Today
+          </span>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-5xl px-4 md:px-8">
+        <div className="grid gap-3 xl:grid-cols-2">
+          {PLANNED_PHASES.map((phase) => (
+            <PhaseCard key={phase.id} phase={phase} />
+          ))}
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-5xl px-4 md:px-8">
+        <div className="grid gap-3 xl:grid-cols-2">
+          {PLANNED_TRACK_BARS.map((bar) => (
+            <TrackBarCard key={bar.id} bar={bar} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/roadmap/components/RoadmapTimeline.tsx
+++ b/apps/roadmap/components/RoadmapTimeline.tsx
@@ -11,6 +11,8 @@ const MIN_TIMELINE_WIDTH_PX = 600
 const TIMELINE_MARKER_LABEL_BAND_PX = 28
 const PREVIEW_OPEN_DELAY_MS = 80
 const PREVIEW_CLOSE_DELAY_MS = 120
+const BASE_ROW_HEIGHT_PX = 26
+const STACK_ROW_GAP_PX = 4
 
 const STATUS_COLORS: Record<FeatureStatus, string> = {
   "not-started": "bg-stone-700 border-stone-600 hover:bg-stone-600",
@@ -178,6 +180,8 @@ function FeatureBlock({
   totalDays,
   ownerAvatars,
   highlight,
+  topPx,
+  heightPx,
   onMouseEnter,
   onMouseLeave,
   onFocusOpen,
@@ -189,6 +193,8 @@ function FeatureBlock({
   totalDays: number
   ownerAvatars: Record<string, string | null>
   highlight: HighlightState
+  topPx: number
+  heightPx: number
   onMouseEnter: (anchor: HTMLAnchorElement) => void
   onMouseLeave: () => void
   onFocusOpen: (anchor: HTMLAnchorElement) => void
@@ -204,10 +210,13 @@ function FeatureBlock({
   return (
     <Link
       href={`/ticket/${feature.id}`}
-      className={`group absolute inset-y-0.5 flex cursor-pointer items-center gap-1 overflow-hidden rounded border px-1.5 transition-all duration-150 sm:gap-1.5 sm:px-2 ${STATUS_COLORS[feature.status]} ${PRIORITY_BORDER[feature.priority]} ${HIGHLIGHT_RING[highlight]}`}
+      className={`group absolute flex cursor-pointer items-center gap-1 overflow-hidden rounded border px-1.5 transition-all duration-150 sm:gap-1.5 sm:px-2 ${STATUS_COLORS[feature.status]} ${PRIORITY_BORDER[feature.priority]} ${HIGHLIGHT_RING[highlight]}`}
       style={{
         left: `${leftPct}%`,
         width: `${Math.max(widthPct, 1)}%`,
+        top: `${topPx}px`,
+        height: `${heightPx}px`,
+        zIndex: highlight === "normal" || highlight === "dimmed" ? 1 : 30,
       }}
       title="Click for more details"
       onMouseEnter={(event) => onMouseEnter(event.currentTarget)}
@@ -257,7 +266,69 @@ type Group = {
   features: Feature[]
 }
 
-type GroupByMode = "lane" | "person"
+export type GroupByMode = "lane" | "person"
+
+type PositionedFeature = {
+  feature: Feature
+  layer: number
+}
+
+type OwnerTimelineRow = {
+  owner: string
+  earliestStart: string
+  stackDepth: number
+  features: PositionedFeature[]
+}
+
+function compareFeatureStart(a: Feature, b: Feature): number {
+  const startDiff = a.start_date.localeCompare(b.start_date)
+  if (startDiff !== 0) return startDiff
+  const durationDiff = b.duration - a.duration
+  if (durationDiff !== 0) return durationDiff
+  return a.title.localeCompare(b.title)
+}
+
+function buildOwnerTimelineRows(features: Feature[]): OwnerTimelineRow[] {
+  const byOwner = new Map<string, Feature[]>()
+
+  for (const feature of features) {
+    const ownerFeatures = byOwner.get(feature.owner) ?? []
+    ownerFeatures.push(feature)
+    byOwner.set(feature.owner, ownerFeatures)
+  }
+
+  return Array.from(byOwner.entries())
+    .map(([owner, ownerFeatures]) => {
+      const sorted = [...ownerFeatures].sort(compareFeatureStart)
+      const layerEndTimes: number[] = []
+      const positionedFeatures = sorted.map((feature) => {
+        const start = toDate(feature.start_date).getTime()
+        const end = start + feature.duration * DAY_MS
+
+        let layer = layerEndTimes.findIndex((layerEnd) => layerEnd <= start)
+        if (layer === -1) {
+          layer = layerEndTimes.length
+          layerEndTimes.push(end)
+        } else {
+          layerEndTimes[layer] = end
+        }
+
+        return { feature, layer }
+      })
+
+      return {
+        owner,
+        earliestStart: sorted[0]?.start_date ?? "",
+        stackDepth: Math.max(layerEndTimes.length, 1),
+        features: positionedFeatures,
+      }
+    })
+    .sort((a, b) => {
+      const startDiff = a.earliestStart.localeCompare(b.earliestStart)
+      if (startDiff !== 0) return startDiff
+      return a.owner.localeCompare(b.owner)
+    })
+}
 
 export default function RoadmapTimeline({
   features,
@@ -265,16 +336,17 @@ export default function RoadmapTimeline({
   owners,
   laneLabels,
   ownerAvatars,
+  groupBy,
 }: {
   features: Feature[]
   lanes: Lane[]
   owners: string[]
   laneLabels: Record<Lane, string>
   ownerAvatars: Record<string, string | null>
+  groupBy: GroupByMode
 }) {
-  const [groupBy, setGroupBy] = useState<GroupByMode>("lane")
-  const [hoveredId, setHoveredId] = useState<string | null>(null)
-  const [previewedId, setPreviewedId] = useState<string | null>(null)
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null)
+  const [previewedKey, setPreviewedKey] = useState<string | null>(null)
   const [supportsPreview, setSupportsPreview] = useState(false)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const openTimerRef = useRef<number | null>(null)
@@ -369,7 +441,7 @@ export default function RoadmapTimeline({
       { dependsOn: Set<string>; blocks: Set<string> }
     >()
     for (const f of features) {
-      map.set(f.id, {
+      map.set(f.filePath, {
         dependsOn: new Set(f.depends_on),
         blocks: new Set(f.blocks),
       })
@@ -377,10 +449,10 @@ export default function RoadmapTimeline({
     return map
   }, [features])
 
-  function getHighlight(featureId: string): HighlightState {
-    if (!hoveredId) return "normal"
-    if (featureId === hoveredId) return "hovered"
-    const hovered = depMap.get(hoveredId)
+  function getHighlight(featureKey: string, featureId: string): HighlightState {
+    if (!hoveredKey) return "normal"
+    if (featureKey === hoveredKey) return "hovered"
+    const hovered = depMap.get(hoveredKey)
     if (!hovered) return "dimmed"
     if (hovered.dependsOn.has(featureId)) return "dependency"
     if (hovered.blocks.has(featureId)) return "blocked-by"
@@ -407,8 +479,10 @@ export default function RoadmapTimeline({
 
   const visibleGroups = groups.filter((g) => g.features.length > 0)
   const previewedFeature =
-    previewedId != null
-      ? (timelineFeatures.find((feature) => feature.id === previewedId) ?? null)
+    previewedKey != null
+      ? (timelineFeatures.find(
+          (feature) => feature.filePath === previewedKey,
+        ) ?? null)
       : null
 
   function clearTimer(ref: { current: number | null }) {
@@ -424,7 +498,7 @@ export default function RoadmapTimeline({
   }
 
   function openPreview(
-    featureId: string,
+    featureKey: string,
     _anchor: HTMLAnchorElement,
     immediate = false,
   ) {
@@ -432,11 +506,11 @@ export default function RoadmapTimeline({
     clearTimer(closeTimerRef)
 
     const applyOpen = () => {
-      setHoveredId(featureId)
-      setPreviewedId(featureId)
+      setHoveredKey(featureKey)
+      setPreviewedKey(featureKey)
     }
 
-    if (previewedId === featureId) {
+    if (previewedKey === featureKey) {
       applyOpen()
       return
     }
@@ -454,8 +528,8 @@ export default function RoadmapTimeline({
     clearTimer(openTimerRef)
 
     const applyClose = () => {
-      setHoveredId(null)
-      setPreviewedId(null)
+      setHoveredKey(null)
+      setPreviewedKey(null)
     }
 
     clearTimer(closeTimerRef)
@@ -479,8 +553,8 @@ export default function RoadmapTimeline({
       setSupportsPreview(next)
       if (!next) {
         clearPreviewTimers()
-        setHoveredId(null)
-        setPreviewedId(null)
+        setHoveredKey(null)
+        setPreviewedKey(null)
       }
     }
 
@@ -500,30 +574,6 @@ export default function RoadmapTimeline({
 
   return (
     <div>
-      {/* Toggle */}
-      <div className="mb-4 flex w-fit items-center gap-1 rounded-lg bg-stone-800 p-1">
-        <button
-          onClick={() => setGroupBy("lane")}
-          className={`cursor-pointer rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-            groupBy === "lane"
-              ? "bg-stone-700 text-white"
-              : "text-stone-400 hover:text-white"
-          }`}
-        >
-          By Lane
-        </button>
-        <button
-          onClick={() => setGroupBy("person")}
-          className={`cursor-pointer rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-            groupBy === "person"
-              ? "bg-stone-700 text-white"
-              : "text-stone-400 hover:text-white"
-          }`}
-        >
-          By Person
-        </button>
-      </div>
-
       {/* Timeline */}
       <div ref={scrollContainerRef} className="overflow-x-auto">
         <div
@@ -613,9 +663,7 @@ export default function RoadmapTimeline({
           {/* Grouped rows */}
           <div className="divide-y divide-stone-800">
             {visibleGroups.map((g) => {
-              const sorted = [...g.features].sort((a, b) =>
-                a.start_date.localeCompare(b.start_date),
-              )
+              const ownerRows = buildOwnerTimelineRows(g.features)
 
               return (
                 <div key={g.key}>
@@ -637,44 +685,104 @@ export default function RoadmapTimeline({
                       {g.features.length}
                     </span>
                   </div>
-                  <div className="space-y-0">
-                    {sorted.map((feature) => (
-                      <div key={feature.id} className="relative h-7 sm:h-8">
-                        {/* Grid lines at week boundaries */}
-                        <div className="absolute inset-0">
-                          {weekColumns.map((col) => {
-                            const colLeft =
-                              ((col.start.getTime() - rangeStart.getTime()) /
-                                DAY_MS /
-                                totalDays) *
-                              100
-                            return (
-                              <div
-                                key={col.start.toISOString()}
-                                className="absolute top-0 bottom-0 w-px border-r border-stone-800"
-                                style={{ left: `${colLeft}%` }}
+                  <div className="space-y-2 pb-2">
+                    {ownerRows.map((ownerRow) => {
+                      const rowHeightPx =
+                        ownerRow.stackDepth * BASE_ROW_HEIGHT_PX +
+                        (ownerRow.stackDepth - 1) * STACK_ROW_GAP_PX
+
+                      return (
+                        <div
+                          key={`${g.key}-${ownerRow.owner}`}
+                          className={
+                            groupBy === "lane" ? "grid gap-3" : "grid gap-0"
+                          }
+                          style={
+                            groupBy === "lane"
+                              ? {
+                                  gridTemplateColumns:
+                                    "minmax(0, 120px) minmax(0, 1fr)",
+                                }
+                              : undefined
+                          }
+                        >
+                          {groupBy === "lane" && (
+                            <div className="flex min-w-0 items-start gap-2 pt-1">
+                              {ownerAvatars[ownerRow.owner] ? (
+                                <img
+                                  src={`${ownerAvatars[ownerRow.owner]}&s=32`}
+                                  alt={ownerRow.owner}
+                                  className="h-4 w-4 shrink-0 rounded-full bg-white"
+                                />
+                              ) : (
+                                <span className="mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-stone-400" />
+                              )}
+                              <div className="min-w-0">
+                                <div className="truncate text-xs font-medium capitalize text-stone-300">
+                                  {ownerRow.owner}
+                                </div>
+                                <div className="text-[10px] text-stone-500">
+                                  {ownerRow.features.length} task
+                                  {ownerRow.features.length === 1 ? "" : "s"}
+                                </div>
+                              </div>
+                            </div>
+                          )}
+
+                          <div
+                            className="relative"
+                            style={{ height: `${rowHeightPx}px` }}
+                          >
+                            {/* Grid lines at week boundaries */}
+                            <div className="absolute inset-0">
+                              {weekColumns.map((col) => {
+                                const colLeft =
+                                  ((col.start.getTime() -
+                                    rangeStart.getTime()) /
+                                    DAY_MS /
+                                    totalDays) *
+                                  100
+                                return (
+                                  <div
+                                    key={col.start.toISOString()}
+                                    className="absolute top-0 bottom-0 w-px border-r border-stone-800"
+                                    style={{ left: `${colLeft}%` }}
+                                  />
+                                )
+                              })}
+                            </div>
+
+                            {ownerRow.features.map(({ feature, layer }) => (
+                              <FeatureBlock
+                                key={feature.filePath}
+                                feature={feature}
+                                rangeStart={rangeStart}
+                                totalDays={totalDays}
+                                ownerAvatars={ownerAvatars}
+                                highlight={getHighlight(
+                                  feature.filePath,
+                                  feature.id,
+                                )}
+                                topPx={
+                                  layer *
+                                  (BASE_ROW_HEIGHT_PX + STACK_ROW_GAP_PX)
+                                }
+                                heightPx={BASE_ROW_HEIGHT_PX}
+                                onMouseEnter={(anchor) =>
+                                  openPreview(feature.filePath, anchor)
+                                }
+                                onMouseLeave={() => closePreview()}
+                                onFocusOpen={(anchor) =>
+                                  openPreview(feature.filePath, anchor, true)
+                                }
+                                onBlurClose={() => closePreview(true)}
+                                onEscapeClose={() => closePreview(true)}
                               />
-                            )
-                          })}
+                            ))}
+                          </div>
                         </div>
-                        <FeatureBlock
-                          feature={feature}
-                          rangeStart={rangeStart}
-                          totalDays={totalDays}
-                          ownerAvatars={ownerAvatars}
-                          highlight={getHighlight(feature.id)}
-                          onMouseEnter={(anchor) =>
-                            openPreview(feature.id, anchor)
-                          }
-                          onMouseLeave={() => closePreview()}
-                          onFocusOpen={(anchor) =>
-                            openPreview(feature.id, anchor, true)
-                          }
-                          onBlurClose={() => closePreview(true)}
-                          onEscapeClose={() => closePreview(true)}
-                        />
-                      </div>
-                    ))}
+                      )
+                    })}
                   </div>
                 </div>
               )

--- a/apps/roadmap/components/Sidebar.tsx
+++ b/apps/roadmap/components/Sidebar.tsx
@@ -28,6 +28,7 @@ export default function Sidebar({
 }) {
   const [open, setOpen] = useState(false)
   const pathname = usePathname()
+  const showDirectorySections = pathname !== "/roadmap"
 
   const close = () => setOpen(false)
 
@@ -57,50 +58,61 @@ export default function Sidebar({
         <Link href="/roadmap" className={linkClass("/roadmap")} onClick={close}>
           Roadmap
         </Link>
+        <Link
+          href="/contributions"
+          className={linkClass("/contributions")}
+          onClick={close}
+        >
+          Tasks
+        </Link>
       </div>
 
-      <div>
-        <h3 className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-stone-500">
-          Lanes
-        </h3>
-        {ALL_LANES.map((lane) => (
-          <Link
-            key={lane}
-            href={`/lane/${lane}`}
-            className={linkClass(`/lane/${lane}`)}
-            onClick={close}
-          >
-            {LANE_LABELS[lane]}
-          </Link>
-        ))}
-      </div>
+      {showDirectorySections ? (
+        <>
+          <div>
+            <h3 className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-stone-500">
+              Lanes
+            </h3>
+            {ALL_LANES.map((lane) => (
+              <Link
+                key={lane}
+                href={`/lane/${lane}`}
+                className={linkClass(`/lane/${lane}`)}
+                onClick={close}
+              >
+                {LANE_LABELS[lane]}
+              </Link>
+            ))}
+          </div>
 
-      <div>
-        <h3 className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-stone-500">
-          People
-        </h3>
-        {owners.map((owner) => (
-          <Link
-            key={owner}
-            href={`/person/${owner}`}
-            className={`flex items-center gap-2 capitalize ${linkClass(`/person/${owner}`)}`}
-            onClick={close}
-          >
-            {ownerAvatars[owner] ? (
-              <img
-                src={`${ownerAvatars[owner]}&s=32`}
-                alt={owner}
-                className="h-4 w-4 rounded-full bg-white"
-              />
-            ) : (
-              <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-stone-700 text-[9px] font-medium uppercase text-stone-400">
-                {owner[0]}
-              </span>
-            )}
-            {owner}
-          </Link>
-        ))}
-      </div>
+          <div>
+            <h3 className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-stone-500">
+              People
+            </h3>
+            {owners.map((owner) => (
+              <Link
+                key={owner}
+                href={`/person/${owner}`}
+                className={`flex items-center gap-2 capitalize ${linkClass(`/person/${owner}`)}`}
+                onClick={close}
+              >
+                {ownerAvatars[owner] ? (
+                  <img
+                    src={`${ownerAvatars[owner]}&s=32`}
+                    alt={owner}
+                    className="h-4 w-4 rounded-full bg-white"
+                  />
+                ) : (
+                  <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-stone-700 text-[9px] font-medium uppercase text-stone-400">
+                    {owner[0]}
+                  </span>
+                )}
+                {owner}
+              </Link>
+            ))}
+          </div>
+        </>
+      ) : null}
     </nav>
   )
 

--- a/apps/roadmap/lib/plannedRoadmap.ts
+++ b/apps/roadmap/lib/plannedRoadmap.ts
@@ -1,0 +1,564 @@
+export type PlannedTone =
+  | "stone"
+  | "amber"
+  | "sky"
+  | "emerald"
+  | "lime"
+  | "rose"
+  | "red"
+
+export type PlannedTrackId =
+  | "milestones"
+  | "foundation"
+  | "surface"
+  | "search"
+  | "agentic-framework"
+  | "mobile-tv"
+
+export type PlannedTrack = {
+  id: PlannedTrackId
+  label: string
+  description: string
+}
+
+export type PlannedTimelineRow = {
+  id: string
+  label: string
+  description: string
+  trackIds: PlannedTrackId[]
+  sublanes?: Array<{
+    id: string
+    trackIds: PlannedTrackId[]
+  }>
+}
+
+export type PlannedPhaseSection = {
+  label: string
+  items: string[]
+}
+
+export type PlannedPhase = {
+  id: string
+  title: string
+  shortTitle: string
+  track: PlannedTrackId
+  tone: PlannedTone
+  startWeek: number
+  spanWeeks: number
+  badge: string
+  rangeLabel: string
+  summary: string
+  sections: PlannedPhaseSection[]
+}
+
+export type PlannedTrackBar = {
+  id: string
+  title: string
+  summary: string
+  track: PlannedTrackId
+  tone: PlannedTone
+  startWeek: number
+  spanWeeks: number
+  badge?: string
+  details?: string[]
+}
+
+export type PlannedMilestone = {
+  id: string
+  label: string
+  dateLabel: string
+  description: string
+  items?: string[]
+  quote?: string
+  track: PlannedTrackId
+  tone: PlannedTone
+  date: string
+}
+
+type PlannedWeek = {
+  index: number
+  shortLabel: string
+  label: string
+  dateLabel: string
+  isoDate: string
+}
+
+const DAY_MS = 86400000
+const WEEK_MS = 7 * 86400000
+const PLANNED_START_DATE = new Date("2026-04-28T00:00:00")
+
+function addWeeks(date: Date, weeks: number): Date {
+  return new Date(date.getTime() + weeks * WEEK_MS)
+}
+
+function formatDateRangeLabel(startDate: Date, endDate: Date): string {
+  const startMonth = startDate.toLocaleDateString("en-US", { month: "short" })
+  const startDay = startDate.toLocaleDateString("en-US", { day: "numeric" })
+  const endMonth = endDate.toLocaleDateString("en-US", { month: "short" })
+  const endDay = endDate.toLocaleDateString("en-US", { day: "numeric" })
+
+  if (startMonth === endMonth) {
+    return `${startMonth} ${startDay}-${endDay}`
+  }
+
+  return `${startMonth} ${startDay}-${endMonth} ${endDay}`
+}
+
+export const PLANNED_WEEK_COUNT = 14
+export const PLANNED_START_ISO = "2026-04-28"
+
+export const PLANNED_WEEKS: PlannedWeek[] = Array.from(
+  { length: PLANNED_WEEK_COUNT },
+  (_, index) => {
+    const date = addWeeks(PLANNED_START_DATE, index)
+    const endDate = new Date(date.getTime() + 6 * DAY_MS)
+    return {
+      index,
+      shortLabel: `W${index + 1}`,
+      label: `Week ${index + 1}`,
+      dateLabel: formatDateRangeLabel(date, endDate),
+      isoDate: date.toISOString().slice(0, 10),
+    }
+  },
+)
+
+export const PLANNED_TITLE = "FORGE ROADMAP - Next 3 Months"
+export const PLANNED_SUBTITLE = "Starting Apr 28, 2026"
+export const PLANNED_RANGE_LABEL = "Apr 28 - Aug 3, 2026"
+export const PLANNED_GOAL =
+  "Migrate to Forge while shipping real user value, prepare Demo Day, and set up the future AI and creator ecosystem."
+
+export const PLANNED_CADENCE = [
+  "2 weeks per feature",
+  "Week 1 = build",
+  "Week 2 = release + polish",
+]
+
+export const PLANNED_TRACKS: PlannedTrack[] = [
+  {
+    id: "milestones",
+    label: "Milestones",
+    description: "External deadline and Demo Day checkpoints",
+  },
+  {
+    id: "foundation",
+    label: "Foundation",
+    description: "CMS, data, infrastructure, stability, shutdown",
+  },
+  {
+    id: "surface",
+    label: "Surface",
+    description: "Player, experiences, homepage",
+  },
+  {
+    id: "search",
+    label: "Search",
+    description: "Hybrid and multilingual search",
+  },
+  {
+    id: "agentic-framework",
+    label: "Agentic Framework",
+    description: "R&D with Mastra AI, non-blocking",
+  },
+  {
+    id: "mobile-tv",
+    label: "Mobile + TV",
+    description: "RN + Expo buildout, delayed release",
+  },
+]
+
+export const PLANNED_TIMELINE_ROWS: PlannedTimelineRow[] = [
+  {
+    id: "migration",
+    label: "Delivery",
+    description: "Core migration, product releases, search",
+    trackIds: ["foundation", "surface", "search"],
+  },
+  {
+    id: "experimentation",
+    label: "Research",
+    description: "Agentic R&D, mobile + TV",
+    trackIds: ["agentic-framework", "mobile-tv"],
+    sublanes: [
+      {
+        id: "agentic",
+        trackIds: ["agentic-framework"],
+      },
+      {
+        id: "mobile-tv",
+        trackIds: ["mobile-tv"],
+      },
+    ],
+  },
+]
+
+export const PLANNED_PHASES: PlannedPhase[] = [
+  {
+    id: "phase-0",
+    title: "Foundation",
+    shortTitle: "Foundation",
+    track: "foundation",
+    tone: "stone",
+    startWeek: 0,
+    spanWeeks: 2,
+    badge: "Weeks 1-2",
+    rangeLabel: "Weeks 1-2 | Apr 28 - May 9",
+    summary: "No release while the migration foundation is put in place.",
+    sections: [
+      {
+        label: "Outcome",
+        items: [
+          "No release",
+          "Strapi -> Postgres + Custom CMS",
+          "Import Core data",
+          "Stable sync with Core",
+        ],
+      },
+      {
+        label: "Parallel",
+        items: [
+          "Player page ready behind flag",
+          "Hybrid search in progress",
+          "Agentic (Mastra AI) setup",
+          "Mobile (Expo) base app",
+        ],
+      },
+    ],
+  },
+  {
+    id: "phase-1",
+    title: "Replace Player Page",
+    shortTitle: "Replace Player Page",
+    track: "surface",
+    tone: "amber",
+    startWeek: 2,
+    spanWeeks: 2,
+    badge: "Weeks 3-4",
+    rangeLabel: "Weeks 3-4",
+    summary: "First user-visible Forge release centered on playback.",
+    sections: [
+      {
+        label: "Week 3 (Build)",
+        items: ["Forge player page", "AI subtitles integration"],
+      },
+      {
+        label: "Week 4 (Release #1)",
+        items: ["Player live", "AI subtitles visible"],
+      },
+    ],
+  },
+  {
+    id: "phase-2",
+    title: "Experiences Rollout",
+    shortTitle: "Experiences Rollout",
+    track: "surface",
+    tone: "amber",
+    startWeek: 4,
+    spanWeeks: 2,
+    badge: "Weeks 5-6",
+    rangeLabel: "Weeks 5-6",
+    summary: "Experience engine plus first prototype release.",
+    sections: [
+      {
+        label: "Week 5 (Build)",
+        items: ["Experience engine", "World Cup prototype"],
+      },
+      {
+        label: "Week 6 (Release #2)",
+        items: ["First Experience live", "UX + content polish"],
+      },
+    ],
+  },
+  {
+    id: "phase-3",
+    title: "Search Rollout",
+    shortTitle: "Search Rollout",
+    track: "search",
+    tone: "sky",
+    startWeek: 6,
+    spanWeeks: 2,
+    badge: "Weeks 7-8",
+    rangeLabel: "Weeks 7-8",
+    summary: "Hybrid search rollout with multilingual validation.",
+    sections: [
+      {
+        label: "Week 7 (Build)",
+        items: [
+          "Hybrid search (text + vector)",
+          "Multilingual validation",
+          "Shadow vs Algolia",
+        ],
+      },
+      {
+        label: "Week 8 (Release #3)",
+        items: ["Forge search live", "Algolia fallback active"],
+      },
+    ],
+  },
+  {
+    id: "phase-4",
+    title: "Watch Homepage",
+    shortTitle: "Watch Homepage",
+    track: "surface",
+    tone: "amber",
+    startWeek: 8,
+    spanWeeks: 2,
+    badge: "Weeks 9-10",
+    rangeLabel: "Weeks 9-10",
+    summary: "Homepage migration after player, experiences, and search.",
+    sections: [
+      {
+        label: "Week 9 (Build)",
+        items: ["Homepage on Forge"],
+      },
+      {
+        label: "Week 10 (Release #4)",
+        items: ["Homepage live", "Integrated with search + experiences"],
+      },
+    ],
+  },
+  {
+    id: "phase-5",
+    title: "i18n + Stability",
+    shortTitle: "i18n + Stability",
+    track: "foundation",
+    tone: "stone",
+    startWeek: 10,
+    spanWeeks: 2,
+    badge: "Weeks 11-12",
+    rangeLabel: "Weeks 11-12",
+    summary: "Language and stability hardening before shutdown.",
+    sections: [
+      {
+        label: "Week 11 (Build)",
+        items: ["Internationalization"],
+      },
+      {
+        label: "Week 12 (Release #5)",
+        items: ["Multilingual UI stable", "Bugs fixed"],
+      },
+    ],
+  },
+  {
+    id: "phase-6",
+    title: "Old Watch Shutdown",
+    shortTitle: "Old Watch Shutdown",
+    track: "foundation",
+    tone: "stone",
+    startWeek: 12,
+    spanWeeks: 2,
+    badge: "Weeks 13-14",
+    rangeLabel: "Weeks 13-14",
+    summary: "Retire the old Watch stack after the migration is stable.",
+    sections: [
+      {
+        label: "Week 13 (Build)",
+        items: ["Remove legacy dependencies"],
+      },
+      {
+        label: "Week 14 (Release #6)",
+        items: ["Retire old Watch", "Remove Algolia"],
+      },
+    ],
+  },
+]
+
+export const PLANNED_TRACK_BARS: PlannedTrackBar[] = [
+  {
+    id: "agentic-track",
+    title: "Agentic Framework",
+    summary:
+      "Build with Mastra AI, validate workflows, integrate after migration.",
+    track: "agentic-framework",
+    tone: "emerald",
+    startWeek: 0,
+    spanWeeks: 4,
+    details: [
+      "Build with Mastra AI",
+      "Validate workflows for search and experiences",
+      "Integrate after migration, not before",
+    ],
+  },
+  {
+    id: "agentic-deployment-track",
+    title: "First agent deployment",
+    summary: "Deploy the first production agent.",
+    track: "agentic-framework",
+    tone: "emerald",
+    startWeek: 4,
+    spanWeeks: 2,
+    details: [
+      "Deploy first agent to production use",
+      "Validate first real agent workflow after framework setup",
+    ],
+  },
+  {
+    id: "agentic-deployment-track-2",
+    title: "New agent deployment",
+    summary: "Ship another production agent.",
+    track: "agentic-framework",
+    tone: "emerald",
+    startWeek: 6,
+    spanWeeks: 2,
+    details: [
+      "Deploy another agent to production use",
+      "Expand agent workflows beyond the first release",
+    ],
+  },
+  {
+    id: "agentic-deployment-track-3",
+    title: "New agent deployment",
+    summary: "Ship another production agent.",
+    track: "agentic-framework",
+    tone: "emerald",
+    startWeek: 8,
+    spanWeeks: 2,
+    details: [
+      "Deploy another agent to production use",
+      "Continue validating repeatable agent delivery",
+    ],
+  },
+  {
+    id: "agentic-deployment-track-4",
+    title: "New agent deployment",
+    summary: "Ship another production agent.",
+    track: "agentic-framework",
+    tone: "emerald",
+    startWeek: 10,
+    spanWeeks: 2,
+    details: [
+      "Deploy another agent to production use",
+      "Strengthen the deployment cadence for agent workflows",
+    ],
+  },
+  {
+    id: "agentic-deployment-track-5",
+    title: "New agent deployment",
+    summary: "Ship another production agent.",
+    track: "agentic-framework",
+    tone: "emerald",
+    startWeek: 12,
+    spanWeeks: 2,
+    details: [
+      "Deploy another agent to production use",
+      "Finish the roadmap with an ongoing agent release rhythm",
+    ],
+  },
+  {
+    id: "mobile-track",
+    title: "Mobile + TV",
+    summary: "Build the mobile + TV foundation for later rollout.",
+    track: "mobile-tv",
+    tone: "lime",
+    startWeek: 0,
+    spanWeeks: 4,
+    badge: "Beta",
+    details: [
+      "Build the Expo / TV app foundation",
+      "Prepare later Forge connection work",
+      "Keep release for a later phase",
+    ],
+  },
+  {
+    id: "mobile-single-player-track",
+    title: "Single player screen",
+    summary: "Build the first mobile playback screen.",
+    track: "mobile-tv",
+    tone: "lime",
+    startWeek: 4,
+    spanWeeks: 2,
+    badge: "Beta",
+    details: [
+      "Build the single-player screen on mobile",
+      "Carry playback UX into the mobile lane",
+    ],
+  },
+  {
+    id: "mobile-experiences-track",
+    title: "Experiences screen",
+    summary: "Roll out experiences to mobile platforms.",
+    track: "mobile-tv",
+    tone: "lime",
+    startWeek: 6,
+    spanWeeks: 2,
+    badge: "Beta",
+    details: [
+      "Port the experiences rollout to mobile + TV",
+      "Carry weeks 5-6 experience work into mobile surfaces",
+    ],
+  },
+  {
+    id: "mobile-search-track",
+    title: "Search on mobile + TV",
+    summary: "Roll out search to mobile platforms.",
+    track: "mobile-tv",
+    tone: "lime",
+    startWeek: 8,
+    spanWeeks: 2,
+    badge: "Beta",
+    details: [
+      "Port weeks 7-8 search work to mobile + TV",
+      "Validate mobile search UX on the new surfaces",
+    ],
+  },
+  {
+    id: "mobile-homepage-track",
+    title: "Mobile homepage rollout",
+    summary: "Port the homepage rollout to mobile + TV.",
+    track: "mobile-tv",
+    tone: "lime",
+    startWeek: 10,
+    spanWeeks: 2,
+    badge: "Beta",
+    details: [
+      "Port weeks 9-10 homepage work to mobile + TV",
+      "Carry the main homepage rollout into mobile surfaces",
+    ],
+  },
+  {
+    id: "mobile-stability-track",
+    title: "Internationalization and stability",
+    summary: "Stabilize the mobile + TV release.",
+    track: "mobile-tv",
+    tone: "lime",
+    startWeek: 12,
+    spanWeeks: 2,
+    badge: "Beta",
+    details: [
+      "Add internationalization to mobile + TV",
+      "Finish with stability and bug-fix work",
+    ],
+  },
+]
+
+export const PLANNED_MILESTONES: PlannedMilestone[] = [
+  {
+    id: "creator-launch",
+    label: "Creator launch",
+    dateLabel: "May 10, 2026",
+    description:
+      "Media Creators Community (Lyuba): launch the AI inspiration board + contest to attract creators and seed future templates/workflows. Visibility only, non-blocking.",
+    track: "milestones",
+    tone: "red",
+    date: "2026-05-10",
+  },
+  {
+    id: "demo-day",
+    label: "Demo Day",
+    dateLabel: "May 15, 2026",
+    description:
+      "Show the player with AI subtitles and experience generation. Narrative: User asks -> AI guides -> media responds.",
+    items: ["Player (AI subtitles)", "Experience generation"],
+    quote: "User asks -> AI guides -> media responds",
+    track: "milestones",
+    tone: "rose",
+    date: "2026-05-15",
+  },
+]
+
+export const PLANNED_DEMO_DAY = {
+  title: "Demo Day",
+  dateLabel: "May 15, 2026",
+  showcase: ["Player (AI subtitles)", "Experience generation"],
+  narrative: "User asks -> AI guides -> media responds",
+}

--- a/apps/roadmap/tsconfig.json
+++ b/apps/roadmap/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -4,14 +4,14 @@
 
 Build trusted, scalable AI capabilities that help people discover gospel content, engage meaningfully with Scripture, and take faithful next steps.
 
-## Status (April 13, 2026)
+## Status (April 29, 2026)
 
-- **Total tickets:** 88
-- **Complete:** 31
-- **In progress:** 3
+- **Total tickets:** 123
+- **Complete:** 60
+- **In progress:** 7
 - **Not started:** 18
-- **Blocked:** 36
-- **Overdue and not complete:** 2
+- **Blocked:** 38
+- **Overdue and not complete:** 16
 
 ## Feature Index
 
@@ -21,25 +21,31 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | ------------------------------------------------------------------------------ | -------------------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
 | [feat-009](content-discovery/feat-009-pgvector-embedding-indexing.md)          | pgvector Setup and Embedding Indexing                    | nisal     | P0       | 2026-04-07 | 14   | 2026-04-20 | complete    |
 | [feat-010](content-discovery/feat-010-semantic-search-api.md)                  | Semantic Search API                                      | nisal     | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
-| [feat-011](content-discovery/feat-011-search-ui-web.md)                        | Search UI — Web                                          | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | not-started |
-| [feat-012](content-discovery/feat-012-search-ui-mobile.md)                     | Search UI — Mobile                                       | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | not-started |
-| [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)        | Experience Embedding Pipeline                            | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | not-started |
-| [feat-037](content-discovery/feat-037-video-content-vectorization.md)          | Video Content Vectorization for Recommendations          | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | blocked     |
+| [feat-011](content-discovery/feat-011-search-ui-web.md)                        | Search UI — Web                                          | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
+| [feat-012](content-discovery/feat-012-search-ui-mobile.md)                     | Search UI — Mobile                                       | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
+| [feat-097](content-discovery/feat-097-investigate-prod-query-embedding.md)     | Investigate Production Query Embedding Degradation       | nisal     | P1       | 2026-04-15 | 2    | 2026-04-16 | complete    |
+| [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)        | Experience Embedding Pipeline                            | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |
+| [feat-037](content-discovery/feat-037-video-content-vectorization.md)          | Video Content Vectorization for Recommendations          | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | complete    |
 | [feat-038](content-discovery/feat-038-video-vectorization-data-audit.md)       | Video Vectorization — Data Audit                         | nisal     | P1       | 2026-04-21 | 3    | 2026-04-23 | complete    |
-| [feat-096](content-discovery/feat-096-experience-embeddings-backfill.md)       | Experience Embeddings Backfill                           | nisal     | P1       | 2026-04-21 | 2    | 2026-04-22 | blocked     |
-| [feat-086](content-discovery/feat-086-experience-search-integration.md)        | Search Extension — Add Experiences to Results            | nisal     | P1       | 2026-04-23 | 5    | 2026-04-27 | blocked     |
+| [feat-090](content-discovery/feat-090-watch-event-collection.md)               | Watch Event Collection & Session Tracking                | nisal     | P1       | 2026-04-21 | 10   | 2026-04-30 | not-started |
+| [feat-096](content-discovery/feat-096-experience-embeddings-backfill.md)       | Experience Embeddings Backfill                           | nisal     | P1       | 2026-04-21 | 2    | 2026-04-22 | complete    |
+| [feat-086](content-discovery/feat-086-experience-search-integration.md)        | Search Extension — Add Experiences to Results            | nisal     | P1       | 2026-04-23 | 5    | 2026-04-27 | complete    |
 | [feat-039](content-discovery/feat-039-chapter-based-scene-boundaries.md)       | Video Vectorization — Chapter-Based Scene Boundaries     | nisal     | P1       | 2026-04-24 | 7    | 2026-04-30 | complete    |
 | [feat-040](content-discovery/feat-040-multimodal-scene-descriptions.md)        | Video Vectorization — Multimodal Scene Analysis          | nisal     | P1       | 2026-05-01 | 10   | 2026-05-10 | complete    |
+| [feat-091](content-discovery/feat-091-fpmc-video-page-recommendations.md)      | FPMC Video Page Recommendations                          | nisal     | P1       | 2026-05-01 | 14   | 2026-05-14 | not-started |
 | [feat-041](content-discovery/feat-041-scene-embeddings-table.md)               | Video Vectorization — Scene Embeddings Table + Indexing  | nisal     | P1       | 2026-05-11 | 7    | 2026-05-17 | complete    |
+| [feat-092](content-discovery/feat-092-two-tower-neural-recommendations.md)     | Two-Tower Neural Recommendation Model                    | nisal     | P1       | 2026-05-15 | 21   | 2026-06-04 | not-started |
 | [feat-042](content-discovery/feat-042-backfill-worker.md)                      | Video Vectorization — Phase 1 Backfill Worker (en/es/fr) | nisal     | P1       | 2026-05-18 | 10   | 2026-05-27 | complete    |
 | [feat-044](content-discovery/feat-044-recommendation-query-api.md)             | Video Vectorization — Recommendation Query API           | nisal     | P1       | 2026-05-28 | 7    | 2026-06-03 | complete    |
 | [feat-055](content-discovery/feat-055-smart-video-playlists.md)                | Smart Video Playlists                                    | vlad      | P1       | 2026-05-31 | 31   | 2026-06-30 | not-started |
 | [feat-045](content-discovery/feat-045-pipeline-integration.md)                 | Video Vectorization — Pipeline Integration               | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
 | [feat-046](content-discovery/feat-046-recommendations-demo-experience.md)      | Video Vectorization — Recommendations Demo Experience    | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
-| [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)  | Deploy Semantic Search Architecture                      | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | blocked     |
+| [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)  | Deploy Semantic Search Architecture                      | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-080](content-discovery/feat-080-transcript-embedding-table-rename.md)    | Transcript Embedding Table Rename                        | nisal     | P2       | 2026-04-10 | 2    | 2026-04-11 | complete    |
-| [feat-043](content-discovery/feat-043-visual-shot-detection-fusion.md)         | Video Vectorization — Visual Shot Detection Fusion       | nisal     | P2       | 2026-05-28 | 10   | 2026-06-06 | not-started |
-| [feat-071](content-discovery/feat-071-recommendation-content-deduplication.md) | Recommendation Content Deduplication                     | nisal     | P2       | 2026-06-15 | 5    | 2026-06-19 | not-started |
+| [feat-043](content-discovery/feat-043-visual-shot-detection-fusion.md)         | Video Vectorization — Visual Shot Detection Fusion       | nisal     | P2       | 2026-05-28 | 10   | 2026-06-06 | blocked     |
+| [feat-093](content-discovery/feat-093-cold-start-context-recommendations.md)   | Cold Start Context-Based Recommendations                 | nisal     | P2       | 2026-06-05 | 7    | 2026-06-11 | not-started |
+| [feat-094](content-discovery/feat-094-recommendation-ab-comparison-logging.md) | Recommendation A/B Comparison Logging                    | nisal     | P2       | 2026-06-12 | 7    | 2026-06-18 | not-started |
+| [feat-071](content-discovery/feat-071-recommendation-content-deduplication.md) | Recommendation Content Deduplication                     | nisal     | P2       | 2026-06-15 | 5    | 2026-06-19 | complete    |
 | [feat-063](content-discovery/feat-063-personalize-discovery-experiences.md)    | Personalize Discovery Experiences                        | tataihono | P2       | 2026-10-01 | 45   | 2026-11-14 | blocked     |
 
 ### Media Generation
@@ -48,6 +54,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | ----------------------------------------------------------------------------------------- | --------------------------------------------------------- | ----- | -------- | ---------- | ---- | ---------- | ----------- |
 | [feat-030](media-generation/feat-030-video-content-discovery-dashboard.md)                | Video Content Discovery Dashboard                         | vlad  | P0       | 2026-03-18 | 14   | 2026-03-31 | complete    |
 | [feat-031](media-generation/feat-031-ai-video-enrichment-pipeline.md)                     | AI Video Enrichment Pipeline                              | vlad  | P0       | 2026-03-18 | 31   | 2026-04-17 | in-progress |
+| [feat-038](media-generation/feat-038-ai-uploading-publishing-studio.md)                   | AI Uploading and Publishing Studio                        | vlad  | P0       | 2026-05-05 | 28   | 2026-06-01 | blocked     |
 | [feat-087](media-generation/feat-087-manager-enrichment-ux.md)                            | Manager Enrichment UX                                     | vlad  | P1       | 2026-04-08 | 11   | 2026-04-18 | complete    |
 | [feat-035](media-generation/feat-035-video-palyer-ux-for-autogenerated-subs.md)           | Video Player UX for Autogenerated Subs                    | vlad  | P1       | 2026-04-13 | 18   | 2026-04-30 | blocked     |
 | [feat-048](media-generation/feat-048-production-transcription-qa-and-prompt-tuning.md)    | Production Transcription QA and Prompt Tuning             | vlad  | P1       | 2026-04-13 | 18   | 2026-04-30 | blocked     |
@@ -59,6 +66,9 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-054](media-generation/feat-054-video-pages-2-0.md)                                  | Video Pages 2.0                                           | vlad  | P1       | 2026-04-21 | 14   | 2026-05-04 | not-started |
 | [feat-050](media-generation/feat-050-speaker-attribution-for-subtitles.md)                | Speaker Attribution for Subtitles                         | vlad  | P1       | 2026-05-01 | 31   | 2026-05-31 | blocked     |
 | [feat-052](media-generation/feat-052-ai-video-contest-platform.md)                        | AI Video Contest Platform                                 | vlad  | P1       | 2026-05-01 | 31   | 2026-05-31 | not-started |
+| [feat-035](media-generation/feat-035-manager-pipeline-transparency-workspace.md)          | Manager Pipeline Transparency Workspace                   | vlad  | P1       | 2026-05-12 | 21   | 2026-06-01 | blocked     |
+| [feat-037](media-generation/feat-037-playback-qa-feedback-loop.md)                        | Playback QA and Feedback Loop                             | vlad  | P1       | 2026-05-19 | 21   | 2026-06-08 | blocked     |
+| [feat-041](media-generation/feat-041-alternative-report-sections.md)                      | Alternative Report Sections                               | vlad  | P1       | 2026-05-26 | 14   | 2026-06-08 | blocked     |
 | [feat-056](media-generation/feat-056-ai-video-template-system.md)                         | AI Video Template System                                  | vlad  | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-057](media-generation/feat-057-automated-video-rendering-engine.md)                 | Automated Video Rendering Engine                          | vlad  | P1       | 2026-08-01 | 31   | 2026-08-31 | blocked     |
 | [feat-060](media-generation/feat-060-on-demand-personalized-video-generation.md)          | On-Demand Personalized Video Generation                   | vlad  | P1       | 2026-09-01 | 30   | 2026-09-30 | blocked     |
@@ -68,31 +78,50 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ### Platform
 
-| ID                                                                               | Feature                                            | Owner     | Priority | Start      | Days | Due        | Status      |
-| -------------------------------------------------------------------------------- | -------------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
-| [feat-026](platform/feat-026-graphql-pipeline.md)                                | GraphQL Pipeline (Contract-First Typed Client)     | tataihono | P0       | 2026-02-12 | 47   | 2026-03-30 | complete    |
-| [feat-032](platform/feat-032-tooling-developer-experience.md)                    | Tooling & Developer Experience                     | tataihono | P0       | 2026-02-12 | 47   | 2026-03-30 | complete    |
-| [feat-022](platform/feat-022-cms-foundation.md)                                  | CMS Foundation (Strapi v5 Content Modeling)        | tataihono | P0       | 2026-02-17 | 24   | 2026-03-12 | complete    |
-| [feat-027](platform/feat-027-infrastructure-evolution.md)                        | Infrastructure Evolution (AWS → Railway)           | tataihono | P0       | 2026-03-03 | 28   | 2026-03-30 | complete    |
-| [feat-028](platform/feat-028-content-sync-pipeline.md)                           | Content Sync Pipeline (Core Sync)                  | nisal     | P0       | 2026-03-20 | 11   | 2026-03-30 | complete    |
-| [feat-033](platform/feat-033-roadmap-dashboard-app.md)                           | Roadmap Dashboard App                              | tataihono | P0       | 2026-03-30 | 2    | 2026-03-31 | complete    |
-| [feat-004](platform/feat-004-web-app-onboarding.md)                              | Web App Onboarding                                 | urim      | P0       | 2026-04-01 | 14   | 2026-04-14 | not-started |
-| [feat-005](platform/feat-005-graphql-contract-stewardship.md)                    | GraphQL Contract Stewardship                       | tataihono | P0       | 2026-04-01 | 56   | 2026-05-26 | not-started |
-| [feat-006](platform/feat-006-code-review-unblocking.md)                          | Code Review and Unblocking                         | tataihono | P0       | 2026-04-01 | 56   | 2026-05-26 | not-started |
-| [feat-104](platform/feat-104-admin-core-consumer-migration-plan.md)              | Admin Core Consumer Migration Plan                 | tataihono | P0       | 2026-04-22 | 2    | 2026-04-23 | in-progress |
-| [feat-036](platform/feat-036-cms-local-postgres-io-concurrency-compatibility.md) | CMS local PostgreSQL I/O concurrency compatibility | tataihono | P1       | 2026-04-01 | 1    | 2026-04-01 | complete    |
-| [feat-019](platform/feat-019-scaffolding-support-urim.md)                        | Scaffolding Support for Urim                       | tataihono | P1       | 2026-04-07 | 21   | 2026-04-27 | blocked     |
-| [feat-077](platform/feat-077-roadmap-operations-and-owner-hygiene.md)            | Roadmap Operations and Owner Hygiene               | josh      | P1       | 2026-04-10 | 14   | 2026-04-23 | in-progress |
-| [feat-051](platform/feat-051-public-report-role.md)                              | Public Report Role                                 | vlad      | P1       | 2026-04-13 | 14   | 2026-04-26 | not-started |
-| [feat-102](platform/feat-102-dependabot-security-remediation.md)                 | Dependabot Security Remediation                    | tataihono | P1       | 2026-04-16 | 1    | 2026-04-16 | complete    |
-| [feat-106](platform/feat-106-manager-single-process-mock-cms-mode.md)            | Manager Single-Process Mock CMS Mode               | vlad      | P1       | 2026-04-22 | 5    | 2026-04-27 | in-progress |
-| [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                            | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |
-| [feat-089](platform/feat-089-agent-agnostic-repo-instructions.md)                | Agent-Agnostic Repo Instructions                   | josh      | P2       | 2026-04-13 | 1    | 2026-04-13 | complete    |
-| [feat-068](platform/feat-068-partner-publishing-and-user-accounts.md)            | Partner Publishing and User Accounts               | tataihono | P2       | 2026-10-01 | 61   | 2026-11-30 | blocked     |
-| [feat-066](platform/feat-066-llm-steering-system-rag-and-guardrails.md)          | LLM Steering System (RAG + Guardrails)             | tataihono | P2       | 2026-10-15 | 78   | 2026-12-31 | blocked     |
-| [feat-064](platform/feat-064-optimize-through-data-driven-insights.md)           | Optimize Through Data-Driven Insights              | tataihono | P2       | 2026-11-15 | 46   | 2026-12-30 | blocked     |
-| [feat-067](platform/feat-067-doctrinal-validation-engine.md)                     | Doctrinal Validation Engine                        | vlad      | P2       | 2026-12-01 | 31   | 2026-12-31 | blocked     |
-| [feat-070](platform/feat-070-public-ai-entry-point.md)                           | Public AI Entry Point                              | tataihono | P2       | 2026-12-01 | 31   | 2026-12-31 | blocked     |
+| ID                                                                               | Feature                                                 | Owner     | Priority | Start      | Days | Due        | Status      |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
+| [feat-026](platform/feat-026-graphql-pipeline.md)                                | GraphQL Pipeline (Contract-First Typed Client)          | tataihono | P0       | 2026-02-12 | 47   | 2026-03-30 | complete    |
+| [feat-032](platform/feat-032-tooling-developer-experience.md)                    | Tooling & Developer Experience                          | tataihono | P0       | 2026-02-12 | 47   | 2026-03-30 | complete    |
+| [feat-022](platform/feat-022-cms-foundation.md)                                  | CMS Foundation (Strapi v5 Content Modeling)             | tataihono | P0       | 2026-02-17 | 24   | 2026-03-12 | complete    |
+| [feat-027](platform/feat-027-infrastructure-evolution.md)                        | Infrastructure Evolution (AWS → Railway)                | tataihono | P0       | 2026-03-03 | 28   | 2026-03-30 | complete    |
+| [feat-028](platform/feat-028-content-sync-pipeline.md)                           | Content Sync Pipeline (Core Sync)                       | nisal     | P0       | 2026-03-20 | 11   | 2026-03-30 | complete    |
+| [feat-033](platform/feat-033-roadmap-dashboard-app.md)                           | Roadmap Dashboard App                                   | tataihono | P0       | 2026-03-30 | 2    | 2026-03-31 | complete    |
+| [feat-004](platform/feat-004-web-app-onboarding.md)                              | Web App Onboarding                                      | urim      | P0       | 2026-04-01 | 14   | 2026-04-14 | not-started |
+| [feat-005](platform/feat-005-graphql-contract-stewardship.md)                    | GraphQL Contract Stewardship                            | tataihono | P0       | 2026-04-01 | 56   | 2026-05-26 | not-started |
+| [feat-006](platform/feat-006-code-review-unblocking.md)                          | Code Review and Unblocking                              | tataihono | P0       | 2026-04-01 | 56   | 2026-05-26 | not-started |
+| [feat-086](platform/feat-086-admin-app-graphql-postgres-foundation.md)           | Admin App GraphQL + Postgres Foundation                 | tataihono | P0       | 2026-04-13 | 21   | 2026-05-03 | complete    |
+| [feat-092](platform/feat-092-admin-experience-embedding-workflow.md)             | Admin Experience Embedding Workflow and Safety Controls | tataihono | P0       | 2026-04-14 | 3    | 2026-04-16 | complete    |
+| [feat-093](platform/feat-093-admin-app-sync-hardening-and-rate-limit.md)         | Admin App Sync Hardening and GraphQL Rate Limit         | tataihono | P0       | 2026-04-14 | 3    | 2026-04-16 | complete    |
+| [feat-097](platform/feat-097-admin-v1-pr-hardening.md)                           | Admin App V1 PR Hardening and Operational Surfaces      | tataihono | P0       | 2026-04-14 | 1    | 2026-04-14 | complete    |
+| [feat-098](platform/feat-098-admin-cms-expansion-loop.md)                        | Admin CMS Expansion Loop                                | tataihono | P0       | 2026-04-14 | 14   | 2026-04-27 | complete    |
+| [feat-104](platform/feat-104-admin-railway-provisioning.md)                      | Provision apps/admin on Railway                         | nisal     | P0       | 2026-04-20 | 1    | 2026-04-20 | in-progress |
+| [feat-105](platform/feat-105-admin-sso-firebase-auth-wiring.md)                  | Wire SSO + Firebase fallback auth on @forge/admin       | tataihono | P0       | 2026-04-21 | 3    | 2026-04-23 | blocked     |
+| [feat-104](platform/feat-104-admin-core-consumer-migration-plan.md)              | Admin Core Consumer Migration Plan                      | tataihono | P0       | 2026-04-22 | 2    | 2026-04-23 | in-progress |
+| [feat-036](platform/feat-036-cms-local-postgres-io-concurrency-compatibility.md) | CMS local PostgreSQL I/O concurrency compatibility      | tataihono | P1       | 2026-04-01 | 1    | 2026-04-01 | complete    |
+| [feat-019](platform/feat-019-scaffolding-support-urim.md)                        | Scaffolding Support for Urim                            | tataihono | P1       | 2026-04-07 | 21   | 2026-04-27 | blocked     |
+| [feat-077](platform/feat-077-roadmap-operations-and-owner-hygiene.md)            | Roadmap Operations and Owner Hygiene                    | josh      | P1       | 2026-04-10 | 14   | 2026-04-23 | in-progress |
+| [feat-051](platform/feat-051-public-report-role.md)                              | Public Report Role                                      | vlad      | P1       | 2026-04-13 | 14   | 2026-04-26 | not-started |
+| [feat-090](platform/feat-090-admin-facebook-sso.md)                              | Add Facebook SSO to admin app                           | tataihono | P1       | 2026-04-14 | 1    | 2026-04-14 | complete    |
+| [feat-091](platform/feat-091-admin-dashboard-ui.md)                              | Build Forge admin dashboard UI                          | tataihono | P1       | 2026-04-14 | 2    | 2026-04-15 | complete    |
+| [feat-099](platform/feat-099-devcontainer-codex-install-and-vm-permissions.md)   | Devcontainer Codex Install And VM Permissions           | tataihono | P1       | 2026-04-15 | 1    | 2026-04-15 | complete    |
+| [feat-100](platform/feat-100-admin-video-and-media-editorial-workflows.md)       | Admin Video And Media Editorial Workflows               | tataihono | P1       | 2026-04-15 | 10   | 2026-04-24 | in-progress |
+| [feat-101](platform/feat-101-admin-experience-block-editor-parity.md)            | Admin Experience Block Editor Parity                    | tataihono | P1       | 2026-04-15 | 7    | 2026-04-21 | complete    |
+| [feat-102](platform/feat-102-dependabot-security-remediation.md)                 | Dependabot Security Remediation                         | tataihono | P1       | 2026-04-16 | 1    | 2026-04-16 | complete    |
+| [feat-103](platform/feat-103-admin-experience-editor-refinement.md)              | Admin Experience Editor Refinement                      | tataihono | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |
+| [feat-106](platform/feat-106-manager-single-process-mock-cms-mode.md)            | Manager Single-Process Mock CMS Mode                    | vlad      | P1       | 2026-04-22 | 5    | 2026-04-26 | complete    |
+| [feat-109](platform/feat-109-roadmap-timeline-planned-current-modes.md)          | Roadmap Timeline Planned/Current Modes                  | vlad      | P1       | 2026-04-23 | 1    | 2026-04-23 | complete    |
+| [feat-110](platform/feat-110-roadmap-owner-stack-timeline-compaction.md)         | Roadmap Owner Stack Timeline Compaction                 | vlad      | P1       | 2026-04-23 | 1    | 2026-04-23 | complete    |
+| [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                              | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
+| [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                     | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
+| [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                 | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |
+| [feat-089](platform/feat-089-agent-agnostic-repo-instructions.md)                | Agent-Agnostic Repo Instructions                        | josh      | P2       | 2026-04-13 | 1    | 2026-04-13 | complete    |
+| [feat-102](platform/feat-102-admin-login-copy-simplification.md)                 | Admin Login Copy Simplification                         | tataihono | P2       | 2026-04-16 | 1    | 2026-04-16 | complete    |
+| [feat-108](platform/feat-108-admin-experiences-dashboard-card-refinement.md)     | Admin Experiences Dashboard Card Refinement             | tataihono | P2       | 2026-04-23 | 1    | 2026-04-23 | complete    |
+| [feat-068](platform/feat-068-partner-publishing-and-user-accounts.md)            | Partner Publishing and User Accounts                    | tataihono | P2       | 2026-10-01 | 61   | 2026-11-30 | blocked     |
+| [feat-066](platform/feat-066-llm-steering-system-rag-and-guardrails.md)          | LLM Steering System (RAG + Guardrails)                  | tataihono | P2       | 2026-10-15 | 78   | 2026-12-31 | blocked     |
+| [feat-064](platform/feat-064-optimize-through-data-driven-insights.md)           | Optimize Through Data-Driven Insights                   | tataihono | P2       | 2026-11-15 | 46   | 2026-12-30 | blocked     |
+| [feat-067](platform/feat-067-doctrinal-validation-engine.md)                     | Doctrinal Validation Engine                             | vlad      | P2       | 2026-12-01 | 31   | 2026-12-31 | blocked     |
+| [feat-070](platform/feat-070-public-ai-entry-point.md)                           | Public AI Entry Point                                   | tataihono | P2       | 2026-12-01 | 31   | 2026-12-31 | blocked     |
 
 ### Topic Experiences
 
@@ -112,15 +141,17 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-047](topic-experiences/feat-047-watch-template-settings-and-single-video-fallback.md) | Watch Template Settings and Single Video Fallback Hardening | urim      | P1       | 2026-04-04 | 3    | 2026-04-06 | complete    |
 | [feat-048](topic-experiences/feat-048-cms-text-block-publish-normalization.md)              | Normalize CMS Text Blocks During Experience Publish         | urim      | P1       | 2026-04-04 | 1    | 2026-04-04 | complete    |
 | [feat-049](topic-experiences/feat-049-single-video-template-related-media-collection.md)    | Single-Video Template Related Media Collection              | urim      | P1       | 2026-04-08 | 2    | 2026-04-09 | complete    |
-| [feat-072](topic-experiences/feat-072-tv-app-spike.md)                                      | TV App — Expo TV Toolchain Spike                            | urim      | P1       | 2026-04-10 | 2    | 2026-04-11 | not-started |
-| [feat-073](topic-experiences/feat-073-tv-app-scaffolding.md)                                | TV App — Scaffolding + GraphQL Wiring                       | urim      | P1       | 2026-04-12 | 3    | 2026-04-14 | blocked     |
+| [feat-072](topic-experiences/feat-072-tv-app-spike.md)                                      | TV App — Expo TV Toolchain Spike                            | urim      | P1       | 2026-04-10 | 2    | 2026-04-11 | complete    |
+| [feat-073](topic-experiences/feat-073-tv-app-scaffolding.md)                                | TV App — Scaffolding + GraphQL Wiring                       | urim      | P1       | 2026-04-12 | 3    | 2026-04-14 | complete    |
 | [feat-015](topic-experiences/feat-015-bulk-experience-write-api.md)                         | Bulk Experience Write API                                   | nisal     | P1       | 2026-04-14 | 21   | 2026-05-04 | blocked     |
-| [feat-074](topic-experiences/feat-074-tv-app-home-screen.md)                                | TV App — Home Screen (Hero + Experiences Rail)              | urim      | P1       | 2026-04-15 | 5    | 2026-04-19 | blocked     |
-| [feat-075](topic-experiences/feat-075-tv-app-experience-screen.md)                          | TV App — Experience Detail Screen (SDUI Renderers)          | urim      | P1       | 2026-04-15 | 7    | 2026-04-21 | blocked     |
+| [feat-074](topic-experiences/feat-074-tv-app-home-screen.md)                                | TV App — Home Screen (Hero + Experiences Rail)              | urim      | P1       | 2026-04-15 | 5    | 2026-04-19 | complete    |
+| [feat-075](topic-experiences/feat-075-tv-app-experience-screen.md)                          | TV App — Experience Detail Screen (SDUI Renderers)          | urim      | P1       | 2026-04-15 | 7    | 2026-04-21 | complete    |
 | [feat-017](topic-experiences/feat-017-topic-browsing-web.md)                                | Topic Browsing — Web                                        | urim      | P1       | 2026-04-21 | 28   | 2026-05-18 | blocked     |
-| [feat-076](topic-experiences/feat-076-tv-app-video-playback.md)                             | TV App — Video Playback + Polish                            | urim      | P1       | 2026-04-22 | 7    | 2026-04-28 | blocked     |
+| [feat-076](topic-experiences/feat-076-tv-app-video-playback.md)                             | TV App — Video Playback + Polish                            | urim      | P1       | 2026-04-22 | 7    | 2026-04-28 | in-progress |
 | [feat-016](topic-experiences/feat-016-topic-experience-graphql.md)                          | Topic / Experience GraphQL Wiring                           | nisal     | P1       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
 | [feat-018](topic-experiences/feat-018-topic-browsing-mobile.md)                             | Topic Browsing — Mobile                                     | urim      | P1       | 2026-04-28 | 28   | 2026-05-25 | blocked     |
+| [feat-036](topic-experiences/feat-036-semantic-visualization-workbench.md)                  | Semantic Visualization Workbench                            | ekkasit   | P1       | 2026-05-19 | 21   | 2026-06-08 | blocked     |
+| [feat-039](topic-experiences/feat-039-topic-discovery-programming-engine.md)                | Topic Programming Engine                                    | ekkasit   | P1       | 2026-06-02 | 28   | 2026-06-29 | blocked     |
 | [feat-061](topic-experiences/feat-061-watch-platform-upgrade-bible-verse-visuals.md)        | Watch Platform Upgrade (Bible Verse Visuals)                | tataihono | P1       | 2026-07-15 | 48   | 2026-08-31 | blocked     |
 | [feat-059](topic-experiences/feat-059-ai-assisted-topic-page-generation-and-flows.md)       | AI-Assisted Topic Page Generation and Flows                 | tataihono | P1       | 2026-08-01 | 45   | 2026-09-14 | blocked     |
 | [feat-020](topic-experiences/feat-020-ai-topic-content-generation.md)                       | AI Topic Content Generation Service                         | vlad      | P2       | 2026-04-28 | 28   | 2026-05-25 | blocked     |

--- a/docs/roadmap/platform/feat-109-roadmap-timeline-planned-current-modes.md
+++ b/docs/roadmap/platform/feat-109-roadmap-timeline-planned-current-modes.md
@@ -1,0 +1,63 @@
+---
+id: "feat-109"
+title: "Roadmap Timeline Planned/Current Modes"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-04-23"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "roadmap"
+  - "frontend"
+  - "dashboard"
+---
+
+## Problem
+
+The roadmap dashboard currently shows only the live ticket timeline derived from `docs/roadmap/`. That is useful for current execution, but it does not give stakeholders a clean way to view the higher-level migration narrative for the next few months. We need a second timeline mode that can present a planned migration arc without replacing the current source-of-truth ticket view.
+
+## Entry Points - Read These First
+
+1. `apps/roadmap/app/(dashboard)/roadmap/page.tsx` - dashboard route that assembles the roadmap timeline inputs.
+2. `apps/roadmap/components/RoadmapTimeline.tsx` - existing client timeline for current roadmap tickets.
+3. `apps/roadmap/lib/features.ts` - current roadmap ticket loading and timeline metadata.
+4. `apps/roadmap/package.json` - roadmap app validation commands.
+5. `docs/roadmap/README.md` - derived roadmap index that should be regenerated after adding this ticket.
+
+## Grep These
+
+- `RoadmapTimeline` in `apps/roadmap/`
+- `getAllFeatures` in `apps/roadmap/`
+- `generate:readme` in `apps/roadmap/package.json`
+
+## What To Build
+
+1. Add a timeline mode switch in the roadmap dashboard with `planned` and `current` options.
+2. Keep `current` wired to the existing live feature timeline based on `docs/roadmap/`.
+3. Add a separate planned timeline surface that shows the requested Forge migration narrative:
+   - roadmap goal and cadence
+   - external deadline milestone
+   - parallel tracks
+   - phased build/release sequence
+   - demo day milestone
+   - ongoing mobile/TV and agentic tracks
+   - end-state success criteria and framing text
+4. Keep the existing ticket-derived data model intact. The planned mode should be additive, not a replacement for live roadmap data.
+5. Validate the roadmap app locally after the UI change.
+
+## Constraints
+
+- Do not change the filesystem-backed roadmap data model for current tickets.
+- Do not remove the existing lane/person grouping controls for the current timeline.
+- Keep planned mode content static and explicit rather than trying to infer it from current feature files.
+- Keep the implementation inside `apps/roadmap/`; no CMS or shared package changes.
+
+## Verification
+
+- `pnpm --filter roadmap lint`
+- `pnpm --filter roadmap build`
+- `pnpm --filter roadmap generate:readme`
+- `pnpm --filter roadmap dev`
+- Open `http://localhost:3100/roadmap` and verify the `planned` and `current` timeline modes both render.

--- a/docs/roadmap/platform/feat-110-roadmap-owner-stack-timeline-compaction.md
+++ b/docs/roadmap/platform/feat-110-roadmap-owner-stack-timeline-compaction.md
@@ -1,0 +1,55 @@
+---
+id: "feat-110"
+title: "Roadmap Owner Stack Timeline Compaction"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-04-23"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "roadmap"
+  - "frontend"
+  - "timeline"
+---
+
+## Problem
+
+The roadmap timeline currently renders each feature as its own full-height row. When one person is running several parallel tasks at the same time, the timeline expands vertically with repeated cards, repeated avatars, and repeated grid rows. That burns space and makes dense areas harder to scan.
+
+## Entry Points - Read These First
+
+1. `apps/roadmap/components/RoadmapTimeline.tsx` - current timeline row layout and feature block rendering.
+2. `apps/roadmap/app/(dashboard)/roadmap/page.tsx` - dashboard route that mounts the current timeline view.
+3. `apps/roadmap/components/RoadmapTimelinePanel.tsx` - planned/current wrapper introduced in the previous roadmap update.
+4. `apps/roadmap/package.json` - roadmap app validation commands.
+
+## Grep These
+
+- `RoadmapTimeline` in `apps/roadmap/`
+- `FeatureBlock` in `apps/roadmap/components/RoadmapTimeline.tsx`
+- `groupBy === "lane"` in `apps/roadmap/components/RoadmapTimeline.tsx`
+
+## What To Build
+
+1. In the current roadmap timeline, collapse same-owner work inside a lane into a single owner row instead of one row per feature.
+2. When the same owner has overlapping date ranges, render them as a compact visual stack inside that owner row rather than separate full-height rows.
+3. Keep non-overlapping work for the same owner on the same owner row when possible.
+4. Preserve ticket links, preview behavior, and lane/person grouping behavior.
+5. Keep the timeline readable on both the lane and person grouping modes.
+
+## Constraints
+
+- Do not change the planned roadmap mode.
+- Do not remove hover/focus preview behavior from feature cards.
+- Do not change the source-of-truth feature data model in `apps/roadmap/lib/features.ts`.
+- Keep the compaction logic local to the roadmap viewer.
+
+## Verification
+
+- `pnpm --filter roadmap lint`
+- `pnpm --filter roadmap build`
+- `pnpm --filter roadmap generate:readme`
+- `curl -I http://localhost:3100/roadmap`
+- Open `http://localhost:3100/roadmap` and confirm parallel tasks from one owner render as one compact stack instead of separate full-height rows.

--- a/docs/solutions/platform/roadmap-planned-timeline-and-tasks-view-split.md
+++ b/docs/solutions/platform/roadmap-planned-timeline-and-tasks-view-split.md
@@ -1,0 +1,210 @@
+---
+title: "Roadmap planned timeline and tasks view split"
+category: platform
+date: 2026-04-29
+tags:
+  - roadmap
+  - timeline
+  - dashboard
+  - information-architecture
+  - nextjs
+  - planned-data
+  - tasks-view
+  - hydration
+---
+
+# Roadmap planned timeline and tasks view split
+
+## Problem
+
+The roadmap viewer had drifted into an awkward hybrid. It was trying to serve two different jobs in one surface:
+
+- a stakeholder-friendly strategic roadmap
+- a contributor-facing live execution tracker
+
+That made the page hard to read, hard to demo, and hard to maintain. The live ticket timeline was useful, but it was not a good vehicle for showing a clean 14-week migration narrative with milestones, parallel tracks, and rollout sequencing.
+
+## Symptoms
+
+- The roadmap page mixed planned narrative and source-of-truth task tracking.
+- Stakeholders could not view a clean migration arc without also seeing dense task-level controls and ticket artifacts.
+- Same-owner parallel work made the live timeline visually noisy.
+- Planned bars needed repeated manual fixes for text overflow, label placement, and lane spacing.
+- Milestone labels and date rows fought each other for space.
+- The roadmap diagram exposed a visible horizontal scrollbar and had repeated alignment issues with the page shell.
+- The `Today` marker produced a hydration mismatch because its position differed between SSR and the client.
+
+## What Didn't Work
+
+### Keeping planned and live views in one mode switch
+
+The original direction started as a `planned | current` toggle inside the same roadmap page. That improved things at first, but the two views still wanted different layout, legend, navigation, and interaction models.
+
+### Treating planned content like live task data
+
+The live timeline is driven by filesystem-backed roadmap tickets. The planned roadmap needed stable editorial content: fixed phases, milestone labels, lane bars, summaries, and anchor-linked detail sections. Trying to make one model drive both surfaces created unnecessary complexity.
+
+### Layering visual tweaks without a dedicated planned model
+
+Once the roadmap started accumulating milestone hairlines, breakout layout, stacked research/mobile sublanes, hover states, and beta rollout labels, it became clear that the planned view needed its own small data model and renderer.
+
+## Solution
+
+### 1. Split strategy from execution
+
+The final pattern uses separate routes:
+
+- `/roadmap` for the strategic planned roadmap
+- `/contributions` for the live task breakdown
+
+This keeps the roadmap polished and narrative-driven while preserving the live ticket timeline as the operational source of truth.
+
+### 2. Keep live task data intact
+
+The file-backed roadmap feature model stays unchanged for the tasks page. `ContributionsTimelinePanel.tsx` keeps the existing live timeline and grouping controls like:
+
+- `By Lane`
+- `By Person`
+
+This avoided turning planned roadmap work into a mutation of the task system.
+
+### 3. Introduce a dedicated planned roadmap model
+
+The planned view is driven by `apps/roadmap/lib/plannedRoadmap.ts`, which acts like a small timeline DSL with separate concepts for:
+
+- `PLANNED_PHASES`
+- `PLANNED_TRACK_BARS`
+- `PLANNED_MILESTONES`
+- `PLANNED_TIMELINE_ROWS`
+
+That distinction matters:
+
+- phases represent major delivery blocks with detail cards
+- track bars represent parallel or follow-on work on the same lane
+- milestones represent overlay markers, not rows
+
+### 4. Use a dedicated planned timeline renderer
+
+`apps/roadmap/components/PlannedRoadmapTimeline.tsx` renders the roadmap in three layers:
+
+- week/date header
+- timeline body with bars and milestone hairlines
+- detail cards below
+
+Each timeline bar links directly to a detail section using stable anchor ids:
+
+- `planned-phase-*`
+- `planned-track-*`
+
+This made the diagram interactive without introducing extra routing complexity.
+
+### 5. Reuse the public shell for roadmap-facing pages
+
+`/roadmap` and `/contributions` both use the shared top navigation shell through `DashboardShell.tsx`, matching the visual language of `Home`, `About`, and `Experiments`.
+
+The diagram itself is allowed to break out wider than the content column, but:
+
+- hero content stays aligned with the shared shell
+- supporting cards below the diagram stay within the normal content width
+
+### 6. Fix roadmap-specific UI problems in the planned renderer
+
+The dedicated planned renderer made it straightforward to solve repeated UI issues:
+
+- current timeline compaction for same-owner parallel work
+- milestone labels above the date row with connected hairlines
+- hidden horizontal scrollbar while preserving scroll behavior
+- cleaner timeline hero and legend placement
+- stronger hover affordances on bars
+- repeated two-week research/mobile cadence blocks
+- beta labeling for internal mobile/TV releases
+- taller stacked sub-lane rows so badge, title, and summary fit
+- client-safe `Today` marker rendering to avoid hydration mismatch
+
+## Files
+
+Primary implementation files:
+
+- `apps/roadmap/app/(dashboard)/roadmap/page.tsx`
+- `apps/roadmap/app/(dashboard)/contributions/page.tsx`
+- `apps/roadmap/components/PlannedRoadmapTimeline.tsx`
+- `apps/roadmap/components/ContributionsTimelinePanel.tsx`
+- `apps/roadmap/components/RoadmapTimeline.tsx`
+- `apps/roadmap/components/DashboardShell.tsx`
+- `apps/roadmap/lib/plannedRoadmap.ts`
+
+Tracking references:
+
+- `docs/roadmap/platform/feat-109-roadmap-timeline-planned-current-modes.md`
+- `docs/roadmap/platform/feat-110-roadmap-owner-stack-timeline-compaction.md`
+
+## Why This Works
+
+- It separates stakeholder storytelling from contributor execution.
+- It preserves the live task model as the source of truth.
+- It gives the planned roadmap a stable, explicit content model.
+- It keeps the visual system maintainable by centralizing timeline geometry and tone rules in one renderer.
+- It makes browser-level UI iteration easier because all roadmap-specific behavior lives in a focused set of files.
+
+## Prevention
+
+### Keep planned and live data separate
+
+- Treat planned roadmap content as editorial timeline data.
+- Treat tasks/contributions as operational live data.
+- Do not create hybrid components that accept both shapes through optional branches.
+
+### Keep timeline items deterministic
+
+- Every phase, track bar, milestone, and detail section should have a stable id.
+- Click-to-scroll, hover detail, and anchors should all reference explicit ids rather than derived display strings.
+
+### Keep time-based UI client-safe
+
+- Normalize or defer time-sensitive decorations like `Today` until after mount when necessary.
+- Avoid server/client drift for timeline marker positioning.
+
+### Centralize layout geometry
+
+Keep constants such as:
+
+- week width
+- label band height
+- track label width
+- stacked row height
+- bar gap
+
+in one place so repeated spacing adjustments do not turn into hidden magic values.
+
+### Prefer narrow browser-proof validation
+
+For roadmap UI work, compile success is not enough. Validate in the browser that:
+
+- the page loads at the intended route
+- there are no hydration warnings
+- hover states feel correct
+- milestone labels sit in the correct band
+- text is not cropped inside bars
+- breakout diagrams still align with contained content
+- click-to-scroll anchors land on the correct detail card
+
+## Validation
+
+This work was repeatedly validated with:
+
+- `pnpm --filter roadmap lint`
+- `pnpm --filter roadmap build`
+- `pnpm --filter roadmap generate:readme`
+- `git diff --check`
+- `curl -I http://localhost:3100/roadmap`
+- `curl -I http://localhost:3100/contributions`
+- browser verification against the live local pages
+
+## Related References
+
+- PR `#856` - `feat(roadmap): add planned roadmap and tasks views`
+- `docs/roadmap/platform/feat-109-roadmap-timeline-planned-current-modes.md`
+- `docs/roadmap/platform/feat-110-roadmap-owner-stack-timeline-compaction.md`
+- `docs/roadmap/platform/feat-033-roadmap-dashboard-app.md`
+- `docs/brainstorms/2026-03-31-roadmap-landing-page-requirements.md`
+- `docs/solutions/ui-bugs/react-duplicate-sibling-keys-append-on-rerender-20260421.md`


### PR DESCRIPTION
## Summary
- split roadmap and tasks into separate pages with shared header navigation
- add a planned roadmap timeline with phased delivery, research/mobile tracks, milestones, and detail views
- compact and polish the live tasks timeline plus roadmap UI interactions and styling

## Validation
- pnpm --filter roadmap lint
- pnpm --filter roadmap build
- pnpm --filter roadmap generate:readme
- git diff --check
- curl -I http://localhost:3100/roadmap
- curl -I http://localhost:3100/contributions