### PR TITLE
feat(web): replace Mux Player chrome with custom React controls on watch page

### DIFF
--- a/apps/web/src/components/FloatingSearchBar.tsx
+++ b/apps/web/src/components/FloatingSearchBar.tsx
@@ -27,9 +27,9 @@ export function FloatingSearchBar() {
       onClick={() => setOpen(true)}
       inert={chromeHidden || undefined}
       aria-hidden={chromeHidden || undefined}
-      className={`fixed left-[calc(50%+8px)] z-50 -translate-x-1/2 rounded-[35px] bg-white/10 px-6 py-3 text-left text-white shadow-xl outline-1 outline-white/20 backdrop-blur-[10px] transition-[top,opacity] duration-300 ease-out w-[calc(100%-2rem)] sm:w-[calc(100%-3rem)] max-w-[810px] focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2 ${topClass} ${openClass}`}
+      className={`fixed left-[calc(50%+8px)] z-50 -translate-x-1/2 rounded-[35px] bg-white/10 px-6 py-3 text-left text-white shadow-xl outline-1 outline-white/20 backdrop-blur-[10px] transition-[top,opacity] duration-300 ease-out w-[calc(100%-2rem)] sm:w-[calc(100%-3rem)] max-w-[810px] [text-shadow:0_1px_3px_rgba(0,0,0,0.5)] focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2 ${topClass} ${openClass}`}
     >
-      <span className={isPlaceholder ? "text-white/70" : "text-white"}>
+      <span className={isPlaceholder ? "text-white/90" : "text-white"}>
         {display}
       </span>
     </button>

--- a/apps/web/src/components/SearchOverlay.tsx
+++ b/apps/web/src/components/SearchOverlay.tsx
@@ -169,7 +169,7 @@ export function SearchOverlay() {
             onChange={handleInputChange}
             placeholder="Search or browse topics…"
             aria-label="Search videos by keyword"
-            className="w-full rounded-[35px] bg-white/10 py-3 pl-6 pr-12 text-base text-white shadow-xl outline-1 outline-white/20 backdrop-blur-[10px] placeholder:text-white/70 focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2"
+            className="w-full rounded-[35px] bg-white/10 py-3 pl-6 pr-12 text-base text-white shadow-xl outline-1 outline-white/20 backdrop-blur-[10px] placeholder:text-white/90 [text-shadow:0_1px_3px_rgba(0,0,0,0.5)] focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2"
           />
           {hasQuery && (
             <button

--- a/apps/web/src/components/watch/ChromeButton.tsx
+++ b/apps/web/src/components/watch/ChromeButton.tsx
@@ -1,0 +1,34 @@
+// Round 44px chrome button used by HeroPlayerControls for play, mute,
+// fullscreen. Black/30 background, white icon, slight darken on hover.
+
+export function ChromeButton({
+  children,
+  onClick,
+  ariaLabel,
+  testId,
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  ariaLabel: string
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-black/30 text-white transition hover:bg-black/55"
+    >
+      {children}
+    </button>
+  )
+}
+
+export function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "0:00"
+  const total = Math.floor(seconds)
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${s.toString().padStart(2, "0")}`
+}

--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -8,6 +8,8 @@ import type { MuxCSSProperties } from "@mux/mux-player-react"
 import { env } from "@/env"
 import type { WatchHeroPlayerBlock } from "@/lib/content"
 import { getViewerId } from "@/lib/viewer-id"
+import { HeroPlayerControls } from "./HeroPlayerControls"
+import { MutedSpeakerIcon, UnmutedSpeakerIcon } from "./chrome-icons"
 
 type PillState = "play-with-sound" | "tap-to-unmute"
 
@@ -21,6 +23,8 @@ function getViewerIdServerSnapshot(): string {
   return ""
 }
 
+// Mux Player's chrome stays hidden at all times — we render our own
+// React-based chrome via <HeroPlayerControls />.
 // CSS Custom Properties: https://github.com/muxinc/elements/blob/main/packages/mux-player/REFERENCE.md
 const CHROME_HIDE_STYLE: MuxCSSProperties = {
   "--controls": "none",
@@ -37,11 +41,14 @@ export function HeroPlayer({
   onPlayerReady?: (player: MuxPlayerRef | null) => void
 }) {
   const { video, variant } = block
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
   const playerRef = useRef<MuxPlayerRef | null>(null)
+  const [player, setPlayer] = useState<MuxPlayerRef | null>(null)
   const setPlayerRef = useCallback(
-    (player: MuxPlayerRef | null) => {
-      playerRef.current = player
-      onPlayerReady?.(player)
+    (next: MuxPlayerRef | null) => {
+      playerRef.current = next
+      setPlayer(next)
+      onPlayerReady?.(next)
     },
     [onPlayerReady],
   )
@@ -77,7 +84,16 @@ export function HeroPlayer({
     if (!player) return
 
     if (pillState === "tap-to-unmute") {
+      // Autoplay was blocked — this gesture both unmutes AND starts playback
+      // since the user is now committed. Without play() the user just
+      // unmuted a still-paused video.
       player.muted = false
+      const tapResult = player.play()
+      if (tapResult && typeof tapResult.then === "function") {
+        tapResult.catch((err: unknown) => {
+          console.warn("[HeroPlayer] tap-to-unmute play() rejected", err)
+        })
+      }
       setChromeRevealed(true)
       return
     }
@@ -109,12 +125,12 @@ export function HeroPlayer({
   const playbackId = variant.muxVideo?.playbackId ?? undefined
   const hlsSrc = variant.hls ?? undefined
 
-  const playerStyle = chromeRevealed ? undefined : CHROME_HIDE_STYLE
   const loop = !chromeRevealed
   const muted = !chromeRevealed
 
   return (
     <div
+      ref={wrapperRef}
       data-block-type="HeroPlayer"
       data-testid="hero-player-wrapper"
       data-chrome-revealed={chromeRevealed ? "true" : "false"}
@@ -136,76 +152,69 @@ export function HeroPlayer({
           video_id: video.documentId,
           viewer_user_id: viewerUserId,
         }}
-        style={playerStyle}
+        style={CHROME_HIDE_STYLE}
         onLoadedMetadata={handleLoadedMetadata}
         onError={handlePlayerError}
         className="block h-full w-full"
       />
 
-      {!chromeRevealed && (
-        <button
-          type="button"
-          data-testid="hero-player-unmute-pill"
-          data-state={pillState}
-          onClick={handleUnmuteClick}
-          className={
-            pillState === "tap-to-unmute"
-              ? "absolute bottom-6 left-1/2 inline-flex -translate-x-1/2 items-center gap-2 rounded-full bg-amber-500 px-5 py-3 text-sm font-semibold text-stone-950 shadow-lg ring-2 ring-amber-300/60 transition hover:bg-amber-400"
-              : "absolute bottom-6 left-1/2 inline-flex -translate-x-1/2 items-center gap-2 rounded-full bg-white/95 px-5 py-3 text-sm font-semibold text-stone-900 shadow-lg transition hover:bg-white"
-          }
-        >
-          {pillState === "tap-to-unmute" ? (
-            <MutedSpeakerIcon />
-          ) : (
-            <UnmutedSpeakerIcon />
-          )}
-          <span>
-            {pillState === "tap-to-unmute"
-              ? "Tap to Unmute"
-              : "Play with Sound"}
-          </span>
-        </button>
+      {chromeRevealed ? (
+        <HeroPlayerControls
+          player={player}
+          playerRef={playerRef}
+          wrapperRef={wrapperRef}
+        />
+      ) : (
+        <>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/80 via-black/40 to-transparent"
+          />
+          <div
+            data-testid="hero-player-overlay"
+            className="absolute right-6 bottom-6 left-10 flex flex-col items-start gap-4 md:right-auto md:left-16 xl:left-24"
+          >
+            {video.label ? (
+              <span
+                data-testid="hero-player-overlay-label"
+                className="text-sm font-semibold tracking-wider text-amber-400 uppercase md:text-base"
+              >
+                {video.label}
+              </span>
+            ) : null}
+            {video.title ? (
+              <h1
+                data-testid="hero-player-overlay-title"
+                className="text-4xl font-bold text-white drop-shadow-lg whitespace-nowrap md:text-6xl xl:text-7xl"
+              >
+                {video.title}
+              </h1>
+            ) : null}
+            <button
+              type="button"
+              data-testid="hero-player-unmute-pill"
+              data-state={pillState}
+              onClick={handleUnmuteClick}
+              className={
+                pillState === "tap-to-unmute"
+                  ? "inline-flex items-center gap-3 rounded-full bg-amber-500 px-7 py-2.5 text-base font-semibold text-stone-950 shadow-lg ring-2 ring-amber-300/60 transition hover:bg-amber-400 md:px-8 md:py-3 md:text-lg"
+                  : "inline-flex items-center gap-3 rounded-full bg-red-600 px-7 py-2.5 text-base font-semibold text-white shadow-lg transition hover:bg-red-500 md:px-8 md:py-3 md:text-lg"
+              }
+            >
+              {pillState === "tap-to-unmute" ? (
+                <MutedSpeakerIcon />
+              ) : (
+                <UnmutedSpeakerIcon />
+              )}
+              <span>
+                {pillState === "tap-to-unmute"
+                  ? "Tap to Unmute"
+                  : "Play with Sound"}
+              </span>
+            </button>
+          </div>
+        </>
       )}
     </div>
-  )
-}
-
-function UnmutedSpeakerIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      width={18}
-      height={18}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M11 5 6 9H2v6h4l5 4V5z" />
-      <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
-      <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
-    </svg>
-  )
-}
-
-function MutedSpeakerIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      width={18}
-      height={18}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M11 5 6 9H2v6h4l5 4V5z" />
-      <line x1="22" y1="9" x2="16" y2="15" />
-      <line x1="16" y1="9" x2="22" y2="15" />
-    </svg>
   )
 }

--- a/apps/web/src/components/watch/HeroPlayerControls.tsx
+++ b/apps/web/src/components/watch/HeroPlayerControls.tsx
@@ -1,0 +1,543 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { MuxPlayerRef } from "@forge/video-player"
+
+import { ChromeButton, formatTime } from "./ChromeButton"
+import {
+  ChromeMutedIcon,
+  ChromeVolumeIcon,
+  EnterFullscreenIcon,
+  ExitFullscreenIcon,
+  PauseIcon,
+  PlayIcon,
+} from "./chrome-icons"
+
+export function HeroPlayerControls({
+  player,
+  playerRef,
+  wrapperRef,
+}: {
+  player: MuxPlayerRef | null
+  playerRef: React.RefObject<MuxPlayerRef | null>
+  wrapperRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const [playing, setPlaying] = useState(false)
+  const [muted, setMuted] = useState(false)
+  const [volume, setVolume] = useState(1)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [bufferedPct, setBufferedPct] = useState(0)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [controlsVisible, setControlsVisible] = useState(true)
+  const [hoveringControls, setHoveringControls] = useState(false)
+  const [volumeOpen, setVolumeOpen] = useState(false)
+  const [volumeDragging, setVolumeDragging] = useState(false)
+  const timelineRef = useRef<HTMLDivElement | null>(null)
+  const volumeTrackRef = useRef<HTMLDivElement | null>(null)
+  const hideTimerRef = useRef<number | null>(null)
+
+  // Refs let scheduleHide read the latest playing/hovering state without
+  // resubscribing the wrapper-level mousemove listener on every render.
+  // Writes happen in commit-phase effects so concurrent rendering replays
+  // can't leave the refs in interim/abandoned states.
+  const playingRef = useRef(false)
+  const hoveringControlsRef = useRef(false)
+  useEffect(() => {
+    playingRef.current = playing
+  }, [playing])
+  useEffect(() => {
+    hoveringControlsRef.current = hoveringControls
+  }, [hoveringControls])
+
+  const volumeDraggingRef = useRef(false)
+  useEffect(() => {
+    volumeDraggingRef.current = volumeDragging
+  }, [volumeDragging])
+
+  const scheduleHide = useCallback(() => {
+    if (hideTimerRef.current != null) {
+      window.clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+    // Don't auto-hide while playing-paused, while user hovers controls, or
+    // while user is actively dragging the volume slider — losing the slider
+    // mid-drag drops pointer capture and leaves volumeDragging stuck.
+    if (
+      !playingRef.current ||
+      hoveringControlsRef.current ||
+      volumeDraggingRef.current
+    ) {
+      return
+    }
+    hideTimerRef.current = window.setTimeout(() => {
+      setControlsVisible(false)
+      hideTimerRef.current = null
+    }, 3000)
+  }, [])
+
+  const showControls = useCallback(() => {
+    setControlsVisible(true)
+    scheduleHide()
+  }, [scheduleHide])
+
+  useEffect(() => {
+    if (!player || typeof player.addEventListener !== "function") return
+
+    const sync = () => {
+      setPlaying(!player.paused)
+      setMuted(!!player.muted)
+      const v = player.volume
+      setVolume(Number.isFinite(v) ? v : 1)
+      setCurrentTime(player.currentTime)
+      const d = player.duration
+      setDuration(Number.isFinite(d) ? d : 0)
+      const b = player.buffered
+      if (b && b.length > 0 && d && Number.isFinite(d) && d > 0) {
+        try {
+          const end = b.end(b.length - 1)
+          setBufferedPct(Math.min(100, (end / d) * 100))
+        } catch {
+          // TimeRanges can throw InvalidStateError mid-seek; ignore until next progress.
+        }
+      } else {
+        setBufferedPct(0)
+      }
+    }
+
+    sync()
+    const events = [
+      "timeupdate",
+      "durationchange",
+      "loadedmetadata",
+      "play",
+      "pause",
+      "volumechange",
+      "progress",
+    ] as const
+    events.forEach((e) => player.addEventListener(e, sync))
+    return () => {
+      events.forEach((e) => player.removeEventListener(e, sync))
+    }
+  }, [player])
+
+  useEffect(() => {
+    const handleFsChange = () => {
+      const fsEl =
+        document.fullscreenElement ??
+        (document as Document & { webkitFullscreenElement?: Element | null })
+          .webkitFullscreenElement
+      setIsFullscreen(!!fsEl)
+    }
+    document.addEventListener("fullscreenchange", handleFsChange)
+    document.addEventListener("webkitfullscreenchange", handleFsChange)
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFsChange)
+      document.removeEventListener("webkitfullscreenchange", handleFsChange)
+    }
+  }, [])
+
+  // When playing/hovering state changes, reschedule (or cancel) the hide
+  // timer. The mousemove listener also calls scheduleHide on every move,
+  // which is what actually keeps the auto-hide working repeatedly. Cleanup
+  // also covers unmount — scheduleHide cancels any pending timer.
+  useEffect(() => {
+    scheduleHide()
+    return () => {
+      if (hideTimerRef.current != null) {
+        window.clearTimeout(hideTimerRef.current)
+        hideTimerRef.current = null
+      }
+    }
+  }, [playing, hoveringControls, scheduleHide])
+
+  // Reveal chrome on any user interaction inside the player wrapper.
+  // pointermove unifies mouse + pen + touch; keydown keeps chrome up while
+  // arrow-key seeking the timeline or volume slider.
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+    const reveal = () => showControls()
+    wrapper.addEventListener("pointermove", reveal)
+    wrapper.addEventListener("touchmove", reveal)
+    wrapper.addEventListener("touchstart", reveal)
+    wrapper.addEventListener("click", reveal)
+    wrapper.addEventListener("keydown", reveal)
+    return () => {
+      wrapper.removeEventListener("pointermove", reveal)
+      wrapper.removeEventListener("touchmove", reveal)
+      wrapper.removeEventListener("touchstart", reveal)
+      wrapper.removeEventListener("click", reveal)
+      wrapper.removeEventListener("keydown", reveal)
+    }
+  }, [wrapperRef, showControls])
+
+  // Hide the OS cursor when chrome auto-hides — sibling cursor styles aren't
+  // enough to win over mux-player's own shadow-DOM styling, so set cursor on
+  // the wrapper element directly. Cursor inherits to descendants by default.
+  // Snapshot any prior cursor value so cleanup restores the wrapper to the
+  // state it was in (rather than clobbering an external writer's value).
+  const wrapperCursorRef = useRef<string | null>(null)
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+    if (wrapperCursorRef.current === null) {
+      wrapperCursorRef.current = wrapper.style.cursor
+    }
+    wrapper.style.cursor = controlsVisible ? wrapperCursorRef.current : "none"
+    return () => {
+      if (wrapperCursorRef.current !== null) {
+        wrapper.style.cursor = wrapperCursorRef.current
+      }
+    }
+  }, [controlsVisible, wrapperRef])
+
+  const togglePlay = useCallback(() => {
+    const p = playerRef.current
+    if (!p) return
+    if (p.paused) {
+      p.play()?.catch((err: unknown) => {
+        console.warn("[HeroPlayer] play() rejected", err)
+      })
+    } else {
+      p.pause()
+    }
+  }, [playerRef])
+
+  const toggleMute = useCallback(() => {
+    const p = playerRef.current
+    if (!p) return
+    // If volume was dragged to 0, clicking unmute bumps it back to a usable level.
+    if (p.muted && p.volume === 0) {
+      p.volume = 0.5
+    }
+    p.muted = !p.muted
+  }, [playerRef])
+
+  const setPlayerVolume = useCallback(
+    (vol: number) => {
+      const p = playerRef.current
+      if (!p) return
+      const clamped = Math.min(1, Math.max(0, vol))
+      p.volume = clamped
+      // Mute/unmute heuristic — intentional YouTube-style behavior:
+      //   * Volume === 0 implies muted (treat as muted regardless of how it
+      //     got there — drag, keyboard, or click on a 0-volume slider).
+      //   * Any positive volume implies unmuted (so dragging the slider is
+      //     always audible — overrides a prior explicit mute).
+      // The trade-off is that an explicitly-muted user who later interacts
+      // with the slider hears sound. Product-validated decision; if user
+      // research flips, swap to a 0->positive transition guard.
+      if (clamped === 0 && !p.muted) {
+        p.muted = true
+      } else if (clamped > 0 && p.muted) {
+        p.muted = false
+      }
+    },
+    [playerRef],
+  )
+
+  const computeVolumeFromClientX = useCallback((clientX: number): number => {
+    const track = volumeTrackRef.current
+    if (!track) return 0
+    const rect = track.getBoundingClientRect()
+    if (rect.width <= 0) return 0
+    return Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+  }, [])
+
+  const handleVolumePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.stopPropagation()
+      setVolumeDragging(true)
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId)
+      } catch {
+        // pointer may have been released before capture acquired
+      }
+      setPlayerVolume(computeVolumeFromClientX(e.clientX))
+    },
+    [computeVolumeFromClientX, setPlayerVolume],
+  )
+
+  const handleVolumePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!volumeDragging) return
+      setPlayerVolume(computeVolumeFromClientX(e.clientX))
+    },
+    [volumeDragging, computeVolumeFromClientX, setPlayerVolume],
+  )
+
+  const handleVolumePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      setVolumeDragging(false)
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      }
+    },
+    [],
+  )
+
+  // If the OS revokes pointer capture (page hidden, touch preempted,
+  // container collapses) the regular pointerup never fires — reset the
+  // drag flag explicitly so auto-hide can resume and the next pointerdown
+  // works correctly.
+  const handleVolumeLostPointerCapture = useCallback(() => {
+    setVolumeDragging(false)
+  }, [])
+
+  const handleVolumeKey = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const p = playerRef.current
+      if (!p) return
+      const step = e.shiftKey ? 0.1 : 0.05
+      // Use the displayed volume (0 while muted) as the base so keyboard
+      // adjustments operate on what the user sees, not a hidden value.
+      const base = p.muted ? 0 : p.volume
+      if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+        e.preventDefault()
+        setPlayerVolume(base + step)
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+        e.preventDefault()
+        setPlayerVolume(base - step)
+      }
+    },
+    [playerRef, setPlayerVolume],
+  )
+
+  const toggleFullscreen = useCallback(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+    const doc = document as Document & {
+      webkitFullscreenElement?: Element | null
+      webkitExitFullscreen?: () => Promise<void> | undefined
+    }
+    const wrapperEl = wrapper as HTMLDivElement & {
+      webkitRequestFullscreen?: () => Promise<void> | undefined
+    }
+    const isFs = !!(document.fullscreenElement ?? doc.webkitFullscreenElement)
+    if (isFs) {
+      const exit = document.exitFullscreen?.() ?? doc.webkitExitFullscreen?.()
+      if (exit && typeof exit.then === "function") {
+        exit.catch((err: unknown) => {
+          console.warn("[HeroPlayer] exitFullscreen rejected", err)
+        })
+      }
+    } else {
+      const req =
+        wrapperEl.requestFullscreen?.() ?? wrapperEl.webkitRequestFullscreen?.()
+      if (req && typeof req.then === "function") {
+        req.catch((err: unknown) => {
+          console.warn("[HeroPlayer] requestFullscreen rejected", err)
+        })
+      }
+    }
+  }, [wrapperRef])
+
+  const seekToClientX = useCallback(
+    (clientX: number) => {
+      const p = playerRef.current
+      const track = timelineRef.current
+      if (!p || !track || !duration) return
+      const rect = track.getBoundingClientRect()
+      const pct = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+      p.currentTime = pct * duration
+    },
+    [playerRef, duration],
+  )
+
+  const handleTimelineClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      seekToClientX(e.clientX)
+    },
+    [seekToClientX],
+  )
+
+  const handleTimelineKey = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const p = playerRef.current
+      if (!p) return
+      // Always preventDefault for the keys we own so the slider role doesn't
+      // produce silent no-ops while duration is still loading.
+      const ownedKeys = [
+        "ArrowRight",
+        "ArrowLeft",
+        "Home",
+        "End",
+        "PageUp",
+        "PageDown",
+      ] as const
+      if (!ownedKeys.includes(e.key as (typeof ownedKeys)[number])) return
+      e.preventDefault()
+      if (!duration) return
+      const arrowStep = e.shiftKey ? 10 : 5
+      const pageStep = 30
+      const cur = p.currentTime
+      if (e.key === "ArrowRight") {
+        p.currentTime = Math.min(duration, cur + arrowStep)
+      } else if (e.key === "ArrowLeft") {
+        p.currentTime = Math.max(0, cur - arrowStep)
+      } else if (e.key === "PageUp") {
+        p.currentTime = Math.min(duration, cur + pageStep)
+      } else if (e.key === "PageDown") {
+        p.currentTime = Math.max(0, cur - pageStep)
+      } else if (e.key === "Home") {
+        p.currentTime = 0
+      } else if (e.key === "End") {
+        p.currentTime = duration
+      }
+    },
+    [playerRef, duration],
+  )
+
+  const progressPct =
+    duration > 0 ? Math.min(100, (currentTime / duration) * 100) : 0
+
+  return (
+    <>
+      {/* Click target only — the canonical "Play/Pause" affordance for AT
+          users is the chrome's hero-chrome-play button. aria-hidden keeps
+          this surface out of the accessibility tree so it doesn't duplicate. */}
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        data-testid="hero-player-click-surface"
+        data-playing={playing ? "true" : "false"}
+        onClick={togglePlay}
+        className={`absolute inset-0 z-0 focus:outline-none ${
+          controlsVisible ? "cursor-pointer" : "cursor-none"
+        }`}
+      />
+      <div
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-black/85 via-black/45 to-transparent transition-opacity duration-300 ${
+          controlsVisible ? "opacity-100" : "opacity-0"
+        }`}
+      />
+      {/* Chrome stays pointer-active even when invisible so agent-driven and
+          keyboard interactions reach the controls — the wrapper-level reveal
+          listeners then bring it back to opacity-100 on the next interaction. */}
+      <div
+        data-testid="hero-player-custom-chrome"
+        data-visible={controlsVisible ? "true" : "false"}
+        onMouseEnter={() => setHoveringControls(true)}
+        onMouseLeave={() => setHoveringControls(false)}
+        className={`absolute bottom-0 left-1/2 z-10 flex w-3/5 -translate-x-1/2 items-center gap-3 pb-6 transition-opacity duration-300 md:gap-4 md:pb-7 ${
+          controlsVisible ? "opacity-100" : "opacity-0"
+        }`}
+      >
+        <ChromeButton
+          onClick={togglePlay}
+          ariaLabel={playing ? "Pause" : "Play"}
+          testId="hero-chrome-play"
+        >
+          {playing ? <PauseIcon /> : <PlayIcon />}
+        </ChromeButton>
+
+        <div
+          ref={timelineRef}
+          role="slider"
+          tabIndex={0}
+          aria-label="Seek"
+          aria-valuemin={0}
+          aria-valuemax={Math.max(0, Math.floor(duration))}
+          aria-valuenow={Math.floor(currentTime)}
+          aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
+          data-testid="hero-chrome-timeline"
+          onClick={handleTimelineClick}
+          onKeyDown={handleTimelineKey}
+          className="group relative h-1 flex-1 cursor-pointer rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
+        >
+          <div
+            className="absolute inset-y-0 left-0 rounded-l-full bg-white/40"
+            style={{ width: `${bufferedPct}%` }}
+          />
+          <div
+            className="absolute inset-y-0 left-0 rounded-l-full bg-[#cb333b]"
+            style={{ width: `${progressPct}%` }}
+          />
+          <div
+            className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#cb333b] opacity-0 shadow transition group-hover:opacity-100 group-focus:opacity-100"
+            style={{ left: `${progressPct}%` }}
+          />
+        </div>
+
+        <div
+          data-testid="hero-chrome-time"
+          data-current-time={Math.floor(currentTime)}
+          data-duration={Math.floor(duration)}
+          className="shrink-0 text-sm font-medium tabular-nums text-white drop-shadow md:text-base"
+        >
+          {formatTime(currentTime)} / {formatTime(duration)}
+        </div>
+
+        <div
+          className="relative flex shrink-0 items-center"
+          onMouseEnter={() => setVolumeOpen(true)}
+          onMouseLeave={() => setVolumeOpen(false)}
+          onFocus={() => setVolumeOpen(true)}
+          onBlur={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+              setVolumeOpen(false)
+            }
+          }}
+        >
+          <ChromeButton
+            onClick={toggleMute}
+            ariaLabel={muted || volume === 0 ? "Unmute" : "Mute"}
+            testId="hero-chrome-mute"
+          >
+            {muted || volume === 0 ? <ChromeMutedIcon /> : <ChromeVolumeIcon />}
+          </ChromeButton>
+          <div
+            data-testid="hero-chrome-volume-container"
+            data-open={volumeOpen || volumeDragging ? "true" : "false"}
+            className={`overflow-hidden transition-[width,margin] duration-200 ease-out ${
+              volumeOpen || volumeDragging ? "ml-2 w-24" : "ml-0 w-0"
+            }`}
+          >
+            <div
+              ref={volumeTrackRef}
+              role="slider"
+              tabIndex={0}
+              aria-label="Volume"
+              data-testid="hero-chrome-volume-slider"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round((muted ? 0 : volume) * 100)}
+              aria-valuetext={`${Math.round((muted ? 0 : volume) * 100)} percent`}
+              onPointerDown={handleVolumePointerDown}
+              onPointerMove={handleVolumePointerMove}
+              onPointerUp={handleVolumePointerUp}
+              onPointerCancel={handleVolumePointerUp}
+              onLostPointerCapture={handleVolumeLostPointerCapture}
+              onKeyDown={handleVolumeKey}
+              className="group relative h-1 w-full cursor-pointer touch-none rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
+            >
+              <div
+                className="absolute inset-y-0 left-0 rounded-l-full bg-white"
+                style={{ width: `${(muted ? 0 : volume) * 100}%` }}
+              />
+              <div
+                className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow transition ${
+                  muted || volume === 0
+                    ? "opacity-0"
+                    : "opacity-0 group-hover:opacity-100 group-focus:opacity-100"
+                }`}
+                style={{ left: `${(muted ? 0 : volume) * 100}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <ChromeButton
+          onClick={toggleFullscreen}
+          ariaLabel={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+          testId="hero-chrome-fullscreen"
+        >
+          {isFullscreen ? <ExitFullscreenIcon /> : <EnterFullscreenIcon />}
+        </ChromeButton>
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -31,9 +31,13 @@ const { muxPlayerMock, mockPlayerRef } = vi.hoisted(() => {
     currentTime: number
     paused: boolean
     duration: number
+    volume: number
     loop: boolean
+    buffered: TimeRanges | null
     play: ReturnType<typeof vi.fn>
     pause: ReturnType<typeof vi.fn>
+    addEventListener: ReturnType<typeof vi.fn>
+    removeEventListener: ReturnType<typeof vi.fn>
   }
 
   // Singleton ref proxy — tests reset its fields in `beforeEach`.
@@ -44,9 +48,13 @@ const { muxPlayerMock, mockPlayerRef } = vi.hoisted(() => {
       currentTime: 0,
       paused: false,
       duration: 60,
+      volume: 1,
       loop: true,
+      buffered: null,
       play: vi.fn(() => Promise.resolve()),
       pause: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
     }
   }
 
@@ -226,7 +234,7 @@ describe("HeroPlayer — iOS-safe click sequence (AE1)", () => {
     expect(mockPlayerRef.current?.play).toHaveBeenCalledTimes(1)
   })
 
-  it("on play() success: reveals chrome (data-chrome-revealed=true) and disables loop", async () => {
+  it("on play() success: reveals custom chrome (data-chrome-revealed=true), disables loop, and keeps Mux chrome hidden", async () => {
     act(() => {
       root.render(<HeroPlayer block={makeBlock()} />)
     })
@@ -239,19 +247,25 @@ describe("HeroPlayer — iOS-safe click sequence (AE1)", () => {
       pill.click()
     })
 
-    // After successful play, the unmute pill is gone (or pill state is
-    // 'revealed') and the wrapper exposes data-chrome-revealed.
     const wrapper = container.querySelector(
       '[data-testid="hero-player-wrapper"]',
     ) as HTMLElement
     expect(wrapper.getAttribute("data-chrome-revealed")).toBe("true")
 
-    // Re-rendered MuxPlayer should now have `loop=false` and no chrome-hide
-    // CSS variables.
+    // The unmute pill is gone, replaced by our custom chrome.
+    expect(
+      container.querySelector('[data-testid="hero-player-unmute-pill"]'),
+    ).toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-player-custom-chrome"]'),
+    ).not.toBeNull()
+
+    // Re-rendered MuxPlayer should now have `loop=false`, but Mux's native
+    // chrome stays hidden — we render our own React-based chrome on top.
     const props = lastMuxProps()
     expect(props.loop).toBe(false)
     const style = (props.style as Record<string, string | undefined>) ?? {}
-    expect(style?.["--controls"]).toBeUndefined()
+    expect(style?.["--controls"]).toBe("none")
   })
 
   it("on play() rejection (iOS NotAllowedError): pill switches to 'Tap to Unmute' (visually distinct)", async () => {
@@ -261,9 +275,13 @@ describe("HeroPlayer — iOS-safe click sequence (AE1)", () => {
       currentTime: 0,
       paused: false,
       duration: 60,
+      volume: 1,
       loop: true,
+      buffered: null,
       play: vi.fn(() => Promise.reject(new Error("NotAllowedError"))),
       pause: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
     } as never
 
     act(() => {
@@ -304,4 +322,310 @@ describe("HeroPlayer — fallback HLS source", () => {
     expect(props.playbackId).toBeUndefined()
     expect(props.src).toBe("https://cdn.example/jesus.m3u8")
   })
+})
+
+// ---------------------------------------------------------------------------
+// Custom chrome (HeroPlayerControls) — added in the chrome-revamp work.
+// Helpers + suite cover render, button wiring, timeline keyboard seek,
+// volume slider mute/unmute heuristics, and the auto-hide timer lifecycle.
+// ---------------------------------------------------------------------------
+
+async function revealChrome(): Promise<void> {
+  act(() => {
+    root.render(<HeroPlayer block={makeBlock()} />)
+  })
+  const pill = container.querySelector(
+    '[data-testid="hero-player-unmute-pill"]',
+  ) as HTMLButtonElement
+  await act(async () => {
+    pill.click()
+  })
+}
+
+describe("HeroPlayer — custom chrome render", () => {
+  it("renders the full chrome element set after Play with Sound", async () => {
+    await revealChrome()
+    expect(
+      container.querySelector('[data-testid="hero-player-custom-chrome"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-player-click-surface"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-chrome-play"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-chrome-mute"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-chrome-fullscreen"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-chrome-timeline"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-chrome-volume-slider"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="hero-chrome-time"]'),
+    ).not.toBeNull()
+  })
+
+  it("removes the unmute pill once chrome is revealed", async () => {
+    await revealChrome()
+    expect(
+      container.querySelector('[data-testid="hero-player-unmute-pill"]'),
+    ).toBeNull()
+  })
+})
+
+describe("HeroPlayer — chrome button interactions", () => {
+  it("play button calls pause() when player is currently playing", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) mockPlayerRef.current.paused = false
+    mockPlayerRef.current?.pause.mockClear()
+    const playBtn = container.querySelector(
+      '[data-testid="hero-chrome-play"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      playBtn.click()
+    })
+    expect(mockPlayerRef.current?.pause).toHaveBeenCalled()
+  })
+
+  it("click-surface toggles play state when paused", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) mockPlayerRef.current.paused = true
+    mockPlayerRef.current?.play.mockClear()
+    const surface = container.querySelector(
+      '[data-testid="hero-player-click-surface"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      surface.click()
+    })
+    expect(mockPlayerRef.current?.play).toHaveBeenCalled()
+  })
+
+  it("mute button toggles player.muted", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) mockPlayerRef.current.muted = false
+    const muteBtn = container.querySelector(
+      '[data-testid="hero-chrome-mute"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      muteBtn.click()
+    })
+    expect(mockPlayerRef.current?.muted).toBe(true)
+  })
+
+  it("mute button at volume=0 bumps volume to 0.5 on unmute", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.muted = true
+      mockPlayerRef.current.volume = 0
+    }
+    const muteBtn = container.querySelector(
+      '[data-testid="hero-chrome-mute"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      muteBtn.click()
+    })
+    expect(mockPlayerRef.current?.volume).toBe(0.5)
+    expect(mockPlayerRef.current?.muted).toBe(false)
+  })
+})
+
+describe("HeroPlayer — timeline keyboard seek", () => {
+  it("ArrowRight seeks +5s; +Shift seeks +10s; clamps at duration", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.currentTime = 10
+      mockPlayerRef.current.duration = 60
+    }
+    const tl = container.querySelector(
+      '[data-testid="hero-chrome-timeline"]',
+    ) as HTMLDivElement
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(15)
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowRight",
+          shiftKey: true,
+          bubbles: true,
+        }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(25)
+    if (mockPlayerRef.current) mockPlayerRef.current.currentTime = 58
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowRight",
+          shiftKey: true,
+          bubbles: true,
+        }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(60)
+  })
+
+  it("ArrowLeft seeks -5s and clamps at 0", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) mockPlayerRef.current.currentTime = 3
+    const tl = container.querySelector(
+      '[data-testid="hero-chrome-timeline"]',
+    ) as HTMLDivElement
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(0)
+  })
+
+  it("Home jumps to 0; End jumps to duration", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.currentTime = 30
+      mockPlayerRef.current.duration = 60
+    }
+    const tl = container.querySelector(
+      '[data-testid="hero-chrome-timeline"]',
+    ) as HTMLDivElement
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Home", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(0)
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "End", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(60)
+  })
+
+  it("PageUp/PageDown seek by 30s", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.currentTime = 30
+      mockPlayerRef.current.duration = 120
+    }
+    const tl = container.querySelector(
+      '[data-testid="hero-chrome-timeline"]',
+    ) as HTMLDivElement
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "PageUp", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(60)
+    await act(async () => {
+      tl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "PageDown", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.currentTime).toBe(30)
+  })
+
+  it.todo(
+    "ignores arrow keys when duration is 0 (still preventDefaults) — needs mock listener-invocation upgrade so React state syncs to mock changes",
+  )
+})
+
+describe("HeroPlayer — volume slider keyboard", () => {
+  it("ArrowUp raises volume by 0.05; +Shift raises by 0.10", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.muted = false
+      mockPlayerRef.current.volume = 0.5
+    }
+    const slider = container.querySelector(
+      '[data-testid="hero-chrome-volume-slider"]',
+    ) as HTMLDivElement
+    await act(async () => {
+      slider.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.volume).toBeCloseTo(0.55, 5)
+    await act(async () => {
+      slider.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowUp",
+          shiftKey: true,
+          bubbles: true,
+        }),
+      )
+    })
+    expect(mockPlayerRef.current?.volume).toBeCloseTo(0.65, 5)
+  })
+
+  it("ArrowDown clamps at 0 and auto-mutes", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.muted = false
+      mockPlayerRef.current.volume = 0.03
+    }
+    const slider = container.querySelector(
+      '[data-testid="hero-chrome-volume-slider"]',
+    ) as HTMLDivElement
+    await act(async () => {
+      slider.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.volume).toBe(0)
+    expect(mockPlayerRef.current?.muted).toBe(true)
+  })
+
+  it("Raising volume from muted state auto-unmutes", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.muted = true
+      mockPlayerRef.current.volume = 0
+    }
+    const slider = container.querySelector(
+      '[data-testid="hero-chrome-volume-slider"]',
+    ) as HTMLDivElement
+    await act(async () => {
+      slider.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+      )
+    })
+    expect(mockPlayerRef.current?.muted).toBe(false)
+    expect(mockPlayerRef.current?.volume).toBeCloseTo(0.05, 5)
+  })
+})
+
+describe("HeroPlayer — auto-hide timer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("auto-hides chrome 3s after reveal while playing", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) mockPlayerRef.current.paused = false
+    const chrome = container.querySelector(
+      '[data-testid="hero-player-custom-chrome"]',
+    ) as HTMLElement
+    expect(chrome.getAttribute("data-visible")).toBe("true")
+    await act(async () => {
+      vi.advanceTimersByTime(3001)
+    })
+    expect(chrome.getAttribute("data-visible")).toBe("false")
+  })
+
+  it.todo(
+    "does not auto-hide while paused — needs mock listener-invocation upgrade so React state syncs to mock changes",
+  )
 })

--- a/apps/web/src/components/watch/chrome-icons.tsx
+++ b/apps/web/src/components/watch/chrome-icons.tsx
@@ -1,0 +1,95 @@
+// Inline SVG icons for the HeroPlayer chrome.
+//
+// Two visual families:
+//   - Chrome controls (Play, Pause, Volume, Muted, Fullscreen) use a 20px
+//     fill-based glyph styled by the parent button's text color.
+//   - The pre-reveal Play with Sound / Tap to Unmute pill uses larger 22px
+//     stroke-based speakers that match the pill's lock-up.
+
+type GlyphProps = { path: string }
+
+function ChromeGlyph({ path }: GlyphProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      width={20}
+      height={20}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
+      <path d={path} />
+    </svg>
+  )
+}
+
+export function PlayIcon() {
+  return <ChromeGlyph path="M8 5v14l11-7z" />
+}
+
+export function PauseIcon() {
+  return <ChromeGlyph path="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
+}
+
+export function ChromeVolumeIcon() {
+  return (
+    <ChromeGlyph path="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
+  )
+}
+
+export function ChromeMutedIcon() {
+  return (
+    <ChromeGlyph path="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zM4.27 3 3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4 9.91 6.09 12 8.18V4z" />
+  )
+}
+
+export function EnterFullscreenIcon() {
+  return (
+    <ChromeGlyph path="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
+  )
+}
+
+export function ExitFullscreenIcon() {
+  return (
+    <ChromeGlyph path="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z" />
+  )
+}
+
+export function UnmutedSpeakerIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width={22}
+      height={22}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M11 5 6 9H2v6h4l5 4V5z" />
+      <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+      <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+    </svg>
+  )
+}
+
+export function MutedSpeakerIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width={22}
+      height={22}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M11 5 6 9H2v6h4l5 4V5z" />
+      <line x1="22" y1="9" x2="16" y2="15" />
+      <line x1="16" y1="9" x2="22" y2="15" />
+    </svg>
+  )
+}

