### PR TITLE
fix(admin): require approval for new OAuth users

### DIFF
--- a/apps/admin/src/app/api/auth/callback/route.test.ts
+++ b/apps/admin/src/app/api/auth/callback/route.test.ts
@@ -8,6 +8,7 @@ const verifyAdminIdToken = vi.fn()
 const userFindUnique = vi.fn()
 const userUpdate = vi.fn()
 const userUpsert = vi.fn()
+const userCreate = vi.fn()
 
 vi.mock("next/headers", () => ({
   cookies: vi.fn(async () => ({
@@ -34,6 +35,7 @@ vi.mock("@/db/client", () => ({
       findUnique: (...args: unknown[]) => userFindUnique(...args),
       update: (...args: unknown[]) => userUpdate(...args),
       upsert: (...args: unknown[]) => userUpsert(...args),
+      create: (...args: unknown[]) => userCreate(...args),
     },
   },
 }))
@@ -49,6 +51,7 @@ describe("admin OAuth callback route", () => {
     userFindUnique.mockReset()
     userUpdate.mockReset()
     userUpsert.mockReset()
+    userCreate.mockReset()
   })
 
   it("rejects callbacks with invalid state", async () => {
@@ -78,7 +81,7 @@ describe("admin OAuth callback route", () => {
     )
   })
 
-  it("exchanges the code and creates an admin-local session", async () => {
+  it("offers access request actions for a first-time OAuth user without creating a row", async () => {
     cookieGet.mockImplementation((name: string) => {
       const values: Record<string, string> = {
         forge_admin_oauth_state: "state_123",
@@ -91,16 +94,15 @@ describe("admin OAuth callback route", () => {
     exchangeAdminAuthorizationCode.mockResolvedValueOnce({
       access_token: "access",
       id_token: "id",
-      scope: "openid admin:access admin:content:write",
+      scope: "openid admin:access",
     })
     verifyAdminIdToken.mockResolvedValueOnce({
       subject: "user_123",
       email: "user@example.com",
       name: "Test User",
-      scopes: ["openid", "admin:access", "admin:content:write"],
+      scopes: ["openid", "admin:access"],
     })
-    userFindUnique.mockResolvedValueOnce(null)
-    userUpsert.mockResolvedValueOnce({ id: "user_123", role: "EDITOR" })
+    userFindUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
 
     const { GET } = await import("./route")
     const response = await GET(
@@ -110,7 +112,7 @@ describe("admin OAuth callback route", () => {
     )
 
     expect(response.headers.get("location")).toBe(
-      "http://localhost:3003/dashboard",
+      "http://localhost:3003/login?error=forbidden&request=available",
     )
     expect(exchangeAdminAuthorizationCode).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -118,13 +120,12 @@ describe("admin OAuth callback route", () => {
         codeVerifier: "verifier_123",
       }),
     )
-    expect(userUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "user_123" },
-        create: expect.objectContaining({ role: "EDITOR" }),
-      }),
-    )
+    expect(userUpsert).not.toHaveBeenCalled()
+    expect(userCreate).not.toHaveBeenCalled()
     expect(response.headers.get("set-cookie")).toContain(
+      "forge_admin_oauth_access_request=",
+    )
+    expect(response.headers.get("set-cookie")).not.toContain(
       "forge_admin_oauth_session=",
     )
   })
@@ -141,13 +142,13 @@ describe("admin OAuth callback route", () => {
     })
     exchangeAdminAuthorizationCode.mockResolvedValueOnce({
       access_token: "access",
-      scope: "openid admin:access admin:content:write",
+      scope: "openid admin:access",
     })
     verifyAdminIdToken.mockResolvedValueOnce({
       subject: "auth_user_123",
       email: "admin@example.com",
       name: "Admin User",
-      scopes: ["openid", "admin:access", "admin:content:write"],
+      scopes: ["openid", "admin:access"],
     })
     userFindUnique.mockResolvedValueOnce({
       id: "existing_admin_user",
@@ -172,7 +173,110 @@ describe("admin OAuth callback route", () => {
     expect(userUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: "existing_admin_user" },
-        data: expect.objectContaining({ role: "ADMIN" }),
+        data: expect.not.objectContaining({ role: expect.any(String) }),
+      }),
+    )
+  })
+
+  it("offers access request actions for existing viewer users", async () => {
+    cookieGet.mockImplementation((name: string) => {
+      const values: Record<string, string> = {
+        forge_admin_oauth_state: "state_123",
+        forge_admin_oauth_verifier: "verifier_123",
+        forge_admin_oauth_callback: "/dashboard",
+      }
+
+      return values[name] ? { value: values[name] } : undefined
+    })
+    exchangeAdminAuthorizationCode.mockResolvedValueOnce({
+      access_token: "access",
+      scope: "openid admin:access",
+    })
+    verifyAdminIdToken.mockResolvedValueOnce({
+      subject: "viewer_user_123",
+      email: "viewer@example.com",
+      name: "Viewer User",
+      scopes: ["openid", "admin:access"],
+    })
+    userFindUnique.mockResolvedValueOnce({
+      id: "viewer_user_123",
+      role: "VIEWER",
+    })
+    userUpdate.mockResolvedValueOnce({
+      id: "viewer_user_123",
+      role: "VIEWER",
+    })
+
+    const { GET } = await import("./route")
+    const response = await GET(
+      new Request(
+        "http://localhost:3003/api/auth/callback?code=code_123&state=state_123",
+      ),
+    )
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3003/login?error=forbidden&request=available",
+    )
+    expect(userUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "viewer_user_123" },
+        data: expect.not.objectContaining({ role: expect.any(String) }),
+      }),
+    )
+    expect(userCreate).not.toHaveBeenCalled()
+    expect(userUpsert).not.toHaveBeenCalled()
+    expect(response.headers.get("set-cookie")).toContain(
+      "forge_admin_oauth_access_request=",
+    )
+    expect(response.headers.get("set-cookie")).not.toContain(
+      "forge_admin_oauth_session=",
+    )
+  })
+
+  it("preserves an existing subject-only user's stored role", async () => {
+    cookieGet.mockImplementation((name: string) => {
+      const values: Record<string, string> = {
+        forge_admin_oauth_state: "state_123",
+        forge_admin_oauth_verifier: "verifier_123",
+        forge_admin_oauth_callback: "/dashboard",
+      }
+
+      return values[name] ? { value: values[name] } : undefined
+    })
+    exchangeAdminAuthorizationCode.mockResolvedValueOnce({
+      access_token: "access",
+      scope: "openid admin:access",
+    })
+    verifyAdminIdToken.mockResolvedValueOnce({
+      subject: "auth_subject_123",
+      name: undefined,
+      scopes: ["openid", "admin:access"],
+    })
+    userFindUnique.mockResolvedValueOnce({
+      id: "auth_subject_123",
+      role: "ADMIN",
+    })
+    userUpdate.mockResolvedValueOnce({
+      id: "auth_subject_123",
+      role: "ADMIN",
+    })
+
+    const { GET } = await import("./route")
+    const response = await GET(
+      new Request(
+        "http://localhost:3003/api/auth/callback?code=code_123&state=state_123",
+      ),
+    )
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3003/dashboard",
+    )
+    expect(userCreate).not.toHaveBeenCalled()
+    expect(userUpsert).not.toHaveBeenCalled()
+    expect(userUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "auth_subject_123" },
+        data: expect.not.objectContaining({ role: expect.any(String) }),
       }),
     )
   })

--- a/apps/admin/src/app/api/auth/callback/route.ts
+++ b/apps/admin/src/app/api/auth/callback/route.ts
@@ -2,11 +2,14 @@ import { cookies } from "next/headers"
 import { NextResponse } from "next/server"
 
 import {
+  ADMIN_OAUTH_ACCESS_REQUEST_COOKIE,
   ADMIN_OAUTH_CALLBACK_COOKIE,
   ADMIN_OAUTH_SESSION_COOKIE,
   ADMIN_OAUTH_STATE_COOKIE,
   ADMIN_OAUTH_VERIFIER_COOKIE,
+  adminOAuthAccessRequestCookieOptions,
   adminOAuthCookieOptions,
+  createAdminOAuthAccessRequestCookie,
   createAdminOAuthSessionCookie,
 } from "@/auth/auth-session"
 import {
@@ -66,8 +69,15 @@ export async function GET(request: Request) {
       subject: verifiedToken.subject,
       email: verifiedToken.email,
       name: verifiedToken.name,
-      role: roleFromScopes(verifiedToken.scopes),
     })
+
+    if (!user || user.role === "VIEWER") {
+      return await redirectToForbiddenLogin(config, {
+        subject: verifiedToken.subject,
+        email: verifiedToken.email,
+        name: verifiedToken.name,
+      })
+    }
 
     const response = NextResponse.redirect(new URL(callbackUrl, request.url))
     response.cookies.set(
@@ -86,30 +96,38 @@ export async function GET(request: Request) {
       message: error instanceof Error ? error.message : "unknown",
     })
 
-    return redirectToForbiddenLogin(config)
+    return await redirectToForbiddenLogin(config)
   }
 }
 
