### PR TITLE
fix(mastra): preserve observability span methods

### DIFF
--- a/apps/mastra/src/mastra/index.ts
+++ b/apps/mastra/src/mastra/index.ts
@@ -48,11 +48,9 @@ const observabilityStore = new DuckDBStore({
 const redactPromptBodies: SpanOutputProcessor = {
   name: "forge-redact-prompt-bodies",
   process(span: AnySpan) {
-    return {
-      ...span,
-      input: span.input == null ? span.input : "[REDACTED_BY_FORGE]",
-      output: span.output == null ? span.output : "[REDACTED_BY_FORGE]",
-    }
+    span.input = span.input == null ? span.input : "[REDACTED_BY_FORGE]"
+    span.output = span.output == null ? span.output : "[REDACTED_BY_FORGE]"
+    return span
   },
   shutdown: async () => {},
 }


### PR DESCRIPTION
## Summary
- update the prompt redaction span output processor to return the original Mastra span instance
- avoid spreading spans into plain objects, which removes exportSpan() and breaks streaming endpoints

## Validation
- pnpm --filter @forge/mastra test
- pnpm --filter @forge/mastra lint
- pnpm --filter @forge/mastra typecheck
- pnpm --filter @forge/mastra build
- git diff --check