### PR TITLE
fix(manager): persist coverage language selection

### DIFF
--- a/apps/manager/src/features/coverage/LanguageGeoSelector.tsx
+++ b/apps/manager/src/features/coverage/LanguageGeoSelector.tsx
@@ -45,6 +45,7 @@ interface LanguageGeoSelectorProps {
   attentionRequired?: boolean
   attentionRequestKey?: number
   openRequestKey?: number
+  onApplyLanguages?: (languageIds: string[]) => void
 }
 
 function normalizeText(value: string): string {
@@ -98,6 +99,7 @@ export function LanguageGeoSelector({
   attentionRequired = false,
   attentionRequestKey = 0,
   openRequestKey = 0,
+  onApplyLanguages,
 }: LanguageGeoSelectorProps) {
   const pathname = usePathname()
   const router = useRouter()
@@ -476,6 +478,11 @@ export function LanguageGeoSelector({
     }
 
     setIsLoading(true)
+    if (onApplyLanguages) {
+      onApplyLanguages(nextLanguageIds)
+      return
+    }
+
     if (navigationTimeoutRef.current) {
       window.clearTimeout(navigationTimeoutRef.current)
     }

--- a/apps/manager/src/features/coverage/coverage-report-client.tsx
+++ b/apps/manager/src/features/coverage/coverage-report-client.tsx
@@ -9,15 +9,19 @@ import React, {
   useState,
 } from "react"
 import { FilterX, Search, ServerOff } from "lucide-react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 
 import { LanguageSelectionEmptyState } from "./coverage-empty-state"
 import { EnrichActionControls } from "./enrich-action-controls"
 import { LanguageGeoSelector } from "./LanguageGeoSelector"
 import {
+  clearRememberedCoverageLanguageIds,
   hasSelectedLanguages as hasSelectedLanguagesInSelection,
   normalizeCoverageLanguageSearchParams,
+  readRememberedCoverageLanguageIds,
+  resolveCoverageLanguageSelection,
   resolveLanguagePresets,
+  writeRememberedCoverageLanguageIds,
   type LanguageOption,
   type LanguagePreset,
 } from "./language-selection"
@@ -874,6 +878,8 @@ export function CoverageReportClient({
   initialLanguages,
 }: CoverageReportClientProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const currentCoverageQuery = searchParams.toString()
   const shell = useOptionalManagerShellState()
   const [videoCollections, setVideoCollections] = useState<CmsCollection[]>([])
   const [videoCollectionsLoadFailed, setVideoCollectionsLoadFailed] =
@@ -913,6 +919,7 @@ export function CoverageReportClient({
   const [languageNameMap, setLanguageNameMap] = useState<Map<string, string>>(
     new Map(),
   )
+  const automaticCoverageSelectionQueryRef = useRef<string | null>(null)
   // Fetch language names once for display in the selection bar
   useEffect(() => {
     void (async () => {
@@ -933,6 +940,57 @@ export function CoverageReportClient({
       }
     })()
   }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const currentQuery = currentCoverageQuery
+    const rememberedLanguageIds = readRememberedCoverageLanguageIds(
+      window.sessionStorage,
+    )
+    if (
+      languageCatalog.length === 0 &&
+      currentQuery.length === 0 &&
+      rememberedLanguageIds.length === 0
+    ) {
+      return
+    }
+
+    const resolution = resolveCoverageLanguageSelection({
+      currentQuery,
+      rememberedLanguageIds,
+      languages: languageCatalog,
+    })
+
+    if (automaticCoverageSelectionQueryRef.current === currentQuery) {
+      automaticCoverageSelectionQueryRef.current = null
+    } else if (resolution.shouldRememberSelection) {
+      writeRememberedCoverageLanguageIds(
+        window.sessionStorage,
+        resolution.languageIds,
+      )
+    }
+
+    if (!resolution.shouldReplaceUrl) return
+
+    const nextParams = normalizeCoverageLanguageSearchParams(
+      currentQuery,
+      resolution.languageIds,
+    )
+    const queryString = nextParams.toString()
+    const nextUrl = queryString
+      ? `/dashboard/coverage?${queryString}`
+      : "/dashboard/coverage"
+
+    if (`${window.location.pathname}${window.location.search}` === nextUrl) {
+      return
+    }
+
+    automaticCoverageSelectionQueryRef.current = queryString
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- typed routes does not accept dynamic query strings here
+    router.replace(nextUrl as any)
+  }, [currentCoverageQuery, languageCatalog, router])
   const errorMessage = initialErrorMessage
   const [filter, setFilter] = useState<CoverageFilter>("all")
   const [hoveredVideo, setHoveredVideo] = useState<HoveredVideoDetails | null>(
@@ -1403,6 +1461,14 @@ export function CoverageReportClient({
 
   const applySelectedLanguages = useCallback(
     (languageIds: string[]) => {
+      if (typeof window !== "undefined") {
+        if (languageIds.length > 0) {
+          writeRememberedCoverageLanguageIds(window.sessionStorage, languageIds)
+        } else {
+          clearRememberedCoverageLanguageIds(window.sessionStorage)
+        }
+      }
+
       const nextParams = normalizeCoverageLanguageSearchParams(
         typeof window === "undefined" ? "" : window.location.search,
         languageIds,
@@ -1481,6 +1547,7 @@ export function CoverageReportClient({
               attentionRequired={languageSelectionRequired}
               attentionRequestKey={languageSelectorFocusRequestCount}
               openRequestKey={languageSelectorOpenRequestCount}
+              onApplyLanguages={applySelectedLanguages}
             />
           </div>
         </section>

--- a/apps/manager/src/features/coverage/language-selection.test.ts
+++ b/apps/manager/src/features/coverage/language-selection.test.ts
@@ -118,7 +118,6 @@ describe("language-selection", () => {
       }),
     ).toEqual({
       languageIds: ["529"],
-      reason: "query",
       shouldReplaceUrl: false,
       shouldRememberSelection: true,
     })
@@ -133,7 +132,6 @@ describe("language-selection", () => {
       }),
     ).toEqual({
       languageIds: ["6414", "529"],
-      reason: "legacy-query",
       shouldReplaceUrl: true,
       shouldRememberSelection: true,
     })
@@ -150,7 +148,6 @@ describe("language-selection", () => {
       }),
     ).toEqual({
       languageIds: ["6414", "529"],
-      reason: "remembered",
       shouldReplaceUrl: true,
       shouldRememberSelection: false,
     })
@@ -168,7 +165,6 @@ describe("language-selection", () => {
       }),
     ).toEqual({
       languageIds: ["529"],
-      reason: "default-english",
       shouldReplaceUrl: true,
       shouldRememberSelection: false,
     })
@@ -185,7 +181,6 @@ describe("language-selection", () => {
       }),
     ).toEqual({
       languageIds: [],
-      reason: "none",
       shouldReplaceUrl: false,
       shouldRememberSelection: false,
     })

--- a/apps/manager/src/features/coverage/language-selection.test.ts
+++ b/apps/manager/src/features/coverage/language-selection.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  clearRememberedCoverageLanguageIds,
   hasSelectedLanguages,
+  readRememberedCoverageLanguageIds,
   normalizeCoverageLanguageSearchParams,
   parseRequestedLanguageIds,
+  resolveCoverageLanguageSelection,
+  resolveEnglishLanguageId,
   resolveLanguagePresets,
   resolveRequestedLanguageIds,
+  writeRememberedCoverageLanguageIds,
   type LanguageOption,
 } from "@/features/coverage/language-selection"
 
@@ -86,5 +91,136 @@ describe("language-selection", () => {
     expect(normalized.get("mediaType")).toBe("series")
     expect(normalized.get("languageIds")).toBeNull()
     expect(normalized.get("languageId")).toBeNull()
+  })
+
+  it("resolves English from the language catalog without hardcoding the id", () => {
+    const languages: LanguageOption[] = [
+      { id: "529", englishLabel: "English", nativeLabel: "English" },
+      { id: "6414", englishLabel: "French", nativeLabel: "Français" },
+    ]
+
+    expect(resolveEnglishLanguageId(languages)).toBe("529")
+    expect(
+      resolveEnglishLanguageId([
+        { id: "6414", englishLabel: "French", nativeLabel: "Français" },
+      ]),
+    ).toBeNull()
+  })
+
+  it("keeps explicit canonical languageId selection authoritative over memory", () => {
+    expect(
+      resolveCoverageLanguageSelection({
+        currentQuery: "languageId=529",
+        rememberedLanguageIds: ["6414"],
+        languages: [
+          { id: "529", englishLabel: "English", nativeLabel: "English" },
+        ],
+      }),
+    ).toEqual({
+      languageIds: ["529"],
+      reason: "query",
+      shouldReplaceUrl: false,
+      shouldRememberSelection: true,
+    })
+  })
+
+  it("normalizes legacy languageIds selection without letting memory win", () => {
+    expect(
+      resolveCoverageLanguageSelection({
+        currentQuery: "origin=jobs&languageIds=6414,529",
+        rememberedLanguageIds: ["21028"],
+        languages: [],
+      }),
+    ).toEqual({
+      languageIds: ["6414", "529"],
+      reason: "legacy-query",
+      shouldReplaceUrl: true,
+      shouldRememberSelection: true,
+    })
+  })
+
+  it("restores remembered languages for bare coverage routes", () => {
+    expect(
+      resolveCoverageLanguageSelection({
+        currentQuery: "",
+        rememberedLanguageIds: ["6414", "529"],
+        languages: [
+          { id: "529", englishLabel: "English", nativeLabel: "English" },
+        ],
+      }),
+    ).toEqual({
+      languageIds: ["6414", "529"],
+      reason: "remembered",
+      shouldReplaceUrl: true,
+      shouldRememberSelection: false,
+    })
+  })
+
+  it("falls back to English for bare routes without remembered languages", () => {
+    expect(
+      resolveCoverageLanguageSelection({
+        currentQuery: "",
+        rememberedLanguageIds: [],
+        languages: [
+          { id: "529", englishLabel: "English", nativeLabel: "English" },
+          { id: "6414", englishLabel: "French", nativeLabel: "Français" },
+        ],
+      }),
+    ).toEqual({
+      languageIds: ["529"],
+      reason: "default-english",
+      shouldReplaceUrl: true,
+      shouldRememberSelection: false,
+    })
+  })
+
+  it("does not invent a default when English is unavailable", () => {
+    expect(
+      resolveCoverageLanguageSelection({
+        currentQuery: "",
+        rememberedLanguageIds: [],
+        languages: [
+          { id: "6414", englishLabel: "French", nativeLabel: "Français" },
+        ],
+      }),
+    ).toEqual({
+      languageIds: [],
+      reason: "none",
+      shouldReplaceUrl: false,
+      shouldRememberSelection: false,
+    })
+  })
+
+  it("stores, reads, and clears remembered coverage language ids", () => {
+    const storage = new Map<string, string>()
+    const memoryStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+    }
+
+    writeRememberedCoverageLanguageIds(memoryStorage, [
+      " 6414 ",
+      "529",
+      "6414",
+      "",
+    ])
+    expect(readRememberedCoverageLanguageIds(memoryStorage)).toEqual([
+      "6414",
+      "529",
+    ])
+
+    writeRememberedCoverageLanguageIds(memoryStorage, [])
+    expect(readRememberedCoverageLanguageIds(memoryStorage)).toEqual([])
+
+    writeRememberedCoverageLanguageIds(memoryStorage, ["21028"])
+    expect(readRememberedCoverageLanguageIds(memoryStorage)).toEqual(["21028"])
+
+    clearRememberedCoverageLanguageIds(memoryStorage)
+    expect(readRememberedCoverageLanguageIds(memoryStorage)).toEqual([])
   })
 })

--- a/apps/manager/src/features/coverage/language-selection.ts
+++ b/apps/manager/src/features/coverage/language-selection.ts
@@ -14,16 +14,8 @@ export type CoverageLanguageSearchParams = {
   languageIds?: string
 }
 
-export type CoverageLanguageSelectionReason =
-  | "query"
-  | "legacy-query"
-  | "remembered"
-  | "default-english"
-  | "none"
-
 export type CoverageLanguageSelectionResolution = {
   languageIds: string[]
-  reason: CoverageLanguageSelectionReason
   shouldReplaceUrl: boolean
   shouldRememberSelection: boolean
 }
@@ -93,13 +85,6 @@ function toSearchParams(
   }
 
   return new URLSearchParams(currentQuery.replace(/^\?/, ""))
-}
-
-export function hasExplicitCoverageLanguageQuery(
-  currentQuery: string | URLSearchParams,
-): boolean {
-  const params = toSearchParams(currentQuery)
-  return params.has("languageId") || params.has("languageIds")
 }
 
 export function normalizeCoverageLanguageSearchParams(
@@ -196,7 +181,6 @@ export function resolveCoverageLanguageSelection({
   if (params.has("languageId")) {
     return {
       languageIds: requestedLanguageIds,
-      reason: "query",
       shouldReplaceUrl: false,
       shouldRememberSelection: requestedLanguageIds.length > 0,
     }
@@ -205,7 +189,6 @@ export function resolveCoverageLanguageSelection({
   if (params.has("languageIds")) {
     return {
       languageIds: requestedLanguageIds,
-      reason: "legacy-query",
       shouldReplaceUrl: true,
       shouldRememberSelection: requestedLanguageIds.length > 0,
     }
@@ -215,7 +198,6 @@ export function resolveCoverageLanguageSelection({
   if (remembered.length > 0) {
     return {
       languageIds: remembered,
-      reason: "remembered",
       shouldReplaceUrl: true,
       shouldRememberSelection: false,
     }
@@ -225,7 +207,6 @@ export function resolveCoverageLanguageSelection({
   if (englishLanguageId) {
     return {
       languageIds: [englishLanguageId],
-      reason: "default-english",
       shouldReplaceUrl: true,
       shouldRememberSelection: false,
     }
@@ -233,7 +214,6 @@ export function resolveCoverageLanguageSelection({
 
   return {
     languageIds: [],
-    reason: "none",
     shouldReplaceUrl: false,
     shouldRememberSelection: false,
   }

--- a/apps/manager/src/features/coverage/language-selection.ts
+++ b/apps/manager/src/features/coverage/language-selection.ts
@@ -14,6 +14,25 @@ export type CoverageLanguageSearchParams = {
   languageIds?: string
 }
 
+export type CoverageLanguageSelectionReason =
+  | "query"
+  | "legacy-query"
+  | "remembered"
+  | "default-english"
+  | "none"
+
+export type CoverageLanguageSelectionResolution = {
+  languageIds: string[]
+  reason: CoverageLanguageSelectionReason
+  shouldReplaceUrl: boolean
+  shouldRememberSelection: boolean
+}
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">
+
+export const COVERAGE_LANGUAGE_SELECTION_STORAGE_KEY =
+  "forge-coverage-language-ids"
+
 const LANGUAGE_PRESET_DEFINITIONS: Array<{
   label: string
   aliases: string[]
@@ -66,6 +85,23 @@ export function resolveRequestedLanguageIds(
   )
 }
 
+function toSearchParams(
+  currentQuery: string | URLSearchParams,
+): URLSearchParams {
+  if (currentQuery instanceof URLSearchParams) {
+    return new URLSearchParams(currentQuery)
+  }
+
+  return new URLSearchParams(currentQuery.replace(/^\?/, ""))
+}
+
+export function hasExplicitCoverageLanguageQuery(
+  currentQuery: string | URLSearchParams,
+): boolean {
+  const params = toSearchParams(currentQuery)
+  return params.has("languageId") || params.has("languageIds")
+}
+
 export function normalizeCoverageLanguageSearchParams(
   currentQuery: string,
   languageIds: string[],
@@ -81,6 +117,126 @@ export function normalizeCoverageLanguageSearchParams(
   }
 
   return nextParams
+}
+
+export function resolveEnglishLanguageId(
+  languages: LanguageOption[],
+): string | null {
+  return (
+    resolveLanguagePresets(languages).find(
+      (preset) => preset.label === "English",
+    )?.id ?? null
+  )
+}
+
+export function readRememberedCoverageLanguageIds(
+  storage: StorageLike | undefined,
+): string[] {
+  if (!storage) return []
+
+  try {
+    return parseRequestedLanguageIds(
+      storage.getItem(COVERAGE_LANGUAGE_SELECTION_STORAGE_KEY) ?? undefined,
+    )
+  } catch {
+    return []
+  }
+}
+
+export function writeRememberedCoverageLanguageIds(
+  storage: StorageLike | undefined,
+  languageIds: string[],
+) {
+  if (!storage) return
+
+  const normalized = parseRequestedLanguageIds(languageIds.join(","))
+
+  try {
+    if (normalized.length === 0) {
+      storage.removeItem(COVERAGE_LANGUAGE_SELECTION_STORAGE_KEY)
+      return
+    }
+
+    storage.setItem(
+      COVERAGE_LANGUAGE_SELECTION_STORAGE_KEY,
+      normalized.join(","),
+    )
+  } catch {
+    // Ignore storage errors so private browsing or quota issues do not break navigation.
+  }
+}
+
+export function clearRememberedCoverageLanguageIds(
+  storage: StorageLike | undefined,
+) {
+  if (!storage) return
+
+  try {
+    storage.removeItem(COVERAGE_LANGUAGE_SELECTION_STORAGE_KEY)
+  } catch {
+    // Ignore storage errors.
+  }
+}
+
+export function resolveCoverageLanguageSelection({
+  currentQuery,
+  rememberedLanguageIds,
+  languages,
+}: {
+  currentQuery: string | URLSearchParams
+  rememberedLanguageIds: string[]
+  languages: LanguageOption[]
+}): CoverageLanguageSelectionResolution {
+  const params = toSearchParams(currentQuery)
+  const requestedLanguageIds = resolveRequestedLanguageIds({
+    languageId: params.get("languageId") ?? undefined,
+    languageIds: params.get("languageIds") ?? undefined,
+  })
+
+  if (params.has("languageId")) {
+    return {
+      languageIds: requestedLanguageIds,
+      reason: "query",
+      shouldReplaceUrl: false,
+      shouldRememberSelection: requestedLanguageIds.length > 0,
+    }
+  }
+
+  if (params.has("languageIds")) {
+    return {
+      languageIds: requestedLanguageIds,
+      reason: "legacy-query",
+      shouldReplaceUrl: true,
+      shouldRememberSelection: requestedLanguageIds.length > 0,
+    }
+  }
+
+  const remembered = parseRequestedLanguageIds(rememberedLanguageIds.join(","))
+  if (remembered.length > 0) {
+    return {
+      languageIds: remembered,
+      reason: "remembered",
+      shouldReplaceUrl: true,
+      shouldRememberSelection: false,
+    }
+  }
+
+  const englishLanguageId = resolveEnglishLanguageId(languages)
+  if (englishLanguageId) {
+    return {
+      languageIds: [englishLanguageId],
+      reason: "default-english",
+      shouldReplaceUrl: true,
+      shouldRememberSelection: false,
+    }
+  }
+
+  return {
+    languageIds: [],
+    reason: "none",
+    shouldReplaceUrl: false,
+    shouldRememberSelection: false,
+  }
 }
 
 export function resolveLanguagePresets(

--- a/docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md
+++ b/docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md
@@ -1,0 +1,83 @@
+---
+date: 2026-05-01
+topic: manager-coverage-language-persistence
+---
+
+# Manager Coverage Language Persistence
+
+Roadmap: `docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md`
+
+## Problem Frame
+
+The Manager coverage report currently treats language selection as URL state only. That keeps shared links honest, but it creates a frustrating operator loop: a user can select a custom language set, move to another dashboard page, return to `/dashboard/coverage`, and land back in the language-first state because the main dashboard navigation points at the bare route.
+
+The default first-run experience also does not match the expected workflow. When a manager opens `/dashboard/coverage` without a language query, English should already be selected so the report is useful immediately. Users should not have to repeatedly reselect English or their own custom languages during normal dashboard navigation.
+
+## Requirements
+
+- R1. A first visit to `/dashboard/coverage` with no explicit language query and no remembered coverage selection selects English by default.
+- R2. English is resolved from the Manager language catalog by the existing language identity, not by hardcoding a display-only label into coverage API calls.
+- R3. When a user selects one or more custom languages, that exact selected set becomes the remembered coverage selection for the current dashboard session.
+- R4. If the user navigates to other Manager dashboard pages and returns to `/dashboard/coverage`, the coverage report restores the remembered custom language selection.
+- R5. An explicit coverage URL query, such as `?languageId=529` or legacy `?languageIds=529`, always wins over remembered state.
+- R6. The browser URL remains canonical: coverage page state should continue to use `languageId` for selected languages, while internal API calls may keep using the existing `languageIds` API contract.
+- R7. Clearing the selected language set intentionally resets the remembered custom selection; the next bare coverage visit falls back to English.
+
+## Success Criteria
+
+- Opening `/dashboard/coverage` from a fresh Manager session shows English selected and loads English-scoped coverage without manual selection.
+- Selecting Spanish, French, or a multi-language custom set, visiting Jobs or Agents, and returning to Report preserves the same selected language chips and report data.
+- Visiting a copied URL with `languageId` produces the URL's selection even if the session previously remembered a different custom set.
+- Existing legacy links that use `languageIds` still work and are normalized to the canonical `languageId` route state.
+
+## Scope Boundaries
+
+- This is not a redesign of the coverage language picker.
+- This does not change coverage aggregation semantics or the `/api/video-coverage` data contract.
+- This does not make metadata coverage language-specific.
+- This does not require persistent cross-device preferences; same-browser session memory is enough for the stated workflow.
+- This does not remove support for legacy `languageIds` links.
+
+## Approaches Considered
+
+### Recommended: URL-Authoritative State With Session Return Memory
+
+Keep the URL as the source of truth whenever it names a language selection, and add a remembered coverage selection only for bare `/dashboard/coverage` returns. First bare visit resolves to English; later bare returns restore the user's last custom selection.
+
+This best fits the existing Manager pattern because coverage already centralizes query parsing and normalization around `languageId`, while shell mode and report type already use session storage for dashboard-scoped preferences.
+
+### Alternative: URL Carry-Forward Only
+
+Every dashboard link back to Report could carry the current `languageId` query. This is transparent and keeps state shareable, but it only works for links that are explicitly rewritten and does not help direct bare-route returns.
+
+### Alternative: Hidden Preference Only
+
+The app could ignore the URL unless users explicitly share one and always restore a stored language preference. That would reduce visible query churn, but it would weaken the existing URL-backed contract and make copied links less predictable.
+
+## Key Decisions
+
+- URL-backed selection remains authoritative: explicit `languageId` must always override remembered state.
+- English is the default only when the user has not provided a language query and has no remembered coverage selection.
+- Remembered selection is dashboard/session scoped, not a new durable account preference.
+- Clearing all languages resets the remembered custom selection rather than preserving an invisible stale value.
+- Planning should reuse `apps/manager/src/features/coverage/language-selection.ts` as the central state contract.
+
+## Dependencies / Assumptions
+
+- The Manager language catalog contains an English language option that can be resolved consistently.
+- The existing language selector and coverage API paths continue to support comma-separated multi-language IDs.
+- The current shell already stores coverage mode and report type in session storage, so session-scoped language memory is consistent with nearby Manager behavior.
+- Related context lives in:
+  - `docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md`
+  - `docs/solutions/integration-issues/manager-coverage-language-first-empty-state-20260410.md`
+  - `docs/solutions/integration-issues/manager-mock-coverage-language-parity-20260422.md`
+  - `docs/solutions/performance-issues/manager-video-coverage-sql-aggregation-20260402.md`
+  - `docs/roadmap/media-generation/feat-041-alternative-report-sections.md`
+
+## Outstanding Questions
+
+None. The requested behavior is specific enough for planning.
+
+## Next Steps
+
+-> `/workflows:plan docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md`

--- a/docs/plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md
+++ b/docs/plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md
@@ -1,0 +1,309 @@
+---
+title: "fix: Manager coverage language persistence"
+type: fix
+status: active
+date: 2026-05-01
+branch: feat/114-manager-coverage-language-persistence
+origin: docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md
+roadmap:
+  - docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
+related_docs:
+  - docs/solutions/integration-issues/manager-coverage-language-first-empty-state-20260410.md
+  - docs/solutions/integration-issues/manager-mock-coverage-language-parity-20260422.md
+  - docs/solutions/integration-issues/manager-coverage-dashboard-review-regression-cleanup.md
+  - docs/solutions/performance-issues/manager-video-coverage-sql-aggregation-20260402.md
+  - docs/solutions/ui-bugs/manager-tailwind-reference-branch-visual-parity-20260429.md
+---
+
+# fix: Manager coverage language persistence
+
+## Overview
+
+Attach a narrow coverage-state follow-up to `feat-114` so Manager users no longer have to repeatedly select the same languages in `/dashboard/coverage`.
+
+The first bare visit to `/dashboard/coverage` should resolve English from the Manager language catalog and canonicalize the URL to `?languageId=<englishId>`. When a user chooses a custom language or multi-language set, that exact user-selected set should be remembered for the current browser session and restored when they return to the bare Report route from Jobs, Agents, or other dashboard pages.
+
+The URL remains the source of truth whenever it is explicit. `languageId` stays canonical browser state, legacy `languageIds` links stay accepted, and `/api/videos` can keep its existing internal `languageIds` API contract.
+
+## Found Brainstorm
+
+Found brainstorm from 2026-05-01: `manager-coverage-language-persistence`.
+Using it as context for planning.
+
+Key decisions:
+
+- URL-backed coverage selection remains authoritative.
+- English is the default only when no explicit query and no remembered custom selection exist.
+- Remembered selection is session-scoped, not a durable account preference.
+- Clearing all selected languages resets custom memory so later bare visits fall back to English.
+- Implementation should reuse `apps/manager/src/features/coverage/language-selection.ts` as the central state contract.
+
+## Problem Statement
+
+Today, `/dashboard/coverage` reads only `searchParams` and passes `initialSelectedLanguageIds` to `CoverageReportClient`. A bare route produces `[]`, so the page skips `/api/videos` and renders the language-first empty state. The Studio shell Report nav also points at bare `/dashboard/coverage`, so users who select a custom language, visit Jobs or Agents, and return to Report lose their selection.
+
+That is frustrating for operators because the coverage dashboard is language-first operational tooling. English should be useful immediately on first entry, and custom language selections should survive ordinary dashboard navigation.
+
+## Research Summary
+
+Local repo research found strong existing patterns, so external research was skipped.
+
+Relevant code:
+
+- `apps/manager/src/app/dashboard/coverage/page.tsx` reads `searchParams` and passes selected IDs into `CoverageReportClient`.
+- `apps/manager/src/features/coverage/language-selection.ts` already parses comma-separated IDs, prefers canonical `languageId`, accepts legacy `languageIds`, and normalizes writes to `languageId`.
+- `apps/manager/src/features/coverage/coverage-report-client.tsx` fetches `/api/languages`, derives presets, and calls `/api/videos?languageIds=...` when languages are selected.
+- `apps/manager/src/features/coverage/LanguageGeoSelector.tsx` owns picker confirmation and pill removal URL writes.
+- `apps/manager/src/features/shell/manager-shell.tsx` stores coverage mode/report type in `sessionStorage` and renders the bare Report nav link.
+- `apps/manager/src/app/api/languages/cache.ts` serves the Manager language catalog from mock or live CMS.
+- `apps/manager/src/cms/mock-seed.ts` contains seeded English `529`, Spanish `21028`, and French `6414`, which makes local smoke practical.
+
+Institutional learnings:
+
+- Keep query parsing/writes centralized; stale plural `languageIds` previously caused selection regressions.
+- Mock coverage must preserve live semantics: the video set stays stable while selected-language coverage counts change.
+- Do not change coverage aggregation semantics or reintroduce GraphQL/N+1 coverage reads.
+- Do not collapse empty data, loading, and failure states; English defaulting should not turn an empty result into an outage.
+- This is part of the Tailwind/Studio follow-up surface, so preserve functional deltas and verify in a real browser.
+
+## SpecFlow Notes
+
+User flows:
+
+1. Fresh bare visit: `/dashboard/coverage` has no language query and no remembered selection. The app resolves English, canonicalizes to `?languageId=<englishId>`, and loads English coverage.
+2. Custom selection return: user selects French, Spanish, or multiple languages, navigates to Jobs or Agents, then clicks Report. The bare Report route restores the remembered custom selection.
+3. Explicit query override: user opens `?languageId=529` or legacy `?languageIds=529` while session memory contains another language. The URL wins.
+4. Clear selection: user removes the final selected language or confirms an empty picker. Custom memory clears; subsequent bare coverage visits fall back to English.
+5. Jobs/detail carry-forward: existing Jobs links that read either query key and write singular `languageId` remain compatible.
+
+Default assumptions for implementation:
+
+- Use `router.replace`, not `router.push`, when canonicalizing automatic default, remembered selection, or legacy query state.
+- Do not store the automatic English default as the custom remembered selection.
+- If the user explicitly chooses English, remember that explicit choice like any other user selection.
+- Use `window.sessionStorage`, matching existing shell mode/report type behavior.
+- If English cannot be resolved from the catalog, keep the existing language-first state and do not hardcode an ID.
+
+## Scope Boundaries
+
+In scope:
+
+- Manager coverage route and language-selection behavior.
+- Session-scoped coverage language memory.
+- Canonical URL normalization for default, remembered, and legacy query states.
+- Focused red/green tests around pure helper contracts.
+- Mock-mode browser smoke through the real Manager UI.
+- Updating the attached `feat-114` roadmap doc and this implementation plan.
+
+Out of scope:
+
+- Redesigning the language picker or coverage layout.
+- Changing `/api/video-coverage` aggregation semantics.
+- Making metadata coverage language-specific.
+- Creating account-level or cross-device language preferences.
+- Removing legacy `languageIds` support.
+- Adding a TSX/jsdom test stack to Manager just for this slice.
+
+## Implementation Plan
+
+### Unit 1: Add Red tests for coverage language state resolution
+
+Red:
+
+- Extend `apps/manager/src/features/coverage/language-selection.test.ts`.
+- Add failing tests for a new pure resolver that can decide the next canonical coverage selection from:
+  - current query string
+  - remembered session IDs
+  - available `LanguageOption[]`
+  - whether the selection came from user intent or automatic defaulting
+- Cover:
+  - explicit `languageId` wins over memory
+  - legacy `languageIds` wins over memory and normalizes to `languageId`
+  - remembered IDs are used when the route has no language query
+  - English is resolved from catalog when no query and no memory exist
+  - no English match returns no automatic default
+  - clearing all IDs resets remembered custom selection
+
+Expected red evidence:
+
+```bash
+pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts
+```
+
+The new tests should fail before helper implementation.
+
+Green:
+
+- Add small helpers in `apps/manager/src/features/coverage/language-selection.ts`, for example:
+  - `hasExplicitCoverageLanguageQuery(searchParamsOrQuery)`
+  - `resolveEnglishLanguageId(languages)`
+  - `resolveCoverageLanguageSelection(input)`
+  - `readRememberedCoverageLanguageIds(storage)`
+  - `writeRememberedCoverageLanguageIds(storage, ids)`
+  - `clearRememberedCoverageLanguageIds(storage)`
+- Keep helper behavior pure or storage-injected where possible so it remains testable under the current Node-only Vitest config.
+- Reuse existing `parseRequestedLanguageIds()` and `normalizeCoverageLanguageSearchParams()`.
+
+Refactor:
+
+- Keep `languageId` as the only canonical browser query key.
+- Keep unrelated query params that `normalizeCoverageLanguageSearchParams()` already preserves.
+- Keep `refresh`, `languageId`, and `languageIds` cleanup centralized.
+
+### Unit 2: Canonicalize bare, remembered, and legacy routes in the coverage client
+
+Red:
+
+- The Unit 1 helper tests should describe the route decisions before React wiring changes.
+- Add at least one focused helper assertion that the intended navigation mode is `replace` for automatic default, remembered restore, and legacy normalization.
+
+Green:
+
+- In `apps/manager/src/features/coverage/coverage-report-client.tsx`, after `/api/languages` resolves:
+  - detect whether the current URL has explicit `languageId` or `languageIds`
+  - if legacy `languageIds` is present, `router.replace()` the canonical singular `languageId`
+  - if no explicit query and remembered custom selection exists, `router.replace()` to canonical `languageId=<remembered>`
+  - if no explicit query and no remembered selection exists, resolve English from `languageCatalog` and `router.replace()` to canonical English
+  - if English is unavailable, leave the current empty-state behavior alone
+- Use `router.replace` to avoid polluting browser history with automatic state repair.
+- Keep `selectedLanguageIds` URL-derived; do not create a second hidden React state source for coverage data.
+
+Refactor:
+
+- Avoid changing coverage filtering, report type, enrichment selection, or `/api/videos` fetch semantics.
+- Avoid adding `any` beyond the existing typed-route escape hatches already used for dynamic query strings.
+
+### Unit 3: Persist user-initiated language changes and reset on clear
+
+Red:
+
+- Extend helper tests for memory write/reset behavior:
+  - non-empty user selection writes the exact deduped IDs
+  - explicit empty selection clears memory
+  - automatic English default does not write custom memory
+  - explicit user-selected English does write memory
+
+Green:
+
+- Update `CoverageReportClient.applySelectedLanguages()` to write remembered custom selection before navigating:
+  - non-empty arrays: store exact normalized IDs in `sessionStorage`
+  - empty arrays: clear stored custom selection
+- Pass an equivalent callback or intent flag into `LanguageGeoSelector` if needed so pill removal and picker confirmation both run through the same memory/update helper.
+- Keep `LanguageGeoSelector` URL writes canonical by continuing to use `normalizeCoverageLanguageSearchParams()`.
+
+Refactor:
+
+- Do not let shell Report nav carry hidden state by manually appending query params. Bare Report links should remain safe because the coverage page repairs bare state using memory/default rules.
+- Keep session memory scoped to a clearly named key, such as `forge-coverage-language-ids`.
+
+### Unit 4: Preserve API and mock coverage parity
+
+Red:
+
+- Existing API tests should continue to pass:
+
+```bash
+pnpm --filter @forge/manager test -- --run src/app/api/videos/route.test.ts src/app/api/videos/route.mock.test.ts
+```
+
+- If implementation touches API code, add a failing route/cache test first. Otherwise, do not broaden API scope.
+
+Green:
+
+- Keep `/api/videos` receiving `languageIds`, not browser-facing `languageId`.
+- Keep mock gateway behavior unchanged: selected IDs alter subtitle/audio coverage counts while preserving the video set.
+- Keep metadata coverage derived from existing `aiMetadata` behavior.
+
+Refactor:
+
+- Do not touch CMS schema, GraphQL codegen, or Strapi video coverage SQL.
+
+### Unit 5: User smoke test and PR validation
+
+Run this only after green focused tests.
+
+Mock-mode browser smoke:
+
+1. Start Manager in mock mode on this branch.
+2. Log in with:
+   - email: `manager@forge.test`
+   - password: `mock-manager-password`
+3. Open `/dashboard/coverage` in a fresh browser session.
+4. Confirm English is selected and the URL is canonicalized to `?languageId=529`.
+5. Confirm the coverage request uses `/api/videos?languageIds=529`.
+6. Select French `6414` or Spanish `21028`.
+7. Navigate to Jobs or Agents.
+8. Click Report.
+9. Confirm the same custom selected language chips return without reselecting.
+10. Confirm the URL is canonical `languageId=...` and coverage data changes meaningfully, not just the selected chip.
+11. Open `/dashboard/coverage?languageId=529` while session memory has another language and confirm English wins.
+12. Open `/dashboard/coverage?languageIds=6414` and confirm it normalizes to `languageId=6414`.
+13. Remove the last selected language, then return to bare `/dashboard/coverage` and confirm English is selected again.
+
+PR-focused validation:
+
+```bash
+pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts src/app/api/videos/route.test.ts src/app/api/videos/route.mock.test.ts
+pnpm --filter @forge/manager lint
+pnpm --filter @forge/manager typecheck
+git diff --check
+```
+
+Before PR:
+
+- Keep branch name `feat/114-manager-coverage-language-persistence`.
+- Keep PR target `main`.
+- Do not skip pre-commit hooks.
+- Include red/green evidence and browser smoke notes in the PR description.
+
+## Acceptance Criteria
+
+- [ ] Bare `/dashboard/coverage` in a fresh Manager session resolves English from `/api/languages`.
+- [ ] Bare `/dashboard/coverage` canonicalizes to `?languageId=<englishId>` via replace-style navigation.
+- [ ] English coverage loads without the user manually selecting English.
+- [ ] Custom single-language selection is remembered across Jobs/Agents/Report dashboard navigation in the same tab.
+- [ ] Custom multi-language selection is remembered exactly and encoded as comma-separated canonical `languageId`.
+- [ ] Explicit `?languageId=...` always wins over remembered session selection.
+- [ ] Legacy `?languageIds=...` works, wins over memory, and normalizes to singular `languageId`.
+- [ ] Clearing the last selected language clears remembered custom state.
+- [ ] After clear/reset, a later bare `/dashboard/coverage` falls back to English.
+- [ ] If English cannot be resolved from the catalog, no hardcoded ID is used and the existing language-first state remains.
+- [ ] `/api/videos` continues to receive `languageIds` internally.
+- [ ] Metadata coverage remains library-wide and is not made language-specific.
+- [ ] Red/Green TDD evidence is captured before implementation is considered complete.
+- [ ] User smoke test evidence is captured before PR.
+
+## Risks & Mitigations
+
+- Risk: auto-defaulting makes clear selection feel impossible.
+  Mitigation: define clear as a custom-memory reset and document that bare coverage falls back to English by product decision.
+- Risk: hidden session memory overrides shared links.
+  Mitigation: explicit `languageId` and legacy `languageIds` always win.
+- Risk: automatic default weakens URL-backed truth.
+  Mitigation: canonicalize with `router.replace` so the browser URL reflects the selected language.
+- Risk: live and mock behavior diverge.
+  Mitigation: keep API unchanged and include mock-mode smoke using seeded English/French/Spanish IDs.
+- Risk: React component tests require new test infrastructure.
+  Mitigation: keep red/green unit coverage in pure helpers under existing Node Vitest, and prove integrated behavior with browser smoke.
+
+## Verification Checklist
+
+- [ ] Red test fails before implementation.
+- [ ] Targeted helper tests pass after implementation.
+- [ ] API regression tests pass.
+- [ ] Lint passes.
+- [ ] Typecheck passes.
+- [ ] `git diff --check` passes.
+- [ ] Mock-mode browser smoke passes with screenshots or written evidence.
+- [ ] `docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md` is returned to `status: "complete"` when implementation and smoke are done.
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md`
+- Roadmap: `docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md`
+- Query helpers: `apps/manager/src/features/coverage/language-selection.ts`
+- Coverage client: `apps/manager/src/features/coverage/coverage-report-client.tsx`
+- Language picker: `apps/manager/src/features/coverage/LanguageGeoSelector.tsx`
+- Shell nav/session pattern: `apps/manager/src/features/shell/manager-shell.tsx`
+- Manager language route: `apps/manager/src/app/api/languages/route.ts`
+- Mock seed language IDs: `apps/manager/src/cms/mock-seed.ts`

--- a/docs/plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md
+++ b/docs/plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Manager coverage language persistence"
 type: fix
-status: active
+status: complete
 date: 2026-05-01
 branch: feat/114-manager-coverage-language-persistence
 origin: docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md
@@ -258,20 +258,20 @@ Before PR:
 
 ## Acceptance Criteria
 
-- [ ] Bare `/dashboard/coverage` in a fresh Manager session resolves English from `/api/languages`.
-- [ ] Bare `/dashboard/coverage` canonicalizes to `?languageId=<englishId>` via replace-style navigation.
-- [ ] English coverage loads without the user manually selecting English.
-- [ ] Custom single-language selection is remembered across Jobs/Agents/Report dashboard navigation in the same tab.
-- [ ] Custom multi-language selection is remembered exactly and encoded as comma-separated canonical `languageId`.
-- [ ] Explicit `?languageId=...` always wins over remembered session selection.
-- [ ] Legacy `?languageIds=...` works, wins over memory, and normalizes to singular `languageId`.
-- [ ] Clearing the last selected language clears remembered custom state.
-- [ ] After clear/reset, a later bare `/dashboard/coverage` falls back to English.
-- [ ] If English cannot be resolved from the catalog, no hardcoded ID is used and the existing language-first state remains.
-- [ ] `/api/videos` continues to receive `languageIds` internally.
-- [ ] Metadata coverage remains library-wide and is not made language-specific.
-- [ ] Red/Green TDD evidence is captured before implementation is considered complete.
-- [ ] User smoke test evidence is captured before PR.
+- [x] Bare `/dashboard/coverage` in a fresh Manager session resolves English from `/api/languages`.
+- [x] Bare `/dashboard/coverage` canonicalizes to `?languageId=<englishId>` via replace-style navigation.
+- [x] English coverage loads without the user manually selecting English.
+- [x] Custom single-language selection is remembered across Jobs/Agents/Report dashboard navigation in the same tab.
+- [x] Custom multi-language selection is remembered exactly and encoded as comma-separated canonical `languageId`.
+- [x] Explicit `?languageId=...` always wins over remembered session selection.
+- [x] Legacy `?languageIds=...` works, wins over memory, and normalizes to singular `languageId`.
+- [x] Clearing the last selected language clears remembered custom state.
+- [x] After clear/reset, a later bare `/dashboard/coverage` falls back to English.
+- [x] If English cannot be resolved from the catalog, no hardcoded ID is used and the existing language-first state remains.
+- [x] `/api/videos` continues to receive `languageIds` internally.
+- [x] Metadata coverage remains library-wide and is not made language-specific.
+- [x] Red/Green TDD evidence is captured before implementation is considered complete.
+- [x] User smoke test evidence is captured before PR.
 
 ## Risks & Mitigations
 
@@ -288,14 +288,21 @@ Before PR:
 
 ## Verification Checklist
 
-- [ ] Red test fails before implementation.
-- [ ] Targeted helper tests pass after implementation.
-- [ ] API regression tests pass.
-- [ ] Lint passes.
-- [ ] Typecheck passes.
-- [ ] `git diff --check` passes.
-- [ ] Mock-mode browser smoke passes with screenshots or written evidence.
-- [ ] `docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md` is returned to `status: "complete"` when implementation and smoke are done.
+- [x] Red test fails before implementation.
+- [x] Targeted helper tests pass after implementation.
+- [x] API regression tests pass.
+- [x] Lint passes.
+- [x] Typecheck passes.
+- [x] `git diff --check` passes.
+- [x] Mock-mode browser smoke passes with screenshots or written evidence.
+- [x] `docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md` is returned to `status: "complete"` when implementation and smoke are done.
+
+## Completion Evidence
+
+- Red: `pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts` failed before helper implementation because the new resolver/storage helpers did not exist.
+- Green: `pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts src/app/api/videos/route.test.ts src/app/api/videos/route.mock.test.ts` passed with 19 tests.
+- Validation: `pnpm --filter @forge/manager lint`, `pnpm --filter @forge/manager typecheck`, and `git diff --check` passed.
+- Smoke: mock-mode Manager browser proof captured screenshots and HAR under `output/smoke/fcdb-coverage-language/`, including default English, custom French restore after Jobs navigation, explicit query override, legacy query normalization, and clear/reset fallback to English.
 
 ## References
 

--- a/docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
+++ b/docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
@@ -47,12 +47,26 @@ The manager app now shares the Studio shell and page-level visual direction, but
 4. Rebuild the Studio shell, auth shell, shared UI primitives, and production screens using Tailwind-backed components and utilities.
 5. Remove migrated global CSS sections as each subsystem moves into TSX-level Tailwind composition.
 
+## Attached Follow-up — Coverage Language Persistence
+
+This ticket also owns the small Manager coverage state follow-up captured in `docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md`.
+
+The follow-up keeps the Studio shell's route and session-state behavior aligned with the migrated Manager UI:
+
+1. Default bare `/dashboard/coverage` visits to English when no explicit query or remembered selection exists.
+2. Remember the user's latest custom coverage language selection for the current dashboard session.
+3. Restore that remembered selection when returning to bare `/dashboard/coverage` from Jobs, Agents, or other Manager pages.
+4. Preserve the canonical URL contract: explicit `languageId` wins, legacy `languageIds` remains accepted, and coverage writes normalize back to `languageId`.
+5. Treat clearing all selected languages as an explicit reset so later bare visits fall back to English.
+
 ## Constraints
 
 - Preserve the current Studio visual language; this is not a redesign.
 - Preserve existing route behavior, auth behavior, URL/query state, and page information architecture.
 - Do not introduce new color tokens or one-off hex values without explicit approval.
 - Keep third-party CSS only where inline migration is unrealistic.
+- Do not replace URL-backed coverage state with hidden-only preferences.
+- Do not hardcode an English core ID; resolve English from the existing language data path.
 
 ## Verification
 
@@ -65,6 +79,7 @@ The manager app now shares the Studio shell and page-level visual direction, but
   - `/dashboard/jobs/[id]`
   - `/dashboard/agents`
 - Confirm no large migrated screen blocks remain in `apps/manager/src/app/globals.css`.
+- Coverage language persistence browser smoke: open `/dashboard/coverage`, confirm English is selected; select a custom language set; navigate to Jobs or Agents; return to Report and confirm the same language set is selected.
 
 ## Completion Notes
 

--- a/docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
+++ b/docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
@@ -3,7 +3,7 @@ id: "feat-114"
 title: "Manager Tailwind Design System Migration"
 owner: "vlad"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-04-20"
 duration: 4
 depends_on:
@@ -86,3 +86,4 @@ The follow-up keeps the Studio shell's route and session-state behavior aligned 
 - Tailwind 4 now powers the manager app through local `apps/manager` configuration, shared UI primitives in `src/components/ui`, and route-level Tailwind composition across shell, auth, coverage, jobs, and agents surfaces.
 - `apps/manager/src/app/globals.css` has been reduced to tokens, theme mapping, base rules, and small browser-specific affordances rather than screen-level styling systems.
 - Browser and route checks were completed for login, coverage, jobs, and agents on the local manager app. The current snapshot exposes no jobs, so a live `/dashboard/jobs/[id]` detail page could not be opened during this pass.
+- The attached coverage language persistence follow-up is complete: bare Coverage defaults to English, custom language selections persist for the dashboard session, explicit query state wins, legacy `languageIds` links normalize to `languageId`, and clearing the final custom language resets back to English fallback behavior.

--- a/docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
+++ b/docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
@@ -3,7 +3,7 @@ id: "feat-114"
 title: "Manager Tailwind Design System Migration"
 owner: "vlad"
 priority: "P1"
-status: "complete"
+status: "in-progress"
 start_date: "2026-04-20"
 duration: 4
 depends_on:
@@ -49,7 +49,7 @@ The manager app now shares the Studio shell and page-level visual direction, but
 
 ## Attached Follow-up — Coverage Language Persistence
 
-This ticket also owns the small Manager coverage state follow-up captured in `docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md`.
+This ticket also owns the small Manager coverage state follow-up captured in `docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md` and planned in `docs/plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md`.
 
 The follow-up keeps the Studio shell's route and session-state behavior aligned with the migrated Manager UI:
 

--- a/docs/solutions/integration-issues/manager-coverage-language-persistence-20260501.md
+++ b/docs/solutions/integration-issues/manager-coverage-language-persistence-20260501.md
@@ -1,0 +1,221 @@
+---
+title: "Manager Coverage Language Persistence"
+category: integration-issues
+date: 2026-05-01
+severity: medium
+tags:
+  - manager
+  - coverage
+  - language-filter
+  - url-state
+  - session-storage
+  - dashboard-navigation
+  - query-params
+affected_components:
+  - apps/manager/src/app/dashboard/coverage/page.tsx
+  - apps/manager/src/features/coverage/language-selection.ts
+  - apps/manager/src/features/coverage/language-selection.test.ts
+  - apps/manager/src/features/coverage/coverage-report-client.tsx
+  - apps/manager/src/features/coverage/LanguageGeoSelector.tsx
+related_docs:
+  - docs/brainstorms/2026-05-01-manager-coverage-language-persistence-requirements.md
+  - docs/plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md
+  - docs/roadmap/platform/feat-114-manager-tailwind-design-system-migration.md
+  - docs/solutions/integration-issues/manager-coverage-language-first-empty-state-20260410.md
+  - docs/solutions/integration-issues/manager-mock-coverage-language-parity-20260422.md
+  - docs/solutions/integration-issues/manager-coverage-dashboard-review-regression-cleanup.md
+  - docs/solutions/performance-issues/manager-video-coverage-sql-aggregation-20260402.md
+related_prs:
+  - https://github.com/JesusFilm/forge/pull/869
+---
+
+# Manager Coverage Language Persistence
+
+## Problem
+
+The Manager Coverage report treated language selection as URL state only. That kept shared links honest, but it made normal dashboard navigation frustrating:
+
+- a bare `/dashboard/coverage` route produced no selected language and showed the language-first empty state
+- fresh Coverage visits did not default to English, so the report was not useful immediately
+- users who selected French, Spanish, or a multi-language set lost that selection after visiting Jobs or Agents and returning through the Report nav
+- legacy `?languageIds=...` links still had to work while the browser URL stayed canonical as `languageId`
+
+The important product distinction was: explicit URL state should always win, but the bare Report route should be repaired into a useful language selection.
+
+## Root Cause
+
+`apps/manager/src/app/dashboard/coverage/page.tsx` parsed only incoming `searchParams` and passed them as `initialSelectedLanguageIds`. When the Studio shell linked back to bare `/dashboard/coverage`, the route resolved to `[]`.
+
+That empty selection made `CoverageReportClient` skip `/api/videos` and render the language-first state. The app already had a good URL contract (`languageId` canonical, `languageIds` legacy), but it did not have:
+
+1. catalog-backed English defaulting for true bare routes
+2. session-scoped return memory for user-applied custom selections
+3. route repair from remembered/default/legacy state back into canonical `languageId`
+4. one shared path for picker confirmation and selected-pill removal to update memory
+
+## Solution
+
+### Keep the URL authoritative
+
+The fix kept the browser URL as the source of truth whenever it explicitly names a selection:
+
+- `languageId` remains the canonical browser query key
+- legacy `languageIds` is still accepted
+- legacy URLs are normalized back to `languageId` with `router.replace`
+- session memory never beats an explicit query
+- `/api/videos` continues to receive internal `languageIds`
+
+That preserves shareable links while still allowing the page to repair bare route state.
+
+### Centralize language-state decisions
+
+`apps/manager/src/features/coverage/language-selection.ts` owns the small state contract:
+
+```ts
+resolveCoverageLanguageSelection({
+  currentQuery,
+  rememberedLanguageIds,
+  languages,
+})
+```
+
+The resolver precedence is:
+
+1. explicit canonical `languageId`
+2. legacy `languageIds`, normalized to canonical URL state
+3. remembered session language IDs
+4. English resolved from the fetched language catalog
+5. no automatic selection if English is unavailable
+
+Supporting helpers keep parsing and storage behavior focused:
+
+- `parseRequestedLanguageIds()` trims, dedupes, and removes empty values
+- `resolveRequestedLanguageIds()` prefers canonical `languageId` while accepting legacy `languageIds`
+- `normalizeCoverageLanguageSearchParams()` removes `refresh`, `languageId`, and `languageIds`, then writes canonical `languageId`
+- `resolveEnglishLanguageId()` resolves English from available `LanguageOption[]`
+- `readRememberedCoverageLanguageIds()`, `writeRememberedCoverageLanguageIds()`, and `clearRememberedCoverageLanguageIds()` wrap `sessionStorage` safely
+
+### Repair bare and legacy routes in the client
+
+`apps/manager/src/features/coverage/coverage-report-client.tsx` fetches `/api/languages`, then asks the resolver what to do with the current query, remembered IDs, and language catalog.
+
+Automatic route repair uses `router.replace()` so defaulting and legacy normalization do not pollute browser history:
+
+- bare route + remembered IDs -> `?languageId=<remembered>`
+- bare route + no memory + English found -> `?languageId=<englishId>`
+- legacy `?languageIds=...` -> canonical `?languageId=...`
+
+The automatic English default is not stored as custom memory. A small ref guard prevents the follow-up `?languageId=<englishId>` render from being treated as a user preference write.
+
+### Route picker writes through one callback
+
+`LanguageGeoSelector` now accepts `onApplyLanguages`. Picker confirmation and selected-pill removal both call back to `CoverageReportClient.applySelectedLanguages()`, which:
+
+- writes non-empty user-applied selections to `sessionStorage`
+- clears remembered selection when the user removes the final language
+- pushes the canonical `languageId` URL
+
+This avoided a split where presets remembered language choices but the geo picker only changed the URL.
+
+### Keep the resolver surface small
+
+A review follow-up removed diagnostic-only resolver API:
+
+- `CoverageLanguageSelectionReason`
+- the `reason` return field
+- unused `hasExplicitCoverageLanguageQuery()`
+
+Tests now assert only the fields production uses: selected IDs, URL replacement intent, and memory-write intent.
+
+## What Didn't Work
+
+**Relying on URL state only**
+
+- **Why it failed:** The shell Report nav points at bare `/dashboard/coverage`, so returning from Jobs or Agents dropped the language query.
+
+**Carrying language state only in shell nav**
+
+- **Why it was not enough:** It helps known dashboard links, but not direct bare routes, reloads, or programmatic route entry. The Coverage page itself needed to repair bare state.
+
+**Hidden preference only**
+
+- **Why it was rejected:** It would weaken the existing shareable URL contract. Explicit `languageId` links must remain predictable and authoritative.
+
+**Hardcoding English as `529`**
+
+- **Why it was rejected:** Mock data uses `529`, but live environments should resolve English from the Manager language catalog rather than baking a core ID into UI logic.
+
+## Why This Works
+
+The durable pattern is URL-authoritative state with visible session repair:
+
+- explicit URLs stay truthful and shareable
+- remembered state only repairs bare Coverage returns
+- every automatic repair is reflected in the URL
+- English defaulting is data-derived from `/api/languages`
+- internal API calls keep the established `/api/videos?languageIds=...` contract
+
+The UI never filters coverage from hidden client-only state. It repairs the URL first, then the route-derived selected language IDs continue to drive the report and `/api/videos` request.
+
+## Verification
+
+Red/green test evidence:
+
+```bash
+pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts
+pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts src/app/api/videos/route.test.ts src/app/api/videos/route.mock.test.ts
+```
+
+PR validation:
+
+```bash
+pnpm --filter @forge/manager lint
+pnpm --filter @forge/manager typecheck
+git diff --check
+```
+
+Browser smoke ran Manager in mock mode at `http://localhost:3002` with `MANAGER_DATA_MODE=mock`. Evidence was captured under `output/smoke/fcdb-coverage-language/`:
+
+- `02-default-english.png` — bare Coverage canonicalized to `?languageId=529`; English coverage loaded
+- `03-selected-french.png` — French selection wrote `forge-coverage-language-ids: 6414`
+- `05-remembered-french-return.png` — Jobs -> Report restored French at `?languageId=6414`
+- `06-explicit-english-overrides-memory.png` — explicit `?languageId=529` beat remembered French
+- `07-legacy-normalized.png` — `?languageIds=21028,6414` normalized to `languageId=21028%2C6414`
+- `08-cleared-falls-back-english.png` — clearing the final custom language removed memory and fell back to English
+- `network.har` — successful `/api/languages` and `/api/videos?languageIds=...` requests for English, French, and multi-language states
+
+## Prevention
+
+1. Keep coverage query parsing and normalization centralized in `language-selection.ts`.
+2. Treat `languageId` as the canonical browser key and `languageIds` as legacy input only.
+3. Let session memory repair only bare routes, and always make the repaired selection visible in the URL.
+4. Resolve defaults from data paths such as `/api/languages`; do not hardcode mock IDs into UI behavior.
+5. Store only deliberate user-applied selections in memory. Automatic defaults should not become custom remembered state.
+6. Route picker confirmation, selected-pill removal, and preset shortcuts through the same memory/update callback.
+7. Keep resolver APIs small and pure. Router and storage side effects belong at the component boundary.
+8. Preserve mock/live parity: changing selected languages should change subtitle/audio counts while preserving the video set.
+
+Future tests should keep covering:
+
+- canonical `languageId` wins over memory
+- legacy `languageIds` normalizes to singular `languageId`
+- bare route restores remembered selection
+- bare route defaults to catalog-resolved English when no memory exists
+- missing English leaves the language-first state intact
+- storage read/write/clear trims, dedupes, and tolerates storage failures
+- browser smoke for default English, custom return memory, legacy normalization, and clear/reset behavior
+
+## Follow-Up
+
+Review found one product nuance that is tracked separately: opening an explicit copied `?languageId=...` URL also updates remembered session memory. That may or may not be desired. If copied links should win only for the current visit, update the resolver/client so memory changes only from user-initiated picker or preset paths.
+
+Tracked locally as `todos/006-pending-p2-explicit-query-overwrites-coverage-language-memory.md`.
+
+## Related
+
+- [`docs/solutions/integration-issues/manager-coverage-language-first-empty-state-20260410.md`](./manager-coverage-language-first-empty-state-20260410.md) — earlier language-first state and `languageId` / `languageIds` normalization work
+- [`docs/solutions/integration-issues/manager-mock-coverage-language-parity-20260422.md`](./manager-mock-coverage-language-parity-20260422.md) — mock coverage must change with selected languages
+- [`docs/solutions/integration-issues/manager-coverage-dashboard-review-regression-cleanup.md`](./manager-coverage-dashboard-review-regression-cleanup.md) — coverage dashboard empty/failure state boundaries
+- [`docs/solutions/performance-issues/manager-video-coverage-sql-aggregation-20260402.md`](../performance-issues/manager-video-coverage-sql-aggregation-20260402.md) — live coverage aggregation and internal `languageIds` filtering contract
+- [`docs/plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md`](../../plans/2026-05-01-fix-manager-coverage-language-persistence-plan.md) — implementation plan and completion evidence
+- [PR #869](https://github.com/JesusFilm/forge/pull/869)


### PR DESCRIPTION
## Summary
- Default bare `/dashboard/coverage` visits to English by resolving the Manager language catalog and canonicalizing to `languageId`.
- Remember user-applied coverage language selections in session storage so returning to Report from Jobs/Agents restores the same custom language set.
- Keep URL-backed state authoritative: explicit `languageId` wins, legacy `languageIds` links normalize to `languageId`, and `/api/videos` still receives internal `languageIds`.
- Attach completion evidence to `feat-114` and mark the implementation plan complete.

## Testing
- Red: `pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts` failed before helper implementation because the new resolver/storage helpers were missing.
- Green: `pnpm --filter @forge/manager test -- --run src/features/coverage/language-selection.test.ts src/app/api/videos/route.test.ts src/app/api/videos/route.mock.test.ts`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager typecheck`
- `git diff --check`

## User Smoke
Mock-mode Manager was launched on `http://localhost:3002` with `MANAGER_DATA_MODE=mock` and tested through the browser.

Evidence captured locally:
- `output/smoke/fcdb-coverage-language/02-default-english.png`: bare Coverage canonicalized to `?languageId=529`, no custom session storage entry, English coverage loaded.
- `output/smoke/fcdb-coverage-language/03-selected-french.png`: user-selected French wrote `forge-coverage-language-ids: 6414` and loaded French coverage.
- `output/smoke/fcdb-coverage-language/05-remembered-french-return.png`: Jobs -> Report restored French at `?languageId=6414`.
- `output/smoke/fcdb-coverage-language/06-explicit-english-overrides-memory.png`: explicit `?languageId=529` won over remembered French.
- `output/smoke/fcdb-coverage-language/07-legacy-normalized.png`: legacy `?languageIds=21028,6414` normalized to canonical `languageId=21028%2C6414`.
- `output/smoke/fcdb-coverage-language/08-cleared-falls-back-english.png`: clearing final custom language removed session memory and fell back to English.
- `output/smoke/fcdb-coverage-language/network.har`: includes successful `/api/languages` and `/api/videos?languageIds=...` requests for English, French, and multi-language states.

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Logs: Manager `/api/languages`, `/api/videos`, and dashboard route errors around `/dashboard/coverage`.
  - Metrics/Dashboards: Manager web error rate and API 4xx/5xx rate for `/api/languages` and `/api/videos`.
- **Validation checks**
  - Open `/dashboard/coverage` in production and confirm the URL canonicalizes to `?languageId=<English core id>`.
  - Select a non-English language, navigate to Jobs or Agents, return to Report, and confirm the same selection is restored.
  - Open a legacy `?languageIds=...` URL and confirm it normalizes to `languageId`.
- **Expected healthy behavior**
  - Coverage loads without an initial language-first empty state for fresh visits.
  - Custom language chips and coverage counts persist within the same dashboard tab session.
  - `/api/videos` requests continue using `languageIds` internally.
- **Failure signals / rollback trigger**
  - Fresh Coverage visits remain empty, selected languages disappear after dashboard navigation, or `/api/videos` requests stop including the expected selected IDs.
  - Roll back the PR if route repair loops, coverage cannot load, or dashboard navigation becomes unstable.
- **Validation window & owner**
  - Window: first production deploy smoke plus 24 hours of normal Manager usage.
  - Owner: Manager feature owner / Vlad.