### PR TITLE
fix(web): polish language modal counts

### DIFF
--- a/apps/web/src/components/watch/LanguagePickerModal.tsx
+++ b/apps/web/src/components/watch/LanguagePickerModal.tsx
@@ -289,16 +289,15 @@ export function LanguagePickerModal({
 
         <div className="flex flex-col gap-14">
           <div className="flex flex-col gap-5">
-            <div className="flex items-baseline justify-between gap-3">
+            <div className="flex items-center gap-3">
               <h2 className="text-2xl font-semibold text-stone-100">
                 Language
               </h2>
               <span
                 data-testid="watch-language-picker-count"
-                className="text-lg font-normal text-stone-400"
+                className="inline-flex min-h-8 min-w-8 items-center justify-center rounded-full border border-stone-500/40 bg-white/10 px-2.5 text-sm font-semibold text-stone-100"
               >
-                {options.length}{" "}
-                {options.length === 1 ? "language" : "languages"}
+                {options.length}
               </span>
             </div>
             <LanguageCombobox
@@ -309,28 +308,19 @@ export function LanguagePickerModal({
           </div>
 
           <div className="flex flex-col gap-5">
-            <div className="flex items-center justify-between gap-3">
-              <div className="flex items-center gap-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
                 <h2 className="text-2xl font-semibold text-stone-100">
                   Subtitles
                 </h2>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={draftSubtitleEnabled}
-                  data-testid="watch-language-picker-subtitles-toggle"
-                  disabled={subtitleOptions.length === 0}
-                  onClick={() => setDraftSubtitleEnabled((value) => !value)}
-                  className="flex h-8 w-[58px] cursor-pointer items-center rounded-full bg-white p-1 transition disabled:cursor-not-allowed disabled:opacity-40"
+                <span
+                  data-testid="watch-language-picker-subtitle-count"
+                  className="inline-flex min-h-8 min-w-8 items-center justify-center rounded-full border border-stone-500/40 bg-white/10 px-2.5 text-sm font-semibold text-stone-100"
                 >
-                  <span
-                    className={`size-6 rounded-full bg-stone-950 transition-transform ${
-                      draftSubtitleEnabled ? "translate-x-6" : "translate-x-0"
-                    }`}
-                  />
-                </button>
+                  {subtitleOptions.length}
+                </span>
               </div>
-              <div className="flex items-center gap-4">
+              <div className="ml-auto flex items-center gap-4">
                 {subtitleOptions.length === 0 ? (
                   <Button
                     type="button"
@@ -345,13 +335,22 @@ export function LanguagePickerModal({
                       : "Translate with AI"}
                   </Button>
                 ) : null}
-                <span
-                  data-testid="watch-language-picker-subtitle-count"
-                  className="text-lg font-normal text-stone-400"
+                <button
+                  type="button"
+                  role="switch"
+                  aria-label="Subtitles"
+                  aria-checked={draftSubtitleEnabled}
+                  data-testid="watch-language-picker-subtitles-toggle"
+                  disabled={subtitleOptions.length === 0}
+                  onClick={() => setDraftSubtitleEnabled((value) => !value)}
+                  className="flex h-8 w-[58px] cursor-pointer items-center rounded-full bg-white p-1 transition disabled:cursor-not-allowed disabled:opacity-40"
                 >
-                  {subtitleOptions.length}{" "}
-                  {subtitleOptions.length === 1 ? "language" : "languages"}
-                </span>
+                  <span
+                    className={`size-6 rounded-full bg-stone-950 transition-transform ${
+                      draftSubtitleEnabled ? "translate-x-6" : "translate-x-0"
+                    }`}
+                  />
+                </button>
               </div>
             </div>
             <LanguageCombobox

--- a/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
@@ -301,9 +301,9 @@ describe("LanguagePickerModal — globe overlay", () => {
       ],
     })
     const count = $('[data-testid="watch-language-picker-count"]')
-    expect(count?.textContent).toBe("3 languages")
-    expect(count?.className).toContain("font-normal")
-    expect(count?.className).not.toContain("font-semibold")
+    expect(count?.textContent).toBe("3")
+    expect(count?.className).toContain("rounded-full")
+    expect(count?.className).toContain("font-semibold")
   })
 
   it("matches the production overlay shell and renders subtitle selector data", () => {
@@ -341,14 +341,20 @@ describe("LanguagePickerModal — globe overlay", () => {
 
     expect(
       $('[data-testid="watch-language-picker-subtitle-count"]')?.textContent,
-    ).toBe("1 language")
+    ).toBe("1")
     expect(
       $('[data-testid="watch-language-picker-subtitle-count"]')?.className,
-    ).toContain("font-normal")
+    ).toContain("rounded-full")
     const toggle = $(
       '[data-testid="watch-language-picker-subtitles-toggle"]',
     ) as HTMLButtonElement
     expect(toggle.disabled).toBe(false)
+    expect(toggle.parentElement?.className).toContain("ml-auto")
+    expect(
+      toggle.parentElement?.contains(
+        $('[data-testid="watch-language-picker-subtitle-count"]'),
+      ),
+    ).toBe(false)
     expect(toggle.getAttribute("aria-checked")).toBe("true")
     expect(toggle.className).toContain("h-8")
     expect(toggle.className).toContain("w-[58px]")
@@ -376,7 +382,12 @@ describe("LanguagePickerModal — globe overlay", () => {
     expect(button.className).toContain("px-4")
     expect(button.className).toContain("py-2")
     const count = $('[data-testid="watch-language-picker-subtitle-count"]')
-    expect(button.parentElement?.contains(count)).toBe(true)
+    const toggle = $(
+      '[data-testid="watch-language-picker-subtitles-toggle"]',
+    ) as HTMLButtonElement
+    expect(count?.textContent).toBe("0")
+    expect(button.parentElement?.contains(count)).toBe(false)
+    expect(button.parentElement?.contains(toggle)).toBe(true)
 
     act(() => {
       button.click()

--- a/docs/plans/2026-05-27-003-fix-web-language-modal-count-chip-plan.md
+++ b/docs/plans/2026-05-27-003-fix-web-language-modal-count-chip-plan.md
@@ -1,0 +1,88 @@
+---
+title: Web language modal count chip polish
+type: fix
+status: complete
+date: 2026-05-27
+origin: docs/roadmap/topic-experiences/feat-144-web-language-modal-count-chip-polish.md
+---
+
+# Web language modal count chip polish
+
+## Problem Frame
+
+The web watch language modal already supports audio-language selection and
+subtitle selection. Its current section counts are right-aligned descriptive
+text (`"N languages"`), and the subtitle switch sits beside the "Subtitles"
+heading. The requested polish is visual and localized: counts should become
+number-only chips immediately following their titles, and the subtitle switch
+should move to the right-side controls.
+
+## Scope
+
+In scope:
+
+- `apps/web/src/components/watch/LanguagePickerModal.tsx`
+- `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+- `docs/roadmap/topic-experiences/feat-144-web-language-modal-count-chip-polish.md`
+
+Out of scope:
+
+- Language routing, saved language preference cookies, subtitle rendering, and
+  translation request behavior.
+- Changes to `LanguageCombobox`, `WatchPageClient`, or player chrome.
+- New shared design primitives.
+
+## Requirements Trace
+
+- R1. Language count appears immediately after the "Language" title.
+- R2. Language count chip text is numeric only.
+- R3. Subtitle count chip appears immediately after the "Subtitles" title.
+- R4. Subtitle switch moves to the right-side control cluster.
+- R5. Existing disabled, dirty-state, Apply, Close, and translation request
+  behavior remains unchanged.
+
+## Existing Patterns
+
+- `LanguagePickerModal.tsx` already owns all relevant layout, count, and switch
+  markup.
+- `LanguagePickerModal.test.tsx` uses `data-testid` selectors and class/text
+  assertions for modal shell details.
+- The modal uses Tailwind utility classes directly for this surface; a new
+  shared chip component would be unnecessary for this one-off polish.
+
+## Implementation Units
+
+### U1. Count Chips And Subtitle Switch Placement
+
+Files:
+
+- Modify `apps/web/src/components/watch/LanguagePickerModal.tsx`
+- Modify `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+
+Approach:
+
+1. Change the language section header to group the `Language` heading and
+   `watch-language-picker-count` chip in the left-side title cluster.
+2. Replace the language count text with `options.length`.
+3. Change the subtitle section header to group the `Subtitles` heading and
+   `watch-language-picker-subtitle-count` chip in the left-side title cluster.
+4. Move `watch-language-picker-subtitles-toggle` into the right-side cluster,
+   alongside the optional AI translation request button.
+5. Keep `watch-language-picker-count` and
+   `watch-language-picker-subtitle-count` test IDs on the chip elements so
+   existing selectors remain stable.
+
+Test scenarios:
+
+- Header count test expects language count text `"3"` and chip classes.
+- Subtitle shell test expects subtitle count text `"1"` and confirms the
+  subtitle switch is inside the right-side control cluster, not the title
+  cluster.
+- No behavioral navigation or subtitle callback tests should change.
+
+## Verification
+
+- `pnpm --filter @forge/web test src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+- `pnpm --filter @forge/web typecheck`
+- Browser smoke on a watch page language modal at mobile width if local web
+  boot is practical in the current environment.

--- a/docs/roadmap/topic-experiences/feat-144-web-language-modal-count-chip-polish.md
+++ b/docs/roadmap/topic-experiences/feat-144-web-language-modal-count-chip-polish.md
@@ -1,0 +1,65 @@
+---
+id: "feat-144"
+title: "Web language modal count chip polish"
+owner: "urim"
+priority: "P2"
+status: "complete"
+start_date: "2026-05-27"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "web"
+  - "watch"
+  - "i18n"
+  - "design"
+---
+
+## Problem
+
+The web watch language modal currently renders language counts as descriptive
+right-aligned text such as "8 languages" and places the subtitle toggle beside
+the "Subtitles" heading. The requested design needs tighter count chips placed
+near each section title, with the subtitle switch moved to the right-side
+control area.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/watch/LanguagePickerModal.tsx` - modal layout,
+   language count, subtitle count, and subtitle switch.
+2. `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx` -
+   focused jsdom coverage for the modal shell and subtitle controls.
+3. `docs/plans/2026-05-25-001-feat-video-subtitle-controls-plan.md` -
+   existing subtitle control layout context.
+
+## Grep These
+
+1. `watch-language-picker-count`
+2. `watch-language-picker-subtitle-count`
+3. `watch-language-picker-subtitles-toggle`
+
+## What To Build
+
+1. Render the playable language count as a chip immediately after the
+   "Language" title.
+2. Render only the numeric count inside the language count chip.
+3. Render the subtitle count as a numeric chip next to the "Subtitles" title.
+4. Move the subtitle switch to the right-side control cluster, preserving its
+   existing state, disabled behavior, and click handler.
+5. Keep the existing language/subtitle combobox behavior and Apply/Close flows
+   unchanged.
+
+## Constraints
+
+- Do not change language routing, subtitle preference state, or translation
+  request behavior.
+- Do not introduce a new UI primitive for this small polish.
+- Preserve the existing `data-testid` hooks used by modal tests.
+- Keep the modal usable at mobile widths without title, chip, and switch
+  overlap.
+
+## Verification
+
+1. `pnpm --filter @forge/web test src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+2. `pnpm --filter @forge/web typecheck`
+3. Browser smoke on a watch page language modal at mobile width.


### PR DESCRIPTION
## Summary
- show language and subtitle counts as number-only chips beside their section titles
- move the subtitle switch into the right-side control cluster
- add the scoped roadmap ticket and CE plan for the modal polish

## Validation
- pnpm --filter @forge/web test src/components/watch/__tests__/LanguagePickerModal.test.tsx
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- pnpm exec prettier --check apps/web/src/components/watch/LanguagePickerModal.tsx apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx docs/roadmap/topic-experiences/feat-144-web-language-modal-count-chip-polish.md docs/plans/2026-05-27-003-fix-web-language-modal-count-chip-plan.md

## Browser smoke
- not run: local web/admin services were not running on 3000/3003, and this checkout needed dependency relinking after fast-forwarding to current main