### PR TITLE
fix(web): adapt hero player sizing to playback phase

### DIFF
--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -54,6 +54,18 @@ const CHROME_HIDE_STYLE: MuxCSSProperties = {
   "--bottom-controls": "none",
 }
 
+// Object-fit modes per playback phase:
+//   pre-reveal (muted preview) → cover: fills the hero box, may crop;
+//   chrome-revealed (sound on) → contain: never crops. The wrapper is
+//   sized so the 16:9 frame fits inside both axes — the inner video
+//   then exactly fills the wrapper.
+const PRE_REVEAL_OBJECT_FIT_STYLE: MuxCSSProperties = {
+  "--media-object-fit": "cover",
+}
+const REVEALED_OBJECT_FIT_STYLE: MuxCSSProperties = {
+  "--media-object-fit": "contain",
+}
+
 // Fraction of the visible video that must be obscured by the body section
 // before the scroll listener pauses the player. 0.6 = 60% obscured — past
 // this point the player is no longer the main element on screen.
@@ -556,8 +568,10 @@ export function HeroPlayer({
         data-testid="hero-player-wrapper"
         data-chrome-revealed={chromeRevealed ? "true" : "false"}
         data-autoplay-blocked={autoplayBlocked ? "true" : "false"}
-        className={`sticky w-full overflow-hidden bg-black ${
-          chromeRevealed ? "aspect-video" : PRE_REVEAL_HERO_SIZE_CLASSES
+        className={`sticky overflow-hidden bg-black ${
+          chromeRevealed
+            ? "mx-auto aspect-video w-full max-h-svh max-w-[calc(100svh*16/9)]"
+            : `w-full ${PRE_REVEAL_HERO_SIZE_CLASSES}`
         }`}
         style={{
           // 100svh tracks the *small* viewport on iOS Safari (visible area
@@ -586,7 +600,12 @@ export function HeroPlayer({
             video_id: video.documentId,
             viewer_user_id: viewerUserId,
           }}
-          style={CHROME_HIDE_STYLE}
+          style={{
+            ...CHROME_HIDE_STYLE,
+            ...(chromeRevealed
+              ? REVEALED_OBJECT_FIT_STYLE
+              : PRE_REVEAL_OBJECT_FIT_STYLE),
+          }}
           onLoadedMetadata={handleLoadedMetadata}
           onCanPlay={handleCanPlay}
           onError={handlePlayerError}


### PR DESCRIPTION
## Summary

Hero player previously kept a fixed 16:9 box driven by width in both
muted preview and revealed (sound on) states. With the revealed-state
chrome visible the 16:9 width-driven height left the video shorter than
the available viewport, while a forced `h-svh` would crop the sides.

Now:

- **Muted preview**: unchanged hero box (`h-[72svh]`), `--media-object-fit: cover` so the frame fills the slot edge-to-edge.
- **Sound on (chrome revealed)**: wrapper is `aspect-video w-full max-h-svh max-w-[calc(100svh*16/9)] mx-auto` with `object-fit: contain`. Width clamps to `100svh × 16/9` on wide viewports (centered, height never exceeds svh); narrow viewports keep full width with height derived from the 16:9 ratio. Result: the playing frame is always fully visible — no vertical letterbox bars and no horizontal crop in either orientation.

## Work Loop

- [ ] \`ce:plan\` done
- [x] \`ce:work\` done
- [ ] \`ce:review\` done
- [ ] \`ce:compound\` done

## Notes

Verified in Claude Preview against \`/watch/the-woman-with-the-issue-of-blood/english\`:

| State | Wrapper size | Object-fit |
|---|---|---|
| Pre-reveal (muted) | `748 × ~538` (72svh slot, w-full) | `cover` |
| Revealed (sound on) | `748 × 421` (aspect-video, w-full, max-h-svh = 754 not hit) | `contain` |

On wider viewports `max-w-[calc(100svh*16/9)]` clamps width so height never exceeds svh; `mx-auto` centers the player.