### PR TITLE
fix(admin): force light color-scheme on demo-keyword-search inputs

### DIFF
--- a/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
+++ b/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
@@ -659,6 +659,9 @@ const inputStyle: React.CSSProperties = {
   fontSize: 14,
   width: "100%",
   boxSizing: "border-box",
+  color: "#111",
+  background: "#fff",
+  colorScheme: "light",
 }
 
 const buttonStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

Form inputs in \`/watch/demo-keyword-search\` were inheriting the user-agent dark-mode default in browsers with \`prefers-color-scheme: dark\`, producing white-on-white (or near-invisible) text in the form fields. This is a tiny one-file fix.

## Fix

Pin \`color\`, \`background\`, and \`colorScheme\` on \`inputStyle\` in \`apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx\` so the demo renders the same regardless of browser dark-mode preference.

\`\`\`ts
const inputStyle: React.CSSProperties = {
  ...
  color: \"#111\",
  background: \"#fff\",
  colorScheme: \"light\",
}
\`\`\`

## Sibling fix

PR #862 (already merged) wrapped the same client component in \`<Suspense>\` so submits actually trigger the fetch in the deployed build. This input-color fix was authored alongside that one but missed the merge window.

## Post-Deploy Monitoring & Validation

- **Validation**: Visit https://admin.jesusfilm.org/watch/demo-keyword-search in a browser with dark-mode preference set. Form inputs should render dark text on white background.
- **Failure signal**: If inputs still show invisible text, check that the browser cached the old bundle (force-reload).
- **Window/Owner**: 5 minutes / @Kneesal.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0