### PR TITLE
feat(admin): store and retain production search traces

### DIFF
--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -19,6 +19,10 @@ Full context in `apps/admin/CLAUDE.md`. Both files stay aligned.
 - UI never accesses the database directly.
 - Pothos `prismaField` / `t.relation` handles reads with `...query` passthrough.
 - Services own mutations, raw SQL (pgvector), and ABAC enforcement.
+- Admin owns live search orchestration, query embedding generation, vector
+  storage, production search traces, raw trace retention, aggregates, and the
+  internal trace sampling contract. Mastra samples later through authenticated
+  Admin HTTP only; it must not import Admin code or read Admin Postgres.
 - Admin auth must not depend on shared `.jesusfilm.org` cookies or
   admin-local credential handlers.
 - Every Pothos type is classified `abac-gated` or `public-shape` — `abac-gated`
@@ -35,6 +39,10 @@ Full context in `apps/admin/CLAUDE.md`. Both files stay aligned.
   maps are compatibility mirrors only.
 - Embedding vector columns never appear in a GraphQL type (technical control,
   not convention).
+- Raw production search traces may retain query text only after first-pass
+  privacy labeling/redaction and for less than 30 days. Aggregates survive
+  without query text; never store bearer tokens, cookies, IPs, user ids, or
+  caller-supplied key ids in trace tables.
 
 ## Workflow
 

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -268,6 +268,49 @@ and keeps raw `RAILWAY_S3_*` credentials inside the production runtime. The
 endpoint requires production admin to have the normal `RAILWAY_S3_*` bucket env
 vars configured; dev/staging should not need those S3 credentials.
 
+### Search trace retention and sampling
+
+Admin is the live search authority. REST `/api/search`, GraphQL `Query.search`,
+query embedding generation, pgvector retrieval, production trace storage,
+rollups, and retention all stay inside `apps/admin`. Mastra must not enter the
+live request path and must not import Admin code or read Admin Postgres for eval
+sampling; later eval jobs use Admin's internal HTTP contract only.
+
+Production search tracing writes two records:
+
+- `search_trace`: short-lived raw rows with query text after first-pass
+  privacy classification/redaction, locale, route source, requested mode,
+  response search mode, result count, latency bucket, outcome, trace class,
+  quality/sensitive/abuse labels, sample eligibility, and timestamps. Raw rows
+  expire after `SEARCH_TRACE_RAW_RETENTION_DAYS` (default 29, max 29) so the
+  daily purge deletes them before the hard 30-day ceiling.
+- `search_trace_aggregate`: long-lived rollups by non-query dimensions. This
+  table never stores query text and is the durable analytical trail after raw
+  rows are purged.
+
+Trace writes are bounded best-effort. `recordSearchTraceSafely` is awaited
+behind a short timeout and every write/timeout failure is swallowed from the
+live search caller's perspective. Failures increment safe process-local
+counters and log `[search] event=trace_record_* ...` without raw query text.
+
+The internal sampling route is
+`POST /api/internal/search-traces/sample`. It is rate-limited before auth/body
+parsing, requires a bearer from `SEARCH_TRACE_SAMPLING_API_KEYS`, and returns
+only recent unexpired `sampleEligible` rows. The bearer CSV is optional at boot
+and is part of the env disjointness invariant; it must not share values with
+workflow, web/consumer, backup, manager, or Mastra ingest credentials.
+
+The Admin worker starts `src/workflows/searchTraceRetention.ts` when
+`WORKFLOW_RUNNER_ENABLED=true` and
+`WORKFLOW_TARGET_WORLD=@workflow/world-postgres`. The scheduler runs one purge
+immediately, then daily at 10:00 UTC. `/api/search/health` reports retention
+health and trace capture counters; in production, raw trace capture is disabled
+when the retention scheduler or recent purge heartbeat cannot be confirmed.
+
+Never add bearer tokens, cookies, IP addresses, full user identifiers,
+caller-supplied key ids, vectors, debug scoring payloads, or raw query text to
+aggregate rows or workflow details.
+
 ### Jesus Film Auth client mode
 
 For local development, admin points at production Auth so engineers do not need

