### PR TITLE
fix: use postgres 18 volume layout in devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     image: pgvector/pgvector:pg18
     restart: unless-stopped
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata18:/var/lib/postgresql
     environment:
       POSTGRES_USER: forge
       POSTGRES_PASSWORD: forge
@@ -56,7 +56,7 @@ services:
       retries: 5
 
 volumes:
-  pgdata:
+  pgdata18:
   redisdata:
   claude-code-bashhistory:
   claude-code-config:

--- a/docs/solutions/platform/devcontainer-setup.md
+++ b/docs/solutions/platform/devcontainer-setup.md
@@ -35,8 +35,9 @@ RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "$FNM_D
 
 - PostgreSQL client tools come from the official PGDG apt repository and install `postgresql-client-18`. Ubuntu 24.04's default `postgresql-client` package resolves to PostgreSQL 16, which cannot read custom-format dumps with header version 1.16 from newer Railway PostgreSQL backups.
 - The local database sidecar uses `pgvector/pgvector:pg18` to match the Railway PostgreSQL 18 production major version as closely as practical in local development.
+- PostgreSQL 18 Docker images expect the persistent volume at `/var/lib/postgresql`, not `/var/lib/postgresql/data`, so the Compose volume is named `pgdata18` and mounted at `/var/lib/postgresql`.
 - After rebuilding the devcontainer, verify `pg_restore --version`, `pg_dump --version`, and `psql --version` all report PostgreSQL 18 before restoring production backup artifacts.
-- PostgreSQL major-version upgrades cannot reuse an old data directory. If a local `pgdata` volume was created with PostgreSQL 16, recreate it before starting the PG18 sidecar.
+- PostgreSQL major-version upgrades cannot reuse an old data directory. Old `pgdata` volumes created with PostgreSQL 16 are intentionally not reused by the PG18 sidecar.
 
 ## Known gaps / watch-outs
 


### PR DESCRIPTION
## Summary
- mount the PG18 sidecar volume at `/var/lib/postgresql`, which PostgreSQL 18 Docker images expect
- use a new `pgdata18` named volume so existing PG16 `pgdata` volumes do not break startup
- document the PG18 volume layout

## Verification
- docker logs forge_devcontainer-db-1 showed PG18 rejecting data at `/var/lib/postgresql/data`
- docker compose --project-name forge_devcontainer -f .devcontainer/docker-compose.yml rm -sf db
- docker compose --project-name forge_devcontainer -f .devcontainer/docker-compose.yml up -d db
- docker inspect forge_devcontainer-db-1 --format '{{.State.Health.Status}}' => healthy\n- pnpm format:check