### PR TITLE
Fix auth login busy and password retry state

### DIFF
--- a/apps/auth/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.test.ts
@@ -348,7 +348,7 @@ describe("Auth route wrapper", () => {
 
     expect(response.status).toBe(303)
     expect(response.headers.get("location")).toBe(
-      "http://localhost:3004/login?client_id=jfp_admin_local&sig=signed&error=credentials",
+      "http://localhost:3004/login?client_id=jfp_admin_local&sig=signed&error=credentials&email=user%40example.com",
     )
     expect(response.headers.get("set-cookie") ?? "").not.toContain(
       "forge_auth_last_login_method",

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -192,9 +192,11 @@ function oauthQueryFromLoginReferer(request: Request): string | undefined {
 }
 
 function rejectEmailSignIn({
+  email,
   isFormPost,
   oauthQuery,
 }: {
+  email?: string
   isFormPost: boolean
   oauthQuery?: string
 }): Response {
@@ -203,6 +205,7 @@ function rejectEmailSignIn({
   const url = new URL("/login", getAuthBaseUrl())
   if (oauthQuery) url.search = oauthQuery
   url.searchParams.set("error", "credentials")
+  if (email) url.searchParams.set("email", email)
   return Response.redirect(url, 303)
 }
 
@@ -396,7 +399,7 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
 
   if (!email || !password) {
     audit("auth.signin.rejected", email)
-    return rejectEmailSignIn({ isFormPost, oauthQuery })
+    return rejectEmailSignIn({ email, isFormPost, oauthQuery })
   }
   const callbackURL = buildOAuthContinuationURL(oauthQuery)
 
@@ -427,20 +430,20 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
   if (existingUser) {
     audit("auth.signin.rejected", email)
     return isFormPost
-      ? rejectEmailSignIn({ isFormPost, oauthQuery })
+      ? rejectEmailSignIn({ email, isFormPost, oauthQuery })
       : primaryResponse
   }
 
   const firebaseSignIn = await signInWithFirebasePassword(email, password)
   if (!firebaseSignIn) {
     audit("auth.signin.rejected", email)
-    return rejectEmailSignIn({ isFormPost, oauthQuery })
+    return rejectEmailSignIn({ email, isFormPost, oauthQuery })
   }
 
   const verified = await verifyFirebaseIdToken(firebaseSignIn.idToken)
   if (!verified || verified.email.toLowerCase() !== email) {
     audit("auth.firebase.rejected.unverified", email)
-    return rejectEmailSignIn({ isFormPost, oauthQuery })
+    return rejectEmailSignIn({ email, isFormPost, oauthQuery })
   }
 
   const signUpResponse = await auth.api.signUpEmail({
@@ -456,7 +459,7 @@ async function handleEmailSignIn(request: Request): Promise<Response> {
 
   if (!signUpResponse.ok) {
     audit("auth.signin.rejected", email)
-    return rejectEmailSignIn({ isFormPost, oauthQuery })
+    return rejectEmailSignIn({ email, isFormPost, oauthQuery })
   }
 
   await prisma.$transaction(async (tx) => {

--- a/apps/auth/src/app/login/login-page-client.tsx
+++ b/apps/auth/src/app/login/login-page-client.tsx
@@ -37,12 +37,14 @@ const loginErrors = {
 export function LoginPageClient({
   enabledProviders,
   flow = "login",
+  initialEmail,
   initialError,
   oauthQuery,
   requestingAppName,
 }: {
   enabledProviders: LoginProviderId[]
   flow?: "login" | "signup"
+  initialEmail?: string
   initialError?: LoginErrorCode
   oauthQuery: string
   requestingAppName?: string | null
@@ -50,9 +52,13 @@ export function LoginPageClient({
   const [error, setError] = useState<
     LoginErrorCode | "credentials" | "lookup" | "start" | null
   >(initialError ?? null)
-  const [email, setEmail] = useState("")
-  const [step, setStep] = useState<LoginStep>("email")
+  const [email, setEmail] = useState(initialEmail ?? "")
+  const [step, setStep] = useState<LoginStep>(
+    initialEmail && initialError === "credentials" ? "password" : "email",
+  )
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isRedirecting, setIsRedirecting] = useState(false)
+  const isRedirectingRef = useRef(false)
   const formRef = useRef<HTMLFormElement>(null)
   const lastLoginMethod = useSyncExternalStore(
     subscribeToCookieSnapshot,
@@ -79,6 +85,7 @@ export function LoginPageClient({
           : error
             ? loginErrors[error]
             : null
+  const isBusy = isSubmitting || isRedirecting
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     if (step === "password") {
@@ -110,7 +117,8 @@ export function LoginPageClient({
         | { method: "provider"; provider: LoginProviderId }
 
       if (data.method === "provider") {
-        await startSocialSignIn(data.provider)
+        const started = await startSocialSignIn(data.provider)
+        if (started) return
         return
       }
 
@@ -121,7 +129,7 @@ export function LoginPageClient({
     } catch {
       setError("lookup")
     } finally {
-      setIsSubmitting(false)
+      if (!isRedirectingRef.current) setIsSubmitting(false)
     }
   }
 
@@ -145,6 +153,7 @@ export function LoginPageClient({
   }
 
   async function startSocialSignIn(providerId: LoginProviderId) {
+    setIsSubmitting(true)
     try {
       const res = await fetch("/api/auth/sign-in/social", {
         method: "POST",
@@ -157,14 +166,20 @@ export function LoginPageClient({
       })
       const redirectUrl = await resolveSocialRedirect(res)
       if (redirectUrl) {
+        isRedirectingRef.current = true
+        setIsRedirecting(true)
         window.location.href = redirectUrl
-        return
+        return true
       }
 
       setError("start")
     } catch {
       setError("start")
     }
+    isRedirectingRef.current = false
+    setIsRedirecting(false)
+    setIsSubmitting(false)
+    return false
   }
 
   return (
@@ -230,7 +245,7 @@ export function LoginPageClient({
                   <button
                     key={providerId}
                     className="relative flex h-[46px] w-full cursor-pointer items-center justify-start gap-3 rounded border border-white/10 bg-transparent px-4 text-left font-medium leading-none text-[#f5f5f4] transition-[background-color,border-color,box-shadow] duration-150 hover:border-white/25 hover:bg-white/[0.04] hover:shadow-[0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:border-[#ef3340] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(239,51,64,0.18)] disabled:cursor-not-allowed disabled:border-white/5 disabled:text-[#78716c] disabled:opacity-70"
-                    disabled={!enabled}
+                    disabled={!enabled || isBusy}
                     type="button"
                     onClick={() => void startSocialSignIn(providerId)}
                   >
@@ -316,10 +331,18 @@ export function LoginPageClient({
 
               <button
                 className="relative mt-5 inline-flex h-[42px] w-full cursor-pointer items-center justify-center gap-2.5 rounded border-0 bg-[#ef3340] font-bold text-white transition-[background-color,box-shadow] duration-150 hover:bg-[#d91f2b] hover:shadow-[0_10px_26px_rgba(239,51,64,0.22)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(239,51,64,0.24)] disabled:cursor-not-allowed disabled:opacity-70"
-                disabled={isSubmitting}
+                disabled={isBusy}
                 type="submit"
               >
-                <span>{step === "password" ? "Log in" : "Continue"}</span>
+                <span className="min-w-0">
+                  {step === "password" ? "Log in" : "Continue"}
+                </span>
+                {isBusy ? (
+                  <span
+                    aria-hidden="true"
+                    className="absolute right-4 size-4 animate-spin rounded-full border-2 border-white/35 border-t-white"
+                  />
+                ) : null}
                 {lastLoginMethod === "email" ? <LastUsedBadge /> : null}
               </button>
             </form>

--- a/apps/auth/src/app/login/login-page-data.ts
+++ b/apps/auth/src/app/login/login-page-data.ts
@@ -29,7 +29,7 @@ export function parseLoginError(
 export function toOAuthQuery(params: LoginSearchParams) {
   const oauthQuery = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
-    if (key === "error") continue
+    if (key === "email" || key === "error") continue
     if (Array.isArray(value)) {
       for (const item of value) oauthQuery.append(key, item)
     } else if (value) {

--- a/apps/auth/src/app/login/page.tsx
+++ b/apps/auth/src/app/login/page.tsx
@@ -24,6 +24,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps = {}) {
     <LoginPageClient
       enabledProviders={getEnabledProviders()}
       flow="login"
+      initialEmail={firstParam(params.email)}
       initialError={parseLoginError(firstParam(params.error))}
       oauthQuery={toOAuthQuery(params)}
       requestingAppName={await resolveRequestingAppName(

--- a/apps/auth/src/app/login/page.ui.test.tsx
+++ b/apps/auth/src/app/login/page.ui.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it, vi } from "vitest"
 
 import { LoginPageClient } from "./login-page-client"
-import { isOAuthAuthorizeRequest } from "./login-page-data"
+import { isOAuthAuthorizeRequest, toOAuthQuery } from "./login-page-data"
 
 vi.mock("@/config/env", () => ({
   env: {},
@@ -41,6 +41,24 @@ describe("auth login UI", () => {
 
     expect(html).toContain("Invalid email or password.")
     expect(html).toContain("Check your email and password, then try again.")
+  })
+
+  it("keeps the email and password fields visible after invalid credentials", () => {
+    const html = renderToStaticMarkup(
+      <LoginPageClient
+        enabledProviders={[]}
+        initialEmail="user@example.com"
+        initialError="credentials"
+        oauthQuery="client_id=jfp_admin_local&sig=signed"
+        requestingAppName="Jesus Film Admin"
+      />,
+    )
+
+    expect(html).toContain('name="email"')
+    expect(html).toContain('value="user@example.com"')
+    expect(html).toContain("Password")
+    expect(html).toContain('name="password"')
+    expect(html).toContain('autoComplete="current-password"')
   })
 
   it("shows disabled provider buttons when provider keys are unavailable", () => {
@@ -85,6 +103,35 @@ describe("auth login UI", () => {
       }),
     ).toBe(true)
     expect(isOAuthAuthorizeRequest({ error: "forbidden" })).toBe(false)
+  })
+
+  it("does not carry login-only parameters into OAuth continuation links", () => {
+    expect(
+      toOAuthQuery({
+        client_id: "jfp_admin_local",
+        email: "user@example.com",
+        error: "credentials",
+        sig: "signed",
+      }),
+    ).toBe("client_id=jfp_admin_local&sig=signed")
+
+    const html = renderToStaticMarkup(
+      <LoginPageClient
+        enabledProviders={[]}
+        initialEmail="user@example.com"
+        initialError="credentials"
+        oauthQuery="client_id=jfp_admin_local&sig=signed"
+        requestingAppName="Jesus Film Admin"
+      />,
+    )
+
+    expect(html).toContain(
+      'name="oauth_query" value="client_id=jfp_admin_local&amp;sig=signed"',
+    )
+    expect(html).toContain(
+      'href="/signup?client_id=jfp_admin_local&amp;sig=signed"',
+    )
+    expect(html).not.toContain("email=user")
   })
 
   it("names Jesus Film One and the requesting application when provided", () => {


### PR DESCRIPTION
## Summary
- keep login buttons disabled once third-party provider redirect starts
- add a fixed-position busy spinner on the Continue button so the label does not shift
- preserve the attempted email and password step after invalid password failures, while keeping login-only params out of OAuth continuation links

## Validation
- pnpm --filter @forge/auth test -- src/app/api/auth/[...all]/route.test.ts src/app/login/page.ui.test.tsx
- pnpm --filter @forge/auth typecheck
- pnpm --filter @forge/auth lint
- pnpm --filter @forge/auth build

Note: build passes with the existing Turbopack NFT tracing warning around Prisma/next.config.ts.