### PR TITLE
docs(roadmap): close out core sync operations

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -4,14 +4,14 @@
 
 Build trusted, scalable AI capabilities that help people discover gospel content, engage meaningfully with Scripture, and take faithful next steps.
 
-## Status (May 22, 2026)
+## Status (May 24, 2026)
 
-- **Total tickets:** 151
-- **Complete:** 80
-- **In progress:** 10
-- **Not started:** 19
-- **Blocked:** 42
-- **Overdue and not complete:** 29
+- **Total tickets:** 153
+- **Complete:** 85
+- **In progress:** 8
+- **Not started:** 20
+- **Blocked:** 40
+- **Overdue and not complete:** 26
 
 ## Feature Index
 
@@ -31,7 +31,6 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-127](content-discovery/feat-127-manager-durable-admin-trigger-job-state.md)                              | Manager durable admin-trigger job state for operator enrichment                                 | nisal     | P0       | 2026-05-19 | 2    | 2026-05-20 | not-started |
 | [feat-128](content-discovery/feat-128-enrichment-backfill-failure-resilience.md)                               | Enrichment backfill failure resilience                                                          | nisal     | P0       | 2026-05-19 | 1    | 2026-05-19 | complete    |
 | [feat-126](content-discovery/feat-126-manager-admin-lookup-tail-latency-recovery.md)                           | Recover manager enrichment dispatch from admin lookup tail latency                              | nisal     | P0       | 2026-05-20 | 1    | 2026-05-20 | complete    |
-| [feat-131](content-discovery/feat-131-mixed-scene-transcript-video-semantic-search.md)                         | Mixed scene and transcript evidence for admin video semantic search                             | nisal     | P1       | 2026-05-21 | 1    | 2026-05-21 | complete    |
 | [feat-097](content-discovery/feat-097-investigate-prod-query-embedding.md)                                     | Investigate Production Query Embedding Degradation                                              | nisal     | P1       | 2026-04-15 | 2    | 2026-04-16 | complete    |
 | [feat-095](content-discovery/feat-095-experience-embedding-pipeline.md)                                        | Experience Embedding Pipeline                                                                   | nisal     | P1       | 2026-04-16 | 5    | 2026-04-20 | complete    |
 | [feat-037](content-discovery/feat-037-video-content-vectorization.md)                                          | Video Content Vectorization for Recommendations                                                 | nisal     | P1       | 2026-04-21 | 42   | 2026-06-01 | complete    |
@@ -44,8 +43,9 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-040](content-discovery/feat-040-multimodal-scene-descriptions.md)                                        | Video Vectorization — Multimodal Scene Analysis                                                 | nisal     | P1       | 2026-05-01 | 10   | 2026-05-10 | complete    |
 | [feat-091](content-discovery/feat-091-fpmc-video-page-recommendations.md)                                      | FPMC Video Page Recommendations                                                                 | nisal     | P1       | 2026-05-10 | 14   | 2026-05-23 | not-started |
 | [feat-041](content-discovery/feat-041-scene-embeddings-table.md)                                               | Video Vectorization — Scene Embeddings Table + Indexing                                         | nisal     | P1       | 2026-05-11 | 7    | 2026-05-17 | complete    |
-| [feat-120](content-discovery/feat-120-localized-scene-embeddings-and-snippets.md)                              | Localized Scene Embeddings + Translated Snippets — true per-locale semantic search              | nisal     | P1       | 2026-05-13 | 7    | 2026-05-19 | blocked     |
+| [feat-120](content-discovery/feat-120-localized-scene-embeddings-and-snippets.md)                              | Localized Scene Embeddings + Translated Snippets — true per-locale semantic search              | nisal     | P1       | 2026-05-13 | 7    | 2026-05-19 | in-progress |
 | [feat-042](content-discovery/feat-042-backfill-worker.md)                                                      | Video Vectorization — Phase 1 Backfill Worker (en/es/fr)                                        | nisal     | P1       | 2026-05-18 | 10   | 2026-05-27 | complete    |
