### PR TITLE
fix(admin): shrink core sync video transactions

### DIFF
--- a/apps/admin/src/services/core-sync/phases/sync-videos.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-videos.ts
@@ -286,7 +286,7 @@ export async function syncVideos({
     }
   }
 
-  const PAGE_SIZE = 200
+  const PAGE_SIZE = 25
   let offset = 0
   let firstPageCount = 0
   const seenCoreIds = new Set<string>()


### PR DESCRIPTION
## Summary
- shrink Core video sync pages from 200 to 25 rows so each nested video write transaction can commit inside the production transaction budget

## Verification
- pnpm --filter @forge/admin test src/services/core-sync/phases/sync-videos.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- git diff --check