### PR TITLE
fix(mastra): derive storage path from railway volume

### DIFF
--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -41,14 +41,14 @@ pnpm --filter @forge/mastra lint
 
 ## Environment
 
-| Variable                  | Purpose                                                                                |
-| ------------------------- | -------------------------------------------------------------------------------------- |
-| `DATABASE_URL`            | Postgres connection string for Mastra runtime storage. Required in production runtime. |
-| `MASTRA_SERVICE_API_KEYS` | CSV allowlist for service bearer calls. Required in production runtime.                |
-| `MASTRA_STORAGE_DIR`      | Directory for Studio-visible observability/log files. Use `/data/mastra` on Railway.   |
-| `OPENAI_API_KEY`          | Model provider key for smoke agent/model-routed calls when model execution is tested.  |
-| `PORT`                    | Railway-provided runtime port. Mastra defaults to `4111` locally.                      |
-| `MASTRA_STUDIO_PATH`      | Set to `.mastra/output/studio` when starting the built server with Studio assets.      |
+| Variable                  | Purpose                                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`            | Postgres connection string for Mastra runtime storage. Required in production runtime.                                     |
+| `MASTRA_SERVICE_API_KEYS` | CSV allowlist for service bearer calls. Required in production runtime.                                                    |
+| `MASTRA_STORAGE_DIR`      | Optional directory for Studio-visible observability/log files. Defaults to `$RAILWAY_VOLUME_MOUNT_PATH/mastra` on Railway. |
+| `OPENAI_API_KEY`          | Model provider key for smoke agent/model-routed calls when model execution is tested.                                      |
+| `PORT`                    | Railway-provided runtime port. Mastra defaults to `4111` locally.                                                          |
+| `MASTRA_STUDIO_PATH`      | Set to `.mastra/output/studio` when starting the built server with Studio assets.                                          |
 
 ## Railway Storage
 
@@ -56,6 +56,8 @@ Production `@forge/mastra` uses the existing Mastra Postgres database through
 `DATABASE_URL` as the default runtime store. Studio-visible observability/log
 data uses Mastra's supported DuckDB store under `MASTRA_STORAGE_DIR`, backed by
 the Railway volume mounted at `/data`.
+If `MASTRA_STORAGE_DIR` is not set, the app derives `/data/mastra` from
+Railway's built-in `RAILWAY_VOLUME_MOUNT_PATH=/data`.
 
 Keep `PinoLogger` configured as the app logger so runtime logs continue to flow
 to stdout/stderr for Railway's platform logs.

--- a/apps/mastra/src/config/env.test.ts
+++ b/apps/mastra/src/config/env.test.ts
@@ -43,7 +43,7 @@ describe("Mastra env", () => {
     )
   })
 
-  it("requires a storage dir in production runtime", async () => {
+  it("accepts production runtime without an explicit storage dir", async () => {
     vi.stubEnv("NODE_ENV", "production")
     vi.stubEnv(
       "DATABASE_URL",
@@ -54,9 +54,7 @@ describe("Mastra env", () => {
 
     const { assertMastraRuntimeEnv } = await import("./env")
 
-    expect(() => assertMastraRuntimeEnv()).toThrow(
-      "MASTRA_STORAGE_DIR required for Mastra production",
-    )
+    expect(() => assertMastraRuntimeEnv()).not.toThrow()
   })
 
   it("defaults storage to the local gateway database in development", async () => {
@@ -77,5 +75,15 @@ describe("Mastra env", () => {
     const { getMastraStorageDir } = await import("./env")
 
     expect(getMastraStorageDir()).toBe(".mastra/storage")
+  })
+
+  it("uses the Railway volume mount path for storage when present", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("MASTRA_STORAGE_DIR", "")
+    vi.stubEnv("RAILWAY_VOLUME_MOUNT_PATH", "/data/")
+
+    const { getMastraStorageDir } = await import("./env")
+
+    expect(getMastraStorageDir()).toBe("/data/mastra")
   })
 })

--- a/apps/mastra/src/config/env.ts
+++ b/apps/mastra/src/config/env.ts
@@ -15,6 +15,7 @@ const envSchema = z.object({
   MASTRA_SERVICE_API_KEYS: z.string().min(1).optional(),
   MASTRA_STORAGE_DIR: z.string().min(1).optional(),
   OPENAI_API_KEY: z.string().min(1).optional(),
+  RAILWAY_VOLUME_MOUNT_PATH: z.string().min(1).optional(),
 })
 
 export const env = envSchema.parse({
@@ -26,6 +27,9 @@ export const env = envSchema.parse({
   ),
   MASTRA_STORAGE_DIR: emptyToUndefined(process.env.MASTRA_STORAGE_DIR),
   OPENAI_API_KEY: emptyToUndefined(process.env.OPENAI_API_KEY),
+  RAILWAY_VOLUME_MOUNT_PATH: emptyToUndefined(
+    process.env.RAILWAY_VOLUME_MOUNT_PATH,
+  ),
 })
 
 export function assertMastraRuntimeEnv() {
@@ -34,7 +38,6 @@ export function assertMastraRuntimeEnv() {
   const missing = [
     ["DATABASE_URL", env.DATABASE_URL],
     ["MASTRA_SERVICE_API_KEYS", env.MASTRA_SERVICE_API_KEYS],
-    ["MASTRA_STORAGE_DIR", env.MASTRA_STORAGE_DIR],
   ]
     .filter(([, value]) => !value)
     .map(([name]) => name)
@@ -49,5 +52,9 @@ export function getMastraDatabaseUrl() {
 }
 
 export function getMastraStorageDir() {
-  return env.MASTRA_STORAGE_DIR ?? ".mastra/storage"
+  if (env.MASTRA_STORAGE_DIR) return env.MASTRA_STORAGE_DIR
+  if (env.RAILWAY_VOLUME_MOUNT_PATH) {
+    return `${env.RAILWAY_VOLUME_MOUNT_PATH.replace(/\/$/, "")}/mastra`
+  }
+  return ".mastra/storage"
 }


### PR DESCRIPTION
## Summary
- stop requiring the custom MASTRA_STORAGE_DIR variable in production
- derive the Studio observability storage path from Railway's built-in RAILWAY_VOLUME_MOUNT_PATH when available
- keep DATABASE_URL and MASTRA_SERVICE_API_KEYS as required production runtime values

## Validation
- pnpm --filter @forge/mastra test
- pnpm --filter @forge/mastra lint
- pnpm --filter @forge/mastra typecheck
- pnpm --filter @forge/mastra build
- git diff --check

## Context
Production was mounting the Railway volume but the container did not receive MASTRA_STORAGE_DIR during startup. This makes the app use RAILWAY_VOLUME_MOUNT_PATH=/data as the source of truth and store Studio observability files under /data/mastra.