### PR TITLE
chore: align devcontainer postgres with production

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,13 @@ ENV TZ="$TZ"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Install PostgreSQL's official apt repository so client tools can track the
+# production dump format instead of Ubuntu 24.04's default PostgreSQL 16 tools.
+RUN install -d /usr/share/postgresql-common/pgdg && \
+  curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+  . /etc/os-release && \
+  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
 # Install additional system packages (base image already includes git, curl, sudo, etc.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
   # Sandboxing support for Claude Code
@@ -21,8 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zsh \
   # Build tools
   build-essential \
-  # PostgreSQL client (server runs in sidecar container)
-  postgresql-client \
+  # PostgreSQL client tools only; server runs in sidecar/Railway containers
+  postgresql-client-18 \
   # Redis CLI client (server runs in sidecar container)
   redis-tools \
   # Utilities

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     command: sleep infinity
 
   db:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg18
     restart: unless-stopped
     volumes:
       - pgdata:/var/lib/postgresql/data

--- a/docs/solutions/cms/local-cms-backend-setup.md
+++ b/docs/solutions/cms/local-cms-backend-setup.md
@@ -29,7 +29,7 @@ No useful context from the default error output — the `ECONNREFUSED` doesn't s
 
 3. **Ran with `NODE_DEBUG=net`** — confirmed Strapi was trying to connect to `localhost:5432` (PostgreSQL) and failing because no Postgres was running.
 
-4. **Found `.devcontainer/docker-compose.yml`** — the repo provides a Postgres 16 container with credentials `forge/forge/forge` on port 5432.
+4. **Found `.devcontainer/docker-compose.yml`** — the repo provides a Postgres 18 container with credentials `forge/forge/forge` on port 5432.
 
 ## Root Cause
 

--- a/docs/solutions/platform/devcontainer-setup.md
+++ b/docs/solutions/platform/devcontainer-setup.md
@@ -31,6 +31,13 @@ RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "$FNM_D
 - `.devcontainer/post_install.py` — post-create: Claude bypassPermissions, Codex full-access config, tmux, gitignore
 - `.devcontainer/.zshrc` — zsh config with fnm, fzf, history
 
+## System packages
+
+- PostgreSQL client tools come from the official PGDG apt repository and install `postgresql-client-18`. Ubuntu 24.04's default `postgresql-client` package resolves to PostgreSQL 16, which cannot read custom-format dumps with header version 1.16 from newer Railway PostgreSQL backups.
+- The local database sidecar uses `pgvector/pgvector:pg18` to match the Railway PostgreSQL 18 production major version as closely as practical in local development.
+- After rebuilding the devcontainer, verify `pg_restore --version`, `pg_dump --version`, and `psql --version` all report PostgreSQL 18 before restoring production backup artifacts.
+- PostgreSQL major-version upgrades cannot reuse an old data directory. If a local `pgdata` volume was created with PostgreSQL 16, recreate it before starting the PG18 sidecar.
+
 ## Known gaps / watch-outs
 
 - `claude plugin marketplace add` runs during Docker build — requires public plugins or pre-auth


### PR DESCRIPTION
## Summary
- install PostgreSQL 18 client tools from PGDG in the devcontainer image
- update the local pgvector sidecar to PostgreSQL 18
- document PG18 restore verification and the PG16 volume recreation requirement

## Verification
- docker compose -f .devcontainer/docker-compose.yml config
- docker compose -f .devcontainer/docker-compose.yml build app
- docker compose -f .devcontainer/docker-compose.yml run --rm --no-deps app bash -lc 'pg_restore --version && pg_dump --version && psql --version && pg_restore --list apps/admin/.tmp/db-backups/video-db-video-core-2026-05-15T00-49-43-665Z.dump | head'\n- docker run --rm pgvector/pgvector:pg18 postgres --version\n- pnpm format:check