### PR TITLE
docs(solutions): capture 4 learnings from PR #864 (Algolia parity column)

### DIFF
--- a/docs/solutions/best-practices/nextjs-server-action-error-redaction-prod-20260430.md
+++ b/docs/solutions/best-practices/nextjs-server-action-error-redaction-prod-20260430.md
@@ -1,0 +1,189 @@
+---
+title: Next.js Server Action thrown errors lose typed-message discrimination in production builds
+date: 2026-04-30
+tags: [nextjs, server-actions, error-handling, production-build, react]
+category: best-practices
+severity: medium
+---
+
+## Problem
+
+A "use server" function that throws `new Error("typed_code_string")`
+to signal failure modes works in dev/test but **silently degrades**
+in production builds. Next.js redacts the thrown `Error.message`
+before it reaches the client, replacing it with a generic:
+
+```
+An error occurred in the Server Components render. The specific
+message is omitted in production builds to avoid leaking sensitive
+details. A digest property is included on this error instance which
+may provide additional details about the nature of the error.
+```
+
+Client code that branches on `error.message === "<typed_code>"`
+will silently skip the typed branch and fall through to the
+generic-error path. A user-experience designed around two distinct
+error states (e.g., "service not configured" muted banner vs.
+"upstream failure" red banner) collapses to always rendering the
+generic-failure branch in prod.
+
+## Symptoms
+
+- Works perfectly in `next dev` and unit tests with mocked thrown errors
+- In production deploys, the "typed" error UI branch never fires
+- Server-side logs show the thrown typed error correctly:
+  `⨯ Error: typed_code_string`
+- Client-side `error.message` is the redacted generic string + a `digest` field
+- The error's `digest` is opaque (an integer-string hash) — useful only
+  for cross-referencing server logs, not for branching client logic
+
+## What Didn't Work
+
+- **Catching `cause` chain client-side** — `Error.cause` is also
+  redacted; only `digest` survives.
+- **Subclassing the Error** — class identity is lost across the
+  serialization boundary. The instance arriving on the client is a
+  generic `Error`, not the subclass.
+- **Disabling sourcemaps / minification** — orthogonal; redaction is
+  controlled by Next's prod build flag, not by minification.
+- **Reading `error.digest` against a server-logged map** — works but
+  fragile (race between client mount and log backend) and adds
+  observability infrastructure for what should be a single function call.
+
+## Solution
+
+**Return a discriminated union from the server action instead of
+throwing.** Return values traverse Next's serialization path
+(`flight-server-edge` → client) which is **not** redacted; only
+thrown errors are.
+
+Before:
+
+```ts
+"use server"
+export async function searchAlgolia(args): Promise<{ hits: Hit[] }> {
+  if (!env.ALGOLIA_APP_ID || !env.ALGOLIA_SEARCH_API_KEY) {
+    throw new Error("algolia_not_configured")
+  }
+  const response = await fetch(...)
+  if (!response.ok) {
+    throw new Error("algolia_upstream_error")
+  }
+  return { hits: parse(response) }
+}
+```
+
+After:
+
+```ts
+"use server"
+type AlgoliaResult =
+  | { ok: true; hits: Hit[] }
+  | { ok: false; code: "not_configured" | "upstream_error"; detail?: string }
+
+export async function searchAlgolia(args): Promise<AlgoliaResult> {
+  if (!env.ALGOLIA_APP_ID || !env.ALGOLIA_SEARCH_API_KEY) {
+    return { ok: false, code: "not_configured" }
+  }
+  const response = await fetch(...)
+  if (!response.ok) {
+    return { ok: false, code: "upstream_error", detail: `status=${response.status}` }
+  }
+  return { ok: true, hits: parse(response) }
+}
+```
+
+Client:
+
+```tsx
+const result = await searchAlgolia(args)
+if (result.ok) {
+  setPane({ status: "ok", hits: result.hits })
+} else if (result.code === "not_configured") {
+  setPane({ status: "not_configured" })
+} else {
+  setPane({ status: "error", message: result.detail })
+}
+```
+
+The `code` field crosses the boundary intact — branching is
+production-safe.
+
+## Why This Works
+
+Next.js redacts thrown errors as a defense against accidental
+secret leakage (e.g., a stack trace exposing internal hostnames,
+DB connection strings, or auth tokens). The redaction is unconditional
+on `Error.message` regardless of whether the thrown content is
+sensitive — Next can't distinguish.
+
+Return values are presumed-intentional output: the developer chose
+what to serialize, so Next does not strip it. A discriminated union
+treats failure as a normal return shape, opting out of the redaction
+path entirely.
+
+This is consistent with the broader React Server Components / Server
+Actions design philosophy: **errors are for unexpected conditions
+that should bubble to the nearest error boundary**; expected failure
+modes (validation rejection, upstream-not-configured, soft 4xx) are
+return values.
+
+## Prevention
+
+1. **Default to discriminated-union return types** in every new
+   server action. Reach for `throw` only when the failure is genuinely
+   unrecoverable and the page should render an error boundary.
+2. **Add an integration test that runs against a `next build`
+   production bundle**, not just `next dev` — the redaction only
+   manifests in production. A vitest run will not catch this.
+3. **Lint rule candidate**: flag `throw new Error("<lowercase_snake_case>")`
+   inside files starting with `"use server"` — the snake_case shape
+   is a tell that someone is encoding a typed error code in
+   `Error.message`. Suggest the discriminated-union refactor.
+4. **Document in the action's JSDoc**: if a server action does throw,
+   call out that callers can branch on `digest` (with a server-log
+   correlation) but **not** on `message` in production.
+
+### Test scaffold
+
+```ts
+// nextjs-server-action.prod.spec.ts — runs against next build output
+test("server action returns typed code, not thrown error", async () => {
+  const result = await searchAlgolia({ q: "x", locale: "en", limit: 5 })
+  expect(result.ok).toBe(false)
+  expect(result.code).toBe("not_configured")
+  // NOT: expect(() => searchAlgolia(...)).rejects.toThrow("not_configured")
+})
+```
+
+## Where this bit us
+
+PR #864 (admin Algolia parity column on `/watch/demo-keyword-search`,
+merged 2026-04-30). The demo client mapped:
+
+```ts
+if (message === "algolia_not_configured") {
+  return { status: "not_configured" }
+}
+return { status: "error", messages: message.split("; ") }
+```
+
+In dev this rendered the muted "Algolia disabled" banner correctly.
+In production, when env vars hadn't propagated through the Railway
+staged-patch trap, the same code path showed the loud red
+"Algolia upstream error" banner with the redacted generic text.
+The muted-banner UX was effectively dead code in prod.
+
+## Related
+
+- [Server Actions docs](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations)
+- `apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts`
+  (the throwaway harness that surfaced the lesson — slated for
+  removal at R8 cutover; the discriminated-union refactor should
+  land before then in any case)
+- `docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md`
+  — the env-var staged-patch trap that triggered the unconfigured
+  state we observed live
+- `docs/solutions/best-practices/nextjs-server-action-llm-structured-output-pattern-2026-04-21.md`
+  — sibling pattern using discriminated-union outputs from server
+  actions for LLM responses