-function redirectToForbiddenLogin(
+async function redirectToForbiddenLogin(
   config: NonNullable<ReturnType<typeof getAdminOAuthConfig>>,
+  accessRequest?: { subject: string; email?: string; name?: string },
 ) {
-  return NextResponse.redirect(
-    new URL("/login?error=forbidden", config.adminBaseUrl),
-  )
+  const url = new URL("/login", config.adminBaseUrl)
+  url.searchParams.set("error", "forbidden")
+  if (accessRequest) {
+    url.searchParams.set("request", "available")
+  }
+  const response = NextResponse.redirect(url)
+  if (accessRequest) {
+    response.cookies.set(
+      ADMIN_OAUTH_ACCESS_REQUEST_COOKIE,
+      await createAdminOAuthAccessRequestCookie(accessRequest),
+      adminOAuthAccessRequestCookieOptions(),
+    )
+  }
+  return response
 }
-
-type AdminUserRole = "ADMIN" | "EDITOR" | "VIEWER"
 
 async function resolveAdminUser({
   subject,
   email,
   name,
-  role,
 }: {
   subject: string
   email?: string
   name?: string
-  role: AdminUserRole
 }) {
   const resolvedEmail = email ?? `${subject}@auth.local`
   const resolvedName = name ?? email ?? "Auth user"
@@ -126,42 +144,28 @@ async function resolveAdminUser({
         data: {
           name: resolvedName,
           emailVerified: true,
-          role: highestRole(existingUser.role, role),
         },
         select: { id: true, role: true },
       })
     }
   }
 
