### PR TITLE
fix(admin): start OAuth login from route handler

### DIFF
--- a/apps/admin/src/app/api/auth/login/route.test.ts
+++ b/apps/admin/src/app/api/auth/login/route.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/auth/oauth-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/auth/oauth-client")>()),
+  getAdminOAuthConfig: vi.fn(() => ({
+    issuerUrl: "https://auth.jesusfilm.org/api/auth",
+    clientId: "jfp_admin_local",
+    adminBaseUrl: "http://localhost:3003",
+  })),
+}))
+
+vi.mock("@/auth/oauth-state", () => ({
+  createOAuthState: vi.fn(() => ({
+    state: "state_123",
+    codeVerifier: "verifier_123",
+    codeChallenge: "challenge_123",
+  })),
+}))
+
+describe("admin OAuth login route", () => {
+  it("sets PKCE cookies from a route handler and redirects to Auth authorize", async () => {
+    const { GET } = await import("./route")
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3003/api/auth/login?callbackURL=http%3A%2F%2Flocalhost%3A3003%2Fdashboard",
+      ),
+    )
+    const location = new URL(response.headers.get("location") ?? "")
+
+    expect(location.origin).toBe("https://auth.jesusfilm.org")
+    expect(location.pathname).toBe("/api/auth/oauth2/authorize")
+    expect(location.searchParams.get("client_id")).toBe("jfp_admin_local")
+    expect(location.searchParams.get("state")).toBe("state_123")
+    expect(location.searchParams.get("code_challenge")).toBe("challenge_123")
+    expect(response.headers.get("set-cookie")).toContain(
+      "forge_admin_oauth_state=state_123",
+    )
+    expect(response.headers.get("set-cookie")).toContain(
+      "forge_admin_oauth_verifier=verifier_123",
+    )
+    expect(response.headers.get("set-cookie")).toContain(
+      "forge_admin_oauth_callback=http%3A%2F%2Flocalhost%3A3003%2Fdashboard",
+    )
+  })
+})

--- a/apps/admin/src/app/api/auth/login/route.ts
+++ b/apps/admin/src/app/api/auth/login/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server"
+
+import {
+  ADMIN_OAUTH_CALLBACK_COOKIE,
+  ADMIN_OAUTH_STATE_COOKIE,
+  ADMIN_OAUTH_VERIFIER_COOKIE,
+  adminOAuthCookieOptions,
+} from "@/auth/auth-session"
+import {
+  buildAdminAuthorizeUrl,
+  getAdminOAuthConfig,
+} from "@/auth/oauth-client"
+import { createOAuthState } from "@/auth/oauth-state"
+import { resolveAuthCallbackURL } from "@/auth/origins"
+
+export async function GET(request: Request) {
+  const config = getAdminOAuthConfig()
+  if (!config) {
+    return NextResponse.redirect(new URL("/login?error=forbidden", request.url))
+  }
+
+  const url = new URL(request.url)
+  const callbackURL = resolveAuthCallbackURL(
+    url.searchParams.get("callbackURL") ?? undefined,
+    `${config.adminBaseUrl.replace(/\/$/, "")}/dashboard`,
+  )
+  const state = createOAuthState()
+  const response = NextResponse.redirect(
+    buildAdminAuthorizeUrl({
+      config,
+      state: state.state,
+      codeChallenge: state.codeChallenge,
+      callbackUrl: callbackURL,
+    }),
+  )
+  const cookieOptions = adminOAuthCookieOptions()
+
+  response.cookies.set(ADMIN_OAUTH_STATE_COOKIE, state.state, {
+    ...cookieOptions,
+    maxAge: 60 * 10,
+  })
+  response.cookies.set(ADMIN_OAUTH_VERIFIER_COOKIE, state.codeVerifier, {
+    ...cookieOptions,
+    maxAge: 60 * 10,
+  })
+  response.cookies.set(ADMIN_OAUTH_CALLBACK_COOKIE, callbackURL, {
+    ...cookieOptions,
+    maxAge: 60 * 10,
+  })
+
+  return response
+}

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -1,18 +1,7 @@
 import { headers as nextHeaders } from "next/headers"
-import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { env } from "@/config/env"
-import {
-  ADMIN_OAUTH_CALLBACK_COOKIE,
-  ADMIN_OAUTH_STATE_COOKIE,
-  ADMIN_OAUTH_VERIFIER_COOKIE,
-  adminOAuthCookieOptions,
-} from "@/auth/auth-session"
-import {
-  buildAdminAuthorizeUrl,
-  getAdminOAuthConfig,
-} from "@/auth/oauth-client"
-import { createOAuthState } from "@/auth/oauth-state"
+import { getAdminOAuthConfig } from "@/auth/oauth-client"
 import {
   getAuthBaseURL,
   getDefaultPostLoginURL,
@@ -80,29 +69,9 @@ export default async function LoginPage({ searchParams }: LoginPageProps = {}) {
   const oauthConfig = getAdminOAuthConfig()
 
   if (oauthConfig && !initialError) {
-    const state = createOAuthState()
-    const cookieStore = await cookies()
-    const cookieOptions = adminOAuthCookieOptions()
-    cookieStore.set(ADMIN_OAUTH_STATE_COOKIE, state.state, {
-      ...cookieOptions,
-      maxAge: 60 * 10,
-    })
-    cookieStore.set(ADMIN_OAUTH_VERIFIER_COOKIE, state.codeVerifier, {
-      ...cookieOptions,
-      maxAge: 60 * 10,
-    })
-    cookieStore.set(ADMIN_OAUTH_CALLBACK_COOKIE, callbackURL, {
-      ...cookieOptions,
-      maxAge: 60 * 10,
-    })
-    redirect(
-      buildAdminAuthorizeUrl({
-        config: oauthConfig,
-        state: state.state,
-        codeChallenge: state.codeChallenge,
-        callbackUrl: callbackURL,
-      }).toString() as Parameters<typeof redirect>[0],
-    )
+    const url = new URL("/api/auth/login", requestOrigin)
+    url.searchParams.set("callbackURL", callbackURL)
+    redirect(url.toString() as Parameters<typeof redirect>[0])
   }
 
   if (requestOrigin !== authBaseURL && isTrustedAuthOrigin(requestOrigin)) {


### PR DESCRIPTION
## Summary
- Moves Admin OAuth login initiation into a route handler so Next.js can set PKCE/state cookies legally.
- Keeps /login responsible for callback resolution, then redirects to /api/auth/login.
- Adds route coverage for the authorize redirect and cookies.

## Validation
- pnpm --filter @forge/admin test -- src/app/api/auth/login/route.test.ts src/app/api/auth/callback/route.test.ts src/auth/oauth-client.test.ts src/auth/auth-session.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- pnpm exec prettier --check apps/admin/src/app/login/page.tsx apps/admin/src/app/api/auth/login/route.ts apps/admin/src/app/api/auth/login/route.test.ts

## Production note
This fixes the 500 seen on https://admin.jesusfilm.org/login after switching ADMIN_AUTH_MODE=oauth.