### PR TITLE
feat(web): route watch-nav href emission through routes.ts builders (Phase 4)

### DIFF
--- a/apps/web/src/components/search/VideoCard.test.tsx
+++ b/apps/web/src/components/search/VideoCard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { formatDuration } from "@/lib/format-duration"
 import type { SearchResult } from "@/lib/search"
-import { formatVideoLabel, pickCardPill } from "./VideoCard"
+import { defaultHrefBuilder, formatVideoLabel, pickCardPill } from "./VideoCard"
 
 function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
   return {
@@ -58,6 +58,20 @@ describe("formatDuration", () => {
   it("returns empty string on invalid input", () => {
     expect(formatDuration(NaN)).toBe("")
     expect(formatDuration(-5)).toBe("")
+  })
+})
+
+describe("defaultHrefBuilder", () => {
+  it("builds the canonical two-segment watch path with the english locale slug", () => {
+    expect(defaultHrefBuilder(makeResult({ slug: "jesus" }))).toBe(
+      "/jesus.html/english.html",
+    )
+  })
+
+  it("falls back to /search on a malformed slug rather than a broken deep link", () => {
+    expect(defaultHrefBuilder(makeResult({ slug: "Not A Slug!" }))).toBe(
+      "/search",
+    )
   })
 })
 

--- a/apps/web/src/components/search/VideoCard.tsx
+++ b/apps/web/src/components/search/VideoCard.tsx
@@ -3,7 +3,12 @@ import Link from "next/link"
 import type { Route } from "next"
 import { Play } from "lucide-react"
 import { formatDuration } from "@/lib/format-duration"
-import { asLocaleSlug, tryAsContentSlug, watchVideoPath } from "@/lib/routes"
+import {
+  asLocaleSlug,
+  searchPath,
+  tryAsContentSlug,
+  watchVideoPath,
+} from "@/lib/routes"
 import type { AdminVideoLabel, SearchResult } from "@/lib/search"
 
 type VideoCardProps = {
@@ -12,13 +17,15 @@ type VideoCardProps = {
   hrefBuilder?: (result: SearchResult) => Route
 }
 
+// English is the default UI locale for search-result deep links. Hoisted to
+// module scope so the throwing constructor runs once at load, not per render.
+const ENGLISH_LOCALE = asLocaleSlug("english")
+
 export const defaultHrefBuilder = (result: SearchResult): Route => {
   const slug = tryAsContentSlug(result.slug)
-  // On a malformed slug, fall back to /search (a safe in-app Route)
+  // On a malformed slug, fall back to the search index (a safe in-app Route)
   // rather than emitting a broken deep link.
-  return slug
-    ? watchVideoPath(slug, asLocaleSlug("english"))
-    : ("/search" as Route)
+  return slug ? watchVideoPath(slug, ENGLISH_LOCALE) : searchPath()
 }
 
 // Full tailwind class strings so JIT can extract them at build time.

--- a/apps/web/src/components/search/VideoCard.tsx
+++ b/apps/web/src/components/search/VideoCard.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import type { Route } from "next"
 import { Play } from "lucide-react"
 import { formatDuration } from "@/lib/format-duration"
+import { asLocaleSlug, tryAsContentSlug, watchVideoPath } from "@/lib/routes"
 import type { AdminVideoLabel, SearchResult } from "@/lib/search"
 
 type VideoCardProps = {
@@ -11,8 +12,14 @@ type VideoCardProps = {
   hrefBuilder?: (result: SearchResult) => Route
 }
 
-const defaultHrefBuilder = (result: SearchResult): Route =>
-  `/${result.slug}/en` as Route
+export const defaultHrefBuilder = (result: SearchResult): Route => {
+  const slug = tryAsContentSlug(result.slug)
+  // On a malformed slug, fall back to /search (a safe in-app Route)
+  // rather than emitting a broken deep link.
+  return slug
+    ? watchVideoPath(slug, asLocaleSlug("english"))
+    : ("/search" as Route)
+}
 
 // Full tailwind class strings so JIT can extract them at build time.
 // Each palette is a dark, saturated gradient that reads as intentional

--- a/apps/web/src/components/sections/MediaCollection.test.tsx
+++ b/apps/web/src/components/sections/MediaCollection.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import type { RouteVideo } from "@/lib/content"
+import type { EnrichedMediaItem } from "@/lib/enrichment"
+
+import { MediaCollection } from "./MediaCollection"
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+// The component destructures these fields off `data` at runtime; the prop
+// type derives from a legacy Strapi fragment, so we cast a minimal literal.
+function makeData(): Parameters<typeof MediaCollection>[0]["data"] {
+  return {
+    id: "mc-1",
+    title: "Related",
+    subtitle: null,
+    mediaDescription: null,
+    categoryLabel: null,
+    itemsSource: "routeVideoChildren",
+    mediaCtaLink: null,
+    mediaCtaLabel: null,
+    showItemNumbers: false,
+    mediaCollectionVariant: "carousel",
+    footerText: null,
+    items: [],
+  } as unknown as Parameters<typeof MediaCollection>[0]["data"]
+}
+
+function makeRouteVideo(videoSlug: string): RouteVideo {
+  const relatedItems: EnrichedMediaItem[] = [
+    {
+      id: "v-1",
+      title: "Episode One",
+      subtitle: "",
+      label: "",
+      collectionSize: "",
+      imageUrl: null,
+      videoSlug,
+    },
+  ]
+  return {
+    documentId: "rv-1",
+    slug: "series",
+    title: "Series",
+    snippet: null,
+    description: null,
+    noIndex: false,
+    imageUrl: null,
+    imageAlt: null,
+    streamingUrl: null,
+    relatedItems,
+  }
+}
+
+describe("MediaCollection VideoCard href", () => {
+  it("emits the canonical /watch/{slug}.html/{lang}.html path via the routes builder", () => {
+    act(() => {
+      root.render(
+        <MediaCollection
+          data={makeData()}
+          routeVideo={makeRouteVideo("the-gospel-of-john")}
+        />,
+      )
+    })
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      'a[aria-label="VideoCard"]',
+    )
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute("href")).toBe(
+      "/watch/the-gospel-of-john.html/english.html",
+    )
+  })
+
+  it("renders a non-link <div> wrapper when the item has no videoSlug", () => {
+    act(() => {
+      root.render(
+        <MediaCollection data={makeData()} routeVideo={makeRouteVideo("")} />,
+      )
+    })
+
+    // Empty videoSlug → href is undefined → wrapper is a <div>, not an <a>.
+    expect(container.querySelector('a[aria-label="VideoCard"]')).toBeNull()
+    expect(
+      container.querySelector('div[aria-label="VideoCard"]'),
+    ).not.toBeNull()
+  })
+})

--- a/apps/web/src/components/sections/MediaCollection.tsx
+++ b/apps/web/src/components/sections/MediaCollection.tsx
@@ -11,6 +11,12 @@ import { CONTENT_WIDTH_CLASSES } from "@/lib/content-width"
 import type { RouteVideo } from "@/lib/content"
 import { mediaCollectionFragment } from "@/lib/fragments/media-collection"
 import {
+  WATCH_BASE_PATH,
+  asLocaleSlug,
+  tryAsContentSlug,
+  watchVideoPath,
+} from "@/lib/routes"
+import {
   Carousel,
   CarouselContent,
   CarouselItem,
@@ -246,7 +252,14 @@ function VideoCard({
   item: EnrichedMediaItem
   onHover?: () => void
 }) {
-  const href = item.videoSlug ? `/watch/${item.videoSlug}` : undefined
+  // Raw <a href> (not next/link), so the `/watch` basePath must be prefixed
+  // manually. EnrichedMediaItem carries no language field, so the locale
+  // segment defaults to `english`.
+  const slug = item.videoSlug ? tryAsContentSlug(item.videoSlug) : null
+  const lang = asLocaleSlug("english")
+  const href = slug
+    ? `${WATCH_BASE_PATH}${watchVideoPath(slug, lang)}`
+    : undefined
   const Wrapper = href ? "a" : "div"
   const imageSrc = resolveMediaImageUrl(item.imageUrl)
 

--- a/apps/web/src/components/sections/MediaCollection.tsx
+++ b/apps/web/src/components/sections/MediaCollection.tsx
@@ -16,6 +16,12 @@ import {
   tryAsContentSlug,
   watchVideoPath,
 } from "@/lib/routes"
+
+// Collections carry no per-item language today, so card deep links default
+// to the English variant and rely on the watch route to re-resolve locale.
+// See todo: EnrichedMediaItem should carry a defaultLanguage (data-model gap).
+// Hoisted so the throwing constructor runs once at module load, not per card.
+const DEFAULT_COLLECTION_LOCALE = asLocaleSlug("english")
 import {
   Carousel,
   CarouselContent,
@@ -254,11 +260,10 @@ function VideoCard({
 }) {
   // Raw <a href> (not next/link), so the `/watch` basePath must be prefixed
   // manually. EnrichedMediaItem carries no language field, so the locale
-  // segment defaults to `english`.
+  // segment defaults to `english` (see DEFAULT_COLLECTION_LOCALE).
   const slug = item.videoSlug ? tryAsContentSlug(item.videoSlug) : null
-  const lang = asLocaleSlug("english")
   const href = slug
-    ? `${WATCH_BASE_PATH}${watchVideoPath(slug, lang)}`
+    ? `${WATCH_BASE_PATH}${watchVideoPath(slug, DEFAULT_COLLECTION_LOCALE)}`
     : undefined
   const Wrapper = href ? "a" : "div"
   const imageSrc = resolveMediaImageUrl(item.imageUrl)

--- a/apps/web/src/components/watch/LanguagePickerModal.tsx
+++ b/apps/web/src/components/watch/LanguagePickerModal.tsx
@@ -214,24 +214,24 @@ export function LanguagePickerModal({
     }
 
     if (languageDirty) {
-      navigatingRef.current.inFlight = true
-      setPendingNavTo(draftSlug)
-      writePreferredLanguageSlug(draftSlug)
       // Validate both segments through the route builder's brand
-      // constructors. If either fails the slug regex, skip navigation
-      // entirely rather than emit a malformed URL — the rest of
+      // constructors BEFORE persisting the preference cookie. If either
+      // fails the slug regex, skip the whole branch — no cookie write, no
+      // navigation — rather than poison the cookie then no-op (matches
+      // SeriesPageClient's validate-before-write ordering). The rest of
       // handleApply (incl. onClose) still runs.
       const slug = tryAsContentSlug(videoSlug)
       const lang = tryAsLocaleSlug(draftSlug)
       if (slug && lang) {
+        navigatingRef.current.inFlight = true
+        setPendingNavTo(draftSlug)
+        writePreferredLanguageSlug(draftSlug)
         if (kind === "series") {
-          const href = watchVideoPath(slug, lang)
-          router.push(href)
+          router.push(watchVideoPath(slug, lang))
         } else {
           const rawT = playerRef.current?.currentTime
-          const t = Number.isFinite(rawT) ? rawT : 0
-          const href = watchVideoPath(slug, lang, { t, autoplay: true })
-          router.push(href)
+          const t = typeof rawT === "number" && Number.isFinite(rawT) ? rawT : 0
+          router.push(watchVideoPath(slug, lang, { t, autoplay: true }))
         }
       }
     }

--- a/apps/web/src/components/watch/LanguagePickerModal.tsx
+++ b/apps/web/src/components/watch/LanguagePickerModal.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import type { Route } from "next"
 import { useRouter } from "next/navigation"
 import type { RefObject } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -14,6 +13,7 @@ import type { WatchSubtitle } from "@/lib/content"
 import { deriveLanguageDisplay } from "@/lib/language-display"
 import { writePreferredLanguageSlug } from "@/lib/language-preference-client"
 import { isPlayableLanguageVariant } from "@/lib/playable-variant"
+import { tryAsContentSlug, tryAsLocaleSlug, watchVideoPath } from "@/lib/routes"
 import { useIsFullscreen } from "@/lib/use-is-fullscreen"
 import { WatchModalViewportCloseButton } from "./WatchModalViewportCloseButton"
 
@@ -217,15 +217,23 @@ export function LanguagePickerModal({
       navigatingRef.current.inFlight = true
       setPendingNavTo(draftSlug)
       writePreferredLanguageSlug(draftSlug)
-      let href: Route
-      if (kind === "series") {
-        href = `/${videoSlug}/${draftSlug}` as Route
-      } else {
-        const rawT = playerRef.current?.currentTime
-        const t = Number.isFinite(rawT) ? rawT : 0
-        href = `/${videoSlug}/${draftSlug}?t=${t}&autoplay=1` as Route
+      // Validate both segments through the route builder's brand
+      // constructors. If either fails the slug regex, skip navigation
+      // entirely rather than emit a malformed URL — the rest of
+      // handleApply (incl. onClose) still runs.
+      const slug = tryAsContentSlug(videoSlug)
+      const lang = tryAsLocaleSlug(draftSlug)
+      if (slug && lang) {
+        if (kind === "series") {
+          const href = watchVideoPath(slug, lang)
+          router.push(href)
+        } else {
+          const rawT = playerRef.current?.currentTime
+          const t = Number.isFinite(rawT) ? rawT : 0
+          const href = watchVideoPath(slug, lang, { t, autoplay: true })
+          router.push(href)
+        }
       }
-      router.push(href)
     }
 
     onClose()

--- a/apps/web/src/components/watch/SeriesEpisodeCard.tsx
+++ b/apps/web/src/components/watch/SeriesEpisodeCard.tsx
@@ -2,11 +2,11 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import type { Route } from "next"
 import { Play } from "lucide-react"
 
 import type { ResolvedSeriesBySlug } from "@/lib/content"
 import { resolveEpisodeImageUrl } from "@/lib/episode-image"
+import { tryAsContentSlug, tryAsLocaleSlug, watchVideoPath } from "@/lib/routes"
 
 type Episodes = NonNullable<ResolvedSeriesBySlug["video"]["children"]>
 type Episode = NonNullable<Episodes[number]>
@@ -57,18 +57,22 @@ export function SeriesEpisodeCard({
   locale,
   backdropUrl,
 }: SeriesEpisodeCardProps) {
-  const href = `/${episode.slug}/${locale}` as Route
+  const slug = episode.slug ? tryAsContentSlug(episode.slug) : null
+  const lang = tryAsLocaleSlug(locale)
+  // Episodes link as standalone videos: canonical two-segment shape.
+  const href = slug && lang ? watchVideoPath(slug, lang) : undefined
   const thumbnailUrl = resolveEpisodeImageUrl(episode)
   const runtimeLabel = formatRuntime(pickRuntimeSeconds(episode))
 
-  return (
-    <Link
-      href={href}
-      data-testid="series-episode-card"
-      data-backdrop-url={backdropUrl ?? ""}
-      className="group animate-card-enter relative flex aspect-video w-full cursor-pointer overflow-hidden rounded-xl ring-1 ring-white/5 transition duration-300 hover:z-10 hover:scale-105 hover:ring-white/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
-      style={{ animationDelay: `${index * 40}ms` }}
-    >
+  // Shared card surface. When the slug/locale is malformed (rare data bug)
+  // the href is undefined, so we render a plain <div> with identical attrs
+  // rather than a dead <Link>.
+  const cardClassName =
+    "group animate-card-enter relative flex aspect-video w-full cursor-pointer overflow-hidden rounded-xl ring-1 ring-white/5 transition duration-300 hover:z-10 hover:scale-105 hover:ring-white/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+  const cardStyle = { animationDelay: `${index * 40}ms` }
+
+  const cardContent = (
+    <>
       {thumbnailUrl ? (
         <Image
           src={thumbnailUrl}
@@ -105,6 +109,31 @@ export function SeriesEpisodeCard({
           {episode.title ?? ""}
         </h3>
       </div>
+    </>
+  )
+
+  if (!href) {
+    return (
+      <div
+        data-testid="series-episode-card"
+        data-backdrop-url={backdropUrl ?? ""}
+        className={cardClassName}
+        style={cardStyle}
+      >
+        {cardContent}
+      </div>
+    )
+  }
+
+  return (
+    <Link
+      href={href}
+      data-testid="series-episode-card"
+      data-backdrop-url={backdropUrl ?? ""}
+      className={cardClassName}
+      style={cardStyle}
+    >
+      {cardContent}
     </Link>
   )
 }

--- a/apps/web/src/components/watch/SeriesPageClient.tsx
+++ b/apps/web/src/components/watch/SeriesPageClient.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import type { Route } from "next"
 import { useRouter } from "next/navigation"
 import { ExternalLink, Globe } from "lucide-react"
 
@@ -24,6 +23,7 @@ import { deriveLanguageDisplay } from "@/lib/language-display"
 import { LOCALE_RESOLVED_PARAM } from "@/lib/locale"
 import { writePreferredLanguageSlug } from "@/lib/language-preference-client"
 import { isPlayableLanguageVariant } from "@/lib/playable-variant"
+import { tryAsContentSlug, tryAsLocaleSlug, watchVideoPath } from "@/lib/routes"
 import { resolvePosterUrl } from "@/lib/url"
 
 // Narrowed from WatchModalState ("none" | "download" | "language" | "share")
@@ -165,10 +165,15 @@ export function SeriesPageClient({
     (nextSlug: string) => {
       const seriesSlug = series.slug
       if (!nextSlug || !seriesSlug || nextSlug === currentLanguageSlug) return
+      // Validate both segments BEFORE writing the cookie or navigating —
+      // an invalid slug must neither persist a preference nor push a URL.
+      const slug = tryAsContentSlug(seriesSlug)
+      const lang = tryAsLocaleSlug(nextSlug)
+      if (!slug || !lang) return
       // Persist preference cookie so subsequent visits respect the choice
       // — matches the watch page's behavior via proxy.ts canonical redirect.
       writePreferredLanguageSlug(nextSlug)
-      router.push(`/${seriesSlug}/${nextSlug}` as Route)
+      router.push(watchVideoPath(slug, lang))
     },
     [router, series.slug, currentLanguageSlug],
   )

--- a/apps/web/src/components/watch/ShareModal.tsx
+++ b/apps/web/src/components/watch/ShareModal.tsx
@@ -28,6 +28,12 @@ import { env } from "@/env"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import {
+  WATCH_BASE_PATH,
+  tryAsContentSlug,
+  tryAsLocaleSlug,
+  watchVideoPath,
+} from "@/lib/routes"
+import {
   PUBLIC_SHARE_FALLBACK_ORIGIN,
   isPublicShareableOrigin,
 } from "@/lib/url"
@@ -73,7 +79,17 @@ export function ShareModal({
   const embedRef = useRef<HTMLTextAreaElement | null>(null)
 
   const origin = env.NEXT_PUBLIC_CANONICAL_ORIGIN
-  const canonicalUrl = `${origin}/watch/${videoSlug}/${currentLanguageSlug}`
+  // Build the watch PATH via the @/lib/routes builder, then prefix each origin
+  // manually: canonical + share-fallback are TWO different origins, so the
+  // canonical-origin-baked `watchVideoAbsolute` builder doesn't fit. Invalid
+  // slugs (which can't happen for a published video) fall back to the bare
+  // origin rather than emitting a malformed path.
+  const slug = tryAsContentSlug(videoSlug)
+  const lang = tryAsLocaleSlug(currentLanguageSlug)
+  const watchPath = slug && lang ? watchVideoPath(slug, lang) : null
+  const canonicalUrl = watchPath
+    ? `${origin}${WATCH_BASE_PATH}${watchPath}`
+    : origin
   // When the configured origin can't be reached by the FB / X scrapers
   // (localhost, private hosts, etc.) we keep the share buttons VISIBLE but
   // render them as disabled. Sharing a localhost URL via the public fallback
@@ -86,7 +102,9 @@ export function ShareModal({
   // the configured origin so devs can copy a localhost URL when that's what
   // they want.
   const shareOrigin = isShareable ? origin : PUBLIC_SHARE_FALLBACK_ORIGIN
-  const shareableUrl = `${shareOrigin}/watch/${videoSlug}/${currentLanguageSlug}`
+  const shareableUrl = watchPath
+    ? `${shareOrigin}${WATCH_BASE_PATH}${watchPath}`
+    : shareOrigin
   // buildEmbedSnippet validates playbackId against PLAYBACK_ID_PATTERN before
   // interpolating into the iframe `src` and returns "" on null/invalid; the
   // Embed Code tab is also gated on `playbackId ?` below, so an invalid id

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
-import type { Route } from "next"
 import { useParams } from "next/navigation"
 import { Play } from "lucide-react"
 
@@ -17,6 +16,7 @@ import {
 } from "@/components/ui/carousel"
 import { cn } from "@/lib/utils"
 import type { WatchSiblingCarouselBlock } from "@/lib/content"
+import { tryAsContentSlug, tryAsLocaleSlug, watchVideoPath } from "@/lib/routes"
 import { resolvePosterUrl } from "@/lib/url"
 
 export function SiblingCarousel({
@@ -31,8 +31,9 @@ export function SiblingCarousel({
 
   // Drop nulls AND items missing a slug — without a slug we can't build a
   // routable href, and rendering an unclickable card is worse than
-  // omitting it entirely. Same for currentLocale: it's URL-encoded for
-  // safety in case Next ever surfaces a non-encoded locale segment.
+  // omitting it entirely. Slug/locale validity is re-checked per child via
+  // the route builders below (a malformed slug still renders, just not as a
+  // <Link>).
   const children = (canonicalParent.children ?? []).filter(
     (child): child is NonNullable<typeof child> & { slug: string } =>
       child != null && typeof child.slug === "string" && child.slug.length > 0,
@@ -126,16 +127,109 @@ export function SiblingCarousel({
             // that returns 400, so a "last resort" fallback to it only
             // ever produces broken images.
             const thumb = resolvePosterUrl(child.images?.[0])
-            // 2-segment watch route: `/{slug}/{locale}`. The earlier
-            // 3-segment shape (`/{parent}/{child}/{locale}`) 404s because
-            // the route was migrated to a flat `[slug]/[locale]` structure.
-            // Both segments are URL-encoded defensively — slugs are
-            // editor-controlled (so far always URL-safe), but encoding
-            // costs nothing and protects against a future Strapi slug
-            // policy change. `currentLocale` is encoded for the same
-            // reason.
-            const href =
-              `/${encodeURIComponent(child.slug)}/${encodeURIComponent(currentLocale)}` as Route
+            // The builder emits the canonical 2-segment `.html` shape
+            // (`/{slug}.html/{locale}.html`).
+            const slug = tryAsContentSlug(child.slug)
+            const lang = tryAsLocaleSlug(currentLocale)
+            const href = slug && lang ? watchVideoPath(slug, lang) : undefined
+
+            const cardClassName = cn(
+              "group relative block aspect-video cursor-pointer overflow-hidden rounded-lg bg-stone-900 transition shadow-[0_2px_6px_rgba(0,0,0,0.35),0_14px_32px_-12px_rgba(0,0,0,0.6)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80",
+              isActive
+                ? "border-4 border-white"
+                : "opacity-70 hover:outline-4 hover:outline-offset-[-4px] hover:outline-brand-red hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
+            )
+
+            // Card contents are identical whether the card is a routable
+            // <Link> or (for a rare malformed slug) a non-clickable <div>.
+            const cardInner = (
+              <>
+                {thumb ? (
+                  <Image
+                    src={thumb}
+                    alt={child.title ?? ""}
+                    fill
+                    sizes="(max-width: 640px) 48vw, (max-width: 768px) 36vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, (max-width: 1536px) 20vw, 16vw"
+                    className="object-cover transition-transform duration-300 group-hover:scale-105"
+                    // Native lazy-loading. Browser still fetches
+                    // above-fold cards immediately (lazy only defers
+                    // far-from-viewport). Avoids the head-preload
+                    // entries next/image emits for `priority` /
+                    // `loading="eager"` that compete with the LCP
+                    // poster fetch.
+                    loading="lazy"
+                  />
+                ) : (
+                  <div
+                    data-testid="sibling-carousel-thumb-placeholder"
+                    className="flex h-full w-full items-center justify-center bg-stone-900 text-xs text-stone-600"
+                  >
+                    No image
+                  </div>
+                )}
+
+                {/* Soften the image into the lower caption zone. */}
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-full bg-black/35 backdrop-blur-[14px] [mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)]"
+                />
+
+                {/* Hover-only play overlay on inactive cards. The active
+                    card already signals "this is what's playing" via the
+                    red border, so we don't double-mark it with a button. */}
+                {!isActive ? (
+                  <div
+                    aria-hidden="true"
+                    data-testid="sibling-carousel-play-overlay"
+                    className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+                  >
+                    <span className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-red text-white shadow-lg ring-1 ring-black/20">
+                      <Play size={20} fill="currentColor" stroke="none" />
+                    </span>
+                  </div>
+                ) : null}
+
+                {/* Caption block — a lower frosted panel like the modern
+                    episode rails, keeping text readable inside the
+                    landscape tile. */}
+                <div
+                  data-testid="sibling-carousel-caption"
+                  className="absolute inset-x-0 bottom-0 z-20 flex h-full flex-col justify-end gap-1.5 bg-gradient-to-t from-black/68 via-black/35 to-transparent p-3 sm:p-4"
+                >
+                  <span className="text-[10px] font-semibold tracking-[0.18em] text-stone-200/90 uppercase drop-shadow-md sm:text-xs">
+                    Chapter
+                  </span>
+                  {/* Card title rendered as <span>, not <h3>: the cards are
+                      sibling-navigation Link items and don't anchor their
+                      own section. Emitting an <h3> with no parent <h2>
+                      skipped the heading order (WCAG 1.3.1) and would
+                      require an artificial sr-only section header. The
+                      Link's accessible name covers the card's title. */}
+                  <span className="line-clamp-2 text-sm leading-tight font-bold text-white drop-shadow-md sm:text-base">
+                    {child.title ?? ""}
+                  </span>
+                </div>
+
+                <div
+                  aria-hidden="true"
+                  data-testid="sibling-carousel-bevel"
+                  className="pointer-events-none absolute inset-0 z-40 rounded-lg border border-white opacity-40 mix-blend-soft-light"
+                />
+
+                {/* Visually-hidden active marker — preserves the existing
+                    `sibling-carousel-playing-now` testid and gives screen
+                    readers a labeled "Playing now" affordance even though
+                    the visual cue is a border, not a pill. */}
+                {isActive ? (
+                  <span
+                    data-testid="sibling-carousel-playing-now"
+                    className="sr-only"
+                  >
+                    Playing now
+                  </span>
+                ) : null}
+              </>
+            )
 
             return (
               <CarouselItem
@@ -143,106 +237,30 @@ export function SiblingCarousel({
                 className="basis-[48%] sm:basis-[36%] md:basis-1/3 lg:basis-1/4 xl:basis-1/5 2xl:basis-1/6"
                 aria-current={isActive ? "true" : undefined}
               >
-                <Link
-                  href={href}
-                  data-testid="sibling-carousel-item"
-                  data-active={isActive ? "true" : "false"}
-                  data-href={href}
-                  // Active cards use a real inside border. Inactive cards keep
-                  // no transparent border; the bevel is drawn by a content
-                  // overlay so it stays visible around the whole picture.
-                  className={cn(
-                    "group relative block aspect-video cursor-pointer overflow-hidden rounded-lg bg-stone-900 transition shadow-[0_2px_6px_rgba(0,0,0,0.35),0_14px_32px_-12px_rgba(0,0,0,0.6)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80",
-                    isActive
-                      ? "border-4 border-white"
-                      : "opacity-70 hover:outline-4 hover:outline-offset-[-4px] hover:outline-brand-red hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
-                  )}
-                >
-                  {thumb ? (
-                    <Image
-                      src={thumb}
-                      alt={child.title ?? ""}
-                      fill
-                      sizes="(max-width: 640px) 48vw, (max-width: 768px) 36vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, (max-width: 1536px) 20vw, 16vw"
-                      className="object-cover transition-transform duration-300 group-hover:scale-105"
-                      // Native lazy-loading. Browser still fetches
-                      // above-fold cards immediately (lazy only defers
-                      // far-from-viewport). Avoids the head-preload
-                      // entries next/image emits for `priority` /
-                      // `loading="eager"` that compete with the LCP
-                      // poster fetch.
-                      loading="lazy"
-                    />
-                  ) : (
-                    <div
-                      data-testid="sibling-carousel-thumb-placeholder"
-                      className="flex h-full w-full items-center justify-center bg-stone-900 text-xs text-stone-600"
-                    >
-                      No image
-                    </div>
-                  )}
-
-                  {/* Soften the image into the lower caption zone. */}
-                  <div
-                    aria-hidden="true"
-                    className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-full bg-black/35 backdrop-blur-[14px] [mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)]"
-                  />
-
-                  {/* Hover-only play overlay on inactive cards. The active
-                      card already signals "this is what's playing" via the
-                      red border, so we don't double-mark it with a button. */}
-                  {!isActive ? (
-                    <div
-                      aria-hidden="true"
-                      data-testid="sibling-carousel-play-overlay"
-                      className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
-                    >
-                      <span className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-red text-white shadow-lg ring-1 ring-black/20">
-                        <Play size={20} fill="currentColor" stroke="none" />
-                      </span>
-                    </div>
-                  ) : null}
-
-                  {/* Caption block — a lower frosted panel like the modern
-                      episode rails, keeping text readable inside the
-                      landscape tile. */}
-                  <div
-                    data-testid="sibling-carousel-caption"
-                    className="absolute inset-x-0 bottom-0 z-20 flex h-full flex-col justify-end gap-1.5 bg-gradient-to-t from-black/68 via-black/35 to-transparent p-3 sm:p-4"
+                {/* Active cards use a real inside border. Inactive cards keep
+                    no transparent border; the bevel is drawn by a content
+                    overlay so it stays visible around the whole picture. A
+                    malformed slug (no routable href) renders a non-clickable
+                    <div> with identical markup minus the href/data-href. */}
+                {href ? (
+                  <Link
+                    href={href}
+                    data-testid="sibling-carousel-item"
+                    data-active={isActive ? "true" : "false"}
+                    data-href={href}
+                    className={cardClassName}
                   >
-                    <span className="text-[10px] font-semibold tracking-[0.18em] text-stone-200/90 uppercase drop-shadow-md sm:text-xs">
-                      Chapter
-                    </span>
-                    {/* Card title rendered as <span>, not <h3>: the cards are
-                        sibling-navigation Link items and don't anchor their
-                        own section. Emitting an <h3> with no parent <h2>
-                        skipped the heading order (WCAG 1.3.1) and would
-                        require an artificial sr-only section header. The
-                        Link's accessible name covers the card's title. */}
-                    <span className="line-clamp-2 text-sm leading-tight font-bold text-white drop-shadow-md sm:text-base">
-                      {child.title ?? ""}
-                    </span>
-                  </div>
-
+                    {cardInner}
+                  </Link>
+                ) : (
                   <div
-                    aria-hidden="true"
-                    data-testid="sibling-carousel-bevel"
-                    className="pointer-events-none absolute inset-0 z-40 rounded-lg border border-white opacity-40 mix-blend-soft-light"
-                  />
-
-                  {/* Visually-hidden active marker — preserves the existing
-                      `sibling-carousel-playing-now` testid and gives screen
-                      readers a labeled "Playing now" affordance even though
-                      the visual cue is a border, not a pill. */}
-                  {isActive ? (
-                    <span
-                      data-testid="sibling-carousel-playing-now"
-                      className="sr-only"
-                    >
-                      Playing now
-                    </span>
-                  ) : null}
-                </Link>
+                    data-testid="sibling-carousel-item"
+                    data-active={isActive ? "true" : "false"}
+                    className={cardClassName}
+                  >
+                    {cardInner}
+                  </div>
+                )}
               </CarouselItem>
             )
           })}

--- a/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
@@ -5,7 +5,7 @@
  *
  * Covers:
  *  - Apply disabled until selection differs from current
- *  - Apply navigates with `/{videoSlug}/{newSlug}?t={currentTime}` (no /watch/)
+ *  - Apply navigates via watchVideoPath: `/{videoSlug}.html/{newSlug}.html?t={currentTime}&autoplay=1`
  *  - Apply writes the language-preference cookie BEFORE router.push
  *  - Close does nothing besides onClose
  *  - Draft resets when the modal reopens
@@ -186,7 +186,7 @@ describe("LanguagePickerModal — globe overlay", () => {
 
     expect(writePreferredLanguageSlugMock).toHaveBeenCalledWith("spanish")
     expect(routerPushMock).toHaveBeenCalledWith(
-      "/the-call/spanish?t=42&autoplay=1",
+      "/the-call.html/spanish.html?t=42&autoplay=1",
     )
     const writeOrder =
       writePreferredLanguageSlugMock.mock.invocationCallOrder[0]!
@@ -215,7 +215,7 @@ describe("LanguagePickerModal — globe overlay", () => {
     })
 
     expect(routerPushMock).toHaveBeenCalledWith(
-      "/the-call/spanish?t=0&autoplay=1",
+      "/the-call.html/spanish.html?t=0&autoplay=1",
     )
   })
 
@@ -451,11 +451,11 @@ describe("LanguagePickerModal — in-flight navigation guard", () => {
       $('[data-testid="watch-language-picker-apply"]')?.click()
     })
     expect(routerPushMock).toHaveBeenCalledWith(
-      "/the-call/spanish?t=42&autoplay=1",
+      "/the-call.html/spanish.html?t=42&autoplay=1",
     )
   })
 
-  it("kind='series' navigates to bare /{slug}/{newLang} (no ?t, no autoplay)", () => {
+  it("kind='series' navigates to bare /{slug}.html/{newLang}.html (no ?t, no autoplay)", () => {
     // The series page has no player. ?t= and autoplay=1 are HeroPlayer
     // gestures; they would mistakenly trigger trailer autoplay on the
     // series destination.
@@ -472,7 +472,7 @@ describe("LanguagePickerModal — in-flight navigation guard", () => {
     act(() => {
       $('[data-testid="watch-language-picker-apply"]')?.click()
     })
-    expect(routerPushMock).toHaveBeenCalledWith("/the-call/spanish")
+    expect(routerPushMock).toHaveBeenCalledWith("/the-call.html/spanish.html")
   })
 
   it("releases the navigation guard after the safety timeout (~5s)", () => {

--- a/apps/web/src/components/watch/__tests__/SeriesEpisodeCard.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SeriesEpisodeCard.test.tsx
@@ -347,22 +347,48 @@ describe("SeriesEpisodeCard — Episode N label", () => {
 })
 
 describe("SeriesEpisodeCard — href", () => {
-  it("routes to /{slug}/{locale}", () => {
+  it("routes to the canonical /{slug}.html/{locale}.html shape", () => {
     renderCard({
-      episode: makeEpisode({ slug: "the-birth-of-jesus" }),
-      locale: "en",
+      episode: makeEpisode({ slug: "wedding-in-cana" }),
+      locale: "english",
     })
     const anchor = container.querySelector("a")
-    expect(anchor?.getAttribute("href")).toBe("/the-birth-of-jesus/en")
+    expect(anchor?.getAttribute("href")).toBe(
+      "/wedding-in-cana.html/english.html",
+    )
   })
 
-  it("preserves a non-en locale", () => {
+  it("preserves a non-english locale", () => {
     renderCard({
-      episode: makeEpisode({ slug: "ep-1" }),
+      episode: makeEpisode({ slug: "the-birth-of-jesus" }),
       locale: "spanish-castilian",
     })
     const anchor = container.querySelector("a")
-    expect(anchor?.getAttribute("href")).toBe("/ep-1/spanish-castilian")
+    expect(anchor?.getAttribute("href")).toBe(
+      "/the-birth-of-jesus.html/spanish-castilian.html",
+    )
+  })
+
+  it("renders a plain div (no <a>) when the slug is malformed", () => {
+    renderCard({
+      episode: makeEpisode({ slug: "Bad Slug!" }),
+      locale: "english",
+    })
+    expect(container.querySelector("a")).toBeNull()
+    const card = container.querySelector('[data-testid="series-episode-card"]')
+    expect(card).not.toBeNull()
+    expect(card?.tagName).toBe("DIV")
+    expect(card?.hasAttribute("href")).toBe(false)
+  })
+
+  it("renders a plain div (no <a>) when the locale is malformed", () => {
+    renderCard({
+      episode: makeEpisode({ slug: "wedding-in-cana" }),
+      locale: "Bad Locale!",
+    })
+    expect(container.querySelector("a")).toBeNull()
+    const card = container.querySelector('[data-testid="series-episode-card"]')
+    expect(card?.tagName).toBe("DIV")
   })
 })
 

--- a/apps/web/src/components/watch/__tests__/SeriesEpisodesGrid.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SeriesEpisodesGrid.test.tsx
@@ -87,7 +87,9 @@ describe("SeriesEpisodesGrid — happy path", () => {
       root.render(<SeriesEpisodesGrid episodes={episodes} locale="en" />)
     })
     const anchor = container.querySelector("a")
-    expect(anchor?.getAttribute("href")).toBe("/storyclubs-birth-of-jesus/en")
+    expect(anchor?.getAttribute("href")).toBe(
+      "/storyclubs-birth-of-jesus.html/en.html",
+    )
   })
 
   it("preserves the locale from the series URL in every episode href", () => {
@@ -99,8 +101,8 @@ describe("SeriesEpisodesGrid — happy path", () => {
       root.render(<SeriesEpisodesGrid episodes={episodes} locale="es" />)
     })
     const anchors = container.querySelectorAll("a")
-    expect(anchors[0]?.getAttribute("href")).toBe("/ep-1/es")
-    expect(anchors[1]?.getAttribute("href")).toBe("/ep-2/es")
+    expect(anchors[0]?.getAttribute("href")).toBe("/ep-1.html/es.html")
+    expect(anchors[1]?.getAttribute("href")).toBe("/ep-2.html/es.html")
   })
 })
 

--- a/apps/web/src/components/watch/__tests__/SeriesPageClient.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SeriesPageClient.test.tsx
@@ -38,14 +38,20 @@ vi.mock("@/components/watch/LanguageCombobox", () => ({
     ({
       options,
       value,
+      onChange,
     }: {
       options: { slug: string; name: string }[]
       value: string
+      onChange: (slug: string) => void
     }) => (
-      <div
+      <button
+        type="button"
         data-testid="language-combobox-mock"
         data-option-count={options.length}
         data-value={value}
+        // Surface onChange so handleLanguageChange can be driven from a
+        // test without standing up the real combobox interaction.
+        onClick={() => onChange(options.find((o) => o.slug !== value)!.slug)}
       />
     ),
   ),
@@ -54,9 +60,16 @@ vi.mock("@/components/watch/LanguageCombobox", () => ({
 // next/navigation's useRouter requires app-router context that
 // createRoot tests don't provide. Stub it to a no-op router so the
 // click → router.push path is observable without app-router setup.
+// The push spy is hoisted so handleLanguageChange navigation can be
+// asserted against the .html-shaped path the @/lib/routes builder emits.
+const { pushMock, writePreferredLanguageSlugMock } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  writePreferredLanguageSlugMock: vi.fn(),
+}))
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    push: vi.fn(),
+    push: pushMock,
     replace: vi.fn(),
     prefetch: vi.fn(),
     back: vi.fn(),
@@ -68,7 +81,7 @@ vi.mock("next/navigation", () => ({
 // language-preference-client writes a document.cookie value. Stub it so
 // tests don't depend on jsdom's cookie store behavior.
 vi.mock("@/lib/language-preference-client", () => ({
-  writePreferredLanguageSlug: vi.fn(),
+  writePreferredLanguageSlug: writePreferredLanguageSlugMock,
 }))
 
 const { shareModalMock, languagePickerModalMock } = vi.hoisted(() => ({
@@ -127,6 +140,8 @@ let root: Root
 beforeEach(() => {
   shareModalMock.mockClear()
   languagePickerModalMock.mockClear()
+  pushMock.mockClear()
+  writePreferredLanguageSlugMock.mockClear()
   container = document.createElement("div")
   document.body.appendChild(container)
   root = createRoot(container)
@@ -504,5 +519,37 @@ describe("SeriesPageClient — globe button + language modal", () => {
     )
     // Only english survives the playable-variant filter.
     expect(modal?.getAttribute("data-variant-count")).toBe("1")
+  })
+})
+
+describe("SeriesPageClient — handleLanguageChange navigation (Phase 4)", () => {
+  it("pushes the .html-shaped two-segment watch path built by @/lib/routes", () => {
+    const children = makeChildrenWithVariants([
+      [{ languageSlug: "english" }, { languageSlug: "spanish-castilian" }],
+    ])
+    act(() => {
+      root.render(
+        <SeriesPageClient
+          series={makeSeries({ slug: "lumo-the-gospel-of-john", children })}
+          selectedVariant={null}
+          locale="english"
+        />,
+      )
+    })
+    const combobox = container.querySelector(
+      '[data-testid="language-combobox-mock"]',
+    ) as HTMLButtonElement
+    // Current value is "english"; the mock onChange picks the first
+    // differing slug → "spanish-castilian".
+    act(() => {
+      combobox.click()
+    })
+    expect(pushMock).toHaveBeenCalledTimes(1)
+    expect(pushMock).toHaveBeenCalledWith(
+      "/lumo-the-gospel-of-john.html/spanish-castilian.html",
+    )
+    expect(writePreferredLanguageSlugMock).toHaveBeenCalledWith(
+      "spanish-castilian",
+    )
   })
 })

--- a/apps/web/src/components/watch/__tests__/ShareModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/ShareModal.test.tsx
@@ -79,7 +79,9 @@ describe("ShareModal — Copy Link", () => {
     const input = $(
       '[data-testid="watch-share-modal-link-input"]',
     ) as HTMLInputElement
-    expect(input.value).toBe("https://share.example/watch/the-call/english")
+    expect(input.value).toBe(
+      "https://share.example/watch/the-call.html/english.html",
+    )
     expect(input.readOnly).toBe(true)
   })
 
@@ -108,7 +110,7 @@ describe("ShareModal — Copy Link", () => {
     })
 
     expect(writeText).toHaveBeenCalledWith(
-      "https://share.example/watch/the-call/english",
+      "https://share.example/watch/the-call.html/english.html",
     )
     expect(copyBtn.textContent).toBe("Copied")
   })
@@ -150,7 +152,7 @@ describe("ShareModal — Facebook + X share intents", () => {
       '[data-testid="watch-share-modal-facebook"]',
     ) as HTMLAnchorElement
     expect(fb.href).toBe(
-      "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fshare.example%2Fwatch%2Fthe-call%2Fenglish",
+      "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fshare.example%2Fwatch%2Fthe-call.html%2Fenglish.html",
     )
   })
 
@@ -168,7 +170,7 @@ describe("ShareModal — Facebook + X share intents", () => {
     })
     const x = $('[data-testid="watch-share-modal-x"]') as HTMLAnchorElement
     expect(x.href).toBe(
-      "https://x.com/intent/tweet?url=https%3A%2F%2Fshare.example%2Fwatch%2Fthe-call%2Fenglish&text=The%20Call",
+      "https://x.com/intent/tweet?url=https%3A%2F%2Fshare.example%2Fwatch%2Fthe-call.html%2Fenglish.html&text=The%20Call",
     )
   })
 })

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -194,9 +194,11 @@ describe("SiblingCarousel — happy path", () => {
     expect(active!.className).not.toContain("after:border-4")
     expect(active!.className).toContain("focus-visible:outline-white/80")
     expect(active!.className).toContain("shadow-[0_2px_6px_rgba")
-    // 2-segment route shape: `/{slug}/{locale}` — the parent slug segment
-    // was removed when the watch route migrated to flat `[slug]/[locale]`.
-    expect(active!.getAttribute("data-href")).toBe("/child-3-slug/english")
+    // Canonical 2-segment `.html` shape `/{slug}.html/{locale}.html`,
+    // emitted by the `watchVideoPath` builder.
+    expect(active!.getAttribute("data-href")).toBe(
+      "/child-3-slug.html/english.html",
+    )
     const caption = active!.querySelector(
       "[data-testid='sibling-carousel-caption']",
     )
@@ -246,6 +248,37 @@ describe("SiblingCarousel — happy path", () => {
     expect(desktopLabel?.textContent).toBe("Clip 3 of 10")
   })
 
+  it("routes a child through watchVideoPath to the canonical `.html` 2-segment shape", () => {
+    // Builder contract: slug `magdalena` + locale `english` →
+    // `/magdalena.html/english.html` (no manual encodeURIComponent, no cast).
+    const block: WatchSiblingCarouselBlock = {
+      kind: "SiblingCarousel",
+      canonicalParent: {
+        documentId: "parent-1",
+        slug: "jesus-collection",
+        title: "Jesus Collection",
+        children: [
+          { ...makeChild(1), slug: "magdalena", documentId: "magdalena-doc" },
+          makeChild(2),
+        ],
+      } as never,
+      currentVideoDocumentId: "magdalena-doc",
+    }
+
+    act(() => {
+      root.render(<SiblingCarousel block={block} />)
+    })
+
+    const active = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-active='true']",
+    )
+    expect(active!.tagName).toBe("A")
+    expect(active!.getAttribute("data-href")).toBe(
+      "/magdalena.html/english.html",
+    )
+    expect(active!.getAttribute("href")).toBe("/magdalena.html/english.html")
+  })
+
   it("renders an in-app href without the /watch/ basePath prefix", () => {
     const block = makeBlock(3, 0)
 
@@ -260,9 +293,10 @@ describe("SiblingCarousel — happy path", () => {
       const href = item.getAttribute("data-href") ?? ""
       // basePath auto-prepends; in-app hrefs MUST NOT include /watch/ literal.
       expect(href.startsWith("/watch/")).toBe(false)
-      // 2-segment route — child slug then locale, no parent segment.
-      expect(href).toMatch(/^\/child-\d+-slug\/english$/)
-      expect(href.endsWith("/english")).toBe(true)
+      // Canonical 2-segment `.html` shape — child slug then locale, no
+      // parent segment.
+      expect(href).toMatch(/^\/child-\d+-slug\.html\/english\.html$/)
+      expect(href.endsWith("/english.html")).toBe(true)
     }
   })
 
@@ -378,7 +412,9 @@ describe("SiblingCarousel — edge cases", () => {
       "[data-testid='sibling-carousel-item'][data-active='true']",
     )
     expect(active).not.toBeNull()
-    expect(active!.getAttribute("data-href")).toBe("/child-12-slug/english")
+    expect(active!.getAttribute("data-href")).toBe(
+      "/child-12-slug.html/english.html",
+    )
     const label = container.querySelector(
       "[data-testid='sibling-carousel-label']",
     )
@@ -388,7 +424,7 @@ describe("SiblingCarousel — edge cases", () => {
     expect(desktopLabel?.textContent).toBe("Clip 12 of 15")
   })
 
-  it("renders an empty currentLocale segment when params lack `locale`", () => {
+  it("renders a non-clickable card (no <Link>/href) when params lack `locale`", () => {
     useParamsMock.mockReturnValue({})
     const block = makeBlock(3, 1)
 
@@ -399,9 +435,17 @@ describe("SiblingCarousel — edge cases", () => {
     const item = container.querySelector(
       "[data-testid='sibling-carousel-item'][data-active='true']",
     )
-    // Trailing slash with empty locale segment — caller is responsible for
-    // ensuring `[locale]` is present in the route; we don't fabricate one.
-    expect(item!.getAttribute("data-href")).toBe("/child-2-slug/")
+    expect(item).not.toBeNull()
+    // Empty locale fails the slug regex, so `watchVideoPath` is never built.
+    // The card still renders — as a plain <div>, not an <a> — with no href.
+    expect(item!.tagName).toBe("DIV")
+    expect(item!.getAttribute("href")).toBeNull()
+    expect(item!.getAttribute("data-href")).toBeNull()
+    // Markup is otherwise identical: same className + active marker present.
+    expect(item!.className).toContain("aspect-video")
+    expect(
+      item!.querySelector("[data-testid='sibling-carousel-caption']"),
+    ).not.toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

Phase 4 of the /watch URL restructure. Every internal watch URL emission now flows through the `lib/routes.ts` builders, so the canonical `.html` shape ships end-to-end (no more bare-shape links relying on the proxy to canonicalize). Slugs convert at each site via `tryAsContentSlug` / `tryAsLocaleSlug`; a malformed slug degrades gracefully (Link omitted / navigation skipped) rather than emitting a broken path.

### Migrated emission sites

| Site | Before | After |
|------|--------|-------|
| `SeriesEpisodeCard` | `` `/${episode.slug}/${locale}` `` | `watchVideoPath(slug, lang)` |
| `SiblingCarousel` | `` `/${child.slug}/${currentLocale}` `` | `watchVideoPath(slug, lang)` |
| `LanguagePickerModal` | `` `/${videoSlug}/${draftSlug}?t=&autoplay=1` `` | `watchVideoPath(slug, lang, { t, autoplay })` |
| `SeriesPageClient` | `` `/${seriesSlug}/${nextSlug}` `` | `watchVideoPath(slug, lang)` |
| `ShareModal` | `` `${origin}/watch/${videoSlug}/${lang}` `` | `${origin}${WATCH_BASE_PATH}${watchVideoPath(...)}` |
| `MediaCollection` | `` `/watch/${item.videoSlug}` `` | `/watch` + `watchVideoPath(slug, english)` |
| search `VideoCard` | `` `/${result.slug}/en` `` | `watchVideoPath(slug, english)` |

`search/VideoCard` also fixes a latent bug: post-Phase-2 URLs use English-**name** language slugs (`english`), not bcp47 (`en`).

`experience-metadata` (canonical/OG/hreflang) + the `/api/revalidate` webhook are deferred to **Phase 5** (SEO surface).

## Test plan

- [x] `pnpm --filter @forge/web test -- --run` — 849 pass (58 files), incl. updated href assertions across all 7 sites + parent `SeriesEpisodesGrid`
- [x] `pnpm --filter @forge/web lint` — clean
- [x] `pnpm --filter @forge/web typecheck` — clean
- [x] grep: zero residual raw watch-nav URL templates in `components/` + `app/[slug]/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)