-  return prisma.user.upsert({
+  const existingUser = await prisma.user.findUnique({
     where: { id: subject },
-    update: {
-      email: resolvedEmail,
-      name: resolvedName,
-      role,
-    },
-    create: {
-      id: subject,
-      email: resolvedEmail,
-      name: resolvedName,
-      emailVerified: true,
-      role,
-    },
     select: { id: true, role: true },
   })
-}
 
-function roleFromScopes(scopes: string[]): AdminUserRole {
-  if (scopes.includes("admin:content:write")) return "EDITOR"
-  return "VIEWER"
-}
-
-function highestRole(current: AdminUserRole, incoming: AdminUserRole) {
-  const rank: Record<AdminUserRole, number> = {
-    VIEWER: 1,
-    EDITOR: 2,
-    ADMIN: 3,
+  if (existingUser) {
+    return prisma.user.update({
+      where: { id: existingUser.id },
+      data: {
+        email: resolvedEmail,
+        name: resolvedName,
+        emailVerified: Boolean(email),
+      },
+      select: { id: true, role: true },
+    })
   }
 
-  return rank[current] >= rank[incoming] ? current : incoming
+  return null
 }

--- a/apps/admin/src/app/api/auth/request-access/route.test.ts
+++ b/apps/admin/src/app/api/auth/request-access/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const cookieGet = vi.fn()
+const cookieDelete = vi.fn()
+const readAdminOAuthAccessRequestCookie = vi.fn()
+const userFindUnique = vi.fn()
+const userUpdate = vi.fn()
+const userCreate = vi.fn()
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: cookieGet,
+    delete: cookieDelete,
+  })),
+}))
+
+vi.mock("@/auth/auth-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/auth/auth-session")>()
+  return {
+    ...actual,
+    readAdminOAuthAccessRequestCookie: (...args: unknown[]) =>
+      readAdminOAuthAccessRequestCookie(...args),
+  }
+})
+
+vi.mock("@/db/client", () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => userFindUnique(...args),
+      update: (...args: unknown[]) => userUpdate(...args),
+      create: (...args: unknown[]) => userCreate(...args),
+    },
+  },
+}))
+
+describe("admin OAuth access request route", () => {
+  beforeEach(() => {
+    cookieGet.mockReset()
+    cookieDelete.mockReset()
+    readAdminOAuthAccessRequestCookie.mockReset()
+    userFindUnique.mockReset()
+    userUpdate.mockReset()
+    userCreate.mockReset()
+  })
+
+  it("creates a pending viewer row from the signed request cookie", async () => {
+    cookieGet.mockReturnValue({ value: "signed" })
+    readAdminOAuthAccessRequestCookie.mockResolvedValueOnce({
+      subject: "subject_123",
+      email: "user@example.com",
+      name: "Test User",
+    })
+    userFindUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+    userCreate.mockResolvedValueOnce({ id: "subject_123" })
+
+    const { POST } = await import("./route")
+    const response = await POST()
+
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(response.status).toBe(202)
+    expect(userCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          id: "subject_123",
+          email: "user@example.com",
+          role: "VIEWER",
+        }),
+      }),
+    )
+  })
+
+  it("rejects missing request cookies", async () => {
+    cookieGet.mockReturnValue(undefined)
+    readAdminOAuthAccessRequestCookie.mockResolvedValueOnce(null)
+
+    const { POST } = await import("./route")
+    const response = await POST()
+
+    expect(response.status).toBe(400)
+    expect(userCreate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/src/app/api/auth/request-access/route.ts
+++ b/apps/admin/src/app/api/auth/request-access/route.ts
@@ -1,0 +1,66 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+import {
+  ADMIN_OAUTH_ACCESS_REQUEST_COOKIE,
+  adminOAuthAccessRequestCookieOptions,
+  readAdminOAuthAccessRequestCookie,
+} from "@/auth/auth-session"
+import { prisma } from "@/db/client"
+
+export async function POST(): Promise<Response> {
+  const cookieStore = await cookies()
+  const request = await readAdminOAuthAccessRequestCookie(
+    cookieStore.get(ADMIN_OAUTH_ACCESS_REQUEST_COOKIE)?.value,
+  )
+
+  if (!request) {
+    return Response.json(
+      { error: "No access request available." },
+      { status: 400 },
+    )
+  }
+
+  const email = request.email ?? `${request.subject}@auth.local`
+  const name = request.name ?? request.email ?? "Auth user"
+  const existingByEmail = request.email
+    ? await prisma.user.findUnique({
+        where: { email: request.email },
+        select: { id: true, role: true },
+      })
+    : null
+  const existingBySubject = await prisma.user.findUnique({
+    where: { id: request.subject },
+    select: { id: true, role: true },
+  })
+  const existing = existingByEmail ?? existingBySubject
+
+  if (existing) {
+    await prisma.user.update({
+      where: { id: existing.id },
+      data: {
+        email,
+        name,
+        emailVerified: Boolean(request.email),
+      },
+      select: { id: true },
+    })
+  } else {
+    await prisma.user.create({
+      data: {
+        id: request.subject,
+        email,
+        name,
+        emailVerified: Boolean(request.email),
+        role: "VIEWER",
+      },
+      select: { id: true },
+    })
+  }
+
+  const response = NextResponse.json({ ok: true }, { status: 202 })
+  response.cookies.delete({
+    name: ADMIN_OAUTH_ACCESS_REQUEST_COOKIE,
+    ...adminOAuthAccessRequestCookieOptions(),
+  })
+  return response
+}

--- a/apps/admin/src/app/dashboard/ops-data.ts
+++ b/apps/admin/src/app/dashboard/ops-data.ts
@@ -1454,9 +1454,9 @@ export async function loadUsersData(): Promise<UsersData> {
         footer: "CONTENT_OPERATORS",
       },
       {
-        label: "Viewers",
+        label: "Access Requests",
         value: counts.viewers.toString(),
-        footer: "READ_ONLY",
+        footer: "PENDING_APPROVAL",
       },
     ],
     rows: rows.map((row) => ({
@@ -1466,7 +1466,8 @@ export async function loadUsersData(): Promise<UsersData> {
         row.accounts.map((account) => account.providerId).join(", ") ||
         "email-password",
       statusLabel: row.emailVerified ? row.role : "UNVERIFIED",
-      statusTone: row.emailVerified ? "success" : "warning",
+      statusTone:
+        !row.emailVerified || row.role === "VIEWER" ? "warning" : "success",
       meta: `${row.sessions.length} session(s) / ${formatDateTime(row.updatedAt)}`,
     })),
     insights: [

--- a/apps/admin/src/app/dashboard/users/page.tsx
+++ b/apps/admin/src/app/dashboard/users/page.tsx
@@ -1,4 +1,5 @@
 import { Shield } from "lucide-react"
+import { revalidatePath } from "next/cache"
 import {
   DashboardPageHeader,
   DataTable,
@@ -7,8 +8,28 @@ import {
   PageSection,
 } from "@/components/admin-ui"
 import { requireAdminSession } from "@/auth/session"
+import { prisma } from "@/db/client"
 import { getAdminMessages } from "@/i18n/server"
 import { loadUsersData } from "@/app/dashboard/ops-data"
+
+async function approveUser(formData: FormData) {
+  "use server"
+
+  await requireAdminSession()
+  const id = formData.get("id")
+  const role = formData.get("role")
+
+  if (typeof id !== "string" || (role !== "EDITOR" && role !== "ADMIN")) {
+    return
+  }
+
+  await prisma.user.update({
+    where: { id },
+    data: { role },
+    select: { id: true },
+  })
+  revalidatePath("/dashboard/users")
+}
 
 export default async function UsersPage() {
   await requireAdminSession()
@@ -51,16 +72,41 @@ export default async function UsersPage() {
                     {row.detail}
                   </div>
                 </div>,
-                <span
-                  key={`${row.key}-status`}
-                  className={`status-pill ${
-                    row.statusTone === "success"
-                      ? "text-[var(--color-success)] border-[var(--color-success-border)]"
-                      : "text-[var(--color-warning)] border-[var(--color-warning-border)]"
-                  }`}
-                >
-                  {row.statusLabel}
-                </span>,
+                <div key={`${row.key}-status`} className="flex flex-wrap gap-2">
+                  <span
+                    className={`status-pill ${
+                      row.statusTone === "success"
+                        ? "text-[var(--color-success)] border-[var(--color-success-border)]"
+                        : "text-[var(--color-warning)] border-[var(--color-warning-border)]"
+                    }`}
+                  >
+                    {row.statusLabel}
+                  </span>
+                  {row.statusLabel === "VIEWER" ? (
+                    <>
+                      <form action={approveUser}>
+                        <input type="hidden" name="id" value={row.key} />
+                        <input type="hidden" name="role" value="EDITOR" />
+                        <button
+                          type="submit"
+                          className="status-pill border-[var(--color-success-border)] text-[var(--color-success)]"
+                        >
+                          Approve Editor
+                        </button>
+                      </form>
+                      <form action={approveUser}>
+                        <input type="hidden" name="id" value={row.key} />
+                        <input type="hidden" name="role" value="ADMIN" />
+                        <button
+                          type="submit"
+                          className="status-pill border-[var(--color-warning-border)] text-[var(--color-warning)]"
+                        >
+                          Approve Admin
+                        </button>
+                      </form>
+                    </>
+                  ) : null}
+                </div>,
                 <span
                   key={`${row.key}-meta`}
                   className="mono-meta text-[var(--color-text-muted)]"

--- a/apps/admin/src/app/login/login-page-client.tsx
+++ b/apps/admin/src/app/login/login-page-client.tsx
@@ -15,12 +15,14 @@ const providerIcons = {
 export type LoginProviderId = keyof typeof providerIcons
 
 export function LoginPageClient({
+  accessRequestAvailable,
   authBaseURL,
   callbackURL,
   destinationName,
   enabledProviders,
   initialError,
 }: {
+  accessRequestAvailable?: boolean
   authBaseURL?: string
   callbackURL?: string
   destinationName?: string
@@ -31,7 +33,9 @@ export function LoginPageClient({
   const [error, setError] = useState(
     initialError === "forbidden" ? messages.login.errors.forbidden : "",
   )
+  const [notice, setNotice] = useState("")
   const [loading, setLoading] = useState(false)
+  const [requestingAccess, setRequestingAccess] = useState(false)
 
   const authApiBase = authBaseURL ? `${authBaseURL}/api/auth` : "/api/auth"
   const resolvedDestinationName =
@@ -93,6 +97,38 @@ export function LoginPageClient({
     }
 
     return undefined
+  }
+
+  async function requestAccess() {
+    setError("")
+    setNotice("")
+    setRequestingAccess(true)
+
+    try {
+      const res = await fetch("/api/auth/request-access", {
+        method: "POST",
+        headers: { accept: "application/json" },
+      })
+
+      if (res.ok) {
+        setNotice(messages.login.access.requested)
+        return
+      }
+    } catch {
+      // Fall through to generic request error.
+    } finally {
+      setRequestingAccess(false)
+    }
+
+    setError(messages.login.errors.requestAccessFailed)
+  }
+
+  function tryDifferentAccount() {
+    const resolvedCallbackURL =
+      callbackURL ?? `${window.location.origin}/dashboard`
+    window.location.assign(
+      `/api/auth/login?callbackURL=${encodeURIComponent(resolvedCallbackURL)}`,
+    )
   }
 
   return (
@@ -158,6 +194,15 @@ export function LoginPageClient({
             </p>
           </header>
 
+          {notice ? (
+            <p
+              role="status"
+              className="mb-5 rounded-sm border border-[var(--color-success-border)] bg-[color-mix(in_oklab,var(--color-success)_10%,var(--color-bg))] px-3 py-2 text-[12px] leading-5 text-[var(--color-success)]"
+            >
+              {notice}
+            </p>
+          ) : null}
+
           <form className="space-y-5" onSubmit={handleSubmit}>
             <div className="space-y-1.5">
               <label
@@ -197,12 +242,32 @@ export function LoginPageClient({
             </div>
 
             {error ? (
-              <p
-                role="alert"
-                className="text-[12px] text-[var(--color-danger)]"
-              >
-                {error}
-              </p>
+              <div role="alert" className="space-y-3">
+                <p className="text-[12px] text-[var(--color-danger)]">
+                  {error}
+                </p>
+                {accessRequestAvailable ? (
+                  <div className="grid gap-2">
+                    <button
+                      type="button"
+                      disabled={requestingAccess}
+                      onClick={requestAccess}
+                      className="flex h-9 w-full items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[12px] font-medium text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                      {requestingAccess
+                        ? messages.login.actions.requestingAccess
+                        : messages.login.actions.requestAccess}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={tryDifferentAccount}
+                      className="flex h-9 w-full items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[12px] font-medium text-[var(--color-text-secondary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]"
+                    >
+                      {messages.login.actions.tryDifferentAccount}
+                    </button>
+                  </div>
+                ) : null}
+              </div>
             ) : null}
 
             <button

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -66,6 +66,8 @@ export default async function LoginPage({ searchParams }: LoginPageProps = {}) {
   )
   const initialError =
     firstParam(params.error) === "forbidden" ? "forbidden" : undefined
+  const accessRequestAvailable =
+    firstParam(params.request) === "available" ? true : undefined
   const oauthConfig = getAdminOAuthConfig()
 
   if (oauthConfig && !initialError) {
@@ -80,6 +82,9 @@ export default async function LoginPage({ searchParams }: LoginPageProps = {}) {
     if (initialError) {
       url.searchParams.set("error", initialError)
     }
+    if (accessRequestAvailable) {
+      url.searchParams.set("request", "available")
+    }
     redirect(url.toString() as Parameters<typeof redirect>[0])
   }
 
@@ -88,6 +93,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps = {}) {
       authBaseURL={authBaseURL}
       callbackURL={callbackURL}
       destinationName={getLoginDestinationName(callbackURL)}
+      accessRequestAvailable={accessRequestAvailable}
       enabledProviders={getEnabledProviders()}
       initialError={initialError}
     />

--- a/apps/admin/src/auth/auth-session.test.ts
+++ b/apps/admin/src/auth/auth-session.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest"
 import { SignJWT } from "jose"
 
 import {
+  createAdminOAuthAccessRequestCookie,
   createAdminOAuthSessionCookie,
+  readAdminOAuthAccessRequestCookie,
   readAdminOAuthSessionCookie,
 } from "./auth-session"
 
@@ -10,12 +12,26 @@ describe("admin OAuth session cookie", () => {
   it("round-trips a signed principal", async () => {
     const cookie = await createAdminOAuthSessionCookie(
       { id: "user_123", role: "EDITOR" },
-      ["admin:access", "admin:content:write"],
+      ["admin:access"],
     )
 
     await expect(readAdminOAuthSessionCookie(cookie)).resolves.toEqual({
       id: "user_123",
       role: "EDITOR",
+    })
+  })
+
+  it("round-trips a signed access request", async () => {
+    const cookie = await createAdminOAuthAccessRequestCookie({
+      subject: "subject_123",
+      email: "user@example.com",
+      name: "Test User",
+    })
+
+    await expect(readAdminOAuthAccessRequestCookie(cookie)).resolves.toEqual({
+      subject: "subject_123",
+      email: "user@example.com",
+      name: "Test User",
     })
   })
 

--- a/apps/admin/src/auth/auth-session.ts
+++ b/apps/admin/src/auth/auth-session.ts
@@ -7,11 +7,20 @@ export const ADMIN_OAUTH_SESSION_COOKIE = "forge_admin_oauth_session"
 export const ADMIN_OAUTH_STATE_COOKIE = "forge_admin_oauth_state"
 export const ADMIN_OAUTH_VERIFIER_COOKIE = "forge_admin_oauth_verifier"
 export const ADMIN_OAUTH_CALLBACK_COOKIE = "forge_admin_oauth_callback"
+export const ADMIN_OAUTH_ACCESS_REQUEST_COOKIE =
+  "forge_admin_oauth_access_request"
 
 const maxAgeSeconds = 60 * 60 * 24 * 7
+const accessRequestMaxAgeSeconds = 60 * 10
 
 type AdminOAuthSessionPayload = Principal & {
   scopes: string[]
+}
+
+export type AdminOAuthAccessRequestPayload = {
+  subject: string
+  email?: string
+  name?: string
 }
 
 export function createAdminOAuthSessionCookie(
@@ -25,6 +34,15 @@ export function createAdminOAuthSessionCookie(
   })
     .setProtectedHeader({ alg: "HS256" })
     .setExpirationTime(`${maxAgeSeconds}s`)
+    .sign(getSigningKey())
+}
+
+export function createAdminOAuthAccessRequestCookie(
+  payload: AdminOAuthAccessRequestPayload,
+) {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime(`${accessRequestMaxAgeSeconds}s`)
     .sign(getSigningKey())
 }
 
@@ -44,6 +62,37 @@ export async function readAdminOAuthSessionCookie(
   }
 }
 
+export async function readAdminOAuthAccessRequestCookie(
+  value?: string,
+): Promise<AdminOAuthAccessRequestPayload | null> {
+  if (!value) return null
+
+  try {
+    const { payload } = await jwtVerify(value, getSigningKey(), {
+      algorithms: ["HS256"],
+    })
+
+    if (
+      typeof payload.subject !== "string" ||
+      ("email" in payload && typeof payload.email !== "string") ||
+      ("name" in payload && typeof payload.name !== "string")
+    ) {
+      return null
+    }
+
+    const email = typeof payload.email === "string" ? payload.email : undefined
+    const name = typeof payload.name === "string" ? payload.name : undefined
+
+    return {
+      subject: payload.subject,
+      email,
+      name,
+    }
+  } catch {
+    return null
+  }
+}
+
 export function adminOAuthCookieOptions() {
   return {
     httpOnly: true,
@@ -51,6 +100,13 @@ export function adminOAuthCookieOptions() {
     secure: env.NODE_ENV === "production",
     path: "/",
     maxAge: maxAgeSeconds,
+  }
+}
+
+export function adminOAuthAccessRequestCookieOptions() {
+  return {
+    ...adminOAuthCookieOptions(),
+    maxAge: accessRequestMaxAgeSeconds,
   }
 }
 

--- a/apps/admin/src/auth/oauth-client.test.ts
+++ b/apps/admin/src/auth/oauth-client.test.ts
@@ -45,6 +45,8 @@ describe("admin OAuth client", () => {
     expect(url.searchParams.get("response_type")).toBe("code")
     expect(url.searchParams.get("code_challenge_method")).toBe("S256")
     expect(url.searchParams.get("scope")).toContain("admin:access")
+    expect(url.searchParams.get("scope")).not.toContain("admin:content:read")
+    expect(url.searchParams.get("scope")).not.toContain("admin:content:write")
     expect(url.searchParams.get("callbackURL")).toBe(
       "https://admin.jesusfilm.org/dashboard",
     )

--- a/apps/admin/src/auth/oauth-client.ts
+++ b/apps/admin/src/auth/oauth-client.ts
@@ -61,8 +61,6 @@ export function buildAdminAuthorizeUrl({
       "email:read",
       "membership:read",
       "admin:access",
-      "admin:content:read",
-      "admin:content:write",
     ].join(" "),
   )
   url.searchParams.set("state", state)

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -148,6 +148,9 @@ export const adminMessages = {
         continue: "Continue",
         signingIn: "Signing in…",
         continueWith: "Continue with {provider}",
+        requestAccess: "Request access",
+        requestingAccess: "Requesting access…",
+        tryDifferentAccount: "Try a different account",
       },
       providers: {
         facebook: "Facebook",
@@ -158,6 +161,11 @@ export const adminMessages = {
       errors: {
         forbidden: "Your account does not have access to the admin dashboard.",
         invalidCredentials: "Invalid email or password",
+        requestAccessFailed: "Access request failed. Try signing in again.",
+      },
+      access: {
+        requested:
+          "Access requested. An administrator must approve your account before you can enter the dashboard.",
       },
     },
     pages: {
@@ -1134,6 +1142,9 @@ export const adminMessages = {
         continue: "Continuar",
         signingIn: "Ingresando…",
         continueWith: "Continuar con {provider}",
+        requestAccess: "Solicitar acceso",
+        requestingAccess: "Solicitando acceso…",
+        tryDifferentAccount: "Probar otra cuenta",
       },
       providers: {
         facebook: "Facebook",
@@ -1144,6 +1155,12 @@ export const adminMessages = {
       errors: {
         forbidden: "Tu cuenta no tiene acceso al panel de administracion.",
         invalidCredentials: "Correo o contrasena no validos",
+        requestAccessFailed:
+          "No se pudo solicitar acceso. Intenta iniciar sesion de nuevo.",
+      },
+      access: {
+        requested:
+          "Acceso solicitado. Un administrador debe aprobar tu cuenta antes de que puedas entrar al panel.",
       },
     },
     pages: {} as Record<string, never>,

--- a/apps/auth/src/domain/apps.ts
+++ b/apps/auth/src/domain/apps.ts
@@ -34,8 +34,6 @@ export const ADMIN_DEFAULT_SCOPES = [
   "email:read",
   "membership:read",
   "admin:access",
-  "admin:content:read",
-  "admin:content:write",
 ] satisfies AuthScopeKey[]
 
 export const ADMIN_APP_SEED: RegisteredAppSeed = {

--- a/apps/auth/src/domain/scopes.ts
+++ b/apps/auth/src/domain/scopes.ts
@@ -26,16 +26,6 @@ export const AUTH_SCOPES = [
     description: "Allow sign-in to the Jesus Film Admin application.",
   },
   {
-    key: "admin:content:read",
-    label: "Read Admin content",
-    description: "Allow Admin to read editorial content on your behalf.",
-  },
-  {
-    key: "admin:content:write",
-    label: "Write Admin content",
-    description: "Allow Admin to change editorial content on your behalf.",
-  },
-  {
     key: "tokens:manage",
     label: "Manage tokens",
     description: "Create, inspect, and revoke scoped Auth tokens.",

--- a/apps/auth/src/services/token-policy.service.test.ts
+++ b/apps/auth/src/services/token-policy.service.test.ts
@@ -42,7 +42,7 @@ describe("token policy", () => {
     expect(() =>
       assertTokenPolicy({
         family: "client_credentials",
-        requestedScopes: ["openid", "admin:content:write"],
+        requestedScopes: ["openid", "email:read"],
         grantedScopes: ["openid"],
         environmentKind: "local",
         audience: "http://localhost:3003",
@@ -50,7 +50,7 @@ describe("token policy", () => {
         now,
         serviceKey: "admin-sync",
       }),
-    ).toThrow("Requested scope(s) not granted: admin:content:write")
+    ).toThrow("Requested scope(s) not granted: email:read")
   })
 
   it("requires matching token subjects", () => {


### PR DESCRIPTION
## Summary
- keep OAuth as identity/app-admission only; Admin no longer requests admin content scopes and Auth no longer exposes admin content read/write scopes
- reject unapproved OAuth callbacks on the Admin side without creating an admin session
- when a rejected callback is for a valid account, show options to try another account or explicitly request access
- create/update a local VIEWER row only when the user clicks Request access; Admins can approve pending VIEWER rows as Editor or Admin from Users

## Tests
- pnpm --filter @forge/admin test -- app/api/auth/callback/route.test.ts app/api/auth/request-access/route.test.ts auth/oauth-client.test.ts auth/auth-session.test.ts
- pnpm --filter @forge/auth test -- domain/scopes.test.ts services/token-policy.service.test.ts services/oauth-policy.service.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/auth typecheck
- pnpm --filter @forge/admin lint