### PR TITLE
fix(web): stop language cookie from overriding explicit URL locale

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,28 +1,20 @@
 import { describe, expect, it } from "vitest"
 
 import { proxy, type ProxyRequest } from "./proxy"
-import { canonicalizeWatchPath } from "./lib/url-canonicalize"
-
-type CookieMap = Record<string, string>
 
 function makeRequest(
   pathname: string,
-  options: { cookies?: CookieMap; acceptLanguage?: string } = {},
+  options: { acceptLanguage?: string } = {},
 ): ProxyRequest {
   // Test stand-in for the `ProxyRequest` structural subset proxy() reads.
   // No cast needed — the factory's return type matches the production
-  // contract directly.
+  // contract directly. NOTE: proxy() no longer reads cookies — the URL is
+  // the sole locale carrier, so there is no cookie field to mock.
   const url = new URL(`https://www.jesusfilm.org${pathname}`)
   return {
     nextUrl: Object.assign(url, {
       clone: () => new URL(url.toString()),
     }),
-    cookies: {
-      get: (name: string) =>
-        options.cookies?.[name] != null
-          ? { value: options.cookies[name] }
-          : undefined,
-    },
     headers: new Headers(
       options.acceptLanguage
         ? { "accept-language": options.acceptLanguage }
@@ -155,126 +147,38 @@ describe("proxy — reserved-subtree pass-through", () => {
 })
 
 // ---------------------------------------------------------------------------
-// Cookie-driven language preference on .html shape (2-segment + 3-segment).
+// No cookie override: the URL is the sole locale carrier. An explicit locale
+// already named in a canonical watch URL must NEVER be redirected to some
+// other language — this is the regression guard for the production bug where
+// a stale `forge_watch_lang` cookie hijacked `/jesus.html/english.html` to
+// `/jesus.html/bangla-2.html`. proxy() no longer reads cookies at all.
 // ---------------------------------------------------------------------------
 
-describe("proxy — cookie language preference on canonical .html shape", () => {
-  it("redirects 2-segment /jesus.html/english.html to /jesus.html/<pref>.html when cookie disagrees", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
-    )
-    expect(response.status).toBe(307)
-    expect(response.headers.get("location")).toContain(
-      "/jesus.html/spanish.html",
-    )
+describe("proxy — explicit locale URLs are never language-redirected", () => {
+  it("does not redirect a canonical 2-segment watch URL", () => {
+    const response = proxy(makeRequest("/jesus.html/english.html"))
+    expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
   })
 
-  it("does not redirect when 2-seg cookie matches URL locale (.html-aware compare)", () => {
+  it("does not redirect a canonical 3-segment episode URL", () => {
     const response = proxy(
-      makeRequest("/jesus.html/spanish.html", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
+      makeRequest("/lumo-the-gospel-of-john.html/wedding-in-cana/english.html"),
     )
     expect(response.status).not.toBe(307)
+    expect(response.status).not.toBe(308)
   })
 
-  it("redirects 3-segment /series.html/episode/english.html to /series.html/episode/<pref>.html", () => {
-    const response = proxy(
-      makeRequest(
-        "/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
-        {
-          cookies: { forge_watch_lang: "spanish" },
-        },
-      ),
-    )
-    expect(response.status).toBe(307)
-    expect(response.headers.get("location")).toContain(
-      "/lumo-the-gospel-of-john.html/wedding-in-cana/spanish.html",
+  it("applies watch security headers (CSP) to the canonical 2-segment URL", () => {
+    const response = proxy(makeRequest("/jesus.html/english.html"))
+    expect(response.headers.get("content-security-policy")).toBe(
+      "frame-ancestors 'self'",
     )
   })
 
-  it("emits Cache-Control: private, max-age=0 on cookie redirect", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
-    )
-    expect(response.headers.get("cache-control")).toBe("private, max-age=0")
-  })
-
-  it("bypasses cookie redirect when ?_lr=1 is present", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html?_lr=1", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
-    )
-    expect(response.status).not.toBe(307)
-  })
-
-  it("strips ?autoplay=1 on cross-variant redirect", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html?autoplay=1", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
-    )
-    expect(response.status).toBe(307)
-    const location = response.headers.get("location") ?? ""
-    expect(location).toContain("/jesus.html/spanish.html")
-    expect(location).not.toContain("autoplay=1")
-  })
-
-  it("strips ?t=120 on cross-variant redirect", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html?t=120", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
-    )
-    expect(response.status).toBe(307)
-    expect(response.headers.get("location") ?? "").not.toMatch(/[?&]t=120/)
-  })
-
-  it("preserves unrelated query params on cookie redirect", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html?source=share", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
-    )
-    expect(response.status).toBe(307)
-    expect(response.headers.get("location")).toContain("source=share")
-  })
-
-  it("ignores malformed cookie value (truncated percent-escape)", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html", {
-        cookies: { forge_watch_lang: "%E0%A4%A" },
-      }),
-    )
-    expect(response.status).not.toBe(307)
-  })
-
-  it("ignores cookie value longer than 64-char cap", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html", {
-        cookies: { forge_watch_lang: "a".repeat(100) },
-      }),
-    )
-    expect(response.status).not.toBe(307)
-  })
-
-  it("URL-decodes cookie value before comparing", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html", {
-        cookies: {
-          forge_watch_lang: encodeURIComponent("chinese-simplified"),
-        },
-      }),
-    )
-    expect(response.status).toBe(307)
-    expect(response.headers.get("location")).toContain(
-      "/jesus.html/chinese-simplified.html",
-    )
+  it("does not emit a Vary: Cookie header (no cookie-dependent redirects)", () => {
+    const response = proxy(makeRequest("/jesus.html/english.html"))
+    expect(response.headers.get("vary") ?? "").not.toContain("Cookie")
   })
 })
 
