### PR TITLE
docs(admin): address ce:review findings on PR #872 (CamelCase recall fix)

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -885,14 +885,27 @@ This is an **extension of R4**, not a new R-stage. The cms-side
 window; admin's surface matches the cms-side contract by R8 cutover.
 
 - **Schema:** Migration `0009_keyword_first_lexical/migration.sql`
-  provisions `pg_trgm`, two STORED generated tsvector columns on
-  `video_locale` (`title_tsv`, `description_tsv`), a weighted GIN
-  index over `(setweight(title_tsv,'A') || setweight(description_tsv,'B'))`,
-  and a trigram GIN index on `title gin_trgm_ops`. Generated columns
-  - GIN indexes attach to `VideoLocale`, NOT `Video` (per-locale
-    attachment per admin's data model). The legacy R4
-    `video_locale_fulltext_search_idx` from `0006` is untouched —
-    hybrid mode keeps reading it via `searchVideoKeyword`.
+  originally provisioned `pg_trgm`, two STORED generated tsvector
+  columns on `video_locale` (`title_tsv`, `description_tsv`), a
+  weighted GIN index over `(setweight(title_tsv,'A') ||
+setweight(description_tsv,'B'))`, and a trigram GIN index on
+  `title gin_trgm_ops`. Migration
+  `0010_camelcase_tsv_and_description_trigram` then DROP-CASCADEd
+  the generated columns and recreated them with a CamelCase-split
+  `regexp_replace` wrapper before `to_tsvector` (so `BibleProject`
+  tokenizes as `bible` + `project`, not just `bibleproject`),
+  recreated the weighted GIN index, and added a second trigram GIN
+  index on `description gin_trgm_ops`. **As of 0010:** generated
+  columns are owned by 0010, the title trigram index from 0009 is
+  untouched, and there are now TWO trigram indexes
+  (`video_locale_title_trgm_idx`, `video_locale_description_trgm_idx`).
+  Generated columns + GIN indexes attach to `VideoLocale`, NOT
+  `Video` (per-locale attachment per admin's data model). The legacy
+  R4 `video_locale_fulltext_search_idx` from `0006` is untouched —
+  hybrid mode keeps reading it via `searchVideoKeyword`, which is
+  why hybrid mode stays byte-identical to R4 even after 0010
+  changed the keyword-first tokenization. See
+  `docs/plans/2026-05-02-001-fix-keyword-first-camelcase-recall-plan.md`.
 
 - **Byte-parity invariant:** `WEIGHTED_TSV_INDEX_EXPR` /
   `WEIGHTED_TSV_QUERY_EXPR` / `TITLE_TSV_GENERATED_EXPR` /
@@ -915,8 +928,16 @@ ADD COLUMN ... GENERATED ALWAYS AS (...)` migration. Per
     `websearch_to_tsquery('simple', q)`, ranked by `ts_rank_cd`
     against the weighted tsvector. `Prisma.raw(WEIGHTED_TSV_QUERY_EXPR)`
     for the unbindable expression fragment.
-  - `searchByTrigram` — `vl.title %> q` with `similarity(vl.title, q)`
-    ranking. Title-only (description trigram index would balloon).
+  - `searchByTrigram` — `vl.title %> q OR vl.description %> q`
+    with ranking by
+    `GREATEST(similarity(vl.title, q), similarity(coalesce(vl.description, ''), q))`.
+    Per-row dedup via `DISTINCT ON (v.id)` collapses rows that match
+    via both fields. Backed by `video_locale_title_trgm_idx` (from 0009) and `video_locale_description_trgm_idx` (from 0010). The
+    description-side index is heavier than the title-side; current
+    catalog is 0 rows in prod, so the precaution that gated R4 on
+    title-only no longer applies — but capture
+    `pg_relation_size('video_locale_description_trgm_idx')` once R0
+    backfill lands and revisit if it grows beyond a few hundred MB.
   - `searchByExactTitle` — dynamic AND-chain of `vl.title ILIKE ?`
     via `Prisma.join`, ranked `LENGTH(title) ASC`. Tokenization is
     Unicode letter / digit split, lowercased, deduped, **capped at
@@ -988,12 +1009,18 @@ ADD COLUMN ... GENERATED ALWAYS AS (...)` migration. Per
 
 **Operational runbook:**
 
-1. Apply migration `0009_keyword_first_lexical` in any environment
+1. Apply migrations `0009_keyword_first_lexical` and
+   `0010_camelcase_tsv_and_description_trigram` in any environment
    that wants keyword-first available. `prisma migrate dev` /
-   `prisma migrate deploy` is idempotent. The two new GIN indexes
-   add disk + write amplification proportional to corpus size; cost
-   is negligible at admin's current zero-row prod data and grows
-   when R0 backfills.
+   `prisma migrate deploy` is idempotent against `_prisma_migrations`.
+   **Re-applying 0010 manually against a populated `video_locale` is
+   destructive** — DROP CASCADE removes the columns and the rebuild
+   takes AccessExclusiveLock. Treat fixes as forward-only
+   counter-migrations, never `migrate resolve --rolled-back` 0010
+   once R0 has populated the table. The three GIN indexes
+   (weighted, title trgm, description trgm) add disk + write
+   amplification proportional to corpus size; cost is negligible at
+   admin's current zero-row prod data and grows when R0 backfills.
 2. Confirm `pg_trgm` extension permission on the prod DB role.
    First migration that needs it; older R0–R5 migrations don't.
 3. To opt in via REST, append `?mode=keyword-first`. To opt in via
@@ -1011,9 +1038,14 @@ setweight(vl.description_tsv,'B') @@
 websearch_to_tsquery('simple', 'jesus') AND vl.locale = 'en'
 LIMIT 10;`
    should show `Bitmap Index Scan on
-video_locale_lexical_weighted_idx`. Trigram probe:
-   `… WHERE vl.title %> 'jesus' …` should show
-   `video_locale_title_trgm_idx`.
+video_locale_lexical_weighted_idx`. Trigram probe (post-0010, both
+   title and description halves should appear in the plan via
+   `BitmapOr`):
+   `… WHERE (vl.title %> 'jesus' OR vl.description %> 'jesus') …`
+   should show `BitmapOr` over `video_locale_title_trgm_idx` and
+   `video_locale_description_trgm_idx`. On an empty corpus the
+   planner correctly prefers Seq Scan; the BitmapOr plan only
+   matters once data lands. Re-run this probe at R0 readiness.
 6. R0 dependency: admin's `video` / `video_locale` tables are 0 rows
    in prod. Real-DB integration tests (canary diff vs cms keyword-first,
    EXPLAIN-based GIN verification) are deferred to R0 readiness.

--- a/apps/admin/prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql
+++ b/apps/admin/prisma/migrations/0010_camelcase_tsv_and_description_trigram/migration.sql
@@ -13,6 +13,16 @@
 --      videos with those titles), while still splitting two-segment
 --      CamelCase like `BibleProject` / `JesusFilm` / `MacOS`.
 --
+--      KNOWN LIMITATION (ASCII-only): POSIX bracket classes `[a-z]` /
+--      `[A-Z]` match ONLY ASCII Latin characters. Cyrillic, Greek, or
+--      accented-Latin CamelCase boundaries (e.g. `СловоБожие`) are
+--      NOT split. JFP is multilingual; recall on those queries falls
+--      through to the trigram retriever, which is locale-blind. A
+--      future migration can broaden the regex to `[[:lower:]]` /
+--      `[[:upper:]]` (Postgres POSIX classes that honor LC_CTYPE)
+--      once the recall trade-off is benchmarked against real corpus
+--      data — out of scope here.
+--
 --      Postgres has no in-place editor for stored generated expressions
 --      (`ALTER COLUMN ... GENERATED` doesn't accept a new expression),
 --      so the migration must DROP the columns CASCADE (which also drops
@@ -28,6 +38,19 @@
 --      is defense-in-depth beyond the CamelCase split for typos and
 --      partial input. The existing `video_locale_title_trgm_idx` is
 --      untouched.
+--
+--      SIZING REVISIT: pg_trgm GIN scales linearly with total characters
+--      indexed; descriptions are typically 10-100x longer than titles,
+--      so this index will be materially larger than the title trgm.
+--      R4 originally avoided it on a populated corpus citing balloon
+--      risk. Admin's prod is 0 rows today (R0 backfill not yet run),
+--      so the cost is theoretical. Capture
+--      `pg_relation_size('video_locale_description_trgm_idx')` once
+--      R0 lands and revisit when it exceeds ~500 MB or when write
+--      latency on `video_locale` INSERT/UPDATE regresses >20% — at
+--      that point consider partial indexing on `WHERE
+--      char_length(description) < N`, or fall back to title-only
+--      trigram with a documented recall trade-off.
 --
 -- Byte-parity invariant: the rewritten generated-column expressions
 -- and the recreated weighted index expression MUST stay byte-equal to
@@ -49,6 +72,19 @@
 -- Created non-CONCURRENTLY for the same reason as 0006 / 0009: admin's
 -- prod corpus is 0 rows today (R0 backfill not yet run) and the
 -- AccessExclusiveLock is acceptable.
+--
+-- POST-R0 WARNING: the DROP COLUMN + ADD COLUMN GENERATED pattern
+-- above takes AccessExclusiveLock on `video_locale` for the full
+-- duration of the column rebuild. On a 0-row table that's instant;
+-- on a hypothetical R0-backfilled table with 100k+ rows it's a full
+-- table rewrite. Any future migration of this shape should be
+-- staged out of the Prisma transaction (split DDL into pieces,
+-- use `CREATE INDEX CONCURRENTLY` via raw psql, or use Prisma's
+-- `Unsupported` escape hatch). Manually re-applying 0010 against a
+-- populated table is destructive — Prisma's `_prisma_migrations`
+-- ledger guards normal redeploys, but `migrate resolve --rolled-back`
+-- on this migration is forbidden post-R0; treat fixes as
+-- forward-only counter-migrations.
 
 ALTER TABLE "video_locale" DROP COLUMN IF EXISTS "title_tsv" CASCADE;
 ALTER TABLE "video_locale" DROP COLUMN IF EXISTS "description_tsv" CASCADE;

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
@@ -64,6 +64,14 @@ type VideoKeywordRowShape = RankedItem & {
 }
 
 export type KeywordWeightedResult = VideoKeywordRowShape & { rank: number }
+/**
+ * Result row from `searchByTrigram`. **As of migration 0010, `similarity`
+ * is the GREATEST of the title-side and description-side trigram
+ * similarities** (`similarity(vl.title, q)` vs
+ * `similarity(coalesce(vl.description, ''), q)`), not title-only as it
+ * was pre-0010. The retriever scans both columns and dedupes per video
+ * via `DISTINCT ON (v.id)`, keeping the higher-similarity row.
+ */
 export type TrigramResult = VideoKeywordRowShape & { similarity: number }
 export type ExactTitleResult = VideoKeywordRowShape & { titleLength: number }
 
@@ -217,16 +225,24 @@ export async function searchByKeywordWeighted(
  *     as the joined-form `BibleProject` matches via description
  *     trigrams (the brand's 3-grams overlap `bibleproject` directly).
  *
- * Uses the `%>` operator ("word similar to") on both fields. Per-row
- * dedup via `DISTINCT ON (v.id)` collapses the case where the same
- * video matches via both title and description; ranking takes the
- * GREATEST similarity across the two fields so a strong title match
- * doesn't get diluted by a weak description match.
+ * SQL shape: `WHERE (vl.title %> ? OR vl.description %> ?)` plus
+ * `DISTINCT ON (v.id) ORDER BY v.id, similarity DESC` to collapse
+ * rows that match via both fields, keeping the higher-similarity row.
+ * Ranking is `GREATEST(similarity(vl.title, q), similarity(coalesce(vl.description, ''), q))`
+ * so a strong title match doesn't get diluted by a weak description
+ * match.
+ *
+ * (Earlier framings called this a "UNION" — implementation is the
+ * equivalent OR + per-row dedup, which lets a single index probe pass
+ * cover both halves and avoids materializing two intermediate row
+ * sets.)
  *
  * Index selection happens via the `%>` operator against
  * `video_locale_title_trgm_idx` (provisioned by 0009) and
  * `video_locale_description_trgm_idx` (provisioned by 0010), both
- * operator-class GIN (`gin_trgm_ops`). No expression byte-parity
+ * operator-class GIN (`gin_trgm_ops`). On a populated table the
+ * planner should choose `BitmapOr` over the two indexes; on an empty
+ * corpus it correctly prefers Seq Scan. No expression byte-parity
  * guard needed — operator-class indexes are selected by the operator
  * regardless of column aliases. Per
  * docs/solutions/best-practices/gin-byte-parity-trigram-vs-expression-indexes-20260429.md.

--- a/apps/admin/src/services/hybrid-search-sql.test.ts
+++ b/apps/admin/src/services/hybrid-search-sql.test.ts
@@ -129,6 +129,105 @@ describe("hybrid-search-sql byte-parity with keyword-first migration", () => {
 })
 
 /**
+ * Behavioural invariant for the CamelCase-split regex.
+ *
+ * The byte-parity tests above verify that the literal regex pattern
+ * appears character-identically inside the migration. They do NOT
+ * exercise the regex's behaviour. This block runs the same pattern
+ * (`([a-z])([A-Z])`, replacement `$1 $2`, global) as a JavaScript
+ * regex against representative inputs and asserts the expected
+ * tokenization split.
+ *
+ * Postgres' POSIX regex and JavaScript's regex implement
+ * non-Unicode-aware `[a-z]` / `[A-Z]` classes identically (both
+ * match only ASCII Latin code points), so the JS form is a faithful
+ * stand-in for Postgres' `regexp_replace` here. A future migration
+ * that broadens the classes to `[[:lower:]]` / `[[:upper:]]` would
+ * diverge — Postgres honors LC_CTYPE there, JS does not — and this
+ * test would need a real-DB run instead. Out of scope today;
+ * documented as a known limit in the migration comment.
+ */
+describe("CamelCase-split regex behaviour (locked in by byte-parity above)", () => {
+  // Same pattern + replacement string used in TITLE_TSV_GENERATED_EXPR /
+  // DESCRIPTION_TSV_GENERATED_EXPR. Re-derived here as a JS RegExp so
+  // we can exercise the transformation without a DB connection.
+  const splitCamel = (input: string): string =>
+    input.replace(/([a-z])([A-Z])/g, "$1 $2")
+
+  const cases: Array<{ input: string; expected: string; rationale: string }> = [
+    {
+      input: "BibleProject",
+      expected: "Bible Project",
+      rationale: "two-segment CamelCase brand splits",
+    },
+    {
+      input: "JesusFilm",
+      expected: "Jesus Film",
+      rationale: "two-segment CamelCase brand splits",
+    },
+    {
+      input: "MacOS",
+      expected: "Mac OS",
+      rationale: "lower-then-upper boundary splits",
+    },
+    {
+      input: "iPhone",
+      expected: "i Phone",
+      rationale: "single-letter prefix splits",
+    },
+    {
+      input: "BibleProjectVideo",
+      expected: "Bible Project Video",
+      rationale: "multi-segment CamelCase splits at every boundary",
+    },
+    {
+      input: "YHWH",
+      expected: "YHWH",
+      rationale: "all-caps acronym preserved (no lower-then-upper boundary)",
+    },
+    {
+      input: "LORD",
+      expected: "LORD",
+      rationale: "all-caps acronym preserved",
+    },
+    {
+      input: "iOS",
+      expected: "i OS",
+      rationale:
+        "single-lower-then-upper boundary splits even when followed by all-caps; trailing 'S' has no upper after it",
+    },
+    {
+      input: "ABCDef",
+      expected: "ABCDef",
+      rationale:
+        "no `[a-z]` followed by `[A-Z]` — leading all-caps run kept whole",
+    },
+    {
+      input: "Bible Project",
+      expected: "Bible Project",
+      rationale: "already split — regex is idempotent",
+    },
+    {
+      input: "",
+      expected: "",
+      rationale: "empty string short-circuits",
+    },
+    {
+      input: "СловоБожие",
+      expected: "СловоБожие",
+      rationale:
+        "ASCII-only regex does NOT split Cyrillic CamelCase — known limit, recall on those locales falls through to trigram retriever",
+    },
+  ]
+
+  for (const { input, expected, rationale } of cases) {
+    it(`splits ${JSON.stringify(input)} -> ${JSON.stringify(expected)} (${rationale})`, () => {
+      expect(splitCamel(input)).toBe(expected)
+    })
+  }
+})
+
+/**
  * Historical invariant for `0009_keyword_first_lexical/migration.sql`.
  *
  * 0009 originally created the `title_tsv` / `description_tsv` generated

--- a/apps/admin/src/services/hybrid-search-sql.ts
+++ b/apps/admin/src/services/hybrid-search-sql.ts
@@ -199,10 +199,12 @@ export const VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME = "video_locale_title_trgm_idx"
  *
  * Provisioned by
  * `0010_camelcase_tsv_and_description_trigram/migration.sql`. Backs the
- * description-side of `searchByTrigram`, which UNIONs title and
- * description trigram matches in keyword-first mode. Same operator-class
- * (`gin_trgm_ops`) shape as the title trigram index — no expression
- * byte-parity guard needed.
+ * description-side of `searchByTrigram` (`vl.description %> q`), which
+ * the planner picks up by operator-class match — production code never
+ * names the index. **Exported only so the byte-parity test can assert
+ * the migration creates the index under a name we control; no
+ * production consumer references this constant.** Same shape as
+ * `VIDEO_LOCALE_TITLE_TRGM_INDEX_NAME` (also test-only).
  */
 export const VIDEO_LOCALE_DESCRIPTION_TRGM_INDEX_NAME =
   "video_locale_description_trgm_idx"

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -365,15 +365,13 @@ describe("Bible Project headline (keyword-first mode)", () => {
     // pre-fix). This test locks in that the orchestrator surfaces such
     // attribution-matched videos within top-15 once retrievers feed
     // them in — i.e., the recall improvement isn't lost in fusion.
-    type AttributionFixture = Fixture & { __isAttribution: true }
-    const ATTRIBUTION_VIDEOS: AttributionFixture[] = [
+    const ATTRIBUTION_VIDEOS: Fixture[] = [
       {
         resultId: "att-1",
         videoCoreId: "11_Sermon0710",
         videoSlug: "lords-prayer",
         videoTitle: "The Lord's Prayer",
         description: "Thanks to BibleProject for providing this series.",
-        __isAttribution: true,
       },
       {
         resultId: "att-2",
@@ -381,7 +379,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "shema-listen",
         videoTitle: "Shema / Listen",
         description: "Animated breakdown by BibleProject.",
-        __isAttribution: true,
       },
       {
         resultId: "att-3",
@@ -389,7 +386,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "yhwh-lord",
         videoTitle: "YHWH / LORD",
         description: "From the BibleProject Sermon on the Mount series.",
-        __isAttribution: true,
       },
       {
         resultId: "att-4",
@@ -397,7 +393,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "the-beatitudes",
         videoTitle: "The Beatitudes",
         description: "BibleProject overview of Matthew 5.",
-        __isAttribution: true,
       },
       {
         resultId: "att-5",
@@ -405,7 +400,6 @@ describe("Bible Project headline (keyword-first mode)", () => {
         videoSlug: "wealth-and-worry",
         videoTitle: "Wealth and Worry",
         description: "BibleProject explainer for Matthew 6:25-34.",
-        __isAttribution: true,
       },
     ]
 


### PR DESCRIPTION
## Summary

Stacked on #872. Eight clarity / documentation cleanups from ce:review on the keyword-first CamelCase recall fix. **No behavioural changes** — the only test-count change is +12 from new regex behaviour cases (156 → 168).

## Changes

### CLAUDE.md keyword-first section (maint-001, conf 0.92)
The 'Hybrid search keyword-first mode (R4 extension)' section was stale on three counts:
- Schema bullet still said 0009 owned the generated columns → updated to name 0010 as live owner
- searchByTrigram bullet still said *"Title-only (description trigram index would balloon)"* → rewritten to describe title + description with GREATEST ranking and the new index
- Operational runbook applied only 0009 → updated to apply both, EXPLAIN probe now shows BitmapOr over both trigram indexes, post-R0 warning added on manual re-application

### Migration 0010 comment expansions
- **Known limit (ASCII-only):** `[a-z][A-Z]` is ASCII-only; Cyrillic / Greek / accented Latin CamelCase boundaries are not split. Documented as a known scope boundary with the POSIX `[[:lower:]]` / `[[:upper:]]` alternative noted for future locale-aware work.
- **Sizing revisit:** capture `pg_relation_size('video_locale_description_trgm_idx')` once R0 lands; revisit at ~500MB or >20% INSERT/UPDATE latency regression with concrete mitigation paths (partial indexing, fall back to title-only).
- **Post-R0 warning:** any future migration of this shape against a populated table needs to be staged out of the Prisma transaction (split DDL / `CREATE INDEX CONCURRENTLY` via raw psql / `Unsupported` escape hatch). Manual re-application of 0010 post-R0 is destructive.

### Code clarity
- `TrigramResult.similarity` now has a JSDoc that calls out the **changed semantics**: post-0010 it's GREATEST(title, description), not title-only (kt-2).
- `searchByTrigram` docstring reconciles the "UNION" framing with the actual `OR + DISTINCT ON` SQL shape — same behaviour, different mechanics, easier for future maintainers to refactor without surprise.
- `VIDEO_LOCALE_DESCRIPTION_TRGM_INDEX_NAME` JSDoc no longer claims production consumers — honest "exported only so the byte-parity test can assert the migration creates this index under a name we control" (maint-003).
- Drop unused `__isAttribution` marker on `AttributionFixture` in the bible-project test (kt-1).

### New tests — CamelCase regex behaviour (testing finding, conf 0.85)
12 table-driven cases lock in:
- `BibleProject` → `Bible Project`, `JesusFilm` → `Jesus Film`, `MacOS` → `Mac OS`, `iPhone` → `i Phone`, `BibleProjectVideo` → `Bible Project Video` — the load-bearing splits
- `YHWH` and `LORD` preserved (all-caps acronym contract)
- `iOS` → `i OS`, `ABCDef` → unchanged (boundary edge cases)
- `"Bible Project"` (already split) → unchanged (idempotent)
- `""` → `""` (empty short-circuit)
- `"СловоБожие"` → unchanged (Cyrillic; locks in the ASCII-only limit so a future broadening to `[[:lower:]]` will fail this and force the author to update the documented contract)

JS regex stand-in for Postgres `regexp_replace`; both engines treat `[a-z]` / `[A-Z]` identically (ASCII-only). A future POSIX-class broadening would diverge and need a real-DB run instead — out of scope, documented in the test docstring + migration comment.

## Findings DEFERRED (covered in plan or explicit non-goals)

| Finding | Reviewer | Why deferred |
|---|---|---|
| EXPLAIN-based BitmapOr verification of both trigram indexes | perf, correctness | Gated on R0 readiness; admin's prod corpus is 0 rows. CLAUDE.md runbook now points at the probe to run at R0. |
| `pg_depend` audit of CASCADE blast radius | data-migrations | Pre-R0 runbook concern, not code. Documented in updated CLAUDE.md migration warning. |
| Counter-rollback migration template | data-migrations | Admin migrations are forward-only by convention. Counter-migration shape is the same DROP CASCADE + ADD GENERATED (with old expression) pattern that 0010 itself models — author at incident time. |
| DISTINCT ON tiebreak determinism | correctness | Pre-existing in `searchByKeywordWeighted`; not introduced by 0010. |
| Real-DB integration tests for trigram dedup | testing | `apps/admin/CLAUDE.md` defers integration tests to R0 readiness. |

## Testing

- `pnpm --filter @forge/admin test src/services/hybrid-search` → **168 / 168 green** (was 156)
- `pnpm --filter @forge/admin lint` clean
- `pnpm --filter @forge/admin typecheck` clean

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: docs / clarity-only commit on top of #872. Behaviour is unchanged; the recall verification on #872 still holds.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.52.0