### PR TITLE
docs(roadmap): embed-backfill performance tickets feat-115..118

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -17,36 +17,40 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ### Content Discovery
 
-| ID                                                                             | Feature                                                  | Owner     | Priority | Start      | Days | Due        | Status      |
-| ------------------------------------------------------------------------------ | -------------------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
-| [feat-009](content-discovery/feat-009-pgvector-embedding-indexing.md)          | pgvector Setup and Embedding Indexing                    | nisal     | P0       | 2026-04-07 | 14   | 2026-04-20 | complete    |
-| [feat-010](content-discovery/feat-010-semantic-search-api.md)                  | Semantic Search API                                      | nisal     | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
-| [feat-011](content-discovery/feat-011-search-ui-web.md)                        | Search UI — Web                                          | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
-| [feat-012](content-discovery/feat-012-search-ui-mobile.md)                     | Search UI — Mobile                                       | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
-| [feat-097](content-discovery/feat-097-investigate-prod-query-embedding.md)     | Investigate Production Query Embedding Degradation       | nisal     | P1       | 2026-04-15 | 2    | 2026-04-16 | complete    |
-| [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)        | Experience Embedding Pipeline                            | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |
-| [feat-037](content-discovery/feat-037-video-content-vectorization.md)          | Video Content Vectorization for Recommendations          | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | complete    |
-| [feat-038](content-discovery/feat-038-video-vectorization-data-audit.md)       | Video Vectorization — Data Audit                         | nisal     | P1       | 2026-04-21 | 3    | 2026-04-23 | complete    |
-| [feat-090](content-discovery/feat-090-watch-event-collection.md)               | Watch Event Collection & Session Tracking                | nisal     | P1       | 2026-04-21 | 10   | 2026-04-30 | not-started |
-| [feat-096](content-discovery/feat-096-experience-embeddings-backfill.md)       | Experience Embeddings Backfill                           | nisal     | P1       | 2026-04-21 | 2    | 2026-04-22 | complete    |
-| [feat-086](content-discovery/feat-086-experience-search-integration.md)        | Search Extension — Add Experiences to Results            | nisal     | P1       | 2026-04-23 | 5    | 2026-04-27 | complete    |
-| [feat-039](content-discovery/feat-039-chapter-based-scene-boundaries.md)       | Video Vectorization — Chapter-Based Scene Boundaries     | nisal     | P1       | 2026-04-24 | 7    | 2026-04-30 | complete    |
-| [feat-040](content-discovery/feat-040-multimodal-scene-descriptions.md)        | Video Vectorization — Multimodal Scene Analysis          | nisal     | P1       | 2026-05-01 | 10   | 2026-05-10 | complete    |
-| [feat-091](content-discovery/feat-091-fpmc-video-page-recommendations.md)      | FPMC Video Page Recommendations                          | nisal     | P1       | 2026-05-01 | 14   | 2026-05-14 | not-started |
-| [feat-041](content-discovery/feat-041-scene-embeddings-table.md)               | Video Vectorization — Scene Embeddings Table + Indexing  | nisal     | P1       | 2026-05-11 | 7    | 2026-05-17 | complete    |
-| [feat-092](content-discovery/feat-092-two-tower-neural-recommendations.md)     | Two-Tower Neural Recommendation Model                    | nisal     | P1       | 2026-05-15 | 21   | 2026-06-04 | not-started |
-| [feat-042](content-discovery/feat-042-backfill-worker.md)                      | Video Vectorization — Phase 1 Backfill Worker (en/es/fr) | nisal     | P1       | 2026-05-18 | 10   | 2026-05-27 | complete    |
-| [feat-044](content-discovery/feat-044-recommendation-query-api.md)             | Video Vectorization — Recommendation Query API           | nisal     | P1       | 2026-05-28 | 7    | 2026-06-03 | complete    |
-| [feat-055](content-discovery/feat-055-smart-video-playlists.md)                | Smart Video Playlists                                    | vlad      | P1       | 2026-05-31 | 31   | 2026-06-30 | not-started |
-| [feat-045](content-discovery/feat-045-pipeline-integration.md)                 | Video Vectorization — Pipeline Integration               | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
-| [feat-046](content-discovery/feat-046-recommendations-demo-experience.md)      | Video Vectorization — Recommendations Demo Experience    | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
-| [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)  | Deploy Semantic Search Architecture                      | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
-| [feat-080](content-discovery/feat-080-transcript-embedding-table-rename.md)    | Transcript Embedding Table Rename                        | nisal     | P2       | 2026-04-10 | 2    | 2026-04-11 | complete    |
-| [feat-043](content-discovery/feat-043-visual-shot-detection-fusion.md)         | Video Vectorization — Visual Shot Detection Fusion       | nisal     | P2       | 2026-05-28 | 10   | 2026-06-06 | blocked     |
-| [feat-093](content-discovery/feat-093-cold-start-context-recommendations.md)   | Cold Start Context-Based Recommendations                 | nisal     | P2       | 2026-06-05 | 7    | 2026-06-11 | not-started |
-| [feat-094](content-discovery/feat-094-recommendation-ab-comparison-logging.md) | Recommendation A/B Comparison Logging                    | nisal     | P2       | 2026-06-12 | 7    | 2026-06-18 | not-started |
-| [feat-071](content-discovery/feat-071-recommendation-content-deduplication.md) | Recommendation Content Deduplication                     | nisal     | P2       | 2026-06-15 | 5    | 2026-06-19 | complete    |
-| [feat-063](content-discovery/feat-063-personalize-discovery-experiences.md)    | Personalize Discovery Experiences                        | tataihono | P2       | 2026-10-01 | 45   | 2026-11-14 | blocked     |
+| ID                                                                                       | Feature                                                  | Owner     | Priority | Start      | Days | Due        | Status      |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------- | --------- | -------- | ---------- | ---- | ---------- | ----------- |
+| [feat-009](content-discovery/feat-009-pgvector-embedding-indexing.md)                    | pgvector Setup and Embedding Indexing                    | nisal     | P0       | 2026-04-07 | 14   | 2026-04-20 | complete    |
+| [feat-010](content-discovery/feat-010-semantic-search-api.md)                            | Semantic Search API                                      | nisal     | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
+| [feat-011](content-discovery/feat-011-search-ui-web.md)                                  | Search UI — Web                                          | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
+| [feat-012](content-discovery/feat-012-search-ui-mobile.md)                               | Search UI — Mobile                                       | urim      | P0       | 2026-04-14 | 21   | 2026-05-04 | complete    |
+| [feat-097](content-discovery/feat-097-investigate-prod-query-embedding.md)               | Investigate Production Query Embedding Degradation       | nisal     | P1       | 2026-04-15 | 2    | 2026-04-16 | complete    |
+| [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)                  | Experience Embedding Pipeline                            | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |
+| [feat-037](content-discovery/feat-037-video-content-vectorization.md)                    | Video Content Vectorization for Recommendations          | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | complete    |
+| [feat-038](content-discovery/feat-038-video-vectorization-data-audit.md)                 | Video Vectorization — Data Audit                         | nisal     | P1       | 2026-04-21 | 3    | 2026-04-23 | complete    |
+| [feat-090](content-discovery/feat-090-watch-event-collection.md)                         | Watch Event Collection & Session Tracking                | nisal     | P1       | 2026-04-21 | 10   | 2026-04-30 | not-started |
+| [feat-096](content-discovery/feat-096-experience-embeddings-backfill.md)                 | Experience Embeddings Backfill                           | nisal     | P1       | 2026-04-21 | 2    | 2026-04-22 | complete    |
+| [feat-086](content-discovery/feat-086-experience-search-integration.md)                  | Search Extension — Add Experiences to Results            | nisal     | P1       | 2026-04-23 | 5    | 2026-04-27 | complete    |
+| [feat-039](content-discovery/feat-039-chapter-based-scene-boundaries.md)                 | Video Vectorization — Chapter-Based Scene Boundaries     | nisal     | P1       | 2026-04-24 | 7    | 2026-04-30 | complete    |
+| [feat-040](content-discovery/feat-040-multimodal-scene-descriptions.md)                  | Video Vectorization — Multimodal Scene Analysis          | nisal     | P1       | 2026-05-01 | 10   | 2026-05-10 | complete    |
+| [feat-091](content-discovery/feat-091-fpmc-video-page-recommendations.md)                | FPMC Video Page Recommendations                          | nisal     | P1       | 2026-05-01 | 14   | 2026-05-14 | not-started |
+| [feat-115](content-discovery/feat-115-embed-backfill-bounded-parallelism.md)             | Embed Backfill — Stage 1 — Bounded Parallelism           | nisal     | P0       | 2026-05-04 | 1    | 2026-05-04 | not-started |
+| [feat-116](content-discovery/feat-116-embed-backfill-s3-cache-and-batched-openrouter.md) | Embed Backfill — Stage 2 — S3 Cache + Batched OpenRouter | nisal     | P0       | 2026-05-06 | 2    | 2026-05-07 | not-started |
+| [feat-117](content-discovery/feat-117-embed-backfill-bulk-sql-writes.md)                 | Embed Backfill — Stage 3 — Bulk DB Writes                | nisal     | P0       | 2026-05-08 | 2    | 2026-05-09 | not-started |
+| [feat-041](content-discovery/feat-041-scene-embeddings-table.md)                         | Video Vectorization — Scene Embeddings Table + Indexing  | nisal     | P1       | 2026-05-11 | 7    | 2026-05-17 | complete    |
+| [feat-118](content-discovery/feat-118-embed-backfill-content-hash-skip.md)               | Embed Backfill — Stage 4 — Content-Hash Skip             | nisal     | P1       | 2026-05-12 | 3    | 2026-05-14 | not-started |
+| [feat-092](content-discovery/feat-092-two-tower-neural-recommendations.md)               | Two-Tower Neural Recommendation Model                    | nisal     | P1       | 2026-05-15 | 21   | 2026-06-04 | not-started |
+| [feat-042](content-discovery/feat-042-backfill-worker.md)                                | Video Vectorization — Phase 1 Backfill Worker (en/es/fr) | nisal     | P1       | 2026-05-18 | 10   | 2026-05-27 | complete    |
+| [feat-044](content-discovery/feat-044-recommendation-query-api.md)                       | Video Vectorization — Recommendation Query API           | nisal     | P1       | 2026-05-28 | 7    | 2026-06-03 | complete    |
+| [feat-055](content-discovery/feat-055-smart-video-playlists.md)                          | Smart Video Playlists                                    | vlad      | P1       | 2026-05-31 | 31   | 2026-06-30 | not-started |
+| [feat-045](content-discovery/feat-045-pipeline-integration.md)                           | Video Vectorization — Pipeline Integration               | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
+| [feat-046](content-discovery/feat-046-recommendations-demo-experience.md)                | Video Vectorization — Recommendations Demo Experience    | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
+| [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)            | Deploy Semantic Search Architecture                      | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
+| [feat-080](content-discovery/feat-080-transcript-embedding-table-rename.md)              | Transcript Embedding Table Rename                        | nisal     | P2       | 2026-04-10 | 2    | 2026-04-11 | complete    |
+| [feat-043](content-discovery/feat-043-visual-shot-detection-fusion.md)                   | Video Vectorization — Visual Shot Detection Fusion       | nisal     | P2       | 2026-05-28 | 10   | 2026-06-06 | blocked     |
+| [feat-093](content-discovery/feat-093-cold-start-context-recommendations.md)             | Cold Start Context-Based Recommendations                 | nisal     | P2       | 2026-06-05 | 7    | 2026-06-11 | not-started |
+| [feat-094](content-discovery/feat-094-recommendation-ab-comparison-logging.md)           | Recommendation A/B Comparison Logging                    | nisal     | P2       | 2026-06-12 | 7    | 2026-06-18 | not-started |
+| [feat-071](content-discovery/feat-071-recommendation-content-deduplication.md)           | Recommendation Content Deduplication                     | nisal     | P2       | 2026-06-15 | 5    | 2026-06-19 | complete    |
+| [feat-063](content-discovery/feat-063-personalize-discovery-experiences.md)              | Personalize Discovery Experiences                        | tataihono | P2       | 2026-10-01 | 45   | 2026-11-14 | blocked     |
 
 ### Media Generation
 