@@ -306,74 +210,5 @@ describe("proxy — resilience on malformed inputs", () => {
     )
     expect(response.status).not.toBe(307)
     expect(response.status).not.toBe(308)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Vary: Cookie — only cookie-dependent redirects carry it (todo 009).
-// ---------------------------------------------------------------------------
-
-describe("proxy — Vary: Cookie on cookie-dependent redirects only", () => {
-  it("sets Vary: Cookie on the cookie-preference redirect", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html", {
-        cookies: { forge_watch_lang: "spanish" },
-      }),
-    )
-    expect(response.status).toBe(307)
-    expect(response.headers.get("vary")).toBe("Cookie")
-  })
-
-  it("does NOT set Vary: Cookie on a canonicalize redirect (not cookie-dependent)", () => {
-    const response = proxy(makeRequest("/jesus/english"))
-    expect(response.status).toBe(307)
-    expect(response.headers.get("vary")).toBeNull()
-  })
-})
-
-// Note: the cookie-path output revalidation (todo 010) is unit-tested at the
-// `isUnsafeRedirectPath` boundary in `lib/url-shape.test.ts` — the WHATWG URL
-// parser in the proxy test fixture normalizes `\`/`//` before they reach the
-// guard, so the guard itself is exercised directly instead.
-
-// ---------------------------------------------------------------------------
-// Cross-module idempotence: the cookie redirect's output must already be
-// canonical, so the next request converges in one hop (todo 011).
-// ---------------------------------------------------------------------------
-
-describe("proxy — cookie redirect output is canonical (single-hop convergence)", () => {
-  for (const input of [
-    "/jesus.html/english.html",
-    "/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
-  ]) {
-    it(`canonicalize(cookieRedirect("${input}")) is canonical`, () => {
-      const r1 = proxy(
-        makeRequest(input, { cookies: { forge_watch_lang: "spanish" } }),
-      )
-      expect(r1.status).toBe(307)
-      const next = new URL(r1.headers.get("location") ?? "").pathname
-      const r2 = canonicalizeWatchPath({ rawPathname: next })
-      expect(r2.kind).toBe("canonical")
-    })
-  }
-})
-
-// ---------------------------------------------------------------------------
-// Slug-form cookie values (e.g. spanish-castilian) round-trip into the
-// redirected locale segment (todo 014). Downstream page-level resolution is
-// slug-aware (resolveUiLocale), so the family-fallback locale renders.
-// ---------------------------------------------------------------------------
-
-describe("proxy — slug-form cookie language preference", () => {
-  it("redirects to a multi-segment slug-form locale (spanish-castilian)", () => {
-    const response = proxy(
-      makeRequest("/jesus.html/english.html", {
-        cookies: { forge_watch_lang: "spanish-castilian" },
-      }),
-    )
-    expect(response.status).toBe(307)
-    expect(response.headers.get("location")).toContain(
-      "/jesus.html/spanish-castilian.html",
-    )
   })
 })

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,32 +1,17 @@
 import { NextResponse } from "next/server"
