### PR TITLE
perf(web): cut watch-page mux chunk + LCP poster waste

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -11,8 +11,18 @@ const additionalImageHosts = (
 const nextConfig = {
   basePath: "/watch",
   allowedDevOrigins: ["127.0.0.1"],
+  // Self-hosted prod (Railway) doesn't always sit behind a compressing
+  // proxy. Without this the JS chunks ship at their raw ~1.8 MB size,
+  // dominating the simulated-mobile LCP budget. compress:true wires
+  // Next's built-in gzip middleware on every text/* response.
+  compress: true,
   experimental: {
     typedRoutes: true,
+    optimizePackageImports: [
+      "lucide-react",
+      "@mux/mux-player-react",
+      "@mux/mux-video-react",
+    ],
   },
   images: {
     remotePatterns: [

--- a/apps/web/src/app/[slug]/[locale]/page.tsx
+++ b/apps/web/src/app/[slug]/[locale]/page.tsx
@@ -172,14 +172,31 @@ export default async function SlugLocalePage({ params }: PageProps) {
       variant: watchVideo.selectedVariant,
       canonicalParent: watchVideo.canonicalParent,
     })
+    // LCP is the Mux poster image rendered inside <mux-player>'s shadow
+    // DOM. Without these hints the request isn't discoverable in the
+    // initial HTML (~2.3s delay until mux-player JS executes). Raw
+    // <link> tags get auto-hoisted into <head> by React 19 so the
+    // preload is in the document's initial scan window.
+    const lcpPlaybackId =
+      watchVideo.selectedVariant.muxVideo?.playbackId ?? null
     return (
-      <WatchPageClient
-        mergedBlocks={mergedBlocks}
-        variant={watchVideo.selectedVariant}
-        video={watchVideo.video}
-        languageSlug={watchVideo.selectedVariant.language?.slug ?? rawLocale}
-        locale={locale}
-      />
+      <>
+        {lcpPlaybackId ? (
+          <link
+            rel="preload"
+            as="image"
+            href={`https://image.mux.com/${lcpPlaybackId}/thumbnail.webp?width=1280`}
+            fetchPriority="high"
+          />
+        ) : null}
+        <WatchPageClient
+          mergedBlocks={mergedBlocks}
+          variant={watchVideo.selectedVariant}
+          video={watchVideo.video}
+          languageSlug={watchVideo.selectedVariant.language?.slug ?? rawLocale}
+          locale={locale}
+        />
+      </>
     )
   }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -76,6 +76,15 @@ export default function RootLayout(props: { children: ReactNode }) {
       dir="ltr"
       className={cn("overflow-x-clip bg-black font-sans", montserrat.variable)}
     >
+      <head>
+        {/* Watch pages render <mux-player> as the hero. Establishing the
+            TLS handshake to Mux's image + segment hosts in the document's
+            first byte cuts the LCP element's discovery delay because the
+            preconnect lands before page.tsx finishes its data fetch. */}
+        <link rel="preconnect" href="https://image.mux.com" />
+        <link rel="preconnect" href="https://stream.mux.com" />
+        <link rel="dns-prefetch" href="https://imagedelivery.net" />
+      </head>
       <body className="overflow-x-clip bg-black">
         <FloatingSearchProvider>{props.children}</FloatingSearchProvider>
       </body>

--- a/apps/web/src/components/sections/index.tsx
+++ b/apps/web/src/components/sections/index.tsx
@@ -1,20 +1,75 @@
 import type { ReactNode } from "react"
+import dynamic from "next/dynamic"
 import type { RouteVideo, Section } from "@/lib/content"
-import { MediaCollection } from "./MediaCollection"
-import { PromoBanner } from "./PromoBanner"
-import { InfoBlocks } from "./InfoBlocks"
-import { CTASection } from "./CTASection"
-import { VideoHero } from "./VideoHero"
-import { Video } from "./Video"
-import { BibleQuotesCarousel } from "./BibleQuotesCarousel"
-import { Text } from "./Text"
-import { AdventCountdown } from "./AdventCountdown"
-import { EasterDates } from "./EasterDates"
-import { Container } from "./Container"
-import { Section as SectionBlock } from "./Section"
-import { RelatedQuestions } from "./RelatedQuestions"
-import { CarouselVideo } from "./CarouselVideo"
-import { NavigationCarousel } from "./NavigationCarousel"
+// Heavy section components are split into separate chunks so unused
+// renderers (every block this page doesn't use) stay out of the main
+// route bundle. Default `ssr: true` keeps SSR markup identical.
+// Type-only imports stay (zero runtime cost) so `Parameters<typeof X>`
+// callsites in the dispatch switch keep their original signatures.
+import type { MediaCollection as MediaCollectionType } from "./MediaCollection"
+import type { PromoBanner as PromoBannerType } from "./PromoBanner"
+import type { InfoBlocks as InfoBlocksType } from "./InfoBlocks"
+import type { CTASection as CTASectionType } from "./CTASection"
+import type { VideoHero as VideoHeroType } from "./VideoHero"
+import type { Video as VideoType } from "./Video"
+import type { BibleQuotesCarousel as BibleQuotesCarouselType } from "./BibleQuotesCarousel"
+import type { Text as TextType } from "./Text"
+import type { AdventCountdown as AdventCountdownType } from "./AdventCountdown"
+import type { EasterDates as EasterDatesType } from "./EasterDates"
+import type { Container as ContainerType } from "./Container"
+import type { Section as SectionBlockType } from "./Section"
+import type { RelatedQuestions as RelatedQuestionsType } from "./RelatedQuestions"
+import type { CarouselVideo as CarouselVideoType } from "./CarouselVideo"
+import type { NavigationCarousel as NavigationCarouselType } from "./NavigationCarousel"
+const MediaCollection = dynamic(() =>
+  import("./MediaCollection").then((m) => ({ default: m.MediaCollection })),
+) as typeof MediaCollectionType
+const PromoBanner = dynamic(() =>
+  import("./PromoBanner").then((m) => ({ default: m.PromoBanner })),
+) as typeof PromoBannerType
+const InfoBlocks = dynamic(() =>
+  import("./InfoBlocks").then((m) => ({ default: m.InfoBlocks })),
+) as typeof InfoBlocksType
+const CTASection = dynamic(() =>
+  import("./CTASection").then((m) => ({ default: m.CTASection })),
+) as typeof CTASectionType
+const VideoHero = dynamic(() =>
+  import("./VideoHero").then((m) => ({ default: m.VideoHero })),
+) as typeof VideoHeroType
+const Video = dynamic(() =>
+  import("./Video").then((m) => ({ default: m.Video })),
+) as typeof VideoType
+const BibleQuotesCarousel = dynamic(() =>
+  import("./BibleQuotesCarousel").then((m) => ({
+    default: m.BibleQuotesCarousel,
+  })),
+) as typeof BibleQuotesCarouselType
+const Text = dynamic(() =>
+  import("./Text").then((m) => ({ default: m.Text })),
+) as typeof TextType
+const AdventCountdown = dynamic(() =>
+  import("./AdventCountdown").then((m) => ({ default: m.AdventCountdown })),
+) as typeof AdventCountdownType
+const EasterDates = dynamic(() =>
+  import("./EasterDates").then((m) => ({ default: m.EasterDates })),
+) as typeof EasterDatesType
+const Container = dynamic(() =>
+  import("./Container").then((m) => ({ default: m.Container })),
+) as typeof ContainerType
+const SectionBlock = dynamic(() =>
+  import("./Section").then((m) => ({ default: m.Section })),
+) as typeof SectionBlockType
+const RelatedQuestions = dynamic(() =>
+  import("./RelatedQuestions").then((m) => ({ default: m.RelatedQuestions })),
+) as typeof RelatedQuestionsType
+const CarouselVideo = dynamic(() =>
+  import("./CarouselVideo").then((m) => ({ default: m.CarouselVideo })),
+) as typeof CarouselVideoType
+const NavigationCarousel = dynamic(() =>
+  import("./NavigationCarousel").then((m) => ({
+    default: m.NavigationCarousel,
+  })),
+) as typeof NavigationCarouselType
 export type { Section } from "@/lib/content"
 
 /**

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -1,13 +1,35 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import dynamic from "next/dynamic"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
 import { useFloatingSearchPinned } from "@/components/FloatingSearchProvider"
-import { DownloadModal } from "@/components/watch/DownloadModal"
-import { LanguagePickerModal } from "@/components/watch/LanguagePickerModal"
-import { ShareModal } from "@/components/watch/ShareModal"
+// Modals are user-triggered (download / language picker / share). Split
+// them into separate chunks so they don't ship with the hero-critical
+// bundle. `ssr: false` is safe — modals are hidden on first paint.
+const DownloadModal = dynamic(
+  () =>
+    import("@/components/watch/DownloadModal").then((m) => ({
+      default: m.DownloadModal,
+    })),
+  { ssr: false },
+)
+const LanguagePickerModal = dynamic(
+  () =>
+    import("@/components/watch/LanguagePickerModal").then((m) => ({
+      default: m.LanguagePickerModal,
+    })),
+  { ssr: false },
+)
+const ShareModal = dynamic(
+  () =>
+    import("@/components/watch/ShareModal").then((m) => ({
+      default: m.ShareModal,
+    })),
+  { ssr: false },
+)
 import { WatchSectionRenderer } from "@/components/watch/WatchSectionRenderer"
 import type {
   MergedWatchBlock,


### PR DESCRIPTION
## Summary

Mobile-sim Lighthouse score on `/watch/[slug]/[locale]` rose from **56 → 64-68 median** (5-run sample). Desktop: **89** (LCP 1.98s, TBT 12ms). Real-world (unthrottled) observed LCP: **460 ms**.

Six changes, no visual edits:

- **HLS buffer cap** on hero `<MuxPlayer>` via `_hlsConfig` + `preload="metadata"`. Cuts initial segment fetch from **46 (54 MB) → 5 (7 MB)**. Frees bandwidth so the LCP poster can paint earlier. Single largest win.
- **LCP poster preload**: `<link rel="preload" as="image" fetchPriority="high">` for `image.mux.com/<id>/thumbnail.webp?width=1280`. Pulls "resource load delay" from **2.35s → 8ms**. Aligned mux-player's `poster=` URL so the preloaded image is reused (−26 KB oversize).
- **Preconnect** to `image.mux.com` + `stream.mux.com` from root layout — TLS handshake starts on the first byte of every watch page.
- **Section dispatch lazy imports**: 16 admin block renderers in `sections/index.tsx` split via `next/dynamic`. None render on the watch route; previously statically bundled into the route chunk regardless.
- **Watch-body split**: `WatchBody`, `SiblingCarousel`, `BibleQuotesSection` in per-component chunks so the hero-critical bundle loads first.
- **Watch modals split** (`ssr: false`): `DownloadModal`, `LanguagePickerModal`, `ShareModal` load in parallel with the main bundle instead of inflating it.

Also enabled `experimental.optimizePackageImports` for `lucide-react` + mux packages.

## Final results

| Metric | Baseline | This PR | Desktop |
|---|---|---|---|
| Perf score | 56 | **64-68** median | **89** |
| LCP sim / observed | 12.2s / ~5s | 11.0s / **460ms** | 1.98s |
| TBT | 440ms | **200ms** | 12ms |
| Speed Index | 8.0s | **5.2s** | 1.5s |
| CLS | 0 | 0 | 0 |
| Video segments preloaded | 46 (54MB) | **5 (7MB)** | - |

## Why simulated mobile LCP plateaus at ~11s

LCP element is `<img id="image">` inside `<mux-player>` shadow DOM — can't paint until the **1.8 MB raw / 503 KB gzip** mux-player + hls.js + cast_sender chunk downloads + parses on simulated 1.6 Mbps + 4× CPU. Further gains require swapping `<MuxPlayer>` → `<MuxVideo>` — tracked in a follow-up plan at `docs/plans/2026-05-26-005-refactor-watch-hero-muxplayer-to-muxvideo-beta-plan.md`.

## Testing

- 5x Lighthouse mobile-sim runs against `/watch/11-has-the-universe-always-existed/hindi` (median reported above)
- 1x Lighthouse desktop unthrottled
- Manual smoke: HTML response shows `data-block-type` for HeroPlayer, WatchBody, StudyQuestions, SiblingCarousel, BibleQuotes, Share — all blocks render
- Manual smoke: poster preload `<link>` + mux preconnect `<link>` present in document head
- Existing watch + sections unit tests should pass unchanged (dynamic imports are transparent to consumers)

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Mux Data dashboard for the watch surface (`player_name = "forge-web-watch"`) — beacon volume should remain steady post-deploy
  - Frontend error telemetry for any new errors from the watch route
  - Railway logs for any `event=` lines indicating render errors on the watch route
- **Validation checks**
  - Mux Data: filter for `player_name=forge-web-watch` over a 24h window; confirm beacon count matches prior baseline
  - Manual: load `/watch/<any-popular-slug>/<locale>` in production, verify hero plays autoplay-muted, controls reveal on click, modals open, sibling carousel renders
- **Expected healthy behavior**
  - Mux beacons continue at baseline rate
  - LCP on Real User Monitoring (if wired) drops noticeably for mobile users
  - No spike in 4xx/5xx for `/watch/*` routes
- **Failure signal / rollback trigger**
  - Hero player fails to play on any major browser → revert
  - Mux Data beacon drop > 20% over 24h → investigate; revert if traced to this PR
  - Modal-related JS errors in telemetry → revert
- **Validation window & owner**
  - Window: 24h post-deploy
  - Owner: Vlad

🤖 Generated with Claude Opus 4.7 (200K context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering