### PR TITLE
fix(admin): speed up manager video lookups

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -762,9 +762,11 @@ scale.
   surfaces the artifact-fetch fan-in for any trigger path).
 - **Trigger:** `triggerSceneEmbeddingBackfill` GraphQL mutation
   (ADMIN-only; permission key `write:scene-embeddings`). Stage 2's
-  reshape is internal — the GraphQL JSON response shape is byte-
-  identical to Stage 1 (modulo `outcomes[]` ordering, already
-  documented as non-deterministic per `Promise.allSettled`).
+  reshape is internal to execution, but the JSON report shape is
+  additive over Stage 1 (`missingArtifacts`, `retrySelection`,
+  `groupedFailures`, and failed-outcome `failureCategory` may appear).
+  `outcomes[]` ordering remains documented as non-deterministic per
+  `Promise.allSettled`.
 - **NoSuchKey classification + missingArtifacts list (feat-119 PR1):**
   AWS S3 `NoSuchKey` errors classify as `skipped { reason: "artifact_missing" }`
   via the typed-error helper `isArtifactMissing` in
@@ -779,6 +781,17 @@ scale.
   Only `skipped { artifact_missing }` outcomes feed the list — `failed`
   outcomes are real failures, not upstream gaps. See
   `docs/solutions/runtime-errors/aws-s3-nosuchkey-classification-pattern-20260506.md`.
+- **Scene retry recovery from prior reports:** for `pnpm run-embeds`,
+  `--pipeline=scene --from-report=<path>` extracts failed
+  `reports.scene.outcomes[]` from a prior `run-embeds.complete` report,
+  dedupes exact `(coreId, videoEditionId, locale)` selectors, and retries
+  only those targets. The workflow reconciles selectors against current
+  enumeration and fails closed when selectors are stale. The final report
+  includes `retrySelection` counts plus `groupedFailures`, which
+  collapses noisy per-locale failures by asset, edition, and category
+  (`dns_failed`, `timeout`, `prisma_transaction`, `provider_validation`,
+  etc.). Use this for transient infrastructure/provider recovery rather
+  than blindly rerunning the full catalog.
 - **Bulk SQL writes (Stage 3 — feat-117):** the per-target write batch
   collapses from a per-row `videoSceneLocale.upsert()` + per-row
   `$executeRaw … UPDATE … embedding` loop into THREE bulk statements
@@ -1628,6 +1641,31 @@ path and the Cloudflare 524 edge timeout. Per
    singleton, mirroring `pnpm run-sync`. Per-pipeline error
    isolation; structured JSON output. R2 is free (vector reuse from
    manager's `embeddings.json`); R1 hits OpenRouter.
+
+   Scene-including runs perform a preflight before indexing: admin S3
+   reachability, manager artifact S3 reachability, mapping load, and
+   (when `--from-report` provides a sample asset) one sample
+   scene-analysis artifact read. Infrastructure failures such as DNS,
+   timeout, bucket/auth errors, or mapping read failures fail before
+   target enumeration; a sample `artifact_missing` is only a warning
+   because missing artifacts are an enrichment gap, not storage outage.
+
+4. **Retry only failed scene outcomes from a prior report:**
+
+   ```bash
+   DATABASE_URL='postgresql://forge:forge@db:5432/forge_admin' \
+   pnpm --filter @forge/admin run-embeds \
+     --pipeline=scene \
+     --from-report=.tmp/prod-embeds/prod-scene-report.json \
+     --report-out=.tmp/prod-embeds/prod-scene-retry-$(date +%Y%m%d%H%M%S).json
+   ```
+
+   `--from-report` is scene-only and mutually exclusive with broad
+   `--core-id`, `--locale`, and `--language` filters. It retries exact
+   failed `(coreId, videoEditionId, locale)` targets from the report
+   after preflight, preserving the one-artifact-read-per-edition group
+   behavior. If `retrySelection.unmatched > 0`, treat the report as
+   stale and inspect the unmatched selectors before proceeding.
 
 **Local DB is the destination.** `DATABASE_URL` is the only safety
 guard — there is no in-script check that detects a prod URL. Mirrors

--- a/apps/admin/src/graphql/mutations/scene-embedding.test.ts
+++ b/apps/admin/src/graphql/mutations/scene-embedding.test.ts
@@ -31,6 +31,8 @@ const BASE_REPORT: SceneEmbeddingBackfillReport = {
   skipped: 0,
   failed: 0,
   missingArtifacts: [],
+  retrySelection: null,
+  groupedFailures: [],
 }
 
 describe("dispatchSceneEmbeddingBackfill", () => {

--- a/apps/admin/src/scripts/run-embeds.test.ts
+++ b/apps/admin/src/scripts/run-embeds.test.ts
@@ -1,8 +1,17 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { resolveReportOutPath, writeReportToPath } from "./run-embeds"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  RunEmbedsConfigError,
+  extractFailedSceneRetryTargetsFromReport,
+  pipelineErrorDetails,
+  pipelineErrorMessage,
+  resolveReportInPath,
+  resolveReportOutPath,
+  runSceneBranch,
+  writeReportToPath,
+} from "./run-embeds"
 
 // feat-119 PR1 — `--report-out=<path>` flag tests. The path-resolve
 // helper is pure; the file-write helper is async + I/O-bound, so use a
@@ -36,6 +45,279 @@ describe("resolveReportOutPath", () => {
     expect(result).toBe(resolve(process.cwd(), rel))
     // Sanity: no double-slash, no preserved `..` segment.
     expect(result?.includes("..")).toBe(false)
+  })
+})
+
+describe("resolveReportInPath", () => {
+  it("returns undefined when unset or empty", () => {
+    expect(resolveReportInPath(undefined)).toBeUndefined()
+    expect(resolveReportInPath("")).toBeUndefined()
+  })
+
+  it("anchors relative paths to process.cwd()", () => {
+    expect(resolveReportInPath(".tmp/report.json")).toBe(
+      resolve(process.cwd(), ".tmp/report.json"),
+    )
+  })
+})
+
+describe("extractFailedSceneRetryTargetsFromReport", () => {
+  it("extracts and dedupes failed scene outcomes in deterministic order", () => {
+    const report = {
+      reports: {
+        scene: {
+          outcomes: [
+            {
+              status: "failed",
+              locale: "es",
+              target: {
+                coreId: "core-b",
+                videoEditionId: "edition-b",
+                cmsVideoId: 2,
+              },
+            },
+            {
+              status: "failed",
+              locale: "en",
+              target: {
+                coreId: "core-a",
+                videoEditionId: "edition-a",
+                cmsVideoId: 1,
+              },
+            },
+            {
+              status: "failed",
+              locale: "en",
+              target: {
+                coreId: "core-a",
+                videoEditionId: "edition-a",
+                cmsVideoId: 1,
+              },
+            },
+            {
+              status: "skipped",
+              locale: "fr",
+              target: {
+                coreId: "core-c",
+                videoEditionId: "edition-c",
+                cmsVideoId: 3,
+              },
+            },
+          ],
+        },
+      },
+    }
+
+    expect(extractFailedSceneRetryTargetsFromReport(report)).toEqual([
+      {
+        coreId: "core-a",
+        videoEditionId: "edition-a",
+        locale: "en",
+        cmsVideoId: 1,
+      },
+      {
+        coreId: "core-b",
+        videoEditionId: "edition-b",
+        locale: "es",
+        cmsVideoId: 2,
+      },
+    ])
+  })
+
+  it("throws a config error when the report is missing scene outcomes", () => {
+    expect(() =>
+      extractFailedSceneRetryTargetsFromReport({ reports: { scene: {} } }),
+    ).toThrow(RunEmbedsConfigError)
+  })
+
+  it("throws a config error instead of skipping malformed failed scene outcomes", () => {
+    expect(() =>
+      extractFailedSceneRetryTargetsFromReport({
+        reports: {
+          scene: {
+            outcomes: [
+              {
+                status: "failed",
+                locale: "en",
+                target: {
+                  coreId: "core-a",
+                  cmsVideoId: 1,
+                },
+              },
+            ],
+          },
+        },
+      }),
+    ).toThrow(/reports\.scene\.outcomes\[0\].*videoEditionId/)
+  })
+
+  it("returns an empty retry set when there are no failed outcomes", () => {
+    expect(
+      extractFailedSceneRetryTargetsFromReport({
+        reports: { scene: { outcomes: [{ status: "succeeded" }] } },
+      }),
+    ).toEqual([])
+  })
+})
+
+describe("pipelineErrorDetails", () => {
+  it("preserves scene retry selection details from stale retry errors", () => {
+    const retrySelection = {
+      requested: 2,
+      matched: 1,
+      unmatched: 1,
+      unmatchedRetryTargets: [
+        { coreId: "core-a", videoEditionId: "stale-edition", locale: "en" },
+      ],
+    }
+    const error = Object.assign(new Error("Scene retry selector mismatch"), {
+      retrySelection,
+    })
+
+    expect(pipelineErrorMessage(error)).toBe("Scene retry selector mismatch")
+    expect(pipelineErrorDetails(error)).toEqual({ retrySelection })
+  })
+
+  it("ignores malformed retry selection details", () => {
+    expect(
+      pipelineErrorDetails({
+        retrySelection: {
+          requested: 1,
+          matched: 0,
+          unmatched: 1,
+          unmatchedRetryTargets: [{ coreId: "core-a" }],
+        },
+      }),
+    ).toBeUndefined()
+  })
+})
+
+describe("runSceneBranch", () => {
+  it("runs preflight with the retry sample asset before invoking the scene workflow", async () => {
+    const writes: string[] = []
+    const preflight = vi.fn(async () => ({
+      ok: true,
+      checks: [
+        { name: "manager_artifact_storage", status: "passed", reason: "ok" },
+      ],
+    }))
+    const runScene = vi.fn(async () => ({
+      totalTargets: 1,
+      succeeded: 1,
+      skipped: 0,
+      failed: 0,
+      retrySelection: null,
+      groupedFailures: [],
+    }))
+
+    const result = await runSceneBranch({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      coreIds: [],
+      locales: [],
+      sceneRetryTargets: [
+        {
+          coreId: "core-a",
+          videoEditionId: "edition-a",
+          locale: "en",
+          cmsVideoId: 123,
+        },
+      ],
+      runManagerArtifactsPreflight: preflight,
+      runSceneEmbeddingBackfill: runScene,
+      writeStdout: (line) => writes.push(line),
+    })
+
+    expect(result.ok).toBe(true)
+    expect(preflight).toHaveBeenCalledWith({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      sampleSceneAssetId: 123,
+    })
+    expect(runScene).toHaveBeenCalledWith({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      coreIds: undefined,
+      locales: undefined,
+      retryTargets: [
+        {
+          coreId: "core-a",
+          videoEditionId: "edition-a",
+          locale: "en",
+          cmsVideoId: 123,
+        },
+      ],
+    })
+    expect(writes.map((line) => JSON.parse(line).event)).toEqual([
+      "run-embeds.scene.preflight",
+      "run-embeds.scene.start",
+      "run-embeds.scene.complete",
+    ])
+  })
+
+  it("does not invoke the scene workflow when preflight fails", async () => {
+    const writes: string[] = []
+    const runScene = vi.fn()
+
+    const result = await runSceneBranch({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      coreIds: ["core-a"],
+      locales: ["en"],
+      sceneRetryTargets: undefined,
+      runManagerArtifactsPreflight: vi.fn(async () => ({
+        ok: false,
+        checks: [
+          {
+            name: "manager_artifact_storage",
+            status: "failed",
+            reason: "dns_failed",
+          },
+        ],
+      })),
+      runSceneEmbeddingBackfill: runScene,
+      writeStdout: (line) => writes.push(line),
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: "scene preflight failed: manager_artifact_storage:dns_failed",
+    })
+    expect(runScene).not.toHaveBeenCalled()
+    expect(writes.map((line) => JSON.parse(line).event)).toEqual([
+      "run-embeds.scene.preflight",
+      "run-embeds.scene.error",
+    ])
+  })
+
+  it("preserves stale retry selection details from workflow errors", async () => {
+    const retrySelection = {
+      requested: 1,
+      matched: 0,
+      unmatched: 1,
+      unmatchedRetryTargets: [
+        { coreId: "core-a", videoEditionId: "stale-edition", locale: "en" },
+      ],
+    }
+
+    const result = await runSceneBranch({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      coreIds: [],
+      locales: [],
+      sceneRetryTargets: undefined,
+      runManagerArtifactsPreflight: vi.fn(async () => ({
+        ok: true,
+        checks: [],
+      })),
+      runSceneEmbeddingBackfill: vi.fn(async () => {
+        throw Object.assign(new Error("Scene retry selector mismatch"), {
+          retrySelection,
+        })
+      }),
+      writeStdout: () => undefined,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Scene retry selector mismatch",
+      details: { retrySelection },
+    })
   })
 })
 

--- a/apps/admin/src/scripts/run-embeds.ts
+++ b/apps/admin/src/scripts/run-embeds.ts
@@ -33,6 +33,7 @@
  *   --force                                             # experience pipeline only — re-embed
  *                                                       # rows that already have a non-NULL embedding
  *   --report-out=<path>                                 # optional; dump final report JSON
+ *   --from-report=<path>                                # scene retry only; retry failed targets
  *
  * The mapping snapshot must already exist at the configured S3 key
  * (or the local-fallback path when RAILWAY_S3_BUCKET is unset).
@@ -49,6 +50,7 @@
  *
  *   stdout:
  *     - `run-embeds.start` — one line at startup with resolved config
+ *     - `run-embeds.scene.preflight`       (pipeline=scene|both)
  *     - `run-embeds.scene.start`           (pipeline=scene|both)
  *     - `run-embeds.scene.complete`        (pipeline=scene|both)
  *     - `run-embeds.scene.error`           (pipeline=scene|both, on error)
@@ -73,7 +75,7 @@
  * check beyond the explicit env var (mirrors run-sync.ts).
  */
 
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, resolve } from "node:path"
 import { DEFAULT_CORE_ID_MAPPING_S3_KEY } from "@/services/core-id-mapping.constants"
 
@@ -116,6 +118,269 @@ export async function writeReportToPath(
       ok: false,
       error: err instanceof Error ? err.message : String(err),
     }
