### PR TITLE
fix(admin): wrap demo-keyword-search useSearchParams in Suspense

### DIFF
--- a/apps/admin/src/app/watch/demo-keyword-search/page.tsx
+++ b/apps/admin/src/app/watch/demo-keyword-search/page.tsx
@@ -13,12 +13,24 @@
  * See docs/plans/2026-04-29-005-feat-admin-keyword-search-demo-route-plan.md
  */
 
+import { Suspense } from "react"
 import { DemoSearchClient } from "./demo-search-client"
 
 export const metadata = {
   title: "Demo — Keyword-First Search Canary",
 }
 
+// `DemoSearchClient` calls `useSearchParams()`; Next.js 16 production
+// builds require any subtree consuming search params to live inside a
+// Suspense boundary. Without it, the page is force-rendered statically
+// and the search-params reactivity never fires on the client — the
+// form submits but the fetch effect doesn't re-run on URL change.
+// Hidden in `next dev` (different rendering path); only manifests in
+// the deployed build.
 export default function DemoKeywordSearchPage() {
-  return <DemoSearchClient />
+  return (
+    <Suspense fallback={null}>
+      <DemoSearchClient />
+    </Suspense>
+  )
 }


### PR DESCRIPTION
## Summary

Production-only fix for `/watch/demo-keyword-search`. The demo page's submits were updating the URL but the panes never repainted on prod (works fine in \`next dev\`).

## Root cause

\`DemoSearchClient\` calls \`useSearchParams()\`. Next.js 16 production builds require any subtree consuming search params to live inside a \`<Suspense>\` boundary — otherwise the page is force-rendered statically and the search-params reactivity never fires on the client. The fetch effect is keyed on \`urlQ\` / \`urlLocale\` / \`urlLimit\` from \`useSearchParams\`; without Suspense those never update post-hydration in prod, so submits never trigger a fetch.

## Fix

Wrap \`<DemoSearchClient />\` in \`<Suspense fallback={null}>\` in \`apps/admin/src/app/watch/demo-keyword-search/page.tsx\`.

## Verified

- Prod GraphQL surface confirmed working independently: \`POST https://admin.jesusfilm.org/api/graphql\` with \`mode=hybrid\` returned 10 real results, \`searchMode: HYBRID\`. The query side is healthy; only the client-side reactivity was broken.
- Typecheck + lint clean.

## Post-Deploy Monitoring & Validation

- **What to monitor**: Visit https://admin.jesusfilm.org/watch/demo-keyword-search after deploy. Submit \`q=jesus\` \`locale=en\`. Both panes should populate with results.
- **Expected**: Each pane shows \`searchMode: HYBRID\` and 10 real video titles. Diff panel shows top-K overlap.
- **Failure signal**: Panes stay idle after submit → revert.
- **Window/Owner**: 30 minutes / @Kneesal.
- **Note**: The \`debug\` payload (retriever badges, fused score) will continue to be withheld until \`SEARCH_DEBUG_ALLOWED_ORIGINS\` is set on the \`forge-admin\` Railway service. That's orthogonal to this fix.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0