--- a/apps/admin/prisma/migrations/0021_admin_search_trace_storage_retention/migration.sql
+++ b/apps/admin/prisma/migrations/0021_admin_search_trace_storage_retention/migration.sql
@@ -1,0 +1,101 @@
+-- Admin-owned production search trace storage.
+--
+-- Raw rows are short-lived and are purged by raw_expires_at. Aggregates never
+-- store query text and may survive raw trace deletion.
+
+CREATE TYPE "SearchTraceRouteSource" AS ENUM ('rest', 'graphql');
+
+CREATE TYPE "SearchTraceOutcome" AS ENUM ('success', 'degraded', 'failed');
+
+CREATE TYPE "SearchTraceLatencyBucket" AS ENUM (
+  'lt_100ms',
+  'lt_250ms',
+  'lt_500ms',
+  'lt_1000ms',
+  'lt_2500ms',
+  'gte_2500ms'
+);
+
+CREATE TABLE "search_trace" (
+  "id" text NOT NULL,
+  "query_text" varchar(1024) NOT NULL,
+  "locale" varchar(32) NOT NULL,
+  "route_source" "SearchTraceRouteSource" NOT NULL,
+  "requested_mode" varchar(64),
+  "search_mode" varchar(64) NOT NULL,
+  "result_count" integer NOT NULL,
+  "latency_bucket" "SearchTraceLatencyBucket" NOT NULL,
+  "outcome" "SearchTraceOutcome" NOT NULL,
+  "trace_class" varchar(64) NOT NULL DEFAULT 'none',
+  "query_quality_label" varchar(64) NOT NULL DEFAULT 'unknown',
+  "sensitive_query_label" varchar(64) NOT NULL DEFAULT 'none',
+  "abuse_label" varchar(64) NOT NULL DEFAULT 'none',
+  "sample_eligible" boolean NOT NULL DEFAULT true,
+  "started_at" timestamp(3) NOT NULL,
+  "completed_at" timestamp(3) NOT NULL,
+  "raw_expires_at" timestamp(3) NOT NULL,
+  "created_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "search_trace_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "search_trace_raw_expires_at_idx"
+  ON "search_trace"("raw_expires_at");
+
+CREATE INDEX "search_trace_created_at_idx"
+  ON "search_trace"("created_at");
+
+CREATE INDEX "search_trace_locale_created_at_idx"
+  ON "search_trace"("locale", "created_at");
+
+CREATE INDEX "search_trace_route_source_created_at_idx"
+  ON "search_trace"("route_source", "created_at");
+
+CREATE INDEX "search_trace_outcome_created_at_idx"
+  ON "search_trace"("outcome", "created_at");
+
+CREATE INDEX "search_trace_sample_eligible_raw_expires_at_created_at_idx"
+  ON "search_trace"("sample_eligible", "raw_expires_at", "created_at");
+
+CREATE TABLE "search_trace_aggregate" (
+  "id" text NOT NULL,
+  "bucket_start" timestamp(3) NOT NULL,
+  "locale" varchar(32) NOT NULL,
+  "route_source" "SearchTraceRouteSource" NOT NULL,
+  "search_mode" varchar(64) NOT NULL,
+  "outcome" "SearchTraceOutcome" NOT NULL,
+  "trace_class" varchar(64) NOT NULL DEFAULT 'none',
+  "latency_bucket" "SearchTraceLatencyBucket" NOT NULL,
+  "query_quality_label" varchar(64) NOT NULL DEFAULT 'unknown',
+  "sensitive_query_label" varchar(64) NOT NULL DEFAULT 'none',
+  "abuse_label" varchar(64) NOT NULL DEFAULT 'none',
+  "query_count" integer NOT NULL DEFAULT 0,
+  "result_count_sum" integer NOT NULL DEFAULT 0,
+  "created_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" timestamp(3) NOT NULL,
+
+  CONSTRAINT "search_trace_aggregate_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "search_trace_aggregate_bucket_dims_key"
+  ON "search_trace_aggregate"(
+    "bucket_start",
+    "route_source",
+    "locale",
+    "search_mode",
+    "outcome",
+    "trace_class",
+    "latency_bucket",
+    "query_quality_label",
+    "sensitive_query_label",
+    "abuse_label"
+  );
+
+CREATE INDEX "search_trace_aggregate_bucket_start_idx"
+  ON "search_trace_aggregate"("bucket_start");
+
+CREATE INDEX "search_trace_aggregate_route_source_bucket_start_idx"
+  ON "search_trace_aggregate"("route_source", "bucket_start");
+
+CREATE INDEX "search_trace_aggregate_outcome_bucket_start_idx"
+  ON "search_trace_aggregate"("outcome", "bucket_start");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -179,6 +179,30 @@ enum WorkflowRunTrigger {
   SYSTEM    @map("system")
 }
 
+/// Public Admin entry point that produced a production search trace.
+enum SearchTraceRouteSource {
+  REST    @map("rest")
+  GRAPHQL @map("graphql")
+}
+
+/// Search execution result from the caller's perspective.
+enum SearchTraceOutcome {
+  SUCCESS  @map("success")
+  DEGRADED @map("degraded")
+  FAILED   @map("failed")
+}
+
+/// Coarse latency buckets keep trace payloads useful without storing exact
+/// per-request timings indefinitely.
+enum SearchTraceLatencyBucket {
+  LT_100_MS   @map("lt_100ms")
+  LT_250_MS   @map("lt_250ms")
+  LT_500_MS   @map("lt_500ms")
+  LT_1000_MS  @map("lt_1000ms")
+  LT_2500_MS  @map("lt_2500ms")
+  GTE_2500_MS @map("gte_2500ms")
+}
+
 // -----------------------------------------------------------------------------
 // Admin access control (Auth SSO relying client)
 // -----------------------------------------------------------------------------
@@ -352,6 +376,65 @@ model WorkflowWorkerHeartbeat {
 
   @@index([lastSeenAt])
   @@map("workflow_worker_heartbeat")
+}
+
+/// Short-lived Admin-owned production search trace. Raw rows are the only place
+/// query text may exist, and they expire before the hard 30-day raw retention
+/// ceiling. The table deliberately has no bearer, cookie, IP, user-id, key-id,
+/// vector, or scoring payload columns.
+model SearchTrace {
+  id                  String                   @id @default(cuid())
+  queryText           String                   @map("query_text") @db.VarChar(1024)
+  locale              String                   @db.VarChar(32)
+  routeSource         SearchTraceRouteSource   @map("route_source")
+  requestedMode       String?                  @map("requested_mode") @db.VarChar(64)
+  searchMode          String                   @map("search_mode") @db.VarChar(64)
+  resultCount         Int                      @map("result_count")
+  latencyBucket       SearchTraceLatencyBucket @map("latency_bucket")
+  outcome             SearchTraceOutcome
+  traceClass          String                   @default("none") @map("trace_class") @db.VarChar(64)
+  queryQualityLabel   String                   @default("unknown") @map("query_quality_label") @db.VarChar(64)
+  sensitiveQueryLabel String                   @default("none") @map("sensitive_query_label") @db.VarChar(64)
+  abuseLabel          String                   @default("none") @map("abuse_label") @db.VarChar(64)
+  sampleEligible      Boolean                  @default(true) @map("sample_eligible")
+  startedAt           DateTime                 @map("started_at")
+  completedAt         DateTime                 @map("completed_at")
+  rawExpiresAt        DateTime                 @map("raw_expires_at")
+  createdAt           DateTime                 @default(now()) @map("created_at")
+
+  @@index([rawExpiresAt])
+  @@index([createdAt])
+  @@index([locale, createdAt])
+  @@index([routeSource, createdAt])
+  @@index([outcome, createdAt])
+  @@index([sampleEligible, rawExpiresAt, createdAt])
+  @@map("search_trace")
+}
+
+/// Long-lived counters for search trace analysis. Aggregates never contain raw
+/// query text, so they may survive raw trace purge.
+model SearchTraceAggregate {
+  id                  String                   @id @default(cuid())
+  bucketStart         DateTime                 @map("bucket_start")
+  locale              String                   @db.VarChar(32)
+  routeSource         SearchTraceRouteSource   @map("route_source")
+  searchMode          String                   @map("search_mode") @db.VarChar(64)
+  outcome             SearchTraceOutcome
+  traceClass          String                   @default("none") @map("trace_class") @db.VarChar(64)
+  latencyBucket       SearchTraceLatencyBucket @map("latency_bucket")
+  queryQualityLabel   String                   @default("unknown") @map("query_quality_label") @db.VarChar(64)
+  sensitiveQueryLabel String                   @default("none") @map("sensitive_query_label") @db.VarChar(64)
+  abuseLabel          String                   @default("none") @map("abuse_label") @db.VarChar(64)
+  queryCount          Int                      @default(0) @map("query_count")
+  resultCountSum      Int                      @default(0) @map("result_count_sum")
+  createdAt           DateTime                 @default(now()) @map("created_at")
+  updatedAt           DateTime                 @updatedAt @map("updated_at")
+
+  @@unique([bucketStart, routeSource, locale, searchMode, outcome, traceClass, latencyBucket, queryQualityLabel, sensitiveQueryLabel, abuseLabel], name: "searchTraceAggregateBucketDims", map: "search_trace_aggregate_bucket_dims_key")
+  @@index([bucketStart])
+  @@index([routeSource, bucketStart])
+  @@index([outcome, bucketStart])
+  @@map("search_trace_aggregate")
 }
 
 /// Core Sync-specific detail for the generic workflow ledger. Kept separate so
@@ -1239,35 +1322,35 @@ model VideoScene {
 /// `schema.test.ts` asserts no embed/vector/similarity field leaks). Search
 /// uses raw SQL with `<=>` cosine distance + the partial HNSW index.
 model VideoSceneLocale {
-  id               String                       @id @default(cuid())
-  videoSceneId     String                       @map("video_scene_id")
-  videoScene       VideoScene                   @relation(fields: [videoSceneId], references: [id], onDelete: Cascade)
+  id                    String                       @id @default(cuid())
+  videoSceneId          String                       @map("video_scene_id")
+  videoScene            VideoScene                   @relation(fields: [videoSceneId], references: [id], onDelete: Cascade)
   /// IETF BCP-47 locale code, e.g. "en", "fr", "es-419".
-  locale           String
+  locale                String
   /// The exact text that was embedded. Stored so a future model upgrade can
   /// re-embed without re-reading manager's S3 artifact.
-  sourceText       String                       @map("source_text")
+  sourceText            String                       @map("source_text")
   /// Scene description from manager's multimodal pipeline (per-language).
-  description      String
-  themes           String[]                     @default([])
-  bibleVerses      String[]                     @default([]) @map("bible_verses")
-  demographics     String[]                     @default([])
-  spiritualContext String[]                     @default([]) @map("spiritual_context")
-  embedding        Unsupported("vector(1536)")?
-  model            String                       @default("text-embedding-3-small")
-  dimensions       Int                          @default(1536)
+  description           String
+  themes                String[]                     @default([])
+  bibleVerses           String[]                     @default([]) @map("bible_verses")
+  demographics          String[]                     @default([])
+  spiritualContext      String[]                     @default([]) @map("spiritual_context")
+  embedding             Unsupported("vector(1536)")?
+  model                 String                       @default("text-embedding-3-small")
+  dimensions            Int                          @default(1536)
   /// Compact provenance for Mastra-written scene embeddings. Nullable so
   /// legacy rows written before the Mastra migration remain searchable.
-  sourceArtifactKey     String?                 @map("source_artifact_key")
-  sourceArtifactVersion String?                 @map("source_artifact_version")
-  sourceContentHash     String?                 @map("source_content_hash")
-  sourceProvider        String?                 @map("source_provider")
-  sourceGeneratedAt     DateTime?               @map("source_generated_at")
-  generationMode        String?                 @map("generation_mode")
-  mastraRunId           String?                 @map("mastra_run_id")
-  generatedAt           DateTime?               @map("generated_at")
-  createdAt        DateTime                     @default(now()) @map("created_at")
-  updatedAt        DateTime                     @updatedAt @map("updated_at")
+  sourceArtifactKey     String?                      @map("source_artifact_key")
+  sourceArtifactVersion String?                      @map("source_artifact_version")
+  sourceContentHash     String?                      @map("source_content_hash")
+  sourceProvider        String?                      @map("source_provider")
+  sourceGeneratedAt     DateTime?                    @map("source_generated_at")
+  generationMode        String?                      @map("generation_mode")
+  mastraRunId           String?                      @map("mastra_run_id")
+  generatedAt           DateTime?                    @map("generated_at")
+  createdAt             DateTime                     @default(now()) @map("created_at")
+  updatedAt             DateTime                     @updatedAt @map("updated_at")
 
   @@unique([videoSceneId, locale])
   @@index([locale])
@@ -1311,48 +1394,48 @@ model Experience {
 /// discriminated union in `src/domain/blocks.ts` (Unit 4e). Reads return the
 /// JSONB column directly; mutations validate before write.
 model ExperienceLocale {
-  id              String                       @id @default(cuid())
-  experienceId    String                       @map("experience_id")
-  experience      Experience                   @relation(fields: [experienceId], references: [id], onDelete: Cascade)
+  id                         String                       @id @default(cuid())
+  experienceId               String                       @map("experience_id")
+  experience                 Experience                   @relation(fields: [experienceId], references: [id], onDelete: Cascade)
   /// IETF BCP-47 locale code, e.g. "en", "fr", "es-419".
-  locale          String
+  locale                     String
   /// URL slug (UID-style). Unique within (locale, slug) when published — the
   /// partial unique index lives in raw migration SQL since Prisma doesn't
   /// model partial uniques natively.
-  slug            String
+  slug                       String
   /// True when this locale is the homepage for its locale.
-  isHomepage      Boolean                      @default(false) @map("is_homepage")
+  isHomepage                 Boolean                      @default(false) @map("is_homepage")
   /// Optional URL path prefix; combines with `slug` to form the canonical path.
-  pathSegment     String?                      @map("path_segment")
-  title           String?
-  metaDescription String?                      @map("meta_description")
-  ogTitle         String?                      @map("og_title")
-  ogDescription   String?                      @map("og_description")
+  pathSegment                String?                      @map("path_segment")
+  title                      String?
+  metaDescription            String?                      @map("meta_description")
+  ogTitle                    String?                      @map("og_title")
+  ogDescription              String?                      @map("og_description")
   /// External media URL for the OG image. Media uploads land in Unit 11
   /// (storage service); this column may later become an FK to a MediaAsset.
-  ogImageUrl      String?                      @map("og_image_url")
+  ogImageUrl                 String?                      @map("og_image_url")
   /// Block-based content composition. Validated by the Zod union before write.
-  blocks          Json                         @default("[]")
+  blocks                     Json                         @default("[]")
   /// Per-locale embedding vector. NULL until the experienceEmbedding workflow
   /// runs against this locale's text. Excluded from Pothos types (technical
   /// control — schema test asserts no embed/vector/similarity field leaks).
   /// Search uses raw SQL inside services with `<=>` cosine distance + the
   /// partial HNSW index `WHERE embedding IS NOT NULL`.
-  embedding       Unsupported("vector(1536)")?
+  embedding                  Unsupported("vector(1536)")?
   /// Compact provenance for vectors generated by Mastra. These fields are
   /// internal-only and are not exposed via GraphQL.
-  embeddingSourceContentHash String?          @map("embedding_source_content_hash")
-  embeddingSourceSummary     String?          @map("embedding_source_summary")
-  embeddingModel             String?          @map("embedding_model")
-  embeddingDimensions        Int?             @map("embedding_dimensions")
-  embeddingProvider          String?          @map("embedding_provider")
-  embeddingGenerationMode    String?          @map("embedding_generation_mode")
-  embeddingMastraRunId       String?          @map("embedding_mastra_run_id")
-  embeddingGeneratedAt       DateTime?        @map("embedding_generated_at")
-  status          LocaleStatus                 @default(DRAFT)
-  publishedAt     DateTime?                    @map("published_at")
-  createdAt       DateTime                     @default(now()) @map("created_at")
-  updatedAt       DateTime                     @updatedAt @map("updated_at")
+  embeddingSourceContentHash String?                      @map("embedding_source_content_hash")
+  embeddingSourceSummary     String?                      @map("embedding_source_summary")
+  embeddingModel             String?                      @map("embedding_model")
+  embeddingDimensions        Int?                         @map("embedding_dimensions")
+  embeddingProvider          String?                      @map("embedding_provider")
+  embeddingGenerationMode    String?                      @map("embedding_generation_mode")
+  embeddingMastraRunId       String?                      @map("embedding_mastra_run_id")
+  embeddingGeneratedAt       DateTime?                    @map("embedding_generated_at")
+  status                     LocaleStatus                 @default(DRAFT)
+  publishedAt                DateTime?                    @map("published_at")
+  createdAt                  DateTime                     @default(now()) @map("created_at")
+  updatedAt                  DateTime                     @updatedAt @map("updated_at")
 
   @@unique([experienceId, locale])
   @@index([locale])
@@ -1372,39 +1455,39 @@ model ExperienceLocale {
 /// compact provenance so model upgrades and repair runs can be audited without
 /// reading manager transcript source artifacts back from S3.
 model VideoTranscript {
-  id             String       @id @default(cuid())
-  videoEditionId String       @map("video_edition_id")
-  videoEdition   VideoEdition @relation(fields: [videoEditionId], references: [id], onDelete: Cascade)
+  id                String       @id @default(cuid())
+  videoEditionId    String       @map("video_edition_id")
+  videoEdition      VideoEdition @relation(fields: [videoEditionId], references: [id], onDelete: Cascade)
   /// Denormalized from the edition's parent video for convenience joins.
-  videoId        String       @map("video_id")
-  video          Video        @relation(fields: [videoId], references: [id], onDelete: Cascade)
+  videoId           String       @map("video_id")
+  video             Video        @relation(fields: [videoId], references: [id], onDelete: Cascade)
   /// IETF BCP-47 language tag of the source transcript.
-  language       String
+  language          String
   /// Embedding model string as reported by the producing workflow (e.g.
   /// `openai/text-embedding-3-small`). Admin logs a warning on drift;
   /// intentional model replacement must use an explicit ingest mode.
-  model          String
+  model             String
   /// Dimension count. Hard-guarded to 1536 at read time.
-  dimensions     Int
+  dimensions        Int
   /// Chunking strategy metadata from the producing pipeline.
-  chunkingType   String       @map("chunking_type")
-  maxChunkTokens Int          @map("max_chunk_tokens")
-  overlapTokens  Int          @map("overlap_tokens")
-  totalChunks    Int          @map("total_chunks")
-  totalTokens    Int          @map("total_tokens")
+  chunkingType      String       @map("chunking_type")
+  maxChunkTokens    Int          @map("max_chunk_tokens")
+  overlapTokens     Int          @map("overlap_tokens")
+  totalChunks       Int          @map("total_chunks")
+  totalTokens       Int          @map("total_tokens")
   /// Artifact's own `generatedAt` timestamp — NOT admin's insert time.
-  generatedAt    DateTime     @map("generated_at")
+  generatedAt       DateTime     @map("generated_at")
   /// Compact provenance for Mastra-written transcript embeddings. Nullable so
   /// legacy rows from the pre-Mastra producer remain readable.
-  sourceArtifactKey String?    @map("source_artifact_key")
-  sourceContentHash String?    @map("source_content_hash")
-  sourceProvider    String?    @map("source_provider")
-  sourceGeneratedAt DateTime?  @map("source_generated_at")
-  generationMode    String?    @map("generation_mode")
-  mastraRunId       String?    @map("mastra_run_id")
-  chunkingVersion   String?    @map("chunking_version")
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
+  sourceArtifactKey String?      @map("source_artifact_key")
+  sourceContentHash String?      @map("source_content_hash")
+  sourceProvider    String?      @map("source_provider")
+  sourceGeneratedAt DateTime?    @map("source_generated_at")
+  generationMode    String?      @map("generation_mode")
+  mastraRunId       String?      @map("mastra_run_id")
+  chunkingVersion   String?      @map("chunking_version")
+  createdAt         DateTime     @default(now()) @map("created_at")
+  updatedAt         DateTime     @updatedAt @map("updated_at")
 
   chunks VideoTranscriptChunk[]
 

--- a/apps/admin/src/app/api/internal/search-traces/sample/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-traces/sample/route.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const rateLimitAuthRoute = vi.fn()
+const isValidSearchTraceSamplingBearer = vi.fn()
+const sampleSearchTraces = vi.fn()
+
+vi.mock("@/auth/rate-limit", () => ({ rateLimitAuthRoute }))
+vi.mock("@/auth/search-trace-bearer", () => ({
+  isValidSearchTraceSamplingBearer,
+}))
+vi.mock("@/db/client", () => ({ prisma: {} }))
+vi.mock("@/services/search-trace.service", async (original) => {
+  const actual =
+    await original<typeof import("@/services/search-trace.service")>()
+  return {
+    ...actual,
+    sampleSearchTraces,
+  }
+})
+
+const { POST, GET } = await import("./route")
+
+function request(body: unknown, headers: HeadersInit = {}) {
+  return new Request("http://admin.test/api/internal/search-traces/sample", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function rawRequest(body: string, headers: HeadersInit = {}) {
+  return new Request("http://admin.test/api/internal/search-traces/sample", {
+    method: "POST",
+    headers,
+    body,
+  })
+}
+
+describe("POST /api/internal/search-traces/sample", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rateLimitAuthRoute.mockResolvedValue({ allowed: true, source: "local" })
+    isValidSearchTraceSamplingBearer.mockReturnValue(true)
+    sampleSearchTraces.mockResolvedValue([
+      {
+        id: "trace-1",
+        queryText: "Jesus film",
+        locale: "en",
+        routeSource: "rest",
+        requestedMode: "hybrid",
+        searchMode: "hybrid",
+        resultCount: 3,
+        latencyBucket: "lt_250ms",
+        outcome: "success",
+        traceClass: "none",
+        queryQualityLabel: "normal",
+        sensitiveQueryLabel: "none",
+        abuseLabel: "none",
+        createdAt: "2026-05-25T00:00:00.000Z",
+      },
+    ])
+  })
+
+  it("returns bounded samples for a valid dedicated bearer", async () => {
+    const response = await POST(
+      request(
+        {
+          locale: "en",
+          routeSource: "rest",
+          searchMode: "hybrid",
+          since: "2026-05-25T00:00:00.000Z",
+          until: "2026-05-26T00:00:00.000Z",
+          limit: 500,
+        },
+        { authorization: "Bearer trace-key" },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      traces: [
+        expect.objectContaining({
+          id: "trace-1",
+          queryText: "Jesus film",
+          locale: "en",
+          routeSource: "rest",
+          searchMode: "hybrid",
+        }),
+      ],
+      generatedAt: expect.any(String),
+    })
+    expect(rateLimitAuthRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: "search-trace-sample",
+        limit: 20,
+        windowMs: 60_000,
+      }),
+    )
+    expect(isValidSearchTraceSamplingBearer).toHaveBeenCalledWith(
+      "Bearer trace-key",
+    )
+    expect(sampleSearchTraces).toHaveBeenCalledWith(
+      {},
+      {
+        locale: "en",
+        routeSource: "rest",
+        searchMode: "hybrid",
+        since: new Date("2026-05-25T00:00:00.000Z"),
+        until: new Date("2026-05-26T00:00:00.000Z"),
+        limit: 500,
+      },
+    )
+  })
+
+  it("rejects missing or wrong bearer before parsing the body", async () => {
+    isValidSearchTraceSamplingBearer.mockReturnValue(false)
+    const text = vi.fn(async () => {
+      throw new Error("body should not be read")
+    })
+    const response = await POST({
+      headers: new Headers(),
+      text,
+    } as unknown as Request)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: "Authorization required",
+    })
+    expect(text).not.toHaveBeenCalled()
+    expect(sampleSearchTraces).not.toHaveBeenCalled()
+  })
+
+  it("returns 429 before auth or body parsing when rate-limited", async () => {
+    rateLimitAuthRoute.mockResolvedValueOnce({
+      allowed: false,
+      source: "local",
+    })
+    const text = vi.fn(async () => JSON.stringify({ locale: "en" }))
+    const response = await POST({
+      headers: new Headers({ authorization: "Bearer trace-key" }),
+      text,
+    } as unknown as Request)
+
+    expect(response.status).toBe(429)
+    expect(isValidSearchTraceSamplingBearer).not.toHaveBeenCalled()
+    expect(text).not.toHaveBeenCalled()
+    expect(sampleSearchTraces).not.toHaveBeenCalled()
+  })
+
+  it("requires JSON content type before parsing the body", async () => {
+    const response = await POST(
+      rawRequest("{}", { authorization: "Bearer trace-key" }),
+    )
+
+    expect(response.status).toBe(415)
+    await expect(response.json()).resolves.toEqual({
+      error: "Content-Type must be application/json",
+    })
+    expect(sampleSearchTraces).not.toHaveBeenCalled()
+  })
+
+  it("rejects oversized bodies before reading them", async () => {
+    const text = vi.fn(async () => JSON.stringify({ locale: "en" }))
+    const response = await POST({
+      headers: new Headers({
+        authorization: "Bearer trace-key",
+        "content-type": "application/json",
+        "content-length": "4097",
+      }),
+      text,
+    } as unknown as Request)
+
+    expect(response.status).toBe(413)
+    expect(text).not.toHaveBeenCalled()
+    expect(sampleSearchTraces).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid JSON", async () => {
+    const response = await POST(
+      rawRequest("{", {
+        authorization: "Bearer trace-key",
+        "content-type": "application/json",
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid JSON body",
+    })
+    expect(sampleSearchTraces).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid routeSource filters", async () => {
+    const response = await POST(
+      request({ routeSource: "public" }, { authorization: "Bearer trace-key" }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(sampleSearchTraces).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed filter values instead of silently ignoring them", async () => {
+    for (const body of [
+      { locale: ["en"] },
+      { searchMode: 12 },
+      { since: "not-a-date" },
+      { until: 12 },
+      { limit: "50" },
+    ]) {
+      const response = await POST(
+        request(body, { authorization: "Bearer trace-key" }),
+      )
+
+      expect(response.status).toBe(400)
+    }
+    expect(sampleSearchTraces).not.toHaveBeenCalled()
+  })
+
+  it("keeps bearer, cookie, IP, user id, vector, and scoring data out of the response", async () => {
+    const response = await POST(
+      request({ locale: "en" }, { authorization: "Bearer trace-key" }),
+    )
+    const serialized = JSON.stringify(await response.json())
+
+    expect(serialized).not.toContain("Bearer")
+    expect(serialized).not.toMatch(/cookie|ipAddress|userId|vector|score/i)
+  })
+
+  it("sanitizes caller-controlled filter values in audit logs", async () => {
+    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const response = await POST(
+      request(
+        { locale: "en\ninjected=true", searchMode: "hybrid\tmode" },
+        { authorization: "Bearer trace-key" },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const line = String(logSpy.mock.calls[0]?.[0] ?? "")
+    expect(line).toContain("locale=en_injected_true")
+    expect(line).toContain("search_mode=hybrid_mode")
+    expect(line).not.toContain("\n")
+    expect(line).not.toContain("\t")
+    logSpy.mockRestore()
+  })
+})
+
+describe("GET /api/internal/search-traces/sample", () => {
+  it("does not expose anything without bearer auth", async () => {
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+  })
+})

--- a/apps/admin/src/app/api/internal/search-traces/sample/route.ts
+++ b/apps/admin/src/app/api/internal/search-traces/sample/route.ts
@@ -1,0 +1,173 @@
+import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { isValidSearchTraceSamplingBearer } from "@/auth/search-trace-bearer"
+import { prisma } from "@/db/client"
+import {
+  sampleSearchTraces,
+  type SearchTraceRouteSourceLabel,
+  type SearchTraceSampleFilters,
+} from "@/services/search-trace.service"
+
+const RATE_LIMIT_MAX = 20
+const RATE_LIMIT_WINDOW_MS = 60_000
+const MAX_SAMPLE_BODY_BYTES = 4096
+
+function tooManyRequests(): Response {
+  return Response.json({ error: "Too many requests" }, { status: 429 })
+}
+
+function unauthorized(): Response {
+  return Response.json({ error: "Authorization required" }, { status: 401 })
+}
+
+function badRequest(error: string): Response {
+  return Response.json({ error }, { status: 400 })
+}
+
+function unsupportedMediaType(): Response {
+  return Response.json(
+    { error: "Content-Type must be application/json" },
+    { status: 415 },
+  )
+}
+
+function payloadTooLarge(): Response {
+  return Response.json({ error: "JSON body is too large" }, { status: 413 })
+}
+
+function parseDate(value: unknown, name: string): Date | Response | undefined {
+  if (value == null) return undefined
+  if (typeof value !== "string" || value.length === 0) {
+    return badRequest(`${name} must be an ISO date string`)
+  }
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? badRequest(`${name} must be a valid date`)
+    : date
+}
+
+function parseLimit(value: unknown): number | Response | undefined {
+  if (value == null) return undefined
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return badRequest("limit must be a finite number")
+  }
+  return value
+}
+
+function parseString(
+  value: unknown,
+  name: string,
+): string | Response | undefined {
+  if (value == null) return undefined
+  if (typeof value !== "string") return badRequest(`${name} must be a string`)
+  return value
+}
+
+function logValue(value: string | undefined): string {
+  if (value == null || value.length === 0) return "all"
+  return value.replace(/[\r\n\t\s=]/g, "_").slice(0, 64)
+}
+
+async function readJsonBody(request: Request): Promise<unknown | Response> {
+  const contentType = request.headers.get("content-type") ?? ""
+  if (!/^\s*application\/json(?:\s*;|$)/i.test(contentType)) {
+    return unsupportedMediaType()
+  }
+
+  const contentLength = request.headers.get("content-length")
+  if (contentLength != null) {
+    const declaredBytes = Number(contentLength)
+    if (!Number.isFinite(declaredBytes) || declaredBytes < 0) {
+      return badRequest("Content-Length must be a non-negative number")
+    }
+    if (declaredBytes > MAX_SAMPLE_BODY_BYTES) return payloadTooLarge()
+  }
+
+  let text: string
+  try {
+    text = await request.text()
+  } catch {
+    return badRequest("Invalid JSON body")
+  }
+  if (new TextEncoder().encode(text).byteLength > MAX_SAMPLE_BODY_BYTES) {
+    return payloadTooLarge()
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return badRequest("Invalid JSON body")
+  }
+}
+
+function parseBody(body: unknown): SearchTraceSampleFilters | Response {
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    return badRequest("JSON body must be an object")
+  }
+  const record = body as Record<string, unknown>
+  const routeSource = record.routeSource
+  if (
+    routeSource != null &&
+    routeSource !== "rest" &&
+    routeSource !== "graphql"
+  ) {
+    return badRequest("routeSource must be 'rest' or 'graphql'")
+  }
+  const locale = parseString(record.locale, "locale")
+  if (locale instanceof Response) return locale
+  const searchMode = parseString(record.searchMode, "searchMode")
+  if (searchMode instanceof Response) return searchMode
+  const since = parseDate(record.since, "since")
+  if (since instanceof Response) return since
+  const until = parseDate(record.until, "until")
+  if (until instanceof Response) return until
+  const limit = parseLimit(record.limit)
+  if (limit instanceof Response) return limit
+
+  return {
+    locale,
+    routeSource: routeSource as SearchTraceRouteSourceLabel | undefined,
+    searchMode,
+    since,
+    until,
+    limit,
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const limit = await rateLimitAuthRoute({
+    request,
+    route: "search-trace-sample",
+    limit: RATE_LIMIT_MAX,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  })
+  if (!limit.allowed) return tooManyRequests()
+
+  if (!isValidSearchTraceSamplingBearer(request.headers.get("authorization"))) {
+    console.warn(
+      `[search] event=trace_sample_auth_denied route=internal rl=${limit.source}`,
+    )
+    return unauthorized()
+  }
+
+  const body = await readJsonBody(request)
+  if (body instanceof Response) return body
+
+  const filters = parseBody(body)
+  if (filters instanceof Response) return filters
+
+  const traces = await sampleSearchTraces(prisma, filters)
+  console.error(
+    `[search] event=trace_sample auth=bearer route=internal rl=${limit.source} locale=${logValue(filters.locale)} route_source=${logValue(filters.routeSource)} search_mode=${logValue(filters.searchMode)} result_count=${traces.length}`,
+  )
+  return Response.json(
+    {
+      traces,
+      generatedAt: new Date().toISOString(),
+    },
+    { status: 200 },
+  )
+}
+
+export async function GET(): Promise<Response> {
+  return unauthorized()
+}

--- a/apps/admin/src/app/api/search/health/route.test.ts
+++ b/apps/admin/src/app/api/search/health/route.test.ts
@@ -8,9 +8,29 @@ vi.mock("@/services/embeddings.service", () => ({
   generateExperienceEmbedding: vi.fn(),
 }))
 
+vi.mock("@/db/client", () => ({ prisma: {} }))
+
+vi.mock("@/services/search-trace.service", () => ({
+  getSearchTraceCaptureStats: vi.fn(() => ({
+    writeSuccesses: 0,
+    writeFailures: 0,
+    writeTimeouts: 0,
+    rawCaptureDisabled: 0,
+    lastWriteSuccessAt: null,
+    lastWriteFailureAt: null,
+    lastWriteTimeoutAt: null,
+    lastRawCaptureDisabledAt: null,
+  })),
+}))
+
+vi.mock("@/services/search-trace-retention.service", () => ({
+  readSearchTraceRetentionHealth: vi.fn(),
+}))
+
 import { rateLimitAuthRoute } from "@/auth/rate-limit"
 import { generateExperienceEmbedding } from "@/services/embeddings.service"
 import { __resetSearchHealthForTest } from "@/services/hybrid-search-health"
+import { readSearchTraceRetentionHealth } from "@/services/search-trace-retention.service"
 import { GET } from "./route"
 
 const allowRateLimit = () =>
@@ -33,6 +53,12 @@ beforeEach(() => {
   vi.clearAllMocks()
   __resetSearchHealthForTest()
   allowRateLimit()
+  vi.mocked(readSearchTraceRetentionHealth).mockResolvedValue({
+    healthy: true,
+    reason: "not-production",
+    latestPurgeAt: null,
+    activeSchedulerRunId: null,
+  })
 })
 
 afterEach(() => {
@@ -54,6 +80,11 @@ describe("GET /api/search/health", () => {
     expect(body.error).toBeNull()
     expect(body.attempts).toBe(1)
     expect(body.failures).toBe(0)
+    expect(body.retention).toMatchObject({ healthy: true })
+    expect(body.traceCapture).toMatchObject({
+      writeSuccesses: 0,
+      writeFailures: 0,
+    })
   })
 
   it("returns 200 + status=degraded when embedding throws", async () => {
@@ -71,6 +102,31 @@ describe("GET /api/search/health", () => {
     expect(body.lastErrorClass).toBe("Error")
     expect(body.lastErrorMessage).toBe("provider down")
     expect(body.lastErrorAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(body.retention).toMatchObject({ healthy: true })
+  })
+
+  it("returns status=degraded when trace retention is unhealthy", async () => {
+    vi.mocked(generateExperienceEmbedding).mockResolvedValue({
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+      embedding: new Array(1536).fill(0.1),
+    })
+    vi.mocked(readSearchTraceRetentionHealth).mockResolvedValueOnce({
+      healthy: false,
+      reason: "missing",
+      latestPurgeAt: null,
+      activeSchedulerRunId: null,
+    })
+
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe("degraded")
+    expect(body.error).toBe("search trace retention unhealthy")
+    expect(body.retention).toMatchObject({
+      healthy: false,
+      reason: "missing",
+    })
   })
 
   // Timeout behavior itself is covered by hybrid-search-health.test.ts;

--- a/apps/admin/src/app/api/search/health/route.ts
+++ b/apps/admin/src/app/api/search/health/route.ts
@@ -14,6 +14,7 @@
  */
 
 import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { prisma } from "@/db/client"
 import { generateExperienceEmbedding } from "@/services/embeddings.service"
 import {
   getStats,
@@ -21,6 +22,8 @@ import {
   recordFailure,
   withTimeout,
 } from "@/services/hybrid-search-health"
+import { getSearchTraceCaptureStats } from "@/services/search-trace.service"
+import { readSearchTraceRetentionHealth } from "@/services/search-trace-retention.service"
 
 const RATE_LIMIT_MAX = 5
 const RATE_LIMIT_WINDOW_MS = 60_000
@@ -34,6 +37,24 @@ const HEALTH_PROBE_INPUT = "health probe"
 
 function tooManyRequests(): Response {
   return Response.json({ error: "Too many requests" }, { status: 429 })
+}
+
+async function loadRetentionHealth() {
+  try {
+    return await readSearchTraceRetentionHealth(prisma)
+  } catch (error) {
+    const errorClass =
+      error instanceof Error ? error.constructor.name : "UnknownError"
+    console.error(
+      `[search] event=trace_retention_health_failed error_class=${errorClass}`,
+    )
+    return {
+      healthy: false,
+      reason: "missing" as const,
+      latestPurgeAt: null,
+      activeSchedulerRunId: null,
+    }
+  }
 }
 
 export async function GET(request: Request): Promise<Response> {
@@ -51,12 +72,20 @@ export async function GET(request: Request): Promise<Response> {
       generateExperienceEmbedding(HEALTH_PROBE_INPUT),
       HEALTH_PROBE_TIMEOUT_MS,
     )
+    const retention = await loadRetentionHealth()
     return Response.json(
-      { status: "ok", error: null, ...getStats() },
+      {
+        status: retention.healthy ? "ok" : "degraded",
+        error: retention.healthy ? null : "search trace retention unhealthy",
+        ...getStats(),
+        traceCapture: getSearchTraceCaptureStats(),
+        retention,
+      },
       { status: 200 },
     )
   } catch (error) {
     recordFailure(error)
+    const retention = await loadRetentionHealth()
     const errorClass =
       error instanceof Error ? error.constructor.name : "UnknownError"
     const message = error instanceof Error ? error.message : String(error)
@@ -65,7 +94,13 @@ export async function GET(request: Request): Promise<Response> {
       `[search] event=health_probe_failed error_class=${errorClass} message=${message}`,
     )
     return Response.json(
-      { status: "degraded", error: message, ...getStats() },
+      {
+        status: "degraded",
+        error: message,
+        ...getStats(),
+        traceCapture: getSearchTraceCaptureStats(),
+        retention,
+      },
       { status: 200 },
     )
   }

--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -15,17 +15,41 @@ vi.mock("@/config/env", () => ({
 // The route constructs a HybridSearchService with the shared `prisma`
 // import; we mock the class so tests don't touch the DB.
 const searchMock = vi.fn()
+const searchWithTraceMock = vi.fn(async (params) => {
+  const response = await searchMock(params)
+  return {
+    response,
+    trace: {
+      searchMode: response.searchMode,
+      resultCount: response.results.length,
+      outcome: response.searchMode === "keyword-only" ? "degraded" : "success",
+      traceClass:
+        response.searchMode === "keyword-only"
+          ? "query_embedding_failure"
+          : "none",
+      failedRetrievers: [],
+      contributingRetrievers: [],
+    },
+  }
+})
 vi.mock("@/services/hybrid-search.service", async () => {
   const actual = await vi.importActual<
     typeof import("@/services/hybrid-search.service")
   >("@/services/hybrid-search.service")
   return {
     ...actual,
-    HybridSearchService: vi.fn(() => ({ search: searchMock })),
+    HybridSearchService: vi.fn(() => ({
+      search: searchMock,
+      searchWithTrace: searchWithTraceMock,
+    })),
   }
 })
 
 vi.mock("@/db/client", () => ({ prisma: {} }))
+
+vi.mock("@/services/search-trace.service", () => ({
+  recordSearchTraceSafely: vi.fn(async () => ({ ok: true, timedOut: false })),
+}))
 
 vi.mock("@/services/hybrid-search-debug-allowlist", () => ({
   isDebugAllowedForOrigin: vi.fn(),
@@ -35,6 +59,7 @@ import { rateLimitAuthRoute } from "@/auth/rate-limit"
 import { isAnyKnownBearer } from "@/auth/search-bearer"
 import { env } from "@/config/env"
 import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
+import { recordSearchTraceSafely } from "@/services/search-trace.service"
 import { GET } from "./route"
 
 const envMutable = env as { SEARCH_AUTH_REQUIRED?: "true" | "false" }
@@ -172,6 +197,38 @@ describe("GET /api/search", () => {
     const body = await res.json()
     expect(body.results).toHaveLength(1)
     expect(body.searchMode).toBe("hybrid")
+    expect(recordSearchTraceSafely).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "jesus",
+        locale: "en",
+        routeSource: "rest",
+        requestedMode: null,
+        searchMode: "hybrid",
+        resultCount: 1,
+        outcome: "success",
+        traceClass: "none",
+        startedAt: expect.any(Date),
+        completedAt: expect.any(Date),
+      }),
+    )
+    expect(body).toEqual({
+      results: [
+        {
+          type: "video",
+          id: "vid-1",
+          slug: "jesus",
+          title: "Jesus",
+          imageUrl: null,
+          snippet: "scene",
+          startSeconds: 0,
+          playbackId: "mux-1",
+          score: 1,
+        },
+      ],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "hybrid",
+    })
   })
 
   it("returns 429 when rate limit exceeded", async () => {
@@ -271,6 +328,44 @@ describe("GET /api/search", () => {
     expect(await res.json()).toMatchObject({
       error: "Search is temporarily unavailable",
     })
+    expect(recordSearchTraceSafely).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "jesus",
+        locale: "en",
+        routeSource: "rest",
+        searchMode: "failed",
+        resultCount: 0,
+        outcome: "failed",
+        traceClass: "search_exception",
+      }),
+    )
+  })
+
+  it("keeps the search response unchanged when trace recording throws", async () => {
+    vi.mocked(recordSearchTraceSafely).mockRejectedValueOnce(
+      new Error("trace db down"),
+    )
+    searchMock.mockResolvedValueOnce({
+      results: [],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "hybrid",
+    })
+
+    const res = await GET(req("/api/search?q=jesus&locale=en"))
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      results: [],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "hybrid",
+    })
+  })
+
+  it("does not trace invalid requests rejected before live search", async () => {
+    const res = await GET(req("/api/search?locale=en"))
+    expect(res.status).toBe(400)
+    expect(recordSearchTraceSafely).not.toHaveBeenCalled()
   })
 
   describe("bearer auth gate (Plan 002)", () => {

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -16,6 +16,7 @@ import {
   type ContentType,
 } from "@/services/hybrid-search.service"
 import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
+import { recordSearchTraceSafely } from "@/services/search-trace.service"
 
 const RATE_LIMIT_MAX = 30
 const RATE_LIMIT_WINDOW_MS = 60_000
@@ -195,10 +196,11 @@ export async function GET(request: Request): Promise<Response> {
   const debugRequested = searchParams.get("debug") === "true"
   const origin = request.headers.get("origin") ?? undefined
   const debug = debugRequested && isDebugAllowedForOrigin(origin)
+  const startedAt = new Date()
 
   try {
     const service = new HybridSearchService({ prisma })
-    const result = await service.search({
+    const { response, trace } = await service.searchWithTrace({
       query: q,
       locale,
       limit: limitParam,
@@ -207,8 +209,32 @@ export async function GET(request: Request): Promise<Response> {
       mode,
       debug,
     })
-    return Response.json(result, { status: 200 })
+    await recordSearchTraceSafely({
+      query: q,
+      locale,
+      routeSource: "rest",
+      requestedMode: mode ?? null,
+      searchMode: trace.searchMode,
+      resultCount: trace.resultCount,
+      outcome: trace.outcome,
+      traceClass: trace.traceClass,
+      startedAt,
+      completedAt: new Date(),
+    }).catch(() => {})
+    return Response.json(response, { status: 200 })
   } catch (error) {
+    await recordSearchTraceSafely({
+      query: q,
+      locale,
+      routeSource: "rest",
+      requestedMode: mode ?? null,
+      searchMode: "failed",
+      resultCount: 0,
+      outcome: "failed",
+      traceClass: "search_exception",
+      startedAt,
+      completedAt: new Date(),
+    }).catch(() => {})
     console.error(
       `[search] Search failed: ${
         error instanceof Error ? error.message : String(error)

--- a/apps/admin/src/auth/search-trace-bearer.test.ts
+++ b/apps/admin/src/auth/search-trace-bearer.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/config/env", () => ({
+  env: {} as { SEARCH_TRACE_SAMPLING_API_KEYS?: string },
+}))
+
+const { env } = await import("@/config/env")
+const { isValidSearchTraceSamplingBearer } =
+  await import("@/auth/search-trace-bearer")
+
+const envMutable = env as { SEARCH_TRACE_SAMPLING_API_KEYS?: string }
+
+describe("search trace sampling bearer validation", () => {
+  beforeEach(() => {
+    envMutable.SEARCH_TRACE_SAMPLING_API_KEYS = "trace-a,trace-b"
+  })
+
+  afterEach(() => {
+    envMutable.SEARCH_TRACE_SAMPLING_API_KEYS = undefined
+  })
+
+  it("accepts a matching dedicated sampling bearer", () => {
+    expect(isValidSearchTraceSamplingBearer("Bearer trace-a")).toBe(true)
+    expect(isValidSearchTraceSamplingBearer("bearer trace-b")).toBe(true)
+  })
+
+  it("rejects missing, malformed, unknown, and empty bearer values", () => {
+    expect(isValidSearchTraceSamplingBearer(null)).toBe(false)
+    expect(isValidSearchTraceSamplingBearer("Basic trace-a")).toBe(false)
+    expect(isValidSearchTraceSamplingBearer("Bearer wrong")).toBe(false)
+    expect(isValidSearchTraceSamplingBearer("Bearer    ")).toBe(false)
+  })
+
+  it("rejects when the allowlist is unset or empty", () => {
+    envMutable.SEARCH_TRACE_SAMPLING_API_KEYS = undefined
+    expect(isValidSearchTraceSamplingBearer("Bearer trace-a")).toBe(false)
+
+    envMutable.SEARCH_TRACE_SAMPLING_API_KEYS = " , "
+    expect(isValidSearchTraceSamplingBearer("Bearer trace-a")).toBe(false)
+  })
+
+  it("rejects jfp_search partner-token shaped values even when pasted into the sampling allowlist", () => {
+    const partnerToken =
+      "jfp_search_ABCDEFGHJKLM_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    envMutable.SEARCH_TRACE_SAMPLING_API_KEYS = partnerToken
+
+    expect(isValidSearchTraceSamplingBearer(`Bearer ${partnerToken}`)).toBe(
+      false,
+    )
+  })
+
+  it("does not throw for length-mismatched unicode keys", () => {
+    envMutable.SEARCH_TRACE_SAMPLING_API_KEYS = "tréce"
+    expect(() => isValidSearchTraceSamplingBearer("Bearer trace")).not.toThrow()
+    expect(isValidSearchTraceSamplingBearer("Bearer trace")).toBe(false)
+  })
+})

--- a/apps/admin/src/auth/search-trace-bearer.ts
+++ b/apps/admin/src/auth/search-trace-bearer.ts
@@ -1,0 +1,44 @@
+// Narrow bearer-key authentication for internal search trace sampling.
+// This intentionally does NOT reuse public search, workflow, backup,
+// or Mastra ingest credentials.
+
+import { timingSafeEqual } from "node:crypto"
+import { env } from "@/config/env"
+import { parsePartnerToken } from "@/auth/partner-token"
+
+const BEARER_PREFIX = /^Bearer\s+/i
+
+function parseAllowlist(csv: string | undefined): string[] {
+  if (!csv) return []
+  return csv
+    .split(",")
+    .map((key) => key.trim())
+    .filter((key) => key.length > 0)
+}
+
+export function isValidSearchTraceSamplingBearer(
+  authHeader: string | null,
+): boolean {
+  if (!authHeader || !BEARER_PREFIX.test(authHeader)) return false
+  const presented = authHeader.replace(BEARER_PREFIX, "")
+  if (presented.trim().length === 0) return false
+
+  const allowlist = parseAllowlist(env.SEARCH_TRACE_SAMPLING_API_KEYS)
+  if (allowlist.length === 0) return false
+
+  const presentedBuffer = Buffer.from(presented)
+  let matched = false
+  for (const key of allowlist) {
+    const keyBuffer = Buffer.from(key)
+    if (keyBuffer.length !== presentedBuffer.length) continue
+    if (timingSafeEqual(presentedBuffer, keyBuffer)) {
+      matched = true
+    }
+  }
+  if (!matched) return false
+
+  // DB-backed public search partner tokens use the jfp_search_* shape. Reject
+  // that entire shape even if an operator accidentally pasted one into the
+  // sampling CSV; public-search credentials must never gain raw trace export.
+  return parsePartnerToken(authHeader) == null
+}

--- a/apps/admin/src/config/env.test.ts
+++ b/apps/admin/src/config/env.test.ts
@@ -6,6 +6,7 @@ import {
   assertBearerCsvsDisjoint,
   concurrencyEnvSchema,
   env,
+  searchTraceRawRetentionDaysEnvSchema,
 } from "@/config/env"
 
 describe("env", () => {
@@ -40,11 +41,29 @@ describe("env", () => {
     })
   })
 
+  describe("searchTraceRawRetentionDaysEnvSchema", () => {
+    it("defaults to 29 days", () => {
+      expect(searchTraceRawRetentionDaysEnvSchema.parse(undefined)).toBe(29)
+    })
+
+    it("accepts integer values from 1 through 29", () => {
+      expect(searchTraceRawRetentionDaysEnvSchema.parse("1")).toBe(1)
+      expect(searchTraceRawRetentionDaysEnvSchema.parse("29")).toBe(29)
+    })
+
+    it("rejects zero, fractional, negative, and 30-day retention values", () => {
+      expect(() => searchTraceRawRetentionDaysEnvSchema.parse("0")).toThrow()
+      expect(() => searchTraceRawRetentionDaysEnvSchema.parse("1.5")).toThrow()
+      expect(() => searchTraceRawRetentionDaysEnvSchema.parse("-1")).toThrow()
+      expect(() => searchTraceRawRetentionDaysEnvSchema.parse("30")).toThrow()
+    })
+  })
+
   // Bearer-CSV disjointness invariant. The bearer CSVs
   // (WORKFLOW_API_KEYS, MASTRA_TRANSCRIPT_INGEST_API_KEYS,
   // MASTRA_SCENE_INGEST_API_KEYS, MASTRA_EXPERIENCE_INGEST_API_KEYS,
   // WEB_ADMIN_API_KEYS,
-  // BACKUP_DOWNLOAD_API_KEYS)
+  // BACKUP_DOWNLOAD_API_KEYS, SEARCH_TRACE_SAMPLING_API_KEYS)
   // MUST NOT share any value; the auth chains mint distinct
   // principals / passports, so a duplicated key silently widens
   // permissions or passes a passport it shouldn't. The legacy
@@ -80,6 +99,11 @@ describe("env", () => {
       expect(() =>
         assertBearerCsvsDisjoint({ BACKUP_DOWNLOAD_API_KEYS: "backup-a" }),
       ).not.toThrow()
+      expect(() =>
+        assertBearerCsvsDisjoint({
+          SEARCH_TRACE_SAMPLING_API_KEYS: "trace-sampling-a",
+        }),
+      ).not.toThrow()
     })
 
     it("passes when all CSVs are disjoint", () => {
@@ -91,6 +115,7 @@ describe("env", () => {
           MASTRA_EXPERIENCE_INGEST_API_KEYS: "experience-a,experience-b",
           WEB_ADMIN_API_KEYS: "web-a,web-b",
           BACKUP_DOWNLOAD_API_KEYS: "backup-a,backup-b",
+          SEARCH_TRACE_SAMPLING_API_KEYS: "trace-sampling-a,trace-sampling-b",
         }),
       ).not.toThrow()
     })
@@ -145,17 +170,23 @@ describe("env", () => {
     })
 
     it("throws when WEB_ADMIN_API_KEYS overlaps BACKUP_DOWNLOAD_API_KEYS", () => {
-      // Closes the matrix: the 3-CSV invariant has 3 pairs and this
-      // covers the WEB_ADMIN ↔ BACKUP_DOWNLOAD pair. A regression
-      // that mis-indexed the inner-loop start (`j = i + 1` →
-      // `j = i + 2`) or swapped the sets tuple order could break
-      // this single pair without any other test failing.
       expect(() =>
         assertBearerCsvsDisjoint({
           WEB_ADMIN_API_KEYS: "shared-key",
           BACKUP_DOWNLOAD_API_KEYS: "shared-key",
         }),
       ).toThrow(/WEB_ADMIN_API_KEYS and BACKUP_DOWNLOAD_API_KEYS/)
+    })
+
+    it("throws when SEARCH_TRACE_SAMPLING overlaps another bearer capability", () => {
+      expect(() =>
+        assertBearerCsvsDisjoint({
+          SEARCH_TRACE_SAMPLING_API_KEYS: "shared-key",
+          MASTRA_EXPERIENCE_INGEST_API_KEYS: "shared-key",
+        }),
+      ).toThrow(
+        /MASTRA_EXPERIENCE_INGEST_API_KEYS and SEARCH_TRACE_SAMPLING_API_KEYS/,
+      )
     })
 
     it("collects ALL overlapping pairs into a single error (not first-fail)", async () => {
@@ -171,6 +202,7 @@ describe("env", () => {
           MASTRA_EXPERIENCE_INGEST_API_KEYS: "experience-a",
           WEB_ADMIN_API_KEYS: "shared-1,shared-2",
           BACKUP_DOWNLOAD_API_KEYS: "shared-2",
+          SEARCH_TRACE_SAMPLING_API_KEYS: "shared-1",
         })
       } catch (err) {
         caught = err as Error
@@ -182,6 +214,9 @@ describe("env", () => {
       )
       expect(caught!.message).toMatch(
         /WEB_ADMIN_API_KEYS and BACKUP_DOWNLOAD_API_KEYS/,
+      )
+      expect(caught!.message).toMatch(
+        /WORKFLOW_API_KEYS and SEARCH_TRACE_SAMPLING_API_KEYS/,
       )
       // And the rotation runbook is referenced.
       expect(caught!.message).toMatch(/Search API authentication/)
@@ -223,6 +258,9 @@ describe("env", () => {
       expect(source).toMatch(/WEB_ADMIN_API_KEYS:\s*env\.WEB_ADMIN_API_KEYS/)
       expect(source).toMatch(
         /BACKUP_DOWNLOAD_API_KEYS:\s*env\.BACKUP_DOWNLOAD_API_KEYS/,
+      )
+      expect(source).toMatch(
+        /SEARCH_TRACE_SAMPLING_API_KEYS:\s*env\.SEARCH_TRACE_SAMPLING_API_KEYS/,
       )
       // Regression guard: SEARCH_API_KEYS must NOT appear in the Zod
       // schema (the receiver-side CSV is retired in Plan 003) and

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -20,6 +20,14 @@ export const concurrencyEnvSchema = z.coerce
   .positive()
   .optional()
 
+export const searchTraceRawRetentionDaysEnvSchema = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .max(29)
+  .optional()
+  .default(29)
+
 // Unit 1 scaffolding shipped a minimal env. Each later unit appends the
 // vars it owns here and in runtimeEnv. Never read process.env directly.
 export const env = createEnv({
@@ -115,6 +123,14 @@ export const env = createEnv({
     // `.optional()` because the harness still works without it during
     // dual-accept — anonymous traffic logs as `auth=anonymous`.
     SEARCH_API_KEY: z.string().min(1).optional(),
+    // Admin-owned production search trace sampling. Future Mastra eval jobs
+    // call the internal Admin sampling route with a dedicated bearer from
+    // this CSV; it must stay disjoint from public search, workflow launch,
+    // backup download, and vector-ingest credentials.
+    SEARCH_TRACE_SAMPLING_API_KEYS: z.string().min(1).optional(),
+    // Raw search traces expire before the 30-day hard ceiling so the daily
+    // purge has a real safety margin. Aggregates survive without query text.
+    SEARCH_TRACE_RAW_RETENTION_DAYS: searchTraceRawRetentionDaysEnvSchema,
     WORKFLOW_HMAC_SECRET: z.string().min(1).optional(),
     WORKFLOW_TARGET_WORLD: z
       .enum(["local", "@workflow/world-postgres"])
@@ -306,6 +322,12 @@ export const env = createEnv({
     ),
     SEARCH_AUTH_REQUIRED: emptyToUndefined(process.env.SEARCH_AUTH_REQUIRED),
     SEARCH_API_KEY: emptyToUndefined(process.env.SEARCH_API_KEY),
+    SEARCH_TRACE_SAMPLING_API_KEYS: emptyToUndefined(
+      process.env.SEARCH_TRACE_SAMPLING_API_KEYS,
+    ),
+    SEARCH_TRACE_RAW_RETENTION_DAYS: emptyToUndefined(
+      process.env.SEARCH_TRACE_RAW_RETENTION_DAYS,
+    ),
     WORKFLOW_HMAC_SECRET: emptyToUndefined(process.env.WORKFLOW_HMAC_SECRET),
     WORKFLOW_TARGET_WORLD: emptyToUndefined(process.env.WORKFLOW_TARGET_WORLD),
     WORKFLOW_RUNNER_ENABLED: emptyToUndefined(
@@ -428,6 +450,7 @@ const BEARER_CSV_KEYS = [
   "MANAGER_ADMIN_API_KEY",
   "WEB_ADMIN_API_KEYS",
   "BACKUP_DOWNLOAD_API_KEYS",
+  "SEARCH_TRACE_SAMPLING_API_KEYS",
 ] as const
 
 type BearerCsvKey = (typeof BEARER_CSV_KEYS)[number]
@@ -503,6 +526,7 @@ assertBearerCsvsDisjoint({
   MANAGER_ADMIN_API_KEY: env.MANAGER_ADMIN_API_KEY,
   WEB_ADMIN_API_KEYS: env.WEB_ADMIN_API_KEYS,
   BACKUP_DOWNLOAD_API_KEYS: env.BACKUP_DOWNLOAD_API_KEYS,
+  SEARCH_TRACE_SAMPLING_API_KEYS: env.SEARCH_TRACE_SAMPLING_API_KEYS,
 })
 
 // Plan 003 retired the SEARCH_API_KEYS env-CSV partner branch — external

--- a/apps/admin/src/graphql/queries/hybrid-search.test.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.test.ts
@@ -11,13 +11,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const searchMock = vi.fn()
+const searchWithTraceMock = vi.fn(async (params) => {
+  const response = await searchMock(params)
+  return {
+    response,
+    trace: {
+      searchMode: response.searchMode,
+      resultCount: response.results.length,
+      outcome: response.searchMode === "keyword-only" ? "degraded" : "success",
+      traceClass:
+        response.searchMode === "keyword-only"
+          ? "query_embedding_failure"
+          : "none",
+      failedRetrievers: [],
+      contributingRetrievers: [],
+    },
+  }
+})
 vi.mock("@/services/hybrid-search.service", async () => {
   const actual = await vi.importActual<
     typeof import("@/services/hybrid-search.service")
   >("@/services/hybrid-search.service")
   return {
     ...actual,
-    HybridSearchService: vi.fn(() => ({ search: searchMock })),
+    HybridSearchService: vi.fn(() => ({
+      search: searchMock,
+      searchWithTrace: searchWithTraceMock,
+    })),
   }
 })
 
@@ -31,6 +51,10 @@ vi.mock("@/auth/search-bearer", () => ({
   isAnyKnownBearer: vi.fn(),
 }))
 
+vi.mock("@/services/search-trace.service", () => ({
+  recordSearchTraceSafely: vi.fn(async () => ({ ok: true, timedOut: false })),
+}))
+
 vi.mock("@/config/env", () => ({
   env: {} as { SEARCH_AUTH_REQUIRED?: "true" | "false" },
 }))
@@ -39,6 +63,7 @@ import { schema } from "@/graphql/schema"
 import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
 import { isAnyKnownBearer } from "@/auth/search-bearer"
 import { env } from "@/config/env"
+import { recordSearchTraceSafely } from "@/services/search-trace.service"
 
 const envMutable = env as { SEARCH_AUTH_REQUIRED?: "true" | "false" }
 
@@ -111,6 +136,7 @@ describe("Query.search resolver", () => {
   it("rejects empty / whitespace-only q", async () => {
     await expect(invoke({ q: "   ", locale: "en" })).rejects.toThrow(/q/)
     expect(searchMock).not.toHaveBeenCalled()
+    expect(recordSearchTraceSafely).not.toHaveBeenCalled()
   })
 
   it("rejects empty locale", async () => {
@@ -183,6 +209,85 @@ describe("Query.search resolver", () => {
         offset: 10,
       }),
     )
+  })
+
+  it("returns the public response unchanged while recording a GraphQL trace", async () => {
+    searchMock.mockResolvedValueOnce({
+      results: [
+        {
+          type: "experience",
+          id: "exp-1",
+          slug: "easter",
+          title: "Easter",
+          imageUrl: null,
+          snippet: "",
+          startSeconds: null,
+          playbackId: null,
+          score: 1,
+          label: null,
+          durationSeconds: null,
+          childCount: null,
+        },
+      ],
+      hasMore: false,
+      query: "easter",
+      searchMode: "hybrid",
+    })
+
+    await expect(invoke({ q: "  easter  ", locale: "en" })).resolves.toEqual({
+      results: [
+        {
+          type: "experience",
+          id: "exp-1",
+          slug: "easter",
+          title: "Easter",
+          imageUrl: null,
+          snippet: "",
+          startSeconds: null,
+          playbackId: null,
+          score: 1,
+          label: null,
+          durationSeconds: null,
+          childCount: null,
+        },
+      ],
+      hasMore: false,
+      query: "easter",
+      searchMode: "hybrid",
+    })
+    expect(recordSearchTraceSafely).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "easter",
+        locale: "en",
+        routeSource: "graphql",
+        requestedMode: null,
+        searchMode: "hybrid",
+        resultCount: 1,
+        outcome: "success",
+        traceClass: "none",
+        startedAt: expect.any(Date),
+        completedAt: expect.any(Date),
+      }),
+    )
+  })
+
+  it("keeps the GraphQL result unchanged when trace recording throws", async () => {
+    vi.mocked(recordSearchTraceSafely).mockRejectedValueOnce(
+      new Error("trace write failed"),
+    )
+    searchMock.mockResolvedValueOnce({
+      results: [],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "hybrid",
+    })
+
+    await expect(invoke({ q: "jesus", locale: "en" })).resolves.toEqual({
+      results: [],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "hybrid",
+    })
   })
 })
 
@@ -485,6 +590,17 @@ describe("Query.search bearer auth gate (Plan 002)", () => {
       // affecting any other GraphQL test.
       searchMock.mockRejectedValueOnce(new Error("boom"))
       await expect(invoke({ q: "jesus", locale: "en" })).rejects.toThrow(/boom/)
+      expect(recordSearchTraceSafely).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: "jesus",
+          locale: "en",
+          routeSource: "graphql",
+          searchMode: "failed",
+          resultCount: 0,
+          outcome: "failed",
+          traceClass: "search_exception",
+        }),
+      )
       const log = parseSearchLogLines()[0]
       expect(log).toMatchObject({
         event: "search.request",

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -22,6 +22,7 @@ import {
   type SearchResponse,
 } from "@/services/hybrid-search.service"
 import { isDebugAllowedForOrigin } from "@/services/hybrid-search-debug-allowlist"
+import { recordSearchTraceSafely } from "@/services/search-trace.service"
 import { SearchResultDebugRef } from "@/graphql/types/hybrid-search-debug"
 import { VideoLabelEnum } from "@/graphql/types/video"
 
@@ -251,15 +252,45 @@ builder.queryFields((t) => ({
       const debug = debugRequested && isDebugAllowedForOrigin(origin)
 
       const service = new HybridSearchService({ prisma })
-      return service.search({
-        query,
-        locale: args.locale,
-        limit: args.limit ?? undefined,
-        offset: args.offset ?? undefined,
-        contentTypes,
-        mode,
-        debug,
-      })
+      const startedAt = new Date()
+      try {
+        const { response, trace } = await service.searchWithTrace({
+          query,
+          locale: args.locale,
+          limit: args.limit ?? undefined,
+          offset: args.offset ?? undefined,
+          contentTypes,
+          mode,
+          debug,
+        })
+        await recordSearchTraceSafely({
+          query,
+          locale: args.locale,
+          routeSource: "graphql",
+          requestedMode: mode ?? null,
+          searchMode: trace.searchMode,
+          resultCount: trace.resultCount,
+          outcome: trace.outcome,
+          traceClass: trace.traceClass,
+          startedAt,
+          completedAt: new Date(),
+        }).catch(() => {})
+        return response
+      } catch (error) {
+        await recordSearchTraceSafely({
+          query,
+          locale: args.locale,
+          routeSource: "graphql",
+          requestedMode: mode ?? null,
+          searchMode: "failed",
+          resultCount: 0,
+          outcome: "failed",
+          traceClass: "search_exception",
+          startedAt,
+          completedAt: new Date(),
+        }).catch(() => {})
+        throw error
+      }
     },
   }),
 }))

--- a/apps/admin/src/instrumentation.test.ts
+++ b/apps/admin/src/instrumentation.test.ts
@@ -15,6 +15,7 @@ const worldStart = vi.hoisted(() => vi.fn())
 const getWorld = vi.hoisted(() => vi.fn(() => ({ start: worldStart })))
 const startWorkflowWorkerHeartbeat = vi.hoisted(() => vi.fn())
 const ensureVideoDbBackupSchedulerStarted = vi.hoisted(() => vi.fn())
+const ensureSearchTraceRetentionSchedulerStarted = vi.hoisted(() => vi.fn())
 
 vi.mock("@/config/env", () => mockEnv)
 vi.mock("workflow/runtime", () => ({ getWorld }))
@@ -23,6 +24,9 @@ vi.mock("@/services/workflow-worker-heartbeat.service", () => ({
 }))
 vi.mock("@/services/video-db-backup/job", () => ({
   ensureVideoDbBackupSchedulerStarted,
+}))
+vi.mock("@/services/search-trace-retention/job", () => ({
+  ensureSearchTraceRetentionSchedulerStarted,
 }))
 
 describe("workflow instrumentation", () => {
@@ -44,6 +48,7 @@ describe("workflow instrumentation", () => {
     expect(worldStart).not.toHaveBeenCalled()
     expect(startWorkflowWorkerHeartbeat).not.toHaveBeenCalled()
     expect(ensureVideoDbBackupSchedulerStarted).not.toHaveBeenCalled()
+    expect(ensureSearchTraceRetentionSchedulerStarted).not.toHaveBeenCalled()
   })
 
   it("does not start a world on web services that only read workflow data", async () => {
@@ -59,6 +64,7 @@ describe("workflow instrumentation", () => {
     expect(worldStart).not.toHaveBeenCalled()
     expect(startWorkflowWorkerHeartbeat).not.toHaveBeenCalled()
     expect(ensureVideoDbBackupSchedulerStarted).not.toHaveBeenCalled()
+    expect(ensureSearchTraceRetentionSchedulerStarted).not.toHaveBeenCalled()
   })
 
   it("does not start a world in the edge runtime", async () => {
@@ -75,6 +81,7 @@ describe("workflow instrumentation", () => {
     expect(worldStart).not.toHaveBeenCalled()
     expect(startWorkflowWorkerHeartbeat).not.toHaveBeenCalled()
     expect(ensureVideoDbBackupSchedulerStarted).not.toHaveBeenCalled()
+    expect(ensureSearchTraceRetentionSchedulerStarted).not.toHaveBeenCalled()
   })
 
   it("starts Postgres World in the node runtime", async () => {
@@ -90,5 +97,6 @@ describe("workflow instrumentation", () => {
     expect(worldStart).toHaveBeenCalledTimes(1)
     expect(startWorkflowWorkerHeartbeat).toHaveBeenCalledTimes(1)
     expect(ensureVideoDbBackupSchedulerStarted).toHaveBeenCalledTimes(1)
+    expect(ensureSearchTraceRetentionSchedulerStarted).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -16,8 +16,11 @@ export async function register(): Promise<void> {
     await import("@/services/workflow-worker-heartbeat.service")
   const { ensureVideoDbBackupSchedulerStarted } =
     await import("@/services/video-db-backup/job")
+  const { ensureSearchTraceRetentionSchedulerStarted } =
+    await import("@/services/search-trace-retention/job")
   const world = getWorld()
   await world.start?.()
   await startWorkflowWorkerHeartbeat()
   await ensureVideoDbBackupSchedulerStarted()
+  await ensureSearchTraceRetentionSchedulerStarted()
 }

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -179,6 +179,111 @@ describe("HybridSearchService", () => {
     )
   })
 
+  it("returns internal trace metadata without changing search() response shape", async () => {
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-1",
+        videoCoreId: "core-1",
+        videoSlug: "jesus",
+        videoTitle: "Jesus",
+        imageUrl: null,
+        sceneDescription: "A scene about Jesus",
+        startSeconds: 12,
+        playbackId: "mux-1",
+        similarity: 0.9,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    const traced = await service.searchWithTrace({
+      query: "jesus",
+      locale: "en",
+    })
+
+    expect(traced.response).toMatchObject({
+      query: "jesus",
+      searchMode: "hybrid",
+      hasMore: false,
+    })
+    expect(traced.trace).toEqual({
+      searchMode: "hybrid",
+      resultCount: 1,
+      outcome: "success",
+      traceClass: "none",
+      failedRetrievers: [],
+      contributingRetrievers: ["semantic-video"],
+    })
+    expect(await service.search({ query: "jesus", locale: "en" })).toEqual(
+      expect.objectContaining({
+        query: "jesus",
+        searchMode: "hybrid",
+      }),
+    )
+  })
+
+  it("classifies embedding failure in trace metadata", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: failingEmbedder(),
+      logger,
+    })
+
+    const traced = await service.searchWithTrace({
+      query: "grace",
+      locale: "en",
+    })
+
+    expect(traced.response.searchMode).toBe("keyword-only")
+    expect(traced.trace).toMatchObject({
+      searchMode: "keyword-only",
+      outcome: "degraded",
+      traceClass: "query_embedding_failure",
+    })
+  })
+
+  it("classifies partial retriever failure separately from zero results", async () => {
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-1",
+        videoCoreId: "core-1",
+        videoSlug: "jesus",
+        videoTitle: "Jesus",
+        imageUrl: null,
+        sceneDescription: "A scene about Jesus",
+        startSeconds: 12,
+        playbackId: "mux-1",
+        similarity: 0.9,
+        embeddingText: "[0.1,0.2,0.3]",
+      },
+    ])
+    vi.mocked(searchVideoKeyword).mockRejectedValueOnce(
+      new Error("keyword index unavailable"),
+    )
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    const traced = await service.searchWithTrace({
+      query: "jesus",
+      locale: "en",
+    })
+
+    expect(traced.response.results).toHaveLength(1)
+    expect(traced.trace.outcome).toBe("degraded")
+    expect(traced.trace.traceClass).toBe("retrieval_failure")
+    expect(traced.trace.failedRetrievers).toEqual(["keyword-video"])
+    expect(traced.trace.contributingRetrievers).toEqual(["semantic-video"])
+  })
+
   it("restricts to video corpus when contentTypes=['video']", async () => {
     const service = new HybridSearchService({
       prisma: mockPrisma,

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -236,6 +236,20 @@ export type SearchResponse = {
   searchMode: SearchMode
 }
 
+export type SearchExecutionSummary = {
+  searchMode: SearchMode
+  resultCount: number
+  outcome: "success" | "degraded"
+  traceClass: string
+  failedRetrievers: string[]
+  contributingRetrievers: string[]
+}
+
+export type SearchWithTraceResult = {
+  response: SearchResponse
+  trace: SearchExecutionSummary
+}
+
 /**
  * Converts a number[] embedding vector to pgvector text format
  * "[0.1,0.2,...]". Kept local rather than importing toPgVector from
@@ -491,6 +505,11 @@ export class HybridSearchService {
   }
 
   async search(params: SearchParams): Promise<SearchResponse> {
+    const { response } = await this.searchWithTrace(params)
+    return response
+  }
+
+  async searchWithTrace(params: SearchParams): Promise<SearchWithTraceResult> {
     const { query, locale } = params
 
     // Decode the opt-in pipeline mode. Unknown values warn-and-fall-back
@@ -520,11 +539,13 @@ export class HybridSearchService {
     // warn let feat-097 hide in production for days) and tracked via
     // process-local counters the health probe exposes.
     let queryEmbeddingText: string | null = null
+    let embeddingFailed = false
     recordAttempt()
     try {
       const vector = await this.embedder(query)
       queryEmbeddingText = toPgvectorText(vector)
     } catch (error) {
+      embeddingFailed = true
       recordFailure(error)
       const errorClass =
         error instanceof Error ? error.constructor.name : "UnknownError"
@@ -626,8 +647,9 @@ export class HybridSearchService {
     }
 
     const outcomes = await Promise.allSettled(retrievals.map((r) => r.promise))
+    const failedRetrievers: string[] = []
     const lists = outcomes.map((outcome, i) =>
-      this.unwrapOutcome(outcome, retrievals[i]!.label),
+      this.unwrapOutcome(outcome, retrievals[i]!.label, failedRetrievers),
     )
 
     // (label, list) pairs for downstream origin tracking. Used by both
@@ -709,22 +731,44 @@ export class HybridSearchService {
       this.logger,
     )
 
-    return {
+    const searchMode = queryEmbeddingText != null ? "hybrid" : "keyword-only"
+    const contributingRetrievers = labeledLists
+      .filter(({ list }) => list.length > 0)
+      .map(({ label }) => label)
+    const traceClasses: string[] = []
+    if (embeddingFailed) traceClasses.push("query_embedding_failure")
+    if (failedRetrievers.length > 0) traceClasses.push("retrieval_failure")
+    const traceClass = traceClasses.length > 0 ? traceClasses.join("+") : "none"
+    const response: SearchResponse = {
       results,
       hasMore,
       query,
       // queryEmbeddingText is non-null iff the embedding call succeeded
       // and both semantic retrievals were dispatched. If null, the
       // response is assembled from keyword retrieval alone.
-      searchMode: queryEmbeddingText != null ? "hybrid" : "keyword-only",
+      searchMode,
+    }
+
+    return {
+      response,
+      trace: {
+        searchMode,
+        resultCount: results.length,
+        outcome: traceClass === "none" ? "success" : "degraded",
+        traceClass,
+        failedRetrievers,
+        contributingRetrievers,
+      },
     }
   }
 
   private unwrapOutcome<T>(
     outcome: PromiseSettledResult<T[]>,
     label: string,
+    failedRetrievers: string[],
   ): T[] {
     if (outcome.status === "fulfilled") return outcome.value
+    failedRetrievers.push(label)
     this.logger.error(
       `[search] ${label} retrieval failed: ${
         outcome.reason instanceof Error

--- a/apps/admin/src/services/search-eval/fingerprint.test.ts
+++ b/apps/admin/src/services/search-eval/fingerprint.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { compareFingerprints, readFingerprint } from "./fingerprint"
+import {
+  compareFingerprints,
+  readFingerprint,
+  readSearchTraceAggregateFingerprint,
+} from "./fingerprint"
 import type { Fingerprint } from "./types"
 
 function buildPrismaStub(rows: unknown[]) {
@@ -151,6 +155,68 @@ describe("readFingerprint", () => {
     const sqlChunks = queryRaw.$queryRaw.mock.calls[0]?.[0]?.join("") ?? ""
 
     expect(sqlChunks).toContain("status = 'published'")
+  })
+})
+
+describe("readSearchTraceAggregateFingerprint", () => {
+  it("reads aggregate counters without changing the content fingerprint shape", async () => {
+    const prisma = buildPrismaStub([
+      {
+        aggregate_count: 5n,
+        aggregate_max_updated_at: new Date("2026-05-25T00:00:00Z"),
+        query_count_sum: 120n,
+        result_count_sum: 350n,
+      },
+    ])
+
+    await expect(readSearchTraceAggregateFingerprint(prisma)).resolves.toEqual({
+      aggregateRows: {
+        count: 5,
+        maxUpdatedAt: "2026-05-25T00:00:00.000Z",
+      },
+      queryCountSum: 120,
+      resultCountSum: 350,
+    })
+  })
+
+  it("uses search_trace_aggregate only and never reads raw query text", async () => {
+    const prisma = buildPrismaStub([
+      {
+        aggregate_count: 0n,
+        aggregate_max_updated_at: null,
+        query_count_sum: 0n,
+        result_count_sum: 0n,
+      },
+    ])
+    await readSearchTraceAggregateFingerprint(prisma)
+
+    const queryRaw = prisma as unknown as {
+      $queryRaw: { mock: { calls: [TemplateStringsArray, ...unknown[]][] } }
+    }
+    const sql = queryRaw.$queryRaw.mock.calls[0]?.[0]?.join(" ") ?? ""
+
+    expect(sql).toContain("search_trace_aggregate")
+    expect(sql).not.toMatch(/query_text|queryText|search_trace\s/i)
+  })
+
+  it("does not add trace fields to the existing baseline Fingerprint type", async () => {
+    const prisma = buildPrismaStub([
+      {
+        scene_count: 0n,
+        scene_max_updated_at: null,
+        transcript_count: 0n,
+        transcript_max_updated_at: null,
+        experience_count: 0n,
+        experience_max_updated_at: null,
+      },
+    ])
+
+    const fp = await readFingerprint(prisma)
+    expect(Object.keys(fp).sort()).toEqual([
+      "experiences",
+      "sceneEmbeddings",
+      "transcriptEmbeddings",
+    ])
   })
 })
 

--- a/apps/admin/src/services/search-eval/fingerprint.ts
+++ b/apps/admin/src/services/search-eval/fingerprint.ts
@@ -37,6 +37,22 @@ type CombinedFingerprintRow = {
   experience_max_updated_at: Date | null
 }
 
+type TraceAggregateFingerprintRow = {
+  aggregate_count: bigint | number
+  aggregate_max_updated_at: Date | null
+  query_count_sum: bigint | number | null
+  result_count_sum: bigint | number | null
+}
+
+export type SearchTraceAggregateFingerprint = {
+  aggregateRows: {
+    count: number
+    maxUpdatedAt: string | null
+  }
+  queryCountSum: number
+  resultCountSum: number
+}
+
 function toNumberCount(value: bigint | number): number {
   return typeof value === "bigint" ? Number(value) : value
 }
@@ -93,6 +109,44 @@ export async function readFingerprint(
       count: toNumberCount(row.experience_count),
       maxUpdatedAt: toIsoOrNull(row.experience_max_updated_at),
     },
+  }
+}
+
+/**
+ * Companion fingerprint for Admin-owned search trace aggregates.
+ *
+ * This intentionally does NOT modify the schemaVersion 1 content
+ * `Fingerprint` shape used by existing eval baselines. It gives future
+ * trace-aware tooling an opt-in way to detect aggregate-store drift after
+ * raw traces have been purged, without reading or exposing raw query text.
+ */
+export async function readSearchTraceAggregateFingerprint(
+  prisma: PrismaClient,
+): Promise<SearchTraceAggregateFingerprint> {
+  const [row] = await prisma.$queryRaw<TraceAggregateFingerprintRow[]>`
+    SELECT
+      COUNT(*) AS aggregate_count,
+      MAX(updated_at) AS aggregate_max_updated_at,
+      COALESCE(SUM(query_count), 0) AS query_count_sum,
+      COALESCE(SUM(result_count_sum), 0) AS result_count_sum
+    FROM search_trace_aggregate
+  `
+
+  if (row == null) {
+    return {
+      aggregateRows: { count: 0, maxUpdatedAt: null },
+      queryCountSum: 0,
+      resultCountSum: 0,
+    }
+  }
+
+  return {
+    aggregateRows: {
+      count: toNumberCount(row.aggregate_count),
+      maxUpdatedAt: toIsoOrNull(row.aggregate_max_updated_at),
+    },
+    queryCountSum: toNumberCount(row.query_count_sum ?? 0),
+    resultCountSum: toNumberCount(row.result_count_sum ?? 0),
   }
 }
 

--- a/apps/admin/src/services/search-trace-health.test.ts
+++ b/apps/admin/src/services/search-trace-health.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  __resetSearchTraceHealthForTest,
+  getSearchTraceHealthCounters,
+  recordSearchTraceRawCaptureDisabled,
+  recordSearchTraceWriteFailure,
+  recordSearchTraceWriteSuccess,
+  recordSearchTraceWriteTimeout,
+} from "./search-trace-health"
+
+describe("search trace health counters", () => {
+  beforeEach(() => {
+    __resetSearchTraceHealthForTest()
+  })
+
+  it("tracks safe capture outcomes without storing query text", () => {
+    recordSearchTraceWriteSuccess()
+    recordSearchTraceWriteFailure()
+    recordSearchTraceWriteTimeout()
+    recordSearchTraceRawCaptureDisabled()
+
+    expect(getSearchTraceHealthCounters()).toMatchObject({
+      writeSuccesses: 1,
+      writeFailures: 1,
+      writeTimeouts: 1,
+      rawCaptureDisabled: 1,
+    })
+    expect(getSearchTraceHealthCounters().lastWriteSuccessAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T/,
+    )
+  })
+})

--- a/apps/admin/src/services/search-trace-health.ts
+++ b/apps/admin/src/services/search-trace-health.ts
@@ -1,0 +1,60 @@
+export type SearchTraceHealthCounters = {
+  writeSuccesses: number
+  writeFailures: number
+  writeTimeouts: number
+  rawCaptureDisabled: number
+  lastWriteSuccessAt: string | null
+  lastWriteFailureAt: string | null
+  lastWriteTimeoutAt: string | null
+  lastRawCaptureDisabledAt: string | null
+}
+
+const counters: SearchTraceHealthCounters = {
+  writeSuccesses: 0,
+  writeFailures: 0,
+  writeTimeouts: 0,
+  rawCaptureDisabled: 0,
+  lastWriteSuccessAt: null,
+  lastWriteFailureAt: null,
+  lastWriteTimeoutAt: null,
+  lastRawCaptureDisabledAt: null,
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+export function recordSearchTraceWriteSuccess(): void {
+  counters.writeSuccesses += 1
+  counters.lastWriteSuccessAt = nowIso()
+}
+
+export function recordSearchTraceWriteFailure(): void {
+  counters.writeFailures += 1
+  counters.lastWriteFailureAt = nowIso()
+}
+
+export function recordSearchTraceWriteTimeout(): void {
+  counters.writeTimeouts += 1
+  counters.lastWriteTimeoutAt = nowIso()
+}
+
+export function recordSearchTraceRawCaptureDisabled(): void {
+  counters.rawCaptureDisabled += 1
+  counters.lastRawCaptureDisabledAt = nowIso()
+}
+
+export function getSearchTraceHealthCounters(): SearchTraceHealthCounters {
+  return { ...counters }
+}
+
+export function __resetSearchTraceHealthForTest(): void {
+  counters.writeSuccesses = 0
+  counters.writeFailures = 0
+  counters.writeTimeouts = 0
+  counters.rawCaptureDisabled = 0
+  counters.lastWriteSuccessAt = null
+  counters.lastWriteFailureAt = null
+  counters.lastWriteTimeoutAt = null
+  counters.lastRawCaptureDisabledAt = null
+}

--- a/apps/admin/src/services/search-trace-privacy.test.ts
+++ b/apps/admin/src/services/search-trace-privacy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { classifySearchTraceQuery } from "./search-trace-privacy"
+
+describe("classifySearchTraceQuery", () => {
+  it("keeps normal production queries sample-eligible", () => {
+    expect(classifySearchTraceQuery("Jesus film for kids")).toEqual({
+      queryText: "Jesus film for kids",
+      queryQualityLabel: "normal",
+      sensitiveQueryLabel: "none",
+      abuseLabel: "none",
+      sampleEligible: true,
+    })
+  })
+
+  it("redacts obvious email, phone, credential, and token values", () => {
+    const result = classifySearchTraceQuery(
+      "email me at viewer@example.com phone +1 (555) 123-4567 api_key abc123 bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.signature123 abcdef1234567890abcdef1234567890",
+    )
+
+    expect(result.sampleEligible).toBe(false)
+    expect(result.sensitiveQueryLabel).toBe("mixed")
+    expect(result.queryText).toContain("[redacted-email]")
+    expect(result.queryText).toContain("[redacted-phone]")
+    expect(result.queryText).toContain("[redacted-credential]")
+    expect(result.queryText).toContain("[redacted-token]")
+    expect(result.queryText).not.toContain("viewer@example.com")
+    expect(result.queryText).not.toContain("abc123")
+    expect(result.queryText).not.toContain("eyJhbGci")
+    expect(result.queryText).not.toContain("abcdef1234567890abcdef1234567890")
+  })
+
+  it("redacts cookie, IP address, and user identifier shaped values", () => {
+    const result = classifySearchTraceQuery(
+      "Cookie: sessionid=abcdef123456; cf_clearance=secret ip 203.0.113.10 user_id usr_123456789",
+    )
+
+    expect(result.sampleEligible).toBe(false)
+    expect(result.sensitiveQueryLabel).toBe("mixed")
+    expect(result.queryText).toContain("[redacted-cookie]")
+    expect(result.queryText).toContain("[redacted-ip]")
+    expect(result.queryText).toContain("[redacted-user-id]")
+    expect(result.queryText).not.toContain("sessionid=abcdef123456")
+    expect(result.queryText).not.toContain("203.0.113.10")
+    expect(result.queryText).not.toContain("usr_123456789")
+  })
+
+  it("marks injection-like queries as non-sampleable abuse", () => {
+    const result = classifySearchTraceQuery("<script>alert(1)</script>")
+
+    expect(result.abuseLabel).toBe("injection_probe")
+    expect(result.sampleEligible).toBe(false)
+    expect(result.queryText).toContain("[redacted-abuse]")
+  })
+
+  it("normalizes whitespace and caps retained query text length", () => {
+    const result = classifySearchTraceQuery(`  ${"a".repeat(1200)}  `)
+
+    expect(result.queryQualityLabel).toBe("long")
+    expect(result.queryText).toHaveLength(1024)
+  })
+})

--- a/apps/admin/src/services/search-trace-privacy.ts
+++ b/apps/admin/src/services/search-trace-privacy.ts
@@ -1,0 +1,138 @@
+export type SearchTracePrivacyResult = {
+  queryText: string
+  queryQualityLabel: "empty" | "short" | "normal" | "long"
+  sensitiveQueryLabel: SearchTraceSensitiveQueryLabel
+  abuseLabel: "none" | "injection_probe" | "spam"
+  sampleEligible: boolean
+}
+
+type SearchTraceSensitiveQueryLabel =
+  | "none"
+  | "email"
+  | "phone"
+  | "credential"
+  | "token"
+  | "cookie"
+  | "ip"
+  | "user_identifier"
+  | "mixed"
+
+type ConcreteSensitiveQueryLabel = Exclude<
+  SearchTraceSensitiveQueryLabel,
+  "none" | "mixed"
+>
+
+const MAX_QUERY_TEXT_LENGTH = 1024
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+const PHONE_RE = /\+?\d[\d\s().-]{7,}\d/g
+const CREDENTIAL_RE =
+  /\b(?:password|passwd|pwd|api[_-]?key|secret|access[_-]?token|refresh[_-]?token|token|bearer)\s*(?::|=|\s+)\S+/gi
+const BEARER_TOKEN_RE = /\bbearer\s+[A-Za-z0-9._~+/=-]{10,}\b/gi
+const JWT_RE = /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g
+const TOKEN_RE =
+  /\b(?=[A-Za-z0-9_-]{32,}\b)(?=[A-Za-z0-9_-]*[A-Za-z])(?=[A-Za-z0-9_-]*\d)[A-Za-z0-9_-]+\b/g
+const COOKIE_RE =
+  /\b(?:cookie|set-cookie)\s*[:=]\s*[^;\s=]+=[^;\s]+(?:\s*;\s*[^;\s=]+=[^;\s]+){0,8}|\b(?:session(?:id)?|session_id|sid|cf_clearance|jwt|authorization|auth(?:entication)?|access[_-]?token|refresh[_-]?token)\s*=\s*[^;\s]{6,}/gi
+const IPV4_RE =
+  /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g
+const USER_IDENTIFIER_RE =
+  /\b(?:user[_-]?id|userid|uid|account[_-]?id|subject|sub)\s*(?::|=|\s+)[A-Za-z0-9][A-Za-z0-9._-]{5,}\b/gi
+const INJECTION_RE = /(?:<\s*script\b|drop\s+table|union\s+select)/gi
+const SPAM_RE = /\b(?:spam|scam)\b(?:\W+\b(?:spam|scam)\b){2,}/gi
+
+function normalizeQueryText(query: string): string {
+  return query.replace(/\s+/g, " ").trim()
+}
+
+function classifyQuality(
+  query: string,
+): SearchTracePrivacyResult["queryQualityLabel"] {
+  if (query.length === 0) return "empty"
+  if (query.length < 3) return "short"
+  if (query.length > 160) return "long"
+  return "normal"
+}
+
+function uniqueLabels<T extends string>(labels: T[]): T[] {
+  return Array.from(new Set(labels))
+}
+
+function hasMatch(pattern: RegExp, value: string): boolean {
+  pattern.lastIndex = 0
+  const matched = pattern.test(value)
+  pattern.lastIndex = 0
+  return matched
+}
+
+function sensitiveLabel(
+  labels: ConcreteSensitiveQueryLabel[],
+): SearchTraceSensitiveQueryLabel {
+  const unique = uniqueLabels(labels)
+  if (unique.length === 0) return "none"
+  if (unique.length === 1) return unique[0]
+  return "mixed"
+}
+
+function truncateQueryText(query: string): string {
+  if (query.length <= MAX_QUERY_TEXT_LENGTH) return query
+  return query.slice(0, MAX_QUERY_TEXT_LENGTH)
+}
+
+export function classifySearchTraceQuery(
+  query: string,
+): SearchTracePrivacyResult {
+  const normalized = normalizeQueryText(query)
+  const sensitiveLabels: ConcreteSensitiveQueryLabel[] = []
+  let redacted = normalized
+
+  if (hasMatch(EMAIL_RE, redacted)) sensitiveLabels.push("email")
+  redacted = redacted.replace(EMAIL_RE, "[redacted-email]")
+
+  if (hasMatch(BEARER_TOKEN_RE, redacted)) sensitiveLabels.push("token")
+  redacted = redacted.replace(BEARER_TOKEN_RE, "[redacted-token]")
+
+  if (hasMatch(JWT_RE, redacted)) sensitiveLabels.push("token")
+  redacted = redacted.replace(JWT_RE, "[redacted-token]")
+
+  if (hasMatch(CREDENTIAL_RE, redacted)) sensitiveLabels.push("credential")
+  redacted = redacted.replace(CREDENTIAL_RE, "[redacted-credential]")
+
+  if (hasMatch(COOKIE_RE, redacted)) sensitiveLabels.push("cookie")
+  redacted = redacted.replace(COOKIE_RE, "[redacted-cookie]")
+
+  if (hasMatch(USER_IDENTIFIER_RE, redacted)) {
+    sensitiveLabels.push("user_identifier")
+  }
+  redacted = redacted.replace(USER_IDENTIFIER_RE, "[redacted-user-id]")
+
+  if (hasMatch(TOKEN_RE, redacted)) sensitiveLabels.push("token")
+  redacted = redacted.replace(TOKEN_RE, "[redacted-token]")
+
+  if (hasMatch(IPV4_RE, redacted)) sensitiveLabels.push("ip")
+  redacted = redacted.replace(IPV4_RE, "[redacted-ip]")
+
+  if (hasMatch(PHONE_RE, redacted)) sensitiveLabels.push("phone")
+  redacted = redacted.replace(PHONE_RE, "[redacted-phone]")
+
+  let abuseLabel: SearchTracePrivacyResult["abuseLabel"] = "none"
+  if (hasMatch(INJECTION_RE, redacted)) {
+    abuseLabel = "injection_probe"
+    redacted = redacted.replace(INJECTION_RE, "[redacted-abuse]")
+  } else if (hasMatch(SPAM_RE, redacted)) {
+    abuseLabel = "spam"
+  }
+
+  const sensitiveQueryLabel = sensitiveLabel(sensitiveLabels)
+  const sampleEligible =
+    sensitiveQueryLabel === "none" &&
+    abuseLabel === "none" &&
+    normalized.length > 0
+
+  return {
+    queryText: truncateQueryText(redacted),
+    queryQualityLabel: classifyQuality(normalized),
+    sensitiveQueryLabel,
+    abuseLabel,
+    sampleEligible,
+  }
+}

--- a/apps/admin/src/services/search-trace-retention.service.test.ts
+++ b/apps/admin/src/services/search-trace-retention.service.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/config/env", () => ({
+  env: {
+    NODE_ENV: "test",
+  },
+}))
+
+const { env } = await import("@/config/env")
+const {
+  SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS,
+  isSearchTraceRetentionSchedulerFresh,
+  purgeExpiredSearchTraces,
+  readSearchTraceRetentionHealth,
+} = await import("./search-trace-retention.service")
+
+const envMutable = env as { NODE_ENV?: "development" | "test" | "production" }
+
+function buildPrisma() {
+  return {
+    searchTrace: {
+      deleteMany: vi.fn(async () => ({ count: 0 })),
+    },
+    workflowRun: {
+      findFirst: vi.fn(),
+    },
+  }
+}
+
+describe("search trace retention service", () => {
+  afterEach(() => {
+    envMutable.NODE_ENV = "test"
+  })
+
+  it("purges only rows whose raw expiration has passed", async () => {
+    const prisma = buildPrisma()
+    prisma.searchTrace.deleteMany.mockResolvedValueOnce({ count: 3 })
+    const now = new Date("2026-05-30T00:00:00.000Z")
+
+    await expect(
+      purgeExpiredSearchTraces(
+        prisma as unknown as Parameters<typeof purgeExpiredSearchTraces>[0],
+        now,
+      ),
+    ).resolves.toEqual({
+      purgedCount: 3,
+      purgedBefore: "2026-05-30T00:00:00.000Z",
+    })
+    expect(prisma.searchTrace.deleteMany).toHaveBeenCalledWith({
+      where: {
+        rawExpiresAt: {
+          lte: now,
+        },
+      },
+    })
+  })
+
+  it("treats non-production retention as healthy for local/test capture", async () => {
+    envMutable.NODE_ENV = "test"
+    const prisma = buildPrisma()
+
+    await expect(
+      readSearchTraceRetentionHealth(
+        prisma as unknown as Parameters<
+          typeof readSearchTraceRetentionHealth
+        >[0],
+      ),
+    ).resolves.toMatchObject({
+      healthy: true,
+      reason: "not-production",
+    })
+    expect(prisma.workflowRun.findFirst).not.toHaveBeenCalled()
+  })
+
+  it("treats an active scheduler ledger as healthy in production", async () => {
+    envMutable.NODE_ENV = "production"
+    const prisma = buildPrisma()
+    const now = new Date("2026-05-30T00:00:00.000Z")
+    prisma.workflowRun.findFirst.mockResolvedValueOnce({
+      id: "scheduler-ledger-1",
+      updatedAt: new Date(
+        now.getTime() - SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS + 1,
+      ),
+    })
+
+    await expect(
+      readSearchTraceRetentionHealth(
+        prisma as unknown as Parameters<
+          typeof readSearchTraceRetentionHealth
+        >[0],
+        now,
+      ),
+    ).resolves.toEqual({
+      healthy: true,
+      reason: "scheduler-active",
+      latestPurgeAt: null,
+      activeSchedulerRunId: "scheduler-ledger-1",
+    })
+  })
+
+  it("does not treat a stale active scheduler ledger as healthy", async () => {
+    envMutable.NODE_ENV = "production"
+    const prisma = buildPrisma()
+    const now = new Date("2026-05-30T00:00:00.000Z")
+    prisma.workflowRun.findFirst
+      .mockResolvedValueOnce({
+        id: "scheduler-ledger-1",
+        updatedAt: new Date(
+          now.getTime() - SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS - 1,
+        ),
+      })
+      .mockResolvedValueOnce(null)
+
+    await expect(
+      readSearchTraceRetentionHealth(
+        prisma as unknown as Parameters<
+          typeof readSearchTraceRetentionHealth
+        >[0],
+        now,
+      ),
+    ).resolves.toMatchObject({
+      healthy: false,
+      reason: "missing",
+      activeSchedulerRunId: null,
+    })
+  })
+
+  it("falls back to a recent purge heartbeat in production", async () => {
+    envMutable.NODE_ENV = "production"
+    const prisma = buildPrisma()
+    const now = new Date("2026-05-30T00:00:00.000Z")
+    const recent = new Date(
+      now.getTime() - SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS + 1,
+    )
+    prisma.workflowRun.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        finishedAt: recent,
+        updatedAt: recent,
+      })
+
+    await expect(
+      readSearchTraceRetentionHealth(
+        prisma as unknown as Parameters<
+          typeof readSearchTraceRetentionHealth
+        >[0],
+        now,
+      ),
+    ).resolves.toEqual({
+      healthy: true,
+      reason: "recent-purge",
+      latestPurgeAt: recent.toISOString(),
+      activeSchedulerRunId: null,
+    })
+  })
+
+  it("reports missing retention health when scheduler and purge heartbeat are absent", async () => {
+    envMutable.NODE_ENV = "production"
+    const prisma = buildPrisma()
+    prisma.workflowRun.findFirst.mockResolvedValue(null)
+
+    await expect(
+      readSearchTraceRetentionHealth(
+        prisma as unknown as Parameters<
+          typeof readSearchTraceRetentionHealth
+        >[0],
+        new Date("2026-05-30T00:00:00.000Z"),
+      ),
+    ).resolves.toEqual({
+      healthy: false,
+      reason: "missing",
+      latestPurgeAt: null,
+      activeSchedulerRunId: null,
+    })
+  })
+
+  it("classifies scheduler freshness by updatedAt/createdAt within the health window", () => {
+    const now = new Date("2026-05-30T00:00:00.000Z")
+    expect(
+      isSearchTraceRetentionSchedulerFresh(
+        {
+          updatedAt: new Date(
+            now.getTime() - SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS + 1,
+          ),
+        },
+        now,
+      ),
+    ).toBe(true)
+    expect(
+      isSearchTraceRetentionSchedulerFresh(
+        {
+          createdAt: new Date(
+            now.getTime() - SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS - 1,
+          ),
+        },
+        now,
+      ),
+    ).toBe(false)
+  })
+})

--- a/apps/admin/src/services/search-trace-retention.service.ts
+++ b/apps/admin/src/services/search-trace-retention.service.ts
@@ -1,0 +1,117 @@
+import { WorkflowRunStatus, type PrismaClient } from "@prisma/client"
+import { env } from "@/config/env"
+
+export const SEARCH_TRACE_RETENTION_WORKFLOW_KEY = "search-trace-retention"
+export const SEARCH_TRACE_RETENTION_SCHEDULER_WORKFLOW_KEY =
+  "search-trace-retention-scheduler"
+export const SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS = 36 * 60 * 60 * 1000
+
+export type SearchTracePurgeResult = {
+  purgedCount: number
+  purgedBefore: string
+}
+
+export type SearchTraceRetentionHealth = {
+  healthy: boolean
+  reason: "not-production" | "scheduler-active" | "recent-purge" | "missing"
+  latestPurgeAt: string | null
+  activeSchedulerRunId: string | null
+}
+
+function toIsoOrNull(value: Date | null | undefined): string | null {
+  return value == null ? null : value.toISOString()
+}
+
+export function isSearchTraceRetentionSchedulerFresh(
+  scheduler: { updatedAt?: Date | null; createdAt?: Date | null },
+  now: Date = new Date(),
+): boolean {
+  const heartbeatAt = scheduler.updatedAt ?? scheduler.createdAt ?? null
+  if (heartbeatAt == null) return false
+  const ageMs = now.getTime() - heartbeatAt.getTime()
+  return ageMs >= 0 && ageMs <= SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS
+}
+
+export async function purgeExpiredSearchTraces(
+  prisma: PrismaClient,
+  now: Date = new Date(),
+): Promise<SearchTracePurgeResult> {
+  const result = await prisma.searchTrace.deleteMany({
+    where: {
+      rawExpiresAt: {
+        lte: now,
+      },
+    },
+  })
+
+  return {
+    purgedCount: result.count,
+    purgedBefore: now.toISOString(),
+  }
+}
+
+export async function readSearchTraceRetentionHealth(
+  prisma: PrismaClient,
+  now: Date = new Date(),
+): Promise<SearchTraceRetentionHealth> {
+  if (env.NODE_ENV !== "production") {
+    return {
+      healthy: true,
+      reason: "not-production",
+      latestPurgeAt: null,
+      activeSchedulerRunId: null,
+    }
+  }
+
+  const activeScheduler = await prisma.workflowRun.findFirst({
+    where: {
+      workflowKey: SEARCH_TRACE_RETENTION_SCHEDULER_WORKFLOW_KEY,
+      status: {
+        in: [WorkflowRunStatus.QUEUED, WorkflowRunStatus.RUNNING],
+      },
+    },
+    orderBy: { updatedAt: "desc" },
+  })
+
+  if (
+    activeScheduler &&
+    isSearchTraceRetentionSchedulerFresh(activeScheduler, now)
+  ) {
+    return {
+      healthy: true,
+      reason: "scheduler-active",
+      latestPurgeAt: null,
+      activeSchedulerRunId: activeScheduler.id,
+    }
+  }
+
+  const latestPurge = await prisma.workflowRun.findFirst({
+    where: {
+      workflowKey: SEARCH_TRACE_RETENTION_WORKFLOW_KEY,
+      status: WorkflowRunStatus.SUCCEEDED,
+    },
+    orderBy: { finishedAt: "desc" },
+  })
+  const latestPurgeAt =
+    latestPurge?.finishedAt ?? latestPurge?.updatedAt ?? null
+  const latestPurgeAgeMs =
+    latestPurgeAt == null
+      ? Number.POSITIVE_INFINITY
+      : now.getTime() - latestPurgeAt.getTime()
+
+  if (latestPurgeAgeMs <= SEARCH_TRACE_RETENTION_HEALTH_WINDOW_MS) {
+    return {
+      healthy: true,
+      reason: "recent-purge",
+      latestPurgeAt: toIsoOrNull(latestPurgeAt),
+      activeSchedulerRunId: null,
+    }
+  }
+
+  return {
+    healthy: false,
+    reason: "missing",
+    latestPurgeAt: toIsoOrNull(latestPurgeAt),
+    activeSchedulerRunId: null,
+  }
+}

--- a/apps/admin/src/services/search-trace-retention/job.test.ts
+++ b/apps/admin/src/services/search-trace-retention/job.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { wrapStartSpy } from "@/test-helpers/workflow-dispatch"
+
+const start = vi.hoisted(() => vi.fn())
+const workflowRun = vi.hoisted(() => ({
+  create: vi.fn(async (args) => ({ id: "ledger-run-1", ...args.data })),
+  findFirst: vi.fn(),
+  update: vi.fn(async (args) => args),
+}))
+const queryRaw = vi.hoisted(() => vi.fn())
+const purgeExpiredSearchTraces = vi.hoisted(() => vi.fn())
+
+vi.mock("workflow/api", () => ({ start }))
+vi.mock("@/db/client", () => ({ prisma: { $queryRaw: queryRaw, workflowRun } }))
+vi.mock("@/services/search-trace-retention.service", async (original) => {
+  const actual =
+    await original<typeof import("@/services/search-trace-retention.service")>()
+  return {
+    ...actual,
+    purgeExpiredSearchTraces,
+  }
+})
+
+describe("search trace retention workflow job", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryRaw.mockResolvedValue([{ locked: true }])
+    workflowRun.findFirst.mockResolvedValue(null)
+    purgeExpiredSearchTraces.mockResolvedValue({
+      purgedCount: 0,
+      purgedBefore: "2026-05-30T00:00:00.000Z",
+    })
+  })
+
+  it("calculates the next daily UTC purge time", async () => {
+    const { nextSearchTraceRetentionRunAt } = await import("./job")
+
+    expect(
+      nextSearchTraceRetentionRunAt(new Date("2026-05-14T09:59:00.000Z")),
+    ).toEqual(new Date("2026-05-14T10:00:00.000Z"))
+    expect(
+      nextSearchTraceRetentionRunAt(new Date("2026-05-14T10:00:00.000Z")),
+    ).toEqual(new Date("2026-05-15T10:00:00.000Z"))
+  })
+
+  it("keeps a just-after-purge trace under 30 days with 29-day expiry plus daily purge", async () => {
+    const { nextSearchTraceRetentionRunAt } = await import("./job")
+    const createdAt = new Date("2026-05-01T10:01:00.000Z")
+    const rawExpiresAt = new Date(
+      createdAt.getTime() + 29 * 24 * 60 * 60 * 1000,
+    )
+    const purgeAt = nextSearchTraceRetentionRunAt(rawExpiresAt)
+    const ageAtPurge = purgeAt.getTime() - createdAt.getTime()
+
+    expect(ageAtPurge).toBeLessThan(30 * 24 * 60 * 60 * 1000)
+  })
+
+  it("starts one durable scheduler workflow when none is running", async () => {
+    start.mockResolvedValueOnce({
+      runId: "scheduler-runtime-run-1",
+      returnValue: Promise.resolve(undefined),
+    })
+    const { ensureSearchTraceRetentionSchedulerStarted } = await import("./job")
+    const { runSearchTraceRetentionScheduler } =
+      await import("@/workflows/searchTraceRetention")
+
+    await expect(ensureSearchTraceRetentionSchedulerStarted()).resolves.toEqual(
+      {
+        started: true,
+        runId: "scheduler-runtime-run-1",
+        ledgerRunId: "ledger-run-1",
+      },
+    )
+    expect(workflowRun.findFirst).toHaveBeenCalledWith({
+      where: {
+        workflowKey: "search-trace-retention-scheduler",
+        status: { in: ["QUEUED", "RUNNING"] },
+      },
+      orderBy: { createdAt: "desc" },
+    })
+    expect(start).toHaveBeenCalledWith(runSearchTraceRetentionScheduler, [
+      { ledgerRunId: "ledger-run-1" },
+    ])
+  })
+
+  it("does not start a duplicate scheduler when one is already active", async () => {
+    workflowRun.findFirst.mockResolvedValueOnce({
+      id: "existing-ledger-run",
+      runtimeRunId: "existing-runtime-run",
+      updatedAt: new Date(),
+    })
+    const { ensureSearchTraceRetentionSchedulerStarted } = await import("./job")
+
+    await expect(ensureSearchTraceRetentionSchedulerStarted()).resolves.toEqual(
+      {
+        started: false,
+        reason: "already-running",
+        ledgerRunId: "existing-ledger-run",
+        runtimeRunId: "existing-runtime-run",
+      },
+    )
+    expect(start).not.toHaveBeenCalled()
+  })
+
+  it("marks a stale active scheduler failed and starts a replacement", async () => {
+    start.mockResolvedValueOnce({
+      runId: "scheduler-runtime-run-2",
+      returnValue: Promise.resolve(undefined),
+    })
+    workflowRun.findFirst.mockResolvedValueOnce({
+      id: "stale-ledger-run",
+      runtimeRunId: "stale-runtime-run",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    })
+    const { ensureSearchTraceRetentionSchedulerStarted } = await import("./job")
+
+    await expect(ensureSearchTraceRetentionSchedulerStarted()).resolves.toEqual(
+      {
+        started: true,
+        runId: "scheduler-runtime-run-2",
+        ledgerRunId: "ledger-run-1",
+      },
+    )
+    expect(workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "stale-ledger-run" },
+      data: expect.objectContaining({
+        status: "FAILED",
+        summary:
+          "Search trace retention scheduler stale; starting a replacement.",
+        error: "scheduler_stale",
+        finishedAt: expect.any(Date),
+      }),
+    })
+    expect(start).toHaveBeenCalledOnce()
+  })
+
+  it("dispatches the purge workflow through useworkflow", async () => {
+    const dispatch = wrapStartSpy(start)
+    start.mockResolvedValueOnce({
+      runId: "runtime-run-1",
+      returnValue: Promise.resolve(undefined),
+    })
+    const { dispatchSearchTraceRetention } = await import("./job")
+    const { runSearchTraceRetention } =
+      await import("@/workflows/searchTraceRetention")
+
+    await expect(
+      dispatchSearchTraceRetention({ trigger: "scheduled" }),
+    ).resolves.toEqual({
+      workflow: "search-trace-retention",
+      runId: "runtime-run-1",
+      trigger: "scheduled",
+      status: "queued",
+    })
+    dispatch.expectDispatched(runSearchTraceRetention, [
+      { trigger: "scheduled", ledgerRunId: "ledger-run-1" },
+    ])
+    expect(workflowRun.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workflowKey: "search-trace-retention",
+        workflowName: "Search Trace Retention",
+        trigger: "SCHEDULED",
+        subjectType: "search-trace",
+        subjectId: "raw",
+      }),
+    })
+  })
+
+  it("marks the ledger succeeded after purge completes with counts only", async () => {
+    purgeExpiredSearchTraces.mockResolvedValueOnce({
+      purgedCount: 12,
+      purgedBefore: "2026-05-30T00:00:00.000Z",
+    })
+    const { runSearchTraceRetentionJob } = await import("./job")
+
+    await runSearchTraceRetentionJob({
+      trigger: "scheduled",
+      ledgerRunId: "ledger-run-1",
+    })
+
+    expect(workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "ledger-run-1" },
+      data: expect.objectContaining({
+        status: "RUNNING",
+        startedAt: expect.any(Date),
+      }),
+    })
+    expect(workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "ledger-run-1" },
+      data: expect.objectContaining({
+        status: "SUCCEEDED",
+        summary: "Purged 12 expired raw search trace(s).",
+        finishedAt: expect.any(Date),
+        durationMs: expect.any(Number),
+        details: {
+          purgedCount: 12,
+          purgedBefore: "2026-05-30T00:00:00.000Z",
+        },
+      }),
+    })
+    expect(JSON.stringify(workflowRun.update.mock.calls)).not.toMatch(
+      /queryText|query_text|Jesus film/i,
+    )
+  })
+
+  it("marks the ledger failed when purge throws", async () => {
+    purgeExpiredSearchTraces.mockRejectedValueOnce(new Error("db unavailable"))
+    const { runSearchTraceRetentionJob } = await import("./job")
+
+    await expect(
+      runSearchTraceRetentionJob({
+        trigger: "scheduled",
+        ledgerRunId: "ledger-run-1",
+      }),
+    ).rejects.toThrow("db unavailable")
+    expect(workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "ledger-run-1" },
+      data: expect.objectContaining({
+        status: "FAILED",
+        error: "db unavailable",
+      }),
+    })
+  })
+})

