### PR TITLE
fix(admin): shrink core sync subtitle transactions

### DIFF
--- a/apps/admin/src/services/core-sync/phases/sync-video-subtitles.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-video-subtitles.ts
@@ -8,7 +8,7 @@ import { CoreVideoSubtitleSchema } from "../schemas/video-subtitle"
 import { emptySyncStats } from "../types"
 import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 
-const PAGE_SIZE = 10000
+const PAGE_SIZE = 25
 
 const VIDEO_SUBTITLES_QUERY = `
   query VideoSubtitles($offset: Int!, $limit: Int!, $where: VideoSubtitlesFilter) {


### PR DESCRIPTION
## Summary
- reduce Core video subtitle sync page size so subtitle upserts stay inside the production Prisma transaction budget

## Verification
- pnpm --filter @forge/admin test src/services/core-sync/phases/sync-video-subtitles.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- git diff --check