### PR TITLE
Keep auth password submit loading

### DIFF
--- a/apps/auth/src/app/login/login-page-client.tsx
+++ b/apps/auth/src/app/login/login-page-client.tsx
@@ -89,6 +89,8 @@ export function LoginPageClient({
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     if (step === "password") {
+      setError(null)
+      setIsSubmitting(true)
       return
     }
 


### PR DESCRIPTION
## Summary
- keep the login button in its loading state during password form submission
- clear the previous error as the native Better Auth email sign-in form posts

## Validation
- pnpm --filter @forge/auth test -- src/app/login/page.ui.test.tsx
- pnpm --filter @forge/auth typecheck
- pnpm --filter @forge/auth lint
- pnpm --filter @forge/auth build

Note: build passes with the existing Turbopack NFT tracing warning around Prisma/next.config.ts.