--- a/apps/admin/src/services/search-trace-retention/job.ts
+++ b/apps/admin/src/services/search-trace-retention/job.ts
@@ -1,0 +1,279 @@
+import { Prisma, WorkflowRunStatus } from "@prisma/client"
+import { start } from "workflow/api"
+import { prisma } from "@/db/client"
+import {
+  attachWorkflowRuntimeRunId,
+  createWorkflowRunLog,
+  markWorkflowRunFailed,
+  markWorkflowRunStarted,
+} from "@/services/workflow-run-log.service"
+import {
+  isSearchTraceRetentionSchedulerFresh,
+  purgeExpiredSearchTraces,
+} from "@/services/search-trace-retention.service"
+import {
+  runSearchTraceRetention,
+  runSearchTraceRetentionScheduler,
+} from "@/workflows/searchTraceRetention"
+
+export type SearchTraceRetentionTrigger = "scheduled"
+export type SearchTraceRetentionSchedulerInput = {
+  ledgerRunId?: string
+}
+
+export type SearchTraceRetentionWorkflowInput = {
+  trigger?: SearchTraceRetentionTrigger
+  ledgerRunId?: string
+}
+
+export type SearchTraceRetentionJobResult = {
+  purgedCount: number
+  purgedBefore: string
+}
+
+export type SearchTraceRetentionDispatchResult = {
+  workflow: "search-trace-retention"
+  runId: string
+  trigger: SearchTraceRetentionTrigger
+  status: "queued"
+}
+
+export type SearchTraceRetentionSchedulerStartResult =
+  | {
+      started: true
+      runId: string
+      ledgerRunId: string
+    }
+  | {
+      started: false
+      reason: "already-running" | "lock-not-acquired"
+      ledgerRunId?: string
+      runtimeRunId?: string | null
+    }
+
+const SCHEDULER_WORKFLOW_KEY = "search-trace-retention-scheduler"
+const SCHEDULER_LOCK_ID = 136_000_021
+const PURGE_HOUR_UTC = 10
+
+export function nextSearchTraceRetentionRunAt(
+  now: Date = new Date(),
+  hourUtc = PURGE_HOUR_UTC,
+): Date {
+  const next = new Date(now)
+  next.setUTCHours(hourUtc, 0, 0, 0)
+  if (next <= now) {
+    next.setUTCDate(next.getUTCDate() + 1)
+  }
+  return next
+}
+
+export async function dispatchSearchTraceRetention(
+  input: SearchTraceRetentionWorkflowInput = {},
+): Promise<SearchTraceRetentionDispatchResult> {
+  const trigger = input.trigger ?? "scheduled"
+  const ledgerRun = await createWorkflowRunLog({
+    workflowKey: "search-trace-retention",
+    workflowName: "Search Trace Retention",
+    trigger,
+    subjectType: "search-trace",
+    subjectId: "raw",
+    summary: "Search trace retention workflow queued.",
+    details: {
+      retention: "raw-search-traces",
+    },
+  })
+
+  try {
+    const run = await start(runSearchTraceRetention, [
+      { trigger, ledgerRunId: ledgerRun.id },
+    ])
+    await attachWorkflowRuntimeRunId(ledgerRun.id, run.runId)
+
+    return {
+      workflow: "search-trace-retention",
+      runId: run.runId,
+      trigger,
+      status: "queued",
+    }
+  } catch (error) {
+    await markWorkflowRunFailed(ledgerRun.id, error).catch(() => {})
+    throw error
+  }
+}
+
+export async function runSearchTraceRetentionJob(
+  input: SearchTraceRetentionWorkflowInput = {},
+): Promise<SearchTraceRetentionJobResult> {
+  const startedAt = Date.now()
+  if (input.ledgerRunId) {
+    await markWorkflowRunStarted(input.ledgerRunId)
+  }
+
+  try {
+    const result = await purgeExpiredSearchTraces(prisma)
+
+    if (input.ledgerRunId) {
+      await prisma.workflowRun.update({
+        where: { id: input.ledgerRunId },
+        data: {
+          status: WorkflowRunStatus.SUCCEEDED,
+          summary: `Purged ${result.purgedCount} expired raw search trace(s).`,
+          finishedAt: new Date(),
+          durationMs: Date.now() - startedAt,
+          details: {
+            purgedCount: result.purgedCount,
+            purgedBefore: result.purgedBefore,
+          } satisfies Prisma.InputJsonValue,
+        },
+      })
+    }
+
+    return result
+  } catch (error) {
+    if (input.ledgerRunId) {
+      await markWorkflowRunFailed(input.ledgerRunId, error).catch(() => {})
+    }
+    throw error
+  }
+}
+
+export async function runSearchTraceRetentionFromScheduler(): Promise<{
+  ok: boolean
+  ledgerRunId: string
+  result?: SearchTraceRetentionJobResult
+  error?: string
+}> {
+  const ledgerRun = await createWorkflowRunLog({
+    workflowKey: "search-trace-retention",
+    workflowName: "Search Trace Retention",
+    trigger: "scheduled",
+    subjectType: "search-trace",
+    subjectId: "raw",
+    summary: "Search trace retention workflow started by scheduler.",
+    details: {
+      retention: "raw-search-traces",
+    },
+  })
+
+  try {
+    const result = await runSearchTraceRetentionJob({
+      trigger: "scheduled",
+      ledgerRunId: ledgerRun.id,
+    })
+    return { ok: true, ledgerRunId: ledgerRun.id, result }
+  } catch (error) {
+    return {
+      ok: false,
+      ledgerRunId: ledgerRun.id,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export async function markSearchTraceRetentionSchedulerStarted(
+  input: SearchTraceRetentionSchedulerInput = {},
+): Promise<void> {
+  if (!input.ledgerRunId) return
+  await markWorkflowRunStarted(input.ledgerRunId)
+}
+
+export async function recordSearchTraceRetentionSchedulerHeartbeat(
+  input: SearchTraceRetentionSchedulerInput,
+  nextRunAt: Date,
+): Promise<void> {
+  if (!input.ledgerRunId) return
+  await prisma.workflowRun.update({
+    where: { id: input.ledgerRunId },
+    data: {
+      summary: `Search trace retention scheduler sleeping until ${nextRunAt.toISOString()}.`,
+      details: {
+        nextRunAt: nextRunAt.toISOString(),
+        schedule: `daily ${String(PURGE_HOUR_UTC).padStart(2, "0")}:00 UTC`,
+      } satisfies Prisma.InputJsonValue,
+    },
+  })
+}
+
+async function withSchedulerStartLock<T>(
+  callback: () => Promise<T>,
+): Promise<T> {
+  const rows = await prisma.$queryRaw<{ locked: boolean }[]>`
+    SELECT pg_try_advisory_lock(${SCHEDULER_LOCK_ID}) AS locked
+  `
+  if (!rows[0]?.locked) {
+    return {
+      started: false,
+      reason: "lock-not-acquired",
+    } as T
+  }
+
+  try {
+    return await callback()
+  } finally {
+    await prisma.$queryRaw`
+      SELECT pg_advisory_unlock(${SCHEDULER_LOCK_ID})
+    `
+  }
+}
+
+export async function ensureSearchTraceRetentionSchedulerStarted(): Promise<SearchTraceRetentionSchedulerStartResult> {
+  return withSchedulerStartLock(async () => {
+    const existing = await prisma.workflowRun.findFirst({
+      where: {
+        workflowKey: SCHEDULER_WORKFLOW_KEY,
+        status: {
+          in: [WorkflowRunStatus.QUEUED, WorkflowRunStatus.RUNNING],
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    })
+
+    if (existing && isSearchTraceRetentionSchedulerFresh(existing)) {
+      return {
+        started: false,
+        reason: "already-running",
+        ledgerRunId: existing.id,
+        runtimeRunId: existing.runtimeRunId,
+      }
+    }
+    if (existing) {
+      await prisma.workflowRun.update({
+        where: { id: existing.id },
+        data: {
+          status: WorkflowRunStatus.FAILED,
+          finishedAt: new Date(),
+          summary:
+            "Search trace retention scheduler stale; starting a replacement.",
+          error: "scheduler_stale",
+        },
+      })
+    }
+
+    const ledgerRun = await createWorkflowRunLog({
+      workflowKey: SCHEDULER_WORKFLOW_KEY,
+      workflowName: "Search Trace Retention Scheduler",
+      trigger: "system",
+      subjectType: "search-trace",
+      subjectId: "raw",
+      summary: "Search trace retention scheduler queued.",
+      details: {
+        schedule: `daily ${String(PURGE_HOUR_UTC).padStart(2, "0")}:00 UTC`,
+      },
+    })
+
+    try {
+      const run = await start(runSearchTraceRetentionScheduler, [
+        { ledgerRunId: ledgerRun.id },
+      ])
+      await attachWorkflowRuntimeRunId(ledgerRun.id, run.runId)
+      return {
+        started: true,
+        runId: run.runId,
+        ledgerRunId: ledgerRun.id,
+      }
+    } catch (error) {
+      await markWorkflowRunFailed(ledgerRun.id, error).catch(() => {})
+      throw error
+    }
+  })
+}

--- a/apps/admin/src/services/search-trace.service.test.ts
+++ b/apps/admin/src/services/search-trace.service.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const envMock = vi.hoisted(() => ({
+  env: {
+    SEARCH_TRACE_RAW_RETENTION_DAYS: 29,
+    NODE_ENV: "test" as "test" | "development" | "production" | undefined,
+  },
+}))
+
+vi.mock("@/config/env", () => envMock)
+vi.mock("@/db/client", () => ({ prisma: {} }))
+
+import {
+  __resetSearchTraceHealthForTest,
+  getSearchTraceHealthCounters,
+} from "./search-trace-health"
+import {
+  classifyLatencyBucket,
+  recordSearchTraceSafely,
+  sampleSearchTraces,
+  writeSearchTrace,
+  type RecordSearchTraceInput,
+} from "./search-trace.service"
+
+function buildPrisma() {
+  return {
+    searchTrace: {
+      create: vi.fn(async (args) => ({ id: "trace-1", ...args.data })),
+      findMany: vi.fn(async (): Promise<unknown[]> => []),
+    },
+    searchTraceAggregate: {
+      upsert: vi.fn(async (args) => ({ id: "aggregate-1", ...args.create })),
+    },
+    workflowRun: {
+      findFirst: vi.fn(),
+    },
+  }
+}
+
+const baseTraceInput: RecordSearchTraceInput = {
+  query: "Jesus film",
+  locale: "en",
+  routeSource: "rest",
+  requestedMode: "hybrid",
+  searchMode: "hybrid",
+  resultCount: 3,
+  outcome: "success",
+  traceClass: "none",
+  startedAt: new Date("2026-05-01T00:00:00.000Z"),
+  completedAt: new Date("2026-05-01T00:00:00.180Z"),
+  now: new Date("2026-05-01T00:00:00.180Z"),
+}
+
+describe("search trace service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetSearchTraceHealthForTest()
+    envMock.env.SEARCH_TRACE_RAW_RETENTION_DAYS = 29
+    envMock.env.NODE_ENV = "test"
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("classifies latency into stable buckets", () => {
+    expect(classifyLatencyBucket(99)).toBe("lt_100ms")
+    expect(classifyLatencyBucket(100)).toBe("lt_250ms")
+    expect(classifyLatencyBucket(249)).toBe("lt_250ms")
+    expect(classifyLatencyBucket(2500)).toBe("gte_2500ms")
+  })
+
+  it("stores a raw trace with 29-day expiry and a query-free aggregate", async () => {
+    const prisma = buildPrisma()
+
+    await expect(
+      writeSearchTrace(
+        baseTraceInput,
+        prisma as unknown as Parameters<typeof writeSearchTrace>[1],
+      ),
+    ).resolves.toEqual({
+      aggregateStored: true,
+      rawStored: true,
+      rawCaptureDisabled: false,
+    })
+
+    expect(prisma.searchTrace.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        queryText: "Jesus film",
+        locale: "en",
+        routeSource: "REST",
+        requestedMode: "hybrid",
+        searchMode: "hybrid",
+        resultCount: 3,
+        latencyBucket: "LT_250_MS",
+        outcome: "SUCCESS",
+        traceClass: "none",
+        queryQualityLabel: "normal",
+        sensitiveQueryLabel: "none",
+        abuseLabel: "none",
+        sampleEligible: true,
+        rawExpiresAt: new Date("2026-05-30T00:00:00.180Z"),
+      }),
+    })
+    const aggregateCreate =
+      prisma.searchTraceAggregate.upsert.mock.calls[0]?.[0]?.create
+    expect(JSON.stringify(aggregateCreate)).not.toContain("queryText")
+    expect(JSON.stringify(aggregateCreate)).not.toContain("Jesus film")
+    expect(aggregateCreate).toMatchObject({
+      queryCount: 1,
+      resultCountSum: 3,
+      routeSource: "REST",
+      outcome: "SUCCESS",
+    })
+  })
+
+  it("redacts sensitive query text and excludes it from sampling by default", async () => {
+    const prisma = buildPrisma()
+    await writeSearchTrace(
+      {
+        ...baseTraceInput,
+        query: "viewer@example.com password=super-secret",
+      },
+      prisma as unknown as Parameters<typeof writeSearchTrace>[1],
+    )
+
+    const rawData = prisma.searchTrace.create.mock.calls[0]?.[0]?.data
+    expect(rawData.queryText).toContain("[redacted-email]")
+    expect(rawData.queryText).toContain("[redacted-credential]")
+    expect(rawData.queryText).not.toContain("viewer@example.com")
+    expect(rawData.queryText).not.toContain("super-secret")
+    expect(rawData.sampleEligible).toBe(false)
+    expect(rawData.sensitiveQueryLabel).toBe("mixed")
+  })
+
+  it("records keyword-only degradation in raw and aggregate dimensions", async () => {
+    const prisma = buildPrisma()
+    await writeSearchTrace(
+      {
+        ...baseTraceInput,
+        searchMode: "keyword-only",
+        outcome: "degraded",
+        traceClass: "query_embedding_failure",
+      },
+      prisma as unknown as Parameters<typeof writeSearchTrace>[1],
+    )
+
+    expect(prisma.searchTrace.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        searchMode: "keyword-only",
+        outcome: "DEGRADED",
+        traceClass: "query_embedding_failure",
+      }),
+    })
+    expect(prisma.searchTraceAggregate.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          searchMode: "keyword-only",
+          outcome: "DEGRADED",
+          traceClass: "query_embedding_failure",
+        }),
+      }),
+    )
+  })
+
+  it("does not throw or log raw query text when persistence fails", async () => {
+    const prisma = buildPrisma()
+    prisma.searchTraceAggregate.upsert.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    )
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    await expect(
+      recordSearchTraceSafely(
+        { ...baseTraceInput, query: "raw private query" },
+        prisma as unknown as Parameters<typeof recordSearchTraceSafely>[1],
+      ),
+    ).resolves.toEqual({ ok: false, timedOut: false })
+
+    expect(getSearchTraceHealthCounters().writeFailures).toBe(1)
+    expect(warn.mock.calls.flat().join(" ")).not.toContain("raw private query")
+  })
+
+  it("returns after timeout and logs no raw query text", async () => {
+    vi.useFakeTimers()
+    const prisma = buildPrisma()
+    prisma.searchTraceAggregate.upsert.mockReturnValueOnce(
+      new Promise(() => {}),
+    )
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const promise = recordSearchTraceSafely(
+      { ...baseTraceInput, query: "timeout private query", timeoutMs: 10 },
+      prisma as unknown as Parameters<typeof recordSearchTraceSafely>[1],
+    )
+    await vi.advanceTimersByTimeAsync(11)
+
+    await expect(promise).resolves.toEqual({ ok: false, timedOut: true })
+    expect(getSearchTraceHealthCounters().writeTimeouts).toBe(1)
+    expect(warn.mock.calls.flat().join(" ")).not.toContain(
+      "timeout private query",
+    )
+  })
+
+  it("keeps aggregate counters when raw capture is disabled", async () => {
+    const prisma = buildPrisma()
+    await writeSearchTrace(
+      { ...baseTraceInput, retentionHealthy: false },
+      prisma as unknown as Parameters<typeof writeSearchTrace>[1],
+    )
+
+    expect(prisma.searchTraceAggregate.upsert).toHaveBeenCalledOnce()
+    expect(prisma.searchTrace.create).not.toHaveBeenCalled()
+    expect(getSearchTraceHealthCounters().rawCaptureDisabled).toBe(1)
+  })
+
+  it("samples only unexpired, eligible rows inside the clamped window", async () => {
+    const prisma = buildPrisma()
+    prisma.searchTrace.findMany.mockResolvedValueOnce([
+      {
+        id: "trace-1",
+        queryText: "Jesus film",
+        locale: "en",
+        routeSource: "REST",
+        requestedMode: "hybrid",
+        searchMode: "hybrid",
+        resultCount: 3,
+        latencyBucket: "LT_250_MS",
+        outcome: "SUCCESS",
+        traceClass: "none",
+        queryQualityLabel: "normal",
+        sensitiveQueryLabel: "none",
+        abuseLabel: "none",
+        createdAt: new Date("2026-05-25T12:00:00.000Z"),
+      },
+    ])
+    const now = new Date("2026-05-26T12:00:00.000Z")
+
+    await expect(
+      sampleSearchTraces(
+        prisma as unknown as Parameters<typeof sampleSearchTraces>[0],
+        {
+          locale: "en",
+          routeSource: "rest",
+          searchMode: "hybrid",
+          since: new Date("2026-05-01T00:00:00.000Z"),
+          until: now,
+          limit: 500,
+        },
+        now,
+      ),
+    ).resolves.toEqual([
+      {
+        id: "trace-1",
+        queryText: "Jesus film",
+        locale: "en",
+        routeSource: "rest",
+        requestedMode: "hybrid",
+        searchMode: "hybrid",
+        resultCount: 3,
+        latencyBucket: "lt_250ms",
+        outcome: "success",
+        traceClass: "none",
+        queryQualityLabel: "normal",
+        sensitiveQueryLabel: "none",
+        abuseLabel: "none",
+        createdAt: "2026-05-25T12:00:00.000Z",
+      },
+    ])
+
+    expect(prisma.searchTrace.findMany).toHaveBeenCalledWith({
+      where: {
+        sampleEligible: true,
+        rawExpiresAt: { gt: now },
+        createdAt: {
+          gte: new Date("2026-05-25T12:00:00.000Z"),
+          lte: now,
+        },
+        locale: "en",
+        routeSource: "REST",
+        searchMode: "hybrid",
+      },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+      select: expect.any(Object),
+    })
+  })
+
+  it("schema keeps raw trace privacy fields and aggregate rows query-free", async () => {
+    const { readFile } = await import("node:fs/promises")
+    const { fileURLToPath } = await import("node:url")
+    const schemaPath = fileURLToPath(
+      new URL("../../prisma/schema.prisma", import.meta.url),
+    )
+    const schema = await readFile(schemaPath, "utf8")
+    const rawModel = schema.match(
+      /model SearchTrace \{[\s\S]*?@@map\("search_trace"\)\n\}/,
+    )?.[0]
+    const aggregateModel = schema.match(
+      /model SearchTraceAggregate \{[\s\S]*?@@map\("search_trace_aggregate"\)\n\}/,
+    )?.[0]
+
+    expect(rawModel).toContain("queryQualityLabel")
+    expect(rawModel).toContain("sensitiveQueryLabel")
+    expect(rawModel).toContain("abuseLabel")
+    expect(rawModel).toContain("sampleEligible")
+    expect(rawModel).not.toMatch(
+      /bearer|cookie|ipAddress|ip_|userId|keyId|vector|score/i,
+    )
+    expect(aggregateModel).not.toMatch(/queryText|query_text/i)
+  })
+})