+| [feat-131](content-discovery/feat-131-mixed-scene-transcript-video-semantic-search.md)                         | Mixed scene and transcript evidence for admin video semantic search                             | nisal     | P1       | 2026-05-21 | 1    | 2026-05-21 | complete    |
 | [feat-092](content-discovery/feat-092-two-tower-neural-recommendations.md)                                     | Two-Tower Neural Recommendation Model                                                           | nisal     | P1       | 2026-05-24 | 21   | 2026-06-13 | not-started |
 | [feat-044](content-discovery/feat-044-recommendation-query-api.md)                                             | Video Vectorization — Recommendation Query API                                                  | nisal     | P1       | 2026-05-28 | 7    | 2026-06-03 | complete    |
 | [feat-055](content-discovery/feat-055-smart-video-playlists.md)                                                | Smart Video Playlists                                                                           | vlad      | P1       | 2026-05-31 | 31   | 2026-06-30 | not-started |
@@ -53,7 +53,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-046](content-discovery/feat-046-recommendations-demo-experience.md)                                      | Video Vectorization — Recommendations Demo Experience                                           | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
 | [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)                                  | Deploy Semantic Search Architecture                                                             | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-080](content-discovery/feat-080-transcript-embedding-table-rename.md)                                    | Transcript Embedding Table Rename                                                               | nisal     | P2       | 2026-04-10 | 2    | 2026-04-11 | complete    |
-| [feat-119](content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md) | Embed Backfill — Classify NoSuchKey + emit missingArtifacts list + decoupled enrichment trigger | nisal     | P2       | 2026-05-06 | 4    | 2026-05-09 | in-progress |
+| [feat-119](content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md) | Embed Backfill — Classify NoSuchKey + emit missingArtifacts list + decoupled enrichment trigger | nisal     | P2       | 2026-05-06 | 4    | 2026-05-09 | complete    |
 | [feat-043](content-discovery/feat-043-visual-shot-detection-fusion.md)                                         | Video Vectorization — Visual Shot Detection Fusion                                              | nisal     | P2       | 2026-06-06 | 10   | 2026-06-15 | blocked     |
 | [feat-093](content-discovery/feat-093-cold-start-context-recommendations.md)                                   | Cold Start Context-Based Recommendations                                                        | nisal     | P2       | 2026-06-14 | 7    | 2026-06-20 | not-started |
 | [feat-071](content-discovery/feat-071-recommendation-content-deduplication.md)                                 | Recommendation Content Deduplication                                                            | nisal     | P2       | 2026-06-15 | 5    | 2026-06-19 | complete    |
@@ -107,11 +107,11 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-093](platform/feat-093-admin-app-sync-hardening-and-rate-limit.md)         | Admin App Sync Hardening and GraphQL Rate Limit         | tataihono | P0       | 2026-04-14 | 3    | 2026-04-16 | complete    |
 | [feat-097](platform/feat-097-admin-v1-pr-hardening.md)                           | Admin App V1 PR Hardening and Operational Surfaces      | tataihono | P0       | 2026-04-14 | 1    | 2026-04-14 | complete    |
 | [feat-098](platform/feat-098-admin-cms-expansion-loop.md)                        | Admin CMS Expansion Loop                                | tataihono | P0       | 2026-04-14 | 14   | 2026-04-27 | complete    |
-| [feat-104](platform/feat-104-admin-railway-provisioning.md)                      | Provision apps/admin on Railway                         | nisal     | P0       | 2026-04-20 | 1    | 2026-04-20 | in-progress |
-| [feat-105](platform/feat-105-admin-sso-firebase-auth-wiring.md)                  | Wire SSO + Firebase fallback auth on @forge/admin       | tataihono | P0       | 2026-04-21 | 3    | 2026-04-23 | blocked     |
+| [feat-104](platform/feat-104-admin-railway-provisioning.md)                      | Provision apps/admin on Railway                         | nisal     | P0       | 2026-04-20 | 1    | 2026-04-20 | complete    |
+| [feat-105](platform/feat-105-admin-sso-firebase-auth-wiring.md)                  | Wire SSO + Firebase fallback auth on @forge/admin       | tataihono | P0       | 2026-04-21 | 3    | 2026-04-23 | in-progress |
 | [feat-104](platform/feat-104-admin-core-consumer-migration-plan.md)              | Admin Core Consumer Migration Plan                      | tataihono | P0       | 2026-04-22 | 2    | 2026-04-23 | in-progress |
 | [feat-109](platform/feat-109-admin-core-sync-entity-coverage.md)                 | Admin Core Sync Entity Coverage                         | tataihono | P0       | 2026-04-28 | 3    | 2026-04-30 | complete    |
