### PR TITLE
feat(admin): automate video db backups

### DIFF
--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -62,6 +62,7 @@ CI's `admin-schema-drift` job catches step 1 if forgotten. CI's `graphql-generat
 | `pnpm --filter @forge/admin run-sync`            | Run the Core data sync against any DATABASE_URL                | DATABASE_URL + Core API creds                                      |
 | `pnpm --filter @forge/admin run-embeds`          | Run scene/transcript embedding workflows locally               | DATABASE_URL + manager S3 + OpenRouter (R1 only)                   |
 | `pnpm --filter @forge/admin run-experience-dump` | Run R3 experience-content-dump from a workstation              | DATABASE_URL + CMS_DATABASE_URL                                    |
+| `pnpm --filter @forge/admin restore:video-db`    | Restore the reviewed video slice into dev/staging Postgres     | TARGET_DATABASE_URL or DATABASE_URL + `--target-env`               |
 | `pnpm --filter @forge/admin seed-easter`         | Seed Easter experience into local Postgres for UI/E2E fixtures | DATABASE_URL (loaded via `--env-file=.env`); destructive on re-run |
 | `pnpm --filter @forge/admin schema:print`        | Regenerate the committed admin SDL artifact                    | None (uses Pothos schema directly)                                 |
 

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -168,6 +168,44 @@ pnpm --filter @forge/admin lint
 pnpm --filter @forge/admin typecheck
 ```
 
+### Video database backup and clone
+
+Production backup is automated only. Do not add or use an operator
+`backup:video-db` script. Run Postgres World from a dedicated admin worker
+Railway service, not from the traffic-serving admin web service. Both services
+can use the same admin build/start command, but only the worker should set
+`WORKFLOW_RUNNER_ENABLED=true`; web should leave it unset or `false` so web
+replicas can scale on traffic without also running jobs. When the worker boots,
+`src/instrumentation.ts` starts Postgres World and ensures one
+`src/workflows/videoDbBackup.ts` scheduler workflow is running. That scheduler
+workflow runs one backup immediately when it is first created, then sleeps until
+the next daily UTC run and repeats on that cadence. The actual `pg_dump` and S3
+upload run inside Postgres World, and each backup gets a `workflow_run` ledger
+row visible in `/dashboard/workflows`. The job backs up the default
+`video-core` profile and uploads to the normal Railway S3 bucket env vars
+already managed through Doppler/Railway:
+`RAILWAY_S3_BUCKET`,
+`RAILWAY_S3_ENDPOINT`, `RAILWAY_S3_REGION`, `RAILWAY_S3_ACCESS_KEY_ID`, and
+`RAILWAY_S3_SECRET_ACCESS_KEY`. Backups upload under the fixed
+`admin-video-db-backups/<profile>/` prefix.
+
+The schedule is fixed in code at daily 09:00 UTC. The admin Railway image gets
+PostgreSQL 18 client tools from the admin service's Railpack variable
+`RAILPACK_PACKAGES=postgres@18.1`; keep that in sync with the managed database
+major version because `pg_dump` cannot dump from a newer server. Railpack's
+Mise Postgres package compiles from source, so the services also need
+`RAILPACK_BUILD_APT_PACKAGES=bison flex`. Because this monorepo has multiple
+Railway services, do not put a root Railpack config in place for this feature
+unless every service should inherit it. Deployment details should be checked
+after merge to confirm the package settings were applied to both admin web and
+worker services.
+
+Use `pnpm --filter @forge/admin restore:video-db -- --target-env=development --in=<dump>`
+to restore into local or staging Postgres. The restore path reads
+`TARGET_DATABASE_URL` first, then `DATABASE_URL`, truncates only the reviewed
+video manifest tables, and refuses `--target-env=production` unless
+`--allow-production-target` is also present.
+
 ### Jesus Film Auth client mode
 
 For local OAuth-mode development, run Auth on `http://localhost:3004`, seed its

--- a/apps/admin/docs/core-sync-recurring-job.md
+++ b/apps/admin/docs/core-sync-recurring-job.md
@@ -10,6 +10,9 @@ calls `runSync(syncPrisma, ...)`.
 - `DATABASE_URL_SYNC` - dedicated Prisma pool for Core Sync. Use a small pool,
   for example `connection_limit=2`.
 - `WORKFLOW_TARGET_WORLD` - set to `@workflow/world-postgres` in Railway.
+- `WORKFLOW_RUNNER_ENABLED` - set to `true` only on the dedicated admin worker
+  service that should execute Postgres World jobs. Leave unset or `false` on
+  the admin web service so web replicas can scale without also running workers.
 - `WORKFLOW_POSTGRES_URL` - Postgres World storage database. Use the admin
   database when the workflows run index and detail routes should read runtime
   rows alongside admin ledger context.
@@ -42,10 +45,13 @@ calls `runSync(syncPrisma, ...)`.
    The command is idempotent and creates the Workflow runtime tables for runs,
    events, steps, hooks, and streams.
 
