### PR TITLE
fix(web): three admin-independent UI tweaks

### DIFF
--- a/apps/web/src/components/watch/DownloadModal.tsx
+++ b/apps/web/src/components/watch/DownloadModal.tsx
@@ -10,6 +10,7 @@ import {
   Play,
 } from "lucide-react"
 
+import { formatDuration as formatDurationShared } from "@/lib/format-duration"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import {
@@ -168,14 +169,16 @@ function SizeLabel({
   return <span className={className}>({label})</span>
 }
 
+// Thin null-tolerant wrapper around the shared formatter. The download
+// modal renders nothing when duration is missing or non-positive
+// (previously returned `null`); preserving that semantic keeps the JSX
+// checks (`durationLabel != null`) unchanged. Note: the shared
+// formatter does NOT zero-pad the leading segment (`1:10`, not
+// `01:10`) — that's a visible label format change for this modal
+// matching the standard media-duration convention used elsewhere.
 function formatDuration(seconds: number | null | undefined): string | null {
   if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) return null
-  const total = Math.floor(seconds)
-  const h = Math.floor(total / 3600)
-  const m = Math.floor((total % 3600) / 60)
-  const s = total % 60
-  const pad = (n: number) => n.toString().padStart(2, "0")
-  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`
+  return formatDurationShared(seconds)
 }
 
 export function DownloadModal({

--- a/apps/web/src/components/watch/LanguageCombobox.tsx
+++ b/apps/web/src/components/watch/LanguageCombobox.tsx
@@ -180,7 +180,13 @@ export function LanguageCombobox({
         <div
           ref={popoverRef}
           data-testid="language-combobox-popover"
-          className="absolute left-0 right-0 z-20 mt-2 rounded-2xl border border-stone-700 bg-stone-900 shadow-xl"
+          // `overflow-hidden` is load-bearing — the listbox <ul> below has
+          // its own `overflow-y-auto` for scrolling, but without clipping
+          // at the popover edge the last option's hover/active background
+          // (the filled `<button>`) paints past the `rounded-2xl` corner.
+          // `shadow-xl` is unaffected because box-shadow renders outside
+          // the element's bounding box, not against its overflow rule.
+          className="absolute left-0 right-0 z-20 mt-2 overflow-hidden rounded-2xl border border-stone-700 bg-stone-900 shadow-xl"
         >
           <div className="border-b border-stone-700 px-3 py-2">
             <input

--- a/apps/web/src/components/watch/__tests__/DownloadModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/DownloadModal.test.tsx
@@ -112,9 +112,13 @@ describe("DownloadModal — header metadata", () => {
     expect(
       $('[data-testid="watch-download-modal-language"]')?.textContent,
     ).toContain("English")
+    // `formatDuration` is the shared util at `@/lib/format-duration` —
+    // hours render without zero-padding (`2:07:54`, not `02:07:54`) to
+    // match the standard media-duration convention and the search-card
+    // pill format.
     expect(
       $('[data-testid="watch-download-modal-duration"]')?.textContent,
-    ).toContain("02:07:54")
+    ).toContain("2:07:54")
     expect($('[data-testid="watch-download-modal-poster"]')).not.toBeNull()
   })
 

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -1065,10 +1065,15 @@ const fetchWatchVideoBySlug = cache(
         fallback as { error?: ErrorLike; errors?: unknown[] },
       )
       if (!fallbackError && fallback.data?.videoBySlug?.locales?.[0]) {
-        return normalizeAdminVideo({
-          ...raw,
-          locales: fallback.data.videoBySlug.locales,
-        })
+        // Use the entire EN-fetched shape, not just top-level `locales`.
+        // The fragment applies `locales(locale: $locale)` at every nesting
+        // tier (parents, parents.children, etc.); a slug-form locale like
+        // "english" matches no BCP-47 row, so all nested `locales[]` come
+        // back empty too. Returning the fallback shape fills the sibling
+        // carousel + canonical-parent titles in one go. `dubs`, `images`,
+        // `parents`, `children` aren't locale-filtered, so the two shapes
+        // are byte-equivalent outside the `locales[]` arrays we want.
+        return normalizeAdminVideo(fallback.data.videoBySlug)
       }
     }
 

--- a/apps/web/src/lib/format-duration.ts
+++ b/apps/web/src/lib/format-duration.ts
@@ -1,0 +1,21 @@
+/**
+ * Format a duration in seconds as a `m:ss` (sub-hour) or `h:mm:ss`
+ * (one hour or longer) timecode. Single source of truth for both the
+ * search-card duration pill and the download-modal duration label.
+ *
+ * Sub-hour: `1:10`, `9:59`, `12:34` (minutes are NOT zero-padded —
+ * standard media-duration convention).
+ * Hour-plus: `1:00:00`, `1:02:05` (hour is NOT zero-padded; minutes
+ * and seconds are).
+ *
+ * Returns `""` for `NaN` / negative input; the empty string lets call
+ * sites render nothing without a separate null branch.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return ""
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  const pad = (n: number) => n.toString().padStart(2, "0")
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`
+}


### PR DESCRIPTION
## Summary

Three standalone web-only UI fixes. All work without any admin schema or GraphQL change and can ship in any order relative to backend work.

- **Sibling-carousel titles** (`lib/content.ts`) — the nested-locale fallback in `fetchWatchVideoBySlug` now returns the entire EN-fetched shape instead of patching only the top-level `locales` array. Fixes empty `CHAPTER` slots on URLs that use slug-form locales (e.g. `/1-jesus-our-loving-pursuer/english`). Admin's `locales(locale:)` filter is bcp47-strict and returns `[]` at every nesting tier when given the slug form; returning the fallback shape fills `parents.children[].child.locales[].title` for the sibling cards.
- **Language combobox bottom corner** (`components/watch/LanguageCombobox.tsx`) — `overflow-hidden` added to the popover container so the last `<li>`'s hover/active background no longer paints past the `rounded-2xl` corner. `shadow-xl` is unaffected because box-shadow renders outside the element's bounding box.
- **Download-modal duration format** (`components/watch/DownloadModal.tsx`, `lib/format-duration.ts`) — extracted the duplicated formatter into a shared util. Labels change format: `01:10 → 1:10`, `02:07:54 → 2:07:54` (drops the leading zero on the highest segment to match the standard media-duration convention).

## Test plan

- [x] `pnpm --filter web test src/components/watch/__tests__/LanguageCombobox.test.tsx src/components/watch/__tests__/DownloadModal.test.tsx src/lib/__tests__/content` — 77/77 pass
- [x] `pnpm --filter web typecheck` — clean
- [x] Browser smoke: sibling carousel populates titles at `/watch/1-jesus-our-loving-pursuer/english`
- [x] Browser smoke: language combobox bottom row (`Zulu`) clips cleanly inside the rounded popover
- [x] Browser smoke: download modal duration label reads `1:10` rather than `01:10`

## Deploy

No coordination required — admin SDL is untouched. The companion PR `fix(admin,web): correct Video relation inversion + add search card pills` (will be pushed separately) is unrelated to these three fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)