--- a/docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md
+++ b/docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md
@@ -1,0 +1,238 @@
+---
+title: Throwaway operator harness with explicit deletion contract — pattern for canary / parity / migration tooling with a known retirement date
+date: 2026-04-30
+tags: [patterns, design, migration, demo, lifecycle, deletion-contract]
+category: best-practices
+severity: low
+---
+
+## Problem
+
+Migration-era tooling — A/B canaries, parity diff dashboards, manual
+verification harnesses, side-by-side-the-old-system comparisons —
+gets built fast under pressure, ships to operators, and then **stays
+in the codebase long after its purpose is gone**. Twelve months
+later it shows up in a PR diff, nobody remembers whether deleting
+it is safe, the implicit env vars and external API keys it depends
+on still sit in Doppler/Railway/dashboards, and one day someone
+reactivates the route by accident or refactors around it instead of
+removing it.
+
+The natural failure mode of "we'll delete it later" is that "later"
+arrives without a checklist of what to delete.
+
+## Symptoms
+
+- Demo / canary / preview routes that hung around past their
+  intended retirement event
+- Env vars in production that nobody can confidently remove because
+  nobody can grep for the consumer
+- Server-layer or service-layer code that was "supposed to be
+  temporary" but grew imports, became a shared dependency, and is
+  now load-bearing
+- PRs that delete one piece of the harness but leave its env-var
+  configuration / its Doppler secret / its Railway dashboard tile
+- Migration completion declared "done" while the parity harness is
+  still serving traffic
+
+## What Didn't Work
+
+- **Inline TODO comments** ("remove at X cutover") — searchable, but
+  no enforcement; routinely outlive their author's tenure.
+- **GitHub issues / Linear tickets** — orthogonal to the code; the
+  issue closes without the deletion happening, or the issue stays
+  open indefinitely as background noise.
+- **Feature flags** — overkill for a demo, and the flag itself
+  becomes another thing that has to be removed; nests the same
+  problem one layer deeper.
+- **"Just delete it when we're done"** without a contract — relies on
+  human memory across a multi-week or multi-month migration.
+
+## Solution
+
+Treat throwaway tooling as a **first-class architectural choice**
+with an explicit deletion contract. Five rules:
+
+### 1. Co-locate everything in one deletable folder
+
+All code for the harness lives under a single directory whose name
+encodes its purpose. The entire folder is one `rm -rf` away from
+deletion. No service-layer entries, no GraphQL types, no shared
+helpers promoted to `src/lib`, no `src/services` cross-reaches.
+
+```
+apps/admin/src/app/watch/demo-keyword-search/
+├── page.tsx
+├── demo-search-client.tsx
+├── algolia-action.ts          # throwaway server action
+├── algolia-action.test.ts
+├── diff.ts
+└── diff.test.ts
+```
+
+If a helper from the harness becomes useful enough to share with
+permanent code, **promote it deliberately** — and at that point
+admit it isn't throwaway anymore. The decision is forced, not drifted.
+
+### 2. State the lifetime in the file headers AND the commit body
+
+The file's docstring is the load-bearing artifact:
+
+```ts
+/**
+ * Throwaway operator harness — server action backing the third
+ * column of /watch/demo-keyword-search.
+ *
+ * Lifetime: this exists only while we refine admin's hybrid +
+ * keyword-first ranking. At R8 cutover, delete this file, drop
+ * the Algolia env vars from Doppler / Railway, and remove the
+ * third pane from `demo-search-client.tsx`. No service layer,
+ * no GraphQL surface, no REST endpoint — that is the point.
+ */
+```
+
+The commit message restates the lifetime + repeats the cleanup
+checklist. Two anchors so a future engineer reading either can find
+the deletion contract.
+
+### 3. Prefer Server Actions / non-addressable surfaces over public REST
+
+When a Next.js Server Action will do, **do not create a `/api/foo`
+route**. Server actions are framework-internal POSTs with no
+externally-visible URL. They:
+
+- Carry no documented contract for third parties to bind to
+- Cannot be invoked by anything outside the app
+- Disappear cleanly when the calling component is removed
+- Don't need a deprecation period
+
+A public REST route, by contrast, becomes a permanent maintenance
+burden the moment it ships — even if nobody uses it, you can't
+prove nobody uses it without an Apache-log audit.
+
+The same logic applies to GraphQL: don't add fields to the public
+schema for a temporary surface.
+
+### 4. Enumerate every deletion target at write time
+
+The cleanup checklist lives in the harness itself (file docstring +
+commit body). It must include:
+
+- **Code**: which files / which sections of which files
+- **Tests**: companion test files
+- **Configuration**: env vars in every relevant Doppler project
+  config (dev / stg / prd), Railway dashboard entries, Cloudflare
+  rules if any
+- **External**: any third-party resources (Algolia search keys,
+  feature-flag definitions, monitoring dashboards) that should be
+  revoked
+- **Documentation**: any README sections, CLAUDE.md notes, brainstorm
+  files that should be retired
+
+The checklist is mechanical: a future engineer (or AI agent) should
+be able to execute it without judgment calls.
+
+### 5. Don't let "soft-fail" disguise abandonment
+
+Throwaway code usually has a `if (!env.X) { return null }` style
+soft-fail so a missing config doesn't 500 the page. That's correct
+defensive coding. The risk: if everyone forgets to set the env vars,
+the soft-fail makes the harness invisibly dead — present in code,
+serving zero value, costing review time on every diff.
+
+Mitigations:
+
+- A startup log line at module load if the harness is "active"
+  (env vars present), so it's visible in deploy logs whether the
+  harness is doing anything
+- A scheduled agent (e.g., `/schedule`) at the planned retirement
+  date that opens a deletion PR automatically
+- An entry in the project's roadmap with the expected deletion
+  trigger so it's tracked alongside the rest of the work
+
+## Why This Works
+
+The pattern works because it makes deletion **the cheapest path**.
+Every other approach makes deletion as expensive as the original
+build. By co-locating, avoiding new public surfaces, and
+enumerating the cleanup, the only judgment call at retirement is
+"has the trigger event happened?" — not "what does this code touch?"
+
+The throwaway-with-contract framing also pre-commits the team to a
+specific scope. If during build someone is tempted to refactor the
+harness's helpers into a service-layer abstraction, the contract
+forces the question: are we still throwaway? Either the work
+properly graduates (and the deletion contract is voided), or the
+abstraction is cut.
+
+## Prevention
+
+### Checklist before merging a "temporary" surface
+
+- [ ] All code in one folder under a clearly-named directory
+- [ ] No imports from outside the folder reach into it (verify with
+      `grep -r "from.*<folder>" apps/`)
+- [ ] No new public REST routes (`/api/*`)
+- [ ] No new GraphQL types/fields exposed to consumers
+- [ ] File docstring states retirement trigger + cleanup steps
+- [ ] Commit body restates retirement trigger + cleanup steps
+- [ ] Env vars (Doppler + Railway) listed in cleanup steps
+- [ ] Soft-fail behavior documented (what happens when env unset)
+
+### When the contract is voided
+
+If the harness becomes load-bearing during its lifetime (a permanent
+consumer adopts it, a helper graduates to service-layer, etc.),
+**explicitly** void the contract:
+
+- Update the file docstring to remove the throwaway framing
+- Move the harness out of the demo folder if appropriate
+- Open a follow-up PR that promotes its helpers to permanent locations
+- Treat the surface as you would any other production feature
+
+The voiding step is the same shape as graduation in any other
+prototype-to-production transition.
+
+## Where this pattern showed up
+
+PR #864 (admin `/watch/demo-keyword-search` + Algolia parity column,
+merged 2026-04-30). The harness compares admin's hybrid +
+keyword-first search rankings against the watch project's Algolia
+stg index. Designed to run only until R8 cutover (when admin
+replaces Algolia on the watch site). All five rules applied:
+
+- Single folder: `apps/admin/src/app/watch/demo-keyword-search/`
+- Lifetime in file docstring + commit body
+- Server Action (`algolia-action.ts` with `"use server"`), no public route
+- Cleanup enumerated: file deletion + 3 env vars + 1 component
+  pane in `demo-search-client.tsx`
+- Soft-fail: muted "Algolia disabled" banner when env unset
+
+The ce:review of the PR scored agent-native parity as **PASS** with
+a non-recommendation: "do not wire agent tooling around a throwaway
+harness." That's a deliberate inversion of the agent-native default,
+and it's the right call for code with a known retirement date.
+
+## Anti-patterns to avoid
+
+- **"We'll add it to a service-layer once we see if it works"** — by
+  the time you "see if it works", you've already coupled callers to
+  a contract that's now hard to remove
+- **Public REST endpoint for a demo** — the URL becomes a public
+  contract the moment it ships
+- **Sharing a helper between throwaway and permanent code** — the
+  helper now has two halves of its userbase with different lifetimes
+- **Linking to the harness from documentation** — readers will find
+  it after retirement and assume it's permanent
+
+## Related
+
+- `apps/admin/src/app/watch/demo-keyword-search/` — the canonical example
+- `apps/admin/CLAUDE.md` (R-stage migration playbook section) — context
+  for what R8 cutover means in this codebase
+- `docs/solutions/best-practices/nextjs-server-action-error-redaction-prod-20260430.md`
+  — sibling lesson from the same PR
+- `docs/solutions/integration-issues/algolia-server-key-vs-public-key-cross-domain-20260430.md`
+  — sibling lesson on the Algolia integration choice
+- `docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md`
+  — related guidance on migration-era code