-4. Deploy admin as a long-lived Railway service. Postgres World requires the
-   Node process to call `world.start()` on server initialization; admin does
-   this in `src/instrumentation.ts` when `WORKFLOW_TARGET_WORLD` is
-   `@workflow/world-postgres`.
+4. Deploy a dedicated admin worker service from the same admin build. Postgres
+   World requires the Node process to call `world.start()` on server
+   initialization; admin does this in `src/instrumentation.ts` only when
+   `WORKFLOW_RUNNER_ENABLED=true` and `WORKFLOW_TARGET_WORLD` is
+   `@workflow/world-postgres`. The web service can keep `WORKFLOW_TARGET_WORLD`
+   and `WORKFLOW_POSTGRES_URL` for dashboard reads, but should leave
+   `WORKFLOW_RUNNER_ENABLED` unset or `false`.
 5. Configure Railway cron or another external scheduler to call:
 
    ```bash

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start",
     "postinstall": "prisma generate",
+    "restore:video-db": "tsx src/scripts/restore-video-db.ts",
     "fetch-secrets": "../../scripts/fetch-secrets.sh forge-admin .env",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
@@ -37,6 +38,7 @@
     "workflow:setup:postgres": "workflow-postgres-setup"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.1030.0",
     "@better-auth/prisma-adapter": "1.6.2",
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "10.0.0",
@@ -72,11 +74,11 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tailwindcss": "4.2.2",
+    "tsx": "^4.21.0",
     "workflow": "^4.2.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@aws-sdk/client-s3": "3.1030.0",
     "@smithy/node-http-handler": "4.4.14",
     "@types/node": "^22",
     "@types/pg": "8.20.0",
@@ -84,7 +86,6 @@
     "@types/react-dom": "19.2.3",
     "eslint": "^9.0.0",
     "eslint-config-next": "^16.1.6",
-    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "3.2.4"
   }

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -110,6 +110,10 @@ export const env = createEnv({
     WORKFLOW_TARGET_WORLD: z
       .enum(["local", "@workflow/world-postgres"])
       .optional(),
+    WORKFLOW_RUNNER_ENABLED: z
+      .enum(["true", "false"])
+      .optional()
+      .default("false"),
     WORKFLOW_POSTGRES_URL: z.string().url().optional(),
     WORKFLOW_POSTGRES_JOB_PREFIX: z.string().min(1).optional(),
     WORKFLOW_POSTGRES_WORKER_CONCURRENCY: z.coerce
@@ -266,6 +270,9 @@ export const env = createEnv({
     PARITY_API_KEYS: emptyToUndefined(process.env.PARITY_API_KEYS),
     WORKFLOW_HMAC_SECRET: emptyToUndefined(process.env.WORKFLOW_HMAC_SECRET),
     WORKFLOW_TARGET_WORLD: emptyToUndefined(process.env.WORKFLOW_TARGET_WORLD),
+    WORKFLOW_RUNNER_ENABLED: emptyToUndefined(
+      process.env.WORKFLOW_RUNNER_ENABLED,
+    ),
     WORKFLOW_POSTGRES_URL: emptyToUndefined(process.env.WORKFLOW_POSTGRES_URL),
     WORKFLOW_POSTGRES_JOB_PREFIX: emptyToUndefined(
       process.env.WORKFLOW_POSTGRES_JOB_PREFIX,

--- a/apps/admin/src/instrumentation.test.ts
+++ b/apps/admin/src/instrumentation.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mockEnv = vi.hoisted(() => ({
   env: {
     NEXT_RUNTIME: "nodejs" as "nodejs" | "edge" | undefined,
+    WORKFLOW_RUNNER_ENABLED: "false" as "true" | "false" | undefined,
     WORKFLOW_TARGET_WORLD: undefined as
       | "local"
       | "@workflow/world-postgres"
@@ -13,17 +14,22 @@ const mockEnv = vi.hoisted(() => ({
 const worldStart = vi.hoisted(() => vi.fn())
 const getWorld = vi.hoisted(() => vi.fn(() => ({ start: worldStart })))
 const startWorkflowWorkerHeartbeat = vi.hoisted(() => vi.fn())
+const ensureVideoDbBackupSchedulerStarted = vi.hoisted(() => vi.fn())
 
 vi.mock("@/config/env", () => mockEnv)
 vi.mock("workflow/runtime", () => ({ getWorld }))
 vi.mock("@/services/workflow-worker-heartbeat.service", () => ({
   startWorkflowWorkerHeartbeat,
 }))
+vi.mock("@/services/video-db-backup/job", () => ({
+  ensureVideoDbBackupSchedulerStarted,
+}))
 
 describe("workflow instrumentation", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     process.env.NEXT_RUNTIME = "nodejs"
+    mockEnv.env.WORKFLOW_RUNNER_ENABLED = "false"
     mockEnv.env.WORKFLOW_TARGET_WORLD = undefined
   })
 
@@ -37,10 +43,11 @@ describe("workflow instrumentation", () => {
     expect(getWorld).not.toHaveBeenCalled()
     expect(worldStart).not.toHaveBeenCalled()
     expect(startWorkflowWorkerHeartbeat).not.toHaveBeenCalled()
+    expect(ensureVideoDbBackupSchedulerStarted).not.toHaveBeenCalled()
   })
 
-  it("does not start a world in the edge runtime", async () => {
-    process.env.NEXT_RUNTIME = "edge"
+  it("does not start a world on web services that only read workflow data", async () => {
+    mockEnv.env.WORKFLOW_RUNNER_ENABLED = "false"
     mockEnv.env.WORKFLOW_TARGET_WORLD = "@workflow/world-postgres"
     const { register, shouldStartWorkflowWorld } =
       await import("./instrumentation")
@@ -51,9 +58,27 @@ describe("workflow instrumentation", () => {
     expect(getWorld).not.toHaveBeenCalled()
     expect(worldStart).not.toHaveBeenCalled()
     expect(startWorkflowWorkerHeartbeat).not.toHaveBeenCalled()
+    expect(ensureVideoDbBackupSchedulerStarted).not.toHaveBeenCalled()
+  })
+
+  it("does not start a world in the edge runtime", async () => {
+    process.env.NEXT_RUNTIME = "edge"
+    mockEnv.env.WORKFLOW_RUNNER_ENABLED = "true"
+    mockEnv.env.WORKFLOW_TARGET_WORLD = "@workflow/world-postgres"
+    const { register, shouldStartWorkflowWorld } =
+      await import("./instrumentation")
+
+    expect(shouldStartWorkflowWorld()).toBe(false)
+    await register()
+
+    expect(getWorld).not.toHaveBeenCalled()
+    expect(worldStart).not.toHaveBeenCalled()
+    expect(startWorkflowWorkerHeartbeat).not.toHaveBeenCalled()
+    expect(ensureVideoDbBackupSchedulerStarted).not.toHaveBeenCalled()
   })
 
   it("starts Postgres World in the node runtime", async () => {
+    mockEnv.env.WORKFLOW_RUNNER_ENABLED = "true"
     mockEnv.env.WORKFLOW_TARGET_WORLD = "@workflow/world-postgres"
     const { register, shouldStartWorkflowWorld } =
       await import("./instrumentation")
@@ -64,5 +89,6 @@ describe("workflow instrumentation", () => {
     expect(getWorld).toHaveBeenCalledTimes(1)
     expect(worldStart).toHaveBeenCalledTimes(1)
     expect(startWorkflowWorkerHeartbeat).toHaveBeenCalledTimes(1)
+    expect(ensureVideoDbBackupSchedulerStarted).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -3,6 +3,7 @@ import { env } from "@/config/env"
 export function shouldStartWorkflowWorld(): boolean {
   return (
     process.env.NEXT_RUNTIME === "nodejs" &&
+    env.WORKFLOW_RUNNER_ENABLED === "true" &&
     env.WORKFLOW_TARGET_WORLD === "@workflow/world-postgres"
   )
 }
@@ -13,7 +14,10 @@ export async function register(): Promise<void> {
   const { getWorld } = await import("workflow/runtime")
   const { startWorkflowWorkerHeartbeat } =
     await import("@/services/workflow-worker-heartbeat.service")
+  const { ensureVideoDbBackupSchedulerStarted } =
+    await import("@/services/video-db-backup/job")
   const world = getWorld()
   await world.start?.()
   await startWorkflowWorkerHeartbeat()
+  await ensureVideoDbBackupSchedulerStarted()
 }

--- a/apps/admin/src/scripts/restore-video-db.ts
+++ b/apps/admin/src/scripts/restore-video-db.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env tsx
+
+import { main } from "./video-db-backup"
+
+main("restore").catch((err) => {
+  process.stderr.write(
+    `[video-db-restore] ${err instanceof Error ? err.message : String(err)}\n`,
+  )
+  process.exit(1)
+})

--- a/apps/admin/src/scripts/video-db-backup.test.ts
+++ b/apps/admin/src/scripts/video-db-backup.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  VIDEO_DB_BACKUP_PROFILES,
+  VideoDbBackupError,
+  buildBackupPlan,
+  buildBackupObjectKey,
+  buildRestorePlan,
+  parseArgs,
+  parseProfile,
+} from "./video-db-backup"
+
+describe("video DB backup profiles", () => {
+  it("keeps video-core focused on catalog data without embedding tables", () => {
+    expect(VIDEO_DB_BACKUP_PROFILES["video-core"]).toContain("video")
+    expect(VIDEO_DB_BACKUP_PROFILES["video-core"]).toContain("video_locale")
+    expect(VIDEO_DB_BACKUP_PROFILES["video-core"]).toContain("video_dub")
+    expect(VIDEO_DB_BACKUP_PROFILES["video-core"]).toContain("video_subtitle")
+    expect(VIDEO_DB_BACKUP_PROFILES["video-core"]).not.toContain(
+      "video_scene_locale",
+    )
+    expect(VIDEO_DB_BACKUP_PROFILES["video-core"]).not.toContain(
+      "video_transcript_chunk",
+    )
+  })
+
+  it("adds scene and transcript embedding tables in video-search", () => {
+    expect(VIDEO_DB_BACKUP_PROFILES["video-search"]).toEqual(
+      expect.arrayContaining([
+        "video_scene",
+        "video_scene_locale",
+        "video_transcript",
+        "video_transcript_chunk",
+      ]),
+    )
+  })
+
+  it("rejects unknown profiles", () => {
+    expect(() => parseProfile("everything")).toThrow(VideoDbBackupError)
+  })
+})
+
+describe("backup command planning", () => {
+  it("builds pg_dump args with one table arg per reviewed table", () => {
+    const plan = buildBackupPlan(
+      parseArgs("backup", ["--profile=video-core", "--out=.tmp/video.dump"]),
+      { SOURCE_DATABASE_URL: "postgresql://user:pass@example.com/prod" },
+    )
+
+    expect(plan.commands).toHaveLength(1)
+    expect(plan.commands[0]?.command).toBe("pg_dump")
+    expect(plan.commands[0]?.env).toEqual({
+      PGDATABASE: "postgresql://user:pass@example.com/prod",
+    })
+    expect(plan.commands[0]?.args).toEqual(
+      expect.arrayContaining([
+        "--format=custom",
+        "--data-only",
+        "--no-owner",
+        "--no-acl",
+        "--file",
+        plan.outPath,
+        "--table=public.video",
+        "--table=public.video_locale",
+      ]),
+    )
+
+    const tableArgs = plan.commands[0]?.args.filter((arg) =>
+      arg.startsWith("--table="),
+    )
+    expect(tableArgs).toHaveLength(plan.tables.length)
+  })
+
+  it("requires a source database URL", () => {
+    expect(() => buildBackupPlan(parseArgs("backup", []), {})).toThrow(
+      "SOURCE_DATABASE_URL or DATABASE_URL is required",
+    )
+  })
+
+  it("plans S3 upload from the normal Railway bucket env vars", () => {
+    const plan = buildBackupPlan(
+      parseArgs("backup", ["--profile=video-search", "--out=.tmp/video.dump"]),
+      {
+        SOURCE_DATABASE_URL: "postgresql://user:pass@example.com/prod",
+        RAILWAY_S3_BUCKET: "admin-db-backups",
+        RAILWAY_S3_ENDPOINT: "https://storage.example.com",
+        RAILWAY_S3_REGION: "sjc",
+        RAILWAY_S3_ACCESS_KEY_ID: "key",
+        RAILWAY_S3_SECRET_ACCESS_KEY: "secret",
+      },
+    )
+
+    expect(plan.upload).toEqual({
+      bucket: "admin-db-backups",
+      endpoint: "https://storage.example.com",
+      region: "sjc",
+      accessKeyId: "key",
+      secretAccessKey: "secret",
+      key: "admin-video-db-backups/video-search/video.dump",
+    })
+  })
+
+  it("requires Railway S3 credentials when the normal bucket is configured", () => {
+    expect(() =>
+      buildBackupPlan(parseArgs("backup", []), {
+        SOURCE_DATABASE_URL: "postgresql://user:pass@example.com/prod",
+        RAILWAY_S3_BUCKET: "admin-db-backups",
+      }),
+    ).toThrow("S3 upload requires RAILWAY_S3_ACCESS_KEY_ID")
+  })
+
+  it("allows scheduled runs to override the S3 object key", () => {
+    expect(
+      buildBackupObjectKey(
+        "video-core",
+        "/tmp/video.dump",
+        "/manual/key.dump",
+        {},
+      ),
+    ).toBe("manual/key.dump")
+  })
+})
+
+describe("restore command planning", () => {
+  it("builds truncate and pg_restore commands for development targets", () => {
+    const plan = buildRestorePlan(
+      parseArgs("restore", [
+        "--profile=video-search",
+        "--target-env=development",
+        "--in=.tmp/video.dump",
+      ]),
+      { TARGET_DATABASE_URL: "postgresql://user:pass@localhost/dev" },
+    )
+
+    expect(plan.commands).toHaveLength(2)
+    expect(plan.commands[0]?.command).toBe("psql")
+    expect(plan.commands[0]?.env).toEqual({
+      PGDATABASE: "postgresql://user:pass@localhost/dev",
+    })
+    expect(plan.commands[0]?.args.join(" ")).toContain(
+      'TRUNCATE TABLE "public"."language"',
+    )
+    expect(plan.commands[0]?.args.join(" ")).toContain(
+      '"public"."video_transcript_chunk"',
+    )
+    expect(plan.commands[0]?.args.join(" ")).toContain(
+      "RESTART IDENTITY CASCADE",
+    )
+
+    expect(plan.commands[1]?.command).toBe("pg_restore")
+    expect(plan.commands[1]?.args).toEqual(
+      expect.arrayContaining([
+        "--data-only",
+        "--no-owner",
+        "--no-acl",
+        "--single-transaction",
+        "--dbname",
+        "postgresql://user:pass@localhost/dev",
+        "--table=public.video",
+        "--table=public.video_transcript_chunk",
+        plan.inPath,
+      ]),
+    )
+  })
+
+  it("requires an input dump path", () => {
+    expect(() =>
+      buildRestorePlan(parseArgs("restore", ["--target-env=development"]), {
+        TARGET_DATABASE_URL: "postgresql://localhost/dev",
+      }),
+    ).toThrow("--in=<dump path> is required")
+  })
+
+  it("refuses production restores without the explicit override", () => {
+    expect(() =>
+      buildRestorePlan(
+        parseArgs("restore", [
+          "--target-env=production",
+          "--in=.tmp/video.dump",
+        ]),
+        { TARGET_DATABASE_URL: "postgresql://localhost/prod" },
+      ),
+    ).toThrow("Refusing production restore")
+  })
+
+  it("allows production restores only when requested explicitly", () => {
+    const plan = buildRestorePlan(
+      parseArgs("restore", [
+        "--target-env=production",
+        "--allow-production-target",
+        "--in=.tmp/video.dump",
+      ]),
+      { TARGET_DATABASE_URL: "postgresql://localhost/prod" },
+    )
+
+    expect(plan.targetEnv).toBe("production")
+  })
+})

--- a/apps/admin/src/scripts/video-db-backup.ts
+++ b/apps/admin/src/scripts/video-db-backup.ts
@@ -1,0 +1,605 @@
+/**
+ * Back up and restore the reviewed admin Postgres video data slice.
+ *
+ * Restore:
+ *   TARGET_DATABASE_URL=postgresql://... \
+ *   pnpm --filter @forge/admin restore:video-db -- \
+ *     --target-env=development \
+ *     --in=apps/admin/.tmp/db-backups/video-db-video-core-2026-05-13.dump
+ *
+ * Restore intentionally reads DATABASE_URL directly from process.env rather
+ * than importing @/config/env. Operators should be able to run the focused
+ * restore tool without satisfying the whole Next.js/admin runtime env matrix.
+ *
+ * Backup is not exposed as an operator CLI. It is invoked only by the
+ * useworkflow job in src/workflows/videoDbBackup.ts.
+ */
+
+import { spawn } from "node:child_process"
+import { createReadStream } from "node:fs"
+import { mkdir } from "node:fs/promises"
+import { basename, dirname, resolve as resolvePath } from "node:path"
+
+export const VIDEO_DB_BACKUP_PROFILES = {
+  "video-core": [
+    "language",
+    "language_locale",
+    "continent",
+    "continent_locale",
+    "country",
+    "country_locale",
+    "country_language",
+    "keyword",
+    "video_origin",
+    "video_edition",
+    "mux_video",
+    "bible_book",
+    "video",
+    "video_locale",
+    "video_relation",
+    "video_keyword",
+    "video_dub",
+    "video_dub_download",
+    "video_subtitle",
+    "video_study_question",
+    "video_image",
+    "bible_citation",
+  ],
+  "video-search": [
+    "language",
+    "language_locale",
+    "continent",
+    "continent_locale",
+    "country",
+    "country_locale",
+    "country_language",
+    "keyword",
+    "video_origin",
+    "video_edition",
+    "mux_video",
+    "bible_book",
+    "video",
+    "video_locale",
+    "video_relation",
+    "video_keyword",
+    "video_dub",
+    "video_dub_download",
+    "video_subtitle",
+    "video_study_question",
+    "video_image",
+    "bible_citation",
+    "video_scene",
+    "video_scene_locale",
+    "video_transcript",
+    "video_transcript_chunk",
+  ],
+  "video-full": [
+    "language",
+    "language_locale",
+    "continent",
+    "continent_locale",
+    "country",
+    "country_locale",
+    "country_language",
+    "keyword",
+    "video_origin",
+    "video_edition",
+    "mux_video",
+    "bible_book",
+    "video",
+    "video_locale",
+    "video_relation",
+    "video_keyword",
+    "video_dub",
+    "video_dub_download",
+    "video_subtitle",
+    "video_study_question",
+    "video_image",
+    "bible_citation",
+    "video_scene",
+    "video_scene_locale",
+    "video_transcript",
+    "video_transcript_chunk",
+  ],
+} as const
+
+export type VideoDbBackupProfile = keyof typeof VIDEO_DB_BACKUP_PROFILES
+export type TargetEnvironment = "development" | "staging" | "production"
+
+type ParsedArgs = {
+  command: "backup" | "restore"
+  profile: VideoDbBackupProfile
+  outPath?: string
+  inPath?: string
+  s3Key?: string
+  targetEnv: TargetEnvironment
+  allowProductionTarget: boolean
+  dryRun: boolean
+}
+
+type CommandPlan = {
+  command: string
+  args: string[]
+  env?: Record<string, string>
+}
+
+type DatabaseUrlEnv = {
+  SOURCE_DATABASE_URL?: string
+  TARGET_DATABASE_URL?: string
+  DATABASE_URL?: string
+}
+
+type BackupStorageEnv = {
+  RAILWAY_S3_BUCKET?: string
+  RAILWAY_S3_ENDPOINT?: string
+  RAILWAY_S3_REGION?: string
+  RAILWAY_S3_ACCESS_KEY_ID?: string
+  RAILWAY_S3_SECRET_ACCESS_KEY?: string
+}
+
+export type BackupUploadPlan = {
+  bucket: string
+  key: string
+  endpoint?: string
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+}
+
+export type BackupPlan = {
+  mode: "backup"
+  profile: VideoDbBackupProfile
+  source: string
+  outPath: string
+  upload?: BackupUploadPlan
+  tables: string[]
+  commands: CommandPlan[]
+}
+
+export type RestorePlan = {
+  mode: "restore"
+  profile: VideoDbBackupProfile
+  target: string
+  targetEnv: TargetEnvironment
+  inPath: string
+  tables: string[]
+  commands: CommandPlan[]
+}
+
+export type VideoDbBackupJobResult = {
+  event: "video-db.backup.complete" | "video-db.backup.dry-run-complete"
+  profile: VideoDbBackupProfile
+  tables: number
+  path: string
+  upload?: {
+    bucket: string
+    key: string
+  }
+}
+
+export class VideoDbBackupError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "VideoDbBackupError"
+  }
+}
+
+function readFlag(args: readonly string[], name: string): string | undefined {
+  const prefix = `--${name}=`
+  const match = args.find((arg) => arg.startsWith(prefix))
+  return match?.slice(prefix.length)
+}
+
+function hasFlag(args: readonly string[], name: string): boolean {
+  return args.includes(`--${name}`)
+}
+
+function currentDatabaseUrlEnv(): DatabaseUrlEnv {
+  return {
+    SOURCE_DATABASE_URL: process.env.SOURCE_DATABASE_URL,
+    TARGET_DATABASE_URL: process.env.TARGET_DATABASE_URL,
+    DATABASE_URL: process.env.DATABASE_URL,
+  }
+}
+
+export function parseProfile(raw: string | undefined): VideoDbBackupProfile {
+  const profile = raw ?? "video-core"
+  if (profile in VIDEO_DB_BACKUP_PROFILES) {
+    return profile as VideoDbBackupProfile
+  }
+  throw new VideoDbBackupError(
+    `Unknown profile ${JSON.stringify(profile)}. Use one of: ${Object.keys(
+      VIDEO_DB_BACKUP_PROFILES,
+    ).join(", ")}`,
+  )
+}
+
+export function parseTargetEnv(raw: string | undefined): TargetEnvironment {
+  const targetEnv = raw ?? "development"
+  if (
+    targetEnv === "development" ||
+    targetEnv === "staging" ||
+    targetEnv === "production"
+  ) {
+    return targetEnv
+  }
+  throw new VideoDbBackupError(
+    `Unknown target env ${JSON.stringify(targetEnv)}. Use development, staging, or production.`,
+  )
+}
+
+export function parseArgs(
+  command: "backup" | "restore",
+  args: readonly string[],
+): ParsedArgs {
+  const normalizedArgs = args.filter((arg) => arg !== "--")
+  return {
+    command,
+    profile: parseProfile(readFlag(normalizedArgs, "profile")),
+    outPath: readFlag(normalizedArgs, "out"),
+    inPath: readFlag(normalizedArgs, "in"),
+    s3Key: readFlag(normalizedArgs, "s3-key"),
+    targetEnv: parseTargetEnv(readFlag(normalizedArgs, "target-env")),
+    allowProductionTarget: hasFlag(normalizedArgs, "allow-production-target"),
+    dryRun: hasFlag(normalizedArgs, "dry-run"),
+  }
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-")
+}
+
+function defaultOutPath(profile: VideoDbBackupProfile): string {
+  return resolvePath(
+    process.cwd(),
+    ".tmp",
+    "db-backups",
+    `video-db-${profile}-${timestamp()}.dump`,
+  )
+}
+
+function normalizeS3Prefix(prefix: string): string {
+  return prefix.replace(/^\/+|\/+$/g, "")
+}
+
+export function buildBackupObjectKey(
+  profile: VideoDbBackupProfile,
+  outPath: string,
+  keyOverride: string | undefined,
+  _env: BackupStorageEnv,
+): string {
+  if (keyOverride) return keyOverride.replace(/^\/+/, "")
+
+  const prefix = normalizeS3Prefix("admin-video-db-backups")
+  const filename = basename(outPath)
+  return prefix.length > 0 ? `${prefix}/${profile}/${filename}` : filename
+}
+
+function tableArgs(tables: readonly string[]): string[] {
+  return tables.map((table) => `--table=public.${table}`)
+}
+
+function quoteTable(table: string): string {
+  return `"public"."${table.replace(/"/g, '""')}"`
+}
+
+export function buildBackupPlan(
+  parsed: ParsedArgs,
+  env: DatabaseUrlEnv & BackupStorageEnv = {
+    ...currentDatabaseUrlEnv(),
+    RAILWAY_S3_BUCKET: process.env.RAILWAY_S3_BUCKET,
+    RAILWAY_S3_ENDPOINT: process.env.RAILWAY_S3_ENDPOINT,
+    RAILWAY_S3_REGION: process.env.RAILWAY_S3_REGION,
+    RAILWAY_S3_ACCESS_KEY_ID: process.env.RAILWAY_S3_ACCESS_KEY_ID,
+    RAILWAY_S3_SECRET_ACCESS_KEY: process.env.RAILWAY_S3_SECRET_ACCESS_KEY,
+  },
+): BackupPlan {
+  const source = env.SOURCE_DATABASE_URL ?? env.DATABASE_URL
+  if (!source) {
+    throw new VideoDbBackupError(
+      "SOURCE_DATABASE_URL or DATABASE_URL is required for backup",
+    )
+  }
+
+  const outPath = resolvePath(parsed.outPath ?? defaultOutPath(parsed.profile))
+  const tables = [...VIDEO_DB_BACKUP_PROFILES[parsed.profile]]
+  const upload = resolveBackupUploadPlan(parsed, outPath, env)
+
+  return {
+    mode: "backup",
+    profile: parsed.profile,
+    source,
+    outPath,
+    upload,
+    tables,
+    commands: [
+      {
+        command: "pg_dump",
+        args: [
+          "--format=custom",
+          "--data-only",
+          "--no-owner",
+          "--no-acl",
+          "--file",
+          outPath,
+          ...tableArgs(tables),
+        ],
+        env: { PGDATABASE: source },
+      },
+    ],
+  }
+}
+
+export function resolveBackupUploadPlan(
+  parsed: ParsedArgs,
+  outPath: string,
+  env: BackupStorageEnv,
+): BackupUploadPlan | undefined {
+  const bucket = env.RAILWAY_S3_BUCKET
+
+  if (!bucket) {
+    return undefined
+  }
+
+  const accessKeyId = env.RAILWAY_S3_ACCESS_KEY_ID
+  const secretAccessKey = env.RAILWAY_S3_SECRET_ACCESS_KEY
+  if (!accessKeyId || !secretAccessKey) {
+    throw new VideoDbBackupError(
+      "S3 upload requires RAILWAY_S3_ACCESS_KEY_ID and RAILWAY_S3_SECRET_ACCESS_KEY when RAILWAY_S3_BUCKET is set",
+    )
+  }
+
+  return {
+    bucket,
+    key: buildBackupObjectKey(parsed.profile, outPath, parsed.s3Key, env),
+    endpoint: env.RAILWAY_S3_ENDPOINT,
+    region: env.RAILWAY_S3_REGION ?? "auto",
+    accessKeyId,
+    secretAccessKey,
+  }
+}
+
+export function buildRestorePlan(
+  parsed: ParsedArgs,
+  env: DatabaseUrlEnv = currentDatabaseUrlEnv(),
+): RestorePlan {
+  const target = env.TARGET_DATABASE_URL ?? env.DATABASE_URL
+  if (!target) {
+    throw new VideoDbBackupError(
+      "TARGET_DATABASE_URL or DATABASE_URL is required for restore",
+    )
+  }
+  if (!parsed.inPath) {
+    throw new VideoDbBackupError("--in=<dump path> is required for restore")
+  }
+  if (parsed.targetEnv === "production" && !parsed.allowProductionTarget) {
+    throw new VideoDbBackupError(
+      "Refusing production restore without --allow-production-target",
+    )
+  }
+
+  const inPath = resolvePath(parsed.inPath)
+  const tables = [...VIDEO_DB_BACKUP_PROFILES[parsed.profile]]
+  const truncateSql = `TRUNCATE TABLE ${tables
+    .map(quoteTable)
+    .join(", ")} RESTART IDENTITY CASCADE;`
+
+  return {
+    mode: "restore",
+    profile: parsed.profile,
+    target,
+    targetEnv: parsed.targetEnv,
+    inPath,
+    tables,
+    commands: [
+      {
+        command: "psql",
+        args: ["--set=ON_ERROR_STOP=1", "--command", truncateSql],
+        env: { PGDATABASE: target },
+      },
+      {
+        command: "pg_restore",
+        args: [
+          "--data-only",
+          "--no-owner",
+          "--no-acl",
+          "--single-transaction",
+          "--dbname",
+          target,
+          ...tableArgs(tables),
+          inPath,
+        ],
+      },
+    ],
+  }
+}
+
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value)
+    if (url.password) url.password = "REDACTED"
+    if (url.username) url.username = "REDACTED"
+    return url.toString()
+  } catch {
+    return value.length > 0 ? "[redacted]" : value
+  }
+}
+
+function printablePlan(plan: BackupPlan | RestorePlan): object {
+  const connectionUrl = plan.mode === "backup" ? plan.source : plan.target
+  const commands = plan.commands.map((command) => ({
+    command: command.command,
+    args: command.args.map((arg) =>
+      arg === connectionUrl ? redactUrl(arg) : arg,
+    ),
+    env: command.env
+      ? Object.fromEntries(
+          Object.entries(command.env).map(([key, value]) => [
+            key,
+            redactUrl(value),
+          ]),
+        )
+      : undefined,
+  }))
+
+  if (plan.mode === "backup") {
+    return {
+      event: "video-db.backup.plan",
+      profile: plan.profile,
+      source: redactUrl(plan.source),
+      outPath: plan.outPath,
+      upload: plan.upload
+        ? {
+            bucket: plan.upload.bucket,
+            key: plan.upload.key,
+            endpoint: plan.upload.endpoint,
+            region: plan.upload.region,
+          }
+        : null,
+      tables: plan.tables,
+      commands,
+    }
+  }
+
+  return {
+    event: "video-db.restore.plan",
+    profile: plan.profile,
+    target: redactUrl(plan.target),
+    targetEnv: plan.targetEnv,
+    inPath: plan.inPath,
+    tables: plan.tables,
+    commands,
+  }
+}
+
+async function runCommand(plan: CommandPlan): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(plan.command, plan.args, {
+      stdio: "inherit",
+      env: { ...process.env, ...plan.env },
+    })
+    child.on("error", reject)
+    child.on("exit", (code, signal) => {
+      if (code === 0) return resolve()
+      reject(
+        new Error(
+          `${plan.command} exited with ${signal ? `signal ${signal}` : `code ${code ?? "null"}`}`,
+        ),
+      )
+    })
+  })
+}
+
+async function runPlan(plan: BackupPlan | RestorePlan): Promise<void> {
+  if (plan.mode === "backup") {
+    await mkdir(dirname(plan.outPath), { recursive: true })
+  }
+  for (const command of plan.commands) {
+    await runCommand(command)
+  }
+}
+
+async function uploadBackup(plan: BackupPlan): Promise<void> {
+  if (!plan.upload) return
+
+  const { S3Client, PutObjectCommand } = await import("@aws-sdk/client-s3")
+
+  const body = createReadStream(plan.outPath)
+  const s3 = new S3Client({
+    endpoint: plan.upload.endpoint,
+    region: plan.upload.region,
+    credentials: {
+      accessKeyId: plan.upload.accessKeyId,
+      secretAccessKey: plan.upload.secretAccessKey,
+    },
+    forcePathStyle: true,
+  })
+
+  try {
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: plan.upload.bucket,
+        Key: plan.upload.key,
+        Body: body,
+        ContentType: "application/vnd.postgresql.dump",
+      }),
+    )
+  } finally {
+    s3.destroy()
+  }
+}
+
+async function executeBackupPlan(
+  parsed: ParsedArgs,
+): Promise<VideoDbBackupJobResult> {
+  const plan = buildBackupPlan(parsed)
+  process.stdout.write(`${JSON.stringify(printablePlan(plan))}\n`)
+
+  if (parsed.dryRun) {
+    const result: VideoDbBackupJobResult = {
+      event: "video-db.backup.dry-run-complete",
+      profile: plan.profile,
+      tables: plan.tables.length,
+      path: plan.outPath,
+      upload: plan.upload
+        ? { bucket: plan.upload.bucket, key: plan.upload.key }
+        : undefined,
+    }
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return result
+  }
+
+  await runPlan(plan)
+  await uploadBackup(plan)
+
+  const result: VideoDbBackupJobResult = {
+    event: "video-db.backup.complete",
+    profile: plan.profile,
+    tables: plan.tables.length,
+    path: plan.outPath,
+    upload: plan.upload
+      ? { bucket: plan.upload.bucket, key: plan.upload.key }
+      : undefined,
+  }
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+  return result
+}
+
+export async function runScheduledVideoDbBackup(): Promise<VideoDbBackupJobResult> {
+  return executeBackupPlan(parseArgs("backup", []))
+}
+
+export async function main(
+  command: "restore",
+  argv: readonly string[] = process.argv.slice(2),
+): Promise<void> {
+  const parsed = parseArgs(command, argv)
+  const plan = buildRestorePlan(parsed)
+
+  process.stdout.write(`${JSON.stringify(printablePlan(plan))}\n`)
+
+  if (parsed.dryRun) {
+    process.stdout.write(
+      `${JSON.stringify({ event: "video-db.restore.dry-run-complete" })}\n`,
+    )
+    return
+  }
+
+  await runPlan(plan)
+  process.stdout.write(
+    `${JSON.stringify({
+      event: "video-db.restore.complete",
+      profile: plan.profile,
+      tables: plan.tables.length,
+      path: plan.inPath,
+    })}\n`,
+  )
+}
+
+const invokedPath = typeof process.argv[1] === "string" ? process.argv[1] : ""
+if (import.meta.url === `file://${invokedPath}`) {
+  process.stderr.write(
+    "[video-db-backup] Backup is scheduled-only. Use pnpm --filter @forge/admin restore:video-db for restores.\n",
+  )
+  process.exit(1)
+}

