### PR TITLE
feat(web): emit .html canonical + revalidate dual-emit + robots (Phase 5)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,11 +22,13 @@ STRAPI_PREVIEW_SECRET=
 OPENROUTER_API_KEY=
 
 ## Production ##
-# Canonical absolute origin used by the watch-page Share modal (Copy Link /
-# Copy Embed Code). Must include scheme + host (no trailing slash). Defaults
-# to http://localhost:3000 for dev/CI; set to https://jesusfilm.org (or your
-# environment's canonical host) in preview/production.
-NEXT_PUBLIC_CANONICAL_ORIGIN=https://jesusfilm.org
+# Canonical absolute origin for the watch surface — used by the Share modal
+# (Copy Link / Copy Embed Code) AND the SEO canonical <link> + OG URLs. Must
+# include scheme + host (no trailing slash). Defaults to http://localhost:3000
+# for dev/CI. In preview/production set to the host where the canonical watch
+# pages are indexed: https://www.jesusfilm.org (NOT the apex — Google indexes
+# the www host at https://www.jesusfilm.org/watch/...).
+NEXT_PUBLIC_CANONICAL_ORIGIN=https://www.jesusfilm.org
 
 ## Feature flags ##
 # Optional LaunchDarkly server-side SDK key. When unset, web falls back to the