--- a/apps/admin/src/services/search-trace.service.ts
+++ b/apps/admin/src/services/search-trace.service.ts
@@ -1,0 +1,439 @@
+import {
+  SearchTraceLatencyBucket as PrismaSearchTraceLatencyBucket,
+  SearchTraceOutcome as PrismaSearchTraceOutcome,
+  SearchTraceRouteSource as PrismaSearchTraceRouteSource,
+  type Prisma,
+  type PrismaClient,
+} from "@prisma/client"
+import { env } from "@/config/env"
+import { prisma as defaultPrisma } from "@/db/client"
+import {
+  getSearchTraceHealthCounters,
+  recordSearchTraceRawCaptureDisabled,
+  recordSearchTraceWriteFailure,
+  recordSearchTraceWriteSuccess,
+  recordSearchTraceWriteTimeout,
+} from "@/services/search-trace-health"
+import { classifySearchTraceQuery } from "@/services/search-trace-privacy"
+import { readSearchTraceRetentionHealth } from "@/services/search-trace-retention.service"
+
+export type SearchTraceRouteSourceLabel = "rest" | "graphql"
+export type SearchTraceOutcomeLabel = "success" | "degraded" | "failed"
+export type SearchTraceLatencyBucketLabel =
+  | "lt_100ms"
+  | "lt_250ms"
+  | "lt_500ms"
+  | "lt_1000ms"
+  | "lt_2500ms"
+  | "gte_2500ms"
+
+export type RecordSearchTraceInput = {
+  query: string
+  locale: string
+  routeSource: SearchTraceRouteSourceLabel
+  requestedMode?: string | null
+  searchMode: string
+  resultCount: number
+  outcome: SearchTraceOutcomeLabel
+  traceClass?: string | null
+  startedAt: Date
+  completedAt: Date
+  now?: Date
+  timeoutMs?: number
+  retentionHealthy?: boolean
+}
+
+export type SearchTraceWriteResult = {
+  aggregateStored: boolean
+  rawStored: boolean
+  rawCaptureDisabled: boolean
+}
+
+export type SearchTraceSafeRecordResult =
+  | (SearchTraceWriteResult & { ok: true; timedOut: false })
+  | { ok: false; timedOut: true }
+  | { ok: false; timedOut: false }
+
+export type SearchTraceSampleFilters = {
+  locale?: string
+  routeSource?: SearchTraceRouteSourceLabel
+  searchMode?: string
+  since?: Date
+  until?: Date
+  limit?: number
+}
+
+export type SearchTraceSample = {
+  id: string
+  queryText: string
+  locale: string
+  routeSource: SearchTraceRouteSourceLabel
+  requestedMode: string | null
+  searchMode: string
+  resultCount: number
+  latencyBucket: SearchTraceLatencyBucketLabel
+  outcome: SearchTraceOutcomeLabel
+  traceClass: string
+  queryQualityLabel: string
+  sensitiveQueryLabel: string
+  abuseLabel: string
+  createdAt: string
+}
+
+const TRACE_RECORD_TIMEOUT_MS = 250
+const DEFAULT_SAMPLE_LIMIT = 50
+const MAX_SAMPLE_LIMIT = 100
+const MAX_SAMPLE_WINDOW_MS = 24 * 60 * 60 * 1000
+
+export function classifyLatencyBucket(
+  latencyMs: number,
+): SearchTraceLatencyBucketLabel {
+  if (latencyMs < 100) return "lt_100ms"
+  if (latencyMs < 250) return "lt_250ms"
+  if (latencyMs < 500) return "lt_500ms"
+  if (latencyMs < 1000) return "lt_1000ms"
+  if (latencyMs < 2500) return "lt_2500ms"
+  return "gte_2500ms"
+}
+
+function toPrismaRouteSource(
+  value: SearchTraceRouteSourceLabel,
+): PrismaSearchTraceRouteSource {
+  return value === "rest"
+    ? PrismaSearchTraceRouteSource.REST
+    : PrismaSearchTraceRouteSource.GRAPHQL
+}
+
+function toPrismaOutcome(
+  value: SearchTraceOutcomeLabel,
+): PrismaSearchTraceOutcome {
+  if (value === "success") return PrismaSearchTraceOutcome.SUCCESS
+  if (value === "degraded") return PrismaSearchTraceOutcome.DEGRADED
+  return PrismaSearchTraceOutcome.FAILED
+}
+
+function toPrismaLatencyBucket(
+  value: SearchTraceLatencyBucketLabel,
+): PrismaSearchTraceLatencyBucket {
+  switch (value) {
+    case "lt_100ms":
+      return PrismaSearchTraceLatencyBucket.LT_100_MS
+    case "lt_250ms":
+      return PrismaSearchTraceLatencyBucket.LT_250_MS
+    case "lt_500ms":
+      return PrismaSearchTraceLatencyBucket.LT_500_MS
+    case "lt_1000ms":
+      return PrismaSearchTraceLatencyBucket.LT_1000_MS
+    case "lt_2500ms":
+      return PrismaSearchTraceLatencyBucket.LT_2500_MS
+    case "gte_2500ms":
+      return PrismaSearchTraceLatencyBucket.GTE_2500_MS
+  }
+}
+
+function fromRouteSource(value: string): SearchTraceRouteSourceLabel {
+  return value === "REST" || value === "rest" ? "rest" : "graphql"
+}
+
+function fromOutcome(value: string): SearchTraceOutcomeLabel {
+  if (value === "SUCCESS" || value === "success") return "success"
+  if (value === "DEGRADED" || value === "degraded") return "degraded"
+  return "failed"
+}
+
+function fromLatencyBucket(value: string): SearchTraceLatencyBucketLabel {
+  switch (value) {
+    case "LT_100_MS":
+    case "lt_100ms":
+      return "lt_100ms"
+    case "LT_250_MS":
+    case "lt_250ms":
+      return "lt_250ms"
+    case "LT_500_MS":
+    case "lt_500ms":
+      return "lt_500ms"
+    case "LT_1000_MS":
+    case "lt_1000ms":
+      return "lt_1000ms"
+    case "LT_2500_MS":
+    case "lt_2500ms":
+      return "lt_2500ms"
+    default:
+      return "gte_2500ms"
+  }
+}
+
+function clampString(value: string | null | undefined, max: number): string {
+  const normalized = (value ?? "").replace(/\s+/g, " ").trim()
+  return normalized.slice(0, max)
+}
+
+function traceClassOrNone(value: string | null | undefined): string {
+  return clampString(value, 64) || "none"
+}
+
+function normalizeMode(value: string | null | undefined): string | null {
+  const normalized = clampString(value, 64)
+  return normalized.length === 0 ? null : normalized
+}
+
+function normalizeLocale(value: string): string {
+  return clampString(value, 32) || "unknown"
+}
+
+function floorToHour(value: Date): Date {
+  const bucket = new Date(value)
+  bucket.setUTCMinutes(0, 0, 0)
+  return bucket
+}
+
+function addRetentionDays(value: Date): Date {
+  return new Date(
+    value.getTime() + env.SEARCH_TRACE_RAW_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+  )
+}
+
+function latencyMs(input: RecordSearchTraceInput): number {
+  return Math.max(0, input.completedAt.getTime() - input.startedAt.getTime())
+}
+
+async function shouldStoreRawTrace(
+  prisma: PrismaClient,
+  input: RecordSearchTraceInput,
+): Promise<boolean> {
+  if (typeof input.retentionHealthy === "boolean") return input.retentionHealthy
+  if (env.NODE_ENV !== "production") return true
+  const health = await readSearchTraceRetentionHealth(prisma)
+  return health.healthy
+}
+
+export async function writeSearchTrace(
+  input: RecordSearchTraceInput,
+  prisma: PrismaClient = defaultPrisma,
+): Promise<SearchTraceWriteResult> {
+  const completedAt = input.completedAt
+  const createdAt = input.now ?? completedAt
+  const routeSource = toPrismaRouteSource(input.routeSource)
+  const outcome = toPrismaOutcome(input.outcome)
+  const latencyBucket = toPrismaLatencyBucket(
+    classifyLatencyBucket(latencyMs(input)),
+  )
+  const locale = normalizeLocale(input.locale)
+  const requestedMode = normalizeMode(input.requestedMode)
+  const searchMode = clampString(input.searchMode, 64) || "unknown"
+  const traceClass = traceClassOrNone(input.traceClass)
+  const privacy = classifySearchTraceQuery(input.query)
+  const aggregateDimensions = {
+    bucketStart: floorToHour(completedAt),
+    routeSource,
+    locale,
+    searchMode,
+    outcome,
+    traceClass,
+    latencyBucket,
+    queryQualityLabel: privacy.queryQualityLabel,
+    sensitiveQueryLabel: privacy.sensitiveQueryLabel,
+    abuseLabel: privacy.abuseLabel,
+  }
+  const aggregatePromise = prisma.searchTraceAggregate.upsert({
+    where: {
+      searchTraceAggregateBucketDims: aggregateDimensions,
+    },
+    create: {
+      ...aggregateDimensions,
+      queryCount: 1,
+      resultCountSum: input.resultCount,
+    },
+    update: {
+      queryCount: { increment: 1 },
+      resultCountSum: { increment: input.resultCount },
+    },
+  })
+
+  const rawEnabled = await shouldStoreRawTrace(prisma, input)
+  const rawPromise = rawEnabled
+    ? prisma.searchTrace.create({
+        data: {
+          queryText: privacy.queryText,
+          locale,
+          routeSource,
+          requestedMode,
+          searchMode,
+          resultCount: input.resultCount,
+          latencyBucket,
+          outcome,
+          traceClass,
+          queryQualityLabel: privacy.queryQualityLabel,
+          sensitiveQueryLabel: privacy.sensitiveQueryLabel,
+          abuseLabel: privacy.abuseLabel,
+          sampleEligible: privacy.sampleEligible,
+          startedAt: input.startedAt,
+          completedAt,
+          rawExpiresAt: addRetentionDays(createdAt),
+          createdAt,
+        },
+      })
+    : Promise.resolve(null)
+
+  const [aggregateResult, rawResult] = await Promise.allSettled([
+    aggregatePromise,
+    rawPromise,
+  ])
+  if (aggregateResult.status === "rejected") throw aggregateResult.reason
+  if (rawResult.status === "rejected") throw rawResult.reason
+
+  if (!rawEnabled) {
+    recordSearchTraceRawCaptureDisabled()
+    console.warn(
+      `[search] event=trace_raw_capture_disabled route=${input.routeSource} outcome=${input.outcome}`,
+    )
+  }
+
+  return {
+    aggregateStored: true,
+    rawStored: rawEnabled,
+    rawCaptureDisabled: !rawEnabled,
+  }
+}
+
+function errorClass(error: unknown): string {
+  return error instanceof Error ? error.constructor.name : "UnknownError"
+}
+
+export async function recordSearchTraceSafely(
+  input: RecordSearchTraceInput,
+  prisma: PrismaClient = defaultPrisma,
+): Promise<SearchTraceSafeRecordResult> {
+  const timeoutMs = input.timeoutMs ?? TRACE_RECORD_TIMEOUT_MS
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let timedOut = false
+
+  const writePromise = writeSearchTrace(input, prisma)
+    .then((result) => {
+      if (timeout) clearTimeout(timeout)
+      recordSearchTraceWriteSuccess()
+      return { ok: true as const, timedOut: false as const, ...result }
+    })
+    .catch((error) => {
+      if (timeout) clearTimeout(timeout)
+      recordSearchTraceWriteFailure()
+      console.warn(
+        `[search] event=trace_record_failed route=${input.routeSource} outcome=${input.outcome} error_class=${errorClass(error)}`,
+      )
+      return { ok: false as const, timedOut: false as const }
+    })
+
+  const timeoutPromise = new Promise<SearchTraceSafeRecordResult>((resolve) => {
+    timeout = setTimeout(() => {
+      timedOut = true
+      recordSearchTraceWriteTimeout()
+      console.warn(
+        `[search] event=trace_record_timeout route=${input.routeSource} outcome=${input.outcome} timeout_ms=${timeoutMs}`,
+      )
+      resolve({ ok: false, timedOut: true })
+    }, timeoutMs)
+  })
+
+  const result = await Promise.race([writePromise, timeoutPromise])
+  if (!timedOut && timeout) clearTimeout(timeout)
+  return result
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit == null || !Number.isFinite(limit)) return DEFAULT_SAMPLE_LIMIT
+  return Math.min(MAX_SAMPLE_LIMIT, Math.max(1, Math.floor(limit)))
+}
+
+function sampleWindow(
+  filters: SearchTraceSampleFilters,
+  now: Date,
+): { since: Date; until: Date } {
+  const until =
+    filters.until && filters.until < now ? filters.until : new Date(now)
+  const requestedSince =
+    filters.since && filters.since < until
+      ? filters.since
+      : new Date(until.getTime() - MAX_SAMPLE_WINDOW_MS)
+  const minimumSince = new Date(until.getTime() - MAX_SAMPLE_WINDOW_MS)
+  return {
+    since: requestedSince < minimumSince ? minimumSince : requestedSince,
+    until,
+  }
+}
+
+type SearchTraceSampleRow = {
+  id: string
+  queryText: string
+  locale: string
+  routeSource: string
+  requestedMode: string | null
+  searchMode: string
+  resultCount: number
+  latencyBucket: string
+  outcome: string
+  traceClass: string
+  queryQualityLabel: string
+  sensitiveQueryLabel: string
+  abuseLabel: string
+  createdAt: Date
+}
+
+export async function sampleSearchTraces(
+  prisma: PrismaClient,
+  filters: SearchTraceSampleFilters = {},
+  now: Date = new Date(),
+): Promise<SearchTraceSample[]> {
+  const { since, until } = sampleWindow(filters, now)
+  const where: Prisma.SearchTraceWhereInput = {
+    sampleEligible: true,
+    rawExpiresAt: { gt: now },
+    createdAt: { gte: since, lte: until },
+  }
+  if (filters.locale) where.locale = normalizeLocale(filters.locale)
+  if (filters.routeSource)
+    where.routeSource = toPrismaRouteSource(filters.routeSource)
+  if (filters.searchMode) where.searchMode = clampString(filters.searchMode, 64)
+
+  const rows = (await prisma.searchTrace.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    take: clampLimit(filters.limit),
+    select: {
+      id: true,
+      queryText: true,
+      locale: true,
+      routeSource: true,
+      requestedMode: true,
+      searchMode: true,
+      resultCount: true,
+      latencyBucket: true,
+      outcome: true,
+      traceClass: true,
+      queryQualityLabel: true,
+      sensitiveQueryLabel: true,
+      abuseLabel: true,
+      createdAt: true,
+    },
+  })) as unknown as SearchTraceSampleRow[]
+
+  return rows.map((row) => ({
+    id: row.id,
+    queryText: row.queryText,
+    locale: row.locale,
+    routeSource: fromRouteSource(row.routeSource),
+    requestedMode: row.requestedMode,
+    searchMode: row.searchMode,
+    resultCount: row.resultCount,
+    latencyBucket: fromLatencyBucket(row.latencyBucket),
+    outcome: fromOutcome(row.outcome),
+    traceClass: row.traceClass,
+    queryQualityLabel: row.queryQualityLabel,
+    sensitiveQueryLabel: row.sensitiveQueryLabel,
+    abuseLabel: row.abuseLabel,
+    createdAt: row.createdAt.toISOString(),
+  }))
+}
+
+export function getSearchTraceCaptureStats() {
+  return getSearchTraceHealthCounters()
+}