--- a/apps/admin/src/services/video-db-backup/job.test.ts
+++ b/apps/admin/src/services/video-db-backup/job.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { wrapStartSpy } from "@/test-helpers/workflow-dispatch"
+
+const start = vi.hoisted(() => vi.fn())
+const workflowRun = vi.hoisted(() => ({
+  create: vi.fn(async (args) => ({ id: "ledger-run-1", ...args.data })),
+  findFirst: vi.fn(),
+  update: vi.fn(async (args) => args),
+}))
+const queryRaw = vi.hoisted(() => vi.fn())
+const backup = vi.hoisted(() => ({
+  runScheduledVideoDbBackup: vi.fn(),
+}))
+
+vi.mock("workflow/api", () => ({ start }))
+vi.mock("@/db/client", () => ({ prisma: { $queryRaw: queryRaw, workflowRun } }))
+vi.mock("@/scripts/video-db-backup", () => backup)
+
+describe("video DB backup workflow job", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryRaw.mockResolvedValue([{ locked: true }])
+    workflowRun.findFirst.mockResolvedValue(null)
+  })
+
+  it("calculates the next daily UTC backup time", async () => {
+    const { nextVideoDbBackupRunAt } = await import("./job")
+
+    expect(
+      nextVideoDbBackupRunAt(new Date("2026-05-14T08:59:00.000Z")),
+    ).toEqual(new Date("2026-05-14T09:00:00.000Z"))
+    expect(
+      nextVideoDbBackupRunAt(new Date("2026-05-14T09:00:00.000Z")),
+    ).toEqual(new Date("2026-05-15T09:00:00.000Z"))
+  })
+
+  it("starts one durable scheduler workflow when none is running", async () => {
+    start.mockResolvedValueOnce({
+      runId: "scheduler-runtime-run-1",
+      returnValue: Promise.resolve(undefined),
+    })
+    const { ensureVideoDbBackupSchedulerStarted } = await import("./job")
+    const { runVideoDbBackupScheduler } =
+      await import("@/workflows/videoDbBackup")
+
+    await expect(ensureVideoDbBackupSchedulerStarted()).resolves.toEqual({
+      started: true,
+      runId: "scheduler-runtime-run-1",
+      ledgerRunId: "ledger-run-1",
+    })
+    expect(workflowRun.findFirst).toHaveBeenCalledWith({
+      where: {
+        workflowKey: "video-db-backup-scheduler",
+        status: { in: ["QUEUED", "RUNNING"] },
+      },
+      orderBy: { createdAt: "desc" },
+    })
+    expect(start).toHaveBeenCalledWith(runVideoDbBackupScheduler, [
+      { ledgerRunId: "ledger-run-1" },
+    ])
+  })
+
+  it("does not start a duplicate scheduler when one is already active", async () => {
+    workflowRun.findFirst.mockResolvedValueOnce({
+      id: "existing-ledger-run",
+      runtimeRunId: "existing-runtime-run",
+    })
+    const { ensureVideoDbBackupSchedulerStarted } = await import("./job")
+
+    await expect(ensureVideoDbBackupSchedulerStarted()).resolves.toEqual({
+      started: false,
+      reason: "already-running",
+      ledgerRunId: "existing-ledger-run",
+      runtimeRunId: "existing-runtime-run",
+    })
+    expect(start).not.toHaveBeenCalled()
+  })
+
+  it("dispatches the scheduled backup through useworkflow", async () => {
+    const dispatch = wrapStartSpy(start)
+    start.mockResolvedValueOnce({
+      runId: "runtime-run-1",
+      returnValue: Promise.resolve(undefined),
+    })
+    const { dispatchVideoDbBackup } = await import("./job")
+    const { runVideoDbBackup } = await import("@/workflows/videoDbBackup")
+
+    await expect(
+      dispatchVideoDbBackup({ trigger: "scheduled" }),
+    ).resolves.toEqual({
+      workflow: "video-db-backup",
+      runId: "runtime-run-1",
+      trigger: "scheduled",
+      status: "queued",
+    })
+    dispatch.expectDispatched(runVideoDbBackup, [
+      { trigger: "scheduled", ledgerRunId: "ledger-run-1" },
+    ])
+    expect(workflowRun.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workflowKey: "video-db-backup",
+        workflowName: "Video DB Backup",
+        trigger: "SCHEDULED",
+        subjectType: "database",
+        subjectId: "admin-video",
+      }),
+    })
+  })
+
+  it("marks the ledger run succeeded after backup completes", async () => {
+    backup.runScheduledVideoDbBackup.mockResolvedValueOnce({
+      event: "video-db.backup.complete",
+      profile: "video-core",
+      tables: 22,
+      path: "/tmp/video.dump",
+      upload: {
+        bucket: "admin-storage",
+        key: "admin-video-db-backups/video-core/video.dump",
+      },
+    })
+    const { runVideoDbBackupJob } = await import("./job")
+
+    await runVideoDbBackupJob({
+      trigger: "scheduled",
+      ledgerRunId: "ledger-run-1",
+    })
+
+    expect(workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "ledger-run-1" },
+      data: expect.objectContaining({
+        status: "RUNNING",
+        startedAt: expect.any(Date),
+      }),
+    })
+    expect(workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "ledger-run-1" },
+      data: expect.objectContaining({
+        status: "SUCCEEDED",
+        summary: expect.stringContaining("Backed up 22 table"),
+        finishedAt: expect.any(Date),
+        durationMs: expect.any(Number),
+      }),
+    })
+  })
+})

