### PR TITLE
fix(web): keep watch header blur on mobile

### DIFF
--- a/apps/web/src/components/FloatingSearchProvider.tsx
+++ b/apps/web/src/components/FloatingSearchProvider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -157,7 +158,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
     }
   }, [open])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof window === "undefined") return
 
     const handleVisibilityChange = (event: Event) => {
@@ -179,7 +180,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof window === "undefined") return
 
     const handleLanguageSwitcherChange = (event: Event) => {
@@ -204,7 +205,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof window === "undefined") return
 
     const handlePlaybackStateChange = (event: Event) => {
@@ -235,7 +236,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setPlayerChromeVisible(true)
     setPlayerPlaybackState({ playing: false, muted: true, preview: false })
     setHeaderLanguageSwitcher({ visible: false, onClick: null })

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { act } from "react"
+import { act, useEffect } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -70,7 +70,36 @@ function dispatchLanguageSwitcher(detail: WatchHeaderLanguageSwitcherDetail) {
   )
 }
 
+function PlaybackStatePublisher({
+  detail,
+}: {
+  detail: WatchPlayerPlaybackStateDetail
+}) {
+  useEffect(() => {
+    dispatchPlaybackState(detail)
+  }, [detail])
+
+  return <main>Page</main>
+}
+
 describe("FloatingSearchProvider — header backdrop", () => {
+  it("catches the initial watch preview state published by a child on mount", () => {
+    act(() => {
+      root.render(
+        <FloatingSearchProvider>
+          <PlaybackStatePublisher
+            detail={{ playing: true, muted: true, preview: true }}
+          />
+        </FloatingSearchProvider>,
+      )
+    })
+
+    const backdrop = document.querySelector(
+      '[data-testid="floating-header-backdrop"]',
+    )
+    expect(backdrop?.className).toContain("opacity-100")
+  })
+
   it("renders a fixed blurred gradient behind the floating header", () => {
     act(() => {
       root.render(


### PR DESCRIPTION
## Summary

The watch page now keeps the blurred floating-header backdrop visible when the hero publishes its initial preview state during mount. The provider registers the watch chrome, language, and playback listeners in layout effects so child passive effects cannot beat listener setup, and the route reset no longer clobbers the first preview state.

## Testing

- pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx
- Mobile browser proof on the current checkout: after scrolling to scrollY=550, [data-testid="floating-header-backdrop"] computed opacity: 1 and backdrop-filter: blur(10px).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
