### PR TITLE
refactor(admin): extract embedExperienceLocale helper + ce:review fixes

### DIFF
--- a/apps/admin/src/scripts/run-embeds.ts
+++ b/apps/admin/src/scripts/run-embeds.ts
@@ -58,6 +58,8 @@
  *     - `run-embeds.experience.start`      (pipeline=experience)
  *     - `run-embeds.experience.complete`   (pipeline=experience)
  *     - `run-embeds.experience.error`      (pipeline=experience, on error)
+ *     - `run-embeds.experience.skipped`    (pipeline=both — both = scene+transcript only;
+ *                                           experience is explicitly omitted)
  *     - `run-embeds.complete` — final aggregated report (pretty-printed JSON)
  *     - `run-embeds.report_out_written` — when --report-out succeeded
  *
@@ -310,6 +312,20 @@ async function main(): Promise<void> {
           }) + "\n",
         )
       }
+    }
+
+    // `pipeline=both` deliberately runs the original R1+R2 pair only.
+    // Emit a structured `experience.skipped` event so agents/operators
+    // parsing the event stream see the omission as an explicit signal
+    // rather than absence-of-event. Pair with `--pipeline=experience`
+    // (or, in the future, `--pipeline=all`) to also run R3.
+    if (pipelineArg === "both") {
+      process.stdout.write(
+        JSON.stringify({
+          event: "run-embeds.experience.skipped",
+          reason: "pipeline_both_excludes_experience",
+        }) + "\n",
+      )
     }
 
     if (pipelineArg === "experience") {

--- a/apps/admin/src/services/embeddings.service.ts
+++ b/apps/admin/src/services/embeddings.service.ts
@@ -2,7 +2,9 @@ import type { PrismaClient } from "@prisma/client"
 import { z } from "zod"
 import { canWriteDerived } from "@/auth/permissions"
 import type { Principal } from "@/auth/principal"
+import { SYSTEM_PRINCIPAL } from "@/auth/principal"
 import { env } from "@/config/env"
+import { prisma as defaultPrisma } from "@/db/client"
 import { BlockSchema } from "@/domain/blocks"
 import { toPgVector } from "@/db/pgvector"
 
@@ -334,4 +336,60 @@ export async function writeExperienceLocaleEmbedding({
         updated_at = NOW()
     WHERE id = ${localeId}
   `
+}
+
+/**
+ * End-to-end per-locale embedding work as a plain async service
+ * function: load → flatten text → generate vector → persist.
+ *
+ * Shared by:
+ *   - `runExperienceEmbedding` (workflow) — wraps this in a single
+ *     `"use step"` so step-replay semantics apply when dispatched via
+ *     the production workflow runtime.
+ *   - `runExperienceEmbeddingBackfill` (workflow) — calls this from its
+ *     per-target step body so the loop never nests `start()` calls.
+ *     Mirrors the R1/R2 pattern (`indexEditionScenes`,
+ *     `indexEditionTranscript`) where the workflow step body invokes a
+ *     plain service function rather than dispatching a sibling workflow.
+ *
+ * Returns the dimensions + model used so the caller can include them
+ * in operator-facing reports. Throws on any failure (load missing,
+ * provider error, persistence error) — callers wrap with their own
+ * try/catch + typed-outcome shaping.
+ */
+export type EmbedExperienceLocaleResult = {
+  localeId: string
+  dimensions: number
+  model: string
+}
+
+export async function embedExperienceLocale(
+  localeId: string,
+  options?: { prisma?: PrismaClient },
+): Promise<EmbedExperienceLocaleResult> {
+  const client = options?.prisma ?? defaultPrisma
+  const locale = await client.experienceLocale.findUniqueOrThrow({
+    where: { id: localeId },
+    select: {
+      id: true,
+      title: true,
+      metaDescription: true,
+      ogTitle: true,
+      ogDescription: true,
+      blocks: true,
+    },
+  })
+  const text = buildExperienceEmbeddingText(locale)
+  const generated = await generateExperienceEmbedding(text)
+  await writeExperienceLocaleEmbedding({
+    prisma: client,
+    localeId,
+    embedding: generated.embedding,
+    user: SYSTEM_PRINCIPAL,
+  })
+  return {
+    localeId,
+    dimensions: generated.dimensions,
+    model: generated.model,
+  }
 }

--- a/apps/admin/src/workflows/experienceEmbedding.ts
+++ b/apps/admin/src/workflows/experienceEmbedding.ts
@@ -1,19 +1,7 @@
-import { prisma } from "@/db/client"
-import { SYSTEM_PRINCIPAL } from "@/auth/principal"
 import {
-  buildExperienceEmbeddingText,
-  generateExperienceEmbedding,
-  writeExperienceLocaleEmbedding,
+  embedExperienceLocale,
+  type EmbedExperienceLocaleResult,
 } from "@/services/embeddings.service"
-
-type ExperienceEmbeddingLocaleRecord = {
-  id: string
-  title: string | null
-  metaDescription: string | null
-  ogTitle: string | null
-  ogDescription: string | null
-  blocks: unknown
-}
 
 export type ExperienceEmbeddingInput = {
   localeId: string
@@ -26,58 +14,35 @@ export type ExperienceEmbeddingOutput = {
   updated: boolean
 }
 
+/**
+ * Per-locale experience embedding workflow. Loads the locale, builds
+ * the embedding text, generates a vector, and persists it.
+ *
+ * The whole sequence is wrapped in a single `"use step"` so the
+ * production workflow runtime gets a clean replay boundary; the
+ * underlying work lives in `embedExperienceLocale` (a plain service
+ * function) so the same code path is reachable without the runtime —
+ * which is what `runExperienceEmbeddingBackfill` and
+ * `pnpm run-embeds --pipeline=experience` rely on.
+ */
 export async function runExperienceEmbedding(
   input: ExperienceEmbeddingInput,
 ): Promise<ExperienceEmbeddingOutput> {
   "use workflow"
 
-  const locale = await stepLoadExperienceLocale(input.localeId)
-  const text = buildExperienceEmbeddingText(locale)
-  const embedding = await stepGenerateExperienceEmbedding(text)
-  await stepPersistExperienceEmbedding(input.localeId, embedding.embedding)
+  const result = await stepEmbed(input.localeId)
 
   return {
-    localeId: input.localeId,
-    dimensions: embedding.dimensions,
-    model: embedding.model,
+    localeId: result.localeId,
+    dimensions: result.dimensions,
+    model: result.model,
     updated: true,
   }
 }
 
-async function stepLoadExperienceLocale(
+async function stepEmbed(
   localeId: string,
-): Promise<ExperienceEmbeddingLocaleRecord> {
+): Promise<EmbedExperienceLocaleResult> {
   "use step"
-
-  return prisma.experienceLocale.findUniqueOrThrow({
-    where: { id: localeId },
-    select: {
-      id: true,
-      title: true,
-      metaDescription: true,
-      ogTitle: true,
-      ogDescription: true,
-      blocks: true,
-    },
-  })
-}
-
-async function stepGenerateExperienceEmbedding(text: string) {
-  "use step"
-
-  return generateExperienceEmbedding(text)
-}
-
-async function stepPersistExperienceEmbedding(
-  localeId: string,
-  embedding: readonly number[],
-) {
-  "use step"
-
-  await writeExperienceLocaleEmbedding({
-    prisma,
-    localeId,
-    embedding,
-    user: SYSTEM_PRINCIPAL,
-  })
+  return embedExperienceLocale(localeId)
 }

--- a/apps/admin/src/workflows/experienceEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/experienceEmbeddingBackfill.test.ts
@@ -8,9 +8,7 @@
 // here.
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
-
-const { start } = vi.hoisted(() => ({ start: vi.fn() }))
-vi.mock("workflow/api", () => ({ start }))
+import { Prisma } from "@prisma/client"
 
 vi.mock("@/db/client", () => {
   const mock = {
@@ -19,40 +17,44 @@ vi.mock("@/db/client", () => {
   return { prisma: mock, syncPrisma: mock }
 })
 
+vi.mock("@/services/embeddings.service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/services/embeddings.service")>()
+  return {
+    ...actual,
+    embedExperienceLocale: vi.fn(async (localeId: string) => ({
+      localeId,
+      dimensions: 1536,
+      model: "text-embedding-3-small",
+    })),
+  }
+})
+
 const { prisma } = await import("@/db/client")
 const { runExperienceEmbeddingBackfill, _internals } =
   await import("./experienceEmbeddingBackfill")
-const { runExperienceEmbedding } = await import("./experienceEmbedding")
+const { embedExperienceLocale } = await import("@/services/embeddings.service")
 
 type PrismaStub = { $queryRaw: ReturnType<typeof vi.fn> }
+type EmbedStub = ReturnType<typeof vi.fn>
 
 function row(id: string, experienceId: string, locale: string) {
   return { id, experience_id: experienceId, locale }
 }
 
-function dispatchSuccess(dimensions = 1536, model = "text-embedding-3-small") {
-  start.mockResolvedValueOnce({
-    runId: `test-run-${Math.random().toString(36).slice(2, 10)}`,
-    returnValue: Promise.resolve({
-      localeId: "ignored-in-this-test",
-      dimensions,
-      model,
-      updated: true,
-    }),
-  })
-}
-
-function dispatchFailure(message: string) {
-  start.mockResolvedValueOnce({
-    runId: `test-run-${Math.random().toString(36).slice(2, 10)}`,
-    returnValue: Promise.reject(new Error(message)),
-  })
+function embedStub() {
+  return embedExperienceLocale as unknown as EmbedStub
 }
 
 describe("runExperienceEmbeddingBackfill", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(prisma as unknown as PrismaStub).$queryRaw.mockReset()
+    embedStub().mockImplementation(async (localeId: string) => ({
+      localeId,
+      dimensions: 1536,
+      model: "text-embedding-3-small",
+    }))
   })
 
   it("returns a clean success-shaped report when zero rows are eligible", async () => {
@@ -69,28 +71,20 @@ describe("runExperienceEmbeddingBackfill", () => {
       succeeded: 0,
       failed: 0,
     })
-    expect(start).not.toHaveBeenCalled()
+    expect(embedStub()).not.toHaveBeenCalled()
   })
 
-  it("dispatches runExperienceEmbedding once per eligible target", async () => {
+  it("calls embedExperienceLocale once per eligible target with the locale id", async () => {
     ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
       row("locale-a", "exp-1", "en"),
       row("locale-b", "exp-1", "es"),
     ])
-    dispatchSuccess()
-    dispatchSuccess()
 
     const report = await runExperienceEmbeddingBackfill({})
 
-    expect(start).toHaveBeenCalledTimes(2)
-    expect(start.mock.calls[0]).toEqual([
-      runExperienceEmbedding,
-      [{ localeId: "locale-a" }],
-    ])
-    expect(start.mock.calls[1]).toEqual([
-      runExperienceEmbedding,
-      [{ localeId: "locale-b" }],
-    ])
+    expect(embedStub()).toHaveBeenCalledTimes(2)
+    expect(embedStub().mock.calls[0]).toEqual(["locale-a"])
+    expect(embedStub().mock.calls[1]).toEqual(["locale-b"])
     expect(report.totalTargets).toBe(2)
     expect(report.succeeded).toBe(2)
     expect(report.failed).toBe(0)
@@ -105,35 +99,86 @@ describe("runExperienceEmbeddingBackfill", () => {
       dimensions: 1536,
       model: "text-embedding-3-small",
     })
+    expect(report.outcomes[1]).toMatchObject({
+      status: "succeeded",
+      target: { experienceLocaleId: "locale-b", locale: "es" },
+    })
   })
 
-  it("isolates per-target failures and continues the loop", async () => {
+  it("isolates per-target failures and continues the loop (siblings still succeed)", async () => {
     ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
       row("locale-a", "exp-1", "en"),
       row("locale-b", "exp-1", "es"),
       row("locale-c", "exp-2", "en"),
     ])
-    dispatchSuccess()
-    dispatchFailure("provider 503")
-    dispatchSuccess()
+    embedStub()
+      .mockImplementationOnce(async () => ({
+        localeId: "locale-a",
+        dimensions: 1536,
+        model: "text-embedding-3-small",
+      }))
+      .mockImplementationOnce(async () => {
+        throw new Error("provider 503")
+      })
+      .mockImplementationOnce(async () => ({
+        localeId: "locale-c",
+        dimensions: 1536,
+        model: "text-embedding-3-small",
+      }))
 
     const report = await runExperienceEmbeddingBackfill({})
 
-    expect(start).toHaveBeenCalledTimes(3)
+    expect(embedStub()).toHaveBeenCalledTimes(3)
     expect(report.succeeded).toBe(2)
     expect(report.failed).toBe(1)
+    expect(report.outcomes[0]).toMatchObject({
+      status: "succeeded",
+      target: { experienceLocaleId: "locale-a" },
+    })
     expect(report.outcomes[1]).toMatchObject({
       status: "failed",
       target: { experienceLocaleId: "locale-b" },
       reason: "provider 503",
     })
+    expect(report.outcomes[2]).toMatchObject({
+      status: "succeeded",
+      target: { experienceLocaleId: "locale-c" },
+    })
+  })
+
+  it("isolates synchronous embedExperienceLocale throws (not just async rejections)", async () => {
+    // Belt-and-suspenders for the per-target try/catch contract — a
+    // helper that throws synchronously before its first `await` must
+    // still classify as a failed outcome, not abort the loop.
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
+      row("locale-sync", "exp-sync", "en"),
+      row("locale-async", "exp-sync", "es"),
+    ])
+    embedStub()
+      .mockImplementationOnce(() => {
+        throw new Error("synchronous boom")
+      })
+      .mockImplementationOnce(async () => ({
+        localeId: "locale-async",
+        dimensions: 1536,
+        model: "text-embedding-3-small",
+      }))
+
+    const report = await runExperienceEmbeddingBackfill({})
+
+    expect(report.succeeded).toBe(1)
+    expect(report.failed).toBe(1)
+    expect(report.outcomes[0]).toMatchObject({
+      status: "failed",
+      reason: "synchronous boom",
+    })
+    expect(report.outcomes[1]).toMatchObject({ status: "succeeded" })
   })
 
   it("propagates the experienceIds + bcp47Locales filters into the report", async () => {
     ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
       row("locale-a", "exp-1", "en"),
     ])
-    dispatchSuccess()
 
     const report = await runExperienceEmbeddingBackfill({
       experienceIds: ["exp-1", "exp-2"],
@@ -143,21 +188,34 @@ describe("runExperienceEmbeddingBackfill", () => {
     expect(report.experienceIdFilter).toEqual(["exp-1", "exp-2"])
     expect(report.localeFilter).toEqual(["en", "es"])
     expect((prisma as unknown as PrismaStub).$queryRaw).toHaveBeenCalledTimes(1)
-    // The actual SQL composition (Prisma.sql + Prisma.join clauses) is
-    // covered by integration-style verification — a unit-test of the
-    // rendered SQL string would couple to Prisma's internal template
-    // wire format. The report-level assertion above proves the filter
-    // values reached the workflow body; a real-DB smoke is the next
-    // load-bearing check.
   })
 
-  it("records force=true in the report (embedding IS NULL clause is dropped)", async () => {
-    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([])
+  it("composes the SQL clauses: force=false adds `embedding IS NULL`, force=true drops it", async () => {
+    // T2 fix: inspect the Prisma.Sql fragments passed to $queryRaw so a
+    // regression that hardcoded the embedding clause (or dropped it
+    // unconditionally) fails loudly. Each clause is a `Prisma.Sql`
+    // instance whose `.text` exposes the rendered SQL fragment with
+    // `$N` placeholders for bound values.
+    ;(prisma as unknown as PrismaStub).$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
 
-    const report = await runExperienceEmbeddingBackfill({ force: true })
+    await runExperienceEmbeddingBackfill({})
+    await runExperienceEmbeddingBackfill({ force: true })
 
-    expect(report.force).toBe(true)
-    expect(report.totalTargets).toBe(0)
+    const calls = (prisma as unknown as PrismaStub).$queryRaw.mock.calls
+    expect(calls).toHaveLength(2)
+
+    // Tagged-template call shape: calls[i][0] is the strings array,
+    // calls[i][1..N] are the interpolated values. The first three
+    // interpolated values are embeddingClause, experienceIdClause,
+    // localeClause (in that order, per stepEnumerateTargets).
+    const defaultEmbeddingClause = calls[0]![1] as Prisma.Sql
+    const forceEmbeddingClause = calls[1]![1] as Prisma.Sql
+
+    expect(defaultEmbeddingClause.text).toMatch(/embedding IS NULL/)
+    // force: true uses Prisma.empty, which renders as an empty string.
+    expect(forceEmbeddingClause.text).toBe("")
   })
 
   it("treats empty filter arrays as omitted (matches R1/R2 contract)", async () => {

--- a/apps/admin/src/workflows/experienceEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/experienceEmbeddingBackfill.ts
@@ -1,6 +1,5 @@
 // Experience embedding backfill — durable useworkflow job that
-// enumerates eligible ExperienceLocale rows and dispatches the
-// per-locale `runExperienceEmbedding` workflow for each.
+// enumerates eligible ExperienceLocale rows and embeds them.
 //
 // Admin-native replacement for the embed-dispatch role the now-deleted
 // R3 experience-content-dump workflow played. Mirrors the R1/R2
@@ -31,19 +30,16 @@
 //   - dispatch test required at the resolver layer (see
 //     experience-embedding-backfill.test.ts in graphql/mutations);
 //     this workflow file is exercised body-only here
-//   - `start(runExperienceEmbedding, [...])` routes through the same
-//     `workflow/api` import the resolver uses; the directive ensures
-//     both paths route through the runtime in production. See
-//     docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md.
+//   - the per-target step calls `embedExperienceLocale` (a plain
+//     service function) directly — no nested `start()`. Same shape
+//     R1/R2 use (workflow step → service helper). This keeps the
+//     `pnpm run-embeds --pipeline=experience` CLI path
+//     runtime-independent: every per-target body executes inline,
+//     no implicit workflow-runtime dependency mid-loop.
 
 import { Prisma } from "@prisma/client"
-import { start } from "workflow/api"
 import { prisma } from "@/db/client"
-import {
-  runExperienceEmbedding,
-  type ExperienceEmbeddingInput,
-  type ExperienceEmbeddingOutput,
-} from "@/workflows/experienceEmbedding"
+import { embedExperienceLocale } from "@/services/embeddings.service"
 
 export type ExperienceEmbeddingBackfillInput = {
   /**
@@ -218,12 +214,7 @@ async function stepEmbedTarget(
 
   const startedAt = Date.now()
   try {
-    const run = await start(runExperienceEmbedding, [
-      {
-        localeId: target.experienceLocaleId,
-      } satisfies ExperienceEmbeddingInput,
-    ])
-    const result: ExperienceEmbeddingOutput = await run.returnValue
+    const result = await embedExperienceLocale(target.experienceLocaleId)
     return {
       status: "succeeded",
       target,

--- a/docs/solutions/best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md
+++ b/docs/solutions/best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md
@@ -295,7 +295,13 @@ beforeEach(() => {
 
 ## When NOT to apply this pattern
 
-`apps/admin/src/workflows/experienceContentDump.ts` (R3) intentionally **stays sequential**. Its per-target work dispatches a downstream `runExperienceEmbedding` workflow plus reads from cms's read-only role — the bottleneck is upstream cms, not admin. Parallelizing R3 would just queue at cms and add concurrent pressure on a fragile read role. See `docs/solutions/platform/admin-experience-content-dump-pattern.md` for the deliberate sequential-`for…of` decision.
+`apps/admin/src/workflows/experienceEmbeddingBackfill.ts` (the admin-native R3 replacement, post-PR-#966 + PR-#967) intentionally **stays sequential**. Its per-target work calls `embedExperienceLocale` (a plain service helper that itself hits OpenRouter / OpenAI) and admin's experience corpus is small enough that sequential `for…of` is fast enough for v1. Parallelizing would shift the bottleneck to the embedding provider's rate limits with no per-target wall-clock win. If the corpus grows or the helper picks up batchable cost, revisit by applying the canonical pattern (`pLimit + Promise.allSettled`) and treating the per-locale embed as the target.
+
+> **Historical note:** earlier revisions of this section pointed at the
+> retired `apps/admin/src/workflows/experienceContentDump.ts` (the cms →
+> admin dump that was deleted in PR #966). That workflow's bottleneck
+> was upstream cms's read-only role, which is no longer a constraint
+> now that experiences live in admin natively.
 
 Not every per-target loop benefits from this pattern. The prerequisites are:
 
@@ -327,7 +333,7 @@ When all three hold, apply the pattern. When they don't, sequential `for…of` i
 - `apps/admin/src/workflows/sceneEmbeddingBackfill.ts` — canonical implementation (R1).
 - `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts` — same shape, different domain (R2).
 - `apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts` — canonical test shape including `vi.spyOn(_internals, ...)`.
-- `apps/admin/src/workflows/experienceContentDump.ts` — counter-example: stays sequential intentionally (R3). Deliberate decision documented in `docs/solutions/platform/admin-experience-content-dump-pattern.md`.
+- `apps/admin/src/workflows/experienceEmbeddingBackfill.ts` — counter-example: stays sequential intentionally (admin-native R3, post-PR-#966 + PR-#967). The per-target step calls `embedExperienceLocale` (plain service helper) — see [`workflow-step-body-calls-service-not-sibling-workflow-20260517.md`](workflow-step-body-calls-service-not-sibling-workflow-20260517.md) for the "step bodies call services, not nested workflows" rule applied here.
 - `apps/admin/src/db/client.ts` — documents the `connection_limit=10` Prisma pool that constrains the concurrency default.
 - `apps/admin/CLAUDE.md` — R1 and R2 sections updated post-PR with the env vars and the `Promise.allSettled` invariant.
 - `docs/solutions/best-practices/parallel-workflow-error-robustness-20260420.md` — the prior learning that established "no `Promise.all`"; this doc complements it.

--- a/docs/solutions/best-practices/workflow-step-body-calls-service-not-sibling-workflow-20260517.md
+++ b/docs/solutions/best-practices/workflow-step-body-calls-service-not-sibling-workflow-20260517.md
@@ -1,0 +1,234 @@
+---
+title: "Workflow step bodies call plain helpers, never nested `start()` — preserves CLI-shim runtime independence"
+category: best-practices
+module: apps/admin
+date: 2026-05-17
+last_updated: 2026-05-17
+tags:
+  - useworkflow
+  - workflows
+  - embeddings
+  - cli-shim
+  - run-embeds
+  - composition-pattern
+  - sibling-symmetry
+  - ce-review
+  - pr-967
+  - pr-966
+problem_type: best_practice
+component: background_job
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+applies_when: >
+  Adding a new useworkflow backfill in apps/admin whose per-target step body
+  needs to do the same work as an existing per-unit workflow. The step body MUST
+  call a plain async service helper — never `start(siblingWorkflow, [...])`.
+  Nested `start()` inside a `"use step"` body silently breaks the
+  `pnpm --filter @forge/admin run-embeds` CLI shim (tsx mode treats
+  `"use workflow"` as inert, so nested `start()` re-enters `workflow/api` and
+  requires a running runtime that the CLI doesn't provide). Verify symmetry
+  with sibling backfills under `apps/admin/src/workflows/` —
+  `sceneEmbeddingBackfill.ts` and `transcriptEmbeddingBackfill.ts` both call
+  plain service functions (`indexEditionScenes`, `indexEditionTranscript`)
+  from their step bodies. Rule: workflow step → plain service function.
+  Never workflow step → nested workflow.
+---
+
+## Problem
+
+A workflow step body (`"use step"`) in `runExperienceEmbeddingBackfill` dispatched a sibling workflow via `start(runExperienceEmbedding, [...])` once per target. Because the CLI shim `pnpm --filter @forge/admin run-embeds` direct-invokes the backfill workflow (the `"use workflow"` directive is inert in the tsx runtime), every per-target iteration re-entered `workflow/api`'s `start()` with no workflow runtime configured — silently breaking the documented "runtime-independent CLI" invariant and adding RPC layering that the sibling R1/R2 backfills had explicitly avoided.
+
+## Symptoms
+
+- **CLI invocation stalls or 500s mid-loop.** `pnpm --filter @forge/admin run-embeds --pipeline=experience` would either hang on the first per-target `start()` (waiting for a runtime that isn't there) or fail with an opaque "no workflow runtime configured" error after target #1. The local-dev path documented in [`apps/admin/CLAUDE.md`](../../../apps/admin/CLAUDE.md) "Running embeds locally (R1 + R2)" would be quietly broken for R3 only.
+- **Production per-target latency creep.** Each `await run.returnValue` is an extra HTTP hop through admin's workflow runtime. For an N-target backfill, that's N extra round-trips beyond what R1/R2 incur. Slower batches, more failure surface, no functional gain.
+- **Replay/lifecycle coupling.** The outer step's durability boundary became entangled with the inner workflow's lifecycle — a retry of the outer step would re-issue a fresh inner `start()`, creating duplicate inner workflow runs with no idempotency key.
+- **Test suite was green.** Unit tests mocked `start()` to return synthetic `{ returnValue }` shapes, so the nested-dispatch path "worked" in tests while the real CLI/runtime contract was broken. Classic mocked-shape-vs-real-contract trap.
+
+## What Didn't Work
+
+- **"Reuse-by-dispatch felt natural."** The original author saw that `runExperienceEmbedding` already existed as a per-locale workflow and reached for `start(runExperienceEmbedding, [...])` as the reuse mechanism. The reasoning — "it's already a workflow, just call it from the backfill" — sounded like good DRY but ignored that workflow-to-workflow dispatch is an RPC boundary, not a function call.
+- **Mocked unit tests gave false confidence.** The backfill's tests stubbed `start` to return canned outcomes. Every branch (`succeeded` / `failed` / `skipped`) had coverage. Nothing in the test surface could distinguish "nested dispatch works" from "nested dispatch is impossible in the CLI runtime" because the runtime itself was mocked away.
+- **CI didn't exercise the CLI path.** `run-embeds` is invoked by humans + cron in dev, not by CI. The inert-directive CLI invariant has no automated guard — it's an oral-tradition contract from `apps/admin/CLAUDE.md`.
+- **Looking at R1/R2 as "different enough to diverge."** Scene + transcript backfills call `indexEditionScenes` / `indexEditionTranscript` directly because those were always plain functions. R3 felt special because the per-locale flow was already wrapped as a workflow. That perceived asymmetry was the trap — the right move was to flatten R3 to match R1/R2, not invent a new pattern.
+- **The reliability persona in `ce:review` caught it** (P2, confidence 0.88), not unit tests, not the type checker, not CI. The signal came from cross-file pattern recognition: "sibling backfills don't do this, why does this one?"
+
+## Solution
+
+Extract a plain async service function as the shared seam. Both the single-trigger workflow and the backfill step body call the helper directly. No nested `start()`.
+
+**Before** (`apps/admin/src/workflows/experienceEmbeddingBackfill.ts`):
+
+```ts
+async function stepEmbedTarget(target): Promise<ExperienceEmbeddingBackfillOutcome> {
+  "use step"
+  const startedAt = Date.now()
+  try {
+    const run = await start(runExperienceEmbedding, [
+      { localeId: target.experienceLocaleId } satisfies ExperienceEmbeddingInput,
+    ])
+    const result: ExperienceEmbeddingOutput = await run.returnValue
+    return { status: "succeeded", target, dimensions: result.dimensions, /* ... */ }
+  } catch (err) {
+    return { status: "failed", target, reason: /* ... */ }
+  }
+}
+```
+
+**After** — new helper at `apps/admin/src/services/embeddings.service.ts`:
+
+```ts
+export type EmbedExperienceLocaleResult = {
+  localeId: string
+  dimensions: number
+  model: string
+}
+
+export async function embedExperienceLocale(
+  localeId: string,
+  options?: { prisma?: PrismaClient },
+): Promise<EmbedExperienceLocaleResult> {
+  const client = options?.prisma ?? defaultPrisma
+  const locale = await client.experienceLocale.findUniqueOrThrow({
+    where: { id: localeId },
+    select: {
+      id: true,
+      title: true,
+      metaDescription: true,
+      ogTitle: true,
+      ogDescription: true,
+      blocks: true,
+    },
+  })
+  const text = buildExperienceEmbeddingText(locale)
+  const generated = await generateExperienceEmbedding(text)
+  await writeExperienceLocaleEmbedding({
+    prisma: client,
+    localeId,
+    embedding: generated.embedding,
+    user: SYSTEM_PRINCIPAL,
+  })
+  return { localeId, dimensions: generated.dimensions, model: generated.model }
+}
+```
+
+**After** — `runExperienceEmbedding` collapses to a thin shim:
+
+```ts
+export async function runExperienceEmbedding(
+  input: ExperienceEmbeddingInput,
+): Promise<ExperienceEmbeddingOutput> {
+  "use workflow"
+  const result = await stepEmbed(input.localeId)
+  return {
+    localeId: result.localeId,
+    dimensions: result.dimensions,
+    model: result.model,
+    updated: true,
+  }
+}
+
+async function stepEmbed(
+  localeId: string,
+): Promise<EmbedExperienceLocaleResult> {
+  "use step"
+  return embedExperienceLocale(localeId)
+}
+```
+
+**After** — backfill step body calls the helper directly:
+
+```ts
+async function stepEmbedTarget(
+  target,
+): Promise<ExperienceEmbeddingBackfillOutcome> {
+  "use step"
+  const startedAt = Date.now()
+  try {
+    const result = await embedExperienceLocale(target.experienceLocaleId)
+    return {
+      status: "succeeded",
+      target,
+      dimensions: result.dimensions,
+      model: result.model /* ... */,
+    }
+  } catch (err) {
+    return {
+      status: "failed",
+      target,
+      reason: err instanceof Error ? err.message : String(err) /* ... */,
+    }
+  }
+}
+```
+
+Net change: one new service function, one workflow flattened to a shim, one backfill step de-nested. **Zero behavior change in production** — only the CLI invariant is restored and per-target RPC overhead is removed.
+
+## Why This Works
+
+A plain async service function is the right shared seam because it carries **no execution-context requirements**. It runs identically whether invoked from:
+
+- A workflow step (durability + replay handled by the outer `"use step"`)
+- A backfill loop's step body (same — the outer step is the boundary)
+- A CLI shim with inert `"use workflow"` directives (just a function call, no runtime needed)
+- A test (no mocking infrastructure beyond Prisma / the embedding client)
+
+The workflow directive (`"use workflow"`) and step directive (`"use step"`) are **deployment-time decorations** on a service-layer function. They add durability and replay semantics at one boundary. Nesting `start()` inside a step means stacking two such boundaries — and the inner boundary needs the runtime that the outer boundary's CLI invocation explicitly opts out of. By contrast, calling the service helper directly keeps exactly one runtime-aware boundary per call stack, which is what both production AND the CLI shim expect.
+
+The rule generalizes: **directives decorate; services compose.** Share work between workflows by sharing services, never by dispatching siblings.
+
+## Prevention
+
+### Codified rule
+
+> **Workflow step bodies call plain service functions. They do not call `start()` on sibling workflows.** If two workflows need to share per-item work, extract a service helper and have each workflow's step body call it directly. The single-trigger workflow becomes a thin shim; the loop workflow's step body calls the helper inline.
+
+### Positive examples (canonical sibling shape)
+
+- `apps/admin/src/workflows/sceneEmbeddingBackfill.ts` — `stepIndexEditionLocale` calls `indexEditionScenes(prisma, {...})` directly.
+- `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts` — per-target step calls `indexEditionTranscript(prisma, {...})` directly.
+- Post-PR-#967: `apps/admin/src/workflows/experienceEmbeddingBackfill.ts` now matches. The shared helper lives at `apps/admin/src/services/embeddings.service.ts::embedExperienceLocale`.
+
+### Lint / test invariant (feasible)
+
+Add a static check that scans `apps/admin/src/workflows/**/*.ts` for any function annotated with `"use step"` whose body contains a call to `start(` from `workflow/api`. Sketch:
+
+```ts
+// apps/admin/src/workflows/__tests__/step-bodies-have-no-nested-start.test.ts
+it("no workflow step body calls start() on a sibling workflow", () => {
+  const stepFunctions = collectStepFunctions("apps/admin/src/workflows/**/*.ts")
+  for (const fn of stepFunctions) {
+    expect(
+      fn.body,
+      `${fn.file}:${fn.name} contains nested start() — extract a service helper`,
+    ).not.toMatch(/\bstart\s*\(/)
+  }
+})
+```
+
+A simpler ratchet: a CI grep that fails if any file under `apps/admin/src/workflows/` contains both `"use step"` and `start(` in the same function block.
+
+### Documentation hooks
+
+- Add a "Workflow step bodies" subsection to `apps/admin/CLAUDE.md` near the existing "Running embeds locally (R1 + R2)" section, stating the rule + cross-linking the two sibling files as positive examples.
+- Cross-reference from `docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md` — this is another instance of mocked-shape passing while runtime contract broke.
+
+### CLI-shim invariant (preserve explicitly)
+
+`apps/admin/CLAUDE.md`'s "Running embeds locally" contract: **workflows invoked from the CLI must not require a workflow runtime mid-loop.** Nested `start()` violates this directly. Any future workflow that the CLI shim invokes must keep its step bodies runtime-free — only the outer driver depends on directives being honored, and the CLI's inert-directive path ensures even that is just function execution.
+
+### Test-quality blind spot to call out
+
+**Dispatch tests that mock `start()` cannot catch nested-`start()` bugs.** If a workflow's tests rely on `vi.mock("workflow/api", () => ({ start: vi.fn(...) }))`, then by construction those tests cannot tell you whether the production runtime would accept the dispatch shape, whether the CLI runtime would refuse it, or whether the nesting is even meaningful. Add a real-invocation smoke (e.g., a tsx-runtime test that imports the workflow file and exercises the inert-directive path with a stubbed Prisma + embedding client) for any workflow that the CLI shim invokes. This is the same blind spot called out for AWS S3 NoSuchKey classification, PG `jsonb_array_elements_text` resolution, and producer-consumer report-file contracts — log it as another worked instance under the META solution `mocked-shape-vs-real-contract-discipline-20260506.md`.
+
+## Pointers
+
+- Parent canonical doc on inert directives: [`docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md`](workflow-dispatch-test-mode-divergence-20260421.md) — covers "test the dispatch at the consumer→workflow boundary." This doc is its corollary: the same inert-directive property creates a NEW failure mode when `start()` is nested inside a step body.
+- CLI-shim invariant source: [`docs/solutions/platform/local-embed-pipeline-pattern-20260429.md`](../platform/local-embed-pipeline-pattern-20260429.md) — Rule 6 names the genus; this doc names a specific species inside a `"use step"` body.
+- Sibling backfill pattern (parallel loop shape inside which the helper sits): [`docs/solutions/best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md`](bounded-parallelism-per-target-workflow-pattern-20260505.md).
+- Per-target outcome contract (helper must surface typed errors back to the loop, not throw raw): [`docs/solutions/best-practices/parallel-workflow-error-robustness-20260420.md`](parallel-workflow-error-robustness-20260420.md).
+- The META home for mocked-shape-vs-real-contract: [`docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md`](mocked-shape-vs-real-contract-discipline-20260506.md) — this PR is another worked instance.
+- Sibling-call-site discipline (the helper extraction had to update two call sites in lockstep): [`docs/solutions/best-practices/review-fix-round-2-sibling-call-site-regressions-20260421.md`](review-fix-round-2-sibling-call-site-regressions-20260421.md).
+- The PR that introduced the bug: [PR #966](https://github.com/JesusFilm/forge/pull/966) (`refactor(admin): decouple experience embeddings from cms`).
+- The PR that fixed it: [PR #967](https://github.com/JesusFilm/forge/pull/967) (`refactor(admin): extract embedExperienceLocale helper + ce:review fixes`).

--- a/docs/solutions/database-issues/first-drop-column-forward-only-migration-playbook-20260517.md
+++ b/docs/solutions/database-issues/first-drop-column-forward-only-migration-playbook-20260517.md
@@ -1,0 +1,292 @@
+---
+title: "First DROP COLUMN forward-only migration playbook — verify prod state, co-version code, IF EXISTS idempotency"
+category: database-issues
+module: apps/admin
+date: 2026-05-17
+last_updated: 2026-05-17
+tags:
+  - prisma
+  - migrations
+  - drop-column
+  - forward-only
+  - postgres
+  - railway
+  - rollback-playbook
+  - prod-verification
+  - schema-evolution
+problem_type: database_issue
+component: database
+root_cause: missing_validation
+resolution_type: migration
+severity: medium
+applies_when: >
+  Authoring the first DROP COLUMN migration in a Prisma + Postgres
+  + Railway codebase that has so far only added/altered columns. The
+  rollback semantics change at the moment a column is removed — code
+  that previously referenced the column will no longer compile or
+  query against the post-migration schema. This doc captures the
+  five-step playbook applied to admin's migration 0014
+  (`0014_drop_experience_locale_cms_snapshot`), the first such drop
+  in admin. Apply when the next admin migration needs to drop
+  columns, drop indexes, drop tables, or DROP TYPE / DROP CONSTRAINT.
+---
+
+## Problem
+
+When a Prisma + Postgres codebase has accumulated only **additive**
+migrations (new tables, new columns, new indexes), the team's
+rollback discipline becomes "rolling back to an earlier image is
+functionally safe — the schema is ahead of the code, but ahead-only,
+and queries against the ahead schema still work because the older
+code just doesn't see the new columns." Every admin migration before
+0014 satisfied this invariant; CLAUDE.md "Migrations" section codified
+it as: _"a code-side rollback is functionally safe."_
+
+The **first** DROP migration breaks that invariant silently. Code
+that previously referenced the dropped column will fail at runtime
+against the post-migration schema. If the rollback playbook is
+copy-pasted from the additive-only era, an operator rolling back will
+brick reads on the affected tables with no warning.
+
+## Symptoms (what failure looks like if the playbook isn't followed)
+
+- `prisma migrate deploy` succeeds on production, dropping the columns.
+- Operator notices an unrelated issue and rolls Railway back one
+  deploy (the "safe" thing under the additive-only rule).
+- The rolled-back image's Prisma client still has typed accessors for
+  the now-dropped columns; any query selecting those fields (even via
+  `select: { ... }`) fails with `column does not exist`.
+- The failure surfaces as Prisma `PrismaClientKnownRequestError` /
+  `P2010` at runtime in unrelated handlers, not at startup.
+- The "fix" (re-deploy the post-drop code) requires forward motion
+  while the operator is mid-incident.
+
+## What didn't work (anti-patterns to avoid)
+
+- **"Just trust `prisma migrate deploy`."** Prisma applies the SQL
+  successfully and updates `_prisma_migrations`; nothing in that flow
+  flags that the migration is **structurally** different from prior
+  additive ones. No CI rule, no Prisma warning, no Railway alert.
+- **"The `IF EXISTS` guard makes the migration safe."** `IF EXISTS`
+  makes the migration **idempotent under retry** — re-applying it
+  against an already-dropped schema is a no-op. It does **not** make
+  rollback safe. The idempotency is about apply, not revert.
+- **"Document the change in the PR description."** The PR description
+  surfaces during merge review but disappears from the operator's
+  view at rollback time. The rollback playbook needs to live in the
+  durable runbook (`CLAUDE.md` or equivalent), not just the PR.
+- **"Inspect the table for non-NULL values before dropping."** A
+  precaution, but it only proves the _current_ state is empty. It
+  says nothing about rollback safety — even a zero-row table will
+  break rollback if the rolled-back code references the dropped
+  columns.
+
+## Solution — the five-step playbook
+
+### 1. Verify prod state with a structured query (proves "no data loss")
+
+Before authoring the migration, prove that the columns being dropped
+are empty in production. For admin, this meant:
+
+```sql
+SELECT COUNT(*) AS total,
+       COUNT(<col1>) AS non_null_col1,
+       COUNT(<col2>) AS non_null_col2,
+       COUNT(<col3>) AS non_null_col3
+FROM <table>;
+```
+
+Capture the result in the migration's commit message AND in the PR
+description. For 0014, the probe returned `0, 0, 0, 0` against admin's
+prod Postgres (the dump that wrote those columns never successfully
+ran in prod). The migration's header comment cites the date + result:
+
+```sql
+-- Verified safe to apply against admin's prod Postgres on 2026-05-17
+-- — `SELECT COUNT(*) FROM experience_locale` returned 0 rows and the
+-- three cms_* counts were trivially 0.
+```
+
+This is **load-bearing audit evidence**, not commentary. A future
+maintainer trying to understand "why is this drop safe?" reads this
+header and either accepts the audit or re-runs the probe.
+
+For Railway-hosted Postgres, the probe is reachable via:
+
+```bash
+# Railway project token has variables-read access. Fetch
+# DATABASE_PUBLIC_URL via the project's GraphQL API, then psql.
+# Memory-saved tokens shortcut the OAuth dance for repeat audits.
+ADMIN_DB_URL=$(curl -s -X POST https://backboard.railway.com/graphql/v2 \
+  -H 'Project-Access-Token: <project-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"query($p:String!,$e:String!,$s:String!){variables(projectId:$p,environmentId:$e,serviceId:$s)}", \
+       "variables":{...}}' \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['variables']['DATABASE_PUBLIC_URL'])")
+psql "$ADMIN_DB_URL" -c "SELECT COUNT(*) ..."
+```
+
+### 2. Co-version the schema + code in one PR
+
+The migration that drops the column lands in the same PR as every
+code change that removed references to it. **Do not** drop the column
+in one PR and clean up the code in a follow-up — that creates a
+window where main has dead column references against a schema that
+no longer has them.
+
+In PR #966 this was 6 commits arranged so each was independently
+buildable:
+
+```
+Unit 1 (additive)  → ship replacement code path
+Unit 2 (subtractive) → remove GraphQL surface + perm key
+Unit 3 (subtractive) → remove workflow + service + cms-coupled modules
+Unit 4 (subtractive) → remove env var
+Unit 5 (schema)    → migration 0014 drops the columns
+Unit 6 (docs)      → update CLAUDE.md, supersede stale docs
+```
+
+The Unit 5 migration is the LAST schema-touching commit; every code
+reference to the dropped columns was removed in Units 2–4. A rollback
+to **any commit on this branch** is co-versioned: schema and code
+agree.
+
+### 3. Write the SQL with `IF EXISTS` everywhere (idempotency under retry)
+
+```sql
+-- Forward-only. See the corresponding code-removal commits in the
+-- same PR. Rollback past this commit requires a re-add migration.
+
+DROP INDEX IF EXISTS "<index_name>";
+
+ALTER TABLE "<table>"
+  DROP COLUMN IF EXISTS "<col1>",
+  DROP COLUMN IF EXISTS "<col2>",
+  DROP COLUMN IF EXISTS "<col3>";
+```
+
+`IF EXISTS` matters because:
+
+- Prisma's chained `startCommand` on Railway retries up to 3× on
+  failure. If the migration applies to one container and a sibling
+  container retries, the second attempt would error on already-dropped
+  columns without `IF EXISTS`.
+- Mid-migration crashes (rare with column drops, but possible) leave
+  Postgres in a partial state. `IF EXISTS` lets the second attempt
+  resume cleanly.
+- Operators occasionally run `prisma migrate deploy` manually against
+  an already-migrated DB during emergency recovery; the no-op behavior
+  prevents accidental errors.
+
+### 4. Update the rollback playbook in the durable runbook
+
+The pre-0014 CLAUDE.md said simply: _"a code-side rollback is
+functionally safe."_ That sentence was correct under the additive-only
+invariant. Update it to encode the new boundary:
+
+```markdown
+Migration `0014_drop_experience_locale_cms_snapshot` (2026-05-17) is
+the first admin migration to drop columns. Code-side rollback rules:
+
+- Rolling back to the **immediately-prior commit** on the PR that
+  added 0014 is functionally safe: that commit no longer references
+  the dropped columns. Schema and code were co-versioned in the same
+  PR.
+- Rolling back further than that — to a commit that still references
+  the dropped columns — is unsafe. The columns are gone from the DB
+  but the code expects them, so Prisma reads fail at runtime. If you
+  need to roll back past 0014, coordinate a re-add migration first.
+- Every earlier migration (0001–0013) is purely additive — new
+  tables, new columns, new indexes — so the pre-0014 rule that
+  "rolling back to an earlier image is functionally safe" still
+  holds for that stretch of history.
+```
+
+The runbook update lives in the same PR as the migration. Future
+operators reading the migrations section at incident-time get the
+correct rollback boundary at the moment they need it.
+
+### 5. Add post-deploy verification queries to the PR's monitoring section
+
+Don't trust `prisma migrate deploy`'s success exit — confirm at the
+schema layer that the drop actually applied:
+
+```sql
+-- Should return 0 rows post-deploy:
+SELECT column_name
+FROM information_schema.columns
+WHERE table_name='<table>' AND column_name LIKE '<dropped-prefix>%';
+
+-- Should NOT include the dropped index:
+SELECT indexname FROM pg_indexes WHERE tablename='<table>' ORDER BY indexname;
+
+-- Migration ledger should show 0014 with finished_at IS NOT NULL,
+-- rolled_back_at IS NULL:
+SELECT migration_name, finished_at, rolled_back_at, applied_steps_count
+FROM _prisma_migrations
+WHERE migration_name = '<your-migration-name>';
+```
+
+These belong in the PR's "Post-Deploy Monitoring & Validation"
+section so they execute as part of the deploy checklist, not as
+forgotten tribal knowledge.
+
+## Why this works
+
+Each step closes a specific gap that the additive-only-era playbook
+left open:
+
+| Step                   | Gap it closes                                   |
+| ---------------------- | ----------------------------------------------- |
+| 1. Verify prod state   | "How do I know this won't lose data?"           |
+| 2. Co-version code     | "Is rollback to the prior commit safe?"         |
+| 3. `IF EXISTS` SQL     | "What if the migration retries mid-apply?"      |
+| 4. Update runbook      | "Where do operators learn the new boundary?"    |
+| 5. Post-deploy queries | "How do I confirm the schema actually changed?" |
+
+Steps 1, 2, and 4 are unique to first-drop or drop-heavy migrations.
+Steps 3 and 5 are good hygiene for every migration. The combination
+is what makes a column drop **safe by construction** rather than
+"safe in practice if you remember the gotchas."
+
+## Prevention
+
+### For the next admin DROP migration
+
+Treat 0014's commit as the canonical template. Specifically:
+
+1. Run the prod-state probe; cite the result + date in the migration
+   header comment.
+2. Pair the migration commit with the code-removal commits in the
+   same PR; the migration is the LAST schema-touching commit in the
+   branch.
+3. Use `IF EXISTS` on every `DROP` statement.
+4. Update `apps/admin/CLAUDE.md`'s Migrations section to extend the
+   rollback boundary (if this is a new shape of drop — e.g., the
+   first DROP TABLE or first DROP TYPE).
+5. Add the post-deploy verification queries to the PR description.
+
+### Lint / CI ratchet (proposed, not yet implemented)
+
+A CI grep against `apps/admin/prisma/migrations/**/*.sql` for any
+`DROP COLUMN`, `DROP TABLE`, `DROP INDEX`, or `ALTER TABLE ... DROP`
+that doesn't carry the corresponding `IF EXISTS` would catch the
+non-idempotent case. A separate check could grep for a "Verified
+safe" header comment on any migration whose body contains a `DROP`
+statement.
+
+### Cross-app applicability
+
+The five-step playbook generalises to any Prisma + Postgres codebase
+that has been additive-only. apps/cms and apps/manager have the same
+shape; if either drops its first column, apply this playbook
+verbatim.
+
+## Pointers
+
+- The canonical worked example: [`apps/admin/prisma/migrations/0014_drop_experience_locale_cms_snapshot/migration.sql`](../../../apps/admin/prisma/migrations/0014_drop_experience_locale_cms_snapshot/migration.sql).
+- The pre-0014 additive-only rule: [`apps/admin/CLAUDE.md`](../../../apps/admin/CLAUDE.md) "Migrations" section (updated in PR #966 with the new 0014-aware boundary).
+- The plan that codified the playbook: [`docs/plans/2026-05-17-001-refactor-decouple-experience-embeds-from-cms-plan.md`](../../plans/2026-05-17-001-refactor-decouple-experience-embeds-from-cms-plan.md) (Unit 5 + Risks & Dependencies sections).
+- Adjacent solutions: [`postgres-generated-column-drift-add-column-if-not-exists-20260429.md`](postgres-generated-column-drift-add-column-if-not-exists-20260429.md) covers the additive `ADD COLUMN IF NOT EXISTS` companion pattern; [`prisma-unsupported-placeholder-for-raw-sql-generated-columns-20260429.md`](prisma-unsupported-placeholder-for-raw-sql-generated-columns-20260429.md) covers Prisma's `Unsupported(...)?` columns that often surface in admin's pgvector context.
+- The PR that introduced 0014: [PR #966](https://github.com/JesusFilm/forge/pull/966).
+- The prod-state verification was performed via Railway API token (project-scoped); cf. memory note `railway_prod_credentials.md` for the token + memory note `project_admin_prod_experience_corpus_empty.md` for the captured probe result.

--- a/docs/solutions/platform/admin-experience-content-dump-pattern.md
+++ b/docs/solutions/platform/admin-experience-content-dump-pattern.md
@@ -1,6 +1,8 @@
 ---
 title: Admin Experience Content Dump — durable cms → admin migration via direct Postgres + canonical-JSON content hash
 date: 2026-04-23
+last_updated: 2026-05-17
+superseded_by: docs/plans/2026-05-17-001-refactor-decouple-experience-embeds-from-cms-plan.md
 category: platform
 problem_type: integration
 component: workflow_orchestration
@@ -30,6 +32,37 @@ related:
   - "docs/solutions/best-practices/experience-embedding-pipeline-pgvector-strapi-v5-20260414.md"
 date_learned: 2026-04-23
 ---
+
+## Status (2026-05-17)
+
+> **The R3 cms-experience-content-dump workflow described in this doc was
+> retired on 2026-05-17.** Experiences now live in admin natively;
+> `apps/admin/src/workflows/experienceContentDump.ts` and its supporting
+> cms-coupled modules (`cms-pg.ts`, `cms-experience-source.repository.ts`,
+> `cms-block-transforms.ts`, `cms-video-id-resolver.ts`, the
+> `triggerExperienceContentDump` mutation, the `CMS_DATABASE_URL` env)
+> were all deleted in [PR #966](https://github.com/JesusFilm/forge/pull/966).
+> The admin-native replacement is `triggerExperienceEmbeddingBackfill` +
+> `pnpm --filter @forge/admin run-embeds --pipeline=experience`; see
+> `apps/admin/CLAUDE.md` "Triggering experience embeddings".
+>
+> Why preserve this doc anyway: three patterns inside remain reusable for
+> future cross-source migrations — (a) repository abstraction for
+> cross-database reads, (b) canonical-JSON content-hash gating for
+> idempotent reruns, (c) "persist the hash AFTER the side effect" recovery
+> loop. Treat code paths and file references as historical; treat the
+> pattern shapes as still load-bearing.
+>
+> Also note: the "R3 has two dispatches: mutation→workflow and
+> workflow→`runExperienceEmbedding`" reviewer rule below is **no longer
+> accurate** even on the live admin-native backfill. PR #967 extracted
+> the embedding side-effect to a plain async helper
+> (`embedExperienceLocale` in `apps/admin/src/services/embeddings.service.ts`),
+> so the modern shape is "one dispatch: mutation→backfill workflow; the
+> per-locale embedding is a plain helper call from the step body." See
+> [`docs/solutions/best-practices/workflow-step-body-calls-service-not-sibling-workflow-20260517.md`](../best-practices/workflow-step-body-calls-service-not-sibling-workflow-20260517.md)
+> for the canonical "workflow step bodies call services, not nested
+> workflows" rule.
 
 ## Problem
 

--- a/docs/solutions/platform/local-embed-pipeline-pattern-20260429.md
+++ b/docs/solutions/platform/local-embed-pipeline-pattern-20260429.md
@@ -255,6 +255,19 @@ them.
    direct-invokes will break at runtime. See
    `docs/solutions/best-practices/workflow-dispatch-test-mode-divergence-20260421.md`.
 
+   **Corollary (added 2026-05-17 after PR #967):** AND `"use workflow"`
+   functions must not call `start()` on **sibling** workflows from inside
+   their own `"use step"` bodies. Nested `start()` re-enters
+   `workflow/api` and requires a workflow runtime at the inner boundary
+   — which the CLI shim's direct-invoke path explicitly does not have.
+   If two workflows need to share per-item work, extract a plain async
+   service helper and have each workflow's step body call it directly.
+   The single-trigger workflow becomes a thin shim around the helper;
+   the backfill loop's step body calls the helper inline. See
+   [`docs/solutions/best-practices/workflow-step-body-calls-service-not-sibling-workflow-20260517.md`](../best-practices/workflow-step-body-calls-service-not-sibling-workflow-20260517.md)
+   for the worked instance (`embedExperienceLocale` between
+   `runExperienceEmbedding` and `runExperienceEmbeddingBackfill`).
+
 7. **HTTP status semantics on the proxy.** 503 (not 500) for
    `config_missing` (manager env not set) — operator-fixable
    misconfig is service-unavailable, not unexpected error. 502 for


### PR DESCRIPTION
## Summary

Follow-up to #966 addressing the three actionable P2 findings from `ce:review`.

- **R1 (reliability)** — Replaces the nested `start(runExperienceEmbedding)` call inside the backfill's per-target step with a direct call to a new `embedExperienceLocale` plain async helper in `embeddings.service.ts`. `runExperienceEmbedding` becomes a thin `"use workflow"` shim that wraps the helper in a single `"use step"`. Matches the R1/R2 sibling pattern (workflow step calls a service helper, never nests a sibling workflow) and removes the implicit workflow-runtime dependency in the `pnpm run-embeds --pipeline=experience` CLI path. Per-target step still gets its replay boundary from the outer backfill workflow when dispatched via the production runtime.
- **T2 (testing)** — Adds an explicit SQL-clause shape assertion that inspects the `Prisma.Sql` fragments passed to `$queryRaw` so a regression that hardcoded the embedding clause (or unconditionally dropped it) now fails loudly. Asserts `embedding IS NULL` is present when `force: false` and absent (Prisma.empty) when `force: true`. T1 (test for synchronous helper rejection) lands in the same file alongside the existing async-rejection test.
- **M1 (UX/observability)** — Emits a structured `run-embeds.experience.skipped` event when `--pipeline=both` is selected, so agents/operators parsing the event stream see the omission as an explicit signal rather than absence-of-event. The `both = scene + transcript only` semantics are preserved for back-compat.

## Testing

- Full admin test suite green: 2182 passed | 1 todo (136 files).
- New tests in `experienceEmbeddingBackfill.test.ts`:
  - `calls embedExperienceLocale once per eligible target with the locale id`
  - `isolates per-target failures and continues the loop (siblings still succeed)` — tightened to positively assert sibling outcomes
  - `isolates synchronous embedExperienceLocale throws (not just async rejections)` (T1)
  - `composes the SQL clauses: force=false adds embedding IS NULL, force=true drops it` (T2)
- `pnpm --filter @forge/admin lint` clean.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `event=experience_embed_complete` / `_failed` (per-locale outcomes from the helper); `event=run-embeds.experience.{start,complete,error,skipped}` (CLI events including the new `skipped` event for `--pipeline=both`).
- **Expected healthy behavior**
  - The new helper path produces byte-identical user-facing report shape — `succeeded/failed/outcomes` carry the same fields. No GraphQL surface change.
  - CLI `pnpm run-embeds --pipeline=experience` now executes inline against any `DATABASE_URL` without requiring a running workflow runtime.
- **Failure signal(s) / rollback trigger**
  - Backfill returns `failed` for every target where the helper throws — e.g., `OPENROUTER_API_KEY` missing, locale not found, DB connectivity. No new failure modes vs the pre-refactor shape.
- **Validation window & owner**
  - Window: first run of `triggerExperienceEmbeddingBackfill` (or `pnpm run-embeds --pipeline=experience`) after merge.
  - Owner: Nisal.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7, 1M context, extended thinking) + Compound Engineering v2.52.0