### PR TITLE
fix(admin): bulk write core sync reference phases

### DIFF
--- a/apps/admin/src/services/core-sync/phases/sync-countries.test.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-countries.test.ts
@@ -50,34 +50,13 @@ describe("syncCountries", () => {
       },
     } as never)
 
-    const tx = {
+    const prisma = {
+      $executeRaw: vi.fn().mockResolvedValue(undefined),
       language: {
         findMany: vi
           .fn()
           .mockResolvedValue([{ id: "language-1", coreId: "lang-en" }]),
       },
-      continent: {
-        upsert: vi.fn().mockResolvedValue({ id: "continent-1" }),
-      },
-      continentLocale: {
-        upsert: vi.fn().mockResolvedValue(undefined),
-        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-      },
-      country: {
-        upsert: vi.fn().mockResolvedValue({ id: "country-1" }),
-      },
-      countryLocale: {
-        upsert: vi.fn().mockResolvedValue(undefined),
-        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-      },
-      countryLanguage: {
-        upsert: vi.fn().mockResolvedValue(undefined),
-      },
-    }
-    const prisma = {
-      $transaction: vi.fn(async (fn: (trx: typeof tx) => Promise<void>) =>
-        fn(tx),
-      ),
       country: {
         updateMany: vi.fn().mockResolvedValue({ count: 0 }),
       },
@@ -96,43 +75,13 @@ describe("syncCountries", () => {
     })
 
     expect(stats.errors).toBe(0)
-    expect(tx.country.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({
-          languageCount: 2,
-          languageHavingMediaCount: 1,
-        }),
-      }),
+    expect(stats.updated).toBe(1)
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(5)
+    expect(prisma.$executeRaw.mock.calls.join("\n")).toContain(
+      'INSERT INTO "country"',
     )
-    expect(tx.countryLanguage.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({
-          coreId: "cl-1",
-          countryId: "country-1",
-          languageId: "language-1",
-          displaySpeakers: "50",
-          primary: true,
-          order: 1,
-        }),
-      }),
-    )
-    expect(tx.continentLocale.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({
-          continentId: "continent-1",
-          locale: "en",
-          value: "North America",
-        }),
-      }),
-    )
-    expect(tx.countryLocale.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({
-          countryId: "country-1",
-          locale: "en",
-          value: "United States",
-        }),
-      }),
+    expect(prisma.$executeRaw.mock.calls.join("\n")).toContain(
+      'INSERT INTO "country_language"',
     )
     expect(prisma.country.updateMany).toHaveBeenCalled()
   })

--- a/apps/admin/src/services/core-sync/phases/sync-countries.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-countries.ts
@@ -1,12 +1,13 @@
 // Sync phase: countries
 // Depends on: languages (for continent localized names)
 
+import { randomUUID } from "node:crypto"
 import type { PrismaClient } from "@prisma/client"
 import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreCountrySchema } from "../schemas/country"
 import { emptySyncStats } from "../types"
