### PR TITLE
fix(auth): include user claims in OAuth tokens

### DIFF
--- a/apps/auth/src/auth/config.ts
+++ b/apps/auth/src/auth/config.ts
@@ -57,6 +57,23 @@ const upstreamProviderPlugins =
       ]
     : []
 
+function firstPartyUserClaims(user: {
+  email?: string | null
+  emailVerified?: boolean | null
+  name?: string | null
+  image?: string | null
+  membershipStatus?: string | null
+}) {
+  return {
+    email: user.email ?? undefined,
+    email_verified: user.emailVerified ?? undefined,
+    name: user.name ?? undefined,
+    picture: user.image ?? undefined,
+    "https://jesusfilm.org/claims/membership_status":
+      user.membershipStatus ?? "invited",
+  }
+}
+
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: "postgresql",
@@ -110,14 +127,8 @@ export const auth = betterAuth({
       silenceWarnings: {
         oauthAuthServerConfig: true,
       },
-      customIdTokenClaims: ({ user }) => ({
-        "https://jesusfilm.org/claims/membership_status":
-          user.membershipStatus ?? "invited",
-      }),
-      customUserInfoClaims: ({ user }) => ({
-        "https://jesusfilm.org/claims/membership_status":
-          user.membershipStatus ?? "invited",
-      }),
+      customIdTokenClaims: ({ user }) => firstPartyUserClaims(user),
+      customUserInfoClaims: ({ user }) => firstPartyUserClaims(user),
     }),
     nextCookies(),
     ...upstreamProviderPlugins,


### PR DESCRIPTION
## Summary
- include standard user claims in first-party OAuth ID/userinfo tokens
- fixes Mastra Studio gateway access resolving to missing_email after sign-in

## Verification
- pnpm --filter @forge/auth typecheck
- pnpm --filter @forge/auth test
- pnpm --filter @forge/auth lint
- deployed @forge/auth to Railway production: 192a9a1d-e70c-4b4c-85c4-8898ca0db0c3
- verified https://mastra-studio.jesusfilm.org/api/health returns 200
- verified gateway login uses jfp_mastra_studio_production and https://mastra-studio.jesusfilm.org/api/auth/callback