### PR TITLE
Fix manager admin lookup tail latency

### DIFF
--- a/apps/admin/src/app/api/manager/videos-by-core-ids/route.test.ts
+++ b/apps/admin/src/app/api/manager/videos-by-core-ids/route.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const isValidWorkflowBearerMock = vi.fn()
+const getByCoreIdsMock = vi.fn()
+
+vi.mock("@/auth/workflow-bearer", () => ({
+  isValidWorkflowBearer: isValidWorkflowBearerMock,
+}))
+
+vi.mock("@/db/client", () => ({
+  prisma: {},
+}))
+
+vi.mock("@/services", () => ({
+  createServices: () => ({
+    video: {
+      getByCoreIds: getByCoreIdsMock,
+    },
+  }),
+}))
+
+const { POST, GET } = await import("./route")
+
+function request(body: unknown, headers: HeadersInit = {}) {
+  return new Request("http://admin.test/api/manager/videos-by-core-ids", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("POST /api/manager/videos-by-core-ids", () => {
+  beforeEach(() => {
+    isValidWorkflowBearerMock.mockReset()
+    getByCoreIdsMock.mockReset()
+    isValidWorkflowBearerMock.mockReturnValue(true)
+    getByCoreIdsMock.mockResolvedValue([
+      {
+        id: "v-1",
+        coreId: "core-1",
+        label: "featureFilm",
+        primaryLanguageBcp47: "en",
+        muxAssetId: "mux-1",
+        subtitleUrl: "https://example.test/subtitles.vtt",
+      },
+    ])
+  })
+
+  it("returns dispatch fields for a valid workflow bearer", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const response = await POST(
+      request(
+        { coreIds: ["core-1"] },
+        { authorization: "Bearer workflow-key" },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      videos: [
+        {
+          id: "v-1",
+          coreId: "core-1",
+          label: "featureFilm",
+          primaryLanguageBcp47: "en",
+          muxAssetId: "mux-1",
+          subtitleUrl: "https://example.test/subtitles.vtt",
+        },
+      ],
+    })
+    expect(isValidWorkflowBearerMock).toHaveBeenCalledWith(
+      "Bearer workflow-key",
+    )
+    expect(getByCoreIdsMock).toHaveBeenCalledWith({ coreIds: ["core-1"] })
+    expect(warn.mock.calls[0][0]).toContain("event=rest_lookup.complete")
+    expect(warn.mock.calls[0][0]).not.toContain("workflow-key")
+    warn.mockRestore()
+  })
+
+  it("rejects missing or invalid bearer without invoking the service", async () => {
+    isValidWorkflowBearerMock.mockReturnValue(false)
+
+    const response = await POST(request({ coreIds: ["core-1"] }))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: "Authorization required",
+    })
+    expect(getByCoreIdsMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed coreIds before invoking the service", async () => {
+    const response = await POST(request({ coreIds: ["core-1", 2] }))
+
+    expect(response.status).toBe(400)
+    expect(getByCoreIdsMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects more than 100 coreIds before invoking the service", async () => {
+    const response = await POST(
+      request({
+        coreIds: Array.from({ length: 101 }, (_, i) => `core-${i}`),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(getByCoreIdsMock).not.toHaveBeenCalled()
+  })
+
+  it("returns a typed 502 envelope on service failure without leaking the error message", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    getByCoreIdsMock.mockRejectedValueOnce(new Error("secret failure detail"))
+
+    const response = await POST(request({ coreIds: ["core-1"] }))
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toEqual({
+      error: "Lookup failed",
+      reason: "lookup_failed",
+      retryable: true,
+    })
+    expect(warn.mock.calls[0][0]).toContain("event=rest_lookup.failed")
+    expect(warn.mock.calls[0][0]).toContain("errorName=Error")
+    expect(warn.mock.calls[0][0]).not.toContain("secret failure detail")
+    expect(warn.mock.calls[0][0]).not.toContain("core-1")
+    warn.mockRestore()
+  })
+
+  it("GET returns 401", async () => {
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+  })
+})

--- a/apps/admin/src/app/api/manager/videos-by-core-ids/route.ts
+++ b/apps/admin/src/app/api/manager/videos-by-core-ids/route.ts
@@ -1,0 +1,95 @@
+// Server-to-server dispatch-field lookup for apps/manager.
+//
+// This route mirrors the data returned by GraphQL `videosByCoreIds`
+// while bypassing GraphQL/Yoga middleware for the hot manager
+// enrichment-trigger path. Auth reuses admin's WORKFLOW_API_KEYS
+// bearer allowlist via `isValidWorkflowBearer`; no browser caller
+// should hit this route directly.
+
+import { isValidWorkflowBearer } from "@/auth/workflow-bearer"
+import { prisma } from "@/db/client"
+import { createServices } from "@/services"
+import {
+  VideoLookupValidationError,
+  VIDEOS_BY_CORE_IDS_MAX,
+} from "@/services/video.service"
+
+type VideosByCoreIdsBody = {
+  coreIds?: unknown
+}
+
+function unauthorized(): Response {
+  return Response.json({ error: "Authorization required" }, { status: 401 })
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isValidWorkflowBearer(request.headers.get("authorization"))) {
+    return unauthorized()
+  }
+
+  let body: VideosByCoreIdsBody
+  try {
+    body = (await request.json()) as VideosByCoreIdsBody
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  if (
+    !Array.isArray(body.coreIds) ||
+    !body.coreIds.every((coreId) => typeof coreId === "string")
+  ) {
+    return Response.json(
+      { error: "Validation failed", details: "coreIds must be string[]" },
+      { status: 400 },
+    )
+  }
+
+  if (body.coreIds.length > VIDEOS_BY_CORE_IDS_MAX) {
+    return Response.json(
+      {
+        error: "Validation failed",
+        details: `coreIds.length exceeds max ${VIDEOS_BY_CORE_IDS_MAX}`,
+      },
+      { status: 400 },
+    )
+  }
+
+  const startedAt = Date.now()
+  try {
+    const videos = await createServices(prisma).video.getByCoreIds({
+      coreIds: body.coreIds,
+    })
+    console.warn(
+      `[videosByCoreIds] event=rest_lookup.complete coreIdCount=${body.coreIds.length} rowCount=${videos.length} durationMs=${Date.now() - startedAt}`,
+    )
+    return Response.json({ videos }, { status: 200 })
+  } catch (error) {
+    const errorName = error instanceof Error ? error.name : "UnknownError"
+    const maybeCode = (error as { code?: unknown } | null)?.code
+    const errorCode =
+      typeof maybeCode === "string" ? ` errorCode=${maybeCode}` : ""
+    console.warn(
+      `[videosByCoreIds] event=rest_lookup.failed coreIdCount=${body.coreIds.length} durationMs=${Date.now() - startedAt} errorName=${errorName}${errorCode}`,
+    )
+
+    if (error instanceof VideoLookupValidationError) {
+      return Response.json(
+        { error: "Validation failed", details: error.message },
+        { status: 400 },
+      )
+    }
+
+    return Response.json(
+      {
+        error: "Lookup failed",
+        reason: "lookup_failed",
+        retryable: true,
+      },
+      { status: 502 },
+    )
+  }
+}
+
+export async function GET(): Promise<Response> {
+  return unauthorized()
+}

--- a/apps/admin/src/services/video.service.test.ts
+++ b/apps/admin/src/services/video.service.test.ts
@@ -400,5 +400,36 @@ describe("VideoService", () => {
 
       warn.mockRestore()
     })
+
+    it("logs slow lookup phase timings without coreIds or secrets", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(10)
+        .mockReturnValueOnce(20)
+        .mockReturnValueOnce(820)
+        .mockReturnValueOnce(820)
+        .mockReturnValueOnce(900)
+      prisma.tx.$queryRaw.mockResolvedValueOnce([rowFixture()])
+
+      await service.getByCoreIds({ coreIds: ["core-1"] })
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("event=lookup.slow"),
+      )
+      const message = warn.mock.calls[0][0]
+      expect(message).toContain("coreIdCount=1")
+      expect(message).toContain("rowCount=1")
+      expect(message).toMatch(/durationMs=\d+/)
+      expect(message).toMatch(/transactionDurationMs=\d+/)
+      expect(message).toMatch(/sqlDurationMs=\d+/)
+      expect(message).not.toContain("core-1")
+      expect(message).not.toContain("Bearer ")
+      expect(message).not.toContain("DATABASE_URL")
+
+      now.mockRestore()
+      warn.mockRestore()
+    })
   })
 })

