### PR TITLE
feat(auth): register Manager OAuth clients

### DIFF
--- a/apps/auth/src/domain/apps.test.ts
+++ b/apps/auth/src/domain/apps.test.ts
@@ -1,13 +1,56 @@
 import { describe, expect, it } from "vitest"
 
-import { ADMIN_APP_SEED } from "./apps"
+import {
+  ADMIN_APP_SEED,
+  FIRST_PARTY_APP_SEEDS,
+  MANAGER_APP_KEY,
+  MANAGER_APP_SEED,
+} from "./apps"
 
 describe("first-party app seeds", () => {
-  it("registers admin clients for RP-initiated logout", () => {
-    for (const environment of ADMIN_APP_SEED.environments) {
-      expect(environment.postLogoutRedirectUris).toEqual([
-        environment.allowedOrigins[0] + "/api/auth/login",
-      ])
-    }
+  it("keeps Admin and Manager registered as distinct first-party OAuth apps", () => {
+    expect(FIRST_PARTY_APP_SEEDS.map((app) => app.key)).toEqual([
+      ADMIN_APP_SEED.key,
+      MANAGER_APP_KEY,
+    ])
+    expect(MANAGER_APP_SEED).toEqual(
+      expect.objectContaining({
+        key: "manager",
+        displayName: "Jesus Film Manager",
+        trustTier: "first_party",
+        ownerType: "jesus_film",
+      }),
+    )
+  })
+
+  it("registers Manager OAuth clients for local, preview, staging, and production", () => {
+    expect(MANAGER_APP_SEED.environments.map((env) => env.key)).toEqual([
+      "local",
+      "preview",
+      "staging",
+      "production",
+    ])
+    expect(MANAGER_APP_SEED.environments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "local",
+          clientId: "jfp_manager_local",
+          redirectUris: ["http://localhost:3002/api/auth/callback"],
+          postLogoutRedirectUris: ["http://localhost:3002/login"],
+          allowedOrigins: ["http://localhost:3002"],
+          defaultScopes: expect.arrayContaining(["manager:access"]),
+          autoApprove: true,
+        }),
+        expect.objectContaining({
+          key: "production",
+          clientId: "jfp_manager_production",
+          redirectUris: ["https://manager.jesusfilm.org/api/auth/callback"],
+          postLogoutRedirectUris: ["https://manager.jesusfilm.org/login"],
+          allowedOrigins: ["https://manager.jesusfilm.org"],
+          defaultScopes: expect.arrayContaining(["manager:access"]),
+          autoApprove: true,
+        }),
+      ]),
+    )
   })
 })

--- a/apps/auth/src/domain/apps.ts
+++ b/apps/auth/src/domain/apps.ts
@@ -7,6 +7,7 @@ export const FIRST_PARTY_OWNER = {
 } as const
 
 export const ADMIN_APP_KEY = "admin"
+export const MANAGER_APP_KEY = "manager"
 
 export type AppEnvironmentSeed = {
   key: string
@@ -35,6 +36,14 @@ export const ADMIN_DEFAULT_SCOPES = [
   "email:read",
   "membership:read",
   "admin:access",
+] satisfies AuthScopeKey[]
+
+export const MANAGER_DEFAULT_SCOPES = [
+  "openid",
+  "profile:read",
+  "email:read",
+  "membership:read",
+  "manager:access",
 ] satisfies AuthScopeKey[]
 
 export const ADMIN_APP_SEED: RegisteredAppSeed = {
@@ -89,3 +98,57 @@ export const ADMIN_APP_SEED: RegisteredAppSeed = {
     },
   ],
 }