--- a/docs/brainstorms/2026-04-30-watch-hero-player-title-overlay-requirements.md
+++ b/docs/brainstorms/2026-04-30-watch-hero-player-title-overlay-requirements.md
@@ -1,0 +1,98 @@
+---
+date: 2026-04-30
+topic: watch-hero-player-title-overlay
+---
+
+# Watch Hero Player — Title & Category Overlay
+
+## Summary
+
+Add a bottom-left overlay inside the watch page's `HeroPlayer` showing the video's category label and title above the existing "Play with Sound" pill. On press, the overlay text disappears alongside the pill, the Mux chrome reveals, and the existing unmute behavior is preserved.
+
+---
+
+## Problem Frame
+
+Today the `HeroPlayer` autoplays muted on a loop with a single bottom-centered "Play with Sound" pill and no contextual labeling — viewers see the visuals but the player carries no signal about what they are about to watch (label, title) without scrolling to the `WatchBody` section below. The reference design treats the muted-loop hero as a poster: a small uppercase category, the title, and a clearly-grouped CTA in the bottom-left corner over a gradient scrim.
+
+---
+
+## Requirements
+
+**Overlay content & layout**
+
+- R1. While `chromeRevealed` is `false`, render an overlay group at the **bottom-left** of the player area containing, top-to-bottom: video label (uppercase, small), video title (large), then the existing Play with Sound pill (left-aligned).
+- R2. The overlay sits over a bottom-up gradient scrim sized to keep the text legible against any video frame.
+- R3. The label respects the same conditional rendering as `WatchBody` — if `video.label` is absent, omit only the label line; the title and pill still render.
+- R4. The title uses `video.title` as already passed to `HeroPlayer` via `block.video`. No new GraphQL fields are needed.
+
+**Pill repositioning**
+
+- R5. Move the Play with Sound / Tap to Unmute pill from its current bottom-center position to bottom-left, grouped immediately below the title.
+- R6. Both pill states (`play-with-sound` and `tap-to-unmute`) inherit the new position. Default-state pill becomes red (matches reference); `tap-to-unmute` keeps its existing amber treatment. Icons unchanged.
+
+**Reveal behavior**
+
+- R7. When the user presses Play with Sound, the existing handler runs unchanged (unmute → reset to 0 → play → reveal chrome).
+- R8. When `chromeRevealed` is `true`, the entire overlay group (label, title, pill, scrim) is gone and does not re-appear if the user later pauses, scrubs, or finishes playback.
+- R9. If autoplay is blocked and the pill swaps to `tap-to-unmute`, the overlay text remains visible until the user successfully unmutes.
+
+**Body section**
+
+- R10. The existing `WatchBody` label + title block remains unchanged — the overlay is additive, not a replacement. Both appear on the page.
+
+**Responsive**
+
+- R11. On narrow viewports the title font scales down so the overlay does not overflow the player; the pill stays left-aligned and full-width-aware.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R5.** Given the watch page has loaded and the player is autoplaying muted, when the user looks at the player, then a bottom-left overlay shows "SHORTFILM" in small uppercase, "Considering Christmas" in large type, and a red "Play with Sound" pill below — all sitting over a bottom-up dark gradient.
+- AE2. **Covers R7, R8.** Given the overlay is visible, when the user clicks Play with Sound, then the video unmutes, restarts from 0, the overlay (label, title, pill, scrim) is removed, and Mux's native chrome appears.
+- AE3. **Covers R9.** Given autoplay was blocked and the pill is in `tap-to-unmute` state, when the user is looking at the player, then the title and label overlay are still visible alongside the amber `Tap to Unmute` pill in the bottom-left.
+- AE4. **Covers R3.** Given a video has no `label` value, when the page loads, then the overlay shows only the title and pill (no label line, no empty placeholder).
+- AE5. **Covers R10.** Given the overlay shows "SHORTFILM / Considering Christmas" inside the player, when the user looks below the player, then the existing `WatchBody` "SHORT FILM / Considering Christmas / description" block is still rendered.
+
+---
+
+## Success Criteria
+
+- A first-time visitor can identify the video's category and title without scrolling, while the muted loop is still playing.
+- The press-to-unmute interaction feels unchanged — the existing user-activation path, autoplay-blocked fallback, and Mux chrome reveal all behave exactly as today.
+- A downstream implementer can build this without re-querying the user about position, gradient, conditional rendering, or duplicate-with-WatchBody intent.
+
+---
+
+## Scope Boundaries
+
+- No changes to `WatchBody`, `SiblingCarousel`, `BibleQuotesSection`, `AskYoursPanel`, or `WatchSectionRenderer`.
+- No changes to GraphQL operations, `WatchVideoFragment`, or `block.video` shape.
+- No changes to the unmute / chrome-reveal logic, autoplay-blocked handling, or Mux Data metadata.
+- No new motion/animation work beyond simple opacity transitions in line with the existing pill's transition class.
+- No mobile-specific redesign — same overlay layout at every breakpoint, just smaller type on narrow viewports.
+
+---
+
+## Key Decisions
+
+- **Overlay & pill share the `!chromeRevealed` gate.** Once the chrome reveals, the overlay never re-appears — matches the existing pill semantics and keeps the post-reveal viewing experience uncluttered.
+- **Title is duplicated between player overlay and `WatchBody`.** The reference design shows both. The overlay is hero-decoration; the body section remains the canonical, scrollable text block (and houses the description and download button).
+- **Audio behavior is unchanged.** Press unmutes, restarts, reveals chrome — explicitly confirmed during brainstorming despite "muted chrome" language in the original ask.
+
+---
+
+## Dependencies / Assumptions
+
+- `block.video.label` and `block.video.title` are already projected by `WatchVideoFragment` and reach `HeroPlayer` today (verified against `src/components/watch/HeroPlayer.tsx` and `src/components/watch/WatchBody.tsx`).
+- The `MuxPlayer` component continues to render its native chrome at the bottom edge when `CHROME_HIDE_STYLE` is not applied — overlay placement at bottom-left assumes no collision while overlay is visible (chrome is hidden) and no collision after reveal (overlay is gone).
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R11][Technical] Exact responsive type-scale ramp for the title — pick during planning to match the existing `WatchBody` title scale (`text-3xl md:text-4xl xl:text-5xl`) or step down for the overlay context.
+- [Affects R2][Technical] Gradient scrim dimensions and opacity stops — pick a Tailwind treatment that holds up against bright frames without darkening the video too aggressively.