--- a/docs/solutions/integration-issues/algolia-server-key-vs-public-key-cross-domain-20260430.md
+++ b/docs/solutions/integration-issues/algolia-server-key-vs-public-key-cross-domain-20260430.md
@@ -1,0 +1,250 @@
+---
+title: Algolia public key vs server key — choosing correctly when integrating a sister project's index from a different domain
+date: 2026-04-30
+tags: [algolia, integration, api-keys, secrets, nextjs, server-actions]
+category: integration-issues
+severity: medium
+---
+
+## Problem
+
+Project A (admin.jesusfilm.org) wants to query Project B's
+(watch.jesusfilm.org's) Algolia index from server code. Both
+projects have an Algolia integration with two env vars:
+
+- `NEXT_PUBLIC_ALGOLIA_API_KEY` — the public key shipped to the
+  browser
+- `ALGOLIA_SERVER_API_KEY` — the server-only key
+
+The naive integration uses `NEXT_PUBLIC_ALGOLIA_API_KEY` (since
+that's the obvious "search from a browser" key) and gets a `403
+{"message":"Method not allowed with this referer"}` from Algolia
+when called from anywhere outside the source project's domain.
+
+## Symptoms
+
+```bash
+$ curl -X POST "https://APPID-dsn.algolia.net/1/indexes/IDX/query" \
+    -H "X-Algolia-API-Key: <NEXT_PUBLIC_ALGOLIA_API_KEY>" \
+    -H "X-Algolia-Application-Id: APPID" \
+    -d '{"query":"jesus"}'
+{"message":"Method not allowed with this referer","status":403}
+```
+
+The error message is misleading — the request is in fact rejected
+by an Algolia-side **referer allowlist** (and/or `validUntil` /
+`restrictSources` API-key restrictions), not because the HTTP
+method is wrong. Adding spoofed `Referer:` headers to match the
+source domain works in some setups but is fragile and depends on
+how the source project's key was provisioned.
+
+## What Didn't Work
+
+- **Setting `Referer: https://watch.jesusfilm.org/`** — sometimes
+  works (if the public key only restricts referers, not source IPs),
+  often doesn't if the key has tighter restrictions; brittle and
+  trivially bypassed in either direction
+- **Adding the new domain to the public key's allowlist** — requires
+  Algolia console access on the source project, splits the security
+  posture between two domains, and means rotating the public key
+  affects both consumers
+- **Using a different public key** — public keys ship to the browser,
+  so any new key would also be public; doesn't change the security
+  shape
+
+## Solution
+
+**Use the source project's `ALGOLIA_SERVER_API_KEY` from a
+server-side proxy in the integrating project.** The server key has
+no referer/origin restrictions — it's intended for backend code.
+Browser code never sees it.
+
+In Next.js, the cleanest shape is a Server Action:
+
+```ts
+// apps/admin/src/.../algolia-action.ts
+"use server"
+
+import { env } from "@/config/env"
+
+export async function searchAlgolia(args: { q: string; limit: number }) {
+  if (
+    !env.ALGOLIA_APP_ID ||
+    !env.ALGOLIA_SEARCH_API_KEY ||
+    !env.ALGOLIA_INDEX
+  ) {
+    return { ok: false as const, code: "not_configured" }
+  }
+  const url = `https://${env.ALGOLIA_APP_ID}-dsn.algolia.net/1/indexes/${encodeURIComponent(env.ALGOLIA_INDEX)}/query`
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "X-Algolia-API-Key": env.ALGOLIA_SEARCH_API_KEY,
+      "X-Algolia-Application-Id": env.ALGOLIA_APP_ID,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: args.q, hitsPerPage: args.limit }),
+    signal: AbortSignal.timeout(5000),
+    cache: "no-store",
+  })
+  // ... handle response, return discriminated union
+}
+```
+
+Env in admin's `.env`:
+
+```
+ALGOLIA_APP_ID=<from watch project>
+ALGOLIA_SEARCH_API_KEY=<watch project's ALGOLIA_SERVER_API_KEY>
+ALGOLIA_INDEX=<watch project's NEXT_PUBLIC_ALGOLIA_INDEX>
+```
+
+## Why This Works
+
+Algolia API keys carry a server-side ACL bundle that includes:
+
+- **Referer allowlist** (`validReferer`) — which domains may invoke
+  this key from browser code
+- **Index restrictions** (`indexes`) — which indexes the key may query
+- **ACL** — read / write / settings / etc
+- **Rate limits** (`maxQueriesPerIPPerHour`)
+
+The "public" key is provisioned with a tight referer allowlist
+(typically just the source domain) so it can ship to browsers
+without being trivially abusable from anywhere on the internet.
+The "server" key has no referer restriction — it's expected to be
+used from server-side code where the request origin is implicitly
+trusted (the server holds the secret).
+
+Cross-domain integration via the public key is fundamentally
+fighting the security model. Cross-domain integration via the
+server key is fundamentally agreeing with it: the integrator's
+server is now an extension of the source project's trust boundary.
+
+## Caveats and gotchas
+
+### 1. Confirm the "server key" is search-scoped, not admin-scoped
+
+Algolia distinguishes "search-only" admin keys from full admin
+keys. Both can sit in env as `ALGOLIA_SERVER_API_KEY`. A full admin
+key has write/delete/settings ACL — exposing it via any future
+server-side bug (a logged Authorization header, an SSRF, an
+errant error message) widens the blast radius enormously.
+
+**Verify with the source project's owner** which scope the key
+carries. If it's admin-scoped, ask them to provision a
+search-only key for cross-project consumers, OR provision your
+own search-only key against the same App ID with a one-time
+setup pass.
+
+Algolia's API key creation flow makes this easy: from the
+dashboard, "API Keys" → "New API Key" → set ACL to `search` only,
+restrict to the specific index, no referer restriction.
+
+### 2. API keys rotate
+
+Server keys rotate. Public keys rotate. Cached values in your
+local development workflow (env files, doppler-pulled `.env`
+snapshots, hardcoded test fixtures) become invalid silently.
+
+**Always re-pull from the canonical source at write time** —
+not from cached chat history, not from a `.env.local` last
+synced last week, not from a teammate's screenshare. For
+Doppler-managed envs:
+
+```bash
+doppler secrets get ALGOLIA_SERVER_API_KEY \
+  --project <source-project> \
+  --config <env> --plain
+```
+
+For Railway, write through the MCP / dashboard with the freshly
+pulled value.
+
+### 3. Verify the key works against the actual endpoint before deploying
+
+Before pushing the key to Railway / Doppler:
+
+```bash
+KEY=$(doppler secrets get ALGOLIA_SERVER_API_KEY --project watch --config stg --plain)
+curl -s -X POST "https://APPID-dsn.algolia.net/1/indexes/IDX/query" \
+  -H "X-Algolia-API-Key: $KEY" \
+  -H "X-Algolia-Application-Id: APPID" \
+  -d '{"query":"test","hitsPerPage":1}' | head -c 200
+```
+
+A non-403 response confirms the key is live. Skipping this step
+costs ~10-20 minutes per failed deploy cycle while you debug a
+key-mismatch in production.
+
+### 4. Server-action surface vs new public REST route
+
+Prefer Server Actions over `/api/algolia-search` route handlers
+when the consumer is your own UI. Server Actions:
+
+- Don't create an addressable URL contract
+- Don't need rate-limit infrastructure (framework-internal)
+- Disappear cleanly when the calling component is removed (relevant
+  for migration-era harnesses, see related lesson)
+
+If the consumer is a different app, a REST endpoint is fine — but
+add the rate-limit middleware up front.
+
+### 5. Server-action error redaction
+
+Server Action thrown errors are **redacted in production builds**
+(see related lesson). If your action signals "not configured" via
+`throw new Error("not_configured")`, the client will not be able
+to distinguish that from a generic upstream error in prod. Use a
+discriminated-union return shape from day one.
+
+## Prevention
+
+1. **First Algolia integration in the codebase**: document the
+   server-key vs public-key choice in the integration's README or
+   inline comments. Future integrations crib from it.
+2. **Pre-deploy curl probe**: include a one-line curl against the
+   target endpoint with the key being deployed. Catches stale
+   values and ACL mismatches before they reach prod.
+3. **Verify scope**: when accepting a key handoff from another
+   team, ask explicitly "is this search-only or admin-scoped?"
+   Don't assume.
+4. **Don't cache keys across session boundaries**: chat history,
+   shell environment vars, sticky tabs — re-pull at the moment of
+   write.
+
+## Where this bit us
+
+PR #864 (admin Algolia parity column on `/watch/demo-keyword-search`,
+merged 2026-04-30):
+
+- **Initial discovery**: tried `NEXT_PUBLIC_ALGOLIA_API_KEY` from
+  watch's stg config, hit `403 "Method not allowed with this
+referer"` from `admin.jesusfilm.org`. Verified by curl with
+  multiple `Referer:` values — none worked.
+- **Resolution**: switched to watch's `ALGOLIA_SERVER_API_KEY` →
+  immediately worked. Verified with curl returning BibleProject hits.
+- **Caching trap**: pulled the key value early in the session,
+  pushed to Railway via MCP an hour later. By that time the key had
+  rotated. Container deploy succeeded but Algolia returned 403
+  "Invalid Application-ID or API key". Cost: 4 deploy cycles + ~45
+  min before re-pulling from Doppler at the time of the Railway
+  write.
+- **Scope check**: the watch team's `ALGOLIA_SERVER_API_KEY` is
+  documented as "unrestricted" — needs follow-up confirmation that
+  it's search-scoped, not admin-scoped, before going beyond a
+  throwaway harness.
+
+## Related
+
+- [Algolia API key documentation](https://www.algolia.com/doc/guides/security/api-keys/)
+- `docs/solutions/best-practices/nextjs-server-action-error-redaction-prod-20260430.md`
+  — sibling lesson on Server Action failure-mode signaling
+- `docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md`
+  — sibling lesson on migration-era tooling lifetime
+- `docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md`
+  (env-var values variant) — the deployment-side trap that compounded
+  the key-rotation issue in PR #864
+- `apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts`
+  — the concrete server-action implementation (throwaway, slated
+  for R8 retirement)

--- a/docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md
+++ b/docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md
@@ -155,6 +155,52 @@ the fix is `mcp__railway__accept-deploy(environmentId)`. Cancel any
 in-flight redeploy that snapshotted the stale config, then re-trigger
 via `accept-deploy` from a clean state.
 
+## Recurrence — 2026-04-30 (env-var VALUES variant)
+
+This trap bit a third time, this time with an extra wrinkle: the
+staged-patch buffer affects env-var **values**, not just build/deploy
+fields like `startCommand`. Earlier framing pushed the trap as a
+build-config concern, which masked the env-var case.
+
+During the demo-search-keyword + Algolia parity column work
+(PR #864, 2026-04-30), four env vars (`ALGOLIA_APP_ID`,
+`ALGOLIA_SEARCH_API_KEY`, `ALGOLIA_INDEX`,
+`SEARCH_DEBUG_ALLOWED_ORIGINS`) were written via the railway-agent's
+`updateServiceTool`. The agent reported `"applied" / "staged for
+deployment"`, then followed up with its own `deployServiceTool` call
+(equivalent to `redeploy`). Two consecutive deploys
+(`960a674c` → `0b4fe905`) booted containers whose runtime
+threw `Error: algolia_not_configured` — env values absent from
+`process.env` despite `getServiceConfigTool` showing all four KEYS
+present in canonical config.
+
+The masking trap: `getServiceConfigTool` returns
+`{ "ALGOLIA_INDEX": { "value": "<hidden_from_agent>" } }` whether
+the value is committed or staged-but-uncommitted. The KEY appearing
+in canonical config is therefore not evidence the VALUE landed.
+
+Resolution required calling `mcp__railway__accept-deploy(envId)`
+explicitly (the railway-agent doesn't expose this tool through its
+own surface; load it via `ToolSearch select:mcp__railway__accept-deploy`).
+After flush, deploy `50ea8af1` came up — but with a **rotated**
+Algolia key (separate problem; see related Algolia learning), so a
+fourth deploy `29b854a1` was needed with the current Doppler value.
+Total: ~45 minutes + 4 build cycles before the column rendered live.
+
+**The corrected detection rule:** The runtime is the source of
+truth. If logs show empty / missing values when canonical-config
+readback "shows" them set, the staged patch never flushed —
+regardless of whether the keys appear present. Don't trust the
+masked readback alone; verify by hitting an endpoint that exercises
+the value, or grep runtime logs for the symptom.
+
+**Why the railway-agent failure repeats:** the `railway-agent`
+MCP tool reports it doesn't have `accept-deploy` available and
+falls back to `deployServiceTool`. That is wrong for any write that
+includes env vars or build/deploy fields. Always load
+`mcp__railway__accept-deploy` directly via ToolSearch and call it
+yourself when staging via the agent.
+
 ## Related
 
 - PR #804 — feat-104 admin Railway provisioning (where the usage


### PR DESCRIPTION
## Summary

Three new solutions docs + one expansion of the existing Railway staged-patch trap. All four learnings surfaced during the demo-search Algolia parity column work shipped in PR #864 (merged + verified live in prod 2026-04-30).

### New docs

- **`best-practices/nextjs-server-action-error-redaction-prod-20260430.md`** — Throwing typed-string errors from \`use server\` works in dev/test but Next.js redacts \`Error.message\` in prod builds. Client-side string matching silently falls through. Fix: discriminated-union return shape (return values are NOT redacted).

- **`best-practices/throwaway-operator-harness-deletion-contract-20260430.md`** — Five-rule pattern for canary / parity / migration tooling with a known retirement date. Co-locate in one folder, state lifetime in headers + commit, prefer Server Actions over public REST, enumerate every deletion target, don't let soft-fail disguise abandonment.

- **`integration-issues/algolia-server-key-vs-public-key-cross-domain-20260430.md`** — Cross-domain Algolia integration: \`NEXT_PUBLIC_ALGOLIA_API_KEY\` is referer-locked to the source domain (403 from elsewhere); \`ALGOLIA_SERVER_API_KEY\` is unrestricted, intended for backend code. Caveats: confirm search-scoped vs admin-scoped, keys rotate (don't cache across session boundaries), pre-deploy curl probe is cheap insurance.

### Expanded

- **`platform/railway-mcp-staged-config-never-commits-20260420.md`** — Added a third recurrence section. The trap also bites env-var **values**, not just build/deploy fields. \`getServiceConfigTool\`'s \`<hidden_from_agent>\` masking makes a staged-but-uncommitted value indistinguishable from a committed one. The runtime is the source of truth — empty values in logs despite present canonical config means the patch never flushed. Always call \`mcp__railway__accept-deploy\` directly; the railway-agent's \`deployServiceTool\` fallback is wrong for any write that includes env vars.

## Why these are load-bearing

All four bit us live in this session. The Server Action redaction issue made the muted "Algolia disabled" UX dead code in prod (we saw the loud red banner instead). The Railway env-var staged-patch variant cost ~45 min + 4 deploy cycles before the column rendered. The Algolia key rotation invalidated a cached value mid-session. The throwaway-harness contract is what makes the eventual R8 cleanup mechanical instead of archeological.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: docs-only change. Validation is whether the next agent / engineer hitting these failure modes finds the doc and saves the time.

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0