### PR TITLE
feat(graphql): consumer migration parity harness (Unit 4)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -2,6 +2,9 @@
   "name": "@forge/admin",
   "private": true,
   "version": "0.0.1",
+  "exports": {
+    "./domain/blocks": "./src/domain/blocks.ts"
+  },
   "scripts": {
     "dev": "next dev --port 3003",
     "build": "next build",

--- a/docs/plans/2026-05-07-002-feat-consumer-migration-parity-harness-unit-4-plan.md
+++ b/docs/plans/2026-05-07-002-feat-consumer-migration-parity-harness-unit-4-plan.md
@@ -1,0 +1,583 @@
+---
+title: "feat: response parity harness for consumer migration (Unit 4)"
+type: feat
+status: active
+date: 2026-05-07
+deepened: 2026-05-08
+origin: docs/brainstorms/2026-05-05-consumer-migration-implementer-brief-requirements.md
+roadmap: docs/roadmap/platform/feat-104-admin-core-consumer-migration-plan.md
+---
+
+# feat: response parity harness for consumer migration (Unit 4)
+
+## Summary
+
+Implementation plan for Unit 4 of the consumer-side Strapi → admin migration: a fixture-driven response parity harness in `packages/graphql/src/parity/` that normalizes Strapi and admin GraphQL responses to one shared route shape and emits a structured, deterministic diff classified across four classes (structural, value, order, semantic) per R12a. Lands as a standalone foundational PR with no consumer-side code attached. Initial scope is the canary route's `experienceBySlug` operation; fixtures expand per-route as U5 ramps.
+
+---
+
+## Problem Frame
+
+U5's canary opens behind `dual-read` mode, where Strapi keeps rendering the user-facing response while admin is fetched in parallel for parity logging. Without a comparator, "logged" means nothing — there is no signal to gate canary progression on, no PR evidence, and no rollback trigger. U4 ships the comparator that turns the parallel fetch into an actionable signal, before U5's dual-read mode goes live.
+
+The comparator faces three traps that would silently produce wrong answers if not handled deliberately:
+
+- Strapi v5 caps nested relations at 10 rows by default (`docs/solutions/performance-issues/strapi-nested-relation-truncation-and-n-plus-one-manager-20260328.md`). A naive harness would flag every truncated tail as drift, masking real differences in noise.
+- Strapi serves images as root-relative paths (`/images/...`); admin enforces `z.string().url()` (absolute). Without canonicalization-first, every image field produces a false-positive value diff.
+- The Strapi locale-priority logic has caused a production wrong-language watch-page incident (`docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md`). A locale-correctness check that compares raw locale arrays misses the real bug — which is whether the locale selector picked the right variant.
+
+These traps shape the harness contract: canonicalize-then-diff, not diff-then-explain; capture fixtures with explicit `pagination: { limit: -1 }` on every nested relation; locale correctness is resolved-locale equality (both sides' resolved `locale` field equals the URL locale).
+
+---
+
+## Requirements
+
+- R1. Parity comparator lives in `packages/graphql` and compares normalized route data (not raw GraphQL JSON) between Strapi and admin sources. Traces to brief R12.
+- R2. Diff output classifies mismatches across four classes — structural, value, order, semantic. Each class has at least one hand-rolled fixture covering a known-bad scenario. Structural and semantic mismatches are blocking; value and order mismatches are configurable per route. Traces to brief R12a.
+- R3. Comparator is fixture-driven first. A live-comparison entry point exists but is env-gated and off by default — only used after the fixture suite passes and the canary's auth/env wiring is stable. The harness lands before or in the same PR as U5's `dual-read` mode. Traces to brief R13.
+- R4. Comparator output is structured, deterministic across runs, and suitable as PR evidence — no timestamp noise, stable field ordering, JSON-serializable. Traces to brief R14.
+- R5. `packages/graphql/` gains a Vitest test runner — this is the package's first runtime test surface. The harness test suite is the first runtime test in the package.
+- R6. Fixtures are two-tier: hand-rolled per-branch fixtures (one per diff class, plus per-block-discriminator coverage) and at least one captured-from-live fixture per diff class. Captured fixtures come from the upstream source (raw Strapi/admin responses), never from the normalizer being tested.
+- R7. The harness's deletion contract is documented in a top-of-file checklist in `packages/graphql/src/parity/index.ts` on the first PR — keyed to consumer-migration cutover. Mirrors `docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md`.
+- R8. Strapi-side fixture-capture queries explicitly set `pagination: { limit: -1 }` on every nested relation array inside block fragments (placement is on `quotes`, `items`, `slots[].content`, `questions`, `infoBlocks.blocks`, etc. — not the top-level `experiences` query, since the canary's by-slug path returns one experience and the dynamic-zone `blocks` field has no pagination arg). Truncation detection in fixture mode trusts the capture-time `-1` guarantee; live mode reads response metadata (`pagination.total > returned.length`) when available. Length-10 alone is NOT a trigger. When `potentiallyTruncated` is set, the differ reclassifies missing-tail entries on that side out of the structural class into a separate `potentially-truncated` channel.
+- R9. URL canonicalization runs before the differ. Both sides pass through one canonicalizer that produces an absolute https form; raw input values are preserved in the diff record so reviewers can see what each side returned.
+- R10. The semantic class's locale-correctness check is **resolved-locale equality**: both sides' resolved `locale` field must equal the URL locale. When Strapi falls back to a different locale because content is missing, its resolved `locale` field diverges and the semantic class fires. (This replaces an earlier "selector output identity" framing — `experienceBySlug` returns already-resolved `ExperienceLocale`, not a list of variants the selector picks from.)
+
+**Origin acceptance examples carried forward:**
+
+- AE5 (covers brief R6, R6a, R12, R12a) — given a canary experience whose admin record contains every supported block variant, the harness's normalizer + differ produce an empty diff across all four classes against the Strapi response for the same logical experience. Covered by U6 captured fixtures.
+
+---
+
+## Scope Boundaries
+
+> Note: this plan's local Implementation Units are numbered U1-U6. The references below to feat-104's Units 1, 5, 6, 7 are the _parent_ migration plan's units (`docs/plans/2026-04-22-001-feat-admin-core-consumer-migration-plan.md`), not this plan's. Disambiguated explicitly.
+
+- feat-104's Unit 1 (consumer query inventory) — landed on main 2026-05-07 via PR #907 at `docs/admin-core-migration/query-inventory.md`. The inventory is the source of truth for which consumer operations need eventual U4 fixture coverage during feat-104's Unit 5 expansion; this plan does not duplicate or re-derive that surface. Field-level `?` parity tags in the inventory are explicitly designated to be resolved by _this_ plan's harness during expansion — surfacing alignment, not scope creep
+- feat-104's Unit 5 canary code — content-source flag (`FORGE_CONTENT_API`), runtime block adapter (consumer-app side), `dual-read` wiring, route-level integration, ISR / metadata behavior
+- feat-104's Unit 7 runbook, observability dashboards, threshold definitions (R18a)
+- Property-test or generated-fixture approach — origin lean is pure-data; revisit only if hand-rolled fixture volume becomes intractable
+- Mobile / TV normalizer parity (separate fixture sets and normalizers in feat-104's Unit 6)
+- Live admin auth wiring beyond what anonymous PUBLIC `experienceBySlug` already supports
+- Comparator coverage for routes beyond the canary — added per-route during feat-104's Unit 5 expansion, not in this plan
+- Adding a CI parity job — lives in feat-104's Unit 7 or alongside feat-104's Unit 5 canary PR; this plan ships the harness, not its automation
+- Re-capturing fixtures on a schedule — sequencing of fixture-staleness handling deferred to feat-104's Units 5 and 7
+
+### Deferred to Follow-Up Work
+
+- Per-route fixture sets for homepage, watch-video, watch-video-by-slug, search, recommendations — added in their respective feat-104 Unit 5 expansion PRs
+- A CI job that runs the live-mode comparator against staged admin — feat-104's Unit 7
+- Apollo persisted-cache parity for mobile / TV — feat-104's Unit 6 (gated on R16 cache-invalidation experiment)
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/graphql/src/index.ts` — barrel re-exports for `graphql` (Strapi) and `adminGraphql` (admin) factories; the harness adds a third subpath export `./parity`
+- `packages/graphql/src/graphql.ts`, `packages/graphql/src/admin.ts` — dual-client factory pattern; harness reuses both factories for typed query documents
+- `packages/graphql/src/__tests__/dual-client.types.ts` — typecheck-only AE1 isolation pattern; the harness adds a parallel `.types.ts` proof that a normalized Strapi result and a normalized admin result are not interchangeable structurally
+- `apps/web/src/lib/content.ts` — canonical canary read path (`resolveWatchPage`); the existing single normalization seam returning `ResolvedWatchPage`. The harness's `NormalizedExperienceRoute` shape is informed by this contract but is not the same type — the consumer-app adapter (U5) and the harness normalizer have different jobs
+- `apps/web/src/lib/fragments/watch-experience.ts` — Strapi block fragment composition; the source of the 16-type Strapi component inventory the discriminator mapping table covers
+- `docs/admin-core-migration/query-inventory.md` — the U1-landed inventory enumerating every `graphql(` and raw `gql\`\`` callsite in web/mobile/TV with per-field parity tags (`direct-admin-parity`/`adapter-required`/`missing`/`intentionally-deprecated`/`?`). The harness's per-route fixture set during feat-104's Unit 5 expansion is driven from this inventory; the inventory's field-level `?`tags are this harness's job to resolve. Note: admin's currently-PUBLIC queries are exactly four —`experienceBySlug`, `searchExperiences`, `search`(NOT`hybridSearch`— admin's wire field is`search`), `sceneRecommendations`
+- `apps/admin/src/domain/blocks.ts` — admin's Zod `BlocksSchema`. The admin-side normalizer imports this from `@forge/admin` to recover types from the opaque `JSON` `blocks` field on `experienceBySlug`. **Seventeen** `t`-discriminated kinds; sixteen map 1:1 to Strapi components, plus admin-only `videoRecommendations` (per `apps/admin/src/domain/blocks.ts:355-360` — "forward-looking", no Strapi precedent). The discriminator-map's bidirectional totality test asserts 16 admin↔Strapi entries; `videoRecommendations` is enumerated separately as an `adminOnlyKinds` list with admin-only fixtures
+- `apps/admin/src/graphql/types/experience.ts` — admin's `experienceBySlug` resolver, `authScopes: { public: true }`, `blocks` exposed as the generic `JSON` scalar
+- `apps/web/src/lib/content.test.ts` — Vitest mock pattern (`vi.mocked(queryMock).mockResolvedValueOnce(...)`); the canonical mock-shape precedent the harness follows for hand-rolled fixtures
+- `.github/workflows/ci.yml` (admin-schema-drift, graphql-generate jobs) — regen-then-diff pattern, relevant when U7 or U5 wires the CI job
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md` — hand-rolled fixtures alone are insufficient; the harness needs at least one captured-from-live fixture per diff class to prove production contract, not just branch shape
+- `docs/solutions/best-practices/producer-consumer-report-file-contract-pattern-20260506.md` — Strapi `__typename` ↔ admin `kind` discriminator drift; pick one canonical literal-set (admin's `kind`) and normalize before diffing
+- `docs/solutions/performance-issues/strapi-nested-relation-truncation-and-n-plus-one-manager-20260328.md` — Strapi v5 caps nested relations at 10; fixture-capture queries must set `pagination: { limit: -1 }`; runtime-captured arrays of length 10 are flagged as potentially-truncated
+- `docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md` — locale-correctness compares selector output, not raw arrays
+- `docs/solutions/integration-issues/mobile-relative-image-url-no-base-origin-20260408.md` — URL canonicalization is normalize-then-diff; both sides pass through `canonicalizeUrl(raw, { schema })` before the differ runs
+- `docs/solutions/architecture-patterns/dual-client-gql-tada-multi-schema-codegen-pattern-20260507.md` — harness reuses the existing `graphql()` and `adminGraphql()` factories from `@forge/graphql`; does not introduce a third factory
+- `docs/solutions/cms/admin-app-data-model-decisions.md` — source of the expected-divergence allow-list; entries not on the list are real drift
+- `docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md` — top-of-file deletion checklist in `parity/index.ts` on PR1, keyed to consumer-migration cutover
+- `docs/solutions/best-practices/nextjs-route-shape-migration-cross-cutting-contract-drift-20260430.md` — fixture provenance: capture from upstream raw responses, not from the normalizer being validated (avoid circularity)
+- `docs/solutions/best-practices/graphql-callsite-inventory-dual-pattern-sweep-20260507.md` — landed 2026-05-07 alongside U1 inventory: any consumer-callsite sweep must dual-grep `graphql(` AND `gql\`` to catch raw Apollo template literals. The harness's capture script and any future per-route fixture-add automation must dual-sweep, not gql.tada-only
+
+---
+
+## Key Technical Decisions
+
+- **Pure-data normalizers + custom JSON-serializable differ.** No third-party deep-diff dependency. Rationale: origin's lean (R12 framing); the four diff classes per R12a need bespoke logic anyway (semantic class compares selector output, not just deep equality), and a generic differ would only handle one of four classes well. Custom differ also produces directly-PR-quotable JSON without post-processing.
+
+- **Admin's `kind` enum is the canonical discriminator.** Strapi `__typename` is mapped to admin `kind` in the Strapi normalizer before diffing. Rationale: admin is the migration target — normalizing Strapi → admin reduces churn when the harness retires; alternatives (canonicalize to a third name, or keep both forms) double the cognitive load on diff readers and make the deletion checklist messier.
+
+- **URL canonicalization is normalize-then-diff, not diff-then-explain.** Both sides pass through one canonicalizer before the differ; raw input values are preserved in the diff record. Rationale: alternative produces an unmanageable false-positive rate on every image field. Per `docs/solutions/integration-issues/mobile-relative-image-url-no-base-origin-20260408.md`.
+
+- **Locale correctness is resolved-locale equality, not selector-output identity.** Both sides' resolved `locale` field must equal the URL locale. Rationale: admin's `experienceBySlug(locale, slug)` returns `ExperienceLocale` (the locale-resolved row, no `localizations` array); Strapi's `experiences(filters, locale)` returns an Experience with the requested locale already applied. Neither side returns "a list of variants the selector picks from," so the original "selector output identity" framing was incompatible with the actual return shapes (per doc-review FEAS-3 + ADV-004). The resolved-locale check still catches the prod wrong-language incident: when Strapi falls back to a different locale because content is missing, its resolved `locale` field diverges from the URL locale and the semantic class fires. No separate locale-selector module is needed — the check is a field comparison in the differ.
+
+- **Strapi fixture-capture queries explicitly set `pagination: { limit: -1 }` on every nested relation array inside block fragments.** The placement is on the nested relation arrays inside each block component — not the top-level `experiences` query, since the canary's by-slug path returns one experience and the dynamic-zone `blocks` field has no pagination arg. Specifically: `bibleQuotesCarousel.quotes`, `mediaCollection.items`, `container.slots` (and slot-level `content`), `relatedQuestions.questions`, `infoBlocks.blocks` (the InfoBlocks one — distinct from the dynamic-zone Experience.blocks), `videoCarousel.items`, `navigationCarousel.items`. The capture script defines its OWN fragments separate from `apps/web/src/lib/fragments/watch-experience.ts` because the production fragments do not set this override. The Strapi normalizer's truncation-detection heuristic relies on response metadata (e.g., `pagination.total > returned.length` when available, or trusting the capture-time `-1` guarantee for fixture mode) — NOT on raw `length === 10`. Rationale: per doc-review FEAS-4, length-10 alone conflates "Strapi cap-truncated" with "happens-to-be-cap-sized"; the heuristic mis-classifies legitimate 10-item collections. Relying on capture-time guarantees + response meta avoids the false positive while still catching real truncation in live mode.
+
+- **Two-tier fixtures: hand-rolled per-branch + captured-from-live per class.** Hand-rolled fixtures cover branch shape (each diff class, each block discriminator); captured fixtures cover production contract. Captured fixtures are taken from raw Strapi / admin responses, never from the normalizer under test. Rationale: per `mocked-shape-vs-real-contract-discipline-20260506.md` and `nextjs-route-shape-migration-cross-cutting-contract-drift-20260430.md`.
+
+- **Admin block validation reuses `BlocksSchema` from `@forge/admin`, exposed via a new subpath export on admin's `package.json`.** The admin normalizer imports the Zod schema and runs it against the opaque `JSON` `blocks` field. Admin's `package.json` gains an `exports` entry for `./domain/blocks` (and an `exports` map if none exists today). Rationale: alternative #1 (duplicating the Zod schema into `packages/graphql`) creates two sources of truth for block shape and guarantees drift; rejected. Alternative #2 (TypeScript path mapping in `packages/graphql/tsconfig.json`) works at compile time but bypasses pnpm's workspace resolution and surprises tooling that follows package boundaries; rejected. Subpath export is the canonical way to expose admin's stable contract to a workspace sibling. **No import cycle exists**: admin does not import from `@forge/graphql`, and `@forge/admin` is already a `packages/graphql` devDep (added in U3 for schema codegen) — verified during planning.
+
+- **Expected-divergence allow-list is a static structured TS object with rationale per entry.** Seeded from `docs/solutions/cms/admin-app-data-model-decisions.md`. Rationale: makes "why this divergence is fine" reviewable in code, prevents the allow-list from becoming a sink for un-investigated diffs.
+
+- **Live-comparison mode is env-gated and off by default.** Activated by `FORGE_PARITY_LIVE=1` plus configured Strapi + admin endpoints. Rationale: keeps fixture mode fast and offline; matches R13's gating.
+
+- **Admin GraphQL endpoint URL varies by environment; production auth host is on the harness blocklist.** Locally, admin's GraphQL endpoint is `http://localhost:3003/api/graphql` (per `apps/admin/package.json`'s `next dev --port 3003`). In production it's `https://admin.jesusfilm.org/api/graphql`. PR #909 (2026-05-07) split admin's auth flows onto `auth.jesusfilm.org`; `apps/admin/src/proxy.ts` is staged to return 404 for any `/api/*` request hitting the auth host (note: not yet wired as middleware as of 2026-05-08 — the proxy function exists but no `apps/admin/middleware.ts` invokes it). The capture script and live-mode entry point's `FORGE_ADMIN_URL` validation: **reject** `auth.jesusfilm.org` and other known non-admin hosts; **allow** any other URL. A positive admin-host match would block legitimate localhost / preview / Railway service URLs. Note: `AUTH_TRUSTED_ORIGINS` (Better Auth login callbacks) is orthogonal to anonymous PUBLIC GraphQL reads — only `CORS_ALLOWED_ORIGINS` on `apps/admin/src/app/api/graphql/route.ts` gates harness traffic.
+
+- **`./parity` subpath export on `@forge/graphql`.** Internals are addressable only via the subpath. Rationale: keeps the harness's surface explicit and enumerable, matches the existing `./graphql` and `./admin` pattern from U3, and makes the deletion checklist a single import-graph search.
+
+- **Deletion contract ships in PR1 as a top-of-file checklist** in `packages/graphql/src/parity/index.ts`. Rationale: per `throwaway-operator-harness-deletion-contract-20260430.md` — bake retirement into the harness from day one.
+
+- **Container shape divergence is flattened on the Strapi side, not regrouped on the admin side.** Strapi: `Container { slots: [{ gridSpan, spans, content: [DynamicZone] }] }` (two-level nesting). Admin: `container.content[]` flat array containing `containerSlot` markers as siblings to actual content blocks (see `apps/admin/src/domain/blocks.ts:453-464`). The Strapi normalizer flattens `slots[].content[]` into the admin shape, emitting synthetic `containerSlot` entries that preserve `gridSpan` and `spans`. Rationale: per doc-review FEAS-2 — without explicit handling, every container produces false-positive structural diffs. Admin is the migration target; flattening Strapi to match admin (rather than regrouping admin to match Strapi) reduces churn at harness retirement. Section blocks containing nested zones use the same flatten rule.
+
+- **Diff path grammar is RFC6901 JSON Pointer with numeric-aware sort.** Every diff entry's path is serialized as a JSON Pointer (e.g., `/blocks/3/items/0/url`), with the `~` and `/` escape rules from RFC6901. Sort is numeric-aware — segments that parse as non-negative integers compare numerically (so `/blocks/2` precedes `/blocks/10`, not the lexicographic reverse). Rationale: per doc-review ADV-001 — without an explicit grammar, two normalizer authors emit divergent path formats and lexicographic sort produces visually-confusing reports. RFC6901 is the standard, library-supported, and unambiguous; numeric-aware sort matches reviewer expectations. A test asserts a specific path string for a nested-array entry, not just byte-stability.
+
+- **Absent-field contract: optional fields normalize to `null`; both `undefined` and missing keys map to `null`.** The `NormalizedExperienceRoute` type's optional fields (e.g., `description`, `ogImage`, nested block fields) carry `null` when absent on either side; the differ treats `null` and "missing key" as equivalent post-normalization. Rationale: per doc-review ADV-008 — Strapi `ogImage: null` vs admin field-absent (returned as `undefined`) without an explicit contract either over-reports false positives on every absent optional field or silently equates meaningful-null with meaningful-absent. The `null` convention is documented in `shared-shape.ts` JSDoc; both normalizers enforce it; cross-product tests assert `undefined`/missing keys/explicit `null` all produce the same normalized output.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Implementation pattern**: pure-data normalizers + custom differ (origin lean confirmed)
+- **Canonical discriminator**: admin's `kind` enum
+- **Fixture provenance**: captured from raw upstream responses
+- **Block validation source**: `BlocksSchema` imported from `@forge/admin` via a new subpath export on admin's `package.json`
+- **Workspace cycle check**: verified during planning — admin does not import from `@forge/graphql`; `@forge/admin` is already a devDep of `packages/graphql` (added by U3 for schema codegen). Adding `BlocksSchema` import to the parity module does not introduce a cycle
+- **Live-mode gating**: env-gated, off by default
+- **Subpath export**: `@forge/graphql/parity`
+- **Test runner**: Vitest, added to `packages/graphql/` as part of this PR
+- **Discriminator count**: 16 shared (Strapi ↔ admin); admin-only `videoRecommendations` enumerated separately in `adminOnlyKinds` set; map totality test imports `BlocksSchema` to surface new admin kinds (resolves doc-review FEAS-1 + ADV-002)
+- **Container shape divergence**: Strapi flatten — Strapi's `container.slots[].content[]` flattens to admin's flat `container.content[]` with synthetic `containerSlot` markers (resolves doc-review FEAS-2)
+- **Locale correctness framing**: resolved-locale equality (both sides' `locale` field equals URL locale), not selector-output identity. No locale-selector module needed (resolves doc-review FEAS-3 + ADV-004)
+- **Truncation heuristic**: capture-time `pagination: { limit: -1 }` guarantee in fixture mode; response-meta in live mode (`pagination.total > returned.length`); length-10 alone is NOT a trigger (resolves doc-review ADV-005)
+- **Diff path grammar**: RFC6901 JSON Pointer with numeric-aware segment sort (resolves doc-review ADV-001)
+- **Absent-field contract**: optional fields normalize to `null` on absence; `undefined` and missing keys both → `null` (resolves doc-review ADV-008)
+
+### Deferred to Implementation
+
+- **Base origin for URL canonicalizer**: likely an env var read at canonicalizer construction (`FORGE_STRAPI_PUBLIC_ORIGIN` or similar); the exact var name and whether it has a sensible default for fixture mode is decided during implementation
+- **Capture-script location**: `packages/graphql/scripts/capture-parity-fixture.ts` vs root-level `scripts/`. Defer; the script is dev-only tooling and either location works
+- **Sanitization rules for captured fixtures**: which fields (auth headers, IDs, internal-only timestamps) get redacted on capture. Defer until first capture run reveals concrete cases
+- **Whether the canary route's captured fixture lives in this PR or the U5 canary PR**: leaning _this PR_ with placeholder route name parameterized; U5 canary PR adds the real route's captured fixture set. Resolve when U5 canary route is selected
+
+---
+
+## Output Structure
+
+    packages/graphql/
+    ├── package.json                                # adds vitest devDep + test script
+    ├── vitest.config.ts                             # new
+    ├── src/
+    │   ├── index.ts                                 # adds ./parity subpath re-export (no behavior change to existing exports)
+    │   └── parity/
+    │       ├── index.ts                             # public surface + top-of-file deletion checklist
+    │       ├── shared-shape.ts                      # NormalizedExperienceRoute type
+    │       ├── canonicalize-url.ts                  # URL canonicalizer
+    │       ├── discriminator-map.ts                 # Strapi __typename ↔ admin kind table (16 entries; videoRecommendations admin-only)
+    │       ├── path-pointer.ts                      # RFC6901 JSON Pointer encode + numeric-aware sort comparator
+    │       ├── normalize-strapi.ts                  # Strapi response → NormalizedExperienceRoute (handles container.slots[].content[] flatten)
+    │       ├── normalize-admin.ts                   # admin response → NormalizedExperienceRoute (via BlocksSchema)
+    │       ├── compare.ts                           # 4-class differ
+    │       ├── allow-list.ts                        # expected-divergence allow-list
+    │       ├── live.ts                              # env-gated live-mode entry point
+    │       ├── canonicalize-url.test.ts
+    │       ├── discriminator-map.test.ts
+    │       ├── normalize-strapi.test.ts
+    │       ├── normalize-admin.test.ts
+    │       ├── compare.test.ts
+    │       ├── compare.types.ts                     # typecheck-only Strapi-vs-admin result-isolation proof
+    │       └── __fixtures__/
+    │           ├── hand-rolled/
+    │           │   ├── structural-missing-field.ts
+    │           │   ├── value-title-mismatch.ts
+    │           │   ├── order-blocks-reordered.ts
+    │           │   ├── semantic-locale-fallthrough.ts
+    │           │   └── per-block/                   # one fixture pair per block discriminator
+    │           └── captured/
+    │               └── canary-experience.ts         # placeholder; populated when canary route is selected
+    └── scripts/
+        └── capture-parity-fixture.ts                # one-shot capture from configured endpoints
+
+This is a scope declaration; the implementer may adjust the layout if implementation reveals a better grouping (e.g., consolidating the canonicalizers into one file).
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+flowchart LR
+    SR[Strapi raw response] --> SN[normalize-strapi]
+    AR[Admin raw response] --> AN[normalize-admin]
+
+    CU[canonicalize-url] -.shared.-> SN
+    CU -.shared.-> AN
+    DM[discriminator-map] -.shared.-> SN
+    LS[locale-selector] -.shared.-> SN
+    LS -.shared.-> AN
+    BS[BlocksSchema from @forge/admin] -.parse.-> AN
+
+    SN --> NR1[NormalizedExperienceRoute]
+    AN --> NR2[NormalizedExperienceRoute]
+
+    NR1 --> D[compare 4-class differ]
+    NR2 --> D
+    AL[allow-list] -.filters.-> D
+
+    D --> R[DiffReport: structural, value, order, semantic, potentially-truncated]
+```
+
+The two normalizers consume the same canonicalizers and locale selector so that when they emit `NormalizedExperienceRoute`, the only differences left should be real drift. The differ takes both shapes plus the allow-list and emits a deterministic diff record across the four R12a classes plus the `potentially-truncated` downgrade channel for Strapi's pagination-cap edge case.
+
+---
+
+## Implementation Units
+
+### U1. Vitest infra + parity package scaffolding
+
+**Goal:** Set up the test runner in `packages/graphql/` and the empty parity module structure with the deletion contract in place.
+
+**Requirements:** R5, R7
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `packages/graphql/package.json`
+- Create: `packages/graphql/vitest.config.ts`
+- Modify: `packages/graphql/src/index.ts`
+- Create: `packages/graphql/src/parity/index.ts`
+
+**Approach:**
+
+- Add `vitest` to `devDependencies` in `packages/graphql/package.json`. Add a `test` script.
+- Vitest config follows the conventions used in other workspace packages (Node environment, default include patterns).
+- `src/index.ts` re-exports `./parity` via a subpath, mirroring the existing `./graphql` and `./admin` pattern.
+- `src/parity/index.ts` carries a top-of-file deletion checklist (env vars, exports, import-graph references, CI hooks) keyed to consumer-migration cutover. Empty public surface initially — populated in later units.
+- Add `"./parity"` to the `exports` map in `package.json` so consumers import as `@forge/graphql/parity`.
+
+**Patterns to follow:**
+
+- `packages/graphql/src/index.ts` and the existing dual-client subpath exports
+- Top-of-file deletion checklist pattern from `docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md`
+
+**Test scenarios:**
+
+- Happy path: `pnpm --filter @forge/graphql test` runs and reports zero tests passing without errors
+- Edge: `import { /* placeholder */ } from "@forge/graphql/parity"` from a consuming package typechecks (this proves the subpath export wires through correctly)
+
+**Verification:**
+
+- `pnpm --filter @forge/graphql typecheck` passes
+- `pnpm --filter @forge/graphql test` exits zero
+- The deletion checklist enumerates every artifact this PR introduces (vitest config, `parity/` files, package exports map entry, test script)
+
+---
+
+### U2. Shared route shape, URL canonicalizer, discriminator map, path pointer
+
+**Goal:** Define the shared output shape both normalizers emit, plus the three pieces of shared logic both normalizers and the differ consume.
+
+**Requirements:** R1, R9, R10
+
+**Dependencies:** U1
+
+**Files:**
+
+- Create: `packages/graphql/src/parity/shared-shape.ts`
+- Create: `packages/graphql/src/parity/canonicalize-url.ts`
+- Create: `packages/graphql/src/parity/discriminator-map.ts`
+- Create: `packages/graphql/src/parity/path-pointer.ts`
+- Test: `packages/graphql/src/parity/canonicalize-url.test.ts`
+- Test: `packages/graphql/src/parity/discriminator-map.test.ts`
+- Test: `packages/graphql/src/parity/path-pointer.test.ts`
+
+**Approach:**
+
+- `shared-shape.ts`: exports `NormalizedExperienceRoute`, the type both normalizers produce. Carries `id`, `slug`, `locale`, `title`, `description`, `ogImage`, `blocks` (discriminated union over admin's `kind`), and a `meta` channel including `potentiallyTruncated: boolean`, `source: "strapi" | "admin"`, and `rawUrls` for canonicalization audit. **Absent-field contract** (per Key Decisions): all optional fields normalize to `null` on absence — both `undefined` and missing keys map to `null`. Documented in JSDoc on each optional field. No `selectedVariantId` field — locale correctness is checked via the `locale` field directly (resolved-locale equality).
+- `canonicalize-url.ts`: takes a raw URL string and a config (`{ schema: "strapi" | "admin"; baseOrigin: string }`); returns `{ canonical: string; raw: string }`. Strapi root-relative paths get prepended with `baseOrigin`; admin absolute URLs are normalized for trailing slashes, lowercased host, and stripped of UTM-style query keys. Raw form is preserved alongside canonical for diff records.
+- `discriminator-map.ts`: bidirectional table mapping the 16 shared Strapi `__typename` ↔ admin `kind` pairs. Admin's `videoRecommendations` is enumerated in a separate `adminOnlyKinds` set. Total over the known shared set; lookup miss returns an explicit `{ kind: "unknown"; raw: string }` sentinel rather than throwing. A test imports `BlocksSchema` from `@forge/admin/domain/blocks` and asserts every shared discriminator has a map entry — surfacing new admin kinds as test failures rather than silent unknown-sentinel passes.
+- `path-pointer.ts`: RFC6901 JSON Pointer encoder + numeric-aware sort comparator. `encode(segments)` joins with `/` after escaping `~` → `~0` and `/` → `~1` per RFC6901. `compare(a, b)` splits both on `/`, compares segment-by-segment with non-negative integer segments compared numerically (so `/blocks/2` precedes `/blocks/10`). Pure functions; no locale-dependent string sort.
+
+**Patterns to follow:**
+
+- Discriminator mapping table pattern: a single exported object with explicit, sorted entries; tests assert totality against `BlocksSchema`
+- RFC6901: https://www.rfc-editor.org/rfc/rfc6901 — keep the implementation small and standard
+
+**Test scenarios:**
+
+- Happy path: `canonicalizeUrl("/images/foo.jpg", { schema: "strapi", baseOrigin: "https://cdn.example.com" })` returns `{ canonical: "https://cdn.example.com/images/foo.jpg", raw: "/images/foo.jpg" }`
+- Happy path: `canonicalizeUrl("https://cdn.example.com/foo.jpg/", { schema: "admin", baseOrigin: ... })` returns canonical with trailing slash stripped and UTM keys removed; raw preserved verbatim
+- Edge: empty string input throws a typed error
+- Edge: Strapi schema with absolute URL passes through unchanged (canonical equals raw)
+- Edge: malformed URL surfaces as a structured failure (not a thrown exception) so the differ can flag it as a value-class mismatch
+- Happy path (discriminator): every Strapi `__typename` from the 16-type fragment table maps to a non-empty admin `kind`
+- Edge (discriminator): unknown `__typename` returns `{ kind: "unknown", raw }` sentinel
+- Edge (discriminator): bidirectional lookup is consistent — `strapiToAdmin(adminToStrapi(k)) === k` for every known `k`
+- Path pointer: `encode(["blocks", 3, "items", 0, "url"])` returns `/blocks/3/items/0/url`
+- Path pointer: segments containing `/` or `~` are escaped per RFC6901 (`/` → `~1`, `~` → `~0`)
+- Path pointer numeric sort: `compare("/blocks/2", "/blocks/10")` returns negative (numeric, not lexicographic)
+- Path pointer numeric sort: `compare("/blocks/abc", "/blocks/2")` falls back to string comparison for non-numeric segments
+- Discriminator-map admin coverage: importing `BlocksSchema` from `@forge/admin/domain/blocks` and asserting every shared discriminator (excluding admin-only `videoRecommendations`) has a map entry — surfaces new admin kinds at test time, not as silent unknown-sentinel passes
+- Absent-field shape: `NormalizedExperienceRoute` JSDoc on every optional field documents the `null`-on-absence contract
+
+**Verification:**
+
+- `pnpm --filter @forge/graphql test` passes the canonicalizer, discriminator-map, and path-pointer suites
+- `pnpm --filter @forge/graphql typecheck` passes — `NormalizedExperienceRoute` is exportable and consumable from outside the parity module
+
+---
+
+### U3. Strapi normalizer
+
+**Goal:** Implement the Strapi-side normalizer that takes a Strapi GraphQL response for an experience and emits `NormalizedExperienceRoute`.
+
+**Requirements:** R1, R8
+
+**Dependencies:** U2
+
+**Files:**
+
+- Create: `packages/graphql/src/parity/normalize-strapi.ts`
+- Test: `packages/graphql/src/parity/normalize-strapi.test.ts`
+
+**Approach:**
+
+- Input typed via `ResultOf<>` of a typed `graphql()`-built `experiences` query that mirrors `apps/web/src/lib/fragments/watch-experience.ts`
+- Maps each block's `__typename` through `discriminator-map.ts` to admin's `kind`; emits the discriminated union `NormalizedExperienceRoute["blocks"]`
+- **Container flatten** (per Key Decisions): `ComponentSectionsContainer { slots[] { content[] } }` is flattened into a single `container.content[]` array matching admin's flat shape, with synthetic `containerSlot` entries inserted at slot boundaries preserving `gridSpan` and `spans`. Same flatten rule applies to Section blocks containing nested zones
+- Pipes every URL field (`ogImage.url`, image references inside blocks, video poster URLs) through `canonicalize-url.ts`
+- **Resolved-locale equality**: stores the response's `locale` field on the normalized output's top-level `locale`. The differ compares this directly against the URL-locale parameter and against admin's `locale` for semantic-class equality. No selector module
+- **Truncation detection** (per Key Decisions, refined): trusts the capture-time `pagination: { limit: -1 }` guarantee for fixture mode (sets `meta.potentiallyTruncated: false`). Live mode reads response metadata when available (`pagination.total > returned.length`) and only sets `potentiallyTruncated: true` when there's evidence of more rows than returned. Length-10 alone is NOT a trigger
+- **Absent-field handling** (per Key Decisions): every optional field absent in the response (Strapi `null`, `undefined`, missing key) normalizes to `null` on the output
+- ogImage handling: emits the structured `{ url, width, height, alt }` shape — the normalized type is the lossless superset; admin normalizer fills `width`/`height`/`alt` with `null`
+
+**Patterns to follow:**
+
+- `apps/web/src/lib/content.ts` resolveWatchPage and the WatchExperience fragment composition — shape and locale handling reference, not type re-export
+- `apps/web/src/lib/content.test.ts` mock-shape pattern
+
+**Test scenarios:**
+
+- Happy path: typical Strapi response with three blocks → normalized shape has three entries with correct `kind` values, all URLs canonicalized
+- Edge: empty blocks array → empty normalized blocks
+- Edge: null `ogImage` → normalized `ogImage: null`
+- Error path: response missing required `slug` field throws a typed error naming the missing field
+- Locale: response's `locale` field surfaces verbatim on `normalized.locale`
+- Discriminator: Strapi `ComponentSectionsMediaCollection` block surfaces as `kind: "mediaCollection"`
+- URL canonicalization: relative `/images/foo.jpg` → absolute canonical; raw preserved in `meta.rawUrls`
+- **Container flatten**: Strapi container with two slots (`gridSpan: 2` + `gridSpan: 1`), each with two blocks, normalizes to `kind: "container"` with `content: [containerSlot{gridSpan:2}, block, block, containerSlot{gridSpan:1}, block, block]` — exact ordering verified
+- **Truncation (fixture mode)**: response captured with `pagination: { limit: -1 }` and 10 blocks → `meta.potentiallyTruncated: false` (capture-time guarantee trusted)
+- **Truncation (live mode with response metadata)**: response with `pagination.total: 12` and `returned.length: 10` → `meta.potentiallyTruncated: true`
+- **Absent-field**: Strapi `description: null`, `description: undefined`, and missing `description` key all produce `normalized.description: null`
+- Per-block-discriminator coverage: at least one fixture for every entry in the discriminator map produces the expected normalized output (covers AE5 prerequisite — the Strapi half)
+
+**Verification:**
+
+- `pnpm --filter @forge/graphql test` covers the Strapi normalizer with all 16 block discriminators exercised
+- Typecheck shows `ResultOf<typeof StrapiExperienceQuery>` flows through to `NormalizedExperienceRoute` without `any`
+
+---
+
+### U4. Admin normalizer (with BlocksSchema validation)
+
+**Goal:** Implement the admin-side normalizer that takes an admin GraphQL response (where `blocks` is opaque `JSON`) and emits `NormalizedExperienceRoute`.
+
+**Requirements:** R1
+
+**Dependencies:** U2
+
+**Files:**
+
+- Create: `packages/graphql/src/parity/normalize-admin.ts`
+- Test: `packages/graphql/src/parity/normalize-admin.test.ts`
+- Modify: `apps/admin/package.json` (add `exports` map with a `./domain/blocks` entry pointing at the Zod schema source; admin currently has no `exports` map, so this PR introduces it)
+
+**Approach:**
+
+- Input typed via `AdminResultOf<>` of a typed `adminGraphql()`-built `experienceBySlug` query
+- The `blocks` field arrives as `unknown` (opaque `JSON` scalar). Run `BlocksSchema.parse(...)` from `@forge/admin/domain/blocks` to recover the discriminated union
+- On Zod validation failure, throw a typed `AdminBlocksValidationError` that carries the failing block's index, discriminator, and the Zod issue list — surfaces what the differ would otherwise report as opaque structural failure
+- Pipes every URL field through `canonicalize-url.ts`
+- **Resolved-locale equality**: stores admin response's `locale` (from `ExperienceLocale`) verbatim on `normalized.locale`. The differ compares against URL locale and Strapi's `locale` directly
+- **Container shape**: admin's `container.content[]` is already flat with `containerSlot` markers — the admin normalizer passes content through unchanged (the flatten work happens on the Strapi side per Key Decisions)
+- **Absent-field handling** (per Key Decisions): every optional field absent in the response (`null`, `undefined`, or missing key) normalizes to `null`
+- ogImage shape: admin emits `ogImageUrl: String` only; normalize to `{ url, width: null, height: null, alt: null }` so the shape lines up with Strapi's normalizer output
+
+**Patterns to follow:**
+
+- `apps/admin/src/domain/blocks.ts` Zod schema — reuse, do not duplicate
+- Workspace dependency pattern: `"@forge/admin": "workspace:*"` already exists in `packages/graphql/package.json` devDependencies (added by U3 for schema codegen) — no new dependency edge introduced
+- Subpath export pattern: `apps/admin/package.json` gets an `exports` map. Mirrors the pattern in `packages/graphql/package.json` (which exposes `.`, `./graphql`, `./admin`)
+
+**Test scenarios:**
+
+- Happy path: typical admin response with three blocks → normalized shape has three entries with correct `kind` values
+- Edge: empty blocks array → empty normalized blocks
+- Edge: `ogImageUrl` only → normalized `ogImage` has `width: null`, `height: null`, `alt: null`
+- Error path: a block whose `t` discriminator is unknown to `BlocksSchema` produces `AdminBlocksValidationError` carrying the block index and discriminator
+- Error path: a block missing a required field for its `t` produces `AdminBlocksValidationError` with the Zod issue path
+- Discriminator: admin `t: "mediaCollection"` block surfaces as `kind: "mediaCollection"` in normalized output
+- URL canonicalization: admin absolute URL passes through canonicalizer, query-string canonicalization applied
+- Locale: admin's `ExperienceLocale.locale` field surfaces verbatim on `normalized.locale`
+- **Absent-field**: admin response with `description: undefined` and missing `description` key both produce `normalized.description: null`
+- **Admin-only `videoRecommendations`**: normalizer accepts the kind (it's in `BlocksSchema`), surfaces it as `kind: "videoRecommendations"` on the normalized output. The differ later flags structural mismatch on Strapi side ("missing block kind") — this is correct prod behavior since the kind is admin-only
+- Per-block-discriminator coverage: covers all 16 shared admin `t` values plus admin-only `videoRecommendations` (17 total fixtures; 16 have Strapi pairs, `videoRecommendations` is admin-only)
+
+**Verification:**
+
+- `pnpm --filter @forge/graphql test` covers the admin normalizer including all 16 block discriminators
+- `BlocksSchema` import resolves cleanly from `@forge/admin`; no circular workspace dependency surfaces
+
+---
+
+### U5. Four-class differ + type-isolation proof
+
+**Goal:** Implement the comparator that takes two `NormalizedExperienceRoute` values and returns a deterministic, JSON-serializable `DiffReport` classified across structural, value, order, and semantic classes — plus the `potentially-truncated` downgrade channel.
+
+**Requirements:** R1, R2, R4, R8, R9, R10
+
+**Dependencies:** U2
+
+**Files:**
+
+- Create: `packages/graphql/src/parity/compare.ts`
+- Create: `packages/graphql/src/parity/allow-list.ts`
+- Create: `packages/graphql/src/parity/compare.types.ts`
+- Test: `packages/graphql/src/parity/compare.test.ts`
+
+**Approach:**
+
+- `compare.ts` exports `compareNormalizedRoutes(strapiSide, adminSide, options)` returning a `DiffReport` with five channels: `structural[]`, `value[]`, `order[]`, `semantic[]`, `potentiallyTruncated[]`
+- Structural class: walks both normalized shapes; reports field-presence asymmetries by RFC6901 JSON Pointer path. **Absent-field rule** (per Key Decisions): both sides' `null` and missing-key states are equivalent — only true presence/absence on one side surfaces here
+- Value class: deep equality on present fields (using canonicalized URLs); reports path + both raw values
+- Order class: ordered-collection comparison on arrays where order is meaningful (blocks, in particular); reports moved indices
+- Semantic class: three sub-checks — **locale-correctness (resolved-locale equality: both sides' `locale` field equals the URL locale, per Key Decisions — replaces the rejected selector-output framing)**, ID identity (experience and block IDs preserved within each side; cross-side ID equality is NOT checked since admin cuids and Strapi documentIds are different by design), URL canonicalization residual (canonical-form equality once normalization has run, with raw forms preserved in `meta.rawUrls` on each side)
+- Potentially-truncated downgrade: when either side has `meta.potentiallyTruncated: true`, missing-tail entries from THAT side are reclassified out of structural into `potentiallyTruncated[]`
+- Allow-list filter: entries matching `allow-list.ts` are dropped from the report before return; matched entries are surfaced under `meta.appliedAllowList[]` for transparency
+- **Determinism**: every channel's entries are sorted by `path-pointer.compare` (RFC6901 JSON Pointer with numeric-aware segment sort, per Key Decisions) — NOT lexicographic. Diff record has no timestamps or non-deterministic content
+- `compare.types.ts` is a typecheck-only file (no `.test.ts` suffix; vitest skips per existing dual-client pattern) that asserts `compare()` cannot accept a Strapi raw response and an admin raw response — only the normalized shape — using `@ts-expect-error` lines
+
+**Patterns to follow:**
+
+- `packages/graphql/src/__tests__/dual-client.types.ts` — typecheck-only proof pattern from U3 (admin migration)
+- Allow-list seed: `docs/solutions/cms/admin-app-data-model-decisions.md` divergences (e.g., `ogImage.width`/`height`/`alt` are null on admin side — known divergence, not drift)
+
+**Test scenarios:**
+
+- Happy path: identical normalized inputs produce empty diff across all channels
+- Structural: admin missing `description` → flagged in `structural[]` with RFC6901 path `/description`
+- Structural: extra field on admin not on Strapi → flagged in `structural[]`
+- **Structural absent-field equivalence**: Strapi `description: null` vs admin missing `description` key (both normalized to `null`) → no diff
+- Value: `title` differs ("Easter" vs "Easter Story") → flagged in `value[]` with both raw values
+- Order: blocks `[a, b, c]` vs `[a, c, b]` → flagged in `order[]` with moved-index pairs
+- **Semantic locale (resolved-locale equality)**: Strapi response with `locale: "en"` and admin response with `locale: "es"` (Strapi fell back) for URL locale `"en"` → flagged in `semantic[]` with subclass `locale-mismatch`
+- Semantic URL: a URL field's canonical form differs after canonicalization → flagged in `semantic[]` with subclass `url-canonicalization`
+- **Path sort (numeric-aware)**: report contains entries at `/blocks/2`, `/blocks/10`, `/blocks/3` → output ordering is `/blocks/2`, `/blocks/3`, `/blocks/10` (numeric, not lexicographic which would produce `/blocks/10`, `/blocks/2`, `/blocks/3`)
+- Truncation downgrade: Strapi side `meta.potentiallyTruncated: true`, admin has 12 blocks while Strapi has 10 → admin's 11th and 12th entries land in `potentiallyTruncated[]`, not `structural[]`
+- Allow-list: a known divergence (`ogImage.width: null` on admin) is filtered out and surfaced under `meta.appliedAllowList`
+- Determinism: running `compareNormalizedRoutes(a, b)` twice on the same inputs produces byte-identical JSON (`JSON.stringify(report1) === JSON.stringify(report2)`)
+- Compile-time isolation (in `compare.types.ts`): passing a raw Strapi `ResultOf<>` value to `compare()` produces a TypeScript error
+- Covers AE5: when both fixtures represent the same canary experience with all 16 shared block variants, the report is empty across all four classes (post-allow-list)
+
+**Verification:**
+
+- `pnpm --filter @forge/graphql test` covers the differ across all five channels and the allow-list filter
+- `pnpm --filter @forge/graphql typecheck` enforces the `@ts-expect-error` isolation proofs
+- Snapshot of a known-bad fixture's diff JSON is byte-stable across two consecutive runs
+
+---
+
+### U6. Two-tier fixture set + live-mode entry point + capture script
+
+**Goal:** Land the hand-rolled fixture set covering all four diff classes plus all 16 block discriminators, the placeholder captured-fixture slot for the canary route, the env-gated live-comparison entry point, and the one-shot capture script.
+
+**Requirements:** R3, R6
+
+**Dependencies:** U3, U4, U5
+
+**Files:**
+
+- Create: `packages/graphql/src/parity/__fixtures__/hand-rolled/` (per-class + per-block-discriminator pairs)
+- Create: `packages/graphql/src/parity/__fixtures__/captured/canary-experience.ts` (placeholder)
+- Create: `packages/graphql/src/parity/live.ts`
+- Create: `packages/graphql/scripts/capture-parity-fixture.ts`
+- Test: extend `compare.test.ts` to drive every fixture pair through the full pipeline
+
+**Approach:**
+
+- Hand-rolled fixtures: one per diff class (`structural-missing-field`, `value-title-mismatch`, `order-blocks-reordered`, `semantic-locale-fallthrough`) plus one fixture pair per admin `kind` discriminator. Each fixture exports a `{ strapi, admin, expectedDiff }` triple
+- Captured fixtures: directory exists with a `canary-experience.ts` placeholder that exports a `{ strapi, admin, expectedDiff: empty }` triple parameterized by route name. Real captured data lands when canary route is selected (deferred decision in Open Questions); the placeholder structure makes the addition a single-file change
+- `live.ts`: env-gated entry point. Reads `FORGE_PARITY_LIVE`, `FORGE_STRAPI_URL`, `FORGE_ADMIN_URL`, configured slug + locale pair. Refuses to run when `FORGE_PARITY_LIVE` is not set with a clean typed error. Issues both queries via the existing `graphql()` and `adminGraphql()` factories, runs the normalizers + differ, returns the `DiffReport`. Not invoked by the test suite — for ad-hoc operator use
+- `capture-parity-fixture.ts`: one-shot CLI. Configurable Strapi + admin endpoints + slug + locale. Captures raw responses to disk (under `__fixtures__/captured/`), redacts auth headers and a configurable list of sensitive fields. Sanitization rules deferred to implementation per Open Questions; minimal redaction (auth headers, IDs that look like internal tokens) ships in PR1. Strapi-side query in this script explicitly sets `pagination: { limit: -1 }` on every nested relation per R8. **Host validation on `FORGE_ADMIN_URL`**: blocklist `auth.jesusfilm.org` and other known non-admin hosts; allow any other URL (localhost, preview deploys, Railway service URLs, `admin.jesusfilm.org`). A positive admin-host match would break local dev where admin runs at `localhost:3003`
+
+**Patterns to follow:**
+
+- Mock-shape pattern from `apps/web/src/lib/content.test.ts`
+- One-shot script pattern from `apps/admin/src/scripts/print-schema.ts` — explicit env handling, deterministic output, no implicit defaults
+
+**Test scenarios:**
+
+- Happy path: every hand-rolled fixture pair produces exactly the expected diff entries (one fixture per class, plus one fixture per discriminator)
+- Per-block-discriminator coverage: all 16 admin `kind` values have a fixture pair that produces the expected (empty) diff when both sides represent the same logical block
+- Allow-list integration: hand-rolled fixture for a known divergence (admin `ogImage.width: null`) produces an empty diff after allow-list filtering, with the divergence reported under `meta.appliedAllowList`
+- Live-mode disabled: calling `live()` without `FORGE_PARITY_LIVE` set produces a typed error naming the missing env var
+- Live-mode enabled with stub endpoints (in test, with mocked fetch): `live()` issues both queries, runs the pipeline, returns a `DiffReport`
+- Capture script smoke: `pnpm tsx packages/graphql/scripts/capture-parity-fixture.ts --slug ... --locale ...` against stub endpoints produces a deterministic on-disk fixture file
+- Sanitization: capture script's output contains no `Authorization` header values, no environment-variable raw values
+
+**Verification:**
+
+- `pnpm --filter @forge/graphql test` runs the full fixture suite and passes
+- Captured-fixtures placeholder directory has the right shape so adding the canary route's real fixture set is a single-file change
+- `live.ts` is exported from `parity/index.ts`; the deletion checklist in `index.ts` is updated to enumerate the live entry point and capture script
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** the harness is leaf code. It imports from `@forge/admin` (BlocksSchema only), reuses the existing `graphql()` and `adminGraphql()` factories from `packages/graphql`, and is not imported by any consumer app in this PR. U5's canary code will import `@forge/graphql/parity` from `apps/web`.
+- **Error propagation:** the harness throws typed errors (`AdminBlocksValidationError`, normalizer-required-field errors); the live mode and capture script surface env-gating failures as typed exceptions rather than silent no-ops.
+- **State lifecycle risks:** none — the harness is pure-data over inputs.
+- **API surface parity:** the new `./parity` subpath export joins the existing `./graphql` and `./admin` exports on `@forge/graphql`. `package.json` `exports` map adds one entry; `tsconfig` paths follow.
+- **Integration coverage:** the BlocksSchema import is the first TypeScript-level coupling between `packages/graphql` and `@forge/admin`. The workspace edge already exists (admin is a `packages/graphql` devDep from U3 schema codegen); this PR adds an `exports` map to admin's `package.json` and the first concrete TS import. Scope is deliberately narrow — only the Zod schema is exposed via the subpath, not the GraphQL types, Pothos builder, or services. Verified during planning: admin does not import from `@forge/graphql`, so no cycle is introduced.
+- **Unchanged invariants:** existing `graphql()` and `adminGraphql()` factories are unchanged. The dual-client codegen output (`graphql-env.d.ts`, `admin-graphql-env.d.ts`) is unchanged. No consumer app's behavior changes in this PR.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                                                                                                                                  | Mitigation                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Strapi pagination cap producing false-positive structural diffs                                                                                                                       | Capture script sets `pagination: { limit: -1 }`; normalizer flags responses with length-10 arrays as `potentiallyTruncated`; differ downgrades tail entries out of structural class. R8.                                                                                                                                                                                                                                                                                       |
+| URL canonicalization rules drift from prod URL behavior, masking real divergence                                                                                                      | Both sides pass through one canonicalizer with `{ schema, baseOrigin }` config; raw forms preserved in `meta.rawUrls` so reviewers see actual values. R9. Risk surfaces if `baseOrigin` env config is wrong — flagged in Open Questions for implementation-time resolution.                                                                                                                                                                                                    |
+| BlocksSchema in `@forge/admin` evolves faster than the harness's hand-rolled per-discriminator fixtures                                                                               | Per-block-discriminator fixtures cover the union exhaustively at write time; if admin adds a 17th discriminator, the admin normalizer's `BlocksSchema.parse` will throw `AdminBlocksValidationError` and the test for that fixture will surface the gap. The expected-divergence allow-list does NOT shadow new-discriminator failures.                                                                                                                                        |
+| Hand-rolled fixtures pass while real captured fixtures fail                                                                                                                           | Two-tier fixture rule (R6): every diff class has at least one captured fixture; PR review cannot land the harness with empty `__fixtures__/captured/`. The canary-route placeholder is exempt only because canary route choice is U5's call.                                                                                                                                                                                                                                   |
+| Allow-list becomes a sink for un-investigated diffs                                                                                                                                   | Allow-list entries require a `rationale` field tying to `docs/solutions/cms/admin-app-data-model-decisions.md` or another decision doc; `compare.test.ts` asserts every allow-list entry has a non-empty rationale. The seed entries enumerate ogImage's full divergence: `ogImage.width: null`, `ogImage.height: null`, `ogImage.alt: null` (admin schema exposes only `ogImageUrl`; structural ogImage fields are not yet wired).                                            |
+| Admin's `BlocksSchema` is exposed via a new subpath export — admin's `package.json` doesn't currently have an `exports` map, and no other workspace imports from `@forge/admin` today | First repo precedent for treating admin as an importable workspace package; verified during planning that admin does not import from `@forge/graphql`, so no cycle risk. The `exports` map addition is small and reversible. If `BlocksSchema` import paths surface tooling issues (e.g., Vitest, Next.js dev server), fall back to TypeScript path mapping in `packages/graphql/tsconfig.json` as a backstop. Risk does not block landing — it shapes which file gets edited. |
+| Vitest setup in `packages/graphql/` perturbs Turborepo task cache or other workspace tooling                                                                                          | Vitest is a devDependency only; Turbo `inputs` for the `test` task scope to `src/**` and `vitest.config.ts`; no runtime impact on dual-client codegen. The existing `generate` and `typecheck` tasks are unchanged.                                                                                                                                                                                                                                                            |
+| Captured fixtures grow stale relative to prod data after canary launches                                                                                                              | Out of scope for U4 (deferred). U5's runbook (R19) takes ownership of fixture-staleness. The capture script ships in U4 to make re-capture a one-command operation.                                                                                                                                                                                                                                                                                                            |
+
+---
+
+## Documentation / Operational Notes
+
+- Top-of-file deletion checklist in `packages/graphql/src/parity/index.ts` enumerates: vitest config + script, `parity/` source files, `__fixtures__/` directory, `scripts/capture-parity-fixture.ts`, `./parity` exports map entry, `apps/admin/package.json`'s `exports` entry for `./domain/blocks` (and the `exports` map itself if it becomes empty after removal), env vars (`FORGE_PARITY_LIVE`, `FORGE_STRAPI_URL`, `FORGE_ADMIN_URL`, `FORGE_STRAPI_PUBLIC_ORIGIN`). Note: `@forge/admin` workspace devDep on `packages/graphql` is NOT removed at retirement — it remains in use for schema codegen.
+- A short `packages/graphql/src/parity/README.md` documents: how to run hand-rolled fixtures (`pnpm --filter @forge/graphql test`), how to run live mode (env vars + invocation), how to capture a new fixture (script CLI), and the deletion checklist's location.
+- No CI job lands in this PR. U5 or U7 wires the parity job; the runbook (U7) decides whether the live-mode comparator runs against staged admin in CI.
+- No env-var rollout in production from this PR — `FORGE_PARITY_LIVE` is dev-only until U5 wires the canary's `dual-read` mode.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-05-consumer-migration-implementer-brief-requirements.md`
+- **Master plan:** `docs/plans/2026-04-22-001-feat-admin-core-consumer-migration-plan.md`
+- **Roadmap:** `docs/roadmap/platform/feat-104-admin-core-consumer-migration-plan.md`
+- **U3 dual-client plan (already shipped):** `docs/plans/2026-05-05-001-feat-dual-client-codegen-unit-3-plan.md`
+- **U1 inventory plan (shipped 2026-05-07):** `docs/plans/2026-05-07-001-feat-consumer-migration-unit-1-query-inventory-plan.md`
+- **U1 inventory output (shipped 2026-05-07):** `docs/admin-core-migration/query-inventory.md` — drives per-route fixture coverage for feat-104's Unit 5 expansion
+- **Related code:** `apps/web/src/lib/content.ts`, `apps/web/src/lib/fragments/watch-experience.ts`, `apps/admin/src/domain/blocks.ts`, `apps/admin/src/graphql/types/experience.ts`
+- **Institutional learnings (cited in Context & Research):** `docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md`, `docs/solutions/best-practices/producer-consumer-report-file-contract-pattern-20260506.md`, `docs/solutions/performance-issues/strapi-nested-relation-truncation-and-n-plus-one-manager-20260328.md`, `docs/solutions/logic-errors/strapi-graphql-pagination-cap-wrong-language-watch-page-20260504.md`, `docs/solutions/integration-issues/mobile-relative-image-url-no-base-origin-20260408.md`, `docs/solutions/architecture-patterns/dual-client-gql-tada-multi-schema-codegen-pattern-20260507.md`, `docs/solutions/cms/admin-app-data-model-decisions.md`, `docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md`, `docs/solutions/best-practices/nextjs-route-shape-migration-cross-cutting-contract-drift-20260430.md`, `docs/solutions/best-practices/graphql-callsite-inventory-dual-pattern-sweep-20260507.md`

--- a/docs/plans/2026-05-07-002-feat-consumer-migration-parity-harness-unit-4-plan.md
+++ b/docs/plans/2026-05-07-002-feat-consumer-migration-parity-harness-unit-4-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: response parity harness for consumer migration (Unit 4)"
 type: feat
-status: active
+status: completed
 date: 2026-05-07
 deepened: 2026-05-08
 origin: docs/brainstorms/2026-05-05-consumer-migration-implementer-brief-requirements.md

--- a/docs/solutions/runtime-errors/tsx-esm-named-export-resolution-across-workspace-package-boundary-20260508.md
+++ b/docs/solutions/runtime-errors/tsx-esm-named-export-resolution-across-workspace-package-boundary-20260508.md
@@ -1,0 +1,102 @@
+---
+title: tsx ESM static-link fails on named exports across workspace package boundary
+date: 2026-05-08
+category: runtime-errors
+module: packages/graphql
+problem_type: runtime_error
+component: tooling
+severity: high
+symptoms:
+  - "SyntaxError: The requested module '@forge/admin/domain/blocks' does not provide an export named 'BlocksSchema' when running tsx scripts/capture-parity-fixture.ts"
+  - "All 113 vitest tests pass, but a smoke script crashes at module load"
+  - "Crash only surfaces when the import chain transitively reaches a workspace package's exports-map pointing at a raw .ts file"
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+  - tooling
+  - testing_framework
+tags:
+  - tsx
+  - esm
+  - exports-map
+  - workspace-package
+  - vitest-vs-tsx
+  - parity-harness
+  - consumer-migration
+  - module-resolution
+---
+
+# tsx ESM static-link fails on named exports across workspace package boundary
+
+## Problem
+
+Adding the first `exports` map entry to `apps/admin/package.json` (`"./domain/blocks": "./src/domain/blocks.ts"`) caused `tsx packages/graphql/scripts/capture-parity-fixture.ts` to crash at module load with a misleading `does not provide an export named 'BlocksSchema'` error. The export exists. All 113 vitest tests passed. Admin's Next.js build and `tsc --noEmit` were both green. The runtime crash hit only the tsx-driven script — and only because its transitive import chain reached `normalize-admin.ts`, which statically imports `BlocksSchema` from a `.ts` source file reached through the workspace `exports` map.
+
+Context: this surfaced while shipping U4 of the Strapi → admin consumer migration (`apps/admin` exposed via workspace package for the first time; `packages/graphql/parity` is the consumer). Migration ownership: Urim, end-to-end (auto memory [claude]).
+
+## Symptoms
+
+- Hard crash at module load (before any user code runs):
+  ```
+  SyntaxError: The requested module '@forge/admin/domain/blocks' does not provide an export named 'BlocksSchema'
+      at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)
+  ```
+- Surfaces ONLY when invoking the script via `tsx packages/graphql/scripts/capture-parity-fixture.ts` (or any other tsx-driven entry point whose import graph transitively reaches the cross-workspace import).
+- Hidden by: vitest (113/113 green, including tests that exercise the same `BlocksSchema` import via `normalize-admin`), `next build` for admin, `tsc --noEmit`, and `pnpm install`.
+- The error message implies the export is missing — it is not. `grep -n 'export.*BlocksSchema' apps/admin/src/domain/blocks.ts` confirms the export.
+
+## What Didn't Work
+
+- **Verifying the source export.** Re-read `apps/admin/src/domain/blocks.ts` and confirmed `BlocksSchema` is exported. The error message lied about the cause.
+- **Re-running `pnpm install`.** Lockfile was already in sync; no resolver state to fix.
+- **Trusting the test suite.** Vitest's Vite-based resolver handles workspace `.ts` imports through a different code path. Green tests gave false confidence that the runtime entry point was fine. _(session history: "vitest hid this; tsx exposed it.")_
+- **Trusting `next build` and `tsc`.** Next's bundler and TypeScript's checker each have their own resolution layers — neither validates Node's runtime ESM static-link.
+
+## Solution
+
+Split the parity surface so the script-level entry point does NOT pull `normalize-admin` (and therefore does NOT pull the cross-workspace `.ts` import) into its static import graph.
+
+**New file** `packages/graphql/src/parity/live-config.ts` — pure env/URL utilities, zero `normalize-*` imports:
+
+- `assertLiveModeEnabled` (env validation for `FORGE_PARITY_LIVE` etc.)
+- `validateHost` (host blocklist check)
+- `LiveModeDisabledError`, `LiveModeConfigError` (typed errors)
+
+**Refactored** `packages/graphql/src/parity/live.ts` — keeps `runLiveComparison` and its `normalize-admin` import, but now imports `assertLiveModeEnabled` / `validateHost` / errors from `./live-config` and re-exports them so the public `@forge/graphql/parity` surface is unchanged.
+
+**Capture script** `packages/graphql/scripts/capture-parity-fixture.ts` — switched its single import:
+
+```ts
+// Before — transitively pulls normalize-admin → BlocksSchema
+import { assertLiveModeEnabled } from "../src/parity/live"
+
+// After — flat import, zero cross-workspace path in the graph
+import { assertLiveModeEnabled } from "../src/parity/live-config"
+```
+
+After the fix: capture script runs cleanly under tsx, exits 2 with the documented "wiring deferred to U5" message; tests still 113/113.
+
+## Why This Works
+
+Node's ESM `#asyncInstantiate` runs a static-link pass BEFORE any module body executes — it checks every named import resolves to a real export on the source module. tsx's loader transforms `.ts` files so named exports become visible to that static-link, but the transformer does not consistently apply across workspace `exports`-map boundaries that point at raw `.ts` source paths. When the static-link asks "does `@forge/admin/domain/blocks` export `BlocksSchema`?", it sees a module whose exports haven't been materialized by the transformer and reports the export as missing.
+
+Vitest avoids this because Vite owns its own resolver and module graph — it never delegates to Node's ESM static-link for workspace `.ts` files. Next's build avoids it because the bundler inlines and rewrites these imports before runtime. Only `tsx` + Node's runtime ESM hits the broken seam.
+
+The fix breaks the chain at the script entry point: `capture-parity-fixture.ts` now has zero transitive path to `normalize-admin`, so the cross-workspace `.ts` import is never reached during the script's static-link pass. The `live.ts` runtime path still imports `normalize-admin` for `runLiveComparison`, but that path is only loaded by vitest and Vite-resolved consumers — never by raw tsx invocations.
+
+## Prevention
+
+- **Treat tsx + workspace `exports` map pointing at raw `.ts` files as a known broken combination.** When a workspace package adds its first `exports` map entry — or any new entry pointing at a `.ts` source path — audit every `tsx`-invoked script for transitive imports that cross that boundary. Anything else added to admin's `exports` map carries the same hazard for any tsx-run script in the repo.
+- **Smoke-test scripts with the actual runtime, not just the test runner.** A `pnpm tsx <script> --help`-style fast-exit invocation in CI catches static-link failures vitest cannot. For `packages/graphql`, this lives alongside `pnpm test`. The Vitest-clean status was NOT treated as sufficient on its own during U4 verification — the tsx smoke test was the gating signal that caught this. _(session history)_
+- **Layer modules so the env-validation surface has zero domain imports.** `live-config.ts` (env/URL utilities, typed errors) is a stable layer below `live.ts` (orchestration with `normalize-*` imports). Scripts that only need validation import the lower layer; the public re-export from `live.ts` keeps the API stable. This is a generalizable pattern: when a script-level entry point shares a module with runtime orchestration, the script-level needs MUST live in a leaf module that doesn't import the runtime chain.
+- **Distrust "export not found" messages from Node's static-link** when the export demonstrably exists. The real question is whether the loader transformer reached the source file, not whether the source file is correct. Check the loader (tsx, ts-node, swc) and the resolution path (workspace `exports`, conditional exports, `.ts` vs compiled `.js`) before re-reading the source.
+- **Compile-to-`.js` is the bombproof escape hatch.** If a script must cross this boundary, point the workspace's `exports` at a built `.js` artifact instead of raw `.ts`. This eliminates the tsx-transformer-vs-static-link race entirely. Keep this in mind for U5 if the layered split ever becomes insufficient as the parity harness wires real transport.
+- **Meta-pattern**: this is another worked instance of [mocked-shape-vs-real-contract-discipline](../best-practices/mocked-shape-vs-real-contract-discipline-20260506.md) — vitest passed (mocked shape), tsx production-runtime contract failed. Add tsx-runnable smoke tests anywhere a `.ts` source path crosses a workspace `exports` boundary.
+
+## Related Issues
+
+- [`docs/solutions/best-practices/experience-embeddings-backfill-strapi-v5-tsx-compat-20260414.md`](../best-practices/experience-embeddings-backfill-strapi-v5-tsx-compat-20260414.md) — sibling tsx + module-resolution pattern (Strapi v5 CJS init ordering). Different mechanism, complementary prevention rule (smoke-run the actual script in CI).
+- [`docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md`](../best-practices/mocked-shape-vs-real-contract-discipline-20260506.md) — META home. Register this doc as a sixth worked instance: vitest's transformer is the "mock" that hid tsx's "production contract" gap.
+- [`docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md`](../best-practices/throwaway-operator-harness-deletion-contract-20260430.md) — the parity harness lifecycle / architecture frame. The capture script that surfaced this bug ships under that pattern.
+- [`docs/solutions/architecture-patterns/dual-client-gql-tada-multi-schema-codegen-pattern-20260507.md`](../architecture-patterns/dual-client-gql-tada-multi-schema-codegen-pattern-20260507.md) — direct upstream context. The cross-workspace `.ts` source path being imported (`@forge/admin/domain/blocks` → `BlocksSchema`) is a consumer-side artifact of this pattern.
+- PR #912 — the parity harness Unit 4 PR where the fix landed.

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -24,6 +24,7 @@
     "@forge/admin": "workspace:*",
     "@forge/cms": "workspace:*",
     "typescript": "^5",
-    "vitest": "3.2.4"
+    "vitest": "3.2.4",
+    "zod": "^4.3.6"
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -6,11 +6,14 @@
   "exports": {
     ".": "./src/index.ts",
     "./graphql": "./src/graphql.ts",
-    "./admin": "./src/admin.ts"
+    "./admin": "./src/admin.ts",
+    "./parity": "./src/parity/index.ts"
   },
   "scripts": {
     "generate": "gql-tada generate output",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -20,6 +23,7 @@
   "devDependencies": {
     "@forge/admin": "workspace:*",
     "@forge/cms": "workspace:*",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "3.2.4"
   }
 }

--- a/packages/graphql/scripts/capture-parity-fixture.ts
+++ b/packages/graphql/scripts/capture-parity-fixture.ts
@@ -1,0 +1,112 @@
+/**
+ * One-shot CLI to capture a Strapi + admin response pair into a
+ * committed fixture file.
+ *
+ * Usage:
+ *   FORGE_PARITY_LIVE=1 \
+ *   FORGE_STRAPI_URL=... \
+ *   FORGE_ADMIN_URL=... \
+ *   FORGE_STRAPI_PUBLIC_ORIGIN=... \
+ *   pnpm tsx packages/graphql/scripts/capture-parity-fixture.ts \
+ *     --slug <slug> --locale <locale> --out <path>
+ *
+ * Sanitization:
+ *   - Authorization headers and the configured `FORGE_*_URL` env-var
+ *     values are stripped from any structured output.
+ *   - Internal-token-shaped strings (long hex / base64) are not auto-
+ *     redacted — the operator inspects the captured fixture before
+ *     committing it.
+ *
+ * Strapi-side query MUST set `pagination: { limit: -1 }` on every
+ * nested relation array inside block fragments per plan R8. The
+ * fragment definitions live alongside this script (parallel to
+ * apps/web/src/lib/fragments/, but with the override applied).
+ *
+ * NOTE: this script is dev-only tooling. The fragment definitions and
+ * full transport wiring are deliberately stubbed below — the structure
+ * is in place so the canary PR can complete the wiring against the
+ * actual chosen route. See plan U6.
+ */
+
+import { writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { assertLiveModeEnabled, validateHost } from "../src/parity/live"
+
+type Args = {
+  slug: string | null
+  locale: string | null
+  out: string | null
+  allowProduction: boolean
+}
+
+function parseArgs(argv: ReadonlyArray<string>): Args {
+  const args: Args = {
+    slug: null,
+    locale: null,
+    out: null,
+    allowProduction: false,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === "--slug") args.slug = argv[++i] ?? null
+    else if (arg === "--locale") args.locale = argv[++i] ?? null
+    else if (arg === "--out") args.out = argv[++i] ?? null
+    else if (arg === "--allow-production") args.allowProduction = true
+  }
+  return args
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.slug || !args.locale || !args.out) {
+    process.stderr.write(
+      "usage: capture-parity-fixture --slug <slug> --locale <locale> --out <path>\n",
+    )
+    process.exit(2)
+  }
+
+  const config = assertLiveModeEnabled(process.env)
+  validateHost(config.adminUrl, "FORGE_ADMIN_URL")
+  validateHost(config.strapiUrl, "FORGE_STRAPI_URL")
+
+  // The actual GraphQL query wiring is deferred to U5's canary PR
+  // (per plan: "Whether the canary route's captured fixture lives in
+  // this PR or the U5 canary PR" — leaning U5). The structure here
+  // proves the script's framing works: env validation, host
+  // validation, output sanitization, and on-disk write.
+  process.stderr.write(
+    `[capture-parity-fixture] env validated; slug=${args.slug} locale=${args.locale}\n`,
+  )
+  process.stderr.write(
+    "[capture-parity-fixture] GraphQL fetcher wiring deferred to canary PR (per U6 plan).\n",
+  )
+
+  const placeholder = {
+    metadata: {
+      capturedAt: new Date().toISOString(),
+      slug: args.slug,
+      locale: args.locale,
+      strapiHost: new URL(config.strapiUrl).host,
+      adminHost: new URL(config.adminUrl).host,
+      note: "Placeholder — real Strapi/admin fetchers land in U5's canary PR.",
+    },
+    strapi: null,
+    admin: null,
+  }
+
+  const outPath = resolve(process.cwd(), args.out)
+  writeFileSync(outPath, JSON.stringify(placeholder, null, 2) + "\n", "utf-8")
+  process.stderr.write(`[capture-parity-fixture] wrote ${outPath}\n`)
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof Error) {
+    process.stderr.write(
+      `[capture-parity-fixture] ${error.name}: ${error.message}\n`,
+    )
+  } else {
+    process.stderr.write(`[capture-parity-fixture] unknown error\n`)
+  }
+  process.exit(1)
+})

--- a/packages/graphql/scripts/capture-parity-fixture.ts
+++ b/packages/graphql/scripts/capture-parity-fixture.ts
@@ -28,7 +28,12 @@
  * actual chosen route. See plan U6.
  */
 
-import { assertLiveModeEnabled } from "../src/parity/live"
+// Import from live-config directly, NOT from live.ts. live.ts transitively
+// pulls in normalize-admin.ts which imports BlocksSchema from
+// @forge/admin/domain/blocks — tsx's ESM static-link step can't resolve
+// named exports from a cross-workspace .ts source path. The script only
+// needs env validation, which lives in live-config (no normalize-* imports).
+import { assertLiveModeEnabled } from "../src/parity/live-config"
 
 type Args = {
   slug: string | null

--- a/packages/graphql/scripts/capture-parity-fixture.ts
+++ b/packages/graphql/scripts/capture-parity-fixture.ts
@@ -28,10 +28,7 @@
  * actual chosen route. See plan U6.
  */
 
-import { writeFileSync } from "node:fs"
-import { resolve } from "node:path"
-
-import { assertLiveModeEnabled, validateHost } from "../src/parity/live"
+import { assertLiveModeEnabled } from "../src/parity/live"
 
 type Args = {
   slug: string | null
@@ -66,38 +63,25 @@ async function main(): Promise<void> {
     process.exit(2)
   }
 
-  const config = assertLiveModeEnabled(process.env)
-  validateHost(config.adminUrl, "FORGE_ADMIN_URL")
-  validateHost(config.strapiUrl, "FORGE_STRAPI_URL")
+  // assertLiveModeEnabled validates env + both host URLs; no extra
+  // validateHost calls needed here.
+  assertLiveModeEnabled(process.env)
 
   // The actual GraphQL query wiring is deferred to U5's canary PR
   // (per plan: "Whether the canary route's captured fixture lives in
-  // this PR or the U5 canary PR" — leaning U5). The structure here
-  // proves the script's framing works: env validation, host
-  // validation, output sanitization, and on-disk write.
+  // this PR or the U5 canary PR" — leaning U5). Until the wiring
+  // lands, the script exits with a deferred-message rather than
+  // writing a misleading null-payload fixture.
   process.stderr.write(
     `[capture-parity-fixture] env validated; slug=${args.slug} locale=${args.locale}\n`,
   )
   process.stderr.write(
-    "[capture-parity-fixture] GraphQL fetcher wiring deferred to canary PR (per U6 plan).\n",
+    "[capture-parity-fixture] GraphQL fetcher wiring is deferred to U5's canary PR.\n",
   )
-
-  const placeholder = {
-    metadata: {
-      capturedAt: new Date().toISOString(),
-      slug: args.slug,
-      locale: args.locale,
-      strapiHost: new URL(config.strapiUrl).host,
-      adminHost: new URL(config.adminUrl).host,
-      note: "Placeholder — real Strapi/admin fetchers land in U5's canary PR.",
-    },
-    strapi: null,
-    admin: null,
-  }
-
-  const outPath = resolve(process.cwd(), args.out)
-  writeFileSync(outPath, JSON.stringify(placeholder, null, 2) + "\n", "utf-8")
-  process.stderr.write(`[capture-parity-fixture] wrote ${outPath}\n`)
+  process.stderr.write(
+    "[capture-parity-fixture] No fixture file written — see plan U6 Open Questions.\n",
+  )
+  process.exit(2)
 }
 
 main().catch((error: unknown) => {

--- a/packages/graphql/src/parity/__fixtures__/captured/canary-experience.ts
+++ b/packages/graphql/src/parity/__fixtures__/captured/canary-experience.ts
@@ -1,0 +1,45 @@
+/**
+ * Captured-from-live canary fixture — PLACEHOLDER.
+ *
+ * Real Strapi + admin response captures land here once the canary
+ * route is selected (U5). The placeholder exports the expected file
+ * shape so adding the real data is a single-file change.
+ *
+ * Per the U6 plan: "Real captured data lands when canary route is
+ * selected (deferred decision in Open Questions); the placeholder
+ * structure makes the addition a single-file change."
+ *
+ * Capture procedure:
+ *   1. Set FORGE_PARITY_LIVE=1, FORGE_STRAPI_URL, FORGE_ADMIN_URL,
+ *      FORGE_STRAPI_PUBLIC_ORIGIN locally.
+ *   2. Run:
+ *        pnpm tsx packages/graphql/scripts/capture-parity-fixture.ts \
+ *          --slug <canary-slug> --locale <locale> \
+ *          --out packages/graphql/src/parity/__fixtures__/captured/canary-experience.json
+ *   3. Inspect the JSON for sensitive fields before committing.
+ *   4. Update this file to import from the JSON.
+ */
+
+import type { NormalizedExperienceRoute } from "../../shared-shape"
+
+export type CapturedFixture = {
+  readonly name: string
+  readonly slug: string
+  readonly locale: string
+  readonly capturedAt: string | null
+  readonly strapi: NormalizedExperienceRoute | null
+  readonly admin: NormalizedExperienceRoute | null
+}
+
+export const CANARY_EXPERIENCE: CapturedFixture = {
+  name: "canary-experience-placeholder",
+  slug: "PLACEHOLDER_SLUG",
+  locale: "en",
+  capturedAt: null,
+  strapi: null,
+  admin: null,
+}
+
+export const CAPTURED_FIXTURES: ReadonlyArray<CapturedFixture> = [
+  CANARY_EXPERIENCE,
+]

--- a/packages/graphql/src/parity/__fixtures__/fixtures.test.ts
+++ b/packages/graphql/src/parity/__fixtures__/fixtures.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+
+import { compareNormalizedRoutes } from "../compare"
+import {
+  CANARY_EXPERIENCE,
+  CAPTURED_FIXTURES,
+} from "./captured/canary-experience"
+import {
+  ORDER_BLOCKS_REORDERED,
+  PER_CLASS_FIXTURES,
+  SEMANTIC_LOCALE_FALLTHROUGH,
+  STRUCTURAL_MISSING_FIELD,
+  VALUE_TITLE_MISMATCH,
+} from "./hand-rolled/per-class"
+
+describe("hand-rolled per-class fixtures", () => {
+  it("STRUCTURAL_MISSING_FIELD produces exactly one structural diff", () => {
+    const r = compareNormalizedRoutes(
+      STRUCTURAL_MISSING_FIELD.strapi,
+      STRUCTURAL_MISSING_FIELD.admin,
+      { urlLocale: "en" },
+    )
+    expect(r.value).toEqual([])
+    expect(r.semantic).toEqual([])
+    expect(r.order).toEqual([])
+    expect(r.structural).toHaveLength(1)
+    expect(r.structural[0]?.path).toBe("/description")
+    expect(r.structural[0]?.side).toBe("admin")
+  })
+
+  it("VALUE_TITLE_MISMATCH produces exactly one value diff", () => {
+    const r = compareNormalizedRoutes(
+      VALUE_TITLE_MISMATCH.strapi,
+      VALUE_TITLE_MISMATCH.admin,
+      { urlLocale: "en" },
+    )
+    expect(r.structural).toEqual([])
+    expect(r.semantic).toEqual([])
+    expect(r.order).toEqual([])
+    expect(r.value).toHaveLength(1)
+    expect(r.value[0]?.path).toBe("/title")
+  })
+
+  it("ORDER_BLOCKS_REORDERED produces exactly one order diff", () => {
+    const r = compareNormalizedRoutes(
+      ORDER_BLOCKS_REORDERED.strapi,
+      ORDER_BLOCKS_REORDERED.admin,
+      { urlLocale: "en" },
+    )
+    expect(r.structural).toEqual([])
+    expect(r.value).toEqual([])
+    expect(r.semantic).toEqual([])
+    expect(r.order).toHaveLength(1)
+    expect(r.order[0]?.path).toBe("/blocks")
+  })
+
+  it("SEMANTIC_LOCALE_FALLTHROUGH produces exactly one semantic locale-mismatch", () => {
+    const r = compareNormalizedRoutes(
+      SEMANTIC_LOCALE_FALLTHROUGH.strapi,
+      SEMANTIC_LOCALE_FALLTHROUGH.admin,
+      { urlLocale: "en" },
+    )
+    expect(r.structural).toEqual([])
+    expect(r.value).toEqual([])
+    expect(r.order).toEqual([])
+    expect(r.semantic).toHaveLength(1)
+    expect(r.semantic[0]?.subclass).toBe("locale-mismatch")
+  })
+
+  it("each per-class fixture produces a non-empty report (smoke check)", () => {
+    for (const fixture of PER_CLASS_FIXTURES) {
+      const r = compareNormalizedRoutes(fixture.strapi, fixture.admin, {
+        urlLocale: "en",
+      })
+      const totalDiffs =
+        r.structural.length +
+        r.value.length +
+        r.order.length +
+        r.semantic.length
+      expect(totalDiffs, `fixture ${fixture.name}`).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("captured fixtures (placeholder)", () => {
+  it("canary-experience placeholder is structured and labeled (will be populated in U5)", () => {
+    expect(CANARY_EXPERIENCE.name).toBe("canary-experience-placeholder")
+    expect(CANARY_EXPERIENCE.strapi).toBeNull()
+    expect(CANARY_EXPERIENCE.admin).toBeNull()
+    expect(CAPTURED_FIXTURES).toHaveLength(1)
+  })
+
+  // When U5 populates the canary fixture, the test above flips to assert
+  // that compareNormalizedRoutes produces an empty diff (modulo the
+  // default allow-list) when given the captured strapi + admin sides.
+  // For now, the placeholder structurally reserves the slot.
+})

--- a/packages/graphql/src/parity/__fixtures__/hand-rolled/per-class.ts
+++ b/packages/graphql/src/parity/__fixtures__/hand-rolled/per-class.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-diff-class hand-rolled fixtures.
+ *
+ * One fixture per known-bad scenario, each producing exactly the
+ * expected diff entry on the corresponding channel. These fixtures
+ * cover BRANCH SHAPE — production-faithful captured-from-live
+ * fixtures live under `../captured/`. Both tiers exist per the
+ * mocked-vs-real-contract-discipline learning.
+ */
+
+import type { NormalizedExperienceRoute } from "../../shared-shape"
+
+function baseRoute(
+  source: "strapi" | "admin",
+  overrides: Partial<NormalizedExperienceRoute> = {},
+): NormalizedExperienceRoute {
+  return {
+    id: source === "strapi" ? "doc-base" : "exp-loc-base",
+    slug: "fixture-slug",
+    locale: "en",
+    title: "Fixture Title",
+    description: null,
+    ogImage: null,
+    blocks: [],
+    meta: {
+      source,
+      potentiallyTruncated: false,
+      rawUrls: {},
+    },
+    ...overrides,
+  }
+}
+
+// Structural class — admin missing a present-on-strapi field.
+export const STRUCTURAL_MISSING_FIELD = {
+  name: "structural-missing-field",
+  strapi: baseRoute("strapi", {
+    description: "present on strapi",
+  }),
+  admin: baseRoute("admin", {
+    description: null, // missing-as-null, treated as absent
+  }),
+} as const
+
+// Value class — same shape, differing scalar value.
+export const VALUE_TITLE_MISMATCH = {
+  name: "value-title-mismatch",
+  strapi: baseRoute("strapi", { title: "Easter" }),
+  admin: baseRoute("admin", { title: "Easter Story" }),
+} as const
+
+// Order class — same set of blocks, different order.
+export const ORDER_BLOCKS_REORDERED = {
+  name: "order-blocks-reordered",
+  strapi: baseRoute("strapi", {
+    blocks: [
+      { kind: "text", id: "a", data: {} },
+      { kind: "cta", id: "b", data: {} },
+      { kind: "video", id: "c", data: {} },
+    ] as unknown as NormalizedExperienceRoute["blocks"],
+  }),
+  admin: baseRoute("admin", {
+    blocks: [
+      { kind: "text", id: "a", data: {} },
+      { kind: "video", id: "c", data: {} },
+      { kind: "cta", id: "b", data: {} },
+    ] as unknown as NormalizedExperienceRoute["blocks"],
+  }),
+} as const
+
+// Semantic class — strapi resolved to a different locale than the URL.
+export const SEMANTIC_LOCALE_FALLTHROUGH = {
+  name: "semantic-locale-fallthrough",
+  strapi: baseRoute("strapi", { locale: "es" }),
+  admin: baseRoute("admin", { locale: "en" }),
+} as const
+
+export const PER_CLASS_FIXTURES = [
+  STRUCTURAL_MISSING_FIELD,
+  VALUE_TITLE_MISMATCH,
+  ORDER_BLOCKS_REORDERED,
+  SEMANTIC_LOCALE_FALLTHROUGH,
+] as const

--- a/packages/graphql/src/parity/allow-list.ts
+++ b/packages/graphql/src/parity/allow-list.ts
@@ -1,0 +1,89 @@
+/**
+ * Expected-divergence allow-list for the parity differ.
+ *
+ * Entries name divergences that are by-design — admin and Strapi
+ * intentionally differ on these fields, so the differ should NOT flag
+ * them as drift. Each entry carries:
+ *
+ * - `path`: the JSON Pointer (RFC6901) of the diff entry to filter
+ * - `channel`: which diff class the entry applies to
+ * - `rationale`: WHY this divergence is expected; should reference a
+ *   decision document under docs/solutions/ or the upstream brief
+ *
+ * The runtime check is a simple substring/exact match. Entries that
+ * apply to multiple paths (e.g., every `ogImage.*` field) need an entry
+ * per path — this keeps each suppression auditable.
+ *
+ * Seeded from `docs/solutions/cms/admin-app-data-model-decisions.md`
+ * and the U4 plan's known divergences.
+ */
+
+export type AllowListChannel = "structural" | "value" | "order" | "semantic"
+
+export type AllowListEntry = {
+  /** RFC6901 JSON Pointer the entry applies to. */
+  readonly path: string
+  /** Diff channel this entry suppresses on. */
+  readonly channel: AllowListChannel
+  /** Why this divergence is expected. NEVER an empty string. */
+  readonly rationale: string
+}
+
+export type AppliedAllowListEntry = {
+  readonly path: string
+  readonly channel: AllowListChannel
+  readonly rationale: string
+}
+
+/**
+ * Default seed allow-list. Captures the known intentional divergences
+ * between Strapi and admin as of 2026-05-08. Add new entries with a
+ * rationale that names the decision doc or PR introducing the divergence.
+ *
+ * Adding entries here without a rationale that points to a tracked
+ * decision is the documented anti-pattern — see plan Risks.
+ */
+export const DEFAULT_ALLOW_LIST: ReadonlyArray<AllowListEntry> = [
+  {
+    path: "/ogImage/width",
+    channel: "structural",
+    rationale:
+      "admin schema exposes ogImageUrl only; structural ogImage fields (width/height/alt) are filled with null by the admin normalizer. See docs/solutions/cms/admin-app-data-model-decisions.md.",
+  },
+  {
+    path: "/ogImage/height",
+    channel: "structural",
+    rationale:
+      "admin schema exposes ogImageUrl only; structural ogImage fields (width/height/alt) are filled with null by the admin normalizer. See docs/solutions/cms/admin-app-data-model-decisions.md.",
+  },
+  {
+    path: "/ogImage/alt",
+    channel: "structural",
+    rationale:
+      "admin schema exposes ogImageUrl only; structural ogImage fields (width/height/alt) are filled with null by the admin normalizer. See docs/solutions/cms/admin-app-data-model-decisions.md.",
+  },
+  {
+    path: "/id",
+    channel: "value",
+    rationale:
+      "Top-level experience id differs by design — admin uses cuid (ExperienceLocale.id); Strapi uses documentId. Cross-side ID equality is NOT a parity check (per U5 semantic class).",
+  },
+]
+
+/**
+ * Lookup table indexed by path for O(1) suppression check.
+ */
+export function indexAllowList(
+  entries: ReadonlyArray<AllowListEntry>,
+): ReadonlyMap<string, AllowListEntry> {
+  const map = new Map<string, AllowListEntry>()
+  for (const entry of entries) {
+    if (entry.rationale === "") {
+      throw new Error(
+        `allow-list entry at path '${entry.path}' has empty rationale`,
+      )
+    }
+    map.set(`${entry.channel}:${entry.path}`, entry)
+  }
+  return map
+}

--- a/packages/graphql/src/parity/canonicalize-url.test.ts
+++ b/packages/graphql/src/parity/canonicalize-url.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+
+import { CanonicalizeUrlError, canonicalizeUrl } from "./canonicalize-url"
+
+const STRAPI = {
+  schema: "strapi",
+  baseOrigin: "https://cdn.example.com",
+} as const
+const ADMIN = {
+  schema: "admin",
+  baseOrigin: "https://cdn.example.com",
+} as const
+
+describe("canonicalizeUrl — strapi schema", () => {
+  it("expands a root-relative path against baseOrigin", () => {
+    const result = canonicalizeUrl("/images/foo.jpg", STRAPI)
+    expect(result.canonical).toBe("https://cdn.example.com/images/foo.jpg")
+    expect(result.raw).toBe("/images/foo.jpg")
+  })
+
+  it("passes through an already-absolute URL unchanged in form", () => {
+    const result = canonicalizeUrl("https://other.example.com/foo.jpg", STRAPI)
+    expect(result.canonical).toBe("https://other.example.com/foo.jpg")
+    expect(result.raw).toBe("https://other.example.com/foo.jpg")
+  })
+
+  it("preserves the raw input alongside the canonical output", () => {
+    const result = canonicalizeUrl("/images/x.png", STRAPI)
+    expect(result.raw).toBe("/images/x.png")
+    expect(result.canonical).not.toBe("/images/x.png")
+  })
+})
+
+describe("canonicalizeUrl — admin schema", () => {
+  it("strips a trailing slash from the pathname", () => {
+    const result = canonicalizeUrl("https://cdn.example.com/foo.jpg/", ADMIN)
+    expect(result.canonical).toBe("https://cdn.example.com/foo.jpg")
+  })
+
+  it("strips UTM-style query keys", () => {
+    const result = canonicalizeUrl(
+      "https://cdn.example.com/foo.jpg?utm_source=email&utm_campaign=launch",
+      ADMIN,
+    )
+    expect(result.canonical).toBe("https://cdn.example.com/foo.jpg")
+  })
+
+  it("strips gclid and fbclid tracking keys", () => {
+    const result = canonicalizeUrl(
+      "https://cdn.example.com/foo.jpg?gclid=abc&fbclid=def",
+      ADMIN,
+    )
+    expect(result.canonical).toBe("https://cdn.example.com/foo.jpg")
+  })
+
+  it("preserves non-tracking query keys", () => {
+    const result = canonicalizeUrl(
+      "https://cdn.example.com/foo.jpg?width=400&utm_source=email",
+      ADMIN,
+    )
+    expect(result.canonical).toBe("https://cdn.example.com/foo.jpg?width=400")
+  })
+
+  it("lowercases the host", () => {
+    const result = canonicalizeUrl("https://CDN.Example.COM/foo.jpg", ADMIN)
+    expect(result.canonical).toBe("https://cdn.example.com/foo.jpg")
+  })
+
+  it("preserves the raw input verbatim regardless of canonicalization", () => {
+    const raw = "https://cdn.example.com/foo.jpg/?utm_source=email"
+    const result = canonicalizeUrl(raw, ADMIN)
+    expect(result.raw).toBe(raw)
+    expect(result.canonical).toBe("https://cdn.example.com/foo.jpg")
+  })
+
+  it("preserves the root pathname '/'", () => {
+    const result = canonicalizeUrl("https://cdn.example.com/", ADMIN)
+    expect(result.canonical).toBe("https://cdn.example.com/")
+  })
+})
+
+describe("canonicalizeUrl — error / failure modes", () => {
+  it("throws on empty input", () => {
+    expect(() => canonicalizeUrl("", STRAPI)).toThrow(CanonicalizeUrlError)
+  })
+
+  it("returns a structured failure for a malformed absolute URL", () => {
+    const result = canonicalizeUrl("not a url", STRAPI)
+    expect(result.canonical).toBeNull()
+    if (result.canonical === null) {
+      expect(result.reason).toBe("malformed")
+      expect(result.raw).toBe("not a url")
+    }
+  })
+
+  it("returns a structured failure for a Strapi-relative path with an invalid base", () => {
+    // baseOrigin without a scheme — `new URL("/foo", "garbage")` throws.
+    const result = canonicalizeUrl("/foo.jpg", {
+      schema: "strapi",
+      baseOrigin: "garbage",
+    })
+    expect(result.canonical).toBeNull()
+  })
+
+  it("does NOT throw on malformed input — only empty input throws", () => {
+    expect(() =>
+      canonicalizeUrl("totally://broken url with spaces", STRAPI),
+    ).not.toThrow()
+  })
+})

--- a/packages/graphql/src/parity/canonicalize-url.ts
+++ b/packages/graphql/src/parity/canonicalize-url.ts
@@ -1,0 +1,110 @@
+/**
+ * URL canonicalization for parity diffing.
+ *
+ * The differ requires both Strapi and admin URLs to be in a single
+ * canonical form before comparison; otherwise every image field
+ * produces a false-positive value diff (Strapi serves root-relative
+ * paths like `/images/foo.jpg`; admin serves absolute URLs from a CDN).
+ *
+ * Both sides pass through `canonicalizeUrl` before reaching the differ.
+ * The raw input is preserved alongside the canonical form so the diff
+ * record can show reviewers what each side actually returned.
+ *
+ * Per the URL-handling learning at
+ * docs/solutions/integration-issues/mobile-relative-image-url-no-base-origin-20260408.md.
+ */
+
+/**
+ * Tracking-style query parameters stripped during canonicalization.
+ * Conservative — only well-known marketing/analytics keys; do not add
+ * keys that might be load-bearing on a content URL.
+ */
+const STRIPPED_QUERY_KEYS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "gclid",
+  "fbclid",
+])
+
+export type CanonicalizeUrlConfig = {
+  readonly schema: "strapi" | "admin"
+  /**
+   * Origin used to resolve Strapi root-relative paths to absolute URLs.
+   * Required for the strapi schema; ignored when admin URLs are already absolute.
+   * Format: `https://example.com` (no trailing slash).
+   */
+  readonly baseOrigin: string
+}
+
+export type CanonicalUrl = {
+  readonly canonical: string
+  readonly raw: string
+}
+
+export type CanonicalUrlFailure = {
+  readonly canonical: null
+  readonly raw: string
+  readonly reason: "empty" | "malformed"
+}
+
+export class CanonicalizeUrlError extends Error {
+  override readonly name = "CanonicalizeUrlError"
+}
+
+/**
+ * Canonicalize a URL string into the form the differ compares.
+ *
+ * Throws `CanonicalizeUrlError` for empty input — the parity contract
+ * requires URL fields to be non-empty strings or `null`; an empty
+ * non-null URL is a producer-side bug worth surfacing immediately.
+ *
+ * Returns a structured `CanonicalUrlFailure` for malformed URLs so the
+ * differ can flag the value as a mismatch without the call site having
+ * to handle a thrown exception.
+ */
+export function canonicalizeUrl(
+  raw: string,
+  config: CanonicalizeUrlConfig,
+): CanonicalUrl | CanonicalUrlFailure {
+  if (raw === "") {
+    throw new CanonicalizeUrlError(
+      "canonicalizeUrl: input must be non-empty; pass null when a URL field is absent",
+    )
+  }
+
+  let parsed: URL
+  try {
+    if (config.schema === "strapi" && raw.startsWith("/")) {
+      parsed = new URL(raw, config.baseOrigin)
+    } else {
+      parsed = new URL(raw)
+    }
+  } catch {
+    return { canonical: null, raw, reason: "malformed" }
+  }
+
+  // Strip tracking query keys.
+  const params = parsed.searchParams
+  const trackedKeys: string[] = []
+  for (const key of params.keys()) {
+    if (STRIPPED_QUERY_KEYS.has(key)) trackedKeys.push(key)
+  }
+  for (const key of trackedKeys) params.delete(key)
+
+  // Lowercase host (origin canonicalization).
+  parsed.host = parsed.host.toLowerCase()
+
+  // Strip trailing slash on the pathname unless it IS the root path.
+  if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "")
+  }
+
+  // Drop any explicit port matching the protocol's default (`new URL`
+  // already handles this, but call it out — `:443` on https never appears
+  // in canonical output).
+
+  return { canonical: parsed.toString(), raw }
+}

--- a/packages/graphql/src/parity/compare.test.ts
+++ b/packages/graphql/src/parity/compare.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest"
+
+import { compareNormalizedRoutes } from "./compare"
+import type { AllowListEntry } from "./allow-list"
+import type { NormalizedExperienceRoute } from "./shared-shape"
+
+const OPTIONS = { urlLocale: "en" } as const
+
+function makeRoute(
+  source: "strapi" | "admin",
+  overrides: Partial<NormalizedExperienceRoute> = {},
+): NormalizedExperienceRoute {
+  return {
+    id: source === "strapi" ? "doc-1" : "exp-loc-1",
+    slug: "test-slug",
+    locale: "en",
+    title: "Test Experience",
+    description: null,
+    ogImage: null,
+    blocks: [],
+    meta: {
+      source,
+      potentiallyTruncated: false,
+      rawUrls: {},
+    },
+    ...overrides,
+  }
+}
+
+const NO_ALLOW_LIST: ReadonlyArray<AllowListEntry> = []
+
+describe("compareNormalizedRoutes — happy path", () => {
+  it("identical inputs produce empty diff across all channels", () => {
+    const strapi = makeRoute("strapi", { id: "same-id" })
+    const admin = makeRoute("admin", { id: "same-id" })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.structural).toEqual([])
+    expect(report.value).toEqual([])
+    expect(report.order).toEqual([])
+    expect(report.semantic).toEqual([])
+    expect(report.potentiallyTruncated).toEqual([])
+  })
+})
+
+describe("compareNormalizedRoutes — structural class", () => {
+  it("flags admin-missing-description as structural { side: 'admin' }", () => {
+    const strapi = makeRoute("strapi", {
+      id: "x",
+      description: "S desc",
+    })
+    const admin = makeRoute("admin", { id: "x", description: null })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.structural).toHaveLength(1)
+    expect(report.structural[0]).toMatchObject({
+      path: "/description",
+      side: "admin",
+    })
+  })
+
+  it("treats null and missing-key as equivalent post-normalization", () => {
+    const strapi = makeRoute("strapi", { id: "x", description: null })
+    const admin = makeRoute("admin", { id: "x", description: null })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.structural).toEqual([])
+  })
+})
+
+describe("compareNormalizedRoutes — value class", () => {
+  it("flags differing titles as value with both raw values", () => {
+    const strapi = makeRoute("strapi", { id: "x", title: "Easter" })
+    const admin = makeRoute("admin", { id: "x", title: "Easter Story" })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.value).toHaveLength(1)
+    expect(report.value[0]).toMatchObject({
+      path: "/title",
+      strapi: "Easter",
+      admin: "Easter Story",
+    })
+  })
+})
+
+describe("compareNormalizedRoutes — order class", () => {
+  it("flags blocks reordered (same set, different order) as order diff", () => {
+    const blocksStrapi = [
+      { kind: "text", id: "a", data: {} },
+      { kind: "cta", id: "b", data: {} },
+      { kind: "video", id: "c", data: {} },
+    ] as const
+    const blocksAdmin = [
+      { kind: "text", id: "a", data: {} },
+      { kind: "video", id: "c", data: {} },
+      { kind: "cta", id: "b", data: {} },
+    ] as const
+    const strapi = makeRoute("strapi", {
+      id: "x",
+      blocks: blocksStrapi as unknown as NormalizedExperienceRoute["blocks"],
+    })
+    const admin = makeRoute("admin", {
+      id: "x",
+      blocks: blocksAdmin as unknown as NormalizedExperienceRoute["blocks"],
+    })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.order).toHaveLength(1)
+    expect(report.order[0]?.path).toBe("/blocks")
+    expect(report.order[0]?.strapiOrder).toEqual(["a", "b", "c"])
+    expect(report.order[0]?.adminOrder).toEqual(["a", "c", "b"])
+  })
+})
+
+describe("compareNormalizedRoutes — semantic locale-mismatch", () => {
+  it("fires when strapi resolved locale differs from URL locale", () => {
+    const strapi = makeRoute("strapi", { id: "x", locale: "es" })
+    const admin = makeRoute("admin", { id: "x", locale: "en" })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.semantic).toHaveLength(1)
+    expect(report.semantic[0]).toMatchObject({
+      path: "/locale",
+      subclass: "locale-mismatch",
+      strapi: "es",
+      admin: "en",
+    })
+  })
+
+  it("fires when admin resolved locale differs from URL locale (Strapi was correct)", () => {
+    const strapi = makeRoute("strapi", { id: "x", locale: "en" })
+    const admin = makeRoute("admin", { id: "x", locale: "es" })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.semantic).toHaveLength(1)
+    expect(report.semantic[0]?.subclass).toBe("locale-mismatch")
+  })
+
+  it("does not fire when both sides match the URL locale", () => {
+    const strapi = makeRoute("strapi", { id: "x", locale: "en" })
+    const admin = makeRoute("admin", { id: "x", locale: "en" })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(report.semantic).toEqual([])
+  })
+})
+
+describe("compareNormalizedRoutes — truncation downgrade", () => {
+  it("admin-tail entries land in potentiallyTruncated when strapi side is flagged truncated", () => {
+    const blocksStrapi = [
+      { kind: "text", id: "a", data: {} },
+      { kind: "text", id: "b", data: {} },
+    ] as const
+    const blocksAdmin = [
+      { kind: "text", id: "a", data: {} },
+      { kind: "text", id: "b", data: {} },
+      { kind: "text", id: "c", data: {} },
+      { kind: "text", id: "d", data: {} },
+    ] as const
+    const strapi = makeRoute("strapi", {
+      id: "x",
+      blocks: blocksStrapi as unknown as NormalizedExperienceRoute["blocks"],
+      meta: {
+        source: "strapi",
+        potentiallyTruncated: true,
+        rawUrls: {},
+      },
+    })
+    const admin = makeRoute("admin", {
+      id: "x",
+      blocks: blocksAdmin as unknown as NormalizedExperienceRoute["blocks"],
+    })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    // Tail entries reclassified out of structural.
+    expect(report.structural).toEqual([])
+    expect(report.potentiallyTruncated).toHaveLength(2)
+    expect(report.potentiallyTruncated.every((e) => e.side === "strapi")).toBe(
+      true,
+    )
+  })
+})
+
+describe("compareNormalizedRoutes — allow-list", () => {
+  it("filters out entries whose path+channel match the allow-list", () => {
+    // Realistic case: admin cuid vs Strapi documentId differ.
+    const strapi = makeRoute("strapi", { id: "doc-strapi-1" })
+    const admin = makeRoute("admin", { id: "exp-loc-cuid-1" })
+    const report = compareNormalizedRoutes(strapi, admin, OPTIONS)
+    // Default allow-list suppresses /id on the value channel.
+    expect(report.value.find((e) => e.path === "/id")).toBeUndefined()
+    expect(report.meta.appliedAllowList.some((e) => e.path === "/id")).toBe(
+      true,
+    )
+  })
+
+  it("indexAllowList rejects entries with empty rationale", () => {
+    expect(() =>
+      compareNormalizedRoutes(makeRoute("strapi"), makeRoute("admin"), {
+        ...OPTIONS,
+        allowList: [{ path: "/x", channel: "value", rationale: "" }],
+      }),
+    ).toThrow(/empty rationale/)
+  })
+})
+
+describe("compareNormalizedRoutes — determinism", () => {
+  it("two consecutive runs over identical inputs produce byte-identical JSON", () => {
+    const blocksStrapi = [
+      { kind: "text", id: "a", data: {} },
+      { kind: "cta", id: "b", data: {} },
+      { kind: "video", id: "c", data: {} },
+    ] as const
+    const strapi = makeRoute("strapi", {
+      id: "same",
+      blocks: blocksStrapi as unknown as NormalizedExperienceRoute["blocks"],
+    })
+    const admin = makeRoute("admin", {
+      id: "same",
+      blocks: [
+        { kind: "text", id: "a", data: {} },
+        { kind: "video", id: "c", data: {} },
+        { kind: "cta", id: "b", data: {} },
+      ] as unknown as NormalizedExperienceRoute["blocks"],
+    })
+    const report1 = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    const report2 = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    expect(JSON.stringify(report1)).toBe(JSON.stringify(report2))
+  })
+
+  it("path-pointer numeric-aware sort: /blocks/2 precedes /blocks/10", () => {
+    // 11 blocks each so /blocks/10 is a meaningful path; differ entries
+    // appear at every index where contents differ.
+    const strapiBlocks = Array.from(
+      { length: 11 },
+      (_, i) =>
+        ({ kind: "text", id: `b-${i}`, data: { v: i } }) as unknown as never,
+    )
+    const adminBlocks = Array.from(
+      { length: 11 },
+      (_, i) =>
+        ({
+          kind: "text",
+          id: `b-${i}`,
+          data: { v: i + 100 }, // every value differs
+        }) as unknown as never,
+    )
+    const strapi = makeRoute("strapi", {
+      id: "x",
+      blocks: strapiBlocks as unknown as NormalizedExperienceRoute["blocks"],
+    })
+    const admin = makeRoute("admin", {
+      id: "x",
+      blocks: adminBlocks as unknown as NormalizedExperienceRoute["blocks"],
+    })
+    const report = compareNormalizedRoutes(strapi, admin, {
+      ...OPTIONS,
+      allowList: NO_ALLOW_LIST,
+    })
+    const valuePaths = report.value.map((e) => e.path)
+    // Find indices of /blocks/2 and /blocks/10 in the sorted output.
+    const idx2 = valuePaths.indexOf("/blocks/2/data/v")
+    const idx10 = valuePaths.indexOf("/blocks/10/data/v")
+    expect(idx2).toBeGreaterThanOrEqual(0)
+    expect(idx10).toBeGreaterThanOrEqual(0)
+    expect(idx2).toBeLessThan(idx10)
+  })
+})

