### PR TITLE
fix(admin): bulk write core sync languages

### DIFF
--- a/apps/admin/src/services/core-sync/phases/sync-languages.test.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-languages.test.ts
@@ -39,7 +39,7 @@ describe("syncLanguages", () => {
 
     const progress = createProgress()
     const prisma = {
-      $transaction: vi.fn(),
+      $executeRaw: vi.fn(),
       language: {
         findMany: vi.fn().mockResolvedValue([]),
         updateMany: vi.fn(),
@@ -52,7 +52,7 @@ describe("syncLanguages", () => {
     })
 
     expect(stats.errors).toBe(1)
-    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(prisma.$executeRaw).not.toHaveBeenCalled()
     expect(prisma.language.updateMany).not.toHaveBeenCalled()
   })
 
@@ -79,19 +79,8 @@ describe("syncLanguages", () => {
     } as never)
 
     const progress = createProgress()
-    const tx = {
-      language: {
-        upsert: vi.fn().mockResolvedValue({ id: "language-1" }),
-      },
-      languageLocale: {
-        upsert: vi.fn().mockResolvedValue(undefined),
-        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-      },
-    }
     const prisma = {
-      $transaction: vi.fn(async (fn: (trx: typeof tx) => Promise<void>) =>
-        fn(tx),
-      ),
+      $executeRaw: vi.fn().mockResolvedValue(undefined),
       language: {
         findMany: vi.fn().mockResolvedValue([]),
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
@@ -106,7 +95,7 @@ describe("syncLanguages", () => {
       progress,
     })
 
-    expect(prisma.$transaction).toHaveBeenCalled()
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3)
     expect(prisma.language.updateMany).toHaveBeenCalledWith({
       where: {
         source: "CORE",
@@ -115,14 +104,8 @@ describe("syncLanguages", () => {
       },
       data: { deletedAt: expect.any(Date) },
     })
-    expect(tx.languageLocale.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({
-          languageId: "language-1",
-          locale: "en",
-          value: "English",
-        }),
-      }),
+    expect(prisma.$executeRaw.mock.calls.join("\n")).toContain(
+      'INSERT INTO "language_locale"',
     )
     expect(stats.softDeleted).toBe(2)
     expect(stats.errors).toBe(0)
@@ -137,7 +120,7 @@ describe("syncLanguages", () => {
 
     const progress = createProgress()
     const prisma = {
-      $transaction: vi.fn(),
+      $executeRaw: vi.fn(),
       language: {
         findMany: vi.fn().mockResolvedValue([]),
         updateMany: vi.fn(),
@@ -170,19 +153,8 @@ describe("syncLanguages", () => {
     } as never)
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
 
-    const tx = {
-      language: {
-        upsert: vi.fn().mockResolvedValue({ id: "language-2" }),
-      },
-      languageLocale: {
-        upsert: vi.fn().mockResolvedValue(undefined),
-        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-      },
-    }
     const prisma = {
-      $transaction: vi.fn(async (fn: (trx: typeof tx) => Promise<void>) =>
-        fn(tx),
-      ),
+      $executeRaw: vi.fn().mockResolvedValue(undefined),
       language: {
         findMany: vi
           .fn()
@@ -200,12 +172,7 @@ describe("syncLanguages", () => {
     })
 
     expect(stats.errors).toBe(0)
-    expect(tx.language.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({ slug: null }),
-        update: expect.objectContaining({ slug: null }),
-      }),
-    )
+    expect(prisma.$executeRaw).toHaveBeenCalled()
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("core-sync.language.duplicate-slug"),
     )

--- a/apps/admin/src/services/core-sync/phases/sync-languages.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-languages.ts
@@ -3,12 +3,13 @@
 // First phase in PHASE_ORDER. Languages are reference data with
 // localized name stored as a JSON column keyed by locale.
 
+import { randomUUID } from "node:crypto"
 import type { PrismaClient } from "@prisma/client"
 import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreLanguageSchema } from "../schemas/language"
 import { emptySyncStats } from "../types"
-import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
+import { toPgArray } from "@/db/pgvector"
 import {
   toLocalizedNames,
   toNameMap,
@@ -51,6 +52,206 @@ type CoreLanguage = {
     bitrate: number | null
     codec: string | null
   } | null
+}
+
+type LanguageLocaleWrite = {
+  id: string
+  languageCoreId: string
+  locale: string
+  value: string
+  primary: boolean
+  order: number | null
+}
+
+function encodeJsonForPgArray(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64")
+}
+
+async function bulkUpsertLanguages(
+  prisma: PrismaClient,
+  languages: ReadonlyArray<{
+    id: string
+    coreId: string
+    bcp47: string | null
+    iso3: string | null
+    slug: string | null
+    nameBase64: string
+    audioPreviewValue: string | null
+    audioPreviewDuration: number | null
+    audioPreviewSize: string | null
+    audioPreviewBitrate: number | null
+    audioPreviewCodec: string | null
+  }>,
+) {
+  if (languages.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "language" (
+      "id",
+      "core_id",
+      "source",
+      "bcp47",
+      "iso3",
+      "slug",
+      "name",
+      "audio_preview_value",
+      "audio_preview_duration",
+      "audio_preview_size",
+      "audio_preview_bitrate",
+      "audio_preview_codec",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      input."core_id",
+      'core'::"SourceTier",
+      input."bcp47",
+      input."iso3",
+      input."slug",
+      convert_from(decode(input."name_base64", 'base64'), 'UTF8')::jsonb,
+      input."audio_preview_value",
+      input."audio_preview_duration_text"::int,
+      input."audio_preview_size_text"::bigint,
+      input."audio_preview_bitrate_text"::int,
+      input."audio_preview_codec",
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(languages.map((language) => language.id))}::text[],
+      ${toPgArray(languages.map((language) => language.coreId))}::text[],
+      ${toPgArray(languages.map((language) => language.bcp47))}::text[],
+      ${toPgArray(languages.map((language) => language.iso3))}::text[],
+      ${toPgArray(languages.map((language) => language.slug))}::text[],
+      ${toPgArray(languages.map((language) => language.nameBase64))}::text[],
+      ${toPgArray(languages.map((language) => language.audioPreviewValue))}::text[],
+      ${toPgArray(languages.map((language) => language.audioPreviewDuration?.toString() ?? null))}::text[],
+      ${toPgArray(languages.map((language) => language.audioPreviewSize))}::text[],
+      ${toPgArray(languages.map((language) => language.audioPreviewBitrate?.toString() ?? null))}::text[],
+      ${toPgArray(languages.map((language) => language.audioPreviewCodec))}::text[]
+    ) AS input(
+      "id",
+      "core_id",
+      "bcp47",
+      "iso3",
+      "slug",
+      "name_base64",
+      "audio_preview_value",
+      "audio_preview_duration_text",
+      "audio_preview_size_text",
+      "audio_preview_bitrate_text",
+      "audio_preview_codec"
+    )
+    ON CONFLICT ("core_id")
+    DO UPDATE SET
+      "bcp47"                  = EXCLUDED."bcp47",
+      "iso3"                   = EXCLUDED."iso3",
+      "slug"                   = EXCLUDED."slug",
+      "name"                   = EXCLUDED."name",
+      "audio_preview_value"    = EXCLUDED."audio_preview_value",
+      "audio_preview_duration" = EXCLUDED."audio_preview_duration",
+      "audio_preview_size"     = EXCLUDED."audio_preview_size",
+      "audio_preview_bitrate"  = EXCLUDED."audio_preview_bitrate",
+      "audio_preview_codec"    = EXCLUDED."audio_preview_codec",
+      "synced_at"              = EXCLUDED."synced_at",
+      "updated_at"             = EXCLUDED."updated_at",
+      "deleted_at"             = NULL
+  `
+}
+
+async function bulkUpsertLanguageLocales(
+  prisma: PrismaClient,
+  locales: ReadonlyArray<LanguageLocaleWrite>,
+) {
+  if (locales.length === 0) return
+
+  await prisma.$executeRaw`
+    INSERT INTO "language_locale" (
+      "id",
+      "source",
+      "language_id",
+      "locale",
+      "value",
+      "primary",
+      "order",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      'core'::"SourceTier",
+      language."id",
+      input."locale",
+      input."value",
+      input."primary_text"::boolean,
+      input."order_text"::int,
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(locales.map((locale) => locale.id))}::text[],
+      ${toPgArray(locales.map((locale) => locale.languageCoreId))}::text[],
+      ${toPgArray(locales.map((locale) => locale.locale))}::text[],
+      ${toPgArray(locales.map((locale) => locale.value))}::text[],
+      ${toPgArray(locales.map((locale) => String(locale.primary)))}::text[],
+      ${toPgArray(locales.map((locale) => locale.order?.toString() ?? null))}::text[]
+    ) AS input(
+      "id",
+      "language_core_id",
+      "locale",
+      "value",
+      "primary_text",
+      "order_text"
+    )
+    JOIN "language" language
+      ON language."core_id" = input."language_core_id"
+    ON CONFLICT ("language_id", "locale")
+    DO UPDATE SET
+      "value"      = EXCLUDED."value",
+      "primary"    = EXCLUDED."primary",
+      "order"      = EXCLUDED."order",
+      "synced_at"  = EXCLUDED."synced_at",
+      "updated_at" = EXCLUDED."updated_at",
+      "deleted_at" = NULL
+  `
+}
+
+async function softDeleteStaleLanguageLocales(
+  prisma: PrismaClient,
+  locales: ReadonlyArray<LanguageLocaleWrite>,
+) {
+  if (locales.length === 0) return
+
+  await prisma.$executeRaw`
+    WITH synced("language_core_id", "locale") AS (
+      SELECT *
+      FROM unnest(
+        ${toPgArray(locales.map((locale) => locale.languageCoreId))}::text[],
+        ${toPgArray(locales.map((locale) => locale.locale))}::text[]
+      )
+    ),
+    synced_languages("language_core_id") AS (
+      SELECT DISTINCT "language_core_id" FROM synced
+    )
+    UPDATE "language_locale" locale
+    SET "deleted_at" = NOW()
+    FROM "language" language
+    WHERE locale."language_id" = language."id"
+      AND locale."source" = 'core'::"SourceTier"
+      AND locale."deleted_at" IS NULL
+      AND language."core_id" IN (
+        SELECT "language_core_id" FROM synced_languages
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM synced
+        WHERE synced."language_core_id" = language."core_id"
+          AND synced."locale" = locale."locale"
+      )
+  `
 }
 
 export async function syncLanguages({
@@ -119,99 +320,56 @@ export async function syncLanguages({
     progress.setTotal(offset + languages.length)
 
     try {
-      let pageUpdated = 0
-      await prisma.$transaction(async (tx) => {
-        for (const lang of languages) {
-          const nameMap = toNameMap(lang.name)
-          const audioPreviewSize = lang.audioPreview?.size
-            ? BigInt(lang.audioPreview.size)
-            : null
-          const slugOwner = lang.slug ? slugOwners.get(lang.slug) : undefined
-          const slug =
-            lang.slug && (!slugOwner || slugOwner === lang.id)
-              ? lang.slug
-              : null
-          if (lang.slug && !slug) {
-            console.warn(
-              JSON.stringify({
-                event: "core-sync.language.duplicate-slug",
-                languageCoreId: lang.id,
-                slug: lang.slug,
-                existingLanguageCoreId: slugOwner,
-              }),
-            )
-          } else if (slug) {
-            slugOwners.set(slug, lang.id)
-          }
-
-          const language = await tx.language.upsert({
-            where: { coreId: lang.id },
-            create: {
-              coreId: lang.id,
-              bcp47: lang.bcp47,
-              iso3: lang.iso3,
-              slug,
-              name: nameMap,
-              audioPreviewValue: lang.audioPreview?.value ?? null,
-              audioPreviewDuration: lang.audioPreview?.duration ?? null,
-              audioPreviewSize,
-              audioPreviewBitrate: lang.audioPreview?.bitrate ?? null,
-              audioPreviewCodec: lang.audioPreview?.codec ?? null,
-              syncedAt: new Date(),
-            },
-            update: {
-              bcp47: lang.bcp47,
-              iso3: lang.iso3,
-              slug,
-              name: nameMap,
-              audioPreviewValue: lang.audioPreview?.value ?? null,
-              audioPreviewDuration: lang.audioPreview?.duration ?? null,
-              audioPreviewSize,
-              audioPreviewBitrate: lang.audioPreview?.bitrate ?? null,
-              audioPreviewCodec: lang.audioPreview?.codec ?? null,
-              syncedAt: new Date(),
-              deletedAt: null,
-            },
-          })
-          const localeRows = toLocalizedNames(lang.name)
-          for (const localeRow of localeRows) {
-            await tx.languageLocale.upsert({
-              where: {
-                languageId_locale: {
-                  languageId: language.id,
-                  locale: localeRow.locale,
-                },
-              },
-              create: {
-                languageId: language.id,
-                locale: localeRow.locale,
-                value: localeRow.value,
-                primary: localeRow.primary,
-                order: localeRow.order,
-                syncedAt: new Date(),
-              },
-              update: {
-                value: localeRow.value,
-                primary: localeRow.primary,
-                order: localeRow.order,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-          }
-          await tx.languageLocale.updateMany({
-            where: {
-              languageId: language.id,
-              source: "CORE",
-              locale: { notIn: localeRows.map((row) => row.locale) },
-              deletedAt: null,
-            },
-            data: { deletedAt: new Date() },
-          })
-          pageUpdated++
+      const localeWrites: LanguageLocaleWrite[] = []
+      const languageWrites = languages.map((lang) => {
+        const slugOwner = lang.slug ? slugOwners.get(lang.slug) : undefined
+        const slug =
+          lang.slug && (!slugOwner || slugOwner === lang.id) ? lang.slug : null
+        if (lang.slug && !slug) {
+          console.warn(
+            JSON.stringify({
+              event: "core-sync.language.duplicate-slug",
+              languageCoreId: lang.id,
+              slug: lang.slug,
+              existingLanguageCoreId: slugOwner,
+            }),
+          )
+        } else if (slug) {
+          slugOwners.set(slug, lang.id)
         }
-      }, CORE_SYNC_TRANSACTION_OPTIONS)
-      stats.updated += pageUpdated
+
+        for (const localeRow of toLocalizedNames(lang.name)) {
+          localeWrites.push({
+            id: randomUUID(),
+            languageCoreId: lang.id,
+            locale: localeRow.locale,
+            value: localeRow.value,
+            primary: localeRow.primary,
+            order: localeRow.order ?? null,
+          })
+        }
+
+        return {
+          id: randomUUID(),
+          coreId: lang.id,
+          bcp47: lang.bcp47,
+          iso3: lang.iso3,
+          slug,
+          nameBase64: encodeJsonForPgArray(toNameMap(lang.name)),
+          audioPreviewValue: lang.audioPreview?.value ?? null,
+          audioPreviewDuration: lang.audioPreview?.duration ?? null,
+          audioPreviewSize: lang.audioPreview?.size
+            ? String(lang.audioPreview.size)
+            : null,
+          audioPreviewBitrate: lang.audioPreview?.bitrate ?? null,
+          audioPreviewCodec: lang.audioPreview?.codec ?? null,
+        }
+      })
+
+      await bulkUpsertLanguages(prisma, languageWrites)
+      await bulkUpsertLanguageLocales(prisma, localeWrites)
+      await softDeleteStaleLanguageLocales(prisma, localeWrites)
+      stats.updated += languageWrites.length
     } catch (err) {
       stats.errors++
       console.error(


### PR DESCRIPTION
## Summary\n- replace row-by-row language and language-locale writes with bulk INSERT ... ON CONFLICT writes\n- preserve duplicate slug protection and stale locale soft-delete behavior\n- avoid production workflow step timeouts in the first Core sync phase\n\n## Verification\n- pnpm --filter @forge/admin test src/services/core-sync/phases/sync-languages.test.ts src/services/core-sync/phases/sync-countries.test.ts src/services/core-sync/phases/sync-dubs.test.ts\n- pnpm --filter @forge/admin typecheck\n- pnpm --filter @forge/admin lint\n- git diff --check