+
+export const MANAGER_APP_SEED: RegisteredAppSeed = {
+  key: MANAGER_APP_KEY,
+  displayName: "Jesus Film Manager",
+  description: "Operator surface for Jesus Film media enrichment pipelines.",
+  ...FIRST_PARTY_OWNER,
+  environments: [
+    {
+      key: "local",
+      kind: "local",
+      clientId: "jfp_manager_local",
+      redirectUris: ["http://localhost:3002/api/auth/callback"],
+      postLogoutRedirectUris: ["http://localhost:3002/login"],
+      allowedOrigins: ["http://localhost:3002"],
+      defaultScopes: MANAGER_DEFAULT_SCOPES,
+      autoApprove: true,
+    },
+    {
+      key: "preview",
+      kind: "preview",
+      clientId: "jfp_manager_preview",
+      redirectUris: ["https://manager-preview.jesusfilm.org/api/auth/callback"],
+      postLogoutRedirectUris: ["https://manager-preview.jesusfilm.org/login"],
+      allowedOrigins: ["https://manager-preview.jesusfilm.org"],
+      defaultScopes: MANAGER_DEFAULT_SCOPES,
+      autoApprove: true,
+    },
+    {
+      key: "staging",
+      kind: "staging",
+      clientId: "jfp_manager_staging",
+      redirectUris: ["https://manager-stage.jesusfilm.org/api/auth/callback"],
+      postLogoutRedirectUris: ["https://manager-stage.jesusfilm.org/login"],
+      allowedOrigins: ["https://manager-stage.jesusfilm.org"],
+      defaultScopes: MANAGER_DEFAULT_SCOPES,
+      autoApprove: true,
+    },
+    {
+      key: "production",
+      kind: "production",
+      clientId: "jfp_manager_production",
+      redirectUris: ["https://manager.jesusfilm.org/api/auth/callback"],
+      postLogoutRedirectUris: ["https://manager.jesusfilm.org/login"],
+      allowedOrigins: ["https://manager.jesusfilm.org"],
+      defaultScopes: MANAGER_DEFAULT_SCOPES,
+      autoApprove: true,
+    },
+  ],
+}
+
+export const FIRST_PARTY_APP_SEEDS = [
+  ADMIN_APP_SEED,
+  MANAGER_APP_SEED,
+] satisfies RegisteredAppSeed[]

--- a/apps/auth/src/domain/scopes.test.ts
+++ b/apps/auth/src/domain/scopes.test.ts
@@ -6,6 +6,7 @@ describe("Auth scopes", () => {
   it("recognizes known scope keys", () => {
     expect(isKnownScope("openid")).toBe(true)
     expect(isKnownScope("admin:access")).toBe(true)
+    expect(isKnownScope("manager:access")).toBe(true)
     expect(isKnownScope("made:up")).toBe(false)
   })
 

--- a/apps/auth/src/domain/scopes.ts
+++ b/apps/auth/src/domain/scopes.ts
@@ -26,6 +26,11 @@ export const AUTH_SCOPES = [
     description: "Allow sign-in to the Jesus Film Admin application.",
   },
   {
+    key: "manager:access",
+    label: "Access Manager",
+    description: "Allow sign-in to the Jesus Film Manager application.",
+  },
+  {
     key: "tokens:manage",
     label: "Manage tokens",
     description: "Create, inspect, and revoke scoped Auth tokens.",

--- a/apps/auth/src/scripts/seed-first-party-apps.test.ts
+++ b/apps/auth/src/scripts/seed-first-party-apps.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const upsertScope = vi.fn()
+const upsertRegisteredApp = vi.fn()
+const upsertAppEnvironment = vi.fn()
+const upsertOAuthClient = vi.fn()
+
+vi.mock("@/db/client", () => ({
+  prisma: {
+    scope: { upsert: upsertScope },
+    registeredApp: { upsert: upsertRegisteredApp },
+    appEnvironment: { upsert: upsertAppEnvironment },
+    oauthClient: { upsert: upsertOAuthClient },
+  },
+}))
+
+describe("seedFirstPartyApps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    upsertRegisteredApp.mockImplementation(async ({ where }) => ({
+      id: `app_${where.key}`,
+    }))
+  })
+
+  it("seeds scopes and OAuth clients for every first-party app", async () => {
+    const { seedFirstPartyApps } = await import("./seed-first-party-apps")
+
+    await expect(seedFirstPartyApps()).resolves.toEqual({
+      apps: 2,
+      environments: 8,
+      oauthClients: 8,
+      scopes: 7,
+    })
+
+    expect(upsertScope).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: "manager:access" },
+      }),
+    )
+    expect(upsertRegisteredApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: "manager" },
+        create: expect.objectContaining({
+          key: "manager",
+          displayName: "Jesus Film Manager",
+        }),
+      }),
+    )
+    expect(upsertOAuthClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clientId: "jfp_manager_local" },
+        create: expect.objectContaining({
+          clientId: "jfp_manager_local",
+          scopes: expect.arrayContaining(["manager:access"]),
+          public: true,
+          requirePKCE: true,
+          tokenEndpointAuthMethod: "none",
+        }),
+      }),
+    )
+  })
+})