--- a/docs/roadmap/content-discovery/feat-115-embed-backfill-bounded-parallelism.md
+++ b/docs/roadmap/content-discovery/feat-115-embed-backfill-bounded-parallelism.md
@@ -1,0 +1,71 @@
+---
+id: "feat-115"
+title: "Embed Backfill — Stage 1 — Bounded Parallelism on Per-Target Loop"
+owner: "nisal"
+priority: "P0"
+status: "not-started"
+start_date: "2026-05-04"
+duration: 1
+depends_on: []
+blocks:
+  - "feat-116"
+tags:
+  - "admin"
+  - "ai-pipeline"
+  - "performance"
+---
+
+## Problem
+
+R1 (scene) and R2 (transcript) embed-backfill workflows iterate `(video, edition, locale)` triples sequentially with `for…of`. At ~1,088 videos × ~30 locales avg the per-target loop is the dominant wall-time cost. Parallelization is documented-rule-bound: `docs/solutions/best-practices/parallel-workflow-error-robustness-20260420.md` says "no `Promise.all`" because one rejection kills the batch. The right shape is `p-limit(N)` + `Promise.allSettled` — bounded concurrency, every per-target outcome captured independently, no full-batch abort on a single failure.
+
+Expected speedup: **5-10×** on R1 (gated by OpenRouter rate limits, not us); **10-20×** on R2 (DB-bound).
+
+## Entry Points — Read These First
+
+1. `apps/admin/src/workflows/sceneEmbeddingBackfill.ts` — R1 workflow body; the `for…of` over enumerated targets is what we replace.
+2. `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts` — R2 workflow; same shape.
+3. `apps/admin/src/scripts/run-embeds.ts` — the local CLI; direct-invokes the workflow function bodies bypassing useworkflow runtime. Must continue to work unchanged.
+4. `docs/solutions/best-practices/parallel-workflow-error-robustness-20260420.md` — the no-`Promise.all` rule and the `allSettled` pattern.
+5. `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md` — every `start()` call site has a dispatch-level test; do not regress.
+
+## Grep These
+
+```
+grep -rn "for (const target of" apps/admin/src/workflows/
+grep -rn "Promise.allSettled\|Promise.all\|p-limit\|pLimit" apps/admin/src/
+grep -rn "SCENE_EMBEDDING_CONCURRENCY\|TRANSCRIPT_EMBEDDING_CONCURRENCY" apps/admin/src/
+```
+
+## What To Build
+
+- Add `p-limit` to `apps/admin/package.json` if not present.
+- Replace the per-target `for…of` in `sceneEmbeddingBackfill.ts` and `transcriptEmbeddingBackfill.ts` with:
+
+  ```ts
+  const limit = pLimit(env.SCENE_EMBEDDING_CONCURRENCY ?? 10)
+  const settled = await Promise.allSettled(
+    targets.map((t) => limit(() => indexEditionScenes(t))),
+  )
+  // Map settled results to the existing outcomes[] shape (succeeded/skipped/failed).
+  ```
+
+- Add env vars `SCENE_EMBEDDING_CONCURRENCY` and `TRANSCRIPT_EMBEDDING_CONCURRENCY` to `apps/admin/src/config/env.ts` (zod-validated, optional, default 10). Surface in CLI output (`run-embeds.start` event).
+- Preserve the existing per-outcome shape (`{ action: "indexed" | "skipped_unchanged", … }` / `{ reason: "artifact_missing" | … }`). The change is internal; the GraphQL trigger response and CLI return JSON must be byte-identical except for ordering.
+- Update CLAUDE.md R1 + R2 subsections with the concurrency env-var name and the rule that the workflow uses `allSettled`, not `Promise.all`.
+
+## Constraints
+
+- **Do NOT** use bare `Promise.all` — one rejection would abort the entire batch (per the workflow-robustness solutions doc).
+- Per-target idempotency must remain intact: re-running any subset must produce identical DB state. Both workflows already use composite-key upserts; nothing to change.
+- Concurrency `N` must be env-tunable so prod can ramp conservatively (start at 5) while local can crank (20+).
+- Dispatch tests for `triggerSceneEmbeddingBackfill` and `triggerTranscriptEmbeddingBackfill` must stay green — no GraphQL surface change.
+- Outcome ordering may differ from sequential. If any test asserts specific ordering, it's a bug in the test (the documented contract is per-target isolation, not order); fix the test.
+
+## Verification
+
+- `pnpm --filter @forge/admin typecheck` ✓
+- `pnpm --filter @forge/admin lint` ✓
+- `pnpm --filter @forge/admin vitest run src/workflows/sceneEmbeddingBackfill src/workflows/transcriptEmbeddingBackfill` — all green; new test asserts that two intentionally-failing target promises do not abort the run.
+- Local benchmark: a `pnpm core-sync:run --full` followed by `pnpm run-embeds --pipeline=both --locale=en` completes meaningfully faster than the pre-change baseline (capture wall-time before/after).
+- New test asserts `pLimit` cap: with concurrency=2 and three targets that each take ≥10ms, the third target's start time is ≥ the first target's end time (timing assertion, generous epsilon).

