### PR TITLE
fix(admin): register video backup scheduler workflow

### DIFF
--- a/apps/admin/src/app/dashboard/workflows/page.tsx
+++ b/apps/admin/src/app/dashboard/workflows/page.tsx
@@ -6,6 +6,7 @@ import { requireSession } from "@/auth/session"
 import { getAdminMessages } from "@/i18n/server"
 import { loadWorkflowRuntimeRuns } from "@/services/workflow-runtime.service"
 import { loadWorkflowWorkerStatusRows } from "@/services/workflow-worker-heartbeat.service"
+import { getKnownVideoDbBackupWorkflowIds } from "@/workflows/registry"
 
 type WorkflowsPageProps = {
   searchParams?: Promise<{
@@ -96,6 +97,7 @@ export default async function WorkflowsPage({
   const statusFilter = parseStatusFilter(resolvedSearchParams?.status)
   const limit = parseLimit(resolvedSearchParams?.limit)
   await requireSession()
+  const knownVideoDbBackupWorkflowIds = getKnownVideoDbBackupWorkflowIds()
   const [runs, workers] = await Promise.all([
     loadWorkflowRuntimeRuns(limit),
     loadWorkflowWorkerStatusRows(),
@@ -109,7 +111,10 @@ export default async function WorkflowsPage({
   const nextLimit = Math.min(limit + 25, 100)
 
   return (
-    <div className="flex flex-col gap-6">
+    <div
+      className="flex flex-col gap-6"
+      data-workflow-registry-count={knownVideoDbBackupWorkflowIds.length}
+    >
       <DashboardPageHeader
         eyebrow={page.eyebrow}
         title={page.title}

--- a/apps/admin/src/services/video-db-backup/job.test.ts
+++ b/apps/admin/src/services/video-db-backup/job.test.ts
@@ -76,6 +76,40 @@ describe("video DB backup workflow job", () => {
     expect(start).not.toHaveBeenCalled()
   })
 
+  it("replaces a stale scheduler ledger row when the runtime run already failed", async () => {
+    queryRaw
+      .mockResolvedValueOnce([{ locked: true }])
+      .mockResolvedValueOnce([
+        { status: "failed", error: "Workflow was not registered." },
+      ])
+      .mockResolvedValueOnce([{ unlocked: true }])
+    workflowRun.findFirst.mockResolvedValueOnce({
+      id: "stale-ledger-run",
+      runtimeRunId: "failed-runtime-run",
+    })
+    start.mockResolvedValueOnce({
+      runId: "scheduler-runtime-run-2",
+      returnValue: Promise.resolve(undefined),
+    })
+    const { ensureVideoDbBackupSchedulerStarted } = await import("./job")
+
+    await expect(ensureVideoDbBackupSchedulerStarted()).resolves.toEqual({
+      started: true,
+      runId: "scheduler-runtime-run-2",
+      ledgerRunId: "ledger-run-1",
+    })
+    expect(workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "stale-ledger-run" },
+      data: expect.objectContaining({
+        status: "FAILED",
+        summary: "Video DB backup scheduler runtime failed.",
+        error: "Workflow was not registered.",
+        finishedAt: expect.any(Date),
+      }),
+    })
+    expect(start).toHaveBeenCalledOnce()
+  })
+
   it("dispatches the scheduled backup through useworkflow", async () => {
     const dispatch = wrapStartSpy(start)
     start.mockResolvedValueOnce({

--- a/apps/admin/src/services/video-db-backup/job.ts
+++ b/apps/admin/src/services/video-db-backup/job.ts
@@ -49,6 +49,17 @@ export type VideoDbBackupSchedulerStartResult =
 const SCHEDULER_WORKFLOW_KEY = "video-db-backup-scheduler"
 const SCHEDULER_LOCK_ID = 862_640_122
 const BACKUP_HOUR_UTC = 9
+const TERMINAL_RUNTIME_STATUSES = new Set(["completed", "failed", "cancelled"])
+
+type SchedulerLedgerRun = {
+  id: string
+  runtimeRunId: string | null
+}
+
+type RuntimeRunStatus = {
+  status: string
+  error: string | null
+}
 
 function summarizeBackupResult(result: VideoDbBackupJobResult): string {
   const destination = result.upload
@@ -219,6 +230,54 @@ async function withSchedulerStartLock<T>(
   }
 }
 
+async function loadRuntimeRunStatus(
+  runtimeRunId: string,
+): Promise<RuntimeRunStatus | null> {
+  try {
+    const rows = await prisma.$queryRaw<RuntimeRunStatus[]>`
+      SELECT status, error
+      FROM workflow.workflow_runs
+      WHERE id = ${runtimeRunId}
+      LIMIT 1
+    `
+    return rows[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+async function reconcileStaleSchedulerRun(
+  existing: SchedulerLedgerRun,
+): Promise<boolean> {
+  if (!existing.runtimeRunId) return false
+
+  const runtimeRun = await loadRuntimeRunStatus(existing.runtimeRunId)
+  if (!runtimeRun || !TERMINAL_RUNTIME_STATUSES.has(runtimeRun.status)) {
+    return false
+  }
+
+  const status =
+    runtimeRun.status === "completed"
+      ? WorkflowRunStatus.SUCCEEDED
+      : WorkflowRunStatus.FAILED
+  const summary =
+    runtimeRun.status === "completed"
+      ? "Video DB backup scheduler stopped after runtime completion."
+      : `Video DB backup scheduler runtime ${runtimeRun.status}.`
+
+  await prisma.workflowRun.update({
+    where: { id: existing.id },
+    data: {
+      status,
+      finishedAt: new Date(),
+      summary,
+      error: runtimeRun.error,
+    },
+  })
+
+  return true
+}
+
 export async function ensureVideoDbBackupSchedulerStarted(): Promise<VideoDbBackupSchedulerStartResult> {
   return withSchedulerStartLock(async () => {
     const existing = await prisma.workflowRun.findFirst({
@@ -232,11 +291,14 @@ export async function ensureVideoDbBackupSchedulerStarted(): Promise<VideoDbBack
     })
 
     if (existing) {
-      return {
-        started: false,
-        reason: "already-running",
-        ledgerRunId: existing.id,
-        runtimeRunId: existing.runtimeRunId,
+      const stale = await reconcileStaleSchedulerRun(existing)
+      if (!stale) {
+        return {
+          started: false,
+          reason: "already-running",
+          ledgerRunId: existing.id,
+          runtimeRunId: existing.runtimeRunId,
+        }
       }
     }
 

--- a/apps/admin/src/workflows/registry.ts
+++ b/apps/admin/src/workflows/registry.ts
@@ -1,0 +1,16 @@
+import {
+  runVideoDbBackup,
+  runVideoDbBackupScheduler,
+} from "@/workflows/videoDbBackup"
+
+type WorkflowExport = {
+  name: string
+  workflowId?: string
+}
+
+export function getKnownVideoDbBackupWorkflowIds(): string[] {
+  return [runVideoDbBackup, runVideoDbBackupScheduler].map((workflow) => {
+    const registered = workflow as WorkflowExport
+    return registered.workflowId ?? registered.name
+  })
+}


### PR DESCRIPTION
## Summary
- force the video DB backup workflows into the Next/useworkflow discovery graph
- reconcile stale scheduler ledger rows when the Postgres World runtime run is already terminal
- add coverage for replacing a failed scheduler runtime row

## Verification
- pnpm --filter @forge/admin test src/services/video-db-backup/job.test.ts src/workflows/videoDbBackup.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- pnpm --filter @forge/admin build