### PR TITLE
feat(web): fix English variant selection + redesign watch share modal + harden hero loading

### DIFF
--- a/apps/web/src/components/FloatingSearchProvider.tsx
+++ b/apps/web/src/components/FloatingSearchProvider.tsx
@@ -386,6 +386,12 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
           aria-label="JesusFilm home"
           inert={chromeHidden || undefined}
           aria-hidden={chromeHidden || undefined}
+          // Clear the search query (and ?q= URL param + cached results) on
+          // click so the home navigation lands on a fresh search bar instead
+          // of carrying the previous query across.
+          onClick={() => {
+            void search("")
+          }}
           className={`fixed left-10 z-50 hidden sm:flex h-12 items-center transition-[top,opacity] duration-300 ease-out focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2 ${
             pinned ? "top-3" : "top-10"
           } ${chromeHidden ? "opacity-0 pointer-events-none" : "opacity-100"}`}

--- a/apps/web/src/components/SearchOverlay.tsx
+++ b/apps/web/src/components/SearchOverlay.tsx
@@ -146,7 +146,13 @@ export function SearchOverlay() {
         <Link
           href={"/" as Route}
           aria-label="JesusFilm home"
-          onClick={(e) => e.stopPropagation()}
+          // stopPropagation keeps the overlay from intercepting the click as
+          // a backdrop dismiss; search("") clears the query + ?q= + cached
+          // results so home navigation lands on a fresh search bar.
+          onClick={(e) => {
+            e.stopPropagation()
+            void search("")
+          }}
           className="absolute left-4 top-[30px] z-10 flex items-center rounded-full p-1 sm:hidden focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2"
         >
           <Image

--- a/apps/web/src/components/SearchOverlay.tsx
+++ b/apps/web/src/components/SearchOverlay.tsx
@@ -7,6 +7,7 @@ import type { Route } from "next"
 
 import { useFloatingSearch } from "./FloatingSearchProvider"
 import { VideoCard } from "./search/VideoCard"
+import { SpinnerIcon } from "@/components/ui/spinner"
 import { CATEGORIES } from "@/lib/search-categories"
 
 export function SearchOverlay() {
@@ -336,26 +337,7 @@ export function SearchOverlay() {
                     className="flex items-center gap-2 rounded-lg bg-white/10 px-6 py-3 text-sm font-medium text-stone-300 transition hover:bg-white/15 disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2"
                   >
                     {loadingMore && (
-                      <svg
-                        className="h-4 w-4 animate-spin"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        aria-hidden="true"
-                      >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                        />
-                      </svg>
+                      <SpinnerIcon className="h-4 w-4 animate-spin" />
                     )}
                     {loadingMore ? "Loading..." : "Load more"}
                   </button>

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,0 +1,30 @@
+// Shared SVG spinner glyph. Two consumers:
+//  - HeroPlayer (h-12 w-12 over the hero's pre-canplay black box)
+//  - SearchOverlay's "Load more" button (h-4 w-4 inline with the label)
+// `className` is forwarded so callers control sizing/coloring; the inner
+// circle/path opacity values are baked in to keep both call sites visually
+// identical to the original inline duplicates.
+export function SpinnerIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  )
+}

--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -14,6 +15,7 @@ import type { MuxCSSProperties } from "@mux/mux-player-react"
 import { env } from "@/env"
 import type { WatchHeroPlayerBlock } from "@/lib/content"
 import { getViewerId } from "@/lib/viewer-id"
+import { SpinnerIcon } from "@/components/ui/spinner"
 import { HeroPlayerControls } from "./HeroPlayerControls"
 import { MutedSpeakerIcon, UnmutedSpeakerIcon } from "./chrome-icons"
 
@@ -63,6 +65,16 @@ export function HeroPlayer({
   const [pillState, setPillState] = useState<PillState>("play-with-sound")
   const [autoplayBlocked, setAutoplayBlocked] = useState(false)
 
+  // Tracks the first paint where Mux Player has buffered enough to render the
+  // muted-loop preview. Without this, the wrapper sits at the player's initial
+  // min-height (~200px) during the buffer phase and the title overflows the
+  // hero — `aspect-video` below pins the layout, this hides the empty box
+  // behind a spinner until there's something to show.
+  const [videoReady, setVideoReady] = useState(false)
+  const handleCanPlay = useCallback(() => {
+    setVideoReady(true)
+  }, [])
+
   // Anchor for the title/pill overlay AND the chrome control bar — both live
   // in this zero-height div right after the sticky hero so they ride on the
   // body section's top edge instead of being trapped at the pinned hero's
@@ -75,7 +87,11 @@ export function HeroPlayer({
   // exactly when its bottom reaches the viewport bottom. Aspect-ratio is
   // determined by mux-player at runtime, so we measure rather than guess.
   const [heroHeight, setHeroHeight] = useState<number | null>(null)
-  useEffect(() => {
+  // useLayoutEffect: aspect-video on the wrapper means we have a real
+  // measurable height before paint, so we can install the ResizeObserver
+  // (and seed heroHeight) without flashing the fallback `top: 0px` for a
+  // frame.
+  useLayoutEffect(() => {
     const el = wrapperRef.current
     if (!el) return
     const apply = (h: number) => {
@@ -155,11 +171,24 @@ export function HeroPlayer({
     const code = (event?.detail as { code?: string } | undefined)?.code
     if (code === "autoplay-blocked") {
       setAutoplayBlocked(true)
+      return
     }
+    // Any non-autoplay-blocked error (network, decode, manifest 404…) means
+    // we will never fire onCanPlay, so videoReady would otherwise stay false
+    // forever and the spinner would sit on a black box. Reveal the player
+    // element so Mux Player can render its own error UI.
+    setVideoReady(true)
   }, [])
 
   const playbackId = variant.muxVideo?.playbackId ?? undefined
   const hlsSrc = variant.hls ?? undefined
+
+  // Reset the buffered/ready spinner when the playable identity changes
+  // (variant switch via the language picker, or new playback id), otherwise
+  // the spinner stays hidden during the next variant's pre-canplay buffer.
+  useEffect(() => {
+    setVideoReady(false)
+  }, [variant.documentId, playbackId])
 
   const loop = !chromeRevealed
   const muted = !chromeRevealed
@@ -172,7 +201,7 @@ export function HeroPlayer({
         data-testid="hero-player-wrapper"
         data-chrome-revealed={chromeRevealed ? "true" : "false"}
         data-autoplay-blocked={autoplayBlocked ? "true" : "false"}
-        className="sticky w-full overflow-hidden bg-black"
+        className="sticky aspect-video w-full overflow-hidden bg-black"
         style={{
           // 100svh tracks the *small* viewport on iOS Safari (visible area
           // when the URL bar is showing). Plain 100vh is the *large*
@@ -202,9 +231,20 @@ export function HeroPlayer({
           }}
           style={CHROME_HIDE_STYLE}
           onLoadedMetadata={handleLoadedMetadata}
+          onCanPlay={handleCanPlay}
           onError={handlePlayerError}
           className="block h-full w-full"
         />
+
+        {!videoReady ? (
+          <div
+            data-testid="hero-player-loading"
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black"
+          >
+            <SpinnerIcon className="h-12 w-12 animate-spin text-white/80" />
+          </div>
+        ) : null}
 
         {chromeRevealed ? (
           <HeroPlayerControls

--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -2,7 +2,6 @@
 
 import {
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -186,9 +185,14 @@ export function HeroPlayer({
   // Reset the buffered/ready spinner when the playable identity changes
   // (variant switch via the language picker, or new playback id), otherwise
   // the spinner stays hidden during the next variant's pre-canplay buffer.
-  useEffect(() => {
+  // The "adjust state during render" pattern (last-rendered key + render-phase
+  // setState) avoids the cascading-render warning the React Compiler raises
+  // on a useEffect-driven reset, since the new state is queued before commit.
+  const [prevVariantKey, setPrevVariantKey] = useState(variant.documentId)
+  if (prevVariantKey !== variant.documentId) {
+    setPrevVariantKey(variant.documentId)
     setVideoReady(false)
-  }, [variant.documentId, playbackId])
+  }
 
   const loop = !chromeRevealed
   const muted = !chromeRevealed

--- a/apps/web/src/components/watch/ShareModal.tsx
+++ b/apps/web/src/components/watch/ShareModal.tsx
@@ -1,105 +1,369 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import Image from "next/image"
+import { Copy, Facebook } from "lucide-react"
+
+// Inline X (formerly Twitter) glyph — lucide-react still ships the legacy
+// blue-bird Twitter icon AND exports its own `XIcon` (the close-button "x"),
+// so we use a brand-specific name to avoid both shadowing and confusion.
+// The X brand mark is a single-path SVG so an inline component keeps the
+// modal free of an extra dependency.
+function XBrandIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M18.244 2H21.5l-7.5 8.572L23 22h-6.86l-5.36-6.78L4.6 22H1.34l8.04-9.187L1 2h6.99l4.84 6.21L18.244 2zm-1.2 18h1.86L7.04 4H5.07l11.974 16z" />
+    </svg>
+  )
+}
 
 import { env } from "@/env"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+  PUBLIC_SHARE_FALLBACK_ORIGIN,
+  isPublicShareableOrigin,
+} from "@/lib/url"
+import { buildEmbedSnippet, buildFbShareUrl, buildXShareUrl } from "@/lib/share"
+import { cn } from "@/lib/utils"
 
-// Embed-snippet section was removed alongside the embed route — shipping a
-// snippet that 404s would leak broken iframes onto partner sites.
+// Re-export for backwards compat with existing tests / consumers that import
+// these from `@/components/watch/ShareModal`.
+export { PUBLIC_SHARE_FALLBACK_ORIGIN, isPublicShareableOrigin }
+
+// Optional fields here accept explicit `null` from the parent's `?? null`
+// fallback chain in WatchPageClient (`video.title ?? null`). The effective
+// type is `string | null | undefined` — callers may pass any of the three
+// without forcing a `?? undefined` re-coercion at every call site.
 export type ShareModalProps = {
   open: boolean
   videoSlug: string
   currentLanguageSlug: string
+  videoTitle?: string | null
+  videoDescription?: string | null
+  posterUrl?: string | null
+  /** Mux playback id — used to build a portable iframe embed via player.mux.com. */
+  playbackId?: string | null
   onClose: () => void
 }
 
+type ShareTab = "link" | "embed"
 type CopyStatus = "idle" | "copied" | "failed"
 
 export function ShareModal({
   open,
   videoSlug,
   currentLanguageSlug,
+  videoTitle,
+  videoDescription,
+  posterUrl,
+  playbackId,
   onClose,
 }: ShareModalProps) {
-  const [linkStatus, setLinkStatus] = useState<CopyStatus>("idle")
+  const [tab, setTab] = useState<ShareTab>("link")
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle")
+  const embedRef = useRef<HTMLTextAreaElement | null>(null)
 
-  // Includes `/watch/` because this is the externally-shareable absolute URL,
-  // not a router.push target — basePath isn't auto-prepended on bare origins.
   const origin = env.NEXT_PUBLIC_CANONICAL_ORIGIN
   const canonicalUrl = `${origin}/watch/${videoSlug}/${currentLanguageSlug}`
+  // When the configured origin can't be reached by the FB / X scrapers
+  // (localhost, private hosts, etc.) we keep the share buttons VISIBLE but
+  // render them as disabled. Sharing a localhost URL via the public fallback
+  // would otherwise poison Facebook's negative cache for the canonical slug
+  // before it actually exists in production. The button stays as an
+  // affordance hint so the user knows where sharing will appear once the
+  // page is live.
+  const isShareable = isPublicShareableOrigin(origin)
+  // Used by the Facebook + X share intents only. Copy Link / Copy Code keep
+  // the configured origin so devs can copy a localhost URL when that's what
+  // they want.
+  const shareOrigin = isShareable ? origin : PUBLIC_SHARE_FALLBACK_ORIGIN
+  const shareableUrl = `${shareOrigin}/watch/${videoSlug}/${currentLanguageSlug}`
+  // buildEmbedSnippet validates playbackId against PLAYBACK_ID_PATTERN before
+  // interpolating into the iframe `src` and returns "" on null/invalid; the
+  // Embed Code tab is also gated on `playbackId ?` below, so an invalid id
+  // hides the tab entirely.
+  const embedSnippet = buildEmbedSnippet(playbackId)
+
+  const fbHref = buildFbShareUrl(shareableUrl)
+  const xHref = buildXShareUrl(shareableUrl, videoTitle ?? undefined)
+
+  const isEmbed = tab === "embed"
+  const currentValue = isEmbed ? embedSnippet : canonicalUrl
+  const copyLabel = isEmbed ? "Copy Code" : "Copy Link"
+
+  // Reset the "Copied" pill back to the default label after 2s so a second
+  // click reads as a fresh copy. Cleanup clears the timer on unmount or when
+  // copyStatus flips early (e.g. user switches tabs).
+  useEffect(() => {
+    if (copyStatus !== "copied") return
+    const timer = window.setTimeout(() => {
+      setCopyStatus("idle")
+    }, 2000)
+    return () => window.clearTimeout(timer)
+  }, [copyStatus])
 
   function handleOpenChange(next: boolean) {
     if (!next) {
-      setLinkStatus("idle")
+      setTab("link")
+      setCopyStatus("idle")
       onClose()
     }
   }
 
-  async function copy(
-    text: string,
-    setter: (status: CopyStatus) => void,
-  ): Promise<void> {
+  function selectTab(next: ShareTab) {
+    setTab(next)
+    setCopyStatus("idle")
+  }
+
+  async function copy(text: string) {
     try {
       await navigator.clipboard.writeText(text)
-      setter("copied")
+      setCopyStatus("copied")
     } catch {
-      setter("failed")
+      setCopyStatus("failed")
     }
   }
 
+  // Auto-fit the embed textarea to its content so the full snippet is visible
+  // without an inner scroll bar. Re-runs when the snippet changes (different
+  // playbackId) and on viewport resize, since the textarea wraps differently
+  // at different modal widths. `useLayoutEffect` runs before paint, so the
+  // user never sees the rows-default height flash.
+  //
+  // Cap the auto-fit at 40% of the viewport so an extreme zoom or a malformed
+  // snippet can't push the Copy Code button below the fold; switch the
+  // textarea to inner-scroll once it would otherwise blow past the cap.
+  useLayoutEffect(() => {
+    if (!isEmbed) return
+    const fit = () => {
+      // Read the ref inside the closure rather than capturing it on the
+      // outer effect run — concurrent rendering may swap the DOM node
+      // underneath us between the effect setup and the resize callback.
+      const el = embedRef.current
+      if (!el) return
+      el.style.height = "auto"
+      const cap = window.innerHeight * 0.4
+      const desired = el.scrollHeight
+      if (desired > cap) {
+        el.style.height = `${cap}px`
+        el.style.overflowY = "auto"
+      } else {
+        el.style.height = `${desired}px`
+        el.style.overflowY = "hidden"
+      }
+    }
+    fit()
+    window.addEventListener("resize", fit)
+    return () => window.removeEventListener("resize", fit)
+  }, [isEmbed, embedSnippet])
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent data-testid="watch-share-modal" className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Share</DialogTitle>
-          <DialogDescription>
-            Copy a link to this video, or embed it on another site.
-          </DialogDescription>
-        </DialogHeader>
+      <DialogContent
+        data-testid="watch-share-modal"
+        className="overflow-hidden rounded-2xl border border-stone-700/50 bg-stone-900 p-0 text-stone-100 sm:max-w-xl"
+      >
+        <DialogTitle className="sr-only">Share video</DialogTitle>
 
-        <section
-          data-testid="watch-share-modal-link"
-          className="flex flex-col gap-2"
-        >
-          <label className="text-xs font-semibold uppercase tracking-widest text-stone-300">
-            Copy link
-          </label>
-          {linkStatus === "failed" ? (
+        <div className="border-b border-stone-700/50 px-6 py-4">
+          <h2 className="text-lg font-semibold text-stone-50">
+            Share this video
+          </h2>
+        </div>
+
+        <div className="flex flex-col gap-4 p-6 pb-2 sm:flex-row sm:gap-6">
+          <div
+            data-testid="watch-share-modal-poster"
+            className="relative aspect-video w-full shrink-0 overflow-hidden rounded-lg bg-stone-800 sm:w-56"
+          >
+            {posterUrl ? (
+              <Image
+                src={posterUrl}
+                alt={videoTitle ?? "Video poster"}
+                fill
+                sizes="(min-width: 640px) 224px, 100vw"
+                className="object-cover"
+              />
+            ) : null}
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            {videoTitle ? (
+              <h3
+                data-testid="watch-share-modal-title"
+                className="text-xl font-bold text-stone-50 sm:text-2xl"
+              >
+                {videoTitle}
+              </h3>
+            ) : null}
+            {videoDescription ? (
+              <p
+                data-testid="watch-share-modal-description"
+                className="line-clamp-4 text-sm leading-relaxed text-stone-300"
+              >
+                {videoDescription}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 px-6 pb-4">
+          <div className="flex gap-3">
+            {isShareable ? (
+              <a
+                href={fbHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Share on Facebook"
+                data-testid="watch-share-modal-facebook"
+                className="flex h-10 w-10 items-center justify-center rounded-full bg-[#1877F2] text-white transition hover:bg-[#0c63d4] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              >
+                <Facebook size={18} fill="currentColor" stroke="none" />
+              </a>
+            ) : (
+              <button
+                type="button"
+                disabled
+                aria-label="Share on Facebook (unavailable on this build)"
+                data-testid="watch-share-modal-facebook"
+                className="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-full bg-[#1877F2] text-white opacity-50"
+              >
+                <Facebook size={18} fill="currentColor" stroke="none" />
+              </button>
+            )}
+            {isShareable ? (
+              <a
+                href={xHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Share on X"
+                data-testid="watch-share-modal-x"
+                className="flex h-10 w-10 items-center justify-center rounded-full bg-black text-white transition hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              >
+                <XBrandIcon size={16} />
+              </a>
+            ) : (
+              <button
+                type="button"
+                disabled
+                aria-label="Share on X (unavailable on this build)"
+                data-testid="watch-share-modal-x"
+                className="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-full bg-black text-white opacity-50"
+              >
+                <XBrandIcon size={16} />
+              </button>
+            )}
+          </div>
+          {!isShareable ? (
+            <p
+              data-testid="watch-share-modal-share-disabled-hint"
+              className="text-xs text-stone-400"
+            >
+              Sharing requires a deployed page — works once this video is in
+              production.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="px-6">
+          <div
+            role="tablist"
+            aria-label="Share format"
+            className="flex border-b border-stone-700/50"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={!isEmbed}
+              data-testid="watch-share-modal-tab-link"
+              onClick={() => selectTab("link")}
+              className={cn(
+                "flex-1 px-4 py-3 text-xs font-semibold tracking-[0.18em] uppercase transition",
+                !isEmbed
+                  ? "border-b-2 border-red-500 text-red-500"
+                  : "border-b-2 border-transparent text-stone-400 hover:text-stone-200",
+              )}
+            >
+              Share Link
+            </button>
+            {embedSnippet ? (
+              <button
+                type="button"
+                role="tab"
+                aria-selected={isEmbed}
+                data-testid="watch-share-modal-tab-embed"
+                onClick={() => selectTab("embed")}
+                className={cn(
+                  "flex-1 px-4 py-3 text-xs font-semibold tracking-[0.18em] uppercase transition",
+                  isEmbed
+                    ? "border-b-2 border-red-500 text-red-500"
+                    : "border-b-2 border-transparent text-stone-400 hover:text-stone-200",
+                )}
+              >
+                Embed Code
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="px-6 pt-4">
+          {copyStatus === "failed" ? (
             <p
               data-testid="watch-share-modal-link-fallback"
               role="alert"
-              className="text-xs text-amber-400"
+              className="mb-2 text-xs text-amber-400"
             >
-              Couldn’t copy automatically — select the link below and copy
+              Couldn’t copy automatically — select the text below and copy
               manually.
             </p>
           ) : null}
-          <div className="flex items-stretch gap-2">
+          {isEmbed ? (
+            <textarea
+              ref={embedRef}
+              data-testid="watch-share-modal-embed-input"
+              readOnly
+              // `rows={2}` is the minimum baseline; the auto-fit effect below
+              // sets `style.height` to `scrollHeight` before paint so the full
+              // snippet is visible without an inner scroll bar (capped at 40vh).
+              rows={2}
+              value={embedSnippet}
+              onFocus={(e) => e.currentTarget.select()}
+              className="w-full resize-none rounded-lg border border-stone-700/70 bg-stone-950/40 px-4 py-3 font-mono text-xs text-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+            />
+          ) : (
             <input
               type="text"
               data-testid="watch-share-modal-link-input"
               readOnly
               value={canonicalUrl}
               onFocus={(e) => e.currentTarget.select()}
-              className="flex-1 rounded-md border border-stone-700 bg-stone-900 px-3 py-2 text-sm text-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              className="w-full rounded-lg border border-stone-700/70 bg-stone-950/40 px-4 py-3 text-sm text-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             />
-            <button
-              type="button"
-              data-testid="watch-share-modal-link-copy"
-              onClick={() => copy(canonicalUrl, setLinkStatus)}
-              className="rounded-md bg-amber-400 px-4 py-2 text-sm font-semibold text-stone-900 transition hover:bg-amber-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
-            >
-              {linkStatus === "copied" ? "Copied" : "Copy"}
-            </button>
-          </div>
-        </section>
+          )}
+        </div>
+
+        <div className="flex justify-end px-6 pt-4 pb-6">
+          <Button
+            variant="pill"
+            data-testid={
+              isEmbed
+                ? "watch-share-modal-embed-copy"
+                : "watch-share-modal-link-copy"
+            }
+            onClick={() => copy(currentValue)}
+            className="gap-2"
+          >
+            <Copy size={16} />
+            <span>{copyStatus === "copied" ? "Copied" : copyLabel}</span>
+          </Button>
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
@@ -69,20 +69,36 @@ export function WatchPageClient({
       url: d.url as string,
     }))
 
-  const variantsForLanguagePicker = (video.variants ?? [])
-    .filter((v): v is NonNullable<typeof v> => v != null)
-    .map((v) => ({
-      documentId: v.documentId,
-      hls: v.hls,
-      published: v.published,
-      language: v.language
-        ? {
-            coreId: v.language.coreId,
-            slug: v.language.slug,
-            name: v.language.name,
-          }
-        : null,
-    }))
+  const variantsForLanguagePicker = useMemo(
+    () =>
+      (video.variants ?? [])
+        .filter((v): v is NonNullable<typeof v> => v != null)
+        .map((v) => ({
+          documentId: v.documentId,
+          hls: v.hls,
+          published: v.published,
+          language: v.language
+            ? {
+                coreId: v.language.coreId,
+                slug: v.language.slug,
+                name: v.language.name,
+              }
+            : null,
+        })),
+    [video.variants],
+  )
+
+  // Prefer the editorial cinematic still over `images[].url` — that raw
+  // `url` is a misshaped Cloudflare Images URL (missing variant path
+  // segment) and 400s. Mux's thumbnail API is the last-resort fallback;
+  // it's a frame from the video, not the curated poster.
+  const posterUrl =
+    video.images?.[0]?.mobileCinematicHigh ??
+    video.images?.[0]?.mobileCinematicLow ??
+    video.images?.[0]?.thumbnail ??
+    (variant.muxVideo?.playbackId
+      ? `https://image.mux.com/${variant.muxVideo.playbackId}/thumbnail.jpg?width=448&height=252&fit_mode=smartcrop`
+      : (video.images?.[0]?.url ?? null))
 
   const [modalState, setModalState] = useState<WatchModalState>("none")
 
@@ -116,18 +132,7 @@ export function WatchPageClient({
         open={modalState === "download"}
         downloads={downloadsForModal}
         videoTitle={video.title ?? null}
-        // Prefer the editorial cinematic still over `images[].url` — that
-        // raw `url` is a misshaped Cloudflare Images URL (missing variant
-        // path segment) and 400s. Mux's thumbnail API is the last-resort
-        // fallback; it's a frame from the video, not the curated poster.
-        posterUrl={
-          video.images?.[0]?.mobileCinematicHigh ??
-          video.images?.[0]?.mobileCinematicLow ??
-          video.images?.[0]?.thumbnail ??
-          (variant.muxVideo?.playbackId
-            ? `https://image.mux.com/${variant.muxVideo.playbackId}/thumbnail.jpg?width=448&height=252&fit_mode=smartcrop`
-            : (video.images?.[0]?.url ?? null))
-        }
+        posterUrl={posterUrl}
         durationSeconds={variant.duration ?? null}
         languageName={variant.language?.name ?? null}
         onClose={closeModal}
@@ -144,6 +149,10 @@ export function WatchPageClient({
         open={modalState === "share"}
         videoSlug={video.slug ?? ""}
         currentLanguageSlug={currentLanguageSlug}
+        videoTitle={video.title ?? null}
+        videoDescription={video.snippet ?? video.description ?? null}
+        posterUrl={posterUrl}
+        playbackId={variant.muxVideo?.playbackId ?? null}
         onClose={closeModal}
       />
       <AskYoursPanel open={modalState === "ask-yours"} onClose={closeModal} />

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 type MuxPlayerCapturedProps = Record<string, unknown> & {
   ref?: React.Ref<unknown>
   onLoadedMetadata?: (event: Event) => void
+  onCanPlay?: (event: Event) => void
   onError?: (event: Event & { detail?: { code?: string } }) => void
 }
 
@@ -129,6 +130,25 @@ function makeBlock(): WatchHeroPlayerBlock {
 function lastMuxProps(): MuxPlayerCapturedProps {
   const calls = muxPlayerMock.mock.calls
   return calls[calls.length - 1]?.[0] as MuxPlayerCapturedProps
+}
+
+// Helpers for firing the captured event handlers — the mock doesn't render
+// a real Mux Player so the consumer-side `onCanPlay` / `onError` paths are
+// otherwise unobservable.
+async function fireCanPlay() {
+  const handler = lastMuxProps()?.onCanPlay
+  await act(async () => {
+    handler?.(new Event("canplay"))
+  })
+}
+
+async function fireError(code: string) {
+  const handler = lastMuxProps()?.onError
+  const evt = new Event("error") as Event & { detail?: { code?: string } }
+  evt.detail = { code }
+  await act(async () => {
+    handler?.(evt)
+  })
 }
 
 describe("HeroPlayer — initial mount", () => {
@@ -303,6 +323,56 @@ describe("HeroPlayer — iOS-safe click sequence (AE1)", () => {
     expect(pillAfter).not.toBeNull()
     expect(pillAfter?.getAttribute("data-state")).toBe("tap-to-unmute")
     expect(pillAfter?.textContent).toContain("Tap to Unmute")
+  })
+})
+
+describe("HeroPlayer — loading spinner lifecycle", () => {
+  it("renders the spinner overlay on mount", () => {
+    act(() => {
+      root.render(<HeroPlayer block={makeBlock()} />)
+    })
+    expect(
+      container.querySelector('[data-testid="hero-player-loading"]'),
+    ).not.toBeNull()
+  })
+
+  it("removes the spinner once onCanPlay fires", async () => {
+    act(() => {
+      root.render(<HeroPlayer block={makeBlock()} />)
+    })
+    await fireCanPlay()
+    expect(
+      container.querySelector('[data-testid="hero-player-loading"]'),
+    ).toBeNull()
+  })
+
+  it("removes the spinner on a non-autoplay-blocked error so Mux's own error UI is visible", async () => {
+    // F1 verification: a network/decode/manifest error never fires onCanPlay,
+    // so without this fallback the spinner sits over a black box forever.
+    act(() => {
+      root.render(<HeroPlayer block={makeBlock()} />)
+    })
+    expect(
+      container.querySelector('[data-testid="hero-player-loading"]'),
+    ).not.toBeNull()
+    await fireError("manifest-load-error")
+    expect(
+      container.querySelector('[data-testid="hero-player-loading"]'),
+    ).toBeNull()
+  })
+
+  it("keeps the spinner up when the error is autoplay-blocked (recovery path is the unmute pill, not the player UI)", async () => {
+    act(() => {
+      root.render(<HeroPlayer block={makeBlock()} />)
+    })
+    await fireError("autoplay-blocked")
+    // Spinner stays only until onCanPlay fires (which it will once the muted
+    // loop buffers). The autoplay-blocked branch must NOT pre-emptively hide
+    // it, because that would expose Mux's empty player while we're still
+    // showing the unmute pill.
+    expect(
+      container.querySelector('[data-testid="hero-player-loading"]'),
+    ).not.toBeNull()
   })
 })
 

--- a/apps/web/src/components/watch/__tests__/ShareModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/ShareModal.test.tsx
@@ -10,9 +10,9 @@
  *    field stays selectable.
  *  - The URL includes `/watch/` (this is the absolute, externally-shared
  *    URL, NOT a router.push target).
- *  - The Copy Embed surface is intentionally absent — see ShareModal.tsx
- *    docstring for the rationale (embed route was removed in the
- *    watch-page-mux-parity refit).
+ *  - Embed Code tab → renders an iframe snippet pointing at player.mux.com
+ *    when a playbackId is provided; tab hidden when the video has no
+ *    playbackId.
  *
  * `env` is mocked at the module boundary so the canonical-origin assertion
  * doesn't depend on the runtime env value.
@@ -28,7 +28,11 @@ vi.mock("@/env", () => ({
   },
 }))
 
-import { ShareModal } from "@/components/watch/ShareModal"
+import {
+  PUBLIC_SHARE_FALLBACK_ORIGIN,
+  ShareModal,
+  isPublicShareableOrigin,
+} from "@/components/watch/ShareModal"
 
 let container: HTMLDivElement
 let root: Root
@@ -130,10 +134,81 @@ describe("ShareModal — Copy Link", () => {
   })
 })
 
-describe("ShareModal — embed section is intentionally absent", () => {
-  it("does not render an embed-snippet textarea", () => {
-    // Embed route was removed in the watch-page-mux-parity refit; shipping
-    // a snippet that 404s would leak broken iframes onto partner sites.
+describe("ShareModal — Facebook + X share intents", () => {
+  it("Facebook intent encodes the canonical URL into ?u=", () => {
+    act(() => {
+      root.render(
+        <ShareModal
+          open
+          videoSlug="the-call"
+          currentLanguageSlug="english"
+          onClose={vi.fn()}
+        />,
+      )
+    })
+    const fb = $(
+      '[data-testid="watch-share-modal-facebook"]',
+    ) as HTMLAnchorElement
+    expect(fb.href).toBe(
+      "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fshare.example%2Fwatch%2Fthe-call%2Fenglish",
+    )
+  })
+
+  it("X intent encodes the canonical URL plus the title", () => {
+    act(() => {
+      root.render(
+        <ShareModal
+          open
+          videoSlug="the-call"
+          currentLanguageSlug="english"
+          videoTitle="The Call"
+          onClose={vi.fn()}
+        />,
+      )
+    })
+    const x = $('[data-testid="watch-share-modal-x"]') as HTMLAnchorElement
+    expect(x.href).toBe(
+      "https://x.com/intent/tweet?url=https%3A%2F%2Fshare.example%2Fwatch%2Fthe-call%2Fenglish&text=The%20Call",
+    )
+  })
+})
+
+describe("ShareModal — public-origin fallback (helper)", () => {
+  it("treats real https origins as shareable", () => {
+    expect(isPublicShareableOrigin("https://jesusfilm.org")).toBe(true)
+    expect(isPublicShareableOrigin("https://staging.jesusfilm.org")).toBe(true)
+    expect(isPublicShareableOrigin("http://example.com")).toBe(true)
+  })
+
+  it("rejects localhost and private hosts that Facebook can't crawl", () => {
+    // Reproduces the reported bug: NEXT_PUBLIC_CANONICAL_ORIGIN defaults to
+    // http://localhost:3000 in dev, which Facebook silently strips from the
+    // composer (no preview card, no link). Treating these as non-shareable
+    // forces a fallback to the public canonical so the dialog populates.
+    expect(isPublicShareableOrigin("http://localhost:3000")).toBe(false)
+    expect(isPublicShareableOrigin("http://127.0.0.1:3000")).toBe(false)
+    expect(isPublicShareableOrigin("http://my-mac.local:3000")).toBe(false)
+    expect(isPublicShareableOrigin("http://0.0.0.0:3000")).toBe(false)
+  })
+
+  it("rejects malformed origins", () => {
+    expect(isPublicShareableOrigin("")).toBe(false)
+    expect(isPublicShareableOrigin("not-a-url")).toBe(false)
+  })
+
+  it("exposes the production canonical as the fallback host", () => {
+    // Sanity guard so a future refactor doesn't silently swap the fallback to
+    // a host that's not the actual public site — that would either 404 the
+    // shared link or share an unrelated origin.
+    expect(PUBLIC_SHARE_FALLBACK_ORIGIN).toBe("https://jesusfilm.org")
+  })
+})
+
+describe("ShareModal — Embed Code tab", () => {
+  it("hides the Embed Code tab when no playbackId is supplied", () => {
+    // Without a Mux playbackId we can't build a portable player.mux.com
+    // iframe, so we don't surface the tab at all rather than copy a broken
+    // snippet onto partner sites.
     act(() => {
       root.render(
         <ShareModal
@@ -144,9 +219,123 @@ describe("ShareModal — embed section is intentionally absent", () => {
         />,
       )
     })
+    expect($('[data-testid="watch-share-modal-tab-embed"]')).toBeNull()
     expect($('[data-testid="watch-share-modal-embed-input"]')).toBeNull()
-    expect($('[data-testid="watch-share-modal-embed-copy"]')).toBeNull()
-    expect($('[data-testid="watch-share-modal-embed-fallback"]')).toBeNull()
+  })
+
+  it("clicking Embed Code reveals an iframe snippet pointing at player.mux.com", async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>(() =>
+      Promise.resolve(),
+    )
+    setClipboard(writeText)
+
+    act(() => {
+      root.render(
+        <ShareModal
+          open
+          videoSlug="the-call"
+          currentLanguageSlug="english"
+          playbackId="ScBFl3LbJCViZNNdZfa4bpJCEyQr9Mw4Cpiirb7gb00E"
+          onClose={vi.fn()}
+        />,
+      )
+    })
+
+    const embedTab = $(
+      '[data-testid="watch-share-modal-tab-embed"]',
+    ) as HTMLButtonElement
+    expect(embedTab).not.toBeNull()
+
+    await act(async () => {
+      embedTab.click()
+    })
+
+    const textarea = $(
+      '[data-testid="watch-share-modal-embed-input"]',
+    ) as HTMLTextAreaElement
+    expect(textarea).not.toBeNull()
+    expect(textarea.value).toContain(
+      'src="https://player.mux.com/ScBFl3LbJCViZNNdZfa4bpJCEyQr9Mw4Cpiirb7gb00E"',
+    )
+    // Responsive wrapper: a single `<div>` that establishes a 16:9 box via
+    // modern CSS `aspect-ratio` (Baseline 2021). The iframe absolute-fills
+    // it. Inline styles only — no `<style>` block, no class attribute, so a
+    // partner site that wraps the snippet inside its own `<style>` block
+    // can't have its outer style terminated by a literal `</style>` here.
+    expect(textarea.value).toContain("aspect-ratio:16/9")
+    expect(textarea.value).toContain("position:absolute")
+    expect(textarea.value).not.toContain("<style>")
+    expect(textarea.value).not.toContain("</style>")
+    expect(textarea.value).not.toContain('class="mux-embed"')
+    // Modern + legacy fullscreen permissions; vendor-prefixed variants are
+    // harmless on current browsers and unblock fullscreen in older WebKit /
+    // Gecko hosts where partners might paste this snippet.
+    expect(textarea.value).toContain("allowfullscreen")
+    expect(textarea.value).toContain("webkitallowfullscreen")
+    expect(textarea.value).toContain("mozallowfullscreen")
+    // `frameborder` is deprecated; inline `border:0` on the iframe is the
+    // canonical replacement and the snippet must not regress to the old
+    // attribute.
+    expect(textarea.value).toContain("border:0")
+    expect(textarea.value).not.toContain("frameborder")
+
+    const copyBtn = $(
+      '[data-testid="watch-share-modal-embed-copy"]',
+    ) as HTMLButtonElement
+    expect(copyBtn).not.toBeNull()
+    expect(copyBtn.textContent).toContain("Copy Code")
+
+    await act(async () => {
+      copyBtn.click()
+    })
+
+    expect(writeText).toHaveBeenCalledWith(textarea.value)
+  })
+})
+
+describe("ShareModal — non-public origin disables FB + X buttons", () => {
+  // F20 regression guard: when NEXT_PUBLIC_CANONICAL_ORIGIN is localhost (or
+  // any non-public host), firing the FB share intent against the production
+  // fallback URL would poison Facebook's negative cache for a slug that
+  // doesn't yet exist in production. The buttons must stay visible (so the
+  // affordance is discoverable) but be disabled, with a hint explaining why.
+  it("renders FB + X as disabled buttons with a hint when origin is localhost", async () => {
+    vi.resetModules()
+    vi.doMock("@/env", () => ({
+      env: {
+        NEXT_PUBLIC_CANONICAL_ORIGIN: "http://localhost:3000",
+      },
+    }))
+    const { ShareModal: ShareModalLocal } =
+      await import("@/components/watch/ShareModal")
+
+    act(() => {
+      root.render(
+        <ShareModalLocal
+          open
+          videoSlug="the-call"
+          currentLanguageSlug="english"
+          onClose={vi.fn()}
+        />,
+      )
+    })
+
+    const fb = $('[data-testid="watch-share-modal-facebook"]')
+    const x = $('[data-testid="watch-share-modal-x"]')
+    expect(fb).not.toBeNull()
+    expect(x).not.toBeNull()
+    // They are now <button disabled>, not <a href=…>.
+    expect(fb?.tagName).toBe("BUTTON")
+    expect(x?.tagName).toBe("BUTTON")
+    expect((fb as HTMLButtonElement).disabled).toBe(true)
+    expect((x as HTMLButtonElement).disabled).toBe(true)
+
+    const hint = $('[data-testid="watch-share-modal-share-disabled-hint"]')
+    expect(hint).not.toBeNull()
+    expect(hint?.textContent ?? "").toContain("deployed page")
+
+    vi.doUnmock("@/env")
+    vi.resetModules()
   })
 })
 

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -32,7 +32,50 @@ export const env = createEnv({
     // for safer dev / CI experience — `z.url()` would otherwise hard-fail
     // boot on environments where the value isn't set explicitly. Production
     // and preview must override to `https://jesusfilm.org` (or equivalent).
-    NEXT_PUBLIC_CANONICAL_ORIGIN: z.url().default("http://localhost:3000"),
+    //
+    // F21: refine with a soft allowlist of known-good host shapes. When a
+    // value falls outside the allowlist we WARN at module-import time
+    // (visible in the deploy logs) but do NOT throw — staging, preview, and
+    // partner-co-deployed instances may legitimately use other hosts (custom
+    // domains, branch URLs, etc.) and we don't want a config drift in those
+    // environments to brick the entire app boot. The warning makes a
+    // misconfigured / leaked env value visible to whoever reads logs while
+    // still letting unrelated deployments stand up cleanly.
+    NEXT_PUBLIC_CANONICAL_ORIGIN: z
+      .url()
+      .default("http://localhost:3000")
+      .refine(
+        (value) => {
+          try {
+            const { hostname } = new URL(value)
+            const allowlistedSuffixes = [
+              ".jesusfilm.org",
+              ".local",
+              ".railway.app",
+            ]
+            const allowlistedExacts = [
+              "jesusfilm.org",
+              "localhost",
+              "127.0.0.1",
+            ]
+            const ok =
+              allowlistedExacts.includes(hostname) ||
+              allowlistedSuffixes.some((suffix) => hostname.endsWith(suffix))
+            if (!ok && typeof console !== "undefined") {
+              console.warn(
+                `[env] NEXT_PUBLIC_CANONICAL_ORIGIN host "${hostname}" is outside the soft allowlist (jesusfilm.org / *.jesusfilm.org / *.local / *.railway.app / localhost / 127.0.0.1). Continuing without throwing — verify this is intentional.`,
+              )
+            }
+          } catch {
+            // The outer z.url() already validates the URL shape; if URL
+            // parsing fails here we let z.url()'s error surface instead.
+          }
+          // Warn-only: always pass refinement so misconfigured hosts don't
+          // brick boot in legitimate-but-unknown deployment topologies.
+          return true
+        },
+        { message: "unreachable" },
+      ),
   },
   runtimeEnv: {
     INTERNAL_GRAPHQL_URL: process.env.INTERNAL_GRAPHQL_URL,

--- a/apps/web/src/lib/content.test.ts
+++ b/apps/web/src/lib/content.test.ts
@@ -128,6 +128,14 @@ describe("resolveWatchPage", () => {
     expect(print(queryMock.mock.calls[1][0].query)).toMatch(
       /children\(pagination:\s*\{limit:\s*24\}\)/,
     )
+    // GET_ROUTE_VIDEO must paginate variants with `limit: -1` for the same
+    // reason WatchVideoFragment does (see watch-video.test.ts): the default
+    // 10-row return would silently drop the playable variant for any video
+    // whose first 10 variants don't include the primary language, sending
+    // the watch page to the wrong locale.
+    expect(print(queryMock.mock.calls[1][0].query)).toMatch(
+      /variants\(pagination:\s*\{\s*limit:\s*-1\s*\}\)/,
+    )
 
     expect(result.error).toBeNull()
     expect(result.data).toMatchObject({

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -71,7 +71,7 @@ const GET_ROUTE_VIDEO = graphql(`
       primaryLanguage {
         coreId
       }
-      variants {
+      variants(pagination: { limit: -1 }) {
         documentId
         hls
         published
@@ -551,80 +551,117 @@ async function fetchWatchVideoRecord(
   return (result.data?.videos?.[0] ?? null) as WatchVideoRecord | null
 }
 
+// Strip the heavy fields (`downloads`, `muxVideo`, `duration`) from every
+// variant in `record.variants` *except* the one matching `selectedDocumentId`.
+// Each non-selected variant retains documentId, slug, published, hls, and
+// language only — enough to power the language picker and the URL/locale
+// guards without shipping ~2KB of MP4 download metadata × 240+ variants.
+//
+// Runtime-only narrowing: the `WatchVideoRecord` type still claims those
+// fields are present on every variant, so we cast through `unknown` to keep
+// the public type stable. Consumers that reach for `variant.downloads` on a
+// non-selected variant will see `undefined` — that's the cost we pay for
+// keeping the RSC payload sub-100KB instead of the original ~500KB.
+function stripNonSelectedVariantFields(
+  record: WatchVideoRecord,
+  selectedDocumentId: string | null,
+): WatchVideoRecord {
+  if (!record.variants?.length) return record
+  const variants = record.variants.map((variant) => {
+    if (variant == null) return variant
+    if (variant.documentId === selectedDocumentId) return variant
+    return {
+      documentId: variant.documentId,
+      slug: variant.slug,
+      published: variant.published,
+      hls: variant.hls,
+      language: variant.language,
+    } as unknown as typeof variant
+  })
+  return { ...record, variants } as WatchVideoRecord
+}
+
+async function tryResolveWatchVideo(
+  collectionSlug: string,
+  videoSlug: string,
+  languageSlug: string,
+): Promise<ResolvedWatchVideo> {
+  const record = await fetchWatchVideoRecord(collectionSlug, videoSlug)
+  if (!record) {
+    throw new WatchVideoError("VIDEO_NOT_FOUND", {
+      collectionSlug,
+      videoSlug,
+      languageSlug,
+    })
+  }
+
+  const parents = (record.parents ?? []).filter(
+    (parent): parent is WatchParent => parent != null,
+  )
+  const canonicalParent =
+    parents.find((parent) => parent.slug === collectionSlug) ?? null
+  if (!canonicalParent) {
+    throw new WatchVideoError("PARENT_NOT_FOUND", {
+      collectionSlug,
+      videoSlug,
+      languageSlug,
+    })
+  }
+
+  const variants = (record.variants ?? []).filter(
+    (variant): variant is WatchVariant => variant != null,
+  )
+  const playableVariants = variants.filter(
+    (variant) => variant.published === true && Boolean(variant.hls),
+  )
+
+  const selectedVariant =
+    playableVariants.find(
+      (variant) => variant.language?.slug === languageSlug,
+    ) ?? null
+
+  if (!selectedVariant) {
+    // Distinguish "language not in this video" vs. "no playable variant at
+    // all" so the error boundary can show a useful English-fallback link.
+    const matchedLanguageVariant = variants.find(
+      (variant) => variant.language?.slug === languageSlug,
+    )
+    if (!playableVariants.length) {
+      throw new WatchVideoError("NO_PLAYABLE_VARIANT", {
+        collectionSlug,
+        videoSlug,
+        languageSlug,
+      })
+    }
+    // Either the requested language has a variant but it's unpublished or
+    // missing HLS, or the language is absent entirely. Both surface as
+    // LOCALE_NOT_FOUND — error.tsx handles fallback link.
+    void matchedLanguageVariant
+    throw new WatchVideoError("LOCALE_NOT_FOUND", {
+      collectionSlug,
+      videoSlug,
+      languageSlug,
+    })
+  }
+
+  const narrowedRecord = stripNonSelectedVariantFields(
+    record,
+    selectedVariant.documentId,
+  )
+
+  const resolved: ResolvedWatchVideo = {
+    video: narrowedRecord,
+    canonicalParent,
+    selectedVariant,
+  }
+
+  // Match resolveWatchPage's plain-data normalization so the result is safe
+  // to serialize across the RSC boundary.
+  return JSON.parse(JSON.stringify(resolved)) as ResolvedWatchVideo
+}
+
 const fetchResolvedWatchVideo = unstable_cache(
-  async (
-    collectionSlug: string,
-    videoSlug: string,
-    languageSlug: string,
-  ): Promise<ResolvedWatchVideo> => {
-    const record = await fetchWatchVideoRecord(collectionSlug, videoSlug)
-    if (!record) {
-      throw new WatchVideoError("VIDEO_NOT_FOUND", {
-        collectionSlug,
-        videoSlug,
-        languageSlug,
-      })
-    }
-
-    const parents = (record.parents ?? []).filter(
-      (parent): parent is WatchParent => parent != null,
-    )
-    const canonicalParent =
-      parents.find((parent) => parent.slug === collectionSlug) ?? null
-    if (!canonicalParent) {
-      throw new WatchVideoError("PARENT_NOT_FOUND", {
-        collectionSlug,
-        videoSlug,
-        languageSlug,
-      })
-    }
-
-    const variants = (record.variants ?? []).filter(
-      (variant): variant is WatchVariant => variant != null,
-    )
-    const playableVariants = variants.filter(
-      (variant) => variant.published === true && Boolean(variant.hls),
-    )
-
-    const selectedVariant =
-      playableVariants.find(
-        (variant) => variant.language?.slug === languageSlug,
-      ) ?? null
-
-    if (!selectedVariant) {
-      // Distinguish "language not in this video" vs. "no playable variant at
-      // all" so the error boundary can show a useful English-fallback link.
-      const matchedLanguageVariant = variants.find(
-        (variant) => variant.language?.slug === languageSlug,
-      )
-      if (!playableVariants.length) {
-        throw new WatchVideoError("NO_PLAYABLE_VARIANT", {
-          collectionSlug,
-          videoSlug,
-          languageSlug,
-        })
-      }
-      // Either the requested language has a variant but it's unpublished or
-      // missing HLS, or the language is absent entirely. Both surface as
-      // LOCALE_NOT_FOUND — error.tsx handles fallback link.
-      void matchedLanguageVariant
-      throw new WatchVideoError("LOCALE_NOT_FOUND", {
-        collectionSlug,
-        videoSlug,
-        languageSlug,
-      })
-    }
-
-    const resolved: ResolvedWatchVideo = {
-      video: record,
-      canonicalParent,
-      selectedVariant,
-    }
-
-    // Match resolveWatchPage's plain-data normalization so the result is safe
-    // to serialize across the RSC boundary.
-    return JSON.parse(JSON.stringify(resolved)) as ResolvedWatchVideo
-  },
+  tryResolveWatchVideo,
   ["watch-video"],
   { revalidate: 60 },
 )
@@ -674,48 +711,66 @@ async function fetchWatchVideoBySlug(
   return (result.data?.videos?.[0] ?? null) as WatchVideoRecord | null
 }
 
+// Sentinel thrown by the cached inner so unstable_cache never persists a
+// "no playable variant" miss. unstable_cache re-throws on error and does
+// NOT cache failures — the outer wrapper catches this sentinel and returns
+// null, while real downstream errors propagate as before.
+const WATCH_VIDEO_BY_SLUG_NOT_FOUND = "watch-video-by-slug:NOT_FOUND"
+
+async function tryResolveWatchVideoBySlug(
+  videoSlug: string,
+  locale: string,
+): Promise<ResolvedWatchVideoBySlug> {
+  const record = await fetchWatchVideoBySlug(videoSlug)
+  if (!record) throw new Error(WATCH_VIDEO_BY_SLUG_NOT_FOUND)
+
+  const parents = (record.parents ?? []).filter(
+    (parent): parent is WatchParent => parent != null,
+  )
+  const canonicalParent = parents[0] ?? null
+
+  const variants = (record.variants ?? []).filter(
+    (variant): variant is WatchVariant => variant != null,
+  )
+  const playableVariants = variants.filter(
+    (variant) => variant.published === true && Boolean(variant.hls),
+  )
+  if (!playableVariants.length) throw new Error(WATCH_VIDEO_BY_SLUG_NOT_FOUND)
+
+  // Priority: URL locale (slug → bcp47), then primary, then first playable.
+  const localeMatch =
+    playableVariants.find((variant) => variant.language?.slug === locale) ??
+    playableVariants.find((variant) => variant.language?.bcp47 === locale)
+  const primaryLanguageId = record.primaryLanguage?.coreId ?? null
+  const primaryMatch = primaryLanguageId
+    ? playableVariants.find(
+        (variant) => variant.language?.coreId === primaryLanguageId,
+      )
+    : null
+  const selectedVariant =
+    localeMatch ?? primaryMatch ?? playableVariants[0] ?? null
+  if (!selectedVariant) throw new Error(WATCH_VIDEO_BY_SLUG_NOT_FOUND)
+
+  const narrowedRecord = stripNonSelectedVariantFields(
+    record,
+    selectedVariant.documentId,
+  )
+
+  const resolved: ResolvedWatchVideoBySlug = {
+    video: narrowedRecord,
+    canonicalParent,
+    selectedVariant,
+  }
+  return JSON.parse(JSON.stringify(resolved)) as ResolvedWatchVideoBySlug
+}
+
+// Cache wraps only the success path. unstable_cache re-throws errors and does
+// NOT cache them, so the NOT_FOUND sentinel naturally bypasses the cache —
+// each request re-queries Strapi until a record exists. This avoids pinning
+// a 60s "null" entry in the cache for a record that just hasn't been
+// published yet (the original bug).
 const fetchResolvedWatchVideoBySlug = unstable_cache(
-  async (
-    videoSlug: string,
-    locale: string,
-  ): Promise<ResolvedWatchVideoBySlug | null> => {
-    const record = await fetchWatchVideoBySlug(videoSlug)
-    if (!record) return null
-
-    const parents = (record.parents ?? []).filter(
-      (parent): parent is WatchParent => parent != null,
-    )
-    const canonicalParent = parents[0] ?? null
-
-    const variants = (record.variants ?? []).filter(
-      (variant): variant is WatchVariant => variant != null,
-    )
-    const playableVariants = variants.filter(
-      (variant) => variant.published === true && Boolean(variant.hls),
-    )
-    if (!playableVariants.length) return null
-
-    // Priority: URL locale (slug → bcp47), then primary, then first playable.
-    const localeMatch =
-      playableVariants.find((variant) => variant.language?.slug === locale) ??
-      playableVariants.find((variant) => variant.language?.bcp47 === locale)
-    const primaryLanguageId = record.primaryLanguage?.coreId ?? null
-    const primaryMatch = primaryLanguageId
-      ? playableVariants.find(
-          (variant) => variant.language?.coreId === primaryLanguageId,
-        )
-      : null
-    const selectedVariant =
-      localeMatch ?? primaryMatch ?? playableVariants[0] ?? null
-    if (!selectedVariant) return null
-
-    const resolved: ResolvedWatchVideoBySlug = {
-      video: record,
-      canonicalParent,
-      selectedVariant,
-    }
-    return JSON.parse(JSON.stringify(resolved)) as ResolvedWatchVideoBySlug
-  },
+  tryResolveWatchVideoBySlug,
   ["watch-video-by-slug"],
   { revalidate: 60 },
 )
@@ -727,7 +782,17 @@ export const resolveWatchVideoBySlug = cache(
     videoSlug: string,
     locale: string,
   ): Promise<ResolvedWatchVideoBySlug | null> => {
-    return fetchResolvedWatchVideoBySlug(videoSlug, locale)
+    try {
+      return await fetchResolvedWatchVideoBySlug(videoSlug, locale)
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === WATCH_VIDEO_BY_SLUG_NOT_FOUND
+      ) {
+        return null
+      }
+      throw error
+    }
   },
 )
 

--- a/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
+++ b/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
@@ -46,18 +46,24 @@ describe("WatchVideoFragment", () => {
       /\bchildren\b\s*\{[\s\S]*?documentId[\s\S]*?\bslug\b[\s\S]*?\btitle\b[\s\S]*?\blabel\b[\s\S]*?images\s*\{\s*url/,
     )
 
-    // variants: identifying + playable + downloads + muxVideo
-    expect(printed).toMatch(/variants\s*\{[\s\S]*?\bhls\b/)
-    expect(printed).toMatch(/variants\s*\{[\s\S]*?\bpublished\b/)
+    // variants: identifying + playable + downloads + muxVideo.
+    // The relation is paginated with `limit: -1` so Strapi returns every
+    // variant — the 10-row default would silently drop the English variant
+    // for any video whose first 10 variants are non-English (242 variants
+    // on `mary-visit-to-elizabeth`, etc.) and the watch page would fall back
+    // to "first playable" → wrong-language playback.
+    expect(printed).toMatch(/variants\(pagination:\s*\{\s*limit:\s*-1\s*\}\)/)
+    expect(printed).toMatch(/variants\([^)]*\)\s*\{[\s\S]*?\bhls\b/)
+    expect(printed).toMatch(/variants\([^)]*\)\s*\{[\s\S]*?\bpublished\b/)
     expect(printed).toMatch(
-      /variants\s*\{[\s\S]*?\bmuxVideo\s*\{[\s\S]*?playbackId/,
+      /variants\([^)]*\)\s*\{[\s\S]*?\bmuxVideo\s*\{[\s\S]*?playbackId/,
     )
     expect(printed).toMatch(
-      /variants\s*\{[\s\S]*?downloads\s*\{[\s\S]*?\bquality\b[\s\S]*?\bsize\b[\s\S]*?\burl\b/,
+      /variants\([^)]*\)\s*\{[\s\S]*?downloads\s*\{[\s\S]*?\bquality\b[\s\S]*?\bsize\b[\s\S]*?\burl\b/,
     )
     // variants.language must include the slug U3 will key off
     expect(printed).toMatch(
-      /variants\s*\{[\s\S]*?language\s*\{[\s\S]*?coreId[\s\S]*?bcp47[\s\S]*?\bslug\b[\s\S]*?\bname\b/,
+      /variants\([^)]*\)\s*\{[\s\S]*?language\s*\{[\s\S]*?coreId[\s\S]*?bcp47[\s\S]*?\bslug\b[\s\S]*?\bname\b/,
     )
 
     // studyQuestions sorted ascending; only `value` + `order` (no `answer`)

--- a/apps/web/src/lib/fragments/watch-video.ts
+++ b/apps/web/src/lib/fragments/watch-video.ts
@@ -40,7 +40,7 @@ export const watchVideoFragment = graphql(`
         }
       }
     }
-    variants {
+    variants(pagination: { limit: -1 }) {
       documentId
       slug
       published

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -1,0 +1,47 @@
+// Share-intent URL builders extracted from ShareModal so the embed snippet
+// + social intent shapes can be unit-tested independently of the modal UI.
+
+// Mux playback ids are URL-safe (alphanumeric + `_-`), and currently 8-64
+// characters in practice. Validating before interpolation prevents an
+// attacker-controlled value from breaking out of the iframe `src` attribute
+// — anything outside this character class is rejected and the embed UI is
+// hidden upstream.
+export const PLAYBACK_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/
+
+/**
+ * Build the responsive iframe snippet pointing at player.mux.com/{playbackId}.
+ *
+ * Returns `""` for a null/invalid playback id. The wrapper uses inline styles
+ * (no `<style>` block, no class names) so the snippet is safe to paste inside
+ * a partner page that itself wraps content in `<style>` — a literal `</style>`
+ * close tag inside the snippet would otherwise terminate the partner's outer
+ * style block. The 16:9 aspect ratio is established by modern CSS
+ * `aspect-ratio: 16/9` (Baseline 2021, supported in every evergreen browser),
+ * which replaces the older `:after { padding-top: 56.25% }` intrinsic-ratio
+ * hack that required a stylesheet. The iframe absolute-fills the container
+ * and uses vendor-prefixed `allowfullscreen` for older WebKit/Gecko hosts and
+ * inline `border:0` to replace the deprecated `frameborder` attribute.
+ */
+export function buildEmbedSnippet(
+  playbackId: string | null | undefined,
+): string {
+  if (!playbackId) return ""
+  if (!PLAYBACK_ID_PATTERN.test(playbackId)) return ""
+  return `<div style="position:relative;display:block;margin:10px auto;width:100%;aspect-ratio:16/9"><iframe src="https://player.mux.com/${playbackId}" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div>`
+}
+
+/** Facebook share-intent URL. */
+export function buildFbShareUrl(url: string): string {
+  return `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`
+}
+
+/**
+ * X (formerly Twitter) share-intent URL. x.com is the canonical host now;
+ * the /intent/tweet path still works and is what the platform itself links
+ * to for share buttons.
+ */
+export function buildXShareUrl(url: string, title?: string | null): string {
+  return `https://x.com/intent/tweet?url=${encodeURIComponent(url)}${
+    title ? `&text=${encodeURIComponent(title)}` : ""
+  }`
+}

--- a/apps/web/src/lib/url.ts
+++ b/apps/web/src/lib/url.ts
@@ -1,0 +1,31 @@
+// Shared URL helpers for share-intent fallbacks.
+//
+// Facebook's URL scraper rejects localhost / private hosts, which empties the
+// composer when share buttons fire from a dev build. The public canonical is
+// what end users would actually see for the page anyway, so we substitute it
+// whenever the configured origin is unreachable from the public internet.
+// Twitter/X is more permissive but still benefits from a real URL preview.
+
+export const PUBLIC_SHARE_FALLBACK_ORIGIN = "https://jesusfilm.org"
+
+// Mirrors RFC1918 ranges plus link-local. We accept a small false-positive risk
+// (e.g. legitimate 10.0.0.0/8 deployments) in exchange for never sending FB a
+// URL its scraper can't reach.
+const PRIVATE_IPV4_PATTERN = /^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/
+
+export function isPublicShareableOrigin(origin: string): boolean {
+  try {
+    const { hostname } = new URL(origin)
+    if (hostname === "localhost" || hostname === "127.0.0.1") return false
+    if (hostname.endsWith(".local")) return false
+    if (hostname === "0.0.0.0") return false
+    // IPv6 loopback: URL("http://[::1]:3000").hostname returns "[::1]" in
+    // browsers and Node, but bare "::1" can also appear if the URL was
+    // pre-stripped — treat both as non-public.
+    if (hostname === "[::1]" || hostname === "::1") return false
+    if (PRIVATE_IPV4_PATTERN.test(hostname)) return false
+    return true
+  } catch {
+    return false
+  }
+}

--- a/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
+++ b/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
@@ -1,7 +1,7 @@
 ---
 title: Mux Player + custom React-rendered chrome (HeroPlayerControls pattern)
 date: 2026-04-30
-last_updated: 2026-05-01
+last_updated: 2026-05-04
 category: docs/solutions/design-patterns
 module: apps/web, packages/video-player
 problem_type: design_pattern
@@ -172,7 +172,14 @@ The hero `<MuxPlayer>` is taller than the viewport on desktop (1071px tall in a 
 // apps/web/src/components/watch/HeroPlayer.tsx
 const [heroHeight, setHeroHeight] = useState<number | null>(null)
 
-useEffect(() => {
+// Updated 2026-05-04: this is `useLayoutEffect`, not `useEffect`. Once
+// `aspect-video` was added to the wrapper className (see below), the
+// wrapper has a real layout-derived height before the first paint.
+// `useEffect` runs after paint, so for one frame `heroHeight` would
+// still be null and `top` would render as `0px` instead of the
+// correct calc — visible on first load. `useLayoutEffect` runs after
+// DOM mutation but before paint, eliminating the flash.
+useLayoutEffect(() => {
   const el = wrapperRef.current
   if (!el) return
   const apply = (h: number) => {
@@ -191,7 +198,16 @@ useEffect(() => {
 // In JSX:
 <div
   ref={wrapperRef}
-  className="sticky w-full overflow-hidden bg-black"
+  // Updated 2026-05-04: `aspect-video` locks the wrapper to 16:9 of
+  // its width from the moment of mount. Without it, the wrapper has
+  // no intrinsic height until Mux Player resolves the video's
+  // dimensions — and Mux's element falls back to its built-in
+  // ~200px min-height during the buffer phase, collapsing the hero
+  // and stacking the title/Play-with-Sound pill on top of the
+  // floating search bar. With `aspect-video`, the wrapper is
+  // deterministic from the first paint and matches the eventual
+  // loaded size on a 16:9 asset.
+  className="sticky aspect-video w-full overflow-hidden bg-black"
   style={{
     top:
       heroHeight != null
@@ -323,6 +339,74 @@ The body section sibling-rendered after the hero already had `bg-stone-800` over
 **Tab-order caveat.** The portaled chrome bar appears far below the sticky hero in DOM source order. Keyboard users tabbing through the page will reach the chrome at a point in the tab sequence that does not match its visual position. Consider `tabindex` management or a focus trap when the chrome is revealed if tab-order fidelity is important.
 
 **Backdrop-blur compositor cost.** `backdrop-blur-2xl` (40px) repaints the blur over a moving Mux video texture every scroll frame. Flagship desktop and recent phones hold 60fps; midrange Android (~2–3 yr old Snapdragon) often drops to 30–45fps during scroll. Profile on a Pixel 6a / Galaxy A-series device before broad rollout. If frame drops are unacceptable, lower the blur radius (`backdrop-blur-xl` / `-lg`) on small viewports or fall back to a solid translucent color when `prefers-reduced-motion` is set. (session history — mobile counterpart pattern quantized scroll updates for the same reason; see Related)
+
+### 5f. Loading spinner with `onCanPlay` + `onError` recovery + render-phase reset (added 2026-05-04)
+
+Once `aspect-video` locks the wrapper at 16:9 (5a), the wrapper has a deterministic full-size box from mount — but Mux Player itself paints a black rectangle while the manifest fetches. On a search-result navigation that hits a cold Mux asset, that black rectangle can sit visible for 1-3 seconds before the muted-loop preview begins. A spinner overlay during that window gives the user feedback that the player is loading rather than broken.
+
+The state machine has three load-bearing pieces. Skip any one and the spinner either flashes incorrectly, sticks forever, or fails to re-show on language switch.
+
+```tsx
+const [videoReady, setVideoReady] = useState(false)
+const handleCanPlay = useCallback(() => {
+  setVideoReady(true)
+}, [])
+
+const handlePlayerError = useCallback((event: CustomEvent) => {
+  const code = (event?.detail as { code?: string } | undefined)?.code
+  if (code === "autoplay-blocked") {
+    setAutoplayBlocked(true)
+  }
+  // Any non-autoplay-blocked error (network, decode, manifest 404…)
+  // means we will never fire onCanPlay, so videoReady would otherwise
+  // stay false forever and the spinner would sit on a black box.
+  // Reveal the player element so Mux Player can render its own
+  // error UI.
+  setVideoReady(true)
+}, [])
+
+// Reset the buffered/ready spinner when the playable identity changes
+// (variant switch via the language picker, or new playback id).
+// Render-phase setState — NOT useEffect — to avoid the React Compiler
+// "cascading renders" lint rule. The new state is queued before commit.
+const [prevVariantKey, setPrevVariantKey] = useState(variant.documentId)
+if (prevVariantKey !== variant.documentId) {
+  setPrevVariantKey(variant.documentId)
+  setVideoReady(false)
+}
+
+// In JSX, layered inside the sticky wrapper from 5a:
+;<MuxPlayer
+  ref={setPlayerRef}
+  playbackId={playbackId}
+  onCanPlay={handleCanPlay}
+  onError={handlePlayerError}
+  /* ...rest of props... */
+/>
+{
+  !videoReady ? (
+    <div
+      data-testid="hero-player-loading"
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black"
+    >
+      <SpinnerIcon className="h-12 w-12 text-white/80" />
+    </div>
+  ) : null
+}
+```
+
+The three load-bearing pieces:
+
+1. **`onError` must call `setVideoReady(true)` for non-autoplay-blocked codes.** Without this, any hard Mux failure (network outage, 404 manifest, decode error, expired playback token) leaves `videoReady=false` permanently — the spinner overlays a black box forever with no recovery path. The spinner is only correct when there is a possibility of `onCanPlay` firing; if that possibility is gone, the spinner has to clear so Mux Player's own error UI becomes visible.
+2. **State reset on prop change must be render-phase, not effect-phase.** The naive pattern is `useEffect(() => setVideoReady(false), [variant.documentId, playbackId])`. The React Compiler ESLint rule (`react-hooks-rule-react-compiler`) flags this as "Calling setState synchronously within an effect can trigger cascading renders" and fails CI at error level. The canonical pattern is "adjust state during render": track the previous variant key in state and reset inline when it changes. The new state is queued before commit, so no cascade.
+3. **`pointer-events-none` on the spinner overlay.** The unmute pill below the wrapper has to remain clickable through the spinner; without `pointer-events-none`, the spinner intercepts the click and the pill never fires.
+
+`onCanPlay` is the right event for "first frame ready to render," not `loadedmetadata` (fires too early — duration is known but no frame is buffered) or `playing` (fires too late — already played past the first frame). The muted-loop preview's `autoPlay="muted"` will trigger `canplay` once enough buffer is available; on hard failures, `error` fires instead and the recovery branch above clears the spinner.
+
+**Stale-spinner-on-language-switch trap.** When the user opens the language picker and switches variants, `<HeroPlayer>` typically does not unmount — only `variant` changes. Without the render-phase reset above, `videoReady=true` from the previous variant suppresses the spinner during the new variant's buffer phase, and the user sees a frozen frame from the previous language while the new manifest loads. The render-phase reset on `variant.documentId` fixes this without remounting the component (which would lose `chromeRevealed`, autoplay state, current playhead, etc.).
+
+**Test coverage requires invoking captured callbacks.** The existing `muxPlayerMock` in `HeroPlayer.test.tsx` captures `onCanPlay`, `onError`, etc. as props but never invokes them. To test the spinner state machine, upgrade the mock to expose helpers like `fireCanPlay()` / `fireError({ code })` and assert the spinner's presence/absence around them. PR #878 includes the mock upgrade and the corresponding lifecycle tests.
 
 ## Why This Matters
 
@@ -621,3 +705,5 @@ The `HeroPlayerControls` test suite lives in `apps/web/src/components/watch/__te
 - `apps/tv/src/components/VideoPlayer.tsx` — TV-side parallel implementation (expo-video + D-pad). Different runtime but the timeline/scrubbing UX should converge with web. (session history)
 - PR [#866](https://github.com/JesusFilm/forge/pull/866) — the original implementation this pattern documents (chrome replacement and lift-to-state).
 - The 2026-05-01 update layer (sections 5a–5e and the iOS-safe sequence patch) was developed against `main` directly without a separate PR; the working tree carries the change.
+- [`docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md`](../logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md) — sibling fix from the same PR (#878). The `aspect-video` + `useLayoutEffect` + `onCanPlay`+`onError` combination in section 5a/5f was added as part of fixing the wrong-language-variant bug, because the original watch page used `useEffect` for the ResizeObserver and had no loading-state coverage at all. Read together for the full context of PR #878.
+- PR [#878](https://github.com/JesusFilm/forge/pull/878) — `feat(web): fix English variant selection + redesign watch share modal + harden hero loading`. Source of the 2026-05-04 updates to sections 5a and 5f.

--- a/docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md
+++ b/docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md
@@ -1,0 +1,105 @@
+---
+title: Strapi GraphQL relation pagination cap causes wrong-language variant playback on watch page
+date: 2026-05-04
+category: logic-errors
+module: web
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "Watch page silently rendered non-English variants (Tarifit, Filipino, German, Norwegian, Thai) when users clicked English search results"
+  - "37 of 95 video search hits resolved to wrong language across 10 sample queries before the fix"
+  - "Strapi v5 GraphQL caps nested relation pagination at 10 rows when no `pagination` argument is supplied"
+  - "REST `maxLimit: 100` in apps/cms/config/api.ts has no effect on GraphQL relations"
+  - "High-variant-count videos (e.g. `mary-visit-to-elizabeth` with 242 variants) reliably reproduced the failure"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components:
+  - tooling
+  - graphql
+tags:
+  - strapi
+  - graphql
+  - pagination
+  - watch-page
+  - variant-selection
+  - locale-fallback
+  - relation-truncation
+---
+
+# Strapi GraphQL relation pagination cap causes wrong-language variant playback on watch page
+
+## Problem
+
+The `apps/web` watch page silently rendered non-English variants when users clicked English search results, because Strapi v5's GraphQL plugin defaults to 10-row pagination on nested relations and the `variants` field in the watch-video fragment had no explicit `pagination` argument. For any video with more than 10 variants, the English variant fell outside the response window — and the watch page's locale-priority selection logic, finding nothing to match the URL locale, fell through to "first playable" and rendered whatever language Strapi happened to return first (Tarifit, Filipino, German, etc.).
+
+## Symptoms
+
+- Watch page rendered a non-English language variant for users who clicked English search results. No error was thrown — the page just played the wrong language.
+- Reproduction was wide: 37 of 95 video search hits across 10 sample queries played in the wrong language before the fix; 0 after.
+- Specific examples (live data probe): `q=father` → `friends-and-enemies` played Thai; `q=kingdom` → `lumo-luke-17-1-18-8` played Norwegian; `q=mary` → `lazarus-rises` played German.
+- High-variant-count videos were the worst affected — `mary-visit-to-elizabeth` (242 variants) reliably reproduced the failure on every load.
+- The bug was introduced in PR #860 (`feat/watch-page-mux-parity`) and survived a full `ce-code-review` pass without detection — silent truncation produces no error to flag.
+
+## What Didn't Work
+
+- **Suspecting the search layer.** First hypothesis: the search query was returning slugs of non-English videos. Disproved by probing live Strapi: the search SQL filters via `JOIN languages l ON l.id = vll.language_id AND l.bcp_47 = ?`, so the English constraint was applied correctly at the search layer. Slugs in search results were correct English video slugs.
+- **Suspecting the variant-selection logic.** Second hypothesis: the priority chain in `fetchResolvedWatchVideoBySlug` (URL locale slug → `bcp47` match → primary language → first playable) was selecting the wrong variant. Disproved by inspection — the logic was correct. Adding more fallbacks would not have helped because English was simply absent from the GraphQL response.
+- **Increasing `maxLimit` in `apps/cms/config/api.ts`.** The REST API config (`rest.maxLimit: 100`) does not apply to the GraphQL plugin. The GraphQL plugin has its own default relation pagination of 10 and is configured separately.
+- **Filtering variants client-side after fetch.** Impossible — the variant didn't come back from Strapi at all, so there was nothing on the client to filter. The missing data had to be fixed at the query layer.
+- **Consulting prior art.** A directly-related solution doc — `docs/solutions/performance-issues/strapi-nested-relation-truncation-and-n-plus-one-manager-20260328.md` — already documented the same Strapi cap from the manager-app angle (silent "no coverage" for languages that exist). This doc was not consulted when authoring `watchVideoFragment` two months later, and the same root cause re-surfaced under a different symptom. (session history)
+
+## Solution
+
+Add explicit `pagination: { limit: -1 }` to every `variants` list in the watch-video GraphQL fragment and the route-video query.
+
+```graphql
+# apps/web/src/lib/fragments/watch-video.ts:43
+variants(pagination: { limit: -1 }) {
+  documentId
+  slug
+  published
+  hls
+  duration
+  language { coreId bcp47 slug name }
+  downloads { documentId quality size url }
+  muxVideo { playbackId }
+}
+```
+
+```graphql
+# apps/web/src/lib/content.ts:74 (GET_ROUTE_VIDEO)
+variants(pagination: { limit: -1 }) {
+  documentId
+  hls
+  published
+  language { coreId }
+}
+```
+
+**RSC payload mitigation** (applied alongside the fix to prevent payload bloat from 242-variant videos): `stripNonSelectedVariantFields` in `apps/web/src/lib/content.ts` strips `downloads`, `muxVideo`, and `duration` from non-selected variants before the `JSON.parse(JSON.stringify(resolved))` normalization. The selected variant retains all fields. This drops the RSC payload from ~500KB (242 × 2KB) to ~100KB. The 60-second `unstable_cache` wrapping `fetchResolvedWatchVideo` and `fetchResolvedWatchVideoBySlug` absorbs the Strapi DB cost.
+
+**Regression test** added to `apps/web/src/lib/fragments/__tests__/watch-video.test.ts` asserting the printed query contains `variants(pagination: { limit: -1 })` so the argument can't silently disappear.
+
+## Why This Works
+
+Strapi v5's GraphQL plugin enforces a default relation pagination limit of 10 rows when no `pagination` argument is supplied. This is separate from and unaffected by the REST API's `rest.maxLimit` config. Passing `limit: -1` is treated by Strapi's GraphQL resolver as "return all records in the relation" — empirically confirmed and used as a pattern across the JFP monorepo (apps/manager applies it to multiple relations).
+
+The variant-selection logic in `fetchResolvedWatchVideoBySlug` (`apps/web/src/lib/content.ts:685-720`) was always correct: URL locale slug → `bcp47` match → primary language → first playable. The bug was not in selection logic but in the input data — with only 10 variants returned for a 242-variant video, the locale priority chain had nothing to find and fell through to "first playable". "First playable" returned whatever language Strapi happened to surface first, which was the alphabetically-first variant for that video.
+
+## Prevention
+
+- **Any Strapi v5 GraphQL fragment that fetches a list-shaped relation must include `pagination: { limit: -1 }` explicitly.** Omitting it silently caps results at 10. This is the failure mode, not an error you can catch — there is no warning, no log, and no exception. Audit existing fragments for this pattern when touching the watch / share / language-picker code.
+- **Add a regex assertion in fragment tests.** Mirror the watch-video pattern at `apps/web/src/lib/fragments/__tests__/watch-video.test.ts` for any new fragment that fetches a relation. The test prints the query AST and asserts `variants(pagination:\s*\{\s*limit:\s*-1\s*\}\)`. A future edit removing the argument fails the test.
+- **Flag in code review.** Any Strapi GraphQL fragment touching a list-shaped relation without an explicit `pagination` argument is a review blocker. The current `ce-code-review` API-contract reviewer missed this on PR #860; consider promoting it to a default check. (session history)
+- **`limit: -1` is undocumented Strapi behavior.** A future Strapi upgrade could close this bypass, silently reverting high-variant-count videos to wrong-language rendering. If Strapi is upgraded, verify `limit: -1` still returns unbounded results with a probe query against a known high-variant video (e.g. `mary-visit-to-elizabeth`) before deploying.
+- **Long-term: split the watch-video fragment.** Decompose into a thin language-picker projection (all variants, minimal fields: `documentId`, `language { bcp47 slug }`, `hls`, `published`) and a selected-variant detail projection (single variant, full fields with `downloads` and `muxVideo`) fetched only after locale resolution. This eliminates the unbounded-fetch payload cost entirely rather than mitigating it in post-processing.
+- **Always cross-link related solutions docs.** When `watchVideoFragment` was authored, the related manager-side solution doc existed but wasn't consulted. Cross-linking from `docs/solutions/best-practices/watch-single-video-template-pages-strapi-nextjs-2026-04-11.md` (and related architecture docs) to the Strapi pagination doc would have surfaced the prior art.
+
+## Related Issues
+
+- **Same root cause, different surface:** [`docs/solutions/performance-issues/strapi-nested-relation-truncation-and-n-plus-one-manager-20260328.md`](../performance-issues/strapi-nested-relation-truncation-and-n-plus-one-manager-20260328.md) — original documentation of the Strapi 10-row cap from the manager app's coverage-dashboard angle. Cross-references this doc for the canonical root-cause explanation; the present doc adds the watch-page wrong-language-playback symptom as a second observed instance.
+- **Architecture context:** [`docs/solutions/best-practices/watch-single-video-template-pages-strapi-nextjs-2026-04-11.md`](../best-practices/watch-single-video-template-pages-strapi-nextjs-2026-04-11.md) — covers the watch page route resolution, `watchVideoFragment` shape, and `resolveWatchPage` priority chain. Add a pointer to the present doc from there so future fragment authors find this fix.
+- **Adjacent player concerns:** [`docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md`](../design-patterns/mux-player-custom-react-chrome-pattern-20260430.md) — covers `HeroPlayer` chrome and loading state. Currently flags `aspect-video` and `onCanPlay` as superseded approaches; PR #878 re-introduces both as part of the watch-page fix bundle. **Refresh candidate** — should be updated post-merge to reflect the combined `aspect-video` + ResizeObserver + `onCanPlay`-with-`onError` pattern.
+- **Shipped in:** [PR #878](https://github.com/JesusFilm/forge/pull/878) — `feat(web): fix English variant selection + redesign watch share modal + harden hero loading`. Bundles the pagination fix with HeroPlayer loading-state hardening and ShareModal redesign; full per-reviewer artifact at `/tmp/compound-engineering/ce-code-review/20260504-144216-141469c4/`.
+- **Bug introduced in:** PR #860 (`feat/watch-page-mux-parity`) — the original watch page implementation that authored `watchVideoFragment` without explicit pagination. (session history)


### PR DESCRIPTION
## Summary

Three watch-page issues land together in this PR. All shipped through `/compound-engineering:ce-code-review` (13 reviewer agents, 22 actionable findings, all applied + verified).

- **English variant selection was broken on long-tail content.** Strapi's GraphQL relation pagination silently caps at 10 by default. Videos with >10 variants (`mary-visit-to-elizabeth` has 242) were having English fall outside the window, and the watch page was selecting "first playable" — which was Tarifit, German, Filipino, etc. depending on the alphabetical ordering. Fix: `pagination: { limit: -1 }` on `variants` in both the `WatchVideo` fragment and `GET_ROUTE_VIDEO`. Live-data probe before/after: **37 of 95 search hits** were resolving to a non-English variant; **0 after the fix.**
- **Watch hero collapsed to ~250 px during buffering.** The wrapper had no intrinsic height, and Mux Player's min-height kicked in until metadata resolved. Title and Play-with-Sound pill were stacking on top of the floating search bar. Fix: `aspect-video` on the wrapper for stable 16 : 9, plus a centered loading spinner gated on `onCanPlay` (and cleared from `onError` for non-autoplay codes so playback failures don't leave a permanent spinner over a black box). `videoReady` resets when `variant.documentId` changes so language switches re-show the spinner.
- **Share modal redesigned** to mirror the DownloadModal: thumbnail + title + description header, Facebook + X social buttons, segmented Share Link / Embed Code tabs with an auto-fitting textarea (capped at 40 vh, scrolls past the cap), and a white-with-red-hover Copy pill. Localhost canonical origin is substituted with `https://jesusfilm.org` for FB / X intents only (Copy Link still copies the configured origin), and the FB + X buttons render disabled with a "works once deployed" hint when the origin isn't publicly shareable so we don't poison FB's negative cache. The Mux iframe embed uses inline `aspect-ratio:16/9` styles instead of a `<style>` block, eliminating the `</style>` break-out concern when partners paste it inside their own `<style>` tag.

Hardening picked up along the way:
- `playbackId` regex-validated (`^[A-Za-z0-9_-]{8,64}$`) before iframe interpolation — prevents stored XSS on partner sites that paste the embed snippet.
- `NEXT_PUBLIC_CANONICAL_ORIGIN` warn-only `z.refine` against a soft allowlist (`jesusfilm.org`, localhost, `*.local`, `*.railway.app`) — surfaces config drift in logs without blocking preview deployments.
- `isPublicShareableOrigin` now also rejects IPv6 loopback `[::1]` and RFC1918 ranges.

Refactors:
- `SpinnerIcon` extracted to `ui/spinner.tsx` (shared with `SearchOverlay`, which had a byte-identical SVG).
- URL validation helpers in `lib/url.ts`; share builders (`buildEmbedSnippet`, `buildFbShareUrl`, `buildXShareUrl`) in `lib/share.ts` — programmatic surface for agents / scripts / future MCP tools.
- `posterUrl` fallback chain extracted in `WatchPageClient`.
- `variantsForLanguagePicker` memoized (242-element array allocated on every modal-state change before).
- `unstable_cache` no longer caches `null` returns from `fetchResolvedWatchVideoBySlug` (sentinel-throw bypass) — a transient Strapi miss no longer blocks the watch page for 60 seconds.
- Per-variant payload narrows: `downloads` / `muxVideo` / `duration` stripped from non-selected variants before RSC serialization (242 × 2 KB = 500 KB → ~100 KB).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 245 passing across 27 files (was 240, +5 new tests covering: HeroPlayer spinner lifecycle, `GET_ROUTE_VIDEO` pagination assertion, FB / X button disabled state on localhost origin, embed-snippet shape with `aspect-ratio:16/9`)
- [ ] Manual smoke after deploy: `/watch/mary-visit-to-elizabeth/en` loads the English variant (`L00qc6Ec…` playback id), not Tarifit / Pashto
- [ ] Manual smoke: open Share modal on a watch page, hit Copy Link / Copy Code, click FB / X buttons, verify URLs populate the platform composer (production origin only — the dev environment will show the disabled state per the new behavior)
- [ ] Watch hero loads with the spinner overlay, then hides on play; force a 404 on the manifest and verify the spinner clears (no permanent black box)

## Notes for review

- `apps/cms/schema.graphql` has a separate **pre-existing** modification (88 `hasPublishedVersion: Boolean` arguments added to Query fields) flagged by `ce-code-review`'s project-standards reviewer as needing `packages/graphql/` codegen regen per the root `CLAUDE.md` GraphQL Change Flow. I deliberately excluded it from this PR — it pre-dates this branch and belongs in its own commit / PR. Worth a follow-up.
- The `mux-player-custom-react-chrome-pattern-20260430.md` solutions doc claims `aspect-video` and `onCanPlay` are "superseded" approaches. This PR re-introduces both because the previous ResizeObserver-only path produced the bug. Worth updating the doc post-merge to reflect the new combined approach (`aspect-video` + `useLayoutEffect`-driven ResizeObserver + `onCanPlay` spinner with `onError` recovery).

## Cache rollout

Watch-page resolvers use `unstable_cache({ revalidate: 60 })`. Warm cache entries built against the **old** truncated-variants query continue to serve the wrong-language fallback for up to 60 s after deploy. Either (a) trigger targeted cache revalidation for known high-variant videos on deploy, or (b) accept and document the rollout window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)