### PR TITLE
feat(web): port Bible Quotes carousel + Related Questions accordion from core/apps/watch

### DIFF
--- a/apps/web/src/app/[slug]/[locale]/page.tsx
+++ b/apps/web/src/app/[slug]/[locale]/page.tsx
@@ -50,6 +50,7 @@ export default async function SlugLocalePage({ params }: PageProps) {
         variant={watchVideo.selectedVariant}
         video={watchVideo.video}
         languageSlug={watchVideo.selectedVariant.language?.slug ?? rawLocale}
+        locale={locale}
       />
     )
   }

--- a/apps/web/src/components/watch/BibleQuotesSection.tsx
+++ b/apps/web/src/components/watch/BibleQuotesSection.tsx
@@ -1,15 +1,22 @@
 "use client"
 
-// Image-less cards: the bibleCitations projection carries reference fields
-// only (no imageUrl / quote text). The Experience-page BibleQuotesCarousel
-// has richer authored content; this surface mirrors its visual vocabulary
-// without forcing the existing component to consume a degraded shape.
+// Visual + verse rendering parity with the legacy `core/apps/watch`
+// BibleCitationCard:
+//   - hard-coded Unsplash photo cycled by index as the card background
+//   - locale-aware verse text fetched client-side from the wldeh/bible-api
+//     mirror on jsdelivr (single-verse JSON, keyed by verseStart)
+//   - "Read more..." link to BibleGateway, shown when verseEnd is present
+//
+// The bibleCitations projection still only carries reference fields, so
+// verse text is fetched per card on mount rather than received from Strapi.
 
+import Image from "next/image"
 import { ExternalLink } from "lucide-react"
