### PR TITLE
Preserve Auth OAuth login continuation

### DIFF
--- a/apps/auth/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.test.ts
@@ -68,4 +68,29 @@ describe("Auth route wrapper", () => {
     expect(response.status).toBe(200)
     expect(authPost).toHaveBeenCalledOnce()
   })
+
+  it("forwards OAuth continuation query through email sign-in", async () => {
+    authPost.mockResolvedValueOnce(Response.json({ ok: true }))
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-in/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email: "USER@example.com",
+          oauth_query: "client_id=jfp_admin_local&sig=signed",
+          password: "password",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["sign-in", "email"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    const forwardedRequest = authPost.mock.calls[0]?.[0] as Request
+    await expect(forwardedRequest.json()).resolves.toMatchObject({
+      email: "user@example.com",
+      oauth_query: "client_id=jfp_admin_local&sig=signed",
+      password: "password",
+    })
+  })
 })

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -30,15 +30,17 @@ function audit(event: string, email?: string): void {
 
 async function parseEmailPasswordRequest(
   request: Request,
-): Promise<{ email: string; password: string }> {
+): Promise<{ email: string; password: string; oauthQuery?: string }> {
   const contentType = request.headers.get("content-type") ?? ""
   if (contentType.includes("application/json")) {
     const body = (await request.json()) as {
       email?: string
+      oauth_query?: string
       password?: string
     }
     return {
       email: body.email?.trim().toLowerCase() ?? "",
+      oauthQuery: body.oauth_query,
       password: body.password ?? "",
     }
   }
@@ -48,6 +50,10 @@ async function parseEmailPasswordRequest(
     email: String(body.get("email") ?? "")
       .trim()
       .toLowerCase(),
+    oauthQuery:
+      typeof body.get("oauth_query") === "string"
+        ? String(body.get("oauth_query"))
+        : undefined,
     password: String(body.get("password") ?? ""),
   }
 }
@@ -79,13 +85,18 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
     return genericUnauthorized()
   }
 
-  const { email, password } = await parseEmailPasswordRequest(request)
+  const { email, oauthQuery, password } =
+    await parseEmailPasswordRequest(request)
   if (!email || !password) {
     audit("auth.signin.rejected", email)
     return genericUnauthorized()
   }
 
-  const jsonBody = { email, password }
+  const jsonBody = {
+    email,
+    password,
+    ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
+  }
   const primaryResponse = await authRouteHandlers.POST(
     toJsonRequest(request, jsonBody),
   )
@@ -123,6 +134,7 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
     body: {
       email,
       password,
+      ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
       name: email.split("@")[0] || "user",
     },
   })

--- a/apps/auth/src/app/globals.css
+++ b/apps/auth/src/app/globals.css
@@ -57,7 +57,7 @@ input {
 
 .login-copy h1 {
   max-width: 560px;
-  margin: 72px 0 0;
+  margin: 0;
   font-size: clamp(38px, 7vw, 72px);
   line-height: 0.96;
   letter-spacing: 0;
@@ -74,13 +74,8 @@ input {
 }
 
 .login-form h2 {
-  margin: 28px 0 8px;
+  margin: 0 0 8px;
   font-size: 24px;
-}
-
-.login-logo {
-  width: 139px;
-  height: 36px;
 }
 
 .form-field {
@@ -115,6 +110,7 @@ input {
 
 .primary-button,
 .provider-button {
+  position: relative;
   display: inline-flex;
   width: 100%;
   height: 42px;
@@ -145,17 +141,22 @@ input {
 }
 
 .last-used-badge {
+  position: absolute;
+  top: 5px;
+  right: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 18px;
+  min-height: 14px;
   border-radius: 999px;
-  padding: 2px 7px;
-  border: 1px solid rgba(251, 191, 36, 0.34);
-  color: #fbbf24;
-  font-size: 10px;
+  padding: 1px 5px;
+  border: 1px solid rgba(214, 211, 209, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  color: #a8a29e;
+  font-size: 8px;
   font-weight: 600;
-  letter-spacing: 0.06em;
+  line-height: 1;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   white-space: nowrap;
 }

--- a/apps/auth/src/app/login/login-page-client.tsx
+++ b/apps/auth/src/app/login/login-page-client.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import Image from "next/image"
 import { useState, type FormEvent } from "react"
 
 const providerLabels = {
@@ -33,9 +32,11 @@ const loginErrors = {
 export function LoginPageClient({
   enabledProviders,
   initialError,
+  oauthQuery,
 }: {
   enabledProviders: LoginProviderId[]
   initialError?: LoginErrorCode
+  oauthQuery: string
 }) {
   const [error, setError] = useState<
     LoginErrorCode | "credentials" | "start" | null
@@ -90,27 +91,11 @@ export function LoginPageClient({
     <main className="login-shell">
       <section className="login-panel">
         <div className="login-copy">
-          <Image
-            src="/images/jesus-film-logo-full.svg"
-            alt="Jesus Film Project"
-            width={139}
-            height={36}
-            className="login-logo"
-            priority
-          />
           <h1>Sign in to continue.</h1>
           <p>Secure access for approved applications.</p>
         </div>
 
         <div className="login-form">
-          <Image
-            src="/images/jesus-film-logo-full.svg"
-            alt="Jesus Film Project"
-            width={139}
-            height={36}
-            className="login-logo"
-            priority
-          />
           <h2>Sign in</h2>
           <p>Use the same method you used when your account was created.</p>
 
@@ -119,6 +104,7 @@ export function LoginPageClient({
             method="post"
             onSubmit={handleSubmit}
           >
+            <input type="hidden" name="oauth_query" value={oauthQuery} />
             <div className="form-field">
               <label htmlFor="email">Email address</label>
               <input
@@ -169,6 +155,7 @@ export function LoginPageClient({
                         credentials: "include",
                         headers: { "content-type": "application/json" },
                         body: JSON.stringify({
+                          oauth_query: oauthQuery,
                           provider: providerId,
                         }),
                       })

--- a/apps/auth/src/app/login/page.tsx
+++ b/apps/auth/src/app/login/page.tsx
@@ -30,6 +30,19 @@ function parseLoginError(
     : undefined
 }
 
+function toOAuthQuery(params: Record<string, string | string[] | undefined>) {
+  const oauthQuery = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (key === "error") continue
+    if (Array.isArray(value)) {
+      for (const item of value) oauthQuery.append(key, item)
+    } else if (value) {
+      oauthQuery.set(key, value)
+    }
+  }
+  return oauthQuery.toString()
+}
+
 function getEnabledProviders(): LoginProviderId[] {
   const providers: LoginProviderId[] = []
 
@@ -59,6 +72,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps = {}) {
     <LoginPageClient
       enabledProviders={getEnabledProviders()}
       initialError={parseLoginError(firstParam(params.error))}
+      oauthQuery={toOAuthQuery(params)}
     />
   )
 }

--- a/apps/auth/src/app/login/page.ui.test.tsx
+++ b/apps/auth/src/app/login/page.ui.test.tsx
@@ -14,12 +14,16 @@ describe("auth login UI", () => {
       <LoginPageClient
         enabledProviders={["google"]}
         initialError="account_not_linked"
+        oauthQuery="client_id=jfp_admin_local&sig=signed"
       />,
     )
 
     expect(html).toContain("This sign-in method is not linked yet.")
     expect(html).toContain("Sign in with the method you used before")
     expect(html).toContain("Continue with Google")
+    expect(html).toContain(
+      'name="oauth_query" value="client_id=jfp_admin_local&amp;sig=signed"',
+    )
   })
 
   it("identifies OAuth authorize requests as the only valid login entry", () => {


### PR DESCRIPTION
## Summary
- pass the signed OAuth authorize query through Auth email and provider sign-in
- keep Better Auth's OAuth provider continuation hook able to resume the admin authorization-code flow
- remove duplicate login logos and restyle the last-used badge as a smaller muted top-right pill

## Validation
- pnpm --filter @forge/auth test
- pnpm --filter @forge/auth typecheck
- pnpm --filter @forge/auth lint
- pnpm --filter @forge/auth build
- pnpm prettier --check apps/auth