### PR TITLE
feat(web): show chapter carousel on watch pages with chapter-aware data

### DIFF
--- a/apps/web/src/components/watch/BibleQuotesSection.tsx
+++ b/apps/web/src/components/watch/BibleQuotesSection.tsx
@@ -34,7 +34,7 @@ export function BibleQuotesSection({
     <section
       data-block-type="BibleQuotes"
       data-testid="watch-bible-quotes"
-      className="pt-14 pb-6"
+      className="pt-4 pb-6"
     >
       <div
         data-testid="watch-bible-quotes-header"

--- a/apps/web/src/components/watch/HeroPlayerControls.tsx
+++ b/apps/web/src/components/watch/HeroPlayerControls.tsx
@@ -44,6 +44,11 @@ export function HeroPlayerControls({
   const [hoveringControls, setHoveringControls] = useState(false)
   const [volumeOpen, setVolumeOpen] = useState(false)
   const [volumeDragging, setVolumeDragging] = useState(false)
+  const [timelineDragging, setTimelineDragging] = useState(false)
+  // Local scrub position (0..1) used by the visual thumb during a drag so
+  // the cursor can lead the player's actual seek-resolved time without
+  // visible lag. `null` outside of a drag — falls back to currentTime.
+  const [scrubPct, setScrubPct] = useState<number | null>(null)
   const timelineRef = useRef<HTMLDivElement | null>(null)
   const volumeTrackRef = useRef<HTMLDivElement | null>(null)
   const hideTimerRef = useRef<number | null>(null)
@@ -62,22 +67,63 @@ export function HeroPlayerControls({
   }, [hoveringControls])
 
   const volumeDraggingRef = useRef(false)
+  const timelineDraggingRef = useRef(false)
+  // Remembers playback state at scrub-start so we can resume on pointerup if
+  // the user was playing before the drag began.
+  const wasPlayingBeforeScrubRef = useRef(false)
+  // Latest scrub position seen by pointermove. The actual `player.currentTime`
+  // write is throttled via rAF to at most one seek per animation frame —
+  // pointermove fires at 60-120 Hz on most browsers, and HLS / Mux Player
+  // cannot process that many seeks per second without visible jerk.
+  const scrubPctRef = useRef<number | null>(null)
+  const scrubRafRef = useRef<number | null>(null)
+  // Snapshot of the timeline's bounding rect captured at pointerdown. Re-using
+  // this for the entire drag prevents thumb oscillation when the volume
+  // slider opens mid-drag and shrinks the flex-1 timeline — re-reading
+  // getBoundingClientRect on every move would otherwise return a moving
+  // target. Cleared on pointerup / lostPointerCapture.
+  const scrubRectRef = useRef<DOMRect | null>(null)
+  // Cancel any pending rAF on unmount to avoid a stray seek after teardown.
+  // Co-located with the ref to match the file convention (see playingRef
+  // above). If the user was scrubbing when controls unmount, also resume
+  // playback so the player isn't left paused indefinitely.
+  useEffect(() => {
+    // Snapshot the playerRef at effect-mount; it's a stable RefObject so its
+    // identity won't change, and reading the same handle in cleanup mirrors
+    // what the unmount tear-down should target.
+    const ref = playerRef
+    return () => {
+      if (scrubRafRef.current != null) {
+        window.cancelAnimationFrame(scrubRafRef.current)
+        scrubRafRef.current = null
+      }
+      const p = ref.current
+      if (wasPlayingBeforeScrubRef.current && p?.paused) {
+        wasPlayingBeforeScrubRef.current = false
+        p.play()?.catch(() => {})
+      }
+    }
+  }, [playerRef])
   useEffect(() => {
     volumeDraggingRef.current = volumeDragging
   }, [volumeDragging])
+  useEffect(() => {
+    timelineDraggingRef.current = timelineDragging
+  }, [timelineDragging])
 
   const scheduleHide = useCallback(() => {
     if (hideTimerRef.current != null) {
       window.clearTimeout(hideTimerRef.current)
       hideTimerRef.current = null
     }
-    // Don't auto-hide while playing-paused, while user hovers controls, or
-    // while user is actively dragging the volume slider — losing the slider
-    // mid-drag drops pointer capture and leaves volumeDragging stuck.
+    // Don't auto-hide while paused, while user hovers controls, or while user
+    // is actively dragging either the volume slider or the timeline — losing
+    // either mid-drag drops pointer capture and leaves the drag flag stuck.
     if (
       !playingRef.current ||
       hoveringControlsRef.current ||
-      volumeDraggingRef.current
+      volumeDraggingRef.current ||
+      timelineDraggingRef.current
     ) {
       return
     }
@@ -279,10 +325,15 @@ export function HeroPlayerControls({
 
   const handleVolumePointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!volumeDragging) return
+      // Read the ref (synchronously updated in pointerdown's commit-phase
+      // effect) instead of the closed-over `volumeDragging` state, mirroring
+      // the timeline pattern. Using state here would either (a) make this
+      // callback resubscribe each render, or (b) leak a stale `false` into
+      // the first move after pointerdown.
+      if (!volumeDraggingRef.current) return
       setPlayerVolume(computeVolumeFromClientX(e.clientX))
     },
-    [volumeDragging, computeVolumeFromClientX, setPlayerVolume],
+    [computeVolumeFromClientX, setPlayerVolume],
   )
 
   const handleVolumePointerUp = useCallback(
@@ -351,29 +402,187 @@ export function HeroPlayerControls({
     }
   }, [wrapperRef])
 
-  const seekToClientX = useCallback(
-    (clientX: number) => {
+  // Compute the 0..1 scrub fraction for a clientX within the timeline rect.
+  // Clamped at the edges so dragging past the bar's bounds still produces a
+  // valid percentage rather than a wild seek target. During an active drag
+  // we use the rect snapshotted at pointerdown so layout shifts (e.g. the
+  // volume slider opening and shrinking the flex-1 timeline) don't make the
+  // thumb oscillate under the cursor.
+  const computeScrubPct = useCallback((clientX: number): number => {
+    const snapshot = scrubRectRef.current
+    if (snapshot && snapshot.width > 0) {
+      return Math.min(
+        1,
+        Math.max(0, (clientX - snapshot.left) / snapshot.width),
+      )
+    }
+    const track = timelineRef.current
+    if (!track) return 0
+    const rect = track.getBoundingClientRect()
+    if (rect.width <= 0) return 0
+    return Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+  }, [])
+
+  // Apply a scrub fraction directly — single seek, no coalescing. Used at
+  // pointerdown (one-off click), pointerup (final position), and inside the
+  // rAF callback that flushes the latest pointermove target.
+  const seekToPct = useCallback(
+    (pct: number) => {
       const p = playerRef.current
-      const track = timelineRef.current
-      if (!p || !track || !duration) return
-      const rect = track.getBoundingClientRect()
-      const pct = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+      if (!p || !duration) return
       p.currentTime = pct * duration
     },
     [playerRef, duration],
   )
 
-  const handleTimelineClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      seekToClientX(e.clientX)
+  // Coalesce seeks to at-most-one-per-frame. pointermove can fire 60-120 Hz;
+  // HLS / Mux Player cannot honor that many `currentTime` writes per second
+  // without visible stalling — the thumb (driven by `timeupdate`) lags behind
+  // the cursor. The local `scrubPct` state drives the visual thumb at full
+  // pointer rate while the seek itself runs at frame rate.
+  const scheduleCoalescedSeek = useCallback(() => {
+    if (scrubRafRef.current != null) return
+    scrubRafRef.current = window.requestAnimationFrame(() => {
+      scrubRafRef.current = null
+      const pct = scrubPctRef.current
+      if (pct == null) return
+      // Read the player + duration directly inside the rAF callback rather
+      // than going through the closed-over `seekToPct`. Collapses the closure
+      // chain so a `durationchange` between rAF schedule and fire doesn't
+      // cause a stale-duration seek.
+      const p = playerRef.current
+      if (!p) return
+      const d = p.duration
+      if (!Number.isFinite(d) || d <= 0) return
+      p.currentTime = pct * d
+    })
+  }, [playerRef])
+
+  // Pointer-driven scrub: pointerdown captures the pointer, pauses playback
+  // (resumed on release if it was playing), and seeks to the click point.
+  // pointermove follows the pointer with instant visual feedback and
+  // throttled actual seeks. pointerup releases capture and resumes playback.
+  // Mirrors the volume slider's setPointerCapture pattern so the drag
+  // survives the cursor leaving the timeline rect.
+  const handleTimelinePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const p = playerRef.current
+      if (!p) return
+      // Snapshot playback state, then pause for a stable scrubbing experience —
+      // without this, playback advances past the scrub target while the user
+      // is still dragging.
+      wasPlayingBeforeScrubRef.current = !p.paused
+      if (!p.paused) p.pause()
+      // Snapshot the timeline rect for the duration of the drag — see
+      // scrubRectRef declaration. Done before the first computeScrubPct so
+      // both pointerdown and subsequent pointermoves share the same frame
+      // of reference.
+      scrubRectRef.current = e.currentTarget.getBoundingClientRect()
+      // Dual-write: ref first (so the synchronous pointermove that some
+      // browsers fire immediately after pointerdown sees the live `true`
+      // before the commit-phase effect runs), then state for render-visible
+      // attrs (data-dragging, thumb opacity, displayTime).
+      timelineDraggingRef.current = true
+      setTimelineDragging(true)
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId)
+      } catch {
+        // pointer may have been released before capture acquired
+      }
+      const pct = computeScrubPct(e.clientX)
+      scrubPctRef.current = pct
+      setScrubPct(pct)
+      seekToPct(pct)
     },
-    [seekToClientX],
+    [playerRef, computeScrubPct, seekToPct],
   )
+
+  const handleTimelinePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!timelineDraggingRef.current) return
+      const pct = computeScrubPct(e.clientX)
+      // Visual update fires every move — instant cursor-following thumb.
+      scrubPctRef.current = pct
+      setScrubPct(pct)
+      // Actual `currentTime =` write is throttled to one per animation frame.
+      scheduleCoalescedSeek()
+    },
+    [computeScrubPct, scheduleCoalescedSeek],
+  )
+
+  const handleTimelinePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // Atomic snapshot+zero so the synchronous lostPointerCapture re-fire
+      // from releasePointerCapture (Chrome/Firefox dispatch it synchronously)
+      // doesn't see a stale `true` and double-fire play().
+      const wasPlaying = wasPlayingBeforeScrubRef.current
+      wasPlayingBeforeScrubRef.current = false
+      const wasDragging = timelineDraggingRef.current
+      // Cancel any pending coalesced seek; we'll apply the final position
+      // synchronously below so the player ends up exactly where the user
+      // released, not wherever the last rAF happened to fire.
+      if (scrubRafRef.current != null) {
+        window.cancelAnimationFrame(scrubRafRef.current)
+        scrubRafRef.current = null
+      }
+      const finalPct = scrubPctRef.current
+      scrubPctRef.current = null
+      scrubRectRef.current = null
+      timelineDraggingRef.current = false
+      const p = playerRef.current
+      // Apply the final seek BEFORE clearing drag state so displayTime stays
+      // pinned to the scrub thumb until `timeupdate` fires — otherwise the
+      // thumb visibly snaps back to the stale `currentTime` for one frame.
+      if (wasDragging && finalPct != null && p) seekToPct(finalPct)
+      setTimelineDragging(false)
+      setScrubPct(null)
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      }
+      if (!wasDragging) return
+      if (!p) return
+      // Gate on live `p.paused` too — if the user pressed space-bar mid-drag,
+      // p.paused will reflect that and we won't override their intent. play()
+      // rejection (e.g. iOS autoplay gate) is rare here since the user gesture
+      // initiated the scrub; swallow silently.
+      if (wasPlaying && p.paused) {
+        p.play()?.catch(() => {})
+      }
+    },
+    [playerRef, seekToPct],
+  )
+
+  // If the OS revokes pointer capture mid-drag (page hidden, touch preempted,
+  // container collapses), pointerup never fires — reset the drag flag, drop
+  // any pending coalesced seek, and resume playback if the user was playing
+  // before, so the player doesn't sit stuck-paused with the auto-hide guard
+  // latched on.
+  const handleTimelineLostPointerCapture = useCallback(() => {
+    if (scrubRafRef.current != null) {
+      window.cancelAnimationFrame(scrubRafRef.current)
+      scrubRafRef.current = null
+    }
+    scrubPctRef.current = null
+    scrubRectRef.current = null
+    timelineDraggingRef.current = false
+    setTimelineDragging(false)
+    setScrubPct(null)
+    const p = playerRef.current
+    if (!p) return
+    if (wasPlayingBeforeScrubRef.current && p.paused) {
+      wasPlayingBeforeScrubRef.current = false
+      p.play()?.catch(() => {})
+    }
+  }, [playerRef])
 
   const handleTimelineKey = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       const p = playerRef.current
       if (!p) return
