### PR TITLE
feat(auth): route login by existing provider

### DIFF
--- a/apps/auth/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.test.ts
@@ -51,6 +51,7 @@ vi.mock("@/auth/firebase-rest", () => ({
 }))
 
 vi.mock("@/auth/firebase-admin", () => ({
+  firebaseUserExistsByEmail: vi.fn(async () => false),
   verifyFirebaseIdToken: vi.fn(async () => null),
 }))
 
@@ -62,6 +63,7 @@ describe("Auth route wrapper", () => {
     rateLimitAuthRoute.mockReset()
     rateLimitAuthRoute.mockResolvedValue({ allowed: true, source: "local" })
     signUpEmail.mockReset()
+    vi.unstubAllEnvs()
   })
 
   it("blocks public email signup", async () => {
@@ -74,6 +76,76 @@ describe("Auth route wrapper", () => {
     )
 
     expect(response.status).toBe(404)
+    expect(authPost).not.toHaveBeenCalled()
+  })
+
+  it("returns a generic sign-in message when email signup already exists", async () => {
+    const { prisma } = await import("@/db/client")
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce({
+      id: "user_123",
+    } as unknown as Awaited<ReturnType<typeof prisma.user.findFirst>>)
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-up/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "USER@example.com" }),
+      }),
+      { params: Promise.resolve({ all: ["sign-up", "email"] }) },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "An account already exists for that email. Sign in to continue.",
+    })
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      where: { email: "user@example.com" },
+      select: { id: true },
+    })
+    expect(authPost).not.toHaveBeenCalled()
+  })
+
+  it("returns the same generic sign-in message for legacy Firebase accounts", async () => {
+    const { prisma } = await import("@/db/client")
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce(null)
+    const { firebaseUserExistsByEmail } = await import("@/auth/firebase-admin")
+    vi.mocked(firebaseUserExistsByEmail).mockResolvedValueOnce(true)
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-up/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "LEGACY@example.com" }),
+      }),
+      { params: Promise.resolve({ all: ["sign-up", "email"] }) },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "An account already exists for that email. Sign in to continue.",
+    })
+    expect(firebaseUserExistsByEmail).toHaveBeenCalledWith("legacy@example.com")
+    expect(authPost).not.toHaveBeenCalled()
+  })
+
+  it("keeps public email signup blocked for new emails", async () => {
+    const { prisma } = await import("@/db/client")
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce(null)
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-up/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "new@example.com" }),
+      }),
+      { params: Promise.resolve({ all: ["sign-up", "email"] }) },
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: "Not found" })
     expect(authPost).not.toHaveBeenCalled()
   })
 
@@ -115,6 +187,83 @@ describe("Auth route wrapper", () => {
         "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&sig=signed",
       provider: "google",
     })
+  })
+
+  it("returns the configured provider for an existing social account", async () => {
+    vi.stubEnv("GOOGLE_CLIENT_ID", "google-client")
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-secret")
+    const { prisma } = await import("@/db/client")
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce({
+      accounts: [{ providerId: "google" }],
+    } as unknown as Awaited<ReturnType<typeof prisma.user.findFirst>>)
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/login-method", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email: "USER@example.com",
+          oauth_query: "client_id=jfp_admin_local&sig=signed",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["login-method"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      method: "provider",
+      provider: "google",
+    })
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      where: { email: "user@example.com" },
+      select: {
+        accounts: {
+          select: { providerId: true },
+        },
+      },
+    })
+  })
+
+  it("falls back to password when the account has no configured social provider", async () => {
+    const { prisma } = await import("@/db/client")
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce({
+      accounts: [{ providerId: "credential" }, { providerId: "firebase" }],
+    } as unknown as Awaited<ReturnType<typeof prisma.user.findFirst>>)
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/login-method", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "user@example.com" }),
+      }),
+      { params: Promise.resolve({ all: ["login-method"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ method: "password" })
+  })
+
+  it("does not expose provider lookup failures when rate limited", async () => {
+    rateLimitAuthRoute.mockResolvedValueOnce({
+      allowed: false,
+      source: "local",
+    })
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/login-method", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "user@example.com" }),
+      }),
+      { params: Promise.resolve({ all: ["login-method"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ method: "password" })
+    expect(authPost).not.toHaveBeenCalled()
   })
 
   it("forwards OAuth continuation as callbackURL through email sign-in", async () => {

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -1,8 +1,12 @@
 import { createHash, randomUUID } from "node:crypto"
 
 import { auth, authRouteHandlers } from "@/auth/config"
-import { verifyFirebaseIdToken } from "@/auth/firebase-admin"
+import {
+  firebaseUserExistsByEmail,
+  verifyFirebaseIdToken,
+} from "@/auth/firebase-admin"
 import { signInWithFirebasePassword } from "@/auth/firebase-rest"
+import { isLoginProviderId, type LoginProviderId } from "@/auth/login-methods"
 import { rateLimitAuthRoute } from "@/auth/rate-limit"
 import { getAuthBaseUrl } from "@/config/env"
 import { prisma } from "@/db/client"
@@ -18,6 +22,7 @@ const LAST_LOGIN_METHOD_COOKIE = "forge_auth_last_login_method"
 const LAST_LOGIN_METHOD_MAX_AGE = 60 * 60 * 24 * 365
 
 type LastLoginMethod = "apple" | "email" | "facebook" | "google" | "okta"
+const providerPriority = ["google", "facebook", "apple", "okta"] as const
 
 function isFormPostRequest(request: Request): boolean {
   return (
@@ -137,8 +142,38 @@ async function parseEmailPasswordRequest(request: Request): Promise<{
   }
 }
 
+async function parseLoginMethodRequest(request: Request): Promise<{
+  email: string
+}> {
+  const contentType = request.headers.get("content-type") ?? ""
+  if (contentType.includes("application/json")) {
+    const body = (await request.json()) as { email?: string }
+    return {
+      email: body.email?.trim().toLowerCase() ?? "",
+    }
+  }
+
+  if (!contentType.includes("application/x-www-form-urlencoded")) {
+    return { email: "" }
+  }
+
+  const body = await request.formData()
+  return {
+    email: String(body.get("email") ?? "")
+      .trim()
+      .toLowerCase(),
+  }
+}
+
 function genericUnauthorized(): Response {
   return Response.json({ error: "Invalid email or password" }, { status: 401 })
+}
+
+function existingAccountSignUpResponse(): Response {
+  return Response.json(
+    { error: "An account already exists for that email. Sign in to continue." },
+    { status: 409 },
+  )
 }
 
 function oauthQueryFromLoginReferer(request: Request): string | undefined {
@@ -218,6 +253,111 @@ async function handleSocialSignIn(request: Request): Promise<Response> {
       ...(callbackURL ? { callbackURL } : {}),
     }),
   )
+}
+
+function enabledProviderIds(): Set<LoginProviderId> {
+  const providers = new Set<LoginProviderId>()
+
+  if (process.env.FACEBOOK_CLIENT_ID && process.env.FACEBOOK_CLIENT_SECRET) {
+    providers.add("facebook")
+  }
+  if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+    providers.add("google")
+  }
+  if (process.env.APPLE_CLIENT_ID && process.env.APPLE_CLIENT_SECRET) {
+    providers.add("apple")
+  }
+  if (
+    process.env.OKTA_CLIENT_ID &&
+    process.env.OKTA_CLIENT_SECRET &&
+    process.env.OKTA_ISSUER
+  ) {
+    providers.add("okta")
+  }
+
+  return providers
+}
+
+async function handleLoginMethod(request: Request): Promise<Response> {
+  const limit = await rateLimitAuthRoute({
+    request,
+    route: "login-method",
+    limit: MAX_ATTEMPTS,
+    windowMs: WINDOW_MS,
+  })
+  if (!limit.allowed) {
+    audit("auth.login_method.rejected.rate_limited")
+    return Response.json({ method: "password" })
+  }
+
+  const { email } = await parseLoginMethodRequest(request)
+  if (!email) {
+    audit("auth.login_method.password")
+    return Response.json({ method: "password" })
+  }
+
+  const enabledProviders = enabledProviderIds()
+  const user = await prisma.user.findFirst({
+    where: { email },
+    select: {
+      accounts: {
+        select: { providerId: true },
+      },
+    },
+  })
+
+  const accountProviders =
+    user?.accounts
+      .map((account) => account.providerId)
+      .filter(isLoginProviderId)
+      .filter((providerId) => enabledProviders.has(providerId)) ?? []
+  const provider = providerPriority.find((providerId) =>
+    accountProviders.includes(providerId),
+  )
+
+  if (provider) {
+    audit("auth.login_method.provider", email)
+    return Response.json({ method: "provider", provider })
+  }
+
+  audit("auth.login_method.password", email)
+  return Response.json({ method: "password" })
+}
+
+async function handleEmailSignUp(request: Request): Promise<Response> {
+  const limit = await rateLimitAuthRoute({
+    request,
+    route: "sign-up/email",
+    limit: MAX_ATTEMPTS,
+    windowMs: WINDOW_MS,
+  })
+  if (!limit.allowed) {
+    audit("auth.signup.rejected.rate_limited")
+    return Response.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const { email } = await parseLoginMethodRequest(request)
+  if (!email) {
+    audit("auth.signup.rejected.public")
+    return Response.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const existingUser = await prisma.user.findFirst({
+    where: { email },
+    select: { id: true },
+  })
+  if (existingUser) {
+    audit("auth.signup.rejected.existing_account", email)
+    return existingAccountSignUpResponse()
+  }
+
+  if (await firebaseUserExistsByEmail(email)) {
+    audit("auth.signup.rejected.legacy_firebase_account", email)
+    return existingAccountSignUpResponse()
+  }
+
+  audit("auth.signup.rejected.public", email)
+  return Response.json({ error: "Not found" }, { status: 404 })
 }
 
 function redirectFormPostAfterSignIn(
@@ -400,12 +540,14 @@ export async function POST(
   if (path === "sign-in/email") {
     return handleEmailSignIn(request)
   }
+  if (path === "login-method") {
+    return handleLoginMethod(request)
+  }
   if (path === "sign-in/social") {
     return handleSocialSignIn(request)
   }
   if (path === "sign-up/email") {
-    audit("auth.signup.rejected.public")
-    return Response.json({ error: "Not found" }, { status: 404 })
+    return handleEmailSignUp(request)
   }
   return authRouteHandlers.POST(request)
 }

--- a/apps/auth/src/app/login/login-page-client.tsx
+++ b/apps/auth/src/app/login/login-page-client.tsx
@@ -2,20 +2,18 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import { useState, useSyncExternalStore, type FormEvent } from "react"
+import type { Route } from "next"
+import { useRef, useState, useSyncExternalStore, type FormEvent } from "react"
+import {
+  providerLabels,
+  type LoginMethodId,
+  type LoginProviderId,
+} from "@/auth/login-methods"
 import { WatchFilmCollageBackground } from "./watch-film-collage-background"
 
-const providerLabels = {
-  google: "Google",
-  facebook: "Facebook",
-  apple: "Apple",
-  okta: "Okta",
-} as const
-
-export type LoginProviderId = keyof typeof providerLabels
 export type LoginErrorCode = "account_not_linked" | "credentials" | "forbidden"
 
-type LoginMethodId = LoginProviderId | "email"
+type LoginStep = "email" | "password"
 
 const providerIds = Object.keys(providerLabels) as LoginProviderId[]
 const lastLoginMethodCookieName = "forge_auth_last_login_method"
@@ -50,8 +48,12 @@ export function LoginPageClient({
   requestingAppName?: string | null
 }) {
   const [error, setError] = useState<
-    LoginErrorCode | "credentials" | "start" | null
+    LoginErrorCode | "credentials" | "lookup" | "start" | null
   >(initialError ?? null)
+  const [email, setEmail] = useState("")
+  const [step, setStep] = useState<LoginStep>("email")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const formRef = useRef<HTMLFormElement>(null)
   const lastLoginMethod = useSyncExternalStore(
     subscribeToCookieSnapshot,
     readLastLoginMethod,
@@ -69,14 +71,58 @@ export function LoginPageClient({
             title: "Provider login did not start.",
             detail: "Refresh the page and try again.",
           }
-        : error
-          ? loginErrors[error]
-          : null
+        : error === "lookup"
+          ? {
+              title: "We could not check that email.",
+              detail: "Refresh the page and try again.",
+            }
+          : error
+            ? loginErrors[error]
+            : null
 
-  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    if (step === "password") {
+      return
+    }
+
     e.preventDefault()
     setError(null)
-    e.currentTarget.submit()
+    setIsSubmitting(true)
+
+    try {
+      const res = await fetch("/api/auth/login-method", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email,
+          oauth_query: oauthQuery,
+        }),
+      })
+
+      if (!res.ok) {
+        setError("lookup")
+        return
+      }
+
+      const data = (await res.json()) as
+        | { method: "password" }
+        | { method: "provider"; provider: LoginProviderId }
+
+      if (data.method === "provider") {
+        await startSocialSignIn(data.provider)
+        return
+      }
+
+      setStep("password")
+      window.requestAnimationFrame(() => {
+        formRef.current?.querySelector<HTMLInputElement>("#password")?.focus()
+      })
+    } catch {
+      setError("lookup")
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   async function resolveSocialRedirect(
@@ -96,6 +142,29 @@ export function LoginPageClient({
     }
 
     return res.redirected && res.url ? res.url : undefined
+  }
+
+  async function startSocialSignIn(providerId: LoginProviderId) {
+    try {
+      const res = await fetch("/api/auth/sign-in/social", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          oauth_query: oauthQuery,
+          provider: providerId,
+        }),
+      })
+      const redirectUrl = await resolveSocialRedirect(res)
+      if (redirectUrl) {
+        window.location.href = redirectUrl
+        return
+      }
+
+      setError("start")
+    } catch {
+      setError("start")
+    }
   }
 
   return (
@@ -163,25 +232,7 @@ export function LoginPageClient({
                     className="relative flex h-[46px] w-full cursor-pointer items-center justify-start gap-3 rounded border border-white/10 bg-transparent px-4 text-left font-medium leading-none text-[#f5f5f4] transition-[background-color,border-color,box-shadow] duration-150 hover:border-white/25 hover:bg-white/[0.04] hover:shadow-[0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:border-[#ef3340] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(239,51,64,0.18)] disabled:cursor-not-allowed disabled:border-white/5 disabled:text-[#78716c] disabled:opacity-70"
                     disabled={!enabled}
                     type="button"
-                    onClick={async () => {
-                      try {
-                        const res = await fetch("/api/auth/sign-in/social", {
-                          method: "POST",
-                          credentials: "include",
-                          headers: { "content-type": "application/json" },
-                          body: JSON.stringify({
-                            oauth_query: oauthQuery,
-                            provider: providerId,
-                          }),
-                        })
-                        const redirectUrl = await resolveSocialRedirect(res)
-                        if (redirectUrl) {
-                          window.location.href = redirectUrl
-                        }
-                      } catch {
-                        setError("start")
-                      }
-                    }}
+                    onClick={() => void startSocialSignIn(providerId)}
                   >
                     <span className="flex size-5 shrink-0 items-center justify-center leading-none">
                       <ProviderLogo providerId={providerId} />
@@ -202,6 +253,7 @@ export function LoginPageClient({
             </div>
 
             <form
+              ref={formRef}
               action="/api/auth/sign-in/email"
               method="post"
               onSubmit={handleSubmit}
@@ -219,27 +271,34 @@ export function LoginPageClient({
                   name="email"
                   type="email"
                   autoComplete="email"
+                  value={email}
+                  onChange={(event) => {
+                    setEmail(event.target.value)
+                    if (step === "password") setStep("email")
+                  }}
                   className="h-[42px] w-full rounded border border-white/10 bg-transparent px-3 text-[#f5f5f4] outline-none focus:border-[#ef3340] focus:shadow-[0_0_0_3px_rgba(239,51,64,0.12)]"
                   required
                 />
               </div>
 
-              <div className="mt-4 grid gap-1.5">
-                <label
-                  className="text-[11px] font-bold uppercase tracking-[0.08em] text-[#d6d3d1]"
-                  htmlFor="password"
-                >
-                  Password
-                </label>
-                <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  autoComplete="current-password"
-                  className="h-[42px] w-full rounded border border-white/10 bg-transparent px-3 text-[#f5f5f4] outline-none focus:border-[#ef3340] focus:shadow-[0_0_0_3px_rgba(239,51,64,0.12)]"
-                  required
-                />
-              </div>
+              {step === "password" ? (
+                <div className="mt-4 grid gap-1.5">
+                  <label
+                    className="text-[11px] font-bold uppercase tracking-[0.08em] text-[#d6d3d1]"
+                    htmlFor="password"
+                  >
+                    Password
+                  </label>
+                  <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    className="h-[42px] w-full rounded border border-white/10 bg-transparent px-3 text-[#f5f5f4] outline-none focus:border-[#ef3340] focus:shadow-[0_0_0_3px_rgba(239,51,64,0.12)]"
+                    required
+                  />
+                </div>
+              ) : null}
 
               {alert ? (
                 <div
@@ -257,9 +316,10 @@ export function LoginPageClient({
 
               <button
                 className="relative mt-5 inline-flex h-[42px] w-full cursor-pointer items-center justify-center gap-2.5 rounded border-0 bg-[#ef3340] font-bold text-white transition-[background-color,box-shadow] duration-150 hover:bg-[#d91f2b] hover:shadow-[0_10px_26px_rgba(239,51,64,0.22)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(239,51,64,0.24)] disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={isSubmitting}
                 type="submit"
               >
-                <span>Continue</span>
+                <span>{step === "password" ? "Log in" : "Continue"}</span>
                 {lastLoginMethod === "email" ? <LastUsedBadge /> : null}
               </button>
             </form>
@@ -270,7 +330,11 @@ export function LoginPageClient({
                 : "Don't have an account?"}{" "}
               <Link
                 className="font-apercu font-bold text-[#f5f5f4] underline decoration-white/25 underline-offset-4 transition-colors duration-150 hover:decoration-white"
-                href={`${flow === "signup" ? "/login" : "/signup"}?${oauthQuery}`}
+                href={
+                  `${
+                    flow === "signup" ? "/login" : "/signup"
+                  }?${oauthQuery}` as Route
+                }
               >
                 {flow === "signup" ? "Log in" : "Sign up"}
               </Link>

--- a/apps/auth/src/app/login/login-page-data.ts
+++ b/apps/auth/src/app/login/login-page-data.ts
@@ -1,10 +1,8 @@
 import { env } from "@/config/env"
 import { prisma } from "@/db/client"
 
-import type {
-  LoginErrorCode,
-  LoginProviderId,
-} from "@/app/login/login-page-client"
+import type { LoginErrorCode } from "@/app/login/login-page-client"
+import type { LoginProviderId } from "@/auth/login-methods"
 
 export type LoginSearchParams = Record<string, string | string[] | undefined>
 

--- a/apps/auth/src/app/login/page.ui.test.tsx
+++ b/apps/auth/src/app/login/page.ui.test.tsx
@@ -22,6 +22,8 @@ describe("auth login UI", () => {
     expect(html).toContain("This login method is not linked yet.")
     expect(html).toContain("Log in with the method you used before")
     expect(html).toContain("Continue with Google")
+    expect(html).toContain("Email address")
+    expect(html).not.toContain("Password")
     expect(html).toContain(
       'name="oauth_query" value="client_id=jfp_admin_local&amp;sig=signed"',
     )
@@ -70,9 +72,9 @@ describe("auth login UI", () => {
       html.indexOf("OR"),
     )
     expect(html.indexOf("OR")).toBeLessThan(html.indexOf("Email address"))
-    expect(html.indexOf("Email address")).toBeLessThan(html.indexOf("Password"))
-    expect(html).toContain('name="password"')
-    expect(html).toContain('autoComplete="current-password"')
+    expect(html).not.toContain("Password")
+    expect(html).not.toContain('name="password"')
+    expect(html).not.toContain('autoComplete="current-password"')
   })
 
   it("identifies OAuth authorize requests as the only valid login entry", () => {

--- a/apps/auth/src/auth/firebase-admin.ts
+++ b/apps/auth/src/auth/firebase-admin.ts
@@ -44,3 +44,19 @@ export async function verifyFirebaseIdToken(
     return null
   }
 }
+
+export async function firebaseUserExistsByEmail(
+  email: string,
+): Promise<boolean> {
+  const auth = getFirebaseAdminAuth()
+  if (!auth) {
+    return false
+  }
+
+  try {
+    await auth.getUserByEmail(email)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/auth/src/auth/login-methods.ts
+++ b/apps/auth/src/auth/login-methods.ts
@@ -1,0 +1,18 @@
+export const providerLabels = {
+  google: "Google",
+  facebook: "Facebook",
+  apple: "Apple",
+  okta: "Okta",
+} as const
+
+export type LoginProviderId = keyof typeof providerLabels
+export type LoginMethodId = LoginProviderId | "email"
+
+export function isLoginProviderId(value: string): value is LoginProviderId {
+  return (
+    value === "facebook" ||
+    value === "google" ||
+    value === "apple" ||
+    value === "okta"
+  )
+}

--- a/docs/solutions/auth/email-first-provider-routing-before-password-20260526.md
+++ b/docs/solutions/auth/email-first-provider-routing-before-password-20260526.md
@@ -1,0 +1,61 @@
+---
+title: "Email-first Auth login should route provider accounts before showing password"
+category: auth
+date: 2026-05-26
+tags:
+  - auth
+  - login
+  - oauth
+  - better-auth
+  - firebase
+problem_type: best_practice
+component: authentication
+module: apps/auth
+severity: medium
+last_updated: 2026-05-26
+---
+
+## Context
+
+Auth login supports both email/password and upstream OAuth providers. Showing the
+password field immediately invites users with Google, Facebook, Apple, or Okta
+accounts to try a password that may not exist for their Auth account.
+
+## Guidance
+
+Keep login email-first. After the user enters an email, ask Auth which configured
+method should handle that address:
+
+- If the account has a configured OAuth provider account, continue through the
+  existing provider sign-in endpoint with the original OAuth authorize query.
+- If the account has only password-compatible account records, no account, or an
+  unconfigured provider, reveal the password field.
+- Keep Firebase lazy migration on the password path. A migrated Firebase account
+  may have a `firebase` account record, but that is not an upstream button and
+  should not prevent password fallback.
+- Signup may use legacy Firebase as an existence check, but it should return the
+  same generic existing-account message as Auth-owned users. Do not migrate a
+  Firebase account or reveal provider details during signup.
+- Rate-limit the lookup endpoint and return the password path when throttled so
+  provider probing cannot cheaply enumerate sign-in methods.
+- Log only hashed email identifiers, matching the rest of Auth's sign-in audit
+  posture.
+
+## Why This Matters
+
+The provider lookup and the final sign-in must stay separate. The lookup is a
+UX routing hint; the existing Better Auth provider or email endpoints still own
+the actual authentication, OAuth continuation, session cookies, and Firebase
+migration behavior.
+
+## When To Apply
+
+Use this pattern for Auth login UI changes that need to route a user between
+password and upstream SSO based on their email address.
+
+## Related
+
+- `apps/auth/src/app/api/auth/[...all]/route.ts`
+- `apps/auth/src/app/login/login-page-client.tsx`
+- `apps/auth/src/auth/login-methods.ts`
+- `apps/auth/src/auth/firebase-rest.ts`


### PR DESCRIPTION
## Summary
- Adds an email-first Auth login-method probe so provider-backed accounts continue through their configured OAuth provider before password is shown.
- Keeps password sign-in and Firebase lazy migration on the existing verified-password path.
- Returns a generic existing-account signup response for Auth and legacy Firebase emails while keeping public signup blocked.
- Documents the email-first provider-routing pattern in `docs/solutions/auth`.

## Validation
- `pnpm --filter @forge/auth test`
- `pnpm --filter @forge/auth typecheck`
- `pnpm --filter @forge/auth lint`
- `pnpm --filter @forge/auth build` (passes with the existing Turbopack NFT tracing warning around Prisma/Next config)

🤖 Generated with Compound Engineering