### PR TITLE
fix(admin): enable full scheduled core sync

### DIFF
--- a/apps/admin/src/app/api/core-sync/scheduled/route.test.ts
+++ b/apps/admin/src/app/api/core-sync/scheduled/route.test.ts
@@ -10,10 +10,14 @@ const dispatchCoreSync = vi.hoisted(() => vi.fn())
 vi.mock("@/config/env", () => mockEnv)
 vi.mock("@/services/core-sync/job", () => ({ dispatchCoreSync }))
 
-function makePost(headers: Record<string, string> = {}): Request {
+function makePost(
+  headers: Record<string, string> = {},
+  body?: unknown,
+): Request {
   return new Request("http://localhost/api/core-sync/scheduled", {
     method: "POST",
     headers,
+    body: body == null ? undefined : JSON.stringify(body),
   })
 }
 
@@ -93,7 +97,52 @@ describe("scheduled Core sync endpoint", () => {
     expect(dispatchCoreSync).toHaveBeenCalledTimes(1)
     expect(dispatchCoreSync).toHaveBeenCalledWith({
       incremental: true,
+      scope: undefined,
       trigger: "scheduled",
     })
+  })
+
+  it("dispatches a requested full scoped sync with valid auth", async () => {
+    dispatchCoreSync.mockResolvedValueOnce({
+      workflow: "core-sync",
+      runId: "run-scheduled-full",
+      scope: ["languages", "videos"],
+      incremental: false,
+      trigger: "scheduled",
+      status: "queued",
+    })
+    const { POST } = await import("./route")
+    const res = await POST(
+      makePost(
+        {
+          authorization: "Bearer cron-secret",
+          "content-type": "application/json",
+        },
+        { incremental: false, scope: "languages,videos" },
+      ),
+    )
+
+    expect(res.status).toBe(202)
+    expect(dispatchCoreSync).toHaveBeenCalledWith({
+      incremental: false,
+      scope: ["languages", "videos"],
+      trigger: "scheduled",
+    })
+  })
+
+  it("rejects invalid scheduled sync options", async () => {
+    const { POST } = await import("./route")
+    const res = await POST(
+      makePost(
+        {
+          authorization: "Bearer cron-secret",
+          "content-type": "application/json",
+        },
+        { incremental: "false" },
+      ),
+    )
+
+    expect(res.status).toBe(400)
+    expect(dispatchCoreSync).not.toHaveBeenCalled()
   })
 })

--- a/apps/admin/src/app/api/core-sync/scheduled/route.ts
+++ b/apps/admin/src/app/api/core-sync/scheduled/route.ts
@@ -2,8 +2,17 @@ import { timingSafeEqual } from "node:crypto"
 import { env } from "@/config/env"
 import { dispatchCoreSync } from "@/services/core-sync/job"
 
+type ScheduledSyncBody = {
+  incremental?: unknown
+  scope?: unknown
+}
+
 function reject(): Response {
   return Response.json({ error: "Unauthorized" }, { status: 401 })
+}
+
+function badRequest(message: string): Response {
+  return Response.json({ error: message }, { status: 400 })
 }
 
 function methodNotAllowed(): Response {
@@ -38,11 +47,56 @@ function isAuthorized(request: Request): boolean {
   return token ? tokenMatches(token, env.CORE_SYNC_CRON_SECRET) : false
 }
 
+async function readBody(request: Request): Promise<ScheduledSyncBody> {
+  if (!request.headers.get("content-type")?.includes("application/json")) {
+    return {}
+  }
+
+  return (await request.json()) as ScheduledSyncBody
+}
+
+function readIncremental(value: unknown): boolean {
+  if (value == null) return true
+  if (typeof value === "boolean") return value
+  throw new Error("incremental must be a boolean")
+}
+
+function readScope(value: unknown): string[] | undefined {
+  if (value == null) return undefined
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value.map((item) => item.trim()).filter(Boolean)
+  }
+  throw new Error("scope must be a string or string array")
+}
+
 export async function POST(request: Request): Promise<Response> {
   if (!isAuthorized(request)) return reject()
 
+  let body: ScheduledSyncBody
+  try {
+    body = await readBody(request)
+  } catch {
+    return badRequest("Invalid JSON body")
+  }
+
+  let incremental: boolean
+  let scope: string[] | undefined
+  try {
+    incremental = readIncremental(body.incremental)
+    scope = readScope(body.scope)
+  } catch (error) {
+    return badRequest(error instanceof Error ? error.message : "Invalid body")
+  }
+
   const dispatch = await dispatchCoreSync({
-    incremental: true,
+    incremental,
+    scope,
     trigger: "scheduled",
   })
 

--- a/apps/admin/src/scripts/video-db-backup.test.ts
+++ b/apps/admin/src/scripts/video-db-backup.test.ts
@@ -169,8 +169,8 @@ describe("restore command planning", () => {
         "--single-transaction",
         "--dbname",
         "postgresql://user:pass@localhost/dev",
-        "--table=public.video",
-        "--table=public.video_transcript_chunk",
+        "--table=video",
+        "--table=video_transcript_chunk",
         plan.inPath,
       ]),
     )