--- a/apps/admin/src/workflows/searchTraceRetention.test.ts
+++ b/apps/admin/src/workflows/searchTraceRetention.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const job = vi.hoisted(() => ({
+  runSearchTraceRetentionJob: vi.fn(),
+}))
+
+vi.mock("@/services/search-trace-retention/job", () => job)
+
+describe("runSearchTraceRetention workflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("runs raw search trace purge as a workflow step", async () => {
+    const result = {
+      purgedCount: 5,
+      purgedBefore: "2026-05-30T00:00:00.000Z",
+    }
+    job.runSearchTraceRetentionJob.mockResolvedValueOnce(result)
+    const { runSearchTraceRetention } = await import("./searchTraceRetention")
+
+    await expect(
+      runSearchTraceRetention({
+        trigger: "scheduled",
+        ledgerRunId: "workflow-run-1",
+      }),
+    ).resolves.toEqual(result)
+    expect(job.runSearchTraceRetentionJob).toHaveBeenCalledWith({
+      trigger: "scheduled",
+      ledgerRunId: "workflow-run-1",
+    })
+  })
+})

--- a/apps/admin/src/workflows/searchTraceRetention.ts
+++ b/apps/admin/src/workflows/searchTraceRetention.ts
@@ -1,0 +1,71 @@
+import { sleep } from "workflow"
+import type {
+  SearchTraceRetentionJobResult,
+  SearchTraceRetentionSchedulerInput,
+  SearchTraceRetentionWorkflowInput,
+} from "@/services/search-trace-retention/job"
+
+export async function runSearchTraceRetention(
+  input: SearchTraceRetentionWorkflowInput = {},
+): Promise<SearchTraceRetentionJobResult> {
+  "use workflow"
+
+  return stepRunSearchTraceRetention(input)
+}
+
+async function stepRunSearchTraceRetention(
+  input: SearchTraceRetentionWorkflowInput,
+): Promise<SearchTraceRetentionJobResult> {
+  "use step"
+
+  const { runSearchTraceRetentionJob } =
+    await import("@/services/search-trace-retention/job")
+  return runSearchTraceRetentionJob(input)
+}
+
+export async function runSearchTraceRetentionScheduler(
+  input: SearchTraceRetentionSchedulerInput = {},
+): Promise<never> {
+  "use workflow"
+
+  await stepMarkSchedulerStarted(input)
+  await stepRunScheduledPurge()
+
+  while (true) {
+    const nextRunAt = await stepNextRunAt(input)
+    await sleep(nextRunAt)
+    await stepRunScheduledPurge()
+  }
+}
+
+async function stepMarkSchedulerStarted(
+  input: SearchTraceRetentionSchedulerInput,
+): Promise<void> {
+  "use step"
+
+  const { markSearchTraceRetentionSchedulerStarted } =
+    await import("@/services/search-trace-retention/job")
+  await markSearchTraceRetentionSchedulerStarted(input)
+}
+
+async function stepNextRunAt(
+  input: SearchTraceRetentionSchedulerInput,
+): Promise<Date> {
+  "use step"
+
+  const {
+    nextSearchTraceRetentionRunAt,
+    recordSearchTraceRetentionSchedulerHeartbeat,
+  } = await import("@/services/search-trace-retention/job")
+  const nextRunAt = nextSearchTraceRetentionRunAt()
+  await recordSearchTraceRetentionSchedulerHeartbeat(input, nextRunAt)
+  return nextRunAt
+}
+
+async function stepRunScheduledPurge(): Promise<void> {
+  "use step"
+
+  const { runSearchTraceRetentionFromScheduler } =
+    await import("@/services/search-trace-retention/job")
+  await runSearchTraceRetentionFromScheduler()
+}