--- a/docs/roadmap/content-discovery/feat-116-embed-backfill-s3-cache-and-batched-openrouter.md
+++ b/docs/roadmap/content-discovery/feat-116-embed-backfill-s3-cache-and-batched-openrouter.md
@@ -1,0 +1,104 @@
+---
+id: "feat-116"
+title: "Embed Backfill — Stage 2 — S3 Artifact Memoization + Batched OpenRouter Calls"
+owner: "nisal"
+priority: "P0"
+status: "not-started"
+start_date: "2026-05-06"
+duration: 2
+depends_on:
+  - "feat-115"
+blocks:
+  - "feat-117"
+tags:
+  - "admin"
+  - "ai-pipeline"
+  - "performance"
+  - "s3"
+  - "openrouter"
+---
+
+## Problem
+
+Two compounding inefficiencies in R1 (and R1's S3-side equivalent in R2):
+
+1. **`scene-analysis.json` is re-fetched per locale.** For a video with 30 locales, the same artifact lands from S3 thirty times. Manager's `embeddings.json` has the same shape for R2.
+2. **R1 makes one OpenRouter call per scene description.** `text-embedding-3-small` accepts up to **2,048 inputs per call**. At ~10-50 scenes per video × ~30 locales the current full backfill makes ~500k API calls. Batching all scenes for one `(video, locale)` into a single call cuts this to ~30k.
+
+Expected speedup: **5-10× R1 wall-time reduction**, **20-50× fewer OpenRouter API calls** (also lower per-call token-overhead cost), **~85% S3 read reduction**.
+
+## Entry Points — Read These First
+
+1. `apps/admin/src/services/scene-embedding.service.ts` — `indexEditionScenes(target)` reads the artifact and embeds per scene; this is where both fixes land.
+2. `apps/admin/src/services/transcript-embedding.service.ts` — R2 reads `embeddings.json` per language; same memoization pattern applies (no embedding batch — R2 reuses vectors).
+3. `apps/admin/src/services/embeddings.service.ts` — the OpenRouter provider; needs a new `embedBatch(strings: string[]): Promise<{ embeddings: number[][] }>` method.
+4. `apps/admin/src/storage/s3.ts` — the S3 read side; consider per-call caching at the storage layer (LRU keyed by S3 key) OR caller-level memoization in the workflow.
+5. `apps/admin/src/workflows/sceneEmbeddingBackfill.ts` — enumerator; reshape outer-loop to `(video, edition)` so artifact-fetch happens once per outer iteration.
+
+## Grep These
+
+```
+grep -rn "scene-analysis.json\|embeddings.json" apps/admin/src/
+grep -rn "embed(" apps/admin/src/services/embeddings.service.ts
+grep -rn "for (const target of\|targets.map(" apps/admin/src/workflows/
+```
+
+## What To Build
+
+### S3 cache (applies to both R1 and R2)
+
+Pick the simpler of two shapes:
+
+- **Per-workflow memoization (recommended):** in the workflow body, before `Promise.allSettled(targets.map(...))`, group targets by `(video, edition)` and pre-fetch the artifact once per group. Pass the already-loaded JSON down as a constructor arg to `indexEditionScenes` / `indexEditionTranscript`.
+- OR **Storage-layer LRU:** wrap `apps/admin/src/storage/s3.ts::getObject` with an LRU keyed by `(bucket, key)`. Bound size (~50 entries; each ~100KB JSON = ~5MB max). Either way, `MANAGER_ARTIFACTS_S3` reads must collapse 1 per `(video, edition)` instead of 1 per `(video, edition, locale)`.
+
+### Batched OpenRouter (R1 only)
+
+In `apps/admin/src/services/embeddings.service.ts`:
+
+```ts
+export async function generateExperienceEmbeddings(
+  inputs: string[],
+): Promise<{ embeddings: number[][] }> {
+  // Single OpenRouter / OpenAI call with `input: inputs[]`.
+  // Validate dimensions === 1536 on every returned vector.
+  // Fail fast on length mismatch (response.length !== inputs.length).
+}
+```
+
+In `scene-embedding.service.ts`:
+
+```ts
+// Before:
+for (const scene of scenes) {
+  const { embedding } = await provider.embed(scene.description)
+  await tx.videoSceneLocale.upsert({ ..., embedding })
+}
+
+// After:
+const { embeddings } = await provider.generateExperienceEmbeddings(
+  scenes.map((s) => s.description),
+)
+// embeddings[i] is the vector for scenes[i]; pass through to the per-scene upsert.
+```
+
+Preserve the existing per-call retry / model-stamp drift handling.
+
+## Constraints
+
+- **Vector ordering must be position-stable.** OpenRouter / OpenAI return embeddings in input order; assert this in tests with deterministic input strings and assert specific embedding vector indices.
+- **Dimension validation stays:** `embedding.length === 1536` per row; reject the whole batch and surface as `failed` per-target if any vector is wrong-dimensioned.
+- **Don't change the per-target outcome shape.** Today: `{ action: "indexed", embeddingsWritten: N, … }`. After batching, `embeddingsWritten` is still the count of rows written; the value just comes from one batched call instead of N single calls.
+- **R2 does not get the OpenRouter batch.** R2 reuses vectors from `embeddings.json` — no provider call. Only the S3 cache applies to R2.
+- **Embeddings provider rate limits:** OpenRouter's `text-embedding-3-small` allows large batches but has per-minute rate limits. The batched call still counts as one request. With `feat-115`'s p-limit at concurrency=10 we now make 10 batched calls in flight simultaneously instead of N×10 single calls — net reduction in rate-limit pressure.
+
+## Verification
+
+- `pnpm --filter @forge/admin typecheck` ✓
+- `pnpm --filter @forge/admin lint` ✓
+- New tests:
+  - S3 cache: a single `indexEditionScenes` invocation against a 5-locale `(video, edition)` group results in exactly **one** `s3.getObject` call (mocked).
+  - Batched embed: `generateExperienceEmbeddings(["a","b","c"])` issues one provider call with `input: ["a","b","c"]` and returns 3 vectors in the same order. A length mismatch in the response surfaces as a typed error.
+  - End-to-end: `indexEditionScenes` for a 10-scene-per-locale fixture issues **one** OpenRouter call per locale (not 10).
+- Local benchmark vs the feat-115 baseline: `pnpm run-embeds --pipeline=scene --locale=en` against the same fixture set completes 5-10× faster.
+- `apps/admin/CLAUDE.md` R1 + R2 subsections updated to document the per-`(video, edition)` cache and the batched provider call.

--- a/docs/roadmap/content-discovery/feat-117-embed-backfill-bulk-sql-writes.md
+++ b/docs/roadmap/content-discovery/feat-117-embed-backfill-bulk-sql-writes.md
@@ -1,0 +1,100 @@
+---
+id: "feat-117"
+title: "Embed Backfill — Stage 3 — Bulk DB Writes via INSERT … ON CONFLICT"
+owner: "nisal"
+priority: "P0"
+status: "not-started"
+start_date: "2026-05-08"
+duration: 2
+depends_on:
+  - "feat-116"
+blocks:
+  - "feat-118"
+tags:
+  - "admin"
+  - "ai-pipeline"
+  - "performance"
+  - "postgres"
+  - "pgvector"
+---
+
+## Problem
+
+Per-row `tx.videoSceneLocale.upsert()` and `tx.videoTranscriptChunk.upsert()` cost ~5-15 ms each on a Railway DB. For a 50-scene × 30-locale video that's ~1,500 round-trips just for R1; the corpus aggregate is millions. Replacing with a single `Prisma.sql` template doing `INSERT … SELECT * FROM unnest(...) ON CONFLICT (...) DO UPDATE SET …` collapses each per-`(video, edition, locale)` write batch to one round-trip.
+
+Expected speedup: **10-50× write throughput**. Compounds with feat-115 (parallelism) + feat-116 (S3 cache + batched embeds) for the full effect.
+
+## Entry Points — Read These First
+
+1. `apps/admin/src/services/scene-embedding.service.ts` — current per-row upsert loop inside `prisma.$transaction`.
+2. `apps/admin/src/services/transcript-embedding.service.ts` — same shape for chunks.
+3. `apps/admin/src/db/pgvector.ts` — `toPgArray` and `toPgVector` helpers; needed for binding string[] and vector[] arrays as single PG-array literals (avoids the 32,767 prepared-statement parameter limit — see `docs/solutions/database-issues/postgres-prepared-statement-bind-variable-limit-32767-20260504.md`).
+4. `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md` — every new `$executeRaw` template needs SQL-shape assertions in tests, not just row-mapping checks.
+5. `docs/solutions/database-issues/prisma-raw-sql-enum-mapping-seam-20260504.md` — any enum-typed column in the raw SQL must use the lowercase `@map`'d DB literal, not the uppercase TS variant name. This bit us on `SourceTier` in feat-104's PR; do not regress.
+6. `apps/admin/src/services/core-sync/phases/sync-dubs.ts` (post-merge of refactor branch) — the array-bound `$executeRaw` soft-delete is the canonical example to mirror.
+
+## Grep These
+
+```
+grep -rn "videoSceneLocale.upsert\|videoTranscriptChunk.upsert" apps/admin/src/
+grep -rn "toPgArray\|toPgVector" apps/admin/src/
+grep -rn "ON CONFLICT" apps/admin/src/services/
+```
+
+## What To Build
+
+Replace per-row upserts with a single `$executeRaw` per `(video, edition, locale)` write batch. Sketch for R1:
+
+```ts
+// Bind every row's columns as parallel PG-array literals; UNNEST them server-side.
+const sceneIds = scenes.map((s) => s.videoSceneId)
+const localesArr = scenes.map(() => locale)
+const descriptions = scenes.map((s) => s.description)
+const embeddingTexts = scenes.map((s, i) => toPgVector(embeddings[i]))
+
+await tx.$executeRaw`
+  INSERT INTO video_scene_locale (
+    video_scene_id, locale, description, embedding, synced_at
+  )
+  SELECT * FROM unnest(
+    ${toPgArray(sceneIds)}::text[],
+    ${toPgArray(localesArr)}::text[],
+    ${toPgArray(descriptions)}::text[],
+    ${toPgArray(embeddingTexts)}::vector(1536)[],
+    ARRAY(SELECT NOW() FROM generate_series(1, ${scenes.length}))
+  )
+  ON CONFLICT (video_scene_id, locale)
+  DO UPDATE SET
+    description = EXCLUDED.description,
+    embedding   = EXCLUDED.embedding,
+    synced_at   = EXCLUDED.synced_at
+`
+```
+
+R2 mirrors the same shape against `video_transcript_chunk`.
+
+### Index considerations
+
+- pgvector HNSW index updates are per-row internally regardless of whether the insert is bulk or single-row; bulk insert helps with **round-trip cost**, not index-maintenance cost.
+- For an "operator-mode" full re-embed run, add an opt-in flag `--rebuild-indexes` that does `DROP INDEX video_scene_locale_embedding_idx → bulk INSERT → CREATE INDEX video_scene_locale_embedding_idx`. Out of scope for this ticket; flag as future enhancement.
+
+## Constraints
+
+- **Bind arrays via `toPgArray`, not as separate parameters.** Per `docs/solutions/database-issues/postgres-prepared-statement-bind-variable-limit-32767-20260504.md`. The whole point of this ticket is to keep parameter count constant in batch size.
+- **Lowercase enum literals only.** No `'CORE'`-style TS variant names in raw SQL. If `SourceTier` or any other `@map`'d enum appears in the new SQL, use the DB literal or an explicit `::"EnumType"` cast. Per `docs/solutions/database-issues/prisma-raw-sql-enum-mapping-seam-20260504.md`.
+- **Preserve generated-column behavior.** `video_scene_locale` does not currently have generated columns; `video_locale` does. If R2 writes touch a table with generated tsvector columns, the `INSERT` must omit them (Postgres rejects writes to generated columns).
+- **Vector serialization:** `toPgVector` already produces pgvector's canonical `[0.1,0.2,...]` text form. For an array of vectors, the wrapping `toPgArray` must NOT escape the brackets; verify with a fixture test that a multi-row insert round-trips correctly.
+- **Per-target idempotency stays:** `ON CONFLICT … DO UPDATE` preserves the upsert semantics. A re-run that produces the same input must produce the same row state.
+
+## Verification
+
+- `pnpm --filter @forge/admin typecheck` ✓
+- `pnpm --filter @forge/admin lint` ✓
+- New tests (per the raw-SQL invariant pattern):
+  - SQL-shape assertions: contains `INSERT INTO`, `unnest(`, `ON CONFLICT`, `DO UPDATE`, `vector(1536)[]` (R1) / `text[]` (R2).
+  - Bound-value count: `mock.calls[0][1..]` has exactly `K` parameters where `K` is the column count, regardless of `scenes.length` (the regression guard against re-introducing per-row binding).
+  - End-to-end against a docker / testcontainer Postgres (or live local DB if cleaner): bulk insert + idempotent re-run produces identical rows.
+  - Mixed insert + update fixture: half new scenes, half existing; `ON CONFLICT` correctly updates the existing rows.
+- Local benchmark: `pnpm run-embeds --pipeline=both --locale=en` finishes 1.5-3× faster than the feat-116 baseline (compound with prior stages).
+- Solutions doc: capture the bulk-insert-pgvector pattern as a new entry under `docs/solutions/database-issues/` so the next service to want bulk vector writes can reuse it. Reference the bind-var-limit and enum-seam docs.
+- `apps/admin/CLAUDE.md` R1 + R2 subsections updated.

--- a/docs/roadmap/content-discovery/feat-118-embed-backfill-content-hash-skip.md
+++ b/docs/roadmap/content-discovery/feat-118-embed-backfill-content-hash-skip.md
@@ -1,0 +1,145 @@
+---
+id: "feat-118"
+title: "Embed Backfill — Stage 4 — Content-Hash Skip for R1 + R2 Re-Runs"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-05-12"
+duration: 3
+depends_on:
+  - "feat-117"
+blocks: []
+tags:
+  - "admin"
+  - "ai-pipeline"
+  - "performance"
+  - "re-embed"
+  - "migration"
+---
+
+## Problem
+
+R1 (scene) and R2 (transcript) re-runs always recompute every embedding. R1 in particular pays full OpenRouter cost on every re-run regardless of whether the scene description text changed. R3 (Experience content dump) already proved the better pattern: a `cms_content_hash` SHA-256 column gates rerun-skip and downstream re-dispatch. Porting that pattern to R1/R2 makes re-embed runs **near-instant** for unchanged content — the killer feature for periodic re-embeds, model upgrades, and partial-corpus re-runs.
+
+Expected effect: re-embed runs that touch the same descriptions / chunks finish in seconds rather than hours, costing $0 in OpenRouter charges.
+
+## Entry Points — Read These First
+
+1. `apps/admin/src/services/experience-content-dump.service.ts` — R3's `cms_content_hash` logic. The pattern to port.
+2. `apps/admin/CLAUDE.md` "Experience content dump (R3)" subsection — describes how the hash gates skip and re-dispatch.
+3. `apps/admin/src/services/scene-embedding.service.ts` and `transcript-embedding.service.ts` — where the new hash check lands.
+4. `apps/admin/prisma/schema.prisma` — needs new nullable `content_hash` columns on `VideoSceneLocale` and `VideoTranscriptChunk`.
+5. `apps/admin/prisma/migrations/` — new migration adding the columns + a partial index for fast lookup. Must be additive (forward-only).
+
+## Grep These
+
+```
+grep -rn "cms_content_hash\|contentHash" apps/admin/src/services/
+grep -rn "VideoSceneLocale\|VideoTranscriptChunk" apps/admin/prisma/schema.prisma
+grep -rn "OPENROUTER_API_KEY\|generateExperienceEmbedding" apps/admin/src/
+```
+
+## What To Build
+
+### Schema migration
+
+```sql
+-- migration: add content_hash columns + indexes
+ALTER TABLE video_scene_locale
+  ADD COLUMN content_hash TEXT;
+CREATE INDEX video_scene_locale_content_hash_idx
+  ON video_scene_locale (content_hash) WHERE content_hash IS NOT NULL;
+
+ALTER TABLE video_transcript_chunk
+  ADD COLUMN content_hash TEXT;
+CREATE INDEX video_transcript_chunk_content_hash_idx
+  ON video_transcript_chunk (content_hash) WHERE content_hash IS NOT NULL;
+```
+
+Update `schema.prisma` to add `contentHash String? @map("content_hash")` on both models. NEVER expose via GraphQL (`schema.test.ts` `embed|vector|similarit|content_*hash`-pattern guard).
+
+### Hash computation
+
+```ts
+import { createHash } from "node:crypto"
+
+const MODEL_NAME = "text-embedding-3-small"
+const HASH_VERSION = "v1"
+
+export function computeSceneContentHash(description: string): string {
+  return createHash("sha256")
+    .update(`${HASH_VERSION}|${MODEL_NAME}|${description}`)
+    .digest("hex")
+}
+```
+
+Versioned envelope: `HASH_VERSION` lets a future hashing-algorithm change invalidate prior hashes without ambiguity. Model name is included so a model upgrade naturally invalidates skips.
+
+### Skip check (R1 example)
+
+```ts
+// In indexEditionScenes, before calling the embedding provider:
+const expectedHashes = scenes.map((s) => computeSceneContentHash(s.description))
+const existing = await tx.videoSceneLocale.findMany({
+  where: {
+    videoSceneId: { in: scenes.map((s) => s.videoSceneId) },
+    locale,
+  },
+  select: { videoSceneId: true, contentHash: true },
+})
+const existingHashByScene = new Map(
+  existing.map((e) => [e.videoSceneId, e.contentHash]),
+)
+
+const scenesToEmbed = scenes.filter(
+  (s, i) => existingHashByScene.get(s.videoSceneId) !== expectedHashes[i],
+)
+const scenesToSkip = scenes.length - scenesToEmbed.length
+
+if (scenesToEmbed.length === 0) {
+  return {
+    action: "skipped_unchanged",
+    embeddingsWritten: 0,
+    scenesSkipped: scenes.length,
+  }
+}
+
+// Else: batch-embed scenesToEmbed only, then bulk-upsert (per feat-117 shape) writing
+// content_hash alongside description + embedding.
+```
+
+R2 mirrors the same shape against `(transcript_id, chunk_index)` keyed by chunk text content.
+
+### Outcome shape
+
+Extend the per-target outcome union with a `skipped_unchanged` action:
+
+```ts
+{ action: "skipped_unchanged", embeddingsWritten: 0, scenesSkipped: N }
+{ action: "indexed", embeddingsWritten: K, scenesSkipped: M }  // partial-skip case
+```
+
+Top-level workflow stats already track `succeeded` / `skipped` / `failed`; the `skipped_unchanged` action increments `succeeded` (the work was successful, just no-op).
+
+## Constraints
+
+- **Forward-only migration.** No DROP / RENAME. The columns are nullable with no default; existing rows simply have `content_hash IS NULL` and are treated as "needs re-embed on next run" until the first re-embed populates the hash.
+- **Hash MUST include model name + a version marker.** A model upgrade or hash-algorithm change naturally invalidates the entire cache without operator intervention.
+- **content_hash is NEVER exposed via GraphQL.** Add it to the existing `embed|vector|similarit`-pattern guard in `apps/admin/src/graphql/schema.test.ts` (extend to also reject `content_hash`).
+- **Partial-skip path matters.** A typical re-run will see most scenes hash-match (skip) and a handful hash-miss (re-embed). The batched OpenRouter call (feat-116) must accept `scenesToEmbed.length` inputs, not the full set.
+- **Soft-delete safety unchanged.** This ticket does not touch the soft-delete path (R1/R2 do not soft-delete today; both are re-derive-from-source pipelines).
+- **R2 hash content is the chunk text.** R2 today reuses vectors verbatim from manager's `embeddings.json`; the savings here are DB-write churn (not OpenRouter). Worth doing even at lower magnitude because R2 does fire bulk writes.
+
+## Verification
+
+- `pnpm --filter @forge/admin typecheck` ✓
+- `pnpm --filter @forge/admin lint` ✓
+- Migration applies cleanly: `pnpm prisma migrate deploy` against a fresh DB AND against the populated `forge_admin` local DB (no destructive changes).
+- New tests:
+  - `computeSceneContentHash` is deterministic, version-prefixed, model-name-dependent.
+  - Re-embed of an unchanged target returns `{ action: "skipped_unchanged", scenesSkipped: N }` and makes ZERO OpenRouter calls (provider mock asserts not called).
+  - Re-embed of a partially-changed target re-embeds only the changed scenes (provider mock receives only the changed inputs in the batch).
+  - GraphQL leak guard extended: `content_hash` field never appears in the schema.
+- End-to-end local re-run benchmark: `pnpm run-embeds --pipeline=both --locale=en` immediately after a green run completes in seconds with `OpenRouter requests: 0`.
+- Solutions doc: capture this as a new entry under `docs/solutions/best-practices/` describing the content-hash skip pattern (reference R3 as the precedent and link the previous embed-backfill performance tickets).
+- `apps/admin/CLAUDE.md` R1 + R2 subsections gain a "Re-runs are incremental — only re-embed when content_hash changes" bullet.


### PR DESCRIPTION
## Summary

Adds the four-ticket queue capturing the embed-backfill performance refactor sequence. These were scoped during today's diagnostic session against the 209k-variant catalogue we just synced — see PR #879 for the dub-sync hardening that unblocked R1/R2 enumeration in the first place.

| Ticket | Priority | Start | Duration | Title |
|---|---|---|---|---|
| feat-115 | P0 | 2026-05-04 | 1d | Bounded Parallelism on Per-Target Loop |
| feat-116 | P0 | 2026-05-06 | 2d | S3 Artifact Memoization + Batched OpenRouter Calls |
| feat-117 | P0 | 2026-05-08 | 2d | Bulk DB Writes via INSERT … ON CONFLICT |
| feat-118 | P1 | 2026-05-12 | 3d | Content-Hash Skip for Re-Runs |

## Why these are now the immediate priority

Today's local dub-sync gave us a fully-populated `forge_admin` (1,088 videos, 209k variants) and we kicked off `pnpm run-embeds --pipeline=both`. Wall time at the current sequential per-target shape projects to many hours for a full multi-locale backfill. The user expects to re-run periodically (model upgrades, content edits) — making re-runs incremental is the long-term win.

Combined effect of the four PRs:
- **Initial backfill:** projected 50-200× speedup
- **Subsequent re-runs of unchanged content:** seconds + $0 OpenRouter cost (vs. hours + ~$0.50)

## Bidirectional dependency chain

`115 → 116 → 117 → 118` — each `depends_on` the prior; each `blocks` the next. The roadmap viewer auto-marks downstream tickets as `blocked` until dependencies complete.

## What's in each ticket body

Per CLAUDE.md roadmap conventions: Problem / Entry Points / Grep These / What To Build (with code sketches) / Constraints (cross-referencing the relevant solutions docs we wrote during the dub-sync session — bind-var limit, enum-mapping seam, parallel-workflow robustness) / Verification gates.

## Why P1 not P0 on feat-118

Content-hash skip is the highest long-run value but only matters once you start re-running. The first three PRs (115/116/117) speed up the *initial* backfill, which is the immediate pain. Stage 4 makes *every subsequent re-run* near-free. P0 is reserved for the things blocking the next backfill cycle; P1 captures "ship after first re-run pain hits."

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a docs-only change. Tickets are tracking artifacts; behavioral validation lives on the implementation PRs.

## Testing

No code changes. The ticket body Markdown is human-readable and the README index entries are visually checked against the existing table format.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7, 1M context, extended thinking)