### PR TITLE
fix(auth): preserve email login oauth continuation

### DIFF
--- a/apps/auth/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const authPost = vi.fn()
+const rateLimitAuthRoute = vi.fn(async (_input: unknown) => ({
+  allowed: true,
+  source: "local",
+}))
+const signUpEmail = vi.fn()
 
 vi.mock("@/auth/config", () => ({
   auth: {
     api: {
-      signUpEmail: vi.fn(),
+      signUpEmail: (...args: unknown[]) => signUpEmail(...args),
     },
   },
   authRouteHandlers: {
@@ -19,6 +24,17 @@ vi.mock("@/auth/config", () => ({
 
 vi.mock("@/db/client", () => ({
   prisma: {
+    $transaction: vi.fn(async (callback) =>
+      callback({
+        account: {
+          upsert: vi.fn(),
+        },
+        user: {
+          findFirst: vi.fn(async () => ({ id: "user_123" })),
+          update: vi.fn(),
+        },
+      }),
+    ),
     user: {
       findFirst: vi.fn(),
     },
@@ -26,7 +42,7 @@ vi.mock("@/db/client", () => ({
 }))
 
 vi.mock("@/auth/rate-limit", () => ({
-  rateLimitAuthRoute: vi.fn(async () => ({ allowed: true, source: "local" })),
+  rateLimitAuthRoute: (input: unknown) => rateLimitAuthRoute(input),
 }))
 
 vi.mock("@/auth/firebase-rest", () => ({
@@ -40,6 +56,9 @@ vi.mock("@/auth/firebase-admin", () => ({
 describe("Auth route wrapper", () => {
   beforeEach(() => {
     authPost.mockReset()
+    rateLimitAuthRoute.mockReset()
+    rateLimitAuthRoute.mockResolvedValue({ allowed: true, source: "local" })
+    signUpEmail.mockReset()
   })
 
   it("blocks public email signup", async () => {
@@ -69,7 +88,7 @@ describe("Auth route wrapper", () => {
     expect(authPost).toHaveBeenCalledOnce()
   })
 
-  it("forwards OAuth continuation query through email sign-in", async () => {
+  it("forwards OAuth continuation as callbackURL through email sign-in", async () => {
     authPost.mockResolvedValueOnce(Response.json({ ok: true }))
     const { POST } = await import("./route")
     const response = await POST(
@@ -88,9 +107,178 @@ describe("Auth route wrapper", () => {
     expect(response.status).toBe(200)
     const forwardedRequest = authPost.mock.calls[0]?.[0] as Request
     await expect(forwardedRequest.json()).resolves.toMatchObject({
+      callbackURL:
+        "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&sig=signed",
+      email: "user@example.com",
+      password: "password",
+    })
+  })
+
+  it("redirects browser email sign-in forms back to OAuth authorize after credentials succeed", async () => {
+    authPost.mockResolvedValueOnce(
+      Response.json(
+        { redirect: true },
+        { headers: { "set-cookie": "better-auth.session=abc; Path=/" } },
+      ),
+    )
+    const { POST } = await import("./route")
+    const body = new URLSearchParams({
       email: "user@example.com",
       oauth_query: "client_id=jfp_admin_local&sig=signed",
       password: "password",
     })
+
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-in/email", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body,
+      }),
+      { params: Promise.resolve({ all: ["sign-in", "email"] }) },
+    )
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&sig=signed",
+    )
+    expect(response.headers.get("set-cookie")).toContain(
+      "better-auth.session=abc",
+    )
+  })
+
+  it("redirects browser email sign-in forms back to login when credentials fail", async () => {
+    authPost.mockResolvedValueOnce(
+      Response.json({ error: "Invalid email or password" }, { status: 401 }),
+    )
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-in/email", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          email: "user@example.com",
+          oauth_query: "client_id=jfp_admin_local&sig=signed",
+          password: "wrong-password",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["sign-in", "email"] }) },
+    )
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3004/login?client_id=jfp_admin_local&sig=signed&error=credentials",
+    )
+  })
+
+  it("rate limits browser email sign-in forms before reading the body", async () => {
+    rateLimitAuthRoute.mockResolvedValueOnce({
+      allowed: false,
+      source: "local",
+    })
+    const request = new Request(
+      "http://localhost:3004/api/auth/sign-in/email",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          referer:
+            "http://localhost:3004/login?client_id=jfp_admin_local&sig=signed",
+        },
+        body: new URLSearchParams({
+          email: "user@example.com",
+          oauth_query: "client_id=jfp_admin_local&sig=signed",
+          password: "password",
+        }),
+      },
+    )
+
+    const { POST } = await import("./route")
+    const response = await POST(request, {
+      params: Promise.resolve({ all: ["sign-in", "email"] }),
+    })
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3004/login?client_id=jfp_admin_local&sig=signed&error=credentials",
+    )
+    expect(authPost).not.toHaveBeenCalled()
+  })
+
+  it("keeps JSON email sign-in failures as 401 responses", async () => {
+    authPost.mockResolvedValueOnce(
+      Response.json({ error: "Invalid email or password" }, { status: 401 }),
+    )
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-in/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email: "user@example.com",
+          oauth_query: "client_id=jfp_admin_local&sig=signed",
+          password: "wrong-password",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["sign-in", "email"] }) },
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid email or password",
+    })
+  })
+
+  it("uses the same OAuth continuation after Firebase fallback migration", async () => {
+    authPost.mockResolvedValueOnce(
+      Response.json({ error: "Nope" }, { status: 401 }),
+    )
+    const { prisma } = await import("@/db/client")
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce(null)
+    const { signInWithFirebasePassword } = await import("@/auth/firebase-rest")
+    vi.mocked(signInWithFirebasePassword).mockResolvedValueOnce({
+      email: "user@example.com",
+      idToken: "firebase_id_token",
+    })
+    const { verifyFirebaseIdToken } = await import("@/auth/firebase-admin")
+    vi.mocked(verifyFirebaseIdToken).mockResolvedValueOnce({
+      email: "user@example.com",
+      uid: "firebase_uid",
+    })
+    signUpEmail.mockResolvedValueOnce(
+      Response.json(
+        { redirect: true },
+        { headers: { "set-cookie": "better-auth.session=abc; Path=/" } },
+      ),
+    )
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-in/email", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          email: "USER@example.com",
+          oauth_query: "client_id=jfp_admin_local&sig=signed",
+          password: "password",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["sign-in", "email"] }) },
+    )
+
+    expect(signUpEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          callbackURL:
+            "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&sig=signed",
+          email: "user@example.com",
+        }),
+      }),
+    )
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&sig=signed",
+    )
   })
 })

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -4,6 +4,7 @@ import { auth, authRouteHandlers } from "@/auth/config"
 import { verifyFirebaseIdToken } from "@/auth/firebase-admin"
 import { signInWithFirebasePassword } from "@/auth/firebase-rest"
 import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { getAuthBaseUrl } from "@/config/env"
 import { prisma } from "@/db/client"
 import { ensureDynamicPreviewRedirectUriRegistered } from "@/services/dynamic-preview-redirect.service"
 
