### PR TITLE
Fix manager admin-trigger dispatch queue

### DIFF
--- a/apps/manager/src/lib/admin-trigger-route.test.ts
+++ b/apps/manager/src/lib/admin-trigger-route.test.ts
@@ -16,6 +16,8 @@ const { env } = await import("@/config/env")
 const {
   processAdminTriggerRequest,
   __clearInFlightMapForTests,
+  __setDispatchConcurrencyForTests,
+  __setMaxPendingDispatchesForTests,
   AdminTriggerBodySchema,
 } = await import("@/lib/admin-trigger-route")
 
@@ -248,6 +250,275 @@ describe("processAdminTriggerRequest — happy path", () => {
     await new Promise((r) => setTimeout(r, 0))
     expect(dispatched).toHaveLength(2)
     expect(dispatched[0].muxAssetId).toBe("mux-c-1")
+  })
+
+  it("queues accepted dispatches behind a bounded process-local concurrency cap", async () => {
+    __setDispatchConcurrencyForTests(1)
+    const adminLookup = vi.fn(async () =>
+      adminLookupOk([
+        videoFixture({ coreId: "c-1" }),
+        videoFixture({ coreId: "c-2" }),
+        videoFixture({ coreId: "c-3" }),
+      ]),
+    )
+    const started: number[] = []
+    const resolvers: Array<() => void> = []
+    const dispatch = vi.fn(
+      (input) =>
+        new Promise<unknown>((resolve) => {
+          started.push(input.assetId)
+          resolvers.push(() => resolve({}))
+        }),
+    )
+
+    const res = await processAdminTriggerRequest({
+      request: makeRequest({
+        items: [
+          { assetId: 1, coreId: "c-1" },
+          { assetId: 2, coreId: "c-2" },
+          { assetId: 3, coreId: "c-3" },
+        ],
+      }),
+      kind: "transcript",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    const body = (await res.json()) as {
+      results: Array<{ status: string }>
+    }
+
+    expect(body.results.map((r) => r.status)).toEqual([
+      "started",
+      "started",
+      "started",
+    ])
+    await new Promise((r) => setTimeout(r, 0))
+    expect(started).toEqual([1])
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    resolvers[0]()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(started).toEqual([1, 2])
+    expect(dispatch).toHaveBeenCalledTimes(2)
+
+    resolvers[1]()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(started).toEqual([1, 2, 3])
+    expect(dispatch).toHaveBeenCalledTimes(3)
+
+    resolvers[2]()
+    await new Promise((r) => setTimeout(r, 0))
+  })
+
+  it("shares the concurrency cap across separate requests and trigger kinds", async () => {
+    __setDispatchConcurrencyForTests(1)
+    const adminLookup = vi.fn(async (coreIds: readonly string[]) =>
+      adminLookupOk(coreIds.map((coreId) => videoFixture({ coreId }))),
+    )
+    const started: Array<{ kind: string; assetId: number }> = []
+    const resolvers: Array<() => void> = []
+    const dispatchFor = (kind: string) =>
+      vi.fn(
+        (input) =>
+          new Promise<unknown>((resolve) => {
+            started.push({ kind, assetId: input.assetId })
+            resolvers.push(() => resolve({}))
+          }),
+      )
+    const transcriptDispatch = dispatchFor("transcript")
+    const sceneDispatch = dispatchFor("scene-analysis")
+
+    await processAdminTriggerRequest({
+      request: makeRequest({ items: [{ assetId: 1, coreId: "c-1" }] }),
+      kind: "transcript",
+      dispatch: transcriptDispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    await processAdminTriggerRequest({
+      request: makeRequest({ items: [{ assetId: 2, coreId: "c-2" }] }),
+      kind: "scene-analysis",
+      dispatch: sceneDispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+    expect(started).toEqual([{ kind: "transcript", assetId: 1 }])
+    expect(transcriptDispatch).toHaveBeenCalledTimes(1)
+    expect(sceneDispatch).not.toHaveBeenCalled()
+
+    resolvers[0]()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(started).toEqual([
+      { kind: "transcript", assetId: 1 },
+      { kind: "scene-analysis", assetId: 2 },
+    ])
+    expect(sceneDispatch).toHaveBeenCalledTimes(1)
+
+    resolvers[1]()
+    await new Promise((r) => setTimeout(r, 0))
+  })
+
+  it("keeps scheduled after work pending until this request's queued jobs settle", async () => {
+    __setDispatchConcurrencyForTests(1)
+    const adminLookup = vi.fn(async () =>
+      adminLookupOk([
+        videoFixture({ coreId: "c-1" }),
+        videoFixture({ coreId: "c-2" }),
+      ]),
+    )
+    const resolvers: Array<() => void> = []
+    const dispatch = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolvers.push(() => resolve({}))
+        }),
+    )
+    let scheduleSettled = false
+
+    await processAdminTriggerRequest({
+      request: makeRequest({
+        items: [
+          { assetId: 1, coreId: "c-1" },
+          { assetId: 2, coreId: "c-2" },
+        ],
+      }),
+      kind: "transcript",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb().then(() => {
+          scheduleSettled = true
+        })
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(scheduleSettled).toBe(false)
+
+    resolvers[0]()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(scheduleSettled).toBe(false)
+
+    resolvers[1]()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(scheduleSettled).toBe(true)
+  })
+
+  it("returns a retryable 503 instead of accepting work when the dispatch queue is full", async () => {
+    __setDispatchConcurrencyForTests(1)
+    __setMaxPendingDispatchesForTests(1)
+    const adminLookup = vi.fn(async (coreIds: readonly string[]) =>
+      adminLookupOk(coreIds.map((coreId) => videoFixture({ coreId }))),
+    )
+    const dispatch = vi.fn(
+      () => new Promise<unknown>(() => {}) as Promise<unknown>,
+    )
+
+    const first = await processAdminTriggerRequest({
+      request: makeRequest({ items: [{ assetId: 1, coreId: "c-1" }] }),
+      kind: "transcript",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    expect(first.status).toBe(200)
+    await new Promise((r) => setTimeout(r, 0))
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    const second = await processAdminTriggerRequest({
+      request: makeRequest({ items: [{ assetId: 2, coreId: "c-2" }] }),
+      kind: "transcript",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    expect(second.status).toBe(503)
+    const body = (await second.json()) as {
+      error: string
+      retryable: boolean
+      maxPendingDispatches: number
+    }
+    expect(body).toEqual(
+      expect.objectContaining({
+        error: "manager dispatch queue full",
+        retryable: true,
+        maxPendingDispatches: 1,
+      }),
+    )
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not spend queue capacity on validation_failed, not_found, or already_in_flight rows", async () => {
+    __setDispatchConcurrencyForTests(1)
+    __setMaxPendingDispatchesForTests(1)
+    const dispatch = vi.fn(
+      () => new Promise<unknown>(() => {}) as Promise<unknown>,
+    )
+    const adminLookup = vi.fn(async (coreIds: readonly string[]) =>
+      adminLookupOk(
+        coreIds.flatMap((coreId) => {
+          if (coreId === "c-missing") return []
+          if (coreId === "c-no-sub") {
+            return [videoFixture({ coreId, subtitleUrl: null })]
+          }
+          return [videoFixture({ coreId })]
+        }),
+      ),
+    )
+
+    const first = await processAdminTriggerRequest({
+      request: makeRequest({ items: [{ assetId: 1, coreId: "c-1" }] }),
+      kind: "transcript",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    expect(first.status).toBe(200)
+    await new Promise((r) => setTimeout(r, 0))
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    const nonDispatching = await processAdminTriggerRequest({
+      request: makeRequest({
+        items: [
+          { assetId: 1, coreId: "c-1" },
+          { assetId: 2, coreId: "c-no-sub" },
+          { assetId: 3, coreId: "c-missing" },
+        ],
+      }),
+      kind: "transcript",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    expect(nonDispatching.status).toBe(200)
+    const body = (await nonDispatching.json()) as {
+      results: Array<{ assetId: number; status: string }>
+    }
+    expect(body.results).toEqual([
+      expect.objectContaining({ assetId: 1, status: "already_in_flight" }),
+      expect.objectContaining({ assetId: 2, status: "validation_failed" }),
+      expect.objectContaining({ assetId: 3, status: "not_found" }),
+    ])
+    expect(dispatch).toHaveBeenCalledTimes(1)
   })
 
   it("does NOT include documentId on the dispatch input (feat-125 — Strapi-only field dropped)", async () => {
@@ -642,6 +913,117 @@ describe("processAdminTriggerRequest — idempotency", () => {
     expect(sceneBody.results[0].status).toBe("started")
     expect(transcriptBody.results[0].status).toBe("started")
     expect(neverDispatch).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps queued items in-flight before their dispatch starts", async () => {
+    __setDispatchConcurrencyForTests(1)
+    const adminLookup = vi.fn(async () =>
+      adminLookupOk([
+        videoFixture({ coreId: "c-1" }),
+        videoFixture({ coreId: "c-2" }),
+      ]),
+    )
+    const resolvers: Array<() => void> = []
+    const dispatch = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolvers.push(() => resolve({}))
+        }),
+    )
+
+    const first = await processAdminTriggerRequest({
+      request: makeRequest({
+        items: [
+          { assetId: 1, coreId: "c-1" },
+          { assetId: 2, coreId: "c-2" },
+        ],
+      }),
+      kind: "scene-analysis",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    const firstBody = (await first.json()) as {
+      results: Array<{ assetId: number; status: string; managerJobId: string }>
+    }
+    await new Promise((r) => setTimeout(r, 0))
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    const queuedJobId = firstBody.results.find(
+      (r) => r.assetId === 2,
+    )?.managerJobId
+    const duplicateQueued = await processAdminTriggerRequest({
+      request: makeRequest({ items: [{ assetId: 2, coreId: "c-2" }] }),
+      kind: "scene-analysis",
+      dispatch,
+      adminLookup,
+      scheduleAfter: (cb) => {
+        void cb()
+      },
+    })
+    const duplicateBody = (await duplicateQueued.json()) as {
+      results: Array<{ status: string; managerJobId: string }>
+    }
+
+    expect(duplicateBody.results[0].status).toBe("already_in_flight")
+    expect(duplicateBody.results[0].managerJobId).toBe(queuedJobId)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    resolvers[0]()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    resolvers[1]()
+    await new Promise((r) => setTimeout(r, 0))
+  })
+
+  it("does not prune queued or running jobs by the old TTL while dispatch is unresolved", async () => {
+    __setDispatchConcurrencyForTests(1)
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0)
+    const adminLookup = neverResolvesLookup()
+    const dispatch = vi.fn(
+      () => new Promise<unknown>(() => {}) as Promise<unknown>,
+    )
+
+    try {
+      const first = await processAdminTriggerRequest({
+        request: makeRequest({ items: [{ assetId: 77, coreId: "c-1" }] }),
+        kind: "transcript",
+        dispatch,
+        adminLookup,
+        scheduleAfter: (cb) => {
+          void cb()
+        },
+      })
+      const firstBody = (await first.json()) as {
+        results: Array<{ status: string; managerJobId: string }>
+      }
+      expect(firstBody.results[0].status).toBe("started")
+      const managerJobId = firstBody.results[0].managerJobId
+      await new Promise((r) => setTimeout(r, 0))
+      expect(dispatch).toHaveBeenCalledTimes(1)
+
+      nowSpy.mockReturnValue(10 * 60 * 1000)
+      const duplicateAfterOldTtl = await processAdminTriggerRequest({
+        request: makeRequest({ items: [{ assetId: 77, coreId: "c-1" }] }),
+        kind: "transcript",
+        dispatch,
+        adminLookup,
+        scheduleAfter: (cb) => {
+          void cb()
+        },
+      })
+      const duplicateBody = (await duplicateAfterOldTtl.json()) as {
+        results: Array<{ status: string; managerJobId: string }>
+      }
+
+      expect(duplicateBody.results[0].status).toBe("already_in_flight")
+      expect(duplicateBody.results[0].managerJobId).toBe(managerJobId)
+      expect(dispatch).toHaveBeenCalledTimes(1)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it("releases the slot after the dispatch REJECTS (sad-path slot leak guard)", async () => {

--- a/apps/manager/src/lib/admin-trigger-route.ts
+++ b/apps/manager/src/lib/admin-trigger-route.ts
@@ -18,7 +18,7 @@
 //   2. Idempotency check against the in-memory map (5-minute TTL,
 //      keyed by `${kind}:${assetId}`). Hit → return existing
 //      managerJobId with status "already_in_flight".
-//   3. Generate a new managerJobId, store in the map, dispatch via
+//   3. Generate a new managerJobId, store in the map, enqueue via
 //      `after()` background-task semantics. Status "started".
 //
 // Pre-feat-125 the lookup hit Strapi GraphQL via Apollo; admin owns
@@ -126,15 +126,33 @@ export type AdminTriggerResult = {
 // `processAdminTriggerRequest` doesn't change.
 // ---------------------------------------------------------------------------
 
-const IN_FLIGHT_TTL_MS = 5 * 60 * 1000
+const DEFAULT_DISPATCH_CONCURRENCY = 3
+const DEFAULT_MAX_PENDING_DISPATCHES = 300
 
-type InFlightEntry = { managerJobId: string; expiresAt: number }
+type InFlightEntry = { managerJobId: string; expiresAt: number | null }
 
 // Module-level so it survives across requests on the same process.
 const inFlightMap = new Map<string, InFlightEntry>()
 
+type QueuedAdminTriggerJob = {
+  kind: TriggerKind
+  item: AdminTriggerItem
+  managerJobId: string
+  key: string
+  dispatchInput: AdminTriggerDispatchInput
+  dispatch: AdminTriggerDispatcher
+  done: Promise<void>
+  resolveDone: () => void
+}
+
+const dispatchQueue: QueuedAdminTriggerJob[] = []
+let activeDispatches = 0
+let dispatchConcurrency = DEFAULT_DISPATCH_CONCURRENCY
+let maxPendingDispatches = DEFAULT_MAX_PENDING_DISPATCHES
+
 function pruneExpired(now: number): void {
   for (const [key, entry] of inFlightMap) {
+    if (entry.expiresAt == null) continue
     if (entry.expiresAt < now) inFlightMap.delete(key)
   }
 }
@@ -151,6 +169,109 @@ function inFlightKey(kind: TriggerKind, assetId: number): string {
  */
 export function __clearInFlightMapForTests(): void {
   inFlightMap.clear()
+  dispatchQueue.splice(0, dispatchQueue.length)
+  activeDispatches = 0
+  dispatchConcurrency = DEFAULT_DISPATCH_CONCURRENCY
+  maxPendingDispatches = DEFAULT_MAX_PENDING_DISPATCHES
+}
+
+/**
+ * Test-only: override queue width so unit tests can prove queuing
+ * behavior without relying on the production cap.
+ */
+export function __setDispatchConcurrencyForTests(concurrency: number): void {
+  dispatchConcurrency = Math.max(1, Math.floor(concurrency))
+  drainDispatchQueue()
+}
+
+/**
+ * Test-only: override the pending queue cap so tests can prove the
+ * backpressure branch without filling hundreds of jobs.
+ */
+export function __setMaxPendingDispatchesForTests(maxPending: number): void {
+  maxPendingDispatches = Math.max(1, Math.floor(maxPending))
+}
+
+function pendingDispatchCount(): number {
+  return activeDispatches + dispatchQueue.length
+}
+
+function enqueueDispatch(job: QueuedAdminTriggerJob): Promise<void> {
+  dispatchQueue.push(job)
+  console.warn(
+    JSON.stringify({
+      event: "admin-trigger.dispatch.queued",
+      kind: job.kind,
+      assetId: job.item.assetId,
+      coreId: job.item.coreId,
+      managerJobId: job.managerJobId,
+      queueDepth: dispatchQueue.length,
+      activeDispatches,
+    }),
+  )
+  drainDispatchQueue()
+  return job.done
+}
+
+function drainDispatchQueue(): void {
+  while (activeDispatches < dispatchConcurrency) {
+    const job = dispatchQueue.shift()
+    if (!job) return
+
+    activeDispatches++
+    void runQueuedDispatch(job)
+  }
+}
+
+async function runQueuedDispatch(job: QueuedAdminTriggerJob): Promise<void> {
+  try {
+    // Use console.warn (stderr) for structured runtime events —
+    // Railway logsV2 silences console.log (stdout) from Next.js
+    // App Router runtime handlers. See
+    // docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md.
+    console.warn(
+      JSON.stringify({
+        event: "admin-trigger.dispatch.running",
+        kind: job.kind,
+        assetId: job.item.assetId,
+        coreId: job.item.coreId,
+        managerJobId: job.managerJobId,
+        queueDepth: dispatchQueue.length,
+        activeDispatches,
+        dispatchConcurrency,
+      }),
+    )
+    await job.dispatch(job.dispatchInput)
+    console.warn(
+      JSON.stringify({
+        event: "admin-trigger.dispatch.complete",
+        kind: job.kind,
+        assetId: job.item.assetId,
+        coreId: job.item.coreId,
+        managerJobId: job.managerJobId,
+      }),
+    )
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: "admin-trigger.dispatch.error",
+        kind: job.kind,
+        assetId: job.item.assetId,
+        coreId: job.item.coreId,
+        managerJobId: job.managerJobId,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+  } finally {
+    // Release the in-flight slot once the dispatch settles
+    // (success OR failure) so a re-trigger after pipeline finish
+    // (operator decided to re-run) is allowed without waiting out
+    // the TTL.
+    inFlightMap.delete(job.key)
+    activeDispatches--
+    job.resolveDone()
+    drainDispatchQueue()
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -305,6 +426,7 @@ export async function processAdminTriggerRequest(
     })
 
   const results: AdminTriggerResult[] = []
+  const queuedJobs: QueuedAdminTriggerJob[] = []
 
   for (const item of items) {
     const video = videos.get(item.coreId)
@@ -360,10 +482,6 @@ export async function processAdminTriggerRequest(
     }
 
     const managerJobId = randomUUID()
-    inFlightMap.set(key, {
-      managerJobId,
-      expiresAt: now + IN_FLIGHT_TTL_MS,
-    })
 
     const dispatchInput: AdminTriggerDispatchInput = {
       assetId: item.assetId,
@@ -374,37 +492,20 @@ export async function processAdminTriggerRequest(
       languageBcp47: video.primaryLanguageBcp47,
     }
 
-    schedule(async () => {
-      // Wrap the ENTIRE callback body in try/finally so the
-      // in-flight slot is released regardless of where in the cb a
-      // throw originates (the dispatch itself, the structured-log
-      // JSON.stringify above the await, or any future side-effect
-      // added between them). A naive `try { await dispatch } finally
-      // { delete }` only covers the await path — a synchronous throw
-      // earlier in the cb would leak the slot until TTL prune,
-      // blocking re-triggers for up to 5 minutes.
-      try {
-        // Use console.warn (stderr) for structured runtime events —
-        // Railway logsV2 silences console.log (stdout) from Next.js
-        // App Router runtime handlers. See
-        // docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md.
-        console.warn(
-          JSON.stringify({
-            event: "admin-trigger.dispatch",
-            kind: args.kind,
-            assetId: item.assetId,
-            coreId: item.coreId,
-            managerJobId,
-          }),
-        )
-        await args.dispatch(dispatchInput)
-      } finally {
-        // Release the in-flight slot once the dispatch settles
-        // (success OR failure) so a re-trigger after pipeline
-        // finish (operator decided to re-run) is allowed without
-        // waiting out the TTL.
-        inFlightMap.delete(key)
-      }
+    let resolveDone: () => void = () => {}
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve
+    })
+
+    queuedJobs.push({
+      kind: args.kind,
+      item,
+      managerJobId,
+      key,
+      dispatchInput,
+      dispatch: args.dispatch,
+      done,
+      resolveDone,
     })
 
     results.push({
@@ -412,6 +513,52 @@ export async function processAdminTriggerRequest(
       coreId: item.coreId,
       managerJobId,
       status: "started",
+    })
+  }
+
+  const pendingAfterThisRequest = pendingDispatchCount() + queuedJobs.length
+  if (pendingAfterThisRequest > maxPendingDispatches) {
+    console.error(
+      JSON.stringify({
+        event: "admin-trigger.dispatch.queue_full",
+        kind: args.kind,
+        itemCount: queuedJobs.length,
+        queueDepth: dispatchQueue.length,
+        activeDispatches,
+        maxPendingDispatches,
+      }),
+    )
+    return NextResponse.json(
+      {
+        error: "manager dispatch queue full",
+        retryable: true,
+        queueDepth: dispatchQueue.length,
+        activeDispatches,
+        maxPendingDispatches,
+      },
+      { status: 503 },
+    )
+  }
+
+  if (queuedJobs.length > 0) {
+    for (const job of queuedJobs) {
+      inFlightMap.set(job.key, {
+        managerJobId: job.managerJobId,
+        expiresAt: null,
+      })
+      console.warn(
+        JSON.stringify({
+          event: "admin-trigger.dispatch.accepted",
+          kind: job.kind,
+          assetId: job.item.assetId,
+          coreId: job.item.coreId,
+          managerJobId: job.managerJobId,
+        }),
+      )
+    }
+
+    schedule(async () => {
+      await Promise.all(queuedJobs.map((job) => enqueueDispatch(job)))
     })
   }
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,10 +6,10 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (May 15, 2026)
 
-- **Total tickets:** 143
-- **Complete:** 75
+- **Total tickets:** 145
+- **Complete:** 76
 - **In progress:** 9
-- **Not started:** 19
+- **Not started:** 20
 - **Blocked:** 40
 - **Overdue and not complete:** 24
 
@@ -26,7 +26,9 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-115](content-discovery/feat-115-embed-backfill-bounded-parallelism.md)                                   | Embed Backfill — Stage 1 — Bounded Parallelism on Per-Target Loop                               | nisal     | P0       | 2026-05-04 | 1    | 2026-05-04 | complete    |
 | [feat-116](content-discovery/feat-116-embed-backfill-s3-cache-and-batched-openrouter.md)                       | Embed Backfill — Stage 2 — S3 Artifact Memoization + Batched OpenRouter Calls                   | nisal     | P0       | 2026-05-06 | 2    | 2026-05-07 | complete    |
 | [feat-117](content-discovery/feat-117-embed-backfill-bulk-sql-writes.md)                                       | Embed Backfill — Stage 3 — Bulk DB Writes via INSERT … ON CONFLICT                              | nisal     | P0       | 2026-05-08 | 2    | 2026-05-09 | complete    |
-| [feat-125](content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md)                         | Admin full-catalog manager enrichment trigger for scene analysis and transcripts                 | nisal     | P0       | 2026-05-19 | 3    | 2026-05-21 | not-started |
+| [feat-125](content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md)                        | Admin full-catalog manager enrichment trigger for scene analysis and transcripts                | nisal     | P0       | 2026-05-19 | 3    | 2026-05-21 | not-started |
+| [feat-126](content-discovery/feat-126-manager-admin-trigger-dispatch-queue.md)                                 | Manager admin-trigger dispatch queue for enrichment backfills                                   | nisal     | P0       | 2026-05-19 | 1    | 2026-05-19 | complete    |
+| [feat-127](content-discovery/feat-127-manager-durable-admin-trigger-job-state.md)                              | Manager durable admin-trigger job state for operator enrichment                                 | nisal     | P0       | 2026-05-19 | 2    | 2026-05-20 | not-started |
 | [feat-097](content-discovery/feat-097-investigate-prod-query-embedding.md)                                     | Investigate Production Query Embedding Degradation                                              | nisal     | P1       | 2026-04-15 | 2    | 2026-04-16 | complete    |
 | [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)                                        | Experience Embedding Pipeline                                                                   | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |
 | [feat-037](content-discovery/feat-037-video-content-vectorization.md)                                          | Video Content Vectorization for Recommendations                                                 | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | complete    |

--- a/docs/roadmap/content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md
+++ b/docs/roadmap/content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md
@@ -10,6 +10,7 @@ depends_on: []
 blocks:
   - "feat-120"
   - "feat-125"
+  - "feat-126"
 tags:
   - "admin"
   - "manager"

--- a/docs/roadmap/content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md
+++ b/docs/roadmap/content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md
@@ -8,6 +8,8 @@ start_date: "2026-05-19"
 duration: 3
 depends_on:
   - "feat-119"
+  - "feat-126"
+  - "feat-127"
 blocks: []
 tags:
   - "admin"

--- a/docs/roadmap/content-discovery/feat-126-manager-admin-trigger-dispatch-queue.md
+++ b/docs/roadmap/content-discovery/feat-126-manager-admin-trigger-dispatch-queue.md
@@ -1,0 +1,96 @@
+---
+id: "feat-126"
+title: "Manager admin-trigger dispatch queue for enrichment backfills"
+owner: "nisal"
+priority: "P0"
+status: "complete"
+start_date: "2026-05-19"
+duration: 1
+depends_on:
+  - "feat-119"
+blocks:
+  - "feat-127"
+  - "feat-125"
+tags:
+  - "manager"
+  - "admin"
+  - "ai-pipeline"
+  - "operator-tools"
+  - "reliability"
+---
+
+## Problem
+
+The production enrichment trigger run on 2026-05-18 showed that manager accepted many transcript-only artifact jobs as `STARTED`, but only a subset produced `{assetId}/embeddings.json`. Manager Railway logs showed repeated Mux `429 Too many requests` errors during the same burst.
+
+The admin-trigger receiver currently schedules one background callback per accepted item. When admin sends full batches, manager fans out Mux-heavy transcript work immediately. `STARTED` therefore means "accepted for background dispatch", not "durably queued" or "will run under provider-safe concurrency".
+
+## Entry Points — Read These First
+
+1. `apps/manager/src/lib/admin-trigger-route.ts` — shared receiver for `/api/admin-trigger/{scene-analysis,transcript}`. It validates, dedupes, tracks process-local in-flight entries, and schedules background dispatches.
+2. `apps/manager/src/app/api/admin-trigger/transcript/route.ts` — wires transcript requests to `runTranscriptOnlyPipeline`.
+3. `apps/manager/src/app/api/admin-trigger/scene-analysis/route.ts` — wires scene requests to `runSceneAnalysisPipeline`.
+4. `apps/manager/src/workflows/transcriptOnlyPipeline.ts` — transcript-only artifact producer; calls Mux transcription first, then writes embeddings.
+5. `apps/manager/src/services/transcription.ts` — Mux subtitle polling/fetch path that hit rate limits in production.
+6. `apps/manager/src/lib/admin-trigger-route.test.ts` — shared receiver tests.
+7. `apps/manager/src/app/api/admin-trigger/transcript/route.test.ts` and `apps/manager/src/app/api/admin-trigger/scene-analysis/route.test.ts` — route integration tests.
+
+## Grep These
+
+```
+grep -rn "processAdminTriggerRequest" apps/manager/src
+grep -rn "admin-trigger.dispatch" apps/manager/src
+grep -rn "transcript_only_pipeline" apps/manager/src
+grep -rn "ADMIN_TRIGGER" apps/manager/src/config apps/manager/CLAUDE.md
+grep -rn "429\\|rate" apps/manager/src/services
+```
+
+## What To Build
+
+Add bounded manager-side dispatch for admin-triggered enrichment pipelines.
+
+1. Replace per-item immediate `after()` fan-out with a process-local queue shared by `/api/admin-trigger/scene-analysis` and `/api/admin-trigger/transcript`.
+2. Process queued jobs with a conservative concurrency cap so one admin request cannot stampede Mux.
+   - Default this slice to a hardcoded cap of 3 concurrent dispatches per manager process.
+   - Treat the cap as a per-process guardrail, not a durable cross-instance provider limit. During the immediate prod backfill, assume manager is running as a single active instance; cross-instance concurrency control belongs to a follow-up if Railway is scaled horizontally.
+   - Validate the cap operationally by watching manager logs for Mux 429s on the next small retry before re-firing large transcript batches.
+3. Keep the existing response contract:
+   - accepted items still return `started`
+   - validation failures remain synchronous per item
+   - `already_in_flight` still protects duplicate asset/kind requests
+4. Bound total pending manager work as well as active concurrency:
+   - reject new trigger requests with a retryable 503 when the process-local pending queue is full
+   - do not partially accept a request when the queue has no capacity
+   - keep this as a manager backpressure signal, not a new per-item result status
+5. Keep the queue in process memory for this slice. Durable cross-deploy status belongs to a follow-up unless implementation finds a small existing local pattern.
+   - `started` in this slice means accepted by the current manager process, not durably persisted
+   - feat-125 must not present `started` as completed progress; artifact existence remains the completion signal until durable job state exists
+6. Keep queued/running idempotency entries alive until dispatch settles. Do not let the legacy 5-minute TTL prune jobs that are still queued or running.
+7. Keep the queue runner attached to Next `after()` lifecycle. A request's scheduled background task must await the queued jobs it accepted through settlement instead of enqueueing detached promises and returning immediately.
+8. Add log breadcrumbs that distinguish accepted, queued, started-running, completed, rejected-queue-full, and failed queued jobs without logging secrets.
+9. Make the cap configurable by optional env var only if needed; default behavior must boot without new required Railway variables.
+
+## Constraints
+
+- Do not create or depend on CMS `EnrichmentJob` rows for this admin-trigger path.
+- Do not broaden into the admin operator UI from `feat-125`.
+- Do not change the public request/response shape of `/api/admin-trigger/*`.
+- Do not hand-edit generated GraphQL outputs.
+- Do not make a new required env var that could break Railway boot.
+- Do not solve durable accepted-job semantics in this PR; create a follow-up if feat-125 needs durable progress state before broad operator rollout.
+
+## Verification
+
+- Focused tests prove that multiple accepted items are queued and only the configured number run concurrently.
+- Tests prove that separate trigger requests and mixed transcript/scene-analysis requests share the same queue cap.
+- Tests prove queue-full backpressure returns a retryable 503 without accepting more work.
+- Tests prove the in-flight slot is retained while a queued/running job is outstanding and released after completion or failure.
+- Tests prove queued/running jobs are not pruned by stale wall-clock TTL while dispatch is unresolved.
+- Tests prove scheduled `after()` work remains pending until the accepted queued jobs settle.
+- Tests prove synchronous validation failures still return without queueing work.
+- Run:
+
+```
+pnpm --filter @forge/manager test -- src/lib/admin-trigger-route.test.ts src/app/api/admin-trigger/transcript/route.test.ts src/app/api/admin-trigger/scene-analysis/route.test.ts
+pnpm --filter @forge/manager typecheck
+```

--- a/docs/roadmap/content-discovery/feat-127-manager-durable-admin-trigger-job-state.md
+++ b/docs/roadmap/content-discovery/feat-127-manager-durable-admin-trigger-job-state.md
@@ -1,0 +1,86 @@
+---
+id: "feat-127"
+title: "Manager durable admin-trigger job state for operator enrichment"
+owner: "nisal"
+priority: "P0"
+status: "not-started"
+start_date: "2026-05-19"
+duration: 2
+depends_on:
+  - "feat-126"
+blocks:
+  - "feat-125"
+tags:
+  - "manager"
+  - "admin"
+  - "ai-pipeline"
+  - "operator-tools"
+  - "reliability"
+---
+
+## Problem
+
+`feat-126` protects manager from stampeding Mux by moving admin-triggered transcript and scene-analysis dispatch into a bounded process-local queue. That fixes provider pressure for the immediate production backfill, but accepted work is still not durable: `started` means the current manager process accepted a job, not that a restart, deploy, or horizontal instance boundary can recover or report that job.
+
+`feat-125` should not expose a broad operator UI that treats `started` as completed progress while manager has no durable accepted-job state. Until durable state exists, artifact presence in manager S3 remains the only reliable completion signal.
+
+## Entry Points — Read These First
+
+1. `apps/manager/src/lib/admin-trigger-route.ts` — current process-local queue, idempotency map, and response contract for `/api/admin-trigger/{scene-analysis,transcript}`.
+2. `apps/manager/src/app/api/admin-trigger/transcript/route.ts` — transcript admin-trigger dispatcher.
+3. `apps/manager/src/app/api/admin-trigger/scene-analysis/route.ts` — scene-analysis admin-trigger dispatcher.
+4. `apps/manager/src/workflows/transcriptOnlyPipeline.ts` — transcript artifact producer.
+5. `apps/manager/src/workflows/sceneAnalysisPipeline.ts` — scene-analysis artifact producer.
+6. `apps/admin/src/services/manager-trigger.service.ts` — admin's outbound manager trigger client and outcome classifier.
+7. `apps/admin/src/scripts/trigger-enrichment.ts` — current report-based trigger CLI that must remain compatible.
+8. `docs/roadmap/content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md` — operator surface blocked on this durable state decision.
+
+## Grep These
+
+```
+grep -rn "admin-trigger" apps/manager/src apps/admin/src
+grep -rn "managerJobId\\|already_in_flight\\|STARTED" apps/manager/src apps/admin/src
+grep -rn "scene-analysis.json\\|embeddings.json" apps/manager/src apps/admin/src
+grep -rn "EnrichmentJob\\|job state\\|inFlight" apps/manager/src apps/cms/src apps/admin/src
+```
+
+## What To Build
+
+Add durable manager-side accepted-job state for admin-triggered enrichment work.
+
+1. Persist a job record when manager accepts admin-trigger work:
+   - trigger kind: `scene-analysis` or `transcript`
+   - `assetId`, `coreId`, and `managerJobId`
+   - status at least: accepted/queued, running, completed, failed
+   - timestamps for accepted, started, finished
+   - retryable failure message or code when available
+2. Keep the current `/api/admin-trigger/*` request/response contract backward-compatible for admin callers.
+3. Preserve idempotency across process restarts and deploys by consulting durable state before accepting duplicate active `{kind, assetId}` work.
+4. Decide and document the storage boundary:
+   - prefer a manager-owned durable store if one exists
+   - do not reintroduce CMS coupling for this admin-trigger path
+   - if no manager-owned store exists, create the smallest manager-owned persistence path that fits current deploy constraints
+5. Expose enough read state for `feat-125` to show operator progress without pretending `started` means complete.
+6. Keep artifact existence as the final verification source of truth; durable job state is an operational progress layer, not a replacement for S3 artifact checks.
+
+## Constraints
+
+- Do not depend on CMS `EnrichmentJob` rows for this admin-trigger path.
+- Do not break existing admin trigger scripts or mutation response parsing.
+- Do not log subtitle URLs, API keys, bearer tokens, workflow keys, database URLs, or third-party credentials.
+- Do not remove the process-local queue from `feat-126`; durable state complements the queue and restart semantics.
+- Do not broaden into unrelated manager pipeline refactors.
+
+## Verification
+
+- Tests prove duplicate active jobs are rejected or reported as in-flight across a simulated process-local queue reset.
+- Tests prove job state transitions through accepted/queued, running, completed, and failed.
+- Tests prove existing `/api/admin-trigger/*` response shape remains compatible.
+- Tests prove admin can read enough state for `feat-125` operator progress without relying on CMS.
+- Run:
+
+```
+pnpm --filter @forge/manager test -- src/lib/admin-trigger-route.test.ts
+pnpm --filter @forge/manager typecheck
+pnpm --filter @forge/admin typecheck
+```

--- a/docs/solutions/best-practices/in-memory-slot-reservation-fire-and-forget-20260506.md
+++ b/docs/solutions/best-practices/in-memory-slot-reservation-fire-and-forget-20260506.md
@@ -1,6 +1,7 @@
 ---
 title: In-memory slot reservation for fire-and-forget background dispatch — wrap the entire callback in try/finally
 date: 2026-05-06
+last_updated: 2026-05-19
 category: best-practices
 problem_type: best_practice
 component: nextjs-after-background-dispatch
@@ -143,6 +144,29 @@ The in-memory variant trades durability for simplicity. Both
 patterns share the same release-on-settle invariant; only the
 storage and recovery mechanism differ.
 
+**Queue-backed variant:** when the "fire-and-forget" work becomes a
+process-local queue, do not let the old short TTL govern queued or
+running slots. A queued job can sit behind other work, and a running
+Mux-heavy transcript job can outlive a 5-minute prune window. In that
+shape, use a non-expiring active marker while the queue owns the job,
+release it only in the queue runner's `finally`, and test that a stale
+clock still returns `already_in_flight` while dispatch is unresolved.
+
+Also keep the `after()` lifecycle attached to the accepted work. If
+the request's `after()` callback only enqueues jobs and returns, later
+queue drain promises become detached process work. Have the scheduled
+callback await the queued jobs accepted by that request through
+settlement, or document an explicit worker lifecycle that survives
+request cleanup.
+
+Finally, add backpressure before accepting new dispatchable jobs. A
+concurrency cap protects the provider, but an unbounded queue shifts
+the problem into manager memory. The queue-full path should reject
+new work with a retryable response before reserving in-flight slots;
+classification-only rows (`not_found`, `validation_failed`, and
+`already_in_flight`) should still be returned normally because they
+do not spend queue capacity.
+
 **Cross-link to the dispatch-error-log path:** schedule wrappers
 typically wrap the cb in `try/catch { console.error(...) }` so a
 thrown dispatch doesn't crash Next. That wrapper is for
@@ -177,3 +201,12 @@ The trap was caught by ce:review's reliability-reviewer (rel-1, conf
 0.88) before it reached prod. The fix added the `try {` above the
 `console.log` line and added the sync-throw test "releases the slot
 when dispatch throws SYNCHRONOUSLY".
+
+2026-05-19 follow-up: PR #981 extended the same helper with a bounded
+admin-trigger dispatch queue after production transcript triggers hit
+Mux `429 Too many requests`. The durable lesson is that slot
+reservation, queue capacity, provider concurrency, and `after()`
+lifecycle are one contract: reserve only after capacity is available,
+hold the slot while queued/running, release in the runner `finally`,
+and keep the scheduled background promise attached until accepted work
+settles.

--- a/docs/solutions/platform/admin-manager-enrichment-trigger-endpoint-20260506.md
+++ b/docs/solutions/platform/admin-manager-enrichment-trigger-endpoint-20260506.md
@@ -1,6 +1,7 @@
 ---
 title: Admin → Manager enrichment-trigger endpoint
 date: 2026-05-06
+last_updated: 2026-05-19
 tags:
   - admin
   - manager
@@ -66,8 +67,9 @@ DISPATCH_FAILED`. NEVER throws; on transport / auth / config
 /api/admin-trigger/{scene-analysis,transcript}`. Body:
    `{ items: [{ assetId: number, coreId: string }, ...] }`. Auth:
    bearer in the `ADMIN_TRIGGER_API_KEYS` CSV allowlist. Per-item
-   flow: CMS lookup by coreId via Strapi GraphQL → idempotency check
-   → background dispatch via `after()` → return per-item outcome.
+   flow: admin lookup by `coreId` → validation/idempotency check
+   → accepted jobs enter a bounded process-local dispatch queue via
+   `after()` → return per-item outcome.
 
 Plus an admin CLI (`pnpm --filter @forge/admin trigger-enrichment`)
 that consumes PR1's `--report-out` JSON via `--from-report=<path>`
@@ -107,12 +109,42 @@ side reconnaissance found three blockers:
    produces two pipeline runs that both write the same S3 key —
    wasteful but not corrupting (S3 PUT is overwrite).
 
-Decision: a process-local `Map<string /* `${kind}:${assetId}` */,
+Original PR2 decision: a process-local `Map<string /* `${kind}:${assetId}` */,
 { managerJobId, expiresAt }>` with a 5-minute TTL inside
 `apps/manager/src/lib/admin-trigger-route.ts`. Pruned lazily on each
-request. Slot is released as soon as the per-id dispatch resolves
+request. Slot released as soon as the per-id dispatch resolved
 (success or failure) so a follow-up trigger after pipeline
-completion doesn't have to wait out the TTL.
+completion did not have to wait out the TTL.
+
+**2026-05-19 hardening:** production transcript triggers showed that
+the original immediate dispatch shape could stampede Mux. Admin
+accepted 288 transcript items as `STARTED`, but manager only produced
+a subset of transcript/embedding artifacts before Railway logs showed
+repeated Mux `429 Too many requests` errors. PR #981 changed the
+receiver from "one `after()` dispatch per accepted item" to a bounded
+process-local queue shared by transcript and scene-analysis triggers:
+
+- accepted jobs log `admin-trigger.dispatch.accepted`, then enter
+  `dispatchQueue`
+- at most `DEFAULT_DISPATCH_CONCURRENCY` jobs run per manager process
+- total active + queued work is capped by
+  `DEFAULT_MAX_PENDING_DISPATCHES`
+- queue-full returns a retryable `503` before accepting new work
+- queued/running in-flight entries use `expiresAt: null`, so the old
+  5-minute TTL cannot prune a long Mux transcript job and admit a
+  duplicate
+- the request's scheduled `after()` work awaits the queued jobs it
+  accepted through settlement instead of enqueueing detached promises
+
+Capacity checks happen **after** lookup, validation, and idempotency
+classification. A full queue must not turn `VALIDATION_FAILED`,
+`NOT_FOUND`, or `ALREADY_IN_FLIGHT` rows into a whole-request 503;
+only genuinely new dispatchable jobs spend queue capacity.
+
+This remains process-local. `started` means "accepted by this manager
+process", not durable acceptance. Until durable manager-owned job
+state exists (roadmap `feat-127`), the only reliable completion signal
+for operators is artifact presence in manager S3.
 
 If concurrency-correctness becomes load-bearing in production,
 swap to a DB-backed mechanism via a follow-up ticket. The shape


### PR DESCRIPTION
## Summary
- replace immediate per-item admin-trigger dispatch fan-out with a bounded process-local queue shared across transcript and scene-analysis triggers
- add queue-full backpressure, lifecycle-safe `after()` draining, and non-expiring in-flight markers for queued/running work
- add roadmap tickets for the queue fix and the durable manager job-state follow-up, with reciprocal dependency links

## Validation
- pnpm --filter @forge/manager test -- src/lib/admin-trigger-route.test.ts src/app/api/admin-trigger/transcript/route.test.ts src/app/api/admin-trigger/scene-analysis/route.test.ts
- pnpm --filter @forge/manager typecheck
- pnpm --filter @forge/manager lint
- pnpm exec prettier --check apps/manager/src/lib/admin-trigger-route.ts apps/manager/src/lib/admin-trigger-route.test.ts docs/roadmap/content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md docs/roadmap/content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md docs/roadmap/content-discovery/feat-126-manager-admin-trigger-dispatch-queue.md docs/roadmap/content-discovery/feat-127-manager-durable-admin-trigger-job-state.md docs/roadmap/README.md

## Notes
- `started` remains accepted-by-current-process semantics for this slice; feat-127 tracks durable manager job state before broad operator UI rollout.