+import { useEffect, useState } from "react"
 
 import type { WatchBibleQuotesBlock } from "@/lib/content"
 import { formatCitation } from "@/lib/citation-format"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
 import {
   Carousel,
   CarouselContent,
@@ -23,13 +30,97 @@ import {
   CAROUSEL_END_SPACER,
 } from "@/lib/content-width"
 
+type WatchBibleCitation = WatchBibleQuotesBlock["bibleCitations"][number]
+
 type BibleQuotesSectionProps = {
   bibleCitations: WatchBibleQuotesBlock["bibleCitations"]
   onShareClick: () => void
+  /**
+   * BCP-47-ish locale used to pick the Bible translation for the inline
+   * verse fetch. Defaults to English. The renderer does not currently
+   * thread locale here; pass it through when wired.
+   */
+  locale?: string
 }
 
 const JOIN_BIBLE_STUDY_URL =
   "https://join.bsfinternational.org/?utm_source=jesusfilm-watch"
+
+// Promo-card hero image. Same fixed Unsplash photo used by
+// `FreeResourceCard` in core/apps/watch — the final slide is intentionally
+// constant, not cycled like the citation cards.
+const PROMO_IMAGE_URL =
+  "https://images.unsplash.com/photo-1650658720644-e1588bd66de3?w=900&auto=format&fit=crop&q=60"
+
+// Unsplash URLs ported verbatim from core/apps/watch BibleCitations.tsx —
+// these are decorative wallpapers cycled by index, not curated per verse.
+const BIBLE_IMAGES = [
+  "https://images.unsplash.com/photo-1480869799327-03916a613b29?q=80&w=1632&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/16/unsplash_526360a842e20_1.JPG?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1497333558196-daaff02b56d0?q=80&w=1738&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1555892727-55b51e5fceae?q=80&w=1674&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1631125915973-e0d155a14e4e?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1659260145900-1ac1afc45dcf?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1535979863199-3c77338429a0?q=80&w=1660&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+] as const
+
+// Locale → translation pair, mirroring core/apps/watch's
+// LOCALE_TO_BIBLE_VERSION_MAP. `bibleApi` is the wldeh/bible-api directory
+// (single-verse JSON), `bibleGateway` is the URL `?version=` for the
+// "Read more..." link.
+type BibleVersion = { bibleApi: string; bibleGateway: string }
+
+// Declared as an independent literal first so the default does not depend on
+// the map's key being present at lookup time. `satisfies` preserves the
+// narrow key inference per CLAUDE.md TypeScript rules.
+const DEFAULT_BIBLE_VERSION = {
+  bibleApi: "en-asv",
+  bibleGateway: "NIV",
+} as const satisfies BibleVersion
+
+const LOCALE_TO_BIBLE_VERSION_MAP = {
+  en: DEFAULT_BIBLE_VERSION,
+  es: { bibleApi: "es-rvr1960", bibleGateway: "NVI" },
+  fr: { bibleApi: "fr-s21", bibleGateway: "BDS" },
+  id: { bibleApi: "id-tlab", bibleGateway: "TB" },
+  ja: { bibleApi: "ja-jc", bibleGateway: "SHINK2017" },
+  ko: { bibleApi: "ko-askv", bibleGateway: "NKRV" },
+  ru: { bibleApi: "ru-synod", bibleGateway: "SYNOD" },
+  th: { bibleApi: "th-tkjv", bibleGateway: "TNCV" },
+  tr: { bibleApi: "tr-tcl02", bibleGateway: "TC-2009" },
+  zh: { bibleApi: "zh-cunp-s", bibleGateway: "CUVMPT" },
+  "zh-Hans-CN": { bibleApi: "zh-cn-cmn-s-cuv", bibleGateway: "CUVS" },
+} as const satisfies Record<string, BibleVersion>
+
+function getBibleVersionForLocale(locale: string): BibleVersion {
+  return (
+    (LOCALE_TO_BIBLE_VERSION_MAP as Record<string, BibleVersion>)[locale] ??
+    DEFAULT_BIBLE_VERSION
+  )
+}
+
+// Strip wldeh/bible-api's inline footnotes (";N:N…" and ",N:N…") and
+// collapse line breaks. Port of formatScripture from core/apps/watch.
+function formatScripture(verse: string): string {
+  return verse
+    .replace(/;\d[\s\S]*/, "")
+    .replace(/,\d:\d[\s\S]*/, "")
+    .replace(/\n/g, " ")
+    .trim()
+}
+
+// Sanitize CMS-supplied book name into a jsdelivr-API-safe path segment.
+// `bookName.toLowerCase()` alone preserves whitespace ("1 Corinthians" →
+// "1 corinthians"), which the URL-encoder converts to "1%20corinthians" —
+// a path the wldeh/bible-api repo does not contain (returns 403). Strip
+// whitespace, validate against an allowlist, and reject anything that
+// could escape the intended path (`..`, query separators, etc.).
+const BIBLE_BOOK_SLUG_PATTERN = /^[a-z0-9-]+$/
+
+function bookSlugForApi(rawBookName: string): string | null {
+  const slug = rawBookName.toLowerCase().replace(/\s+/g, "")
+  return BIBLE_BOOK_SLUG_PATTERN.test(slug) ? slug : null
+}
 
 // Disable click-and-drag when the carousel has at most one snap point —
 // dragging a single visible card is a no-op gesture that visibly tugs and
@@ -57,6 +148,7 @@ const CAROUSEL_OPTS = {
 export function BibleQuotesSection({
   bibleCitations,
   onShareClick,
+  locale = "en",
 }: BibleQuotesSectionProps) {
   // The carousel always renders, even when the video has no Bible citations —
   // the trailing "Join Our Bible Study" promo card is the always-on CTA, and
@@ -95,43 +187,64 @@ export function BibleQuotesSection({
             data-testid="watch-bible-quotes-list"
             className={`-ml-4 ${CAROUSEL_CONTENT_PADDING}`}
           >
-            {bibleCitations.map((citation) => (
+            {bibleCitations.map((citation, i) => (
               <CarouselItem
                 key={citation.documentId}
                 data-testid="watch-bible-quotes-item"
                 className="basis-[85vw] pl-4 sm:basis-[50%] lg:basis-1/4"
               >
-                <BibleQuoteCard>
-                  <span
-                    data-testid="watch-bible-quotes-reference"
-                    className="block text-[10px] font-semibold tracking-[0.15em] text-amber-200/60 uppercase"
-                  >
-                    {formatCitation(citation)}
-                  </span>
-                </BibleQuoteCard>
+                <BibleCitationCard
+                  citation={citation}
+                  imageUrl={BIBLE_IMAGES[i % BIBLE_IMAGES.length]!}
+                  locale={locale}
+                />
               </CarouselItem>
             ))}
             <CarouselItem
               data-testid="watch-bible-quotes-promo"
               className="basis-[85vw] pl-4 sm:basis-[50%] lg:basis-1/4"
             >
-              <BibleQuoteCard bgColor="#3a2510">
-                <span className="mb-1 block text-xs font-semibold tracking-[0.15em] text-white/70 uppercase">
-                  Free Resources
-                </span>
-                <h3 className="mt-1 mb-4 text-xl font-bold leading-snug text-balance text-white/90">
-                  Join Our Bible Study
-                </h3>
-                <a
-                  href={JOIN_BIBLE_STUDY_URL}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  data-testid="watch-bible-quotes-promo-cta"
-                  className={`${buttonVariants({ variant: "pill" })} self-start`}
-                >
-                  Join our Bible study
-                </a>
-              </BibleQuoteCard>
+              <div
+                className="relative flex aspect-square w-full flex-col justify-end overflow-hidden rounded-lg border border-white/10 shadow-2xl shadow-stone-950/70"
+                style={{ backgroundColor: "rgba(0, 0, 0, 0.1)" }}
+              >
+                <Image
+                  fill
+                  src={PROMO_IMAGE_URL}
+                  alt=""
+                  aria-hidden="true"
+                  // When there are no editorial citations the promo card is
+                  // the section's only content and would otherwise lazy-load
+                  // into view with a visible pop-in. Mark it eager only on
+                  // that path so the typical N-citations case stays lazy.
+                  priority={bibleCitations.length === 0}
+                  className="absolute top-0 overflow-hidden rounded-lg object-cover"
+                  sizes="(max-width: 640px) 85vw, (max-width: 1024px) 50vw, 25vw"
+                />
+                <div className="z-1 p-6 pt-0">
+                  <span className="mb-1 block text-xs font-semibold tracking-[0.15em] text-white/80 uppercase">
+                    Free Resources
+                  </span>
+                  <h3 className="mt-1 mb-4 text-xl font-bold leading-snug text-balance text-white">
+                    Want to grow deep in your understanding of the Bible?
+                  </h3>
+                  <Button
+                    variant="pill"
+                    nativeButton={false}
+                    data-testid="watch-bible-quotes-promo-cta"
+                    className="self-start"
+                    render={
+                      <a
+                        href={JOIN_BIBLE_STUDY_URL}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      />
+                    }
+                  >
+                    Join our Bible study
+                  </Button>
+                </div>
+              </div>
             </CarouselItem>
             <CarouselItem
               className="basis-auto pl-0"
@@ -159,19 +272,165 @@ export function BibleQuotesSection({
   )
 }
 
-function BibleQuoteCard({
-  bgColor = "#1A1815",
-  children,
+// Wall-clock budget for a single jsdelivr verse fetch. Bounds the request
+// independently of `AbortController` (which only fires on unmount), so a
+// hanging CDN connection cannot hold a per-origin slot indefinitely.
+const VERSE_FETCH_TIMEOUT_MS = 8000
+
+// jsdelivr returns `{ verse: string, text: string }` for valid verses and a
+// 403 (NOT 200 with empty body) for missing ones. The historical "200 with
+// empty body" guard remains as a belt-and-braces backstop in case a future
+// translation drops content into a partial shape.
+function isFetchedScripture(value: unknown): value is { text: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "text" in value &&
+    typeof (value as { text: unknown }).text === "string" &&
+    (value as { text: string }).text.length > 0
+  )
+}
+
+function BibleCitationCard({
+  citation,
+  imageUrl,
+  locale,
 }: {
-  bgColor?: string | null
-  children: React.ReactNode
+  citation: WatchBibleCitation
+  imageUrl: string
+  locale: string
 }) {
+  const [scripture, setScripture] = useState<{ text: string } | null>(null)
+  // Destructured to primitive strings so the effect's dependency list
+  // captures stable values, not the per-render object identity returned by
+  // `getBibleVersionForLocale`.
+  const { bibleApi, bibleGateway } = getBibleVersionForLocale(locale)
+  const bookSlug =
+    citation.bibleBook?.name != null
+      ? bookSlugForApi(citation.bibleBook.name)
+      : null
+
+  // Reset scripture when the fetch key (book+chapter+verse+translation)
+  // changes — locale switch, variant switch, or citation reshape. Done in
+  // render via React's "adjusting state in render" pattern instead of a
+  // useEffect so the stale verse text never paints alongside the new
+  // citation reference for even one frame.
+  const fetchKey = `${bibleApi}|${bookSlug ?? ""}|${citation.chapterStart ?? ""}|${citation.verseStart ?? ""}`
+  const [prevFetchKey, setPrevFetchKey] = useState(fetchKey)
+  if (prevFetchKey !== fetchKey) {
+    setPrevFetchKey(fetchKey)
+    setScripture(null)
+  }
+
+  useEffect(() => {
+    if (
+      bookSlug == null ||
+      citation.chapterStart == null ||
+      citation.verseStart == null
+    ) {
+      // Missing required field(s) — no fetch possible. Initial state is
+      // already null, so nothing to set.
+      return
+    }
+    const controller = new AbortController()
+    // Wall-clock timeout via setTimeout + controller.abort rather than
+    // AbortSignal.any — the latter trips on jsdom/undici realm checks in
+    // vitest tests. Single AbortController serves both the unmount
+    // cleanup and the timeout deadline.
+    const timeoutId = setTimeout(() => {
+      controller.abort()
+    }, VERSE_FETCH_TIMEOUT_MS)
+    // Closure flag — `AbortController` cancels the in-flight network leg
+    // but not an awaited `res.json()` body parse. Without this guard, a
+    // body that finishes parsing after the component unmounts (or after
+    // the deps change) would write stale state via the trailing
+    // `setScripture` call.
+    let cancelled = false
+    void (async () => {
+      try {
+        const url = `https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/${bibleApi}/books/${bookSlug}/chapters/${citation.chapterStart}/verses/${citation.verseStart}.json`
+        const res = await fetch(url, {
+          signal: controller.signal,
+          cache: "force-cache",
+        })
+        if (cancelled || !res.ok) return
+        const data: unknown = await res.json()
+        if (cancelled) return
+        if (isFetchedScripture(data)) {
+          setScripture({ text: data.text })
+        }
+      } catch (error) {
+        // Distinguish intentional aborts (unmount / locale change / timeout)
+        // from real failures. AbortError lands here but does NOT mean the
+        // verse is unavailable — suppressing the null-write avoids the
+        // flicker where the previous verse disappears before the new one
+        // arrives. Other errors (network, JSON parse) are logged so CDN
+        // problems are visible in devtools rather than silently degrading.
+        if (cancelled) return
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return
+        }
+        console.error(
+          "[BibleCitationCard] verse fetch failed",
+          {
+            url: `${bibleApi}/${bookSlug}/${citation.chapterStart}:${citation.verseStart}`,
+          },
+          error,
+        )
+      } finally {
+        clearTimeout(timeoutId)
+      }
+    })()
+    return () => {
+      cancelled = true
+      controller.abort()
+      clearTimeout(timeoutId)
+    }
+  }, [bibleApi, bookSlug, citation.chapterStart, citation.verseStart])
+
+  const referenceLabel = formatCitation(citation)
+  const bibleGatewayUrl = `https://www.biblegateway.com/passage/?search=${encodeURIComponent(referenceLabel)}&version=${bibleGateway}`
+
   return (
     <div
-      className="relative flex aspect-square w-full flex-col justify-end overflow-hidden rounded-lg shadow-2xl shadow-stone-950/70"
-      style={{ backgroundColor: bgColor ?? "#1A1815" }}
+      className="relative flex aspect-square w-full flex-col justify-end overflow-hidden rounded-lg border border-white/10 shadow-2xl shadow-stone-950/70"
+      style={{ backgroundColor: "#1A1815" }}
     >
-      <div className="z-1 p-6 pt-0">{children}</div>
+      <Image
+        fill
+        src={imageUrl}
+        alt=""
+        aria-hidden="true"
+        className="absolute top-0 overflow-hidden rounded-lg object-cover [mask-image:linear-gradient(to_bottom,rgba(0,0,0,1)_20%,transparent_100%)] [mask-size:cover]"
+        sizes="(max-width: 640px) 85vw, (max-width: 1024px) 50vw, 25vw"
+      />
+      <div className="z-1 p-6 pt-0">
+        <span
+          data-testid="watch-bible-quotes-reference"
+          className="relative block text-[10px] font-semibold tracking-[0.15em] text-amber-200/60 uppercase"
+        >
+          {referenceLabel}
+        </span>
+        {scripture != null && (
+          <p
+            data-testid="watch-bible-quotes-verse"
+            className="relative mt-3 text-sm text-white/90"
+          >
+            {formatScripture(scripture.text)}
+          </p>
+        )}
+        {citation.verseEnd != null && (
+          <a
+            href={bibleGatewayUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="watch-bible-quotes-read-more"
+            className="relative mt-3 block text-sm text-white/80 underline transition-colors duration-200 hover:text-white"
+          >
+            Read more...
+          </a>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -40,6 +40,12 @@ type WatchPageClientProps = {
    * links round-trip cleanly.
    */
   languageSlug?: string
+  /**
+   * Validated ISO locale ("en" | "es" | ...) from the URL `[locale]` segment.
+   * Threaded into `BibleQuotesSection` so the wldeh/bible-api fetch and
+   * BibleGateway "Read more..." link pick the right translation.
+   */
+  locale?: string
 }
 
 export function WatchPageClient({
@@ -47,6 +53,7 @@ export function WatchPageClient({
   variant,
   video,
   languageSlug,
+  locale,
 }: WatchPageClientProps) {
   // Lifted so LanguagePickerModal can read `currentTime` for the `?t=` clamp
   // on language switches.
@@ -125,6 +132,7 @@ export function WatchPageClient({
         blocks={mergedBlocks}
         modalCallbacks={modalCallbacks}
         onPlayerReady={handlePlayerReady}
+        locale={locale}
       />
 
       <DownloadModal

--- a/apps/web/src/components/watch/WatchSectionRenderer.tsx
+++ b/apps/web/src/components/watch/WatchSectionRenderer.tsx
@@ -31,10 +31,16 @@ export function WatchSectionRenderer({
   blocks,
   modalCallbacks,
   onPlayerReady,
+  locale,
 }: {
   blocks: MergedWatchBlock[]
   modalCallbacks?: WatchModalCallbacks
   onPlayerReady?: (player: MuxPlayerRef | null) => void
+  /**
+   * Validated ISO locale passed down to locale-aware children
+   * (currently: BibleQuotesSection's verse fetch + Read-more link).
+   */
+  locale?: string
 }) {
   // WatchBody owns both columns; the standalone StudyQuestions slot
   // renders as a hidden marker to avoid double-mounting.
@@ -64,6 +70,7 @@ export function WatchSectionRenderer({
           studyQuestionsBlock={studyQuestionsBlock}
           modalCallbacks={modalCallbacks}
           onPlayerReady={onPlayerReady}
+          locale={locale}
         />
       ))}
       {bodyBlocks.length > 0 ? (
@@ -93,6 +100,7 @@ export function WatchSectionRenderer({
                   studyQuestionsBlock={studyQuestionsBlock}
                   modalCallbacks={modalCallbacks}
                   onPlayerReady={onPlayerReady}
+                  locale={locale}
                 />
               ))}
             </div>
@@ -109,12 +117,14 @@ function WatchBlockEntry({
   studyQuestionsBlock,
   modalCallbacks,
   onPlayerReady,
+  locale,
 }: {
   block: MergedWatchBlock
   index: number
   studyQuestionsBlock: WatchStudyQuestionsBlock | null
   modalCallbacks?: WatchModalCallbacks
   onPlayerReady?: (player: MuxPlayerRef | null) => void
+  locale?: string
 }) {
   if (isWatchBlock(block)) {
     return (
@@ -123,6 +133,7 @@ function WatchBlockEntry({
         studyQuestionsBlock={studyQuestionsBlock}
         modalCallbacks={modalCallbacks}
         onPlayerReady={onPlayerReady}
+        locale={locale}
       />
     )
   }
@@ -134,11 +145,13 @@ function SyntheticBlock({
   studyQuestionsBlock,
   modalCallbacks,
   onPlayerReady,
+  locale,
 }: {
   block: WatchBlock
   studyQuestionsBlock: WatchStudyQuestionsBlock | null
   modalCallbacks?: WatchModalCallbacks
   onPlayerReady?: (player: MuxPlayerRef | null) => void
+  locale?: string
 }) {
   switch (block.kind) {
     case "HeroPlayer":
@@ -173,6 +186,7 @@ function SyntheticBlock({
         <BibleQuotesSection
           bibleCitations={block.bibleCitations}
           onShareClick={modalCallbacks?.openShare ?? noop}
+          locale={locale}
         />
       )
     case "Share":

--- a/apps/web/src/components/watch/WatchStudyQuestions.tsx
+++ b/apps/web/src/components/watch/WatchStudyQuestions.tsx
@@ -1,19 +1,32 @@
 "use client"
 
+// Each prompt row is expandable. The forge `Video.studyQuestions` projection
+// carries only the question text — no answer field — so the expanded body
+// renders the same "no-answer" fallback the legacy core/apps/watch app shows
+// for every question: a "Have a private discussion…" line plus two pill CTAs
+// pointing at the public Chat / Ask-a-Bible-question endpoints. The
+// placeholder row shown when there are no editorial prompts uses the same
+// fallback. Mirrors core/apps/watch's DiscussionQuestions/Question.tsx.
+
+import { useId, useState } from "react"
+import { Mail as MailIcon } from "lucide-react"
+
 import {
   MessageCircleIcon,
   QuestionIcon,
 } from "@/components/sections/RelatedQuestions"
 import { Button } from "@/components/ui/button"
 
-// Prompts are intentionally non-interactive: Video.studyQuestions has no
-// `answer` field, so any chevron/expand affordance would be a false promise.
-// The placeholder row shown when there are no editorial prompts is also
-// non-interactive -- it's an invite-to-engage copy string, not a question
-// with a hidden answer. Tests in WatchBody.test.tsx pin this contract for
-// both branches.
 const PLACEHOLDER_QUESTION =
   "If you could ask the creator of this video a question, what would it be?"
+
+const FALLBACK_BODY =
+  "Have a private discussion with someone who is ready to listen."
+
+const CHAT_WITH_PERSON_URL =
+  "https://chataboutjesus.com/chat/?utm_source=jesusfilm-watch"
+const ASK_BIBLE_QUESTION_URL =
+  "https://www.everystudent.com/contact.php?utm_source=jesusfilm-watch"
 
 export function WatchStudyQuestions({
   prompts,
@@ -23,6 +36,23 @@ export function WatchStudyQuestions({
   onAskYoursClick: () => void
 }) {
   const hasPrompts = prompts.length > 0
+  const items = hasPrompts ? prompts : [PLACEHOLDER_QUESTION]
+  const itemTestId = hasPrompts
+    ? "watch-study-questions-item"
+    : "watch-study-questions-placeholder"
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+  // Reset the open row whenever the prompts reference changes (e.g., when
+  // the user navigates to a sibling video and the same component instance
+  // receives a new prompts array). Using React's "adjusting state in
+  // render" pattern — explicitly supported and safer than a useEffect
+  // because it avoids the brief frame where a stale index points at the
+  // wrong question's panel.
+  const [prevPrompts, setPrevPrompts] = useState(prompts)
+  if (prevPrompts !== prompts) {
+    setPrevPrompts(prompts)
+    setOpenIndex(null)
+  }
+
   return (
     <section
       data-testid="watch-study-questions"
@@ -57,31 +87,107 @@ export function WatchStudyQuestions({
         data-testid="watch-study-questions-list"
         className="relative flex flex-col"
       >
-        {hasPrompts ? (
-          prompts.map((prompt, index) => (
-            <li
-              key={`${index}-${prompt}`}
-              data-testid="watch-study-questions-item"
-              className="border-b border-stone-500/20 py-3"
-            >
-              <p className="flex text-base leading-[1.6] font-semibold text-stone-100 sm:pr-4 md:text-lg md:text-balance">
-                <QuestionIcon />
-                {prompt}
-              </p>
-            </li>
-          ))
-        ) : (
-          <li
-            data-testid="watch-study-questions-placeholder"
-            className="border-b border-stone-500/20 py-3"
-          >
-            <p className="flex text-base leading-[1.6] font-semibold text-stone-100 sm:pr-4 md:text-lg md:text-balance">
-              <QuestionIcon />
-              {PLACEHOLDER_QUESTION}
-            </p>
-          </li>
-        )}
+        {items.map((prompt, index) => (
+          <StudyQuestionRow
+            key={`${index}-${prompt}`}
+            testId={itemTestId}
+            question={prompt}
+            isOpen={openIndex === index}
+            onToggle={() =>
+              setOpenIndex((prev) => (prev === index ? null : index))
+            }
+          />
+        ))}
       </ul>
     </section>
+  )
+}
+
+function StudyQuestionRow({
+  testId,
+  question,
+  isOpen,
+  onToggle,
+}: {
+  testId: string
+  question: string
+  isOpen: boolean
+  onToggle: () => void
+}) {
+  const panelId = `${useId()}-panel`
+  return (
+    <li data-testid={testId} className="border-b border-stone-500/20">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        data-testid={`${testId}-trigger`}
+        className="group flex w-full cursor-pointer items-start justify-between rounded-lg py-3 text-left transition-colors hover:bg-white/5"
+      >
+        <p className="flex text-base leading-[1.6] font-semibold text-stone-100 sm:pr-4 md:text-lg md:text-balance">
+          <QuestionIcon />
+          {question}
+        </p>
+        <span className="hidden shrink-0 p-2 text-stone-400 transition-colors group-hover:text-white sm:block">
+          <svg
+            className={`size-6 transform transition-transform ${isOpen ? "rotate-180" : ""}`}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            />
+          </svg>
+        </span>
+      </button>
+      {isOpen && (
+        <div
+          id={panelId}
+          data-testid={`${testId}-panel`}
+          className="pt-2 pr-2 pb-6 pl-8 sm:pl-10"
+        >
+          <p
+            data-testid={`${testId}-fallback-body`}
+            className="leading-relaxed text-stone-200/80"
+          >
+            {FALLBACK_BODY}
+          </p>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button
+              variant="pill"
+              nativeButton={false}
+              data-testid="watch-study-questions-chat-cta"
+              render={
+                <a
+                  href={CHAT_WITH_PERSON_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+            >
+              <MessageCircleIcon />
+              <span>Chat with a person</span>
+            </Button>
+            <Button
+              variant="pill"
+              nativeButton={false}
+              data-testid="watch-study-questions-ask-bible-cta"
+              render={
+                <a
+                  href={ASK_BIBLE_QUESTION_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+            >
+              <MailIcon className="size-4" aria-hidden="true" />
+              <span>Ask a Bible question</span>
+            </Button>
+          </div>
+        </div>
+      )}
+    </li>
   )
 }

--- a/apps/web/src/components/watch/__tests__/BibleQuotesSection.test.tsx
+++ b/apps/web/src/components/watch/__tests__/BibleQuotesSection.test.tsx
@@ -31,6 +31,15 @@ beforeEach(() => {
   container = document.createElement("div")
   document.body.appendChild(container)
   root = createRoot(container)
+  // Stub fetch globally so non-fetch-focused tests don't accidentally hit
+  // undici with a cross-realm AbortSignal (which logs a noisy TypeError
+  // through the component's catch block but does not affect rendered DOM).
+  // Tests in the verse-fetch describe block install their own mock and
+  // override this one.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => new Promise(() => undefined)),
+  )
 })
 
 afterEach(() => {
@@ -38,6 +47,7 @@ afterEach(() => {
     root.unmount()
   })
   container.remove()
+  vi.unstubAllGlobals()
 })
 
 type Citation = WatchBibleQuotesBlock["bibleCitations"][number]
@@ -187,7 +197,16 @@ describe("BibleQuotesSection — citations + promo", () => {
     )
     expect(promo).not.toBeNull()
     expect(promo!.textContent).toContain("Free Resources")
-    expect(promo!.textContent).toContain("Join Our Bible Study")
+    expect(promo!.textContent).toContain(
+      "Want to grow deep in your understanding of the Bible?",
+    )
+    // The fixed Bible-photo background must always appear on the promo card —
+    // verifies the "blank card" regression from May 11 doesn't return.
+    const promoImg = promo!.querySelector("img")
+    expect(promoImg).not.toBeNull()
+    expect(promoImg!.getAttribute("src") ?? "").toContain(
+      "photo-1650658720644-e1588bd66de3",
+    )
     const spacer = container.querySelector(
       '[data-testid="watch-bible-quotes-end-spacer"]',
     )
@@ -263,6 +282,390 @@ describe("BibleQuotesSection — Share button", () => {
     })
 
     expect(onShareClick).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("BibleQuotesSection — Unsplash image + verse fetch", () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("renders an <img> per citation using the index-cycled Unsplash URLs", () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined))
+    const citations: Citation[] = [
+      makeCitation({
+        documentId: "bc-1",
+        bookName: "Psalms",
+        chapterStart: 139,
+        verseStart: 13,
+        verseEnd: 18,
+      }),
+      makeCitation({
+        documentId: "bc-2",
+        bookName: "Luke",
+        chapterStart: 8,
+        verseStart: 2,
+      }),
+    ]
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={citations}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    const imgs = container.querySelectorAll(
+      '[data-testid="watch-bible-quotes-item"] img',
+    )
+    // next/image emits an <img> per card; both src values should reference
+    // an Unsplash URL (next/image wraps the original).
+    expect(imgs.length).toBeGreaterThanOrEqual(2)
+    const src0 = imgs[0]?.getAttribute("src") ?? ""
+    const src1 = imgs[1]?.getAttribute("src") ?? ""
+    expect(src0).toContain("images.unsplash.com")
+    expect(src1).toContain("images.unsplash.com")
+    // Different index → different underlying URL.
+    expect(src0).not.toBe(src1)
+  })
+
+  it("fetches the verse text from wldeh/bible-api with lowercased book name", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ text: "Verse body", reference: "Psalms 139:13" }),
+        { status: 200 },
+      ),
+    )
+    const citation = makeCitation({
+      documentId: "bc-psalms",
+      bookName: "Psalms",
+      chapterStart: 139,
+      verseStart: 13,
+      verseEnd: 18,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    // Effect ran on mount; flush microtasks so the fetched body renders.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalled()
+    const url = String(fetchMock.mock.calls[0]?.[0] ?? "")
+    expect(url).toContain(
+      "https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/en-asv/books/psalms/chapters/139/verses/13.json",
+    )
+    const verse = container.querySelector(
+      '[data-testid="watch-bible-quotes-verse"]',
+    )
+    expect(verse?.textContent).toBe("Verse body")
+  })
+
+  it("uses the locale-mapped Bible version when locale='es'", async () => {
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }))
+    const citation = makeCitation({
+      bookName: "Lucas",
+      chapterStart: 8,
+      verseStart: 2,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+          locale="es"
+        />,
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const url = String(fetchMock.mock.calls[0]?.[0] ?? "")
+    expect(url).toContain("/bibles/es-rvr1960/")
+  })
+
+  it("renders a Read more... link only when verseEnd is present", () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined))
+    const citations: Citation[] = [
+      makeCitation({ documentId: "single", verseStart: 20, verseEnd: null }),
+      makeCitation({ documentId: "range", verseStart: 20, verseEnd: 25 }),
+    ]
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={citations}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    const readMores = container.querySelectorAll(
+      '[data-testid="watch-bible-quotes-read-more"]',
+    )
+    expect(readMores.length).toBe(1)
+    const anchor = readMores[0] as HTMLAnchorElement
+    expect(anchor.getAttribute("target")).toBe("_blank")
+    const rel = anchor.getAttribute("rel") ?? ""
+    expect(rel).toContain("noopener")
+    expect(rel).toContain("noreferrer")
+    expect(anchor.getAttribute("href")).toContain("biblegateway.com/passage/")
+    expect(anchor.getAttribute("href")).toContain("version=NIV")
+  })
+
+  it("locale='es' maps the BibleGateway Read-more link to version=NVI", () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined))
+    const citation = makeCitation({
+      bookName: "Lucas",
+      chapterStart: 8,
+      verseStart: 2,
+      verseEnd: 5,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+          locale="es"
+        />,
+      )
+    })
+    const anchor = container.querySelector(
+      '[data-testid="watch-bible-quotes-read-more"]',
+    ) as HTMLAnchorElement | null
+    expect(anchor).not.toBeNull()
+    expect(anchor!.getAttribute("href")).toContain("version=NVI")
+    expect(anchor!.getAttribute("href")).not.toContain("version=NIV")
+  })
+
+  it("multi-word book names are normalized to whitespace-stripped slugs in the jsdelivr URL", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ verse: "1", text: "Body" }), {
+        status: 200,
+      }),
+    )
+    const citation = makeCitation({
+      bookName: "1 Corinthians",
+      chapterStart: 13,
+      verseStart: 4,
+      verseEnd: 7,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalled()
+    const url = String(fetchMock.mock.calls[0]?.[0] ?? "")
+    expect(url).toContain("/books/1corinthians/")
+    expect(url).not.toContain("%20")
+    expect(url).not.toContain(" ")
+  })
+
+  it("hostile book names containing path-traversal segments are rejected before fetch", () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined))
+    const citation = makeCitation({
+      bookName: "../etc/passwd",
+      chapterStart: 1,
+      verseStart: 1,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("null bookName / null chapterStart / null verseStart skip the fetch entirely", () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined))
+    const citations: Citation[] = [
+      makeCitation({
+        documentId: "null-book",
+        bookName: null,
+        chapterStart: 1,
+        verseStart: 1,
+      }),
+    ]
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={citations}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(
+      container.querySelector('[data-testid="watch-bible-quotes-verse"]'),
+    ).toBeNull()
+  })
+
+  it("fetch is called with cache: 'force-cache' so cross-navigation hits dedupe", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ text: "Body" }), { status: 200 }),
+    )
+    const citation = makeCitation({
+      bookName: "Psalms",
+      chapterStart: 23,
+      verseStart: 1,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalled()
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(init?.cache).toBe("force-cache")
+  })
+
+  it("non-ok fetch responses render the card without a verse element", async () => {
+    fetchMock.mockResolvedValue(new Response("", { status: 404 }))
+    const citation = makeCitation({
+      bookName: "Psalms",
+      chapterStart: 1,
+      verseStart: 1,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(
+      container.querySelector('[data-testid="watch-bible-quotes-verse"]'),
+    ).toBeNull()
+  })
+
+  it("fetch reject (network error) renders the card without a verse element", async () => {
+    fetchMock.mockRejectedValue(new TypeError("network unreachable"))
+    const citation = makeCitation({
+      bookName: "Psalms",
+      chapterStart: 1,
+      verseStart: 1,
+    })
+    // Swallow the expected error log so the test output stays clean.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      act(() => {
+        root.render(
+          <BibleQuotesSection
+            bibleCitations={[citation]}
+            onShareClick={vi.fn()}
+          />,
+        )
+      })
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(
+        container.querySelector('[data-testid="watch-bible-quotes-verse"]'),
+      ).toBeNull()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it("formatScripture strips ';N:N…' and ',N:N…' footnote markers before rendering", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          text: "For God so loved the world;1 he gave,2:3 his only Son.",
+        }),
+        { status: 200 },
+      ),
+    )
+    const citation = makeCitation({
+      bookName: "John",
+      chapterStart: 3,
+      verseStart: 16,
+      verseEnd: 16,
+    })
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={[citation]}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const verse = container.querySelector(
+      '[data-testid="watch-bible-quotes-verse"]',
+    )
+    // Semicolon-footnote regex strips everything from `;1` onward, so the
+    // rendered text is just the lead-in.
+    expect(verse?.textContent).toBe("For God so loved the world")
+  })
+
+  it("BIBLE_IMAGES cycles by index modulo array length (no silent repeat of image 0)", () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined))
+    const citations: Citation[] = Array.from({ length: 9 }).map((_, i) =>
+      makeCitation({
+        documentId: `bc-${i}`,
+        bookName: "Psalms",
+        chapterStart: 1,
+        verseStart: i + 1,
+      }),
+    )
+    act(() => {
+      root.render(
+        <BibleQuotesSection
+          bibleCitations={citations}
+          onShareClick={vi.fn()}
+        />,
+      )
+    })
+    const imgs = container.querySelectorAll(
+      '[data-testid="watch-bible-quotes-item"] img',
+    )
+    const src0 = imgs[0]?.getAttribute("src") ?? ""
+    const src7 = imgs[7]?.getAttribute("src") ?? ""
+    // 7 % 7 === 0, so the 8th citation card should reuse image 0.
+    expect(src7).toBe(src0)
+    // 8 % 7 === 1, so the 9th citation should reuse image 1 (NOT image 0).
+    const src8 = imgs[8]?.getAttribute("src") ?? ""
+    const src1 = imgs[1]?.getAttribute("src") ?? ""
+    expect(src8).toBe(src1)
+    expect(src8).not.toBe(src0)
   })
 })
 

--- a/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
@@ -10,8 +10,10 @@
  *  - Download button hidden when `variant.downloads` empty.
  *  - Mobile DOM order — left column first in source.
  *  - Click integration for both modal triggers.
- *  - UX regression: WatchStudyQuestions has NO chevron / accordion semantics
- *    on either prompt rows or the placeholder row.
+ *  - WatchStudyQuestions accordion: each prompt row (and the placeholder row)
+ *    is expandable; the expanded body always renders the "no-answer"
+ *    fallback (private-discussion line + Chat / Ask-a-Bible-question CTAs),
+ *    mirroring core/apps/watch's DiscussionQuestions component.
  */
 
 import { act } from "react"
@@ -452,29 +454,8 @@ describe("WatchBody — modal trigger integration", () => {
   })
 })
 
-describe("WatchStudyQuestions — UX regression: no false-affordance chevrons", () => {
-  it("renders prompts as a static <ul> bullet list (no <details>/<summary>)", () => {
-    act(() => {
-      root.render(
-        <WatchStudyQuestions
-          prompts={["A?", "B?"]}
-          onAskYoursClick={vi.fn()}
-        />,
-      )
-    })
-
-    const ul = container.querySelector(
-      '[data-testid="watch-study-questions-list"]',
-    )
-    expect(ul).not.toBeNull()
-    expect(ul!.tagName.toLowerCase()).toBe("ul")
-
-    // No accordion semantics anywhere in the rendered tree.
-    expect(container.querySelectorAll("details").length).toBe(0)
-    expect(container.querySelectorAll("summary").length).toBe(0)
-  })
-
-  it("does not put aria-haspopup or expand affordances on prompt items", () => {
+describe("WatchStudyQuestions — accordion expand with no-answer fallback", () => {
+  it("each prompt row carries a trigger button with aria-expanded=false by default", () => {
     act(() => {
       root.render(
         <WatchStudyQuestions
@@ -490,98 +471,229 @@ describe("WatchStudyQuestions — UX regression: no false-affordance chevrons", 
     expect(items.length).toBe(3)
     for (const item of items) {
       expect(item.tagName.toLowerCase()).toBe("li")
-      // Prompt rows must NOT signal interactivity.
-      expect(item.hasAttribute("aria-haspopup")).toBe(false)
-      expect(item.hasAttribute("aria-expanded")).toBe(false)
-      expect(item.hasAttribute("role")).toBe(false)
-      // No nested button or link inside the prompt rows. Decorative SVG (the
-      // shared `QuestionIcon` mirrored from RelatedQuestions) is allowed —
-      // what's banned is anything that *implies* interactivity, e.g. a
-      // chevron with `rotate` transitions.
-      expect(item.querySelector("button")).toBeNull()
-      expect(item.querySelector("a")).toBeNull()
-      // Any SVG present must be explicitly decorative (`aria-hidden="true"`)
-      // and must not carry rotate/transition classes that would suggest an
-      // expandable affordance.
-      const svgs = item.querySelectorAll("svg")
-      for (const svg of svgs) {
-        expect(svg.getAttribute("aria-hidden")).toBe("true")
-        const cls = svg.getAttribute("class") ?? ""
-        expect(cls).not.toMatch(/\brotate-/)
-        expect(cls).not.toMatch(/\btransition\b/)
-      }
+      const trigger = item.querySelector(
+        '[data-testid="watch-study-questions-item-trigger"]',
+      ) as HTMLButtonElement | null
+      expect(trigger).not.toBeNull()
+      expect(trigger!.tagName.toLowerCase()).toBe("button")
+      expect(trigger!.getAttribute("aria-expanded")).toBe("false")
+      // Panel is unmounted while collapsed so closed rows stay free of
+      // fallback body text.
+      expect(
+        item.querySelector('[data-testid="watch-study-questions-item-panel"]'),
+      ).toBeNull()
     }
   })
 
-  it("renders the Ask Yours CTA as the only interactive element in the section", () => {
+  it("clicking a row opens its panel and reveals the no-answer fallback + two CTAs", () => {
     act(() => {
       root.render(
         <WatchStudyQuestions
-          prompts={["A?", "B?"]}
+          prompts={["What is hope?"]}
           onAskYoursClick={vi.fn()}
         />,
       )
     })
 
-    const section = container.querySelector(
-      '[data-testid="watch-study-questions"]',
+    const trigger = container.querySelector(
+      '[data-testid="watch-study-questions-item-trigger"]',
+    ) as HTMLButtonElement
+    expect(trigger).not.toBeNull()
+    act(() => {
+      trigger.click()
+    })
+    expect(trigger.getAttribute("aria-expanded")).toBe("true")
+
+    const panel = container.querySelector(
+      '[data-testid="watch-study-questions-item-panel"]',
     )
-    expect(section).not.toBeNull()
-    const buttons = section!.querySelectorAll("button")
-    expect(buttons.length).toBe(1)
-    expect(buttons[0]?.getAttribute("data-testid")).toBe(
-      "watch-study-questions-ask-yours",
+    expect(panel).not.toBeNull()
+    expect(panel!.textContent).toContain(
+      "Have a private discussion with someone who is ready to listen.",
     )
+
+    const chat = container.querySelector(
+      '[data-testid="watch-study-questions-chat-cta"]',
+    ) as HTMLAnchorElement | null
+    expect(chat).not.toBeNull()
+    expect(chat!.tagName.toLowerCase()).toBe("a")
+    expect(chat!.getAttribute("href")).toBe(
+      "https://chataboutjesus.com/chat/?utm_source=jesusfilm-watch",
+    )
+    expect(chat!.getAttribute("target")).toBe("_blank")
+    const chatRel = chat!.getAttribute("rel") ?? ""
+    expect(chatRel).toContain("noopener")
+    expect(chatRel).toContain("noreferrer")
+    expect(chat!.textContent).toContain("Chat with a person")
+
+    const ask = container.querySelector(
+      '[data-testid="watch-study-questions-ask-bible-cta"]',
+    ) as HTMLAnchorElement | null
+    expect(ask).not.toBeNull()
+    expect(ask!.tagName.toLowerCase()).toBe("a")
+    expect(ask!.getAttribute("href")).toBe(
+      "https://www.everystudent.com/contact.php?utm_source=jesusfilm-watch",
+    )
+    expect(ask!.getAttribute("target")).toBe("_blank")
+    const askRel = ask!.getAttribute("rel") ?? ""
+    expect(askRel).toContain("noopener")
+    expect(askRel).toContain("noreferrer")
+    expect(ask!.textContent).toContain("Ask a Bible question")
   })
 
-  it("placeholder row (empty prompts) is non-interactive: no nested button/anchor, decorative SVG only, and Ask Yours stays the only button", () => {
+  it("only one row is open at a time — clicking a second row closes the first", () => {
+    act(() => {
+      root.render(
+        <WatchStudyQuestions
+          prompts={["First?", "Second?"]}
+          onAskYoursClick={vi.fn()}
+        />,
+      )
+    })
+
+    const triggers = container.querySelectorAll(
+      '[data-testid="watch-study-questions-item-trigger"]',
+    )
+    expect(triggers.length).toBe(2)
+    act(() => {
+      ;(triggers[0] as HTMLButtonElement).click()
+    })
+    expect(
+      container.querySelectorAll(
+        '[data-testid="watch-study-questions-item-panel"]',
+      ).length,
+    ).toBe(1)
+    act(() => {
+      ;(triggers[1] as HTMLButtonElement).click()
+    })
+    const panels = container.querySelectorAll(
+      '[data-testid="watch-study-questions-item-panel"]',
+    )
+    expect(panels.length).toBe(1)
+    expect(triggers[0]?.getAttribute("aria-expanded")).toBe("false")
+    expect(triggers[1]?.getAttribute("aria-expanded")).toBe("true")
+  })
+
+  it("resets openIndex when the prompts array reference changes — stale index never reveals a different question's panel", () => {
+    // Open the second row, then re-render with a shorter prompts array that
+    // no longer has an index 1 — the new render must NOT show any panel.
+    const firstPrompts = ["A?", "B?"]
+    const secondPrompts = ["Only one?"]
+
+    act(() => {
+      root.render(
+        <WatchStudyQuestions
+          prompts={firstPrompts}
+          onAskYoursClick={vi.fn()}
+        />,
+      )
+    })
+
+    const triggers = container.querySelectorAll(
+      '[data-testid="watch-study-questions-item-trigger"]',
+    )
+    expect(triggers.length).toBe(2)
+    act(() => {
+      ;(triggers[1] as HTMLButtonElement).click()
+    })
+    expect(
+      container.querySelectorAll(
+        '[data-testid="watch-study-questions-item-panel"]',
+      ).length,
+    ).toBe(1)
+
+    // Re-render with a different (shorter) prompts reference.
+    act(() => {
+      root.render(
+        <WatchStudyQuestions
+          prompts={secondPrompts}
+          onAskYoursClick={vi.fn()}
+        />,
+      )
+    })
+
+    // No panel should be open after prompts changed.
+    expect(
+      container.querySelectorAll(
+        '[data-testid="watch-study-questions-item-panel"]',
+      ).length,
+    ).toBe(0)
+    const newTriggers = container.querySelectorAll(
+      '[data-testid="watch-study-questions-item-trigger"]',
+    )
+    expect(newTriggers.length).toBe(1)
+    expect(newTriggers[0]?.getAttribute("aria-expanded")).toBe("false")
+  })
+
+  it("clicking an open row's trigger again collapses it (toggle off)", () => {
+    act(() => {
+      root.render(
+        <WatchStudyQuestions prompts={["A?"]} onAskYoursClick={vi.fn()} />,
+      )
+    })
+
+    const trigger = container.querySelector(
+      '[data-testid="watch-study-questions-item-trigger"]',
+    ) as HTMLButtonElement
+    act(() => {
+      trigger.click()
+    })
+    expect(trigger.getAttribute("aria-expanded")).toBe("true")
+    act(() => {
+      trigger.click()
+    })
+    expect(trigger.getAttribute("aria-expanded")).toBe("false")
+    expect(
+      container.querySelector(
+        '[data-testid="watch-study-questions-item-panel"]',
+      ),
+    ).toBeNull()
+  })
+
+  it("placeholder row (empty prompts) is also expandable and reveals the same fallback content", () => {
     act(() => {
       root.render(
         <WatchStudyQuestions prompts={[]} onAskYoursClick={vi.fn()} />,
       )
     })
 
-    // Accordion semantics still banned across the placeholder branch.
-    expect(container.querySelectorAll("details").length).toBe(0)
-    expect(container.querySelectorAll("summary").length).toBe(0)
-
     const placeholder = container.querySelector(
       '[data-testid="watch-study-questions-placeholder"]',
     )
     expect(placeholder).not.toBeNull()
     expect(placeholder!.tagName.toLowerCase()).toBe("li")
-    expect(placeholder!.hasAttribute("aria-haspopup")).toBe(false)
-    expect(placeholder!.hasAttribute("aria-expanded")).toBe(false)
-    expect(placeholder!.hasAttribute("role")).toBe(false)
-    expect(placeholder!.querySelector("button")).toBeNull()
-    expect(placeholder!.querySelector("a")).toBeNull()
-    // Any SVG inside the placeholder row must be decorative and free of
-    // rotate/transition classes that would suggest an expandable affordance.
-    const svgs = placeholder!.querySelectorAll("svg")
-    expect(svgs.length).toBeGreaterThan(0)
-    for (const svg of svgs) {
-      expect(svg.getAttribute("aria-hidden")).toBe("true")
-      const cls = svg.getAttribute("class") ?? ""
-      expect(cls).not.toMatch(/\brotate-/)
-      expect(cls).not.toMatch(/\btransition\b/)
-    }
+    const trigger = placeholder!.querySelector(
+      '[data-testid="watch-study-questions-placeholder-trigger"]',
+    ) as HTMLButtonElement | null
+    expect(trigger).not.toBeNull()
+    expect(trigger!.getAttribute("aria-expanded")).toBe("false")
 
-    // Real prompt rows must be absent in the placeholder branch.
+    act(() => {
+      trigger!.click()
+    })
+    expect(trigger!.getAttribute("aria-expanded")).toBe("true")
+    const panel = container.querySelector(
+      '[data-testid="watch-study-questions-placeholder-panel"]',
+    )
+    expect(panel).not.toBeNull()
+    expect(panel!.textContent).toContain(
+      "Have a private discussion with someone who is ready to listen.",
+    )
+    // Same external-target CTAs are reachable from the placeholder body.
+    expect(
+      container.querySelector('[data-testid="watch-study-questions-chat-cta"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector(
+        '[data-testid="watch-study-questions-ask-bible-cta"]',
+      ),
+    ).not.toBeNull()
+
+    // Real prompt rows must still be absent in the placeholder branch.
     expect(
       container.querySelectorAll('[data-testid="watch-study-questions-item"]')
         .length,
     ).toBe(0)
-
-    // Singleton-button contract holds across the empty-prompts path too.
-    const section = container.querySelector(
-      '[data-testid="watch-study-questions"]',
-    )
-    expect(section).not.toBeNull()
-    const buttons = section!.querySelectorAll("button")
-    expect(buttons.length).toBe(1)
-    expect(buttons[0]?.getAttribute("data-testid")).toBe(
-      "watch-study-questions-ask-yours",
-    )
   })
 })
 

--- a/docs/solutions/design-patterns/button-render-prop-over-raw-buttonvariants-20260511.md
+++ b/docs/solutions/design-patterns/button-render-prop-over-raw-buttonvariants-20260511.md
@@ -1,0 +1,148 @@
+---
+title: "Use Button render prop instead of raw buttonVariants() on anchor elements"
+date: "2026-05-11"
+category: design-patterns
+module: apps/web
+problem_type: design_pattern
+component: tooling
+severity: medium
+applies_when:
+  - "Styling an <a>, <Link>, or other non-button element with a Button variant (pill, ghost, etc.)"
+  - "Consuming buttonVariants() directly as className outside of the Button component"
+  - "Any element that needs Button visual styles but must render as a different HTML tag"
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+  - apps/web/src/components/ui/button.tsx
+  - apps/web/src/components/watch/WatchStudyQuestions.tsx
+  - apps/web/src/components/sections/RelatedQuestions.tsx
+  - apps/web/src/components/watch/BibleQuotesSection.tsx
+tags:
+  - tailwind-merge
+  - cva
+  - class-variance-authority
+  - base-ui
+  - button-component
+  - render-prop
+  - anchor-link
+  - pill-variant
+  - class-conflict
+---
+
+# Use Button render prop instead of raw buttonVariants() on anchor elements
+
+## Context
+
+When adding an external-link CTA that should visually match a pill button, the natural reach is `buttonVariants()` — the exported `cva` factory from `apps/web/src/components/ui/button.tsx`. It looks like the right escape hatch: it returns the same class string the `Button` component uses, so you can apply it directly to any element.
+
+```tsx
+// naive approach — looks correct, breaks visually
+<a className={buttonVariants({ variant: "pill" })}>Chat with a person</a>
+```
+
+This is exactly what happened with the `CHAT_WITH_PERSON_URL` and `ASK_BIBLE_QUESTION_URL` CTAs in `WatchStudyQuestions.tsx` before the fix. The links rendered as `rounded-lg` rectangles instead of pill capsules, mismatching the Download / Ask Yours / Share buttons on the same page.
+
+The same anti-pattern was introduced on the `BibleQuotesSection` promo-card CTA in an earlier session (2026-04-30 → 2026-05-04, branch `main`) with the comment "Using `buttonVariants` to style an anchor as a pill (preserves the new-tab semantics naturally)." That session also fixed a _separate_ CVA conflict — pill buttons capping at `h-8` because the size variant's `h-8 px-2.5` overrode pill padding, requiring a `compoundVariants` entry in `button.tsx`. The corner-radius variant of the same conflict went unnoticed because nothing on screen visually adjacent to the promo card surfaced the mismatch. (session history)
+
+## Guidance
+
+Use `<Button render={<a />}>` with `nativeButton={false}` instead of applying `buttonVariants()` directly to an `<a>` tag.
+
+**Before (broken):**
+
+```tsx
+<a
+  className={buttonVariants({ variant: "pill" })}
+  href={CHAT_WITH_PERSON_URL}
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  Chat with a person
+</a>
+```
+
+**After (correct):**
+
+```tsx
+<Button
+  variant="pill"
+  nativeButton={false}
+  render={
+    <a href={CHAT_WITH_PERSON_URL} target="_blank" rel="noopener noreferrer" />
+  }
+>
+  Chat with a person
+</Button>
+```
+
+The `render` prop is a Base UI pattern: `ButtonPrimitive` substitutes the rendered element while keeping the `Button` wrapper's logic intact. On the Base UI version in use as of this writing (`@base-ui/react/button`), passing `nativeButton={false}` silences a runtime warning that the rendered element is not a `<button>`. If Base UI drops or renames this prop in a future version, the rest of the pattern still works — `nativeButton` is an opt-out signal, not a load-bearing part of the class-dedup fix.
+
+## Why This Matters
+
+The `buttonVariants` `cva` declaration in `button.tsx` sets `rounded-lg` in the **base** string and `rounded-full` in the **`pill` variant**:
+
+```ts
+const buttonVariants = cva(
+  "... rounded-lg ...", // base — always included
+  {
+    variants: {
+      variant: {
+        pill: "... rounded-full ...", // added on top
+      },
+    },
+  },
+)
+```
+
+`cva` concatenates these; it does not deduplicate. The raw output of `buttonVariants({ variant: "pill" })` contains **both** `rounded-lg` and `rounded-full`. In a raw class string (no further processing), CSS cascade order determines the winner — and because Tailwind emits utilities in a generated order that is not lexicographic with respect to user expectations, `rounded-full` is not guaranteed to appear after `rounded-lg`. The observed result was `rounded-lg` winning, producing a rectangle.
+
+Inside the `Button` component, the class string is passed through `cn(buttonVariants(...))`. `cn` is a `clsx` + `tailwind-merge` wrapper. `tailwind-merge` recognises that `rounded-lg` and `rounded-full` target the same CSS property and keeps only the last one, so `rounded-full` wins. **That deduplication only runs inside the `Button` component.** Calling `buttonVariants()` and assigning the raw result directly to a `className` attribute bypasses `tailwind-merge` entirely. (`buttonVariants` itself is compatible with `tailwind-merge` — it just needs to be wrapped in `cn(...)` at the call site, which the `Button` component does for you.)
+
+The same mechanic applies to every other CVA conflict (e.g., the `h-8` height vs pill padding bug fixed via `compoundVariants` in the April session): raw `buttonVariants()` carries the merged class string without dedup, and the rendered element silently inherits the wrong winner.
+
+## When to Apply
+
+Use `<Button render={<a />} nativeButton={false}>` any time you need:
+
+- An external link (`target="_blank"`) styled as a button
+- A download link (`<a href="..." download>`) styled as a button
+- In-app `<a>` navigation (e.g., Next.js `<Link>`) with a button appearance — prefer `<Button render={<Link href="..." />} nativeButton={false}>` as the render target
+- Any case where the semantic element must not be `<button>` but the visual treatment must exactly match a `Button` variant
+
+If you only need the class names without the `tailwind-merge` dedup (e.g., building a className dynamically for a third-party component that wraps its own element), call `cn(buttonVariants({ variant }))` explicitly rather than `buttonVariants(...)` raw — the `cn` import lives in `@/lib/utils`.
+
+## Examples
+
+**Existing precedent — `RelatedQuestions.tsx` (line ~149):**
+
+```tsx
+<Button
+  variant="pill"
+  aria-label={ctaLabel || "Ask a question"}
+  render={<a href={ctaLink} target="_blank" rel="noopener noreferrer" />}
+>
+  <MessageCircleIcon />
+  <span>{ctaLabel || "Ask yours"}</span>
+</Button>
+```
+
+Note: `nativeButton` is omitted at this older callsite — the Base UI version in use when it was written did not surface the warning. Adding `nativeButton={false}` is still the safe default and silences a runtime warning on newer Base UI.
+
+**Fixed CTAs — `WatchStudyQuestions.tsx`:**
+
+Both `CHAT_WITH_PERSON_URL` and `ASK_BIBLE_QUESTION_URL` buttons use the `render={<a />} + nativeButton={false}` pattern. The `BibleQuotesSection` promo-card "Join our Bible study" CTA was also migrated to the same pattern in the same PR.
+
+**Verification:** A computed-style probe across all five pill controls on the watch page (Download, Ask Yours, Share, Chat with a person, Ask a Bible question) returned **identical** `border-radius`, `height`, `padding`, `font-size`, `font-weight`, and `background-color` values — confirming that routing through `Button`'s `cn()` call is the only correct path for per-variant class deduplication.
+
+## Prevention
+
+- **Lint rule (proposed):** flag direct uses of `buttonVariants(` outside of `button.tsx`. The legitimate consumers are the `Button` component itself; everything else should go through `<Button render={...}>`.
+- **Code-review checklist:** when reviewing a new external-link CTA, look for `className={buttonVariants(` on a non-Button element. If found, request a refactor to `<Button render={<a/>} nativeButton={false}>`.
+- **Visual regression coverage:** the watch-page pill controls now share a computed-style probe (see CDP smoke script). Any new pill-styled control on that surface should be added to the probe so a regression of this shape is caught visually.
+
+## Related
+
+- Base UI `Button` `render` prop documentation — https://base-ui.com/react/components/button (substitutes the rendered element via React composition)
+- `class-variance-authority` README — concatenation semantics that this pattern works around
+- `tailwind-merge` README — explains class-conflict resolution that `cn()` provides
+- The `compoundVariants` entry in `apps/web/src/components/ui/button.tsx` (April 2026) — same CVA-conflict family, applied to the `h-8` × pill-padding collision


### PR DESCRIPTION
## Summary

Brings the watch-page UX closer to the legacy `core/apps/watch` reference and lands 13+ fixes from a multi-agent code review (`/ce-code-review`).

### Bible Quotes carousel (`BibleQuotesSection.tsx`)
- Full-bleed Unsplash backgrounds per citation card, cycled by `i % 7` (no silent index-0 repeat for >7 citations).
- Client-side verse fetch from `cdn.jsdelivr.net/gh/wldeh/bible-api` with `AbortController` cleanup, `setTimeout` deadline (8s), `cancelled` flag against post-unmount writes, AbortError early-return, and `cache: "force-cache"` for cross-navigation dedup.
- Locale-aware translation map (en, es, fr, id, ja, ko, ru, th, tr, zh, zh-Hans-CN), threaded through page → WatchPageClient → WatchSectionRenderer → BibleQuotesSection. **Previously the `locale` prop was added but never wired** — every non-English page silently rendered English ASV.
- CMS book-name sanitization: lowercase + strip whitespace + allowlist regex. Fixes multi-word books (1 John, Song of Solomon, 1/2 Corinthians, etc.) that previously silently 404'd on jsdelivr, and hardens against path-traversal attempts from hostile CMS input.
- `res.json()` narrowed via a type predicate instead of `as Partial<…>` cast.
- Promo card got the open-Bible Unsplash photo with the reference heading; conditional `priority` flag when no editorial citations are present.
- Promo CTA refactored to `<Button render={<a/>} nativeButton={false}>` for pill-radius parity with Download / Ask Yours / Share.

### Related Questions accordion (`WatchStudyQuestions.tsx`)
- Inverted from non-interactive prompts to single-open accordion. Each row expands into the same "no-answer" fallback the legacy app shows: "Have a private discussion with someone who is ready to listen." plus pill CTAs to `chataboutjesus.com` and `everystudent.com`.
- Placeholder row (empty prompts) also expandable with the same fallback.
- `openIndex` resets on prompts-reference change via React's adjusting-state-in-render pattern.

### Code-review fixes applied this PR
1. Locale prop never threaded → now plumbed through 4 components.
2. Multi-word book names silently 404 on jsdelivr → whitespace-stripped slug.
3. `res.json() as Partial<…>` → unknown-narrowing type predicate.
4. No fetch timeout → 8 s `setTimeout` + `controller.abort`.
5. Post-unmount setScripture race → cancelled flag.
6. AbortError flicker on locale change → early-return + synchronous state reset.
7. `DEFAULT_BIBLE_VERSION` unsound under noUncheckedIndexedAccess → independent literal.
8. `getBibleVersionForLocale` identity trap → destructure to primitives.
9. CMS book-name path traversal → allowlist regex + reject.
10. N parallel fetches, no cache → `cache: "force-cache"`.
11. Promo image lazy on zero-citations path → conditional `priority`.
12. `BIBLE_IMAGES[i] ?? BIBLE_IMAGES[0]` → cycling via modulo.
13. Dead `data.reference` read → dropped from state shape.
14. `openIndex` stale-index after prompts swap → reset via during-render pattern.
15. (M-04 pre-existing) Promo CTA pill-radius inconsistency → fixed alongside the new pattern.
16. `satisfies` annotation for the locale map.

Finding #15 (`formatScripture` returns empty string for footnote-only verses) deferred — it's a UX-design call about how to render that edge case.

## Test plan

- [x] `pnpm test` — 344 pass, 3 todo, 0 fail across 31 test files (apps/web)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] CDP smoke `/watch/yakhal-hope/english` — Bible Quotes renders, Psalms 130:1 verse loads, Related Questions accordion expands with fallback CTAs
- [x] CDP smoke `/watch/agape-love/english` — **multi-word book name fix proof**: 1 John 4:9 now renders ("Herein was the love of God manifested in us…"). Before this PR the verse would have been blank (jsdelivr 404 on `1%20john`)
- [x] CDP smoke `/watch/yakhal-hope/es` — **locale plumbing proof**: jsdelivr URL switches from `en-asv` to `es-rvr1960`
- [x] Zero console errors across all three routes
- [x] All `data-testid` contracts preserved; existing dispatch tests unchanged
- [x] Visual: promo card now shows the open-Bible photo (matches `core/apps/watch` reference)
- [x] Visual: pill-radius CTAs match Download / Ask Yours / Share

### Known limitation (pre-existing, inherited from `core/apps/watch`)
jsdelivr's non-English bible translations use localized book names (`salmos`, `juan`, `lucas`), but our CMS stores English book names. So non-English locales fetch a valid URL but get no verse body. Same gap exists in legacy `core/apps/watch`. Tracked as follow-up — needs OSIS-ID mapping or per-locale book-name translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)