### PR TITLE
feat(web): extract watch-component UI strings to i18n catalogs (Phase 3)

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -12,5 +12,105 @@
   "VideosPage": {
     "title": "Alle Videos",
     "placeholder": "Das Durchsuchen des Katalogs kommt bald. In der Zwischenzeit nutzen Sie die Suche oder eine themenspezifische URL."
+  },
+  "BibleQuotes": {
+    "title": "Bibelzitate",
+    "share": "Teilen",
+    "readMore": "Mehr lesen...",
+    "freeResources": "Kostenlose Ressourcen",
+    "promoHeading": "Möchten Sie Ihr Verständnis der Bibel vertiefen?",
+    "joinBibleStudy": "Nehmen Sie an unserem Bibelstudium teil",
+    "previousQuote": "Vorheriges Bibelzitat",
+    "nextQuote": "Nächstes Bibelzitat"
+  },
+  "DownloadButton": {
+    "download": "Herunterladen"
+  },
+  "DownloadModal": {
+    "dialogTitle": "Video herunterladen",
+    "eyebrow": "Video herunterladen",
+    "posterAlt": "Video-Vorschaubild",
+    "noDownloads": "Für dieses Video sind keine Downloads verfügbar.",
+    "errorUnavailableSource": "Download von dieser Quelle nicht verfügbar",
+    "tierHighest": "Höchste",
+    "tierHigh": "Hoch",
+    "tierLow": "Niedrig"
+  },
+  "HeroPlayerControls": {
+    "play": "Abspielen",
+    "pause": "Pause",
+    "seek": "Suchen",
+    "seekValue": "{current} von {total}",
+    "volume": "Lautstärke",
+    "volumeValue": "{percent} Prozent",
+    "mute": "Stummschalten",
+    "unmute": "Stummschaltung aufheben",
+    "changeAudioLanguage": "Audiosprache ändern",
+    "enterFullscreen": "Vollbild",
+    "exitFullscreen": "Vollbild beenden"
+  },
+  "LanguageCombobox": {
+    "selectLanguage": "Sprache auswählen",
+    "searchPlaceholder": "Sprachen suchen…",
+    "languages": "Sprachen",
+    "noMatches": "Keine Treffer"
+  },
+  "LanguagePickerModal": {
+    "dialogTitle": "Sprache",
+    "dialogTitleWithSubtitles": "Sprache & Untertitel",
+    "languageHeading": "Sprache",
+    "subtitlesHeading": "Untertitel",
+    "languageCount": "{count, plural, one {# Sprache} other {# Sprachen}}",
+    "requestSent": "Anfrage gesendet",
+    "translateWithAi": "Mit KI übersetzen",
+    "noSubtitles": "Keine Untertitel",
+    "close": "Schließen",
+    "apply": "Anwenden"
+  },
+  "SeriesPage": {
+    "episodeCount": "{count, plural, one {1 FOLGE} other {# FOLGEN}}",
+    "seriesLabel": "SERIE · {episodes}",
+    "changeAudioLanguage": "Audiosprache ändern",
+    "share": "Teilen",
+    "languages": "Sprachen"
+  },
+  "WatchModal": {
+    "close": "Schließen"
+  },
+  "WatchStudyQuestions": {
+    "placeholderQuestion": "Wenn Sie dem Ersteller dieses Videos eine Frage stellen könnten, welche wäre das?",
+    "fallbackBody": "Führen Sie ein privates Gespräch mit jemandem, der bereit ist zuzuhören.",
+    "questionsShort": "Fragen",
+    "questions": "Verwandte Fragen",
+    "askYours": "Stellen Sie Ihre",
+    "chatWithPerson": "Mit einer Person chatten",
+    "askBibleQuestion": "Eine Bibelfrage stellen"
+  },
+  "ShareModal": {
+    "dialogTitle": "Video teilen",
+    "heading": "Dieses Video teilen",
+    "posterAlt": "Video-Vorschaubild",
+    "shareOnFacebook": "Auf Facebook teilen",
+    "shareOnFacebookUnavailable": "Auf Facebook teilen (in dieser Version nicht verfügbar)",
+    "shareOnX": "Auf X teilen",
+    "shareOnXUnavailable": "Auf X teilen (in dieser Version nicht verfügbar)",
+    "shareDisabledHint": "Zum Teilen ist eine veröffentlichte Seite erforderlich — funktioniert, sobald dieses Video in Produktion ist.",
+    "shareFormat": "Freigabeformat",
+    "shareLinkTab": "Link teilen",
+    "embedCodeTab": "Einbettungscode",
+    "copyFailed": "Automatisches Kopieren fehlgeschlagen — markieren Sie den Text unten und kopieren Sie ihn manuell.",
+    "copyLink": "Link kopieren",
+    "copyCode": "Code kopieren",
+    "copied": "Kopiert",
+    "close": "Schließen"
+  },
+  "SubtitleTranscript": {
+    "heading": "Transkript",
+    "subheading": "Tippen Sie auf eine Zeile, um zu diesem Moment zu springen.",
+    "subtitleLanguage": "Untertitelsprache",
+    "aiSuffix": " · KI",
+    "loading": "Transkript wird geladen…",
+    "unavailable": "Transkript für diese Untertitelspur nicht verfügbar.",
+    "empty": "Keine Transkriptzeilen gefunden."
   }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -12,5 +12,105 @@
   "VideosPage": {
     "title": "All Videos",
     "placeholder": "Catalog browsing is coming. In the meantime use search or a topic-specific URL."
+  },
+  "BibleQuotes": {
+    "title": "Bible Quotes",
+    "share": "Share",
+    "readMore": "Read more...",
+    "freeResources": "Free Resources",
+    "promoHeading": "Want to grow deep in your understanding of the Bible?",
+    "joinBibleStudy": "Join our Bible study",
+    "previousQuote": "Previous Bible quote",
+    "nextQuote": "Next Bible quote"
+  },
+  "DownloadButton": {
+    "download": "Download"
+  },
+  "DownloadModal": {
+    "dialogTitle": "Download video",
+    "eyebrow": "Download Video",
+    "posterAlt": "Video poster",
+    "noDownloads": "No downloads are available for this video.",
+    "errorUnavailableSource": "Download unavailable from this source",
+    "tierHighest": "Highest",
+    "tierHigh": "High",
+    "tierLow": "Low"
+  },
+  "HeroPlayerControls": {
+    "play": "Play",
+    "pause": "Pause",
+    "seek": "Seek",
+    "seekValue": "{current} of {total}",
+    "volume": "Volume",
+    "volumeValue": "{percent} percent",
+    "mute": "Mute",
+    "unmute": "Unmute",
+    "changeAudioLanguage": "Change audio language",
+    "enterFullscreen": "Enter fullscreen",
+    "exitFullscreen": "Exit fullscreen"
+  },
+  "LanguageCombobox": {
+    "selectLanguage": "Select language",
+    "searchPlaceholder": "Search languages…",
+    "languages": "Languages",
+    "noMatches": "No matches"
+  },
+  "LanguagePickerModal": {
+    "dialogTitle": "Language",
+    "dialogTitleWithSubtitles": "Language & Subtitles",
+    "languageHeading": "Language",
+    "subtitlesHeading": "Subtitles",
+    "languageCount": "{count, plural, one {# language} other {# languages}}",
+    "requestSent": "Request sent",
+    "translateWithAi": "Translate with AI",
+    "noSubtitles": "No subtitles",
+    "close": "Close",
+    "apply": "Apply"
+  },
+  "SeriesPage": {
+    "episodeCount": "{count, plural, one {1 EPISODE} other {# EPISODES}}",
+    "seriesLabel": "SERIES · {episodes}",
+    "changeAudioLanguage": "Change audio language",
+    "share": "Share",
+    "languages": "Languages"
+  },
+  "WatchModal": {
+    "close": "Close"
+  },
+  "WatchStudyQuestions": {
+    "placeholderQuestion": "If you could ask the creator of this video a question, what would it be?",
+    "fallbackBody": "Have a private discussion with someone who is ready to listen.",
+    "questionsShort": "Questions",
+    "questions": "Related Questions",
+    "askYours": "Ask yours",
+    "chatWithPerson": "Chat with a person",
+    "askBibleQuestion": "Ask a Bible question"
+  },
+  "ShareModal": {
+    "dialogTitle": "Share video",
+    "heading": "Share this video",
+    "posterAlt": "Video poster",
+    "shareOnFacebook": "Share on Facebook",
+    "shareOnFacebookUnavailable": "Share on Facebook (unavailable on this build)",
+    "shareOnX": "Share on X",
+    "shareOnXUnavailable": "Share on X (unavailable on this build)",
+    "shareDisabledHint": "Sharing requires a deployed page — works once this video is in production.",
+    "shareFormat": "Share format",
+    "shareLinkTab": "Share Link",
+    "embedCodeTab": "Embed Code",
+    "copyFailed": "Couldn’t copy automatically — select the text below and copy manually.",
+    "copyLink": "Copy Link",
+    "copyCode": "Copy Code",
+    "copied": "Copied",
+    "close": "Close"
+  },
+  "SubtitleTranscript": {
+    "heading": "Transcript",
+    "subheading": "Tap any line to jump to that moment.",
+    "subtitleLanguage": "Subtitle language",
+    "aiSuffix": " · AI",
+    "loading": "Loading transcript…",
+    "unavailable": "Transcript unavailable for this subtitle track.",
+    "empty": "No transcript lines found."
   }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -12,5 +12,105 @@
   "VideosPage": {
     "title": "Todos los videos",
     "placeholder": "La exploración del catálogo está en camino. Mientras tanto, use la búsqueda o una URL específica del tema."
+  },
+  "BibleQuotes": {
+    "title": "Citas bíblicas",
+    "share": "Compartir",
+    "readMore": "Leer más...",
+    "freeResources": "Recursos gratuitos",
+    "promoHeading": "¿Quieres profundizar en tu comprensión de la Biblia?",
+    "joinBibleStudy": "Únete a nuestro estudio bíblico",
+    "previousQuote": "Cita bíblica anterior",
+    "nextQuote": "Cita bíblica siguiente"
+  },
+  "DownloadButton": {
+    "download": "Descargar"
+  },
+  "DownloadModal": {
+    "dialogTitle": "Descargar video",
+    "eyebrow": "Descargar video",
+    "posterAlt": "Miniatura del video",
+    "noDownloads": "No hay descargas disponibles para este video.",
+    "errorUnavailableSource": "Descarga no disponible desde esta fuente",
+    "tierHighest": "Máxima",
+    "tierHigh": "Alta",
+    "tierLow": "Baja"
+  },
+  "HeroPlayerControls": {
+    "play": "Reproducir",
+    "pause": "Pausar",
+    "seek": "Buscar",
+    "seekValue": "{current} de {total}",
+    "volume": "Volumen",
+    "volumeValue": "{percent} por ciento",
+    "mute": "Silenciar",
+    "unmute": "Activar sonido",
+    "changeAudioLanguage": "Cambiar idioma del audio",
+    "enterFullscreen": "Pantalla completa",
+    "exitFullscreen": "Salir de pantalla completa"
+  },
+  "LanguageCombobox": {
+    "selectLanguage": "Seleccionar idioma",
+    "searchPlaceholder": "Buscar idiomas…",
+    "languages": "Idiomas",
+    "noMatches": "Sin coincidencias"
+  },
+  "LanguagePickerModal": {
+    "dialogTitle": "Idioma",
+    "dialogTitleWithSubtitles": "Idioma y subtítulos",
+    "languageHeading": "Idioma",
+    "subtitlesHeading": "Subtítulos",
+    "languageCount": "{count, plural, one {# idioma} other {# idiomas}}",
+    "requestSent": "Solicitud enviada",
+    "translateWithAi": "Traducir con IA",
+    "noSubtitles": "Sin subtítulos",
+    "close": "Cerrar",
+    "apply": "Aplicar"
+  },
+  "SeriesPage": {
+    "episodeCount": "{count, plural, one {1 EPISODIO} other {# EPISODIOS}}",
+    "seriesLabel": "SERIE · {episodes}",
+    "changeAudioLanguage": "Cambiar idioma del audio",
+    "share": "Compartir",
+    "languages": "Idiomas"
+  },
+  "WatchModal": {
+    "close": "Cerrar"
+  },
+  "WatchStudyQuestions": {
+    "placeholderQuestion": "Si pudieras hacerle una pregunta al creador de este video, ¿cuál sería?",
+    "fallbackBody": "Ten una conversación privada con alguien dispuesto a escuchar.",
+    "questionsShort": "Preguntas",
+    "questions": "Preguntas relacionadas",
+    "askYours": "Haz la tuya",
+    "chatWithPerson": "Chatear con una persona",
+    "askBibleQuestion": "Hacer una pregunta bíblica"
+  },
+  "ShareModal": {
+    "dialogTitle": "Compartir video",
+    "heading": "Comparte este video",
+    "posterAlt": "Miniatura del video",
+    "shareOnFacebook": "Compartir en Facebook",
+    "shareOnFacebookUnavailable": "Compartir en Facebook (no disponible en esta versión)",
+    "shareOnX": "Compartir en X",
+    "shareOnXUnavailable": "Compartir en X (no disponible en esta versión)",
+    "shareDisabledHint": "Compartir requiere una página desplegada — funciona cuando este video esté en producción.",
+    "shareFormat": "Formato para compartir",
+    "shareLinkTab": "Enlace para compartir",
+    "embedCodeTab": "Código de inserción",
+    "copyFailed": "No se pudo copiar automáticamente — selecciona el texto a continuación y cópialo manualmente.",
+    "copyLink": "Copiar enlace",
+    "copyCode": "Copiar código",
+    "copied": "Copiado",
+    "close": "Cerrar"
+  },
+  "SubtitleTranscript": {
+    "heading": "Transcripción",
+    "subheading": "Toca cualquier línea para saltar a ese momento.",
+    "subtitleLanguage": "Idioma de los subtítulos",
+    "aiSuffix": " · IA",
+    "loading": "Cargando transcripción…",
+    "unavailable": "Transcripción no disponible para esta pista de subtítulos.",
+    "empty": "No se encontraron líneas de transcripción."
   }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -12,5 +12,105 @@
   "VideosPage": {
     "title": "Toutes les vidéos",
     "placeholder": "La navigation dans le catalogue arrive. En attendant, utilisez la recherche ou une URL spécifique au sujet."
+  },
+  "BibleQuotes": {
+    "title": "Citations bibliques",
+    "share": "Partager",
+    "readMore": "Lire la suite...",
+    "freeResources": "Ressources gratuites",
+    "promoHeading": "Vous voulez approfondir votre compréhension de la Bible ?",
+    "joinBibleStudy": "Rejoignez notre étude biblique",
+    "previousQuote": "Citation biblique précédente",
+    "nextQuote": "Citation biblique suivante"
+  },
+  "DownloadButton": {
+    "download": "Télécharger"
+  },
+  "DownloadModal": {
+    "dialogTitle": "Télécharger la vidéo",
+    "eyebrow": "Télécharger la vidéo",
+    "posterAlt": "Miniature de la vidéo",
+    "noDownloads": "Aucun téléchargement n'est disponible pour cette vidéo.",
+    "errorUnavailableSource": "Téléchargement indisponible depuis cette source",
+    "tierHighest": "Maximale",
+    "tierHigh": "Élevée",
+    "tierLow": "Basse"
+  },
+  "HeroPlayerControls": {
+    "play": "Lire",
+    "pause": "Pause",
+    "seek": "Rechercher",
+    "seekValue": "{current} sur {total}",
+    "volume": "Volume",
+    "volumeValue": "{percent} pour cent",
+    "mute": "Couper le son",
+    "unmute": "Activer le son",
+    "changeAudioLanguage": "Changer la langue audio",
+    "enterFullscreen": "Plein écran",
+    "exitFullscreen": "Quitter le plein écran"
+  },
+  "LanguageCombobox": {
+    "selectLanguage": "Sélectionner la langue",
+    "searchPlaceholder": "Rechercher des langues…",
+    "languages": "Langues",
+    "noMatches": "Aucune correspondance"
+  },
+  "LanguagePickerModal": {
+    "dialogTitle": "Langue",
+    "dialogTitleWithSubtitles": "Langue et sous-titres",
+    "languageHeading": "Langue",
+    "subtitlesHeading": "Sous-titres",
+    "languageCount": "{count, plural, one {# langue} other {# langues}}",
+    "requestSent": "Demande envoyée",
+    "translateWithAi": "Traduire avec l'IA",
+    "noSubtitles": "Aucun sous-titre",
+    "close": "Fermer",
+    "apply": "Appliquer"
+  },
+  "SeriesPage": {
+    "episodeCount": "{count, plural, one {1 ÉPISODE} other {# ÉPISODES}}",
+    "seriesLabel": "SÉRIE · {episodes}",
+    "changeAudioLanguage": "Changer la langue audio",
+    "share": "Partager",
+    "languages": "Langues"
+  },
+  "WatchModal": {
+    "close": "Fermer"
+  },
+  "WatchStudyQuestions": {
+    "placeholderQuestion": "Si vous pouviez poser une question au créateur de cette vidéo, quelle serait-elle ?",
+    "fallbackBody": "Ayez une discussion privée avec quelqu'un prêt à écouter.",
+    "questionsShort": "Questions",
+    "questions": "Questions connexes",
+    "askYours": "Posez la vôtre",
+    "chatWithPerson": "Discuter avec une personne",
+    "askBibleQuestion": "Poser une question biblique"
+  },
+  "ShareModal": {
+    "dialogTitle": "Partager la vidéo",
+    "heading": "Partagez cette vidéo",
+    "posterAlt": "Miniature de la vidéo",
+    "shareOnFacebook": "Partager sur Facebook",
+    "shareOnFacebookUnavailable": "Partager sur Facebook (indisponible sur cette version)",
+    "shareOnX": "Partager sur X",
+    "shareOnXUnavailable": "Partager sur X (indisponible sur cette version)",
+    "shareDisabledHint": "Le partage nécessite une page déployée — fonctionne une fois cette vidéo en production.",
+    "shareFormat": "Format de partage",
+    "shareLinkTab": "Lien de partage",
+    "embedCodeTab": "Code d'intégration",
+    "copyFailed": "Impossible de copier automatiquement — sélectionnez le texte ci-dessous et copiez-le manuellement.",
+    "copyLink": "Copier le lien",
+    "copyCode": "Copier le code",
+    "copied": "Copié",
+    "close": "Fermer"
+  },
+  "SubtitleTranscript": {
+    "heading": "Transcription",
+    "subheading": "Touchez une ligne pour accéder à ce moment.",
+    "subtitleLanguage": "Langue des sous-titres",
+    "aiSuffix": " · IA",
+    "loading": "Chargement de la transcription…",
+    "unavailable": "Transcription indisponible pour cette piste de sous-titres.",
+    "empty": "Aucune ligne de transcription trouvée."
   }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -12,5 +12,105 @@
   "VideosPage": {
     "title": "Todos os vídeos",
     "placeholder": "A navegação pelo catálogo está chegando. Enquanto isso, use a busca ou uma URL específica do tópico."
+  },
+  "BibleQuotes": {
+    "title": "Citações bíblicas",
+    "share": "Compartilhar",
+    "readMore": "Leia mais...",
+    "freeResources": "Recursos gratuitos",
+    "promoHeading": "Quer aprofundar sua compreensão da Bíblia?",
+    "joinBibleStudy": "Participe do nosso estudo bíblico",
+    "previousQuote": "Citação bíblica anterior",
+    "nextQuote": "Próxima citação bíblica"
+  },
+  "DownloadButton": {
+    "download": "Baixar"
+  },
+  "DownloadModal": {
+    "dialogTitle": "Baixar vídeo",
+    "eyebrow": "Baixar vídeo",
+    "posterAlt": "Miniatura do vídeo",
+    "noDownloads": "Nenhum download disponível para este vídeo.",
+    "errorUnavailableSource": "Download indisponível nesta fonte",
+    "tierHighest": "Máxima",
+    "tierHigh": "Alta",
+    "tierLow": "Baixa"
+  },
+  "HeroPlayerControls": {
+    "play": "Reproduzir",
+    "pause": "Pausar",
+    "seek": "Buscar",
+    "seekValue": "{current} de {total}",
+    "volume": "Volume",
+    "volumeValue": "{percent} por cento",
+    "mute": "Silenciar",
+    "unmute": "Ativar som",
+    "changeAudioLanguage": "Alterar idioma do áudio",
+    "enterFullscreen": "Tela cheia",
+    "exitFullscreen": "Sair da tela cheia"
+  },
+  "LanguageCombobox": {
+    "selectLanguage": "Selecionar idioma",
+    "searchPlaceholder": "Buscar idiomas…",
+    "languages": "Idiomas",
+    "noMatches": "Nenhuma correspondência"
+  },
+  "LanguagePickerModal": {
+    "dialogTitle": "Idioma",
+    "dialogTitleWithSubtitles": "Idioma e legendas",
+    "languageHeading": "Idioma",
+    "subtitlesHeading": "Legendas",
+    "languageCount": "{count, plural, one {# idioma} other {# idiomas}}",
+    "requestSent": "Solicitação enviada",
+    "translateWithAi": "Traduzir com IA",
+    "noSubtitles": "Sem legendas",
+    "close": "Fechar",
+    "apply": "Aplicar"
+  },
+  "SeriesPage": {
+    "episodeCount": "{count, plural, one {1 EPISÓDIO} other {# EPISÓDIOS}}",
+    "seriesLabel": "SÉRIE · {episodes}",
+    "changeAudioLanguage": "Alterar idioma do áudio",
+    "share": "Compartilhar",
+    "languages": "Idiomas"
+  },
+  "WatchModal": {
+    "close": "Fechar"
+  },
+  "WatchStudyQuestions": {
+    "placeholderQuestion": "Se você pudesse fazer uma pergunta ao criador deste vídeo, qual seria?",
+    "fallbackBody": "Tenha uma conversa privada com alguém disposto a ouvir.",
+    "questionsShort": "Perguntas",
+    "questions": "Perguntas relacionadas",
+    "askYours": "Faça a sua",
+    "chatWithPerson": "Conversar com uma pessoa",
+    "askBibleQuestion": "Fazer uma pergunta bíblica"
+  },
+  "ShareModal": {
+    "dialogTitle": "Compartilhar vídeo",
+    "heading": "Compartilhe este vídeo",
+    "posterAlt": "Miniatura do vídeo",
+    "shareOnFacebook": "Compartilhar no Facebook",
+    "shareOnFacebookUnavailable": "Compartilhar no Facebook (indisponível nesta versão)",
+    "shareOnX": "Compartilhar no X",
+    "shareOnXUnavailable": "Compartilhar no X (indisponível nesta versão)",
+    "shareDisabledHint": "Compartilhar requer uma página publicada — funciona quando este vídeo estiver em produção.",
+    "shareFormat": "Formato de compartilhamento",
+    "shareLinkTab": "Link de compartilhamento",
+    "embedCodeTab": "Código de incorporação",
+    "copyFailed": "Não foi possível copiar automaticamente — selecione o texto abaixo e copie manualmente.",
+    "copyLink": "Copiar link",
+    "copyCode": "Copiar código",
+    "copied": "Copiado",
+    "close": "Fechar"
+  },
+  "SubtitleTranscript": {
+    "heading": "Transcrição",
+    "subheading": "Toque em qualquer linha para pular para aquele momento.",
+    "subtitleLanguage": "Idioma das legendas",
+    "aiSuffix": " · IA",
+    "loading": "Carregando transcrição…",
+    "unavailable": "Transcrição indisponível para esta faixa de legendas.",
+    "empty": "Nenhuma linha de transcrição encontrada."
   }
 }