--- a/packages/graphql/src/parity/compare.ts
+++ b/packages/graphql/src/parity/compare.ts
@@ -305,7 +305,7 @@ function walkArrays(
     if (i >= strapi.length) {
       // Admin has more entries.
       const tailPath = encodePointer([...segments, i])
-      if (ctx.strapiTruncated && i >= strapi.length) {
+      if (ctx.strapiTruncated) {
         ctx.potentiallyTruncated.push({
           path: tailPath,
           side: "strapi",

--- a/packages/graphql/src/parity/compare.ts
+++ b/packages/graphql/src/parity/compare.ts
@@ -1,0 +1,382 @@
+/**
+ * Four-class response parity differ.
+ *
+ * Takes two `NormalizedExperienceRoute` values (one per source) and
+ * returns a deterministic, JSON-serializable `DiffReport` classified
+ * across five channels:
+ *
+ *   - structural: field-presence asymmetries
+ *   - value:      deep-equality mismatches on present fields
+ *   - order:      ordered-collection identity mismatches
+ *   - semantic:   locale-mismatch, URL-canonicalization residual
+ *   - potentiallyTruncated: missing-tail entries on a side flagged
+ *                  with `meta.potentiallyTruncated: true`
+ *
+ * Determinism: every channel's entries are sorted by RFC6901 JSON
+ * Pointer with numeric-aware segment sort (per `path-pointer.ts`).
+ * Two consecutive runs over identical inputs produce byte-identical
+ * `JSON.stringify(report)`.
+ *
+ * Absent-field equivalence: `null` and missing-key are equivalent
+ * post-normalization (per plan Key Decisions). Only true presence /
+ * absence on one side surfaces in the structural channel.
+ */
+
+import {
+  DEFAULT_ALLOW_LIST,
+  indexAllowList,
+  type AllowListEntry,
+  type AppliedAllowListEntry,
+  type AllowListChannel,
+} from "./allow-list"
+import { comparePointer, encodePointer } from "./path-pointer"
+import type { NormalizedExperienceRoute } from "./shared-shape"
+
+// ---------------------------------------------------------------------------
+// Diff record types
+// ---------------------------------------------------------------------------
+
+export type StructuralDiff = {
+  readonly path: string
+  readonly side: "strapi" | "admin"
+  readonly message: string
+}
+
+export type ValueDiff = {
+  readonly path: string
+  readonly strapi: unknown
+  readonly admin: unknown
+}
+
+export type OrderDiff = {
+  readonly path: string
+  readonly strapiOrder: ReadonlyArray<string | number>
+  readonly adminOrder: ReadonlyArray<string | number>
+}
+
+export type SemanticSubclass = "locale-mismatch" | "url-canonicalization"
+
+export type SemanticDiff = {
+  readonly path: string
+  readonly subclass: SemanticSubclass
+  readonly strapi: unknown
+  readonly admin: unknown
+}
+
+export type PotentialTruncationDiff = {
+  readonly path: string
+  readonly side: "strapi" | "admin"
+  readonly message: string
+}
+
+export type DiffReport = {
+  readonly structural: ReadonlyArray<StructuralDiff>
+  readonly value: ReadonlyArray<ValueDiff>
+  readonly order: ReadonlyArray<OrderDiff>
+  readonly semantic: ReadonlyArray<SemanticDiff>
+  readonly potentiallyTruncated: ReadonlyArray<PotentialTruncationDiff>
+  readonly meta: {
+    readonly appliedAllowList: ReadonlyArray<AppliedAllowListEntry>
+  }
+}
+
+export type CompareOptions = {
+  /** URL locale the request asked for. Drives the locale semantic check. */
+  readonly urlLocale: string
+  /** Override the default allow-list. Pass an empty array to disable suppression. */
+  readonly allowList?: ReadonlyArray<AllowListEntry>
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+export function compareNormalizedRoutes(
+  strapi: NormalizedExperienceRoute,
+  admin: NormalizedExperienceRoute,
+  options: CompareOptions,
+): DiffReport {
+  const ctx: DiffContext = {
+    structural: [],
+    value: [],
+    order: [],
+    semantic: [],
+    potentiallyTruncated: [],
+    strapiTruncated: strapi.meta.potentiallyTruncated,
+    adminTruncated: admin.meta.potentiallyTruncated,
+  }
+
+  // Resolved-locale equality — semantic class. Both sides' locale must
+  // equal the URL locale. (We keep this BEFORE the structural walk so
+  // the locale path is treated as semantic, not value-class.)
+  if (strapi.locale !== options.urlLocale) {
+    ctx.semantic.push({
+      path: "/locale",
+      subclass: "locale-mismatch",
+      strapi: strapi.locale,
+      admin: admin.locale,
+    })
+  } else if (admin.locale !== options.urlLocale) {
+    ctx.semantic.push({
+      path: "/locale",
+      subclass: "locale-mismatch",
+      strapi: strapi.locale,
+      admin: admin.locale,
+    })
+  }
+
+  // Walk both normalized routes in lockstep, skipping `meta` (per-source
+  // metadata) and `locale` (handled above).
+  const skipKeys = new Set(["meta", "locale"])
+  walkObjects(strapi, admin, [], ctx, skipKeys)
+
+  // Apply allow-list suppression.
+  const allowList = options.allowList ?? DEFAULT_ALLOW_LIST
+  const allowIndex = indexAllowList(allowList)
+  const applied: AppliedAllowListEntry[] = []
+  const filterChannel = <T extends { path: string }>(
+    channel: AllowListChannel,
+    entries: T[],
+  ): T[] =>
+    entries.filter((e) => {
+      const key = `${channel}:${e.path}`
+      const match = allowIndex.get(key)
+      if (match) {
+        applied.push({
+          path: match.path,
+          channel: match.channel,
+          rationale: match.rationale,
+        })
+        return false
+      }
+      return true
+    })
+
+  const structural = filterChannel("structural", ctx.structural)
+  const valueChannel = filterChannel("value", ctx.value)
+  const order = filterChannel("order", ctx.order)
+  const semantic = filterChannel("semantic", ctx.semantic)
+
+  // Sort each channel by JSON-Pointer numeric-aware order — determinism.
+  structural.sort((a, b) => comparePointer(a.path, b.path))
+  valueChannel.sort((a, b) => comparePointer(a.path, b.path))
+  order.sort((a, b) => comparePointer(a.path, b.path))
+  semantic.sort((a, b) => comparePointer(a.path, b.path))
+  ctx.potentiallyTruncated.sort((a, b) => comparePointer(a.path, b.path))
+  applied.sort(
+    (a, b) =>
+      comparePointer(a.path, b.path) || a.channel.localeCompare(b.channel),
+  )
+
+  return {
+    structural: Object.freeze(structural),
+    value: Object.freeze(valueChannel),
+    order: Object.freeze(order),
+    semantic: Object.freeze(semantic),
+    potentiallyTruncated: Object.freeze(ctx.potentiallyTruncated),
+    meta: {
+      appliedAllowList: Object.freeze(applied),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Walk helpers
+// ---------------------------------------------------------------------------
+
+type DiffContext = {
+  structural: StructuralDiff[]
+  value: ValueDiff[]
+  order: OrderDiff[]
+  semantic: SemanticDiff[]
+  potentiallyTruncated: PotentialTruncationDiff[]
+  strapiTruncated: boolean
+  adminTruncated: boolean
+}
+
+function walkObjects(
+  strapi: unknown,
+  admin: unknown,
+  segments: ReadonlyArray<string | number>,
+  ctx: DiffContext,
+  skipKeys: ReadonlySet<string>,
+): void {
+  const path = encodePointer(segments)
+
+  // Treat null and undefined-or-missing as equivalent post-normalization.
+  const sNull = strapi === null || strapi === undefined
+  const aNull = admin === null || admin === undefined
+  if (sNull && aNull) return
+  if (sNull && !aNull) {
+    ctx.structural.push({
+      path,
+      side: "strapi",
+      message: "missing on strapi (admin has value)",
+    })
+    return
+  }
+  if (!sNull && aNull) {
+    ctx.structural.push({
+      path,
+      side: "admin",
+      message: "missing on admin (strapi has value)",
+    })
+    return
+  }
+
+  // Primitives → value compare.
+  if (typeof strapi !== "object" || typeof admin !== "object") {
+    if (strapi !== admin) {
+      ctx.value.push({ path, strapi, admin })
+    }
+    return
+  }
+
+  // Arrays → order + element walk.
+  const sArr = Array.isArray(strapi)
+  const aArr = Array.isArray(admin)
+  if (sArr || aArr) {
+    if (!sArr || !aArr) {
+      ctx.value.push({ path, strapi, admin })
+      return
+    }
+    walkArrays(
+      strapi as ReadonlyArray<unknown>,
+      admin as ReadonlyArray<unknown>,
+      segments,
+      ctx,
+      skipKeys,
+    )
+    return
+  }
+
+  // Objects → field-by-field.
+  const sObj = strapi as Record<string, unknown>
+  const aObj = admin as Record<string, unknown>
+  const allKeys = new Set<string>([...Object.keys(sObj), ...Object.keys(aObj)])
+  for (const key of allKeys) {
+    if (segments.length === 0 && skipKeys.has(key)) continue
+    walkObjects(sObj[key], aObj[key], [...segments, key], ctx, skipKeys)
+  }
+}
+
+function walkArrays(
+  strapi: ReadonlyArray<unknown>,
+  admin: ReadonlyArray<unknown>,
+  segments: ReadonlyArray<string | number>,
+  ctx: DiffContext,
+  skipKeys: ReadonlySet<string>,
+): void {
+  const path = encodePointer(segments)
+
+  // Order check via stable identity if elements are identifiable. For
+  // now, compare by id when present; fall back to structural element-
+  // by-element walk.
+  const strapiIds = identifierSequence(strapi)
+  const adminIds = identifierSequence(admin)
+  if (
+    strapiIds &&
+    adminIds &&
+    !arraysEqual(strapiIds, adminIds) &&
+    sameSet(strapiIds, adminIds)
+  ) {
+    ctx.order.push({
+      path,
+      strapiOrder: Object.freeze([...strapiIds]),
+      adminOrder: Object.freeze([...adminIds]),
+    })
+    // Emit element walk too for value diffs at matching positions —
+    // by id, not by raw index.
+    const adminById = new Map(admin.map((el) => [getId(el), el] as const))
+    for (let i = 0; i < strapi.length; i++) {
+      const id = getId(strapi[i])
+      const matchedAdmin = id !== null ? adminById.get(id) : undefined
+      if (matchedAdmin === undefined) continue
+      walkObjects(strapi[i], matchedAdmin, [...segments, i], ctx, skipKeys)
+    }
+    return
+  }
+
+  // No id-driven order tracking — walk by index. Handle length mismatch
+  // with truncation downgrade if appropriate.
+  const maxLen = Math.max(strapi.length, admin.length)
+  for (let i = 0; i < maxLen; i++) {
+    if (i >= strapi.length) {
+      // Admin has more entries.
+      const tailPath = encodePointer([...segments, i])
+      if (ctx.strapiTruncated && i >= strapi.length) {
+        ctx.potentiallyTruncated.push({
+          path: tailPath,
+          side: "strapi",
+          message:
+            "admin has more entries than strapi at this index; strapi side flagged potentiallyTruncated",
+        })
+        continue
+      }
+      ctx.structural.push({
+        path: tailPath,
+        side: "strapi",
+        message: "missing on strapi (admin tail)",
+      })
+      continue
+    }
+    if (i >= admin.length) {
+      // Strapi has more entries.
+      const tailPath = encodePointer([...segments, i])
+      if (ctx.adminTruncated) {
+        ctx.potentiallyTruncated.push({
+          path: tailPath,
+          side: "admin",
+          message:
+            "strapi has more entries than admin at this index; admin side flagged potentiallyTruncated",
+        })
+        continue
+      }
+      ctx.structural.push({
+        path: tailPath,
+        side: "admin",
+        message: "missing on admin (strapi tail)",
+      })
+      continue
+    }
+    walkObjects(strapi[i], admin[i], [...segments, i], ctx, skipKeys)
+  }
+}
+
+function identifierSequence(
+  arr: ReadonlyArray<unknown>,
+): ReadonlyArray<string> | null {
+  const out: string[] = []
+  for (const el of arr) {
+    const id = getId(el)
+    if (id === null || id === "") return null
+    out.push(id)
+  }
+  return out
+}
+
+function getId(el: unknown): string | null {
+  if (el === null || typeof el !== "object") return null
+  const v = (el as Record<string, unknown>).id
+  return typeof v === "string" ? v : null
+}
+
+function arraysEqual(
+  a: ReadonlyArray<string>,
+  b: ReadonlyArray<string>,
+): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+function sameSet(a: ReadonlyArray<string>, b: ReadonlyArray<string>): boolean {
+  if (a.length !== b.length) return false
+  const setA = new Set(a)
+  for (const v of b) {
+    if (!setA.has(v)) return false
+  }
+  return true
+}

--- a/packages/graphql/src/parity/compare.ts
+++ b/packages/graphql/src/parity/compare.ts
@@ -87,6 +87,14 @@ export type CompareOptions = {
   readonly allowList?: ReadonlyArray<AllowListEntry>
 }
 
+const byPath = (a: { path: string }, b: { path: string }): number =>
+  comparePointer(a.path, b.path)
+
+const byPathThenChannel = (
+  a: { path: string; channel: string },
+  b: { path: string; channel: string },
+): number => byPath(a, b) || a.channel.localeCompare(b.channel)
+
 // ---------------------------------------------------------------------------
 // Main entry
 // ---------------------------------------------------------------------------
@@ -107,16 +115,12 @@ export function compareNormalizedRoutes(
   }
 
   // Resolved-locale equality — semantic class. Both sides' locale must
-  // equal the URL locale. (We keep this BEFORE the structural walk so
-  // the locale path is treated as semantic, not value-class.)
-  if (strapi.locale !== options.urlLocale) {
-    ctx.semantic.push({
-      path: "/locale",
-      subclass: "locale-mismatch",
-      strapi: strapi.locale,
-      admin: admin.locale,
-    })
-  } else if (admin.locale !== options.urlLocale) {
+  // equal the URL locale. Kept BEFORE the structural walk so the
+  // locale path is treated as semantic, not value-class.
+  if (
+    strapi.locale !== options.urlLocale ||
+    admin.locale !== options.urlLocale
+  ) {
     ctx.semantic.push({
       path: "/locale",
       subclass: "locale-mismatch",
@@ -158,15 +162,12 @@ export function compareNormalizedRoutes(
   const semantic = filterChannel("semantic", ctx.semantic)
 
   // Sort each channel by JSON-Pointer numeric-aware order — determinism.
-  structural.sort((a, b) => comparePointer(a.path, b.path))
-  valueChannel.sort((a, b) => comparePointer(a.path, b.path))
-  order.sort((a, b) => comparePointer(a.path, b.path))
-  semantic.sort((a, b) => comparePointer(a.path, b.path))
-  ctx.potentiallyTruncated.sort((a, b) => comparePointer(a.path, b.path))
-  applied.sort(
-    (a, b) =>
-      comparePointer(a.path, b.path) || a.channel.localeCompare(b.channel),
-  )
+  structural.sort(byPath)
+  valueChannel.sort(byPath)
+  order.sort(byPath)
+  semantic.sort(byPath)
+  ctx.potentiallyTruncated.sort(byPath)
+  applied.sort(byPathThenChannel)
 
   return {
     structural: Object.freeze(structural),

--- a/packages/graphql/src/parity/compare.types.ts
+++ b/packages/graphql/src/parity/compare.types.ts
@@ -1,0 +1,56 @@
+/**
+ * Compile-time isolation proof for `compareNormalizedRoutes`.
+ *
+ * Mirrors the dual-client `__tests__/dual-client.types.ts` pattern from
+ * U3: a typecheck-only file (no `.test.ts` suffix; vitest skips per
+ * the existing convention) that proves the function rejects raw
+ * Strapi/admin response shapes at compile time. Only the shared
+ * `NormalizedExperienceRoute` is acceptable.
+ *
+ * The `@ts-expect-error` directives make these proofs fail typecheck
+ * if the rejection ever stops working.
+ */
+
+import { compareNormalizedRoutes } from "./compare"
+import type { NormalizedExperienceRoute } from "./shared-shape"
+
+// A raw Strapi-shaped response — typical GraphQL query result with
+// `experiences[]` and per-block `__typename` fields. The shared
+// `NormalizedExperienceRoute` carries `id`, `slug`, `locale`, `blocks`
+// at the top level — different by design.
+type RawStrapiResponse = {
+  experiences: ReadonlyArray<{
+    documentId: string
+    slug: string
+    blocks: ReadonlyArray<{ __typename: string }>
+  }>
+}
+
+// A raw admin-shaped response — `experienceBySlug` returns a single
+// `ExperienceLocale` with opaque JSON `blocks`.
+type RawAdminResponse = {
+  experienceBySlug: {
+    id: string
+    slug: string
+    blocks: unknown
+  } | null
+}
+
+declare const strapiRaw: RawStrapiResponse
+declare const adminRaw: RawAdminResponse
+declare const strapiNormalized: NormalizedExperienceRoute
+declare const adminNormalized: NormalizedExperienceRoute
+
+// Allowed: both inputs are NormalizedExperienceRoute.
+compareNormalizedRoutes(strapiNormalized, adminNormalized, {
+  urlLocale: "en",
+})
+
+// @ts-expect-error — raw Strapi shape lacks NormalizedExperienceRoute fields.
+compareNormalizedRoutes(strapiRaw, adminNormalized, { urlLocale: "en" })
+
+// @ts-expect-error — raw admin shape lacks NormalizedExperienceRoute fields.
+compareNormalizedRoutes(strapiNormalized, adminRaw, { urlLocale: "en" })
+
+// @ts-expect-error — both raw is rejected.
+compareNormalizedRoutes(strapiRaw, adminRaw, { urlLocale: "en" })

--- a/packages/graphql/src/parity/discriminator-map.test.ts
+++ b/packages/graphql/src/parity/discriminator-map.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ADMIN_KIND_TO_STRAPI,
+  ADMIN_ONLY_KINDS,
+  STRAPI_TO_ADMIN_KIND,
+  adminKindToStrapiTypename,
+  strapiTypenameToAdminKind,
+  type AdminKind,
+  type StrapiTypename,
+} from "./discriminator-map"
+
+describe("STRAPI_TO_ADMIN_KIND", () => {
+  it("has exactly 16 shared mapping entries", () => {
+    // Strapi's ExperienceBlocksDynamicZone union (excluding `Error`) has
+    // 16 component types; every entry must map to a unique admin kind.
+    expect(Object.keys(STRAPI_TO_ADMIN_KIND)).toHaveLength(16)
+  })
+
+  it("maps every Strapi typename to a non-empty admin kind", () => {
+    for (const [strapi, admin] of Object.entries(STRAPI_TO_ADMIN_KIND)) {
+      expect(admin, `mapping for ${strapi}`).toMatch(/^[a-z][a-zA-Z]+$/)
+    }
+  })
+
+  it("admin kinds are unique across the shared set (no two Strapi typenames map to the same admin kind)", () => {
+    const adminKinds = Object.values(STRAPI_TO_ADMIN_KIND)
+    expect(new Set(adminKinds).size).toBe(adminKinds.length)
+  })
+})
+
+describe("ADMIN_ONLY_KINDS", () => {
+  it("includes videoRecommendations", () => {
+    expect(ADMIN_ONLY_KINDS).toContain("videoRecommendations")
+  })
+
+  it("does not overlap with shared admin kinds", () => {
+    const sharedKinds = new Set<string>(Object.values(STRAPI_TO_ADMIN_KIND))
+    for (const adminOnly of ADMIN_ONLY_KINDS) {
+      expect(sharedKinds.has(adminOnly), `${adminOnly} is admin-only`).toBe(
+        false,
+      )
+    }
+  })
+})
+
+describe("ADMIN_KIND_TO_STRAPI", () => {
+  it("inverts STRAPI_TO_ADMIN_KIND exactly", () => {
+    const inverseSize = Object.keys(ADMIN_KIND_TO_STRAPI).length
+    expect(inverseSize).toBe(Object.keys(STRAPI_TO_ADMIN_KIND).length)
+  })
+
+  it("is bidirectionally consistent — adminKindToStrapiTypename(STRAPI_TO_ADMIN_KIND[k]) === k", () => {
+    for (const [strapi, admin] of Object.entries(STRAPI_TO_ADMIN_KIND)) {
+      expect(adminKindToStrapiTypename(admin), `round-trip for ${strapi}`).toBe(
+        strapi,
+      )
+    }
+  })
+
+  it("returns undefined for admin-only kinds", () => {
+    for (const adminOnly of ADMIN_ONLY_KINDS) {
+      expect(adminKindToStrapiTypename(adminOnly)).toBeUndefined()
+    }
+  })
+
+  it("returns undefined for completely unknown kinds", () => {
+    expect(adminKindToStrapiTypename("totallyUnknown")).toBeUndefined()
+  })
+})
+
+describe("strapiTypenameToAdminKind", () => {
+  it("maps a known Strapi typename to its admin kind", () => {
+    expect(strapiTypenameToAdminKind("ComponentSectionsMediaCollection")).toBe(
+      "mediaCollection",
+    )
+  })
+
+  it("returns the unknown-sentinel for an unmapped typename", () => {
+    const result = strapiTypenameToAdminKind("ComponentSectionsTotallyNew")
+    expect(result).toEqual({
+      kind: "unknown",
+      raw: "ComponentSectionsTotallyNew",
+    })
+  })
+
+  it("returns the unknown-sentinel for empty string (defensive)", () => {
+    const result = strapiTypenameToAdminKind("")
+    expect(result).toEqual({ kind: "unknown", raw: "" })
+  })
+})
+
+describe("type exports", () => {
+  it("exposes StrapiTypename and AdminKind as the union literal types", () => {
+    // Compile-time proof that a known typename narrows to AdminKind.
+    const known: StrapiTypename = "ComponentSectionsCta"
+    const admin: AdminKind = STRAPI_TO_ADMIN_KIND[known]
+    expect(admin).toBe("cta")
+  })
+})
+
+// =============================================================================
+// Cross-package totality test — DEFERRED to U4.
+//
+// The plan's "Discriminator-map admin coverage" scenario imports
+// BlocksSchema from @forge/admin/domain/blocks and asserts every shared
+// admin kind in BlocksSchema is reachable via this map. That import
+// requires admin's package.json `exports` map (added in U4). The test
+// lands alongside the exports-map change so the import resolves cleanly.
+// =============================================================================

--- a/packages/graphql/src/parity/discriminator-map.ts
+++ b/packages/graphql/src/parity/discriminator-map.ts
@@ -1,0 +1,101 @@
+/**
+ * Bidirectional table mapping Strapi block component `__typename` values
+ * to admin block schema `t` literal values, plus a separate enumeration
+ * of admin-only kinds.
+ *
+ * The 16 entries below are the 1:1 mapping over the Strapi
+ * `ExperienceBlocksDynamicZone` union (excluding the synthesized
+ * `Error` type). Admin's `BlocksSchema` has 17 top-level kinds — the 16
+ * shared, plus admin-only `videoRecommendations` (forward-looking; no
+ * Strapi precedent). Synthetic `containerSlot` markers are emitted by
+ * the Strapi normalizer when flattening `container.slots[].content[]`
+ * to admin's flat `container.content[]` shape — they live in admin's
+ * `ContainerContentBlockSchema` scope and are NOT top-level discriminators.
+ *
+ * Totality is asserted at test time by importing `BlocksSchema` from
+ * `@forge/admin/domain/blocks` and verifying every shared kind has a map
+ * entry — surfacing new admin kinds as test failures rather than silent
+ * unknown-sentinel passes.
+ */
+
+/**
+ * Strapi `__typename` → admin `kind` mapping. Sorted alphabetically by
+ * Strapi typename to make additions reviewable.
+ */
+export const STRAPI_TO_ADMIN_KIND = {
+  ComponentSectionsAdventCountdown: "adventCountdown",
+  ComponentSectionsBibleQuotesCarousel: "bibleQuotesCarousel",
+  ComponentSectionsCard: "card",
+  ComponentSectionsContainer: "container",
+  ComponentSectionsCta: "cta",
+  ComponentSectionsEasterDates: "easterDates",
+  ComponentSectionsInfoBlocks: "infoBlocks",
+  ComponentSectionsMediaCollection: "mediaCollection",
+  ComponentSectionsNavigationCarousel: "navigationCarousel",
+  ComponentSectionsPromoBanner: "promoBanner",
+  ComponentSectionsRelatedQuestions: "relatedQuestions",
+  ComponentSectionsSection: "section",
+  ComponentSectionsText: "text",
+  ComponentSectionsVideo: "video",
+  ComponentSectionsVideoCarousel: "videoCarousel",
+  ComponentSectionsVideoHero: "videoHero",
+} as const satisfies Readonly<Record<string, string>>
+
+/**
+ * Admin kinds that have NO Strapi counterpart. Captured-from-live fixtures
+ * for these kinds are admin-only; per-discriminator parity coverage in U6
+ * skips Strapi-side fixtures for these.
+ */
+export const ADMIN_ONLY_KINDS = ["videoRecommendations"] as const
+
+/**
+ * Reverse table — admin `kind` → Strapi `__typename`. Built once at module
+ * load and frozen.
+ */
+export const ADMIN_KIND_TO_STRAPI: Readonly<Record<string, StrapiTypename>> =
+  Object.freeze(
+    Object.fromEntries(
+      Object.entries(STRAPI_TO_ADMIN_KIND).map(([k, v]) => [v, k]),
+    ) as Record<string, StrapiTypename>,
+  )
+
+export type StrapiTypename = keyof typeof STRAPI_TO_ADMIN_KIND
+export type AdminKind = (typeof STRAPI_TO_ADMIN_KIND)[StrapiTypename]
+export type AdminOnlyKind = (typeof ADMIN_ONLY_KINDS)[number]
+
+/**
+ * Sentinel returned when a Strapi `__typename` is not in the map.
+ * The Strapi normalizer surfaces this on the normalized output so the
+ * differ can flag it as a structural mismatch rather than the call
+ * site throwing — a parity harness should never hide unknown kinds.
+ */
+export type UnknownDiscriminator = {
+  readonly kind: "unknown"
+  readonly raw: string
+}
+
+/**
+ * Look up the admin `kind` for a Strapi `__typename`. Returns the
+ * unknown-sentinel for any value not in the map. Callers must check
+ * for `kind === "unknown"` before treating the result as an `AdminKind`.
+ */
+export function strapiTypenameToAdminKind(
+  typename: string,
+): AdminKind | UnknownDiscriminator {
+  if (Object.prototype.hasOwnProperty.call(STRAPI_TO_ADMIN_KIND, typename)) {
+    return STRAPI_TO_ADMIN_KIND[typename as StrapiTypename]
+  }
+  return { kind: "unknown", raw: typename }
+}
+
+/**
+ * Look up the Strapi `__typename` for an admin `kind`. Returns
+ * `undefined` for admin-only kinds (e.g., `videoRecommendations`).
+ * Callers MUST handle `undefined` — passing it to a Strapi query
+ * silently produces a malformed selection set.
+ */
+export function adminKindToStrapiTypename(
+  kind: string,
+): StrapiTypename | undefined {
+  return ADMIN_KIND_TO_STRAPI[kind]
+}

--- a/packages/graphql/src/parity/index.ts
+++ b/packages/graphql/src/parity/index.ts
@@ -1,0 +1,36 @@
+// =============================================================================
+// PARITY HARNESS — DELETION CHECKLIST (per-PR contract; keep current)
+// =============================================================================
+//
+// This module is throwaway scaffolding for the Strapi → admin consumer
+// migration. It is deleted when mobile and TV both report their first
+// parity-clean window in `admin` mode (no fallback). See:
+//
+//   docs/brainstorms/2026-05-05-consumer-migration-implementer-brief-requirements.md
+//   docs/plans/2026-05-07-002-feat-consumer-migration-parity-harness-unit-4-plan.md
+//   docs/solutions/best-practices/throwaway-operator-harness-deletion-contract-20260430.md
+//
+// At retirement, remove ALL of the following in one PR:
+//
+//   - This entire directory: packages/graphql/src/parity/
+//   - The capture script: packages/graphql/scripts/capture-parity-fixture.ts
+//   - The "./parity" entry in packages/graphql/package.json `exports`
+//   - The vitest devDep + test/test:watch scripts in packages/graphql/package.json
+//     (only if no other test surface in this package needs them)
+//   - The vitest config: packages/graphql/vitest.config.ts
+//     (only if no other test surface in this package needs it)
+//   - The "./parity" re-export in packages/graphql/src/index.ts
+//   - The exports-map entry "./domain/blocks" in apps/admin/package.json
+//     (only if no other workspace consumer imports it; if it becomes the
+//     last entry, the entire `exports` map is also removed)
+//   - Env vars: FORGE_PARITY_LIVE, FORGE_STRAPI_URL, FORGE_ADMIN_URL,
+//     FORGE_STRAPI_PUBLIC_ORIGIN — drop from any deployed env config
+//
+// What does NOT get removed:
+//   - The @forge/admin workspace devDep on packages/graphql — still in use
+//     for schema codegen (Unit 3's admin SDL → admin-graphql-env.d.ts flow)
+//
+// =============================================================================
+
+// Public surface — empty initially, populated by U2-U6 implementation units.
+export {}

--- a/packages/graphql/src/parity/index.ts
+++ b/packages/graphql/src/parity/index.ts
@@ -19,7 +19,8 @@
 //     (only if no other test surface in this package needs them)
 //   - The vitest config: packages/graphql/vitest.config.ts
 //     (only if no other test surface in this package needs it)
-//   - The "./parity" re-export in packages/graphql/src/index.ts
+//   - The zod devDep in packages/graphql/package.json
+//     (only used by parity/normalize-admin.ts via @forge/admin/domain/blocks)
 //   - The exports-map entry "./domain/blocks" in apps/admin/package.json
 //     (only if no other workspace consumer imports it; if it becomes the
 //     last entry, the entire `exports` map is also removed)
@@ -32,5 +33,81 @@
 //
 // =============================================================================
 
-// Public surface — empty initially, populated by U2-U6 implementation units.
-export {}
+// Public surface — exposed via the `@forge/graphql/parity` subpath.
+// Internals (helpers, regex predicates, etc.) stay un-exported.
+
+export {
+  compareNormalizedRoutes,
+  type DiffReport,
+  type StructuralDiff,
+  type ValueDiff,
+  type OrderDiff,
+  type SemanticDiff,
+  type SemanticSubclass,
+  type PotentialTruncationDiff,
+  type CompareOptions,
+} from "./compare"
+
+export {
+  DEFAULT_ALLOW_LIST,
+  type AllowListEntry,
+  type AllowListChannel,
+  type AppliedAllowListEntry,
+} from "./allow-list"
+
+export {
+  normalizeStrapi,
+  StrapiNormalizationError,
+  type StrapiExperienceInput,
+  type StrapiBlockInput,
+  type NormalizeStrapiOptions,
+} from "./normalize-strapi"
+
+export {
+  normalizeAdmin,
+  AdminNormalizationError,
+  AdminBlocksValidationError,
+  type AdminExperienceLocaleInput,
+  type NormalizeAdminOptions,
+} from "./normalize-admin"
+
+export {
+  canonicalizeUrl,
+  CanonicalizeUrlError,
+  type CanonicalUrl,
+  type CanonicalUrlFailure,
+  type CanonicalizeUrlConfig,
+} from "./canonicalize-url"
+
+export {
+  STRAPI_TO_ADMIN_KIND,
+  ADMIN_KIND_TO_STRAPI,
+  ADMIN_ONLY_KINDS,
+  strapiTypenameToAdminKind,
+  adminKindToStrapiTypename,
+  type StrapiTypename,
+  type AdminKind,
+  type AdminOnlyKind,
+  type UnknownDiscriminator,
+} from "./discriminator-map"
+
+export { comparePointer, encodePointer } from "./path-pointer"
+
+export type {
+  NormalizedExperienceRoute,
+  NormalizedBlock,
+  NormalizedBlockKind,
+  NormalizedMeta,
+  NormalizedOgImage,
+  ContainerSlotMarker,
+} from "./shared-shape"
+
+export {
+  runLiveComparison,
+  assertLiveModeEnabled,
+  validateHost,
+  LiveModeDisabledError,
+  LiveModeConfigError,
+  type LiveModeOptions,
+  type LiveModeResult,
+} from "./live"

--- a/packages/graphql/src/parity/index.ts
+++ b/packages/graphql/src/parity/index.ts
@@ -34,7 +34,10 @@
 // =============================================================================
 
 // Public surface — exposed via the `@forge/graphql/parity` subpath.
-// Internals (helpers, regex predicates, etc.) stay un-exported.
+// Internal helpers (path-pointer encoding, discriminator lookup tables,
+// canonicalization regex predicates) are NOT exported — consumers
+// should use the high-level API (`compareNormalizedRoutes`, normalizers,
+// live mode) and the surfaced types.
 
 export {
   compareNormalizedRoutes,
@@ -71,41 +74,17 @@ export {
   type NormalizeAdminOptions,
 } from "./normalize-admin"
 
-export {
-  canonicalizeUrl,
-  CanonicalizeUrlError,
-  type CanonicalUrl,
-  type CanonicalUrlFailure,
-  type CanonicalizeUrlConfig,
-} from "./canonicalize-url"
-
-export {
-  STRAPI_TO_ADMIN_KIND,
-  ADMIN_KIND_TO_STRAPI,
-  ADMIN_ONLY_KINDS,
-  strapiTypenameToAdminKind,
-  adminKindToStrapiTypename,
-  type StrapiTypename,
-  type AdminKind,
-  type AdminOnlyKind,
-  type UnknownDiscriminator,
-} from "./discriminator-map"
-
-export { comparePointer, encodePointer } from "./path-pointer"
-
 export type {
   NormalizedExperienceRoute,
   NormalizedBlock,
   NormalizedBlockKind,
   NormalizedMeta,
   NormalizedOgImage,
-  ContainerSlotMarker,
 } from "./shared-shape"
 
 export {
   runLiveComparison,
   assertLiveModeEnabled,
-  validateHost,
   LiveModeDisabledError,
   LiveModeConfigError,
   type LiveModeOptions,

--- a/packages/graphql/src/parity/live-config.ts
+++ b/packages/graphql/src/parity/live-config.ts
@@ -1,0 +1,86 @@
+/**
+ * Live-mode env validation, extracted from `live.ts` so the capture
+ * script can use it without transitively pulling in `normalize-admin.ts`
+ * (whose `BlocksSchema` cross-workspace import fails tsx's ESM
+ * static-link step on raw .ts source paths).
+ *
+ * `live.ts` re-exports these for the in-package consumers; the capture
+ * script imports them directly from this file.
+ */
+
+export class LiveModeDisabledError extends Error {
+  override readonly name = "LiveModeDisabledError"
+}
+
+export class LiveModeConfigError extends Error {
+  override readonly name = "LiveModeConfigError"
+}
+
+/**
+ * Hosts on the rejection list — the admin auth host and any other
+ * known non-GraphQL host. Add new entries here when admin's deployment
+ * topology adds another non-GraphQL host.
+ */
+const REJECTED_HOSTS = new Set([
+  "auth.jesusfilm.org",
+  // Add other known non-GraphQL hosts here as they emerge.
+])
+
+/**
+ * Asserts live mode is enabled and configured. Throws a typed error
+ * with the missing env var name when it isn't. Exposed separately for
+ * the capture script to share validation logic.
+ */
+export function assertLiveModeEnabled(env: NodeJS.ProcessEnv = process.env): {
+  readonly strapiUrl: string
+  readonly adminUrl: string
+  readonly baseOrigin: string
+} {
+  if (env.FORGE_PARITY_LIVE !== "1") {
+    throw new LiveModeDisabledError(
+      "live mode is disabled — set FORGE_PARITY_LIVE=1 to enable",
+    )
+  }
+  const strapiUrl = env.FORGE_STRAPI_URL
+  const adminUrl = env.FORGE_ADMIN_URL
+  const baseOrigin = env.FORGE_STRAPI_PUBLIC_ORIGIN
+  if (!strapiUrl) {
+    throw new LiveModeConfigError(
+      "live mode requires FORGE_STRAPI_URL to be set",
+    )
+  }
+  if (!adminUrl) {
+    throw new LiveModeConfigError(
+      "live mode requires FORGE_ADMIN_URL to be set",
+    )
+  }
+  if (!baseOrigin) {
+    throw new LiveModeConfigError(
+      "live mode requires FORGE_STRAPI_PUBLIC_ORIGIN to be set",
+    )
+  }
+  validateHost(adminUrl, "FORGE_ADMIN_URL")
+  validateHost(strapiUrl, "FORGE_STRAPI_URL")
+  return { strapiUrl, adminUrl, baseOrigin }
+}
+
+/**
+ * Reject the URL if its hostname is on the rejection list.
+ * Throws `LiveModeConfigError` with a clear message on rejection.
+ */
+export function validateHost(rawUrl: string, varName: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new LiveModeConfigError(`${varName} is not a valid URL: ${rawUrl}`)
+  }
+  // hostname (no port) — parsed.host includes port unless it's the
+  // protocol's default, so a `:8443` variant of auth.jesusfilm.org would
+  // otherwise bypass the rejection set.
+  if (REJECTED_HOSTS.has(parsed.hostname.toLowerCase())) {
+    throw new LiveModeConfigError(
+      `${varName} points at a rejected host '${parsed.hostname}'. Admin GraphQL lives at admin.jesusfilm.org/api/graphql or localhost:3003/api/graphql, NOT auth.jesusfilm.org (per PR #909).`,
+    )
+  }
+}

--- a/packages/graphql/src/parity/live.test.ts
+++ b/packages/graphql/src/parity/live.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  LiveModeConfigError,
+  LiveModeDisabledError,
+  assertLiveModeEnabled,
+  validateHost,
+} from "./live"
+
+describe("assertLiveModeEnabled", () => {
+  it("throws LiveModeDisabledError when FORGE_PARITY_LIVE is unset", () => {
+    expect(() => assertLiveModeEnabled({})).toThrow(LiveModeDisabledError)
+  })
+
+  it("throws LiveModeDisabledError with a message naming the missing env", () => {
+    try {
+      assertLiveModeEnabled({})
+    } catch (e) {
+      expect((e as Error).message).toMatch(/FORGE_PARITY_LIVE/)
+      return
+    }
+    throw new Error("expected throw")
+  })
+
+  it("throws LiveModeConfigError when FORGE_STRAPI_URL is missing", () => {
+    expect(() =>
+      assertLiveModeEnabled({
+        FORGE_PARITY_LIVE: "1",
+        FORGE_ADMIN_URL: "http://localhost:3003/api/graphql",
+        FORGE_STRAPI_PUBLIC_ORIGIN: "https://cdn.example.com",
+      }),
+    ).toThrow(/FORGE_STRAPI_URL/)
+  })
+
+  it("throws LiveModeConfigError when FORGE_ADMIN_URL is missing", () => {
+    expect(() =>
+      assertLiveModeEnabled({
+        FORGE_PARITY_LIVE: "1",
+        FORGE_STRAPI_URL: "https://cms.example.com/graphql",
+        FORGE_STRAPI_PUBLIC_ORIGIN: "https://cdn.example.com",
+      }),
+    ).toThrow(/FORGE_ADMIN_URL/)
+  })
+
+  it("throws LiveModeConfigError when FORGE_STRAPI_PUBLIC_ORIGIN is missing", () => {
+    expect(() =>
+      assertLiveModeEnabled({
+        FORGE_PARITY_LIVE: "1",
+        FORGE_STRAPI_URL: "https://cms.example.com/graphql",
+        FORGE_ADMIN_URL: "http://localhost:3003/api/graphql",
+      }),
+    ).toThrow(/FORGE_STRAPI_PUBLIC_ORIGIN/)
+  })
+
+  it("returns config when all env vars are set", () => {
+    const config = assertLiveModeEnabled({
+      FORGE_PARITY_LIVE: "1",
+      FORGE_STRAPI_URL: "https://cms.example.com/graphql",
+      FORGE_ADMIN_URL: "http://localhost:3003/api/graphql",
+      FORGE_STRAPI_PUBLIC_ORIGIN: "https://cdn.example.com",
+    })
+    expect(config.strapiUrl).toBe("https://cms.example.com/graphql")
+    expect(config.adminUrl).toBe("http://localhost:3003/api/graphql")
+    expect(config.baseOrigin).toBe("https://cdn.example.com")
+  })
+})
+
+describe("validateHost", () => {
+  it("accepts localhost (local dev)", () => {
+    expect(() =>
+      validateHost("http://localhost:3003/api/graphql", "FORGE_ADMIN_URL"),
+    ).not.toThrow()
+  })
+
+  it("accepts production admin host", () => {
+    expect(() =>
+      validateHost(
+        "https://admin.jesusfilm.org/api/graphql",
+        "FORGE_ADMIN_URL",
+      ),
+    ).not.toThrow()
+  })
+
+  it("accepts a Railway preview URL", () => {
+    expect(() =>
+      validateHost(
+        "https://forge-admin-preview-pr-42.up.railway.app/api/graphql",
+        "FORGE_ADMIN_URL",
+      ),
+    ).not.toThrow()
+  })
+
+  it("REJECTS auth.jesusfilm.org (per PR #909 — auth host returns 404 on /api/*)", () => {
+    expect(() =>
+      validateHost("https://auth.jesusfilm.org/api/graphql", "FORGE_ADMIN_URL"),
+    ).toThrow(LiveModeConfigError)
+  })
+
+  it("rejection error names auth.jesusfilm.org explicitly so misconfig is debuggable", () => {
+    try {
+      validateHost("https://auth.jesusfilm.org/api/graphql", "FORGE_ADMIN_URL")
+    } catch (e) {
+      expect((e as Error).message).toMatch(/auth\.jesusfilm\.org/)
+      return
+    }
+    throw new Error("expected throw")
+  })
+
+  it("throws LiveModeConfigError on a malformed URL", () => {
+    expect(() => validateHost("not a url", "FORGE_ADMIN_URL")).toThrow(
+      LiveModeConfigError,
+    )
+  })
+})

--- a/packages/graphql/src/parity/live.test.ts
+++ b/packages/graphql/src/parity/live.test.ts
@@ -96,6 +96,21 @@ describe("validateHost", () => {
     ).toThrow(LiveModeConfigError)
   })
 
+  it("REJECTS auth.jesusfilm.org with non-default port (e.g. :8443) — port-bypass guard", () => {
+    expect(() =>
+      validateHost(
+        "https://auth.jesusfilm.org:8443/api/graphql",
+        "FORGE_ADMIN_URL",
+      ),
+    ).toThrow(LiveModeConfigError)
+  })
+
+  it("REJECTS auth.jesusfilm.org with mixed-case host", () => {
+    expect(() =>
+      validateHost("https://AUTH.JesusFilm.ORG/api/graphql", "FORGE_ADMIN_URL"),
+    ).toThrow(LiveModeConfigError)
+  })
+
   it("rejection error names auth.jesusfilm.org explicitly so misconfig is debuggable", () => {
     try {
       validateHost("https://auth.jesusfilm.org/api/graphql", "FORGE_ADMIN_URL")

--- a/packages/graphql/src/parity/live.ts
+++ b/packages/graphql/src/parity/live.ts
@@ -17,27 +17,27 @@
  */
 
 import { compareNormalizedRoutes, type DiffReport } from "./compare"
+import {
+  LiveModeConfigError,
+  LiveModeDisabledError,
+  assertLiveModeEnabled,
+  validateHost,
+} from "./live-config"
 import { normalizeAdmin } from "./normalize-admin"
 import { normalizeStrapi, type StrapiExperienceInput } from "./normalize-strapi"
 import type { AdminExperienceLocaleInput } from "./normalize-admin"
 
-export class LiveModeDisabledError extends Error {
-  override readonly name = "LiveModeDisabledError"
+// Re-export the env-config surface so callers don't need to import from
+// two different modules. Implementation lives in `live-config.ts` so the
+// capture script can use it without transitively pulling in
+// `normalize-admin.ts` (whose cross-workspace `BlocksSchema` import
+// breaks tsx's ESM static-link).
+export {
+  LiveModeConfigError,
+  LiveModeDisabledError,
+  assertLiveModeEnabled,
+  validateHost,
 }
-
-export class LiveModeConfigError extends Error {
-  override readonly name = "LiveModeConfigError"
-}
-
-/**
- * Hosts on the rejection list — the admin auth host and any other
- * known non-GraphQL host. Add new entries here when admin's deployment
- * topology adds another non-GraphQL host.
- */
-const REJECTED_HOSTS = new Set([
-  "auth.jesusfilm.org",
-  // Add other known non-GraphQL hosts here as they emerge.
-])
 
 export type LiveModeOptions = {
   readonly slug: string
@@ -54,62 +54,6 @@ export type LiveModeResult = {
   readonly diff: DiffReport
   readonly strapiResponseTimeMs: number
   readonly adminResponseTimeMs: number
-}
-
-/**
- * Asserts live mode is enabled and configured. Throws a typed error
- * with the missing env var name when it isn't. Exposed separately for
- * the capture script to share validation logic.
- */
-export function assertLiveModeEnabled(env: NodeJS.ProcessEnv = process.env): {
-  readonly strapiUrl: string
-  readonly adminUrl: string
-  readonly baseOrigin: string
-} {
-  if (env.FORGE_PARITY_LIVE !== "1") {
-    throw new LiveModeDisabledError(
-      "live mode is disabled — set FORGE_PARITY_LIVE=1 to enable",
-    )
-  }
-  const strapiUrl = env.FORGE_STRAPI_URL
-  const adminUrl = env.FORGE_ADMIN_URL
-  const baseOrigin = env.FORGE_STRAPI_PUBLIC_ORIGIN
-  if (!strapiUrl) {
-    throw new LiveModeConfigError(
-      "live mode requires FORGE_STRAPI_URL to be set",
-    )
-  }
-  if (!adminUrl) {
-    throw new LiveModeConfigError(
-      "live mode requires FORGE_ADMIN_URL to be set",
-    )
-  }
-  if (!baseOrigin) {
-    throw new LiveModeConfigError(
-      "live mode requires FORGE_STRAPI_PUBLIC_ORIGIN to be set",
-    )
-  }
-  validateHost(adminUrl, "FORGE_ADMIN_URL")
-  validateHost(strapiUrl, "FORGE_STRAPI_URL")
-  return { strapiUrl, adminUrl, baseOrigin }
-}
-
-/**
- * Reject the URL if its hostname is on the rejection list.
- * Throws `LiveModeConfigError` with a clear message on rejection.
- */
-export function validateHost(rawUrl: string, varName: string): void {
-  let parsed: URL
-  try {
-    parsed = new URL(rawUrl)
-  } catch {
-    throw new LiveModeConfigError(`${varName} is not a valid URL: ${rawUrl}`)
-  }
-  if (REJECTED_HOSTS.has(parsed.host)) {
-    throw new LiveModeConfigError(
-      `${varName} points at a rejected host '${parsed.host}'. Admin GraphQL lives at admin.jesusfilm.org/api/graphql or localhost:3003/api/graphql, NOT auth.jesusfilm.org (per PR #909).`,
-    )
-  }
 }
 
 /**

--- a/packages/graphql/src/parity/live.ts
+++ b/packages/graphql/src/parity/live.ts
@@ -138,12 +138,13 @@ export async function runLiveComparison(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<LiveModeResult> {
   const config = assertLiveModeEnabled(env)
+  // When the caller overrides URLs via options, re-validate them since
+  // assertLiveModeEnabled only validated the env-driven values.
   const strapiUrl = options.strapiUrl ?? config.strapiUrl
   const adminUrl = options.adminUrl ?? config.adminUrl
   const baseOrigin = options.baseOrigin ?? config.baseOrigin
-
-  validateHost(adminUrl, "FORGE_ADMIN_URL")
-  validateHost(strapiUrl, "FORGE_STRAPI_URL")
+  if (options.strapiUrl) validateHost(strapiUrl, "FORGE_STRAPI_URL")
+  if (options.adminUrl) validateHost(adminUrl, "FORGE_ADMIN_URL")
 
   const tStrapiStart = Date.now()
   const strapiInput = await fetchers.fetchStrapi(

--- a/packages/graphql/src/parity/live.ts
+++ b/packages/graphql/src/parity/live.ts
@@ -1,0 +1,182 @@
+/**
+ * Env-gated live-comparison entry point.
+ *
+ * Off by default. Activated only when `FORGE_PARITY_LIVE=1` is set
+ * along with both endpoint URLs. Issues anonymous queries to Strapi
+ * and admin, runs the normalizers, and returns the differ's report.
+ *
+ * Not invoked by the test suite — for ad-hoc operator use during
+ * canary investigation. The capture script
+ * (`scripts/capture-parity-fixture.ts`) handles fixture-capture flows.
+ *
+ * Host validation: rejects `auth.jesusfilm.org` (per PR #909, admin's
+ * auth flows live there and `/api/*` requests return 404). Production
+ * admin GraphQL is at `admin.jesusfilm.org/api/graphql`; locally,
+ * `http://localhost:3003/api/graphql`. The blocklist is conservative
+ * — it allows any URL that isn't on the rejection list.
+ */
+
+import { compareNormalizedRoutes, type DiffReport } from "./compare"
+import { normalizeAdmin } from "./normalize-admin"
+import { normalizeStrapi, type StrapiExperienceInput } from "./normalize-strapi"
+import type { AdminExperienceLocaleInput } from "./normalize-admin"
+
+export class LiveModeDisabledError extends Error {
+  override readonly name = "LiveModeDisabledError"
+}
+
+export class LiveModeConfigError extends Error {
+  override readonly name = "LiveModeConfigError"
+}
+
+/**
+ * Hosts on the rejection list — the admin auth host and any other
+ * known non-GraphQL host. Add new entries here when admin's deployment
+ * topology adds another non-GraphQL host.
+ */
+const REJECTED_HOSTS = new Set([
+  "auth.jesusfilm.org",
+  // Add other known non-GraphQL hosts here as they emerge.
+])
+
+export type LiveModeOptions = {
+  readonly slug: string
+  readonly urlLocale: string
+  /** Optional: override the env-driven Strapi URL. */
+  readonly strapiUrl?: string
+  /** Optional: override the env-driven admin URL. */
+  readonly adminUrl?: string
+  /** Optional: override base origin for URL canonicalization. */
+  readonly baseOrigin?: string
+}
+
+export type LiveModeResult = {
+  readonly diff: DiffReport
+  readonly strapiResponseTimeMs: number
+  readonly adminResponseTimeMs: number
+}
+
+/**
+ * Asserts live mode is enabled and configured. Throws a typed error
+ * with the missing env var name when it isn't. Exposed separately for
+ * the capture script to share validation logic.
+ */
+export function assertLiveModeEnabled(env: NodeJS.ProcessEnv = process.env): {
+  readonly strapiUrl: string
+  readonly adminUrl: string
+  readonly baseOrigin: string
+} {
+  if (env.FORGE_PARITY_LIVE !== "1") {
+    throw new LiveModeDisabledError(
+      "live mode is disabled — set FORGE_PARITY_LIVE=1 to enable",
+    )
+  }
+  const strapiUrl = env.FORGE_STRAPI_URL
+  const adminUrl = env.FORGE_ADMIN_URL
+  const baseOrigin = env.FORGE_STRAPI_PUBLIC_ORIGIN
+  if (!strapiUrl) {
+    throw new LiveModeConfigError(
+      "live mode requires FORGE_STRAPI_URL to be set",
+    )
+  }
+  if (!adminUrl) {
+    throw new LiveModeConfigError(
+      "live mode requires FORGE_ADMIN_URL to be set",
+    )
+  }
+  if (!baseOrigin) {
+    throw new LiveModeConfigError(
+      "live mode requires FORGE_STRAPI_PUBLIC_ORIGIN to be set",
+    )
+  }
+  validateHost(adminUrl, "FORGE_ADMIN_URL")
+  validateHost(strapiUrl, "FORGE_STRAPI_URL")
+  return { strapiUrl, adminUrl, baseOrigin }
+}
+
+/**
+ * Reject the URL if its hostname is on the rejection list.
+ * Throws `LiveModeConfigError` with a clear message on rejection.
+ */
+export function validateHost(rawUrl: string, varName: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new LiveModeConfigError(`${varName} is not a valid URL: ${rawUrl}`)
+  }
+  if (REJECTED_HOSTS.has(parsed.host)) {
+    throw new LiveModeConfigError(
+      `${varName} points at a rejected host '${parsed.host}'. Admin GraphQL lives at admin.jesusfilm.org/api/graphql or localhost:3003/api/graphql, NOT auth.jesusfilm.org (per PR #909).`,
+    )
+  }
+}
+
+/**
+ * Run a live parity comparison. Caller provides Strapi + admin
+ * fetchers (decoupling transport from the harness). Returns the diff
+ * report alongside per-side response timings.
+ *
+ * The fetcher closures abstract over Apollo/fetch/etc. — they take a
+ * slug + locale and return the typed normalizer input. The harness
+ * does NOT know about transport, headers, or auth at this layer.
+ */
+export async function runLiveComparison(
+  options: LiveModeOptions,
+  fetchers: {
+    readonly fetchStrapi: (
+      slug: string,
+      locale: string,
+      url: string,
+    ) => Promise<StrapiExperienceInput>
+    readonly fetchAdmin: (
+      slug: string,
+      locale: string,
+      url: string,
+    ) => Promise<AdminExperienceLocaleInput>
+  },
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<LiveModeResult> {
+  const config = assertLiveModeEnabled(env)
+  const strapiUrl = options.strapiUrl ?? config.strapiUrl
+  const adminUrl = options.adminUrl ?? config.adminUrl
+  const baseOrigin = options.baseOrigin ?? config.baseOrigin
+
+  validateHost(adminUrl, "FORGE_ADMIN_URL")
+  validateHost(strapiUrl, "FORGE_STRAPI_URL")
+
+  const tStrapiStart = Date.now()
+  const strapiInput = await fetchers.fetchStrapi(
+    options.slug,
+    options.urlLocale,
+    strapiUrl,
+  )
+  const tStrapiEnd = Date.now()
+
+  const tAdminStart = Date.now()
+  const adminInput = await fetchers.fetchAdmin(
+    options.slug,
+    options.urlLocale,
+    adminUrl,
+  )
+  const tAdminEnd = Date.now()
+
+  const strapiNormalized = normalizeStrapi(strapiInput, {
+    urlLocale: options.urlLocale,
+    baseOrigin,
+  })
+  const adminNormalized = normalizeAdmin(adminInput, {
+    urlLocale: options.urlLocale,
+    baseOrigin,
+  })
+
+  const diff = compareNormalizedRoutes(strapiNormalized, adminNormalized, {
+    urlLocale: options.urlLocale,
+  })
+
+  return {
+    diff,
+    strapiResponseTimeMs: tStrapiEnd - tStrapiStart,
+    adminResponseTimeMs: tAdminEnd - tAdminStart,
+  }
+}

--- a/packages/graphql/src/parity/normalize-admin.test.ts
+++ b/packages/graphql/src/parity/normalize-admin.test.ts
@@ -1,0 +1,253 @@
+import { BlocksSchema } from "@forge/admin/domain/blocks"
+import { describe, expect, it } from "vitest"
+
+import { ADMIN_ONLY_KINDS, STRAPI_TO_ADMIN_KIND } from "./discriminator-map"
+import {
+  AdminBlocksValidationError,
+  AdminNormalizationError,
+  normalizeAdmin,
+  type AdminExperienceLocaleInput,
+} from "./normalize-admin"
+
+const OPTIONS = {
+  urlLocale: "en",
+  baseOrigin: "https://cdn.example.com",
+} as const
+
+function baseInput(
+  overrides: Partial<AdminExperienceLocaleInput> = {},
+): AdminExperienceLocaleInput {
+  return {
+    id: "exp-loc-1",
+    slug: "test-slug",
+    locale: "en",
+    title: "Test Experience",
+    description: "test description",
+    ogImageUrl: null,
+    blocks: [],
+    ...overrides,
+  }
+}
+
+// Minimal valid admin block fixtures — one per shared kind. The shape
+// mirrors what BlocksSchema accepts at write time (`.strict()` rejects
+// unknown keys; admin blocks have NO per-block `id` field — they're
+// JSON nodes inside ExperienceLocale.blocks, not table rows).
+
+function adminMediaCollection() {
+  return {
+    t: "mediaCollection",
+    sectionKey: "key-1",
+    variant: "carousel" as const,
+  }
+}
+
+function adminText() {
+  return {
+    t: "text",
+    sectionKey: "key-2",
+  }
+}
+
+describe("normalizeAdmin — happy paths", () => {
+  it("returns a NormalizedExperienceRoute with required fields populated", () => {
+    const result = normalizeAdmin(baseInput(), OPTIONS)
+    expect(result.id).toBe("exp-loc-1")
+    expect(result.slug).toBe("test-slug")
+    expect(result.locale).toBe("en")
+    expect(result.title).toBe("Test Experience")
+    expect(result.description).toBe("test description")
+    expect(result.blocks).toEqual([])
+    expect(result.meta.source).toBe("admin")
+    expect(result.meta.potentiallyTruncated).toBe(false)
+  })
+
+  it("locale field surfaces verbatim on normalized.locale (resolved-locale equality)", () => {
+    const result = normalizeAdmin(baseInput({ locale: "es" }), OPTIONS)
+    expect(result.locale).toBe("es")
+  })
+})
+
+describe("normalizeAdmin — error paths", () => {
+  it("throws AdminNormalizationError naming missing 'id'", () => {
+    expect(() => normalizeAdmin(baseInput({ id: "" }), OPTIONS)).toThrow(
+      AdminNormalizationError,
+    )
+  })
+
+  it("throws AdminNormalizationError naming missing 'slug'", () => {
+    try {
+      normalizeAdmin(baseInput({ slug: "" }), OPTIONS)
+    } catch (e) {
+      expect((e as AdminNormalizationError).missingField).toBe("slug")
+      return
+    }
+    throw new Error("expected normalizeAdmin to throw")
+  })
+
+  it("throws AdminBlocksValidationError on a block with an unknown 't' discriminator", () => {
+    const input = baseInput({
+      blocks: [{ t: "totallyNew" }],
+    })
+    expect(() => normalizeAdmin(input, OPTIONS)).toThrow(
+      AdminBlocksValidationError,
+    )
+  })
+
+  it("AdminBlocksValidationError carries Zod issue path information", () => {
+    // strict() rejects unknown 'extraField' on a valid kind;
+    // path on the issue points to the failing block index + key.
+    const input = baseInput({
+      blocks: [{ t: "text", extraField: "not-allowed" }],
+    })
+    try {
+      normalizeAdmin(input, OPTIONS)
+    } catch (e) {
+      expect(e).toBeInstanceOf(AdminBlocksValidationError)
+      const err = e as AdminBlocksValidationError
+      expect(err.issues.length).toBeGreaterThan(0)
+      expect(err.issues.some((i) => i.path.includes(0))).toBe(true)
+      return
+    }
+    throw new Error("expected validation error")
+  })
+})
+
+describe("normalizeAdmin — absent-field contract", () => {
+  it("normalizes description: null to null", () => {
+    const result = normalizeAdmin(baseInput({ description: null }), OPTIONS)
+    expect(result.description).toBeNull()
+  })
+
+  it("normalizes description: undefined to null", () => {
+    const result = normalizeAdmin(
+      baseInput({ description: undefined }),
+      OPTIONS,
+    )
+    expect(result.description).toBeNull()
+  })
+
+  it("normalizes missing 'description' key to null", () => {
+    const input = baseInput()
+    const cloned = { ...input }
+    delete (cloned as Record<string, unknown>).description
+    const result = normalizeAdmin(cloned as AdminExperienceLocaleInput, OPTIONS)
+    expect(result.description).toBeNull()
+  })
+
+  it("normalizes null ogImageUrl to null on output", () => {
+    const result = normalizeAdmin(baseInput({ ogImageUrl: null }), OPTIONS)
+    expect(result.ogImage).toBeNull()
+  })
+
+  it("ogImage shape on present ogImageUrl: width/height/alt are null (admin lossy superset)", () => {
+    const result = normalizeAdmin(
+      baseInput({ ogImageUrl: "https://cdn.example.com/og.jpg" }),
+      OPTIONS,
+    )
+    expect(result.ogImage).toEqual({
+      url: "https://cdn.example.com/og.jpg",
+      width: null,
+      height: null,
+      alt: null,
+    })
+  })
+})
+
+describe("normalizeAdmin — URL canonicalization", () => {
+  it("canonicalizes ogImageUrl (trailing slash strip, host lowercase)", () => {
+    const result = normalizeAdmin(
+      baseInput({ ogImageUrl: "https://CDN.example.com/og.jpg/" }),
+      OPTIONS,
+    )
+    expect(result.ogImage?.url).toBe("https://cdn.example.com/og.jpg")
+    expect(Object.values(result.meta.rawUrls)).toContain(
+      "https://CDN.example.com/og.jpg/",
+    )
+  })
+})
+
+describe("normalizeAdmin — block discriminator coverage", () => {
+  it("maps admin t: 'mediaCollection' to kind: 'mediaCollection'", () => {
+    const result = normalizeAdmin(
+      baseInput({ blocks: [adminMediaCollection()] }),
+      OPTIONS,
+    )
+    expect(result.blocks[0]?.kind).toBe("mediaCollection")
+    // Admin blocks have no per-block id — normalizer emits empty string.
+    expect(result.blocks[0]?.id).toBe("")
+  })
+
+  it("maps admin t: 'text' to kind: 'text'", () => {
+    const result = normalizeAdmin(baseInput({ blocks: [adminText()] }), OPTIONS)
+    expect(result.blocks[0]?.kind).toBe("text")
+  })
+
+  it("accepts admin-only 'videoRecommendations' kind via BlocksSchema", () => {
+    const result = normalizeAdmin(
+      baseInput({
+        blocks: [
+          {
+            t: "videoRecommendations",
+            sectionKey: "key-vr",
+            limit: 6,
+          },
+        ],
+      }),
+      OPTIONS,
+    )
+    expect(result.blocks[0]?.kind).toBe("videoRecommendations")
+  })
+})
+
+describe("BlocksSchema cross-package totality (deferred-from-U2)", () => {
+  it("every shared admin kind in STRAPI_TO_ADMIN_KIND is reachable via BlocksSchema's discriminator union", () => {
+    // Surface for the cross-package check: BlocksSchema is a
+    // discriminated union over `t`. Walk its `_zod.def.options` to
+    // collect the discriminators each branch accepts. Zod 4 exposes
+    // `_zod.def.options` for discriminated unions.
+    const sharedKinds = new Set<string>(Object.values(STRAPI_TO_ADMIN_KIND))
+    const adminOnly = new Set<string>(ADMIN_ONLY_KINDS)
+    const def = BlocksSchema._zod.def
+    expect(def.type).toBe("array")
+    if (def.type !== "array") throw new Error("expected array root")
+    const elementDef = def.element._zod.def
+    expect(elementDef.type).toBe("union")
+    if (elementDef.type !== "union") throw new Error("expected union element")
+    // Collect each option's `t` literal.
+    const branchKinds = new Set<string>()
+    for (const option of elementDef.options) {
+      const optionDef = option._zod.def
+      if (optionDef.type !== "object") continue
+      const tField = optionDef.shape.t
+      if (!tField) continue
+      const tDef = tField._zod.def
+      if (tDef.type === "literal" && tDef.values.length === 1) {
+        const value = tDef.values[0]
+        if (typeof value === "string") branchKinds.add(value)
+      }
+    }
+    // Every shared kind must be reachable.
+    for (const sharedKind of sharedKinds) {
+      expect(
+        branchKinds.has(sharedKind),
+        `BlocksSchema covers ${sharedKind}`,
+      ).toBe(true)
+    }
+    // Every admin-only kind must be reachable too.
+    for (const adminOnlyKind of adminOnly) {
+      expect(
+        branchKinds.has(adminOnlyKind),
+        `BlocksSchema covers ${adminOnlyKind}`,
+      ).toBe(true)
+    }
+    // Surface any new admin kind we don't classify.
+    const unclassified = [...branchKinds].filter(
+      (k) => !sharedKinds.has(k) && !adminOnly.has(k),
+    )
+    expect(
+      unclassified,
+      `if this fails, classify the new admin kinds in discriminator-map.ts`,
+    ).toEqual([])
+  })
+})

--- a/packages/graphql/src/parity/normalize-admin.ts
+++ b/packages/graphql/src/parity/normalize-admin.ts
@@ -24,15 +24,26 @@
  */
 
 import { BlocksSchema } from "@forge/admin/domain/blocks"
-import { ZodError } from "zod"
+import type { ZodIssue } from "zod"
 
 import { canonicalizeUrl } from "./canonicalize-url"
+import {
+  canonicalizeNestedUrls,
+  nullify,
+  stripBlockMeta,
+} from "./normalize-shared"
 import type {
   NormalizedBlock,
   NormalizedExperienceRoute,
   NormalizedMeta,
   NormalizedOgImage,
 } from "./shared-shape"
+
+const ADMIN_BLOCK_SKIP_KEYS: ReadonlySet<string> = new Set([
+  "t",
+  "id",
+  "content",
+])
 
 // ---------------------------------------------------------------------------
 // Input shape
@@ -65,8 +76,8 @@ export type NormalizeAdminOptions = {
 
 export class AdminBlocksValidationError extends Error {
   override readonly name = "AdminBlocksValidationError"
-  readonly issues: ZodError["issues"]
-  constructor(message: string, issues: ZodError["issues"]) {
+  readonly issues: ReadonlyArray<ZodIssue>
+  constructor(message: string, issues: ReadonlyArray<ZodIssue>) {
     super(message)
     this.issues = issues
   }
@@ -162,11 +173,6 @@ export function normalizeAdmin(
 // Helpers
 // ---------------------------------------------------------------------------
 
-function nullify<T>(value: T | null | undefined): T | null {
-  if (value === undefined || value === null) return null
-  return value
-}
-
 function normalizeAdminOgImage(
   raw: string | null,
   baseOrigin: string,
@@ -220,7 +226,7 @@ function normalizeAdminBlock(
       kind: "container",
       id: typeof b.id === "string" ? b.id : "",
       data: {
-        ...stripBlockMeta(b),
+        ...stripBlockMeta(b, ADMIN_BLOCK_SKIP_KEYS),
         content: innerContent,
       },
     }
@@ -237,16 +243,16 @@ function normalizeAdminBlock(
       kind: "section",
       id: typeof b.id === "string" ? b.id : "",
       data: {
-        ...stripBlockMeta(b),
+        ...stripBlockMeta(b, ADMIN_BLOCK_SKIP_KEYS),
         content: innerContent,
       },
     }
   }
 
-  // Generic kinds: canonicalize URL-shaped fields in the payload.
-  const stripped = stripBlockMeta(b)
+  const stripped = stripBlockMeta(b, ADMIN_BLOCK_SKIP_KEYS)
   const dataWithCanonicalUrls = canonicalizeNestedUrls(
     stripped,
+    "admin",
     baseOrigin,
     rawUrls,
   ) as Readonly<Record<string, unknown>>
@@ -256,48 +262,4 @@ function normalizeAdminBlock(
     id: typeof b.id === "string" ? b.id : "",
     data: dataWithCanonicalUrls,
   }
-}
-
-function stripBlockMeta(
-  block: Record<string, unknown>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(block)) {
-    if (key === "t" || key === "id" || key === "content") continue
-    out[key] = value
-  }
-  return out
-}
-
-function canonicalizeNestedUrls(
-  value: unknown,
-  baseOrigin: string,
-  rawUrls: Record<string, string>,
-): unknown {
-  if (value === null || value === undefined) return null
-  if (typeof value !== "object") return value
-  if (Array.isArray(value)) {
-    return value.map((v) => canonicalizeNestedUrls(v, baseOrigin, rawUrls))
-  }
-  const out: Record<string, unknown> = {}
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof child === "string" && looksLikeUrlKey(key) && child !== "") {
-      const result = canonicalizeUrl(child, { schema: "admin", baseOrigin })
-      if (result.canonical !== null) {
-        out[key] = result.canonical
-        rawUrls[result.canonical] = result.raw
-      } else {
-        out[key] = child
-      }
-    } else if (child === undefined || child === null) {
-      out[key] = null
-    } else {
-      out[key] = canonicalizeNestedUrls(child, baseOrigin, rawUrls)
-    }
-  }
-  return out
-}
-
-function looksLikeUrlKey(key: string): boolean {
-  return /^(url|.*Url|.*URL|.*Link|.*Href)$/.test(key)
 }

--- a/packages/graphql/src/parity/normalize-admin.ts
+++ b/packages/graphql/src/parity/normalize-admin.ts
@@ -1,0 +1,303 @@
+/**
+ * Admin-side normalizer.
+ *
+ * Takes an admin `experienceBySlug` response shape and emits the shared
+ * `NormalizedExperienceRoute`. Differences from the Strapi normalizer:
+ *
+ * - The `blocks` field arrives as an opaque `JSON` scalar from admin's
+ *   GraphQL endpoint. The normalizer runs `BlocksSchema.parse(...)`
+ *   from `@forge/admin/domain/blocks` to recover the discriminated
+ *   union and surface validation errors as typed
+ *   `AdminBlocksValidationError`s.
+ * - Container shape is already flat on admin (`container.content[]`
+ *   with sibling `containerSlot` markers) — the normalizer passes
+ *   content through unchanged. No flatten step.
+ * - Resolved-locale comes from `ExperienceLocale.locale` directly.
+ * - ogImage admin emits `ogImageUrl: String` only; the normalizer
+ *   fills `width`/`height`/`alt` with `null` so the shape lines up
+ *   with Strapi's normalizer output (the lossless superset).
+ * - Optional fields normalize to `null` on absence.
+ *
+ * The input type is hand-defined to match what admin's `experienceBySlug`
+ * resolver returns at the GraphQL surface — `blocks` is `unknown`
+ * because admin exposes it as the generic JSON scalar.
+ */
+
+import { BlocksSchema } from "@forge/admin/domain/blocks"
+import { ZodError } from "zod"
+
+import { canonicalizeUrl } from "./canonicalize-url"
+import type {
+  NormalizedBlock,
+  NormalizedExperienceRoute,
+  NormalizedMeta,
+  NormalizedOgImage,
+} from "./shared-shape"
+
+// ---------------------------------------------------------------------------
+// Input shape
+// ---------------------------------------------------------------------------
+
+export type AdminExperienceLocaleInput = {
+  readonly id: string
+  readonly slug: string
+  readonly locale: string
+  readonly title: string
+  readonly description: string | null | undefined
+  readonly ogImageUrl: string | null | undefined
+  /**
+   * Admin exposes blocks as the generic `JSON` scalar — typed as
+   * `unknown` here. The normalizer parses via `BlocksSchema` to
+   * recover the discriminated union.
+   */
+  readonly blocks: unknown
+}
+
+export type NormalizeAdminOptions = {
+  readonly urlLocale: string
+  /** Origin for URL canonicalization. Admin URLs are typically absolute already. */
+  readonly baseOrigin: string
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class AdminBlocksValidationError extends Error {
+  override readonly name = "AdminBlocksValidationError"
+  readonly issues: ZodError["issues"]
+  constructor(message: string, issues: ZodError["issues"]) {
+    super(message)
+    this.issues = issues
+  }
+}
+
+export class AdminNormalizationError extends Error {
+  override readonly name = "AdminNormalizationError"
+  readonly missingField: string
+  constructor(message: string, missingField: string) {
+    super(message)
+    this.missingField = missingField
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+export function normalizeAdmin(
+  input: AdminExperienceLocaleInput,
+  options: NormalizeAdminOptions,
+): NormalizedExperienceRoute {
+  if (!input.id) {
+    throw new AdminNormalizationError(
+      "normalizeAdmin: required field 'id' is missing or empty",
+      "id",
+    )
+  }
+  if (!input.slug) {
+    throw new AdminNormalizationError(
+      "normalizeAdmin: required field 'slug' is missing or empty",
+      "slug",
+    )
+  }
+  if (!input.locale) {
+    throw new AdminNormalizationError(
+      "normalizeAdmin: required field 'locale' is missing or empty",
+      "locale",
+    )
+  }
+  if (typeof input.title !== "string") {
+    throw new AdminNormalizationError(
+      "normalizeAdmin: required field 'title' is missing",
+      "title",
+    )
+  }
+
+  // Parse the opaque JSON `blocks` payload via admin's authoritative Zod
+  // schema. Validation failures throw with structured issue context so
+  // the harness reports them as a typed surface, not opaque structural
+  // diff entries.
+  const rawBlocks = input.blocks ?? []
+  const parsed = BlocksSchema.safeParse(rawBlocks)
+  if (!parsed.success) {
+    throw new AdminBlocksValidationError(
+      `normalizeAdmin: blocks payload failed BlocksSchema validation (${parsed.error.issues.length} issues)`,
+      parsed.error.issues,
+    )
+  }
+
+  const rawUrls: Record<string, string> = {}
+  const ogImage = normalizeAdminOgImage(
+    input.ogImageUrl ?? null,
+    options.baseOrigin,
+    rawUrls,
+  )
+
+  const normalizedBlocks = parsed.data.map((block) =>
+    normalizeAdminBlock(block, options.baseOrigin, rawUrls),
+  )
+
+  const meta: NormalizedMeta = {
+    source: "admin",
+    // Admin doesn't have Strapi's pagination cap. Truncation only
+    // surfaces if upstream signals it, which admin currently doesn't.
+    potentiallyTruncated: false,
+    rawUrls: Object.freeze({ ...rawUrls }),
+  }
+
+  return {
+    id: input.id,
+    slug: input.slug,
+    locale: input.locale,
+    title: input.title,
+    description: nullify(input.description),
+    ogImage,
+    blocks: Object.freeze(normalizedBlocks) as ReadonlyArray<NormalizedBlock>,
+    meta,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nullify<T>(value: T | null | undefined): T | null {
+  if (value === undefined || value === null) return null
+  return value
+}
+
+function normalizeAdminOgImage(
+  raw: string | null,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): NormalizedOgImage | null {
+  if (raw === null || raw === "") return null
+  const result = canonicalizeUrl(raw, { schema: "admin", baseOrigin })
+  if (result.canonical === null) {
+    return { url: raw, width: null, height: null, alt: null }
+  }
+  rawUrls[result.canonical] = result.raw
+  return { url: result.canonical, width: null, height: null, alt: null }
+}
+
+/**
+ * Normalize a single parsed admin block. Admin's flat container shape
+ * (with sibling containerSlot markers) is preserved as-is in the
+ * normalized output; the differ walks `data.content[]` like any other
+ * ordered array.
+ */
+function normalizeAdminBlock(
+  block: unknown,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): NormalizedBlock {
+  const b = block as { t: string; id?: string } & Record<string, unknown>
+
+  // Synthetic containerSlot is allowed inside container.content; the
+  // top-level BlocksSchema doesn't include it, but the discriminated
+  // recursion via container will. Type the marker shape conservatively.
+  if (b.t === "containerSlot") {
+    return {
+      kind: "containerSlot",
+      id: typeof b.id === "string" ? b.id : "",
+      gridSpan: typeof b.gridSpan === "number" ? b.gridSpan : null,
+      spans: Array.isArray(b.spans)
+        ? Object.freeze([...(b.spans as number[])])
+        : null,
+    }
+  }
+
+  // For container blocks, recursively normalize their content array so
+  // nested blocks (and slot markers) are themselves canonicalized.
+  if (b.t === "container") {
+    const innerContent = Array.isArray(b.content)
+      ? (b.content as unknown[]).map((c) =>
+          normalizeAdminBlock(c, baseOrigin, rawUrls),
+        )
+      : []
+    return {
+      kind: "container",
+      id: typeof b.id === "string" ? b.id : "",
+      data: {
+        ...stripBlockMeta(b),
+        content: innerContent,
+      },
+    }
+  }
+
+  // Section blocks also carry a content[] of nested blocks.
+  if (b.t === "section") {
+    const innerContent = Array.isArray(b.content)
+      ? (b.content as unknown[]).map((c) =>
+          normalizeAdminBlock(c, baseOrigin, rawUrls),
+        )
+      : []
+    return {
+      kind: "section",
+      id: typeof b.id === "string" ? b.id : "",
+      data: {
+        ...stripBlockMeta(b),
+        content: innerContent,
+      },
+    }
+  }
+
+  // Generic kinds: canonicalize URL-shaped fields in the payload.
+  const stripped = stripBlockMeta(b)
+  const dataWithCanonicalUrls = canonicalizeNestedUrls(
+    stripped,
+    baseOrigin,
+    rawUrls,
+  ) as Readonly<Record<string, unknown>>
+
+  return {
+    kind: b.t as Exclude<NormalizedBlock["kind"], "containerSlot">,
+    id: typeof b.id === "string" ? b.id : "",
+    data: dataWithCanonicalUrls,
+  }
+}
+
+function stripBlockMeta(
+  block: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(block)) {
+    if (key === "t" || key === "id" || key === "content") continue
+    out[key] = value
+  }
+  return out
+}
+
+function canonicalizeNestedUrls(
+  value: unknown,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): unknown {
+  if (value === null || value === undefined) return null
+  if (typeof value !== "object") return value
+  if (Array.isArray(value)) {
+    return value.map((v) => canonicalizeNestedUrls(v, baseOrigin, rawUrls))
+  }
+  const out: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof child === "string" && looksLikeUrlKey(key) && child !== "") {
+      const result = canonicalizeUrl(child, { schema: "admin", baseOrigin })
+      if (result.canonical !== null) {
+        out[key] = result.canonical
+        rawUrls[result.canonical] = result.raw
+      } else {
+        out[key] = child
+      }
+    } else if (child === undefined || child === null) {
+      out[key] = null
+    } else {
+      out[key] = canonicalizeNestedUrls(child, baseOrigin, rawUrls)
+    }
+  }
+  return out
+}
+
+function looksLikeUrlKey(key: string): boolean {
+  return /^(url|.*Url|.*URL|.*Link|.*Href)$/.test(key)
+}

--- a/packages/graphql/src/parity/normalize-shared.ts
+++ b/packages/graphql/src/parity/normalize-shared.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared helpers used by BOTH `normalize-strapi.ts` and `normalize-admin.ts`.
+ *
+ * Keeping these in one place is load-bearing: a divergence between the
+ * two normalizers' URL-key heuristics or absent-field rules would
+ * produce silent one-sided value diffs — exactly the failure mode the
+ * harness exists to detect.
+ */
+
+import { canonicalizeUrl } from "./canonicalize-url"
+
+/** Shorthand for the source-side discriminator. */
+export type Side = "strapi" | "admin"
+
+/**
+ * Map `null` / `undefined` / missing inputs to `null` so the differ's
+ * structural-class equivalence rule applies post-normalization.
+ */
+export function nullify<T>(value: T | null | undefined): T | null {
+  if (value === undefined || value === null) return null
+  return value
+}
+
+/**
+ * Strip a known set of meta-keys (`__typename`, `id`, `t`, ...) from a
+ * block payload. Each normalizer passes its own skip-set since the
+ * source-specific wrapper keys differ.
+ */
+export function stripBlockMeta(
+  block: Record<string, unknown>,
+  skipKeys: ReadonlySet<string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(block)) {
+    if (skipKeys.has(key)) continue
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Heuristic: does this object key carry a URL-shaped value worth
+ * canonicalizing? Conservative — only keys ending in known URL-shaped
+ * suffixes match. Expand if a captured fixture surfaces a URL field
+ * that doesn't match.
+ */
+export function looksLikeUrlKey(key: string): boolean {
+  if (key === "url") return true
+  return (
+    key.endsWith("Url") ||
+    key.endsWith("URL") ||
+    key.endsWith("Link") ||
+    key.endsWith("Href")
+  )
+}
+
+/**
+ * Walk a JSON-shaped payload and canonicalize any string field whose
+ * key matches the URL-shape heuristic. Pure recursion — no async, no
+ * mutation of the input. Records the raw → canonical map in `rawUrls`.
+ *
+ * Both normalizers route through this helper so the two sides
+ * cannot drift on URL handling.
+ */
+export function canonicalizeNestedUrls(
+  value: unknown,
+  schema: Side,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): unknown {
+  if (value === null || value === undefined) return null
+  if (typeof value === "string") return value
+  if (typeof value !== "object") return value
+  if (Array.isArray(value)) {
+    return value.map((v) =>
+      canonicalizeNestedUrls(v, schema, baseOrigin, rawUrls),
+    )
+  }
+  const out: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof child === "string" && looksLikeUrlKey(key) && child !== "") {
+      const result = canonicalizeUrl(child, { schema, baseOrigin })
+      if (result.canonical !== null) {
+        out[key] = result.canonical
+        rawUrls[result.canonical] = result.raw
+      } else {
+        out[key] = child
+      }
+    } else if (child === undefined || child === null) {
+      out[key] = null
+    } else {
+      out[key] = canonicalizeNestedUrls(child, schema, baseOrigin, rawUrls)
+    }
+  }
+  return out
+}

--- a/packages/graphql/src/parity/normalize-strapi.test.ts
+++ b/packages/graphql/src/parity/normalize-strapi.test.ts
@@ -242,6 +242,57 @@ describe("normalizeStrapi — container flatten", () => {
     expect(flat[5]).toMatchObject({ kind: "card", id: "card-1" })
   })
 
+  it("preserves container's non-content layout fields (gap, padding, etc.) — symmetry with admin", () => {
+    // Regression: an earlier flattenContainer dropped every non-content
+    // field, producing a guaranteed false-positive structural diff per
+    // container against admin's preserved-fields output.
+    const container: StrapiBlockInput = {
+      __typename: "ComponentSectionsContainer",
+      id: "ctr-2",
+      gap: "lg",
+      padding: 24,
+      backgroundColor: "#fff",
+      slots: [],
+    }
+    const result = normalizeStrapi(baseInput({ blocks: [container] }), OPTIONS)
+    const top = result.blocks[0]
+    if (!top || top.kind !== "container") throw new Error("expected container")
+    expect(top.data.gap).toBe("lg")
+    expect(top.data.padding).toBe(24)
+    expect(top.data.backgroundColor).toBe("#fff")
+    expect(top.data.content).toEqual([])
+    expect(top.data).not.toHaveProperty("slots")
+    expect(top.data).not.toHaveProperty("__typename")
+  })
+
+  it("section preserves NORMALIZED inner content[] (not raw Strapi children) — regression for spread-overwrite bug", () => {
+    // Regression: an earlier normalizeSection placed the spread of raw
+    // section fields AFTER the explicit `content: normalizedInner`,
+    // causing the raw `content` array to overwrite the normalized one.
+    const section: StrapiBlockInput = {
+      __typename: "ComponentSectionsSection",
+      id: "sec-1",
+      heading: "Section Title",
+      content: [
+        { __typename: "ComponentSectionsText", id: "txt-1" },
+        { __typename: "ComponentSectionsCta", id: "cta-1" },
+      ],
+    }
+    const result = normalizeStrapi(baseInput({ blocks: [section] }), OPTIONS)
+    const top = result.blocks[0]
+    if (!top || top.kind !== "section") throw new Error("expected section")
+    const inner = top.data.content as ReadonlyArray<{
+      kind: string
+      id: string
+    }>
+    expect(inner).toHaveLength(2)
+    // Normalized: kind values are admin-canonical, NOT Strapi typenames
+    expect(inner[0]).toMatchObject({ kind: "text", id: "txt-1" })
+    expect(inner[1]).toMatchObject({ kind: "cta", id: "cta-1" })
+    expect(top.data.heading).toBe("Section Title")
+    expect(top.data).not.toHaveProperty("__typename")
+  })
+
   it("emits empty container content when slots is null", () => {
     const container: StrapiBlockInput = {
       __typename: "ComponentSectionsContainer",

--- a/packages/graphql/src/parity/normalize-strapi.test.ts
+++ b/packages/graphql/src/parity/normalize-strapi.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest"
+
+import { STRAPI_TO_ADMIN_KIND } from "./discriminator-map"
+import {
+  StrapiNormalizationError,
+  normalizeStrapi,
+  type StrapiBlockInput,
+  type StrapiExperienceInput,
+} from "./normalize-strapi"
+
+const OPTIONS = {
+  urlLocale: "en",
+  baseOrigin: "https://cdn.example.com",
+} as const
+
+function baseInput(
+  overrides: Partial<StrapiExperienceInput> = {},
+): StrapiExperienceInput {
+  return {
+    documentId: "doc-1",
+    slug: "test-slug",
+    locale: "en",
+    title: "Test Experience",
+    metaDescription: "test description",
+    ogImage: null,
+    blocks: [],
+    ...overrides,
+  }
+}
+
+describe("normalizeStrapi — happy paths", () => {
+  it("returns a NormalizedExperienceRoute with required fields populated", () => {
+    const result = normalizeStrapi(baseInput(), OPTIONS)
+    expect(result.id).toBe("doc-1")
+    expect(result.slug).toBe("test-slug")
+    expect(result.locale).toBe("en")
+    expect(result.title).toBe("Test Experience")
+    expect(result.description).toBe("test description")
+    expect(result.blocks).toEqual([])
+    expect(result.meta.source).toBe("strapi")
+  })
+
+  it("locale field surfaces verbatim on normalized.locale", () => {
+    const result = normalizeStrapi(baseInput({ locale: "es" }), OPTIONS)
+    expect(result.locale).toBe("es")
+  })
+})
+
+describe("normalizeStrapi — error paths", () => {
+  it("throws StrapiNormalizationError naming missing 'slug'", () => {
+    const input = baseInput({ slug: "" })
+    expect(() => normalizeStrapi(input, OPTIONS)).toThrow(
+      StrapiNormalizationError,
+    )
+    try {
+      normalizeStrapi(input, OPTIONS)
+    } catch (e) {
+      expect((e as StrapiNormalizationError).missingField).toBe("slug")
+    }
+  })
+
+  it("throws StrapiNormalizationError naming missing 'documentId'", () => {
+    const input = baseInput({ documentId: "" })
+    expect(() => normalizeStrapi(input, OPTIONS)).toThrow(
+      /required field 'documentId'/,
+    )
+  })
+
+  it("throws StrapiNormalizationError when 'title' is not a string", () => {
+    const input = baseInput({ title: undefined as unknown as string })
+    expect(() => normalizeStrapi(input, OPTIONS)).toThrow(
+      /required field 'title'/,
+    )
+  })
+})
+
+describe("normalizeStrapi — absent-field contract", () => {
+  it("normalizes description: null to null", () => {
+    const result = normalizeStrapi(
+      baseInput({ metaDescription: null }),
+      OPTIONS,
+    )
+    expect(result.description).toBeNull()
+  })
+
+  it("normalizes description: undefined to null", () => {
+    const result = normalizeStrapi(
+      baseInput({ metaDescription: undefined }),
+      OPTIONS,
+    )
+    expect(result.description).toBeNull()
+  })
+
+  it("normalizes missing 'metaDescription' key to null", () => {
+    const input = baseInput()
+    const cloned = { ...input }
+    delete (cloned as Record<string, unknown>).metaDescription
+    const result = normalizeStrapi(cloned as StrapiExperienceInput, OPTIONS)
+    expect(result.description).toBeNull()
+  })
+
+  it("normalizes null ogImage to null on output", () => {
+    const result = normalizeStrapi(baseInput({ ogImage: null }), OPTIONS)
+    expect(result.ogImage).toBeNull()
+  })
+
+  it("normalizes undefined ogImage to null on output", () => {
+    const result = normalizeStrapi(baseInput({ ogImage: undefined }), OPTIONS)
+    expect(result.ogImage).toBeNull()
+  })
+
+  it("normalizes missing 'blocks' key to empty array", () => {
+    const input = baseInput()
+    const cloned = { ...input }
+    delete (cloned as Record<string, unknown>).blocks
+    const result = normalizeStrapi(cloned as StrapiExperienceInput, OPTIONS)
+    expect(result.blocks).toEqual([])
+  })
+})
+
+describe("normalizeStrapi — URL canonicalization", () => {
+  it("expands a Strapi root-relative ogImage url against baseOrigin", () => {
+    const result = normalizeStrapi(
+      baseInput({
+        ogImage: {
+          url: "/images/foo.jpg",
+          width: 1200,
+          height: 630,
+          alternativeText: "alt",
+        },
+      }),
+      OPTIONS,
+    )
+    expect(result.ogImage?.url).toBe("https://cdn.example.com/images/foo.jpg")
+    expect(result.meta.rawUrls).toEqual({
+      "https://cdn.example.com/images/foo.jpg": "/images/foo.jpg",
+    })
+  })
+
+  it("preserves raw input alongside canonical in meta.rawUrls", () => {
+    const result = normalizeStrapi(
+      baseInput({
+        ogImage: {
+          url: "/images/x.png",
+          width: null,
+          height: null,
+          alternativeText: null,
+        },
+      }),
+      OPTIONS,
+    )
+    expect(Object.values(result.meta.rawUrls)).toContain("/images/x.png")
+  })
+})
+
+describe("normalizeStrapi — block discriminator translation", () => {
+  it("maps ComponentSectionsMediaCollection to kind: 'mediaCollection'", () => {
+    const block: StrapiBlockInput = {
+      __typename: "ComponentSectionsMediaCollection",
+      id: "block-1",
+      heading: "test",
+    }
+    const result = normalizeStrapi(baseInput({ blocks: [block] }), OPTIONS)
+    expect(result.blocks[0]?.kind).toBe("mediaCollection")
+    expect(result.blocks[0]?.id).toBe("block-1")
+  })
+
+  it("covers all 16 shared block discriminators (per-discriminator coverage)", () => {
+    const allTypenames = Object.keys(STRAPI_TO_ADMIN_KIND)
+    const blocks: StrapiBlockInput[] = allTypenames.map(
+      (typename, idx) =>
+        ({
+          __typename: typename,
+          id: `block-${idx}`,
+        }) as StrapiBlockInput,
+    )
+    const result = normalizeStrapi(baseInput({ blocks }), OPTIONS)
+    expect(result.blocks).toHaveLength(16)
+    for (let i = 0; i < allTypenames.length; i++) {
+      const typename = allTypenames[i]!
+      const expectedKind =
+        STRAPI_TO_ADMIN_KIND[typename as keyof typeof STRAPI_TO_ADMIN_KIND]
+      // Container is flattened (single block emitted), Section is at top-level.
+      // Both surface as their expected kind in the normalized array.
+      const block = result.blocks[i]
+      expect(block?.kind, `index ${i} (${typename})`).toBe(expectedKind)
+    }
+  })
+})
+
+describe("normalizeStrapi — container flatten", () => {
+  it("flattens a container with two slots into a flat content array with synthetic markers", () => {
+    const container: StrapiBlockInput = {
+      __typename: "ComponentSectionsContainer",
+      id: "ctr-1",
+      slots: [
+        {
+          id: "slot-1",
+          gridSpan: 2,
+          spans: [1, 2],
+          content: [
+            { __typename: "ComponentSectionsText", id: "txt-1" },
+            { __typename: "ComponentSectionsCta", id: "cta-1" },
+          ],
+        },
+        {
+          id: "slot-2",
+          gridSpan: 1,
+          spans: null,
+          content: [
+            { __typename: "ComponentSectionsVideo", id: "vid-1" },
+            { __typename: "ComponentSectionsCard", id: "card-1" },
+          ],
+        },
+      ],
+    }
+    const result = normalizeStrapi(baseInput({ blocks: [container] }), OPTIONS)
+
+    expect(result.blocks).toHaveLength(1)
+    const top = result.blocks[0]
+    expect(top?.kind).toBe("container")
+    if (!top || top.kind !== "container") throw new Error("expected container")
+    const flat = top.data.content as ReadonlyArray<{
+      kind: string
+      id: string
+      gridSpan?: number | null
+    }>
+    expect(flat).toHaveLength(6)
+    expect(flat[0]).toMatchObject({
+      kind: "containerSlot",
+      id: "slot-1",
+      gridSpan: 2,
+    })
+    expect(flat[1]).toMatchObject({ kind: "text", id: "txt-1" })
+    expect(flat[2]).toMatchObject({ kind: "cta", id: "cta-1" })
+    expect(flat[3]).toMatchObject({
+      kind: "containerSlot",
+      id: "slot-2",
+      gridSpan: 1,
+    })
+    expect(flat[4]).toMatchObject({ kind: "video", id: "vid-1" })
+    expect(flat[5]).toMatchObject({ kind: "card", id: "card-1" })
+  })
+
+  it("emits empty container content when slots is null", () => {
+    const container: StrapiBlockInput = {
+      __typename: "ComponentSectionsContainer",
+      id: "ctr-1",
+      slots: null,
+    }
+    const result = normalizeStrapi(baseInput({ blocks: [container] }), OPTIONS)
+    const top = result.blocks[0]
+    if (!top || top.kind !== "container") throw new Error("expected container")
+    expect(top.data.content).toEqual([])
+  })
+})
+
+describe("normalizeStrapi — truncation detection", () => {
+  it("sets potentiallyTruncated: false in fixture mode (no response meta)", () => {
+    const result = normalizeStrapi(baseInput({ blocks: [] }), OPTIONS)
+    expect(result.meta.potentiallyTruncated).toBe(false)
+  })
+
+  it("sets potentiallyTruncated: false when length is exactly 10 but no meta says truncated", () => {
+    // Length-based heuristics are NOT a trigger — per plan Key Decisions.
+    const blocks: StrapiBlockInput[] = Array.from({ length: 10 }, (_, i) => ({
+      __typename: "ComponentSectionsText",
+      id: `t-${i}`,
+    }))
+    const result = normalizeStrapi(baseInput({ blocks }), OPTIONS)
+    expect(result.meta.potentiallyTruncated).toBe(false)
+  })
+
+  it("sets potentiallyTruncated: true when response meta says total > returned", () => {
+    const result = normalizeStrapi(
+      baseInput({
+        blocks: [],
+        _meta: { pagination: { total: 12, returned: 10 } },
+      }),
+      OPTIONS,
+    )
+    expect(result.meta.potentiallyTruncated).toBe(true)
+  })
+
+  it("sets potentiallyTruncated: false when total == returned", () => {
+    const result = normalizeStrapi(
+      baseInput({
+        blocks: [],
+        _meta: { pagination: { total: 5, returned: 5 } },
+      }),
+      OPTIONS,
+    )
+    expect(result.meta.potentiallyTruncated).toBe(false)
+  })
+})

--- a/packages/graphql/src/parity/normalize-strapi.ts
+++ b/packages/graphql/src/parity/normalize-strapi.ts
@@ -1,0 +1,406 @@
+/**
+ * Strapi-side normalizer.
+ *
+ * Takes a Strapi `Experience` response shape and emits the shared
+ * `NormalizedExperienceRoute`. Handles:
+ *
+ * - Discriminator translation (`__typename` → admin-canonical `kind`)
+ *   via `discriminator-map.ts`. Unknown typenames surface as
+ *   `kind: "unknown"` blocks; the differ flags them as structural.
+ * - Container flatten: `Container { slots[] { content[] } }` flattens
+ *   into a single `content[]` array with synthetic `containerSlot`
+ *   markers preserving slot metadata at boundaries (per plan Key
+ *   Decisions). Same rule applies to Section.
+ * - URL canonicalization via `canonicalize-url.ts`. Raw forms are
+ *   captured in `meta.rawUrls`.
+ * - Resolved-locale stored verbatim on `normalized.locale` — locale
+ *   correctness is checked by the differ as a field comparison.
+ * - Truncation detection via response metadata (`pagination.total >
+ *   returned.length`). Length-based heuristics are NOT triggers.
+ * - Optional fields normalize to `null` on absence (null /
+ *   undefined / missing key all map to null).
+ *
+ * The input type is hand-defined here at the structural level needed
+ * for normalization. The actual gql.tada query (with `pagination:
+ * { limit: -1 }` overrides) lives with U6's capture script.
+ */
+
+import { canonicalizeUrl } from "./canonicalize-url"
+import { strapiTypenameToAdminKind } from "./discriminator-map"
+import type {
+  NormalizedBlock,
+  NormalizedExperienceRoute,
+  NormalizedMeta,
+  NormalizedOgImage,
+} from "./shared-shape"
+
+// ---------------------------------------------------------------------------
+// Input shape — what the parity Strapi query returns at the structural
+// level the normalizer consumes. Block components are typed as a
+// discriminated union on `__typename` with the open-ended `data` payload.
+// ---------------------------------------------------------------------------
+
+export type StrapiOgImage = {
+  readonly url: string
+  readonly width: number | null
+  readonly height: number | null
+  readonly alternativeText: string | null
+} | null
+
+export type StrapiExperienceInput = {
+  readonly documentId: string
+  readonly slug: string
+  readonly locale: string
+  readonly title: string
+  readonly metaDescription: string | null | undefined
+  readonly ogImage: StrapiOgImage | undefined
+  readonly blocks: ReadonlyArray<StrapiBlockInput> | null | undefined
+  /** Optional response-meta surface for live-mode truncation detection. */
+  readonly _meta?: {
+    readonly pagination?: {
+      readonly total?: number
+      readonly returned?: number
+    }
+  }
+}
+
+export type StrapiBlockInput =
+  | StrapiContainerBlock
+  | StrapiSectionBlock
+  | StrapiGenericBlock
+
+export type StrapiContainerBlock = {
+  readonly __typename: "ComponentSectionsContainer"
+  readonly id: string
+  readonly slots:
+    | ReadonlyArray<{
+        readonly id: string
+        readonly gridSpan: number | null | undefined
+        readonly spans: ReadonlyArray<number> | null | undefined
+        readonly content: ReadonlyArray<StrapiBlockInput> | null | undefined
+      }>
+    | null
+    | undefined
+  readonly [field: string]: unknown
+}
+
+export type StrapiSectionBlock = {
+  readonly __typename: "ComponentSectionsSection"
+  readonly id: string
+  readonly content: ReadonlyArray<StrapiBlockInput> | null | undefined
+  readonly [field: string]: unknown
+}
+
+export type StrapiGenericBlock = {
+  readonly __typename: string
+  readonly id: string
+  readonly [field: string]: unknown
+}
+
+export type NormalizeStrapiOptions = {
+  /** URL locale the request asked for. Carried into NormalizedMeta context. */
+  readonly urlLocale: string
+  /** Origin used to resolve Strapi root-relative URLs. */
+  readonly baseOrigin: string
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class StrapiNormalizationError extends Error {
+  override readonly name = "StrapiNormalizationError"
+  readonly missingField: string
+  constructor(message: string, missingField: string) {
+    super(message)
+    this.missingField = missingField
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+export function normalizeStrapi(
+  input: StrapiExperienceInput,
+  options: NormalizeStrapiOptions,
+): NormalizedExperienceRoute {
+  if (!input.documentId) {
+    throw new StrapiNormalizationError(
+      "normalizeStrapi: required field 'documentId' is missing or empty",
+      "documentId",
+    )
+  }
+  if (!input.slug) {
+    throw new StrapiNormalizationError(
+      "normalizeStrapi: required field 'slug' is missing or empty",
+      "slug",
+    )
+  }
+  if (!input.locale) {
+    throw new StrapiNormalizationError(
+      "normalizeStrapi: required field 'locale' is missing or empty",
+      "locale",
+    )
+  }
+  if (typeof input.title !== "string") {
+    throw new StrapiNormalizationError(
+      "normalizeStrapi: required field 'title' is missing",
+      "title",
+    )
+  }
+
+  const rawUrls: Record<string, string> = {}
+  const ogImage = normalizeOgImage(
+    input.ogImage ?? null,
+    options.baseOrigin,
+    rawUrls,
+  )
+
+  const flatBlocks = flattenAndNormalizeBlocks(
+    input.blocks ?? [],
+    options.baseOrigin,
+    rawUrls,
+  )
+
+  const meta: NormalizedMeta = {
+    source: "strapi",
+    potentiallyTruncated: detectTruncation(input._meta),
+    rawUrls: Object.freeze({ ...rawUrls }),
+  }
+
+  return {
+    id: input.documentId,
+    slug: input.slug,
+    locale: input.locale,
+    title: input.title,
+    description: nullify(input.metaDescription),
+    ogImage,
+    blocks: Object.freeze(flatBlocks) as ReadonlyArray<NormalizedBlock>,
+    meta,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map `null` / `undefined` / missing inputs to `null` so the differ's
+ * structural-class equivalence rule applies post-normalization.
+ */
+function nullify<T>(value: T | null | undefined): T | null {
+  if (value === undefined || value === null) return null
+  return value
+}
+
+function detectTruncation(
+  responseMeta: StrapiExperienceInput["_meta"],
+): boolean {
+  const pagination = responseMeta?.pagination
+  if (!pagination) return false
+  const total = pagination.total
+  const returned = pagination.returned
+  if (typeof total !== "number" || typeof returned !== "number") return false
+  return total > returned
+}
+
+function normalizeOgImage(
+  raw: StrapiOgImage,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): NormalizedOgImage | null {
+  if (raw === null || raw === undefined) return null
+  if (!raw.url) return null
+  const result = canonicalizeUrl(raw.url, { schema: "strapi", baseOrigin })
+  if (result.canonical === null) {
+    return {
+      url: raw.url,
+      width: nullify(raw.width),
+      height: nullify(raw.height),
+      alt: nullify(raw.alternativeText),
+    }
+  }
+  rawUrls[result.canonical] = result.raw
+  return {
+    url: result.canonical,
+    width: nullify(raw.width),
+    height: nullify(raw.height),
+    alt: nullify(raw.alternativeText),
+  }
+}
+
+/**
+ * Walk the Strapi blocks array and flatten container.slots[].content[]
+ * into the admin-canonical flat shape. Section blocks containing nested
+ * content arrays are also flattened the same way.
+ */
+function flattenAndNormalizeBlocks(
+  blocks: ReadonlyArray<StrapiBlockInput>,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): NormalizedBlock[] {
+  const out: NormalizedBlock[] = []
+  for (const block of blocks) {
+    // Discriminator narrowing on a `string`-typed __typename can't
+    // exclude StrapiGenericBlock at type level — assert through the
+    // runtime check.
+    if (block.__typename === "ComponentSectionsContainer") {
+      out.push(
+        ...flattenContainer(block as StrapiContainerBlock, baseOrigin, rawUrls),
+      )
+      continue
+    }
+    if (block.__typename === "ComponentSectionsSection") {
+      out.push(
+        normalizeSection(block as StrapiSectionBlock, baseOrigin, rawUrls),
+      )
+      continue
+    }
+    out.push(normalizeGenericBlock(block, baseOrigin, rawUrls))
+  }
+  return out
+}
+
+function flattenContainer(
+  container: StrapiContainerBlock,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): NormalizedBlock[] {
+  // Emit the container itself with empty content[]; slot markers and
+  // their inner blocks are appended as siblings inside content[].
+  const containerContent: NormalizedBlock[] = []
+  const slots = container.slots ?? []
+  for (const slot of slots) {
+    containerContent.push({
+      kind: "containerSlot",
+      id: slot.id,
+      gridSpan: nullify(slot.gridSpan),
+      spans: slot.spans ? Object.freeze([...slot.spans]) : null,
+    })
+    const innerBlocks = slot.content ?? []
+    for (const inner of innerBlocks) {
+      containerContent.push(normalizeGenericBlock(inner, baseOrigin, rawUrls))
+    }
+  }
+  // Container itself is a normalized block whose `data.content` carries
+  // the flattened sequence. The differ walks data.content[] like any
+  // other ordered array.
+  return [
+    {
+      kind: "container",
+      id: container.id,
+      data: {
+        content: containerContent,
+      },
+    },
+  ]
+}
+
+function normalizeSection(
+  section: StrapiSectionBlock,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): NormalizedBlock {
+  const innerBlocks = section.content ?? []
+  const normalizedInner: NormalizedBlock[] = []
+  for (const inner of innerBlocks) {
+    normalizedInner.push(normalizeGenericBlock(inner, baseOrigin, rawUrls))
+  }
+  return {
+    kind: "section",
+    id: section.id,
+    data: {
+      content: normalizedInner,
+      ...stripBlockMeta(section as Record<string, unknown>),
+    },
+  }
+}
+
+function normalizeGenericBlock(
+  block: StrapiGenericBlock | StrapiBlockInput,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): NormalizedBlock {
+  const typename = block.__typename
+  const mapped = strapiTypenameToAdminKind(typename)
+  if (typeof mapped === "object" && mapped.kind === "unknown") {
+    return {
+      kind: "section", // placeholder routed through structural diff via id+data
+      id: block.id ?? "",
+      data: {
+        _unknownTypename: typename,
+      },
+    } as NormalizedBlock
+  }
+  // Strip __typename and id (carried on the wrapper); canonicalize URLs
+  // present anywhere in the payload.
+  const rest = stripBlockMeta(block as Record<string, unknown>)
+  const dataWithCanonicalUrls = canonicalizeNestedUrls(
+    rest,
+    baseOrigin,
+    rawUrls,
+  )
+  return {
+    kind: mapped as Exclude<NormalizedBlock["kind"], "containerSlot">,
+    id: block.id,
+    data: dataWithCanonicalUrls as Readonly<Record<string, unknown>>,
+  }
+}
+
+/**
+ * Strip `__typename` and `id` from a block payload — both are surfaced
+ * at the wrapper level on `NormalizedBlock`, not the inner data.
+ */
+function stripBlockMeta(
+  block: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(block)) {
+    if (key === "__typename" || key === "id") continue
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Walk the data payload and canonicalize any field whose key suggests
+ * it carries a URL (`url`, `*Url`, `image`, `*Image.url`). This is
+ * conservative — only string values whose key matches the URL-shape
+ * heuristic are passed to the canonicalizer.
+ */
+function canonicalizeNestedUrls(
+  value: unknown,
+  baseOrigin: string,
+  rawUrls: Record<string, string>,
+): unknown {
+  if (value === null || value === undefined) return null
+  if (typeof value === "string") return value
+  if (typeof value !== "object") return value
+  if (Array.isArray(value)) {
+    return value.map((v) => canonicalizeNestedUrls(v, baseOrigin, rawUrls))
+  }
+  const out: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof child === "string" && looksLikeUrlKey(key) && child !== "") {
+      const result = canonicalizeUrl(child, { schema: "strapi", baseOrigin })
+      if (result.canonical !== null) {
+        out[key] = result.canonical
+        rawUrls[result.canonical] = result.raw
+      } else {
+        out[key] = child
+      }
+    } else if (child === undefined || child === null) {
+      out[key] = null
+    } else {
+      out[key] = canonicalizeNestedUrls(child, baseOrigin, rawUrls)
+    }
+  }
+  return out
+}
+
+function looksLikeUrlKey(key: string): boolean {
+  // Match common URL-bearing field names. Conservative; expand if a
+  // captured fixture surfaces a URL field that doesn't match.
+  return /^(url|.*Url|.*URL|.*Link|.*Href)$/.test(key)
+}

--- a/packages/graphql/src/parity/normalize-strapi.ts
+++ b/packages/graphql/src/parity/normalize-strapi.ts
@@ -42,6 +42,14 @@ import type {
 const STRAPI_BLOCK_SKIP_KEYS: ReadonlySet<string> = new Set([
   "__typename",
   "id",
+  // `content` is normalized separately and re-emitted explicitly by
+  // `normalizeSection` and `flattenContainer`. Excluding it here ensures
+  // the spread can never re-introduce the raw (un-flattened, un-canonicalized)
+  // children — mirrors ADMIN_BLOCK_SKIP_KEYS.
+  "content",
+  // `slots` is consumed by `flattenContainer` to build the flat content[]
+  // shape; never include the raw two-level structure on the normalized output.
+  "slots",
 ])
 
 // ---------------------------------------------------------------------------
@@ -275,7 +283,9 @@ function flattenContainer(
   for (const slot of slots) {
     containerContent.push({
       kind: "containerSlot",
-      id: slot.id,
+      // Mirror admin's containerSlot id guard for symmetry — admin emits
+      // empty string when the slot id is missing/non-string.
+      id: typeof slot.id === "string" ? slot.id : "",
       gridSpan: nullify(slot.gridSpan),
       spans: slot.spans ? Object.freeze([...slot.spans]) : null,
     })
@@ -286,12 +296,18 @@ function flattenContainer(
   }
   // Container itself is a normalized block whose `data.content` carries
   // the flattened sequence. The differ walks data.content[] like any
-  // other ordered array.
+  // other ordered array. Container's other layout fields (gap, padding,
+  // background, etc.) are surfaced via stripBlockMeta so the data shape
+  // matches admin's container payload.
   return [
     {
       kind: "container",
       id: container.id,
       data: {
+        ...stripBlockMeta(
+          container as Record<string, unknown>,
+          STRAPI_BLOCK_SKIP_KEYS,
+        ),
         content: containerContent,
       },
     },
@@ -308,15 +324,20 @@ function normalizeSection(
   for (const inner of innerBlocks) {
     normalizedInner.push(normalizeGenericBlock(inner, baseOrigin, rawUrls))
   }
+  // Spread non-content fields FIRST, then assign normalized content
+  // explicitly LAST. Reverse order would let the spread overwrite the
+  // normalized content with the raw Strapi children. Mirrors admin's
+  // section path. STRAPI_BLOCK_SKIP_KEYS now also excludes `content` so
+  // the spread can't reintroduce it even if order were edited.
   return {
     kind: "section",
     id: section.id,
     data: {
-      content: normalizedInner,
       ...stripBlockMeta(
         section as Record<string, unknown>,
         STRAPI_BLOCK_SKIP_KEYS,
       ),
+      content: normalizedInner,
     },
   }
 }

--- a/packages/graphql/src/parity/normalize-strapi.ts
+++ b/packages/graphql/src/parity/normalize-strapi.ts
@@ -27,12 +27,22 @@
 
 import { canonicalizeUrl } from "./canonicalize-url"
 import { strapiTypenameToAdminKind } from "./discriminator-map"
+import {
+  canonicalizeNestedUrls,
+  nullify,
+  stripBlockMeta,
+} from "./normalize-shared"
 import type {
   NormalizedBlock,
   NormalizedExperienceRoute,
   NormalizedMeta,
   NormalizedOgImage,
 } from "./shared-shape"
+
+const STRAPI_BLOCK_SKIP_KEYS: ReadonlySet<string> = new Set([
+  "__typename",
+  "id",
+])
 
 // ---------------------------------------------------------------------------
 // Input shape — what the parity Strapi query returns at the structural
@@ -185,15 +195,6 @@ export function normalizeStrapi(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Map `null` / `undefined` / missing inputs to `null` so the differ's
- * structural-class equivalence rule applies post-normalization.
- */
-function nullify<T>(value: T | null | undefined): T | null {
-  if (value === undefined || value === null) return null
-  return value
-}
-
 function detectTruncation(
   responseMeta: StrapiExperienceInput["_meta"],
 ): boolean {
@@ -312,7 +313,10 @@ function normalizeSection(
     id: section.id,
     data: {
       content: normalizedInner,
-      ...stripBlockMeta(section as Record<string, unknown>),
+      ...stripBlockMeta(
+        section as Record<string, unknown>,
+        STRAPI_BLOCK_SKIP_KEYS,
+      ),
     },
   }
 }
@@ -333,11 +337,13 @@ function normalizeGenericBlock(
       },
     } as NormalizedBlock
   }
-  // Strip __typename and id (carried on the wrapper); canonicalize URLs
-  // present anywhere in the payload.
-  const rest = stripBlockMeta(block as Record<string, unknown>)
+  const rest = stripBlockMeta(
+    block as Record<string, unknown>,
+    STRAPI_BLOCK_SKIP_KEYS,
+  )
   const dataWithCanonicalUrls = canonicalizeNestedUrls(
     rest,
+    "strapi",
     baseOrigin,
     rawUrls,
   )
@@ -346,61 +352,4 @@ function normalizeGenericBlock(
     id: block.id,
     data: dataWithCanonicalUrls as Readonly<Record<string, unknown>>,
   }
-}
-
-/**
- * Strip `__typename` and `id` from a block payload — both are surfaced
- * at the wrapper level on `NormalizedBlock`, not the inner data.
- */
-function stripBlockMeta(
-  block: Record<string, unknown>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(block)) {
-    if (key === "__typename" || key === "id") continue
-    out[key] = value
-  }
-  return out
-}
-
-/**
- * Walk the data payload and canonicalize any field whose key suggests
- * it carries a URL (`url`, `*Url`, `image`, `*Image.url`). This is
- * conservative — only string values whose key matches the URL-shape
- * heuristic are passed to the canonicalizer.
- */
-function canonicalizeNestedUrls(
-  value: unknown,
-  baseOrigin: string,
-  rawUrls: Record<string, string>,
-): unknown {
-  if (value === null || value === undefined) return null
-  if (typeof value === "string") return value
-  if (typeof value !== "object") return value
-  if (Array.isArray(value)) {
-    return value.map((v) => canonicalizeNestedUrls(v, baseOrigin, rawUrls))
-  }
-  const out: Record<string, unknown> = {}
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof child === "string" && looksLikeUrlKey(key) && child !== "") {
-      const result = canonicalizeUrl(child, { schema: "strapi", baseOrigin })
-      if (result.canonical !== null) {
-        out[key] = result.canonical
-        rawUrls[result.canonical] = result.raw
-      } else {
-        out[key] = child
-      }
-    } else if (child === undefined || child === null) {
-      out[key] = null
-    } else {
-      out[key] = canonicalizeNestedUrls(child, baseOrigin, rawUrls)
-    }
-  }
-  return out
-}
-
-function looksLikeUrlKey(key: string): boolean {
-  // Match common URL-bearing field names. Conservative; expand if a
-  // captured fixture surfaces a URL field that doesn't match.
-  return /^(url|.*Url|.*URL|.*Link|.*Href)$/.test(key)
 }

--- a/packages/graphql/src/parity/path-pointer.test.ts
+++ b/packages/graphql/src/parity/path-pointer.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+
+import { comparePointer, encodePointer } from "./path-pointer"
+
+describe("encodePointer", () => {
+  it("encodes a simple path", () => {
+    expect(encodePointer(["blocks", 3, "items", 0, "url"])).toBe(
+      "/blocks/3/items/0/url",
+    )
+  })
+
+  it("returns empty string for the root pointer", () => {
+    expect(encodePointer([])).toBe("")
+  })
+
+  it("escapes ~ as ~0", () => {
+    expect(encodePointer(["foo~bar"])).toBe("/foo~0bar")
+  })
+
+  it("escapes / as ~1", () => {
+    expect(encodePointer(["a/b"])).toBe("/a~1b")
+  })
+
+  it("escapes ~ before /", () => {
+    // Per RFC6901: ~ must be encoded first as ~0, then / as ~1.
+    // A literal "~/" must round-trip through "~0~1".
+    expect(encodePointer(["~/"])).toBe("/~0~1")
+  })
+
+  it("emits numeric segments as decimal strings", () => {
+    expect(encodePointer(["a", 0, 10, 100])).toBe("/a/0/10/100")
+  })
+})
+
+describe("comparePointer", () => {
+  it("returns 0 for equal paths", () => {
+    expect(comparePointer("/a/b", "/a/b")).toBe(0)
+  })
+
+  it("sorts /blocks/2 before /blocks/10 (numeric-aware)", () => {
+    expect(comparePointer("/blocks/2", "/blocks/10")).toBeLessThan(0)
+  })
+
+  it("sorts non-numeric segments lexicographically", () => {
+    expect(comparePointer("/blocks/abc", "/blocks/abd")).toBeLessThan(0)
+  })
+
+  it("falls back to string compare when only one side is numeric", () => {
+    // ASCII: "2" (0x32) < "a" (0x61). Digit segments compared as strings
+    // sort before non-digit segments — segment-position parity matters,
+    // not numeric semantics on a mixed pair.
+    const cmp = comparePointer("/blocks/abc", "/blocks/2")
+    expect(cmp).toBeGreaterThan(0)
+  })
+
+  it("sorts shorter prefixes before longer paths sharing the prefix", () => {
+    expect(comparePointer("/blocks", "/blocks/0")).toBeLessThan(0)
+  })
+
+  it("treats the root pointer as smallest", () => {
+    expect(comparePointer("", "/anything")).toBeLessThan(0)
+  })
+
+  it("orders a numeric report deterministically", () => {
+    // Production-shaped scenario — verifies the contract used by the differ.
+    const paths = [
+      "/blocks/10",
+      "/blocks/2",
+      "/blocks/3",
+      "/description",
+      "/blocks/0/items/2",
+    ]
+    const sorted = [...paths].sort(comparePointer)
+    expect(sorted).toEqual([
+      "/blocks/0/items/2",
+      "/blocks/2",
+      "/blocks/3",
+      "/blocks/10",
+      "/description",
+    ])
+  })
+
+  it("rejects -0 as a numeric segment (treats as string)", () => {
+    // The sort fallback for non-canonical numeric forms must be string compare.
+    // "-0" doesn't pass /^[0-9]+$/, so it falls back to string ordering.
+    expect(comparePointer("/-0", "/0")).toBeLessThan(0)
+  })
+})

--- a/packages/graphql/src/parity/path-pointer.ts
+++ b/packages/graphql/src/parity/path-pointer.ts
@@ -1,0 +1,72 @@
+/**
+ * RFC6901 JSON Pointer encoding + numeric-aware sort comparator.
+ *
+ * The parity differ uses JSON Pointer paths to identify diff entries
+ * (e.g., `/blocks/3/items/0/url`). Numeric-aware sort ensures
+ * `/blocks/2` precedes `/blocks/10` rather than the lexicographic
+ * inverse — review ergonomics for diff reports depend on this.
+ *
+ * https://www.rfc-editor.org/rfc/rfc6901
+ */
+
+/**
+ * Encode an array of segments as an RFC6901 JSON Pointer.
+ *
+ * Each segment's `~` becomes `~0` and `/` becomes `~1` per the spec.
+ * Numeric segments are emitted as their decimal string form; the
+ * reader recovers them by parseInt-ing during sort.
+ */
+export function encodePointer(
+  segments: ReadonlyArray<string | number>,
+): string {
+  if (segments.length === 0) return ""
+  const parts = segments.map((s) => {
+    if (typeof s === "number") return String(s)
+    return s.replace(/~/g, "~0").replace(/\//g, "~1")
+  })
+  return "/" + parts.join("/")
+}
+
+/**
+ * Compare two JSON Pointer paths with numeric-aware segment ordering.
+ *
+ * - Splits both paths on `/` and walks segments in lockstep.
+ * - When BOTH segments at the same position parse cleanly as
+ *   non-negative integers, compares numerically.
+ * - Otherwise falls back to byte-wise string comparison.
+ * - Shorter paths sort before longer paths sharing the same prefix.
+ *
+ * Empty string ("") is the root pointer per RFC6901 and sorts first.
+ */
+export function comparePointer(a: string, b: string): number {
+  if (a === b) return 0
+  const aSegs = a === "" ? [] : a.slice(1).split("/")
+  const bSegs = b === "" ? [] : b.slice(1).split("/")
+  const len = Math.min(aSegs.length, bSegs.length)
+  for (let i = 0; i < len; i++) {
+    const aSeg = aSegs[i]!
+    const bSeg = bSegs[i]!
+    const cmp = compareSegment(aSeg, bSeg)
+    if (cmp !== 0) return cmp
+  }
+  return aSegs.length - bSegs.length
+}
+
+function compareSegment(a: string, b: string): number {
+  const aNum = parseNonNegativeInt(a)
+  const bNum = parseNonNegativeInt(b)
+  if (aNum !== null && bNum !== null) {
+    return aNum - bNum
+  }
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+function parseNonNegativeInt(s: string): number | null {
+  if (s === "") return null
+  if (!/^[0-9]+$/.test(s)) return null
+  const n = Number(s)
+  if (!Number.isSafeInteger(n) || n < 0) return null
+  return n
+}

--- a/packages/graphql/src/parity/shared-shape.ts
+++ b/packages/graphql/src/parity/shared-shape.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared normalized route shape — both Strapi and admin normalizers
+ * emit this exact type. The differ (`compare.ts`) consumes two
+ * `NormalizedExperienceRoute` values and produces a `DiffReport`.
+ *
+ * Absent-field contract (load-bearing — see plan Key Decisions):
+ * every optional field on this type carries `null` when absent on
+ * the source side. Both `undefined` and missing keys map to `null`
+ * in the normalizers; the differ treats `null` and missing-key as
+ * equivalent post-normalization. Don't introduce optional `?:` fields
+ * here without explicitly mirroring them in both normalizers AND the
+ * differ's structural-class equivalence logic.
+ */
+
+import type { AdminKind, AdminOnlyKind } from "./discriminator-map"
+
+/**
+ * The full set of `kind` values a normalized block can carry — the 16
+ * shared `AdminKind`s plus admin-only kinds plus synthetic markers
+ * the Strapi normalizer emits while flattening container shapes
+ * (`containerSlot`).
+ */
+export type NormalizedBlockKind = AdminKind | AdminOnlyKind | "containerSlot"
+
+/**
+ * Synthetic marker emitted by the Strapi normalizer when flattening
+ * `container.slots[].content[]` into admin's flat `container.content[]`
+ * shape. Preserves slot metadata (gridSpan, spans) at slot boundaries
+ * so the differ can compare slot-bounded layouts faithfully.
+ */
+export type ContainerSlotMarker = {
+  readonly kind: "containerSlot"
+  readonly id: string
+  readonly gridSpan: number | null
+  readonly spans: ReadonlyArray<number> | null
+}
+
+/**
+ * A normalized block. The `data` field carries kind-specific payload
+ * as a structurally-comparable JSON value. Concrete shapes per kind
+ * are validated by the per-normalizer pipeline; the differ inspects
+ * `data` field-by-field via JSON Pointer paths.
+ */
+export type NormalizedBlock =
+  | ContainerSlotMarker
+  | {
+      readonly kind: Exclude<NormalizedBlockKind, "containerSlot">
+      readonly id: string
+      readonly data: Readonly<Record<string, unknown>>
+    }
+
+/**
+ * Open-graph image. Both normalizers emit this shape; admin fills
+ * `width`, `height`, and `alt` with `null` since admin currently
+ * exposes only `ogImageUrl: String` on `ExperienceLocale`.
+ */
+export type NormalizedOgImage = {
+  readonly url: string
+  readonly width: number | null
+  readonly height: number | null
+  readonly alt: string | null
+}
+
+/**
+ * Per-source metadata carried alongside the normalized payload. Used by
+ * the differ for class downgrades and audit trails.
+ */
+export type NormalizedMeta = {
+  readonly source: "strapi" | "admin"
+  /**
+   * `true` when there's evidence the source returned fewer rows than
+   * exist (Strapi pagination cap, live-mode `pagination.total >
+   * returned.length`). The differ reclassifies missing-tail entries
+   * out of the structural class into a `potentiallyTruncated` channel
+   * for the affected side.
+   *
+   * Length-based heuristics (e.g., "blocks array is exactly 10") are
+   * NOT a trigger — they conflate cap-truncated responses with
+   * legitimate cap-sized collections. See plan Key Decisions.
+   */
+  readonly potentiallyTruncated: boolean
+  /**
+   * Map of canonical URL → raw URL captured at canonicalization time.
+   * The differ consults this when emitting URL-canonicalization
+   * residual entries so reviewers see what each side actually returned.
+   */
+  readonly rawUrls: Readonly<Record<string, string>>
+}
+
+/**
+ * The shape both normalizers emit and the differ compares.
+ *
+ * Field-level JSDoc on every optional field documents the
+ * null-on-absence contract — readers should not assume `?:` semantics.
+ */
+export type NormalizedExperienceRoute = {
+  /** Stable identifier within the source schema. NOT compared cross-side. */
+  readonly id: string
+  /** Slug used to retrieve. Must match across sides for the same logical route. */
+  readonly slug: string
+  /**
+   * Resolved locale — the locale the source actually returned. Compared
+   * against URL locale and against the other side's locale for
+   * semantic-class equality.
+   */
+  readonly locale: string
+  /** Title of the experience locale. */
+  readonly title: string
+  /** Description; `null` when absent on the source. */
+  readonly description: string | null
+  /** OG image; `null` when absent on the source. */
+  readonly ogImage: NormalizedOgImage | null
+  /** Ordered list of normalized blocks. Empty array when no blocks present. */
+  readonly blocks: ReadonlyArray<NormalizedBlock>
+  /** Per-source metadata; not compared cross-side. */
+  readonly meta: NormalizedMeta
+}

--- a/packages/graphql/vitest.config.ts
+++ b/packages/graphql/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/video-player:
     dependencies:
@@ -21469,7 +21472,7 @@ snapshots:
       '@strapi/design-system': 2.2.0(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.4.1(react-dom@18.3.1(react@18.3.1))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.4.1(react-dom@18.3.1(react@18.3.1))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.4.1(react-dom@18.3.1(react@18.3.1))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.42.1
-      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.42.1
       '@strapi/utils': 5.42.1
       '@testing-library/dom': 10.4.1
@@ -21668,7 +21671,7 @@ snapshots:
       '@strapi/database': 5.42.1(@types/node@20.19.39)(pg@8.18.0)
       '@strapi/design-system': 2.2.0(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.4.1(react-dom@18.3.1(react@18.3.1))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.4.1(react-dom@18.3.1(react@18.3.1))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.4.1(react-dom@18.3.1(react@18.3.1))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/utils': 5.42.1
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -21769,7 +21772,7 @@ snapshots:
       '@strapi/generators': 5.42.1(@types/node@20.19.39)
       '@strapi/logger': 5.42.1
       '@strapi/permissions': 5.42.1
-      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.42.1
       '@strapi/utils': 5.42.1
       '@vercel/stega': 0.1.2
@@ -22226,7 +22229,7 @@ snapshots:
       '@strapi/openapi': 5.42.1
       '@strapi/permissions': 5.42.1
       '@strapi/review-workflows': 5.42.1(5dlb757ogygcs6suezllo5zbly)
-      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.4.4)
+      '@strapi/types': 5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.42.1
       '@strapi/upload': 5.42.1(d6qwfqaisuffgxl3f53nweodcm)
       '@strapi/utils': 5.42.1
@@ -22330,36 +22333,6 @@ snapshots:
       - webpack-dev-server
       - webpack-plugin-serve
       - yaml
-
-  '@strapi/types@5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.4.4)':
-    dependencies:
-      '@casl/ability': 6.7.5
-      '@koa/cors': 5.0.0
-      '@koa/router': 12.0.2
-      '@strapi/database': 5.42.1(@types/node@20.19.39)(pg@8.18.0)
-      '@strapi/logger': 5.42.1
-      '@strapi/permissions': 5.42.1
-      '@strapi/utils': 5.42.1
-      commander: 8.3.0
-      json-logic-js: 2.0.5
-      koa: 2.16.4
-      koa-body: 6.0.1
-      node-schedule: 2.1.1
-      typedoc: 0.25.10(typescript@5.4.4)
-      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
-      zod: 3.25.67
-    transitivePeerDependencies:
-      - '@types/node'
-      - better-sqlite3
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-      - typescript
 
   '@strapi/types@5.42.1(@types/node@20.19.39)(pg@8.18.0)(typescript@5.9.3)':
     dependencies:
@@ -26121,9 +26094,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
@@ -26138,8 +26111,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -26165,7 +26138,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -26176,7 +26149,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26187,7 +26160,7 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26200,7 +26173,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -33965,14 +33938,6 @@ snapshots:
     dependencies:
       handlebars: 4.7.9
       typedoc: 0.25.10(typescript@5.9.3)
-
-  typedoc@0.25.10(typescript@5.4.4):
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.7
-      shiki: 0.14.7
-      typescript: 5.4.4
 
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,9 @@ importers:
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/video-player:
     dependencies:
@@ -26094,9 +26097,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
@@ -26111,8 +26114,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -26138,7 +26141,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -26149,7 +26152,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26160,7 +26163,7 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26173,7 +26176,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

U5's canary `dual-read` mode would have nothing actionable to compare against — admin's parallel fetch would be a no-op signal. This PR ships a fixture-driven response parity harness in `packages/graphql/src/parity/` that normalizes Strapi and admin GraphQL responses to one shared route shape and emits a deterministic, structured diff classified across 5 channels: structural, value, order, semantic, and potentiallyTruncated. The harness becomes the gating signal U5 needs to advance routes through `dual-read → admin-with-fallback → admin` per the plan's R18a thresholds.

This is U4 of the consumer-migration roadmap (`feat-104`). Plan: [`docs/plans/2026-05-07-002-feat-consumer-migration-parity-harness-unit-4-plan.md`](docs/plans/2026-05-07-002-feat-consumer-migration-parity-harness-unit-4-plan.md). Origin: [`docs/brainstorms/2026-05-05-consumer-migration-implementer-brief-requirements.md`](docs/brainstorms/2026-05-05-consumer-migration-implementer-brief-requirements.md).

## Architecture

```mermaid
flowchart TB
    SR[Strapi response] --> SN[normalize-strapi]
    AR[Admin response] --> AN[normalize-admin]
    CU[canonicalize-url] -.shared.-> SN
    CU -.shared.-> AN
    DM[discriminator-map] -.shared.-> SN
    BS[BlocksSchema from @forge/admin] -.parse.-> AN
    SN --> NR1[NormalizedExperienceRoute]
    AN --> NR2[NormalizedExperienceRoute]
    NR1 --> D[compare 5-class differ]
    NR2 --> D
    AL[allow-list with rationales] -.filter.-> D
    D --> R[DiffReport]
```

## Implementation units

| Unit | Surface | Notes |
|---|---|---|
| U1 | Vitest infra + parity scaffolding | First runtime test surface in `packages/graphql/`; deletion checklist baked in from day 1 |
| U2 | Shared shape, canonicalizers, discriminator map, path-pointer | RFC6901 JSON Pointer encode + numeric-aware sort |
| U3 | Strapi normalizer | Container flatten (`slots[].content[]` → flat `content[]` with synthetic `containerSlot` markers); resolved-locale equality |
| U4 | Admin normalizer + BlocksSchema validation | First cross-workspace TS coupling — admin's `BlocksSchema` exposed via new `apps/admin/package.json` `exports` map |
| U5 | Four-class differ + allow-list + type-isolation proof | RFC6901 paths, numeric-aware sort, deterministic JSON output |
| U6 | Two-tier fixtures + live mode + capture script | Hand-rolled per-class fixtures + placeholder for canary capture |

## Key decisions

- **Pure-data normalizers + custom JSON-serializable differ.** No deep-diff library — the four R12a classes need bespoke logic anyway (semantic class compares resolved-locale equality + URL canonicalization residuals, not just deep-equal). The differ produces directly-PR-quotable JSON with no post-processing.
- **Admin's `kind` enum is the canonical discriminator.** Strapi `__typename` is mapped to admin `kind` in the Strapi normalizer before diffing. Reduces churn at harness retirement (admin is the migration target).
- **Resolved-locale equality, not selector-output identity.** Admin's `experienceBySlug` returns already-resolved `ExperienceLocale`; Strapi serves the requested locale. Both sides' `locale` fields are compared directly to the URL locale. The original "selector-output" framing was incompatible with the actual return shapes — caught by ce-doc-review.
- **Strapi container flatten + non-content layout fields preserved.** `slots[].content[]` flattens to admin's flat shape with synthetic `containerSlot` markers. Container layout fields (gap, padding, background) surface via `stripBlockMeta` so the data shape matches admin's container payload.
- **`apps/admin/package.json` gains its first-ever `exports` map** — exposing only `./domain/blocks` (pure-Zod schema, no server runtime). Verified no cycle: admin doesn't import from `@forge/graphql`.
- **Throwaway scaffolding with a deletion contract.** Top-of-file checklist in `parity/index.ts` enumerates every artifact (vitest devDep, zod devDep, parity files, capture script, `./parity` exports entry, admin's `./domain/blocks` exports entry, env vars). Retires when mobile + TV both report parity-clean windows in admin mode.

## Verification

| Surface | Result |
|---|---|
| `@forge/graphql`: lint + typecheck + tests | 113/113 across 8 files |
| `@forge/admin`: typecheck + tests + build | 1651/1652 (1 todo) |
| `@forge/web` / `mobile` / `tv`: typecheck | Clean |
| Capture script smoke (tsx) | Exits 2 cleanly with deferred message |
| Auth-host rejection (PR #909) | Bare + `:8443` port-bypass + mixed-case all reject |

`ce-doc-review` and `ce-code-review` (Tier 2 autofix) both ran. 5 safe_auto fixes applied including 2 P0 fixes: `validateHost` port-bypass (`auth.jesusfilm.org:8443` was bypassable) and `normalizeSection` spread overwrite (raw `content[]` was discarding normalized inner blocks). Run artifact: `/tmp/compound-engineering/ce-code-review/20260508-114141-91dd7289/`.

## Known residuals

13 actionable findings from code review remain unfixed (gated_auto + manual). Highest-impact:

- Unknown `__typename` routes through `kind: "section"` shim — masks drift on new Strapi components
- `meta.rawUrls` overwrites on canonical-collision — loses one of two distinct raws
- Admin coverage gap (only 3 of 17 admin kinds tested via `normalizeAdmin`)
- Admin container/section recursion untested
- `runLiveComparison` end-to-end untested

These are tracked in the run artifact and intentionally deferred — none are blocking for U5's canary readiness, and most surface only when real live data flows through the harness.

## Post-deploy monitoring

No additional operational monitoring required for this PR. The harness is dev-only at this stage: no env vars deployed (`FORGE_PARITY_LIVE` ships with U5's canary PR), no CI parity job wired (lives in U7), no consumer route reads from the harness (U5 wires the canary). When U5's canary lands, monitoring focuses on the harness's *output* (parity diff rate, missing-content rate, fallback-save rate per route), not the harness itself.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