--- a/apps/admin/src/services/video.service.ts
+++ b/apps/admin/src/services/video.service.ts
@@ -137,13 +137,17 @@ export class VideoService {
     }
 
     let rows: VideoForEnrichmentRow[]
+    let transactionDurationMs: number | null = null
+    let sqlDurationMs: number | null = null
     const startedAt = Date.now()
     try {
       rows = await this.prisma.$transaction(
         async (tx) => {
+          const transactionStartedAt = Date.now()
           await tx.$executeRawUnsafe(VIDEOS_BY_CORE_IDS_STATEMENT_TIMEOUT_SQL)
 
-          return tx.$queryRaw<VideoForEnrichmentRow[]>`
+          const sqlStartedAt = Date.now()
+          const result = await tx.$queryRaw<VideoForEnrichmentRow[]>`
             SELECT
               v.id,
               v.core_id AS "coreId",
@@ -192,6 +196,9 @@ export class VideoService {
             WHERE v.core_id IN (${Prisma.join([...coreIds])})
               AND v.deleted_at IS NULL
           `
+          sqlDurationMs = Date.now() - sqlStartedAt
+          transactionDurationMs = Date.now() - transactionStartedAt
+          return result
         },
         { timeout: VIDEOS_BY_CORE_IDS_TRANSACTION_TIMEOUT_MS },
       )
@@ -199,7 +206,11 @@ export class VideoService {
       logVideoLookupFailure(coreIds.length, Date.now() - startedAt, error)
       throw error
     }
-    logSlowVideoLookup(coreIds.length, Date.now() - startedAt)
+    logSlowVideoLookup(coreIds.length, Date.now() - startedAt, {
+      rowCount: rows.length,
+      transactionDurationMs,
+      sqlDurationMs,
+    })
 
     return rows.map((video): VideoForEnrichment => {
       return {
@@ -224,10 +235,18 @@ export class VideoService {
 
 type VideoForEnrichmentRow = VideoForEnrichment
 
-function logSlowVideoLookup(coreIdCount: number, durationMs: number): void {
+function logSlowVideoLookup(
+  coreIdCount: number,
+  durationMs: number,
+  details: {
+    rowCount: number
+    transactionDurationMs: number | null
+    sqlDurationMs: number | null
+  },
+): void {
   if (durationMs < 500) return
   console.warn(
-    `[videosByCoreIds] event=lookup.slow coreIdCount=${coreIdCount} durationMs=${durationMs}`,
+    `[videosByCoreIds] event=lookup.slow coreIdCount=${coreIdCount} rowCount=${details.rowCount} durationMs=${durationMs} transactionDurationMs=${formatMetric(details.transactionDurationMs)} sqlDurationMs=${formatMetric(details.sqlDurationMs)}`,
   )
 }
 
@@ -239,6 +258,10 @@ function logVideoLookupFailure(
   console.warn(
     `[videosByCoreIds] event=lookup.failed coreIdCount=${coreIdCount} durationMs=${durationMs} ${formatLookupError(error)}`,
   )
+}
+
+function formatMetric(value: number | null): string {
+  return value == null ? "unknown" : String(value)
 }
 
 function formatLookupError(error: unknown): string {

--- a/apps/manager/src/lib/admin-video-lookup.test.ts
+++ b/apps/manager/src/lib/admin-video-lookup.test.ts
@@ -50,12 +50,10 @@ describe("admin-video-lookup", () => {
     it("returns ok:true with Map keyed by coreId", async () => {
       fetchSpy.mockResolvedValueOnce(
         jsonResponse({
-          data: {
-            videosByCoreIds: [
-              FIXTURE_ROW,
-              { ...FIXTURE_ROW, id: "v-2", coreId: "core-2" },
-            ],
-          },
+          videos: [
+            FIXTURE_ROW,
+            { ...FIXTURE_ROW, id: "v-2", coreId: "core-2" },
+          ],
         }),
       )
 
@@ -68,10 +66,8 @@ describe("admin-video-lookup", () => {
       expect(result.data.get("core-2")?.id).toBe("v-2")
     })
 
-    it("sends bearer + GraphQL POST shape", async () => {
-      fetchSpy.mockResolvedValueOnce(
-        jsonResponse({ data: { videosByCoreIds: [] } }),
-      )
+    it("sends bearer + REST POST shape derived from ADMIN_GRAPHQL_URL", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ videos: [] }))
 
       await lookupVideosByCoreIdFromAdmin(["core-1"])
 
@@ -80,18 +76,65 @@ describe("admin-video-lookup", () => {
         string,
         { headers: Record<string, string>; body: string; method: string },
       ]
-      expect(url).toBe("https://admin.example/api/graphql")
+      expect(url).toBe("https://admin.example/api/manager/videos-by-core-ids")
       expect(init.method).toBe("POST")
       expect(init.headers).toMatchObject({
         authorization: "Bearer test-key",
         "content-type": "application/json",
       })
       const parsed = JSON.parse(init.body) as {
-        query: string
-        variables: { coreIds: string[] }
+        coreIds: string[]
       }
-      expect(parsed.variables.coreIds).toEqual(["core-1"])
-      expect(parsed.query).toContain("videosByCoreIds")
+      expect(parsed.coreIds).toEqual(["core-1"])
+    })
+
+    it("falls back to GraphQL when the derived REST route is not deployed yet", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ error: "Not Found" }, 404))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: {
+              videosByCoreIds: [FIXTURE_ROW],
+            },
+          }),
+        )
+
+      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error("expected ok envelope")
+      expect(result.data.get("core-1")).toEqual(FIXTURE_ROW)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      expect(fetchSpy.mock.calls[0][0]).toBe(
+        "https://admin.example/api/manager/videos-by-core-ids",
+      )
+      expect(fetchSpy.mock.calls[1][0]).toBe(
+        "https://admin.example/api/graphql",
+      )
+    })
+
+    it("falls back to GraphQL when missing REST route returns non-JSON 404", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(
+          new Response("<!DOCTYPE html><html>not found</html>", {
+            status: 404,
+            headers: { "content-type": "text/html" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: {
+              videosByCoreIds: [FIXTURE_ROW],
+            },
+          }),
+        )
+
+      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error("expected ok envelope")
+      expect(result.data.get("core-1")).toEqual(FIXTURE_ROW)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
     })
 
     it("returns an empty Map without making a fetch call when coreIds is empty", async () => {
@@ -101,10 +144,8 @@ describe("admin-video-lookup", () => {
       expect(fetchSpy).not.toHaveBeenCalled()
     })
 
-    it("returns an empty Map (no fetch) when admin returns no rows", async () => {
-      fetchSpy.mockResolvedValueOnce(
-        jsonResponse({ data: { videosByCoreIds: [] } }),
-      )
+    it("returns an empty Map when admin returns no rows", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ videos: [] }))
 
       const result = await lookupVideosByCoreIdFromAdmin(["core-missing"])
 
@@ -229,12 +270,83 @@ describe("admin-video-lookup", () => {
   })
 
   describe("graphql_error", () => {
-    it("envelope when payload.errors is non-empty", async () => {
+    it("envelope when REST payload is missing videos", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ data: {} }))
+
+      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "graphql_error",
+        retryable: false,
+      })
+    })
+
+    it("envelope when REST videos is null", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ videos: null }))
+
+      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "graphql_error",
+        retryable: false,
+      })
+    })
+
+    it("envelope when REST videos is not an array", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ videos: {} }))
+
+      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "graphql_error",
+        retryable: false,
+      })
+      if (result.ok) throw new Error("unreachable")
+      expect(result.messages[0]).toContain("invalid video rows")
+    })
+
+    it("envelope when REST row is missing coreId", async () => {
+      const rowWithoutCoreId = { ...FIXTURE_ROW } as Partial<typeof FIXTURE_ROW>
+      delete rowWithoutCoreId.coreId
       fetchSpy.mockResolvedValueOnce(
-        jsonResponse({
-          errors: [{ message: "Forbidden" }],
-        }),
+        jsonResponse({ videos: [rowWithoutCoreId] }),
       )
+
+      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "graphql_error",
+        retryable: false,
+      })
+    })
+
+    it("envelope on non-2xx REST response", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ error: "Lookup failed", retryable: true }, 502),
+      )
+
+      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "graphql_error",
+        retryable: true,
+        httpStatus: 502,
+      })
+    })
+
+    it("GraphQL fallback envelope when payload.errors is non-empty", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ error: "Not Found" }, 404))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            errors: [{ message: "Forbidden" }],
+          }),
+        )
 
       const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
 
@@ -247,8 +359,18 @@ describe("admin-video-lookup", () => {
       expect(result.messages).toContain("Forbidden")
     })
 
-    it("envelope when payload is missing data.videosByCoreIds", async () => {
-      fetchSpy.mockResolvedValueOnce(jsonResponse({ data: {} }))
+    it("GraphQL fallback envelope when returned row is missing coreId", async () => {
+      const rowWithoutCoreId = { ...FIXTURE_ROW } as Partial<typeof FIXTURE_ROW>
+      delete rowWithoutCoreId.coreId
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({ error: "Not Found" }, 404))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: {
+              videosByCoreIds: [rowWithoutCoreId],
+            },
+          }),
+        )
 
       const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
 
@@ -257,35 +379,8 @@ describe("admin-video-lookup", () => {
         reason: "graphql_error",
         retryable: false,
       })
-    })
-
-    it("envelope when data.videosByCoreIds is null", async () => {
-      fetchSpy.mockResolvedValueOnce(
-        jsonResponse({ data: { videosByCoreIds: null } }),
-      )
-
-      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
-
-      expect(result).toMatchObject({
-        ok: false,
-        reason: "graphql_error",
-        retryable: false,
-      })
-    })
-
-    it("envelope on non-2xx response (treats body as JSON if parseable but flags non-2xx as graphql_error)", async () => {
-      fetchSpy.mockResolvedValueOnce(
-        jsonResponse({ errors: [{ message: "Internal" }] }, 503),
-      )
-
-      const result = await lookupVideosByCoreIdFromAdmin(["core-1"])
-
-      expect(result).toMatchObject({
-        ok: false,
-        reason: "graphql_error",
-        retryable: false,
-        httpStatus: 503,
-      })
+      if (result.ok) throw new Error("unreachable")
+      expect(result.messages[0]).toContain("invalid video rows")
     })
   })
 })

--- a/apps/manager/src/lib/admin-video-lookup.ts
+++ b/apps/manager/src/lib/admin-video-lookup.ts
@@ -1,10 +1,11 @@
-// Manager → admin GraphQL lookup for video dispatch fields (feat-125).
+// Manager → admin lookup for video dispatch fields (feat-125 / feat-126).
 //
 // Replaces the Apollo-to-Strapi query that lived in
-// `admin-trigger-route.ts::lookupVideosByCoreId`. Mirrors the
-// `admin-embed-trigger.ts` shape verbatim — bearer + 15s
-// AbortSignal.timeout + discriminated AdminVideoLookupEnvelope — so
-// the failure-mode contract is identical to the inverse direction.
+// `admin-trigger-route.ts::lookupVideosByCoreId`. Prefer the narrow
+// admin REST route because production debugging showed GraphQL/Yoga
+// request-path tail latency even though the underlying SQL projection
+// was fast. Keep GraphQL as a deploy-order fallback when the REST
+// route is not present yet.
 //
 // Why fetch instead of Apollo: the existing `cms/client.ts` Apollo
 // singleton is bound to Strapi's GraphQL surface + STRAPI_API_TOKEN;
@@ -14,11 +15,13 @@
 //
 // Env (validated at module load via @/config/env):
 //   - ADMIN_GRAPHQL_URL          full URL of admin's /api/graphql
+//                                (REST lookup URL is derived from it)
 //   - ADMIN_EMBED_TRIGGER_API_KEY  matches one of admin's WORKFLOW_API_KEYS
 //
 // The bearer key is reused from the inverse direction (no new env
 // coordination) — admin's WORKFLOW_TRIGGER allowlist (feat-125) now
-// grants `read:video-metadata` to the same set of keys.
+// grants `read:video-metadata` to the same set of keys. The REST route
+// accepts the same bearer via admin's WORKFLOW_API_KEYS allowlist.
 //
 // Failure shape: every non-ok variant carries `messages: string[]` +
 // `retryable: boolean` so the caller in `admin-trigger-route.ts` can
@@ -72,7 +75,7 @@ export type AdminVideoLookupEnvelope =
       reason: "graphql_error"
       messages: string[]
       httpStatus: number
-      retryable: false
+      retryable: boolean
     }
   | {
       ok: false
@@ -101,6 +104,18 @@ const VIDEOS_BY_CORE_IDS_QUERY = /* GraphQL */ `
   }
 `
 
+type RestLookupBody = {
+  videos?: unknown
+  error?: string
+  details?: string
+  reason?: string
+  retryable?: boolean
+}
+
+type LookupRowsResult =
+  | { ok: true; rows: VideoForEnrichment[] }
+  | Extract<AdminVideoLookupEnvelope, { reason: "graphql_error" }>
+
 /**
  * Batched coreId → dispatch-fields lookup against admin's
  * `videosByCoreIds` query. Returns a discriminated envelope; never
@@ -127,6 +142,8 @@ export async function lookupVideosByCoreIdFromAdmin(
       retryable: false,
     }
   }
+  const adminGraphqlUrl = env.ADMIN_GRAPHQL_URL
+  const adminEmbedTriggerApiKey = env.ADMIN_EMBED_TRIGGER_API_KEY
 
   // Empty input is cheap to short-circuit after the config check —
   // skip the network round-trip but only once the operator has
@@ -135,13 +152,142 @@ export async function lookupVideosByCoreIdFromAdmin(
     return { ok: true, data: new Map() }
   }
 
+  const restEnvelope = await lookupVideosByCoreIdFromAdminRest(coreIds, {
+    adminGraphqlUrl,
+    adminEmbedTriggerApiKey,
+  })
+  if (restEnvelope.ok || restEnvelope.httpStatus !== 404) {
+    return restEnvelope
+  }
+
+  // Deploy-order fallback: if manager rolls before admin's narrow REST
+  // route exists, keep the original GraphQL contract working. Any other
+  // REST failure should surface directly so operators see the typed
+  // failure rather than hiding it behind a second request.
+  return lookupVideosByCoreIdFromAdminGraphql(coreIds, {
+    adminGraphqlUrl,
+    adminEmbedTriggerApiKey,
+  })
+}
+
+function adminRestLookupUrl(adminGraphqlUrl: string): string {
+  const url = new URL(adminGraphqlUrl)
+  if (url.pathname.endsWith("/api/graphql")) {
+    url.pathname = url.pathname.replace(
+      /\/api\/graphql$/,
+      "/api/manager/videos-by-core-ids",
+    )
+  } else {
+    url.pathname = `${url.pathname.replace(/\/+$/, "")}/api/manager/videos-by-core-ids`
+  }
+  url.search = ""
+  return url.toString()
+}
+
+async function lookupVideosByCoreIdFromAdminRest(
+  coreIds: readonly string[],
+  config: {
+    adminGraphqlUrl: string
+    adminEmbedTriggerApiKey: string
+  },
+): Promise<AdminVideoLookupEnvelope & { httpStatus?: number }> {
   let response: Response
   try {
-    response = await fetch(env.ADMIN_GRAPHQL_URL, {
+    response = await fetch(adminRestLookupUrl(config.adminGraphqlUrl), {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${env.ADMIN_EMBED_TRIGGER_API_KEY}`,
+        authorization: `Bearer ${config.adminEmbedTriggerApiKey}`,
+      },
+      body: JSON.stringify({ coreIds }),
+      signal: AbortSignal.timeout(ADMIN_FETCH_TIMEOUT_MS),
+    })
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : String(error)
+    const isTimeout =
+      error instanceof Error &&
+      (error.name === "TimeoutError" || error.name === "AbortError")
+    return {
+      ok: false,
+      reason: "network_error",
+      messages: [
+        isTimeout
+          ? `admin REST lookup request timed out after ${ADMIN_FETCH_TIMEOUT_MS}ms`
+          : messageText,
+      ],
+      retryable: true,
+    }
+  }
+
+  if (response.status === 404) {
+    return {
+      ok: false,
+      reason: "graphql_error",
+      messages: ["admin REST lookup route was not found"],
+      httpStatus: response.status,
+      retryable: false,
+    }
+  }
+
+  let payload: RestLookupBody
+  try {
+    payload = (await response.json()) as RestLookupBody
+  } catch {
+    return {
+      ok: false,
+      reason: "parse_error",
+      messages: ["admin REST lookup endpoint returned invalid JSON"],
+      httpStatus: response.status,
+      retryable: true,
+    }
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason: "graphql_error",
+      messages: [
+        payload.error ??
+          payload.details ??
+          `admin REST lookup returned status ${response.status}`,
+      ],
+      httpStatus: response.status,
+      retryable: response.status >= 500 && payload.retryable !== false,
+    }
+  }
+
+  const rows = payload.videos
+  if (rows === undefined || rows === null) {
+    return {
+      ok: false,
+      reason: "graphql_error",
+      messages: [
+        `admin REST lookup response missing videos (status ${response.status})`,
+      ],
+      httpStatus: response.status,
+      retryable: false,
+    }
+  }
+  const validatedRows = validateLookupRows(rows, "REST", response.status)
+  if (!validatedRows.ok) return validatedRows
+
+  return { ok: true, data: rowsToMap(validatedRows.rows) }
+}
+
+async function lookupVideosByCoreIdFromAdminGraphql(
+  coreIds: readonly string[],
+  config: {
+    adminGraphqlUrl: string
+    adminEmbedTriggerApiKey: string
+  },
+): Promise<AdminVideoLookupEnvelope> {
+  let response: Response
+  try {
+    response = await fetch(config.adminGraphqlUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${config.adminEmbedTriggerApiKey}`,
       },
       body: JSON.stringify({
         query: VIDEOS_BY_CORE_IDS_QUERY,
@@ -167,7 +313,7 @@ export async function lookupVideosByCoreIdFromAdmin(
   }
 
   let payload: {
-    data?: { videosByCoreIds?: VideoForEnrichment[] | null }
+    data?: { videosByCoreIds?: unknown }
     errors?: Array<{ message: string }>
   }
   try {
@@ -204,10 +350,60 @@ export async function lookupVideosByCoreIdFromAdmin(
       retryable: false,
     }
   }
+  const validatedRows = validateLookupRows(rows, "GraphQL", response.status)
+  if (!validatedRows.ok) return validatedRows
 
+  return { ok: true, data: rowsToMap(validatedRows.rows) }
+}
+
+function rowsToMap(rows: readonly VideoForEnrichment[]) {
   const data = new Map<string, VideoForEnrichment>()
-  for (const row of rows) {
-    data.set(row.coreId, row)
+  for (const row of rows) data.set(row.coreId, row)
+  return data
+}
+
+function validateLookupRows(
+  rows: unknown,
+  source: "REST" | "GraphQL",
+  httpStatus: number,
+): LookupRowsResult {
+  if (!Array.isArray(rows)) {
+    return invalidLookupRows(source, httpStatus)
   }
-  return { ok: true, data }
+
+  if (!rows.every(isVideoForEnrichment)) {
+    return invalidLookupRows(source, httpStatus)
+  }
+
+  return { ok: true, rows }
+}
+
+function invalidLookupRows(
+  source: "REST" | "GraphQL",
+  httpStatus: number,
+): Extract<AdminVideoLookupEnvelope, { reason: "graphql_error" }> {
+  return {
+    ok: false,
+    reason: "graphql_error",
+    messages: [`admin ${source} lookup response had invalid video rows`],
+    httpStatus,
+    retryable: false,
+  }
+}
+
+function isVideoForEnrichment(value: unknown): value is VideoForEnrichment {
+  if (typeof value !== "object" || value === null) return false
+  const row = value as Record<string, unknown>
+  return (
+    typeof row.id === "string" &&
+    typeof row.coreId === "string" &&
+    isNullableString(row.label) &&
+    isNullableString(row.primaryLanguageBcp47) &&
+    isNullableString(row.muxAssetId) &&
+    isNullableString(row.subtitleUrl)
+  )
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string"
 }

--- a/docs/brainstorms/2026-05-20-manager-admin-lookup-tail-latency-requirements.md
+++ b/docs/brainstorms/2026-05-20-manager-admin-lookup-tail-latency-requirements.md
@@ -1,0 +1,119 @@
+---
+date: 2026-05-20
+topic: manager-admin-lookup-tail-latency
+---
+
+# Manager Admin Lookup Tail Latency Recovery
+
+## Summary
+
+Recover the manager enrichment dispatch path by identifying and removing the admin `videosByCoreIds` tail latency that causes manager 502s during transcript retries. The recovery should preserve the existing enrichment contract while making the slow phase visible enough to operate safely in production.
+
+---
+
+## Problem Frame
+
+Production transcript enrichment retries are paused because manager returned Cloudflare 502s from `POST /api/admin-trigger/transcript`. The manager route itself is alive: unauthenticated requests return 401, and one authorized single-item probe returned 200 and started a transcript job.
+
+The fragile part is the authorized route's dependency on admin GraphQL `videosByCoreIds`. That lookup now returns successfully but takes seconds even for small inputs, while direct SQL for the same projection completes in milliseconds. Admin HTTP logs also showed a request abort near 15 seconds, matching the manager/admin timeout envelope. The failure is therefore not missing subtitle/mux data and not a slow SQL scan; it is request-path tail latency above the database query.
+
+---
+
+## Actors
+
+- A1. Operator: triggers and monitors production enrichment recovery.
+- A2. Admin service: resolves dispatch metadata and reports lookup latency.
+- A3. Manager service: validates dispatch fields and schedules transcript or scene-analysis pipelines.
+- A4. Implementing agent: instruments, fixes, verifies, and documents the recovery path without leaking secrets.
+
+---
+
+## Key Flows
+
+- F1. Diagnose lookup latency
+  - **Trigger:** Enrichment retries are paused after manager 502s.
+  - **Actors:** A2, A3, A4
+  - **Steps:** Add scoped timing around admin GraphQL context, auth/rate-limit, resolver, service, transaction, and response path; deploy; inspect production-safe logs.
+  - **Outcome:** The dominant latency phase is known from production evidence, not inferred from wall-clock totals.
+  - **Covered by:** R1, R2, R5
+
+- F2. Recover dispatch
+  - **Trigger:** The latency source is identified and a fix is deployed.
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** Run a small manager lookup probe, then a 10-item transcript retry batch, then resume larger paced batches only if outcomes are healthy.
+  - **Outcome:** Manager dispatch no longer returns Cloudflare 502 for the retry path.
+  - **Covered by:** R3, R4, R6
+
+---
+
+## Requirements
+
+**Observability**
+
+- R1. The admin `videosByCoreIds` path must emit production-visible timing breadcrumbs for the major request phases needed to distinguish GraphQL/runtime overhead from database work.
+- R2. Runtime logs must avoid secrets and use Railway-visible plain-string `event=name key=value` format.
+
+**Recovery Behavior**
+
+- R3. The manager/admin trigger contract must remain backward-compatible: manager continues to return per-item outcomes, and admin continues to classify `STARTED`, `ALREADY_IN_FLIGHT`, `VALIDATION_FAILED`, `NOT_FOUND`, and `DISPATCH_FAILED`.
+- R4. Missing subtitle, mux, or primary-language data must remain `VALIDATION_FAILED`, not be reclassified as retryable transport failure.
+- R5. Timeout budgets must fail in the inner lookup path before the outer admin-to-manager caller aborts, so failures are typed JSON envelopes rather than Cloudflare HTML 502s.
+- R6. Transcript enrichment retries must resume only after a small smoke batch proves the dispatch path no longer returns `remote_5xx`.
+
+**Scope Control**
+
+- R7. The fix must stay focused on manager/admin dispatch lookup latency, not the separate scene embedding Prisma/OpenRouter backfill failures.
+- R8. The fix must not reintroduce manager coupling to CMS for the admin-trigger path.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2.** Given a manager-triggered `videosByCoreIds` request, when it completes, production logs include bounded timing fields for the relevant admin request phases and no raw secrets or core ID lists.
+- AE2. **Covers R3, R4.** Given a video with missing dispatch fields, when manager processes the admin lookup result, the item returns `VALIDATION_FAILED` with the missing field reason and does not become a retryable transport failure.
+- AE3. **Covers R5.** Given admin lookup latency exceeds the inner budget, when manager handles the lookup failure, admin receives a typed manager JSON response before its outer timeout wins.
+- AE4. **Covers R6.** Given the fix is deployed, when a 10-item transcript retry batch runs, it produces no `DISPATCH_FAILED remote_5xx` outcomes before broader retries resume.
+
+---
+
+## Success Criteria
+
+- Operators can tell whether `videosByCoreIds` time is spent in admin request setup, rate limiting, resolver/service code, Prisma/DB acquisition, SQL execution, or response handling.
+- A small production retry batch proves manager dispatch is healthy before any remaining transcript enrichment retries continue.
+- The handoff is concrete enough for `ce:work` to implement without re-deciding the scope or conflating this with scene embedding recovery.
+
+---
+
+## Scope Boundaries
+
+- Do not build the full-catalog admin enrichment dashboard in this recovery fix.
+- Do not change manager pipeline semantics or artifact formats.
+- Do not backfill or repair videos missing mux/subtitle/primary-language dispatch data.
+- Do not resume full retry batches inside this planning/brainstorming work.
+- Do not modify scene embedding retry/backfill behavior.
+
+---
+
+## Key Decisions
+
+- Treat the current issue as request-path tail latency above SQL, because direct prod SQL completes quickly while GraphQL requests take seconds and sometimes abort near the timeout budget.
+- Instrument before replacing the boundary, because the remaining slow phase is not proven and a blind REST bypass could hide rather than solve the underlying runtime problem.
+- Keep a REST bypass as an acceptable follow-up shape if instrumentation shows GraphQL middleware/runtime overhead is the bottleneck.
+
+---
+
+## Dependencies / Assumptions
+
+- PR #985 is already merged and deployed to admin production.
+- Manager's current successful deployment predates the admin lookup fix but is reachable and can process authorized requests.
+- Railway request-path logs are sufficient to confirm high-level HTTP status and duration, but app logs need plain-string formatting to be reliable.
+- The single authorized probe for assetId `662` already started one transcript job and should be considered when choosing future retry inputs.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] Which timing boundaries can be captured with minimal code and without widening public API surface?
+- [Affects R5][Technical] Should the first fix preserve GraphQL and adjust the slow phase, or add a narrow REST lookup after instrumentation proves GraphQL overhead dominates?

--- a/docs/plans/2026-05-20-002-fix-manager-admin-lookup-tail-latency-plan.md
+++ b/docs/plans/2026-05-20-002-fix-manager-admin-lookup-tail-latency-plan.md
@@ -1,0 +1,333 @@
+---
+title: Fix Manager Admin Lookup Tail Latency
+type: fix
+status: completed
+date: 2026-05-20
+origin: docs/brainstorms/2026-05-20-manager-admin-lookup-tail-latency-requirements.md
+roadmap: docs/roadmap/content-discovery/feat-126-manager-admin-lookup-tail-latency-recovery.md
+---
+
+# Fix Manager Admin Lookup Tail Latency
+
+## Summary
+
+Instrument and fix the admin `videosByCoreIds` request path that manager depends on before enrichment dispatch. The plan preserves the existing manager/admin enrichment contract, proves where the latency lives, and resumes production retries only after a small smoke batch no longer returns manager 502s.
+
+---
+
+## Problem Frame
+
+Manager enrichment retries failed with Cloudflare 502s from `POST /api/admin-trigger/transcript`. Debugging showed manager routing is healthy, the authorized path can return 200, and the exact database SQL for `videosByCoreIds` completes quickly in production. The remaining failure mode is tail latency in admin's GraphQL/Prisma/runtime path above SQL, which sometimes reaches the caller timeout envelope and turns into a remote 5xx.
+
+---
+
+## Requirements Trace
+
+- R1, R2: Add production-visible, secret-safe timing breadcrumbs for admin lookup phases.
+- R3, R4: Keep the manager/admin per-item outcome contract and missing-field validation behavior unchanged.
+- R5: Preserve explicit nested timeout budgets so the inner lookup fails before the outer caller aborts.
+- R6: Resume enrichment only after a healthy small-batch smoke.
+- R7, R8: Exclude scene embedding recovery and CMS recoupling.
+
+---
+
+## Context & Research
+
+### Existing Patterns
+
+- `apps/admin/src/services/video.service.ts` already has the targeted SQL projection and slow/failure breadcrumbs, but they only measure the service method wall clock.
+- `apps/admin/src/app/api/graphql/route.ts` mounts GraphQL Yoga with context creation, Armor plugins, introspection, and rate limiting.
+- `apps/admin/src/graphql/context.ts` resolves session/bearer principals and creates per-request loaders/services.
+- `apps/admin/src/graphql/plugins/rate-limit.ts` uses Redis-backed `@envelop/rate-limiter` in production.
+- `apps/manager/src/lib/admin-video-lookup.ts` calls admin GraphQL with a 10 second inner timeout.
+- `apps/admin/src/services/manager-trigger.service.ts` calls manager with a 15 second outer timeout and classifies manager non-2xx responses.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md` requires the inner downstream call budget to be shorter than the upstream caller's timeout.
+- `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md` says Next.js request-path logs should use `[label] event=name key=value`, not JSON-shaped log lines.
+- `docs/solutions/platform/admin-manager-enrichment-trigger-endpoint-20260506.md` documents the existing admin -> manager trigger contract and auth rotation pattern.
+
+### Current Production Evidence
+
+- Unauthenticated manager trigger returns 401, proving routing and service reachability.
+- Authorized single-item trigger returned 200 but took about 8.2 seconds and started one transcript job.
+- Manager -> admin `videosByCoreIds` probes returned 200 but took several seconds for one to ten core IDs.
+- Admin HTTP logs showed `/api/graphql` 499 near 15 seconds.
+- Direct prod Postgres `EXPLAIN ANALYZE` for the exact lookup SQL took about 16ms.
+
+---
+
+## Key Technical Decisions
+
+- **Instrument before bypassing GraphQL.** The SQL is already fast, but the slow phase is not proven. Add timing boundaries first so the fix targets the actual bottleneck.
+- **Keep the public GraphQL contract stable initially.** Manager already consumes `videosByCoreIds`; changing that contract before evidence would widen recovery risk.
+- **Use Railway-visible plain-string logs.** Timing breadcrumbs should be greppable in production and must not include bearer keys, DB URLs, or full core ID lists.
+- **Treat REST bypass as a conditional follow-up.** If instrumentation proves GraphQL middleware/runtime overhead dominates and cannot be cheaply removed, add a narrow server-to-server REST lookup rather than pushing batch retries through a fragile GraphQL path.
+
+---
+
+## High-Level Technical Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```mermaid
+sequenceDiagram
+  participant AdminCLI as "Admin trigger script"
+  participant AdminSvc as "Admin manager-trigger client"
+  participant Manager as "Manager admin-trigger route"
+  participant AdminGQL as "Admin GraphQL videosByCoreIds"
+  participant AdminDB as "Admin Postgres"
+
+  AdminCLI->>AdminSvc: "trigger transcript batch"
+  AdminSvc->>Manager: "POST /api/admin-trigger/transcript"
+  Manager->>AdminGQL: "videosByCoreIds"
+  AdminGQL->>AdminGQL: "timed context/auth/rate-limit/resolver phases"
+  AdminGQL->>AdminDB: "targeted dispatch-fields query"
+  AdminDB-->>AdminGQL: "rows"
+  AdminGQL-->>Manager: "dispatch fields or typed lookup error"
+  Manager-->>AdminSvc: "per-item outcomes"
+```
+
+---
+
+## Implementation Units
+
+### U1. Add Admin Lookup Timing Boundaries
+
+**Goal:** Make the slow phase visible without changing lookup behavior.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/admin/src/app/api/graphql/route.ts`
+- Modify: `apps/admin/src/graphql/context.ts`
+- Modify: `apps/admin/src/graphql/types/video.ts`
+- Modify: `apps/admin/src/services/video.service.ts`
+- Test: `apps/admin/src/graphql/context.test.ts`
+- Test: `apps/admin/src/services/video.service.test.ts`
+
+**Approach:**
+
+- Add timing breadcrumbs that are emitted only for the `videosByCoreIds` operation/path.
+- Capture boundaries around context creation, bearer/session resolution, resolver entry/exit, service entry/exit, transaction start/end, and SQL completion where practical.
+- Keep emitted fields bounded: operation name, core ID count, phase durations, result count, status, and error class/code only.
+- Use `[videosByCoreIds] event=... key=value` style logs rather than JSON strings.
+
+**Execution note:** Characterization-first: add logger-focused tests for emitted shape and redaction before changing production log behavior.
+
+**Patterns to follow:**
+
+- `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`
+- Existing `[videosByCoreIds] event=lookup.slow ...` and `event=lookup.failed ...` helpers in `apps/admin/src/services/video.service.ts`.
+
+**Test scenarios:**
+
+- Happy path: a successful lookup emits timing fields when duration crosses the configured diagnostic threshold.
+- Edge case: empty input does not emit noisy timing logs.
+- Error path: a service exception emits a failure breadcrumb with error class/code but not core IDs or secrets.
+- Redaction: log output does not contain bearer tokens, DB URLs, Railway tokens, or raw authorization headers.
+
+**Verification:**
+
+- Local tests prove the log shape is stable and secret-safe.
+- A production probe produces greppable timing logs for `videosByCoreIds`.
+
+### U2. Identify and Fix the Dominant Slow Phase
+
+**Goal:** Remove the phase responsible for multi-second lookup latency.
+
+**Requirements:** R1, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/app/api/graphql/route.ts` if GraphQL middleware is the slow phase.
+- Modify: `apps/admin/src/graphql/plugins/rate-limit.ts` if rate limiting or Redis access is the slow phase.
+- Modify: `apps/admin/src/graphql/context.ts` if auth/session/context construction is the slow phase.
+- Modify: `apps/admin/src/services/video.service.ts` if Prisma connection acquisition or transaction setup is the slow phase.
+- Test: the matching unit test file for whichever component is changed.
+
+**Approach:**
+
+- Use production timing output from U1 to choose exactly one first fix.
+- If rate limiting dominates, exempt the workflow bearer `videosByCoreIds` lookup from unnecessary limiter overhead or make limiter fallback behavior bounded and observable.
+- If session resolution dominates for bearer-only calls, avoid unnecessary cookie/session verification work when a valid workflow bearer is present and no session cookie is present.
+- If Prisma transaction setup dominates while SQL is fast, evaluate whether `SET LOCAL statement_timeout` plus transaction overhead should be replaced with a lower-overhead query path that still preserves timeout guarantees.
+- If GraphQL/Yoga overhead dominates and local fixes are insufficient, defer to U3 rather than stacking incidental patches.
+
+**Execution note:** One change at a time. After each fix, re-run the production-safe lookup probe before choosing another change.
+
+**Patterns to follow:**
+
+- `docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md`
+- `apps/admin/src/graphql/plugins/rate-limit.test.ts` for rate-limit identity behavior.
+- `apps/admin/src/graphql/context.test.ts` for workflow bearer resolution behavior.
+
+**Test scenarios:**
+
+- Happy path: workflow bearer lookup still authenticates and returns dispatch fields.
+- Error path: downstream Redis/session/Prisma failure is either bounded or classified without leaking secrets.
+- Regression: public/admin-session GraphQL behavior remains unchanged outside the manager lookup path.
+
+**Verification:**
+
+- A manager -> admin 10-coreId lookup probe returns comfortably below the inner timeout budget.
+- Admin logs show the prior dominant phase no longer dominates lookup wall time.
+
+### U3. Add a Narrow REST Lookup Fallback if GraphQL Remains the Bottleneck
+
+**Goal:** Provide a server-to-server lookup path that bypasses GraphQL request overhead while preserving authorization and response shape.
+
+**Requirements:** R1, R3, R4, R5, R8
+
+**Dependencies:** U1, U2 evidence showing GraphQL overhead remains material
+
+**Files:**
+
+- Create or modify: `apps/admin/src/app/api/manager/videos-by-core-ids/route.ts`
+- Modify: `apps/manager/src/lib/admin-video-lookup.ts`
+- Modify: `apps/admin/src/config/env.ts` only if a new URL/env is required.
+- Modify: `apps/manager/src/config/env.ts` only if manager needs a new explicit endpoint env.
+- Test: new admin route test near `apps/admin/src/app/api/manager/videos-by-core-ids/`
+- Test: `apps/manager/src/lib/admin-video-lookup.test.ts`
+
+**Approach:**
+
+- Only implement this unit if U1/U2 prove GraphQL cannot meet the latency budget reliably.
+- Reuse the same workflow bearer trust boundary as GraphQL; do not introduce a browser-callable or unauthenticated path.
+- Reuse `VideoService.getByCoreIds` so the dispatch-field selection semantics stay in one admin service.
+- Return a narrow JSON envelope that manager can classify into the same `AdminVideoLookupEnvelope` success/error cases.
+- Keep the GraphQL query intact for backward compatibility while manager can prefer the REST path.
+
+**Patterns to follow:**
+
+- Existing app route auth and workflow bearer patterns in `apps/admin/src/app/api/workflows/[...workflow]/route.ts`.
+- Existing manager envelope handling in `apps/manager/src/lib/admin-video-lookup.ts`.
+
+**Test scenarios:**
+
+- Happy path: valid workflow bearer returns the same rows as `videosByCoreIds`.
+- Auth failure: missing or wrong bearer returns 401/403 without invoking the service.
+- Validation failure: more than 100 core IDs or malformed input returns a typed client error.
+- Service failure: admin route returns a typed server error manager can classify without producing Cloudflare HTML.
+- Manager preference: manager uses the REST lookup when configured and preserves GraphQL fallback only if intentionally supported.
+
+**Verification:**
+
+- REST lookup probe returns well below the timeout budget.
+- Manager trigger still reports `VALIDATION_FAILED` for missing mux/subtitle rows rather than treating them as transport failures.
+
+### U4. Preserve Timeout Budget Semantics
+
+**Goal:** Ensure failures surface as typed envelopes before the outer caller aborts.
+
+**Requirements:** R5
+
+**Dependencies:** U2 or U3
+
+**Files:**
+
+- Modify: `apps/manager/src/lib/admin-video-lookup.ts`
+- Modify: `apps/admin/src/services/manager-trigger.service.ts` only if outer budget documentation or classification needs adjustment.
+- Test: `apps/manager/src/lib/admin-video-lookup.test.ts`
+- Test: `apps/admin/src/services/manager-trigger.service.test.ts` if admin classification changes.
+
+**Approach:**
+
+- Keep manager's admin lookup timeout comfortably below admin's outbound manager timeout.
+- Ensure timeout, parse, GraphQL, auth, and network failures continue to map to discriminated reasons.
+- Avoid simply raising timeouts to mask the latency; that would recreate the retry-storm risk documented in prior solutions.
+
+**Patterns to follow:**
+
+- `docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md`
+
+**Test scenarios:**
+
+- Timeout path: admin lookup exceeding the inner budget returns `network_error` or the established typed reason before the outer 15 second admin caller timeout.
+- Remote 5xx path: admin returns a server error and manager returns a typed JSON response that admin classifies deterministically.
+- Parse path: invalid JSON from admin remains retryable parse failure.
+
+**Verification:**
+
+- Tests prove the inner lookup failure wins the race.
+- Production logs no longer show `/api/graphql` 499s from manager-triggered lookups during smoke.
+
+### U5. Production Smoke and Retry Resume Plan
+
+**Goal:** Prove the recovery path safely before resuming remaining transcript enrichment.
+
+**Requirements:** R6, R7
+
+**Dependencies:** U2 or U3, U4
+
+**Files:**
+
+- Modify: `docs/plans/2026-05-20-002-fix-manager-admin-lookup-tail-latency-plan.md` only if smoke findings require plan updates.
+- Runtime reports under `.tmp/prod-embeds/` during execution, not committed.
+
+**Approach:**
+
+- Run a direct manager -> admin lookup probe for the known failed 10 core IDs.
+- Run one 10-item transcript retry batch, excluding items whose latest status is already `STARTED`, `ALREADY_IN_FLIGHT`, `VALIDATION_FAILED`, or `NOT_FOUND`.
+- Stop immediately on any `DISPATCH_FAILED remote_5xx`.
+- If the smoke is clean, resume paced 10-item retries and write reports under `.tmp/prod-embeds/`.
+
+**Test scenarios:**
+
+- Test expectation: none in code. This is an operational verification unit using production-safe probes and saved reports.
+
+**Verification:**
+
+- First 10-item retry batch after the fix has zero `DISPATCH_FAILED remote_5xx` outcomes.
+- Reports are saved under `.tmp/prod-embeds/` and summarized without secrets.
+
+---
+
+## System-Wide Impact
+
+- **Admin GraphQL:** gains targeted timing visibility for a service-to-service lookup path.
+- **Manager dispatch:** should stop returning Cloudflare HTML 502 for healthy small batches.
+- **Operational recovery:** transcript retries remain paused until the smoke path is healthy.
+- **Security:** bearer keys and DB URLs remain server-side and must not appear in logs.
+
+---
+
+## Scope Boundaries
+
+- Full-catalog enrichment dashboard work from `feat-125` remains out of this recovery fix.
+- Scene embedding Prisma/OpenRouter backfill failures remain separate.
+- Missing mux/subtitle/primary-language data remains a validation/data-quality follow-up.
+
+### Deferred to Follow-Up Work
+
+- Durable admin-side audit trail for full-catalog enrichment runs.
+- DB-backed manager idempotency if process-local in-flight tracking becomes insufficient.
+- Full-catalog UI for dry-run/preflight/retry orchestration.
+
+---
+
+## Risks & Mitigations
+
+- **Risk:** Instrumentation adds noise or leaks sensitive data.
+  - **Mitigation:** Log only counts, durations, status, and error class/code; unit-test redaction.
+- **Risk:** The first measured bottleneck is intermittent.
+  - **Mitigation:** Use repeated small probes and Railway HTTP duration logs before selecting a code fix.
+- **Risk:** A GraphQL bypass creates contract drift.
+  - **Mitigation:** Reuse `VideoService.getByCoreIds` and keep tests comparing response semantics.
+- **Risk:** Raising timeouts hides the issue.
+  - **Mitigation:** Preserve nested timeout budget discipline and prefer reducing latency over widening budgets.
+
+---
+
+## Verification
+
+- Admin unit tests for timing/redaction and whichever slow phase is fixed.
+- Manager lookup tests for timeout and error-envelope behavior if manager client changes.
+- Production-safe lookup probe for one and ten core IDs.
+- Production-safe 10-item transcript retry smoke with zero `remote_5xx` outcomes before broader retries resume.

--- a/docs/roadmap/content-discovery/feat-126-manager-admin-lookup-tail-latency-recovery.md
+++ b/docs/roadmap/content-discovery/feat-126-manager-admin-lookup-tail-latency-recovery.md
@@ -1,0 +1,79 @@
+---
+id: "feat-126"
+title: "Recover manager enrichment dispatch from admin lookup tail latency"
+owner: "nisal"
+priority: "P0"
+status: "complete"
+start_date: "2026-05-20"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "admin"
+  - "manager"
+  - "ai-pipeline"
+  - "reliability"
+  - "production-recovery"
+---
+
+## Problem
+
+Production transcript enrichment retries are blocked by manager returning Cloudflare 502s from `POST /api/admin-trigger/transcript`.
+
+The manager route is reachable: an unauthenticated probe returns a clean 401, and an authorized single-item probe eventually returned 200 and started one transcript job. The authorized path is still too close to timeout budgets because manager must call admin GraphQL `videosByCoreIds` before dispatching. Debug probes showed:
+
+- manager -> admin `videosByCoreIds` takes multiple seconds even for one to ten core IDs
+- admin HTTP logs showed `/api/graphql` 499 near 15 seconds, matching caller abort behavior
+- direct prod Postgres `EXPLAIN ANALYZE` for the exact lookup SQL completes in milliseconds
+
+This means the remaining bottleneck is above SQL, inside admin's GraphQL/Prisma/runtime request path or its surrounding middleware. Batch enrichment should stay paused until this tail-latency cause is instrumented and fixed.
+
+## Entry Points
+
+1. `apps/admin/src/app/api/graphql/route.ts` — Yoga GraphQL handler and plugin chain.
+2. `apps/admin/src/graphql/context.ts` — per-request context, bearer resolution, service construction.
+3. `apps/admin/src/graphql/plugins/rate-limit.ts` — Redis-backed GraphQL limiter on every operation.
+4. `apps/admin/src/graphql/types/video.ts` — `videosByCoreIds` resolver.
+5. `apps/admin/src/services/video.service.ts` — targeted SQL projection and current slow/failure breadcrumbs.
+6. `apps/manager/src/lib/admin-video-lookup.ts` — manager outbound admin lookup client and timeout budget.
+7. `apps/manager/src/lib/admin-trigger-route.ts` — authorized trigger route using the admin lookup before dispatch.
+8. `apps/admin/src/services/manager-trigger.service.ts` — admin outbound manager client and `DISPATCH_FAILED` classifier.
+
+## Grep These
+
+```
+grep -rn "videosByCoreIds\\|VideoForEnrichment" apps/admin/src apps/manager/src
+grep -rn "lookup.slow\\|lookup.failed" apps/admin/src
+grep -rn "ADMIN_FETCH_TIMEOUT_MS\\|MANAGER_FETCH_TIMEOUT_MS" apps/admin/src apps/manager/src
+grep -rn "rateLimitPlugin\\|createContext" apps/admin/src/graphql apps/admin/src/app/api/graphql
+grep -rn "admin-trigger" apps/manager/src apps/admin/src
+```
+
+## What To Build
+
+Fix the authorized manager enrichment dispatch path so a small transcript retry batch can complete without manager 502s.
+
+The work should:
+
+1. Add production-safe timing breadcrumbs around the admin `videosByCoreIds` request path so operators can see where time is spent.
+2. Preserve the existing manager/admin trigger contract and outcome statuses.
+3. Remove or bypass the latency source once identified.
+4. Keep timeout budgets explicit so manager fails with typed JSON errors before admin's outbound 15 second ceiling.
+5. Verify with a small production-safe retry before resuming larger transcript enrichment batches.
+
+## Constraints
+
+- Do not resume full transcript enrichment retries until the lookup tail-latency cause is fixed or explicitly overridden.
+- Do not print bearer tokens, DB URLs, Railway tokens, or workflow keys in logs or reports.
+- Do not change missing mux/subtitle validation semantics.
+- Do not make manager depend on CMS for this path.
+- Do not hand-edit generated GraphQL type outputs.
+- Prefer plain-string `event=name key=value` logs in request paths; Railway logsV2 may drop JSON-shaped runtime log lines.
+
+## Verification
+
+1. Local tests cover the timing/instrumentation path without leaking secrets.
+2. Production logs show which phase dominates `videosByCoreIds` latency.
+3. After the fix deploys, a manager -> admin 10-coreId lookup returns comfortably below timeout budgets.
+4. A 10-item transcript retry batch returns `STARTED`, `ALREADY_IN_FLIGHT`, or `VALIDATION_FAILED`, not `DISPATCH_FAILED remote_5xx`.
+5. Remaining `DISPATCH_FAILED` items are retried only after the healthy smoke passes.


### PR DESCRIPTION
## Summary
- add a narrow admin REST videos-by-core-ids route for manager enrichment dispatch metadata
- update manager to prefer REST with GraphQL fallback for deploy-order 404s
- add secret-safe timing breadcrumbs for admin video lookup phases
- harden manager response parsing so malformed lookup payloads return typed envelopes instead of throwing

## Validation
- pnpm --filter @forge/manager test -- src/lib/admin-video-lookup.test.ts src/lib/admin-trigger-route.test.ts
- pnpm --filter @forge/admin test -- src/services/video.service.test.ts src/app/api/manager/videos-by-core-ids/route.test.ts
- pnpm --filter @forge/manager typecheck
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/manager lint
- pnpm --filter @forge/admin lint

## Notes
- leaves unrelated dirty roadmap/.codex local files unstaged
- enrichment retries should stay paused until this deploys and a small smoke batch passes