--- a/apps/admin/src/scripts/video-db-backup.ts
+++ b/apps/admin/src/scripts/video-db-backup.ts
@@ -332,6 +332,10 @@ function tableArgs(tables: readonly string[]): string[] {
   return tables.map((table) => `--table=public.${table}`)
 }
 
+function restoreTableArgs(tables: readonly string[]): string[] {
+  return tables.map((table) => `--table=${table}`)
+}
+
 function quoteTable(table: string): string {
   return `"public"."${table.replace(/"/g, '""')}"`
 }
@@ -479,7 +483,7 @@ export function buildRestorePlan(
           "--single-transaction",
           "--dbname",
           target,
-          ...tableArgs(tables),
+          ...restoreTableArgs(tables),
           inPath,
         ],
       },

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -128,6 +128,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-115](platform/feat-115-admin-image-enrichment-workflow.md)                 | Admin Image Enrichment Workflow                         | tataihono | P1       | 2026-05-04 | 7    | 2026-05-10 | complete    |
 | [feat-122](platform/feat-122-admin-video-database-backup-and-clone.md)           | Admin video database backup and clone tooling           | tataihono | P1       | 2026-05-13 | 5    | 2026-05-17 | complete    |
 | [feat-123](platform/feat-123-admin-video-db-presigned-restore.md)                | Admin video database presigned restore access           | tataihono | P1       | 2026-05-15 | 1    | 2026-05-15 | complete    |
+| [feat-124](platform/feat-124-admin-prod-core-sync-restore-fix.md)                | Admin production core sync restore fix                  | tataihono | P1       | 2026-05-15 | 1    | 2026-05-15 | in-progress |
 | [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                              | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
 | [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                     | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                 | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |

--- a/docs/roadmap/platform/feat-124-admin-prod-core-sync-restore-fix.md
+++ b/docs/roadmap/platform/feat-124-admin-prod-core-sync-restore-fix.md
@@ -1,0 +1,38 @@
+---
+id: "feat-124"
+title: "Admin production core sync restore fix"
+owner: "tataihono"
+priority: "P1"
+status: "in-progress"
+start_date: "2026-05-15"
+duration: 1
+depends_on:
+  - "feat-123"
+blocks: []
+tags:
+  - "admin"
+  - "infrastructure"
+  - "database"
+---
+
+## Problem
+
+Production admin needs an authenticated way to enqueue a full Core sync run so
+the Railway worker can populate the production admin database over private
+networking. The restore path also filtered `pg_restore` tables with
+schema-qualified names, which caused custom archive restores to match no data.
+
+## Scope
+
+1. Allow `POST /api/core-sync/scheduled` callers with
+   `CORE_SYNC_CRON_SECRET` to pass `incremental` and `scope`.
+2. Keep the existing default behavior as incremental all-scope sync.
+3. Restore custom archive table data with unqualified `pg_restore --table`
+   selectors while keeping backup dumps schema-qualified.
+
+## Verification
+
+```bash
+pnpm --filter @forge/admin test src/app/api/core-sync/scheduled/route.test.ts src/scripts/video-db-backup.test.ts
+pnpm --filter @forge/admin typecheck
+```


### PR DESCRIPTION
## Summary
- allow the authenticated scheduled Core sync endpoint to request full/scoped runs
- fix video DB restores from custom archives by using unqualified pg_restore table selectors
- add roadmap ticket feat-124 for the production sync/restore incident

## Verification
- pnpm --filter @forge/admin test src/app/api/core-sync/scheduled/route.test.ts src/scripts/video-db-backup.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint