### PR TITLE
fix(admin): keyword-first recall on CamelCased brand queries (BibleProject parity)

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -885,14 +885,27 @@ This is an **extension of R4**, not a new R-stage. The cms-side
 window; admin's surface matches the cms-side contract by R8 cutover.
 
 - **Schema:** Migration `0009_keyword_first_lexical/migration.sql`
-  provisions `pg_trgm`, two STORED generated tsvector columns on
-  `video_locale` (`title_tsv`, `description_tsv`), a weighted GIN
-  index over `(setweight(title_tsv,'A') || setweight(description_tsv,'B'))`,
-  and a trigram GIN index on `title gin_trgm_ops`. Generated columns
-  - GIN indexes attach to `VideoLocale`, NOT `Video` (per-locale
-    attachment per admin's data model). The legacy R4
-    `video_locale_fulltext_search_idx` from `0006` is untouched —
-    hybrid mode keeps reading it via `searchVideoKeyword`.
+  originally provisioned `pg_trgm`, two STORED generated tsvector
+  columns on `video_locale` (`title_tsv`, `description_tsv`), a
+  weighted GIN index over `(setweight(title_tsv,'A') ||
+setweight(description_tsv,'B'))`, and a trigram GIN index on
+  `title gin_trgm_ops`. Migration
+  `0010_camelcase_tsv_and_description_trigram` then DROP-CASCADEd
+  the generated columns and recreated them with a CamelCase-split
+  `regexp_replace` wrapper before `to_tsvector` (so `BibleProject`
+  tokenizes as `bible` + `project`, not just `bibleproject`),
+  recreated the weighted GIN index, and added a second trigram GIN
+  index on `description gin_trgm_ops`. **As of 0010:** generated
+  columns are owned by 0010, the title trigram index from 0009 is
+  untouched, and there are now TWO trigram indexes
+  (`video_locale_title_trgm_idx`, `video_locale_description_trgm_idx`).
+  Generated columns + GIN indexes attach to `VideoLocale`, NOT
+  `Video` (per-locale attachment per admin's data model). The legacy
+  R4 `video_locale_fulltext_search_idx` from `0006` is untouched —
+  hybrid mode keeps reading it via `searchVideoKeyword`, which is
+  why hybrid mode stays byte-identical to R4 even after 0010
+  changed the keyword-first tokenization. See
+  `docs/plans/2026-05-02-001-fix-keyword-first-camelcase-recall-plan.md`.
 
 - **Byte-parity invariant:** `WEIGHTED_TSV_INDEX_EXPR` /
   `WEIGHTED_TSV_QUERY_EXPR` / `TITLE_TSV_GENERATED_EXPR` /
@@ -915,8 +928,16 @@ ADD COLUMN ... GENERATED ALWAYS AS (...)` migration. Per
     `websearch_to_tsquery('simple', q)`, ranked by `ts_rank_cd`
     against the weighted tsvector. `Prisma.raw(WEIGHTED_TSV_QUERY_EXPR)`
     for the unbindable expression fragment.
-  - `searchByTrigram` — `vl.title %> q` with `similarity(vl.title, q)`
-    ranking. Title-only (description trigram index would balloon).
+  - `searchByTrigram` — `vl.title %> q OR vl.description %> q`
+    with ranking by
+    `GREATEST(similarity(vl.title, q), similarity(coalesce(vl.description, ''), q))`.
+    Per-row dedup via `DISTINCT ON (v.id)` collapses rows that match
+    via both fields. Backed by `video_locale_title_trgm_idx` (from 0009) and `video_locale_description_trgm_idx` (from 0010). The
+    description-side index is heavier than the title-side; current
+    catalog is 0 rows in prod, so the precaution that gated R4 on
+    title-only no longer applies — but capture
+    `pg_relation_size('video_locale_description_trgm_idx')` once R0
+    backfill lands and revisit if it grows beyond a few hundred MB.
   - `searchByExactTitle` — dynamic AND-chain of `vl.title ILIKE ?`
     via `Prisma.join`, ranked `LENGTH(title) ASC`. Tokenization is
     Unicode letter / digit split, lowercased, deduped, **capped at
@@ -988,12 +1009,18 @@ ADD COLUMN ... GENERATED ALWAYS AS (...)` migration. Per
 
 **Operational runbook:**
 
-1. Apply migration `0009_keyword_first_lexical` in any environment
+1. Apply migrations `0009_keyword_first_lexical` and
+   `0010_camelcase_tsv_and_description_trigram` in any environment
    that wants keyword-first available. `prisma migrate dev` /
-   `prisma migrate deploy` is idempotent. The two new GIN indexes
-   add disk + write amplification proportional to corpus size; cost
-   is negligible at admin's current zero-row prod data and grows
-   when R0 backfills.
+   `prisma migrate deploy` is idempotent against `_prisma_migrations`.
+   **Re-applying 0010 manually against a populated `video_locale` is
+   destructive** — DROP CASCADE removes the columns and the rebuild
+   takes AccessExclusiveLock. Treat fixes as forward-only
+   counter-migrations, never `migrate resolve --rolled-back` 0010
+   once R0 has populated the table. The three GIN indexes
+   (weighted, title trgm, description trgm) add disk + write
+   amplification proportional to corpus size; cost is negligible at
+   admin's current zero-row prod data and grows when R0 backfills.
 2. Confirm `pg_trgm` extension permission on the prod DB role.
    First migration that needs it; older R0–R5 migrations don't.
 3. To opt in via REST, append `?mode=keyword-first`. To opt in via
@@ -1011,9 +1038,14 @@ setweight(vl.description_tsv,'B') @@
 websearch_to_tsquery('simple', 'jesus') AND vl.locale = 'en'
 LIMIT 10;`
    should show `Bitmap Index Scan on
-video_locale_lexical_weighted_idx`. Trigram probe:
-   `… WHERE vl.title %> 'jesus' …` should show
-   `video_locale_title_trgm_idx`.
+video_locale_lexical_weighted_idx`. Trigram probe (post-0010, both
+   title and description halves should appear in the plan via
+   `BitmapOr`):
+   `… WHERE (vl.title %> 'jesus' OR vl.description %> 'jesus') …`
+   should show `BitmapOr` over `video_locale_title_trgm_idx` and
+   `video_locale_description_trgm_idx`. On an empty corpus the
+   planner correctly prefers Seq Scan; the BitmapOr plan only
+   matters once data lands. Re-run this probe at R0 readiness.
 6. R0 dependency: admin's `video` / `video_locale` tables are 0 rows
    in prod. Real-DB integration tests (canary diff vs cms keyword-first,
    EXPLAIN-based GIN verification) are deferred to R0 readiness.

--- a/apps/admin/prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql
+++ b/apps/admin/prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql
@@ -13,6 +13,16 @@
 --      videos with those titles), while still splitting two-segment
 --      CamelCase like `BibleProject` / `JesusFilm` / `MacOS`.
 --
+--      KNOWN LIMITATION (ASCII-only): POSIX bracket classes `[a-z]` /
+--      `[A-Z]` match ONLY ASCII Latin characters. Cyrillic, Greek, or
+--      accented-Latin CamelCase boundaries (e.g. `СловоБожие`) are
+--      NOT split. JFP is multilingual; recall on those queries falls
+--      through to the trigram retriever, which is locale-blind. A
+--      future migration can broaden the regex to `[[:lower:]]` /
+--      `[[:upper:]]` (Postgres POSIX classes that honor LC_CTYPE)
+--      once the recall trade-off is benchmarked against real corpus
+--      data — out of scope here.
+--
 --      Postgres has no in-place editor for stored generated expressions
 --      (`ALTER COLUMN ... GENERATED` doesn't accept a new expression),
 --      so the migration must DROP the columns CASCADE (which also drops
@@ -28,6 +38,19 @@
 --      is defense-in-depth beyond the CamelCase split for typos and
 --      partial input. The existing `video_locale_title_trgm_idx` is
 --      untouched.
+--
+--      SIZING REVISIT: pg_trgm GIN scales linearly with total characters
+--      indexed; descriptions are typically 10-100x longer than titles,
+--      so this index will be materially larger than the title trgm.
+--      R4 originally avoided it on a populated corpus citing balloon
+--      risk. Admin's prod is 0 rows today (R0 backfill not yet run),
+--      so the cost is theoretical. Capture
+--      `pg_relation_size('video_locale_description_trgm_idx')` once
+--      R0 lands and revisit when it exceeds ~500 MB or when write
+--      latency on `video_locale` INSERT/UPDATE regresses >20% — at
+--      that point consider partial indexing on `WHERE
+--      char_length(description) < N`, or fall back to title-only
+--      trigram with a documented recall trade-off.
 --
 -- Byte-parity invariant: the rewritten generated-column expressions
 -- and the recreated weighted index expression MUST stay byte-equal to
@@ -49,6 +72,19 @@
 -- Created non-CONCURRENTLY for the same reason as 0006 / 0009: admin's
 -- prod corpus is 0 rows today (R0 backfill not yet run) and the
 -- AccessExclusiveLock is acceptable.
+--
+-- POST-R0 WARNING: the DROP COLUMN + ADD COLUMN GENERATED pattern
+-- above takes AccessExclusiveLock on `video_locale` for the full
+-- duration of the column rebuild. On a 0-row table that's instant;
+-- on a hypothetical R0-backfilled table with 100k+ rows it's a full
+-- table rewrite. Any future migration of this shape should be
+-- staged out of the Prisma transaction (split DDL into pieces,
+-- use `CREATE INDEX CONCURRENTLY` via raw psql, or use Prisma's
+-- `Unsupported` escape hatch). Manually re-applying 0010 against a
+-- populated table is destructive — Prisma's `_prisma_migrations`
+-- ledger guards normal redeploys, but `migrate resolve --rolled-back`
+-- on this migration is forbidden post-R0; treat fixes as
+-- forward-only counter-migrations.
 
 ALTER TABLE "video_locale" DROP COLUMN IF EXISTS "title_tsv" CASCADE;
 ALTER TABLE "video_locale" DROP COLUMN IF EXISTS "description_tsv" CASCADE;

--- a/apps/admin/prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql
+++ b/apps/admin/prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql
@@ -1,0 +1,70 @@
+-- Recall fix for keyword-first search on CamelCased brand queries.
+--
+-- Two coordinated changes:
+--   1. Rewrite the `video_locale.title_tsv` and `video_locale.description_tsv`
+--      generated columns to inject a space at every camelCase boundary
+--      BEFORE `to_tsvector` runs. `BibleProject` becomes `Bible Project`
+--      and tokenizes as `bible` + `project`, so a user query like
+--      `"the bible project"` (which `websearch_to_tsquery` parses as
+--      `'the' & 'bible' & 'project'`, three separate tokens ANDed)
+--      matches descriptions written with the joined-form brand. The
+--      regex `([a-z])([A-Z])` is the conservative form: it preserves
+--      all-caps acronyms like `YHWH` and `LORD` intact (admin has
+--      videos with those titles), while still splitting two-segment
+--      CamelCase like `BibleProject` / `JesusFilm` / `MacOS`.
+--
+--      Postgres has no in-place editor for stored generated expressions
+--      (`ALTER COLUMN ... GENERATED` doesn't accept a new expression),
+--      so the migration must DROP the columns CASCADE (which also drops
+--      `video_locale_lexical_weighted_idx`, which referenced them) and
+--      ADD them back with the new expression, then recreate the
+--      weighted index. Per
+--      docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md.
+--
+--   2. Add a trigram GIN index on `video_locale.description` so the
+--      keyword-first `searchByTrigram` retriever can also match the
+--      description column. Trigrams ignore token boundaries entirely —
+--      `bible project` 3-grams overlap `bibleproject` directly — which
+--      is defense-in-depth beyond the CamelCase split for typos and
+--      partial input. The existing `video_locale_title_trgm_idx` is
+--      untouched.
+--
+-- Byte-parity invariant: the rewritten generated-column expressions
+-- and the recreated weighted index expression MUST stay byte-equal to
+-- the corresponding `*_GENERATED_EXPR` and `WEIGHTED_TSV_INDEX_EXPR`
+-- constants in `src/services/hybrid-search-sql.ts`. The planner only
+-- matches expression-based GIN indexes when the query-side expression
+-- is character-for-character identical to the indexed expression.
+-- `hybrid-search-sql.test.ts` enforces this by reading this file at
+-- test time.
+--
+-- Hybrid mode: the legacy R4 `video_locale_fulltext_search_idx` from
+-- `0006_hybrid_search_gin/migration.sql` is intentionally untouched.
+-- That index is built over a separate expression on the raw `title` /
+-- `description` columns (not on `*_tsv`), so its content is unchanged
+-- by this migration. `searchVideoKeyword` (used by hybrid mode) keeps
+-- reading it; `hybrid-search.regression.test.ts` enforces hybrid
+-- byte-identity against deterministic mocked retrievers.
+--
+-- Created non-CONCURRENTLY for the same reason as 0006 / 0009: admin's
+-- prod corpus is 0 rows today (R0 backfill not yet run) and the
+-- AccessExclusiveLock is acceptable.
+
+ALTER TABLE "video_locale" DROP COLUMN IF EXISTS "title_tsv" CASCADE;
+ALTER TABLE "video_locale" DROP COLUMN IF EXISTS "description_tsv" CASCADE;
+
+ALTER TABLE "video_locale"
+  ADD COLUMN IF NOT EXISTS "title_tsv" tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', regexp_replace(coalesce(title, ''), '([a-z])([A-Z])', '\1 \2', 'g'))) STORED;
+
+ALTER TABLE "video_locale"
+  ADD COLUMN IF NOT EXISTS "description_tsv" tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', regexp_replace(coalesce(description, ''), '([a-z])([A-Z])', '\1 \2', 'g'))) STORED;
+
+CREATE INDEX IF NOT EXISTS "video_locale_lexical_weighted_idx"
+  ON "video_locale"
+  USING GIN ((setweight(title_tsv, 'A') || setweight(description_tsv, 'B')));
+
+CREATE INDEX IF NOT EXISTS "video_locale_description_trgm_idx"
+  ON "video_locale"
+  USING GIN (description gin_trgm_ops);

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
@@ -234,7 +234,7 @@ describe("searchByTrigram", () => {
     expect(prisma.$queryRaw).not.toHaveBeenCalled()
   })
 
-  it("uses %> operator (operator-class trigram GIN selection)", async () => {
+  it("uses %> operator on BOTH title and description (operator-class trigram GIN selection)", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([])
     await searchByTrigram(prisma, {
       query: "bible",
@@ -243,8 +243,54 @@ describe("searchByTrigram", () => {
     })
     const [strings] = prisma.$queryRaw.mock.calls[0] as [TemplateStringsArray]
     const joined = strings.join("?")
+    // Title-side match drives `video_locale_title_trgm_idx`; description-side
+    // drives the new `video_locale_description_trgm_idx` from migration 0010.
     expect(joined).toMatch(/vl\.title\s*%>\s*\?/)
-    expect(joined).toMatch(/similarity\(vl\.title,\s*\?\)/)
+    expect(joined).toMatch(/vl\.description\s*%>\s*\?/)
+  })
+
+  it("ranks by GREATEST similarity across title and description", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchByTrigram(prisma, {
+      query: "bible project",
+      locale: "en",
+      limit: 10,
+    })
+    const [strings] = prisma.$queryRaw.mock.calls[0] as [TemplateStringsArray]
+    const joined = strings.join("?")
+    // GREATEST keeps a strong title match from being diluted by a weak
+    // description match (or vice versa) when the same row matches both.
+    expect(joined).toMatch(/GREATEST\(\s*similarity\(vl\.title/)
+    expect(joined).toMatch(/similarity\(coalesce\(vl\.description/)
+  })
+
+  it("returns rows whose match came via description-side trigram", async () => {
+    // Simulates a video like "The Lord's Prayer" whose title doesn't
+    // match the query but whose description contains "BibleProject"
+    // attribution text — only reachable post-0010 description trigram
+    // index.
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-2",
+        video_core_id: "11_Sermon0710",
+        video_slug: "lords-prayer",
+        video_title: "The Lord's Prayer",
+        description:
+          "Line-by-line breakdown of the Lord's Prayer. Thanks to BibleProject for providing this series.",
+        similarity: 0.42,
+      },
+    ])
+    const rows = await searchByTrigram(prisma, {
+      query: "bible project",
+      locale: "en",
+      limit: 10,
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      resultId: "vid-2",
+      videoTitle: "The Lord's Prayer",
+      similarity: 0.42,
+    })
   })
 })
 

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
@@ -64,6 +64,14 @@ type VideoKeywordRowShape = RankedItem & {
 }
 
 export type KeywordWeightedResult = VideoKeywordRowShape & { rank: number }
+/**
+ * Result row from `searchByTrigram`. **As of migration 0010, `similarity`
+ * is the GREATEST of the title-side and description-side trigram
+ * similarities** (`similarity(vl.title, q)` vs
+ * `similarity(coalesce(vl.description, ''), q)`), not title-only as it
+ * was pre-0010. The retriever scans both columns and dedupes per video
+ * via `DISTINCT ON (v.id)`, keeping the higher-similarity row.
+ */
 export type TrigramResult = VideoKeywordRowShape & { similarity: number }
 export type ExactTitleResult = VideoKeywordRowShape & { titleLength: number }
 
@@ -217,16 +225,24 @@ export async function searchByKeywordWeighted(
  *     as the joined-form `BibleProject` matches via description
  *     trigrams (the brand's 3-grams overlap `bibleproject` directly).
  *
- * Uses the `%>` operator ("word similar to") on both fields. Per-row
- * dedup via `DISTINCT ON (v.id)` collapses the case where the same
- * video matches via both title and description; ranking takes the
- * GREATEST similarity across the two fields so a strong title match
- * doesn't get diluted by a weak description match.
+ * SQL shape: `WHERE (vl.title %> ? OR vl.description %> ?)` plus
+ * `DISTINCT ON (v.id) ORDER BY v.id, similarity DESC` to collapse
+ * rows that match via both fields, keeping the higher-similarity row.
+ * Ranking is `GREATEST(similarity(vl.title, q), similarity(coalesce(vl.description, ''), q))`
+ * so a strong title match doesn't get diluted by a weak description
+ * match.
+ *
+ * (Earlier framings called this a "UNION" — implementation is the
+ * equivalent OR + per-row dedup, which lets a single index probe pass
+ * cover both halves and avoids materializing two intermediate row
+ * sets.)
  *
  * Index selection happens via the `%>` operator against
  * `video_locale_title_trgm_idx` (provisioned by 0009) and
  * `video_locale_description_trgm_idx` (provisioned by 0010), both
- * operator-class GIN (`gin_trgm_ops`). No expression byte-parity
+ * operator-class GIN (`gin_trgm_ops`). On a populated table the
+ * planner should choose `BitmapOr` over the two indexes; on an empty
+ * corpus it correctly prefers Seq Scan. No expression byte-parity
  * guard needed — operator-class indexes are selected by the operator
  * regardless of column aliases. Per
  * docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md.

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
@@ -206,20 +206,30 @@ export async function searchByKeywordWeighted(
 }
 
 /**
- * Trigram word-similarity retrieval over `video_locale.title`.
+ * Trigram word-similarity retrieval over `video_locale.title` AND
+ * `video_locale.description`.
  *
- * Closes the typo / partial-prefix gap that `websearch_to_tsquery`
- * misses: `q="bibel project"` won't match a tsvector lemma but will
- * still score highly here, because pg_trgm computes character-trigram
- * overlap.
+ * Closes the typo / partial-prefix / CamelCase gap that
+ * `websearch_to_tsquery` misses:
+ *   - `q="bibel project"` (typo) won't match a tsvector lemma but
+ *     scores highly via character-trigram overlap.
+ *   - `q="the bible project"` against a description writing the brand
+ *     as the joined-form `BibleProject` matches via description
+ *     trigrams (the brand's 3-grams overlap `bibleproject` directly).
  *
- * Uses the `%>` operator ("word similar to") rather than `%`, which
- * tends to overmatch on long descriptions. Title-only — the
- * description trigram index would balloon without meaningful gain.
+ * Uses the `%>` operator ("word similar to") on both fields. Per-row
+ * dedup via `DISTINCT ON (v.id)` collapses the case where the same
+ * video matches via both title and description; ranking takes the
+ * GREATEST similarity across the two fields so a strong title match
+ * doesn't get diluted by a weak description match.
  *
- * Index selection happens via the `%>` operator against the
- * `video_locale_title_trgm_idx` GIN trigram index (operator-class
- * `gin_trgm_ops`); no expression byte-parity guard needed.
+ * Index selection happens via the `%>` operator against
+ * `video_locale_title_trgm_idx` (provisioned by 0009) and
+ * `video_locale_description_trgm_idx` (provisioned by 0010), both
+ * operator-class GIN (`gin_trgm_ops`). No expression byte-parity
+ * guard needed — operator-class indexes are selected by the operator
+ * regardless of column aliases. Per
+ * docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md.
  *
  * Empty input short-circuits to `[]`.
  */
@@ -240,11 +250,14 @@ export async function searchByTrigram(
         v.slug         AS video_slug,
         vl.title       AS video_title,
         vl.description AS description,
-        similarity(vl.title, ${trimmed}) AS similarity
+        GREATEST(
+          similarity(vl.title, ${trimmed}),
+          similarity(coalesce(vl.description, ''), ${trimmed})
+        ) AS similarity
       FROM video_locale vl
       JOIN video v ON v.id = vl.video_id
         AND v.deleted_at IS NULL
-      WHERE vl.title %> ${trimmed}
+      WHERE (vl.title %> ${trimmed} OR vl.description %> ${trimmed})
         AND vl.locale = ${locale}
         AND vl.status = 'published'
       ORDER BY v.id, similarity DESC

--- a/apps/admin/src/services/hybrid-search-sql.test.ts
+++ b/apps/admin/src/services/hybrid-search-sql.test.ts
@@ -129,6 +129,105 @@ describe("hybrid-search-sql byte-parity with keyword-first migration", () => {
 })
 
 /**
+ * Behavioural invariant for the CamelCase-split regex.
+ *
+ * The byte-parity tests above verify that the literal regex pattern
+ * appears character-identically inside the migration. They do NOT
+ * exercise the regex's behaviour. This block runs the same pattern
+ * (`([a-z])([A-Z])`, replacement `$1 $2`, global) as a JavaScript
+ * regex against representative inputs and asserts the expected
+ * tokenization split.
+ *
+ * Postgres' POSIX regex and JavaScript's regex implement
+ * non-Unicode-aware `[a-z]` / `[A-Z]` classes identically (both
+ * match only ASCII Latin code points), so the JS form is a faithful
+ * stand-in for Postgres' `regexp_replace` here. A future migration
+ * that broadens the classes to `[[:lower:]]` / `[[:upper:]]` would
+ * diverge — Postgres honors LC_CTYPE there, JS does not — and this
+ * test would need a real-DB run instead. Out of scope today;
+ * documented as a known limit in the migration comment.
+ */
+describe("CamelCase-split regex behaviour (locked in by byte-parity above)", () => {
+  // Same pattern + replacement string used in TITLE_TSV_GENERATED_EXPR /
+  // DESCRIPTION_TSV_GENERATED_EXPR. Re-derived here as a JS RegExp so
+  // we can exercise the transformation without a DB connection.
+  const splitCamel = (input: string): string =>
+    input.replace(/([a-z])([A-Z])/g, "$1 $2")
+
+  const cases: Array<{ input: string; expected: string; rationale: string }> = [
+    {
+      input: "BibleProject",
+      expected: "Bible Project",
+      rationale: "two-segment CamelCase brand splits",
+    },
+    {
+      input: "JesusFilm",
+      expected: "Jesus Film",
+      rationale: "two-segment CamelCase brand splits",
+    },
+    {
+      input: "MacOS",
+      expected: "Mac OS",
+      rationale: "lower-then-upper boundary splits",
+    },
+    {
+      input: "iPhone",
+      expected: "i Phone",
+      rationale: "single-letter prefix splits",
+    },
+    {
+      input: "BibleProjectVideo",
+      expected: "Bible Project Video",
+      rationale: "multi-segment CamelCase splits at every boundary",
+    },
+    {
+      input: "YHWH",
+      expected: "YHWH",
+      rationale: "all-caps acronym preserved (no lower-then-upper boundary)",
+    },
+    {
+      input: "LORD",
+      expected: "LORD",
+      rationale: "all-caps acronym preserved",
+    },
+    {
+      input: "iOS",
+      expected: "i OS",
+      rationale:
+        "single-lower-then-upper boundary splits even when followed by all-caps; trailing 'S' has no upper after it",
+    },
+    {
+      input: "ABCDef",
+      expected: "ABCDef",
+      rationale:
+        "no `[a-z]` followed by `[A-Z]` — leading all-caps run kept whole",
+    },
+    {
+      input: "Bible Project",
+      expected: "Bible Project",
+      rationale: "already split — regex is idempotent",
+    },
+    {
+      input: "",
+      expected: "",
+      rationale: "empty string short-circuits",
+    },
+    {
+      input: "СловоБожие",
+      expected: "СловоБожие",
+      rationale:
+        "ASCII-only regex does NOT split Cyrillic CamelCase — known limit, recall on those locales falls through to trigram retriever",
+    },
+  ]
+
+  for (const { input, expected, rationale } of cases) {
+    it(`splits ${JSON.stringify(input)} -> ${JSON.stringify(expected)} (${rationale})`, () => {
+      expect(splitCamel(input)).toBe(expected)
+    })
+  }
+})
+
+/**
  * Historical invariant for `0009_keyword_first_lexical/migration.sql`.
  *
  * 0009 originally created the `title_tsv` / `description_tsv` generated

--- a/apps/admin/src/services/hybrid-search-sql.test.ts
+++ b/apps/admin/src/services/hybrid-search-sql.test.ts
@@ -7,6 +7,7 @@ import {
   DESCRIPTION_TSV_GENERATED_EXPR,
   EXPERIENCE_LOCALE_TSVECTOR_INDEX_EXPR,
   TITLE_TSV_GENERATED_EXPR,
+  VIDEO_LOCALE_DESCRIPTION_TRGM_INDEX_NAME,
   VIDEO_LOCALE_LEXICAL_WEIGHTED_INDEX_NAME,
   VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME,
   VIDEO_LOCALE_TSVECTOR_INDEX_EXPR,
@@ -49,15 +50,24 @@ describe("hybrid-search-sql byte-parity with GIN migration", () => {
 /**
  * Byte-parity invariant for R4-extension keyword-first lexical search.
  *
- * The generated-column expressions and weighted GIN index expression
- * MUST appear byte-equal inside `0009_keyword_first_lexical/migration.sql`.
+ * The generated-column expressions and the weighted GIN index expression
+ * MUST appear byte-equal inside the migration that currently defines
+ * the live `video_locale.title_tsv` / `video_locale.description_tsv`
+ * columns. As of `0010_camelcase_tsv_and_description_trigram`, the
+ * generated-column expressions inject a CamelCase-split via
+ * `regexp_replace` BEFORE `to_tsvector` runs (closes the BibleProject
+ * recall gap on keyword-first mode). The migration also DROP-CASCADEs
+ * the previous columns + index from `0009_keyword_first_lexical` and
+ * recreates them, so any byte-parity check against 0009 is now
+ * historical and the LIVE invariant lives against 0010.
+ *
  * Drift on the generated columns means a future migration would
  * compute different tsvectors than the live data carries; drift on
  * the weighted index expression silently reverts the
  * `searchByKeywordWeighted` retriever to seq scan.
  *
- * The trigram retriever uses operator-class GIN (`gin_trgm_ops`) and
- * has no expression byte-parity to enforce — only the index name is
+ * The trigram retrievers use operator-class GIN (`gin_trgm_ops`) and
+ * have no expression byte-parity to enforce — only the index names are
  * cross-checked here so a future rename can't go un-noticed.
  */
 describe("hybrid-search-sql byte-parity with keyword-first migration", () => {
@@ -68,7 +78,7 @@ describe("hybrid-search-sql byte-parity with keyword-first migration", () => {
       "..",
       "prisma",
       "migrations",
-      "0009_keyword_first_lexical",
+      "0010_camelcase_tsv_and_description_trigram",
       "migration.sql",
     ),
     "utf8",
@@ -92,15 +102,9 @@ describe("hybrid-search-sql byte-parity with keyword-first migration", () => {
     )
   })
 
-  it("creates the trigram GIN index under the canonical name", () => {
+  it("creates the description trigram GIN index under the canonical name", () => {
     expect(keywordFirstMigrationSql).toContain(
-      VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME,
-    )
-  })
-
-  it("provisions pg_trgm idempotently", () => {
-    expect(keywordFirstMigrationSql).toMatch(
-      /CREATE EXTENSION IF NOT EXISTS pg_trgm/i,
+      VIDEO_LOCALE_DESCRIPTION_TRGM_INDEX_NAME,
     )
   })
 
@@ -112,5 +116,47 @@ describe("hybrid-search-sql byte-parity with keyword-first migration", () => {
     expect(keywordFirstMigrationSql).not.toMatch(
       /\b(DROP|ALTER)\s+INDEX[^\n]*video_locale_fulltext_search_idx/i,
     )
+  })
+
+  it("leaves the title trigram GIN index from 0009 untouched", () => {
+    // 0009 provisioned `video_locale_title_trgm_idx`; 0010 only adds the
+    // description trigram counterpart. Drop/Alter the title index would
+    // be a regression for the existing trigram retriever path.
+    expect(keywordFirstMigrationSql).not.toMatch(
+      /\b(DROP|ALTER)\s+INDEX[^\n]*video_locale_title_trgm_idx/i,
+    )
+  })
+})
+
+/**
+ * Historical invariant for `0009_keyword_first_lexical/migration.sql`.
+ *
+ * 0009 originally created the `title_tsv` / `description_tsv` generated
+ * columns + the weighted GIN index + the title trigram GIN index. 0010
+ * supersedes 0009's generated-column definitions (DROP CASCADE + ADD
+ * with the CamelCase-split expression) but keeps the title trigram
+ * index untouched. This block locks the invariants 0009 still owns:
+ * the trigram extension and the title trigram index name.
+ */
+describe("hybrid-search-sql historical invariants on 0009", () => {
+  const oldMigrationSql = readFileSync(
+    resolve(
+      __dirname,
+      "..",
+      "..",
+      "prisma",
+      "migrations",
+      "0009_keyword_first_lexical",
+      "migration.sql",
+    ),
+    "utf8",
+  )
+
+  it("provisions pg_trgm idempotently in 0009", () => {
+    expect(oldMigrationSql).toMatch(/CREATE EXTENSION IF NOT EXISTS pg_trgm/i)
+  })
+
+  it("creates the title trigram GIN index under the canonical name", () => {
+    expect(oldMigrationSql).toContain(VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME)
   })
 })

--- a/apps/admin/src/services/hybrid-search-sql.ts
+++ b/apps/admin/src/services/hybrid-search-sql.ts
@@ -199,10 +199,12 @@ export const VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME = "video_locale_title_trgm_idx"
  *
  * Provisioned by
  * `0010_camelcase_tsv_and_description_trigram/migration.sql`. Backs the
- * description-side of `searchByTrigram`, which UNIONs title and
- * description trigram matches in keyword-first mode. Same operator-class
- * (`gin_trgm_ops`) shape as the title trigram index — no expression
- * byte-parity guard needed.
+ * description-side of `searchByTrigram` (`vl.description %> q`), which
+ * the planner picks up by operator-class match — production code never
+ * names the index. **Exported only so the byte-parity test can assert
+ * the migration creates the index under a name we control; no
+ * production consumer references this constant.** Same shape as
+ * `VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME` (also test-only).
  */
 export const VIDEO_LOCALE_DESCRIPTION_TRGM_INDEX_NAME =
   "video_locale_description_trgm_idx"

--- a/apps/admin/src/services/hybrid-search-sql.ts
+++ b/apps/admin/src/services/hybrid-search-sql.ts
@@ -120,24 +120,36 @@ export const EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR =
 /**
  * Generated-column expression for `video_locale.title_tsv`.
  *
- * Used by `prisma/migrations/0009_keyword_first_lexical/migration.sql`
- * inside `ALTER TABLE video_locale ADD COLUMN title_tsv tsvector
- * GENERATED ALWAYS AS (<expr>) STORED`. Must appear byte-equal in the
- * migration. Service code never references this expression directly —
- * the column it produces (`title_tsv`) is what queries read.
+ * Used by `prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql`
+ * (which superseded the original `0009_keyword_first_lexical/migration.sql`
+ * definition) inside `ALTER TABLE video_locale ADD COLUMN title_tsv
+ * tsvector GENERATED ALWAYS AS (<expr>) STORED`. Must appear byte-equal
+ * in the migration. Service code never references this expression
+ * directly — the column it produces (`title_tsv`) is what queries read.
+ *
+ * The `regexp_replace` injects a space at every camelCase boundary
+ * (`BibleProject` → `Bible Project`) BEFORE `to_tsvector` runs, so the
+ * single lexeme `bibleproject` becomes the two lexemes `bible` + `project`
+ * and a user query of `"the bible project"` (which
+ * `websearch_to_tsquery` parses as `'the' & 'bible' & 'project'`)
+ * matches descriptions where the brand is written joined-form. Regex
+ * is the conservative `([a-z])([A-Z])` form: preserves all-caps
+ * acronyms like `YHWH` / `LORD` intact while still splitting
+ * two-segment CamelCase. See
+ * `docs/plans/2026-05-02-001-fix-keyword-first-camelcase-recall-plan.md`.
  */
 export const TITLE_TSV_GENERATED_EXPR =
-  "to_tsvector('simple', coalesce(title, ''))"
+  "to_tsvector('simple', regexp_replace(coalesce(title, ''), '([a-z])([A-Z])', '\\1 \\2', 'g'))"
 
 /**
  * Generated-column expression for `video_locale.description_tsv`.
  *
- * Same byte-parity contract as `TITLE_TSV_GENERATED_EXPR`. Service
- * code reads the resulting `description_tsv` column rather than
- * recomputing the expression.
+ * Same byte-parity contract as `TITLE_TSV_GENERATED_EXPR`, same
+ * CamelCase-split rationale. Service code reads the resulting
+ * `description_tsv` column rather than recomputing the expression.
  */
 export const DESCRIPTION_TSV_GENERATED_EXPR =
-  "to_tsvector('simple', coalesce(description, ''))"
+  "to_tsvector('simple', regexp_replace(coalesce(description, ''), '([a-z])([A-Z])', '\\1 \\2', 'g'))"
 
 /**
  * Per-field weighted tsvector expression, INDEX form (bare columns).
@@ -181,3 +193,16 @@ export const VIDEO_LOCALE_LEXICAL_WEIGHTED_INDEX_NAME =
  * runbooks share one canonical name.
  */
 export const VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME = "video_locale_title_trgm_idx"
+
+/**
+ * Index name for the trigram GIN index on `video_locale.description`.
+ *
+ * Provisioned by
+ * `0010_camelcase_tsv_and_description_trigram/migration.sql`. Backs the
+ * description-side of `searchByTrigram`, which UNIONs title and
+ * description trigram matches in keyword-first mode. Same operator-class
+ * (`gin_trgm_ops`) shape as the title trigram index — no expression
+ * byte-parity guard needed.
+ */
+export const VIDEO_LOCALE_DESCRIPTION_TRGM_INDEX_NAME =
+  "video_locale_description_trgm_idx"

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -365,15 +365,13 @@ describe("Bible Project headline (keyword-first mode)", () => {
     // pre-fix). This test locks in that the orchestrator surfaces such
     // attribution-matched videos within top-15 once retrievers feed
     // them in — i.e., the recall improvement isn't lost in fusion.
-    type AttributionFixture = Fixture & { __isAttribution: true }
-    const ATTRIBUTION_VIDEOS: AttributionFixture[] = [
+    const ATTRIBUTION_VIDEOS: Fixture[] = [
       {
         resultId: "att-1",
         videoCoreId: "11_Sermon0710",
         videoSlug: "lords-prayer",
         videoTitle: "The Lord's Prayer",
         description: "Thanks to BibleProject for providing this series.",
-        __isAttribution: true,
       },
       {
         resultId: "att-2",
@@ -381,7 +379,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "shema-listen",
         videoTitle: "Shema / Listen",
         description: "Animated breakdown by BibleProject.",
-        __isAttribution: true,
       },
       {
         resultId: "att-3",
@@ -389,7 +386,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "yhwh-lord",
         videoTitle: "YHWH / LORD",
         description: "From the BibleProject Sermon on the Mount series.",
-        __isAttribution: true,
       },
       {
         resultId: "att-4",
@@ -397,7 +393,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "the-beatitudes",
         videoTitle: "The Beatitudes",
         description: "BibleProject overview of Matthew 5.",
-        __isAttribution: true,
       },
       {
         resultId: "att-5",
@@ -405,7 +400,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "wealth-and-worry",
         videoTitle: "Wealth and Worry",
         description: "BibleProject explainer for Matthew 6:25-34.",
-        __isAttribution: true,
       },
     ]
 

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -349,6 +349,113 @@ describe("Bible Project headline (keyword-first mode)", () => {
     expect(result.searchMode).toBe("hybrid")
   })
 
+  it("surfaces attribution-matched videos in top-N when retrievers return them (post-0010 CamelCase + description-trigram fix)", async () => {
+    // Models the post-0010 world: descriptions writing the brand as
+    // joined-form `BibleProject` are now reachable via two paths —
+    //   (a) `searchByKeywordWeighted` because the new generated columns
+    //       CamelCase-split the input before tokenizing, so
+    //       `bibleproject` lexes to `bible` + `project` and matches
+    //       `websearch_to_tsquery('the bible project')`'s AND-of-tokens.
+    //   (b) `searchByTrigram` because trigrams ignore token boundaries
+    //       and now run over both title AND description (the new
+    //       `video_locale_description_trgm_idx` from migration 0010).
+    //
+    // Live verification ran against the local DB on 2026-05-02 and
+    // returned 25 keyword-weighted matches for the same query (vs 6
+    // pre-fix). This test locks in that the orchestrator surfaces such
+    // attribution-matched videos within top-15 once retrievers feed
+    // them in — i.e., the recall improvement isn't lost in fusion.
+    type AttributionFixture = Fixture & { __isAttribution: true }
+    const ATTRIBUTION_VIDEOS: AttributionFixture[] = [
+      {
+        resultId: "att-1",
+        videoCoreId: "11_Sermon0710",
+        videoSlug: "lords-prayer",
+        videoTitle: "The Lord's Prayer",
+        description: "Thanks to BibleProject for providing this series.",
+        __isAttribution: true,
+      },
+      {
+        resultId: "att-2",
+        videoCoreId: "11_Shema0106",
+        videoSlug: "shema-listen",
+        videoTitle: "Shema / Listen",
+        description: "Animated breakdown by BibleProject.",
+        __isAttribution: true,
+      },
+      {
+        resultId: "att-3",
+        videoCoreId: "11_Shema0206",
+        videoSlug: "yhwh-lord",
+        videoTitle: "YHWH / LORD",
+        description: "From the BibleProject Sermon on the Mount series.",
+        __isAttribution: true,
+      },
+      {
+        resultId: "att-4",
+        videoCoreId: "11_Sermon0210",
+        videoSlug: "the-beatitudes",
+        videoTitle: "The Beatitudes",
+        description: "BibleProject overview of Matthew 5.",
+        __isAttribution: true,
+      },
+      {
+        resultId: "att-5",
+        videoCoreId: "11_Sermon0810",
+        videoSlug: "wealth-and-worry",
+        videoTitle: "Wealth and Worry",
+        description: "BibleProject explainer for Matthew 6:25-34.",
+        __isAttribution: true,
+      },
+    ]
+
+    vi.mocked(searchVideoSemantic).mockResolvedValue([])
+    // Keyword-weighted: BP titles (5) + 5 attribution-matched
+    // descriptions all clear the AND-of-tokens gate.
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([
+      ...BIBLE_PROJECT_VIDEOS.map((f, i) => asKeywordWeighted(f, 1 - i * 0.05)),
+      ...ATTRIBUTION_VIDEOS.map((f, i) => asKeywordWeighted(f, 0.4 - i * 0.03)),
+    ])
+    // Trigram: title-side matches BP collection; description-side
+    // matches the attribution videos (BibleProject as one word).
+    vi.mocked(searchByTrigram).mockResolvedValue([
+      ...BIBLE_PROJECT_VIDEOS.map((f, i) => asTrigram(f, 0.6 - i * 0.05)),
+      ...ATTRIBUTION_VIDEOS.map((f, i) => asTrigram(f, 0.45 - i * 0.03)),
+    ])
+    // Exact-title: only BP titles satisfy "the AND bible AND project"
+    // all in title.
+    vi.mocked(searchByExactTitle).mockResolvedValue(
+      BIBLE_PROJECT_VIDEOS.map((f, i) =>
+        asExactTitle(f, f.videoTitle.length + i),
+      ),
+    )
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+      contentTypes: ["video"],
+      limit: 15,
+    })
+
+    const titles = result.results.map((r) => r.title)
+    const attributionTitles = ATTRIBUTION_VIDEOS.map((v) => v.videoTitle)
+    const attributionMatchedInTopN = titles.filter((t) =>
+      attributionTitles.includes(t),
+    )
+
+    // ≥5 attribution-matched videos (Sermon on the Mount series, etc.)
+    // appear within top-15. This is the recall floor that locks in the
+    // 0010 fix at the orchestrator boundary.
+    expect(attributionMatchedInTopN.length).toBeGreaterThanOrEqual(5)
+  })
+
   // Reference fixture coverage marker so unused-export linting flags
   // don't fire on intentionally-shared fixtures.
   it("fixture coverage sanity — every fixture is reachable by ID", () => {

--- a/docs/plans/2026-05-02-001-fix-keyword-first-camelcase-recall-plan.md
+++ b/docs/plans/2026-05-02-001-fix-keyword-first-camelcase-recall-plan.md
@@ -1,0 +1,281 @@
+---
+title: "fix: Keyword-first recall on CamelCased brand queries (BibleProject parity with Algolia)"
+type: fix
+status: active
+date: 2026-05-02
+---
+
+# fix: Keyword-first recall on CamelCased brand queries (BibleProject parity with Algolia)
+
+## Overview
+
+Two coordinated changes to admin's keyword-first hybrid search retrievers so the `q="the bible project"` canary returns the full BibleProject series (currently 6 hits, expected ~15–20 to match Algolia's stg corpus). Root cause confirmed via psql in the 2026-05-02 diagnostic session: descriptions write the brand as one word (`BibleProject`), Postgres `to_tsvector('simple', ...)` keeps it as the single lexeme `bibleproject`, and `websearch_to_tsquery('simple', 'the bible project')` produces `'the' & 'bible' & 'project'` (three tokens, ANDed) which never matches the lexeme.
+
+Fix is two complementary techniques shipped together:
+
+1. **CamelCase-split before tokenizing** — modify the `title_tsv` / `description_tsv` GENERATED column expressions on `video_locale` to inject a space at every camelCase boundary before `to_tsvector` runs. `BibleProject` → `Bible Project` → tokens `bible` + `project`. Both single-word and two-word user queries now match. Generalizes to any CamelCased brand or compound (JesusFilm, BibleStudy, etc.).
+2. **Extend trigram retriever to title+description** — add a trigram GIN index on `video_locale.description` and update `searchByTrigram` to UNION title-side and description-side matches. Trigrams ignore token boundaries entirely (`bible project` 3-grams overlap `bibleproject` directly), catching CamelCase, typos, and partial matches as defense-in-depth beyond what (1) alone covers.
+
+Hybrid mode (default, byte-identical to R4) stays untouched — both fixes are keyword-first-mode-only.
+
+## Problem Frame
+
+Admin's hybrid-search keyword-first mode (R4 extension, 2026-04-29) was tuned for "natural" multi-word queries against typical title/description copy. The `BibleProject` brand pattern — one CamelCased word in marketing attribution text across 14+ Sermon-on-the-Mount and related videos — defeats the simple tokenizer in two ways: titles don't contain the brand at all (so trigram and exact-title fail), and descriptions contain the brand only as the joined-form lexeme `bibleproject` (so `websearch_to_tsquery` AND-of-tokens fails).
+
+Algolia handles this for free because its default tokenizer splits CamelCase and adds prefix matches at index time — every BibleProject record indexes both `bibleproject` AND `bible` + `project`. The session-2026-05-02 demo-keyword-search diff against `q="the bible project"` showed admin returning 6 hits (BibleProject Collection + 4 Gospel Parts + StoryClubs) versus Algolia returning 20+ (the full Sermon-on-the-Mount series, Wisdom Within Laws series, Beatitudes, Shema, etc.). Per-row token-presence verification confirmed all 14 missing videos exist in admin's local DB with the brand attribution intact — the gap is purely the tokenization mismatch.
+
+## Requirements Trace
+
+- R1. For `q="the bible project"`, keyword-first mode returns at least 15 of the ~20 videos Algolia stg returns. Validated via the demo-keyword-search canary (manual) and a strengthened bible-project headline test (automated).
+- R2. The CamelCase-split tokenization generalizes — any CamelCased brand in `title` or `description` becomes searchable as both the joined form and the split form. Verified via a unit test with synthetic CamelCased fixtures.
+- R3. Hybrid mode (default, byte-identical to R4) remains byte-identical post-change. Enforced by `apps/admin/src/services/hybrid-search.regression.test.ts`.
+- R4. Byte-parity invariant between TypeScript `*_GENERATED_EXPR` constants and the migration SQL is preserved. Enforced by `apps/admin/src/services/hybrid-search-sql.test.ts`.
+- R5. Generated-column rewrite uses the coordinated `DROP COLUMN ... CASCADE + ADD COLUMN ... GENERATED ALWAYS AS (...)` pattern (no in-place ALTER attempt). Per `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`.
+- R6. New description trigram index `CREATE INDEX CONCURRENTLY` not required (admin uses `prisma migrate deploy` which runs in a transaction; non-concurrent CREATE INDEX is the convention). Sized + verified via `pg_relation_size` against the local backfilled DB.
+
+## Scope Boundaries
+
+- **Only the keyword-first mode retrievers + their generated-column inputs.** No changes to hybrid-mode retrievers (`searchVideoSemantic`, `searchVideoKeyword`), no changes to fusion / dedup, no changes to `searchExperience*`. Hybrid mode reads the same `title_tsv` / `description_tsv` columns post-fix, so its tsquery results may shift slightly when descriptions contain CamelCased brands — this is acceptable because the regression test asserts byte-identity against deterministic mocked retrievers, not against real DB content. Re-verify the regression-test mocks are unchanged.
+- **No changes to the `searchByKeywordWeighted` SQL beyond reading the regenerated columns.** The retriever's expression and rank function stay the same; only the underlying tsvector column content changes.
+- **No changes to the demo-keyword-search throwaway harness.** That tool exists to validate this fix, not to be modified by it.
+- **No new ranking weights, no editorial-boost field, no parent-child collection expansion.** Those are separate semantic-search-report.md follow-ups; out of scope here.
+- **No production data migration concerns.** Admin's prod `video` / `video_locale` tables are 0 rows today (R0 backfill not yet run). The generated-column rewrite is a no-op in prod; on local + stage envs, regeneration runs over the test corpus during `prisma migrate deploy`.
+- **No changes to title-side trigram retriever shape or index name.** The existing `video_locale_title_trgm_idx` stays; only a new `video_locale_description_trgm_idx` is added and `searchByTrigram` learns to query both.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql` — current generated-column definitions + indexes for the keyword-first work. The new migration must reference it as the predecessor.
+- `apps/admin/src/services/hybrid-search-sql.ts` — `TITLE_TSV_GENERATED_EXPR` (line ~129), `DESCRIPTION_TSV_GENERATED_EXPR` (line ~139), `WEIGHTED_TSV_INDEX_EXPR` (line ~152), `WEIGHTED_TSV_QUERY_EXPR` (line ~164). All four are byte-parity-locked with the migration.
+- `apps/admin/src/services/hybrid-search-sql.test.ts` — reads the 0009 migration file and asserts byte-equality against the constants. Will need to either point at the new migration or include both depending on convention.
+- `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts` — `searchByTrigram` is title-only today; this unit extends it.
+- `apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts` — existing trigram-path tests; new tests for description-side matches and per-row dedup.
+- `apps/admin/src/services/hybrid-search.bible-project.test.ts` — currently asserts top-3 are all `/bible\s*project/i` titles. Strengthen to assert top-N includes ≥5 Sermon-on-the-Mount titles (Lord's Prayer, Shema, YHWH, Beatitudes, Sermon on the Mount, etc.).
+- `apps/admin/src/services/hybrid-search.regression.test.ts` — protects hybrid mode's byte-identity. Re-run on every commit; should stay green.
+- `apps/admin/src/app/watch/demo-keyword-search/` — throwaway canary for live verification (untouched by this plan).
+
+### Institutional Learnings
+
+- `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md` — Postgres has no `ALTER COLUMN ... GENERATED` editor for stored expressions. Coordinated `DROP COLUMN ... CASCADE + ADD COLUMN ... GENERATED` migration is the only correct path.
+- `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md` — operator-class GIN (`gin_trgm_ops`) doesn't need a shared constant for byte-parity; index selection happens via the `%>` / `%` operators. The new description trigram index follows the title trigram pattern.
+- `docs/solutions/database-issues/prisma-unsupported-placeholder-for-raw-sql-generated-columns-20260429.md` — Prisma's schema mirror needs the column declared as `Unsupported("tsvector")` (or similar) to keep its diff reconciliation happy when the column is migration-managed.
+- `docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md` — re-derive every SQL invariant against admin's current schema, not against cms's older shape. Already applied in R4; this fix doesn't introduce new invariants.
+- `apps/admin/CLAUDE.md` "Hybrid search keyword-first mode (R4 extension)" section — describes the byte-parity invariant, the generated-column drift trap, and the operational runbook (EXPLAIN ANALYZE for index selection).
+- `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md` — the regression-test approach used by `hybrid-search.regression.test.ts`. Don't break the snapshot.
+
+### External References
+
+None gathered — Postgres `to_tsvector` / `websearch_to_tsquery` / pg_trgm semantics are stable and well-documented in the local solutions corpus. The CamelCase-split regex pattern (`'([a-z])([A-Z])'`) is the canonical Postgres recipe for this transformation; both forms (one-letter and multi-letter prefix variants) are equivalent for our case since admin's brands are simple two-segment CamelCase.
+
+## Key Technical Decisions
+
+- **Single new migration** that does both the generated-column rewrite AND the description trigram index. Atomic from an admin-deploy standpoint; both ship or neither does. The two changes are conceptually independent but operationally coupled (both touch `video_locale` + both want the same backfill pass).
+- **CamelCase regex applied to both `title` and `description`**, not just description. Titles in admin are usually space-separated already, but applying the regex uniformly: (a) keeps the two `*_GENERATED_EXPR` constants symmetric, (b) cheap insurance against future title copy that uses CamelCase brands (e.g., `JesusFilm` in a future title), (c) avoids subtle differences in how titles vs descriptions tokenize.
+- **The regex `([a-z])([A-Z])` over the lower-then-upper boundary**, not the more aggressive `([a-zA-Z])([A-Z][a-z])` variant. The simpler form preserves all-caps acronyms (`YHWH`, `LORD`) intact rather than breaking them into single letters. Admin has YHWH-titled videos in the corpus; the simpler regex leaves them as one token, which is correct.
+- **Description trigram index alongside the existing title trigram index, not replacing it.** Two indexes, two query paths in `searchByTrigram`. UNION via SQL with per-row dedup at the boundary (same video_id rows collapsed; rank by `GREATEST(similarity(title, q), similarity(description, q))`).
+- **Non-concurrent `CREATE INDEX`** in the migration. Admin uses `prisma migrate deploy` which runs migrations in transactions; `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. Acceptable because admin's prod corpus is 0 rows today and the index will populate as part of the R0 backfill flow (not as a hot-path operation against a busy table).
+- **No `IF NOT EXISTS` guard on the new trigram index.** The migration is forward-only and authored once; failing on duplicate creation is the correct behavior, surfacing the mistake immediately. (The IF NOT EXISTS pattern is reserved for the generated-column drift case where re-running is a recovery path.)
+- **Bible-project headline test gets a stronger top-N assertion.** Today: top-3 are all `/bible\s*project/i` titles. Strengthen: top-15 includes at least 5 of `[The Lord's Prayer, Shema, YHWH, Beatitudes, Sermon on the Mount, Wisdom Within Laws (any), Wisdom in Relationships, The Choice, Jesus Fulfills the Law, Intro to Sermon on the Mount, Nephesh, Advent Series]`. The list is conservative — the local DB content is known, so the test asserts a concrete recall floor.
+- **Skip a separate verification migration script.** Admin's existing test suite (`hybrid-search-sql.test.ts` for byte-parity, `hybrid-search.bible-project.test.ts` for recall, `hybrid-search.regression.test.ts` for hybrid byte-identity) already covers what we'd verify. Adding a one-off script is YAGNI.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Why CamelCase-split AND trigram on description, instead of just one?** Defense in depth + each catches different failure modes. CamelCase-split fixes the BibleProject case exactly. Description trigram catches typos ("biblproject"), partial input ("biblepro"), and any future CamelCased brand we forget exists. Combined cost is one migration + one new index + ~30 lines of SQL in `searchByTrigram`.
+- **Will the regex break existing passing tests?** Hybrid-mode regression test uses deterministic mocked retrievers, not real DB content — green. Byte-parity test reads the migration; updated together — green. Bible-project test currently passes with admin returning the BibleProject Collection at #1; the strengthened assertion uses the same fixture but adds expectations.
+- **Migration sequencing — does the generated-column rewrite need to run before the trigram index?** No. They're independent. Same migration file, two top-level statements. Postgres applies them in declaration order regardless.
+- **What about `\W`-stripping or accent-folding?** Out of scope. The brand-attribution failure is purely a CamelCase tokenization issue. Accent folding is a separate concern with its own tradeoffs (Unicode normalization, locale collation) and isn't required to close the BibleProject recall gap.
+- **Should we also cover the lower-then-digit boundary (`Genesis19` → `Genesis 19`)?** Not now. Admin's title and description corpus doesn't show that pattern affecting recall. Pure CamelCase boundary is enough; revisit if a future query class fails on number-suffixed tokens.
+
+### Deferred to Implementation
+
+- **Exact form of the SQL UNION in `searchByTrigram`** — `UNION ALL` + outer GROUP BY for dedup, vs. `UNION` (which dedups) + a different rank synthesis, vs. two separate CTEs joined. Pick the form that reads cleanest given the existing retriever's structure; verify with EXPLAIN ANALYZE that both indexes are selected.
+- **`pg_relation_size` of the new description trigram index** on the local backfilled corpus. Capture as part of Unit 4 verification; if it's > 1 GB, surface as a follow-up risk for the R0-prod-backfill rollout (but don't block landing — admin has zero prod data today).
+- **Whether the strengthened bible-project test's recall floor (≥5 of 12 candidate titles in top-15) is the right number.** Tune to whatever the local fix actually produces; the floor should be high enough to lock in the improvement, low enough not to flake on small ranking shifts. Pick during Unit 4.
+- **Handling of `text` vs `varchar(N)` differences in the regex output.** `regexp_replace` returns `text`; `to_tsvector` accepts both. Trivial but verify the migration runs without an explicit cast.
+
+## Implementation Units
+
+- [ ] **Unit 1: Migration — CamelCase-split generated columns + description trigram index**
+
+**Goal:** Write a single forward-only migration that drops + recreates `title_tsv` / `description_tsv` with the CamelCase-split expression, and adds a trigram GIN index on `description`.
+
+**Requirements:** R2, R5, R6.
+
+**Dependencies:** None (admin's `pg_trgm` extension was provisioned by `0009_keyword_first_lexical`).
+
+**Files:**
+
+- Create: `apps/admin/prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql`
+- Modify (Prisma schema mirror): `apps/admin/prisma/schema.prisma` — verify `title_tsv` / `description_tsv` declarations still match (likely no change needed if they're `Unsupported("tsvector")?`)
+
+**Approach:**
+
+- Drop both existing generated columns with `CASCADE` (drops `video_locale_lexical_weighted_idx` automatically — the migration recreates it).
+- Re-add `title_tsv` and `description_tsv` as `GENERATED ALWAYS AS (to_tsvector('simple', regexp_replace(coalesce(<col>, ''), '([a-z])([A-Z])', '\1 \2', 'g'))) STORED`.
+- Recreate `video_locale_lexical_weighted_idx` over the weighted expression (same as 0009 — byte-equal to `WEIGHTED_TSV_INDEX_EXPR`).
+- Recreate `video_locale_fulltext_search_idx` (the R4 GIN index referenced in `searchVideoKeyword`) — confirm it was column-based not expression-based; if expression-based on the OLD `to_tsvector` call, it must also drop+recreate to use the new column content. Per CLAUDE.md the R4 index is over `to_tsvector('simple', coalesce(title,'') || ' ' || coalesce(description,''))` — that expression is unchanged by this migration (still operates on raw `title`/`description`, not on `*_tsv`), but its CONTENT now differs because... actually no, the R4 index expression is independent of the regenerated columns. It builds its tsvector on the fly from raw `title`/`description`. So it does NOT pick up the CamelCase split. **Decision:** the R4 index continues to use the un-split tokenization; that's correct because hybrid mode (which uses the R4 index via `searchVideoKeyword`) must stay byte-identical. Hybrid mode's recall on CamelCased brands is unchanged by this fix; only keyword-first mode picks up the improvement.
+- Add `CREATE INDEX video_locale_description_trgm_idx ON video_locale USING gin (description gin_trgm_ops);`.
+- Add a comment header in the migration referencing the byte-parity contract with `hybrid-search-sql.ts` and the parent solutions doc on generated-column drift.
+
+**Patterns to follow:**
+
+- `apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql` for the generated-column shape and the trigram index syntax.
+- `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md` for the DROP CASCADE + ADD pattern.
+
+**Test scenarios:**
+
+- (covered by Unit 2's byte-parity test) Migration file's generated-column expressions are byte-equal to `TITLE_TSV_GENERATED_EXPR` / `DESCRIPTION_TSV_GENERATED_EXPR`.
+- Migration runs cleanly via `pnpm --filter @forge/admin db:migrate:dev` against local Postgres.
+- After migration, `SELECT title_tsv, description_tsv FROM video_locale WHERE title = 'The BibleProject Collection' LIMIT 1` shows tokens including both `bibleproject` AND `bible` + `project` (or shows only the split form, depending on whether the regex is applied before or after concatenation — verify which).
+
+**Verification:**
+
+- `pnpm --filter @forge/admin db:migrate:dev` succeeds on a fresh local DB.
+- `\d+ video_locale` shows both columns with the new generated expression.
+- `\di video_locale*` shows `video_locale_description_trgm_idx` exists with `gin_trgm_ops`.
+
+---
+
+- [ ] **Unit 2: Update TypeScript constants + byte-parity test pointer**
+
+**Goal:** Update the `*_GENERATED_EXPR` constants in `hybrid-search-sql.ts` to match the new migration, byte-equal. Update the byte-parity test to read the new migration file (or both, depending on the existing test's pattern).
+
+**Requirements:** R4.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+
+- Modify: `apps/admin/src/services/hybrid-search-sql.ts` — `TITLE_TSV_GENERATED_EXPR`, `DESCRIPTION_TSV_GENERATED_EXPR`. (`WEIGHTED_TSV_INDEX_EXPR` and `WEIGHTED_TSV_QUERY_EXPR` are unchanged — they reference the columns, not the expressions inside them.)
+- Modify: `apps/admin/src/services/hybrid-search-sql.test.ts` — update the migration file path used by the byte-parity assertion to point at the new `0010_*` migration. If the test reads ALL migration files, no change needed.
+
+**Approach:**
+
+- The new constant values are the regex-wrapped `to_tsvector('simple', regexp_replace(coalesce(<col>, ''), '([a-z])([A-Z])', '\1 \2', 'g'))`.
+- Update the JSDoc on each constant to mention the CamelCase-split intent + reference the new migration.
+- Confirm by running `pnpm --filter @forge/admin test src/services/hybrid-search-sql.test.ts` — should pass.
+
+**Patterns to follow:**
+
+- The existing byte-parity test pattern (reads migration text, asserts substring match against the constant) — mirror it for the new constants.
+
+**Test scenarios:**
+
+- Byte-parity test passes: every `*_GENERATED_EXPR` constant appears verbatim in the new migration.
+- A small unit can also verify a sample CamelCase string transforms as expected: `to_tsvector('simple', regexp_replace('BibleProject', '([a-z])([A-Z])', '\1 \2', 'g'))` produces tokens `bible` + `project` (run via raw `$queryRaw` against the test DB).
+
+**Verification:**
+
+- `pnpm --filter @forge/admin test src/services/hybrid-search-sql.test.ts` green.
+- `pnpm --filter @forge/admin typecheck` clean.
+
+---
+
+- [ ] **Unit 3: Extend `searchByTrigram` to title+description**
+
+**Goal:** Update the trigram retriever to UNION title-side and description-side matches, with per-row dedup and `GREATEST(similarity(title, q), similarity(description, q))` ranking.
+
+**Requirements:** R1.
+
+**Dependencies:** Unit 1 (the new description trigram index must exist for this query to use the index path).
+
+**Files:**
+
+- Modify: `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts` — `searchByTrigram`.
+- Modify: `apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts` — add description-match scenarios.
+
+**Approach:**
+
+- The retriever currently uses `vl.title %> $1` with `similarity(vl.title, $1)` ranking. Extend to a UNION of two halves: title-match path (unchanged) and description-match path (`vl.description %> $1` with `similarity(vl.description, $1)`).
+- Per-row dedup: same video_id can appear via both halves; collapse to one row keeping the higher similarity score. Either via `UNION` (which dedups), or `UNION ALL` + outer GROUP BY video_id.
+- Honor the existing R4-extension chain: locale + status + `deleted_at IS NULL`.
+- Cap the limit at the same `limit * OVERFETCH_FACTOR` used elsewhere in the keyword-first retrievers.
+
+**Patterns to follow:**
+
+- The existing `searchByTrigram` for the title-side query shape.
+- `searchByKeywordWeighted` for the LATERAL playback resolution + status filter pattern.
+- `apps/cms/src/api/search/services/keyword-weighted-search.ts` if a sibling exists for cross-checking.
+
+**Test scenarios:**
+
+- Hit-via-title-only: query matches title's trigram; description doesn't contain the query. Result includes the row, similarity reflects the title score.
+- Hit-via-description-only: query matches description's trigram; title doesn't. Result includes the row, similarity reflects the description score. Specifically: `q="bibleproject"` matches "The Lord's Prayer" via its description.
+- Hit-via-both: query matches both; result row appears once, similarity is the GREATEST of the two.
+- Locale/status filter respected: row in a different locale or with `status != 'published'` does NOT appear.
+- Soft-deleted video excluded: `v.deleted_at IS NOT NULL` rows do NOT appear.
+- Limit respected: result count ≤ `limit * OVERFETCH_FACTOR`.
+
+**Verification:**
+
+- `pnpm --filter @forge/admin test src/services/hybrid-search-keyword-first-retrievers.test.ts` green.
+- Manual `EXPLAIN ANALYZE` shows both `video_locale_title_trgm_idx` AND `video_locale_description_trgm_idx` appear in the plan for a query that matches both fields.
+
+---
+
+- [ ] **Unit 4: Strengthen bible-project headline test + verify regression-test invariant**
+
+**Goal:** Lock in the recall improvement with a stronger assertion in the bible-project headline test. Confirm hybrid-mode regression test still passes.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** Units 1–3.
+
+**Files:**
+
+- Modify: `apps/admin/src/services/hybrid-search.bible-project.test.ts` — add the top-N recall assertion.
+- (verify only) `apps/admin/src/services/hybrid-search.regression.test.ts` — should pass unchanged.
+- (verify only) `apps/admin/src/services/hybrid-search.keyword-first.test.ts` — should pass unchanged or update fixtures if they overlap with the corpus shift.
+
+**Approach:**
+
+- Existing test asserts top-3 titles all match `/bible\s*project/i`. Keep that, add a parallel assertion that top-15 includes at least 5 titles from a curated list of Sermon-on-the-Mount + BibleProject series titles known to exist in the local fixture corpus (Lord's Prayer, Shema, YHWH, Beatitudes, Sermon on the Mount, Wisdom Within Laws (Murder/Adultery/Divorce), Wisdom in Relationships, The Choice, Jesus Fulfills the Law, Intro to Sermon on the Mount, Nephesh, Advent Series). Floor of 5 is conservative — actual results will likely surface more.
+- Run `hybrid-search.regression.test.ts` to confirm hybrid mode's byte-identity-against-mocks still holds. If it fails, the regression-test mocks have somehow taken a dependency on the new tsvector content (they shouldn't), and the failure is the right place to investigate.
+
+**Test scenarios:**
+
+- top-3 are all bible-project titles (existing).
+- top-15 includes ≥5 of the curated Sermon-on-the-Mount list (new).
+- Hybrid mode regression test stays green (existing — verification only).
+
+**Verification:**
+
+- `pnpm --filter @forge/admin test src/services/hybrid-search.bible-project.test.ts` green with new assertion.
+- `pnpm --filter @forge/admin test src/services/hybrid-search.regression.test.ts` green.
+- Manual canary at `http://localhost:3003/watch/demo-keyword-search?q=the+bible+project&locale=en&limit=20&k=20`: keyword-first column shows ≥15 results, "Algolia ∩ Keyword" tile and "In all 3" tile populated with multiple slugs.
+
+## System-Wide Impact
+
+- **Interaction graph:** generated-column regeneration runs once per `prisma migrate deploy` invocation. Backfill cost = O(rows × description-length) but admin's prod corpus is 0 rows today; on local + stage envs the cost is bounded by test-fixture size.
+- **Error propagation:** migration failure leaves the DB in a broken state (columns dropped but not recreated). The forward-only migration is wrapped in a transaction by `prisma migrate deploy`, so partial-failure rollback is automatic — but a failed migration on a deployed environment requires manual `prisma migrate resolve --rolled-back` per the existing playbook in `apps/admin/CLAUDE.md`.
+- **State lifecycle risks:** the regenerated columns will produce different lexemes than the old columns. Any cached query results downstream would be stale. Admin doesn't cache search results today, so this is moot — but if a future cache lands, this fix is a cache-invalidation event.
+- **API surface parity:** none — keyword-first is admin-internal today (no consumer outside the demo route + the future apps/web cutover at R8). The contract (`HybridSearchResult` shape) is unchanged.
+- **Integration coverage:** the bible-project headline test is the integration probe. The regression test guards hybrid mode's contract. No new cross-layer scenarios introduced.
+
+## Risks & Dependencies
+
+- **Hybrid-mode regression test could fail unexpectedly** if its mocks somehow depend on the new tsvector content (they shouldn't — mocks are typed return values, not real SQL). If it does fail, the right answer is to fix the mock dependency, not weaken the regression assertion.
+- **CamelCase regex misclassifies a real-world string.** Examples: `iPhone` → `i Phone` (correct); `YHWH` → unchanged (correct, all-caps preserved); `iOS` → unchanged (no lower-then-upper boundary); `MacOS` → `Mac OS` (correct). The chosen regex (`([a-z])([A-Z])`) is the conservative form. Anything we tokenize as one piece that should be two pieces (or vice versa) shows up as a recall miss against future canary queries — log and revisit.
+- **Description trigram index size.** Per `apps/admin/CLAUDE.md` R4-extension notes, this was explicitly avoided in R4 because of corpus-size concerns. The 2026-05-02 reasoning to add it now: admin's prod corpus is 0 rows, so the size penalty is theoretical until R0 backfill. **Mitigation:** capture `pg_relation_size('video_locale_description_trgm_idx')` after local backfill in the Unit 4 verification log; if > 1 GB, surface as a follow-up to consider partial indexing or alternative approaches before R0 prod backfill.
+- **Migration ordering in a multi-app deploy.** This migration is admin-only and doesn't touch shared infra. apps/cms's keyword-first port (`docs/plans/2026-04-29-002-feat-search-cms-to-admin-keyword-first-port-plan.md`) does NOT need a parallel change unless the cms-side R4 sibling work also needs CamelCase recall — out of scope here, follow-up if so.
+
+## Documentation / Operational Notes
+
+- Update `apps/admin/CLAUDE.md` "Hybrid search keyword-first mode (R4 extension)" section: brief addendum noting that the generated-column expressions now CamelCase-split before tokenizing, and that `searchByTrigram` queries title+description. Reference the new migration `0010_camelcase_tsv_and_description_trigram`.
+- No solutions doc needed for the fix itself — but the BibleProject root-cause investigation produced reusable diagnostic moves (psql `to_tsquery` + `position()` + `description_tsv @@` checks). Those are worth a separate `ce:compound` capture as a "diagnosing keyword-search recall gaps" runbook. **Defer to a follow-up `ce:compound` after this lands** so the doc cites concrete file paths from the merged fix.
+- No Railway env-var changes, no Doppler changes. Pure code + migration.
+
+## Sources & References
+
+- Diagnostic session 2026-05-02 (this conversation) — root cause confirmed via psql; demo-keyword-search canary; per-video token-presence verification.
+- `apps/admin/CLAUDE.md` "Hybrid search keyword-first mode (R4 extension)" + "Common pitfalls" sections.
+- `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`
+- `docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md`
+- `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`
+- `apps/admin/prisma/migrations/0009_keyword_first_lexical/migration.sql` — predecessor pattern.
+- `apps/admin/src/services/hybrid-search-sql.ts` — byte-parity-locked constants.
+- `docs/plans/2026-04-29-001-feat-search-keyword-first-mode-plan.md` — R4-extension origin.
+- `docs/plans/2026-04-30-001-feat-algolia-column-demo-keyword-search-plan.md` — the canary that surfaced the recall gap.


### PR DESCRIPTION
## Summary

Two coordinated fixes so admin's keyword-first hybrid search returns the full BibleProject series for `q="the bible project"` — recall jumps from 6 → 20, matching Algolia's stg corpus.

**Root cause** (confirmed via psql in the 2026-05-02 diagnostic session, see plan): descriptions write the brand as one word (`BibleProject`), Postgres `to_tsvector('simple', ...)` keeps that as a single lexeme `bibleproject`, and `websearch_to_tsquery('simple', 'the bible project')` produces `'the' & 'bible' & 'project'` (three tokens, ANDed) which never matches the lexeme. 14 of 20 BibleProject-series videos (Lord's Prayer, Shema, YHWH, Beatitudes, Sermon on the Mount, Wisdom Within Laws, etc.) silently failed.

### Fix 1 — CamelCase-split before tokenizing

Generated columns `title_tsv` / `description_tsv` on `video_locale` now wrap `to_tsvector` around:
```sql
regexp_replace(coalesce(<col>, ''), '([a-z])([A-Z])', '\1 \2', 'g')
```
`BibleProject` → `Bible Project` → tokens `bible` + `project`. Both joined-form and split-form spellings match. The `[a-z][A-Z]` form is conservative — preserves all-caps acronyms like YHWH / LORD intact while still splitting two-segment CamelCase. Generalizes to any CamelCased brand or compound (`JesusFilm`, `BibleStudy`, etc.).

### Fix 2 — Trigram retriever extended to title + description

- New `video_locale_description_trgm_idx` (operator-class GIN with `gin_trgm_ops`).
- `searchByTrigram` now UNIONs title-side and description-side `%>` matches and ranks by `GREATEST(similarity(title, q), similarity(coalesce(description, ''), q))`.
- Catches CamelCase, typos, and partial matches as defense-in-depth beyond fix 1.

### Hybrid mode untouched

The legacy R4 `video_locale_fulltext_search_idx` is expression-based on raw `title` / `description` (not on the regenerated `*_tsv` columns), so its content is unchanged. `hybrid-search.regression.test.ts` confirms hybrid mode's byte-identity-against-mocks stays green.

### Migration shape

Migration `0010_camelcase_tsv_and_description_trigram` follows the documented `DROP COLUMN CASCADE + ADD COLUMN GENERATED` pattern (Postgres has no in-place `ALTER COLUMN ... GENERATED` for stored expressions). Per `docs/solutions/database-issues/postgres-generated-column-drift-add-column-if-not-exists-20260429.md`. Byte-parity invariant between TS `*_GENERATED_EXPR` constants and the migration SQL preserved (`hybrid-search-sql.test.ts` enforces).

## Testing

- **1282 / 1282 admin tests green** including:
  - `hybrid-search-sql.test.ts` (byte-parity against the new 0010 migration + historical invariants for 0009)
  - `hybrid-search-keyword-first-retrievers.test.ts` (3 new tests for description-side trigram match path)
  - `hybrid-search.bible-project.test.ts` (1 new test locking in attribution-matched recall in top-15 at the orchestrator level)
  - `hybrid-search.regression.test.ts` (hybrid byte-identity preserved)
- **Live verified** against the local `forge_admin` DB:
  - psql keyword-weighted query returns 25 matches for "the bible project" (was 6 pre-fix)
  - `/watch/demo-keyword-search?q=the+bible+project&locale=en&limit=20&k=20` shows:
    - 20 keyword-first results
    - "Algolia ∩ Keyword" tile: ~4 → 14
    - "In all 3" tile: 0 → 6
    - Algolia parity column is the visual confirmation

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs (Railway): grep `[search]` and `event=query_embedding_failure` on `@forge/admin` — no new error patterns expected.
  - The /watch/demo-keyword-search canary post-merge: keyword-first column should populate with the full BibleProject series.
- **Validation checks**
  - `EXPLAIN ANALYZE` against the local DB confirms `video_locale_lexical_weighted_idx` AND `video_locale_description_trgm_idx` appear in the plan for keyword-first queries.
  - `SELECT pg_relation_size('video_locale_description_trgm_idx');` — capture size; today admin's prod corpus is 0 rows so the index is empty. Re-measure after R0 backfill; if > 1 GB, surface as a follow-up to consider partial indexing.
- **Expected healthy behavior**
  - Hybrid search regression test stays green on every commit.
  - Keyword-first canary on `/watch/demo-keyword-search?q=the+bible+project` returns ≥15 of the videos Algolia returns.
- **Failure signal / rollback trigger**
  - Hybrid mode results regress (different from byte-identity baseline) → rollback (revert the migration by writing a sibling migration that restores 0009's expressions; constants update in lockstep).
  - Keyword-first surfaces obviously-broken tokenization (e.g., breaks `YHWH` into `Y H W H`) → tighten the regex; the conservative `([a-z])([A-Z])` shouldn't but if observed in any locale, surface here.
  - Description trigram index unexpectedly large in prod after R0 backfill → consider partial indexing or fall back to title-only trigram.
- **Validation window & owner**
  - Window: 24 hours post-merge; the keyword-first canary should be re-checked once admin's prod corpus has any data.
  - Owner: @Kneesal.

## Related

- `docs/plans/2026-05-02-001-fix-keyword-first-camelcase-recall-plan.md` — the plan
- PR #864 — the throwaway Algolia parity demo that surfaced this gap
- `apps/admin/CLAUDE.md` "Hybrid search keyword-first mode (R4 extension)" + the `0009_keyword_first_lexical` migration

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0