-import { LANGUAGE_PREFERENCE_COOKIE } from "@/lib/language-preference-constants"
-import {
-  DEFAULT_LOCALE,
-  LOCALE_RESOLVED_PARAM,
-  isLocale,
-  parseAcceptLanguage,
-} from "@/lib/locale"
+import { DEFAULT_LOCALE, isLocale, parseAcceptLanguage } from "@/lib/locale"
 import { WATCH_PATHNAME_HEADER } from "@/lib/proxy-headers"
 import { canonicalizeWatchPath } from "@/lib/url-canonicalize"
 import {
   SAFE_SLUG_PATTERN,
   getWatchLocaleSegmentIndex,
-  isUnsafeRedirectPath,
   stripHtmlSuffix,
 } from "@/lib/url-shape"
 
-// `SAFE_SLUG_PATTERN` (kebab-case ASCII, from url-shape.ts) is the
-// language-slug validator here: it recognises slug-form watch URLs
-// (`/jesus/english`) in isWatchRoute and validates the language-preference
-// cookie value before it lands in a redirect Location (defends against
-// open-redirect / path traversal via a tampered cookie).
-
-// Hard length cap on the cookie value. The longest real Arclight
-// language slug observed in production is ~50 chars
-// ("arabic-modern-standard-egyptian"). 64 leaves margin for new
-// additions without admitting pathological values from a tampered
-// cookie (e.g. a megabyte-sized string passing the regex).
-const PREFERRED_LANG_SLUG_MAX_LEN = 64
+// `SAFE_SLUG_PATTERN` (kebab-case ASCII, from url-shape.ts) recognises
+// slug-form watch URLs (`/jesus/english`) in isWatchRoute so the security
+// headers + WATCH_PATHNAME_HEADER are applied to both bcp47 and slug-form
+// locale segments.
 
 // Structural subset of `NextRequest` that `proxy()` actually consumes.
 // Declaring the precise surface (rather than the full NextRequest type)
