### PR TITLE
fix(web): align watch carousel snaps

### DIFF
--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -109,7 +109,14 @@ export function SiblingCarousel({
         setApi={setApi}
         className="w-full"
       >
-        <CarouselContent className="pl-10 md:pl-0">
+        <CarouselContent
+          className={cn(
+            "pl-10 md:pl-0",
+            activeIndex > 0 && activeIndex < children.length - 1
+              ? "translate-x-14 md:translate-x-0"
+              : "",
+          )}
+        >
           {children.map((child, index) => {
             const isActive = index === activeIndex
             // `resolvePosterUrl` codifies the editorial-cinematic priority
@@ -141,20 +148,14 @@ export function SiblingCarousel({
                   data-testid="sibling-carousel-item"
                   data-active={isActive ? "true" : "false"}
                   data-href={href}
-                  // The border is drawn inside the element (not as a ring,
-                  // which extends outside the box and gets clipped by
-                  // CarouselContent's `overflow-hidden` viewport at the
-                  // top/bottom edges). Inactive cards have no border so
-                  // the body-zone's frosted-glass backdrop doesn't read
-                  // as a faint grey halo through a transparent border.
-                  // The 4 px difference in image content area between
-                  // active/inactive is imperceptible because the outer
-                  // card geometry (carousel slot) stays the same.
+                  // Active cards use a real inside border. Inactive cards keep
+                  // no transparent border; the bevel is drawn by a content
+                  // overlay so it stays visible around the whole picture.
                   className={cn(
-                    "group relative block aspect-square cursor-pointer overflow-hidden rounded-lg bg-stone-900 transition outline-1 outline-white/15 outline-offset-[-4px] shadow-[0_2px_6px_rgba(0,0,0,0.35),0_14px_32px_-12px_rgba(0,0,0,0.6)]",
+                    "group relative block aspect-video cursor-pointer overflow-hidden rounded-lg bg-stone-900 transition shadow-[0_2px_6px_rgba(0,0,0,0.35),0_14px_32px_-12px_rgba(0,0,0,0.6)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80",
                     isActive
                       ? "border-4 border-white"
-                      : "border-4 border-transparent opacity-70 hover:border-brand-red hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
+                      : "opacity-70 hover:outline-4 hover:outline-offset-[-4px] hover:outline-brand-red hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
                   )}
                 >
                   {thumb ? (
@@ -184,7 +185,7 @@ export function SiblingCarousel({
                   {/* Soften the image into the lower caption zone. */}
                   <div
                     aria-hidden="true"
-                    className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-[52%] bg-black/35 backdrop-blur-[14px] [mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_45%,rgba(0,0,0,0.35)_78%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_45%,rgba(0,0,0,0.35)_78%,transparent_100%)]"
+                    className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-full bg-black/35 backdrop-blur-[14px] [mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)]"
                   />
 
                   {/* Hover-only play overlay on inactive cards. The active
@@ -203,11 +204,11 @@ export function SiblingCarousel({
                   ) : null}
 
                   {/* Caption block — a lower frosted panel like the modern
-                      episode rails, leaving the sharp artwork to the top
-                      ~60% of the square tile. */}
+                      episode rails, keeping text readable inside the
+                      landscape tile. */}
                   <div
                     data-testid="sibling-carousel-caption"
-                    className="absolute inset-x-0 bottom-0 z-20 flex h-[44%] flex-col justify-end gap-1.5 bg-gradient-to-t from-black/68 via-black/35 to-transparent p-3 sm:p-4"
+                    className="absolute inset-x-0 bottom-0 z-20 flex h-full flex-col justify-end gap-1.5 bg-gradient-to-t from-black/68 via-black/35 to-transparent p-3 sm:p-4"
                   >
                     <span className="text-[10px] font-semibold tracking-[0.18em] text-stone-200/90 uppercase drop-shadow-md sm:text-xs">
                       Chapter
@@ -222,6 +223,12 @@ export function SiblingCarousel({
                       {child.title ?? ""}
                     </span>
                   </div>
+
+                  <div
+                    aria-hidden="true"
+                    data-testid="sibling-carousel-bevel"
+                    className="pointer-events-none absolute inset-0 z-40 rounded-lg border border-white opacity-40 mix-blend-soft-light"
+                  />
 
                   {/* Visually-hidden active marker — preserves the existing
                       `sibling-carousel-playing-now` testid and gives screen
@@ -239,6 +246,11 @@ export function SiblingCarousel({
               </CarouselItem>
             )
           })}
+          <div
+            aria-hidden="true"
+            data-testid="sibling-carousel-end-spacer"
+            className="min-w-0 shrink-0 grow-0 basis-[52%] sm:basis-[64%] md:basis-[66.666%] lg:basis-[75%] xl:basis-[80%] 2xl:basis-[83.333%]"
+          />
         </CarouselContent>
 
         {/* The shared `outline` Button variant only sets text color on

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -162,11 +162,22 @@ describe("SiblingCarousel — happy path", () => {
     const header = rail?.querySelector("header")
     expect(header?.className).toContain("px-10")
     expect(header?.className).toContain("md:px-0")
+    const carousel = container.querySelector("[data-slot='carousel']")
+    expect(carousel?.className).not.toContain("translate-x-10")
+    expect(carousel?.className).not.toContain("md:translate-x-0")
     const content = container.querySelector(
       "[data-slot='carousel-content'] > div",
     )
     expect(content?.className).toContain("pl-10")
     expect(content?.className).toContain("md:pl-0")
+    expect(content?.className).toContain("translate-x-14")
+    expect(content?.className).toContain("md:translate-x-0")
+    const endSpacer = container.querySelector(
+      "[data-testid='sibling-carousel-end-spacer']",
+    )
+    expect(endSpacer).not.toBeNull()
+    expect(endSpacer?.className).toContain("basis-[52%]")
+    expect(endSpacer?.className).toContain("md:basis-[66.666%]")
 
     // Active item carries data-active="true" and renders the "Playing now" pill.
     const active = container.querySelector(
@@ -174,10 +185,14 @@ describe("SiblingCarousel — happy path", () => {
     )
     expect(active).not.toBeNull()
     expect(active!.className).toContain("border-white")
-    expect(active!.className).toContain("aspect-square")
-    expect(active!.className).not.toContain("aspect-[1.58/1]")
+    expect(active!.className).toContain("aspect-video")
+    expect(active!.className).not.toContain("translate-x-10")
+    expect(active!.className).not.toContain("md:translate-x-0")
+    expect(active!.className).not.toContain("-translate-x-4")
+    expect(active!.className).not.toContain("aspect-square")
     expect(active!.className).not.toContain("after:inset-0")
     expect(active!.className).not.toContain("after:border-4")
+    expect(active!.className).toContain("focus-visible:outline-white/80")
     expect(active!.className).toContain("shadow-[0_2px_6px_rgba")
     // 2-segment route shape: `/{slug}/{locale}` — the parent slug segment
     // was removed when the watch route migrated to flat `[slug]/[locale]`.
@@ -186,16 +201,28 @@ describe("SiblingCarousel — happy path", () => {
       "[data-testid='sibling-carousel-caption']",
     )
     expect(caption).not.toBeNull()
-    expect(caption?.className).toContain("h-[44%]")
+    expect(caption?.className).toContain("h-full")
     expect(caption?.className).toContain("bg-gradient-to-t")
     expect(caption?.className).toContain("via-black/35")
     expect(caption?.className).toContain("z-20")
 
     const blurMask = active!.querySelector("[aria-hidden='true']")
-    expect(blurMask?.className).toContain("h-[52%]")
+    expect(blurMask?.className).toContain("h-full")
     expect(blurMask?.className).toContain("bg-black/35")
     expect(blurMask?.className).toContain("backdrop-blur-[14px]")
-    expect(blurMask?.className).toContain("rgba(0,0,0,0.35)_78%")
+    expect(blurMask?.className).toContain("rgba(0,0,0,0.35)_62%")
+
+    const bevel = active!.querySelector(
+      "[data-testid='sibling-carousel-bevel']",
+    )
+    expect(bevel).not.toBeNull()
+    expect(bevel?.className).toContain("absolute")
+    expect(bevel?.className).toContain("inset-0")
+    expect(bevel?.className).toContain("z-40")
+    expect(bevel?.className).toContain("border")
+    expect(bevel?.className).toContain("border-white")
+    expect(bevel?.className).toContain("opacity-40")
+    expect(bevel?.className).toContain("mix-blend-soft-light")
 
     const playingNow = container.querySelector(
       "[data-testid='sibling-carousel-playing-now']",
@@ -205,9 +232,9 @@ describe("SiblingCarousel — happy path", () => {
     const inactive = container.querySelector(
       "[data-testid='sibling-carousel-item'][data-active='false']",
     )
-    expect(inactive?.className).toContain("border-transparent")
+    expect(inactive?.className).not.toContain("border-transparent")
     expect(inactive?.className).toContain("opacity-70")
-    expect(inactive?.className).toContain("hover:border-brand-red")
+    expect(inactive?.className).toContain("hover:outline-brand-red")
     expect(inactive?.className).toContain("hover:opacity-100")
 
     const label = container.querySelector(


### PR DESCRIPTION
## Summary

Fixes the watch-page episode carousel so landscape chapter cards keep their bevel inside the image block and snap predictably against the content gutter. Middle and trailing chapter snaps still align the active card, while the first slide clamps cleanly to the left content edge instead of leaving a right-shifted gap.

## Changes

- Converts sibling chapter cards to landscape `aspect-video` tiles with a soft-light inside bevel overlay.
- Removes the transparent inactive border that read as a dark edge, while keeping hover and focus states visible.
- Adds the carousel trailing spacer and mobile track offset needed for middle and final active-card alignment.
- Updates `SiblingCarousel` coverage for the landscape card shape, bevel overlay, spacer, and inactive-card border behavior.

## Validation

- `pnpm --filter @forge/web test -- SiblingCarousel.test.tsx`
- Visual checked `http://localhost:3030/watch/12-is-god-in-the-details/hindi` in the Codex in-app browser and Helium. The first slide snaps to the content left edge with Previous disabled at the true start.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
