### PR TITLE
feat(admin): mix transcript evidence into video search

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1141,8 +1141,12 @@ cutover with zero response-shape drift.
   `MAX_LIMIT = 50`.
 - **Retrievers:** `src/services/hybrid-search-retrievers.ts` exports
   four functions. Each is a thin `$queryRaw` caller.
-  - `searchVideoSemantic` — pgvector cosine over `VideoSceneLocale.embedding`,
-    `DISTINCT ON (video_scene.video_id)`, locale-filtered. Resolves
+  - `searchVideoSemantic` — pgvector cosine over
+    `VideoSceneLocale.embedding` and `VideoTranscriptChunk.embedding`,
+    locale/language-filtered, mixed inside one `semantic-video`
+    retriever. It performs bounded scene + transcript scans, collapses
+    to one candidate per video before RRF, and lets the winning raw
+    evidence own `snippet`/`startSeconds`/`embeddingText`. Resolves
     `playbackId` via a LATERAL lookup on `video_dub → mux_video` keyed
     by `(video_edition_id, language.bcp47 = locale)`. When no dub
     matches, playbackId is NULL and the row still returns.
@@ -1167,10 +1171,12 @@ description`, same `'simple'` config as cms, locale + status gate.
   `cosineSimilarityFromText`. Line-for-line port of cms's `fusion.ts`
   with `resultId: string` (admin cuids) instead of cms's integer ids.
   Experience rows skip all three dedup layers.
-- **Scene-only for video-semantic in R4.** `VideoTranscriptChunk.embedding`
-  (R2-indexed) is deliberately NOT fused. Strict cms parity during the
-  R3→R8 window; adding a 5th RRF list for transcripts is a post-cutover
-  follow-up that won't change the consumer contract.
+- **Mixed evidence inside `semantic-video`.** Transcript chunks are NOT
+  a fifth RRF list. `VideoTranscriptChunk.embedding` is mixed with
+  scene evidence inside `searchVideoSemantic`, then a single ranked
+  video semantic list flows into the existing RRF pipeline. This avoids
+  double-counting videos that match both scene and transcript evidence
+  while preserving the public REST/GraphQL response shape.
 - **Video imageUrl resolves via LATERAL on `VideoImage`.** Both
   retrievers (semantic + keyword) emit
   `COALESCE(mobile_cinematic_high, url)` from the per-video

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -9,6 +9,8 @@
 
 import { describe, expect, it, vi, beforeEach } from "vitest"
 import {
+  calculateVideoSemanticMixedScore,
+  mixVideoSemanticEvidenceRows,
   searchVideoSemantic,
   searchVideoKeyword,
   searchExperienceSemantic,
@@ -21,6 +23,16 @@ function mockPrisma() {
     $queryRaw,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
+}
+
+function latestRawSql(prisma: ReturnType<typeof mockPrisma>): string {
+  const call = prisma.$queryRaw.mock.calls.at(-1)
+  return (call?.[0] as TemplateStringsArray | undefined)?.join(" ") ?? ""
+}
+
+function latestRawValues(prisma: ReturnType<typeof mockPrisma>): unknown[] {
+  const call = prisma.$queryRaw.mock.calls.at(-1)
+  return call?.slice(1) ?? []
 }
 
 describe("searchVideoSemantic", () => {
@@ -38,9 +50,12 @@ describe("searchVideoSemantic", () => {
         video_slug: "jesus",
         video_title: "Jesus",
         image_url: "https://images.example/jesus.jpg",
+        evidence_id: "scene-1",
+        evidence_source: "scene",
         scene_description: "Peter denies Jesus",
         start_seconds: 42.5,
         playback_id: "mux-abc",
+        source_score: 0.87,
         similarity: 0.87,
         embedding_text: "[0.1,0.2]",
       },
@@ -68,6 +83,42 @@ describe("searchVideoSemantic", () => {
     })
   })
 
+  it("maps transcript evidence rows through the same semantic-video result shape", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-transcript",
+        video_core_id: "core-transcript",
+        video_slug: "spoken-story",
+        video_title: "Spoken Story",
+        image_url: null,
+        evidence_id: "chunk-1",
+        evidence_source: "transcript",
+        scene_description: "The exact spoken phrase from the transcript",
+        start_seconds: 123.25,
+        playback_id: "mux-transcript",
+        source_score: 0.91,
+        similarity: 0.91,
+        embedding_text: "[0.3,0.4]",
+      },
+    ])
+
+    const rows = await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.3,0.4]",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows[0]).toMatchObject({
+      resultType: "video",
+      resultId: "vid-transcript",
+      sceneDescription: "The exact spoken phrase from the transcript",
+      startSeconds: 123.25,
+      playbackId: "mux-transcript",
+      similarity: 0.91,
+      embeddingText: "[0.3,0.4]",
+    })
+  })
+
   it("tolerates null playback_id (no matching dub for (edition, locale))", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([
       {
@@ -76,9 +127,12 @@ describe("searchVideoSemantic", () => {
         video_slug: "x",
         video_title: "X",
         image_url: null,
+        evidence_id: "scene-2",
+        evidence_source: "scene",
         scene_description: "d",
         start_seconds: 0,
         playback_id: null,
+        source_score: 0.5,
         similarity: 0.5,
         embedding_text: "[]",
       },
@@ -104,9 +158,12 @@ describe("searchVideoSemantic", () => {
         video_slug: "",
         video_title: "",
         image_url: null,
+        evidence_id: "scene-3",
+        evidence_source: "scene",
         scene_description: "",
         start_seconds: "7" as unknown as number,
         playback_id: null,
+        source_score: "0.42" as unknown as number,
         similarity: "0.42" as unknown as number,
         embedding_text: "[]",
       },
@@ -120,6 +177,286 @@ describe("searchVideoSemantic", () => {
 
     expect(rows[0]!.startSeconds).toBe(7)
     expect(rows[0]!.similarity).toBeCloseTo(0.42)
+  })
+
+  it("allows null transcript timecodes to flow through as null", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-no-timecode",
+        video_core_id: null,
+        video_slug: "",
+        video_title: "",
+        image_url: null,
+        evidence_id: "chunk-no-timecode",
+        evidence_source: "transcript",
+        scene_description: "Transcript chunk without segment timing",
+        start_seconds: null,
+        playback_id: null,
+        source_score: 0.7,
+        similarity: 0.7,
+        embedding_text: "[]",
+      },
+    ])
+
+    const rows = await searchVideoSemantic(prisma, {
+      queryEmbedding: "[]",
+      locale: "en",
+      limit: 1,
+    })
+
+    expect(rows[0]!.startSeconds).toBeNull()
+  })
+
+  it("queries both scene and transcript embeddings inside one semantic-video retriever", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 10,
+    })
+
+    const sql = latestRawSql(prisma)
+    expect(sql).toContain("WITH scene_source AS")
+    expect(sql).toContain("transcript_source AS")
+    expect(sql).toContain("FROM video_scene_locale vsl")
+    expect(sql).toContain("FROM video_transcript_chunk vtc")
+    expect(sql).toContain("UNION ALL")
+    expect(sql).not.toContain("semantic-transcript-video")
+  })
+
+  it("keeps locale/language, visibility, and non-null embedding gates in SQL", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "fr",
+      limit: 10,
+    })
+
+    const sql = latestRawSql(prisma)
+    expect((sql.match(/v\.deleted_at IS NULL/g) ?? []).length).toBe(2)
+    expect((sql.match(/vl\.status = 'published'/g) ?? []).length).toBe(2)
+    expect(sql).toContain("vsl.embedding IS NOT NULL")
+    expect(sql).toContain("vsl.locale =")
+    expect(sql).toContain("vtc.embedding IS NOT NULL")
+    expect(sql).toContain("vtc.language =")
+    expect(sql).toContain("vt.language =")
+  })
+
+  it("selects best per-source evidence before bounding source windows", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 5,
+    })
+
+    const sql = latestRawSql(prisma)
+    expect(sql).toContain("SELECT DISTINCT ON (vs.video_id)")
+    expect(sql).toContain("SELECT DISTINCT ON (vt.video_id)")
+    expect(sql).toContain("ORDER BY")
+    expect(sql).toContain("vs.video_id")
+    expect(sql).toContain("vt.video_id")
+    expect(sql).toContain("LIMIT")
+  })
+
+  it("uses bounded per-source candidate windows after per-video collapse", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 7,
+    })
+
+    const values = latestRawValues(prisma)
+    expect(values).toContain(14)
+  })
+})
+
+describe("mixVideoSemanticEvidenceRows", () => {
+  const base = {
+    video_core_id: null,
+    video_slug: "video",
+    video_title: "Video",
+    image_url: null,
+    playback_id: null,
+    embedding_text: "[0]",
+  }
+
+  it("collapses scene+transcript evidence to one candidate per video", () => {
+    const rows = mixVideoSemanticEvidenceRows([
+      {
+        ...base,
+        video_id: "vid-1",
+        evidence_id: "scene-1",
+        evidence_source: "scene",
+        scene_description: "Scene evidence",
+        start_seconds: 20,
+        source_score: 0.86,
+        similarity: 0.86,
+      },
+      {
+        ...base,
+        video_id: "vid-1",
+        evidence_id: "chunk-1",
+        evidence_source: "transcript",
+        scene_description: "Transcript evidence",
+        start_seconds: 10,
+        source_score: 0.84,
+        similarity: 0.84,
+      },
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      video_id: "vid-1",
+      scene_description: "Scene evidence",
+      start_seconds: 20,
+      embedding_text: "[0]",
+    })
+    expect(rows[0]!.similarity).toBeGreaterThan(0.86)
+  })
+
+  it("takes snippet, timecode, playback, and embedding text from winning transcript evidence", () => {
+    const rows = mixVideoSemanticEvidenceRows([
+      {
+        ...base,
+        video_id: "vid-1",
+        evidence_id: "scene-1",
+        evidence_source: "scene",
+        scene_description: "Scene evidence",
+        start_seconds: 5,
+        playback_id: "scene-playback",
+        source_score: 0.8,
+        similarity: 0.8,
+        embedding_text: "[scene]",
+      },
+      {
+        ...base,
+        video_id: "vid-1",
+        evidence_id: "chunk-1",
+        evidence_source: "transcript",
+        scene_description: "Transcript evidence",
+        start_seconds: 15,
+        playback_id: "transcript-playback",
+        source_score: 0.9,
+        similarity: 0.9,
+        embedding_text: "[transcript]",
+      },
+    ])
+
+    expect(rows[0]).toMatchObject({
+      scene_description: "Transcript evidence",
+      start_seconds: 15,
+      playback_id: "transcript-playback",
+      embedding_text: "[transcript]",
+    })
+  })
+
+  it("keeps strong single-source videos above weaker mixed videos", () => {
+    const rows = mixVideoSemanticEvidenceRows([
+      {
+        ...base,
+        video_id: "single",
+        evidence_id: "single-scene",
+        evidence_source: "scene",
+        scene_description: "Strong scene",
+        start_seconds: 0,
+        source_score: 0.9,
+        similarity: 0.9,
+      },
+      {
+        ...base,
+        video_id: "mixed",
+        evidence_id: "mixed-scene",
+        evidence_source: "scene",
+        scene_description: "Mixed scene",
+        start_seconds: 0,
+        source_score: 0.85,
+        similarity: 0.85,
+      },
+      {
+        ...base,
+        video_id: "mixed",
+        evidence_id: "mixed-chunk",
+        evidence_source: "transcript",
+        scene_description: "Mixed transcript",
+        start_seconds: 1,
+        source_score: 0.8,
+        similarity: 0.8,
+      },
+    ])
+
+    expect(rows.map((row) => row.video_id)).toEqual(["single", "mixed"])
+  })
+
+  it("uses deterministic tie ordering with scene before transcript and early timecode before id", () => {
+    const rows = mixVideoSemanticEvidenceRows([
+      {
+        ...base,
+        video_id: "b",
+        evidence_id: "chunk-b",
+        evidence_source: "transcript",
+        scene_description: "Transcript B",
+        start_seconds: 3,
+        source_score: 0.8,
+        similarity: 0.8,
+      },
+      {
+        ...base,
+        video_id: "a",
+        evidence_id: "scene-a",
+        evidence_source: "scene",
+        scene_description: "Scene A",
+        start_seconds: 7,
+        source_score: 0.8,
+        similarity: 0.8,
+      },
+      {
+        ...base,
+        video_id: "a",
+        evidence_id: "chunk-a",
+        evidence_source: "transcript",
+        scene_description: "Transcript A",
+        start_seconds: 1,
+        source_score: 0.8,
+        similarity: 0.8,
+      },
+    ])
+
+    expect(rows.map((row) => row.video_id)).toEqual(["a", "b"])
+    expect(rows[0]!.scene_description).toBe("Scene A")
+  })
+})
+
+describe("calculateVideoSemanticMixedScore", () => {
+  it("lets close scene+transcript evidence outrank a nearby single-source result", () => {
+    const mixed = calculateVideoSemanticMixedScore([0.86, 0.84])
+    const single = calculateVideoSemanticMixedScore([0.862])
+
+    expect(mixed).toBeGreaterThan(single)
+  })
+
+  it("keeps strong single-source evidence above weaker mixed evidence", () => {
+    const single = calculateVideoSemanticMixedScore([0.9])
+    const mixed = calculateVideoSemanticMixedScore([0.85, 0.8])
+
+    expect(single).toBeGreaterThan(mixed)
+  })
+
+  it("does not boost weak second-source evidence below the agreement threshold", () => {
+    const mixed = calculateVideoSemanticMixedScore([0.85, 0.7])
+
+    expect(mixed).toBe(0.85)
+  })
+
+  it("caps mixed scores at 1", () => {
+    const mixed = calculateVideoSemanticMixedScore([0.999, 0.99])
+
+    expect(mixed).toBe(1)
   })
 })
 

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -44,6 +44,27 @@ export type SemanticSearchParams = {
   limit: number
 }
 
+export const VIDEO_SEMANTIC_MAX_AGREEMENT_BONUS = 0.01
+export const VIDEO_SEMANTIC_AGREEMENT_THRESHOLD = 0.75
+export const VIDEO_SEMANTIC_AGREEMENT_FACTOR = 0.04
+
+export function calculateVideoSemanticMixedScore(
+  sourceScores: readonly number[],
+): number {
+  if (sourceScores.length === 0) return 0
+  const bestSourceScore = Math.max(...sourceScores)
+  if (sourceScores.length < 2) return bestSourceScore
+
+  const weakestSourceScore = Math.min(...sourceScores)
+  const agreementBonus = Math.min(
+    VIDEO_SEMANTIC_MAX_AGREEMENT_BONUS,
+    Math.max(0, weakestSourceScore - VIDEO_SEMANTIC_AGREEMENT_THRESHOLD) *
+      VIDEO_SEMANTIC_AGREEMENT_FACTOR,
+  )
+
+  return Math.min(1, bestSourceScore + agreementBonus)
+}
+
 export type KeywordSearchParams = {
   query: string
   locale: string
@@ -62,7 +83,7 @@ export type VideoSemanticResult = RankedItem & {
   videoTitle: string
   imageUrl: string | null
   sceneDescription: string
-  startSeconds: number
+  startSeconds: number | null
   playbackId: string | null
   similarity: number
   embeddingText: string
@@ -119,10 +140,116 @@ type VideoSemanticRow = {
   video_title: string | null
   image_url: string | null
   scene_description: string
-  start_seconds: number
+  start_seconds: number | null
   playback_id: string | null
   similarity: number
   embedding_text: string
+}
+
+type VideoSemanticEvidenceRow = VideoSemanticRow & {
+  evidence_id: string
+  evidence_source: "scene" | "transcript"
+  source_score: number
+}
+
+function evidenceSourcePriority(source: "scene" | "transcript"): number {
+  return source === "scene" ? 0 : 1
+}
+
+function compareNullableStartSeconds(
+  a: number | null,
+  b: number | null,
+): number {
+  if (a == null && b == null) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+  return a - b
+}
+
+export function mixVideoSemanticEvidenceRows(
+  rows: readonly VideoSemanticEvidenceRow[],
+): VideoSemanticRow[] {
+  const byVideo = new Map<string, VideoSemanticEvidenceRow[]>()
+  for (const row of rows) {
+    const existing = byVideo.get(row.video_id)
+    if (existing == null) {
+      byVideo.set(row.video_id, [row])
+    } else {
+      existing.push(row)
+    }
+  }
+
+  const mixed: Array<
+    VideoSemanticRow & {
+      best_source_score: number
+      winner_source_priority: number
+    }
+  > = []
+  for (const evidenceRows of byVideo.values()) {
+    evidenceRows.sort((a, b) => {
+      const scoreDelta = Number(b.source_score) - Number(a.source_score)
+      if (scoreDelta !== 0) return scoreDelta
+
+      const sourceDelta =
+        evidenceSourcePriority(a.evidence_source) -
+        evidenceSourcePriority(b.evidence_source)
+      if (sourceDelta !== 0) return sourceDelta
+
+      const timeDelta = compareNullableStartSeconds(
+        a.start_seconds,
+        b.start_seconds,
+      )
+      if (timeDelta !== 0) return timeDelta
+
+      return a.evidence_id.localeCompare(b.evidence_id)
+    })
+
+    const winner = evidenceRows[0]!
+    const sourceScores = evidenceRows.map((row) => Number(row.source_score))
+    const bestSourceScore = Math.max(...sourceScores)
+    mixed.push({
+      video_id: winner.video_id,
+      video_core_id: winner.video_core_id,
+      video_slug: winner.video_slug,
+      video_title: winner.video_title,
+      image_url: winner.image_url,
+      scene_description: winner.scene_description,
+      start_seconds: winner.start_seconds,
+      playback_id: winner.playback_id,
+      similarity: calculateVideoSemanticMixedScore(sourceScores),
+      embedding_text: winner.embedding_text,
+      best_source_score: bestSourceScore,
+      winner_source_priority: evidenceSourcePriority(winner.evidence_source),
+    })
+  }
+
+  mixed.sort((a, b) => {
+    const mixedScoreDelta = Number(b.similarity) - Number(a.similarity)
+    if (mixedScoreDelta !== 0) return mixedScoreDelta
+
+    const sourceScoreDelta =
+      Number(b.best_source_score) - Number(a.best_source_score)
+    if (sourceScoreDelta !== 0) return sourceScoreDelta
+
+    const sourceDelta = a.winner_source_priority - b.winner_source_priority
+    if (sourceDelta !== 0) return sourceDelta
+
+    const timeDelta = compareNullableStartSeconds(
+      a.start_seconds,
+      b.start_seconds,
+    )
+    if (timeDelta !== 0) return timeDelta
+
+    return a.video_id.localeCompare(b.video_id)
+  })
+
+  return mixed.map(
+    ({
+      best_source_score: _bestSourceScore,
+      winner_source_priority: _winnerSourcePriority,
+      ...row
+    }) => row,
+  )
 }
 
 type VideoKeywordRow = {
@@ -157,10 +284,12 @@ type ExperienceKeywordRow = {
 // -----------------------------------------------------------------------------
 
 /**
- * Per-locale semantic search over VideoSceneLocale embeddings.
+ * Per-locale semantic search over video scene + transcript embeddings.
  *
- * One row per video (DISTINCT ON video_id) carrying the best-matching
- * scene for the requested locale. `playbackId` resolves via a LATERAL
+ * One row per video carrying the best mixed evidence for the requested
+ * locale. Scene and transcript candidates are collapsed inside this
+ * retriever so RRF still sees a single `semantic-video` list.
+ * `playbackId` resolves via a LATERAL
  * lookup on `video_dub` → `mux_video`, keyed by
  * `(video_edition_id, language.bcp47 = locale)`. When no dub matches
  * `(edition, locale)`, `playbackId` is NULL and the row still returns —
@@ -177,69 +306,139 @@ export async function searchVideoSemantic(
   params: SemanticSearchParams,
 ): Promise<VideoSemanticResult[]> {
   const { queryEmbedding, locale, limit } = params
+  const candidateLimit = Math.max(limit * 2, limit)
 
-  const rows = await prisma.$queryRaw<VideoSemanticRow[]>`
-    SELECT * FROM (
-      SELECT DISTINCT ON (vs.video_id)
-        vs.video_id                       AS video_id,
-        v.core_id                         AS video_core_id,
-        v.slug                            AS video_slug,
-        vl.title                          AS video_title,
-        COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
-        vsl.description                   AS scene_description,
-        vs.start_seconds                  AS start_seconds,
-        dub_mux.playback_id               AS playback_id,
-        1 - (vsl.embedding <=> ${queryEmbedding}::vector) AS similarity,
-        vsl.embedding::text               AS embedding_text
-      FROM video_scene_locale vsl
-      JOIN video_scene vs ON vs.id = vsl.video_scene_id
-      JOIN video v ON v.id = vs.video_id
-        AND v.deleted_at IS NULL
-      JOIN video_locale vl
-        ON vl.video_id = v.id
-        AND vl.locale = ${locale}
-        AND vl.status = 'published'
-      LEFT JOIN LATERAL (
-        SELECT mv.playback_id
-        FROM video_dub vd
-        JOIN language lg ON lg.id = vd.language_id
-          AND lg.bcp47 = ${locale}
+  const evidenceRows = await prisma.$queryRaw<VideoSemanticEvidenceRow[]>`
+    WITH scene_source AS (
+      SELECT * FROM (
+        SELECT DISTINCT ON (vs.video_id)
+          vs.video_id                       AS video_id,
+          v.core_id                         AS video_core_id,
+          v.slug                            AS video_slug,
+          vl.title                          AS video_title,
+          COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
+          vsl.id                            AS evidence_id,
+          'scene'                           AS evidence_source,
+          vsl.description                   AS scene_description,
+          vs.start_seconds                  AS start_seconds,
+          dub_mux.playback_id               AS playback_id,
+          1 - (vsl.embedding <=> ${queryEmbedding}::vector) AS source_score,
+          vsl.embedding::text               AS embedding_text
+        FROM video_scene_locale vsl
+        JOIN video_scene vs ON vs.id = vsl.video_scene_id
+        JOIN video v ON v.id = vs.video_id
+          AND v.deleted_at IS NULL
+        JOIN video_locale vl
+          ON vl.video_id = v.id
+          AND vl.locale = ${locale}
+          AND vl.status = 'published'
+        LEFT JOIN LATERAL (
+          SELECT mv.playback_id
+          FROM video_dub vd
+          JOIN language lg ON lg.id = vd.language_id
+            AND lg.bcp47 = ${locale}
 
-        LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
-        WHERE vd.video_edition_id = vs.video_edition_id
-          AND vd.deleted_at IS NULL
-        ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
-        LIMIT 1
-      ) dub_mux ON true
-      LEFT JOIN LATERAL (
-        SELECT vi2.mobile_cinematic_high, vi2.url
-        FROM video_image vi2
-        WHERE vi2.video_id = v.id
-          AND vi2.deleted_at IS NULL
-        ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
-        LIMIT 1
-      ) vi ON true
-      WHERE vsl.embedding IS NOT NULL
-        AND vsl.locale = ${locale}
-      ORDER BY vs.video_id, vsl.embedding <=> ${queryEmbedding}::vector
-    ) sub
-    ORDER BY sub.similarity DESC
-    LIMIT ${limit}
+          LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+          WHERE vd.video_edition_id = vs.video_edition_id
+            AND vd.deleted_at IS NULL
+          ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
+          LIMIT 1
+        ) dub_mux ON true
+        LEFT JOIN LATERAL (
+          SELECT vi2.mobile_cinematic_high, vi2.url
+          FROM video_image vi2
+          WHERE vi2.video_id = v.id
+            AND vi2.deleted_at IS NULL
+          ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
+          LIMIT 1
+        ) vi ON true
+        WHERE vsl.embedding IS NOT NULL
+          AND vsl.locale = ${locale}
+        ORDER BY
+          vs.video_id,
+          vsl.embedding <=> ${queryEmbedding}::vector,
+          vs.start_seconds ASC,
+          vsl.id ASC
+      ) best_scene_per_video
+      ORDER BY source_score DESC, start_seconds ASC, evidence_id ASC
+      LIMIT ${candidateLimit}
+    ),
+    transcript_source AS (
+      SELECT * FROM (
+        SELECT DISTINCT ON (vt.video_id)
+          vt.video_id                       AS video_id,
+          v.core_id                         AS video_core_id,
+          v.slug                            AS video_slug,
+          vl.title                          AS video_title,
+          COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
+          vtc.id                            AS evidence_id,
+          'transcript'                      AS evidence_source,
+          vtc.text                          AS scene_description,
+          vtc.start_seconds                 AS start_seconds,
+          dub_mux.playback_id               AS playback_id,
+          1 - (vtc.embedding <=> ${queryEmbedding}::vector) AS source_score,
+          vtc.embedding::text               AS embedding_text
+        FROM video_transcript_chunk vtc
+        JOIN video_transcript vt ON vt.id = vtc.transcript_id
+        JOIN video v ON v.id = vt.video_id
+          AND v.deleted_at IS NULL
+        JOIN video_locale vl
+          ON vl.video_id = v.id
+          AND vl.locale = ${locale}
+          AND vl.status = 'published'
+        LEFT JOIN LATERAL (
+          SELECT mv.playback_id
+          FROM video_dub vd
+          JOIN language lg ON lg.id = vd.language_id
+            AND lg.bcp47 = ${locale}
+
+          LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+          WHERE vd.video_edition_id = vt.video_edition_id
+            AND vd.deleted_at IS NULL
+          ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
+          LIMIT 1
+        ) dub_mux ON true
+        LEFT JOIN LATERAL (
+          SELECT vi2.mobile_cinematic_high, vi2.url
+          FROM video_image vi2
+          WHERE vi2.video_id = v.id
+            AND vi2.deleted_at IS NULL
+          ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
+          LIMIT 1
+        ) vi ON true
+        WHERE vtc.embedding IS NOT NULL
+          AND vtc.language = ${locale}
+          AND vt.language = ${locale}
+        ORDER BY
+          vt.video_id,
+          vtc.embedding <=> ${queryEmbedding}::vector,
+          vtc.start_seconds ASC NULLS LAST,
+          vtc.id ASC
+      ) best_transcript_per_video
+      ORDER BY source_score DESC, start_seconds ASC NULLS LAST, evidence_id ASC
+      LIMIT ${candidateLimit}
+    )
+    SELECT * FROM scene_source
+    UNION ALL
+    SELECT * FROM transcript_source
   `
 
-  return rows.map((row) => ({
-    resultType: "video" as const,
-    resultId: row.video_id,
-    videoCoreId: row.video_core_id,
-    videoSlug: row.video_slug ?? "",
-    videoTitle: row.video_title ?? "",
-    imageUrl: row.image_url ?? null,
-    sceneDescription: row.scene_description,
-    startSeconds: Number(row.start_seconds),
-    playbackId: row.playback_id,
-    similarity: Number(row.similarity),
-    embeddingText: row.embedding_text,
-  }))
+  return mixVideoSemanticEvidenceRows(evidenceRows)
+    .slice(0, limit)
+    .map((row) => ({
+      resultType: "video" as const,
+      resultId: row.video_id,
+      videoCoreId: row.video_core_id,
+      videoSlug: row.video_slug ?? "",
+      videoTitle: row.video_title ?? "",
+      imageUrl: row.image_url ?? null,
+      sceneDescription: row.scene_description,
+      startSeconds:
+        row.start_seconds == null ? null : Number(row.start_seconds),
+      playbackId: row.playback_id,
+      similarity: Number(row.similarity),
+      embeddingText: row.embedding_text,
+    }))
 }
 
 /**

--- a/apps/admin/src/services/hybrid-search.debug.test.ts
+++ b/apps/admin/src/services/hybrid-search.debug.test.ts
@@ -181,6 +181,60 @@ describe("HybridSearchService debug payload routing", () => {
     expect(labels).toEqual(["keyword-video", "semantic-video"])
   })
 
+  it("a mixed semantic-video hit still exposes one debug origin and no public evidence fields", async () => {
+    vi.mocked(searchVideoKeyword).mockResolvedValue([])
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-mixed",
+        videoCoreId: "core-mixed",
+        videoSlug: "mixed",
+        videoTitle: "Mixed Evidence",
+        imageUrl: null,
+        sceneDescription: "Winning transcript or scene snippet",
+        startSeconds: 12,
+        playbackId: "mux-mixed",
+        similarity: 0.91,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "spoken phrase",
+      locale: "en",
+      debug: true,
+      contentTypes: ["video"],
+    })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0]!.debug!.retrieverRanks).toEqual([
+      { label: "semantic-video", rank: 1 },
+    ])
+    expect(Object.keys(result.results[0]!).sort()).toEqual(
+      [
+        "childCount",
+        "debug",
+        "durationSeconds",
+        "id",
+        "imageUrl",
+        "label",
+        "playbackId",
+        "score",
+        "slug",
+        "snippet",
+        "startSeconds",
+        "title",
+        "type",
+      ].sort(),
+    )
+  })
+
   it("dilutionCapApplied reflects the cap's per-result decision in keyword-first mode", async () => {
     // Bring up a keyword-first scenario where the cap fires on a
     // semantic-only row.

--- a/docs/plans/2026-05-21-001-feat-mixed-scene-transcript-video-semantic-search-plan.md
+++ b/docs/plans/2026-05-21-001-feat-mixed-scene-transcript-video-semantic-search-plan.md
@@ -1,0 +1,380 @@
+---
+title: "feat: Mix scene and transcript evidence in video semantic search"
+type: feat
+status: completed
+date: 2026-05-21
+origin: docs/brainstorms/2026-04-23-admin-hybrid-search-r4-requirements.md
+---
+
+# feat: Mix scene and transcript evidence in video semantic search
+
+## Problem Frame
+
+Admin search currently preserves the R4 migration shape: `semantic-video`
+is backed only by `video_scene_locale.embedding`, matching the old CMS
+scene-embedding behavior. `video_transcript_chunk.embedding` exists and is
+included in corpus fingerprints, but it is not part of live semantic search.
+
+That was correct for migration parity, but it is no longer the product goal.
+The video semantic signal should use both visual scene understanding and spoken
+transcript evidence as primary sources. The important architecture constraint is
+that transcript should **not** become another top-level RRF list. Scene and
+transcript evidence should be mixed inside one `semantic-video` retriever, then
+the existing RRF stage should continue to fuse one video semantic list with
+keyword video, semantic experience, and keyword experience.
+
+## Scope
+
+In scope:
+
+- Change admin's video semantic retriever so `semantic-video` internally queries
+  both `video_scene_locale.embedding` and `video_transcript_chunk.embedding`.
+- Collapse scene and transcript matches to one ranked semantic candidate per
+  video before RRF.
+- Preserve the public `/api/search` and GraphQL search response shape unless
+  debug-only metadata can be added without changing the normal contract.
+- Add targeted tests that prove transcript-only, scene-only, and mixed
+  scene+transcript cases behave deterministically.
+- Update the relevant plan/solution notes so future work does not reintroduce
+  the "transcript as fifth RRF list" framing.
+
+Out of scope:
+
+- Running production embedding backfills or manager enrichment jobs.
+- Changing transcript/scene embedding generation workflows.
+- Adding personalization, cross-encoder reranking, popularity boosting, or a new
+  public search-result field.
+- Fixing incomplete scene or transcript coverage in production data.
+- Changing apps/cms search.
+
+## Requirements
+
+- **R1. Single RRF input.** `semantic-video` remains one top-level list in
+  `HybridSearchService`; do not add `semantic-transcript-video` as a fifth RRF
+  list.
+- **R2. Dual evidence sources.** The video semantic retriever considers both
+  `video_scene_locale.embedding` and `video_transcript_chunk.embedding` for the
+  requested locale/language.
+- **R3. One row per video.** Scene and transcript candidates are mixed before
+  returning from the retriever. RRF receives at most one semantic video item per
+  video.
+- **R4. Consumer visibility.** Preserve the existing published-only gate:
+  `video.deleted_at IS NULL` plus `video_locale.status = 'published'` for the
+  requested locale.
+- **R5. Contract stability.** Normal search responses still return
+  `SearchResult` fields: `type`, `id`, `slug`, `title`, `imageUrl`, `snippet`,
+  `startSeconds`, `playbackId`, `score`.
+- **R6. Degradation behavior.** Query embedding failure still produces
+  `searchMode: "keyword-only"` and skips all semantic retrievers.
+- **R7. Dedup compatibility.** Preserve service-internal `embeddingText` for
+  video dedup. When both sources match a video, carry the winning evidence
+  vector text rather than exposing or averaging vectors.
+- **R8. Debug clarity.** Existing debug origin labels continue to show one
+  `semantic-video` contribution. If source metadata is added, it must be
+  internal/debug-only and must not encourage consumers to branch on it.
+
+## Current Architecture
+
+```mermaid
+flowchart TD
+  Q["User query"] --> E["Query embedding"]
+  E --> SV["semantic-video retriever"]
+  SV --> VSL["video_scene_locale.embedding"]
+  VSL --> BV["Best scene per video"]
+  BV --> RRF["RRF fusion"]
+  Q --> KV["keyword-video"]
+  E --> SE["semantic-experience"]
+  Q --> KE["keyword-experience"]
+  KV --> RRF
+  SE --> RRF
+  KE --> RRF
+```
+
+## Target Architecture
+
+```mermaid
+flowchart TD
+  Q["User query"] --> E["Query embedding"]
+  E --> SV["Video semantic retriever"]
+  SV --> SC["Scene candidate scan\nvideo_scene_locale.embedding"]
+  SV --> TC["Transcript candidate scan\nvideo_transcript_chunk.embedding"]
+  SC --> MX["Evidence mixer\none semantic candidate per video"]
+  TC --> MX
+  MX --> RRF["RRF fusion"]
+  Q --> KV["keyword-video"]
+  E --> SE["semantic-experience"]
+  Q --> KE["keyword-experience"]
+  KV --> RRF
+  SE --> RRF
+  KE --> RRF
+```
+
+## Existing Patterns To Follow
+
+- `apps/admin/src/services/hybrid-search-retrievers.ts` owns raw SQL retrievers
+  and should remain the main implementation point.
+- `apps/admin/src/services/hybrid-search.service.ts` owns orchestration and
+  list labels. The `semantic-video` label should stay stable.
+- `apps/admin/src/services/hybrid-search-fusion.ts` and
+  `apps/admin/src/services/video-dedup.ts` already consume `embeddingText` for
+  video-only dedup.
+- `apps/admin/src/services/search-eval/fingerprint.ts` already fingerprints
+  `video_transcript_chunk`, which becomes accurate once transcripts participate
+  in search.
+- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md` documents the old
+  migration-parity decision and should be updated after implementation.
+- `docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md`
+  documents the transcript embedding storage/source pattern.
+- `docs/solutions/platform/admin-scene-embeddings-indexer-pattern.md` documents
+  the scene embedding storage/source pattern.
+
+## Technical Decisions
+
+### Decision 1: Mix inside `searchVideoSemantic`
+
+Keep `searchVideoSemantic` as the public service-level retriever function and
+change its internals from "best scene per video" to "best mixed evidence per
+video." This preserves orchestration, debug labels, and RRF assumptions.
+
+Rationale: the user intent is one video semantic signal. A separate transcript
+list would double-count videos that match both modalities and would make RRF
+the modality mixer, which is not the desired architecture.
+
+### Decision 2: Use candidate CTEs plus a mixer
+
+Use two bounded candidate sets:
+
+- scene evidence from `video_scene_locale.embedding`;
+- transcript evidence from `video_transcript_chunk.embedding` joined through
+  `video_transcript`.
+
+Then union or join those candidate sets into a per-video mixer that chooses one
+output row per video. Keep limits bounded before and after mixing so pgvector
+work does not expand unboundedly.
+
+Rationale: this keeps each pgvector scan simple and lets tests reason about the
+mixing rules independently from RRF.
+
+### Decision 3: Start with conservative score mixing
+
+Use the best individual evidence score as the base score. When the same video
+has both scene and transcript evidence in the candidate window, apply at most a
+small bounded agreement bonus. The implementation should make the bonus easy to
+adjust and tests should assert ordering relationships rather than brittle exact
+floating-point formulas.
+
+Rationale: transcript and scene should reinforce each other, but a weak second
+source should not overpower a clearly stronger single-source result.
+
+### Decision 4: Snippet/timecode comes from winning evidence
+
+The returned `snippet`, `startSeconds`, `playbackId`, and `embeddingText` should
+come from the evidence source that wins the per-video mix. A transcript win uses
+chunk text and chunk `startSeconds`; a scene win uses scene description and
+scene `startSeconds`. If both sources contribute but scene has the stronger
+score, keep the scene snippet; if transcript has the stronger score, keep the
+transcript snippet.
+
+Rationale: the result should show the user why that video matched, and
+`embeddingText` must stay aligned with the snippet source for dedup.
+
+### Decision 5: No normal response-shape change
+
+Do not add source fields to the normal REST/GraphQL result. If source reporting
+is useful for operations, keep it behind existing debug structures or service-
+internal metadata.
+
+Rationale: this is an internal ranking improvement, not a consumer contract
+expansion.
+
+## Implementation Units
+
+### U1. Add roadmap trace and characterization tests
+
+Files:
+
+- `docs/roadmap/content-discovery/feat-010-semantic-search-api.md`
+- `docs/roadmap/content-discovery/feat-086-experience-search-integration.md`
+- new or updated roadmap ticket under `docs/roadmap/content-discovery/`
+- `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+
+Work:
+
+- Add or update a content-discovery roadmap ticket before implementation so the
+  work is traceable under the repo's roadmap rules.
+- Mark the ticket `status: "in-progress"` before code work.
+- Add characterization coverage for current `searchVideoSemantic` result shape:
+  one semantic video row, `embeddingText` present, published locale gate applied,
+  and `semantic-video` still expected as the service label.
+
+Test scenarios:
+
+- A scene row with matching locale and published `video_locale` maps to one
+  `VideoSemanticResult`.
+- A scene row with non-matching locale is excluded.
+- A video with `deleted_at` set or unpublished `video_locale.status` is excluded.
+- The retriever still returns `embeddingText` for video dedup.
+
+### U2. Add transcript semantic candidates
+
+Files:
+
+- `apps/admin/src/services/hybrid-search-retrievers.ts`
+- `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+- `apps/admin/prisma/schema.prisma` for reference only; avoid schema changes
+  unless implementation uncovers a missing index.
+
+Work:
+
+- Extend the video semantic SQL to read transcript chunk evidence from
+  `video_transcript_chunk`.
+- Join through `video_transcript` to resolve `video_id`, `video_edition_id`, and
+  language.
+- Apply locale/language gating consistently with admin's `Language.bcp47` and
+  existing `video_locale.locale`.
+- Resolve `playbackId` for transcript wins through the same video edition and
+  locale-aware dub/mux chain used by scene semantic results.
+- Keep transcript chunks with null playback available as semantic matches; they
+  should behave like existing scene results whose mux lookup returns null.
+
+Test scenarios:
+
+- A transcript chunk with an embedding and matching language/locale can produce
+  a semantic video result when there is no scene embedding.
+- A transcript chunk in a different language is excluded.
+- A transcript chunk for an unpublished locale is excluded.
+- A transcript chunk with null `embedding` is excluded.
+- Transcript result snippet uses chunk text and `startSeconds` uses chunk
+  `startSeconds`.
+
+### U3. Mix scene and transcript evidence per video
+
+Files:
+
+- `apps/admin/src/services/hybrid-search-retrievers.ts`
+- `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+
+Work:
+
+- Build scene and transcript candidate sets with source markers.
+- Combine them into one per-video output using deterministic ordering:
+  combined score desc, best raw source score desc, source tie-breaker, stable id
+  tie-breaker.
+- Return one `VideoSemanticResult` per video.
+- Preserve `similarity` as the mixed score used for rank ordering. If retaining
+  raw source score is useful, keep it internal unless debug plumbing needs it.
+
+Test scenarios:
+
+- Scene-only video returns normally.
+- Transcript-only video returns normally.
+- A video with both scene and transcript evidence outranks a single-source video
+  when raw scores are close enough for the bounded agreement bonus to matter.
+- A much stronger single-source video can still outrank a weaker dual-source
+  video.
+- When scene wins, result snippet/timecode/embeddingText come from the scene.
+- When transcript wins, result snippet/timecode/embeddingText come from the
+  transcript chunk.
+- Tie-breaking is deterministic across repeated calls.
+
+### U4. Preserve orchestration, RRF, debug, and keyword-first behavior
+
+Files:
+
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/services/hybrid-search.service.test.ts`
+- `apps/admin/src/services/hybrid-search.keyword-first.test.ts`
+- `apps/admin/src/services/hybrid-search.dilution-cap.test.ts`
+- `apps/admin/src/services/hybrid-search.debug.test.ts`
+- `apps/admin/src/graphql/types/hybrid-search-debug.ts` only if debug metadata
+  changes.
+
+Work:
+
+- Keep `searchVideoSemantic` dispatched under the `semantic-video` label.
+- Confirm keyword-first mode still shares the same video semantic retriever.
+- Confirm dilution cap logic still sees one semantic-video source.
+- If adding debug-only evidence metadata, ensure normal response shape does not
+  change and debug descriptions warn labels/metadata are unstable.
+
+Test scenarios:
+
+- Hybrid search still dispatches one `semantic-video` list, not separate scene
+  and transcript lists.
+- Keyword-first search still calls `searchVideoSemantic` when embeddings are
+  available.
+- Query embedding failure still skips semantic retrievers and returns
+  `searchMode: "keyword-only"`.
+- Debug origins include `semantic-video` once for a mixed semantic match.
+- Dilution cap behavior is unchanged for semantic-video rows.
+
+### U5. Update search eval and durable docs
+
+Files:
+
+- `apps/admin/src/services/search-eval/fingerprint.ts`
+- `apps/admin/src/services/search-eval/fingerprint.test.ts`
+- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md`
+- optional new solution doc under `docs/solutions/platform/`
+- roadmap ticket from U1
+
+Work:
+
+- Keep transcript embedding counts in the search-eval fingerprint and update any
+  wording that implied transcript embeddings were unused by live search.
+- Update the R4 solution doc's post-cutover note: the selected follow-up is not
+  a fifth RRF list; it is mixed video semantic evidence.
+- Mark the roadmap ticket `status: "complete"` after code and validation.
+
+Test scenarios:
+
+- Fingerprint tests still assert `video_transcript_chunk` participates in corpus
+  drift detection.
+- Documentation mentions one mixed `semantic-video` retriever and avoids "fifth
+  list" as the recommended architecture.
+
+## Verification Plan
+
+Run PR-focused validation for the admin search scope:
+
+- `pnpm --filter @forge/admin test -- hybrid-search-retrievers.test.ts`
+- `pnpm --filter @forge/admin test -- hybrid-search.service.test.ts`
+- `pnpm --filter @forge/admin test -- hybrid-search.keyword-first.test.ts`
+- `pnpm --filter @forge/admin test -- hybrid-search.dilution-cap.test.ts`
+- `pnpm --filter @forge/admin test -- hybrid-search.debug.test.ts`
+- `pnpm --filter @forge/admin test -- search-eval/fingerprint.test.ts`
+
+If implementation changes GraphQL debug types or public schema descriptions,
+also regenerate and validate the admin schema according to
+`apps/admin/AGENTS.md`.
+
+Before merging, run a small search-eval comparison with canary queries that
+include spoken-content phrases likely to appear in transcript chunks but not in
+scene descriptions. The expected outcome is that transcript-only evidence can
+surface a video without adding an extra RRF list.
+
+## Risks And Mitigations
+
+- **Ranking regression from over-boosting dual-source videos.** Use a bounded
+  agreement bonus and tests that prove a strong single-source result can still
+  win.
+- **SQL performance regression from two pgvector scans.** Bound candidate
+  windows, inspect existing indexes before implementation, and use EXPLAIN on a
+  prod-like dataset before broad rollout.
+- **Locale mismatch between transcript language and video locale.** Gate through
+  admin's language model deliberately; do not invent an English fallback.
+- **Public contract drift.** Keep source metadata out of normal responses.
+- **Data readiness confusion.** Product code can support transcript evidence
+  before production has full transcript coverage; rollout notes should separate
+  code readiness from corpus completeness.
+
+## Open Questions For Implementation
+
+- What exact bounded agreement bonus produces the best search-eval result on
+  current canaries?
+- Should debug mode expose `semanticEvidenceSource` values such as `scene`,
+  `transcript`, or `scene+transcript`, or is that too tempting for consumers to
+  depend on?
+- Are current pgvector indexes sufficient for transcript candidate scans at full
+  production corpus size, or do we need a migration for partial HNSW indexes by
+  language/locale?

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (May 22, 2026)
 
-- **Total tickets:** 150
-- **Complete:** 79
+- **Total tickets:** 151
+- **Complete:** 80
 - **In progress:** 10
 - **Not started:** 19
 - **Blocked:** 42
@@ -31,6 +31,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-127](content-discovery/feat-127-manager-durable-admin-trigger-job-state.md)                              | Manager durable admin-trigger job state for operator enrichment                                 | nisal     | P0       | 2026-05-19 | 2    | 2026-05-20 | not-started |
 | [feat-128](content-discovery/feat-128-enrichment-backfill-failure-resilience.md)                               | Enrichment backfill failure resilience                                                          | nisal     | P0       | 2026-05-19 | 1    | 2026-05-19 | complete    |
 | [feat-126](content-discovery/feat-126-manager-admin-lookup-tail-latency-recovery.md)                           | Recover manager enrichment dispatch from admin lookup tail latency                              | nisal     | P0       | 2026-05-20 | 1    | 2026-05-20 | complete    |
+| [feat-131](content-discovery/feat-131-mixed-scene-transcript-video-semantic-search.md)                         | Mixed scene and transcript evidence for admin video semantic search                             | nisal     | P1       | 2026-05-21 | 1    | 2026-05-21 | complete    |
 | [feat-097](content-discovery/feat-097-investigate-prod-query-embedding.md)                                     | Investigate Production Query Embedding Degradation                                              | nisal     | P1       | 2026-04-15 | 2    | 2026-04-16 | complete    |
 | [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)                                        | Experience Embedding Pipeline                                                                   | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |
 | [feat-037](content-discovery/feat-037-video-content-vectorization.md)                                          | Video Content Vectorization for Recommendations                                                 | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | complete    |

--- a/docs/roadmap/content-discovery/feat-010-semantic-search-api.md
+++ b/docs/roadmap/content-discovery/feat-010-semantic-search-api.md
@@ -14,6 +14,7 @@ blocks:
   - "feat-012"
   - "feat-086"
   - "feat-106"
+  - "feat-131"
 tags:
   - "cms"
   - "search"

--- a/docs/roadmap/content-discovery/feat-041-scene-embeddings-table.md
+++ b/docs/roadmap/content-discovery/feat-041-scene-embeddings-table.md
@@ -13,6 +13,7 @@ blocks:
   - "feat-042"
   - "feat-044"
   - "feat-045"
+  - "feat-131"
 tags:
   - "cms"
   - "pgvector"

--- a/docs/roadmap/content-discovery/feat-080-transcript-embedding-table-rename.md
+++ b/docs/roadmap/content-discovery/feat-080-transcript-embedding-table-rename.md
@@ -8,7 +8,8 @@ start_date: "2026-04-10"
 duration: 2
 depends_on:
   - "feat-009"
-blocks: []
+blocks:
+  - "feat-131"
 tags:
   - "cms"
   - "pgvector"

--- a/docs/roadmap/content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md
+++ b/docs/roadmap/content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md
@@ -3,14 +3,13 @@ id: "feat-119"
 title: "Embed Backfill — Classify NoSuchKey + emit missingArtifacts list + decoupled enrichment trigger"
 owner: "nisal"
 priority: "P2"
-status: "in-progress"
+status: "complete"
 start_date: "2026-05-06"
 duration: 4
 depends_on: []
 blocks:
   - "feat-120"
   - "feat-125"
-  - "feat-126"
 tags:
   - "admin"
   - "manager"
@@ -329,6 +328,19 @@ The embed workflow has zero knowledge of the enrichment workflow. The trigger en
 - **Idempotency.** Two calls for the same `(assetId, kind)` in flight produce one manager job, not two.
 
 ## Verification
+
+### Completion evidence
+
+Verified 2026-05-19 during the Compound Engineering work loop. The
+implementation already landed on `main` in the expected stacked PRs:
+
+- PR #892 / `87d2b985` — `feat(admin): classify NoSuchKey as artifact_missing + emit missingArtifacts list (feat-119 PR1)`.
+- PR #893 / `e56aceac` — `feat(admin): decoupled enrichment-trigger endpoint + GraphQL mutation + CLI (feat-119 PR2)`.
+
+Focused validation on the current checkout:
+
+- `pnpm --filter @forge/admin test -- manager-artifacts.service.test.ts sceneEmbeddingBackfill.test.ts transcriptEmbeddingBackfill.test.ts graphql/mutations/manager-enrichment.test.ts graphql/mutations/scene-embedding.test.ts graphql/mutations/transcript-embedding.test.ts services/manager-trigger.service.test.ts` — 7 files / 137 tests passed.
+- `pnpm --filter @forge/manager test -- admin-trigger-auth.test.ts admin-trigger-route.test.ts app/api/admin-trigger/scene-analysis/route.test.ts app/api/admin-trigger/transcript/route.test.ts` — 4 files / 42 tests passed.
 
 ### PR1
 

--- a/docs/roadmap/content-discovery/feat-120-localized-scene-embeddings-and-snippets.md
+++ b/docs/roadmap/content-discovery/feat-120-localized-scene-embeddings-and-snippets.md
@@ -3,7 +3,7 @@ id: "feat-120"
 title: "Localized Scene Embeddings + Translated Snippets — true per-locale semantic search"
 owner: "nisal"
 priority: "P1"
-status: "not-started"
+status: "in-progress"
 start_date: "2026-05-13"
 duration: 7
 depends_on:

--- a/docs/roadmap/content-discovery/feat-131-mixed-scene-transcript-video-semantic-search.md
+++ b/docs/roadmap/content-discovery/feat-131-mixed-scene-transcript-video-semantic-search.md
@@ -1,0 +1,100 @@
+---
+id: "feat-131"
+title: "Mixed scene and transcript evidence for admin video semantic search"
+owner: "nisal"
+priority: "P1"
+status: "complete"
+start_date: "2026-05-21"
+duration: 1
+depends_on:
+  - "feat-010"
+  - "feat-041"
+  - "feat-080"
+blocks: []
+tags:
+  - "admin"
+  - "search"
+  - "embeddings"
+  - "pgvector"
+---
+
+## Problem
+
+Admin video semantic search currently reads only `video_scene_locale.embedding`.
+That preserves the original scene-search migration shape, but it misses spoken
+phrases and subtitle/transcript-only concepts that already exist in
+`video_transcript_chunk.embedding`.
+
+The next phase should treat scene descriptions and transcript chunks as primary
+video-semantic evidence without changing the public search contract or adding a
+separate top-level RRF list.
+
+## Entry Points - Read These First
+
+1. `apps/admin/src/services/hybrid-search-retrievers.ts` - `searchVideoSemantic`
+   owns the raw pgvector SQL for video semantic retrieval.
+2. `apps/admin/src/services/hybrid-search.service.ts` - dispatches
+   `semantic-video` as one labeled list into RRF and owns debug rank origins.
+3. `apps/admin/src/services/hybrid-search-fusion.ts` - RRF property merge and
+   dedup input shape.
+4. `apps/admin/src/services/video-dedup.ts` - consumes semantic
+   `embeddingText` internally for video dedup.
+5. `apps/admin/prisma/schema.prisma` - `VideoSceneLocale` and
+   `VideoTranscriptChunk` vector storage and locale/language fields.
+
+## Grep These
+
+```
+grep -rn "searchVideoSemantic\\|semantic-video" apps/admin/src/services
+grep -rn "video_scene_locale\\|video_transcript_chunk" apps/admin/src apps/admin/prisma
+grep -rn "embeddingText\\|deduplicateResults" apps/admin/src/services
+grep -rn "semantic-transcript-video\\|5th RRF\\|fifth RRF" docs apps/admin
+```
+
+## What To Build
+
+1. Extend `searchVideoSemantic` so it queries both:
+   - `video_scene_locale.embedding`
+   - `video_transcript_chunk.embedding`
+2. Keep transcript evidence inside the existing `semantic-video` retriever; do
+   not add `semantic-transcript-video` or any fifth RRF list.
+3. Collapse scene and transcript evidence to one ranked semantic candidate per
+   video before RRF.
+4. Preserve published/deleted gates:
+   - `video.deleted_at IS NULL`
+   - `video_locale.status = 'published'`
+   - requested locale/language only
+   - `embedding IS NOT NULL`
+5. Preserve public REST and GraphQL response shape. Normal results still expose
+   `type`, `id`, `slug`, `title`, `imageUrl`, `snippet`, `startSeconds`,
+   `playbackId`, and `score`.
+6. Preserve query-embedding failure degradation to
+   `searchMode: "keyword-only"`.
+7. Preserve service-internal `embeddingText` for video dedup, sourced from the
+   winning scene or transcript evidence.
+
+## Constraints
+
+- Do not change transcript or scene embedding generation workflows.
+- Do not run production backfills from this work.
+- Do not expose vector, embedding, similarity, or evidence-source fields on the
+  normal public search result.
+- Do not make transcript a separate RRF contributor.
+- Keep pgvector filters on the same table as the vector column:
+  `video_scene_locale.locale` for scenes and `video_transcript_chunk.language`
+  for transcripts.
+
+## Verification
+
+- Transcript-only semantic evidence can surface a video.
+- Scene-only semantic evidence still works.
+- Scene+transcript evidence for one video is mixed into one `semantic-video`
+  candidate, not two RRF entries.
+- Strong single-source evidence can outrank weaker mixed evidence.
+- Snippet, timecode, and `embeddingText` come from the winning evidence source.
+- Debug origins still show one `semantic-video` contribution.
+- Run:
+
+```
+pnpm --filter @forge/admin test -- hybrid-search-retrievers.test.ts hybrid-search.service.test.ts hybrid-search.keyword-first.test.ts hybrid-search.dilution-cap.test.ts hybrid-search.debug.test.ts search-eval/fingerprint.test.ts
+```

--- a/docs/roadmap/platform/feat-104-admin-railway-provisioning.md
+++ b/docs/roadmap/platform/feat-104-admin-railway-provisioning.md
@@ -3,7 +3,7 @@ id: "feat-104"
 title: "Provision apps/admin on Railway"
 owner: "nisal"
 priority: "P0"
-status: "in-progress"
+status: "complete"
 start_date: "2026-04-20"
 duration: 1
 depends_on:
@@ -112,6 +112,22 @@ guidance.
   passes. R2 is its own handoff.
 
 ## Verification
+
+### Completion evidence
+
+Verified 2026-05-19 via Railway GraphQL project token and live production
+endpoints:
+
+- Railway `forge` / `production` has service `@forge/admin`
+  (`bdb15048-1ca9-4217-ae01-ef7cc19ca6f4`).
+- Latest deployment `5e8d4569-bb61-4037-ba86-3a239f6f6a71` is `SUCCESS`.
+- Custom domain `admin.jesusfilm.org` and Railway service domain
+  `forgeadmin-production-f4d1.up.railway.app` are attached.
+- Service start command runs `pnpm --filter @forge/admin db:migrate:deploy`
+  before starting the standalone Next.js server.
+- `https://admin.jesusfilm.org/api/health` returns HTTP 200.
+- `https://admin.jesusfilm.org/api/graphql` responds to `{ __typename }`
+  with `{"data":{"__typename":"Query"}}`.
 
 ### Deploy health
 

--- a/docs/solutions/platform/admin-hybrid-search-r4-pattern.md
+++ b/docs/solutions/platform/admin-hybrid-search-r4-pattern.md
@@ -24,7 +24,8 @@ shape-equivalent on top of admin's per-locale Prisma schema.
    `keyword-experience`. RRF k = 60, normalization by `lists.length /
 (k + 1)`, descending score sort. Empty lists are filtered out
    before fusion (RRF normalizes by list count — feeding empty ones
-   dilutes scores from lists that did contribute).
+   dilutes scores from lists that did contribute). Transcript evidence
+   belongs inside `semantic-video`, not as a fifth list.
 2. **3-layer video-only dedup.** coreId prefix match, exact title,
    embedding cosine > 0.95. Experience rows bypass all three checks.
    Cosine dedup needs per-row `embeddingText`, which is why the
@@ -87,13 +88,27 @@ silently reverts the query to Seq Scan.
 
 ## What stays unused in R4
 
-- **`VideoTranscriptChunk.embedding`** (R2). Deliberately not fused.
-  Adding a 5th RRF list for transcripts would diverge from cms's
-  4-list ranking during the R3→R8 validation window. Post-cutover
-  follow-up that won't require consumer-contract changes.
 - **`ExperienceLocale.ogImageUrl`.** Populated by R3, but the R4
   response maps `imageUrl: null` for experience results per cms
   parity. Upgrade lands after R8.
+
+## Post-R4 video semantic upgrade
+
+`semantic-video` now mixes two primary evidence sources internally:
+
+- `video_scene_locale.embedding` for localized multimodal scene descriptions.
+- `video_transcript_chunk.embedding` for spoken transcript chunks.
+
+The retriever performs bounded scene and transcript vector scans, collapses to
+the best evidence per source per video, applies a small bounded agreement bonus
+when both sources support the same video, and returns one ranked semantic video
+candidate per video to RRF. The winning raw source owns the public-facing
+snippet/timecode and the service-internal `embeddingText` used by video dedup.
+
+This keeps the four-list RRF invariant intact. Do **not** add
+`semantic-transcript-video` as a separate RRF input unless the product decision
+changes explicitly; doing so double-counts semantic video evidence and changes
+debug/dilution semantics.
 
 ## What R4 establishes as admin-first patterns
 
@@ -129,9 +144,6 @@ tradeoff.
 
 - Wire `ExperienceLocale.ogImageUrl` through `imageUrl` for experience
   results (once cms/admin diff invariant is no longer needed).
-- Add `VideoTranscriptChunk.embedding` as a 5th RRF list (`semantic-
-transcript-video`) with per-chunk dedup to avoid double-counting a
-  video that hits on both scene and transcript matches.
 - Rename `generateExperienceEmbedding` to `embedText`.
 - Add EDITOR/ADMIN widening to the `search` field if the admin
   dashboard grows a search UX that needs to see drafts.

--- a/docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md
+++ b/docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md
@@ -1,0 +1,92 @@
+---
+title: "Admin video semantic search: mix scene and transcript evidence inside one retriever"
+date: 2026-05-21
+problem_type: architecture_pattern
+component: service_object
+severity: medium
+module: apps/admin
+tags:
+  - admin
+  - search
+  - pgvector
+  - rrf
+  - transcript-embedding
+  - scene-embedding
+related_features:
+  - feat-010
+  - feat-041
+  - feat-080
+  - feat-131
+related:
+  - "docs/solutions/platform/admin-hybrid-search-r4-pattern.md"
+  - "docs/solutions/platform/admin-scene-embeddings-indexer-pattern.md"
+  - "docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md"
+date_learned: 2026-05-21
+---
+
+## Context
+
+Admin search originally kept R4 parity with cms: `semantic-video` was backed by
+scene embeddings only. Once transcript chunk vectors became product-relevant,
+the tempting implementation was a new `semantic-transcript-video` list in RRF.
+That would double-count videos that match both scene and transcript evidence.
+
+## Guidance
+
+Keep the public retrieval topology stable: one `semantic-video` list flows into
+RRF. Mix source evidence inside `searchVideoSemantic`.
+
+The pattern:
+
+1. Query scene evidence from `video_scene_locale.embedding`.
+2. Query transcript evidence from `video_transcript_chunk.embedding`.
+3. Select the best row per video per source before bounding each source window.
+4. In service code, group rows by video and choose one winning evidence row.
+5. Score the video by best raw source score plus a small bounded agreement bonus
+   when both sources support it.
+6. Return one `VideoSemanticResult` per video.
+
+The winning evidence row owns `sceneDescription`, `startSeconds`, `playbackId`,
+and service-internal `embeddingText`. Do not average vectors or expose evidence
+source in the normal REST/GraphQL result.
+
+## Why This Matters
+
+RRF should combine different retrieval families, not independently count every
+semantic modality. Keeping transcript inside `semantic-video` preserves debug
+labels, keyword-first dilution semantics, public response shape, and video dedup
+behavior.
+
+The pgvector constraint is also important: filters that should use partial HNSW
+indexes must live on the same table as the vector:
+
+- scenes filter `video_scene_locale.locale`;
+- transcripts filter `video_transcript_chunk.language`.
+
+Filtering only through joined parent rows risks planner index bypass.
+
+## When To Apply
+
+Use this pattern when adding another evidence source that is still part of the
+same product signal. A new RRF list is appropriate only when the source is a
+distinct retrieval family with independent product meaning.
+
+## Examples
+
+Good:
+
+```text
+semantic-video = mixed(scene evidence, transcript evidence)
+RRF inputs = semantic-video, keyword-video, semantic-experience, keyword-experience
+```
+
+Avoid:
+
+```text
+semantic-video = scene evidence
+semantic-transcript-video = transcript evidence
+RRF inputs = five lists
+```
+
+The second shape changes scoring semantics and makes a video with both scene and
+transcript hits look like it matched two independent retrieval families.

--- a/docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md
+++ b/docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md
@@ -1,6 +1,6 @@
 ---
 title: "Admin transcript-embeddings indexer: reuse manager's precomputed vectors from S3, never regenerate"
-last_updated: 2026-04-22
+last_updated: 2026-05-21
 problem_type: best_practice
 component: service_object
 root_cause: cross_service_vector_trust_boundary
@@ -28,6 +28,19 @@ related:
   - "docs/solutions/best-practices/zod-validation-errors-must-not-echo-user-controlled-input-20260420.md"
 date_learned: 2026-04-22
 ---
+
+## Search usage update (feat-131)
+
+Transcript chunk vectors are now live search evidence in admin, but they still
+do not form a separate RRF list. `searchVideoSemantic` mixes
+`video_transcript_chunk.embedding` with `video_scene_locale.embedding` inside
+one `semantic-video` retriever, then emits one candidate per video to the
+existing RRF pipeline.
+
+The performance rule from this doc remains load-bearing: transcript semantic
+search filters on `video_transcript_chunk.language`, not only
+`video_transcript.language`, so the planner can use the same-table partial HNSW
+indexes.
 
 ## Stage 3 (feat-117) update
 


### PR DESCRIPTION
## Summary

Admin video semantic search can now find videos from either visual scene descriptions or spoken transcript chunks without changing the public search contract. Transcript matches are mixed inside the existing `semantic-video` retriever, so RRF still sees one video-semantic list instead of double-counting scene and transcript evidence as separate retrieval families.

This keeps snippets, timecodes, playback ids, and dedup embedding text tied to the winning evidence source while still giving a small bounded bonus when both scene and transcript evidence support the same video. The roadmap ticket was renumbered to `feat-131` while rebasing onto current `main`, because `feat-129` and `feat-130` now belong to the Mastra work.

## Validation

- `pnpm --filter @forge/admin test -- hybrid-search-retrievers.test.ts hybrid-search.service.test.ts hybrid-search.keyword-first.test.ts hybrid-search.dilution-cap.test.ts hybrid-search.debug.test.ts search-eval/fingerprint.test.ts`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin db:generate`
- `pnpm --filter @forge/admin typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