--- a/apps/web/src/app/[slug]/[...rest]/page.tsx
+++ b/apps/web/src/app/[slug]/[...rest]/page.tsx
@@ -128,7 +128,6 @@ export async function generateMetadata({
         return generateSeriesMetadata(locale, {
           series: watchVideo.video,
           pathLocale: rawLocale,
-          pathPrefix: "watch",
         })
       }
       if (!watchVideo) {
@@ -137,7 +136,6 @@ export async function generateMetadata({
           return generateSeriesMetadata(locale, {
             series: series.video,
             pathLocale: rawLocale,
-            pathPrefix: "watch",
           })
         }
       }
@@ -147,7 +145,6 @@ export async function generateMetadata({
     return getWatchPageMetadata(locale, {
       slug,
       pathLocale: rawLocale,
-      pathPrefix: "watch",
     })
   }
 
@@ -158,7 +155,6 @@ export async function generateMetadata({
     return getWatchPageMetadata(locale, {
       slug: episodeSlug,
       pathLocale: rawLocale,
-      pathPrefix: "watch",
     })
   }
 

--- a/apps/web/src/app/[slug]/page.tsx
+++ b/apps/web/src/app/[slug]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
   // homepage handle metadata.
   if (isLocale(slug)) return {}
 
-  return getWatchPageMetadata(DEFAULT_LOCALE, { slug, pathPrefix: "watch" })
+  return getWatchPageMetadata(DEFAULT_LOCALE, { slug })
 }
 
 export default async function SlugPage({ params }: PageProps) {

--- a/apps/web/src/app/api/revalidate/route.test.ts
+++ b/apps/web/src/app/api/revalidate/route.test.ts
@@ -36,10 +36,24 @@ describe("POST /api/revalidate", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
       revalidated: true,
-      paths: ["/ (layout)", "/", "/de", "/en", "/es", "/fr", "/pt"],
+      paths: [
+        "/ (layout)",
+        "/",
+        "/de.html",
+        "/de",
+        "/en.html",
+        "/en",
+        "/es.html",
+        "/es",
+        "/fr.html",
+        "/fr",
+        "/pt.html",
+        "/pt",
+      ],
     })
     expect(revalidatePathMock).toHaveBeenCalledWith("/", "layout")
     expect(revalidatePathMock).toHaveBeenCalledWith("/")
+    expect(revalidatePathMock).toHaveBeenCalledWith("/en.html")
     expect(revalidatePathMock).toHaveBeenCalledWith("/en")
   })
 
@@ -67,18 +81,27 @@ describe("POST /api/revalidate", () => {
     await expect(response.json()).resolves.toEqual({
       revalidated: true,
       paths: [
+        "/jesus.html/en.html",
         "/jesus/en",
+        "/jesus.html",
         "/jesus",
         "/ (layout)",
         "/",
+        "/de.html",
         "/de",
+        "/en.html",
         "/en",
+        "/es.html",
         "/es",
+        "/fr.html",
         "/fr",
+        "/pt.html",
         "/pt",
       ],
     })
+    expect(revalidatePathMock).toHaveBeenCalledWith("/jesus.html/en.html")
     expect(revalidatePathMock).toHaveBeenCalledWith("/jesus/en")
+    expect(revalidatePathMock).toHaveBeenCalledWith("/jesus.html")
     expect(revalidatePathMock).toHaveBeenCalledWith("/jesus")
     expect(revalidatePathMock).toHaveBeenCalledWith("/", "layout")
   })

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server"
 import { env } from "@/env"
 import { AVAILABLE_UI_LOCALES } from "@/i18n/locales"
 import { DEFAULT_LOCALE, isLocale } from "@/lib/locale"
+import { appendHtmlSuffix } from "@/lib/url-shape"
 
 const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
 const BEARER_PREFIX = "Bearer "
@@ -69,41 +70,51 @@ export async function POST(request: Request) {
 
   const revalidated: string[] = []
 
+  const push = (path: string) => {
+    revalidatePath(path)
+    revalidated.push(path)
+  }
+
+  // Emit BOTH the canonical `.html` shape (post-Phase-2 rendered route) AND
+  // the legacy bare shape. The bare shape is kept for a 30-day overlap so an
+  // inflight webhook from an older admin deploy — or a still-cached bare route
+  // — still gets busted. `.html` is appended per segment via appendHtmlSuffix
+  // (idempotent). Over-revalidating a non-existent variant is harmless.
+  const pushOneSeg = (seg: string) => {
+    push(`/${appendHtmlSuffix(seg)}`) // canonical `/{seg}.html`
+    push(`/${seg}`) // legacy bare (overlap)
+  }
+  const pushTwoSeg = (a: string, b: string) => {
+    push(`/${appendHtmlSuffix(a)}/${appendHtmlSuffix(b)}`) // `/{a}.html/{b}.html`
+    push(`/${a}/${b}`) // legacy bare (overlap)
+  }
+
   const revalidateAllWatchPages = () => {
     revalidatePath("/", "layout")
     revalidated.push("/ (layout)")
   }
 
   const revalidateHomepagePaths = () => {
-    revalidatePath("/")
-    revalidated.push("/")
-
+    push("/")
     for (const loc of AVAILABLE_UI_LOCALES) {
-      revalidatePath(`/${loc}`)
-      revalidated.push(`/${loc}`)
+      pushOneSeg(loc)
     }
   }
 
   const revalidateSlugPaths = () => {
     if (slug && locale) {
-      revalidatePath(`/${slug}/${locale}`)
-      revalidated.push(`/${slug}/${locale}`)
-
+      pushTwoSeg(slug, locale)
       if (locale === DEFAULT_LOCALE) {
-        revalidatePath(`/${slug}`)
-        revalidated.push(`/${slug}`)
+        pushOneSeg(slug)
       }
       return
     }
 
     if (!slug) return
 
-    revalidatePath(`/${slug}`)
-    revalidated.push(`/${slug}`)
-
+    pushOneSeg(slug)
     for (const loc of AVAILABLE_UI_LOCALES) {
-      revalidatePath(`/${slug}/${loc}`)
-      revalidated.push(`/${slug}/${loc}`)
+      pushTwoSeg(slug, loc)
     }
   }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,7 +10,7 @@ import { ExperienceError } from "@/components/ExperienceError"
 export const revalidate = 60
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getWatchPageMetadata(DEFAULT_LOCALE, { pathPrefix: "watch" })
+  return getWatchPageMetadata(DEFAULT_LOCALE)
 }
 
 export default async function HomePage() {

--- a/apps/web/src/app/robots.test.ts
+++ b/apps/web/src/app/robots.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import robots from "./robots"
+
+describe("robots", () => {
+  it("allows crawling and disallows api / _next subtrees", () => {
+    const result = robots()
+    const rule = Array.isArray(result.rules) ? result.rules[0] : result.rules
+    expect(rule?.userAgent).toBe("*")
+    expect(rule?.allow).toBe("/")
+    expect(rule?.disallow).toEqual(["/api/", "/_next/"])
+  })
+
+  it("sets host to the canonical watch origin + basePath", () => {
+    const result = robots()
+    expect(result.host).toBe("http://localhost:3000/watch")
+  })
+
+  it("emits no sitemap directive yet (sitemap deferred)", () => {
+    const result = robots()
+    expect(result.sitemap).toBeUndefined()
+  })
+})

--- a/apps/web/src/app/robots.test.ts
+++ b/apps/web/src/app/robots.test.ts
@@ -11,9 +11,9 @@ describe("robots", () => {
     expect(rule?.disallow).toEqual(["/api/", "/_next/"])
   })
 
-  it("sets host to the canonical watch origin + basePath", () => {
+  it("emits no host directive (non-standard Yandex-ism)", () => {
     const result = robots()
-    expect(result.host).toBe("http://localhost:3000/watch")
+    expect(result.host).toBeUndefined()
   })
 
   it("emits no sitemap directive yet (sitemap deferred)", () => {

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,24 +1,23 @@
 import type { MetadataRoute } from "next"
 
-import { WATCH_BASE_PATH, WATCH_CANONICAL_ORIGIN } from "@/lib/routes"
-
-// Robots policy for the /watch surface. Allows the canonical watch routes and
-// disallows the framework / API subtrees that must never be crawled (they
-// mirror the proxy matcher + canonicalize RESERVED_PREFIXES). Paths are
-// basePath-relative as Next.js serves robots.txt at the basePath root.
+// Robots policy for the /watch surface. Allows crawling and disallows the
+// framework / API subtrees (`/api/`, `/_next/`) that must never be indexed.
+// Paths are basePath-relative as Next.js serves robots.txt at the basePath
+// root.
+//
+// No `host` directive: it's a non-standard Yandex-ism that Google/Bing
+// ignore, and pointing it at a basePath sub-path would be misleading.
 //
 // No `sitemap` directive yet: the sitemap is deferred to its own ticket
 // (no bulk video-list query exists, and a full video×language sitemap needs
-// a sitemap-index + admin bulk query). Add the `sitemap` field here once
-// `app/sitemap.ts` ships so crawlers discover it.
+// a sitemap-index + admin bulk query — see todo 025). Add the `sitemap`
+// field here once `app/sitemap.ts` ships so crawlers discover it.
 export default function robots(): MetadataRoute.Robots {
-  const base = `${WATCH_CANONICAL_ORIGIN}${WATCH_BASE_PATH}`
   return {
     rules: {
       userAgent: "*",
       allow: "/",
       disallow: ["/api/", "/_next/"],
     },
-    host: base,
   }
 }

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next"
+
+import { WATCH_BASE_PATH, WATCH_CANONICAL_ORIGIN } from "@/lib/routes"
+
+// Robots policy for the /watch surface. Allows the canonical watch routes and
+// disallows the framework / API subtrees that must never be crawled (they
+// mirror the proxy matcher + canonicalize RESERVED_PREFIXES). Paths are
+// basePath-relative as Next.js serves robots.txt at the basePath root.
+//
+// No `sitemap` directive yet: the sitemap is deferred to its own ticket
+// (no bulk video-list query exists, and a full video×language sitemap needs
+// a sitemap-index + admin bulk query). Add the `sitemap` field here once
+// `app/sitemap.ts` ships so crawlers discover it.
+export default function robots(): MetadataRoute.Robots {
+  const base = `${WATCH_CANONICAL_ORIGIN}${WATCH_BASE_PATH}`
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/_next/"],
+    },
+    host: base,
+  }
+}

--- a/apps/web/src/lib/__tests__/experience-metadata-series.test.ts
+++ b/apps/web/src/lib/__tests__/experience-metadata-series.test.ts
@@ -66,13 +66,13 @@ describe("generateSeriesMetadata", () => {
     expect(meta.description).toBeUndefined()
   })
 
-  it("constructs the canonical URL with the /watch prefix and pathLocale", () => {
+  it("constructs the canonical URL in the .html shape via the route builder", () => {
     const meta = generateSeriesMetadata("en", {
       series: makeSeries(),
       pathLocale: "en",
     })
     expect(meta.alternates?.canonical).toBe(
-      "https://www.jesusfilm.org/watch/storyclubs/en",
+      "http://localhost:3000/watch/storyclubs.html/en.html",
     )
   })
 

--- a/apps/web/src/lib/experience-metadata.test.ts
+++ b/apps/web/src/lib/experience-metadata.test.ts
@@ -43,7 +43,6 @@ describe("getWatchPageMetadata", () => {
 
     const metadata = await getWatchPageMetadata("en", {
       slug: "jesus",
-      pathPrefix: "watch",
     })
 
     // Title always appends the brand suffix on the video-template branch
@@ -53,7 +52,7 @@ describe("getWatchPageMetadata", () => {
     // `snippet` for SEO (Google likes 120–160 chars). Snippet is the fallback.
     expect(metadata.description).toBe("Longer description")
     expect(metadata.alternates?.canonical).toBe(
-      "https://www.jesusfilm.org/watch/jesus",
+      "http://localhost:3000/watch/jesus.html",
     )
     expect(metadata.openGraph).toMatchObject({
       title: "Jesus | Jesus Film Project",
@@ -93,7 +92,6 @@ describe("getWatchPageMetadata", () => {
     const { getWatchPageMetadata } = await import("./experience-metadata")
     const metadata = await getWatchPageMetadata("en", {
       slug: "snippet-only",
-      pathPrefix: "watch",
     })
 
     expect(metadata.description).toBe("Just a snippet")

--- a/apps/web/src/lib/experience-metadata.ts
+++ b/apps/web/src/lib/experience-metadata.ts
@@ -32,9 +32,14 @@ const TITLE_SUFFIX = "| Jesus Film Project"
  *   (localized home or single-segment collection — same URL shape)
  * - neither → the watch root `/watch`
  *
- * Inputs arrive `.html`-stripped from `classify()`, but we strip again
- * defensively. On a malformed slug the builders can't run, so we fall back
- * to a bare origin+basePath+segment string (never throws in metadata).
+ * Inputs arrive `.html`-stripped from `classify()` but are NOT slug-regex
+ * validated there, so a malformed slug (uppercase, dot) can reach here. On
+ * such input the branded builders can't run, so we fall back to a bare
+ * origin+basePath+segment string. This deliberately diverges from the
+ * Phase 4 nav-emission sites (which OMIT a link on invalid input): a
+ * canonical `<link>` must always be present, and metadata must never throw.
+ * The fallback is injection-safe — Next.js HTML-entity-encodes the canonical
+ * href attribute, so a slug with quotes/brackets can't break out.
  */
 function buildCanonicalUrl(slug?: string, pathLocale?: string): string {
   const root = `${WATCH_CANONICAL_ORIGIN}${WATCH_BASE_PATH}`

--- a/apps/web/src/lib/experience-metadata.ts
+++ b/apps/web/src/lib/experience-metadata.ts
@@ -5,11 +5,62 @@ import {
   type ResolvedSeriesBySlug,
   type ResolvedWatchPage,
 } from "@/lib/content"
+import {
+  WATCH_BASE_PATH,
+  WATCH_CANONICAL_ORIGIN,
+  localizedHomeAbsolute,
+  tryAsContentSlug,
+  tryAsLocaleSlug,
+  watchVideoAbsolute,
+} from "@/lib/routes"
 import { getSocialConfig } from "@/lib/social-config"
 import { resolvePosterUrl } from "@/lib/url"
+import { stripHtmlSuffix } from "@/lib/url-shape"
 
-const SITE_BASE = "https://www.jesusfilm.org"
 const TITLE_SUFFIX = "| Jesus Film Project"
+
+/**
+ * Build the canonical absolute URL for a watch page in the `.html` shape,
+ * keyed off the (slug, pathLocale) the route resolved. Routes through the
+ * `lib/routes.ts` absolute builders so the canonical `<link>` matches the
+ * production URL contract exactly (origin from `WATCH_CANONICAL_ORIGIN`,
+ * `.html` per segment).
+ *
+ * Shapes:
+ * - slug + pathLocale → 2-segment `/{slug}.html/{locale}.html`
+ * - one segment (slug-only OR pathLocale-only) → 1-segment `/{seg}.html`
+ *   (localized home or single-segment collection — same URL shape)
+ * - neither → the watch root `/watch`
+ *
+ * Inputs arrive `.html`-stripped from `classify()`, but we strip again
+ * defensively. On a malformed slug the builders can't run, so we fall back
+ * to a bare origin+basePath+segment string (never throws in metadata).
+ */
+function buildCanonicalUrl(slug?: string, pathLocale?: string): string {
+  const root = `${WATCH_CANONICAL_ORIGIN}${WATCH_BASE_PATH}`
+  const s = slug ? stripHtmlSuffix(slug) : undefined
+  const l = pathLocale ? stripHtmlSuffix(pathLocale) : undefined
+
+  if (s && l) {
+    const cs = tryAsContentSlug(s)
+    const ls = tryAsLocaleSlug(l)
+    if (cs && ls) return watchVideoAbsolute(cs, ls)
+    return `${root}/${s}/${l}`
+  }
+
+  const single = s ?? l
+  if (single) {
+    const ls = tryAsLocaleSlug(single)
+    // localizedHomeAbsolute emits `${origin}/watch/{seg}.html` — the correct
+    // 1-segment canonical for both a localized home (seg is a language) and a
+    // single-segment collection landing (seg is content); the URL shape is
+    // identical, so the nominal LocaleSlug brand is fine here.
+    if (ls) return localizedHomeAbsolute(ls)
+    return `${root}/${single}`
+  }
+
+  return root
+}
 
 const OG_LOCALE_OVERRIDES: Record<string, string> = {
   en: "en_US",
@@ -33,17 +84,9 @@ const DEFAULT_OG_IMAGE = {
 function toMetadata(
   locale: string,
   resolvedPage: ResolvedWatchPage | null,
-  options?: { slug?: string; pathLocale?: string; pathPrefix?: string },
+  options?: { slug?: string; pathLocale?: string },
 ): Metadata {
-  const prefix = options?.pathPrefix ? `/${options.pathPrefix}` : ""
-  const pathSuffix = options?.slug
-    ? options?.pathLocale
-      ? `/${options.slug}/${options.pathLocale}`
-      : `/${options.slug}`
-    : options?.pathLocale
-      ? `/${options.pathLocale}`
-      : ""
-  const url = `${SITE_BASE}${prefix}${pathSuffix}`
+  const url = buildCanonicalUrl(options?.slug, options?.pathLocale)
 
   const { fbAppId } = getSocialConfig()
 
@@ -156,7 +199,7 @@ function toMetadata(
 
 export async function getWatchPageMetadata(
   locale: string,
-  options?: { slug?: string; pathLocale?: string; pathPrefix?: string },
+  options?: { slug?: string; pathLocale?: string },
 ): Promise<Metadata> {
   const result = await resolveWatchPage(locale, options?.slug)
   return toMetadata(locale, result.data, options)
@@ -173,14 +216,11 @@ export function generateSeriesMetadata(
   options: {
     series: ResolvedSeriesBySlug["video"]
     pathLocale?: string
-    pathPrefix?: string
   },
 ): Metadata {
-  const { series, pathLocale, pathPrefix = "watch" } = options
-  const prefix = pathPrefix ? `/${pathPrefix}` : ""
+  const { series, pathLocale } = options
   const slug = series.slug ?? ""
-  const pathSuffix = pathLocale ? `/${slug}/${pathLocale}` : `/${slug}`
-  const url = `${SITE_BASE}${prefix}${pathSuffix}`
+  const url = buildCanonicalUrl(slug, pathLocale)
 
   const { fbAppId } = getSocialConfig()
 


### PR DESCRIPTION
## Summary

Phase 5 of the /watch URL restructure — SEO + revalidation. Scoped to the unblocked surfaces; sitemap + hreflang are fast-follows (see Deferred).

- **experience-metadata.ts** — canonical `<link rel="canonical">` now emits the `.html` shape via the `lib/routes.ts` absolute builders (`watchVideoAbsolute` / `localizedHomeAbsolute`), keyed off the resolved `(slug, locale)`, against `WATCH_CANONICAL_ORIGIN`. **Before:** bare shape (`/watch/jesus/en`) against a hardcoded `www.jesusfilm.org`. **After:** `https://<canonical-origin>/watch/jesus.html/en.html`. Fixes both the shape and the host. Drops the now-dead `pathPrefix` option (the builders own the basePath) across the helpers + 4 call sites.
- **/api/revalidate/route.ts** — dual-emit: every revalidated path is pushed in BOTH the canonical `.html` shape and the legacy bare shape. The bare shape is kept for a 30-day overlap so an inflight webhook from an older admin deploy still busts the right route.
- **robots.ts (NEW)** — allow watch, disallow `/api/`, `/_next/`. No `sitemap` directive yet (sitemap deferred — todo 025).

## Deferred to fast-follow (tracked)

- **hreflang `alternates.languages`** (todo 024) — needs dub-locales threaded into `RouteVideo` for uniform coverage across the video-template + series metadata paths.
- **Watch sitemap** (todo 025) — needs a paginated admin bulk query + a sitemap index (corpus exceeds the 50k-URL single-file limit).

## Test plan

- [x] `experience-metadata.test.ts` + `-series.test.ts` — canonical is the `.html` shape via builder
- [x] `revalidate/route.test.ts` — emits both `.html` + bare during overlap
- [x] `robots.test.ts` (NEW) — allow/disallow + host, no sitemap yet
- [x] `pnpm --filter @forge/web test -- --run` — 849 pass (60 files)
- [x] `lint` + `typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)