-import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
+import { toPgArray } from "@/db/pgvector"
 import {
   toLocalizedNames,
   toNameMap,
@@ -62,6 +63,356 @@ type CoreCountry = {
     order: number | null
     language: { id: string }
   }>
+}
+
+type LocalizedNameRow = {
+  id: string
+  parentCoreId: string
+  locale: string
+  value: string
+  primary: boolean
+  order: number | null
+}
+
+function encodeJsonForPgArray(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64")
+}
+
+async function bulkUpsertContinents(
+  prisma: PrismaClient,
+  continents: ReadonlyArray<{
+    id: string
+    coreId: string
+    nameBase64: string
+  }>,
+) {
+  if (continents.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "continent" (
+      "id",
+      "core_id",
+      "source",
+      "name",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      input."core_id",
+      'core'::"SourceTier",
+      convert_from(decode(input."name_base64", 'base64'), 'UTF8')::jsonb,
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(continents.map((continent) => continent.id))}::text[],
+      ${toPgArray(continents.map((continent) => continent.coreId))}::text[],
+      ${toPgArray(continents.map((continent) => continent.nameBase64))}::text[]
+    ) AS input("id", "core_id", "name_base64")
+    ON CONFLICT ("core_id")
+    DO UPDATE SET
+      "name"       = EXCLUDED."name",
+      "synced_at"  = EXCLUDED."synced_at",
+      "updated_at" = EXCLUDED."updated_at",
+      "deleted_at" = NULL
+  `
+}
+
+async function bulkUpsertContinentLocales(
+  prisma: PrismaClient,
+  locales: ReadonlyArray<LocalizedNameRow>,
+) {
+  if (locales.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "continent_locale" (
+      "id",
+      "source",
+      "continent_id",
+      "locale",
+      "value",
+      "primary",
+      "order",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      'core'::"SourceTier",
+      continent."id",
+      input."locale",
+      input."value",
+      input."primary_text"::boolean,
+      input."order_text"::int,
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(locales.map((locale) => locale.id))}::text[],
+      ${toPgArray(locales.map((locale) => locale.parentCoreId))}::text[],
+      ${toPgArray(locales.map((locale) => locale.locale))}::text[],
+      ${toPgArray(locales.map((locale) => locale.value))}::text[],
+      ${toPgArray(locales.map((locale) => String(locale.primary)))}::text[],
+      ${toPgArray(locales.map((locale) => locale.order?.toString() ?? null))}::text[]
+    ) AS input(
+      "id",
+      "continent_core_id",
+      "locale",
+      "value",
+      "primary_text",
+      "order_text"
+    )
+    JOIN "continent" continent
+      ON continent."core_id" = input."continent_core_id"
+    ON CONFLICT ("continent_id", "locale")
+    DO UPDATE SET
+      "value"      = EXCLUDED."value",
+      "primary"    = EXCLUDED."primary",
+      "order"      = EXCLUDED."order",
+      "synced_at"  = EXCLUDED."synced_at",
+      "updated_at" = EXCLUDED."updated_at",
+      "deleted_at" = NULL
+  `
+}
+
+async function bulkUpsertCountries(
+  prisma: PrismaClient,
+  countries: ReadonlyArray<{
+    id: string
+    coreId: string
+    nameBase64: string
+    population: number | null
+    latitude: number | null
+    longitude: number | null
+    flagPngSrc: string | null
+    flagWebpSrc: string | null
+    languageCount: number | null
+    languageHavingMediaCount: number | null
+    continentCoreId: string | null
+  }>,
+) {
+  if (countries.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "country" (
+      "id",
+      "core_id",
+      "source",
+      "name",
+      "population",
+      "latitude",
+      "longitude",
+      "flag_png_src",
+      "flag_webp_src",
+      "language_count",
+      "language_having_media_count",
+      "continent_id",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      input."core_id",
+      'core'::"SourceTier",
+      convert_from(decode(input."name_base64", 'base64'), 'UTF8')::jsonb,
+      input."population_text"::int,
+      input."latitude_text"::double precision,
+      input."longitude_text"::double precision,
+      input."flag_png_src",
+      input."flag_webp_src",
+      input."language_count_text"::int,
+      input."language_having_media_count_text"::int,
+      continent."id",
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(countries.map((country) => country.id))}::text[],
+      ${toPgArray(countries.map((country) => country.coreId))}::text[],
+      ${toPgArray(countries.map((country) => country.nameBase64))}::text[],
+      ${toPgArray(countries.map((country) => country.population?.toString() ?? null))}::text[],
+      ${toPgArray(countries.map((country) => country.latitude?.toString() ?? null))}::text[],
+      ${toPgArray(countries.map((country) => country.longitude?.toString() ?? null))}::text[],
+      ${toPgArray(countries.map((country) => country.flagPngSrc))}::text[],
+      ${toPgArray(countries.map((country) => country.flagWebpSrc))}::text[],
+      ${toPgArray(countries.map((country) => country.languageCount?.toString() ?? null))}::text[],
+      ${toPgArray(countries.map((country) => country.languageHavingMediaCount?.toString() ?? null))}::text[],
+      ${toPgArray(countries.map((country) => country.continentCoreId))}::text[]
+    ) AS input(
+      "id",
+      "core_id",
+      "name_base64",
+      "population_text",
+      "latitude_text",
+      "longitude_text",
+      "flag_png_src",
+      "flag_webp_src",
+      "language_count_text",
+      "language_having_media_count_text",
+      "continent_core_id"
+    )
+    LEFT JOIN "continent" continent
+      ON continent."core_id" = input."continent_core_id"
+    ON CONFLICT ("core_id")
+    DO UPDATE SET
+      "name"                        = EXCLUDED."name",
+      "population"                  = EXCLUDED."population",
+      "latitude"                    = EXCLUDED."latitude",
+      "longitude"                   = EXCLUDED."longitude",
+      "flag_png_src"                = EXCLUDED."flag_png_src",
+      "flag_webp_src"               = EXCLUDED."flag_webp_src",
+      "language_count"              = EXCLUDED."language_count",
+      "language_having_media_count" = EXCLUDED."language_having_media_count",
+      "continent_id"                = EXCLUDED."continent_id",
+      "synced_at"                   = EXCLUDED."synced_at",
+      "updated_at"                  = EXCLUDED."updated_at",
+      "deleted_at"                  = NULL
+  `
+}
+
+async function bulkUpsertCountryLocales(
+  prisma: PrismaClient,
+  locales: ReadonlyArray<LocalizedNameRow>,
+) {
+  if (locales.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "country_locale" (
+      "id",
+      "source",
+      "country_id",
+      "locale",
+      "value",
+      "primary",
+      "order",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      'core'::"SourceTier",
+      country."id",
+      input."locale",
+      input."value",
+      input."primary_text"::boolean,
+      input."order_text"::int,
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(locales.map((locale) => locale.id))}::text[],
+      ${toPgArray(locales.map((locale) => locale.parentCoreId))}::text[],
+      ${toPgArray(locales.map((locale) => locale.locale))}::text[],
+      ${toPgArray(locales.map((locale) => locale.value))}::text[],
+      ${toPgArray(locales.map((locale) => String(locale.primary)))}::text[],
+      ${toPgArray(locales.map((locale) => locale.order?.toString() ?? null))}::text[]
+    ) AS input(
+      "id",
+      "country_core_id",
+      "locale",
+      "value",
+      "primary_text",
+      "order_text"
+    )
+    JOIN "country" country
+      ON country."core_id" = input."country_core_id"
+    ON CONFLICT ("country_id", "locale")
+    DO UPDATE SET
+      "value"      = EXCLUDED."value",
+      "primary"    = EXCLUDED."primary",
+      "order"      = EXCLUDED."order",
+      "synced_at"  = EXCLUDED."synced_at",
+      "updated_at" = EXCLUDED."updated_at",
+      "deleted_at" = NULL
+  `
+}
+
+async function bulkUpsertCountryLanguages(
+  prisma: PrismaClient,
+  countryLanguages: ReadonlyArray<{
+    id: string
+    coreId: string
+    countryCoreId: string
+    languageId: string
+    speakers: number | null
+    displaySpeakers: string | null
+    primary: boolean | null
+    suggested: boolean | null
+    order: number | null
+  }>,
+) {
+  if (countryLanguages.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "country_language" (
+      "id",
+      "core_id",
+      "source",
+      "country_id",
+      "language_id",
+      "speakers",
+      "display_speakers",
+      "primary",
+      "suggested",
+      "order",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      input."core_id",
+      'core'::"SourceTier",
+      country."id",
+      input."language_id",
+      input."speakers_text"::int,
+      input."display_speakers",
+      input."primary_text"::boolean,
+      input."suggested_text"::boolean,
+      input."order_text"::int,
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(countryLanguages.map((countryLanguage) => countryLanguage.id))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => countryLanguage.coreId))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => countryLanguage.countryCoreId))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => countryLanguage.languageId))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => countryLanguage.speakers?.toString() ?? null))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => countryLanguage.displaySpeakers))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => (countryLanguage.primary == null ? null : String(countryLanguage.primary))))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => (countryLanguage.suggested == null ? null : String(countryLanguage.suggested))))}::text[],
+      ${toPgArray(countryLanguages.map((countryLanguage) => countryLanguage.order?.toString() ?? null))}::text[]
+    ) AS input(
+      "id",
+      "core_id",
+      "country_core_id",
+      "language_id",
+      "speakers_text",
+      "display_speakers",
+      "primary_text",
+      "suggested_text",
+      "order_text"
+    )
+    JOIN "country" country
+      ON country."core_id" = input."country_core_id"
+    ON CONFLICT ("country_id", "language_id")
+    DO UPDATE SET
+      "core_id"          = EXCLUDED."core_id",
+      "speakers"         = EXCLUDED."speakers",
+      "display_speakers" = EXCLUDED."display_speakers",
+      "primary"          = EXCLUDED."primary",
+      "suggested"        = EXCLUDED."suggested",
+      "order"            = EXCLUDED."order",
+      "synced_at"        = EXCLUDED."synced_at",
+      "updated_at"       = EXCLUDED."updated_at",
+      "deleted_at"       = NULL
+  `
 }
 
 export async function syncCountries({
@@ -120,184 +471,109 @@ export async function syncCountries({
   progress.setTotal(countries.length)
 
   try {
-    let pageUpdated = 0
-    await prisma.$transaction(async (tx) => {
-      const languages = await tx.language.findMany({
-        select: { id: true, coreId: true },
-      })
-      const langMap = new Map(languages.map((l) => [l.coreId, l.id]))
+    const languages = await prisma.language.findMany({
+      select: { id: true, coreId: true },
+    })
+    const langMap = new Map(languages.map((l) => [l.coreId, l.id]))
+    const continentsByCoreId = new Map<
+      string,
+      { id: string; coreId: string; nameBase64: string }
+    >()
+    const continentLocales: LocalizedNameRow[] = []
+    const countryLocales: LocalizedNameRow[] = []
+    const countryLanguageRows: Array<{
+      id: string
+      coreId: string
+      countryCoreId: string
+      languageId: string
+      speakers: number | null
+      displaySpeakers: string | null
+      primary: boolean | null
+      suggested: boolean | null
+      order: number | null
+    }> = []
 
-      for (const country of countries) {
-        let continentId: string | undefined
-        if (country.continent) {
-          const continent = await tx.continent.upsert({
-            where: { coreId: country.continent.id },
-            create: {
-              coreId: country.continent.id,
-              name: toNameMap(country.continent.name),
-              syncedAt: new Date(),
-            },
-            update: {
-              name: toNameMap(country.continent.name),
-              syncedAt: new Date(),
-              deletedAt: null,
-            },
-          })
-          continentId = continent.id
-          const continentLocales = toLocalizedNames(country.continent.name)
-          for (const localeRow of continentLocales) {
-            await tx.continentLocale.upsert({
-              where: {
-                continentId_locale: {
-                  continentId: continent.id,
-                  locale: localeRow.locale,
-                },
-              },
-              create: {
-                continentId: continent.id,
-                locale: localeRow.locale,
-                value: localeRow.value,
-                primary: localeRow.primary,
-                order: localeRow.order,
-                syncedAt: new Date(),
-              },
-              update: {
-                value: localeRow.value,
-                primary: localeRow.primary,
-                order: localeRow.order,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-          }
-          await tx.continentLocale.updateMany({
-            where: {
-              continentId: continent.id,
-              source: "CORE",
-              locale: { notIn: continentLocales.map((row) => row.locale) },
-              deletedAt: null,
-            },
-            data: { deletedAt: new Date() },
-          })
-        }
-
-        const countryRow = await tx.country.upsert({
-          where: { coreId: country.id },
-          create: {
-            coreId: country.id,
-            name: toNameMap(country.name),
-            population: country.population,
-            latitude: country.latitude,
-            longitude: country.longitude,
-            flagPngSrc: country.flagPngSrc,
-            flagWebpSrc: country.flagWebpSrc,
-            languageCount: country.languageCount,
-            languageHavingMediaCount: country.languageHavingMediaCount,
-            continentId: continentId ?? null,
-            syncedAt: new Date(),
-          },
-          update: {
-            name: toNameMap(country.name),
-            population: country.population,
-            latitude: country.latitude,
-            longitude: country.longitude,
-            flagPngSrc: country.flagPngSrc,
-            flagWebpSrc: country.flagWebpSrc,
-            languageCount: country.languageCount,
-            languageHavingMediaCount: country.languageHavingMediaCount,
-            continentId: continentId ?? null,
-            syncedAt: new Date(),
-            deletedAt: null,
-          },
+    const countryRows = countries.map((country) => {
+      if (country.continent && !continentsByCoreId.has(country.continent.id)) {
+        continentsByCoreId.set(country.continent.id, {
+          id: randomUUID(),
+          coreId: country.continent.id,
+          nameBase64: encodeJsonForPgArray(toNameMap(country.continent.name)),
         })
-        const countryLocales = toLocalizedNames(country.name)
-        for (const localeRow of countryLocales) {
-          await tx.countryLocale.upsert({
-            where: {
-              countryId_locale: {
-                countryId: countryRow.id,
-                locale: localeRow.locale,
-              },
-            },
-            create: {
-              countryId: countryRow.id,
-              locale: localeRow.locale,
-              value: localeRow.value,
-              primary: localeRow.primary,
-              order: localeRow.order,
-              syncedAt: new Date(),
-            },
-            update: {
-              value: localeRow.value,
-              primary: localeRow.primary,
-              order: localeRow.order,
-              syncedAt: new Date(),
-              deletedAt: null,
-            },
+        for (const localeRow of toLocalizedNames(country.continent.name)) {
+          continentLocales.push({
+            id: randomUUID(),
+            parentCoreId: country.continent.id,
+            locale: localeRow.locale,
+            value: localeRow.value,
+            primary: localeRow.primary,
+            order: localeRow.order ?? null,
           })
         }
-        await tx.countryLocale.updateMany({
-          where: {
-            countryId: countryRow.id,
-            source: "CORE",
-            locale: { notIn: countryLocales.map((row) => row.locale) },
-            deletedAt: null,
-          },
-          data: { deletedAt: new Date() },
-        })
-
-        for (const countryLanguage of country.countryLanguages) {
-          const languageId = langMap.get(countryLanguage.language.id)
-          if (!languageId) {
-            stats.errors++
-            console.warn(
-              JSON.stringify({
-                event: "core-sync.country-language.missing-language",
-                countryCoreId: country.id,
-                countryLanguageCoreId: countryLanguage.id,
-                languageCoreId: countryLanguage.language.id,
-              }),
-            )
-            continue
-          }
-
-          seenCountryLanguageCoreIds.add(countryLanguage.id)
-          await tx.countryLanguage.upsert({
-            where: {
-              countryId_languageId: {
-                countryId: countryRow.id,
-                languageId,
-              },
-            },
-            create: {
-              coreId: countryLanguage.id,
-              countryId: countryRow.id,
-              languageId,
-              speakers: countryLanguage.speakers,
-              displaySpeakers: countryLanguage.displaySpeakers,
-              primary: countryLanguage.primary,
-              suggested: countryLanguage.suggested,
-              order: countryLanguage.order,
-              syncedAt: new Date(),
-            },
-            update: {
-              coreId: countryLanguage.id,
-              countryId: countryRow.id,
-              languageId,
-              speakers: countryLanguage.speakers,
-              displaySpeakers: countryLanguage.displaySpeakers,
-              primary: countryLanguage.primary,
-              suggested: countryLanguage.suggested,
-              order: countryLanguage.order,
-              syncedAt: new Date(),
-              deletedAt: null,
-            },
-          })
-        }
-        pageUpdated++
       }
-    }, CORE_SYNC_TRANSACTION_OPTIONS)
-    stats.updated += pageUpdated
+
+      for (const localeRow of toLocalizedNames(country.name)) {
+        countryLocales.push({
+          id: randomUUID(),
+          parentCoreId: country.id,
+          locale: localeRow.locale,
+          value: localeRow.value,
+          primary: localeRow.primary,
+          order: localeRow.order ?? null,
+        })
+      }
+
+      for (const countryLanguage of country.countryLanguages) {
+        const languageId = langMap.get(countryLanguage.language.id)
+        if (!languageId) {
+          stats.errors++
+          console.warn(
+            JSON.stringify({
+              event: "core-sync.country-language.missing-language",
+              countryCoreId: country.id,
+              countryLanguageCoreId: countryLanguage.id,
+              languageCoreId: countryLanguage.language.id,
+            }),
+          )
+          continue
+        }
+
+        seenCountryLanguageCoreIds.add(countryLanguage.id)
+        countryLanguageRows.push({
+          id: randomUUID(),
+          coreId: countryLanguage.id,
+          countryCoreId: country.id,
+          languageId,
+          speakers: countryLanguage.speakers,
+          displaySpeakers: countryLanguage.displaySpeakers,
+          primary: countryLanguage.primary,
+          suggested: countryLanguage.suggested,
+          order: countryLanguage.order,
+        })
+      }
+
+      return {
+        id: randomUUID(),
+        coreId: country.id,
+        nameBase64: encodeJsonForPgArray(toNameMap(country.name)),
+        population: country.population,
+        latitude: country.latitude,
+        longitude: country.longitude,
+        flagPngSrc: country.flagPngSrc,
+        flagWebpSrc: country.flagWebpSrc,
+        languageCount: country.languageCount,
+        languageHavingMediaCount: country.languageHavingMediaCount,
+        continentCoreId: country.continent?.id ?? null,
+      }
+    })
+
+    await bulkUpsertContinents(prisma, [...continentsByCoreId.values()])
+    await bulkUpsertContinentLocales(prisma, continentLocales)
+    await bulkUpsertCountries(prisma, countryRows)
+    await bulkUpsertCountryLocales(prisma, countryLocales)
+    await bulkUpsertCountryLanguages(prisma, countryLanguageRows)
+
+    stats.updated += countryRows.length
   } catch (err) {
     stats.errors++
     console.error(

--- a/apps/admin/src/services/core-sync/phases/sync-keywords.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-keywords.ts
@@ -1,12 +1,13 @@
 // Sync phase: keywords
 // Depends on: languages (keyword.languageId FK)
 
+import { randomUUID } from "node:crypto"
 import type { PrismaClient } from "@prisma/client"
 import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreKeywordSchema } from "../schemas/keyword"
 import { emptySyncStats } from "../types"
-import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
+import { toPgArray } from "@/db/pgvector"
 
 const KEYWORDS_QUERY = `
   query Keywords($offset: Int!, $limit: Int!, $where: KeywordsFilter) {
@@ -24,6 +25,53 @@ type CoreKeyword = {
   updatedAt?: string
   value: string
   language: { id: string } | null
+}
+
+async function bulkUpsertKeywords(
+  prisma: PrismaClient,
+  keywords: ReadonlyArray<{
+    id: string
+    coreId: string
+    value: string
+    languageId: string | null
+  }>,
+) {
+  if (keywords.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "keyword" (
+      "id",
+      "core_id",
+      "source",
+      "value",
+      "language_id",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      input."core_id",
+      'core'::"SourceTier",
+      input."value",
+      input."language_id",
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(keywords.map((keyword) => keyword.id))}::text[],
+      ${toPgArray(keywords.map((keyword) => keyword.coreId))}::text[],
+      ${toPgArray(keywords.map((keyword) => keyword.value))}::text[],
+      ${toPgArray(keywords.map((keyword) => keyword.languageId))}::text[]
+    ) AS input("id", "core_id", "value", "language_id")
+    ON CONFLICT ("core_id")
+    DO UPDATE SET
+      "value"       = EXCLUDED."value",
+      "language_id" = EXCLUDED."language_id",
+      "synced_at"   = EXCLUDED."synced_at",
+      "updated_at"  = EXCLUDED."updated_at",
+      "deleted_at"  = NULL
+  `
 }
 
 export async function syncKeywords({
@@ -84,32 +132,17 @@ export async function syncKeywords({
     progress.setTotal(offset + keywords.length)
 
     try {
-      let pageUpdated = 0
-      await prisma.$transaction(async (tx) => {
-        for (const keyword of keywords) {
-          const languageId = keyword.language
-            ? (langMap.get(keyword.language.id) ?? null)
-            : null
+      const writes = keywords.map((keyword) => ({
+        id: randomUUID(),
+        coreId: keyword.id,
+        value: keyword.value,
+        languageId: keyword.language
+          ? (langMap.get(keyword.language.id) ?? null)
+          : null,
+      }))
 
-          await tx.keyword.upsert({
-            where: { coreId: keyword.id },
-            create: {
-              coreId: keyword.id,
-              value: keyword.value,
-              languageId,
-              syncedAt: new Date(),
-            },
-            update: {
-              value: keyword.value,
-              languageId,
-              syncedAt: new Date(),
-              deletedAt: null,
-            },
-          })
-          pageUpdated++
-        }
-      }, CORE_SYNC_TRANSACTION_OPTIONS)
-      stats.updated += pageUpdated
+      await bulkUpsertKeywords(prisma, writes)
+      stats.updated += writes.length
     } catch (err) {
       stats.errors++
       console.error(


### PR DESCRIPTION
## Summary\n- replace row-by-row country and keyword sync writes with bulk INSERT ... ON CONFLICT writes\n- keep country, continent, locale, and country-language sync idempotent without long interactive transactions\n- avoid production workflow step timeouts during full Core sync\n\n## Verification\n- pnpm --filter @forge/admin test src/services/core-sync/phases/sync-countries.test.ts src/services/core-sync/phases/sync-languages.test.ts src/services/core-sync/phases/sync-dubs.test.ts\n- pnpm --filter @forge/admin typecheck\n- pnpm --filter @forge/admin lint\n- git diff --check