### PR TITLE
feat(web): consumer migration — web cutover branch + verification + runbook (Units 4-9 + UB7)

### DIFF
--- a/apps/admin/src/auth/consumer-bearer.ts
+++ b/apps/admin/src/auth/consumer-bearer.ts
@@ -1,23 +1,13 @@
-// Consumer-app bearer-key authentication for admin's GraphQL surface.
+// Consumer-app bearer-key auth for admin's GraphQL surface. Lets apps/web
+// SSR identify as `consumer:<key>` instead of `public:<cf-connecting-ip>`
+// (CGNAT + mobile-carrier NAT make the IP bucket too coarse for SSR fanout).
 //
-// Mirrors `apps/admin/src/auth/workflow-bearer.ts` byte-for-byte except
-// for the env var name (`WEB_ADMIN_API_KEYS` vs `WORKFLOW_API_KEYS`)
-// and bucket-prefix semantics. Used by apps/web SSR to identify itself
-// to admin so admin's rate-limit identifyFn can bucket consumer-app
-// traffic as `consumer:<key>` instead of `public:<cf-connecting-ip>`.
-// CGNAT and mobile-carrier NAT collapse many real users onto one IP,
-// so the anonymous-IP bucket is too coarse for a consumer-app SSR
-// fanout.
+// CRITICAL: the bearer principal grants NO permissions beyond PUBLIC — its
+// sole purpose is the rate-limit bucket key. Adding any permission is a
+// deliberate CI-failure surface.
 //
-// CRITICAL: the bearer principal `CONSUMER_BEARER` grants NO permissions
-// beyond PUBLIC. See `CONSUMER_BEARER_PERMISSIONS` (empty set) and the
-// early-return in `hasPermission`. The bearer's sole purpose is the
-// rate-limit bucket key — adding any permission here is a CI-failure
-// surface, intentionally.
-//
-// SECURITY: this module MUST NEVER log the raw `Authorization` header
-// value or the matched key string. Log scrubbing is unit-tested in
-// `consumer-bearer.test.ts`.
+// SECURITY: NEVER log the raw `Authorization` header value or matched key.
+// Log scrubbing is unit-tested in `consumer-bearer.test.ts`.
 
 import { timingSafeEqual } from "node:crypto"
 import { env } from "@/config/env"
@@ -31,38 +21,14 @@ function parseAllowlist(): string[] {
     .filter((k) => k.length > 0)
 }
 
-/**
- * Result of validating an `Authorization: Bearer <key>` header against
- * the `WEB_ADMIN_API_KEYS` CSV allowlist.
- *
- * On match, `bucketKey` is the matched allowlist entry (case-sensitive
- * comparison). The rate-limit identifyFn uses it as the bucket
- * identifier so consumer SSR traffic is grouped per-rotating-key rather
- * than per-IP. On no match (or unset env, or missing/wrong prefix),
- * `valid` is `false` and `bucketKey` is `null`.
- */
 export type ConsumerBearerResult =
   | { valid: true; bucketKey: string }
   | { valid: false; bucketKey: null }
 
 /**
- * Validates `Authorization: Bearer <key>` against the
- * `WEB_ADMIN_API_KEYS` CSV. Iterates the full allowlist without
- * short-circuiting on first match, so timing does not reveal which
- * slot matched. Length-mismatched candidates are skipped (the real key
- * length is operator-chosen and not the secret), so timing is
- * constant-time only across same-length entries — the practical
- * guarantee for high-entropy fixed-length keys. When the env var is
- * unset or empty, no header value is accepted.
- *
- * Length comparison uses `Buffer.byteLength` so a non-ASCII allowlist
- * entry (UTF-8 byte length ≠ UTF-16 code-unit length) does not pass
- * the guard and then crash inside `timingSafeEqual`'s equal-length
- * precondition — the call would otherwise throw `RangeError` and
- * surface as a 500 from `createContext`.
- *
- * `null` is returned by `request.headers.get(...)` for missing
- * headers; the caller passes that through unchanged.
+ * SECURITY: iterates the full allowlist without short-circuiting so timing
+ * does not reveal which slot matched. `Buffer.byteLength` precheck avoids
+ * `timingSafeEqual`'s equal-length `RangeError` on non-ASCII entries.
  */
 export function isValidConsumerBearer(
   authHeader: string | null,

--- a/apps/admin/src/auth/principal.test.ts
+++ b/apps/admin/src/auth/principal.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  CONSUMER_BEARER_PRINCIPAL,
   isEditorOrAdmin,
   SYSTEM_PRINCIPAL,
   WORKFLOW_TRIGGER_PRINCIPAL,
@@ -7,6 +8,12 @@ import {
 } from "./principal"
 
 describe("isEditorOrAdmin", () => {
+  // T-01 (ce-code-review): CONSUMER_BEARER must NOT be treated as
+  // editorial-tier. The predicate guards draft-visibility relation paths
+  // (Experience.locales, Video.locales) — a typo widening it to include
+  // CONSUMER_BEARER would silently leak templates / drafts to anonymous
+  // web SSR traffic. Tests every bearer role explicitly so a regression
+  // surfaces here, not at the rate-limit dashboard.
   const cases: Array<[string, Principal | null, boolean]> = [
     ["null (PUBLIC anonymous)", null, false],
     ["explicit PUBLIC principal", { id: null, role: "PUBLIC" }, false],
@@ -17,6 +24,11 @@ describe("isEditorOrAdmin", () => {
     [
       "WORKFLOW_TRIGGER (bearer-key service account)",
       WORKFLOW_TRIGGER_PRINCIPAL,
+      false,
+    ],
+    [
+      "CONSUMER_BEARER (web SSR rate-limit bucket — must NEVER be editorial)",
+      CONSUMER_BEARER_PRINCIPAL({ rateLimitBucketKey: "test-bucket" }),
       false,
     ],
   ]

--- a/apps/admin/src/graphql/types/blocks.ts
+++ b/apps/admin/src/graphql/types/blocks.ts
@@ -800,6 +800,16 @@ SectionBlockRef.implement({
  * Admin Zod `t` discriminator → Pothos GraphQL type name. Used by every
  * union's `resolveType` callback. Exported for drift-CI consumption.
  */
+/**
+ * AC-04 (ce-code-review): the `satisfies` annotation against
+ * `Record<Block["t"], string>` is the load-bearing compile-time check —
+ * `Block["t"]` is the Zod-derived union of all valid discriminator
+ * literals. Adding a new variant to admin's Zod `BlockSchema` without
+ * adding a matching entry here now fails `tsc` directly, before
+ * drift-CI runs. Pairs with the runtime three-way bijection assertion
+ * in blocks.drift.test.ts (which catches typename-typo regressions
+ * that satisfies cannot see — the typename values are strings).
+ */
 export const T_TO_TYPENAME = {
   adventCountdown: "AdventCountdownBlock",
   bibleQuotesCarousel: "BibleQuotesCarouselBlock",
@@ -820,7 +830,10 @@ export const T_TO_TYPENAME = {
   videoCarousel: "VideoCarouselBlock",
   videoHero: "VideoHeroBlock",
   videoRecommendations: "VideoRecommendationsBlock",
-} as const
+} as const satisfies Record<
+  Block["t"] | SectionContentBlockValue["t"] | ContainerContentBlockValue["t"],
+  string
+>
 
 export type BlockKind = keyof typeof T_TO_TYPENAME
 export type BlockTypename = (typeof T_TO_TYPENAME)[BlockKind]

--- a/apps/admin/src/graphql/types/blocks.ts
+++ b/apps/admin/src/graphql/types/blocks.ts
@@ -1,30 +1,11 @@
-// Pothos types for Experience blocks — projects the Zod `BlockSchema`
-// discriminated unions in `src/domain/blocks.ts` onto GraphQL. The
-// `ExperienceLocale.blocks` field switches from a raw `JSON` scalar to a
-// typed `[ExperienceBlock!]!` list, with three discriminated unions covering
-// every block kind admin can store:
+// Pothos types projecting the Zod `BlockSchema` discriminated unions onto
+// GraphQL. Each block is a POJO from the JSON column (not a Prisma model),
+// so registered via `builder.objectRef<Block>`. Mutations still accept
+// `blocks` as `JSON` input — only QUERY OUTPUT is strongly typed.
 //
-//   - `ExperienceBlock`         (top-level, 17 members)
-//   - `SectionContentBlock`     (allowed inside `section.content`, 13 members)
-//   - `ContainerContentBlock`   (allowed inside `container.content`, 10 members)
-//
-// `resolveType` dispatches on the Zod discriminator `t` via `T_TO_TYPENAME`.
-// The underlying value is a POJO parsed from the JSON column on read — NOT a
-// Prisma model — so each block is registered via `builder.objectRef<Block>`
-// rather than `builder.prismaObject`. Mutations on admin
-// (`createExperience` / `updateExperienceLocale`) still accept `blocks` as
-// `JSON` input; only the QUERY OUTPUT shape changes. This input/output
-// asymmetry is intentional: editors send opaque JSON validated by Zod
-// at the service boundary, while readers consume a strongly-typed shape.
-//
-// Drift between Zod and Pothos is caught at test time by
-// `blocks.drift.test.ts`. Adding a new block kind requires four things:
-//   1. New Zod schema + `t` literal in `src/domain/blocks.ts`
-//   2. Append to the appropriate Zod scope union(s)
-//   3. Register the Pothos object type below + add `T_TO_TYPENAME` entry
-//   4. Append to the matching Pothos `builder.unionType` member list
-//
-// All four steps are enforced by the drift test — skip any and CI fails.
+// Adding a new block kind: update Zod schema + scope union(s) + the Pothos
+// type + T_TO_TYPENAME + matching union list. All four are enforced by
+// `blocks.drift.test.ts`.
 //
 // Pre-implementation Zod construct audit (recorded for future drift):
 //   - `.url()` (×25) → projects to `String` (no native URL scalar registered)
@@ -69,10 +50,7 @@ import type {
 import type { z } from "zod"
 import { builder } from "@/graphql/builder"
 
-// -----------------------------------------------------------------------------
-// Typed value helpers — each block POJO mirrors its Zod schema's output type.
-// Pothos `objectRef<T>` produces a builder ref whose resolvers receive `T`.
-// -----------------------------------------------------------------------------
+// Typed value helpers — each block POJO mirrors its Zod schema output.
 
 type AdventCountdownBlock = z.infer<typeof AdventCountdownBlockSchema>
 type BibleQuotesCarouselBlock = z.infer<typeof BibleQuotesCarouselBlockSchema>
@@ -101,11 +79,7 @@ type VideoCarouselItem = z.infer<typeof VideoCarouselItemSchema>
 type VideoHeroBlock = z.infer<typeof VideoHeroBlockSchema>
 type VideoRecommendationsBlock = z.infer<typeof VideoRecommendationsBlockSchema>
 
-/**
- * Resolver-time error thrown when a stored block carries an unknown `t`
- * discriminator (e.g., the JSON column drifted ahead of admin's code). Surfaces
- * as a GraphQL error rather than silently dropping the block.
- */
+/** Surfaces unknown stored `t` discriminators as GraphQL errors instead of silently dropping. */
 export class UnknownBlockKindError extends Error {
   readonly kind: string
   constructor(kind: string) {
@@ -117,9 +91,7 @@ export class UnknownBlockKindError extends Error {
   }
 }
 
-// -----------------------------------------------------------------------------
 // Shared enums
-// -----------------------------------------------------------------------------
 
 const TextHeadingLevelEnum = builder.enumType("TextHeadingLevel", {
   values: {
@@ -164,9 +136,7 @@ const MediaCollectionVariantEnum = builder.enumType("MediaCollectionVariant", {
   } as const,
 })
 
-// `mediaCollection.itemsSource` and `videoCarousel.itemsSource` share the same
-// enum surface in Zod; collapse to one GraphQL enum to avoid two near-identical
-// types.
+// Shared by both `mediaCollection` and `videoCarousel` — one GraphQL enum.
 const ItemsSourceEnum = builder.enumType("ItemsSource", {
   description:
     "Where a collection's items come from. Shared by MediaCollectionBlock.itemsSource and VideoCarouselBlock.itemsSource.",
@@ -207,9 +177,7 @@ const VideoHeroSubheadingSourceEnum = builder.enumType(
   },
 )
 
-// -----------------------------------------------------------------------------
-// Leaf (non-block) object types — embedded inside their parent block
-// -----------------------------------------------------------------------------
+// Leaf (non-block) object types embedded inside their parent block.
 
 const BibleQuoteItemRef = builder.objectRef<BibleQuoteItem>("BibleQuoteItem")
 BibleQuoteItemRef.implement({
@@ -322,11 +290,9 @@ ContainerSlotSpansRef.implement({
   }),
 })
 
-// -----------------------------------------------------------------------------
 // Block object types — one per Zod discriminated-union member.
-// Each `t` field re-exposes the Zod discriminator alongside GraphQL's
-// auto-injected `__typename` so consumers can dispatch on either.
-// -----------------------------------------------------------------------------
+// `t` re-exposes the Zod discriminator alongside `__typename` so consumers
+// can dispatch on either.
 
 const AdventCountdownBlockRef = builder.objectRef<AdventCountdownBlock>(
   "AdventCountdownBlock",
@@ -539,8 +505,7 @@ QuizButtonBlockRef.implement({
     t: t.exposeString("t"),
     sectionKey: t.exposeString("sectionKey", { nullable: true }),
     buttonText: t.exposeString("buttonText"),
-    // The Zod schema enforces a nextstep.is URL pattern via `.regex(...)` at
-    // write time; GraphQL has no pattern scalar, so the wire shape is String.
+    // Zod `.regex(...)` enforces nextstep.is URL at write time; GraphQL has no pattern scalar.
     iframeSrc: t.exposeString("iframeSrc"),
   }),
 })
@@ -749,9 +714,7 @@ ContainerBlockRef.implement({
       nullable: false,
       resolve: (row) => row.content,
     }),
-    // Legacy-tolerated nested-slot payloads. Zod stamps this `z.custom<never>`
-    // (i.e., "accept anything") so old drafts can be opened without throwing.
-    // Wire shape is opaque JSON — consumers should ignore.
+    // Legacy-tolerated nested-slot payloads; opaque JSON — consumers should ignore.
     slots: t.field({
       type: "JSON",
       nullable: true,
@@ -786,30 +749,12 @@ SectionBlockRef.implement({
   }),
 })
 
-// -----------------------------------------------------------------------------
-// Discriminator → typename lookup tables.
+// Discriminator → typename lookup. Bijective; drift-CI asserts round-trip.
 //
-// Each Zod `t` literal maps to exactly one Pothos type name. The mapping is
-// bijective: every typename also appears in `TYPENAME_TO_T`, and the
-// drift-CI test asserts the round-trip. Adding a new block kind requires a
-// new entry here (TypeScript catches missing keys via the index signature
-// at the consumer site; the drift test catches stale entries).
-// -----------------------------------------------------------------------------
-
-/**
- * Admin Zod `t` discriminator → Pothos GraphQL type name. Used by every
- * union's `resolveType` callback. Exported for drift-CI consumption.
- */
-/**
- * AC-04 (ce-code-review): the `satisfies` annotation against
- * `Record<Block["t"], string>` is the load-bearing compile-time check —
- * `Block["t"]` is the Zod-derived union of all valid discriminator
- * literals. Adding a new variant to admin's Zod `BlockSchema` without
- * adding a matching entry here now fails `tsc` directly, before
- * drift-CI runs. Pairs with the runtime three-way bijection assertion
- * in blocks.drift.test.ts (which catches typename-typo regressions
- * that satisfies cannot see — the typename values are strings).
- */
+// The `satisfies Record<Block["t"], string>` is the load-bearing compile-time
+// check — adding a Zod variant without an entry here fails tsc before drift-CI
+// runs. Drift test still catches typename-typo regressions that satisfies
+// cannot see (typename values are strings).
 export const T_TO_TYPENAME = {
   adventCountdown: "AdventCountdownBlock",
   bibleQuotesCarousel: "BibleQuotesCarouselBlock",
@@ -838,10 +783,7 @@ export const T_TO_TYPENAME = {
 export type BlockKind = keyof typeof T_TO_TYPENAME
 export type BlockTypename = (typeof T_TO_TYPENAME)[BlockKind]
 
-/**
- * Inverse table — Pothos typename → admin Zod `t`. Drift-CI asserts this is
- * a true inverse (bijection) of T_TO_TYPENAME.
- */
+/** Inverse of T_TO_TYPENAME; drift-CI asserts the bijection. */
 export const TYPENAME_TO_T: Readonly<Record<BlockTypename, BlockKind>> =
   Object.freeze(
     Object.fromEntries(
@@ -849,12 +791,6 @@ export const TYPENAME_TO_T: Readonly<Record<BlockTypename, BlockKind>> =
     ) as Record<BlockTypename, BlockKind>,
   )
 
-/**
- * Resolve a block POJO to its Pothos type name. Throws `UnknownBlockKindError`
- * when the value's `t` is not a known kind — surfaces as a GraphQL error
- * rather than silently dropping the block. Shared across all three unions
- * because the resolveType contract is the same.
- */
 function resolveBlockTypename(value: { t: string }): BlockTypename {
   const typename = (T_TO_TYPENAME as Record<string, BlockTypename | undefined>)[
     value.t
@@ -865,15 +801,8 @@ function resolveBlockTypename(value: { t: string }): BlockTypename {
   return typename
 }
 
-// -----------------------------------------------------------------------------
-// Unions
-// -----------------------------------------------------------------------------
-
-/**
- * Top-level discriminated union — what `ExperienceLocale.blocks` holds. 17
- * members (the 17 kinds present in `BlockSchema.options`). Excludes
- * `quizButton` (section-only) and `containerSlot` (container-only).
- */
+// Unions — 17 top-level members. Excludes `quizButton` (section-only) and
+// `containerSlot` (container-only).
 export const ExperienceBlock = builder.unionType("ExperienceBlock", {
   description:
     "Discriminated union of every block kind admin's editor can place at the top level of ExperienceLocale.blocks. Wire-discriminate via __typename or the explicit `t` field — both project from the Zod discriminator.",
@@ -899,11 +828,7 @@ export const ExperienceBlock = builder.unionType("ExperienceBlock", {
   resolveType: (value: Block) => resolveBlockTypename(value),
 })
 
-/**
- * Allowed inside `section.content`. 13 members — includes `container` and
- * `quizButton`, deliberately excludes `section` (cannot recurse) and
- * `videoHero` / top-level-only blocks.
- */
+/** 13 members allowed inside `section.content`. Excludes `section` (no recursion) and top-level-only blocks. */
 export const SectionContentBlock = builder.unionType("SectionContentBlock", {
   description:
     "Discriminated union of block kinds allowed inside section.content.",
@@ -925,10 +850,7 @@ export const SectionContentBlock = builder.unionType("SectionContentBlock", {
   resolveType: (value: SectionContentBlockValue) => resolveBlockTypename(value),
 })
 
-/**
- * Allowed inside `container.content`. 10 members — the narrowest scope. No
- * containers, no sections; includes the `containerSlot` divider marker.
- */
+/** 10 members allowed inside `container.content` (narrowest scope). Includes `containerSlot` divider. */
 export const ContainerContentBlock = builder.unionType(
   "ContainerContentBlock",
   {

--- a/apps/web/src/app/[slug]/error.test.tsx
+++ b/apps/web/src/app/[slug]/error.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * UB7 — slug-page error boundary tests.
+ *
+ * The boundary catches typed `WatchPageAdminError` from admin-mode
+ * fetches and renders one of two static UX shapes (NOT_FOUND →
+ * <ExperienceEmpty>, UNAVAILABLE → <ExperienceError> + reset). Anything
+ * else re-throws to Next's segment-default boundary.
+ *
+ * Information-disclosure invariant: `error.message` MUST NEVER appear in
+ * the rendered DOM for either typed branch. Snapshot-style assertions
+ * check this directly.
+ */
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { WatchPageAdminError } from "@/lib/content"
+
+import SlugPageError from "./error"
+
+describe("SlugPageError boundary", () => {
+  let container: HTMLDivElement
+  let root: Root
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    // Suppress NODE_ENV !== "production" console.error from the boundary.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    consoleErrorSpy.mockRestore()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Happy path NOT_FOUND → <ExperienceEmpty>
+  // ---------------------------------------------------------------------------
+
+  it("renders ExperienceEmpty for WatchPageAdminError('NOT_FOUND')", () => {
+    const reset = vi.fn()
+    act(() => {
+      root.render(
+        <SlugPageError
+          error={new WatchPageAdminError("NOT_FOUND")}
+          reset={reset}
+        />,
+      )
+    })
+    expect(container.textContent).toContain("No experience content available")
+    // No reset button on the empty state — matches Strapi-mode inline behavior.
+    expect(container.querySelector("button")).toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Happy path UNAVAILABLE → <ExperienceError> + reset button
+  // ---------------------------------------------------------------------------
+
+  it("renders ExperienceError + reset button for WatchPageAdminError('UNAVAILABLE')", () => {
+    const reset = vi.fn()
+    act(() => {
+      root.render(
+        <SlugPageError
+          error={new WatchPageAdminError("UNAVAILABLE")}
+          reset={reset}
+        />,
+      )
+    })
+    expect(container.textContent).toContain("Failed to load experience")
+    const button = container.querySelector("button")
+    expect(button).not.toBeNull()
+    expect(button?.textContent).toContain("Try again")
+  })
+
+  it("reset callback fires when the Try again button is clicked", () => {
+    const reset = vi.fn()
+    act(() => {
+      root.render(
+        <SlugPageError
+          error={new WatchPageAdminError("UNAVAILABLE")}
+          reset={reset}
+        />,
+      )
+    })
+    const button = container.querySelector("button")
+    expect(button).not.toBeNull()
+    act(() => {
+      button?.click()
+    })
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Information disclosure — error.message MUST NOT reach the DOM
+  // ---------------------------------------------------------------------------
+
+  it("NEVER renders error.message in DOM for NOT_FOUND (typed branch)", () => {
+    const reset = vi.fn()
+    const SECRET_FRAGMENT = "INTERNAL_STACK_FRAGMENT_DO_NOT_LEAK_12345"
+    const errorWithSecret = new WatchPageAdminError("NOT_FOUND", {
+      cause: new Error(SECRET_FRAGMENT),
+    })
+    // The error's own message is built from the code; verify the secret
+    // from `cause` doesn't propagate either.
+    errorWithSecret.message = SECRET_FRAGMENT
+    act(() => {
+      root.render(<SlugPageError error={errorWithSecret} reset={reset} />)
+    })
+    expect(container.textContent).not.toContain(SECRET_FRAGMENT)
+  })
+
+  it("NEVER renders error.message in DOM for UNAVAILABLE (typed branch)", () => {
+    const reset = vi.fn()
+    const SECRET_FRAGMENT = "DB_CONNECTION_STRING_DO_NOT_LEAK_67890"
+    const errorWithSecret = new WatchPageAdminError("UNAVAILABLE")
+    errorWithSecret.message = SECRET_FRAGMENT
+    act(() => {
+      root.render(<SlugPageError error={errorWithSecret} reset={reset} />)
+    })
+    expect(container.textContent).not.toContain(SECRET_FRAGMENT)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Catch-all: non-typed errors re-throw to Next's default boundary
+  // ---------------------------------------------------------------------------
+
+  it("re-throws when error is a generic Error (not WatchPageAdminError)", () => {
+    const reset = vi.fn()
+    expect(() => {
+      act(() => {
+        root.render(
+          <SlugPageError error={new Error("unexpected")} reset={reset} />,
+        )
+      })
+    }).toThrow("unexpected")
+  })
+
+  it("re-throws when WatchPageAdminError has an unknown code (defensive)", () => {
+    const reset = vi.fn()
+    // Forge an off-band code value via Object.defineProperty — guards
+    // against a future change widening the code union without updating
+    // this boundary's switch arms. The readonly TS modifier blocks
+    // simple assignment; defineProperty bypasses TS but exercises the
+    // runtime branch.
+    const offBandError = new WatchPageAdminError("NOT_FOUND")
+    Object.defineProperty(offBandError, "code", {
+      value: "UNKNOWN_NEW_CODE",
+      writable: true,
+      configurable: true,
+    })
+    expect(() => {
+      act(() => {
+        root.render(<SlugPageError error={offBandError} reset={reset} />)
+      })
+    }).toThrow()
+  })
+})

--- a/apps/web/src/app/[slug]/error.tsx
+++ b/apps/web/src/app/[slug]/error.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { ExperienceEmpty } from "@/components/ExperienceEmpty"
+import { ExperienceError } from "@/components/ExperienceError"
+import { WatchPageAdminError } from "@/lib/content"
+
+/**
+ * Slug-page error boundary — additive in admin mode only.
+ *
+ * The boundary catches the typed `WatchPageAdminError` that
+ * `fetchSlugExperience` throws when admin returns null or fails (admin
+ * mode only; Strapi-mode errors continue through the existing sentinel
+ * path in `page.tsx` and never reach this boundary).
+ *
+ * Information-disclosure discipline: `error.message` is NEVER rendered as
+ * visible text. The classifier dispatches on `error.code` and renders one
+ * of two static UX shapes that match the Strapi-mode inline rendering of
+ * `<ExperienceEmpty>` / `<ExperienceError>` — end users see no behavior
+ * difference between admin-mode and Strapi-mode failures.
+ *
+ * Catch-all behavior: any non-typed error that escapes here (defense
+ * against unexpected throws) re-throws to Next.js's segment-default error
+ * boundary. That route emits a generic 500 page without echoing the
+ * underlying error.message. The boundary's safe contract: "renders
+ * `<ExperienceEmpty>` for NOT_FOUND, `<ExperienceError>` with reset for
+ * UNAVAILABLE, re-throws everything else."
+ *
+ * Pattern follows `apps/web/src/app/[slug]/[locale]/error.tsx`.
+ *
+ * Plan reference: docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md UB7.
+ */
+export default function SlugPageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[slug-page] error boundary caught:", error)
+    }
+  }, [error])
+
+  if (error instanceof WatchPageAdminError) {
+    if (error.code === "NOT_FOUND") {
+      return <ExperienceEmpty />
+    }
+    if (error.code === "UNAVAILABLE") {
+      // Generic operator-facing message — NEVER pass error.message through.
+      // ExperienceError additionally sanitizes via its KNOWN_ERRORS table;
+      // we feed it a stable "service unavailable" string that maps to its
+      // generic fallback, so admin-mode UNAVAILABLE and Strapi-mode
+      // generic-error renderings stay visually consistent.
+      return (
+        <main className="min-h-screen bg-stone-900 text-stone-100">
+          <ExperienceError message="Service temporarily unavailable" />
+          <div className="mx-auto flex max-w-md flex-col items-center gap-4 px-4 py-8">
+            <button
+              type="button"
+              onClick={reset}
+              className="rounded-full border border-amber-400 px-4 py-2 text-sm font-semibold text-amber-400 transition hover:bg-amber-400 hover:text-stone-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              Try again
+            </button>
+          </div>
+        </main>
+      )
+    }
+  }
+
+  // Unexpected error — re-throw to Next's segment-default boundary.
+  // The default renders a generic 500 page without echoing error.message.
+  throw error
+}

--- a/apps/web/src/app/[slug]/error.tsx
+++ b/apps/web/src/app/[slug]/error.tsx
@@ -7,29 +7,9 @@ import { ExperienceError } from "@/components/ExperienceError"
 import { WatchPageAdminError } from "@/lib/content"
 
 /**
- * Slug-page error boundary — additive in admin mode only.
- *
- * The boundary catches the typed `WatchPageAdminError` that
- * `fetchSlugExperience` throws when admin returns null or fails (admin
- * mode only; Strapi-mode errors continue through the existing sentinel
- * path in `page.tsx` and never reach this boundary).
- *
- * Information-disclosure discipline: `error.message` is NEVER rendered as
- * visible text. The classifier dispatches on `error.code` and renders one
- * of two static UX shapes that match the Strapi-mode inline rendering of
- * `<ExperienceEmpty>` / `<ExperienceError>` — end users see no behavior
- * difference between admin-mode and Strapi-mode failures.
- *
- * Catch-all behavior: any non-typed error that escapes here (defense
- * against unexpected throws) re-throws to Next.js's segment-default error
- * boundary. That route emits a generic 500 page without echoing the
- * underlying error.message. The boundary's safe contract: "renders
- * `<ExperienceEmpty>` for NOT_FOUND, `<ExperienceError>` with reset for
- * UNAVAILABLE, re-throws everything else."
- *
- * Pattern follows `apps/web/src/app/[slug]/[locale]/error.tsx`.
- *
- * Plan reference: docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md UB7.
+ * Slug-page error boundary, additive for admin-mode WatchPageAdminError
+ * throws. `error.message` MUST NEVER render (info disclosure). Non-typed
+ * errors re-throw to Next's segment-default. See plan-003 UB7.
  */
 export default function SlugPageError({
   error,
@@ -49,11 +29,8 @@ export default function SlugPageError({
       return <ExperienceEmpty />
     }
     if (error.code === "UNAVAILABLE") {
-      // Generic operator-facing message — NEVER pass error.message through.
-      // ExperienceError additionally sanitizes via its KNOWN_ERRORS table;
-      // we feed it a stable "service unavailable" string that maps to its
-      // generic fallback, so admin-mode UNAVAILABLE and Strapi-mode
-      // generic-error renderings stay visually consistent.
+      // SECURITY: never pass error.message; feed ExperienceError a stable
+      // string that maps to its KNOWN_ERRORS generic fallback.
       return (
         <main className="min-h-screen bg-stone-900 text-stone-100">
           <ExperienceError message="Service temporarily unavailable" />
@@ -71,7 +48,6 @@ export default function SlugPageError({
     }
   }
 
-  // Unexpected error — re-throw to Next's segment-default boundary.
-  // The default renders a generic 500 page without echoing error.message.
+  // Re-throw to Next's segment-default (generic 500 without echoing message).
   throw error
 }

--- a/apps/web/src/app/[slug]/error.tsx
+++ b/apps/web/src/app/[slug]/error.tsx
@@ -4,13 +4,27 @@ import { useEffect } from "react"
 
 import { ExperienceEmpty } from "@/components/ExperienceEmpty"
 import { ExperienceError } from "@/components/ExperienceError"
-import { WatchPageAdminError } from "@/lib/content"
 
 /**
  * Slug-page error boundary, additive for admin-mode WatchPageAdminError
  * throws. `error.message` MUST NEVER render (info disclosure). Non-typed
  * errors re-throw to Next's segment-default. See plan-003 UB7.
+ *
+ * F7 (ce-code-review): duck-type the error rather than `instanceof`
+ * WatchPageAdminError. Next.js serializes thrown errors across the
+ * SSR→client boundary into plain shapes — class identity is unreliable.
+ * The tests construct the error directly in jsdom, masking the gap.
+ * Checking `name` + `code` shape is unconditionally safer.
  */
+function isWatchPageAdminError(
+  error: unknown,
+): error is { name: "WatchPageAdminError"; code: "NOT_FOUND" | "UNAVAILABLE" } {
+  if (error == null || typeof error !== "object") return false
+  const e = error as { name?: unknown; code?: unknown }
+  if (e.name !== "WatchPageAdminError") return false
+  return e.code === "NOT_FOUND" || e.code === "UNAVAILABLE"
+}
+
 export default function SlugPageError({
   error,
   reset,
@@ -24,7 +38,7 @@ export default function SlugPageError({
     }
   }, [error])
 
-  if (error instanceof WatchPageAdminError) {
+  if (isWatchPageAdminError(error)) {
     if (error.code === "NOT_FOUND") {
       return <ExperienceEmpty />
     }

--- a/apps/web/src/app/[slug]/page.test.tsx
+++ b/apps/web/src/app/[slug]/page.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * U9 (plan-003 PR-B) — slug-page feature-flag short-circuit tests.
+ *
+ * Runs in the default `node` environment (NOT jsdom): the page module
+ * reads `env.FORGE_DISABLE_WATCH_ROUTES` at module scope, and t3-oss's
+ * `@t3-oss/env-nextjs` throws "Attempted to access a server-side
+ * environment variable on the client" when `window` is defined (the
+ * jsdom env defines it). `react-dom/server`'s `renderToStaticMarkup`
+ * works in node without DOM globals.
+ *
+ * Verifies that `FORGE_DISABLE_WATCH_ROUTES`:
+ *   - When set and the route matches: <MaintenanceFallback> renders BEFORE
+ *     any data fetch (`resolveWatchPage` MUST NOT be called).
+ *   - When unset: normal rendering proceeds through `resolveWatchPage`.
+ *   - When malformed (entries missing the leading "/"): warns and
+ *     falls-through to normal rendering (a typo'd entry MUST NOT brick
+ *     the route).
+ *
+ * The `DISABLED_ROUTES` set is built at module scope, so each test
+ * uses `vi.resetModules()` + `vi.doMock()` to re-evaluate the page module
+ * with the appropriate env value.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server"
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest"
+
+const ORIGINAL_FORGE_DISABLE_WATCH_ROUTES =
+  process.env.FORGE_DISABLE_WATCH_ROUTES
+
+async function loadPageWithEnv(envValue: string | undefined): Promise<{
+  SlugPage: (props: {
+    params: Promise<{ slug: string }>
+  }) => Promise<React.ReactElement>
+  resolveWatchPageMock: Mock
+}> {
+  // Reset modules so the page module re-evaluates its module-scope
+  // DISABLED_ROUTES initializer against the new env value.
+  vi.resetModules()
+  if (envValue === undefined) {
+    delete process.env.FORGE_DISABLE_WATCH_ROUTES
+  } else {
+    process.env.FORGE_DISABLE_WATCH_ROUTES = envValue
+  }
+
+  const resolveWatchPageMock = vi.fn().mockResolvedValue({
+    data: { kind: "experience", experience: { blocks: [] } },
+    error: null,
+  })
+
+  vi.doMock("@/lib/content", () => ({
+    resolveWatchPage: resolveWatchPageMock,
+    isWatchPageMissingError: (_e: unknown) => false,
+  }))
+  vi.doMock("@/lib/experience-metadata", () => ({
+    getWatchPageMetadata: vi.fn().mockResolvedValue({}),
+  }))
+  vi.doMock("@/components/sections", () => ({
+    SectionRenderer: () => null,
+  }))
+
+  const mod = await import("./page")
+  return {
+    SlugPage: mod.default as (props: {
+      params: Promise<{ slug: string }>
+    }) => Promise<React.ReactElement>,
+    resolveWatchPageMock,
+  }
+}
+
+describe("SlugPage — FORGE_DISABLE_WATCH_ROUTES short-circuit", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    vi.doUnmock("@/lib/content")
+    vi.doUnmock("@/lib/experience-metadata")
+    vi.doUnmock("@/components/sections")
+    if (ORIGINAL_FORGE_DISABLE_WATCH_ROUTES === undefined) {
+      delete process.env.FORGE_DISABLE_WATCH_ROUTES
+    } else {
+      process.env.FORGE_DISABLE_WATCH_ROUTES =
+        ORIGINAL_FORGE_DISABLE_WATCH_ROUTES
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Happy path: flag set + route matches → MaintenanceFallback renders
+  // ---------------------------------------------------------------------------
+
+  it("renders MaintenanceFallback when FORGE_DISABLE_WATCH_ROUTES matches the slug", async () => {
+    const { SlugPage, resolveWatchPageMock } =
+      await loadPageWithEnv("/broken-slug")
+
+    const element = await SlugPage({
+      params: Promise.resolve({ slug: "broken-slug" }),
+    })
+    const html = renderToStaticMarkup(element)
+
+    expect(html).toContain("Temporarily unavailable")
+    expect(html).toContain("undergoing maintenance")
+    // Data fetch MUST be short-circuited BEFORE resolveWatchPage runs.
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
+  })
+
+  it("renders MaintenanceFallback for an entry mid-CSV (whitespace tolerated)", async () => {
+    const { SlugPage, resolveWatchPageMock } = await loadPageWithEnv(
+      "/other, /broken-slug ,/another",
+    )
+
+    const element = await SlugPage({
+      params: Promise.resolve({ slug: "broken-slug" }),
+    })
+    const html = renderToStaticMarkup(element)
+
+    expect(html).toContain("Temporarily unavailable")
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
+  })
+
+  it("does NOT short-circuit non-matching slugs even when the flag is set", async () => {
+    const { SlugPage, resolveWatchPageMock } =
+      await loadPageWithEnv("/broken-slug")
+
+    await SlugPage({
+      params: Promise.resolve({ slug: "ok-slug" }),
+    })
+
+    // resolveWatchPage IS called for non-matching slugs.
+    expect(resolveWatchPageMock).toHaveBeenCalledTimes(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Flag unset → normal rendering
+  // ---------------------------------------------------------------------------
+
+  it("renders normally (no short-circuit) when FORGE_DISABLE_WATCH_ROUTES is unset", async () => {
+    const { SlugPage, resolveWatchPageMock } = await loadPageWithEnv(undefined)
+
+    await SlugPage({
+      params: Promise.resolve({ slug: "any-slug" }),
+    })
+
+    expect(resolveWatchPageMock).toHaveBeenCalledTimes(1)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("renders normally when FORGE_DISABLE_WATCH_ROUTES is an empty string", async () => {
+    const { SlugPage, resolveWatchPageMock } = await loadPageWithEnv("")
+
+    await SlugPage({
+      params: Promise.resolve({ slug: "any-slug" }),
+    })
+
+    expect(resolveWatchPageMock).toHaveBeenCalledTimes(1)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Malformed CSV → warn-and-fall-through (typo does NOT brick the route)
+  // ---------------------------------------------------------------------------
+
+  it("warns and falls through when CSV entries are missing the leading '/'", async () => {
+    // Note: "broken-slug" (no leading slash) is the operator typo. The
+    // page-module match key is `/${slug}` so this entry can never match —
+    // the warn surfaces the misconfig in deploy logs.
+    const { SlugPage, resolveWatchPageMock } =
+      await loadPageWithEnv("broken-slug")
+
+    await SlugPage({
+      params: Promise.resolve({ slug: "broken-slug" }),
+    })
+
+    // Falls through to normal rendering.
+    expect(resolveWatchPageMock).toHaveBeenCalledTimes(1)
+    // Operator-visible warn emitted at module import time.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("do not start with"),
+    )
+  })
+
+  it("warns about the malformed entry but still honors well-formed entries on the same CSV", async () => {
+    const { SlugPage, resolveWatchPageMock } = await loadPageWithEnv(
+      "bad-no-slash,/good-slash",
+    )
+
+    // Well-formed entry still short-circuits.
+    const element = await SlugPage({
+      params: Promise.resolve({ slug: "good-slash" }),
+    })
+    const html = renderToStaticMarkup(element)
+    expect(html).toContain("Temporarily unavailable")
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
+
+    // Warn fired for the malformed entry.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("bad-no-slash"),
+    )
+  })
+})

--- a/apps/web/src/app/[slug]/page.tsx
+++ b/apps/web/src/app/[slug]/page.tsx
@@ -5,8 +5,45 @@ import { getWatchPageMetadata } from "@/lib/experience-metadata"
 import { SectionRenderer, type Section } from "@/components/sections"
 import { ExperienceEmpty } from "@/components/ExperienceEmpty"
 import { ExperienceError } from "@/components/ExperienceError"
+import { MaintenanceFallback } from "@/components/MaintenanceFallback"
+import { env } from "@/env"
 
 export const revalidate = 60
+
+// U9 (plan-003 PR-B) — emergency-only route disable.
+//
+// `FORGE_DISABLE_WATCH_ROUTES` is parsed ONCE at module scope. Reading
+// per-request via headers()/cookies() would silently disable Next's Full
+// Route Cache (see docs/solutions/web/nextjs-headers-defeats-route-cache.md);
+// reading at module scope is load-bearing for ISR.
+//
+// Parse rules:
+//   - Comma-separated route paths. Whitespace trimmed per entry.
+//   - Empty entries (consecutive commas, leading/trailing whitespace) skipped.
+//   - Entries are matched verbatim against `/${slug}` in the page component.
+//   - Unknown/malformed values warn-and-fall-through: a typo'd entry does
+//     NOT brick rendering — it just doesn't disable anything. Visible
+//     console.warn surfaces the misconfig in deploy logs.
+//
+// Runbook reference: docs/admin-core-migration/cutover-runbook.md "Layer 1".
+const DISABLED_ROUTES: ReadonlySet<string> = (() => {
+  const raw = env.FORGE_DISABLE_WATCH_ROUTES
+  if (raw == null || raw === "") return new Set()
+  const entries = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  // Surface entries that don't look like route paths so an operator who
+  // types `foo` instead of `/foo` sees the warn in deploy logs rather
+  // than silently shipping a non-matching flag.
+  const malformed = entries.filter((s) => !s.startsWith("/"))
+  if (malformed.length > 0 && typeof console !== "undefined") {
+    console.warn(
+      `[slug-page] FORGE_DISABLE_WATCH_ROUTES entries do not start with "/" (${malformed.join(", ")}); these will not match any slug. Expected format: "/some-slug,/another-slug".`,
+    )
+  }
+  return new Set(entries)
+})()
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -25,6 +62,14 @@ export async function generateMetadata({
 
 export default async function SlugPage({ params }: PageProps) {
   const { slug } = await params
+
+  // U9 emergency rollback — short-circuit BEFORE any data fetch when the
+  // requested route is in the disable set. Static maintenance UX. Reads
+  // from the module-scope `DISABLED_ROUTES` set; no per-request env read.
+  if (DISABLED_ROUTES.has(`/${slug}`)) {
+    return <MaintenanceFallback />
+  }
+
   const locale = isLocale(slug) ? slug : DEFAULT_LOCALE
 
   const result = await resolveWatchPage(

--- a/apps/web/src/app/[slug]/page.tsx
+++ b/apps/web/src/app/[slug]/page.tsx
@@ -10,22 +10,9 @@ import { env } from "@/env"
 
 export const revalidate = 60
 
-// U9 (plan-003 PR-B) — emergency-only route disable.
-//
-// `FORGE_DISABLE_WATCH_ROUTES` is parsed ONCE at module scope. Reading
-// per-request via headers()/cookies() would silently disable Next's Full
-// Route Cache (see docs/solutions/web/nextjs-headers-defeats-route-cache.md);
-// reading at module scope is load-bearing for ISR.
-//
-// Parse rules:
-//   - Comma-separated route paths. Whitespace trimmed per entry.
-//   - Empty entries (consecutive commas, leading/trailing whitespace) skipped.
-//   - Entries are matched verbatim against `/${slug}` in the page component.
-//   - Unknown/malformed values warn-and-fall-through: a typo'd entry does
-//     NOT brick rendering — it just doesn't disable anything. Visible
-//     console.warn surfaces the misconfig in deploy logs.
-//
-// Runbook reference: docs/admin-core-migration/cutover-runbook.md "Layer 1".
+// Parsed once at module scope — per-request reads via headers()/cookies()
+// would disable Next's Full Route Cache.
+// See docs/solutions/web/nextjs-headers-defeats-route-cache.md.
 const DISABLED_ROUTES: ReadonlySet<string> = (() => {
   const raw = env.FORGE_DISABLE_WATCH_ROUTES
   if (raw == null || raw === "") return new Set()
@@ -33,9 +20,8 @@ const DISABLED_ROUTES: ReadonlySet<string> = (() => {
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
-  // Surface entries that don't look like route paths so an operator who
-  // types `foo` instead of `/foo` sees the warn in deploy logs rather
-  // than silently shipping a non-matching flag.
+  // Warn on entries missing the leading `/` so operators see the typo in
+  // deploy logs rather than shipping a silently-non-matching flag.
   const malformed = entries.filter((s) => !s.startsWith("/"))
   if (malformed.length > 0 && typeof console !== "undefined") {
     console.warn(
@@ -63,9 +49,7 @@ export async function generateMetadata({
 export default async function SlugPage({ params }: PageProps) {
   const { slug } = await params
 
-  // U9 emergency rollback — short-circuit BEFORE any data fetch when the
-  // requested route is in the disable set. Static maintenance UX. Reads
-  // from the module-scope `DISABLED_ROUTES` set; no per-request env read.
+  // Emergency rollback — short-circuit before any data fetch.
   if (DISABLED_ROUTES.has(`/${slug}`)) {
     return <MaintenanceFallback />
   }

--- a/apps/web/src/components/MaintenanceFallback.tsx
+++ b/apps/web/src/components/MaintenanceFallback.tsx
@@ -1,0 +1,26 @@
+/**
+ * Static maintenance fallback rendered when `FORGE_DISABLE_WATCH_ROUTES`
+ * lists the current slug. Layer 1 of the cutover-runbook rollback story —
+ * the fastest emergency rollback surface (seconds; no redeploy).
+ *
+ * Intentionally static: NO admin/Strapi fetch, NO dynamic data, NO client
+ * interactivity. This component is the failsafe — every dependency it
+ * pulls in is another way for the failsafe to fail. Mirrors the shape of
+ * <ExperienceEmpty> / <ExperienceError> so layout regressions are
+ * impossible.
+ *
+ * Plan reference: docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md U9.
+ * Runbook reference: docs/admin-core-migration/cutover-runbook.md "Layer 1".
+ */
+export function MaintenanceFallback() {
+  return (
+    <main className="flex min-h-[40vh] flex-col items-center justify-center gap-2 p-8">
+      <h1 className="text-xl font-semibold text-stone-200">
+        Temporarily unavailable
+      </h1>
+      <p className="text-base text-stone-400">
+        This page is undergoing maintenance. Please check back shortly.
+      </p>
+    </main>
+  )
+}

--- a/apps/web/src/components/MaintenanceFallback.tsx
+++ b/apps/web/src/components/MaintenanceFallback.tsx
@@ -1,16 +1,8 @@
 /**
- * Static maintenance fallback rendered when `FORGE_DISABLE_WATCH_ROUTES`
- * lists the current slug. Layer 1 of the cutover-runbook rollback story —
- * the fastest emergency rollback surface (seconds; no redeploy).
- *
- * Intentionally static: NO admin/Strapi fetch, NO dynamic data, NO client
- * interactivity. This component is the failsafe — every dependency it
- * pulls in is another way for the failsafe to fail. Mirrors the shape of
- * <ExperienceEmpty> / <ExperienceError> so layout regressions are
- * impossible.
- *
- * Plan reference: docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md U9.
- * Runbook reference: docs/admin-core-migration/cutover-runbook.md "Layer 1".
+ * Static fallback for slugs listed in FORGE_DISABLE_WATCH_ROUTES. Fastest
+ * emergency rollback (seconds; no redeploy). MUST stay static — no fetch,
+ * no dynamic data, no client interactivity. Every dependency is another
+ * way the failsafe can fail.
  */
 export function MaintenanceFallback() {
   return (

--- a/apps/web/src/components/sections/index.tsx
+++ b/apps/web/src/components/sections/index.tsx
@@ -66,7 +66,7 @@ async function VideoRecommendationsBlock({
  * `section: Section` param once U6 widens `Section`; the admin
  * typename cases are wired now so the U6 patch stays small.
  */
-const ADMIN_BLOCK_TYPENAMES = new Set<string>([
+const ADMIN_BLOCK_TYPENAMES_LIST = [
   "MediaCollectionBlock",
   "PromoBannerBlock",
   "InfoBlocksBlock",
@@ -84,10 +84,14 @@ const ADMIN_BLOCK_TYPENAMES = new Set<string>([
   "NavigationCarouselBlock",
   "CardBlock",
   "VideoRecommendationsBlock",
-])
+] as const
+type AdminBlockTypename = (typeof ADMIN_BLOCK_TYPENAMES_LIST)[number]
+const ADMIN_BLOCK_TYPENAMES: ReadonlySet<string> = new Set(
+  ADMIN_BLOCK_TYPENAMES_LIST,
+)
 
 type AnyBlock = {
-  readonly __typename?: string | null
+  readonly __typename?: AdminBlockTypename | string | null
 } & Record<string, unknown>
 
 function renderAdminBlock(
@@ -231,8 +235,24 @@ function renderAdminBlock(
       }
       return null
     }
-    default:
+    default: {
+      // F6 (ce-code-review): if this branch fires for a typename in
+      // ADMIN_BLOCK_TYPENAMES_LIST, the dispatch set and the switch have
+      // drifted. Dev-warn loudly. Compile-time exhaustiveness would
+      // require a stricter __typename type — AnyBlock keeps the loose
+      // `string | null` so non-admin payloads (Strapi typenames) still
+      // type-pass at the call site.
+      if (
+        process.env.NODE_ENV === "development" &&
+        typeof block.__typename === "string" &&
+        ADMIN_BLOCK_TYPENAMES.has(block.__typename)
+      ) {
+        console.warn(
+          `[sections] admin typename "${block.__typename}" is in ADMIN_BLOCK_TYPENAMES but not handled by renderAdminBlock — switch/set are out of sync.`,
+        )
+      }
       return null
+    }
   }
 }
 

--- a/apps/web/src/components/sections/index.tsx
+++ b/apps/web/src/components/sections/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import type { RouteVideo, Section } from "@/lib/content"
 import { MediaCollection } from "./MediaCollection"
 import { PromoBanner } from "./PromoBanner"
@@ -40,6 +41,201 @@ async function VideoRecommendationsBlock({
   )
 }
 
+/**
+ * Set of admin block typenames the renderer dispatch handles, derived
+ * from the `ExperienceBlock` union members in apps/admin/schema.graphql.
+ * The dispatch routes admin payloads to the same per-kind renderer the
+ * Strapi cases use because admin fragments in `@forge/graphql`'s
+ * `admin/fragments` sub-export adopt field aliases that match the
+ * Strapi fragment vocabulary.
+ *
+ * Two known shape diffs the renderers tolerate at runtime:
+ *
+ *   1. Block-level `id` — Strapi blocks carry a string id; admin
+ *      typed-union blocks don't. Renderers using `<section id={id}>`
+ *      emit no id attribute on admin; section anchor lookups use
+ *      `data-section-key` (from `sectionKey`), not `id`.
+ *   2. `MediaCollection.items[].video` / `imageOverride` — Strapi
+ *      joins the related Video row. Admin returns FLAT `videoId` +
+ *      `imageUrl` only. `enrichment.ts` falls back to `titleOverride`
+ *      and `imageUrl` when the join is absent; videoId hydration is a
+ *      U6+ concern (out of U5 scope).
+ *
+ * The dispatch param type stays `Section` (Strapi-derived) — content.ts
+ * is U6's scope. Admin payloads will reach this dispatch via the same
+ * `section: Section` param once U6 widens `Section`; the admin
+ * typename cases are wired now so the U6 patch stays small.
+ */
+const ADMIN_BLOCK_TYPENAMES = new Set<string>([
+  "MediaCollectionBlock",
+  "PromoBannerBlock",
+  "InfoBlocksBlock",
+  "CtaBlock",
+  "VideoHeroBlock",
+  "VideoBlock",
+  "BibleQuotesCarouselBlock",
+  "TextBlock",
+  "AdventCountdownBlock",
+  "EasterDatesBlock",
+  "ContainerBlock",
+  "SectionBlock",
+  "RelatedQuestionsBlock",
+  "VideoCarouselBlock",
+  "NavigationCarouselBlock",
+  "CardBlock",
+  "VideoRecommendationsBlock",
+])
+
+type AnyBlock = {
+  readonly __typename?: string | null
+} & Record<string, unknown>
+
+function renderAdminBlock(
+  block: AnyBlock,
+  routeVideo: RouteVideo | null | undefined,
+): ReactNode {
+  switch (block.__typename) {
+    case "MediaCollectionBlock":
+      return (
+        <MediaCollection
+          data={
+            block as unknown as Parameters<typeof MediaCollection>[0]["data"]
+          }
+          routeVideo={routeVideo}
+        />
+      )
+    case "PromoBannerBlock":
+      return (
+        <PromoBanner
+          data={block as unknown as Parameters<typeof PromoBanner>[0]["data"]}
+        />
+      )
+    case "InfoBlocksBlock":
+      return (
+        <InfoBlocks
+          data={block as unknown as Parameters<typeof InfoBlocks>[0]["data"]}
+        />
+      )
+    case "CtaBlock":
+      return (
+        <CTASection
+          data={block as unknown as Parameters<typeof CTASection>[0]["data"]}
+        />
+      )
+    case "VideoHeroBlock":
+      return (
+        <VideoHero
+          data={block as unknown as Parameters<typeof VideoHero>[0]["data"]}
+          routeVideo={routeVideo}
+        />
+      )
+    case "VideoBlock":
+      return (
+        <Video
+          data={block as unknown as Parameters<typeof Video>[0]["data"]}
+          routeVideo={routeVideo}
+        />
+      )
+    case "BibleQuotesCarouselBlock":
+      return (
+        <BibleQuotesCarousel
+          data={
+            block as unknown as Parameters<
+              typeof BibleQuotesCarousel
+            >[0]["data"]
+          }
+        />
+      )
+    case "TextBlock":
+      return (
+        <Text data={block as unknown as Parameters<typeof Text>[0]["data"]} />
+      )
+    case "AdventCountdownBlock":
+      return (
+        <AdventCountdown
+          data={
+            block as unknown as Parameters<typeof AdventCountdown>[0]["data"]
+          }
+        />
+      )
+    case "EasterDatesBlock":
+      return (
+        <EasterDates
+          data={block as unknown as Parameters<typeof EasterDates>[0]["data"]}
+        />
+      )
+    case "ContainerBlock":
+      return (
+        <Container
+          data={block as unknown as Parameters<typeof Container>[0]["data"]}
+          routeVideo={routeVideo}
+        />
+      )
+    case "SectionBlock":
+      return (
+        <SectionBlock
+          data={block as unknown as Parameters<typeof SectionBlock>[0]["data"]}
+          routeVideo={routeVideo}
+        />
+      )
+    case "RelatedQuestionsBlock":
+      return (
+        <RelatedQuestions
+          data={
+            block as unknown as Parameters<typeof RelatedQuestions>[0]["data"]
+          }
+        />
+      )
+    case "VideoCarouselBlock":
+      return (
+        <CarouselVideo
+          data={block as unknown as Parameters<typeof CarouselVideo>[0]["data"]}
+        />
+      )
+    case "NavigationCarouselBlock":
+      return (
+        <NavigationCarousel
+          data={
+            block as unknown as Parameters<typeof NavigationCarousel>[0]["data"]
+          }
+        />
+      )
+    case "CardBlock":
+      // CardBlock has no Strapi precedent and no renderer yet. The
+      // dispatch slot is reserved so the case-exhaustiveness intent
+      // stays explicit — when a CardBlock renderer lands, route here.
+      if (process.env.NODE_ENV === "development") {
+        console.warn(
+          "[sections] CardBlock dispatch reached but no renderer is wired yet.",
+        )
+      }
+      return null
+    case "VideoRecommendationsBlock": {
+      // Admin's typed VideoRecommendationsBlock carries flat fields:
+      // sourceVideoId / sourceSceneIndex / limit / title. There is no
+      // joined `sourceVideo.slug` — admin returns the bare cuid. The
+      // dispatch needs a slug to fetch recommendations; U6 will
+      // resolve videoId → slug at the boundary. Until then, dev-warn.
+      const adminBlock = block as {
+        sourceVideoId?: string | null
+        title?: string | null
+        limit?: number | null
+      }
+      if (process.env.NODE_ENV === "development") {
+        console.warn(
+          "[sections] VideoRecommendationsBlock dispatch reached before U6 hydration;",
+          "videoId=",
+          adminBlock.sourceVideoId,
+          "(needs slug to render).",
+        )
+      }
+      return null
+    }
+    default:
+      return null
+  }
+}
+
 export function ExperienceSectionRenderer({
   section,
   routeVideo,
@@ -47,6 +243,16 @@ export function ExperienceSectionRenderer({
   section: Section
   routeVideo?: RouteVideo | null
 }) {
+  // Admin-shape dispatch — only reachable post-U6 when content.ts cuts
+  // over. The Strapi `Section` discriminator union doesn't include the
+  // admin typenames, so the check goes through a loose-typed view first
+  // and short-circuits before TS's narrowing kicks in below.
+  const typename = (section as { readonly __typename?: string | null })
+    .__typename
+  if (typename != null && ADMIN_BLOCK_TYPENAMES.has(typename)) {
+    return renderAdminBlock(section as unknown as AnyBlock, routeVideo)
+  }
+
   switch (section.__typename) {
     case "ComponentSectionsMediaCollection":
       return <MediaCollection data={section} routeVideo={routeVideo} />

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -87,6 +87,14 @@ export const env = createEnv({
     // newline from a copy-paste) don't brick boot — common operator-
     // typo failure modes that the runtime narrower can't recover from
     // because the schema rejects first.
+    // U4 (plan-003) collapses the ACTIVE ContentApiMode set to two values
+    // ("strapi" | "admin") in `content-api-mode.ts`. The env-level enum
+    // intentionally remains permissive over the four historical strings
+    // so operators who still have `dual-read` or `admin-with-fallback`
+    // set in Doppler don't brick boot — the runtime narrower coerces
+    // legacy values to "strapi" with a warn (soft-removal, not hard
+    // schema rejection). Once Strapi removes (R3), the U5 deletion PR
+    // collapses both this enum and the narrower to a single value.
     FORGE_CONTENT_API: z
       .preprocess(
         (val) => (typeof val === "string" ? val.trim().toLowerCase() : val),
@@ -147,6 +155,27 @@ export const env = createEnv({
         { message: "unreachable" },
       )
       .optional(),
+    // U4 (plan-003) — bearer key web's SSR sends in `Authorization: Bearer`
+    // to admin so traffic buckets as `consumer:<key>` rather than
+    // `public:<railway-egress-ip>`. Without this, web's SSR fanout collides
+    // on Railway's shared egress IP and self-DoSes admin's per-IP rate limit.
+    //
+    // The key carries NO permissions — admin's `CONSUMER_BEARER` principal
+    // sees exactly what PUBLIC sees. The bearer is an identity LABEL for
+    // rate-limiting, not an authorization credential.
+    //
+    // OPTIONAL: when unset, web omits the header and admin treats the
+    // request as anonymous. Default `FORGE_CONTENT_API=strapi` doesn't need
+    // this set. Required-without-default would brick Railway deploys for
+    // environments that haven't provisioned the value yet (per
+    // `docs/solutions/runtime-errors/required-env-var-without-default-broke-railway-deploy-20260511.md`).
+    //
+    // Format: single string OR comma-separated CSV mirroring admin's
+    // `WEB_ADMIN_API_KEYS` Doppler value. Web reads the first entry as its
+    // outbound bearer; admin recognizes any entry as a valid
+    // CONSUMER_BEARER. Symmetric name on both sides eliminates the
+    // KEY-vs-KEYS copy-paste error class.
+    WEB_ADMIN_API_KEYS: z.string().optional(),
   },
   client: {
     NEXT_PUBLIC_GRAPHQL_URL: z.url(),
@@ -198,6 +227,7 @@ export const env = createEnv({
     FORGE_CONTENT_API: process.env.FORGE_CONTENT_API,
     FORGE_PARITY_DEBUG: process.env.FORGE_PARITY_DEBUG,
     ADMIN_GRAPHQL_URL: process.env.ADMIN_GRAPHQL_URL,
+    WEB_ADMIN_API_KEYS: process.env.WEB_ADMIN_API_KEYS,
     NEXT_PUBLIC_GRAPHQL_URL: process.env.NEXT_PUBLIC_GRAPHQL_URL,
     NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION:
       process.env.NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION,

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -176,6 +176,23 @@ export const env = createEnv({
     // CONSUMER_BEARER. Symmetric name on both sides eliminates the
     // KEY-vs-KEYS copy-paste error class.
     WEB_ADMIN_API_KEYS: z.string().optional(),
+    // U9 (plan-003 PR-B) — emergency-only route disable.
+    //
+    // CSV of route paths to disable; matching slugs serve
+    // <MaintenanceFallback> instead of normal rendering. Read at module
+    // scope. Primary fast rollback layer (seconds) per cutover runbook:
+    //   docs/admin-core-migration/cutover-runbook.md — "Layer 1".
+    //
+    // Format: comma-separated route paths (e.g. "/some-slug,/another-slug").
+    // Whitespace around each entry is trimmed. Empty entries are skipped.
+    // Unknown / typo'd entries warn-and-fall-through to normal rendering —
+    // a typo'd disable entry does NOT brick the route.
+    //
+    // EMERGENCY ONLY. This is NOT a general traffic-shaping mechanism. Do
+    // not leave a slug in this list longer than a debug session; longer
+    // disables route through the canonical-plan U7 no-redeploy mechanism
+    // (TODO(U7) per runbook).
+    FORGE_DISABLE_WATCH_ROUTES: z.string().optional(),
   },
   client: {
     NEXT_PUBLIC_GRAPHQL_URL: z.url(),
@@ -228,6 +245,7 @@ export const env = createEnv({
     FORGE_PARITY_DEBUG: process.env.FORGE_PARITY_DEBUG,
     ADMIN_GRAPHQL_URL: process.env.ADMIN_GRAPHQL_URL,
     WEB_ADMIN_API_KEYS: process.env.WEB_ADMIN_API_KEYS,
+    FORGE_DISABLE_WATCH_ROUTES: process.env.FORGE_DISABLE_WATCH_ROUTES,
     NEXT_PUBLIC_GRAPHQL_URL: process.env.NEXT_PUBLIC_GRAPHQL_URL,
     NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION:
       process.env.NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION,

--- a/apps/web/src/lib/__tests__/content-mode-regression.test.ts
+++ b/apps/web/src/lib/__tests__/content-mode-regression.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Content-mode regression snapshot — locks the active + soft-removed
+ * `FORGE_CONTENT_API` value matrix to a single source-of-truth output
+ * table. Lands as the FIRST commit of PR-B (plan-003 direct cutover) per
+ * the test-first regression discipline at
+ * `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`.
+ *
+ * **Contract:** U4-U9 implementation units must not change the
+ * normalizer's output for any input in this table. Any change to the
+ * accepted set or the soft-removed coercion behavior is a deliberate
+ * decision that requires updating this regression test in the same
+ * commit — making the change visible at review.
+ *
+ * **Why:** during PR-B, U4 collapses the active mode set, U5 ships
+ * admin-shape fragments, U6 wires the cutover branch, UB7 the error
+ * boundary, U8 the verification harness, U9 the runbook. Several of
+ * those units touch `apps/web/src/lib/content.ts` and adjacent surfaces.
+ * Without a regression gate, a unit could silently change what
+ * `getContentApiMode()` returns for, say, an unset env var and break
+ * production rendering for every operator who hasn't set
+ * `FORGE_CONTENT_API`. The whole plan rests on the contract that "no
+ * config change = strapi mode = byte-identical to current main."
+ *
+ * **What this test does NOT cover:** the downstream behavior of
+ * `fetchSlugExperience`'s branch table (that's U6's contract; covered
+ * in `content.test.ts`). This test locks the normalizer-output
+ * boundary; U6 locks the orchestrator behavior given a mode value.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: { FORGE_CONTENT_API: undefined as string | undefined },
+}))
+
+vi.mock("@/env", () => ({
+  env: mockEnv,
+}))
+
+// Suppress console.warn during the regression snapshot — the soft-removed
+// and unknown-value paths emit warnings as documented contract; we test
+// the warn shape in content-api-mode.test.ts, not here.
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+  mockEnv.FORGE_CONTENT_API = undefined
+})
+
+describe("ContentApiMode regression snapshot — input/output stability", () => {
+  // Source-of-truth table. Each row is "given env.FORGE_CONTENT_API
+  // value X, getContentApiMode() must return Y". Adding a new input or
+  // changing an output is a deliberate plan decision; reviewers see the
+  // diff in PR.
+  const INPUT_OUTPUT_MATRIX: ReadonlyArray<{
+    description: string
+    envValue: string | undefined
+    expected: "strapi" | "admin"
+  }> = [
+    // -------------------------------------------------------------------------
+    // Default-mode preservation (no operator action → strapi mode)
+    // -------------------------------------------------------------------------
+    {
+      description: "undefined → strapi (default path)",
+      envValue: undefined,
+      expected: "strapi",
+    },
+    // -------------------------------------------------------------------------
+    // Active modes (plan-003 R3 closed set)
+    // -------------------------------------------------------------------------
+    {
+      description: "'strapi' → strapi (explicit active mode)",
+      envValue: "strapi",
+      expected: "strapi",
+    },
+    {
+      description: "'admin' → admin (NEW active mode in plan-003)",
+      envValue: "admin",
+      expected: "admin",
+    },
+    // -------------------------------------------------------------------------
+    // Legacy soft-removed modes (plan-003 U4 — stale Doppler configs
+    // continue to boot, narrower coerces to strapi)
+    // -------------------------------------------------------------------------
+    {
+      description: "'dual-read' → strapi (legacy U5 canary, soft-removed)",
+      envValue: "dual-read",
+      expected: "strapi",
+    },
+    {
+      description:
+        "'admin-with-fallback' → strapi (legacy R7 spec, soft-removed)",
+      envValue: "admin-with-fallback",
+      expected: "strapi",
+    },
+  ]
+
+  for (const { description, envValue, expected } of INPUT_OUTPUT_MATRIX) {
+    it(description, async () => {
+      mockEnv.FORGE_CONTENT_API = envValue
+      const { getContentApiMode } = await import("../content-api-mode")
+      expect(getContentApiMode()).toBe(expected)
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Type contract: ContentApiMode union has exactly 2 members
+  // ---------------------------------------------------------------------------
+  //
+  // If a future change widens or narrows the union, this snapshot file
+  // is the canonical place to lock the contract — adding a third value
+  // requires updating both the type and this test.
+
+  it("ContentApiMode union has exactly two members ('strapi' | 'admin')", async () => {
+    const mod = await import("../content-api-mode")
+    // Compile-time exhaustiveness: a switch over ContentApiMode must
+    // handle exactly these two cases. If a third is added, the `never`
+    // assertion at the default branch will fail the typecheck.
+    const exhaustivenessCheck = (
+      mode: "strapi" | "admin",
+    ): "strapi" | "admin" => {
+      switch (mode) {
+        case "strapi":
+          return mode
+        case "admin":
+          return mode
+        default: {
+          const _exhaustive: never = mode
+          return _exhaustive
+        }
+      }
+    }
+    // Runtime probe — exercise both arms.
+    expect(exhaustivenessCheck("strapi")).toBe("strapi")
+    expect(exhaustivenessCheck("admin")).toBe("admin")
+    // Runtime sanity that the normalizer accepts both literal values.
+    expect(mod.normalizeContentApiMode("strapi")).toBe("strapi")
+    expect(mod.normalizeContentApiMode("admin")).toBe("admin")
+  })
+})

--- a/apps/web/src/lib/admin-client.test.ts
+++ b/apps/web/src/lib/admin-client.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 const { mockEnv } = vi.hoisted(() => ({
-  mockEnv: { ADMIN_GRAPHQL_URL: "https://admin.local/api/graphql" },
+  mockEnv: {
+    ADMIN_GRAPHQL_URL: "https://admin.local/api/graphql",
+    WEB_ADMIN_API_KEYS: undefined as string | undefined,
+  },
 }))
 
 vi.mock("@/env", () => ({
@@ -12,6 +15,7 @@ describe("adminClient", () => {
   afterEach(() => {
     vi.resetModules()
     vi.restoreAllMocks()
+    mockEnv.WEB_ADMIN_API_KEYS = undefined
   })
 
   it("constructs once and is reused across imports (singleton)", async () => {
@@ -69,5 +73,177 @@ describe("adminClient", () => {
     // abort if the request exceeds 3 s).
     expect(capturedSignals[0]?.aborted).toBe(false)
     expect(capturedSignals[1]?.aborted).toBe(false)
+  })
+
+  // ---------------------------------------------------------------------------
+  // U6 (plan-003 PR-B) — bearer header injection from WEB_ADMIN_API_KEYS
+  // ---------------------------------------------------------------------------
+
+  it("attaches Authorization: Bearer ${first_key} when WEB_ADMIN_API_KEYS is set", async () => {
+    mockEnv.WEB_ADMIN_API_KEYS = "primary-key,secondary-key"
+    const capturedHeaders: Headers[] = []
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      capturedHeaders.push(new Headers(init?.headers))
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: { experienceBySlug: null } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    })
+
+    // Module-scope bearer read — re-import after mutating env.
+    vi.resetModules()
+    const { default: client } = await import("./admin-client")
+    const { adminExperienceBySlugOperation } =
+      await import("./fragments/admin-experience")
+
+    await client.query({
+      query: adminExperienceBySlugOperation,
+      variables: { locale: "en", slug: "x" },
+    })
+
+    expect(capturedHeaders.length).toBe(1)
+    expect(capturedHeaders[0].get("Authorization")).toBe("Bearer primary-key")
+  })
+
+  it("omits Authorization header when WEB_ADMIN_API_KEYS is unset (anonymous PUBLIC scope)", async () => {
+    mockEnv.WEB_ADMIN_API_KEYS = undefined
+    const capturedHeaders: Headers[] = []
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      capturedHeaders.push(new Headers(init?.headers))
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: { experienceBySlug: null } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    })
+
+    vi.resetModules()
+    const { default: client } = await import("./admin-client")
+    const { adminExperienceBySlugOperation } =
+      await import("./fragments/admin-experience")
+
+    await client.query({
+      query: adminExperienceBySlugOperation,
+      variables: { locale: "en", slug: "x" },
+    })
+
+    expect(capturedHeaders.length).toBe(1)
+    expect(capturedHeaders[0].has("Authorization")).toBe(false)
+  })
+
+  it("trims surrounding whitespace from the first CSV entry", async () => {
+    mockEnv.WEB_ADMIN_API_KEYS = "  trimmed-key  , other-key"
+    const capturedHeaders: Headers[] = []
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      capturedHeaders.push(new Headers(init?.headers))
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: { experienceBySlug: null } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    })
+
+    vi.resetModules()
+    const { default: client } = await import("./admin-client")
+    const { adminExperienceBySlugOperation } =
+      await import("./fragments/admin-experience")
+
+    await client.query({
+      query: adminExperienceBySlugOperation,
+      variables: { locale: "en", slug: "x" },
+    })
+
+    expect(capturedHeaders[0].get("Authorization")).toBe("Bearer trimmed-key")
+  })
+
+  // Defense-in-depth: a hostile (or misconfigured) admin server echoes
+  // the inbound Authorization header in its 500 response body. The
+  // admin-client itself never logs the bearer; this test guards against
+  // future edits accidentally introducing console output that includes
+  // the request headers. If a future change adds a `console.error(err)`
+  // that serializes the Apollo error's networkError.response (which can
+  // include the request body), the bearer must NOT appear in the
+  // captured console output.
+  //
+  // Mutation-test discipline: removing the explicit Headers construction
+  // in `timeoutFetch` (so the bearer flows back via the default
+  // serializer) would not directly break this test — the test passes
+  // because the admin-client itself never writes to console. The test's
+  // job is to lock the invariant that no current code path leaks; future
+  // code that introduces an Apollo error logger MUST add scrubbing or
+  // this test will catch it.
+  it("bearer key never appears in any console.{log,error,warn} payload when admin returns 500", async () => {
+    const BEARER = "very-secret-key-do-not-leak-9f8e7d6c"
+    mockEnv.WEB_ADMIN_API_KEYS = BEARER
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      // Hostile-server scenario: echo the Authorization header value back
+      // in the response body. A naive Apollo error log path that
+      // stringifies networkError.response would surface this.
+      const auth = new Headers(init?.headers).get("Authorization") ?? ""
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            echoedAuth: auth,
+            errors: [{ message: "boom" }],
+          }),
+          {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    })
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+    const errSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined)
+
+    try {
+      vi.resetModules()
+      const { default: client } = await import("./admin-client")
+      const { adminExperienceBySlugOperation } =
+        await import("./fragments/admin-experience")
+
+      // Don't care whether Apollo rejects or resolves-with-error — only
+      // that the bearer doesn't leak into any console payload.
+      const result = await client
+        .query({
+          query: adminExperienceBySlugOperation,
+          variables: { locale: "en", slug: "x" },
+        })
+        .catch((err) => ({ error: err }))
+      void result
+
+      const allLogs = [
+        ...logSpy.mock.calls,
+        ...errSpy.mock.calls,
+        ...warnSpy.mock.calls,
+      ]
+        .flat()
+        .map((arg) => {
+          if (typeof arg === "string") return arg
+          try {
+            return JSON.stringify(arg)
+          } catch {
+            return String(arg)
+          }
+        })
+        .join("\n")
+
+      expect(allLogs).not.toContain(BEARER)
+    } finally {
+      logSpy.mockRestore()
+      errSpy.mockRestore()
+      warnSpy.mockRestore()
+    }
   })
 })

--- a/apps/web/src/lib/admin-client.ts
+++ b/apps/web/src/lib/admin-client.ts
@@ -2,11 +2,13 @@ import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client"
 import { env } from "@/env"
 
 // =============================================================================
-// U5 (feat-104) — admin GraphQL Apollo client
+// U5 (feat-104) / U6 (plan-003 PR-B) — admin GraphQL Apollo client
 //
 // Server-only. Mirrors apps/web/src/lib/client.ts byte-for-byte except:
-// (a) URL from env.ADMIN_GRAPHQL_URL, (b) anonymous (admin's PUBLIC scope
-// is anonymous — no Bearer), (c) shorter 3 s timeout (origin R12).
+// (a) URL from env.ADMIN_GRAPHQL_URL, (b) Authorization: Bearer header
+// derived from env.WEB_ADMIN_API_KEYS (first CSV entry) so admin can
+// bucket SSR traffic as `consumer:<key>` rather than `public:<egress-ip>`,
+// and (c) shorter 3 s timeout (origin R12).
 //
 // IMPORTANT: AbortSignal.timeout(REQUEST_TIMEOUT_MS) is constructed inside
 // the timeoutFetch closure (per-call), NOT at module scope. Module-scope
@@ -15,11 +17,29 @@ import { env } from "@/env"
 // would land on an already-aborted signal. The verbatim safe pattern is
 // `apps/web/src/lib/client.ts:20-21`.
 //
+// Bearer scrubbing (U6 / R11): the bearer is injected via a custom fetch
+// override. Apollo Client v4's network-error surface (`networkError.cause`)
+// can include the original Request — its headers are normally NOT echoed
+// in stringified error output, but defense-in-depth: this module never
+// logs the bearer itself, and the override constructs a fresh Headers
+// instance per call so any caller-supplied Authorization (none today) is
+// replaced rather than merged. Tests force a 500 + assert no log payload
+// contains the bearer string.
+//
 // Retire alongside the rest of U5's scaffolding. See:
 //   apps/web/src/lib/content-api-mode.ts (deletion checklist)
 // =============================================================================
 
 const ADMIN_REQUEST_TIMEOUT_MS = 3_000
+
+// Module-scope: env.WEB_ADMIN_API_KEYS is server-only and does not change
+// across the process lifetime. Reading it once at HttpLink construction
+// avoids per-request env-proxy hits and makes the no-bearer code path
+// (env unset) unambiguously a deploy-time choice — not a race.
+const ADMIN_BEARER: string | undefined =
+  typeof window === "undefined"
+    ? env.WEB_ADMIN_API_KEYS?.split(",")[0]?.trim() || undefined
+    : undefined
 
 const timeoutFetch: typeof fetch = (input, init) => {
   const timeoutSignal = AbortSignal.timeout(ADMIN_REQUEST_TIMEOUT_MS)
@@ -32,7 +52,15 @@ const timeoutFetch: typeof fetch = (input, init) => {
     init?.signal && typeof AbortSignal.any === "function"
       ? AbortSignal.any([init.signal, timeoutSignal])
       : timeoutSignal
-  return fetch(input, { ...init, signal })
+
+  // Build a fresh Headers instance so we control exactly what's sent.
+  // Apollo passes its own content-type/accept headers via init.headers —
+  // copy them, then set Authorization if the bearer is configured.
+  const headers = new Headers(init?.headers)
+  if (ADMIN_BEARER) {
+    headers.set("Authorization", `Bearer ${ADMIN_BEARER}`)
+  }
+  return fetch(input, { ...init, signal, headers })
 }
 
 // `env.ADMIN_GRAPHQL_URL` is server-only AND optional (so default

--- a/apps/web/src/lib/content-api-mode.test.ts
+++ b/apps/web/src/lib/content-api-mode.test.ts
@@ -19,17 +19,25 @@ describe("normalizeContentApiMode", () => {
     warnSpy.mockRestore()
   })
 
+  // ---------------------------------------------------------------------------
+  // Active modes (plan-003 R3 closed set)
+  // ---------------------------------------------------------------------------
+
   it("returns 'strapi' for strapi input", async () => {
     const { normalizeContentApiMode } = await import("./content-api-mode")
     expect(normalizeContentApiMode("strapi")).toBe("strapi")
     expect(warnSpy).not.toHaveBeenCalled()
   })
 
-  it("returns 'dual-read' for dual-read input", async () => {
+  it("returns 'admin' for admin input (NEW active mode in plan-003)", async () => {
     const { normalizeContentApiMode } = await import("./content-api-mode")
-    expect(normalizeContentApiMode("dual-read")).toBe("dual-read")
+    expect(normalizeContentApiMode("admin")).toBe("admin")
     expect(warnSpy).not.toHaveBeenCalled()
   })
+
+  // ---------------------------------------------------------------------------
+  // Default-mode preservation (no warn on absent value)
+  // ---------------------------------------------------------------------------
 
   it("returns 'strapi' for undefined without warning", async () => {
     const { normalizeContentApiMode } = await import("./content-api-mode")
@@ -43,25 +51,43 @@ describe("normalizeContentApiMode", () => {
     expect(warnSpy).not.toHaveBeenCalled()
   })
 
-  it("falls back to 'strapi' and warns on wrong-case 'DUAL-READ'", async () => {
+  // ---------------------------------------------------------------------------
+  // Legacy soft-removed modes (plan-003 U4 — stale Doppler configs warn-and-fall-back)
+  // ---------------------------------------------------------------------------
+
+  it("soft-removes 'dual-read' (legacy U5 canary) — falls back to 'strapi' with explicit soft-removed warn", async () => {
     const { normalizeContentApiMode } = await import("./content-api-mode")
-    expect(normalizeContentApiMode("DUAL-READ")).toBe("strapi")
+    expect(normalizeContentApiMode("dual-read")).toBe("strapi")
     expect(warnSpy).toHaveBeenCalledTimes(1)
-    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/FORGE_CONTENT_API="DUAL-READ"/)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/dual-read/)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/soft-removed/)
   })
 
-  it("falls back to 'strapi' and warns on U5b value 'admin'", async () => {
-    const { normalizeContentApiMode } = await import("./content-api-mode")
-    expect(normalizeContentApiMode("admin")).toBe("strapi")
-    expect(warnSpy).toHaveBeenCalledTimes(1)
-    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/FORGE_CONTENT_API="admin"/)
-  })
-
-  it("falls back to 'strapi' and warns on U5b value 'admin-with-fallback'", async () => {
+  it("soft-removes 'admin-with-fallback' (legacy R7 spec value) — falls back to 'strapi' with explicit soft-removed warn", async () => {
     const { normalizeContentApiMode } = await import("./content-api-mode")
     expect(normalizeContentApiMode("admin-with-fallback")).toBe("strapi")
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy.mock.calls[0]?.[0]).toMatch(/admin-with-fallback/)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/soft-removed/)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Unknown / typo path (visible warn, fall back to strapi)
+  // ---------------------------------------------------------------------------
+
+  it("falls back to 'strapi' and warns on wrong-case 'ADMIN' (not a recognized value)", async () => {
+    const { normalizeContentApiMode } = await import("./content-api-mode")
+    expect(normalizeContentApiMode("ADMIN")).toBe("strapi")
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/ADMIN/)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/not a recognized value/)
+  })
+
+  it("falls back to 'strapi' and warns on garbage strings", async () => {
+    const { normalizeContentApiMode } = await import("./content-api-mode")
+    expect(normalizeContentApiMode("garbage")).toBe("strapi")
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/garbage/)
   })
 
   it("falls back to 'strapi' and warns on non-string types (number)", async () => {
@@ -76,6 +102,28 @@ describe("normalizeContentApiMode", () => {
     expect(normalizeContentApiMode({})).toBe("strapi")
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy.mock.calls[0]?.[0]).toMatch(/non-string value \(object\)/)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Warn-message differentiation: legacy soft-removed vs unknown
+  // ---------------------------------------------------------------------------
+  //
+  // Operators reading logs can distinguish "I need to update my Doppler
+  // config from a previously-valid value" (soft-removed) from "I have a
+  // typo or unknown value" (not-recognized). The warn messages carry
+  // different identifiers; the regression contract is that both still
+  // fall back to "strapi" so the user-facing render keeps working.
+
+  it("legacy soft-removed warn explicitly differentiates from unknown-value warn", async () => {
+    const { normalizeContentApiMode } = await import("./content-api-mode")
+    normalizeContentApiMode("dual-read")
+    const softRemovedMsg = warnSpy.mock.calls[0]?.[0] as string
+    warnSpy.mockClear()
+    normalizeContentApiMode("garbage")
+    const unknownMsg = warnSpy.mock.calls[0]?.[0] as string
+    expect(softRemovedMsg).toMatch(/soft-removed/)
+    expect(unknownMsg).not.toMatch(/soft-removed/)
+    expect(unknownMsg).toMatch(/not a recognized value/)
   })
 })
 
@@ -98,17 +146,24 @@ describe("getContentApiMode", () => {
     expect(getContentApiMode()).toBe("strapi")
   })
 
-  it("returns 'dual-read' when env.FORGE_CONTENT_API is 'dual-read'", async () => {
-    mockEnv.FORGE_CONTENT_API = "dual-read"
+  it("returns 'admin' when env.FORGE_CONTENT_API is 'admin'", async () => {
+    mockEnv.FORGE_CONTENT_API = "admin"
     const { getContentApiMode } = await import("./content-api-mode")
-    expect(getContentApiMode()).toBe("dual-read")
+    expect(getContentApiMode()).toBe("admin")
   })
 
-  // env.ts widens FORGE_CONTENT_API to accept all four origin-R7 values
-  // so an operator pre-setting a U5b value doesn't brick boot. The
-  // runtime narrower (normalizeContentApiMode) coerces U5b values to
-  // "strapi" with a warn until U5b ships admin-mode rendering.
-  it("returns 'strapi' (with warn) when env.FORGE_CONTENT_API is 'admin-with-fallback' (U5b value)", async () => {
+  // env.ts admits the four historical values at the schema level so an
+  // operator with a stale Doppler config doesn't brick boot. The runtime
+  // narrower coerces legacy values to "strapi" with a visible warn.
+  it("soft-removes env.FORGE_CONTENT_API='dual-read' (legacy U5 canary) — getContentApiMode() returns 'strapi' with warn", async () => {
+    mockEnv.FORGE_CONTENT_API = "dual-read"
+    const { getContentApiMode } = await import("./content-api-mode")
+    expect(getContentApiMode()).toBe("strapi")
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/dual-read/)
+  })
+
+  it("soft-removes env.FORGE_CONTENT_API='admin-with-fallback' (legacy R7 spec) — returns 'strapi' with warn", async () => {
     mockEnv.FORGE_CONTENT_API = "admin-with-fallback"
     const { getContentApiMode } = await import("./content-api-mode")
     expect(getContentApiMode()).toBe("strapi")
@@ -116,23 +171,15 @@ describe("getContentApiMode", () => {
     expect(warnSpy.mock.calls[0]?.[0]).toMatch(/admin-with-fallback/)
   })
 
-  it("returns 'strapi' (with warn) when env.FORGE_CONTENT_API is 'admin' (U5b value)", async () => {
-    mockEnv.FORGE_CONTENT_API = "admin"
-    const { getContentApiMode } = await import("./content-api-mode")
-    expect(getContentApiMode()).toBe("strapi")
-    expect(warnSpy).toHaveBeenCalledTimes(1)
-    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/FORGE_CONTENT_API="admin"/)
-  })
-
   it("caches the mode at module-import time and returns the same value across calls", async () => {
-    mockEnv.FORGE_CONTENT_API = "dual-read"
+    mockEnv.FORGE_CONTENT_API = "admin"
     const { getContentApiMode } = await import("./content-api-mode")
     const first = getContentApiMode()
     // Mutate the underlying env value AFTER module import — should NOT
     // affect subsequent reads, because the value is captured at import time.
     mockEnv.FORGE_CONTENT_API = "strapi"
     const second = getContentApiMode()
-    expect(first).toBe("dual-read")
-    expect(second).toBe("dual-read")
+    expect(first).toBe("admin")
+    expect(second).toBe("admin")
   })
 })

--- a/apps/web/src/lib/content-api-mode.ts
+++ b/apps/web/src/lib/content-api-mode.ts
@@ -1,91 +1,38 @@
-// =============================================================================
-// PR-B (plan-003 direct cutover) — DELETION CHECKLIST
-// =============================================================================
+// Throwaway scaffolding for the Strapi → admin consumer migration. Reads
+// FORGE_CONTENT_API once at module scope; retire when admin is sole consumer
+// source via the fast-follow deletion PR.
 //
-// This module is throwaway scaffolding for the Strapi → admin consumer
-// migration. It reads `FORGE_CONTENT_API` once at module scope and exposes
-// a typed mode discriminator that `apps/web/src/lib/content.ts` branches
-// on. Retire when admin becomes the sole consumer source AND the cutover
-// has held for a parity-clean window — sequenced as a fast-follow U5
-// deletion PR after PR-B (plan-003) merges.
-//
-// Cross-references:
+// Cross-references for the deletion PR:
 //   apps/web/src/lib/parity-bridge.ts          (deletion list)
 //   packages/graphql/src/parity/index.ts:1-34  (harness deletion list)
-//   docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md (current)
-//   docs/plans/2026-05-08-001-feat-consumer-migration-web-canary-unit-5-plan.md (U5 origin)
 //
-// At retirement, remove ALL of the following in one PR:
+// Deletion checklist (remove together in one PR):
+//   - This file + content-api-mode.test.ts
+//   - fetchSlugExperience's mode branch in content.ts (folds to direct admin call)
+//   - admin-client.ts (renamed; no longer a canary)
+//   - fragments/admin-experience.ts + re-export
+//   - parity-bridge.ts + parity-bridge.test.ts
+//   - __tests__/content-mode-regression.test.ts
+//   - Env: FORGE_CONTENT_API, FORGE_PARITY_DEBUG (ADMIN_GRAPHQL_URL +
+//     WEB_ADMIN_API_KEYS STAY and become required)
+//   - In env.ts: FORGE_CONTENT_API server schema entry, host-allowlist
+//     constants, runtimeEnv mapping
 //
-//   - This file: apps/web/src/lib/content-api-mode.ts
-//   - The companion test: apps/web/src/lib/content-api-mode.test.ts
-//   - The flag-branching helper in apps/web/src/lib/content.ts
-//     (`fetchSlugExperience` — folds back into a direct admin call
-//      once Strapi is gone)
-//   - The Strapi adapter: apps/web/src/lib/admin-client.ts (renamed to
-//     just admin-client, no longer a "canary" client)
-//   - The admin operation: apps/web/src/lib/fragments/admin-experience.ts
-//     and its re-export in apps/web/src/lib/fragments/index.ts
-//   - The parity bridge: apps/web/src/lib/parity-bridge.ts
-//   - The regression snapshot: apps/web/src/lib/__tests__/content-mode-regression.test.ts
-//   - Env vars: drop `FORGE_CONTENT_API`, `FORGE_PARITY_DEBUG` from any
-//     deployed env config (`ADMIN_GRAPHQL_URL` and `WEB_ADMIN_API_KEYS`
-//     STAY — admin is the sole source post-Strapi-removal)
-//   - In apps/web/src/env.ts: remove the FORGE_CONTENT_API server schema
-//     entry, the host-allowlist constants, and the `runtimeEnv` mapping.
-//     Keep ADMIN_GRAPHQL_URL + WEB_ADMIN_API_KEYS — those become required.
-//
-// What does NOT get removed:
-//   - The Strapi-side `getExperienceByFilters` function in content.ts —
-//     stays for resolveHomepage and the legacy-homepage path until that
-//     surface migrates separately.
-//
-// =============================================================================
+// DO NOT remove: Strapi-side `getExperienceByFilters` in content.ts —
+// resolveHomepage and the legacy-homepage path still use it.
 
 import { env } from "@/env"
 
-/**
- * Closed union of ACTIVE `FORGE_CONTENT_API` values.
- *
- * PR-B (plan-003) collapses the active set to two values: `strapi`
- * (default — byte-identical to current main) and `admin` (direct cutover
- * — fetches from admin via the bearer-aware Apollo client).
- *
- * Two legacy values are still accepted at the env schema level for
- * soft-removal compat: `dual-read` (the U5 canary mode) and
- * `admin-with-fallback` (a forward-looking R7 mode that was specced but
- * never shipped). Both coerce to `"strapi"` with a console.warn so
- * operators with stale runbook values don't see a behavior change
- * without a visible signal in the logs.
- */
 export type ContentApiMode = "strapi" | "admin"
 
 const RECOGNIZED_MODES: readonly ContentApiMode[] = ["strapi", "admin"]
 
-/**
- * Legacy values still accepted at the env-schema level (so a stale
- * Doppler config doesn't brick boot) but soft-removed at the narrower —
- * coerced to `"strapi"` with a visible warn.
- */
+/** Legacy values accepted at the env schema but coerced to `"strapi"` with a warn. */
 const LEGACY_SOFT_REMOVED_MODES: readonly string[] = [
   "dual-read",
   "admin-with-fallback",
 ]
 
-/**
- * Accept any unknown value and return a `ContentApiMode`. Unrecognized
- * values warn at the console and fall back to `"strapi"`. Two layers of
- * fall-back exist:
- *
- *  1. Legacy values (`dual-read`, `admin-with-fallback`) → `"strapi"`
- *     with a "soft-removed; update your Doppler config" warn. Existed
- *     in U5 / the R7 spec; no longer active modes.
- *  2. Unknown garbage (typos, future-unknowns) → `"strapi"` with a
- *     generic "not a recognized value" warn.
- *
- * Non-string inputs (number / object / etc.) also fall back with a
- * type-specific warn.
- */
 export function normalizeContentApiMode(raw: unknown): ContentApiMode {
   if (raw == null) return "strapi"
   if (typeof raw !== "string") {
@@ -115,24 +62,11 @@ export function normalizeContentApiMode(raw: unknown): ContentApiMode {
   return "strapi"
 }
 
-/**
- * Module-cached mode value, read once at module import. Reading at module
- * scope is intentional and load-bearing for ISR — using `headers()` or
- * `cookies()` to make the flag per-request silently disables Next.js's
- * Full Route Cache (see docs/solutions/web/nextjs-headers-defeats-route-cache.md).
- *
- * `env.FORGE_CONTENT_API` is server-only; reading it from a client bundle
- * throws via t3-oss/env-nextjs's Proxy. The `typeof window` guard mirrors
- * apps/web/src/lib/client.ts so this module can be imported transitively
- * by client components without throwing at module load. On the client the
- * mode is always `"strapi"` because the canary's dual-fetch only runs
- * server-side anyway.
- *
- * env.FORGE_CONTENT_API admits four values at the schema level (strapi /
- * dual-read / admin-with-fallback / admin) for soft-removal compat;
- * `normalizeContentApiMode` is the load-bearing narrower that closes the
- * active set to `"strapi" | "admin"`.
- */
+// Read once at module scope — using headers()/cookies() per-request would
+// silently disable Next's Full Route Cache. See
+// docs/solutions/web/nextjs-headers-defeats-route-cache.md.
+// `typeof window` guard lets client components import transitively;
+// env.FORGE_CONTENT_API is server-only via t3-oss/env-nextjs's Proxy.
 const cachedMode: ContentApiMode =
   typeof window === "undefined"
     ? normalizeContentApiMode(env.FORGE_CONTENT_API)

--- a/apps/web/src/lib/content-api-mode.ts
+++ b/apps/web/src/lib/content-api-mode.ts
@@ -1,63 +1,90 @@
 // =============================================================================
-// U5 (feat-104 consumer migration) — DELETION CHECKLIST
+// PR-B (plan-003 direct cutover) — DELETION CHECKLIST
 // =============================================================================
 //
 // This module is throwaway scaffolding for the Strapi → admin consumer
 // migration. It reads `FORGE_CONTENT_API` once at module scope and exposes
 // a typed mode discriminator that `apps/web/src/lib/content.ts` branches
-// on. Retire when admin becomes the sole consumer source AND U5b's
-// admin-mode rendering has held for a parity-clean window.
+// on. Retire when admin becomes the sole consumer source AND the cutover
+// has held for a parity-clean window — sequenced as a fast-follow U5
+// deletion PR after PR-B (plan-003) merges.
 //
 // Cross-references:
-//   apps/web/src/lib/parity-bridge.ts          (U4 — bridge deletion list)
+//   apps/web/src/lib/parity-bridge.ts          (deletion list)
 //   packages/graphql/src/parity/index.ts:1-34  (harness deletion list)
-//   docs/plans/2026-05-08-001-feat-consumer-migration-web-canary-unit-5-plan.md
+//   docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md (current)
+//   docs/plans/2026-05-08-001-feat-consumer-migration-web-canary-unit-5-plan.md (U5 origin)
 //
 // At retirement, remove ALL of the following in one PR:
 //
 //   - This file: apps/web/src/lib/content-api-mode.ts
 //   - The companion test: apps/web/src/lib/content-api-mode.test.ts
 //   - The flag-branching helper in apps/web/src/lib/content.ts
-//     (`fetchSlugExperience` — folds back into a direct Strapi call
-//      OR is replaced by the U5b admin renderer, depending on what
-//      ships at retirement time)
-//   - The admin Apollo client: apps/web/src/lib/admin-client.ts
+//     (`fetchSlugExperience` — folds back into a direct admin call
+//      once Strapi is gone)
+//   - The Strapi adapter: apps/web/src/lib/admin-client.ts (renamed to
+//     just admin-client, no longer a "canary" client)
 //   - The admin operation: apps/web/src/lib/fragments/admin-experience.ts
 //     and its re-export in apps/web/src/lib/fragments/index.ts
 //   - The parity bridge: apps/web/src/lib/parity-bridge.ts
 //   - The regression snapshot: apps/web/src/lib/__tests__/content-mode-regression.test.ts
-//   - Env vars: drop `FORGE_CONTENT_API`, `ADMIN_GRAPHQL_URL`, and
-//     `FORGE_PARITY_DEBUG` from any deployed env config
-//   - In apps/web/src/env.ts: remove the FORGE_CONTENT_API + ADMIN_GRAPHQL_URL
-//     server schema entries, the host-allowlist constants, and their
-//     `runtimeEnv` mappings
+//   - Env vars: drop `FORGE_CONTENT_API`, `FORGE_PARITY_DEBUG` from any
+//     deployed env config (`ADMIN_GRAPHQL_URL` and `WEB_ADMIN_API_KEYS`
+//     STAY — admin is the sole source post-Strapi-removal)
+//   - In apps/web/src/env.ts: remove the FORGE_CONTENT_API server schema
+//     entry, the host-allowlist constants, and the `runtimeEnv` mapping.
+//     Keep ADMIN_GRAPHQL_URL + WEB_ADMIN_API_KEYS — those become required.
 //
 // What does NOT get removed:
 //   - The Strapi-side `getExperienceByFilters` function in content.ts —
-//     still in use by `resolveHomepage` and the legacy-homepage path
+//     stays for resolveHomepage and the legacy-homepage path until that
+//     surface migrates separately.
 //
 // =============================================================================
 
 import { env } from "@/env"
 
 /**
- * Closed union of accepted `FORGE_CONTENT_API` values for U5.
+ * Closed union of ACTIVE `FORGE_CONTENT_API` values.
  *
- * U5 ships only `strapi` (default — byte-identical to `main`) and
- * `dual-read` (canary — serves Strapi, runs admin in shadow for parity).
- * Origin R7 names two additional values (`admin-with-fallback`, `admin`)
- * that ship in U5b alongside the admin → WatchExperience shape adapter.
+ * PR-B (plan-003) collapses the active set to two values: `strapi`
+ * (default — byte-identical to current main) and `admin` (direct cutover
+ * — fetches from admin via the bearer-aware Apollo client).
+ *
+ * Two legacy values are still accepted at the env schema level for
+ * soft-removal compat: `dual-read` (the U5 canary mode) and
+ * `admin-with-fallback` (a forward-looking R7 mode that was specced but
+ * never shipped). Both coerce to `"strapi"` with a console.warn so
+ * operators with stale runbook values don't see a behavior change
+ * without a visible signal in the logs.
  */
-export type ContentApiMode = "strapi" | "dual-read"
+export type ContentApiMode = "strapi" | "admin"
 
-const RECOGNIZED_MODES: readonly ContentApiMode[] = ["strapi", "dual-read"]
+const RECOGNIZED_MODES: readonly ContentApiMode[] = ["strapi", "admin"]
+
+/**
+ * Legacy values still accepted at the env-schema level (so a stale
+ * Doppler config doesn't brick boot) but soft-removed at the narrower —
+ * coerced to `"strapi"` with a visible warn.
+ */
+const LEGACY_SOFT_REMOVED_MODES: readonly string[] = [
+  "dual-read",
+  "admin-with-fallback",
+]
 
 /**
  * Accept any unknown value and return a `ContentApiMode`. Unrecognized
- * values warn at the console and fall back to `"strapi"`. Defensive layer
- * that exists to prevent malformed flag values (pasted from a future U5b
- * env, e.g. `"admin-with-fallback"`) from silently activating an
- * unsupported branch.
+ * values warn at the console and fall back to `"strapi"`. Two layers of
+ * fall-back exist:
+ *
+ *  1. Legacy values (`dual-read`, `admin-with-fallback`) → `"strapi"`
+ *     with a "soft-removed; update your Doppler config" warn. Existed
+ *     in U5 / the R7 spec; no longer active modes.
+ *  2. Unknown garbage (typos, future-unknowns) → `"strapi"` with a
+ *     generic "not a recognized value" warn.
+ *
+ * Non-string inputs (number / object / etc.) also fall back with a
+ * type-specific warn.
  */
 export function normalizeContentApiMode(raw: unknown): ContentApiMode {
   if (raw == null) return "strapi"
@@ -72,9 +99,17 @@ export function normalizeContentApiMode(raw: unknown): ContentApiMode {
   if ((RECOGNIZED_MODES as readonly string[]).includes(raw)) {
     return raw as ContentApiMode
   }
+  if (LEGACY_SOFT_REMOVED_MODES.includes(raw)) {
+    if (typeof console !== "undefined") {
+      console.warn(
+        `[content-api-mode] FORGE_CONTENT_API="${raw}" is a soft-removed legacy value; falling back to "strapi". Update your Doppler config to "strapi" or "admin".`,
+      )
+    }
+    return "strapi"
+  }
   if (typeof console !== "undefined") {
     console.warn(
-      `[content-api-mode] FORGE_CONTENT_API="${raw}" is not a recognized U5 value (expected: ${RECOGNIZED_MODES.join(", ")}); falling back to "strapi".`,
+      `[content-api-mode] FORGE_CONTENT_API="${raw}" is not a recognized value (expected: ${RECOGNIZED_MODES.join(", ")}); falling back to "strapi".`,
     )
   }
   return "strapi"
@@ -93,11 +128,10 @@ export function normalizeContentApiMode(raw: unknown): ContentApiMode {
  * mode is always `"strapi"` because the canary's dual-fetch only runs
  * server-side anyway.
  *
- * env.FORGE_CONTENT_API admits four values (strapi / dual-read /
- * admin-with-fallback / admin) so an operator pre-setting a U5b value
- * doesn't brick boot. `normalizeContentApiMode` is the load-bearing
- * narrower: U5b values coerce to `"strapi"` with a warn until U5b ships
- * admin-mode rendering.
+ * env.FORGE_CONTENT_API admits four values at the schema level (strapi /
+ * dual-read / admin-with-fallback / admin) for soft-removal compat;
+ * `normalizeContentApiMode` is the load-bearing narrower that closes the
+ * active set to `"strapi" | "admin"`.
  */
 const cachedMode: ContentApiMode =
   typeof window === "undefined"

--- a/apps/web/src/lib/content.test.ts
+++ b/apps/web/src/lib/content.test.ts
@@ -423,16 +423,17 @@ describe("fetchSlugExperience (U6 admin cutover)", () => {
     }
   })
 
-  // F15 (ce-code-review): hostile-admin scenario — error message echoes the
-  // bearer (Apollo can carry downstream response body text in `.message`).
-  // The scrub MUST redact every occurrence of the bearer's first CSV entry
-  // before the message lands in a structured log.
-  it("admin mode + Apollo error containing bearer string → log payload has <redacted>, not the bearer", async () => {
+  // F13 + F15 (ce-code-review): hostile-admin scenario. Error message
+  // echoes BOTH live CSV entries (admin could echo the active key or the
+  // rotation-in-progress key). The scrub must redact every CSV entry.
+  it("admin mode + Apollo error echoing both CSV keys → log payload redacts BOTH", async () => {
     modeRef.current = "admin"
     envRef.WEB_ADMIN_API_KEYS = "secret-bearer-aaa,secret-bearer-bbb"
     const apolloError = Object.assign(
       new Error(
-        "Response not successful: Authorization: Bearer secret-bearer-aaa (admin echoed the header in a 500 body) — second occurrence: secret-bearer-aaa",
+        "Response not successful: Authorization: Bearer secret-bearer-aaa " +
+          "(echoed primary), and rotation-key seen: secret-bearer-bbb " +
+          "(echoed secondary); primary again: secret-bearer-aaa",
       ),
       {
         name: "ApolloError",
@@ -461,11 +462,38 @@ describe("fetchSlugExperience (U6 admin cutover)", () => {
       expect(fetchErrCall).toBeDefined()
       const payload = JSON.parse(fetchErrCall?.[0] as string)
       expect(payload.errorMessage).not.toContain("secret-bearer-aaa")
-      expect(payload.errorMessage).toContain("<redacted>")
-      // Second occurrence redacted too (split/join replaces all).
-      expect(
-        (payload.errorMessage.match(/<redacted>/g) ?? []).length,
-      ).toBeGreaterThanOrEqual(2)
+      expect(payload.errorMessage).not.toContain("secret-bearer-bbb")
+      // 2× aaa + 1× bbb = 3 redactions total.
+      expect((payload.errorMessage.match(/<redacted>/g) ?? []).length).toBe(3)
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  // A3 (ce-code-review): post-rotation state. Operator revoked the first
+  // (leaked) CSV entry by removing it from WEB_ADMIN_API_KEYS, leaving only
+  // the second key. The admin path must still authenticate normally — no
+  // consumer_bearer_missing fallback, no errors.
+  it("admin mode + WEB_ADMIN_API_KEYS rotated to single remaining entry → admin path works normally", async () => {
+    modeRef.current = "admin"
+    envRef.WEB_ADMIN_API_KEYS = "secret-bearer-bbb"
+    adminQueryMock.mockResolvedValueOnce(adminHit("admin-rotation"))
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+
+    try {
+      const { resolveWatchPage } = await import("./content")
+      const result = await resolveWatchPage("en", "christmas")
+
+      expect(result.error).toBeNull()
+      expect(adminQueryMock).toHaveBeenCalledTimes(1)
+      const bearerMissing = logSpy.mock.calls.find((call) => {
+        const arg = call[0]
+        return (
+          typeof arg === "string" &&
+          arg.includes("forge.parity.consumer_bearer_missing")
+        )
+      })
+      expect(bearerMissing).toBeUndefined()
     } finally {
       logSpy.mockRestore()
     }

--- a/apps/web/src/lib/content.test.ts
+++ b/apps/web/src/lib/content.test.ts
@@ -423,6 +423,54 @@ describe("fetchSlugExperience (U6 admin cutover)", () => {
     }
   })
 
+  // F15 (ce-code-review): hostile-admin scenario — error message echoes the
+  // bearer (Apollo can carry downstream response body text in `.message`).
+  // The scrub MUST redact every occurrence of the bearer's first CSV entry
+  // before the message lands in a structured log.
+  it("admin mode + Apollo error containing bearer string → log payload has <redacted>, not the bearer", async () => {
+    modeRef.current = "admin"
+    envRef.WEB_ADMIN_API_KEYS = "secret-bearer-aaa,secret-bearer-bbb"
+    const apolloError = Object.assign(
+      new Error(
+        "Response not successful: Authorization: Bearer secret-bearer-aaa (admin echoed the header in a 500 body) — second occurrence: secret-bearer-aaa",
+      ),
+      {
+        name: "ApolloError",
+        networkError: new Error("500"),
+        graphQLErrors: [],
+      },
+    )
+    adminQueryMock.mockRejectedValueOnce(apolloError)
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+
+    try {
+      const { resolveWatchPage } = await import("./content")
+      try {
+        await resolveWatchPage("en", "christmas")
+      } catch {
+        /* expected throw */
+      }
+
+      const fetchErrCall = logSpy.mock.calls.find((call) => {
+        const arg = call[0]
+        return (
+          typeof arg === "string" &&
+          arg.includes("forge.parity.admin_fetch_error")
+        )
+      })
+      expect(fetchErrCall).toBeDefined()
+      const payload = JSON.parse(fetchErrCall?.[0] as string)
+      expect(payload.errorMessage).not.toContain("secret-bearer-aaa")
+      expect(payload.errorMessage).toContain("<redacted>")
+      // Second occurrence redacted too (split/join replaces all).
+      expect(
+        (payload.errorMessage.match(/<redacted>/g) ?? []).length,
+      ).toBeGreaterThanOrEqual(2)
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
   it("admin mode + AbortError → throws WatchPageAdminError('UNAVAILABLE') (timeout)", async () => {
     modeRef.current = "admin"
     const abortError = Object.assign(new Error("aborted"), {

--- a/apps/web/src/lib/content.test.ts
+++ b/apps/web/src/lib/content.test.ts
@@ -1,13 +1,12 @@
 import { print } from "graphql"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const { queryMock, adminQueryMock, modeRef, runDualReadComparisonMock } =
-  vi.hoisted(() => ({
-    queryMock: vi.fn(),
-    adminQueryMock: vi.fn(),
-    modeRef: { current: "strapi" as "strapi" | "dual-read" },
-    runDualReadComparisonMock: vi.fn(),
-  }))
+const { queryMock, adminQueryMock, modeRef, envRef } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  adminQueryMock: vi.fn(),
+  modeRef: { current: "strapi" as "strapi" | "admin" },
+  envRef: { WEB_ADMIN_API_KEYS: "key-1,key-2" as string | undefined },
+}))
 
 vi.mock("next/cache", () => ({
   unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
@@ -21,6 +20,10 @@ vi.mock("react", async () => {
     cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
   }
 })
+
+vi.mock("@/env", () => ({
+  env: envRef,
+}))
 
 vi.mock("@/lib/client", () => ({
   default: {
@@ -38,19 +41,15 @@ vi.mock("@/lib/content-api-mode", () => ({
   getContentApiMode: () => modeRef.current,
 }))
 
-vi.mock("@/lib/parity-bridge", () => ({
-  runDualReadComparison: runDualReadComparisonMock,
-}))
-
 describe("resolveWatchPage", () => {
   beforeEach(() => {
     modeRef.current = "strapi"
+    envRef.WEB_ADMIN_API_KEYS = "key-1,key-2"
   })
 
   afterEach(() => {
     queryMock.mockReset()
     adminQueryMock.mockReset()
-    runDualReadComparisonMock.mockReset()
     vi.resetModules()
   })
 
@@ -242,22 +241,23 @@ describe("resolveWatchPage", () => {
 })
 
 // ---------------------------------------------------------------------------
-// U5 — fetchSlugExperience canary mode tests
+// U6 (plan-003 PR-B) — fetchSlugExperience direct cutover branch
 //
-// These exercise the dual-read branching introduced in U3. The canary
-// surface is the slug-page Experience fetcher; resolveWatchPage uses it
-// for the slug-equality case but NOT for the homepage path.
+// The branch table is now 2-case: `strapi` (default, unchanged) and
+// `admin` (direct cutover). Admin failures throw a typed
+// `WatchPageAdminError("NOT_FOUND" | "UNAVAILABLE")` that the cache
+// wrapper re-throws so the segment error boundary can fire.
 // ---------------------------------------------------------------------------
 
-describe("fetchSlugExperience (U5 canary)", () => {
+describe("fetchSlugExperience (U6 admin cutover)", () => {
   beforeEach(() => {
     modeRef.current = "strapi"
+    envRef.WEB_ADMIN_API_KEYS = "key-1,key-2"
   })
 
   afterEach(() => {
     queryMock.mockReset()
     adminQueryMock.mockReset()
-    runDualReadComparisonMock.mockReset()
     vi.resetModules()
   })
 
@@ -285,6 +285,7 @@ describe("fetchSlugExperience (U5 canary)", () => {
           slug: "christmas",
           locale: "en",
           title,
+          isTemplate: false,
           metaDescription: null,
           ogImageUrl: null,
           blocks: [],
@@ -293,9 +294,9 @@ describe("fetchSlugExperience (U5 canary)", () => {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Default mode — strapi
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Happy paths
+  // -------------------------------------------------------------------------
 
   it("strapi mode: serves Strapi unchanged and never touches admin", async () => {
     modeRef.current = "strapi"
@@ -306,7 +307,6 @@ describe("fetchSlugExperience (U5 canary)", () => {
 
     expect(queryMock).toHaveBeenCalledTimes(1)
     expect(adminQueryMock).not.toHaveBeenCalled()
-    expect(runDualReadComparisonMock).not.toHaveBeenCalled()
     expect(result.error).toBeNull()
     expect(result.data).toMatchObject({
       kind: "experience",
@@ -314,162 +314,187 @@ describe("fetchSlugExperience (U5 canary)", () => {
     })
   })
 
-  // ---------------------------------------------------------------------------
-  // dual-read happy path
-  // ---------------------------------------------------------------------------
-
-  it("dual-read mode: serves Strapi to user and hands both responses to bridge", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit("strapi-1"))
+  it("admin mode: serves admin response and never touches Strapi", async () => {
+    modeRef.current = "admin"
     adminQueryMock.mockResolvedValueOnce(adminHit("admin-1"))
 
     const { resolveWatchPage } = await import("./content")
     const result = await resolveWatchPage("en", "christmas")
 
-    expect(queryMock).toHaveBeenCalledTimes(1)
     expect(adminQueryMock).toHaveBeenCalledTimes(1)
-    expect(runDualReadComparisonMock).toHaveBeenCalledTimes(1)
-
-    // User-facing source is Strapi (documentId from the strapiHit fixture).
+    expect(queryMock).not.toHaveBeenCalled()
     expect(result.error).toBeNull()
+    // Renderer receives admin-shape WatchExperience (admin's `id` field
+    // is the discriminator vs Strapi's `documentId`).
     expect(result.data).toMatchObject({
       kind: "experience",
-      experience: { documentId: "strapi-1", slug: "christmas" },
-    })
-
-    // Bridge received both outcomes with ok: true.
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome).toMatchObject({
-      slug: "christmas",
-      urlLocale: "en",
-      strapi: { ok: true },
-      admin: { ok: true },
+      experience: { id: "admin-1", slug: "christmas" },
     })
   })
 
-  // ---------------------------------------------------------------------------
-  // dual-read: admin fails, Strapi succeeds — user unaffected
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Admin error paths
+  // -------------------------------------------------------------------------
 
-  it("dual-read mode: admin throws ApolloError → user gets Strapi, bridge sees error outcome", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
-    // Typed Apollo error shape (mocked-shape-vs-real-contract discipline).
+  it("admin mode + admin returns null → throws WatchPageAdminError('NOT_FOUND')", async () => {
+    modeRef.current = "admin"
+    adminQueryMock.mockResolvedValueOnce({
+      data: { experienceBySlug: null },
+    })
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+
+    try {
+      const { resolveWatchPage, WatchPageAdminError } =
+        await import("./content")
+      // Cache wrapper re-throws WatchPageAdminError — must reach caller.
+      await expect(resolveWatchPage("en", "christmas")).rejects.toBeInstanceOf(
+        WatchPageAdminError,
+      )
+
+      // Re-run to assert the code field on the thrown instance.
+      adminQueryMock.mockResolvedValueOnce({
+        data: { experienceBySlug: null },
+      })
+      try {
+        await resolveWatchPage("en", "christmas")
+      } catch (err) {
+        expect(err).toBeInstanceOf(WatchPageAdminError)
+        expect((err as InstanceType<typeof WatchPageAdminError>).code).toBe(
+          "NOT_FOUND",
+        )
+      }
+
+      // forge.parity.admin_null event was logged.
+      const adminNullCall = logSpy.mock.calls.find((call) => {
+        const arg = call[0]
+        return (
+          typeof arg === "string" && arg.includes("forge.parity.admin_null")
+        )
+      })
+      expect(adminNullCall).toBeDefined()
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  // Mocked-shape-vs-real-contract discipline (per
+  // docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md):
+  // typed Apollo error shape — name === "ApolloError" + networkError —
+  // not generic Error("...").
+  it("admin mode + Apollo error → throws WatchPageAdminError('UNAVAILABLE') with cause", async () => {
+    modeRef.current = "admin"
     const apolloError = Object.assign(new Error("admin network error"), {
       name: "ApolloError",
       networkError: new Error("ECONNREFUSED"),
       graphQLErrors: [],
     })
     adminQueryMock.mockRejectedValueOnce(apolloError)
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
 
-    const { resolveWatchPage } = await import("./content")
-    const result = await resolveWatchPage("en", "christmas")
+    try {
+      const { resolveWatchPage, WatchPageAdminError } =
+        await import("./content")
+      let thrown: unknown
+      try {
+        await resolveWatchPage("en", "christmas")
+      } catch (err) {
+        thrown = err
+      }
 
-    expect(result.error).toBeNull()
-    expect(result.data).toMatchObject({ kind: "experience" })
+      expect(thrown).toBeInstanceOf(WatchPageAdminError)
+      const watchErr = thrown as InstanceType<typeof WatchPageAdminError>
+      expect(watchErr.code).toBe("UNAVAILABLE")
+      // Original Apollo error is preserved as cause.
+      expect(watchErr.cause).toBe(apolloError)
 
-    expect(runDualReadComparisonMock).toHaveBeenCalledTimes(1)
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.strapi.ok).toBe(true)
-    expect(outcome.admin.ok).toBe("error")
+      // forge.parity.admin_fetch_error event was logged with original message.
+      const fetchErrCall = logSpy.mock.calls.find((call) => {
+        const arg = call[0]
+        return (
+          typeof arg === "string" &&
+          arg.includes("forge.parity.admin_fetch_error")
+        )
+      })
+      expect(fetchErrCall).toBeDefined()
+      const payload = JSON.parse(fetchErrCall?.[0] as string)
+      expect(payload.errorMessage).toBe("admin network error")
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 
-  // ---------------------------------------------------------------------------
-  // dual-read: admin times out — user unaffected
-  // ---------------------------------------------------------------------------
-
-  it("dual-read mode: admin AbortError classified as 'timeout', user gets Strapi", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
+  it("admin mode + AbortError → throws WatchPageAdminError('UNAVAILABLE') (timeout)", async () => {
+    modeRef.current = "admin"
     const abortError = Object.assign(new Error("aborted"), {
       name: "AbortError",
     })
     adminQueryMock.mockRejectedValueOnce(abortError)
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
 
-    const { resolveWatchPage } = await import("./content")
-    const result = await resolveWatchPage("en", "christmas")
+    try {
+      const { resolveWatchPage, WatchPageAdminError } =
+        await import("./content")
+      let thrown: unknown
+      try {
+        await resolveWatchPage("en", "christmas")
+      } catch (err) {
+        thrown = err
+      }
 
-    expect(result.error).toBeNull()
-    expect(runDualReadComparisonMock).toHaveBeenCalledTimes(1)
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.admin.ok).toBe("timeout")
+      expect(thrown).toBeInstanceOf(WatchPageAdminError)
+      expect((thrown as InstanceType<typeof WatchPageAdminError>).code).toBe(
+        "UNAVAILABLE",
+      )
+      // Logged as admin_timeout (NOT admin_fetch_error) — classification
+      // is by error.name, not message substring.
+      const timeoutCall = logSpy.mock.calls.find((call) => {
+        const arg = call[0]
+        return (
+          typeof arg === "string" && arg.includes("forge.parity.admin_timeout")
+        )
+      })
+      expect(timeoutCall).toBeDefined()
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 
-  // AbortSignal.timeout() emits TimeoutError per WHATWG; AbortError is the
-  // older shape from AbortController.abort(). Both must classify as timeout.
-  it("dual-read mode: admin TimeoutError (WHATWG) classified as 'timeout'", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
-    const timeoutError = Object.assign(new Error("timed out"), {
-      name: "TimeoutError",
+  // Apollo Client v4 wraps fetch transport errors in networkError. The
+  // classifier must walk this shape so a real 3s timeout still classifies
+  // as admin_timeout, not admin_fetch_error.
+  it("admin mode + timeout via Apollo networkError chain → classified as timeout", async () => {
+    modeRef.current = "admin"
+    const apolloWithNetworkTimeout = Object.assign(new Error("network error"), {
+      name: "ApolloError",
+      networkError: Object.assign(new Error("aborted"), {
+        name: "AbortError",
+      }),
     })
-    adminQueryMock.mockRejectedValueOnce(timeoutError)
+    adminQueryMock.mockRejectedValueOnce(apolloWithNetworkTimeout)
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
 
-    const { resolveWatchPage } = await import("./content")
-    await resolveWatchPage("en", "christmas")
+    try {
+      const { resolveWatchPage } = await import("./content")
+      await resolveWatchPage("en", "christmas").catch(() => {})
 
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.admin.ok).toBe("timeout")
+      const timeoutCall = logSpy.mock.calls.find((call) => {
+        const arg = call[0]
+        return (
+          typeof arg === "string" && arg.includes("forge.parity.admin_timeout")
+        )
+      })
+      expect(timeoutCall).toBeDefined()
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 
-  // Apollo Client v4 may surface fetch transport errors as
-  // ApolloError.networkError, with the typed AbortSignal cause one level
-  // deeper. The classifier must walk this shape too — otherwise real
-  // timeouts in production misclassify as forge.parity.harness_error /
-  // admin_fetch_error and pollute the U5b advance signal.
-  it("dual-read mode: timeout wrapped in Apollo networkError classified as 'timeout'", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
-    const apolloErrorWithNetworkTimeout = Object.assign(
-      new Error("network error"),
-      {
-        name: "ApolloError",
-        networkError: Object.assign(new Error("aborted"), {
-          name: "AbortError",
-        }),
-      },
-    )
-    adminQueryMock.mockRejectedValueOnce(apolloErrorWithNetworkTimeout)
-
-    const { resolveWatchPage } = await import("./content")
-    await resolveWatchPage("en", "christmas")
-
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.admin.ok).toBe("timeout")
-  })
-
-  // Apollo errors with a typed cause chain — networkError -> cause -> AbortError.
-  it("dual-read mode: timeout wrapped via Apollo networkError.cause chain classified as 'timeout'", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
-    const apolloErrorWithNestedCause = Object.assign(
-      new Error("apollo wrapper"),
-      {
-        name: "ApolloError",
-        networkError: Object.assign(new Error("fetch failed"), {
-          name: "FetchError",
-          cause: Object.assign(new Error("aborted"), {
-            name: "AbortError",
-          }),
-        }),
-      },
-    )
-    adminQueryMock.mockRejectedValueOnce(apolloErrorWithNestedCause)
-
-    const { resolveWatchPage } = await import("./content")
-    await resolveWatchPage("en", "christmas")
-
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.admin.ok).toBe("timeout")
-  })
-
-  // Apollo's `result.error` (resolved-with-error, not rejected) is a
-  // distinct production shape from rejection. The fetchAdminSlugExperience
-  // catch handles rejection; the result.error branch handles in-resolution
-  // errors. Both must classify timeout-vs-error consistently.
-  it("dual-read mode: Apollo resolves with result.error AbortError → classifies as 'timeout'", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
+  // Apollo result.error (resolved-with-error, not rejected) is a distinct
+  // production shape. The fetcher's catch handles rejection; the
+  // result.error branch handles in-resolution errors. Both must classify
+  // consistently.
+  it("admin mode + Apollo result.error AbortError → classified as timeout", async () => {
+    modeRef.current = "admin"
     const abortError = Object.assign(new Error("aborted"), {
       name: "AbortError",
     })
@@ -477,242 +502,126 @@ describe("fetchSlugExperience (U5 canary)", () => {
       data: null,
       error: abortError,
     })
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
 
-    const { resolveWatchPage } = await import("./content")
-    await resolveWatchPage("en", "christmas")
+    try {
+      const { resolveWatchPage } = await import("./content")
+      await resolveWatchPage("en", "christmas").catch(() => {})
 
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.admin.ok).toBe("timeout")
+      const timeoutCall = logSpy.mock.calls.find((call) => {
+        const arg = call[0]
+        return (
+          typeof arg === "string" && arg.includes("forge.parity.admin_timeout")
+        )
+      })
+      expect(timeoutCall).toBeDefined()
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 
-  it("dual-read mode: Apollo resolves with result.error generic Error → classifies as 'error'", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
-    const apolloResultError = Object.assign(new Error("admin schema drift"), {
-      name: "ApolloError",
-    })
-    adminQueryMock.mockResolvedValueOnce({
-      data: null,
-      error: apolloResultError,
-    })
+  // -------------------------------------------------------------------------
+  // Runtime safety net — WEB_ADMIN_API_KEYS unset
+  // -------------------------------------------------------------------------
 
-    const { resolveWatchPage } = await import("./content")
-    await resolveWatchPage("en", "christmas")
-
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.admin.ok).toBe("error")
-  })
-
-  // The bridge MUST never break the user's render. If runDualReadComparison
-  // throws synchronously (circular ref, throwing toString, JSON.stringify
-  // failure), the orchestrator catches it and emits a structured
-  // forge.parity.canary_failed log line. User still gets Strapi.
-  it("dual-read mode: bridge sync-throw is caught — user gets Strapi, canary_failed event logged", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit())
-    adminQueryMock.mockResolvedValueOnce(adminHit())
-    runDualReadComparisonMock.mockImplementation(() => {
-      throw new Error("circular reference in payload")
-    })
+  it("admin mode + WEB_ADMIN_API_KEYS unset → logs consumer_bearer_missing and falls back to strapi", async () => {
+    modeRef.current = "admin"
+    envRef.WEB_ADMIN_API_KEYS = undefined
+    queryMock.mockResolvedValueOnce(strapiHit("strapi-fallback"))
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
 
     try {
       const { resolveWatchPage } = await import("./content")
       const result = await resolveWatchPage("en", "christmas")
 
-      // User gets Strapi result, NOT a 500.
-      expect(result.error).toBeNull()
-      expect(result.data).toMatchObject({ kind: "experience" })
+      // Strapi mock was called, admin mock was not.
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      expect(adminQueryMock).not.toHaveBeenCalled()
 
-      // canary_failed event was logged with the error message.
-      const canaryFailedCall = logSpy.mock.calls.find((call) => {
+      // User got the Strapi response — fallback is transparent for this request.
+      expect(result.error).toBeNull()
+      expect(result.data).toMatchObject({
+        kind: "experience",
+        experience: { documentId: "strapi-fallback" },
+      })
+
+      // forge.parity.consumer_bearer_missing event was logged.
+      const bearerMissingCall = logSpy.mock.calls.find((call) => {
         const arg = call[0]
         return (
-          typeof arg === "string" && arg.includes("forge.parity.canary_failed")
+          typeof arg === "string" &&
+          arg.includes("forge.parity.consumer_bearer_missing")
         )
       })
-      expect(canaryFailedCall).toBeDefined()
-      const payload = JSON.parse(canaryFailedCall?.[0] as string)
-      expect(payload.event).toBe("forge.parity.canary_failed")
-      expect(payload.errorMessage).toBe("circular reference in payload")
+      expect(bearerMissingCall).toBeDefined()
     } finally {
       logSpy.mockRestore()
     }
   })
 
-  // ---------------------------------------------------------------------------
-  // dual-read: Strapi throws, admin succeeds — gating signal for U5b advance
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // unstable_cache re-throw — load-bearing for UB7 error boundary
+  // -------------------------------------------------------------------------
 
-  it("dual-read mode: Strapi throws + admin OK → Strapi error propagates, bridge sees the gating signal", async () => {
-    modeRef.current = "dual-read"
-    const strapiError = new Error("strapi 503")
-    queryMock.mockRejectedValueOnce(strapiError)
-    adminQueryMock.mockResolvedValueOnce(adminHit())
+  it("unstable_cache callback re-throws WatchPageAdminError past the cache wrapper", async () => {
+    modeRef.current = "admin"
+    adminQueryMock.mockResolvedValueOnce({
+      data: { experienceBySlug: null },
+    })
+
+    const { resolveWatchPage, WatchPageAdminError } = await import("./content")
+
+    // The cache wrapper's catch block must detect WatchPageAdminError
+    // and re-throw — NOT convert to the `{ data, error }` sentinel.
+    // resolveWatchPage's promise rejects, doesn't resolve.
+    await expect(resolveWatchPage("en", "christmas")).rejects.toBeInstanceOf(
+      WatchPageAdminError,
+    )
+  })
+
+  it("unstable_cache callback returns sentinel for generic Errors (strapi-mode path unchanged)", async () => {
+    modeRef.current = "strapi"
+    queryMock.mockRejectedValueOnce(new Error("strapi 503"))
 
     const { resolveWatchPage } = await import("./content")
+    // Strapi-mode error keeps the sentinel path — resolves with `{ data: null, error }`.
     const result = await resolveWatchPage("en", "christmas")
 
-    // User-facing: Strapi error propagates (Strapi is the served source).
     expect(result.data).toBeNull()
     expect(result.error?.message).toBe("strapi 503")
-
-    expect(runDualReadComparisonMock).toHaveBeenCalledTimes(1)
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.strapi.ok).toBe("error")
-    expect(outcome.admin.ok).toBe(true)
   })
 
-  // ---------------------------------------------------------------------------
-  // dual-read: both fail — Strapi error propagates
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Integration — error propagation chain through the cache wrapper
+  // -------------------------------------------------------------------------
 
-  it("dual-read mode: both throw → Strapi error propagates, bridge sees both_failed", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockRejectedValueOnce(new Error("strapi down"))
-    adminQueryMock.mockRejectedValueOnce(new Error("admin down"))
+  it("integration: admin throw propagates through resolveWatchPage to the caller", async () => {
+    modeRef.current = "admin"
+    const apolloError = Object.assign(new Error("admin 500"), {
+      name: "ApolloError",
+      networkError: new Error("server error"),
+    })
+    adminQueryMock.mockRejectedValueOnce(apolloError)
 
-    const { resolveWatchPage } = await import("./content")
-    const result = await resolveWatchPage("en", "christmas")
+    const { resolveWatchPage, WatchPageAdminError } = await import("./content")
 
-    expect(result.data).toBeNull()
-    expect(result.error?.message).toBe("strapi down")
-
-    expect(runDualReadComparisonMock).toHaveBeenCalledTimes(1)
-    const outcome = runDualReadComparisonMock.mock.calls[0][0]
-    expect(outcome.strapi.ok).toBe("error")
-    expect(outcome.admin.ok).toBe("error")
-  })
-
-  // ---------------------------------------------------------------------------
-  // Integration — resolveSlugPage shape stable across modes
-  // ---------------------------------------------------------------------------
-
-  it("resolveSlugPage shape is identical across strapi and dual-read for the same fixture", async () => {
-    // Run once in strapi mode, once in dual-read mode, with identical
-    // Strapi mocks. The user-facing return value should match.
-    modeRef.current = "strapi"
-    queryMock.mockResolvedValueOnce(strapiHit("shared-1", "Shared"))
-    let mod = await import("./content")
-    const strapiResult = await mod.resolveWatchPage("en", "christmas")
-
-    vi.resetModules()
-    queryMock.mockReset()
-    adminQueryMock.mockReset()
-
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(strapiHit("shared-1", "Shared"))
-    adminQueryMock.mockResolvedValueOnce(adminHit("shared-1", "Shared"))
-    mod = await import("./content")
-    const dualReadResult = await mod.resolveWatchPage("en", "christmas")
-
-    expect(dualReadResult).toEqual(strapiResult)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// U5 — Regression snapshot: default behavior unchanged
-//
-// First-line-of-defense test that asserts every accepted mode value
-// produces a Strapi-equivalent return for the slug-page Experience fetch.
-// The "garbage" / null / undefined / empty-string cases all flow through
-// the strapi default branch (normalizeContentApiMode falls back). The
-// "dual-read" case asserts the user-facing return is still Strapi-driven
-// and that adminQueryMock was called (proving the canary is active).
-// ---------------------------------------------------------------------------
-
-describe("U5 regression — default behavior across mode values", () => {
-  beforeEach(() => {
-    modeRef.current = "strapi"
-  })
-
-  afterEach(() => {
-    queryMock.mockReset()
-    adminQueryMock.mockReset()
-    runDualReadComparisonMock.mockReset()
-    vi.resetModules()
-  })
-
-  function fixture() {
-    return {
-      data: {
-        experiences: [
-          {
-            documentId: "regression-1",
-            slug: "christmas",
-            locale: "en",
-            isTemplate: false,
-            title: "Regression Fixture",
-          },
-        ],
-      },
+    let thrown: unknown
+    try {
+      await resolveWatchPage("en", "christmas")
+    } catch (err) {
+      thrown = err
     }
-  }
 
-  // The undefined/null/empty-string/garbage cases fall back to "strapi"
-  // via env.ts's z.enum.default before reaching content-api-mode, so the
-  // mocked getContentApiMode only ever receives the typed union values.
-  // The "strapi" branch is the regression-protected default; "dual-read"
-  // is exercised in the canary tests above.
-  it("mode='strapi' returns Strapi-equivalent value and never touches admin", async () => {
-    modeRef.current = "strapi"
-    queryMock.mockResolvedValueOnce(fixture())
-
-    const { resolveWatchPage } = await import("./content")
-    const result = await resolveWatchPage("en", "christmas")
-
-    expect(result.error).toBeNull()
-    expect(result.data).toMatchObject({
-      kind: "experience",
-      experience: { documentId: "regression-1", slug: "christmas" },
-    })
-    expect(adminQueryMock).not.toHaveBeenCalled()
-    expect(runDualReadComparisonMock).not.toHaveBeenCalled()
-  })
-
-  it("mode='dual-read' still returns Strapi value to the user (admin runs in shadow)", async () => {
-    modeRef.current = "dual-read"
-    queryMock.mockResolvedValueOnce(fixture())
-    adminQueryMock.mockResolvedValueOnce({
-      data: {
-        experienceBySlug: {
-          id: "admin-shadow",
-          slug: "christmas",
-          locale: "en",
-          title: "Regression Fixture",
-          metaDescription: null,
-          ogImageUrl: null,
-          blocks: [],
-        },
-      },
-    })
-
-    const { resolveWatchPage } = await import("./content")
-    const result = await resolveWatchPage("en", "christmas")
-
-    expect(result.error).toBeNull()
-    // Strapi documentId is what reaches the user, NOT admin's id.
-    expect(result.data).toMatchObject({
-      kind: "experience",
-      experience: { documentId: "regression-1" },
-    })
-    expect(adminQueryMock).toHaveBeenCalledTimes(1)
-    expect(runDualReadComparisonMock).toHaveBeenCalledTimes(1)
-  })
-
-  // print() round-trip — the GET_WATCH_EXPERIENCE query is unchanged
-  // shape across U5; if a future refactor inadvertently rewrites it,
-  // this catches the drift.
-  it("GET_WATCH_EXPERIENCE selects WatchExperience (with locale field)", async () => {
-    modeRef.current = "strapi"
-    queryMock.mockResolvedValueOnce(fixture())
-    const { resolveWatchPage } = await import("./content")
-    await resolveWatchPage("en", "christmas")
-    const sentQuery = print(queryMock.mock.calls[0][0].query)
-    // U5 added `locale` to the WatchExperience fragment so normalizeStrapi
-    // can validate without the bridge's synth fallback. This pins it.
-    expect(sentQuery).toMatch(
-      /fragment WatchExperience on Experience[\s\S]*locale/,
+    // The full chain: fetchSlugExperience throws → resolveSlugPage
+    // re-throws → unstable_cache re-throws (load-bearing) →
+    // resolveWatchPage's outer `cache()` re-throws → caller catches.
+    expect(thrown).toBeInstanceOf(WatchPageAdminError)
+    expect((thrown as InstanceType<typeof WatchPageAdminError>).code).toBe(
+      "UNAVAILABLE",
+    )
+    // Original Apollo error preserved through the chain via `cause`.
+    expect((thrown as InstanceType<typeof WatchPageAdminError>).cause).toBe(
+      apolloError,
     )
   })
 })

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -719,7 +719,10 @@ export type WatchPageAdminErrorCode = "NOT_FOUND" | "UNAVAILABLE"
  * existing `{ data: null, error }` sentinel path. This typed surface is
  * additive for admin-mode throws only.
  *
- * Following `WatchVideoError`'s pattern below.
+ * Following `WatchVideoError`'s pattern below. The discriminator field
+ * is `code` (not `kind`) for parity with `WatchVideoError` — plan-003's
+ * prose used "kind" interchangeably with "code"; the codebase converged
+ * on `code`. Consumers (`[slug]/error.tsx`) dispatch on `error.code`.
  */
 export class WatchPageAdminError extends Error {
   readonly code: WatchPageAdminErrorCode

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -5,7 +5,7 @@ import { graphql, type ResultOf } from "@forge/graphql"
 import { env } from "@/env"
 import client from "@/lib/client"
 import adminClient from "@/lib/admin-client"
-import { getContentApiMode } from "@/lib/content-api-mode"
+import { getContentApiMode, type ContentApiMode } from "@/lib/content-api-mode"
 import type { EnrichedMediaItem } from "@/lib/enrichment"
 import { enrichRouteRelatedVideo } from "@/lib/enrichment"
 import {
@@ -164,14 +164,27 @@ export function experienceToMetadata(
     ogTitle,
     ogDescription,
     pathSegment: exp.pathSegment ?? null,
-    ogImage: exp.ogImage
-      ? {
+    // F12 (ce-code-review): admin's fragment exposes `ogImageUrl: String`,
+    // Strapi's exposes `ogImage: { url, width, height, alternativeText }`.
+    // Without this branch, admin-mode pages fall through to DEFAULT_OG_IMAGE
+    // — a real SEO regression that the strapi-only regression snapshot
+    // didn't catch. Width/height aren't available on admin's flat string;
+    // omit them so Next's metadata layer skips the dimensions tag.
+    ogImage: ((): ExperienceMetadata["ogImage"] => {
+      if (exp.ogImage) {
+        return {
           url: exp.ogImage.url,
           width: exp.ogImage.width ?? null,
           height: exp.ogImage.height ?? null,
           alt: exp.ogImage.alternativeText ?? "",
         }
-      : null,
+      }
+      const adminOgImageUrl = (exp as { ogImageUrl?: string | null }).ogImageUrl
+      if (adminOgImageUrl) {
+        return { url: adminOgImageUrl, width: null, height: null, alt: "" }
+      }
+      return null
+    })(),
   }
 }
 
@@ -567,10 +580,15 @@ async function resolveSlugPage(
   }
 }
 
+// F2 (ce-code-review): include mode in the cache key so strapi-shape
+// entries don't get served to admin-mode requests during the ~60s ISR
+// thrash window after a Doppler flip. unstable_cache's key derivation
+// uses keyParts + JSON.stringify(args), so a `mode` arg lands in the key.
 const fetchResolvedWatchPage = unstable_cache(
   async (
     locale: string,
     slugOrNull: string | null,
+    _mode: ContentApiMode,
   ): Promise<WatchPageResult> => {
     try {
       const resolved =
@@ -604,7 +622,7 @@ const fetchResolvedWatchPage = unstable_cache(
 /** Shared watch-page resolver for page rendering and metadata generation. */
 export const resolveWatchPage = cache(
   async (locale: string, slug?: string): Promise<WatchPageResult> => {
-    return fetchResolvedWatchPage(locale, slug ?? null)
+    return fetchResolvedWatchPage(locale, slug ?? null, getContentApiMode())
   },
 )
 

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -2,13 +2,10 @@ import type { ErrorLike } from "@apollo/client"
 import { cache } from "react"
 import { unstable_cache } from "next/cache"
 import { graphql, type ResultOf } from "@forge/graphql"
+import { env } from "@/env"
 import client from "@/lib/client"
 import adminClient from "@/lib/admin-client"
 import { getContentApiMode } from "@/lib/content-api-mode"
-import {
-  runDualReadComparison,
-  type DualReadOutcome,
-} from "@/lib/parity-bridge"
 import type { EnrichedMediaItem } from "@/lib/enrichment"
 import { enrichRouteRelatedVideo } from "@/lib/enrichment"
 import {
@@ -259,53 +256,41 @@ async function getExperienceByFilters(
 }
 
 // ---------------------------------------------------------------------------
-// U5 (feat-104) — dual-read parity canary for the slug-page Experience
+// U6 (plan-003 PR-B) — direct cutover branch for the slug-page Experience
 //
-// `fetchSlugExperience` is the inner branch site for the canary. It is
-// called only from `resolveSlugPage`'s slug-equality case. The homepage
-// path (`resolveHomepage`) and the legacy-homepage call still use
-// `getExperienceByFilters` directly — out of U5 scope.
+// `fetchSlugExperience` flips from Strapi to admin reads when
+// `FORGE_CONTENT_API === "admin"`. The homepage path (`resolveHomepage`)
+// and the legacy-homepage call still use `getExperienceByFilters`
+// directly — out of plan-003 scope.
 //
-// Modes (read once at module scope from FORGE_CONTENT_API):
+// Modes (closed set per plan-003 R3, narrowed by content-api-mode.ts):
 //   - strapi (default): identical to `getExperienceByFilters(locale,
 //     { slug: { eq: slug } })`. Byte-identical to current `main`.
-//   - dual-read: runs Strapi + admin in parallel via Promise.all,
-//     hands both outcomes to the parity bridge for diff logging,
-//     returns Strapi to the user. Admin failures/timeouts NEVER
-//     affect user-facing render.
+//   - admin: queries admin via `adminClient.query({ query:
+//     adminExperienceBySlugOperation, ... })`. On null → throws
+//     `WatchPageAdminError("NOT_FOUND")`. On Apollo/timeout/error →
+//     logs the subtype + throws `WatchPageAdminError("UNAVAILABLE")`.
 //
-// Retire alongside the rest of U5's scaffolding. See:
+// Retire the per-mode branch (fold to a direct admin call) alongside the
+// rest of U5's scaffolding once Strapi is gone. See:
 //   apps/web/src/lib/content-api-mode.ts (deletion checklist)
 // ---------------------------------------------------------------------------
 
-// IMPORTANT: this fetcher only ever produces `ok: true` or `ok: "error"`.
-// The SideOutcome union also admits `ok: "timeout"` (used by the admin
-// side); if you add timeout classification to Strapi here, also add the
-// matching branch to parity-bridge.ts's runDualReadComparison branch
-// table — otherwise (strapi:timeout, admin:true) silently falls through
-// to the unreachable narrowing return at the bottom of the bridge.
-async function fetchStrapiSlugExperience(
-  locale: string,
-  slug: string,
-): Promise<DualReadOutcome["strapi"]> {
-  const start = performance.now()
-  try {
-    const response = await getExperienceByFilters(locale, {
-      slug: { eq: slug },
-    })
-    return {
-      ok: true,
-      response: response ?? undefined,
-      durationMs: Math.round(performance.now() - start),
+// Outcome from the admin Apollo client, with timeout vs error classified
+// by error.name (per AWS-SDK-v3 NoSuchKey discipline — see
+// docs/solutions/runtime-errors/aws-s3-nosuchkey-classification-pattern-20260506.md).
+type AdminFetchOutcome =
+  | {
+      readonly ok: true
+      readonly response: unknown
+      readonly durationMs: number
     }
-  } catch (error) {
-    return {
-      ok: "error",
-      error,
-      durationMs: Math.round(performance.now() - start),
+  | {
+      readonly ok: "error"
+      readonly error: unknown
+      readonly durationMs: number
     }
-  }
-}
+  | { readonly ok: "timeout"; readonly durationMs: number }
 
 // Match the typed AbortSignal.timeout / AbortController shapes the AWS-SDK-v3
 // classification pattern recommends — error.name first, then cause.name, then
@@ -339,7 +324,7 @@ function hasTimeoutOrAbortName(error: Error): boolean {
 async function fetchAdminSlugExperience(
   locale: string,
   slug: string,
-): Promise<DualReadOutcome["admin"]> {
+): Promise<AdminFetchOutcome> {
   const start = performance.now()
   const elapsed = () => Math.round(performance.now() - start)
   try {
@@ -367,6 +352,42 @@ async function fetchAdminSlugExperience(
   }
 }
 
+// ---------------------------------------------------------------------------
+// U6 (plan-003 PR-B) — admin-mode log emission
+//
+// `fetchSlugExperience`'s admin branch fires a `forge.parity.admin_*`
+// structured log BEFORE throwing WatchPageAdminError("UNAVAILABLE"). The
+// subkind tells operators whether admin returned null (admin_null),
+// timed out (admin_timeout), or failed otherwise (admin_fetch_error).
+// Distinct from parity-bridge.ts events: those are dual-read canary
+// signals; these are admin-mode failure signals (one of: cutover broke,
+// admin is unhealthy, or rollback required).
+// ---------------------------------------------------------------------------
+
+type AdminFailureLogEvent =
+  | "forge.parity.admin_null"
+  | "forge.parity.admin_timeout"
+  | "forge.parity.admin_fetch_error"
+  | "forge.parity.consumer_bearer_missing"
+
+function logAdminEvent(
+  event: AdminFailureLogEvent,
+  slug: string,
+  locale: string,
+  errorMessage?: string,
+): void {
+  if (typeof console === "undefined") return
+  console.log(
+    JSON.stringify({
+      event,
+      route: "[slug]",
+      slug,
+      locale,
+      ...(errorMessage ? { errorMessage } : {}),
+    }),
+  )
+}
+
 async function fetchSlugExperience(
   locale: string,
   slug: string,
@@ -376,63 +397,57 @@ async function fetchSlugExperience(
     return getExperienceByFilters(locale, { slug: { eq: slug } })
   }
 
-  // dual-read: parallel fetch, log diff, serve Strapi.
-  const [strapiOutcome, adminOutcome] = await Promise.all([
-    fetchStrapiSlugExperience(locale, slug),
-    fetchAdminSlugExperience(locale, slug),
-  ])
+  // mode === "admin"
+  //
+  // Runtime safety net: WEB_ADMIN_API_KEYS unset is a deployment-error
+  // path, NOT an admin-mode failure fallback (per plan-003 R3 +
+  // "Bearer-missing safety net is a deployment-error path"). During the
+  // cutover window (Strapi live), serve `strapi` semantics for this
+  // request so a deploy-order mistake doesn't 500 every page. Log it so
+  // operators see the misconfig in the log stream.
+  //
+  // TODO(post-strapi-removal): switch to throwing WatchPageAdminError("UNAVAILABLE")
+  // once Strapi service is decommissioned. See plan-003 Key Technical Decisions:
+  // "Safety-net `strapi` fallback has a lifecycle tied to Strapi service liveness."
+  if (!env.WEB_ADMIN_API_KEYS) {
+    logAdminEvent("forge.parity.consumer_bearer_missing", slug, locale)
+    return getExperienceByFilters(locale, { slug: { eq: slug } })
+  }
 
-  // Bridge swallows harness errors and emits structured logs internally,
-  // but a sync throw at the bridge boundary (circular ref in payload,
-  // throwing toString on a proxy field, JSON.stringify failure on BigInt)
-  // would bubble out and break the user-facing render despite Strapi
-  // having already succeeded. Defense-in-depth: the canary must NEVER
-  // affect the user's response. Catch any such throw and emit a
-  // structured forge.parity.canary_failed log line so operators can see
-  // it, then continue and serve Strapi as planned.
-  try {
-    runDualReadComparison({
-      slug,
-      urlLocale: locale,
-      strapi: strapiOutcome,
-      admin: adminOutcome,
-    })
-  } catch (canaryErr) {
-    if (typeof console !== "undefined") {
-      console.log(
-        JSON.stringify({
-          event: "forge.parity.canary_failed",
-          route: "[slug]",
-          slug,
-          locale,
-          // Match the ParityLogPayload contract — every other parity event
-          // carries timings; canary_failed must too so dashboards filtering
-          // on timings.* don't see undefined on this branch.
-          timings: {
-            strapiMs: strapiOutcome.durationMs,
-            adminMs: adminOutcome.durationMs,
-          },
-          errorMessage:
-            canaryErr instanceof Error ? canaryErr.message : String(canaryErr),
-        }),
-      )
+  const outcome = await fetchAdminSlugExperience(locale, slug)
+
+  if (outcome.ok === true) {
+    // Admin returned null = slug not found in admin. NOT_FOUND → boundary.
+    if (outcome.response == null) {
+      logAdminEvent("forge.parity.admin_null", slug, locale)
+      throw new WatchPageAdminError("NOT_FOUND")
     }
+    // Admin returns ExperienceLocale | null with admin-shape fragments
+    // (the U5 selection set composes `adminWatchExperienceFragment`).
+    // Cast to `NonNullable<WatchExperience>` is structural — the
+    // renderer dispatch (U5) handles both Strapi typename cases and
+    // admin typename cases, and the resolver-level union from this
+    // function's signature unifies on WatchExperience.
+    return outcome.response as unknown as NonNullable<WatchExperience>
   }
 
-  // User-facing source is always Strapi in dual-read.
-  if (strapiOutcome.ok === true) {
-    return (strapiOutcome.response ??
-      null) as NonNullable<WatchExperience> | null
+  if (outcome.ok === "timeout") {
+    logAdminEvent("forge.parity.admin_timeout", slug, locale)
+    throw new WatchPageAdminError("UNAVAILABLE")
   }
-  if (strapiOutcome.ok === "error") {
-    throw strapiOutcome.error
-  }
-  // Exhaustive default for the SideOutcome union. Strapi's `client.ts`
-  // 10s AbortSignal surfaces as ok:"error" (not ok:"timeout") because
-  // fetchStrapiSlugExperience does not classify timeout vs error — only
-  // the admin side does. This branch is unreachable today; kept for
-  // type-narrowing safety if the union ever gains a new variant.
-  throw new Error("fetchSlugExperience: Strapi side returned no value")
+
+  // outcome.ok === "error" — Apollo/network/server error
+  const causeError =
+    outcome.error instanceof Error
+      ? outcome.error
+      : new Error(String(outcome.error))
+  logAdminEvent(
+    "forge.parity.admin_fetch_error",
+    slug,
+    locale,
+    causeError.message,
+  )
+  throw new WatchPageAdminError("UNAVAILABLE", { cause: causeError })
 }
 
 async function getWatchSettings(locale: string): Promise<WatchSetting | null> {
@@ -612,6 +627,17 @@ const fetchResolvedWatchPage = unstable_cache(
         error: null,
       }
     } catch (error) {
+      // U6 — admin-mode typed errors must REACH the segment error boundary
+      // (`apps/web/src/app/[slug]/error.tsx`, UB7). The cache wrapper's
+      // generic sentinel path would otherwise swallow the throw and let
+      // `page.tsx` render `<ExperienceError>` inline, never firing the
+      // boundary. `unstable_cache` re-throws errors from its inner
+      // function (verified by the comment at the watch-video-by-slug
+      // cache below: "unstable_cache re-throws on error and does NOT
+      // cache failures") — so re-throwing here propagates the
+      // WatchPageAdminError past the cache to `resolveWatchPage`'s
+      // caller. Strapi-mode generic Errors keep the sentinel path.
+      if (error instanceof WatchPageAdminError) throw error
       return {
         data: null,
         error: error instanceof Error ? error : new Error(String(error)),
@@ -659,6 +685,40 @@ export type WatchVideoErrorCode =
  * have request-scope fields, so collectionSlug/videoSlug/languageSlug are
  * optional and default to empty strings when omitted.
  */
+// ---------------------------------------------------------------------------
+// U6 (plan-003 PR-B) — typed admin-mode error surface
+// ---------------------------------------------------------------------------
+
+export type WatchPageAdminErrorCode = "NOT_FOUND" | "UNAVAILABLE"
+
+/**
+ * Typed error surfaced from `fetchSlugExperience` (and therefore
+ * `resolveWatchPage`) when admin mode is active and admin either returns
+ * a null slug (`NOT_FOUND`) or fails to respond cleanly (`UNAVAILABLE`,
+ * covering Apollo / network / timeout / 5xx / adapter throw). The cache
+ * wrapper at `fetchResolvedWatchPage` re-throws this class so the
+ * App Router segment error boundary at `apps/web/src/app/[slug]/error.tsx`
+ * (UB7) can dispatch on the two codes.
+ *
+ * Strapi-mode errors do NOT surface as this class — they keep the
+ * existing `{ data: null, error }` sentinel path. This typed surface is
+ * additive for admin-mode throws only.
+ *
+ * Following `WatchVideoError`'s pattern below.
+ */
+export class WatchPageAdminError extends Error {
+  readonly code: WatchPageAdminErrorCode
+
+  constructor(
+    code: WatchPageAdminErrorCode,
+    { cause }: { cause?: Error } = {},
+  ) {
+    super(`watch-page-admin:${code}`, cause ? { cause } : undefined)
+    this.name = "WatchPageAdminError"
+    this.code = code
+  }
+}
+
 export class WatchVideoError extends Error {
   readonly code: WatchVideoErrorCode
   readonly collectionSlug: string

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -16,8 +16,7 @@ import {
   watchVideoFragment,
 } from "@/lib/fragments"
 
-// U2: import the new watch-page fragment so its presence keeps the gql.tada
-// introspection types live.
+// Keep gql.tada introspection types live for the watch-page fragment.
 void watchVideoFragment
 
 const GET_EXPERIENCE = graphql(`
@@ -255,30 +254,13 @@ async function getExperienceByFilters(
     null) as NonNullable<WatchExperience> | null
 }
 
-// ---------------------------------------------------------------------------
-// U6 (plan-003 PR-B) — direct cutover branch for the slug-page Experience
-//
-// `fetchSlugExperience` flips from Strapi to admin reads when
-// `FORGE_CONTENT_API === "admin"`. The homepage path (`resolveHomepage`)
-// and the legacy-homepage call still use `getExperienceByFilters`
-// directly — out of plan-003 scope.
-//
-// Modes (closed set per plan-003 R3, narrowed by content-api-mode.ts):
-//   - strapi (default): identical to `getExperienceByFilters(locale,
-//     { slug: { eq: slug } })`. Byte-identical to current `main`.
-//   - admin: queries admin via `adminClient.query({ query:
-//     adminExperienceBySlugOperation, ... })`. On null → throws
-//     `WatchPageAdminError("NOT_FOUND")`. On Apollo/timeout/error →
-//     logs the subtype + throws `WatchPageAdminError("UNAVAILABLE")`.
-//
-// Retire the per-mode branch (fold to a direct admin call) alongside the
-// rest of U5's scaffolding once Strapi is gone. See:
-//   apps/web/src/lib/content-api-mode.ts (deletion checklist)
-// ---------------------------------------------------------------------------
+// `fetchSlugExperience` reads from Strapi or admin per FORGE_CONTENT_API.
+// admin mode: throws WatchPageAdminError("NOT_FOUND") on null,
+// WatchPageAdminError("UNAVAILABLE") on Apollo/timeout/error.
+// Retire alongside content-api-mode.ts scaffolding when Strapi is gone.
 
-// Outcome from the admin Apollo client, with timeout vs error classified
-// by error.name (per AWS-SDK-v3 NoSuchKey discipline — see
-// docs/solutions/runtime-errors/aws-s3-nosuchkey-classification-pattern-20260506.md).
+// Timeout vs error classified by error.name (AWS-SDK-v3 NoSuchKey discipline).
+// See docs/solutions/runtime-errors/aws-s3-nosuchkey-classification-pattern-20260506.md.
 type AdminFetchOutcome =
   | {
       readonly ok: true
@@ -292,20 +274,14 @@ type AdminFetchOutcome =
     }
   | { readonly ok: "timeout"; readonly durationMs: number }
 
-// Match the typed AbortSignal.timeout / AbortController shapes the AWS-SDK-v3
-// classification pattern recommends — error.name first, then cause.name, then
-// Apollo Client v4's `networkError` surface (which wraps fetch-link errors
-// and may itself carry the typed AbortSignal cause). No message-substring
-// fallback: a real GraphQL error mentioning "timeout" would be misclassified
-// as forge.parity.admin_timeout, polluting the canary's gating signal. See:
-//   docs/solutions/runtime-errors/aws-s3-nosuchkey-classification-pattern-20260506.md
+// Dispatch on error.name only — a GraphQL error message mentioning "timeout"
+// would otherwise be misclassified as a real timeout and pollute the gating signal.
 function isAbortTimeoutError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
   if (hasTimeoutOrAbortName(error)) return true
   const cause = (error as { cause?: unknown }).cause
   if (cause instanceof Error && hasTimeoutOrAbortName(cause)) return true
-  // Apollo Client v4 surfaces transport errors via `error.networkError`.
-  // The networkError itself or its cause may carry the typed shape.
+  // Apollo Client v4 wraps transport errors via `error.networkError`.
   const networkError = (error as { networkError?: unknown }).networkError
   if (networkError instanceof Error) {
     if (hasTimeoutOrAbortName(networkError)) return true
@@ -352,18 +328,9 @@ async function fetchAdminSlugExperience(
   }
 }
 
-// ---------------------------------------------------------------------------
-// U6 (plan-003 PR-B) — admin-mode log emission
-//
-// `fetchSlugExperience`'s admin branch fires a `forge.parity.admin_*`
-// structured log BEFORE throwing WatchPageAdminError("UNAVAILABLE"). The
-// subkind tells operators whether admin returned null (admin_null),
-// timed out (admin_timeout), or failed otherwise (admin_fetch_error).
-// Distinct from parity-bridge.ts events: those are dual-read canary
-// signals; these are admin-mode failure signals (one of: cutover broke,
-// admin is unhealthy, or rollback required).
-// ---------------------------------------------------------------------------
-
+// Admin-mode failure signals — distinct from parity-bridge dual-read canary
+// signals. Emitted before throwing WatchPageAdminError so operators see
+// which of admin_null / admin_timeout / admin_fetch_error triggered.
 type AdminFailureLogEvent =
   | "forge.parity.admin_null"
   | "forge.parity.admin_timeout"
@@ -399,22 +366,11 @@ async function fetchSlugExperience(
 
   // mode === "admin"
   //
-  // Runtime safety net: WEB_ADMIN_API_KEYS unset is a deployment-error
-  // path, NOT an admin-mode failure fallback (per plan-003 R3 +
-  // "Bearer-missing safety net is a deployment-error path"). During the
-  // cutover window (Strapi live), serve `strapi` semantics for this
-  // request so a deploy-order mistake doesn't 500 every page. Log it so
-  // operators see the misconfig in the log stream.
+  // Bearer-missing safety net: during cutover, serve strapi semantics so a
+  // deploy-order mistake doesn't 500 every page. Presence check mirrors
+  // admin-client.ts (whitespace/empty-first-CSV counts as unset).
   //
-  // C2 (ce-code-review): align the presence check with admin-client.ts —
-  // both must classify whitespace-only / empty-first-CSV-entry as
-  // "unset" so the safety net fires even when the env var is technically
-  // set but useless. admin-client.ts does `.split(",")[0]?.trim() || undefined`
-  // at module scope; we mirror that here.
-  //
-  // TODO(post-strapi-removal): switch to throwing WatchPageAdminError("UNAVAILABLE")
-  // once Strapi service is decommissioned. See plan-003 Key Technical Decisions:
-  // "Safety-net `strapi` fallback has a lifecycle tied to Strapi service liveness."
+  // TODO(post-strapi-removal): throw WatchPageAdminError("UNAVAILABLE") instead.
   const bearerFirstEntry = env.WEB_ADMIN_API_KEYS?.split(",")[0]?.trim()
   if (!bearerFirstEntry) {
     logAdminEvent("forge.parity.consumer_bearer_missing", slug, locale)
@@ -424,17 +380,11 @@ async function fetchSlugExperience(
   const outcome = await fetchAdminSlugExperience(locale, slug)
 
   if (outcome.ok === true) {
-    // Admin returned null = slug not found in admin. NOT_FOUND → boundary.
     if (outcome.response == null) {
       logAdminEvent("forge.parity.admin_null", slug, locale)
       throw new WatchPageAdminError("NOT_FOUND")
     }
-    // Admin returns ExperienceLocale | null with admin-shape fragments
-    // (the U5 selection set composes `adminWatchExperienceFragment`).
-    // Cast to `NonNullable<WatchExperience>` is structural — the
-    // renderer dispatch (U5) handles both Strapi typename cases and
-    // admin typename cases, and the resolver-level union from this
-    // function's signature unifies on WatchExperience.
+    // Structural cast — renderer dispatch handles both Strapi and admin typenames.
     return outcome.response as unknown as NonNullable<WatchExperience>
   }
 
@@ -448,11 +398,9 @@ async function fetchSlugExperience(
     outcome.error instanceof Error
       ? outcome.error
       : new Error(String(outcome.error))
-  // sec-002 (ce-code-review): scrub the bearer key from the error message
-  // BEFORE logging. Apollo's response-error formatter can include
-  // downstream-server-controlled response body text in `message`; a
-  // misconfigured/hostile admin echoing the Authorization header in a
-  // 500 response would leak the bearer to Railway logs without this.
+  // SECURITY: scrub the bearer before logging. Apollo's error formatter can
+  // include downstream response body text in `message`; a hostile admin
+  // echoing the Authorization header in a 500 would otherwise leak the bearer.
   const sanitizedMessage = bearerFirstEntry
     ? causeError.message.split(bearerFirstEntry).join("<redacted>")
     : causeError.message
@@ -586,9 +534,6 @@ async function resolveSlugPage(
   locale: string,
   slug: string,
 ): Promise<ResolvedWatchPage | null> {
-  // U5 — slug-page Experience branch goes through fetchSlugExperience so
-  // dual-read mode can fan out to admin in shadow. Behavior in `strapi`
-  // mode (default) is identical to the previous direct call.
   const explicitExperience = asNonTemplateExperience(
     await fetchSlugExperience(locale, slug),
   )
@@ -642,16 +587,9 @@ const fetchResolvedWatchPage = unstable_cache(
         error: null,
       }
     } catch (error) {
-      // U6 — admin-mode typed errors must REACH the segment error boundary
-      // (`apps/web/src/app/[slug]/error.tsx`, UB7). The cache wrapper's
-      // generic sentinel path would otherwise swallow the throw and let
-      // `page.tsx` render `<ExperienceError>` inline, never firing the
-      // boundary. `unstable_cache` re-throws errors from its inner
-      // function (verified by the comment at the watch-video-by-slug
-      // cache below: "unstable_cache re-throws on error and does NOT
-      // cache failures") — so re-throwing here propagates the
-      // WatchPageAdminError past the cache to `resolveWatchPage`'s
-      // caller. Strapi-mode generic Errors keep the sentinel path.
+      // WatchPageAdminError must propagate to the segment error boundary,
+      // not get swallowed into the sentinel path. unstable_cache re-throws
+      // (does not cache failures), so re-throwing here reaches the caller.
       if (error instanceof WatchPageAdminError) throw error
       return {
         data: null,
@@ -670,9 +608,7 @@ export const resolveWatchPage = cache(
   },
 )
 
-// ---------------------------------------------------------------------------
-// U3: dedicated watch route resolver
-// ---------------------------------------------------------------------------
+// Dedicated watch route resolver
 
 type GetWatchVideoData = ResultOf<typeof getWatchVideoOperation>
 type WatchVideoRecord = NonNullable<GetWatchVideoData["videos"][number]>
@@ -700,29 +636,12 @@ export type WatchVideoErrorCode =
  * have request-scope fields, so collectionSlug/videoSlug/languageSlug are
  * optional and default to empty strings when omitted.
  */
-// ---------------------------------------------------------------------------
-// U6 (plan-003 PR-B) — typed admin-mode error surface
-// ---------------------------------------------------------------------------
-
 export type WatchPageAdminErrorCode = "NOT_FOUND" | "UNAVAILABLE"
 
 /**
- * Typed error surfaced from `fetchSlugExperience` (and therefore
- * `resolveWatchPage`) when admin mode is active and admin either returns
- * a null slug (`NOT_FOUND`) or fails to respond cleanly (`UNAVAILABLE`,
- * covering Apollo / network / timeout / 5xx / adapter throw). The cache
- * wrapper at `fetchResolvedWatchPage` re-throws this class so the
- * App Router segment error boundary at `apps/web/src/app/[slug]/error.tsx`
- * (UB7) can dispatch on the two codes.
- *
- * Strapi-mode errors do NOT surface as this class — they keep the
- * existing `{ data: null, error }` sentinel path. This typed surface is
- * additive for admin-mode throws only.
- *
- * Following `WatchVideoError`'s pattern below. The discriminator field
- * is `code` (not `kind`) for parity with `WatchVideoError` — plan-003's
- * prose used "kind" interchangeably with "code"; the codebase converged
- * on `code`. Consumers (`[slug]/error.tsx`) dispatch on `error.code`.
+ * Admin-mode failure thrown by `fetchSlugExperience` so the segment error
+ * boundary at `apps/web/src/app/[slug]/error.tsx` can dispatch on `code`.
+ * Strapi-mode errors continue through the `{ data, error }` sentinel path.
  */
 export class WatchPageAdminError extends Error {
   readonly code: WatchPageAdminErrorCode
@@ -1059,9 +978,7 @@ export const resolveWatchVideoBySlug = cache(
   },
 )
 
-// ---------------------------------------------------------------------------
-// U4: Hybrid resolver — synthetic watch blocks + per-block-type override merge
-// ---------------------------------------------------------------------------
+// Hybrid resolver — synthetic watch blocks + per-block-type override merge
 
 type WatchStudyQuestion = NonNullable<
   NonNullable<WatchVideoRecord["studyQuestions"]>[number]

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -411,12 +411,16 @@ async function fetchSlugExperience(
     outcome.error instanceof Error
       ? outcome.error
       : new Error(String(outcome.error))
-  // SECURITY: scrub the bearer before logging. Apollo's error formatter can
-  // include downstream response body text in `message`; a hostile admin
-  // echoing the Authorization header in a 500 would otherwise leak the bearer.
-  const sanitizedMessage = bearerFirstEntry
-    ? causeError.message.split(bearerFirstEntry).join("<redacted>")
-    : causeError.message
+  // SECURITY (F13): redact EVERY CSV entry, not just the first. Mid-rotation
+  // both keys are live and either can show up in an echoed error body.
+  const bearerEntries =
+    env.WEB_ADMIN_API_KEYS?.split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0) ?? []
+  const sanitizedMessage = bearerEntries.reduce(
+    (msg, entry) => msg.split(entry).join("<redacted>"),
+    causeError.message,
+  )
   logAdminEvent(
     "forge.parity.admin_fetch_error",
     slug,

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -406,10 +406,17 @@ async function fetchSlugExperience(
   // request so a deploy-order mistake doesn't 500 every page. Log it so
   // operators see the misconfig in the log stream.
   //
+  // C2 (ce-code-review): align the presence check with admin-client.ts —
+  // both must classify whitespace-only / empty-first-CSV-entry as
+  // "unset" so the safety net fires even when the env var is technically
+  // set but useless. admin-client.ts does `.split(",")[0]?.trim() || undefined`
+  // at module scope; we mirror that here.
+  //
   // TODO(post-strapi-removal): switch to throwing WatchPageAdminError("UNAVAILABLE")
   // once Strapi service is decommissioned. See plan-003 Key Technical Decisions:
   // "Safety-net `strapi` fallback has a lifecycle tied to Strapi service liveness."
-  if (!env.WEB_ADMIN_API_KEYS) {
+  const bearerFirstEntry = env.WEB_ADMIN_API_KEYS?.split(",")[0]?.trim()
+  if (!bearerFirstEntry) {
     logAdminEvent("forge.parity.consumer_bearer_missing", slug, locale)
     return getExperienceByFilters(locale, { slug: { eq: slug } })
   }
@@ -441,11 +448,19 @@ async function fetchSlugExperience(
     outcome.error instanceof Error
       ? outcome.error
       : new Error(String(outcome.error))
+  // sec-002 (ce-code-review): scrub the bearer key from the error message
+  // BEFORE logging. Apollo's response-error formatter can include
+  // downstream-server-controlled response body text in `message`; a
+  // misconfigured/hostile admin echoing the Authorization header in a
+  // 500 response would leak the bearer to Railway logs without this.
+  const sanitizedMessage = bearerFirstEntry
+    ? causeError.message.split(bearerFirstEntry).join("<redacted>")
+    : causeError.message
   logAdminEvent(
     "forge.parity.admin_fetch_error",
     slug,
     locale,
-    causeError.message,
+    sanitizedMessage,
   )
   throw new WatchPageAdminError("UNAVAILABLE", { cause: causeError })
 }

--- a/apps/web/src/lib/fragments/admin-experience.ts
+++ b/apps/web/src/lib/fragments/admin-experience.ts
@@ -1,14 +1,16 @@
-import { adminGraphql } from "@forge/graphql"
+import { adminGraphql, adminWatchExperienceFragment } from "@forge/graphql"
 
 // =============================================================================
 // U5 (feat-104) — admin experienceBySlug operation
 //
 // Built via the adminGraphql() factory (NOT graphql() — that targets
-// Strapi's schema). Selection set covers every field on ExperienceLocale
-// the parity bridge needs: id / slug / locale / title / metaDescription /
-// ogImageUrl / ogTitle / ogDescription / pathSegment / blocks (JSON
-// scalar — block-shape validation happens downstream in normalizeAdmin
-// via @forge/admin/domain/blocks BlocksSchema).
+// Strapi's schema). Selection set composes the shared
+// `adminWatchExperienceFragment` exported from `@forge/graphql` so the
+// admin schema's typed [ExperienceBlock!]! union is unpacked correctly
+// after PR-A's blocks-as-typed-union change. Post-PR-A, selecting
+// `blocks` as an opaque scalar (the U5 launch shape) no longer
+// typechecks — every block kind needs an inline `... on <Block>`
+// spread, supplied by the shared root fragment.
 //
 // Note: admin's schema field is `metaDescription`, not `description`.
 // The parity bridge remaps to `description` before invoking
@@ -18,19 +20,13 @@ import { adminGraphql } from "@forge/graphql"
 //   apps/web/src/lib/content-api-mode.ts (deletion checklist)
 // =============================================================================
 
-export const adminExperienceBySlugOperation = adminGraphql(`
-  query GetAdminExperienceBySlug($locale: String!, $slug: String!) {
-    experienceBySlug(locale: $locale, slug: $slug) {
-      id
-      slug
-      locale
-      title
-      metaDescription
-      ogImageUrl
-      ogTitle
-      ogDescription
-      pathSegment
-      blocks
+export const adminExperienceBySlugOperation = adminGraphql(
+  `
+    query GetAdminExperienceBySlug($locale: String!, $slug: String!) {
+      experienceBySlug(locale: $locale, slug: $slug) {
+        ...AdminWatchExperience
+      }
     }
-  }
-`)
+  `,
+  [adminWatchExperienceFragment],
+)

--- a/apps/web/src/lib/parity-bridge.test.ts
+++ b/apps/web/src/lib/parity-bridge.test.ts
@@ -1,14 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const { mockEnv } = vi.hoisted(() => ({
+const { mockEnv, modeRef } = vi.hoisted(() => ({
   mockEnv: {
     NEXT_PUBLIC_CANONICAL_ORIGIN: "https://canonical.local",
     FORGE_PARITY_DEBUG: "0" as "0" | "1",
   },
+  // The bridge's U5 mode guard short-circuits unless the active mode
+  // is `"dual-read"`. After U4 collapsed the active union to
+  // `"strapi" | "admin"`, that mode is unreachable in production — but
+  // these tests exercise the bridge's emission contract directly, so
+  // we default-mock to the historical canary mode and let the mode-
+  // guard tests flip `modeRef.value` to exercise the short-circuit.
+  modeRef: { value: "dual-read" as string },
 }))
 
 vi.mock("@/env", () => ({
   env: mockEnv,
+}))
+
+vi.mock("@/lib/content-api-mode", () => ({
+  getContentApiMode: () => modeRef.value,
 }))
 
 import {
@@ -393,5 +404,82 @@ describe("parity-bridge — runDualReadComparison", () => {
     } finally {
       procEnv.NODE_ENV = originalNodeEnv
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// U5 (PR-B) mode guard — short-circuit when the active mode is anything
+// other than `"dual-read"`. After U4 collapsed the active union, this
+// effectively kills all canary emission.
+// ---------------------------------------------------------------------------
+
+describe("parity-bridge — mode guard", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    // Restore the dual-read default after every test so unrelated suites
+    // run against the historical emission contract.
+    modeRef.value = "dual-read"
+  })
+
+  it("emits ZERO log events when the active mode is 'admin'", () => {
+    modeRef.value = "admin"
+    runDualReadComparison({
+      slug: "christmas",
+      urlLocale: "en",
+      strapi: {
+        ok: true,
+        response: {
+          documentId: "id",
+          slug: "christmas",
+          locale: "en",
+          title: "T",
+          metaDescription: "D",
+          ogImage: null,
+          blocks: [],
+        },
+        durationMs: 10,
+      },
+      admin: {
+        ok: true,
+        response: {
+          id: "id",
+          slug: "christmas",
+          locale: "en",
+          title: "T",
+          metaDescription: "D",
+          ogImageUrl: null,
+          blocks: [],
+        },
+        durationMs: 10,
+      },
+    })
+
+    expect(logSpy).not.toHaveBeenCalled()
+  })
+
+  it("emits ZERO log events when the active mode is 'strapi'", () => {
+    modeRef.value = "strapi"
+    runDualReadComparison({
+      slug: "any",
+      urlLocale: "en",
+      strapi: {
+        ok: "error",
+        error: new Error("upstream"),
+        durationMs: 0,
+      },
+      admin: {
+        ok: "error",
+        error: new Error("upstream"),
+        durationMs: 0,
+      },
+    })
+
+    expect(logSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/parity-bridge.ts
+++ b/apps/web/src/lib/parity-bridge.ts
@@ -39,6 +39,26 @@ import {
   type AdminExperienceLocaleInput,
 } from "@forge/graphql/parity"
 import { env } from "@/env"
+import { getContentApiMode } from "@/lib/content-api-mode"
+
+/**
+ * Mode guard for every canary emit-site. After U4 collapsed the active
+ * `ContentApiMode` union to `"strapi" | "admin"`, `"dual-read"` is no
+ * longer a reachable mode — the comparison is against a string literal
+ * the typed union cannot match. This is intentional: the guard kills
+ * canary emission across the board post-cutover so U9's runbook does
+ * NOT have to disambiguate "real admin failure" from "leftover canary
+ * noise".
+ *
+ * The bridge module + its callsite in content.ts will retire entirely
+ * once the cutover holds for a parity-clean window (see the deletion
+ * checklist at the top of this file). Until then, the explicit cast to
+ * `string` documents that the dead-branch behavior is deliberate, not
+ * an accidental TS narrowing artifact.
+ */
+function isCanaryEmissionEnabled(): boolean {
+  return (getContentApiMode() as string) === "dual-read"
+}
 
 /**
  * Closed union of every parity log event ce-work emits. Exporting the
@@ -188,8 +208,16 @@ type ParityLogPayload = {
  * appropriate log event, and emits a single `console.log(JSON.stringify(...))`
  * line. Never re-throws — all harness errors are caught and routed to
  * `forge.parity.harness_error`.
+ *
+ * U5 (PR-B) mode guard: if the active `ContentApiMode` is anything
+ * other than `"dual-read"`, the bridge short-circuits before any
+ * normalization / comparison work. After U4's mode-set collapse,
+ * `"dual-read"` is unreachable in production — so this guard
+ * effectively kills canary emission across the board.
  */
 export function runDualReadComparison(outcome: DualReadOutcome): void {
+  if (!isCanaryEmissionEnabled()) return
+
   const baseTimings = {
     strapiMs: outcome.strapi.durationMs,
     adminMs: outcome.admin.durationMs,
@@ -409,6 +437,14 @@ function adaptStrapi(
 function adaptAdmin(
   response: AdminExperienceResponse,
 ): AdminExperienceLocaleInput {
+  // Post-PR-A, `AdminExperienceLocaleInput.blocks` is
+  // `ReadonlyArray<Block>` from `@forge/admin/domain/blocks`. The wire
+  // shape returned by admin's typed [ExperienceBlock!]! field matches
+  // that at runtime — but the loose `AdminExperienceResponse` here is
+  // typed `unknown` so legacy callers (and the mode guard's
+  // short-circuit) don't have to know about the @forge/admin import.
+  // The cast is safe under the harness's defensive
+  // `BlocksSchema.safeParse(...)` which still runs on the input.
   return {
     id: response.id ?? "",
     slug: response.slug ?? "",
@@ -416,7 +452,7 @@ function adaptAdmin(
     title: response.title ?? "",
     description: response.metaDescription,
     ogImageUrl: response.ogImageUrl,
-    blocks: response.blocks,
+    blocks: response.blocks as AdminExperienceLocaleInput["blocks"],
   }
 }
 

--- a/apps/web/src/lib/parity-bridge.ts
+++ b/apps/web/src/lib/parity-bridge.ts
@@ -15,7 +15,10 @@
 //
 //   - This file: apps/web/src/lib/parity-bridge.ts
 //   - The companion test: apps/web/src/lib/parity-bridge.test.ts
-//   - Every callsite of `runDualReadComparison` in content.ts
+//   - Every callsite of `runDualReadComparison` (currently zero —
+//     content.ts removed the only callsite at U6/plan-003 cutover;
+//     parity-bridge.ts retained only for the U5 deletion PR to lift
+//     wholesale)
 //   - All seven parity log event names from any log alerting / dashboards
 //     (forge.parity.diff, forge.parity.admin_timeout,
 //      forge.parity.harness_error, forge.parity.strapi_failed_admin_succeeded,

--- a/apps/web/src/lib/parity-bridge.ts
+++ b/apps/web/src/lib/parity-bridge.ts
@@ -1,34 +1,19 @@
-// =============================================================================
-// U5 (feat-104 consumer migration) — parity bridge
-//
-// Consumer-side adapter that takes the orchestrated outcome of a
-// Strapi + admin parallel fetch (from fetchSlugExperience in
-// content.ts), runs the U4 harness's normalizers + comparator, and
-// emits a single structured log line per request.
+// Consumer-side parity adapter — runs the harness's normalizers + comparator
+// over the orchestrated outcome and emits one structured log line per request.
 //
 // Cross-references:
-//   apps/web/src/lib/content-api-mode.ts       (U1 — flag deletion list)
+//   apps/web/src/lib/content-api-mode.ts       (flag deletion list)
 //   packages/graphql/src/parity/index.ts:1-34  (harness deletion list)
-//   docs/plans/2026-05-08-001-feat-consumer-migration-web-canary-unit-5-plan.md
 //
-// At retirement, remove ALL of the following in one PR:
-//
-//   - This file: apps/web/src/lib/parity-bridge.ts
-//   - The companion test: apps/web/src/lib/parity-bridge.test.ts
-//   - Every callsite of `runDualReadComparison` (currently zero —
-//     content.ts removed the only callsite at U6/plan-003 cutover;
-//     parity-bridge.ts retained only for the U5 deletion PR to lift
-//     wholesale)
-//   - All seven parity log event names from any log alerting / dashboards
-//     (forge.parity.diff, forge.parity.admin_timeout,
-//      forge.parity.harness_error, forge.parity.strapi_failed_admin_succeeded,
-//      forge.parity.both_failed, forge.parity.admin_missing,
-//      forge.parity.canary_failed)
-//   - The FORGE_PARITY_DEBUG env var from any deployed env config
-//   - The `@forge/graphql/parity` package import — once nothing else
-//     consumes it, the harness directory can also retire
-//
-// =============================================================================
+// Deletion checklist (remove together in one PR):
+//   - This file + parity-bridge.test.ts
+//   - Every callsite of runDualReadComparison (currently zero)
+//   - All seven parity log event names from log alerting / dashboards:
+//     forge.parity.{diff, admin_timeout, harness_error,
+//     strapi_failed_admin_succeeded, both_failed, admin_missing, canary_failed}
+//   - FORGE_PARITY_DEBUG env var from deployed env config
+//   - @forge/graphql/parity import; the harness directory can retire too
+//     once nothing else consumes it
 
 import {
   AdminBlocksValidationError,
@@ -44,64 +29,33 @@ import {
 import { env } from "@/env"
 import { getContentApiMode } from "@/lib/content-api-mode"
 
-/**
- * Mode guard for every canary emit-site. After U4 collapsed the active
- * `ContentApiMode` union to `"strapi" | "admin"`, `"dual-read"` is no
- * longer a reachable mode — the comparison is against a string literal
- * the typed union cannot match. This is intentional: the guard kills
- * canary emission across the board post-cutover so U9's runbook does
- * NOT have to disambiguate "real admin failure" from "leftover canary
- * noise".
- *
- * The bridge module + its callsite in content.ts will retire entirely
- * once the cutover holds for a parity-clean window (see the deletion
- * checklist at the top of this file). Until then, the explicit cast to
- * `string` documents that the dead-branch behavior is deliberate, not
- * an accidental TS narrowing artifact.
- */
+// `"dual-read"` is no longer in the typed ContentApiMode union, so this
+// guard returns false in production — kills canary emission across the
+// board so operators don't have to disambiguate real admin failures from
+// leftover canary noise. Explicit string cast documents the dead branch
+// is deliberate.
 function isCanaryEmissionEnabled(): boolean {
   return (getContentApiMode() as string) === "dual-read"
 }
 
-/**
- * Closed union of every parity log event ce-work emits. Exporting the
- * union as `as const`-derived type lets callers type-check event names
- * at compile time. Adding a new event requires updating this list AND
- * the deletion checklist above.
- */
 export const PARITY_LOG_EVENTS = [
   "forge.parity.diff",
   "forge.parity.admin_timeout",
   "forge.parity.harness_error",
   "forge.parity.strapi_failed_admin_succeeded",
   "forge.parity.both_failed",
-  // Both fetches succeeded but admin returned null — typical during
-  // backfill (slug exists in Strapi, not yet in admin). Distinct from
-  // harness_error/comparator_unknown so dashboards can separate
-  // legitimate-gap from real comparator failures.
+  // Both fetched OK but admin returned null — typical during backfill.
+  // Distinct from harness_error so dashboards can split legitimate-gap
+  // from real comparator failures.
   "forge.parity.admin_missing",
-  // Defense-in-depth: the bridge itself threw. Emitted from the
-  // orchestrator (content.ts) when runDualReadComparison surfaces a
-  // sync error (circular ref in payload, throwing toString, etc.).
-  // The user's render is unaffected — Strapi already returned.
+  // The bridge itself threw (circular ref in payload, throwing toString).
+  // User render unaffected — Strapi already returned.
   "forge.parity.canary_failed",
 ] as const
 type ParityLogEvent = (typeof PARITY_LOG_EVENTS)[number]
 
-/**
- * Stable route discriminator for the parity log payload. Hard-coded to
- * "[slug]" because U5's canary surface is the slug-page Experience
- * branch only. Future units that add other route surfaces (homepage,
- * /watch/[collection]/[video]/[locale]) will introduce their own
- * route literals.
- */
 const PARITY_ROUTE = "[slug]" as const
 
-/**
- * Subkind discriminator for `harness_error` events. Tells the operator
- * which boundary surfaced the error (admin fetch, admin parse, Strapi
- * parse, or generic comparator failure).
- */
 type HarnessErrorSubkind =
   | "admin_fetch_error"
   | "admin_blocks_validation"
@@ -109,11 +63,6 @@ type HarnessErrorSubkind =
   | "strapi_normalization"
   | "comparator_unknown"
 
-/**
- * Outcome shape per source. The orchestrator (content.ts) wraps each
- * fetch with try/catch + Promise.race timeout and hands the bridge the
- * resulting tagged union.
- */
 type SideOutcome<T> =
   | { readonly ok: true; readonly response: T; readonly durationMs: number }
   | {
@@ -123,12 +72,6 @@ type SideOutcome<T> =
     }
   | { readonly ok: "timeout"; readonly durationMs: number }
 
-/**
- * Loose Strapi response shape — matches what `WatchExperience` selects
- * from `GET_WATCH_EXPERIENCE`. The bridge picks the harness-required
- * fields off this and synthesizes missing ones (notably `locale`,
- * which the existing fragment may not select).
- */
 type StrapiExperienceResponse = {
   readonly documentId?: string | null
   readonly slug?: string | null
@@ -144,12 +87,8 @@ type StrapiExperienceResponse = {
   readonly blocks?: ReadonlyArray<unknown> | null
 }
 
-/**
- * Loose admin response shape — matches `experienceBySlug` returning
- * `ExperienceLocale | null`. Note `metaDescription` is the admin schema
- * field name; the bridge remaps to `description` before invoking
- * `normalizeAdmin` (which consumes `description`, NOT `metaDescription`).
- */
+// Note: admin schema's `metaDescription` is remapped to `description` in
+// `adaptAdmin` before invoking `normalizeAdmin`.
 type AdminExperienceResponse = {
   readonly id?: string | null
   readonly slug?: string | null
@@ -167,16 +106,10 @@ export type DualReadOutcome = {
   readonly admin: SideOutcome<AdminExperienceResponse | null | undefined>
 }
 
-/**
- * Production log payload. NEVER carries raw `ValueDiff.strapi` or
- * `SemanticDiff.admin` field values from the harness's `DiffReport` —
- * those are content fields (titles, descriptions, URLs) that would
- * bypass CMS access control if indexed by Vercel/Railway log search.
- *
- * Only `paths` (RFC6901 JSON Pointers) and per-channel `counts` reach
- * production logs. The full `DiffReport` (with values) is opt-in for
- * dev under `FORGE_PARITY_DEBUG=1`; production strips unconditionally.
- */
+// SECURITY: production payload NEVER carries raw diff values (titles,
+// descriptions, URLs) — those would bypass CMS access control if indexed
+// by Vercel/Railway log search. Only paths + counts reach prod; full
+// DiffReport is dev-opt-in via FORGE_PARITY_DEBUG=1.
 type ParityLogPayload = {
   readonly event: ParityLogEvent
   readonly route: typeof PARITY_ROUTE
@@ -207,16 +140,9 @@ type ParityLogPayload = {
 }
 
 /**
- * Bridge entry. Inspects the orchestrated outcome, routes to the
- * appropriate log event, and emits a single `console.log(JSON.stringify(...))`
- * line. Never re-throws — all harness errors are caught and routed to
- * `forge.parity.harness_error`.
- *
- * U5 (PR-B) mode guard: if the active `ContentApiMode` is anything
- * other than `"dual-read"`, the bridge short-circuits before any
- * normalization / comparison work. After U4's mode-set collapse,
- * `"dual-read"` is unreachable in production — so this guard
- * effectively kills canary emission across the board.
+ * Routes the orchestrated outcome to one parity log event. Never re-throws —
+ * harness errors are caught and routed to `forge.parity.harness_error`.
+ * Short-circuits when not in `dual-read` mode (currently always — see above).
  */
 export function runDualReadComparison(outcome: DualReadOutcome): void {
   if (!isCanaryEmissionEnabled()) return
@@ -285,20 +211,10 @@ export function runDualReadComparison(outcome: DualReadOutcome): void {
   const strapiResponse = outcome.strapi.response
   const adminResponse = outcome.admin.response
 
-  // Both fetches succeeded HTTP-wise but one or both responses are null
-  // (slug doesn't exist on that side). Three distinct signals:
-  //
-  //   - admin null + Strapi has data → forge.parity.admin_missing.
-  //     Typical during backfill: Strapi is the source of truth; admin
-  //     hasn't synced this slug yet. R-18a uses this rate as a gating
-  //     metric for advancing to admin-mode rendering.
-  //   - both null → harness_error/comparator_unknown. Rare; both sides
-  //     agree the slug doesn't exist. Real comparator failures share
-  //     this bucket with this case — operators triage on count, not
-  //     individual events.
-  //   - Strapi null + admin has data → harness_error/comparator_unknown.
-  //     Anomalous: Strapi is supposed to be the source of truth in U5.
-  //     Logged as an error because it indicates schema/sync drift.
+  // Null-response signals:
+  //   admin null + Strapi data → admin_missing (typical during backfill;
+  //     gating metric for advancing to admin-mode rendering)
+  //   both null OR Strapi null + admin data → comparator_unknown
   if (!strapiResponse && !adminResponse) {
     emit({
       event: "forge.parity.harness_error",
@@ -333,8 +249,6 @@ export function runDualReadComparison(outcome: DualReadOutcome): void {
     })
     return
   }
-  // Defensive narrowing — TS can't infer both are non-null after the three
-  // checks above without an explicit re-assert.
   if (!strapiResponse || !adminResponse) return
 
   try {
@@ -357,13 +271,9 @@ export function runDualReadComparison(outcome: DualReadOutcome): void {
     })
 
     const diffPaths = collectDiffPaths(report)
-    // R13 defense-in-depth: production NEVER includes raw values, even if
-    // FORGE_PARITY_DEBUG=1 is set in error. The dev-opt-in path requires
-    // BOTH the explicit flag AND a non-production NODE_ENV. A typo or
-    // copy-paste of the dev flag into a production env config is a no-op.
-    // Read FORGE_PARITY_DEBUG via the typed env (not process.env) so the
-    // schema's z.enum validation actually runs against the value the
-    // bridge reads. NODE_ENV stays on process.env — Next.js inlines it.
+    // SECURITY: dev opt-in requires BOTH the flag AND non-prod NODE_ENV, so
+    // a typo'd flag in prod env is a no-op. NODE_ENV stays on process.env
+    // (Next inlines it); FORGE_PARITY_DEBUG via typed env so z.enum runs.
     const debugEnabled =
       process.env.NODE_ENV !== "production" && env.FORGE_PARITY_DEBUG === "1"
 
@@ -399,16 +309,9 @@ export function runDualReadComparison(outcome: DualReadOutcome): void {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Input adaptation
-// ---------------------------------------------------------------------------
 
-/**
- * Adapt the Strapi `WatchExperience` shape to the harness's
- * `StrapiExperienceInput` shape. Synthesizes `locale` from the URL
- * locale if the response lacks it (defense-in-depth for fragments
- * that haven't yet added `locale` to their selection set).
- */
+/** Synthesizes `locale` from URL when the Strapi fragment hasn't selected it. */
 function adaptStrapi(
   response: StrapiExperienceResponse,
   urlLocale: string,
@@ -431,23 +334,11 @@ function adaptStrapi(
   }
 }
 
-/**
- * Adapt the admin `experienceBySlug` shape to the harness's
- * `AdminExperienceLocaleInput` shape. The single semantic delta is
- * `metaDescription → description` — admin's schema field is
- * `metaDescription` but the harness consumes `description`.
- */
+/** Single semantic delta: `metaDescription → description` for the harness. */
 function adaptAdmin(
   response: AdminExperienceResponse,
 ): AdminExperienceLocaleInput {
-  // Post-PR-A, `AdminExperienceLocaleInput.blocks` is
-  // `ReadonlyArray<Block>` from `@forge/admin/domain/blocks`. The wire
-  // shape returned by admin's typed [ExperienceBlock!]! field matches
-  // that at runtime — but the loose `AdminExperienceResponse` here is
-  // typed `unknown` so legacy callers (and the mode guard's
-  // short-circuit) don't have to know about the @forge/admin import.
-  // The cast is safe under the harness's defensive
-  // `BlocksSchema.safeParse(...)` which still runs on the input.
+  // Blocks cast is safe under the harness's BlocksSchema.safeParse.
   return {
     id: response.id ?? "",
     slug: response.slug ?? "",
@@ -459,9 +350,7 @@ function adaptAdmin(
   }
 }
 
-// ---------------------------------------------------------------------------
 // Helpers
-// ---------------------------------------------------------------------------
 
 function emit(payload: ParityLogPayload): void {
   if (typeof console === "undefined") return

--- a/docs/admin-core-migration/cutover-runbook.md
+++ b/docs/admin-core-migration/cutover-runbook.md
@@ -98,9 +98,11 @@ Five-step sequential. Do not skip steps; do not parallelize.
 
 Listed in escalation order. **Use the lowest-numbered layer that resolves the regression.** Higher layers are progressively more invasive.
 
-### Layer 1 — `FORGE_DISABLE_WATCH_ROUTES` (seconds, fastest)
+### Layer 1 — `FORGE_DISABLE_WATCH_ROUTES` (surgical, Railway redeploy)
 
 CSV of route paths to disable. Matched against the requested slug at `apps/web/src/app/[slug]/page.tsx` module scope; matching slugs render `<MaintenanceFallback>` instead of fetching from admin or Strapi.
+
+> **TTR reality check:** "fastest" was misleading — module-scope reads mean any change to this var requires a Railway redeploy (same as Layer 2). Layer 1's advantage is **surgical scope** (specific slugs only, leaving the rest of the route healthy), not raw speed. P50/worst-case timings live in the MTTR section above once the operator records them. Choose Layer 1 over Layer 2 when only a known set of slugs misbehaves; choose Layer 2 when the regression is global to admin-mode.
 
 ```sh
 # Disable specific slugs while admin debugs:

--- a/docs/admin-core-migration/cutover-runbook.md
+++ b/docs/admin-core-migration/cutover-runbook.md
@@ -1,9 +1,9 @@
 # Web → Admin Cutover Runbook
 
-> **Status:** `draft until measured`
-> The mean-time-to-rollback (MTTR) section contains a `TODO` placeholder. This runbook moves from `draft` to `live` only after the operator records observed P50 and worst-case timings/impact numbers from two real flip tests. Until then, do NOT execute the cutover from this document alone — a fresh on-call engineer must be paired with the plan author.
+> **Status:** `live`
+> Staging is decommissioned — dev + prod only. The first prod flip doubles as the measurement flip: capture observed timings into the [Mean-time-to-rollback](#mean-time-to-rollback) table as you go, and update this doc in the same session. Subsequent operators rely on those numbers.
 >
-> **Date stamp:** 2026-05-12 (U9 of PR-B)
+> **Date stamp:** 2026-05-13 (F18 update — MTTR gate removed)
 > **Plan reference:** [`docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md`](../plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md)
 > **Scope:** apps/web's `[slug]` watch route only. Homepage (`watchSetting`) and watch-video (`getVideoBySlug`, `getWatchVideoOperation`) stay on Strapi during this cutover window and route through Strapi's own incident response, not this runbook.
 
@@ -54,25 +54,23 @@ Implications:
 
 ---
 
-## Mean-time-to-rollback measurement
+## Mean-time-to-rollback
 
-> **TODO(MTTR):** operator action required before this runbook publishes. Numbers below are placeholders.
+Staging is decommissioned, so the first prod flip is also the measurement flip. Flip during an off-peak hour, watch the Railway and admin dashboards in two tabs, and write observed timings into the table below as you go. Future operators rely on these numbers to size the blast window for subsequent flips.
 
-Before flipping `FORGE_CONTENT_API` to `admin` in prod, run **two test flips** between `strapi` and `feature-flag-maintenance` (i.e., `FORGE_DISABLE_WATCH_ROUTES` set to a canary slug) on forge-web. Measure for each flip:
+| Metric                             | Definition                                                                 | P50      | Worst-case |
+| ---------------------------------- | -------------------------------------------------------------------------- | -------- | ---------- |
+| End-to-end deploy time             | env save → deploy trigger → container build → health-check → traffic shift | _record_ | _record_   |
+| Request 5xx-rate during flip       | Railway response codes during the build/redeploy window                    | _record_ | _record_   |
+| Cache thrash duration              | seconds of mode-mixed serves before ISR converges                          | _record_ | _record_   |
+| Maintenance-fallback response time | TTFB when `FORGE_DISABLE_WATCH_ROUTES` engages                             | _record_ | _record_   |
 
-| Metric                             | Definition                                                                 | P50    | Worst-case |
-| ---------------------------------- | -------------------------------------------------------------------------- | ------ | ---------- |
-| End-to-end deploy time             | env save → deploy trigger → container build → health-check → traffic shift | `TODO` | `TODO`     |
-| Request 5xx-rate during flip       | Vercel/Railway response codes during the build/redeploy window             | `TODO` | `TODO`     |
-| Cache thrash duration              | seconds of mode-mixed serves before ISR converges                          | `TODO` | `TODO`     |
-| Maintenance-fallback response time | TTFB when `FORGE_DISABLE_WATCH_ROUTES` engages                             | `TODO` | `TODO`     |
+**Escalation thresholds (rules of thumb until measured):**
 
-**Escalation thresholds:**
+- If worst-case deploy time exceeds **10 minutes**, the fast-rollback story (layer 1) is degraded — pause the flip and investigate Railway throughput before continuing.
+- If user-impact 5xx-rate exceeds **5%** during the flip, pull the rip cord (layer 2) immediately and post in #ops before debugging.
 
-- If worst-case deploy time exceeds **10 minutes**, escalate before cutover. The fast-rollback story (layer 1) depends on a sub-10-minute redeploy budget.
-- If user-impact 5xx-rate exceeds **5%** during the flip, escalate before cutover. Operators care about user impact, not just deploy seconds.
-
-The operator who runs these measurements is responsible for replacing `TODO` with observed values **before** opening the runbook to a fresh on-call engineer.
+After your first flip, replace `_record_` with observed values and commit this file in the same session.
 
 ---
 
@@ -313,6 +311,8 @@ Distinct from this plan's UB7 (`apps/web/src/app/[slug]/error.tsx` boundary), wh
 
 ## Document history
 
-| Date       | Author             | Change                                                                        |
-| ---------- | ------------------ | ----------------------------------------------------------------------------- |
-| 2026-05-12 | U9 (plan-003 PR-B) | Initial draft — pre-cutover, pre-measurement. Status: `draft until measured`. |
+| Date       | Author               | Change                                                                                                                                                                                                                                                                |
+| ---------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-12 | U9 (plan-003 PR-B)   | Initial draft — pre-cutover, pre-measurement. Status: `draft until measured`.                                                                                                                                                                                         |
+| 2026-05-13 | F18 (ce-code-review) | MTTR gate removed. Staging is decommissioned; first prod flip doubles as measurement flip. Layer 1 wording corrected (Railway redeploy, not "seconds, fastest"). Status: `live`.                                                                                      |
+| 2026-05-13 | F13 (ce-code-review) | Bearer scrub now redacts every CSV entry, not just the first. Test extended to cover both keys in the same error message + post-rotation (single remaining key) case. No runbook change — Emergency revocation section already covered the operator-facing procedure. |

--- a/docs/admin-core-migration/cutover-runbook.md
+++ b/docs/admin-core-migration/cutover-runbook.md
@@ -1,0 +1,316 @@
+# Web → Admin Cutover Runbook
+
+> **Status:** `draft until measured`
+> The mean-time-to-rollback (MTTR) section contains a `TODO` placeholder. This runbook moves from `draft` to `live` only after the operator records observed P50 and worst-case timings/impact numbers from two real flip tests. Until then, do NOT execute the cutover from this document alone — a fresh on-call engineer must be paired with the plan author.
+>
+> **Date stamp:** 2026-05-12 (U9 of PR-B)
+> **Plan reference:** [`docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md`](../plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md)
+> **Scope:** apps/web's `[slug]` watch route only. Homepage (`watchSetting`) and watch-video (`getVideoBySlug`, `getWatchVideoOperation`) stay on Strapi during this cutover window and route through Strapi's own incident response, not this runbook.
+
+This runbook is the single source of truth for flipping forge-web from `FORGE_CONTENT_API=strapi` to `admin`, monitoring the cutover, and rolling back if anything goes sideways. Read it end-to-end before touching Doppler.
+
+---
+
+## Pre-cutover checklist
+
+Tick every box before flipping the env var. The cutover is irreversible only at the cache layer (ISR will thrash for ~60s either direction); operationally, every box below has a corresponding rollback path further down. None of them is optional.
+
+- [ ] **PR-A deployed to forge-admin production.** `CONSUMER_BEARER` principal recognition, `experienceBySlug` `isTemplate` filter, and Pothos block typings are all live. Verify by checking the admin deploy stream for the PR-A merge SHA.
+- [ ] **`WEB_ADMIN_API_KEYS` set on forge-admin Doppler (CSV).** Admin recognizes each entry as a valid bearer; this is the receiver-side allowlist.
+- [ ] **Symmetric `WEB_ADMIN_API_KEYS` set on forge-web Doppler.** Web reads ONE entry from admin's CSV as its outbound bearer. The variable name is intentionally identical on both sides to eliminate the KEY-vs-KEYS copy-paste error class.
+- [ ] **`ADMIN_GRAPHQL_URL` healthy on forge-web.** Manual confirmation: from a workstation with the same bearer, run:
+
+  ```sh
+  curl -sS -H "Authorization: Bearer $WEB_ADMIN_API_KEY" \
+       -H "Content-Type: application/json" \
+       -d '{"query":"{ __typename }"}' \
+       "$ADMIN_GRAPHQL_URL"
+  ```
+
+  Confirm admin recognizes the bearer (admin dashboard's rate-limit identity bucket shows up as `consumer:<key-prefix>`, not `public:<railway-egress-ip>`).
+
+- [ ] **`apps/admin/schema.graphql` regenerated and committed.** PR-A landed this; verify the file's mtime on the deployed admin matches the PR-A merge commit.
+- [ ] **`packages/graphql/src/admin-graphql-env.d.ts` regenerated.** PR-A landed this too; verify by `git log packages/graphql/src/admin-graphql-env.d.ts` shows the PR-A commit.
+- [ ] **Batch verification harness gate is green.** Latest run of `pnpm --filter @forge/graphql run-batch-verification` produces empty (or fully allow-listed) diff output. See [batch-verification harness](../../packages/graphql/scripts/run-batch-verification.ts) (U8).
+- [ ] **Editorial freeze coordinated** for the 24-48h window between gate-green and env-flip — OR an `--since <last-full-run-ts>` delta-run confirms no new diffs were introduced just before the flip. The gate is only meaningful if content state is stable between gate-green and env-flip; without one of those two, R5 isn't actually a gate.
+
+---
+
+## Concurrent-backend exposure note
+
+During the cutover window, forge-web has **two live backends serving the same user session**:
+
+| Surface                                                  | Backend (during cutover)   | Backend (post-cutover, pre-Strapi-removal) |
+| -------------------------------------------------------- | -------------------------- | ------------------------------------------ |
+| `/[slug]` watch page                                     | Strapi → admin (this flip) | admin                                      |
+| Homepage (`watchSetting`)                                | Strapi                     | Strapi (until separate migration)          |
+| Watch video (`getVideoBySlug`, `getWatchVideoOperation`) | Strapi                     | Strapi (until separate migration)          |
+
+Implications:
+
+- A **Strapi outage** during the window breaks homepage + watch-video but does NOT break `/[slug]`. Rollback layers below are for slug-page outages only.
+- An **admin outage** breaks `/[slug]` but does NOT break homepage. Layers 1-2 below address this.
+- Both backends must outlast TV burn-in completion before Strapi can shut down. Do not request Strapi sunset until TV is live AND a separate plan migrates the homepage / watch-video surfaces. See plan-003 Dependencies/Assumptions.
+
+---
+
+## Mean-time-to-rollback measurement
+
+> **TODO(MTTR):** operator action required before this runbook publishes. Numbers below are placeholders.
+
+Before flipping `FORGE_CONTENT_API` to `admin` in prod, run **two test flips** between `strapi` and `feature-flag-maintenance` (i.e., `FORGE_DISABLE_WATCH_ROUTES` set to a canary slug) on forge-web. Measure for each flip:
+
+| Metric                             | Definition                                                                 | P50    | Worst-case |
+| ---------------------------------- | -------------------------------------------------------------------------- | ------ | ---------- |
+| End-to-end deploy time             | env save → deploy trigger → container build → health-check → traffic shift | `TODO` | `TODO`     |
+| Request 5xx-rate during flip       | Vercel/Railway response codes during the build/redeploy window             | `TODO` | `TODO`     |
+| Cache thrash duration              | seconds of mode-mixed serves before ISR converges                          | `TODO` | `TODO`     |
+| Maintenance-fallback response time | TTFB when `FORGE_DISABLE_WATCH_ROUTES` engages                             | `TODO` | `TODO`     |
+
+**Escalation thresholds:**
+
+- If worst-case deploy time exceeds **10 minutes**, escalate before cutover. The fast-rollback story (layer 1) depends on a sub-10-minute redeploy budget.
+- If user-impact 5xx-rate exceeds **5%** during the flip, escalate before cutover. Operators care about user impact, not just deploy seconds.
+
+The operator who runs these measurements is responsible for replacing `TODO` with observed values **before** opening the runbook to a fresh on-call engineer.
+
+---
+
+## Cutover procedure
+
+Five-step sequential. Do not skip steps; do not parallelize.
+
+1. **Verify gate is green + editorial freeze in effect** (or `--since` delta-run is empty). See pre-cutover checklist.
+2. **Flip `FORGE_CONTENT_API` to `admin`** on forge-web Doppler.
+
+   ```sh
+   # On the operator's workstation, authenticated to Doppler.
+   doppler secrets set --project forge-web --config prd FORGE_CONTENT_API=admin
+   ```
+
+3. **Trigger redeploy.** Railway auto-redeploys on env change in most projects; verify the deploy actually fired by watching the Railway dashboard for forge-web. If the deploy did not auto-trigger, manually re-deploy the current build.
+4. **Monitor admin error rate + page-render success rate** in Railway logs for the first **30 minutes**. See [Monitoring queries](#monitoring-queries) below.
+5. **Confirm the `consumer:` bucket** is the dominant rate-limit identity on the admin dashboard. Pre-cutover, web's SSR traffic shows up as `public:<railway-egress-ip>` (because no bearer). Post-cutover, the `consumer:<key-prefix>` bucket should dominate. If `public:` traffic remains dominant, web is missing the bearer header — investigate `WEB_ADMIN_API_KEYS` deploy ordering before allowing the cutover to settle.
+
+---
+
+## Rollback layers
+
+Listed in escalation order. **Use the lowest-numbered layer that resolves the regression.** Higher layers are progressively more invasive.
+
+### Layer 1 — `FORGE_DISABLE_WATCH_ROUTES` (seconds, fastest)
+
+CSV of route paths to disable. Matched against the requested slug at `apps/web/src/app/[slug]/page.tsx` module scope; matching slugs render `<MaintenanceFallback>` instead of fetching from admin or Strapi.
+
+```sh
+# Disable specific slugs while admin debugs:
+doppler secrets set --project forge-web --config prd \
+  FORGE_DISABLE_WATCH_ROUTES='/some-broken-slug,/another-broken-slug'
+
+# Disable everything (broad rollback):
+# (set the var to a wildcard sentinel — currently not supported; use
+# layer 2 instead. The flag is for surgical route disable, not blanket.)
+```
+
+Properties:
+
+- Reads at module scope (NEVER via `headers()` / `cookies()` — that would defeat Next's Full Route Cache; see `docs/solutions/web/nextjs-headers-defeats-route-cache.md`).
+- Maintenance page is static text — no admin/Strapi fetch, no dynamic data. Failsafe.
+- Emergency only. NOT a traffic-shaping mechanism. Do not leave a slug in this list longer than a debug session.
+- Unknown CSV values warn-and-fall-through to normal rendering — typo'd entries don't brick the route.
+
+### Layer 2 — Revert `FORGE_CONTENT_API` to `strapi` (minutes)
+
+```sh
+doppler secrets set --project forge-web --config prd FORGE_CONTENT_API=strapi
+# Wait for Railway redeploy (see MTTR section for the budget).
+```
+
+Properties:
+
+- Only works **while Strapi service is still live**. Post-Strapi-removal, this layer is gone — escalate directly to layer 3.
+- If `WEB_ADMIN_API_KEYS` is somehow missing/invalid when this layer fires, U6's runtime safety net falls through to Strapi semantics for the bearer-missing path automatically. Expected to be a no-op during the cutover window.
+- Time-bound: depends on Railway redeploy time (see MTTR).
+
+### Layer 3 — Code-revert the PR-B cutover commit (5-15 min)
+
+Use when the regression is in apps/web code that PR-B shipped (admin-shape fragments, `fetchSlugExperience` branch, error boundary, etc.) and layers 1-2 are insufficient.
+
+```sh
+# On a workstation with main checked out:
+git revert <PR-B-merge-commit-sha> --no-edit
+git push origin main
+# Railway auto-deploys main; verify the revert lands and Strapi-mode is active.
+```
+
+Properties:
+
+- Drops PR-B's code; web reverts to Strapi-only consumer behavior.
+- Does NOT touch admin (that's layer 4).
+- Time-bound: depends on Railway redeploy time.
+
+### Layer 4 — PR-A regression: revert admin SDL (last resort)
+
+Use **only** when the regression source is PR-A (e.g., Pothos block types cause a downstream consumer to break, the `CONSUMER_BEARER` principal mis-routes auth, etc.). Layers 1-3 are insufficient because they only revert web — admin's SDL is unchanged.
+
+> **Order matters.** Sequence layer 4 **only after** layer 3 has reverted web back to Strapi mode. Otherwise admin's SDL revert blast radius extends past slug-page to any other consumer of admin's typed blocks (web, manager, any future consumers).
+
+Steps:
+
+```sh
+# (a) Revert the PR-A commit on forge-admin.
+git revert <PR-A-merge-commit-sha> --no-edit
+# (b) Regenerate admin's printed schema.
+pnpm --filter @forge/admin schema:print
+# (c) Regenerate the consumer-side types in packages/graphql.
+pnpm --filter @forge/graphql generate
+# (d) Commit the regenerated files and push.
+git add apps/admin/schema.graphql packages/graphql/src/admin-graphql-env.d.ts
+git commit -m "revert: PR-A admin SDL — regenerated schema"
+git push origin main
+# (e) Wait for forge-admin to redeploy.
+```
+
+Properties:
+
+- Reverses `ExperienceLocale.blocks` from `[ExperienceBlock!]!` back to `JSON`.
+- Breaks **any** consumer of admin's typed blocks. Currently that's just web (in Strapi mode this revert is invisible), but manager and any future consumer will see the type widen.
+- Layer 3 must complete before layer 4 starts. If web is still in admin mode when admin's SDL reverts, slug-page crashes at type-check boundary.
+
+---
+
+## No degraded hybrid mode — escalation reminder
+
+There is **no per-request "try admin, fall back to Strapi" runtime mode**. The R3 + plan-003 "No degraded hybrid mode" KTD collapses `FORGE_CONTENT_API` to two values (`strapi | admin`), period.
+
+If admin partially regresses on a subset of slugs during burn-in:
+
+1. **First reflex:** `FORGE_DISABLE_WATCH_ROUTES` (layer 1) — surgical disable of the broken slugs.
+2. **If broader:** revert `FORGE_CONTENT_API=strapi` (layer 2) — full revert to Strapi-only.
+3. **Do NOT improvise a hybrid mode at incident time.** None exists in the code; reintroducing one requires a re-plan + redeploy and is not faster than layer 3.
+
+A future plan **could** re-introduce `admin-with-fallback` if operationally needed, but it requires a deliberate re-plan, not an incident-time hack.
+
+---
+
+## Monitoring queries
+
+Run these in Vercel/Railway log search (forge-web) and admin's dashboard during the first 30 minutes post-cutover, and as needed during burn-in.
+
+| Query                                          | What it tells you                              | Expected post-cutover                                                                                                                                                                      |
+| ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `event:"forge.parity.admin_null"`              | admin returned `null` for a slug; sanity check | Non-zero is expected for unknown slugs. Investigate spikes against the batch-verification baseline.                                                                                        |
+| `event:"forge.parity.admin_timeout"`           | admin timed out on a slug                      | Should be near zero. Non-zero rate signals admin latency regression OR web's `Promise.race` budget is too tight.                                                                           |
+| `event:"forge.parity.consumer_bearer_missing"` | web tried to call admin without a bearer       | **Should be ZERO post-cutover.** Non-zero rate signals deploy ordering went wrong (web flipped to admin mode before `WEB_ADMIN_API_KEYS` was set) OR a missing-env regression.             |
+| `event:"forge.parity.canary_failed"`           | leftover U5 dual-read canary event             | **Should emit ZERO events post-cutover.** U5's parity-bridge mode guard ensures admin-mode emits no canary events. Non-zero rate signals the guard regressed or U5 deletion is incomplete. |
+| Apollo client error rate                       | admin Apollo client error events               | Near zero. Spikes here usually correlate with admin-side incidents — cross-reference admin's dashboard.                                                                                    |
+| Slug-page 5xx rate in Railway                  | HTTP 5xx on `/[slug]` route                    | < baseline Strapi-mode 5xx rate. A spike here is the primary trigger for layer 1 / layer 2 rollback.                                                                                       |
+
+If any of the four `forge.parity.*` queries fires a non-zero rate post-cutover, document the event-payload sample in the incident channel before escalating — the payload's `bucket`/`subkind` field tells you which rollback layer is appropriate.
+
+---
+
+## Planned bearer-key rotation (R8a)
+
+**Cadence:** 90-day calendar OR trigger events:
+
+- Team-member offboarding (anyone who had Doppler write access to `WEB_ADMIN_API_KEYS`).
+- Security audit finding.
+- Suspected exfiltration (escalate to [Emergency bearer-key revocation](#emergency-bearer-key-revocation) instead).
+
+**Routine rotation is ADDITIVE then remove-old.** (Opposite ordering from emergency revocation.) Sequence:
+
+1. **Generate fresh key.** 32+ bytes of entropy, base64-encoded. E.g.:
+
+   ```sh
+   openssl rand -base64 32
+   ```
+
+2. **Add fresh key to forge-admin Doppler `WEB_ADMIN_API_KEYS` CSV.** Both old and new entries are now valid bearers.
+
+   ```sh
+   # Existing CSV: oldKey
+   # New CSV: oldKey,newKey
+   doppler secrets set --project forge-admin --config prd \
+     WEB_ADMIN_API_KEYS=oldKey,newKey
+   ```
+
+3. **Deploy admin.** Admin now recognizes both keys.
+4. **Update forge-web `WEB_ADMIN_API_KEYS` to the fresh key.**
+
+   ```sh
+   doppler secrets set --project forge-web --config prd WEB_ADMIN_API_KEYS=newKey
+   ```
+
+5. **Deploy web.** Web now sends `newKey` in its bearer header.
+6. **Remove old key from forge-admin CSV.**
+
+   ```sh
+   doppler secrets set --project forge-admin --config prd WEB_ADMIN_API_KEYS=newKey
+   ```
+
+7. **Deploy admin.** Old key is no longer a valid bearer; rotation complete.
+
+**Source-control prohibition:** the `WEB_ADMIN_API_KEYS` value MUST NEVER appear in committed files, PR descriptions, or CI logs. Admin-side (`consumer-bearer.ts`, `context.ts`, `rate-limit.ts`) and web-side (`admin-client.ts`, Apollo `HttpLink.responseHandler`) structured logging assert this at unit-test time via log-scrub spies. Paste keys into Doppler directly — never via a PR.
+
+---
+
+## Emergency bearer-key revocation
+
+Distinct from planned rotation. Use **only** when `WEB_ADMIN_API_KEYS` is known or strongly suspected to be exfiltrated.
+
+**Order matters: remove the bad key FIRST, then provision a new one.** Adding the new key first leaves the exfiltrated key valid for the duration of the rotation — which is the entire window an attacker needs.
+
+1. **REMOVE the exfiltrated key** from forge-admin Doppler `WEB_ADMIN_API_KEYS` CSV.
+
+   ```sh
+   # If CSV was `compromisedKey`, set it to empty (or, if multiple, omit the bad one).
+   doppler secrets set --project forge-admin --config prd WEB_ADMIN_API_KEYS=""
+   ```
+
+2. **Deploy admin.** Admin no longer recognizes the exfiltrated key.
+3. **Accept brief degradation.** Web's runtime safety net (U6) falls back to Strapi semantics for the bearer-missing path; `forge.parity.consumer_bearer_missing` events spike. This is expected and bounded by steps 4-5.
+4. **Update web's `WEB_ADMIN_API_KEYS` to a fresh key.** Generate per the [planned rotation](#planned-bearer-key-rotation-r8a) step 1.
+
+   ```sh
+   doppler secrets set --project forge-admin --config prd WEB_ADMIN_API_KEYS=newKey
+   doppler secrets set --project forge-web --config prd WEB_ADMIN_API_KEYS=newKey
+   ```
+
+5. **Deploy admin then web** (receiver-first). `forge.parity.consumer_bearer_missing` returns to zero.
+
+Document the exfiltration vector in a security postmortem before closing the incident.
+
+---
+
+## Unbounded-cycles contingency (R6 + T-7 threshold)
+
+The batch verification harness (U8) is the cutover gate. If batch verification cycles have **not** converged to empty-or-allow-listed by **T-7 days before Strapi's scheduled removal**, escalate to operator with the current diff classes.
+
+Contingencies, in operator-preferred order:
+
+1. **Negotiate Strapi extension** with the team driving Strapi sunset. Buys time to fix the remaining diff classes. First choice — gate convergence is the cleanest outcome.
+2. **Extend allow-list aggressively + cut over with documented residual diff.** Each allow-list entry is a documented "we know this differs, we accept it" decision. Use sparingly — every allow-listed diff is a future content-discrepancy bug report.
+3. **Defer cutover entirely and re-plan against a longer timeline.** Last resort. Requires explicit operator/PM sign-off; not a developer-side decision.
+
+**Do NOT default to "revert to phased ramp."** The phased-ramp architecture (`admin-with-fallback`, dual-read canary, etc.) is formally superseded by plan-003 and requires re-planning to reintroduce. Treating phased ramp as a casual fallback obscures the architectural decision being unwound.
+
+---
+
+## TODO(U7) — canonical-plan U7 follow-up
+
+The following items are explicitly **out of scope** for this plan and owned by the canonical 7-unit plan's U7 ([`docs/plans/2026-04-22-001-feat-admin-core-consumer-migration-plan.md`](../plans/2026-04-22-001-feat-admin-core-consumer-migration-plan.md)). Search this file for `TODO(U7)` to find every reference; U7's PR can grep for its work surface here.
+
+- **TODO(U7): R17 no-redeploy rollback mechanism.** Per-slug or per-route feature flag without requiring a redeploy. This plan's `FORGE_DISABLE_WATCH_ROUTES` is process-wide and requires a Railway redeploy on every change; U7 will land a no-redeploy variant (likely backed by an admin-side toggle or edge-config flag).
+- **TODO(U7): parity-diff CI gate.** The batch verification harness (U8) runs manually; U7 lands a scheduled CI job that gates `main` merges on parity diff staying empty.
+- **TODO(U7): GraphQL Armor cost-limit recalibration.** Admin's `experienceBySlug` cost is currently set conservatively; U7 measures real-world cost and recalibrates.
+
+Distinct from this plan's UB7 (`apps/web/src/app/[slug]/error.tsx` boundary), which is shipped.
+
+---
+
+## Document history
+
+| Date       | Author             | Change                                                                        |
+| ---------- | ------------------ | ----------------------------------------------------------------------------- |
+| 2026-05-12 | U9 (plan-003 PR-B) | Initial draft — pre-cutover, pre-measurement. Status: `draft until measured`. |

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./graphql": "./src/graphql.ts",
     "./admin": "./src/admin.ts",
+    "./admin/fragments": "./src/fragments/admin/index.ts",
     "./parity": "./src/parity/index.ts"
   },
   "scripts": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "gql.tada": "^1.9.0",
-    "graphql": "16.13.1"
+    "graphql": "16.13.1",
+    "p-limit": "^7.3.0"
   },
   "devDependencies": {
     "@forge/admin": "workspace:*",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "generate": "gql-tada generate output",
     "lint": "eslint .",
+    "run-batch-verification": "tsx scripts/run-batch-verification.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/graphql/scripts/run-batch-verification.ts
+++ b/packages/graphql/scripts/run-batch-verification.ts
@@ -99,16 +99,476 @@ const STRAPI_EXPERIENCE_QUERY = /* GraphQL */ `
   }
 `
 
+// Per-kind block selections — every field admin's Pothos type exposes.
+// Required because normalize-admin runs BlocksSchema.safeParse(), which
+// rejects unknown fields AND missing required fields. Using the per-kind
+// renderer fragments would NOT work: they alias names to Strapi vocab
+// (e.g., `mediaDescription: description`) for the renderer's prop shape,
+// which Zod would reject. Native admin field names only.
+const BLOCK_LEAF_FRAGMENTS = /* GraphQL */ `
+  fragment LeafAdventCountdown on AdventCountdownBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    locale
+    title
+    scripture
+    scriptureReference
+  }
+  fragment LeafBibleQuotesCarousel on BibleQuotesCarouselBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    heading
+    quotes {
+      reference
+      text
+      backgroundImageUrl
+      backgroundImageAssetId
+      ctaEnabled
+      ctaLabel
+      ctaLink
+      attribution
+      imageUrl
+      imageAssetId
+      backgroundColor
+    }
+  }
+  fragment LeafCard on CardBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    title
+    description
+    mediaUrl
+    mediaAssetId
+    link
+    variant
+  }
+  fragment LeafContainerSlot on ContainerSlotBlock {
+    __typename
+    t
+    backgroundColor
+    backgroundImageUrl
+    backgroundImageAssetId
+    gridSpan
+    spans {
+      xs
+      sm
+      md
+      lg
+      xl
+    }
+  }
+  fragment LeafCta on CtaBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    heading
+    body
+    buttonLabel
+    buttonLink
+    variant
+  }
+  fragment LeafEasterDates on EasterDatesBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    locale
+    easterDatesTitle
+    orthodoxEasterEnabled
+    orthodoxEasterLabel
+    passoverEnabled
+    passoverLabel
+    westernEasterEnabled
+    westernEasterLabel
+  }
+  fragment LeafInfoBlocks on InfoBlocksBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    heading
+    intro
+    description
+    widthPercent
+    blocks {
+      title
+      body
+      icon
+    }
+  }
+  fragment LeafMediaCollection on MediaCollectionBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    categoryLabel
+    variant
+    itemsSource
+    title
+    subtitle
+    description
+    ctaLink
+    ctaLabel
+    showItemNumbers
+    footerText
+    items {
+      videoId
+      imageOverrideUrl
+      imageOverrideAssetId
+      titleOverride
+      subtitleOverride
+      labelOverride
+      collectionSize
+      imageUrl
+      imageAssetId
+      linkToSectionKey
+    }
+  }
+  fragment LeafNavigationCarousel on NavigationCarouselBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    items {
+      title
+      category
+      contentId
+      imageUrl
+      imageAssetId
+      backgroundColor
+    }
+  }
+  fragment LeafPromoBanner on PromoBannerBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    heading
+    intro
+    description
+    ctaEnabled
+    ctaLabel
+    ctaLink
+    widthPercent
+  }
+  fragment LeafQuizButton on QuizButtonBlock {
+    __typename
+    t
+    sectionKey
+    buttonText
+    iframeSrc
+  }
+  fragment LeafRelatedQuestions on RelatedQuestionsBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    heading
+    ctaEnabled
+    ctaLabel
+    ctaLink
+    questions {
+      question
+      answer
+    }
+  }
+  fragment LeafText on TextBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    heading
+    headingLevel
+    subtitle
+    variant
+    contentParagraphs
+  }
+  fragment LeafVideo on VideoBlock {
+    __typename
+    t
+    sectionKey
+    title
+    titleSource
+    subtitle
+    subtitleSource
+    mediaUrl
+    mediaAssetId
+    streamingUrl
+    videoId
+    useRouteVideo
+    autoplay
+    loop
+    muted
+    showControls
+    clipStartSeconds
+    clipEndSeconds
+  }
+  fragment LeafVideoCarousel on VideoCarouselBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    imageAssetId
+    itemsSource
+    title
+    subtitle
+    description
+    items {
+      videoId
+      imageUrl
+      imageAssetId
+      imageOverrideUrl
+      imageOverrideAssetId
+      streamingUrl
+      backgroundColor
+    }
+  }
+  fragment LeafVideoHero on VideoHeroBlock {
+    __typename
+    t
+    sectionKey
+    heading
+    headingSource
+    subheading
+    subheadingSource
+    ctaEnabled
+    ctaLabel
+    ctaLink
+    streamingUrl
+    videoId
+    useRouteVideo
+    autoplay
+    loop
+    muted
+    showControls
+    clipStartSeconds
+    clipEndSeconds
+  }
+  fragment LeafVideoRecommendations on VideoRecommendationsBlock {
+    __typename
+    t
+    sectionKey
+    backgroundColor
+    imageUrl
+    title
+    description
+    sourceVideoId
+    sourceSceneIndex
+    limit
+  }
+`
+
+// Container.content unfolds into a narrower union (no SectionBlock /
+// ContainerBlock — admin's schema forbids those at the container slot).
+const CONTAINER_CONTENT_FRAGMENT = /* GraphQL */ `
+  fragment AdminContainerContent on ContainerContentBlock {
+    __typename
+    ... on AdventCountdownBlock {
+      ...LeafAdventCountdown
+    }
+    ... on BibleQuotesCarouselBlock {
+      ...LeafBibleQuotesCarousel
+    }
+    ... on CardBlock {
+      ...LeafCard
+    }
+    ... on ContainerSlotBlock {
+      ...LeafContainerSlot
+    }
+    ... on CtaBlock {
+      ...LeafCta
+    }
+    ... on EasterDatesBlock {
+      ...LeafEasterDates
+    }
+    ... on MediaCollectionBlock {
+      ...LeafMediaCollection
+    }
+    ... on RelatedQuestionsBlock {
+      ...LeafRelatedQuestions
+    }
+    ... on TextBlock {
+      ...LeafText
+    }
+    ... on VideoBlock {
+      ...LeafVideo
+    }
+  }
+`
+
+// Section.content allows containers (and therefore nested ContainerContent).
+const SECTION_CONTENT_FRAGMENT = /* GraphQL */ `
+  fragment AdminSectionContent on SectionContentBlock {
+    __typename
+    ... on BibleQuotesCarouselBlock {
+      ...LeafBibleQuotesCarousel
+    }
+    ... on CardBlock {
+      ...LeafCard
+    }
+    ... on ContainerBlock {
+      __typename
+      t
+      sectionKey
+      backgroundColor
+      backgroundImageUrl
+      backgroundImageAssetId
+      content {
+        ...AdminContainerContent
+      }
+    }
+    ... on CtaBlock {
+      ...LeafCta
+    }
+    ... on InfoBlocksBlock {
+      ...LeafInfoBlocks
+    }
+    ... on MediaCollectionBlock {
+      ...LeafMediaCollection
+    }
+    ... on NavigationCarouselBlock {
+      ...LeafNavigationCarousel
+    }
+    ... on PromoBannerBlock {
+      ...LeafPromoBanner
+    }
+    ... on QuizButtonBlock {
+      ...LeafQuizButton
+    }
+    ... on RelatedQuestionsBlock {
+      ...LeafRelatedQuestions
+    }
+    ... on TextBlock {
+      ...LeafText
+    }
+    ... on VideoBlock {
+      ...LeafVideo
+    }
+    ... on VideoCarouselBlock {
+      ...LeafVideoCarousel
+    }
+  }
+`
+
+// Top-level ExperienceBlock union — every kind plus the two nested
+// section/container content shapes.
 const ADMIN_EXPERIENCE_QUERY = /* GraphQL */ `
+  ${BLOCK_LEAF_FRAGMENTS}
+  ${CONTAINER_CONTENT_FRAGMENT}
+  ${SECTION_CONTENT_FRAGMENT}
   query ParityAdminExperienceBySlug($slug: String!, $locale: String!) {
     experienceBySlug(slug: $slug, locale: $locale) {
       id
       slug
       locale
       title
-      description
+      # F1: admin's field is metaDescription; alias to "description" so the
+      # response shape matches AdminExperienceLocaleInput's Strapi-vocab
+      # "description" key (the normalizer's adapted input type).
+      description: metaDescription
       ogImageUrl
-      blocks
+      blocks {
+        __typename
+        ... on AdventCountdownBlock {
+          ...LeafAdventCountdown
+        }
+        ... on BibleQuotesCarouselBlock {
+          ...LeafBibleQuotesCarousel
+        }
+        ... on CardBlock {
+          ...LeafCard
+        }
+        ... on ContainerBlock {
+          __typename
+          t
+          sectionKey
+          backgroundColor
+          backgroundImageUrl
+          backgroundImageAssetId
+          content {
+            ...AdminContainerContent
+          }
+        }
+        ... on CtaBlock {
+          ...LeafCta
+        }
+        ... on EasterDatesBlock {
+          ...LeafEasterDates
+        }
+        ... on InfoBlocksBlock {
+          ...LeafInfoBlocks
+        }
+        ... on MediaCollectionBlock {
+          ...LeafMediaCollection
+        }
+        ... on NavigationCarouselBlock {
+          ...LeafNavigationCarousel
+        }
+        ... on PromoBannerBlock {
+          ...LeafPromoBanner
+        }
+        ... on RelatedQuestionsBlock {
+          ...LeafRelatedQuestions
+        }
+        ... on SectionBlock {
+          __typename
+          t
+          sectionKey
+          backgroundColor
+          backgroundImageUrl
+          backgroundImageAssetId
+          blurHash
+          backgroundOpacity
+          dynamicBackgroundImage
+          staticOverlay
+          content {
+            ...AdminSectionContent
+          }
+        }
+        ... on TextBlock {
+          ...LeafText
+        }
+        ... on VideoBlock {
+          ...LeafVideo
+        }
+        ... on VideoCarouselBlock {
+          ...LeafVideoCarousel
+        }
+        ... on VideoHeroBlock {
+          ...LeafVideoHero
+        }
+        ... on VideoRecommendationsBlock {
+          ...LeafVideoRecommendations
+        }
+      }
     }
   }
 `

--- a/packages/graphql/scripts/run-batch-verification.ts
+++ b/packages/graphql/scripts/run-batch-verification.ts
@@ -1,0 +1,345 @@
+/**
+ * Batch verification CLI — the cutover gate (plan-003 U8).
+ *
+ * Thin shim over `src/parity/batch-verification.ts`: parses argv,
+ * resolves env (bearer, endpoints, base origin), constructs real
+ * GraphQL fetchers, then hands off to `runBatchVerification`. The
+ * orchestration loop, gate logic, and JSON-report shape live in the
+ * module so they're typechecked and unit-tested.
+ *
+ * Usage:
+ *   WEB_ADMIN_API_KEYS=<key> \
+ *   STRAPI_GRAPHQL_URL=... \
+ *   ADMIN_GRAPHQL_URL=... \
+ *   STRAPI_PUBLIC_ORIGIN=... \
+ *   pnpm tsx packages/graphql/scripts/run-batch-verification.ts \
+ *     [--sample 100] [--concurrency 5] [--out path.json]
+ *     [--allow-list path.json] [--since 2026-05-12T00:00:00Z] [--anonymous]
+ *
+ * Exit codes:
+ *   0  Gate PASSED.
+ *   1  Gate FAILED.
+ *   2  Misconfiguration (bad args, missing env, allow-list parse error).
+ *
+ * NOTE: the script imports from the relative module path under
+ * `src/parity/` rather than `@forge/graphql/parity`. Mirrors the
+ * `capture-parity-fixture.ts` convention — running scripts via tsx
+ * during local development resolves relative source paths without
+ * waiting for a workspace build step.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+
+import {
+  BearerMissingError,
+  HELP_TEXT,
+  buildReport,
+  combineAllowLists,
+  formatSummary,
+  parseAllowListFile,
+  parseArgs,
+  postGraphQL,
+  readBearerFromEnv,
+  runBatchVerification,
+  sanitizeError,
+  type BatchReport,
+  type CorpusEntry,
+  type Fetchers,
+} from "../src/parity/batch-verification"
+import type { AdminExperienceLocaleInput } from "../src/parity/normalize-admin"
+import type { StrapiExperienceInput } from "../src/parity/normalize-strapi"
+
+// ---------------------------------------------------------------------------
+// GraphQL queries — kept inline to avoid pulling apps/admin / apps/web
+// fragment modules into this dev-only script. Queries match the parity
+// normalizer input shapes (StrapiExperienceInput / AdminExperienceLocaleInput).
+// Operators iterating on fields should update these in lockstep with the
+// normalizer types in src/parity/.
+// ---------------------------------------------------------------------------
+
+const STRAPI_CORPUS_QUERY = /* GraphQL */ `
+  query ParityCorpusEnumerate {
+    experiences(
+      filters: { isTemplate: { eq: false }, publishedAt: { notNull: true } }
+      pagination: { limit: -1 }
+    ) {
+      slug
+      locale
+      updatedAt
+    }
+  }
+`
+
+const STRAPI_EXPERIENCE_QUERY = /* GraphQL */ `
+  query ParityExperienceBySlug($slug: String!, $locale: I18NLocaleCode!) {
+    experiences(
+      filters: { slug: { eq: $slug } }
+      locale: $locale
+      pagination: { limit: 1 }
+    ) {
+      documentId
+      slug
+      locale
+      title
+      metaDescription
+      ogImage {
+        url
+        width
+        height
+        alternativeText
+      }
+      blocks {
+        __typename
+      }
+    }
+  }
+`
+
+const ADMIN_EXPERIENCE_QUERY = /* GraphQL */ `
+  query ParityAdminExperienceBySlug($slug: String!, $locale: String!) {
+    experienceBySlug(slug: $slug, locale: $locale) {
+      id
+      slug
+      locale
+      title
+      description
+      ogImageUrl
+      blocks
+    }
+  }
+`
+
+// ---------------------------------------------------------------------------
+// Env validation
+// ---------------------------------------------------------------------------
+
+type EnvConfig = {
+  readonly strapiUrl: string
+  readonly adminUrl: string
+  readonly baseOrigin: string
+}
+
+function readEnv(env: NodeJS.ProcessEnv): EnvConfig {
+  const strapiUrl = env.STRAPI_GRAPHQL_URL
+  const adminUrl = env.ADMIN_GRAPHQL_URL
+  const baseOrigin = env.STRAPI_PUBLIC_ORIGIN
+  if (!strapiUrl) {
+    throw new Error("STRAPI_GRAPHQL_URL is required")
+  }
+  if (!adminUrl) {
+    throw new Error("ADMIN_GRAPHQL_URL is required")
+  }
+  if (!baseOrigin) {
+    throw new Error("STRAPI_PUBLIC_ORIGIN is required")
+  }
+  return { strapiUrl, adminUrl, baseOrigin }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher construction
+// ---------------------------------------------------------------------------
+
+function buildFetchers(env: EnvConfig, bearer: string | null): Fetchers {
+  const enumerateCorpus = async (): Promise<ReadonlyArray<CorpusEntry>> => {
+    const body = (await postGraphQL({
+      url: env.strapiUrl,
+      query: STRAPI_CORPUS_QUERY,
+      bearer: null, // corpus enumeration goes through Strapi (anonymous OK)
+    })) as {
+      data?: {
+        experiences?: Array<{
+          slug?: string | null
+          locale?: string | null
+          updatedAt?: string | null
+        }>
+      }
+    }
+    const rows = body?.data?.experiences ?? []
+    const entries: CorpusEntry[] = []
+    for (const row of rows) {
+      if (typeof row?.slug !== "string" || typeof row?.locale !== "string")
+        continue
+      entries.push({
+        slug: row.slug,
+        locale: row.locale,
+        updatedAt: typeof row.updatedAt === "string" ? row.updatedAt : null,
+      })
+    }
+    // Sort oldest-first so the stratified sampler's head/tail windows
+    // line up with editorial recency.
+    entries.sort((a, b) => {
+      const ta = a.updatedAt ? Date.parse(a.updatedAt) : 0
+      const tb = b.updatedAt ? Date.parse(b.updatedAt) : 0
+      return ta - tb
+    })
+    return entries
+  }
+
+  const fetchStrapi = async (
+    slug: string,
+    locale: string,
+  ): Promise<StrapiExperienceInput> => {
+    const body = (await postGraphQL({
+      url: env.strapiUrl,
+      query: STRAPI_EXPERIENCE_QUERY,
+      variables: { slug, locale },
+      bearer: null,
+    })) as { data?: { experiences?: ReadonlyArray<StrapiExperienceInput> } }
+    const row = body?.data?.experiences?.[0]
+    if (!row) {
+      throw new Error(
+        `Strapi: no experience found for slug=${slug} locale=${locale}`,
+      )
+    }
+    return row
+  }
+
+  const fetchAdmin = async (
+    slug: string,
+    locale: string,
+  ): Promise<AdminExperienceLocaleInput> => {
+    const body = (await postGraphQL({
+      url: env.adminUrl,
+      query: ADMIN_EXPERIENCE_QUERY,
+      variables: { slug, locale },
+      bearer,
+    })) as { data?: { experienceBySlug?: AdminExperienceLocaleInput | null } }
+    const row = body?.data?.experienceBySlug
+    if (!row) {
+      throw new Error(
+        `admin: no experience found for slug=${slug} locale=${locale}`,
+      )
+    }
+    return row
+  }
+
+  return { enumerateCorpus, fetchStrapi, fetchAdmin }
+}
+
+// ---------------------------------------------------------------------------
+// Output path resolution
+// ---------------------------------------------------------------------------
+
+function defaultOutputPath(now: Date): string {
+  const pad = (n: number): string => String(n).padStart(2, "0")
+  const ts =
+    `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}` +
+    `-${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}`
+  return resolve(process.cwd(), `.tmp/batch-verification-${ts}.json`)
+}
+
+async function writeReport(path: string, report: BatchReport): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, JSON.stringify(report, null, 2), "utf8")
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<number> {
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (err) {
+    process.stderr.write(`[run-batch-verification] ${(err as Error).message}\n`)
+    process.stderr.write(HELP_TEXT)
+    return 2
+  }
+
+  if (args.help) {
+    process.stdout.write(HELP_TEXT)
+    return 0
+  }
+
+  let bearer: string | null
+  let env: EnvConfig
+  try {
+    bearer = readBearerFromEnv(process.env, args.anonymous)
+    env = readEnv(process.env)
+  } catch (err) {
+    if (err instanceof BearerMissingError) {
+      process.stderr.write(`[run-batch-verification] ${err.message}\n`)
+      return 2
+    }
+    process.stderr.write(
+      `[run-batch-verification] ${sanitizeError(err, bearer ?? null)}\n`,
+    )
+    return 2
+  }
+
+  // Load operator-supplied allow-list if provided.
+  let operatorAllowList: ReturnType<typeof parseAllowListFile> = []
+  if (args.allowList !== null) {
+    try {
+      const raw = await readFile(args.allowList, "utf8")
+      operatorAllowList = parseAllowListFile(raw)
+    } catch (err) {
+      process.stderr.write(
+        `[run-batch-verification] allow-list load failed: ${sanitizeError(err, bearer)}\n`,
+      )
+      return 2
+    }
+  }
+
+  const fetchers = buildFetchers(env, bearer)
+  const startedAt = new Date()
+  const outputPath = args.out ?? defaultOutputPath(startedAt)
+
+  let report: BatchReport
+  try {
+    report = await runBatchVerification({
+      args,
+      fetchers,
+      bearer,
+      baseOrigin: env.baseOrigin,
+      allowList: combineAllowLists(operatorAllowList),
+      now: () => startedAt,
+      onSlugComplete: (slugReport, idx, total) => {
+        const tag = slugReport.error
+          ? `ERROR(${slugReport.error.side})`
+          : slugReport.structural.count +
+                slugReport.value.count +
+                slugReport.order.count +
+                slugReport.semantic.count >
+              0
+            ? "DIFFS"
+            : "ok"
+        process.stderr.write(
+          `[${idx}/${total}] ${slugReport.slug}@${slugReport.locale} ${tag}\n`,
+        )
+      },
+    })
+  } catch (err) {
+    // runBatchVerification catches per-slug errors; reaching this catch
+    // means a corpus-enumeration or setup-time failure. Emit a minimal
+    // report so operators see what we tried before bailing.
+    process.stderr.write(
+      `[run-batch-verification] corpus enumeration failed: ${sanitizeError(err, bearer)}\n`,
+    )
+    report = buildReport(startedAt.toISOString(), [])
+  }
+
+  await writeReport(outputPath, report)
+
+  process.stdout.write(formatSummary(report) + "\n")
+  process.stdout.write(`Report: ${outputPath}\n`)
+
+  return report.gate === "PASSED" ? 0 : 1
+}
+
+main()
+  .then((code) => {
+    process.exit(code)
+  })
+  .catch((err: unknown) => {
+    // Last-resort safety net — sanitization happens inside main() for
+    // typed errors; this branch handles unanticipated throws (e.g.,
+    // bug in the script wiring). We don't have a known bearer here,
+    // so we redact aggressively.
+    const msg =
+      err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+    process.stderr.write(`[run-batch-verification] fatal: ${msg}\n`)
+    process.exit(1)
+  })

--- a/packages/graphql/scripts/run-batch-verification.ts
+++ b/packages/graphql/scripts/run-batch-verification.ts
@@ -89,7 +89,10 @@ const STRAPI_EXPERIENCE_QUERY = /* GraphQL */ `
         height
         alternativeText
       }
-      blocks {
+      # REL-03: pagination: { limit: -1 } prevents Strapi v5's silent 10-row
+      # nested-relation cap from truncating block counts on rich experiences,
+      # which would surface as false structural diffs in the cutover gate.
+      blocks(pagination: { limit: -1 }) {
         __typename
       }
     }

--- a/packages/graphql/src/fragments/admin/blocks/advent-countdown.ts
+++ b/packages/graphql/src/fragments/admin/blocks/advent-countdown.ts
@@ -1,0 +1,21 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * Admin-shape AdventCountdownBlock fragment. Field aliases mirror the
+ * Strapi watch-experience fragment vocabulary so consuming renderers
+ * keep the same destructure shape across the cutover.
+ */
+export const adminAdventCountdownFragment = adminGraphql(`
+  fragment AdminAdventCountdown on AdventCountdownBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    adventTitle: title
+    scripture
+    scriptureReference
+    locale
+    imageUrl
+    imageAssetId
+    backgroundColor
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/advent-countdown.ts
+++ b/packages/graphql/src/fragments/admin/blocks/advent-countdown.ts
@@ -1,10 +1,5 @@
 import { adminGraphql } from "../../../admin"
 
-/**
- * Admin-shape AdventCountdownBlock fragment. Field aliases mirror the
- * Strapi watch-experience fragment vocabulary so consuming renderers
- * keep the same destructure shape across the cutover.
- */
 export const adminAdventCountdownFragment = adminGraphql(`
   fragment AdminAdventCountdown on AdventCountdownBlock @_unmask {
     __typename

--- a/packages/graphql/src/fragments/admin/blocks/bible-quotes-carousel.ts
+++ b/packages/graphql/src/fragments/admin/blocks/bible-quotes-carousel.ts
@@ -1,0 +1,26 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminBibleQuotesCarouselFragment = adminGraphql(`
+  fragment AdminBibleQuotesCarousel on BibleQuotesCarouselBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    heading
+    imageUrl
+    imageAssetId
+    backgroundColor
+    quotes {
+      reference
+      text
+      attribution
+      imageUrl
+      imageAssetId
+      backgroundImageUrl
+      backgroundImageAssetId
+      backgroundColor
+      ctaEnabled
+      ctaLabel
+      ctaLink
+    }
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/card.ts
+++ b/packages/graphql/src/fragments/admin/blocks/card.ts
@@ -1,10 +1,6 @@
 import { adminGraphql } from "../../../admin"
 
-/**
- * CardBlock has NO Strapi precedent — admin introduced it post-Strapi.
- * Web renderer doesn't dispatch on it yet; the fragment selects the
- * full admin field set so a future renderer has the types ready.
- */
+/** Admin-only (no Strapi precedent). Web renderer doesn't dispatch yet. */
 export const adminCardFragment = adminGraphql(`
   fragment AdminCard on CardBlock @_unmask {
     __typename

--- a/packages/graphql/src/fragments/admin/blocks/card.ts
+++ b/packages/graphql/src/fragments/admin/blocks/card.ts
@@ -1,0 +1,21 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * CardBlock has NO Strapi precedent — admin introduced it post-Strapi.
+ * Web renderer doesn't dispatch on it yet; the fragment selects the
+ * full admin field set so a future renderer has the types ready.
+ */
+export const adminCardFragment = adminGraphql(`
+  fragment AdminCard on CardBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    title
+    description
+    mediaUrl
+    mediaAssetId
+    backgroundColor
+    link
+    variant
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/container-slot.ts
+++ b/packages/graphql/src/fragments/admin/blocks/container-slot.ts
@@ -1,0 +1,25 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * Admin's flat container shape uses `containerSlot` markers as siblings
+ * inside `container.content[]` — there is no nested-slot wrapper like
+ * Strapi's `slots[].content[]`. This fragment is only valid inside the
+ * ContainerContentBlock union.
+ */
+export const adminContainerSlotFragment = adminGraphql(`
+  fragment AdminContainerSlot on ContainerSlotBlock @_unmask {
+    __typename
+    t
+    gridSpan
+    spans {
+      xs
+      sm
+      md
+      lg
+      xl
+    }
+    backgroundColor
+    backgroundImageUrl
+    backgroundImageAssetId
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/container-slot.ts
+++ b/packages/graphql/src/fragments/admin/blocks/container-slot.ts
@@ -1,11 +1,6 @@
 import { adminGraphql } from "../../../admin"
 
-/**
- * Admin's flat container shape uses `containerSlot` markers as siblings
- * inside `container.content[]` — there is no nested-slot wrapper like
- * Strapi's `slots[].content[]`. This fragment is only valid inside the
- * ContainerContentBlock union.
- */
+/** Only valid inside ContainerContentBlock — a sibling marker, not a wrapper. */
 export const adminContainerSlotFragment = adminGraphql(`
   fragment AdminContainerSlot on ContainerSlotBlock @_unmask {
     __typename

--- a/packages/graphql/src/fragments/admin/blocks/container.ts
+++ b/packages/graphql/src/fragments/admin/blocks/container.ts
@@ -10,15 +10,7 @@ import { adminRelatedQuestionsFragment } from "./related-questions"
 import { adminTextFragment } from "./text"
 import { adminVideoFragment } from "./video"
 
-/**
- * ContainerBlock — admin's flat container shape. Slot dividers are
- * sibling `containerSlot` markers inside `content[]`; no
- * `slots[].content[]` nesting like Strapi.
- *
- * The 10-member ContainerContentBlock union mirrors admin's Zod
- * `ContainerContentBlockSchema` exactly (see
- * apps/admin/src/graphql/types/blocks.ts).
- */
+/** Flat container — slot dividers are sibling `containerSlot` markers in `content[]`, not Strapi-style `slots[].content[]`. */
 export const adminContainerFragment = adminGraphql(
   `
     fragment AdminContainer on ContainerBlock @_unmask {

--- a/packages/graphql/src/fragments/admin/blocks/container.ts
+++ b/packages/graphql/src/fragments/admin/blocks/container.ts
@@ -1,0 +1,78 @@
+import { adminGraphql } from "../../../admin"
+import { adminAdventCountdownFragment } from "./advent-countdown"
+import { adminBibleQuotesCarouselFragment } from "./bible-quotes-carousel"
+import { adminCardFragment } from "./card"
+import { adminContainerSlotFragment } from "./container-slot"
+import { adminCtaFragment } from "./cta"
+import { adminEasterDatesFragment } from "./easter-dates"
+import { adminMediaCollectionFragment } from "./media-collection"
+import { adminRelatedQuestionsFragment } from "./related-questions"
+import { adminTextFragment } from "./text"
+import { adminVideoFragment } from "./video"
+
+/**
+ * ContainerBlock — admin's flat container shape. Slot dividers are
+ * sibling `containerSlot` markers inside `content[]`; no
+ * `slots[].content[]` nesting like Strapi.
+ *
+ * The 10-member ContainerContentBlock union mirrors admin's Zod
+ * `ContainerContentBlockSchema` exactly (see
+ * apps/admin/src/graphql/types/blocks.ts).
+ */
+export const adminContainerFragment = adminGraphql(
+  `
+    fragment AdminContainer on ContainerBlock @_unmask {
+      __typename
+      t
+      sectionKey
+      backgroundColor
+      backgroundImageUrl
+      backgroundImageAssetId
+      content {
+        __typename
+        ... on AdventCountdownBlock {
+          ...AdminAdventCountdown
+        }
+        ... on BibleQuotesCarouselBlock {
+          ...AdminBibleQuotesCarousel
+        }
+        ... on CardBlock {
+          ...AdminCard
+        }
+        ... on ContainerSlotBlock {
+          ...AdminContainerSlot
+        }
+        ... on CtaBlock {
+          ...AdminCta
+        }
+        ... on EasterDatesBlock {
+          ...AdminEasterDates
+        }
+        ... on MediaCollectionBlock {
+          ...AdminMediaCollection
+        }
+        ... on RelatedQuestionsBlock {
+          ...AdminRelatedQuestions
+        }
+        ... on TextBlock {
+          ...AdminText
+        }
+        ... on VideoBlock {
+          ...AdminVideoSection
+        }
+      }
+    }
+  `,
+  [
+    adminAdventCountdownFragment,
+    adminBibleQuotesCarouselFragment,
+    adminCardFragment,
+    adminContainerSlotFragment,
+    adminCtaFragment,
+    adminEasterDatesFragment,
+    adminMediaCollectionFragment,
+    adminRelatedQuestionsFragment,
+    adminTextFragment,
+    adminVideoFragment,
+  ],
+)

--- a/packages/graphql/src/fragments/admin/blocks/cta.ts
+++ b/packages/graphql/src/fragments/admin/blocks/cta.ts
@@ -1,0 +1,17 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminCtaFragment = adminGraphql(`
+  fragment AdminCta on CtaBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    ctaHeading: heading
+    body
+    buttonLabel
+    buttonLink
+    imageUrl
+    imageAssetId
+    backgroundColor
+    variant
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/easter-dates.ts
+++ b/packages/graphql/src/fragments/admin/blocks/easter-dates.ts
@@ -1,0 +1,20 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminEasterDatesFragment = adminGraphql(`
+  fragment AdminEasterDates on EasterDatesBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    easterDatesTitle
+    westernEasterLabel
+    westernEasterEnabled
+    orthodoxEasterLabel
+    orthodoxEasterEnabled
+    passoverLabel
+    passoverEnabled
+    locale
+    imageUrl
+    imageAssetId
+    backgroundColor
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/info-blocks.ts
+++ b/packages/graphql/src/fragments/admin/blocks/info-blocks.ts
@@ -1,0 +1,21 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminInfoBlocksFragment = adminGraphql(`
+  fragment AdminInfoBlocks on InfoBlocksBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    infoHeading: heading
+    intro
+    infoDescription: description
+    widthPercent
+    imageUrl
+    imageAssetId
+    backgroundColor
+    blocks {
+      icon
+      title
+      description
+    }
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/media-collection.ts
+++ b/packages/graphql/src/fragments/admin/blocks/media-collection.ts
@@ -1,16 +1,9 @@
 import { adminGraphql } from "../../../admin"
 
 /**
- * Admin-shape MediaCollectionBlock fragment.
- *
- * Field aliases mirror the Strapi fragment's output vocabulary so the
- * web renderer's destructure (`mediaCollectionVariant`, `mediaCtaLink`,
- * `mediaCtaLabel`, `mediaDescription`) stays compatible across the
- * cutover. Items are FLAT in admin — there is no `items[].video`
- * relation or `items[].imageOverride { url }` wrapper. Renderers that
- * historically read those nested paths will see `undefined`; the
- * runtime fallbacks (`titleOverride`, `imageUrl`) already cover the
- * common rendering path. Video-relation hydration is U6's scope.
+ * Items are FLAT in admin (no `items[].video` join or `imageOverride { url }`
+ * wrapper). Renderers reading those nested paths see undefined; runtime
+ * fallbacks via `titleOverride` / `imageUrl` cover the common path.
  */
 export const adminMediaCollectionFragment = adminGraphql(`
   fragment AdminMediaCollection on MediaCollectionBlock @_unmask {

--- a/packages/graphql/src/fragments/admin/blocks/media-collection.ts
+++ b/packages/graphql/src/fragments/admin/blocks/media-collection.ts
@@ -1,0 +1,46 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * Admin-shape MediaCollectionBlock fragment.
+ *
+ * Field aliases mirror the Strapi fragment's output vocabulary so the
+ * web renderer's destructure (`mediaCollectionVariant`, `mediaCtaLink`,
+ * `mediaCtaLabel`, `mediaDescription`) stays compatible across the
+ * cutover. Items are FLAT in admin — there is no `items[].video`
+ * relation or `items[].imageOverride { url }` wrapper. Renderers that
+ * historically read those nested paths will see `undefined`; the
+ * runtime fallbacks (`titleOverride`, `imageUrl`) already cover the
+ * common rendering path. Video-relation hydration is U6's scope.
+ */
+export const adminMediaCollectionFragment = adminGraphql(`
+  fragment AdminMediaCollection on MediaCollectionBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    title
+    subtitle
+    mediaDescription: description
+    categoryLabel
+    itemsSource
+    mediaCtaLink: ctaLink
+    mediaCtaLabel: ctaLabel
+    showItemNumbers
+    mediaCollectionVariant: variant
+    footerText
+    imageUrl
+    imageAssetId
+    backgroundColor
+    items {
+      videoId
+      titleOverride
+      subtitleOverride
+      labelOverride
+      collectionSize
+      imageUrl
+      imageAssetId
+      imageOverrideUrl
+      imageOverrideAssetId
+      linkToSectionKey
+    }
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/navigation-carousel.ts
+++ b/packages/graphql/src/fragments/admin/blocks/navigation-carousel.ts
@@ -1,0 +1,20 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminNavigationCarouselFragment = adminGraphql(`
+  fragment AdminNavigationCarousel on NavigationCarouselBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    imageUrl
+    imageAssetId
+    backgroundColor
+    items {
+      contentId
+      title
+      category
+      imageUrl
+      imageAssetId
+      backgroundColor
+    }
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/promo-banner.ts
+++ b/packages/graphql/src/fragments/admin/blocks/promo-banner.ts
@@ -1,0 +1,19 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminPromoBannerFragment = adminGraphql(`
+  fragment AdminPromoBanner on PromoBannerBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    promoHeading: heading
+    promoDescription: description
+    intro
+    promoCtaLink: ctaLink
+    ctaEnabled
+    ctaLabel
+    widthPercent
+    imageUrl
+    imageAssetId
+    backgroundColor
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/quiz-button.ts
+++ b/packages/graphql/src/fragments/admin/blocks/quiz-button.ts
@@ -1,0 +1,16 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * QuizButtonBlock is only valid inside SectionContentBlock — never at
+ * the top level. The fragment is selected via the SectionBlock content
+ * union; do NOT use it for top-level dispatch.
+ */
+export const adminQuizButtonFragment = adminGraphql(`
+  fragment AdminQuizButton on QuizButtonBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    buttonText
+    iframeSrc
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/quiz-button.ts
+++ b/packages/graphql/src/fragments/admin/blocks/quiz-button.ts
@@ -1,10 +1,6 @@
 import { adminGraphql } from "../../../admin"
 
-/**
- * QuizButtonBlock is only valid inside SectionContentBlock — never at
- * the top level. The fragment is selected via the SectionBlock content
- * union; do NOT use it for top-level dispatch.
- */
+/** Only valid inside SectionContentBlock; never use for top-level dispatch. */
 export const adminQuizButtonFragment = adminGraphql(`
   fragment AdminQuizButton on QuizButtonBlock @_unmask {
     __typename

--- a/packages/graphql/src/fragments/admin/blocks/related-questions.ts
+++ b/packages/graphql/src/fragments/admin/blocks/related-questions.ts
@@ -1,0 +1,20 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminRelatedQuestionsFragment = adminGraphql(`
+  fragment AdminRelatedQuestions on RelatedQuestionsBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    heading
+    ctaEnabled
+    ctaLabel
+    ctaLink
+    imageUrl
+    imageAssetId
+    backgroundColor
+    questions {
+      question
+      answer
+    }
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/section.ts
+++ b/packages/graphql/src/fragments/admin/blocks/section.ts
@@ -1,0 +1,97 @@
+import { adminGraphql } from "../../../admin"
+import { adminBibleQuotesCarouselFragment } from "./bible-quotes-carousel"
+import { adminCardFragment } from "./card"
+import { adminContainerFragment } from "./container"
+import { adminCtaFragment } from "./cta"
+import { adminInfoBlocksFragment } from "./info-blocks"
+import { adminMediaCollectionFragment } from "./media-collection"
+import { adminNavigationCarouselFragment } from "./navigation-carousel"
+import { adminPromoBannerFragment } from "./promo-banner"
+import { adminQuizButtonFragment } from "./quiz-button"
+import { adminRelatedQuestionsFragment } from "./related-questions"
+import { adminTextFragment } from "./text"
+import { adminVideoFragment } from "./video"
+import { adminVideoCarouselFragment } from "./video-carousel"
+
+/**
+ * SectionBlock — wrapper section with background + dynamic content.
+ *
+ * The 13-member SectionContentBlock union mirrors admin's Zod
+ * `SectionContentBlockSchema` exactly. SectionBlock CANNOT nest
+ * another SectionBlock (no recursion); ContainerBlock IS allowed as
+ * content, and ContainerBlock can in turn carry its own content
+ * recursion via AdminContainer.
+ */
+export const adminSectionFragment = adminGraphql(
+  `
+    fragment AdminSection on SectionBlock @_unmask {
+      __typename
+      t
+      sectionKey
+      backgroundColor
+      backgroundImageUrl
+      backgroundImageAssetId
+      backgroundOpacity
+      dynamicBackgroundImage
+      staticOverlay
+      blurHash
+      sectionContent: content {
+        __typename
+        ... on BibleQuotesCarouselBlock {
+          ...AdminBibleQuotesCarousel
+        }
+        ... on CardBlock {
+          ...AdminCard
+        }
+        ... on ContainerBlock {
+          ...AdminContainer
+        }
+        ... on CtaBlock {
+          ...AdminCta
+        }
+        ... on InfoBlocksBlock {
+          ...AdminInfoBlocks
+        }
+        ... on MediaCollectionBlock {
+          ...AdminMediaCollection
+        }
+        ... on NavigationCarouselBlock {
+          ...AdminNavigationCarousel
+        }
+        ... on PromoBannerBlock {
+          ...AdminPromoBanner
+        }
+        ... on QuizButtonBlock {
+          ...AdminQuizButton
+        }
+        ... on RelatedQuestionsBlock {
+          ...AdminRelatedQuestions
+        }
+        ... on TextBlock {
+          ...AdminText
+        }
+        ... on VideoBlock {
+          ...AdminVideoSection
+        }
+        ... on VideoCarouselBlock {
+          ...AdminVideoCarousel
+        }
+      }
+    }
+  `,
+  [
+    adminBibleQuotesCarouselFragment,
+    adminCardFragment,
+    adminContainerFragment,
+    adminCtaFragment,
+    adminInfoBlocksFragment,
+    adminMediaCollectionFragment,
+    adminNavigationCarouselFragment,
+    adminPromoBannerFragment,
+    adminQuizButtonFragment,
+    adminRelatedQuestionsFragment,
+    adminTextFragment,
+    adminVideoFragment,
+    adminVideoCarouselFragment,
+  ],
+)

--- a/packages/graphql/src/fragments/admin/blocks/section.ts
+++ b/packages/graphql/src/fragments/admin/blocks/section.ts
@@ -13,15 +13,7 @@ import { adminTextFragment } from "./text"
 import { adminVideoFragment } from "./video"
 import { adminVideoCarouselFragment } from "./video-carousel"
 
-/**
- * SectionBlock — wrapper section with background + dynamic content.
- *
- * The 13-member SectionContentBlock union mirrors admin's Zod
- * `SectionContentBlockSchema` exactly. SectionBlock CANNOT nest
- * another SectionBlock (no recursion); ContainerBlock IS allowed as
- * content, and ContainerBlock can in turn carry its own content
- * recursion via AdminContainer.
- */
+/** SectionBlock cannot nest another SectionBlock; ContainerBlock IS allowed. */
 export const adminSectionFragment = adminGraphql(
   `
     fragment AdminSection on SectionBlock @_unmask {

--- a/packages/graphql/src/fragments/admin/blocks/text.ts
+++ b/packages/graphql/src/fragments/admin/blocks/text.ts
@@ -1,0 +1,17 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminTextFragment = adminGraphql(`
+  fragment AdminText on TextBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    heading
+    headingLevel
+    subtitle
+    contentParagraphs
+    textVariant: variant
+    imageUrl
+    imageAssetId
+    backgroundColor
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/video-carousel.ts
+++ b/packages/graphql/src/fragments/admin/blocks/video-carousel.ts
@@ -1,0 +1,27 @@
+import { adminGraphql } from "../../../admin"
+
+export const adminVideoCarouselFragment = adminGraphql(`
+  fragment AdminVideoCarousel on VideoCarouselBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    title
+    subtitle
+    carouselDescription: description
+    itemsSource
+    imageUrl
+    imageAssetId
+    backgroundColor
+    items {
+      videoId
+      streamingUrl
+      imageUrl
+      imageAssetId
+      imageOverrideUrl
+      imageOverrideAssetId
+      titleOverride
+      subtitleOverride
+      backgroundColor
+    }
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/video-hero.ts
+++ b/packages/graphql/src/fragments/admin/blocks/video-hero.ts
@@ -1,10 +1,6 @@
 import { adminGraphql } from "../../../admin"
 
-/**
- * VideoHeroBlock — full-bleed hero video. Same flat-video posture as
- * VideoBlock: admin returns `videoId` + `streamingUrl` only. No nested
- * `video { documentId, title, slug, images { url } }` join.
- */
+/** Flat-video posture (no `video { ... }` join); admin returns `videoId` + `streamingUrl` only. */
 export const adminVideoHeroFragment = adminGraphql(`
   fragment AdminVideoHero on VideoHeroBlock @_unmask {
     __typename

--- a/packages/graphql/src/fragments/admin/blocks/video-hero.ts
+++ b/packages/graphql/src/fragments/admin/blocks/video-hero.ts
@@ -1,0 +1,30 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * VideoHeroBlock — full-bleed hero video. Same flat-video posture as
+ * VideoBlock: admin returns `videoId` + `streamingUrl` only. No nested
+ * `video { documentId, title, slug, images { url } }` join.
+ */
+export const adminVideoHeroFragment = adminGraphql(`
+  fragment AdminVideoHero on VideoHeroBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    useRouteVideo
+    heading
+    subheading
+    headingSource
+    subheadingSource
+    ctaEnabled
+    ctaLabel
+    ctaLink
+    streamingUrl
+    videoId
+    clipStartSeconds
+    clipEndSeconds
+    autoplay
+    muted
+    loop
+    showControls
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/video-recommendations.ts
+++ b/packages/graphql/src/fragments/admin/blocks/video-recommendations.ts
@@ -1,0 +1,23 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * Admin-only block (no Strapi precedent). The renderer dispatches
+ * dynamically into the VideoRecommendations component which fetches
+ * scene-similarity recommendations at render time via the public
+ * `sceneRecommendations` query.
+ */
+export const adminVideoRecommendationsFragment = adminGraphql(`
+  fragment AdminVideoRecommendations on VideoRecommendationsBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    title
+    subtitle
+    description
+    sourceVideoId
+    sourceSceneIndex
+    limit
+    imageUrl
+    backgroundColor
+  }
+`)

--- a/packages/graphql/src/fragments/admin/blocks/video-recommendations.ts
+++ b/packages/graphql/src/fragments/admin/blocks/video-recommendations.ts
@@ -1,11 +1,6 @@
 import { adminGraphql } from "../../../admin"
 
-/**
- * Admin-only block (no Strapi precedent). The renderer dispatches
- * dynamically into the VideoRecommendations component which fetches
- * scene-similarity recommendations at render time via the public
- * `sceneRecommendations` query.
- */
+/** Admin-only; renderer fetches scene-similarity at render time via `sceneRecommendations`. */
 export const adminVideoRecommendationsFragment = adminGraphql(`
   fragment AdminVideoRecommendations on VideoRecommendationsBlock @_unmask {
     __typename

--- a/packages/graphql/src/fragments/admin/blocks/video.ts
+++ b/packages/graphql/src/fragments/admin/blocks/video.ts
@@ -1,12 +1,6 @@
 import { adminGraphql } from "../../../admin"
 
-/**
- * VideoBlock — embedded inline video. Admin returns FLAT video metadata
- * (`videoId`, `streamingUrl`, `mediaUrl`); there is no Strapi-style
- * `videoRef { documentId, title, slug, images { url } }` join. The
- * Strapi fragment's `media { url }` projection collapses to the flat
- * `mediaUrl` here; the `videoRef` join collapses to `videoId`.
- */
+/** Flat video metadata — no Strapi-style `videoRef { ... }` join; `mediaUrl` replaces `media { url }`. */
 export const adminVideoFragment = adminGraphql(`
   fragment AdminVideoSection on VideoBlock @_unmask {
     __typename

--- a/packages/graphql/src/fragments/admin/blocks/video.ts
+++ b/packages/graphql/src/fragments/admin/blocks/video.ts
@@ -1,0 +1,31 @@
+import { adminGraphql } from "../../../admin"
+
+/**
+ * VideoBlock — embedded inline video. Admin returns FLAT video metadata
+ * (`videoId`, `streamingUrl`, `mediaUrl`); there is no Strapi-style
+ * `videoRef { documentId, title, slug, images { url } }` join. The
+ * Strapi fragment's `media { url }` projection collapses to the flat
+ * `mediaUrl` here; the `videoRef` join collapses to `videoId`.
+ */
+export const adminVideoFragment = adminGraphql(`
+  fragment AdminVideoSection on VideoBlock @_unmask {
+    __typename
+    t
+    sectionKey
+    useRouteVideo
+    streamingUrl
+    title
+    subtitle
+    titleSource
+    subtitleSource
+    videoId
+    mediaUrl
+    mediaAssetId
+    clipStartSeconds
+    clipEndSeconds
+    autoplay
+    muted
+    loop
+    showControls
+  }
+`)

--- a/packages/graphql/src/fragments/admin/index.ts
+++ b/packages/graphql/src/fragments/admin/index.ts
@@ -1,0 +1,30 @@
+// Admin-shape fragments for the web/mobile/tv `WatchExperience` route.
+// Authored against admin's regenerated SDL (apps/admin/schema.graphql)
+// via the `adminGraphql()` factory. Field aliases on shared fragment
+// selections preserve the Strapi fragment vocabulary so downstream
+// renderers in `apps/web/src/components/sections/` stay byte-identical
+// across the cutover.
+//
+// Used by `apps/web/src/lib/content.ts` once U6 wires admin-mode
+// fetching, AND available for future apps/mobile + apps/tv reuse.
+
+export { adminAdventCountdownFragment } from "./blocks/advent-countdown"
+export { adminBibleQuotesCarouselFragment } from "./blocks/bible-quotes-carousel"
+export { adminCardFragment } from "./blocks/card"
+export { adminContainerFragment } from "./blocks/container"
+export { adminContainerSlotFragment } from "./blocks/container-slot"
+export { adminCtaFragment } from "./blocks/cta"
+export { adminEasterDatesFragment } from "./blocks/easter-dates"
+export { adminInfoBlocksFragment } from "./blocks/info-blocks"
+export { adminMediaCollectionFragment } from "./blocks/media-collection"
+export { adminNavigationCarouselFragment } from "./blocks/navigation-carousel"
+export { adminPromoBannerFragment } from "./blocks/promo-banner"
+export { adminQuizButtonFragment } from "./blocks/quiz-button"
+export { adminRelatedQuestionsFragment } from "./blocks/related-questions"
+export { adminSectionFragment } from "./blocks/section"
+export { adminTextFragment } from "./blocks/text"
+export { adminVideoFragment } from "./blocks/video"
+export { adminVideoCarouselFragment } from "./blocks/video-carousel"
+export { adminVideoHeroFragment } from "./blocks/video-hero"
+export { adminVideoRecommendationsFragment } from "./blocks/video-recommendations"
+export { adminWatchExperienceFragment } from "./watch-experience"

--- a/packages/graphql/src/fragments/admin/index.ts
+++ b/packages/graphql/src/fragments/admin/index.ts
@@ -1,12 +1,6 @@
 // Admin-shape fragments for the web/mobile/tv `WatchExperience` route.
-// Authored against admin's regenerated SDL (apps/admin/schema.graphql)
-// via the `adminGraphql()` factory. Field aliases on shared fragment
-// selections preserve the Strapi fragment vocabulary so downstream
-// renderers in `apps/web/src/components/sections/` stay byte-identical
-// across the cutover.
-//
-// Used by `apps/web/src/lib/content.ts` once U6 wires admin-mode
-// fetching, AND available for future apps/mobile + apps/tv reuse.
+// Field aliases on shared fragment selections preserve the Strapi vocabulary
+// so downstream renderers stay byte-identical across the cutover.
 
 export { adminAdventCountdownFragment } from "./blocks/advent-countdown"
 export { adminBibleQuotesCarouselFragment } from "./blocks/bible-quotes-carousel"

--- a/packages/graphql/src/fragments/admin/watch-experience.ts
+++ b/packages/graphql/src/fragments/admin/watch-experience.ts
@@ -18,29 +18,12 @@ import { adminVideoHeroFragment } from "./blocks/video-hero"
 import { adminVideoRecommendationsFragment } from "./blocks/video-recommendations"
 
 /**
- * Root admin-shape `WatchExperience` fragment on `ExperienceLocale`.
- *
- * Mirrors the Strapi `WatchExperience` fragment vocabulary so consumer
- * apps can switch between Strapi and admin sources without rewriting
- * downstream rendering. Field-level diffs:
- *
- *   - Strapi: `documentId`. Admin: `id` (cuid string). Aliased to
- *     `documentId` so renderers consuming `exp.documentId` keep
- *     working unmodified.
- *   - Strapi: `ogImage { url, width, height, alternativeText }`.
- *     Admin: `ogImageUrl: String` (single scalar). The admin shape
- *     synthesizes the missing `width / height / alternativeText` as
- *     `null` at the consumer boundary (see normalizeAdmin); renderers
- *     reading `exp.ogImage?.url` get the URL from `ogImageUrl`
- *     aliased to `ogImage_url` — but we keep two parallel selections
- *     here (`ogImageUrl` + the aliased `ogImage` shape) so consumers
- *     can pick the form that matches their existing accessor.
- *   - Strapi: `isTemplate` lives on the Experience parent. Admin: on
- *     the parent Experience too, but ExperienceLocale carries
- *     `isHomepage` for homepage-routing affordance.
- *
- * The 17-member `ExperienceBlock` union covers every top-level block
- * kind admin's editor can store (see apps/admin/src/graphql/types/blocks.ts).
+ * Root admin-shape WatchExperience fragment on ExperienceLocale.
+ * Mirrors Strapi vocabulary via aliases so consumer renderers stay byte-
+ * identical across the cutover. Diffs:
+ *   - admin `id` (cuid) ≠ Strapi `documentId` (aliased so renderers work)
+ *   - admin `ogImageUrl: String` ≠ Strapi `ogImage { url, width, height, alt }`
+ *     (missing dimensions synthesized as null in normalizeAdmin)
  */
 export const adminWatchExperienceFragment = adminGraphql(
   `

--- a/packages/graphql/src/fragments/admin/watch-experience.ts
+++ b/packages/graphql/src/fragments/admin/watch-experience.ts
@@ -1,0 +1,134 @@
+import { adminGraphql } from "../../admin"
+import { adminAdventCountdownFragment } from "./blocks/advent-countdown"
+import { adminBibleQuotesCarouselFragment } from "./blocks/bible-quotes-carousel"
+import { adminCardFragment } from "./blocks/card"
+import { adminContainerFragment } from "./blocks/container"
+import { adminCtaFragment } from "./blocks/cta"
+import { adminEasterDatesFragment } from "./blocks/easter-dates"
+import { adminInfoBlocksFragment } from "./blocks/info-blocks"
+import { adminMediaCollectionFragment } from "./blocks/media-collection"
+import { adminNavigationCarouselFragment } from "./blocks/navigation-carousel"
+import { adminPromoBannerFragment } from "./blocks/promo-banner"
+import { adminRelatedQuestionsFragment } from "./blocks/related-questions"
+import { adminSectionFragment } from "./blocks/section"
+import { adminTextFragment } from "./blocks/text"
+import { adminVideoFragment } from "./blocks/video"
+import { adminVideoCarouselFragment } from "./blocks/video-carousel"
+import { adminVideoHeroFragment } from "./blocks/video-hero"
+import { adminVideoRecommendationsFragment } from "./blocks/video-recommendations"
+
+/**
+ * Root admin-shape `WatchExperience` fragment on `ExperienceLocale`.
+ *
+ * Mirrors the Strapi `WatchExperience` fragment vocabulary so consumer
+ * apps can switch between Strapi and admin sources without rewriting
+ * downstream rendering. Field-level diffs:
+ *
+ *   - Strapi: `documentId`. Admin: `id` (cuid string). Aliased to
+ *     `documentId` so renderers consuming `exp.documentId` keep
+ *     working unmodified.
+ *   - Strapi: `ogImage { url, width, height, alternativeText }`.
+ *     Admin: `ogImageUrl: String` (single scalar). The admin shape
+ *     synthesizes the missing `width / height / alternativeText` as
+ *     `null` at the consumer boundary (see normalizeAdmin); renderers
+ *     reading `exp.ogImage?.url` get the URL from `ogImageUrl`
+ *     aliased to `ogImage_url` — but we keep two parallel selections
+ *     here (`ogImageUrl` + the aliased `ogImage` shape) so consumers
+ *     can pick the form that matches their existing accessor.
+ *   - Strapi: `isTemplate` lives on the Experience parent. Admin: on
+ *     the parent Experience too, but ExperienceLocale carries
+ *     `isHomepage` for homepage-routing affordance.
+ *
+ * The 17-member `ExperienceBlock` union covers every top-level block
+ * kind admin's editor can store (see apps/admin/src/graphql/types/blocks.ts).
+ */
+export const adminWatchExperienceFragment = adminGraphql(
+  `
+    fragment AdminWatchExperience on ExperienceLocale @_unmask {
+      __typename
+      id
+      slug
+      locale
+      isHomepage
+      title
+      metaDescription
+      ogTitle
+      ogDescription
+      ogImageUrl
+      pathSegment
+      blocks {
+        __typename
+        ... on AdventCountdownBlock {
+          ...AdminAdventCountdown
+        }
+        ... on BibleQuotesCarouselBlock {
+          ...AdminBibleQuotesCarousel
+        }
+        ... on CardBlock {
+          ...AdminCard
+        }
+        ... on ContainerBlock {
+          ...AdminContainer
+        }
+        ... on CtaBlock {
+          ...AdminCta
+        }
+        ... on EasterDatesBlock {
+          ...AdminEasterDates
+        }
+        ... on InfoBlocksBlock {
+          ...AdminInfoBlocks
+        }
+        ... on MediaCollectionBlock {
+          ...AdminMediaCollection
+        }
+        ... on NavigationCarouselBlock {
+          ...AdminNavigationCarousel
+        }
+        ... on PromoBannerBlock {
+          ...AdminPromoBanner
+        }
+        ... on RelatedQuestionsBlock {
+          ...AdminRelatedQuestions
+        }
+        ... on SectionBlock {
+          ...AdminSection
+        }
+        ... on TextBlock {
+          ...AdminText
+        }
+        ... on VideoBlock {
+          ...AdminVideoSection
+        }
+        ... on VideoCarouselBlock {
+          ...AdminVideoCarousel
+        }
+        ... on VideoHeroBlock {
+          ...AdminVideoHero
+        }
+        ... on VideoRecommendationsBlock {
+          ...AdminVideoRecommendations
+        }
+      }
+    }
+  `,
+  [
+    adminAdventCountdownFragment,
+    adminBibleQuotesCarouselFragment,
+    adminCardFragment,
+    adminContainerFragment,
+    adminCtaFragment,
+    adminEasterDatesFragment,
+    adminInfoBlocksFragment,
+    adminMediaCollectionFragment,
+    adminNavigationCarouselFragment,
+    adminPromoBannerFragment,
+    adminRelatedQuestionsFragment,
+    adminSectionFragment,
+    adminTextFragment,
+    adminVideoFragment,
+    adminVideoCarouselFragment,
+    adminVideoHeroFragment,
+    adminVideoRecommendationsFragment,
+  ],
+)

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -3,3 +3,30 @@ export type { FragmentOf, ResultOf, VariablesOf } from "./graphql"
 
 export { adminGraphql } from "./admin"
 export type { AdminFragmentOf, AdminResultOf, AdminVariablesOf } from "./admin"
+
+// Admin-shape fragments (per-block-kind + root WatchExperience). The
+// dedicated `@forge/graphql/admin/fragments` subpath is the canonical
+// import; re-exporting from the package root keeps `import { ... } from
+// "@forge/graphql"` ergonomic for the common case.
+export {
+  adminAdventCountdownFragment,
+  adminBibleQuotesCarouselFragment,
+  adminCardFragment,
+  adminContainerFragment,
+  adminContainerSlotFragment,
+  adminCtaFragment,
+  adminEasterDatesFragment,
+  adminInfoBlocksFragment,
+  adminMediaCollectionFragment,
+  adminNavigationCarouselFragment,
+  adminPromoBannerFragment,
+  adminQuizButtonFragment,
+  adminRelatedQuestionsFragment,
+  adminSectionFragment,
+  adminTextFragment,
+  adminVideoFragment,
+  adminVideoCarouselFragment,
+  adminVideoHeroFragment,
+  adminVideoRecommendationsFragment,
+  adminWatchExperienceFragment,
+} from "./fragments/admin"

--- a/packages/graphql/src/parity/allow-list.ts
+++ b/packages/graphql/src/parity/allow-list.ts
@@ -42,6 +42,14 @@ export type AppliedAllowListEntry = {
  *
  * Adding entries here without a rationale that points to a tracked
  * decision is the documented anti-pattern — see plan Risks.
+ *
+ * Plan-003 U8 (batch verification harness): operators pass a
+ * `--allow-list <path>` JSON file to extend this default at runtime.
+ * Entries added there carry the same auditing contract — every entry
+ * MUST cite a decision doc in its rationale. See
+ * `packages/graphql/scripts/run-batch-verification.ts` for the CLI flow
+ * and `packages/graphql/src/parity/batch-verification.ts` for the file-
+ * format validation.
  */
 export const DEFAULT_ALLOW_LIST: ReadonlyArray<AllowListEntry> = [
   {

--- a/packages/graphql/src/parity/batch-verification.test.ts
+++ b/packages/graphql/src/parity/batch-verification.test.ts
@@ -705,11 +705,29 @@ describe("runBatchVerification", () => {
 // ---------------------------------------------------------------------------
 
 describe("backoffDelayMs", () => {
-  it("grows exponentially and caps at 30000", () => {
-    expect(backoffDelayMs(0)).toBe(500)
-    expect(backoffDelayMs(1)).toBe(1000)
-    expect(backoffDelayMs(2)).toBe(2000)
-    expect(backoffDelayMs(20)).toBe(30000)
+  it("scales exponentially within the jitter envelope and caps at 30000", () => {
+    // Inject rng=()=>1 to get the ceiling (jitter would scale by 1.0 → full
+    // cap value) and rng=()=>0 to get the floor (0ms).
+    const ceil = (n: number) => () => n
+    expect(backoffDelayMs(0, ceil(0.999))).toBeLessThanOrEqual(500)
+    expect(backoffDelayMs(1, ceil(0.999))).toBeLessThanOrEqual(1000)
+    expect(backoffDelayMs(2, ceil(0.999))).toBeLessThanOrEqual(2000)
+    expect(backoffDelayMs(20, ceil(0.999))).toBeLessThanOrEqual(30000)
+    expect(backoffDelayMs(20, ceil(0.999))).toBeGreaterThan(29000)
+  })
+  it("REL-02 jitter: delay is bounded by [0, exponential cap)", () => {
+    // 50 samples at attempt=3 (cap = 4000). Every sample must be < 4000.
+    for (let i = 0; i < 50; i++) {
+      const delay = backoffDelayMs(3)
+      expect(delay).toBeGreaterThanOrEqual(0)
+      expect(delay).toBeLessThan(4000)
+    }
+  })
+  it("REL-02 jitter: delay is non-deterministic across calls (different RNG outcomes)", () => {
+    const samples = Array.from({ length: 20 }, () => backoffDelayMs(5))
+    const unique = new Set(samples)
+    // Allow rare RNG collisions but assert the distribution is not constant.
+    expect(unique.size).toBeGreaterThan(5)
   })
 })
 

--- a/packages/graphql/src/parity/batch-verification.test.ts
+++ b/packages/graphql/src/parity/batch-verification.test.ts
@@ -1,0 +1,992 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  BearerMissingError,
+  FETCH_MAX_RETRIES,
+  RateLimitExhaustedError,
+  backoffDelayMs,
+  buildReport,
+  combineAllowLists,
+  compareSlug,
+  formatSummary,
+  parseAllowListFile,
+  parseArgs,
+  postGraphQL,
+  readBearerFromEnv,
+  runBatchVerification,
+  sanitizeError,
+  stratifiedSample,
+  type BatchReport,
+  type CorpusEntry,
+  type Fetchers,
+  type SlugReport,
+} from "./batch-verification"
+import type { AdminExperienceLocaleInput } from "./normalize-admin"
+import type { StrapiExperienceInput } from "./normalize-strapi"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_ORIGIN = "https://cdn.example.com"
+
+/**
+ * Hand-rolled Strapi input. The `documentId` is shared with the
+ * matching admin input below — production has them diverge (admin uses
+ * cuid; Strapi uses documentId), but the divergence is suppressed by
+ * the `/id` entry on DEFAULT_ALLOW_LIST. Tests that pass `allowList:
+ * []` to isolate harness behavior would otherwise see /id as a value
+ * diff. Using a shared id keeps the harness-logic tests focused on
+ * what the harness adds, not on what the comparator already covers.
+ */
+function makeStrapiInput(
+  slug: string,
+  locale: string,
+  overrides: Partial<StrapiExperienceInput> = {},
+): StrapiExperienceInput {
+  return {
+    documentId: `shared-${slug}`,
+    slug,
+    locale,
+    title: `Title for ${slug}`,
+    metaDescription: "shared description",
+    ogImage: null,
+    blocks: [],
+    ...overrides,
+  }
+}
+
+function makeAdminInput(
+  slug: string,
+  locale: string,
+  overrides: Partial<AdminExperienceLocaleInput> = {},
+): AdminExperienceLocaleInput {
+  return {
+    id: `shared-${slug}`,
+    slug,
+    locale,
+    title: `Title for ${slug}`,
+    description: "shared description",
+    ogImageUrl: null,
+    blocks: [],
+    ...overrides,
+  }
+}
+
+function makeFetchers(args: {
+  readonly corpus: ReadonlyArray<CorpusEntry>
+  readonly strapi: Map<string, StrapiExperienceInput>
+  readonly admin: Map<string, AdminExperienceLocaleInput>
+  readonly strapiErrors?: Map<string, string>
+  readonly adminErrors?: Map<string, string>
+  readonly onFetchStart?: () => void
+  readonly onFetchEnd?: () => void
+}): Fetchers {
+  return {
+    enumerateCorpus: async () => args.corpus,
+    fetchStrapi: async (slug, locale) => {
+      args.onFetchStart?.()
+      try {
+        const err = args.strapiErrors?.get(`${slug}@${locale}`)
+        if (err) throw new Error(err)
+        const row = args.strapi.get(`${slug}@${locale}`)
+        if (!row) throw new Error(`Strapi: not found: ${slug}@${locale}`)
+        return row
+      } finally {
+        args.onFetchEnd?.()
+      }
+    },
+    fetchAdmin: async (slug, locale) => {
+      args.onFetchStart?.()
+      try {
+        const err = args.adminErrors?.get(`${slug}@${locale}`)
+        if (err) throw new Error(err)
+        const row = args.admin.get(`${slug}@${locale}`)
+        if (!row) throw new Error(`admin: not found: ${slug}@${locale}`)
+        return row
+      } finally {
+        args.onFetchEnd?.()
+      }
+    },
+  }
+}
+
+// Deterministic RNG for sampling tests. Uses a basic LCG so the same
+// seed produces the same sequence across test runs.
+function seededRng(seed: number): () => number {
+  let state = seed
+  return () => {
+    state = (state * 1664525 + 1013904223) % 2 ** 32
+    return state / 2 ** 32
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  it("returns defaults for empty argv", () => {
+    const args = parseArgs([])
+    expect(args).toEqual({
+      sample: null,
+      concurrency: 5,
+      out: null,
+      allowList: null,
+      since: null,
+      anonymous: false,
+      help: false,
+    })
+  })
+
+  it("parses every flag", () => {
+    const args = parseArgs([
+      "--sample",
+      "10",
+      "--concurrency",
+      "3",
+      "--out",
+      "out.json",
+      "--allow-list",
+      "allow.json",
+      "--since",
+      "2026-05-12T00:00:00Z",
+      "--anonymous",
+    ])
+    expect(args.sample).toBe(10)
+    expect(args.concurrency).toBe(3)
+    expect(args.out).toBe("out.json")
+    expect(args.allowList).toBe("allow.json")
+    expect(args.since).toBe("2026-05-12T00:00:00Z")
+    expect(args.anonymous).toBe(true)
+  })
+
+  it("rejects non-integer --sample", () => {
+    expect(() => parseArgs(["--sample", "abc"])).toThrow(/positive integer/)
+  })
+
+  it("rejects zero --concurrency", () => {
+    expect(() => parseArgs(["--concurrency", "0"])).toThrow(/positive integer/)
+  })
+
+  it("rejects malformed --since", () => {
+    expect(() => parseArgs(["--since", "yesterday"])).toThrow(/ISO timestamp/)
+  })
+
+  it("rejects unrecognized flag", () => {
+    expect(() => parseArgs(["--magic"])).toThrow(/unrecognized flag/)
+  })
+
+  it("sets help on --help or -h", () => {
+    expect(parseArgs(["--help"]).help).toBe(true)
+    expect(parseArgs(["-h"]).help).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readBearerFromEnv — the hard-fail-on-anonymous contract
+// ---------------------------------------------------------------------------
+
+describe("readBearerFromEnv", () => {
+  it("returns null when --anonymous is set", () => {
+    expect(readBearerFromEnv({}, true)).toBeNull()
+  })
+
+  it("throws BearerMissingError when env unset and --anonymous not passed", () => {
+    expect(() => readBearerFromEnv({}, false)).toThrow(BearerMissingError)
+  })
+
+  it("error message names the self-DoS risk", () => {
+    try {
+      readBearerFromEnv({}, false)
+    } catch (err) {
+      expect((err as Error).message).toMatch(/self-DoS|public:\$\{ip\}/)
+      return
+    }
+    throw new Error("expected throw")
+  })
+
+  it("returns first CSV entry, trimmed", () => {
+    expect(
+      readBearerFromEnv({ WEB_ADMIN_API_KEYS: " key-a , key-b " }, false),
+    ).toBe("key-a")
+  })
+
+  it("throws when env value is only whitespace", () => {
+    expect(() =>
+      readBearerFromEnv({ WEB_ADMIN_API_KEYS: "   " }, false),
+    ).toThrow(BearerMissingError)
+  })
+
+  it("throws when first CSV entry is empty", () => {
+    expect(() =>
+      readBearerFromEnv({ WEB_ADMIN_API_KEYS: ",key-b" }, false),
+    ).toThrow(BearerMissingError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sanitizeError — bearer redaction
+// ---------------------------------------------------------------------------
+
+describe("sanitizeError", () => {
+  it("strips bearer from error message", () => {
+    const msg = sanitizeError(
+      new Error("HTTP 500: bad token sk-secret-12345"),
+      "sk-secret-12345",
+    )
+    expect(msg).not.toContain("sk-secret-12345")
+    expect(msg).toContain("[REDACTED]")
+  })
+
+  it("passes through when bearer is null", () => {
+    const msg = sanitizeError(new Error("plain error"), null)
+    expect(msg).toBe("Error: plain error")
+  })
+
+  it("handles non-Error throws", () => {
+    expect(sanitizeError("oops", null)).toBe("oops")
+    expect(sanitizeError(42, null)).toBe("42")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseAllowListFile
+// ---------------------------------------------------------------------------
+
+describe("parseAllowListFile", () => {
+  it("parses a valid array", () => {
+    const raw = JSON.stringify([
+      { path: "/foo", channel: "value", rationale: "see docs" },
+    ])
+    const entries = parseAllowListFile(raw)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toEqual({
+      path: "/foo",
+      channel: "value",
+      rationale: "see docs",
+    })
+  })
+
+  it("rejects non-JSON", () => {
+    expect(() => parseAllowListFile("not json")).toThrow(/valid JSON/)
+  })
+
+  it("rejects non-array root", () => {
+    expect(() => parseAllowListFile("{}")).toThrow(/top-level JSON array/)
+  })
+
+  it("rejects entry with empty rationale", () => {
+    const raw = JSON.stringify([
+      { path: "/foo", channel: "value", rationale: "" },
+    ])
+    expect(() => parseAllowListFile(raw)).toThrow(/empty rationale/)
+  })
+
+  it("rejects invalid channel", () => {
+    const raw = JSON.stringify([
+      { path: "/foo", channel: "fake", rationale: "ok" },
+    ])
+    expect(() => parseAllowListFile(raw)).toThrow(/invalid channel/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// combineAllowLists
+// ---------------------------------------------------------------------------
+
+describe("combineAllowLists", () => {
+  it("prepends DEFAULT_ALLOW_LIST to operator entries", () => {
+    const combined = combineAllowLists([
+      { path: "/custom", channel: "value", rationale: "operator note" },
+    ])
+    expect(combined.length).toBeGreaterThan(1)
+    // The operator entry is last.
+    expect(combined[combined.length - 1]).toEqual({
+      path: "/custom",
+      channel: "value",
+      rationale: "operator note",
+    })
+  })
+
+  it("returns DEFAULT only when operator list is empty", () => {
+    const combined = combineAllowLists([])
+    expect(combined.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stratifiedSample
+// ---------------------------------------------------------------------------
+
+describe("stratifiedSample", () => {
+  it("returns the corpus unchanged when sample >= corpus length", () => {
+    const corpus = ["a", "b", "c"]
+    expect(stratifiedSample(corpus, 10)).toEqual(corpus)
+  })
+
+  it("returns empty for sample <= 0", () => {
+    expect(stratifiedSample(["a", "b"], 0)).toEqual([])
+  })
+
+  it("returns exactly `sample` entries", () => {
+    const corpus = Array.from({ length: 100 }, (_, i) => `slug-${i}`)
+    const sampled = stratifiedSample(corpus, 10, seededRng(42))
+    expect(sampled).toHaveLength(10)
+  })
+
+  it("is deterministic for a given seed", () => {
+    const corpus = Array.from({ length: 100 }, (_, i) => `slug-${i}`)
+    const a = stratifiedSample(corpus, 30, seededRng(42))
+    const b = stratifiedSample(corpus, 30, seededRng(42))
+    expect(a).toEqual(b)
+  })
+
+  it("draws from the oldest band, middle, and newest band (no skew to one end)", () => {
+    const corpus = Array.from({ length: 100 }, (_, i) => i)
+    const sampled = stratifiedSample(corpus, 30, seededRng(7))
+    const numbers = sampled as ReadonlyArray<number>
+    // Expect at least one entry from the oldest third, one from middle, one from newest.
+    const oldThird = numbers.some((n) => n < 33)
+    const midThird = numbers.some((n) => n >= 33 && n < 66)
+    const newThird = numbers.some((n) => n >= 66)
+    expect(oldThird).toBe(true)
+    expect(midThird).toBe(true)
+    expect(newThird).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// compareSlug — happy path + per-side error edges
+// ---------------------------------------------------------------------------
+
+describe("compareSlug", () => {
+  it("returns a clean report when both sides match", async () => {
+    const entry: CorpusEntry = { slug: "happy", locale: "en", updatedAt: null }
+    const fetchers = makeFetchers({
+      corpus: [entry],
+      strapi: new Map([[`happy@en`, makeStrapiInput("happy", "en")]]),
+      admin: new Map([[`happy@en`, makeAdminInput("happy", "en")]]),
+    })
+    const report = await compareSlug(entry, {
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+    })
+    expect(report.error).toBeUndefined()
+    expect(report.structural.count).toBe(0)
+    expect(report.value.count).toBe(0)
+    expect(report.order.count).toBe(0)
+    expect(report.semantic.count).toBe(0)
+  })
+
+  it("records 'admin missing' when admin fetch fails", async () => {
+    const entry: CorpusEntry = { slug: "lost", locale: "en", updatedAt: null }
+    const fetchers = makeFetchers({
+      corpus: [entry],
+      strapi: new Map([[`lost@en`, makeStrapiInput("lost", "en")]]),
+      admin: new Map(),
+      adminErrors: new Map([[`lost@en`, "admin missing"]]),
+    })
+    const report = await compareSlug(entry, {
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+    })
+    expect(report.error).toEqual({
+      side: "admin",
+      message: "Error: admin missing",
+    })
+  })
+
+  it("records 'both' when both sides fail", async () => {
+    const entry: CorpusEntry = { slug: "gone", locale: "en", updatedAt: null }
+    const fetchers = makeFetchers({
+      corpus: [entry],
+      strapi: new Map(),
+      admin: new Map(),
+      strapiErrors: new Map([[`gone@en`, "strapi 500"]]),
+      adminErrors: new Map([[`gone@en`, "admin 500"]]),
+    })
+    const report = await compareSlug(entry, {
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+    })
+    expect(report.error?.side).toBe("both")
+    expect(report.error?.message).toContain("strapi 500")
+    expect(report.error?.message).toContain("admin 500")
+  })
+
+  it("redacts the bearer from any per-fetch error message", async () => {
+    const bearer = "sk-secret-7777"
+    const entry: CorpusEntry = { slug: "leaky", locale: "en", updatedAt: null }
+    const fetchers = makeFetchers({
+      corpus: [entry],
+      strapi: new Map([[`leaky@en`, makeStrapiInput("leaky", "en")]]),
+      admin: new Map(),
+      adminErrors: new Map([
+        [`leaky@en`, `unauthorized — supplied ${bearer} not allowed`],
+      ]),
+    })
+    const report = await compareSlug(entry, {
+      fetchers,
+      bearer,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+    })
+    expect(report.error?.message).not.toContain(bearer)
+    expect(report.error?.message).toContain("[REDACTED]")
+  })
+
+  it("records a value diff when titles differ", async () => {
+    const entry: CorpusEntry = { slug: "diff", locale: "en", updatedAt: null }
+    const fetchers = makeFetchers({
+      corpus: [entry],
+      strapi: new Map([
+        [`diff@en`, makeStrapiInput("diff", "en", { title: "Strapi" })],
+      ]),
+      admin: new Map([
+        [`diff@en`, makeAdminInput("diff", "en", { title: "Admin" })],
+      ]),
+    })
+    const report = await compareSlug(entry, {
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+    })
+    expect(report.value.count).toBe(1)
+    expect(report.value.paths).toContain("/title")
+  })
+
+  it("applies the allow-list — listed diffs land in allowListed bucket, not value", async () => {
+    const entry: CorpusEntry = { slug: "allow", locale: "en", updatedAt: null }
+    const fetchers = makeFetchers({
+      corpus: [entry],
+      strapi: new Map([
+        [`allow@en`, makeStrapiInput("allow", "en", { title: "Strapi" })],
+      ]),
+      admin: new Map([
+        [`allow@en`, makeAdminInput("allow", "en", { title: "Admin" })],
+      ]),
+    })
+    const report = await compareSlug(entry, {
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [
+        {
+          path: "/title",
+          channel: "value",
+          rationale: "test override",
+        },
+      ],
+    })
+    expect(report.value.count).toBe(0)
+    expect(report.allowListed.count).toBe(1)
+    expect(report.allowListed.paths).toContain("/title")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runBatchVerification — orchestration + concurrency + gate logic
+// ---------------------------------------------------------------------------
+
+describe("runBatchVerification", () => {
+  it("PASSED gate when every slug is diff-free", async () => {
+    const corpus: CorpusEntry[] = ["a", "b", "c"].map((slug) => ({
+      slug,
+      locale: "en",
+      updatedAt: null,
+    }))
+    const strapi = new Map(
+      corpus.map((c) => [
+        `${c.slug}@${c.locale}`,
+        makeStrapiInput(c.slug, c.locale),
+      ]),
+    )
+    const admin = new Map(
+      corpus.map((c) => [
+        `${c.slug}@${c.locale}`,
+        makeAdminInput(c.slug, c.locale),
+      ]),
+    )
+    const fetchers = makeFetchers({ corpus, strapi, admin })
+    const report = await runBatchVerification({
+      args: parseArgs([]),
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+      now: () => new Date("2026-05-12T00:00:00Z"),
+    })
+    expect(report.gate).toBe("PASSED")
+    expect(report.totals.slugs).toBe(3)
+  })
+
+  it("FAILED gate when any slug has a non-allow-listed diff", async () => {
+    const corpus: CorpusEntry[] = [
+      { slug: "ok", locale: "en", updatedAt: null },
+      { slug: "drift", locale: "en", updatedAt: null },
+    ]
+    const strapi = new Map([
+      [`ok@en`, makeStrapiInput("ok", "en")],
+      [`drift@en`, makeStrapiInput("drift", "en", { title: "S" })],
+    ])
+    const admin = new Map([
+      [`ok@en`, makeAdminInput("ok", "en")],
+      [`drift@en`, makeAdminInput("drift", "en", { title: "A" })],
+    ])
+    const fetchers = makeFetchers({ corpus, strapi, admin })
+    const report = await runBatchVerification({
+      args: parseArgs([]),
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+      now: () => new Date("2026-05-12T00:00:00Z"),
+    })
+    expect(report.gate).toBe("FAILED")
+    expect(report.totals.withValue).toBe(1)
+  })
+
+  it("FAILED gate when any slug has an error row (even with zero diffs elsewhere)", async () => {
+    const corpus: CorpusEntry[] = [
+      { slug: "good", locale: "en", updatedAt: null },
+      { slug: "lost", locale: "en", updatedAt: null },
+    ]
+    const strapi = new Map([[`good@en`, makeStrapiInput("good", "en")]])
+    const admin = new Map([[`good@en`, makeAdminInput("good", "en")]])
+    const fetchers = makeFetchers({
+      corpus,
+      strapi,
+      admin,
+      strapiErrors: new Map([[`lost@en`, "strapi 500"]]),
+      adminErrors: new Map([[`lost@en`, "admin 500"]]),
+    })
+    const report = await runBatchVerification({
+      args: parseArgs([]),
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+      now: () => new Date("2026-05-12T00:00:00Z"),
+    })
+    expect(report.gate).toBe("FAILED")
+    expect(report.totals.withErrors).toBe(1)
+  })
+
+  it("respects the concurrency cap — never more than N concurrent fetches", async () => {
+    // 8 slugs, concurrency 3. Each fetch holds 20ms before resolving.
+    let inFlight = 0
+    let maxInFlight = 0
+    const corpus: CorpusEntry[] = Array.from({ length: 8 }, (_, i) => ({
+      slug: `s${i}`,
+      locale: "en",
+      updatedAt: null,
+    }))
+    const strapi = new Map(
+      corpus.map((c) => [
+        `${c.slug}@${c.locale}`,
+        makeStrapiInput(c.slug, c.locale),
+      ]),
+    )
+    const admin = new Map(
+      corpus.map((c) => [
+        `${c.slug}@${c.locale}`,
+        makeAdminInput(c.slug, c.locale),
+      ]),
+    )
+
+    // Wrap fetchers to count concurrent in-flight invocations across both sides.
+    // The per-slug worker fetches Strapi THEN admin sequentially, but pLimit
+    // controls how many slug-workers run in parallel. Track at the slug level.
+    let slugInFlight = 0
+    let maxSlugInFlight = 0
+    const baseFetchers = makeFetchers({ corpus, strapi, admin })
+    const wrapped: Fetchers = {
+      enumerateCorpus: baseFetchers.enumerateCorpus,
+      fetchStrapi: async (slug, locale) => {
+        slugInFlight++
+        maxSlugInFlight = Math.max(maxSlugInFlight, slugInFlight)
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise<void>((r) => setTimeout(r, 5))
+        inFlight--
+        return baseFetchers.fetchStrapi(slug, locale)
+      },
+      fetchAdmin: async (slug, locale) => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise<void>((r) => setTimeout(r, 5))
+        inFlight--
+        const out = await baseFetchers.fetchAdmin(slug, locale)
+        slugInFlight--
+        return out
+      },
+    }
+
+    await runBatchVerification({
+      args: parseArgs(["--concurrency", "3"]),
+      fetchers: wrapped,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+      now: () => new Date("2026-05-12T00:00:00Z"),
+    })
+    expect(maxSlugInFlight).toBeLessThanOrEqual(3)
+  })
+
+  it("applies --since filter to corpus", async () => {
+    const corpus: CorpusEntry[] = [
+      { slug: "old", locale: "en", updatedAt: "2025-01-01T00:00:00Z" },
+      { slug: "new", locale: "en", updatedAt: "2026-05-12T12:00:00Z" },
+    ]
+    const strapi = new Map(
+      corpus.map((c) => [
+        `${c.slug}@${c.locale}`,
+        makeStrapiInput(c.slug, c.locale),
+      ]),
+    )
+    const admin = new Map(
+      corpus.map((c) => [
+        `${c.slug}@${c.locale}`,
+        makeAdminInput(c.slug, c.locale),
+      ]),
+    )
+    const fetchers = makeFetchers({ corpus, strapi, admin })
+    const report = await runBatchVerification({
+      args: parseArgs(["--since", "2026-01-01T00:00:00Z"]),
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+      now: () => new Date("2026-05-12T00:00:00Z"),
+    })
+    expect(report.totals.slugs).toBe(1)
+    expect(report.slugs[0].slug).toBe("new")
+  })
+
+  it("does not crash when a slug fetcher throws (Promise.allSettled posture)", async () => {
+    const corpus: CorpusEntry[] = [
+      { slug: "a", locale: "en", updatedAt: null },
+      { slug: "b", locale: "en", updatedAt: null },
+    ]
+    const fetchers: Fetchers = {
+      enumerateCorpus: async () => corpus,
+      fetchStrapi: async (slug, locale) =>
+        slug === "a"
+          ? makeStrapiInput(slug, locale)
+          : Promise.reject(new Error("transient strapi")),
+      fetchAdmin: async (slug, locale) =>
+        slug === "a"
+          ? makeAdminInput(slug, locale)
+          : Promise.reject(new Error("transient admin")),
+    }
+    const report = await runBatchVerification({
+      args: parseArgs([]),
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+      now: () => new Date("2026-05-12T00:00:00Z"),
+    })
+    expect(report.totals.slugs).toBe(2)
+    expect(report.totals.withErrors).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 429 backoff + timeout — postGraphQL retry shape
+// ---------------------------------------------------------------------------
+
+describe("backoffDelayMs", () => {
+  it("grows exponentially and caps at 30000", () => {
+    expect(backoffDelayMs(0)).toBe(500)
+    expect(backoffDelayMs(1)).toBe(1000)
+    expect(backoffDelayMs(2)).toBe(2000)
+    expect(backoffDelayMs(20)).toBe(30000)
+  })
+})
+
+describe("postGraphQL — 429 backoff", () => {
+  it("retries on 429 then succeeds on 200", async () => {
+    let calls = 0
+    const fetchImpl = vi.fn(async () => {
+      calls++
+      if (calls === 1) {
+        return new Response("rate limited", { status: 429 })
+      }
+      return new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+      })
+    }) as unknown as typeof fetch
+
+    const sleep = vi.fn(async () => undefined)
+    const result = await postGraphQL({
+      url: "https://example.test/graphql",
+      query: "{ ok }",
+      bearer: null,
+      fetchImpl,
+      sleep,
+    })
+    expect(result).toEqual({ data: { ok: true } })
+    expect(calls).toBe(2)
+    expect(sleep).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws RateLimitExhaustedError after FETCH_MAX_RETRIES consecutive 429s", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("rate limited", { status: 429 }),
+    ) as unknown as typeof fetch
+    const sleep = vi.fn(async () => undefined)
+    await expect(
+      postGraphQL({
+        url: "https://example.test/graphql",
+        query: "{ ok }",
+        bearer: null,
+        fetchImpl,
+        sleep,
+      }),
+    ).rejects.toBeInstanceOf(RateLimitExhaustedError)
+    // FETCH_MAX_RETRIES total attempts.
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls
+        .length,
+    ).toBe(FETCH_MAX_RETRIES)
+  })
+
+  it("sets Authorization header when bearer is provided", async () => {
+    const fetchImpl = vi.fn(async (_url: unknown, init: unknown) => {
+      const headers = (init as { headers: Record<string, string> }).headers
+      expect(headers.Authorization).toBe("Bearer abc123")
+      return new Response(JSON.stringify({ data: {} }), { status: 200 })
+    }) as unknown as typeof fetch
+    await postGraphQL({
+      url: "https://example.test/graphql",
+      query: "{}",
+      bearer: "abc123",
+      fetchImpl,
+      sleep: async () => undefined,
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not set Authorization header in anonymous mode", async () => {
+    const fetchImpl = vi.fn(async (_url: unknown, init: unknown) => {
+      const headers = (init as { headers: Record<string, string> }).headers
+      expect(headers.Authorization).toBeUndefined()
+      return new Response(JSON.stringify({ data: {} }), { status: 200 })
+    }) as unknown as typeof fetch
+    await postGraphQL({
+      url: "https://example.test/graphql",
+      query: "{}",
+      bearer: null,
+      fetchImpl,
+      sleep: async () => undefined,
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatSummary + buildReport
+// ---------------------------------------------------------------------------
+
+describe("buildReport", () => {
+  it("counts a slug toward exactly the channels with positive count", () => {
+    const slugs: SlugReport[] = [
+      makeSlugReport({ structural: ["/a"] }),
+      makeSlugReport({ value: ["/b"], structural: ["/c"] }),
+    ]
+    const report = buildReport("2026-05-12T00:00:00Z", slugs)
+    expect(report.totals.withStructural).toBe(2)
+    expect(report.totals.withValue).toBe(1)
+    expect(report.gate).toBe("FAILED")
+  })
+
+  it("PASSED only when totals across all channels are zero AND no errors", () => {
+    const slugs: SlugReport[] = [makeSlugReport({})]
+    const report = buildReport("2026-05-12T00:00:00Z", slugs)
+    expect(report.gate).toBe("PASSED")
+  })
+})
+
+describe("formatSummary", () => {
+  it("prints the gate verdict on the last line", () => {
+    const report = buildReport("2026-05-12T00:00:00Z", [makeSlugReport({})])
+    const text = formatSummary(report)
+    expect(text).toMatch(/Gate: PASSED/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// JSON-shape snapshot — locks the downstream contract.
+// ---------------------------------------------------------------------------
+
+describe("report JSON shape — downstream contract", () => {
+  it("matches the locked snapshot", async () => {
+    // Deterministic two-slug fixture: one clean, one with a value diff.
+    const corpus: CorpusEntry[] = [
+      { slug: "clean", locale: "en", updatedAt: "2026-05-01T00:00:00Z" },
+      { slug: "drift", locale: "en", updatedAt: "2026-05-02T00:00:00Z" },
+    ]
+    const strapi = new Map([
+      [`clean@en`, makeStrapiInput("clean", "en")],
+      [`drift@en`, makeStrapiInput("drift", "en", { title: "From Strapi" })],
+    ])
+    const admin = new Map([
+      [`clean@en`, makeAdminInput("clean", "en")],
+      [`drift@en`, makeAdminInput("drift", "en", { title: "From Admin" })],
+    ])
+    const fetchers = makeFetchers({ corpus, strapi, admin })
+    const report = await runBatchVerification({
+      args: parseArgs([]),
+      fetchers,
+      bearer: null,
+      baseOrigin: BASE_ORIGIN,
+      allowList: [],
+      now: () => new Date("2026-05-12T00:00:00Z"),
+    })
+    // Strip timing values from the snapshot — they're nondeterministic
+    // but the shape (the keys themselves) is what's load-bearing.
+    const stripped = stripTimings(report)
+    expect(stripped).toMatchInlineSnapshot(`
+      {
+        "gate": "FAILED",
+        "generatedAt": "2026-05-12T00:00:00.000Z",
+        "slugs": [
+          {
+            "allowListed": {
+              "count": 0,
+              "paths": [],
+            },
+            "locale": "en",
+            "order": {
+              "count": 0,
+              "paths": [],
+            },
+            "semantic": {
+              "count": 0,
+              "paths": [],
+            },
+            "slug": "clean",
+            "structural": {
+              "count": 0,
+              "paths": [],
+            },
+            "timingMs": "REDACTED",
+            "value": {
+              "count": 0,
+              "paths": [],
+            },
+          },
+          {
+            "allowListed": {
+              "count": 0,
+              "paths": [],
+            },
+            "locale": "en",
+            "order": {
+              "count": 0,
+              "paths": [],
+            },
+            "semantic": {
+              "count": 0,
+              "paths": [],
+            },
+            "slug": "drift",
+            "structural": {
+              "count": 0,
+              "paths": [],
+            },
+            "timingMs": "REDACTED",
+            "value": {
+              "count": 1,
+              "paths": [
+                "/title",
+              ],
+            },
+          },
+        ],
+        "totals": {
+          "allowListed": 0,
+          "slugs": 2,
+          "withErrors": 0,
+          "withOrder": 0,
+          "withSemantic": 0,
+          "withStructural": 0,
+          "withValue": 1,
+        },
+      }
+    `)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function makeSlugReport(overrides: {
+  readonly structural?: ReadonlyArray<string>
+  readonly value?: ReadonlyArray<string>
+  readonly order?: ReadonlyArray<string>
+  readonly semantic?: ReadonlyArray<string>
+  readonly allowListed?: ReadonlyArray<string>
+  readonly error?: SlugReport["error"]
+}): SlugReport {
+  return {
+    slug: "test",
+    locale: "en",
+    structural: {
+      count: overrides.structural?.length ?? 0,
+      paths: overrides.structural ?? [],
+    },
+    value: {
+      count: overrides.value?.length ?? 0,
+      paths: overrides.value ?? [],
+    },
+    order: {
+      count: overrides.order?.length ?? 0,
+      paths: overrides.order ?? [],
+    },
+    semantic: {
+      count: overrides.semantic?.length ?? 0,
+      paths: overrides.semantic ?? [],
+    },
+    allowListed: {
+      count: overrides.allowListed?.length ?? 0,
+      paths: overrides.allowListed ?? [],
+    },
+    timingMs: { strapi: 0, admin: 0, compare: 0 },
+    error: overrides.error,
+  }
+}
+
+/**
+ * Strip the per-slug `timingMs` block from a BatchReport for snapshot
+ * purposes — timings are nondeterministic but the surrounding shape is.
+ */
+function stripTimings(report: BatchReport): unknown {
+  return {
+    ...report,
+    slugs: report.slugs.map((s) => {
+      // Sort keys for stable snapshot ordering, drop timings entirely.
+      const out: Record<string, unknown> = {}
+      const keys = Object.keys(s).sort()
+      for (const k of keys) {
+        if (k === "timingMs") {
+          out[k] = "REDACTED"
+          continue
+        }
+        if (k === "error" && s.error === undefined) continue
+        out[k] = (s as unknown as Record<string, unknown>)[k]
+      }
+      return out
+    }),
+  }
+}

--- a/packages/graphql/src/parity/batch-verification.ts
+++ b/packages/graphql/src/parity/batch-verification.ts
@@ -1,0 +1,886 @@
+/**
+ * Batch verification harness — THE cutover gate (plan-003 U8).
+ *
+ * Drives the four-class differ across every published slug from Strapi
+ * and admin in parallel, producing a structured per-slug report. The
+ * harness is the gate operators read before flipping consumer apps from
+ * Strapi to admin: when the report shows zero non-allow-listed diffs
+ * across all four channels, the migration is safe to ship.
+ *
+ * Design split — the CLI shim (`scripts/run-batch-verification.ts`)
+ * provides real GraphQL fetchers and parses argv; the orchestration
+ * loop, gate logic, and JSON-report shape live HERE so they're
+ * typechecked and unit-tested. Mirrors the live.ts / capture-parity-
+ * fixture.ts split — same reason: scripts/ is outside tsconfig's
+ * include glob, but src/ is unit-testable + typechecked.
+ *
+ * Critical invariants:
+ *
+ * - Bounded parallelism via p-limit + Promise.allSettled — never bare
+ *   Promise.all. Per `docs/solutions/best-practices/bounded-parallelism-
+ *   per-target-workflow-pattern-20260505.md`.
+ * - Bearer is auto-read from env (`WEB_ADMIN_API_KEYS`, first CSV
+ *   entry) — NOT a CLI flag. Anonymous mode requires explicit opt-in.
+ *   Running anonymous against admin would consume the `public:${ip}`
+ *   bucket and self-DoS the verification window.
+ * - The bearer never appears in any log, error message, or JSON report
+ *   field. `sanitizeError` strips it from any error string before
+ *   surfacing.
+ * - The report JSON shape is a DOWNSTREAM CONTRACT. Operators automate
+ *   dashboards against this shape. Adding a field is safe; renaming or
+ *   removing one breaks operator tooling. The snapshot test locks it.
+ *
+ * This harness is throwaway scaffolding — it ships with the rest of
+ * parity/ and gets deleted when consumer migration completes. See
+ * `parity/index.ts` deletion checklist.
+ */
+
+import pLimit from "p-limit"
+
+import {
+  DEFAULT_ALLOW_LIST,
+  type AllowListEntry,
+  type AllowListChannel,
+} from "./allow-list"
+import { compareNormalizedRoutes, type DiffReport } from "./compare"
+import {
+  normalizeAdmin,
+  type AdminExperienceLocaleInput,
+} from "./normalize-admin"
+import { normalizeStrapi, type StrapiExperienceInput } from "./normalize-strapi"
+
+// ---------------------------------------------------------------------------
+// Public types — the JSON report shape is a downstream contract.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-channel projection of diff entries by path. Operators dedupe and
+ * pivot on this — keeping `count` alongside `paths` lets dashboards
+ * sum counts without re-scanning `paths`.
+ */
+export type ChannelSummary = {
+  readonly count: number
+  readonly paths: ReadonlyArray<string>
+}
+
+export type SlugTimings = {
+  readonly strapi: number
+  readonly admin: number
+  readonly compare: number
+}
+
+export type SlugErrorSide = "strapi" | "admin" | "compare" | "both"
+
+export type SlugError = {
+  readonly side: SlugErrorSide
+  readonly message: string
+}
+
+/**
+ * Per-slug report entry. This shape is the cutover-gate contract —
+ * locked by the snapshot test. ADDING fields is safe; renaming or
+ * removing breaks operator tooling. Do not change without a coordinated
+ * dashboard update.
+ */
+export type SlugReport = {
+  readonly slug: string
+  readonly locale: string
+  readonly structural: ChannelSummary
+  readonly value: ChannelSummary
+  readonly order: ChannelSummary
+  readonly semantic: ChannelSummary
+  /** Diffs suppressed by the combined allow-list (DEFAULT + operator-supplied). */
+  readonly allowListed: ChannelSummary
+  readonly timingMs: SlugTimings
+  /** Present when fetch or normalization failed on one or both sides. */
+  readonly error?: SlugError
+}
+
+export type BatchReport = {
+  /** ISO timestamp at run start. */
+  readonly generatedAt: string
+  readonly totals: {
+    readonly slugs: number
+    readonly withStructural: number
+    readonly withValue: number
+    readonly withOrder: number
+    readonly withSemantic: number
+    readonly withErrors: number
+    readonly allowListed: number
+  }
+  /** PASSED when remaining non-allow-listed diffs across all channels are zero AND no error rows. */
+  readonly gate: "PASSED" | "FAILED"
+  readonly slugs: ReadonlyArray<SlugReport>
+}
+
+// ---------------------------------------------------------------------------
+// Args + CLI parsing
+// ---------------------------------------------------------------------------
+
+export type BatchArgs = {
+  /** Random-stratified sample size. `null` = full corpus. */
+  readonly sample: number | null
+  /** Parallel fetch ceiling. */
+  readonly concurrency: number
+  /** Report output path. `null` = default `.tmp/batch-verification-${ts}.json`. */
+  readonly out: string | null
+  /** Path to operator-supplied allow-list JSON. `null` = DEFAULT only. */
+  readonly allowList: string | null
+  /** ISO timestamp filter for delta-mode runs. `null` = no filter. */
+  readonly since: string | null
+  /** When true, skip auto-bearer-from-env. Required to bypass hard-fail. */
+  readonly anonymous: boolean
+  /** When set, print help text and exit 0. */
+  readonly help: boolean
+}
+
+export const HELP_TEXT = `\
+run-batch-verification — Strapi/admin parity gate (plan-003 U8)
+
+Runs the four-class differ against every published slug from Strapi and
+admin in parallel, producing a structured per-slug report. PASS gate is
+zero non-allow-listed diffs across all channels AND zero error rows.
+
+USAGE
+  pnpm tsx packages/graphql/scripts/run-batch-verification.ts [flags]
+
+FLAGS
+  --sample <n>          Random-stratified sample (default: full corpus).
+  --concurrency <n>     Parallel fetch ceiling (default: 5).
+  --out <path>          Report output path (default: .tmp/batch-verification-<ts>.json).
+  --allow-list <path>   Operator-supplied additional allow-list JSON.
+  --since <iso>         Delta-mode filter — only slugs updated at or after this ISO timestamp.
+  --anonymous           Opt out of bearer auto-read. Risks self-DoS; use only for
+                        ad-hoc local checks against a non-rate-limited target.
+  --help                Print this help and exit 0.
+
+REQUIRED ENV
+  WEB_ADMIN_API_KEYS    Comma-separated bearer keys (first entry used).
+                        Mandatory unless --anonymous is set.
+                        Hard-fail rationale: anonymous queries consume
+                        admin's \`public:\${ip}\` bucket and would self-DoS
+                        the verification window.
+  STRAPI_GRAPHQL_URL    Strapi GraphQL endpoint URL.
+  ADMIN_GRAPHQL_URL     Admin GraphQL endpoint URL.
+  STRAPI_PUBLIC_ORIGIN  Base origin for URL canonicalization.
+
+EDITORIAL FREEZE COORDINATION
+  Run within the 24-48h editorial freeze window between gate-green and
+  env-flip, OR use \`--since <iso>\` for a delta re-run immediately before
+  env-flip. Editorial-freeze coordination is operator workflow, not code.
+
+EXIT CODES
+  0   Gate PASSED.
+  1   Gate FAILED.
+  2   Misconfiguration (bad args, missing env).
+`
+
+/**
+ * Parse argv (post-`process.argv.slice(2)`). Throws `Error` with a
+ * human-friendly message on unrecognized flag or invalid value.
+ */
+export function parseArgs(argv: ReadonlyArray<string>): BatchArgs {
+  const args: BatchArgs = {
+    sample: null,
+    concurrency: 5,
+    out: null,
+    allowList: null,
+    since: null,
+    anonymous: false,
+    help: false,
+  }
+  // Mutable shadow so we can assign on each flag pass without losing readonly.
+  const mut = args as { -readonly [K in keyof BatchArgs]: BatchArgs[K] }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    switch (arg) {
+      case "--help":
+      case "-h":
+        mut.help = true
+        break
+      case "--anonymous":
+        mut.anonymous = true
+        break
+      case "--sample": {
+        const v = argv[++i]
+        if (v === undefined) throw new Error("--sample requires a value")
+        const n = Number(v)
+        if (!Number.isInteger(n) || n <= 0) {
+          throw new Error(`--sample must be a positive integer, got ${v}`)
+        }
+        mut.sample = n
+        break
+      }
+      case "--concurrency": {
+        const v = argv[++i]
+        if (v === undefined) throw new Error("--concurrency requires a value")
+        const n = Number(v)
+        if (!Number.isInteger(n) || n <= 0) {
+          throw new Error(`--concurrency must be a positive integer, got ${v}`)
+        }
+        mut.concurrency = n
+        break
+      }
+      case "--out": {
+        const v = argv[++i]
+        if (v === undefined) throw new Error("--out requires a path")
+        mut.out = v
+        break
+      }
+      case "--allow-list": {
+        const v = argv[++i]
+        if (v === undefined) throw new Error("--allow-list requires a path")
+        mut.allowList = v
+        break
+      }
+      case "--since": {
+        const v = argv[++i]
+        if (v === undefined)
+          throw new Error("--since requires an ISO timestamp")
+        const t = Date.parse(v)
+        if (Number.isNaN(t)) {
+          throw new Error(`--since requires a valid ISO timestamp, got ${v}`)
+        }
+        mut.since = v
+        break
+      }
+      default:
+        throw new Error(`unrecognized flag: ${arg}`)
+    }
+  }
+  return args
+}
+
+// ---------------------------------------------------------------------------
+// Allow-list combination
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an allow-list JSON file's contents into a typed array. The file
+ * format is a top-level JSON array of `AllowListEntry` objects.
+ * Mismatched shape throws — operators should fix the file, not silently
+ * suppress unrelated diffs.
+ */
+export function parseAllowListFile(raw: string): ReadonlyArray<AllowListEntry> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(
+      `allow-list file is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("allow-list file must contain a top-level JSON array")
+  }
+  const out: AllowListEntry[] = []
+  const validChannels: ReadonlySet<AllowListChannel> = new Set([
+    "structural",
+    "value",
+    "order",
+    "semantic",
+  ])
+  for (let i = 0; i < parsed.length; i++) {
+    const entry = parsed[i] as Record<string, unknown>
+    if (
+      typeof entry?.path !== "string" ||
+      typeof entry?.channel !== "string" ||
+      typeof entry?.rationale !== "string"
+    ) {
+      throw new Error(
+        `allow-list entry [${i}] must have string fields: path, channel, rationale`,
+      )
+    }
+    if (!validChannels.has(entry.channel as AllowListChannel)) {
+      throw new Error(
+        `allow-list entry [${i}] has invalid channel '${entry.channel}'; expected one of: structural, value, order, semantic`,
+      )
+    }
+    if (entry.rationale === "") {
+      throw new Error(
+        `allow-list entry [${i}] has empty rationale — every entry MUST cite a decision doc`,
+      )
+    }
+    out.push({
+      path: entry.path,
+      channel: entry.channel as AllowListChannel,
+      rationale: entry.rationale,
+    })
+  }
+  return out
+}
+
+/**
+ * Combine DEFAULT_ALLOW_LIST with operator-supplied entries. Operator
+ * entries are appended after defaults — both halves are auditable.
+ */
+export function combineAllowLists(
+  operator: ReadonlyArray<AllowListEntry>,
+): ReadonlyArray<AllowListEntry> {
+  return [...DEFAULT_ALLOW_LIST, ...operator]
+}
+
+// ---------------------------------------------------------------------------
+// Sampling
+// ---------------------------------------------------------------------------
+
+/**
+ * Stratified random sample of an enumerated corpus. The corpus is
+ * expected to be pre-sorted by `updatedAt` ascending (oldest first); we
+ * stratify into newest 30 / oldest 30 / middle 40 so the report's
+ * coverage spans editorial recency rather than skewing to the heaviest
+ * bucket.
+ *
+ * When `sample >= corpus.length`, returns the whole corpus unchanged.
+ * `rng` is injectable for deterministic tests.
+ */
+export function stratifiedSample<T>(
+  corpus: ReadonlyArray<T>,
+  sample: number,
+  rng: () => number = Math.random,
+): ReadonlyArray<T> {
+  if (sample >= corpus.length) return corpus
+  if (sample <= 0) return []
+
+  // Edge-case: tiny corpus / tiny sample, fall back to simple shuffle-trim.
+  if (corpus.length < 10 || sample < 10) {
+    const idx = Array.from({ length: corpus.length }, (_, i) => i)
+    shuffleInPlace(idx, rng)
+    return idx.slice(0, sample).map((i) => corpus[i])
+  }
+
+  const newestCount = Math.floor(sample * 0.3)
+  const oldestCount = Math.floor(sample * 0.3)
+  const middleCount = sample - newestCount - oldestCount
+
+  // Corpus is oldest-first. Last N are newest, first N are oldest.
+  const oldestIdx = Array.from(
+    { length: Math.min(corpus.length, sample) },
+    (_, i) => i,
+  )
+  const newestIdx = Array.from(
+    { length: Math.min(corpus.length, sample) },
+    (_, i) => corpus.length - 1 - i,
+  )
+  // Middle band is everything except the head/tail sample windows.
+  const headSize = Math.min(oldestCount * 3, Math.floor(corpus.length / 3))
+  const tailSize = Math.min(newestCount * 3, Math.floor(corpus.length / 3))
+  const middleStart = headSize
+  const middleEnd = corpus.length - tailSize
+  const middleIdx: number[] = []
+  for (let i = middleStart; i < middleEnd; i++) middleIdx.push(i)
+
+  shuffleInPlace(oldestIdx, rng)
+  shuffleInPlace(newestIdx, rng)
+  shuffleInPlace(middleIdx, rng)
+
+  const picked = new Set<number>()
+  for (const list of [oldestIdx, newestIdx, middleIdx]) {
+    // No-op; just to keep TS happy that the loop var is read.
+    void list
+  }
+  for (const i of oldestIdx.slice(0, oldestCount)) picked.add(i)
+  for (const i of newestIdx.slice(0, newestCount)) picked.add(i)
+  for (const i of middleIdx.slice(0, middleCount)) picked.add(i)
+
+  // Top up from anywhere if dedup shrunk us below target.
+  if (picked.size < sample) {
+    const all = Array.from({ length: corpus.length }, (_, i) => i)
+    shuffleInPlace(all, rng)
+    for (const i of all) {
+      if (picked.size >= sample) break
+      picked.add(i)
+    }
+  }
+
+  return Array.from(picked)
+    .slice(0, sample)
+    .map((i) => corpus[i])
+}
+
+function shuffleInPlace<T>(arr: T[], rng: () => number): void {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    const tmp = arr[i]
+    arr[i] = arr[j]
+    arr[j] = tmp
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher interfaces — transport is injected from the CLI shim.
+// ---------------------------------------------------------------------------
+
+export type CorpusEntry = {
+  readonly slug: string
+  readonly locale: string
+  /** ISO timestamp of source-of-truth last update. Used for `--since` filter. */
+  readonly updatedAt: string | null
+}
+
+export type EnumerateCorpus = () => Promise<ReadonlyArray<CorpusEntry>>
+
+export type FetchStrapi = (
+  slug: string,
+  locale: string,
+) => Promise<StrapiExperienceInput>
+
+export type FetchAdmin = (
+  slug: string,
+  locale: string,
+) => Promise<AdminExperienceLocaleInput>
+
+export type Fetchers = {
+  readonly enumerateCorpus: EnumerateCorpus
+  readonly fetchStrapi: FetchStrapi
+  readonly fetchAdmin: FetchAdmin
+}
+
+// ---------------------------------------------------------------------------
+// Sanitization — bearer key must never appear in output.
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip the bearer key (and any obvious bearer-prefixed string) from
+ * an error message. The bearer is the only secret the harness touches;
+ * URLs, slugs, and locales are safe to surface.
+ */
+export function sanitizeError(err: unknown, bearer: string | null): string {
+  let msg: string
+  if (err instanceof Error) msg = `${err.name}: ${err.message}`
+  else msg = String(err)
+  if (bearer && bearer !== "" && msg.includes(bearer)) {
+    msg = msg.split(bearer).join("[REDACTED]")
+  }
+  return msg
+}
+
+// ---------------------------------------------------------------------------
+// Per-slug worker
+// ---------------------------------------------------------------------------
+
+export type RunSlugDeps = {
+  readonly fetchers: Fetchers
+  readonly bearer: string | null
+  readonly baseOrigin: string
+  readonly allowList: ReadonlyArray<AllowListEntry>
+}
+
+/**
+ * Compare one slug. Catches all per-side errors and converts them into
+ * a SlugReport with an `error` field — the orchestrator never sees a
+ * thrown exception from this function (matches Promise.allSettled
+ * usage pattern).
+ */
+export async function compareSlug(
+  entry: CorpusEntry,
+  deps: RunSlugDeps,
+): Promise<SlugReport> {
+  const tStrapiStart = Date.now()
+  let strapiInput: StrapiExperienceInput | null = null
+  let strapiErr: string | null = null
+  try {
+    strapiInput = await deps.fetchers.fetchStrapi(entry.slug, entry.locale)
+  } catch (err) {
+    strapiErr = sanitizeError(err, deps.bearer)
+  }
+  const tStrapiEnd = Date.now()
+
+  const tAdminStart = Date.now()
+  let adminInput: AdminExperienceLocaleInput | null = null
+  let adminErr: string | null = null
+  try {
+    adminInput = await deps.fetchers.fetchAdmin(entry.slug, entry.locale)
+  } catch (err) {
+    adminErr = sanitizeError(err, deps.bearer)
+  }
+  const tAdminEnd = Date.now()
+
+  // Both failed — record "both" so the operator sees the join-failure case.
+  if (strapiErr && adminErr) {
+    return errorReport(
+      entry,
+      "both",
+      `strapi: ${strapiErr} | admin: ${adminErr}`,
+      {
+        strapi: tStrapiEnd - tStrapiStart,
+        admin: tAdminEnd - tAdminStart,
+        compare: 0,
+      },
+    )
+  }
+  if (strapiErr) {
+    return errorReport(entry, "strapi", strapiErr, {
+      strapi: tStrapiEnd - tStrapiStart,
+      admin: tAdminEnd - tAdminStart,
+      compare: 0,
+    })
+  }
+  if (adminErr) {
+    return errorReport(entry, "admin", adminErr, {
+      strapi: tStrapiEnd - tStrapiStart,
+      admin: tAdminEnd - tAdminStart,
+      compare: 0,
+    })
+  }
+
+  // Both sides loaded. Normalize + compare.
+  const tCompareStart = Date.now()
+  let diff: DiffReport
+  try {
+    const strapiNormalized = normalizeStrapi(strapiInput!, {
+      urlLocale: entry.locale,
+      baseOrigin: deps.baseOrigin,
+    })
+    const adminNormalized = normalizeAdmin(adminInput!, {
+      urlLocale: entry.locale,
+      baseOrigin: deps.baseOrigin,
+    })
+    diff = compareNormalizedRoutes(strapiNormalized, adminNormalized, {
+      urlLocale: entry.locale,
+      allowList: deps.allowList,
+    })
+  } catch (err) {
+    const tCompareEnd = Date.now()
+    return errorReport(entry, "compare", sanitizeError(err, deps.bearer), {
+      strapi: tStrapiEnd - tStrapiStart,
+      admin: tAdminEnd - tAdminStart,
+      compare: tCompareEnd - tCompareStart,
+    })
+  }
+  const tCompareEnd = Date.now()
+
+  return {
+    slug: entry.slug,
+    locale: entry.locale,
+    structural: channelSummary(diff.structural.map((d) => d.path)),
+    value: channelSummary(diff.value.map((d) => d.path)),
+    order: channelSummary(diff.order.map((d) => d.path)),
+    semantic: channelSummary(diff.semantic.map((d) => d.path)),
+    allowListed: channelSummary(diff.meta.appliedAllowList.map((d) => d.path)),
+    timingMs: {
+      strapi: tStrapiEnd - tStrapiStart,
+      admin: tAdminEnd - tAdminStart,
+      compare: tCompareEnd - tCompareStart,
+    },
+  }
+}
+
+function errorReport(
+  entry: CorpusEntry,
+  side: SlugErrorSide,
+  message: string,
+  timingMs: SlugTimings,
+): SlugReport {
+  return {
+    slug: entry.slug,
+    locale: entry.locale,
+    structural: { count: 0, paths: [] },
+    value: { count: 0, paths: [] },
+    order: { count: 0, paths: [] },
+    semantic: { count: 0, paths: [] },
+    allowListed: { count: 0, paths: [] },
+    timingMs,
+    error: { side, message },
+  }
+}
+
+function channelSummary(paths: ReadonlyArray<string>): ChannelSummary {
+  return { count: paths.length, paths: Object.freeze([...paths]) }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export type RunBatchOptions = {
+  readonly args: BatchArgs
+  readonly fetchers: Fetchers
+  readonly bearer: string | null
+  readonly baseOrigin: string
+  readonly allowList: ReadonlyArray<AllowListEntry>
+  readonly rng?: () => number
+  /** Injectable clock for deterministic `generatedAt` in tests. */
+  readonly now?: () => Date
+  /** Optional progress callback — called per-slug completion with the result. */
+  readonly onSlugComplete?: (
+    report: SlugReport,
+    index: number,
+    total: number,
+  ) => void
+}
+
+export async function runBatchVerification(
+  opts: RunBatchOptions,
+): Promise<BatchReport> {
+  const generatedAt = (opts.now?.() ?? new Date()).toISOString()
+  const corpus = await opts.fetchers.enumerateCorpus()
+
+  // Apply --since filter if set.
+  const filtered = opts.args.since
+    ? corpus.filter((e) => {
+        if (e.updatedAt === null) return false
+        return Date.parse(e.updatedAt) >= Date.parse(opts.args.since!)
+      })
+    : corpus
+
+  // Apply --sample if set.
+  const targets =
+    opts.args.sample !== null
+      ? stratifiedSample(filtered, opts.args.sample, opts.rng)
+      : filtered
+
+  // Bounded parallelism — never bare Promise.all.
+  const limit = pLimit(opts.args.concurrency)
+  const deps: RunSlugDeps = {
+    fetchers: opts.fetchers,
+    bearer: opts.bearer,
+    baseOrigin: opts.baseOrigin,
+    allowList: opts.allowList,
+  }
+
+  let completed = 0
+  const settled = await Promise.allSettled(
+    targets.map((entry) =>
+      limit(async () => {
+        const report = await compareSlug(entry, deps)
+        completed++
+        opts.onSlugComplete?.(report, completed, targets.length)
+        return report
+      }),
+    ),
+  )
+
+  // compareSlug catches its own errors; a rejection here means a bug
+  // (e.g., onSlugComplete threw). Surface as an error row so the harness
+  // never crashes mid-run.
+  const slugs: SlugReport[] = []
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]
+    if (result.status === "fulfilled") {
+      slugs.push(result.value)
+    } else {
+      const entry = targets[i]
+      slugs.push(
+        errorReport(
+          entry,
+          "compare",
+          sanitizeError(result.reason, opts.bearer),
+          { strapi: 0, admin: 0, compare: 0 },
+        ),
+      )
+    }
+  }
+
+  return buildReport(generatedAt, slugs)
+}
+
+export function buildReport(
+  generatedAt: string,
+  slugs: ReadonlyArray<SlugReport>,
+): BatchReport {
+  let withStructural = 0
+  let withValue = 0
+  let withOrder = 0
+  let withSemantic = 0
+  let withErrors = 0
+  let allowListed = 0
+  for (const s of slugs) {
+    if (s.structural.count > 0) withStructural++
+    if (s.value.count > 0) withValue++
+    if (s.order.count > 0) withOrder++
+    if (s.semantic.count > 0) withSemantic++
+    if (s.error) withErrors++
+    if (s.allowListed.count > 0) allowListed++
+  }
+  const gate: BatchReport["gate"] =
+    withStructural === 0 &&
+    withValue === 0 &&
+    withOrder === 0 &&
+    withSemantic === 0 &&
+    withErrors === 0
+      ? "PASSED"
+      : "FAILED"
+
+  return {
+    generatedAt,
+    totals: {
+      slugs: slugs.length,
+      withStructural,
+      withValue,
+      withOrder,
+      withSemantic,
+      withErrors,
+      allowListed,
+    },
+    gate,
+    slugs: Object.freeze([...slugs]),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stdout summary
+// ---------------------------------------------------------------------------
+
+export function formatSummary(report: BatchReport): string {
+  const t = report.totals
+  const lines = [
+    `Batch verification — ${t.slugs} slugs verified at ${report.generatedAt}`,
+    `  structural: ${t.withStructural} slugs with diffs`,
+    `      value: ${t.withValue} slugs with diffs`,
+    `      order: ${t.withOrder} slugs with diffs`,
+    `   semantic: ${t.withSemantic} slugs with diffs`,
+    `     errors: ${t.withErrors} slugs failed to fetch/compare`,
+    `allow-listed: ${t.allowListed} slugs had diffs suppressed by allow-list`,
+    ``,
+    `Gate: ${report.gate}`,
+  ]
+  return lines.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers (used by the CLI shim) — exposed here so the test suite
+// can verify the 429-backoff + timeout shape against a mocked fetcher
+// rather than reaching the network.
+// ---------------------------------------------------------------------------
+
+export class BearerMissingError extends Error {
+  override readonly name = "BearerMissingError"
+}
+
+export class RateLimitExhaustedError extends Error {
+  override readonly name = "RateLimitExhaustedError"
+}
+
+/**
+ * Read the first CSV entry from `WEB_ADMIN_API_KEYS`. Returns `null`
+ * when the caller has explicitly opted into anonymous mode; throws
+ * `BearerMissingError` when neither is provided (the hard-fail path).
+ *
+ * Rationale for hard-fail: running anonymous against admin would
+ * consume the `public:${ip}` rate-limit bucket and could self-DoS the
+ * verification window. Operators who genuinely want anonymous (against
+ * a non-rate-limited local target) must opt in explicitly.
+ */
+export function readBearerFromEnv(
+  env: NodeJS.ProcessEnv,
+  anonymous: boolean,
+): string | null {
+  if (anonymous) return null
+  const raw = env.WEB_ADMIN_API_KEYS
+  if (!raw || raw.trim() === "") {
+    throw new BearerMissingError(
+      "WEB_ADMIN_API_KEYS is required (or pass --anonymous to opt out). " +
+        "Running anonymous against admin consumes the public:${ip} bucket " +
+        "and may self-DoS the verification window.",
+    )
+  }
+  const first = raw.split(",")[0]?.trim() ?? ""
+  if (first === "") {
+    throw new BearerMissingError(
+      "WEB_ADMIN_API_KEYS is set but its first CSV entry is empty.",
+    )
+  }
+  return first
+}
+
+/**
+ * Compute the next backoff delay for a 429 response. Caps at 30s; the
+ * caller is responsible for tracking retry count and giving up after
+ * 3 attempts (RateLimitExhaustedError).
+ */
+export function backoffDelayMs(attempt: number): number {
+  // Exponential, base 500ms, cap 30000ms.
+  const raw = 500 * Math.pow(2, attempt)
+  return Math.min(raw, 30000)
+}
+
+export const FETCH_TIMEOUT_MS = 3000
+export const FETCH_MAX_RETRIES = 3
+
+/**
+ * Issue a GraphQL POST with the U6 outbound budget (3s) and 429 retry.
+ * Returns the parsed JSON body; throws on non-2xx-after-retries or
+ * timeout. The caller wraps the JSON.parse if it needs typed shape
+ * narrowing.
+ *
+ * `fetchImpl` is injected so tests can drive 429-then-200 sequences
+ * without spinning a real HTTP server.
+ */
+export async function postGraphQL(args: {
+  readonly url: string
+  readonly query: string
+  readonly variables?: Record<string, unknown>
+  readonly bearer: string | null
+  readonly fetchImpl?: typeof fetch
+  readonly sleep?: (ms: number) => Promise<void>
+}): Promise<unknown> {
+  const fetchFn = args.fetchImpl ?? fetch
+  const sleep =
+    args.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  }
+  if (args.bearer) headers["Authorization"] = `Bearer ${args.bearer}`
+  const body = JSON.stringify({
+    query: args.query,
+    variables: args.variables ?? {},
+  })
+
+  for (let attempt = 0; attempt < FETCH_MAX_RETRIES; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    try {
+      const res = await fetchFn(args.url, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller.signal,
+      })
+      clearTimeout(timer)
+      if (res.status === 429) {
+        if (attempt === FETCH_MAX_RETRIES - 1) {
+          throw new RateLimitExhaustedError(
+            `429 from ${redactUrl(args.url)} after ${FETCH_MAX_RETRIES} attempts`,
+          )
+        }
+        await sleep(backoffDelayMs(attempt))
+        continue
+      }
+      if (!res.ok) {
+        const text = await res.text().catch(() => "")
+        throw new Error(
+          `HTTP ${res.status} from ${redactUrl(args.url)}: ${text.slice(0, 200)}`,
+        )
+      }
+      return (await res.json()) as unknown
+    } catch (err) {
+      clearTimeout(timer)
+      // Re-throw rate-limit so the outer caller can classify it.
+      if (err instanceof RateLimitExhaustedError) throw err
+      // On the last attempt, surface the error.
+      if (attempt === FETCH_MAX_RETRIES - 1) throw err
+      // Otherwise, brief backoff and retry (covers transient AbortError /
+      // network blips).
+      await sleep(backoffDelayMs(attempt))
+    }
+  }
+  // Unreachable — the loop either returns or throws.
+  throw new Error("postGraphQL: exhausted retries without returning")
+}
+
+/**
+ * Strip query-string and userinfo from a URL when surfacing in errors —
+ * the URL path is useful diagnostically but credentials and tokens in
+ * query strings must never appear in logs.
+ */
+function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+  } catch {
+    return "[unparseable-url]"
+  }
+}

--- a/packages/graphql/src/parity/batch-verification.ts
+++ b/packages/graphql/src/parity/batch-verification.ts
@@ -413,27 +413,50 @@ export async function compareSlug(
   deps: RunSlugDeps,
 ): Promise<SlugReport> {
   // Parallel Strapi+admin halves the per-slug wall-clock vs sequential.
-  const tStrapiStart = Date.now()
-  const tAdminStart = tStrapiStart
-  const [strapiSettled, adminSettled] = await Promise.allSettled([
-    deps.fetchers.fetchStrapi(entry.slug, entry.locale),
-    deps.fetchers.fetchAdmin(entry.slug, entry.locale),
-  ])
-  const tStrapiEnd = Date.now()
-  const tAdminEnd = tStrapiEnd
+  // Timings captured INSIDE each promise (not at the join boundary) so the
+  // report distinguishes per-side latency. Joining-only timings give
+  // strapi === admin === max(both) and hide which side regressed.
+  type StrapiOutcome =
+    | { kind: "ok"; value: StrapiExperienceInput; durationMs: number }
+    | { kind: "err"; error: unknown; durationMs: number }
+  type AdminOutcome =
+    | { kind: "ok"; value: AdminExperienceLocaleInput; durationMs: number }
+    | { kind: "err"; error: unknown; durationMs: number }
+
+  const strapiP: Promise<StrapiOutcome> = (async () => {
+    const start = Date.now()
+    try {
+      const value = await deps.fetchers.fetchStrapi(entry.slug, entry.locale)
+      return { kind: "ok", value, durationMs: Date.now() - start }
+    } catch (error) {
+      return { kind: "err", error, durationMs: Date.now() - start }
+    }
+  })()
+  const adminP: Promise<AdminOutcome> = (async () => {
+    const start = Date.now()
+    try {
+      const value = await deps.fetchers.fetchAdmin(entry.slug, entry.locale)
+      return { kind: "ok", value, durationMs: Date.now() - start }
+    } catch (error) {
+      return { kind: "err", error, durationMs: Date.now() - start }
+    }
+  })()
+  const [strapiResult, adminResult] = await Promise.all([strapiP, adminP])
 
   const strapiInput: StrapiExperienceInput | null =
-    strapiSettled.status === "fulfilled" ? strapiSettled.value : null
+    strapiResult.kind === "ok" ? strapiResult.value : null
   const strapiErr: string | null =
-    strapiSettled.status === "rejected"
-      ? sanitizeError(strapiSettled.reason, deps.bearer)
+    strapiResult.kind === "err"
+      ? sanitizeError(strapiResult.error, deps.bearer)
       : null
   const adminInput: AdminExperienceLocaleInput | null =
-    adminSettled.status === "fulfilled" ? adminSettled.value : null
+    adminResult.kind === "ok" ? adminResult.value : null
   const adminErr: string | null =
-    adminSettled.status === "rejected"
-      ? sanitizeError(adminSettled.reason, deps.bearer)
+    adminResult.kind === "err"
+      ? sanitizeError(adminResult.error, deps.bearer)
       : null
+  const strapiDurationMs = strapiResult.durationMs
+  const adminDurationMs = adminResult.durationMs
 
   // Both failed — record "both" so the operator sees the join-failure case.
   if (strapiErr && adminErr) {
@@ -442,23 +465,23 @@ export async function compareSlug(
       "both",
       `strapi: ${strapiErr} | admin: ${adminErr}`,
       {
-        strapi: tStrapiEnd - tStrapiStart,
-        admin: tAdminEnd - tAdminStart,
+        strapi: strapiDurationMs,
+        admin: adminDurationMs,
         compare: 0,
       },
     )
   }
   if (strapiErr) {
     return errorReport(entry, "strapi", strapiErr, {
-      strapi: tStrapiEnd - tStrapiStart,
-      admin: tAdminEnd - tAdminStart,
+      strapi: strapiDurationMs,
+      admin: adminDurationMs,
       compare: 0,
     })
   }
   if (adminErr) {
     return errorReport(entry, "admin", adminErr, {
-      strapi: tStrapiEnd - tStrapiStart,
-      admin: tAdminEnd - tAdminStart,
+      strapi: strapiDurationMs,
+      admin: adminDurationMs,
       compare: 0,
     })
   }
@@ -482,8 +505,8 @@ export async function compareSlug(
   } catch (err) {
     const tCompareEnd = Date.now()
     return errorReport(entry, "compare", sanitizeError(err, deps.bearer), {
-      strapi: tStrapiEnd - tStrapiStart,
-      admin: tAdminEnd - tAdminStart,
+      strapi: strapiDurationMs,
+      admin: adminDurationMs,
       compare: tCompareEnd - tCompareStart,
     })
   }
@@ -498,8 +521,8 @@ export async function compareSlug(
     semantic: channelSummary(diff.semantic.map((d) => d.path)),
     allowListed: channelSummary(diff.meta.appliedAllowList.map((d) => d.path)),
     timingMs: {
-      strapi: tStrapiEnd - tStrapiStart,
-      admin: tAdminEnd - tAdminStart,
+      strapi: strapiDurationMs,
+      admin: adminDurationMs,
       compare: tCompareEnd - tCompareStart,
     },
   }

--- a/packages/graphql/src/parity/batch-verification.ts
+++ b/packages/graphql/src/parity/batch-verification.ts
@@ -1,38 +1,24 @@
 /**
- * Batch verification harness — THE cutover gate (plan-003 U8).
+ * Batch verification harness — the cutover gate. Operators read this report
+ * before flipping consumers from Strapi to admin; zero non-allow-listed
+ * diffs across all four channels means the migration is safe to ship.
  *
- * Drives the four-class differ across every published slug from Strapi
- * and admin in parallel, producing a structured per-slug report. The
- * harness is the gate operators read before flipping consumer apps from
- * Strapi to admin: when the report shows zero non-allow-listed diffs
- * across all four channels, the migration is safe to ship.
- *
- * Design split — the CLI shim (`scripts/run-batch-verification.ts`)
- * provides real GraphQL fetchers and parses argv; the orchestration
- * loop, gate logic, and JSON-report shape live HERE so they're
- * typechecked and unit-tested. Mirrors the live.ts / capture-parity-
- * fixture.ts split — same reason: scripts/ is outside tsconfig's
- * include glob, but src/ is unit-testable + typechecked.
+ * The CLI shim (scripts/run-batch-verification.ts) provides fetchers + argv;
+ * orchestration + report shape live here so they're typechecked + testable.
  *
  * Critical invariants:
+ * - Bounded parallelism via p-limit + Promise.allSettled (never bare
+ *   Promise.all). See docs/solutions/best-practices/bounded-parallelism-
+ *   per-target-workflow-pattern-20260505.md.
+ * - SECURITY: bearer is auto-read from env, never a CLI flag. Anonymous
+ *   mode requires explicit opt-in (anonymous-against-admin consumes
+ *   `public:${ip}` and self-DoSes the verification window). The bearer
+ *   never appears in any log; `sanitizeError` strips it before surfacing.
+ * - Report JSON shape is a DOWNSTREAM CONTRACT — operator dashboards
+ *   automate against it. Adding is safe; renaming/removing breaks tooling.
+ *   Snapshot test locks it.
  *
- * - Bounded parallelism via p-limit + Promise.allSettled — never bare
- *   Promise.all. Per `docs/solutions/best-practices/bounded-parallelism-
- *   per-target-workflow-pattern-20260505.md`.
- * - Bearer is auto-read from env (`WEB_ADMIN_API_KEYS`, first CSV
- *   entry) — NOT a CLI flag. Anonymous mode requires explicit opt-in.
- *   Running anonymous against admin would consume the `public:${ip}`
- *   bucket and self-DoS the verification window.
- * - The bearer never appears in any log, error message, or JSON report
- *   field. `sanitizeError` strips it from any error string before
- *   surfacing.
- * - The report JSON shape is a DOWNSTREAM CONTRACT. Operators automate
- *   dashboards against this shape. Adding a field is safe; renaming or
- *   removing one breaks operator tooling. The snapshot test locks it.
- *
- * This harness is throwaway scaffolding — it ships with the rest of
- * parity/ and gets deleted when consumer migration completes. See
- * `parity/index.ts` deletion checklist.
+ * Throwaway; deletes with the rest of parity/. See parity/index.ts checklist.
  */
 
 import pLimit from "p-limit"
@@ -49,15 +35,9 @@ import {
 } from "./normalize-admin"
 import { normalizeStrapi, type StrapiExperienceInput } from "./normalize-strapi"
 
-// ---------------------------------------------------------------------------
 // Public types — the JSON report shape is a downstream contract.
-// ---------------------------------------------------------------------------
 
-/**
- * Per-channel projection of diff entries by path. Operators dedupe and
- * pivot on this — keeping `count` alongside `paths` lets dashboards
- * sum counts without re-scanning `paths`.
- */
+/** `count` alongside `paths` lets dashboards sum without re-scanning paths. */
 export type ChannelSummary = {
   readonly count: number
   readonly paths: ReadonlyArray<string>
@@ -76,12 +56,7 @@ export type SlugError = {
   readonly message: string
 }
 
-/**
- * Per-slug report entry. This shape is the cutover-gate contract —
- * locked by the snapshot test. ADDING fields is safe; renaming or
- * removing breaks operator tooling. Do not change without a coordinated
- * dashboard update.
- */
+/** Cutover-gate contract — snapshot-locked. Add fields freely; never rename/remove. */
 export type SlugReport = {
   readonly slug: string
   readonly locale: string
@@ -113,9 +88,7 @@ export type BatchReport = {
   readonly slugs: ReadonlyArray<SlugReport>
 }
 
-// ---------------------------------------------------------------------------
 // Args + CLI parsing
-// ---------------------------------------------------------------------------
 
 export type BatchArgs = {
   /** Random-stratified sample size. `null` = full corpus. */
@@ -175,10 +148,6 @@ EXIT CODES
   2   Misconfiguration (bad args, missing env).
 `
 
-/**
- * Parse argv (post-`process.argv.slice(2)`). Throws `Error` with a
- * human-friendly message on unrecognized flag or invalid value.
- */
 export function parseArgs(argv: ReadonlyArray<string>): BatchArgs {
   const args: BatchArgs = {
     sample: null,
@@ -189,7 +158,6 @@ export function parseArgs(argv: ReadonlyArray<string>): BatchArgs {
     anonymous: false,
     help: false,
   }
-  // Mutable shadow so we can assign on each flag pass without losing readonly.
   const mut = args as { -readonly [K in keyof BatchArgs]: BatchArgs[K] }
 
   for (let i = 0; i < argv.length; i++) {
@@ -252,16 +220,9 @@ export function parseArgs(argv: ReadonlyArray<string>): BatchArgs {
   return args
 }
 
-// ---------------------------------------------------------------------------
 // Allow-list combination
-// ---------------------------------------------------------------------------
 
-/**
- * Parse an allow-list JSON file's contents into a typed array. The file
- * format is a top-level JSON array of `AllowListEntry` objects.
- * Mismatched shape throws — operators should fix the file, not silently
- * suppress unrelated diffs.
- */
+/** Mismatched shape throws — operators fix the file, not silently suppress unrelated diffs. */
 export function parseAllowListFile(raw: string): ReadonlyArray<AllowListEntry> {
   let parsed: unknown
   try {
@@ -311,29 +272,18 @@ export function parseAllowListFile(raw: string): ReadonlyArray<AllowListEntry> {
   return out
 }
 
-/**
- * Combine DEFAULT_ALLOW_LIST with operator-supplied entries. Operator
- * entries are appended after defaults — both halves are auditable.
- */
 export function combineAllowLists(
   operator: ReadonlyArray<AllowListEntry>,
 ): ReadonlyArray<AllowListEntry> {
   return [...DEFAULT_ALLOW_LIST, ...operator]
 }
 
-// ---------------------------------------------------------------------------
 // Sampling
-// ---------------------------------------------------------------------------
 
 /**
- * Stratified random sample of an enumerated corpus. The corpus is
- * expected to be pre-sorted by `updatedAt` ascending (oldest first); we
- * stratify into newest 30 / oldest 30 / middle 40 so the report's
- * coverage spans editorial recency rather than skewing to the heaviest
- * bucket.
- *
- * When `sample >= corpus.length`, returns the whole corpus unchanged.
- * `rng` is injectable for deterministic tests.
+ * Corpus must be sorted by `updatedAt` ascending. Stratifies newest 30 /
+ * oldest 30 / middle 40 so coverage spans editorial recency rather than
+ * skewing to the heaviest bucket. `rng` is injectable for deterministic tests.
  */
 export function stratifiedSample<T>(
   corpus: ReadonlyArray<T>,
@@ -408,14 +358,11 @@ function shuffleInPlace<T>(arr: T[], rng: () => number): void {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Fetcher interfaces — transport is injected from the CLI shim.
-// ---------------------------------------------------------------------------
 
 export type CorpusEntry = {
   readonly slug: string
   readonly locale: string
-  /** ISO timestamp of source-of-truth last update. Used for `--since` filter. */
   readonly updatedAt: string | null
 }
 
@@ -437,15 +384,8 @@ export type Fetchers = {
   readonly fetchAdmin: FetchAdmin
 }
 
-// ---------------------------------------------------------------------------
-// Sanitization — bearer key must never appear in output.
-// ---------------------------------------------------------------------------
-
-/**
- * Strip the bearer key (and any obvious bearer-prefixed string) from
- * an error message. The bearer is the only secret the harness touches;
- * URLs, slugs, and locales are safe to surface.
- */
+// SECURITY: bearer key must never appear in output.
+// URLs / slugs / locales are safe; the bearer is the only secret here.
 export function sanitizeError(err: unknown, bearer: string | null): string {
   let msg: string
   if (err instanceof Error) msg = `${err.name}: ${err.message}`
@@ -456,9 +396,7 @@ export function sanitizeError(err: unknown, bearer: string | null): string {
   return msg
 }
 
-// ---------------------------------------------------------------------------
 // Per-slug worker
-// ---------------------------------------------------------------------------
 
 export type RunSlugDeps = {
   readonly fetchers: Fetchers
@@ -468,20 +406,13 @@ export type RunSlugDeps = {
 }
 
 /**
- * Compare one slug. Catches all per-side errors and converts them into
- * a SlugReport with an `error` field — the orchestrator never sees a
- * thrown exception from this function (matches Promise.allSettled
- * usage pattern).
+ * Catches per-side errors → SlugReport.error; orchestrator never sees throws.
  */
 export async function compareSlug(
   entry: CorpusEntry,
   deps: RunSlugDeps,
 ): Promise<SlugReport> {
-  // PERF-01: fetch Strapi and admin in parallel via Promise.allSettled.
-  // Sequential `await` doubles the per-slug wall-clock (strapi+admin in
-  // series); parallel is bounded by max(strapi, admin). Across a 1000-slug
-  // corpus this materially shortens the editorial-freeze window the
-  // runbook requires.
+  // Parallel Strapi+admin halves the per-slug wall-clock vs sequential.
   const tStrapiStart = Date.now()
   const tAdminStart = tStrapiStart
   const [strapiSettled, adminSettled] = await Promise.allSettled([
@@ -597,9 +528,7 @@ function channelSummary(paths: ReadonlyArray<string>): ChannelSummary {
   return { count: paths.length, paths: Object.freeze([...paths]) }
 }
 
-// ---------------------------------------------------------------------------
 // Orchestrator
-// ---------------------------------------------------------------------------
 
 export type RunBatchOptions = {
   readonly args: BatchArgs
@@ -624,7 +553,6 @@ export async function runBatchVerification(
   const generatedAt = (opts.now?.() ?? new Date()).toISOString()
   const corpus = await opts.fetchers.enumerateCorpus()
 
-  // Apply --since filter if set.
   const filtered = opts.args.since
     ? corpus.filter((e) => {
         if (e.updatedAt === null) return false
@@ -632,13 +560,11 @@ export async function runBatchVerification(
       })
     : corpus
 
-  // Apply --sample if set.
   const targets =
     opts.args.sample !== null
       ? stratifiedSample(filtered, opts.args.sample, opts.rng)
       : filtered
 
-  // Bounded parallelism — never bare Promise.all.
   const limit = pLimit(opts.args.concurrency)
   const deps: RunSlugDeps = {
     fetchers: opts.fetchers,
@@ -659,9 +585,8 @@ export async function runBatchVerification(
     ),
   )
 
-  // compareSlug catches its own errors; a rejection here means a bug
-  // (e.g., onSlugComplete threw). Surface as an error row so the harness
-  // never crashes mid-run.
+  // A rejection here is a bug (onSlugComplete threw). Surface as an error
+  // row so the harness never crashes mid-run.
   const slugs: SlugReport[] = []
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i]
@@ -726,9 +651,7 @@ export function buildReport(
   }
 }
 
-// ---------------------------------------------------------------------------
 // Stdout summary
-// ---------------------------------------------------------------------------
 
 export function formatSummary(report: BatchReport): string {
   const t = report.totals
@@ -746,11 +669,8 @@ export function formatSummary(report: BatchReport): string {
   return lines.join("\n")
 }
 
-// ---------------------------------------------------------------------------
-// HTTP helpers (used by the CLI shim) — exposed here so the test suite
-// can verify the 429-backoff + timeout shape against a mocked fetcher
-// rather than reaching the network.
-// ---------------------------------------------------------------------------
+// HTTP helpers — exposed so tests can drive 429-backoff + timeout shape
+// against a mocked fetcher without reaching the network.
 
 export class BearerMissingError extends Error {
   override readonly name = "BearerMissingError"
@@ -761,14 +681,9 @@ export class RateLimitExhaustedError extends Error {
 }
 
 /**
- * Read the first CSV entry from `WEB_ADMIN_API_KEYS`. Returns `null`
- * when the caller has explicitly opted into anonymous mode; throws
- * `BearerMissingError` when neither is provided (the hard-fail path).
- *
- * Rationale for hard-fail: running anonymous against admin would
- * consume the `public:${ip}` rate-limit bucket and could self-DoS the
- * verification window. Operators who genuinely want anonymous (against
- * a non-rate-limited local target) must opt in explicitly.
+ * SECURITY: hard-fails when neither `WEB_ADMIN_API_KEYS` nor `--anonymous`
+ * is set. Anonymous against admin would consume `public:${ip}` and self-DoS
+ * the verification window — operators must opt in explicitly.
  */
 export function readBearerFromEnv(
   env: NodeJS.ProcessEnv,
@@ -792,32 +707,18 @@ export function readBearerFromEnv(
   return first
 }
 
-/**
- * Compute the next backoff delay for a 429 response. Caps at 30s; the
- * caller is responsible for tracking retry count and giving up after
- * 3 attempts (RateLimitExhaustedError).
- */
+/** Exponential base-500ms, cap 30s, full-jitter to avoid retry-storm collisions. */
 export function backoffDelayMs(
   attempt: number,
   rng: () => number = Math.random,
 ): number {
-  // Exponential, base 500ms, cap 30000ms. REL-02: full-jitter scaling so
-  // N concurrent workers hitting 429 simultaneously don't all resume at
-  // the same millisecond (which would re-trigger the rate limiter).
-  // `rng` is injectable so tests can assert deterministic delays.
   const raw = 500 * Math.pow(2, attempt)
   const capped = Math.min(raw, 30000)
   return Math.floor(rng() * capped)
 }
 
-/**
- * Discriminator for AbortError / TimeoutError. AbortSignal.timeout() in
- * Node produces `name: "TimeoutError"`; manual abort produces
- * `name: "AbortError"`. Both indicate the request hit the outbound budget
- * and should fast-fail in the harness rather than retry — a persistent
- * admin slowness is not a transient blip and 3× retries × 3s wastes
- * gate-convergence wall time.
- */
+// Fast-fail timeouts/aborts rather than retry — a persistent admin slowness
+// is not a transient blip; 3× retries × 3s wastes gate-convergence time.
 function isTimeoutOrAbortError(err: unknown): boolean {
   if (err == null || typeof err !== "object") return false
   const name = (err as { name?: unknown }).name
@@ -827,15 +728,7 @@ function isTimeoutOrAbortError(err: unknown): boolean {
 export const FETCH_TIMEOUT_MS = 3000
 export const FETCH_MAX_RETRIES = 3
 
-/**
- * Issue a GraphQL POST with the U6 outbound budget (3s) and 429 retry.
- * Returns the parsed JSON body; throws on non-2xx-after-retries or
- * timeout. The caller wraps the JSON.parse if it needs typed shape
- * narrowing.
- *
- * `fetchImpl` is injected so tests can drive 429-then-200 sequences
- * without spinning a real HTTP server.
- */
+/** GraphQL POST with 3s budget + 429 retry. `fetchImpl` is injected for tests. */
 export async function postGraphQL(args: {
   readonly url: string
   readonly query: string
@@ -886,28 +779,18 @@ export async function postGraphQL(args: {
       return (await res.json()) as unknown
     } catch (err) {
       clearTimeout(timer)
-      // Re-throw rate-limit so the outer caller can classify it.
       if (err instanceof RateLimitExhaustedError) throw err
-      // REL-01: fast-fail timeouts/aborts. A persistent admin slowness
-      // surfaces as the same error 3× and consumes 9s + backoff. The
-      // outer caller (compareSlug) records this as a per-slug error
-      // and continues — retries don't recover a hung backend.
+      // Don't retry timeouts/aborts — see isTimeoutOrAbortError above.
       if (isTimeoutOrAbortError(err)) throw err
-      // On the last attempt, surface the error.
       if (attempt === FETCH_MAX_RETRIES - 1) throw err
-      // Otherwise, brief backoff and retry (covers transient network blips).
       await sleep(backoffDelayMs(attempt))
     }
   }
-  // Unreachable — the loop either returns or throws.
   throw new Error("postGraphQL: exhausted retries without returning")
 }
 
-/**
- * Strip query-string and userinfo from a URL when surfacing in errors —
- * the URL path is useful diagnostically but credentials and tokens in
- * query strings must never appear in logs.
- */
+// SECURITY: strip query-string + userinfo before surfacing in errors — path
+// is diagnostic but tokens in query strings must never reach logs.
 function redactUrl(url: string): string {
   try {
     const parsed = new URL(url)

--- a/packages/graphql/src/parity/batch-verification.ts
+++ b/packages/graphql/src/parity/batch-verification.ts
@@ -477,25 +477,32 @@ export async function compareSlug(
   entry: CorpusEntry,
   deps: RunSlugDeps,
 ): Promise<SlugReport> {
+  // PERF-01: fetch Strapi and admin in parallel via Promise.allSettled.
+  // Sequential `await` doubles the per-slug wall-clock (strapi+admin in
+  // series); parallel is bounded by max(strapi, admin). Across a 1000-slug
+  // corpus this materially shortens the editorial-freeze window the
+  // runbook requires.
   const tStrapiStart = Date.now()
-  let strapiInput: StrapiExperienceInput | null = null
-  let strapiErr: string | null = null
-  try {
-    strapiInput = await deps.fetchers.fetchStrapi(entry.slug, entry.locale)
-  } catch (err) {
-    strapiErr = sanitizeError(err, deps.bearer)
-  }
+  const tAdminStart = tStrapiStart
+  const [strapiSettled, adminSettled] = await Promise.allSettled([
+    deps.fetchers.fetchStrapi(entry.slug, entry.locale),
+    deps.fetchers.fetchAdmin(entry.slug, entry.locale),
+  ])
   const tStrapiEnd = Date.now()
+  const tAdminEnd = tStrapiEnd
 
-  const tAdminStart = Date.now()
-  let adminInput: AdminExperienceLocaleInput | null = null
-  let adminErr: string | null = null
-  try {
-    adminInput = await deps.fetchers.fetchAdmin(entry.slug, entry.locale)
-  } catch (err) {
-    adminErr = sanitizeError(err, deps.bearer)
-  }
-  const tAdminEnd = Date.now()
+  const strapiInput: StrapiExperienceInput | null =
+    strapiSettled.status === "fulfilled" ? strapiSettled.value : null
+  const strapiErr: string | null =
+    strapiSettled.status === "rejected"
+      ? sanitizeError(strapiSettled.reason, deps.bearer)
+      : null
+  const adminInput: AdminExperienceLocaleInput | null =
+    adminSettled.status === "fulfilled" ? adminSettled.value : null
+  const adminErr: string | null =
+    adminSettled.status === "rejected"
+      ? sanitizeError(adminSettled.reason, deps.bearer)
+      : null
 
   // Both failed — record "both" so the operator sees the join-failure case.
   if (strapiErr && adminErr) {
@@ -790,10 +797,31 @@ export function readBearerFromEnv(
  * caller is responsible for tracking retry count and giving up after
  * 3 attempts (RateLimitExhaustedError).
  */
-export function backoffDelayMs(attempt: number): number {
-  // Exponential, base 500ms, cap 30000ms.
+export function backoffDelayMs(
+  attempt: number,
+  rng: () => number = Math.random,
+): number {
+  // Exponential, base 500ms, cap 30000ms. REL-02: full-jitter scaling so
+  // N concurrent workers hitting 429 simultaneously don't all resume at
+  // the same millisecond (which would re-trigger the rate limiter).
+  // `rng` is injectable so tests can assert deterministic delays.
   const raw = 500 * Math.pow(2, attempt)
-  return Math.min(raw, 30000)
+  const capped = Math.min(raw, 30000)
+  return Math.floor(rng() * capped)
+}
+
+/**
+ * Discriminator for AbortError / TimeoutError. AbortSignal.timeout() in
+ * Node produces `name: "TimeoutError"`; manual abort produces
+ * `name: "AbortError"`. Both indicate the request hit the outbound budget
+ * and should fast-fail in the harness rather than retry — a persistent
+ * admin slowness is not a transient blip and 3× retries × 3s wastes
+ * gate-convergence wall time.
+ */
+function isTimeoutOrAbortError(err: unknown): boolean {
+  if (err == null || typeof err !== "object") return false
+  const name = (err as { name?: unknown }).name
+  return name === "AbortError" || name === "TimeoutError"
 }
 
 export const FETCH_TIMEOUT_MS = 3000
@@ -860,10 +888,14 @@ export async function postGraphQL(args: {
       clearTimeout(timer)
       // Re-throw rate-limit so the outer caller can classify it.
       if (err instanceof RateLimitExhaustedError) throw err
+      // REL-01: fast-fail timeouts/aborts. A persistent admin slowness
+      // surfaces as the same error 3× and consumes 9s + backoff. The
+      // outer caller (compareSlug) records this as a per-slug error
+      // and continues — retries don't recover a hung backend.
+      if (isTimeoutOrAbortError(err)) throw err
       // On the last attempt, surface the error.
       if (attempt === FETCH_MAX_RETRIES - 1) throw err
-      // Otherwise, brief backoff and retry (covers transient AbortError /
-      // network blips).
+      // Otherwise, brief backoff and retry (covers transient network blips).
       await sleep(backoffDelayMs(attempt))
     }
   }

--- a/packages/graphql/src/parity/normalize-admin.test.ts
+++ b/packages/graphql/src/parity/normalize-admin.test.ts
@@ -1,4 +1,4 @@
-import { BlocksSchema } from "@forge/admin/domain/blocks"
+import { BlocksSchema, type Block } from "@forge/admin/domain/blocks"
 import { describe, expect, it } from "vitest"
 
 import { ADMIN_ONLY_KINDS, STRAPI_TO_ADMIN_KIND } from "./discriminator-map"
@@ -14,9 +14,15 @@ const OPTIONS = {
   baseOrigin: "https://cdn.example.com",
 } as const
 
-function baseInput(
-  overrides: Partial<AdminExperienceLocaleInput> = {},
-): AdminExperienceLocaleInput {
+// Post-PR-A `AdminExperienceLocaleInput.blocks` is `ReadonlyArray<Block>`.
+// Many adversarial fixtures below intentionally violate that contract to
+// exercise the defensive `BlocksSchema.safeParse(...)` branch — they go
+// in via this loose-typed shape so the call site doesn't have to cast.
+type LooseAdminInput = Omit<AdminExperienceLocaleInput, "blocks"> & {
+  readonly blocks: ReadonlyArray<unknown>
+}
+
+function baseInput(overrides: Partial<LooseAdminInput> = {}): LooseAdminInput {
   return {
     id: "exp-loc-1",
     slug: "test-slug",
@@ -24,34 +30,47 @@ function baseInput(
     title: "Test Experience",
     description: "test description",
     ogImageUrl: null,
-    blocks: [],
+    blocks: [] as ReadonlyArray<Block>,
     ...overrides,
   }
+}
+
+// Pass-through helper: casts the loose-typed fixture to the strict
+// `AdminExperienceLocaleInput` shape at the boundary. Production code
+// receives `Block[]` typed by gql.tada off the regenerated admin SDL;
+// test fixtures use the loose union so adversarial cases compile.
+function toInput(input: LooseAdminInput): AdminExperienceLocaleInput {
+  return input as unknown as AdminExperienceLocaleInput
 }
 
 // Minimal valid admin block fixtures — one per shared kind. The shape
 // mirrors what BlocksSchema accepts at write time (`.strict()` rejects
 // unknown keys; admin blocks have NO per-block `id` field — they're
-// JSON nodes inside ExperienceLocale.blocks, not table rows).
+// JSON nodes inside ExperienceLocale.blocks, not table rows). Each
+// fixture matches its `BlockSchema.options[N]` member exactly so the
+// safeParse roundtrip succeeds.
 
-function adminMediaCollection() {
+function adminMediaCollection(): Block {
   return {
     t: "mediaCollection",
     sectionKey: "key-1",
-    variant: "carousel" as const,
-  }
+    variant: "carousel",
+    itemsSource: "manual",
+    showItemNumbers: false,
+    items: [],
+  } as Block
 }
 
-function adminText() {
+function adminText(): Block {
   return {
     t: "text",
     sectionKey: "key-2",
-  }
+  } as Block
 }
 
 describe("normalizeAdmin — happy paths", () => {
   it("returns a NormalizedExperienceRoute with required fields populated", () => {
-    const result = normalizeAdmin(baseInput(), OPTIONS)
+    const result = normalizeAdmin(toInput(baseInput()), OPTIONS)
     expect(result.id).toBe("exp-loc-1")
     expect(result.slug).toBe("test-slug")
     expect(result.locale).toBe("en")
@@ -63,21 +82,21 @@ describe("normalizeAdmin — happy paths", () => {
   })
 
   it("locale field surfaces verbatim on normalized.locale (resolved-locale equality)", () => {
-    const result = normalizeAdmin(baseInput({ locale: "es" }), OPTIONS)
+    const result = normalizeAdmin(toInput(baseInput({ locale: "es" })), OPTIONS)
     expect(result.locale).toBe("es")
   })
 })
 
 describe("normalizeAdmin — error paths", () => {
   it("throws AdminNormalizationError naming missing 'id'", () => {
-    expect(() => normalizeAdmin(baseInput({ id: "" }), OPTIONS)).toThrow(
-      AdminNormalizationError,
-    )
+    expect(() =>
+      normalizeAdmin(toInput(baseInput({ id: "" })), OPTIONS),
+    ).toThrow(AdminNormalizationError)
   })
 
   it("throws AdminNormalizationError naming missing 'slug'", () => {
     try {
-      normalizeAdmin(baseInput({ slug: "" }), OPTIONS)
+      normalizeAdmin(toInput(baseInput({ slug: "" })), OPTIONS)
     } catch (e) {
       expect((e as AdminNormalizationError).missingField).toBe("slug")
       return
@@ -86,10 +105,14 @@ describe("normalizeAdmin — error paths", () => {
   })
 
   it("throws AdminBlocksValidationError on a block with an unknown 't' discriminator", () => {
+    // Adversarial fixture — drifted `t` literal. The loose-typed
+    // LooseAdminInput accepts the shape; the defensive parse rejects
+    // it. This is exactly the scenario `BlocksSchema.safeParse(...)`
+    // exists for after the wire type narrows.
     const input = baseInput({
       blocks: [{ t: "totallyNew" }],
     })
-    expect(() => normalizeAdmin(input, OPTIONS)).toThrow(
+    expect(() => normalizeAdmin(toInput(input), OPTIONS)).toThrow(
       AdminBlocksValidationError,
     )
   })
@@ -101,7 +124,7 @@ describe("normalizeAdmin — error paths", () => {
       blocks: [{ t: "text", extraField: "not-allowed" }],
     })
     try {
-      normalizeAdmin(input, OPTIONS)
+      normalizeAdmin(toInput(input), OPTIONS)
     } catch (e) {
       expect(e).toBeInstanceOf(AdminBlocksValidationError)
       const err = e as AdminBlocksValidationError
@@ -115,13 +138,16 @@ describe("normalizeAdmin — error paths", () => {
 
 describe("normalizeAdmin — absent-field contract", () => {
   it("normalizes description: null to null", () => {
-    const result = normalizeAdmin(baseInput({ description: null }), OPTIONS)
+    const result = normalizeAdmin(
+      toInput(baseInput({ description: null })),
+      OPTIONS,
+    )
     expect(result.description).toBeNull()
   })
 
   it("normalizes description: undefined to null", () => {
     const result = normalizeAdmin(
-      baseInput({ description: undefined }),
+      toInput(baseInput({ description: undefined })),
       OPTIONS,
     )
     expect(result.description).toBeNull()
@@ -136,13 +162,16 @@ describe("normalizeAdmin — absent-field contract", () => {
   })
 
   it("normalizes null ogImageUrl to null on output", () => {
-    const result = normalizeAdmin(baseInput({ ogImageUrl: null }), OPTIONS)
+    const result = normalizeAdmin(
+      toInput(baseInput({ ogImageUrl: null })),
+      OPTIONS,
+    )
     expect(result.ogImage).toBeNull()
   })
 
   it("ogImage shape on present ogImageUrl: width/height/alt are null (admin lossy superset)", () => {
     const result = normalizeAdmin(
-      baseInput({ ogImageUrl: "https://cdn.example.com/og.jpg" }),
+      toInput(baseInput({ ogImageUrl: "https://cdn.example.com/og.jpg" })),
       OPTIONS,
     )
     expect(result.ogImage).toEqual({
@@ -157,7 +186,7 @@ describe("normalizeAdmin — absent-field contract", () => {
 describe("normalizeAdmin — URL canonicalization", () => {
   it("canonicalizes ogImageUrl (trailing slash strip, host lowercase)", () => {
     const result = normalizeAdmin(
-      baseInput({ ogImageUrl: "https://CDN.example.com/og.jpg/" }),
+      toInput(baseInput({ ogImageUrl: "https://CDN.example.com/og.jpg/" })),
       OPTIONS,
     )
     expect(result.ogImage?.url).toBe("https://cdn.example.com/og.jpg")
@@ -169,8 +198,12 @@ describe("normalizeAdmin — URL canonicalization", () => {
 
 describe("normalizeAdmin — block discriminator coverage", () => {
   it("maps admin t: 'mediaCollection' to kind: 'mediaCollection'", () => {
+    // Typed-union shape: matches `BlockSchema.options[N]` for
+    // `mediaCollection` exactly. Required-field set comes from
+    // MediaCollectionBlockSchema (variant, itemsSource, items,
+    // showItemNumbers).
     const result = normalizeAdmin(
-      baseInput({ blocks: [adminMediaCollection()] }),
+      toInput(baseInput({ blocks: [adminMediaCollection()] })),
       OPTIONS,
     )
     expect(result.blocks[0]?.kind).toBe("mediaCollection")
@@ -179,21 +212,23 @@ describe("normalizeAdmin — block discriminator coverage", () => {
   })
 
   it("maps admin t: 'text' to kind: 'text'", () => {
-    const result = normalizeAdmin(baseInput({ blocks: [adminText()] }), OPTIONS)
+    const result = normalizeAdmin(
+      toInput(baseInput({ blocks: [adminText()] })),
+      OPTIONS,
+    )
     expect(result.blocks[0]?.kind).toBe("text")
   })
 
   it("accepts admin-only 'videoRecommendations' kind via BlocksSchema", () => {
+    // VideoRecommendationsBlockSchema's required fields: t, limit.
+    // sectionKey is optional.
+    const block: Block = {
+      t: "videoRecommendations",
+      sectionKey: "key-vr",
+      limit: 6,
+    } as Block
     const result = normalizeAdmin(
-      baseInput({
-        blocks: [
-          {
-            t: "videoRecommendations",
-            sectionKey: "key-vr",
-            limit: 6,
-          },
-        ],
-      }),
+      toInput(baseInput({ blocks: [block] })),
       OPTIONS,
     )
     expect(result.blocks[0]?.kind).toBe("videoRecommendations")

--- a/packages/graphql/src/parity/normalize-admin.ts
+++ b/packages/graphql/src/parity/normalize-admin.ts
@@ -23,7 +23,7 @@
  * because admin exposes it as the generic JSON scalar.
  */
 
-import { BlocksSchema } from "@forge/admin/domain/blocks"
+import { BlocksSchema, type Block } from "@forge/admin/domain/blocks"
 import type { ZodIssue } from "zod"
 
 import { canonicalizeUrl } from "./canonicalize-url"
@@ -57,11 +57,23 @@ export type AdminExperienceLocaleInput = {
   readonly description: string | null | undefined
   readonly ogImageUrl: string | null | undefined
   /**
-   * Admin exposes blocks as the generic `JSON` scalar — typed as
-   * `unknown` here. The normalizer parses via `BlocksSchema` to
-   * recover the discriminated union.
+   * Post PR-A, admin's `ExperienceLocale.blocks` field is the typed
+   * `[ExperienceBlock!]!` union — the GraphQL surface returns a real
+   * discriminated array, not a `JSON` scalar. The lifecycle of this
+   * field is now:
+   *
+   *   1. wire transport: typed by gql.tada via admin's regenerated SDL
+   *   2. normalizer input: `readonly Block[]` (admin's Zod-derived
+   *      domain type)
+   *   3. defensive `BlocksSchema.safeParse(...)` below — belt-and-
+   *      suspenders against runtime drift (rejected blocks, hand-
+   *      edited DB rows, future schema add-without-migration cases).
+   *
+   * The defensive parse is intentionally kept — narrowing the input
+   * type doesn't make the parse unreachable, because parity tests
+   * exercise this branch with adversarial fixtures.
    */
-  readonly blocks: unknown
+  readonly blocks: ReadonlyArray<Block>
 }
 
 export type NormalizeAdminOptions = {
@@ -125,10 +137,12 @@ export function normalizeAdmin(
     )
   }
 
-  // Parse the opaque JSON `blocks` payload via admin's authoritative Zod
-  // schema. Validation failures throw with structured issue context so
-  // the harness reports them as a typed surface, not opaque structural
-  // diff entries.
+  // Defense-in-depth: admin's GraphQL surface returns typed
+  // `[ExperienceBlock!]!` post-PR-A, so `input.blocks` is now Block[]
+  // by construction. The safeParse below remains intentionally — the
+  // parity harness exercises adversarial fixtures (hand-crafted
+  // payloads with drifted `t` literals, extra keys, etc.) that the
+  // wire-type alone can't catch.
   const rawBlocks = input.blocks ?? []
   const parsed = BlocksSchema.safeParse(rawBlocks)
   if (!parsed.success) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,10 +608,10 @@ importers:
         version: 10.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
       jest-expo:
         specifier: ~54.0.0
-        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -757,10 +757,10 @@ importers:
         version: 10.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
       jest-expo:
         specifier: ~54.0.0
-        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
+        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0)
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -879,6 +879,9 @@ importers:
       graphql:
         specifier: 16.13.1
         version: 16.13.1
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
     devDependencies:
       '@forge/admin':
         specifier: workspace:*
@@ -6871,6 +6874,11 @@ packages:
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -17942,7 +17950,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -18021,7 +18029,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3(supports-color@5.5.0)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -24187,13 +24195,15 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
+  acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.15.0
 
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
+
+  acorn@8.15.0: {}
 
   acorn@8.16.0: {}
 
@@ -24616,7 +24626,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.6
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -26226,7 +26236,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -26243,7 +26253,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -26270,7 +26280,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -26292,7 +26302,7 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26461,8 +26471,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
@@ -26675,7 +26685,7 @@ snapshots:
 
   expo-keep-awake@15.0.8(expo@54.0.34)(react@19.1.0):
     dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
 
   expo-linear-gradient@15.0.8(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
@@ -26713,7 +26723,7 @@ snapshots:
   expo-manifests@1.0.11(expo@54.0.34):
     dependencies:
       '@expo/config': 12.0.13
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-json-utils: 0.15.0
     transitivePeerDependencies:
       - supports-color
@@ -26836,7 +26846,7 @@ snapshots:
 
   expo-updates-interface@2.0.0(expo@54.0.34):
     dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-updates@29.0.17(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -28855,21 +28865,21 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0):
+  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/json-file': 10.0.13
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
       jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0))
       json5: 2.2.3
       lodash: 4.18.1
-      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
       react-test-renderer: 19.1.0(react@19.1.0)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -28882,21 +28892,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native-tvos@0.81.5-2)(react@19.1.0):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/json-file': 10.0.13
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.1)(react-native-tvos@0.81.5-2)(react-native-webview@13.15.0(react-native-tvos@0.81.5-2)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
       jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))
       json5: 2.2.3
       lodash: 4.18.1
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native: react-native-tvos@0.81.5-2(@babel/core@7.29.0)(@types/react@19.1.17)(react-native-tvos@0.81.5-2)(react@19.1.0)
       react-test-renderer: 19.1.0(react@19.1.0)
       server-only: 0.0.1
       stacktrace-js: 2.0.2


### PR DESCRIPTION
PR-B of the web slug-page cutover from Strapi to admin (plan-003). Stacked on top of #932 (PR-A) and targets the \`feat/admin-consumer-migration\` integration branch.

**Opened as DRAFT until PR-A (#932) merges into the integration branch.** Then this branch gets rebased (which drops PR-A's commits from this PR's diff, leaving only U4-U9's ~5.3K LOC) and marked ready-for-review.

## What this ships

**U4 — ContentApiMode collapse + regression snapshot** (\`apps/web/src/env.ts\`, \`apps/web/src/lib/content-api-mode.ts\`, regression test). \`ContentApiMode\` collapses to \`\"strapi\" | \"admin\"\`. Legacy values (\`dual-read\`, \`admin-with-fallback\`) soft-fallback to strapi with a distinct warn. Adds \`WEB_ADMIN_API_KEYS\` env (optional, CSV). First commit is the regression snapshot test that locks strapi-mode behavior byte-identical across U4-U9.

**U5 — admin-shape fragments + dispatch + parity infra** (20 new files under \`packages/graphql/src/fragments/admin/\`, ~740 LOC). Root \`WatchExperience\` fragment + 17 per-block-kind fragments + 2 nested-union fragments. Renderer dispatch in \`apps/web/src/components/sections/index.tsx\` adds 17 admin-typename cases alongside Strapi (additive — keeps every commit shippable). Parity normalizer narrows blocks type from \`unknown\` to \`ReadonlyArray<Block>\`. Parity-bridge mode guard kills canary emission post-cutover.

**U6 — fetchSlugExperience cutover + bearer-aware admin client + cache re-throw** (\`apps/web/src/lib/admin-client.ts\`, \`apps/web/src/lib/content.ts\`). Bearer auto-read at module scope from \`WEB_ADMIN_API_KEYS\`. \`WatchPageAdminError\` class with NOT_FOUND/UNAVAILABLE codes. \`unstable_cache\` re-throw inside catch block (prior plan flagged P0 if missing). Runtime safety net for bearer-missing case (logs \`forge.parity.consumer_bearer_missing\` + serves strapi for that request).

**UB7 — \`[slug]/error.tsx\` Client Component** (mode-aware). Catches only \`WatchPageAdminError\`. NOT_FOUND → \`<ExperienceEmpty>\`; UNAVAILABLE → \`<ExperienceError>\` + reset button. Information-disclosure invariant: \`error.message\` NEVER renders.

**U8 — batch verification harness** (\`packages/graphql/scripts/run-batch-verification.ts\` + \`packages/graphql/src/parity/batch-verification.ts\` ~1.8K LOC + 992 LOC of tests). The cutover gate. Stratified-sample-first (100 slugs), concurrency cap 5, 429 backoff, JSON report. Bearer auto-read from env (hard-fails without \`--anonymous\` opt-out — self-DoS guard). Locked JSON report shape via inline snapshot.

**U9 — cutover runbook + route-disable feature flag** (\`docs/admin-core-migration/cutover-runbook.md\` 315 lines + \`FORGE_DISABLE_WATCH_ROUTES\` env + \`<MaintenanceFallback>\`). Pre-cutover checklist, 4-layer rollback (route-disable → mode-flip → code-revert → admin-SDL-revert), MTTR procedure with user-impact metrics, planned + emergency bearer rotation procedures, unbounded-cycles contingency.

## Pre-merge gates

1. **PR-A (#932) merges first** into the integration branch.
2. **Rebase this branch** onto the now-updated integration branch.
3. **Mark ready-for-review.**
4. **MTTR numbers measured** and written into \`docs/admin-core-migration/cutover-runbook.md\` (replaces the \`TODO\` placeholders + flips runbook header from \`draft until measured\` to a dated value).

## Verification

- \`pnpm --filter @forge/web typecheck\`: clean
- \`pnpm --filter @forge/web test\`: 34 files, 367 tests + 3 todo, 0 fails
- \`pnpm --filter @forge/graphql typecheck\`: clean
- \`pnpm --filter @forge/graphql test\`: 162 tests (49 new for U8), 0 fails

## Cutover is NOT automatic

Merging this PR does NOT change user behavior. \`FORGE_CONTENT_API\` stays at \`strapi\` by default. The cutover is a separate operator action (flip the env var to \`admin\` on forge-web Doppler) gated on the batch verification report being green. Full procedure in the runbook.

## Open Questions (carry forward)

- MTTR pre-merge gate authority (whether the runbook-MTTR fill must block merge).
- Homepage scope decision authority (\`watchSetting\` migration is out-of-scope for this plan; needs separate confirmation).

Plan: \`docs/plans/2026-05-11-003-feat-web-admin-direct-cutover-plan.md\` (committed in PR-A)