### PR TITLE
chore(devcontainer): enable local ssh access

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   socat \
   # Modern CLI tools
   fd-find \
+  openssh-server \
   ripgrep \
   tmux \
   zsh \
@@ -72,6 +73,15 @@ RUN mkdir -p /commandhistory /workspace /home/vscode/.claude /home/vscode/.codex
   touch /commandhistory/.bash_history && \
   touch /commandhistory/.zsh_history && \
   chown -R vscode:vscode /commandhistory /workspace /home/vscode/.claude /home/vscode/.codex /opt
+
+RUN mkdir -p /run/sshd /etc/ssh/sshd_config.d && \
+  printf '%s\n' \
+    'PasswordAuthentication no' \
+    'KbdInteractiveAuthentication no' \
+    'PermitRootLogin no' \
+    'PubkeyAuthentication yes' \
+    'AllowUsers vscode' \
+    > /etc/ssh/sshd_config.d/forge-devcontainer.conf
 
 # Set environment variables
 ENV DEVCONTAINER=true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "name": "Forge",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
+  "shutdownAction": "none",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,8 +13,11 @@ services:
       - claude-code-config:/home/vscode/.claude
       - codex-config:/home/vscode/.codex
       - claude-code-gh:/home/vscode/.config/gh
+      - devcontainer-ssh:/home/vscode/.ssh
       - ${HOME}/.gitconfig:/home/vscode/.gitconfig:ro
       - .:/workspace/.devcontainer:ro
+    ports:
+      - "127.0.0.1:2222:22"
     cap_add:
       - NET_ADMIN
       - NET_RAW
@@ -25,7 +28,11 @@ services:
       redis:
         condition: service_healthy
     # Keep the container alive for VS Code to attach
-    command: sleep infinity
+    command: >
+      bash -lc "sudo ssh-keygen -A &&
+      sudo install -d -m 0755 /run/sshd &&
+      sudo /usr/sbin/sshd &&
+      sleep infinity"
 
   db:
     image: pgvector/pgvector:pg18
@@ -62,3 +69,4 @@ volumes:
   claude-code-config:
   codex-config:
   claude-code-gh:
+  devcontainer-ssh:


### PR DESCRIPTION
## Summary
- keep the VS Code devcontainer running after VS Code closes
- install and start OpenSSH server inside the app container
- expose SSH only on localhost port 2222 with key-only vscode user access
- persist authorized keys in a named devcontainer SSH volume

## Validation
- jq empty .devcontainer/devcontainer.json
- ruby -e 'require "yaml"; YAML.load_file(".devcontainer/docker-compose.yml"); puts "yaml ok"'
- docker compose -f .devcontainer/docker-compose.yml config --quiet