--- a/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
+++ b/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
@@ -1,0 +1,363 @@
+---
+title: Mux Player + custom React-rendered chrome (HeroPlayerControls pattern)
+date: 2026-04-30
+category: docs/solutions/design-patterns
+module: apps/web, packages/video-player
+problem_type: design_pattern
+component: tooling
+severity: medium
+related_components:
+  - apps/web
+  - packages/video-player
+tags:
+  - mux-player
+  - react
+  - video-chrome
+  - shadow-dom
+  - css-custom-properties
+  - pointer-capture
+  - auto-hide
+  - keyboard-accessibility
+  - lift-state
+  - ios-fullscreen
+applies_when:
+  - You need to customize Mux Player chrome beyond what its CSS Custom Properties expose
+  - You need a layout that media-chrome's slot system cannot express (e.g., play+timeline inline at 60% width with auto-hide)
+  - You need first-party React state for the chrome (auto-hide timers, hover-pauses-timer logic, focus-within keyboard reveal)
+  - You need agent-native test IDs / data attributes that you can't add to Mux's shadow DOM
+  - You need iOS Safari fullscreen on the wrapper element (requires webkit-prefixed fallbacks)
+  - You explicitly accept the trade — losing Mux's accessibility, captions, AirPlay, and quality-selector affordances and rebuilding only what you ship
+---
+
+# Mux Player + custom React-rendered chrome (HeroPlayerControls pattern)
+
+## Context
+
+Mux Player (`@mux/mux-player-react`) ships with built-in chrome via the [media-chrome](https://github.com/muxinc/media-chrome) primitives. Its theming surface is **CSS Custom Properties only** — useful for color tweaks, control visibility toggles, gradient backdrops — but it cannot express:
+
+- Custom layouts (e.g., play button to the **left** of the timeline rather than stacked above it)
+- Inline-row controls constrained to a centered fraction of the player width
+- Auto-hide on inactivity with a focus/hover-aware cancel system
+- Per-control accessibility hooks (`data-testid`, `aria-pressed`, `data-current-time`) for agent-driven E2E tests
+- Pointer-capture-driven volume sliders that survive auto-hide mid-drag
+
+Earlier in `feat-watch-page-mux-parity`, the team evaluated **Video.js v10** specifically _because_ its flagship feature is a JSX-composable, tree-shakeable skin model — exactly this paradigm out of the box (~25 KB gz). v10 was rejected because the beta lacks captions/audio-track menus, AirPlay, quality selector, and settings cog (epic #500 blocks all menu features), with the maintainers themselves saying "not yet" for major migrations. **Mux Player won, with the explicit acceptance that bespoke chrome would have to be built.** This pattern is the realization of that acceptance.
+
+The original plan ([`docs/plans/2026-04-29-001-feat-watch-page-mux-parity-plan.md`](../../plans/2026-04-29-001-feat-watch-page-mux-parity-plan.md), R5/R6/U5) anticipated a **hide-then-reveal** model: hide Mux's chrome during the muted autoplay loop, then reveal Mux's native chrome after the user clicks "Play with Sound." This works but ties the team to Mux's chrome layout and leaves the agent-native, accessibility, and layout asks above unresolved. **The current pattern diverges to "always hidden + parallel React chrome"** — Mux's chrome is permanently disabled and `<HeroPlayerControls />` renders the entire control surface in plain React. (session history)
+
+## Guidance
+
+The pattern has four load-bearing pieces. Skip any one and the chrome breaks subtly.
+
+### 1. Hide Mux's chrome unconditionally
+
+Pass a constant `style` prop with the four chrome-region disabling CSS Custom Properties. Reference: <https://github.com/muxinc/elements/blob/main/packages/mux-player/REFERENCE.md>
+
+```tsx
+const CHROME_HIDE_STYLE: MuxCSSProperties = {
+  "--controls": "none",
+  "--top-controls": "none",
+  "--center-controls": "none",
+  "--bottom-controls": "none",
+}
+
+<MuxPlayer
+  ref={setPlayerRef}
+  style={CHROME_HIDE_STYLE}   // always — never toggle to undefined
+  /* ...playbackId, autoPlay, etc... */
+/>
+```
+
+This is per-instance. Hiding chrome via global CSS like `mux-player::part(...)` gets blocked by media-chrome's stacking and positioning of the slot containers — `display: flex` on the part disrupts the absolute-bottom anchor and the controls jump to the top of the player. Use the CSS Custom Properties path; do not try to layout-pierce the shadow DOM.
+
+### 2. Lift the player ref to React state for re-bind on remount
+
+This is the most subtle correctness requirement. The naive pattern uses `useRef<MuxPlayerRef | null>(null)` and reads `playerRef.current` inside the chrome's subscribe `useEffect` with deps `[playerRef]`. The deps watch the **ref object identity**, which never changes — so the effect runs once at mount and never re-binds if Mux remounts (language switch, `playbackId` change, suspense recovery, error retry). Symptom: chrome appears responsive but `play`, `mute`, `seek`, `volume`, fullscreen all silently no-op. No error, no log.
+
+The fix is to lift the player to React state alongside the ref:
+
+```tsx
+// In the parent (HeroPlayer):
+const playerRef = useRef<MuxPlayerRef | null>(null)
+const [player, setPlayer] = useState<MuxPlayerRef | null>(null)
+const setPlayerRef = useCallback((next: MuxPlayerRef | null) => {
+  playerRef.current = next
+  setPlayer(next)
+  onPlayerReady?.(next)
+}, [onPlayerReady])
+
+return (
+  <MuxPlayer ref={setPlayerRef} ... />
+  {chromeRevealed && (
+    <HeroPlayerControls
+      player={player}              // state, drives effect re-runs
+      playerRef={playerRef}        // ref, used inside callbacks
+      wrapperRef={wrapperRef}
+    />
+  )}
+)
+```
+
+Inside the chrome:
+
+```tsx
+useEffect(() => {
+  if (!player || typeof player.addEventListener !== "function") return
+  const sync = () => {
+    /* read player.paused / .muted / .currentTime / .volume / .duration / .buffered */
+  }
+  sync()
+  const events = [
+    "timeupdate",
+    "durationchange",
+    "loadedmetadata",
+    "play",
+    "pause",
+    "volumechange",
+    "progress",
+  ] as const
+  events.forEach((e) => player.addEventListener(e, sync))
+  return () => events.forEach((e) => player.removeEventListener(e, sync))
+}, [player]) // <-- player state, NOT playerRef
+```
+
+This matches the [React StrictMode + DOM-wrapping widget teardown](./react-strictmode-dom-wrapping-widget-teardown-20260424.md) guidance: split widget-init from data effects, depend on the lifted state so React-driven re-bind boundaries align with the widget's lifecycle.
+
+### 3. Subscribe to player events; never read live values during render
+
+The `sync` function reads `player.paused`, `player.muted`, `player.volume`, `player.currentTime`, `player.duration`, and `player.buffered` and pushes them into local React state. The chrome reads only the React state — never `playerRef.current.x` during render. This keeps render pure, plays nicely with concurrent rendering, and gives Strict-Mode-stable behavior.
+
+Two failure modes to guard:
+
+- **`buffered.end(b.length-1)` can throw `InvalidStateError`** mid-seek. Wrap in try/catch:
+  ```tsx
+  try {
+    const end = b.end(b.length - 1)
+    setBufferedPct(Math.min(100, (end / d) * 100))
+  } catch {
+    // TimeRanges can throw mid-seek; ignore until next progress event.
+  }
+  ```
+- **Clamp percentages to ≤100.** End-of-stream samples can produce `progressPct > 100`; Tailwind doesn't clamp `width: 105%` and the bar overflows.
+
+### 4. Render the entire chrome in React with first-party state
+
+Stack the chrome layers explicitly. Inside the player wrapper:
+
+| Layer                                                | z-index | Pointer events | Purpose                                           |
+| ---------------------------------------------------- | ------- | -------------- | ------------------------------------------------- |
+| `<MuxPlayer>`                                        | (flow)  | auto           | The video                                         |
+| Click surface (`<button aria-hidden tabIndex={-1}>`) | `z-0`   | auto           | Click anywhere → toggle play/pause; cursor source |
+| Backdrop gradient (`<div aria-hidden>`)              | (no z)  | none           | Visual readability backdrop                       |
+| Chrome (`<div data-visible={...}>`)                  | `z-10`  | auto (always)  | Play / timeline / time / volume / fullscreen      |
+
+Do **not** flip the chrome to `pointer-events-none` when auto-hiding. Doing so blocks agent `.click()` and keyboard interactions even though the user can still see roughly where the controls were. Keep `pointer-events: auto` always; toggle only `opacity` (and let the wrapper-level reveal listeners bring it back to opacity-100 on the next interaction).
+
+## Why This Matters
+
+- **Total layout control.** Mux's slot system anchors regions; React composes them however you want. The watch page wanted `[play] [—— timeline ——] [time] [mute] [vol slider] [fullscreen]` at 60% width centered with a tall bottom-up gradient. CSS Custom Properties can't express this; React can.
+- **Agent-native by construction.** Every interactive element is a real React DOM node with `data-testid`, `aria-label`, `role="slider"`, `aria-valuemin/max/now/valuetext`. Playwright/Stagehand can drive it without any shadow-DOM piercing. Mux's chrome is in shadow DOM; you can't add testids to it.
+- **First-party state for delicate interactions.**
+  - 3-second auto-hide timer that pauses while paused / hovering controls / dragging volume
+  - Cursor hides with the chrome (`wrapper.style.cursor = "none"`) and restores on mousemove
+  - Volume slider expands on hover **and on focus-within** (keyboard accessibility)
+  - Volume drag uses `setPointerCapture` + `onLostPointerCapture` so capture release (page hidden, touch preempted, container collapses) doesn't leak `volumeDragging = true`
+- **Preserves Mux Data attribution.** `MuxPlayer` is still mounted and its `metadata` prop is still wired (player_name, video_title, video_id, viewer_user_id via `useSyncExternalStore`). Hiding chrome does not affect analytics. (session history — viewer-id SSR snapshot pattern is load-bearing)
+- **Survives the iOS user-activation gate.** The pre-reveal "Play with Sound" pill still calls `muted=false; currentTime=0; play()` synchronously inside the click task with **no `await` between** — that invariant from the prior session's U5 spike must be preserved when adding new chrome state. `setChromeRevealed(true)` only fires from the resolved `play()` promise. (session history — load-bearing iOS invariant)
+
+## When to Apply
+
+- You're customizing Mux Player chrome on a single, controlled surface (not a polymorphic Video block — for those, accept Mux's default chrome).
+- You need any of: custom layout, agent-native testids, focus-within keyboard accessibility, auto-hide with hover/drag pauses, cursor auto-hide, or first-party React state for the controls.
+- You accept the trade-off: **you ship every control yourself.** Mux's captions menu, audio-track picker, AirPlay button, quality selector, settings cog — all gone. Add only the controls your product needs (this watch page ships play, timeline, time, mute+volume slider, fullscreen).
+
+Don't apply when:
+
+- The Mux defaults are good enough — accept them.
+- You can solve the issue with CSS Custom Properties alone (color, gradient backdrop, hide individual buttons via `--bottom-pip-button: none`, etc.).
+- You need a polymorphic player surface where editors swap player implementations — the pattern assumes a single hard-wired player instance.
+- The page is the standalone Mux embed route (`/watch/[c]/[v]/[l]/embed`) where Mux's default chrome is intentional. (session history — embed route is non-customized by design)
+
+## Examples
+
+### File layout
+
+The pattern lives across three files in `apps/web/src/components/watch/`:
+
+- **`HeroPlayer.tsx`** (~225 LOC) — orchestration. Owns `playerRef` + `player` state, `chromeRevealed` state, the pre-reveal "Play with Sound" pill, and the `<MuxPlayer>` mount.
+- **`HeroPlayerControls.tsx`** (~530 LOC) — the custom chrome itself. Subscribes to player events, owns auto-hide / cursor / volume drag / fullscreen state, renders the entire control surface.
+- **`ChromeButton.tsx`** (~30 LOC) — 44px round black/30 button primitive used by play, mute, fullscreen. Plus `formatTime(seconds)` helper.
+- **`chrome-icons.tsx`** (~100 LOC) — 8 inline SVG icons (Play, Pause, ChromeVolume, ChromeMuted, EnterFullscreen, ExitFullscreen, MutedSpeaker, UnmutedSpeaker). The 6 chrome glyphs share a `ChromeGlyph` primitive parameterized by SVG path.
+
+### Auto-hide timer with refs in commit-phase effects
+
+The auto-hide timer reads `playing` and `hoveringControls` from refs (so the wrapper-level mousemove listener doesn't get re-subscribed on every render), but the ref **writes** happen in commit-phase `useEffect` blocks — never during render — so concurrent rendering replays don't leave the refs in interim states.
+
+```tsx
+const playingRef = useRef(false)
+const hoveringControlsRef = useRef(false)
+useEffect(() => {
+  playingRef.current = playing
+}, [playing])
+useEffect(() => {
+  hoveringControlsRef.current = hoveringControls
+}, [hoveringControls])
+
+const scheduleHide = useCallback(() => {
+  if (hideTimerRef.current != null) {
+    window.clearTimeout(hideTimerRef.current)
+    hideTimerRef.current = null
+  }
+  if (
+    !playingRef.current ||
+    hoveringControlsRef.current ||
+    volumeDraggingRef.current
+  ) {
+    return // paused / hovering / mid-drag — don't auto-hide
+  }
+  hideTimerRef.current = window.setTimeout(() => {
+    setControlsVisible(false)
+    hideTimerRef.current = null
+  }, 3000)
+}, [])
+```
+
+The wrapper-level reveal listener (`pointermove`, `touchmove`, `touchstart`, `click`, `keydown`) calls `showControls()` on every interaction; `showControls` calls `scheduleHide()` which always cancels-then-reschedules. The result is a self-resetting 3s countdown that respects every "don't hide" condition.
+
+### iOS Safari fullscreen with webkit fallbacks
+
+```tsx
+const toggleFullscreen = useCallback(() => {
+  const wrapper = wrapperRef.current
+  if (!wrapper) return
+  const doc = document as Document & {
+    webkitFullscreenElement?: Element | null
+    webkitExitFullscreen?: () => Promise<void> | undefined
+  }
+  const wrapperEl = wrapper as HTMLDivElement & {
+    webkitRequestFullscreen?: () => Promise<void> | undefined
+  }
+  const isFs = !!(document.fullscreenElement ?? doc.webkitFullscreenElement)
+  if (isFs) {
+    const exit = document.exitFullscreen?.() ?? doc.webkitExitFullscreen?.()
+    exit?.catch?.((err) =>
+      console.warn("[HeroPlayer] exitFullscreen rejected", err),
+    )
+  } else {
+    const req =
+      wrapperEl.requestFullscreen?.() ?? wrapperEl.webkitRequestFullscreen?.()
+    req?.catch?.((err) =>
+      console.warn("[HeroPlayer] requestFullscreen rejected", err),
+    )
+  }
+}, [wrapperRef])
+
+// And the listener:
+useEffect(() => {
+  const handleFsChange = () => {
+    const fsEl =
+      document.fullscreenElement ??
+      (document as Document & { webkitFullscreenElement?: Element | null })
+        .webkitFullscreenElement
+    setIsFullscreen(!!fsEl)
+  }
+  document.addEventListener("fullscreenchange", handleFsChange)
+  document.addEventListener("webkitfullscreenchange", handleFsChange)
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFsChange)
+    document.removeEventListener("webkitfullscreenchange", handleFsChange)
+  }
+}, [])
+```
+
+iPhone Safari does **not** allow fullscreen on arbitrary elements like the wrapper `div` — only the inner `<video>` element via `videoEl.webkitEnterFullscreen()`. The webkit-prefixed fallbacks above cover desktop Safari and iPad, but iPhone-specific full-fullscreen still needs to delegate to the `<video>` element directly. **Verify on real device hardware** before claiming iPhone fullscreen works.
+
+### Volume slider with pointer capture + lost-capture safety
+
+```tsx
+const handleVolumePointerDown = useCallback(
+  (e: React.PointerEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+    setVolumeDragging(true)
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId)
+    } catch {
+      /* pointer released early */
+    }
+    setPlayerVolume(computeVolumeFromClientX(e.clientX))
+  },
+  [computeVolumeFromClientX, setPlayerVolume],
+)
+
+const handleVolumePointerUp = useCallback(
+  (e: React.PointerEvent<HTMLDivElement>) => {
+    setVolumeDragging(false)
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+  },
+  [],
+)
+
+// Critical: the OS can revoke capture (page hidden, touch preempted, container animates closed)
+// and the regular pointerup never fires. Without this handler, volumeDragging stays stuck true
+// and the auto-hide guard never re-arms.
+const handleVolumeLostPointerCapture = useCallback(() => {
+  setVolumeDragging(false)
+}, [])
+```
+
+### Pre-reveal pill iOS-safe sequence (preserve from prior session)
+
+Do not perturb this sequence. Both the unmute branch and the tap-to-unmute (autoplay-blocked) branch must call `play()` synchronously inside the click handler with no `await` separating them. (session history — load-bearing invariant)
+
+```tsx
+const handleUnmuteClick = useCallback(() => {
+  const player = playerRef.current
+  if (!player) return
+
+  if (pillState === "tap-to-unmute") {
+    player.muted = false
+    const tapResult = player.play() // MUST call play() — earlier code only set muted=false
+    tapResult?.catch?.((err) =>
+      console.warn("[HeroPlayer] tap-to-unmute play() rejected", err),
+    )
+    setChromeRevealed(true)
+    return
+  }
+
+  player.muted = false
+  player.currentTime = 0
+  const result = player.play()
+  if (result?.then) {
+    result
+      .then(() => {
+        setChromeRevealed(true)
+        setAutoplayBlocked(false)
+      })
+      .catch(() => {
+        setPillState("tap-to-unmute")
+      })
+  } else {
+    setChromeRevealed(true)
+  }
+}, [pillState])
+```
+
+### Don't rebuild what's already there
+
+Before building the chrome from scratch, check `packages/video-player/src/useVideoPlayerCore.ts` — it already exposes `formatTime()`, `handlePlayPause`, `handleMuteToggle`, `handleSeek`, `handleFullscreen` for the legacy video.js 8 surface. Some of those primitives can be lifted directly (e.g., `formatTime`). The HeroPlayerControls implementation duplicated `formatTime` rather than importing it — a minor follow-up to consolidate. (session history — prior art exists; check before reimplementing)
+
+### Test fixture pattern
+
+The new `HeroPlayerControls` test suite lives in `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`. The Mux Player is mocked at the module boundary with a singleton mock player exposing `paused`, `muted`, `volume`, `currentTime`, `duration`, `buffered`, `play`, `pause`, `addEventListener`, `removeEventListener`. The `revealChrome()` helper renders `<HeroPlayer>`, clicks the pill, awaits the play promise — the chrome is now mounted and `mockPlayerRef.current` is the singleton. Tests then directly mutate the mock and dispatch `KeyboardEvent`s on `data-testid="hero-chrome-timeline"` etc.
+
+**Limitation to be aware of:** the mock's `addEventListener` is `vi.fn()` — it doesn't actually invoke captured callbacks. So tests that need React state to _react_ to mock-state changes (e.g., "does not auto-hide while paused" needs `playingRef.current` to flip to `false`) currently fail and are marked `it.todo`. Upgrading the mock to capture and replay listeners would unlock those tests; tracked as a follow-up.
+
+## Related
+
+- [`docs/solutions/design-patterns/react-strictmode-dom-wrapping-widget-teardown-20260424.md`](./react-strictmode-dom-wrapping-widget-teardown-20260424.md) — sibling pattern for the widget setup/teardown rules; the lift-to-state guidance here is the same principle applied to event subscription.
+- [`docs/plans/2026-04-29-001-feat-watch-page-mux-parity-plan.md`](../../plans/2026-04-29-001-feat-watch-page-mux-parity-plan.md) — the plan that documented the Mux-vs-Video.js decision, the iOS-safe play() invariant (U5), and the original "hide-then-reveal" model that this pattern diverges from.
+- `packages/video-player/src/useVideoPlayerCore.ts` — direct prior art for the timeline/slider/play-pause/fullscreen primitives on video.js 8; reference when extending the Mux chrome with new controls.
+- `apps/tv/src/components/VideoPlayer.tsx` — TV-side parallel implementation (expo-video + D-pad). Different runtime but the timeline/scrubbing UX should converge with web. (session history)
+- PR [#866](https://github.com/JesusFilm/forge/pull/866) — the implementation this pattern documents.


### PR DESCRIPTION
## Summary

- Replaces Mux Player's native chrome on `HeroPlayer` with a fully custom React-rendered chrome (`HeroPlayerControls`): play/pause, click-to-seek timeline (full keyboard support — Arrow / Home / End / PageUp / PageDown), pointer-capture volume slider with auto-mute at zero, fullscreen toggle (with iOS Safari `webkit*` fallbacks), 3s auto-hide on inactivity (cancels while paused, hovering controls, or dragging volume), cursor auto-hide on the wrapper, click-on-video toggles play/pause, bottom-up gradient backdrop.
- Adds bottom-left title/category overlay with a repositioned & restyled "Play with Sound" pill (replaces the prior bottom-center pill).
- Search bar (`FloatingSearchBar` + `SearchOverlay` input) gets `text-shadow` + bumped placeholder opacity (70 → 90) for legibility against bright video frames.
- Splits `HeroPlayer.tsx` into sibling files: `HeroPlayerControls.tsx` (532 LOC), `ChromeButton.tsx` (31 LOC), `chrome-icons.tsx` (100 LOC). `HeroPlayer.tsx` returns to ~225 LOC of orchestration.
- 21 new vitest cases covering the chrome render, button wiring, timeline keyboard seek, volume keyboard with auto-mute/unmute heuristics, and auto-hide timer.

## Code-review fixes landed in this PR

This branch was produced by a `/ce-code-review` walk-through. Key fixes:

- **P1 — Stale player ref:** lift player to React state, pass as prop, subscribe-effect deps `[player]` so listeners re-bind on Mux remount.
- **P1 — Tap-to-Unmute pause bug:** the autoplay-blocked branch now calls `play()` so the unmute also resumes playback.
- **P1 — `buffered.end()` crash:** wrap in try/catch + clamp `bufferedPct` to ≤100, reset to 0 when buffered unavailable.
- **P1 — `volumeDragging` stuck on auto-hide:** guard `scheduleHide` on drag state + `onLostPointerCapture` resets the flag when the OS revokes capture.
- **P1 — iOS Safari fullscreen (partial):** `requestFullscreen` / `exitFullscreen` fall through to `webkitRequestFullscreen` / `webkitExitFullscreen`; `webkitfullscreenchange` listener wired. **Needs device QA.**
- **P2 — Volume slider keyboard accessibility:** `onFocus` / `onBlur` open the slider for keyboard users.
- **P2 — Refs in render → useEffects:** concurrent-rendering safe.
- **P2 — Auto-hide reset listeners:** added `pointermove` / `touchmove` / `keydown` so touch drag and keyboard seek don't trigger hide.
- **P2 — Click-surface a11y:** `aria-hidden`, role removed; chrome's `hero-chrome-play` is the canonical AT target.
- **P2 — Drop `pointer-events-none`** when chrome is hidden so agents/keyboard interactions still reach controls.
- **P2 — `.catch(() => {})` silent swallow** replaced with `console.warn` to preserve diagnostics.
- **P3 — Timeline keyboard:** Home / End / PageUp / PageDown per WAI-ARIA APG; always `preventDefault` on owned keys.
- **P3 — Volume keyboard** uses `(muted ? 0 : volume)` as base.
- **P3 — Wrapper cursor** snapshot/restore.
- **P3 — Various**: progressPct/bufferedPct clamp, ?? 0 removal, testid additions, webkit fullscreenchange listener, mock player extended with volume.

## Test plan

- [ ] `pnpm vitest run apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx` — 21 pass, 2 todo
- [ ] Manual: load `/watch/considering-christmas/en` (or any watch page), click Play with Sound, verify chrome renders with play/timeline/time/volume/fullscreen
- [ ] Manual: pause video, verify chrome stays visible
- [ ] Manual: play video, leave mouse still ~3s, verify chrome auto-hides + cursor hides
- [ ] Manual: move mouse, verify chrome and cursor reappear, repeat the auto-hide cycle
- [ ] Manual: click video surface, verify play/pause toggles
- [ ] Manual: hover volume button, verify slider expands; drag, verify volume changes; drag to 0, verify auto-mute; raise from 0, verify auto-unmute
- [ ] Manual: focus timeline (Tab), use Arrow / Home / End / PageUp / PageDown
- [ ] **Critical:** test on a real iPhone — confirm the `webkit*` fullscreen fallbacks actually open fullscreen (the code adds the calls; only device testing confirms they work)
- [ ] Confirm Search bar placeholder text is readable against bright video backgrounds

## Out of scope

- 2 vitest cases marked `it.todo` — require the mock to capture and replay `addEventListener` callbacks (current mock just `vi.fn()`s `addEventListener`, so changing mock state after `revealChrome()` doesn't sync to React state).
- iOS Safari `webkitEnterFullscreen` on the inner `<video>` element if wrapper-level fullscreen still doesn't open on iPhone after this PR ships.
- Live-stream support (`Number.isFinite(duration)` collapses `Infinity` to 0 — current scope is VOD only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)