+      // Drop keyboard seeks while a pointer drag is in flight — otherwise
+      // arrow / Home / End / PageUp / PageDown writes get clobbered by the
+      // next rAF flush or pointerup's final seek.
+      if (timelineDraggingRef.current) return
       // Always preventDefault for the keys we own so the slider role doesn't
       // produce silent no-ops while duration is still loading.
       const ownedKeys = [
@@ -407,8 +616,14 @@ export function HeroPlayerControls({
     [playerRef, duration],
   )
 
+  // During a drag, the thumb and the time readout both track the local scrub
+  // position rather than the player's `currentTime` (which only updates after
+  // the seek resolves). This is what makes the cursor "lead" the player
+  // without visible lag.
+  const displayTime =
+    timelineDragging && scrubPct != null ? scrubPct * duration : currentTime
   const progressPct =
-    duration > 0 ? Math.min(100, (currentTime / duration) * 100) : 0
+    duration > 0 ? Math.min(100, (displayTime / duration) * 100) : 0
 
   // Chrome control bar — portaled into the overlay anchor (just below the
   // sticky hero) so it rides on the body section's top edge as the body
@@ -438,12 +653,17 @@ export function HeroPlayerControls({
         aria-label="Seek"
         aria-valuemin={0}
         aria-valuemax={Math.max(0, Math.floor(duration))}
-        aria-valuenow={Math.floor(currentTime)}
-        aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
+        aria-valuenow={Math.floor(displayTime)}
+        aria-valuetext={`${formatTime(displayTime)} of ${formatTime(duration)}`}
         data-testid="hero-chrome-timeline"
-        onClick={handleTimelineClick}
+        data-dragging={timelineDragging ? "true" : "false"}
+        onPointerDown={handleTimelinePointerDown}
+        onPointerMove={handleTimelinePointerMove}
+        onPointerUp={handleTimelinePointerUp}
+        onPointerCancel={handleTimelinePointerUp}
+        onLostPointerCapture={handleTimelineLostPointerCapture}
         onKeyDown={handleTimelineKey}
-        className="group relative h-1 flex-1 cursor-pointer rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
+        className="group relative h-1 flex-1 cursor-pointer touch-pan-y rounded-full bg-white/20 focus:ring-2 focus:ring-white/60 focus:outline-none"
       >
         <div
           className="absolute inset-y-0 left-0 rounded-l-full bg-white/40"
@@ -454,18 +674,20 @@ export function HeroPlayerControls({
           style={{ width: `${progressPct}%` }}
         />
         <div
-          className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#cb333b] opacity-0 shadow transition group-hover:opacity-100 group-focus:opacity-100"
+          className={`absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#cb333b] shadow transition group-hover:opacity-100 group-focus:opacity-100 ${
+            timelineDragging ? "opacity-100" : "opacity-0"
+          }`}
           style={{ left: `${progressPct}%` }}
         />
       </div>
 
       <div
         data-testid="hero-chrome-time"
-        data-current-time={Math.floor(currentTime)}
+        data-current-time={Math.floor(displayTime)}
         data-duration={Math.floor(duration)}
         className="shrink-0 text-sm font-medium tabular-nums text-white drop-shadow md:text-base"
       >
-        {formatTime(currentTime)} / {formatTime(duration)}
+        {formatTime(displayTime)} / {formatTime(duration)}
       </div>
 
       <div

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import type { Route } from "next"
 import { useParams } from "next/navigation"
+import { Play } from "lucide-react"
 
 import {
   Carousel,
@@ -16,6 +17,7 @@ import {
 } from "@/components/ui/carousel"
 import { cn } from "@/lib/utils"
 import type { WatchSiblingCarouselBlock } from "@/lib/content"
+import { resolvePosterUrl } from "@/lib/url"
 
 export function SiblingCarousel({
   block,
@@ -27,35 +29,53 @@ export function SiblingCarousel({
   const params = useParams<{ locale?: string }>()
   const currentLocale = params?.locale ?? ""
 
+  // Drop nulls AND items missing a slug — without a slug we can't build a
+  // routable href, and rendering an unclickable card is worse than
+  // omitting it entirely. Same for currentLocale: it's URL-encoded for
+  // safety in case Next ever surfaces a non-encoded locale segment.
   const children = (canonicalParent.children ?? []).filter(
-    (child): child is NonNullable<typeof child> => child != null,
+    (child): child is NonNullable<typeof child> & { slug: string } =>
+      child != null && typeof child.slug === "string" && child.slug.length > 0,
   )
 
   const activeIndex = children.findIndex(
     (child) => child.documentId === currentVideoDocumentId,
   )
+  const isParentMode = activeIndex < 0
   const clipIndex = activeIndex >= 0 ? activeIndex + 1 : 1
   const clipTotal = children.length
 
   const [api, setApi] = useState<CarouselApi | null>(null)
 
-  // Snap to active item once on mount. Depend on `api` only (not
-  // `activeIndex`) so re-renders don't yank the user's scroll position back.
-  const initialActiveIndex = useRef(activeIndex)
+  // Snap to the active item whenever it changes (or when `api` first
+  // becomes available). Re-keying on `activeIndex` covers variant-switch
+  // scenarios where the same SiblingCarousel instance now has a new
+  // active child — without this, the carousel would stay scrolled to the
+  // previous chapter. The early-return guard handles parent-page mode
+  // (activeIndex === -1, no card to snap to).
   useEffect(() => {
     if (!api) return
-    const idx = initialActiveIndex.current
-    if (idx < 0) return
-    api.scrollTo(idx, true)
-  }, [api])
+    if (activeIndex < 0) return
+    api.scrollTo(activeIndex, true)
+  }, [api, activeIndex])
 
   if (children.length < 2) return null
+
+  // Parent-page mode (current video IS the parent / collection): suppress
+  // the "Clip N of M" position counter. There's no active position to
+  // count from, and rendering "Clip 1 of N" would be misleading. Show a
+  // simple "{N} chapters" total instead, mirroring the change in
+  // aria-label below.
+  const ariaLabel = isParentMode
+    ? `${canonicalParent.title ?? "Collection"} · ${clipTotal} chapters`
+    : `${canonicalParent.title ?? "Collection"} · Clip ${clipIndex} of ${clipTotal}`
 
   return (
     <section
       data-block-type="SiblingCarousel"
-      className="relative w-full px-4 py-8 md:px-8"
-      aria-label={`${canonicalParent.title ?? "Collection"} · Clip ${clipIndex} of ${clipTotal}`}
+      data-mode={isParentMode ? "parent" : "chapter"}
+      className="relative w-full px-4 pt-2 pb-2 md:px-8"
+      aria-label={ariaLabel}
     >
       <header className="mb-4">
         <p className="text-sm font-medium text-stone-300">
@@ -64,7 +84,9 @@ export function SiblingCarousel({
           </span>
           <span className="px-2 text-stone-500">·</span>
           <span data-testid="sibling-carousel-label">
-            Clip {clipIndex} of {clipTotal}
+            {isParentMode
+              ? `${clipTotal} chapters`
+              : `Clip ${clipIndex} of ${clipTotal}`}
           </span>
         </p>
       </header>
@@ -77,14 +99,28 @@ export function SiblingCarousel({
         <CarouselContent>
           {children.map((child, index) => {
             const isActive = index === activeIndex
-            const thumb = child.images?.[0]?.url ?? null
+            // `resolvePosterUrl` codifies the editorial-cinematic priority
+            // chain shared with WatchPageClient. The raw `images[].url`
+            // value is excluded from that chain entirely: it's a misshaped
+            // Cloudflare Images URL (missing the variant path segment)
+            // that returns 400, so a "last resort" fallback to it only
+            // ever produces broken images.
+            const thumb = resolvePosterUrl(child.images?.[0])
+            // 2-segment watch route: `/{slug}/{locale}`. The earlier
+            // 3-segment shape (`/{parent}/{child}/{locale}`) 404s because
+            // the route was migrated to a flat `[slug]/[locale]` structure.
+            // Both segments are URL-encoded defensively — slugs are
+            // editor-controlled (so far always URL-safe), but encoding
+            // costs nothing and protects against a future Strapi slug
+            // policy change. `currentLocale` is encoded for the same
+            // reason.
             const href =
-              `/${canonicalParent.slug}/${child.slug}/${currentLocale}` as Route
+              `/${encodeURIComponent(child.slug)}/${encodeURIComponent(currentLocale)}` as Route
 
             return (
               <CarouselItem
                 key={child.documentId}
-                className="basis-[55%] sm:basis-[40%] md:basis-1/3 lg:basis-1/4 xl:basis-1/5"
+                className="basis-[70%] sm:basis-[45%] md:basis-1/3 lg:basis-1/4 xl:basis-1/5 2xl:basis-1/6"
                 aria-current={isActive ? "true" : undefined}
               >
                 <Link
@@ -92,58 +128,100 @@ export function SiblingCarousel({
                   data-testid="sibling-carousel-item"
                   data-active={isActive ? "true" : "false"}
                   data-href={href}
+                  // The border is drawn inside the element (not as a ring,
+                  // which extends outside the box and gets clipped by
+                  // CarouselContent's `overflow-hidden` viewport at the
+                  // top/bottom edges). Inactive cards have no border so
+                  // the body-zone's frosted-glass backdrop doesn't read
+                  // as a faint grey halo through a transparent border.
+                  // The 4 px difference in image content area between
+                  // active/inactive is imperceptible because the outer
+                  // card geometry (carousel slot) stays the same.
                   className={cn(
-                    "group block overflow-hidden rounded-lg bg-stone-800 transition",
+                    "group relative block aspect-video overflow-hidden rounded-lg bg-stone-900 transition",
                     isActive
-                      ? "ring-2 ring-amber-400"
-                      : "opacity-70 hover:opacity-100",
+                      ? "border-4 border-red-600"
+                      : "opacity-80 hover:opacity-100",
                   )}
                 >
-                  <div className="relative aspect-video w-full overflow-hidden bg-stone-900">
-                    {thumb ? (
-                      <Image
-                        src={thumb}
-                        alt={child.title ?? ""}
-                        fill
-                        sizes="(max-width: 640px) 55vw, (max-width: 768px) 40vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, 20vw"
-                        className="object-cover transition group-hover:scale-105"
-                      />
-                    ) : (
-                      <div
-                        data-testid="sibling-carousel-thumb-placeholder"
-                        className="flex h-full items-center justify-center text-xs text-stone-600"
-                      >
-                        No image
-                      </div>
-                    )}
-                    {isActive ? (
-                      <span
-                        data-testid="sibling-carousel-playing-now"
-                        className="absolute left-2 top-2 rounded-full bg-amber-400 px-2 py-0.5 text-xs font-semibold text-stone-950"
-                      >
-                        Playing now
-                      </span>
-                    ) : null}
-                  </div>
+                  {thumb ? (
+                    <Image
+                      src={thumb}
+                      alt={child.title ?? ""}
+                      fill
+                      sizes="(max-width: 640px) 70vw, (max-width: 768px) 45vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, (max-width: 1536px) 20vw, 16vw"
+                      className="object-cover transition-transform duration-300 group-hover:scale-105"
+                      // Mark the first 5 cards above-the-fold so Next can
+                      // preload them and avoid CLS / late paints on the
+                      // initial visible strip. Cards beyond the first 5
+                      // are off-screen at most viewport widths.
+                      priority={index < 5}
+                    />
+                  ) : (
+                    <div
+                      data-testid="sibling-carousel-thumb-placeholder"
+                      className="flex h-full w-full items-center justify-center bg-stone-900 text-xs text-stone-600"
+                    >
+                      No image
+                    </div>
+                  )}
 
-                  <div className="flex flex-col gap-1 p-3">
-                    <h3 className="line-clamp-2 text-sm font-semibold text-white">
+                  {/* Bottom gradient for caption legibility over the thumbnail. */}
+                  <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent"
+                  />
+
+                  {/* Hover-only play overlay on inactive cards. The active
+                      card already signals "this is what's playing" via the
+                      red border, so we don't double-mark it with a button. */}
+                  {!isActive ? (
+                    <div
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+                    >
+                      <span className="flex h-12 w-12 items-center justify-center rounded-full bg-red-600 text-white shadow-lg ring-1 ring-black/20">
+                        <Play size={20} fill="currentColor" stroke="none" />
+                      </span>
+                    </div>
+                  ) : null}
+
+                  {/* Caption block — CHAPTER label + title overlaid on the
+                      thumbnail's lower-left, matching the watch-page mockup. */}
+                  <div className="absolute inset-x-0 bottom-0 flex flex-col gap-1 p-3 sm:p-4">
+                    <span className="text-[10px] font-semibold tracking-[0.18em] text-stone-300 uppercase drop-shadow-md sm:text-xs">
+                      Chapter
+                    </span>
+                    <h3 className="line-clamp-2 text-sm font-bold text-white drop-shadow-md sm:text-base">
                       {child.title ?? ""}
                     </h3>
-                    {child.label ? (
-                      <p className="text-xs uppercase tracking-wide text-stone-400">
-                        {child.label}
-                      </p>
-                    ) : null}
                   </div>
+
+                  {/* Visually-hidden active marker — preserves the existing
+                      `sibling-carousel-playing-now` testid and gives screen
+                      readers a labeled "Playing now" affordance even though
+                      the visual cue is a border, not a pill. */}
+                  {isActive ? (
+                    <span
+                      data-testid="sibling-carousel-playing-now"
+                      className="sr-only"
+                    >
+                      Playing now
+                    </span>
+                  ) : null}
                 </Link>
               </CarouselItem>
             )
           })}
         </CarouselContent>
 
-        <CarouselPrevious className="hidden md:inline-flex" />
-        <CarouselNext className="hidden md:inline-flex" />
+        {/* The shared `outline` Button variant only sets text color on
+            hover (via `hover:text-foreground`); against this dark-themed
+            page the chevrons inherit white from the parent until hover.
+            Force the chevrons to a near-black at all times so the arrow
+            stays legible against the light circular background. */}
+        <CarouselPrevious className="hidden text-stone-900 hover:text-stone-900 md:inline-flex" />
+        <CarouselNext className="hidden text-stone-900 hover:text-stone-900 md:inline-flex" />
       </Carousel>
     </section>
   )

--- a/apps/web/src/components/watch/WatchBody.tsx
+++ b/apps/web/src/components/watch/WatchBody.tsx
@@ -35,16 +35,6 @@ export function WatchBody({
         data-testid="watch-body-left"
         className="col-span-12 flex min-w-0 flex-col gap-4 md:col-span-8"
       >
-        {hasDownloads ? (
-          // pt-6 xl:pt-4 matches WatchStudyQuestions' top padding so the
-          // Download pill and the Related Questions / Ask Yours row align
-          // on the same horizontal axis at the top of both columns.
-          // pr-12 xl:pr-16 fixes Download's right edge inside the left
-          // column.
-          <div className="flex justify-end pt-6 md:pr-12 xl:pt-4 xl:pr-16">
-            <DownloadButton onClick={onDownloadClick} />
-          </div>
-        ) : null}
         {video.label ? (
           <span
             data-testid="watch-body-label"
@@ -53,12 +43,27 @@ export function WatchBody({
             {video.label}
           </span>
         ) : null}
-        <h1
-          data-testid="watch-body-title"
-          className="text-3xl font-bold text-stone-100 md:text-4xl xl:text-5xl"
+        {/* Download lives in the title row so its Y axis matches the h1
+            (and, by symmetry, the Related Questions / Ask Yours row in the
+            right column whose pt is tuned to match this same Y). With
+            Download here instead of above the SEGMENT label, increasing pt
+            on a sibling can no longer push Download out of alignment. */}
+        <div
+          data-testid="watch-body-title-row"
+          className="flex items-center justify-between gap-4"
         >
-          {video.title ?? ""}
-        </h1>
+          <h1
+            data-testid="watch-body-title"
+            className="min-w-0 text-3xl font-bold text-stone-100 md:text-4xl xl:text-5xl"
+          >
+            {video.title ?? ""}
+          </h1>
+          {hasDownloads ? (
+            <div className="shrink-0">
+              <DownloadButton onClick={onDownloadClick} />
+            </div>
+          ) : null}
+        </div>
         {video.description ? (
           <p
             data-testid="watch-body-description"

--- a/apps/web/src/components/watch/WatchBody.tsx
+++ b/apps/web/src/components/watch/WatchBody.tsx
@@ -20,27 +20,27 @@ export function WatchBody({
   const prompts = (studyQuestions?.studyQuestions ?? [])
     .map((q) => q.value)
     .filter((v): v is string => v != null && v.length > 0)
-  const hasRightColumn = prompts.length > 0
 
+  // The right column (Related Questions + Ask Yours CTA) always renders.
+  // When there are no editorial prompts, WatchStudyQuestions falls back to
+  // a single placeholder row -- the Ask Yours flow is always relevant, so
+  // hiding the section was leaving the CTA stranded on prompt-less videos.
   return (
     <section
       data-block-type="WatchBody"
       data-testid="watch-body"
-      data-has-right-column={hasRightColumn ? "true" : "false"}
       className="grid w-full grid-cols-12 gap-10 py-8 text-stone-100 md:grid-cols-12 md:gap-6"
     >
       <div
         data-testid="watch-body-left"
-        className={
-          hasRightColumn
-            ? "col-span-12 flex min-w-0 flex-col gap-4 md:col-span-8"
-            : "col-span-12 flex min-w-0 flex-col gap-4 md:col-span-12"
-        }
+        className="col-span-12 flex min-w-0 flex-col gap-4 md:col-span-8"
       >
         {hasDownloads ? (
           // pt-6 xl:pt-4 matches WatchStudyQuestions' top padding so the
           // Download pill and the Related Questions / Ask Yours row align
           // on the same horizontal axis at the top of both columns.
+          // pr-12 xl:pr-16 fixes Download's right edge inside the left
+          // column.
           <div className="flex justify-end pt-6 md:pr-12 xl:pt-4 xl:pr-16">
             <DownloadButton onClick={onDownloadClick} />
           </div>
@@ -69,17 +69,15 @@ export function WatchBody({
         ) : null}
       </div>
 
-      {hasRightColumn ? (
-        <div
-          data-testid="watch-body-right"
-          className="col-span-12 flex min-w-0 flex-col gap-4 md:col-span-4"
-        >
-          <WatchStudyQuestions
-            prompts={prompts}
-            onAskYoursClick={onAskYoursClick}
-          />
-        </div>
-      ) : null}
+      <div
+        data-testid="watch-body-right"
+        className="col-span-12 flex min-w-0 flex-col gap-4 md:col-span-4"
+      >
+        <WatchStudyQuestions
+          prompts={prompts}
+          onAskYoursClick={onAskYoursClick}
+        />
+      </div>
     </section>
   )
 }

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -10,6 +10,7 @@ import { LanguagePickerModal } from "@/components/watch/LanguagePickerModal"
 import { ShareModal } from "@/components/watch/ShareModal"
 import { WatchSectionRenderer } from "@/components/watch/WatchSectionRenderer"
 import type { MergedWatchBlock, ResolvedWatchVideo } from "@/lib/content"
+import { resolvePosterUrl } from "@/lib/url"
 
 type WatchVideoRecord = ResolvedWatchVideo["video"]
 type WatchVariant = ResolvedWatchVideo["selectedVariant"]
@@ -91,14 +92,12 @@ export function WatchPageClient({
   // Prefer the editorial cinematic still over `images[].url` — that raw
   // `url` is a misshaped Cloudflare Images URL (missing variant path
   // segment) and 400s. Mux's thumbnail API is the last-resort fallback;
-  // it's a frame from the video, not the curated poster.
-  const posterUrl =
-    video.images?.[0]?.mobileCinematicHigh ??
-    video.images?.[0]?.mobileCinematicLow ??
-    video.images?.[0]?.thumbnail ??
-    (variant.muxVideo?.playbackId
-      ? `https://image.mux.com/${variant.muxVideo.playbackId}/thumbnail.jpg?width=448&height=252&fit_mode=smartcrop`
-      : (video.images?.[0]?.url ?? null))
+  // it's a frame from the video, not the curated poster. See
+  // `resolvePosterUrl` for the full priority chain.
+  const posterUrl = resolvePosterUrl(
+    video.images?.[0],
+    variant.muxVideo?.playbackId,
+  )
 
   const [modalState, setModalState] = useState<WatchModalState>("none")
 

--- a/apps/web/src/components/watch/WatchSectionRenderer.tsx
+++ b/apps/web/src/components/watch/WatchSectionRenderer.tsx
@@ -11,17 +11,21 @@ import {
 import { ExperienceSectionRenderer } from "@/components/sections"
 import { BibleQuotesSection } from "@/components/watch/BibleQuotesSection"
 import { HeroPlayer } from "@/components/watch/HeroPlayer"
-// `SiblingCarousel` import skipped — dispatch case below returns null until
-// thumbnail-image plumbing is restored.
+import { SiblingCarousel } from "@/components/watch/SiblingCarousel"
 import { WatchBody } from "@/components/watch/WatchBody"
 import type { WatchModalCallbacks } from "@/components/watch/WatchPageClient"
 import { CONTENT_WIDTH_CLASSES } from "@/lib/content-width"
 
 // Typo guard: literal-union typing fails the type check on misspellings.
-const TOP_ZONE_KINDS: Set<WatchBlock["kind"]> = new Set([
-  "HeroPlayer",
-  "SiblingCarousel",
-])
+//
+// `HeroPlayer` is the only top-zone block — it's the sticky cinematic player
+// that pins to the viewport while body content slides over it. The
+// `SiblingCarousel` was originally part of this zone too, but rendering it
+// alongside the sticky hero meant the carousel would scroll over and visually
+// "cover" the hero during scroll. Demoting the carousel into the body zone
+// keeps it directly below the hero in normal flow, with the rest of the body
+// content (WatchBody, StudyQuestions, BibleQuotes, Share) following it.
+const TOP_ZONE_KINDS: Set<WatchBlock["kind"]> = new Set(["HeroPlayer"])
 
 export function WatchSectionRenderer({
   blocks,
@@ -79,7 +83,7 @@ export function WatchSectionRenderer({
               aria-hidden="true"
             />
             <div
-              className={`relative z-2 flex flex-col items-stretch justify-center gap-10 pt-4 pb-16 ${CONTENT_WIDTH_CLASSES}`}
+              className={`relative z-2 flex flex-col items-stretch justify-center gap-6 pt-2 pb-16 ${CONTENT_WIDTH_CLASSES}`}
             >
               {bodyBlocks.map((block, index) => (
                 <WatchBlockEntry
@@ -140,8 +144,8 @@ function SyntheticBlock({
     case "HeroPlayer":
       return <HeroPlayer block={block} onPlayerReady={onPlayerReady} />
     case "SiblingCarousel":
-      // Hidden until thumbnail-image plumbing is restored. Single-line revert.
-      return null
+      return <SiblingCarousel block={block} />
+
     case "WatchBody":
       return (
         <WatchBody

--- a/apps/web/src/components/watch/WatchStudyQuestions.tsx
+++ b/apps/web/src/components/watch/WatchStudyQuestions.tsx
@@ -8,7 +8,13 @@ import { Button } from "@/components/ui/button"
 
 // Prompts are intentionally non-interactive: Video.studyQuestions has no
 // `answer` field, so any chevron/expand affordance would be a false promise.
-// Tests in WatchBody.test.tsx pin this contract.
+// The placeholder row shown when there are no editorial prompts is also
+// non-interactive -- it's an invite-to-engage copy string, not a question
+// with a hidden answer. Tests in WatchBody.test.tsx pin this contract for
+// both branches.
+const PLACEHOLDER_QUESTION =
+  "If you could ask the creator of this video a question, what would it be?"
+
 export function WatchStudyQuestions({
   prompts,
   onAskYoursClick,
@@ -16,6 +22,7 @@ export function WatchStudyQuestions({
   prompts: string[]
   onAskYoursClick: () => void
 }) {
+  const hasPrompts = prompts.length > 0
   return (
     <section
       data-testid="watch-study-questions"
@@ -44,18 +51,30 @@ export function WatchStudyQuestions({
         data-testid="watch-study-questions-list"
         className="relative flex flex-col"
       >
-        {prompts.map((prompt, index) => (
+        {hasPrompts ? (
+          prompts.map((prompt, index) => (
+            <li
+              key={`${index}-${prompt}`}
+              data-testid="watch-study-questions-item"
+              className="border-b border-stone-500/20 py-3"
+            >
+              <p className="flex text-base leading-[1.6] font-semibold text-stone-100 sm:pr-4 md:text-lg md:text-balance">
+                <QuestionIcon />
+                {prompt}
+              </p>
+            </li>
+          ))
+        ) : (
           <li
-            key={`${index}-${prompt}`}
-            data-testid="watch-study-questions-item"
+            data-testid="watch-study-questions-placeholder"
             className="border-b border-stone-500/20 py-3"
           >
             <p className="flex text-base leading-[1.6] font-semibold text-stone-100 sm:pr-4 md:text-lg md:text-balance">
               <QuestionIcon />
-              {prompt}
+              {PLACEHOLDER_QUESTION}
             </p>
           </li>
-        ))}
+        )}
       </ul>
     </section>
   )

--- a/apps/web/src/components/watch/WatchStudyQuestions.tsx
+++ b/apps/web/src/components/watch/WatchStudyQuestions.tsx
@@ -27,8 +27,14 @@ export function WatchStudyQuestions({
     <section
       data-testid="watch-study-questions"
       aria-labelledby="watch-related-questions-heading"
-      className="w-full pt-6 xl:pt-4"
+      className="w-full pt-0 md:pt-9 xl:pt-11"
     >
+      {/* Section pt is tuned so the header (Related Questions + Ask Yours)
+          lands on the same Y axis as the h1 title in the left column --
+          which now hosts the Download pill in its flex row. The mb below
+          the header is sized so the first prompt / placeholder row lines
+          up with the start of the video description, keeping the two
+          columns visually parallel. */}
       <div className="mb-4 flex flex-wrap items-center justify-between">
         <h4
           id="watch-related-questions-heading"

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -851,3 +851,261 @@ describe("HeroPlayer — sticky-hero / portal layout", () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// Timeline pointer-driven scrub. JSDOM's getBoundingClientRect returns zeros,
+// so we stub it on the timeline element. The vitest setup polyfills rAF as
+// `setTimeout(fn, 0)`, so `vi.useFakeTimers()` lets us deterministically flush
+// the coalesced seek by advancing 0ms.
+// ---------------------------------------------------------------------------
+
+function stubTimelineRect(): HTMLDivElement {
+  const tl = container.querySelector(
+    '[data-testid="hero-chrome-timeline"]',
+  ) as HTMLDivElement
+  Object.defineProperty(tl, "getBoundingClientRect", {
+    value: () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 1,
+        width: 100,
+        height: 1,
+        toJSON() {
+          return this
+        },
+      }) as DOMRect,
+    configurable: true,
+  })
+  // JSDOM lacks setPointerCapture / hasPointerCapture. Stub them to no-ops
+  // so the production code's defensive guards don't throw under test. Cast
+  // through unknown so we can attach element-level methods that JSDOM
+  // hasn't implemented; production browsers ship them on every Element.
+  const noop = (): void => undefined
+  ;(tl as unknown as { setPointerCapture: () => void }).setPointerCapture = noop
+  ;(
+    tl as unknown as { releasePointerCapture: () => void }
+  ).releasePointerCapture = noop
+  ;(tl as unknown as { hasPointerCapture: () => boolean }).hasPointerCapture =
+    () => false
+  return tl
+}
+
+function makePointerEvent(
+  type: string,
+  init: { clientX?: number; pointerId?: number } = {},
+): PointerEvent {
+  // JSDOM lacks PointerEvent; fall back to MouseEvent + manual fields.
+  const Ctor =
+    typeof PointerEvent === "function" ? PointerEvent : (MouseEvent as never)
+  const evt = new Ctor(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+  }) as PointerEvent
+  Object.defineProperty(evt, "pointerId", {
+    value: init.pointerId ?? 1,
+    configurable: true,
+  })
+  return evt
+}
+
+describe("HeroPlayer — timeline pointer-driven scrub", () => {
+  it("data-dragging flips to 'true' on pointerdown and 'false' on pointerup", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.duration = 60
+      mockPlayerRef.current.paused = false
+    }
+    const tl = stubTimelineRect()
+    expect(tl.getAttribute("data-dragging")).toBe("false")
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerdown", { clientX: 50 }))
+    })
+    expect(tl.getAttribute("data-dragging")).toBe("true")
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerup", { clientX: 50 }))
+    })
+    expect(tl.getAttribute("data-dragging")).toBe("false")
+  })
+
+  it("data-current-time reflects scrubPct * duration during drag (not player.currentTime)", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.duration = 60
+      mockPlayerRef.current.currentTime = 10
+      mockPlayerRef.current.paused = false
+    }
+    const tl = stubTimelineRect()
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerdown", { clientX: 25 })) // 25/100 * 60 = 15
+    })
+    const time = container.querySelector(
+      '[data-testid="hero-chrome-time"]',
+    ) as HTMLElement
+    // displayTime should follow the scrub thumb (15s), not currentTime (10s).
+    expect(time.getAttribute("data-current-time")).toBe("15")
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointermove", { clientX: 75 })) // 75/100 * 60 = 45
+    })
+    expect(time.getAttribute("data-current-time")).toBe("45")
+  })
+
+  it("pointerdown pauses a playing player; pointerup resumes if was playing", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.duration = 60
+      mockPlayerRef.current.paused = false
+      mockPlayerRef.current.pause.mockClear()
+      mockPlayerRef.current.play.mockClear()
+    }
+    const tl = stubTimelineRect()
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerdown", { clientX: 50 }))
+    })
+    expect(mockPlayerRef.current?.pause).toHaveBeenCalledTimes(1)
+    // Simulate the pause taking effect so the resume gate (p.paused) is true.
+    if (mockPlayerRef.current) mockPlayerRef.current.paused = true
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerup", { clientX: 60 }))
+    })
+    expect(mockPlayerRef.current?.play).toHaveBeenCalledTimes(1)
+  })
+
+  it("lostPointerCapture clears drag state and resumes if was playing", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.duration = 60
+      mockPlayerRef.current.paused = false
+      mockPlayerRef.current.play.mockClear()
+    }
+    const tl = stubTimelineRect()
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerdown", { clientX: 50 }))
+    })
+    expect(tl.getAttribute("data-dragging")).toBe("true")
+    if (mockPlayerRef.current) mockPlayerRef.current.paused = true
+    await act(async () => {
+      tl.dispatchEvent(
+        new Event("lostpointercapture", { bubbles: true }) as never,
+      )
+    })
+    expect(tl.getAttribute("data-dragging")).toBe("false")
+    expect(mockPlayerRef.current?.play).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("HeroPlayer — timeline pointer-driven scrub (fake-timer driven)", () => {
+  // Fake timers let us hold the rAF (polyfilled as setTimeout(0)) before it
+  // flushes, so we can prove the coalescing window and the unmount
+  // cancellation path. Microtasks (the play() promise inside revealChrome)
+  // still resolve under fake timers, so reveal works without real time.
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("multiple pointermoves coalesce into a single rAF flush per batch", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      // Mock's addEventListener is vi.fn() so durationchange never fires —
+      // React state is whatever the initial sync() captured (default 60).
+      // The rAF callback reads p.duration directly (F6), so 100 is what the
+      // coalesced seek will use; the synchronous pointerdown seek uses the
+      // closed-over state duration of 60.
+      mockPlayerRef.current.duration = 100
+      mockPlayerRef.current.currentTime = 0
+      mockPlayerRef.current.paused = false
+    }
+    const tl = stubTimelineRect()
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerdown", { clientX: 10 }))
+    })
+    // Pointerdown's synchronous seek uses state-duration (60): 0.1 * 60 = 6.
+    expect(mockPlayerRef.current?.currentTime).toBe(6)
+
+    // Track every currentTime write to prove only one happens per batch.
+    let writes = 0
+    let lastWrite = mockPlayerRef.current?.currentTime ?? 0
+    if (mockPlayerRef.current) {
+      const player = mockPlayerRef.current
+      let ct = player.currentTime
+      Object.defineProperty(player, "currentTime", {
+        get: () => ct,
+        set: (v: number) => {
+          ct = v
+          writes++
+          lastWrite = v
+        },
+        configurable: true,
+      })
+    }
+
+    // Three pointermoves before the rAF flushes — only the last should land.
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointermove", { clientX: 30 }))
+      tl.dispatchEvent(makePointerEvent("pointermove", { clientX: 50 }))
+      tl.dispatchEvent(makePointerEvent("pointermove", { clientX: 70 }))
+    })
+    // Before timers fire, no seek write has landed since the trap was
+    // installed.
+    expect(writes).toBe(0)
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+    // Exactly one rAF wrote the latest pct (0.7 * live p.duration = 70).
+    expect(writes).toBe(1)
+    expect(lastWrite).toBe(70)
+  })
+
+  it("unmounting mid-drag does not write currentTime after unmount", async () => {
+    await revealChrome()
+    if (mockPlayerRef.current) {
+      mockPlayerRef.current.duration = 100
+      mockPlayerRef.current.currentTime = 0
+      mockPlayerRef.current.paused = false
+    }
+    const tl = stubTimelineRect()
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointerdown", { clientX: 10 }))
+    })
+
+    // Trap any subsequent currentTime writes.
+    let writes = 0
+    if (mockPlayerRef.current) {
+      const player = mockPlayerRef.current
+      let ct = player.currentTime
+      Object.defineProperty(player, "currentTime", {
+        get: () => ct,
+        set: (v: number) => {
+          ct = v
+          writes++
+        },
+        configurable: true,
+      })
+    }
+
+    // Queue a coalesced seek for the pending rAF.
+    await act(async () => {
+      tl.dispatchEvent(makePointerEvent("pointermove", { clientX: 90 }))
+    })
+    // Pre-flush: the rAF hasn't fired, so no seek write yet.
+    expect(writes).toBe(0)
+
+    act(() => {
+      root.unmount()
+    })
+    // Re-create root so afterEach's unmount() targets a fresh tree.
+    root = createRoot(container)
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+    expect(writes).toBe(0)
+  })
+})

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -126,13 +126,34 @@ afterEach(() => {
   container.remove()
 })
 
-function makeChild(i: number, opts: { thumb?: boolean } = {}) {
+type ImageVariantFields = {
+  url?: string | null
+  thumbnail?: string | null
+  mobileCinematicHigh?: string | null
+  mobileCinematicLow?: string | null
+}
+
+function makeChild(
+  i: number,
+  opts: { thumb?: boolean; image?: ImageVariantFields } = {},
+) {
+  // When `opts.image` is supplied, use it verbatim — lets tests assert on
+  // the priority chain (`mobileCinematicHigh` > `mobileCinematicLow` >
+  // `thumbnail` > nothing; `url` is intentionally NOT in the chain).
+  // Default fixture uses `thumbnail` (NOT `url`) because resolvePosterUrl
+  // dropped `url` entirely — see F2 in the watch-page review queue.
+  const images =
+    opts.thumb === false
+      ? []
+      : opts.image
+        ? [opts.image]
+        : [{ thumbnail: `https://cdn.test/${i}.jpg` }]
   return {
     documentId: `child-${i}`,
     slug: `child-${i}-slug`,
     title: `Child ${i}`,
     label: i % 2 === 0 ? `Label ${i}` : null,
-    images: opts.thumb === false ? [] : [{ url: `https://cdn.test/${i}.jpg` }],
+    images,
   }
 }
 
@@ -174,9 +195,9 @@ describe("SiblingCarousel — happy path", () => {
       "[data-testid='sibling-carousel-item'][data-active='true']",
     )
     expect(active).not.toBeNull()
-    expect(active!.getAttribute("data-href")).toBe(
-      "/jesus-collection/child-3-slug/english",
-    )
+    // 2-segment route shape: `/{slug}/{locale}` — the parent slug segment
+    // was removed when the watch route migrated to flat `[slug]/[locale]`.
+    expect(active!.getAttribute("data-href")).toBe("/child-3-slug/english")
 
     const playingNow = container.querySelector(
       "[data-testid='sibling-carousel-playing-now']",
@@ -203,7 +224,8 @@ describe("SiblingCarousel — happy path", () => {
       const href = item.getAttribute("data-href") ?? ""
       // basePath auto-prepends; in-app hrefs MUST NOT include /watch/ literal.
       expect(href.startsWith("/watch/")).toBe(false)
-      expect(href.startsWith("/jesus-collection/")).toBe(true)
+      // 2-segment route — child slug then locale, no parent segment.
+      expect(href).toMatch(/^\/child-\d+-slug\/english$/)
       expect(href.endsWith("/english")).toBe(true)
     }
   })
@@ -281,9 +303,7 @@ describe("SiblingCarousel — edge cases", () => {
       "[data-testid='sibling-carousel-item'][data-active='true']",
     )
     expect(active).not.toBeNull()
-    expect(active!.getAttribute("data-href")).toBe(
-      "/jesus-collection/child-12-slug/english",
-    )
+    expect(active!.getAttribute("data-href")).toBe("/child-12-slug/english")
     const label = container.querySelector(
       "[data-testid='sibling-carousel-label']",
     )
@@ -303,8 +323,110 @@ describe("SiblingCarousel — edge cases", () => {
     )
     // Trailing slash with empty locale segment — caller is responsible for
     // ensuring `[locale]` is present in the route; we don't fabricate one.
-    expect(item!.getAttribute("data-href")).toBe(
-      "/jesus-collection/child-2-slug/",
+    expect(item!.getAttribute("data-href")).toBe("/child-2-slug/")
+  })
+})
+
+describe("SiblingCarousel — image priority (resolvePosterUrl)", () => {
+  // Each test renders a single-active-item block and reads the active item's
+  // <Image> stand-in (`data-src`) to assert which image variant won the
+  // priority chain. The variant order is:
+  //   mobileCinematicHigh > mobileCinematicLow > thumbnail > placeholder
+  //   (`url` is intentionally NOT in the chain — it 400s on Cloudflare.)
+  function singleChildBlock(
+    image: ImageVariantFields,
+  ): WatchSiblingCarouselBlock {
+    return {
+      kind: "SiblingCarousel",
+      canonicalParent: {
+        documentId: "parent-1",
+        slug: "p",
+        title: "P",
+        children: [
+          makeChild(1, { image }),
+          makeChild(2), // sibling so children.length >= 2 (carousel renders)
+        ],
+      } as never,
+      currentVideoDocumentId: "child-1",
+    }
+  }
+
+  function activeImage(): HTMLElement | null {
+    return container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-active='true'] [data-testid='next-image-mock']",
     )
+  }
+
+  function activePlaceholder(): HTMLElement | null {
+    return container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-active='true'] [data-testid='sibling-carousel-thumb-placeholder']",
+    )
+  }
+
+  it("uses mobileCinematicHigh when all four variants are present", () => {
+    act(() => {
+      root.render(
+        <SiblingCarousel
+          block={singleChildBlock({
+            mobileCinematicHigh: "https://cdn.test/high.jpg",
+            mobileCinematicLow: "https://cdn.test/low.jpg",
+            thumbnail: "https://cdn.test/thumb.jpg",
+            url: "https://cdn.test/url.jpg",
+          })}
+        />,
+      )
+    })
+    const img = activeImage()
+    expect(img).not.toBeNull()
+    expect(img!.getAttribute("data-src")).toBe("https://cdn.test/high.jpg")
+  })
+
+  it("falls through to mobileCinematicLow when mobileCinematicHigh is absent", () => {
+    act(() => {
+      root.render(
+        <SiblingCarousel
+          block={singleChildBlock({
+            mobileCinematicLow: "https://cdn.test/low.jpg",
+            thumbnail: "https://cdn.test/thumb.jpg",
+            url: "https://cdn.test/url.jpg",
+          })}
+        />,
+      )
+    })
+    expect(activeImage()!.getAttribute("data-src")).toBe(
+      "https://cdn.test/low.jpg",
+    )
+  })
+
+  it("falls through to thumbnail when both mobileCinematic* variants are absent", () => {
+    act(() => {
+      root.render(
+        <SiblingCarousel
+          block={singleChildBlock({
+            thumbnail: "https://cdn.test/thumb.jpg",
+            url: "https://cdn.test/url.jpg",
+          })}
+        />,
+      )
+    })
+    expect(activeImage()!.getAttribute("data-src")).toBe(
+      "https://cdn.test/thumb.jpg",
+    )
+  })
+
+  it("renders the placeholder when only `url` is present (url is dropped from the chain)", () => {
+    act(() => {
+      root.render(
+        <SiblingCarousel
+          block={singleChildBlock({
+            url: "https://cdn.test/url.jpg",
+          })}
+        />,
+      )
+    })
+    // No image — `url` is intentionally NOT a fallback (returns 400 on
+    // Cloudflare due to a misshaped variant path). Placeholder wins.
+    expect(activeImage()).toBeNull()
+    expect(activePlaceholder()).not.toBeNull()
   })
 })

--- a/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
@@ -143,6 +143,36 @@ describe("WatchBody — two-column layout", () => {
     // Download button visible.
     const dl = container.querySelector('[data-testid="watch-download-button"]')
     expect(dl).not.toBeNull()
+
+    // Title and Download share the same flex row (alignment contract for the
+    // top-of-watch-page UI -- Download must sit on the same Y axis as the
+    // h1 title; a future move out of this row would break that intent).
+    const titleRow = container.querySelector(
+      '[data-testid="watch-body-title-row"]',
+    )
+    expect(titleRow).not.toBeNull()
+    expect(titleRow!.className).toContain("flex")
+    expect(titleRow!.className).toContain("items-center")
+    expect(titleRow!.className).toContain("justify-between")
+    const titleEl = container.querySelector('[data-testid="watch-body-title"]')
+    expect(titleEl!.parentElement).toBe(titleRow)
+    expect(dl!.closest('[data-testid="watch-body-title-row"]')).toBe(titleRow)
+
+    // Right-column header pt and mb are alignment-critical -- pinning them
+    // so a revert / merge resolution cannot silently clobber the values.
+    // pt-0 mobile (columns stack, no extra gap) -> md:pt-9 (text-4xl h1)
+    // -> xl:pt-11 (text-5xl h1) tracks the h1 size scale across breakpoints.
+    const studySection = container.querySelector(
+      '[data-testid="watch-study-questions"]',
+    )
+    expect(studySection).not.toBeNull()
+    expect(studySection!.className).toContain("pt-0")
+    expect(studySection!.className).toContain("md:pt-9")
+    expect(studySection!.className).toContain("xl:pt-11")
+    const headerRow = studySection!.querySelector(
+      "div.mb-4.flex.flex-wrap.items-center.justify-between",
+    )
+    expect(headerRow).not.toBeNull()
   })
 
   it("renders the optional uppercase label tag when present", () => {

--- a/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
@@ -5,12 +5,13 @@
  *
  * Covers:
  *  - Two-column layout when both columns have content.
- *  - Right column collapse + `md:col-span-2` when no study questions.
+ *  - Right column always renders -- placeholder row + Ask Yours CTA appear
+ *    even when studyQuestions is null or empty (the CTA is always relevant).
  *  - Download button hidden when `variant.downloads` empty.
- *  - Both columns empty → only left column rendered, no Download button.
  *  - Mobile DOM order — left column first in source.
  *  - Click integration for both modal triggers.
- *  - UX regression: WatchStudyQuestions has NO chevron / accordion semantics.
+ *  - UX regression: WatchStudyQuestions has NO chevron / accordion semantics
+ *    on either prompt rows or the placeholder row.
  */
 
 import { act } from "react"
@@ -117,7 +118,6 @@ describe("WatchBody — two-column layout", () => {
 
     const wrapper = container.querySelector('[data-testid="watch-body"]')
     expect(wrapper).not.toBeNull()
-    expect(wrapper!.getAttribute("data-has-right-column")).toBe("true")
     // Two-column grid classes present (12-col grid mirroring Container.tsx).
     expect(wrapper!.className).toContain("md:grid-cols-12")
     const left = container.querySelector('[data-testid="watch-body-left"]')
@@ -184,8 +184,8 @@ describe("WatchBody — two-column layout", () => {
   })
 })
 
-describe("WatchBody — collapse to single column when right column is empty", () => {
-  it("hides right column and applies md:col-span-2 to left when studyQuestions block is null", () => {
+describe("WatchBody — right column always renders (Ask Yours CTA is always relevant)", () => {
+  it("renders right column with placeholder row when studyQuestions block is null", () => {
     const block = makeBlock({ downloadCount: 2 })
 
     act(() => {
@@ -199,14 +199,26 @@ describe("WatchBody — collapse to single column when right column is empty", (
       )
     })
 
-    const wrapper = container.querySelector('[data-testid="watch-body"]')
-    expect(wrapper!.getAttribute("data-has-right-column")).toBe("false")
-
     const left = container.querySelector('[data-testid="watch-body-left"]')
-    expect(left!.className).toContain("md:col-span-12")
+    expect(left!.className).toContain("md:col-span-8")
 
     const right = container.querySelector('[data-testid="watch-body-right"]')
-    expect(right).toBeNull()
+    expect(right).not.toBeNull()
+
+    // Placeholder row + Ask Yours CTA both present.
+    const placeholder = container.querySelector(
+      '[data-testid="watch-study-questions-placeholder"]',
+    )
+    expect(placeholder).not.toBeNull()
+    // Pin the user-visible copy so silent edits to the constant get caught.
+    expect(placeholder!.textContent).toContain(
+      "If you could ask the creator of this video a question, what would it be?",
+    )
+    expect(
+      container.querySelector(
+        '[data-testid="watch-study-questions-ask-yours"]',
+      ),
+    ).not.toBeNull()
 
     // Download button still visible.
     expect(
@@ -214,7 +226,7 @@ describe("WatchBody — collapse to single column when right column is empty", (
     ).not.toBeNull()
   })
 
-  it("treats an empty studyQuestions array as empty right column too", () => {
+  it("renders right column with placeholder when studyQuestions array is empty", () => {
     const block = makeBlock({ downloadCount: 1 })
     const emptySq: WatchStudyQuestionsBlock = {
       kind: "StudyQuestions",
@@ -232,10 +244,20 @@ describe("WatchBody — collapse to single column when right column is empty", (
       )
     })
 
-    const wrapper = container.querySelector('[data-testid="watch-body"]')
-    expect(wrapper!.getAttribute("data-has-right-column")).toBe("false")
     const left = container.querySelector('[data-testid="watch-body-left"]')
-    expect(left!.className).toContain("md:col-span-12")
+    expect(left!.className).toContain("md:col-span-8")
+    expect(
+      container.querySelector(
+        '[data-testid="watch-study-questions-placeholder"]',
+      ),
+    ).not.toBeNull()
+    // Ask Yours CTA must also render in the empty-array path; the null path
+    // already pins this and the two cases should stay symmetric.
+    expect(
+      container.querySelector(
+        '[data-testid="watch-study-questions-ask-yours"]',
+      ),
+    ).not.toBeNull()
   })
 })
 
@@ -260,14 +282,12 @@ describe("WatchBody — Download button visibility", () => {
     ).toBeNull()
 
     // Two-column layout still preserved.
-    const wrapper = container.querySelector('[data-testid="watch-body"]')
-    expect(wrapper!.getAttribute("data-has-right-column")).toBe("true")
     expect(
       container.querySelector('[data-testid="watch-body-right"]'),
     ).not.toBeNull()
   })
 
-  it("renders only left column with no Download button when both are empty", () => {
+  it("renders right column placeholder with no Download button when both are empty", () => {
     const block = makeBlock({ downloadCount: 0 })
 
     act(() => {
@@ -281,16 +301,24 @@ describe("WatchBody — Download button visibility", () => {
       )
     })
 
+    // Right column with placeholder still renders -- the Ask Yours CTA is
+    // always relevant, even when there are no editorial prompts and no
+    // downloadable variants.
     expect(
       container.querySelector('[data-testid="watch-body-right"]'),
-    ).toBeNull()
+    ).not.toBeNull()
+    expect(
+      container.querySelector(
+        '[data-testid="watch-study-questions-placeholder"]',
+      ),
+    ).not.toBeNull()
     expect(
       container.querySelector('[data-testid="watch-download-button"]'),
     ).toBeNull()
 
     const left = container.querySelector('[data-testid="watch-body-left"]')
     expect(left).not.toBeNull()
-    expect(left!.className).toContain("md:col-span-12")
+    expect(left!.className).toContain("md:col-span-8")
   })
 })
 
@@ -465,6 +493,56 @@ describe("WatchStudyQuestions — UX regression: no false-affordance chevrons", 
       )
     })
 
+    const section = container.querySelector(
+      '[data-testid="watch-study-questions"]',
+    )
+    expect(section).not.toBeNull()
+    const buttons = section!.querySelectorAll("button")
+    expect(buttons.length).toBe(1)
+    expect(buttons[0]?.getAttribute("data-testid")).toBe(
+      "watch-study-questions-ask-yours",
+    )
+  })
+
+  it("placeholder row (empty prompts) is non-interactive: no nested button/anchor, decorative SVG only, and Ask Yours stays the only button", () => {
+    act(() => {
+      root.render(
+        <WatchStudyQuestions prompts={[]} onAskYoursClick={vi.fn()} />,
+      )
+    })
+
+    // Accordion semantics still banned across the placeholder branch.
+    expect(container.querySelectorAll("details").length).toBe(0)
+    expect(container.querySelectorAll("summary").length).toBe(0)
+
+    const placeholder = container.querySelector(
+      '[data-testid="watch-study-questions-placeholder"]',
+    )
+    expect(placeholder).not.toBeNull()
+    expect(placeholder!.tagName.toLowerCase()).toBe("li")
+    expect(placeholder!.hasAttribute("aria-haspopup")).toBe(false)
+    expect(placeholder!.hasAttribute("aria-expanded")).toBe(false)
+    expect(placeholder!.hasAttribute("role")).toBe(false)
+    expect(placeholder!.querySelector("button")).toBeNull()
+    expect(placeholder!.querySelector("a")).toBeNull()
+    // Any SVG inside the placeholder row must be decorative and free of
+    // rotate/transition classes that would suggest an expandable affordance.
+    const svgs = placeholder!.querySelectorAll("svg")
+    expect(svgs.length).toBeGreaterThan(0)
+    for (const svg of svgs) {
+      expect(svg.getAttribute("aria-hidden")).toBe("true")
+      const cls = svg.getAttribute("class") ?? ""
+      expect(cls).not.toMatch(/\brotate-/)
+      expect(cls).not.toMatch(/\btransition\b/)
+    }
+
+    // Real prompt rows must be absent in the placeholder branch.
+    expect(
+      container.querySelectorAll('[data-testid="watch-study-questions-item"]')
+        .length,
+    ).toBe(0)
+
+    // Singleton-button contract holds across the empty-prompts path too.
     const section = container.querySelector(
       '[data-testid="watch-study-questions"]',
     )

--- a/apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx
@@ -210,6 +210,10 @@ function makeVideo(overrides: Record<string, unknown> = {}) {
     images: [],
     primaryLanguage: { coreId: "529", bcp47: "en" },
     parents: [],
+    // Top-level `children` powers the SiblingCarousel for parent/collection
+    // videos (e.g. JESUS). Default empty so the builder falls back to the
+    // canonicalParent.children path — mirrors content-watch-merge.test.ts.
+    children: [],
     variants: [],
     studyQuestions: [],
     bibleCitations: [],
@@ -284,30 +288,38 @@ describe("WatchSectionRenderer — synthetic block dispatch", () => {
     const rendered = Array.from(
       container.querySelectorAll("[data-block-type]"),
     ).map((el) => el.getAttribute("data-block-type"))
-    // SiblingCarousel is intentionally skipped at the renderer level (its
-    // dispatch case returns null) until the thumbnail-image plumbing is
-    // restored. The block is still emitted by `mergeWatchExperience`, but
-    // does not produce DOM today — so the rendered list omits it.
+    // SiblingCarousel is dispatched again (the prior `return null` was
+    // reverted once the chapter-children data path was wired up). The block
+    // is still emitted by `mergeWatchExperience` and now produces DOM.
     expect(rendered).toEqual([
       "HeroPlayer",
+      "SiblingCarousel",
       "WatchBody",
       "StudyQuestions",
       "BibleQuotes",
       "Share",
     ])
-    // Explicit negative guard: when the dispatch case is reverted, this
-    // assertion will start failing alongside the positive list above —
-    // making the "single-line revert" promise traceable in CI.
-    expect(rendered).not.toContain("SiblingCarousel")
-    // The block IS still emitted by `mergeWatchExperience` even though the
-    // renderer skips dispatch — protect that contract so a future change to
-    // the merge layer doesn't silently drop it.
+    // The block IS still emitted by `mergeWatchExperience` — protect that
+    // contract so a future change to the merge layer doesn't silently drop it.
     expect(
       blocks.some((b) => "kind" in b && b.kind === "SiblingCarousel"),
     ).toBe(true)
 
     // Synthetic types must NOT delegate to ExperienceSectionRenderer.
     expect(experienceSectionRendererMock).not.toHaveBeenCalled()
+
+    // SiblingCarousel must live INSIDE the watch-body-zone (the
+    // frosted-glass body wrapper), not as a top-level sibling alongside
+    // the sticky HeroPlayer. The carousel was originally rendered in the
+    // top zone; demoting it into the body zone keeps it in normal flow
+    // beneath the hero instead of scrolling over it. Guard that move
+    // here so a future refactor doesn't silently regress.
+    const bodyZone = container.querySelector("[data-testid='watch-body-zone']")
+    expect(bodyZone).not.toBeNull()
+    const siblingInsideBody = bodyZone!.querySelector(
+      "[data-block-type='SiblingCarousel']",
+    )
+    expect(siblingInsideBody).not.toBeNull()
   })
 
   it("HeroPlayer placeholder serializes playbackId and hls into data-content", () => {

--- a/apps/web/src/lib/__tests__/content-watch-merge.test.ts
+++ b/apps/web/src/lib/__tests__/content-watch-merge.test.ts
@@ -70,6 +70,11 @@ function makeVideo(overrides: Record<string, unknown> = {}) {
     images: [],
     primaryLanguage: { coreId: "529", bcp47: "en" },
     parents: [],
+    // Top-level `children` powers the SiblingCarousel for parent/collection
+    // videos (e.g. JESUS with 61 chapter segments). Default empty so the
+    // builder falls back to canonicalParent.children — matching the existing
+    // tests' assumption that the carousel is fed from sibling content.
+    children: [],
     variants: [],
     studyQuestions: [],
     bibleCitations: [],
@@ -420,6 +425,68 @@ describe("mergeWatchExperience — HeroPlayer slot type-restriction", () => {
       }
     },
   )
+})
+
+describe("buildSiblingCarouselBlock — virtualParent branch (parent/collection videos)", () => {
+  it("synthesizes a virtual parent from video.children when video has >= 2 own children", () => {
+    const ownChildren = [
+      makeChild("chapter-1", "chapter-1", "Chapter 1"),
+      makeChild("chapter-2", "chapter-2", "Chapter 2"),
+      makeChild("chapter-3", "chapter-3", "Chapter 3"),
+    ]
+    const video = makeVideo({
+      documentId: "jesus-parent",
+      slug: "jesus",
+      title: "JESUS",
+      children: ownChildren,
+    })
+
+    const block = buildSiblingCarouselBlock(null, video as never)
+
+    expect(block).not.toBeNull()
+    // (a) canonicalParent identity comes from the current video.
+    expect(block!.canonicalParent.documentId).toBe(video.documentId)
+    // (b) canonicalParent.children matches video.children content. Deep
+    // equality, not reference equality — the builder filters nulls out so
+    // it allocates a fresh array even when no entries are dropped.
+    expect(block!.canonicalParent.children).toEqual(ownChildren)
+    expect(block!.canonicalParent.children).toHaveLength(ownChildren.length)
+    // (c) currentVideoDocumentId === video.documentId — no child can match,
+    // so the "Playing now" badge never fires for the parent-page view.
+    expect(block!.currentVideoDocumentId).toBe(video.documentId)
+    expect(
+      ownChildren.some((c) => c.documentId === block!.currentVideoDocumentId),
+    ).toBe(false)
+  })
+
+  it("prefers video.children over canonicalParent.children when both are populated", () => {
+    const ownChildren = [
+      makeChild("chapter-1", "chapter-1", "Chapter 1"),
+      makeChild("chapter-2", "chapter-2", "Chapter 2"),
+    ]
+    const video = makeVideo({
+      documentId: "jesus-parent",
+      slug: "jesus",
+      title: "JESUS",
+      children: ownChildren,
+    })
+    const canonicalParent = makeParent({
+      children: [
+        makeChild("sibling-a", "sibling-a", "Sibling A"),
+        makeChild("sibling-b", "sibling-b", "Sibling B"),
+      ],
+    })
+
+    const block = buildSiblingCarouselBlock(
+      canonicalParent as never,
+      video as never,
+    )
+
+    expect(block).not.toBeNull()
+    // The video's own children win — virtual-parent identity is video.documentId.
+    expect(block!.canonicalParent.documentId).toBe(video.documentId)
+    expect(block!.canonicalParent.children).toEqual(ownChildren)
+  })
 })
 
 describe("Auto-template builders return null on empty data", () => {

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -824,9 +824,23 @@ export type WatchHeroPlayerBlock = {
   variant: WatchVariant
 }
 
+/**
+ * Structural subtype shared between the canonical-parent and
+ * synthesized-from-current-video carousel sources. Captures the exact set
+ * of fields the carousel UI reads, so the virtualParent literal in
+ * `buildSiblingCarouselBlock` satisfies the type without an `as` cast or
+ * a cross-path filter assertion.
+ */
+export type CarouselParent = {
+  documentId: string
+  slug: string | null
+  title: string | null
+  children: NonNullable<WatchParent["children"]>
+}
+
 export type WatchSiblingCarouselBlock = {
   kind: "SiblingCarousel"
-  canonicalParent: WatchParent
+  canonicalParent: CarouselParent
   currentVideoDocumentId: string
 }
 
@@ -889,19 +903,61 @@ export function buildHeroBlock(
   return { kind: "HeroPlayer", video, variant }
 }
 
-/** Returns null when the canonical parent has fewer than 2 children. */
+/**
+ * Returns a carousel block with the most relevant peer set, or null when none
+ * is available:
+ *
+ * 1. When the current video has its **own** children (a parent / collection
+ *    video like JESUS with 61 chapter segments), surface those — the user is
+ *    looking at the parent, so chapters are the relevant peers.
+ * 2. Otherwise, fall back to the canonical parent's children — the current
+ *    video is itself a chapter, and the user wants to navigate between
+ *    siblings of the same parent (e.g. between segments of JESUS).
+ *
+ * Returns null when neither source has at least 2 entries.
+ */
 export function buildSiblingCarouselBlock(
   canonicalParent: WatchParent | null,
   video: WatchVideoRecord,
 ): WatchSiblingCarouselBlock | null {
-  if (!canonicalParent) return null
-  const children = (canonicalParent.children ?? []).filter(
+  // Narrow nulls only — both the parent's children and the current video's
+  // children share the same element type at the schema level, so we don't
+  // need a cross-path type assertion (each branch's narrow already lands
+  // inside `CarouselParent.children`).
+  const ownChildren = (video.children ?? []).filter(
     (child): child is NonNullable<typeof child> => child != null,
   )
-  if (children.length < 2) return null
+  if (ownChildren.length >= 2) {
+    // Synthesize a virtual parent from the current video so the carousel's
+    // header reads correctly ("JESUS · Clip N of M") and so the existing
+    // canonicalParent.children consumer in <SiblingCarousel> doesn't need a
+    // second branch. `currentVideoDocumentId` won't match any of its own
+    // children, so no "Playing now" badge — accurate for a parent-page view.
+    const virtualParent: CarouselParent = {
+      documentId: video.documentId,
+      slug: video.slug ?? "",
+      title: video.title ?? "",
+      children: ownChildren,
+    }
+    return {
+      kind: "SiblingCarousel",
+      canonicalParent: virtualParent,
+      currentVideoDocumentId: video.documentId,
+    }
+  }
+  if (!canonicalParent) return null
+  const siblings = (canonicalParent.children ?? []).filter(
+    (child): child is NonNullable<typeof child> => child != null,
+  )
+  if (siblings.length < 2) return null
   return {
     kind: "SiblingCarousel",
-    canonicalParent,
+    canonicalParent: {
+      documentId: canonicalParent.documentId,
+      slug: canonicalParent.slug ?? null,
+      title: canonicalParent.title ?? null,
+      children: siblings,
+    },
     currentVideoDocumentId: video.documentId,
   }
 }

--- a/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
+++ b/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
@@ -43,7 +43,24 @@ describe("WatchVideoFragment", () => {
     // (U6) will fall back to client-side ordering if needed.
     expect(printed).toMatch(/parents\s*\{[\s\S]*?\bchildren\b/)
     expect(printed).toMatch(
-      /\bchildren\b\s*\{[\s\S]*?documentId[\s\S]*?\bslug\b[\s\S]*?\btitle\b[\s\S]*?\blabel\b[\s\S]*?images\s*\{\s*url/,
+      /\bchildren\b[^{]*\{[\s\S]*?documentId[\s\S]*?\bslug\b[\s\S]*?\btitle\b[\s\S]*?\blabel\b[\s\S]*?images\s*\{\s*url/,
+    )
+
+    // Top-level `children(pagination: { limit: -1 })` — required so Strapi
+    // returns every chapter for parent/collection videos (e.g. JESUS has 61
+    // segments). The default 10-row pagination would silently drop chapters
+    // and the SiblingCarousel would render an incomplete strip. Mirrors the
+    // variants assertion shape below. graphql-js prints selections in source
+    // order, so the printed fragment shape is:
+    //   parents { ... children(pagination) { ... } }
+    //   children(pagination) { ... }      ← top-level
+    //   variants(pagination) { ... }
+    // The top-level occurrence is uniquely anchored by what appears AFTER
+    // the closing `}` of the children block — the next field is
+    // `variants(`. The nested occurrence is followed by another `}` (the
+    // parents block close) instead.
+    expect(printed).toMatch(
+      /\bchildren\(pagination:\s*\{\s*limit:\s*-1\s*\}\)\s*\{[\s\S]*?\}\s*variants\s*\(/,
     )
 
     // variants: identifying + playable + downloads + muxVideo.

--- a/apps/web/src/lib/fragments/watch-video.ts
+++ b/apps/web/src/lib/fragments/watch-video.ts
@@ -6,6 +6,10 @@ import { graphql } from "@forge/graphql"
 // - Video.studyQuestions has no `answer` field — see WatchStudyQuestions.
 // - parents.children does NOT accept sort:"order:asc" — Video has no `order`
 //   field. Children come back in editor-curated relation order.
+// - Top-level `children` powers the SiblingCarousel when the current video
+//   is itself a parent/collection (e.g. JESUS with 61 chapter segments).
+//   When the current video is a chapter, the carousel falls back to
+//   `parents[0].children` for siblings — see buildSiblingCarouselBlock.
 export const watchVideoFragment = graphql(`
   fragment WatchVideo on Video @_unmask {
     documentId
@@ -30,14 +34,29 @@ export const watchVideoFragment = graphql(`
       documentId
       slug
       title
-      children {
+      children(pagination: { limit: -1 }) {
         documentId
         slug
         title
         label
         images {
           url
+          thumbnail
+          mobileCinematicHigh
+          mobileCinematicLow
         }
+      }
+    }
+    children(pagination: { limit: -1 }) {
+      documentId
+      slug
+      title
+      label
+      images {
+        url
+        thumbnail
+        mobileCinematicHigh
+        mobileCinematicLow
       }
     }
     variants(pagination: { limit: -1 }) {

--- a/apps/web/src/lib/url.ts
+++ b/apps/web/src/lib/url.ts
@@ -29,3 +29,43 @@ export function isPublicShareableOrigin(origin: string): boolean {
     return false
   }
 }
+
+/**
+ * Resolve a usable poster URL for a watch-page video image.
+ *
+ * Priority order:
+ *   1. mobileCinematicHigh (curated cinematic still, large)
+ *   2. mobileCinematicLow  (curated cinematic still, small)
+ *   3. thumbnail           (thumbnail crop)
+ *   4. Mux fallback when `muxPlaybackId` is provided — a frame from the
+ *      video, not a curated poster, but always available.
+ *   5. null
+ *
+ * The raw `images[].url` field from Strapi is intentionally NOT in the
+ * fallback chain: that value is a misshaped Cloudflare Images URL (missing
+ * the variant path segment) and returns 400 from Cloudflare, so including
+ * it as a "last resort" only ever produces broken images.
+ */
+export function resolvePosterUrl(
+  image:
+    | {
+        mobileCinematicHigh?: string | null
+        mobileCinematicLow?: string | null
+        thumbnail?: string | null
+        url?: string | null
+      }
+    | null
+    | undefined,
+  muxPlaybackId?: string | null,
+): string | null {
+  const editorial =
+    image?.mobileCinematicHigh ??
+    image?.mobileCinematicLow ??
+    image?.thumbnail ??
+    null
+  if (editorial) return editorial
+  if (muxPlaybackId) {
+    return `https://image.mux.com/${muxPlaybackId}/thumbnail.jpg?width=448&height=252&fit_mode=smartcrop`
+  }
+  return null
+}

--- a/docs/solutions/design-patterns/always-render-cta-section-with-placeholder-row-20260505.md
+++ b/docs/solutions/design-patterns/always-render-cta-section-with-placeholder-row-20260505.md
@@ -1,0 +1,249 @@
+---
+title: "Always-render CTA section with placeholder row when editorial content is empty"
+date: 2026-05-05
+category: docs/solutions/design-patterns
+module: apps/web
+problem_type: design_pattern
+component: frontend_stimulus
+severity: low
+related_components:
+  - WatchStudyQuestions
+  - WatchBody
+  - BibleQuotesSection
+tags:
+  - watch-page
+  - related-questions
+  - ask-yours
+  - placeholder-row
+  - cta
+  - conditional-rendering
+  - ui-pattern
+  - design-pattern
+  - react
+  - next-js
+applies_when:
+  - "Section contains both editorial content (data-driven list) and an always-relevant CTA"
+  - "CMS or upstream data may legitimately return zero editorial items"
+  - "Hiding the entire section would also hide the CTA, stranding the user"
+---
+
+# Always-render CTA section with placeholder row when editorial content is empty
+
+## Context
+
+The watch page on `apps/web` renders a "Related Questions" section in the right column, populated by editorial study questions from Strapi, plus an "Ask Yours" CTA that opens a modal letting the viewer pose their own question to the creator. The original gating was:
+
+```ts
+// WatchBody.tsx — original
+const hasRightColumn = prompts.length > 0
+return (
+  <section data-has-right-column={hasRightColumn ? "true" : "false"}>
+    <div className={hasRightColumn ? "md:col-span-8" : "md:col-span-12"}>
+      {/* left column */}
+    </div>
+    {hasRightColumn ? (
+      <div data-testid="watch-body-right">
+        <WatchStudyQuestions prompts={prompts} onAskYoursClick={...} />
+      </div>
+    ) : null}
+  </section>
+)
+```
+
+For videos with no editorial study questions in the CMS (e.g., the Lumo Mark 3:20–4:41 chapter), the entire right column was hidden — including the always-relevant "Ask Yours" CTA. The reference design at jesusfilm.org always shows the section with a single placeholder row inviting the user to engage:
+
+> If you could ask the creator of this video a question, what would it be?
+
+The placeholder row is non-interactive (no hidden answer to expand), but the "Ask Yours" pill in the section header is always live.
+
+The same shape appears elsewhere on the watch page: `BibleQuotesSection` already follows this pattern — its "Join Our Bible Study" promo card always renders even when `bibleCitations` is empty. The fix below brings `WatchStudyQuestions` into alignment with that precedent.
+
+## Guidance
+
+When a section combines editorial content with an always-relevant CTA, gate the section on **the CTA's relevance**, not on **the editorial content's presence**. Use a placeholder fallback for the editorial portion when it is empty.
+
+Two practical rules:
+
+1. **Section visibility decisions live above the editorial conditional.** Whether the section renders is a parent-level question (driven by CTA relevance, layout intent, or product decision). Whether the inside renders editorial vs placeholder is a child-level question. Keep these two decisions in different files / different scopes; do not couple them through a single `prompts.length > 0` gate.
+2. **The placeholder row matches the editorial row's visual contract.** Same `<li>` shape, same icon, same className — so the layout does not shift when CMS data flips between empty and populated.
+
+```tsx
+// WatchBody.tsx — right column always renders
+<div data-testid="watch-body-right" className="md:col-span-4">
+  <WatchStudyQuestions prompts={prompts} onAskYoursClick={onAskYoursClick} />
+</div>
+```
+
+```tsx
+// WatchStudyQuestions.tsx — the empty/populated branch lives inside the section
+const PLACEHOLDER_QUESTION =
+  "If you could ask the creator of this video a question, what would it be?"
+
+const hasPrompts = prompts.length > 0
+
+return (
+  <section>
+    <header>
+      <h4>Related Questions</h4>
+      <Button onClick={onAskYoursClick}>Ask yours</Button>
+    </header>
+    <ul>
+      {hasPrompts ? (
+        prompts.map((prompt, index) => (
+          <li
+            key={`${index}-${prompt}`}
+            data-testid="watch-study-questions-item"
+          >
+            <p>
+              <QuestionIcon />
+              {prompt}
+            </p>
+          </li>
+        ))
+      ) : (
+        <li data-testid="watch-study-questions-placeholder">
+          <p>
+            <QuestionIcon />
+            {PLACEHOLDER_QUESTION}
+          </p>
+        </li>
+      )}
+    </ul>
+  </section>
+)
+```
+
+## Why This Matters
+
+- **Stranded CTAs.** A CTA's relevance rarely depends on whether its sibling editorial content exists. Gating both on the same condition silently hides one of them. A user who happens to land on a video without editorial prompts loses the entire path to engage with the creator.
+- **Layout consistency.** When sections appear and disappear based on CMS data, the surrounding layout reflows in ways editors and ops cannot preview. An always-rendered placeholder row keeps the layout stable across content states — what an editor sees while authoring matches what a viewer sees on a freshly-published video.
+- **Accessibility contract preservation.** The placeholder row should preserve the same a11y guarantees as the populated row: no `aria-haspopup`, no `aria-expanded`, decorative SVGs only (`aria-hidden="true"`, no `rotate-` / `transition` classes that imply expandability), no nested interactive elements. Otherwise the empty-state UX silently regresses the contract pinned by the populated-state tests.
+- **Dead conditional signals.** A `data-has-X={cond ? "true" : "false"}` attribute that ends up always emitting `"true"` after this refactor is dead code. Remove it; do not leave a hardcoded literal that trains future readers (or future Playwright selectors) to expect variability that no longer exists.
+
+## When to Apply
+
+Apply this pattern when **all** of:
+
+- The section contains both editorial content (data-driven list, fetched item, or similar) and a CTA / always-on invite.
+- The CTA is meaningful even when editorial content is empty.
+- Hiding the entire section would feel like a missing feature, not a clean empty state.
+
+Do not apply when:
+
+- The CTA itself depends on the editorial content (e.g., a "share these prompts" button that has nothing to share without prompts).
+- The section is purely informational with no user action — there, just hide it on empty.
+- The empty case is degenerate and the page should re-arrange around it (different layout entirely).
+
+## Examples
+
+### Before — section gated on editorial content (`WatchBody.tsx`)
+
+```tsx
+const hasRightColumn = prompts.length > 0
+
+return (
+  <section data-has-right-column={hasRightColumn ? "true" : "false"}>
+    <div className={hasRightColumn ? "md:col-span-8" : "md:col-span-12"}>
+      {/* left column */}
+    </div>
+    {hasRightColumn ? (
+      <div data-testid="watch-body-right">
+        <WatchStudyQuestions prompts={prompts} onAskYoursClick={...} />
+      </div>
+    ) : null}
+  </section>
+)
+```
+
+### After — section always renders, branch is internal
+
+```tsx
+return (
+  <section>
+    <div className="md:col-span-8">
+      {/* left column */}
+    </div>
+    <div data-testid="watch-body-right">
+      <WatchStudyQuestions prompts={prompts} onAskYoursClick={...} />
+    </div>
+  </section>
+)
+```
+
+### After — `WatchStudyQuestions.tsx` owns the empty case
+
+```tsx
+{
+  prompts.length > 0 ? (
+    prompts.map((prompt, index) => (
+      <li key={`${index}-${prompt}`} data-testid="watch-study-questions-item">
+        <p>
+          <QuestionIcon />
+          {prompt}
+        </p>
+      </li>
+    ))
+  ) : (
+    <li data-testid="watch-study-questions-placeholder">
+      <p>
+        <QuestionIcon />
+        {PLACEHOLDER_QUESTION}
+      </p>
+    </li>
+  )
+}
+```
+
+The "Ask Yours" CTA in the section header renders unconditionally above the list.
+
+### Test contract — pin the placeholder branch against the same UX-regression rules
+
+The populated branch is already pinned by `WatchBody.test.tsx > "WatchStudyQuestions — UX regression: no false-affordance chevrons"`. Add a sibling test for the empty branch so the contract holds across both states:
+
+```tsx
+it("placeholder row (empty prompts) is non-interactive: no nested button/anchor, decorative SVG only, and Ask Yours stays the only button", () => {
+  render(<WatchStudyQuestions prompts={[]} onAskYoursClick={vi.fn()} />)
+
+  const placeholder = screen.getByTestId("watch-study-questions-placeholder")
+  expect(placeholder.tagName.toLowerCase()).toBe("li")
+  expect(placeholder.hasAttribute("aria-haspopup")).toBe(false)
+  expect(placeholder.hasAttribute("aria-expanded")).toBe(false)
+  expect(placeholder.querySelector("button")).toBeNull()
+  expect(placeholder.querySelector("a")).toBeNull()
+
+  for (const svg of placeholder.querySelectorAll("svg")) {
+    expect(svg.getAttribute("aria-hidden")).toBe("true")
+    const cls = svg.getAttribute("class") ?? ""
+    expect(cls).not.toMatch(/\brotate-/)
+    expect(cls).not.toMatch(/\btransition\b/)
+  }
+
+  // Real prompt rows must be absent in the placeholder branch.
+  expect(screen.queryAllByTestId("watch-study-questions-item").length).toBe(0)
+
+  // Singleton-button contract holds across the empty-prompts path too.
+  const buttons = screen
+    .getByTestId("watch-study-questions")
+    .querySelectorAll("button")
+  expect(buttons.length).toBe(1)
+  expect(buttons[0]?.getAttribute("data-testid")).toBe(
+    "watch-study-questions-ask-yours",
+  )
+})
+```
+
+The textContent of the placeholder should also be asserted against the constant in at least one parent-level test so that silent edits to `PLACEHOLDER_QUESTION` get caught:
+
+```tsx
+expect(
+  screen.getByTestId("watch-study-questions-placeholder").textContent,
+).toContain(
+  "If you could ask the creator of this video a question, what would it be?",
+)
+```
+
+## Related
+
+- `docs/solutions/best-practices/watch-single-video-template-pages-strapi-nextjs-2026-04-11.md` — same watch-page architecture; documents the route-bound block model (`useRouteVideo` / `itemsSource`) that backs `WatchBody`'s data shape.
+- `docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md` — sibling fix from the same release branch; same symptom class ("CMS absence causes silent UX failure").
+- `docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md` — same `apps/web/src/components/watch/` directory; documents the sticky-hero layout the right column lives inside.

--- a/docs/solutions/developer-experience/measurement-driven-layout-iteration-chrome-mcp-20260505.md
+++ b/docs/solutions/developer-experience/measurement-driven-layout-iteration-chrome-mcp-20260505.md
@@ -1,0 +1,185 @@
+---
+title: "Measurement-driven layout iteration via Chrome MCP getBoundingClientRect"
+date: 2026-05-05
+category: docs/solutions/developer-experience
+module: apps/web
+problem_type: developer_experience
+component: development_workflow
+severity: low
+related_components:
+  - claude-in-chrome
+  - chrome-devtools-mcp
+tags:
+  - layout
+  - alignment
+  - tailwind
+  - chrome-mcp
+  - claude-in-chrome
+  - getboundingclientrect
+  - workflow
+  - iteration-loop
+  - frontend
+  - measurement-driven
+applies_when:
+  - "Tuning cross-component spacing, alignment, or layout values that depend on visual position"
+  - "User keeps saying the gap is off / jarring after multiple eyeball-driven attempts"
+  - "Two or more elements need to sit on the same axis (vertical, horizontal, or column gutter)"
+  - "A dev server is running and the page can be loaded in a browser MCP"
+---
+
+# Measurement-driven layout iteration via Chrome MCP getBoundingClientRect
+
+## Context
+
+A long session iterated on watch-page layout alignment across four turns. Each turn the user said the gap was "jarring" or "still off", and the orchestrator adjusted Tailwind `pt`/`mb` values by guessing — bumping `pt-6` to `pt-12`, then `pt-16`, then `pt-14`, with mixed results. After four rounds, the user explicitly asked the agent to switch to MCP-driven verification: open the page, measure, then iterate.
+
+The breakthrough was using `mcp__claude-in-chrome__javascript_tool` to run a script that returned `getBoundingClientRect` for each element involved in the alignment intent (Download button, h1 title, Related Questions header, Ask Yours pill). With centerY values in hand, the orchestrator could see the actual delta — the Download row was 107 px above the title — and immediately knew that no `pt` adjustment alone would close it. The fix needed an architectural change (Download into the title flex row), and a single new `pt` value on the right column. Verified within 1 px on the first try.
+
+Eyeball-driven iteration had accumulated: four+ rounds of guesses, multiple architectural reverts (Download in title row → out → back in), stale doc comments referencing wrappers that had been torn out, and a downstream code-review cycle that flagged the staleness. Measurement-driven iteration finished the same alignment in one round.
+
+## Guidance
+
+When the user says "that's still off" about UI alignment more than once, switch from eyeball to measurement. Two MCP paths exist; pick by what's available.
+
+**Claude in Chrome MCP** (preferred when the user already has the page open in their Chrome):
+
+- Uses the user's actual logged-in browser session, real fonts, real CSS, no separate browser to spin up
+- `mcp__claude-in-chrome__tabs_context_mcp` (with `createIfEmpty: true` if no group exists) to grab a tab id
+- `mcp__claude-in-chrome__navigate` to load the page (or have the user open it)
+- `mcp__claude-in-chrome__javascript_tool` with `action: "javascript_exec"` to run a measurement script
+
+**Chrome DevTools MCP** (when you need a screenshot, Lighthouse, or headless automation):
+
+- `mcp__chrome-devtools__take_screenshot` for visual review
+- `mcp__chrome-devtools__evaluate_script` for measurement
+- `mcp__chrome-devtools__lighthouse_audit` for performance / Core Web Vitals
+- Requires a bundled browser binary at the configured executable path; was broken in this environment, hence the fallback to claude-in-chrome
+
+For pure alignment work, `getBoundingClientRect` measurement is more precise than a screenshot — the script returns numbers, not pixels you have to interpret.
+
+### Measurement script template
+
+```javascript
+new Promise((resolve) => {
+  let i = 0
+  const tick = () => {
+    i++
+    // Pick any anchor element that should be present once the page has laid out.
+    const t = document.querySelector('[data-testid="watch-body-title"]')
+    const r = t && t.getBoundingClientRect()
+    if (r && r.height > 0) {
+      const pick = (sel) => {
+        const el = document.querySelector(sel)
+        if (!el) return null
+        const rr = el.getBoundingClientRect()
+        return {
+          top: Math.round(rr.top + window.scrollY),
+          centerY: Math.round(rr.top + rr.height / 2 + window.scrollY),
+          height: Math.round(rr.height),
+        }
+      }
+      resolve(
+        JSON.stringify({
+          viewport: { w: window.innerWidth, h: window.innerHeight },
+          // Add every element involved in the alignment intent.
+          title: pick('[data-testid="watch-body-title"]'),
+          download: pick('[data-testid="watch-download-button"]'),
+          relatedHeader: pick("#watch-related-questions-heading"),
+          askYours: pick('[data-testid="watch-study-questions-ask-yours"]'),
+        }),
+      )
+    } else if (i > 50) {
+      resolve("TIMEOUT")
+    } else {
+      setTimeout(tick, 200)
+    }
+  }
+  tick()
+})
+```
+
+Two details that matter:
+
+1. **Polling loop, not single-shot.** SSR'd Next.js pages hydrate over multiple frames; a measurement that runs immediately after `navigate` often returns zero heights. The polling loop waits up to ~10 s for at least one anchor element to have non-zero height before measuring.
+2. **Absolute Y coordinates** (`rr.top + window.scrollY`). Reporting `top` relative to the viewport breaks when the user scrolls between measurements. Adding `window.scrollY` makes values stable.
+
+### Reading the deltas
+
+Compare `centerY` (or `top` for top-edge alignment) across elements. The size of the delta tells you what kind of fix is needed:
+
+- **0–8 px off:** small `pt`/`mb` adjustment will close it.
+- **8–30 px off:** likely a single-step Tailwind change away (e.g. `pt-2` → `pt-4`).
+- **>30 px off:** structural — you cannot close this gap with spacing alone, the element is in the wrong flex flow / column. Look at where it actually sits in the DOM tree, not just its className.
+
+## Why This Matters
+
+- **Eyeball accuracy floor is ~10–20 px.** Below that, observers disagree about whether something is "aligned" or "jarring." Measurement removes the disagreement.
+- **Iteration cost compounds.** Each guess-and-check round costs the user a screenshot, a description, and your editing + test cycle. One measurement-backed change costs one tool call.
+- **Cross-component coupling is invisible without numbers.** When component A's spacing is tuned to component B's element height, the coupling is real but undocumented in code. Measurements expose the relationship; once exposed it can be addressed (breakpoint variants, shared CSS variables, restructure).
+- **Test pinning becomes meaningful.** Once you know `pt-11` produces alignment, you can pin that token in tests as alignment-load-bearing. Without measurement, the value looks arbitrary and any future refactor silently changes it.
+- **Cuts off the architectural-revert loop.** Knowing the delta is 100+ px tells you immediately not to attempt another `pt` bump — you need to move the element. Without measurement you can spend several turns adjusting spacing in increments that physically can't close the gap.
+
+## When to Apply
+
+Apply this pattern when:
+
+- Two or more elements need to sit on the same axis (vertical Y, horizontal X, or a shared right edge)
+- User feedback is starting to repeat ("still off", "lowered slightly", "the gap is jarring")
+- The fix involves Tailwind spacing utilities (`pt-`, `mb-`, `gap-`, `mt-`, etc.) rather than structural changes
+- A dev server is running and a page can be loaded in either Chrome MCP
+
+Skip this pattern when:
+
+- The fix is purely visual taste (color contrast, font weight) — measurement doesn't help
+- The user explicitly says "doesn't have to be perfect" — eyeball is fine for that bar
+- No browser MCP is available — fall back to screenshots and reasoning
+- The page is behind auth and the MCP browser session can't reach it without the user's intervention
+
+## Examples
+
+### Before — eyeball-driven, four turns
+
+```
+User: "the gap is a bit jarring"
+Agent: changes pt-6 → pt-12
+User: "lowered slightly please"
+Agent: changes pt-12 → pt-16
+User: "now it's overcorrected"
+Agent: changes pt-16 → pt-14
+User: "still off"
+Agent: ... another guess
+```
+
+Four turns, three failed adjustments, growing user frustration, no convergence.
+
+### After — measurement-driven, one turn
+
+```
+Agent: mcp__claude-in-chrome__navigate { url, tabId }
+Agent: mcp__claude-in-chrome__javascript_tool { measurement script }
+Returns: {
+  title:    { centerY: 1413 },
+  download: { centerY: 1424 },  // 11 px above title
+  ...
+}
+
+Agent: "Top row is 11 px above title centerY. The previous pt adjustments
+        are mathematically incapable of closing it because Download is
+        the FIRST child of the left column flex flow — increasing pt
+        moves the title down by the same amount, preserving the gap.
+        Need to move Download into the title row architecturally."
+
+Applies architectural fix + targeted pt change on the sibling column.
+Re-measures. All four elements within 1 px of the target Y.
+```
+
+One round. The measurement made the architectural insight obvious.
+
+### Verifying after the fix
+
+After applying spacing or structural changes, run the measurement script again before declaring done. The earlier rounds' "guess, ask user, wait for response" can be collapsed to "guess, measure, confirm" — the agent does its own verification loop. The user gets one report at the end, not N rounds of "is this better?"
+
+## Related
+
+- `docs/solutions/design-patterns/always-render-cta-section-with-placeholder-row-20260505.md` — companion learning from the same session, documents the section-renders-unconditionally-with-placeholder pattern that the layout work refined.
+- `docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md` — also uses `getBoundingClientRect` for sticky-hero scroll-over math (different application, same family of measurement-driven layout techniques).


### PR DESCRIPTION
## Summary

Resurfaces the chapter / scene carousel on watch pages — was previously stubbed with `return null` "until thumbnail-image plumbing is restored." Now wired correctly for both **parent videos** (e.g. JESUS displays its 61 chapter segments) and **chapter videos** (segments display siblings within the parent collection). Shipped through `/compound-engineering:ce-code-review` (10 reviewer agents → 13 fixes applied + 4 policy items skipped per preference).

### What changed

- **Data flow.** `watchVideoFragment` gains a top-level `children(pagination: { limit: -1 })` projection so a parent video's own children populate the carousel. The pre-existing nested `parents[].children` selection also gains the same `pagination: { limit: -1 }` argument so chapter-mode siblings aren't silently truncated at Strapi's 10-row default — same root cause documented this morning in `docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md`. Image variant fields (`thumbnail`, `mobileCinematicHigh`, `mobileCinematicLow`) added to both projections so thumbnails render through the variant URLs Cloudflare expects.
- **Builder.** `buildSiblingCarouselBlock` prefers `video.children` when the current video is itself a parent (≥2 own children); otherwise falls back to `canonicalParent.children`. Synthesized virtualParent uses a new `CarouselParent` structural subtype instead of casting to the full `WatchParent` — drops both the `as WatchParent` cast and the cross-path filter predicate that previously bypassed the type checker.
- **UI restyle.** 16:9 cards with full-bleed thumbnail, "CHAPTER" caption + title overlay, gradient for legibility. Active card carries `border-4 border-red-600` (drawn _inside_ the box so `CarouselContent`'s `overflow-hidden` doesn't clip it at top/bottom). Inactive cards have no border so the body-zone backdrop doesn't read as a halo. Inactive hover reveals a centered red Play overlay. Carousel arrow chevrons fixed to be black at all times instead of white-until-hover.
- **Layout.** Carousel removed from `TOP_ZONE_KINDS` so it sits in the body zone in normal flow below the sticky hero (was sticky alongside it). Body-zone padding tightened (`gap-10` → `gap-6`, `pt-4` → `pt-2`).
- **Image URL handling.** New `resolvePosterUrl(image, playbackId?)` helper in `lib/url.ts` centralizes the cinematic-still → thumbnail → Mux fallback chain shared by `SiblingCarousel` and `WatchPageClient` (was duplicated and already drifting apart). The legacy `images[].url` field is **dropped from the chain entirely** — it returns a misshaped Cloudflare Images URL that 400s; falling through to it only ever produced broken thumbnails.
- **href shape.** Switched to the 2-segment route (`/{slug}/{locale}`) that matches the flat `[slug]/[locale]` watch route. Both segments URL-encoded. Children without a `slug` are filtered out (no unclickable cards).
- **Parent-page mode.** Current video has no chapter to highlight → header reads "{N} chapters" instead of misleading "Clip 1 of N", and a `data-mode="parent" | "chapter"` attribute on the `<section>` root gives agents a clean signal.
- **Snap-to-active.** Effect now depends on `[api, activeIndex]` so a variant switch that flips the active chapter actually re-snaps the carousel.
- **LCP.** First 5 visible cards get `<Image priority>` so the above-the-fold strip preloads.

### Tests + verification

- `pnpm typecheck`, `pnpm lint`, and `pnpm test` all clean. **251 tests passing across 27 files** (was 245 → +6 new tests for the changes above).
- New tests: image-priority chain (mobileCinematicHigh > Low > thumbnail); `buildSiblingCarouselBlock` virtualParent branch; fragment-regression for top-level `children(pagination: { limit: -1 })`; DOM containment assertion that the carousel is a descendant of `[data-testid="watch-body-zone"]` (catches a re-promotion to TOP_ZONE_KINDS); `WatchSectionRenderer.test.tsx` `makeVideo` fixture brought in line with the required `children: []` field.

### Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (251 tests)
- [ ] Manual smoke: load `/watch/jesus/en` and verify the carousel renders 61 cards with thumbnails and a clean "61 chapters" header (no "Clip 1 of 61")
- [ ] Manual smoke: load `/watch/the-beginning/en` (a chapter) and verify the active red border lands on the correct card and the carousel scroll-snaps to it
- [ ] Manual smoke: switch language via the language picker and verify the carousel re-snaps to the new active card (regression guard for the `[api, activeIndex]` deps fix)

### Notes for review

- **Pre-existing carry-over:** `apps/cms/schema.graphql` has 88 `hasPublishedVersion` arguments + new SearchResultDebug types from earlier sessions, with no `packages/graphql/` codegen regen. Deliberately **not** in this PR — flagged on PR #878's review and belongs in its own commit. This branch's intentional fragment additions (`children`, image variants) are clean — those types already exist in the generated `graphql-env.d.ts`.
- **Skipped policy items** (intentionally not addressed here, may want follow-ups):
  - Hardcoded "Chapter" caption vs `child.label` data — accepted current behavior.
  - 60-second `unstable_cache` rollout window post-deploy — accepted (fallback handles it gracefully).
  - `next/image` host trust for CMS-controlled URLs — accepted (per-card placeholder on bad URLs).
  - RSC payload fan-out from doubled `children` projections — accepted (revisit if Strapi response time degrades).

### Cache rollout

Watch-page resolvers use `unstable_cache({ revalidate: 60 })`. Warm cache entries built against the **old** fragment shape lack the new `children` field; the runtime `?? []` fallback handles this gracefully so the carousel just renders empty until the cache expires (max 60 s). No targeted invalidation is wired up — accept the rollout window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)