### PR TITLE
feat(admin): Algolia parity column on /watch/demo-keyword-search

### DIFF
--- a/apps/admin/src/app/watch/demo-keyword-search/algolia-action.test.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/algolia-action.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Mock the env singleton — vitest hoists vi.mock before imports, so the
+// action under test reads the mocked values when first imported below.
+vi.mock("@/config/env", () => ({
+  env: {
+    ALGOLIA_APP_ID: "TESTAPP",
+    ALGOLIA_SEARCH_API_KEY: "test-key",
+    ALGOLIA_INDEX: "video-variants-test",
+  },
+}))
+
+import { env } from "@/config/env"
+import { searchAlgolia } from "./algolia-action"
+
+const ENV = env as {
+  ALGOLIA_APP_ID: string | undefined
+  ALGOLIA_SEARCH_API_KEY: string | undefined
+  ALGOLIA_INDEX: string | undefined
+}
+
+describe("searchAlgolia", () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+    ENV.ALGOLIA_APP_ID = "TESTAPP"
+    ENV.ALGOLIA_SEARCH_API_KEY = "test-key"
+    ENV.ALGOLIA_INDEX = "video-variants-test"
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    })
+  }
+
+  it("returns shaped hits for a successful Algolia response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        hits: [
+          {
+            videoId: "BibleProject",
+            titles: ["The BibleProject Collection", "Other"],
+            description: ["A short film collection."],
+          },
+          {
+            videoId: "JesusFilm",
+            titles: ["JESUS Film"],
+          },
+        ],
+      }),
+    )
+
+    const result = await searchAlgolia({
+      q: "the bible project",
+      locale: "en",
+      limit: 5,
+    })
+
+    expect(result).toEqual({
+      hits: [
+        {
+          videoId: "BibleProject",
+          title: "The BibleProject Collection",
+          description: "A short film collection.",
+        },
+        {
+          videoId: "JesusFilm",
+          title: "JESUS Film",
+          description: null,
+        },
+      ],
+    })
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe(
+      "https://TESTAPP-dsn.algolia.net/1/indexes/video-variants-test/query",
+    )
+    expect((init as RequestInit).method).toBe("POST")
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers["X-Algolia-API-Key"]).toBe("test-key")
+    expect(headers["X-Algolia-Application-Id"]).toBe("TESTAPP")
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      query: "the bible project",
+      hitsPerPage: 5,
+    })
+  })
+
+  it("throws algolia_not_configured when any env var is missing", async () => {
+    ENV.ALGOLIA_INDEX = undefined
+    await expect(
+      searchAlgolia({ q: "x", locale: "en", limit: 5 }),
+    ).rejects.toThrow("algolia_not_configured")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("throws algolia_upstream_error on non-2xx response", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }))
+    await expect(
+      searchAlgolia({ q: "x", locale: "en", limit: 5 }),
+    ).rejects.toThrow("algolia_upstream_error")
+  })
+
+  it("throws algolia_upstream_error on fetch network failure", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("connection refused"))
+    await expect(
+      searchAlgolia({ q: "x", locale: "en", limit: 5 }),
+    ).rejects.toThrow("algolia_upstream_error")
+  })
+
+  it("throws algolia_upstream_error on invalid JSON", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("<not json>", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+    await expect(
+      searchAlgolia({ q: "x", locale: "en", limit: 5 }),
+    ).rejects.toThrow("algolia_upstream_error")
+  })
+
+  it("clamps limit to MAX_LIMIT (50)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ hits: [] }))
+    await searchAlgolia({ q: "x", locale: "en", limit: 999 })
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]![1] as RequestInit).body),
+    )
+    expect(body.hitsPerPage).toBe(50)
+  })
+
+  it("clamps non-positive / non-numeric limit to a sane minimum", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ hits: [] }))
+    await searchAlgolia({ q: "x", locale: "en", limit: 0 })
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]![1] as RequestInit).body),
+    )
+    expect(body.hitsPerPage).toBeGreaterThanOrEqual(1)
+  })
+
+  it("tolerates hits without titles or description fields", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        hits: [
+          { videoId: "OnlyId" },
+          { videoId: "EmptyArrays", titles: [], description: [] },
+        ],
+      }),
+    )
+    const result = await searchAlgolia({ q: "x", locale: "en", limit: 5 })
+    expect(result.hits).toEqual([
+      { videoId: "OnlyId", title: null, description: null },
+      { videoId: "EmptyArrays", title: null, description: null },
+    ])
+  })
+
+  it("drops hits without a string videoId", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        hits: [
+          { videoId: 123, titles: ["bad"] },
+          { videoId: "Good", titles: ["yes"] },
+        ],
+      }),
+    )
+    const result = await searchAlgolia({ q: "x", locale: "en", limit: 5 })
+    expect(result.hits).toEqual([
+      { videoId: "Good", title: "yes", description: null },
+    ])
+  })
+})

--- a/apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts
@@ -1,0 +1,138 @@
+"use server"
+
+/**
+ * Throwaway operator harness — server action backing the third
+ * column of /watch/demo-keyword-search.
+ *
+ * Proxies a query to the watch project's Algolia index using
+ * `ALGOLIA_SEARCH_API_KEY` (the watch project's `ALGOLIA_SERVER_API_KEY`
+ * value, which is unrestricted; the public `NEXT_PUBLIC_ALGOLIA_API_KEY`
+ * is referer-locked to the watch domain and cannot be used from
+ * admin.jesusfilm.org).
+ *
+ * Lifetime: this exists only while we refine admin's hybrid +
+ * keyword-first ranking. At R8 cutover, delete this file, drop the
+ * Algolia env vars from Doppler / Railway, and remove the third pane
+ * from `demo-search-client.tsx`. No service layer, no GraphQL surface,
+ * no REST endpoint — that is the point.
+ *
+ * `locale` is accepted for log context / forward compatibility but
+ * NOT forwarded to Algolia in v1 — the index returns multi-locale
+ * hits and the demo renders `titles[0]` defensively.
+ */
+
+import { env } from "@/config/env"
+
+const ALGOLIA_TIMEOUT_MS = 5000
+const MAX_LIMIT = 50
+
+export type AlgoliaHit = {
+  videoId: string
+  title: string | null
+  description: string | null
+}
+
+export type AlgoliaSearchResult = {
+  hits: AlgoliaHit[]
+}
+
+type AlgoliaRawHit = {
+  videoId?: unknown
+  titles?: unknown
+  description?: unknown
+}
+
+type AlgoliaRawResponse = {
+  hits?: AlgoliaRawHit[]
+}
+
+export async function searchAlgolia(args: {
+  q: string
+  locale: string
+  limit: number
+}): Promise<AlgoliaSearchResult> {
+  const appId = env.ALGOLIA_APP_ID
+  const apiKey = env.ALGOLIA_SEARCH_API_KEY
+  const index = env.ALGOLIA_INDEX
+  if (!appId || !apiKey || !index) {
+    throw new Error("algolia_not_configured")
+  }
+
+  const hitsPerPage = Math.max(
+    1,
+    Math.min(MAX_LIMIT, Math.floor(Number(args.limit) || 10)),
+  )
+
+  const url = `https://${appId}-dsn.algolia.net/1/indexes/${encodeURIComponent(index)}/query`
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "X-Algolia-API-Key": apiKey,
+        "X-Algolia-Application-Id": appId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query: args.q, hitsPerPage }),
+      signal: AbortSignal.timeout(ALGOLIA_TIMEOUT_MS),
+      cache: "no-store",
+    })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(
+      `[demo-search][algolia] fetch failed msg=${sanitize(msg)} q=${sanitize(args.q)}`,
+    )
+    throw new Error("algolia_upstream_error")
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    console.error(
+      `[demo-search][algolia] upstream error status=${response.status} body=${sanitize(body)} q=${sanitize(args.q)}`,
+    )
+    throw new Error("algolia_upstream_error")
+  }
+
+  let payload: AlgoliaRawResponse
+  try {
+    payload = (await response.json()) as AlgoliaRawResponse
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(
+      `[demo-search][algolia] invalid JSON msg=${sanitize(msg)} q=${sanitize(args.q)}`,
+    )
+    throw new Error("algolia_upstream_error")
+  }
+
+  const rawHits = Array.isArray(payload.hits) ? payload.hits : []
+  const hits: AlgoliaHit[] = []
+  for (const raw of rawHits) {
+    const videoId = typeof raw.videoId === "string" ? raw.videoId : null
+    if (!videoId) continue
+    hits.push({
+      videoId,
+      title: pickFirstString(raw.titles),
+      description: pickFirstString(raw.description),
+    })
+  }
+
+  return { hits }
+}
+
+function pickFirstString(value: unknown): string | null {
+  if (typeof value === "string") return value
+  if (Array.isArray(value)) {
+    for (const v of value) {
+      if (typeof v === "string" && v.length > 0) return v
+    }
+  }
+  return null
+}
+
+/** Strip CR/LF/TAB from log inputs and clamp length so a malicious or
+ * just-large value can't pollute structured-log lines. */
+function sanitize(input: string): string {
+  const stripped = input.replace(/[\r\n\t]/g, " ")
+  return stripped.length > 200 ? `${stripped.slice(0, 200)}…` : stripped
+}

