### PR TITLE
feat(web): wire canonicalizeWatchPath into proxy (Phase 3)

### DIFF
--- a/apps/web/src/lib/url-canonicalize.ts
+++ b/apps/web/src/lib/url-canonicalize.ts
@@ -14,6 +14,7 @@ import { tryResolveLanguageAlias } from "./language-aliases"
 import {
   HTML_SUFFIX,
   RESERVED_PREFIXES,
+  getWatchLocaleSegmentIndex,
   hasHtmlSuffix,
   stripHtmlSuffix,
 } from "./url-shape"
@@ -220,7 +221,7 @@ export function canonicalizeWatchPath(
   // 2-segment: alias applies to segments[1]. 3-segment: applies to segments[2].
   {
     const segs = path.split("/").filter(Boolean)
-    const localeIdx = segs.length === 2 ? 1 : segs.length === 3 ? 2 : -1
+    const localeIdx = getWatchLocaleSegmentIndex(segs)
     if (localeIdx >= 0 && hasHtmlSuffix(segs[localeIdx])) {
       const bare = stripHtmlSuffix(segs[localeIdx])
       const canonical = tryResolveLanguageAlias(bare)

--- a/apps/web/src/lib/url-shape.test.ts
+++ b/apps/web/src/lib/url-shape.test.ts
@@ -4,6 +4,7 @@ import {
   HTML_SUFFIX,
   HTML_SUFFIX_REGEX,
   appendHtmlSuffix,
+  getWatchLocaleSegmentIndex,
   hasHtmlSuffix,
   stripHtmlSuffix,
 } from "./url-shape"
@@ -83,5 +84,38 @@ describe("appendHtmlSuffix", () => {
     for (const x of inputs) {
       expect(appendHtmlSuffix(appendHtmlSuffix(x))).toBe(appendHtmlSuffix(x))
     }
+  })
+})
+
+describe("getWatchLocaleSegmentIndex", () => {
+  it("returns 1 for 2-segment shape /{slug}/{locale}", () => {
+    expect(getWatchLocaleSegmentIndex(["jesus", "english.html"])).toBe(1)
+  })
+
+  it("returns 2 for 3-segment shape /{series}/{episode}/{locale}", () => {
+    expect(
+      getWatchLocaleSegmentIndex([
+        "lumo-the-gospel-of-john.html",
+        "wedding-in-cana",
+        "english.html",
+      ]),
+    ).toBe(2)
+  })
+
+  it("returns -1 for empty segments", () => {
+    expect(getWatchLocaleSegmentIndex([])).toBe(-1)
+  })
+
+  it("returns -1 for 1-segment shape", () => {
+    expect(getWatchLocaleSegmentIndex(["jesus.html"])).toBe(-1)
+  })
+
+  it("returns -1 for 4+ segments", () => {
+    expect(getWatchLocaleSegmentIndex(["a", "b", "c", "d"])).toBe(-1)
+  })
+
+  it("accepts both .html-suffixed and bare segments (shape-only check)", () => {
+    expect(getWatchLocaleSegmentIndex(["jesus", "english"])).toBe(1)
+    expect(getWatchLocaleSegmentIndex(["jesus.html", "english.html"])).toBe(1)
   })
 })

--- a/apps/web/src/lib/url-shape.ts
+++ b/apps/web/src/lib/url-shape.ts
@@ -22,6 +22,12 @@ export function appendHtmlSuffix(segment: string): string {
 // Reserved first-segment prefixes that bypass watch URL canonicalization
 // and parsing. Single source of truth — both proxy/canonicalize and the
 // route parser read this set so the two halves cannot drift.
+//
+// Pairs with the matcher regex in apps/web/src/proxy.ts. Narrowing this
+// set reopens any gaps in the matcher (e.g. if the matcher only excludes
+// `_next/static|_next/image|_next/data|_next/webpack-hmr` but
+// canonicalize stops protecting bare `_next`, future Next subtrees slip
+// through). Keep this set BROADER than the matcher.
 export const RESERVED_PREFIXES: ReadonlySet<string> = new Set([
   "api",
   "_next",
@@ -31,3 +37,21 @@ export const RESERVED_PREFIXES: ReadonlySet<string> = new Set([
   "sitemap.xml",
   ".well-known",
 ])
+
+/**
+ * Index of the locale segment for a canonical /watch URL split into
+ * segments. Returns `1` for the 2-segment shape `/{slug}/{locale}`,
+ * `2` for the 3-segment episode shape `/{series}/{episode}/{locale}`,
+ * and `-1` for any other length.
+ *
+ * Single source of truth for the "locale is the last segment" invariant
+ * shared by proxy.ts (isWatchRoute + cookie redirect) and
+ * url-canonicalize.ts (Rule 6 alias resolution).
+ */
+export function getWatchLocaleSegmentIndex(
+  segments: readonly string[],
+): 1 | 2 | -1 {
+  if (segments.length === 2) return 1
+  if (segments.length === 3) return 2
+  return -1
+}

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,44 +1,34 @@
 import { describe, expect, it } from "vitest"
 
-import { proxy } from "./proxy"
+import { proxy, type ProxyRequest } from "./proxy"
 
 type CookieMap = Record<string, string>
 
 function makeRequest(
   pathname: string,
   options: { cookies?: CookieMap; acceptLanguage?: string } = {},
-) {
-  // Minimal NextRequest stand-in. proxy() only touches:
-  //   - request.nextUrl.pathname
-  //   - request.nextUrl.clone()
-  //   - request.nextUrl.searchParams (for ?_lr=1 + one-shot strip)
-  //   - request.cookies.get()
-  //   - request.headers.get()
+): ProxyRequest {
+  // Test stand-in for the `ProxyRequest` structural subset proxy() reads.
+  // No cast needed — the factory's return type matches the production
+  // contract directly.
   const url = new URL(`https://www.jesusfilm.org${pathname}`)
-  const cookies = {
-    get: (name: string) =>
-      options.cookies?.[name] != null
-        ? { name, value: options.cookies[name] }
-        : undefined,
-  }
-  const headers = {
-    get: (name: string) =>
-      name.toLowerCase() === "accept-language"
-        ? (options.acceptLanguage ?? null)
-        : null,
-  }
   return {
     nextUrl: Object.assign(url, {
-      clone: () => {
-        const cloned = new URL(url.toString())
-        return Object.assign(cloned, {
-          clone: () => new URL(cloned.toString()),
-        })
-      },
+      clone: () => new URL(url.toString()),
     }),
-    cookies,
-    headers,
-  } as unknown as Parameters<typeof proxy>[0]
+    cookies: {
+      get: (name: string) =>
+        options.cookies?.[name] != null
+          ? { value: options.cookies[name] }
+          : undefined,
+    },
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "accept-language"
+          ? (options.acceptLanguage ?? null)
+          : null,
+    },
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -11,6 +11,7 @@ function makeRequest(
   // Minimal NextRequest stand-in. proxy() only touches:
   //   - request.nextUrl.pathname
   //   - request.nextUrl.clone()
+  //   - request.nextUrl.searchParams (for ?_lr=1 + one-shot strip)
   //   - request.cookies.get()
   //   - request.headers.get()
   const url = new URL(`https://www.jesusfilm.org${pathname}`)
@@ -28,151 +29,292 @@ function makeRequest(
   }
   return {
     nextUrl: Object.assign(url, {
-      clone: () => new URL(url.toString()),
+      clone: () => {
+        const cloned = new URL(url.toString())
+        return Object.assign(cloned, {
+          clone: () => new URL(cloned.toString()),
+        })
+      },
     }),
     cookies,
     headers,
   } as unknown as Parameters<typeof proxy>[0]
 }
 
-describe("proxy — language preference cookie", () => {
-  it("redirects /<slug>/<locale> to /<slug>/<preferredSlug> when cookie disagrees", () => {
-    const request = makeRequest("/jesus/english", {
-      cookies: { forge_watch_lang: "spanish" },
-    })
-    const response = proxy(request)
+// ---------------------------------------------------------------------------
+// Phase 3 canonicalize integration — every row from research §5.4 must
+// produce the exact (status, Location) tuple, AND every redirect must
+// emit Cache-Control: private, max-age=0 for the cutover window.
+// ---------------------------------------------------------------------------
+
+describe("proxy — canonicalize integration (§5.4)", () => {
+  it("strips trailing slash on /watch root variant → 308", () => {
+    const response = proxy(makeRequest("/foo/"))
+    // /foo/ → Rule 1 (trailing slash) THEN Rule 4 (.html append)
+    // Net redirect; one hop; 307 (not just trailing-slash) because Rule 4 fired.
     expect(response.status).toBe(307)
-    const location = response.headers.get("location")
-    expect(location).toContain("/jesus/spanish")
+    expect(response.headers.get("location")).toContain("/foo.html/foo.html")
   })
 
-  it("does not redirect when cookie matches the URL locale", () => {
-    const request = makeRequest("/jesus/spanish", {
-      cookies: { forge_watch_lang: "spanish" },
-    })
-    const response = proxy(request)
-    expect(response.status).not.toBe(307)
+  it("strips trailing slash on .html-shape /jesus.html/ → 308 → /jesus.html", () => {
+    const response = proxy(makeRequest("/jesus.html/"))
+    expect(response.status).toBe(308)
+    expect(response.headers.get("location")).toMatch(/\/jesus\.html($|\?)/)
   })
 
-  it("does not redirect when no cookie is set", () => {
-    const request = makeRequest("/jesus/english")
-    const response = proxy(request)
-    expect(response.status).not.toBe(307)
+  it("strips trailing slash on full .html shape → 308", () => {
+    const response = proxy(makeRequest("/jesus.html/english.html/"))
+    expect(response.status).toBe(308)
+    expect(response.headers.get("location")).toContain(
+      "/jesus.html/english.html",
+    )
   })
 
-  it("URL-decodes the cookie value before comparing", () => {
-    const request = makeRequest("/jesus/english", {
-      cookies: { forge_watch_lang: encodeURIComponent("chinese-simplified") },
-    })
-    const response = proxy(request)
+  it("lowercases uppercase .HTML → 307", () => {
+    const response = proxy(makeRequest("/jesus.HTML/english.html"))
     expect(response.status).toBe(307)
     expect(response.headers.get("location")).toContain(
-      "/jesus/chinese-simplified",
+      "/jesus.html/english.html",
     )
   })
 
-  it("ignores a malformed cookie value rather than crashing", () => {
-    const request = makeRequest("/jesus/english", {
-      cookies: { forge_watch_lang: "%E0%A4%A" }, // truncated percent-escape
-    })
-    const response = proxy(request)
-    expect(response.status).not.toBe(307)
-  })
-
-  it("ignores an empty cookie value", () => {
-    const request = makeRequest("/jesus/english", {
-      cookies: { forge_watch_lang: "" },
-    })
-    const response = proxy(request)
-    expect(response.status).not.toBe(307)
-  })
-
-  it("ignores a cookie value longer than the 64-char cap", () => {
-    // Pathological tampered cookie — passes the regex shape check but is
-    // not plausibly a real language slug.
-    const longSlug = "a".repeat(100)
-    const request = makeRequest("/jesus/english", {
-      cookies: { forge_watch_lang: longSlug },
-    })
-    const response = proxy(request)
-    expect(response.status).not.toBe(307)
-  })
-})
-
-describe("proxy — non-watch routes are unaffected by the cookie", () => {
-  it("does not redirect a single-segment path even with a cookie", () => {
-    const request = makeRequest("/jesus", {
-      cookies: { forge_watch_lang: "spanish" },
-    })
-    const response = proxy(request)
-    // /jesus is not a watch route shape (only 1 segment); cookie ignored.
-    expect(response.status).not.toBe(307)
-  })
-
-  it("does not redirect demo-search 3-segment paths even with a cookie", () => {
-    // /demo-search/[slug]/[locale] is 3-segment after basePath strip; the
-    // 2-segment watch-route check naturally excludes it.
-    const request = makeRequest("/demo-search/foo/english", {
-      cookies: { forge_watch_lang: "spanish" },
-    })
-    const response = proxy(request)
-    expect(response.status).not.toBe(307)
-  })
-})
-
-describe("proxy — slug-form watch URLs", () => {
-  it("recognises /jesus/english as a watch route (no Accept-Language append)", () => {
-    // Pre-fix this fell through to the Accept-Language redirect and got
-    // /es appended, producing /jesus/english/es 404s.
-    const request = makeRequest("/jesus/english", { acceptLanguage: "es" })
-    const response = proxy(request)
-    expect(response.status).not.toBe(307)
-  })
-
-  it("redirects slug-form to cookie preference (no /es double-append)", () => {
-    const request = makeRequest("/jesus/english", {
-      cookies: { forge_watch_lang: "spanish" },
-      acceptLanguage: "es",
-    })
-    const response = proxy(request)
+  it("appends missing .html on bare locale segment → 307", () => {
+    const response = proxy(makeRequest("/jesus.html/english"))
     expect(response.status).toBe(307)
-    expect(response.headers.get("location")).toContain("/jesus/spanish")
-    // Must NOT have a third segment appended by the Accept-Language branch
-    expect(response.headers.get("location")).not.toMatch(
-      /\/jesus\/spanish\/es($|\?|#)/,
+    expect(response.headers.get("location")).toContain(
+      "/jesus.html/english.html",
     )
+  })
+
+  it("duplicate-expands single-segment bare slug → 307", () => {
+    const response = proxy(makeRequest("/jesus"))
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain("/jesus.html/jesus.html")
+  })
+
+  it("appends .html per-segment on two-segment bare → 307", () => {
+    const response = proxy(makeRequest("/jesus/english"))
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain(
+      "/jesus.html/english.html",
+    )
+  })
+
+  it("resolves chinese-mandarin alias → mandarin-china → 307", () => {
+    const response = proxy(makeRequest("/jesus.html/chinese-mandarin.html"))
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain(
+      "/jesus.html/mandarin-china.html",
+    )
+  })
+
+  it("rewrites legacy 4-segment episode shape into canonical 3-segment → 307", () => {
+    const response = proxy(
+      makeRequest("/lumo-the-gospel-of-john/wedding-in-cana.html/english.html"),
+    )
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain(
+      "/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+    )
+  })
+
+  it("emits Cache-Control: private, max-age=0 on every canonicalize redirect", () => {
+    const response = proxy(makeRequest("/jesus/english"))
+    expect(response.status).toBe(307)
+    expect(response.headers.get("cache-control")).toBe("private, max-age=0")
+  })
+
+  it("reaches a terminal canonical in one hop (idempotence)", () => {
+    // /jesus → /jesus.html/jesus.html (first hop). Re-feeding the output
+    // through proxy should NOT produce another redirect.
+    const second = proxy(makeRequest("/jesus.html/jesus.html"))
+    expect(second.status).not.toBe(307)
+    expect(second.status).not.toBe(308)
   })
 })
 
-describe("proxy — query string handling on language redirect", () => {
-  it("strips ?autoplay=1 on cross-variant redirect (originating-gesture only)", () => {
-    const request = makeRequest("/jesus/english?autoplay=1", {
-      cookies: { forge_watch_lang: "spanish" },
-    })
-    const response = proxy(request)
+// ---------------------------------------------------------------------------
+// Reserved-subtree pass-through. The matcher OR canonicalize's RESERVED_PREFIXES
+// guard MUST keep these from being amplified by Rule 5.
+// ---------------------------------------------------------------------------
+
+describe("proxy — reserved-subtree pass-through", () => {
+  it("does not rewrite /assets/* (would amplify into /assets.html/...)", () => {
+    const response = proxy(makeRequest("/assets/footer/facebook.svg"))
+    expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
+  })
+
+  it("does not rewrite /api/preview", () => {
+    const response = proxy(makeRequest("/api/preview"))
+    expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
+  })
+
+  it("does not rewrite /_next/data/...", () => {
+    const response = proxy(makeRequest("/_next/data/build/x.json"))
+    expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
+  })
+
+  it("does not rewrite /.well-known/security.txt", () => {
+    const response = proxy(makeRequest("/.well-known/security.txt"))
+    expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cookie-driven language preference on .html shape (2-segment + 3-segment).
+// ---------------------------------------------------------------------------
+
+describe("proxy — cookie language preference on canonical .html shape", () => {
+  it("redirects 2-segment /jesus.html/english.html to /jesus.html/<pref>.html when cookie disagrees", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain(
+      "/jesus.html/spanish.html",
+    )
+  })
+
+  it("does not redirect when 2-seg cookie matches URL locale (.html-aware compare)", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/spanish.html", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
+    expect(response.status).not.toBe(307)
+  })
+
+  it("redirects 3-segment /series.html/episode/english.html to /series.html/episode/<pref>.html", () => {
+    const response = proxy(
+      makeRequest(
+        "/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+        {
+          cookies: { forge_watch_lang: "spanish" },
+        },
+      ),
+    )
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain(
+      "/lumo-the-gospel-of-john.html/wedding-in-cana/spanish.html",
+    )
+  })
+
+  it("emits Cache-Control: private, max-age=0 on cookie redirect", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
+    expect(response.headers.get("cache-control")).toBe("private, max-age=0")
+  })
+
+  it("bypasses cookie redirect when ?_lr=1 is present", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html?_lr=1", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
+    expect(response.status).not.toBe(307)
+  })
+
+  it("strips ?autoplay=1 on cross-variant redirect", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html?autoplay=1", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
     expect(response.status).toBe(307)
     const location = response.headers.get("location") ?? ""
-    expect(location).toContain("/jesus/spanish")
+    expect(location).toContain("/jesus.html/spanish.html")
     expect(location).not.toContain("autoplay=1")
   })
 
-  it("strips ?t=120 on cross-variant redirect (timestamp ties to source variant)", () => {
-    const request = makeRequest("/jesus/english?t=120", {
-      cookies: { forge_watch_lang: "spanish" },
-    })
-    const response = proxy(request)
+  it("strips ?t=120 on cross-variant redirect", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html?t=120", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
     expect(response.status).toBe(307)
-    const location = response.headers.get("location") ?? ""
-    expect(location).toContain("/jesus/spanish")
-    expect(location).not.toMatch(/[?&]t=120/)
+    expect(response.headers.get("location") ?? "").not.toMatch(/[?&]t=120/)
   })
 
-  it("preserves unrelated query params on cross-variant redirect", () => {
-    const request = makeRequest("/jesus/english?source=share", {
-      cookies: { forge_watch_lang: "spanish" },
-    })
-    const response = proxy(request)
+  it("preserves unrelated query params on cookie redirect", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html?source=share", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
     expect(response.status).toBe(307)
     expect(response.headers.get("location")).toContain("source=share")
+  })
+
+  it("ignores malformed cookie value (truncated percent-escape)", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html", {
+        cookies: { forge_watch_lang: "%E0%A4%A" },
+      }),
+    )
+    expect(response.status).not.toBe(307)
+  })
+
+  it("ignores cookie value longer than 64-char cap", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html", {
+        cookies: { forge_watch_lang: "a".repeat(100) },
+      }),
+    )
+    expect(response.status).not.toBe(307)
+  })
+
+  it("URL-decodes cookie value before comparing", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html", {
+        cookies: {
+          forge_watch_lang: encodeURIComponent("chinese-simplified"),
+        },
+      }),
+    )
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain(
+      "/jesus.html/chinese-simplified.html",
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Resilience: malformed inputs do not crash. Canonical shape is preserved.
+// ---------------------------------------------------------------------------
+
+describe("proxy — resilience on malformed inputs", () => {
+  it("handles double-.html on a segment without crashing", () => {
+    // Not a recognised rule input. Just must not throw.
+    expect(() =>
+      proxy(makeRequest("/jesus.html.html/english.html")),
+    ).not.toThrow()
+  })
+
+  it("handles empty segment (/.html) without crashing", () => {
+    expect(() => proxy(makeRequest("/.html"))).not.toThrow()
+  })
+
+  it("does not rewrite percent-encoded paths (positive allowlist rejects)", () => {
+    const response = proxy(makeRequest("/jesus%20test/english"))
+    expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
+  })
+
+  it("does not rewrite cyrillic slugs (positive allowlist rejects non-ASCII)", () => {
+    const response = proxy(
+      makeRequest(`/${encodeURIComponent("Иисус")}/english`),
+    )
+    expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
   })
 })

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server"
-import type { NextRequest } from "next/server"
 import { LANGUAGE_PREFERENCE_COOKIE } from "@/lib/language-preference-constants"
 import {
   DEFAULT_LOCALE,
@@ -8,7 +7,11 @@ import {
   parseAcceptLanguage,
 } from "@/lib/locale"
 import { canonicalizeWatchPath } from "@/lib/url-canonicalize"
-import { hasHtmlSuffix, stripHtmlSuffix } from "@/lib/url-shape"
+import {
+  getWatchLocaleSegmentIndex,
+  hasHtmlSuffix,
+  stripHtmlSuffix,
+} from "@/lib/url-shape"
 
 // Slug shape that the watch picker writes — kebab-case ASCII or bcp47
 // codes. Used by both isWatchRoute (to recognise slug-form watch URLs
@@ -23,6 +26,24 @@ const PREFERRED_LANG_SLUG = /^[a-z0-9-]+$/
 // additions without admitting pathological values from a tampered
 // cookie (e.g. a megabyte-sized string passing the regex).
 const PREFERRED_LANG_SLUG_MAX_LEN = 64
+
+// Structural subset of `NextRequest` that `proxy()` actually consumes.
+// Declaring the precise surface (rather than the full NextRequest type)
+// (1) documents the contract, (2) lets the test fixture satisfy the
+// signature without a double-cast, and (3) prevents accidental reliance
+// on future NextRequest fields that haven't been mocked.
+//
+// Production `NextRequest` from `next/server` satisfies this shape via
+// structural subtyping — no runtime adapter needed.
+export type ProxyRequest = {
+  nextUrl: {
+    readonly pathname: string
+    readonly searchParams: { has: (name: string) => boolean }
+    clone: () => URL
+  }
+  cookies: { get: (name: string) => { value: string } | undefined }
+  headers: { get: (name: string) => string | null }
+}
 
 // Cache-Control emitted on every proxy-issued redirect during the cutover
 // window. Prevents Cloudflare / browser caches from pinning a 307/308 to
@@ -49,19 +70,12 @@ function buildRedirect(url: URL, status: 307 | 308): NextResponse {
 // consistent across legacy + canonical traffic during cutover.
 function isWatchRoute(pathname: string): boolean {
   const segments = pathname.split("/").filter(Boolean)
-  if (segments.length === 2) {
-    const last = segments[1]
-    if (last == null) return false
-    const bare = stripHtmlSuffix(last)
-    return isLocale(bare) || PREFERRED_LANG_SLUG.test(bare)
-  }
-  if (segments.length === 3) {
-    const last = segments[2]
-    if (last == null) return false
-    const bare = stripHtmlSuffix(last)
-    return isLocale(bare) || PREFERRED_LANG_SLUG.test(bare)
-  }
-  return false
+  const localeIdx = getWatchLocaleSegmentIndex(segments)
+  if (localeIdx < 0) return false
+  const last = segments[localeIdx]
+  if (last == null) return false
+  const bare = stripHtmlSuffix(last)
+  return isLocale(bare) || PREFERRED_LANG_SLUG.test(bare)
 }
 
 function applyWatchSecurityHeaders(response: NextResponse): NextResponse {
@@ -93,7 +107,7 @@ const ONE_SHOT_QUERY_PARAMS = ["autoplay", "t"] as const
 // cookie language has no variant for a given video, the page falls back
 // to the experience template rather than crashing.
 function maybeRedirectToPreferredLanguage(
-  request: NextRequest,
+  request: ProxyRequest,
   pathname: string,
 ): NextResponse | null {
   if (!isWatchRoute(pathname)) return null
@@ -114,10 +128,7 @@ function maybeRedirectToPreferredLanguage(
   if (preferredSlug.length > PREFERRED_LANG_SLUG_MAX_LEN) return null
   if (!PREFERRED_LANG_SLUG.test(preferredSlug)) return null
   const segments = pathname.split("/").filter(Boolean)
-  // Index of the locale segment depends on shape:
-  //   2-segment: /{slug}/{locale}                → idx 1
-  //   3-segment: /{series}/{episode}/{locale}    → idx 2
-  const localeIdx = segments.length === 2 ? 1 : segments.length === 3 ? 2 : -1
+  const localeIdx = getWatchLocaleSegmentIndex(segments)
   if (localeIdx < 0) return null
   const currentLocaleSeg = segments[localeIdx]
   if (!currentLocaleSeg) return null
@@ -136,7 +147,7 @@ function maybeRedirectToPreferredLanguage(
   return buildRedirect(url, 307)
 }
 
-export function proxy(request: NextRequest) {
+export function proxy(request: ProxyRequest): NextResponse {
   const { pathname } = request.nextUrl
 
   // Step 1: canonicalize legacy /watch shapes into the .html-suffix

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -7,6 +7,8 @@ import {
   isLocale,
   parseAcceptLanguage,
 } from "@/lib/locale"
+import { canonicalizeWatchPath } from "@/lib/url-canonicalize"
+import { hasHtmlSuffix, stripHtmlSuffix } from "@/lib/url-shape"
 
 // Slug shape that the watch picker writes — kebab-case ASCII or bcp47
 // codes. Used by both isWatchRoute (to recognise slug-form watch URLs
@@ -22,21 +24,44 @@ const PREFERRED_LANG_SLUG = /^[a-z0-9-]+$/
 // cookie (e.g. a megabyte-sized string passing the regex).
 const PREFERRED_LANG_SLUG_MAX_LEN = 64
 
+// Cache-Control emitted on every proxy-issued redirect during the cutover
+// window. Prevents Cloudflare / browser caches from pinning a 307/308 to
+// a stale legacy URL — every redirect is per-request user-state-dependent
+// (cookie) or aliased (canonicalize) and must not be reused across users.
+const REDIRECT_CACHE_CONTROL = "private, max-age=0"
+
+function buildRedirect(url: URL, status: 307 | 308): NextResponse {
+  const response = NextResponse.redirect(url, status)
+  response.headers.set("Cache-Control", REDIRECT_CACHE_CONTROL)
+  return response
+}
+
 // Matched after Next.js strips `basePath: '/watch'`, so a real request
 // for `/watch/foo/en` is matched here as `/foo/en`. Recognises both
 // bcp47 codes ('en', 'es') and slug-form language identifiers
-// ('english', 'spanish', 'arabic-modern-standard') — the watch picker
-// navigates with slug-form, so the proxy must treat both as valid watch
-// shapes to:
-//   (1) apply CSP headers consistently, and
-//   (2) skip the Accept-Language redirect for slug-form URLs (which
-//       would otherwise produce 3-segment 404s like /jesus/english/es).
+// ('english', 'spanish', 'arabic-modern-standard'), in both bare and
+// `.html`-suffix shapes (post-Phase-2 canonical):
+//   - 2-segment: /{slug}/{locale}              (legacy)
+//   - 2-segment: /{slug}.html/{locale}.html    (canonical)
+//   - 3-segment: /{series}.html/{episode}/{locale}.html (canonical episode)
+//
+// CSP headers are applied for both shapes so the watch route policy is
+// consistent across legacy + canonical traffic during cutover.
 function isWatchRoute(pathname: string): boolean {
   const segments = pathname.split("/").filter(Boolean)
-  if (segments.length !== 2) return false
-  const last = segments[1]
-  if (last == null) return false
-  return isLocale(last) || PREFERRED_LANG_SLUG.test(last)
+  if (segments.length === 2) {
+    const last = segments[1]
+    if (last == null) return false
+    const bare = stripHtmlSuffix(last)
+    return isLocale(bare) || PREFERRED_LANG_SLUG.test(bare)
+  }
+  if (segments.length === 3) {
+    const last = segments[2]
+    if (last == null) return false
+    const bare = stripHtmlSuffix(last)
+    return isLocale(bare) || PREFERRED_LANG_SLUG.test(bare)
+  }
+  return false
 }
 
 function applyWatchSecurityHeaders(response: NextResponse): NextResponse {
@@ -58,28 +83,24 @@ const ONE_SHOT_QUERY_PARAMS = ["autoplay", "t"] as const
 // route eligible for ISR caching (cookies() in a page silently opts the
 // route out of ISR; see docs/solutions/web/nextjs-headers-defeats-route-cache.md).
 //
-// Trade-off: the proxy doesn't know whether the preferred language has a
-// playable variant for this specific video. The previous page-level check
-// guarded against redirecting to a non-existent variant; we accept the
-// simpler proxy-level redirect because:
-//   - Returning users (those with a cookie) are a minority.
-//   - When the cookie language has no variant for a given video, the page
-//     falls back to the experience template rather than crashing.
-//   - The win is significant: most watch-page traffic (no cookie) stays
-//     ISR-cached. See also PR #903 which moved locale detection out of
-//     the page for the same reason.
+// Phase 3: operates on canonical `.html`-shape URLs and supports both
+// 2-segment (locale at segments[1]) and 3-segment episode (locale at
+// segments[2]) shapes. The locale segment may be `.html`-suffixed; we
+// strip the suffix before comparing to the cookie value (which is bare).
+//
+// Trade-off (unchanged): the proxy doesn't know whether the preferred
+// language has a playable variant for this specific video. When the
+// cookie language has no variant for a given video, the page falls back
+// to the experience template rather than crashing.
 function maybeRedirectToPreferredLanguage(
   request: NextRequest,
   pathname: string,
 ): NextResponse | null {
-  // Only fire for watch routes. Otherwise /demo-search/<slug>/<locale> and
-  // similar 2-segment paths would receive an unintended cookie redirect.
   if (!isWatchRoute(pathname)) return null
   // `LOCALE_RESOLVED_PARAM` is the page's signal that it has already
-  // resolved the URL locale to match the actually-rendered variant
-  // (see the watchVideo branch in [slug]/[locale]/page.tsx). Without
-  // this bypass the cookie redirect bounces the user back to a locale
-  // with no playable variant; the page would loop redirecting forever.
+  // resolved the URL locale to match the actually-rendered variant.
+  // Without this bypass the cookie redirect bounces the user back to a
+  // locale with no playable variant; the page would loop redirecting.
   if (request.nextUrl.searchParams.has(LOCALE_RESOLVED_PARAM)) return null
   const rawCookie = request.cookies.get(LANGUAGE_PREFERENCE_COOKIE)?.value
   if (!rawCookie) return null
@@ -87,44 +108,64 @@ function maybeRedirectToPreferredLanguage(
   try {
     preferredSlug = decodeURIComponent(rawCookie)
   } catch {
-    // Cookie value is malformed; ignore the preference.
     return null
   }
   if (!preferredSlug) return null
   if (preferredSlug.length > PREFERRED_LANG_SLUG_MAX_LEN) return null
   if (!PREFERRED_LANG_SLUG.test(preferredSlug)) return null
   const segments = pathname.split("/").filter(Boolean)
-  const [slug, currentLocale] = segments
-  if (!slug || !currentLocale) return null
-  if (preferredSlug === currentLocale) return null
+  // Index of the locale segment depends on shape:
+  //   2-segment: /{slug}/{locale}                → idx 1
+  //   3-segment: /{series}/{episode}/{locale}    → idx 2
+  const localeIdx = segments.length === 2 ? 1 : segments.length === 3 ? 2 : -1
+  if (localeIdx < 0) return null
+  const currentLocaleSeg = segments[localeIdx]
+  if (!currentLocaleSeg) return null
+  const currentLocaleBare = stripHtmlSuffix(currentLocaleSeg)
+  if (preferredSlug === currentLocaleBare) return null
+  // Rebuild path preserving the .html-suffix shape of the locale segment.
+  const localeHadHtml = hasHtmlSuffix(currentLocaleSeg)
+  const newLocaleSeg = localeHadHtml ? `${preferredSlug}.html` : preferredSlug
+  const newSegments = segments.slice()
+  newSegments[localeIdx] = newLocaleSeg
   const url = request.nextUrl.clone()
-  // basePath '/watch' is auto-prepended; pathname here is post-strip.
-  url.pathname = `/${slug}/${preferredSlug}`
-  // Drop one-shot signals tied to the originating slug. See
-  // ONE_SHOT_QUERY_PARAMS for the rationale.
+  url.pathname = `/${newSegments.join("/")}`
   for (const param of ONE_SHOT_QUERY_PARAMS) {
     url.searchParams.delete(param)
   }
-  return NextResponse.redirect(url, 307)
+  return buildRedirect(url, 307)
 }
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  // Language-preference redirect runs first. It is now scoped to watch
-  // routes inside `maybeRedirectToPreferredLanguage`, so non-watch
-  // 2-segment paths (e.g. /demo-search/<slug>/<locale>) are unaffected.
+  // Step 1: canonicalize legacy /watch shapes into the .html-suffix
+  // canonical. Single deterministic pass — six rules with a termination
+  // guarantee (canonicalize ∘ canonicalize === canonicalize). Reserved
+  // subtrees (api, _next, assets, favicon, robots, sitemap, .well-known)
+  // are excluded at the canonicalize level so framework asset URLs are
+  // never amplified by Rule 5's single-segment-duplicate rule.
+  const canonical = canonicalizeWatchPath({ rawPathname: pathname })
+  if (canonical.kind === "redirect") {
+    const url = request.nextUrl.clone()
+    url.pathname = canonical.pathname
+    return buildRedirect(url, canonical.status)
+  }
+
+  // Step 2: cookie-driven language preference redirect on canonical
+  // shape (.html-aware, 2-seg + 3-seg).
   const preferenceRedirect = maybeRedirectToPreferredLanguage(request, pathname)
   if (preferenceRedirect) return preferenceRedirect
 
-  // Apply CSP/Referrer headers for watch routes — both bcp47-form and
-  // slug-form (isWatchRoute now recognises both, so slug-form watch URLs
-  // also receive the security headers, and they are exempted from the
-  // Accept-Language redirect block below).
+  // Step 3: CSP / Referrer headers for watch routes (both .html and
+  // legacy bare 2-segment forms; 3-segment episode shape included).
   if (isWatchRoute(pathname)) {
     return applyWatchSecurityHeaders(NextResponse.next())
   }
 
+  // Step 4: Accept-Language fallback for non-watch shapes. Preserved
+  // unchanged from pre-Phase-3 behaviour — fires only when the path does
+  // not already terminate in a bcp47 locale segment.
   const segments = pathname.split("/").filter(Boolean)
   const lastSegment = segments[segments.length - 1]
   if (lastSegment && isLocale(lastSegment)) {
@@ -138,11 +179,16 @@ export function proxy(request: NextRequest) {
 
   const url = request.nextUrl.clone()
   url.pathname = `${pathname === "/" ? "" : pathname}/${detected}`
-  return NextResponse.redirect(url, 307)
+  return buildRedirect(url, 307)
 }
 
 export const config = {
   matcher: [
-    "/((?!api|_next/static|_next/image|favicon\\.ico|robots\\.txt|sitemap\\.xml).*)",
+    // Reserved framework + asset subtrees that must never enter the
+    // canonicalize pipeline (Rule 5's single-segment duplicate would
+    // amplify e.g. /assets into /assets.html/assets.html). The matcher
+    // is the first line of defense; canonicalize's RESERVED_PREFIXES is
+    // the second. Both must agree.
+    "/((?!api|_next/static|_next/image|_next/data|_next/webpack-hmr|assets|favicon\\.ico|robots\\.txt|sitemap|\\.well-known).*)",
   ],
 }


### PR DESCRIPTION
## Summary

- Replace ad-hoc redirect logic in `apps/web/src/proxy.ts` with the Phase 1 `canonicalizeWatchPath` composed canonicalizer. Six normalization rules + language-slug alias resolution run in one deterministic pass.
- Cookie-driven language preference now operates on canonical `.html`-shape URLs and supports the three-segment episode shape (locale at `segments[2]`). One-shot query params (`?t`, `?autoplay`) still strip on the cross-variant hop.
- Every proxy-issued redirect emits `Cache-Control: private, max-age=0` for the cutover window — keeps Cloudflare from pinning stale 307/308s.
- Matcher widened to exclude `_next/data`, `_next/webpack-hmr`, `assets`, broader `sitemap`, and `.well-known`. RESERVED_PREFIXES in canonicalize is the second line of defense.

## Test plan

- [x] `pnpm --filter @forge/web test -- --run src/proxy.test.ts` — 30 tests, every §5.4 row + cookie redirect on 2-seg/3-seg + reserved subtree pass-through + Cache-Control + ?_lr=1 bypass + one-shot strip + idempotence one-hop
- [x] `pnpm --filter @forge/web test -- --run` — 818 tests pass
- [x] `pnpm --filter @forge/web lint` — clean
- [x] `pnpm --filter @forge/web typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)