### PR TITLE
fix(web): harden /watch proxy from Phase 3 review (009-016)

### DIFF
--- a/apps/web/src/lib/url-canonicalize.ts
+++ b/apps/web/src/lib/url-canonicalize.ts
@@ -14,8 +14,11 @@ import { tryResolveLanguageAlias } from "./language-aliases"
 import {
   HTML_SUFFIX,
   RESERVED_PREFIXES,
+  SAFE_SLUG_PATTERN,
+  UNSAFE_PATH_PATTERN,
   getWatchLocaleSegmentIndex,
   hasHtmlSuffix,
+  isUnsafeRedirectPath,
   stripHtmlSuffix,
 } from "./url-shape"
 
@@ -54,20 +57,16 @@ const MAX_PATH_LEN = 2048
 // other 1-segment slug is treated as legacy and duplicate-expanded.
 const ONE_SEGMENT_EXEMPT = new Set(["videos", "search"])
 
-// Origin-invariance + injection guards. Any input that fails MUST short-circuit
+// Origin-invariance + injection guard. Any input that fails MUST short-circuit
 // to `{kind: "canonical"}` (let the route handler 404 it). NEVER emit a
 // Location derived from a path that could escape origin (// at start, \, CRLF,
-// percent-encoded CRLF) or carry traversal (.. segments).
-const UNSAFE_INPUT = /(^\/\/)|[\\\r\n]|(%0[ad])/i
+// percent-encoded CRLF) or carry traversal (.. segments). Shared with proxy.ts
+// via `UNSAFE_PATH_PATTERN` in url-shape.ts.
 
 // Positive allowlist applied after the negative guards. Rejects any path
 // containing percent-encoding, colons, query/fragment markers, or non-ASCII.
 // Only ASCII URL-safe path characters survive into the rule chain.
 const SAFE_PATH = /^\/[A-Za-z0-9._\-/]+$/
-
-// SLUG_PATTERN constrains Rule 5 (single-segment-duplicate) so host-shaped
-// inputs like /evil.com don't get amplified into /evil.com.html/evil.com.html.
-const SLUG_PATTERN_SAFE = /^[a-z0-9-]+$/
 
 const HTML_SUFFIX_LOWER = HTML_SUFFIX // ".html"
 const HTML_SUFFIX_REGEX_GI = /\.html(?=\/|$)/gi
@@ -104,7 +103,7 @@ export function canonicalizeWatchPath(
   }
 
   // 0c: injection guard — origin invariance + CRLF + traversal
-  if (UNSAFE_INPUT.test(raw)) return { kind: "canonical" }
+  if (UNSAFE_PATH_PATTERN.test(raw)) return { kind: "canonical" }
   if (raw.split("/").some((seg) => seg === "..")) {
     return { kind: "canonical" }
   }
