### PR TITLE
fix(admin): harden workflow worker status

### DIFF
--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -168,10 +168,8 @@ export const env = createEnv({
     // search rate-limit.
     EVAL_JUDGE_CONCURRENCY: concurrencyEnvSchema,
     EVAL_SEARCH_CONCURRENCY: concurrencyEnvSchema,
-    // ADMIN_BASE_URL: target for the harness's `GET /api/search` calls.
-    // Defaults to the local dev port (`http://localhost:3003`) at the
-    // call site; override to point at staging or prod admin.
-    ADMIN_BASE_URL: z.string().url().optional(),
+    // The eval harness reuses ADMIN_BASE_URL as the target for `GET /api/search`.
+    // It defaults to the local dev port at the call site when unset.
     // EVAL_GIT_SHA: stamped into the run JSON's metadata header so an
     // operator reviewing an old report can correlate it with a commit.
     // Optional; defaults to "unknown" at the call site. Operators set
@@ -299,7 +297,6 @@ export const env = createEnv({
     EVAL_SEARCH_CONCURRENCY: emptyToUndefined(
       process.env.EVAL_SEARCH_CONCURRENCY,
     ),
-    ADMIN_BASE_URL: emptyToUndefined(process.env.ADMIN_BASE_URL),
     EVAL_GIT_SHA: emptyToUndefined(process.env.EVAL_GIT_SHA),
     NODE_ENV: emptyToUndefined(process.env.NODE_ENV),
     NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,

--- a/apps/admin/src/services/workflow-worker-heartbeat.service.test.ts
+++ b/apps/admin/src/services/workflow-worker-heartbeat.service.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { loadWorkflowWorkerStatusRows } from "./workflow-worker-heartbeat.service"
+
+const queryRaw = vi.hoisted(() => vi.fn())
+const executeRaw = vi.hoisted(() => vi.fn())
+
+vi.mock("@/db/client", () => ({
+  prisma: {
+    $executeRaw: executeRaw,
+    $queryRaw: queryRaw,
+  },
+}))
+
+function sqlText(query: unknown) {
+  if (
+    query &&
+    typeof query === "object" &&
+    "strings" in query &&
+    Array.isArray(query.strings)
+  ) {
+    return query.strings.join("?")
+  }
+
+  return String(query)
+}
+
+const heartbeatRow = {
+  workerId: "admin:test:1",
+  service: "admin",
+  status: "online",
+  startedAt: new Date(Date.now() - 30_000),
+  lastSeenAt: new Date(),
+  currentJob: null,
+  currentRunId: null,
+}
+
+describe("loadWorkflowWorkerStatusRows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps heartbeat rows available when Graphile jobs are not initialized", async () => {
+    queryRaw
+      .mockResolvedValueOnce([heartbeatRow])
+      .mockResolvedValueOnce([{ exists: false }])
+
+    const rows = await loadWorkflowWorkerStatusRows()
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: "admin:test:1",
+        statusLabel: "Online",
+        statusTone: "success",
+      }),
+    ])
+    expect(queryRaw).toHaveBeenCalledTimes(2)
+  })
+
+  it("reads locked jobs from the Graphile public jobs view", async () => {
+    queryRaw
+      .mockResolvedValueOnce([heartbeatRow])
+      .mockResolvedValueOnce([{ exists: true }])
+      .mockResolvedValueOnce([
+        {
+          workerId: "graphile-worker-1",
+          lockedJobs: 2n,
+          lockedAt: new Date(),
+          task: "forge_adminflows",
+          queueName: null,
+        },
+      ])
+
+    const rows = await loadWorkflowWorkerStatusRows()
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "graphile:graphile-worker-1",
+          statusLabel: "Processing",
+          detail: expect.stringContaining("2 locked job(s)"),
+        }),
+      ]),
+    )
+
+    const lockedJobsQuery = sqlText(queryRaw.mock.calls[2][0])
+    expect(lockedJobsQuery).toContain("FROM graphile_worker.jobs")
+    expect(lockedJobsQuery).not.toContain("_private_jobs")
+  })
+})

--- a/apps/admin/src/services/workflow-worker-heartbeat.service.ts
+++ b/apps/admin/src/services/workflow-worker-heartbeat.service.ts
@@ -32,6 +32,10 @@ type LockedGraphileJobRow = {
   queueName: string | null
 }
 
+type RelationExistsRow = {
+  exists: boolean
+}
+
 export type WorkflowWorkerStatusRow = {
   id: string
   statusLabel: string
@@ -150,20 +154,23 @@ async function loadHeartbeatRows() {
 }
 
 async function loadLockedGraphileJobRows() {
+  const [jobsView] = await prisma.$queryRaw<RelationExistsRow[]>(Prisma.sql`
+    SELECT to_regclass('graphile_worker.jobs') IS NOT NULL AS "exists"
+  `)
+
+  if (!jobsView?.exists) return []
+
   return prisma.$queryRaw<LockedGraphileJobRow[]>(Prisma.sql`
     SELECT
-      jobs.locked_by AS "workerId",
+      locked_by AS "workerId",
       count(*)::bigint AS "lockedJobs",
-      min(jobs.locked_at) AS "lockedAt",
-      min(tasks.identifier) AS "task",
-      min(queues.queue_name) AS "queueName"
-    FROM graphile_worker._private_jobs jobs
-    JOIN graphile_worker._private_tasks tasks ON tasks.id = jobs.task_id
-    LEFT JOIN graphile_worker._private_job_queues queues
-      ON queues.id = jobs.job_queue_id
-    WHERE jobs.locked_by IS NOT NULL
-    GROUP BY jobs.locked_by
-    ORDER BY min(jobs.locked_at) ASC
+      min(locked_at) AS "lockedAt",
+      min(task_identifier) AS "task",
+      min(queue_name) AS "queueName"
+    FROM graphile_worker.jobs
+    WHERE locked_by IS NOT NULL
+    GROUP BY locked_by
+    ORDER BY min(locked_at) ASC
     LIMIT 10
   `)
 }
@@ -172,10 +179,8 @@ export async function loadWorkflowWorkerStatusRows(): Promise<
   WorkflowWorkerStatusRow[]
 > {
   try {
-    const [heartbeats, lockedJobs] = await Promise.all([
-      loadHeartbeatRows(),
-      loadLockedGraphileJobRows(),
-    ])
+    const heartbeats = await loadHeartbeatRows()
+    const lockedJobs = await loadLockedGraphileJobRows().catch(() => [])
 
     const heartbeatRows = heartbeats.map((row) => {
       const status = workerStatus(row)


### PR DESCRIPTION
## Summary

Workflow worker status now tolerates production environments where Graphile Worker has not initialized yet. The dashboard keeps showing admin heartbeat rows, skips locked-job data when `graphile_worker.jobs` is absent, and reads locked jobs through Graphile Worker’s public `jobs` view instead of private runtime tables.

This also removes duplicate `ADMIN_BASE_URL` entries from admin env validation so the current admin build can typecheck again.

## Verification

- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin test -- workflow-worker-heartbeat.service.test.ts`
- `pnpm --filter @forge/admin exec eslint src/config/env.ts src/services/workflow-worker-heartbeat.service.ts src/services/workflow-worker-heartbeat.service.test.ts`