+  }
+}
+
+export type SceneRetryTargetFromReport = {
+  coreId: string
+  videoEditionId: string
+  locale: string
+  cmsVideoId: number
+}
+
+export type SceneRetrySelectionDetails = {
+  requested: number
+  matched: number
+  unmatched: number
+  unmatchedRetryTargets: ReadonlyArray<{
+    coreId: string
+    videoEditionId: string
+    locale: string
+  }>
+}
+
+export type PipelineErrorDetails = {
+  retrySelection?: SceneRetrySelectionDetails
+}
+
+export class RunEmbedsConfigError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: 2 = 2,
+  ) {
+    super(message)
+    this.name = "RunEmbedsConfigError"
+  }
+}
+
+export function resolveReportInPath(
+  arg: string | undefined,
+): string | undefined {
+  if (arg === undefined || arg === "") return undefined
+  return isAbsolute(arg) ? arg : resolve(process.cwd(), arg)
+}
+
+export function extractFailedSceneRetryTargetsFromReport(
+  report: unknown,
+): SceneRetryTargetFromReport[] {
+  if (!report || typeof report !== "object") {
+    throw new RunEmbedsConfigError(
+      "[run-embeds] --from-report is not an object",
+    )
+  }
+  const reports = (report as Record<string, unknown>).reports
+  if (!reports || typeof reports !== "object") {
+    throw new RunEmbedsConfigError(
+      "[run-embeds] --from-report missing reports object",
+    )
+  }
+  const scene = (reports as Record<string, unknown>).scene
+  if (!scene || typeof scene !== "object") {
+    throw new RunEmbedsConfigError(
+      "[run-embeds] --from-report missing reports.scene",
+    )
+  }
+  const outcomes = (scene as Record<string, unknown>).outcomes
+  if (!Array.isArray(outcomes)) {
+    throw new RunEmbedsConfigError(
+      "[run-embeds] --from-report missing reports.scene.outcomes",
+    )
+  }
+
+  const byKey = new Map<string, SceneRetryTargetFromReport>()
+  outcomes.forEach((outcome, index) => {
+    if (!outcome || typeof outcome !== "object") return
+    const o = outcome as Record<string, unknown>
+    if (o.status !== "failed") return
+    const target = o.target
+    if (!target || typeof target !== "object") {
+      throw new RunEmbedsConfigError(
+        `[run-embeds] failed scene outcome at reports.scene.outcomes[${index}] is missing target`,
+      )
+    }
+    const t = target as Record<string, unknown>
+    const coreId = typeof t.coreId === "string" ? t.coreId : undefined
+    const videoEditionId =
+      typeof t.videoEditionId === "string" ? t.videoEditionId : undefined
+    const locale = typeof o.locale === "string" ? o.locale : undefined
+    const cmsVideoId =
+      typeof t.cmsVideoId === "number" ? t.cmsVideoId : undefined
+    if (!coreId || !videoEditionId || !locale || cmsVideoId === undefined) {
+      throw new RunEmbedsConfigError(
+        `[run-embeds] failed scene outcome at reports.scene.outcomes[${index}] is missing target.coreId, target.videoEditionId, locale, or numeric target.cmsVideoId`,
+      )
+    }
+    const key = `${coreId}::${videoEditionId}::${locale}`
+    if (!byKey.has(key)) {
+      byKey.set(key, { coreId, videoEditionId, locale, cmsVideoId })
+    }
+  })
+  return [...byKey.values()].sort((a, b) => {
+    const ak = `${a.coreId}::${a.videoEditionId}::${a.locale}`
+    const bk = `${b.coreId}::${b.videoEditionId}::${b.locale}`
+    return ak.localeCompare(bk)
+  })
+}
+
+export function pipelineErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function pipelineErrorDetails(
+  error: unknown,
+): PipelineErrorDetails | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const retrySelection = (error as Record<string, unknown>).retrySelection
+  if (!isSceneRetrySelectionDetails(retrySelection)) return undefined
+  return { retrySelection }
+}
+
+function isSceneRetrySelectionDetails(
+  value: unknown,
+): value is SceneRetrySelectionDetails {
+  if (!value || typeof value !== "object") return false
+  const record = value as Record<string, unknown>
+  return (
+    typeof record.requested === "number" &&
+    typeof record.matched === "number" &&
+    typeof record.unmatched === "number" &&
+    Array.isArray(record.unmatchedRetryTargets) &&
+    record.unmatchedRetryTargets.every(isSceneRetryTargetSummary)
+  )
+}
+
+function isSceneRetryTargetSummary(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false
+  const record = value as Record<string, unknown>
+  return (
+    typeof record.coreId === "string" &&
+    typeof record.videoEditionId === "string" &&
+    typeof record.locale === "string"
+  )
+}
+
+export async function loadSceneRetryTargetsFromReport(
+  reportPath: string,
+): Promise<SceneRetryTargetFromReport[]> {
+  let raw: string
+  try {
+    raw = await readFile(reportPath, "utf8")
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new RunEmbedsConfigError(
+      `[run-embeds] failed to read --from-report=${reportPath}: ${message}`,
+    )
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw) as unknown
+  } catch {
+    throw new RunEmbedsConfigError(
+      `[run-embeds] --from-report=${reportPath} is not valid JSON`,
+    )
+  }
+  const retryTargets = extractFailedSceneRetryTargetsFromReport(parsed)
+  if (retryTargets.length === 0) {
+    throw new RunEmbedsConfigError(
+      `[run-embeds] no failed scene outcomes found in ${reportPath}`,
+    )
+  }
+  return retryTargets
+}
+
+export type SceneBranchPreflightReport = {
+  ok: boolean
+  checks: ReadonlyArray<{
+    name: string
+    status: string
+    reason: string
+  }>
+}
+
+export type SceneBranchReport = {
+  totalTargets: number
+  succeeded: number
+  skipped: number
+  failed: number
+}
+
+export type SceneBranchResult =
+  | { ok: true; report: SceneBranchReport }
+  | { ok: false; error: string; details?: PipelineErrorDetails }
+
+export async function runSceneBranch(args: {
+  mappingS3Key: string
+  coreIds: readonly string[]
+  locales: readonly string[]
+  sceneRetryTargets: readonly SceneRetryTargetFromReport[] | undefined
+  runManagerArtifactsPreflight: (input: {
+    mappingS3Key: string
+    sampleSceneAssetId?: number
+  }) => Promise<SceneBranchPreflightReport>
+  runSceneEmbeddingBackfill: (input: {
+    mappingS3Key: string
+    coreIds?: readonly string[]
+    locales?: readonly string[]
+    retryTargets?: readonly SceneRetryTargetFromReport[]
+  }) => Promise<SceneBranchReport>
+  writeStdout?: (line: string) => void
+}): Promise<SceneBranchResult> {
+  const writeStdout = args.writeStdout ?? ((line) => process.stdout.write(line))
+
+  try {
+    const preflight = await args.runManagerArtifactsPreflight({
+      mappingS3Key: args.mappingS3Key,
+      sampleSceneAssetId: args.sceneRetryTargets?.[0]?.cmsVideoId,
+    })
+    writeStdout(
+      JSON.stringify({
+        event: "run-embeds.scene.preflight",
+        ok: preflight.ok,
+        checks: preflight.checks,
+      }) + "\n",
+    )
+    if (!preflight.ok) {
+      throw new Error(
+        `scene preflight failed: ${preflight.checks
+          .filter((check) => check.status === "failed")
+          .map((check) => `${check.name}:${check.reason}`)
+          .join(", ")}`,
+      )
+    }
+    writeStdout(
+      JSON.stringify({
+        event: "run-embeds.scene.start",
+        mappingS3Key: args.mappingS3Key,
+        retryTargets: args.sceneRetryTargets?.length ?? null,
+      }) + "\n",
+    )
+    const report = await args.runSceneEmbeddingBackfill({
+      mappingS3Key: args.mappingS3Key,
+      coreIds: args.coreIds.length > 0 ? args.coreIds : undefined,
+      locales: args.locales.length > 0 ? args.locales : undefined,
+      retryTargets: args.sceneRetryTargets,
+    })
+    writeStdout(
+      JSON.stringify({
+        event: "run-embeds.scene.complete",
+        totalTargets: report.totalTargets,
+        succeeded: report.succeeded,
+        skipped: report.skipped,
+        failed: report.failed,
+      }) + "\n",
+    )
+    return { ok: true, report }
+  } catch (err) {
+    const error = pipelineErrorMessage(err)
+    const details = pipelineErrorDetails(err)
+    writeStdout(
+      JSON.stringify({
+        event: "run-embeds.scene.error",
+        error,
+        details,
+      }) + "\n",
+    )
+    return details ? { ok: false, error, details } : { ok: false, error }
   }
 }
 
@@ -177,6 +442,36 @@ async function main(): Promise<void> {
   // `pnpm trigger-enrichment --from-report=<path>` need a stable
   // file format. When unset, behavior is unchanged (stdout only).
   const reportOutPath = resolveReportOutPath(parseSingle("report-out"))
+  const reportInPath = resolveReportInPath(parseSingle("from-report"))
+
+  if (reportInPath !== undefined && pipelineArg !== "scene") {
+    process.stderr.write(
+      "[run-embeds] --from-report is only supported with --pipeline=scene\n",
+    )
+    process.exit(2)
+  }
+  if (
+    reportInPath !== undefined &&
+    (coreIds.length > 0 || locales.length > 0 || languages.length > 0)
+  ) {
+    process.stderr.write(
+      "[run-embeds] --from-report is mutually exclusive with --core-id/--locale/--language filters\n",
+    )
+    process.exit(2)
+  }
+
+  let sceneRetryTargets: SceneRetryTargetFromReport[] | undefined
+  if (reportInPath !== undefined) {
+    try {
+      sceneRetryTargets = await loadSceneRetryTargetsFromReport(reportInPath)
+    } catch (err) {
+      if (err instanceof RunEmbedsConfigError) {
+        process.stderr.write(err.message + "\n")
+        process.exit(err.exitCode)
+      }
+      throw err
+    }
+  }
 
   // Lazy-import the workflow modules AFTER the DATABASE_URL guard
   // above so a missing var produces our friendly stderr line instead
@@ -195,6 +490,8 @@ async function main(): Promise<void> {
     await import("@/workflows/experienceEmbeddingBackfill")
   const { prisma } = await import("@/db/client")
   const { env } = await import("@/config/env")
+  const { runManagerArtifactsPreflight } =
+    await import("@/services/manager-artifacts-preflight.service")
 
   const sceneConcurrency =
     env.SCENE_EMBEDDING_CONCURRENCY ?? DEFAULT_SCENE_EMBEDDING_CONCURRENCY
@@ -218,6 +515,8 @@ async function main(): Promise<void> {
       transcriptConcurrency,
       managerArtifactsBucket:
         process.env.MANAGER_ARTIFACTS_S3_BUCKET ?? "(unset)",
+      fromReport: reportInPath ?? null,
+      sceneRetryTargets: sceneRetryTargets?.length ?? null,
     }) + "\n",
   )
 