--- a/docs/plans/2026-05-26-003-feat-admin-search-trace-retention-plan.md
+++ b/docs/plans/2026-05-26-003-feat-admin-search-trace-retention-plan.md
@@ -1,0 +1,477 @@
+---
+title: "feat: Add Admin search trace storage and retention"
+type: feat
+status: completed
+date: 2026-05-26
+origin: docs/brainstorms/2026-05-25-mastra-embedding-search-migration-requirements.md
+---
+
+# feat: Add Admin search trace storage and retention
+
+## Summary
+
+Add Admin-owned production search trace storage, bounded best-effort capture from both public search entry points, 29-day raw expiry with daily purge, durable aggregate rollups, and a narrow authenticated internal sampling route for later Mastra eval work. Public REST and GraphQL search response shapes remain unchanged; Mastra stays out of the live request path.
+
+---
+
+## Problem Frame
+
+Search quality work needs real viewer-intent queries, but the Mastra migration deliberately keeps live search orchestration and query embedding generation inside Admin. This plan gives Admin a short-lived raw trace store and a longer-lived aggregate trail so eval work can sample recent production behavior without retaining raw per-query data beyond 30 days (see origin: docs/brainstorms/2026-05-25-mastra-embedding-search-migration-requirements.md).
+
+---
+
+## Assumptions
+
+_This plan was authored in pipeline mode without synchronous plan-confirmation. The items below are agent inferences that should be reviewed during implementation and code review._
+
+- The feat-135 roadmap frontmatter still says `not-started`, but the user explicitly stated that feat-135 has moved the embedding ownership boundary into its hardened final shape; this plan proceeds from that newer context.
+- The internal sampling contract can be a narrow Admin REST route guarded by a dedicated bearer CSV rather than a public GraphQL field.
+- A daily workflow-runner purge is the right production retention mechanism only if raw rows expire before the 30-day ceiling, giving the daily run a safety margin.
+
+---
+
+## Requirements
+
+- R17. Mastra must not participate in live user search handling, including live query embedding generation.
+- R18. Admin must store production search query runs as the trace source of truth for no longer than 30 days.
+- R19. Raw per-query traces must be deleted after 30 days; only aggregate metrics and human-approved sanitized eval queries may survive.
+- R20. Admin must apply transparent first-pass query quality, sensitive-data, and abuse labels before storing or sampling production traces.
+
+**Plan constraints:**
+
+- C1. Search trace write and rollup failures must not fail live REST or GraphQL search responses.
+- C2. Later Mastra eval work must use an authenticated Admin contract, not Admin database access or app-context imports.
+- C3. Raw trace storage may keep short-lived query text only after first-pass sensitive-query handling; it must not store bearer tokens, cookies, IP addresses, full user identifiers, or unverified caller-supplied key identifiers.
+- C4. When trace persistence is unavailable, Admin must emit safe loss metrics/logs so capture gaps are observable without logging raw query text.
+
+**Origin actors:** A2 Admin, A3 Mastra, A5 Search evaluator.
+**Origin flows:** F3 Search observability and eval generation.
+**Origin acceptance examples:** AE4 Raw trace deletion with aggregate survival; AE5 Admin-only live search handling.
+
+---
+
+## Scope Boundaries
+
+- Do not move live search orchestration or live query embedding generation into Mastra.
+- Do not change public REST or GraphQL search response shapes.
+- Do not expose raw traces through public REST or public GraphQL.
+- Do not store bearer tokens, cookies, IP addresses, full user identifiers, or unverified caller-supplied key identifiers.
+- Do not add CMS/Strapi fields, compatibility paths, or dependencies.
+- Do not hand-edit generated GraphQL or Prisma outputs.
+
+### Deferred to Follow-Up Work
+
+- Human approval and promotion of sanitized eval queries: future search-eval work can add a durable promoted-query model or workflow after the raw trace sampling contract exists.
+- Mastra-side trace sampling and LLM classification: Mastra will call the internal Admin route later; this plan only creates the Admin contract.
+- Origin R21-R22 remain future eval-generation scope; feat-136 only enables Admin retention, aggregate rollups, and the internal sampling contract.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/app/api/search/route.ts` and `apps/admin/src/graphql/queries/hybrid-search.ts` already share `HybridSearchService.search(...)`, bearer-as-passport auth, and plain-string request logs.
+- `apps/admin/src/services/hybrid-search.service.ts` already distinguishes successful hybrid responses, embedding-provider degradation via `searchMode: "keyword-only"`, and partial retriever failures via `Promise.allSettled`.
+- `apps/admin/src/auth/mastra-ingest-bearer.ts` and `apps/admin/src/app/api/internal/mastra/*/route.ts` provide the narrow internal-bearer route pattern to mirror.
+- `apps/admin/src/services/video-db-backup/job.ts`, `apps/admin/src/workflows/videoDbBackup.ts`, and `apps/admin/src/instrumentation.ts` provide the existing daily scheduler and workflow-runner startup pattern.
+- `apps/admin/src/services/search-eval/fingerprint.ts` demonstrates raw SQL invariant testing for search-adjacent analytical reads.
+
+### Institutional Learnings
+
+- Mastra workflow pattern docs keep the ownership line crisp: Mastra owns background embedding generation and Studio-visible diagnostics; Admin owns pgvector storage, public search contracts, and query-time retrieval.
+- `docs/solutions/integration-issues/mastra-studio-api-auth-guard.md` warns against broad service-bearer route guards and supports narrow Forge-owned service routes.
+- Search API authentication docs in `apps/admin/CLAUDE.md` require bearer logs to avoid raw secret values and preserve source tagging only after a known bearer match.
+- Railway logsV2 drops JSON-stringified runtime logs in this stack; search-adjacent logging should stay in `[search] event=name key=value` format and avoid raw query text.
+
+### External References
+
+- None. The repo has current patterns for Next route handlers, Pothos GraphQL resolvers, Prisma migrations, internal bearers, and workflow schedulers; local ownership and privacy constraints are more specific than generic external guidance.
+
+---
+
+## Key Technical Decisions
+
+- Store raw trace rows separately from aggregate rollups: raw rows may contain query text and are deleted by `rawExpiresAt`, while aggregate rows never contain query text and survive purge.
+- Capture traces through shared Admin service helpers, not public response envelopes: REST and GraphQL can record route source and outcome while leaving client contracts unchanged.
+- Treat trace persistence as bounded best-effort with observable loss: REST and GraphQL await trace recording only behind a short timeout budget, then swallow timeout/write failures so live search behavior stays unchanged while safe counters/logs expose capture gaps.
+- Use a dedicated sampling bearer: future Mastra eval sampling should not reuse public search partner keys, consumer keys, backup download keys, or vector-ingest keys.
+- Keep retrieval diagnostics internal: partial retriever failure labels and contributing retrievers may feed trace classification, but they must not become public REST or GraphQL fields.
+- Use 29-day raw expiry plus the workflow runner for purge: raw trace deletion is a production lifecycle requirement, so the daily purge should start alongside other Admin worker schedulers and have one day of margin before the 30-day ceiling.
+- Disable raw capture when retention is not healthy: if the retention scheduler cannot be confirmed active in production, capture aggregates and safe loss metrics only until the purge scheduler is healthy again.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should sampling be public GraphQL or internal REST? Internal REST, because exposing raw trace data through public GraphQL would widen the public contract and trigger unnecessary SDL/codegen churn.
+- Should trace rows retain caller identity details? No. The raw trace store should keep route source and execution metadata only; it should not retain bearer tokens, cookies, IPs, full user ids, or attempted key identifiers.
+
+### Deferred to Implementation
+
+- Exact latency bucket boundaries: choose a small stable bucket set while implementing tests around bucket classification.
+- Exact aggregate grain: likely hourly or daily by locale, route, search mode, and failure/degradation class; settle the final unique key against Prisma index ergonomics during implementation.
+- Final sampling filters: implement only the minimum needed for later Mastra eval work, such as locale, route, search mode, and limit.
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+sequenceDiagram
+  participant Client as "Search caller"
+  participant AdminRoute as "Admin REST or GraphQL"
+  participant Search as "HybridSearchService"
+  participant Trace as "SearchTraceService"
+  participant DB as "Admin Postgres"
+  participant Worker as "Admin workflow runner"
+  participant Mastra as "Future Mastra eval job"
+
+  Client->>AdminRoute: public search request
+  AdminRoute->>Search: live Admin search
+  Search-->>AdminRoute: response or failure
+  AdminRoute->>Trace: bounded trace capture
+  Trace->>DB: raw trace + aggregate rollup
+  AdminRoute-->>Client: unchanged public response
+  Worker->>Trace: daily purge 29-day raw traces
+  Trace->>DB: delete raw rows where rawExpiresAt passed
+  Mastra->>AdminRoute: authenticated internal sample request
+  AdminRoute->>Trace: recent trace sample
+  Trace-->>Mastra: bounded raw samples for offline eval
+```
+
+---
+
+## Implementation Units
+
+### U1. Trace Schema And Configuration
+
+**Goal:** Add Admin-owned storage for raw traces, aggregate rollups, and a dedicated sampling bearer without introducing new required boot-time env vars.
+
+**Requirements:** R18, R19, R20, C2, C3, AE4.
+
+**Dependencies:** None.
+
+**Files:**
+
+- Modify: `apps/admin/prisma/schema.prisma`
+- Create: `apps/admin/prisma/migrations/0021_admin_search_trace_storage_retention/migration.sql`
+- Modify: `apps/admin/src/config/env.ts`
+- Test: `apps/admin/src/config/env.test.ts`
+
+**Approach:**
+
+- Add a raw trace model keyed by created/expires timestamps, route source, locale, pipeline mode, response search mode, result count, latency bucket, failure/degradation class, query quality label, sensitive-data label, abuse label, and sample eligibility.
+- Add an aggregate model keyed by time bucket and non-query dimensions only; do not store raw query text in the aggregate table.
+- Add an optional `SEARCH_TRACE_SAMPLING_API_KEYS` CSV and include it in the bearer disjointness invariant.
+- Add a raw retention config only if implementation needs operator control; default raw row expiry to 29 days and validate any override as `1..29` so the daily purge can physically delete rows before the 30-day ceiling.
+- Keep all new env vars optional or defaulted so preview/local deployments do not brick before operators provision keys.
+
+**Execution note:** Start with schema/env tests that lock the no-secret/no-required-env and 30-day retention constraints before wiring callers.
+
+**Patterns to follow:**
+
+- `apps/admin/prisma/schema.prisma` mapped field/index style.
+- `apps/admin/src/config/env.ts` bearer CSV disjointness invariant and optional-env pattern.
+- `docs/solutions/runtime-errors/required-env-var-without-default-broke-railway-deploy-20260511.md`.
+
+**Test scenarios:**
+
+- Happy path: schema contains indexed expiration and aggregate bucket columns that support purge and rollup reads.
+- Edge case: missing sampling bearer env still lets env validation pass.
+- Edge case: retention config cannot exceed 29 days when purge runs daily.
+- Error path: duplicate sampling bearer value across existing bearer CSVs fails the disjointness check with values redacted.
+- Privacy: raw trace model has no token, cookie, IP, or user-id columns.
+- Privacy: raw trace model has explicit quality/sensitive/abuse label fields and sample eligibility so sensitive rows are not sampled by default.
+
+**Verification:**
+
+- Prisma generation succeeds after the migration and schema update.
+- Env tests prove the new sampling key is optional and disjoint from other bearer CSVs.
+
+---
+
+### U2. Trace Capture, Rollup, And Purge Services
+
+**Goal:** Create service-layer APIs for best-effort trace recording, aggregate upsert, recent sampling, and raw trace purge.
+
+**Requirements:** R18, R19, R20, C1, C2, C3, C4, AE4.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- Create: `apps/admin/src/services/search-trace.service.ts`
+- Test: `apps/admin/src/services/search-trace.service.test.ts`
+- Create: `apps/admin/src/services/search-trace-health.ts`
+- Test: `apps/admin/src/services/search-trace-health.test.ts`
+- Create: `apps/admin/src/services/search-trace-privacy.ts`
+- Test: `apps/admin/src/services/search-trace-privacy.test.ts`
+- Create: `apps/admin/src/services/search-trace-retention.service.ts`
+- Test: `apps/admin/src/services/search-trace-retention.service.test.ts`
+- Modify: `apps/admin/src/services/search-eval/fingerprint.ts`
+- Test: `apps/admin/src/services/search-eval/fingerprint.test.ts`
+
+**Approach:**
+
+- Normalize trace inputs into a compact record: query text or redacted query text, locale, route source, requested pipeline mode, response search mode, result count, latency bucket, degradation/failure class, first-pass quality/sensitive/abuse labels, sampling eligibility, started/completed timestamps, and raw expiration timestamp no later than 29 days after creation.
+- Add a first-pass privacy classifier for obvious emails, phone-like strings, token-like strings, credential patterns, and abuse categories. Sensitive matches should store a redacted query plus non-sampleable label rather than exportable raw text.
+- Upsert aggregate counters by non-query dimensions and time bucket in the same best-effort path, so aggregate survival does not depend on raw trace retention.
+- Add a purge service that deletes rows whose raw expiration has passed and reports counts only.
+- Add process-local trace health counters for successful writes, timed-out writes, failed writes, and raw-capture-disabled events; logs must use plain key/value format and omit raw query text.
+- Add a companion trace aggregate fingerprint helper without changing the existing `Fingerprint` baseline schema, so eval tools can opt into trace-store drift checks without invalidating schemaVersion 1 baselines.
+
+**Execution note:** Implement service behavior test-first because it owns the privacy and retention invariants.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/hybrid-search.service.ts` best-effort degradation posture.
+- `apps/admin/src/services/search-eval/fingerprint.ts` single-query analytical reads and SQL invariant tests.
+- `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`.
+
+**Test scenarios:**
+
+- Covers AE4. Happy path: recording a successful hybrid REST trace stores allowed query text with an expiration at or before 29 days and increments an aggregate row without query text.
+- Error path: obvious sensitive or credential-like query text is redacted, marked non-sampleable, and excluded from default sampling.
+- Happy path: recording a keyword-only response classifies embedding degradation and increments the matching aggregate dimension.
+- Error path: a Prisma create/upsert failure is caught, logged without query text, and resolves without throwing to the caller.
+- Error path: timed-out or failed trace writes increment safe loss counters and log no query text.
+- Error path: purge deletes only expired raw traces and does not delete aggregate rows.
+- Privacy: sampling output excludes tokens, cookies, IPs, full user identifiers, and unverified caller-supplied key identifiers.
+- Integration: aggregate counters remain readable after all matching raw traces are purged.
+- Integration: companion trace fingerprint output can describe aggregate trace state without exposing query text or changing existing baseline schemas.
+
+**Verification:**
+
+- Service tests show raw trace capture, rollup survival, and purge behavior are separated and privacy-safe.
+
+---
+
+### U3. REST And GraphQL Search Instrumentation
+
+**Goal:** Instrument successful, degraded, and failed search attempts from both public search entry points without changing public response shapes.
+
+**Requirements:** R17, R18, R20, C1, C4, AE5.
+
+**Dependencies:** U2.
+
+**Files:**
+
+- Modify: `apps/admin/src/app/api/search/route.ts`
+- Test: `apps/admin/src/app/api/search/route.test.ts`
+- Modify: `apps/admin/src/graphql/queries/hybrid-search.ts`
+- Test: `apps/admin/src/graphql/queries/hybrid-search.test.ts`
+- Modify: `apps/admin/src/services/hybrid-search.service.ts`
+- Test: `apps/admin/src/services/hybrid-search.service.test.ts`
+
+**Approach:**
+
+- Time each valid live search attempt and record traces after the service returns or throws.
+- Use `routeSource` values that distinguish REST from GraphQL; classify success, keyword-only degradation, retrieval partial failure where available, and service failure.
+- Keep invalid-argument and unauthenticated requests out of raw production query tracing unless implementation discovers a strong reason to trace rejected input; the roadmap asks for production search query runs, not request-probing logs.
+- Surface internal non-response metadata such as retriever failure class, failed retriever labels, and contributing retrievers through an internal execution summary used by the route/resolver, not through REST JSON or GraphQL fields.
+- Await trace recording behind a strict short timeout budget; on timeout or write failure, increment safe loss counters, log safely, and return or throw the original search outcome unchanged. Do not add an outbox or queue in this PR.
+- Ensure trace failures are logged in plain key/value format without raw query text and never change the live response/throw behavior.
+
+**Execution note:** Add characterization assertions around existing response bodies before adding trace side effects.
+
+**Patterns to follow:**
+
+- Existing `event=search.request` logging in REST and GraphQL search.
+- Existing `query_embedding_failure` degradation path in `HybridSearchService`.
+- `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`.
+
+**Test scenarios:**
+
+- Covers AE5. Happy path: REST `200` search response body remains byte-shape equivalent while the trace recorder receives query, locale, route source, result count, latency bucket, and search mode.
+- Covers AE5. Happy path: GraphQL resolver return value remains the existing `HybridSearchResponse` while the trace recorder receives the same metadata with route source `graphql`.
+- Error path: service throws; REST still returns the existing `503` body and records a failed trace best-effort.
+- Error path: GraphQL service throw propagates as before and records a failed trace best-effort.
+- Error path: trace recorder throws; REST and GraphQL outcomes remain unchanged and logs do not contain the raw query.
+- Error path: trace recorder exceeds its timeout budget; REST and GraphQL outcomes remain unchanged and timeout logging omits raw query text.
+- Edge case: keyword-only degradation records a degradation class while still returning the existing degraded response.
+- Edge case: partial retriever failure records failed retriever labels distinctly from a legitimate zero-result search.
+
+**Verification:**
+
+- REST and GraphQL tests prove response shapes are unchanged and trace side effects are best-effort.
+
+---
+
+### U4. Internal Sampling Contract
+
+**Goal:** Add a narrow authenticated Admin route that lets future Mastra eval jobs sample recent raw traces without database access.
+
+**Requirements:** R19, R20, C2, C3.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+
+- Create: `apps/admin/src/auth/search-trace-bearer.ts`
+- Test: `apps/admin/src/auth/search-trace-bearer.test.ts`
+- Create: `apps/admin/src/app/api/internal/search-traces/sample/route.ts`
+- Test: `apps/admin/src/app/api/internal/search-traces/sample/route.test.ts`
+
+**Approach:**
+
+- Rate-limit the sampling route before auth/body parsing, then validate a dedicated `SEARCH_TRACE_SAMPLING_API_KEYS` bearer before parsing filters.
+- Return a bounded sample of recent, unexpired, sample-eligible raw traces with minimal fields needed for offline eval generation: query text, locale, route source, search mode, result count, latency bucket, degradation/failure class, quality/sensitive/abuse labels, and timestamp.
+- Support simple filters such as locale, route source, mode, since, until, and limit; clamp limits and maximum time windows server-side. Default maximum sampling window should be small, such as 24 hours, with broader windows requiring an explicit server-side allowlist or follow-up.
+- Reject any bearer not in `SEARCH_TRACE_SAMPLING_API_KEYS`; env validation must reject a sampling key that duplicates any public search, backup download, Mastra ingest, or workflow launch bearer.
+- Emit structured audit logs with auth outcome, filter dimensions, result count, and no query text.
+
+**Patterns to follow:**
+
+- `apps/admin/src/auth/mastra-ingest-bearer.ts` narrow capability bearer.
+- `apps/admin/src/app/api/internal/mastra/experience-embeddings/route.ts` auth-before-body route shape.
+- `docs/solutions/architecture-patterns/parity-bearer-narrow-carveout-pattern-20260513.md`.
+
+**Test scenarios:**
+
+- Happy path: valid sampling bearer returns bounded recent samples and omits aggregate-only rows.
+- Error path: missing or wrong bearer returns unauthorized before reading the request body.
+- Error path: rate-limited requests return before auth/body parsing.
+- Edge case: over-large limit and time window are clamped and do not return expired or non-sampleable rows.
+- Privacy: response contains no bearer token, cookie, IP, full user id, vector, or debug scoring payload.
+- Privacy: sensitive-query rows are excluded by default even while their redacted raw trace rows remain unexpired.
+- Integration: service sampling call receives parsed filters and never exposes raw traces publicly through GraphQL.
+
+**Verification:**
+
+- Internal route tests prove authentication, filtering, response minimization, and no-public-contract changes.
+
+---
+
+### U5. Scheduled Retention Workflow
+
+**Goal:** Run raw trace purge automatically from the Admin workflow runner so raw per-query trace data does not survive beyond the retention window.
+
+**Requirements:** R19, C1, C4, AE4.
+
+**Dependencies:** U2.
+
+**Files:**
+
+- Create: `apps/admin/src/workflows/searchTraceRetention.ts`
+- Test: `apps/admin/src/workflows/searchTraceRetention.test.ts`
+- Create: `apps/admin/src/services/search-trace-retention/job.ts`
+- Test: `apps/admin/src/services/search-trace-retention/job.test.ts`
+- Modify: `apps/admin/src/app/api/search/health/route.ts`
+- Test: `apps/admin/src/app/api/search/health/route.test.ts`
+- Modify: `apps/admin/src/instrumentation.ts`
+- Test: `apps/admin/src/instrumentation.test.ts`
+
+**Approach:**
+
+- Add a daily scheduler workflow that invokes the purge service and records only counts/timestamps in the workflow ledger. Because raw rows expire at or before 29 days, the next daily purge deletes them before the 30-day physical retention ceiling during normal worker operation.
+- Guard scheduler startup with the same duplicate-run protection used by the video DB backup scheduler.
+- Add a retention health check that can confirm an active retention scheduler or recent purge heartbeat. In production, raw trace capture should be disabled and counted/logged when retention health is absent, while aggregate-only counters may continue.
+- Keep purge failures out of the live search path; failures should appear in workflow logs/ledger and retry on the next schedule.
+- Use aggregate rows as the long-lived analytical record; do not copy raw query text into workflow details.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/video-db-backup/job.ts`
+- `apps/admin/src/workflows/videoDbBackup.ts`
+- `apps/admin/src/instrumentation.ts`
+
+**Test scenarios:**
+
+- Covers AE4. Happy path: scheduler dispatches one purge workflow and records a ledger summary with purged count only.
+- Edge case: a trace created just after one daily purge expires at day 29 and is deleted by the next daily run before age 30 days.
+- Error path: when the worker scheduler is disabled or unhealthy, raw capture is disabled, aggregate/loss counters remain safe, and `/api/search/health` reports the retention degradation.
+- Edge case: existing active scheduler prevents duplicate startup.
+- Error path: purge failure marks the ledger failed without exposing raw query text.
+- Integration: instrumentation starts the search trace retention scheduler only when the workflow runner is enabled.
+
+**Verification:**
+
+- Workflow tests prove daily purge startup, duplicate prevention, and safe ledger details.
+
+---
+
+### U6. Documentation And Roadmap Closeout
+
+**Goal:** Document the final Admin/Mastra search trace ownership and retention model, then complete the roadmap ticket when validation passes.
+
+**Requirements:** R17, R18, R19, R20, C2, C3.
+
+**Dependencies:** U1, U2, U3, U4, U5.
+
+**Files:**
+
+- Modify: `apps/admin/AGENTS.md`
+- Modify: `apps/admin/CLAUDE.md`
+- Modify: `docs/roadmap/content-discovery/feat-136-admin-search-trace-storage-retention.md`
+- Create or modify: `docs/solutions/platform/admin-search-trace-retention-pattern.md`
+
+**Approach:**
+
+- Add package-guide notes explaining Admin-owned live search traces, raw 30-day retention, aggregate survival, and narrow internal sampling.
+- Add a durable solution note that explicitly says Mastra samples through Admin HTTP contracts and never imports Admin code or reads Admin DB directly.
+- Mark the roadmap ticket complete only after focused validation passes; create a follow-up ticket for sanitized eval promotion if implementation reveals concrete scope.
+
+**Patterns to follow:**
+
+- Existing Mastra workflow pattern docs in `docs/solutions/platform/`.
+- Root roadmap status rules in `AGENTS.md` and `CLAUDE.md`.
+
+**Test scenarios:**
+
+- Test expectation: none -- documentation-only unit, validated by review and roadmap consistency.
+
+**Verification:**
+
+- Docs capture the final ownership/retention model and the roadmap ticket status reflects the implementation outcome.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** REST search, GraphQL search, `HybridSearchService`, new trace services, Prisma persistence, internal sampling route, and workflow instrumentation are affected.
+- **Error propagation:** search and trace failures are intentionally separated; trace writes and rollups log safely and do not alter REST/GraphQL responses.
+- **State lifecycle risks:** raw query text has a hard expiration and scheduled purge; aggregates survive without query text.
+- **API surface parity:** public REST and GraphQL search shapes remain unchanged; the only new API is internal and bearer-gated.
+- **Integration coverage:** tests must cover successful, degraded, and failed search attempts across both public entry points plus purge and sampling boundaries.
+- **Unchanged invariants:** Admin remains the live search authority; Mastra remains a later offline sampler/evaluator through authenticated Admin HTTP.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                        | Mitigation                                                                                                                                                       |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Raw query text accidentally retained longer than 30 days    | Set raw expiry no later than 29 days, filter sampling to unexpired rows, and run a daily purge workflow with tests proving physical deletion before age 30 days. |
+| Trace failures impact search availability                   | Make trace writes best-effort and assert failure swallowing at REST, GraphQL, and service levels.                                                                |
+| Internal sampling route becomes a public data leak          | Use a dedicated disjoint bearer, auth before body parse, no public GraphQL field, and minimal response fields.                                                   |
+| A valid sampling bearer exports sensitive pasted query text | First-pass classify and redact obvious PII, credential-like, token-like, and abuse queries; mark those rows non-sampleable by default.                           |
+| Aggregates accidentally retain query text                   | Separate aggregate table/schema and test that aggregate payloads contain counters/dimensions only.                                                               |
+| Public search response drift                                | Characterize current REST/GraphQL response bodies and avoid Pothos schema changes.                                                                               |
+
+---
+
+## Documentation / Operational Notes
+
+- Operators must provision `SEARCH_TRACE_SAMPLING_API_KEYS` only for trusted internal eval callers after the route ships.
+- The Admin worker service must keep `WORKFLOW_RUNNER_ENABLED=true` and `WORKFLOW_TARGET_WORLD=@workflow/world-postgres` for scheduled purge execution, matching the existing worker pattern.
+- If a future PR promotes sanitized eval queries, it must create a separate human-approval model and never reuse raw trace rows as long-lived benchmarks.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-25-mastra-embedding-search-migration-requirements.md](../brainstorms/2026-05-25-mastra-embedding-search-migration-requirements.md)
+- Roadmap ticket: [docs/roadmap/content-discovery/feat-136-admin-search-trace-storage-retention.md](../roadmap/content-discovery/feat-136-admin-search-trace-storage-retention.md)
+- Admin guide: [apps/admin/CLAUDE.md](../../apps/admin/CLAUDE.md)
+- Search REST entry: [apps/admin/src/app/api/search/route.ts](../../apps/admin/src/app/api/search/route.ts)
+- Search GraphQL entry: [apps/admin/src/graphql/queries/hybrid-search.ts](../../apps/admin/src/graphql/queries/hybrid-search.ts)
+- Search service: [apps/admin/src/services/hybrid-search.service.ts](../../apps/admin/src/services/hybrid-search.service.ts)
+- Mastra transcript pattern: [docs/solutions/platform/mastra-transcript-embedding-workflow-pattern.md](../solutions/platform/mastra-transcript-embedding-workflow-pattern.md)
+- Mastra scene pattern: [docs/solutions/platform/mastra-scene-embedding-workflow-pattern.md](../solutions/platform/mastra-scene-embedding-workflow-pattern.md)
+- Mastra experience pattern: [docs/solutions/platform/mastra-experience-embedding-workflow-pattern.md](../solutions/platform/mastra-experience-embedding-workflow-pattern.md)
+- Studio auth guard learning: [docs/solutions/integration-issues/mastra-studio-api-auth-guard.md](../solutions/integration-issues/mastra-studio-api-auth-guard.md)

--- a/docs/roadmap/content-discovery/feat-135-mastra-embedding-workflow-hardening.md
+++ b/docs/roadmap/content-discovery/feat-135-mastra-embedding-workflow-hardening.md
@@ -3,7 +3,7 @@ id: "feat-135"
 title: "Mastra embedding workflow hardening"
 owner: "nisal"
 priority: "P0"
-status: "not-started"
+status: "complete"
 start_date: "2026-05-25"
 duration: 3
 depends_on:

--- a/docs/roadmap/content-discovery/feat-136-admin-search-trace-storage-retention.md
+++ b/docs/roadmap/content-discovery/feat-136-admin-search-trace-storage-retention.md
@@ -3,7 +3,7 @@ id: "feat-136"
 title: "Admin production search trace storage and retention"
 owner: "nisal"
 priority: "P0"
-status: "not-started"
+status: "complete"
 start_date: "2026-05-25"
 duration: 4
 depends_on:

--- a/docs/solutions/platform/admin-search-trace-retention-pattern.md
+++ b/docs/solutions/platform/admin-search-trace-retention-pattern.md
@@ -1,0 +1,106 @@
+---
+title: "Admin search trace retention and sampling ownership pattern"
+date: "2026-05-26"
+category: "platform"
+module: "apps/admin"
+problem_type: "architecture_pattern"
+component: "database"
+severity: "high"
+applies_when:
+  - "Admin records production search traces for eval sampling or quality analysis"
+  - "Raw per-query search data must expire under a hard 30-day retention ceiling"
+  - "Mastra needs future eval input without joining the live search path or reading Admin Postgres"
+tags:
+  - admin
+  - search
+  - retention
+  - sampling
+  - mastra
+  - pgvector
+  - privacy
+  - observability
+related:
+  - "docs/solutions/integration-issues/mastra-studio-api-auth-guard.md"
+  - "docs/solutions/architecture-patterns/bearer-as-passport-multi-csv-composition-20260518.md"
+  - "docs/solutions/architecture-patterns/db-backed-vs-env-csv-credential-storage-20260518.md"
+  - "docs/solutions/platform/admin-hybrid-search-r4-pattern.md"
+---
+
+# Admin Search Trace Retention Pattern
+
+## Context
+
+Mastra owns background embedding workflows, provider calls, retries,
+diagnostics, and Studio observability. Admin owns live search orchestration,
+live query embedding generation, vector storage, public REST/GraphQL contracts,
+production search traces, retention, aggregates, and sampling contracts.
+
+That ownership line matters because production user search must not depend on a
+Mastra workflow hop. Search tracing exists to improve later eval work, not to
+move the live request path.
+
+## Pattern
+
+- Store short-lived raw traces in Admin only. `search_trace` may contain query
+  text only after deterministic first-pass privacy handling has normalized,
+  labeled, and redacted obvious sensitive or abusive input.
+- Expire raw traces before the legal/product ceiling. The default and maximum
+  `SEARCH_TRACE_RAW_RETENTION_DAYS` is 29 days, giving the daily purge workflow
+  a one-day margin before the 30-day raw-retention limit.
+- Keep aggregate rollups query-free. `search_trace_aggregate` stores counts and
+  non-query dimensions only, so it can survive raw trace deletion.
+- Keep trace writes out of the availability path. REST and GraphQL await
+  `recordSearchTraceSafely` behind a short timeout and swallow write failures.
+  Safe counters and key/value logs expose loss without logging query text.
+- Sample through Admin HTTP only. Future Mastra eval jobs use
+  `POST /api/internal/search-traces/sample` with
+  `SEARCH_TRACE_SAMPLING_API_KEYS`; Mastra must not import Admin packages or
+  read Admin Postgres directly.
+- Prove retention is alive before raw capture in production. Admin health reads
+  the retention scheduler/recent purge heartbeat; if retention is not healthy,
+  raw trace capture is disabled while aggregate/loss counters continue.
+- Treat stale retention schedulers as unhealthy. A QUEUED/RUNNING scheduler
+  ledger only counts as healthy when its `updatedAt`/`createdAt` heartbeat is
+  inside the health window; startup marks stale active ledgers failed before
+  creating a replacement.
+- Keep the sampling route deliberately narrow. It accepts JSON-only bounded
+  request bodies, strict typed filters, a dedicated sampling bearer allowlist,
+  and rejects public `jfp_search_*` partner-token shaped values even if one is
+  accidentally pasted into the sampling environment variable.
+
+## Data Safety Rules
+
+Raw trace rows must not store bearer tokens, cookies, IP addresses, full user
+identifiers, caller-supplied key ids, vectors, or debug scoring payloads.
+Aggregate rows and workflow ledger details must not store raw query text.
+
+Sensitive rows are redacted and marked non-sampleable by default. The only data
+that may survive raw deletion is aggregate data or future human-approved,
+sanitized eval queries created by a separate approval workflow.
+
+## Implementation Anchors
+
+- Schema: `apps/admin/prisma/schema.prisma` models `SearchTrace` and
+  `SearchTraceAggregate`.
+- Capture: `apps/admin/src/services/search-trace.service.ts`.
+- Privacy labels: `apps/admin/src/services/search-trace-privacy.ts`.
+- Purge and health: `apps/admin/src/services/search-trace-retention.service.ts`
+  and `apps/admin/src/services/search-trace-retention/job.ts`.
+- Scheduler: `apps/admin/src/workflows/searchTraceRetention.ts`, started by
+  `apps/admin/src/instrumentation.ts`.
+- Public instrumentation:
+  `apps/admin/src/app/api/search/route.ts` and
+  `apps/admin/src/graphql/queries/hybrid-search.ts`.
+- Internal sampling:
+  `apps/admin/src/app/api/internal/search-traces/sample/route.ts`.
+
+## Gotchas
+
+- A daily purge with a 30-day raw expiry can retain rows for almost 31 days.
+  Use 29-day expiry with daily purge.
+- Do not add a public GraphQL trace field. The sampling contract is internal
+  REST, bearer-gated, bounded, and rate-limited.
+- Do not log raw queries on trace failures. Logs should use
+  `[search] event=... key=value` and safe dimensions only.
+- Do not let a long-lived scheduler ledger mask a dead retention loop. Health
+  must use a fresh scheduler heartbeat or a recent successful purge.


### PR DESCRIPTION
## Summary

Search quality tooling can now sample short-lived, Admin-owned production search traces without putting Mastra in the live request path. Admin records REST and GraphQL search attempts behind a safe timeout, keeps public response shapes unchanged, rolls up query-free counters that survive purge, and exposes a dedicated internal sampling contract for later eval work.

Key decisions:

- Raw query traces expire after 29 days so the daily purge has margin under the 30-day ceiling.
- Aggregates never retain query text, tokens, cookies, IPs, user identifiers, vectors, or scoring payloads.
- Trace writes are best-effort and cannot fail live search responses.
- Sampling is internal REST only, bearer-gated with a dedicated key set, rate-limited, JSON-bounded, and rejects public `jfp_search_*` partner-token shaped values.
- Production raw capture is gated on retention health; stale scheduler ledgers are treated as unhealthy and replaced.

## Validation

- `pnpm --filter @forge/admin test -- hybrid-search.service.test.ts graphql/queries/hybrid-search.test.ts app/api/search/route.test.ts search-eval/fingerprint.test.ts search-trace.service.test.ts search-trace-privacy.test.ts search-trace-health.test.ts search-trace-retention.service.test.ts services/search-trace-retention/job.test.ts workflows/searchTraceRetention.test.ts app/api/internal/search-traces/sample/route.test.ts auth/search-trace-bearer.test.ts app/api/search/health/route.test.ts instrumentation.test.ts env.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin exec prisma validate`
- `pnpm --filter @forge/admin db:generate`
- Local smoke against Docker Admin DB:
  - applied migration `0021_admin_search_trace_storage_retention`
  - REST `/api/search` returned unchanged envelope and wrote a raw + aggregate trace
  - GraphQL `search` returned unchanged envelope and wrote a raw + aggregate trace
  - internal sampling returned the smoke traces with a dedicated bearer
  - public-shaped `jfp_search_*` bearer was rejected with `401`
  - purge deleted an inserted expired raw trace

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