@@ -39,10 +24,8 @@ const PREFERRED_LANG_SLUG_MAX_LEN = 64
 export type ProxyRequest = {
   nextUrl: {
     readonly pathname: string
-    readonly searchParams: { has: (name: string) => boolean }
     clone: () => URL
   }
-  cookies: { get: (name: string) => { value: string } | undefined }
   // Real `Headers` (not just `{ get }`) because `nextWithPathname` forwards
   // the inbound headers via `new Headers(request.headers)` for the
   // WATCH_PATHNAME_HEADER contract. Production `NextRequest.headers` is a
@@ -52,8 +35,8 @@ export type ProxyRequest = {
 
 // Cache-Control emitted on every proxy-issued redirect during the cutover
 // window. Prevents Cloudflare / browser caches from pinning a 307/308 to
-// a stale legacy URL — every redirect is per-request user-state-dependent
-// (cookie) or aliased (canonicalize) and must not be reused across users.
+// a stale legacy URL — redirects are alias normalizations (canonicalize) or
+// Accept-Language appends and must not be reused indiscriminately.
 const REDIRECT_CACHE_CONTROL = "private, max-age=0"
 
 // Note: CSP / Referrer headers (applyWatchSecurityHeaders) are intentionally
@@ -116,84 +99,6 @@ function nextWithPathname(
   return NextResponse.next({ request: { headers } })
 }
 
-// Query params that are deliberate one-shot signals tied to the originating
-// request and must NOT be replayed onto the redirected target slug. `?t=<n>`
-// is the seek timestamp; valid for the variant the user asked for, not for
-// the cookie-preferred one we redirect to. `?autoplay=1` is the gesture-came-
-// from-Apply signal; replaying it for receivers of shared links would
-// attempt unmuted autoplay without their gesture.
-const ONE_SHOT_QUERY_PARAMS = ["autoplay", "t"] as const
-
-// Cookie-driven language preference redirect. Reading the cookie here in
-// middleware — instead of in the page Server Component — keeps the page
-// route eligible for ISR caching (cookies() in a page silently opts the
-// route out of ISR; see docs/solutions/web/nextjs-headers-defeats-route-cache.md).
-//
-// Phase 3: operates on canonical `.html`-shape URLs and supports both
-// 2-segment (locale at segments[1]) and 3-segment episode (locale at
-// segments[2]) shapes. The locale segment may be `.html`-suffixed; we
-// strip the suffix before comparing to the cookie value (which is bare).
-//
-// Trade-off (unchanged): the proxy doesn't know whether the preferred
-// language has a playable variant for this specific video. When the
-// cookie language has no variant for a given video, the page falls back
-// to the experience template rather than crashing.
-function maybeRedirectToPreferredLanguage(
-  request: ProxyRequest,
-  pathname: string,
-): NextResponse | null {
-  if (!isWatchRoute(pathname)) return null
-  // `LOCALE_RESOLVED_PARAM` is the page's signal that it has already
-  // resolved the URL locale to match the actually-rendered variant.
-  // Without this bypass the cookie redirect bounces the user back to a
-  // locale with no playable variant; the page would loop redirecting.
-  if (request.nextUrl.searchParams.has(LOCALE_RESOLVED_PARAM)) return null
-  const rawCookie = request.cookies.get(LANGUAGE_PREFERENCE_COOKIE)?.value
-  if (!rawCookie) return null
-  let preferredSlug: string
-  try {
-    preferredSlug = decodeURIComponent(rawCookie)
-  } catch {
-    return null
-  }
-  if (!preferredSlug) return null
-  if (preferredSlug.length > PREFERRED_LANG_SLUG_MAX_LEN) return null
-  if (!SAFE_SLUG_PATTERN.test(preferredSlug)) return null
-  const segments = pathname.split("/").filter(Boolean)
-  const localeIdx = getWatchLocaleSegmentIndex(segments)
-  if (localeIdx < 0) return null
-  const currentLocaleSeg = segments[localeIdx]
-  if (!currentLocaleSeg) return null
-  const currentLocaleBare = stripHtmlSuffix(currentLocaleSeg)
-  if (preferredSlug === currentLocaleBare) return null
-  // The locale segment is always `.html`-suffixed here: proxy() runs
-  // canonicalize (Rule 4 appends `.html` to bare locale segments on 2-seg
-  // and 3-seg watch paths) BEFORE this cookie redirect, so any path that
-  // reaches here in canonical form has a `.html` locale. Build the new
-  // segment with the suffix unconditionally.
-  const newSegments = segments.slice()
-  newSegments[localeIdx] = `${preferredSlug}.html`
-  const url = request.nextUrl.clone()
-  const candidatePathname = `/${newSegments.join("/")}`
-  // Defense-in-depth: the cookie value is regex-clean, but the OTHER
-  // segments (slug, episode) pass through unsanitized from the request
-  // pathname. Run the same output-shape guard canonicalize applies to its
-  // synthesized Location before emitting a redirect.
-  if (isUnsafeRedirectPath(candidatePathname)) return null
-  url.pathname = candidatePathname
-  for (const param of ONE_SHOT_QUERY_PARAMS) {
-    url.searchParams.delete(param)
-  }
-  const response = buildRedirect(url, 307)
-  // This redirect target depends on the language-preference cookie. Without
-  // `Vary: Cookie`, any shared cache that ignores `private`/`max-age=0`
-  // (a mis-set Cloudflare transform rule, a corporate proxy) could serve
-  // one user's locale to another. Canonicalize redirects are NOT
-  // cookie-dependent, so they don't carry this header.
-  response.headers.set("Vary", "Cookie")
-  return response
-}
-
 export function proxy(request: ProxyRequest): NextResponse {
   const { pathname } = request.nextUrl
 
@@ -210,26 +115,28 @@ export function proxy(request: ProxyRequest): NextResponse {
     return buildRedirect(url, canonical.status)
   }
 
-  // Step 2: cookie-driven language preference redirect on canonical
-  // shape (.html-aware, 2-seg + 3-seg).
-  const preferenceRedirect = maybeRedirectToPreferredLanguage(request, pathname)
-  if (preferenceRedirect) return preferenceRedirect
-
-  // Step 3: CSP / Referrer headers for watch routes (both .html and
+  // Step 2: CSP / Referrer headers for watch routes (both .html and
   // legacy bare 2-segment forms; 3-segment episode shape included).
+  //
+  // NOTE: there is deliberately NO cookie-driven language redirect here.
+  // The URL is the sole locale carrier (see apps/web/CLAUDE.md "i18n").
+  // A stale `forge_watch_lang` cookie must NEVER override an explicit
+  // locale already named in the path — doing so hijacked canonical /
+  // shared / SEO links (e.g. `/jesus.html/english.html` → cookie's
+  // language) and was the cause of the production redirect bug.
   if (isWatchRoute(pathname)) {
     return applyWatchSecurityHeaders(nextWithPathname(request, pathname))
   }
 
-  // Step 4: Accept-Language fallback. Post-Phase-3 this serves a NARROW
+  // Step 3: Accept-Language fallback. Post-Phase-3 this serves a NARROW
   // surface: canonicalize (Step 1) already redirects every 1-seg bare slug
   // (Rule 5) and 2-seg bare pair (Rule 4), and canonical `.html` watch
   // shapes exit at Step 3. What survives to here: the root `/`, the
   // 1-segment exempt routes (`/videos`, `/search`), 4+ segment paths, and
   // percent-encoded / non-ASCII paths the canonicalize allowlist rejected.
-  // For those, if the path doesn't already terminate in a bcp47 locale, we
-  // append the Accept-Language-detected locale. (Phase 4 may retire this
-  // once route-level locale detection fully owns non-watch paths.)
+  // (Canonical `.html` watch shapes already exited at Step 2.) For those, if
+  // the path doesn't already terminate in a bcp47 locale, append the
+  // Accept-Language-detected locale.
   const segments = pathname.split("/").filter(Boolean)
   const lastSegment = segments[segments.length - 1]
   if (lastSegment && isLocale(lastSegment)) {


### PR DESCRIPTION
## 🔴 Production bug fix

`https://watch.jesusfilm.org/watch/jesus.html/english.html` 307-redirects to `/watch/jesus.html/bangla-2.html` and renders a degraded fallback. **Probe-confirmed on live production:**

| Request | Result |
|---------|--------|
| english.html, no cookie | 200, english loads ✓ |
| english.html, `forge_watch_lang=bangla-2` cookie | **307 → bangla-2.html** ← the bug |
| bangla-2.html target | 200 (no loop) |
| english.html + `?_lr=1` | 200 (old bypass) |

## Root cause

`maybeRedirectToPreferredLanguage` in `proxy.ts` overrode the locale **already named in the URL** with the `forge_watch_lang` cookie's language. Since every 2-seg/3-seg watch URL carries an explicit locale, the cookie redirect always hijacked canonical / shared / SEO links for any returning user with a stale cookie.

This also **contradicted the documented i18n contract** — `apps/web/CLAUDE.md`: *"The URL is the sole locale carrier — no cookie, no `[locale]` segment."*

## Fix

Remove the cookie-driven redirect from the proxy entirely. The proxy no longer reads cookies (`cookies` + `searchParams` dropped from `ProxyRequest`). The canonicalize, CSP/header, and Accept-Language-fallback paths are unchanged.

The `forge_watch_lang` cookie is still written by the language picker but is now vestigial — full removal of that machinery is tracked as a follow-up (todo 023).

**Net: −299/+41** (mostly deleting the cookie redirect + its now-moot tests).

## Test plan

- [x] Regression test: explicit canonical 2-seg + 3-seg watch URLs are never language-redirected and carry no `Vary: Cookie`
- [x] `pnpm --filter @forge/web test -- --run` — 846 pass (59 files)
- [x] `pnpm --filter @forge/web lint` + `typecheck` — clean

## Post-merge

Users with an existing `forge_watch_lang` cookie are fixed immediately (the proxy no longer reads it). No cookie-clear needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)