--- a/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
+++ b/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
@@ -9,7 +9,13 @@ import {
   type SearchResponse,
   type SearchResult,
 } from "./search-operation"
-import { computeTopKDiff } from "./diff"
+import {
+  buildProvenanceMap,
+  computeThreeWayDiff,
+  computeTopKDiff,
+  type Source,
+} from "./diff"
+import { searchAlgolia, type AlgoliaHit } from "./algolia-action"
 
 type ModeKey = "hybrid" | "keyword-first"
 
@@ -17,6 +23,13 @@ type PaneState =
   | { status: "idle" }
   | { status: "loading" }
   | { status: "ok"; response: SearchResponse }
+  | { status: "error"; messages: string[] }
+
+type AlgoliaPaneState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ok"; hits: AlgoliaHit[] }
+  | { status: "not_configured" }
   | { status: "error"; messages: string[] }
 
 const DEFAULTS = {
@@ -53,6 +66,9 @@ export function DemoSearchClient() {
 
   const [hybridPane, setHybridPane] = useState<PaneState>({ status: "idle" })
   const [keywordPane, setKeywordPane] = useState<PaneState>({ status: "idle" })
+  const [algoliaPane, setAlgoliaPane] = useState<AlgoliaPaneState>({
+    status: "idle",
+  })
 
   // Fire on URL change (effective query). Empty q skips.
   useEffect(() => {
@@ -62,6 +78,8 @@ export function DemoSearchClient() {
       setHybridPane({ status: "idle" })
 
       setKeywordPane({ status: "idle" })
+
+      setAlgoliaPane({ status: "idle" })
       return
     }
 
@@ -70,6 +88,8 @@ export function DemoSearchClient() {
     setHybridPane({ status: "loading" })
 
     setKeywordPane({ status: "loading" })
+
+    setAlgoliaPane({ status: "loading" })
 
     void Promise.allSettled([
       runSearch({
@@ -84,10 +104,20 @@ export function DemoSearchClient() {
         limit: urlLimit,
         mode: "keyword-first",
       }),
+      searchAlgolia({ q: trimmed, locale: urlLocale, limit: urlLimit }),
     ]).then((settled) => {
       if (cancelled) return
-      setHybridPane(toPaneState(settled[0]))
-      setKeywordPane(toPaneState(settled[1]))
+      setHybridPane(
+        toPaneState(settled[0] as PromiseSettledResult<SearchResponse>),
+      )
+      setKeywordPane(
+        toPaneState(settled[1] as PromiseSettledResult<SearchResponse>),
+      )
+      setAlgoliaPane(
+        toAlgoliaPaneState(
+          settled[2] as PromiseSettledResult<{ hits: AlgoliaHit[] }>,
+        ),
+      )
     })
 
     return () => {
@@ -120,6 +150,36 @@ export function DemoSearchClient() {
         : []
     return computeTopKDiff(aIds, bIds, urlK)
   }, [hybridPane, keywordPane, urlK])
+
+  // 3-way diff is keyed by SLUG (Algolia's `videoId` ≈ admin's `slug`).
+  // Admin cuids and Algolia videoIds are not directly comparable.
+  const hybridSlugs = useMemo(
+    () =>
+      hybridPane.status === "ok"
+        ? hybridPane.response.results.map((r) => r.slug)
+        : [],
+    [hybridPane],
+  )
+  const keywordSlugs = useMemo(
+    () =>
+      keywordPane.status === "ok"
+        ? keywordPane.response.results.map((r) => r.slug)
+        : [],
+    [keywordPane],
+  )
+  const algoliaSlugs = useMemo(
+    () =>
+      algoliaPane.status === "ok" ? algoliaPane.hits.map((h) => h.videoId) : [],
+    [algoliaPane],
+  )
+  const triDiff = useMemo(
+    () => computeThreeWayDiff(hybridSlugs, keywordSlugs, algoliaSlugs, urlK),
+    [hybridSlugs, keywordSlugs, algoliaSlugs, urlK],
+  )
+  const provenance = useMemo(
+    () => buildProvenanceMap(hybridSlugs, keywordSlugs, algoliaSlugs, urlK),
+    [hybridSlugs, keywordSlugs, algoliaSlugs, urlK],
+  )
 
   const rowAccent = useMemo(() => buildRowAccentMap(diff), [diff])
 
@@ -207,20 +267,33 @@ export function DemoSearchClient() {
         keywordPane={keywordPane}
       />
 
+      <AlgoliaDiffPanel diff={triDiff} k={urlK} algoliaPane={algoliaPane} />
+
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "1fr 1fr",
+          gridTemplateColumns: "1fr 1fr 1fr",
           gap: 16,
           marginTop: 16,
         }}
       >
-        <Pane heading="mode: hybrid" state={hybridPane} rowAccent={rowAccent} />
+        <Pane
+          heading="mode: hybrid"
+          state={hybridPane}
+          rowAccent={rowAccent}
+          provenance={provenance}
+          ownSource="H"
+          slugFor={(r) => r.slug}
+        />
         <Pane
           heading="mode: keyword-first"
           state={keywordPane}
           rowAccent={rowAccent}
+          provenance={provenance}
+          ownSource="K"
+          slugFor={(r) => r.slug}
         />
+        <AlgoliaPane state={algoliaPane} provenance={provenance} />
       </div>
     </main>
   )
@@ -248,6 +321,20 @@ function toPaneState(settled: PromiseSettledResult<SearchResponse>): PaneState {
   }
   const reason = settled.reason
   const message = reason instanceof Error ? reason.message : String(reason)
+  return { status: "error", messages: message.split("; ") }
+}
+
+function toAlgoliaPaneState(
+  settled: PromiseSettledResult<{ hits: AlgoliaHit[] }>,
+): AlgoliaPaneState {
+  if (settled.status === "fulfilled") {
+    return { status: "ok", hits: settled.value.hits }
+  }
+  const reason = settled.reason
+  const message = reason instanceof Error ? reason.message : String(reason)
+  if (message === "algolia_not_configured") {
+    return { status: "not_configured" }
+  }
   return { status: "error", messages: message.split("; ") }
 }
 
@@ -373,10 +460,16 @@ function Pane({
   heading,
   state,
   rowAccent,
+  provenance,
+  ownSource,
+  slugFor,
 }: {
   heading: string
   state: PaneState
   rowAccent: Map<string, string>
+  provenance: Map<string, Set<Source>>
+  ownSource: Source
+  slugFor: (r: SearchResult) => string
 }) {
   return (
     <section
@@ -396,7 +489,13 @@ function Pane({
       >
         {heading}
       </h2>
-      <PaneBody state={state} rowAccent={rowAccent} />
+      <PaneBody
+        state={state}
+        rowAccent={rowAccent}
+        provenance={provenance}
+        ownSource={ownSource}
+        slugFor={slugFor}
+      />
     </section>
   )
 }
@@ -404,12 +503,18 @@ function Pane({
 function PaneBody({
   state,
   rowAccent,
+  provenance,
+  ownSource,
+  slugFor,
 }: {
   state: PaneState
   rowAccent: Map<string, string>
+  provenance: Map<string, Set<Source>>
+  ownSource: Source
+  slugFor: (r: SearchResult) => string
 }) {
   if (state.status === "idle") {
-    return <Hint>Enter a query above and submit to canary both modes.</Hint>
+    return <Hint>Enter a query above and submit to canary all sources.</Hint>
   }
   if (state.status === "loading") {
     return <Hint>Loading…</Hint>
@@ -469,7 +574,13 @@ function PaneBody({
       {response.results.length === 0 ? (
         <Hint>No results.</Hint>
       ) : (
-        <ResultTable results={response.results} rowAccent={rowAccent} />
+        <ResultTable
+          results={response.results}
+          rowAccent={rowAccent}
+          provenance={provenance}
+          ownSource={ownSource}
+          slugFor={slugFor}
+        />
       )}
     </div>
   )
@@ -478,9 +589,15 @@ function PaneBody({
 function ResultTable({
   results,
   rowAccent,
+  provenance,
+  ownSource,
+  slugFor,
 }: {
   results: SearchResult[]
   rowAccent: Map<string, string>
+  provenance: Map<string, Set<Source>>
+  ownSource: Source
+  slugFor: (r: SearchResult) => string
 }) {
   return (
     <table
@@ -494,6 +611,7 @@ function ResultTable({
         <tr style={{ textAlign: "left", color: "#666" }}>
           <th style={thStyle}>#</th>
           <th style={thStyle}>id / title</th>
+          <th style={thStyle}>also in</th>
           <th style={thStyle}>score</th>
           <th style={thStyle}>retrievers</th>
           <th style={thStyle}>cap</th>
@@ -502,6 +620,11 @@ function ResultTable({
       <tbody>
         {results.map((r, i) => {
           const accent = rowAccent.get(r.id) ?? "#fff"
+          const otherSources = otherSourcesFor(
+            provenance,
+            slugFor(r),
+            ownSource,
+          )
           return (
             <tr
               key={r.id}
@@ -524,6 +647,9 @@ function ResultTable({
                   {r.type.toLowerCase()} · {truncateId(r.id)}
                   {r.playbackId ? ` · mux:${truncateId(r.playbackId)}` : ""}
                 </div>
+              </td>
+              <td style={tdStyle}>
+                <ProvenanceChips sources={otherSources} />
               </td>
               <td style={{ ...tdStyle, fontFamily: "ui-monospace, monospace" }}>
                 {r.score.toFixed(4)}
@@ -568,6 +694,260 @@ function ResultTable({
       </tbody>
     </table>
   )
+}
+
+// ---------------------------------------------------------------------------
+// 3-way diff panel + Algolia pane
+// ---------------------------------------------------------------------------
+
+function AlgoliaDiffPanel({
+  diff,
+  k,
+  algoliaPane,
+}: {
+  diff: {
+    inAll: string[]
+    hybridAlgolia: string[]
+    keywordAlgolia: string[]
+    algoliaOnly: string[]
+  }
+  k: number
+  algoliaPane: AlgoliaPaneState
+}) {
+  const haveData = algoliaPane.status === "ok"
+  return (
+    <section
+      style={{
+        marginTop: 12,
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr 1fr 1fr",
+        gap: 12,
+      }}
+    >
+      <DiffTile
+        label={`In all 3 (top ${k}, by slug)`}
+        ids={diff.inAll}
+        accent="#0a7d2f"
+        background="#e8f6ec"
+        haveData={haveData}
+      />
+      <DiffTile
+        label={`Algolia ∩ Hybrid (top ${k})`}
+        ids={diff.hybridAlgolia}
+        accent="#5a3199"
+        background="#ede4fb"
+        haveData={haveData}
+      />
+      <DiffTile
+        label={`Algolia ∩ Keyword (top ${k})`}
+        ids={diff.keywordAlgolia}
+        accent="#0a4a99"
+        background="#e6efff"
+        haveData={haveData}
+      />
+      <DiffTile
+        label={`Algolia only (top ${k})`}
+        ids={diff.algoliaOnly}
+        accent="#9a5a00"
+        background="#fbecd5"
+        haveData={haveData}
+      />
+    </section>
+  )
+}
+
+function AlgoliaPane({
+  state,
+  provenance,
+}: {
+  state: AlgoliaPaneState
+  provenance: Map<string, Set<Source>>
+}) {
+  return (
+    <section
+      style={{
+        border: "1px solid #ddd",
+        borderRadius: 6,
+        padding: "12px 14px",
+        background: "#fafafa",
+      }}
+    >
+      <h2
+        style={{
+          margin: "0 0 8px",
+          fontSize: 14,
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+        }}
+      >
+        algolia (watch stg)
+      </h2>
+      <AlgoliaPaneBody state={state} provenance={provenance} />
+    </section>
+  )
+}
+
+function AlgoliaPaneBody({
+  state,
+  provenance,
+}: {
+  state: AlgoliaPaneState
+  provenance: Map<string, Set<Source>>
+}) {
+  if (state.status === "idle") {
+    return <Hint>Enter a query above and submit to canary all sources.</Hint>
+  }
+  if (state.status === "loading") {
+    return <Hint>Loading…</Hint>
+  }
+  if (state.status === "not_configured") {
+    return (
+      <Banner tone="muted">
+        Algolia not configured for this environment. Set{" "}
+        <code>ALGOLIA_APP_ID</code>, <code>ALGOLIA_SEARCH_API_KEY</code>, and{" "}
+        <code>ALGOLIA_INDEX</code> on the admin Railway service.
+      </Banner>
+    )
+  }
+  if (state.status === "error") {
+    return (
+      <Banner tone="error">
+        <strong>Algolia upstream error.</strong>
+        <ul style={{ margin: "4px 0 0 16px", padding: 0 }}>
+          {state.messages.map((m, i) => (
+            <li key={i}>{m}</li>
+          ))}
+        </ul>
+      </Banner>
+    )
+  }
+
+  const hits = state.hits
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          fontSize: 12,
+          color: "#444",
+          marginBottom: 6,
+        }}
+      >
+        <span>
+          source: <code>video-variants-stg</code>
+        </span>
+        <span>
+          results: <code>{hits.length}</code>
+        </span>
+      </div>
+      <Banner tone="muted">
+        Throwaway parity column — Algolia stg index, plain query, no locale
+        filter, no facets. Removed at R8 cutover.
+      </Banner>
+      {hits.length === 0 ? (
+        <Hint>No results.</Hint>
+      ) : (
+        <table
+          style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}
+        >
+          <thead>
+            <tr style={{ textAlign: "left", color: "#666" }}>
+              <th style={thStyle}>#</th>
+              <th style={thStyle}>id / title</th>
+              <th style={thStyle}>also in</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hits.map((h, i) => {
+              const otherSources = otherSourcesFor(provenance, h.videoId, "A")
+              return (
+                <tr
+                  key={`${h.videoId}-${i}`}
+                  style={{ borderTop: "1px solid #eee" }}
+                >
+                  <td style={tdStyle}>{i + 1}</td>
+                  <td style={tdStyle}>
+                    <div style={{ fontWeight: 500 }}>
+                      {h.title || "(no title)"}
+                    </div>
+                    <div
+                      style={{
+                        fontFamily:
+                          "ui-monospace, SFMono-Regular, Menlo, monospace",
+                        color: "#666",
+                        fontSize: 11,
+                      }}
+                    >
+                      slug:{truncateId(h.videoId)}
+                    </div>
+                  </td>
+                  <td style={tdStyle}>
+                    <ProvenanceChips sources={otherSources} />
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+function ProvenanceChips({ sources }: { sources: Source[] }) {
+  if (sources.length === 0) {
+    return <span style={{ color: "#bbb" }}>—</span>
+  }
+  const palette: Record<Source, { bg: string; border: string; color: string }> =
+    {
+      H: { bg: "#fdeede", border: "#9a4400", color: "#9a4400" },
+      K: { bg: "#e6efff", border: "#0a4a99", color: "#0a4a99" },
+      A: { bg: "#fbecd5", border: "#9a5a00", color: "#9a5a00" },
+    }
+  return (
+    <div style={{ display: "flex", gap: 4 }}>
+      {sources.map((s) => {
+        const p = palette[s]
+        return (
+          <span
+            key={s}
+            title={
+              s === "H"
+                ? "Also in hybrid top-K"
+                : s === "K"
+                  ? "Also in keyword-first top-K"
+                  : "Also in Algolia top-K"
+            }
+            style={{
+              ...chipStyle,
+              background: p.bg,
+              borderColor: p.border,
+              color: p.color,
+              fontWeight: 600,
+            }}
+          >
+            {s}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+function otherSourcesFor(
+  provenance: Map<string, Set<Source>>,
+  slug: string,
+  own: Source,
+): Source[] {
+  const set = provenance.get(slug)
+  if (!set) return []
+  const out: Source[] = []
+  for (const s of ["H", "K", "A"] as const) {
+    if (s === own) continue
+    if (set.has(s)) out.push(s)
+  }
+  return out
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/admin/src/app/watch/demo-keyword-search/diff.test.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/diff.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { computeTopKDiff } from "./diff"
+import {
+  buildProvenanceMap,
+  computeThreeWayDiff,
+  computeTopKDiff,
+} from "./diff"
 
 describe("computeTopKDiff", () => {
   it("returns full overlap when inputs are identical", () => {
@@ -86,5 +90,111 @@ describe("computeTopKDiff", () => {
       aOnly: [],
       bOnly: [],
     })
+  })
+})
+
+describe("computeThreeWayDiff", () => {
+  const empty = {
+    inAll: [],
+    hybridKeyword: [],
+    hybridAlgolia: [],
+    keywordAlgolia: [],
+    hybridOnly: [],
+    keywordOnly: [],
+    algoliaOnly: [],
+  }
+
+  it("places identical inputs entirely in inAll", () => {
+    const ids = ["a", "b", "c"]
+    expect(computeThreeWayDiff(ids, ids, ids, 10)).toEqual({
+      ...empty,
+      inAll: ["a", "b", "c"],
+    })
+  })
+
+  it("classifies disjoint inputs into per-source-only buckets", () => {
+    expect(computeThreeWayDiff(["a"], ["b"], ["c"], 10)).toEqual({
+      ...empty,
+      hybridOnly: ["a"],
+      keywordOnly: ["b"],
+      algoliaOnly: ["c"],
+    })
+  })
+
+  it("classifies pairwise overlaps without leaking into inAll", () => {
+    // a: H+K, b: H+A, c: K+A, d: only H, e: only K, f: only A
+    expect(
+      computeThreeWayDiff(
+        ["a", "b", "d"],
+        ["a", "c", "e"],
+        ["b", "c", "f"],
+        10,
+      ),
+    ).toEqual({
+      inAll: [],
+      hybridKeyword: ["a"],
+      hybridAlgolia: ["b"],
+      keywordAlgolia: ["c"],
+      hybridOnly: ["d"],
+      keywordOnly: ["e"],
+      algoliaOnly: ["f"],
+    })
+  })
+
+  it("respects per-source top-k truncation independently", () => {
+    // k=2 — "z" only appears via hybrid index 2 + algolia index 2,
+    // both truncated. So z drops out entirely.
+    expect(
+      computeThreeWayDiff(["a", "b", "z"], ["a"], ["c", "d", "z"], 2),
+    ).toEqual({
+      ...empty,
+      hybridKeyword: ["a"],
+      hybridOnly: ["b"],
+      algoliaOnly: ["c", "d"],
+    })
+  })
+
+  it("dedupes within each source (first occurrence wins)", () => {
+    expect(
+      computeThreeWayDiff(["a", "a", "b"], ["b", "b"], ["a", "c"], 10),
+    ).toEqual({
+      inAll: [],
+      hybridKeyword: ["b"],
+      hybridAlgolia: ["a"],
+      keywordAlgolia: [],
+      hybridOnly: [],
+      keywordOnly: [],
+      algoliaOnly: ["c"],
+    })
+  })
+
+  it("returns all empty buckets for k <= 0", () => {
+    expect(computeThreeWayDiff(["a"], ["b"], ["c"], 0)).toEqual(empty)
+    expect(computeThreeWayDiff(["a"], ["b"], ["c"], -3)).toEqual(empty)
+  })
+
+  it("handles empty inputs without throwing", () => {
+    expect(computeThreeWayDiff([], [], [], 5)).toEqual(empty)
+  })
+})
+
+describe("buildProvenanceMap", () => {
+  it("records source membership per id within top-k", () => {
+    const map = buildProvenanceMap(["a", "b"], ["a", "c"], ["b", "c"], 10)
+    expect(Array.from(map.get("a") ?? [])).toEqual(["H", "K"])
+    expect(Array.from(map.get("b") ?? [])).toEqual(["H", "A"])
+    expect(Array.from(map.get("c") ?? [])).toEqual(["K", "A"])
+  })
+
+  it("respects k truncation per source", () => {
+    const map = buildProvenanceMap(["a", "b"], ["b"], ["a"], 1)
+    // Only the first id of each source counts at k=1:
+    // hybrid -> a, keyword -> b, algolia -> a
+    expect(Array.from(map.get("a") ?? [])).toEqual(["H", "A"])
+    expect(Array.from(map.get("b") ?? [])).toEqual(["K"])
+  })
+
+  it("returns an empty map for k <= 0", () => {
+    expect(buildProvenanceMap(["a"], ["b"], ["c"], 0).size).toBe(0)
   })
 })

--- a/apps/admin/src/app/watch/demo-keyword-search/diff.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/diff.ts
@@ -41,6 +41,122 @@ export function computeTopKDiff(
   return { both, aOnly, bOnly }
 }
 
+/**
+ * 3-way overlap variant. Operates on the same {first-k, dedupe-first}
+ * semantics as `computeTopKDiff` but partitions the union of three
+ * ordered id lists into 7 buckets:
+ *
+ * - `inAll`             — present in all three
+ * - `hybridKeyword`     — hybrid + keyword-first only
+ * - `hybridAlgolia`     — hybrid + algolia only
+ * - `keywordAlgolia`    — keyword-first + algolia only
+ * - `hybridOnly`        — hybrid alone
+ * - `keywordOnly`       — keyword-first alone
+ * - `algoliaOnly`       — algolia alone
+ *
+ * Bucket order preserves the order of the source the id was first seen
+ * in (hybrid, then keyword, then algolia).
+ *
+ * The 3-way diff in the demo route compares by SLUG, not cuid, because
+ * Algolia hits don't carry admin's cuid id — `videoId` on the Algolia
+ * hit is the same shape as admin's `SearchResult.slug`.
+ */
+export type ThreeWayDiff = {
+  inAll: string[]
+  hybridKeyword: string[]
+  hybridAlgolia: string[]
+  keywordAlgolia: string[]
+  hybridOnly: string[]
+  keywordOnly: string[]
+  algoliaOnly: string[]
+}
+
+export function computeThreeWayDiff(
+  hybrid: readonly string[],
+  keyword: readonly string[],
+  algolia: readonly string[],
+  k: number,
+): ThreeWayDiff {
+  const empty: ThreeWayDiff = {
+    inAll: [],
+    hybridKeyword: [],
+    hybridAlgolia: [],
+    keywordAlgolia: [],
+    hybridOnly: [],
+    keywordOnly: [],
+    algoliaOnly: [],
+  }
+  if (k <= 0) return empty
+
+  const h = dedupeFirst(hybrid.slice(0, k))
+  const kk = dedupeFirst(keyword.slice(0, k))
+  const a = dedupeFirst(algolia.slice(0, k))
+  const hSet = new Set(h)
+  const kSet = new Set(kk)
+  const aSet = new Set(a)
+
+  const out: ThreeWayDiff = {
+    inAll: [],
+    hybridKeyword: [],
+    hybridAlgolia: [],
+    keywordAlgolia: [],
+    hybridOnly: [],
+    keywordOnly: [],
+    algoliaOnly: [],
+  }
+  const seen = new Set<string>()
+
+  const classify = (id: string): void => {
+    if (seen.has(id)) return
+    seen.add(id)
+    const inH = hSet.has(id)
+    const inK = kSet.has(id)
+    const inA = aSet.has(id)
+    if (inH && inK && inA) out.inAll.push(id)
+    else if (inH && inK) out.hybridKeyword.push(id)
+    else if (inH && inA) out.hybridAlgolia.push(id)
+    else if (inK && inA) out.keywordAlgolia.push(id)
+    else if (inH) out.hybridOnly.push(id)
+    else if (inK) out.keywordOnly.push(id)
+    else if (inA) out.algoliaOnly.push(id)
+  }
+
+  for (const id of h) classify(id)
+  for (const id of kk) classify(id)
+  for (const id of a) classify(id)
+
+  return out
+}
+
+/**
+ * Per-id provenance map: which of {H, K, A} contains each id within
+ * its top-K. Used by the demo route to render "also in" badges on
+ * each result row without re-traversing arrays.
+ */
+export type Source = "H" | "K" | "A"
+
+export function buildProvenanceMap(
+  hybrid: readonly string[],
+  keyword: readonly string[],
+  algolia: readonly string[],
+  k: number,
+): Map<string, Set<Source>> {
+  const map = new Map<string, Set<Source>>()
+  if (k <= 0) return map
+  const add = (ids: readonly string[], source: Source): void => {
+    const top = dedupeFirst(ids.slice(0, k))
+    for (const id of top) {
+      const set = map.get(id) ?? new Set<Source>()
+      set.add(source)
+      map.set(id, set)
+    }
+  }
+  add(hybrid, "H")
+  add(keyword, "K")
+  add(algolia, "A")
+  return map
+}
+
 function dedupeFirst(ids: readonly string[]): string[] {
   const seen = new Set<string>()
   const out: string[] = []

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -77,6 +77,19 @@ export const env = createEnv({
     // configuration error if a runtime caller invokes it without this
     // env set. Recommend a dedicated read-only PG role on cms.
     CMS_DATABASE_URL: z.string().url().optional(),
+    // Algolia (watch-project parity demo column on /watch/demo-keyword-search).
+    // Server-side only — the demo route's `searchAlgolia` server action
+    // (`apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts`)
+    // proxies queries using ALGOLIA_SEARCH_API_KEY (the watch project's
+    // ALGOLIA_SERVER_API_KEY value, which is unrestricted; the public
+    // NEXT_PUBLIC_ALGOLIA_API_KEY is referer-locked to the watch domain
+    // and cannot be used from admin.jesusfilm.org). All three optional —
+    // the action throws `algolia_not_configured` when any is absent and
+    // the demo client renders a muted "Algolia disabled" banner.
+    // Throwaway: removed at R8 cutover when admin replaces Algolia.
+    ALGOLIA_APP_ID: z.string().min(1).optional(),
+    ALGOLIA_SEARCH_API_KEY: z.string().min(1).optional(),
+    ALGOLIA_INDEX: z.string().min(1).optional(),
     NODE_ENV: z.enum(["development", "test", "production"]).optional(),
   },
   client: {
@@ -149,6 +162,11 @@ export const env = createEnv({
       process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY,
     ),
     CMS_DATABASE_URL: emptyToUndefined(process.env.CMS_DATABASE_URL),
+    ALGOLIA_APP_ID: emptyToUndefined(process.env.ALGOLIA_APP_ID),
+    ALGOLIA_SEARCH_API_KEY: emptyToUndefined(
+      process.env.ALGOLIA_SEARCH_API_KEY,
+    ),
+    ALGOLIA_INDEX: emptyToUndefined(process.env.ALGOLIA_INDEX),
     NODE_ENV: emptyToUndefined(process.env.NODE_ENV),
     NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
   },

--- a/docs/plans/2026-04-30-001-feat-algolia-column-demo-keyword-search-plan.md
+++ b/docs/plans/2026-04-30-001-feat-algolia-column-demo-keyword-search-plan.md
@@ -1,0 +1,274 @@
+---
+title: "feat: Add Algolia column to demo-keyword-search canary"
+type: feat
+status: active
+date: 2026-04-30
+revised: 2026-04-30
+---
+
+# feat: Add Algolia column to demo-keyword-search canary
+
+## Overview
+
+Extend `apps/admin/src/app/watch/demo-keyword-search/` from a 2-way (hybrid vs keyword-first) canary into a 3-way comparison that includes the **watch** site's Algolia index as a third column. This is a **throwaway operator harness** — Algolia exists in admin only while we refine hybrid/keyword-first ranking, and gets ripped out cleanly at R8 cutover.
+
+**Hard constraints from this revision:**
+
+- **No new API surface.** No public route handler, no `/api/algolia-search`. The Algolia call lives in a Next.js **Server Action** (`"use server"`) co-located with the demo route. The function is callable only from the demo client component within the same app — no externally addressable URL, no contract to maintain, no rate-limit infra to wire up.
+- **Minimize new client-side code.** The existing client orchestrator (`demo-search-client.tsx`) gains the smallest possible diff: one extra `runAlgolia(...)` call inside the existing `Promise.allSettled` block, one extra `PaneState`, one extra column in the result grid, and the diff-tile / provenance changes for the 3-way overlap. No new client client-fetch wrapper, no new TypeScript shape that mirrors the watch project's index.
+- **Easy to delete.** When Algolia is retired, the cleanup is: delete the server-action file, delete the third column in the client, revert `diff.ts` to the 2-way variant (or leave the 3-way helper as dead code if simpler), drop the three env vars from Doppler / Railway. One small PR.
+
+## Problem Frame
+
+The keyword-first work introduced a canary diff route to compare admin's two ranking modes. Operators can't yet validate either against the de-facto baseline — the Algolia index live behind `watch.jesusfilm.org`. The watch app uses Algolia today; admin's hybrid + keyword-first will replace it at R8 cutover. Without a side-by-side, ranking regressions are invisible until the cutover.
+
+The watch project's public Algolia search key (`NEXT_PUBLIC_ALGOLIA_API_KEY`) is referer-allowlisted to the watch domain, so a browser-side query from `admin.jesusfilm.org` returns 403. The `ALGOLIA_SERVER_API_KEY` is unrestricted (verified via direct curl against `https://FJYYBFHBHS-dsn.algolia.net/1/indexes/video-variants-stg/query`), so a Server Action solves this cleanly while keeping the key off the browser.
+
+## Requirements Trace
+
+- R1. The demo route renders a third column showing top-N hits from the watch Algolia index for the current query/locale/limit, alongside the existing hybrid and keyword-first columns.
+- R2. The 3-way overlap panel shows which results appear in 1, 2, or all 3 sources, using a comparison key compatible across admin (cuid + slug) and Algolia (videoId/slug).
+- R3. Algolia is queried via a Next.js **Server Action** using `ALGOLIA_SEARCH_API_KEY`. The browser never sees the key, and no public REST endpoint is created.
+- R4. New env vars (`ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_API_KEY`, `ALGOLIA_INDEX`) flow through `src/config/env.ts` (validated, never read via `process.env` directly) and are set on the `forge-admin` Railway prod environment.
+- R5. The same Railway write also lands `SEARCH_DEBUG_ALLOWED_ORIGINS=https://admin.jesusfilm.org` so the existing debug payload starts surfacing in prod.
+- R6. Default behaviour of the existing 2-column diff is unchanged when the Algolia column is unavailable (env unset, transient 5xx) — pane shows an error; hybrid + keyword-first panes continue to render.
+- R7. The Algolia integration is **easily removable**: the surface area touched is the demo route directory + `env.ts` + Doppler/Railway. No code outside `apps/admin/src/app/watch/demo-keyword-search/` (other than env declarations) references Algolia.
+
+## Scope Boundaries
+
+- **Throwaway, demo-only.** Not a permanent admin capability. No GraphQL surface, no REST endpoint, no service-layer entry, no CLAUDE.md "feature" entry — it lives in the demo route directory and that's it.
+- v1 uses Algolia's **default** query construction (`{query, hitsPerPage}`) only. Replicating watch's filter/facet/ranking parity is out of scope.
+- No editor / admin-app config UI for the index name. Index is env-driven.
+- No `algoliasearch` npm dependency. Direct `fetch` from the server action.
+- No new public API endpoint under `/api/`. No rate-limit bucket. No structured-logging convention beyond `console.error` for failures.
+- No promotion of any Algolia logic to `src/lib`, `src/services`, or anywhere reusable. Stays demo-route-local.
+- No Doppler integration on admin's side — values are hand-copied from watch's Doppler stg config to forge-admin's Doppler config (and Railway env). Cross-project inheritance is out of scope.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/app/watch/demo-keyword-search/page.tsx` — Suspense-wrapped client entry.
+- `apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx` — 2-pane client orchestrator using `Promise.allSettled` + per-pane `idle | loading | ok | error` state machines. Easy to extend to a third pane.
+- `apps/admin/src/app/watch/demo-keyword-search/diff.ts` + `diff.test.ts` — pure helper for top-K overlap. Pattern to mirror for the 3-way variant.
+- `apps/admin/src/app/watch/demo-keyword-search/graphql-client.ts` — same-origin fetch wrapper for the existing 2 panes. The Algolia pane does NOT mirror this — it calls a server action directly, no fetch wrapper needed.
+- `apps/admin/src/config/env.ts` — schema + `runtimeEnv` extension pattern (every var declared in both blocks).
+
+### Institutional Learnings
+
+- `docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md` — `updateServiceTool` stages patches; flush with `accept-deploy(environmentId)`. **Never use `redeploy`** — it snapshots the unchanged canonical config and the staged patch silently disappears. This is the single most important rule for Unit 5.
+- `docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md` — sanitize CR/LF/TAB out of any user input that lands in a log line. Server action's failure log applies the same convention.
+
+### External References
+
+- Algolia REST search API: `POST https://{appId}-dsn.algolia.net/1/indexes/{index}/query` with headers `X-Algolia-API-Key`, `X-Algolia-Application-Id`, `Content-Type: application/json` and body `{ query, hitsPerPage }`. Verified working with the watch-project server key against `video-variants-stg` (returned BibleProject hits for `q="the bible project"`).
+- Next.js 16 Server Actions: `"use server"` directive at the top of a file (or per-function) marks an async function as a server-only callable invocable from a client component as if it were a regular async function. Compiles to a framework-internal POST to a non-public endpoint with anti-CSRF wiring. No public API contract; cannot be invoked from outside the app.
+
+## Key Technical Decisions
+
+- **Server Action, not a route handler.** Earlier draft proposed `POST /api/algolia-search`. Rejected because it creates a permanent-looking API surface for a throwaway demo. A server action gives the same key-on-server semantics without producing a deletable contract.
+- **Direct `fetch` rather than the `algoliasearch` npm dep.** One endpoint, fixed body shape, no need for client-state caching / typeahead / insights. Eliminates a dependency and a pinning concern.
+- **Comparison key for the 3-way overlap is `slug`** (Algolia's `videoId` field is the watch-side slug, e.g. `"BibleProject"`; admin's `SearchResult.slug` is the same shape). Admin's cuid IDs cannot be compared directly to Algolia, but slug is stable across both. The existing 2-way diff is by admin cuid; the 3-way variant operates on slug. Keep the 2-way diff intact for the legacy hybrid-vs-keyword tile so the existing semantic is preserved.
+- **3-way diff UX = per-row provenance badges + 6 diff tiles.** The existing 3 hybrid↔keyword tiles stay. Add a parallel 3 tiles for the Algolia overlap. Each result row also gets a small "also in" badge stack (`H` / `K` / `A` chips) indicating which other panes returned the same slug in their top-K.
+- **Stg index for v1** (`video-variants-stg`). Only `dev`/`stg` Doppler configs are reachable from the available token. Document in copy that the comparison is against the stg corpus.
+- **No env exposure to the browser.** All three Algolia env vars are server-only (no `NEXT_PUBLIC_` prefix).
+- **No rate limiting.** Server actions are framework-internal — only invocable from the demo route in the same app, by an operator visiting the page. The natural rate limit is "one operator clicking submit." Skipping the limiter is consistent with throwaway-tool posture.
+- **Soft-fail when env unset.** If any of the three Algolia env vars is missing, the action throws a typed error (`AlgoliaNotConfiguredError`) the client maps to a muted "Algolia disabled" banner. Other two columns render unaffected.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Server Action vs route handler:** server action (no permanent API surface for a throwaway tool).
+- **Browser SDK vs direct fetch:** direct fetch.
+- **Public vs server key:** server key (public is referer-locked to the watch domain).
+- **Stg vs prod index:** stg, with a TODO when prod-config Doppler access lands.
+- **Comparison key for 3-way diff:** slug (admin `SearchResult.slug` ↔ Algolia hit `videoId`).
+- **Overlap visualization:** parallel diff tiles (3 + 3) plus per-row provenance badges, not a 7-bucket grid.
+- **Rate limiting:** none. Server action access is framework-internal; the existing demo route is operator-only.
+
+### Deferred to Implementation
+
+- **Exact slug-equality assumption.** Admin's `SearchResult.slug` and Algolia's `hit.videoId` are believed to overlap byte-for-byte for the same video, but the prod admin DB is empty (per `apps/admin/CLAUDE.md` R4 notes: "admin's `video` / `video_locale` tables are 0 rows in prod"). The first time the demo runs against admin prod, expect the `In all 3` and 2-way overlap tiles to be empty until R0 backfill. Validate the slug-equality assumption locally during ce:work.
+- **Locale handling on Algolia.** Algolia hits carry `titles[]` + `titlesWithLanguages[{value, languageId}]` — multiple languages flattened. v1 just renders `titles[0]` and ignores the demo's `locale` param on the Algolia side. Known visual quirk; flag it in copy.
+- **TypeScript types for the Algolia hit.** Inline narrow type covering only `{ videoId: string, titles?: string[], description?: string[] }` rather than mirroring the full hit shape.
+
+## Implementation Units
+
+- [x] **Unit 1: env declarations**
+
+**Goal:** Three new optional vars on the validated env singleton.
+
+**Requirements:** R4.
+
+**Status:** ✅ Done (committed locally on branch).
+
+**Files modified:** `apps/admin/src/config/env.ts` — added `ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_API_KEY`, `ALGOLIA_INDEX` in `server` schema + `runtimeEnv`.
+
+---
+
+- [x] **Unit 2: 3-way diff helper + tests**
+
+**Goal:** Pure helpers for 3-way slug overlap and per-id provenance.
+
+**Requirements:** R2.
+
+**Status:** ✅ Done. 19/19 tests pass.
+
+**Files modified:**
+
+- `apps/admin/src/app/watch/demo-keyword-search/diff.ts` — added `computeThreeWayDiff` + `buildProvenanceMap` + `Source` type. `computeTopKDiff` untouched.
+- `apps/admin/src/app/watch/demo-keyword-search/diff.test.ts` — 10 new tests for the new helpers.
+
+---
+
+- [ ] **Unit 3: Algolia server action**
+
+**Goal:** Co-located, demo-route-local server action that proxies to Algolia using `ALGOLIA_SEARCH_API_KEY` and returns a normalized hit list. Throws typed errors on misconfiguration / upstream failure for the client to discriminate.
+
+**Requirements:** R3, R6, R7.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+
+- Create: `apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts`
+- Create: `apps/admin/src/app/watch/demo-keyword-search/algolia-action.test.ts`
+
+**Approach:**
+
+- Top-of-file `"use server"` directive — every export is a server action.
+- Single export: `searchAlgolia({ q, locale, limit }): Promise<{ hits: AlgoliaHit[] }>`. `locale` accepted for forward compatibility / log context but not forwarded to Algolia in v1 (documented in the JSDoc).
+- Read `env.ALGOLIA_APP_ID`, `env.ALGOLIA_SEARCH_API_KEY`, `env.ALGOLIA_INDEX` from the validated singleton. If any is undefined, throw `new Error("algolia_not_configured")`. The client matches on the message (cheap, throwaway-shaped error discrimination — typed error class is overkill for a temporary harness).
+- Direct `fetch` to `https://${appId}-dsn.algolia.net/1/indexes/${index}/query` with the headers + body documented above. 5s timeout via `AbortSignal.timeout(5000)`.
+- On Algolia 4xx/5xx: log a sanitized `console.error("[demo-search][algolia] upstream error status=… msg=…")` line and throw `new Error("algolia_upstream_error")`. Sanitization = strip CR/LF/TAB and clamp to 200 chars.
+- Normalize the response into `{ hits: Array<{ videoId: string; title: string | null; description: string | null }> }` — pick `titles[0]` / `description[0]` defensively, drop everything else.
+- Inline narrow type for the Algolia hit; do not import or re-export anything that could be mistaken for a service-layer surface.
+
+**Test scenarios:**
+
+- Returns shaped hits when fetch resolves with a populated `hits` array (mock global `fetch`).
+- Throws `algolia_not_configured` when any env var is undefined.
+- Throws `algolia_upstream_error` on Algolia 5xx.
+- Throws `algolia_upstream_error` on fetch network failure.
+- Clamps `limit` to ≤ 50 (defensive — matches `/api/search` upper bound, keeps Algolia from billing for over-fetched pages).
+- Handles a hit missing `titles[]` / `description[]` without crashing (yields nulls).
+
+**Verification:**
+
+- `pnpm --filter @forge/admin test` passes the new test file.
+- Manual: with env set on local admin dev, click the demo page submit and confirm the third column populates from the action call.
+
+---
+
+- [ ] **Unit 4: Demo client wires the third pane**
+
+**Goal:** Smallest possible client diff: one extra await alongside the existing two `runSearch(...)` calls, one extra `PaneState`, one extra column in the result grid, 3 extra diff tiles, per-row "also in" provenance badges.
+
+**Requirements:** R1, R2, R6, R7.
+
+**Dependencies:** Unit 2, Unit 3.
+
+**Files:**
+
+- Modify: `apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx`
+
+**Approach:**
+
+- Import the server action directly (`import { searchAlgolia } from "./algolia-action"`). The client component invokes it as a regular async function — Next.js handles the server bridge.
+- Extend the `Promise.allSettled` block to fire three calls instead of two. Each call gets its own pane state.
+- Map the action's typed-error messages (`"algolia_not_configured"`, `"algolia_upstream_error"`) to specific `PaneState` shapes — `not_configured` renders the muted banner; `upstream_error` falls through the existing `error` pane.
+- Grid moves from `1fr 1fr` to `1fr 1fr 1fr` for the result panes.
+- DiffPanel grows from 3 tiles to 6: existing `In both` / `Hybrid only` / `Keyword-first only` row stays (semantic: hybrid↔keyword overlap by admin cuid). Add a parallel row: `Algolia ∩ Hybrid (slug)` / `Algolia ∩ Keyword-first (slug)` / `Algolia only (slug)`. Label both rows so operators see the mixed comparison axes (cuid vs slug).
+- Per-row provenance: each pane's result table renders an `H` / `K` / `A` chip stack on each row indicating which OTHER panes also returned the same slug in their top-K. Source the data from `buildProvenanceMap(hybrid, keyword, algolia, k)`.
+- Empty state for the Algolia pane when `algolia_not_configured` is thrown: muted banner reading "Algolia not configured for this environment. Set `ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_API_KEY`, `ALGOLIA_INDEX` on the admin Railway service." This is the only branch in the client that distinguishes Algolia-specific failure modes from generic errors.
+
+**Patterns to follow:**
+
+- Existing pane-state state machine — extend, don't replace.
+- `Banner` component for muted / warn / error degradation messaging.
+
+**Test scenarios:**
+
+- Manual: open `/watch/demo-keyword-search?q=the+bible+project&locale=en` against local admin with env set; all three columns populate; tiles + provenance badges render; idle / loading / error states behave per existing pattern.
+- Manual: with one of the three Algolia env vars unset, the third column shows the muted "not configured" banner and the other two columns are unaffected.
+- No new automated rendering tests — UI is operator-only and visually verifiable.
+
+**Verification:**
+
+- `pnpm --filter @forge/admin lint` clean.
+- `pnpm --filter @forge/admin typecheck` clean.
+- Manual browser check at `http://localhost:3003/watch/demo-keyword-search?q=jesus&locale=en` exercising both env-set and env-unset behaviours.
+
+---
+
+- [ ] **Unit 5: Railway prod env push (Algolia + SEARCH_DEBUG_ALLOWED_ORIGINS)**
+
+**Goal:** Land all four env vars on the `forge-admin` Railway prod environment in a single coordinated MCP write so prod's demo route shows three columns and surfaces debug payloads.
+
+**Requirements:** R4, R5.
+
+**Dependencies:** Unit 3 (the prod env vars only matter once the server action is deployed; this unit can land before or after, the env vars are no-op for older builds).
+
+**Files:**
+
+- No code changes. Doppler `forge-admin` (prd config) + Railway dashboard via MCP.
+
+**Approach:**
+
+- Doppler push to `forge-admin` `prd` config:
+  - `ALGOLIA_APP_ID=FJYYBFHBHS`
+  - `ALGOLIA_SEARCH_API_KEY=<server key from watch stg>`
+  - `ALGOLIA_INDEX=video-variants-stg`
+  - `SEARCH_DEBUG_ALLOWED_ORIGINS=https://admin.jesusfilm.org`
+- Railway MCP dashboard write on the `forge-admin` service, environment id `5f41e037-90e4-4674-a3ea-66bbd05fb3b4`, project `98952497-a4d9-4714-8fe8-0cdbff3147c9`. Resolve the admin service id at execution time via `mcp__railway__list-services` filtered by project.
+- **Tool sequence (per `docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md`):**
+  1. `mcp__railway__updateServiceTool` — apply all four env vars in one staged patch.
+  2. `mcp__railway__accept-deploy(environmentId)` — flush. **Never call `redeploy`** — it snapshots the unchanged canonical config and the staged patch silently disappears.
+- Verify post-flush by reading the service environment config back via `mcp__railway__list-services` and confirming the four keys are present.
+
+**Patterns to follow:**
+
+- Search `docs/solutions/platform/railway-*` BEFORE issuing any MCP write (per saved feedback memory).
+
+**Test scenarios:**
+
+- Post-deploy, `https://admin.jesusfilm.org/watch/demo-keyword-search?q=the+bible+project&locale=en` shows three populated columns (with admin columns possibly empty until R0 backfill — Algolia column populates regardless).
+- Per-row debug payloads now render in the hybrid + keyword-first panes (no more "Debug payload withheld" muted banner).
+
+**Verification:**
+
+- Browser check on prod URL above.
+- Confirm absence of the "Debug payload withheld" banner.
+- Railway MCP `list-services` shows the four env vars set.
+
+## System-Wide Impact
+
+- **Interaction graph:** Server action is local to the demo route. No shared service or data-access path; no `/api/*` route added; no GraphQL schema change.
+- **Error propagation:** Per-pane error isolation in the demo client. An Algolia upstream failure surfaces in the third column without affecting the other two.
+- **State lifecycle risks:** None — the action is a synchronous proxy with no DB writes, no workflow dispatch, no cache.
+- **API surface parity:** None added. The whole point of using a server action is that there is no addressable URL contract.
+- **Integration coverage:** Unit-test coverage on the server action + diff helper is sufficient. Browser-level rendering is operator-verified.
+- **Removability:** When Algolia is retired, deleting `algolia-action.ts`, the third pane in `demo-search-client.tsx`, and the three env vars cleans up the entire integration. No service-layer or schema entanglement.
+
+## Risks & Dependencies
+
+- **Slug-equality assumption is unverified at scale.** v1 ships and the first prod run will reveal whether admin `SearchResult.slug` matches Algolia `hit.videoId` byte-for-byte. If it diverges, overlap will under-report. Verify locally during ce:work using the sample data already in the local DB.
+- **Stg vs prd Algolia index drift.** Watch Doppler `prd` config invisible to the available token. Comparison is against stg, not prd. Document in copy.
+- **Server key in transit.** Standard env-var protection (Doppler-managed, never logged, never browser-exposed). No new threat surface beyond existing OPENROUTER / OPENAI keys.
+- **Railway MCP staging trap (Unit 5).** Documented; mitigation is following the playbook exactly.
+- **Server-action invocation in a Suspense / client-rendered subtree.** The demo route is already wrapped in `<Suspense fallback={null}>`. Server actions invoked from a client component during render are fine; we invoke from a `useEffect` (the existing pattern), which is the safest path. No special wiring needed.
+
+## Documentation / Operational Notes
+
+- Update `apps/admin/CLAUDE.md` with a small line in the existing "Hybrid search keyword-first mode (R4 extension)" section noting the demo route's third Algolia column and the `ALGOLIA_*` env triple — explicitly tagged as "throwaway operator harness, removed at R8 cutover."
+- No solutions doc — the architectural shape (server action + direct fetch) is conventional Next.js.
+
+## Sources & References
+
+- `apps/admin/src/app/watch/demo-keyword-search/` — existing 2-way demo
+- `docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md` — Unit 5's required playbook
+- `docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md` — log sanitization for Unit 3
+- Watch project Doppler `stg` config (read during planning): `ALGOLIA_APP_ID=FJYYBFHBHS`, `ALGOLIA_INDEX=video-variants-stg`, `ALGOLIA_SERVER_API_KEY=<redacted>` — verified working against `https://FJYYBFHBHS-dsn.algolia.net/1/indexes/video-variants-stg/query`
+- Algolia REST API: `POST /1/indexes/{index}/query`
+- Next.js Server Actions: `"use server"` directive


### PR DESCRIPTION
## Summary

Throwaway operator harness — extends the existing 2-way (hybrid vs keyword-first) canary at `/watch/demo-keyword-search` into a 3-way comparison that includes the watch project's Algolia stg index as a third column. Lets us validate admin's hybrid + keyword-first ranking against the Algolia baseline that powers `watch.jesusfilm.org` today.

**Lifetime:** lives in the demo-route directory + three env vars. At R8 cutover (admin replaces Algolia on watch), delete `algolia-action.ts`, the third pane in `demo-search-client.tsx`, and the env vars. No service-layer or schema entanglement to unwind.

### Implementation choices

- **Server Action, not a route handler.** `apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts` uses `"use server"` to expose `searchAlgolia(...)` as a framework-internal callable. **No public REST endpoint, no `/api/algolia-search`, no rate-limit bucket** — server actions aren't externally addressable, which is the right shape for a throwaway tool.
- **Server-side `ALGOLIA_SEARCH_API_KEY`.** The watch project's public `NEXT_PUBLIC_ALGOLIA_API_KEY` is referer-locked to the watch domain, so a browser query from `admin.jesusfilm.org` returns 403. The watch-project server key is unrestricted; we proxy through it on the server. Browser never sees the key.
- **Direct `fetch`, no `algoliasearch` dep.** One endpoint, fixed body shape, no client-state caching needed.
- **3-way diff keyed by slug.** Algolia hits expose `videoId` (the watch slug, e.g. `BibleProject`); admin's `SearchResult.slug` matches. Admin cuids and Algolia videoIds aren't directly comparable, so the new `computeThreeWayDiff` operates on slug. The existing 2-way `computeTopKDiff` (by admin cuid) is untouched so the legacy hybrid↔keyword tile preserves its semantic.
- **Provenance chips on every row.** Each result row in each pane shows a small `H` / `K` / `A` chip stack indicating which OTHER panes' top-K contains the same slug — operator can scan a single column and immediately see overlap.
- **Soft-fail when env unset.** `algolia_not_configured` thrown by the action maps to a muted "Algolia disabled" banner in the third column; the other two columns render unaffected.

### Files

- `apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts` (new, `"use server"`)
- `apps/admin/src/app/watch/demo-keyword-search/algolia-action.test.ts` (new, 9 tests)
- `apps/admin/src/app/watch/demo-keyword-search/diff.ts` (added `computeThreeWayDiff`, `buildProvenanceMap`, `Source` type — `computeTopKDiff` untouched)
- `apps/admin/src/app/watch/demo-keyword-search/diff.test.ts` (10 new tests, 19 total)
- `apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx` (third pane + 4 extra diff tiles + provenance chips)
- `apps/admin/src/config/env.ts` (three optional vars: `ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_API_KEY`, `ALGOLIA_INDEX`)
- `docs/plans/2026-04-30-001-feat-algolia-column-demo-keyword-search-plan.md` (planning artifact)

### Tests

- `pnpm --filter @forge/admin test src/app/watch/demo-keyword-search/` → **28 / 28 passing**
- `pnpm --filter @forge/admin lint` clean
- `pnpm --filter @forge/admin typecheck` clean
- Manual browser check on local admin (port 3003) with env set: three columns populate; BibleProject collection appears in the Algolia pane on `q="the bible project"`; overlap tiles + provenance chips render.

### Railway env push (already applied to prod)

The four env vars below are already set on `@forge/admin` prod (deployment `23685e16-4baf-4a08-aa16-ff9c62c78e2a`, applied before this PR opened so the merge can pick them up immediately):

- `ALGOLIA_APP_ID=FJYYBFHBHS`
- `ALGOLIA_SEARCH_API_KEY=<watch project's ALGOLIA_SERVER_API_KEY, stg>`
- `ALGOLIA_INDEX=video-variants-stg`
- `SEARCH_DEBUG_ALLOWED_ORIGINS=https://admin.jesusfilm.org` (re-enables the existing keyword-first debug payload from admin's prod origin — outstanding from prior session)

### Caveats

- Algolia stg index, not prd. Only `dev`/`stg` Doppler configs are reachable from the available token. Documented in the third pane's muted banner. Swap to `video-variants-prd` (when prd Doppler access lands) is a one-line env-var change.
- Admin's `video` / `video_locale` tables are still 0 rows in prod (per `apps/admin/CLAUDE.md` R4 notes). Until R0 backfill lands, the hybrid + keyword-first columns will return ~0-1 results and the Algolia column will dominate the screen — that is the expected pre-R0 state.
- v1 query construction is plain (`{query, hitsPerPage}`) — no filter / facet / ranking parity with the watch app's actual Algolia query. Documented as a TODO; ranking divergence between admin and Algolia in this harness is partly a query-construction artifact, not pure ranking signal.

### Operational note on Railway MCP

Used the Railway agent to upsert the four env vars + flush. The agent fell back to `deployServiceTool` rather than literal `accept-deploy` — the documented staged-patch trap (`docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md`) applies to **build/deploy fields** (startCommand, buildCommand, healthcheckPath), not env vars. Post-update canonical-config readback confirms all four keys are present on the @forge/admin service. Worth a follow-up to refine the solutions doc with the env-var-vs-build-config distinction.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs (Railway): grep `[demo-search][algolia]` on `@forge/admin` — any lines indicate Algolia upstream errors. Expected healthy state: zero such lines under operator usage.
  - The demo route itself: `https://admin.jesusfilm.org/watch/demo-keyword-search?q=the+bible+project&locale=en` — three columns render, Algolia pane populates with BibleProject hits.
- **Validation checks**
  - `gh pr checks` — CI green before merge.
  - Post-merge prod: open the URL above; confirm 3 columns + the muted "stg index" banner on the Algolia pane.
  - Confirm the existing "Debug payload withheld" banner is GONE on the hybrid + keyword-first panes (`SEARCH_DEBUG_ALLOWED_ORIGINS` now set).
- **Expected healthy behaviour**
  - All three panes load within a few seconds of page render.
  - Algolia pane shows hits for common queries (e.g. `q="jesus"`, `q="the bible project"`).
  - Per-row `H` / `K` / `A` provenance chips render where slugs overlap.
- **Failure signal / mitigation trigger**
  - Algolia pane stays in `loading` indefinitely → check Railway logs for upstream errors / network failure to `*.algolia.net`.
  - Algolia pane shows the muted "not configured" banner → one of the three env vars didn't land; re-run the Railway MCP write.
  - "Debug payload withheld" banner persists post-merge → `SEARCH_DEBUG_ALLOWED_ORIGINS` not propagated; confirm value via Railway dashboard.
  - Rollback path: revert this PR. The three Algolia env vars become no-ops on the older code; `SEARCH_DEBUG_ALLOWED_ORIGINS` continues to work on the older code (already shipped by prior PR).
- **Validation window & owner**
  - Window: 15 minutes post-merge.
  - Owner: @Kneesal (PR author).

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0