### PR TITLE
fix(admin): use public URL for OAuth callback failures

### DIFF
--- a/apps/admin/src/app/api/auth/callback/route.test.ts
+++ b/apps/admin/src/app/api/auth/callback/route.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/db/client", () => ({
 
 describe("admin OAuth callback route", () => {
   beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined)
     cookieGet.mockReset()
     cookieSet.mockReset()
     cookieDelete.mockReset()
@@ -62,6 +63,19 @@ describe("admin OAuth callback route", () => {
       "http://localhost:3003/login?error=forbidden",
     )
     expect(exchangeAdminAuthorizationCode).not.toHaveBeenCalled()
+  })
+
+  it("uses the public admin base URL for forbidden redirects", async () => {
+    cookieGet.mockReturnValue(undefined)
+    const { GET } = await import("./route")
+
+    const response = await GET(
+      new Request("http://0.0.0.0:8080/api/auth/callback?code=c&state=s"),
+    )
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3003/login?error=forbidden",
+    )
   })
 
   it("exchanges the code and creates an admin-local session", async () => {

--- a/apps/admin/src/app/api/auth/callback/route.ts
+++ b/apps/admin/src/app/api/auth/callback/route.ts
@@ -38,7 +38,16 @@ export async function GET(request: Request) {
     state !== expectedState ||
     !codeVerifier
   ) {
-    return NextResponse.redirect(new URL("/login?error=forbidden", request.url))
+    console.warn("admin.oauth.callback.forbidden", {
+      reason: "invalid_state",
+      hasCode: Boolean(code),
+      hasState: Boolean(state),
+      hasExpectedState: Boolean(expectedState),
+      stateMatches: state === expectedState,
+      hasCodeVerifier: Boolean(codeVerifier),
+    })
+
+    return redirectToForbiddenLogin(config)
   }
 
   try {
@@ -71,9 +80,22 @@ export async function GET(request: Request) {
     response.cookies.delete(ADMIN_OAUTH_CALLBACK_COOKIE)
 
     return response
-  } catch {
-    return NextResponse.redirect(new URL("/login?error=forbidden", request.url))
+  } catch (error) {
+    console.warn("admin.oauth.callback.forbidden", {
+      reason: "callback_failed",
+      message: error instanceof Error ? error.message : "unknown",
+    })
+
+    return redirectToForbiddenLogin(config)
   }
+}
+
+function redirectToForbiddenLogin(
+  config: NonNullable<ReturnType<typeof getAdminOAuthConfig>>,
+) {
+  return NextResponse.redirect(
+    new URL("/login?error=forbidden", config.adminBaseUrl),
+  )
 }
 
 type AdminUserRole = "ADMIN" | "EDITOR" | "VIEWER"


### PR DESCRIPTION
## Summary
- Redirects Admin OAuth callback failures to ADMIN_BASE_URL instead of Railway internal request hosts like 0.0.0.0:8080.
- Adds safe warning logs for invalid state and callback exchange/token failures.
- Covers the 0.0.0.0 callback failure redirect with a regression test.

## Validation
- pnpm --filter @forge/admin test -- src/app/api/auth/callback/route.test.ts src/app/api/auth/login/route.test.ts src/auth/oauth-client.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint