### PR TITLE
chore(devcontainer): sync GitHub SSH keys

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -83,6 +83,72 @@ RUN mkdir -p /run/sshd /etc/ssh/sshd_config.d && \
     'AllowUsers vscode' \
     > /etc/ssh/sshd_config.d/forge-devcontainer.conf
 
+RUN cat > /usr/local/bin/sync-github-authorized-keys <<'EOF' && \
+  chmod 0755 /usr/local/bin/sync-github-authorized-keys
+#!/usr/bin/env bash
+set -euo pipefail
+
+authorized_keys="${HOME}/.ssh/authorized_keys"
+managed_begin="# BEGIN github.com public keys"
+managed_end="# END github.com public keys"
+
+if ! install -d -m 0700 "${HOME}/.ssh" 2>/dev/null; then
+  sudo install -d -o "$(id -u)" -g "$(id -g)" -m 0700 "${HOME}/.ssh"
+fi
+
+if ! touch "$authorized_keys" 2>/dev/null; then
+  sudo touch "$authorized_keys"
+  sudo chown "$(id -u):$(id -g)" "$authorized_keys"
+fi
+
+chmod 0600 "$authorized_keys"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI is not available; skipping automatic SSH authorized_keys setup." >&2
+  exit 0
+fi
+
+github_user="$(
+  gh auth status --hostname github.com 2>&1 |
+    sed -nE 's/.*Logged in to github\.com account ([^ ]+).*/\1/p' |
+    head -n 1
+)"
+
+if [ -z "$github_user" ]; then
+  echo "GitHub CLI is not authenticated; run 'gh auth login' inside the devcontainer to enable automatic SSH access." >&2
+  exit 0
+fi
+
+github_keys="$(
+  curl -fsSL "https://github.com/${github_user}.keys" |
+    grep -E '^(ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp[0-9]+|sk-ssh-ed25519@openssh.com|sk-ecdsa-sha2-nistp256@openssh.com) ' || true
+)"
+
+if [ -z "$github_keys" ]; then
+  echo "No SSH public keys found at https://github.com/${github_user}.keys." >&2
+  echo "Add an SSH key to GitHub, then restart the devcontainer to enable local SSH access." >&2
+  echo "GitHub SSH key settings: https://github.com/settings/keys" >&2
+  exit 0
+fi
+
+tmp="$(mktemp)"
+awk -v begin="$managed_begin" -v end="$managed_end" '
+  $0 == begin { skip = 1; next }
+  $0 == end { skip = 0; next }
+  !skip { print }
+' "$authorized_keys" > "$tmp"
+
+{
+  cat "$tmp"
+  printf '%s\n' "$managed_begin"
+  printf '%s\n' "$github_keys"
+  printf '%s\n' "$managed_end"
+} > "$authorized_keys"
+
+rm -f "$tmp"
+chmod 0600 "$authorized_keys"
+EOF
+
 # Set environment variables
 ENV DEVCONTAINER=true
 ENV SHELL=/bin/zsh

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     command: >
       bash -lc "sudo ssh-keygen -A &&
       sudo install -d -m 0755 /run/sshd &&
+      sudo install -d -o vscode -g vscode -m 0700 /home/vscode/.ssh &&
+      sync-github-authorized-keys &&
       sudo /usr/sbin/sshd &&
       sleep infinity"
 

--- a/docs/solutions/platform/devcontainer-setup.md
+++ b/docs/solutions/platform/devcontainer-setup.md
@@ -39,6 +39,14 @@ RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "$FNM_D
 - After rebuilding the devcontainer, verify `pg_restore --version`, `pg_dump --version`, and `psql --version` all report PostgreSQL 18 before restoring production backup artifacts.
 - PostgreSQL major-version upgrades cannot reuse an old data directory. Old `pgdata` volumes created with PostgreSQL 16 are intentionally not reused by the PG18 sidecar.
 
+## Local SSH access
+
+- The devcontainer exposes SSH on host port `127.0.0.1:2222` and disables password authentication.
+- Keep `/home/vscode/.ssh` on a named Compose volume so `authorized_keys` survives rebuilds and restarts.
+- Have the key-sync helper repair root-owned fresh named volumes with `sudo install`/`chown`; direct helper runs and normal container startup should both work.
+- Use the persisted GitHub CLI config volume to discover the authenticated GitHub username, then sync public keys from `https://github.com/<user>.keys` into a clearly marked managed block in `~/.ssh/authorized_keys`.
+- The sync step must be idempotent: remove the prior managed block before writing the latest GitHub keys so users can rotate keys without accumulating stale entries.
+
 ## Known gaps / watch-outs
 
 - `claude plugin marketplace add` runs during Docker build — requires public plugins or pre-auth


### PR DESCRIPTION
## Summary

- Add a devcontainer helper that syncs the authenticated GitHub user's public SSH keys into `~/.ssh/authorized_keys` using an idempotent managed block.
- Run the helper during app container startup before `sshd` starts, while repairing fresh/root-owned `.ssh` volumes.
- Document the local SSH access pattern in the devcontainer solution note.

## Validation

- `git diff --check`
- embedded `sync-github-authorized-keys` script parsed with `bash -n`
- `docker compose -f .devcontainer/docker-compose.yml config`
- `docker compose -f .devcontainer/docker-compose.yml build app`
- `docker compose -f .devcontainer/docker-compose.yml run --rm --no-deps app sync-github-authorized-keys`