@@ -13,6 +14,14 @@ type RouteContext = {
 
 const WINDOW_MS = 60_000
 const MAX_ATTEMPTS = 10
+
+function isFormPostRequest(request: Request): boolean {
+  return (
+    request.headers
+      .get("content-type")
+      ?.includes("application/x-www-form-urlencoded") ?? false
+  )
+}
 
 function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex")
@@ -28,9 +37,12 @@ function audit(event: string, email?: string): void {
   )
 }
 
-async function parseEmailPasswordRequest(
-  request: Request,
-): Promise<{ email: string; password: string; oauthQuery?: string }> {
+async function parseEmailPasswordRequest(request: Request): Promise<{
+  email: string
+  isFormPost: boolean
+  oauthQuery?: string
+  password: string
+}> {
   const contentType = request.headers.get("content-type") ?? ""
   if (contentType.includes("application/json")) {
     const body = (await request.json()) as {
@@ -40,6 +52,7 @@ async function parseEmailPasswordRequest(
     }
     return {
       email: body.email?.trim().toLowerCase() ?? "",
+      isFormPost: false,
       oauthQuery: body.oauth_query,
       password: body.password ?? "",
     }
@@ -50,6 +63,7 @@ async function parseEmailPasswordRequest(
     email: String(body.get("email") ?? "")
       .trim()
       .toLowerCase(),
+    isFormPost: true,
     oauthQuery:
       typeof body.get("oauth_query") === "string"
         ? String(body.get("oauth_query"))
@@ -60,6 +74,36 @@ async function parseEmailPasswordRequest(
 
 function genericUnauthorized(): Response {
   return Response.json({ error: "Invalid email or password" }, { status: 401 })
+}
+
+function oauthQueryFromLoginReferer(request: Request): string | undefined {
+  const referer = request.headers.get("referer")
+  if (!referer) return undefined
+
+  try {
+    const url = new URL(referer)
+    if (url.pathname !== "/login") return undefined
+
+    url.searchParams.delete("error")
+    return url.searchParams.toString() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+function rejectEmailSignIn({
+  isFormPost,
+  oauthQuery,
+}: {
+  isFormPost: boolean
+  oauthQuery?: string
+}): Response {
+  if (!isFormPost) return genericUnauthorized()
+
+  const url = new URL("/login", getAuthBaseUrl())
+  if (oauthQuery) url.search = oauthQuery
+  url.searchParams.set("error", "credentials")
+  return Response.redirect(url, 303)
 }
 
 function toJsonRequest(original: Request, body: object): Request {
@@ -73,6 +117,30 @@ function toJsonRequest(original: Request, body: object): Request {
   })
 }
 
+function buildOAuthContinuationURL(oauthQuery: string | undefined) {
+  if (!oauthQuery) return undefined
+
+  const url = new URL("/api/auth/oauth2/authorize", getAuthBaseUrl())
+  url.search = oauthQuery
+  return url.toString()
+}
+
+function redirectFormPostAfterSignIn(
+  response: Response,
+  callbackURL: string | undefined,
+): Response {
+  if (!response.ok || !callbackURL) return response
+
+  const headers = new Headers(response.headers)
+  headers.set("location", callbackURL)
+  headers.delete("content-length")
+
+  return new Response(null, {
+    headers,
+    status: 303,
+  })
+}
+
 async function handleEmailSignIn(request: Request): Promise<Response> {
   const limit = await rateLimitAuthRoute({
     request,
@@ -82,20 +150,25 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
   })
   if (!limit.allowed) {
     audit("auth.firebase.rejected.rate_limited")
-    return genericUnauthorized()
+    return rejectEmailSignIn({
+      isFormPost: isFormPostRequest(request),
+      oauthQuery: oauthQueryFromLoginReferer(request),
+    })
   }
 
-  const { email, oauthQuery, password } =
+  const { email, isFormPost, oauthQuery, password } =
     await parseEmailPasswordRequest(request)
+
   if (!email || !password) {
     audit("auth.signin.rejected", email)
-    return genericUnauthorized()
+    return rejectEmailSignIn({ isFormPost, oauthQuery })
   }
+  const callbackURL = buildOAuthContinuationURL(oauthQuery)
 
   const jsonBody = {
+    ...(callbackURL ? { callbackURL } : {}),
     email,
     password,
-    ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
   }
   const primaryResponse = await authRouteHandlers.POST(
     toJsonRequest(request, jsonBody),
@@ -104,7 +177,9 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
     if (primaryResponse.ok) {
       audit("auth.signin.success")
     }
-    return primaryResponse
+    return isFormPost
+      ? redirectFormPostAfterSignIn(primaryResponse, callbackURL)
+      : primaryResponse
   }
 
   const existingUser = await prisma.user.findFirst({
@@ -113,35 +188,37 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
   })
   if (existingUser) {
     audit("auth.signin.rejected", email)
-    return primaryResponse
+    return isFormPost
+      ? rejectEmailSignIn({ isFormPost, oauthQuery })
+      : primaryResponse
   }
 
   const firebaseSignIn = await signInWithFirebasePassword(email, password)
   if (!firebaseSignIn) {
     audit("auth.signin.rejected", email)
-    return genericUnauthorized()
+    return rejectEmailSignIn({ isFormPost, oauthQuery })
   }
 
   const verified = await verifyFirebaseIdToken(firebaseSignIn.idToken)
   if (!verified || verified.email.toLowerCase() !== email) {
     audit("auth.firebase.rejected.unverified", email)
-    return genericUnauthorized()
+    return rejectEmailSignIn({ isFormPost, oauthQuery })
   }
 
   const signUpResponse = await auth.api.signUpEmail({
     headers: request.headers,
     asResponse: true,
     body: {
+      ...(callbackURL ? { callbackURL } : {}),
       email,
       password,
-      ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
       name: email.split("@")[0] || "user",
     },
   })
 
   if (!signUpResponse.ok) {
     audit("auth.signin.rejected", email)
-    return genericUnauthorized()
+    return rejectEmailSignIn({ isFormPost, oauthQuery })
   }
 
   await prisma.$transaction(async (tx) => {
@@ -181,7 +258,9 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
   })
 
   audit("auth.firebase.migrated", email)
-  return signUpResponse
+  return isFormPost
+    ? redirectFormPostAfterSignIn(signUpResponse, callbackURL)
+    : signUpResponse
 }
 
 export async function GET(

--- a/apps/auth/src/app/login/login-page-client.tsx
+++ b/apps/auth/src/app/login/login-page-client.tsx
@@ -10,7 +10,7 @@ const providerLabels = {
 } as const
 
 export type LoginProviderId = keyof typeof providerLabels
-export type LoginErrorCode = "account_not_linked" | "forbidden"
+export type LoginErrorCode = "account_not_linked" | "credentials" | "forbidden"
 
 type LoginMethodId = LoginProviderId | "email"
 
@@ -27,7 +27,10 @@ const loginErrors = {
     detail:
       "Your account signed in successfully, but it is not approved for this application.",
   },
-} satisfies Record<LoginErrorCode, { title: string; detail: string }>
+} satisfies Record<
+  Exclude<LoginErrorCode, "credentials">,
+  { title: string; detail: string }
+>
 
 export function LoginPageClient({
   enabledProviders,
@@ -48,7 +51,7 @@ export function LoginPageClient({
   const alert =
     error === "credentials"
       ? {
-          title: "Unable to sign in.",
+          title: "Invalid email or password.",
           detail: "Check your email and password, then try again.",
         }
       : error === "start"

--- a/apps/auth/src/app/login/page.tsx
+++ b/apps/auth/src/app/login/page.tsx
@@ -25,7 +25,9 @@ export function isOAuthAuthorizeRequest(
 function parseLoginError(
   value: string | undefined,
 ): LoginErrorCode | undefined {
-  return value === "account_not_linked" || value === "forbidden"
+  return value === "account_not_linked" ||
+    value === "credentials" ||
+    value === "forbidden"
     ? value
     : undefined
 }

--- a/apps/auth/src/app/login/page.ui.test.tsx
+++ b/apps/auth/src/app/login/page.ui.test.tsx
@@ -26,6 +26,19 @@ describe("auth login UI", () => {
     )
   })
 
+  it("shows the generic invalid credentials message", () => {
+    const html = renderToStaticMarkup(
+      <LoginPageClient
+        enabledProviders={[]}
+        initialError="credentials"
+        oauthQuery="client_id=jfp_admin_local&sig=signed"
+      />,
+    )
+
+    expect(html).toContain("Invalid email or password.")
+    expect(html).toContain("Check your email and password, then try again.")
+  })
+
   it("identifies OAuth authorize requests as the only valid login entry", () => {
     expect(
       isOAuthAuthorizeRequest({


### PR DESCRIPTION
## Summary
- Preserve OAuth authorize params through Auth email/password sign-in by translating `oauth_query` into Better Auth `callbackURL`.
- Redirect successful browser form posts back to `/api/auth/oauth2/authorize` so Admin receives its normal code/state callback.
- Redirect invalid browser credential attempts back to the original login screen with the generic "Invalid email or password" message while keeping JSON callers on `401`.
- Keep the auth route rate limiter ahead of body parsing; rate-limited form posts use the login referer to preserve OAuth params where possible.

## Verification
- `pnpm --filter @forge/auth test`
- `pnpm --filter @forge/auth typecheck`
- `pnpm --filter @forge/auth lint`
- `pnpm run format:check`
- `pnpm --filter @forge/auth build` (passes; emits existing Turbopack NFT/Prisma tracing warning)

## Notes
Root cause: the login page submitted the OAuth continuation as `oauth_query`, but Better Auth ignores that field. Successful email/password sign-in or Firebase fallback migration could create a session without continuing back into the OAuth authorize flow, making valid credentials look like a failed login from Admin.
