### PR TITLE
fix(web): unify watch-page header chrome and pause video for modals

### DIFF
--- a/apps/web/src/components/FloatingSearchProvider.tsx
+++ b/apps/web/src/components/FloatingSearchProvider.tsx
@@ -60,6 +60,10 @@ export type FloatingSearchPinnedContextValue = {
   pinned: boolean
   playerChromeVisible: boolean
   searchChromeVisible: boolean
+  // True while the search overlay is open OR running its close animation.
+  // Watch-page modal coordinators read this to pause/resume the video
+  // alongside their own (download / language / share) modal state.
+  searchOpen: boolean
 }
 
 const FloatingSearchContext = createContext<FloatingSearchContextValue | null>(
@@ -470,10 +474,9 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
   const modalChromeHidden = open || closing
   const playerPlayingWithSound =
     playerPlaybackState.playing && !playerPlaybackState.muted
-  const searchChromeVisible =
-    !modalChromeHidden && (!playerPlayingWithSound || headerHovered)
   const headerChromeHidden =
     modalChromeHidden || (!playerChromeVisible && !headerHovered)
+  const searchChromeVisible = !headerChromeHidden
   const headerBackdropHidden =
     modalChromeHidden ||
     ((playerPlayingWithSound || !playerChromeVisible) && !headerHovered)
@@ -495,8 +498,13 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
   }, [headerHoverZoneActive])
 
   const pinnedValue = useMemo<FloatingSearchPinnedContextValue>(
-    () => ({ pinned, playerChromeVisible, searchChromeVisible }),
-    [pinned, playerChromeVisible, searchChromeVisible],
+    () => ({
+      pinned,
+      playerChromeVisible,
+      searchChromeVisible,
+      searchOpen: modalChromeHidden,
+    }),
+    [pinned, playerChromeVisible, searchChromeVisible, modalChromeHidden],
   )
 
   return (

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -114,7 +114,7 @@ describe("FloatingSearchProvider — header backdrop", () => {
 })
 
 describe("FloatingSearchProvider — watch playback chrome", () => {
-  it("hides the floating search bar while the player is playing with sound", () => {
+  it("hides the floating search bar with the rest of the header chrome", () => {
     act(() => {
       root.render(
         <FloatingSearchProvider>
@@ -160,21 +160,21 @@ describe("FloatingSearchProvider — watch playback chrome", () => {
     ).toContain("group-hover:drop-shadow-none")
 
     act(() => {
-      dispatchPlaybackState({ playing: true, muted: false })
+      dispatchChromeVisibility(false)
     })
 
     expect(searchButton?.className).toContain("opacity-0")
     expect(mobileSearchButton?.className).toContain("opacity-0")
 
     act(() => {
-      dispatchPlaybackState({ playing: false, muted: false })
+      dispatchChromeVisibility(true)
     })
 
     expect(searchButton?.className).toContain("opacity-100")
     expect(mobileSearchButton?.className).toContain("opacity-100")
   })
 
-  it("keeps the floating search bar visible for muted playback", () => {
+  it("keeps the floating search bar visible during unmuted playback while the player chrome is up", () => {
     act(() => {
       root.render(
         <FloatingSearchProvider>
@@ -184,16 +184,20 @@ describe("FloatingSearchProvider — watch playback chrome", () => {
     })
 
     act(() => {
-      dispatchPlaybackState({ playing: true, muted: true })
+      dispatchPlaybackState({ playing: true, muted: false })
     })
 
     const searchButton = document.querySelector(
       '[data-testid="floating-search-desktop-button"]',
     )
+    const mobileSearchButton = document.querySelector(
+      '[data-testid="floating-search-mobile-button"]',
+    )
     expect(searchButton?.className).toContain("opacity-100")
+    expect(mobileSearchButton?.className).toContain("opacity-100")
   })
 
-  it("reveals the floating search bar while hovering the header during playback", () => {
+  it("reveals the floating search bar while hovering the header after the player chrome hides", () => {
     act(() => {
       root.render(
         <FloatingSearchProvider>
@@ -213,7 +217,7 @@ describe("FloatingSearchProvider — watch playback chrome", () => {
     )
 
     act(() => {
-      dispatchPlaybackState({ playing: true, muted: false })
+      dispatchChromeVisibility(false)
     })
 
     expect(searchButton?.className).toContain("opacity-0")

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
+import { useFloatingSearchPinned } from "@/components/FloatingSearchProvider"
 import { DownloadModal } from "@/components/watch/DownloadModal"
 import { LanguagePickerModal } from "@/components/watch/LanguagePickerModal"
 import { ShareModal } from "@/components/watch/ShareModal"
@@ -197,6 +198,34 @@ export function WatchPageClient({
   const openLanguage = useCallback(() => setModalState("language"), [])
   const openShare = useCallback(() => setModalState("share"), [])
   const closeModal = useCallback(() => setModalState("none"), [])
+
+  // Pause the video whenever any modal (search / language / download / share)
+  // opens, and restore the prior playing state on close. Captures the snapshot
+  // at the open-edge so a paused video stays paused after the modal closes.
+  const { searchOpen } = useFloatingSearchPinned()
+  const anyModalOpen = searchOpen || modalState !== "none"
+  const wasPlayingRef = useRef(false)
+  const prevAnyModalOpenRef = useRef(false)
+  useEffect(() => {
+    const player = playerRef.current
+    const wasOpen = prevAnyModalOpenRef.current
+    prevAnyModalOpenRef.current = anyModalOpen
+    if (!player) return
+    if (anyModalOpen && !wasOpen) {
+      wasPlayingRef.current = !player.paused
+      if (wasPlayingRef.current) {
+        player.pause()
+      }
+    } else if (!anyModalOpen && wasOpen) {
+      if (wasPlayingRef.current) {
+        const result = player.play()
+        if (result && typeof (result as Promise<void>).then === "function") {
+          ;(result as Promise<void>).catch(() => {})
+        }
+      }
+      wasPlayingRef.current = false
+    }
+  }, [anyModalOpen])
 
   const modalCallbacks: WatchModalCallbacks = {
     openDownload,


### PR DESCRIPTION
## Summary

Two coupled watch-page fixes:

1. **Header-chrome symmetry** — search bar now hides on the same `headerChromeHidden` gate as the logo / language globe / chat icons. Previous gate (`!playerPlayingWithSound || headerHovered`) made the search input vanish whenever the video played unmuted, while sibling header controls stayed on screen — visually inconsistent. All four header surfaces now fade together when the player chrome fades or a modal opens, and reveal together on header-hover during playback.

2. **Modal playback coordination** — opening any modal (search overlay, language picker, download, share) now pauses the watch-page video, and closing the last modal restores the prior playing state. The pre-open `paused` snapshot lives in a ref so a paused video stays paused after the modal closes. Overlapping modals resume only after the last one closes; if `playerRef` is not yet ready, the effect is a no-op.

## Changes

- `apps/web/src/components/FloatingSearchProvider.tsx`
  - `searchChromeVisible = !headerChromeHidden` (unified gate)
  - Pinned context exposes `searchOpen` (= `modalChromeHidden`) so the watch coordinator can react to overlay open/closing without subscribing to the heavy main search context
- `apps/web/src/components/watch/WatchPageClient.tsx`
  - New effect: `anyModalOpen = searchOpen || modalState !== "none"` → pause + snapshot on open-edge, restore on close-edge (catches `play()` autoplay-policy rejection silently)
- `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`
  - Updated three search-visibility tests to match the new gate: "hides with rest of header chrome", "keeps visible during unmuted playback while chrome up", "reveals on hover after player chrome hides"

## Verification

- `pnpm --filter @forge/web typecheck` — clean
- `pnpm --filter @forge/web lint` — clean
- `pnpm --filter @forge/web test` — 597 passed (47 files)
- Manual smoke on `/watch/11-has-the-universe-always-existed/hindi`: header surfaces fade/restore together; opening each modal pauses, closing resumes

## Work Loop

- [x] `ce:plan` done
- [x] `ce:work` done
- [ ] `ce:review` done
- [ ] `ce:compound` done

🤖 Generated with [Claude Code](https://claude.com/claude-code)