### PR TITLE
docs(manager): clarify job state helper comment

### DIFF
--- a/apps/manager/src/lib/state.ts
+++ b/apps/manager/src/lib/state.ts
@@ -1,5 +1,5 @@
-// Job state manager backed by Strapi CMS via GraphQL.
-// Uses typed operations from @forge/graphql with gql.tada.
+// Job state access helpers for live and mock manager data modes.
+// Live mode uses typed Strapi GraphQL operations from @forge/graphql.
 
 import { graphql, type ResultOf, type VariablesOf } from "@forge/graphql"
 import getClient from "@/cms/client"


### PR DESCRIPTION
## Summary
- remove the misleading top-level comment that described manager job state as backed by Strapi CMS
- clarify that this file provides live/mock manager data-mode helpers, with live mode using typed Strapi GraphQL operations

## Verification
- Confirmed the old misleading phrase no longer appears in apps/manager.