### PR TITLE
fix(admin): extend core sync transaction budget

### DIFF
--- a/apps/admin/src/services/core-sync/phases/sync-countries.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-countries.ts
@@ -6,6 +6,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreCountrySchema } from "../schemas/country"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 import {
   toLocalizedNames,
   toNameMap,
@@ -120,107 +121,40 @@ export async function syncCountries({
 
   try {
     let pageUpdated = 0
-    await prisma.$transaction(
-      async (tx) => {
-        const languages = await tx.language.findMany({
-          select: { id: true, coreId: true },
-        })
-        const langMap = new Map(languages.map((l) => [l.coreId, l.id]))
+    await prisma.$transaction(async (tx) => {
+      const languages = await tx.language.findMany({
+        select: { id: true, coreId: true },
+      })
+      const langMap = new Map(languages.map((l) => [l.coreId, l.id]))
 
-        for (const country of countries) {
-          let continentId: string | undefined
-          if (country.continent) {
-            const continent = await tx.continent.upsert({
-              where: { coreId: country.continent.id },
-              create: {
-                coreId: country.continent.id,
-                name: toNameMap(country.continent.name),
-                syncedAt: new Date(),
-              },
-              update: {
-                name: toNameMap(country.continent.name),
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-            continentId = continent.id
-            const continentLocales = toLocalizedNames(country.continent.name)
-            for (const localeRow of continentLocales) {
-              await tx.continentLocale.upsert({
-                where: {
-                  continentId_locale: {
-                    continentId: continent.id,
-                    locale: localeRow.locale,
-                  },
-                },
-                create: {
-                  continentId: continent.id,
-                  locale: localeRow.locale,
-                  value: localeRow.value,
-                  primary: localeRow.primary,
-                  order: localeRow.order,
-                  syncedAt: new Date(),
-                },
-                update: {
-                  value: localeRow.value,
-                  primary: localeRow.primary,
-                  order: localeRow.order,
-                  syncedAt: new Date(),
-                  deletedAt: null,
-                },
-              })
-            }
-            await tx.continentLocale.updateMany({
-              where: {
-                continentId: continent.id,
-                source: "CORE",
-                locale: { notIn: continentLocales.map((row) => row.locale) },
-                deletedAt: null,
-              },
-              data: { deletedAt: new Date() },
-            })
-          }
-
-          const countryRow = await tx.country.upsert({
-            where: { coreId: country.id },
+      for (const country of countries) {
+        let continentId: string | undefined
+        if (country.continent) {
+          const continent = await tx.continent.upsert({
+            where: { coreId: country.continent.id },
             create: {
-              coreId: country.id,
-              name: toNameMap(country.name),
-              population: country.population,
-              latitude: country.latitude,
-              longitude: country.longitude,
-              flagPngSrc: country.flagPngSrc,
-              flagWebpSrc: country.flagWebpSrc,
-              languageCount: country.languageCount,
-              languageHavingMediaCount: country.languageHavingMediaCount,
-              continentId: continentId ?? null,
+              coreId: country.continent.id,
+              name: toNameMap(country.continent.name),
               syncedAt: new Date(),
             },
             update: {
-              name: toNameMap(country.name),
-              population: country.population,
-              latitude: country.latitude,
-              longitude: country.longitude,
-              flagPngSrc: country.flagPngSrc,
-              flagWebpSrc: country.flagWebpSrc,
-              languageCount: country.languageCount,
-              languageHavingMediaCount: country.languageHavingMediaCount,
-              continentId: continentId ?? null,
+              name: toNameMap(country.continent.name),
               syncedAt: new Date(),
               deletedAt: null,
             },
           })
-          const countryLocales = toLocalizedNames(country.name)
-          for (const localeRow of countryLocales) {
-            await tx.countryLocale.upsert({
+          continentId = continent.id
+          const continentLocales = toLocalizedNames(country.continent.name)
+          for (const localeRow of continentLocales) {
+            await tx.continentLocale.upsert({
               where: {
-                countryId_locale: {
-                  countryId: countryRow.id,
+                continentId_locale: {
+                  continentId: continent.id,
                   locale: localeRow.locale,
                 },
               },
               create: {
-                countryId: countryRow.id,
+                continentId: continent.id,
                 locale: localeRow.locale,
                 value: localeRow.value,
                 primary: localeRow.primary,
@@ -236,69 +170,133 @@ export async function syncCountries({
               },
             })
           }
-          await tx.countryLocale.updateMany({
+          await tx.continentLocale.updateMany({
             where: {
-              countryId: countryRow.id,
+              continentId: continent.id,
               source: "CORE",
-              locale: { notIn: countryLocales.map((row) => row.locale) },
+              locale: { notIn: continentLocales.map((row) => row.locale) },
               deletedAt: null,
             },
             data: { deletedAt: new Date() },
           })
-
-          for (const countryLanguage of country.countryLanguages) {
-            const languageId = langMap.get(countryLanguage.language.id)
-            if (!languageId) {
-              stats.errors++
-              console.warn(
-                JSON.stringify({
-                  event: "core-sync.country-language.missing-language",
-                  countryCoreId: country.id,
-                  countryLanguageCoreId: countryLanguage.id,
-                  languageCoreId: countryLanguage.language.id,
-                }),
-              )
-              continue
-            }
-
-            seenCountryLanguageCoreIds.add(countryLanguage.id)
-            await tx.countryLanguage.upsert({
-              where: {
-                countryId_languageId: {
-                  countryId: countryRow.id,
-                  languageId,
-                },
-              },
-              create: {
-                coreId: countryLanguage.id,
-                countryId: countryRow.id,
-                languageId,
-                speakers: countryLanguage.speakers,
-                displaySpeakers: countryLanguage.displaySpeakers,
-                primary: countryLanguage.primary,
-                suggested: countryLanguage.suggested,
-                order: countryLanguage.order,
-                syncedAt: new Date(),
-              },
-              update: {
-                coreId: countryLanguage.id,
-                countryId: countryRow.id,
-                languageId,
-                speakers: countryLanguage.speakers,
-                displaySpeakers: countryLanguage.displaySpeakers,
-                primary: countryLanguage.primary,
-                suggested: countryLanguage.suggested,
-                order: countryLanguage.order,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-          }
-          pageUpdated++
         }
-      },
-      { timeout: 60_000, maxWait: 5_000 },
-    )
+
+        const countryRow = await tx.country.upsert({
+          where: { coreId: country.id },
+          create: {
+            coreId: country.id,
+            name: toNameMap(country.name),
+            population: country.population,
+            latitude: country.latitude,
+            longitude: country.longitude,
+            flagPngSrc: country.flagPngSrc,
+            flagWebpSrc: country.flagWebpSrc,
+            languageCount: country.languageCount,
+            languageHavingMediaCount: country.languageHavingMediaCount,
+            continentId: continentId ?? null,
+            syncedAt: new Date(),
+          },
+          update: {
+            name: toNameMap(country.name),
+            population: country.population,
+            latitude: country.latitude,
+            longitude: country.longitude,
+            flagPngSrc: country.flagPngSrc,
+            flagWebpSrc: country.flagWebpSrc,
+            languageCount: country.languageCount,
+            languageHavingMediaCount: country.languageHavingMediaCount,
+            continentId: continentId ?? null,
+            syncedAt: new Date(),
+            deletedAt: null,
+          },
+        })
+        const countryLocales = toLocalizedNames(country.name)
+        for (const localeRow of countryLocales) {
+          await tx.countryLocale.upsert({
+            where: {
+              countryId_locale: {
+                countryId: countryRow.id,
+                locale: localeRow.locale,
+              },
+            },
+            create: {
+              countryId: countryRow.id,
+              locale: localeRow.locale,
+              value: localeRow.value,
+              primary: localeRow.primary,
+              order: localeRow.order,
+              syncedAt: new Date(),
+            },
+            update: {
+              value: localeRow.value,
+              primary: localeRow.primary,
+              order: localeRow.order,
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+        }
+        await tx.countryLocale.updateMany({
+          where: {
+            countryId: countryRow.id,
+            source: "CORE",
+            locale: { notIn: countryLocales.map((row) => row.locale) },
+            deletedAt: null,
+          },
+          data: { deletedAt: new Date() },
+        })
+
+        for (const countryLanguage of country.countryLanguages) {
+          const languageId = langMap.get(countryLanguage.language.id)
+          if (!languageId) {
+            stats.errors++
+            console.warn(
+              JSON.stringify({
+                event: "core-sync.country-language.missing-language",
+                countryCoreId: country.id,
+                countryLanguageCoreId: countryLanguage.id,
+                languageCoreId: countryLanguage.language.id,
+              }),
+            )
+            continue
+          }
+
+          seenCountryLanguageCoreIds.add(countryLanguage.id)
+          await tx.countryLanguage.upsert({
+            where: {
+              countryId_languageId: {
+                countryId: countryRow.id,
+                languageId,
+              },
+            },
+            create: {
+              coreId: countryLanguage.id,
+              countryId: countryRow.id,
+              languageId,
+              speakers: countryLanguage.speakers,
+              displaySpeakers: countryLanguage.displaySpeakers,
+              primary: countryLanguage.primary,
+              suggested: countryLanguage.suggested,
+              order: countryLanguage.order,
+              syncedAt: new Date(),
+            },
+            update: {
+              coreId: countryLanguage.id,
+              countryId: countryRow.id,
+              languageId,
+              speakers: countryLanguage.speakers,
+              displaySpeakers: countryLanguage.displaySpeakers,
+              primary: countryLanguage.primary,
+              suggested: countryLanguage.suggested,
+              order: countryLanguage.order,
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+        }
+        pageUpdated++
+      }
+    }, CORE_SYNC_TRANSACTION_OPTIONS)
     stats.updated += pageUpdated
   } catch (err) {
     stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-dub-downloads.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-dub-downloads.ts
@@ -7,6 +7,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery, CoreGraphQLError } from "../core-client"
 import { CoreDubDownloadSchema } from "../schemas/dub-download"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 import { assertParallelArrayLengthsMatch, toPgArray } from "@/db/pgvector"
 
 export const PAGE_SIZE = 20000
@@ -270,14 +271,11 @@ export async function syncDubDownloads({
     })
 
     try {
-      await prisma.$transaction(
-        async (tx) => {
-          await bulkUpsertDownloads(tx, writes, {
-            refreshUnchangedRows: !since,
-          })
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+      await prisma.$transaction(async (tx) => {
+        await bulkUpsertDownloads(tx, writes, {
+          refreshUnchangedRows: !since,
+        })
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += writes.length
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-dubs.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-dubs.ts
@@ -10,6 +10,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery, CoreGraphQLError } from "../core-client"
 import { CoreDubSchema } from "../schemas/dub"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 import { assertParallelArrayLengthsMatch, toPgArray } from "@/db/pgvector"
 
 // Page size sized to Core's resolver fan-out budget, not to client-side
@@ -379,103 +380,100 @@ export async function syncDubs({
       let pageUpdated = 0
       let pageSkippedMissingVideo = 0
       const missingVideoSamples: Array<{ dubId: string; videoId: string }> = []
-      await prisma.$transaction(
-        async (tx) => {
-          const existingCoreDubs = await tx.videoDub.findMany({
-            where: { coreId: { in: variants.map((variant) => variant.id) } },
-            select: { coreId: true, source: true },
-          })
-          const managerOwnedCoreIds = new Set(
-            existingCoreDubs
-              .filter((dub) => dub.source === "MANAGER")
-              .map((dub) => dub.coreId),
-          )
-          const pageMuxVideos = new Map<
-            string,
-            {
-              id: string
-              coreId: string
-              assetId: string | null
-              playbackId: string | null
-            }
-          >()
-
-          for (const variant of variants) {
-            if (variant.muxVideo) {
-              pageMuxVideos.set(variant.muxVideo.id, {
-                id: randomUUID(),
-                coreId: variant.muxVideo.id,
-                assetId: variant.muxVideo.assetId,
-                playbackId: variant.muxVideo.playbackId,
-              })
-            }
+      await prisma.$transaction(async (tx) => {
+        const existingCoreDubs = await tx.videoDub.findMany({
+          where: { coreId: { in: variants.map((variant) => variant.id) } },
+          select: { coreId: true, source: true },
+        })
+        const managerOwnedCoreIds = new Set(
+          existingCoreDubs
+            .filter((dub) => dub.source === "MANAGER")
+            .map((dub) => dub.coreId),
+        )
+        const pageMuxVideos = new Map<
+          string,
+          {
+            id: string
+            coreId: string
+            assetId: string | null
+            playbackId: string | null
           }
-          const muxVideoIdByCoreId = await bulkUpsertMuxVideos(
-            tx,
-            Array.from(pageMuxVideos.values()),
-          )
-          const pageDubs: DubWrite[] = []
+        >()
 
-          for (const variant of variants) {
-            const videoId = videoMap.get(variant.videoId)
-            if (!videoId) {
-              pageSkippedMissingVideo++
-              if (missingVideoSamples.length < 5) {
-                missingVideoSamples.push({
-                  dubId: variant.id,
-                  videoId: variant.videoId,
-                })
-              }
-              continue
-            }
-
-            if (managerOwnedCoreIds.has(variant.id)) {
-              continue
-            }
-
-            const languageId = variant.language
-              ? (langMap.get(variant.language.id) ?? null)
-              : null
-            const videoEditionId = variant.videoEdition
-              ? editionMap.get(variant.videoEdition.id)
-              : undefined
-            const muxVideoId = variant.muxVideo
-              ? muxVideoIdByCoreId.get(variant.muxVideo.id)
-              : undefined
-
-            const updatedAt = variant.updatedAt
-              ? new Date(variant.updatedAt)
-              : new Date()
-
-            pageDubs.push({
+        for (const variant of variants) {
+          if (variant.muxVideo) {
+            pageMuxVideos.set(variant.muxVideo.id, {
               id: randomUUID(),
-              coreId: variant.id,
-              videoId,
-              slug: variant.slug,
-              duration: String(variant.duration),
-              lengthInMilliseconds: variant.lengthInMilliseconds
-                ? String(variant.lengthInMilliseconds)
-                : null,
-              hls: variant.hls,
-              dash: variant.dash,
-              share: variant.share,
-              downloadable: String(variant.downloadable),
-              published: String(variant.published),
-              brightcoveId: variant.brightcoveId,
-              languageId,
-              videoEditionId: videoEditionId ?? null,
-              muxVideoId: muxVideoId ?? null,
-              updatedAt: updatedAt.toISOString(),
+              coreId: variant.muxVideo.id,
+              assetId: variant.muxVideo.assetId,
+              playbackId: variant.muxVideo.playbackId,
             })
           }
+        }
+        const muxVideoIdByCoreId = await bulkUpsertMuxVideos(
+          tx,
+          Array.from(pageMuxVideos.values()),
+        )
+        const pageDubs: DubWrite[] = []
 
-          await bulkUpsertDubs(tx, pageDubs, {
-            refreshUnchangedRows: !since,
+        for (const variant of variants) {
+          const videoId = videoMap.get(variant.videoId)
+          if (!videoId) {
+            pageSkippedMissingVideo++
+            if (missingVideoSamples.length < 5) {
+              missingVideoSamples.push({
+                dubId: variant.id,
+                videoId: variant.videoId,
+              })
+            }
+            continue
+          }
+
+          if (managerOwnedCoreIds.has(variant.id)) {
+            continue
+          }
+
+          const languageId = variant.language
+            ? (langMap.get(variant.language.id) ?? null)
+            : null
+          const videoEditionId = variant.videoEdition
+            ? editionMap.get(variant.videoEdition.id)
+            : undefined
+          const muxVideoId = variant.muxVideo
+            ? muxVideoIdByCoreId.get(variant.muxVideo.id)
+            : undefined
+
+          const updatedAt = variant.updatedAt
+            ? new Date(variant.updatedAt)
+            : new Date()
+
+          pageDubs.push({
+            id: randomUUID(),
+            coreId: variant.id,
+            videoId,
+            slug: variant.slug,
+            duration: String(variant.duration),
+            lengthInMilliseconds: variant.lengthInMilliseconds
+              ? String(variant.lengthInMilliseconds)
+              : null,
+            hls: variant.hls,
+            dash: variant.dash,
+            share: variant.share,
+            downloadable: String(variant.downloadable),
+            published: String(variant.published),
+            brightcoveId: variant.brightcoveId,
+            languageId,
+            videoEditionId: videoEditionId ?? null,
+            muxVideoId: muxVideoId ?? null,
+            updatedAt: updatedAt.toISOString(),
           })
-          pageUpdated += pageDubs.length
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+        }
+
+        await bulkUpsertDubs(tx, pageDubs, {
+          refreshUnchangedRows: !since,
+        })
+        pageUpdated += pageDubs.length
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += pageUpdated
       if (pageSkippedMissingVideo > 0) {
         console.warn(

--- a/apps/admin/src/services/core-sync/phases/sync-keywords.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-keywords.ts
@@ -6,6 +6,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreKeywordSchema } from "../schemas/keyword"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 
 const KEYWORDS_QUERY = `
   query Keywords($offset: Int!, $limit: Int!, $where: KeywordsFilter) {
@@ -84,33 +85,30 @@ export async function syncKeywords({
 
     try {
       let pageUpdated = 0
-      await prisma.$transaction(
-        async (tx) => {
-          for (const keyword of keywords) {
-            const languageId = keyword.language
-              ? (langMap.get(keyword.language.id) ?? null)
-              : null
+      await prisma.$transaction(async (tx) => {
+        for (const keyword of keywords) {
+          const languageId = keyword.language
+            ? (langMap.get(keyword.language.id) ?? null)
+            : null
 
-            await tx.keyword.upsert({
-              where: { coreId: keyword.id },
-              create: {
-                coreId: keyword.id,
-                value: keyword.value,
-                languageId,
-                syncedAt: new Date(),
-              },
-              update: {
-                value: keyword.value,
-                languageId,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-            pageUpdated++
-          }
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+          await tx.keyword.upsert({
+            where: { coreId: keyword.id },
+            create: {
+              coreId: keyword.id,
+              value: keyword.value,
+              languageId,
+              syncedAt: new Date(),
+            },
+            update: {
+              value: keyword.value,
+              languageId,
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+          pageUpdated++
+        }
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += pageUpdated
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-languages.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-languages.ts
@@ -8,6 +8,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreLanguageSchema } from "../schemas/language"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 import {
   toLocalizedNames,
   toNameMap,
@@ -119,100 +120,97 @@ export async function syncLanguages({
 
     try {
       let pageUpdated = 0
-      await prisma.$transaction(
-        async (tx) => {
-          for (const lang of languages) {
-            const nameMap = toNameMap(lang.name)
-            const audioPreviewSize = lang.audioPreview?.size
-              ? BigInt(lang.audioPreview.size)
+      await prisma.$transaction(async (tx) => {
+        for (const lang of languages) {
+          const nameMap = toNameMap(lang.name)
+          const audioPreviewSize = lang.audioPreview?.size
+            ? BigInt(lang.audioPreview.size)
+            : null
+          const slugOwner = lang.slug ? slugOwners.get(lang.slug) : undefined
+          const slug =
+            lang.slug && (!slugOwner || slugOwner === lang.id)
+              ? lang.slug
               : null
-            const slugOwner = lang.slug ? slugOwners.get(lang.slug) : undefined
-            const slug =
-              lang.slug && (!slugOwner || slugOwner === lang.id)
-                ? lang.slug
-                : null
-            if (lang.slug && !slug) {
-              console.warn(
-                JSON.stringify({
-                  event: "core-sync.language.duplicate-slug",
-                  languageCoreId: lang.id,
-                  slug: lang.slug,
-                  existingLanguageCoreId: slugOwner,
-                }),
-              )
-            } else if (slug) {
-              slugOwners.set(slug, lang.id)
-            }
+          if (lang.slug && !slug) {
+            console.warn(
+              JSON.stringify({
+                event: "core-sync.language.duplicate-slug",
+                languageCoreId: lang.id,
+                slug: lang.slug,
+                existingLanguageCoreId: slugOwner,
+              }),
+            )
+          } else if (slug) {
+            slugOwners.set(slug, lang.id)
+          }
 
-            const language = await tx.language.upsert({
-              where: { coreId: lang.id },
+          const language = await tx.language.upsert({
+            where: { coreId: lang.id },
+            create: {
+              coreId: lang.id,
+              bcp47: lang.bcp47,
+              iso3: lang.iso3,
+              slug,
+              name: nameMap,
+              audioPreviewValue: lang.audioPreview?.value ?? null,
+              audioPreviewDuration: lang.audioPreview?.duration ?? null,
+              audioPreviewSize,
+              audioPreviewBitrate: lang.audioPreview?.bitrate ?? null,
+              audioPreviewCodec: lang.audioPreview?.codec ?? null,
+              syncedAt: new Date(),
+            },
+            update: {
+              bcp47: lang.bcp47,
+              iso3: lang.iso3,
+              slug,
+              name: nameMap,
+              audioPreviewValue: lang.audioPreview?.value ?? null,
+              audioPreviewDuration: lang.audioPreview?.duration ?? null,
+              audioPreviewSize,
+              audioPreviewBitrate: lang.audioPreview?.bitrate ?? null,
+              audioPreviewCodec: lang.audioPreview?.codec ?? null,
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+          const localeRows = toLocalizedNames(lang.name)
+          for (const localeRow of localeRows) {
+            await tx.languageLocale.upsert({
+              where: {
+                languageId_locale: {
+                  languageId: language.id,
+                  locale: localeRow.locale,
+                },
+              },
               create: {
-                coreId: lang.id,
-                bcp47: lang.bcp47,
-                iso3: lang.iso3,
-                slug,
-                name: nameMap,
-                audioPreviewValue: lang.audioPreview?.value ?? null,
-                audioPreviewDuration: lang.audioPreview?.duration ?? null,
-                audioPreviewSize,
-                audioPreviewBitrate: lang.audioPreview?.bitrate ?? null,
-                audioPreviewCodec: lang.audioPreview?.codec ?? null,
+                languageId: language.id,
+                locale: localeRow.locale,
+                value: localeRow.value,
+                primary: localeRow.primary,
+                order: localeRow.order,
                 syncedAt: new Date(),
               },
               update: {
-                bcp47: lang.bcp47,
-                iso3: lang.iso3,
-                slug,
-                name: nameMap,
-                audioPreviewValue: lang.audioPreview?.value ?? null,
-                audioPreviewDuration: lang.audioPreview?.duration ?? null,
-                audioPreviewSize,
-                audioPreviewBitrate: lang.audioPreview?.bitrate ?? null,
-                audioPreviewCodec: lang.audioPreview?.codec ?? null,
+                value: localeRow.value,
+                primary: localeRow.primary,
+                order: localeRow.order,
                 syncedAt: new Date(),
                 deletedAt: null,
               },
             })
-            const localeRows = toLocalizedNames(lang.name)
-            for (const localeRow of localeRows) {
-              await tx.languageLocale.upsert({
-                where: {
-                  languageId_locale: {
-                    languageId: language.id,
-                    locale: localeRow.locale,
-                  },
-                },
-                create: {
-                  languageId: language.id,
-                  locale: localeRow.locale,
-                  value: localeRow.value,
-                  primary: localeRow.primary,
-                  order: localeRow.order,
-                  syncedAt: new Date(),
-                },
-                update: {
-                  value: localeRow.value,
-                  primary: localeRow.primary,
-                  order: localeRow.order,
-                  syncedAt: new Date(),
-                  deletedAt: null,
-                },
-              })
-            }
-            await tx.languageLocale.updateMany({
-              where: {
-                languageId: language.id,
-                source: "CORE",
-                locale: { notIn: localeRows.map((row) => row.locale) },
-                deletedAt: null,
-              },
-              data: { deletedAt: new Date() },
-            })
-            pageUpdated++
           }
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+          await tx.languageLocale.updateMany({
+            where: {
+              languageId: language.id,
+              source: "CORE",
+              locale: { notIn: localeRows.map((row) => row.locale) },
+              deletedAt: null,
+            },
+            data: { deletedAt: new Date() },
+          })
+          pageUpdated++
+        }
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += pageUpdated
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-video-editions.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-video-editions.ts
@@ -7,6 +7,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreVideoEditionSchema } from "../schemas/video-edition"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 
 const VIDEO_EDITIONS_QUERY = `
   query VideoEditions($offset: Int!, $limit: Int!, $where: VideoEditionsFilter) {
@@ -78,27 +79,24 @@ export async function syncVideoEditions({
 
     try {
       let updated = 0
-      await prisma.$transaction(
-        async (tx) => {
-          for (const edition of editions) {
-            await tx.videoEdition.upsert({
-              where: { coreId: edition.id },
-              create: {
-                coreId: edition.id,
-                name: edition.name ?? "",
-                syncedAt: new Date(),
-              },
-              update: {
-                name: edition.name ?? "",
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-            updated++
-          }
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+      await prisma.$transaction(async (tx) => {
+        for (const edition of editions) {
+          await tx.videoEdition.upsert({
+            where: { coreId: edition.id },
+            create: {
+              coreId: edition.id,
+              name: edition.name ?? "",
+              syncedAt: new Date(),
+            },
+            update: {
+              name: edition.name ?? "",
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+          updated++
+        }
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += updated
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-video-images.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-video-images.ts
@@ -6,6 +6,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreVideoImageSchema } from "../schemas/video-image"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 
 const PAGE_SIZE = 10000
 
@@ -96,47 +97,44 @@ export async function syncVideoImages({
 
     try {
       let updated = 0
-      await prisma.$transaction(
-        async (tx) => {
-          for (const image of images) {
-            if (!image.videoId) continue
-            const videoId = videoMap.get(image.videoId)
-            if (!videoId) continue
+      await prisma.$transaction(async (tx) => {
+        for (const image of images) {
+          if (!image.videoId) continue
+          const videoId = videoMap.get(image.videoId)
+          if (!videoId) continue
 
-            await tx.videoImage.upsert({
-              where: { coreId: image.id },
-              create: {
-                coreId: image.id,
-                videoId,
-                url: image.url,
-                aspectRatio: image.aspectRatio,
-                mobileCinematicHigh: image.mobileCinematicHigh,
-                mobileCinematicLow: image.mobileCinematicLow,
-                mobileCinematicVeryLow: image.mobileCinematicVeryLow,
-                thumbnail: image.thumbnail,
-                videoStill: image.videoStill,
-                blurhash: image.blurhash,
-                syncedAt: new Date(),
-              },
-              update: {
-                videoId,
-                url: image.url,
-                aspectRatio: image.aspectRatio,
-                mobileCinematicHigh: image.mobileCinematicHigh,
-                mobileCinematicLow: image.mobileCinematicLow,
-                mobileCinematicVeryLow: image.mobileCinematicVeryLow,
-                thumbnail: image.thumbnail,
-                videoStill: image.videoStill,
-                blurhash: image.blurhash,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-            updated++
-          }
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+          await tx.videoImage.upsert({
+            where: { coreId: image.id },
+            create: {
+              coreId: image.id,
+              videoId,
+              url: image.url,
+              aspectRatio: image.aspectRatio,
+              mobileCinematicHigh: image.mobileCinematicHigh,
+              mobileCinematicLow: image.mobileCinematicLow,
+              mobileCinematicVeryLow: image.mobileCinematicVeryLow,
+              thumbnail: image.thumbnail,
+              videoStill: image.videoStill,
+              blurhash: image.blurhash,
+              syncedAt: new Date(),
+            },
+            update: {
+              videoId,
+              url: image.url,
+              aspectRatio: image.aspectRatio,
+              mobileCinematicHigh: image.mobileCinematicHigh,
+              mobileCinematicLow: image.mobileCinematicLow,
+              mobileCinematicVeryLow: image.mobileCinematicVeryLow,
+              thumbnail: image.thumbnail,
+              videoStill: image.videoStill,
+              blurhash: image.blurhash,
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+          updated++
+        }
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += updated
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-video-origins.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-video-origins.ts
@@ -5,6 +5,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreVideoOriginSchema } from "../schemas/video-origin"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 
 const PAGE_SIZE = 10000
 
@@ -78,29 +79,26 @@ export async function syncVideoOrigins({
 
     try {
       let updated = 0
-      await prisma.$transaction(
-        async (tx) => {
-          for (const origin of origins) {
-            await tx.videoOrigin.upsert({
-              where: { coreId: origin.id },
-              create: {
-                coreId: origin.id,
-                name: origin.name,
-                description: origin.description,
-                syncedAt: new Date(),
-              },
-              update: {
-                name: origin.name,
-                description: origin.description,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-            updated++
-          }
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+      await prisma.$transaction(async (tx) => {
+        for (const origin of origins) {
+          await tx.videoOrigin.upsert({
+            where: { coreId: origin.id },
+            create: {
+              coreId: origin.id,
+              name: origin.name,
+              description: origin.description,
+              syncedAt: new Date(),
+            },
+            update: {
+              name: origin.name,
+              description: origin.description,
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+          updated++
+        }
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += updated
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-video-subtitles.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-video-subtitles.ts
@@ -6,6 +6,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreVideoSubtitleSchema } from "../schemas/video-subtitle"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 
 const PAGE_SIZE = 10000
 
@@ -103,44 +104,41 @@ export async function syncVideoSubtitles({
 
     try {
       let updated = 0
-      await prisma.$transaction(
-        async (tx) => {
-          for (const subtitle of subtitles) {
-            const videoId = videoMap.get(subtitle.videoId)
-            const languageId = langMap.get(subtitle.languageId)
-            const videoEditionId = editionMap.get(subtitle.videoEdition.id)
-            if (!videoId || !videoEditionId) continue
+      await prisma.$transaction(async (tx) => {
+        for (const subtitle of subtitles) {
+          const videoId = videoMap.get(subtitle.videoId)
+          const languageId = langMap.get(subtitle.languageId)
+          const videoEditionId = editionMap.get(subtitle.videoEdition.id)
+          if (!videoId || !videoEditionId) continue
 
-            await tx.videoSubtitle.upsert({
-              where: { coreId: subtitle.id },
-              create: {
-                coreId: subtitle.id,
-                videoId,
-                videoEditionId,
-                languageId: languageId ?? null,
-                value: subtitle.value,
-                primary: subtitle.primary,
-                vttSrc: subtitle.vttSrc,
-                srtSrc: subtitle.srtSrc,
-                syncedAt: new Date(),
-              },
-              update: {
-                videoId,
-                videoEditionId,
-                languageId: languageId ?? null,
-                value: subtitle.value,
-                primary: subtitle.primary,
-                vttSrc: subtitle.vttSrc,
-                srtSrc: subtitle.srtSrc,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-            updated++
-          }
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+          await tx.videoSubtitle.upsert({
+            where: { coreId: subtitle.id },
+            create: {
+              coreId: subtitle.id,
+              videoId,
+              videoEditionId,
+              languageId: languageId ?? null,
+              value: subtitle.value,
+              primary: subtitle.primary,
+              vttSrc: subtitle.vttSrc,
+              srtSrc: subtitle.srtSrc,
+              syncedAt: new Date(),
+            },
+            update: {
+              videoId,
+              videoEditionId,
+              languageId: languageId ?? null,
+              value: subtitle.value,
+              primary: subtitle.primary,
+              vttSrc: subtitle.vttSrc,
+              srtSrc: subtitle.srtSrc,
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
+          })
+          updated++
+        }
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += updated
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/phases/sync-videos.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-videos.ts
@@ -9,6 +9,7 @@ import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreBibleBookSchema, CoreVideoSchema } from "../schemas/video"
 import { emptySyncStats } from "../types"
+import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 import {
   mapVideoLabel,
   mapVideoSource,
@@ -264,238 +265,235 @@ export async function syncVideos({
 
     try {
       let pageUpdated = 0
-      await prisma.$transaction(
-        async (tx) => {
-          const keywords = await tx.keyword.findMany({
-            select: { id: true, coreId: true },
+      await prisma.$transaction(async (tx) => {
+        const keywords = await tx.keyword.findMany({
+          select: { id: true, coreId: true },
+        })
+        const keywordMap = new Map(keywords.map((k) => [k.coreId, k.id]))
+        const bibleBooks = await tx.bibleBook.findMany({
+          select: { id: true, coreId: true },
+        })
+        const bibleBookMap = new Map(bibleBooks.map((b) => [b.coreId, b.id]))
+
+        for (const video of videos) {
+          const primaryLanguageId = video.primaryLanguageId
+            ? (langMap.get(video.primaryLanguageId) ?? null)
+            : null
+          const originId = video.origin
+            ? (originMap.get(video.origin.id) ?? null)
+            : null
+
+          const existing = await tx.video.findUnique({
+            where: { coreId: video.id },
+            select: { source: true },
           })
-          const keywordMap = new Map(keywords.map((k) => [k.coreId, k.id]))
-          const bibleBooks = await tx.bibleBook.findMany({
-            select: { id: true, coreId: true },
+          if (existing?.source === "MANAGER") {
+            continue
+          }
+
+          const videoRow = await tx.video.upsert({
+            where: { coreId: video.id },
+            create: {
+              coreId: video.id,
+              slug: video.slug,
+              label: mapVideoLabel(video.label),
+              videoSource: mapVideoSource(video.source),
+              publishedAt: video.publishedAt
+                ? new Date(video.publishedAt)
+                : null,
+              locked: video.locked,
+              noIndex: video.noIndex,
+              aiMetadata: false,
+              source: "CORE",
+              primaryLanguageId,
+              originId,
+              updatedAt: new Date(video.updatedAt),
+              syncedAt: new Date(),
+            },
+            update: {
+              slug: video.slug,
+              label: mapVideoLabel(video.label),
+              videoSource: mapVideoSource(video.source),
+              publishedAt: video.publishedAt
+                ? new Date(video.publishedAt)
+                : null,
+              locked: video.locked,
+              noIndex: video.noIndex,
+              primaryLanguageId,
+              originId,
+              updatedAt: new Date(video.updatedAt),
+              syncedAt: new Date(),
+              deletedAt: null,
+            },
           })
-          const bibleBookMap = new Map(bibleBooks.map((b) => [b.coreId, b.id]))
 
-          for (const video of videos) {
-            const primaryLanguageId = video.primaryLanguageId
-              ? (langMap.get(video.primaryLanguageId) ?? null)
-              : null
-            const originId = video.origin
-              ? (originMap.get(video.origin.id) ?? null)
-              : null
-
-            const existing = await tx.video.findUnique({
-              where: { coreId: video.id },
-              select: { source: true },
-            })
-            if (existing?.source === "MANAGER") {
-              continue
-            }
-
-            const videoRow = await tx.video.upsert({
-              where: { coreId: video.id },
+          for (const localeRow of toVideoLocales(
+            {
+              title: video.title,
+              description: video.description,
+              snippet: video.snippet,
+              imageAlt: video.imageAlt,
+            },
+            { bcp47ByCoreId },
+          )) {
+            await tx.videoLocale.upsert({
+              where: {
+                videoId_locale: {
+                  videoId: videoRow.id,
+                  locale: localeRow.locale,
+                },
+              },
               create: {
-                coreId: video.id,
-                slug: video.slug,
-                label: mapVideoLabel(video.label),
-                videoSource: mapVideoSource(video.source),
+                videoId: videoRow.id,
+                locale: localeRow.locale,
+                title: localeRow.title,
+                description: localeRow.description,
+                snippet: localeRow.snippet,
+                imageAlt: localeRow.imageAlt,
+                status: "PUBLISHED",
                 publishedAt: video.publishedAt
                   ? new Date(video.publishedAt)
                   : null,
-                locked: video.locked,
-                noIndex: video.noIndex,
-                aiMetadata: false,
-                source: "CORE",
-                primaryLanguageId,
-                originId,
-                updatedAt: new Date(video.updatedAt),
+              },
+              update: {
+                title: localeRow.title,
+                description: localeRow.description,
+                snippet: localeRow.snippet,
+                imageAlt: localeRow.imageAlt,
+                publishedAt: video.publishedAt
+                  ? new Date(video.publishedAt)
+                  : null,
+              },
+            })
+          }
+
+          const seenStudyQuestionIds = new Set(
+            video.studyQuestions.map((question) => question.id),
+          )
+          for (const question of toStudyQuestions(video.studyQuestions, {
+            bcp47ByCoreId,
+          })) {
+            await tx.videoStudyQuestion.upsert({
+              where: { coreId: question.coreId },
+              create: {
+                coreId: question.coreId,
+                videoId: videoRow.id,
+                locale: question.locale,
+                languageId: question.languageCoreId
+                  ? (langMap.get(question.languageCoreId) ?? null)
+                  : null,
+                text: question.text,
+                primary: question.primary,
+                order: question.order,
                 syncedAt: new Date(),
               },
               update: {
-                slug: video.slug,
-                label: mapVideoLabel(video.label),
-                videoSource: mapVideoSource(video.source),
-                publishedAt: video.publishedAt
-                  ? new Date(video.publishedAt)
+                videoId: videoRow.id,
+                locale: question.locale,
+                languageId: question.languageCoreId
+                  ? (langMap.get(question.languageCoreId) ?? null)
                   : null,
-                locked: video.locked,
-                noIndex: video.noIndex,
-                primaryLanguageId,
-                originId,
-                updatedAt: new Date(video.updatedAt),
+                text: question.text,
+                primary: question.primary,
+                order: question.order,
                 syncedAt: new Date(),
                 deletedAt: null,
               },
             })
-
-            for (const localeRow of toVideoLocales(
-              {
-                title: video.title,
-                description: video.description,
-                snippet: video.snippet,
-                imageAlt: video.imageAlt,
-              },
-              { bcp47ByCoreId },
-            )) {
-              await tx.videoLocale.upsert({
-                where: {
-                  videoId_locale: {
-                    videoId: videoRow.id,
-                    locale: localeRow.locale,
-                  },
-                },
-                create: {
-                  videoId: videoRow.id,
-                  locale: localeRow.locale,
-                  title: localeRow.title,
-                  description: localeRow.description,
-                  snippet: localeRow.snippet,
-                  imageAlt: localeRow.imageAlt,
-                  status: "PUBLISHED",
-                  publishedAt: video.publishedAt
-                    ? new Date(video.publishedAt)
-                    : null,
-                },
-                update: {
-                  title: localeRow.title,
-                  description: localeRow.description,
-                  snippet: localeRow.snippet,
-                  imageAlt: localeRow.imageAlt,
-                  publishedAt: video.publishedAt
-                    ? new Date(video.publishedAt)
-                    : null,
-                },
-              })
-            }
-
-            const seenStudyQuestionIds = new Set(
-              video.studyQuestions.map((question) => question.id),
-            )
-            for (const question of toStudyQuestions(video.studyQuestions, {
-              bcp47ByCoreId,
-            })) {
-              await tx.videoStudyQuestion.upsert({
-                where: { coreId: question.coreId },
-                create: {
-                  coreId: question.coreId,
-                  videoId: videoRow.id,
-                  locale: question.locale,
-                  languageId: question.languageCoreId
-                    ? (langMap.get(question.languageCoreId) ?? null)
-                    : null,
-                  text: question.text,
-                  primary: question.primary,
-                  order: question.order,
-                  syncedAt: new Date(),
-                },
-                update: {
-                  videoId: videoRow.id,
-                  locale: question.locale,
-                  languageId: question.languageCoreId
-                    ? (langMap.get(question.languageCoreId) ?? null)
-                    : null,
-                  text: question.text,
-                  primary: question.primary,
-                  order: question.order,
-                  syncedAt: new Date(),
-                  deletedAt: null,
-                },
-              })
-            }
-            await tx.videoStudyQuestion.updateMany({
-              where: {
-                videoId: videoRow.id,
-                source: "CORE",
-                coreId: { notIn: [...seenStudyQuestionIds] },
-                deletedAt: null,
-              },
-              data: { deletedAt: new Date() },
-            })
-
-            const seenCitationIds = new Set(
-              video.bibleCitations.map((citation) => citation.id),
-            )
-            for (const citation of video.bibleCitations) {
-              const bibleBookId = bibleBookMap.get(citation.bibleBook.id)
-              if (!bibleBookId) {
-                stats.errors++
-                console.warn(
-                  JSON.stringify({
-                    event: "core-sync.video-citation.missing-bible-book",
-                    videoCoreId: video.id,
-                    citationCoreId: citation.id,
-                    bibleBookCoreId: citation.bibleBook.id,
-                  }),
-                )
-                continue
-              }
-              await tx.bibleCitation.upsert({
-                where: { coreId: citation.id },
-                create: {
-                  coreId: citation.id,
-                  videoId: videoRow.id,
-                  bibleBookId,
-                  osisId: citation.osisId,
-                  order: citation.order,
-                  chapterStart: citation.chapterStart,
-                  chapterEnd: citation.chapterEnd,
-                  verseStart: citation.verseStart,
-                  verseEnd: citation.verseEnd,
-                  syncedAt: new Date(),
-                },
-                update: {
-                  videoId: videoRow.id,
-                  bibleBookId,
-                  osisId: citation.osisId,
-                  order: citation.order,
-                  chapterStart: citation.chapterStart,
-                  chapterEnd: citation.chapterEnd,
-                  verseStart: citation.verseStart,
-                  verseEnd: citation.verseEnd,
-                  syncedAt: new Date(),
-                  deletedAt: null,
-                },
-              })
-            }
-            await tx.bibleCitation.updateMany({
-              where: {
-                videoId: videoRow.id,
-                source: "CORE",
-                coreId: { notIn: [...seenCitationIds] },
-                deletedAt: null,
-              },
-              data: { deletedAt: new Date() },
-            })
-
-            await tx.videoKeyword.deleteMany({
-              where: { videoId: videoRow.id },
-            })
-            for (const keyword of video.keywords) {
-              const keywordId = keywordMap.get(keyword.id)
-              if (!keywordId) continue
-              await tx.videoKeyword.create({
-                data: { videoId: videoRow.id, keywordId },
-              })
-            }
-
-            await tx.videoRelation.deleteMany({
-              where: { parentId: videoRow.id },
-            })
-            for (const child of video.children) {
-              const childVideo = await tx.video.findUnique({
-                where: { coreId: child.id },
-                select: { id: true },
-              })
-              if (!childVideo) continue
-              await tx.videoRelation.create({
-                data: { parentId: videoRow.id, childId: childVideo.id },
-              })
-            }
-
-            pageUpdated++
           }
-        },
-        { timeout: 60_000, maxWait: 5_000 },
-      )
+          await tx.videoStudyQuestion.updateMany({
+            where: {
+              videoId: videoRow.id,
+              source: "CORE",
+              coreId: { notIn: [...seenStudyQuestionIds] },
+              deletedAt: null,
+            },
+            data: { deletedAt: new Date() },
+          })
+
+          const seenCitationIds = new Set(
+            video.bibleCitations.map((citation) => citation.id),
+          )
+          for (const citation of video.bibleCitations) {
+            const bibleBookId = bibleBookMap.get(citation.bibleBook.id)
+            if (!bibleBookId) {
+              stats.errors++
+              console.warn(
+                JSON.stringify({
+                  event: "core-sync.video-citation.missing-bible-book",
+                  videoCoreId: video.id,
+                  citationCoreId: citation.id,
+                  bibleBookCoreId: citation.bibleBook.id,
+                }),
+              )
+              continue
+            }
+            await tx.bibleCitation.upsert({
+              where: { coreId: citation.id },
+              create: {
+                coreId: citation.id,
+                videoId: videoRow.id,
+                bibleBookId,
+                osisId: citation.osisId,
+                order: citation.order,
+                chapterStart: citation.chapterStart,
+                chapterEnd: citation.chapterEnd,
+                verseStart: citation.verseStart,
+                verseEnd: citation.verseEnd,
+                syncedAt: new Date(),
+              },
+              update: {
+                videoId: videoRow.id,
+                bibleBookId,
+                osisId: citation.osisId,
+                order: citation.order,
+                chapterStart: citation.chapterStart,
+                chapterEnd: citation.chapterEnd,
+                verseStart: citation.verseStart,
+                verseEnd: citation.verseEnd,
+                syncedAt: new Date(),
+                deletedAt: null,
+              },
+            })
+          }
+          await tx.bibleCitation.updateMany({
+            where: {
+              videoId: videoRow.id,
+              source: "CORE",
+              coreId: { notIn: [...seenCitationIds] },
+              deletedAt: null,
+            },
+            data: { deletedAt: new Date() },
+          })
+
+          await tx.videoKeyword.deleteMany({
+            where: { videoId: videoRow.id },
+          })
+          for (const keyword of video.keywords) {
+            const keywordId = keywordMap.get(keyword.id)
+            if (!keywordId) continue
+            await tx.videoKeyword.create({
+              data: { videoId: videoRow.id, keywordId },
+            })
+          }
+
+          await tx.videoRelation.deleteMany({
+            where: { parentId: videoRow.id },
+          })
+          for (const child of video.children) {
+            const childVideo = await tx.video.findUnique({
+              where: { coreId: child.id },
+              select: { id: true },
+            })
+            if (!childVideo) continue
+            await tx.videoRelation.create({
+              data: { parentId: videoRow.id, childId: childVideo.id },
+            })
+          }
+
+          pageUpdated++
+        }
+      }, CORE_SYNC_TRANSACTION_OPTIONS)
       stats.updated += pageUpdated
     } catch (err) {
       stats.errors++

--- a/apps/admin/src/services/core-sync/transaction-options.ts
+++ b/apps/admin/src/services/core-sync/transaction-options.ts
@@ -1,0 +1,7 @@
+// Core reference phases write large pages from the external Core API. The
+// default Prisma interactive transaction budget is too small for production
+// pages, especially language/country locale fan-out.
+export const CORE_SYNC_TRANSACTION_OPTIONS = {
+  timeout: 300_000,
+  maxWait: 10_000,
+} as const


### PR DESCRIPTION
## Summary\n- add shared Core sync Prisma transaction options\n- raise phase transaction timeout to survive full production Core pages\n- apply the same budget across all Core sync phase writers\n\n## Verification\n- pnpm --filter @forge/admin test src/services/core-sync/phases/sync-languages.test.ts src/services/core-sync/phases/sync-dubs.test.ts src/services/core-sync/job.test.ts\n- pnpm --filter @forge/admin typecheck\n- pnpm --filter @forge/admin lint\n- git diff --check