-| [feat-110](platform/feat-110-admin-core-sync-recurring-job.md)                   | Admin Core Sync Recurring Background Job                | tataihono | P0       | 2026-04-29 | 2    | 2026-04-30 | in-progress |
+| [feat-110](platform/feat-110-admin-core-sync-recurring-job.md)                   | Admin Core Sync Recurring Background Job                | tataihono | P0       | 2026-04-29 | 2    | 2026-04-30 | complete    |
 | [feat-121](platform/feat-121-jesus-film-auth-platform.md)                        | Jesus Film Auth Platform                                | tataihono | P0       | 2026-05-11 | 14   | 2026-05-24 | blocked     |
 | [feat-125](platform/feat-125-manager-auth-oauth-admin-backend-migration.md)      | Manager Auth OAuth and Admin Backend Migration          | vlad      | P0       | 2026-05-20 | 5    | 2026-05-24 | blocked     |
 | [feat-036](platform/feat-036-cms-local-postgres-io-concurrency-compatibility.md) | CMS local PostgreSQL I/O concurrency compatibility      | tataihono | P1       | 2026-04-01 | 1    | 2026-04-01 | complete    |
@@ -135,9 +135,10 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-115](platform/feat-115-admin-image-enrichment-workflow.md)                 | Admin Image Enrichment Workflow                         | tataihono | P1       | 2026-05-04 | 7    | 2026-05-10 | complete    |
 | [feat-122](platform/feat-122-admin-video-database-backup-and-clone.md)           | Admin video database backup and clone tooling           | tataihono | P1       | 2026-05-13 | 5    | 2026-05-17 | complete    |
 | [feat-123](platform/feat-123-admin-video-db-presigned-restore.md)                | Admin video database presigned restore access           | tataihono | P1       | 2026-05-15 | 1    | 2026-05-15 | complete    |
-| [feat-124](platform/feat-124-admin-prod-core-sync-restore-fix.md)                | Admin production core sync restore fix                  | tataihono | P1       | 2026-05-15 | 1    | 2026-05-15 | in-progress |
+| [feat-124](platform/feat-124-admin-prod-core-sync-restore-fix.md)                | Admin production core sync restore fix                  | tataihono | P1       | 2026-05-15 | 1    | 2026-05-15 | complete    |
 | [feat-129](platform/feat-129-mastra-railway-workflow-runtime.md)                 | Mastra Railway Workflow Runtime                         | vlad      | P1       | 2026-05-22 | 7    | 2026-05-28 | complete    |
 | [feat-130](platform/feat-130-mastra-observability-storage.md)                    | Mastra Observability Storage                            | vlad      | P1       | 2026-05-22 | 1    | 2026-05-22 | complete    |
+| [feat-132](platform/feat-132-admin-core-sync-production-error-triage.md)         | Admin Core Sync Production Error Triage                 | tataihono | P1       | 2026-05-24 | 1    | 2026-05-24 | not-started |
 | [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                              | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
 | [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                     | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                 | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |

--- a/docs/roadmap/platform/feat-110-admin-core-sync-recurring-job.md
+++ b/docs/roadmap/platform/feat-110-admin-core-sync-recurring-job.md
@@ -3,12 +3,13 @@ id: "feat-110"
 title: "Admin Core Sync Recurring Background Job"
 owner: "tataihono"
 priority: "P0"
-status: "in-progress"
+status: "complete"
 start_date: "2026-04-29"
 duration: 2
 depends_on:
   - "feat-109"
-blocks: []
+blocks:
+  - "feat-132"
 tags:
   - "platform"
   - "admin"
@@ -101,3 +102,24 @@ experience with Core Sync visuals and a durable work log.
   execution.
 - Verification records local full-sync and incremental-sync timings, including
   whether a dev-data snapshot path is required for underpowered machines.
+
+## Completion Evidence
+
+Verified on 2026-05-24:
+
+- Production `@forge/admin` has `WORKFLOW_TARGET_WORLD=@workflow/world-postgres`
+  and `WORKFLOW_RUNNER_ENABLED=false`.
+- Production `@forge/admin/worker` has
+  `WORKFLOW_TARGET_WORLD=@workflow/world-postgres` and
+  `WORKFLOW_RUNNER_ENABLED=true`.
+- Both services are deployed with Railway status `SUCCESS`.
+- Production `workflow_worker_heartbeat` has a current online worker heartbeat.
+- Production `workflow_run` and `core_sync_run` contain scheduled Core Sync
+  rows with runtime run IDs, phase summaries, lock release, and coverage audit
+  data.
+- Latest coverage audit from 2026-05-20 is `pass`; the latest run still
+  reported two row-level phase errors, tracked separately in `feat-132`.
+- Focused local verification passed:
+  `pnpm --filter @forge/admin test src/services/core-sync/job.test.ts src/workflows/coreSync.test.ts src/app/api/core-sync/scheduled/route.test.ts src/app/api/core-sync/manual/route.test.ts src/services/workflow-run-log.service.test.ts src/services/workflow-runtime.service.test.ts src/instrumentation.test.ts`.
+  Also passed: `pnpm --filter @forge/admin typecheck` and
+  `pnpm --filter @forge/admin lint`.

--- a/docs/roadmap/platform/feat-124-admin-prod-core-sync-restore-fix.md
+++ b/docs/roadmap/platform/feat-124-admin-prod-core-sync-restore-fix.md
@@ -3,7 +3,7 @@ id: "feat-124"
 title: "Admin production core sync restore fix"
 owner: "tataihono"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-05-15"
 duration: 1
 depends_on:
@@ -36,3 +36,8 @@ schema-qualified names, which caused custom archive restores to match no data.
 pnpm --filter @forge/admin test src/app/api/core-sync/scheduled/route.test.ts src/scripts/video-db-backup.test.ts
 pnpm --filter @forge/admin typecheck
 ```
+
+Verified on 2026-05-24:
+
+- Focused test command above passed.
+- Full admin typecheck passed as part of the Core Sync operations closeout.

--- a/docs/roadmap/platform/feat-132-admin-core-sync-production-error-triage.md
+++ b/docs/roadmap/platform/feat-132-admin-core-sync-production-error-triage.md
@@ -1,0 +1,106 @@
+---
+id: "feat-132"
+title: "Admin Core Sync Production Error Triage"
+owner: "tataihono"
+priority: "P1"
+status: "not-started"
+start_date: "2026-05-24"
+duration: 1
+depends_on:
+  - "feat-110"
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "core-sync"
+  - "operations"
+  - "database"
+---
+
+## Problem
+
+Recurring Core Sync is deployed and writing production workflow evidence, but
+the latest production scheduled run failed because two phases reported row-level
+errors. The workflow path itself completed: the lock cleared, runtime run IDs
+were persisted, phase summaries were written, and coverage audit status was
+`pass`. The remaining work is to identify and resolve the row-level data errors
+so the next scheduled run lands `succeeded`.
+
+Production evidence captured on 2026-05-24:
+
+- Latest `workflow_run.workflow_key = 'core-sync'` row:
+  `runtime_run_id = wrun_01KS3KK4VFHJ4H24AJQQ76NN5Y`, `trigger = scheduled`,
+  `status = failed`, `created_at = 2026-05-20T21:10:14.701Z`,
+  `finished_at = 2026-05-20T22:02:23.101Z`.
+- Latest summary:
+  `10 phase(s), 0 created, 1595212 updated, 8438 soft-deleted, 2 error(s).`
+- Phase summary shows `videos.errors = 1` and `video-editions.errors = 1`.
+- `core_sync_run.coverage_audit.status = pass`.
+- `sync_locks.key = core-sync` has `held_by = null`, so the run did not leave
+  the production lock stuck.
+- `workflow_worker_heartbeat` has a current online worker heartbeat.
+
+## Entry Points - Read These First
+
+1. `apps/admin/src/services/core-sync/orchestrator.ts` - run lifecycle,
+   watermark advancement, phase result aggregation, and lock release.
+2. `apps/admin/src/services/core-sync/phases/sync-videos.ts` - the latest run's
+   `videos` phase reported one error.
+3. `apps/admin/src/services/core-sync/phases/sync-video-editions.ts` - the
+   latest run's `video-editions` phase reported one error.
+4. `apps/admin/src/services/core-sync/job.ts` - workflow ledger recording and
+   `CoreSyncRun` result persistence.
+5. `apps/admin/src/app/dashboard/system-status/page.tsx` and
+   `apps/admin/src/app/dashboard/ops-data.ts` - operator-visible Core Sync
+   health and phase summaries.
+6. `apps/admin/docs/core-sync-recurring-job.md` - production verification
+   checklist.
+
+## Grep These
+
+- `errors:` in `apps/admin/src/services/core-sync/phases/sync-videos.ts`
+- `errors:` in `apps/admin/src/services/core-sync/phases/sync-video-editions.ts`
+- `phaseSummary|coverageAudit|recordCoreSyncRunResult` in `apps/admin/src`
+- `workflow_run|core_sync_run|sync_state|sync_locks` in `apps/admin/src`
+
+## What To Build
+
+1. Pull the production phase-level error detail for the failed
+   `wrun_01KS3KK4VFHJ4H24AJQQ76NN5Y` run from workflow/runtime logs or the
+   relevant persisted phase details.
+2. Classify the two errors as one of:
+   - upstream Core data shape issue,
+   - admin transform/validation bug,
+   - transient Core API/network failure,
+   - database constraint/mapping issue.
+3. Fix the smallest code or data-handling path that lets the affected rows sync
+   without regressing existing Core Sync invariants.
+4. If the errors are legitimate bad upstream records, make the phase projection
+   surface the offending Core IDs clearly in the run summary/operator logs.
+5. Run a targeted sync for the affected phase or a scheduled incremental sync
+   and confirm the next `core-sync` ledger row is `succeeded` with
+   `error_count = 0`.
+
+## Constraints
+
+- Do not change the recurring workflow architecture from `feat-110`.
+- Do not bypass `SyncLock`, `syncPrisma`, or phase watermarks.
+- Do not mark phases successful when row-level errors still occurred.
+- Do not run a production full sync unless the operator explicitly intends it;
+  prefer incremental or phase-targeted verification.
+- Do not print Core API tokens, database URLs, bearer tokens, or raw secrets in
+  logs or docs.
+
+## Verification
+
+- Query production `workflow_run` / `core_sync_run` for the next Core Sync run
+  and confirm `status = succeeded`, `error_count = 0`, and
+  `runtime_run_id IS NOT NULL`.
+- Query `sync_locks` and confirm `held_by IS NULL` after the verification run.
+- Query `sync_state` for `videos` and `video-editions` and confirm both phases
+  have zero errors in their latest `stats`.
+- Confirm `/dashboard/system-status` reports Core Sync coverage audit `pass`.
+- Confirm `/dashboard/workflows` shows the verification run and its runtime
+  detail view.
+- Run focused local tests for any touched phase:
+  `pnpm --filter @forge/admin test src/services/core-sync/phases/<phase>.test.ts`.


### PR DESCRIPTION
## Summary

- mark the Core Sync recurring operations and production restore-fix roadmap tickets complete
- record production verification evidence for the Core Sync worker/service split, workflow ledger, lock release, and coverage audit
- add `feat-132` for the remaining production row-level Core Sync errors in `videos` and `video-editions`
- regenerate the roadmap index so the dashboard/README reflect the updated ticket state

## Review

Local review pass completed on the roadmap diff. One pre-existing roadmap issue was observed but left out of scope: duplicate historical feature IDs already exist across lanes.

## Validation

- `pnpm --filter @forge/admin test src/services/core-sync/job.test.ts src/workflows/coreSync.test.ts src/app/api/core-sync/scheduled/route.test.ts src/app/api/core-sync/manual/route.test.ts src/services/workflow-run-log.service.test.ts src/services/workflow-runtime.service.test.ts src/instrumentation.test.ts`
- `pnpm --filter @forge/admin test src/app/api/core-sync/scheduled/route.test.ts src/scripts/video-db-backup.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter roadmap lint`
- production Railway read-back: `@forge/admin` and `@forge/admin/worker` deployed successfully with Postgres World split as documented