--- a/apps/auth/src/scripts/seed-first-party-apps.ts
+++ b/apps/auth/src/scripts/seed-first-party-apps.ts
@@ -1,4 +1,4 @@
-import { ADMIN_APP_SEED } from "@/domain/apps"
+import { FIRST_PARTY_APP_SEEDS, type RegisteredAppSeed } from "@/domain/apps"
 import { AUTH_SCOPES } from "@/domain/scopes"
 import { prisma } from "@/db/client"
 
@@ -14,28 +14,47 @@ export async function seedFirstPartyApps() {
     })
   }
 
+  for (const appSeed of FIRST_PARTY_APP_SEEDS) {
+    await seedFirstPartyApp(appSeed)
+  }
+
+  return {
+    apps: FIRST_PARTY_APP_SEEDS.length,
+    environments: FIRST_PARTY_APP_SEEDS.reduce(
+      (total, app) => total + app.environments.length,
+      0,
+    ),
+    oauthClients: FIRST_PARTY_APP_SEEDS.reduce(
+      (total, app) => total + app.environments.length,
+      0,
+    ),
+    scopes: AUTH_SCOPES.length,
+  }
+}
+
+async function seedFirstPartyApp(appSeed: RegisteredAppSeed) {
   const app = await prisma.registeredApp.upsert({
-    where: { key: ADMIN_APP_SEED.key },
+    where: { key: appSeed.key },
     update: {
-      displayName: ADMIN_APP_SEED.displayName,
-      description: ADMIN_APP_SEED.description,
+      displayName: appSeed.displayName,
+      description: appSeed.description,
       trustTier: "FIRST_PARTY",
       ownerType: "JESUS_FILM",
-      ownerName: ADMIN_APP_SEED.ownerName,
+      ownerName: appSeed.ownerName,
       status: "ACTIVE",
     },
     create: {
-      key: ADMIN_APP_SEED.key,
-      displayName: ADMIN_APP_SEED.displayName,
-      description: ADMIN_APP_SEED.description,
+      key: appSeed.key,
+      displayName: appSeed.displayName,
+      description: appSeed.description,
       trustTier: "FIRST_PARTY",
       ownerType: "JESUS_FILM",
-      ownerName: ADMIN_APP_SEED.ownerName,
+      ownerName: appSeed.ownerName,
       status: "ACTIVE",
     },
   })
 
-  for (const environment of ADMIN_APP_SEED.environments) {
+  for (const environment of appSeed.environments) {
     await prisma.appEnvironment.upsert({
       where: {
         appId_key: {
@@ -68,7 +87,7 @@ export async function seedFirstPartyApps() {
     await prisma.oauthClient.upsert({
       where: { clientId: environment.clientId },
       update: {
-        name: `${ADMIN_APP_SEED.displayName} (${environment.key})`,
+        name: `${appSeed.displayName} (${environment.key})`,
         redirectUris: environment.redirectUris,
         postLogoutRedirectUris: environment.postLogoutRedirectUris,
         scopes: environment.defaultScopes,
@@ -81,15 +100,15 @@ export async function seedFirstPartyApps() {
         grantTypes: ["authorization_code", "refresh_token"],
         responseTypes: ["code"],
         metadata: {
-          appKey: ADMIN_APP_SEED.key,
+          appKey: appSeed.key,
           environmentKey: environment.key,
           environmentKind: environment.kind,
-          trustTier: ADMIN_APP_SEED.trustTier,
+          trustTier: appSeed.trustTier,
         },
       },
       create: {
         clientId: environment.clientId,
-        name: `${ADMIN_APP_SEED.displayName} (${environment.key})`,
+        name: `${appSeed.displayName} (${environment.key})`,
         redirectUris: environment.redirectUris,
         postLogoutRedirectUris: environment.postLogoutRedirectUris,
         scopes: environment.defaultScopes,
@@ -102,20 +121,13 @@ export async function seedFirstPartyApps() {
         grantTypes: ["authorization_code", "refresh_token"],
         responseTypes: ["code"],
         metadata: {
-          appKey: ADMIN_APP_SEED.key,
+          appKey: appSeed.key,
           environmentKey: environment.key,
           environmentKind: environment.kind,
-          trustTier: ADMIN_APP_SEED.trustTier,
+          trustTier: appSeed.trustTier,
         },
       },
     })
-  }
-
-  return {
-    apps: 1,
-    environments: ADMIN_APP_SEED.environments.length,
-    oauthClients: ADMIN_APP_SEED.environments.length,
-    scopes: AUTH_SCOPES.length,
   }
 }
 
@@ -127,7 +139,7 @@ if (process.argv[1]?.endsWith("seed-first-party-apps.ts")) {
   seedFirstPartyApps()
     .then((result) => {
       console.log(
-        `Seeded ${result.apps} first-party app, ${result.environments} environments, ${result.oauthClients} OAuth clients, and ${result.scopes} scopes.`,
+        `Seeded ${result.apps} first-party apps, ${result.environments} environments, ${result.oauthClients} OAuth clients, and ${result.scopes} scopes.`,
       )
     })
     .finally(async () => {

--- a/apps/auth/src/services/app-registry.service.test.ts
+++ b/apps/auth/src/services/app-registry.service.test.ts
@@ -40,20 +40,21 @@ describe("app registry policy", () => {
   it("validates first-party seeds", () => {
     const seeds = getFirstPartyAppSeeds()
 
-    expect(seeds).toHaveLength(1)
-    expect(seeds[0]?.key).toBe("admin")
+    expect(seeds.map((seed) => seed.key)).toEqual(["admin", "manager"])
 
-    for (const environment of seeds[0]?.environments ?? []) {
-      expect(() =>
-        validateAppEnvironmentPolicy({
-          kind: environment.kind,
-          status: "approved",
-          autoApprove: environment.autoApprove,
-          redirectUris: environment.redirectUris,
-          allowedOrigins: environment.allowedOrigins,
-          defaultScopes: environment.defaultScopes,
-        }),
-      ).not.toThrow()
+    for (const seed of seeds) {
+      for (const environment of seed.environments) {
+        expect(() =>
+          validateAppEnvironmentPolicy({
+            kind: environment.kind,
+            status: "approved",
+            autoApprove: environment.autoApprove,
+            redirectUris: environment.redirectUris,
+            allowedOrigins: environment.allowedOrigins,
+            defaultScopes: environment.defaultScopes,
+          }),
+        ).not.toThrow()
+      }
     }
   })
 })

--- a/apps/auth/src/services/app-registry.service.ts
+++ b/apps/auth/src/services/app-registry.service.ts
@@ -1,4 +1,4 @@
-import { ADMIN_APP_SEED, type RegisteredAppSeed } from "@/domain/apps"
+import { FIRST_PARTY_APP_SEEDS, type RegisteredAppSeed } from "@/domain/apps"
 import { assertKnownScopes } from "@/domain/scopes"
 
 export type AppEnvironmentPolicyInput = {
@@ -40,5 +40,5 @@ export function validateAppEnvironmentPolicy(input: AppEnvironmentPolicyInput) {
 }
 
 export function getFirstPartyAppSeeds(): RegisteredAppSeed[] {
-  return [ADMIN_APP_SEED]
+  return [...FIRST_PARTY_APP_SEEDS]
 }


### PR DESCRIPTION
## Summary
- add the Manager first-party app seed with local, preview, staging, and production OAuth clients
- add the manager:access scope to the Auth scope registry
- update the first-party seed path so Admin and Manager clients/scopes are seeded together

## Why
Local and staging Manager OAuth use auth.jesusfilm.org. Today the live Auth service does not know client_id=jfp_manager_local, so local Manager login falls through to www.jesusfilm.org instead of returning to localhost:3002/api/auth/callback. This is the minimum Auth-only change needed to seed/register those clients without including the broader Manager/Admin migration branch.

## Validation
- pnpm install
- pnpm --filter @forge/auth test src/domain/apps.test.ts src/services/app-registry.service.test.ts src/scripts/seed-first-party-apps.test.ts src/domain/scopes.test.ts
- pnpm --filter @forge/auth typecheck
- git diff --check

## Rollout note
After deploy, run the Auth first-party app seed against the auth.jesusfilm.org database so jfp_manager_local, jfp_manager_preview, jfp_manager_staging, and jfp_manager_production exist in the OAuth client registry.