### PR TITLE
fix(web): bump admin-client timeout 3s → 15s for slow videoBySlug

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -20,7 +20,7 @@
 
 Web reads from admin via the typed `adminGraphql()` factory exported from `@forge/admin-graphql`. The package consumes admin's committed SDL (`apps/admin/schema.graphql`); SDL drift breaks codegen at the package level, not at the app level.
 
-- `src/lib/admin-client.ts` — singleton Apollo client pointed at `env.ADMIN_GRAPHQL_URL` with `Authorization: Bearer ${env.WEB_ADMIN_API_KEYS.split(",")[0]}`. 3 s timeout.
+- `src/lib/admin-client.ts` — singleton Apollo client pointed at `env.ADMIN_GRAPHQL_URL` with `Authorization: Bearer ${env.WEB_ADMIN_API_KEYS.split(",")[0]}`. 15 s timeout (temporary headroom for admin's slow `videoBySlug` resolver on COLLECTION rows; see the comment in `admin-client.ts`).
 - `src/lib/content.ts` — `resolveWatchPage`, `resolveWatchVideo*`, `resolveSeriesBySlug`, plus the 6 synthetic-watch-block builders. Returns admin shapes flattened via `normalizeAdminVideo`.
 - `src/lib/fragments/watch-experience.ts` — re-exports `adminWatchExperienceFragment` from `@forge/admin-graphql/fragments` (the root composition over admin's 17 block fragments).
 - `src/lib/fragments/watch-video.ts` — local `WatchVideo` fragment + the two query operations on admin's `Video` with field aliases bridging vocab (`documentId: id`, `variants: dubs`, `value: text`).

--- a/apps/web/src/lib/admin-client.ts
+++ b/apps/web/src/lib/admin-client.ts
@@ -2,11 +2,16 @@ import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client"
 
 import { env } from "@/env"
 
-// 3 s end-to-end budget. Admin is internal-network from Railway, so a
-// healthy SSR call returns in <500 ms; the budget exists to fail fast when
-// the upstream is sick rather than pinning Next.js workers on stuck calls.
+// 15 s end-to-end budget. Healthy SSR calls return in <500 ms over Railway's
+// internal network, but admin's `videoBySlug` resolver currently takes ~6 s
+// for COLLECTION rows because of the `parents.parent.children.child` 2-deep
+// fan-out in the WatchVideo fragment (observed 6.2 s on `easter` post-flip,
+// 2026-05-14). The budget exists to fail fast when the upstream is sick
+// rather than pinning Next.js workers on stuck calls; the size is sized to
+// admin's worst-observed resolver latency plus headroom. Drop back toward
+// 3 s once admin's resolver fan-out is trimmed.
 // Pattern: docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md
-const REQUEST_TIMEOUT_MS = 3_000
+const REQUEST_TIMEOUT_MS = 15_000
 
 const timeoutFetch: typeof fetch = (input, init) =>
   fetch(input, { ...init, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })


### PR DESCRIPTION
## Summary

Post-flip (PR #941 deployed 2026-05-14T16:31), `/watch/easter` renders "Failed to load experience: An unexpected error occurred." in red while `/watch` and `/watch/christmas` render the expected empty state.

**Root cause:** admin's `videoBySlug` resolver takes ~6 s for COLLECTION rows (`easter` measured at 6.2 s) because the WatchVideo fragment's `parents { parent { children { child { … } } } }` 2-deep fan-out triggers heavy resolver traversal server-side. Web's admin-client budget was 3 s, sized for "<500 ms healthy" — slow collection calls fail every SSR attempt, ISR caches the error, page stays red.

**Patch:** raise `REQUEST_TIMEOUT_MS` from `3_000` to `15_000` so slow collection calls complete and the page renders. Drop back toward 3 s once admin trims the fan-out (separate follow-up — known issue, not addressed here).

**The cost:** Next.js workers will sit on slow admin calls longer when the upstream is sick. Acceptable while admin is the single read upstream and the alternative is a broken site.

## Verification

After deploy, `/watch/easter` should render the gray empty state ("No experience content available.") matching `/watch` and `/watch/christmas`. The real Easter Experience content is a separate concern — admin's prod DB still has `experienceBySlug(easter) = null`, so the page will be empty until the R3 cms→admin content dump runs.

## Test plan

- [ ] CI green
- [ ] After merge + deploy: `curl https://watch.jesusfilm.org/watch/easter` returns gray empty state body, not red error
- [ ] Other `/watch/*` slugs unchanged
- [ ] Followup tracked: admin `videoBySlug` resolver fan-out trim

🤖 Generated with [Claude Code](https://claude.com/claude-code)