### PR TITLE
fix(admin): bulk write core sync video editions

### DIFF
--- a/apps/admin/src/services/core-sync/phases/sync-video-editions.test.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-video-editions.test.ts
@@ -28,9 +28,7 @@ describe("syncVideoEditions", () => {
     } as never)
 
     const tx = {
-      videoEdition: {
-        upsert: vi.fn().mockResolvedValue({ id: "edition-admin-1" }),
-      },
+      $executeRaw: vi.fn().mockResolvedValue(1),
     }
     const prisma = {
       $transaction: vi.fn(async (fn: (trx: typeof tx) => Promise<void>) =>
@@ -48,19 +46,7 @@ describe("syncVideoEditions", () => {
 
     expect(stats.errors).toBe(0)
     expect(stats.updated).toBe(1)
-    expect(tx.videoEdition.upsert).toHaveBeenCalledWith({
-      where: { coreId: "edition-1" },
-      create: {
-        coreId: "edition-1",
-        name: "Standard",
-        syncedAt: expect.any(Date),
-      },
-      update: {
-        name: "Standard",
-        syncedAt: expect.any(Date),
-        deletedAt: null,
-      },
-    })
+    expect(tx.$executeRaw).toHaveBeenCalledOnce()
     expect(prisma.videoEdition.updateMany).toHaveBeenCalledWith({
       where: {
         source: "CORE",

--- a/apps/admin/src/services/core-sync/phases/sync-video-editions.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-video-editions.ts
@@ -2,12 +2,14 @@
 // Depends on: videos indirectly through downstream dubs/subtitles, but the
 // edition catalogue itself is a standalone Core query.
 
-import type { PrismaClient } from "@prisma/client"
+import type { Prisma, PrismaClient } from "@prisma/client"
+import { randomUUID } from "node:crypto"
 import type { SyncStats, ProgressReporter } from "../types"
 import { coreQuery } from "../core-client"
 import { CoreVideoEditionSchema } from "../schemas/video-edition"
 import { emptySyncStats } from "../types"
 import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
+import { assertParallelArrayLengthsMatch, toPgArray } from "@/db/pgvector"
 
 const VIDEO_EDITIONS_QUERY = `
   query VideoEditions($offset: Int!, $limit: Int!, $where: VideoEditionsFilter) {
@@ -23,6 +25,74 @@ type CoreVideoEdition = {
   id: string
   name: string | null
   updatedAt?: string
+}
+
+type EditionWrite = {
+  id: string
+  coreId: string
+  name: string
+}
+
+class VideoEditionSyncBulkWriteError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "VideoEditionSyncBulkWriteError"
+  }
+}
+
+function assertEditionWriteLengths(editions: readonly EditionWrite[]) {
+  assertParallelArrayLengthsMatch(
+    editions.length,
+    [
+      { name: "ids", length: editions.length },
+      { name: "coreIds", length: editions.length },
+      { name: "names", length: editions.length },
+    ],
+    (message) => new VideoEditionSyncBulkWriteError(message),
+  )
+}
+
+async function bulkUpsertVideoEditions(
+  tx: Pick<Prisma.TransactionClient, "$executeRaw">,
+  editions: readonly EditionWrite[],
+) {
+  if (editions.length === 0) return 0
+
+  assertEditionWriteLengths(editions)
+
+  return tx.$executeRaw`
+    INSERT INTO "video_edition" (
+      "id",
+      "core_id",
+      "source",
+      "name",
+      "synced_at",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      input."id",
+      input."core_id",
+      'core'::"SourceTier",
+      input."name",
+      NOW(),
+      NOW(),
+      NOW()
+    FROM unnest(
+      ${toPgArray(editions.map((edition) => edition.id))}::text[],
+      ${toPgArray(editions.map((edition) => edition.coreId))}::text[],
+      ${toPgArray(editions.map((edition) => edition.name))}::text[]
+    ) AS input("id", "core_id", "name")
+    ON CONFLICT ("core_id")
+    DO UPDATE SET
+      "name"       = EXCLUDED."name",
+      "synced_at"  = EXCLUDED."synced_at",
+      "updated_at" = EXCLUDED."updated_at",
+      "deleted_at" = NULL
+    WHERE
+      "video_edition"."deleted_at" IS NOT NULL
+      OR "video_edition"."name" IS DISTINCT FROM EXCLUDED."name"
+  `
 }
 
 export async function syncVideoEditions({
@@ -78,26 +148,16 @@ export async function syncVideoEditions({
     progress.setTotal(offset + editions.length)
 
     try {
-      let updated = 0
+      const writes: EditionWrite[] = editions.map((edition) => ({
+        id: randomUUID(),
+        coreId: edition.id,
+        name: edition.name ?? "",
+      }))
+
       await prisma.$transaction(async (tx) => {
-        for (const edition of editions) {
-          await tx.videoEdition.upsert({
-            where: { coreId: edition.id },
-            create: {
-              coreId: edition.id,
-              name: edition.name ?? "",
-              syncedAt: new Date(),
-            },
-            update: {
-              name: edition.name ?? "",
-              syncedAt: new Date(),
-              deletedAt: null,
-            },
-          })
-          updated++
-        }
+        await bulkUpsertVideoEditions(tx, writes)
       }, CORE_SYNC_TRANSACTION_OPTIONS)
-      stats.updated += updated
+      stats.updated += writes.length
     } catch (err) {
       stats.errors++
       console.error(


### PR DESCRIPTION
## Summary
- Replace per-row Prisma video edition upserts with a single bulk SQL upsert per Core page.
- Keep soft-delete behavior and focused phase coverage intact.

## Validation
- pnpm --filter @forge/admin exec vitest run src/services/core-sync/phases/sync-video-editions.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- git diff --check