### PR TITLE
fix(admin): emit search.request log via console.warn so Railway captures it

### DIFF
--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -277,7 +277,10 @@ describe("GET /api/search", () => {
     let logSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
-      logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+      // The search.request log uses console.warn (stderr) because
+      // Railway's logsV2 silences info-level stdout from Next.js App
+      // Router runtime requests. See route.ts for the rationale.
+      logSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
     })
 
     afterEach(() => {

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -114,7 +114,18 @@ export async function GET(request: Request): Promise<Response> {
     : authHeader != null
       ? "invalid_bearer"
       : "anonymous"
-  console.log(
+  // Emit via console.warn (stderr) rather than console.log (stdout)
+  // because Railway's logsV2 reliably captures stderr from Next.js
+  // App Router runtime requests but silences info-level stdout
+  // output on this Next.js 16 + Node 24 + standalone configuration
+  // (verified 2026-05-18: deployment c62112c2 shows console.error
+  // lines from this same file in Railway logs but no console.log
+  // lines for served requests). The structured payload is unchanged.
+  // Operators rely on grepping `auth=anonymous` / `auth=invalid_bearer`
+  // before the Phase 4 SEARCH_AUTH_REQUIRED flip — that observability
+  // is the whole point of Phase 1, and it only works if the log
+  // lines actually surface.
+  console.warn(
     JSON.stringify({
       event: "search.request",
       auth: authTag,

--- a/apps/admin/src/graphql/queries/hybrid-search.test.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.test.ts
@@ -246,7 +246,10 @@ describe("Query.search bearer auth gate (Plan 002)", () => {
   let logSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+    // The search.request log uses console.warn (stderr) because
+    // Railway's logsV2 silences info-level stdout from Next.js App
+    // Router runtime requests. See hybrid-search.ts for the rationale.
+    logSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
   })
 
   afterEach(() => {

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -153,7 +153,11 @@ builder.queryFields((t) => ({
         : authHeader != null
           ? "invalid_bearer"
           : "anonymous"
-      console.log(
+      // See route.ts for the rationale — Railway's logsV2 silences
+      // info-level stdout from Next.js App Router runtime requests on
+      // the current Next.js 16 + Node 24 + standalone stack. Using
+      // console.warn (stderr) keeps the observability signal alive.
+      console.warn(
         JSON.stringify({
           event: "search.request",
           auth: authTag,


### PR DESCRIPTION
## Summary

Empirical finding from probing PR #968's deployment (commit `a88d269c`): Railway's logsV2 silences info-level stdout from Next.js App Router runtime requests on the current Next.js 16 + Node 24 + standalone stack. The existing `[search] Search failed: ...` log on the same route surfaces fine because it uses `console.error` (stderr), but the new structured `search.request` log emitted via `console.log` was **invisible** in the Railway dashboard for served requests. Boot-time stdout from Prisma + Next.js readiness DID surface — runtime stdout did not.

## Why this matters

Operators rely on grepping `auth=anonymous` / `auth=invalid_bearer` before the Phase 4 `SEARCH_AUTH_REQUIRED` flip to identify un-migrated callers. That observability is the whole point of Phase 1's structured-log discipline — and it only works if the log lines actually reach Railway's log pipeline.

Without this fix, flipping required-auth would be operationally blind: any internal caller still presenting as anonymous wouldn't surface in admin logs, and the flip's first symptom would be 401s on production traffic.

## What changed

- `apps/admin/src/app/api/search/route.ts:117` — `console.log` → `console.warn`
- `apps/admin/src/graphql/queries/hybrid-search.ts:156` — same
- Tests at both seams spy on `console.warn` instead of `console.log`
- Structured JSON payload unchanged. Log content is byte-identical to before.

## Why this is empirical pragmatism, not a clean solution

The underlying Railway/Next.js stdout-silencing issue affects other code paths in admin too (e.g., `revalidate-webhook.ts` uses `console.log(JSON.stringify(...))` which may also be silenced under runtime load). A proper fix would either (a) introduce a structured logger that always goes through stderr, or (b) configure Next.js to force-flush stdout on every request. Both out of scope for the immediate Phase 4 unblock.

## Testing

- `pnpm --filter @forge/admin test` — 2253 passing (1 todo, unchanged from baseline; +1 net new in this branch is actually 0 — the test count is the same as PR #968 because the spy target changed but no new tests were added)
- `pnpm --filter @forge/admin lint` — clean
- `pnpm --filter @forge/admin typecheck` — clean

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Railway logs for `@forge/admin`: grep for `event=search.request`
- **Validation check**
  - After deploy, run the same curl probe used pre-merge:
    ```
    curl -H "Authorization: Bearer fake-key-not-in-csv" \
      "https://admin.jesusfilm.org/api/search?q=test&locale=en"
    ```
  - Within 1-2 minutes, the admin log stream should show a structured line: `{"event":"search.request","auth":"invalid_bearer","path":"rest","rl":"redis"}`
- **Expected healthy behavior**
  - `search.request` events appear in Railway logs at WARN severity, one per `/api/search` or `Query.search` request
  - No change in HTTP status codes, response shapes, or request handling
- **Failure signal / rollback trigger**
  - If `search.request` still doesn't appear in logs after this deploys → the root cause is something other than stdout-vs-stderr (e.g., logsV2 sampling, GraphQL endpoint specifics). Revert and investigate.
- **Validation window & owner**
  - 30 minutes post-deploy. Owner: Nisal.

🤖 Generated with [Claude Opus 4.7 (1M context)](https://claude.com/claude-code) via Claude Code + Compound Engineering v2.52.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>