--- a/apps/web/src/components/watch/BibleQuotesSection.tsx
+++ b/apps/web/src/components/watch/BibleQuotesSection.tsx
@@ -12,6 +12,7 @@
 
 import Image from "next/image"
 import { ExternalLink } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 
 import type { WatchBibleQuotesBlock } from "@/lib/content"
@@ -144,6 +145,7 @@ export function BibleQuotesSection({
   onShareClick,
   locale = "en",
 }: BibleQuotesSectionProps) {
+  const t = useTranslations("BibleQuotes")
   // The carousel always renders, even when the video has no Bible citations —
   // the trailing "Join Our Bible Study" promo card is the always-on CTA, and
   // every video page should surface it.
@@ -157,16 +159,16 @@ export function BibleQuotesSection({
         data-testid="watch-bible-quotes-header"
         className="mb-6 flex flex-wrap items-center justify-between gap-3 pb-2"
       >
-        <h2 className={WATCH_SECTION_EYEBROW_CLASS}>Bible Quotes</h2>
+        <h2 className={WATCH_SECTION_EYEBROW_CLASS}>{t("title")}</h2>
         <Button
           variant="pill"
           className={WATCH_PILL_BUTTON_CLASS}
           onClick={onShareClick}
-          aria-label="Share"
+          aria-label={t("share")}
           data-testid="watch-share-button"
         >
           <ExternalLink size={16} />
-          <span>Share</span>
+          <span>{t("share")}</span>
         </Button>
       </div>
 
@@ -175,7 +177,7 @@ export function BibleQuotesSection({
         className="-mx-10 w-[calc(100%+5rem)] md:mx-0 md:w-full"
       >
         <Carousel
-          aria-label="Bible Quotes"
+          aria-label={t("title")}
           opts={CAROUSEL_OPTS}
           className="w-full"
         >
@@ -193,6 +195,7 @@ export function BibleQuotesSection({
                   citation={citation}
                   imageUrl={BIBLE_IMAGES[i % BIBLE_IMAGES.length]!}
                   locale={locale}
+                  readMoreLabel={t("readMore")}
                 />
                 {/*
                   Previously passed `isLcpCandidate={i === 0}` to mark the
@@ -230,10 +233,10 @@ export function BibleQuotesSection({
                 />
                 <div className="z-1 p-8 pt-0 md:p-10 md:pt-0">
                   <span className="mb-3 block text-sm font-bold tracking-normal text-white/80 uppercase">
-                    Free Resources
+                    {t("freeResources")}
                   </span>
                   <h3 className="mb-6 max-w-[19ch] text-3xl leading-tight font-black text-balance text-white md:text-4xl">
-                    Want to grow deep in your understanding of the Bible?
+                    {t("promoHeading")}
                   </h3>
                   <Button
                     variant="pill"
@@ -248,7 +251,7 @@ export function BibleQuotesSection({
                       />
                     }
                   >
-                    Join our Bible study
+                    {t("joinBibleStudy")}
                   </Button>
                 </div>
               </div>
@@ -266,12 +269,12 @@ export function BibleQuotesSection({
               controls so large quote cards are browsable without dragging. */}
           <CarouselPrevious
             className="hidden text-stone-900 hover:text-stone-900 md:inline-flex"
-            label="Previous Bible quote"
+            label={t("previousQuote")}
             data-testid="watch-bible-quotes-prev"
           />
           <CarouselNext
             className="hidden text-stone-900 hover:text-stone-900 md:inline-flex"
-            label="Next Bible quote"
+            label={t("nextQuote")}
             data-testid="watch-bible-quotes-next"
           />
         </Carousel>
@@ -303,11 +306,14 @@ function BibleCitationCard({
   citation,
   imageUrl,
   locale,
+  readMoreLabel,
   eager = false,
 }: {
   citation: WatchBibleCitation
   imageUrl: string
   locale: string
+  /** Localized "Read more..." link label, threaded from the parent's t(). */
+  readMoreLabel: string
   // Whether to load the card image eagerly with high fetch priority. Off
   // by default — the section sits below the fold on the watch page, so
   // marking a card priority diverts budget without helping LCP. Callers
@@ -456,7 +462,7 @@ function BibleCitationCard({
             data-testid="watch-bible-quotes-read-more"
             className="relative mt-7 block w-fit cursor-pointer text-xl leading-none font-semibold text-white/85 underline decoration-white/45 decoration-2 underline-offset-4 transition-colors duration-200 hover:text-white hover:decoration-white md:text-2xl"
           >
-            Read more...
+            {readMoreLabel}
           </a>
         )}
       </div>

--- a/apps/web/src/components/watch/DownloadButton.tsx
+++ b/apps/web/src/components/watch/DownloadButton.tsx
@@ -1,19 +1,22 @@
 "use client"
 
+import { useTranslations } from "next-intl"
+
 import { Button } from "@/components/ui/button"
 import { WATCH_PILL_BUTTON_CLASS } from "@/components/watch/watch-section-styles"
 
 export function DownloadButton({ onClick }: { onClick: () => void }) {
+  const t = useTranslations("DownloadButton")
   return (
     <Button
       variant="pill"
       className={WATCH_PILL_BUTTON_CLASS}
-      aria-label="Download"
+      aria-label={t("download")}
       data-testid="watch-download-button"
       onClick={onClick}
     >
       <DownloadIcon />
-      <span>Download</span>
+      <span>{t("download")}</span>
     </Button>
   )
 }

--- a/apps/web/src/components/watch/DownloadModal.tsx
+++ b/apps/web/src/components/watch/DownloadModal.tsx
@@ -10,6 +10,7 @@ import {
   Play,
   X as XIcon,
 } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { formatDuration as formatDurationShared } from "@/lib/format-duration"
 import { Button } from "@/components/ui/button"
@@ -191,6 +192,16 @@ export function DownloadModal({
   languageName,
   onClose,
 }: DownloadModalProps) {
+  const t = useTranslations("DownloadModal")
+  // Localized label for a quality tier. `bucketDownloads` carries an English
+  // `label` for back-compat, but the rendered text is resolved here so it
+  // translates.
+  const tierLabel = (tier: Tier): string =>
+    tier === "highest"
+      ? t("tierHighest")
+      : tier === "high"
+        ? t("tierHigh")
+        : t("tierLow")
   const [tosAgreed, setTosAgreed] = useState(false)
   const [selectedTier, setSelectedTier] = useState<Tier | null>(null)
   const [dropdownOpen, setDropdownOpen] = useState(false)
@@ -375,7 +386,7 @@ export function DownloadModal({
         "[DownloadModal] Refusing to download from non-allowlisted origin",
         { url: sourceUrl },
       )
-      setError("Download unavailable from this source")
+      setError(t("errorUnavailableSource"))
       return
     }
     setError(null)
@@ -415,7 +426,7 @@ export function DownloadModal({
         overlayClassName="bg-black/85 supports-backdrop-filter:backdrop-blur-md"
         showCloseButton={false}
       >
-        <DialogTitle className="sr-only">Download video</DialogTitle>
+        <DialogTitle className="sr-only">{t("dialogTitle")}</DialogTitle>
 
         <div className="flex max-h-[82vh] flex-col gap-7 overflow-y-auto pr-2 [scrollbar-color:theme(colors.stone.700)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-stone-700 [&::-webkit-scrollbar-track]:bg-transparent hover:[&::-webkit-scrollbar-thumb]:bg-stone-600">
           {/* Header: thumbnail + metadata */}
@@ -427,7 +438,7 @@ export function DownloadModal({
               {posterUrl ? (
                 <Image
                   src={posterUrl}
-                  alt={videoTitle ?? "Video poster"}
+                  alt={videoTitle ?? t("posterAlt")}
                   fill
                   sizes="(min-width: 640px) 224px, 100vw"
                   className="object-cover"
@@ -449,7 +460,7 @@ export function DownloadModal({
                 data-testid="watch-download-modal-eyebrow"
                 className={WATCH_SECTION_EYEBROW_CLASS}
               >
-                Download Video
+                {t("eyebrow")}
               </span>
               <h2
                 data-testid="watch-download-modal-title"
@@ -476,7 +487,7 @@ export function DownloadModal({
                 data-testid="watch-download-modal-empty"
                 className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-stone-400"
               >
-                No downloads are available for this video.
+                {t("noDownloads")}
               </p>
             ) : (
               <div className="-mx-2 flex flex-col gap-3 px-2">
@@ -503,7 +514,7 @@ export function DownloadModal({
                       {selected ? (
                         <>
                           <span className="font-semibold">
-                            {selected.label}
+                            {tierLabel(selected.tier)}
                           </span>
                           <SizeLabel
                             bytes={resolveSize(selected.download)}
@@ -559,7 +570,9 @@ export function DownloadModal({
                                   isSelected ? "opacity-100" : "opacity-0"
                                 }
                               />
-                              <span className="font-semibold">{t.label}</span>
+                              <span className="font-semibold">
+                                {tierLabel(t.tier)}
+                              </span>
                               <SizeLabel
                                 bytes={resolveSize(t.download)}
                                 className={cn(

--- a/apps/web/src/components/watch/HeroPlayerControls.tsx
+++ b/apps/web/src/components/watch/HeroPlayerControls.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Globe } from "lucide-react"
+import { useTranslations } from "next-intl"
 import {
   useCallback,
   useEffect,
@@ -61,6 +62,7 @@ export function HeroPlayerControls({
   showLanguageButton?: boolean
   onVisibilityChange?: (visible: boolean) => void
 }) {
+  const t = useTranslations("HeroPlayerControls")
   const [playing, setPlaying] = useState(false)
   const [muted, setMuted] = useState(false)
   const [volume, setVolume] = useState(1)
@@ -726,7 +728,7 @@ export function HeroPlayerControls({
     >
       <ChromeButton
         onClick={togglePlay}
-        ariaLabel={playing ? "Pause" : "Play"}
+        ariaLabel={playing ? t("pause") : t("play")}
         testId="hero-chrome-play"
       >
         {playing ? <PauseIcon /> : <PlayIcon />}
@@ -736,11 +738,14 @@ export function HeroPlayerControls({
         ref={timelineRef}
         role="slider"
         tabIndex={0}
-        aria-label="Seek"
+        aria-label={t("seek")}
         aria-valuemin={0}
         aria-valuemax={Math.max(0, Math.floor(duration))}
         aria-valuenow={Math.floor(displayTime)}
-        aria-valuetext={`${formatTime(displayTime)} of ${formatTime(duration)}`}
+        aria-valuetext={t("seekValue", {
+          current: formatTime(displayTime),
+          total: formatTime(duration),
+        })}
         data-testid="hero-chrome-timeline"
         data-dragging={timelineDragging ? "true" : "false"}
         onPointerDown={handleTimelinePointerDown}
@@ -798,12 +803,14 @@ export function HeroPlayerControls({
             ref={volumeTrackRef}
             role="slider"
             tabIndex={0}
-            aria-label="Volume"
+            aria-label={t("volume")}
             data-testid="hero-chrome-volume-slider"
             aria-valuemin={0}
             aria-valuemax={100}
             aria-valuenow={Math.round((muted ? 0 : volume) * 100)}
-            aria-valuetext={`${Math.round((muted ? 0 : volume) * 100)} percent`}
+            aria-valuetext={t("volumeValue", {
+              percent: Math.round((muted ? 0 : volume) * 100),
+            })}
             onPointerDown={handleVolumePointerDown}
             onPointerMove={handleVolumePointerMove}
             onPointerUp={handleVolumePointerUp}
@@ -828,7 +835,7 @@ export function HeroPlayerControls({
         </div>
         <ChromeButton
           onClick={toggleMute}
-          ariaLabel={muted || volume === 0 ? "Unmute" : "Mute"}
+          ariaLabel={muted || volume === 0 ? t("unmute") : t("mute")}
           testId="hero-chrome-mute"
         >
           {muted || volume === 0 ? <ChromeMutedIcon /> : <ChromeVolumeIcon />}
@@ -838,7 +845,7 @@ export function HeroPlayerControls({
       {showLanguageButton && onLanguageClick ? (
         <ChromeButton
           onClick={onLanguageClick}
-          ariaLabel="Change audio language"
+          ariaLabel={t("changeAudioLanguage")}
           testId="hero-chrome-language"
         >
           <Globe aria-hidden className="h-6 w-6" />
@@ -847,7 +854,7 @@ export function HeroPlayerControls({
 
       <ChromeButton
         onClick={toggleFullscreen}
-        ariaLabel={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        ariaLabel={isFullscreen ? t("exitFullscreen") : t("enterFullscreen")}
         testId="hero-chrome-fullscreen"
       >
         {isFullscreen ? <ExitFullscreenIcon /> : <EnterFullscreenIcon />}

--- a/apps/web/src/components/watch/LanguageCombobox.tsx
+++ b/apps/web/src/components/watch/LanguageCombobox.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Captions, ChevronsUpDown, Languages } from "lucide-react"
+import { useTranslations } from "next-intl"
 import {
   useCallback,
   useEffect,
@@ -418,8 +419,12 @@ export function LanguageCombobox({
   onChange,
   icon = "language",
   disabled = false,
-  placeholder = "Select language",
+  placeholder,
 }: LanguageComboboxProps) {
+  const t = useTranslations("LanguageCombobox")
+  // Fall back to the localized default only when the caller did not pass an
+  // explicit placeholder (e.g. LanguagePickerModal passes "No subtitles").
+  const resolvedPlaceholder = placeholder ?? t("selectLanguage")
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
   const [activeIndex, setActiveIndex] = useState(0)
@@ -577,7 +582,7 @@ export function LanguageCombobox({
           )}
           <span className="min-w-0">
             <span className="block truncate leading-tight">
-              {selected?.name ?? placeholder}
+              {selected?.name ?? resolvedPlaceholder}
             </span>
             {selectedNativeName ? (
               <span
@@ -615,7 +620,7 @@ export function LanguageCombobox({
               // In production both fire on every keystroke; React batches identical setQuery values, so no double-render.
               onInput={(e) => resetQuery((e.target as HTMLInputElement).value)}
               onKeyDown={handleSearchKeyDown}
-              placeholder="Search languages…"
+              placeholder={t("searchPlaceholder")}
               aria-activedescendant={
                 filtered[activeIndex]
                   ? `lcb-opt-${filtered[activeIndex].slug}`
@@ -633,7 +638,7 @@ export function LanguageCombobox({
           */}
           <ul
             role="listbox"
-            aria-label="Languages"
+            aria-label={t("languages")}
             className="max-h-72 overflow-y-auto py-1 [scrollbar-color:theme(colors.stone.700)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-stone-700 hover:[&::-webkit-scrollbar-thumb]:bg-stone-600 [&::-webkit-scrollbar-track]:bg-transparent"
           >
             {filtered.length === 0 ? (
@@ -641,7 +646,7 @@ export function LanguageCombobox({
                 data-testid="language-combobox-empty"
                 className="px-4 py-3 text-sm text-stone-500"
               >
-                No matches
+                {t("noMatches")}
               </li>
             ) : (
               filtered.map((option, index) => {

--- a/apps/web/src/components/watch/LanguagePickerModal.tsx
+++ b/apps/web/src/components/watch/LanguagePickerModal.tsx
@@ -2,6 +2,7 @@
 
 import type { Route } from "next"
 import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
 import type { RefObject } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
@@ -86,6 +87,7 @@ export function LanguagePickerModal({
   currentSubtitleSlug = null,
   onSubtitleChange,
 }: LanguagePickerModalProps) {
+  const t = useTranslations("LanguagePickerModal")
   const router = useRouter()
 
   // Per row, deriveLanguageDisplay decides whether Strapi's `name` is a
@@ -284,21 +286,22 @@ export function LanguagePickerModal({
         portalContainer={portalContainer}
       >
         <DialogTitle className="sr-only">
-          Language{subtitles.length > 0 ? " & Subtitles" : ""}
+          {subtitles.length > 0
+            ? t("dialogTitleWithSubtitles")
+            : t("dialogTitle")}
         </DialogTitle>
 
         <div className="flex flex-col gap-14">
           <div className="flex flex-col gap-5">
             <div className="flex items-baseline justify-between gap-3">
               <h2 className="text-2xl font-semibold text-stone-100">
-                Language
+                {t("languageHeading")}
               </h2>
               <span
                 data-testid="watch-language-picker-count"
                 className="text-lg font-normal text-stone-400"
               >
-                {options.length}{" "}
-                {options.length === 1 ? "language" : "languages"}
+                {t("languageCount", { count: options.length })}
               </span>
             </div>
             <LanguageCombobox
@@ -312,7 +315,7 @@ export function LanguagePickerModal({
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-6">
                 <h2 className="text-2xl font-semibold text-stone-100">
-                  Subtitles
+                  {t("subtitlesHeading")}
                 </h2>
                 <button
                   type="button"
@@ -341,16 +344,15 @@ export function LanguagePickerModal({
                     className="cursor-pointer rounded-full border border-stone-400/50 bg-transparent px-4 py-2 text-xs font-bold tracking-wider text-stone-300 uppercase transition-colors duration-200 hover:border-stone-200 hover:bg-transparent hover:text-white disabled:cursor-default disabled:border-stone-500/35 disabled:text-stone-500 disabled:opacity-100"
                   >
                     {translationRequestSent
-                      ? "Request sent"
-                      : "Translate with AI"}
+                      ? t("requestSent")
+                      : t("translateWithAi")}
                   </Button>
                 ) : null}
                 <span
                   data-testid="watch-language-picker-subtitle-count"
                   className="text-lg font-normal text-stone-400"
                 >
-                  {subtitleOptions.length}{" "}
-                  {subtitleOptions.length === 1 ? "language" : "languages"}
+                  {t("languageCount", { count: subtitleOptions.length })}
                 </span>
               </div>
             </div>
@@ -360,7 +362,7 @@ export function LanguagePickerModal({
               onChange={setDraftSubtitleSlug}
               icon="subtitles"
               disabled={!draftSubtitleEnabled || subtitleOptions.length === 0}
-              placeholder="No subtitles"
+              placeholder={t("noSubtitles")}
             />
           </div>
 
@@ -371,7 +373,7 @@ export function LanguagePickerModal({
               onClick={onClose}
               className="cursor-pointer rounded-full px-5 py-3.5 text-sm font-bold tracking-wider text-stone-400 uppercase transition-colors duration-200 hover:bg-transparent hover:text-stone-100"
             >
-              Close
+              {t("close")}
             </Button>
             <Button
               variant="pill"
@@ -380,7 +382,7 @@ export function LanguagePickerModal({
               onClick={handleApply}
               className="bg-stone-300 px-7 py-4 text-sm text-stone-950 hover:bg-white hover:text-stone-950 disabled:bg-stone-300 disabled:text-stone-950"
             >
-              Apply
+              {t("apply")}
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/watch/SeriesPageClient.tsx
+++ b/apps/web/src/components/watch/SeriesPageClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { Route } from "next"
 import { useRouter } from "next/navigation"
 import { ExternalLink, Globe } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
@@ -40,18 +41,12 @@ type SeriesPageClientProps = {
   locale: string
 }
 
-// R8 pluralization rule: N === 1 → "1 EPISODE"; N === 0 or N >= 2 →
-// "{N} EPISODES". Plural form covers the empty case ("0 EPISODES") because
-// English plural matches the empty count.
-function formatEpisodeCount(count: number): string {
-  return count === 1 ? "1 EPISODE" : `${count} EPISODES`
-}
-
 export function SeriesPageClient({
   series,
   selectedVariant,
   locale,
 }: SeriesPageClientProps) {
+  const t = useTranslations("SeriesPage")
   const router = useRouter()
   const [modalState, setModalState] = useState<SeriesModalState>("none")
   const openShare = useCallback(() => setModalState("share"), [])
@@ -81,7 +76,9 @@ export function SeriesPageClient({
     (child): child is NonNullable<(typeof series.children)[number]> =>
       child != null,
   )
-  const episodeLabel = formatEpisodeCount(episodes.length)
+  // R8 pluralization: ICU plural covers N === 0 / 1 / 2+. The "SERIES · …"
+  // composite is built from the localized episode-count string.
+  const episodeLabel = t("episodeCount", { count: episodes.length })
   const description = series.description ?? series.snippet ?? null
   const posterUrl = resolvePosterUrl(series.images?.[0], null)
 
@@ -192,8 +189,8 @@ export function SeriesPageClient({
           type="button"
           data-testid="series-page-language-button"
           onClick={openLanguage}
-          aria-label="Change audio language"
-          title="Change audio language"
+          aria-label={t("changeAudioLanguage")}
+          title={t("changeAudioLanguage")}
           className="fixed top-10 right-10 z-50 inline-flex h-12 w-12 cursor-pointer items-center justify-center rounded-full text-stone-100 transition hover:text-white focus-visible:ring-2 focus-visible:ring-stone-300 focus-visible:outline-none"
         >
           <Globe
@@ -221,7 +218,7 @@ export function SeriesPageClient({
               data-testid="series-page-label"
               className="text-sm font-semibold tracking-wider text-amber-400 uppercase md:text-base"
             >
-              {`SERIES · ${episodeLabel}`}
+              {t("seriesLabel", { episodes: episodeLabel })}
             </span>
             <div className="flex items-baseline justify-between gap-4">
               <h1
@@ -234,11 +231,11 @@ export function SeriesPageClient({
                 <Button
                   variant="pill"
                   onClick={openShare}
-                  aria-label="Share"
+                  aria-label={t("share")}
                   data-testid="series-page-share-button"
                 >
                   <ExternalLink size={16} />
-                  <span>Share</span>
+                  <span>{t("share")}</span>
                 </Button>
               </div>
             </div>
@@ -284,7 +281,7 @@ export function SeriesPageClient({
                 data-testid="series-page-languages-label"
                 className="text-xs font-semibold tracking-[0.18em] text-stone-400 uppercase"
               >
-                Languages
+                {t("languages")}
               </span>
               <LanguageCombobox
                 options={languageOptions}

--- a/apps/web/src/components/watch/ShareModal.tsx
+++ b/apps/web/src/components/watch/ShareModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import Image from "next/image"
 import { Copy, Facebook } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 // Inline X (formerly Twitter) glyph — lucide-react still ships the legacy
 // blue-bird Twitter icon AND exports its own `XIcon` (the close-button "x"),
@@ -68,6 +69,7 @@ export function ShareModal({
   playbackId,
   onClose,
 }: ShareModalProps) {
+  const t = useTranslations("ShareModal")
   const [tab, setTab] = useState<ShareTab>("link")
   const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle")
   const embedRef = useRef<HTMLTextAreaElement | null>(null)
@@ -98,7 +100,7 @@ export function ShareModal({
 
   const isEmbed = tab === "embed"
   const currentValue = isEmbed ? embedSnippet : canonicalUrl
-  const copyLabel = isEmbed ? "Copy Code" : "Copy Link"
+  const copyLabel = isEmbed ? t("copyCode") : t("copyLink")
 
   // Reset the "Copied" pill back to the default label after 2s so a second
   // click reads as a fresh copy. Cleanup clears the timer on unmount or when
@@ -179,11 +181,11 @@ export function ShareModal({
         overlayClassName="bg-black/85 supports-backdrop-filter:backdrop-blur-md"
         showCloseButton={false}
       >
-        <DialogTitle className="sr-only">Share video</DialogTitle>
+        <DialogTitle className="sr-only">{t("dialogTitle")}</DialogTitle>
 
         <div className="flex max-h-[82vh] flex-col gap-6 overflow-y-auto pr-2 [scrollbar-color:theme(colors.stone.700)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-stone-700 [&::-webkit-scrollbar-track]:bg-transparent hover:[&::-webkit-scrollbar-thumb]:bg-stone-600">
           <h2 className="text-2xl font-semibold text-stone-100">
-            Share this video
+            {t("heading")}
           </h2>
 
           <div className="flex flex-col gap-5 sm:flex-row sm:gap-6">
@@ -194,7 +196,7 @@ export function ShareModal({
               {posterUrl ? (
                 <Image
                   src={posterUrl}
-                  alt={videoTitle ?? "Video poster"}
+                  alt={videoTitle ?? t("posterAlt")}
                   fill
                   sizes="(min-width: 640px) 224px, 100vw"
                   className="object-cover"
@@ -228,7 +230,7 @@ export function ShareModal({
                   href={fbHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  aria-label="Share on Facebook"
+                  aria-label={t("shareOnFacebook")}
                   data-testid="watch-share-modal-facebook"
                   className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-[#1877F2] text-white transition hover:bg-[#0c63d4] focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:outline-none"
                 >
@@ -238,7 +240,7 @@ export function ShareModal({
                 <button
                   type="button"
                   disabled
-                  aria-label="Share on Facebook (unavailable on this build)"
+                  aria-label={t("shareOnFacebookUnavailable")}
                   data-testid="watch-share-modal-facebook"
                   className="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-full bg-[#1877F2] text-white opacity-50"
                 >
@@ -250,7 +252,7 @@ export function ShareModal({
                   href={xHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  aria-label="Share on X"
+                  aria-label={t("shareOnX")}
                   data-testid="watch-share-modal-x"
                   className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-black text-white transition hover:bg-stone-800 focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:outline-none"
                 >
@@ -260,7 +262,7 @@ export function ShareModal({
                 <button
                   type="button"
                   disabled
-                  aria-label="Share on X (unavailable on this build)"
+                  aria-label={t("shareOnXUnavailable")}
                   data-testid="watch-share-modal-x"
                   className="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-full bg-black text-white opacity-50"
                 >
@@ -273,8 +275,7 @@ export function ShareModal({
                 data-testid="watch-share-modal-share-disabled-hint"
                 className="text-xs font-semibold text-stone-400"
               >
-                Sharing requires a deployed page — works once this video is in
-                production.
+                {t("shareDisabledHint")}
               </p>
             ) : null}
           </div>
@@ -289,7 +290,7 @@ export function ShareModal({
           {embedSnippet ? (
             <div
               role="tablist"
-              aria-label="Share format"
+              aria-label={t("shareFormat")}
               className="flex border-b border-white/10"
             >
               <button
@@ -305,7 +306,7 @@ export function ShareModal({
                     : "border-b-2 border-transparent text-stone-400 hover:text-stone-200",
                 )}
               >
-                Share Link
+                {t("shareLinkTab")}
               </button>
               <button
                 type="button"
@@ -320,7 +321,7 @@ export function ShareModal({
                     : "border-b-2 border-transparent text-stone-400 hover:text-stone-200",
                 )}
               >
-                Embed Code
+                {t("embedCodeTab")}
               </button>
             </div>
           ) : null}
@@ -332,8 +333,7 @@ export function ShareModal({
                 role="alert"
                 className="mb-2 text-xs font-semibold text-amber-400"
               >
-                Couldn’t copy automatically — select the text below and copy
-                manually.
+                {t("copyFailed")}
               </p>
             ) : null}
             {isEmbed ? (
@@ -367,7 +367,7 @@ export function ShareModal({
               onClick={() => handleOpenChange(false)}
               className="cursor-pointer rounded-full px-5 py-3.5 text-sm font-bold tracking-wider text-stone-400 uppercase transition-colors duration-200 hover:bg-transparent hover:text-stone-100"
             >
-              Close
+              {t("close")}
             </Button>
             <Button
               variant="pill"
@@ -380,7 +380,7 @@ export function ShareModal({
               className="gap-2 px-7 py-4 text-sm"
             >
               <Copy size={16} />
-              <span>{copyStatus === "copied" ? "Copied" : copyLabel}</span>
+              <span>{copyStatus === "copied" ? t("copied") : copyLabel}</span>
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type RefObject,
 } from "react"
+import { useTranslations } from "next-intl"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
@@ -159,6 +160,7 @@ export function SubtitleTranscript({
   audioSlug,
   durationSeconds,
 }: SubtitleTranscriptProps) {
+  const t = useTranslations("SubtitleTranscript")
   const initialSlug = useMemo(
     () => pickInitialSubtitleSlug(subtitles, audioSlug ?? null),
     [subtitles, audioSlug],
@@ -324,16 +326,14 @@ export function SubtitleTranscript({
                 id="watch-transcript-heading"
                 className="text-2xl font-semibold tracking-tight text-stone-50"
               >
-                Transcript
+                {t("heading")}
               </h2>
-              <p className="mt-1 text-sm text-stone-400">
-                Tap any line to jump to that moment.
-              </p>
+              <p className="mt-1 text-sm text-stone-400">{t("subheading")}</p>
             </div>
             <div className="flex items-center gap-3">
               {subtitles.length > 1 ? (
                 <label className="flex items-center gap-2 text-sm text-stone-300">
-                  <span className="sr-only">Subtitle language</span>
+                  <span className="sr-only">{t("subtitleLanguage")}</span>
                   <select
                     data-testid="watch-subtitle-language"
                     value={selectedSlug ?? ""}
@@ -343,7 +343,7 @@ export function SubtitleTranscript({
                     {subtitles.map((s) => (
                       <option key={s.documentId} value={s.language.slug}>
                         {languageLabel(s)}
-                        {s.aiGenerated ? " · AI" : ""}
+                        {s.aiGenerated ? t("aiSuffix") : ""}
                       </option>
                     ))}
                   </select>
@@ -351,7 +351,7 @@ export function SubtitleTranscript({
               ) : (
                 <span className="rounded-full bg-stone-900/60 px-3 py-1 text-xs font-medium uppercase tracking-wide text-stone-300">
                   {activeSubtitle ? languageLabel(activeSubtitle) : ""}
-                  {activeSubtitle?.aiGenerated ? " · AI" : ""}
+                  {activeSubtitle?.aiGenerated ? t("aiSuffix") : ""}
                 </span>
               )}
             </div>
@@ -359,11 +359,11 @@ export function SubtitleTranscript({
 
           {status === "loading" ? (
             <div className="flex items-center justify-center px-8 py-16 text-sm text-stone-400">
-              Loading transcript…
+              {t("loading")}
             </div>
           ) : status === "error" ? (
             <div className="px-8 py-16 text-center text-sm text-stone-400">
-              Transcript unavailable for this subtitle track.
+              {t("unavailable")}
             </div>
           ) : cues && cues.length > 0 ? (
             <ol
@@ -407,7 +407,7 @@ export function SubtitleTranscript({
             </ol>
           ) : (
             <div className="px-8 py-16 text-center text-sm text-stone-400">
-              No transcript lines found.
+              {t("empty")}
             </div>
           )}
         </div>

--- a/apps/web/src/components/watch/WatchModalViewportCloseButton.tsx
+++ b/apps/web/src/components/watch/WatchModalViewportCloseButton.tsx
@@ -2,6 +2,7 @@
 
 import { createPortal } from "react-dom"
 import { X } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 export function WatchModalViewportCloseButton({
   open,
@@ -16,12 +17,13 @@ export function WatchModalViewportCloseButton({
   portalContainer?: HTMLElement | null
   positionClassName?: string
 }) {
+  const t = useTranslations("WatchModal")
   if (!open || typeof document === "undefined") return null
 
   return createPortal(
     <button
       type="button"
-      aria-label="Close"
+      aria-label={t("close")}
       data-testid={testId}
       onClick={onClose}
       className={`fixed ${positionClassName} z-[60] flex h-[52px] w-12 cursor-pointer items-center justify-center rounded-full bg-transparent text-stone-300 transition hover:text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none`}

--- a/apps/web/src/components/watch/WatchStudyQuestions.tsx
+++ b/apps/web/src/components/watch/WatchStudyQuestions.tsx
@@ -10,6 +10,7 @@
 
 import { useId, useState } from "react"
 import { ChevronDown, Mail as MailIcon } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { MessageCircleIcon } from "@/components/sections/RelatedQuestions"
 import { Button } from "@/components/ui/button"
@@ -17,12 +18,6 @@ import {
   WATCH_PILL_BUTTON_CLASS,
   WATCH_SECTION_EYEBROW_CLASS,
 } from "@/components/watch/watch-section-styles"
-
-const PLACEHOLDER_QUESTION =
-  "If you could ask the creator of this video a question, what would it be?"
-
-const FALLBACK_BODY =
-  "Have a private discussion with someone who is ready to listen."
 
 const CHAT_WITH_PERSON_URL =
   "https://chataboutjesus.com/chat/?utm_source=jesusfilm-watch"
@@ -48,8 +43,9 @@ function WatchQuestionIcon() {
 }
 
 export function WatchStudyQuestions({ prompts }: { prompts: string[] }) {
+  const t = useTranslations("WatchStudyQuestions")
   const hasPrompts = prompts.length > 0
-  const items = hasPrompts ? prompts : [PLACEHOLDER_QUESTION]
+  const items = hasPrompts ? prompts : [t("placeholderQuestion")]
   const itemTestId = hasPrompts
     ? "watch-study-questions-item"
     : "watch-study-questions-placeholder"
@@ -79,21 +75,21 @@ export function WatchStudyQuestions({ prompts }: { prompts: string[] }) {
           id="watch-related-questions-heading"
           className={`flex shrink-0 items-center gap-4 ${WATCH_SECTION_EYEBROW_CLASS}`}
         >
-          <span className="md:hidden">Questions</span>
-          <span className="hidden md:inline">Related Questions</span>
+          <span className="md:hidden">{t("questionsShort")}</span>
+          <span className="hidden md:inline">{t("questions")}</span>
         </h2>
         <Button
           variant="pill"
           nativeButton={false}
           className={WATCH_PILL_BUTTON_CLASS}
-          aria-label="Ask yours"
+          aria-label={t("askYours")}
           data-testid="watch-study-questions-ask-yours"
           render={
             <a href={ASK_YOURS_URL} target="_blank" rel="noopener noreferrer" />
           }
         >
           <MessageCircleIcon />
-          <span>Ask yours</span>
+          <span>{t("askYours")}</span>
         </Button>
       </div>
 
@@ -106,6 +102,9 @@ export function WatchStudyQuestions({ prompts }: { prompts: string[] }) {
             key={`${index}-${prompt}`}
             testId={itemTestId}
             question={prompt}
+            fallbackBody={t("fallbackBody")}
+            chatLabel={t("chatWithPerson")}
+            askBibleLabel={t("askBibleQuestion")}
             isOpen={openIndex === index}
             onToggle={() =>
               setOpenIndex((prev) => (prev === index ? null : index))
@@ -120,11 +119,20 @@ export function WatchStudyQuestions({ prompts }: { prompts: string[] }) {
 function StudyQuestionRow({
   testId,
   question,
+  fallbackBody,
+  chatLabel,
+  askBibleLabel,
   isOpen,
   onToggle,
 }: {
   testId: string
   question: string
+  /** Localized "Have a private discussion…" body, threaded from the parent's t(). */
+  fallbackBody: string
+  /** Localized "Chat with a person" CTA label. */
+  chatLabel: string
+  /** Localized "Ask a Bible question" CTA label. */
+  askBibleLabel: string
   isOpen: boolean
   onToggle: () => void
 }) {
@@ -164,7 +172,7 @@ function StudyQuestionRow({
             data-testid={`${testId}-fallback-body`}
             className="leading-relaxed font-normal text-stone-200/80"
           >
-            {FALLBACK_BODY}
+            {fallbackBody}
           </p>
           <div className="mt-4 flex flex-wrap items-center gap-2">
             <Button
@@ -181,7 +189,7 @@ function StudyQuestionRow({
               }
             >
               <MessageCircleIcon />
-              <span>Chat with a person</span>
+              <span>{chatLabel}</span>
             </Button>
             <Button
               variant="pill"
@@ -197,7 +205,7 @@ function StudyQuestionRow({
               }
             >
               <MailIcon className="size-4" aria-hidden="true" />
-              <span>Ask a Bible question</span>
+              <span>{askBibleLabel}</span>
             </Button>
           </div>
         </div>

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -8,46 +8,61 @@ process.env.ADMIN_GRAPHQL_URL ??= "http://localhost:1437/admin/api/graphql"
 process.env.WEB_ADMIN_API_KEYS ??= "test-admin-bearer-key"
 
 // next-intl provider context isn't set up in route-render tests. Mock
-// useTranslations to look up keys in messages/en.json so existing
-// assertions on user-visible English copy keep working. ICU interpolation
-// supports the simple `{name}` placeholder pattern; component code passes
-// values via t(key, {name: value}).
-vi.mock("next-intl", () => {
-  const messages = enMessages as Record<string, Record<string, string>>
-  function lookup(namespace: string, key: string): string {
-    const ns = messages[namespace]
-    if (!ns) return `${namespace}.${key}`
-    return ns[key] ?? `${namespace}.${key}`
-  }
-  function interpolate(template: string, values?: Record<string, unknown>) {
-    if (!values) return template
-    return template.replace(/\{(\w+)\}/g, (_, name) =>
-      name in values ? String(values[name]) : `{${name}}`,
-    )
-  }
-  function useTranslations(namespace: string) {
-    return (key: string, values?: Record<string, unknown>) =>
-      interpolate(lookup(namespace, key), values)
-  }
-  return {
-    useTranslations,
-    NextIntlClientProvider: ({ children }: { children: unknown }) => children,
-  }
-})
+// useTranslations / getTranslations to look up keys in messages/en.json
+// so assertions on user-visible English copy keep working without a
+// provider wrap. Minimal ICU formatter below covers the two shapes our
+// catalogs use: simple `{name}` interpolation and `{count, plural, one
+// {…} other {…}}` (with `#` → the count). NOT a full ICU engine — if a
+// catalog grows select/selectordinal/nested-plural, swap this for the
+// real intl-messageformat. Keep in sync across both next-intl exports.
+const enCatalog = enMessages as Record<string, Record<string, string>>
+
+function selectPlural(template: string, values: Record<string, unknown>) {
+  // {var, plural, one {…} other {…}} — one nesting level of braces in arms.
+  return template.replace(
+    /\{(\w+),\s*plural,\s*((?:[^{}]|\{[^{}]*\})*)\}/g,
+    (_, name: string, body: string) => {
+      const n = Number(values[name])
+      if (Number.isNaN(n)) return `{${name}}`
+      const arms: Record<string, string> = {}
+      const armRe = /(=\d+|zero|one|two|few|many|other)\s*\{([^{}]*)\}/g
+      let m: RegExpExecArray | null
+      while ((m = armRe.exec(body)) !== null) arms[m[1]] = m[2]
+      const category = new Intl.PluralRules("en").select(n)
+      const chosen = arms[`=${n}`] ?? arms[category] ?? arms.other ?? ""
+      return chosen.replace(/#/g, String(n))
+    },
+  )
+}
+
+function formatIcu(template: string, values?: Record<string, unknown>) {
+  if (!values) return template
+  const withPlurals = selectPlural(template, values)
+  // Simple {name} substitution (runs after plural so `#` inside arms is
+  // already resolved and arm-local placeholders still interpolate).
+  return withPlurals.replace(/\{(\w+)\}/g, (_, name: string) =>
+    name in values ? String(values[name]) : `{${name}}`,
+  )
+}
+
+function lookup(namespace: string, key: string): string {
+  return enCatalog[namespace]?.[key] ?? `${namespace}.${key}`
+}
+
+function makeT(namespace: string) {
+  return (key: string, values?: Record<string, unknown>) =>
+    formatIcu(lookup(namespace, key), values)
+}
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => makeT(namespace),
+  NextIntlClientProvider: ({ children }: { children: unknown }) => children,
+}))
 
 vi.mock("next-intl/server", () => ({
   setRequestLocale: vi.fn(),
   getLocale: vi.fn(async () => "en"),
-  getTranslations: vi.fn(async (namespace: string) => {
-    const messages = enMessages as Record<string, Record<string, string>>
-    return (key: string, values?: Record<string, unknown>) => {
-      const template = messages[namespace]?.[key] ?? `${namespace}.${key}`
-      if (!values) return template
-      return template.replace(/\{(\w+)\}/g, (_, name) =>
-        name in values ? String(values[name]) : `{${name}}`,
-      )
-    }
-  }),
+  getTranslations: vi.fn(async (namespace: string) => makeT(namespace)),
 }))
 
 // Required for React 19 + react-dom/client `act` under vitest jsdom environment.


### PR DESCRIPTION
## Summary

Phase 3 of [the i18n migration](docs/plans/2026-05-28-001-feat-i18n-migration-next-intl-plan.md), building on the merged runtime (#1053). Extracts user-facing English literals from **11 watch components** into next-intl `t()` calls and populates all 5 message catalogs (en/es/fr/pt/de).

Namespaces (one PascalCase per component):
`BibleQuotes`, `DownloadButton`, `DownloadModal`, `HeroPlayerControls`, `LanguageCombobox`, `LanguagePickerModal`, `SeriesPage`, `WatchModal`, `WatchStudyQuestions`, `ShareModal`, `SubtitleTranscript`.

**ICU plurals**: `LanguagePickerModal.languageCount`, `SeriesPage.episodeCount` use `{count, plural, one {…} other {…}}`. `seekValue` / `volumeValue` / `seriesLabel` use simple `{name}` interpolation.

**Bug fixed mid-extraction**: `DownloadModal` had a `tierLabel()` helper (keys `tierHighest`/`tierHigh`/`tierLow`) defined but never wired into the two render sites — they still rendered the raw English `.label`. Wired `tierLabel(tier)` into both so the keys are live, not dead code.

## Testing

- 843 unit tests green (+33 from baseline).
- `vitest.setup.ts` next-intl mock gained a minimal ICU formatter (simple `{name}` + `{count, plural, …}` with `#` via `Intl.PluralRules`) so plural-rendering tests assert real output instead of the raw template. Documented swap-to-`intl-messageformat` path if catalogs grow `select`/nested plurals.
- Structural-parity + tuple↔filesystem drift gates stay green.
- `pnpm --filter @forge/web build` + `lint` clean.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: Railway logs for `MISSING_MESSAGE` / `INSUFFICIENT_PATH` next-intl warnings (would indicate a `t()` key with no catalog entry).
- **Validation checks**
  - `curl -s https://www.jesusfilm.org/watch/jesus.html/spanish-castilian.html | grep -i 'compartir'` — expect Spanish share label present.
  - Open a video page, check player chrome aria-labels render translated under a non-en audio slug.
- **Expected healthy behavior**
  - Watch player chrome, modals, transcript section render translated copy for es/fr/pt/de audio slugs; English fallback otherwise.
- **Failure signal / rollback trigger**
  - Raw `{count, plural, …}` template or `Namespace.key` strings visible in the UI → catalog/key mismatch → revert.
- **Validation window & owner**: 24h, Vlad.

## Deferred to follow-up

- Section components: `CarouselVideo`, `QuizButton`, `BibleQuotesCarousel`, `Video`, `MediaCollection`.
- Search/overlay: `FloatingSearch*`, `SearchOverlay`, `SearchInput`, `SearchResults`, `ui/dialog`.
- Native-speaker QA on the LLM-translated catalogs.

---

[![Compound Engineering v2.50.0](https://img.shields.io/badge/Compound_Engineering-v2.50.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 via [Claude Code](https://claude.com/claude-code)