@@ -244,39 +543,25 @@ async function main(): Promise<void> {
 
   const reports: Record<string, unknown> = {}
   const errors: Record<string, string> = {}
+  const errorDetails: Record<string, PipelineErrorDetails> = {}
 
   try {
     if (pipelineArg === "scene" || pipelineArg === "both") {
-      try {
-        process.stdout.write(
-          JSON.stringify({
-            event: "run-embeds.scene.start",
-            mappingS3Key,
-          }) + "\n",
-        )
-        const sceneReport = await runSceneEmbeddingBackfill({
-          mappingS3Key,
-          coreIds: coreIds.length > 0 ? coreIds : undefined,
-          locales: locales.length > 0 ? locales : undefined,
-        })
-        reports.scene = sceneReport
-        process.stdout.write(
-          JSON.stringify({
-            event: "run-embeds.scene.complete",
-            totalTargets: sceneReport.totalTargets,
-            succeeded: sceneReport.succeeded,
-            skipped: sceneReport.skipped,
-            failed: sceneReport.failed,
-          }) + "\n",
-        )
-      } catch (err) {
-        errors.scene = err instanceof Error ? err.message : String(err)
-        process.stdout.write(
-          JSON.stringify({
-            event: "run-embeds.scene.error",
-            error: errors.scene,
-          }) + "\n",
-        )
+      const sceneResult = await runSceneBranch({
+        mappingS3Key,
+        coreIds,
+        locales,
+        sceneRetryTargets,
+        runManagerArtifactsPreflight,
+        runSceneEmbeddingBackfill,
+      })
+      if (sceneResult.ok) {
+        reports.scene = sceneResult.report
+      } else {
+        errors.scene = sceneResult.error
+        if (sceneResult.details) {
+          errorDetails.scene = sceneResult.details
+        }
       }
     }
 
@@ -369,6 +654,8 @@ async function main(): Promise<void> {
       wallClockMs: Date.now() - startedAt,
       reports,
       errors: Object.keys(errors).length > 0 ? errors : undefined,
+      errorDetails:
+        Object.keys(errorDetails).length > 0 ? errorDetails : undefined,
     }
 
     process.stdout.write(JSON.stringify(finalReport, null, 2) + "\n")

--- a/apps/admin/src/services/manager-artifacts-preflight.service.test.ts
+++ b/apps/admin/src/services/manager-artifacts-preflight.service.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { CoreIdMappingError } from "./core-id-mapping.service"
+import { ManagerArtifactError } from "./manager-artifacts.service"
+
+vi.mock("@/storage/s3", () => ({
+  assertObjectStorageReachable: vi.fn(async () => undefined),
+  assertManagerArtifactsReachable: vi.fn(async () => undefined),
+}))
+
+vi.mock("@/services/core-id-mapping.service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./core-id-mapping.service")>()
+  return {
+    ...actual,
+    loadCoreIdMapping: vi.fn(async () => ({
+      generatedAt: "2026-05-20T00:00:00.000Z",
+      byCoreId: new Map(),
+    })),
+  }
+})
+
+vi.mock("@/services/manager-artifacts.service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./manager-artifacts.service")>()
+  return {
+    ...actual,
+    readSceneAnalysisArtifact: vi.fn(async () => ({ scenes: [] })),
+  }
+})
+
+const { assertObjectStorageReachable, assertManagerArtifactsReachable } =
+  await import("@/storage/s3")
+const { loadCoreIdMapping } = await import("./core-id-mapping.service")
+const { readSceneAnalysisArtifact } =
+  await import("./manager-artifacts.service")
+const { runManagerArtifactsPreflight } =
+  await import("./manager-artifacts-preflight.service")
+
+describe("runManagerArtifactsPreflight", () => {
+  beforeEach(() => {
+    vi.mocked(assertObjectStorageReachable).mockReset()
+    vi.mocked(assertObjectStorageReachable).mockResolvedValue(undefined)
+    vi.mocked(assertManagerArtifactsReachable).mockReset()
+    vi.mocked(assertManagerArtifactsReachable).mockResolvedValue(undefined)
+    vi.mocked(loadCoreIdMapping).mockReset()
+    vi.mocked(loadCoreIdMapping).mockResolvedValue({
+      generatedAt: "2026-05-20T00:00:00.000Z",
+      byCoreId: new Map(),
+    })
+    vi.mocked(readSceneAnalysisArtifact).mockReset()
+    vi.mocked(readSceneAnalysisArtifact).mockResolvedValue({ scenes: [] })
+  })
+
+  it("passes when storage, mapping, and sample artifact are reachable", async () => {
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      sampleSceneAssetId: 123,
+    })
+
+    expect(report.ok).toBe(true)
+    expect(report.checks.map((check) => check.status)).toEqual([
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+    ])
+    expect(readSceneAnalysisArtifact).toHaveBeenCalledWith("123")
+  })
+
+  it("classifies manager artifact DNS failure as retryable dns_failed", async () => {
+    vi.mocked(assertManagerArtifactsReachable).mockRejectedValueOnce(
+      Object.assign(new Error("getaddrinfo ENOTFOUND t3.storageapi.dev"), {
+        code: "ENOTFOUND",
+      }),
+    )
+
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        name: "manager_artifact_storage",
+        status: "failed",
+        reason: "dns_failed",
+        retryable: true,
+      }),
+    )
+  })
+
+  it("classifies sample artifact read failure by underlying transport cause", async () => {
+    vi.mocked(readSceneAnalysisArtifact).mockRejectedValueOnce(
+      new ManagerArtifactError(
+        "artifact_read_failed",
+        "failed to read scene-analysis artifact for assetId=123: getaddrinfo ENOTFOUND t3.storageapi.dev",
+        Object.assign(new Error("getaddrinfo ENOTFOUND t3.storageapi.dev"), {
+          code: "ENOTFOUND",
+        }),
+      ),
+    )
+
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      sampleSceneAssetId: 123,
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        name: "sample_scene_artifact",
+        status: "failed",
+        reason: "dns_failed",
+        retryable: true,
+      }),
+    )
+  })
+
+  it("classifies Smithy timeout as retryable timeout", async () => {
+    vi.mocked(assertManagerArtifactsReachable).mockRejectedValueOnce(
+      Object.assign(new Error("request timed out"), { name: "TimeoutError" }),
+    )
+
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        name: "manager_artifact_storage",
+        status: "failed",
+        reason: "timeout",
+        retryable: true,
+      }),
+    )
+  })
+
+  it("classifies AccessDenied as non-retryable access_denied", async () => {
+    vi.mocked(assertManagerArtifactsReachable).mockRejectedValueOnce(
+      Object.assign(new Error("AccessDenied"), { name: "AccessDenied" }),
+    )
+
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        reason: "access_denied",
+        retryable: false,
+      }),
+    )
+  })
+
+  it("preserves mapping_key_rejected classification", async () => {
+    vi.mocked(loadCoreIdMapping).mockRejectedValueOnce(
+      new CoreIdMappingError("mapping_key_rejected", "bad key"),
+    )
+
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "../bad.json",
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        name: "core_id_mapping",
+        status: "failed",
+        reason: "mapping_key_rejected",
+      }),
+    )
+  })
+
+  it("treats sample artifact_missing as warning by default", async () => {
+    vi.mocked(readSceneAnalysisArtifact).mockRejectedValueOnce(
+      new ManagerArtifactError("artifact_missing", "not found"),
+    )
+
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      sampleSceneAssetId: 123,
+    })
+
+    expect(report.ok).toBe(true)
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        name: "sample_scene_artifact",
+        status: "warning",
+        reason: "artifact_missing",
+      }),
+    )
+  })
+
+  it("does not attempt a sample artifact read when no sample is provided", async () => {
+    const report = await runManagerArtifactsPreflight({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.ok).toBe(true)
+    expect(report.checks).toHaveLength(3)
+    expect(readSceneAnalysisArtifact).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/src/services/manager-artifacts-preflight.service.ts
+++ b/apps/admin/src/services/manager-artifacts-preflight.service.ts
@@ -1,0 +1,235 @@
+import { loadCoreIdMapping } from "@/services/core-id-mapping.service"
+import {
+  ManagerArtifactError,
+  readSceneAnalysisArtifact,
+} from "@/services/manager-artifacts.service"
+import {
+  assertManagerArtifactsReachable,
+  assertObjectStorageReachable,
+} from "@/storage/s3"
+
+export type PreflightCheckStatus = "passed" | "warning" | "failed"
+
+export type PreflightCheckReason =
+  | "ok"
+  | "artifact_missing"
+  | "artifact_invalid"
+  | "artifact_read_failed"
+  | "mapping_missing"
+  | "mapping_invalid"
+  | "mapping_read_failed"
+  | "mapping_key_rejected"
+  | "dns_failed"
+  | "timeout"
+  | "access_denied"
+  | "bucket_not_found"
+  | "config_missing"
+  | "unknown"
+
+export type PreflightCheck = {
+  name:
+    | "admin_object_storage"
+    | "manager_artifact_storage"
+    | "core_id_mapping"
+    | "sample_scene_artifact"
+  status: PreflightCheckStatus
+  reason: PreflightCheckReason
+  retryable: boolean
+  message: string
+}
+
+export type ManagerArtifactsPreflightReport = {
+  ok: boolean
+  checks: PreflightCheck[]
+}
+
+export type ManagerArtifactsPreflightInput = {
+  mappingS3Key: string
+  sampleSceneAssetId?: number
+  strictSampleArtifact?: boolean
+}
+
+export async function runManagerArtifactsPreflight(
+  input: ManagerArtifactsPreflightInput,
+): Promise<ManagerArtifactsPreflightReport> {
+  const checks: PreflightCheck[] = []
+
+  checks.push(
+    await runCheck("admin_object_storage", async () => {
+      await assertObjectStorageReachable()
+    }),
+  )
+
+  checks.push(
+    await runCheck("manager_artifact_storage", async () => {
+      await assertManagerArtifactsReachable()
+    }),
+  )
+
+  checks.push(
+    await runCheck("core_id_mapping", async () => {
+      await loadCoreIdMapping(input.mappingS3Key)
+    }),
+  )
+
+  if (input.sampleSceneAssetId !== undefined) {
+    checks.push(
+      await runCheck(
+        "sample_scene_artifact",
+        async () => {
+          await readSceneAnalysisArtifact(String(input.sampleSceneAssetId))
+        },
+        {
+          missingAsWarning: !input.strictSampleArtifact,
+        },
+      ),
+    )
+  }
+
+  return {
+    ok: checks.every((check) => check.status !== "failed"),
+    checks,
+  }
+}
+
+async function runCheck(
+  name: PreflightCheck["name"],
+  fn: () => Promise<void>,
+  options: { missingAsWarning?: boolean } = {},
+): Promise<PreflightCheck> {
+  try {
+    await fn()
+    return {
+      name,
+      status: "passed",
+      reason: "ok",
+      retryable: false,
+      message: `${name} ok`,
+    }
+  } catch (error) {
+    const classified = classifyPreflightError(error)
+    const status =
+      options.missingAsWarning && classified.reason === "artifact_missing"
+        ? "warning"
+        : "failed"
+    return {
+      name,
+      status,
+      ...classified,
+    }
+  }
+}
+
+function classifyPreflightError(error: unknown): {
+  reason: PreflightCheckReason
+  retryable: boolean
+  message: string
+} {
+  const message = sanitizeMessage(
+    error instanceof Error ? error.message : String(error),
+  )
+  const code = getStringProp(error, "code") ?? getStringProp(error, "Code")
+  const name = getStringProp(error, "name")
+  const lower = message.toLowerCase()
+
+  if (error instanceof ManagerArtifactError) {
+    if (error.code === "artifact_read_failed" && error.cause !== undefined) {
+      const cause = classifyPreflightError(error.cause)
+      if (isInfrastructureReason(cause.reason)) {
+        return {
+          ...cause,
+          message,
+        }
+      }
+    }
+    return {
+      reason: error.code,
+      retryable: error.code === "artifact_read_failed",
+      message,
+    }
+  }
+
+  if (
+    code === "mapping_missing" ||
+    code === "mapping_invalid" ||
+    code === "mapping_read_failed" ||
+    code === "mapping_key_rejected"
+  ) {
+    return {
+      reason: code,
+      retryable: code === "mapping_read_failed",
+      message,
+    }
+  }
+
+  if (
+    code === "ENOTFOUND" ||
+    code === "EAI_AGAIN" ||
+    lower.includes("getaddrinfo enotfound")
+  ) {
+    return { reason: "dns_failed", retryable: true, message }
+  }
+
+  if (
+    name === "TimeoutError" ||
+    name === "AbortError" ||
+    code === "ETIMEDOUT" ||
+    lower.includes("timeout") ||
+    lower.includes("timed out")
+  ) {
+    return { reason: "timeout", retryable: true, message }
+  }
+
+  if (
+    name === "AccessDenied" ||
+    code === "AccessDenied" ||
+    lower.includes("accessdenied") ||
+    lower.includes("access denied")
+  ) {
+    return { reason: "access_denied", retryable: false, message }
+  }
+
+  if (
+    name === "NoSuchBucket" ||
+    code === "NoSuchBucket" ||
+    lower.includes("nosuchbucket")
+  ) {
+    return { reason: "bucket_not_found", retryable: false, message }
+  }
+
+  if (
+    lower.includes("is required when") ||
+    lower.includes("is not set") ||
+    lower.includes("config")
+  ) {
+    return { reason: "config_missing", retryable: false, message }
+  }
+
+  return { reason: "unknown", retryable: false, message }
+}
+
+function isInfrastructureReason(reason: PreflightCheckReason): boolean {
+  return (
+    reason === "dns_failed" ||
+    reason === "timeout" ||
+    reason === "access_denied" ||
+    reason === "bucket_not_found" ||
+    reason === "config_missing"
+  )
+}
+
+function getStringProp(error: unknown, prop: string): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined
+  const value = (error as Record<string, unknown>)[prop]
+  return typeof value === "string" ? value : undefined
+}
+
+function sanitizeMessage(message: string): string {
+  return message
+    .replace(/postgres(?:ql)?:\/\/\S+/gi, "[redacted-db-url]")
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(
+      /(access[_-]?key|secret[_-]?key|api[_-]?key)=\S+/gi,
+      "$1=[redacted]",
+    )
+}

--- a/apps/admin/src/services/manager-trigger.service.ts
+++ b/apps/admin/src/services/manager-trigger.service.ts
@@ -195,10 +195,9 @@ function logResults(
 
 /**
  * Dispatch a list of (assetId, coreId) pairs to apps/manager's
- * `/api/admin-trigger/{kind}` endpoint. The manager looks up each
- * cms video via Strapi GraphQL (filtered by coreId) and dispatches
- * the matching pipeline (scene-analysis or transcript-only) in the
- * background.
+ * `/api/admin-trigger/{kind}` endpoint. The manager resolves dispatch
+ * metadata from admin by coreId and schedules the matching pipeline
+ * (scene-analysis or transcript-only) in the background.
  *
  * Returns one result per requested item — the function never
  * partial-fails. On HTTP non-2xx, network error, parse error, or

--- a/apps/admin/src/services/video.service.test.ts
+++ b/apps/admin/src/services/video.service.test.ts
@@ -12,6 +12,7 @@ function mockPrisma() {
       findMany: vi.fn(),
       findFirst: vi.fn(),
     },
+    $queryRaw: vi.fn(),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
 }
@@ -20,17 +21,9 @@ type Row = {
   id: string
   coreId: string
   label: string | null
-  primaryLanguage: { bcp47: string } | null
-  dubs: Array<{
-    language: { bcp47: string } | null
-    muxVideo: { assetId: string | null } | null
-  }>
-  subtitles: Array<{
-    language: { bcp47: string } | null
-    vttSrc: string | null
-    primary: boolean
-    aiGenerated: boolean
-  }>
+  primaryLanguageBcp47: string | null
+  muxAssetId: string | null
+  subtitleUrl: string | null
 }
 
 function rowFixture(overrides: Partial<Row> = {}): Row {
@@ -40,21 +33,9 @@ function rowFixture(overrides: Partial<Row> = {}): Row {
     // Prisma exposes the TS enum identifier (UPPER_SNAKE_CASE);
     // the service normalizes it to camelCase on the way out.
     label: "FEATURE_FILM",
-    primaryLanguage: { bcp47: "en" },
-    dubs: [
-      {
-        language: { bcp47: "en" },
-        muxVideo: { assetId: "mux-asset-en" },
-      },
-    ],
-    subtitles: [
-      {
-        language: { bcp47: "en" },
-        vttSrc: "https://example.com/en.vtt",
-        primary: true,
-        aiGenerated: false,
-      },
-    ],
+    primaryLanguageBcp47: "en",
+    muxAssetId: "mux-asset-en",
+    subtitleUrl: "https://example.com/en.vtt",
     ...overrides,
   }
 }
@@ -157,7 +138,7 @@ describe("VideoService", () => {
 
   describe("getByCoreIds (feat-125 manager admin-trigger lookup)", () => {
     it("returns dispatch fields for a fully-populated video", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([rowFixture()])
+      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const result = await service.getByCoreIds({ coreIds: ["core-1"] })
 
@@ -173,23 +154,29 @@ describe("VideoService", () => {
       ])
     })
 
-    it("filters out soft-deleted videos via where clause", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([])
+    it("uses one targeted raw SQL projection instead of loading relation graphs", async () => {
+      prisma.$queryRaw.mockResolvedValueOnce([])
 
       await service.getByCoreIds({ coreIds: ["core-1"] })
 
-      const call = prisma.video.findMany.mock.calls[0][0]
-      expect(call.where).toMatchObject({
-        coreId: { in: ["core-1"] },
-        deletedAt: null,
-      })
+      expect(prisma.video.findMany).not.toHaveBeenCalled()
+      expect(prisma.$queryRaw).toHaveBeenCalledOnce()
+      const sql = prisma.$queryRaw.mock.calls[0][0].join(" ")
+      expect(sql).toContain("LEFT JOIN LATERAL")
+      expect(sql).toContain("video_dub")
+      expect(sql).toContain("video_subtitle")
+      expect(sql).toContain("primary_language.deleted_at IS NULL")
+      expect(sql).toContain("dub.deleted_at IS NULL")
+      expect(sql).toContain("mux_video.deleted_at IS NULL")
+      expect(sql).toContain("subtitle.deleted_at IS NULL")
+      expect(sql).toContain("v.deleted_at IS NULL")
     })
 
     it("returns empty array on empty input without Prisma round-trip", async () => {
       const result = await service.getByCoreIds({ coreIds: [] })
 
       expect(result).toEqual([])
-      expect(prisma.video.findMany).not.toHaveBeenCalled()
+      expect(prisma.$queryRaw).not.toHaveBeenCalled()
     })
 
     it("throws VideoLookupValidationError when coreIds exceeds cap", async () => {
@@ -201,12 +188,16 @@ describe("VideoService", () => {
       await expect(
         service.getByCoreIds({ coreIds: tooMany }),
       ).rejects.toBeInstanceOf(VideoLookupValidationError)
-      expect(prisma.video.findMany).not.toHaveBeenCalled()
+      expect(prisma.$queryRaw).not.toHaveBeenCalled()
     })
 
     it("returns null primaryLanguageBcp47 when video has no primary language", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({ primaryLanguage: null }),
+      prisma.$queryRaw.mockResolvedValueOnce([
+        rowFixture({
+          primaryLanguageBcp47: null,
+          muxAssetId: null,
+          subtitleUrl: null,
+        }),
       ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
@@ -217,16 +208,7 @@ describe("VideoService", () => {
     })
 
     it("returns null muxAssetId when no primary-language dub exists", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          dubs: [
-            {
-              language: { bcp47: "es" },
-              muxVideo: { assetId: "mux-asset-es" },
-            },
-          ],
-        }),
-      ])
+      prisma.$queryRaw.mockResolvedValueOnce([rowFixture({ muxAssetId: null })])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
@@ -234,65 +216,29 @@ describe("VideoService", () => {
     })
 
     it("returns null muxAssetId when primary-language dub has no muxVideo assetId", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          dubs: [
-            {
-              language: { bcp47: "en" },
-              muxVideo: { assetId: null },
-            },
-          ],
-        }),
-      ])
+      prisma.$queryRaw.mockResolvedValueOnce([rowFixture({ muxAssetId: null })])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
       expect(row.muxAssetId).toBeNull()
     })
 
-    it("prefers primary non-AI subtitle when multiple primary-language candidates exist", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          subtitles: [
-            {
-              language: { bcp47: "en" },
-              vttSrc: "https://example.com/en-ai.vtt",
-              primary: false,
-              aiGenerated: true,
-            },
-            {
-              language: { bcp47: "en" },
-              vttSrc: "https://example.com/en-primary.vtt",
-              primary: true,
-              aiGenerated: false,
-            },
-            {
-              language: { bcp47: "en" },
-              vttSrc: "https://example.com/en-secondary.vtt",
-              primary: false,
-              aiGenerated: false,
-            },
-          ],
-        }),
+    it("orders subtitle candidates by primary/non-AI score in SQL", async () => {
+      prisma.$queryRaw.mockResolvedValueOnce([
+        rowFixture({ subtitleUrl: "https://example.com/en-primary.vtt" }),
       ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
       expect(row.subtitleUrl).toBe("https://example.com/en-primary.vtt")
+      const sql = prisma.$queryRaw.mock.calls[0][0].join(" ")
+      expect(sql).toContain("CASE WHEN subtitle.primary THEN 0 ELSE 1 END")
+      expect(sql).toContain("CASE WHEN subtitle.ai_generated THEN 1 ELSE 0 END")
     })
 
     it("falls back to an AI subtitle when no non-AI primary-language subtitle exists", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          subtitles: [
-            {
-              language: { bcp47: "en" },
-              vttSrc: "https://example.com/en-ai.vtt",
-              primary: false,
-              aiGenerated: true,
-            },
-          ],
-        }),
+      prisma.$queryRaw.mockResolvedValueOnce([
+        rowFixture({ subtitleUrl: "https://example.com/en-ai.vtt" }),
       ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
@@ -301,17 +247,8 @@ describe("VideoService", () => {
     })
 
     it("returns null subtitleUrl when no primary-language subtitle exists", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          subtitles: [
-            {
-              language: { bcp47: "es" },
-              vttSrc: "https://example.com/es.vtt",
-              primary: true,
-              aiGenerated: false,
-            },
-          ],
-        }),
+      prisma.$queryRaw.mockResolvedValueOnce([
+        rowFixture({ subtitleUrl: null }),
       ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
@@ -320,32 +257,17 @@ describe("VideoService", () => {
     })
 
     it("ignores subtitles with null vttSrc", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          subtitles: [
-            {
-              language: { bcp47: "en" },
-              vttSrc: null,
-              primary: true,
-              aiGenerated: false,
-            },
-            {
-              language: { bcp47: "en" },
-              vttSrc: "https://example.com/en.vtt",
-              primary: false,
-              aiGenerated: false,
-            },
-          ],
-        }),
-      ])
+      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
       expect(row.subtitleUrl).toBe("https://example.com/en.vtt")
+      const sql = prisma.$queryRaw.mock.calls[0][0].join(" ")
+      expect(sql).toContain("subtitle.vtt_src IS NOT NULL")
     })
 
     it("excludes a coreId from results when no matching video exists", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([rowFixture()])
+      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const result = await service.getByCoreIds({
         coreIds: ["core-1", "core-missing"],
@@ -360,40 +282,29 @@ describe("VideoService", () => {
         { length: VIDEOS_BY_CORE_IDS_MAX },
         (_, i) => `core-${i}`,
       )
-      prisma.video.findMany.mockResolvedValueOnce([])
+      prisma.$queryRaw.mockResolvedValueOnce([])
 
       await expect(service.getByCoreIds({ coreIds: exact })).resolves.toEqual(
         [],
       )
-      expect(prisma.video.findMany).toHaveBeenCalledOnce()
+      expect(prisma.$queryRaw).toHaveBeenCalledOnce()
     })
 
-    it("passes duplicate coreIds through to the Prisma `in` clause (caller dedupe is upstream)", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([rowFixture()])
+    it("passes duplicate coreIds through to the raw SQL IN list (caller dedupe is upstream)", async () => {
+      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const result = await service.getByCoreIds({
         coreIds: ["core-1", "core-1"],
       })
 
-      // Prisma's `in` clause natively dedupes; the result map keyed
-      // by coreId stays at one entry even with duplicate input.
       expect(result).toHaveLength(1)
-      const call = prisma.video.findMany.mock.calls[0][0]
-      expect(call.where.coreId.in).toEqual(["core-1", "core-1"])
+      const coreIdJoin = prisma.$queryRaw.mock.calls[0][1]
+      expect(coreIdJoin.values).toEqual(["core-1", "core-1"])
     })
 
     it("normalizes empty-string vttSrc as missing (parity with null vttSrc)", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          subtitles: [
-            {
-              language: { bcp47: "en" },
-              vttSrc: "",
-              primary: true,
-              aiGenerated: false,
-            },
-          ],
-        }),
+      prisma.$queryRaw.mockResolvedValueOnce([
+        rowFixture({ subtitleUrl: null }),
       ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
@@ -402,16 +313,7 @@ describe("VideoService", () => {
     })
 
     it("normalizes empty-string muxVideo.assetId as missing (parity with null assetId)", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
-        rowFixture({
-          dubs: [
-            {
-              language: { bcp47: "en" },
-              muxVideo: { assetId: "" },
-            },
-          ],
-        }),
-      ])
+      prisma.$queryRaw.mockResolvedValueOnce([rowFixture({ muxAssetId: null })])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
@@ -419,7 +321,7 @@ describe("VideoService", () => {
     })
 
     it("converts uppercase VideoLabel enum to camelCase wire shape", async () => {
-      prisma.video.findMany.mockResolvedValueOnce([
+      prisma.$queryRaw.mockResolvedValueOnce([
         rowFixture({ label: "FEATURE_FILM" }),
         { ...rowFixture({ coreId: "core-2" }), label: "BEHIND_THE_SCENES" },
       ])
@@ -437,7 +339,7 @@ describe("VideoService", () => {
       // DB-stored camelCase value directly, the normalizer must
       // NOT silently lowercase it (`featureFilm` -> `featurefilm`
       // would corrupt the wire shape).
-      prisma.video.findMany.mockResolvedValueOnce([
+      prisma.$queryRaw.mockResolvedValueOnce([
         { ...rowFixture(), label: "featureFilm" },
       ])
 

--- a/apps/admin/src/services/video.service.test.ts
+++ b/apps/admin/src/services/video.service.test.ts
@@ -7,12 +7,21 @@ import {
 } from "./video.service"
 
 function mockPrisma() {
+  const tx = {
+    $executeRaw: vi.fn(),
+    $executeRawUnsafe: vi.fn(),
+    $queryRaw: vi.fn(),
+  }
   return {
     video: {
       findMany: vi.fn(),
       findFirst: vi.fn(),
     },
     $queryRaw: vi.fn(),
+    $executeRaw: vi.fn(),
+    $executeRawUnsafe: vi.fn(),
+    $transaction: vi.fn((callback) => callback(tx)),
+    tx,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
 }
@@ -138,7 +147,7 @@ describe("VideoService", () => {
 
   describe("getByCoreIds (feat-125 manager admin-trigger lookup)", () => {
     it("returns dispatch fields for a fully-populated video", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const result = await service.getByCoreIds({ coreIds: ["core-1"] })
 
@@ -155,13 +164,14 @@ describe("VideoService", () => {
     })
 
     it("uses one targeted raw SQL projection instead of loading relation graphs", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([])
 
       await service.getByCoreIds({ coreIds: ["core-1"] })
 
       expect(prisma.video.findMany).not.toHaveBeenCalled()
-      expect(prisma.$queryRaw).toHaveBeenCalledOnce()
-      const sql = prisma.$queryRaw.mock.calls[0][0].join(" ")
+      expect(prisma.$queryRaw).not.toHaveBeenCalled()
+      expect(prisma.tx.$queryRaw).toHaveBeenCalledOnce()
+      const sql = prisma.tx.$queryRaw.mock.calls[0][0].join(" ")
       expect(sql).toContain("LEFT JOIN LATERAL")
       expect(sql).toContain("video_dub")
       expect(sql).toContain("video_subtitle")
@@ -172,11 +182,24 @@ describe("VideoService", () => {
       expect(sql).toContain("v.deleted_at IS NULL")
     })
 
+    it("sets a transaction-local statement timeout below manager's admin lookup timeout", async () => {
+      prisma.tx.$queryRaw.mockResolvedValueOnce([])
+
+      await service.getByCoreIds({ coreIds: ["core-1"] })
+
+      expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        timeout: 9000,
+      })
+      expect(prisma.tx.$executeRawUnsafe).toHaveBeenCalledWith(
+        "SET LOCAL statement_timeout = '8000ms'",
+      )
+    })
+
     it("returns empty array on empty input without Prisma round-trip", async () => {
       const result = await service.getByCoreIds({ coreIds: [] })
 
       expect(result).toEqual([])
-      expect(prisma.$queryRaw).not.toHaveBeenCalled()
+      expect(prisma.$transaction).not.toHaveBeenCalled()
     })
 
     it("throws VideoLookupValidationError when coreIds exceeds cap", async () => {
@@ -188,11 +211,11 @@ describe("VideoService", () => {
       await expect(
         service.getByCoreIds({ coreIds: tooMany }),
       ).rejects.toBeInstanceOf(VideoLookupValidationError)
-      expect(prisma.$queryRaw).not.toHaveBeenCalled()
+      expect(prisma.$transaction).not.toHaveBeenCalled()
     })
 
     it("returns null primaryLanguageBcp47 when video has no primary language", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
         rowFixture({
           primaryLanguageBcp47: null,
           muxAssetId: null,
@@ -208,7 +231,9 @@ describe("VideoService", () => {
     })
 
     it("returns null muxAssetId when no primary-language dub exists", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([rowFixture({ muxAssetId: null })])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
+        rowFixture({ muxAssetId: null }),
+      ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
@@ -216,7 +241,9 @@ describe("VideoService", () => {
     })
 
     it("returns null muxAssetId when primary-language dub has no muxVideo assetId", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([rowFixture({ muxAssetId: null })])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
+        rowFixture({ muxAssetId: null }),
+      ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
@@ -224,20 +251,20 @@ describe("VideoService", () => {
     })
 
     it("orders subtitle candidates by primary/non-AI score in SQL", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
         rowFixture({ subtitleUrl: "https://example.com/en-primary.vtt" }),
       ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
       expect(row.subtitleUrl).toBe("https://example.com/en-primary.vtt")
-      const sql = prisma.$queryRaw.mock.calls[0][0].join(" ")
+      const sql = prisma.tx.$queryRaw.mock.calls[0][0].join(" ")
       expect(sql).toContain("CASE WHEN subtitle.primary THEN 0 ELSE 1 END")
       expect(sql).toContain("CASE WHEN subtitle.ai_generated THEN 1 ELSE 0 END")
     })
 
     it("falls back to an AI subtitle when no non-AI primary-language subtitle exists", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
         rowFixture({ subtitleUrl: "https://example.com/en-ai.vtt" }),
       ])
 
@@ -247,7 +274,7 @@ describe("VideoService", () => {
     })
 
     it("returns null subtitleUrl when no primary-language subtitle exists", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
         rowFixture({ subtitleUrl: null }),
       ])
 
@@ -257,17 +284,17 @@ describe("VideoService", () => {
     })
 
     it("ignores subtitles with null vttSrc", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
       expect(row.subtitleUrl).toBe("https://example.com/en.vtt")
-      const sql = prisma.$queryRaw.mock.calls[0][0].join(" ")
+      const sql = prisma.tx.$queryRaw.mock.calls[0][0].join(" ")
       expect(sql).toContain("subtitle.vtt_src IS NOT NULL")
     })
 
     it("excludes a coreId from results when no matching video exists", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const result = await service.getByCoreIds({
         coreIds: ["core-1", "core-missing"],
@@ -282,28 +309,28 @@ describe("VideoService", () => {
         { length: VIDEOS_BY_CORE_IDS_MAX },
         (_, i) => `core-${i}`,
       )
-      prisma.$queryRaw.mockResolvedValueOnce([])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([])
 
       await expect(service.getByCoreIds({ coreIds: exact })).resolves.toEqual(
         [],
       )
-      expect(prisma.$queryRaw).toHaveBeenCalledOnce()
+      expect(prisma.tx.$queryRaw).toHaveBeenCalledOnce()
     })
 
     it("passes duplicate coreIds through to the raw SQL IN list (caller dedupe is upstream)", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([rowFixture()])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([rowFixture()])
 
       const result = await service.getByCoreIds({
         coreIds: ["core-1", "core-1"],
       })
 
       expect(result).toHaveLength(1)
-      const coreIdJoin = prisma.$queryRaw.mock.calls[0][1]
+      const coreIdJoin = prisma.tx.$queryRaw.mock.calls[0][1]
       expect(coreIdJoin.values).toEqual(["core-1", "core-1"])
     })
 
     it("normalizes empty-string vttSrc as missing (parity with null vttSrc)", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
         rowFixture({ subtitleUrl: null }),
       ])
 
@@ -313,7 +340,9 @@ describe("VideoService", () => {
     })
 
     it("normalizes empty-string muxVideo.assetId as missing (parity with null assetId)", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([rowFixture({ muxAssetId: null })])
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
+        rowFixture({ muxAssetId: null }),
+      ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
@@ -321,7 +350,7 @@ describe("VideoService", () => {
     })
 
     it("converts uppercase VideoLabel enum to camelCase wire shape", async () => {
-      prisma.$queryRaw.mockResolvedValueOnce([
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
         rowFixture({ label: "FEATURE_FILM" }),
         { ...rowFixture({ coreId: "core-2" }), label: "BEHIND_THE_SCENES" },
       ])
@@ -339,13 +368,37 @@ describe("VideoService", () => {
       // DB-stored camelCase value directly, the normalizer must
       // NOT silently lowercase it (`featureFilm` -> `featurefilm`
       // would corrupt the wire shape).
-      prisma.$queryRaw.mockResolvedValueOnce([
+      prisma.tx.$queryRaw.mockResolvedValueOnce([
         { ...rowFixture(), label: "featureFilm" },
       ])
 
       const [row] = await service.getByCoreIds({ coreIds: ["core-1"] })
 
       expect(row.label).toBe("featureFilm")
+    })
+
+    it("logs a sanitized failure breadcrumb when the lookup throws", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+      const error = Object.assign(new Error("canceling statement"), {
+        code: "P2010",
+      })
+      prisma.tx.$queryRaw.mockRejectedValueOnce(error)
+
+      await expect(service.getByCoreIds({ coreIds: ["core-1"] })).rejects.toBe(
+        error,
+      )
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("event=lookup.failed"),
+      )
+      const message = warn.mock.calls[0][0]
+      expect(message).toContain("coreIdCount=1")
+      expect(message).toContain("errorName=Error")
+      expect(message).toContain("errorCode=P2010")
+      expect(message).not.toContain("core-1")
+      expect(message).not.toContain("canceling statement")
+
+      warn.mockRestore()
     })
   })
 })

--- a/apps/admin/src/services/video.service.ts
+++ b/apps/admin/src/services/video.service.ts
@@ -8,7 +8,7 @@
 // breaks `video.service.test.ts:52`. `getByCoreId` is service-to-service
 // only (Core sync internals) and keeps its guard.
 
-import type { PrismaClient } from "@prisma/client"
+import { Prisma, type PrismaClient } from "@prisma/client"
 import type { Principal } from "@/auth/principal"
 import { hasPermission } from "@/auth/permissions"
 import { ForbiddenError } from "./errors"
@@ -132,56 +132,59 @@ export class VideoService {
       )
     }
 
-    const rows = await this.prisma.video.findMany({
-      where: { coreId: { in: [...coreIds] }, deletedAt: null },
-      include: {
-        primaryLanguage: { select: { bcp47: true } },
-        dubs: {
-          where: { deletedAt: null },
-          include: {
-            language: { select: { bcp47: true } },
-            muxVideo: { select: { assetId: true } },
-          },
-        },
-        subtitles: {
-          where: { deletedAt: null },
-          include: { language: { select: { bcp47: true } } },
-        },
-      },
-    })
+    const startedAt = Date.now()
+    const rows = await this.prisma.$queryRaw<VideoForEnrichmentRow[]>`
+      SELECT
+        v.id,
+        v.core_id AS "coreId",
+        v.label::text AS label,
+        primary_language.bcp47 AS "primaryLanguageBcp47",
+        primary_mux.asset_id AS "muxAssetId",
+        primary_subtitle.vtt_src AS "subtitleUrl"
+      FROM video v
+      LEFT JOIN language primary_language
+        ON primary_language.id = v.primary_language_id
+        AND primary_language.deleted_at IS NULL
+      LEFT JOIN LATERAL (
+        SELECT mux_video.asset_id
+        FROM video_dub dub
+        JOIN language dub_language
+          ON dub_language.id = dub.language_id
+          AND dub_language.deleted_at IS NULL
+        JOIN mux_video
+          ON mux_video.id = dub.mux_video_id
+          AND mux_video.deleted_at IS NULL
+        WHERE dub.video_id = v.id
+          AND dub.deleted_at IS NULL
+          AND dub_language.bcp47 = primary_language.bcp47
+          AND mux_video.asset_id IS NOT NULL
+          AND mux_video.asset_id <> ''
+        ORDER BY dub.published DESC NULLS LAST, dub.updated_at DESC
+        LIMIT 1
+      ) primary_mux ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT subtitle.vtt_src
+        FROM video_subtitle subtitle
+        JOIN language subtitle_language
+          ON subtitle_language.id = subtitle.language_id
+          AND subtitle_language.deleted_at IS NULL
+        WHERE subtitle.video_id = v.id
+          AND subtitle.deleted_at IS NULL
+          AND subtitle_language.bcp47 = primary_language.bcp47
+          AND subtitle.vtt_src IS NOT NULL
+          AND subtitle.vtt_src <> ''
+        ORDER BY
+          (CASE WHEN subtitle.primary THEN 0 ELSE 1 END) +
+          (CASE WHEN subtitle.ai_generated THEN 1 ELSE 0 END) ASC,
+          subtitle.updated_at DESC
+        LIMIT 1
+      ) primary_subtitle ON TRUE
+      WHERE v.core_id IN (${Prisma.join([...coreIds])})
+        AND v.deleted_at IS NULL
+    `
+    logSlowVideoLookup(coreIds.length, Date.now() - startedAt)
 
     return rows.map((video): VideoForEnrichment => {
-      const primaryBcp47 = video.primaryLanguage?.bcp47 ?? null
-
-      let muxAssetId: string | null = null
-      if (primaryBcp47 != null) {
-        const variantWithMux = video.dubs.find(
-          (d) =>
-            d.language?.bcp47 === primaryBcp47 &&
-            typeof d.muxVideo?.assetId === "string" &&
-            d.muxVideo.assetId.length > 0,
-        )
-        muxAssetId = variantWithMux?.muxVideo?.assetId ?? null
-      }
-
-      let subtitleUrl: string | null = null
-      if (primaryBcp47 != null) {
-        // `.filter()` already returns a fresh array, so the
-        // subsequent `.sort()` does not mutate Prisma's result row.
-        const candidates = video.subtitles.filter(
-          (s) =>
-            s.language?.bcp47 === primaryBcp47 &&
-            typeof s.vttSrc === "string" &&
-            s.vttSrc.length > 0,
-        )
-        candidates.sort((a, b) => {
-          const aScore = (a.primary ? 0 : 1) + (a.aiGenerated ? 1 : 0)
-          const bScore = (b.primary ? 0 : 1) + (b.aiGenerated ? 1 : 0)
-          return aScore - bScore
-        })
-        subtitleUrl = candidates[0]?.vttSrc ?? null
-      }
-
       return {
         id: video.id,
         coreId: video.coreId,
@@ -194,12 +197,21 @@ export class VideoService {
         // tests pass `videoLabel: "shortFilm"`-style fixtures, so
         // any drift here changes the LLM prompt content.
         label: snakeUpperToCamel(video.label),
-        primaryLanguageBcp47: primaryBcp47,
-        muxAssetId,
-        subtitleUrl,
+        primaryLanguageBcp47: video.primaryLanguageBcp47,
+        muxAssetId: video.muxAssetId,
+        subtitleUrl: video.subtitleUrl,
       }
     })
   }
+}
+
+type VideoForEnrichmentRow = VideoForEnrichment
+
+function logSlowVideoLookup(coreIdCount: number, durationMs: number): void {
+  if (durationMs < 500) return
+  console.warn(
+    `[videosByCoreIds] event=lookup.slow coreIdCount=${coreIdCount} durationMs=${durationMs}`,
+  )
 }
 
 /**

--- a/apps/admin/src/services/video.service.ts
+++ b/apps/admin/src/services/video.service.ts
@@ -50,6 +50,9 @@ export class VideoLookupValidationError extends Error {
  * contract is double-locked.
  */
 export const VIDEOS_BY_CORE_IDS_MAX = 100
+const VIDEOS_BY_CORE_IDS_STATEMENT_TIMEOUT_MS = 8_000
+const VIDEOS_BY_CORE_IDS_TRANSACTION_TIMEOUT_MS = 9_000
+const VIDEOS_BY_CORE_IDS_STATEMENT_TIMEOUT_SQL = `SET LOCAL statement_timeout = '${VIDEOS_BY_CORE_IDS_STATEMENT_TIMEOUT_MS}ms'`
 
 export class VideoService {
   constructor(private prisma: PrismaClient) {}
@@ -132,56 +135,69 @@ export class VideoService {
       )
     }
 
+    let rows: VideoForEnrichmentRow[]
     const startedAt = Date.now()
-    const rows = await this.prisma.$queryRaw<VideoForEnrichmentRow[]>`
-      SELECT
-        v.id,
-        v.core_id AS "coreId",
-        v.label::text AS label,
-        primary_language.bcp47 AS "primaryLanguageBcp47",
-        primary_mux.asset_id AS "muxAssetId",
-        primary_subtitle.vtt_src AS "subtitleUrl"
-      FROM video v
-      LEFT JOIN language primary_language
-        ON primary_language.id = v.primary_language_id
-        AND primary_language.deleted_at IS NULL
-      LEFT JOIN LATERAL (
-        SELECT mux_video.asset_id
-        FROM video_dub dub
-        JOIN language dub_language
-          ON dub_language.id = dub.language_id
-          AND dub_language.deleted_at IS NULL
-        JOIN mux_video
-          ON mux_video.id = dub.mux_video_id
-          AND mux_video.deleted_at IS NULL
-        WHERE dub.video_id = v.id
-          AND dub.deleted_at IS NULL
-          AND dub_language.bcp47 = primary_language.bcp47
-          AND mux_video.asset_id IS NOT NULL
-          AND mux_video.asset_id <> ''
-        ORDER BY dub.published DESC NULLS LAST, dub.updated_at DESC
-        LIMIT 1
-      ) primary_mux ON TRUE
-      LEFT JOIN LATERAL (
-        SELECT subtitle.vtt_src
-        FROM video_subtitle subtitle
-        JOIN language subtitle_language
-          ON subtitle_language.id = subtitle.language_id
-          AND subtitle_language.deleted_at IS NULL
-        WHERE subtitle.video_id = v.id
-          AND subtitle.deleted_at IS NULL
-          AND subtitle_language.bcp47 = primary_language.bcp47
-          AND subtitle.vtt_src IS NOT NULL
-          AND subtitle.vtt_src <> ''
-        ORDER BY
-          (CASE WHEN subtitle.primary THEN 0 ELSE 1 END) +
-          (CASE WHEN subtitle.ai_generated THEN 1 ELSE 0 END) ASC,
-          subtitle.updated_at DESC
-        LIMIT 1
-      ) primary_subtitle ON TRUE
-      WHERE v.core_id IN (${Prisma.join([...coreIds])})
-        AND v.deleted_at IS NULL
-    `
+    try {
+      rows = await this.prisma.$transaction(
+        async (tx) => {
+          await tx.$executeRawUnsafe(VIDEOS_BY_CORE_IDS_STATEMENT_TIMEOUT_SQL)
+
+          return tx.$queryRaw<VideoForEnrichmentRow[]>`
+            SELECT
+              v.id,
+              v.core_id AS "coreId",
+              v.label::text AS label,
+              primary_language.bcp47 AS "primaryLanguageBcp47",
+              primary_mux.asset_id AS "muxAssetId",
+              primary_subtitle.vtt_src AS "subtitleUrl"
+            FROM video v
+            LEFT JOIN language primary_language
+              ON primary_language.id = v.primary_language_id
+              AND primary_language.deleted_at IS NULL
+            LEFT JOIN LATERAL (
+              SELECT mux_video.asset_id
+              FROM video_dub dub
+              JOIN language dub_language
+                ON dub_language.id = dub.language_id
+                AND dub_language.deleted_at IS NULL
+              JOIN mux_video
+                ON mux_video.id = dub.mux_video_id
+                AND mux_video.deleted_at IS NULL
+              WHERE dub.video_id = v.id
+                AND dub.deleted_at IS NULL
+                AND dub_language.bcp47 = primary_language.bcp47
+                AND mux_video.asset_id IS NOT NULL
+                AND mux_video.asset_id <> ''
+              ORDER BY dub.published DESC NULLS LAST, dub.updated_at DESC
+              LIMIT 1
+            ) primary_mux ON TRUE
+            LEFT JOIN LATERAL (
+              SELECT subtitle.vtt_src
+              FROM video_subtitle subtitle
+              JOIN language subtitle_language
+                ON subtitle_language.id = subtitle.language_id
+                AND subtitle_language.deleted_at IS NULL
+              WHERE subtitle.video_id = v.id
+                AND subtitle.deleted_at IS NULL
+                AND subtitle_language.bcp47 = primary_language.bcp47
+                AND subtitle.vtt_src IS NOT NULL
+                AND subtitle.vtt_src <> ''
+              ORDER BY
+                (CASE WHEN subtitle.primary THEN 0 ELSE 1 END) +
+                (CASE WHEN subtitle.ai_generated THEN 1 ELSE 0 END) ASC,
+                subtitle.updated_at DESC
+              LIMIT 1
+            ) primary_subtitle ON TRUE
+            WHERE v.core_id IN (${Prisma.join([...coreIds])})
+              AND v.deleted_at IS NULL
+          `
+        },
+        { timeout: VIDEOS_BY_CORE_IDS_TRANSACTION_TIMEOUT_MS },
+      )
+    } catch (error) {
+      logVideoLookupFailure(coreIds.length, Date.now() - startedAt, error)
+      throw error
+    }
     logSlowVideoLookup(coreIds.length, Date.now() - startedAt)
 
     return rows.map((video): VideoForEnrichment => {
@@ -212,6 +228,24 @@ function logSlowVideoLookup(coreIdCount: number, durationMs: number): void {
   console.warn(
     `[videosByCoreIds] event=lookup.slow coreIdCount=${coreIdCount} durationMs=${durationMs}`,
   )
+}
+
+function logVideoLookupFailure(
+  coreIdCount: number,
+  durationMs: number,
+  error: unknown,
+): void {
+  console.warn(
+    `[videosByCoreIds] event=lookup.failed coreIdCount=${coreIdCount} durationMs=${durationMs} ${formatLookupError(error)}`,
+  )
+}
+
+function formatLookupError(error: unknown): string {
+  if (!(error instanceof Error)) return "errorName=UnknownError"
+
+  const maybeCode = (error as Error & { code?: unknown }).code
+  const code = typeof maybeCode === "string" ? ` errorCode=${maybeCode}` : ""
+  return `errorName=${error.name}${code}`
 }
 
 /**

--- a/apps/admin/src/storage/s3.manager-artifacts-backend.test.ts
+++ b/apps/admin/src/storage/s3.manager-artifacts-backend.test.ts
@@ -21,10 +21,19 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const { s3Send, GetObjectCommand, capturedClientConfigs } = vi.hoisted(() => ({
+const {
+  s3Send,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  capturedClientConfigs,
+} = vi.hoisted(() => ({
   s3Send: vi.fn(),
   GetObjectCommand: vi.fn().mockImplementation((input: unknown) => ({
     __command: "GetObject",
+    input,
+  })),
+  ListObjectsV2Command: vi.fn().mockImplementation((input: unknown) => ({
+    __command: "ListObjectsV2",
     input,
   })),
   capturedClientConfigs: [] as Array<Record<string, unknown>>,
@@ -47,6 +56,7 @@ vi.mock("@aws-sdk/client-s3", () => ({
   S3Client: StubS3Client,
   PutObjectCommand: vi.fn(),
   GetObjectCommand,
+  ListObjectsV2Command,
 }))
 
 vi.mock("@smithy/node-http-handler", () => ({
@@ -69,12 +79,18 @@ process.env.MANAGER_ARTIFACTS_S3_ACCESS_KEY_ID = "MANAGER_AKIA"
 process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY = "manager-secret"
 
 const storage = await import("./s3")
-const { readManagerArtifact, readArtifact } = storage
+const {
+  readManagerArtifact,
+  readArtifact,
+  assertManagerArtifactsReachable,
+  assertObjectStorageReachable,
+} = storage
 
 describe("storage — readManagerArtifact (S3 backend)", () => {
   beforeEach(() => {
     s3Send.mockReset()
     GetObjectCommand.mockClear()
+    ListObjectsV2Command.mockClear()
     // capturedClientConfigs is intentionally NOT reset between tests —
     // the s3 module memoizes both clients at module scope, so only the
     // first test that triggers each lazy init appends a config. Tests
@@ -172,6 +188,7 @@ describe("storage — readManagerArtifact (S3 backend)", () => {
     // surface here.
     const exports = storage as Record<string, unknown>
     expect("readManagerArtifact" in exports).toBe(true)
+    expect("assertManagerArtifactsReachable" in exports).toBe(true)
     expect("getManagerArtifactsS3" in exports).toBe(false)
     expect("_s3ManagerArtifacts" in exports).toBe(false)
     expect("writeManagerArtifact" in exports).toBe(false)
@@ -201,5 +218,41 @@ describe("storage — readManagerArtifact (S3 backend)", () => {
       process.env.MANAGER_ARTIFACTS_S3_SECRET_ACCESS_KEY = "manager-secret"
       vi.resetModules()
     }
+  })
+
+  it("probes manager artifact bucket reachability with MANAGER_ARTIFACTS_S3_BUCKET", async () => {
+    s3Send.mockResolvedValueOnce({})
+
+    await assertManagerArtifactsReachable()
+
+    expect(ListObjectsV2Command).toHaveBeenCalledTimes(1)
+    expect(ListObjectsV2Command).toHaveBeenCalledWith({
+      Bucket: "manager-bucket",
+      MaxKeys: 1,
+    })
+    expect(s3Send).toHaveBeenCalledTimes(1)
+  })
+
+  it("probes admin object bucket reachability with RAILWAY_S3_BUCKET", async () => {
+    s3Send.mockResolvedValueOnce({})
+
+    await assertObjectStorageReachable()
+
+    expect(ListObjectsV2Command).toHaveBeenCalledTimes(1)
+    expect(ListObjectsV2Command).toHaveBeenCalledWith({
+      Bucket: "wrong-bucket",
+      MaxKeys: 1,
+    })
+    expect(s3Send).toHaveBeenCalledTimes(1)
+  })
+
+  it("propagates manager artifact bucket reachability failures", async () => {
+    s3Send.mockRejectedValueOnce(new Error("network down"))
+
+    await expect(assertManagerArtifactsReachable()).rejects.toThrow(
+      "network down",
+    )
+    expect(ListObjectsV2Command).toHaveBeenCalledTimes(1)
+    expect(s3Send).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/admin/src/storage/s3.ts
+++ b/apps/admin/src/storage/s3.ts
@@ -313,6 +313,31 @@ export async function readManagerArtifact(
   return new Uint8Array(await response.Body.transformToByteArray())
 }
 
+/**
+ * Cheap reachability probe for manager's artifact bucket. Used by
+ * long-running operator CLIs before they start enumerating/indexing a
+ * large corpus. This intentionally exposes only an ok/error boundary;
+ * callers classify the thrown AWS/transport error for operator output.
+ */
+export async function assertManagerArtifactsReachable(): Promise<void> {
+  assertManagerArtifactsConfiguredForProduction()
+
+  if (!useManagerArtifactsS3) {
+    // Local fallback is reachable if the process can read its cwd; the
+    // real artifact read will report ENOENT for individual files.
+    return
+  }
+
+  const { ListObjectsV2Command } = await import("@aws-sdk/client-s3")
+  const s3 = await getManagerArtifactsS3()
+  await s3.send(
+    new ListObjectsV2Command({
+      Bucket: env.MANAGER_ARTIFACTS_S3_BUCKET,
+      MaxKeys: 1,
+    }),
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Object-key API — reads/writes to an arbitrary S3 key (slash-separated
 // path segments), rather than the `{assetId}/{artifactType}.{ext}` shape.
@@ -377,4 +402,24 @@ export async function readObject(key: string): Promise<Uint8Array> {
 
   if (!response.Body) throw new Error(`Empty body for ${key}`)
   return new Uint8Array(await response.Body.transformToByteArray())
+}
+
+/**
+ * Cheap reachability probe for admin's own object bucket. Kept separate
+ * from readObject so callers can distinguish "bucket/config/transport
+ * broken" from "specific mapping object missing".
+ */
+export async function assertObjectStorageReachable(): Promise<void> {
+  assertStorageConfiguredForProduction()
+
+  if (!useS3) return
+
+  const { ListObjectsV2Command } = await import("@aws-sdk/client-s3")
+  const s3 = await getS3()
+  await s3.send(
+    new ListObjectsV2Command({
+      Bucket: env.RAILWAY_S3_BUCKET,
+      MaxKeys: 1,
+    }),
+  )
 }

--- a/apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts
@@ -464,6 +464,79 @@ describe("runSceneEmbeddingBackfill", () => {
     // No groups → no S3 reads.
     expect(readSceneAnalysisArtifact).not.toHaveBeenCalled()
   })
+
+  it("filters exact retry targets after enumeration and preserves group artifact reuse", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
+      row("v-a", "e-a", "core-a", "en"),
+      row("v-a", "e-a", "core-a", "es"),
+      row("v-a", "e-b", "core-a", "en"),
+      row("v-b", "e-c", "core-b", "en"),
+    ])
+
+    const report = await runSceneEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      retryTargets: [
+        { coreId: "core-a", videoEditionId: "e-a", locale: "es" },
+        { coreId: "core-b", videoEditionId: "e-c", locale: "en" },
+      ],
+    })
+
+    expect(report.totalTargets).toBe(2)
+    expect(report.retrySelection).toEqual({
+      requested: 2,
+      matched: 2,
+      unmatched: 0,
+      unmatchedRetryTargets: [],
+    })
+    expect(readSceneAnalysisArtifact).toHaveBeenCalledTimes(2)
+    expect(indexEditionScenes).toHaveBeenCalledTimes(2)
+    expect(
+      vi
+        .mocked(indexEditionScenes)
+        .mock.calls.map((call) => ({
+          editionId: call[1].editionId,
+          locale: call[1].locale,
+        }))
+        .sort((a, b) =>
+          `${a.editionId}:${a.locale}`.localeCompare(
+            `${b.editionId}:${b.locale}`,
+          ),
+        ),
+    ).toEqual([
+      { editionId: "e-a", locale: "es" },
+      { editionId: "e-c", locale: "en" },
+    ])
+  })
+
+  it("fails closed when exact retry targets no longer match current enumeration", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
+      row("v-a", "e-a", "core-a", "en"),
+    ])
+
+    await expect(
+      runSceneEmbeddingBackfill({
+        mappingS3Key: "admin-migrations/core-id-mapping.json",
+        retryTargets: [
+          { coreId: "core-a", videoEditionId: "stale-edition", locale: "en" },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: "SceneRetrySelectionError",
+      retrySelection: {
+        requested: 1,
+        matched: 0,
+        unmatched: 1,
+        unmatchedRetryTargets: [
+          {
+            coreId: "core-a",
+            videoEditionId: "stale-edition",
+            locale: "en",
+          },
+        ],
+      },
+    })
+    expect(indexEditionScenes).not.toHaveBeenCalled()
+  })
 })
 
 // feat-119 PR1 — `missingArtifacts` is a deduped, sorted projection of
@@ -967,6 +1040,7 @@ describe("_internals.stepReport", () => {
       mappingGeneratedAt: "2026-04-19T00:00:00.000Z",
       targets: 3,
       localeFilter: null,
+      retrySelection: null,
       outcomes: [
         {
           status: "succeeded",
@@ -981,6 +1055,7 @@ describe("_internals.stepReport", () => {
           target,
           locale: "en",
           reason: "boom",
+          failureCategory: "other",
           durationMs: 50,
         },
         {
@@ -995,5 +1070,87 @@ describe("_internals.stepReport", () => {
     expect(report.succeeded).toBe(1)
     expect(report.failed).toBe(1)
     expect(report.skipped).toBe(1)
+  })
+})
+
+describe("runSceneEmbeddingBackfill — groupedFailures projection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockReset()
+    vi.mocked(indexEditionScenes).mockReset()
+    vi.mocked(readSceneAnalysisArtifact).mockReset()
+    vi.mocked(readSceneAnalysisArtifact).mockResolvedValue(STUB_ARTIFACT)
+  })
+
+  it("collapses repeated artifact read failures by asset, edition, and category", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
+      row("v-a", "e-a", "core-a", "en"),
+      row("v-a", "e-a", "core-a", "es"),
+      row("v-a", "e-a", "core-a", "fr"),
+    ])
+    vi.mocked(readSceneAnalysisArtifact).mockRejectedValueOnce(
+      new ManagerArtifactError(
+        "artifact_read_failed",
+        "failed to read scene-analysis artifact for assetId=1: getaddrinfo ENOTFOUND t3.storageapi.dev",
+        Object.assign(new Error("getaddrinfo ENOTFOUND t3.storageapi.dev"), {
+          code: "ENOTFOUND",
+        }),
+      ),
+    )
+
+    const report = await runSceneEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.failed).toBe(3)
+    expect(report.groupedFailures).toEqual([
+      expect.objectContaining({
+        assetId: 1,
+        coreId: "core-a",
+        videoEditionId: "e-a",
+        category: "dns_failed",
+        count: 3,
+        sampleLocales: ["en", "es", "fr"],
+      }),
+    ])
+    expect(report.missingArtifacts).toEqual([])
+  })
+
+  it("classifies Prisma and provider validation failures", () => {
+    expect(
+      _internals.classifySceneFailure(
+        new Error("PrismaClientKnownRequestError(P2028) during write"),
+      ),
+    ).toBe("prisma_transaction")
+    expect(
+      _internals.classifySceneFailure(
+        new Error("Embedding response validation failed"),
+      ),
+    ).toBe("provider_validation")
+  })
+
+  it("classifies storage transport categories distinctly", () => {
+    expect(
+      _internals.classifySceneFailure(
+        Object.assign(new Error("getaddrinfo ENOTFOUND t3.storageapi.dev"), {
+          code: "ENOTFOUND",
+        }),
+      ),
+    ).toBe("dns_failed")
+    expect(
+      _internals.classifySceneFailure(
+        Object.assign(new Error("request timed out"), { name: "TimeoutError" }),
+      ),
+    ).toBe("timeout")
+    expect(
+      _internals.classifySceneFailure(
+        Object.assign(new Error("AccessDenied"), { name: "AccessDenied" }),
+      ),
+    ).toBe("access_denied")
+    expect(
+      _internals.classifySceneFailure(
+        Object.assign(new Error("NoSuchBucket"), { name: "NoSuchBucket" }),
+      ),
+    ).toBe("bucket_not_found")
   })
 })

