### PR TITLE
feat(web): add subtitle transcript section to watch page

### DIFF
--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -36,12 +36,12 @@ function toSeconds(
 
 function decodeEntities(text: string): string {
   return text
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
 }
 
 /**

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -44,6 +44,35 @@ function decodeEntities(text: string): string {
     .replace(/&nbsp;/g, " ")
 }
 
+/**
+ * SMPTE-offset normalization. Broadcast-authored VTT files often start at
+ * 01:00:00 (the first hour reserved for color bars / leader), so cues run
+ * 01:HH:MM:SS instead of 00:HH:MM:SS. The video file itself plays from
+ * 0:00, so the raw cues never line up with `currentTime`. Detect by
+ * comparing the last cue's end against the variant duration with a 60s
+ * grace; shift by the largest whole-hour offset that brings cues back
+ * inside duration. No-op when duration is unknown.
+ */
+export function normalizeCueOffset(
+  cues: Cue[],
+  durationSeconds: number | null | undefined,
+): Cue[] {
+  if (cues.length === 0) return cues
+  if (!durationSeconds || durationSeconds <= 0) return cues
+  const first = cues[0]!.start
+  const last = cues[cues.length - 1]!.end
+  if (last <= durationSeconds + 60) return cues
+  if (first < 3600) return cues
+  const offset = Math.floor(first / 3600) * 3600
+  const candidateLast = last - offset
+  if (candidateLast < 0 || candidateLast > durationSeconds + 60) return cues
+  return cues.map((c) => ({
+    start: c.start - offset,
+    end: c.end - offset,
+    text: c.text,
+  }))
+}
+
 export function parseVtt(raw: string): Cue[] {
   const cues: Cue[] = []
   const normalized = raw.replace(/\r\n?/g, "\n")
@@ -98,12 +127,20 @@ type SubtitleTranscriptProps = {
   subtitles: WatchSubtitle[]
   playerRef: RefObject<MuxPlayerRef | null>
   audioSlug?: string | null
+  /**
+   * Selected variant's duration in seconds. Used to detect and unwind
+   * SMPTE-style 1-hour authoring offsets in the VTT timing (see
+   * `normalizeCueOffset`). Optional — when omitted, cues render as
+   * authored.
+   */
+  durationSeconds?: number | null
 }
 
 export function SubtitleTranscript({
   subtitles,
   playerRef,
   audioSlug,
+  durationSeconds,
 }: SubtitleTranscriptProps) {
   const initialSlug = useMemo(
     () => pickInitialSubtitleSlug(subtitles, audioSlug ?? null),
@@ -162,14 +199,17 @@ export function SubtitleTranscript({
         return r.text()
       })
       .then((text) => {
-        setLoaded({ vttSrc: activeVttSrc, cues: parseVtt(text) })
+        setLoaded({
+          vttSrc: activeVttSrc,
+          cues: normalizeCueOffset(parseVtt(text), durationSeconds),
+        })
       })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return
         setLoaded({ vttSrc: activeVttSrc, cues: null })
       })
     return () => controller.abort()
-  }, [activeVttSrc])
+  }, [activeVttSrc, durationSeconds])
 
   useEffect(() => {
     const el = playerRef.current as HTMLMediaElement | null

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -362,7 +362,7 @@ export function SubtitleTranscript({
                       onClick={() => handleSeek(cue)}
                       aria-current={isActive ? "true" : undefined}
                       className={[
-                        "group flex w-full items-baseline gap-4 rounded-lg px-4 py-3 text-left transition-colors duration-150",
+                        "group flex w-full cursor-pointer items-baseline gap-4 rounded-lg px-4 py-3 text-left transition-colors duration-150",
                         "focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2",
                         isActive
                           ? "bg-white/10 text-stone-50"

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -34,14 +34,36 @@ function toSeconds(
   )
 }
 
+// Entity map. Single-pass replace so a literal `&amp;lt;` in source
+// decodes to `&lt;` (not `<`). Decoding `&amp;` last in a chained
+// `.replace()` would double-unescape that case — see CodeQL js/double-escaping.
+const HTML_ENTITY_MAP: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&nbsp;": " ",
+}
+const HTML_ENTITY_RE = /&(?:amp|lt|gt|quot|#39|nbsp);/g
+
 function decodeEntities(text: string): string {
-  return text
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
+  return text.replace(HTML_ENTITY_RE, (m) => HTML_ENTITY_MAP[m] ?? m)
+}
+
+// Strip VTT/HTML-ish tags. Iterate until the string stabilises so nested
+// or overlapping payloads (e.g. `<scr<script>ipt>`) can't survive a single
+// pass — see CodeQL js/incomplete-multi-character-sanitization. Output
+// still flows into a React text node, so the regex is defense-in-depth
+// over auto-escaped JSX rather than the primary safety boundary.
+function stripTags(text: string): string {
+  let prev = ""
+  let cur = text
+  while (cur !== prev) {
+    prev = cur
+    cur = cur.replace(/<[^>]*>/g, "")
+  }
+  return cur
 }
 
 /**
@@ -86,12 +108,7 @@ export function parseVtt(raw: string): Cue[] {
     const start = toSeconds(m[1], m[2]!, m[3]!, m[4]!)
     const end = toSeconds(m[5], m[6]!, m[7]!, m[8]!)
     const textLines = lines.slice(timingIdx + 1)
-    const text = decodeEntities(
-      textLines
-        .join(" ")
-        .replace(/<[^>]+>/g, "")
-        .trim(),
-    )
+    const text = decodeEntities(stripTags(textLines.join(" ")).trim())
     if (text) cues.push({ start, end, text })
   }
   return cues

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -4,7 +4,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type RefObject,
 } from "react"
@@ -16,16 +15,6 @@ import { WATCH_PAGE_CONTENT_CLASSES } from "@/lib/content-width"
 import { GLASS_OUTLINE_CLASS } from "@/lib/glass-outline"
 
 type Cue = { start: number; end: number; text: string }
-
-// Window after a programmatic scrollTo within which trailing scroll events
-// are treated as smooth-scroll settling rather than user interaction.
-// Smooth scrolls to far cues observed at ~700ms on desktop Chrome; 900ms
-// gives margin without leaving a noticeable lag before the "Follow
-// playback" pill can appear after a real user scroll.
-const AUTO_SCROLL_WINDOW_MS = 900
-// Tolerance in pixels: if scrollTop is still within this band of the last
-// auto target, treat as auto-scroll noise even after the time window.
-const AUTO_SCROLL_TOLERANCE_PX = 8
 
 const TIMING_RE =
   /(?:(\d+):)?(\d+):(\d+)[.,](\d+)\s*-->\s*(?:(\d+):)?(\d+):(\d+)[.,](\d+)/
@@ -143,21 +132,6 @@ export function SubtitleTranscript({
     cues: Cue[] | null
     idx: number
   }>({ cues: null, idx: -1 })
-  const [userScrolled, setUserScrolled] = useState(false)
-  const listRef = useRef<HTMLOListElement | null>(null)
-  const userScrolledRef = useRef(false)
-  // Programmatic auto-scrolls set BOTH refs (time + target scrollTop). The
-  // onScroll handler ignores any settling event whose timestamp falls inside
-  // the AUTO_SCROLL_WINDOW_MS budget OR whose scrollTop is within
-  // AUTO_SCROLL_TOLERANCE_PX of the most recent auto target. Either alone
-  // misclassifies: long smooth-scrolls outlast a tight window, and a real
-  // user scroll that briefly crosses the target tripled-touches the band.
-  const lastAutoScrollAtRef = useRef(0)
-  const lastAutoScrollTopRef = useRef(0)
-  const setUserScrolledBoth = useCallback((v: boolean) => {
-    userScrolledRef.current = v
-    setUserScrolled(v)
-  }, [])
 
   const activeVttSrc = activeSubtitle?.vttSrc ?? null
   const cues =
@@ -226,78 +200,18 @@ export function SubtitleTranscript({
     }
   }, [cues, playerRef])
 
-  useEffect(() => {
-    const list = listRef.current
-    if (!list) return
-    const onScroll = () => {
-      const now = Date.now()
-      const sinceAuto = now - lastAutoScrollAtRef.current
-      const delta = Math.abs(list.scrollTop - lastAutoScrollTopRef.current)
-      // Treat as auto-scroll settling if EITHER the time window is open
-      // OR scrollTop still tracks the last auto target within tolerance.
-      // A real user scroll fails both — outside the window AND off-target.
-      if (
-        sinceAuto < AUTO_SCROLL_WINDOW_MS ||
-        delta <= AUTO_SCROLL_TOLERANCE_PX
-      )
-        return
-      if (!userScrolledRef.current) {
-        userScrolledRef.current = true
-        setUserScrolled(true)
-      }
-    }
-    list.addEventListener("scroll", onScroll, { passive: true })
-    return () => list.removeEventListener("scroll", onScroll)
-  }, [cues])
-
-  const autoScrollToActive = useCallback(
-    (list: HTMLOListElement, li: HTMLElement) => {
-      const listRect = list.getBoundingClientRect()
-      const liRect = li.getBoundingClientRect()
-      const target =
-        list.scrollTop +
-        (liRect.top - listRect.top) -
-        list.clientHeight / 2 +
-        li.clientHeight / 2
-      lastAutoScrollAtRef.current = Date.now()
-      lastAutoScrollTopRef.current = target
-      list.scrollTo({ top: target, behavior: "smooth" })
-    },
-    [],
-  )
-
-  useEffect(() => {
-    if (activeIdx < 0) return
-    if (userScrolledRef.current) return
-    const list = listRef.current
-    if (!list) return
-    const li = list.children.item(activeIdx) as HTMLElement | null
-    if (!li) return
-    autoScrollToActive(list, li)
-  }, [activeIdx, autoScrollToActive])
-
   const handleSeek = useCallback(
     (cue: Cue) => {
       const el = playerRef.current as HTMLMediaElement | null
       if (!el) return
-      setUserScrolledBoth(false)
       el.currentTime = cue.start
       const result = el.play()
       if (result && typeof (result as Promise<void>).then === "function") {
         ;(result as Promise<void>).catch(() => {})
       }
     },
-    [playerRef, setUserScrolledBoth],
+    [playerRef],
   )
-
-  const handleResumeAutoscroll = useCallback(() => {
-    setUserScrolledBoth(false)
-    if (activeIdx < 0) return
-    const list = listRef.current
-    const li = list?.children.item(activeIdx) as HTMLElement | null
-    if (!list || !li) return
-    autoScrollToActive(list, li)
-  }, [activeIdx, autoScrollToActive, setUserScrolledBoth])
 
   if (subtitles.length === 0) return null
 
@@ -353,73 +267,59 @@ export function SubtitleTranscript({
             </div>
           </header>
 
-          <div className="relative">
-            {status === "loading" ? (
-              <div className="flex items-center justify-center px-8 py-16 text-sm text-stone-400">
-                Loading transcript…
-              </div>
-            ) : status === "error" ? (
-              <div className="px-8 py-16 text-center text-sm text-stone-400">
-                Transcript unavailable for this subtitle track.
-              </div>
-            ) : cues && cues.length > 0 ? (
-              <>
-                <ol
-                  ref={listRef}
-                  data-testid="watch-subtitle-cues"
-                  className="max-h-[60vh] overflow-y-auto px-2 py-3 sm:px-4 sm:py-4"
-                >
-                  {cues.map((cue, idx) => {
-                    const isActive = idx === activeIdx
-                    return (
-                      <li key={`${cue.start}-${idx}`}>
-                        <button
-                          type="button"
-                          onClick={() => handleSeek(cue)}
-                          aria-current={isActive ? "true" : undefined}
-                          className={[
-                            "group flex w-full items-baseline gap-4 rounded-lg px-4 py-3 text-left transition-colors duration-150",
-                            "focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2",
-                            isActive
-                              ? "bg-white/10 text-stone-50"
-                              : "text-stone-300 hover:bg-white/5 hover:text-stone-100",
-                          ].join(" ")}
-                        >
-                          <time
-                            dateTime={`PT${Math.floor(cue.start)}S`}
-                            className={[
-                              "shrink-0 font-mono text-xs tabular-nums tracking-tight transition-colors",
-                              isActive
-                                ? "text-amber-300"
-                                : "text-stone-500 group-hover:text-stone-300",
-                            ].join(" ")}
-                          >
-                            {formatTimestamp(cue.start)}
-                          </time>
-                          <span className="text-base leading-relaxed sm:text-lg">
-                            {cue.text}
-                          </span>
-                        </button>
-                      </li>
-                    )
-                  })}
-                </ol>
-                {userScrolled && activeIdx >= 0 ? (
-                  <button
-                    type="button"
-                    onClick={handleResumeAutoscroll}
-                    className={`absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-stone-900/90 px-4 py-2 text-xs font-medium text-stone-100 shadow-lg ${GLASS_OUTLINE_CLASS} hover:bg-stone-800`}
-                  >
-                    Follow playback
-                  </button>
-                ) : null}
-              </>
-            ) : (
-              <div className="px-8 py-16 text-center text-sm text-stone-400">
-                No transcript lines found.
-              </div>
-            )}
-          </div>
+          {status === "loading" ? (
+            <div className="flex items-center justify-center px-8 py-16 text-sm text-stone-400">
+              Loading transcript…
+            </div>
+          ) : status === "error" ? (
+            <div className="px-8 py-16 text-center text-sm text-stone-400">
+              Transcript unavailable for this subtitle track.
+            </div>
+          ) : cues && cues.length > 0 ? (
+            <ol
+              data-testid="watch-subtitle-cues"
+              className="px-2 py-3 sm:px-4 sm:py-4"
+            >
+              {cues.map((cue, idx) => {
+                const isActive = idx === activeIdx
+                return (
+                  <li key={`${cue.start}-${idx}`}>
+                    <button
+                      type="button"
+                      onClick={() => handleSeek(cue)}
+                      aria-current={isActive ? "true" : undefined}
+                      className={[
+                        "group flex w-full items-baseline gap-4 rounded-lg px-4 py-3 text-left transition-colors duration-150",
+                        "focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2",
+                        isActive
+                          ? "bg-white/10 text-stone-50"
+                          : "text-stone-300 hover:bg-white/5 hover:text-stone-100",
+                      ].join(" ")}
+                    >
+                      <time
+                        dateTime={`PT${Math.floor(cue.start)}S`}
+                        className={[
+                          "shrink-0 font-mono text-xs tabular-nums tracking-tight transition-colors",
+                          isActive
+                            ? "text-amber-300"
+                            : "text-stone-500 group-hover:text-stone-300",
+                        ].join(" ")}
+                      >
+                        {formatTimestamp(cue.start)}
+                      </time>
+                      <span className="text-base leading-relaxed sm:text-lg">
+                        {cue.text}
+                      </span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ol>
+          ) : (
+            <div className="px-8 py-16 text-center text-sm text-stone-400">
+              No transcript lines found.
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -17,6 +17,16 @@ import { GLASS_OUTLINE_CLASS } from "@/lib/glass-outline"
 
 type Cue = { start: number; end: number; text: string }
 
+// Window after a programmatic scrollTo within which trailing scroll events
+// are treated as smooth-scroll settling rather than user interaction.
+// Smooth scrolls to far cues observed at ~700ms on desktop Chrome; 900ms
+// gives margin without leaving a noticeable lag before the "Follow
+// playback" pill can appear after a real user scroll.
+const AUTO_SCROLL_WINDOW_MS = 900
+// Tolerance in pixels: if scrollTop is still within this band of the last
+// auto target, treat as auto-scroll noise even after the time window.
+const AUTO_SCROLL_TOLERANCE_PX = 8
+
 const TIMING_RE =
   /(?:(\d+):)?(\d+):(\d+)[.,](\d+)\s*-->\s*(?:(\d+):)?(\d+):(\d+)[.,](\d+)/
 
@@ -125,11 +135,25 @@ export function SubtitleTranscript({
     vttSrc: string
     cues: Cue[] | null
   } | null>(null)
-  const [activeIdx, setActiveIdx] = useState(-1)
+  // activeMark carries BOTH the cue-list identity and the highlighted index,
+  // so render-time we only treat the index as valid when it belongs to the
+  // currently-rendered cues array. Switching subtitle language drops the
+  // stale highlight without an extra effect-driven setState.
+  const [activeMark, setActiveMark] = useState<{
+    cues: Cue[] | null
+    idx: number
+  }>({ cues: null, idx: -1 })
   const [userScrolled, setUserScrolled] = useState(false)
   const listRef = useRef<HTMLOListElement | null>(null)
   const userScrolledRef = useRef(false)
+  // Programmatic auto-scrolls set BOTH refs (time + target scrollTop). The
+  // onScroll handler ignores any settling event whose timestamp falls inside
+  // the AUTO_SCROLL_WINDOW_MS budget OR whose scrollTop is within
+  // AUTO_SCROLL_TOLERANCE_PX of the most recent auto target. Either alone
+  // misclassifies: long smooth-scrolls outlast a tight window, and a real
+  // user scroll that briefly crosses the target tripled-touches the band.
   const lastAutoScrollAtRef = useRef(0)
+  const lastAutoScrollTopRef = useRef(0)
   const setUserScrolledBoth = useCallback((v: boolean) => {
     userScrolledRef.current = v
     setUserScrolled(v)
@@ -150,25 +174,27 @@ export function SubtitleTranscript({
           ? "error"
           : "ready"
 
+  const activeIdx = activeMark.cues === cues ? activeMark.idx : -1
+
   useEffect(() => {
     if (!activeVttSrc) return
-    let cancelled = false
-    fetch(activeVttSrc, { credentials: "omit" })
+    const controller = new AbortController()
+    fetch(activeVttSrc, {
+      credentials: "omit",
+      signal: controller.signal,
+    })
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`)
         return r.text()
       })
       .then((text) => {
-        if (cancelled) return
         setLoaded({ vttSrc: activeVttSrc, cues: parseVtt(text) })
       })
-      .catch(() => {
-        if (cancelled) return
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return
         setLoaded({ vttSrc: activeVttSrc, cues: null })
       })
-    return () => {
-      cancelled = true
-    }
+    return () => controller.abort()
   }, [activeVttSrc])
 
   useEffect(() => {
@@ -188,7 +214,7 @@ export function SubtitleTranscript({
       }
       if (idx !== lastIdx) {
         lastIdx = idx
-        setActiveIdx(idx)
+        setActiveMark({ cues, idx })
       }
     }
     update()
@@ -205,7 +231,16 @@ export function SubtitleTranscript({
     if (!list) return
     const onScroll = () => {
       const now = Date.now()
-      if (now - lastAutoScrollAtRef.current < 250) return
+      const sinceAuto = now - lastAutoScrollAtRef.current
+      const delta = Math.abs(list.scrollTop - lastAutoScrollTopRef.current)
+      // Treat as auto-scroll settling if EITHER the time window is open
+      // OR scrollTop still tracks the last auto target within tolerance.
+      // A real user scroll fails both — outside the window AND off-target.
+      if (
+        sinceAuto < AUTO_SCROLL_WINDOW_MS ||
+        delta <= AUTO_SCROLL_TOLERANCE_PX
+      )
+        return
       if (!userScrolledRef.current) {
         userScrolledRef.current = true
         setUserScrolled(true)
@@ -215,6 +250,22 @@ export function SubtitleTranscript({
     return () => list.removeEventListener("scroll", onScroll)
   }, [cues])
 
+  const autoScrollToActive = useCallback(
+    (list: HTMLOListElement, li: HTMLElement) => {
+      const listRect = list.getBoundingClientRect()
+      const liRect = li.getBoundingClientRect()
+      const target =
+        list.scrollTop +
+        (liRect.top - listRect.top) -
+        list.clientHeight / 2 +
+        li.clientHeight / 2
+      lastAutoScrollAtRef.current = Date.now()
+      lastAutoScrollTopRef.current = target
+      list.scrollTo({ top: target, behavior: "smooth" })
+    },
+    [],
+  )
+
   useEffect(() => {
     if (activeIdx < 0) return
     if (userScrolledRef.current) return
@@ -222,16 +273,8 @@ export function SubtitleTranscript({
     if (!list) return
     const li = list.children.item(activeIdx) as HTMLElement | null
     if (!li) return
-    const listRect = list.getBoundingClientRect()
-    const liRect = li.getBoundingClientRect()
-    const target =
-      list.scrollTop +
-      (liRect.top - listRect.top) -
-      list.clientHeight / 2 +
-      li.clientHeight / 2
-    lastAutoScrollAtRef.current = Date.now()
-    list.scrollTo({ top: target, behavior: "smooth" })
-  }, [activeIdx])
+    autoScrollToActive(list, li)
+  }, [activeIdx, autoScrollToActive])
 
   const handleSeek = useCallback(
     (cue: Cue) => {
@@ -253,16 +296,8 @@ export function SubtitleTranscript({
     const list = listRef.current
     const li = list?.children.item(activeIdx) as HTMLElement | null
     if (!list || !li) return
-    const listRect = list.getBoundingClientRect()
-    const liRect = li.getBoundingClientRect()
-    const target =
-      list.scrollTop +
-      (liRect.top - listRect.top) -
-      list.clientHeight / 2 +
-      li.clientHeight / 2
-    lastAutoScrollAtRef.current = Date.now()
-    list.scrollTo({ top: target, behavior: "smooth" })
-  }, [activeIdx, setUserScrolledBoth])
+    autoScrollToActive(list, li)
+  }, [activeIdx, autoScrollToActive, setUserScrolledBoth])
 
   if (subtitles.length === 0) return null
 
@@ -274,15 +309,19 @@ export function SubtitleTranscript({
   return (
     <section
       data-testid="watch-subtitle-transcript"
+      aria-labelledby="watch-transcript-heading"
       className="bg-stone-900 pt-12 pb-20 sm:pt-16 sm:pb-24"
     >
       <div className={WATCH_PAGE_CONTENT_CLASSES}>
         <div
-          className={`rounded-2xl bg-stone-800/40 backdrop-blur-sm ${GLASS_OUTLINE_CLASS}`}
+          className={`rounded-2xl bg-stone-800/40 backdrop-blur-md ${GLASS_OUTLINE_CLASS}`}
         >
           <header className="flex flex-col gap-3 border-b border-white/10 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
             <div>
-              <h2 className="text-2xl font-semibold tracking-tight text-stone-50">
+              <h2
+                id="watch-transcript-heading"
+                className="text-2xl font-semibold tracking-tight text-stone-50"
+              >
                 Transcript
               </h2>
               <p className="mt-1 text-sm text-stone-400">

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -209,6 +209,13 @@ export function SubtitleTranscript({
       if (result && typeof (result as Promise<void>).then === "function") {
         ;(result as Promise<void>).catch(() => {})
       }
+      // Bring the player into view so the user sees the moment they
+      // jumped to. The hero wrapper is sticky-positioned, so
+      // scrollIntoView is a no-op (it's always at viewport top); scroll
+      // the window to the document origin instead.
+      if (typeof window !== "undefined") {
+        window.scrollTo({ top: 0, behavior: "smooth" })
+      }
     },
     [playerRef],
   )

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -1,0 +1,390 @@
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react"
+
+import type { MuxPlayerRef } from "@forge/video-player"
+
+import type { WatchSubtitle } from "@/lib/content"
+import { WATCH_PAGE_CONTENT_CLASSES } from "@/lib/content-width"
+import { GLASS_OUTLINE_CLASS } from "@/lib/glass-outline"
+
+type Cue = { start: number; end: number; text: string }
+
+const TIMING_RE =
+  /(?:(\d+):)?(\d+):(\d+)[.,](\d+)\s*-->\s*(?:(\d+):)?(\d+):(\d+)[.,](\d+)/
+
+function toSeconds(
+  h: string | undefined,
+  m: string,
+  s: string,
+  ms: string,
+): number {
+  const hours = h ? parseInt(h, 10) : 0
+  return (
+    hours * 3600 +
+    parseInt(m, 10) * 60 +
+    parseInt(s, 10) +
+    parseInt(ms.padEnd(3, "0").slice(0, 3), 10) / 1000
+  )
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+}
+
+export function parseVtt(raw: string): Cue[] {
+  const cues: Cue[] = []
+  const normalized = raw.replace(/\r\n?/g, "\n")
+  const blocks = normalized.split(/\n\n+/)
+  for (const block of blocks) {
+    const lines = block.split("\n").filter((l) => l.length > 0)
+    const timingIdx = lines.findIndex((l) => l.includes("-->"))
+    if (timingIdx < 0) continue
+    const m = lines[timingIdx]!.match(TIMING_RE)
+    if (!m) continue
+    const start = toSeconds(m[1], m[2]!, m[3]!, m[4]!)
+    const end = toSeconds(m[5], m[6]!, m[7]!, m[8]!)
+    const textLines = lines.slice(timingIdx + 1)
+    const text = decodeEntities(
+      textLines
+        .join(" ")
+        .replace(/<[^>]+>/g, "")
+        .trim(),
+    )
+    if (text) cues.push({ start, end, text })
+  }
+  return cues
+}
+
+function formatTimestamp(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const pad = (n: number) => n.toString().padStart(2, "0")
+  if (h > 0) return `${h}:${pad(m)}:${pad(s)}`
+  return `${m}:${pad(s)}`
+}
+
+function pickInitialSubtitleSlug(
+  subtitles: WatchSubtitle[],
+  audioSlug: string | null | undefined,
+): string | null {
+  if (subtitles.length === 0) return null
+  if (audioSlug) {
+    const match = subtitles.find((s) => s.language.slug === audioSlug)
+    if (match) return match.language.slug
+  }
+  const primary = subtitles.find((s) => s.primary)
+  if (primary) return primary.language.slug
+  const human = subtitles.find((s) => !s.aiGenerated)
+  if (human) return human.language.slug
+  return subtitles[0]!.language.slug
+}
+
+type SubtitleTranscriptProps = {
+  subtitles: WatchSubtitle[]
+  playerRef: RefObject<MuxPlayerRef | null>
+  audioSlug?: string | null
+}
+
+export function SubtitleTranscript({
+  subtitles,
+  playerRef,
+  audioSlug,
+}: SubtitleTranscriptProps) {
+  const initialSlug = useMemo(
+    () => pickInitialSubtitleSlug(subtitles, audioSlug ?? null),
+    [subtitles, audioSlug],
+  )
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(initialSlug)
+
+  const activeSubtitle = useMemo(() => {
+    if (!selectedSlug) return null
+    return (
+      subtitles.find((s) => s.language.slug === selectedSlug) ??
+      subtitles[0] ??
+      null
+    )
+  }, [selectedSlug, subtitles])
+
+  const [loaded, setLoaded] = useState<{
+    vttSrc: string
+    cues: Cue[] | null
+  } | null>(null)
+  const [activeIdx, setActiveIdx] = useState(-1)
+  const [userScrolled, setUserScrolled] = useState(false)
+  const listRef = useRef<HTMLOListElement | null>(null)
+  const userScrolledRef = useRef(false)
+  const lastAutoScrollAtRef = useRef(0)
+  const setUserScrolledBoth = useCallback((v: boolean) => {
+    userScrolledRef.current = v
+    setUserScrolled(v)
+  }, [])
+
+  const activeVttSrc = activeSubtitle?.vttSrc ?? null
+  const cues =
+    loaded && activeVttSrc && loaded.vttSrc === activeVttSrc
+      ? loaded.cues
+      : null
+  const status: "idle" | "loading" | "error" | "ready" = !activeVttSrc
+    ? "idle"
+    : !loaded || loaded.vttSrc !== activeVttSrc
+      ? "loading"
+      : loaded.cues === null
+        ? "error"
+        : loaded.cues.length === 0
+          ? "error"
+          : "ready"
+
+  useEffect(() => {
+    if (!activeVttSrc) return
+    let cancelled = false
+    fetch(activeVttSrc, { credentials: "omit" })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.text()
+      })
+      .then((text) => {
+        if (cancelled) return
+        setLoaded({ vttSrc: activeVttSrc, cues: parseVtt(text) })
+      })
+      .catch(() => {
+        if (cancelled) return
+        setLoaded({ vttSrc: activeVttSrc, cues: null })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [activeVttSrc])
+
+  useEffect(() => {
+    const el = playerRef.current as HTMLMediaElement | null
+    if (!el || !cues || cues.length === 0) return
+    let lastIdx = -1
+    const update = () => {
+      const t = el.currentTime
+      let idx = -1
+      for (let i = 0; i < cues.length; i++) {
+        const c = cues[i]!
+        if (t >= c.start && t < c.end) {
+          idx = i
+          break
+        }
+        if (c.start > t) break
+      }
+      if (idx !== lastIdx) {
+        lastIdx = idx
+        setActiveIdx(idx)
+      }
+    }
+    update()
+    el.addEventListener("timeupdate", update)
+    el.addEventListener("seeking", update)
+    return () => {
+      el.removeEventListener("timeupdate", update)
+      el.removeEventListener("seeking", update)
+    }
+  }, [cues, playerRef])
+
+  useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+    const onScroll = () => {
+      const now = Date.now()
+      if (now - lastAutoScrollAtRef.current < 250) return
+      if (!userScrolledRef.current) {
+        userScrolledRef.current = true
+        setUserScrolled(true)
+      }
+    }
+    list.addEventListener("scroll", onScroll, { passive: true })
+    return () => list.removeEventListener("scroll", onScroll)
+  }, [cues])
+
+  useEffect(() => {
+    if (activeIdx < 0) return
+    if (userScrolledRef.current) return
+    const list = listRef.current
+    if (!list) return
+    const li = list.children.item(activeIdx) as HTMLElement | null
+    if (!li) return
+    const listRect = list.getBoundingClientRect()
+    const liRect = li.getBoundingClientRect()
+    const target =
+      list.scrollTop +
+      (liRect.top - listRect.top) -
+      list.clientHeight / 2 +
+      li.clientHeight / 2
+    lastAutoScrollAtRef.current = Date.now()
+    list.scrollTo({ top: target, behavior: "smooth" })
+  }, [activeIdx])
+
+  const handleSeek = useCallback(
+    (cue: Cue) => {
+      const el = playerRef.current as HTMLMediaElement | null
+      if (!el) return
+      setUserScrolledBoth(false)
+      el.currentTime = cue.start
+      const result = el.play()
+      if (result && typeof (result as Promise<void>).then === "function") {
+        ;(result as Promise<void>).catch(() => {})
+      }
+    },
+    [playerRef, setUserScrolledBoth],
+  )
+
+  const handleResumeAutoscroll = useCallback(() => {
+    setUserScrolledBoth(false)
+    if (activeIdx < 0) return
+    const list = listRef.current
+    const li = list?.children.item(activeIdx) as HTMLElement | null
+    if (!list || !li) return
+    const listRect = list.getBoundingClientRect()
+    const liRect = li.getBoundingClientRect()
+    const target =
+      list.scrollTop +
+      (liRect.top - listRect.top) -
+      list.clientHeight / 2 +
+      li.clientHeight / 2
+    lastAutoScrollAtRef.current = Date.now()
+    list.scrollTo({ top: target, behavior: "smooth" })
+  }, [activeIdx, setUserScrolledBoth])
+
+  if (subtitles.length === 0) return null
+
+  const languageLabel = (s: WatchSubtitle) =>
+    s.language.nativeName && s.language.nativeName !== s.language.name
+      ? `${s.language.name} (${s.language.nativeName})`
+      : s.language.name
+
+  return (
+    <section
+      data-testid="watch-subtitle-transcript"
+      className="bg-stone-900 pt-12 pb-20 sm:pt-16 sm:pb-24"
+    >
+      <div className={WATCH_PAGE_CONTENT_CLASSES}>
+        <div
+          className={`rounded-2xl bg-stone-800/40 backdrop-blur-sm ${GLASS_OUTLINE_CLASS}`}
+        >
+          <header className="flex flex-col gap-3 border-b border-white/10 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight text-stone-50">
+                Transcript
+              </h2>
+              <p className="mt-1 text-sm text-stone-400">
+                Tap any line to jump to that moment.
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              {subtitles.length > 1 ? (
+                <label className="flex items-center gap-2 text-sm text-stone-300">
+                  <span className="sr-only">Subtitle language</span>
+                  <select
+                    data-testid="watch-subtitle-language"
+                    value={selectedSlug ?? ""}
+                    onChange={(e) => setSelectedSlug(e.target.value)}
+                    className={`appearance-none rounded-full bg-stone-900/80 px-4 py-2 text-sm font-medium text-stone-100 ${GLASS_OUTLINE_CLASS} focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2`}
+                  >
+                    {subtitles.map((s) => (
+                      <option key={s.documentId} value={s.language.slug}>
+                        {languageLabel(s)}
+                        {s.aiGenerated ? " · AI" : ""}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : (
+                <span className="rounded-full bg-stone-900/60 px-3 py-1 text-xs font-medium uppercase tracking-wide text-stone-300">
+                  {activeSubtitle ? languageLabel(activeSubtitle) : ""}
+                  {activeSubtitle?.aiGenerated ? " · AI" : ""}
+                </span>
+              )}
+            </div>
+          </header>
+
+          <div className="relative">
+            {status === "loading" ? (
+              <div className="flex items-center justify-center px-8 py-16 text-sm text-stone-400">
+                Loading transcript…
+              </div>
+            ) : status === "error" ? (
+              <div className="px-8 py-16 text-center text-sm text-stone-400">
+                Transcript unavailable for this subtitle track.
+              </div>
+            ) : cues && cues.length > 0 ? (
+              <>
+                <ol
+                  ref={listRef}
+                  data-testid="watch-subtitle-cues"
+                  className="max-h-[60vh] overflow-y-auto px-2 py-3 sm:px-4 sm:py-4"
+                >
+                  {cues.map((cue, idx) => {
+                    const isActive = idx === activeIdx
+                    return (
+                      <li key={`${cue.start}-${idx}`}>
+                        <button
+                          type="button"
+                          onClick={() => handleSeek(cue)}
+                          aria-current={isActive ? "true" : undefined}
+                          className={[
+                            "group flex w-full items-baseline gap-4 rounded-lg px-4 py-3 text-left transition-colors duration-150",
+                            "focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2",
+                            isActive
+                              ? "bg-white/10 text-stone-50"
+                              : "text-stone-300 hover:bg-white/5 hover:text-stone-100",
+                          ].join(" ")}
+                        >
+                          <time
+                            dateTime={`PT${Math.floor(cue.start)}S`}
+                            className={[
+                              "shrink-0 font-mono text-xs tabular-nums tracking-tight transition-colors",
+                              isActive
+                                ? "text-amber-300"
+                                : "text-stone-500 group-hover:text-stone-300",
+                            ].join(" ")}
+                          >
+                            {formatTimestamp(cue.start)}
+                          </time>
+                          <span className="text-base leading-relaxed sm:text-lg">
+                            {cue.text}
+                          </span>
+                        </button>
+                      </li>
+                    )
+                  })}
+                </ol>
+                {userScrolled && activeIdx >= 0 ? (
+                  <button
+                    type="button"
+                    onClick={handleResumeAutoscroll}
+                    className={`absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-stone-900/90 px-4 py-2 text-xs font-medium text-stone-100 shadow-lg ${GLASS_OUTLINE_CLASS} hover:bg-stone-800`}
+                  >
+                    Follow playback
+                  </button>
+                ) : null}
+              </>
+            ) : (
+              <div className="px-8 py-16 text-center text-sm text-stone-400">
+                No transcript lines found.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -244,6 +244,32 @@ export function SubtitleTranscript({
     (cue: Cue) => {
       const el = playerRef.current as HTMLMediaElement | null
       if (!el) return
+      // Promote the hero out of muted-preview if it has not committed yet.
+      // The pre-reveal click surface owns the unmute + chrome-revealed
+      // state transition inside HeroPlayer; clicking it from this cue-click
+      // handler chains the user gesture so the browser still treats the
+      // synthetic click as user-initiated and grants unmuted playback.
+      // The synthetic click also resets `currentTime` to 0 inside
+      // HeroPlayer, so we apply the seek AFTER the click to land at the
+      // requested cue.
+      if (typeof document !== "undefined") {
+        const wrapper = document.querySelector(
+          '[data-testid="hero-player-wrapper"]',
+        )
+        const revealed =
+          wrapper?.getAttribute("data-chrome-revealed") === "true"
+        if (!revealed) {
+          const surface = document.querySelector(
+            '[data-testid="hero-player-pre-reveal-click-surface"]',
+          ) as HTMLButtonElement | null
+          surface?.click()
+        }
+      }
+      // Belt-and-suspenders unmute for the already-revealed case (the
+      // click surface above is absent post-reveal). Safe to set on every
+      // click — the user explicitly asked for the moment, so silent
+      // playback is never the desired outcome here.
+      el.muted = false
       el.currentTime = cue.start
       const result = el.play()
       if (result && typeof (result as Promise<void>).then === "function") {

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -310,12 +310,10 @@ export function SubtitleTranscript({
     <section
       data-testid="watch-subtitle-transcript"
       aria-labelledby="watch-transcript-heading"
-      className="bg-stone-900 pt-12 pb-20 sm:pt-16 sm:pb-24"
+      className="bg-stone-900/60 pt-12 pb-20 backdrop-blur-md sm:pt-16 sm:pb-24"
     >
       <div className={WATCH_PAGE_CONTENT_CLASSES}>
-        <div
-          className={`rounded-2xl bg-stone-800/40 backdrop-blur-md ${GLASS_OUTLINE_CLASS}`}
-        >
+        <div className={`rounded-2xl bg-stone-800/40 ${GLASS_OUTLINE_CLASS}`}>
           <header className="flex flex-col gap-3 border-b border-white/10 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
             <div>
               <h2

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -275,6 +275,7 @@ export function WatchPageClient({
         subtitles={subtitles}
         playerRef={playerRef}
         audioSlug={currentLanguageSlug}
+        durationSeconds={variant.duration ?? null}
       />
 
       <DownloadModal

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -30,6 +30,7 @@ const ShareModal = dynamic(
     })),
   { ssr: false },
 )
+import { SubtitleTranscript } from "@/components/watch/SubtitleTranscript"
 import { WatchSectionRenderer } from "@/components/watch/WatchSectionRenderer"
 import type {
   MergedWatchBlock,
@@ -268,6 +269,12 @@ export function WatchPageClient({
         onPlayerReady={handlePlayerReady}
         locale={locale}
         subtitleVttSrc={subtitleVttSrc}
+      />
+
+      <SubtitleTranscript
+        subtitles={subtitles}
+        playerRef={playerRef}
+        audioSlug={currentLanguageSlug}
       />
 
       <DownloadModal

--- a/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
@@ -94,6 +94,39 @@ Real`
     expect(parseVtt(vtt)).toEqual([{ start: 5, end: 6, text: "Real" }])
   })
 
+  test("does not double-unescape encoded entities (CodeQL js/double-escaping)", () => {
+    // Literal `&amp;lt;` in the source should decode to `&lt;` once, not
+    // collapse to `<`. A chained-replace decoder that handled `&amp;`
+    // first would re-trigger the `&lt;` branch.
+    const vtt = `WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+&amp;lt;encoded&amp;gt;`
+
+    expect(parseVtt(vtt)).toEqual([
+      { start: 1, end: 2, text: "&lt;encoded&gt;" },
+    ])
+  })
+
+  test("strips nested-tag payloads with no reconstructible <tag> residue", () => {
+    // Iterate-until-stable strip prevents a nested-tag payload from
+    // collapsing back into a complete `<script>` tag after one pass.
+    // Defensive only — output flows into a React text node — but the
+    // assertion guards against CodeQL js/incomplete-multi-character-
+    // sanitization regressions. Garbage characters can remain (they
+    // render as literal text), but no `<...>` pattern survives.
+    const cues = parseVtt(`WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+keep <scr<script>ipt>alert(1)</script> me`)
+
+    expect(cues).toHaveLength(1)
+    expect(cues[0]!.text).not.toMatch(/<[^>]*>/)
+    expect(cues[0]!.text).toContain("keep")
+    expect(cues[0]!.text).toContain("alert(1)")
+    expect(cues[0]!.text).toContain("me")
+  })
+
   test("accepts comma decimal separator (SRT-style timing)", () => {
     const vtt = `WEBVTT
 

--- a/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * SubtitleTranscript — parseVtt unit tests.
+ *
+ * The transcript section reads cues from VTT files served by Arclight's
+ * api-media-core. parseVtt is the pure transform: VTT text -> cue list.
+ * Each test exercises one VTT-grammar wrinkle observed in the wild
+ * (Windows line endings, hour-prefix timing, inline <c> tags, HTML
+ * entities) so a regression in any path fails an isolated assertion.
+ */
+
+import { describe, expect, test } from "vitest"
+
+import { parseVtt } from "@/components/watch/SubtitleTranscript"
+
+describe("parseVtt", () => {
+  test("parses a happy-path cue", () => {
+    const vtt = `WEBVTT
+
+00:00:01.000 --> 00:00:04.500
+Hello world`
+
+    expect(parseVtt(vtt)).toEqual([{ start: 1, end: 4.5, text: "Hello world" }])
+  })
+
+  test("accepts CRLF and CR line endings", () => {
+    const crlf = "WEBVTT\r\n\r\n00:00:02.000 --> 00:00:03.000\r\nLine"
+    const cr = "WEBVTT\r\r00:00:02.000 --> 00:00:03.000\rLine"
+
+    expect(parseVtt(crlf)).toEqual([{ start: 2, end: 3, text: "Line" }])
+    expect(parseVtt(cr)).toEqual([{ start: 2, end: 3, text: "Line" }])
+  })
+
+  test("parses hour-prefix timing", () => {
+    const vtt = `WEBVTT
+
+01:00:25.860 --> 01:00:33.400
+Hour-prefixed cue`
+
+    expect(parseVtt(vtt)).toEqual([
+      { start: 3625.86, end: 3633.4, text: "Hour-prefixed cue" },
+    ])
+  })
+
+  test("skips blocks with malformed or missing timing", () => {
+    const vtt = `WEBVTT
+
+NOTE this is a comment block
+
+garbage line without arrow
+
+00:00:05.000 --> 00:00:06.000
+Valid cue`
+
+    expect(parseVtt(vtt)).toEqual([{ start: 5, end: 6, text: "Valid cue" }])
+  })
+
+  test("strips inline <c> and <i> tags from cue text", () => {
+    const vtt = `WEBVTT
+
+00:00:10.000 --> 00:00:12.000
+<c.yellow>Bright</c> <i>italic</i> word`
+
+    expect(parseVtt(vtt)).toEqual([
+      { start: 10, end: 12, text: "Bright italic word" },
+    ])
+  })
+
+  test("decodes common HTML entities", () => {
+    const vtt = `WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+Tom &amp; Jerry &lt;3 &quot;hi&quot; &#39;yo&#39;&nbsp;&gt;`
+
+    expect(parseVtt(vtt)).toEqual([
+      { start: 1, end: 2, text: "Tom & Jerry <3 \"hi\" 'yo' >" },
+    ])
+  })
+
+  test("skips cues with empty text after stripping", () => {
+    const vtt = `WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+
+
+00:00:03.000 --> 00:00:04.000
+<c></c>
+
+00:00:05.000 --> 00:00:06.000
+Real`
+
+    expect(parseVtt(vtt)).toEqual([{ start: 5, end: 6, text: "Real" }])
+  })
+
+  test("accepts comma decimal separator (SRT-style timing)", () => {
+    const vtt = `WEBVTT
+
+00:00:01,250 --> 00:00:02,750
+Comma decimals`
+
+    expect(parseVtt(vtt)).toEqual([
+      { start: 1.25, end: 2.75, text: "Comma decimals" },
+    ])
+  })
+
+  test("returns empty array for header-only input", () => {
+    expect(parseVtt("WEBVTT\n\n")).toEqual([])
+  })
+})

--- a/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
@@ -10,7 +10,10 @@
 
 import { describe, expect, test } from "vitest"
 
-import { parseVtt } from "@/components/watch/SubtitleTranscript"
+import {
+  normalizeCueOffset,
+  parseVtt,
+} from "@/components/watch/SubtitleTranscript"
 
 describe("parseVtt", () => {
   test("parses a happy-path cue", () => {
@@ -104,5 +107,52 @@ Comma decimals`
 
   test("returns empty array for header-only input", () => {
     expect(parseVtt("WEBVTT\n\n")).toEqual([])
+  })
+})
+
+describe("normalizeCueOffset", () => {
+  test("subtracts one-hour SMPTE offset when cues fall outside duration", () => {
+    // Real-world example from Arclight: the-covenant Amharic VTT has
+    // cues starting at 01:00:25 (3625s) while the variant is 5730s
+    // long. Subtracting 3600s lands the cues at 25s..1521s — inside
+    // the playable range.
+    const cues = [
+      { start: 3625, end: 3630, text: "first" },
+      { start: 9120, end: 9125, text: "last" },
+    ]
+    expect(normalizeCueOffset(cues, 5730)).toEqual([
+      { start: 25, end: 30, text: "first" },
+      { start: 5520, end: 5525, text: "last" },
+    ])
+  })
+
+  test("preserves cues that already fit within duration", () => {
+    const cues = [
+      { start: 5, end: 10, text: "intro" },
+      { start: 5700, end: 5710, text: "outro" },
+    ]
+    expect(normalizeCueOffset(cues, 5730)).toEqual(cues)
+  })
+
+  test("no-ops when duration is unknown", () => {
+    const cues = [{ start: 3625, end: 3630, text: "offset" }]
+    expect(normalizeCueOffset(cues, null)).toEqual(cues)
+    expect(normalizeCueOffset(cues, undefined)).toEqual(cues)
+    expect(normalizeCueOffset(cues, 0)).toEqual(cues)
+  })
+
+  test("no-ops on empty cue list", () => {
+    expect(normalizeCueOffset([], 5730)).toEqual([])
+  })
+
+  test("does not shift when shifted result would underflow zero", () => {
+    // First cue starts at 5s — no whole-hour offset applies even if
+    // the last cue overshoots duration; the safer fallback is to
+    // render cues as authored.
+    const cues = [
+      { start: 5, end: 10, text: "ok" },
+      { start: 7000, end: 7005, text: "way past" },
+    ]
+    expect(normalizeCueOffset(cues, 1000)).toEqual(cues)
   })
 })


### PR DESCRIPTION
## Summary
- New `SubtitleTranscript` client component mounted at the bottom of `WatchPageClient`. Fetches the selected subtitle track's VTT, parses cues, and renders a scrollable transcript card.
- Click any line to seek; the active cue highlights and the list center-scrolls to follow playback. A "Follow playback" pill returns to autoscroll after the viewer scrolls manually.
- Surfaces a language picker when a video has multiple subtitle tracks; auto-prefers an audio-matched track, then the primary, then the first available. Section is hidden entirely when no subtitles exist.
- Reuses the existing `WatchSubtitle` shape from `video.subtitles` — no new GraphQL, no admin changes.

## Test plan
- [ ] Open `/watch/the-covenant/english` — confirm transcript card renders at bottom with cues.
- [ ] Click a cue — confirm player seeks to that timestamp and starts playing.
- [ ] Let video play — confirm active cue highlights and list autoscrolls.
- [ ] Scroll the transcript manually — confirm "Follow playback" pill appears; click it to resume autoscroll.
- [ ] Open a video with multiple subtitle tracks — confirm language `<select>` swaps the transcript content.
- [ ] Open a video with no subtitles — confirm section is not rendered.
- [ ] `pnpm --filter @forge/web lint --max-warnings=0` clean.
- [ ] `pnpm --filter @forge/web typecheck` clean.
- [ ] `pnpm --filter @forge/web test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)