### PR TITLE
fix(web): polish data-layer-flip — render gaps, locale sync, slug-collision precedence

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1146,9 +1146,20 @@ description`, same `'simple'` config as cms, locale + status gate.
   (R2-indexed) is deliberately NOT fused. Strict cms parity during the
   R3→R8 window; adding a 5th RRF list for transcripts is a post-cutover
   follow-up that won't change the consumer contract.
-- **Experience imageUrl is null in R4.** cms parity. `ExperienceLocale.ogImageUrl`
-  exists on admin but wiring it is a deliberate post-cutover upgrade
-  so the pre-R8 diff-against-cms invariant holds.
+- **Video imageUrl resolves via LATERAL on `VideoImage`.** Both
+  retrievers (semantic + keyword) emit
+  `COALESCE(mobile_cinematic_high, url)` from the per-video
+  `video_image` row, matching cms's `keyword-search.ts:54` /
+  `semantic-search.ts:62` lookup. Earlier R4 doc claimed "imageUrl
+  is null for video corpus (cms parity)" — that was a regression,
+  not parity. cms's video retrievers DID populate `image_url` from
+  `video_images.mobile_cinematic_high`; only the experience side
+  defers the image join.
+- **Experience imageUrl is null in R4.** cms parity (cms's
+  experience retrievers also return null with comment "og_image
+  join deferred"). `ExperienceLocale.ogImageUrl` exists on admin
+  but wiring it is a deliberate post-cutover upgrade so the pre-R8
+  diff-against-cms invariant holds for the experience corpus.
 - **Degradation signal:** `searchMode: "hybrid" | "keyword-only"`. Set
   to `"keyword-only"` when the embedding provider throws. Structured
   log at error level: `[search] event=query_embedding_failure
@@ -1474,8 +1485,14 @@ shape drift.
   React key, so the cutover is a one-line TypeScript-type update on
   `apps/web/src/lib/recommendations.ts::SceneRecommendation`. Documented
   in plan §Key Technical Decisions #2.
-- **`imageUrl` is null** (cms parity stance inherited from R4). Wiring
-  a real `imageUrl` from `VideoImage` / MuxVideo thumbnail is a
+- **`imageUrl` is null in R5** (was claimed "cms parity inherited
+  from R4" but R4 was itself a regression — see R4's "Video imageUrl"
+  bullet above; cms's scene-recommendations DID populate `image_url`
+  via VideoImage LATERAL). Wiring R5 to match the R4 LATERAL JOIN
+  pattern is a parallel follow-up. Until then, scene-recommendation
+  thumbnails depend on consumer-side fallbacks (Mux thumbnail from
+  `playbackId`, gradient placeholder). Original note: wiring a real
+  `imageUrl` from `VideoImage` / MuxVideo thumbnail is a
   post-cutover upgrade so the pre-R8 diff-against-cms invariant holds.
 - **REST endpoint:** `GET /api/scene-embedding/recommendations`
   (singular) at `src/app/api/scene-embedding/recommendations/route.ts`.

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -850,8 +850,15 @@ model Video {
   keywords       VideoKeyword[]
   scenes         VideoScene[]
   transcripts    VideoTranscript[]
-  parents        VideoRelation[]      @relation("VideoChildren")
-  children       VideoRelation[]      @relation("VideoParents")
+  // Naming convention: `Video.parents` lists VideoRelation rows where
+  // THIS video is the CHILD (so accessing `.parent` on each row yields
+  // the actual parent video). `Video.children` is the reverse. Pair with
+  // VideoRelation.parent (`@relation("VideoParents")` on parentId) and
+  // VideoRelation.child (`@relation("VideoChildren")` on childId)
+  // respectively — the relation NAME on this side picks the column the
+  // *other* side stores, not the column this side describes.
+  parents        VideoRelation[]      @relation("VideoParents")
+  children       VideoRelation[]      @relation("VideoChildren")
 
   @@index([primaryLanguageId])
   @@index([originId])

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -850,15 +850,8 @@ model Video {
   keywords       VideoKeyword[]
   scenes         VideoScene[]
   transcripts    VideoTranscript[]
-  // Naming convention: `Video.parents` lists VideoRelation rows where
-  // THIS video is the CHILD (so accessing `.parent` on each row yields
-  // the actual parent video). `Video.children` is the reverse. Pair with
-  // VideoRelation.parent (`@relation("VideoParents")` on parentId) and
-  // VideoRelation.child (`@relation("VideoChildren")` on childId)
-  // respectively — the relation NAME on this side picks the column the
-  // *other* side stores, not the column this side describes.
-  parents        VideoRelation[]      @relation("VideoParents")
-  children       VideoRelation[]      @relation("VideoChildren")
+  parents        VideoRelation[]      @relation("VideoChildren")
+  children       VideoRelation[]      @relation("VideoParents")
 
   @@index([primaryLanguageId])
   @@index([originId])

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -37,6 +37,7 @@ describe("searchVideoSemantic", () => {
         video_core_id: "1_Jesus",
         video_slug: "jesus",
         video_title: "Jesus",
+        image_url: "https://images.example/jesus.jpg",
         scene_description: "Peter denies Jesus",
         start_seconds: 42.5,
         playback_id: "mux-abc",
@@ -58,7 +59,7 @@ describe("searchVideoSemantic", () => {
       videoCoreId: "1_Jesus",
       videoSlug: "jesus",
       videoTitle: "Jesus",
-      imageUrl: null,
+      imageUrl: "https://images.example/jesus.jpg",
       sceneDescription: "Peter denies Jesus",
       startSeconds: 42.5,
       playbackId: "mux-abc",
@@ -74,6 +75,7 @@ describe("searchVideoSemantic", () => {
         video_core_id: null,
         video_slug: "x",
         video_title: "X",
+        image_url: null,
         scene_description: "d",
         start_seconds: 0,
         playback_id: null,
@@ -90,6 +92,7 @@ describe("searchVideoSemantic", () => {
 
     expect(rows[0]!.playbackId).toBeNull()
     expect(rows[0]!.videoCoreId).toBeNull()
+    expect(rows[0]!.imageUrl).toBeNull()
   })
 
   it("coerces Postgres numeric columns to JS number", async () => {
@@ -100,6 +103,7 @@ describe("searchVideoSemantic", () => {
         video_core_id: null,
         video_slug: "",
         video_title: "",
+        image_url: null,
         scene_description: "",
         start_seconds: "7" as unknown as number,
         playback_id: null,
@@ -143,6 +147,7 @@ describe("searchVideoKeyword", () => {
         video_core_id: "1_Jesus",
         video_slug: "jesus",
         video_title: "Jesus",
+        image_url: "https://images.example/jesus.jpg",
         description: "Film about Jesus",
         rank: 0.0913,
       },
@@ -157,7 +162,7 @@ describe("searchVideoKeyword", () => {
     expect(rows[0]).toMatchObject({
       resultType: "video",
       resultId: "vid-1",
-      imageUrl: null,
+      imageUrl: "https://images.example/jesus.jpg",
       description: "Film about Jesus",
       rank: 0.0913,
     })

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -12,8 +12,12 @@
  * - `resultId` is a cuid string for both corpora (admin-native). For
  *   experience rows it's the `ExperienceLocale.id` (see inline comment
  *   on searchExperienceSemantic for why).
- * - `imageUrl` is `null` for both corpora in R4 (cms parity). Wiring
- *   `ExperienceLocale.ogImageUrl` is a deliberate post-R8 follow-up.
+ * - Video retrievers resolve `imageUrl` via LATERAL on `VideoImage`,
+ *   matching cms's `keyword-search.ts` / `semantic-search.ts` lookup
+ *   over `video_images_video_lnk → video_images.mobile_cinematic_high`.
+ *   Experience retrievers still return `imageUrl: null` (cms parity —
+ *   cms's experience retrievers also defer the og_image join); wiring
+ *   `ExperienceLocale.ogImageUrl` is a post-R8 follow-up.
  * - Semantic-video exposes `embedding_text` so the 3-layer dedup can
  *   recompute cosine similarity across survivors. This field is a
  *   service-internal transport only; the schema.test.ts
@@ -56,7 +60,7 @@ export type VideoSemanticResult = RankedItem & {
   videoCoreId: string | null
   videoSlug: string
   videoTitle: string
-  imageUrl: null
+  imageUrl: string | null
   sceneDescription: string
   startSeconds: number
   playbackId: string | null
@@ -70,7 +74,7 @@ export type VideoKeywordResult = RankedItem & {
   videoCoreId: string | null
   videoSlug: string
   videoTitle: string
-  imageUrl: null
+  imageUrl: string | null
   description: string | null
   rank: number
 }
@@ -104,6 +108,7 @@ type VideoSemanticRow = {
   video_core_id: string | null
   video_slug: string | null
   video_title: string | null
+  image_url: string | null
   scene_description: string
   start_seconds: number
   playback_id: string | null
@@ -116,6 +121,7 @@ type VideoKeywordRow = {
   video_core_id: string | null
   video_slug: string | null
   video_title: string | null
+  image_url: string | null
   description: string | null
   rank: number
 }
@@ -169,6 +175,7 @@ export async function searchVideoSemantic(
         v.core_id                         AS video_core_id,
         v.slug                            AS video_slug,
         vl.title                          AS video_title,
+        COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
         vsl.description                   AS scene_description,
         vs.start_seconds                  AS start_seconds,
         dub_mux.playback_id               AS playback_id,
@@ -194,6 +201,14 @@ export async function searchVideoSemantic(
         ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
         LIMIT 1
       ) dub_mux ON true
+      LEFT JOIN LATERAL (
+        SELECT vi2.mobile_cinematic_high, vi2.url
+        FROM video_image vi2
+        WHERE vi2.video_id = v.id
+          AND vi2.deleted_at IS NULL
+        ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
+        LIMIT 1
+      ) vi ON true
       WHERE vsl.embedding IS NOT NULL
         AND vsl.locale = ${locale}
       ORDER BY vs.video_id, vsl.embedding <=> ${queryEmbedding}::vector
@@ -208,7 +223,7 @@ export async function searchVideoSemantic(
     videoCoreId: row.video_core_id,
     videoSlug: row.video_slug ?? "",
     videoTitle: row.video_title ?? "",
-    imageUrl: null,
+    imageUrl: row.image_url ?? null,
     sceneDescription: row.scene_description,
     startSeconds: Number(row.start_seconds),
     playbackId: row.playback_id,
@@ -244,6 +259,7 @@ export async function searchVideoKeyword(
         v.core_id      AS video_core_id,
         v.slug         AS video_slug,
         vl.title       AS video_title,
+        COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
         vl.description AS description,
         ts_rank(
           ${tsvector},
@@ -252,6 +268,14 @@ export async function searchVideoKeyword(
       FROM video_locale vl
       JOIN video v ON v.id = vl.video_id
         AND v.deleted_at IS NULL
+      LEFT JOIN LATERAL (
+        SELECT vi2.mobile_cinematic_high, vi2.url
+        FROM video_image vi2
+        WHERE vi2.video_id = v.id
+          AND vi2.deleted_at IS NULL
+        ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
+        LIMIT 1
+      ) vi ON true
       WHERE ${tsvector} @@ plainto_tsquery('simple', ${trimmed})
         AND vl.locale = ${locale}
         AND vl.status = 'published'
@@ -267,7 +291,7 @@ export async function searchVideoKeyword(
     videoCoreId: row.video_core_id,
     videoSlug: row.video_slug ?? "",
     videoTitle: row.video_title ?? "",
-    imageUrl: null,
+    imageUrl: row.image_url ?? null,
     description: row.description,
     rank: Number(row.rank),
   }))

--- a/apps/web/src/app/[slug]/[locale]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[slug]/[locale]/__tests__/page-routing.test.tsx
@@ -96,7 +96,14 @@ afterEach(() => {
   container.remove()
 })
 
-function makeWatchVideoResult(label: string) {
+function makeWatchVideoResult(
+  label: string,
+  variantLang: { slug: string; bcp47: string; name: string } = {
+    slug: "english",
+    bcp47: "en",
+    name: "English",
+  },
+) {
   return {
     video: {
       documentId: "v1",
@@ -112,7 +119,7 @@ function makeWatchVideoResult(label: string) {
       documentId: "var1",
       hls: "https://cdn.example/storyclubs.m3u8",
       muxVideo: { playbackId: "pb1" },
-      language: { slug: "english", name: "English" },
+      language: variantLang,
       published: true,
       duration: 30,
       downloads: [],
@@ -236,8 +243,14 @@ describe("SlugLocalePage routing — passes correct props to SeriesPageClient", 
     // returns false, so the bcp47-normalised value would collapse to
     // DEFAULT_LOCALE ("en") and the combobox/globe modal would render
     // English instead of the user's actual selection. The page must
-    // forward rawLocale into SeriesPageClient.
-    const watchVideo = makeWatchVideoResult("collection")
+    // forward rawLocale into SeriesPageClient. Variant carries the
+    // matching slug-form language so the URL-↔-variant sync redirect
+    // does not fire and rewrite the URL to "english".
+    const watchVideo = makeWatchVideoResult("collection", {
+      slug: "spanish-castilian",
+      bcp47: "es",
+      name: "Spanish, Castilian",
+    })
     resolveWatchVideoBySlugMock.mockResolvedValue(watchVideo)
     await renderPage("storyclubs", "spanish-castilian")
     const args = seriesPageClientMock.mock.calls[0]?.[0]

--- a/apps/web/src/app/[slug]/[locale]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[slug]/[locale]/__tests__/page-routing.test.tsx
@@ -80,6 +80,14 @@ beforeEach(() => {
   resolveWatchVideoBySlugMock.mockReset()
   resolveSeriesBySlugMock.mockReset()
   resolveWatchPageMock.mockReset()
+  // Default: no Experience curated for the slug. The page now consults
+  // resolveWatchPage up-front to honor Experience precedence over slug-
+  // colliding videos; tests that want to override this set their own
+  // mockResolvedValue. The error sentinel matches isWatchPageMissingError.
+  resolveWatchPageMock.mockResolvedValue({
+    data: null,
+    error: new Error("No experience found"),
+  })
   seriesPageClientMock.mockClear()
   watchPageClientMock.mockClear()
   experienceEmptyMock.mockClear()
@@ -188,6 +196,46 @@ describe("SlugLocalePage routing — series branch", () => {
     await renderPage("jesus", "en")
     expect(watchPageClientMock).toHaveBeenCalledTimes(1)
     expect(seriesPageClientMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("SlugLocalePage routing — Experience precedence", () => {
+  it("renders Experience and skips video resolver when an Experience exists for the slug", async () => {
+    // Slug "easter" exists as BOTH a COLLECTION-labeled Video and a
+    // curated Experience. The Experience is the editor's intended
+    // landing and must win.
+    resolveWatchPageMock.mockResolvedValue({
+      data: {
+        kind: "experience",
+        experience: {
+          id: "exp-1",
+          slug: "easter",
+          title: "Easter",
+          blocks: [{ __typename: "TextBlock", id: "blk-1", text: "Hello" }],
+        },
+      },
+      error: null,
+    })
+    resolveWatchVideoBySlugMock.mockResolvedValue(
+      makeWatchVideoResult("collection"),
+    )
+    await renderPage("easter", "en")
+    expect(seriesPageClientMock).not.toHaveBeenCalled()
+    expect(watchPageClientMock).not.toHaveBeenCalled()
+    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
+  })
+
+  it("falls through to video resolver when Experience exists but has no blocks", async () => {
+    resolveWatchPageMock.mockResolvedValue({
+      data: {
+        kind: "experience",
+        experience: { id: "exp-1", slug: "x", title: "X", blocks: [] },
+      },
+      error: null,
+    })
+    await renderPage("x", "en")
+    expect(experienceEmptyMock).toHaveBeenCalledTimes(1)
+    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/app/[slug]/[locale]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[slug]/[locale]/__tests__/page-routing.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@/components/ExperienceError", () => ({
 }))
 
 vi.mock("@/components/sections", () => ({
-  SectionRenderer: vi.fn(() => null),
+  ExperienceSectionRenderer: vi.fn(() => null),
 }))
 
 import SlugLocalePage from "@/app/[slug]/[locale]/page"

--- a/apps/web/src/app/[slug]/[locale]/page.tsx
+++ b/apps/web/src/app/[slug]/[locale]/page.tsx
@@ -1,4 +1,5 @@
-import type { Metadata } from "next"
+import type { Metadata, Route } from "next"
+import { redirect } from "next/navigation"
 import { isLocale, DEFAULT_LOCALE } from "@/lib/locale"
 import {
   isSeriesRecord,
@@ -98,6 +99,18 @@ export default async function SlugLocalePage({ params }: PageProps) {
   // non-bcp47-locale URL — exactly what the language switcher writes.
   const watchVideo = await resolveWatchVideoBySlug(slug, rawLocale)
   if (watchVideo) {
+    // URL ↔ rendered-variant sync: the resolver's variant chain falls back
+    // to primary/first-playable when no dub matches `rawLocale`. Without
+    // this redirect the URL says e.g. /afrikaans while the page renders
+    // English. The `_lr` sentinel breaks the proxy's cookie redirect loop
+    // (see apps/web/src/proxy.ts — `?_lr=1` skips the language-preference
+    // override); `WatchPageClient` strips the param post-hydration so the
+    // user-visible URL stays clean.
+    const actualSlug = watchVideo.selectedVariant.language?.slug ?? null
+    const actualBcp47 = watchVideo.selectedVariant.language?.bcp47 ?? null
+    if (actualSlug && rawLocale !== actualSlug && rawLocale !== actualBcp47) {
+      redirect(`/${slug}/${actualSlug}?_lr=1` as Route)
+    }
     if (isSeriesRecord(watchVideo.video)) {
       // Series with a playable trailer: render the series page using the
       // record + the trailer variant. SeriesPageClient's hero will mount

--- a/apps/web/src/app/[slug]/[locale]/page.tsx
+++ b/apps/web/src/app/[slug]/[locale]/page.tsx
@@ -88,7 +88,37 @@ export default async function SlugLocalePage({ params }: PageProps) {
   const { slug, locale: rawLocale } = await params
   const locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE
 
-  // Video-by-slug first — bypasses resolveWatchPage's Watch Settings +
+  // Experience-first precedence: when an editor has curated an Experience
+  // at this slug, that's the intended landing — even when a slug-colliding
+  // Video (e.g., a COLLECTION-labeled `easter` Video alongside an `easter`
+  // Experience) exists. Without this short-circuit the video resolver
+  // below would catch first and render the slug as a series page.
+  // `resolveWatchPage` is React `cache()`-wrapped, so the second call at
+  // the tail of this function for the video-template fallback is free.
+  const watchPage = await resolveWatchPage(locale, slug)
+  if (watchPage.data?.kind === "experience") {
+    const blocks = (watchPage.data.experience.blocks ?? []).filter(
+      (b): b is Section => b !== null,
+    )
+    if (blocks.length) {
+      return (
+        <main className="min-h-screen bg-stone-900">
+          {blocks.map((block, i) => {
+            const key =
+              "id" in block && typeof block.id === "string"
+                ? block.id
+                : `block-${i}`
+            return (
+              <SectionRenderer key={key} section={block} routeVideo={null} />
+            )
+          })}
+        </main>
+      )
+    }
+    return <ExperienceEmpty />
+  }
+
+  // Video-by-slug second — bypasses resolveWatchPage's Watch Settings +
   // default template dependency, which isn't always present in dev.
   //
   // Pass rawLocale (not the bcp47-normalised `locale`): the resolver picks

--- a/apps/web/src/app/[slug]/[locale]/page.tsx
+++ b/apps/web/src/app/[slug]/[locale]/page.tsx
@@ -13,7 +13,7 @@ import {
   generateSeriesMetadata,
   getWatchPageMetadata,
 } from "@/lib/experience-metadata"
-import { SectionRenderer, type Section } from "@/components/sections"
+import { ExperienceSectionRenderer, type Section } from "@/components/sections"
 import { ExperienceEmpty } from "@/components/ExperienceEmpty"
 import { ExperienceError } from "@/components/ExperienceError"
 import { SeriesPageClient } from "@/components/watch/SeriesPageClient"
@@ -109,7 +109,11 @@ export default async function SlugLocalePage({ params }: PageProps) {
                 ? block.id
                 : `block-${i}`
             return (
-              <SectionRenderer key={key} section={block} routeVideo={null} />
+              <ExperienceSectionRenderer
+                key={key}
+                section={block}
+                routeVideo={null}
+              />
             )
           })}
         </main>
@@ -225,7 +229,11 @@ export default async function SlugLocalePage({ params }: PageProps) {
             ? block.id
             : `block-${i}`
         return (
-          <SectionRenderer key={key} section={block} routeVideo={routeVideo} />
+          <ExperienceSectionRenderer
+            key={key}
+            section={block}
+            routeVideo={routeVideo}
+          />
         )
       })}
     </main>

--- a/apps/web/src/app/[slug]/[locale]/page.tsx
+++ b/apps/web/src/app/[slug]/[locale]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Route } from "next"
 import { redirect } from "next/navigation"
-import { isLocale, DEFAULT_LOCALE } from "@/lib/locale"
+import { DEFAULT_LOCALE, LOCALE_RESOLVED_PARAM, isLocale } from "@/lib/locale"
 import {
   isSeriesRecord,
   isWatchPageMissingError,
@@ -139,7 +139,7 @@ export default async function SlugLocalePage({ params }: PageProps) {
     const actualSlug = watchVideo.selectedVariant.language?.slug ?? null
     const actualBcp47 = watchVideo.selectedVariant.language?.bcp47 ?? null
     if (actualSlug && rawLocale !== actualSlug && rawLocale !== actualBcp47) {
-      redirect(`/${slug}/${actualSlug}?_lr=1` as Route)
+      redirect(`/${slug}/${actualSlug}?${LOCALE_RESOLVED_PARAM}=1` as Route)
     }
     if (isSeriesRecord(watchVideo.video)) {
       // Series with a playable trailer: render the series page using the

--- a/apps/web/src/app/[slug]/page.tsx
+++ b/apps/web/src/app/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import { DEFAULT_LOCALE, isLocale } from "@/lib/locale"
 import { isWatchPageMissingError, resolveWatchPage } from "@/lib/content"
 import { getWatchPageMetadata } from "@/lib/experience-metadata"
-import { SectionRenderer, type Section } from "@/components/sections"
+import { ExperienceSectionRenderer, type Section } from "@/components/sections"
 import { ExperienceEmpty } from "@/components/ExperienceEmpty"
 import { ExperienceError } from "@/components/ExperienceError"
 
@@ -59,7 +59,11 @@ export default async function SlugPage({ params }: PageProps) {
             ? block.id
             : `block-${i}`
         return (
-          <SectionRenderer key={key} section={block} routeVideo={routeVideo} />
+          <ExperienceSectionRenderer
+            key={key}
+            section={block}
+            routeVideo={routeVideo}
+          />
         )
       })}
     </main>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import { DEFAULT_LOCALE } from "@/lib/locale"
 import { isWatchPageMissingError, resolveWatchPage } from "@/lib/content"
 import { getWatchPageMetadata } from "@/lib/experience-metadata"
-import { SectionRenderer, type Section } from "@/components/sections"
+import { ExperienceSectionRenderer, type Section } from "@/components/sections"
 import { ExperienceEmpty } from "@/components/ExperienceEmpty"
 import { ExperienceError } from "@/components/ExperienceError"
 
@@ -40,7 +40,11 @@ export default async function HomePage() {
             ? block.id
             : `block-${i}`
         return (
-          <SectionRenderer key={key} section={block} routeVideo={routeVideo} />
+          <ExperienceSectionRenderer
+            key={key}
+            section={block}
+            routeVideo={routeVideo}
+          />
         )
       })}
     </main>

--- a/apps/web/src/components/SearchOverlay.tsx
+++ b/apps/web/src/components/SearchOverlay.tsx
@@ -130,7 +130,7 @@ export function SearchOverlay() {
       aria-modal="true"
       aria-label="Search and browse videos"
       onClick={() => closeAndKeepQuery()}
-      className={`fixed inset-0 flex flex-col ${closing ? "animate-overlay-fade-out" : "animate-overlay-fade-in"}`}
+      className={`fixed inset-0 overflow-hidden ${closing ? "animate-overlay-fade-out" : "animate-overlay-fade-in"}`}
       style={{
         zIndex: 9999,
         backgroundColor: "rgba(0, 0, 0, 0.75)",
@@ -138,12 +138,16 @@ export function SearchOverlay() {
         WebkitBackdropFilter: "blur(12px)",
       }}
     >
-      {/* Top bar: input is viewport-centered via mx-auto; mobile logo and
-          close button are absolutely positioned so they don't push the input
-          off-center. Outer padding (px-4 sm:px-6) matches the floating
-          searchbar's side margin (w-[calc(100%-2rem)] sm:w-[calc(100%-3rem)])
-          so the input's position and size on open match the bar's exactly. */}
-      <div className="relative shrink-0 px-4 pt-6 sm:px-6 sm:pt-10">
+      {/* Floating top bar: input is viewport-centered via mx-auto; mobile
+          logo and close button are absolutely positioned so they don't push
+          the input off-center. Outer padding (px-4 sm:px-6) matches the
+          floating searchbar's side margin (w-[calc(100%-2rem)]
+          sm:w-[calc(100%-3rem)]) so the input's position and size on open
+          match the bar's exactly. The wrapper is `pointer-events-none` so
+          scroll wheel events over the empty edges pass through to the
+          body; the pill + logo + close button re-enable pointer events
+          on themselves. */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 px-4 pt-6 sm:px-6 sm:pt-10">
         <Link
           href={"/" as Route}
           aria-label="JesusFilm home"
@@ -154,7 +158,7 @@ export function SearchOverlay() {
             e.stopPropagation()
             void search("")
           }}
-          className="absolute left-4 top-[30px] z-10 flex items-center rounded-full p-1 sm:hidden focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2"
+          className="pointer-events-auto absolute left-4 top-[30px] z-10 flex items-center rounded-full p-1 sm:hidden focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2"
         >
           <Image
             src="/watch/images/jesusfilm-sign.svg"
@@ -168,7 +172,7 @@ export function SearchOverlay() {
           role="search"
           aria-label="Search videos"
           onClick={(e) => e.stopPropagation()}
-          className="relative mx-auto w-full max-w-[810px]"
+          className="pointer-events-auto relative mx-auto w-full max-w-[810px]"
         >
           <input
             ref={inputRef}
@@ -210,7 +214,7 @@ export function SearchOverlay() {
             closeAndKeepQuery()
           }}
           aria-label="Close search"
-          className="absolute right-2 top-[18px] z-10 rounded-full p-3 text-stone-400 transition hover:text-white focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2 sm:right-4 sm:top-[34px]"
+          className="pointer-events-auto absolute right-2 top-[18px] z-10 rounded-full p-3 text-stone-400 transition hover:text-white focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2 sm:right-4 sm:top-[34px]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -229,9 +233,12 @@ export function SearchOverlay() {
         </button>
       </div>
 
-      {/* Body: category grid when empty, results grid when queried */}
+      {/* Body: category grid when empty, results grid when queried.
+          Fills the entire dialog so the floating bar can sit ABOVE it
+          with backdrop-blur — `pt-24 sm:pt-32` clears the bar's height
+          (input ≈48px + bar pt-6/pt-10 + breathing room). */}
       <div
-        className="search-overlay-scroll min-h-0 flex-1 overflow-y-auto px-4 pb-8 pt-6 sm:px-6"
+        className="search-overlay-scroll absolute inset-0 overflow-y-auto px-4 pb-8 pt-24 sm:px-6 sm:pt-32"
         aria-live="polite"
       >
         <div

--- a/apps/web/src/components/search/VideoCard.tsx
+++ b/apps/web/src/components/search/VideoCard.tsx
@@ -37,11 +37,30 @@ function gradientForSlug(slug: string): string {
   return EXPERIENCE_PLACEHOLDER_GRADIENTS[index]
 }
 
+// Admin's hybrid-search response sets `imageUrl: null` until R8 wires
+// real ogImage / VideoImage; `playbackId` is reliably populated for
+// video results (INNER JOIN on dub/mux at the retriever), so the Mux
+// thumbnail endpoint gives us a frame-accurate poster — and when the
+// match is scene-level, `startSeconds` lets us land on the matched scene.
+function muxSearchThumbnail(
+  playbackId: string,
+  startSeconds: number | null,
+): string {
+  const time = startSeconds != null ? `&time=${startSeconds}` : ""
+  return `https://image.mux.com/${playbackId}/thumbnail.jpg?width=448&height=336&fit_mode=smartcrop${time}`
+}
+
 export function VideoCard({
   result,
   index = 0,
   hrefBuilder = defaultHrefBuilder,
 }: VideoCardProps) {
+  const thumbnailSrc =
+    result.imageUrl ??
+    (result.type === "video" && result.playbackId
+      ? muxSearchThumbnail(result.playbackId, result.startSeconds)
+      : null)
+
   return (
     <Link
       href={hrefBuilder(result)}
@@ -50,9 +69,9 @@ export function VideoCard({
     >
       {/* Full-bleed thumbnail */}
       <div className="relative aspect-[4/3] w-full overflow-hidden bg-stone-800">
-        {result.imageUrl ? (
+        {thumbnailSrc ? (
           <Image
-            src={result.imageUrl}
+            src={thumbnailSrc}
             alt={result.title ?? "Video thumbnail"}
             fill
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"

--- a/apps/web/src/components/sections/Container.tsx
+++ b/apps/web/src/components/sections/Container.tsx
@@ -16,11 +16,6 @@ import { MediaCollection } from "./MediaCollection"
 import { CTASection } from "./CTASection"
 import { Video } from "./Video"
 import { RelatedQuestions } from "./RelatedQuestions"
-import { ADMIN_BLOCK_TYPENAMES, renderAdminBlock } from "./index"
-
-type AnyBlock = {
-  readonly __typename?: string | null
-} & Record<string, unknown>
 
 export { containerFragment }
 
@@ -76,7 +71,9 @@ function SlotContentRenderer({
   routeVideo?: RouteVideo | null
 }) {
   if (!item || item.__typename === "Error") return null
-  switch (item.__typename) {
+  // Cast to broader string so the admin typename cases below (which
+  // are not in the Strapi-derived discriminated union) type-check.
+  switch (item.__typename as string) {
     case "ComponentSectionsText":
       return (
         <Text
@@ -121,26 +118,121 @@ function SlotContentRenderer({
           data={item as unknown as FragmentOf<typeof relatedQuestionsFragment>}
         />
       )
-    default: {
-      // Admin typenames (TextBlock, EasterDatesBlock, VideoBlock, etc.)
-      // arrive here when a ContainerSlot composes admin-shape blocks.
-      // Strapi-era cases above only know `ComponentSections*` typenames;
-      // fall back to the top-level admin dispatch so nested admin blocks
-      // render correctly inside container slots.
-      const typename = (item as { __typename?: string | null }).__typename
-      if (typename != null && ADMIN_BLOCK_TYPENAMES.has(typename)) {
-        return renderAdminBlock(item as unknown as AnyBlock, routeVideo)
-      }
+    // Admin GraphQL typenames inlined directly (rather than bouncing
+    // through `renderAdminBlock` in `./index`) to avoid an import cycle —
+    // `index.tsx` already imports `Container.tsx`, so the reverse import
+    // resolves undefined at module load.
+    case "TextBlock":
+      return (
+        <Text
+          data={item as unknown as FragmentOf<typeof textSectionFragment>}
+        />
+      )
+    case "EasterDatesBlock":
+      return (
+        <EasterDates
+          data={item as unknown as FragmentOf<typeof easterDatesFragment>}
+        />
+      )
+    case "AdventCountdownBlock":
+      return (
+        <AdventCountdown
+          data={item as unknown as FragmentOf<typeof adventCountdownFragment>}
+        />
+      )
+    case "MediaCollectionBlock":
+      return (
+        <MediaCollection
+          data={item as unknown as FragmentOf<typeof mediaCollectionFragment>}
+          routeVideo={routeVideo}
+        />
+      )
+    case "CtaBlock":
+      return (
+        <CTASection
+          data={item as unknown as FragmentOf<typeof ctaSectionFragment>}
+        />
+      )
+    case "VideoBlock":
+      return (
+        <Video
+          data={item as unknown as FragmentOf<typeof videoSectionFragment>}
+          routeVideo={routeVideo}
+        />
+      )
+    case "RelatedQuestionsBlock":
+      return (
+        <RelatedQuestions
+          data={item as unknown as FragmentOf<typeof relatedQuestionsFragment>}
+        />
+      )
+    default:
       return null
-    }
   }
 }
 
+/**
+ * Group admin's flat `content[]` by `ContainerSlotBlock` markers.
+ * Items appearing AFTER a slot marker (until the next marker) belong
+ * to that slot. Items before the first marker are silently dropped —
+ * admin's editor always emits a leading slot marker per the Zod
+ * domain schema, and a stray leading orphan is malformed data.
+ */
+function groupAdminContentBySlot(
+  content: readonly (Record<string, unknown> | null)[],
+): { gridSpan: number; spans: unknown; items: Record<string, unknown>[] }[] {
+  const groups: ReturnType<typeof groupAdminContentBySlot> = []
+  let current: (typeof groups)[number] | null = null
+  for (const item of content) {
+    if (!item) continue
+    const typename = (item as { __typename?: string | null }).__typename
+    const t = (item as { t?: string }).t
+    if (typename === "ContainerSlotBlock" || t === "containerSlot") {
+      const gridSpan = clampSpan((item as { gridSpan?: unknown }).gridSpan)
+      current = {
+        gridSpan,
+        spans: (item as { spans?: unknown }).spans,
+        items: [],
+      }
+      groups.push(current)
+      continue
+    }
+    if (current) current.items.push(item)
+  }
+  return groups
+}
+
 export function Container({ data, routeVideo }: ContainerProps) {
-  const { id, slots } = data
-  const validSlots =
-    slots?.filter((s): s is NonNullable<typeof s> => s != null) ?? []
-  if (!validSlots.length) return null
+  const id = (data as { id?: string | null }).id
+  const legacySlots = (data as { slots?: readonly unknown[] | null }).slots
+  const adminContent = (data as { content?: readonly unknown[] | null }).content
+
+  // Strapi-era data has `slots[].content[]`; admin's flat shape is
+  // `content[]` with `ContainerSlotBlock` markers. Normalize both into a
+  // common groups array so the rendering path is single.
+  const groups: { gridSpan: number; spans: unknown; items: unknown[] }[] =
+    legacySlots && legacySlots.length > 0
+      ? (legacySlots
+          .filter((s): s is NonNullable<typeof s> => s != null)
+          .map((s) => {
+            const slot = s as {
+              gridSpan?: unknown
+              spans?: unknown
+              content?: readonly unknown[]
+              id?: string
+            }
+            return {
+              gridSpan: clampSpan(slot.gridSpan),
+              spans: slot.spans,
+              items: (slot.content ?? []).filter(Boolean) as unknown[],
+            }
+          }) as never)
+      : adminContent
+        ? groupAdminContentBySlot(
+            adminContent as readonly (Record<string, unknown> | null)[],
+          )
+        : []
+  if (!groups.length) return null
 
   return (
     <section
@@ -148,13 +240,16 @@ export function Container({ data, routeVideo }: ContainerProps) {
       className="grid w-full grid-cols-12 gap-10 py-8 text-stone-100 md:gap-6"
       data-testid="Container"
     >
-      {validSlots.map((slot) => (
+      {groups.map((group, idx) => (
         <div
-          key={slot.id}
+          key={`slot-${idx}`}
           className="min-w-0 space-y-10 [grid-column:span_var(--slot-xs)_/_span_var(--slot-xs)] sm:[grid-column:span_var(--slot-sm)_/_span_var(--slot-sm)] md:space-y-6 md:[grid-column:span_var(--slot-md)_/_span_var(--slot-md)] lg:[grid-column:span_var(--slot-lg)_/_span_var(--slot-lg)] xl:[grid-column:span_var(--slot-xl)_/_span_var(--slot-xl)]"
-          style={slotSpanStyle(slot)}
+          style={slotSpanStyle({
+            gridSpan: group.gridSpan,
+            spans: group.spans,
+          } as unknown as Slot)}
         >
-          {slot.content?.map((item, index) => {
+          {group.items.map((item, index) => {
             if (
               !item ||
               (item as { __typename?: string }).__typename === "Error"
@@ -163,7 +258,7 @@ export function Container({ data, routeVideo }: ContainerProps) {
             }
             return (
               <SlotContentRenderer
-                key={`${slot.id}-${index}`}
+                key={`slot-${idx}-${index}`}
                 item={item as SlotContentItem}
                 routeVideo={routeVideo}
               />

--- a/apps/web/src/components/sections/Container.tsx
+++ b/apps/web/src/components/sections/Container.tsx
@@ -16,6 +16,11 @@ import { MediaCollection } from "./MediaCollection"
 import { CTASection } from "./CTASection"
 import { Video } from "./Video"
 import { RelatedQuestions } from "./RelatedQuestions"
+import { ADMIN_BLOCK_TYPENAMES, renderAdminBlock } from "./index"
+
+type AnyBlock = {
+  readonly __typename?: string | null
+} & Record<string, unknown>
 
 export { containerFragment }
 
@@ -116,8 +121,18 @@ function SlotContentRenderer({
           data={item as unknown as FragmentOf<typeof relatedQuestionsFragment>}
         />
       )
-    default:
+    default: {
+      // Admin typenames (TextBlock, EasterDatesBlock, VideoBlock, etc.)
+      // arrive here when a ContainerSlot composes admin-shape blocks.
+      // Strapi-era cases above only know `ComponentSections*` typenames;
+      // fall back to the top-level admin dispatch so nested admin blocks
+      // render correctly inside container slots.
+      const typename = (item as { __typename?: string | null }).__typename
+      if (typename != null && ADMIN_BLOCK_TYPENAMES.has(typename)) {
+        return renderAdminBlock(item as unknown as AnyBlock, routeVideo)
+      }
       return null
+    }
   }
 }
 

--- a/apps/web/src/components/sections/Container.tsx
+++ b/apps/web/src/components/sections/Container.tsx
@@ -11,11 +11,14 @@ import type { videoSectionFragment } from "@/lib/fragments/video-section"
 import type { relatedQuestionsFragment } from "@/lib/fragments/related-questions"
 import { Text } from "./Text"
 import { AdventCountdown } from "./AdventCountdown"
+import { BibleQuotesCarousel } from "./BibleQuotesCarousel"
 import { EasterDates } from "./EasterDates"
 import { MediaCollection } from "./MediaCollection"
 import { CTASection } from "./CTASection"
 import { Video } from "./Video"
 import { RelatedQuestions } from "./RelatedQuestions"
+
+import type { bibleQuotesCarouselFragment } from "@/lib/fragments/bible-quotes-carousel"
 
 export { containerFragment }
 
@@ -166,6 +169,14 @@ function SlotContentRenderer({
           data={item as unknown as FragmentOf<typeof relatedQuestionsFragment>}
         />
       )
+    case "BibleQuotesCarouselBlock":
+      return (
+        <BibleQuotesCarousel
+          data={
+            item as unknown as FragmentOf<typeof bibleQuotesCarouselFragment>
+          }
+        />
+      )
     default:
       return null
   }
@@ -183,6 +194,7 @@ function groupAdminContentBySlot(
 ): { gridSpan: number; spans: unknown; items: Record<string, unknown>[] }[] {
   const groups: ReturnType<typeof groupAdminContentBySlot> = []
   let current: (typeof groups)[number] | null = null
+  let droppedOrphans = 0
   for (const item of content) {
     if (!item) continue
     const typename = (item as { __typename?: string | null }).__typename
@@ -197,9 +209,24 @@ function groupAdminContentBySlot(
       groups.push(current)
       continue
     }
-    if (current) current.items.push(item)
+    if (current) {
+      current.items.push(item)
+    } else {
+      droppedOrphans += 1
+    }
+  }
+  if (droppedOrphans > 0 && process.env.NODE_ENV === "development") {
+    console.warn(
+      `[Container] groupAdminContentBySlot dropped ${droppedOrphans} item(s) appearing before the first ContainerSlotBlock marker — admin content[] should start with a slot marker. The Zod schema does not enforce this; check admin's transform.`,
+    )
   }
   return groups
+}
+
+type SlotGroup = {
+  gridSpan: number
+  spans: unknown
+  items: unknown[]
 }
 
 export function Container({ data, routeVideo }: ContainerProps) {
@@ -209,29 +236,35 @@ export function Container({ data, routeVideo }: ContainerProps) {
 
   // Strapi-era data has `slots[].content[]`; admin's flat shape is
   // `content[]` with `ContainerSlotBlock` markers. Normalize both into a
-  // common groups array so the rendering path is single.
-  const groups: { gridSpan: number; spans: unknown; items: unknown[] }[] =
-    legacySlots && legacySlots.length > 0
-      ? (legacySlots
-          .filter((s): s is NonNullable<typeof s> => s != null)
-          .map((s) => {
-            const slot = s as {
-              gridSpan?: unknown
-              spans?: unknown
-              content?: readonly unknown[]
-              id?: string
-            }
-            return {
-              gridSpan: clampSpan(slot.gridSpan),
-              spans: slot.spans,
-              items: (slot.content ?? []).filter(Boolean) as unknown[],
-            }
-          }) as never)
-      : adminContent
-        ? groupAdminContentBySlot(
-            adminContent as readonly (Record<string, unknown> | null)[],
-          )
-        : []
+  // common `SlotGroup[]` so the rendering path is single.
+  let groups: SlotGroup[]
+  if (legacySlots && legacySlots.length > 0) {
+    groups = legacySlots
+      .filter((s): s is NonNullable<typeof s> => s != null)
+      .map((s) => {
+        const slot = s as {
+          gridSpan?: unknown
+          spans?: unknown
+          content?: readonly unknown[]
+          id?: string
+        }
+        return {
+          gridSpan: clampSpan(slot.gridSpan),
+          spans: slot.spans,
+          items: (slot.content ?? []).filter(Boolean) as unknown[],
+        }
+      })
+  } else if (adminContent) {
+    groups = groupAdminContentBySlot(
+      adminContent as readonly (Record<string, unknown> | null)[],
+    )
+  } else {
+    groups = []
+  }
+  // Skip slot groups that have no items — two adjacent ContainerSlotBlock
+  // markers in admin's content[] would otherwise render an empty grid cell
+  // with `aspect-ratio` styling and confuse the layout.
+  groups = groups.filter((g) => g.items.length > 0)
   if (!groups.length) return null
 
   return (

--- a/apps/web/src/components/sections/MediaCollection.tsx
+++ b/apps/web/src/components/sections/MediaCollection.tsx
@@ -270,8 +270,14 @@ function VideoCard({
                 sizes="(max-width: 768px) 50vw, 200px"
                 className="transition-transform duration-300 group-hover:scale-105"
                 style={{
+                  // `center` keeps the subject in frame regardless of the
+                  // source image's aspect ratio. Portrait poster artwork
+                  // (the original cms data) stays centered; landscape
+                  // `mobileCinematicHigh` variants (post-data-layer-flip,
+                  // when admin only carries banner-aspect rows) show the
+                  // middle of the scene instead of the left edge.
                   objectFit: "cover",
-                  objectPosition: "left top",
+                  objectPosition: "center",
                   color: "transparent",
                   maskImage:
                     "linear-gradient(to top, transparent 0%, rgba(0,0,0,0.4) 30%, black 42%)",

--- a/apps/web/src/components/sections/RelatedQuestions.tsx
+++ b/apps/web/src/components/sections/RelatedQuestions.tsx
@@ -120,15 +120,21 @@ export function RelatedQuestions({ data }: RelatedQuestionsProps) {
   const { id, sectionKey, heading, questions } = data
   const ctaLabel = String((data as Record<string, unknown>).ctaLabel ?? "")
   const ctaLink = String((data as Record<string, unknown>).ctaLink ?? "")
-  const [openQuestion, setOpenQuestion] = useState<string | null>(null)
+  // Identify each question by its array index. Admin's
+  // `RelatedQuestionItemSchema` (apps/admin/src/domain/blocks.ts) does
+  // NOT carry an `id` field on individual items — only `question` +
+  // `answer` — so `q.id` is `undefined` for every item. Without an
+  // index-based identifier, `openQuestion === q.id` (both undefined)
+  // matches every row and clicking one expands all of them.
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
 
   const validQuestions =
     questions?.filter((q): q is NonNullable<typeof q> => q != null) ?? []
 
   if (!validQuestions.length) return null
 
-  const handleToggle = (qId: string) => {
-    setOpenQuestion(openQuestion === qId ? null : qId)
+  const handleToggle = (idx: number) => {
+    setOpenIndex(openIndex === idx ? null : idx)
   }
 
   return (
@@ -160,13 +166,13 @@ export function RelatedQuestions({ data }: RelatedQuestionsProps) {
       </div>
 
       <div className="relative">
-        {validQuestions.map((q) => (
+        {validQuestions.map((q, idx) => (
           <QuestionItem
-            key={q.id}
+            key={q.id ?? `q-${idx}`}
             question={q.question ?? ""}
             answer={q.answer ?? ""}
-            isOpen={openQuestion === q.id}
-            onToggle={() => handleToggle(q.id)}
+            isOpen={openIndex === idx}
+            onToggle={() => handleToggle(idx)}
           />
         ))}
       </div>

--- a/apps/web/src/components/sections/Section.tsx
+++ b/apps/web/src/components/sections/Section.tsx
@@ -331,6 +331,18 @@ function SectionContentRenderer({
           data={item as unknown as FragmentOf<typeof relatedQuestionsFragment>}
         />
       )
+    case "QuizButtonBlock":
+      return (
+        <QuizButton
+          data={
+            item as unknown as {
+              id: string
+              buttonText: string
+              iframeSrc: string
+            }
+          }
+        />
+      )
     case "VideoCarouselBlock":
       return (
         <CarouselVideo

--- a/apps/web/src/components/sections/Section.tsx
+++ b/apps/web/src/components/sections/Section.tsx
@@ -18,11 +18,18 @@ import { NavigationCarousel } from "./NavigationCarousel"
 import { QuizButton } from "./QuizButton"
 import { RelatedQuestions } from "./RelatedQuestions"
 import { Video } from "./Video"
-import { ADMIN_BLOCK_TYPENAMES, renderAdminBlock } from "./index"
+import { AdventCountdown } from "./AdventCountdown"
+import { CTASection } from "./CTASection"
+import { EasterDates } from "./EasterDates"
+import { Text } from "./Text"
 
-type AnyBlock = {
-  readonly __typename?: string | null
-} & Record<string, unknown>
+// Admin GraphQL typenames for blocks that can appear nested inside a
+// SectionBlock's `content[]`. The Strapi switch above only knows
+// `ComponentSections*` typenames; admin's payloads carry these instead.
+// We inline the dispatch (rather than reusing `renderAdminBlock` from
+// `./index`) to avoid an import cycle — `index.tsx` already imports
+// `Section.tsx`, so the reverse import resolves undefined at module
+// load and the component silently no-ops.
 
 export { sectionFragment }
 
@@ -191,7 +198,9 @@ function SectionContentRenderer({
 }) {
   if (!item || item.__typename === "Error") return null
   const typename = item.__typename as string
-  switch (typename) {
+  // Cast to broader string so the admin typename cases below (which
+  // are not in the Strapi-derived discriminated union) type-check.
+  switch (typename as string) {
     case "ComponentSectionsContainer":
       return (
         <Container
@@ -253,18 +262,82 @@ function SectionContentRenderer({
           }
         />
       )
+    // Admin GraphQL typenames inlined here. See module-level comment for
+    // why we don't bounce through `renderAdminBlock` in `./index`.
+    case "ContainerBlock":
+      return (
+        <Container
+          data={item as unknown as FragmentOf<typeof containerFragment>}
+          routeVideo={routeVideo}
+        />
+      )
+    case "VideoBlock":
+      return (
+        <Video
+          data={item as unknown as FragmentOf<typeof videoSectionFragment>}
+          routeVideo={routeVideo}
+        />
+      )
+    case "TextBlock":
+      return (
+        <Text data={item as unknown as Parameters<typeof Text>[0]["data"]} />
+      )
+    case "CtaBlock":
+      return (
+        <CTASection
+          data={item as unknown as Parameters<typeof CTASection>[0]["data"]}
+        />
+      )
+    case "EasterDatesBlock":
+      return (
+        <EasterDates
+          data={item as unknown as Parameters<typeof EasterDates>[0]["data"]}
+        />
+      )
+    case "AdventCountdownBlock":
+      return (
+        <AdventCountdown
+          data={
+            item as unknown as Parameters<typeof AdventCountdown>[0]["data"]
+          }
+        />
+      )
+    case "BibleQuotesCarouselBlock":
+      return (
+        <BibleQuotesCarousel
+          data={
+            item as unknown as FragmentOf<typeof bibleQuotesCarouselFragment>
+          }
+        />
+      )
+    case "MediaCollectionBlock":
+      return (
+        <MediaCollection
+          data={item as unknown as FragmentOf<typeof mediaCollectionFragment>}
+          routeVideo={routeVideo}
+        />
+      )
+    case "NavigationCarouselBlock":
+      return (
+        <NavigationCarousel
+          data={
+            item as unknown as FragmentOf<typeof navigationCarouselFragment>
+          }
+        />
+      )
+    case "RelatedQuestionsBlock":
+      return (
+        <RelatedQuestions
+          data={item as unknown as FragmentOf<typeof relatedQuestionsFragment>}
+        />
+      )
+    case "VideoCarouselBlock":
+      return (
+        <CarouselVideo
+          data={item as unknown as FragmentOf<typeof videoCarouselFragment>}
+        />
+      )
     default: {
-      // Admin typenames (NavigationCarouselBlock, ContainerBlock, etc.)
-      // arrive here when a Section's nested content composes admin-shape
-      // blocks. The Strapi-era cases above only know `ComponentSections*`
-      // typenames; fall back to the top-level admin dispatch so nested
-      // admin blocks render correctly. See packages/admin-graphql/
-      // src/fragments/blocks/section.ts where `content` is aliased to
-      // `sectionContent` — the alias preserves field name; per-item
-      // __typename still carries admin's `*Block` shape.
-      if (ADMIN_BLOCK_TYPENAMES.has(typename)) {
-        return renderAdminBlock(item as unknown as AnyBlock, routeVideo)
-      }
       if (process.env.NODE_ENV === "development") {
         console.warn("[Section] Unhandled content type:", typename)
       }

--- a/apps/web/src/components/sections/Section.tsx
+++ b/apps/web/src/components/sections/Section.tsx
@@ -18,6 +18,11 @@ import { NavigationCarousel } from "./NavigationCarousel"
 import { QuizButton } from "./QuizButton"
 import { RelatedQuestions } from "./RelatedQuestions"
 import { Video } from "./Video"
+import { ADMIN_BLOCK_TYPENAMES, renderAdminBlock } from "./index"
+
+type AnyBlock = {
+  readonly __typename?: string | null
+} & Record<string, unknown>
 
 export { sectionFragment }
 
@@ -249,6 +254,17 @@ function SectionContentRenderer({
         />
       )
     default: {
+      // Admin typenames (NavigationCarouselBlock, ContainerBlock, etc.)
+      // arrive here when a Section's nested content composes admin-shape
+      // blocks. The Strapi-era cases above only know `ComponentSections*`
+      // typenames; fall back to the top-level admin dispatch so nested
+      // admin blocks render correctly. See packages/admin-graphql/
+      // src/fragments/blocks/section.ts where `content` is aliased to
+      // `sectionContent` — the alias preserves field name; per-item
+      // __typename still carries admin's `*Block` shape.
+      if (ADMIN_BLOCK_TYPENAMES.has(typename)) {
+        return renderAdminBlock(item as unknown as AnyBlock, routeVideo)
+      }
       if (process.env.NODE_ENV === "development") {
         console.warn("[Section] Unhandled content type:", typename)
       }

--- a/apps/web/src/components/sections/Section.tsx
+++ b/apps/web/src/components/sections/Section.tsx
@@ -21,6 +21,8 @@ import { Video } from "./Video"
 import { AdventCountdown } from "./AdventCountdown"
 import { CTASection } from "./CTASection"
 import { EasterDates } from "./EasterDates"
+import { InfoBlocks } from "./InfoBlocks"
+import { PromoBanner } from "./PromoBanner"
 import { Text } from "./Text"
 
 // Admin GraphQL typenames for blocks that can appear nested inside a
@@ -347,6 +349,18 @@ function SectionContentRenderer({
       return (
         <CarouselVideo
           data={item as unknown as FragmentOf<typeof videoCarouselFragment>}
+        />
+      )
+    case "PromoBannerBlock":
+      return (
+        <PromoBanner
+          data={item as unknown as Parameters<typeof PromoBanner>[0]["data"]}
+        />
+      )
+    case "InfoBlocksBlock":
+      return (
+        <InfoBlocks
+          data={item as unknown as Parameters<typeof InfoBlocks>[0]["data"]}
         />
       )
     default: {

--- a/apps/web/src/components/sections/index.tsx
+++ b/apps/web/src/components/sections/index.tsx
@@ -252,14 +252,3 @@ export function ExperienceSectionRenderer({
   }
   return null
 }
-
-/** @deprecated Use ExperienceSectionRenderer */
-export function SectionRenderer({
-  section,
-  routeVideo,
-}: {
-  section: Section
-  routeVideo?: RouteVideo | null
-}) {
-  return <ExperienceSectionRenderer section={section} routeVideo={routeVideo} />
-}

--- a/apps/web/src/components/sections/index.tsx
+++ b/apps/web/src/components/sections/index.tsx
@@ -62,7 +62,7 @@ const ADMIN_BLOCK_TYPENAMES_LIST = [
   "VideoRecommendationsBlock",
 ] as const
 type AdminBlockTypename = (typeof ADMIN_BLOCK_TYPENAMES_LIST)[number]
-export const ADMIN_BLOCK_TYPENAMES: ReadonlySet<string> = new Set(
+const ADMIN_BLOCK_TYPENAMES: ReadonlySet<string> = new Set(
   ADMIN_BLOCK_TYPENAMES_LIST,
 )
 
@@ -70,7 +70,7 @@ type AnyBlock = {
   readonly __typename?: AdminBlockTypename | string | null
 } & Record<string, unknown>
 
-export function renderAdminBlock(
+function renderAdminBlock(
   block: AnyBlock,
   routeVideo: RouteVideo | null | undefined,
 ): ReactNode {

--- a/apps/web/src/components/sections/index.tsx
+++ b/apps/web/src/components/sections/index.tsx
@@ -62,7 +62,7 @@ const ADMIN_BLOCK_TYPENAMES_LIST = [
   "VideoRecommendationsBlock",
 ] as const
 type AdminBlockTypename = (typeof ADMIN_BLOCK_TYPENAMES_LIST)[number]
-const ADMIN_BLOCK_TYPENAMES: ReadonlySet<string> = new Set(
+export const ADMIN_BLOCK_TYPENAMES: ReadonlySet<string> = new Set(
   ADMIN_BLOCK_TYPENAMES_LIST,
 )
 
@@ -70,7 +70,7 @@ type AnyBlock = {
   readonly __typename?: AdminBlockTypename | string | null
 } & Record<string, unknown>
 
-function renderAdminBlock(
+export function renderAdminBlock(
   block: AnyBlock,
   routeVideo: RouteVideo | null | undefined,
 ): ReactNode {

--- a/apps/web/src/components/watch/DownloadModal.tsx
+++ b/apps/web/src/components/watch/DownloadModal.tsx
@@ -70,6 +70,14 @@ type TierOption = {
   download: DownloadModalDownload
 }
 
+// Sort primarily by size (largest first) so the "Highest" tier always
+// surfaces the largest file even when admin's `quality` enum is wrong
+// for the underlying asset. Observed in the wild: the Albanian dub of
+// `1-jesus-our-loving-pursuer` reports a 606 KB `fhd` entry pointing
+// at a 1080p Mux URL, which the old quality-enum-only sort promoted
+// to the "Highest" slot ahead of the real 21 MB `highest` row. Tied or
+// unknown sizes fall back to the original QUALITY_PRIORITY order so
+// the historical behavior holds for clean data.
 function sortByQuality(
   downloads: DownloadModalDownload[],
 ): DownloadModalDownload[] {
@@ -78,6 +86,9 @@ function sortByQuality(
   )
   const tail = QUALITY_PRIORITY.length
   return [...downloads].sort((a, b) => {
+    const aSize = a.size != null && a.size > 0 ? a.size : 0
+    const bSize = b.size != null && b.size > 0 ? b.size : 0
+    if (aSize > 0 && bSize > 0 && aSize !== bSize) return bSize - aSize
     const ai = priority.get(a.quality) ?? tail
     const bi = priority.get(b.quality) ?? tail
     return ai - bi

--- a/apps/web/src/components/watch/SeriesPageClient.tsx
+++ b/apps/web/src/components/watch/SeriesPageClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { Route } from "next"
 import { useRouter } from "next/navigation"
 import { ExternalLink, Globe } from "lucide-react"
@@ -18,6 +18,7 @@ import { SeriesHero } from "@/components/watch/SeriesHero"
 import { ShareModal } from "@/components/watch/ShareModal"
 import type { ResolvedSeriesBySlug } from "@/lib/content"
 import { deriveLanguageDisplay } from "@/lib/language-display"
+import { LOCALE_RESOLVED_PARAM } from "@/lib/locale"
 import { writePreferredLanguageSlug } from "@/lib/language-preference-client"
 import { isPlayableLanguageVariant } from "@/lib/playable-variant"
 import { resolvePosterUrl } from "@/lib/url"
@@ -53,6 +54,18 @@ export function SeriesPageClient({
   const openShare = useCallback(() => setModalState("share"), [])
   const openLanguage = useCallback(() => setModalState("language"), [])
   const closeModal = useCallback(() => setModalState("none"), [])
+
+  // Mirror `WatchPageClient`'s `LOCALE_RESOLVED_PARAM` strip — series
+  // pages can also receive the server-side URL-↔-variant sync redirect
+  // (when the requested locale has no matching dub for any of the
+  // series' children), so the sentinel must be cleaned up here too.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const url = new URL(window.location.href)
+    if (!url.searchParams.has(LOCALE_RESOLVED_PARAM)) return
+    url.searchParams.delete(LOCALE_RESOLVED_PARAM)
+    window.history.replaceState(window.history.state, "", url.toString())
+  }, [])
 
   // LanguagePickerModal expects a MuxPlayerRef to read currentTime for
   // the `?t=` query clamp. The series page has no player, so we hand

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
@@ -53,6 +53,19 @@ export function WatchPageClient({
   const playerRef = useRef<MuxPlayerRef | null>(null)
   const handlePlayerReady = useCallback((player: MuxPlayerRef | null) => {
     playerRef.current = player
+  }, [])
+
+  // `?_lr=1` is the server's URL-resolved sentinel (see the watchVideo
+  // branch in `[slug]/[locale]/page.tsx` + the matching bypass in
+  // proxy.ts). Strip it post-hydration via history.replaceState so the
+  // user-visible URL stays clean without triggering a router navigation
+  // that would re-enter the middleware.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const url = new URL(window.location.href)
+    if (!url.searchParams.has("_lr")) return
+    url.searchParams.delete("_lr")
+    window.history.replaceState(window.history.state, "", url.toString())
   }, [])
 
   const currentLanguageSlug = languageSlug ?? variant.language?.slug ?? ""

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -9,6 +9,7 @@ import { LanguagePickerModal } from "@/components/watch/LanguagePickerModal"
 import { ShareModal } from "@/components/watch/ShareModal"
 import { WatchSectionRenderer } from "@/components/watch/WatchSectionRenderer"
 import type { MergedWatchBlock, ResolvedWatchVideo } from "@/lib/content"
+import { LOCALE_RESOLVED_PARAM } from "@/lib/locale"
 import { resolvePosterUrl } from "@/lib/url"
 
 type WatchVideoRecord = ResolvedWatchVideo["video"]
@@ -55,16 +56,16 @@ export function WatchPageClient({
     playerRef.current = player
   }, [])
 
-  // `?_lr=1` is the server's URL-resolved sentinel (see the watchVideo
-  // branch in `[slug]/[locale]/page.tsx` + the matching bypass in
-  // proxy.ts). Strip it post-hydration via history.replaceState so the
-  // user-visible URL stays clean without triggering a router navigation
-  // that would re-enter the middleware.
+  // LOCALE_RESOLVED_PARAM is the server's URL-resolved sentinel — see
+  // the watchVideo branch in `[slug]/[locale]/page.tsx` + the matching
+  // bypass in proxy.ts. Strip it post-hydration via history.replaceState
+  // so the user-visible URL stays clean without triggering a router
+  // navigation that would re-enter the middleware.
   useEffect(() => {
     if (typeof window === "undefined") return
     const url = new URL(window.location.href)
-    if (!url.searchParams.has("_lr")) return
-    url.searchParams.delete("_lr")
+    if (!url.searchParams.has(LOCALE_RESOLVED_PARAM)) return
+    url.searchParams.delete(LOCALE_RESOLVED_PARAM)
     window.history.replaceState(window.history.state, "", url.toString())
   }, [])
 

--- a/apps/web/src/lib/admin-client.ts
+++ b/apps/web/src/lib/admin-client.ts
@@ -8,23 +8,40 @@ import { env } from "@/env"
 // Pattern: docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md
 const REQUEST_TIMEOUT_MS = 3_000
 
-// Module-scope bearer cache. WEB_ADMIN_API_KEYS may be a single key or a
-// CSV mirroring admin's keyring. We read the first entry as our outbound
-// bearer so traffic identifies as `consumer:<key>` at admin's rate-limit
-// layer rather than `public:<railway-egress-ip>`. Cached at module load to
-// avoid re-parsing on every request.
-const bearer = env.WEB_ADMIN_API_KEYS.split(",")[0]?.trim() ?? ""
-
 const timeoutFetch: typeof fetch = (input, init) =>
   fetch(input, { ...init, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
 
-const adminClient = new ApolloClient({
-  link: new HttpLink({
-    uri: env.ADMIN_GRAPHQL_URL,
-    headers: bearer ? { Authorization: `Bearer ${bearer}` } : {},
-    fetch: timeoutFetch,
-  }),
-  cache: new InMemoryCache(),
+// Deferred construction: types in `content.ts` are imported transitively
+// by a few `"use client"` renderers (e.g. `WatchSectionRenderer` needs
+// the `isWatchBlock` type-guard alongside block types). Reading
+// `env.WEB_ADMIN_API_KEYS` / `env.ADMIN_GRAPHQL_URL` at module-load
+// trips t3-oss/env-nextjs's client guard the moment any such client
+// chunk evaluates this file. A lazy singleton keeps module-load inert
+// on the client; server callers still hit a single shared instance.
+let realClient: ApolloClient | undefined
+
+function ensureClient(): ApolloClient {
+  if (realClient) return realClient
+  // WEB_ADMIN_API_KEYS may be a single key or a CSV mirroring admin's
+  // keyring. We read the first entry as our outbound bearer so traffic
+  // identifies as `consumer:<key>` at admin's rate-limit layer rather
+  // than `public:<railway-egress-ip>`.
+  const bearer = env.WEB_ADMIN_API_KEYS.split(",")[0]?.trim() ?? ""
+  realClient = new ApolloClient({
+    link: new HttpLink({
+      uri: env.ADMIN_GRAPHQL_URL,
+      headers: bearer ? { Authorization: `Bearer ${bearer}` } : {},
+      fetch: timeoutFetch,
+    }),
+    cache: new InMemoryCache(),
+  })
+  return realClient
+}
+
+const adminClient = new Proxy({} as ApolloClient, {
+  get(_target, prop, receiver) {
+    return Reflect.get(ensureClient(), prop, receiver)
+  },
 })
 
 export default adminClient

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -352,6 +352,26 @@ function normalizeImages(
     .filter((i): i is WatchImage => i != null)
 }
 
+// Admin's `Language.name` and `BibleBook.name` are typed `JSON` — a
+// locale-keyed object like `{ "en": "Afrikaans", "af": "Afrikaans" }`
+// (or, for some Core-synced rows, a plain string). Prefer the English
+// label so the language pill on the download dialog + language picker
+// always shows a readable string; fall back to any other locale value
+// if `en` is absent. Returns null only when the input is missing or
+// has no usable string entries.
+function pickLocalizedName(value: unknown): string | null {
+  if (typeof value === "string") return value.length > 0 ? value : null
+  if (value && typeof value === "object") {
+    const map = value as Record<string, unknown>
+    const en = map.en
+    if (typeof en === "string" && en.length > 0) return en
+    for (const v of Object.values(map)) {
+      if (typeof v === "string" && v.length > 0) return v
+    }
+  }
+  return null
+}
+
 function normalizeChildVariant(
   dub: NonNullable<
     NonNullable<NonNullable<AdminVideoRaw["children"]>[number]["child"]>["dubs"]
@@ -366,8 +386,7 @@ function normalizeChildVariant(
     language: dub.language
       ? {
           slug: dub.language.slug ?? null,
-          name:
-            typeof dub.language.name === "string" ? dub.language.name : null,
+          name: pickLocalizedName(dub.language.name),
           bcp47: dub.language.bcp47 ?? null,
         }
       : null,
@@ -441,7 +460,7 @@ function normalizeVariant(
           coreId: v.language.coreId ?? null,
           bcp47: v.language.bcp47 ?? null,
           slug: v.language.slug ?? null,
-          name: typeof v.language.name === "string" ? v.language.name : null,
+          name: pickLocalizedName(v.language.name),
         }
       : null,
     downloads: (v.downloads ?? [])
@@ -512,15 +531,12 @@ function normalizeAdminVideo(raw: AdminVideoRaw): WatchVideoRecord | null {
             c.bibleBook && c.bibleBook.documentId
               ? {
                   documentId: c.bibleBook.documentId,
-                  // Admin's `BibleBook.name` is JSON (legacy compatibility
-                  // mirror of Core's localised display name). Coerce to
-                  // string here so consumers can render it directly; admin
-                  // emits plain strings for the English book names in
-                  // practice.
-                  name:
-                    typeof c.bibleBook.name === "string"
-                      ? c.bibleBook.name
-                      : null,
+                  // Admin's `BibleBook.name` is JSON keyed by locale (Core
+                  // mirror). `pickLocalizedName` prefers the English entry
+                  // so the citation card renders something readable; for
+                  // rows admin still emits as a plain string the helper
+                  // returns it verbatim.
+                  name: pickLocalizedName(c.bibleBook.name),
                 }
               : null,
         }

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -352,6 +352,21 @@ function normalizeImages(
     .filter((i): i is WatchImage => i != null)
 }
 
+// Stable-order dedup by documentId. Keeps the first occurrence so the
+// editor-curated ordering survives. Used to scrub the parents/children
+// lists in `normalizeAdminVideo` against admin's duplicate VideoRelation
+// rows.
+function dedupeByDocumentId<T extends { documentId: string }>(items: T[]): T[] {
+  const seen = new Set<string>()
+  const result: T[] = []
+  for (const item of items) {
+    if (seen.has(item.documentId)) continue
+    seen.add(item.documentId)
+    result.push(item)
+  }
+  return result
+}
+
 // Admin's `Language.name` and `BibleBook.name` are typed `JSON` — a
 // locale-keyed object like `{ "en": "Afrikaans", "af": "Afrikaans" }`
 // (or, for some Core-synced rows, a plain string). Prefer the English
@@ -497,12 +512,26 @@ function normalizeAdminVideo(raw: AdminVideoRaw): WatchVideoRecord | null {
           bcp47: raw.primaryLanguage.bcp47 ?? null,
         }
       : null,
-    parents: (raw.parents ?? [])
-      .map(normalizeParent)
-      .filter((p): p is WatchParent => p != null),
-    children: (raw.children ?? [])
-      .map(normalizeChild)
-      .filter((c): c is WatchChild => c != null),
+    // Belt-and-braces against admin data-quality issues: filter out
+    // self-references (a VideoRelation row pointing the video at itself
+    // — seen in the wild for `1-jesus-our-loving-pursuer` with 3 such
+    // rows) and dedupe by documentId so a duplicated relation never
+    // surfaces as repeated sibling-carousel tiles or React duplicate-key
+    // warnings.
+    parents: dedupeByDocumentId(
+      (raw.parents ?? [])
+        .map(normalizeParent)
+        .filter(
+          (p): p is WatchParent => p != null && p.documentId !== raw.documentId,
+        ),
+    ),
+    children: dedupeByDocumentId(
+      (raw.children ?? [])
+        .map(normalizeChild)
+        .filter(
+          (c): c is WatchChild => c != null && c.documentId !== raw.documentId,
+        ),
+    ),
     variants: (raw.variants ?? [])
       .map(normalizeVariant)
       .filter((v): v is WatchVariant => v != null),

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -371,18 +371,45 @@ function dedupeByDocumentId<T extends { documentId: string }>(items: T[]): T[] {
 // locale-keyed object like `{ "en": "Afrikaans", "af": "Afrikaans" }`
 // (or, for some Core-synced rows, a plain string). Prefer the English
 // label so the language pill on the download dialog + language picker
-// always shows a readable string; fall back to any other locale value
-// if `en` is absent. Returns null only when the input is missing or
-// has no usable string entries.
+// always shows a readable string; fall back to other locale keys
+// in a fixed priority order if `en` is absent. Returns null only when
+// the input is missing or has no usable string entries.
+//
+// The fallback list is pinned (not `Object.values(map)` iteration
+// order) so admin-side jsonb key-ordering changes can't shift the
+// rendered label between deploys. New high-traffic locales should be
+// added here explicitly rather than relying on insertion order.
+const LOCALIZED_NAME_FALLBACK_ORDER = [
+  "en",
+  "es",
+  "fr",
+  "pt",
+  "de",
+  "id",
+  "ja",
+  "ko",
+  "ru",
+  "th",
+  "tr",
+  "zh",
+  "zh-Hans-CN",
+] as const
+
 function pickLocalizedName(value: unknown): string | null {
   if (typeof value === "string") return value.length > 0 ? value : null
-  if (value && typeof value === "object") {
-    const map = value as Record<string, unknown>
-    const en = map.en
-    if (typeof en === "string" && en.length > 0) return en
-    for (const v of Object.values(map)) {
-      if (typeof v === "string" && v.length > 0) return v
+  if (!value || typeof value !== "object") return null
+  const map = value as Record<string, unknown>
+  for (const key of LOCALIZED_NAME_FALLBACK_ORDER) {
+    const candidate = map[key]
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate
     }
+  }
+  // Last-ditch: any remaining non-empty string entry. Order is
+  // implementation-defined; this branch should rarely fire because
+  // every locale we support has a key in the fallback list above.
+  for (const v of Object.values(map)) {
+    if (typeof v === "string" && v.length > 0) return v
   }
   return null
 }

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -973,7 +973,35 @@ const fetchWatchVideoBySlug = cache(
     if (error) throw error
 
     const raw = result.data?.videoBySlug ?? null
-    return raw ? normalizeAdminVideo(raw) : null
+    if (!raw) return null
+
+    // Locale-text fallback: admin's `locales(locale:)` arg filters on
+    // bcp47 strictly, but URLs use the language slug ("afrikaans" not
+    // "af") and many videos don't have a localized VideoLocale row in
+    // every requested language. Either case returns an empty `locales[]`
+    // — which would render an empty <h1> on the watch page. Re-fetch
+    // with "en" when the primary record came back without locale text;
+    // the variant chain already handles audio-language selection so
+    // the user still gets the right dub, just with English title /
+    // description as a graceful fallback.
+    if (!raw.locales?.[0] && locale !== "en") {
+      const fallback = await client.query({
+        query: getWatchVideoBySlugOperation,
+        variables: { locale: "en", videoSlug },
+        fetchPolicy: "no-cache",
+      })
+      const fallbackError = graphqlError(
+        fallback as { error?: ErrorLike; errors?: unknown[] },
+      )
+      if (!fallbackError && fallback.data?.videoBySlug?.locales?.[0]) {
+        return normalizeAdminVideo({
+          ...raw,
+          locales: fallback.data.videoBySlug.locales,
+        })
+      }
+    }
+
+    return normalizeAdminVideo(raw)
   },
 )
 

--- a/apps/web/src/lib/locale.ts
+++ b/apps/web/src/lib/locale.ts
@@ -2,6 +2,27 @@ export const DEFAULT_LOCALE = "en"
 
 export const SUPPORTED_LOCALES = ["en", "es", "fr", "pt", "de"] as const
 
+/**
+ * Query-param sentinel that signals "this URL's locale has already been
+ * resolved server-side; do not re-apply the cookie-driven language
+ * redirect for this request." Used as the contract between three sites:
+ *
+ *   1. `apps/web/src/app/[slug]/[locale]/page.tsx` — sets it on the
+ *      server redirect when the requested locale has no matching dub
+ *      and the resolver falls back to a different variant.
+ *   2. `apps/web/src/proxy.ts` — short-circuits
+ *      `maybeRedirectToPreferredLanguage` when the param is present,
+ *      breaking the redirect loop where the cookie would otherwise
+ *      bounce the user back to the unmatched locale.
+ *   3. `apps/web/src/components/watch/{WatchPageClient,SeriesPageClient}.tsx`
+ *      — strips the param via `history.replaceState` after hydration
+ *      so the user-visible URL stays clean.
+ *
+ * Renaming the param requires editing all four sites in lockstep;
+ * exporting one constant makes the contract explicit and grep-able.
+ */
+export const LOCALE_RESOLVED_PARAM = "_lr"
+
 export function isLocale(
   param: string,
 ): param is (typeof SUPPORTED_LOCALES)[number] {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -70,6 +70,12 @@ function maybeRedirectToPreferredLanguage(
   // Only fire for watch routes. Otherwise /demo-search/<slug>/<locale> and
   // similar 2-segment paths would receive an unintended cookie redirect.
   if (!isWatchRoute(pathname)) return null
+  // `?_lr=1` is the page's signal that it has already resolved the URL
+  // locale to match the actually-rendered variant (see the watchVideo
+  // branch in apps/web/src/app/[slug]/[locale]/page.tsx). Without this
+  // bypass the cookie redirect bounces the user back to a locale with
+  // no playable variant; the page would loop redirecting forever.
+  if (request.nextUrl.searchParams.has("_lr")) return null
   const rawCookie = request.cookies.get(LANGUAGE_PREFERENCE_COOKIE)?.value
   if (!rawCookie) return null
   let preferredSlug: string

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { LANGUAGE_PREFERENCE_COOKIE } from "@/lib/language-preference-constants"
-import { DEFAULT_LOCALE, isLocale, parseAcceptLanguage } from "@/lib/locale"
+import {
+  DEFAULT_LOCALE,
+  LOCALE_RESOLVED_PARAM,
+  isLocale,
+  parseAcceptLanguage,
+} from "@/lib/locale"
 
 // Slug shape that the watch picker writes — kebab-case ASCII or bcp47
 // codes. Used by both isWatchRoute (to recognise slug-form watch URLs
@@ -70,12 +75,12 @@ function maybeRedirectToPreferredLanguage(
   // Only fire for watch routes. Otherwise /demo-search/<slug>/<locale> and
   // similar 2-segment paths would receive an unintended cookie redirect.
   if (!isWatchRoute(pathname)) return null
-  // `?_lr=1` is the page's signal that it has already resolved the URL
-  // locale to match the actually-rendered variant (see the watchVideo
-  // branch in apps/web/src/app/[slug]/[locale]/page.tsx). Without this
-  // bypass the cookie redirect bounces the user back to a locale with
-  // no playable variant; the page would loop redirecting forever.
-  if (request.nextUrl.searchParams.has("_lr")) return null
+  // `LOCALE_RESOLVED_PARAM` is the page's signal that it has already
+  // resolved the URL locale to match the actually-rendered variant
+  // (see the watchVideo branch in [slug]/[locale]/page.tsx). Without
+  // this bypass the cookie redirect bounces the user back to a locale
+  // with no playable variant; the page would loop redirecting forever.
+  if (request.nextUrl.searchParams.has(LOCALE_RESOLVED_PARAM)) return null
   const rawCookie = request.cookies.get(LANGUAGE_PREFERENCE_COOKIE)?.value
   if (!rawCookie) return null
   let preferredSlug: string

--- a/docs/solutions/cms/admin-app-data-model-decisions.md
+++ b/docs/solutions/cms/admin-app-data-model-decisions.md
@@ -300,6 +300,15 @@ Reasoning: low-cardinality reference data with a single localized field
 locale rows are reserved for content where editors curate translations
 independently and embeddings are per-locale (Experience, Video).
 
+**Consumer-side contract.** Admin's GraphQL exposes these columns as
+`name: JSON`, so every downstream consumer must treat the value as a
+`Record<string, string>` keyed by locale — never `typeof === "string"`
+and never `Object.values(map)[0]` (jsonb does not pin key order across
+updates / replication). See
+[`docs/solutions/integration-issues/admin-jsonb-locale-map-vs-strapi-string-silent-drop-20260515.md`](../integration-issues/admin-jsonb-locale-map-vs-strapi-string-silent-drop-20260515.md)
+for the apps/web incident and the `pickLocalizedName` helper that
+encodes the contract.
+
 ## Decisions captured for future work (deferred but documented)
 
 - **Encoding decoupling**: `hls`, `dash`, `muxVideoId`, `brightcoveId` on

--- a/docs/solutions/database-issues/prisma-video-relation-inverted-back-references-20260514.md
+++ b/docs/solutions/database-issues/prisma-video-relation-inverted-back-references-20260514.md
@@ -86,6 +86,18 @@ The one-line schema swap was applied and reverted in branch `feat/web-admin-poli
 
 The repo's full admin test suite (2266 tests) passes after the swap, but coverage gaps over Experience Builder runtime behavior are a possibility. A clean fix wants its own branch with explicit Experience Builder regression sweep.
 
+## ⚠️ Production cutover risk
+
+This bug is latent on `main` today but does **not** affect prod web, because prod web still reads from Strapi (apps/cms data layer). The inverted back-references only become user-visible once `feat/web-admin-data-layer-flip` (PR #939 U1-U8 + PR #941 U9-U22) ships and prod web starts calling admin's GraphQL.
+
+When that cutover lands without the schema swap, prod will exhibit:
+
+- Series details pages (`/watch/<series-slug>/<locale>`) showing "0 EPISODES" and no episode grid — even for series with 60+ chapters in admin's DB.
+- Watch-page SiblingCarousel staying hidden on every video (the defensive web-side dedupe in commit `d6b1eb7d` suppresses self-refs, so the carousel never renders).
+- admin's own Experience Builder `routeVideoChildren` blocks rendering the route video's _parents_ instead of its children.
+
+The fix is a 2-line edit + `pnpm --filter @forge/admin db:generate`. It should land on its own branch **before** the data-layer-flip reaches prod, to keep cutover risk contained to one diff at a time.
+
 ## Workaround currently in place
 
 `apps/web/src/lib/content.ts` (commit `d6b1eb7d`):

--- a/docs/solutions/database-issues/prisma-video-relation-inverted-back-references-20260514.md
+++ b/docs/solutions/database-issues/prisma-video-relation-inverted-back-references-20260514.md
@@ -1,0 +1,121 @@
+---
+title: Prisma `Video.parents` and `Video.children` back-references are semantically inverted
+date: 2026-05-14
+last_updated: 2026-05-14
+category: database-issues
+module: apps/admin
+problem_type: database_issue
+component: prisma_schema
+root_cause: wrong_relation_name
+resolution_type: deferred
+severity: high
+applies_when:
+  - Adding a feature that surfaces a Video's actual parent collection or child episodes via GraphQL.
+  - Reviewing why the apps/web SiblingCarousel renders empty (or, before the defensive dedupe in `apps/web/src/lib/content.ts`, rendered the current video as its own children).
+  - Debugging an admin Experience Builder `routeVideoChildren` block that surfaces a video's parents instead of its children.
+tags:
+  - prisma
+  - schema
+  - relation
+  - back-reference
+  - video
+  - VideoRelation
+  - Pothos
+  - sibling-carousel
+  - experience-builder
+---
+
+## Symptom
+
+The Pothos GraphQL field `Video.children` returns `VideoRelation` rows where the queried video's id is the **child** of the relation (parent of someone else's catalogue page), not its parent. Traversing `.child` on those rows yields the queried video itself.
+
+Concrete probe against local dev (`/watch/jesus/english`):
+
+```graphql
+{
+  videoBySlug(slug: "jesus") {
+    id
+    children {
+      child {
+        id
+        slug
+      }
+    }
+  }
+}
+```
+
+Returns 4 rows, all with `child.id === jesus.id` and `child.slug === "jesus"`. The actual catalogue parents of the JESUS film (`jf-language-stack-collection`, `jfm-collection`, `classic`, `women-resources`) are hidden behind the inverted back-reference and inaccessible via `Video.parents` either.
+
+Symmetric inversion on `Video.parents`.
+
+## Root cause
+
+`apps/admin/prisma/schema.prisma`:
+
+```prisma
+model Video {
+  ...
+  parents        VideoRelation[]      @relation("VideoChildren")  // ← mis-labeled
+  children       VideoRelation[]      @relation("VideoParents")   // ← mis-labeled
+}
+
+model VideoRelation {
+  parent  Video @relation("VideoChildren", fields: [parentId], references: [id], onDelete: Cascade)
+  child   Video @relation("VideoParents",  fields: [childId],  references: [id], onDelete: Cascade)
+}
+```
+
+Prisma pairs the two halves of a relation by the `@relation("name")` label. `Video.parents @relation("VideoChildren")` pairs with `VideoRelation.parent @relation("VideoChildren", fields: [parentId])`, which means `Video.parents` returns `VideoRelation` rows where this video's id equals the row's `parentId` — i.e. relations where **this video is the parent**, not its parents.
+
+Correct pairing would be:
+
+```prisma
+parents        VideoRelation[]      @relation("VideoParents")    // rows where childId = this.id
+children       VideoRelation[]      @relation("VideoChildren")   // rows where parentId = this.id
+```
+
+Then `.parent` / `.child` on each row yields the actual related video.
+
+## Why this is deferred
+
+The one-line schema swap was applied and reverted in branch `feat/web-admin-polish` (commits `ba7c5545` then `2393eff5` on 2026-05-14). Risk concern: even though the swap requires no DB migration (Prisma relation names are client-side pairing labels), changing the runtime semantics of `Video.parents` / `Video.children` affects any consumer of those fields, including:
+
+- apps/admin's `routeVideoChildren` block setting in Experience Builder (`apps/admin/src/app/dashboard/experiences/experience-editor.tsx`, `block-helpers.ts`)
+- Any in-flight admin work that may rely on the inverted shape (intentionally or not)
+
+The repo's full admin test suite (2266 tests) passes after the swap, but coverage gaps over Experience Builder runtime behavior are a possibility. A clean fix wants its own branch with explicit Experience Builder regression sweep.
+
+## Workaround currently in place
+
+`apps/web/src/lib/content.ts` (commit `d6b1eb7d`):
+
+- `dedupeByDocumentId<T>(items: T[]): T[]` collapses duplicate `documentId`s after the relation walk.
+- The `normalizeAdminVideo` parents/children pipelines additionally filter out any entry whose `documentId` equals the parent video's `documentId` (self-reference).
+
+Effect: the SiblingCarousel block-builder's `siblings.length < 2` guard suppresses the carousel entirely when admin returns only self-refs (every video probed locally — `1-jesus-our-loving-pursuer`, `jesus`, `easter-explained`, `darkroom-faith` — exhibits this). Better than rendering the video as its own three siblings (which the previous behaviour did, plus a React duplicate-key warning).
+
+The carousel still renders correctly for videos that genuinely have no parent and a populated own-children list, because the synthesized-virtual-parent branch in `buildSiblingCarouselBlock` short-circuits on `ownChildren.length >= 2`. With the inversion in place, `ownChildren` is currently never populated for any Video, so that branch never fires for real catalogue data.
+
+## How to fully fix
+
+1. Open `apps/admin/prisma/schema.prisma`, swap the relation labels:
+
+   ```prisma
+   parents        VideoRelation[]      @relation("VideoParents")
+   children       VideoRelation[]      @relation("VideoChildren")
+   ```
+
+2. Run `pnpm --filter @forge/admin db:generate` — Prisma client only; no migration file.
+
+3. Restart admin. The GraphQL `Video.children` field then returns real children. Verified end-to-end: `videoBySlug(slug:"magdalena").children` jumps from 0 to 46.
+
+4. Sweep admin's Experience Builder + dashboard usages of `routeVideoChildren` to confirm they now render the intended direction. (They were buggy in the same direction; the swap fixes them too. But confirm visually.)
+
+5. The defensive web-side filter in `dedupeByDocumentId` + self-ref check should stay in place as belt-and-braces against future relation-row anomalies.
+
+## Pointers
+
+- The unwanted-symptom defensive fix: commit `d6b1eb7d` in `feat/web-admin-polish`.
+- The attempted-and-reverted schema swap: commits `ba7c5545` and `2393eff5` in `feat/web-admin-polish`.
+- Affected consumers: `apps/web/src/components/watch/SiblingCarousel.tsx`, `apps/admin/src/app/dashboard/experiences/experience-editor.tsx` (`routeVideoChildren` branch).

--- a/docs/solutions/deployment/admin-local-dev-cms-content-dump-blocked-20260515.md
+++ b/docs/solutions/deployment/admin-local-dev-cms-content-dump-blocked-20260515.md
@@ -1,0 +1,108 @@
+---
+title: Running `triggerExperienceContentDump` locally is blocked behind a three-layer auth/proxy gauntlet
+date: 2026-05-15
+last_updated: 2026-05-15
+category: deployment
+module: apps/admin
+problem_type: workflow_issue
+component: dev_environment
+root_cause: dev_env_gap
+resolution_type: deferred
+severity: medium
+applies_when:
+  - Trying to populate admin's local Experience corpus with real cms (Strapi) content for local-dev parity.
+  - Trying to invoke any ADMIN-only GraphQL mutation that also dispatches a useworkflow job from a local-dev machine.
+  - Debugging why `/dashboard` redirects infinitely on `localhost:3003` after a successful login.
+tags:
+  - better-auth
+  - workflow
+  - useworkflow
+  - dev-environment
+  - dashboard-redirect-loop
+  - auth-host-proxy
+  - cms-content-dump
+  - experience-locale
+  - WORKFLOW_API_KEYS
+  - permissions
+---
+
+## What this is
+
+This is the post-mortem of a 2026-05-15 attempt to get prod-equivalent Experience content (Easter, Christmas, etc.) into a local admin DB by running the `triggerExperienceContentDump` GraphQL mutation. The mutation exists, the cms-side data is in local Strapi (13 components for easter), but three stacked dev-environment quirks each block a different path to invoking it.
+
+## The three layers
+
+### Layer 1 — Auth host proxy 404s `/api/graphql` on `localhost:3003`
+
+`apps/admin/src/proxy.ts:79-81` returns `404 Not Found` for any path starting with `/api/` (except `/api/auth/*`) when the request origin matches `getAuthBaseURL()`. In dev that's `http://localhost:3003` by default, so:
+
+- `localhost:3003/api/graphql` → 404 from middleware
+- `127.0.0.1:3003/api/graphql` → bypasses middleware, but Better Auth's session cookie is host-only on `localhost` and won't be sent to `127.0.0.1`
+
+### Layer 2 — `/dashboard` redirect loop on `localhost:3003`
+
+`apps/admin/src/proxy.ts:54-60`'s `redirectAuthPageToAdmin` redirects any non-auth path to `getDefaultPostLoginURL()`. In production, that resolves to `https://admin.jesusfilm.org/dashboard` (a different origin from `https://auth.jesusfilm.org`), so the redirect lands cleanly. In dev with no `AUTH_TRUSTED_ORIGINS` set:
+
+- `getAuthTrustedOrigins()` returns `[]`
+- `primaryAppOrigin` is `undefined`
+- `getDefaultPostLoginURL()` falls back to `${getAuthBaseURL()}/dashboard` = `http://localhost:3003/dashboard`
+- Same origin as the request → middleware fires again → redirect again → `ERR_TOO_MANY_REDIRECTS`
+
+User-impacting workaround in the repo (memory): use `127.0.0.1:3003` for `/dashboard` to bypass the proxy. Works for the dashboard, breaks for `/login` (cookie doesn't transfer).
+
+### Layer 3 — Workflow runner can't reach its own webhook in dev
+
+When `triggerExperienceContentDump` finally resolved (after we wired up `WORKFLOW_API_KEYS` + temporarily widened the `WORKFLOW_TRIGGER` permission allowlist to include `write:experience-content-dump`), the mutation hung indefinitely. Admin's logs:
+
+```
+[local world] Queue operation failed: [TypeError: fetch failed] {
+  [cause]: Error: redirect count exceeded
+}
+```
+
+The useworkflow runner's "local world" queue dispatches HTTP callbacks to the admin server's own webhook URL. That URL gets caught by the same auth-host proxy chain as `/dashboard`, redirects loop, dispatch fails, mutation never completes. We killed the curl at the 2-minute mark with the `experience_locale` row unchanged.
+
+## What we tried (and what didn't work)
+
+| Approach                                                   | Why it failed                                                                                                    |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `WEB_ADMIN_API_KEYS` bearer (`CONSUMER_BEARER` role)       | Permission set is intentionally empty                                                                            |
+| `WORKFLOW_API_KEYS` bearer (`WORKFLOW_TRIGGER` role)       | `WORKFLOW_TRIGGER_PERMISSIONS` doesn't include `write:experience-content-dump`                                   |
+| Login form on `localhost:3003/login`                       | Submits as GET (form has no `method` attr; React hydration broke due to host-mismatch); password leaked into URL |
+| Login form on `127.0.0.1:3003/login`                       | Better Auth's `authBaseURL` is baked at `localhost:3003`, mismatched origin breaks client hydration the same way |
+| Login success + browse `/dashboard` on localhost           | Layer 2 redirect loop                                                                                            |
+| DB session token as Cookie to `localhost:3003/api/graphql` | Layer 1 404                                                                                                      |
+| DB session token as Cookie to `127.0.0.1:3003/api/graphql` | Better Auth signature mismatch — token from DB is unsigned, expected signed cookie value                         |
+| Signed cookie via HMAC-SHA256 with `BETTER_AUTH_SECRET`    | Signature format guess didn't match; principal stayed `PUBLIC`                                                   |
+| Widen `WORKFLOW_TRIGGER_PERMISSIONS` + use bearer          | Auth resolved ✓ but Layer 3 hung the workflow dispatch                                                           |
+
+## What works locally without a real dump
+
+Hand-edit `experience_locale.blocks` JSON directly. The Apollo + Pothos layer reads the JSON column as-is, maps `t` → `__typename`, and the apps/web renderer dispatches on `__typename` correctly. The Experience-precedence routing fix in `apps/web/src/app/[slug]/[locale]/page.tsx` (commit `3c8c7d78`) is independently verifiable that way.
+
+Limitation: rich block sets (the prod Easter page has ~98 headings spread across video carousels, bible quotes, info blocks, CTAs, etc.) require hand-crafting hundreds of lines of JSON — throwaway work that doesn't ship.
+
+## How to actually fix this
+
+The cleanest path is a dedicated apps/admin branch that addresses Layer 1, 2, and 3 together:
+
+1. **Layer 1 fix:** Skip the auth-host proxy when `getAuthBaseURL() === getDefaultPostLoginURL().origin` (i.e., when there's no distinct admin origin from the auth origin in dev). One condition in `proxy.ts:proxy()`.
+2. **Layer 2 fix:** Same condition fixes the `/dashboard` loop simultaneously.
+3. **Layer 3 fix:** Configure the useworkflow runner's webhook base URL via env var so it can point at the admin server's internal-IP / `127.0.0.1` directly in dev, bypassing its own auth-host gate.
+
+Alternatively, ship a `pnpm --filter @forge/admin run-content-dump` CLI script that imports the service layer (`dumpExperienceLocale`) directly with a synthetic `ADMIN` principal — bypasses GraphQL auth + useworkflow dispatch entirely. Mirrors the `pnpm run-embeds` script the R1/R2 backfills use locally.
+
+## Why this is deferred
+
+The fix is admin-side. The current branch (`feat/web-admin-polish`) is scoped to apps/web polish ahead of the data-layer-flip. Touching admin's auth + workflow runner in this branch would expand the diff into territory that needs its own regression sweep against admin's dashboard, login, OAuth flow, and workflow dispatch.
+
+The local-dev gauntlet documented here does NOT affect production. In prod:
+
+- `auth.jesusfilm.org` and `admin.jesusfilm.org` are distinct origins, so Layers 1 and 2 don't fire.
+- Layer 3's webhook URL resolves via Railway internal networking, no proxy in the path.
+
+## Pointers
+
+- The earlier related learning: `prisma-video-relation-inverted-back-references-20260514.md` (also a latent bug that only becomes user-visible after the data-layer-flip ships).
+- The Experience-precedence routing fix that lets editor-curated Experiences override slug-colliding Videos: commit `3c8c7d78` on `feat/web-admin-polish`.
+- The local Strapi has real-ish data for `easter` (13 components, 12 sections + 1 video-hero). The cms-content-dump would translate those into admin's per-locale blocks JSON if it could run.

--- a/docs/solutions/integration-issues/admin-jsonb-locale-map-vs-strapi-string-silent-drop-20260515.md
+++ b/docs/solutions/integration-issues/admin-jsonb-locale-map-vs-strapi-string-silent-drop-20260515.md
@@ -1,0 +1,143 @@
+---
+module: apps/web
+date: "2026-05-15"
+problem_type: integration_issue
+component: service_object
+severity: high
+symptoms:
+  - "DownloadModal language pill renders blank for non-English dubs (Albanian, Afrikaans, …) after the data-layer flip to admin GraphQL"
+  - "BibleQuotesCarousel citation cards render with an empty book-name slot next to chapter/verse references"
+  - "Empty `<h1>` on some watch pages where title fell through to `language.name` as fallback"
+  - "No TypeScript error at compile time — gql.tada surfaces `name: JSON` as `unknown`, consumer code coerced via `typeof === 'string'` and silently dropped the value"
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+  - database
+  - tooling
+tags:
+  - admin-graphql
+  - strapi-migration
+  - jsonb-locale
+  - i18n
+  - data-layer-flip
+  - silent-drop
+  - pothos
+  - gql-tada
+---
+
+# JSON-locale-keyed name fields trap (Strapi-vs-admin seam)
+
+## Problem
+
+Admin's GraphQL schema types localized `name` columns as scalar `JSON` (`Language.name`, `BibleBook.name`, plus three other types' `name` fields at `apps/admin/schema.graphql` lines 32 / 140 / 167 / 414), but web's normalizers in `apps/web/src/lib/content.ts` were written against the Strapi vocabulary where those fields were plain `String`. The seam silently dropped every value that arrived as a locale-keyed object, so admin's actual payload — `{ "en": "Afrikaans", "af": "Afrikaans" }` — collapsed to `null`.
+
+## Symptoms
+
+User-visible breakage after the U13 cutover to admin:
+
+- **DownloadModal** (`apps/web/src/components/watch/DownloadModal.tsx`): the language pill rendered blank for Albanian / Afrikaans dubs because `WatchChildVariant.language.name` came through as `null`. The conditional `{languageName ? (…) : null}` at line 443 silently swallowed the missing label.
+- **Language picker** + child-variant rows: same root cause via `normalizeChildVariant` and `normalizeVariant`.
+- **BibleQuotesCarousel** citation cards: `BibleBook.name` came in as `null`, so the book-name slot rendered empty next to the chapter/verse reference.
+- Empty `<h1>` on some watch pages where the title fell through to `language.name`.
+
+## What Didn't Work
+
+The original code at all four call sites did:
+
+```ts
+name: typeof v.language.name === "string" ? v.language.name : null,
+```
+
+The `typeof === "string"` guard is correct for Strapi (where `name` is `String!`) but wrong for admin (where `name: JSON`). Every locale-keyed object failed the guard and was dropped.
+
+The first fix attempt (commit `6d0b676f`) introduced `pickLocalizedName` but used `Object.values(map)` as the fallback when `en` was missing. JS spec guarantees insertion order on `Object.values`, but **admin-side jsonb serialization order is not contractually pinned** — a future Pothos transform, jsonb operator, or Postgres rewrite could reorder keys silently, shifting the rendered label between deploys with no code change here.
+
+## Solution
+
+Commit `9df13232` pinned a deterministic fallback list. The helper lives at `apps/web/src/lib/content.ts` lines 382–415:
+
+```ts
+const LOCALIZED_NAME_FALLBACK_ORDER = [
+  "en",
+  "es",
+  "fr",
+  "pt",
+  "de",
+  "id",
+  "ja",
+  "ko",
+  "ru",
+  "th",
+  "tr",
+  "zh",
+  "zh-Hans-CN",
+] as const
+
+function pickLocalizedName(value: unknown): string | null {
+  if (typeof value === "string") return value.length > 0 ? value : null
+  if (!value || typeof value !== "object") return null
+  const map = value as Record<string, unknown>
+  for (const key of LOCALIZED_NAME_FALLBACK_ORDER) {
+    const candidate = map[key]
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate
+    }
+  }
+  // Last-ditch: any remaining non-empty string entry. Order is
+  // implementation-defined; this branch should rarely fire because
+  // every locale we support has a key in the fallback list above.
+  for (const v of Object.values(map)) {
+    if (typeof v === "string" && v.length > 0) return v
+  }
+  return null
+}
+```
+
+Call sites (all in `content.ts`):
+
+- Line 431 — `normalizeChildVariant` (child variant language pill)
+- Line 505 — `normalizeVariant` (top-level variant language)
+- Line 595 — `normalizeAdminVideo` BibleBook citation
+
+Before / after at line 505:
+
+```ts
+// before
+name: typeof v.language.name === "string" ? v.language.name : null,
+// after
+name: pickLocalizedName(v.language.name),
+```
+
+String-typed inputs pass through unchanged at line 399, so any rows admin still emits as plain strings keep working through the same helper.
+
+## Why This Works
+
+**(a) Why admin uses jsonb here.** Admin's Prisma model mirrors JesusFilm Core's localized name shape — Core stores `name` as a per-locale map so a single row carries every translation. Pothos exposes that column as `name: JSON` (`apps/admin/schema.graphql` lines 32, 140, 167, 414). Strapi flattened to a single locale per request; admin doesn't.
+
+**(b) Why insertion-order fallback is unsafe.** Even though `Object.values` iteration order is spec'd on JS objects, the values come from admin's jsonb serialization. Postgres jsonb does not preserve key order — `UPDATE`, vacuum, or replication can rewrite the order. A Pothos transform that touches the map (e.g. trimming unsupported locales) could equally reorder. Relying on `Object.values()[0]` makes the rendered label environment-dependent.
+
+**(c) Why a pinned fallback order is the right contract.** The English label is the product-wide default for the language pill / citation card. Pinning `"en"` first and listing the next 12 high-traffic locales explicitly makes the rendered label a function of the input map's _contents_, not its _key order_. New locales get added to the constant deliberately, not by accident of jsonb serialization.
+
+## Prevention
+
+- **Treat every admin column whose schema type is `JSON` as `Record<string, string>` keyed by locale, not a flat string.** The five `name: JSON` fields in `apps/admin/schema.graphql` (lines 32, 140, 167, 414, plus any future additions) all route through `pickLocalizedName`. New jsonb-locale call sites must use this helper — never `typeof === "string"` and never `Object.values(map)[0]`.
+
+- **Cross-link in the data-model decisions doc.** The principles in `docs/solutions/cms/admin-app-data-model-decisions.md` cover the admin schema-design intent but don't enumerate the locale-jsonb migration trap. Add a one-line pointer there so future schema ports surface this trap at review time.
+
+- **Document the known JSON-locale fields** in `apps/admin/CLAUDE.md` and `apps/web/CLAUDE.md` so reviewers catch any new `name: JSON` Pothos field at PR time and require a `pickLocalizedName` consumer (or a server-side projection that flattens).
+
+- **Add unit tests for `pickLocalizedName`** covering:
+  1. `pickLocalizedName({ en: "Afrikaans" })` → `"Afrikaans"` (en-only object).
+  2. `pickLocalizedName({ en: "Korean", ko: "한국어" })` → `"Korean"` (multi-locale must prefer `en`).
+  3. `pickLocalizedName({ en: null, es: "Coreano", ko: "한국어" })` → `"Coreano"` (non-string `en` falls back deterministically per `LOCALIZED_NAME_FALLBACK_ORDER`, not insertion order).
+  4. `pickLocalizedName(null)` → `null`.
+  5. `pickLocalizedName("Plain string")` → `"Plain string"` (legacy string passthrough).
+
+- **Watch for the same trap on other Strapi → admin field-type changes.** Any field whose admin schema type differs from its Strapi schema type (scalar widening to `JSON`, single-value to array, nullable-to-non-null) needs a normalizer pass — the typecheck won't catch it because gql.tada types `JSON` as `unknown`/`any` and consumers are free to over-narrow.
+
+## Related
+
+- `docs/solutions/database-issues/prisma-video-relation-inverted-back-references-20260514.md` — sibling-session doc covering a different schema-shape mismatch (inverted `@relation` direction on `Video.parents` / `Video.children`) discovered in the same admin↔web port window.
+- `docs/solutions/deployment/admin-local-dev-cms-content-dump-blocked-20260515.md` — same-session sibling on the local-dev auth/proxy gauntlet that blocked rerunning the cms content-dump while diagnosing this.
+- `docs/solutions/cms/admin-app-data-model-decisions.md` — admin schema-design decisions log; this learning is a concrete instance of a gap there (no enumeration of the locale-jsonb consumer contract).
+- `docs/solutions/best-practices/admin-image-enrichment-localized-media-workflow-20260504.md` — different concern (AI enrichment provenance) on the same admin localized-text surface.


### PR DESCRIPTION
Stacked on `feat/web-admin-data-layer-flip` (#941). Polish-only — every commit here is a bug surfaced by live-testing `apps/web` against admin.

## Summary
- **Routing precedence**: when a slug exists as both an Experience and a Video (e.g. `easter` collection + `easter` experience), the Experience wins. Falls through to video on empty.
- **URL ↔ variant sync**: redirect to the actual rendered variant's locale slug when the URL doesn't match any dub. New `LOCALE_RESOLVED_PARAM` (`_lr=1`) sentinel breaks the cookie-redirect ↔ variant-resolution loop; `WatchPageClient` + `SeriesPageClient` strip it post-hydration; `proxy.ts` bypasses cookie override when present.
- **Render gaps on admin shape**: Section dispatch missing `PromoBannerBlock` / `InfoBlocksBlock`; Container slot dispatch missing `BibleQuotesCarouselBlock`. Inlined cases (avoids the cycle with `./index`).
- **Container slot grouping**: admin returns flat `content[]` with `ContainerSlotBlock` markers; `groupAdminContentBySlot` reducer groups items between markers. Dev-warn for orphan items before the first marker; empty slot groups filtered. Named `SlotGroup` type replaces `as never`.
- **Localization fixes**: admin's `Language.name` and `BibleBook.name` are JSON-locale-keyed; `pickLocalizedName` picks the en entry first, with a pinned `LOCALIZED_NAME_FALLBACK_ORDER` (not insertion order). Re-fetch en-locale text when the requested locale has no `VideoLocale` row.
- **Self-ref + dedupe**: `normalizeAdminVideo` filters self-references and dedupes parents/children by `documentId`. Workaround for the inverted `@relation` labels on `Video.parents` / `Video.children` (deferred per project policy — see `docs/solutions/database-issues/prisma-video-relation-inverted-back-references-20260514.md` for the prod-cutover prerequisite).
- **DownloadModal sort**: sort by size descending, with quality enum as tiebreaker (was: quality enum only, which mis-ranked Albanian dubs where size and quality enum disagreed).
- **RelatedQuestions**: toggle by row index, not `id` (admin items carry no id, so every row was matching).
- **Search**: `muxSearchThumbnail()` fallback when `imageUrl` is null on search cards.
- **Apollo client**: lazy Proxy-based singleton — `WEB_ADMIN_API_KEYS` is server-only and was tripping t3-env's client guard when transitively imported.
- **`SectionRenderer` deprecated shim removed**; 4 callers migrated to `ExperienceSectionRenderer`.

## Heads-up
- One commit (`5ab87c45`) touches `apps/admin/src/services/hybrid-search-retrievers.ts` — a `LEFT JOIN LATERAL` against `video_image` so semantic + keyword retrievers carry `imageUrl`. Predates the firmer no-admin-changes rule from later in the session. Drop or keep, your call.
- Documented `docs/solutions/deployment/admin-local-dev-cms-content-dump-blocked-20260515.md` and `docs/solutions/database-issues/prisma-video-relation-inverted-back-references-20260514.md` for blockers discovered along the way.

## Residuals from `/compound-engineering:ce-code-review`
Best-judgment auto-resolve applied; remaining items surfaced rather than auto-fixed (full list in the chat thread): test coverage gaps for `groupAdminContentBySlot`, `pickLocalizedName`/`dedupeByDocumentId`, `DownloadModal` sort, the new redirect path, and proxy `_lr` bypass; M1 dispatch dedup across the three switches; M3 helper extraction out of `content.ts`; M4 content.ts size; `correctness-proxy-lr-param-bypass-affects-all-urls` (P3 — design call on scoping).

## Test plan
- [ ] `pnpm --filter web typecheck` — clean
- [ ] `pnpm --filter web vitest` — 496 passing, 2 todo
- [ ] `/watch/easter/english` — renders Experience (12 sections), not series page
- [ ] `/watch/storyclubs/english` — series grid renders with episode cards
- [ ] `/watch/jesus/english` vs `jesusfilm.org/watch/jesus.html/english.html` — visual parity
- [ ] Download dialog on Albanian variant — ordered by size, quality pill shows
- [ ] Search `plot` → click result → video details page renders (no ECONNREFUSED if admin is running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)