### PR TITLE
chore(manager): retrigger Railway deployment

### DIFF
--- a/apps/manager/src/instrumentation.ts
+++ b/apps/manager/src/instrumentation.ts
@@ -1,6 +1,6 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    // Warm caches before first request arrives.
+    // Warm read-heavy caches before first request arrives.
     // Railway rolling deploys give us a few seconds before traffic routes here.
     const { videoCache } = await import("@/app/api/videos/cache")
     const { languageCache } = await import("@/app/api/languages/cache")


### PR DESCRIPTION
## Summary
- touch Manager instrumentation with a comment-only clarification
- create a fresh Manager-path change after PR #827 to retrigger Railway deployment

## Validation
- pnpm --filter @forge/manager lint
- git diff --check