--- a/apps/admin/src/services/video-db-backup/job.ts
+++ b/apps/admin/src/services/video-db-backup/job.ts
@@ -1,0 +1,270 @@
+import { Prisma, WorkflowRunStatus } from "@prisma/client"
+import { start } from "workflow/api"
+import { prisma } from "@/db/client"
+import {
+  attachWorkflowRuntimeRunId,
+  createWorkflowRunLog,
+  markWorkflowRunFailed,
+  markWorkflowRunStarted,
+} from "@/services/workflow-run-log.service"
+import {
+  runScheduledVideoDbBackup,
+  type VideoDbBackupJobResult,
+} from "@/scripts/video-db-backup"
+import {
+  runVideoDbBackup,
+  runVideoDbBackupScheduler,
+} from "@/workflows/videoDbBackup"
+
+export type VideoDbBackupTrigger = "scheduled"
+export type VideoDbBackupSchedulerInput = {
+  ledgerRunId?: string
+}
+
+export type VideoDbBackupWorkflowInput = {
+  trigger?: VideoDbBackupTrigger
+  ledgerRunId?: string
+}
+
+export type VideoDbBackupDispatchResult = {
+  workflow: "video-db-backup"
+  runId: string
+  trigger: VideoDbBackupTrigger
+  status: "queued"
+}
+
+export type VideoDbBackupSchedulerStartResult =
+  | {
+      started: true
+      runId: string
+      ledgerRunId: string
+    }
+  | {
+      started: false
+      reason: "already-running" | "lock-not-acquired"
+      ledgerRunId?: string
+      runtimeRunId?: string | null
+    }
+
+const SCHEDULER_WORKFLOW_KEY = "video-db-backup-scheduler"
+const SCHEDULER_LOCK_ID = 862_640_122
+const BACKUP_HOUR_UTC = 9
+
+function summarizeBackupResult(result: VideoDbBackupJobResult): string {
+  const destination = result.upload
+    ? `${result.upload.bucket}/${result.upload.key}`
+    : result.path
+  return `Backed up ${result.tables} table(s) for ${result.profile} to ${destination}.`
+}
+
+export function nextVideoDbBackupRunAt(
+  now: Date = new Date(),
+  hourUtc = BACKUP_HOUR_UTC,
+): Date {
+  const next = new Date(now)
+  next.setUTCHours(hourUtc, 0, 0, 0)
+  if (next <= now) {
+    next.setUTCDate(next.getUTCDate() + 1)
+  }
+  return next
+}
+
+export async function dispatchVideoDbBackup(
+  input: VideoDbBackupWorkflowInput = {},
+): Promise<VideoDbBackupDispatchResult> {
+  const trigger = input.trigger ?? "scheduled"
+  const ledgerRun = await createWorkflowRunLog({
+    workflowKey: "video-db-backup",
+    workflowName: "Video DB Backup",
+    trigger,
+    subjectType: "database",
+    subjectId: "admin-video",
+    summary: "Video DB backup workflow queued.",
+    details: {
+      profile: "video-core",
+      storage: "railway-s3",
+    },
+  })
+
+  try {
+    const run = await start(runVideoDbBackup, [
+      { trigger, ledgerRunId: ledgerRun.id },
+    ])
+    await attachWorkflowRuntimeRunId(ledgerRun.id, run.runId)
+
+    return {
+      workflow: "video-db-backup",
+      runId: run.runId,
+      trigger,
+      status: "queued",
+    }
+  } catch (error) {
+    await markWorkflowRunFailed(ledgerRun.id, error).catch(() => {})
+    throw error
+  }
+}
+
+export async function runVideoDbBackupJob(
+  input: VideoDbBackupWorkflowInput = {},
+): Promise<VideoDbBackupJobResult> {
+  const startedAt = Date.now()
+  if (input.ledgerRunId) {
+    await markWorkflowRunStarted(input.ledgerRunId)
+  }
+
+  try {
+    const result = await runScheduledVideoDbBackup()
+
+    if (input.ledgerRunId) {
+      await prisma.workflowRun.update({
+        where: { id: input.ledgerRunId },
+        data: {
+          status: WorkflowRunStatus.SUCCEEDED,
+          summary: summarizeBackupResult(result),
+          finishedAt: new Date(),
+          durationMs: Date.now() - startedAt,
+          details: {
+            result,
+          } satisfies Prisma.InputJsonValue,
+        },
+      })
+    }
+
+    return result
+  } catch (error) {
+    if (input.ledgerRunId) {
+      await markWorkflowRunFailed(input.ledgerRunId, error).catch(() => {})
+    }
+    throw error
+  }
+}
+
+export async function runVideoDbBackupFromScheduler(): Promise<{
+  ok: boolean
+  ledgerRunId: string
+  result?: VideoDbBackupJobResult
+  error?: string
+}> {
+  const ledgerRun = await createWorkflowRunLog({
+    workflowKey: "video-db-backup",
+    workflowName: "Video DB Backup",
+    trigger: "scheduled",
+    subjectType: "database",
+    subjectId: "admin-video",
+    summary: "Video DB backup workflow started by scheduler.",
+    details: {
+      profile: "video-core",
+      storage: "railway-s3",
+    },
+  })
+
+  try {
+    const result = await runVideoDbBackupJob({
+      trigger: "scheduled",
+      ledgerRunId: ledgerRun.id,
+    })
+    return { ok: true, ledgerRunId: ledgerRun.id, result }
+  } catch (error) {
+    return {
+      ok: false,
+      ledgerRunId: ledgerRun.id,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export async function markVideoDbBackupSchedulerStarted(
+  input: VideoDbBackupSchedulerInput = {},
+): Promise<void> {
+  if (!input.ledgerRunId) return
+  await markWorkflowRunStarted(input.ledgerRunId)
+}
+
+export async function recordVideoDbBackupSchedulerHeartbeat(
+  input: VideoDbBackupSchedulerInput,
+  nextRunAt: Date,
+): Promise<void> {
+  if (!input.ledgerRunId) return
+  await prisma.workflowRun.update({
+    where: { id: input.ledgerRunId },
+    data: {
+      summary: `Video DB backup scheduler sleeping until ${nextRunAt.toISOString()}.`,
+      details: {
+        nextRunAt: nextRunAt.toISOString(),
+        schedule: `daily ${String(BACKUP_HOUR_UTC).padStart(2, "0")}:00 UTC`,
+      } satisfies Prisma.InputJsonValue,
+    },
+  })
+}
+
+async function withSchedulerStartLock<T>(
+  callback: () => Promise<T>,
+): Promise<T> {
+  const rows = await prisma.$queryRaw<{ locked: boolean }[]>`
+    SELECT pg_try_advisory_lock(${SCHEDULER_LOCK_ID}) AS locked
+  `
+  if (!rows[0]?.locked) {
+    return {
+      started: false,
+      reason: "lock-not-acquired",
+    } as T
+  }
+
+  try {
+    return await callback()
+  } finally {
+    await prisma.$queryRaw`
+      SELECT pg_advisory_unlock(${SCHEDULER_LOCK_ID})
+    `
+  }
+}
+
+export async function ensureVideoDbBackupSchedulerStarted(): Promise<VideoDbBackupSchedulerStartResult> {
+  return withSchedulerStartLock(async () => {
+    const existing = await prisma.workflowRun.findFirst({
+      where: {
+        workflowKey: SCHEDULER_WORKFLOW_KEY,
+        status: {
+          in: [WorkflowRunStatus.QUEUED, WorkflowRunStatus.RUNNING],
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    })
+
+    if (existing) {
+      return {
+        started: false,
+        reason: "already-running",
+        ledgerRunId: existing.id,
+        runtimeRunId: existing.runtimeRunId,
+      }
+    }
+
+    const ledgerRun = await createWorkflowRunLog({
+      workflowKey: SCHEDULER_WORKFLOW_KEY,
+      workflowName: "Video DB Backup Scheduler",
+      trigger: "system",
+      subjectType: "database",
+      subjectId: "admin-video",
+      summary: "Video DB backup scheduler queued.",
+      details: {
+        schedule: `daily ${String(BACKUP_HOUR_UTC).padStart(2, "0")}:00 UTC`,
+      },
+    })
+
+    try {
+      const run = await start(runVideoDbBackupScheduler, [
+        { ledgerRunId: ledgerRun.id },
+      ])
+      await attachWorkflowRuntimeRunId(ledgerRun.id, run.runId)
+      return {
+        started: true,
+        runId: run.runId,
+        ledgerRunId: ledgerRun.id,
+      }
+    } catch (error) {
+      await markWorkflowRunFailed(ledgerRun.id, error).catch(() => {})
+      throw error
+    }
+  })
+}

--- a/apps/admin/src/services/workflow-run-log.service.ts
+++ b/apps/admin/src/services/workflow-run-log.service.ts
@@ -9,12 +9,13 @@ import type { SyncResult } from "@/services/core-sync/orchestrator"
 import type { CoreSyncTrigger } from "@/services/core-sync/job"
 
 type WorkflowRunClient = Pick<PrismaClient, "workflowRun" | "coreSyncRun">
+export type WorkflowRunLogTrigger = CoreSyncTrigger | "system"
 
 export type WorkflowRunLogInput = {
   workflowKey: string
   workflowName?: string
   runtimeRunId?: string
-  trigger: CoreSyncTrigger
+  trigger: WorkflowRunLogTrigger
   actorId?: string
   subjectType?: string
   subjectId?: string
@@ -22,10 +23,11 @@ export type WorkflowRunLogInput = {
   details?: Prisma.InputJsonValue
 }
 
-const TRIGGER_MAP: Record<CoreSyncTrigger, WorkflowRunTrigger> = {
+const TRIGGER_MAP: Record<WorkflowRunLogTrigger, WorkflowRunTrigger> = {
   manual: WorkflowRunTrigger.MANUAL,
   scheduled: WorkflowRunTrigger.SCHEDULED,
   graphql: WorkflowRunTrigger.GRAPHQL,
+  system: WorkflowRunTrigger.SYSTEM,
 }
 
 function asErrorMessage(error: unknown): string {

--- a/apps/admin/src/workflows/videoDbBackup.test.ts
+++ b/apps/admin/src/workflows/videoDbBackup.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const job = vi.hoisted(() => ({
+  runVideoDbBackupJob: vi.fn(),
+}))
+
+vi.mock("@/services/video-db-backup/job", () => job)
+
+describe("runVideoDbBackup workflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("runs video DB backup as a workflow step", async () => {
+    const result = {
+      event: "video-db.backup.complete",
+      profile: "video-core",
+      tables: 22,
+      path: "/tmp/video.dump",
+      upload: {
+        bucket: "admin-storage",
+        key: "admin-video-db-backups/video-core/video.dump",
+      },
+    } as const
+    job.runVideoDbBackupJob.mockResolvedValueOnce(result)
+    const { runVideoDbBackup } = await import("./videoDbBackup")
+
+    await expect(
+      runVideoDbBackup({
+        trigger: "scheduled",
+        ledgerRunId: "workflow-run-1",
+      }),
+    ).resolves.toEqual(result)
+    expect(job.runVideoDbBackupJob).toHaveBeenCalledWith({
+      trigger: "scheduled",
+      ledgerRunId: "workflow-run-1",
+    })
+  })
+})

--- a/apps/admin/src/workflows/videoDbBackup.ts
+++ b/apps/admin/src/workflows/videoDbBackup.ts
@@ -1,0 +1,68 @@
+import { sleep } from "workflow"
+import type {
+  VideoDbBackupSchedulerInput,
+  VideoDbBackupWorkflowInput,
+} from "@/services/video-db-backup/job"
+import type { VideoDbBackupJobResult } from "@/scripts/video-db-backup"
+
+export async function runVideoDbBackup(
+  input: VideoDbBackupWorkflowInput = {},
+): Promise<VideoDbBackupJobResult> {
+  "use workflow"
+
+  return stepRunVideoDbBackup(input)
+}
+
+async function stepRunVideoDbBackup(
+  input: VideoDbBackupWorkflowInput,
+): Promise<VideoDbBackupJobResult> {
+  "use step"
+
+  const { runVideoDbBackupJob } = await import("@/services/video-db-backup/job")
+  return runVideoDbBackupJob(input)
+}
+
+export async function runVideoDbBackupScheduler(
+  input: VideoDbBackupSchedulerInput = {},
+): Promise<never> {
+  "use workflow"
+
+  await stepMarkSchedulerStarted(input)
+  await stepRunScheduledBackup()
+
+  while (true) {
+    const nextRunAt = await stepNextRunAt(input)
+    await sleep(nextRunAt)
+    await stepRunScheduledBackup()
+  }
+}
+
+async function stepMarkSchedulerStarted(
+  input: VideoDbBackupSchedulerInput,
+): Promise<void> {
+  "use step"
+
+  const { markVideoDbBackupSchedulerStarted } =
+    await import("@/services/video-db-backup/job")
+  await markVideoDbBackupSchedulerStarted(input)
+}
+
+async function stepNextRunAt(
+  input: VideoDbBackupSchedulerInput,
+): Promise<Date> {
+  "use step"
+
+  const { nextVideoDbBackupRunAt, recordVideoDbBackupSchedulerHeartbeat } =
+    await import("@/services/video-db-backup/job")
+  const nextRunAt = nextVideoDbBackupRunAt()
+  await recordVideoDbBackupSchedulerHeartbeat(input, nextRunAt)
+  return nextRunAt
+}
+
+async function stepRunScheduledBackup(): Promise<void> {
+  "use step"
+
+  const { runVideoDbBackupFromScheduler } =
+    await import("@/services/video-db-backup/job")
+  await runVideoDbBackupFromScheduler()
+}

--- a/docs/plans/2026-05-13-001-feat-admin-video-db-backup-clone-plan.md
+++ b/docs/plans/2026-05-13-001-feat-admin-video-db-backup-clone-plan.md
@@ -1,0 +1,159 @@
+---
+title: "Admin Video DB Backup and Clone"
+type: feat
+status: complete
+date: 2026-05-13
+origin: docs/roadmap/platform/feat-122-admin-video-database-backup-and-clone.md
+---
+
+# Admin Video DB Backup and Clone
+
+## Summary
+
+Create reviewed tooling for automatically backing up the admin production video
+data slice and manually restoring it into staging or local development. The
+backup path is non-interactive and can run on a Railway schedule with Doppler
+env vars. The restore path remains an explicit CLI command with
+target-environment guardrails.
+
+## Problem Frame
+
+Production video metadata now lives in admin Postgres. Developers need realistic
+video catalog data for search, playback, editorial flows, and embedding work,
+but full database clones are noisy and risky. A focused video slice should be
+easy to dump from production, move to staging/dev, and restore without including
+auth/session/workflow/editorial data.
+
+## Scope Boundaries
+
+In scope: admin Postgres video/reference table manifest, useworkflow-backed
+scheduled backup, S3-compatible backup upload, restore CLI, package scripts,
+unit tests, Railpack runtime PostgreSQL client tooling, roadmap/docs updates.
+
+Out of scope: dashboard UI, direct Railway API integration, retention pruning,
+auth/user/workflow/media asset data, cross-app CMS database backup.
+
+## Context And Patterns
+
+- `apps/admin/prisma/schema.prisma` maps Prisma models to snake-case Postgres
+  tables. The backup manifest should use DB table names, not model names.
+- `apps/admin/src/scripts/refresh-core-id-mapping.ts` is the closest operator
+  script pattern: direct env reads, child process execution, timeout-oriented
+  failure messages, and no dependency on the full admin runtime env matrix.
+- `docs/solutions/best-practices/verify-infra-writes-via-independent-read-path-20260420.md`
+  applies operationally: dry runs should reveal exact table/command intent
+  before a write path touches staging/dev.
+- `docs/solutions/best-practices/admin-postgres-workflow-operations-pattern-20260501.md`
+  keeps long-running production workflows separate from throwaway/local scripts.
+  The backup path runs as a Postgres World workflow job on the dedicated admin
+  worker; the restore path stays as operator CLI tooling.
+
+## Key Decisions
+
+- Use native PostgreSQL tools. `pg_dump`/`pg_restore` already understand table
+  dependencies and custom-format archives; wrapping them is safer than retyping
+  SQL export/import code.
+- Automate backup, not restore. Production backup should run unattended with
+  credentials supplied by the normal Railway S3 env vars. Restore is
+  intentionally operator-run because it truncates target tables.
+- Upload automated backups to the existing Railway S3 bucket when
+  `RAILWAY_S3_BUCKET` is configured. No backup-specific env vars are introduced
+  in this slice; a dedicated bucket/key family can be added later if needed.
+- Install PostgreSQL 18 client tools through the admin service's Railpack
+  variables. Production uses Railway PostgreSQL 18, and `pg_dump` refuses to
+  dump from a server newer than its own major version. Set
+  `RAILPACK_PACKAGES=postgres@18.1` and
+  `RAILPACK_BUILD_APT_PACKAGES=bison flex` on the admin Railway services so the
+  package requirement is scoped to admin instead of every Railway service in the
+  monorepo.
+- Start with data-only dumps. Target databases should already be migrated by
+  Prisma. This keeps schema ownership with `apps/admin/prisma/migrations/`.
+- Use fixed profiles instead of arbitrary `--table` passthrough. Operators can
+  choose `video-core` or `video-search`, but the reviewed manifest prevents
+  accidental auth/workflow data leakage.
+- Backup is automated only. Operators should not get a `backup:video-db` CLI;
+  the dedicated admin worker starts a durable useworkflow scheduler, and that
+  workflow performs the dump and upload.
+- Restore is destructive only for the selected manifest. It truncates selected
+  tables with `RESTART IDENTITY CASCADE` before `pg_restore`, so staging/local
+  gets a clean video slice without dropping schemas.
+
+## Implementation Units
+
+### Unit 1: Video Backup Manifest And Restore CLI Helpers
+
+Files:
+
+- Create `apps/admin/src/scripts/video-db-backup.ts`
+- Create `apps/admin/src/scripts/video-db-backup.test.ts`
+- Create `apps/admin/src/services/video-db-backup/job.ts`
+- Create `apps/admin/src/workflows/videoDbBackup.ts`
+
+Approach:
+
+- Define table profiles in one exported constant.
+- Add argument parsing for `--profile`, `--out`, `--in`, `--target-env`,
+  `--allow-production-target`, `--s3-key`, and `--dry-run`.
+- Build command argument arrays for `pg_dump`, `psql`, and `pg_restore`.
+- Build an optional S3 upload plan from Doppler/Railway env vars.
+- Export pure helpers so tests can assert command shape without shelling out.
+- Make `apps/admin/src/scripts/video-db-backup.ts` refuse direct execution;
+  backup is invoked only by the workflow job.
+- Add a useworkflow dispatcher and one workflow step that executes the
+  scheduled backup and updates the generic `workflow_run` ledger.
+
+Test Scenarios:
+
+- `video-core` expands to reference and video catalog tables but excludes scene
+  and transcript embedding tables.
+- `video-search` includes all `video-core` tables plus scene/transcript tables.
+- Invalid profiles and missing database URLs fail with clean errors.
+- Backup plans include an S3 destination when `RAILWAY_S3_BUCKET` and
+  credentials are present.
+- `@forge/admin` Railway service sets `RAILPACK_PACKAGES=postgres@18.1` so
+  `pg_dump`, `pg_restore`, and `psql` are available in scheduled runs.
+- Restore rejects `--target-env=production` unless `--allow-production-target`
+  is present.
+- Generated command args include `--format=custom`, `--data-only`, `--no-owner`,
+  `--no-acl`, and every selected table as a distinct argument.
+
+### Unit 2: Workflow Scheduler And Operator Docs
+
+Files:
+
+- Modify `apps/admin/src/instrumentation.ts`
+- Modify `apps/admin/package.json`
+- Modify `apps/admin/CLAUDE.md`
+- Modify `docs/roadmap/README.md`
+
+Approach:
+
+- Add only the `restore:video-db` operator script.
+- Start exactly one durable video backup scheduler workflow from a dedicated
+  admin worker service with `WORKFLOW_RUNNER_ENABLED=true`; the admin web
+  service leaves that flag unset or `false` so web replicas do not run jobs.
+- The scheduler workflow runs one backup immediately when first created, then
+  sleeps until the next daily UTC run, records normal backup ledger rows, and
+  loops.
+- Document the useworkflow scheduler boundary and the fact that no external
+  backup endpoint or CLI is required.
+- Add the feature to the platform roadmap index.
+
+Test Scenarios:
+
+- `pnpm --filter @forge/admin exec tsx src/scripts/video-db-backup.ts` refuses
+  to run backup directly.
+- `pnpm --filter @forge/admin restore:video-db -- --dry-run --target-env=development --in=...`
+  prints truncate and restore plan without connecting.
+
+## Verification
+
+Run:
+
+```bash
+pnpm --filter @forge/admin test src/scripts/video-db-backup.test.ts
+pnpm --filter @forge/admin typecheck
+pnpm --filter @forge/admin lint
+pnpm --filter @forge/admin exec tsx src/scripts/video-db-backup.ts
+TARGET_DATABASE_URL=postgresql://forge:forge@localhost:5433/forge_admin pnpm --filter @forge/admin restore:video-db -- --dry-run --target-env=development --in=.tmp/db-backups/example.dump
+```

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -112,6 +112,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-091](platform/feat-091-admin-dashboard-ui.md)                              | Build Forge admin dashboard UI                          | tataihono | P1       | 2026-04-14 | 2    | 2026-04-15 | complete    |
 | [feat-099](platform/feat-099-devcontainer-codex-install-and-vm-permissions.md)   | Devcontainer Codex Install And VM Permissions           | tataihono | P1       | 2026-04-15 | 1    | 2026-04-15 | complete    |
 | [feat-100](platform/feat-100-admin-video-and-media-editorial-workflows.md)       | Admin Video And Media Editorial Workflows               | tataihono | P1       | 2026-04-15 | 10   | 2026-04-24 | in-progress |
+| [feat-122](platform/feat-122-admin-video-database-backup-and-clone.md)           | Admin video database backup and clone tooling           | tataihono | P1       | 2026-05-13 | 5    | 2026-05-17 | complete    |
 | [feat-101](platform/feat-101-admin-experience-block-editor-parity.md)            | Admin Experience Block Editor Parity                    | tataihono | P1       | 2026-04-15 | 7    | 2026-04-21 | complete    |
 | [feat-102](platform/feat-102-dependabot-security-remediation.md)                 | Dependabot Security Remediation                         | tataihono | P1       | 2026-04-16 | 1    | 2026-04-16 | complete    |
 | [feat-103](platform/feat-103-admin-experience-editor-refinement.md)              | Admin Experience Editor Refinement                      | tataihono | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |

--- a/docs/roadmap/platform/feat-086-admin-app-graphql-postgres-foundation.md
+++ b/docs/roadmap/platform/feat-086-admin-app-graphql-postgres-foundation.md
@@ -13,6 +13,7 @@ blocks:
   - "feat-092"
   - "feat-093"
   - "feat-097"
+  - "feat-122"
 tags:
   - "platform"
   - "cms"

--- a/docs/roadmap/platform/feat-122-admin-video-database-backup-and-clone.md
+++ b/docs/roadmap/platform/feat-122-admin-video-database-backup-and-clone.md
@@ -1,0 +1,124 @@
+---
+id: "feat-122"
+title: "Admin video database backup and clone tooling"
+owner: "tataihono"
+priority: "P1"
+status: "complete"
+start_date: "2026-05-13"
+duration: 5
+depends_on:
+  - "feat-086"
+blocks: []
+tags:
+  - "admin"
+  - "infrastructure"
+  - "database"
+---
+
+## Problem
+
+Operators need an automated way to back up production Postgres data for the
+admin video catalog and a repeatable CLI path to clone that slice into staging
+or local development.
+Today the admin app has local operational scripts for Core sync, embeddings,
+and CMS dumps, but no reviewed table manifest or restore guardrails for
+production video data. Ad hoc dumps risk omitting dependent tables, restoring
+into the wrong database, or accidentally pulling far more data than a focused
+video workflow needs.
+
+## Entry Points — Read These First
+
+1. `apps/admin/prisma/schema.prisma` — canonical table names and dependencies
+   for `Video`, `VideoLocale`, `VideoDub`, `VideoSubtitle`, `VideoScene`,
+   `VideoTranscript`, and reference tables.
+2. `apps/admin/src/scripts/refresh-core-id-mapping.ts` — operator CLI pattern
+   with child-process timeout, clean stderr, and direct `process.env` reads.
+3. `apps/admin/src/scripts/pull-mapping-from-prod.ts` — production-read,
+   local-write script shape.
+4. `apps/admin/src/workflows/` — useworkflow jobs compiled by the SDK plugin.
+5. `apps/admin/package.json` — add discoverable restore script only.
+6. `apps/admin/CLAUDE.md` — admin operational script inventory.
+
+## Grep These
+
+```bash
+rg -n "^model (Video|VideoLocale|VideoDub|VideoSubtitle|VideoScene|VideoTranscript|Language|Country|Keyword|BibleBook|VideoEdition|MuxVideo)" apps/admin/prisma/schema.prisma
+rg -n "spawn\\(|execFile\\(|process.env.DATABASE_URL" apps/admin/src/scripts apps/admin/src/services
+rg -n "use workflow|dispatchCoreSync|createWorkflowRunLog" apps/admin/src/workflows apps/admin/src/services
+```
+
+## What To Build
+
+1. Add an admin-local table manifest for video backup profiles:
+   - `video-core`: reference tables plus video catalog tables required for
+     browsing, playback metadata, relations, dubs, subtitles, images, Bible
+     citations, and study questions.
+   - `video-search`: `video-core` plus scene and transcript embedding tables.
+   - `video-full`: alias for the largest reviewed video slice.
+2. Add a scheduled-only video DB backup job:
+   - Source URL from `SOURCE_DATABASE_URL` first, then `DATABASE_URL`.
+   - Output path defaults to a timestamped file under
+     `apps/admin/.tmp/db-backups/`.
+   - Uses `pg_dump --format=custom --data-only --no-owner --no-acl` with the
+     reviewed table manifest.
+   - Uploads to the normal Railway S3 bucket when `RAILWAY_S3_BUCKET` is
+     configured.
+   - Does not expose an operator `backup:video-db` CLI script.
+   - A dedicated admin worker service with `WORKFLOW_RUNNER_ENABLED=true`
+     starts Postgres World and ensures one durable
+     `src/workflows/videoDbBackup.ts` scheduler workflow is running. The admin
+     web service leaves that flag unset or `false`.
+   - The scheduler workflow performs one immediate backup when first created,
+     then sleeps until the next daily UTC run, performs the dump/upload work as
+     a workflow step, records status in the generic `workflow_run` ledger, and
+     loops.
+3. Add `restore:video-db`:
+   - Target URL from `TARGET_DATABASE_URL` first, then `DATABASE_URL`.
+   - Requires `--in=...`.
+   - Requires `--target-env=development` or `--target-env=staging` by default;
+     rejects production targets unless `--allow-production-target` is present.
+   - Truncates the selected manifest tables with `RESTART IDENTITY CASCADE`
+     before `pg_restore --data-only`.
+   - Supports `--dry-run`.
+4. Add PostgreSQL 18 client tools through the admin service's Railpack variables
+   so Railway scheduled runs have `pg_dump`, `pg_restore`, and `psql` available
+   without changing other monorepo services. Configure the `@forge/admin`
+   Railway services with `RAILPACK_PACKAGES=postgres@18.1` and
+   `RAILPACK_BUILD_APT_PACKAGES=bison flex`; do not place a root `railpack.json`
+   for this feature.
+5. Add focused unit tests for profile expansion, command arguments, env guards,
+   and restore safety behavior. Do not connect to a database in unit tests.
+
+## Constraints
+
+- Do not read `@/config/env` from the scripts; backup tooling must run with only
+  the database URL it needs.
+- Do not add a production restore path that can run by accident. Production
+  restore must require an explicit override flag and should not be the normal
+  documented path.
+- Do not dump auth/session/user tables, workflow runtime tables, media asset
+  editorial upload tables, or experience content in this first slice.
+- Use the normal Railway S3 env vars already managed through Doppler/Railway.
+  Do not add backup-specific env vars in this slice.
+- Backup is automated only. Do not add a package script that lets operators run
+  production backup manually from the CLI.
+- Use PostgreSQL 18 client tooling in the admin Railway container through
+  `RAILPACK_PACKAGES=postgres@18.1`. A `pg_dump` client older than the server
+  major version refuses to dump.
+- Verify the deployment details show the admin Railpack package setting was
+  applied.
+- Verify the production admin service starts the video backup scheduler workflow
+  after Postgres World starts, and that scheduled backup rows appear in
+  `/dashboard/workflows`.
+- Do not hand-edit generated Prisma client output.
+- Keep `pg_dump` and `pg_restore` invocation argument-array based; do not shell
+  interpolate database URLs.
+
+## Verification
+
+1. `pnpm --filter @forge/admin test src/scripts/video-db-backup.test.ts`
+2. `pnpm --filter @forge/admin typecheck`
+3. `pnpm --filter @forge/admin lint`
+4. `pnpm --filter @forge/admin exec tsx src/scripts/video-db-backup.ts` exits
+   non-zero and says backup is scheduled-only.
+5. `TARGET_DATABASE_URL=postgresql://forge:forge@localhost:5433/forge_admin pnpm --filter @forge/admin restore:video-db -- --dry-run --target-env=development --in=.tmp/db-backups/example.dump`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
 
   apps/admin:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: 3.1030.0
+        version: 3.1030.0
       '@better-auth/prisma-adapter':
         specifier: 1.6.2
         version: 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.1)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.3(typescript@5.9.3))
@@ -208,6 +211,9 @@ importers:
       tailwindcss:
         specifier: 4.2.2
         version: 4.2.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       workflow:
         specifier: ^4.2.2
         version: 4.2.2(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -215,9 +221,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@aws-sdk/client-s3':
-        specifier: 3.1030.0
-        version: 3.1030.0
       '@smithy/node-http-handler':
         specifier: 4.4.14
         version: 4.4.14
@@ -239,9 +242,6 @@ importers:
       eslint-config-next:
         specifier: ^16.1.6
         version: 16.1.6(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3


### PR DESCRIPTION
## Summary

- add reviewed video-table backup profiles plus a scheduled-only Postgres World backup workflow
- add a guarded restore CLI for local/staging video slice restores
- gate Postgres World startup behind `WORKFLOW_RUNNER_ENABLED` so the dedicated Railway worker runs jobs while admin web only serves traffic
- document the Railway worker/Railpack configuration, including PostgreSQL 18 client tooling and build packages

## Validation

- `pnpm --filter @forge/admin test src/instrumentation.test.ts src/scripts/video-db-backup.test.ts src/workflows/videoDbBackup.test.ts src/services/video-db-backup/job.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin exec tsx src/scripts/video-db-backup.ts` exits non-zero with scheduled-only message
- `TARGET_DATABASE_URL=postgresql://user:secret@localhost:5432/dev pnpm --filter @forge/admin restore:video-db -- --target-env=development --in=.tmp/video.dump --dry-run`

## Deployment Notes

The production Railway worker service is already created and configured. This PR is what gives that worker the scheduler code. After merge/deploy, verify `/dashboard/workflows` has the `video-db-backup-scheduler` ledger row and the first scheduled backup row.
