### PR TITLE
feat(admin): add media asset library

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -82,3 +82,13 @@ MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY=
 OPENROUTER_API_KEY=
 # OPENAI_API_KEY=
 # OPENAI_BASE_URL=
+
+# Unit 11 / Media assets — Railway S3-compatible object storage.
+# Leave unset for the local filesystem fallback used by normal dev/test runs.
+# To exercise production-like object APIs locally, point these at MinIO or
+# LocalStack and create the bucket before starting the app.
+# RAILWAY_S3_ENDPOINT=http://127.0.0.1:9000
+# RAILWAY_S3_REGION=auto
+# RAILWAY_S3_BUCKET=forge-admin-local
+# RAILWAY_S3_ACCESS_KEY_ID=minioadmin
+# RAILWAY_S3_SECRET_ACCESS_KEY=minioadmin

--- a/apps/admin/prisma/migrations/0005_media_assets/migration.sql
+++ b/apps/admin/prisma/migrations/0005_media_assets/migration.sql
@@ -1,0 +1,63 @@
+-- Admin media asset library.
+--
+-- MediaAsset is the canonical editorial identity for uploaded/reusable media.
+-- Storage keys, Mux IDs, local fallback paths, and preview keys are backend
+-- details. This deliberately does not replace VideoImage, which remains
+-- Core/video-derived poster and still metadata.
+
+CREATE TYPE "MediaAssetKind" AS ENUM ('image', 'video', 'pdf', 'file');
+CREATE TYPE "MediaAssetBackend" AS ENUM ('local', 's3', 'mux');
+CREATE TYPE "MediaAssetStatus" AS ENUM (
+    'pending',
+    'uploading',
+    'processing',
+    'ready',
+    'failed',
+    'missing'
+);
+CREATE TYPE "MediaAssetVisibility" AS ENUM ('private', 'public');
+
+CREATE TABLE "media_asset" (
+    "id"                TEXT                   PRIMARY KEY,
+    "kind"              "MediaAssetKind"       NOT NULL,
+    "backend"           "MediaAssetBackend"    NOT NULL,
+    "status"            "MediaAssetStatus"     NOT NULL DEFAULT 'pending',
+    "visibility"        "MediaAssetVisibility" NOT NULL DEFAULT 'private',
+    "display_name"      TEXT                   NOT NULL,
+    "description"       TEXT,
+    "alt_text"          TEXT,
+    "mime_type"         TEXT                   NOT NULL,
+    "byte_size"         BIGINT,
+    "width"             INTEGER,
+    "height"            INTEGER,
+    "duration_ms"       BIGINT,
+    "original_filename" TEXT,
+    "checksum_sha256"   TEXT,
+    "object_key"        TEXT,
+    "preview_object_key" TEXT,
+    "mux_asset_id"      TEXT,
+    "mux_upload_id"     TEXT,
+    "mux_playback_id"   TEXT,
+    "error_code"        TEXT,
+    "error_message"     TEXT,
+    "created_by_id"     TEXT,
+    "created_at"        TIMESTAMPTZ            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"        TIMESTAMPTZ            NOT NULL,
+    CONSTRAINT "media_asset_created_by_id_fkey"
+        FOREIGN KEY ("created_by_id") REFERENCES "user"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX "media_asset_kind_status_updated_at_idx"
+    ON "media_asset"("kind", "status", "updated_at");
+
+CREATE INDEX "media_asset_backend_status_idx"
+    ON "media_asset"("backend", "status");
+
+CREATE INDEX "media_asset_visibility_idx"
+    ON "media_asset"("visibility");
+
+CREATE INDEX "media_asset_created_by_id_idx"
+    ON "media_asset"("created_by_id");
+
+CREATE INDEX "media_asset_display_name_idx"
+    ON "media_asset"("display_name");

--- a/apps/admin/prisma/migrations/0006_media_folders/migration.sql
+++ b/apps/admin/prisma/migrations/0006_media_folders/migration.sql
@@ -1,0 +1,45 @@
+-- CreateTable
+CREATE TABLE "media_folder" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "parent_id" TEXT,
+    "created_by_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "media_folder_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "media_asset"
+ADD COLUMN "folder_id" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "media_folder_parent_id_name_key" ON "media_folder"("parent_id", "name");
+
+-- CreateIndex
+CREATE INDEX "media_folder_parent_id_updated_at_idx" ON "media_folder"("parent_id", "updated_at");
+
+-- CreateIndex
+CREATE INDEX "media_folder_created_by_id_idx" ON "media_folder"("created_by_id");
+
+-- CreateIndex
+CREATE INDEX "media_asset_folder_id_updated_at_idx" ON "media_asset"("folder_id", "updated_at");
+
+-- AddForeignKey
+ALTER TABLE "media_folder"
+ADD CONSTRAINT "media_folder_parent_id_fkey"
+FOREIGN KEY ("parent_id") REFERENCES "media_folder"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "media_folder"
+ADD CONSTRAINT "media_folder_created_by_id_fkey"
+FOREIGN KEY ("created_by_id") REFERENCES "user"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "media_asset"
+ADD CONSTRAINT "media_asset_folder_id_fkey"
+FOREIGN KEY ("folder_id") REFERENCES "media_folder"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -101,6 +101,39 @@ enum VideoSource {
   MUX        @map("mux")
 }
 
+/// Editorial media kind. The first UI slice is image-forward, but the model is
+/// generic enough for PDFs, miscellaneous files, and future Mux-backed videos.
+enum MediaAssetKind {
+  IMAGE @map("image")
+  VIDEO @map("video")
+  PDF   @map("pdf")
+  FILE  @map("file")
+}
+
+/// Where the original bytes or playback authority live.
+enum MediaAssetBackend {
+  LOCAL @map("local")
+  S3    @map("s3")
+  MUX   @map("mux")
+}
+
+/// Processing lifecycle for an editorial media asset.
+enum MediaAssetStatus {
+  PENDING    @map("pending")
+  UPLOADING  @map("uploading")
+  PROCESSING @map("processing")
+  READY      @map("ready")
+  FAILED     @map("failed")
+  MISSING    @map("missing")
+}
+
+/// Delivery visibility. Private assets require admin-mediated access; public
+/// assets can be exposed through generated preview/download URLs.
+enum MediaAssetVisibility {
+  PRIVATE @map("private")
+  PUBLIC  @map("public")
+}
+
 /// Generic workflow run lifecycle used by the admin-owned operator ledger.
 enum WorkflowRunStatus {
   QUEUED    @map("queued")
@@ -134,8 +167,10 @@ model User {
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")
 
-  sessions Session[]
-  accounts Account[]
+  sessions     Session[]
+  accounts     Account[]
+  mediaAssets  MediaAsset[]
+  mediaFolders MediaFolder[]
 
   @@unique([email])
   @@map("user")
@@ -351,6 +386,73 @@ model ContentRevision {
   @@index([entityType, entityId, status, revisedAt])
   @@index([revisedAt])
   @@map("content_revision")
+}
+
+// -----------------------------------------------------------------------------
+// Editorial media assets
+// -----------------------------------------------------------------------------
+
+/// Canonical editorial asset managed by apps/admin. The asset row is the stable
+/// identity used by editors and agents; storage object keys, local paths, Mux
+/// upload IDs, and playback IDs are backend-specific implementation details.
+///
+/// `VideoImage` remains separate: it represents Core/video-derived poster and
+/// still metadata. `MediaAsset` is for editorial uploads and reusable files.
+model MediaAsset {
+  id               String               @id @default(cuid())
+  kind             MediaAssetKind
+  backend          MediaAssetBackend
+  status           MediaAssetStatus     @default(PENDING)
+  visibility       MediaAssetVisibility @default(PRIVATE)
+  displayName      String               @map("display_name")
+  description      String?
+  altText          String?              @map("alt_text")
+  mimeType         String               @map("mime_type")
+  byteSize         BigInt?              @map("byte_size")
+  width            Int?
+  height           Int?
+  durationMs       BigInt?              @map("duration_ms")
+  originalFilename String?              @map("original_filename")
+  checksumSha256   String?              @map("checksum_sha256")
+  objectKey        String?              @map("object_key")
+  previewObjectKey String?              @map("preview_object_key")
+  muxAssetId       String?              @map("mux_asset_id")
+  muxUploadId      String?              @map("mux_upload_id")
+  muxPlaybackId    String?              @map("mux_playback_id")
+  errorCode        String?              @map("error_code")
+  errorMessage     String?              @map("error_message")
+  folderId         String?              @map("folder_id")
+  folder           MediaFolder?         @relation(fields: [folderId], references: [id], onDelete: SetNull)
+  createdById      String?              @map("created_by_id")
+  createdBy        User?                @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  createdAt        DateTime             @default(now()) @map("created_at")
+  updatedAt        DateTime             @updatedAt @map("updated_at")
+
+  @@index([kind, status, updatedAt])
+  @@index([backend, status])
+  @@index([visibility])
+  @@index([folderId, updatedAt])
+  @@index([createdById])
+  @@index([displayName])
+  @@map("media_asset")
+}
+
+model MediaFolder {
+  id          String        @id @default(cuid())
+  name        String
+  parentId    String?       @map("parent_id")
+  parent      MediaFolder?  @relation("MediaFolderTree", fields: [parentId], references: [id], onDelete: Restrict)
+  children    MediaFolder[] @relation("MediaFolderTree")
+  createdById String?       @map("created_by_id")
+  createdBy   User?         @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  assets      MediaAsset[]
+  createdAt   DateTime      @default(now()) @map("created_at")
+  updatedAt   DateTime      @updatedAt @map("updated_at")
+
+  @@unique([parentId, name])
+  @@index([parentId, updatedAt])
+  @@index([createdById])
+  @@map("media_folder")
 }
 
 // -----------------------------------------------------------------------------
@@ -707,19 +809,19 @@ model Video {
 /// Per-locale Video content. Editors curate localized title / description /
 /// snippet / imageAlt and publish them independently of other locales.
 model VideoLocale {
-  id             String                       @id @default(cuid())
-  videoId        String                       @map("video_id")
-  video          Video                        @relation(fields: [videoId], references: [id], onDelete: Cascade)
+  id             String                   @id @default(cuid())
+  videoId        String                   @map("video_id")
+  video          Video                    @relation(fields: [videoId], references: [id], onDelete: Cascade)
   /// IETF BCP-47 locale code, e.g. "en", "fr", "es-419".
   locale         String
   title          String?
   description    String?
   snippet        String?
-  imageAlt       String?                      @map("image_alt")
-  status         LocaleStatus                 @default(DRAFT)
-  publishedAt    DateTime?                    @map("published_at")
-  createdAt      DateTime                     @default(now()) @map("created_at")
-  updatedAt      DateTime                     @updatedAt @map("updated_at")
+  imageAlt       String?                  @map("image_alt")
+  status         LocaleStatus             @default(DRAFT)
+  publishedAt    DateTime?                @map("published_at")
+  createdAt      DateTime                 @default(now()) @map("created_at")
+  updatedAt      DateTime                 @updatedAt @map("updated_at")
   /// STORED generated tsvector columns — derived from `title` /
   /// `description` by `0009_keyword_first_lexical/migration.sql`. Backed by
   /// `video_locale_lexical_weighted_idx` (GIN over the per-field weighted
@@ -730,8 +832,8 @@ model VideoLocale {
   /// the generated expression requires a coordinated DROP CASCADE + ADD
   /// COLUMN migration (Postgres has no in-place editor for stored
   /// generated expressions).
-  titleTsv       Unsupported("tsvector")?     @map("title_tsv")
-  descriptionTsv Unsupported("tsvector")?     @map("description_tsv")
+  titleTsv       Unsupported("tsvector")? @map("title_tsv")
+  descriptionTsv Unsupported("tsvector")? @map("description_tsv")
 
   @@unique([videoId, locale])
   @@index([locale])

--- a/apps/admin/src/app/api/media-assets/[id]/[variant]/route.ts
+++ b/apps/admin/src/app/api/media-assets/[id]/[variant]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server"
+import { requireSession } from "@/auth/session"
+import { prisma } from "@/db/client"
+import { createServices } from "@/services"
+import { mediaAssetPreviewUrl } from "@/services/media-asset.service"
+import { readMediaObject, safeMediaFilename } from "@/storage/media"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; variant: string }> },
+) {
+  const user = await requireSession()
+  const { id, variant } = await params
+  if (variant !== "preview" && variant !== "download") {
+    return new NextResponse("Not found", { status: 404 })
+  }
+
+  const services = createServices(prisma)
+  const asset = await services.mediaAsset.getById({
+    id,
+    user,
+    query: {},
+  })
+
+  if (!asset) {
+    return new NextResponse("Not found", { status: 404 })
+  }
+
+  if (variant === "preview" && asset.backend === "MUX") {
+    const url = mediaAssetPreviewUrl(asset)
+    return url
+      ? NextResponse.redirect(url)
+      : new NextResponse("Not found", { status: 404 })
+  }
+
+  const key =
+    variant === "preview"
+      ? (asset.previewObjectKey ?? asset.objectKey)
+      : asset.objectKey
+
+  if (!key || asset.backend === "MUX") {
+    return new NextResponse("Not found", { status: 404 })
+  }
+
+  const bytes = await readMediaObject({ backend: asset.backend, key })
+  const headers = new Headers({
+    "content-type": asset.mimeType,
+    "cache-control": "private, max-age=60",
+  })
+
+  if (variant === "download") {
+    const filename = safeMediaFilename(asset.originalFilename ?? `${asset.id}`)
+    headers.set("content-disposition", `attachment; filename="${filename}"`)
+  }
+
+  const body = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(body).set(bytes)
+
+  return new NextResponse(new Blob([body], { type: asset.mimeType }), {
+    headers,
+  })
+}

--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -18,9 +18,60 @@ vi.mock("@/auth/session", () => ({
 }))
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
+  usePathname: vi.fn(() => "/dashboard/media"),
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
     refresh: vi.fn(),
-  }),
+  })),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}))
+
+vi.mock("@/services", () => ({
+  createServices: vi.fn(() => ({
+    mediaAsset: {
+      getById: vi.fn(async () => ({
+        id: "media1",
+        kind: "IMAGE",
+        backend: "LOCAL",
+        visibility: "PRIVATE",
+        displayName: "poster",
+        description: null,
+        altText: "Poster alt",
+        mimeType: "image/webp",
+        byteSize: 2048n,
+        width: 1200,
+        height: 675,
+        durationMs: null,
+        originalFilename: "poster.webp",
+        checksumSha256: null,
+        objectKey: "media-assets/media1/original/poster.webp",
+        previewObjectKey: null,
+        muxPlaybackId: null,
+        updatedAt: new Date("2023-10-24T14:02:00.000Z"),
+      })),
+      usage: vi.fn(async () => [
+        {
+          experienceId: "exp_1",
+          experienceLocaleId: "loc_1",
+          locale: "en",
+          title: "Stories of Forgiveness",
+          location: "blocks",
+          fieldPath: "$.blocks[0].imageUrl",
+          fieldName: "imageUrl",
+          value: "/api/media-assets/media1/preview",
+          match: "url",
+        },
+      ]),
+    },
+  })),
+}))
+
+vi.mock("@/app/dashboard/media/folder-tree", () => ({
+  MediaFolderTree: vi.fn(
+    ({ folders }: { folders: Array<{ label: string }> }) => (
+      <div>{folders.map((folder) => folder.label).join(", ")}</div>
+    ),
+  ),
 }))
 
 vi.mock("@/app/dashboard/live-data", () => ({
@@ -268,9 +319,20 @@ vi.mock("@/app/dashboard/ops-data", () => ({
   })),
   loadMediaData: vi.fn(async () => ({
     metrics: [
-      { label: "Images", value: "2", footer: "VIDEO_IMAGES" },
-      { label: "Downloads", value: "2", footer: "DUB_ARTIFACTS" },
-      { label: "Subtitles", value: "2", footer: "TEXT_TRACKS" },
+      { label: "Assets", value: "2", footer: "MEDIA_ASSET_ROWS" },
+      { label: "Images", value: "2", footer: "IMAGE_LIBRARY" },
+      { label: "Processing", value: "0", footer: "ACTIVE_UPLOADS" },
+    ],
+    folders: [
+      {
+        id: "folder-1",
+        label: "Campaigns",
+        count: 1,
+        directAssetCount: 1,
+        childFolderCount: 0,
+        parentId: null,
+        depth: 0,
+      },
     ],
     rows: [
       {
@@ -280,13 +342,22 @@ vi.mock("@/app/dashboard/ops-data", () => ({
         statusLabel: "Ready",
         statusTone: "success",
         meta: "10/24/2023, 14:02",
+        kind: "IMAGE",
+        folderId: "folder-1",
+        backend: "LOCAL",
+        byteSize: "2.0 KB",
+        dimensions: "1200x675",
+        previewUrl: "/api/media-assets/media1/preview",
+        downloadUrl: "/api/media-assets/media1/download",
       },
     ],
     insights: [
-      { label: "Image Catalog", value: "2", detail: "detail" },
-      { label: "Download Artifacts", value: "2", detail: "detail" },
-      { label: "Subtitle Tracks", value: "2", detail: "detail" },
+      { label: "Image Assets", value: "2", detail: "detail" },
+      { label: "Video Assets", value: "0", detail: "detail" },
+      { label: "PDF Assets", value: "0", detail: "detail" },
     ],
+    totalCount: 2,
+    unfiledCount: 1,
   })),
 }))
 
@@ -371,8 +442,8 @@ describe("dashboard UI routes", () => {
         title: uiMessages.pages.languages.title,
       },
       {
-        html: await htmlFrom(MediaPage()),
-        title: uiMessages.pages.media.title,
+        html: await htmlFrom(MediaPage({ searchParams: Promise.resolve({}) })),
+        title: "Media Library",
       },
     ]
 
@@ -381,5 +452,8 @@ describe("dashboard UI routes", () => {
     }
 
     expect(pages[0].html).toContain("Recent Workflow Runs")
+    expect(pages[6].html).toContain("Media Library")
+    expect(pages[6].html).toContain("Library")
+    expect(pages[6].html).toContain("Campaigns")
   })
 })

--- a/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
@@ -8,6 +8,16 @@ import { prisma } from "@/db/client"
 import { getAdminLocale } from "@/i18n/server"
 import { createServices } from "@/services"
 import { ForbiddenError } from "@/services/errors"
+import { mediaAssetPreviewUrl } from "@/services/media-asset.service"
+
+function formatBytes(value: bigint | null) {
+  if (value == null) return "N/A"
+  const bytes = Number(value)
+  if (!Number.isFinite(bytes)) return value.toString()
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
 
 type LocaleSnapshot = {
   title: string | null
@@ -102,6 +112,36 @@ function snapshotFromLocale(locale: {
   }
 }
 
+async function loadMediaLibrary() {
+  const assets = await prisma.mediaAsset.findMany({
+    where: { kind: "IMAGE", status: "READY" },
+    select: {
+      id: true,
+      backend: true,
+      displayName: true,
+      altText: true,
+      mimeType: true,
+      byteSize: true,
+      objectKey: true,
+      previewObjectKey: true,
+      muxPlaybackId: true,
+      updatedAt: true,
+    },
+    orderBy: { updatedAt: "desc" },
+    take: 80,
+  })
+
+  return assets.map((asset) => ({
+    id: asset.id,
+    displayName: asset.displayName,
+    altText: asset.altText,
+    mimeType: asset.mimeType,
+    byteSize: formatBytes(asset.byteSize),
+    previewUrl: mediaAssetPreviewUrl(asset),
+    updated: formatDateTime(asset.updatedAt),
+  }))
+}
+
 function summarizeSnapshotDiff(
   previous: LocaleSnapshot | null,
   current: LocaleSnapshot,
@@ -177,7 +217,10 @@ export default async function ExperienceEditorPage({
       requireSession(),
       getAdminLocale(),
     ])
-  const videoLibrary = await loadVideoRows(principal)
+  const [videoLibrary, mediaLibrary] = await Promise.all([
+    loadVideoRows(principal),
+    loadMediaLibrary(),
+  ])
 
   const services = createServices(prisma)
   const experienceSummary = await services.experience.getById({
@@ -515,6 +558,7 @@ export default async function ExperienceEditorPage({
         }))}
         revisionEntries={revisionEntries}
         videoLibrary={videoLibrary}
+        mediaLibrary={mediaLibrary}
         saveAction={saveLocaleAction}
         publishAction={publishLocaleAction}
         createLocaleAction={createLocaleAction}

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
@@ -54,6 +54,17 @@ function renderEditor(
           previewStreamUrl: "https://example.com/video.mp4",
         },
       ]}
+      mediaLibrary={[
+        {
+          id: "asset-1",
+          displayName: "Managed hero",
+          altText: "Hero alt text",
+          mimeType: "image/webp",
+          byteSize: "12.0 KB",
+          previewUrl: "/api/media-assets/asset-1/preview",
+          updated: "2026-04-16T00:00:00.000Z",
+        },
+      ]}
       initialValues={{
         localeId: "locale-1",
         title: "Experience title",

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
@@ -141,6 +141,23 @@ type RevisionEntry = {
   isActive: boolean
 }
 
+type MediaLibraryItem = {
+  id: string
+  displayName: string
+  altText: string | null
+  mimeType: string
+  byteSize: string
+  previewUrl: string | null
+  updated: string
+}
+
+type ImagePickerTarget = {
+  blockIndex: number
+  urlField: "backgroundImageUrl" | "imageUrl" | "mediaUrl"
+  assetField: "backgroundImageAssetId" | "imageAssetId" | "mediaAssetId"
+  label: string
+}
+
 type LocaleEntry = {
   id: string
   code: string
@@ -852,6 +869,7 @@ export function ExperienceEditor({
   revisionEntries,
   localeEntries,
   videoLibrary,
+  mediaLibrary,
   calendarDate,
   initialValues,
   saveAction,
@@ -864,6 +882,7 @@ export function ExperienceEditor({
   revisionEntries: RevisionEntry[]
   localeEntries: LocaleEntry[]
   videoLibrary: VideoLibraryItem[]
+  mediaLibrary: MediaLibraryItem[]
   calendarDate: string
   initialValues: {
     localeId: string
@@ -966,6 +985,9 @@ export function ExperienceEditor({
   const [videoLibrarySort, setVideoLibrarySort] = useState<
     "recent" | "title" | "duration"
   >("recent")
+  const [imagePickerTarget, setImagePickerTarget] =
+    useState<ImagePickerTarget | null>(null)
+  const [imageLibraryQuery, setImageLibraryQuery] = useState("")
   const [carouselDragState, setCarouselDragState] =
     useState<CarouselDragState | null>(null)
   const [carouselDragHandleState, setCarouselDragHandleState] =
@@ -1235,6 +1257,15 @@ export function ExperienceEditor({
       (item) => item.key !== videoPickerCurrentVideo?.key,
     ),
   ]
+  const normalizedImageLibraryQuery = imageLibraryQuery.trim().toLowerCase()
+  const filteredImageLibrary = mediaLibrary.filter((asset) => {
+    const haystack =
+      `${asset.displayName} ${asset.altText ?? ""} ${asset.mimeType} ${asset.id}`.toLowerCase()
+    return (
+      normalizedImageLibraryQuery.length === 0 ||
+      haystack.includes(normalizedImageLibraryQuery)
+    )
+  })
   const videoPickerSelectedVideo = findVideoLibraryItem(
     videoPickerDraft.videoKey,
   )
@@ -2903,36 +2934,60 @@ export function ExperienceEditor({
     })
   }
 
-  function updateContainerVisual(
-    index: number,
-    field: "backgroundColor" | "backgroundImageUrl",
-    value: string,
-  ) {
-    updateBlockAt(index, (block) => {
-      if (block.t !== "container") return block
-      return {
-        ...block,
-        [field]: value,
-      }
-    })
-  }
-
   function chooseBackgroundImage(
     index: number,
     block: BlockRecord,
-    field: "backgroundImageUrl" | "imageUrl",
+    field: ImagePickerTarget["urlField"],
   ) {
-    const current = asString(block[field])
-    const nextValue = window.prompt("Background image URL", current)
-    if (nextValue === null) return
-    updateBlockStringField(index, field, nextValue.trim())
+    openImagePicker(index, block, field)
   }
 
   function chooseContainerBackgroundImage(index: number, block: BlockRecord) {
-    const current = asString(block.backgroundImageUrl)
-    const nextValue = window.prompt("Background image URL", current)
-    if (nextValue === null) return
-    updateContainerVisual(index, "backgroundImageUrl", nextValue.trim())
+    openImagePicker(index, block, "backgroundImageUrl")
+  }
+
+  function openImagePicker(
+    blockIndex: number,
+    block: BlockRecord,
+    urlField: ImagePickerTarget["urlField"],
+  ) {
+    const blockType = asString(block.t) || "block"
+    setImagePickerTarget({
+      blockIndex,
+      urlField,
+      assetField: visualIdentityAssetField(urlField),
+      label: blockType === "card" ? "card image" : `${blockType} image`,
+    })
+    setImageLibraryQuery("")
+  }
+
+  function closeImagePicker() {
+    setImagePickerTarget(null)
+    setImageLibraryQuery("")
+  }
+
+  function applyImagePickerSelection(asset: MediaLibraryItem) {
+    if (!imagePickerTarget || !asset.previewUrl) return
+
+    updateBlockAt(imagePickerTarget.blockIndex, (block) => ({
+      ...block,
+      [imagePickerTarget.urlField]: asset.previewUrl,
+      [imagePickerTarget.assetField]: asset.id,
+    }))
+    pushToast(`Attached ${asset.displayName}.`, "success")
+    closeImagePicker()
+  }
+
+  function clearVisualIdentityImage(
+    index: number,
+    urlField: ImagePickerTarget["urlField"],
+  ) {
+    const assetField = visualIdentityAssetField(urlField)
+    updateBlockAt(index, (block) => ({
+      ...block,
+      [urlField]: "",
+      [assetField]: "",
+    }))
   }
 
   function appendContainerSlot(index: number) {
@@ -3685,6 +3740,12 @@ export function ExperienceEditor({
   function visualIdentityImageField(type: string) {
     if (type === "container" || type === "section") return "backgroundImageUrl"
     return type === "card" ? "mediaUrl" : "imageUrl"
+  }
+
+  function visualIdentityAssetField(field: ImagePickerTarget["urlField"]) {
+    if (field === "backgroundImageUrl") return "backgroundImageAssetId"
+    if (field === "mediaUrl") return "mediaAssetId"
+    return "imageAssetId"
   }
 
   function blockVisualIdentity(block: BlockRecord | null) {
@@ -7073,9 +7134,7 @@ export function ExperienceEditor({
                     chooseBackgroundImage(
                       index,
                       blockRecord ?? {},
-                      visualIdentityImageFieldName as
-                        | "backgroundImageUrl"
-                        | "imageUrl",
+                      visualIdentityImageFieldName as ImagePickerTarget["urlField"],
                     )
                   }}
                   className={cx(
@@ -7099,10 +7158,9 @@ export function ExperienceEditor({
                       event.preventDefault()
                       event.stopPropagation()
                       activateBlock(index)
-                      updateBlockStringField(
+                      clearVisualIdentityImage(
                         index,
-                        visualIdentityImageFieldName,
-                        "",
+                        visualIdentityImageFieldName as ImagePickerTarget["urlField"],
                       )
                     }}
                     className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-r-sm border border-[var(--color-hairline)] bg-[var(--color-surface-inset)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:text-[var(--color-danger)]"
@@ -9133,6 +9191,132 @@ export function ExperienceEditor({
           </div>
         </div>
       ) : null}
+      <div
+        className={cx(
+          "fixed inset-0 z-50 flex items-center justify-center px-4 transition-all duration-180 ease-out sm:px-6",
+          imagePickerTarget
+            ? "pointer-events-auto bg-[rgba(4,6,10,0.78)] backdrop-blur-[8px]"
+            : "pointer-events-none bg-[rgba(4,6,10,0)] backdrop-blur-0",
+        )}
+        onClick={(event) => {
+          if (event.target !== event.currentTarget) return
+          closeImagePicker()
+        }}
+        role="presentation"
+        aria-hidden={!imagePickerTarget}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="image-library-title"
+          className={cx(
+            "flex h-[min(80vh,760px)] w-full max-w-[920px] flex-col overflow-hidden rounded-sm border border-[var(--color-hairline-strong)] bg-[color-mix(in_oklab,var(--color-surface)_96%,black)] p-5 shadow-[0_32px_120px_rgba(0,0,0,0.58)] transition-[opacity,transform] duration-180 ease-out",
+            imagePickerTarget
+              ? "translate-y-0 scale-100 opacity-100"
+              : "translate-y-2 scale-[0.98] opacity-0",
+          )}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--color-text-muted)]">
+                Media Library
+              </div>
+              <h2
+                id="image-library-title"
+                className="mt-2 text-[22px] font-semibold tracking-[-0.03em] text-[var(--color-text-primary)]"
+              >
+                Choose an image
+              </h2>
+              <p className="mt-2 max-w-2xl text-[13px] leading-6 text-[var(--color-text-secondary)]">
+                Attach a managed image asset to this{" "}
+                {imagePickerTarget?.label ?? "block"}. The editor stores the
+                asset ID and keeps the preview URL for current renderers.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={closeImagePicker}
+              className="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+              aria-label="Close image library"
+            >
+              <X className="h-4 w-4" strokeWidth={1.5} />
+            </button>
+          </div>
+
+          <label className="mt-5 grid gap-1.5 border-b border-[var(--color-hairline)] pb-4">
+            <span className="label-text">Search</span>
+            <div className="flex h-10 items-center gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3">
+              <Search className="h-4 w-4 text-[var(--color-text-muted)]" />
+              <input
+                value={imageLibraryQuery}
+                onChange={(event) => setImageLibraryQuery(event.target.value)}
+                className="w-full border-0 bg-transparent text-[13px] text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-disabled)]"
+                placeholder="Search display name, alt text, MIME type, or asset ID"
+              />
+            </div>
+          </label>
+
+          <div className="mt-4 min-h-0 flex-1 overflow-y-auto [scrollbar-color:rgba(255,255,255,0.12)_transparent] [scrollbar-width:thin]">
+            {filteredImageLibrary.length === 0 ? (
+              <div className="rounded-sm border border-dashed border-[var(--color-hairline)] px-4 py-8 text-center">
+                <div className="text-[14px] font-medium text-[var(--color-text-primary)]">
+                  No image assets match these filters
+                </div>
+                <div className="mt-2 text-[12px] leading-5 text-[var(--color-text-muted)]">
+                  Upload images in the Media Library, then return here to use
+                  them in experience blocks.
+                </div>
+              </div>
+            ) : (
+              <div className="grid gap-3 pb-6 md:grid-cols-2 xl:grid-cols-3">
+                {filteredImageLibrary.map((asset) => (
+                  <button
+                    key={asset.id}
+                    type="button"
+                    disabled={!asset.previewUrl}
+                    onClick={() => applyImagePickerSelection(asset)}
+                    className="group grid cursor-pointer overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] text-left transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <div className="aspect-video bg-[var(--color-bg)]">
+                      {asset.previewUrl ? (
+                        <div
+                          className="h-full w-full bg-cover bg-center transition-transform duration-[180ms] ease-out group-hover:scale-[1.02]"
+                          style={{
+                            backgroundImage: `url("${asset.previewUrl}")`,
+                          }}
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center">
+                          <ImageIcon
+                            className="h-8 w-8 text-[var(--color-text-muted)]"
+                            strokeWidth={1.5}
+                          />
+                        </div>
+                      )}
+                    </div>
+                    <div className="grid gap-2 p-3">
+                      <div className="truncate text-[13px] font-medium text-[var(--color-text-primary)]">
+                        {asset.displayName}
+                      </div>
+                      <div className="mono-meta truncate text-[var(--color-text-muted)]">
+                        {asset.altText || asset.id}
+                      </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="mono-meta text-[var(--color-text-secondary)]">
+                          {asset.byteSize}
+                        </span>
+                        <span className="mono-meta text-[var(--color-text-muted)]">
+                          {asset.updated}
+                        </span>
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
       <div
         className={cx(
           "fixed inset-0 z-50 flex items-center justify-center px-4 transition-all duration-180 ease-out sm:px-6",

--- a/apps/admin/src/app/dashboard/media/folder-tree-dnd.test.ts
+++ b/apps/admin/src/app/dashboard/media/folder-tree-dnd.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest"
+import {
+  intersectsRootDropZone,
+  isDescendantFolderTarget,
+  persistRootDropTarget,
+  resolveFolderDropTarget,
+} from "./folder-tree-dnd"
+
+describe("resolveFolderDropTarget", () => {
+  it("prefers the explicit over target", () => {
+    expect(
+      resolveFolderDropTarget({
+        overId: "folder-2",
+        collisions: [{ id: "root" }],
+      }),
+    ).toBe("folder-2")
+  })
+
+  it("falls back to collisions when over is missing", () => {
+    expect(
+      resolveFolderDropTarget({
+        overId: null,
+        collisions: [{ id: "root" }],
+      }),
+    ).toBe("root")
+  })
+
+  it("falls back to the persisted root target when release clears the event target", () => {
+    expect(
+      resolveFolderDropTarget({
+        overId: null,
+        collisions: null,
+        persistedRootTarget: "root",
+      }),
+    ).toBe("root")
+  })
+
+  it("prefers root when the dragged rect overlaps the root drop zone", () => {
+    expect(
+      resolveFolderDropTarget({
+        overId: "folder-2",
+        collisions: [{ id: "folder-2" }],
+        activeRect: {
+          top: 120,
+          right: 180,
+          bottom: 164,
+          left: 100,
+        },
+        rootRect: {
+          top: 140,
+          right: 320,
+          bottom: 320,
+          left: 40,
+        },
+      }),
+    ).toBe("root")
+  })
+
+  it("does not reuse stale non-root targets", () => {
+    expect(
+      resolveFolderDropTarget({
+        overId: null,
+        collisions: null,
+        persistedRootTarget: "folder-2",
+      }),
+    ).toBeNull()
+  })
+})
+
+describe("persistRootDropTarget", () => {
+  it("persists root only when root is the resolved target", () => {
+    expect(
+      persistRootDropTarget({
+        overId: "root",
+        collisions: null,
+      }),
+    ).toBe("root")
+
+    expect(
+      persistRootDropTarget({
+        overId: null,
+        collisions: [{ id: "root" }],
+      }),
+    ).toBe("root")
+  })
+
+  it("clears the persisted target for non-root collisions", () => {
+    expect(
+      persistRootDropTarget({
+        overId: "folder-2",
+        collisions: [{ id: "root" }],
+      }),
+    ).toBeNull()
+  })
+})
+
+describe("intersectsRootDropZone", () => {
+  it("returns true when the dragged rect overlaps the root drop zone", () => {
+    expect(
+      intersectsRootDropZone({
+        activeRect: {
+          top: 120,
+          right: 180,
+          bottom: 164,
+          left: 100,
+        },
+        rootRect: {
+          top: 140,
+          right: 320,
+          bottom: 320,
+          left: 40,
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it("returns false when the dragged rect misses the root drop zone", () => {
+    expect(
+      intersectsRootDropZone({
+        activeRect: {
+          top: 40,
+          right: 120,
+          bottom: 84,
+          left: 60,
+        },
+        rootRect: {
+          top: 140,
+          right: 320,
+          bottom: 320,
+          left: 40,
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("isDescendantFolderTarget", () => {
+  const folders = [
+    { id: "parent", depth: 0 },
+    { id: "child", depth: 1 },
+    { id: "grandchild", depth: 2 },
+    { id: "sibling", depth: 0 },
+  ]
+
+  it("returns true for descendant targets", () => {
+    expect(
+      isDescendantFolderTarget({
+        folders,
+        folderId: "parent",
+        parentId: "child",
+      }),
+    ).toBe(true)
+
+    expect(
+      isDescendantFolderTarget({
+        folders,
+        folderId: "parent",
+        parentId: "grandchild",
+      }),
+    ).toBe(true)
+  })
+
+  it("returns true for self-targets", () => {
+    expect(
+      isDescendantFolderTarget({
+        folders,
+        folderId: "parent",
+        parentId: "parent",
+      }),
+    ).toBe(true)
+  })
+
+  it("returns false for siblings, ancestors, and root", () => {
+    expect(
+      isDescendantFolderTarget({
+        folders,
+        folderId: "child",
+        parentId: "sibling",
+      }),
+    ).toBe(false)
+
+    expect(
+      isDescendantFolderTarget({
+        folders,
+        folderId: "grandchild",
+        parentId: "parent",
+      }),
+    ).toBe(false)
+
+    expect(
+      isDescendantFolderTarget({
+        folders,
+        folderId: "parent",
+        parentId: null,
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/admin/src/app/dashboard/media/folder-tree-dnd.ts
+++ b/apps/admin/src/app/dashboard/media/folder-tree-dnd.ts
@@ -1,0 +1,123 @@
+type DropCollision = {
+  id: string | number
+}
+
+type FlatFolderNode = {
+  id: string
+  depth: number
+}
+
+type DropRect = {
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+export function isDescendantFolderTarget({
+  folders,
+  folderId,
+  parentId,
+}: {
+  folders: FlatFolderNode[]
+  folderId: string
+  parentId: string | null
+}) {
+  if (!parentId) {
+    return false
+  }
+
+  if (parentId === folderId) {
+    return true
+  }
+
+  const sourceIndex = folders.findIndex((folder) => folder.id === folderId)
+  if (sourceIndex === -1) {
+    return false
+  }
+
+  const sourceDepth = folders[sourceIndex]!.depth
+
+  for (let index = sourceIndex + 1; index < folders.length; index += 1) {
+    const folder = folders[index]!
+    if (folder.depth <= sourceDepth) {
+      break
+    }
+
+    if (folder.id === parentId) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export function resolveFolderDropTarget({
+  overId,
+  collisions,
+  persistedRootTarget,
+  activeRect,
+  rootRect,
+}: {
+  overId: string | null
+  collisions: DropCollision[] | null
+  persistedRootTarget?: string | null
+  activeRect?: DropRect | null
+  rootRect?: DropRect | null
+}) {
+  if (
+    intersectsRootDropZone({
+      activeRect: activeRect ?? null,
+      rootRect: rootRect ?? null,
+    })
+  ) {
+    return "root"
+  }
+
+  if (overId) {
+    return overId
+  }
+
+  const collisionId = collisions?.[0]?.id
+  if (collisionId !== undefined && collisionId !== null) {
+    return String(collisionId)
+  }
+
+  return persistedRootTarget === "root" ? "root" : null
+}
+
+export function intersectsRootDropZone({
+  activeRect,
+  rootRect,
+}: {
+  activeRect: DropRect | null
+  rootRect: DropRect | null
+}) {
+  if (!activeRect || !rootRect) {
+    return false
+  }
+
+  return (
+    activeRect.left < rootRect.right &&
+    activeRect.right > rootRect.left &&
+    activeRect.top < rootRect.bottom &&
+    activeRect.bottom > rootRect.top
+  )
+}
+
+export function persistRootDropTarget({
+  overId,
+  collisions,
+}: {
+  overId: string | null
+  collisions: DropCollision[] | null
+}) {
+  const collisionId = collisions?.[0]?.id
+  const resolvedId =
+    overId ??
+    (collisionId !== undefined && collisionId !== null
+      ? String(collisionId)
+      : null)
+
+  return resolvedId === "root" ? "root" : null
+}

--- a/apps/admin/src/app/dashboard/media/folder-tree.tsx
+++ b/apps/admin/src/app/dashboard/media/folder-tree.tsx
@@ -1,0 +1,1408 @@
+"use client"
+
+import type { Route } from "next"
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type RefObject,
+} from "react"
+import { useRouter } from "next/navigation"
+import {
+  DragOverlay,
+  type Modifier,
+  useDraggable,
+  useDndMonitor,
+  useDroppable,
+  type DragEndEvent,
+  type DragMoveEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core"
+import { ChevronDown, Folder, FolderPlus } from "lucide-react"
+import { cx } from "@/components/admin-ui"
+import type { MediaFolderRow } from "@/app/dashboard/ops-data"
+import {
+  getAssetDragData,
+  getFolderDragData,
+} from "@/app/dashboard/media/media-library-dnd"
+import {
+  isDescendantFolderTarget,
+  persistRootDropTarget,
+  resolveFolderDropTarget,
+} from "@/app/dashboard/media/folder-tree-dnd"
+const HOVER_EXPAND_DELAY_MS = 450
+
+type MoveFolderActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation"
+      message: string
+    }
+
+type CreateFolderActionResult =
+  | { ok: true; id: string }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type RenameFolderActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type MoveAssetActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type FolderTreeProps = {
+  folders: MediaFolderRow[]
+  selectedFolderId: string | null
+  queryText: string
+  selectedType: "all" | "IMAGE" | "VIDEO" | "PDF" | "FILE"
+  selectedSort: "name" | "size" | "updated"
+  selectedDirection: "asc" | "desc"
+  onCreateFolder: (formData: FormData) => Promise<CreateFolderActionResult>
+  onRenameFolder: (formData: FormData) => Promise<RenameFolderActionResult>
+  onMoveFolder: (formData: FormData) => Promise<MoveFolderActionResult>
+  onMoveAsset: (formData: FormData) => Promise<MoveAssetActionResult>
+}
+
+type DraftFolder = {
+  parentId: string | null
+  depth: number
+}
+
+type OptimisticFolder = MediaFolderRow
+
+type FolderTreeEntry =
+  | {
+      kind: "folder"
+      folder: MediaFolderRow
+    }
+  | {
+      kind: "draft"
+      parentId: string | null
+      depth: number
+    }
+
+type FolderTreeRowProps = {
+  folder: MediaFolderRow
+  selected: boolean
+  expanded: boolean
+  editing: boolean
+  editingError: string | null
+  activeDragId: string | null
+  interactionLocked: boolean
+  invalidDropTarget: boolean
+  activeDropTargetId: string | null
+  onSelect: () => void
+  onToggleCollapse: () => void
+  onStartEditing: () => void
+  onEditingNameChange: (value: string) => void
+  onSubmitEditing: () => void
+  onCancelEditing: () => void
+  editingContentRef: RefObject<HTMLSpanElement | null>
+}
+
+const rowNameChipClass =
+  "flex min-w-0 max-w-full items-start rounded-[2px] px-1.5"
+const rowNameTextClass =
+  "px-0.5 text-[13px] font-medium leading-5 text-[var(--color-text-primary)]"
+
+function isEditableKeyTarget(target: EventTarget | null) {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("input,textarea,select,[contenteditable=true]")
+  )
+}
+
+function FolderTreeRow({
+  folder,
+  selected,
+  expanded,
+  editing,
+  editingError,
+  activeDragId,
+  interactionLocked,
+  invalidDropTarget,
+  activeDropTargetId,
+  onSelect,
+  onToggleCollapse,
+  onStartEditing,
+  onEditingNameChange,
+  onSubmitEditing,
+  onCancelEditing,
+  editingContentRef,
+}: FolderTreeRowProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `folder:${folder.id}`,
+    disabled: editing,
+    data: {
+      type: "folder",
+      folderId: folder.id,
+    },
+  })
+  const { setNodeRef: setDropNodeRef } = useDroppable({
+    id: folder.id,
+    disabled: editing || activeDragId === folder.id || invalidDropTarget,
+  })
+  const isActiveDropTarget =
+    activeDropTargetId === folder.id && !invalidDropTarget && !isDragging
+  const canCollapse = folder.childFolderCount > 0
+
+  return (
+    <div
+      ref={(node) => {
+        setNodeRef(node)
+      }}
+      className={cx(
+        "group transition-opacity duration-[120ms] ease-out",
+        isDragging && "opacity-40",
+      )}
+    >
+      <div
+        data-media-folder-row-id={folder.id}
+        ref={setDropNodeRef}
+        {...attributes}
+        {...listeners}
+        onClick={() => {
+          if (editing || interactionLocked) {
+            return
+          }
+
+          onSelect()
+        }}
+        className={cx(
+          "grid min-h-8 w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-sm border border-transparent px-2 py-1 text-[13px] text-left transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface)] focus:outline-none focus-visible:outline-none",
+          !editing && "cursor-grab active:cursor-grabbing",
+          editing && "cursor-text",
+          selected &&
+            "bg-[var(--color-brand-soft)] text-[var(--color-text-primary)]",
+          isActiveDropTarget &&
+            "border-[var(--color-brand)] bg-[var(--color-surface)] shadow-[inset_0_0_0_1px_var(--color-brand)]",
+        )}
+      >
+        <span
+          className="flex min-w-0 items-start gap-2"
+          style={{ paddingLeft: `${folder.depth * 16}px` }}
+        >
+          <button
+            type="button"
+            aria-label={
+              canCollapse
+                ? expanded
+                  ? `Collapse ${folder.label}`
+                  : `Expand ${folder.label}`
+                : `${folder.label} has no child folders`
+            }
+            aria-expanded={canCollapse ? expanded : undefined}
+            disabled={!canCollapse}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              if (canCollapse) {
+                onToggleCollapse()
+              }
+            }}
+            className={cx(
+              "mt-[2px] inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[2px] text-[var(--color-text-muted)] transition-transform duration-[120ms] ease-out",
+              canCollapse ? "cursor-pointer" : "cursor-default opacity-45",
+            )}
+          >
+            <ChevronDown
+              className={cx(
+                "h-4 w-4 shrink-0",
+                canCollapse && !expanded && "-rotate-90",
+              )}
+              strokeWidth={1.5}
+            />
+          </button>
+          <Folder className="mt-[2px] h-4 w-4 shrink-0" strokeWidth={1.5} />
+          {editing ? (
+            <span
+              className={cx(rowNameChipClass, "cursor-text")}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <span
+                ref={editingContentRef}
+                contentEditable="plaintext-only"
+                suppressContentEditableWarning
+                role="textbox"
+                spellCheck={false}
+                aria-invalid={editingError ? "true" : "false"}
+                onPointerDown={(event) => {
+                  event.stopPropagation()
+                }}
+                onClick={(event) => {
+                  event.stopPropagation()
+                }}
+                onInput={(event) => {
+                  onEditingNameChange(event.currentTarget.textContent ?? "")
+                }}
+                onBlur={onSubmitEditing}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault()
+                    onSubmitEditing()
+                  }
+                  if (event.key === "Escape") {
+                    event.preventDefault()
+                    onCancelEditing()
+                  }
+                }}
+                className={cx(
+                  rowNameTextClass,
+                  "block min-w-0 max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] bg-transparent caret-[var(--color-brand)] outline-none",
+                )}
+              />
+            </span>
+          ) : (
+            <span
+              className={cx(rowNameChipClass, "cursor-text")}
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+
+                if (interactionLocked) {
+                  return
+                }
+
+                if (selected) {
+                  onStartEditing()
+                  return
+                }
+
+                onSelect()
+              }}
+            >
+              <span
+                className={cx(
+                  rowNameTextClass,
+                  "block min-w-0 max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere]",
+                )}
+              >
+                {folder.label}
+              </span>
+            </span>
+          )}
+        </span>
+        <span className="mono-meta mt-[2px] shrink-0 leading-5 text-[var(--color-text-muted)]">
+          {folder.count}
+        </span>
+      </div>
+      {editingError ? (
+        <div
+          role="alert"
+          className="px-2 pt-1 text-[11px] text-[var(--color-danger)]"
+          style={{ paddingLeft: `${folder.depth * 16 + 53}px` }}
+        >
+          {editingError}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+type DraftFolderRowProps = {
+  depth: number
+  value: string
+  error: string | null
+  contentRef: RefObject<HTMLSpanElement | null>
+  onNameChange: (value: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+}
+
+function DraftFolderRow({
+  depth,
+  value,
+  error,
+  contentRef,
+  onNameChange,
+  onSubmit,
+  onCancel,
+}: DraftFolderRowProps) {
+  return (
+    <div className="group transition-opacity duration-[120ms] ease-out">
+      <div className="grid min-h-8 w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-sm border border-transparent bg-[var(--color-brand-soft)] px-2 py-1 text-[13px] text-left">
+        <span
+          className="flex min-w-0 items-start gap-2"
+          style={{ paddingLeft: `${depth * 16}px` }}
+        >
+          <span className="mt-[2px] inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[2px] text-[var(--color-text-muted)] opacity-45">
+            <ChevronDown className="h-4 w-4 shrink-0" strokeWidth={1.5} />
+          </span>
+          <Folder className="mt-[2px] h-4 w-4 shrink-0" strokeWidth={1.5} />
+          <span
+            className={cx(rowNameChipClass, "relative cursor-text")}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {value.trim().length === 0 ? (
+              <span className="pointer-events-none absolute inset-x-1.5 px-0.5 text-[13px] font-medium leading-5 whitespace-nowrap text-[var(--color-text-muted)]">
+                Untitled folder
+              </span>
+            ) : null}
+            <span
+              ref={contentRef}
+              contentEditable="plaintext-only"
+              suppressContentEditableWarning
+              role="textbox"
+              spellCheck={false}
+              aria-invalid={error ? "true" : "false"}
+              onInput={(event) => {
+                onNameChange(event.currentTarget.textContent ?? "")
+              }}
+              onBlur={onSubmit}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault()
+                  onSubmit()
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault()
+                  onCancel()
+                }
+              }}
+              className={cx(
+                rowNameTextClass,
+                "relative block min-w-0 max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] bg-transparent caret-[var(--color-brand)] outline-none",
+              )}
+            />
+          </span>
+        </span>
+        <span className="mono-meta mt-[2px] shrink-0 leading-5 text-[var(--color-text-muted)]">
+          0
+        </span>
+      </div>
+      {error ? (
+        <div
+          role="alert"
+          className="px-2 pt-1 text-[11px] text-[var(--color-danger)]"
+          style={{ paddingLeft: `${depth * 16 + 53}px` }}
+        >
+          {error}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function getEventCoordinates(event: Event) {
+  if (isPointerLikeEvent(event)) {
+    return { x: event.clientX, y: event.clientY }
+  }
+
+  if (isTouchEvent(event) && event.touches[0]) {
+    return {
+      x: event.touches[0].clientX,
+      y: event.touches[0].clientY,
+    }
+  }
+
+  if (isTouchEvent(event) && event.changedTouches[0]) {
+    return {
+      x: event.changedTouches[0].clientX,
+      y: event.changedTouches[0].clientY,
+    }
+  }
+
+  return null
+}
+
+function isTouchEvent(event: Event): event is TouchEvent {
+  return typeof TouchEvent !== "undefined" && event instanceof TouchEvent
+}
+
+function isPointerLikeEvent(event: Event): event is MouseEvent | PointerEvent {
+  return (
+    (typeof PointerEvent !== "undefined" && event instanceof PointerEvent) ||
+    (typeof MouseEvent !== "undefined" && event instanceof MouseEvent)
+  )
+}
+
+export function MediaFolderTree({
+  folders,
+  selectedFolderId,
+  queryText,
+  selectedType,
+  selectedSort,
+  selectedDirection,
+  onCreateFolder,
+  onRenameFolder,
+  onMoveFolder,
+  onMoveAsset,
+}: FolderTreeProps) {
+  const router = useRouter()
+  const folderTreeRootRef = useRef<HTMLDivElement | null>(null)
+  const draftContentRef = useRef<HTMLSpanElement | null>(null)
+  const editingContentRef = useRef<HTMLSpanElement | null>(null)
+  const initializedDraftRef = useRef(false)
+  const initializedEditingFolderIdRef = useRef<string | null>(null)
+  const lastRootDropTargetRef = useRef<string | null>(null)
+  const rootDropZoneRef = useRef<HTMLDivElement | null>(null)
+  const dragOverlayRef = useRef<HTMLDivElement | null>(null)
+  const hoverExpandTimerRef = useRef<number | null>(null)
+  const hoverExpandTargetIdRef = useRef<string | null>(null)
+  const dragOverlayPointerOffsetRef = useRef<{ x: number; y: number } | null>(
+    null,
+  )
+  const [draftFolder, setDraftFolder] = useState<DraftFolder | null>(null)
+  const [draftName, setDraftName] = useState("")
+  const [draftError, setDraftError] = useState<string | null>(null)
+  const [editingFolderId, setEditingFolderId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState("")
+  const [editingError, setEditingError] = useState<string | null>(null)
+  const [optimisticCreatedFolders, setOptimisticCreatedFolders] = useState<
+    OptimisticFolder[]
+  >([])
+  const [optimisticFolderLabels, setOptimisticFolderLabels] = useState<
+    Record<string, string>
+  >({})
+  const [clientSelectedFolderId, setClientSelectedFolderId] = useState<
+    string | null
+  >(selectedFolderId)
+  const [activeFolderId, setActiveFolderId] = useState<string | null>(null)
+  const [activeDropTargetId, setActiveDropTargetId] = useState<string | null>(
+    null,
+  )
+  const [activeAssetDrag, setActiveAssetDrag] = useState<{
+    id: string
+    title: string
+    folderId: string | null
+  } | null>(null)
+  const [activeAssetDropTargetId, setActiveAssetDropTargetId] = useState<
+    string | null
+  >(null)
+  const [activeDragPointerOffset, setActiveDragPointerOffset] = useState<{
+    x: number
+    y: number
+  } | null>(null)
+  const [collapsedFolderIds, setCollapsedFolderIds] = useState<Set<string>>(
+    () => new Set(),
+  )
+  const [, startTransition] = useTransition()
+  const { setNodeRef: setRootDropRef } = useDroppable({
+    id: "root",
+  })
+
+  const resolvedFolders = useMemo(() => {
+    const serverFolderIds = new Set(folders.map((folder) => folder.id))
+    const pendingFolders = optimisticCreatedFolders.filter(
+      (folder) => !serverFolderIds.has(folder.id),
+    )
+    const optimisticChildCounts = new Map<string, number>()
+
+    for (const folder of pendingFolders) {
+      if (!folder.parentId) {
+        continue
+      }
+      optimisticChildCounts.set(
+        folder.parentId,
+        (optimisticChildCounts.get(folder.parentId) ?? 0) + 1,
+      )
+    }
+
+    const combinedFolders = [...folders, ...pendingFolders]
+
+    return combinedFolders.map((folder) => {
+      const optimisticLabel = optimisticFolderLabels[folder.id]
+      return {
+        ...folder,
+        label:
+          optimisticLabel && optimisticLabel !== folder.label
+            ? optimisticLabel
+            : folder.label,
+        childFolderCount:
+          folder.childFolderCount + (optimisticChildCounts.get(folder.id) ?? 0),
+      }
+    })
+  }, [folders, optimisticCreatedFolders, optimisticFolderLabels])
+  const folderById = useMemo(
+    () => new Map(resolvedFolders.map((folder) => [folder.id, folder])),
+    [resolvedFolders],
+  )
+  const foldersByParent = useMemo(() => {
+    const grouped = new Map<string | null, MediaFolderRow[]>()
+    for (const folder of resolvedFolders) {
+      const siblings = grouped.get(folder.parentId) ?? []
+      siblings.push(folder)
+      grouped.set(folder.parentId, siblings)
+    }
+    return grouped
+  }, [resolvedFolders])
+
+  useEffect(() => {
+    if (!draftFolder) {
+      initializedDraftRef.current = false
+      return
+    }
+
+    const node = draftContentRef.current
+
+    if (!node) {
+      return
+    }
+
+    if (node.textContent !== draftName) {
+      node.textContent = draftName
+    }
+
+    if (initializedDraftRef.current) {
+      return
+    }
+
+    node.focus()
+
+    const selection = window.getSelection()
+
+    if (!selection) {
+      return
+    }
+
+    const range = document.createRange()
+    range.selectNodeContents(node)
+    selection.removeAllRanges()
+    selection.addRange(range)
+    initializedDraftRef.current = true
+  }, [draftFolder, draftName])
+
+  useEffect(() => {
+    if (!editingFolderId) {
+      initializedEditingFolderIdRef.current = null
+      return
+    }
+
+    const node = editingContentRef.current
+
+    if (!node) {
+      return
+    }
+
+    if (node.textContent !== editingName) {
+      node.textContent = editingName
+    }
+
+    if (initializedEditingFolderIdRef.current === editingFolderId) {
+      return
+    }
+
+    node.focus()
+
+    const selection = window.getSelection()
+
+    if (!selection) {
+      return
+    }
+
+    const range = document.createRange()
+    range.selectNodeContents(node)
+    selection.removeAllRanges()
+    selection.addRange(range)
+    initializedEditingFolderIdRef.current = editingFolderId
+  }, [editingFolderId, editingName])
+
+  useEffect(() => {
+    return () => {
+      if (hoverExpandTimerRef.current !== null) {
+        window.clearTimeout(hoverExpandTimerRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    setClientSelectedFolderId(selectedFolderId)
+  }, [selectedFolderId])
+
+  useEffect(() => {
+    setOptimisticFolderLabels((current) => {
+      let changed = false
+      const next = { ...current }
+
+      for (const [folderId, optimisticLabel] of Object.entries(current)) {
+        const serverFolder = folders.find((folder) => folder.id === folderId)
+        if (!serverFolder || serverFolder.label === optimisticLabel) {
+          delete next[folderId]
+          changed = true
+        }
+      }
+
+      return changed ? next : current
+    })
+  }, [folders])
+
+  useEffect(() => {
+    setOptimisticCreatedFolders((current) => {
+      const serverFolderIds = new Set(folders.map((folder) => folder.id))
+      const next = current.filter((folder) => !serverFolderIds.has(folder.id))
+      return next.length === current.length ? current : next
+    })
+  }, [folders])
+
+  function buildHref(folderId: string | null) {
+    const query = new URLSearchParams()
+    if (folderId) {
+      query.set("folder", folderId)
+    }
+    if (queryText.trim().length > 0) {
+      query.set("q", queryText.trim())
+    }
+    if (selectedType !== "all") {
+      query.set("type", selectedType)
+    }
+    if (selectedSort !== "name" || selectedDirection !== "asc") {
+      query.set("sort", selectedSort)
+      query.set("dir", selectedDirection)
+    }
+    const suffix = query.toString()
+    return `/dashboard/media${suffix ? `?${suffix}` : ""}` as Route
+  }
+
+  function startCreatingFolder() {
+    const selectedFolder = clientSelectedFolderId
+      ? folderById.get(clientSelectedFolderId)
+      : null
+    setEditingFolderId(null)
+    setEditingName("")
+    setEditingError(null)
+    setDraftFolder({
+      parentId: clientSelectedFolderId,
+      depth: selectedFolder ? selectedFolder.depth + 1 : 0,
+    })
+    setDraftName("")
+    setDraftError(null)
+  }
+
+  function submitDraftFolder() {
+    if (!draftFolder || !draftName.trim()) {
+      setDraftFolder(null)
+      setDraftName("")
+      setDraftError(null)
+      return
+    }
+
+    const nextName = draftName.trim()
+    const nextDraftFolder = draftFolder
+    const formData = new FormData()
+    formData.set("name", nextName)
+    if (nextDraftFolder.parentId) {
+      formData.set("parentId", nextDraftFolder.parentId)
+    }
+
+    startTransition(async () => {
+      const result = await onCreateFolder(formData)
+      if (!result.ok) {
+        setDraftError(result.message)
+        draftContentRef.current?.focus()
+        return
+      }
+
+      setOptimisticCreatedFolders((current) => [
+        ...current,
+        {
+          id: result.id,
+          label: nextName,
+          count: 0,
+          directAssetCount: 0,
+          childFolderCount: 0,
+          parentId: nextDraftFolder.parentId,
+          depth: nextDraftFolder.depth,
+        },
+      ])
+      setClientSelectedFolderId(result.id)
+      setDraftFolder(null)
+      setDraftName("")
+      setDraftError(null)
+      router.push(buildHref(result.id))
+    })
+  }
+
+  function moveFolder(folderId: string, parentId: string | null) {
+    if (
+      isDescendantFolderTarget({
+        folders,
+        folderId,
+        parentId,
+      })
+    ) {
+      setActiveFolderId(null)
+      return
+    }
+
+    const formData = new FormData()
+    formData.set("id", folderId)
+    if (parentId) {
+      formData.set("parentId", parentId)
+    }
+
+    startTransition(async () => {
+      const result = await onMoveFolder(formData)
+      setActiveFolderId(null)
+      setActiveDropTargetId(null)
+      dragOverlayRef.current = null
+      if (!result.ok) {
+        return
+      }
+
+      router.refresh()
+    })
+  }
+
+  function clearHoverExpandTimer() {
+    if (hoverExpandTimerRef.current !== null) {
+      window.clearTimeout(hoverExpandTimerRef.current)
+      hoverExpandTimerRef.current = null
+    }
+    hoverExpandTargetIdRef.current = null
+  }
+
+  function expandFolder(folderId: string) {
+    setCollapsedFolderIds((current) => {
+      if (!current.has(folderId)) {
+        return current
+      }
+
+      const next = new Set(current)
+      next.delete(folderId)
+      return next
+    })
+  }
+
+  function scheduleHoverExpand(
+    targetId: string | null,
+    options?: {
+      folderDragId?: string | null
+      assetSourceFolderId?: string | null
+    },
+  ) {
+    if (!targetId || targetId === "root") {
+      clearHoverExpandTimer()
+      return
+    }
+
+    const folderDragId =
+      options?.folderDragId !== undefined
+        ? options.folderDragId
+        : activeFolderId
+    const assetSourceFolderId = options?.assetSourceFolderId
+
+    if (!folderDragId && assetSourceFolderId === undefined) {
+      clearHoverExpandTimer()
+      return
+    }
+
+    if (folderDragId) {
+      if (
+        isDescendantFolderTarget({
+          folders: resolvedFolders,
+          folderId: folderDragId,
+          parentId: targetId,
+        })
+      ) {
+        clearHoverExpandTimer()
+        return
+      }
+    }
+
+    if (assetSourceFolderId !== undefined && assetSourceFolderId === targetId) {
+      clearHoverExpandTimer()
+      return
+    }
+
+    const folder = folderById.get(targetId)
+    if (!folder || folder.childFolderCount === 0 || isFolderExpanded(folder)) {
+      clearHoverExpandTimer()
+      return
+    }
+
+    if (hoverExpandTargetIdRef.current === targetId) {
+      return
+    }
+
+    clearHoverExpandTimer()
+    hoverExpandTargetIdRef.current = targetId
+    hoverExpandTimerRef.current = window.setTimeout(() => {
+      expandFolder(targetId)
+      hoverExpandTimerRef.current = null
+    }, HOVER_EXPAND_DELAY_MS)
+  }
+
+  function handleDragStart(event: DragStartEvent) {
+    clearHoverExpandTimer()
+    lastRootDropTargetRef.current = null
+    setActiveFolderId(null)
+    setActiveDropTargetId(null)
+    setActiveAssetDrag(null)
+    setActiveAssetDropTargetId(null)
+    const pointerCoordinates = getEventCoordinates(event.activatorEvent)
+    const initialRect = event.active.rect.current.initial
+    dragOverlayPointerOffsetRef.current =
+      pointerCoordinates && initialRect
+        ? {
+            x: pointerCoordinates.x - initialRect.left,
+            y: pointerCoordinates.y - initialRect.top,
+          }
+        : null
+    setActiveDragPointerOffset(dragOverlayPointerOffsetRef.current)
+
+    const folderDragData = getFolderDragData(event.active.data)
+    if (folderDragData) {
+      setActiveFolderId(folderDragData.folderId)
+      return
+    }
+
+    const assetDragData = getAssetDragData(event.active.data)
+    if (assetDragData) {
+      setActiveAssetDrag({
+        id: assetDragData.assetId,
+        title: assetDragData.title,
+        folderId: assetDragData.folderId,
+      })
+    }
+  }
+
+  function updateActiveDropTarget(event: DragMoveEvent | DragEndEvent) {
+    const overlayRect = dragOverlayRef.current?.getBoundingClientRect() ?? null
+    const resolvedTargetId = resolveFolderDropTarget({
+      overId: event.over ? String(event.over.id) : null,
+      collisions: event.collisions,
+      activeRect:
+        overlayRect ??
+        event.active.rect.current.translated ??
+        event.active.rect.current.initial,
+      rootRect: rootDropZoneRef.current?.getBoundingClientRect() ?? null,
+    })
+
+    lastRootDropTargetRef.current = persistRootDropTarget({
+      overId: resolvedTargetId,
+      collisions: null,
+    })
+    const folderDragData = getFolderDragData(event.active.data)
+    if (folderDragData) {
+      setActiveDropTargetId(resolvedTargetId)
+      scheduleHoverExpand(resolvedTargetId, {
+        folderDragId: folderDragData.folderId,
+      })
+      return resolvedTargetId
+    }
+
+    const assetDragData = getAssetDragData(event.active.data)
+    if (assetDragData) {
+      const nextTargetId =
+        assetDragData.folderId === resolvedTargetId ? null : resolvedTargetId
+      setActiveAssetDropTargetId(nextTargetId)
+      scheduleHoverExpand(nextTargetId, {
+        assetSourceFolderId: assetDragData.folderId,
+      })
+      return nextTargetId
+    }
+
+    return resolvedTargetId
+  }
+
+  function handleDragMove(event: DragMoveEvent) {
+    updateActiveDropTarget(event)
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const overId = updateActiveDropTarget(event)
+    const folderDragData = getFolderDragData(event.active.data)
+    const assetDragData = getAssetDragData(event.active.data)
+    clearHoverExpandTimer()
+    lastRootDropTargetRef.current = null
+    dragOverlayPointerOffsetRef.current = null
+    setActiveFolderId(null)
+    setActiveDropTargetId(null)
+    setActiveAssetDrag(null)
+    setActiveAssetDropTargetId(null)
+    setActiveDragPointerOffset(null)
+    dragOverlayRef.current = null
+
+    if (!overId) {
+      return
+    }
+
+    if (folderDragData) {
+      if (folderDragData.folderId === overId) {
+        return
+      }
+
+      moveFolder(folderDragData.folderId, overId === "root" ? null : overId)
+      return
+    }
+
+    if (assetDragData) {
+      moveAsset(
+        assetDragData.assetId,
+        assetDragData.folderId,
+        overId === "root" ? null : overId,
+      )
+    }
+  }
+
+  function clearActiveAssetDropState() {
+    clearHoverExpandTimer()
+    setActiveAssetDrag(null)
+    setActiveAssetDropTargetId(null)
+  }
+
+  function moveAsset(
+    assetId: string,
+    sourceFolderId: string | null,
+    targetFolderId: string | null,
+  ) {
+    if (sourceFolderId === targetFolderId) {
+      clearActiveAssetDropState()
+      return
+    }
+
+    const formData = new FormData()
+    formData.set("id", assetId)
+    if (targetFolderId) {
+      formData.set("folderId", targetFolderId)
+    }
+
+    clearActiveAssetDropState()
+    startTransition(async () => {
+      const result = await onMoveAsset(formData)
+      if (!result.ok) {
+        return
+      }
+
+      router.refresh()
+    })
+  }
+
+  function selectRoot() {
+    cancelEditingFolder()
+    setClientSelectedFolderId(null)
+    router.push(buildHref(null))
+  }
+
+  function selectFolder(folderId: string) {
+    if (editingFolderId && editingFolderId !== folderId) {
+      cancelEditingFolder()
+    }
+
+    setClientSelectedFolderId(folderId)
+    router.push(buildHref(folderId))
+  }
+
+  function focusFolderTree() {
+    window.requestAnimationFrame(() => {
+      folderTreeRootRef.current?.focus()
+    })
+  }
+
+  function startEditingFolder(folder: MediaFolderRow) {
+    setDraftFolder(null)
+    setDraftName("")
+    setDraftError(null)
+    setEditingFolderId(folder.id)
+    setEditingName(folder.label)
+    setEditingError(null)
+  }
+
+  function cancelEditingFolder() {
+    setEditingFolderId(null)
+    setEditingName("")
+    setEditingError(null)
+    focusFolderTree()
+  }
+
+  function submitEditingFolder() {
+    if (!editingFolderId) {
+      return
+    }
+
+    const folder = folderById.get(editingFolderId)
+    if (!folder) {
+      cancelEditingFolder()
+      return
+    }
+
+    const nextName = (
+      editingContentRef.current?.textContent ?? editingName
+    ).trim()
+    if (!nextName) {
+      setEditingError("Name the folder before renaming it.")
+      editingContentRef.current?.focus()
+      return
+    }
+
+    if (nextName === folder.label) {
+      cancelEditingFolder()
+      return
+    }
+
+    const formData = new FormData()
+    formData.set("id", editingFolderId)
+    formData.set("name", nextName)
+
+    startTransition(async () => {
+      const result = await onRenameFolder(formData)
+      if (!result.ok) {
+        setEditingError(result.message)
+        editingContentRef.current?.focus()
+        return
+      }
+
+      setOptimisticFolderLabels((current) => ({
+        ...current,
+        [editingFolderId]: nextName,
+      }))
+      cancelEditingFolder()
+      router.refresh()
+      focusFolderTree()
+    })
+  }
+
+  useDndMonitor({
+    onDragStart: handleDragStart,
+    onDragMove: handleDragMove,
+    onDragEnd: handleDragEnd,
+    onDragCancel: () => {
+      clearHoverExpandTimer()
+      lastRootDropTargetRef.current = null
+      dragOverlayPointerOffsetRef.current = null
+      setActiveFolderId(null)
+      setActiveDropTargetId(null)
+      setActiveAssetDrag(null)
+      setActiveAssetDropTargetId(null)
+      setActiveDragPointerOffset(null)
+      dragOverlayRef.current = null
+    },
+  })
+
+  const forcedExpandedFolderIds = (() => {
+    const next = new Set<string>()
+
+    if (draftFolder?.parentId) {
+      next.add(draftFolder.parentId)
+    }
+
+    let currentParentId = clientSelectedFolderId
+      ? (folderById.get(clientSelectedFolderId)?.parentId ?? null)
+      : null
+
+    while (currentParentId) {
+      next.add(currentParentId)
+      currentParentId = folderById.get(currentParentId)?.parentId ?? null
+    }
+
+    return next
+  })()
+
+  function isFolderExpanded(folder: MediaFolderRow) {
+    if (forcedExpandedFolderIds.has(folder.id)) {
+      return true
+    }
+
+    return folder.childFolderCount > 0 && !collapsedFolderIds.has(folder.id)
+  }
+
+  function toggleFolderExpansion(folder: MediaFolderRow) {
+    if (folder.childFolderCount === 0) {
+      return
+    }
+
+    setCollapsedFolderIds((current) => {
+      const next = new Set(current)
+      if (next.has(folder.id)) {
+        next.delete(folder.id)
+      } else {
+        next.add(folder.id)
+      }
+      return next
+    })
+  }
+
+  const entries = (() => {
+    const nextEntries: FolderTreeEntry[] = []
+
+    function appendEntries(parentId: string | null) {
+      const siblings = foldersByParent.get(parentId) ?? []
+      for (const folder of siblings) {
+        nextEntries.push({
+          kind: "folder",
+          folder,
+        })
+
+        if (isFolderExpanded(folder) || draftFolder?.parentId === folder.id) {
+          appendEntries(folder.id)
+        }
+      }
+
+      if (draftFolder?.parentId === parentId) {
+        nextEntries.push({
+          kind: "draft",
+          parentId,
+          depth: draftFolder.depth,
+        })
+      }
+    }
+
+    appendEntries(null)
+    return nextEntries
+  })()
+  const visibleFolderEntries = entries.flatMap((entry) =>
+    entry.kind === "folder" ? [entry.folder] : [],
+  )
+
+  function navigateFolders(direction: -1 | 1) {
+    if (
+      visibleFolderEntries.length === 0 ||
+      editingFolderId ||
+      draftFolder ||
+      interactionLocked
+    ) {
+      return
+    }
+
+    const selectedIndex =
+      clientSelectedFolderId === null
+        ? -1
+        : visibleFolderEntries.findIndex(
+            (folder) => folder.id === clientSelectedFolderId,
+          )
+    const nextIndex =
+      selectedIndex === -1
+        ? direction > 0
+          ? 0
+          : visibleFolderEntries.length - 1
+        : Math.min(
+            visibleFolderEntries.length - 1,
+            Math.max(0, selectedIndex + direction),
+          )
+    const nextFolder = visibleFolderEntries[nextIndex]
+    if (!nextFolder || nextFolder.id === clientSelectedFolderId) {
+      return
+    }
+
+    selectFolder(nextFolder.id)
+  }
+
+  function handleFolderTreeKeyDown(
+    event: globalThis.React.KeyboardEvent<HTMLDivElement>,
+  ) {
+    if (isEditableKeyTarget(event.target)) {
+      return
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      navigateFolders(-1)
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault()
+      navigateFolders(1)
+    } else if (event.key === "Enter") {
+      const selectedFolder = clientSelectedFolderId
+        ? folderById.get(clientSelectedFolderId)
+        : null
+      if (!selectedFolder) {
+        return
+      }
+
+      event.preventDefault()
+      startEditingFolder(selectedFolder)
+    } else if (event.key === " ") {
+      const selectedFolder = clientSelectedFolderId
+        ? folderById.get(clientSelectedFolderId)
+        : null
+      if (!selectedFolder || selectedFolder.childFolderCount === 0) {
+        return
+      }
+
+      event.preventDefault()
+      toggleFolderExpansion(selectedFolder)
+    }
+  }
+
+  const effectiveSelectedFolderId = clientSelectedFolderId
+  const activeFolder = activeFolderId ? folderById.get(activeFolderId) : null
+  const interactionLocked = activeFolderId !== null || activeAssetDrag !== null
+  const effectiveDropTargetId =
+    activeFolderId !== null ? activeDropTargetId : activeAssetDropTargetId
+  const rootDropActive =
+    (activeFolderId !== null && activeDropTargetId === "root") ||
+    (activeAssetDrag !== null &&
+      activeAssetDrag.folderId !== null &&
+      activeAssetDropTargetId === "root")
+  const centerDragOverlayOnPointer = useMemo<Modifier[]>(
+    () => [
+      ({
+        activeNodeRect,
+        overlayNodeRect,
+        transform,
+      }: Parameters<Modifier>[0]) => {
+        const pointerOffset = dragOverlayPointerOffsetRef.current
+        if (!pointerOffset || !activeNodeRect || !overlayNodeRect) {
+          return transform
+        }
+
+        return {
+          ...transform,
+          x: transform.x + (pointerOffset.x - overlayNodeRect.width / 2),
+          y: transform.y + (pointerOffset.y - overlayNodeRect.height / 2),
+        }
+      },
+    ],
+    [],
+  )
+
+  return (
+    <div
+      ref={folderTreeRootRef}
+      tabIndex={-1}
+      onKeyDown={handleFolderTreeKeyDown}
+      className="flex min-h-0 flex-1 flex-col focus:outline-none"
+    >
+      <div className="flex items-center justify-between border-b border-[var(--color-hairline)] px-2 py-2 text-[12px] font-medium text-[var(--color-text-primary)]">
+        <span className="flex items-center gap-2">
+          <Folder className="h-4 w-4" strokeWidth={1.5} />
+          Folders
+        </span>
+        <button
+          type="button"
+          onClick={startCreatingFolder}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface)]"
+          aria-label="Create folder"
+        >
+          <FolderPlus className="h-4 w-4" strokeWidth={1.5} />
+        </button>
+      </div>
+      <div
+        className={cx(
+          "relative flex min-h-0 flex-1 flex-col rounded-sm border border-[color-mix(in_srgb,var(--color-brand)_18%,transparent)]",
+          rootDropActive && "border-[var(--color-brand)]",
+        )}
+      >
+        <div
+          aria-hidden="true"
+          className={cx(
+            "pointer-events-none absolute inset-0 rounded-sm transition-[background-color,box-shadow,opacity] duration-[120ms] ease-out",
+            rootDropActive &&
+              "bg-transparent opacity-100 shadow-[inset_0_0_0_1px_var(--color-brand)]",
+            !rootDropActive && "bg-transparent opacity-100",
+          )}
+        />
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="flex min-h-full flex-col py-1">
+            <nav className="shrink-0">
+              {entries.map((entry, index) => {
+                if (entry.kind === "draft") {
+                  return (
+                    <DraftFolderRow
+                      key={`draft-${entry.parentId ?? "root"}-${index}`}
+                      depth={entry.depth}
+                      value={draftName}
+                      error={draftError}
+                      contentRef={draftContentRef}
+                      onNameChange={(value) => {
+                        setDraftName(value)
+                        if (draftError) {
+                          setDraftError(null)
+                        }
+                      }}
+                      onSubmit={submitDraftFolder}
+                      onCancel={() => {
+                        setDraftFolder(null)
+                        setDraftName("")
+                        setDraftError(null)
+                      }}
+                    />
+                  )
+                }
+
+                return (
+                  <FolderTreeRow
+                    key={entry.folder.id}
+                    folder={entry.folder}
+                    selected={effectiveSelectedFolderId === entry.folder.id}
+                    expanded={isFolderExpanded(entry.folder)}
+                    editing={editingFolderId === entry.folder.id}
+                    editingError={
+                      editingFolderId === entry.folder.id ? editingError : null
+                    }
+                    activeDragId={activeFolderId}
+                    interactionLocked={interactionLocked}
+                    activeDropTargetId={effectiveDropTargetId}
+                    invalidDropTarget={
+                      (activeFolderId !== null &&
+                        isDescendantFolderTarget({
+                          folders: resolvedFolders,
+                          folderId: activeFolderId,
+                          parentId: entry.folder.id,
+                        })) ||
+                      activeAssetDrag?.folderId === entry.folder.id
+                    }
+                    onToggleCollapse={() => toggleFolderExpansion(entry.folder)}
+                    onStartEditing={() => startEditingFolder(entry.folder)}
+                    onEditingNameChange={setEditingName}
+                    onSubmitEditing={submitEditingFolder}
+                    onCancelEditing={cancelEditingFolder}
+                    editingContentRef={editingContentRef}
+                    onSelect={() => selectFolder(entry.folder.id)}
+                  />
+                )
+              })}
+            </nav>
+            <div
+              data-media-root-drop-zone="true"
+              ref={(node) => {
+                rootDropZoneRef.current = node
+                setRootDropRef(node)
+              }}
+              role="button"
+              tabIndex={0}
+              onClick={selectRoot}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault()
+                  selectRoot()
+                }
+              }}
+              className="mb-1 mt-2 min-h-20 flex-1 rounded-sm transition-[background-color] duration-[120ms] ease-out focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-brand)]"
+            />
+          </div>
+        </div>
+      </div>
+
+      <DragOverlay modifiers={centerDragOverlayOnPointer}>
+        {activeFolder ? (
+          <div
+            ref={dragOverlayRef}
+            data-media-folder-drag-overlay="true"
+            className="inline-flex w-fit max-w-max items-center gap-2 whitespace-nowrap rounded-sm border border-[var(--color-brand)] bg-[var(--color-surface)] px-3 py-2 text-[13px] shadow-[0_18px_40px_rgba(0,0,0,0.35)]"
+          >
+            <Folder className="h-4 w-4 shrink-0" strokeWidth={1.5} />
+            <span>{activeFolder.label}</span>
+          </div>
+        ) : activeAssetDrag ? (
+          <div
+            ref={dragOverlayRef}
+            data-media-asset-drag-overlay="true"
+            className="pointer-events-none absolute inline-flex max-w-[240px] items-center rounded-sm border border-[var(--color-brand)] bg-[var(--color-surface)] px-3 py-2 text-[13px] font-medium shadow-[0_18px_40px_rgba(0,0,0,0.35)]"
+            style={{
+              left: (activeDragPointerOffset?.x ?? 0) + 10,
+              top: (activeDragPointerOffset?.y ?? 0) + 10,
+            }}
+          >
+            <span className="truncate">{activeAssetDrag.title}</span>
+          </div>
+        ) : null}
+      </DragOverlay>
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/media-actions.tsx
+++ b/apps/admin/src/app/dashboard/media/media-actions.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useState } from "react"
+import { Upload, X } from "lucide-react"
+
+export type UploadActionResult = {
+  ok: boolean
+  error?: "forbidden" | "missing-file" | "unknown"
+}
+
+export function MediaActions({
+  canUpload,
+  uploadAction,
+  selectedFolderId,
+  selectedFolderLabel,
+}: {
+  canUpload: boolean
+  uploadAction: (formData: FormData) => Promise<UploadActionResult>
+  selectedFolderId: string | null
+  selectedFolderLabel: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState("")
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          if (canUpload) {
+            setError("")
+            setOpen(true)
+            return
+          }
+          setError("Your account cannot upload media assets.")
+        }}
+        className="inline-flex h-8 items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)]"
+      >
+        <Upload className="h-4 w-4" strokeWidth={1.5} />
+        Upload
+      </button>
+      {error ? (
+        <p className="text-[12px] text-[var(--color-danger)]">{error}</p>
+      ) : null}
+
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-6">
+          <div className="w-full max-w-lg rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] shadow-[0_8px_24px_rgba(0,0,0,0.4)]">
+            <div className="hairline-strong-b flex items-center justify-between px-4 py-3">
+              <div>
+                <h2 className="text-[14px] font-semibold">
+                  Upload media asset
+                </h2>
+                <p className="mt-1 text-[12px] text-[var(--color-text-muted)]">
+                  Images, PDFs, files, and local video placeholders are stored
+                  through the media backend.
+                </p>
+                <p className="mt-1 text-[12px] text-[var(--color-text-muted)]">
+                  Destination: {selectedFolderLabel}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-sm border border-[var(--color-hairline)] p-1.5 text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                aria-label="Close upload dialog"
+              >
+                <X className="h-4 w-4" strokeWidth={1.5} />
+              </button>
+            </div>
+            <form
+              action={async (formData) => {
+                setError("")
+                const result = await uploadAction(formData)
+                if (result.ok) {
+                  setOpen(false)
+                  return
+                }
+
+                setError(
+                  result.error === "forbidden"
+                    ? "Your account cannot upload media assets."
+                    : result.error === "missing-file"
+                      ? "Choose a file before uploading."
+                      : "Upload failed. Check the file and try again.",
+                )
+              }}
+              className="grid gap-4 p-4"
+            >
+              {selectedFolderId ? (
+                <input type="hidden" name="folderId" value={selectedFolderId} />
+              ) : null}
+              <label className="grid gap-1.5">
+                <span className="label-text">File</span>
+                <input
+                  type="file"
+                  name="file"
+                  required
+                  className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 py-2 text-[13px] outline-none file:mr-3 file:rounded-sm file:border-0 file:bg-[var(--color-surface-raised)] file:px-3 file:py-1.5 file:text-[12px] file:text-[var(--color-text-primary)]"
+                />
+              </label>
+              <label className="grid gap-1.5">
+                <span className="label-text">Display name</span>
+                <input
+                  name="displayName"
+                  placeholder="Campaign hero image"
+                  className="h-9 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 text-[13px] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)]"
+                />
+              </label>
+              <label className="grid gap-1.5">
+                <span className="label-text">Alt text</span>
+                <input
+                  name="altText"
+                  className="h-9 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 text-[13px] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)]"
+                />
+              </label>
+              <div className="mt-1 flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="inline-flex h-8 items-center rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] text-[var(--color-text-secondary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="inline-flex h-8 items-center rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)]"
+                >
+                  Upload asset
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/media-asset-drop-target.tsx
+++ b/apps/admin/src/app/dashboard/media/media-asset-drop-target.tsx
@@ -1,0 +1,179 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { useRef, useState } from "react"
+import { Upload } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { cx } from "@/components/admin-ui"
+import { ToastStack, useToastStack } from "@/components/toast-stack"
+import type { UploadActionResult } from "@/app/dashboard/media/media-actions"
+
+type MediaAssetDropTargetProps = {
+  canUpload: boolean
+  uploadAction: (formData: FormData) => Promise<UploadActionResult>
+  selectedFolderId: string | null
+  selectedFolderLabel: string
+  children: ReactNode
+}
+
+function hasFiles(dataTransfer: DataTransfer | null) {
+  if (!dataTransfer) {
+    return false
+  }
+
+  return Array.from(dataTransfer.types).includes("Files")
+}
+
+export function MediaAssetDropTarget({
+  canUpload,
+  uploadAction,
+  selectedFolderId,
+  selectedFolderLabel,
+  children,
+}: MediaAssetDropTargetProps) {
+  const router = useRouter()
+  const dragDepthRef = useRef(0)
+  const [dragActive, setDragActive] = useState(false)
+  const [uploadingCount, setUploadingCount] = useState(0)
+  const { toasts, pushToast, dismissToast } = useToastStack()
+
+  function resetDragState() {
+    dragDepthRef.current = 0
+    setDragActive(false)
+  }
+
+  async function handleDrop(files: File[]) {
+    if (!canUpload) {
+      pushToast("Your account cannot upload media assets.", "error")
+      return
+    }
+
+    const validFiles = files.filter((file) => file.size > 0)
+    if (validFiles.length === 0) {
+      pushToast("Choose at least one file to upload.", "error")
+      return
+    }
+
+    setUploadingCount(validFiles.length)
+
+    let successCount = 0
+    let forbidden = false
+    let failed = false
+
+    for (const file of validFiles) {
+      const formData = new FormData()
+      formData.set("file", file)
+      if (selectedFolderId) {
+        formData.set("folderId", selectedFolderId)
+      }
+
+      const result = await uploadAction(formData)
+      if (result.ok) {
+        successCount += 1
+        continue
+      }
+
+      if (result.error === "forbidden") {
+        forbidden = true
+      } else {
+        failed = true
+      }
+    }
+
+    setUploadingCount(0)
+
+    if (successCount > 0) {
+      router.refresh()
+      pushToast(
+        successCount === 1
+          ? `Uploaded 1 file to ${selectedFolderLabel}.`
+          : `Uploaded ${successCount} files to ${selectedFolderLabel}.`,
+        "success",
+      )
+    }
+
+    if (forbidden) {
+      pushToast("Your account cannot upload media assets.", "error")
+    } else if (failed) {
+      pushToast("Some files could not be uploaded. Try again.", "error")
+    }
+  }
+
+  return (
+    <div
+      onDragEnter={(event) => {
+        if (!hasFiles(event.dataTransfer)) {
+          return
+        }
+
+        event.preventDefault()
+        dragDepthRef.current += 1
+        setDragActive(true)
+      }}
+      onDragOver={(event) => {
+        if (!hasFiles(event.dataTransfer)) {
+          return
+        }
+
+        event.preventDefault()
+        event.dataTransfer.dropEffect = canUpload ? "copy" : "none"
+        if (!dragActive) {
+          setDragActive(true)
+        }
+      }}
+      onDragLeave={(event) => {
+        if (!hasFiles(event.dataTransfer)) {
+          return
+        }
+
+        event.preventDefault()
+        dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+        if (dragDepthRef.current === 0) {
+          setDragActive(false)
+        }
+      }}
+      onDrop={(event) => {
+        if (!hasFiles(event.dataTransfer)) {
+          return
+        }
+
+        event.preventDefault()
+        const files = Array.from(event.dataTransfer.files)
+        resetDragState()
+        void handleDrop(files)
+      }}
+      className="relative min-h-0 flex-1"
+    >
+      <div className="min-h-full">{children}</div>
+
+      {(dragActive || uploadingCount > 0) && (
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-sm">
+          <div
+            className={cx(
+              "absolute inset-0 rounded-sm border border-[var(--color-brand)] bg-[color-mix(in_srgb,var(--color-brand)_8%,transparent)] shadow-[inset_0_0_0_1px_var(--color-brand)] transition-all duration-[120ms] ease-out",
+              uploadingCount > 0 &&
+                "bg-[color-mix(in_srgb,var(--color-brand)_12%,transparent)]",
+            )}
+          />
+          <div className="absolute inset-4 flex items-center justify-center">
+            <div className="inline-flex items-center gap-3 rounded-sm border border-[var(--color-hairline)] bg-[color-mix(in_srgb,var(--color-surface)_92%,transparent)] px-4 py-3 text-[13px] text-[var(--color-text-primary)] shadow-[0_18px_40px_rgba(0,0,0,0.28)]">
+              <Upload
+                className={cx("h-4 w-4", uploadingCount > 0 && "animate-pulse")}
+                strokeWidth={1.5}
+              />
+              <span>
+                {uploadingCount > 0
+                  ? uploadingCount === 1
+                    ? `Uploading 1 file to ${selectedFolderLabel}...`
+                    : `Uploading ${uploadingCount} files to ${selectedFolderLabel}...`
+                  : `Drop files to upload to ${selectedFolderLabel}`}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ToastStack toasts={toasts} onDismiss={dismissToast} />
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/media-asset-inspector.tsx
+++ b/apps/admin/src/app/dashboard/media/media-asset-inspector.tsx
@@ -1,0 +1,444 @@
+"use client"
+
+import type { Route } from "next"
+import { useRouter } from "next/navigation"
+import { useMemo, useState, useTransition } from "react"
+import Link from "next/link"
+import {
+  Download,
+  File as FileIcon,
+  FileText,
+  Image as ImageIcon,
+  Trash2,
+  Video,
+  X,
+} from "lucide-react"
+import { cx } from "@/components/admin-ui"
+import { ConfirmModal } from "@/components/confirm-modal"
+import { ToastStack, useToastStack } from "@/components/toast-stack"
+
+type UpdateAssetMetadataActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type DeleteAssetActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type UsageItem = {
+  experienceId: string
+  experienceLocaleId: string
+  locale: string
+  title: string | null
+  fieldPath: string
+}
+
+type MediaAssetInspectorProps = {
+  asset: {
+    id: string
+    kind: "IMAGE" | "VIDEO" | "PDF" | "FILE"
+    displayName: string
+    description: string | null
+    altText: string | null
+    folderLabel: string
+    originalFilename: string | null
+    supplementalLabel: string
+    backend: string
+    updatedAtIso: string
+    updatedAtLabel: string
+    width: number | null
+    height: number | null
+    previewUrl: string | null
+    downloadUrl: string | null
+  }
+  closeHref: Route
+  usage: UsageItem[]
+  canEditMetadata: boolean
+  canDeleteAsset: boolean
+  onUpdateAsset: (
+    formData: FormData,
+  ) => Promise<UpdateAssetMetadataActionResult>
+  onDeleteAsset: (formData: FormData) => Promise<DeleteAssetActionResult>
+}
+
+type DraftState = {
+  displayName: string
+  description: string
+  altText: string
+}
+
+function initialDraft(asset: MediaAssetInspectorProps["asset"]): DraftState {
+  return {
+    displayName: asset.displayName,
+    description: asset.description ?? "",
+    altText: asset.altText ?? "",
+  }
+}
+
+export function MediaAssetInspector({
+  asset,
+  closeHref,
+  usage,
+  canEditMetadata,
+  canDeleteAsset,
+  onUpdateAsset,
+  onDeleteAsset,
+}: MediaAssetInspectorProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [isDeletePending, startDeleteTransition] = useTransition()
+  const { toasts, pushToast, dismissToast } = useToastStack()
+  const [draft, setDraft] = useState(() => initialDraft(asset))
+  const [error, setError] = useState<string | null>(null)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+
+  const hasChanges = useMemo(
+    () =>
+      draft.displayName.trim() !== asset.displayName ||
+      draft.description.trim() !== (asset.description ?? "") ||
+      draft.altText.trim() !== (asset.altText ?? ""),
+    [asset.altText, asset.description, asset.displayName, draft],
+  )
+
+  function resetDraft() {
+    setDraft(initialDraft(asset))
+    setError(null)
+  }
+
+  function submitForm(event: globalThis.React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const nextDisplayName = draft.displayName.trim()
+    if (!nextDisplayName) {
+      setError("Name the file before saving.")
+      return
+    }
+
+    const formData = new FormData()
+    formData.set("id", asset.id)
+    formData.set("displayName", nextDisplayName)
+    formData.set("description", draft.description.trim())
+    formData.set("altText", draft.altText.trim())
+
+    startTransition(async () => {
+      const result = await onUpdateAsset(formData)
+
+      if (!result.ok) {
+        setError(result.message)
+        pushToast(result.message, "error")
+        return
+      }
+
+      setError(null)
+      pushToast("Asset metadata saved.", "success")
+      router.refresh()
+    })
+  }
+
+  function deleteAsset() {
+    if (!canDeleteAsset || usage.length > 0 || isDeletePending) {
+      return
+    }
+
+    const formData = new FormData()
+    formData.set("id", asset.id)
+
+    startDeleteTransition(async () => {
+      const result = await onDeleteAsset(formData)
+
+      if (!result.ok) {
+        pushToast(result.message, "error")
+        setDeleteDialogOpen(false)
+        return
+      }
+
+      setDeleteDialogOpen(false)
+      pushToast("Asset deleted.", "success")
+      router.push(closeHref)
+      router.refresh()
+    })
+  }
+
+  return (
+    <aside className="relative flex min-h-0 flex-col border-l border-[var(--color-hairline)] bg-[var(--color-surface-raised)]">
+      <div className="hairline-strong-b flex items-start justify-between gap-3 px-4 py-3">
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-medium text-[var(--color-text-primary)]">
+            {asset.displayName}
+          </div>
+          {asset.supplementalLabel ? (
+            <div className="mono-meta mt-1 truncate text-[var(--color-text-muted)]">
+              {asset.supplementalLabel}
+            </div>
+          ) : null}
+        </div>
+        <Link
+          href={closeHref}
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface)] hover:text-[var(--color-text-primary)]"
+          aria-label="Close asset inspector"
+        >
+          <X className="h-4 w-4" strokeWidth={1.5} />
+        </Link>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3">
+        <div>
+          {asset.kind === "IMAGE" && asset.previewUrl ? (
+            <div className="w-full overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] p-1.5">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={asset.previewUrl}
+                alt={draft.altText.trim() || asset.displayName}
+                width={asset.width ?? undefined}
+                height={asset.height ?? undefined}
+                className="block h-auto max-h-40 w-full object-contain"
+              />
+            </div>
+          ) : (
+            <div className="flex h-16 w-16 items-center justify-center rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)]">
+              {asset.kind === "PDF" ? (
+                <FileText
+                  className="h-7 w-7 text-[var(--color-text-muted)]"
+                  strokeWidth={1.5}
+                />
+              ) : asset.kind === "VIDEO" ? (
+                <Video
+                  className="h-7 w-7 text-[var(--color-text-muted)]"
+                  strokeWidth={1.5}
+                />
+              ) : asset.kind === "FILE" ? (
+                <FileIcon
+                  className="h-7 w-7 text-[var(--color-text-muted)]"
+                  strokeWidth={1.5}
+                />
+              ) : (
+                <ImageIcon
+                  className="h-7 w-7 text-[var(--color-text-muted)]"
+                  strokeWidth={1.5}
+                />
+              )}
+            </div>
+          )}
+        </div>
+
+        <form
+          onSubmit={submitForm}
+          className="grid gap-3 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] p-3"
+        >
+          <div className="text-[13px] font-medium text-[var(--color-text-primary)]">
+            Metadata
+          </div>
+          <label className="grid gap-1.5">
+            <span className="label-text">Display name</span>
+            <input
+              value={draft.displayName}
+              onChange={(event) =>
+                setDraft((current) => ({
+                  ...current,
+                  displayName: event.target.value,
+                }))
+              }
+              disabled={!canEditMetadata || isPending}
+              className="h-9 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 text-[13px] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+          </label>
+
+          {asset.kind === "IMAGE" ? (
+            <label className="grid gap-1.5">
+              <span className="label-text">Alt text</span>
+              <input
+                value={draft.altText}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    altText: event.target.value,
+                  }))
+                }
+                disabled={!canEditMetadata || isPending}
+                className="h-9 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 text-[13px] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+              />
+            </label>
+          ) : null}
+
+          <label className="grid gap-1.5">
+            <span className="label-text">Description</span>
+            <textarea
+              value={draft.description}
+              onChange={(event) =>
+                setDraft((current) => ({
+                  ...current,
+                  description: event.target.value,
+                }))
+              }
+              disabled={!canEditMetadata || isPending}
+              rows={4}
+              className="min-h-24 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 py-2 text-[13px] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+          </label>
+
+          {error ? (
+            <div className="text-[12px] text-[var(--color-danger)]">
+              {error}
+            </div>
+          ) : null}
+
+          {canEditMetadata ? (
+            <div className="mt-1 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={resetDraft}
+                disabled={!hasChanges || isPending}
+                className="inline-flex h-8 items-center rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] text-[var(--color-text-secondary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Reset
+              </button>
+              <button
+                type="submit"
+                disabled={!hasChanges || isPending}
+                className={cx(
+                  "inline-flex h-8 items-center rounded-sm px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out",
+                  !hasChanges || isPending
+                    ? "cursor-not-allowed bg-[var(--color-brand)] opacity-60"
+                    : "bg-[var(--color-brand)] hover:bg-[var(--color-brand-pressed)]",
+                )}
+              >
+                {isPending ? "Saving..." : "Save changes"}
+              </button>
+            </div>
+          ) : (
+            <div className="text-[12px] text-[var(--color-text-muted)]">
+              Your account cannot edit media metadata.
+            </div>
+          )}
+        </form>
+
+        <div className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] px-3 py-2">
+          <div className="grid grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-baseline gap-x-2 gap-y-1.5 text-[12px]">
+            <div className="label-text">Kind</div>
+            <div className="truncate text-[var(--color-text-secondary)]">
+              {asset.kind}
+            </div>
+            <div className="label-text">Folder</div>
+            <div
+              className="truncate text-[var(--color-text-secondary)]"
+              title={asset.folderLabel}
+            >
+              {asset.folderLabel}
+            </div>
+            <div className="label-text">Backend</div>
+            <div className="truncate text-[var(--color-text-secondary)]">
+              {asset.backend}
+            </div>
+            <div className="label-text">Original</div>
+            <div
+              className="truncate text-[var(--color-text-secondary)]"
+              title={asset.originalFilename ?? ""}
+            >
+              {asset.originalFilename ?? "n/a"}
+            </div>
+            <div className="label-text">Updated</div>
+            <div
+              className="truncate text-[var(--color-text-secondary)]"
+              title={asset.updatedAtIso}
+            >
+              {asset.updatedAtLabel}
+            </div>
+          </div>
+        </div>
+
+        {asset.downloadUrl ? (
+          <a
+            href={asset.downloadUrl}
+            className="inline-flex h-8 items-center gap-2 self-start rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface)]"
+          >
+            <Download className="h-4 w-4" strokeWidth={1.5} />
+            Download
+          </a>
+        ) : null}
+
+        {canDeleteAsset ? (
+          <div className="grid gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-[13px] font-medium text-[var(--color-text-primary)]">
+                  Delete asset
+                </div>
+                <div className="mt-1 text-[12px] leading-5 text-[var(--color-text-muted)]">
+                  {usage.length > 0
+                    ? "Clear references before deleting this asset."
+                    : "Unused assets can be permanently deleted."}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDeleteDialogOpen(true)}
+                disabled={usage.length > 0 || isDeletePending}
+                className={cx(
+                  "inline-flex h-8 shrink-0 cursor-pointer items-center gap-2 rounded-sm border px-3 text-[13px] font-medium transition-all duration-[120ms] ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-danger)] focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-55",
+                  "border-[var(--color-hairline)] text-[var(--color-danger)] hover:bg-[var(--color-surface-raised)]",
+                )}
+              >
+                <Trash2 className="h-4 w-4" strokeWidth={1.5} />
+                {isDeletePending ? "Deleting..." : "Delete"}
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)]">
+          <div className="hairline-strong-b px-3 py-2">
+            <div className="text-[13px] font-medium text-[var(--color-text-primary)]">
+              Where used
+            </div>
+            <div className="mono-meta mt-1 text-[var(--color-text-muted)]">
+              {usage.length} references
+            </div>
+          </div>
+          <div className="divide-y divide-[var(--color-hairline)]">
+            {usage.map((item) => (
+              <Link
+                key={`${item.experienceLocaleId}:${item.fieldPath}`}
+                href={
+                  `/dashboard/experiences/${item.experienceId}?locale=${item.locale}` as Route
+                }
+                className="grid gap-1 px-3 py-3 transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+              >
+                <div className="text-[13px] font-medium text-[var(--color-text-primary)]">
+                  {item.title ?? item.experienceLocaleId}
+                </div>
+                <div className="mono-meta text-[var(--color-text-muted)]">
+                  {item.locale} / {item.fieldPath}
+                </div>
+              </Link>
+            ))}
+            {usage.length === 0 ? (
+              <div className="px-3 py-6 text-[12px] text-[var(--color-text-muted)]">
+                This asset is not currently referenced by any experience
+                metadata or block field.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <ConfirmModal
+        open={deleteDialogOpen}
+        title="Delete This Asset?"
+        description={`This will permanently delete ${asset.displayName}. This cannot be undone.`}
+        confirmLabel="Delete Asset"
+        pending={isDeletePending}
+        onCancel={() => setDeleteDialogOpen(false)}
+        onConfirm={deleteAsset}
+      />
+      <ToastStack toasts={toasts} onDismiss={dismissToast} />
+    </aside>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/media-asset-table.tsx
+++ b/apps/admin/src/app/dashboard/media/media-asset-table.tsx
@@ -1,0 +1,697 @@
+"use client"
+
+import type {
+  CSSProperties,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+  RefObject,
+} from "react"
+import type { Route } from "next"
+import { useEffect, useMemo, useRef, useState, useTransition } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useDraggable } from "@dnd-kit/core"
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  File as FileIcon,
+  FileText,
+  Video,
+} from "lucide-react"
+import { cx } from "@/components/admin-ui"
+import type { MediaLibraryAssetDragData } from "@/app/dashboard/media/media-library-dnd"
+
+type MediaSortField = "name" | "size" | "updated"
+type SortDirection = "asc" | "desc"
+type ResizableColumn = "name" | "size" | "updated"
+
+type MediaAssetTableRow = {
+  key: string
+  title: string
+  detail: string
+  detailHref?: Route
+  kind: "IMAGE" | "VIDEO" | "PDF" | "FILE"
+  folderId: string | null
+  previewUrl: string | null
+  byteSize: string
+  updatedLabel: string
+  href: Route
+  selected: boolean
+}
+
+type MediaAssetTableProps = {
+  rows: MediaAssetTableRow[]
+  selectedSort: MediaSortField
+  selectedDirection: SortDirection
+  sortHrefs: Record<MediaSortField, Route>
+  onRenameAsset: (formData: FormData) => Promise<{
+    ok: boolean
+    error?: "forbidden" | "validation" | "unknown"
+    message?: string
+  }>
+  emptyState?: ReactNode
+}
+
+const DEFAULT_NAME_WIDTH = 320
+const DEFAULT_SIZE_WIDTH = 120
+const DEFAULT_UPDATED_WIDTH = 132
+const MIN_NAME_WIDTH = 220
+const MAX_NAME_WIDTH = 460
+const MIN_SIZE_WIDTH = 92
+const MAX_SIZE_WIDTH = 240
+const MIN_UPDATED_WIDTH = 108
+const MAX_UPDATED_WIDTH = 260
+
+function isEditableKeyTarget(target: EventTarget | null) {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("input,textarea,select,[contenteditable=true]")
+  )
+}
+
+function clampColumnWidth(column: ResizableColumn, value: number) {
+  if (column === "name") {
+    return Math.min(MAX_NAME_WIDTH, Math.max(MIN_NAME_WIDTH, value))
+  }
+
+  if (column === "size") {
+    return Math.min(MAX_SIZE_WIDTH, Math.max(MIN_SIZE_WIDTH, value))
+  }
+
+  return Math.min(MAX_UPDATED_WIDTH, Math.max(MIN_UPDATED_WIDTH, value))
+}
+
+function SortIndicator({
+  active,
+  direction,
+}: {
+  active: boolean
+  direction: SortDirection
+}) {
+  if (!active) {
+    return <ArrowUpDown className="h-3.5 w-3.5" strokeWidth={1.5} />
+  }
+
+  return direction === "asc" ? (
+    <ArrowUp className="h-3.5 w-3.5" strokeWidth={1.5} />
+  ) : (
+    <ArrowDown className="h-3.5 w-3.5" strokeWidth={1.5} />
+  )
+}
+
+type MediaAssetTableRowItemProps = {
+  row: MediaAssetTableRow
+  tableStyle: CSSProperties
+  selected: boolean
+  editing: boolean
+  editingContentRef: RefObject<HTMLSpanElement | null>
+  editingError: string | null
+  isPending: boolean
+  onSelect: () => void
+  onStartEditing: () => void
+  onEditingNameChange: (value: string) => void
+  onSubmitEditing: () => void
+  onCancelEditing: () => void
+}
+
+function MediaAssetTableRowItem({
+  row,
+  tableStyle,
+  selected,
+  editing,
+  editingContentRef,
+  editingError,
+  isPending,
+  onSelect,
+  onStartEditing,
+  onEditingNameChange,
+  onSubmitEditing,
+  onCancelEditing,
+}: MediaAssetTableRowItemProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `asset:${row.key}`,
+    disabled: editing,
+    data: {
+      type: "asset",
+      assetId: row.key,
+      title: row.title,
+      folderId: row.folderId,
+    } satisfies MediaLibraryAssetDragData,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      onClick={() => {
+        if (editing) {
+          return
+        }
+
+        if (!selected) {
+          onSelect()
+        }
+      }}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget || editing) {
+          return
+        }
+
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault()
+          if (!selected) {
+            onSelect()
+          }
+        }
+      }}
+      className={cx(
+        "grid items-center gap-4 px-4 py-3 text-left transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-brand)] focus-visible:ring-inset",
+        !editing && "cursor-grab active:cursor-grabbing",
+        selected && "bg-[var(--color-brand-soft)]",
+        isDragging && "opacity-60",
+      )}
+      style={tableStyle}
+    >
+      <div className="overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)]">
+        <div className="flex aspect-video items-center justify-center">
+          {row.kind === "IMAGE" && row.previewUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={row.previewUrl}
+              alt={row.title}
+              className="h-full w-full object-cover"
+            />
+          ) : row.kind === "PDF" ? (
+            <FileText
+              className="h-6 w-6 text-[var(--color-text-muted)]"
+              strokeWidth={1.5}
+            />
+          ) : row.kind === "VIDEO" ? (
+            <Video
+              className="h-6 w-6 text-[var(--color-text-muted)]"
+              strokeWidth={1.5}
+            />
+          ) : (
+            <FileIcon
+              className="h-6 w-6 text-[var(--color-text-muted)]"
+              strokeWidth={1.5}
+            />
+          )}
+        </div>
+      </div>
+      <div className="min-w-0">
+        {editing ? (
+          <span
+            className="inline-flex min-w-0 max-w-full rounded-[2px] bg-[var(--color-bg)] px-1.5 shadow-[inset_0_0_0_1px_var(--color-brand)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <span
+              ref={editingContentRef}
+              contentEditable="plaintext-only"
+              suppressContentEditableWarning
+              role="textbox"
+              spellCheck={false}
+              aria-invalid={editingError ? "true" : "false"}
+              onPointerDown={(event) => {
+                event.stopPropagation()
+              }}
+              onClick={(event) => {
+                event.stopPropagation()
+              }}
+              onInput={(event) => {
+                onEditingNameChange(event.currentTarget.textContent ?? "")
+              }}
+              onBlur={onSubmitEditing}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault()
+                  onSubmitEditing()
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault()
+                  onCancelEditing()
+                }
+              }}
+              className={cx(
+                "block min-w-0 max-w-full whitespace-pre-wrap break-words bg-transparent px-0.5 text-[13px] font-medium leading-5 text-[var(--color-text-primary)] [overflow-wrap:anywhere] caret-[var(--color-brand)] outline-none",
+                isPending && "opacity-70",
+              )}
+            />
+          </span>
+        ) : (
+          <span
+            className="inline-flex min-w-0 max-w-full cursor-text rounded-[2px] px-1.5"
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+
+              if (selected) {
+                onStartEditing()
+                return
+              }
+
+              onSelect()
+            }}
+          >
+            <span className="block min-w-0 truncate px-0.5 text-[13px] font-medium text-[var(--color-text-primary)]">
+              {row.title}
+            </span>
+          </span>
+        )}
+        {row.detail ? (
+          row.detailHref ? (
+            <Link
+              href={row.detailHref}
+              onClick={(event) => {
+                event.stopPropagation()
+              }}
+              className="mono-meta mt-1 block truncate px-2 text-[var(--color-text-muted)] transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-brand)] focus-visible:ring-inset"
+            >
+              {row.detail}
+            </Link>
+          ) : (
+            <div className="mono-meta mt-1 truncate px-2 text-[var(--color-text-muted)]">
+              {row.detail}
+            </div>
+          )
+        ) : null}
+        {editing && editingError ? (
+          <div
+            role="alert"
+            className="mt-1 px-2 text-[11px] text-[var(--color-danger)]"
+          >
+            {editingError}
+          </div>
+        ) : null}
+      </div>
+      <div className="mono-meta justify-self-end text-[var(--color-text-secondary)]">
+        {row.byteSize}
+      </div>
+      <div className="mono-meta justify-self-end text-[var(--color-text-muted)]">
+        {row.updatedLabel}
+      </div>
+    </div>
+  )
+}
+
+export function MediaAssetTable({
+  rows,
+  selectedSort,
+  selectedDirection,
+  sortHrefs,
+  onRenameAsset,
+  emptyState,
+}: MediaAssetTableProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [nameWidth, setNameWidth] = useState(DEFAULT_NAME_WIDTH)
+  const [sizeWidth, setSizeWidth] = useState(DEFAULT_SIZE_WIDTH)
+  const [updatedWidth, setUpdatedWidth] = useState(DEFAULT_UPDATED_WIDTH)
+  const editingContentRef = useRef<HTMLSpanElement | null>(null)
+  const tableRootRef = useRef<HTMLDivElement | null>(null)
+  const initializedEditingRowIdRef = useRef<string | null>(null)
+  const submittingRowIdRef = useRef<string | null>(null)
+  const dragStateRef = useRef<{
+    column: ResizableColumn
+    startX: number
+    startWidth: number
+  } | null>(null)
+  const [editingRowId, setEditingRowId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState("")
+  const [editingError, setEditingError] = useState<string | null>(null)
+  const [optimisticTitles, setOptimisticTitles] = useState<
+    Record<string, { from: string; to: string }>
+  >({})
+  const displayRows = useMemo(
+    () =>
+      rows.map((row) => ({
+        ...row,
+        title:
+          optimisticTitles[row.key] &&
+          (row.title === optimisticTitles[row.key].from ||
+            row.title === optimisticTitles[row.key].to)
+            ? optimisticTitles[row.key].to
+            : row.title,
+      })),
+    [optimisticTitles, rows],
+  )
+  const rowById = useMemo(
+    () => new Map(displayRows.map((row) => [row.key, row])),
+    [displayRows],
+  )
+  const selectedRowId = rows.find((row) => row.selected)?.key ?? null
+
+  useEffect(() => {
+    if (!editingRowId || !editingContentRef.current) {
+      initializedEditingRowIdRef.current = null
+      return
+    }
+
+    if (initializedEditingRowIdRef.current === editingRowId) {
+      return
+    }
+
+    const node = editingContentRef.current
+    node.textContent = editingName
+    node.focus()
+
+    const selection = window.getSelection()
+    if (selection) {
+      const range = document.createRange()
+      range.selectNodeContents(node)
+      selection.removeAllRanges()
+      selection.addRange(range)
+    }
+
+    initializedEditingRowIdRef.current = editingRowId
+  }, [editingName, editingRowId])
+
+  useEffect(() => {
+    function handlePointerMove(event: PointerEvent) {
+      const dragState = dragStateRef.current
+      if (!dragState) {
+        return
+      }
+
+      const deltaX = event.clientX - dragState.startX
+      const nextWidth = clampColumnWidth(
+        dragState.column,
+        dragState.startWidth + deltaX,
+      )
+
+      if (dragState.column === "name") {
+        setNameWidth(nextWidth)
+      } else if (dragState.column === "size") {
+        setSizeWidth(nextWidth)
+      } else {
+        setUpdatedWidth(nextWidth)
+      }
+    }
+
+    function handlePointerUp() {
+      dragStateRef.current = null
+      document.body.style.cursor = ""
+      document.body.style.userSelect = ""
+    }
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerUp)
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+    }
+  }, [])
+
+  const tableStyle = useMemo(
+    () => ({
+      gridTemplateColumns: `80px ${nameWidth}px ${sizeWidth}px ${updatedWidth}px`,
+      justifyContent: "start",
+      minWidth: `${80 + nameWidth + sizeWidth + updatedWidth}px`,
+    }),
+    [nameWidth, sizeWidth, updatedWidth],
+  )
+
+  function startResizing(column: ResizableColumn) {
+    return (event: ReactPointerEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+
+      dragStateRef.current = {
+        column,
+        startX: event.clientX,
+        startWidth:
+          column === "name"
+            ? nameWidth
+            : column === "size"
+              ? sizeWidth
+              : updatedWidth,
+      }
+
+      document.body.style.cursor = "ew-resize"
+      document.body.style.userSelect = "none"
+    }
+  }
+
+  function cancelEditingRow() {
+    submittingRowIdRef.current = null
+    setEditingRowId(null)
+    setEditingName("")
+    setEditingError(null)
+    focusAssetTable()
+  }
+
+  function focusAssetTable() {
+    window.requestAnimationFrame(() => {
+      tableRootRef.current?.focus()
+    })
+  }
+
+  function selectRow(row: MediaAssetTableRow) {
+    if (editingRowId && editingRowId !== row.key) {
+      cancelEditingRow()
+    }
+
+    router.push(row.href, { scroll: false })
+  }
+
+  function navigateRows(direction: -1 | 1) {
+    if (displayRows.length === 0 || editingRowId) {
+      return
+    }
+
+    const selectedIndex = selectedRowId
+      ? displayRows.findIndex((row) => row.key === selectedRowId)
+      : -1
+    const nextIndex =
+      selectedIndex === -1
+        ? direction > 0
+          ? 0
+          : displayRows.length - 1
+        : Math.min(
+            displayRows.length - 1,
+            Math.max(0, selectedIndex + direction),
+          )
+    const nextRow = displayRows[nextIndex]
+    if (!nextRow || nextRow.key === selectedRowId) {
+      return
+    }
+
+    selectRow(nextRow)
+  }
+
+  function handleAssetTableKeyDown(
+    event: globalThis.React.KeyboardEvent<HTMLDivElement>,
+  ) {
+    if (isEditableKeyTarget(event.target)) {
+      return
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      navigateRows(-1)
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault()
+      navigateRows(1)
+    }
+  }
+
+  function startEditingRow(row: MediaAssetTableRow) {
+    setEditingRowId(row.key)
+    setEditingName(row.title)
+    setEditingError(null)
+  }
+
+  function submitEditingRow() {
+    if (!editingRowId || submittingRowIdRef.current === editingRowId) {
+      return
+    }
+
+    const row = rowById.get(editingRowId)
+    if (!row) {
+      cancelEditingRow()
+      return
+    }
+
+    const nextName = (
+      editingContentRef.current?.textContent ?? editingName
+    ).trim()
+
+    if (!nextName) {
+      setEditingError("Name the file before renaming it.")
+      editingContentRef.current?.focus()
+      return
+    }
+
+    if (nextName === row.title) {
+      cancelEditingRow()
+      return
+    }
+
+    const targetRowId = editingRowId
+    const previousTitle = row.title
+    const formData = new FormData()
+    formData.set("id", targetRowId)
+    formData.set("displayName", nextName)
+    submittingRowIdRef.current = targetRowId
+
+    startTransition(async () => {
+      const result = await onRenameAsset(formData)
+      submittingRowIdRef.current = null
+
+      if (!result.ok) {
+        setEditingError(
+          result.message ?? "We couldn't rename that file just now.",
+        )
+        editingContentRef.current?.focus()
+        return
+      }
+
+      setOptimisticTitles((current) => {
+        return {
+          ...current,
+          [targetRowId]: {
+            from: previousTitle,
+            to: nextName,
+          },
+        }
+      })
+      cancelEditingRow()
+      router.refresh()
+      focusAssetTable()
+    })
+  }
+
+  return (
+    <div
+      ref={tableRootRef}
+      tabIndex={-1}
+      onKeyDown={handleAssetTableKeyDown}
+      className="min-h-full overflow-x-auto focus:outline-none"
+    >
+      <div className="min-h-full">
+        <div
+          className="grid items-center gap-4 border-b border-[var(--color-hairline)] px-4 py-2"
+          style={tableStyle}
+        >
+          <div />
+          <div className="relative">
+            <Link
+              href={sortHrefs.name}
+              className={cx(
+                "inline-flex h-7 items-center gap-1 rounded-[2px] px-1.5 text-left label-text transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)]",
+                selectedSort === "name"
+                  ? "text-[var(--color-text-primary)]"
+                  : "text-[var(--color-text-muted)]",
+              )}
+            >
+              <span>File name</span>
+              <SortIndicator
+                active={selectedSort === "name"}
+                direction={selectedDirection}
+              />
+            </Link>
+            <button
+              type="button"
+              aria-label="Resize file name column"
+              onPointerDown={startResizing("name")}
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              className="absolute -right-3 top-1/2 z-10 inline-flex h-7 w-6 -translate-y-1/2 cursor-ew-resize items-center justify-center text-[var(--color-text-muted)] transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)]"
+            >
+              <span className="h-4 w-px bg-current" />
+            </button>
+          </div>
+          <div className="relative">
+            <button
+              type="button"
+              aria-label="Resize file size column"
+              onPointerDown={startResizing("size")}
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              className="absolute -right-3 top-1/2 z-10 inline-flex h-7 w-6 -translate-y-1/2 cursor-ew-resize items-center justify-center text-[var(--color-text-muted)] transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)]"
+            >
+              <span className="h-4 w-px bg-current" />
+            </button>
+            <Link
+              href={sortHrefs.size}
+              className={cx(
+                "inline-flex h-7 w-full items-center justify-end gap-1 rounded-[2px] px-1.5 text-left label-text transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)]",
+                selectedSort === "size"
+                  ? "text-[var(--color-text-primary)]"
+                  : "text-[var(--color-text-muted)]",
+              )}
+            >
+              <span>File size</span>
+              <SortIndicator
+                active={selectedSort === "size"}
+                direction={selectedDirection}
+              />
+            </Link>
+          </div>
+          <div className="relative">
+            <button
+              type="button"
+              aria-label="Resize updated column"
+              onPointerDown={startResizing("updated")}
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              className="absolute -right-3 top-1/2 z-10 inline-flex h-7 w-6 -translate-y-1/2 cursor-ew-resize items-center justify-center text-[var(--color-text-muted)] transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)]"
+            >
+              <span className="h-4 w-px bg-current" />
+            </button>
+            <Link
+              href={sortHrefs.updated}
+              className={cx(
+                "inline-flex h-7 w-full items-center justify-end gap-1 rounded-[2px] px-1.5 text-left label-text transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)]",
+                selectedSort === "updated"
+                  ? "text-[var(--color-text-primary)]"
+                  : "text-[var(--color-text-muted)]",
+              )}
+            >
+              <span>Updated</span>
+              <SortIndicator
+                active={selectedSort === "updated"}
+                direction={selectedDirection}
+              />
+            </Link>
+          </div>
+        </div>
+
+        <div className="divide-y divide-[var(--color-hairline)]">
+          {displayRows.map((row) => {
+            const isSelected = selectedRowId === row.key
+            const isEditing = editingRowId === row.key
+
+            return (
+              <MediaAssetTableRowItem
+                key={row.key}
+                row={row}
+                tableStyle={tableStyle}
+                selected={isSelected}
+                editing={isEditing}
+                editingContentRef={editingContentRef}
+                editingError={isEditing ? editingError : null}
+                isPending={isPending}
+                onSelect={() => selectRow(row)}
+                onStartEditing={() => startEditingRow(row)}
+                onEditingNameChange={setEditingName}
+                onSubmitEditing={submitEditingRow}
+                onCancelEditing={cancelEditingRow}
+              />
+            )
+          })}
+
+          {rows.length === 0 ? emptyState : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/media-folder-inspector.tsx
+++ b/apps/admin/src/app/dashboard/media/media-folder-inspector.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import type { Route } from "next"
+import { useRouter } from "next/navigation"
+import { useEffect, useState, useTransition } from "react"
+import { Folder, FolderTree, Trash2, X } from "lucide-react"
+import Link from "next/link"
+import { cx } from "@/components/admin-ui"
+import { ConfirmModal } from "@/components/confirm-modal"
+import { ToastStack, useToastStack } from "@/components/toast-stack"
+
+type DeleteFolderActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type MediaFolderInspectorProps = {
+  folder: {
+    id: string
+    label: string
+    pathLabel: string
+    parentLabel: string
+    directAssetCount: number
+    childFolderCount: number
+  }
+  closeHref: Route
+  afterDeleteHref: Route
+  canDeleteFolder: boolean
+  onDeleteFolder: (formData: FormData) => Promise<DeleteFolderActionResult>
+}
+
+export function MediaFolderInspector({
+  folder,
+  closeHref,
+  afterDeleteHref,
+  canDeleteFolder,
+  onDeleteFolder,
+}: MediaFolderInspectorProps) {
+  const router = useRouter()
+  const [isDeletePending, startDeleteTransition] = useTransition()
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const { toasts, pushToast, dismissToast } = useToastStack()
+  const canDeleteEmptyFolder =
+    canDeleteFolder &&
+    folder.directAssetCount === 0 &&
+    folder.childFolderCount === 0
+
+  useEffect(() => {
+    if (!canDeleteEmptyFolder || deleteDialogOpen || isDeletePending) {
+      return
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Delete" && event.key !== "Backspace") {
+        return
+      }
+
+      const target = event.target
+      if (
+        target instanceof HTMLElement &&
+        target.closest("button,input,textarea,select,a,[contenteditable=true]")
+      ) {
+        return
+      }
+
+      event.preventDefault()
+      setDeleteDialogOpen(true)
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [canDeleteEmptyFolder, deleteDialogOpen, isDeletePending])
+
+  function deleteFolder() {
+    if (!canDeleteEmptyFolder || isDeletePending) {
+      return
+    }
+
+    const formData = new FormData()
+    formData.set("id", folder.id)
+
+    startDeleteTransition(async () => {
+      const result = await onDeleteFolder(formData)
+
+      if (!result.ok) {
+        pushToast(result.message, "error")
+        setDeleteDialogOpen(false)
+        return
+      }
+
+      setDeleteDialogOpen(false)
+      pushToast("Folder deleted.", "success")
+      router.push(afterDeleteHref)
+      router.refresh()
+    })
+  }
+
+  return (
+    <aside className="relative flex min-h-0 flex-col border-l border-[var(--color-hairline)] bg-[var(--color-surface-raised)]">
+      <div className="hairline-strong-b flex items-start justify-between gap-3 px-4 py-3">
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-medium text-[var(--color-text-primary)]">
+            {folder.label}
+          </div>
+          <div className="mono-meta mt-1 truncate text-[var(--color-text-muted)]">
+            {folder.pathLabel}
+          </div>
+        </div>
+        <Link
+          href={closeHref}
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface)] hover:text-[var(--color-text-primary)]"
+          aria-label="Close folder inspector"
+        >
+          <X className="h-4 w-4" strokeWidth={1.5} />
+        </Link>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3">
+        <div className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] p-3">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--color-text-primary)]">
+            <Folder className="h-4 w-4" strokeWidth={1.5} />
+            Folder details
+          </div>
+          <div className="mt-3 grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-3 gap-y-2 text-[12px]">
+            <div className="label-text">Parent</div>
+            <div className="truncate text-[var(--color-text-secondary)]">
+              {folder.parentLabel}
+            </div>
+            <div className="label-text">Assets</div>
+            <div className="truncate text-[var(--color-text-secondary)]">
+              {folder.directAssetCount}
+            </div>
+            <div className="label-text">Child folders</div>
+            <div className="truncate text-[var(--color-text-secondary)]">
+              {folder.childFolderCount}
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] p-3">
+          <div className="flex items-start gap-3">
+            <FolderTree
+              className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-text-muted)]"
+              strokeWidth={1.5}
+            />
+            <div className="min-w-0 text-[12px] leading-5 text-[var(--color-text-muted)]">
+              Folder counts only include assets directly inside this folder.
+              Assets in child folders stay with those child folders.
+            </div>
+          </div>
+        </div>
+
+        {canDeleteFolder ? (
+          <div className="grid gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-[13px] font-medium text-[var(--color-text-primary)]">
+                  Delete folder
+                </div>
+                <div className="mt-1 text-[12px] leading-5 text-[var(--color-text-muted)]">
+                  {canDeleteEmptyFolder
+                    ? "Empty folders can be permanently deleted."
+                    : "Move or delete contained assets and child folders first."}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDeleteDialogOpen(true)}
+                disabled={!canDeleteEmptyFolder || isDeletePending}
+                className={cx(
+                  "inline-flex h-8 shrink-0 cursor-pointer items-center gap-2 rounded-sm border px-3 text-[13px] font-medium transition-all duration-[120ms] ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-danger)] focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-55",
+                  "border-[var(--color-hairline)] text-[var(--color-danger)] hover:bg-[var(--color-surface-raised)]",
+                )}
+              >
+                <Trash2 className="h-4 w-4" strokeWidth={1.5} />
+                {isDeletePending ? "Deleting..." : "Delete"}
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <ConfirmModal
+        open={deleteDialogOpen}
+        title="Delete This Folder?"
+        description={`This will permanently delete ${folder.label}. This cannot be undone.`}
+        confirmLabel="Delete Folder"
+        pending={isDeletePending}
+        onCancel={() => setDeleteDialogOpen(false)}
+        onConfirm={deleteFolder}
+      />
+      <ToastStack toasts={toasts} onDismiss={dismissToast} />
+    </aside>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/media-library-dnd-provider.tsx
+++ b/apps/admin/src/app/dashboard/media/media-library-dnd-provider.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import type { ComponentProps } from "react"
+import { DndContext, PointerSensor, useSensor, useSensors } from "@dnd-kit/core"
+import {
+  MEDIA_LIBRARY_DND_ID,
+  mediaLibraryCollisionDetection,
+} from "@/app/dashboard/media/media-library-dnd"
+
+type DndContextChildren = ComponentProps<typeof DndContext>["children"]
+
+export function MediaLibraryDndProvider({
+  children,
+}: {
+  children: DndContextChildren
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 4,
+      },
+    }),
+  )
+
+  return (
+    <DndContext
+      id={MEDIA_LIBRARY_DND_ID}
+      sensors={sensors}
+      collisionDetection={mediaLibraryCollisionDetection}
+    >
+      {children}
+    </DndContext>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/media-library-dnd.ts
+++ b/apps/admin/src/app/dashboard/media/media-library-dnd.ts
@@ -1,0 +1,80 @@
+import {
+  pointerWithin,
+  type CollisionDetection,
+  type DataRef,
+} from "@dnd-kit/core"
+
+export const MEDIA_LIBRARY_DND_ID = "media-library"
+
+export type MediaLibraryFolderDragData = {
+  type: "folder"
+  folderId: string
+}
+
+export type MediaLibraryAssetDragData = {
+  type: "asset"
+  assetId: string
+  title: string
+  folderId: string | null
+}
+
+type DragDataRecord = Record<string, unknown>
+
+function isDragDataRecord(value: unknown): value is DragDataRecord {
+  return typeof value === "object" && value !== null
+}
+
+export function getFolderDragData(dataRef: DataRef<unknown> | undefined) {
+  const value = dataRef?.current
+  if (!isDragDataRecord(value)) {
+    return null
+  }
+
+  if (value.type !== "folder" || typeof value.folderId !== "string") {
+    return null
+  }
+
+  return value as MediaLibraryFolderDragData
+}
+
+export function getAssetDragData(dataRef: DataRef<unknown> | undefined) {
+  const value = dataRef?.current
+  if (!isDragDataRecord(value)) {
+    return null
+  }
+
+  if (
+    value.type !== "asset" ||
+    typeof value.assetId !== "string" ||
+    typeof value.title !== "string" ||
+    (value.folderId !== null && typeof value.folderId !== "string")
+  ) {
+    return null
+  }
+
+  return value as MediaLibraryAssetDragData
+}
+
+export const mediaLibraryCollisionDetection: CollisionDetection = (args) => {
+  const activeId = String(args.active.id)
+  const pointerCollisions = pointerWithin(args).filter(
+    (collision) => String(collision.id) !== activeId,
+  )
+  const nonRootPointerCollisions = pointerCollisions.filter(
+    (collision) => collision.id !== "root",
+  )
+
+  if (nonRootPointerCollisions.length > 0) {
+    return nonRootPointerCollisions
+  }
+
+  const rootPointerCollision = pointerCollisions.find(
+    (collision) => collision.id === "root",
+  )
+
+  if (rootPointerCollision) {
+    return [rootPointerCollision]
+  }
+
+  return []
+}

--- a/apps/admin/src/app/dashboard/media/media-library-toolbar.tsx
+++ b/apps/admin/src/app/dashboard/media/media-library-toolbar.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import type { Route } from "next"
+import { Check, ChevronDown, Folder, Search } from "lucide-react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { cx } from "@/components/admin-ui"
+
+type SupportedMediaKind = "IMAGE" | "VIDEO" | "PDF" | "FILE"
+
+type ToolbarProps = {
+  queryText: string
+  selectedType: "all" | SupportedMediaKind
+}
+
+const TYPE_OPTIONS: Array<{
+  value: "all" | SupportedMediaKind
+  label: string
+}> = [
+  { value: "all", label: "All types" },
+  { value: "IMAGE", label: "Images" },
+  { value: "VIDEO", label: "Videos" },
+  { value: "PDF", label: "PDFs" },
+  { value: "FILE", label: "Files" },
+]
+
+export function MediaLibraryToolbar({ queryText, selectedType }: ToolbarProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [searchValue, setSearchValue] = useState(queryText)
+
+  const selectedTypeLabel = useMemo(
+    () =>
+      TYPE_OPTIONS.find((option) => option.value === selectedType)?.label ??
+      "All types",
+    [selectedType],
+  )
+
+  useEffect(() => {
+    setSearchValue(queryText)
+  }, [queryText])
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return
+    }
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setMenuOpen(false)
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown)
+    document.addEventListener("keydown", handleEscape)
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown)
+      document.removeEventListener("keydown", handleEscape)
+    }
+  }, [menuOpen])
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      const currentQuery = searchParams.get("q") ?? ""
+      const nextQuery = searchValue.trim()
+
+      if (currentQuery === nextQuery) {
+        return
+      }
+
+      const nextParams = new URLSearchParams(searchParams.toString())
+      nextParams.delete("asset")
+      if (nextQuery.length > 0) {
+        nextParams.set("q", nextQuery)
+      } else {
+        nextParams.delete("q")
+      }
+
+      const suffix = nextParams.toString()
+      router.replace(`${pathname}${suffix ? `?${suffix}` : ""}` as Route)
+    }, 200)
+
+    return () => window.clearTimeout(timeout)
+  }, [pathname, router, searchParams, searchValue])
+
+  function applyTypeFilter(nextType: "all" | SupportedMediaKind) {
+    const nextParams = new URLSearchParams(searchParams.toString())
+    nextParams.delete("asset")
+    if (nextType === "all") {
+      nextParams.delete("type")
+    } else {
+      nextParams.set("type", nextType)
+    }
+
+    const suffix = nextParams.toString()
+    router.replace(`${pathname}${suffix ? `?${suffix}` : ""}` as Route)
+    setMenuOpen(false)
+  }
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-3">
+      <div className="min-w-0 shrink-0">
+        <div className="flex items-center gap-2">
+          <Folder
+            className="h-4 w-4 text-[var(--color-text-muted)]"
+            strokeWidth={1.5}
+          />
+          <span className="truncate text-[13px] font-medium text-[var(--color-text-primary)]">
+            Media Library
+          </span>
+        </div>
+      </div>
+
+      <div className="flex min-w-0 max-w-xl flex-1 items-center gap-2">
+        <label className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3">
+          <Search
+            className="h-4 w-4 shrink-0 text-[var(--color-text-muted)]"
+            strokeWidth={1.5}
+          />
+          <input
+            type="search"
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+            placeholder="Search assets"
+            className="w-full border-0 bg-transparent text-[13px] text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-muted)]"
+          />
+        </label>
+
+        <div ref={menuRef} className="relative shrink-0">
+          <button
+            type="button"
+            onClick={() => setMenuOpen((open) => !open)}
+            className="inline-flex h-8 items-center gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 text-[12px] text-[var(--color-text-primary)] transition-colors duration-[120ms] ease-out hover:bg-[var(--color-surface)]"
+            aria-expanded={menuOpen}
+            aria-haspopup="menu"
+          >
+            {selectedTypeLabel}
+            <ChevronDown className="h-3.5 w-3.5" strokeWidth={1.5} />
+          </button>
+
+          {menuOpen ? (
+            <div
+              className="absolute right-0 z-30 mt-2 grid min-w-36 gap-1 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] p-1 shadow-[0_18px_50px_rgba(0,0,0,0.45)]"
+              role="menu"
+            >
+              {TYPE_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => applyTypeFilter(option.value)}
+                  className={cx(
+                    "inline-flex h-8 items-center justify-between gap-3 rounded-[2px] px-3 text-left text-[12px] transition-colors duration-[120ms] ease-out",
+                    selectedType === option.value
+                      ? "bg-[var(--color-surface-raised)] text-[var(--color-text-primary)]"
+                      : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]",
+                  )}
+                  role="menuitemradio"
+                  aria-checked={selectedType === option.value}
+                >
+                  <span>{option.label}</span>
+                  <Check
+                    className={cx(
+                      "h-3.5 w-3.5",
+                      selectedType === option.value
+                        ? "opacity-100"
+                        : "opacity-0",
+                    )}
+                    strokeWidth={1.5}
+                  />
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/media/page.tsx
+++ b/apps/admin/src/app/dashboard/media/page.tsx
@@ -1,97 +1,1177 @@
-import { Image } from "lucide-react"
-import {
-  DashboardPageHeader,
-  DataTable,
-  InsightGrid,
-  OperatorRail,
-  PageSection,
-} from "@/components/admin-ui"
-import { getAdminMessages } from "@/i18n/server"
+import { Buffer } from "node:buffer"
+import { revalidatePath } from "next/cache"
+import type { Route } from "next"
+import Link from "next/link"
+import { Fragment } from "react"
+import { Upload } from "lucide-react"
+import { cx } from "@/components/admin-ui"
+import { MediaAssetDropTarget } from "@/app/dashboard/media/media-asset-drop-target"
+import { MediaAssetInspector } from "@/app/dashboard/media/media-asset-inspector"
+import { MediaActions } from "@/app/dashboard/media/media-actions"
+import { MediaAssetTable } from "@/app/dashboard/media/media-asset-table"
+import { MediaFolderInspector } from "@/app/dashboard/media/media-folder-inspector"
+import { MediaLibraryDndProvider } from "@/app/dashboard/media/media-library-dnd-provider"
+import { MediaFolderTree } from "@/app/dashboard/media/folder-tree"
+import { MediaLibraryToolbar } from "@/app/dashboard/media/media-library-toolbar"
+import { hasPermission } from "@/auth/permissions"
+import { requireSession } from "@/auth/session"
+import { prisma } from "@/db/client"
 import { loadMediaData } from "@/app/dashboard/ops-data"
+import { createServices } from "@/services"
+import { ForbiddenError } from "@/services/errors"
+import {
+  mediaAssetDownloadUrl,
+  mediaAssetPreviewUrl,
+  MediaAssetValidationError,
+} from "@/services/media-asset.service"
+import {
+  defaultBackend,
+  safeMediaFilename,
+  writeMediaObject,
+} from "@/storage/media"
+import { MediaFolderValidationError } from "@/services/media-folder.service"
 
-export default async function MediaPage() {
-  const messages = await getAdminMessages()
-  const page = messages.pages.media
-  const data = await loadMediaData()
+type CreateFolderActionResult =
+  | { ok: true; id: string }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type RenameFolderActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type RenameAssetActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type MoveAssetActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type UpdateAssetMetadataActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type DeleteAssetActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type DeleteFolderActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      error: "forbidden" | "validation" | "unknown"
+      message: string
+    }
+
+type MediaPageProps = {
+  searchParams?: Promise<{
+    folder?: string
+    asset?: string
+    q?: string
+    type?: string
+    sort?: string
+    dir?: string
+  }>
+}
+
+type SupportedMediaKind = "IMAGE" | "VIDEO" | "PDF" | "FILE"
+type MediaSortField = "name" | "size" | "updated"
+type SortDirection = "asc" | "desc"
+const mediaNameCollator = new Intl.Collator("en", {
+  sensitivity: "base",
+  numeric: true,
+})
+
+function mediaKindForMimeType(mimeType: string): SupportedMediaKind {
+  if (mimeType.startsWith("image/")) return "IMAGE"
+  if (mimeType.startsWith("video/")) return "VIDEO"
+  if (mimeType === "application/pdf") return "PDF"
+  return "FILE"
+}
+
+function uploadedFile(value: FormDataEntryValue | null) {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "arrayBuffer" in value &&
+    "size" in value &&
+    "name" in value &&
+    "type" in value
+  ) {
+    return value as File
+  }
+
+  return null
+}
+
+function defaultDirectionForSort(sort: MediaSortField): SortDirection {
+  return sort === "name" ? "asc" : "desc"
+}
+
+function mediaSupplementalLabel(
+  displayName: string,
+  originalFilename: string | null,
+  mimeType: string,
+) {
+  if (!originalFilename) {
+    return mimeType
+  }
+
+  const normalizedDisplayName = displayName.trim().toLowerCase()
+  const normalizedFilename = originalFilename.trim().toLowerCase()
+  const normalizedFilenameStem = normalizedFilename.replace(/\.[^.]+$/, "")
+
+  if (
+    normalizedDisplayName === normalizedFilename ||
+    normalizedDisplayName === normalizedFilenameStem
+  ) {
+    return ""
+  }
+
+  return originalFilename
+}
+
+function mediaLibraryQueryString(values: {
+  folder?: string | null
+  asset?: string | null
+  q?: string
+  type?: "all" | SupportedMediaKind
+  sort?: MediaSortField
+  direction?: SortDirection
+}) {
+  const query = new URLSearchParams()
+  if (values.folder) {
+    query.set("folder", values.folder)
+  }
+  if (values.asset) {
+    query.set("asset", values.asset)
+  }
+  if (values.q?.trim()) {
+    query.set("q", values.q.trim())
+  }
+  if (values.type && values.type !== "all") {
+    query.set("type", values.type)
+  }
+  if (
+    values.sort &&
+    (values.sort !== "name" || (values.direction ?? "asc") !== "asc")
+  ) {
+    query.set("sort", values.sort)
+    query.set("dir", values.direction ?? defaultDirectionForSort(values.sort))
+  }
+  return query.toString()
+}
+
+function compareNullableBigInt(left: bigint | null, right: bigint | null) {
+  if (left == null && right == null) {
+    return 0
+  }
+  if (left == null) {
+    return 1
+  }
+  if (right == null) {
+    return -1
+  }
+  if (left < right) {
+    return -1
+  }
+  if (left > right) {
+    return 1
+  }
+  return 0
+}
+
+function compareMediaRowsByName(
+  left: { title: string; detail: string },
+  right: { title: string; detail: string },
+) {
+  const byTitle = mediaNameCollator.compare(left.title, right.title)
+  if (byTitle !== 0) {
+    return byTitle
+  }
+
+  return mediaNameCollator.compare(left.detail, right.detail)
+}
+
+function compareMediaRows(
+  left: {
+    title: string
+    detail: string
+    byteSizeValue: bigint | null
+    updatedAtValue: Date
+  },
+  right: {
+    title: string
+    detail: string
+    byteSizeValue: bigint | null
+    updatedAtValue: Date
+  },
+  sort: MediaSortField,
+  direction: SortDirection,
+) {
+  const directionMultiplier = direction === "asc" ? 1 : -1
+
+  const comparison =
+    sort === "size"
+      ? compareNullableBigInt(left.byteSizeValue, right.byteSizeValue)
+      : sort === "updated"
+        ? left.updatedAtValue.getTime() - right.updatedAtValue.getTime()
+        : compareMediaRowsByName(left, right)
+
+  if (comparison !== 0) {
+    return comparison * directionMultiplier
+  }
+
+  return compareMediaRowsByName(left, right)
+}
+
+async function performRenameMediaFolder(
+  formData: FormData,
+): Promise<RenameFolderActionResult> {
+  const user = await requireSession()
+  const services = createServices(prisma)
+  const id = String(formData.get("id") ?? "").trim()
+  const name = String(formData.get("name") ?? "").trim()
+
+  if (!id || !name) {
+    return {
+      ok: false as const,
+      error: "validation" as const,
+      message: "Name the folder before renaming it.",
+    }
+  }
+
+  try {
+    await services.mediaFolder.update({
+      input: { id, name },
+      user,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return {
+        ok: false as const,
+        error: "forbidden" as const,
+        message: "Your account cannot rename media folders.",
+      }
+    }
+
+    if (error instanceof MediaFolderValidationError) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: error.message,
+      }
+    }
+
+    return {
+      ok: false as const,
+      error: "unknown" as const,
+      message: "We couldn't rename that folder just now.",
+    }
+  }
+
+  revalidatePath("/dashboard/media")
+  return { ok: true as const }
+}
+
+async function performRenameMediaAsset(
+  formData: FormData,
+): Promise<RenameAssetActionResult> {
+  const user = await requireSession()
+  const services = createServices(prisma)
+  const id = String(formData.get("id") ?? "").trim()
+  const displayName = String(formData.get("displayName") ?? "").trim()
+
+  if (!id || !displayName) {
+    return {
+      ok: false as const,
+      error: "validation" as const,
+      message: "Name the file before renaming it.",
+    }
+  }
+
+  try {
+    await services.mediaAsset.update({
+      input: { id, displayName },
+      user,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return {
+        ok: false as const,
+        error: "forbidden" as const,
+        message: "Your account cannot rename media assets.",
+      }
+    }
+
+    if (error instanceof MediaAssetValidationError) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: error.message,
+      }
+    }
+
+    return {
+      ok: false as const,
+      error: "unknown" as const,
+      message: "We couldn't rename that file just now.",
+    }
+  }
+
+  revalidatePath("/dashboard/media")
+  return { ok: true as const }
+}
+
+async function performUpdateMediaAssetMetadata(
+  formData: FormData,
+): Promise<UpdateAssetMetadataActionResult> {
+  const user = await requireSession()
+  const services = createServices(prisma)
+  const id = String(formData.get("id") ?? "").trim()
+  const displayName = String(formData.get("displayName") ?? "").trim()
+  const description = String(formData.get("description") ?? "").trim()
+  const altText = String(formData.get("altText") ?? "").trim()
+
+  if (!id || !displayName) {
+    return {
+      ok: false as const,
+      error: "validation" as const,
+      message: "Name the file before saving.",
+    }
+  }
+
+  try {
+    await services.mediaAsset.update({
+      input: {
+        id,
+        displayName,
+        description: description || null,
+        altText: altText || null,
+      },
+      user,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return {
+        ok: false as const,
+        error: "forbidden" as const,
+        message: "Your account cannot edit media metadata.",
+      }
+    }
+
+    if (error instanceof MediaAssetValidationError) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: error.message,
+      }
+    }
+
+    return {
+      ok: false as const,
+      error: "unknown" as const,
+      message: "We couldn't save those asset details just now.",
+    }
+  }
+
+  revalidatePath("/dashboard/media")
+  return { ok: true as const }
+}
+
+async function performDeleteMediaAsset(
+  formData: FormData,
+): Promise<DeleteAssetActionResult> {
+  const user = await requireSession()
+  const services = createServices(prisma)
+  const id = String(formData.get("id") ?? "").trim()
+
+  if (!id) {
+    return {
+      ok: false as const,
+      error: "validation" as const,
+      message: "Choose a file before deleting it.",
+    }
+  }
+
+  try {
+    await services.mediaAsset.delete({ id, user })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return {
+        ok: false as const,
+        error: "forbidden" as const,
+        message: "Your account cannot delete media assets.",
+      }
+    }
+
+    if (error instanceof MediaAssetValidationError) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: error.message,
+      }
+    }
+
+    return {
+      ok: false as const,
+      error: "unknown" as const,
+      message: "We couldn't delete that asset just now.",
+    }
+  }
+
+  revalidatePath("/dashboard/media")
+  return { ok: true as const }
+}
+
+async function performDeleteMediaFolder(
+  formData: FormData,
+): Promise<DeleteFolderActionResult> {
+  const user = await requireSession()
+  const services = createServices(prisma)
+  const id = String(formData.get("id") ?? "").trim()
+
+  if (!id) {
+    return {
+      ok: false as const,
+      error: "validation" as const,
+      message: "Choose a folder before deleting it.",
+    }
+  }
+
+  try {
+    await services.mediaFolder.delete({
+      input: { id },
+      user,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return {
+        ok: false as const,
+        error: "forbidden" as const,
+        message: "Your account cannot delete media folders.",
+      }
+    }
+
+    if (error instanceof MediaFolderValidationError) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: error.message,
+      }
+    }
+
+    return {
+      ok: false as const,
+      error: "unknown" as const,
+      message: "We couldn't delete that folder just now.",
+    }
+  }
+
+  revalidatePath("/dashboard/media")
+  return { ok: true as const }
+}
+
+function formatDateTime(value: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(value)
+}
+
+export default async function MediaPage({ searchParams }: MediaPageProps) {
+  const principal = await requireSession()
+  const params = (await searchParams) ?? {}
+  const services = createServices(prisma)
+  const canUpload = hasPermission(principal, "write:media-assets")
+  const data = await loadMediaData(principal)
+  const folderById = new Map(data.folders.map((folder) => [folder.id, folder]))
+  const selectedFolderValue =
+    params.folder && folderById.has(params.folder) ? params.folder : null
+  const selectedFolder = selectedFolderValue
+    ? (folderById.get(selectedFolderValue) ?? null)
+    : null
+  const queryText = params.q?.trim() ?? ""
+  const normalizedQuery = queryText.toLowerCase()
+  const selectedType: "all" | SupportedMediaKind =
+    params.type === "IMAGE" ||
+    params.type === "VIDEO" ||
+    params.type === "PDF" ||
+    params.type === "FILE"
+      ? params.type
+      : "all"
+  const selectedSort: MediaSortField =
+    params.sort === "size" || params.sort === "updated" ? params.sort : "name"
+  const selectedDirection: SortDirection =
+    params.dir === "asc" || params.dir === "desc"
+      ? params.dir
+      : defaultDirectionForSort(selectedSort)
+  const isSearching = normalizedQuery.length > 0
+  const rootFolderLabel = "Library"
+  function folderPathLabel(folderId: string | null) {
+    if (!folderId) {
+      return rootFolderLabel
+    }
+
+    const segments: string[] = []
+    let currentFolderId: string | null = folderId
+
+    while (currentFolderId) {
+      const folder = folderById.get(currentFolderId)
+      if (!folder) {
+        break
+      }
+
+      segments.unshift(folder.label)
+      currentFolderId = folder.parentId
+    }
+
+    return [rootFolderLabel, ...segments].join(" / ")
+  }
+
+  function folderHref(folderId: string | null) {
+    const query = mediaLibraryQueryString({
+      folder: folderId,
+      q: queryText,
+      type: selectedType,
+      sort: selectedSort,
+      direction: selectedDirection,
+    })
+
+    return `/dashboard/media${query ? `?${query}` : ""}` as Route
+  }
+  const currentPathSegments = (() => {
+    if (!selectedFolder) {
+      return [{ label: rootFolderLabel, href: folderHref(null) }]
+    }
+
+    const segments = [
+      { label: selectedFolder.label, href: folderHref(selectedFolder.id) },
+    ]
+    let currentParentId = selectedFolder.parentId
+
+    while (currentParentId) {
+      const parent = folderById.get(currentParentId)
+      if (!parent) {
+        break
+      }
+
+      segments.unshift({
+        label: parent.label,
+        href: folderHref(parent.id),
+      })
+      currentParentId = parent.parentId
+    }
+
+    return [{ label: rootFolderLabel, href: folderHref(null) }, ...segments]
+  })()
+  const searchableFolderIds = (() => {
+    if (!selectedFolderValue) {
+      return null
+    }
+
+    const next = new Set<string>([selectedFolderValue])
+    const queue = [selectedFolderValue]
+
+    while (queue.length > 0) {
+      const folderId = queue.shift()
+      if (!folderId) {
+        continue
+      }
+
+      for (const folder of data.folders) {
+        if (folder.parentId === folderId && !next.has(folder.id)) {
+          next.add(folder.id)
+          queue.push(folder.id)
+        }
+      }
+    }
+
+    return next
+  })()
+
+  const visibleRows = data.rows
+    .filter((row) => {
+      if (isSearching) {
+        if (!searchableFolderIds) {
+          return true
+        }
+
+        return row.folderId != null && searchableFolderIds.has(row.folderId)
+      }
+
+      if (!selectedFolderValue) {
+        return row.folderId == null
+      }
+      return row.folderId === selectedFolderValue
+    })
+    .filter((row) => {
+      const matchesType = selectedType === "all" || row.kind === selectedType
+      const matchesQuery =
+        normalizedQuery.length === 0 ||
+        row.title.toLowerCase().includes(normalizedQuery) ||
+        row.detail.toLowerCase().includes(normalizedQuery) ||
+        row.meta.toLowerCase().includes(normalizedQuery)
+      return matchesType && matchesQuery
+    })
+    .sort((left, right) =>
+      compareMediaRows(left, right, selectedSort, selectedDirection),
+    )
+
+  const selectedAssetKey = params.asset?.trim() || null
+  const selectedRow =
+    selectedAssetKey == null
+      ? null
+      : (visibleRows.find((row) => row.key === selectedAssetKey) ?? null)
+  const selectedAsset = selectedRow
+    ? await services.mediaAsset.getById({
+        id: selectedRow.key,
+        user: principal,
+        query: {},
+      })
+    : null
+  const selectedUsage = selectedAsset
+    ? await services.mediaAsset.usage({ id: selectedAsset.id, user: principal })
+    : []
+  const selectedAssetSupplementalLabel = selectedAsset
+    ? mediaSupplementalLabel(
+        selectedAsset.displayName,
+        selectedAsset.originalFilename,
+        selectedAsset.mimeType,
+      )
+    : ""
+  const selectedAssetFolderLabel = selectedAsset
+    ? folderPathLabel(selectedAsset.folderId)
+    : rootFolderLabel
+  const dropTargetLabel = selectedFolder?.label ?? rootFolderLabel
+  const canEditMetadata = hasPermission(principal, "write:media-assets")
+  const canDeleteAsset = hasPermission(principal, "delete:media-assets")
+  const canDeleteFolder = hasPermission(principal, "delete:media-assets")
+  const mediaLibraryBaseQuery = mediaLibraryQueryString({
+    folder: selectedFolderValue,
+    q: queryText,
+    type: selectedType,
+    sort: selectedSort,
+    direction: selectedDirection,
+  })
+  const closeInspectorHref = `/dashboard/media${
+    mediaLibraryBaseQuery ? `?${mediaLibraryBaseQuery}` : ""
+  }` as Route
+  const closeFolderInspectorQuery = mediaLibraryQueryString({
+    q: queryText,
+    type: selectedType,
+    sort: selectedSort,
+    direction: selectedDirection,
+  })
+  const closeFolderInspectorHref = `/dashboard/media${
+    closeFolderInspectorQuery ? `?${closeFolderInspectorQuery}` : ""
+  }` as Route
+
+  function sortHref(field: MediaSortField) {
+    const next =
+      field === selectedSort
+        ? {
+            sort: field,
+            direction:
+              selectedDirection === "asc"
+                ? ("desc" as const)
+                : ("asc" as const),
+          }
+        : {
+            sort: field,
+            direction: defaultDirectionForSort(field),
+          }
+    const query = mediaLibraryQueryString({
+      folder: selectedFolderValue,
+      asset: selectedAsset?.id ?? null,
+      q: queryText,
+      type: selectedType,
+      sort: next.sort,
+      direction: next.direction,
+    })
+
+    return `/dashboard/media${query ? `?${query}` : ""}` as Route
+  }
+
+  const sortHrefs = {
+    name: sortHref("name"),
+    size: sortHref("size"),
+    updated: sortHref("updated"),
+  } as const
+
+  const tableRows = visibleRows.map((row) => {
+    const isOutsideCurrentDirectory = row.folderId !== selectedFolderValue
+
+    return {
+      key: row.key,
+      title: row.title,
+      detail:
+        isSearching && isOutsideCurrentDirectory
+          ? folderPathLabel(row.folderId)
+          : row.detail,
+      detailHref:
+        isSearching && isOutsideCurrentDirectory
+          ? folderHref(row.folderId)
+          : undefined,
+      kind: row.kind,
+      folderId: row.folderId,
+      previewUrl: row.previewUrl,
+      byteSize: row.byteSize,
+      updatedLabel: row.meta,
+      href: `/dashboard/media?${mediaLibraryQueryString({
+        folder: selectedFolderValue,
+        asset: row.key,
+        q: queryText,
+        type: selectedType,
+        sort: selectedSort,
+        direction: selectedDirection,
+      })}` as Route,
+      selected: selectedAsset?.id === row.key,
+    }
+  })
+
+  async function uploadMediaAssetAction(formData: FormData) {
+    "use server"
+
+    const user = await requireSession()
+    const services = createServices(prisma)
+    if (!hasPermission(user, "write:media-assets")) {
+      return { ok: false as const, error: "forbidden" as const }
+    }
+
+    const file = uploadedFile(formData.get("file"))
+    if (!file || file.size === 0) {
+      return { ok: false as const, error: "missing-file" as const }
+    }
+
+    const folderId = String(formData.get("folderId") ?? "").trim()
+    const backend = defaultBackend()
+    const displayName =
+      String(formData.get("displayName") ?? "").trim() || file.name
+    const altText = String(formData.get("altText") ?? "").trim()
+    const kind = mediaKindForMimeType(file.type)
+
+    try {
+      const asset = await services.mediaAsset.create({
+        input: {
+          kind,
+          backend,
+          status: "UPLOADING",
+          displayName,
+          altText: altText || undefined,
+          mimeType: file.type || "application/octet-stream",
+          byteSize: file.size.toString(),
+          originalFilename: file.name,
+          ...(folderId ? { folderId } : {}),
+        },
+        user,
+      })
+      const filename = safeMediaFilename(file.name)
+      const key = await writeMediaObject({
+        backend,
+        assetId: asset.id,
+        filename,
+        body: Buffer.from(await file.arrayBuffer()),
+        contentType: file.type || undefined,
+      })
+
+      await services.mediaAsset.update({
+        input: {
+          id: asset.id,
+          status: "READY",
+          objectKey: key,
+          ...(folderId ? { folderId } : {}),
+        },
+        user,
+      })
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        return { ok: false as const, error: "forbidden" as const }
+      }
+      return { ok: false as const, error: "unknown" as const }
+    }
+
+    revalidatePath("/dashboard/media")
+    return { ok: true as const }
+  }
+
+  async function createMediaFolderAction(
+    formData: FormData,
+  ): Promise<CreateFolderActionResult> {
+    "use server"
+
+    const user = await requireSession()
+    const services = createServices(prisma)
+    const name = String(formData.get("name") ?? "").trim()
+    const parentId = String(formData.get("parentId") ?? "").trim()
+
+    if (!name) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: "Name the folder before creating it.",
+      }
+    }
+
+    try {
+      const folder = await services.mediaFolder.create({
+        input: {
+          name,
+          ...(parentId ? { parentId } : {}),
+        },
+        user,
+      })
+      revalidatePath("/dashboard/media")
+      return { ok: true as const, id: folder.id }
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        return {
+          ok: false as const,
+          error: "forbidden" as const,
+          message: "Your account cannot create media folders.",
+        }
+      }
+
+      if (error instanceof MediaFolderValidationError) {
+        return {
+          ok: false as const,
+          error: "validation" as const,
+          message: error.message,
+        }
+      }
+
+      return {
+        ok: false as const,
+        error: "unknown" as const,
+        message: "We couldn't create that folder just now.",
+      }
+    }
+  }
+
+  async function renameMediaFolderAction(
+    formData: FormData,
+  ): Promise<RenameFolderActionResult> {
+    "use server"
+
+    return performRenameMediaFolder(formData)
+  }
+
+  async function renameMediaAssetAction(
+    formData: FormData,
+  ): Promise<RenameAssetActionResult> {
+    "use server"
+
+    return performRenameMediaAsset(formData)
+  }
+
+  async function moveMediaAssetAction(
+    formData: FormData,
+  ): Promise<MoveAssetActionResult> {
+    "use server"
+
+    const user = await requireSession()
+    const services = createServices(prisma)
+    const id = String(formData.get("id") ?? "").trim()
+    const folderId = String(formData.get("folderId") ?? "").trim()
+
+    if (!id) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: "Choose a file before moving it.",
+      }
+    }
+
+    try {
+      await services.mediaAsset.update({
+        input: {
+          id,
+          folderId: folderId || null,
+        },
+        user,
+      })
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        return {
+          ok: false as const,
+          error: "forbidden" as const,
+          message: "Your account cannot reorganize media files.",
+        }
+      }
+
+      if (error instanceof MediaAssetValidationError) {
+        return {
+          ok: false as const,
+          error: "validation" as const,
+          message: error.message,
+        }
+      }
+
+      return {
+        ok: false as const,
+        error: "unknown" as const,
+        message: "We couldn't move that file just now.",
+      }
+    }
+
+    revalidatePath("/dashboard/media")
+    return { ok: true as const }
+  }
+
+  async function updateMediaAssetMetadataAction(
+    formData: FormData,
+  ): Promise<UpdateAssetMetadataActionResult> {
+    "use server"
+
+    return performUpdateMediaAssetMetadata(formData)
+  }
+
+  async function deleteMediaAssetAction(
+    formData: FormData,
+  ): Promise<DeleteAssetActionResult> {
+    "use server"
+
+    return performDeleteMediaAsset(formData)
+  }
+
+  async function deleteMediaFolderAction(
+    formData: FormData,
+  ): Promise<DeleteFolderActionResult> {
+    "use server"
+
+    return performDeleteMediaFolder(formData)
+  }
+
+  async function moveMediaFolderAction(formData: FormData) {
+    "use server"
+
+    const user = await requireSession()
+    const services = createServices(prisma)
+    const id = String(formData.get("id") ?? "").trim()
+    const parentId = String(formData.get("parentId") ?? "").trim()
+
+    if (!id) {
+      return {
+        ok: false as const,
+        error: "validation" as const,
+        message: "Choose a folder before moving it.",
+      }
+    }
+
+    try {
+      await services.mediaFolder.update({
+        input: {
+          id,
+          parentId: parentId || null,
+        },
+        user,
+      })
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        return {
+          ok: false as const,
+          error: "forbidden" as const,
+          message: "Your account cannot reorganize media folders.",
+        }
+      }
+
+      if (error instanceof MediaFolderValidationError) {
+        return {
+          ok: false as const,
+          error: "validation" as const,
+          message: error.message,
+        }
+      }
+
+      throw error
+    }
+
+    revalidatePath("/dashboard/media")
+    return { ok: true as const }
+  }
 
   return (
-    <div className="flex flex-col gap-6">
-      <DashboardPageHeader
-        eyebrow={page.eyebrow}
-        title={page.title}
-        description={page.description}
-      />
-
-      <div className="grid gap-4 md:grid-cols-3">
-        {data.metrics.map((card) => (
-          <div key={card.label} className="app-card flex flex-col gap-2 p-4">
-            <span className="label-text">{card.label}</span>
-            <span className="font-mono text-xl font-medium">{card.value}</span>
-            <span className="font-mono text-[10px] uppercase text-[var(--color-text-muted)]">
-              {card.footer}
-            </span>
-          </div>
-        ))}
-      </div>
-
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(340px,0.75fr)]">
-        <div className="flex flex-col gap-6">
-          <PageSection
-            title="Recent Media Rows"
-            meta="IMAGES / DOWNLOADS / SUBTITLES"
-          >
-            <DataTable
-              columns={["Asset", "State", "Updated"]}
-              rows={data.rows.map((row) => [
-                <div key={`${row.key}-title`}>
-                  <div className="text-[13px] font-medium">{row.title}</div>
-                  <div className="mono-meta text-[var(--color-text-muted)]">
-                    {row.detail}
-                  </div>
-                </div>,
-                <span
-                  key={`${row.key}-status`}
-                  className={`status-pill ${
-                    row.statusTone === "success"
-                      ? "text-[var(--color-success)] border-[var(--color-success-border)]"
-                      : "text-[var(--color-warning)] border-[var(--color-warning-border)]"
-                  }`}
-                >
-                  {row.statusLabel}
-                </span>,
-                <span
-                  key={`${row.key}-meta`}
-                  className="mono-meta text-[var(--color-text-muted)]"
-                >
-                  {row.meta}
-                </span>,
-              ])}
-            />
-          </PageSection>
-
-          <PageSection title="Asset Signals" meta="LIBRARY_POSTURE">
-            <div className="p-4">
-              <InsightGrid
-                items={data.insights.map((item) => ({
-                  ...item,
-                  icon: Image,
-                }))}
-              />
-            </div>
-          </PageSection>
-        </div>
-
-        <OperatorRail
-          title={messages.common.operatorNotes}
-          meta={messages.common.fieldGuide}
-          notes="This route now inspects persisted media-adjacent rows in the admin database rather than pointing at a future asset library concept."
-          chips={[
-            { label: "Source", value: "VIDEO_MEDIA_ROWS" },
-            { label: "Mode", value: "READ_ONLY_CATALOG" },
-            { label: "Surface", value: "MEDIA_OPERATIONS" },
-          ]}
+    <div className="flex min-h-[calc(100vh-3rem)] flex-col">
+      <div className="hairline-strong-b flex items-center justify-between gap-4 px-4 py-3">
+        <MediaLibraryToolbar
+          queryText={queryText}
+          selectedType={selectedType}
+        />
+        <MediaActions
+          canUpload={canUpload}
+          uploadAction={uploadMediaAssetAction}
+          selectedFolderId={selectedFolder?.id ?? null}
+          selectedFolderLabel={dropTargetLabel}
         />
       </div>
+
+      <MediaLibraryDndProvider>
+        <div
+          className={cx(
+            "grid min-h-0 flex-1",
+            selectedAsset || selectedFolder
+              ? "xl:grid-cols-[260px_minmax(0,1fr)_minmax(320px,380px)]"
+              : "xl:grid-cols-[260px_minmax(0,1fr)]",
+          )}
+        >
+          <aside className="flex min-h-0 flex-col border-r border-[var(--color-hairline)] bg-[var(--color-surface-raised)]">
+            <MediaFolderTree
+              folders={data.folders}
+              selectedFolderId={selectedFolder?.id ?? null}
+              queryText={queryText}
+              selectedType={selectedType}
+              selectedSort={selectedSort}
+              selectedDirection={selectedDirection}
+              onCreateFolder={createMediaFolderAction}
+              onRenameFolder={renameMediaFolderAction}
+              onMoveFolder={moveMediaFolderAction}
+              onMoveAsset={moveMediaAssetAction}
+            />
+          </aside>
+
+          <section className="flex min-h-0 flex-col">
+            <div className="flex items-center gap-2 border-b border-[var(--color-hairline)] px-4 py-2">
+              {currentPathSegments.map((segment, index) => (
+                <Fragment key={`${segment.href}-${index}`}>
+                  {index > 0 ? (
+                    <span className="mono-meta text-[var(--color-text-muted)]">
+                      /
+                    </span>
+                  ) : null}
+                  <Link
+                    href={segment.href}
+                    aria-current={
+                      index === currentPathSegments.length - 1
+                        ? "page"
+                        : undefined
+                    }
+                    className={cx(
+                      "truncate rounded-[2px] text-[12px] transition-colors duration-[120ms] ease-out hover:text-[var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-brand)] focus-visible:ring-inset",
+                      index === currentPathSegments.length - 1
+                        ? "font-medium text-[var(--color-text-primary)]"
+                        : "text-[var(--color-text-muted)]",
+                    )}
+                  >
+                    {segment.label}
+                  </Link>
+                </Fragment>
+              ))}
+            </div>
+
+            <MediaAssetDropTarget
+              canUpload={canUpload}
+              uploadAction={uploadMediaAssetAction}
+              selectedFolderId={selectedFolder?.id ?? null}
+              selectedFolderLabel={dropTargetLabel}
+            >
+              <MediaAssetTable
+                rows={tableRows}
+                selectedSort={selectedSort}
+                selectedDirection={selectedDirection}
+                sortHrefs={sortHrefs}
+                onRenameAsset={renameMediaAssetAction}
+                emptyState={
+                  <div className="flex min-h-[320px] items-center justify-center px-6 py-10">
+                    <div className="grid max-w-md justify-items-center gap-3 text-center">
+                      <div className="flex h-11 w-11 items-center justify-center rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] text-[var(--color-text-muted)]">
+                        <Upload className="h-5 w-5" strokeWidth={1.5} />
+                      </div>
+                      <div className="text-[14px] font-medium text-[var(--color-text-primary)]">
+                        {canUpload
+                          ? `Drop files here to upload to ${dropTargetLabel}`
+                          : "No assets match this view yet"}
+                      </div>
+                      <div className="max-w-sm text-[13px] leading-6 text-[var(--color-text-muted)]">
+                        {queryText || selectedType !== "all"
+                          ? selectedFolder && isSearching
+                            ? "Nothing in this folder or its subfolders matches the current search or type filter."
+                            : "Nothing in this library view matches the current search or type filter."
+                          : selectedFolder
+                            ? "This folder is empty right now."
+                            : "This library folder is empty right now."}
+                        {canUpload
+                          ? " You can drag files into this area or use the Upload button."
+                          : ""}
+                      </div>
+                    </div>
+                  </div>
+                }
+              />
+            </MediaAssetDropTarget>
+          </section>
+
+          {selectedAsset ? (
+            <MediaAssetInspector
+              key={`${selectedAsset.id}:${selectedAsset.updatedAt.toISOString()}`}
+              asset={{
+                id: selectedAsset.id,
+                kind: selectedAsset.kind,
+                displayName: selectedAsset.displayName,
+                description: selectedAsset.description,
+                altText: selectedAsset.altText,
+                folderLabel: selectedAssetFolderLabel,
+                originalFilename: selectedAsset.originalFilename,
+                supplementalLabel: selectedAssetSupplementalLabel,
+                backend: selectedAsset.backend,
+                updatedAtIso: selectedAsset.updatedAt.toISOString(),
+                updatedAtLabel: formatDateTime(selectedAsset.updatedAt),
+                width: selectedAsset.width,
+                height: selectedAsset.height,
+                previewUrl: mediaAssetPreviewUrl(selectedAsset),
+                downloadUrl: mediaAssetDownloadUrl(selectedAsset),
+              }}
+              closeHref={closeInspectorHref}
+              usage={selectedUsage}
+              canEditMetadata={canEditMetadata}
+              canDeleteAsset={canDeleteAsset}
+              onUpdateAsset={updateMediaAssetMetadataAction}
+              onDeleteAsset={deleteMediaAssetAction}
+            />
+          ) : selectedFolder ? (
+            <MediaFolderInspector
+              key={selectedFolder.id}
+              folder={{
+                id: selectedFolder.id,
+                label: selectedFolder.label,
+                pathLabel: folderPathLabel(selectedFolder.id),
+                parentLabel: folderPathLabel(selectedFolder.parentId),
+                directAssetCount: selectedFolder.directAssetCount,
+                childFolderCount: selectedFolder.childFolderCount,
+              }}
+              closeHref={closeFolderInspectorHref}
+              afterDeleteHref={folderHref(selectedFolder.parentId)}
+              canDeleteFolder={canDeleteFolder}
+              onDeleteFolder={deleteMediaFolderAction}
+            />
+          ) : null}
+        </div>
+      </MediaLibraryDndProvider>
     </div>
   )
 }

--- a/apps/admin/src/app/dashboard/ops-data.ts
+++ b/apps/admin/src/app/dashboard/ops-data.ts
@@ -1,10 +1,19 @@
-import { Prisma, type LocaleStatus } from "@prisma/client"
+import {
+  Prisma,
+  type LocaleStatus,
+  type MediaAssetKind,
+  type MediaAssetStatus,
+} from "@prisma/client"
 import type { Principal } from "@/auth/principal"
 import { env } from "@/config/env"
 import { prisma } from "@/db/client"
 import { createServices } from "@/services"
 import { generateExperienceEmbedding } from "@/services/embeddings.service"
 import { getAllWatermarks } from "@/services/core-sync/watermark"
+import {
+  mediaAssetDownloadUrl,
+  mediaAssetPreviewUrl,
+} from "@/services/media-asset.service"
 import { loadWorkflowRuntimeRuns } from "@/services/workflow-runtime.service"
 import { loadWorkflowWorkerStatusRows } from "@/services/workflow-worker-heartbeat.service"
 
@@ -101,8 +110,33 @@ type LanguagesData = {
 
 type MediaData = {
   metrics: Metric[]
-  rows: TableRow[]
+  folders: MediaFolderRow[]
+  rows: MediaAssetTableRow[]
   insights: Insight[]
+  totalCount: number
+  unfiledCount: number
+}
+
+export type MediaFolderRow = {
+  id: string
+  label: string
+  count: number
+  directAssetCount: number
+  childFolderCount: number
+  parentId: string | null
+  depth: number
+}
+
+type MediaAssetTableRow = TableRow & {
+  kind: MediaAssetKind
+  folderId: string | null
+  backend: string
+  byteSize: string
+  byteSizeValue: bigint | null
+  dimensions: string
+  previewUrl: string | null
+  downloadUrl: string | null
+  updatedAtValue: Date
 }
 
 type UsersData = {
@@ -232,6 +266,37 @@ function statusToneForWorkflowStatus(
   return "muted"
 }
 
+function statusToneForMediaAsset(
+  status: MediaAssetStatus,
+): "success" | "warning" | "danger" | "info" | "muted" {
+  if (status === "READY") return "success"
+  if (status === "FAILED" || status === "MISSING") return "danger"
+  if (status === "PROCESSING" || status === "UPLOADING") return "info"
+  return "warning"
+}
+
+function formatBytes(value: bigint | null) {
+  if (value == null) return "N/A"
+  const bytes = Number(value)
+  if (!Number.isFinite(bytes)) return value.toString()
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+function mediaDimensions(row: {
+  width: number | null
+  height: number | null
+  durationMs: bigint | null
+}) {
+  if (row.width && row.height) return `${row.width}x${row.height}`
+  if (row.durationMs != null) return `${Number(row.durationMs / 1000n)}s`
+  return "N/A"
+}
+
 function workflowStatusBucket(status: string) {
   const normalized = status.toLowerCase()
   if (normalized === "running" || normalized === "queued") return "active"
@@ -323,6 +388,29 @@ async function getSyncRows() {
     () => getAllWatermarks(prisma),
     [] as SyncWatermarkRow[],
   )
+}
+
+function mediaSupplementalLabel(
+  displayName: string,
+  originalFilename: string | null,
+  mimeType: string,
+) {
+  if (!originalFilename) {
+    return mimeType
+  }
+
+  const normalizedDisplayName = displayName.trim().toLowerCase()
+  const normalizedFilename = originalFilename.trim().toLowerCase()
+  const normalizedFilenameStem = normalizedFilename.replace(/\.[^.]+$/, "")
+
+  if (
+    normalizedDisplayName === normalizedFilename ||
+    normalizedDisplayName === normalizedFilenameStem
+  ) {
+    return ""
+  }
+
+  return originalFilename
 }
 
 async function getWorkflowRunRows(limit = 5) {
@@ -1086,75 +1174,161 @@ export async function loadLanguagesData(): Promise<LanguagesData> {
   }
 }
 
-export async function loadMediaData(): Promise<MediaData> {
-  const [images, downloads, subtitles, rows] = await Promise.all([
-    withTableFallback(() => prisma.videoImage.count(), 0),
-    withTableFallback(() => prisma.videoDubDownload.count(), 0),
-    withTableFallback(() => prisma.videoSubtitle.count(), 0),
-    withTableFallback(
-      () =>
-        prisma.videoImage.findMany({
-          select: {
-            id: true,
-            kind: true,
-            url: true,
-            blurhash: true,
-            updatedAt: true,
-            video: { select: { slug: true } },
-          },
-          orderBy: { updatedAt: "desc" },
-          take: 8,
-        }),
-      [] as Array<{
-        id: string
-        kind: string | null
-        url: string | null
-        blurhash: string | null
-        updatedAt: Date
-        video: { slug: string } | null
-      }>,
-    ),
-  ])
+export async function loadMediaData(principal: Principal): Promise<MediaData> {
+  const services = createServices(prisma)
+  const [total, images, videos, pdfs, processing, rows, folders, folderCounts] =
+    await Promise.all([
+      withTableFallback(() => prisma.mediaAsset.count(), 0),
+      withTableFallback(
+        () => prisma.mediaAsset.count({ where: { kind: "IMAGE" } }),
+        0,
+      ),
+      withTableFallback(
+        () => prisma.mediaAsset.count({ where: { kind: "VIDEO" } }),
+        0,
+      ),
+      withTableFallback(
+        () => prisma.mediaAsset.count({ where: { kind: "PDF" } }),
+        0,
+      ),
+      withTableFallback(
+        () =>
+          prisma.mediaAsset.count({
+            where: { status: { in: ["PENDING", "UPLOADING", "PROCESSING"] } },
+          }),
+        0,
+      ),
+      withTableFallback(
+        () =>
+          services.mediaAsset.list({
+            input: { limit: 120, offset: 0 },
+            user: principal,
+            query: {},
+          }),
+        [] as Awaited<ReturnType<typeof services.mediaAsset.list>>,
+      ),
+      withTableFallback(
+        () =>
+          services.mediaFolder.list({
+            input: {},
+            user: principal,
+            query: {},
+          }),
+        [] as Awaited<ReturnType<typeof services.mediaFolder.list>>,
+      ),
+      withTableFallback(
+        () =>
+          prisma.mediaAsset.groupBy({
+            by: ["folderId"],
+            _count: { _all: true },
+          }),
+        [] as Array<{
+          folderId: string | null
+          _count: { _all: number }
+        }>,
+      ),
+    ])
+
+  const directFolderCount = new Map<string | null, number>()
+  for (const row of folderCounts) {
+    directFolderCount.set(row.folderId, row._count._all)
+  }
+
+  const foldersByParent = new Map<string | null, typeof folders>()
+  for (const folder of folders) {
+    const siblings = foldersByParent.get(folder.parentId) ?? []
+    siblings.push(folder)
+    foldersByParent.set(folder.parentId, siblings)
+  }
+
+  const flattenedFolders: MediaFolderRow[] = []
+
+  function visit(parentId: string | null, depth: number): number {
+    const siblings = foldersByParent.get(parentId) ?? []
+    let branchCount = 0
+
+    for (const folder of siblings) {
+      const ownCount = directFolderCount.get(folder.id) ?? 0
+      const childFolders = foldersByParent.get(folder.id) ?? []
+      flattenedFolders.push({
+        id: folder.id,
+        label: folder.name,
+        count: ownCount,
+        directAssetCount: ownCount,
+        childFolderCount: childFolders.length,
+        parentId: folder.parentId,
+        depth,
+      })
+      const childCount = visit(folder.id, depth + 1)
+      const totalCount = ownCount + childCount
+      branchCount += totalCount
+    }
+
+    return branchCount
+  }
+
+  visit(null, 0)
+  const unfiledCount = directFolderCount.get(null) ?? 0
 
   return {
     metrics: [
-      { label: "Images", value: images.toString(), footer: "VIDEO_IMAGES" },
       {
-        label: "Downloads",
-        value: downloads.toString(),
-        footer: "DUB_ARTIFACTS",
+        label: "Assets",
+        value: total.toString(),
+        footer: "MEDIA_ASSET_ROWS",
       },
       {
-        label: "Subtitles",
-        value: subtitles.toString(),
-        footer: "TEXT_TRACKS",
+        label: "Images",
+        value: images.toString(),
+        footer: "IMAGE_LIBRARY",
+      },
+      {
+        label: "Processing",
+        value: processing.toString(),
+        footer: "ACTIVE_UPLOADS",
       },
     ],
+    folders: flattenedFolders,
     rows: rows.map((row) => ({
       key: row.id,
-      title: row.kind ?? "video-image",
-      detail: row.video?.slug ?? row.url ?? row.id,
-      statusLabel: row.blurhash ? "Ready" : "Review",
-      statusTone: row.blurhash ? "success" : "warning",
+      title: row.displayName,
+      detail: mediaSupplementalLabel(
+        row.displayName,
+        row.originalFilename,
+        row.mimeType,
+      ),
+      statusLabel: row.status,
+      statusTone: statusToneForMediaAsset(row.status),
       meta: formatDateTime(row.updatedAt),
+      kind: row.kind,
+      folderId: row.folderId ?? null,
+      backend: row.backend,
+      byteSize: formatBytes(row.byteSize),
+      byteSizeValue: row.byteSize,
+      dimensions: mediaDimensions(row),
+      previewUrl: mediaAssetPreviewUrl(row),
+      downloadUrl: mediaAssetDownloadUrl(row),
+      updatedAtValue: row.updatedAt,
     })),
     insights: [
       {
-        label: "Image Catalog",
+        label: "Image Assets",
         value: images.toString(),
-        detail: "Persisted image rows associated with synced videos.",
+        detail: "Reusable image files registered in the admin media library.",
       },
       {
-        label: "Download Artifacts",
-        value: downloads.toString(),
-        detail: "Quality-tier downloads currently attached to video dubs.",
+        label: "Video Assets",
+        value: videos.toString(),
+        detail: "Video placeholders ready for the future Mux storage backend.",
       },
       {
-        label: "Subtitle Tracks",
-        value: subtitles.toString(),
-        detail: "Timed-text resources available across video editions.",
+        label: "PDF Assets",
+        value: pdfs.toString(),
+        detail: "Document uploads tracked by the generic asset model.",
       },
     ],
+    totalCount: total,
+    unfiledCount,
   }
 }
 

--- a/apps/admin/src/auth/permissions.test.ts
+++ b/apps/admin/src/auth/permissions.test.ts
@@ -58,14 +58,18 @@ describe("hasPermission — tier-based gate", () => {
       { key: "read:reference", role: "PUBLIC", expected: true },
       { key: "read:experiences", role: "PUBLIC", expected: false },
       { key: "read:videos", role: "PUBLIC", expected: false },
+      { key: "read:media-assets", role: "PUBLIC", expected: false },
       { key: "write:experiences", role: "PUBLIC", expected: false },
+      { key: "write:media-assets", role: "PUBLIC", expected: false },
       { key: "admin:all", role: "PUBLIC", expected: false },
 
       // VIEWER reach
       { key: "read:reference", role: "VIEWER", expected: true },
       { key: "read:experiences", role: "VIEWER", expected: true },
       { key: "read:videos", role: "VIEWER", expected: true },
+      { key: "read:media-assets", role: "VIEWER", expected: false },
       { key: "write:experiences", role: "VIEWER", expected: false },
+      { key: "write:media-assets", role: "VIEWER", expected: false },
       { key: "publish:experiences", role: "VIEWER", expected: false },
 
       // EDITOR reach
@@ -73,6 +77,9 @@ describe("hasPermission — tier-based gate", () => {
       { key: "write:experiences", role: "EDITOR", expected: true },
       { key: "publish:experiences", role: "EDITOR", expected: true },
       { key: "archive:experiences", role: "EDITOR", expected: true },
+      { key: "read:media-assets", role: "EDITOR", expected: true },
+      { key: "write:media-assets", role: "EDITOR", expected: true },
+      { key: "delete:media-assets", role: "EDITOR", expected: false },
       { key: "write:videos", role: "EDITOR", expected: false },
       { key: "system:trigger-workflow", role: "EDITOR", expected: false },
       { key: "admin:all", role: "EDITOR", expected: false },
@@ -81,6 +88,9 @@ describe("hasPermission — tier-based gate", () => {
       { key: "read:experiences", role: "ADMIN", expected: true },
       { key: "write:experiences", role: "ADMIN", expected: true },
       { key: "write:videos", role: "ADMIN", expected: true },
+      { key: "read:media-assets", role: "ADMIN", expected: true },
+      { key: "write:media-assets", role: "ADMIN", expected: true },
+      { key: "delete:media-assets", role: "ADMIN", expected: true },
       { key: "publish:experiences", role: "ADMIN", expected: true },
       { key: "system:trigger-workflow", role: "ADMIN", expected: true },
       { key: "admin:all", role: "ADMIN", expected: true },
@@ -94,6 +104,8 @@ describe("hasPermission — tier-based gate", () => {
       // SYSTEM is workflow-only — never satisfies editorial gates.
       { key: "read:experiences", role: "SYSTEM", expected: false },
       { key: "write:experiences", role: "SYSTEM", expected: false },
+      { key: "read:media-assets", role: "SYSTEM", expected: false },
+      { key: "write:media-assets", role: "SYSTEM", expected: false },
       { key: "system:write-derived", role: "SYSTEM", expected: true },
       { key: "system:trigger-workflow", role: "SYSTEM", expected: false },
     ]
@@ -330,10 +342,14 @@ describe("permission matrix completeness", () => {
       "read:experiences",
       "read:videos",
       "read:reference",
+      "read:media-assets",
       "write:experiences",
       "write:videos",
+      "write:media-assets",
       "write:scene-embeddings",
       "write:transcript-embeddings",
+      "write:experience-content-dump",
+      "delete:media-assets",
       "publish:experiences",
       "archive:experiences",
       "system:trigger-workflow",
@@ -363,6 +379,15 @@ describe("permission matrix completeness", () => {
     // SYSTEM does not satisfy editorial write gates (intentional; the
     // indexer's canWriteDerived is the SYSTEM-reachable path).
     expect(hasPermission(SYSTEM, "write:transcript-embeddings")).toBe(false)
+  })
+
+  it("media asset write is EDITOR+, but delete is ADMIN-only", () => {
+    expect(hasPermission(EDITOR_ALICE, "read:media-assets")).toBe(true)
+    expect(hasPermission(EDITOR_ALICE, "write:media-assets")).toBe(true)
+    expect(hasPermission(EDITOR_ALICE, "delete:media-assets")).toBe(false)
+    expect(hasPermission(ADMIN, "delete:media-assets")).toBe(true)
+    expect(hasPermission(VIEWER, "read:media-assets")).toBe(false)
+    expect(hasPermission(PUBLIC_USER, "read:media-assets")).toBe(false)
   })
 
   describe("WORKFLOW_TRIGGER (service-account, plan 006)", () => {
@@ -398,11 +423,14 @@ describe("permission matrix completeness", () => {
         "read:experiences": true,
         "read:videos": true,
         "read:reference": true,
+        "read:media-assets": true,
         "write:experiences": true,
         "write:videos": true,
+        "write:media-assets": true,
         "write:scene-embeddings": true,
         "write:transcript-embeddings": true,
         "write:experience-content-dump": true,
+        "delete:media-assets": true,
         "publish:experiences": true,
         "archive:experiences": true,
         "system:trigger-workflow": true,

--- a/apps/admin/src/auth/permissions.ts
+++ b/apps/admin/src/auth/permissions.ts
@@ -42,16 +42,19 @@ export type PermissionKey =
   // Read scopes
   | "read:experiences"
   | "read:videos"
+  | "read:media-assets"
   | "read:reference"
   // Write scopes (admin-write on Core-sourced is intentionally restricted)
   | "write:experiences"
   | "write:videos"
+  | "write:media-assets"
   | "write:scene-embeddings"
   | "write:transcript-embeddings"
   | "write:experience-content-dump"
   // Lifecycle scopes (publish / archive ExperienceLocale, etc.)
   | "publish:experiences"
   | "archive:experiences"
+  | "delete:media-assets"
   // Workflow / system scopes
   | "system:trigger-workflow"
   | "system:write-derived"
@@ -70,12 +73,14 @@ const permissionMatrix: Record<PermissionKey, MinTier> = {
   // narrow to "is the entity actually published?" or "do I own this draft?"
   "read:experiences": "VIEWER",
   "read:videos": "VIEWER",
+  "read:media-assets": "EDITOR",
   // Reference data is public-shape; PUBLIC may read.
   "read:reference": "PUBLIC",
   // Editor writes
   "write:experiences": "EDITOR",
   // Core-sourced; only ADMIN may override (also flips source='manager').
   "write:videos": "ADMIN",
+  "write:media-assets": "EDITOR",
   // Derived-column trigger (scene-embedding backfill). ADMIN-only.
   "write:scene-embeddings": "ADMIN",
   // Derived-column trigger (transcript-embedding backfill). ADMIN-only.
@@ -87,6 +92,7 @@ const permissionMatrix: Record<PermissionKey, MinTier> = {
   // Lifecycle
   "publish:experiences": "EDITOR",
   "archive:experiences": "EDITOR",
+  "delete:media-assets": "ADMIN",
   // System / workflow
   "system:trigger-workflow": "ADMIN",
   "system:write-derived": "SYSTEM",

--- a/apps/admin/src/components/admin-shell.tsx
+++ b/apps/admin/src/components/admin-shell.tsx
@@ -51,8 +51,9 @@ export function AdminShell({
   const [isSwitchingLocale, setIsSwitchingLocale] = useState(false)
   const activeItem = getNavItem(pathname)
   const isFullCanvasRoute =
-    pathname.startsWith("/dashboard/experiences/") &&
-    pathname !== "/dashboard/experiences"
+    (pathname.startsWith("/dashboard/experiences/") &&
+      pathname !== "/dashboard/experiences") ||
+    pathname.startsWith("/dashboard/media")
   const visibleNavItems = adminNavItems.filter((item) =>
     isNavItemVisible(principal.role, item),
   )

--- a/apps/admin/src/domain/blocks.test.ts
+++ b/apps/admin/src/domain/blocks.test.ts
@@ -466,6 +466,40 @@ describe("BlocksSchema", () => {
     expect(BlocksSchema.safeParse(input).success).toBe(true)
   })
 
+  it("accepts canonical media asset ids beside transitional URL fields", () => {
+    const input = [
+      {
+        t: "section",
+        backgroundImageUrl: "https://example.com/section.jpg",
+        backgroundImageAssetId: "asset-section",
+        content: [
+          {
+            t: "card",
+            title: "A",
+            description: "B",
+            mediaUrl: "https://example.com/card.jpg",
+            mediaAssetId: "asset-card",
+          },
+          {
+            t: "mediaCollection",
+            variant: "grid",
+            itemsSource: "manual",
+            imageUrl: "https://example.com/collection.jpg",
+            imageAssetId: "asset-collection",
+            items: [
+              {
+                imageOverrideUrl: "https://example.com/item.jpg",
+                imageOverrideAssetId: "asset-item",
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    expect(BlocksSchema.safeParse(input).success).toBe(true)
+  })
+
   it("rejects if any single block is invalid", () => {
     const input = [
       { t: "text", heading: "ok" },

--- a/apps/admin/src/domain/blocks.ts
+++ b/apps/admin/src/domain/blocks.ts
@@ -40,6 +40,7 @@ const sectionKey = z.string().min(1).max(200).optional()
 
 /** Explicit union of Strapi heading levels so downstream renderers are narrow. */
 const headingLevel = z.enum(["h1", "h2", "h3", "h4", "h5", "h6"])
+const assetId = z.string().min(1).optional()
 
 // -----------------------------------------------------------------------------
 // Leaf components (embedded inside blocks; not top-level)
@@ -51,11 +52,13 @@ export const BibleQuoteItemSchema = z
     reference: z.string().min(1),
     text: z.string().min(1),
     backgroundImageUrl: z.string().url().optional(),
+    backgroundImageAssetId: assetId,
     ctaEnabled: z.boolean().optional(),
     ctaLabel: z.string().optional(),
     ctaLink: z.string().optional(),
     attribution: z.string().optional(),
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
   })
   .strict()
@@ -75,11 +78,13 @@ export const MediaCollectionItemSchema = z
     /** Reference to a Video row by id (resolved on read). */
     videoId: z.string().optional(),
     imageOverrideUrl: z.string().url().optional(),
+    imageOverrideAssetId: assetId,
     titleOverride: z.string().optional(),
     subtitleOverride: z.string().optional(),
     labelOverride: z.string().optional(),
     collectionSize: z.string().optional(),
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     linkToSectionKey: z.string().optional(),
   })
   .strict()
@@ -91,6 +96,7 @@ export const NavigationCarouselItemSchema = z
     title: z.string().min(1),
     category: z.string().optional(),
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
   })
   .strict()
@@ -110,7 +116,9 @@ export const VideoCarouselItemSchema = z
     videoId: z.string().optional(),
     streamingUrl: z.string().optional(),
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     imageOverrideUrl: z.string().url().optional(),
+    imageOverrideAssetId: assetId,
     titleOverride: z.string().optional(),
     subtitleOverride: z.string().optional(),
     backgroundColor: z.string().optional(),
@@ -126,6 +134,7 @@ export const AdventCountdownBlockSchema = z
     t: z.literal("adventCountdown"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     title: z.string().min(1),
     scripture: z.string().optional(),
@@ -139,6 +148,7 @@ export const BibleQuotesCarouselBlockSchema = z
     t: z.literal("bibleQuotesCarousel"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     heading: z.string().optional(),
     quotes: z.array(BibleQuoteItemSchema).default([]),
@@ -152,6 +162,7 @@ export const CardBlockSchema = z
     title: z.string().min(1),
     description: z.string().min(1),
     mediaUrl: z.string().url().optional(),
+    mediaAssetId: assetId,
     backgroundColor: z.string().optional(),
     link: z.string().optional(),
     variant: z.enum(["default", "featured"]).default("default"),
@@ -163,6 +174,7 @@ export const CtaBlockSchema = z
     t: z.literal("cta"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     heading: z.string().optional(),
     body: z.string().optional(),
@@ -177,6 +189,7 @@ export const EasterDatesBlockSchema = z
     t: z.literal("easterDates"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     easterDatesTitle: z.string().min(1),
     westernEasterLabel: z.string().min(1),
@@ -194,6 +207,7 @@ export const InfoBlocksBlockSchema = z
     t: z.literal("infoBlocks"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     widthPercent: z.number().int().min(1).max(100).optional(),
     intro: z.string().optional(),
@@ -208,6 +222,7 @@ export const MediaCollectionBlockSchema = z
     t: z.literal("mediaCollection"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     categoryLabel: z.string().optional(),
     variant: z.enum(["carousel", "grid", "collection", "hero", "player"]),
@@ -228,6 +243,7 @@ export const NavigationCarouselBlockSchema = z
     t: z.literal("navigationCarousel"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     items: z.array(NavigationCarouselItemSchema).default([]),
   })
@@ -238,6 +254,7 @@ export const PromoBannerBlockSchema = z
     t: z.literal("promoBanner"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     widthPercent: z.number().int().min(1).max(100).optional(),
     intro: z.string().optional(),
@@ -270,6 +287,7 @@ export const RelatedQuestionsBlockSchema = z
     t: z.literal("relatedQuestions"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     heading: z.string().optional(),
     questions: z.array(RelatedQuestionItemSchema).default([]),
@@ -284,6 +302,7 @@ export const TextBlockSchema = z
     t: z.literal("text"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     heading: z.string().optional(),
     headingLevel: headingLevel.optional(),
@@ -302,6 +321,7 @@ export const VideoBlockSchema = z
     /** Reference to a Video row by id. */
     videoId: z.string().optional(),
     mediaUrl: z.string().url().optional(),
+    mediaAssetId: assetId,
     clipStartSeconds: z.number().min(0).optional(),
     clipEndSeconds: z.number().min(0).optional(),
     autoplay: z.boolean().optional(),
@@ -320,6 +340,7 @@ export const VideoCarouselBlockSchema = z
     t: z.literal("videoCarousel"),
     sectionKey,
     imageUrl: z.string().url().optional(),
+    imageAssetId: assetId,
     backgroundColor: z.string().optional(),
     itemsSource: z.enum(["manual", "routeVideoChildren"]).default("manual"),
     title: z.string().optional(),
@@ -404,6 +425,7 @@ export const ContainerSlotBlockSchema = z
     spans: ContainerSlotSpansSchema.optional(),
     backgroundColor: z.string().optional(),
     backgroundImageUrl: z.string().url().optional(),
+    backgroundImageAssetId: assetId,
   })
   .strict()
 
@@ -434,6 +456,7 @@ export const ContainerBlockSchema = z
     sectionKey,
     backgroundColor: z.string().optional(),
     backgroundImageUrl: z.string().url().optional(),
+    backgroundImageAssetId: assetId,
     content: z.array(ContainerContentBlockSchema).default([]),
     /** Legacy nested-slot payloads are tolerated so old drafts can be opened. */
     slots: z.custom<never>(() => true).optional(),
@@ -479,6 +502,7 @@ export const SectionBlockSchema = z
     sectionKey,
     backgroundColor: z.string().optional(),
     backgroundImageUrl: z.string().url().optional(),
+    backgroundImageAssetId: assetId,
     blurHash: z.string().optional(),
     backgroundOpacity: z.number().min(0).max(1).optional(),
     dynamicBackgroundImage: z.boolean().default(false),

--- a/apps/admin/src/graphql/mutations/media-asset.ts
+++ b/apps/admin/src/graphql/mutations/media-asset.ts
@@ -1,0 +1,174 @@
+// Media asset mutations. Resolvers are thin wiring; MediaAssetService owns
+// permission checks, validation, storage-shape rules, and Prisma writes.
+
+import { builder } from "@/graphql/builder"
+import {
+  MediaAssetBackendEnum,
+  MediaAssetKindEnum,
+  MediaAssetStatusEnum,
+  MediaAssetVisibilityEnum,
+} from "@/graphql/types/mediaAsset"
+
+type DeleteMediaAssetResult = {
+  deleted: boolean
+  usageCount: number
+}
+
+const DeleteMediaAssetResultRef = builder
+  .objectRef<DeleteMediaAssetResult>("DeleteMediaAssetResult")
+  .implement({
+    fields: (t) => ({
+      deleted: t.exposeBoolean("deleted"),
+      usageCount: t.exposeInt("usageCount"),
+    }),
+  })
+
+builder.mutationFields((t) => ({
+  registerMediaAsset: t.prismaField({
+    type: "MediaAsset",
+    authScopes: { hasPermission: "write:media-assets" },
+    description:
+      "Register an uploaded file in the media library after its bytes are stored.",
+    args: {
+      kind: t.arg({ type: MediaAssetKindEnum, required: true }),
+      backend: t.arg({ type: MediaAssetBackendEnum, required: false }),
+      status: t.arg({ type: MediaAssetStatusEnum, required: false }),
+      visibility: t.arg({ type: MediaAssetVisibilityEnum, required: false }),
+      displayName: t.arg.string({ required: true }),
+      description: t.arg.string({ required: false }),
+      altText: t.arg.string({ required: false }),
+      mimeType: t.arg.string({ required: true }),
+      folderId: t.arg.id({ required: false }),
+      byteSize: t.arg.string({ required: false }),
+      width: t.arg.int({ required: false }),
+      height: t.arg.int({ required: false }),
+      durationMs: t.arg.string({ required: false }),
+      originalFilename: t.arg.string({ required: false }),
+      checksumSha256: t.arg.string({ required: false }),
+      muxAssetId: t.arg.string({ required: false }),
+      muxUploadId: t.arg.string({ required: false }),
+      muxPlaybackId: t.arg.string({ required: false }),
+    },
+    resolve: (_query, _root, args, ctx) =>
+      ctx.services.mediaAsset.create({
+        input: {
+          kind: args.kind,
+          ...(args.backend != null ? { backend: args.backend } : {}),
+          ...(args.status != null ? { status: args.status } : {}),
+          ...(args.visibility != null ? { visibility: args.visibility } : {}),
+          displayName: args.displayName,
+          ...(args.description !== undefined
+            ? { description: args.description }
+            : {}),
+          ...(args.altText !== undefined ? { altText: args.altText } : {}),
+          mimeType: args.mimeType,
+          ...(args.folderId != null ? { folderId: String(args.folderId) } : {}),
+          ...(args.byteSize != null ? { byteSize: args.byteSize } : {}),
+          ...(args.width != null ? { width: args.width } : {}),
+          ...(args.height != null ? { height: args.height } : {}),
+          ...(args.durationMs != null ? { durationMs: args.durationMs } : {}),
+          ...(args.originalFilename !== undefined
+            ? { originalFilename: args.originalFilename }
+            : {}),
+          ...(args.checksumSha256 !== undefined
+            ? { checksumSha256: args.checksumSha256 }
+            : {}),
+          ...(args.muxAssetId !== undefined
+            ? { muxAssetId: args.muxAssetId }
+            : {}),
+          ...(args.muxUploadId !== undefined
+            ? { muxUploadId: args.muxUploadId }
+            : {}),
+          ...(args.muxPlaybackId !== undefined
+            ? { muxPlaybackId: args.muxPlaybackId }
+            : {}),
+        },
+        user: ctx.user,
+      }),
+  }),
+
+  updateMediaAsset: t.prismaField({
+    type: "MediaAsset",
+    authScopes: { hasPermission: "write:media-assets" },
+    description: "Update editable media asset metadata and processing state.",
+    args: {
+      id: t.arg.id({ required: true }),
+      status: t.arg({ type: MediaAssetStatusEnum, required: false }),
+      visibility: t.arg({ type: MediaAssetVisibilityEnum, required: false }),
+      displayName: t.arg.string({ required: false }),
+      description: t.arg.string({ required: false }),
+      altText: t.arg.string({ required: false }),
+      folderId: t.arg.id({ required: false }),
+      byteSize: t.arg.string({ required: false }),
+      width: t.arg.int({ required: false }),
+      height: t.arg.int({ required: false }),
+      durationMs: t.arg.string({ required: false }),
+      originalFilename: t.arg.string({ required: false }),
+      checksumSha256: t.arg.string({ required: false }),
+      muxAssetId: t.arg.string({ required: false }),
+      muxUploadId: t.arg.string({ required: false }),
+      muxPlaybackId: t.arg.string({ required: false }),
+      errorCode: t.arg.string({ required: false }),
+      errorMessage: t.arg.string({ required: false }),
+    },
+    resolve: (_query, _root, args, ctx) =>
+      ctx.services.mediaAsset.update({
+        input: {
+          id: String(args.id),
+          ...(args.status != null ? { status: args.status } : {}),
+          ...(args.visibility != null ? { visibility: args.visibility } : {}),
+          ...(args.displayName !== undefined
+            ? { displayName: args.displayName }
+            : {}),
+          ...(args.description !== undefined
+            ? { description: args.description }
+            : {}),
+          ...(args.altText !== undefined ? { altText: args.altText } : {}),
+          ...(args.folderId !== undefined
+            ? { folderId: args.folderId ? String(args.folderId) : null }
+            : {}),
+          ...(args.byteSize != null ? { byteSize: args.byteSize } : {}),
+          ...(args.width != null ? { width: args.width } : {}),
+          ...(args.height != null ? { height: args.height } : {}),
+          ...(args.durationMs != null ? { durationMs: args.durationMs } : {}),
+          ...(args.originalFilename !== undefined
+            ? { originalFilename: args.originalFilename }
+            : {}),
+          ...(args.checksumSha256 !== undefined
+            ? { checksumSha256: args.checksumSha256 }
+            : {}),
+          ...(args.muxAssetId !== undefined
+            ? { muxAssetId: args.muxAssetId }
+            : {}),
+          ...(args.muxUploadId !== undefined
+            ? { muxUploadId: args.muxUploadId }
+            : {}),
+          ...(args.muxPlaybackId !== undefined
+            ? { muxPlaybackId: args.muxPlaybackId }
+            : {}),
+          ...(args.errorCode !== undefined
+            ? { errorCode: args.errorCode }
+            : {}),
+          ...(args.errorMessage !== undefined
+            ? { errorMessage: args.errorMessage }
+            : {}),
+        },
+        user: ctx.user,
+      }),
+  }),
+
+  deleteMediaAsset: t.field({
+    type: DeleteMediaAssetResultRef,
+    authScopes: { hasPermission: "delete:media-assets" },
+    description:
+      "Delete a media asset only when no experience metadata or block fields still reference it.",
+    args: {
+      id: t.arg.id({ required: true }),
+    },
+    resolve: (_root, args, ctx) =>
+      ctx.services.mediaAsset.delete({
+        id: String(args.id),
+        user: ctx.user,
+      }),
+  }),
+}))

--- a/apps/admin/src/graphql/mutations/media-folder.ts
+++ b/apps/admin/src/graphql/mutations/media-folder.ts
@@ -1,0 +1,65 @@
+import { builder } from "@/graphql/builder"
+import type { MediaFolderDeleteResult } from "@/services/media-folder.service"
+
+const DeleteMediaFolderResultRef = builder
+  .objectRef<MediaFolderDeleteResult>("DeleteMediaFolderResult")
+  .implement({
+    fields: (t) => ({
+      deleted: t.exposeBoolean("deleted"),
+      childCount: t.exposeInt("childCount"),
+      assetCount: t.exposeInt("assetCount"),
+    }),
+  })
+
+builder.mutationFields((t) => ({
+  createMediaFolder: t.prismaField({
+    type: "MediaFolder",
+    authScopes: { hasPermission: "write:media-assets" },
+    description: "Create a media folder at the root or inside another folder.",
+    args: {
+      name: t.arg.string({ required: true }),
+      parentId: t.arg.id({ required: false }),
+    },
+    resolve: (_query, _root, args, ctx) =>
+      ctx.services.mediaFolder.create({
+        input: {
+          name: args.name,
+          ...(args.parentId != null ? { parentId: String(args.parentId) } : {}),
+        },
+        user: ctx.user,
+      }),
+  }),
+
+  updateMediaFolder: t.prismaField({
+    type: "MediaFolder",
+    authScopes: { hasPermission: "write:media-assets" },
+    description: "Rename a media folder.",
+    args: {
+      id: t.arg.id({ required: true }),
+      name: t.arg.string({ required: true }),
+    },
+    resolve: (_query, _root, args, ctx) =>
+      ctx.services.mediaFolder.update({
+        input: {
+          id: String(args.id),
+          name: args.name,
+        },
+        user: ctx.user,
+      }),
+  }),
+
+  deleteMediaFolder: t.field({
+    type: DeleteMediaFolderResultRef,
+    authScopes: { hasPermission: "delete:media-assets" },
+    description:
+      "Delete an empty media folder. Fails when child folders or assets remain.",
+    args: {
+      id: t.arg.id({ required: true }),
+    },
+    resolve: (_root, args, ctx) =>
+      ctx.services.mediaFolder.delete({
+        input: { id: String(args.id) },
+        user: ctx.user,
+      }),
+  }),
+}))

--- a/apps/admin/src/graphql/schema.test.ts
+++ b/apps/admin/src/graphql/schema.test.ts
@@ -38,6 +38,11 @@ describe("GraphQL schema — Unit 4 content types", () => {
         "languages",
         "countries",
         "keywords",
+        // Media assets
+        "mediaAsset",
+        "mediaAssets",
+        "mediaAssetUsage",
+        "mediaFolders",
         // Video
         "video",
         "videoBySlug",
@@ -61,6 +66,18 @@ describe("GraphQL schema — Unit 4 content types", () => {
     expect(mutation).toBeTruthy()
     const fields = mutation!.getFields()
     expect(fields.triggerExperienceEmbedding).toBeDefined()
+  })
+
+  it("Mutation root exposes media asset write entry points", () => {
+    const mutation = schema.getMutationType()
+    expect(mutation).toBeTruthy()
+    const fields = mutation!.getFields()
+    expect(fields.registerMediaAsset).toBeDefined()
+    expect(fields.updateMediaAsset).toBeDefined()
+    expect(fields.deleteMediaAsset).toBeDefined()
+    expect(fields.createMediaFolder).toBeDefined()
+    expect(fields.updateMediaFolder).toBeDefined()
+    expect(fields.deleteMediaFolder).toBeDefined()
   })
 
   it("Mutation root exposes the scene embedding backfill trigger", () => {
@@ -257,6 +274,49 @@ describe("Video type", () => {
   it("does NOT expose subtitles directly (they attach to VideoEdition)", () => {
     const fields = fieldsOf("Video")
     expect(fields.subtitles).toBeUndefined()
+  })
+})
+
+describe("MediaAsset type", () => {
+  it("exposes media metadata and stable app routes without raw object keys", () => {
+    const fields = fieldsOf("MediaAsset")
+    expect(Object.keys(fields)).toEqual(
+      expect.arrayContaining([
+        "id",
+        "kind",
+        "backend",
+        "status",
+        "visibility",
+        "displayName",
+        "mimeType",
+        "byteSize",
+        "previewUrl",
+        "downloadUrl",
+        "editUrl",
+        "createdById",
+      ]),
+    )
+    expect(fields.objectKey).toBeUndefined()
+    expect(fields.previewObjectKey).toBeUndefined()
+    expect(fields.muxAssetId).toBeUndefined()
+    expect(fields.muxUploadId).toBeUndefined()
+  })
+})
+
+describe("MediaAssetUsage type", () => {
+  it("exposes structured where-used references", () => {
+    const fields = fieldsOf("MediaAssetUsage")
+    expect(Object.keys(fields)).toEqual(
+      expect.arrayContaining([
+        "experienceId",
+        "experienceLocaleId",
+        "locale",
+        "location",
+        "fieldPath",
+        "fieldName",
+        "match",
+      ]),
+    )
   })
 })
 

--- a/apps/admin/src/graphql/schema.ts
+++ b/apps/admin/src/graphql/schema.ts
@@ -5,12 +5,16 @@
 
 import { builder } from "@/graphql/builder"
 // Order matters: reference types first (they define the JSON scalar used by
-// Experience), then Video, then Experience.
+// Experience), then asset/content types, then mutations.
 import "@/graphql/types/reference"
+import "@/graphql/types/mediaAsset"
+import "@/graphql/types/mediaFolder"
 import "@/graphql/types/video"
 import "@/graphql/types/videoScene"
 import "@/graphql/types/videoTranscript"
 import "@/graphql/types/experience"
+import "@/graphql/mutations/media-asset"
+import "@/graphql/mutations/media-folder"
 import "@/graphql/mutations/experience"
 import "@/graphql/mutations/scene-embedding"
 import "@/graphql/mutations/transcript-embedding"

--- a/apps/admin/src/graphql/types/mediaAsset.ts
+++ b/apps/admin/src/graphql/types/mediaAsset.ts
@@ -1,0 +1,173 @@
+// Pothos types for media assets managed by Apps admin.
+//
+// MediaAsset is `@classification abac-gated`: assets may be private, backed
+// by local/S3/Mux storage, and are editable by privileged admin principals.
+// Raw storage object keys are intentionally not exposed; clients receive
+// durable asset IDs and app routes for previews/downloads.
+
+import { builder } from "@/graphql/builder"
+import {
+  mediaAssetDownloadUrl,
+  mediaAssetPreviewUrl,
+} from "@/services/media-asset.service"
+import type { MediaAssetUsageRow } from "@/services/media-asset.usage"
+
+export const MediaAssetKindEnum = builder.enumType("MediaAssetKind", {
+  values: {
+    IMAGE: { value: "IMAGE" },
+    VIDEO: { value: "VIDEO" },
+    PDF: { value: "PDF" },
+    FILE: { value: "FILE" },
+  } as const,
+})
+
+export const MediaAssetBackendEnum = builder.enumType("MediaAssetBackend", {
+  values: {
+    LOCAL: { value: "LOCAL" },
+    S3: { value: "S3" },
+    MUX: { value: "MUX" },
+  } as const,
+})
+
+export const MediaAssetStatusEnum = builder.enumType("MediaAssetStatus", {
+  values: {
+    PENDING: { value: "PENDING" },
+    UPLOADING: { value: "UPLOADING" },
+    PROCESSING: { value: "PROCESSING" },
+    READY: { value: "READY" },
+    FAILED: { value: "FAILED" },
+    MISSING: { value: "MISSING" },
+  } as const,
+})
+
+export const MediaAssetVisibilityEnum = builder.enumType(
+  "MediaAssetVisibility",
+  {
+    values: {
+      PRIVATE: { value: "PRIVATE" },
+      PUBLIC: { value: "PUBLIC" },
+    } as const,
+  },
+)
+
+const MediaAssetUsageRef = builder
+  .objectRef<MediaAssetUsageRow>("MediaAssetUsage")
+  .implement({
+    description:
+      "A structured reference to an experience metadata or block field that uses a media asset.",
+    fields: (t) => ({
+      experienceId: t.exposeString("experienceId"),
+      experienceLocaleId: t.exposeString("experienceLocaleId"),
+      locale: t.exposeString("locale"),
+      title: t.exposeString("title", { nullable: true }),
+      location: t.exposeString("location"),
+      fieldPath: t.exposeString("fieldPath"),
+      fieldName: t.exposeString("fieldName"),
+      value: t.exposeString("value"),
+      match: t.exposeString("match"),
+    }),
+  })
+
+/** @classification abac-gated */
+builder.prismaObject("MediaAsset", {
+  description:
+    "An uploaded image, video, PDF, or file registered in the Apps admin media library.",
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    kind: t.expose("kind", { type: MediaAssetKindEnum }),
+    backend: t.expose("backend", { type: MediaAssetBackendEnum }),
+    status: t.expose("status", { type: MediaAssetStatusEnum }),
+    visibility: t.expose("visibility", { type: MediaAssetVisibilityEnum }),
+    displayName: t.exposeString("displayName"),
+    description: t.exposeString("description", { nullable: true }),
+    altText: t.exposeString("altText", { nullable: true }),
+    mimeType: t.exposeString("mimeType"),
+    byteSize: t.string({
+      nullable: true,
+      resolve: (row) => row.byteSize?.toString() ?? null,
+    }),
+    width: t.exposeInt("width", { nullable: true }),
+    height: t.exposeInt("height", { nullable: true }),
+    durationMs: t.string({
+      nullable: true,
+      resolve: (row) => row.durationMs?.toString() ?? null,
+    }),
+    originalFilename: t.exposeString("originalFilename", { nullable: true }),
+    checksumSha256: t.exposeString("checksumSha256", { nullable: true }),
+    folderId: t.exposeID("folderId", { nullable: true }),
+    previewUrl: t.string({
+      nullable: true,
+      resolve: (row) => mediaAssetPreviewUrl(row),
+    }),
+    downloadUrl: t.string({
+      nullable: true,
+      resolve: (row) => mediaAssetDownloadUrl(row),
+    }),
+    editUrl: t.string({
+      resolve: (row) => `/dashboard/media?asset=${row.id}`,
+    }),
+    createdById: t.exposeID("createdById", { nullable: true }),
+    createdAt: t.string({ resolve: (row) => row.createdAt.toISOString() }),
+    updatedAt: t.string({ resolve: (row) => row.updatedAt.toISOString() }),
+  }),
+})
+
+builder.queryFields((t) => ({
+  mediaAsset: t.prismaField({
+    type: "MediaAsset",
+    nullable: true,
+    authScopes: { hasPermission: "read:media-assets" },
+    description: "Fetch a single media asset by id.",
+    args: {
+      id: t.arg.id({ required: true }),
+    },
+    resolve: (query, _root, args, ctx) =>
+      ctx.services.mediaAsset.getById({
+        id: String(args.id),
+        user: ctx.user,
+        query,
+      }),
+  }),
+  mediaAssets: t.prismaField({
+    type: ["MediaAsset"],
+    authScopes: { hasPermission: "read:media-assets" },
+    description: "List media assets ordered by most recent update.",
+    args: {
+      kind: t.arg({ type: MediaAssetKindEnum, required: false }),
+      backend: t.arg({ type: MediaAssetBackendEnum, required: false }),
+      status: t.arg({ type: MediaAssetStatusEnum, required: false }),
+      folderId: t.arg.id({ required: false }),
+      search: t.arg.string({ required: false }),
+      limit: t.arg.int({ required: false, defaultValue: 50 }),
+      offset: t.arg.int({ required: false, defaultValue: 0 }),
+    },
+    resolve: (query, _root, args, ctx) =>
+      ctx.services.mediaAsset.list({
+        input: {
+          ...(args.kind != null ? { kind: args.kind } : {}),
+          ...(args.backend != null ? { backend: args.backend } : {}),
+          ...(args.status != null ? { status: args.status } : {}),
+          ...(args.folderId != null ? { folderId: String(args.folderId) } : {}),
+          ...(args.search != null ? { search: args.search } : {}),
+          limit: args.limit ?? 50,
+          offset: args.offset ?? 0,
+        },
+        user: ctx.user,
+        query,
+      }),
+  }),
+  mediaAssetUsage: t.field({
+    type: [MediaAssetUsageRef],
+    authScopes: { hasPermission: "read:media-assets" },
+    description:
+      "List experience metadata and block fields that currently reference a media asset.",
+    args: {
+      id: t.arg.id({ required: true }),
+    },
+    resolve: (_root, args, ctx) =>
+      ctx.services.mediaAsset.usage({
+        id: String(args.id),
+        user: ctx.user,
+      }),
+  }),
+}))

--- a/apps/admin/src/graphql/types/mediaFolder.ts
+++ b/apps/admin/src/graphql/types/mediaFolder.ts
@@ -1,0 +1,32 @@
+import { builder } from "@/graphql/builder"
+
+/** @classification abac-gated */
+builder.prismaObject("MediaFolder", {
+  description:
+    "A logical folder used to organize media assets in the Apps admin library.",
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    name: t.exposeString("name"),
+    parentId: t.exposeID("parentId", { nullable: true }),
+    createdById: t.exposeID("createdById", { nullable: true }),
+    editUrl: t.string({
+      resolve: (row) => `/dashboard/media?folder=${row.id}`,
+    }),
+    createdAt: t.string({ resolve: (row) => row.createdAt.toISOString() }),
+    updatedAt: t.string({ resolve: (row) => row.updatedAt.toISOString() }),
+  }),
+})
+
+builder.queryFields((t) => ({
+  mediaFolders: t.prismaField({
+    type: ["MediaFolder"],
+    authScopes: { hasPermission: "read:media-assets" },
+    description: "List media folders ordered for tree rendering.",
+    resolve: (query, _root, _args, ctx) =>
+      ctx.services.mediaFolder.list({
+        input: {},
+        user: ctx.user,
+        query,
+      }),
+  }),
+}))

--- a/apps/admin/src/services/index.ts
+++ b/apps/admin/src/services/index.ts
@@ -8,6 +8,8 @@
 import type { PrismaClient } from "@prisma/client"
 import { ExperienceService } from "@/services/experience.service"
 import { ExperienceSearchService } from "@/services/experience.search"
+import { MediaAssetService } from "@/services/media-asset.service"
+import { MediaFolderService } from "@/services/media-folder.service"
 import { VideoService } from "@/services/video.service"
 
 export type Services = ReturnType<typeof createServices>
@@ -16,6 +18,8 @@ export function createServices(prisma: PrismaClient) {
   return {
     experience: new ExperienceService(prisma),
     experienceSearch: new ExperienceSearchService(prisma),
+    mediaAsset: new MediaAssetService(prisma),
+    mediaFolder: new MediaFolderService(prisma),
     video: new VideoService(prisma),
   }
 }

--- a/apps/admin/src/services/media-asset.schemas.ts
+++ b/apps/admin/src/services/media-asset.schemas.ts
@@ -1,0 +1,98 @@
+// Zod input schemas for media asset service operations.
+//
+// The service owns coercion for GraphQL/agent callers so storage and Prisma
+// receive normalized enum values, BigInts, and bounded strings.
+
+import { z } from "zod"
+
+export const MediaAssetKindSchema = z.enum(["IMAGE", "VIDEO", "PDF", "FILE"])
+export const MediaAssetBackendSchema = z.enum(["LOCAL", "S3", "MUX"])
+export const MediaAssetStatusSchema = z.enum([
+  "PENDING",
+  "UPLOADING",
+  "PROCESSING",
+  "READY",
+  "FAILED",
+  "MISSING",
+])
+export const MediaAssetVisibilitySchema = z.enum(["PRIVATE", "PUBLIC"])
+
+const NullableString = z.string().max(2000).nullable().optional()
+const OptionalPositiveInt = z.number().int().positive().nullable().optional()
+const MediaObjectKey = z
+  .string()
+  .max(1024)
+  .regex(
+    /^media-assets\/[a-zA-Z0-9_-]+\/(original|preview)\/[a-zA-Z0-9][a-zA-Z0-9._-]{0,199}$/,
+    "Invalid media object key",
+  )
+  .nullable()
+  .optional()
+const OptionalBigInt = z
+  .union([
+    z.bigint(),
+    z.number().int().nonnegative(),
+    z.string().regex(/^\d+$/),
+  ])
+  .transform((value) => BigInt(value))
+  .nullable()
+  .optional()
+
+export const ListMediaAssetsInput = z.object({
+  kind: MediaAssetKindSchema.optional(),
+  backend: MediaAssetBackendSchema.optional(),
+  status: MediaAssetStatusSchema.optional(),
+  folderId: z.string().min(1).nullable().optional(),
+  search: z.string().trim().min(1).max(200).optional(),
+  limit: z.number().int().positive().max(500).optional(),
+  offset: z.number().int().nonnegative().optional(),
+})
+export type ListMediaAssetsInput = z.infer<typeof ListMediaAssetsInput>
+
+export const CreateMediaAssetInput = z.object({
+  kind: MediaAssetKindSchema,
+  backend: MediaAssetBackendSchema.default("LOCAL"),
+  status: MediaAssetStatusSchema.default("READY"),
+  visibility: MediaAssetVisibilitySchema.default("PRIVATE"),
+  displayName: z.string().trim().min(1).max(300),
+  description: NullableString,
+  altText: z.string().max(500).nullable().optional(),
+  mimeType: z.string().trim().min(1).max(255),
+  byteSize: OptionalBigInt,
+  width: OptionalPositiveInt,
+  height: OptionalPositiveInt,
+  durationMs: OptionalBigInt,
+  originalFilename: z.string().max(255).nullable().optional(),
+  checksumSha256: z.string().length(64).nullable().optional(),
+  objectKey: MediaObjectKey,
+  previewObjectKey: MediaObjectKey,
+  folderId: z.string().min(1).nullable().optional(),
+  muxAssetId: z.string().max(255).nullable().optional(),
+  muxUploadId: z.string().max(255).nullable().optional(),
+  muxPlaybackId: z.string().max(255).nullable().optional(),
+})
+export type CreateMediaAssetInput = z.infer<typeof CreateMediaAssetInput>
+
+export const UpdateMediaAssetInput = z.object({
+  id: z.string().min(1),
+  status: MediaAssetStatusSchema.optional(),
+  visibility: MediaAssetVisibilitySchema.optional(),
+  displayName: z.string().trim().min(1).max(300).optional(),
+  description: NullableString,
+  altText: z.string().max(500).nullable().optional(),
+  byteSize: OptionalBigInt,
+  width: OptionalPositiveInt,
+  height: OptionalPositiveInt,
+  durationMs: OptionalBigInt,
+  originalFilename: z.string().max(255).nullable().optional(),
+  checksumSha256: z.string().length(64).nullable().optional(),
+  objectKey: MediaObjectKey,
+  previewObjectKey: MediaObjectKey,
+  folderId: z.string().min(1).nullable().optional(),
+  muxAssetId: z.string().max(255).nullable().optional(),
+  muxUploadId: z.string().max(255).nullable().optional(),
+  muxPlaybackId: z.string().max(255).nullable().optional(),
+  errorCode: z.string().max(100).nullable().optional(),
+  errorMessage: z.string().max(1000).nullable().optional(),
+})
+export type UpdateMediaAssetInput = z.infer<typeof UpdateMediaAssetInput>

--- a/apps/admin/src/services/media-asset.service.test.ts
+++ b/apps/admin/src/services/media-asset.service.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import type { Principal } from "@/auth/principal"
+import {
+  MediaAssetService,
+  mediaAssetDownloadUrl,
+  mediaAssetPreviewUrl,
+} from "./media-asset.service"
+
+function mockPrisma() {
+  return {
+    mediaAsset: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    mediaFolder: {
+      findFirst: vi.fn(),
+    },
+    experienceLocale: {
+      findMany: vi.fn(),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+const ADMIN: Principal = { id: "admin-1", role: "ADMIN" }
+const EDITOR: Principal = { id: "editor-1", role: "EDITOR" }
+const VIEWER: Principal = { id: "viewer-1", role: "VIEWER" }
+const PUBLIC_USER: Principal | null = null
+
+describe("MediaAssetService", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+  let service: MediaAssetService
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+    service = new MediaAssetService(prisma)
+  })
+
+  describe("list", () => {
+    it("EDITOR can list media assets with filters", async () => {
+      prisma.mediaAsset.findMany.mockResolvedValueOnce([])
+
+      await service.list({
+        input: {
+          kind: "IMAGE",
+          status: "READY",
+          search: "hero",
+          folderId: "folder-1",
+        },
+        user: EDITOR,
+        query: {},
+      })
+
+      const call = prisma.mediaAsset.findMany.mock.calls[0][0]
+      expect(call.where).toMatchObject({
+        kind: "IMAGE",
+        status: "READY",
+        folderId: "folder-1",
+      })
+      expect(call.where.OR).toHaveLength(3)
+    })
+
+    it("VIEWER cannot list media assets", async () => {
+      await expect(
+        service.list({ input: {}, user: VIEWER, query: {} }),
+      ).rejects.toThrow("Forbidden")
+    })
+
+    it("clamps limit to 200", async () => {
+      prisma.mediaAsset.findMany.mockResolvedValueOnce([])
+
+      await service.list({
+        input: { limit: 500 },
+        user: ADMIN,
+        query: {},
+      })
+
+      expect(prisma.mediaAsset.findMany.mock.calls[0][0].take).toBe(200)
+    })
+  })
+
+  describe("getById", () => {
+    it("EDITOR can get an asset by id", async () => {
+      prisma.mediaAsset.findFirst.mockResolvedValueOnce({ id: "asset-1" })
+
+      const result = await service.getById({
+        id: "asset-1",
+        user: EDITOR,
+        query: {},
+      })
+
+      expect(result).toEqual({ id: "asset-1" })
+      expect(prisma.mediaAsset.findFirst.mock.calls[0][0].where).toEqual({
+        id: "asset-1",
+      })
+    })
+
+    it("PUBLIC cannot read an asset", async () => {
+      await expect(
+        service.getById({ id: "asset-1", user: PUBLIC_USER, query: {} }),
+      ).rejects.toThrow("Forbidden")
+    })
+  })
+
+  describe("create", () => {
+    it("EDITOR can register an image asset", async () => {
+      prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "folder-1" })
+      prisma.mediaAsset.create.mockResolvedValueOnce({ id: "asset-1" })
+
+      await service.create({
+        input: {
+          kind: "IMAGE",
+          displayName: "Hero image",
+          mimeType: "image/webp",
+          byteSize: "12345",
+          folderId: "folder-1",
+          objectKey: "media-assets/asset-1/original/hero.webp",
+        },
+        user: EDITOR,
+      })
+
+      expect(prisma.mediaAsset.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            kind: "IMAGE",
+            backend: "LOCAL",
+            status: "READY",
+            visibility: "PRIVATE",
+            createdById: "editor-1",
+            folderId: "folder-1",
+            byteSize: 12345n,
+          }),
+        }),
+      )
+    })
+
+    it("rejects an unknown folder id on create", async () => {
+      prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+
+      await expect(
+        service.create({
+          input: {
+            kind: "IMAGE",
+            displayName: "Hero image",
+            mimeType: "image/webp",
+            folderId: "missing-folder",
+          },
+          user: EDITOR,
+        }),
+      ).rejects.toThrow("Media folder not found")
+    })
+
+    it("rejects a mismatched MIME type", async () => {
+      await expect(
+        service.create({
+          input: {
+            kind: "IMAGE",
+            displayName: "Not an image",
+            mimeType: "application/pdf",
+          },
+          user: EDITOR,
+        }),
+      ).rejects.toThrow("does not match media kind")
+    })
+
+    it("rejects unsafe storage object keys on create", async () => {
+      await expect(
+        service.create({
+          input: {
+            kind: "IMAGE",
+            displayName: "Hero image",
+            mimeType: "image/webp",
+            objectKey: "../secret",
+          },
+          user: EDITOR,
+        }),
+      ).rejects.toThrow("Invalid media object key")
+    })
+
+    it("requires Mux assets to be videos with Mux metadata", async () => {
+      await expect(
+        service.create({
+          input: {
+            kind: "PDF",
+            backend: "MUX",
+            displayName: "PDF",
+            mimeType: "application/pdf",
+          },
+          user: EDITOR,
+        }),
+      ).rejects.toThrow("Mux media assets must be videos")
+    })
+
+    it("VIEWER cannot create media assets", async () => {
+      await expect(
+        service.create({
+          input: {
+            kind: "PDF",
+            displayName: "Doc",
+            mimeType: "application/pdf",
+          },
+          user: VIEWER,
+        }),
+      ).rejects.toThrow("Forbidden")
+    })
+  })
+
+  describe("update", () => {
+    it("ADMIN can update asset metadata", async () => {
+      prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "folder-2" })
+      prisma.mediaAsset.update.mockResolvedValueOnce({ id: "asset-1" })
+
+      await service.update({
+        input: {
+          id: "asset-1",
+          displayName: "Updated",
+          altText: "A clear alt text",
+          folderId: "folder-2",
+        },
+        user: ADMIN,
+      })
+
+      expect(prisma.mediaAsset.update).toHaveBeenCalledWith({
+        where: { id: "asset-1" },
+        data: {
+          displayName: "Updated",
+          altText: "A clear alt text",
+          folderId: "folder-2",
+        },
+      })
+    })
+
+    it("rejects unsafe storage object keys on update", async () => {
+      await expect(
+        service.update({
+          input: {
+            id: "asset-1",
+            previewObjectKey: "media-assets/asset-1/preview/../../secret",
+          },
+          user: ADMIN,
+        }),
+      ).rejects.toThrow("Invalid media object key")
+      expect(prisma.mediaAsset.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("URL helpers", () => {
+    it("returns stable app routes for local/S3 assets", () => {
+      const asset = {
+        id: "asset-1",
+        backend: "LOCAL",
+        objectKey: "media-assets/asset-1/original/hero.webp",
+        previewObjectKey: null,
+        muxPlaybackId: null,
+      }
+
+      expect(mediaAssetPreviewUrl(asset)).toBe(
+        "/api/media-assets/asset-1/preview",
+      )
+      expect(mediaAssetDownloadUrl(asset)).toBe(
+        "/api/media-assets/asset-1/download",
+      )
+    })
+
+    it("returns Mux thumbnail URLs for Mux video previews", () => {
+      expect(
+        mediaAssetPreviewUrl({
+          id: "asset-1",
+          backend: "MUX",
+          objectKey: null,
+          previewObjectKey: null,
+          muxPlaybackId: "playback-1",
+        }),
+      ).toBe("https://image.mux.com/playback-1/thumbnail.jpg")
+    })
+  })
+
+  describe("usage", () => {
+    it("scans experience locale metadata and blocks for asset usage", async () => {
+      prisma.mediaAsset.findFirst.mockResolvedValueOnce({
+        id: "asset-1",
+        backend: "LOCAL",
+        objectKey: "media-assets/asset-1/original/hero.webp",
+        previewObjectKey: null,
+        muxPlaybackId: null,
+      })
+      prisma.experienceLocale.findMany.mockResolvedValueOnce([
+        {
+          id: "loc-1",
+          experienceId: "exp-1",
+          locale: "en",
+          title: "Landing",
+          ogImageUrl: null,
+          blocks: [
+            {
+              t: "cta",
+              imageUrl: "media-assets/asset-1/original/hero.webp",
+            },
+          ],
+        },
+      ])
+
+      const result = await service.usage({ id: "asset-1", user: EDITOR })
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          experienceLocaleId: "loc-1",
+          fieldPath: "$.blocks[0].imageUrl",
+          match: "object-key",
+        }),
+      ])
+    })
+
+    it("VIEWER cannot inspect media usage", async () => {
+      await expect(
+        service.usage({ id: "asset-1", user: VIEWER }),
+      ).rejects.toThrow("Forbidden")
+    })
+  })
+
+  describe("delete", () => {
+    it("ADMIN can delete an unused media asset", async () => {
+      prisma.mediaAsset.findFirst.mockResolvedValueOnce({
+        id: "asset-1",
+        backend: "LOCAL",
+        objectKey: null,
+        previewObjectKey: null,
+        muxPlaybackId: null,
+      })
+      prisma.experienceLocale.findMany.mockResolvedValueOnce([])
+      prisma.mediaAsset.delete.mockResolvedValueOnce({ id: "asset-1" })
+
+      const result = await service.delete({ id: "asset-1", user: ADMIN })
+
+      expect(result).toEqual({ deleted: true, usageCount: 0 })
+      expect(prisma.mediaAsset.delete).toHaveBeenCalledWith({
+        where: { id: "asset-1" },
+      })
+    })
+
+    it("refuses to delete an asset while usage exists", async () => {
+      prisma.mediaAsset.findFirst.mockResolvedValueOnce({
+        id: "asset-1",
+        backend: "LOCAL",
+        objectKey: "media-assets/asset-1/original/hero.webp",
+        previewObjectKey: null,
+        muxPlaybackId: null,
+      })
+      prisma.experienceLocale.findMany.mockResolvedValueOnce([
+        {
+          id: "loc-1",
+          experienceId: "exp-1",
+          locale: "en",
+          title: "Landing",
+          ogImageUrl: null,
+          blocks: [
+            {
+              t: "cta",
+              imageUrl: "media-assets/asset-1/original/hero.webp",
+            },
+          ],
+        },
+      ])
+
+      await expect(
+        service.delete({ id: "asset-1", user: ADMIN }),
+      ).rejects.toThrow("still used")
+      expect(prisma.mediaAsset.delete).not.toHaveBeenCalled()
+    })
+
+    it("EDITOR cannot delete media assets", async () => {
+      await expect(
+        service.delete({ id: "asset-1", user: EDITOR }),
+      ).rejects.toThrow("Forbidden")
+    })
+  })
+})

--- a/apps/admin/src/services/media-asset.service.ts
+++ b/apps/admin/src/services/media-asset.service.ts
@@ -1,0 +1,242 @@
+// Media asset service — permissioned registry for images, videos, PDFs, and
+// other uploaded files. The service stores canonical metadata and exposes
+// stable routes; storage backends remain an implementation detail.
+
+import type { MediaAssetKind, Prisma, PrismaClient } from "@prisma/client"
+import type { Principal } from "@/auth/principal"
+import { hasPermission } from "@/auth/permissions"
+import { ForbiddenError } from "./errors"
+import {
+  CreateMediaAssetInput,
+  ListMediaAssetsInput,
+  UpdateMediaAssetInput,
+} from "./media-asset.schemas"
+import { scanMediaAssetUsage } from "./media-asset.usage"
+
+export class MediaAssetValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "MediaAssetValidationError"
+  }
+}
+
+export class MediaAssetService {
+  constructor(private prisma: PrismaClient) {}
+
+  async list({
+    input: raw,
+    user,
+    query,
+  }: {
+    input: unknown
+    user: Principal | null
+    query: object
+  }) {
+    if (!hasPermission(user, "read:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const input = ListMediaAssetsInput.parse(raw)
+    const where: Prisma.MediaAssetWhereInput = {
+      ...(input.kind ? { kind: input.kind } : {}),
+      ...(input.backend ? { backend: input.backend } : {}),
+      ...(input.status ? { status: input.status } : {}),
+      ...(input.folderId !== undefined ? { folderId: input.folderId } : {}),
+      ...(input.search
+        ? {
+            OR: [
+              { displayName: { contains: input.search, mode: "insensitive" } },
+              { description: { contains: input.search, mode: "insensitive" } },
+              {
+                originalFilename: {
+                  contains: input.search,
+                  mode: "insensitive",
+                },
+              },
+            ],
+          }
+        : {}),
+    }
+
+    return this.prisma.mediaAsset.findMany({
+      ...query,
+      where,
+      orderBy: { updatedAt: "desc" },
+      take: Math.min(input.limit ?? 50, 200),
+      skip: input.offset ?? 0,
+    })
+  }
+
+  async getById({
+    id,
+    user,
+    query,
+  }: {
+    id: string
+    user: Principal | null
+    query: object
+  }) {
+    if (!hasPermission(user, "read:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    return this.prisma.mediaAsset.findFirst({
+      ...query,
+      where: { id },
+    })
+  }
+
+  async create({
+    input: raw,
+    user,
+  }: {
+    input: unknown
+    user: Principal | null
+  }) {
+    if (!hasPermission(user, "write:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const input = CreateMediaAssetInput.parse(raw)
+    validateMimeKind(input.kind, input.mimeType)
+    validateBackendShape(input)
+    await assertFolderExists(this.prisma, input.folderId ?? null)
+
+    return this.prisma.mediaAsset.create({
+      data: {
+        ...input,
+        createdById: user?.id ?? null,
+      },
+    })
+  }
+
+  async update({
+    input: raw,
+    user,
+  }: {
+    input: unknown
+    user: Principal | null
+  }) {
+    if (!hasPermission(user, "write:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const input = UpdateMediaAssetInput.parse(raw)
+    const { id, ...data } = input
+    await assertFolderExists(this.prisma, input.folderId ?? null)
+
+    return this.prisma.mediaAsset.update({
+      where: { id },
+      data,
+    })
+  }
+
+  async delete({ id, user }: { id: string; user: Principal | null }) {
+    if (!hasPermission(user, "delete:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const usage = await this.usage({ id, user })
+    if (usage.length > 0) {
+      throw new MediaAssetValidationError(
+        "Cannot delete a media asset while it is still used",
+      )
+    }
+
+    await this.prisma.mediaAsset.delete({ where: { id } })
+    return { deleted: true, usageCount: 0 }
+  }
+
+  async usage({ id, user }: { id: string; user: Principal | null }) {
+    if (!hasPermission(user, "read:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const asset = await this.prisma.mediaAsset.findFirst({ where: { id } })
+    if (!asset) return []
+
+    const previewUrl = mediaAssetPreviewUrl(asset)
+    const downloadUrl = mediaAssetDownloadUrl(asset)
+
+    return scanMediaAssetUsage(this.prisma, {
+      assetId: asset.id,
+      urls: [previewUrl, downloadUrl].filter((value): value is string =>
+        Boolean(value),
+      ),
+      objectKeys: [asset.objectKey, asset.previewObjectKey].filter(
+        (value): value is string => Boolean(value),
+      ),
+    })
+  }
+}
+
+export function mediaAssetPreviewUrl(asset: {
+  id: string
+  backend: string
+  objectKey: string | null
+  previewObjectKey: string | null
+  muxPlaybackId: string | null
+}) {
+  if (asset.muxPlaybackId) {
+    return `https://image.mux.com/${asset.muxPlaybackId}/thumbnail.jpg`
+  }
+  if (asset.previewObjectKey || asset.objectKey) {
+    return `/api/media-assets/${asset.id}/preview`
+  }
+  return null
+}
+
+export function mediaAssetDownloadUrl(asset: {
+  id: string
+  backend: string
+  objectKey: string | null
+}) {
+  if (asset.backend === "MUX") {
+    return null
+  }
+  return asset.objectKey ? `/api/media-assets/${asset.id}/download` : null
+}
+
+function validateMimeKind(kind: MediaAssetKind, mimeType: string) {
+  const ok =
+    kind === "FILE" ||
+    (kind === "IMAGE" && mimeType.startsWith("image/")) ||
+    (kind === "VIDEO" && mimeType.startsWith("video/")) ||
+    (kind === "PDF" && mimeType === "application/pdf")
+
+  if (!ok) {
+    throw new MediaAssetValidationError(
+      `MIME type ${mimeType} does not match media kind ${kind}`,
+    )
+  }
+}
+
+function validateBackendShape(input: CreateMediaAssetInput) {
+  if (input.backend === "MUX" && input.kind !== "VIDEO") {
+    throw new MediaAssetValidationError("Mux media assets must be videos")
+  }
+
+  if (input.backend === "MUX" && !input.muxAssetId && !input.muxUploadId) {
+    throw new MediaAssetValidationError(
+      "Mux media assets require muxAssetId or muxUploadId",
+    )
+  }
+}
+
+async function assertFolderExists(
+  prisma: PrismaClient,
+  folderId: string | null,
+) {
+  if (!folderId) {
+    return
+  }
+
+  const folder = await prisma.mediaFolder.findFirst({
+    where: { id: folderId },
+    select: { id: true },
+  })
+
+  if (!folder) {
+    throw new MediaAssetValidationError("Media folder not found")
+  }
+}

--- a/apps/admin/src/services/media-asset.usage.test.ts
+++ b/apps/admin/src/services/media-asset.usage.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+import { findMediaAssetUsages } from "./media-asset.usage"
+
+describe("findMediaAssetUsages", () => {
+  it("finds canonical asset-id references in nested block JSON", () => {
+    const matches = findMediaAssetUsages({ assetId: "asset-1" }, [
+      {
+        id: "loc-1",
+        experienceId: "exp-1",
+        locale: "en",
+        title: "Landing",
+        ogImageUrl: null,
+        blocks: [
+          {
+            t: "mediaCollection",
+            items: [{ imageAssetId: "asset-1" }],
+          },
+        ],
+      },
+    ])
+
+    expect(matches).toEqual([
+      expect.objectContaining({
+        experienceLocaleId: "loc-1",
+        location: "blocks",
+        fieldPath: "$.blocks[0].items[0].imageAssetId",
+        fieldName: "imageAssetId",
+        match: "asset-id",
+      }),
+    ])
+  })
+
+  it("finds legacy URL references in metadata and blocks", () => {
+    const matches = findMediaAssetUsages(
+      {
+        assetId: "asset-1",
+        urls: ["/api/media-assets/asset-1/preview"],
+      },
+      [
+        {
+          id: "loc-1",
+          experienceId: "exp-1",
+          locale: "en",
+          title: "Landing",
+          ogImageUrl: "/api/media-assets/asset-1/preview",
+          blocks: [
+            {
+              t: "bibleQuotesCarousel",
+              quotes: [
+                {
+                  backgroundImageUrl: "/api/media-assets/asset-1/preview",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    )
+
+    expect(matches.map((item) => item.fieldPath)).toEqual([
+      "$.ogImageUrl",
+      "$.blocks[0].quotes[0].backgroundImageUrl",
+    ])
+    expect(matches.every((item) => item.match === "url")).toBe(true)
+  })
+
+  it("matches object keys during the storage transition", () => {
+    const matches = findMediaAssetUsages(
+      {
+        assetId: "asset-1",
+        objectKeys: ["media-assets/asset-1/original/hero.webp"],
+      },
+      [
+        {
+          id: "loc-1",
+          experienceId: "exp-1",
+          locale: "en",
+          title: "Landing",
+          ogImageUrl: null,
+          blocks: [
+            {
+              t: "cta",
+              imageUrl: "media-assets/asset-1/original/hero.webp",
+            },
+          ],
+        },
+      ],
+    )
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toMatchObject({
+      fieldName: "imageUrl",
+      match: "object-key",
+    })
+  })
+
+  it("ignores unrelated URL-looking fields", () => {
+    const matches = findMediaAssetUsages(
+      {
+        assetId: "asset-1",
+        urls: ["https://example.com/hero.webp"],
+      },
+      [
+        {
+          id: "loc-1",
+          experienceId: "exp-1",
+          locale: "en",
+          title: "Landing",
+          ogImageUrl: null,
+          blocks: [{ t: "cta", buttonLink: "https://example.com/hero.webp" }],
+        },
+      ],
+    )
+
+    expect(matches).toEqual([])
+  })
+})

--- a/apps/admin/src/services/media-asset.usage.ts
+++ b/apps/admin/src/services/media-asset.usage.ts
@@ -1,0 +1,190 @@
+// Deterministic on-demand usage scanning for media assets.
+//
+// This covers the transition period where experience metadata and blocks may
+// contain either canonical asset-id fields or legacy URL/object-key strings.
+
+import type { PrismaClient } from "@prisma/client"
+
+export type MediaAssetUsageTarget = {
+  assetId: string
+  urls?: readonly string[]
+  objectKeys?: readonly string[]
+}
+
+export type MediaAssetUsageRow = {
+  experienceId: string
+  experienceLocaleId: string
+  locale: string
+  title: string | null
+  location: "metadata" | "blocks"
+  fieldPath: string
+  fieldName: string
+  value: string
+  match: "asset-id" | "url" | "object-key"
+}
+
+type ExperienceLocaleUsageSource = {
+  id: string
+  experienceId: string
+  locale: string
+  title: string | null
+  ogImageUrl: string | null
+  blocks: unknown
+}
+
+const URL_FIELD_PATTERN =
+  /(^|_)(image|media|backgroundImage|thumbnail|poster|ogImage)(Url|Src)$/i
+const ASSET_ID_FIELD_PATTERN =
+  /(^|_)(image|media|backgroundImage|thumbnail|poster|ogImage)(AssetId)$/i
+
+export async function scanMediaAssetUsage(
+  prisma: PrismaClient,
+  target: MediaAssetUsageTarget,
+): Promise<MediaAssetUsageRow[]> {
+  const rows = await prisma.experienceLocale.findMany({
+    select: {
+      id: true,
+      experienceId: true,
+      locale: true,
+      title: true,
+      ogImageUrl: true,
+      blocks: true,
+    },
+    orderBy: { updatedAt: "desc" },
+  })
+
+  return findMediaAssetUsages(target, rows)
+}
+
+export function findMediaAssetUsages(
+  target: MediaAssetUsageTarget,
+  rows: readonly ExperienceLocaleUsageSource[],
+): MediaAssetUsageRow[] {
+  const matches: MediaAssetUsageRow[] = []
+  const urls = new Set((target.urls ?? []).filter(Boolean))
+  const objectKeys = new Set((target.objectKeys ?? []).filter(Boolean))
+
+  for (const row of rows) {
+    addMatchForField({
+      matches,
+      row,
+      location: "metadata",
+      fieldPath: "$.ogImageUrl",
+      fieldName: "ogImageUrl",
+      value: row.ogImageUrl,
+      target,
+      urls,
+      objectKeys,
+    })
+
+    walkBlockValue(row.blocks, "$.blocks", (fieldPath, fieldName, value) => {
+      addMatchForField({
+        matches,
+        row,
+        location: "blocks",
+        fieldPath,
+        fieldName,
+        value,
+        target,
+        urls,
+        objectKeys,
+      })
+    })
+  }
+
+  return matches
+}
+
+function addMatchForField({
+  matches,
+  row,
+  location,
+  fieldPath,
+  fieldName,
+  value,
+  target,
+  urls,
+  objectKeys,
+}: {
+  matches: MediaAssetUsageRow[]
+  row: ExperienceLocaleUsageSource
+  location: "metadata" | "blocks"
+  fieldPath: string
+  fieldName: string
+  value: unknown
+  target: MediaAssetUsageTarget
+  urls: Set<string>
+  objectKeys: Set<string>
+}) {
+  if (typeof value !== "string" || value.length === 0) return
+
+  const match = matchFieldValue({
+    fieldName,
+    value,
+    assetId: target.assetId,
+    urls,
+    objectKeys,
+  })
+  if (!match) return
+
+  matches.push({
+    experienceId: row.experienceId,
+    experienceLocaleId: row.id,
+    locale: row.locale,
+    title: row.title,
+    location,
+    fieldPath,
+    fieldName,
+    value,
+    match,
+  })
+}
+
+function matchFieldValue({
+  fieldName,
+  value,
+  assetId,
+  urls,
+  objectKeys,
+}: {
+  fieldName: string
+  value: string
+  assetId: string
+  urls: Set<string>
+  objectKeys: Set<string>
+}): MediaAssetUsageRow["match"] | null {
+  if (ASSET_ID_FIELD_PATTERN.test(fieldName) && value === assetId) {
+    return "asset-id"
+  }
+
+  if (URL_FIELD_PATTERN.test(fieldName) && urls.has(value)) {
+    return "url"
+  }
+
+  if (URL_FIELD_PATTERN.test(fieldName) && objectKeys.has(value)) {
+    return "object-key"
+  }
+
+  return null
+}
+
+function walkBlockValue(
+  value: unknown,
+  path: string,
+  visit: (fieldPath: string, fieldName: string, value: unknown) => void,
+) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      walkBlockValue(item, `${path}[${index}]`, visit)
+    })
+    return
+  }
+
+  if (typeof value !== "object" || value === null) return
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`
+    visit(childPath, key, child)
+    walkBlockValue(child, childPath, visit)
+  }
+}

--- a/apps/admin/src/services/media-folder.schemas.ts
+++ b/apps/admin/src/services/media-folder.schemas.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const ListMediaFoldersInput = z.object({})
+export type ListMediaFoldersInput = z.infer<typeof ListMediaFoldersInput>
+
+export const CreateMediaFolderInput = z.object({
+  name: z.string().trim().min(1).max(120),
+  parentId: z.string().min(1).nullable().optional(),
+})
+export type CreateMediaFolderInput = z.infer<typeof CreateMediaFolderInput>
+
+export const UpdateMediaFolderInput = z.object({
+  id: z.string().min(1),
+  name: z.string().trim().min(1).max(120).optional(),
+  parentId: z.string().min(1).nullable().optional(),
+})
+export type UpdateMediaFolderInput = z.infer<typeof UpdateMediaFolderInput>
+
+export const DeleteMediaFolderInput = z.object({
+  id: z.string().min(1),
+})
+export type DeleteMediaFolderInput = z.infer<typeof DeleteMediaFolderInput>

--- a/apps/admin/src/services/media-folder.service.test.ts
+++ b/apps/admin/src/services/media-folder.service.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { Principal } from "@/auth/principal"
+import {
+  MediaFolderService,
+  MediaFolderValidationError,
+} from "./media-folder.service"
+
+class FakePrismaUniqueError extends Error {
+  readonly code = "P2002"
+
+  constructor() {
+    super("Unique constraint failed on the fields: (`parent_id`,`name`)")
+    this.name = "PrismaClientKnownRequestError"
+  }
+}
+
+function mockPrisma() {
+  return {
+    mediaFolder: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    mediaAsset: {
+      count: vi.fn(),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+const ADMIN: Principal = { id: "admin-1", role: "ADMIN" }
+const EDITOR: Principal = { id: "editor-1", role: "EDITOR" }
+const VIEWER: Principal = { id: "viewer-1", role: "VIEWER" }
+
+describe("MediaFolderService", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+  let service: MediaFolderService
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+    service = new MediaFolderService(prisma)
+  })
+
+  it("lists folders for editors", async () => {
+    prisma.mediaFolder.findMany.mockResolvedValueOnce([])
+
+    await service.list({ input: {}, user: EDITOR, query: {} })
+
+    expect(prisma.mediaFolder.findMany).toHaveBeenCalledWith({
+      orderBy: [{ parentId: "asc" }, { name: "asc" }],
+    })
+  })
+
+  it("creates a nested folder", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "parent-1" })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      id: "parent-1",
+      name: "Library",
+      parentId: null,
+    })
+    prisma.mediaFolder.create.mockResolvedValueOnce({ id: "folder-1" })
+
+    await service.create({
+      input: { name: "Campaign", parentId: "parent-1" },
+      user: EDITOR,
+    })
+
+    expect(prisma.mediaFolder.create).toHaveBeenCalledWith({
+      data: {
+        name: "Campaign",
+        parentId: "parent-1",
+        createdById: "editor-1",
+      },
+    })
+  })
+
+  it("rejects missing parent folders", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+
+    await expect(
+      service.create({
+        input: { name: "Campaign", parentId: "missing-parent" },
+        user: ADMIN,
+      }),
+    ).rejects.toThrow("Parent media folder not found")
+  })
+
+  it("rejects duplicate root folder names before create", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "existing-root" })
+
+    await expect(
+      service.create({
+        input: { name: "Campaign" },
+        user: ADMIN,
+      }),
+    ).rejects.toThrow("already exists")
+
+    expect(prisma.mediaFolder.create).not.toHaveBeenCalled()
+  })
+
+  it("rejects creating a folder with the same name as its parent", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "parent-1" })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      id: "parent-1",
+      name: "Campaign",
+      parentId: null,
+    })
+
+    await expect(
+      service.create({
+        input: { name: "Campaign", parentId: "parent-1" },
+        user: ADMIN,
+      }),
+    ).rejects.toThrow("parent folders")
+
+    expect(prisma.mediaFolder.create).not.toHaveBeenCalled()
+  })
+
+  it("remaps duplicate sibling names during create", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+    prisma.mediaFolder.create.mockRejectedValueOnce(new FakePrismaUniqueError())
+
+    const thrown = await service
+      .create({
+        input: { name: "Campaign" },
+        user: ADMIN,
+      })
+      .catch((error) => error)
+
+    expect(thrown).toBeInstanceOf(MediaFolderValidationError)
+    expect((thrown as Error).message).toContain("already exists")
+  })
+
+  it("updates folder names", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      name: "Original",
+      parentId: null,
+    })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+    prisma.mediaFolder.update.mockResolvedValueOnce({ id: "folder-1" })
+
+    await service.update({
+      input: { id: "folder-1", name: "Updated" },
+      user: ADMIN,
+    })
+
+    expect(prisma.mediaFolder.update).toHaveBeenCalledWith({
+      where: { id: "folder-1" },
+      data: { name: "Updated" },
+    })
+  })
+
+  it("remaps duplicate sibling names during update", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      name: "Original",
+      parentId: null,
+    })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+    prisma.mediaFolder.update.mockRejectedValueOnce(new FakePrismaUniqueError())
+
+    const thrown = await service
+      .update({
+        input: { id: "folder-1", name: "Updated" },
+        user: ADMIN,
+      })
+      .catch((error) => error)
+
+    expect(thrown).toBeInstanceOf(MediaFolderValidationError)
+    expect((thrown as Error).message).toContain("already exists")
+  })
+
+  it("moves folders to a new parent", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      name: "Folder",
+      parentId: null,
+    })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "parent-2" })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ parentId: null })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      id: "parent-2",
+      name: "Destination",
+      parentId: null,
+    })
+    prisma.mediaFolder.update.mockResolvedValueOnce({ id: "folder-1" })
+
+    await service.update({
+      input: { id: "folder-1", parentId: "parent-2" },
+      user: ADMIN,
+    })
+
+    expect(prisma.mediaFolder.update).toHaveBeenCalledWith({
+      where: { id: "folder-1" },
+      data: { parentId: "parent-2" },
+    })
+  })
+
+  it("rejects moving a folder into itself", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      name: "Folder",
+      parentId: null,
+    })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "folder-1" })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+
+    await expect(
+      service.update({
+        input: { id: "folder-1", parentId: "folder-1" },
+        user: ADMIN,
+      }),
+    ).rejects.toThrow("own parent")
+  })
+
+  it("rejects moving a folder into its descendants", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      name: "Folder",
+      parentId: null,
+    })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "child-1" })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ parentId: "folder-1" })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+
+    await expect(
+      service.update({
+        input: { id: "folder-1", parentId: "child-1" },
+        user: ADMIN,
+      }),
+    ).rejects.toThrow("descendants")
+  })
+
+  it("rejects duplicate root folder names during update", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      name: "Original",
+      parentId: null,
+    })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({ id: "existing-root" })
+
+    await expect(
+      service.update({
+        input: { id: "folder-1", name: "Campaign" },
+        user: ADMIN,
+      }),
+    ).rejects.toThrow("already exists")
+
+    expect(prisma.mediaFolder.update).not.toHaveBeenCalled()
+  })
+
+  it("rejects renaming a folder to match an ancestor folder", async () => {
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      name: "Child",
+      parentId: "parent-1",
+    })
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce(null)
+    prisma.mediaFolder.findFirst.mockResolvedValueOnce({
+      id: "parent-1",
+      name: "Campaign",
+      parentId: null,
+    })
+
+    await expect(
+      service.update({
+        input: { id: "folder-1", name: "Campaign" },
+        user: ADMIN,
+      }),
+    ).rejects.toThrow("parent folders")
+
+    expect(prisma.mediaFolder.update).not.toHaveBeenCalled()
+  })
+
+  it("refuses to delete folders with children", async () => {
+    prisma.mediaFolder.count.mockResolvedValueOnce(1)
+    prisma.mediaAsset.count.mockResolvedValueOnce(0)
+
+    await expect(
+      service.delete({ input: { id: "folder-1" }, user: ADMIN }),
+    ).rejects.toThrow("child folders")
+  })
+
+  it("refuses to delete folders with assets", async () => {
+    prisma.mediaFolder.count.mockResolvedValueOnce(0)
+    prisma.mediaAsset.count.mockResolvedValueOnce(2)
+
+    await expect(
+      service.delete({ input: { id: "folder-1" }, user: ADMIN }),
+    ).rejects.toThrow("contains assets")
+  })
+
+  it("deletes empty folders", async () => {
+    prisma.mediaFolder.count.mockResolvedValueOnce(0)
+    prisma.mediaAsset.count.mockResolvedValueOnce(0)
+    prisma.mediaFolder.delete.mockResolvedValueOnce({ id: "folder-1" })
+
+    const result = await service.delete({
+      input: { id: "folder-1" },
+      user: ADMIN,
+    })
+
+    expect(result).toEqual({ deleted: true, childCount: 0, assetCount: 0 })
+    expect(prisma.mediaFolder.delete).toHaveBeenCalledWith({
+      where: { id: "folder-1" },
+    })
+  })
+
+  it("blocks viewers from creating folders", async () => {
+    await expect(
+      service.create({
+        input: { name: "Campaign" },
+        user: VIEWER,
+      }),
+    ).rejects.toThrow("Forbidden")
+  })
+})

--- a/apps/admin/src/services/media-folder.service.ts
+++ b/apps/admin/src/services/media-folder.service.ts
@@ -1,0 +1,312 @@
+import type { PrismaClient } from "@prisma/client"
+import type { Principal } from "@/auth/principal"
+import { hasPermission } from "@/auth/permissions"
+import { ForbiddenError } from "./errors"
+import {
+  CreateMediaFolderInput,
+  DeleteMediaFolderInput,
+  ListMediaFoldersInput,
+  UpdateMediaFolderInput,
+} from "./media-folder.schemas"
+
+export class MediaFolderValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "MediaFolderValidationError"
+  }
+}
+
+export class MediaFolderService {
+  constructor(private prisma: PrismaClient) {}
+
+  async list({
+    input: raw,
+    user,
+    query,
+  }: {
+    input: unknown
+    user: Principal | null
+    query: object
+  }) {
+    if (!hasPermission(user, "read:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    ListMediaFoldersInput.parse(raw)
+
+    return this.prisma.mediaFolder.findMany({
+      ...query,
+      orderBy: [{ parentId: "asc" }, { name: "asc" }],
+    })
+  }
+
+  async create({
+    input: raw,
+    user,
+  }: {
+    input: unknown
+    user: Principal | null
+  }) {
+    if (!hasPermission(user, "write:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const input = CreateMediaFolderInput.parse(raw)
+    await assertParentExists(this.prisma, input.parentId ?? null)
+    await assertUniqueFolderName(this.prisma, {
+      name: input.name,
+      parentId: input.parentId ?? null,
+    })
+    await assertNoAncestorFolderNameConflict(this.prisma, {
+      name: input.name,
+      parentId: input.parentId ?? null,
+    })
+
+    try {
+      return await this.prisma.mediaFolder.create({
+        data: {
+          name: input.name,
+          parentId: input.parentId ?? null,
+          createdById: user?.id ?? null,
+        },
+      })
+    } catch (error) {
+      throw remapMediaFolderWriteError(error)
+    }
+  }
+
+  async update({
+    input: raw,
+    user,
+  }: {
+    input: unknown
+    user: Principal | null
+  }) {
+    if (!hasPermission(user, "write:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const input = UpdateMediaFolderInput.parse(raw)
+    const currentFolder = await this.prisma.mediaFolder.findFirst({
+      where: { id: input.id },
+      select: { name: true, parentId: true },
+    })
+
+    if (input.parentId !== undefined) {
+      await assertParentExists(this.prisma, input.parentId ?? null)
+      await assertNoFolderCycle(this.prisma, {
+        folderId: input.id,
+        parentId: input.parentId ?? null,
+      })
+    }
+
+    if (currentFolder) {
+      const effectiveName = input.name ?? currentFolder.name
+      const effectiveParentId =
+        input.parentId !== undefined
+          ? (input.parentId ?? null)
+          : currentFolder.parentId
+
+      await assertUniqueFolderName(this.prisma, {
+        name: effectiveName,
+        parentId: effectiveParentId,
+        excludeId: input.id,
+      })
+      await assertNoAncestorFolderNameConflict(this.prisma, {
+        name: effectiveName,
+        parentId: effectiveParentId,
+        excludeId: input.id,
+      })
+    }
+
+    try {
+      return await this.prisma.mediaFolder.update({
+        where: { id: input.id },
+        data: {
+          ...(input.name !== undefined ? { name: input.name } : {}),
+          ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+        },
+      })
+    } catch (error) {
+      throw remapMediaFolderWriteError(error)
+    }
+  }
+
+  async delete({
+    input: raw,
+    user,
+  }: {
+    input: unknown
+    user: Principal | null
+  }) {
+    if (!hasPermission(user, "delete:media-assets")) {
+      throw new ForbiddenError()
+    }
+
+    const input = DeleteMediaFolderInput.parse(raw)
+    const [childCount, assetCount] = await Promise.all([
+      this.prisma.mediaFolder.count({ where: { parentId: input.id } }),
+      this.prisma.mediaAsset.count({ where: { folderId: input.id } }),
+    ])
+
+    if (childCount > 0) {
+      throw new MediaFolderValidationError(
+        "Cannot delete a media folder while it still contains child folders",
+      )
+    }
+
+    if (assetCount > 0) {
+      throw new MediaFolderValidationError(
+        "Cannot delete a media folder while it still contains assets",
+      )
+    }
+
+    await this.prisma.mediaFolder.delete({ where: { id: input.id } })
+    return { deleted: true as const, childCount, assetCount }
+  }
+}
+
+function remapMediaFolderWriteError(error: unknown) {
+  if (isPrismaKnownRequestError(error) && error.code === "P2002") {
+    return new MediaFolderValidationError(
+      "A folder with this name already exists in this location",
+    )
+  }
+
+  return error
+}
+
+function isPrismaKnownRequestError(
+  error: unknown,
+): error is { code: string; name: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    "name" in error &&
+    error.name === "PrismaClientKnownRequestError"
+  )
+}
+
+async function assertParentExists(
+  prisma: PrismaClient,
+  parentId: string | null,
+) {
+  if (!parentId) {
+    return
+  }
+
+  const folder = await prisma.mediaFolder.findFirst({
+    where: { id: parentId },
+    select: { id: true },
+  })
+
+  if (!folder) {
+    throw new MediaFolderValidationError("Parent media folder not found")
+  }
+}
+
+async function assertUniqueFolderName(
+  prisma: PrismaClient,
+  {
+    name,
+    parentId,
+    excludeId,
+  }: {
+    name: string
+    parentId: string | null
+    excludeId?: string
+  },
+) {
+  const existing = await prisma.mediaFolder.findFirst({
+    where: {
+      name,
+      parentId,
+      ...(excludeId ? { id: { not: excludeId } } : {}),
+    },
+    select: { id: true },
+  })
+
+  if (existing) {
+    throw new MediaFolderValidationError(
+      "A folder with this name already exists in this location",
+    )
+  }
+}
+
+async function assertNoAncestorFolderNameConflict(
+  prisma: PrismaClient,
+  {
+    name,
+    parentId,
+    excludeId,
+  }: {
+    name: string
+    parentId: string | null
+    excludeId?: string
+  },
+) {
+  let currentParentId = parentId
+
+  while (currentParentId) {
+    const current = await prisma.mediaFolder.findFirst({
+      where: { id: currentParentId },
+      select: { id: true, name: true, parentId: true },
+    })
+
+    if (!current) {
+      return
+    }
+
+    if (current.name === name && current.id !== excludeId) {
+      throw new MediaFolderValidationError(
+        "A folder cannot use the same name as one of its parent folders",
+      )
+    }
+
+    currentParentId = current.parentId
+  }
+}
+
+async function assertNoFolderCycle(
+  prisma: PrismaClient,
+  {
+    folderId,
+    parentId,
+  }: {
+    folderId: string
+    parentId: string | null
+  },
+) {
+  if (!parentId) {
+    return
+  }
+
+  if (folderId === parentId) {
+    throw new MediaFolderValidationError(
+      "A media folder cannot become its own parent",
+    )
+  }
+
+  let currentParentId: string | null = parentId
+  while (currentParentId) {
+    if (currentParentId === folderId) {
+      throw new MediaFolderValidationError(
+        "A media folder cannot be moved into one of its descendants",
+      )
+    }
+
+    const current: { parentId: string | null } | null =
+      await prisma.mediaFolder.findFirst({
+        where: { id: currentParentId },
+        select: { parentId: true },
+      })
+
+    currentParentId = current?.parentId ?? null
+  }
+}
+
+export type MediaFolderDeleteResult = Awaited<
+  ReturnType<MediaFolderService["delete"]>
+>

--- a/apps/admin/src/storage/media.test.ts
+++ b/apps/admin/src/storage/media.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { rm } from "node:fs/promises"
+import { join } from "node:path"
+import {
+  mediaObjectKey,
+  readMediaObject,
+  safeMediaFilename,
+  UnsupportedMediaBackendError,
+  writeMediaObject,
+} from "./media"
+import { writeObject } from "./s3"
+
+vi.mock("./s3", () => ({
+  writeObject: vi.fn(async (key: string) => key),
+  readObject: vi.fn(async () => new TextEncoder().encode("from-s3")),
+}))
+
+const LOCAL_MEDIA_DIR = join(process.cwd(), ".tmp", "media-assets")
+
+afterEach(async () => {
+  vi.clearAllMocks()
+  await rm(LOCAL_MEDIA_DIR, { recursive: true, force: true })
+})
+
+describe("media storage", () => {
+  it("builds stable object keys under the media-assets prefix", () => {
+    expect(
+      mediaObjectKey({
+        assetId: "asset_123",
+        variant: "preview",
+        filename: "hero.jpg",
+      }),
+    ).toBe("media-assets/asset_123/preview/hero.jpg")
+  })
+
+  it("rejects unsafe asset ids and filenames before storage writes", async () => {
+    await expect(
+      writeMediaObject({
+        backend: "LOCAL",
+        assetId: "../escape",
+        filename: "hero.jpg",
+        body: "x",
+      }),
+    ).rejects.toThrow("Invalid assetId")
+
+    await expect(
+      writeMediaObject({
+        backend: "LOCAL",
+        assetId: "asset_123",
+        filename: "../hero.jpg",
+        body: "x",
+      }),
+    ).rejects.toThrow("Invalid filename")
+  })
+
+  it("normalizes uploaded filenames into safe object key components", () => {
+    expect(safeMediaFilename("Hero Image (Final).webp")).toBe(
+      "Hero-Image-Final-.webp",
+    )
+    expect(safeMediaFilename("../../secret")).toBe("secret")
+    expect(safeMediaFilename("")).toBe("upload.bin")
+  })
+
+  it("writes and reads local media objects without S3 credentials", async () => {
+    const key = await writeMediaObject({
+      backend: "LOCAL",
+      assetId: "asset_123",
+      filename: "hero.jpg",
+      body: "image-bytes",
+      contentType: "image/jpeg",
+    })
+
+    expect(key).toBe("media-assets/asset_123/original/hero.jpg")
+
+    const bytes = await readMediaObject({ backend: "LOCAL", key })
+    expect(new TextDecoder().decode(bytes)).toBe("image-bytes")
+  })
+
+  it("rejects unsafe object keys before storage reads", async () => {
+    await expect(
+      readMediaObject({ backend: "LOCAL", key: "../secret" }),
+    ).rejects.toThrow("Invalid media object key")
+
+    await expect(
+      readMediaObject({
+        backend: "S3",
+        key: "media-assets/asset_123/original/../../secret",
+      }),
+    ).rejects.toThrow("Invalid media object key")
+  })
+
+  it("delegates S3-compatible writes to the object-key API", async () => {
+    const key = await writeMediaObject({
+      backend: "S3",
+      assetId: "asset_123",
+      filename: "hero.jpg",
+      body: "image-bytes",
+      contentType: "image/jpeg",
+    })
+
+    expect(key).toBe("media-assets/asset_123/original/hero.jpg")
+    expect(writeObject).toHaveBeenCalledWith(
+      "media-assets/asset_123/original/hero.jpg",
+      "image-bytes",
+      "image/jpeg",
+    )
+  })
+
+  it("does not support direct byte writes to the future Mux backend", async () => {
+    await expect(
+      writeMediaObject({
+        backend: "MUX",
+        assetId: "asset_123",
+        filename: "source.mp4",
+        body: "video",
+        contentType: "video/mp4",
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedMediaBackendError)
+  })
+})

--- a/apps/admin/src/storage/media.ts
+++ b/apps/admin/src/storage/media.ts
@@ -1,0 +1,146 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { env } from "@/config/env"
+import { readObject, writeObject } from "./s3"
+
+export type MediaStorageBackend = "LOCAL" | "S3" | "MUX"
+export type MediaObjectVariant = "original" | "preview"
+
+export type WriteMediaObjectOptions = {
+  assetId: string
+  filename: string
+  variant?: MediaObjectVariant
+  body: Buffer | Uint8Array | string
+  contentType?: string
+  backend?: MediaStorageBackend
+}
+
+export type ReadMediaObjectOptions = {
+  key: string
+  backend?: MediaStorageBackend
+}
+
+export class UnsupportedMediaBackendError extends Error {
+  constructor(backend: MediaStorageBackend) {
+    super(`${backend} media storage does not support direct byte writes`)
+    this.name = "UnsupportedMediaBackendError"
+  }
+}
+
+const LOCAL_MEDIA_DIR = join(process.cwd(), ".tmp", "media-assets")
+const SAFE_KEY_COMPONENT_PATTERN = /^[a-zA-Z0-9_-]+$/
+const SAFE_FILENAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,199}$/
+
+export function defaultBackend(): MediaStorageBackend {
+  return env.RAILWAY_S3_BUCKET ? "S3" : "LOCAL"
+}
+
+export function safeMediaFilename(filename: string): string {
+  const cleaned = filename
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[^a-zA-Z0-9]+/, "")
+    .slice(0, 200)
+
+  return SAFE_FILENAME_PATTERN.test(cleaned) ? cleaned : "upload.bin"
+}
+
+function assertSafeAssetId(assetId: string): void {
+  if (!SAFE_KEY_COMPONENT_PATTERN.test(assetId)) {
+    throw new Error(
+      "Invalid assetId: must contain only alphanumeric characters, hyphens, and underscores",
+    )
+  }
+}
+
+function assertSafeVariant(variant: MediaObjectVariant): void {
+  if (variant !== "original" && variant !== "preview") {
+    throw new Error("Invalid media object variant")
+  }
+}
+
+function assertSafeFilename(filename: string): void {
+  if (!SAFE_FILENAME_PATTERN.test(filename)) {
+    throw new Error(
+      "Invalid filename: must start with a letter or digit and contain only letters, digits, '.', '-', '_'",
+    )
+  }
+}
+
+export function mediaObjectKey({
+  assetId,
+  filename,
+  variant = "original",
+}: {
+  assetId: string
+  filename: string
+  variant?: MediaObjectVariant
+}): string {
+  assertSafeAssetId(assetId)
+  assertSafeVariant(variant)
+  assertSafeFilename(filename)
+  return `media-assets/${assetId}/${variant}/${filename}`
+}
+
+export function isSafeMediaObjectKey(key: string): boolean {
+  const parts = key.split("/")
+  if (parts.length !== 4) {
+    return false
+  }
+
+  const [prefix, assetId, variant, filename] = parts
+  return (
+    prefix === "media-assets" &&
+    SAFE_KEY_COMPONENT_PATTERN.test(assetId) &&
+    (variant === "original" || variant === "preview") &&
+    SAFE_FILENAME_PATTERN.test(filename)
+  )
+}
+
+function assertSafeMediaObjectKey(key: string): void {
+  if (!isSafeMediaObjectKey(key)) {
+    throw new Error("Invalid media object key")
+  }
+}
+
+export async function writeMediaObject({
+  assetId,
+  filename,
+  variant = "original",
+  body,
+  contentType,
+  backend = defaultBackend(),
+}: WriteMediaObjectOptions): Promise<string> {
+  const key = mediaObjectKey({ assetId, filename, variant })
+
+  if (backend === "MUX") {
+    throw new UnsupportedMediaBackendError(backend)
+  }
+
+  if (backend === "S3") {
+    return writeObject(key, body, contentType)
+  }
+
+  const filePath = join(LOCAL_MEDIA_DIR, key)
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, body)
+  return key
+}
+
+export async function readMediaObject({
+  key,
+  backend = defaultBackend(),
+}: ReadMediaObjectOptions): Promise<Uint8Array> {
+  assertSafeMediaObjectKey(key)
+
+  if (backend === "MUX") {
+    throw new UnsupportedMediaBackendError(backend)
+  }
+
+  if (backend === "S3") {
+    return readObject(key)
+  }
+
+  return readFile(join(LOCAL_MEDIA_DIR, key))
+}

--- a/docs/brainstorms/2026-04-23-admin-media-asset-library-requirements.md
+++ b/docs/brainstorms/2026-04-23-admin-media-asset-library-requirements.md
@@ -1,0 +1,186 @@
+---
+date: 2026-04-23
+topic: admin-media-asset-library
+---
+
+# Admin Media Asset Library
+
+## Problem Frame
+
+`apps/admin` is replacing Strapi as the editorial source of truth, but media is
+still treated as scattered URL fields inside experience metadata and block JSON.
+Editors need a real media library for uploaded images and generic files, and
+agents need a structured way to inspect, manage, and trace media usage without
+manually spelunking through blocks.
+
+The first version should solve the immediate image needs across existing
+experience blocks while choosing a storage model that can also handle PDFs and
+future video assets. Video storage should be Mux-ready, but local development
+must never require uploading test videos to Mux. Images and generic files need
+the same local-development rule: useful local behavior without depending on
+production object storage.
+
+## Requirements
+
+**Asset Library**
+
+- R1. `apps/admin` owns the canonical media asset library for new editorial
+  work; Strapi compatibility is out of scope.
+- R2. The library supports generic asset records from the start, at minimum
+  images, videos, PDFs, and other files, while making the first authoring UX
+  image-forward for experience blocks.
+- R3. Each asset has enough editor-facing metadata to support search,
+  accessibility, and safe reuse: display name, description or notes, alt text
+  when relevant, media kind, MIME type, file size, dimensions or duration when
+  known, storage backend, processing status, and timestamps.
+- R4. Assets can be browsed, searched, filtered, previewed, and selected from
+  the media library without opening raw JSON.
+- R5. Replacing or deleting an asset must show usage impact before the action
+  is allowed, so editors do not silently break published experiences.
+
+**Storage And Backends**
+
+- R6. The media system uses a backend abstraction so metadata, usage, and block
+  references are independent of where the bytes live.
+- R7. Production images and generic files use admin-managed object storage,
+  matching the existing Railway S3 direction.
+- R8. Production videos are modeled so a future Mux backend can own video bytes,
+  processing, playback IDs, thumbnails, and duration metadata.
+- R9. Local development never uploads to Mux by default. Local video assets use
+  a local placeholder/file backend with enough metadata to exercise library,
+  selection, usage, and editor workflows.
+- R10. Local development for images and generic files uses a filesystem-backed
+  object store plus local database metadata, so uploads work offline and tests
+  can run without Railway S3 credentials.
+- R11. Public or preview URLs are generated through admin-owned access rules;
+  callers should not build storage URLs by concatenating paths.
+- R11a. Planning should evaluate S3-compatible local emulators from npm or
+  containerized tooling as an alternative or supplement to plain filesystem
+  fallback, so development can exercise production-like object-store APIs
+  without real Railway S3 credentials.
+
+**Experience Blocks And Metadata**
+
+- R12. Existing image-bearing experience surfaces can select managed assets:
+  locale OG image, block-level images, card media, background images, Bible quote
+  images, navigation carousel images, media collection item overrides, video
+  carousel item images, and video/video hero media fields.
+- R13. Block references should be asset-aware rather than durable arbitrary URL
+  strings, while planning may define a migration bridge for any existing URL
+  payloads already stored in admin.
+- R14. The editor keeps image selection ergonomic inside the block inspector:
+  choose, preview, clear, replace, and jump to the asset detail page.
+- R15. Non-image files such as PDFs can be attached where the product needs a
+  downloadable or linked file, but the first milestone does not need bespoke PDF
+  rendering inside every block.
+
+**Usage Visibility**
+
+- R16. The media library shows every known place an asset is used, including
+  entity type, entity title, locale, block type, nested item label when known,
+  field name, and a direct route back to the editor context.
+- R17. Usage detection covers both structured asset references and legacy
+  admin URL fields during the transition, so agents can find real usage even
+  before every block payload has been normalized.
+- R18. Usage data is queryable by agents in a structured form; the answer should
+  not require interpreting raw JSON paths without labels.
+
+**Agent Operations**
+
+- R19. Agents can list assets, inspect metadata, inspect usage, register or
+  upload local/dev assets, attach assets to known fields, replace asset
+  references, and report blockers with typed errors.
+- R20. Agent operations respect the same permission and service-layer rules as
+  the UI; no direct database or storage bypass becomes the blessed path.
+- R21. Agent-facing results include stable identifiers, media kind, backend,
+  status, human-readable labels, and edit routes so follow-up work is grounded.
+
+**Safety And Operations**
+
+- R22. Uploads enforce size, MIME type, and extension allowlists by media kind.
+- R23. Image uploads should capture or derive dimensions and support preview
+  placeholders where practical.
+- R24. Failed processing, missing local files, missing object-store keys, and
+  unsupported backend operations surface clear operator messages without
+  leaking storage credentials or raw provider errors.
+- R25. The first version includes tests for local storage behavior, usage
+  detection, permission gates, and block editor asset selection.
+
+## Success Criteria
+
+- An editor can upload or register an image in `apps/admin`, select it inside an
+  image-bearing experience block, save the locale, and see the image preview
+  without touching raw JSON.
+- An editor can upload or register a PDF or other generic file and see it in the
+  library with correct type/status metadata.
+- A developer can exercise image, file, and video-placeholder workflows locally
+  without Railway S3 or Mux credentials.
+- An asset detail view answers "where else is this used?" with direct links to
+  the relevant experience editor contexts.
+- An agent can answer "show me all places this image is used" and perform a
+  guarded replacement through admin service/API paths.
+- Production design is ready for Railway S3-backed images/files and future
+  Mux-backed videos without rewriting block usage semantics.
+
+## Scope Boundaries
+
+- Do not use Strapi as the source of truth for this capability.
+- Do not build Mux video upload/transcoding in the first milestone; make the
+  model and local-dev behavior ready for it.
+- Do not require public web/mobile/TV consumer migration as part of this work.
+- Do not build a full digital asset management system with approvals,
+  licensing workflows, renditions marketplace, or external CDN purge tooling.
+- Do not make deletion silent for assets with usage.
+
+## Key Decisions
+
+- **Admin-native source of truth:** The work belongs in `apps/admin` because it
+  is replacing Strapi and already owns the new editorial model.
+- **Generic assets now, image-forward UX first:** Supporting generic file kinds
+  early avoids painting the model into an image-only corner, while keeping the
+  first user workflow focused on the blocks that need images today.
+- **Backend abstraction:** Assets should not be synonymous with S3 objects or
+  Mux assets. The product needs stable editorial references even as storage
+  backends differ by environment and media kind.
+- **Local-first development behavior:** Local uploads should use filesystem
+  storage and local metadata. Local videos should not call Mux unless explicitly
+  configured for an integration test or staging workflow.
+- **Production-like local storage is worth exploring:** A simple filesystem
+  fallback is useful, but an S3-compatible local emulator may catch integration
+  issues earlier while still keeping local development offline.
+- **Structured usage map:** "Where used" is a first-class requirement because
+  both editors and agents need safe replacement and cleanup workflows.
+
+## Dependencies / Assumptions
+
+- `apps/admin` already has service-layer, permission, storage, and dashboard
+  foundations to extend.
+- Existing admin block payloads include URL-shaped media fields; planning should
+  decide whether to migrate them immediately or support a transitional bridge.
+- Railway S3 remains the production object storage direction for admin-managed
+  non-video files.
+- Mux is the preferred future production backend for uploaded videos, but local
+  development should default to a non-Mux backend.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R3-R8][Technical] What exact asset table shape, backend enum, and
+  processing status model best fit the existing Prisma conventions?
+- [Affects R11][Technical] Should preview/public delivery use signed admin
+  routes, direct object URLs, or a mixed policy by asset visibility?
+- [Affects R10-R11a][Needs research] Should local development keep the current
+  filesystem fallback, use an npm/container S3-compatible emulator, or support
+  both with explicit test tiers?
+- [Affects R12-R17][Technical] Should usage be computed on demand from block
+  JSON, maintained as an index table, or both?
+- [Affects R13][Technical] How aggressively should existing URL fields in admin
+  data be normalized to asset references in the first implementation?
+- [Affects R19-R21][Technical] Should agent operations be exposed as GraphQL
+  mutations/queries only, or should MCP/tool wrappers be added after the API is
+  stable?
+
+## Next Steps
+
+-> /ce:plan for structured implementation planning.

--- a/docs/plans/2026-04-23-001-feat-admin-media-asset-library-plan.md
+++ b/docs/plans/2026-04-23-001-feat-admin-media-asset-library-plan.md
@@ -1,0 +1,742 @@
+---
+title: Admin Media Asset Library
+type: feat
+status: active
+date: 2026-04-23
+origin: docs/brainstorms/2026-04-23-admin-media-asset-library-requirements.md
+---
+
+# Admin Media Asset Library
+
+## Overview
+
+Build an admin-native media asset library in `apps/admin` for images, PDFs,
+generic files, and future video assets. The first user-facing slice makes image
+selection work inside the experience editor, while the underlying model supports
+generic files and a future Mux-backed video backend. Local development must work
+without Railway S3 or Mux credentials.
+
+The plan intentionally treats this as a media subsystem, not a widget. Assets
+get canonical metadata, backend-aware storage, usage discovery, permissioned
+service operations, and editor/agent entry points.
+
+## Problem Frame
+
+`apps/admin` is replacing Strapi as the editorial source of truth, but media is
+currently stored as scattered URL strings in `ExperienceLocale.ogImageUrl` and
+block JSON. Editors cannot safely reuse, replace, or delete images because they
+cannot see where a file is used. Agents have the same problem at a lower level:
+they can inspect raw JSON, but there is no structured answer to "where is this
+image used?" or "replace this image everywhere it appears."
+
+The origin requirements define the durable behavior and boundaries (see origin:
+`docs/brainstorms/2026-04-23-admin-media-asset-library-requirements.md`).
+
+## Requirements Trace
+
+- R1-R5. Add an admin-owned asset library with browsable, searchable, reusable
+  asset records and guarded replacement/deletion.
+- R6-R11a. Keep storage backend-aware, with Railway S3 for production
+  images/files, local development without real cloud credentials, future
+  Mux-ready video metadata, and a decision on S3-compatible local emulation.
+- R12-R15. Let existing image-bearing experience metadata and blocks choose
+  managed assets while keeping first-slice PDF/file support pragmatic.
+- R16-R18. Provide structured "where used" visibility across metadata and
+  nested block JSON, including transitional URL fields.
+- R19-R21. Expose agent-friendly operations through the same service/API layer
+  as the UI.
+- R22-R25. Enforce upload validation, derive image metadata where practical,
+  surface clear errors, and test local storage, usage, permissions, and editor
+  asset selection.
+
+## Scope Boundaries
+
+- Do not use Strapi as a source-of-truth or migration dependency.
+- Do not build real Mux upload/transcoding in this first milestone.
+- Do not require web/mobile/TV consumer migration.
+- Do not build approvals, licensing workflows, rendition marketplaces, or CDN
+  purge tooling.
+- Do not permit silent deletion or replacement when usage exists.
+- Do not let callers concatenate object storage URLs; all preview/download URLs
+  come from admin-owned helpers.
+
+### Deferred to Separate Tasks
+
+- **Mux upload/transcoding:** This plan defines the backend boundary and fields,
+  but actual Mux direct-upload creation, webhooks, and playback publication land
+  later.
+- **Materialized usage index:** This plan starts with deterministic on-demand
+  usage scanning. A persisted usage index is a later optimization if scan cost
+  becomes meaningful.
+- **Public consumer rendering:** Existing public apps keep their current content
+  path until the broader admin consumer migration work lands.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/AGENTS.md` and `apps/admin/CLAUDE.md` define the hard boundary:
+  UI calls services/GraphQL, services own mutations, Prisma is the data layer,
+  and permission checks belong in services.
+- `apps/admin/src/storage/s3.ts` already provides Railway S3 plus local fallback
+  object APIs with safe key validation and timeout-bound S3 calls.
+- `apps/admin/src/storage/s3.test.ts` and
+  `apps/admin/src/storage/s3.s3-backend.test.ts` split local fallback tests
+  from S3-client behavior tests. Keep that tiering.
+- `apps/admin/src/services/experience.service.ts` shows the service mutation
+  pattern: Zod parse, permission/ABAC check, Prisma write, revision snapshot.
+- `apps/admin/src/services/experience.schemas.ts` and
+  `apps/admin/src/domain/blocks.ts` are the service-boundary validation layer
+  for experience metadata and blocks.
+- `apps/admin/src/graphql/types/experience.ts` and
+  `apps/admin/src/graphql/schema.ts` show the Pothos side-effect registration
+  pattern and classification tags.
+- `apps/admin/src/app/dashboard/media/page.tsx` is currently a read-heavy media
+  signals page. This becomes the asset library workflow surface.
+- `apps/admin/src/app/dashboard/experiences/experience-editor.tsx` already has
+  visual affordances and strings for choosing images/videos from a media
+  library, but the backing asset picker is not real yet.
+- `apps/admin/prisma/schema.prisma` already has `VideoImage`, `MuxVideo`, and
+  `ExperienceLocale.ogImageUrl`, but no generic `MediaAsset`.
+
+### Institutional Learnings
+
+- `docs/solutions/deployment/nextjs-pnpm-monorepo-railway-standalone.md`:
+  production storage cannot rely on ephemeral local files.
+- `docs/solutions/platform/optional-railway-s3-local-fallback.md` is referenced
+  by the admin foundation plan as the local-storage fallback precedent.
+- `docs/solutions/security-issues/zod-validation-errors-must-not-echo-user-controlled-input-20260420.md`:
+  upload/type validation errors should be clear but not echo unsafe input or
+  raw provider details.
+- `docs/solutions/best-practices/verify-infra-writes-via-independent-read-path-20260420.md`:
+  verify stored object writes through a read path, not only by trusting the
+  write call response.
+
+### External References
+
+- `s3rver` is an npm S3-like server for sandbox testing, but the current npm
+  package is `3.7.1` and last modified in 2022. Useful as a lightweight option,
+  but not a strong default for production-like parity.
+- `fake-s3` is also old (`3.1.3`, modified in 2022) and should not be the main
+  recommendation.
+- MinIO provides S3-compatible object storage that can run in a local container
+  and works with normal S3 clients by changing endpoint/credentials:
+  https://docs.min.io/
+- LocalStack supports S3 locally and can serve as a broader AWS-service emulator:
+  https://docs.localstack.cloud/aws/services/s3/
+- Mux Direct Uploads return signed upload URLs and create assets asynchronously;
+  local development should not call this path by default:
+  https://www.mux.com/docs/api-reference/video/direct-uploads
+
+## Key Technical Decisions
+
+- **Canonical `MediaAsset` records, not storage-object records:** The asset
+  record is the editorial identity. Storage object keys, Mux IDs, local paths,
+  and preview keys are backend details.
+- **Generic model now, image-forward UI first:** Add kinds for `IMAGE`, `VIDEO`,
+  `PDF`, and `FILE`. The first polished picker/preview path targets images
+  because that unblocks existing blocks.
+- **Additive asset references in block JSON:** Introduce asset-ID fields beside
+  existing URL fields (`imageAssetId`, `backgroundImageAssetId`,
+  `mediaAssetId`, `imageOverrideAssetId`, etc.). New editor writes treat the
+  asset ID as canonical; existing URL fields remain transitional preview/cache
+  fields until downstream consumers are migrated.
+- **On-demand usage scanning first:** Build a deterministic scanner over
+  `ExperienceLocale` metadata and blocks. It returns structured labels and JSON
+  paths. Persisting a usage index is deferred until scan cost or replacement
+  concurrency proves it is needed.
+- **Filesystem fallback remains the default local/test backend:** Keep normal
+  tests fast and offline. Add documentation and env support for pointing the
+  existing S3 backend at MinIO/LocalStack for integration parity rather than
+  adding a stale npm emulator dependency now.
+- **Mux is a backend boundary, not first-slice behavior:** Store Mux-ready
+  fields and statuses for video assets, but local videos use placeholder/local
+  metadata and never upload to Mux unless explicitly configured later.
+- **UI uploads can use server actions, but all behavior goes through services:**
+  Binary upload through GraphQL is not required for this milestone. The UI can
+  submit multipart forms to server actions/routes that call `MediaAssetService`;
+  GraphQL exposes listing, inspection, usage, registration, and replacement
+  operations for agents and non-binary workflows.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Filesystem fallback vs S3 emulator:** Use filesystem fallback for normal
+  dev/test and support S3-compatible emulators as an optional integration tier
+  by configuring the existing S3 endpoint/bucket/env vars. Do not add `s3rver`
+  or `fake-s3` as a dependency in the first implementation.
+- **Usage table vs on-demand scan:** Start on demand. Keep the scanner pure and
+  deterministic so a future materialized table can reuse it.
+- **GraphQL upload vs service-backed server action:** Avoid GraphQL multipart
+  upload complexity for the first slice. Use services as the invariant; expose
+  non-binary agent operations through GraphQL.
+- **Existing URL fields:** Do not break them immediately. Treat URL fields as
+  legacy/preview and introduce canonical asset-ID fields additively.
+
+### Deferred to Implementation
+
+- Exact migration filename after implementation starts. The next migration will
+  follow `apps/admin/prisma/migrations/0005_*`.
+- Final field names in the experience editor helper functions; the plan names
+  canonical concepts, not exact local variable names.
+- Whether image dimension extraction uses a small dependency or built-in
+  parsing. The implementer should choose based on package health and supported
+  formats during implementation.
+
+## Output Structure
+
+Expected new/expanded shape:
+
+```text
+apps/admin/src/services/
+  media-asset.schemas.ts
+  media-asset.service.ts
+  media-asset.usage.ts
+  media-asset.service.test.ts
+  media-asset.usage.test.ts
+apps/admin/src/graphql/types/
+  mediaAsset.ts
+apps/admin/src/graphql/mutations/
+  media-asset.ts
+apps/admin/src/storage/
+  media.ts
+  media.test.ts
+apps/admin/src/app/dashboard/media/
+  page.tsx
+  media-actions.ts
+  [id]/page.tsx
+apps/admin/prisma/migrations/0005_media_assets/
+  migration.sql
+```
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+flowchart TB
+  Editor["Experience editor"] --> Picker["Asset picker / upload action"]
+  MediaPage["/dashboard/media"] --> MediaService["MediaAssetService"]
+  Agent["GraphQL / agent caller"] --> MediaGraphQL["MediaAsset GraphQL fields"]
+  Picker --> MediaService
+  MediaGraphQL --> MediaService
+  MediaService --> Prisma["Prisma MediaAsset rows"]
+  MediaService --> Storage["Media storage adapter"]
+  Storage --> Local["Local filesystem"]
+  Storage --> S3["Railway S3 or local S3 emulator"]
+  Storage -. future .-> Mux["Mux video backend"]
+  MediaService --> Usage["Usage scanner"]
+  Usage --> ExperienceLocale["ExperienceLocale metadata + blocks JSON"]
+```
+
+Asset references in blocks should follow this transition rule:
+
+```text
+new writes:
+  imageAssetId = "asset_cuid"
+  imageUrl = generated preview URL/cache only when needed by current renderers
+
+usage scanner:
+  prefer asset-id matches
+  also match legacy URL fields against asset URLs/object keys during transition
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Media Asset Data Model And Permissions**
+
+**Goal:** Add first-class `MediaAsset` persistence and permission gates.
+
+**Requirements:** R1-R3, R5-R8, R19-R22
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/admin/prisma/schema.prisma`
+- Create: `apps/admin/prisma/migrations/0005_media_assets/migration.sql`
+- Modify: `apps/admin/src/auth/permissions.ts`
+- Test: `apps/admin/src/auth/permissions.test.ts`
+- Test: `apps/admin/src/graphql/classification.test.ts`
+
+**Approach:**
+
+- Add enums for media kind, storage backend, visibility, and processing status.
+  Suggested concepts:
+  - kind: image, video, pdf, file
+  - backend: local, s3, mux
+  - status: pending, uploading, processing, ready, failed, missing
+  - visibility: private, public
+- Add `MediaAsset` with editor metadata (`displayName`, `description`,
+  `altText`), file metadata (`mimeType`, `byteSize`, `width`, `height`,
+  `durationMs`, `originalFilename`, `checksumSha256`), backend identifiers
+  (`objectKey`, `previewObjectKey`, `muxAssetId`, `muxUploadId`,
+  `muxPlaybackId`), status/error metadata, creator, timestamps, and indexes for
+  browse/search filters.
+- Keep `VideoImage` unchanged. It remains Core/video-derived poster metadata,
+  not the generic editorial asset model.
+- Add permission keys such as `read:media-assets`, `write:media-assets`, and
+  `delete:media-assets`. EDITOR can create/update non-destructive assets;
+  destructive delete remains ADMIN or explicitly usage-gated in service.
+- Add classification expectations for the future Pothos `MediaAsset` type.
+
+**Patterns to follow:**
+
+- `apps/admin/prisma/schema.prisma` enum/comment style.
+- `apps/admin/src/auth/permissions.ts` permission matrix pattern.
+- `apps/admin/src/graphql/classification.test.ts` for type classification
+  guardrails.
+
+**Test scenarios:**
+
+- Happy path: `hasPermission(editor, "write:media-assets")` returns true.
+- Error path: VIEWER cannot write or delete media assets.
+- Error path: PUBLIC cannot read private media assets once service ABAC exists.
+- Schema guard: a new Pothos media type must include a classification tag.
+
+**Verification:**
+
+- Prisma schema has a generic asset table with backend-independent metadata.
+- Permission matrix compiles and tests cover read/write/delete tiers.
+
+- [ ] **Unit 2: Storage Adapter For Media Objects**
+
+**Goal:** Add a media-focused storage boundary that supports local filesystem,
+S3-compatible object storage, and future Mux video backends without exposing
+raw object paths to callers.
+
+**Requirements:** R6-R11a, R22-R24
+
+**Dependencies:** Unit 1
+
+**Files:**
+
+- Create: `apps/admin/src/storage/media.ts`
+- Test: `apps/admin/src/storage/media.test.ts`
+- Modify: `apps/admin/src/storage/s3.ts`
+- Test: `apps/admin/src/storage/s3.test.ts`
+- Test: `apps/admin/src/storage/s3.s3-backend.test.ts`
+- Modify: `apps/admin/src/config/env.ts`
+- Test: `apps/admin/src/config/env.test.ts`
+- Modify: `apps/admin/.env.example`
+
+**Approach:**
+
+- Keep `apps/admin/src/storage/s3.ts` as the low-level object API. Add a
+  media adapter above it for object-key construction, backend selection,
+  content type, byte limits, and preview URL generation.
+- Local backend writes under a media-specific directory such as
+  `.tmp/media-assets/<asset-id>/original`.
+- S3 backend writes under stable object keys such as
+  `media-assets/<asset-id>/original/<safe-filename>` and optional preview keys.
+- Add env/config support only where needed. Existing `RAILWAY_S3_*` variables
+  should already allow pointing at MinIO or LocalStack through endpoint,
+  bucket, region, and credentials.
+- Document emulator usage in `.env.example` or operational docs, but do not add
+  `s3rver`/`fake-s3` dependencies.
+- Represent Mux as an unsupported/future backend in this unit: service calls
+  should fail clearly if an implementation tries to upload bytes to Mux before
+  the real backend exists.
+
+**Patterns to follow:**
+
+- `apps/admin/src/storage/s3.ts` safe key validation and production fail-fast.
+- `apps/admin/src/storage/s3.s3-backend.test.ts` mocked AWS SDK behavior.
+- `apps/admin/src/scripts/refresh-core-id-mapping.ts` local fallback layout
+  comments for developer ergonomics.
+
+**Test scenarios:**
+
+- Happy path: local media write returns a stable object key and read path can
+  retrieve the same bytes.
+- Happy path: S3 backend sends `PutObjectCommand` with bucket, key, body, and
+  content type.
+- Error path: unsafe filenames/object keys are rejected before storage calls.
+- Error path: production without configured S3 fails loudly for non-local
+  backend.
+- Error path: Mux byte upload returns a typed unsupported-backend error.
+- Integration expectation: document a MinIO/LocalStack env profile; do not make
+  it part of normal unit test runs.
+
+**Verification:**
+
+- Media service callers can ask for write/read/preview behavior without knowing
+  whether the backend is local or S3.
+- Local tests run without Railway S3 credentials.
+
+- [ ] **Unit 3: Media Asset Service And GraphQL API**
+
+**Goal:** Implement service-layer asset CRUD/registration, metadata validation,
+preview/download URL generation, and agent-friendly GraphQL operations.
+
+**Requirements:** R1-R5, R11, R18-R24
+
+**Dependencies:** Units 1-2
+
+**Files:**
+
+- Create: `apps/admin/src/services/media-asset.schemas.ts`
+- Create: `apps/admin/src/services/media-asset.service.ts`
+- Test: `apps/admin/src/services/media-asset.service.test.ts`
+- Modify: `apps/admin/src/services/index.ts`
+- Create: `apps/admin/src/graphql/types/mediaAsset.ts`
+- Create: `apps/admin/src/graphql/mutations/media-asset.ts`
+- Modify: `apps/admin/src/graphql/schema.ts`
+- Test: `apps/admin/src/graphql/schema.test.ts`
+- Test: `apps/admin/src/graphql/schema.security.test.ts`
+
+**Approach:**
+
+- Add Zod schemas for create/register/update/filter inputs. Validate MIME kind
+  compatibility (`image/*` -> image, `application/pdf` -> pdf, common video
+  MIME types -> video).
+- Add service methods for:
+  - list/search/filter assets
+  - get asset by id
+  - create/register asset metadata
+  - upload/store image or file bytes from UI server actions
+  - update metadata such as display name, notes, alt text
+  - generate preview/download URLs through the storage adapter
+  - mark missing/failed states with sanitized messages
+- Add GraphQL query/mutation fields for non-binary operations useful to agents:
+  list, inspect, usage handoff in Unit 4, register local/dev asset, update
+  metadata, request replacement.
+- Avoid GraphQL file upload in this milestone. UI binary uploads call service
+  methods directly from server actions/routes.
+- Ensure all service mutations call permission helpers before storage or Prisma
+  writes.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/experience.service.ts` service method structure.
+- `apps/admin/src/services/errors.ts` typed service errors.
+- `apps/admin/src/graphql/types/experience.ts` Pothos type/query style.
+
+**Test scenarios:**
+
+- Happy path: EDITOR registers an image asset with metadata and receives a
+  ready local-backed asset row.
+- Happy path: ADMIN updates asset metadata and generated preview URL comes from
+  the service/storage helper.
+- Happy path: agent-style GraphQL list returns stable id, kind, backend, status,
+  label, and timestamps.
+- Edge case: PDF registers as `PDF`, not generic `FILE`.
+- Error path: MIME/kind mismatch is rejected.
+- Error path: VIEWER cannot create or update assets.
+- Error path: raw storage/provider error maps to a sanitized service error.
+
+**Verification:**
+
+- Asset list/inspect/update operations work through services and GraphQL.
+- No resolver directly calls Prisma for media mutations.
+
+- [ ] **Unit 4: Usage Scanner And Safe Replacement Guards**
+
+**Goal:** Provide structured "where used" data and block destructive operations
+when assets are still referenced.
+
+**Requirements:** R5, R16-R18, R19-R21, R24
+
+**Dependencies:** Units 1 and 3
+
+**Files:**
+
+- Create: `apps/admin/src/services/media-asset.usage.ts`
+- Test: `apps/admin/src/services/media-asset.usage.test.ts`
+- Modify: `apps/admin/src/services/media-asset.service.ts`
+- Test: `apps/admin/src/services/media-asset.service.test.ts`
+- Modify: `apps/admin/src/graphql/types/mediaAsset.ts`
+- Modify: `apps/admin/src/graphql/mutations/media-asset.ts`
+
+**Approach:**
+
+- Build a pure usage scanner that accepts asset rows and `ExperienceLocale`
+  records and emits structured usage objects:
+  - asset id
+  - entity type/id/title
+  - locale
+  - field name
+  - block type
+  - nested item label/index when available
+  - JSON path
+  - editor route
+  - source type: asset-id reference or legacy URL match
+- Scan:
+  - `ExperienceLocale.ogImageUrl`
+  - top-level block fields
+  - nested section/container content
+  - Bible quote items
+  - navigation carousel items
+  - media collection items
+  - video carousel items
+- Add a registry of media field descriptors rather than scattering ad hoc
+  string checks through the scanner.
+- Add service guard methods:
+  - `getUsage(assetId)`
+  - `canDelete(assetId)` or `deleteAsset({ force: false })`
+  - guarded replacement for known asset-ID fields, leaving legacy URL-only
+    mass replacement either unsupported or preview-only until a human confirms.
+- Do not maintain a materialized usage table in this unit.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/embeddings.service.ts` block traversal style.
+- `apps/admin/src/domain/blocks.ts` block shape and nested field names.
+- `apps/admin/src/app/dashboard/experiences/[id]/page.tsx` editor route shape.
+
+**Test scenarios:**
+
+- Happy path: usage scanner finds an asset used in `ogImageAssetId` or
+  equivalent locale metadata.
+- Happy path: usage scanner finds an asset in a top-level card media field.
+- Happy path: usage scanner finds an asset inside a nested media collection
+  item and includes block/item labels.
+- Transition path: scanner reports legacy URL usage when an asset's generated
+  URL/object URL matches an existing `imageUrl` field.
+- Error path: delete without force is rejected when usage exists.
+- Error path: replacement rejects incompatible kind, such as replacing an image
+  field with a PDF asset.
+
+**Verification:**
+
+- Asset detail and GraphQL usage calls can answer where an asset is used without
+  exposing raw JSON only.
+- Destructive operations are usage-aware.
+
+- [ ] **Unit 5: Block Schemas And Experience Editor Asset References**
+
+**Goal:** Make existing image-bearing blocks asset-aware while preserving
+current save/publish behavior and transitional URL compatibility.
+
+**Requirements:** R12-R15, R22-R25
+
+**Dependencies:** Units 1, 3, and 4
+
+**Files:**
+
+- Modify: `apps/admin/src/domain/blocks.ts`
+- Test: `apps/admin/src/domain/blocks.test.ts`
+- Modify: `apps/admin/src/services/experience.schemas.ts`
+- Test: `apps/admin/src/services/experience.service.test.ts`
+- Modify: `apps/admin/src/app/dashboard/experiences/[id]/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/experiences/experience-editor.tsx`
+- Test: `apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx`
+
+**Approach:**
+
+- Add optional asset-ID fields to the current block schemas:
+  - `imageAssetId` next to `imageUrl`
+  - `backgroundImageAssetId` next to `backgroundImageUrl`
+  - `mediaAssetId` next to `mediaUrl`
+  - `imageOverrideAssetId` next to `imageOverrideUrl`
+- Add `ogImageAssetId` to the experience locale edit path if the data model
+  supports it in Unit 1. Keep `ogImageUrl` as transitional metadata.
+- Validate that asset-ID fields are strings and let the service check existence
+  and kind compatibility before save.
+- Update save actions to preserve asset IDs through JSON serialization.
+- In the editor, implement at least one complete image-field integration first
+  (recommended: card `mediaAssetId` or section `backgroundImageAssetId`), then
+  apply the same picker control to the other image fields.
+- The picker should support choose, preview, clear, replace, and jump to asset
+  detail.
+- Keep URL fields visible or available only as legacy/advanced fallback if
+  needed during transition.
+
+**Patterns to follow:**
+
+- Existing `experience-editor.tsx` block inspector helpers around
+  `backgroundImageUrl`, `mediaUrl`, and `imageUrl`.
+- Existing video picker modal patterns in the experience editor.
+- `apps/admin/src/domain/blocks.ts` strict Zod schemas.
+
+**Test scenarios:**
+
+- Happy path: block schema accepts `imageAssetId` plus existing `imageUrl`.
+- Happy path: editor selecting an image asset updates the selected block and
+  hidden blocks JSON submitted to the server.
+- Happy path: clearing an asset removes the asset ID and preview URL/cache for
+  that field.
+- Edge case: existing URL-only block data still parses and renders in the
+  editor.
+- Error path: saving a block with a non-image asset in an image field is
+  rejected by the service.
+- Integration: update an experience locale with an asset-aware block, reload
+  the editor, and see the selected asset preview state restored.
+
+**Verification:**
+
+- An editor can select a managed image for at least one block image field,
+  persist it, reload, and see usage on the asset detail page.
+
+- [ ] **Unit 6: Media Library Dashboard And Asset Detail View**
+
+**Goal:** Turn `/dashboard/media` into an operational asset library with upload,
+search/filter, preview, metadata editing, and usage inspection.
+
+**Requirements:** R3-R5, R14-R18, R22-R25
+
+**Dependencies:** Units 1-5
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/media/page.tsx`
+- Create: `apps/admin/src/app/dashboard/media/media-actions.ts`
+- Create: `apps/admin/src/app/dashboard/media/[id]/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Modify: `apps/admin/src/i18n/messages.ts`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Replace the read-heavy "Recent Media Rows" posture with an asset library
+  table/grid fed by `MediaAssetService`.
+- Add filters for kind, backend, status, and search text.
+- Add an upload/register form. Image/PDF/file binary upload can go through a
+  server action that calls the service; local video assets should be
+  register/placeholder only in this milestone.
+- Add asset detail page with metadata, preview/download action, backend/status,
+  usage list, and guarded delete/replace actions.
+- Use existing `admin-ui` primitives (`DashboardPageHeader`, `DataTable`,
+  `PageSection`, `OperatorRail`) unless the current primitives cannot support
+  the workflow.
+- Keep copy operational, not marketing. Avoid in-app explanatory text about
+  implementation details.
+
+**Patterns to follow:**
+
+- `apps/admin/src/app/dashboard/experiences/page.tsx` server-action pattern.
+- `apps/admin/src/app/dashboard/media/page.tsx` current layout primitives.
+- `apps/admin/src/components/confirm-modal.tsx` for destructive confirmation.
+
+**Test scenarios:**
+
+- Happy path: media page renders asset rows with kind, status, backend, and
+  updated timestamp.
+- Happy path: image upload/register action calls service and redirects or
+  revalidates to show the new asset.
+- Happy path: asset detail shows metadata and usage rows.
+- Edge case: empty library shows an operator-ready empty state with upload
+  action.
+- Error path: delete action with usage returns a visible blocked state.
+- Error path: failed/missing asset shows status without raw provider errors.
+
+**Verification:**
+
+- `/dashboard/media` is a real asset workflow, not just an operations summary.
+- Asset detail gives editors a safe place to inspect and act.
+
+- [ ] **Unit 7: Documentation, Emulator Guidance, And Roadmap Closeout**
+
+**Goal:** Document the media subsystem, local storage choices, and follow-up
+boundaries so future agents do not rediscover the same decisions.
+
+**Requirements:** R6-R11a, R19-R21, R24-R25
+
+**Dependencies:** Units 1-6
+
+**Files:**
+
+- Modify: `apps/admin/CLAUDE.md`
+- Modify: `apps/admin/docs/cms-operational-vs-deferred.md`
+- Create: `apps/admin/docs/media-assets.md`
+- Modify: `docs/roadmap/platform/feat-107-admin-media-asset-library.md`
+- Optional create: `docs/solutions/platform/admin-media-asset-local-storage-pattern.md`
+
+**Approach:**
+
+- Add an admin playbook section covering:
+  - MediaAsset model role
+  - local filesystem backend
+  - optional S3 emulator tier via S3 endpoint env vars
+  - future Mux backend boundary
+  - how to add a new asset kind or field usage descriptor
+  - agent operations and permission constraints
+- Update operational/deferred docs to mark what is now real and what remains
+  future work.
+- If implementation discovers a durable local storage/emulator pattern, capture
+  it in `docs/solutions/platform/`.
+- Complete the roadmap ticket only after implementation and validation pass.
+
+**Patterns to follow:**
+
+- `apps/admin/docs/add-a-new-entity.md` for agent-readable structure.
+- Existing `docs/solutions/` concise learning style.
+- Roadmap status rules in `CLAUDE.md`.
+
+**Test scenarios:**
+
+- Test expectation: none for documentation-only updates, beyond the validation
+  commands for the whole feature.
+
+**Verification:**
+
+- A future agent can understand how to use and extend media assets without
+  reading the full implementation first.
+
+## System-Wide Impact
+
+- **Interaction graph:** Media touches dashboard pages, server actions,
+  services, Prisma, storage, GraphQL, and experience editor block JSON.
+- **Error propagation:** Storage/provider failures should map to typed service
+  errors, then UI/GraphQL-safe messages. Do not expose credentials, object-store
+  internals, or raw provider responses.
+- **State lifecycle risks:** Uploads can create metadata without bytes or bytes
+  without committed metadata if not transactional. Prefer writing bytes first to
+  a deterministic key, then committing metadata with clear cleanup/status rules.
+- **API surface parity:** UI and agent paths must use the same service methods
+  for register, inspect, usage, replace, and delete decisions.
+- **Integration coverage:** Unit tests cover pure scanner/storage/service logic;
+  at least one cross-layer test should prove editor save -> asset usage detail.
+- **Unchanged invariants:** Existing `VideoImage` Core sync data remains
+  read-oriented video poster metadata. Existing public consumers are not
+  migrated by this work.
+
+## Risks & Dependencies
+
+| Risk                                                            | Mitigation                                                                                                       |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Block JSON migration becomes too large for one PR               | Add asset-ID fields additively and preserve URL fields during transition.                                        |
+| Local storage diverges from production S3 behavior              | Keep filesystem tests for speed and document MinIO/LocalStack as optional S3 endpoint integration tier.          |
+| Usage scanning misses nested fields                             | Centralize media field descriptors and test top-level, section/container, carousel, quote, and collection cases. |
+| Deleting/replacing breaks published content                     | Make service delete/replace usage-aware by default and require explicit guarded behavior for destructive paths.  |
+| Mux-ready fields imply Mux is implemented                       | Keep statuses/backend errors explicit; document real Mux upload as future work.                                  |
+| Large binary uploads through server actions stress Next runtime | Keep file size allowlists conservative; defer resumable/large video uploads to future Mux direct-upload work.    |
+
+## Documentation / Operational Notes
+
+- Update `.env.example` or admin docs with a local S3 emulator example that
+  points `RAILWAY_S3_ENDPOINT`, `RAILWAY_S3_BUCKET`,
+  `RAILWAY_S3_ACCESS_KEY_ID`, and `RAILWAY_S3_SECRET_ACCESS_KEY` at a local
+  MinIO/LocalStack instance.
+- Production must continue to fail closed when object storage is required but
+  not configured.
+- Local video placeholders should be visually and operationally distinguishable
+  from real Mux-backed assets.
+- Roadmap `feat-107` is already in progress for planning. Mark complete only
+  after implementation validation, not after this plan alone.
+
+## Success Metrics
+
+- Editors can upload/register an image, choose it in an experience block, save,
+  reload, and see usage from the asset detail page.
+- Editors can register/upload a PDF/generic file and see correct metadata and
+  status in the media library.
+- Developers can run normal tests without Railway S3 or Mux credentials.
+- Agents can query asset metadata and structured usage through the admin API.
+- Destructive operations are blocked or clearly guarded when usage exists.
+
+## Sources & References
+
+- Origin document:
+  `docs/brainstorms/2026-04-23-admin-media-asset-library-requirements.md`
+- Roadmap ticket: `docs/roadmap/platform/feat-107-admin-media-asset-library.md`
+- Admin guide: `apps/admin/AGENTS.md`
+- Admin conventions: `apps/admin/CLAUDE.md`
+- Existing storage adapter: `apps/admin/src/storage/s3.ts`
+- Existing block schemas: `apps/admin/src/domain/blocks.ts`
+- Existing editor: `apps/admin/src/app/dashboard/experiences/experience-editor.tsx`
+- MinIO docs: https://docs.min.io/
+- LocalStack S3 docs: https://docs.localstack.cloud/aws/services/s3/
+- Mux Direct Uploads: https://www.mux.com/docs/api-reference/video/direct-uploads
+- s3rver npm package: https://www.npmjs.com/package/s3rver

--- a/docs/roadmap/platform/feat-107-admin-media-asset-library.md
+++ b/docs/roadmap/platform/feat-107-admin-media-asset-library.md
@@ -1,0 +1,104 @@
+---
+id: "feat-107"
+title: "Admin Media Asset Library"
+owner: "tataihono"
+priority: "P1"
+status: "complete"
+start_date: "2026-04-23"
+duration: 10
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "media"
+  - "editor"
+---
+
+## Problem
+
+`apps/admin` is replacing Strapi as the editorial source of truth, but media is
+still scattered across URL fields in experience metadata and block JSON. Editors
+need a real media library for images and generic files, and agents need a
+structured way to inspect assets, manage references, and answer where an image
+or file is used before replacing it.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-04-23-admin-media-asset-library-requirements.md` — product and architecture requirements.
+2. `apps/admin/AGENTS.md` — admin architecture rules.
+3. `apps/admin/CLAUDE.md` — service, GraphQL, Prisma, storage, and permission conventions.
+4. `apps/admin/docs/cms-operational-vs-deferred.md` — current media workflow gap.
+5. `apps/admin/src/storage/s3.ts` — existing Railway S3/local fallback storage pattern.
+6. `apps/admin/src/domain/blocks.ts` — current media URL fields in experience blocks.
+7. `apps/admin/src/app/dashboard/media/page.tsx` — current media route.
+8. `apps/admin/src/app/dashboard/experiences/experience-editor.tsx` — block editor selection UX.
+9. `apps/admin/prisma/schema.prisma` — ExperienceLocale blocks and existing VideoImage model.
+
+## Grep These
+
+- `MediaAsset|media asset|asset library` in `apps/admin docs`
+- `imageUrl|mediaUrl|backgroundImageUrl|imageOverrideUrl|ogImageUrl` in `apps/admin/src`
+- `writeArtifact|readArtifact|writeObject|readObject` in `apps/admin/src/storage`
+- `S3Client|RAILWAY_S3_BUCKET|LOCAL_OBJECT_DIR|local fallback` in `apps/admin/src`
+- `dashboard/media|Choose .* image from asset library|media library` in `apps/admin/src/app/dashboard`
+- `VideoImage|ExperienceLocale|blocks Json` in `apps/admin/prisma/schema.prisma`
+- `read:|write:|canEdit|hasPermission` in `apps/admin/src/auth apps/admin/src/services`
+
+## What To Build
+
+1. Define admin-native media asset requirements from the brainstorm as a
+   concrete implementation plan covering data model, GraphQL/service API,
+   storage, UI, usage detection, permissions, and tests.
+2. Add first-class media asset support in `apps/admin` for images, videos,
+   PDFs, and generic files, with the first editor UX optimized for image
+   selection in experience blocks.
+3. Keep storage backend-aware: Railway S3/object storage for production
+   images/files, local filesystem fallback for development/tests, and a
+   Mux-ready video backend design that does not upload to Mux in local dev.
+   During planning, evaluate whether an S3-compatible local emulator from npm
+   or containerized tooling should supplement or replace plain filesystem
+   fallback for production-like integration tests.
+4. Upgrade `/dashboard/media` from read-heavy status surface to an asset
+   library workflow: browse, filter, upload/register, preview, inspect metadata,
+   and open usage.
+5. Integrate asset selection into the experience editor for existing
+   image-bearing fields: locale OG image, block image fields, card media,
+   background images, Bible quote images, navigation carousel items, media
+   collection item overrides, video carousel item images, and video/video hero
+   media fields.
+6. Provide a structured "where used" view that can locate asset references
+   inside `ExperienceLocale` metadata and nested block JSON, with direct links
+   back to the relevant editor context.
+7. Expose agent-friendly service/API operations for listing assets, inspecting
+   metadata, inspecting usage, registering/uploading local assets, attaching
+   assets to known fields, and safely replacing references.
+
+## Constraints
+
+- Keep Strapi out of the source-of-truth path for this work.
+- Preserve admin's architecture: UI -> GraphQL/services -> Prisma/storage.
+- Do not make Mux upload/transcoding part of the first milestone; only design
+  the video backend boundary and local development behavior.
+- Do not require web/mobile/TV consumer migration in this ticket.
+- Do not allow silent deletion or replacement of assets with known usage.
+- Do not build direct storage URL concatenation into callers; centralize URL or
+  preview generation behind admin-owned logic.
+- Do not require a real Railway S3 bucket for local development or normal test
+  runs.
+
+## Verification
+
+- `pnpm --filter @forge/admin lint`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin test`
+- `pnpm --filter @forge/admin build`
+- Local dev can register/upload image, PDF, and video-placeholder assets without
+  Railway S3 or Mux credentials.
+- Plan explicitly decides filesystem fallback vs S3-compatible local emulator
+  vs both, including which test tier uses each backend.
+- Experience editor can select a managed image asset for at least one block
+  image field and persist the reference through the existing save flow.
+- Asset detail shows usage for an asset referenced by an `ExperienceLocale`
+  field and by a nested block field.
+- Replacement/deletion flow blocks or warns when usage exists.

--- a/docs/solutions/platform/admin-media-storage-local-development.md
+++ b/docs/solutions/platform/admin-media-storage-local-development.md
@@ -1,0 +1,95 @@
+---
+title: "Admin Media Storage Local Development"
+category: platform
+module: apps/admin
+date: 2026-04-23
+last_updated: 2026-05-03
+problem_type: best_practice
+component: service_object
+severity: medium
+applies_when:
+  - "Adding or changing admin MediaAsset storage, previews, or downloads"
+  - "Allowing service callers to register object keys directly"
+  - "Serving local or S3-backed media through app routes"
+tags:
+  - admin
+  - media-assets
+  - storage
+  - object-keys
+  - local-development
+---
+
+# Admin Media Storage Local Development
+
+`apps/admin` stores editorial media through `MediaAsset` records and a
+backend-aware storage helper. The asset row is the editorial identity; object
+keys, local paths, S3 buckets, and future Mux IDs are backend details.
+
+## Default Local Mode
+
+Local development and normal tests use the filesystem backend when
+`RAILWAY_S3_BUCKET` is unset:
+
+```text
+apps/admin/.tmp/media-assets/media-assets/<asset-id>/<variant>/<filename>
+```
+
+This keeps development offline and avoids accidental production object writes.
+The storage helper validates asset IDs, variants, filenames, and stored object
+keys before any write or read. Do not join a database-provided object key onto
+the local media directory until it has passed the same `media-assets/<asset-id>/<variant>/<filename>`
+shape used by `mediaObjectKey`.
+
+## Object Key Boundary
+
+`MediaAsset.objectKey` and `MediaAsset.previewObjectKey` are storage
+identifiers, not arbitrary paths. Service schemas should reject object keys
+outside this shape:
+
+```text
+media-assets/<asset-id>/(original|preview)/<filename>
+```
+
+The storage read path should also validate the key before calling local
+filesystem or S3 APIs. This prevents a bad row, unsafe service caller, or future
+import path from turning the app route into a path traversal or unrelated bucket
+object reader.
+
+## Optional S3-Compatible Mode
+
+For integration parity, run MinIO or LocalStack and point the existing Railway
+S3 env vars at that endpoint. The admin app does not need a separate emulator
+package for the common path.
+
+```env
+RAILWAY_S3_ENDPOINT=http://localhost:9000
+RAILWAY_S3_BUCKET=forge-admin-local
+RAILWAY_S3_ACCESS_KEY_ID=minioadmin
+RAILWAY_S3_SECRET_ACCESS_KEY=minioadmin
+RAILWAY_S3_REGION=us-east-1
+```
+
+Use this mode when validating S3-compatible behavior such as endpoint wiring,
+credentials, bucket policy, or object reads through the API route.
+
+## App Route Downloads
+
+The API route should serve downloads with stable app URLs such as
+`/api/media-assets/:id/download`, but response headers must not trust
+`originalFilename` directly. Normalize the header filename with the same
+filename sanitizer used for storage keys before setting `content-disposition`.
+
+## Future Mux Mode
+
+Mux is modeled as a media backend for video assets, but direct byte writes are
+not supported locally. Future Mux work should add direct-upload creation,
+webhook handling, and playback publication behind the same `MediaAsset` service
+boundary. Local video development should keep using `LOCAL` or `S3` placeholder
+assets unless Mux credentials are explicitly configured.
+
+## Usage Discovery
+
+`MediaAssetService.usage` scans `ExperienceLocale.ogImageUrl` and nested block
+JSON on demand. It matches canonical asset-id fields and transitional URL or
+object-key fields, returning structured JSON paths so editors and agents can
+see where an asset is used before replacement or deletion.


### PR DESCRIPTION
## Summary
- Adds the admin Media Library with folder navigation, asset table, inspectors, keyboard navigation, drag-and-drop moves, rename, and confirmed delete flows.
- Adds MediaAsset and MediaFolder persistence, GraphQL types/mutations, permissions, local/S3 storage helpers, and app routes for preview/download delivery.
- Integrates media asset selection into the experience editor while preserving durable asset IDs.
- Completes feat-107 roadmap docs and compounds the media storage/local development guidance.

## Review Fixes
- Hardened media object key handling so database-provided keys are validated before local/S3 reads and at service input boundaries.
- Sanitized download filenames before writing the `content-disposition` header.

## Validation
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin test`
- `pnpm --filter @forge/admin build` (passes with existing workflow heartbeat Edge-runtime warnings)