--- a/apps/admin/src/workflows/sceneEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/sceneEmbeddingBackfill.ts
@@ -49,10 +49,7 @@ import {
   loadCoreIdMapping,
   type CoreIdMapping,
 } from "@/services/core-id-mapping.service"
-import {
-  ManagerArtifactError,
-  type SceneAnalysisResult,
-} from "@/services/manager-artifacts.service"
+import type { SceneAnalysisResult } from "@/services/manager-artifacts.service"
 import {
   indexEditionScenes,
   type IndexEditionScenesResult,
@@ -563,8 +560,7 @@ async function processGroup(group: BackfillGroup): Promise<BackfillOutcome[]> {
     // analysis yet" → skipped. Anything else → failed (including
     // ManagerArtifactError artifact_invalid / artifact_read_failed).
     const durationMs = Date.now() - groupStartedAt
-    const isMissing =
-      error instanceof ManagerArtifactError && error.code === "artifact_missing"
+    const isMissing = getManagerArtifactCode(error) === "artifact_missing"
     const reason = isMissing
       ? "artifact_missing"
       : error instanceof Error
@@ -628,19 +624,16 @@ async function stepIndexEditionLocale(
     return toSucceeded(target, target.locale, result, Date.now() - startedAt)
   } catch (error) {
     const durationMs = Date.now() - startedAt
-    // Branch on the typed error class, not error-message regex. Only a
+    // Branch on the stable error code, not error-message regex. Only a
     // genuinely-missing artifact gets demoted to skipped; every other
-    // error shape (including ManagerArtifactError artifact_invalid,
-    // artifact_read_failed, EmbeddingsBatchError, and Prisma P2025
-    // "Record not found") stays classified as failed so the operator
-    // sees it in the report. With Stage 2's group-level artifact load,
-    // an `artifact_missing` here would only fire if the indexer's
-    // empty-`loadedArtifact` short-circuit somehow bypassed the cache;
-    // keep the classification path intact for safety in depth.
-    if (
-      error instanceof ManagerArtifactError &&
-      error.code === "artifact_missing"
-    ) {
+    // error shape (including artifact_invalid, artifact_read_failed,
+    // EmbeddingsBatchError, and Prisma P2025 "Record not found") stays
+    // classified as failed so the operator sees it in the report. With
+    // Stage 2's group-level artifact load, an `artifact_missing` here
+    // would only fire if the indexer's empty-`loadedArtifact`
+    // short-circuit somehow bypassed the cache; keep the classification
+    // path intact for safety in depth.
+    if (getManagerArtifactCode(error) === "artifact_missing") {
       return {
         status: "skipped",
         target,
@@ -802,11 +795,13 @@ function deriveGroupedFailures(
 }
 
 function classifySceneFailure(error: unknown): SceneFailureCategory {
-  if (error instanceof ManagerArtifactError) {
-    if (error.code === "artifact_invalid") return "artifact_invalid"
-    if (error.code === "artifact_read_failed") {
-      return classifySceneFailure(error.cause ?? error.message)
-    }
+  const artifactCode = getManagerArtifactCode(error)
+  if (artifactCode === "artifact_invalid") return "artifact_invalid"
+  if (artifactCode === "artifact_read_failed") {
+    return classifySceneFailure(
+      getUnknownProp(error, "cause") ??
+        (error instanceof Error ? error.message : String(error)),
+    )
   }
   const name = getStringProp(error, "name")
   const code = getStringProp(error, "code") ?? getStringProp(error, "Code")
@@ -858,10 +853,29 @@ function classifySceneFailure(error: unknown): SceneFailureCategory {
   return "other"
 }
 
+function getManagerArtifactCode(
+  error: unknown,
+):
+  | "artifact_missing"
+  | "artifact_invalid"
+  | "artifact_read_failed"
+  | undefined {
+  const code = getStringProp(error, "code")
+  if (code === "artifact_missing") return code
+  if (code === "artifact_invalid") return code
+  if (code === "artifact_read_failed") return code
+  return undefined
+}
+
 function getStringProp(error: unknown, prop: string): string | undefined {
   if (typeof error !== "object" || error === null) return undefined
   const value = (error as Record<string, unknown>)[prop]
   return typeof value === "string" ? value : undefined
+}
+
+function getUnknownProp(error: unknown, prop: string): unknown {
+  if (typeof error !== "object" || error === null) return undefined
+  return (error as Record<string, unknown>)[prop]
 }
 
 function stepReport(args: {

--- a/apps/admin/src/workflows/sceneEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/sceneEmbeddingBackfill.ts
@@ -99,6 +99,7 @@ export type SceneEmbeddingBackfillInput = {
    * derivation.
    */
   locales?: readonly string[]
+  retryTargets?: readonly SceneEmbeddingRetryTarget[]
 }
 
 export type BackfillTarget = {
@@ -115,6 +116,19 @@ export type BackfillTarget = {
    * edition, the edition produces no targets.
    */
   locale: string
+}
+
+export type SceneEmbeddingRetryTarget = {
+  coreId: string
+  videoEditionId: string
+  locale: string
+}
+
+export type RetrySelectionReport = {
+  requested: number
+  matched: number
+  unmatched: number
+  unmatchedRetryTargets: ReadonlyArray<SceneEmbeddingRetryTarget>
 }
 
 /**
@@ -150,6 +164,7 @@ export type BackfillOutcome =
       target: BackfillTarget
       locale: string
       reason: string
+      failureCategory: SceneFailureCategory
       durationMs: number
     }
 
@@ -187,6 +202,27 @@ export type MissingArtifact = {
   readonly kind: "scene-analysis"
 }
 
+export type SceneFailureCategory =
+  | "artifact_read_failed"
+  | "artifact_invalid"
+  | "dns_failed"
+  | "timeout"
+  | "access_denied"
+  | "bucket_not_found"
+  | "prisma_transaction"
+  | "provider_validation"
+  | "other"
+
+export type GroupedSceneFailure = {
+  readonly assetId: number
+  readonly coreId: string
+  readonly videoEditionId: string
+  readonly category: SceneFailureCategory
+  readonly count: number
+  readonly sampleReason: string
+  readonly sampleLocales: readonly string[]
+}
+
 export type SceneEmbeddingBackfillReport = {
   mappingGeneratedAt: string
   totalTargets: number
@@ -206,6 +242,18 @@ export type SceneEmbeddingBackfillReport = {
    * had its scene-analysis artifact present. See `MissingArtifact`.
    */
   missingArtifacts: ReadonlyArray<MissingArtifact>
+  retrySelection: RetrySelectionReport | null
+  groupedFailures: ReadonlyArray<GroupedSceneFailure>
+}
+
+export class SceneRetrySelectionError extends Error {
+  constructor(
+    message: string,
+    readonly retrySelection: RetrySelectionReport,
+  ) {
+    super(message)
+    this.name = "SceneRetrySelectionError"
+  }
 }
 
 export async function runSceneEmbeddingBackfill(
@@ -225,9 +273,19 @@ export async function runSceneEmbeddingBackfill(
     input.locales && input.locales.length > 0 ? new Set(input.locales) : null
 
   const allTargets = await stepEnumerateTargets(coreIdsFilter, mapping)
-  const targets = localeFilter
+  const broadTargets = localeFilter
     ? allTargets.filter((t) => localeFilter.has(t.locale))
     : allTargets
+  const retrySelection = reconcileRetryTargets(broadTargets, input.retryTargets)
+  if (retrySelection && retrySelection.unmatched > 0) {
+    throw new SceneRetrySelectionError(
+      `Scene retry selector mismatch: ${retrySelection.unmatched} of ${retrySelection.requested} requested retry targets no longer match current enumeration`,
+      retrySelection,
+    )
+  }
+  const targets = retrySelection
+    ? applyRetrySelection(broadTargets, input.retryTargets ?? [])
+    : broadTargets
 
   // Group flat targets by (video, edition) so the artifact load
   // collapses from per-target to per-group.
@@ -303,6 +361,7 @@ export async function runSceneEmbeddingBackfill(
         target,
         locale: target.locale,
         reason,
+        failureCategory: classifySceneFailure(result.reason),
         durationMs,
       }
       logOutcome(synthetic)
@@ -315,6 +374,7 @@ export async function runSceneEmbeddingBackfill(
     targets: targets.length,
     localeFilter:
       input.locales && input.locales.length > 0 ? input.locales : null,
+    retrySelection,
     outcomes,
   })
 }
@@ -524,6 +584,7 @@ async function processGroup(group: BackfillGroup): Promise<BackfillOutcome[]> {
             target,
             locale: target.locale,
             reason,
+            failureCategory: classifySceneFailure(error),
             durationMs,
           }
       logOutcome(outcome)
@@ -594,9 +655,71 @@ async function stepIndexEditionLocale(
       target,
       locale: target.locale,
       reason,
+      failureCategory: classifySceneFailure(error),
       durationMs,
     }
   }
+}
+
+function retryTargetKey(target: SceneEmbeddingRetryTarget): string {
+  return `${target.coreId}::${target.videoEditionId}::${target.locale}`
+}
+
+function dedupeRetryTargets(
+  retryTargets: readonly SceneEmbeddingRetryTarget[],
+): SceneEmbeddingRetryTarget[] {
+  const byKey = new Map<string, SceneEmbeddingRetryTarget>()
+  for (const target of retryTargets) {
+    const key = retryTargetKey(target)
+    if (!byKey.has(key)) byKey.set(key, target)
+  }
+  return [...byKey.values()].sort((a, b) =>
+    retryTargetKey(a).localeCompare(retryTargetKey(b)),
+  )
+}
+
+function reconcileRetryTargets(
+  targets: readonly BackfillTarget[],
+  retryTargets: readonly SceneEmbeddingRetryTarget[] | undefined,
+): RetrySelectionReport | null {
+  if (retryTargets === undefined) return null
+  const available = new Set(
+    targets.map((target) =>
+      retryTargetKey({
+        coreId: target.coreId,
+        videoEditionId: target.videoEditionId,
+        locale: target.locale,
+      }),
+    ),
+  )
+  const deduped = dedupeRetryTargets(retryTargets)
+  const unmatchedRetryTargets = deduped.filter(
+    (target) => !available.has(retryTargetKey(target)),
+  )
+  return {
+    requested: deduped.length,
+    matched: deduped.length - unmatchedRetryTargets.length,
+    unmatched: unmatchedRetryTargets.length,
+    unmatchedRetryTargets,
+  }
+}
+
+function applyRetrySelection(
+  targets: readonly BackfillTarget[],
+  retryTargets: readonly SceneEmbeddingRetryTarget[],
+): BackfillTarget[] {
+  const requested = new Set(
+    dedupeRetryTargets(retryTargets).map(retryTargetKey),
+  )
+  return targets.filter((target) =>
+    requested.has(
+      retryTargetKey({
+        coreId: target.coreId,
+        videoEditionId: target.videoEditionId,
+        locale: target.locale,
+      }),
+    ),
+  )
 }
 
 /**
@@ -635,10 +758,117 @@ function deriveMissingArtifacts(
   return Array.from(byAssetId.values()).sort((a, b) => a.assetId - b.assetId)
 }
 
+function deriveGroupedFailures(
+  outcomes: readonly BackfillOutcome[],
+): GroupedSceneFailure[] {
+  const byKey = new Map<
+    string,
+    { failure: GroupedSceneFailure; locales: Set<string> }
+  >()
+  for (const outcome of outcomes) {
+    if (outcome.status !== "failed") continue
+    const key = `${outcome.target.cmsVideoId}::${outcome.target.videoEditionId}::${outcome.failureCategory}`
+    let entry = byKey.get(key)
+    if (!entry) {
+      entry = {
+        failure: {
+          assetId: outcome.target.cmsVideoId,
+          coreId: outcome.target.coreId,
+          videoEditionId: outcome.target.videoEditionId,
+          category: outcome.failureCategory,
+          count: 0,
+          sampleReason: outcome.reason,
+          sampleLocales: [],
+        },
+        locales: new Set<string>(),
+      }
+      byKey.set(key, entry)
+    }
+    entry.failure = { ...entry.failure, count: entry.failure.count + 1 }
+    if (entry.locales.size < 5) entry.locales.add(outcome.locale)
+  }
+
+  return [...byKey.values()]
+    .map(({ failure, locales }) => ({
+      ...failure,
+      sampleLocales: [...locales].sort(),
+    }))
+    .sort(
+      (a, b) =>
+        a.assetId - b.assetId ||
+        a.videoEditionId.localeCompare(b.videoEditionId) ||
+        a.category.localeCompare(b.category),
+    )
+}
+
+function classifySceneFailure(error: unknown): SceneFailureCategory {
+  if (error instanceof ManagerArtifactError) {
+    if (error.code === "artifact_invalid") return "artifact_invalid"
+    if (error.code === "artifact_read_failed") {
+      return classifySceneFailure(error.cause ?? error.message)
+    }
+  }
+  const name = getStringProp(error, "name")
+  const code = getStringProp(error, "code") ?? getStringProp(error, "Code")
+  const message = error instanceof Error ? error.message : String(error)
+  const lower = message.toLowerCase()
+
+  if (
+    code === "ENOTFOUND" ||
+    code === "EAI_AGAIN" ||
+    lower.includes("getaddrinfo enotfound")
+  ) {
+    return "dns_failed"
+  }
+  if (
+    name === "TimeoutError" ||
+    name === "AbortError" ||
+    code === "ETIMEDOUT" ||
+    lower.includes("timeout") ||
+    lower.includes("timed out")
+  ) {
+    return "timeout"
+  }
+  if (
+    name === "AccessDenied" ||
+    code === "AccessDenied" ||
+    lower.includes("accessdenied") ||
+    lower.includes("access denied")
+  ) {
+    return "access_denied"
+  }
+  if (
+    name === "NoSuchBucket" ||
+    code === "NoSuchBucket" ||
+    lower.includes("nosuchbucket")
+  ) {
+    return "bucket_not_found"
+  }
+  if (lower.includes("artifact_read_failed")) return "artifact_read_failed"
+  if (lower.includes("artifact_invalid")) return "artifact_invalid"
+  if (lower.includes("p1017") || lower.includes("p2028")) {
+    return "prisma_transaction"
+  }
+  if (
+    lower.includes("embedding response validation failed") ||
+    lower.includes("provider validation")
+  ) {
+    return "provider_validation"
+  }
+  return "other"
+}
+
+function getStringProp(error: unknown, prop: string): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined
+  const value = (error as Record<string, unknown>)[prop]
+  return typeof value === "string" ? value : undefined
+}
+
 function stepReport(args: {
   mappingGeneratedAt: string
   targets: number
   localeFilter: readonly string[] | null
+  retrySelection: RetrySelectionReport | null
   outcomes: BackfillOutcome[]
 }): SceneEmbeddingBackfillReport {
   let succeeded = 0
@@ -675,6 +905,8 @@ function stepReport(args: {
     skipped,
     failed,
     missingArtifacts: deriveMissingArtifacts(args.outcomes),
+    retrySelection: args.retrySelection,
+    groupedFailures: deriveGroupedFailures(args.outcomes),
   }
 }
 
@@ -773,4 +1005,8 @@ export const _internals = {
   toSucceeded,
   logOutcome,
   groupTargetsByVideoEdition,
+  reconcileRetryTargets,
+  applyRetrySelection,
+  classifySceneFailure,
+  deriveGroupedFailures,
 }

--- a/docs/plans/2026-05-20-001-fix-scene-embedding-retry-recovery-plan.md
+++ b/docs/plans/2026-05-20-001-fix-scene-embedding-retry-recovery-plan.md
@@ -1,0 +1,397 @@
+---
+title: "fix: Recover failed production scene embedding backfill"
+type: fix
+status: complete
+date: 2026-05-20
+origin: docs/roadmap/content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md
+---
+
+# fix: Recover failed production scene embedding backfill
+
+## Summary
+
+Recover the failed production scene embedding backfill without rerunning the full 202,504-target corpus blindly. The plan adds a fail-fast manager-artifact S3 preflight, exact retry selectors for failed scene targets from the prior report/log, and operator-friendly failure projections so the retry can be scoped to the ~928 failed groups instead of the whole catalog.
+
+---
+
+## Problem Frame
+
+The completed production scene embedding report shows `totalTargets=202504`, `succeeded=40568`, `skipped=4139`, and `failed=157797`. Follow-up analysis found the dominant failure was not Prisma or OpenRouter: roughly 155k per-locale outcomes failed because admin could not resolve manager artifact storage at `t3.storageapi.dev` while reading `{assetId}/scene-analysis.json`.
+
+The backfill grouped work correctly, but the final report is per target/locale. One transient artifact-read outage therefore exploded into a frightening failure count across many locales. Railway now resolves and reaches the endpoint, so the right recovery is a focused retry after preflight, not another full-catalog run.
+
+---
+
+## Requirements
+
+- R1. Before any long scene embedding run, including `--pipeline=scene` and `--pipeline=both`, the admin CLI can fail fast when manager artifact storage or admin mapping storage is misconfigured, unreachable, or returning infrastructure errors.
+- R2. A scene retry can be built from the previous `run-embeds.complete` report and target only failed scene outcomes.
+- R3. Retry selectors can narrow to exact `(coreId, videoEditionId, locale)` targets so a retry does not reprocess unrelated editions/locales for the same core ID.
+- R4. The retry preserves the existing one-artifact-read-per-`(video, edition)` grouping behavior.
+- R5. Operator reports distinguish grouped artifact read failures from per-locale failures so future incidents are readable at the asset/group level.
+- R6. Missing artifacts remain `skipped`/operator-enrichment work; transient DNS, timeout, auth, invalid artifact, Prisma, and provider failures remain failed/retry or fix work.
+- R7. Production retry operations save report artifacts under `.tmp/prod-embeds/` and never print secrets.
+- R8. Exact retry runs reconcile requested selectors against current enumeration and surface `requested`, `matched`, and `unmatched` counts so stale reports cannot silently under-run.
+
+### Traceability to `feat-125`
+
+- The origin ticket calls for batching, previews/status counts, retryable failure capture, and an audit trail for manager enrichment and embed-readiness operations. R1, R5, and R7 are the recovery-local version of those operator-safety requirements for the scene embed backfill.
+- The origin ticket’s production-smoke criterion says prior missing/failed artifacts should become successful embeds after the right upstream state exists. R2, R3, R4, and R8 make that smoke possible without rerunning unrelated catalog rows.
+- R6 preserves the origin ticket’s separation between validation failures that require upstream data fixes and retryable dispatch/runtime failures.
+- This plan intentionally does not build the full admin UI from `feat-125`; it creates the CLI/workflow safety slice needed to recover the current production incident.
+
+---
+
+## Scope Boundaries
+
+- Do not kill or mutate any completed prior backfill process.
+- Do not automatically trigger manager enrichment from inside the embed workflow.
+- Do not rerun all scene targets as the default recovery path.
+- Do not expose new retry selectors through GraphQL in this pass. If implementation proves the retry must be run from a server/API context rather than the operator CLI, stop and create a follow-up plan/ticket instead of expanding this PR.
+- Do not change scene embedding vector generation semantics, OpenRouter model choice, pgvector write shape, or search ranking behavior.
+- Do not treat `VALIDATION_FAILED` manager enrichment items as retryable; missing mux/subtitle dispatch fields remain separate upstream data work.
+
+### Deferred to Follow-Up Work
+
+- Full admin UI for full-catalog manager enrichment remains owned by `feat-125`.
+- A recurring Railway-hosted embed worker or durable job runner is separate from this local/operator CLI recovery.
+- Automatic scene retry scheduling after manager enrichment completes should be planned separately if operators want closed-loop orchestration.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/scripts/run-embeds.ts` already owns the operator CLI, `--report-out`, `--core-id`, `--locale`, structured events, SIGTERM handling, and final `run-embeds.complete` JSON.
+- `apps/admin/src/scripts/trigger-enrichment.ts` provides the report-consumer pattern: `--from-report`, strict JSON parse, dedupe, stable sorting, and mutually exclusive manual/report inputs.
+- `apps/admin/src/workflows/sceneEmbeddingBackfill.ts` enumerates targets, filters by core ID/locale, groups by `(videoId, videoEditionId)`, reads one scene-analysis artifact per group, and emits per-locale outcomes.
+- `apps/admin/src/services/manager-artifacts.service.ts` wraps artifact storage errors into `ManagerArtifactError` with `artifact_missing`, `artifact_invalid`, or `artifact_read_failed`.
+- `apps/admin/src/storage/s3.ts` cleanly separates admin storage (`RAILWAY_S3_*`) from manager artifact storage (`MANAGER_ARTIFACTS_S3_*`) and already uses bounded S3 request timeouts.
+- `apps/admin/src/services/core-id-mapping.service.ts` has a useful mapping error taxonomy and key-prefix guard to mirror in preflight reporting.
+- `apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts` already proves grouping, artifact-missing cascade, non-missing failure cascade, synthetic failure isolation, and `missingArtifacts` projection behavior.
+
+### Institutional Learnings
+
+- `docs/solutions/platform/local-embed-pipeline-pattern-20260429.md` establishes local/operator embed CLI posture and the rule that manager artifacts are read live from manager S3.
+- `docs/solutions/best-practices/per-parent-child-memoization-loadedartifact-pattern-20260505.md` explains why scene artifact reads are group-scoped, not locale-scoped.
+- `docs/solutions/best-practices/workflow-report-operator-actionable-projection-pattern-20260506.md` supports adding operator projections that collapse noisy per-target outcomes into actionable lists.
+- `docs/solutions/runtime-errors/aws-s3-nosuchkey-classification-pattern-20260506.md` is the precedent for typed storage error classification instead of message-only regex checks.
+- `docs/solutions/best-practices/parallel-workflow-error-robustness-20260420.md` is the robustness pattern for bounded parallel work plus per-target isolation.
+
+### External References
+
+- External research skipped. The needed patterns are already local: AWS/S3 classification, Railway-safe operator CLI reports, workflow grouping, and bounded retry behavior.
+
+---
+
+## Key Technical Decisions
+
+- Add preflight as an explicit CLI/workflow-adjacent service, not as ad hoc shell checks. This makes the guard testable and reusable by future full-catalog enrichment surfaces.
+- Keep exact retry selectors inside the scene workflow input rather than forcing the CLI to decompose them into broad `--core-id` and `--locale` filters. Broad filters would reprocess unrelated editions.
+- Parse prior `run-embeds.complete` reports first, and support log-derived retry sets only as a fallback. The report has the full target object; logs are missing `videoId` and `cmsVideoId`.
+- Preserve existing group execution. Filtering happens before `groupTargetsByVideoEdition`, so a focused retry still reads each scene artifact once per failed group.
+- Add new report projections rather than changing `BackfillOutcome` shape incompatibly. The per-target outcome contract is already consumed by tests and operator logs; grouped projections should be additive. If reliable categorization requires more than reason-string inspection, add an additive normalized failure category at outcome creation time.
+- Treat GraphQL/API parity as follow-up work, not an implementation escape hatch. This recovery is CLI-first so it avoids schema/codegen churn and limits blast radius.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this become a new roadmap ticket? No. `feat-125` already owns full-catalog manager enrichment and recovery-oriented operator tooling; this plan is a focused recovery slice under that context.
+- Should retry be full catalog? No. The prior report/log has enough information to retry exact failed targets/groups.
+- Should manager be changed for the scene embedding retry? No for this recovery. Manager enrichment and missing mux/subtitle validation are separate from admin’s transient artifact-read failure.
+
+### Deferred to Implementation
+
+- Exact preflight classification names may be adjusted to match the most ergonomic test fixtures, but they should preserve the operator categories in this plan.
+- Whether log-derived retry input is worth implementing in the same PR depends on report quality in `prod-scene-report.json`; report-derived retry is the required path.
+- Whether preflight sample artifact miss is blocking should be controlled by mode: infrastructure failures block; a sample `artifact_missing` should warn unless the operator explicitly requires that asset to exist.
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+flowchart TD
+  A["Operator starts scene retry from prior report"] --> B["Parse failed scene outcomes"]
+  B --> C["Build exact target allowlist"]
+  C --> D["Run preflight"]
+  D --> E{"Infrastructure OK?"}
+  E -- "No" --> F["Exit before enumerating/indexing"]
+  E -- "Yes" --> G["Enumerate normal scene targets"]
+  G --> H["Apply exact retry allowlist"]
+  H --> I["Group by video + edition"]
+  I --> J["Read one manager artifact per group"]
+  J --> K["Index selected locales"]
+  K --> L["Write final report + grouped failure projections"]
+```
+
+---
+
+## Implementation Units
+
+### U1. Manager Artifact Preflight
+
+**Goal:** Add a reusable preflight that verifies admin can safely start a long scene embedding run before it enumerates and indexes targets.
+
+**Requirements:** R1, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `apps/admin/src/services/manager-artifacts-preflight.service.ts`
+- Create: `apps/admin/src/services/manager-artifacts-preflight.service.test.ts`
+- Modify: `apps/admin/src/storage/s3.ts`
+- Modify: `apps/admin/src/scripts/run-embeds.ts`
+- Test: `apps/admin/src/storage/s3.manager-artifacts-backend.test.ts`
+
+**Approach:**
+
+- Introduce a preflight result shape with `ok`, `checks`, `status`, `reason`, `retryable`, and sanitized `message`.
+- Check manager artifact env presence and admin mapping env presence without printing values.
+- Add storage-level helpers, if needed, for cheap manager/admin bucket reachability checks using existing S3 client configuration and timeout discipline.
+- Call `loadCoreIdMapping(mappingS3Key)` as part of preflight so mapping key rejection, missing mapping, invalid mapping, and read failures are caught before the main run.
+- Parse retry/report inputs before preflight when `--from-report` is present, so one failed report item can provide the sample `cmsVideoId`/asset ID for an optional artifact read.
+- When no retry/report sample is available, run bucket/config/mapping preflight only; do not enumerate the whole target set just to find a sample.
+- Optionally read one sample scene-analysis artifact through `readSceneAnalysisArtifact` when a sample target is available; classify `artifact_missing` as a warning unless strict mode is requested.
+- Wire every scene-including CLI invocation (`--pipeline=scene` and `--pipeline=both`) to run preflight by default, with an explicit escape hatch only if implementation determines local tests need it.
+
+**Execution note:** Start with classification tests for DNS/timeout/auth/bucket failures before wiring the CLI.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/core-id-mapping.service.ts` error taxonomy.
+- `apps/admin/src/services/manager-artifacts.service.ts` typed error wrapping.
+- `apps/admin/src/storage/s3.manager-artifacts-backend.test.ts` env isolation and S3 client assertions.
+
+**Test scenarios:**
+
+- Happy path: manager artifact env and admin mapping env are present, bucket reachability succeeds, mapping loads, and preflight returns `ok: true`.
+- Error path: `getaddrinfo ENOTFOUND` from manager artifact storage returns a failed `dns_failed` check and prevents the run from continuing.
+- Error path: Smithy timeout returns a retryable timeout check and prevents the run.
+- Error path: `AccessDenied` returns an auth/config failure, not `artifact_missing`.
+- Error path: `NoSuchBucket` returns a bucket/config failure, not `artifact_missing`.
+- Error path: invalid mapping key returns `mapping_key_rejected` before indexing.
+- Edge case: sample artifact returns typed `NoSuchKey`; preflight records a warning/skippable check rather than treating the whole infrastructure as broken.
+- Edge case: no sample target is available; preflight still validates env, bucket reachability, and mapping without attempting an artifact read.
+- Integration: `run-embeds --pipeline=scene` exits before `runSceneEmbeddingBackfill` when preflight is not ok.
+- Integration: `run-embeds --pipeline=both` also runs scene preflight before entering the scene branch.
+
+**Verification:**
+
+- A storage outage is visible as a preflight failure before target enumeration.
+- No preflight output includes S3 credentials, DB URLs, OpenRouter keys, workflow keys, or Railway tokens.
+
+### U2. Exact Scene Retry Selectors
+
+**Goal:** Allow the scene backfill to retry exactly the failed targets from a previous report.
+
+**Requirements:** R2, R3, R4, R7, R8
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/workflows/sceneEmbeddingBackfill.ts`
+- Modify: `apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts`
+- Modify: `apps/admin/src/scripts/run-embeds.ts`
+- Modify: `apps/admin/src/scripts/run-embeds.test.ts`
+
+**Approach:**
+
+- Extend `SceneEmbeddingBackfillInput` with an optional exact target allowlist keyed by `coreId`, `videoEditionId`, and `locale`.
+- Apply the allowlist after normal `stepEnumerateTargets` and before `groupTargetsByVideoEdition`.
+- Reconcile requested selectors against the enumerated target set and include `retrySelection` metadata in the report: requested count, matched count, unmatched count, and a sanitized `unmatchedRetryTargets` list.
+- Fail closed by default when any retry selector is unmatched. If implementation adds an override, the override must be explicit and visible in the final report.
+- Add `run-embeds --from-report=<path>` for scene retry mode, mirroring `trigger-enrichment.ts`.
+- Extract only `reports.scene.outcomes[]` where `status === "failed"` by default.
+- Deduplicate exact target keys and sort deterministically.
+- Make `--from-report` valid only with `--pipeline=scene` for this recovery pass. `--pipeline=both --from-report` should be rejected so a scene retry report cannot accidentally drive transcript work.
+- Make `--from-report` mutually exclusive with broad manual scene filters unless implementation finds a safe composition rule.
+- Keep transcript and experience behavior unchanged.
+
+**Execution note:** Add workflow filtering tests before CLI parsing so selector semantics are pinned independently of file parsing.
+
+**Patterns to follow:**
+
+- `apps/admin/src/scripts/trigger-enrichment.ts` report parser and config error style.
+- `apps/admin/src/workflows/sceneEmbeddingBackfill.ts` existing `coreIds` and `locales` filter flow.
+- `apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts` grouping and artifact-read count tests.
+
+**Test scenarios:**
+
+- Happy path: a report with two failed scene outcomes produces two exact retry selectors.
+- Happy path: multiple failed locales in the same edition are grouped into one artifact read and multiple locale index attempts.
+- Edge case: a failed core ID with two editions retries only the failed `videoEditionId`, not every edition for the core ID.
+- Edge case: duplicate failed outcomes in the report dedupe to one selector.
+- Edge case: an empty failed set exits with a clear CLI config error rather than running the full catalog.
+- Edge case: stale `videoEditionId` from an old report is reported in `unmatchedRetryTargets` and blocks the retry by default.
+- Edge case: locale no longer enumerates for a previously failed edition is reported as unmatched and blocks by default.
+- Edge case: mapping/core ID drift that prevents a selector from matching is reported as unmatched and blocks by default.
+- Error path: malformed JSON report exits with code 2 and a sanitized message.
+- Error path: report missing `reports.scene.outcomes` exits with code 2.
+- Error path: `--pipeline=both --from-report=<path>` exits with code 2.
+- Integration: retry allowlist preserves `Promise.allSettled` per-group isolation and synthetic failed cascade behavior.
+
+**Verification:**
+
+- The operator can point `run-embeds` at `prod-scene-report.json` and produce a retry report covering only failed scene targets.
+- Existing `--core-id` and `--locale` behavior remains unchanged when `--from-report` is omitted.
+
+### U3. Grouped Failure Projections
+
+**Goal:** Make future scene reports explain infrastructure failures at the group/asset level instead of forcing operators to infer the root cause from thousands of per-locale failures.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** U2
+
+**Files:**
+
+- Modify: `apps/admin/src/workflows/sceneEmbeddingBackfill.ts`
+- Modify: `apps/admin/src/workflows/sceneEmbeddingBackfill.test.ts`
+
+**Approach:**
+
+- Add an additive report projection for grouped scene failures, separate from `missingArtifacts`.
+- Derive the projection from failed outcomes, grouped by `cmsVideoId`/asset ID, `coreId`, `videoEditionId`, and normalized reason category.
+- Prefer recording a normalized failure category at outcome creation time while typed/cause information is still available. Use conservative reason-string inspection only as a fallback for older reports or synthetic failures.
+- Classify common categories such as `artifact_read_failed`, `artifact_invalid`, `dns_failed`, `timeout`, `access_denied`, `bucket_not_found`, `prisma_transaction`, `provider_validation`, and `other`.
+- Keep `missingArtifacts` unchanged and fed only by skipped `artifact_missing` outcomes.
+- Include counts per group and representative locales so operators can see blast radius without reading every outcome.
+
+**Execution note:** Characterize the current report shape first; add the projection as additive JSON only.
+
+**Patterns to follow:**
+
+- `deriveMissingArtifacts` in `apps/admin/src/workflows/sceneEmbeddingBackfill.ts`.
+- `docs/solutions/best-practices/workflow-report-operator-actionable-projection-pattern-20260506.md`.
+
+**Test scenarios:**
+
+- Happy path: many per-locale `artifact_read_failed` outcomes for one asset collapse into one grouped failure with the correct count.
+- Happy path: Prisma `P1017` and `P2028` outcomes classify as `prisma_transaction`.
+- Happy path: OpenRouter response validation failures classify as provider validation.
+- Happy path: `getaddrinfo ENOTFOUND`, Smithy timeout, `AccessDenied`, and `NoSuchBucket` classify distinctly while enough typed error context is still available.
+- Edge case: failed outcomes are excluded from `missingArtifacts`.
+- Edge case: skipped `artifact_missing` outcomes are excluded from grouped failures.
+- Error path: unknown reason text classifies as `other` without throwing.
+
+**Verification:**
+
+- Future reports can answer “how many assets/groups failed and why?” without a separate ad hoc log parser.
+
+### U4. Operator Recovery Runbook
+
+**Goal:** Document the safe production recovery path so the retry can be run repeatably and audited.
+
+**Requirements:** R1, R2, R6, R7
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+
+- Create: `docs/solutions/runtime-errors/manager-artifact-dns-outage-scene-backfill-retry-20260520.md`
+- Modify: `apps/admin/CLAUDE.md`
+- Modify: `docs/roadmap/content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md`
+
+**Approach:**
+
+- Document the root cause: transient manager artifact S3 DNS/transport failure during a local prod backfill, amplified by per-locale reporting.
+- Record the recovery procedure: preflight, extract failed retry set, run focused retry, save report under `.tmp/prod-embeds/`, inspect grouped failures, then decide whether any manager enrichment is needed.
+- Clarify that manager enrichment retry applies to missing/validation cases, not to admin artifact-read outages.
+- Keep secrets guidance explicit: Railway tokens, DB URLs, S3 credentials, workflow keys, and provider keys never appear in logs or reports.
+- If touching `feat-125`, update only the parts relevant to recovery/preflight; do not expand into the full UI build.
+
+**Test scenarios:**
+
+- Test expectation: none -- documentation-only unit.
+
+**Verification:**
+
+- A future operator can recover from the same failure class without relying on this chat history.
+
+### U5. Production Retry Execution Plan
+
+**Goal:** Define the post-merge operational sequence for the actual failed scene retry.
+
+**Requirements:** R2, R3, R4, R5, R7, R8
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+
+- No code files; produces runtime artifacts under `.tmp/prod-embeds/` during execution.
+
+**Approach:**
+
+- Run the new preflight against production admin env and manager artifact storage.
+- Generate the retry set from `.tmp/prod-embeds/prod-scene-report.json`.
+- Start a focused scene retry with a new report path under `.tmp/prod-embeds/`, preserving production DB/S3/OpenRouter env handling.
+- Monitor logs for grouped failure categories and OpenRouter/Prisma residuals.
+- After completion, run final prod DB counts for scene, transcript, and experience embeddings.
+- Retry only residual transient categories if the report shows a small count and preflight remains healthy.
+
+**Test scenarios:**
+
+- Test expectation: none -- this is an operational run sequence after code verification, not a unit-testable code path.
+
+**Verification:**
+
+- The focused retry materially reduces or clears the `artifact_read_failed`/DNS failure set.
+- Any remaining failures are small, categorized, and actionable.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The main interaction remains operator CLI -> admin workflow -> manager artifact S3 -> OpenRouter -> admin Postgres. Manager runtime does not become part of the scene embedding execution path.
+- **Error propagation:** Infrastructure failures should stop at preflight; per-target failures still flow into outcomes and additive grouped projections.
+- **State lifecycle risks:** Retrying is idempotent because scene embedding writes already upsert by stable scene/locale keys. Partial retry completion remains resumable.
+- **API surface parity:** CLI gets retry selectors for this recovery. GraphQL/admin UI parity is deferred to `feat-125` or a follow-up plan if a server/API path becomes necessary.
+- **Integration coverage:** Unit tests cover selection and classification; the final confidence comes from a small production preflight plus focused retry report.
+- **Unchanged invariants:** No automatic enrichment, no vector leakage in GraphQL schema, no direct browser-to-manager secret exposure, no changes to generated GraphQL outputs unless GraphQL scope is intentionally expanded.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                | Mitigation                                                                                                 |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Preflight sample artifact is missing even though storage is healthy | Treat `artifact_missing` as warning by default; hard-fail only infrastructure/config/invalid cases.        |
+| Report-derived retry accidentally runs full catalog                 | Make empty/malformed retry set a config error; keep `--from-report` mutually exclusive with broad filters. |
+| Exact retry selector misses targets because report shape drifts     | Validate report shape and fail closed with a clear parser error.                                           |
+| DNS outage recurs mid-run after preflight passes                    | Grouped failure projection makes the recurrence obvious; retry remains resumable and scoped.               |
+| OpenRouter or Prisma residual failures remain                       | Categorize them separately and retry only the small residual set after artifact-read failures are cleared. |
+| Roadmap ticket is currently untracked/dirty in this workspace       | Keep this plan as the durable source; update roadmap status only when implementing in a clean scoped PR.   |
+
+---
+
+## Documentation / Operational Notes
+
+- The prior final scene report is `.tmp/prod-embeds/prod-scene-report.json`.
+- Save retry reports under `.tmp/prod-embeds/` with timestamped names.
+- Do not print Railway tokens, S3 credentials, DB URLs, workflow keys, OpenRouter keys, or signed URLs.
+- Before retrying, confirm Railway production `@forge/admin` and `@forge/manager` remain deployed on the expected merge commit and that manager artifact storage resolves from the runtime.
+
+---
+
+## Sources & References
+
+- Origin ticket: `docs/roadmap/content-discovery/feat-125-admin-full-catalog-manager-enrichment-trigger.md`
+- Prior classification/enrichment ticket: `docs/roadmap/content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md`
+- Prior plan: `docs/plans/2026-05-05-001-feat-embed-backfill-classification-and-enrichment-trigger-plan.md`
+- CLI producer: `apps/admin/src/scripts/run-embeds.ts`
+- CLI report consumer pattern: `apps/admin/src/scripts/trigger-enrichment.ts`
+- Scene workflow: `apps/admin/src/workflows/sceneEmbeddingBackfill.ts`
+- Manager artifact reader: `apps/admin/src/services/manager-artifacts.service.ts`
+- Storage boundary: `apps/admin/src/storage/s3.ts`
+- Mapping loader: `apps/admin/src/services/core-id-mapping.service.ts`
+- Local embed pattern: `docs/solutions/platform/local-embed-pipeline-pattern-20260429.md`
+- Operator projection pattern: `docs/solutions/best-practices/workflow-report-operator-actionable-projection-pattern-20260506.md`

--- a/docs/plans/2026-05-20-fix-manager-admin-video-lookup-timeout-plan.md
+++ b/docs/plans/2026-05-20-fix-manager-admin-video-lookup-timeout-plan.md
@@ -1,0 +1,130 @@
+---
+title: Fix Manager Admin Video Lookup Timeout
+type: fix
+status: completed
+date: 2026-05-20
+---
+
+# Fix Manager Admin Video Lookup Timeout
+
+## Summary
+
+Reduce the admin `videosByCoreIds` lookup latency used by manager enrichment dispatch so transcript retries do not fail at manager's 10 second admin-fetch timeout. Keep the manager/admin trigger contract unchanged and make the fix observable with a slow-lookup breadcrumb.
+
+## Problem Frame
+
+Production enrichment retries showed manager returning 502 after roughly 10010ms while admin GraphQL logged aborted `videosByCoreIds` requests near 9975ms. The trigger path needs only primary-language dispatch fields, but admin was loading full relation graphs for every video in the batch before filtering in application code.
+
+## Requirements
+
+- R1. Preserve the existing `videosByCoreIds` response contract for manager enrichment dispatch.
+- R2. Avoid loading all dubs/subtitles relation rows for each requested core ID.
+- R3. Preserve missing-artifact behavior: absent mux asset IDs or subtitle URLs still surface as null fields.
+- R4. Add regression coverage that proves the lookup uses a targeted projection and keeps existing normalization rules.
+- R5. Add a production-safe breadcrumb for slow lookups without printing secrets.
+
+## Scope Boundaries
+
+- Do not change manager enrichment job semantics, queue behavior, or retry batch policy in this fix.
+- Do not backfill missing mux/subtitle data; validation failures from missing media metadata remain separate data follow-up.
+- Do not change scene embedding retry behavior or the admin embedding pipelines.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/services/video.service.ts` owns `getByCoreIds`, the service method behind admin GraphQL `videosByCoreIds`.
+- `apps/admin/src/services/video.service.test.ts` contains feat-125 manager admin-trigger lookup coverage.
+- `apps/manager/src/lib/admin-video-lookup.ts` sets the manager admin lookup timeout and reports admin lookup failures back to trigger routes.
+- `apps/admin/src/services/manager-trigger.service.ts` converts manager HTTP failures into `DISPATCH_FAILED` trigger report items.
+
+## Key Technical Decisions
+
+- Use a single SQL projection for enrichment dispatch fields: the trigger needs video ID, core ID, label, primary language, primary-language mux asset ID, and primary-language subtitle URL, not the full Prisma relation graph.
+- Keep the raw SQL inside `VideoService.getByCoreIds`: this preserves the GraphQL/service contract and avoids widening manager coupling to admin persistence details.
+- Prefer the same subtitle selection score as the old implementation: primary subtitles first, then non-AI over AI when possible.
+
+## Implementation Units
+
+### U1. Replace Relation-Graph Lookup With Targeted Projection
+
+**Goal:** Query only the fields manager needs for enrichment dispatch.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/admin/src/services/video.service.ts`
+- Test: `apps/admin/src/services/video.service.test.ts`
+
+**Approach:**
+
+- Replace the Prisma `video.findMany(...include...)` relation graph load with a `$queryRaw` projection.
+- Use `LEFT JOIN LATERAL` subqueries to pick at most one primary-language mux asset and one primary-language subtitle per video.
+- Keep soft-delete and empty-string filtering in SQL so missing artifact fields remain null.
+
+**Execution note:** Characterization-first: preserve the existing test cases for null/empty mux and subtitle values, label normalization, cap validation, and duplicate input handling.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/video.service.test.ts` existing feat-125 tests.
+
+**Test scenarios:**
+
+- Happy path: fully populated row returns the same dispatch fields as before.
+- Edge case: no primary language, no mux asset, or no subtitle returns null fields.
+- Edge case: empty mux asset ID and empty subtitle URL normalize to missing.
+- Regression: service does not call `video.findMany` for `getByCoreIds` and the SQL includes targeted `video_dub` and `video_subtitle` projections.
+
+**Verification:**
+
+- Admin service tests pass for `video.service.test.ts`.
+
+### U2. Add Slow Lookup Breadcrumb
+
+**Goal:** Make future production latency regressions visible without exposing secrets.
+
+**Requirements:** R5
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/services/video.service.ts`
+- Test: `apps/admin/src/services/video.service.test.ts`
+
+**Approach:**
+
+- Measure wall-clock duration around the targeted lookup.
+- Emit a concise warning only when duration crosses a small threshold, including core ID count and duration only.
+
+**Test scenarios:**
+
+- Test expectation: none for logger timing; this is a diagnostic breadcrumb and the existing behavior contract remains covered by service tests.
+
+**Verification:**
+
+- Typecheck and lint pass with the new helper.
+
+## System-Wide Impact
+
+- **Interaction graph:** Admin GraphQL `videosByCoreIds` remains the manager lookup endpoint; manager route contracts do not change.
+- **Error propagation:** Faster admin lookup should reduce manager 502 timeout failures; real missing media metadata still returns validation failures.
+- **State lifecycle risks:** Read-only query; no writes or migrations.
+- **API surface parity:** Response shape is unchanged.
+
+## Risks & Dependencies
+
+| Risk                                        | Mitigation                                                                                             |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Raw SQL drifts from Prisma schema names     | Cover query shape in tests and keep table/column names aligned with `apps/admin/prisma/schema.prisma`. |
+| Subtitle/mux selection changes subtly       | Preserve primary-language filtering and subtitle preference scoring from the old service behavior.     |
+| Timeout failures continue for another cause | Slow-lookup breadcrumb narrows whether admin lookup latency is still the bottleneck after deploy.      |
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/services/video.service.test.ts src/graphql/schema.test.ts`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`

--- a/docs/solutions/runtime-errors/manager-artifact-storage-dns-scene-backfill-retry-20260520.md
+++ b/docs/solutions/runtime-errors/manager-artifact-storage-dns-scene-backfill-retry-20260520.md
@@ -1,0 +1,86 @@
+---
+title: "Manager artifact storage DNS outage: recover scene embedding backfills with exact retries"
+tags:
+  - admin
+  - embeddings
+  - manager-artifacts
+  - production-recovery
+  - s3
+---
+
+# Manager artifact storage DNS outage: recover scene embedding backfills with exact retries
+
+## Symptom
+
+A production scene embedding backfill can finish with a huge `failed`
+count even though the embedding/indexing code is mostly healthy. In
+the May 2026 prod run, the final report showed `202504` total targets,
+`40568` succeeded, `4139` skipped, and `157797` failed. The scary
+number came from per-locale outcome fan-out: one transient manager
+artifact storage read outage affected many `(videoEdition, locale)`
+targets.
+
+## Root Cause
+
+Admin does not own the upstream scene-analysis artifact. The R1 scene
+embed workflow reads manager's `{assetId}/scene-analysis.json`, then
+admin regenerates text embeddings and writes them to admin Postgres.
+
+When manager artifact storage DNS/transport fails, the workflow cannot
+read the shared artifact for a `(video, edition)` group. That single
+group-level read failure cascades to every locale in the group as a
+failed outcome. This is different from `artifact_missing`, which means
+manager has not produced the artifact yet and should remain a skipped
+upstream enrichment gap.
+
+## Fix Pattern
+
+Add three operator-safety layers:
+
+1. Run a preflight before scene-including `run-embeds` work:
+   admin object storage reachability, manager artifact storage
+   reachability, core-id mapping load, and optionally one sample
+   scene-analysis artifact read from a retry report.
+2. Retry from the previous report with exact
+   `(coreId, videoEditionId, locale)` selectors using
+   `--pipeline=scene --from-report=<path>`.
+3. Keep grouped failure projections in the report so operators can see
+   asset/edition/category counts instead of reading every per-locale
+   failure.
+
+## Recovery Command
+
+```bash
+DATABASE_URL='postgresql://forge:forge@db:5432/forge_admin' \
+pnpm --filter @forge/admin run-embeds \
+  --pipeline=scene \
+  --from-report=.tmp/prod-embeds/prod-scene-report.json \
+  --report-out=.tmp/prod-embeds/prod-scene-retry-$(date +%Y%m%d%H%M%S).json
+```
+
+Use the production DB URL only when the intent is a production retry.
+Do not print DB URLs, Railway tokens, S3 credentials, workflow keys, or
+provider keys in logs or reports.
+
+## Read The Result
+
+- `retrySelection.requested`: deduped failed selectors parsed from the
+  prior report.
+- `retrySelection.matched`: selectors still present in current admin
+  enumeration.
+- `retrySelection.unmatched`: stale selectors. Default behavior is to
+  fail closed so an old report cannot silently under-run.
+- `groupedFailures[].category`: the operator action bucket, such as
+  `dns_failed`, `timeout`, `access_denied`, `bucket_not_found`,
+  `prisma_transaction`, `provider_validation`, `artifact_invalid`, or
+  `other`.
+- `missingArtifacts`: only upstream artifacts manager has not produced
+  yet. These are enrichment-trigger work, not embed retry failures.
+
+## Operational Rule
+
+Do not blindly rerun the full scene corpus after a transient storage
+outage. First verify preflight passes, then retry exact failed targets
+from the final report. If grouped failures still show storage
+transport categories, pause and check Railway/storage health before
+starting another long run.


### PR DESCRIPTION
## Summary

- Replaces the admin `videosByCoreIds` relation-graph load with a targeted SQL projection for manager enrichment dispatch fields.
- Runs that projection inside a short transaction with an 8s Postgres `statement_timeout` and a 9s Prisma transaction timeout, below manager's 10s admin-fetch budget.
- Keeps the manager/admin trigger contract unchanged while avoiding loading every dub/subtitle row for each requested video.
- Adds slow and failed lookup breadcrumbs for production debugging without logging core IDs, DB URLs, tokens, or provider secrets.
- Removes the stale CMS/Strapi lookup comment.
- Adds the CE plan at `docs/plans/2026-05-20-fix-manager-admin-video-lookup-timeout-plan.md`.

## Root Cause

Manager transcript enrichment retries were failing with 502s at roughly 10010ms because manager aborts its admin GraphQL video lookup at 10s. Admin GraphQL was logging matching 499s near 9975ms, consistent with manager canceling `videosByCoreIds` before admin completed the lookup.

The expensive part was `VideoService.getByCoreIds`: it loaded full Prisma relation graphs for videos, dubs, mux videos, subtitles, and languages, then selected the primary-language mux/subtitle in application code. The dispatch path only needs six fields, so this PR makes admin fetch exactly those fields and bounds the DB work if the query ever regresses.

## Compound Engineering Review

Ran CE-style multi-agent review against PR #985. Findings fixed in the follow-up commit:

- Added DB-side timeout protection so Postgres does not continue running the lookup beyond manager's request budget.
- Added sanitized failure logging for lookup errors/timeouts, not only slow successful lookups.
- Added tests asserting the transaction timeout, statement timeout, and sanitized failure breadcrumb.

Residual advisory: a DB-backed SQL smoke/performance test would be stronger than the current mocked unit tests. This PR keeps the production fix focused; post-deploy monitoring will tell us whether composite/partial indexes are needed.

## Testing

- `PATH=/Users/nisalcottingham/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @forge/admin test -- src/services/video.service.test.ts src/graphql/schema.test.ts src/services/manager-trigger.service.test.ts src/graphql/mutations/manager-enrichment.test.ts`
- `PATH=/Users/nisalcottingham/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @forge/admin test -- src/services/video.service.test.ts`
- `PATH=/Users/nisalcottingham/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @forge/admin typecheck`
- `PATH=/Users/nisalcottingham/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @forge/admin lint`

## Post-Deploy Monitoring & Validation

Validation window: first production enrichment retry after deploy, owned by the operator running the retry.

Watch Railway production logs for `@forge/admin` and `@forge/manager`.

Healthy signals:
- Manager `/api/admin-trigger/transcript` requests complete well below the 10s admin lookup timeout.
- Admin logs do not show `POST /api/graphql 499` clustered around manager transcript trigger requests.
- Admin slow lookup breadcrumbs are absent or rare: `[videosByCoreIds] event=lookup.slow`.
- Admin failed lookup breadcrumbs are absent: `[videosByCoreIds] event=lookup.failed`.
- Retry batches return mostly `STARTED` or true `VALIDATION_FAILED` missing-artifact outcomes, not `DISPATCH_FAILED remote_5xx`.

Failure signals:
- Manager still returns 502 around 10010ms.
- Admin emits repeated `[videosByCoreIds] event=lookup.slow` warnings near or above 8s.
- Admin emits `[videosByCoreIds] event=lookup.failed` with timeout/Prisma error codes during retry batches.
- Admin GraphQL continues logging 499s for `videosByCoreIds` during trigger batches.

Mitigation trigger:
- If 8s/10s timeout failures continue after deploy, pause transcript retry batches and capture `EXPLAIN (ANALYZE, BUFFERS)` for the new query against a representative 100-coreId batch; consider a follow-up migration with composite/partial indexes on `video_dub` and `video_subtitle`.

🤖 Compound Engineered with Codex
