### PR TITLE
feat(web): sticky-hero scroll-over-video on the watch page

### DIFF
--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { useCallback, useRef, useState, useSyncExternalStore } from "react"
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react"
 import { useSearchParams } from "next/navigation"
 import { MuxPlayer, type MuxPlayerRef } from "@forge/video-player"
 import type { MuxCSSProperties } from "@mux/mux-player-react"
@@ -57,6 +63,34 @@ export function HeroPlayer({
   const [pillState, setPillState] = useState<PillState>("play-with-sound")
   const [autoplayBlocked, setAutoplayBlocked] = useState(false)
 
+  // Anchor for the title/pill overlay AND the chrome control bar — both live
+  // in this zero-height div right after the sticky hero so they ride on the
+  // body section's top edge instead of being trapped at the pinned hero's
+  // bottom (which the body slides over).
+  const [overlayAnchor, setOverlayAnchor] = useState<HTMLDivElement | null>(
+    null,
+  )
+
+  // Measured rendered height drives the sticky `top` so the player pins
+  // exactly when its bottom reaches the viewport bottom. Aspect-ratio is
+  // determined by mux-player at runtime, so we measure rather than guess.
+  const [heroHeight, setHeroHeight] = useState<number | null>(null)
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    const apply = (h: number) => {
+      if (h > 0) setHeroHeight(h)
+    }
+    apply(el.getBoundingClientRect().height)
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) apply(entry.contentRect.height)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   const viewerUserId = useSyncExternalStore(
     subscribeViewerId,
     getViewerId,
@@ -98,8 +132,10 @@ export function HeroPlayer({
       return
     }
 
+    // Continue from the current playhead — the muted-loop preview is already
+    // running, so resetting currentTime would force a re-buffer and restart
+    // from frame 0, which the user reads as "the video reloaded."
     player.muted = false
-    player.currentTime = 0
     const result = player.play()
     if (result && typeof result.then === "function") {
       result
@@ -129,50 +165,80 @@ export function HeroPlayer({
   const muted = !chromeRevealed
 
   return (
-    <div
-      ref={wrapperRef}
-      data-block-type="HeroPlayer"
-      data-testid="hero-player-wrapper"
-      data-chrome-revealed={chromeRevealed ? "true" : "false"}
-      data-autoplay-blocked={autoplayBlocked ? "true" : "false"}
-      className="relative w-full overflow-hidden bg-black"
-    >
-      <MuxPlayer
-        ref={setPlayerRef}
-        playbackId={playbackId}
-        src={playbackId ? undefined : hlsSrc}
-        autoPlay="muted"
-        muted={muted}
-        loop={loop}
-        envKey={env.NEXT_PUBLIC_MUX_DATA_ENV_KEY}
-        disableCookies={true}
-        metadata={{
-          player_name: "forge-web-watch",
-          video_title: video.title ?? undefined,
-          video_id: video.documentId,
-          viewer_user_id: viewerUserId,
+    <>
+      <div
+        ref={wrapperRef}
+        data-block-type="HeroPlayer"
+        data-testid="hero-player-wrapper"
+        data-chrome-revealed={chromeRevealed ? "true" : "false"}
+        data-autoplay-blocked={autoplayBlocked ? "true" : "false"}
+        className="sticky w-full overflow-hidden bg-black"
+        style={{
+          // 100svh tracks the *small* viewport on iOS Safari (visible area
+          // when the URL bar is showing). Plain 100vh is the *large*
+          // viewport, so calc(100vh - heroHeight) goes positive while the
+          // URL bar is up and `min()` clamps `top` to 0 — defeating the
+          // pin-when-bottom-hits-viewport-bottom contract on mobile.
+          top:
+            heroHeight != null
+              ? `min(0px, calc(100svh - ${heroHeight}px))`
+              : "0px",
         }}
-        style={CHROME_HIDE_STYLE}
-        onLoadedMetadata={handleLoadedMetadata}
-        onError={handlePlayerError}
-        className="block h-full w-full"
-      />
-
-      {chromeRevealed ? (
-        <HeroPlayerControls
-          player={player}
-          playerRef={playerRef}
-          wrapperRef={wrapperRef}
+      >
+        <MuxPlayer
+          ref={setPlayerRef}
+          playbackId={playbackId}
+          src={playbackId ? undefined : hlsSrc}
+          autoPlay="muted"
+          muted={muted}
+          loop={loop}
+          envKey={env.NEXT_PUBLIC_MUX_DATA_ENV_KEY}
+          disableCookies={true}
+          metadata={{
+            player_name: "forge-web-watch",
+            video_title: video.title ?? undefined,
+            video_id: video.documentId,
+            viewer_user_id: viewerUserId,
+          }}
+          style={CHROME_HIDE_STYLE}
+          onLoadedMetadata={handleLoadedMetadata}
+          onError={handlePlayerError}
+          className="block h-full w-full"
         />
-      ) : (
-        <>
+
+        {chromeRevealed ? (
+          <HeroPlayerControls
+            player={player}
+            playerRef={playerRef}
+            wrapperRef={wrapperRef}
+            overlayAnchor={overlayAnchor}
+          />
+        ) : (
           <div
             aria-hidden="true"
             className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/80 via-black/40 to-transparent"
           />
+        )}
+      </div>
+
+      {/*
+        Zero-height anchor right after the sticky hero. The title/label/pill
+        (pre-reveal) and the chrome control bar (post-reveal, portaled in
+        from <HeroPlayerControls>) both attach to this anchor's bottom edge.
+        The anchor lives in normal flow and so scrolls with the document —
+        which means everything attached here rides up on the body section's
+        top edge instead of being trapped at the sticky hero's pinned bottom
+        (which the body slides over).
+      */}
+      <div
+        ref={setOverlayAnchor}
+        data-testid="hero-player-overlay-anchor"
+        className="relative z-10 h-0 w-full"
+      >
+        {!chromeRevealed ? (
           <div
             data-testid="hero-player-overlay"
-            className="absolute right-6 bottom-6 left-10 flex flex-col items-start gap-4 md:right-auto md:left-16 xl:left-24"
+            className="absolute right-6 bottom-0 left-10 flex flex-col items-start gap-4 pb-6 md:right-auto md:left-16 xl:left-24"
           >
             {video.label ? (
               <span
@@ -213,8 +279,8 @@ export function HeroPlayer({
               </span>
             </button>
           </div>
-        </>
-      )}
-    </div>
+        ) : null}
+      </div>
+    </>
   )
 }

--- a/apps/web/src/components/watch/HeroPlayerControls.tsx
+++ b/apps/web/src/components/watch/HeroPlayerControls.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import type { MuxPlayerRef } from "@forge/video-player"
 
 import { ChromeButton, formatTime } from "./ChromeButton"
@@ -17,10 +18,20 @@ export function HeroPlayerControls({
   player,
   playerRef,
   wrapperRef,
+  overlayAnchor,
 }: {
   player: MuxPlayerRef | null
   playerRef: React.RefObject<MuxPlayerRef | null>
   wrapperRef: React.RefObject<HTMLDivElement | null>
+  /**
+   * Out-of-flow anchor (zero-height div right after the sticky hero) into
+   * which the chrome control bar is portaled, so the bar slides up with the
+   * body section instead of being trapped at the sticky hero's pinned
+   * bottom and covered by the sliding body. The parent always renders the
+   * anchor div before this component mounts (gated on `chromeRevealed`),
+   * so this is null for one render at most before the ref callback fires.
+   */
+  overlayAnchor: HTMLDivElement | null
 }) {
   const [playing, setPlaying] = useState(false)
   const [muted, setMuted] = useState(false)
@@ -151,26 +162,33 @@ export function HeroPlayerControls({
     }
   }, [playing, hoveringControls, scheduleHide])
 
-  // Reveal chrome on any user interaction inside the player wrapper.
-  // pointermove unifies mouse + pen + touch; keydown keeps chrome up while
-  // arrow-key seeking the timeline or volume slider.
+  // Reveal chrome on any user interaction inside the player wrapper OR on
+  // the overlay anchor (where the chrome bar is portaled). Native listeners
+  // only see events bubbling through their own DOM subtree; without binding
+  // to the anchor, hovering / keyboard-focusing the portaled chrome bar
+  // never triggers reveal, and the bar can't be re-summoned after auto-hide.
   useEffect(() => {
-    const wrapper = wrapperRef.current
-    if (!wrapper) return
     const reveal = () => showControls()
-    wrapper.addEventListener("pointermove", reveal)
-    wrapper.addEventListener("touchmove", reveal)
-    wrapper.addEventListener("touchstart", reveal)
-    wrapper.addEventListener("click", reveal)
-    wrapper.addEventListener("keydown", reveal)
-    return () => {
-      wrapper.removeEventListener("pointermove", reveal)
-      wrapper.removeEventListener("touchmove", reveal)
-      wrapper.removeEventListener("touchstart", reveal)
-      wrapper.removeEventListener("click", reveal)
-      wrapper.removeEventListener("keydown", reveal)
+    const targets = [wrapperRef.current, overlayAnchor].filter(
+      (t): t is HTMLDivElement => t != null,
+    )
+    for (const target of targets) {
+      target.addEventListener("pointermove", reveal)
+      target.addEventListener("touchmove", reveal)
+      target.addEventListener("touchstart", reveal)
+      target.addEventListener("click", reveal)
+      target.addEventListener("keydown", reveal)
     }
-  }, [wrapperRef, showControls])
+    return () => {
+      for (const target of targets) {
+        target.removeEventListener("pointermove", reveal)
+        target.removeEventListener("touchmove", reveal)
+        target.removeEventListener("touchstart", reveal)
+        target.removeEventListener("click", reveal)
+        target.removeEventListener("keydown", reveal)
+      }
+    }
+  }, [wrapperRef, overlayAnchor, showControls])
 
   // Hide the OS cursor when chrome auto-hides — sibling cursor styles aren't
   // enough to win over mux-player's own shadow-DOM styling, so set cursor on
@@ -392,6 +410,133 @@ export function HeroPlayerControls({
   const progressPct =
     duration > 0 ? Math.min(100, (currentTime / duration) * 100) : 0
 
+  // Chrome control bar — portaled into the overlay anchor (just below the
+  // sticky hero) so it rides on the body section's top edge as the body
+  // slides up over the pinned hero, matching the title-overlay behavior.
+  const chromeBar = (
+    <div
+      data-testid="hero-player-custom-chrome"
+      data-visible={controlsVisible ? "true" : "false"}
+      onMouseEnter={() => setHoveringControls(true)}
+      onMouseLeave={() => setHoveringControls(false)}
+      className={`absolute bottom-0 left-1/2 z-10 flex w-3/5 -translate-x-1/2 items-center gap-3 pb-6 transition-opacity duration-300 md:gap-4 md:pb-7 ${
+        controlsVisible ? "opacity-100" : "opacity-0"
+      }`}
+    >
+      <ChromeButton
+        onClick={togglePlay}
+        ariaLabel={playing ? "Pause" : "Play"}
+        testId="hero-chrome-play"
+      >
+        {playing ? <PauseIcon /> : <PlayIcon />}
+      </ChromeButton>
+
+      <div
+        ref={timelineRef}
+        role="slider"
+        tabIndex={0}
+        aria-label="Seek"
+        aria-valuemin={0}
+        aria-valuemax={Math.max(0, Math.floor(duration))}
+        aria-valuenow={Math.floor(currentTime)}
+        aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
+        data-testid="hero-chrome-timeline"
+        onClick={handleTimelineClick}
+        onKeyDown={handleTimelineKey}
+        className="group relative h-1 flex-1 cursor-pointer rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
+      >
+        <div
+          className="absolute inset-y-0 left-0 rounded-l-full bg-white/40"
+          style={{ width: `${bufferedPct}%` }}
+        />
+        <div
+          className="absolute inset-y-0 left-0 rounded-l-full bg-[#cb333b]"
+          style={{ width: `${progressPct}%` }}
+        />
+        <div
+          className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#cb333b] opacity-0 shadow transition group-hover:opacity-100 group-focus:opacity-100"
+          style={{ left: `${progressPct}%` }}
+        />
+      </div>
+
+      <div
+        data-testid="hero-chrome-time"
+        data-current-time={Math.floor(currentTime)}
+        data-duration={Math.floor(duration)}
+        className="shrink-0 text-sm font-medium tabular-nums text-white drop-shadow md:text-base"
+      >
+        {formatTime(currentTime)} / {formatTime(duration)}
+      </div>
+
+      <div
+        className="relative flex shrink-0 items-center"
+        onMouseEnter={() => setVolumeOpen(true)}
+        onMouseLeave={() => setVolumeOpen(false)}
+        onFocus={() => setVolumeOpen(true)}
+        onBlur={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+            setVolumeOpen(false)
+          }
+        }}
+      >
+        <ChromeButton
+          onClick={toggleMute}
+          ariaLabel={muted || volume === 0 ? "Unmute" : "Mute"}
+          testId="hero-chrome-mute"
+        >
+          {muted || volume === 0 ? <ChromeMutedIcon /> : <ChromeVolumeIcon />}
+        </ChromeButton>
+        <div
+          data-testid="hero-chrome-volume-container"
+          data-open={volumeOpen || volumeDragging ? "true" : "false"}
+          className={`overflow-hidden transition-[width,margin] duration-200 ease-out ${
+            volumeOpen || volumeDragging ? "ml-2 w-24" : "ml-0 w-0"
+          }`}
+        >
+          <div
+            ref={volumeTrackRef}
+            role="slider"
+            tabIndex={0}
+            aria-label="Volume"
+            data-testid="hero-chrome-volume-slider"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round((muted ? 0 : volume) * 100)}
+            aria-valuetext={`${Math.round((muted ? 0 : volume) * 100)} percent`}
+            onPointerDown={handleVolumePointerDown}
+            onPointerMove={handleVolumePointerMove}
+            onPointerUp={handleVolumePointerUp}
+            onPointerCancel={handleVolumePointerUp}
+            onLostPointerCapture={handleVolumeLostPointerCapture}
+            onKeyDown={handleVolumeKey}
+            className="group relative h-1 w-full cursor-pointer touch-none rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
+          >
+            <div
+              className="absolute inset-y-0 left-0 rounded-l-full bg-white"
+              style={{ width: `${(muted ? 0 : volume) * 100}%` }}
+            />
+            <div
+              className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow transition ${
+                muted || volume === 0
+                  ? "opacity-0"
+                  : "opacity-0 group-hover:opacity-100 group-focus:opacity-100"
+              }`}
+              style={{ left: `${(muted ? 0 : volume) * 100}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <ChromeButton
+        onClick={toggleFullscreen}
+        ariaLabel={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        testId="hero-chrome-fullscreen"
+      >
+        {isFullscreen ? <ExitFullscreenIcon /> : <EnterFullscreenIcon />}
+      </ChromeButton>
+    </div>
+  )
+
   return (
     <>
       {/* Click target only — the canonical "Play/Pause" affordance for AT
@@ -417,127 +562,7 @@ export function HeroPlayerControls({
       {/* Chrome stays pointer-active even when invisible so agent-driven and
           keyboard interactions reach the controls — the wrapper-level reveal
           listeners then bring it back to opacity-100 on the next interaction. */}
-      <div
-        data-testid="hero-player-custom-chrome"
-        data-visible={controlsVisible ? "true" : "false"}
-        onMouseEnter={() => setHoveringControls(true)}
-        onMouseLeave={() => setHoveringControls(false)}
-        className={`absolute bottom-0 left-1/2 z-10 flex w-3/5 -translate-x-1/2 items-center gap-3 pb-6 transition-opacity duration-300 md:gap-4 md:pb-7 ${
-          controlsVisible ? "opacity-100" : "opacity-0"
-        }`}
-      >
-        <ChromeButton
-          onClick={togglePlay}
-          ariaLabel={playing ? "Pause" : "Play"}
-          testId="hero-chrome-play"
-        >
-          {playing ? <PauseIcon /> : <PlayIcon />}
-        </ChromeButton>
-
-        <div
-          ref={timelineRef}
-          role="slider"
-          tabIndex={0}
-          aria-label="Seek"
-          aria-valuemin={0}
-          aria-valuemax={Math.max(0, Math.floor(duration))}
-          aria-valuenow={Math.floor(currentTime)}
-          aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
-          data-testid="hero-chrome-timeline"
-          onClick={handleTimelineClick}
-          onKeyDown={handleTimelineKey}
-          className="group relative h-1 flex-1 cursor-pointer rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
-        >
-          <div
-            className="absolute inset-y-0 left-0 rounded-l-full bg-white/40"
-            style={{ width: `${bufferedPct}%` }}
-          />
-          <div
-            className="absolute inset-y-0 left-0 rounded-l-full bg-[#cb333b]"
-            style={{ width: `${progressPct}%` }}
-          />
-          <div
-            className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#cb333b] opacity-0 shadow transition group-hover:opacity-100 group-focus:opacity-100"
-            style={{ left: `${progressPct}%` }}
-          />
-        </div>
-
-        <div
-          data-testid="hero-chrome-time"
-          data-current-time={Math.floor(currentTime)}
-          data-duration={Math.floor(duration)}
-          className="shrink-0 text-sm font-medium tabular-nums text-white drop-shadow md:text-base"
-        >
-          {formatTime(currentTime)} / {formatTime(duration)}
-        </div>
-
-        <div
-          className="relative flex shrink-0 items-center"
-          onMouseEnter={() => setVolumeOpen(true)}
-          onMouseLeave={() => setVolumeOpen(false)}
-          onFocus={() => setVolumeOpen(true)}
-          onBlur={(e) => {
-            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
-              setVolumeOpen(false)
-            }
-          }}
-        >
-          <ChromeButton
-            onClick={toggleMute}
-            ariaLabel={muted || volume === 0 ? "Unmute" : "Mute"}
-            testId="hero-chrome-mute"
-          >
-            {muted || volume === 0 ? <ChromeMutedIcon /> : <ChromeVolumeIcon />}
-          </ChromeButton>
-          <div
-            data-testid="hero-chrome-volume-container"
-            data-open={volumeOpen || volumeDragging ? "true" : "false"}
-            className={`overflow-hidden transition-[width,margin] duration-200 ease-out ${
-              volumeOpen || volumeDragging ? "ml-2 w-24" : "ml-0 w-0"
-            }`}
-          >
-            <div
-              ref={volumeTrackRef}
-              role="slider"
-              tabIndex={0}
-              aria-label="Volume"
-              data-testid="hero-chrome-volume-slider"
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-valuenow={Math.round((muted ? 0 : volume) * 100)}
-              aria-valuetext={`${Math.round((muted ? 0 : volume) * 100)} percent`}
-              onPointerDown={handleVolumePointerDown}
-              onPointerMove={handleVolumePointerMove}
-              onPointerUp={handleVolumePointerUp}
-              onPointerCancel={handleVolumePointerUp}
-              onLostPointerCapture={handleVolumeLostPointerCapture}
-              onKeyDown={handleVolumeKey}
-              className="group relative h-1 w-full cursor-pointer touch-none rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
-            >
-              <div
-                className="absolute inset-y-0 left-0 rounded-l-full bg-white"
-                style={{ width: `${(muted ? 0 : volume) * 100}%` }}
-              />
-              <div
-                className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow transition ${
-                  muted || volume === 0
-                    ? "opacity-0"
-                    : "opacity-0 group-hover:opacity-100 group-focus:opacity-100"
-                }`}
-                style={{ left: `${(muted ? 0 : volume) * 100}%` }}
-              />
-            </div>
-          </div>
-        </div>
-
-        <ChromeButton
-          onClick={toggleFullscreen}
-          ariaLabel={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-          testId="hero-chrome-fullscreen"
-        >
-          {isFullscreen ? <ExitFullscreenIcon /> : <EnterFullscreenIcon />}
-        </ChromeButton>
-      </div>
+      {overlayAnchor != null ? createPortal(chromeBar, overlayAnchor) : null}
     </>
   )
 }

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -179,7 +179,7 @@ describe("HeroPlayer — initial mount", () => {
 })
 
 describe("HeroPlayer — iOS-safe click sequence (AE1)", () => {
-  it("synchronously assigns muted=false, currentTime=0, then calls play() inside the click task", async () => {
+  it("synchronously assigns muted=false then calls play() inside the click task — leaves currentTime alone so the muted-loop preview continues seamlessly", async () => {
     act(() => {
       root.render(<HeroPlayer block={makeBlock()} />)
     })
@@ -230,7 +230,7 @@ describe("HeroPlayer — iOS-safe click sequence (AE1)", () => {
       pill.click()
     })
 
-    expect(events).toEqual(["muted=false", "currentTime=0", "play()"])
+    expect(events).toEqual(["muted=false", "play()"])
     expect(mockPlayerRef.current?.play).toHaveBeenCalledTimes(1)
   })
 
@@ -628,4 +628,156 @@ describe("HeroPlayer — auto-hide timer", () => {
   it.todo(
     "does not auto-hide while paused — needs mock listener-invocation upgrade so React state syncs to mock changes",
   )
+})
+
+// ---------------------------------------------------------------------------
+// Sticky-hero / portal layout (the scroll-over-hero refactor).
+// These tests cover what the visual refactor introduced: the chrome bar
+// gets portaled into the overlay anchor (not the sticky wrapper), the
+// tap-to-unmute branch leaves currentTime alone, and the sticky `top`
+// inline style is computed from the measured wrapper height.
+// ---------------------------------------------------------------------------
+
+describe("HeroPlayer — sticky-hero / portal layout", () => {
+  it("portals the chrome bar into the overlay anchor, not the sticky hero wrapper", async () => {
+    await revealChrome()
+    const chrome = container.querySelector(
+      '[data-testid="hero-player-custom-chrome"]',
+    )
+    const anchor = container.querySelector(
+      '[data-testid="hero-player-overlay-anchor"]',
+    )
+    const wrapper = container.querySelector(
+      '[data-testid="hero-player-wrapper"]',
+    )
+    expect(chrome).not.toBeNull()
+    expect(anchor).not.toBeNull()
+    expect(wrapper).not.toBeNull()
+    // Portal target — chrome bar lives under the zero-height anchor that
+    // scrolls with the body section, not under the sticky hero wrapper.
+    expect(anchor!.contains(chrome!)).toBe(true)
+    expect(wrapper!.contains(chrome!)).toBe(false)
+  })
+
+  it("tap-to-unmute branch calls play() without resetting currentTime", async () => {
+    // mockPlayerRef.current is null until the muxPlayerMock factory runs
+    // during render — so we have to render first, then swap play() to
+    // reject (driving the pill into 'tap-to-unmute' state on click 1).
+    act(() => {
+      root.render(<HeroPlayer block={makeBlock()} />)
+    })
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.play = vi.fn(() =>
+        Promise.reject(new Error("NotAllowedError")),
+      )
+    }
+
+    const pillFirst = container.querySelector(
+      '[data-testid="hero-player-unmute-pill"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      pillFirst.click()
+    })
+
+    const pillNow = container.querySelector(
+      '[data-testid="hero-player-unmute-pill"]',
+    )
+    expect(pillNow).not.toBeNull()
+    expect(pillNow?.getAttribute("data-state")).toBe("tap-to-unmute")
+
+    // Phase 2: snapshot a non-zero playhead, swap play() back to resolve
+    // (so click 2 hits the tap-to-unmute branch's setChromeRevealed path),
+    // and trap any currentTime writes.
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.currentTime = 5.5
+      mockPlayerRef.current.play = vi.fn(() => Promise.resolve())
+    }
+    const events: string[] = []
+    if (mockPlayerRef.current) {
+      const player = mockPlayerRef.current
+      let currentTime = player.currentTime
+      Object.defineProperty(player, "currentTime", {
+        get: () => currentTime,
+        set: (v: number) => {
+          currentTime = v
+          events.push("currentTime=" + String(v))
+        },
+        configurable: true,
+      })
+    }
+
+    await act(async () => {
+      ;(pillNow as HTMLButtonElement).click()
+    })
+
+    // The tap-to-unmute branch must call play() but must NOT touch
+    // currentTime — resetting to 0 here is exactly the muted-preview
+    // restart the play-with-sound fix removed, and the same rule applies
+    // to the autoplay-blocked recovery path.
+    expect(events).toEqual([])
+    expect(mockPlayerRef.current?.play).toHaveBeenCalledTimes(1)
+  })
+
+  it("computes sticky `top` from measured hero height once ResizeObserver fires", async () => {
+    // Stub ResizeObserver so we can trigger the height-update callback by
+    // hand. JSDOM ships without it; the component falls back to the initial
+    // getBoundingClientRect read (which returns 0 in JSDOM, so heroHeight
+    // stays null without this stub).
+    const callbacks: ResizeObserverCallback[] = []
+    class MockResizeObserver {
+      callback: ResizeObserverCallback
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
+        callbacks.push(callback)
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+    const originalRO = (
+      globalThis as { ResizeObserver?: typeof ResizeObserver }
+    ).ResizeObserver
+    ;(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver
+
+    try {
+      act(() => {
+        root.render(<HeroPlayer block={makeBlock()} />)
+      })
+
+      const wrapper = container.querySelector(
+        '[data-testid="hero-player-wrapper"]',
+      ) as HTMLDivElement
+      expect(wrapper).not.toBeNull()
+      // Pre-measurement: heroHeight is null, top falls back to "0px".
+      expect(wrapper.style.top).toBe("0px")
+
+      // Fire the observer with a 1071px (16:9 at 1920w) measurement.
+      await act(async () => {
+        callbacks[0]?.(
+          [
+            { contentRect: { height: 1071 } } as ResizeObserverEntry,
+          ] as ResizeObserverEntry[],
+          {} as ResizeObserver,
+        )
+      })
+
+      // Spot-check the substantive parts of the calc — JSDOM's CSS
+      // serializer normalizes whitespace inconsistently around operators
+      // inside min(), so we don't pin the exact format.
+      const top = wrapper.style.top
+      expect(top.startsWith("min(")).toBe(true)
+      expect(top).toContain("0px")
+      expect(top).toContain("calc(100svh - 1071px)")
+    } finally {
+      if (originalRO) {
+        ;(
+          globalThis as { ResizeObserver?: typeof ResizeObserver }
+        ).ResizeObserver = originalRO
+      } else {
+        delete (globalThis as { ResizeObserver?: typeof ResizeObserver })
+          .ResizeObserver
+      }
+    }
+  })
 })

--- a/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
+++ b/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
@@ -1,6 +1,7 @@
 ---
 title: Mux Player + custom React-rendered chrome (HeroPlayerControls pattern)
 date: 2026-04-30
+last_updated: 2026-05-01
 category: docs/solutions/design-patterns
 module: apps/web, packages/video-player
 problem_type: design_pattern
@@ -20,12 +21,18 @@ tags:
   - keyboard-accessibility
   - lift-state
   - ios-fullscreen
+  - sticky-positioning
+  - react-portal
+  - scroll-over-video
+  - resize-observer
+  - svh-units
 applies_when:
   - You need to customize Mux Player chrome beyond what its CSS Custom Properties expose
   - You need a layout that media-chrome's slot system cannot express (e.g., play+timeline inline at 60% width with auto-hide)
   - You need first-party React state for the chrome (auto-hide timers, hover-pauses-timer logic, focus-within keyboard reveal)
   - You need agent-native test IDs / data attributes that you can't add to Mux's shadow DOM
   - You need iOS Safari fullscreen on the wrapper element (requires webkit-prefixed fallbacks)
+  - You want a sticky-hero scroll-over layout where body content slides over the pinned video with a frosted-glass effect
   - You explicitly accept the trade — losing Mux's accessibility, captions, AirPlay, and quality-selector affordances and rebuilding only what you ship
 ---
 
@@ -151,7 +158,171 @@ Stack the chrome layers explicitly. Inside the player wrapper:
 | Backdrop gradient (`<div aria-hidden>`)              | (no z)  | none           | Visual readability backdrop                       |
 | Chrome (`<div data-visible={...}>`)                  | `z-10`  | auto (always)  | Play / timeline / time / volume / fullscreen      |
 
-Do **not** flip the chrome to `pointer-events-none` when auto-hiding. Doing so blocks agent `.click()` and keyboard interactions even though the user can still see roughly where the controls were. Keep `pointer-events: auto` always; toggle only `opacity` (and let the wrapper-level reveal listeners bring it back to opacity-100 on the next interaction).
+Do **not** flip the chrome to `pointer-events-none` when auto-hiding. Doing so blocks agent `.click()` and keyboard interactions even though the user can still see roughly where the controls were. Keep `pointer-events: auto` always; toggle only `opacity` (and let the reveal listeners — see section 5 below for the dual-target binding rule once chrome is portaled — bring it back to opacity-100 on the next interaction).
+
+### 5. Sticky-hero scroll-over-video layout (added 2026-05-01)
+
+When the watch page wants the video to **pin** at the viewport while body content slides over it with a frosted-glass effect, four pieces are load-bearing. Skip any one and the layout breaks subtly.
+
+#### 5a. Sticky positioning with measured height — `top: min(0px, calc(100svh - heroHeight))`
+
+The hero `<MuxPlayer>` is taller than the viewport on desktop (1071px tall in a 783px viewport at 1920w). Naive `position: sticky; top: 0` pins the **top** edge immediately and the hero never scrolls — users never reach the bottom of the player. The desired contract is _let the hero scroll naturally until its bottom edge reaches the viewport bottom, then pin._ That requires a negative `top` value derived from the live measured height.
+
+```tsx
+// apps/web/src/components/watch/HeroPlayer.tsx
+const [heroHeight, setHeroHeight] = useState<number | null>(null)
+
+useEffect(() => {
+  const el = wrapperRef.current
+  if (!el) return
+  const apply = (h: number) => {
+    if (h > 0) setHeroHeight(h)
+  }
+  apply(el.getBoundingClientRect().height)
+  if (typeof ResizeObserver === "undefined") return
+  const observer = new ResizeObserver((entries) => {
+    const entry = entries[0]
+    if (entry) apply(entry.contentRect.height)
+  })
+  observer.observe(el)
+  return () => observer.disconnect()
+}, [])
+
+// In JSX:
+<div
+  ref={wrapperRef}
+  className="sticky w-full overflow-hidden bg-black"
+  style={{
+    top:
+      heroHeight != null
+        ? `min(0px, calc(100svh - ${heroHeight}px))`
+        : "0px",
+  }}
+>
+```
+
+The formula `min(0px, calc(100svh - heroHeight))` has two cases:
+
+- When `heroHeight > 100svh`: the result is negative. The hero scrolls naturally until its bottom hits the viewport bottom, then pins.
+- When `heroHeight <= 100svh`: the result is `0px` or positive; `min` clamps it to `0px`. The hero pins flush to the top from the start. (Equivalent to ordinary sticky-top-zero on small viewports.)
+
+**Use `100svh`, not `100vh`.** On iOS Safari, `100vh` resolves to the _large_ viewport (URL bar hidden) regardless of whether the URL bar is currently showing. While the URL bar is up, `getBoundingClientRect` reflects the actual constrained height — so `100vh - heroHeight` may go slightly positive, `min(0px, +)` clamps to zero, and the hero pins immediately at the top. `100svh` (small viewport) is always ≤ the visible height, keeping the formula negative when the hero is taller than the current visible area.
+
+The `if (h > 0)` guard prevents a brief flash where `getBoundingClientRect` returns zero before layout. The `typeof ResizeObserver === "undefined"` guard keeps the effect compatible with jsdom (the test environment ships without RO; the initial getBoundingClientRect read is enough for `top: 0px` fallback rendering).
+
+#### 5b. Zero-height anchor in normal flow
+
+Render a `<div className="relative z-10 h-0 w-full">` immediately after the sticky wrapper. The anchor is in normal flow (not sticky), so it scrolls with the document body. Anything absolutely-positioned to its `bottom-0` edge therefore travels upward as the user scrolls — exactly tracking the top of the body section.
+
+```tsx
+const [overlayAnchor, setOverlayAnchor] = useState<HTMLDivElement | null>(null)
+
+return (
+  <>
+    <div ref={wrapperRef} className="sticky ...">
+      {/* MuxPlayer + click surface + gradient */}
+    </div>
+    <div
+      ref={setOverlayAnchor}
+      data-testid="hero-player-overlay-anchor"
+      className="relative z-10 h-0 w-full"
+    >
+      {!chromeRevealed ? (
+        <div
+          data-testid="hero-player-overlay"
+          className="absolute right-6 bottom-0 left-10 pb-6 ..."
+        >
+          {/* SHORTFILM label, title, Play with Sound pill */}
+        </div>
+      ) : null}
+    </div>
+  </>
+)
+```
+
+`h-0` is critical. The anchor takes up no vertical space in layout — it is purely a positioning origin. Two pieces attach to its `bottom-0`:
+
+- The pre-reveal title/label/Play-with-Sound overlay renders as a direct child while `chromeRevealed === false`.
+- The post-reveal chrome control bar from `<HeroPlayerControls>` is portaled into the same anchor while `chromeRevealed === true` (see 5c).
+
+Both ride the body section's top edge during scroll instead of being trapped at the sticky hero's pinned bottom (where they would otherwise be covered by the sliding body).
+
+#### 5c. Portal the chrome bar into the anchor
+
+Inside `HeroPlayerControls`, the chrome bar JSX is portaled into the anchor passed in as a prop. The click-surface and bottom gradient stay inside the sticky wrapper (they need to cover/darken the player); only the chrome bar moves out.
+
+```tsx
+// apps/web/src/components/watch/HeroPlayerControls.tsx
+import { createPortal } from "react-dom"
+
+const chromeBar = (
+  <div
+    data-testid="hero-player-custom-chrome"
+    className="absolute bottom-0 left-1/2 z-10 -translate-x-1/2 ..."
+  >
+    {/* Play / Timeline / Time / Mute / Fullscreen */}
+  </div>
+)
+
+return (
+  <>
+    <button
+      data-testid="hero-player-click-surface" /* inside wrapper, click-anywhere-to-pause */
+    />
+    <div /* gradient at bottom of wrapper */ />
+    {overlayAnchor != null ? createPortal(chromeBar, overlayAnchor) : null}
+  </>
+)
+```
+
+The portal severs the React component tree from the DOM tree: `<HeroPlayerControls>` lives under `<HeroPlayer>` in React (receiving `player`, `playerRef`, `wrapperRef`, `overlayAnchor` props naturally), but its chrome-bar DOM is injected into the anchor that lives in normal flow. This is the only way to keep a single component reading wrapper/player refs while rendering chrome DOM at a different scroll-tracking position.
+
+The parent always renders the anchor div before this component mounts (gated on `chromeRevealed`), so `overlayAnchor` is non-null by the time `HeroPlayerControls` renders. There is no need for an inline-render fallback — at first that path looked defensive, but it is unreachable in practice and adds confusion.
+
+#### 5d. Reveal listeners on BOTH the wrapper AND the anchor
+
+This is the gotcha that wasted real time. `HeroPlayerControls` attaches reveal listeners (`pointermove`, `touchmove`, `touchstart`, `click`, `keydown`) to a target element so `showControls()` re-runs on user interaction. The naive choice is `wrapperRef.current` — and that worked when the chrome bar was a child of the wrapper. **Once the chrome bar is portaled into the anchor**, the chrome bar lives in a DOM subtree that is a _sibling_ of the wrapper, not a descendant. Native event listeners only fire on events bubbling through their own DOM subtree. Wrapper-only binding silently misses every event on the portaled chrome bar — the auto-hide cycle becomes one-way: 3-second timer hides controls, hovering or keyboard-focusing the bar never re-reveals them.
+
+Bind to **both** targets:
+
+```tsx
+useEffect(() => {
+  const reveal = () => showControls()
+  const targets = [wrapperRef.current, overlayAnchor].filter(
+    (t): t is HTMLDivElement => t != null,
+  )
+  for (const target of targets) {
+    target.addEventListener("pointermove", reveal)
+    target.addEventListener("touchmove", reveal)
+    target.addEventListener("touchstart", reveal)
+    target.addEventListener("click", reveal)
+    target.addEventListener("keydown", reveal)
+  }
+  return () => {
+    for (const target of targets) {
+      target.removeEventListener("pointermove", reveal)
+      target.removeEventListener("touchmove", reveal)
+      target.removeEventListener("touchstart", reveal)
+      target.removeEventListener("click", reveal)
+      target.removeEventListener("keydown", reveal)
+    }
+  }
+}, [wrapperRef, overlayAnchor, showControls])
+```
+
+Pointermove on the chrome bar bubbles through chrome → anchor → reveal handler. Pointermove on the video itself bubbles through MuxPlayer → wrapper → reveal handler. Both paths covered.
+
+**Verify by dispatching `new PointerEvent("pointermove", { bubbles: true })` on the chrome bar** after auto-hide and confirming `data-visible` flips back to `"true"`. This is the single behavior worth a Playwright assertion.
+
+#### 5e. Frosted-glass body slides over the pinned hero
+
+The body section sibling-rendered after the hero already had `bg-stone-800` overridden with `rgb(var(--color-section-default) / 0.65)` plus `backdrop-blur-2xl`. With sticky hero behind it in paint order and `backdrop-filter: blur(40px)` on the body, the browser samples the playing video texture through the translucent body — the dark frosted-glass effect "for free." No JavaScript or canvas compositing is required.
+
+**Stacking-context caveat.** The pattern depends on the sticky hero and the body section sharing a stacking context rooted at or near the page root. Any ancestor with `transform`, `filter`, `backdrop-filter`, `will-change`, `opacity < 1`, or `isolation: isolate` between page root and the hero will silently create a new stacking context and can flip paint order — breaking the glass effect or trapping the chrome bar under the body. Cross-reference [`docs/solutions/best-practices/nextjs-search-overlay-ui-patterns-20260415.md`](../best-practices/nextjs-search-overlay-ui-patterns-20260415.md) §2 for the full list of stacking-context-creating CSS properties; portaling out of trapping subtrees is the same escape hatch used by the search overlay.
+
+**Tab-order caveat.** The portaled chrome bar appears far below the sticky hero in DOM source order. Keyboard users tabbing through the page will reach the chrome at a point in the tab sequence that does not match its visual position. Consider `tabindex` management or a focus trap when the chrome is revealed if tab-order fidelity is important.
+
+**Backdrop-blur compositor cost.** `backdrop-blur-2xl` (40px) repaints the blur over a moving Mux video texture every scroll frame. Flagship desktop and recent phones hold 60fps; midrange Android (~2–3 yr old Snapdragon) often drops to 30–45fps during scroll. Profile on a Pixel 6a / Galaxy A-series device before broad rollout. If frame drops are unacceptable, lower the blur radius (`backdrop-blur-xl` / `-lg`) on small viewports or fall back to a solid translucent color when `prefers-reduced-motion` is set. (session history — mobile counterpart pattern quantized scroll updates for the same reason; see Related)
 
 ## Why This Matters
 
@@ -309,7 +480,9 @@ const handleVolumeLostPointerCapture = useCallback(() => {
 
 ### Pre-reveal pill iOS-safe sequence (preserve from prior session)
 
-Do not perturb this sequence. Both the unmute branch and the tap-to-unmute (autoplay-blocked) branch must call `play()` synchronously inside the click handler with no `await` separating them. (session history — load-bearing invariant)
+The load-bearing invariant is **"no `await` between the click gesture and `player.play()`"** — both branches must call `play()` synchronously in the same task as the click. (session history — iOS user-activation requirement)
+
+**Updated 2026-05-01:** the `player.currentTime = 0` reset that originally appeared in the play-with-sound branch was removed. The muted-loop preview is already running by the time the user clicks Play with Sound (typically 2–8 seconds in); resetting to frame 0 on unmute sends a visual + auditory cue users read as "the video reloaded." Continuing from the current playhead is the correct affordance, and it does not perturb the iOS invariant — only the `await`-free contract between click and `play()` is load-bearing.
 
 ```tsx
 const handleUnmuteClick = useCallback(() => {
@@ -326,8 +499,10 @@ const handleUnmuteClick = useCallback(() => {
     return
   }
 
+  // Continue from the current playhead — the muted-loop preview is already
+  // running, so resetting currentTime would force a re-buffer and restart
+  // from frame 0, which the user reads as "the video reloaded."
   player.muted = false
-  player.currentTime = 0
   const result = player.play()
   if (result?.then) {
     result
@@ -344,20 +519,105 @@ const handleUnmuteClick = useCallback(() => {
 }, [pillState])
 ```
 
+**Race window worth knowing about (not currently fixed).** `loop = !chromeRevealed` flips on the next render after `setChromeRevealed(true)`. There is a ~16ms window where the muted-loop preview is at `currentTime ≈ duration` and the user clicks Play with Sound: `play()` resolves, `setChromeRevealed(true)` is queued, but `ended` could fire while `loop` is still `true` — looping the preview to `0`, the very symptom the `currentTime = 0` removal was avoiding. Worst on short clips clicked within milliseconds of `duration`. Narrow window, low impact; flagged for future hardening if it turns into a reproducible regression.
+
 ### Don't rebuild what's already there
 
 Before building the chrome from scratch, check `packages/video-player/src/useVideoPlayerCore.ts` — it already exposes `formatTime()`, `handlePlayPause`, `handleMuteToggle`, `handleSeek`, `handleFullscreen` for the legacy video.js 8 surface. Some of those primitives can be lifted directly (e.g., `formatTime`). The HeroPlayerControls implementation duplicated `formatTime` rather than importing it — a minor follow-up to consolidate. (session history — prior art exists; check before reimplementing)
 
 ### Test fixture pattern
 
-The new `HeroPlayerControls` test suite lives in `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`. The Mux Player is mocked at the module boundary with a singleton mock player exposing `paused`, `muted`, `volume`, `currentTime`, `duration`, `buffered`, `play`, `pause`, `addEventListener`, `removeEventListener`. The `revealChrome()` helper renders `<HeroPlayer>`, clicks the pill, awaits the play promise — the chrome is now mounted and `mockPlayerRef.current` is the singleton. Tests then directly mutate the mock and dispatch `KeyboardEvent`s on `data-testid="hero-chrome-timeline"` etc.
+The `HeroPlayerControls` test suite lives in `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`. The Mux Player is mocked at the module boundary with a singleton mock player exposing `paused`, `muted`, `volume`, `currentTime`, `duration`, `buffered`, `play`, `pause`, `addEventListener`, `removeEventListener`. The `revealChrome()` helper renders `<HeroPlayer>`, clicks the pill, awaits the play promise — the chrome is now mounted and `mockPlayerRef.current` is the singleton. Tests then directly mutate the mock and dispatch `KeyboardEvent`s on `data-testid="hero-chrome-timeline"` etc.
 
 **Limitation to be aware of:** the mock's `addEventListener` is `vi.fn()` — it doesn't actually invoke captured callbacks. So tests that need React state to _react_ to mock-state changes (e.g., "does not auto-hide while paused" needs `playingRef.current` to flip to `false`) currently fail and are marked `it.todo`. Upgrading the mock to capture and replay listeners would unlock those tests; tracked as a follow-up.
+
+**Coverage added 2026-05-01 for the sticky/portal layout.** Three tests cover the new layer:
+
+1. **Portal placement** — asserts the chrome bar lives inside the overlay anchor, not the sticky hero wrapper. Required because both DOM positions resolve the same `[data-testid="hero-player-custom-chrome"]` selector (`container.querySelector` finds it whether portaled or rendered inline), so the assertions in the existing chrome-render tests pass for either branch. Without this test, the portal contract is unenforced.
+
+   ```tsx
+   it("portals the chrome bar into the overlay anchor, not the sticky hero wrapper", async () => {
+     await revealChrome()
+     const chrome = container.querySelector(
+       '[data-testid="hero-player-custom-chrome"]',
+     )
+     const anchor = container.querySelector(
+       '[data-testid="hero-player-overlay-anchor"]',
+     )
+     const wrapper = container.querySelector(
+       '[data-testid="hero-player-wrapper"]',
+     )
+     expect(anchor!.contains(chrome!)).toBe(true)
+     expect(wrapper!.contains(chrome!)).toBe(false)
+   })
+   ```
+
+2. **Tap-to-unmute leaves currentTime alone** — the play-with-sound branch's no-restart contract is already covered by the iOS-safe click sequence test (event order `["muted=false", "play()"]` with no `currentTime=0`). The tap-to-unmute branch needs the same coverage. Phase 1: render, swap `mockPlayerRef.current.play` to reject so the pill flips into `data-state="tap-to-unmute"`. Phase 2: snapshot a non-zero playhead, swap `play` back to resolve, install an `Object.defineProperty` setter spy on `currentTime`, click. Assert no `currentTime` writes occurred.
+
+3. **Sticky `top` from measured height** — JSDOM ships without `ResizeObserver`, so the component's RO branch is normally unreachable in tests. Stub it locally:
+
+   ```tsx
+   const callbacks: ResizeObserverCallback[] = []
+   class MockResizeObserver {
+     constructor(cb: ResizeObserverCallback) {
+       callbacks.push(cb)
+     }
+     observe() {}
+     disconnect() {}
+     unobserve() {}
+   }
+   const originalRO = (globalThis as { ResizeObserver?: typeof ResizeObserver })
+     .ResizeObserver
+   ;(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+     MockResizeObserver as unknown as typeof ResizeObserver
+
+   try {
+     act(() => {
+       root.render(<HeroPlayer block={makeBlock()} />)
+     })
+     // Trigger the captured RO callback with a measured height.
+     await act(async () => {
+       callbacks[0]?.(
+         [
+           { contentRect: { height: 1071 } } as ResizeObserverEntry,
+         ] as ResizeObserverEntry[],
+         {} as ResizeObserver,
+       )
+     })
+     const wrapper = container.querySelector(
+       '[data-testid="hero-player-wrapper"]',
+     ) as HTMLDivElement
+     // JSDOM's CSSOM normalizes whitespace inside min() inconsistently
+     // across engines — check structure rather than exact format.
+     expect(wrapper.style.top).toContain("calc(100svh - 1071px)")
+   } finally {
+     if (originalRO) {
+       ;(
+         globalThis as { ResizeObserver?: typeof ResizeObserver }
+       ).ResizeObserver = originalRO
+     } else {
+       delete (globalThis as { ResizeObserver?: typeof ResizeObserver })
+         .ResizeObserver
+     }
+   }
+   ```
+
+   The `finally` block restores the prior global unconditionally (in JSDOM, `originalRO` is `undefined`, so the block deletes the global rather than reassigning it) — preventing test pollution across the suite.
+
+**Live verification before declaring done.** The dev server + browser-automation MCP catch the things JSDOM cannot. The minimum smoke after a sticky/portal change:
+
+- `wrapper.getBoundingClientRect().height` matches the rendered video aspect (1071px on a 1920w window for 16:9).
+- `getComputedStyle(wrapper).top` is negative (e.g., `-288.56px`) on a desktop viewport.
+- After clicking Play with Sound: `anchor.contains(chrome) === true && wrapper.contains(chrome) === false`.
+- After 3s auto-hide, dispatching `new PointerEvent("pointermove", { bubbles: true })` on the chrome bar flips `data-visible` from `"false"` back to `"true"`.
 
 ## Related
 
 - [`docs/solutions/design-patterns/react-strictmode-dom-wrapping-widget-teardown-20260424.md`](./react-strictmode-dom-wrapping-widget-teardown-20260424.md) — sibling pattern for the widget setup/teardown rules; the lift-to-state guidance here is the same principle applied to event subscription.
+- [`docs/solutions/best-practices/nextjs-search-overlay-ui-patterns-20260415.md`](../best-practices/nextjs-search-overlay-ui-patterns-20260415.md) — `createPortal` and the stacking-context trap. Same escape hatch (portal out of trapping subtrees) used by the search overlay; the load-bearing rule about ancestors that silently create stacking contexts (`transform`, `filter`, `backdrop-filter`, `will-change`, `opacity < 1`, `isolation`) applies equally here.
+- [`docs/solutions/mobile/full-bleed-video-hero-with-scroll-over-content.md`](../mobile/full-bleed-video-hero-with-scroll-over-content.md) — the React Native counterpart of the same UX. Different runtime (RN absolute positioning + JS scroll callbacks vs. CSS sticky + portal), but the design decisions translate: render overlay content inside the scroll content (not the hero layer), quantize scroll updates to avoid 60fps re-renders, and avoid event-binding patterns whose silent failure mode hides controls forever.
 - [`docs/plans/2026-04-29-001-feat-watch-page-mux-parity-plan.md`](../../plans/2026-04-29-001-feat-watch-page-mux-parity-plan.md) — the plan that documented the Mux-vs-Video.js decision, the iOS-safe play() invariant (U5), and the original "hide-then-reveal" model that this pattern diverges from.
 - `packages/video-player/src/useVideoPlayerCore.ts` — direct prior art for the timeline/slider/play-pause/fullscreen primitives on video.js 8; reference when extending the Mux chrome with new controls.
 - `apps/tv/src/components/VideoPlayer.tsx` — TV-side parallel implementation (expo-video + D-pad). Different runtime but the timeline/scrubbing UX should converge with web. (session history)
-- PR [#866](https://github.com/JesusFilm/forge/pull/866) — the implementation this pattern documents.
+- PR [#866](https://github.com/JesusFilm/forge/pull/866) — the original implementation this pattern documents (chrome replacement and lift-to-state).
+- The 2026-05-01 update layer (sections 5a–5e and the iOS-safe sequence patch) was developed against `main` directly without a separate PR; the working tree carries the change.


### PR DESCRIPTION
## Summary

The watch page hero player becomes `position: sticky` with a measured-height-driven `top: min(0px, calc(100svh - heroHeight))`. A zero-height anchor div in normal flow hosts the title/Play-with-Sound overlay (pre-reveal) and the chrome control bar (post-reveal, via `react-dom/createPortal`), so both ride the body section's top edge as the body slides over the pinned video with the existing frosted-glass backdrop.

`handleUnmuteClick` no longer resets `currentTime` to 0 — the muted-loop preview continues seamlessly when the user clicks "Play with Sound." The iOS user-activation invariant ("no `await` between gesture and `play()`") is preserved.

A `/ce-code-review` pass surfaced and fixed an interaction bug: chrome auto-hide reveal listeners were attached to `wrapperRef` only, which silently misses events on the portaled chrome bar (it lives in a sibling DOM subtree). Reveal listeners now bind to BOTH `wrapperRef` and `overlayAnchor`.

`100svh` (not `100vh`) keeps the pin point correct on iOS Safari while the URL bar is up. The unreachable inline-render fallback for the chrome bar is removed; the `overlayAnchor` prop is now non-optional.

## Why

- **User asked for it**: "When I scroll, the page should scroll until the bottom of the video player is visible, then the body content should slide over the video with a dark frosted-glass effect, the video still visible blurred behind."
- **Plus follow-on requests**: title/pill must slide with the body; chrome bar must slide with the body; "Play with Sound" must not restart the video.

## What changed

- `apps/web/src/components/watch/HeroPlayer.tsx` — sticky positioning + ResizeObserver-driven height, zero-height overlay anchor, removed `currentTime = 0` from unmute, `data-testid="hero-player-overlay-anchor"` for tests.
- `apps/web/src/components/watch/HeroPlayerControls.tsx` — chrome bar portaled into the anchor via `createPortal`; reveal listeners dual-bind to wrapper + anchor; `overlayAnchor` prop now non-optional; dead inline-render fallback removed.
- `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx` — three new tests:
  - portal placement (chrome lives in anchor, not wrapper)
  - tap-to-unmute branch leaves currentTime alone
  - sticky `top` computed from measured height once ResizeObserver fires (uses a local ResizeObserver stub with `finally`-block restore)
- `docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md` — compound learning updated with sections 5a–5e covering the sticky/portal layer, the dual-target reveal-listener rule, the `100svh` rationale, and the `currentTime = 0` removal. Existing stale snippet patched. Cross-references added to the search-overlay stacking-context doc and the mobile full-bleed counterpart.

## Test plan

- [x] `pnpm vitest run src/components/watch/__tests__/` — 92 tests pass (3 new + 89 existing across 10 watch suites).
- [x] `pnpm tsc --noEmit -p tsconfig.json` — clean.
- [x] Live browser smoke at `http://localhost:3000/watch/considering-christmas/en`:
  - Sticky `top` resolves to `-288.56px` after measurement on a 1920×783 viewport with a 1071px hero.
  - After "Play with Sound": `chromeInsideAnchor: true`, `chromeInsideWrapper: false`.
  - Auto-hide → dispatched `pointermove` on the chrome bar flips `data-visible` from `"false"` back to `"true"`.
  - Body slides up over the pinned hero with the dark frosted-glass effect; title/pill (pre-reveal) and chrome bar (post-reveal) ride the body's top edge.
- [ ] **Verify on real iPhone hardware** before declaring done — `100svh` and the iPhone fullscreen delegation caveat still apply.
- [ ] **Profile on a midrange Android** (Pixel 6a / Galaxy A-series) before broad rollout — `backdrop-blur-2xl` over a moving Mux video texture every scroll frame is a known compositor stress pattern.

## Code review

Ran `/ce-code-review` (10-reviewer pass: correctness, testing, maintainability, project-standards, agent-native, learnings, adversarial, kieran-typescript, julik-frontend-races, performance). The reveal-listener race (P1) and the iOS dynamic-viewport bug (P2) were caught by the adversarial + julik reviewers and fixed in the same branch via the option-B "auto-resolve with best judgment" path. No P0 findings; pre-existing P3s on the tap-to-unmute branch are unchanged.

## Compound learning

Documented at `docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md` (extended from the prior chrome doc rather than creating a duplicate, per high overlap detected by the related-docs research pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)