@@ -210,7 +209,7 @@ export function canonicalizeWatchPath(
       segs.length === 1 &&
       !hasHtmlSuffix(segs[0]) &&
       !ONE_SEGMENT_EXEMPT.has(segs[0]) &&
-      SLUG_PATTERN_SAFE.test(segs[0])
+      SAFE_SLUG_PATTERN.test(segs[0])
     ) {
       path = `/${segs[0]}${HTML_SUFFIX_LOWER}/${segs[0]}${HTML_SUFFIX_LOWER}`
       onlyTrailingSlashChanged = false
@@ -236,11 +235,9 @@ export function canonicalizeWatchPath(
   if (path === raw) return { kind: "canonical" }
 
   // Defense-in-depth: re-check origin-invariance on the output. Any rule
-  // composition that synthesized an unsafe Location MUST be rejected.
-  if (UNSAFE_INPUT.test(path)) return { kind: "canonical" }
-  if (!path.startsWith("/") || path.startsWith("//")) {
-    return { kind: "canonical" }
-  }
+  // composition that synthesized an unsafe Location MUST be rejected. Same
+  // guard proxy.ts applies to its cookie-redirect output.
+  if (isUnsafeRedirectPath(path)) return { kind: "canonical" }
 
   return {
     kind: "redirect",

--- a/apps/web/src/lib/url-shape.test.ts
+++ b/apps/web/src/lib/url-shape.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest"
 import {
   HTML_SUFFIX,
   HTML_SUFFIX_REGEX,
+  SAFE_SLUG_PATTERN,
+  UNSAFE_PATH_PATTERN,
   appendHtmlSuffix,
   getWatchLocaleSegmentIndex,
   hasHtmlSuffix,
+  isUnsafeRedirectPath,
   stripHtmlSuffix,
 } from "./url-shape"
 
@@ -117,5 +120,51 @@ describe("getWatchLocaleSegmentIndex", () => {
   it("accepts both .html-suffixed and bare segments (shape-only check)", () => {
     expect(getWatchLocaleSegmentIndex(["jesus", "english"])).toBe(1)
     expect(getWatchLocaleSegmentIndex(["jesus.html", "english.html"])).toBe(1)
+  })
+})
+
+describe("SAFE_SLUG_PATTERN", () => {
+  it("accepts kebab-case ASCII slugs", () => {
+    expect(SAFE_SLUG_PATTERN.test("english")).toBe(true)
+    expect(SAFE_SLUG_PATTERN.test("spanish-castilian")).toBe(true)
+    expect(SAFE_SLUG_PATTERN.test("arabic-modern-standard")).toBe(true)
+    expect(SAFE_SLUG_PATTERN.test("magdalena-2")).toBe(true)
+  })
+
+  it("rejects uppercase, dots, slashes, and host shapes", () => {
+    expect(SAFE_SLUG_PATTERN.test("English")).toBe(false)
+    expect(SAFE_SLUG_PATTERN.test("jesus.html")).toBe(false)
+    expect(SAFE_SLUG_PATTERN.test("a/b")).toBe(false)
+    expect(SAFE_SLUG_PATTERN.test("evil.com")).toBe(false)
+    expect(SAFE_SLUG_PATTERN.test("")).toBe(false)
+  })
+})
+
+describe("UNSAFE_PATH_PATTERN / isUnsafeRedirectPath", () => {
+  it("flags protocol-relative and escape vectors", () => {
+    expect(isUnsafeRedirectPath("//evil.com")).toBe(true)
+    expect(isUnsafeRedirectPath("/foo\\bar")).toBe(true)
+    expect(isUnsafeRedirectPath("/foo\r\nSet-Cookie: x")).toBe(true)
+    expect(isUnsafeRedirectPath("/foo%0d%0abar")).toBe(true)
+    expect(isUnsafeRedirectPath("/foo%0Abar")).toBe(true)
+  })
+
+  it("flags non-absolute paths", () => {
+    expect(isUnsafeRedirectPath("foo/bar")).toBe(true)
+    expect(isUnsafeRedirectPath("")).toBe(true)
+  })
+
+  it("accepts well-formed canonical watch paths", () => {
+    expect(isUnsafeRedirectPath("/jesus.html/english.html")).toBe(false)
+    expect(
+      isUnsafeRedirectPath(
+        "/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+      ),
+    ).toBe(false)
+  })
+
+  it("UNSAFE_PATH_PATTERN matches the raw escape classes", () => {
+    expect(UNSAFE_PATH_PATTERN.test("//x")).toBe(true)
+    expect(UNSAFE_PATH_PATTERN.test("/ok/path")).toBe(false)
   })
 })

--- a/apps/web/src/lib/url-shape.ts
+++ b/apps/web/src/lib/url-shape.ts
@@ -55,3 +55,31 @@ export function getWatchLocaleSegmentIndex(
   if (segments.length === 3) return 2
   return -1
 }
+
+// Origin-invariance + header-injection guard. Matches any path that could
+// escape origin (leading `//`, backslash) or carry CRLF / percent-encoded
+// CRLF for header injection. Single source of truth: both
+// url-canonicalize.ts (input + output revalidation) and proxy.ts (cookie
+// redirect output revalidation) test every synthesized Location against it.
+export const UNSAFE_PATH_PATTERN = /(^\/\/)|[\\\r\n]|(%0[ad])/i
+
+/**
+ * True if a synthesized redirect path could escape origin or inject
+ * headers. Combines the `UNSAFE_PATH_PATTERN` scan with the absolute-path
+ * + no-protocol-relative invariants. Every redirect Location built from
+ * partly-untrusted input MUST pass `!isUnsafeRedirectPath(path)` before
+ * being emitted.
+ */
+export function isUnsafeRedirectPath(path: string): boolean {
+  return (
+    UNSAFE_PATH_PATTERN.test(path) ||
+    !path.startsWith("/") ||
+    path.startsWith("//")
+  )
+}
+
+// Kebab-case ASCII slug: lowercase alphanumerics + hyphen. The canonical
+// URL-segment vocabulary. Single source of truth shared by proxy.ts (the
+// language-preference cookie validator) and url-canonicalize.ts (the Rule 5
+// single-segment-duplicate guard that rejects host-shaped segments).
+export const SAFE_SLUG_PATTERN = /^[a-z0-9-]+$/

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { proxy, type ProxyRequest } from "./proxy"
+import { canonicalizeWatchPath } from "./lib/url-canonicalize"
 
 type CookieMap = Record<string, string>
 
@@ -305,5 +306,74 @@ describe("proxy — resilience on malformed inputs", () => {
     )
     expect(response.status).not.toBe(307)
     expect(response.status).not.toBe(308)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Vary: Cookie — only cookie-dependent redirects carry it (todo 009).
+// ---------------------------------------------------------------------------
+
+describe("proxy — Vary: Cookie on cookie-dependent redirects only", () => {
+  it("sets Vary: Cookie on the cookie-preference redirect", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html", {
+        cookies: { forge_watch_lang: "spanish" },
+      }),
+    )
+    expect(response.status).toBe(307)
+    expect(response.headers.get("vary")).toBe("Cookie")
+  })
+
+  it("does NOT set Vary: Cookie on a canonicalize redirect (not cookie-dependent)", () => {
+    const response = proxy(makeRequest("/jesus/english"))
+    expect(response.status).toBe(307)
+    expect(response.headers.get("vary")).toBeNull()
+  })
+})
+
+// Note: the cookie-path output revalidation (todo 010) is unit-tested at the
+// `isUnsafeRedirectPath` boundary in `lib/url-shape.test.ts` — the WHATWG URL
+// parser in the proxy test fixture normalizes `\`/`//` before they reach the
+// guard, so the guard itself is exercised directly instead.
+
+// ---------------------------------------------------------------------------
+// Cross-module idempotence: the cookie redirect's output must already be
+// canonical, so the next request converges in one hop (todo 011).
+// ---------------------------------------------------------------------------
+
+describe("proxy — cookie redirect output is canonical (single-hop convergence)", () => {
+  for (const input of [
+    "/jesus.html/english.html",
+    "/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+  ]) {
+    it(`canonicalize(cookieRedirect("${input}")) is canonical`, () => {
+      const r1 = proxy(
+        makeRequest(input, { cookies: { forge_watch_lang: "spanish" } }),
+      )
+      expect(r1.status).toBe(307)
+      const next = new URL(r1.headers.get("location") ?? "").pathname
+      const r2 = canonicalizeWatchPath({ rawPathname: next })
+      expect(r2.kind).toBe("canonical")
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Slug-form cookie values (e.g. spanish-castilian) round-trip into the
+// redirected locale segment (todo 014). Downstream page-level resolution is
+// slug-aware (resolveUiLocale), so the family-fallback locale renders.
+// ---------------------------------------------------------------------------
+
+describe("proxy — slug-form cookie language preference", () => {
+  it("redirects to a multi-segment slug-form locale (spanish-castilian)", () => {
+    const response = proxy(
+      makeRequest("/jesus.html/english.html", {
+        cookies: { forge_watch_lang: "spanish-castilian" },
+      }),
+    )
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toContain(
+      "/jesus.html/spanish-castilian.html",
+    )
   })
 })

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -9,17 +9,17 @@ import {
 import { WATCH_PATHNAME_HEADER } from "@/lib/proxy-headers"
 import { canonicalizeWatchPath } from "@/lib/url-canonicalize"
 import {
+  SAFE_SLUG_PATTERN,
   getWatchLocaleSegmentIndex,
-  hasHtmlSuffix,
+  isUnsafeRedirectPath,
   stripHtmlSuffix,
 } from "@/lib/url-shape"
 
-// Slug shape that the watch picker writes — kebab-case ASCII or bcp47
-// codes. Used by both isWatchRoute (to recognise slug-form watch URLs
-// like /jesus/english) and the cookie-driven redirect (to validate the
-// cookie value is a safe URL segment — defends against open-redirect /
-// path traversal via tampered cookies).
-const PREFERRED_LANG_SLUG = /^[a-z0-9-]+$/
+// `SAFE_SLUG_PATTERN` (kebab-case ASCII, from url-shape.ts) is the
+// language-slug validator here: it recognises slug-form watch URLs
+// (`/jesus/english`) in isWatchRoute and validates the language-preference
+// cookie value before it lands in a redirect Location (defends against
+// open-redirect / path traversal via a tampered cookie).
 
 // Hard length cap on the cookie value. The longest real Arclight
 // language slug observed in production is ~50 chars
@@ -56,6 +56,10 @@ export type ProxyRequest = {
 // (cookie) or aliased (canonicalize) and must not be reused across users.
 const REDIRECT_CACHE_CONTROL = "private, max-age=0"
 
+// Note: CSP / Referrer headers (applyWatchSecurityHeaders) are intentionally
+// NOT applied to redirects. Browsers ignore CSP on 3xx responses — the policy
+// attaches to the terminal 200 the redirect lands on. Don't "fix" the apparent
+// gap by wrapping buildRedirect in applyWatchSecurityHeaders.
 function buildRedirect(url: URL, status: 307 | 308): NextResponse {
   const response = NextResponse.redirect(url, status)
   response.headers.set("Cache-Control", REDIRECT_CACHE_CONTROL)
@@ -80,7 +84,7 @@ function isWatchRoute(pathname: string): boolean {
   const last = segments[localeIdx]
   if (last == null) return false
   const bare = stripHtmlSuffix(last)
-  return isLocale(bare) || PREFERRED_LANG_SLUG.test(bare)
+  return isLocale(bare) || SAFE_SLUG_PATTERN.test(bare)
 }
 
 function applyWatchSecurityHeaders(response: NextResponse): NextResponse {
@@ -154,7 +158,7 @@ function maybeRedirectToPreferredLanguage(
   }
   if (!preferredSlug) return null
   if (preferredSlug.length > PREFERRED_LANG_SLUG_MAX_LEN) return null
-  if (!PREFERRED_LANG_SLUG.test(preferredSlug)) return null
+  if (!SAFE_SLUG_PATTERN.test(preferredSlug)) return null
   const segments = pathname.split("/").filter(Boolean)
   const localeIdx = getWatchLocaleSegmentIndex(segments)
   if (localeIdx < 0) return null
@@ -162,17 +166,32 @@ function maybeRedirectToPreferredLanguage(
   if (!currentLocaleSeg) return null
   const currentLocaleBare = stripHtmlSuffix(currentLocaleSeg)
   if (preferredSlug === currentLocaleBare) return null
-  // Rebuild path preserving the .html-suffix shape of the locale segment.
-  const localeHadHtml = hasHtmlSuffix(currentLocaleSeg)
-  const newLocaleSeg = localeHadHtml ? `${preferredSlug}.html` : preferredSlug
+  // The locale segment is always `.html`-suffixed here: proxy() runs
+  // canonicalize (Rule 4 appends `.html` to bare locale segments on 2-seg
+  // and 3-seg watch paths) BEFORE this cookie redirect, so any path that
+  // reaches here in canonical form has a `.html` locale. Build the new
+  // segment with the suffix unconditionally.
   const newSegments = segments.slice()
-  newSegments[localeIdx] = newLocaleSeg
+  newSegments[localeIdx] = `${preferredSlug}.html`
   const url = request.nextUrl.clone()
-  url.pathname = `/${newSegments.join("/")}`
+  const candidatePathname = `/${newSegments.join("/")}`
+  // Defense-in-depth: the cookie value is regex-clean, but the OTHER
+  // segments (slug, episode) pass through unsanitized from the request
+  // pathname. Run the same output-shape guard canonicalize applies to its
+  // synthesized Location before emitting a redirect.
+  if (isUnsafeRedirectPath(candidatePathname)) return null
+  url.pathname = candidatePathname
   for (const param of ONE_SHOT_QUERY_PARAMS) {
     url.searchParams.delete(param)
   }
-  return buildRedirect(url, 307)
+  const response = buildRedirect(url, 307)
+  // This redirect target depends on the language-preference cookie. Without
+  // `Vary: Cookie`, any shared cache that ignores `private`/`max-age=0`
+  // (a mis-set Cloudflare transform rule, a corporate proxy) could serve
+  // one user's locale to another. Canonicalize redirects are NOT
+  // cookie-dependent, so they don't carry this header.
+  response.headers.set("Vary", "Cookie")
+  return response
 }
 
 export function proxy(request: ProxyRequest): NextResponse {
@@ -202,9 +221,15 @@ export function proxy(request: ProxyRequest): NextResponse {
     return applyWatchSecurityHeaders(nextWithPathname(request, pathname))
   }
 
-  // Step 4: Accept-Language fallback for non-watch shapes. Preserved
-  // unchanged from pre-Phase-3 behaviour — fires only when the path does
-  // not already terminate in a bcp47 locale segment.
+  // Step 4: Accept-Language fallback. Post-Phase-3 this serves a NARROW
+  // surface: canonicalize (Step 1) already redirects every 1-seg bare slug
+  // (Rule 5) and 2-seg bare pair (Rule 4), and canonical `.html` watch
+  // shapes exit at Step 3. What survives to here: the root `/`, the
+  // 1-segment exempt routes (`/videos`, `/search`), 4+ segment paths, and
+  // percent-encoded / non-ASCII paths the canonicalize allowlist rejected.
+  // For those, if the path doesn't already terminate in a bcp47 locale, we
+  // append the Accept-Language-detected locale. (Phase 4 may retire this
+  // once route-level locale detection fully owns non-watch paths.)
   const segments = pathname.split("/").filter(Boolean)
   const lastSegment = segments[segments.length - 1]
   if (lastSegment && isLocale(lastSegment)) {


### PR DESCRIPTION
## Summary

Security + robustness follow-ups surfaced by the Phase 3 (#1052) multi-agent review. All target `apps/web/src/proxy.ts` + the shared `url-shape.ts` vocabulary.

- **Vary: Cookie (009)** — the language-preference redirect now carries `Vary: Cookie`. Canonicalize redirects stay un-Varied (not cookie-dependent) so they remain CDN-cacheable.
- **Cookie-path output revalidation (010)** — sibling segments (slug, episode) pass through unsanitized from the request pathname; the rebuilt Location now runs the same origin-invariance guard canonicalize applies to its own output.
- **Single source of truth (016)** — `UNSAFE_PATH_PATTERN` + `isUnsafeRedirectPath` + `SAFE_SLUG_PATTERN` live in `url-shape.ts`, consumed by both `proxy.ts` and `url-canonicalize.ts`. Drops two duplicated regexes.
- **Remove unreachable branch (012)** — post-canonicalize the locale segment is always `.html`-suffixed (Rule 4 invariant); the `localeHadHtml ? … : …` branch is gone, invariant documented.
- **Cross-module idempotence test (011)** — `canonicalize(cookieRedirect(x))` is canonical for both 2-seg and 3-seg shapes.
- **Slug-form cookie regression (014)** — `spanish-castilian` round-trips into the redirect; the `[...rest]` catch-all resolves it slug-aware via `resolveUiLocale`.
- **Comment trail (013, 015)** — CSP intentionally omitted on redirects; Accept-Language fallback scope-narrowed post-Phase-3.

P3 items 016 (regex dedup) folded in; 017 (test cast) already resolved during the Phase 3 merge.

## Test plan

- [x] `pnpm --filter @forge/web test -- --run src/proxy.test.ts src/lib/url-shape.test.ts src/lib/url-canonicalize.test.ts` — 127 tests
- [x] `pnpm --filter @forge/web test -- --run` — 841 pass
- [x] `pnpm --filter @forge/web lint` — clean
- [x] `pnpm --filter @forge/web typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)