### PR TITLE
feat(search): add search eval promotion and native suite

### DIFF
--- a/apps/admin/eval/README.md
+++ b/apps/admin/eval/README.md
@@ -29,6 +29,15 @@ locale, provenance, source anchors, advisory judge summaries, and promotion
 status, but they are not durable regression gates until a later sanitized
 human-promotion flow moves selected cases into committed harness data.
 
+Promoted candidates now remain in Admin Postgres as durable sanitized
+regression truth. The local Admin harness still reads this hand-edited
+`regressions.json` file first, then appends promoted `search_eval_candidate`
+rows when the CLI has a Prisma client. Promoted rows must use
+`sanitized_query_text`, `sanitized_expected_result_notes`,
+`sanitized_source_anchors`, reviewer identity, timestamps, and safe run
+context. Raw trace text, bearer tokens, provider secrets, vectors, and
+unsanitized source payloads must never be copied into the sanitized columns.
+
 ### `baselines/{name}.json`
 
 Frozen snapshot of `(queries, top-K results, content fingerprint)`
@@ -76,6 +85,73 @@ Schema:
 `locale` and `query` are required; `notes`, `addedAt`, `addedBy` are
 optional but please fill them in — it's the only context a future
 operator has when this regression starts failing.
+
+Promoted Admin candidates join the same durable regression set without editing
+this file. Use the Mastra `search-eval-candidate-review` workflow, backed by
+Admin's authenticated `/api/internal/search-eval/candidates` contracts, to:
+
+- list pending seed, generated, trace-derived, and user-submitted candidates;
+- inspect review-safe candidate detail;
+- edit sanitized query text, expected-result notes, and source anchors;
+- reject or archive low-quality, ambiguous, abusive, sensitive, or unsafe rows;
+- promote approved rows into regression truth.
+
+Review standards:
+
+- Seed prompts are operator-authored coverage and should stay broad, editable,
+  and ministry-representative. Audience-intent prompts may cover life stage,
+  family role, ministry role, and locale, but must not encode stereotypes as
+  expected-result truth.
+- Generated catalog and locale-quality prompts need clear viewer intent plus
+  safe Admin/Core source anchors or expected-result notes before promotion.
+- Trace-derived candidates require a human-written sanitized query. Promotion
+  overwrites the raw candidate query with the sanitized query so the promoted
+  row can outlive raw trace retention.
+- User-submitted prompts enter the same pending queue and cannot become gates
+  until a reviewer records sanitization status, reviewer identity, notes, and
+  safe anchors or expected-result context. Free-form submission notes and
+  source claims are not copied into candidate provenance; add sanitized anchors
+  during review instead.
+- LLM judge summaries are advisory only. They can help review, but durable
+  truth must come from human notes and source anchors.
+
+Feat-142 native Dataset item bridge:
+
+```json
+{
+  "input": {
+    "query": "sanitized promoted query",
+    "locale": "en",
+    "source": "seed | generated_catalog | generated_locale_quality | generated_trace | user_submitted",
+    "searchOptions": {
+      "mode": "hybrid",
+      "contentType": "all"
+    }
+  },
+  "groundTruth": {
+    "expectedResultNotes": "human-reviewed safe notes",
+    "sourceAnchors": [
+      {
+        "type": "video | experience | seed_prompt_set",
+        "id": "Admin/Core owned id",
+        "locale": "en"
+      }
+    ]
+  },
+  "metadata": {
+    "candidateId": "search_eval_candidate id",
+    "sanitizationStatus": "sanitized",
+    "reviewerIdentity": "operator identity",
+    "reviewedAt": "ISO timestamp",
+    "promotedAt": "ISO timestamp",
+    "mastraRunId": "safe Mastra run id when present",
+    "promotionRunContext": "safe JSON only"
+  }
+}
+```
+
+This is only a bridge shape. Native Mastra Dataset, Scorer, and Experiment
+records are not populated until feat-142 creates real native records.
 
 ### `calibration.json`
 

--- a/apps/admin/prisma/migrations/0024_search_eval_human_promotion/migration.sql
+++ b/apps/admin/prisma/migrations/0024_search_eval_human_promotion/migration.sql
@@ -1,0 +1,32 @@
+-- Human review and promotion metadata for Admin-owned search eval candidates.
+--
+-- The raw candidate payload remains short-lived or staged. Durable regression
+-- truth must read from the sanitized_* columns after human promotion.
+
+ALTER TYPE "SearchEvalCandidateSource" ADD VALUE 'seed';
+ALTER TYPE "SearchEvalCandidateSource" ADD VALUE 'user_submitted';
+
+ALTER TYPE "SearchEvalCandidatePromotionStatus" ADD VALUE 'archived';
+
+CREATE TYPE "SearchEvalCandidateSanitizationStatus" AS ENUM (
+  'pending',
+  'sanitized',
+  'unsafe'
+);
+
+ALTER TABLE "search_eval_candidate"
+  ADD COLUMN "sanitized_query_text" varchar(512),
+  ADD COLUMN "sanitized_expected_result_notes" varchar(2048),
+  ADD COLUMN "sanitized_source_anchors" jsonb NOT NULL DEFAULT '[]',
+  ADD COLUMN "sanitization_status" "SearchEvalCandidateSanitizationStatus" NOT NULL DEFAULT 'pending',
+  ADD COLUMN "reviewer_identity" varchar(256),
+  ADD COLUMN "reviewed_at" timestamp(3),
+  ADD COLUMN "review_notes" varchar(2048),
+  ADD COLUMN "promoted_at" timestamp(3),
+  ADD COLUMN "promotion_run_context" jsonb NOT NULL DEFAULT '{}';
+
+CREATE INDEX "search_eval_candidate_promotion_status_reviewed_at_idx"
+  ON "search_eval_candidate"("promotion_status", "reviewed_at");
+
+CREATE INDEX "search_eval_candidate_promoted_at_idx"
+  ON "search_eval_candidate"("promoted_at");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -210,6 +210,8 @@ enum SearchEvalCandidateSource {
   CATALOG        @map("catalog")
   LOCALE_QUALITY @map("locale_quality")
   TRACE          @map("trace")
+  SEED           @map("seed")
+  USER_SUBMITTED @map("user_submitted")
 }
 
 /// Human-promotion lifecycle for generated search-eval candidates.
@@ -217,6 +219,14 @@ enum SearchEvalCandidatePromotionStatus {
   GENERATED @map("generated")
   REJECTED  @map("rejected")
   PROMOTED  @map("promoted")
+  ARCHIVED  @map("archived")
+}
+
+/// Sanitization state for a reviewed search-eval candidate.
+enum SearchEvalCandidateSanitizationStatus {
+  PENDING   @map("pending")
+  SANITIZED @map("sanitized")
+  UNSAFE    @map("unsafe")
 }
 
 // -----------------------------------------------------------------------------
@@ -471,26 +481,37 @@ model SearchTraceAggregate {
 /// Generated rows do not participate in permanent regression gates until a
 /// future human-promotion workflow sanitizes and promotes them.
 model SearchEvalCandidate {
-  id                  String                             @id @default(cuid())
-  source              SearchEvalCandidateSource
-  locale              String                             @db.VarChar(32)
-  queryText           String                             @map("query_text") @db.VarChar(512)
-  expectedResultHints Json                               @default("[]") @map("expected_result_hints")
-  sourceAnchors       Json                               @default("[]") @map("source_anchors")
-  labelProvenance     Json                               @default("{}") @map("label_provenance")
-  generationModel     String                             @map("generation_model") @db.VarChar(128)
-  generationProvider  String?                            @map("generation_provider") @db.VarChar(64)
-  judgeSummary        Json?                              @map("judge_summary")
-  promotionStatus     SearchEvalCandidatePromotionStatus @default(GENERATED) @map("promotion_status")
-  mastraRunId         String?                            @map("mastra_run_id") @db.VarChar(128)
-  dedupeKey           String                             @unique @map("dedupe_key") @db.VarChar(64)
-  retentionExpiresAt  DateTime?                          @map("retention_expires_at")
-  generatedAt         DateTime                           @default(now()) @map("generated_at")
-  createdAt           DateTime                           @default(now()) @map("created_at")
-  updatedAt           DateTime                           @updatedAt @map("updated_at")
+  id                           String                                @id @default(cuid())
+  source                       SearchEvalCandidateSource
+  locale                       String                                @db.VarChar(32)
+  queryText                    String                                @map("query_text") @db.VarChar(512)
+  expectedResultHints          Json                                  @default("[]") @map("expected_result_hints")
+  sourceAnchors                Json                                  @default("[]") @map("source_anchors")
+  labelProvenance              Json                                  @default("{}") @map("label_provenance")
+  generationModel              String                                @map("generation_model") @db.VarChar(128)
+  generationProvider           String?                               @map("generation_provider") @db.VarChar(64)
+  judgeSummary                 Json?                                 @map("judge_summary")
+  promotionStatus              SearchEvalCandidatePromotionStatus    @default(GENERATED) @map("promotion_status")
+  sanitizedQueryText           String?                               @map("sanitized_query_text") @db.VarChar(512)
+  sanitizedExpectedResultNotes String?                               @map("sanitized_expected_result_notes") @db.VarChar(2048)
+  sanitizedSourceAnchors       Json                                  @default("[]") @map("sanitized_source_anchors")
+  sanitizationStatus           SearchEvalCandidateSanitizationStatus @default(PENDING) @map("sanitization_status")
+  reviewerIdentity             String?                               @map("reviewer_identity") @db.VarChar(256)
+  reviewedAt                   DateTime?                             @map("reviewed_at")
+  reviewNotes                  String?                               @map("review_notes") @db.VarChar(2048)
+  promotedAt                   DateTime?                             @map("promoted_at")
+  promotionRunContext          Json                                  @default("{}") @map("promotion_run_context")
+  mastraRunId                  String?                               @map("mastra_run_id") @db.VarChar(128)
+  dedupeKey                    String                                @unique @map("dedupe_key") @db.VarChar(64)
+  retentionExpiresAt           DateTime?                             @map("retention_expires_at")
+  generatedAt                  DateTime                              @default(now()) @map("generated_at")
+  createdAt                    DateTime                              @default(now()) @map("created_at")
+  updatedAt                    DateTime                              @updatedAt @map("updated_at")
 
   @@index([source, locale, createdAt])
   @@index([promotionStatus, createdAt])
+  @@index([promotionStatus, reviewedAt])
+  @@index([promotedAt])
   @@index([retentionExpiresAt])
   @@index([mastraRunId])
   @@map("search_eval_candidate")

--- a/apps/admin/src/app/api/internal/search-eval/candidates/[id]/action-helpers.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/[id]/action-helpers.ts
@@ -1,0 +1,75 @@
+import type {
+  PromoteSearchEvalCandidateInput,
+  SearchEvalCandidateDecisionInput,
+} from "@/services/search-eval/candidates"
+
+import { badRequest } from "../review-route-helpers"
+
+function stringOrNullish(
+  value: unknown,
+  name: string,
+): string | null | undefined | Response {
+  if (value == null) return value as null | undefined
+  if (typeof value === "string") return value
+  return badRequest(`${name} must be a string`)
+}
+
+export function parseDecisionBody(
+  body: unknown,
+): SearchEvalCandidateDecisionInput | Response {
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    return badRequest("JSON body must be an object")
+  }
+  const input = body as Record<string, unknown>
+  const reviewerIdentity = stringOrNullish(
+    input.reviewerIdentity,
+    "reviewerIdentity",
+  )
+  if (reviewerIdentity instanceof Response) return reviewerIdentity
+  if (reviewerIdentity == null || reviewerIdentity.trim().length === 0) {
+    return badRequest("reviewerIdentity is required")
+  }
+  const reviewNotes = stringOrNullish(input.reviewNotes, "reviewNotes")
+  if (reviewNotes instanceof Response) return reviewNotes
+
+  return {
+    reviewerIdentity,
+    reviewNotes,
+    promotionRunContext: input.promotionRunContext,
+  }
+}
+
+export function parsePromoteBody(
+  body: unknown,
+): PromoteSearchEvalCandidateInput | Response {
+  const decision = parseDecisionBody(body)
+  if (decision instanceof Response) return decision
+  const input = body as Record<string, unknown>
+
+  const sanitizedQueryText = stringOrNullish(
+    input.sanitizedQueryText,
+    "sanitizedQueryText",
+  )
+  if (sanitizedQueryText instanceof Response) return sanitizedQueryText
+  const sanitizedExpectedResultNotes = stringOrNullish(
+    input.sanitizedExpectedResultNotes,
+    "sanitizedExpectedResultNotes",
+  )
+  if (sanitizedExpectedResultNotes instanceof Response) {
+    return sanitizedExpectedResultNotes
+  }
+  if (
+    input.sanitizationStatus != null &&
+    input.sanitizationStatus !== "sanitized"
+  ) {
+    return badRequest("promotion requires sanitizationStatus sanitized")
+  }
+
+  return {
+    ...decision,
+    sanitizedQueryText,
+    sanitizedExpectedResultNotes,
+    sanitizedSourceAnchors: input.sanitizedSourceAnchors,
+    sanitizationStatus: input.sanitizationStatus as "sanitized" | undefined,
+  }
+}

--- a/apps/admin/src/app/api/internal/search-eval/candidates/[id]/archive/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/[id]/archive/route.ts
@@ -1,0 +1,44 @@
+import { prisma } from "@/db/client"
+import { archiveSearchEvalCandidate } from "@/services/search-eval/candidates"
+
+import { parseDecisionBody } from "../action-helpers"
+import {
+  authorizeSearchEvalCandidateRequest,
+  logValue,
+  readJsonBody,
+  responseForCandidateError,
+  serviceUnavailable,
+} from "../../review-route-helpers"
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await authorizeSearchEvalCandidateRequest(
+    request,
+    "search-eval-candidate-archive",
+  )
+  if (auth instanceof Response) return auth
+
+  const body = await readJsonBody(request)
+  if (body instanceof Response) return body
+
+  const parsed = parseDecisionBody(body)
+  if (parsed instanceof Response) return parsed
+
+  const { id } = await params
+  try {
+    const candidate = await archiveSearchEvalCandidate(prisma, id, parsed)
+    console.info(
+      `[search] event=eval_candidate_archive auth=bearer route=internal rl=${auth.rateLimitSource} candidate_id=${logValue(id)}`,
+    )
+    return Response.json({ candidate }, { status: 200 })
+  } catch (error) {
+    const response = responseForCandidateError(error)
+    if (response) return response
+    console.error(
+      `[search] event=eval_candidate_archive_failed route=internal error_class=${logValue(error instanceof Error ? error.name : typeof error)}`,
+    )
+    return serviceUnavailable()
+  }
+}

--- a/apps/admin/src/app/api/internal/search-eval/candidates/[id]/promote/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/[id]/promote/route.ts
@@ -1,0 +1,44 @@
+import { prisma } from "@/db/client"
+import { promoteSearchEvalCandidate } from "@/services/search-eval/candidates"
+
+import { parsePromoteBody } from "../action-helpers"
+import {
+  authorizeSearchEvalCandidateRequest,
+  logValue,
+  readJsonBody,
+  responseForCandidateError,
+  serviceUnavailable,
+} from "../../review-route-helpers"
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await authorizeSearchEvalCandidateRequest(
+    request,
+    "search-eval-candidate-promote",
+  )
+  if (auth instanceof Response) return auth
+
+  const body = await readJsonBody(request)
+  if (body instanceof Response) return body
+
+  const parsed = parsePromoteBody(body)
+  if (parsed instanceof Response) return parsed
+
+  const { id } = await params
+  try {
+    const candidate = await promoteSearchEvalCandidate(prisma, id, parsed)
+    console.info(
+      `[search] event=eval_candidate_promote auth=bearer route=internal rl=${auth.rateLimitSource} candidate_id=${logValue(id)}`,
+    )
+    return Response.json({ candidate }, { status: 200 })
+  } catch (error) {
+    const response = responseForCandidateError(error)
+    if (response) return response
+    console.error(
+      `[search] event=eval_candidate_promote_failed route=internal error_class=${logValue(error instanceof Error ? error.name : typeof error)}`,
+    )
+    return serviceUnavailable()
+  }
+}

--- a/apps/admin/src/app/api/internal/search-eval/candidates/[id]/reject/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/[id]/reject/route.ts
@@ -1,0 +1,44 @@
+import { prisma } from "@/db/client"
+import { rejectSearchEvalCandidate } from "@/services/search-eval/candidates"
+
+import { parseDecisionBody } from "../action-helpers"
+import {
+  authorizeSearchEvalCandidateRequest,
+  logValue,
+  readJsonBody,
+  responseForCandidateError,
+  serviceUnavailable,
+} from "../../review-route-helpers"
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await authorizeSearchEvalCandidateRequest(
+    request,
+    "search-eval-candidate-reject",
+  )
+  if (auth instanceof Response) return auth
+
+  const body = await readJsonBody(request)
+  if (body instanceof Response) return body
+
+  const parsed = parseDecisionBody(body)
+  if (parsed instanceof Response) return parsed
+
+  const { id } = await params
+  try {
+    const candidate = await rejectSearchEvalCandidate(prisma, id, parsed)
+    console.info(
+      `[search] event=eval_candidate_reject auth=bearer route=internal rl=${auth.rateLimitSource} candidate_id=${logValue(id)}`,
+    )
+    return Response.json({ candidate }, { status: 200 })
+  } catch (error) {
+    const response = responseForCandidateError(error)
+    if (response) return response
+    console.error(
+      `[search] event=eval_candidate_reject_failed route=internal error_class=${logValue(error instanceof Error ? error.name : typeof error)}`,
+    )
+    return serviceUnavailable()
+  }
+}

--- a/apps/admin/src/app/api/internal/search-eval/candidates/[id]/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/[id]/route.ts
@@ -1,0 +1,142 @@
+import { prisma } from "@/db/client"
+import {
+  getSearchEvalCandidateForReview,
+  updateSearchEvalCandidateReviewFields,
+  type UpdateSearchEvalCandidateReviewInput,
+} from "@/services/search-eval/candidates"
+
+import {
+  authorizeSearchEvalCandidateRequest,
+  badRequest,
+  logValue,
+  readJsonBody,
+  responseForCandidateError,
+  serviceUnavailable,
+} from "../review-route-helpers"
+
+function stringOrNullish(
+  value: unknown,
+  name: string,
+): string | null | undefined | Response {
+  if (value == null) return value as null | undefined
+  if (typeof value === "string") return value
+  return badRequest(`${name} must be a string`)
+}
+
+function parsePatchBody(
+  body: unknown,
+): UpdateSearchEvalCandidateReviewInput | Response {
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    return badRequest("JSON body must be an object")
+  }
+  const input = body as Record<string, unknown>
+  if ("promotionStatus" in input) {
+    return badRequest("promotionStatus is server-owned")
+  }
+  if (
+    input.sanitizationStatus != null &&
+    input.sanitizationStatus !== "pending" &&
+    input.sanitizationStatus !== "sanitized" &&
+    input.sanitizationStatus !== "unsafe"
+  ) {
+    return badRequest(
+      "sanitizationStatus must be pending, sanitized, or unsafe",
+    )
+  }
+
+  const reviewerIdentity = stringOrNullish(
+    input.reviewerIdentity,
+    "reviewerIdentity",
+  )
+  if (reviewerIdentity instanceof Response) return reviewerIdentity
+  const sanitizedQueryText = stringOrNullish(
+    input.sanitizedQueryText,
+    "sanitizedQueryText",
+  )
+  if (sanitizedQueryText instanceof Response) return sanitizedQueryText
+  const sanitizedExpectedResultNotes = stringOrNullish(
+    input.sanitizedExpectedResultNotes,
+    "sanitizedExpectedResultNotes",
+  )
+  if (sanitizedExpectedResultNotes instanceof Response) {
+    return sanitizedExpectedResultNotes
+  }
+  const reviewNotes = stringOrNullish(input.reviewNotes, "reviewNotes")
+  if (reviewNotes instanceof Response) return reviewNotes
+
+  return {
+    reviewerIdentity,
+    sanitizedQueryText,
+    sanitizedExpectedResultNotes,
+    sanitizedSourceAnchors: input.sanitizedSourceAnchors,
+    sanitizationStatus: input.sanitizationStatus as
+      | UpdateSearchEvalCandidateReviewInput["sanitizationStatus"]
+      | undefined,
+    reviewNotes,
+    promotionRunContext: input.promotionRunContext,
+  }
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await authorizeSearchEvalCandidateRequest(
+    request,
+    "search-eval-candidate-detail",
+  )
+  if (auth instanceof Response) return auth
+
+  const { id } = await params
+  try {
+    const candidate = await getSearchEvalCandidateForReview(prisma, id)
+    console.info(
+      `[search] event=eval_candidate_detail auth=bearer route=internal rl=${auth.rateLimitSource} candidate_id=${logValue(id)}`,
+    )
+    return Response.json({ candidate }, { status: 200 })
+  } catch (error) {
+    const response = responseForCandidateError(error)
+    if (response) return response
+    console.error(
+      `[search] event=eval_candidate_detail_failed route=internal error_class=${logValue(error instanceof Error ? error.name : typeof error)}`,
+    )
+    return serviceUnavailable()
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const auth = await authorizeSearchEvalCandidateRequest(
+    request,
+    "search-eval-candidate-edit",
+  )
+  if (auth instanceof Response) return auth
+
+  const body = await readJsonBody(request)
+  if (body instanceof Response) return body
+
+  const parsed = parsePatchBody(body)
+  if (parsed instanceof Response) return parsed
+
+  const { id } = await params
+  try {
+    const candidate = await updateSearchEvalCandidateReviewFields(
+      prisma,
+      id,
+      parsed,
+    )
+    console.info(
+      `[search] event=eval_candidate_edit auth=bearer route=internal rl=${auth.rateLimitSource} candidate_id=${logValue(id)}`,
+    )
+    return Response.json({ candidate }, { status: 200 })
+  } catch (error) {
+    const response = responseForCandidateError(error)
+    if (response) return response
+    console.error(
+      `[search] event=eval_candidate_edit_failed route=internal error_class=${logValue(error instanceof Error ? error.name : typeof error)}`,
+    )
+    return serviceUnavailable()
+  }
+}

--- a/apps/admin/src/app/api/internal/search-eval/candidates/review-route-helpers.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/review-route-helpers.ts
@@ -1,0 +1,121 @@
+import { rateLimitAuthRoute } from "@/auth/rate-limit"
+import { isValidSearchTraceSamplingBearer } from "@/auth/search-trace-bearer"
+import { SearchEvalCandidateStoreError } from "@/services/search-eval/candidates"
+
+const RATE_LIMIT_MAX = 20
+const RATE_LIMIT_WINDOW_MS = 60_000
+const MAX_BODY_BYTES = 64 * 1024
+
+export function badRequest(error: string): Response {
+  return Response.json({ error }, { status: 400 })
+}
+
+export function serviceUnavailable(): Response {
+  return Response.json(
+    { error: "Candidate review is temporarily unavailable" },
+    { status: 503 },
+  )
+}
+
+export function responseForCandidateError(error: unknown): Response | null {
+  if (!(error instanceof SearchEvalCandidateStoreError)) return null
+  if (error.code === "not_found") {
+    return Response.json({ error: error.message }, { status: 404 })
+  }
+  if (error.code === "invalid_state") {
+    return Response.json({ error: error.message }, { status: 409 })
+  }
+  return badRequest(error.message)
+}
+
+export function logValue(value: string | undefined): string {
+  if (value == null || value.length === 0) return "none"
+  return value.replace(/[\r\n\t\s=]/g, "_").slice(0, 64)
+}
+
+export async function authorizeSearchEvalCandidateRequest(
+  request: Request,
+  route: string,
+): Promise<{ rateLimitSource: string } | Response> {
+  const limit = await rateLimitAuthRoute({
+    request,
+    route,
+    limit: RATE_LIMIT_MAX,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  })
+  if (!limit.allowed) {
+    return Response.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "retry-after": "60" } },
+    )
+  }
+
+  if (!isValidSearchTraceSamplingBearer(request.headers.get("authorization"))) {
+    return Response.json({ error: "Authorization required" }, { status: 401 })
+  }
+
+  return { rateLimitSource: limit.source }
+}
+
+function unsupportedMediaType(): Response {
+  return Response.json(
+    { error: "Content-Type must be application/json" },
+    { status: 415 },
+  )
+}
+
+function payloadTooLarge(): Response {
+  return Response.json({ error: "JSON body is too large" }, { status: 413 })
+}
+
+export async function readJsonBody(
+  request: Request,
+): Promise<unknown | Response> {
+  const contentType = request.headers.get("content-type") ?? ""
+  if (!/^\s*application\/json(?:\s*;|$)/i.test(contentType)) {
+    return unsupportedMediaType()
+  }
+
+  const contentLength = request.headers.get("content-length")
+  if (contentLength != null) {
+    const declaredBytes = Number(contentLength)
+    if (!Number.isFinite(declaredBytes) || declaredBytes < 0) {
+      return badRequest("Content-Length must be a non-negative number")
+    }
+    if (declaredBytes > MAX_BODY_BYTES) return payloadTooLarge()
+  }
+
+  const body = request.body
+  if (body == null) return badRequest("Invalid JSON body")
+
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      totalBytes += value.byteLength
+      if (totalBytes > MAX_BODY_BYTES) {
+        await reader.cancel().catch(() => undefined)
+        return payloadTooLarge()
+      }
+      chunks.push(value)
+    }
+  } catch {
+    return badRequest("Invalid JSON body")
+  }
+
+  const bytes = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes))
+  } catch {
+    return badRequest("Invalid JSON body")
+  }
+}

--- a/apps/admin/src/app/api/internal/search-eval/candidates/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/route.test.ts
@@ -4,6 +4,11 @@ const rateLimitAuthRoute = vi.fn()
 const isValidSearchTraceSamplingBearer = vi.fn()
 const listSearchEvalCandidates = vi.fn()
 const storeSearchEvalCandidates = vi.fn()
+const getSearchEvalCandidateForReview = vi.fn()
+const updateSearchEvalCandidateReviewFields = vi.fn()
+const promoteSearchEvalCandidate = vi.fn()
+const rejectSearchEvalCandidate = vi.fn()
+const archiveSearchEvalCandidate = vi.fn()
 
 vi.mock("@/auth/rate-limit", () => ({ rateLimitAuthRoute }))
 vi.mock("@/auth/search-trace-bearer", () => ({
@@ -15,12 +20,21 @@ vi.mock("@/services/search-eval/candidates", async (original) => {
     await original<typeof import("@/services/search-eval/candidates")>()
   return {
     ...actual,
+    archiveSearchEvalCandidate,
+    getSearchEvalCandidateForReview,
     listSearchEvalCandidates,
+    promoteSearchEvalCandidate,
+    rejectSearchEvalCandidate,
     storeSearchEvalCandidates,
+    updateSearchEvalCandidateReviewFields,
   }
 })
 
 const { POST, GET } = await import("./route")
+const { GET: GET_DETAIL, PATCH: PATCH_DETAIL } = await import("./[id]/route")
+const { POST: POST_PROMOTE } = await import("./[id]/promote/route")
+const { POST: POST_REJECT } = await import("./[id]/reject/route")
+const { POST: POST_ARCHIVE } = await import("./[id]/archive/route")
 
 function request(body: unknown, headers: HeadersInit = {}) {
   return new Request("http://admin.test/api/internal/search-eval/candidates", {
@@ -50,6 +64,23 @@ function rawRequest(body: string, headers: HeadersInit = {}) {
     body,
   })
 }
+
+function candidateActionRequest(body: unknown, headers: HeadersInit = {}) {
+  return new Request(
+    "http://admin.test/api/internal/search-eval/candidates/1",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer trace-key",
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    },
+  )
+}
+
+const params = { params: Promise.resolve({ id: "candidate-1" }) }
 
 describe("POST /api/internal/search-eval/candidates", () => {
   beforeEach(() => {
@@ -460,5 +491,192 @@ describe("GET /api/internal/search-eval/candidates", () => {
     expect(serializedLogs).toContain("error_class=Error")
     expect(serializedLogs).not.toContain("db password leak")
     logSpy.mockRestore()
+  })
+})
+
+describe("candidate review action routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rateLimitAuthRoute.mockResolvedValue({ allowed: true, source: "local" })
+    isValidSearchTraceSamplingBearer.mockReturnValue(true)
+    const candidate = {
+      id: "candidate-1",
+      source: "catalog",
+      promotionStatus: "generated",
+      locale: "en",
+      queryText: "Jesus",
+      expectedResultHints: [],
+      sourceAnchors: [],
+      labelProvenance: {},
+      generationModel: "seed:v1",
+      generationProvider: "mastra",
+      judgeSummary: null,
+      sanitizedQueryText: null,
+      sanitizedExpectedResultNotes: null,
+      sanitizedSourceAnchors: [],
+      sanitizationStatus: "pending",
+      reviewerIdentity: null,
+      reviewedAt: null,
+      reviewNotes: null,
+      promotedAt: null,
+      promotionRunContext: {},
+      mastraRunId: "run-1",
+      retentionExpiresAt: null,
+      generatedAt: "2026-05-26T00:00:00.000Z",
+      createdAt: "2026-05-26T00:00:00.000Z",
+    }
+    getSearchEvalCandidateForReview.mockResolvedValue(candidate)
+    updateSearchEvalCandidateReviewFields.mockResolvedValue({
+      ...candidate,
+      sanitizedQueryText: "Who is Jesus?",
+      sanitizationStatus: "sanitized",
+    })
+    promoteSearchEvalCandidate.mockResolvedValue({
+      ...candidate,
+      promotionStatus: "promoted",
+      queryText: "Who is Jesus?",
+      sanitizedQueryText: "Who is Jesus?",
+      sanitizationStatus: "sanitized",
+      reviewerIdentity: "nisal",
+      reviewedAt: "2026-05-28T00:00:00.000Z",
+      promotedAt: "2026-05-28T00:00:00.000Z",
+    })
+    rejectSearchEvalCandidate.mockResolvedValue({
+      ...candidate,
+      promotionStatus: "rejected",
+      reviewerIdentity: "nisal",
+    })
+    archiveSearchEvalCandidate.mockResolvedValue({
+      ...candidate,
+      promotionStatus: "archived",
+      reviewerIdentity: "nisal",
+    })
+  })
+
+  it("returns review-safe candidate detail through bearer auth", async () => {
+    const response = await GET_DETAIL(getRequest(), params)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      candidate: { id: "candidate-1", queryText: "Jesus" },
+    })
+    expect(getSearchEvalCandidateForReview).toHaveBeenCalledWith(
+      {},
+      "candidate-1",
+    )
+  })
+
+  it("edits sanitized fields without accepting server-owned status", async () => {
+    const response = await PATCH_DETAIL(
+      candidateActionRequest({
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizedExpectedResultNotes: "Should surface Jesus overview content",
+        sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+        sanitizationStatus: "sanitized",
+        promotionRunContext: { mastraRunId: "run-review" },
+      }),
+      params,
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateSearchEvalCandidateReviewFields).toHaveBeenCalledWith(
+      {},
+      "candidate-1",
+      expect.objectContaining({
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizationStatus: "sanitized",
+      }),
+    )
+  })
+
+  it("rejects malformed sanitized edit fields", async () => {
+    const response = await PATCH_DETAIL(
+      candidateActionRequest({
+        sanitizedQueryText: 123,
+      }),
+      params,
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: "sanitizedQueryText must be a string",
+    })
+    expect(updateSearchEvalCandidateReviewFields).not.toHaveBeenCalled()
+  })
+
+  it("promotes sanitized candidates with reviewer and run context", async () => {
+    const response = await POST_PROMOTE(
+      candidateActionRequest({
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizedExpectedResultNotes: "Should surface Jesus overview content",
+        sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+        sanitizationStatus: "sanitized",
+        promotionRunContext: { mastraRunId: "run-review" },
+      }),
+      params,
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      candidate: {
+        id: "candidate-1",
+        promotionStatus: "promoted",
+        reviewerIdentity: "nisal",
+      },
+    })
+    expect(promoteSearchEvalCandidate).toHaveBeenCalledWith(
+      {},
+      "candidate-1",
+      expect.objectContaining({
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizationStatus: "sanitized",
+      }),
+    )
+  })
+
+  it("rejects and archives pending candidates without promotion", async () => {
+    const rejectResponse = await POST_REJECT(
+      candidateActionRequest({
+        reviewerIdentity: "nisal",
+        reviewNotes: "Ambiguous intent",
+      }),
+      params,
+    )
+    const archiveResponse = await POST_ARCHIVE(
+      candidateActionRequest({
+        reviewerIdentity: "nisal",
+        reviewNotes: "Duplicate candidate",
+      }),
+      params,
+    )
+
+    expect(rejectResponse.status).toBe(200)
+    expect(archiveResponse.status).toBe(200)
+    expect(rejectSearchEvalCandidate).toHaveBeenCalledWith(
+      {},
+      "candidate-1",
+      expect.objectContaining({ reviewerIdentity: "nisal" }),
+    )
+    expect(archiveSearchEvalCandidate).toHaveBeenCalledWith(
+      {},
+      "candidate-1",
+      expect.objectContaining({ reviewerIdentity: "nisal" }),
+    )
+  })
+
+  it("requires bearer auth before review actions", async () => {
+    isValidSearchTraceSamplingBearer.mockReturnValue(false)
+
+    const response = await POST_PROMOTE(
+      candidateActionRequest({ reviewerIdentity: "nisal" }),
+      params,
+    )
+
+    expect(response.status).toBe(401)
+    expect(promoteSearchEvalCandidate).not.toHaveBeenCalled()
   })
 })

--- a/apps/admin/src/app/api/internal/search-eval/candidates/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/candidates/route.ts
@@ -6,6 +6,7 @@ import {
   listSearchEvalCandidates,
   storeSearchEvalCandidates,
   type ListSearchEvalCandidatesFilters,
+  type SearchEvalCandidatePromotionStatusLabel,
   type SearchEvalCandidateSourceLabel,
   type StoreSearchEvalCandidateInput,
 } from "@/services/search-eval/candidates"
@@ -164,13 +165,39 @@ function parseSources(
     if (
       source !== "catalog" &&
       source !== "locale_quality" &&
-      source !== "trace"
+      source !== "trace" &&
+      source !== "seed" &&
+      source !== "user_submitted"
     ) {
-      return badRequest("source must be catalog, locale_quality, or trace")
+      return badRequest(
+        "source must be catalog, locale_quality, trace, seed, or user_submitted",
+      )
     }
     if (!sources.includes(source)) sources.push(source)
   }
   return sources
+}
+
+function parseStatuses(
+  value: string | null,
+): SearchEvalCandidatePromotionStatusLabel[] | Response | undefined {
+  const values = parseCsv(value)
+  if (values == null) return undefined
+  const statuses: SearchEvalCandidatePromotionStatusLabel[] = []
+  for (const status of values) {
+    if (
+      status !== "generated" &&
+      status !== "rejected" &&
+      status !== "promoted" &&
+      status !== "archived"
+    ) {
+      return badRequest(
+        "status must be generated, rejected, promoted, or archived",
+      )
+    }
+    if (!statuses.includes(status)) statuses.push(status)
+  }
+  return statuses
 }
 
 function parseListFilters(
@@ -184,6 +211,8 @@ function parseListFilters(
   }
   const sources = parseSources(searchParams.get("source"))
   if (sources instanceof Response) return sources
+  const statuses = parseStatuses(searchParams.get("status"))
+  if (statuses instanceof Response) return statuses
   const locales = parseCsv(searchParams.get("locale"))
   if (locales != null && locales.length > 30) {
     return badRequest("locale must contain at most 30 values")
@@ -193,6 +222,7 @@ function parseListFilters(
   return {
     limit,
     sources,
+    statuses,
     locales,
     mastraRunId,
   }
@@ -205,7 +235,8 @@ type ListedCandidateResponse = Awaited<
 function sanitizeCandidateForResponse(
   candidate: ListedCandidateResponse,
 ): ListedCandidateResponse {
-  if (candidate.source !== "trace") return candidate
+  if (candidate.source !== "trace" || candidate.promotionStatus === "promoted")
+    return candidate
   return {
     ...candidate,
     queryText: null,

--- a/apps/admin/src/scripts/eval-search.ts
+++ b/apps/admin/src/scripts/eval-search.ts
@@ -275,7 +275,7 @@ async function rebaselineSubcommand(args: {
       return []
     })
 
-    const regressions = await loadRegressions()
+    const regressions = await loadRegressions({ prisma })
 
     const allQueries = [...syntheticAll, ...regressions]
 

--- a/apps/admin/src/services/search-eval/baseline.test.ts
+++ b/apps/admin/src/services/search-eval/baseline.test.ts
@@ -52,6 +52,7 @@ const sampleBaseline: Baseline = {
     },
     { locale: "fr", query: "espoir", source: "synthetic", results: [] },
     { locale: "fr", query: "test reg", source: "regression", results: [] },
+    { locale: "en", query: "promoted query", source: "promoted", results: [] },
   ],
 }
 

--- a/apps/admin/src/services/search-eval/baseline.ts
+++ b/apps/admin/src/services/search-eval/baseline.ts
@@ -34,7 +34,7 @@ const BaselineSchema = z.object({
     z.object({
       locale: z.string().min(1),
       query: z.string().min(1),
-      source: z.enum(["synthetic", "regression"]),
+      source: z.enum(["synthetic", "regression", "promoted"]),
       results: z.array(SearchResultSchema),
     }),
   ),

--- a/apps/admin/src/services/search-eval/candidates.test.ts
+++ b/apps/admin/src/services/search-eval/candidates.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest"
 
 import {
   SearchEvalCandidateStoreError,
+  archiveSearchEvalCandidate,
   listSearchEvalCandidates,
+  promoteSearchEvalCandidate,
+  rejectSearchEvalCandidate,
   storeSearchEvalCandidates,
 } from "./candidates"
 
@@ -372,6 +375,16 @@ describe("listSearchEvalCandidates", () => {
         generationModel: "seed:v1",
         generationProvider: "mastra",
         judgeSummary: null,
+        promotionStatus: "GENERATED",
+        sanitizedQueryText: null,
+        sanitizedExpectedResultNotes: null,
+        sanitizedSourceAnchors: [],
+        sanitizationStatus: "PENDING",
+        reviewerIdentity: null,
+        reviewedAt: null,
+        reviewNotes: null,
+        promotedAt: null,
+        promotionRunContext: {},
         mastraRunId: "run-1",
         retentionExpiresAt: null,
         generatedAt: new Date("2026-05-26T00:00:00.000Z"),
@@ -405,6 +418,16 @@ describe("listSearchEvalCandidates", () => {
         generationModel: "seed:v1",
         generationProvider: "mastra",
         judgeSummary: null,
+        promotionStatus: "generated",
+        sanitizedQueryText: null,
+        sanitizedExpectedResultNotes: null,
+        sanitizedSourceAnchors: [],
+        sanitizationStatus: "pending",
+        reviewerIdentity: null,
+        reviewedAt: null,
+        reviewNotes: null,
+        promotedAt: null,
+        promotionRunContext: {},
         mastraRunId: "run-1",
         retentionExpiresAt: null,
         generatedAt: "2026-05-26T00:00:00.000Z",
@@ -416,11 +439,12 @@ describe("listSearchEvalCandidates", () => {
       1,
       expect.objectContaining({
         where: expect.objectContaining({
-          promotionStatus: "GENERATED",
+          promotionStatus: { in: ["GENERATED"] },
           source: { in: ["CATALOG"] },
           locale: { in: ["en"] },
           mastraRunId: "run-1",
           OR: [
+            { promotionStatus: "PROMOTED" },
             { source: { not: "TRACE" } },
             { retentionExpiresAt: { gt: now } },
           ],
@@ -448,6 +472,7 @@ describe("listSearchEvalCandidates", () => {
       {
         id: "candidate-trace",
         source: "TRACE",
+        promotionStatus: "GENERATED",
         locale: "en",
         expectedResultHints: ["raw trace query Jesus movie"],
         sourceAnchors: [
@@ -467,6 +492,15 @@ describe("listSearchEvalCandidates", () => {
         judgeSummary: { rationale: "raw trace query Jesus movie" },
         mastraRunId: "raw trace query Jesus movie",
         retentionExpiresAt: new Date("2026-05-27T00:00:00.000Z"),
+        sanitizedQueryText: null,
+        sanitizedExpectedResultNotes: null,
+        sanitizedSourceAnchors: [],
+        sanitizationStatus: "PENDING",
+        reviewerIdentity: null,
+        reviewedAt: null,
+        reviewNotes: null,
+        promotedAt: null,
+        promotionRunContext: {},
         generatedAt: new Date("2026-05-26T00:00:00.000Z"),
         createdAt: new Date("2026-05-26T00:00:01.000Z"),
       },
@@ -502,6 +536,7 @@ describe("listSearchEvalCandidates", () => {
         where: expect.objectContaining({
           source: { in: ["TRACE"] },
           OR: [
+            { promotionStatus: "PROMOTED" },
             { source: { not: "TRACE" } },
             { retentionExpiresAt: { gt: now } },
           ],
@@ -519,6 +554,7 @@ describe("listSearchEvalCandidates", () => {
       {
         id: "legacy-candidate",
         source: "CATALOG",
+        promotionStatus: "GENERATED",
         locale: "en",
         expectedResultHints: ["raw trace query Jesus movie"],
         sourceAnchors: [{ type: "trace", id: "trace-1" }],
@@ -531,6 +567,15 @@ describe("listSearchEvalCandidates", () => {
         judgeSummary: { rationale: "raw trace query Jesus movie" },
         mastraRunId: "raw trace query Jesus movie",
         retentionExpiresAt: null,
+        sanitizedQueryText: null,
+        sanitizedExpectedResultNotes: null,
+        sanitizedSourceAnchors: [],
+        sanitizationStatus: "PENDING",
+        reviewerIdentity: null,
+        reviewedAt: null,
+        reviewNotes: null,
+        promotedAt: null,
+        promotionRunContext: {},
         generatedAt: new Date("2026-05-26T00:00:00.000Z"),
         createdAt: new Date("2026-05-26T00:00:01.000Z"),
       },
@@ -573,6 +618,7 @@ describe("listSearchEvalCandidates", () => {
         where: expect.objectContaining({
           source: { in: ["TRACE"] },
           OR: [
+            { promotionStatus: "PROMOTED" },
             { source: { not: "TRACE" } },
             { retentionExpiresAt: { gt: now } },
           ],
@@ -597,5 +643,165 @@ describe("listSearchEvalCandidates", () => {
         { locales: ["../en"] },
       ),
     ).rejects.toMatchObject({ code: "validation" })
+  })
+})
+
+describe("review state transitions", () => {
+  it("promotes a pending candidate with sanitized truth and overwrites raw query text", async () => {
+    const prisma = buildPrisma()
+    const now = new Date("2026-05-28T00:00:00.000Z")
+    prisma.searchEvalCandidate.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "candidate-1",
+          source: "TRACE",
+          promotionStatus: "GENERATED",
+          locale: "en",
+          expectedResultHints: ["raw trace query"],
+          sourceAnchors: [{ type: "trace", text: "raw trace query" }],
+          labelProvenance: { rawQueryText: "raw trace query" },
+          generationModel: "admin-trace-sample:v1",
+          generationProvider: "mastra",
+          judgeSummary: { rationale: "raw trace query" },
+          sanitizedQueryText: "Who is Jesus?",
+          sanitizedExpectedResultNotes: "Should surface Jesus overview content",
+          sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+          sanitizationStatus: "SANITIZED",
+          reviewerIdentity: "nisal",
+          reviewedAt: now,
+          reviewNotes: "safe",
+          promotedAt: null,
+          promotionRunContext: { reportId: "report-1" },
+          mastraRunId: "run-1",
+          retentionExpiresAt: new Date("2026-06-01T00:00:00.000Z"),
+          generatedAt: new Date("2026-05-26T00:00:00.000Z"),
+          createdAt: new Date("2026-05-26T00:00:00.000Z"),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "candidate-1",
+          source: "TRACE",
+          promotionStatus: "PROMOTED",
+          locale: "en",
+          expectedResultHints: ["raw trace query"],
+          sourceAnchors: [{ type: "trace", text: "raw trace query" }],
+          labelProvenance: { rawQueryText: "raw trace query" },
+          generationModel: "admin-trace-sample:v1",
+          generationProvider: "mastra",
+          judgeSummary: { rationale: "raw trace query" },
+          sanitizedQueryText: "Who is Jesus?",
+          sanitizedExpectedResultNotes: "Should surface Jesus overview content",
+          sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+          sanitizationStatus: "SANITIZED",
+          reviewerIdentity: "nisal",
+          reviewedAt: now,
+          reviewNotes: "safe",
+          promotedAt: now,
+          promotionRunContext: { reportId: "report-1" },
+          mastraRunId: "run-1",
+          retentionExpiresAt: new Date("2026-06-01T00:00:00.000Z"),
+          generatedAt: new Date("2026-05-26T00:00:00.000Z"),
+          createdAt: new Date("2026-05-26T00:00:00.000Z"),
+        },
+      ])
+
+    const promoted = await promoteSearchEvalCandidate(
+      prisma as unknown as Parameters<typeof promoteSearchEvalCandidate>[0],
+      "candidate-1",
+      {
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizedExpectedResultNotes: "Should surface Jesus overview content",
+        sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+        promotionRunContext: { reportId: "report-1" },
+      },
+      now,
+    )
+
+    expect(prisma.searchEvalCandidate.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          promotionStatus: "PROMOTED",
+          queryText: "Who is Jesus?",
+          sanitizedQueryText: "Who is Jesus?",
+          sanitizationStatus: "SANITIZED",
+          reviewerIdentity: "nisal",
+          reviewedAt: now,
+          promotedAt: now,
+        }),
+      }),
+    )
+    expect(promoted).toMatchObject({
+      id: "candidate-1",
+      promotionStatus: "promoted",
+      queryText: "Who is Jesus?",
+      sourceAnchors: [{ type: "video", id: "video-1" }],
+    })
+    expect(JSON.stringify(promoted)).not.toContain("raw trace query")
+  })
+
+  it("rejects and archives only pending candidates with reviewer identity", async () => {
+    const prisma = buildPrisma()
+    const now = new Date("2026-05-28T00:00:00.000Z")
+    prisma.searchEvalCandidate.findMany.mockResolvedValue([
+      {
+        id: "candidate-1",
+        source: "CATALOG",
+        promotionStatus: "REJECTED",
+        locale: "en",
+        expectedResultHints: [],
+        sourceAnchors: [],
+        labelProvenance: {},
+        generationModel: "seed:v1",
+        generationProvider: "mastra",
+        judgeSummary: null,
+        sanitizedQueryText: null,
+        sanitizedExpectedResultNotes: null,
+        sanitizedSourceAnchors: [],
+        sanitizationStatus: "UNSAFE",
+        reviewerIdentity: "nisal",
+        reviewedAt: now,
+        reviewNotes: "ambiguous",
+        promotedAt: null,
+        promotionRunContext: {},
+        mastraRunId: "run-1",
+        retentionExpiresAt: null,
+        generatedAt: now,
+        createdAt: now,
+      },
+    ])
+
+    await rejectSearchEvalCandidate(
+      prisma as unknown as Parameters<typeof rejectSearchEvalCandidate>[0],
+      "candidate-1",
+      { reviewerIdentity: "nisal", reviewNotes: "ambiguous" },
+      now,
+    )
+    await archiveSearchEvalCandidate(
+      prisma as unknown as Parameters<typeof archiveSearchEvalCandidate>[0],
+      "candidate-1",
+      { reviewerIdentity: "nisal", reviewNotes: "duplicate" },
+      now,
+    )
+
+    expect(prisma.searchEvalCandidate.updateMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: expect.objectContaining({ promotionStatus: "GENERATED" }),
+        data: expect.objectContaining({
+          promotionStatus: "REJECTED",
+          sanitizationStatus: "UNSAFE",
+          reviewerIdentity: "nisal",
+          reviewedAt: now,
+        }),
+      }),
+    )
+    expect(prisma.searchEvalCandidate.updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: expect.objectContaining({ promotionStatus: "ARCHIVED" }),
+      }),
+    )
   })
 })

--- a/apps/admin/src/services/search-eval/candidates.ts
+++ b/apps/admin/src/services/search-eval/candidates.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 
 import {
+  SearchEvalCandidateSanitizationStatus as PrismaSanitizationStatus,
   SearchEvalCandidatePromotionStatus as PrismaPromotionStatus,
   SearchEvalCandidateSource as PrismaCandidateSource,
   type Prisma,
@@ -12,6 +13,8 @@ const MAX_LOCALE_LENGTH = 32
 const MAX_GENERATION_MODEL_LENGTH = 128
 const MAX_GENERATION_PROVIDER_LENGTH = 64
 const MAX_MASTRA_RUN_ID_LENGTH = 128
+const MAX_REVIEWER_IDENTITY_LENGTH = 256
+const MAX_REVIEW_NOTES_LENGTH = 2048
 const MAX_JSON_BYTES = 16 * 1024
 const MAX_TRACE_RETENTION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
 const BCP47_REGEX = /^[a-zA-Z]{2,3}(-[A-Za-z0-9]{2,8})*$/
@@ -20,6 +23,19 @@ export type SearchEvalCandidateSourceLabel =
   | "catalog"
   | "locale_quality"
   | "trace"
+  | "seed"
+  | "user_submitted"
+
+export type SearchEvalCandidatePromotionStatusLabel =
+  | "generated"
+  | "rejected"
+  | "promoted"
+  | "archived"
+
+export type SearchEvalCandidateSanitizationStatusLabel =
+  | "pending"
+  | "sanitized"
+  | "unsafe"
 
 export type StoreSearchEvalCandidateInput = {
   source: SearchEvalCandidateSourceLabel
@@ -54,6 +70,7 @@ export type StoreSearchEvalCandidatesResult = {
 
 export type ListSearchEvalCandidatesFilters = {
   sources?: SearchEvalCandidateSourceLabel[]
+  statuses?: SearchEvalCandidatePromotionStatusLabel[]
   locales?: string[]
   mastraRunId?: string | null
   limit?: number
@@ -63,6 +80,7 @@ export type ListSearchEvalCandidatesFilters = {
 export type ListedSearchEvalCandidate = {
   id: string
   source: SearchEvalCandidateSourceLabel
+  promotionStatus: SearchEvalCandidatePromotionStatusLabel
   locale: string
   queryText: string | null
   expectedResultHints: unknown
@@ -71,11 +89,44 @@ export type ListedSearchEvalCandidate = {
   generationModel: string
   generationProvider: string | null
   judgeSummary: unknown | null
+  sanitizedQueryText: string | null
+  sanitizedExpectedResultNotes: string | null
+  sanitizedSourceAnchors: unknown
+  sanitizationStatus: SearchEvalCandidateSanitizationStatusLabel
+  reviewerIdentity: string | null
+  reviewedAt: string | null
+  reviewNotes: string | null
+  promotedAt: string | null
+  promotionRunContext: unknown
   mastraRunId: string | null
   retentionExpiresAt: string | null
   generatedAt: string
   createdAt: string
 }
+
+export type UpdateSearchEvalCandidateReviewInput = {
+  reviewerIdentity?: string | null
+  sanitizedQueryText?: string | null
+  sanitizedExpectedResultNotes?: string | null
+  sanitizedSourceAnchors?: unknown
+  sanitizationStatus?: SearchEvalCandidateSanitizationStatusLabel
+  reviewNotes?: string | null
+  promotionRunContext?: unknown
+}
+
+export type SearchEvalCandidateDecisionInput = {
+  reviewerIdentity: string
+  reviewNotes?: string | null
+  promotionRunContext?: unknown
+}
+
+export type PromoteSearchEvalCandidateInput =
+  SearchEvalCandidateDecisionInput & {
+    sanitizedQueryText?: string | null
+    sanitizedExpectedResultNotes?: string | null
+    sanitizedSourceAnchors?: unknown
+    sanitizationStatus?: SearchEvalCandidateSanitizationStatusLabel
+  }
 
 const REDACTED_TRACE_LABEL_PROVENANCE = {
   source: "trace",
@@ -84,7 +135,7 @@ const REDACTED_TRACE_LABEL_PROVENANCE = {
 
 export class SearchEvalCandidateStoreError extends Error {
   constructor(
-    readonly code: "validation",
+    readonly code: "validation" | "not_found" | "invalid_state",
     message: string,
     readonly cause?: unknown,
   ) {
@@ -95,6 +146,17 @@ export class SearchEvalCandidateStoreError extends Error {
 
 function validation(message: string, cause?: unknown): never {
   throw new SearchEvalCandidateStoreError("validation", message, cause)
+}
+
+function notFound(id: string): never {
+  throw new SearchEvalCandidateStoreError(
+    "not_found",
+    `search eval candidate ${id} was not found`,
+  )
+}
+
+function invalidState(message: string): never {
+  throw new SearchEvalCandidateStoreError("invalid_state", message)
 }
 
 function normalizeQuery(value: string): string {
@@ -129,6 +191,17 @@ function normalizeBoundedString(
   if (normalized.length > max)
     validation(`${name} must be at most ${max} chars`)
   return normalized
+}
+
+function normalizeRequiredBoundedString(
+  value: string | null | undefined,
+  max: number,
+  name: string,
+): string {
+  return (
+    normalizeBoundedString(value, max, name) ??
+    validation(`${name} is required`)
+  )
 }
 
 function parseDate(
@@ -198,7 +271,28 @@ function toPrismaSource(
     return PrismaCandidateSource.LOCALE_QUALITY
   }
   if (source === "trace") return PrismaCandidateSource.TRACE
+  if (source === "seed") return PrismaCandidateSource.SEED
+  if (source === "user_submitted") return PrismaCandidateSource.USER_SUBMITTED
   validation("candidate source is unsupported")
+}
+
+function toPrismaStatus(
+  status: SearchEvalCandidatePromotionStatusLabel,
+): PrismaPromotionStatus {
+  if (status === "generated") return PrismaPromotionStatus.GENERATED
+  if (status === "rejected") return PrismaPromotionStatus.REJECTED
+  if (status === "promoted") return PrismaPromotionStatus.PROMOTED
+  if (status === "archived") return PrismaPromotionStatus.ARCHIVED
+  validation("candidate status is unsupported")
+}
+
+function toPrismaSanitizationStatus(
+  status: SearchEvalCandidateSanitizationStatusLabel,
+): PrismaSanitizationStatus {
+  if (status === "pending") return PrismaSanitizationStatus.PENDING
+  if (status === "sanitized") return PrismaSanitizationStatus.SANITIZED
+  if (status === "unsafe") return PrismaSanitizationStatus.UNSAFE
+  validation("candidate sanitizationStatus is unsupported")
 }
 
 function hasTraceMarker(value: unknown): boolean {
@@ -245,7 +339,26 @@ function fromPrismaSource(
 ): SearchEvalCandidateSourceLabel {
   if (source === PrismaCandidateSource.CATALOG) return "catalog"
   if (source === PrismaCandidateSource.LOCALE_QUALITY) return "locale_quality"
-  return "trace"
+  if (source === PrismaCandidateSource.TRACE) return "trace"
+  if (source === PrismaCandidateSource.SEED) return "seed"
+  return "user_submitted"
+}
+
+function fromPrismaStatus(
+  status: PrismaPromotionStatus,
+): SearchEvalCandidatePromotionStatusLabel {
+  if (status === PrismaPromotionStatus.GENERATED) return "generated"
+  if (status === PrismaPromotionStatus.REJECTED) return "rejected"
+  if (status === PrismaPromotionStatus.PROMOTED) return "promoted"
+  return "archived"
+}
+
+function fromPrismaSanitizationStatus(
+  status: PrismaSanitizationStatus,
+): SearchEvalCandidateSanitizationStatusLabel {
+  if (status === PrismaSanitizationStatus.SANITIZED) return "sanitized"
+  if (status === PrismaSanitizationStatus.UNSAFE) return "unsafe"
+  return "pending"
 }
 
 function shouldRedactCandidateRow(row: {
@@ -491,6 +604,10 @@ export async function listSearchEvalCandidates(
     filters.sources == null
       ? undefined
       : filters.sources.map((source) => toPrismaSource(source))
+  const statuses =
+    filters.statuses == null
+      ? [PrismaPromotionStatus.GENERATED]
+      : filters.statuses.map((status) => toPrismaStatus(status))
   const locales = filters.locales?.map((locale) => normalizeLocale(locale))
   const mastraRunId = normalizeBoundedString(
     filters.mastraRunId,
@@ -501,46 +618,88 @@ export async function listSearchEvalCandidates(
 
   const rows = await prisma.searchEvalCandidate.findMany({
     where: {
-      promotionStatus: PrismaPromotionStatus.GENERATED,
+      promotionStatus: { in: statuses },
       ...(sources ? { source: { in: sources } } : {}),
       ...(locales ? { locale: { in: locales } } : {}),
       ...(mastraRunId ? { mastraRunId } : {}),
-      OR: [
-        { source: { not: PrismaCandidateSource.TRACE } },
-        { retentionExpiresAt: { gt: now } },
-      ],
+      OR: reviewVisibleCandidateWhere(now),
     },
     orderBy: [{ createdAt: "desc" }, { id: "asc" }],
     take: limit,
-    select: {
-      id: true,
-      source: true,
-      locale: true,
-      expectedResultHints: true,
-      sourceAnchors: true,
-      labelProvenance: true,
-      generationModel: true,
-      generationProvider: true,
-      judgeSummary: true,
-      mastraRunId: true,
-      retentionExpiresAt: true,
-      generatedAt: true,
-      createdAt: true,
-    },
+    select: CANDIDATE_REVIEW_SELECT,
   })
 
-  const redactedIds = new Set(
-    rows.filter(shouldRedactCandidateRow).map((row) => row.id),
+  return serializeReviewCandidateRows(prisma, rows)
+}
+
+const CANDIDATE_REVIEW_SELECT = {
+  id: true,
+  source: true,
+  promotionStatus: true,
+  locale: true,
+  expectedResultHints: true,
+  sourceAnchors: true,
+  labelProvenance: true,
+  generationModel: true,
+  generationProvider: true,
+  judgeSummary: true,
+  sanitizedQueryText: true,
+  sanitizedExpectedResultNotes: true,
+  sanitizedSourceAnchors: true,
+  sanitizationStatus: true,
+  reviewerIdentity: true,
+  reviewedAt: true,
+  reviewNotes: true,
+  promotedAt: true,
+  promotionRunContext: true,
+  mastraRunId: true,
+  retentionExpiresAt: true,
+  generatedAt: true,
+  createdAt: true,
+} satisfies Prisma.SearchEvalCandidateSelect
+
+type ReviewCandidateRow = Prisma.SearchEvalCandidateGetPayload<{
+  select: typeof CANDIDATE_REVIEW_SELECT
+}>
+
+function reviewVisibleCandidateWhere(
+  now: Date,
+): Prisma.SearchEvalCandidateWhereInput[] {
+  return [
+    { promotionStatus: PrismaPromotionStatus.PROMOTED },
+    { source: { not: PrismaCandidateSource.TRACE } },
+    { retentionExpiresAt: { gt: now } },
+  ]
+}
+
+function shouldRedactReviewRow(row: ReviewCandidateRow): boolean {
+  return (
+    row.promotionStatus !== PrismaPromotionStatus.PROMOTED &&
+    shouldRedactCandidateRow(row)
   )
-  const nonTraceIds = rows
-    .filter((row) => !redactedIds.has(row.id))
+}
+
+async function serializeReviewCandidateRows(
+  prisma: PrismaClient,
+  rows: ReviewCandidateRow[],
+): Promise<ListedSearchEvalCandidate[]> {
+  const redactedIds = new Set(
+    rows.filter(shouldRedactReviewRow).map((row) => row.id),
+  )
+  const pendingReadableIds = rows
+    .filter(
+      (row) =>
+        row.promotionStatus !== PrismaPromotionStatus.PROMOTED &&
+        !redactedIds.has(row.id),
+    )
     .map((row) => row.id)
+
   const queryRows =
-    nonTraceIds.length === 0
+    pendingReadableIds.length === 0
       ? []
       : await prisma.searchEvalCandidate.findMany({
           where: {
-            id: { in: nonTraceIds },
+            id: { in: pendingReadableIds },
             source: { not: PrismaCandidateSource.TRACE },
           },
           select: { id: true, queryText: true },
@@ -549,33 +708,330 @@ export async function listSearchEvalCandidates(
     queryRows.map((row) => [row.id, row.queryText] as const),
   )
 
-  return rows.map((row) => ({
-    id: row.id,
-    source: redactedIds.has(row.id) ? "trace" : fromPrismaSource(row.source),
-    locale: row.locale,
-    queryText: redactedIds.has(row.id)
-      ? null
-      : (queryTextById.get(row.id) ?? ""),
-    expectedResultHints: redactedIds.has(row.id) ? [] : row.expectedResultHints,
-    sourceAnchors: redactedIds.has(row.id) ? [] : row.sourceAnchors,
-    labelProvenance: redactedIds.has(row.id)
-      ? REDACTED_TRACE_LABEL_PROVENANCE
-      : row.labelProvenance,
-    generationModel: redactedIds.has(row.id)
-      ? "trace:redacted"
-      : row.generationModel,
-    generationProvider: redactedIds.has(row.id) ? null : row.generationProvider,
-    judgeSummary: redactedIds.has(row.id) ? null : row.judgeSummary,
-    mastraRunId: redactedIds.has(row.id) ? null : row.mastraRunId,
-    retentionExpiresAt: row.retentionExpiresAt?.toISOString() ?? null,
-    generatedAt: row.generatedAt.toISOString(),
-    createdAt: row.createdAt.toISOString(),
-  }))
+  return rows.map((row) => {
+    const promotionStatus =
+      row.promotionStatus ?? PrismaPromotionStatus.GENERATED
+    const sanitizationStatus =
+      row.sanitizationStatus ?? PrismaSanitizationStatus.PENDING
+    const redactsOperationalFields =
+      redactedIds.has(row.id) ||
+      (promotionStatus === PrismaPromotionStatus.PROMOTED &&
+        shouldRedactCandidateRow(row))
+    return {
+      id: row.id,
+      source: redactedIds.has(row.id) ? "trace" : fromPrismaSource(row.source),
+      promotionStatus: fromPrismaStatus(promotionStatus),
+      locale: row.locale,
+      queryText:
+        promotionStatus === PrismaPromotionStatus.PROMOTED
+          ? row.sanitizedQueryText
+          : redactedIds.has(row.id)
+            ? null
+            : (queryTextById.get(row.id) ?? ""),
+      expectedResultHints:
+        promotionStatus === PrismaPromotionStatus.PROMOTED ||
+        redactedIds.has(row.id)
+          ? []
+          : row.expectedResultHints,
+      sourceAnchors:
+        promotionStatus === PrismaPromotionStatus.PROMOTED
+          ? row.sanitizedSourceAnchors
+          : redactedIds.has(row.id)
+            ? []
+            : row.sourceAnchors,
+      labelProvenance:
+        promotionStatus === PrismaPromotionStatus.PROMOTED
+          ? {
+              source: fromPrismaSource(row.source),
+              promoted: true,
+              sanitized: true,
+            }
+          : redactedIds.has(row.id)
+            ? REDACTED_TRACE_LABEL_PROVENANCE
+            : row.labelProvenance,
+      generationModel: redactsOperationalFields
+        ? "trace:redacted"
+        : row.generationModel,
+      generationProvider: redactsOperationalFields
+        ? null
+        : row.generationProvider,
+      judgeSummary:
+        redactsOperationalFields ||
+        promotionStatus === PrismaPromotionStatus.PROMOTED
+          ? null
+          : row.judgeSummary,
+      sanitizedQueryText: row.sanitizedQueryText ?? null,
+      sanitizedExpectedResultNotes: row.sanitizedExpectedResultNotes ?? null,
+      sanitizedSourceAnchors: row.sanitizedSourceAnchors ?? [],
+      sanitizationStatus: fromPrismaSanitizationStatus(sanitizationStatus),
+      reviewerIdentity: row.reviewerIdentity ?? null,
+      reviewedAt: row.reviewedAt?.toISOString() ?? null,
+      reviewNotes: row.reviewNotes ?? null,
+      promotedAt: row.promotedAt?.toISOString() ?? null,
+      promotionRunContext: row.promotionRunContext ?? {},
+      mastraRunId: redactsOperationalFields ? null : row.mastraRunId,
+      retentionExpiresAt: row.retentionExpiresAt?.toISOString() ?? null,
+      generatedAt: row.generatedAt.toISOString(),
+      createdAt: row.createdAt.toISOString(),
+    }
+  })
+}
+
+export async function getSearchEvalCandidateForReview(
+  prisma: PrismaClient,
+  id: string,
+  now: Date = new Date(),
+): Promise<ListedSearchEvalCandidate> {
+  const rows = await prisma.searchEvalCandidate.findMany({
+    where: {
+      id,
+      OR: reviewVisibleCandidateWhere(now),
+    },
+    take: 1,
+    select: CANDIDATE_REVIEW_SELECT,
+  })
+  if (rows.length === 0) notFound(id)
+  return (await serializeReviewCandidateRows(prisma, rows))[0] ?? notFound(id)
+}
+
+function reviewUpdateDataFor(
+  input: UpdateSearchEvalCandidateReviewInput,
+  now: Date,
+): Prisma.SearchEvalCandidateUpdateManyMutationInput {
+  const data: Prisma.SearchEvalCandidateUpdateManyMutationInput = {}
+
+  if ("sanitizedQueryText" in input) {
+    data.sanitizedQueryText =
+      input.sanitizedQueryText == null
+        ? null
+        : normalizeQuery(input.sanitizedQueryText)
+  }
+  if ("sanitizedExpectedResultNotes" in input) {
+    data.sanitizedExpectedResultNotes = normalizeBoundedString(
+      input.sanitizedExpectedResultNotes,
+      MAX_REVIEW_NOTES_LENGTH,
+      "sanitizedExpectedResultNotes",
+    )
+  }
+  if ("sanitizedSourceAnchors" in input) {
+    data.sanitizedSourceAnchors = toJsonArray(
+      input.sanitizedSourceAnchors,
+      [],
+      "sanitizedSourceAnchors",
+    )
+  }
+  if (input.sanitizationStatus != null) {
+    data.sanitizationStatus = toPrismaSanitizationStatus(
+      input.sanitizationStatus,
+    )
+  }
+  if ("reviewNotes" in input) {
+    data.reviewNotes = normalizeBoundedString(
+      input.reviewNotes,
+      MAX_REVIEW_NOTES_LENGTH,
+      "reviewNotes",
+    )
+  }
+  if ("promotionRunContext" in input) {
+    data.promotionRunContext = toJsonObject(
+      input.promotionRunContext,
+      {},
+      "promotionRunContext",
+    )
+  }
+  if ("reviewerIdentity" in input) {
+    data.reviewerIdentity = normalizeBoundedString(
+      input.reviewerIdentity,
+      MAX_REVIEWER_IDENTITY_LENGTH,
+      "reviewerIdentity",
+    )
+    if (data.reviewerIdentity != null) data.reviewedAt = now
+  }
+
+  return data
+}
+
+export async function updateSearchEvalCandidateReviewFields(
+  prisma: PrismaClient,
+  id: string,
+  input: UpdateSearchEvalCandidateReviewInput,
+  now: Date = new Date(),
+): Promise<ListedSearchEvalCandidate> {
+  const updated = await prisma.searchEvalCandidate.updateMany({
+    where: {
+      id,
+      promotionStatus: PrismaPromotionStatus.GENERATED,
+      OR: reviewVisibleCandidateWhere(now),
+    },
+    data: reviewUpdateDataFor(input, now),
+  })
+  if (updated.count === 0) {
+    await getSearchEvalCandidateForReview(prisma, id, now).catch(() =>
+      notFound(id),
+    )
+    invalidState("only pending candidates can be edited")
+  }
+  return getSearchEvalCandidateForReview(prisma, id, now)
+}
+
+async function transitionSearchEvalCandidate(
+  prisma: PrismaClient,
+  id: string,
+  status: (typeof PrismaPromotionStatus)[keyof typeof PrismaPromotionStatus],
+  input: SearchEvalCandidateDecisionInput,
+  now: Date,
+): Promise<ListedSearchEvalCandidate> {
+  const reviewerIdentity = normalizeRequiredBoundedString(
+    input.reviewerIdentity,
+    MAX_REVIEWER_IDENTITY_LENGTH,
+    "reviewerIdentity",
+  )
+  const updated = await prisma.searchEvalCandidate.updateMany({
+    where: {
+      id,
+      promotionStatus: PrismaPromotionStatus.GENERATED,
+      OR: reviewVisibleCandidateWhere(now),
+    },
+    data: {
+      promotionStatus: status,
+      sanitizationStatus: PrismaSanitizationStatus.UNSAFE,
+      reviewerIdentity,
+      reviewedAt: now,
+      reviewNotes: normalizeBoundedString(
+        input.reviewNotes,
+        MAX_REVIEW_NOTES_LENGTH,
+        "reviewNotes",
+      ),
+      promotionRunContext: toJsonObject(
+        input.promotionRunContext,
+        {},
+        "promotionRunContext",
+      ),
+    },
+  })
+  if (updated.count === 0) {
+    await getSearchEvalCandidateForReview(prisma, id, now).catch(() =>
+      notFound(id),
+    )
+    invalidState("only pending candidates can change review state")
+  }
+  return getSearchEvalCandidateForReview(prisma, id, now)
+}
+
+export function rejectSearchEvalCandidate(
+  prisma: PrismaClient,
+  id: string,
+  input: SearchEvalCandidateDecisionInput,
+  now: Date = new Date(),
+): Promise<ListedSearchEvalCandidate> {
+  return transitionSearchEvalCandidate(
+    prisma,
+    id,
+    PrismaPromotionStatus.REJECTED,
+    input,
+    now,
+  )
+}
+
+export function archiveSearchEvalCandidate(
+  prisma: PrismaClient,
+  id: string,
+  input: SearchEvalCandidateDecisionInput,
+  now: Date = new Date(),
+): Promise<ListedSearchEvalCandidate> {
+  return transitionSearchEvalCandidate(
+    prisma,
+    id,
+    PrismaPromotionStatus.ARCHIVED,
+    input,
+    now,
+  )
+}
+
+export async function promoteSearchEvalCandidate(
+  prisma: PrismaClient,
+  id: string,
+  input: PromoteSearchEvalCandidateInput,
+  now: Date = new Date(),
+): Promise<ListedSearchEvalCandidate> {
+  const existing = await getSearchEvalCandidateForReview(prisma, id, now)
+  if (existing.promotionStatus !== "generated") {
+    invalidState("only pending candidates can be promoted")
+  }
+
+  const reviewerIdentity = normalizeRequiredBoundedString(
+    input.reviewerIdentity,
+    MAX_REVIEWER_IDENTITY_LENGTH,
+    "reviewerIdentity",
+  )
+  const sanitizedQueryText =
+    normalizeBoundedString(
+      input.sanitizedQueryText,
+      MAX_QUERY_LENGTH,
+      "sanitizedQueryText",
+    ) ??
+    existing.sanitizedQueryText ??
+    validation("sanitizedQueryText is required for promotion")
+  const sanitizedExpectedResultNotes =
+    "sanitizedExpectedResultNotes" in input
+      ? normalizeBoundedString(
+          input.sanitizedExpectedResultNotes,
+          MAX_REVIEW_NOTES_LENGTH,
+          "sanitizedExpectedResultNotes",
+        )
+      : existing.sanitizedExpectedResultNotes
+  const sanitizedSourceAnchors =
+    "sanitizedSourceAnchors" in input
+      ? toJsonArray(input.sanitizedSourceAnchors, [], "sanitizedSourceAnchors")
+      : toJsonArray(
+          existing.sanitizedSourceAnchors,
+          [],
+          "sanitizedSourceAnchors",
+        )
+
+  if (
+    input.sanitizationStatus != null &&
+    input.sanitizationStatus !== "sanitized"
+  ) {
+    validation("promotion requires sanitizationStatus sanitized")
+  }
+
+  const updated = await prisma.searchEvalCandidate.updateMany({
+    where: {
+      id,
+      promotionStatus: PrismaPromotionStatus.GENERATED,
+      OR: reviewVisibleCandidateWhere(now),
+    },
+    data: {
+      promotionStatus: PrismaPromotionStatus.PROMOTED,
+      queryText: sanitizedQueryText,
+      sanitizedQueryText,
+      sanitizedExpectedResultNotes,
+      sanitizedSourceAnchors,
+      sanitizationStatus: PrismaSanitizationStatus.SANITIZED,
+      reviewerIdentity,
+      reviewedAt: now,
+      promotedAt: now,
+      reviewNotes: normalizeBoundedString(
+        input.reviewNotes,
+        MAX_REVIEW_NOTES_LENGTH,
+        "reviewNotes",
+      ),
+      promotionRunContext: toJsonObject(
+        input.promotionRunContext,
+        {},
+        "promotionRunContext",
+      ),
+    },
+  })
+  if (updated.count === 0) invalidState("candidate promotion state changed")
+  return getSearchEvalCandidateForReview(prisma, id, now)
 }
 
 export const _internal = {
   dedupeKeyFor,
   fromPrismaSource,
+  fromPrismaStatus,
   hasTraceMarker,
   normalizeLocale,
   normalizeQuery,

--- a/apps/admin/src/services/search-eval/regressions.test.ts
+++ b/apps/admin/src/services/search-eval/regressions.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RegressionLoadError, loadRegressions } from "./regressions"
 
@@ -129,5 +129,61 @@ describe("loadRegressions", () => {
       query: "esperanza",
       source: "regression",
     })
+  })
+
+  it("appends promoted sanitized candidates when prisma is provided", async () => {
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        entries: [{ locale: "en", query: "hand edited", notes: "manual" }],
+      }),
+    )
+    const prisma = {
+      searchEvalCandidate: {
+        findMany: vi.fn(async () => [
+          {
+            id: "candidate-1",
+            locale: "en",
+            sanitizedQueryText: "Who is Jesus?",
+            sanitizedExpectedResultNotes: "Should surface Jesus overview",
+            sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+            reviewerIdentity: "nisal",
+            promotedAt: new Date("2026-05-28T00:00:00.000Z"),
+          },
+        ]),
+      },
+    }
+
+    const out = await loadRegressions({
+      filePath,
+      prisma: prisma as never,
+    })
+
+    expect(out).toEqual([
+      {
+        locale: "en",
+        query: "hand edited",
+        source: "regression",
+        notes: "manual",
+      },
+      {
+        locale: "en",
+        query: "Who is Jesus?",
+        source: "promoted",
+        notes: "Should surface Jesus overview",
+        promotedCandidateId: "candidate-1",
+        sourceAnchors: [{ type: "video", id: "video-1" }],
+        reviewerIdentity: "nisal",
+        promotedAt: "2026-05-28T00:00:00.000Z",
+      },
+    ])
+    expect(prisma.searchEvalCandidate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          promotionStatus: "PROMOTED",
+          sanitizationStatus: "SANITIZED",
+        }),
+      }),
+    )
   })
 })

--- a/apps/admin/src/services/search-eval/regressions.ts
+++ b/apps/admin/src/services/search-eval/regressions.ts
@@ -13,6 +13,11 @@
 
 import { readFile } from "node:fs/promises"
 
+import {
+  SearchEvalCandidatePromotionStatus,
+  SearchEvalCandidateSanitizationStatus,
+  type PrismaClient,
+} from "@prisma/client"
 import { z } from "zod"
 
 import { regressionsPath } from "./paths"
@@ -37,6 +42,10 @@ export type LoadedRegressionQuery = {
   query: string
   source: QuerySource
   notes?: string
+  promotedCandidateId?: string
+  sourceAnchors?: unknown
+  reviewerIdentity?: string
+  promotedAt?: string
 }
 
 export class RegressionLoadError extends Error {
@@ -53,10 +62,51 @@ export class RegressionLoadError extends Error {
 export type LoadRegressionsOptions = {
   /** Override path for tests. Defaults to `apps/admin/eval/regressions.json`. */
   filePath?: string
+  /** Optional Admin DB client. When supplied, promoted sanitized candidates
+   *  are appended after hand-edited regressions. */
+  prisma?: PrismaClient
   /** Treat ENOENT as `entries: []` rather than throwing. Default `true`
    *  because the file is optional — operators may not have authored
    *  any regressions yet. */
   allowMissing?: boolean
+}
+
+export async function loadPromotedRegressions(
+  prisma: PrismaClient,
+): Promise<LoadedRegressionQuery[]> {
+  const rows = await prisma.searchEvalCandidate.findMany({
+    where: {
+      promotionStatus: SearchEvalCandidatePromotionStatus.PROMOTED,
+      sanitizationStatus: SearchEvalCandidateSanitizationStatus.SANITIZED,
+      sanitizedQueryText: { not: null },
+    },
+    orderBy: [{ promotedAt: "asc" }, { id: "asc" }],
+    select: {
+      id: true,
+      locale: true,
+      sanitizedQueryText: true,
+      sanitizedExpectedResultNotes: true,
+      sanitizedSourceAnchors: true,
+      reviewerIdentity: true,
+      promotedAt: true,
+    },
+  })
+
+  return rows.flatMap((row) => {
+    if (!row.sanitizedQueryText) return []
+    return [
+      {
+        locale: row.locale,
+        query: row.sanitizedQueryText,
+        source: "promoted" as const,
+        notes: row.sanitizedExpectedResultNotes ?? undefined,
+        promotedCandidateId: row.id,
+        sourceAnchors: row.sanitizedSourceAnchors,
+        reviewerIdentity: row.reviewerIdentity ?? undefined,
+        promotedAt: row.promotedAt?.toISOString(),
+      },
+    ]
+  })
 }
 
 export async function loadRegressions(
@@ -75,7 +125,7 @@ export async function loadRegressions(
       "code" in cause &&
       (cause as NodeJS.ErrnoException).code === "ENOENT"
     ) {
-      return []
+      return options.prisma ? loadPromotedRegressions(options.prisma) : []
     }
     throw new RegressionLoadError(
       "not_found",
@@ -103,10 +153,15 @@ export async function loadRegressions(
     )
   }
 
-  return validated.data.entries.map<LoadedRegressionQuery>((entry) => ({
-    locale: entry.locale,
-    query: entry.query,
-    source: "regression",
-    notes: entry.notes,
-  }))
+  const fileEntries = validated.data.entries.map<LoadedRegressionQuery>(
+    (entry) => ({
+      locale: entry.locale,
+      query: entry.query,
+      source: "regression",
+      notes: entry.notes,
+    }),
+  )
+  if (!options.prisma) return fileEntries
+
+  return [...fileEntries, ...(await loadPromotedRegressions(options.prisma))]
 }

--- a/apps/admin/src/services/search-eval/types.ts
+++ b/apps/admin/src/services/search-eval/types.ts
@@ -49,7 +49,7 @@ export type Verdict =
  * and intentionally do not enter this durable harness union until a sanitized
  * human-promotion flow lands.
  */
-export type QuerySource = "synthetic" | "regression"
+export type QuerySource = "synthetic" | "regression" | "promoted"
 
 /** Run-level mode for the harness CLI. */
 export type RunMode = "quick" | "full" | "locale"

--- a/apps/admin/src/services/search-trace-retention.service.test.ts
+++ b/apps/admin/src/services/search-trace-retention.service.test.ts
@@ -64,7 +64,9 @@ describe("search trace retention service", () => {
         retentionExpiresAt: {
           lte: now,
         },
-        promotionStatus: "GENERATED",
+        promotionStatus: {
+          not: "PROMOTED",
+        },
       },
     })
   })

--- a/apps/admin/src/services/search-trace-retention.service.ts
+++ b/apps/admin/src/services/search-trace-retention.service.ts
@@ -54,7 +54,9 @@ export async function purgeExpiredSearchTraces(
       retentionExpiresAt: {
         lte: now,
       },
-      promotionStatus: SearchEvalCandidatePromotionStatus.GENERATED,
+      promotionStatus: {
+        not: SearchEvalCandidatePromotionStatus.PROMOTED,
+      },
     },
   })
 

--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -72,7 +72,7 @@ pnpm --filter @forge/mastra lint
 | `MASTRA_SERVICE_API_KEYS`                | CSV allowlist for service bearer calls. Required in production runtime.                                                    |
 | `MASTRA_NATIVE_EVAL_ENVIRONMENT`         | Optional label for native search-eval Dataset and Experiment names. Defaults to Mastra environment.                        |
 | `MASTRA_STORAGE_DIR`                     | Optional directory for Studio-visible observability/log files. Defaults to `$RAILWAY_VOLUME_MOUNT_PATH/mastra` on Railway. |
-| `MASTRA_STORAGE_BACKEND`                 | Mastra runtime storage backend. Use `postgres` normally; `memory` is local/test-only and rejected in production.            |
+| `MASTRA_STORAGE_BACKEND`                 | Mastra runtime storage backend. Use `postgres` normally; `memory` is local/test-only and rejected in production.           |
 | `OPENROUTER_API_KEY`                     | OpenRouter key for locale-quality eval query generation and offline compare judging. Required for compare mode.            |
 | `OPENROUTER_EMBEDDINGS_BASE_URL`         | Optional OpenRouter-compatible embedding base URL. Defaults to OpenRouter's `/api/v1` endpoint.                            |
 | `OPENAI_API_KEY`                         | Fallback model provider key for smoke agent/model-routed calls and transcript embeddings when OpenRouter is unavailable.   |

--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -70,7 +70,9 @@ pnpm --filter @forge/mastra lint
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `DATABASE_URL`                           | Postgres connection string for Mastra runtime storage. Required in production runtime.                                     |
 | `MASTRA_SERVICE_API_KEYS`                | CSV allowlist for service bearer calls. Required in production runtime.                                                    |
+| `MASTRA_NATIVE_EVAL_ENVIRONMENT`         | Optional label for native search-eval Dataset and Experiment names. Defaults to Mastra environment.                        |
 | `MASTRA_STORAGE_DIR`                     | Optional directory for Studio-visible observability/log files. Defaults to `$RAILWAY_VOLUME_MOUNT_PATH/mastra` on Railway. |
+| `MASTRA_STORAGE_BACKEND`                 | Mastra runtime storage backend. Use `postgres` normally; `memory` is local/test-only and rejected in production.            |
 | `OPENROUTER_API_KEY`                     | OpenRouter key for locale-quality eval query generation and offline compare judging. Required for compare mode.            |
 | `OPENROUTER_EMBEDDINGS_BASE_URL`         | Optional OpenRouter-compatible embedding base URL. Defaults to OpenRouter's `/api/v1` endpoint.                            |
 | `OPENAI_API_KEY`                         | Fallback model provider key for smoke agent/model-routed calls and transcript embeddings when OpenRouter is unavailable.   |
@@ -138,6 +140,43 @@ enters the public search request path. The Studio-facing offline eval workflow
 is seed-only for now. Generated candidates from the feat-138 staging table are
 not exposed as operator inputs, are not stored in baselines, and do not become
 regression gates.
+
+## Native search eval suite
+
+The service route `POST /forge-search-eval-native-suite` is protected by
+`MASTRA_SERVICE_API_KEYS` and launches the `search-eval-native-suite` workflow.
+The workflow projects safe search-eval reports and promoted Admin candidates
+into native Mastra Evaluation records:
+
+- `create-sample-report` writes a realistic local sample comparison report,
+  syncs it into a native Dataset, registers the pairwise search scorer, starts
+  a native Experiment, and writes the synced native ids back into the report
+  artifact. This action is local/development only.
+- `sync-report` loads an existing report artifact by `reportId`, syncs it into
+  native Evaluation, and updates the report's `mastraEvaluation` projection.
+- `sync-promoted` reads promoted candidates through Admin HTTP, then only syncs
+  rows that are both `promotionStatus=promoted` and
+  `sanitizationStatus=sanitized`.
+
+Native record names include the environment label, for example
+`search-eval:local:seed-baseline`, and native metadata carries stable keys for
+idempotent reruns. Re-running a report sync should update Dataset items by
+source key and reuse the existing report Experiment instead of duplicating
+records.
+
+For local Studio smoke without Postgres or Admin data, run Mastra with:
+
+```bash
+MASTRA_STORAGE_BACKEND=memory \
+MASTRA_NATIVE_EVAL_ENVIRONMENT=local \
+MASTRA_SERVICE_API_KEYS=local-mastra-service-key \
+MASTRA_SEARCH_EVAL_ARTIFACT_DIR=.mastra/storage/search-eval \
+pnpm --filter @forge/mastra dev
+```
+
+Open `http://localhost:4111/studio/workflows/search-eval-native-suite`, run the
+default `create-sample-report` action, then inspect Studio's native Evaluation
+Datasets, Scorers, and Experiments.
 
 ## Railway Storage
 

--- a/apps/mastra/src/config/env.ts
+++ b/apps/mastra/src/config/env.ts
@@ -25,7 +25,9 @@ const envSchema = z.object({
     .default("development"),
   NEXT_PHASE: z.string().optional(),
   MASTRA_SERVICE_API_KEYS: z.string().min(1).optional(),
+  MASTRA_NATIVE_EVAL_ENVIRONMENT: z.string().min(1).optional(),
   MASTRA_SEARCH_EVAL_ARTIFACT_DIR: z.string().min(1).optional(),
+  MASTRA_STORAGE_BACKEND: z.enum(["postgres", "memory"]).default("postgres"),
   MASTRA_STORAGE_DIR: z.string().min(1).optional(),
   OPENAI_EMBEDDINGS_BASE_URL: z
     .string()
@@ -101,9 +103,13 @@ export const env = envSchema.parse({
   MASTRA_SERVICE_API_KEYS: emptyToUndefined(
     process.env.MASTRA_SERVICE_API_KEYS,
   ),
+  MASTRA_NATIVE_EVAL_ENVIRONMENT: emptyToUndefined(
+    process.env.MASTRA_NATIVE_EVAL_ENVIRONMENT,
+  ),
   MASTRA_SEARCH_EVAL_ARTIFACT_DIR: emptyToUndefined(
     process.env.MASTRA_SEARCH_EVAL_ARTIFACT_DIR,
   ),
+  MASTRA_STORAGE_BACKEND: emptyToUndefined(process.env.MASTRA_STORAGE_BACKEND),
   MASTRA_STORAGE_DIR: emptyToUndefined(process.env.MASTRA_STORAGE_DIR),
   OPENAI_EMBEDDINGS_BASE_URL: emptyToUndefined(
     process.env.OPENAI_EMBEDDINGS_BASE_URL,
@@ -141,6 +147,15 @@ export const env = envSchema.parse({
 })
 
 export function assertMastraRuntimeEnv() {
+  if (
+    env.NODE_ENV === "production" &&
+    env.MASTRA_STORAGE_BACKEND === "memory"
+  ) {
+    throw new Error(
+      "MASTRA_STORAGE_BACKEND=memory is not allowed in production",
+    )
+  }
+
   if (env.NODE_ENV !== "production") return
 
   const missing = [

--- a/apps/mastra/src/mastra/index.ts
+++ b/apps/mastra/src/mastra/index.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { Mastra } from "@mastra/core"
 import type { AnySpan, SpanOutputProcessor } from "@mastra/core/observability"
 import { registerApiRoute } from "@mastra/core/server"
-import { MastraCompositeStore } from "@mastra/core/storage"
+import { InMemoryStore, MastraCompositeStore } from "@mastra/core/storage"
 import { DuckDBStore } from "@mastra/duckdb"
 import { PinoLogger } from "@mastra/loggers"
 import {
@@ -42,6 +42,15 @@ import {
   offlineSearchEvalWorkflow,
 } from "./workflows/offline-search-eval"
 import {
+  handleSearchEvalCandidateReviewRouteRequest,
+  searchEvalCandidateReviewWorkflow,
+} from "./workflows/search-eval-candidate-review"
+import {
+  configureSearchEvalNativeSuiteRuntime,
+  handleSearchEvalNativeSuiteRouteRequest,
+  searchEvalNativeSuiteWorkflow,
+} from "./workflows/search-eval-native-suite"
+import {
   isValidServiceBearer,
   parseServiceApiKeys,
 } from "../server/service-bearer"
@@ -54,11 +63,14 @@ const storageSchemaName = "mastra"
 
 mkdirSync(storageDir, { recursive: true })
 
-const storage = new PostgresStore({
-  id: "mastra-postgres-storage",
-  connectionString: getMastraDatabaseUrl(),
-  schemaName: storageSchemaName,
-})
+const storage =
+  env.MASTRA_STORAGE_BACKEND === "memory"
+    ? new InMemoryStore({ id: "mastra-memory-storage" })
+    : new PostgresStore({
+        id: "mastra-postgres-storage",
+        connectionString: getMastraDatabaseUrl(),
+        schemaName: storageSchemaName,
+      })
 const observabilityStore = new DuckDBStore({
   id: "mastra-observability-storage",
   path: join(storageDir, "mastra-observability.duckdb"),
@@ -82,6 +94,8 @@ export const mastra = new Mastra({
     experienceEmbeddingWorkflow,
     evalQueryGenerationWorkflow,
     offlineSearchEvalWorkflow,
+    searchEvalCandidateReviewWorkflow,
+    searchEvalNativeSuiteWorkflow,
   },
   logger: new PinoLogger({
     name: "ForgeMastra",
@@ -215,6 +229,38 @@ export const mastra = new Mastra({
           })
         },
       }),
+      registerApiRoute("/forge-search-eval-candidate-review", {
+        method: "POST",
+        handler: async (c) => {
+          const outcome = await handleSearchEvalCandidateReviewRouteRequest({
+            authHeader: c.req.header("authorization"),
+            serviceKeys,
+            readJson: () => c.req.json(),
+          })
+
+          return new Response(JSON.stringify(outcome.body), {
+            status: outcome.status,
+            headers: { "content-type": "application/json" },
+          })
+        },
+      }),
+      registerApiRoute("/forge-search-eval-native-suite", {
+        method: "POST",
+        handler: async (c) => {
+          const outcome = await handleSearchEvalNativeSuiteRouteRequest({
+            authHeader: c.req.header("authorization"),
+            serviceKeys,
+            request: c.req.raw,
+          })
+
+          return new Response(JSON.stringify(outcome.body), {
+            status: outcome.status,
+            headers: { "content-type": "application/json" },
+          })
+        },
+      }),
     ],
   },
 })
+
+configureSearchEvalNativeSuiteRuntime(() => mastra)

--- a/apps/mastra/src/mastra/workflows/eval-query-generation.ts
+++ b/apps/mastra/src/mastra/workflows/eval-query-generation.ts
@@ -237,7 +237,9 @@ async function readCatalogContext(
 }
 
 function sourceCounts(
-  candidates: readonly { source: "catalog" | "locale_quality" | "trace" }[],
+  candidates: readonly {
+    source: "catalog" | "locale_quality" | "trace" | "seed" | "user_submitted"
+  }[],
 ) {
   return {
     catalog: candidates.filter((candidate) => candidate.source === "catalog")

--- a/apps/mastra/src/mastra/workflows/search-eval-candidate-review.test.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-candidate-review.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  _internal,
+  runSearchEvalCandidateReviewWorkflow,
+} from "./search-eval-candidate-review"
+import type { AdminCandidateListResponse } from "../../services/admin-search-eval-client"
+
+const candidate: AdminCandidateListResponse["candidates"][number] = {
+  id: "candidate-1",
+  source: "catalog",
+  promotionStatus: "generated",
+  locale: "en",
+  queryText: "Jesus",
+  expectedResultHints: [],
+  sourceAnchors: [],
+  labelProvenance: {},
+  generationModel: "seed:v1",
+  generationProvider: "mastra",
+  judgeSummary: null,
+  sanitizedQueryText: null,
+  sanitizedExpectedResultNotes: null,
+  sanitizedSourceAnchors: [],
+  sanitizationStatus: "pending",
+  reviewerIdentity: null,
+  reviewedAt: null,
+  reviewNotes: null,
+  promotedAt: null,
+  promotionRunContext: {},
+  mastraRunId: "run-1",
+  retentionExpiresAt: null,
+  generatedAt: "2026-05-26T00:00:00.000Z",
+  createdAt: "2026-05-26T00:00:00.000Z",
+}
+
+describe("search eval candidate review workflow", () => {
+  it("lists candidates through Admin HTTP client only", async () => {
+    const listClient = vi.fn(async () => ({
+      ok: true as const,
+      result: {
+        candidates: [candidate],
+        generatedAt: "2026-05-28T00:00:00.000Z",
+      },
+    }))
+
+    const result = await runSearchEvalCandidateReviewWorkflow(
+      {
+        action: "list",
+        filters: { sources: ["catalog"], statuses: ["generated"], limit: 10 },
+      },
+      {
+        adminBearer: "eval-key",
+        candidateUrl:
+          "https://admin.internal/api/internal/search-eval/candidates",
+        listClient,
+        runId: "run-review",
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: "list",
+      candidates: [candidate],
+      nativeDatasetItemShape: expect.objectContaining({
+        nativeWrites: expect.objectContaining({ deferredTo: "feat-142" }),
+      }),
+    })
+    expect(listClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bearer: "eval-key",
+        url: "https://admin.internal/api/internal/search-eval/candidates",
+        filters: {
+          sources: ["catalog"],
+          statuses: ["generated"],
+          limit: 10,
+        },
+      }),
+    )
+  })
+
+  it("promotes by calling Admin promote endpoint with reviewer context", async () => {
+    const promoteClient = vi.fn(async () => ({
+      ok: true as const,
+      result: {
+        candidate: {
+          ...candidate,
+          promotionStatus: "promoted" as const,
+          queryText: "Who is Jesus?",
+          sanitizedQueryText: "Who is Jesus?",
+          sanitizationStatus: "sanitized" as const,
+          reviewerIdentity: "nisal",
+        },
+      },
+    }))
+
+    const result = await runSearchEvalCandidateReviewWorkflow(
+      {
+        action: "promote",
+        candidateId: "candidate-1",
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizedExpectedResultNotes: "Should surface Jesus overview",
+        sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+        promotionRunContext: { reportId: "report-1" },
+      },
+      {
+        adminBearer: "eval-key",
+        candidateUrl:
+          "https://admin.internal/api/internal/search-eval/candidates",
+        promoteClient,
+        runId: "run-review",
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: "promote",
+      candidate: {
+        id: "candidate-1",
+        promotionStatus: "promoted",
+        reviewerIdentity: "nisal",
+      },
+    })
+    expect(promoteClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateId: "candidate-1",
+        payload: expect.objectContaining({
+          reviewerIdentity: "nisal",
+          sanitizedQueryText: "Who is Jesus?",
+          sanitizationStatus: "sanitized",
+          promotionRunContext: expect.objectContaining({
+            reportId: "report-1",
+            mastraReviewAction: "promote",
+          }),
+        }),
+      }),
+    )
+  })
+
+  it("submits seed and user prompts as pending Admin candidates", async () => {
+    const storeClient = vi.fn(async () => ({
+      ok: true as const,
+      result: {
+        storedCount: 1,
+        skippedCount: 0,
+        candidates: [
+          { id: "candidate-1", dedupeKey: "abc", status: "created" as const },
+        ],
+        skipped: [],
+      },
+    }))
+
+    await runSearchEvalCandidateReviewWorkflow(
+      { action: "submit-seed", seedLocales: ["en"] },
+      {
+        adminBearer: "eval-key",
+        candidateUrl:
+          "https://admin.internal/api/internal/search-eval/candidates",
+        storeClient,
+        runId: "run-seed",
+      },
+    )
+    await runSearchEvalCandidateReviewWorkflow(
+      {
+        action: "submit-user",
+        userSubmission: {
+          locale: "en",
+          queryText: "videos for new believers",
+          submittedBy: "operator",
+          expectedResultHints: [{ raw: "operator-only hint" }],
+          sourceAnchors: [{ raw: "operator-only source claim" }],
+          notes: "operator-only submission note",
+        },
+      },
+      {
+        adminBearer: "eval-key",
+        candidateUrl:
+          "https://admin.internal/api/internal/search-eval/candidates",
+        storeClient,
+        runId: "run-user",
+      },
+    )
+
+    expect(storeClient).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          candidates: expect.arrayContaining([
+            expect.objectContaining({
+              source: "seed",
+              mastraRunId: "run-seed",
+            }),
+          ]),
+        }),
+      }),
+    )
+    expect(storeClient).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        payload: {
+          candidates: [
+            expect.objectContaining({
+              source: "user_submitted",
+              queryText: "videos for new believers",
+              expectedResultHints: [],
+              sourceAnchors: [],
+              labelProvenance: expect.objectContaining({
+                rawSubmissionPayloadStored: false,
+              }),
+              mastraRunId: "run-user",
+            }),
+          ],
+        },
+      }),
+    )
+    expect(JSON.stringify(storeClient.mock.calls[1])).not.toContain(
+      "operator-only",
+    )
+  })
+
+  it("returns typed config failure instead of using Admin DB when client config is missing", async () => {
+    const result = await runSearchEvalCandidateReviewWorkflow({
+      action: "list",
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "admin_config_missing",
+      retryable: false,
+      adminStatus: undefined,
+      adminReason: undefined,
+    })
+  })
+
+  it("documents native Dataset item shape without native ids", () => {
+    expect(_internal.nativeDatasetItemShape).toMatchObject({
+      targetId: "offline-search-eval",
+      nativeWrites: {
+        datasetId: null,
+        scorerIds: [],
+        experimentIds: [],
+        deferredTo: "feat-142",
+      },
+    })
+  })
+})

--- a/apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts
@@ -1,0 +1,573 @@
+import { randomUUID } from "node:crypto"
+
+import { createStep, createWorkflow } from "@mastra/core/workflows"
+import { z } from "zod"
+
+import { env } from "../../config/env"
+import { isValidServiceBearer } from "../../server/service-bearer"
+import {
+  callAdminCandidateArchive,
+  callAdminCandidateDetail,
+  callAdminCandidateList,
+  callAdminCandidatePromote,
+  callAdminCandidateReject,
+  callAdminCandidateReviewPatch,
+  callAdminCandidateStore,
+  type AdminCandidateDecisionPayload,
+  type AdminCandidateDetailResponse,
+  type AdminCandidateListResponse,
+  type AdminCandidatePromotePayload,
+  type AdminCandidateReviewPatchPayload,
+  type AdminCandidateStoreResponse,
+  type AdminSearchEvalCandidatePayload,
+  type AdminSearchEvalClientResult,
+} from "../../services/admin-search-eval-client"
+import {
+  SEARCH_EVAL_SEED_PROMPTS,
+  SEARCH_EVAL_SEED_PROMPT_SET_VERSION,
+} from "../../services/offline-search-eval/seed-prompt-set"
+
+const SourceSchema = z.enum([
+  "catalog",
+  "locale_quality",
+  "trace",
+  "seed",
+  "user_submitted",
+])
+const StatusSchema = z.enum(["generated", "rejected", "promoted", "archived"])
+const SanitizationStatusSchema = z.enum(["pending", "sanitized", "unsafe"])
+
+export const SearchEvalCandidateReviewWorkflowInputSchema = z
+  .object({
+    action: z.enum([
+      "list",
+      "detail",
+      "edit",
+      "reject",
+      "archive",
+      "promote",
+      "submit-seed",
+      "submit-user",
+    ]),
+    candidateId: z.string().min(1).max(256).optional(),
+    filters: z
+      .object({
+        sources: z.array(SourceSchema).min(1).max(5).optional(),
+        statuses: z.array(StatusSchema).min(1).max(4).optional(),
+        locales: z.array(z.string().min(1).max(32)).min(1).max(30).optional(),
+        mastraRunId: z.string().min(1).max(128).optional(),
+        limit: z.number().int().positive().max(100).optional(),
+      })
+      .strict()
+      .optional(),
+    reviewerIdentity: z.string().min(1).max(256).optional(),
+    sanitizedQueryText: z.string().min(1).max(512).optional(),
+    sanitizedExpectedResultNotes: z.string().max(2048).optional(),
+    sanitizedSourceAnchors: z.array(z.unknown()).optional(),
+    sanitizationStatus: SanitizationStatusSchema.optional(),
+    reviewNotes: z.string().max(2048).optional(),
+    promotionRunContext: z.record(z.string(), z.unknown()).optional(),
+    userSubmission: z
+      .object({
+        locale: z.string().min(1).max(32),
+        queryText: z.string().min(1).max(512),
+        submittedBy: z.string().min(1).max(256).optional(),
+        expectedResultHints: z.array(z.unknown()).optional(),
+        sourceAnchors: z.array(z.unknown()).optional(),
+        notes: z.string().max(2048).optional(),
+      })
+      .strict()
+      .optional(),
+    seedLocales: z.array(z.string().min(1).max(32)).min(1).max(30).optional(),
+  })
+  .strict()
+
+const CandidateReviewFailureReasonSchema = z.enum([
+  "invalid_input",
+  "admin_config_missing",
+  "admin_auth_failed",
+  "admin_read_failed",
+  "admin_read_rejected",
+  "admin_store_failed",
+  "admin_store_rejected",
+  "admin_review_failed",
+  "admin_review_rejected",
+])
+
+const CandidateReviewResultSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      action: SearchEvalCandidateReviewWorkflowInputSchema.shape.action,
+      mastraRunId: z.string(),
+      candidates: z.array(z.unknown()).optional(),
+      candidate: z.unknown().optional(),
+      storeResult: z.unknown().optional(),
+      nativeDatasetItemShape: z.unknown(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      reason: CandidateReviewFailureReasonSchema,
+      retryable: z.boolean(),
+      adminStatus: z.string().optional(),
+      adminReason: z.string().optional(),
+    })
+    .strict(),
+])
+
+export type SearchEvalCandidateReviewWorkflowInput = z.infer<
+  typeof SearchEvalCandidateReviewWorkflowInputSchema
+>
+export type SearchEvalCandidateReviewWorkflowResult = z.infer<
+  typeof CandidateReviewResultSchema
+>
+type CandidateReviewFailure = Extract<
+  SearchEvalCandidateReviewWorkflowResult,
+  { ok: false }
+>
+
+type ClientOptions = {
+  adminBearer?: string
+  candidateUrl?: string
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+  runId?: string
+  listClient?: typeof callAdminCandidateList
+  detailClient?: typeof callAdminCandidateDetail
+  patchClient?: typeof callAdminCandidateReviewPatch
+  rejectClient?: typeof callAdminCandidateReject
+  archiveClient?: typeof callAdminCandidateArchive
+  promoteClient?: typeof callAdminCandidatePromote
+  storeClient?: typeof callAdminCandidateStore
+}
+
+type RouteHandlerInput = {
+  authHeader: string | null | undefined
+  serviceKeys: readonly string[]
+  readJson: () => Promise<unknown>
+  launch?: (
+    input: unknown,
+    options: { runId: string },
+  ) => Promise<SearchEvalCandidateReviewWorkflowResult>
+}
+
+export type SearchEvalCandidateReviewRouteOutcome = {
+  status: number
+  body: { result?: SearchEvalCandidateReviewWorkflowResult; error?: string }
+}
+
+const nativeDatasetItemShape = {
+  targetType: "workflow",
+  targetId: "offline-search-eval",
+  input: {
+    query: "string",
+    locale: "BCP-47 string",
+    source: "seed | generated_* | user_submitted | promoted",
+    searchOptions: {
+      contentType: "video | experience | all",
+      mode: "hybrid | keyword-first",
+    },
+  },
+  groundTruth: {
+    expectedResultNotes: "sanitized operator text",
+    sourceAnchors: "sanitized Admin/Core content anchors",
+  },
+  metadata: {
+    candidateId: "Admin search_eval_candidate id",
+    sanitizationStatus: "sanitized",
+    reviewerIdentity: "operator identity string",
+    reviewedAt: "ISO timestamp",
+    promotedAt: "ISO timestamp",
+    provenance: "safe source/provenance labels only",
+  },
+  nativeWrites: {
+    datasetId: null,
+    scorerIds: [],
+    experimentIds: [],
+    deferredTo: "feat-142",
+  },
+} as const
+
+function failure(
+  reason: CandidateReviewFailure["reason"],
+  options: {
+    retryable: boolean
+    adminStatus?: string
+    adminReason?: string
+  },
+): CandidateReviewFailure {
+  return {
+    ok: false,
+    reason,
+    retryable: options.retryable,
+    adminStatus: options.adminStatus,
+    adminReason: options.adminReason,
+  }
+}
+
+function adminFailure(
+  result: Exclude<
+    AdminSearchEvalClientResult<unknown>,
+    { ok: true; result: unknown }
+  >,
+  operation: "read" | "store" | "review",
+): CandidateReviewFailure {
+  if (result.reason === "config_missing") {
+    return failure("admin_config_missing", { retryable: false })
+  }
+  if (result.reason === "auth_failed") {
+    return failure("admin_auth_failed", {
+      retryable: false,
+      adminStatus: result.status == null ? undefined : String(result.status),
+    })
+  }
+  if (result.reason === "rejected") {
+    const reason =
+      operation === "store"
+        ? "admin_store_rejected"
+        : operation === "review"
+          ? "admin_review_rejected"
+          : "admin_read_rejected"
+    return failure(reason, {
+      retryable: false,
+      adminStatus: result.status == null ? undefined : String(result.status),
+      adminReason: result.adminReason,
+    })
+  }
+  const reason =
+    operation === "store"
+      ? "admin_store_failed"
+      : operation === "review"
+        ? "admin_review_failed"
+        : "admin_read_failed"
+  return failure(reason, {
+    retryable: result.retryable,
+    adminStatus: result.status == null ? undefined : String(result.status),
+    adminReason: result.adminReason,
+  })
+}
+
+function success(
+  input: SearchEvalCandidateReviewWorkflowInput,
+  mastraRunId: string,
+  result:
+    | AdminCandidateListResponse
+    | AdminCandidateDetailResponse
+    | AdminCandidateStoreResponse,
+): SearchEvalCandidateReviewWorkflowResult {
+  if ("candidates" in result && "generatedAt" in result) {
+    return {
+      ok: true,
+      action: input.action,
+      mastraRunId,
+      candidates: result.candidates,
+      nativeDatasetItemShape,
+    }
+  }
+  if ("candidate" in result) {
+    return {
+      ok: true,
+      action: input.action,
+      mastraRunId,
+      candidate: result.candidate,
+      nativeDatasetItemShape,
+    }
+  }
+  return {
+    ok: true,
+    action: input.action,
+    mastraRunId,
+    storeResult: result,
+    nativeDatasetItemShape,
+  }
+}
+
+function clientBase(options: ClientOptions) {
+  return {
+    url: options.candidateUrl ?? env.ADMIN_SEARCH_EVAL_CANDIDATES_URL,
+    bearer: options.adminBearer ?? env.ADMIN_SEARCH_EVAL_API_KEY,
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  }
+}
+
+function decisionPayload(
+  input: SearchEvalCandidateReviewWorkflowInput,
+): AdminCandidateDecisionPayload | null {
+  if (!input.reviewerIdentity) return null
+  return {
+    reviewerIdentity: input.reviewerIdentity,
+    reviewNotes: input.reviewNotes,
+    promotionRunContext: {
+      ...(input.promotionRunContext ?? {}),
+      mastraReviewAction: input.action,
+    },
+  }
+}
+
+function patchPayload(
+  input: SearchEvalCandidateReviewWorkflowInput,
+): AdminCandidateReviewPatchPayload {
+  return {
+    reviewerIdentity: input.reviewerIdentity,
+    sanitizedQueryText: input.sanitizedQueryText,
+    sanitizedExpectedResultNotes: input.sanitizedExpectedResultNotes,
+    sanitizedSourceAnchors: input.sanitizedSourceAnchors,
+    sanitizationStatus: input.sanitizationStatus,
+    reviewNotes: input.reviewNotes,
+    promotionRunContext: {
+      ...(input.promotionRunContext ?? {}),
+      mastraReviewAction: input.action,
+    },
+  }
+}
+
+function promotePayload(
+  input: SearchEvalCandidateReviewWorkflowInput,
+): AdminCandidatePromotePayload | null {
+  const decision = decisionPayload(input)
+  if (!decision) return null
+  return {
+    ...decision,
+    sanitizedQueryText: input.sanitizedQueryText,
+    sanitizedExpectedResultNotes: input.sanitizedExpectedResultNotes,
+    sanitizedSourceAnchors: input.sanitizedSourceAnchors,
+    sanitizationStatus: "sanitized",
+  }
+}
+
+function seedCandidatePayloads(
+  input: SearchEvalCandidateReviewWorkflowInput,
+  mastraRunId: string,
+): AdminSearchEvalCandidatePayload[] {
+  const locales = input.seedLocales ? new Set(input.seedLocales) : null
+  return SEARCH_EVAL_SEED_PROMPTS.filter(
+    (prompt) => locales == null || locales.has(prompt.locale),
+  ).map((prompt) => ({
+    source: "seed",
+    locale: prompt.locale,
+    queryText: prompt.queryText,
+    expectedResultHints: [],
+    sourceAnchors: [
+      {
+        source: "seed_prompt_set",
+        version: SEARCH_EVAL_SEED_PROMPT_SET_VERSION,
+        id: prompt.id,
+        tags: prompt.tags,
+      },
+    ],
+    labelProvenance: {
+      source: "mastra_seed_prompt_set",
+      version: SEARCH_EVAL_SEED_PROMPT_SET_VERSION,
+    },
+    generationModel: SEARCH_EVAL_SEED_PROMPT_SET_VERSION,
+    generationProvider: "mastra",
+    judgeSummary: prompt.operatorNotes
+      ? { operatorNotes: prompt.operatorNotes }
+      : null,
+    mastraRunId,
+    generatedAt: new Date().toISOString(),
+  }))
+}
+
+function userSubmissionPayload(
+  input: SearchEvalCandidateReviewWorkflowInput,
+  mastraRunId: string,
+): AdminSearchEvalCandidatePayload[] | null {
+  if (!input.userSubmission) return null
+  return [
+    {
+      source: "user_submitted",
+      locale: input.userSubmission.locale,
+      queryText: input.userSubmission.queryText,
+      expectedResultHints: [],
+      sourceAnchors: [],
+      labelProvenance: {
+        source: "mastra_operator_submission",
+        submittedByProvided: input.userSubmission.submittedBy != null,
+        notesProvided: input.userSubmission.notes != null,
+        rawSubmissionPayloadStored: false,
+      },
+      generationModel: "user-submitted:v1",
+      generationProvider: "mastra",
+      judgeSummary: null,
+      mastraRunId,
+      generatedAt: new Date().toISOString(),
+    },
+  ]
+}
+
+export async function runSearchEvalCandidateReviewWorkflow(
+  rawInput: unknown,
+  options: ClientOptions = {},
+): Promise<SearchEvalCandidateReviewWorkflowResult> {
+  const parsed =
+    SearchEvalCandidateReviewWorkflowInputSchema.safeParse(rawInput)
+  if (!parsed.success) {
+    return failure("invalid_input", { retryable: false })
+  }
+
+  const input = parsed.data
+  const mastraRunId = options.runId ?? randomUUID()
+  const base = clientBase(options)
+
+  if (input.action === "list") {
+    const result = await (options.listClient ?? callAdminCandidateList)({
+      ...base,
+      filters: input.filters,
+    })
+    return result.ok
+      ? success(input, mastraRunId, result.result)
+      : adminFailure(result, "read")
+  }
+
+  if (input.action === "submit-seed" || input.action === "submit-user") {
+    const candidates =
+      input.action === "submit-seed"
+        ? seedCandidatePayloads(input, mastraRunId)
+        : userSubmissionPayload(input, mastraRunId)
+    if (candidates == null || candidates.length === 0) {
+      return failure("invalid_input", { retryable: false })
+    }
+    const result = await (options.storeClient ?? callAdminCandidateStore)({
+      ...base,
+      payload: { candidates },
+    })
+    return result.ok
+      ? success(input, mastraRunId, result.result)
+      : adminFailure(result, "store")
+  }
+
+  if (!input.candidateId) {
+    return failure("invalid_input", { retryable: false })
+  }
+
+  if (input.action === "detail") {
+    const result = await (options.detailClient ?? callAdminCandidateDetail)({
+      ...base,
+      candidateId: input.candidateId,
+    })
+    return result.ok
+      ? success(input, mastraRunId, result.result)
+      : adminFailure(result, "read")
+  }
+
+  if (input.action === "edit") {
+    const result = await (options.patchClient ?? callAdminCandidateReviewPatch)(
+      {
+        ...base,
+        candidateId: input.candidateId,
+        payload: patchPayload(input),
+      },
+    )
+    return result.ok
+      ? success(input, mastraRunId, result.result)
+      : adminFailure(result, "review")
+  }
+
+  const decision =
+    input.action === "promote" ? promotePayload(input) : decisionPayload(input)
+  if (!decision) return failure("invalid_input", { retryable: false })
+
+  const client =
+    input.action === "promote"
+      ? (options.promoteClient ?? callAdminCandidatePromote)
+      : input.action === "reject"
+        ? (options.rejectClient ?? callAdminCandidateReject)
+        : (options.archiveClient ?? callAdminCandidateArchive)
+  const result = await client({
+    ...base,
+    candidateId: input.candidateId,
+    payload: decision,
+  })
+  return result.ok
+    ? success(input, mastraRunId, result.result)
+    : adminFailure(result, "review")
+}
+
+const searchEvalCandidateReviewStep = createStep({
+  id: "review-search-eval-candidate",
+  description:
+    "Review, sanitize, reject, archive, promote, or submit search eval candidates through Admin HTTP.",
+  inputSchema: SearchEvalCandidateReviewWorkflowInputSchema,
+  outputSchema: CandidateReviewResultSchema,
+  execute: async ({ inputData, runId }) =>
+    runSearchEvalCandidateReviewWorkflow(inputData, { runId }),
+})
+
+export const searchEvalCandidateReviewWorkflow = createWorkflow({
+  id: "search-eval-candidate-review",
+  description:
+    "Human review and promotion workflow for search eval regression candidates.",
+  inputSchema: SearchEvalCandidateReviewWorkflowInputSchema,
+  outputSchema: CandidateReviewResultSchema,
+})
+  .then(searchEvalCandidateReviewStep)
+  .commit()
+
+export async function launchSearchEvalCandidateReviewWorkflow(
+  rawInput: unknown,
+  options: ClientOptions = {},
+): Promise<SearchEvalCandidateReviewWorkflowResult> {
+  const parsed =
+    SearchEvalCandidateReviewWorkflowInputSchema.safeParse(rawInput)
+  if (!parsed.success) {
+    return failure("invalid_input", { retryable: false })
+  }
+  const runId = options.runId ?? randomUUID()
+  const run = await searchEvalCandidateReviewWorkflow.createRun({ runId })
+  const result = await run.start({ inputData: parsed.data }).catch(() => null)
+  if (result?.status === "success") {
+    return result.result as SearchEvalCandidateReviewWorkflowResult
+  }
+  return failure("admin_review_failed", { retryable: true })
+}
+
+function routeStatusForResult(result: SearchEvalCandidateReviewWorkflowResult) {
+  if (result.ok) return 200
+  if (result.reason === "invalid_input") return 400
+  if (result.reason === "admin_config_missing") return 503
+  if (result.reason === "admin_auth_failed") return 502
+  if (
+    result.reason === "admin_read_rejected" ||
+    result.reason === "admin_store_rejected" ||
+    result.reason === "admin_review_rejected"
+  ) {
+    return 409
+  }
+  return 502
+}
+
+export async function handleSearchEvalCandidateReviewRouteRequest({
+  authHeader,
+  serviceKeys,
+  readJson,
+  launch = launchSearchEvalCandidateReviewWorkflow,
+}: RouteHandlerInput): Promise<SearchEvalCandidateReviewRouteOutcome> {
+  if (!isValidServiceBearer({ authHeader, allowlist: serviceKeys })) {
+    return {
+      status: 401,
+      body: { error: "Service bearer required" },
+    }
+  }
+
+  const runId = randomUUID()
+  const body = await readJson().catch(() => undefined)
+  const result =
+    body === undefined
+      ? failure("invalid_input", { retryable: false })
+      : await launch(body, { runId })
+
+  return {
+    status: routeStatusForResult(result),
+    body: { result },
+  }
+}
+
+export const _internal = {
+  nativeDatasetItemShape,
+  seedCandidatePayloads,
+  userSubmissionPayload,
+}

--- a/apps/mastra/src/mastra/workflows/search-eval-native-suite.test.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-native-suite.test.ts
@@ -1,0 +1,171 @@
+import type { DatasetItem, DatasetRecord } from "@mastra/core/storage"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  _internal,
+  handleSearchEvalNativeSuiteRouteRequest,
+  runSearchEvalNativeSuiteWorkflow,
+} from "./search-eval-native-suite"
+import type { NativeSearchEvalMastra } from "../../services/offline-search-eval/native-evaluation"
+
+function fakeMastra(): NativeSearchEvalMastra & {
+  records: DatasetRecord[]
+  items: DatasetItem[]
+} {
+  const now = new Date("2026-05-28T00:00:00.000Z")
+  const records: DatasetRecord[] = []
+  const items: DatasetItem[] = []
+  const scorers: Record<string, unknown> = {}
+  async function addItems(input: {
+    items: Array<{
+      input: unknown
+      groundTruth?: unknown
+      metadata?: Record<string, unknown>
+    }>
+  }) {
+    const added = input.items.map((item, index) => ({
+      id: `item-${index + 1}`,
+      datasetId: "dataset-1",
+      datasetVersion: 1,
+      input: item.input,
+      groundTruth: item.groundTruth,
+      metadata: item.metadata,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    items.push(...added)
+    return added
+  }
+
+  async function updateItem(input: { itemId: string }) {
+    const item = items.find((candidate) => candidate.id === input.itemId)
+    if (!item) throw new Error("not expected")
+    return item
+  }
+
+  const dataset = {
+    id: "dataset-1",
+    addItems,
+    updateItem,
+    async listItems() {
+      return { items }
+    },
+    async listExperiments() {
+      return { experiments: [] }
+    },
+    async startExperiment() {
+      throw new Error("not expected")
+    },
+  }
+
+  return {
+    records,
+    items,
+    datasets: {
+      async list() {
+        return { datasets: records }
+      },
+      async get() {
+        return dataset
+      },
+      async create(input) {
+        records.push({
+          id: "dataset-1",
+          name: input.name,
+          metadata: input.metadata,
+          targetType: "workflow",
+          targetIds: ["offline-search-eval"],
+          scorerIds: ["search-result-pairwise-judge"],
+          version: 1,
+          createdAt: now,
+          updatedAt: now,
+        })
+        return dataset
+      },
+    },
+    listScorers() {
+      return scorers
+    },
+    addScorer(scorer, key) {
+      scorers[key ?? "unknown"] = scorer
+    },
+  } as NativeSearchEvalMastra & {
+    records: DatasetRecord[]
+    items: DatasetItem[]
+  }
+}
+
+describe("search eval native suite workflow", () => {
+  it("syncs promoted candidates through Admin HTTP with promoted filters", async () => {
+    const listClient = vi.fn(async () => ({
+      ok: true as const,
+      result: {
+        candidates: [],
+        generatedAt: "2026-05-28T00:00:00.000Z",
+      },
+    }))
+    const result = await runSearchEvalNativeSuiteWorkflow(
+      { action: "sync-promoted", promotedLimit: 7, environmentLabel: "local" },
+      {
+        mastra: fakeMastra(),
+        adminBearer: "eval-key",
+        candidateUrl:
+          "https://admin.internal/api/internal/search-eval/candidates",
+        listClient,
+        runId: "run-native",
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: "sync-promoted",
+      dataset: expect.objectContaining({
+        name: "search-eval:local:promoted-regression",
+      }),
+    })
+    expect(listClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bearer: "eval-key",
+        url: "https://admin.internal/api/internal/search-eval/candidates",
+        filters: { statuses: ["promoted"], limit: 7 },
+      }),
+    )
+  })
+
+  it("rejects sample data creation for production-like environment labels", async () => {
+    await expect(
+      runSearchEvalNativeSuiteWorkflow(
+        { action: "create-sample-report", environmentLabel: "production" },
+        { mastra: fakeMastra(), runId: "run-native" },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "sample_not_allowed",
+      retryable: false,
+      reportPath: undefined,
+      adminStatus: undefined,
+      adminReason: undefined,
+    })
+  })
+
+  it("requires service bearer auth on the route", async () => {
+    const outcome = await handleSearchEvalNativeSuiteRouteRequest({
+      authHeader: null,
+      serviceKeys: ["service-key"],
+      readJson: async () => ({ action: "sync-promoted" }),
+    })
+
+    expect(outcome).toEqual({
+      status: 401,
+      body: { error: "Service bearer required" },
+    })
+  })
+
+  it("ignores malformed workflow failure envelopes", () => {
+    expect(
+      _internal.workflowFailureFromUnknown(
+        new Error("SEARCH_EVAL_NATIVE_SUITE_FAILED:{not-json"),
+      ),
+    ).toBeNull()
+  })
+})

--- a/apps/mastra/src/mastra/workflows/search-eval-native-suite.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-native-suite.ts
@@ -1,0 +1,578 @@
+import { randomUUID } from "node:crypto"
+
+import { createStep, createWorkflow } from "@mastra/core/workflows"
+import { z } from "zod"
+
+import { env } from "../../config/env"
+import { isValidServiceBearer } from "../../server/service-bearer"
+import {
+  callAdminCandidateList,
+  type AdminCandidateListResponse,
+  type AdminSearchEvalClientResult,
+} from "../../services/admin-search-eval-client"
+import {
+  SearchEvalArtifactError,
+  SearchEvalReportSchema,
+  createSearchEvalArtifactStore,
+  type SearchEvalArtifactStore,
+} from "../../services/offline-search-eval/artifacts"
+import {
+  createSampleSearchEvalReport,
+  isSampleNativeSearchEvalAllowed,
+  searchEvalNativeEnvironmentLabel,
+  syncPromotedCandidatesToNativeDataset,
+  syncSearchEvalReportToNativeEvaluation,
+  withNativeMastraEvaluationProjection,
+  type NativeSearchEvalMastra,
+} from "../../services/offline-search-eval/native-evaluation"
+
+export const SEARCH_EVAL_NATIVE_SUITE_MAX_BODY_BYTES = 8192
+const WORKFLOW_FAILURE_ERROR_PREFIX = "SEARCH_EVAL_NATIVE_SUITE_FAILED:"
+const DEFAULT_SAMPLE_BASELINE_NAME = "local-smoke"
+
+export const SearchEvalNativeSuiteWorkflowInputSchema = z
+  .object({
+    action: z
+      .enum(["create-sample-report", "sync-report", "sync-promoted"])
+      .default("create-sample-report")
+      .describe(
+        "Create a local sample report and native suite, sync an existing report, or sync promoted Admin candidates.",
+      ),
+    reportId: z
+      .string()
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/)
+      .optional()
+      .describe("Report id to sync when action is sync-report."),
+    baselineName: z
+      .string()
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/)
+      .default(DEFAULT_SAMPLE_BASELINE_NAME)
+      .describe("Sample baseline name for create-sample-report."),
+    environmentLabel: z
+      .string()
+      .min(1)
+      .max(64)
+      .optional()
+      .describe("Native Evaluation environment label. Defaults to Mastra env."),
+    promotedLimit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(100)
+      .default(100)
+      .describe("Maximum promoted Admin candidates to sync."),
+  })
+  .strict()
+
+export type SearchEvalNativeSuiteWorkflowInput = z.output<
+  typeof SearchEvalNativeSuiteWorkflowInputSchema
+>
+
+const FailureReasonSchema = z.enum([
+  "invalid_input",
+  "runtime_unavailable",
+  "sample_not_allowed",
+  "artifact_not_found",
+  "artifact_invalid",
+  "artifact_read_failed",
+  "artifact_write_failed",
+  "native_sync_failed",
+  "admin_config_missing",
+  "admin_auth_failed",
+  "admin_read_failed",
+  "admin_read_rejected",
+])
+
+const NativeSuiteResultSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      action: SearchEvalNativeSuiteWorkflowInputSchema.shape.action,
+      mastraRunId: z.string(),
+      environmentLabel: z.string(),
+      reportId: z.string().optional(),
+      reportPath: z.string().optional(),
+      report: SearchEvalReportSchema.optional(),
+      projection: z.unknown().optional(),
+      dataset: z.unknown().optional(),
+      scorer: z.unknown().optional(),
+      experiment: z.unknown().optional(),
+      promoted: z.unknown().optional(),
+      skipped: z.array(z.unknown()).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      reason: FailureReasonSchema,
+      retryable: z.boolean(),
+      reportPath: z.string().optional(),
+      adminStatus: z.string().optional(),
+      adminReason: z.string().optional(),
+    })
+    .strict(),
+])
+
+export type SearchEvalNativeSuiteWorkflowResult = z.infer<
+  typeof NativeSuiteResultSchema
+>
+type SearchEvalNativeSuiteFailure = Extract<
+  SearchEvalNativeSuiteWorkflowResult,
+  { ok: false }
+>
+
+type NativeRuntimeResolver = () => NativeSearchEvalMastra | null | undefined
+let nativeRuntimeResolver: NativeRuntimeResolver | null = null
+
+export function configureSearchEvalNativeSuiteRuntime(
+  resolver: NativeRuntimeResolver,
+) {
+  nativeRuntimeResolver = resolver
+}
+
+type WorkflowOptions = {
+  runId?: string
+  mastra?: NativeSearchEvalMastra
+  artifactStore?: SearchEvalArtifactStore
+  adminBearer?: string
+  candidateUrl?: string
+  listClient?: typeof callAdminCandidateList
+}
+
+type RouteHandlerInput = {
+  authHeader: string | null | undefined
+  serviceKeys: readonly string[]
+  request?: Request
+  readJson?: () => Promise<unknown>
+  launch?: (
+    input: SearchEvalNativeSuiteWorkflowInput,
+    options: { runId: string },
+  ) => Promise<SearchEvalNativeSuiteWorkflowResult>
+}
+
+export type SearchEvalNativeSuiteRouteOutcome = {
+  status: number
+  body: { result?: SearchEvalNativeSuiteWorkflowResult; error?: string }
+}
+
+class SearchEvalNativeSuiteWorkflowFailureError extends Error {
+  constructor(readonly result: SearchEvalNativeSuiteFailure) {
+    super(`${WORKFLOW_FAILURE_ERROR_PREFIX}${JSON.stringify(result)}`)
+    this.name = "SearchEvalNativeSuiteWorkflowFailureError"
+  }
+}
+
+class NativeSuiteRouteBodyError extends Error {
+  constructor(
+    readonly code: "payload_too_large" | "invalid_json",
+    readonly cause?: unknown,
+  ) {
+    super(code)
+    this.name = "NativeSuiteRouteBodyError"
+  }
+}
+
+function failure(
+  reason: SearchEvalNativeSuiteFailure["reason"],
+  options: {
+    retryable: boolean
+    reportPath?: string
+    adminStatus?: string
+    adminReason?: string
+  },
+): SearchEvalNativeSuiteFailure {
+  return {
+    ok: false,
+    reason,
+    retryable: options.retryable,
+    reportPath: options.reportPath,
+    adminStatus: options.adminStatus,
+    adminReason: options.adminReason,
+  }
+}
+
+function throwWorkflowFailure(result: SearchEvalNativeSuiteFailure): never {
+  throw new SearchEvalNativeSuiteWorkflowFailureError(result)
+}
+
+function workflowFailureFromUnknown(
+  value: unknown,
+): SearchEvalNativeSuiteFailure | null {
+  if (value instanceof SearchEvalNativeSuiteWorkflowFailureError) {
+    return value.result
+  }
+  const message =
+    value instanceof Error
+      ? value.message
+      : typeof value === "string"
+        ? value
+        : ""
+  const prefixIndex = message.indexOf(WORKFLOW_FAILURE_ERROR_PREFIX)
+  if (prefixIndex < 0) return null
+  let payload: unknown
+  try {
+    payload = JSON.parse(
+      message.slice(prefixIndex + WORKFLOW_FAILURE_ERROR_PREFIX.length),
+    )
+  } catch {
+    return null
+  }
+  const parsed = NativeSuiteResultSchema.safeParse(payload)
+  return parsed.success && !parsed.data.ok ? parsed.data : null
+}
+
+function resolveMastra(
+  options: WorkflowOptions,
+): NativeSearchEvalMastra | null {
+  return options.mastra ?? nativeRuntimeResolver?.() ?? null
+}
+
+function artifactFailure(error: unknown): SearchEvalNativeSuiteFailure | null {
+  if (!(error instanceof SearchEvalArtifactError)) return null
+  if (error.code === "not_found") {
+    return failure("artifact_not_found", { retryable: false })
+  }
+  if (error.code === "invalid_artifact" || error.code === "invalid_name") {
+    return failure("artifact_invalid", { retryable: false })
+  }
+  if (error.code === "write_failed") {
+    return failure("artifact_write_failed", { retryable: true })
+  }
+  return failure("artifact_read_failed", { retryable: true })
+}
+
+function adminFailure(
+  result: Exclude<
+    AdminSearchEvalClientResult<AdminCandidateListResponse>,
+    { ok: true; result: AdminCandidateListResponse }
+  >,
+): SearchEvalNativeSuiteFailure {
+  if (result.reason === "config_missing") {
+    return failure("admin_config_missing", { retryable: false })
+  }
+  if (result.reason === "auth_failed") {
+    return failure("admin_auth_failed", {
+      retryable: false,
+      adminStatus: result.status == null ? undefined : String(result.status),
+      adminReason: result.adminReason,
+    })
+  }
+  if (result.reason === "rejected") {
+    return failure("admin_read_rejected", {
+      retryable: false,
+      adminStatus: result.status == null ? undefined : String(result.status),
+      adminReason: result.adminReason,
+    })
+  }
+  return failure("admin_read_failed", {
+    retryable: result.retryable,
+    adminStatus: result.status == null ? undefined : String(result.status),
+    adminReason: result.adminReason,
+  })
+}
+
+export async function runSearchEvalNativeSuiteWorkflow(
+  rawInput: unknown,
+  options: WorkflowOptions = {},
+): Promise<SearchEvalNativeSuiteWorkflowResult> {
+  const parsed = SearchEvalNativeSuiteWorkflowInputSchema.safeParse(rawInput)
+  if (!parsed.success) return failure("invalid_input", { retryable: false })
+
+  const input = parsed.data
+  const mastraRunId = options.runId ?? randomUUID()
+  const environmentLabel = searchEvalNativeEnvironmentLabel(
+    input.environmentLabel,
+  )
+  const mastra = resolveMastra(options)
+  if (!mastra) return failure("runtime_unavailable", { retryable: true })
+
+  const artifactStore = options.artifactStore ?? createSearchEvalArtifactStore()
+
+  if (input.action === "create-sample-report") {
+    if (!isSampleNativeSearchEvalAllowed(environmentLabel)) {
+      return failure("sample_not_allowed", { retryable: false })
+    }
+    const report = createSampleSearchEvalReport({
+      runId: mastraRunId,
+      baselineName: input.baselineName,
+    })
+    let reportPath: string
+    try {
+      reportPath = (await artifactStore.writeReport(report)).path
+    } catch (error) {
+      return (
+        artifactFailure(error) ??
+        failure("artifact_write_failed", { retryable: true })
+      )
+    }
+    try {
+      const synced = await syncSearchEvalReportToNativeEvaluation({
+        mastra,
+        report,
+        reportPath,
+        environmentLabel,
+      })
+      const syncedReport = withNativeMastraEvaluationProjection(
+        report,
+        synced.projection,
+      )
+      await artifactStore.writeReport(syncedReport)
+      return {
+        ok: true,
+        action: input.action,
+        mastraRunId,
+        environmentLabel,
+        reportId: report.reportId,
+        reportPath,
+        report: syncedReport,
+        projection: synced.projection,
+        dataset: {
+          datasetId: synced.dataset.datasetId,
+          name: synced.dataset.name,
+          status: synced.dataset.status,
+          itemCount: synced.dataset.itemCount,
+          createdItems: synced.dataset.createdItems,
+          updatedItems: synced.dataset.updatedItems,
+        },
+        scorer: {
+          scorerId: synced.scorer.scorerId,
+          status: synced.scorer.status,
+        },
+        experiment: synced.experiment,
+      }
+    } catch {
+      return failure("native_sync_failed", { retryable: true, reportPath })
+    }
+  }
+
+  if (input.action === "sync-report") {
+    if (!input.reportId) return failure("invalid_input", { retryable: false })
+    try {
+      const report = await artifactStore.readReport(input.reportId)
+      const reportPath = `${artifactStore.rootDir.replace(/\/$/, "")}/reports/${input.reportId}.json`
+      const synced = await syncSearchEvalReportToNativeEvaluation({
+        mastra,
+        report,
+        reportPath,
+        environmentLabel,
+      })
+      const syncedReport = withNativeMastraEvaluationProjection(
+        report,
+        synced.projection,
+      )
+      await artifactStore.writeReport(syncedReport)
+      return {
+        ok: true,
+        action: input.action,
+        mastraRunId,
+        environmentLabel,
+        reportId: report.reportId,
+        reportPath,
+        report: syncedReport,
+        projection: synced.projection,
+        dataset: {
+          datasetId: synced.dataset.datasetId,
+          name: synced.dataset.name,
+          status: synced.dataset.status,
+          itemCount: synced.dataset.itemCount,
+          createdItems: synced.dataset.createdItems,
+          updatedItems: synced.dataset.updatedItems,
+        },
+        scorer: {
+          scorerId: synced.scorer.scorerId,
+          status: synced.scorer.status,
+        },
+        experiment: synced.experiment,
+      }
+    } catch (error) {
+      return (
+        artifactFailure(error) ??
+        failure("native_sync_failed", { retryable: true })
+      )
+    }
+  }
+
+  const result = await (options.listClient ?? callAdminCandidateList)({
+    url: options.candidateUrl ?? env.ADMIN_SEARCH_EVAL_CANDIDATES_URL,
+    bearer: options.adminBearer ?? env.ADMIN_SEARCH_EVAL_API_KEY,
+    filters: { statuses: ["promoted"], limit: input.promotedLimit },
+  })
+  if (!result.ok) return adminFailure(result)
+  try {
+    const synced = await syncPromotedCandidatesToNativeDataset({
+      mastra,
+      candidates: result.result.candidates,
+      environmentLabel,
+    })
+    return {
+      ok: true,
+      action: input.action,
+      mastraRunId,
+      environmentLabel,
+      dataset: {
+        datasetId: synced.dataset.datasetId,
+        name: synced.dataset.name,
+        status: synced.dataset.status,
+        itemCount: synced.dataset.itemCount,
+        createdItems: synced.dataset.createdItems,
+        updatedItems: synced.dataset.updatedItems,
+      },
+      scorer: {
+        scorerId: synced.scorer.scorerId,
+        status: synced.scorer.status,
+      },
+      promoted: { received: result.result.candidates.length },
+      skipped: synced.skipped,
+    }
+  } catch {
+    return failure("native_sync_failed", { retryable: true })
+  }
+}
+
+const nativeSuiteStep = createStep({
+  id: "run-search-eval-native-suite",
+  description:
+    "Project search eval report artifacts and promoted candidates into native Mastra Evaluation records.",
+  inputSchema: SearchEvalNativeSuiteWorkflowInputSchema,
+  outputSchema: NativeSuiteResultSchema,
+  execute: async ({ inputData, runId }) => {
+    const result = await runSearchEvalNativeSuiteWorkflow(inputData, { runId })
+    if (!result.ok) throwWorkflowFailure(result)
+    return result
+  },
+})
+
+export const searchEvalNativeSuiteWorkflow = createWorkflow({
+  id: "search-eval-native-suite",
+  description:
+    "Sync Forge search eval artifacts and promoted truth into native Mastra Evaluation datasets, scorers, and experiments.",
+  inputSchema: SearchEvalNativeSuiteWorkflowInputSchema,
+  outputSchema: NativeSuiteResultSchema,
+})
+  .then(nativeSuiteStep)
+  .commit()
+
+export async function launchSearchEvalNativeSuiteWorkflow(
+  rawInput: SearchEvalNativeSuiteWorkflowInput,
+  options: { runId?: string } = {},
+): Promise<SearchEvalNativeSuiteWorkflowResult> {
+  const parsed = SearchEvalNativeSuiteWorkflowInputSchema.safeParse(rawInput)
+  if (!parsed.success) return failure("invalid_input", { retryable: false })
+  const runId = options.runId ?? randomUUID()
+  const run = await searchEvalNativeSuiteWorkflow.createRun({ runId })
+  let result: Awaited<ReturnType<typeof run.start>>
+  try {
+    result = await run.start({ inputData: parsed.data })
+  } catch (error) {
+    return (
+      workflowFailureFromUnknown(error) ??
+      failure("native_sync_failed", { retryable: true })
+    )
+  }
+  if (result?.status === "success") {
+    return result.result as SearchEvalNativeSuiteWorkflowResult
+  }
+  return failure("native_sync_failed", { retryable: true })
+}
+
+async function readBoundedJson(request: Request): Promise<unknown> {
+  const contentLength = request.headers.get("content-length")
+  if (contentLength != null) {
+    const declaredBytes = Number(contentLength)
+    if (
+      !Number.isFinite(declaredBytes) ||
+      declaredBytes < 0 ||
+      declaredBytes > SEARCH_EVAL_NATIVE_SUITE_MAX_BODY_BYTES
+    ) {
+      throw new NativeSuiteRouteBodyError("payload_too_large")
+    }
+  }
+
+  const body = request.body
+  if (body == null) throw new NativeSuiteRouteBodyError("invalid_json")
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    totalBytes += value.byteLength
+    if (totalBytes > SEARCH_EVAL_NATIVE_SUITE_MAX_BODY_BYTES) {
+      await reader.cancel().catch(() => undefined)
+      throw new NativeSuiteRouteBodyError("payload_too_large")
+    }
+    chunks.push(value)
+  }
+
+  const bytes = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes))
+  } catch (cause) {
+    throw new NativeSuiteRouteBodyError("invalid_json", cause)
+  }
+}
+
+function routeStatusForResult(result: SearchEvalNativeSuiteWorkflowResult) {
+  if (result.ok) return 200
+  if (result.reason === "invalid_input") return 400
+  if (result.reason === "sample_not_allowed") return 403
+  if (result.reason === "runtime_unavailable") return 503
+  if (result.reason === "artifact_not_found") return 404
+  if (result.reason === "artifact_invalid") return 400
+  if (result.reason === "admin_config_missing") return 503
+  if (result.reason === "admin_auth_failed") return 502
+  if (result.reason === "admin_read_rejected") return 409
+  return 502
+}
+
+export async function handleSearchEvalNativeSuiteRouteRequest({
+  authHeader,
+  serviceKeys,
+  request,
+  readJson,
+  launch = launchSearchEvalNativeSuiteWorkflow,
+}: RouteHandlerInput): Promise<SearchEvalNativeSuiteRouteOutcome> {
+  if (!isValidServiceBearer({ authHeader, allowlist: serviceKeys })) {
+    return {
+      status: 401,
+      body: { error: "Service bearer required" },
+    }
+  }
+
+  const runId = randomUUID()
+  let body: unknown
+  try {
+    body = request ? await readBoundedJson(request) : await readJson?.()
+  } catch (error) {
+    return {
+      status:
+        error instanceof NativeSuiteRouteBodyError &&
+        error.code === "payload_too_large"
+          ? 413
+          : 400,
+      body: { result: failure("invalid_input", { retryable: false }) },
+    }
+  }
+  const parsed = SearchEvalNativeSuiteWorkflowInputSchema.safeParse(body)
+  const result = parsed.success
+    ? await launch(parsed.data, { runId }).catch(() =>
+        failure("native_sync_failed", { retryable: true }),
+      )
+    : failure("invalid_input", { retryable: false })
+
+  return {
+    status: routeStatusForResult(result),
+    body: { result },
+  }
+}
+
+export const _internal = {
+  FailureReasonSchema,
+  NativeSuiteResultSchema,
+  workflowFailureFromUnknown,
+}

--- a/apps/mastra/src/services/admin-search-eval-client.test.ts
+++ b/apps/mastra/src/services/admin-search-eval-client.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from "vitest"
 
 import {
+  callAdminCandidateArchive,
+  callAdminCandidateDetail,
   callAdminCandidateStore,
   callAdminCandidateList,
+  callAdminCandidatePromote,
+  callAdminCandidateReject,
+  callAdminCandidateReviewPatch,
   callAdminCatalogContext,
   callAdminEvalSearch,
   callAdminTraceSample,
@@ -94,6 +99,7 @@ const candidateListResponse = {
     {
       id: "candidate-1",
       source: "catalog",
+      promotionStatus: "generated",
       locale: "en",
       queryText: "Jesus",
       expectedResultHints: [],
@@ -102,6 +108,15 @@ const candidateListResponse = {
       generationModel: "seed:v1",
       generationProvider: "mastra",
       judgeSummary: null,
+      sanitizedQueryText: null,
+      sanitizedExpectedResultNotes: null,
+      sanitizedSourceAnchors: [],
+      sanitizationStatus: "pending",
+      reviewerIdentity: null,
+      reviewedAt: null,
+      reviewNotes: null,
+      promotedAt: null,
+      promotionRunContext: {},
       mastraRunId: "run-1",
       retentionExpiresAt: null,
       generatedAt: "2026-05-26T00:00:00.000Z",
@@ -384,6 +399,91 @@ describe("Admin search eval client", () => {
         fetchImpl: vi.fn(async () => Response.json(response)),
       }),
     ).resolves.toEqual({ ok: true, result: response })
+  })
+
+  it("calls candidate detail and review action endpoints", async () => {
+    const detailResponse = { candidate: candidateListResponse.candidates[0] }
+    const fetchImpl = vi.fn(async () => Response.json(detailResponse))
+
+    await expect(
+      callAdminCandidateDetail({
+        url: "https://admin.internal/api/internal/search-eval/candidates",
+        bearer: "eval-key",
+        candidateId: "candidate-1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({ ok: true, result: detailResponse })
+    const firstCall = fetchImpl.mock.calls[0] as unknown as [URL, RequestInit]
+    expect(String(firstCall[0])).toBe(
+      "https://admin.internal/api/internal/search-eval/candidates/candidate-1",
+    )
+    expect(firstCall[1]).toMatchObject({ method: "GET" })
+
+    await callAdminCandidateReviewPatch({
+      url: "https://admin.internal/api/internal/search-eval/candidates",
+      bearer: "eval-key",
+      candidateId: "candidate-1",
+      payload: {
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizationStatus: "sanitized",
+      },
+      fetchImpl,
+    })
+    await callAdminCandidatePromote({
+      url: "https://admin.internal/api/internal/search-eval/candidates",
+      bearer: "eval-key",
+      candidateId: "candidate-1",
+      payload: {
+        reviewerIdentity: "nisal",
+        sanitizedQueryText: "Who is Jesus?",
+        sanitizationStatus: "sanitized",
+      },
+      fetchImpl,
+    })
+    await callAdminCandidateReject({
+      url: "https://admin.internal/api/internal/search-eval/candidates",
+      bearer: "eval-key",
+      candidateId: "candidate-1",
+      payload: { reviewerIdentity: "nisal" },
+      fetchImpl,
+    })
+    await callAdminCandidateArchive({
+      url: "https://admin.internal/api/internal/search-eval/candidates",
+      bearer: "eval-key",
+      candidateId: "candidate-1",
+      payload: { reviewerIdentity: "nisal" },
+      fetchImpl,
+    })
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      new URL(
+        "https://admin.internal/api/internal/search-eval/candidates/candidate-1",
+      ),
+      expect.objectContaining({ method: "PATCH" }),
+    )
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      new URL(
+        "https://admin.internal/api/internal/search-eval/candidates/candidate-1/promote",
+      ),
+      expect.objectContaining({ method: "POST" }),
+    )
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      4,
+      new URL(
+        "https://admin.internal/api/internal/search-eval/candidates/candidate-1/reject",
+      ),
+      expect.objectContaining({ method: "POST" }),
+    )
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      5,
+      new URL(
+        "https://admin.internal/api/internal/search-eval/candidates/candidate-1/archive",
+      ),
+      expect.objectContaining({ method: "POST" }),
+    )
   })
 
   it("retries generated candidate reads on rate limits and transient failures", async () => {

--- a/apps/mastra/src/services/admin-search-eval-client.ts
+++ b/apps/mastra/src/services/admin-search-eval-client.ts
@@ -121,7 +121,7 @@ export type AdminCatalogContextResponse = z.infer<
 >
 
 export type AdminSearchEvalCandidatePayload = {
-  source: "catalog" | "locale_quality" | "trace"
+  source: "catalog" | "locale_quality" | "trace" | "seed" | "user_submitted"
   locale: string
   queryText: string
   expectedResultHints?: unknown[]
@@ -175,7 +175,16 @@ const CandidateListResponseSchema = z
       z
         .object({
           id: z.string(),
-          source: z.enum(["catalog", "locale_quality", "trace"]),
+          source: z.enum([
+            "catalog",
+            "locale_quality",
+            "trace",
+            "seed",
+            "user_submitted",
+          ]),
+          promotionStatus: z
+            .enum(["generated", "rejected", "promoted", "archived"])
+            .optional(),
           locale: z.string(),
           queryText: z.string().nullable(),
           expectedResultHints: z.unknown(),
@@ -184,6 +193,17 @@ const CandidateListResponseSchema = z
           generationModel: z.string(),
           generationProvider: z.string().nullable(),
           judgeSummary: z.unknown().nullable(),
+          sanitizedQueryText: z.string().nullable().optional(),
+          sanitizedExpectedResultNotes: z.string().nullable().optional(),
+          sanitizedSourceAnchors: z.unknown().optional(),
+          sanitizationStatus: z
+            .enum(["pending", "sanitized", "unsafe"])
+            .optional(),
+          reviewerIdentity: z.string().nullable().optional(),
+          reviewedAt: z.string().nullable().optional(),
+          reviewNotes: z.string().nullable().optional(),
+          promotedAt: z.string().nullable().optional(),
+          promotionRunContext: z.unknown().optional(),
           mastraRunId: z.string().nullable(),
           retentionExpiresAt: z.string().nullable(),
           generatedAt: z.string(),
@@ -198,6 +218,39 @@ const CandidateListResponseSchema = z
 export type AdminCandidateListResponse = z.infer<
   typeof CandidateListResponseSchema
 >
+
+const CandidateDetailResponseSchema = z
+  .object({
+    candidate: CandidateListResponseSchema.shape.candidates.element,
+  })
+  .strict()
+
+export type AdminCandidateDetailResponse = z.infer<
+  typeof CandidateDetailResponseSchema
+>
+
+export type AdminCandidateReviewPatchPayload = {
+  reviewerIdentity?: string | null
+  sanitizedQueryText?: string | null
+  sanitizedExpectedResultNotes?: string | null
+  sanitizedSourceAnchors?: unknown
+  sanitizationStatus?: "pending" | "sanitized" | "unsafe"
+  reviewNotes?: string | null
+  promotionRunContext?: unknown
+}
+
+export type AdminCandidateDecisionPayload = {
+  reviewerIdentity: string
+  reviewNotes?: string | null
+  promotionRunContext?: unknown
+}
+
+export type AdminCandidatePromotePayload = AdminCandidateDecisionPayload & {
+  sanitizedQueryText?: string | null
+  sanitizedExpectedResultNotes?: string | null
+  sanitizedSourceAnchors?: unknown
+  sanitizationStatus?: "sanitized"
+}
 
 const CandidateStoreResponseSchema = z
   .object({
@@ -313,6 +366,74 @@ async function postJson<TResult>({
         "content-type": "application/json",
       },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+  } catch {
+    return { ok: false, reason: "network_error", retryable: true }
+  }
+
+  const body = await response.json().catch(() => undefined)
+  if (!response.ok) {
+    const adminReason =
+      body &&
+      typeof body === "object" &&
+      !Array.isArray(body) &&
+      typeof (body as { error?: unknown }).error === "string"
+        ? (body as { error: string }).error
+        : undefined
+    return failureForStatus(response.status, adminReason)
+  }
+
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: "parse_error",
+      retryable: true,
+      status: response.status,
+    }
+  }
+
+  return { ok: true, result: parsed.data }
+}
+
+type JsonRequestInput<TResult> = {
+  url?: string
+  bearer?: string
+  method: "GET" | "PATCH" | "POST"
+  payload?: unknown
+  schema: z.ZodType<TResult>
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}
+
+async function requestJson<TResult>({
+  url,
+  bearer,
+  method,
+  payload,
+  schema,
+  timeoutMs = 30_000,
+  fetchImpl = fetch,
+}: JsonRequestInput<TResult>): Promise<AdminSearchEvalClientResult<TResult>> {
+  if (!url || !bearer) {
+    return { ok: false, reason: "config_missing", retryable: false }
+  }
+
+  let response: Response
+  try {
+    response = await fetchImpl(new URL(url), {
+      method,
+      headers: {
+        authorization: `Bearer ${bearer}`,
+        ...(method === "GET"
+          ? { accept: "application/json" }
+          : {
+              accept: "application/json",
+              "content-type": "application/json",
+            }),
+      },
+      body: method === "GET" ? undefined : JSON.stringify(payload ?? {}),
       signal: AbortSignal.timeout(timeoutMs),
     })
   } catch {
@@ -460,7 +581,10 @@ export async function callAdminCandidateList(input: {
   url?: string
   bearer?: string
   filters?: {
-    sources?: Array<"catalog" | "locale_quality" | "trace">
+    sources?: Array<
+      "catalog" | "locale_quality" | "trace" | "seed" | "user_submitted"
+    >
+    statuses?: Array<"generated" | "rejected" | "promoted" | "archived">
     locales?: string[]
     mastraRunId?: string
     limit?: number
@@ -486,6 +610,9 @@ export async function callAdminCandidateList(input: {
   const requestUrl = new URL(url)
   if (filters?.sources && filters.sources.length > 0) {
     requestUrl.searchParams.set("source", filters.sources.join(","))
+  }
+  if (filters?.statuses && filters.statuses.length > 0) {
+    requestUrl.searchParams.set("status", filters.statuses.join(","))
   }
   if (filters?.locales && filters.locales.length > 0) {
     requestUrl.searchParams.set("locale", filters.locales.join(","))
@@ -585,5 +712,97 @@ export function callAdminCandidateStore(input: {
   return postJson({
     ...input,
     schema: CandidateStoreResponseSchema,
+  })
+}
+
+function candidateActionUrl(
+  baseUrl: string | undefined,
+  candidateId: string,
+  action?: "promote" | "reject" | "archive",
+): string | undefined {
+  if (!baseUrl) return undefined
+  const root = new URL(baseUrl)
+  const pathname = `${root.pathname.replace(/\/$/, "")}/${encodeURIComponent(candidateId)}${action ? `/${action}` : ""}`
+  root.pathname = pathname
+  root.search = ""
+  return root.toString()
+}
+
+export function callAdminCandidateDetail(input: {
+  url?: string
+  bearer?: string
+  candidateId: string
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}): Promise<AdminSearchEvalClientResult<AdminCandidateDetailResponse>> {
+  return requestJson({
+    ...input,
+    method: "GET",
+    url: candidateActionUrl(input.url, input.candidateId),
+    schema: CandidateDetailResponseSchema,
+  })
+}
+
+export function callAdminCandidateReviewPatch(input: {
+  url?: string
+  bearer?: string
+  candidateId: string
+  payload: AdminCandidateReviewPatchPayload
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}): Promise<AdminSearchEvalClientResult<AdminCandidateDetailResponse>> {
+  return requestJson({
+    ...input,
+    method: "PATCH",
+    url: candidateActionUrl(input.url, input.candidateId),
+    schema: CandidateDetailResponseSchema,
+  })
+}
+
+export function callAdminCandidateReject(input: {
+  url?: string
+  bearer?: string
+  candidateId: string
+  payload: AdminCandidateDecisionPayload
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}): Promise<AdminSearchEvalClientResult<AdminCandidateDetailResponse>> {
+  return requestJson({
+    ...input,
+    method: "POST",
+    url: candidateActionUrl(input.url, input.candidateId, "reject"),
+    schema: CandidateDetailResponseSchema,
+  })
+}
+
+export function callAdminCandidateArchive(input: {
+  url?: string
+  bearer?: string
+  candidateId: string
+  payload: AdminCandidateDecisionPayload
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}): Promise<AdminSearchEvalClientResult<AdminCandidateDetailResponse>> {
+  return requestJson({
+    ...input,
+    method: "POST",
+    url: candidateActionUrl(input.url, input.candidateId, "archive"),
+    schema: CandidateDetailResponseSchema,
+  })
+}
+
+export function callAdminCandidatePromote(input: {
+  url?: string
+  bearer?: string
+  candidateId: string
+  payload: AdminCandidatePromotePayload
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}): Promise<AdminSearchEvalClientResult<AdminCandidateDetailResponse>> {
+  return requestJson({
+    ...input,
+    method: "POST",
+    url: candidateActionUrl(input.url, input.candidateId, "promote"),
+    schema: CandidateDetailResponseSchema,
   })
 }

--- a/apps/mastra/src/services/offline-search-eval/artifacts.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/artifacts.test.ts
@@ -83,6 +83,52 @@ describe("search eval artifact store", () => {
     await expect(store.writeReport(report())).resolves.toMatchObject({
       path: expect.stringContaining("reports/run-1.json"),
     })
+    await expect(store.readReport("run-1")).resolves.toEqual(report())
+  })
+
+  it("accepts reports after real native Evaluation records are synced", async () => {
+    const store = createSearchEvalArtifactStore(rootDir)
+    const syncedReport: SearchEvalReport = {
+      ...report(),
+      mastraEvaluation: {
+        integrationStatus: "native_synced",
+        dataset: {
+          name: "search-eval:local:default",
+          datasetId: "dataset-1",
+          source: "seed_prompt_set",
+          version: "seed/v1",
+          itemCount: 0,
+          targetType: "workflow",
+          targetId: "offline-search-eval",
+          environmentLabel: "local",
+          nativeKey: "search-eval:local:default:seed/v1",
+          status: "created",
+        },
+        scorers: [
+          {
+            id: "search-result-pairwise-judge",
+            scorerId: "search-result-pairwise-judge",
+            status: "registered",
+            kind: "pairwise_search_results",
+          },
+        ],
+        experiment: {
+          name: "search-eval-compare:local:default:run-1",
+          experimentId: "experiment-1",
+          status: "created",
+          mode: "comparison",
+          reportId: "run-1",
+          baselineName: "default",
+          environmentLabel: "local",
+          nativeKey: "search-eval:local:default:seed/v1:report:run-1",
+        },
+      },
+    }
+
+    await expect(store.writeReport(syncedReport)).resolves.toMatchObject({
+      path: expect.stringContaining("reports/run-1.json"),
+    })
+    await expect(store.readReport("run-1")).resolves.toEqual(syncedReport)
   })
 
   it("rejects unsafe artifact names", () => {

--- a/apps/mastra/src/services/offline-search-eval/artifacts.ts
+++ b/apps/mastra/src/services/offline-search-eval/artifacts.ts
@@ -109,7 +109,7 @@ const BaselineArtifactSchema = z
   })
   .strict()
 
-const MastraEvaluationProjectionSchema = z
+const ArtifactOnlyMastraEvaluationProjectionSchema = z
   .object({
     integrationStatus: z.literal("custom_artifact_only"),
     dataset: z
@@ -148,6 +148,59 @@ const MastraEvaluationProjectionSchema = z
       .strict(),
   })
   .strict()
+
+const NativeSyncedMastraEvaluationProjectionSchema = z
+  .object({
+    integrationStatus: z.literal("native_synced"),
+    dataset: z
+      .object({
+        name: z.string().max(256),
+        datasetId: z.string().min(1).max(256),
+        source: z.literal("seed_prompt_set"),
+        version: z.string().max(128),
+        itemCount: z.number().int().nonnegative().max(MAX_BASELINE_CASES),
+        targetType: z.literal("workflow"),
+        targetId: z.literal("offline-search-eval"),
+        environmentLabel: z.string().min(1).max(64),
+        nativeKey: z.string().min(1).max(512),
+        status: z.enum(["created", "updated", "reused"]),
+      })
+      .strict(),
+    scorers: z
+      .array(
+        z
+          .object({
+            id: z.literal("search-result-pairwise-judge"),
+            scorerId: z.string().min(1).max(256),
+            status: z.enum(["registered", "reused"]),
+            kind: z.literal("pairwise_search_results"),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(10),
+    experiment: z
+      .object({
+        name: z.string().max(256),
+        experimentId: z.string().min(1).max(256),
+        status: z.enum(["created", "reused"]),
+        mode: z.enum(["baseline_capture", "comparison"]),
+        reportId: z.string().max(128),
+        baselineName: z.string().max(128),
+        environmentLabel: z.string().min(1).max(64),
+        nativeKey: z.string().min(1).max(512),
+      })
+      .strict(),
+  })
+  .strict()
+
+const MastraEvaluationProjectionSchema = z.discriminatedUnion(
+  "integrationStatus",
+  [
+    ArtifactOnlyMastraEvaluationProjectionSchema,
+    NativeSyncedMastraEvaluationProjectionSchema,
+  ],
+)
 
 const ComparisonOutcomeSchema = z
   .object({
@@ -261,8 +314,18 @@ export const SearchEvalReportSchema = z
       report.kind === "baseline-report" ? "baseline_capture" : "comparison"
     const expectedExperimentVerb =
       report.kind === "baseline-report" ? "baseline" : "compare"
-    const expectedDatasetName = `search-eval:${report.metadata.baselineName}`
-    const expectedExperimentName = `search-eval-${expectedExperimentVerb}:${report.metadata.baselineName}:${report.reportId}`
+    const environmentLabel =
+      report.mastraEvaluation.integrationStatus === "native_synced"
+        ? report.mastraEvaluation.dataset.environmentLabel
+        : null
+    const expectedDatasetName =
+      environmentLabel == null
+        ? `search-eval:${report.metadata.baselineName}`
+        : `search-eval:${environmentLabel}:${report.metadata.baselineName}`
+    const expectedExperimentName =
+      environmentLabel == null
+        ? `search-eval-${expectedExperimentVerb}:${report.metadata.baselineName}:${report.reportId}`
+        : `search-eval-${expectedExperimentVerb}:${environmentLabel}:${report.metadata.baselineName}:${report.reportId}`
 
     if (report.mastraEvaluation.dataset.name !== expectedDatasetName) {
       context.addIssue({
@@ -319,6 +382,16 @@ export const SearchEvalReportSchema = z
         message: "experiment baseline name must match report metadata",
       })
     }
+    if (
+      report.mastraEvaluation.integrationStatus === "native_synced" &&
+      report.mastraEvaluation.experiment.environmentLabel !== environmentLabel
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["mastraEvaluation", "experiment", "environmentLabel"],
+        message: "experiment environment must match dataset environment",
+      })
+    }
 
     report.exploratoryGenerated.forEach((outcome, index) => {
       if (!outcome.traceDerived) return
@@ -367,6 +440,7 @@ export type SearchEvalArtifactStore = {
   writeBaseline: (baseline: BaselineArtifact) => Promise<{ path: string }>
   readBaseline: (name: string) => Promise<BaselineArtifact>
   writeReport: (report: SearchEvalReport) => Promise<{ path: string }>
+  readReport: (reportId: string) => Promise<SearchEvalReport>
 }
 
 export function searchEvalArtifactRoot() {
@@ -499,6 +573,46 @@ export function createSearchEvalArtifactStore(
       const filePath = reportPath(rootDir, report.reportId)
       await writeJson(filePath, parsed.data)
       return { path: filePath }
+    },
+    async readReport(reportId) {
+      const filePath = reportPath(rootDir, reportId)
+      let text: string
+      try {
+        text = await readFile(filePath, "utf8")
+      } catch (cause) {
+        if (!isNodeErrorCode(cause, "ENOENT")) {
+          throw new SearchEvalArtifactError(
+            "read_failed",
+            `report '${reportId}' could not be read`,
+            cause,
+          )
+        }
+        throw new SearchEvalArtifactError(
+          "not_found",
+          `report '${reportId}' was not found`,
+          cause,
+        )
+      }
+
+      let payload: unknown
+      try {
+        payload = JSON.parse(text)
+      } catch (cause) {
+        throw new SearchEvalArtifactError(
+          "invalid_artifact",
+          `report '${reportId}' is not valid JSON`,
+          cause,
+        )
+      }
+      const parsed = SearchEvalReportSchema.safeParse(payload)
+      if (!parsed.success) {
+        throw new SearchEvalArtifactError(
+          "invalid_artifact",
+          `report '${reportId}' failed artifact validation`,
+          parsed.error,
+        )
+      }
+      return parsed.data
     },
   }
 }

--- a/apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts
@@ -1,0 +1,432 @@
+import type {
+  DatasetItem,
+  DatasetRecord,
+  Experiment,
+} from "@mastra/core/storage"
+import { describe, expect, it } from "vitest"
+
+import type { AdminCandidateListResponse } from "../admin-search-eval-client"
+import {
+  NativeSearchEvalInputSchema,
+  createSampleSearchEvalReport,
+  scoreForOutcomeKind,
+  searchResultPairwiseJudgeScorer,
+  syncPromotedCandidatesToNativeDataset,
+  syncSearchEvalReportToNativeEvaluation,
+  type NativeSearchEvalMastra,
+} from "./native-evaluation"
+
+function fakeRecord(input: {
+  id: string
+  name: string
+  metadata?: Record<string, unknown>
+}): DatasetRecord {
+  const now = new Date("2026-05-28T00:00:00.000Z")
+  return {
+    id: input.id,
+    name: input.name,
+    metadata: input.metadata,
+    targetType: "workflow",
+    targetIds: ["offline-search-eval"],
+    scorerIds: ["search-result-pairwise-judge"],
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function createFakeMastra(): NativeSearchEvalMastra & {
+  records: DatasetRecord[]
+  datasetsById: Map<string, FakeDataset>
+  scorers: Record<string, unknown>
+} {
+  const records: DatasetRecord[] = []
+  const datasetsById = new Map<string, FakeDataset>()
+  const scorers: Record<string, unknown> = {}
+  const mastra = {
+    records,
+    datasetsById,
+    scorers,
+    datasets: {
+      async list(args?: { page?: number; perPage?: number }) {
+        return { datasets: paginate(records, args) }
+      },
+      async get({ id }: { id: string }) {
+        const dataset = datasetsById.get(id)
+        if (!dataset) throw new Error(`missing dataset ${id}`)
+        return dataset
+      },
+      async create(input: {
+        name: string
+        metadata?: Record<string, unknown>
+      }) {
+        const id = `dataset-${records.length + 1}`
+        const record = fakeRecord({
+          id,
+          name: input.name,
+          metadata: input.metadata,
+        })
+        records.push(record)
+        const dataset = new FakeDataset(record)
+        datasetsById.set(id, dataset)
+        return dataset
+      },
+    },
+    listScorers() {
+      return scorers
+    },
+    addScorer(scorer: unknown, key?: string) {
+      scorers[key ?? "unknown"] = scorer
+    },
+  }
+  return mastra as NativeSearchEvalMastra & {
+    records: DatasetRecord[]
+    datasetsById: Map<string, FakeDataset>
+    scorers: Record<string, unknown>
+  }
+}
+
+class FakeDataset {
+  readonly id: string
+  readonly items: DatasetItem[] = []
+  readonly experiments: Experiment[] = []
+
+  constructor(private readonly record: DatasetRecord) {
+    this.id = record.id
+  }
+
+  async update(input: { name?: string; metadata?: Record<string, unknown> }) {
+    if (input.name) this.record.name = input.name
+    if (input.metadata) this.record.metadata = input.metadata
+    return this.record
+  }
+
+  async addItems(input: {
+    items: Array<{
+      input: unknown
+      groundTruth?: unknown
+      metadata?: Record<string, unknown>
+    }>
+  }) {
+    const now = new Date("2026-05-28T00:00:00.000Z")
+    const added = input.items.map((item, index) => ({
+      id: `item-${this.items.length + index + 1}`,
+      datasetId: this.id,
+      datasetVersion: 1,
+      input: item.input,
+      groundTruth: item.groundTruth,
+      metadata: item.metadata,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    this.items.push(...added)
+    return added
+  }
+
+  async updateItem(input: {
+    itemId: string
+    input?: unknown
+    groundTruth?: unknown
+    metadata?: Record<string, unknown>
+  }) {
+    const item = this.items.find((candidate) => candidate.id === input.itemId)
+    if (!item) throw new Error(`missing item ${input.itemId}`)
+    item.input = input.input
+    item.groundTruth = input.groundTruth
+    item.metadata = input.metadata
+    return item
+  }
+
+  async listItems(args?: { page?: number; perPage?: number }) {
+    return { items: paginate(this.items, args) }
+  }
+
+  async listExperiments(args?: { page?: number; perPage?: number }) {
+    return { experiments: paginate(this.experiments, args) }
+  }
+
+  async startExperiment(config: {
+    name?: string
+    targetType?: "workflow"
+    targetId?: string
+    metadata?: Record<string, unknown>
+    task?: (args: {
+      input: unknown
+      groundTruth?: unknown
+      metadata?: Record<string, unknown>
+    }) => Promise<unknown> | unknown
+  }) {
+    for (const item of this.items) {
+      await config.task?.({
+        input: item.input,
+        groundTruth: item.groundTruth,
+        metadata: item.metadata,
+      })
+    }
+    const now = new Date("2026-05-28T00:00:00.000Z")
+    const experiment: Experiment = {
+      id: `experiment-${this.experiments.length + 1}`,
+      name: config.name,
+      metadata: config.metadata,
+      datasetId: this.id,
+      datasetVersion: 1,
+      targetType: config.targetType ?? "workflow",
+      targetId: config.targetId ?? "offline-search-eval",
+      status: "completed",
+      totalItems: this.items.length,
+      succeededCount: this.items.length,
+      failedCount: 0,
+      skippedCount: 0,
+      startedAt: now,
+      completedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }
+    this.experiments.push(experiment)
+    return {
+      experimentId: experiment.id,
+      status: experiment.status,
+      totalItems: experiment.totalItems,
+      succeededCount: experiment.succeededCount,
+      failedCount: experiment.failedCount,
+      skippedCount: experiment.skippedCount,
+    }
+  }
+}
+
+function paginate<T>(
+  records: T[],
+  args?: { page?: number; perPage?: number },
+): T[] {
+  if (args?.perPage == null) return records
+  const page = args.page ?? 0
+  const start = page * args.perPage
+  return records.slice(start, start + args.perPage)
+}
+
+describe("native search eval projection", () => {
+  it("maps search outcome categories to native numeric scores with reasons", async () => {
+    expect(scoreForOutcomeKind("win")).toBe(1)
+    expect(scoreForOutcomeKind("tie")).toBe(0.5)
+    expect(scoreForOutcomeKind("both-irrelevant")).toBe(0.5)
+    expect(scoreForOutcomeKind("judge-disagreement")).toBe(0.5)
+    expect(scoreForOutcomeKind("loss")).toBe(0)
+    expect(scoreForOutcomeKind("judge-failure")).toBe(0)
+    expect(scoreForOutcomeKind("search-failure")).toBe(0)
+
+    const result = await searchResultPairwiseJudgeScorer.run({
+      input: NativeSearchEvalInputSchema.parse({
+        query: "Who is Jesus?",
+        locale: "en",
+        source: "seed",
+        searchOptions: { limit: 5, mode: "hybrid", contentType: "all" },
+      }),
+      output: {
+        outcomeKind: "judge-disagreement",
+        caseId: "seed-1",
+        locale: "en",
+        query: "Who is Jesus?",
+        baselineTopResults: [],
+        currentTopResults: [],
+        rationale: "The swapped comparison disagreed with the forward pass.",
+        verdicts: ["clearly-A-better", "tie"],
+        failureCode: null,
+      },
+    })
+
+    expect(result.score).toBe(0.5)
+    expect(result.reason).toContain("judge-disagreement")
+  })
+
+  it("syncs a report into native records idempotently", async () => {
+    const mastra = createFakeMastra()
+    const report = createSampleSearchEvalReport({
+      runId: "sample-run-1",
+      now: new Date("2026-05-28T00:00:00.000Z"),
+    })
+
+    const first = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report,
+      reportPath: ".mastra/storage/search-eval/reports/sample-run-1.json",
+      environmentLabel: "local",
+    })
+    const second = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report,
+      reportPath: ".mastra/storage/search-eval/reports/sample-run-1.json",
+      environmentLabel: "local",
+    })
+
+    expect(first.projection.integrationStatus).toBe("native_synced")
+    expect(first.dataset.status).toBe("created")
+    expect(first.dataset.createdItems).toBe(3)
+    expect(first.experiment.status).toBe("created")
+    expect(second.dataset.status).toBe("updated")
+    expect(second.dataset.createdItems).toBe(0)
+    expect(second.dataset.updatedItems).toBe(3)
+    expect(second.experiment.status).toBe("reused")
+    expect(mastra.records).toHaveLength(1)
+    expect(mastra.datasetsById.get("dataset-1")?.items).toHaveLength(3)
+    expect(mastra.datasetsById.get("dataset-1")?.experiments).toHaveLength(1)
+  })
+
+  it("reuses native records beyond the first list page", async () => {
+    const mastra = createFakeMastra()
+    for (let index = 0; index < 200; index++) {
+      mastra.records.push(
+        fakeRecord({
+          id: `unrelated-${index}`,
+          name: `unrelated-${index}`,
+          metadata: {
+            forgeSearchEval: { nativeKey: `unrelated:${index}` },
+          },
+        }),
+      )
+    }
+    const report = createSampleSearchEvalReport({
+      runId: "sample-run-1",
+      now: new Date("2026-05-28T00:00:00.000Z"),
+    })
+
+    const first = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report,
+      environmentLabel: "local",
+    })
+    const second = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report,
+      environmentLabel: "local",
+    })
+
+    expect(first.dataset.status).toBe("created")
+    expect(second.dataset.datasetId).toBe(first.dataset.datasetId)
+    expect(second.dataset.status).toBe("updated")
+    expect(mastra.records).toHaveLength(201)
+  })
+
+  it("keeps report Dataset items stable across repeated sample reports", async () => {
+    const mastra = createFakeMastra()
+    const firstReport = createSampleSearchEvalReport({
+      runId: "sample-run-1",
+      now: new Date("2026-05-28T00:00:00.000Z"),
+    })
+    const secondReport = createSampleSearchEvalReport({
+      runId: "sample-run-2",
+      now: new Date("2026-05-28T00:01:00.000Z"),
+    })
+
+    const first = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report: firstReport,
+      environmentLabel: "local",
+    })
+    const second = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report: secondReport,
+      environmentLabel: "local",
+    })
+
+    expect(second.dataset.datasetId).toBe(first.dataset.datasetId)
+    expect(second.dataset.createdItems).toBe(0)
+    expect(second.dataset.updatedItems).toBe(3)
+    expect(mastra.records).toHaveLength(1)
+    expect(mastra.datasetsById.get("dataset-1")?.items).toHaveLength(3)
+    expect(mastra.datasetsById.get("dataset-1")?.experiments).toHaveLength(2)
+  })
+
+  it("keeps only sanitized promoted candidates in native datasets", async () => {
+    const mastra = createFakeMastra()
+    const candidates = [
+      {
+        id: "candidate-1",
+        source: "trace",
+        promotionStatus: "promoted",
+        locale: "en",
+        queryText: "raw trace query",
+        expectedResultHints: [],
+        sourceAnchors: [{ raw: true }],
+        labelProvenance: {},
+        generationModel: "model",
+        generationProvider: null,
+        judgeSummary: null,
+        sanitizedQueryText: "safe promoted query",
+        sanitizedExpectedResultNotes: "Expect a Jesus Film result.",
+        sanitizedSourceAnchors: [{ type: "video", id: "video-1" }],
+        sanitizationStatus: "sanitized",
+        reviewerIdentity: "operator@example.com",
+        reviewedAt: "2026-05-28T00:00:00.000Z",
+        reviewNotes: null,
+        promotedAt: "2026-05-28T00:01:00.000Z",
+        promotionRunContext: { safeKey: "safe value" },
+        mastraRunId: "run-1",
+        retentionExpiresAt: null,
+        generatedAt: "2026-05-28T00:00:00.000Z",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      },
+      {
+        id: "candidate-2",
+        source: "catalog",
+        promotionStatus: "generated",
+        locale: "en",
+        queryText: "pending generated query",
+        expectedResultHints: [],
+        sourceAnchors: [],
+        labelProvenance: {},
+        generationModel: "model",
+        generationProvider: null,
+        judgeSummary: null,
+        mastraRunId: "run-2",
+        retentionExpiresAt: null,
+        generatedAt: "2026-05-28T00:00:00.000Z",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      },
+      {
+        id: "candidate-3",
+        source: "catalog",
+        promotionStatus: "promoted",
+        locale: "en",
+        queryText: "unsafe promoted query",
+        expectedResultHints: [],
+        sourceAnchors: [],
+        labelProvenance: {},
+        generationModel: "model",
+        generationProvider: null,
+        judgeSummary: null,
+        sanitizedQueryText: null,
+        sanitizedExpectedResultNotes: null,
+        sanitizedSourceAnchors: [],
+        sanitizationStatus: "unsafe",
+        reviewerIdentity: null,
+        reviewedAt: null,
+        reviewNotes: null,
+        promotedAt: null,
+        promotionRunContext: {},
+        mastraRunId: "run-3",
+        retentionExpiresAt: null,
+        generatedAt: "2026-05-28T00:00:00.000Z",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      },
+    ] satisfies AdminCandidateListResponse["candidates"]
+
+    const result = await syncPromotedCandidatesToNativeDataset({
+      mastra,
+      candidates,
+      environmentLabel: "local",
+    })
+    const item = mastra.datasetsById.get("dataset-1")?.items[0]
+
+    expect(result.dataset.createdItems).toBe(1)
+    expect(result.skipped).toEqual([
+      { candidateId: "candidate-2", reason: "not_promoted" },
+      { candidateId: "candidate-3", reason: "not_sanitized" },
+    ])
+    expect(item?.input).toMatchObject({
+      query: "safe promoted query",
+      source: "generated_trace",
+    })
+    expect(JSON.stringify(item?.metadata)).not.toContain("raw trace query")
+    expect(JSON.stringify(item?.metadata)).not.toContain("safe value")
+  })
+})

--- a/apps/mastra/src/services/offline-search-eval/native-evaluation.ts
+++ b/apps/mastra/src/services/offline-search-eval/native-evaluation.ts
@@ -1,0 +1,1049 @@
+import { createScorer, type MastraScorer } from "@mastra/core/evals"
+import type {
+  DatasetItem,
+  DatasetRecord,
+  Experiment,
+} from "@mastra/core/storage"
+import { z } from "zod"
+
+import type { AdminCandidateListResponse } from "../admin-search-eval-client"
+import { env } from "../../config/env"
+import { finalizeReport } from "./report"
+import type {
+  ComparisonOutcome,
+  MastraEvaluationProjection,
+  NativeSyncedMastraEvaluationProjection,
+  ReportOutcomeKind,
+  SearchEvalReport,
+  SearchEvalResult,
+} from "./types"
+
+export const SEARCH_RESULT_PAIRWISE_SCORER_ID =
+  "search-result-pairwise-judge" as const
+const NATIVE_SEARCH_EVAL_TARGET_ID = "offline-search-eval" as const
+const SAMPLE_PROMPT_SET_VERSION = "sample/search-eval/v1"
+const NATIVE_LIST_PAGE_SIZE = 200
+const MAX_NATIVE_LIST_PAGES = 25
+
+type NativeScorer = MastraScorer<
+  string,
+  unknown,
+  unknown,
+  Record<string, unknown>
+>
+
+const SearchEvalNativeResultSchema = z
+  .object({
+    type: z.enum(["video", "experience"]),
+    id: z.string(),
+    slug: z.string(),
+    title: z.string(),
+    score: z.number(),
+    label: z.string().nullable(),
+  })
+  .strict()
+
+export const NativeSearchEvalInputSchema = z
+  .object({
+    query: z.string(),
+    locale: z.string(),
+    source: z.enum([
+      "seed",
+      "generated_catalog",
+      "generated_locale_quality",
+      "generated_trace",
+      "user_submitted",
+      "promoted",
+    ]),
+    searchOptions: z
+      .object({
+        limit: z.number().int().positive(),
+        mode: z.enum(["hybrid", "keyword-first"]),
+        contentType: z.enum(["all", "video", "experience"]),
+      })
+      .strict(),
+  })
+  .strict()
+
+export const NativeSearchEvalGroundTruthSchema = z
+  .object({
+    expectedResultNotes: z.string().nullable(),
+    sourceAnchors: z.array(z.unknown()),
+    baselineTopResults: z.array(SearchEvalNativeResultSchema).optional(),
+  })
+  .strict()
+
+export const NativeSearchEvalOutputSchema = z
+  .object({
+    outcomeKind: z.enum([
+      "win",
+      "loss",
+      "tie",
+      "both-irrelevant",
+      "judge-disagreement",
+      "judge-failure",
+      "search-failure",
+    ]),
+    caseId: z.string(),
+    locale: z.string(),
+    query: z.string(),
+    baselineTopResults: z.array(SearchEvalNativeResultSchema),
+    currentTopResults: z.array(SearchEvalNativeResultSchema),
+    rationale: z.string().nullable(),
+    verdicts: z.array(z.string()).nullable(),
+    failureCode: z.string().nullable(),
+  })
+  .strict()
+
+export type NativeSearchEvalInput = z.infer<typeof NativeSearchEvalInputSchema>
+export type NativeSearchEvalGroundTruth = z.infer<
+  typeof NativeSearchEvalGroundTruthSchema
+>
+export type NativeSearchEvalOutput = z.infer<
+  typeof NativeSearchEvalOutputSchema
+>
+
+type NativeDatasetLike = {
+  id: string
+  getDetails?: () => Promise<DatasetRecord>
+  update?: (input: {
+    name?: string
+    description?: string
+    metadata?: Record<string, unknown>
+    inputSchema?: unknown
+    groundTruthSchema?: unknown
+    targetType?: "workflow"
+    targetIds?: string[]
+    scorerIds?: string[]
+  }) => Promise<unknown>
+  addItems: (input: {
+    items: Array<{
+      input: unknown
+      groundTruth?: unknown
+      metadata?: Record<string, unknown>
+      source?: { type: "json"; referenceId?: string }
+    }>
+  }) => Promise<DatasetItem[]>
+  updateItem: (input: {
+    itemId: string
+    input?: unknown
+    groundTruth?: unknown
+    metadata?: Record<string, unknown>
+  }) => Promise<DatasetItem>
+  listItems: (args?: {
+    page?: number
+    perPage?: number
+  }) => Promise<DatasetItem[] | { items: DatasetItem[] }>
+  listExperiments: (args?: {
+    page?: number
+    perPage?: number
+  }) => Promise<{ experiments: Experiment[] }>
+  startExperiment: <I = unknown, O = unknown, E = unknown>(config: {
+    name?: string
+    description?: string
+    targetType?: "workflow"
+    targetId?: string
+    task?: (args: {
+      input: I
+      groundTruth?: E
+      metadata?: Record<string, unknown>
+    }) => O | Promise<O>
+    scorers?: Array<string | NativeScorer>
+    metadata?: Record<string, unknown>
+    maxConcurrency?: number
+    itemTimeout?: number
+    maxRetries?: number
+  }) => Promise<{
+    experimentId: string
+    status: "pending" | "running" | "completed" | "failed"
+    totalItems: number
+    succeededCount: number
+    failedCount: number
+    skippedCount: number
+  }>
+}
+
+export type NativeSearchEvalMastra = {
+  datasets: {
+    list: (args?: {
+      page?: number
+      perPage?: number
+    }) => Promise<{ datasets: DatasetRecord[] }>
+    get: (args: { id: string }) => Promise<NativeDatasetLike>
+    create: (input: {
+      name: string
+      description?: string
+      inputSchema?: unknown
+      groundTruthSchema?: unknown
+      metadata?: Record<string, unknown>
+      targetType?: "workflow"
+      targetIds?: string[]
+      scorerIds?: string[]
+    }) => Promise<NativeDatasetLike>
+  }
+  listScorers?: () => Record<string, unknown> | undefined
+  addScorer?: (scorer: NativeScorer, key?: string) => void
+}
+
+type SyncDatasetOutcome = {
+  dataset: NativeDatasetLike
+  datasetId: string
+  name: string
+  nativeKey: string
+  itemCount: number
+  status: "created" | "updated" | "reused"
+  createdItems: number
+  updatedItems: number
+}
+
+type ScorerRegistrationOutcome = {
+  scorer: NativeScorer
+  scorerId: typeof SEARCH_RESULT_PAIRWISE_SCORER_ID
+  status: "registered" | "reused"
+}
+
+type ExperimentOutcome = {
+  experimentId: string
+  name: string
+  nativeKey: string
+  status: "created" | "reused"
+}
+
+export type NativeSearchEvalSyncResult = {
+  projection: NativeSyncedMastraEvaluationProjection
+  dataset: SyncDatasetOutcome
+  scorer: ScorerRegistrationOutcome
+  experiment: ExperimentOutcome
+}
+
+export type PromotedSearchEvalSyncResult = {
+  dataset: SyncDatasetOutcome
+  scorer: ScorerRegistrationOutcome
+  skipped: Array<{ candidateId: string; reason: string }>
+}
+
+type Candidate = AdminCandidateListResponse["candidates"][number]
+
+export function searchEvalNativeEnvironmentLabel(
+  explicitLabel?: string,
+): string {
+  const raw =
+    explicitLabel ??
+    env.MASTRA_NATIVE_EVAL_ENVIRONMENT ??
+    env.NODE_ENV ??
+    "development"
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+  return normalized.length > 0 ? normalized.slice(0, 64) : "development"
+}
+
+export function isSampleNativeSearchEvalAllowed(environmentLabel: string) {
+  if (env.NODE_ENV === "production") return false
+  return !["prod", "production"].includes(environmentLabel)
+}
+
+export function scoreForOutcomeKind(kind: ReportOutcomeKind): number {
+  if (kind === "win") return 1
+  if (kind === "tie" || kind === "both-irrelevant") return 0.5
+  if (kind === "judge-disagreement") return 0.5
+  return 0
+}
+
+export const searchResultPairwiseJudgeScorer = createScorer({
+  id: SEARCH_RESULT_PAIRWISE_SCORER_ID,
+  name: "Search result pairwise judge",
+  description:
+    "Scores baseline-vs-current search eval outcomes while preserving search-specific result categories.",
+  type: {
+    input: NativeSearchEvalInputSchema,
+    output: NativeSearchEvalOutputSchema,
+  },
+})
+  .generateScore(({ run }) => scoreForOutcomeKind(run.output.outcomeKind))
+  .generateReason(({ run, score }) => {
+    const failure = run.output.failureCode
+      ? ` Failure code: ${run.output.failureCode}.`
+      : ""
+    const rationale = run.output.rationale ? ` ${run.output.rationale}` : ""
+    return `Outcome ${run.output.outcomeKind} mapped to native score ${score}.${failure}${rationale}`
+  })
+
+export function registerSearchEvalScorer(
+  mastra: NativeSearchEvalMastra,
+): ScorerRegistrationOutcome {
+  const existing = mastra.listScorers?.() ?? {}
+  if (
+    Object.hasOwn(existing, SEARCH_RESULT_PAIRWISE_SCORER_ID) ||
+    Object.values(existing).some(
+      (scorer) =>
+        scorer != null &&
+        typeof scorer === "object" &&
+        "id" in scorer &&
+        (scorer as { id?: unknown }).id === SEARCH_RESULT_PAIRWISE_SCORER_ID,
+    )
+  ) {
+    return {
+      scorer: searchResultPairwiseJudgeScorer as unknown as NativeScorer,
+      scorerId: SEARCH_RESULT_PAIRWISE_SCORER_ID,
+      status: "reused",
+    }
+  }
+
+  mastra.addScorer?.(
+    searchResultPairwiseJudgeScorer as unknown as NativeScorer,
+    SEARCH_RESULT_PAIRWISE_SCORER_ID,
+  )
+  return {
+    scorer: searchResultPairwiseJudgeScorer as unknown as NativeScorer,
+    scorerId: SEARCH_RESULT_PAIRWISE_SCORER_ID,
+    status: "registered",
+  }
+}
+
+export async function syncSearchEvalReportToNativeEvaluation(input: {
+  mastra: NativeSearchEvalMastra
+  report: SearchEvalReport
+  reportPath?: string
+  environmentLabel?: string
+}): Promise<NativeSearchEvalSyncResult> {
+  const environmentLabel = searchEvalNativeEnvironmentLabel(
+    input.environmentLabel,
+  )
+  const scorer = registerSearchEvalScorer(input.mastra)
+  const desiredItems = input.report.outcomes.map((outcome) =>
+    nativeDatasetItemFromOutcome({
+      report: input.report,
+      outcome,
+      reportPath: input.reportPath,
+      environmentLabel,
+    }),
+  )
+  const dataset = await upsertNativeDataset({
+    mastra: input.mastra,
+    name: nativeReportDatasetName(input.report, environmentLabel),
+    description:
+      "Search eval seed prompt outcomes projected from Forge offline search-eval reports.",
+    nativeKey: nativeReportDatasetKey(input.report, environmentLabel),
+    metadata: nativeReportDatasetMetadata(input.report, environmentLabel),
+    items: desiredItems,
+  })
+  const experiment = await upsertNativeExperiment({
+    dataset: dataset.dataset,
+    report: input.report,
+    reportPath: input.reportPath,
+    environmentLabel,
+  })
+  const projection = nativeProjectionFromSync({
+    report: input.report,
+    environmentLabel,
+    dataset,
+    scorer,
+    experiment,
+  })
+
+  return { projection, dataset, scorer, experiment }
+}
+
+export async function syncPromotedCandidatesToNativeDataset(input: {
+  mastra: NativeSearchEvalMastra
+  candidates: readonly Candidate[]
+  environmentLabel?: string
+}): Promise<PromotedSearchEvalSyncResult> {
+  const environmentLabel = searchEvalNativeEnvironmentLabel(
+    input.environmentLabel,
+  )
+  const scorer = registerSearchEvalScorer(input.mastra)
+  const skipped: Array<{ candidateId: string; reason: string }> = []
+  const items = input.candidates.flatMap((candidate) => {
+    const item = nativeDatasetItemFromPromotedCandidate({
+      candidate,
+      environmentLabel,
+    })
+    if (!item.ok) {
+      skipped.push({ candidateId: candidate.id, reason: item.reason })
+      return []
+    }
+    return [item.item]
+  })
+  const dataset = await upsertNativeDataset({
+    mastra: input.mastra,
+    name: `search-eval:${environmentLabel}:promoted-regression`,
+    description:
+      "Human-promoted sanitized search eval regression prompts synced from Admin.",
+    nativeKey: `search-eval:${environmentLabel}:promoted-regression`,
+    metadata: {
+      forgeSearchEval: {
+        nativeKey: `search-eval:${environmentLabel}:promoted-regression`,
+        kind: "promoted_regression_dataset",
+        environmentLabel,
+        source: "admin_search_eval_candidates",
+      },
+    },
+    items,
+  })
+
+  return { dataset, scorer, skipped }
+}
+
+export function withNativeMastraEvaluationProjection(
+  report: SearchEvalReport,
+  projection: MastraEvaluationProjection,
+): SearchEvalReport {
+  return { ...report, mastraEvaluation: projection }
+}
+
+export function createSampleSearchEvalReport(input: {
+  runId: string
+  reportId?: string
+  baselineName?: string
+  now?: Date
+}): SearchEvalReport {
+  const startedAt = input.now ?? new Date()
+  const finishedAt = new Date(startedAt.getTime() + 1120)
+  const baselineName = input.baselineName ?? "local-smoke"
+  return finalizeReport({
+    schemaVersion: "1",
+    kind: "comparison-report",
+    reportId: input.reportId ?? input.runId,
+    metadata: {
+      mastraRunId: input.runId,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      baselineName,
+      promptSetVersion: SAMPLE_PROMPT_SET_VERSION,
+      adminSearchUrl: null,
+      judgeModel: "sample-fixture",
+      search: { limit: 5, mode: "hybrid", contentType: null },
+    },
+    calibration: { passed: true, matched: 3, total: 3, skipped: false },
+    cost: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalUsd: 0,
+      pricingModel: "sample-fixture",
+      estimated: false,
+    },
+    timings: { searchMs: 420, judgeMs: 700, totalMs: 1120 },
+    judgeFailures: [],
+    outcomes: sampleOutcomes(),
+    exploratoryGenerated: [],
+  })
+}
+
+function nativeReportDatasetName(
+  report: SearchEvalReport,
+  environmentLabel: string,
+) {
+  return `search-eval:${environmentLabel}:${report.metadata.baselineName}`
+}
+
+function nativeReportDatasetKey(
+  report: SearchEvalReport,
+  environmentLabel: string,
+) {
+  return `search-eval:${environmentLabel}:${report.metadata.baselineName}:${report.metadata.promptSetVersion}`
+}
+
+function nativeReportExperimentName(
+  report: SearchEvalReport,
+  environmentLabel: string,
+) {
+  const verb = report.kind === "baseline-report" ? "baseline" : "compare"
+  return `search-eval-${verb}:${environmentLabel}:${report.metadata.baselineName}:${report.reportId}`
+}
+
+function nativeReportExperimentKey(
+  report: SearchEvalReport,
+  environmentLabel: string,
+) {
+  return `${nativeReportDatasetKey(report, environmentLabel)}:report:${report.reportId}`
+}
+
+function nativeReportDatasetMetadata(
+  report: SearchEvalReport,
+  environmentLabel: string,
+): Record<string, unknown> {
+  return {
+    forgeSearchEval: {
+      nativeKey: nativeReportDatasetKey(report, environmentLabel),
+      kind: "report_seed_prompt_dataset",
+      environmentLabel,
+      baselineName: report.metadata.baselineName,
+      promptSetVersion: report.metadata.promptSetVersion,
+      source: "search_eval_report",
+      lastReportId: report.reportId,
+      search: {
+        limit: report.metadata.search.limit,
+        mode: searchMode(report.metadata.search.mode),
+        contentType: contentType(report.metadata.search.contentType),
+      },
+    },
+  }
+}
+
+async function upsertNativeDataset(input: {
+  mastra: NativeSearchEvalMastra
+  name: string
+  description: string
+  nativeKey: string
+  metadata: Record<string, unknown>
+  items: Array<{
+    input: NativeSearchEvalInput
+    groundTruth: NativeSearchEvalGroundTruth
+    metadata: Record<string, unknown>
+    source?: { type: "json"; referenceId?: string }
+  }>
+}): Promise<SyncDatasetOutcome> {
+  const existing = await findDatasetByNativeKey(input.mastra, input.nativeKey)
+  const dataset =
+    existing == null
+      ? await input.mastra.datasets.create({
+          name: input.name,
+          description: input.description,
+          inputSchema: NativeSearchEvalInputSchema,
+          groundTruthSchema: NativeSearchEvalGroundTruthSchema,
+          metadata: input.metadata,
+          targetType: "workflow",
+          targetIds: [NATIVE_SEARCH_EVAL_TARGET_ID],
+          scorerIds: [SEARCH_RESULT_PAIRWISE_SCORER_ID],
+        })
+      : await input.mastra.datasets.get({ id: existing.id })
+
+  let status: SyncDatasetOutcome["status"] =
+    existing == null ? "created" : "reused"
+  if (existing != null && dataset.update) {
+    await dataset.update({
+      name: input.name,
+      description: input.description,
+      inputSchema: NativeSearchEvalInputSchema,
+      groundTruthSchema: NativeSearchEvalGroundTruthSchema,
+      metadata: input.metadata,
+      targetType: "workflow",
+      targetIds: [NATIVE_SEARCH_EVAL_TARGET_ID],
+      scorerIds: [SEARCH_RESULT_PAIRWISE_SCORER_ID],
+    })
+    status = "updated"
+  }
+
+  const itemResult = await upsertDatasetItems(dataset, input.items)
+  return {
+    dataset,
+    datasetId: dataset.id,
+    name: input.name,
+    nativeKey: input.nativeKey,
+    itemCount: input.items.length,
+    status,
+    ...itemResult,
+  }
+}
+
+async function findDatasetByNativeKey(
+  mastra: NativeSearchEvalMastra,
+  nativeKey: string,
+): Promise<DatasetRecord | null> {
+  for (let page = 0; page < MAX_NATIVE_LIST_PAGES; page++) {
+    const listed = await mastra.datasets.list({
+      page,
+      perPage: NATIVE_LIST_PAGE_SIZE,
+    })
+    const match = listed.datasets.find(
+      (dataset) =>
+        forgeMetadata(dataset.metadata).nativeKey === nativeKey ||
+        dataset.name === nativeKey,
+    )
+    if (match) return match
+    if (listed.datasets.length < NATIVE_LIST_PAGE_SIZE) return null
+  }
+  return null
+}
+
+async function upsertDatasetItems(
+  dataset: NativeDatasetLike,
+  desiredItems: Array<{
+    input: NativeSearchEvalInput
+    groundTruth: NativeSearchEvalGroundTruth
+    metadata: Record<string, unknown>
+    source?: { type: "json"; referenceId?: string }
+  }>,
+): Promise<{ createdItems: number; updatedItems: number }> {
+  const existingItems = await listAllDatasetItems(dataset)
+  const bySourceKey = new Map(
+    existingItems.flatMap((item) => {
+      const sourceKey = forgeMetadata(item.metadata).sourceKey
+      return typeof sourceKey === "string" ? [[sourceKey, item] as const] : []
+    }),
+  )
+  let createdItems = 0
+  let updatedItems = 0
+  const toCreate: typeof desiredItems = []
+  for (const item of desiredItems) {
+    const sourceKey = forgeMetadata(item.metadata).sourceKey
+    const existing =
+      typeof sourceKey === "string" ? bySourceKey.get(sourceKey) : undefined
+    if (!existing) {
+      toCreate.push(item)
+      continue
+    }
+    await dataset.updateItem({
+      itemId: existing.id,
+      input: item.input,
+      groundTruth: item.groundTruth,
+      metadata: item.metadata,
+    })
+    updatedItems++
+  }
+  if (toCreate.length > 0) {
+    await dataset.addItems({ items: toCreate })
+    createdItems = toCreate.length
+  }
+  return { createdItems, updatedItems }
+}
+
+async function upsertNativeExperiment(input: {
+  dataset: NativeDatasetLike
+  report: SearchEvalReport
+  reportPath?: string
+  environmentLabel: string
+}): Promise<ExperimentOutcome> {
+  const nativeKey = nativeReportExperimentKey(
+    input.report,
+    input.environmentLabel,
+  )
+  const name = nativeReportExperimentName(input.report, input.environmentLabel)
+  const existing = await findExperimentByNativeKey(input.dataset, nativeKey)
+  if (existing) {
+    return {
+      experimentId: existing.id,
+      name: existing.name ?? name,
+      nativeKey,
+      status: "reused",
+    }
+  }
+
+  const outputBySourceKey = new Map(
+    input.report.outcomes.map((outcome) => [
+      reportOutcomeSourceKey(input.report, outcome),
+      nativeOutputFromOutcome(outcome),
+    ]),
+  )
+  const summary = await input.dataset.startExperiment<
+    NativeSearchEvalInput,
+    NativeSearchEvalOutput,
+    NativeSearchEvalGroundTruth
+  >({
+    name,
+    description:
+      "Native Mastra Evaluation experiment projected from a Forge search-eval report.",
+    targetType: "workflow",
+    targetId: NATIVE_SEARCH_EVAL_TARGET_ID,
+    task: async ({ metadata }) => {
+      const sourceKey = forgeMetadata(metadata).sourceKey
+      const output =
+        typeof sourceKey === "string"
+          ? outputBySourceKey.get(sourceKey)
+          : undefined
+      if (!output) {
+        throw new Error("search eval native output missing for dataset item")
+      }
+      return output
+    },
+    maxConcurrency: 4,
+    itemTimeout: 10_000,
+    maxRetries: 0,
+    metadata: {
+      forgeSearchEval: {
+        nativeKey,
+        kind: "report_experiment",
+        environmentLabel: input.environmentLabel,
+        reportId: input.report.reportId,
+        reportPath: input.reportPath ?? null,
+        baselineName: input.report.metadata.baselineName,
+        promptSetVersion: input.report.metadata.promptSetVersion,
+        totals: input.report.totals,
+        localeMix: input.report.localeMix,
+        promptSourceMix: input.report.promptSourceMix,
+        generatedCandidateBehavior: input.report.generatedCandidateBehavior,
+        cost: input.report.cost,
+        timings: input.report.timings,
+      },
+    },
+  })
+  return {
+    experimentId: summary.experimentId,
+    name,
+    nativeKey,
+    status: "created",
+  }
+}
+
+async function findExperimentByNativeKey(
+  dataset: NativeDatasetLike,
+  nativeKey: string,
+): Promise<Experiment | null> {
+  for (let page = 0; page < MAX_NATIVE_LIST_PAGES; page++) {
+    const listed = await dataset.listExperiments({
+      page,
+      perPage: NATIVE_LIST_PAGE_SIZE,
+    })
+    const match = listed.experiments.find(
+      (experiment) =>
+        forgeMetadata(experiment.metadata).nativeKey === nativeKey,
+    )
+    if (match) return match
+    if (listed.experiments.length < NATIVE_LIST_PAGE_SIZE) return null
+  }
+  return null
+}
+
+function nativeProjectionFromSync(input: {
+  report: SearchEvalReport
+  environmentLabel: string
+  dataset: SyncDatasetOutcome
+  scorer: ScorerRegistrationOutcome
+  experiment: ExperimentOutcome
+}): NativeSyncedMastraEvaluationProjection {
+  const mode =
+    input.report.kind === "baseline-report" ? "baseline_capture" : "comparison"
+  return {
+    integrationStatus: "native_synced",
+    dataset: {
+      name: input.dataset.name,
+      datasetId: input.dataset.datasetId,
+      source: "seed_prompt_set",
+      version: input.report.metadata.promptSetVersion,
+      itemCount: input.report.outcomes.length,
+      targetType: "workflow",
+      targetId: NATIVE_SEARCH_EVAL_TARGET_ID,
+      environmentLabel: input.environmentLabel,
+      nativeKey: input.dataset.nativeKey,
+      status: input.dataset.status,
+    },
+    scorers: [
+      {
+        id: SEARCH_RESULT_PAIRWISE_SCORER_ID,
+        scorerId: input.scorer.scorerId,
+        status: input.scorer.status,
+        kind: "pairwise_search_results",
+      },
+    ],
+    experiment: {
+      name: input.experiment.name,
+      experimentId: input.experiment.experimentId,
+      status: input.experiment.status,
+      mode,
+      reportId: input.report.reportId,
+      baselineName: input.report.metadata.baselineName,
+      environmentLabel: input.environmentLabel,
+      nativeKey: input.experiment.nativeKey,
+    },
+  }
+}
+
+function nativeDatasetItemFromOutcome(input: {
+  report: SearchEvalReport
+  outcome: ComparisonOutcome
+  reportPath?: string
+  environmentLabel: string
+}) {
+  const sourceKey = reportOutcomeSourceKey(input.report, input.outcome)
+  return {
+    input: {
+      query: input.outcome.queryText,
+      locale: input.outcome.locale,
+      source: input.outcome.source,
+      searchOptions: {
+        limit: input.report.metadata.search.limit,
+        mode: searchMode(input.report.metadata.search.mode),
+        contentType: contentType(input.report.metadata.search.contentType),
+      },
+    },
+    groundTruth: {
+      expectedResultNotes: input.outcome.rationale ?? null,
+      sourceAnchors: input.outcome.baselineResults
+        .slice(0, 5)
+        .map(resultAnchor),
+      baselineTopResults: input.outcome.baselineResults
+        .slice(0, 5)
+        .map(nativeResult),
+    },
+    source: { type: "json" as const, referenceId: input.report.reportId },
+    metadata: {
+      forgeSearchEval: {
+        sourceKey,
+        kind: "report_outcome_item",
+        environmentLabel: input.environmentLabel,
+        reportId: input.report.reportId,
+        reportPath: input.reportPath ?? null,
+        baselineName: input.report.metadata.baselineName,
+        promptSetVersion: input.report.metadata.promptSetVersion,
+        caseId: input.outcome.caseId,
+        locale: input.outcome.locale,
+        promptSource: input.outcome.source,
+        outcomeKind: input.outcome.kind,
+        generatedCandidate: false,
+        verdicts: input.outcome.verdicts ?? null,
+        searchFailureCode: input.outcome.searchFailure?.code ?? null,
+      },
+    },
+  }
+}
+
+function nativeOutputFromOutcome(
+  outcome: ComparisonOutcome,
+): NativeSearchEvalOutput {
+  return {
+    outcomeKind: outcome.kind,
+    caseId: outcome.caseId,
+    locale: outcome.locale,
+    query: outcome.queryText,
+    baselineTopResults: outcome.baselineResults.slice(0, 5).map(nativeResult),
+    currentTopResults: outcome.currentResults.slice(0, 5).map(nativeResult),
+    rationale: outcome.rationale ?? null,
+    verdicts: outcome.verdicts ? [...outcome.verdicts] : null,
+    failureCode: outcome.searchFailure?.code ?? null,
+  }
+}
+
+function nativeDatasetItemFromPromotedCandidate(input: {
+  candidate: Candidate
+  environmentLabel: string
+}):
+  | {
+      ok: true
+      item: {
+        input: NativeSearchEvalInput
+        groundTruth: NativeSearchEvalGroundTruth
+        metadata: Record<string, unknown>
+        source: { type: "json"; referenceId: string }
+      }
+    }
+  | { ok: false; reason: string } {
+  const { candidate } = input
+  if (candidate.promotionStatus !== "promoted") {
+    return { ok: false, reason: "not_promoted" }
+  }
+  if (candidate.sanitizationStatus !== "sanitized") {
+    return { ok: false, reason: "not_sanitized" }
+  }
+  if (!candidate.sanitizedQueryText) {
+    return { ok: false, reason: "missing_sanitized_query" }
+  }
+  return {
+    ok: true,
+    item: {
+      input: {
+        query: candidate.sanitizedQueryText,
+        locale: candidate.locale,
+        source: promotedSource(candidate.source),
+        searchOptions: { limit: 20, mode: "hybrid", contentType: "all" },
+      },
+      groundTruth: {
+        expectedResultNotes: candidate.sanitizedExpectedResultNotes ?? null,
+        sourceAnchors: Array.isArray(candidate.sanitizedSourceAnchors)
+          ? candidate.sanitizedSourceAnchors
+          : [],
+      },
+      source: { type: "json", referenceId: candidate.id },
+      metadata: {
+        forgeSearchEval: {
+          sourceKey: `admin-candidate:${candidate.id}`,
+          kind: "promoted_candidate_item",
+          environmentLabel: input.environmentLabel,
+          candidateId: candidate.id,
+          source: candidate.source,
+          sanitizationStatus: candidate.sanitizationStatus,
+          reviewerIdentity: candidate.reviewerIdentity ?? null,
+          reviewedAt: candidate.reviewedAt ?? null,
+          promotedAt: candidate.promotedAt ?? null,
+          mastraRunId: candidate.mastraRunId ?? null,
+          promotionRunContextKeys: objectKeys(candidate.promotionRunContext),
+        },
+      },
+    },
+  }
+}
+
+function reportOutcomeSourceKey(
+  report: SearchEvalReport,
+  outcome: ComparisonOutcome,
+) {
+  return `prompt-set:${report.metadata.promptSetVersion}:case:${outcome.caseId}`
+}
+
+function nativeResult(result: SearchEvalResult) {
+  return {
+    type: result.type,
+    id: result.id,
+    slug: result.slug,
+    title: result.title,
+    score: result.score,
+    label: result.label,
+  }
+}
+
+function resultAnchor(result: SearchEvalResult) {
+  return {
+    type: result.type,
+    id: result.id,
+    slug: result.slug,
+    title: result.title,
+  }
+}
+
+function searchMode(mode: string | null): "hybrid" | "keyword-first" {
+  return mode === "keyword-first" ? "keyword-first" : "hybrid"
+}
+
+function contentType(
+  value: "video" | "experience" | null,
+): "all" | "video" | "experience" {
+  return value ?? "all"
+}
+
+function promotedSource(
+  source: Candidate["source"],
+): NativeSearchEvalInput["source"] {
+  if (source === "catalog") return "generated_catalog"
+  if (source === "locale_quality") return "generated_locale_quality"
+  if (source === "trace") return "generated_trace"
+  return source
+}
+
+function normalizeItemsList(
+  value: DatasetItem[] | { items: DatasetItem[] },
+): DatasetItem[] {
+  return Array.isArray(value) ? value : value.items
+}
+
+async function listAllDatasetItems(
+  dataset: NativeDatasetLike,
+): Promise<DatasetItem[]> {
+  const items: DatasetItem[] = []
+  for (let page = 0; page < MAX_NATIVE_LIST_PAGES; page++) {
+    const current = normalizeItemsList(
+      await dataset.listItems({ page, perPage: NATIVE_LIST_PAGE_SIZE }),
+    )
+    items.push(...current)
+    if (current.length < NATIVE_LIST_PAGE_SIZE) break
+  }
+  return items
+}
+
+function forgeMetadata(metadata: unknown): Record<string, unknown> {
+  if (metadata == null || typeof metadata !== "object") return {}
+  const forge = (metadata as { forgeSearchEval?: unknown }).forgeSearchEval
+  return forge != null && typeof forge === "object" && !Array.isArray(forge)
+    ? (forge as Record<string, unknown>)
+    : {}
+}
+
+function objectKeys(value: unknown): string[] {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return []
+  }
+  return Object.keys(value).slice(0, 20)
+}
+
+function sampleResult(input: {
+  type: "video" | "experience"
+  id: string
+  slug: string
+  title: string
+  snippet: string
+  score: number
+  label?: string | null
+}): SearchEvalResult {
+  return {
+    type: input.type,
+    id: input.id,
+    slug: input.slug,
+    title: input.title,
+    imageUrl: null,
+    snippet: input.snippet,
+    startSeconds: null,
+    playbackId: null,
+    score: input.score,
+    label: input.label ?? null,
+    durationSeconds: null,
+    childCount: null,
+  }
+}
+
+function sampleOutcomes(): ComparisonOutcome[] {
+  return [
+    {
+      kind: "win",
+      caseId: "sample-who-is-jesus",
+      locale: "en",
+      queryText: "Who is Jesus?",
+      source: "seed",
+      baselineResults: [
+        sampleResult({
+          type: "video",
+          id: "video-baseline-jesus",
+          slug: "jesus-film-clip",
+          title: "JESUS Film Clip",
+          snippet: "A baseline clip about Jesus from the JESUS film.",
+          score: 0.72,
+        }),
+      ],
+      currentResults: [
+        sampleResult({
+          type: "experience",
+          id: "experience-current-jesus",
+          slug: "who-is-jesus",
+          title: "Who Is Jesus?",
+          snippet: "A stronger experience explaining who Jesus is.",
+          score: 0.93,
+        }),
+      ],
+      verdicts: ["clearly-B-better", "clearly-A-better"],
+      rationale:
+        "Current results put the direct explanatory experience first and better match the query intent.",
+    },
+    {
+      kind: "tie",
+      caseId: "sample-bible-project",
+      locale: "en",
+      queryText: "Bible Project",
+      source: "seed",
+      baselineResults: [
+        sampleResult({
+          type: "video",
+          id: "video-baseline-bible-project",
+          slug: "bible-project-overview",
+          title: "BibleProject Overview",
+          snippet: "A relevant overview for BibleProject searches.",
+          score: 0.88,
+        }),
+      ],
+      currentResults: [
+        sampleResult({
+          type: "video",
+          id: "video-current-bible-project",
+          slug: "bible-project-overview",
+          title: "BibleProject Overview",
+          snippet: "The same strong BibleProject overview remains first.",
+          score: 0.9,
+        }),
+      ],
+      verdicts: ["tie", "tie"],
+      rationale:
+        "Both result sets satisfy the branded query with the same primary result.",
+    },
+    {
+      kind: "both-irrelevant",
+      caseId: "sample-vague-query",
+      locale: "en",
+      queryText: "random ocean clip",
+      source: "seed",
+      baselineResults: [],
+      currentResults: [],
+      verdicts: ["both-irrelevant", "both-irrelevant"],
+      rationale:
+        "Neither result set contains a safe search result for the deliberately out-of-domain query.",
+    },
+  ]
+}

--- a/apps/mastra/src/services/offline-search-eval/runner.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/runner.test.ts
@@ -5,7 +5,11 @@ import {
   SearchEvalArtifactError,
   type SearchEvalArtifactStore,
 } from "./artifacts"
-import type { BaselineArtifact, SearchEvalResult } from "./types"
+import type {
+  BaselineArtifact,
+  SearchEvalReport,
+  SearchEvalResult,
+} from "./types"
 
 const resultA: SearchEvalResult = {
   type: "video",
@@ -85,6 +89,22 @@ function memoryStore(baseline?: BaselineArtifact): SearchEvalArtifactStore & {
     async writeReport(report) {
       reports.push(report)
       return { path: `/tmp/search-eval/reports/${report.reportId}.json` }
+    },
+    async readReport(reportId) {
+      const found = reports.find(
+        (entry): entry is SearchEvalReport =>
+          typeof entry === "object" &&
+          entry !== null &&
+          "reportId" in entry &&
+          (entry as { reportId?: unknown }).reportId === reportId,
+      )
+      if (!found) {
+        throw new SearchEvalArtifactError(
+          "not_found",
+          `report '${reportId}' was not found`,
+        )
+      }
+      return found
     },
   }
 }

--- a/apps/mastra/src/services/offline-search-eval/types.ts
+++ b/apps/mastra/src/services/offline-search-eval/types.ts
@@ -149,7 +149,7 @@ export type ReportTotals = {
   netWinRate: number
 }
 
-export type MastraEvaluationProjection = {
+export type ArtifactOnlyMastraEvaluationProjection = {
   integrationStatus: "custom_artifact_only"
   dataset: {
     name: string
@@ -175,6 +175,42 @@ export type MastraEvaluationProjection = {
     baselineName: string
   }
 }
+
+export type NativeSyncedMastraEvaluationProjection = {
+  integrationStatus: "native_synced"
+  dataset: {
+    name: string
+    datasetId: string
+    source: "seed_prompt_set"
+    version: string
+    itemCount: number
+    targetType: "workflow"
+    targetId: "offline-search-eval"
+    environmentLabel: string
+    nativeKey: string
+    status: "created" | "updated" | "reused"
+  }
+  scorers: Array<{
+    id: "search-result-pairwise-judge"
+    scorerId: string
+    status: "registered" | "reused"
+    kind: "pairwise_search_results"
+  }>
+  experiment: {
+    name: string
+    experimentId: string
+    status: "created" | "reused"
+    mode: "baseline_capture" | "comparison"
+    reportId: string
+    baselineName: string
+    environmentLabel: string
+    nativeKey: string
+  }
+}
+
+export type MastraEvaluationProjection =
+  | ArtifactOnlyMastraEvaluationProjection
+  | NativeSyncedMastraEvaluationProjection
 
 export type SearchEvalReport = {
   schemaVersion: typeof SEARCH_EVAL_ARTIFACT_SCHEMA_VERSION

--- a/docs/brainstorms/2026-05-28-mastra-native-evaluation-search-eval-suite-requirements.md
+++ b/docs/brainstorms/2026-05-28-mastra-native-evaluation-search-eval-suite-requirements.md
@@ -1,0 +1,273 @@
+---
+date: 2026-05-28
+topic: mastra-native-evaluation-search-eval-suite
+related:
+  - docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md
+  - docs/roadmap/content-discovery/feat-139-mastra-offline-search-eval-runner-reports.md
+  - docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md
+  - docs/roadmap/content-discovery/feat-141-mastra-retrieval-strategy-investigation.md
+  - docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md
+  - docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md
+---
+
+# Mastra Native Evaluation Search Eval Suite
+
+## Summary
+
+Feat-142 should make Mastra Studio's native Evaluation area the primary
+operator surface for search evals. Operators should be able to understand and
+use search eval runs through native Datasets, Scorers, Experiments, and Overview
+signals without opening JSON artifacts first; custom artifacts remain an audit
+and full-fidelity backing layer.
+
+---
+
+## Problem Frame
+
+Feat-138, feat-139, and feat-140 create the pieces of a safer search-eval loop:
+generated candidate prompts, seed and comparison reports, and human promotion
+into durable regression truth. Those pieces are useful, but the operator
+experience is still fragmented if the real understanding lives in workflow cards
+and filesystem artifacts.
+
+Feat-142 is the convergence ticket. It should turn the safe search-eval domain
+into actual native Mastra Evaluation records and make local reproduction part of
+the product contract, not a side quest. A developer should be able to start
+Admin and Mastra locally, run the same sync and experiment path used elsewhere,
+and see the expected native Evaluation records in Studio.
+
+---
+
+## Key Decisions
+
+- **Native Evaluation normalization first:** Transform every safe search-eval
+  concept into native Mastra Evaluation records wherever that preserves operator
+  meaning. Artifacts remain backing evidence, not the first place operators go.
+- **Meaning beats force-fitting:** If a native field cannot express a
+  search-specific concept without hiding meaning, the native record should still
+  carry a clear summary and a safe link or metadata pointer to the backing
+  detail.
+- **One path across environments:** Local, staging, and production should use
+  the same sync and run behavior with environment-specific configuration, stable
+  names, and idempotent writes.
+- **Keep the safety boundary:** Native Evaluation integration must not collapse
+  generated-candidate staging, human promotion, and durable regression truth
+  into one unsafe state.
+
+---
+
+## Actors
+
+- A1. Operator: Uses Mastra Studio to inspect search eval Datasets, Scorers,
+  Experiments, and roll-up signals.
+- A2. Developer: Runs the suite locally and verifies the same native Evaluation
+  shapes that staging or production would create.
+- A3. Mastra: Owns the operator-facing native Evaluation suite, offline
+  experiments, scoring, and search-specific report metadata.
+- A4. Admin: Owns live search behavior, search-eval storage, sanitization,
+  review metadata, retention policy, and authenticated HTTP contracts.
+- A5. Planner or future investigator: Uses feat-142 native Evaluation evidence
+  as the basis for feat-141 retrieval strategy decisions.
+
+---
+
+## Key Flows
+
+- F1. Native Evaluation sync
+  - **Trigger:** A developer or operator runs the search-eval native sync for an
+    environment.
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** Mastra reads safe seed and promoted search-eval truth through
+    Admin contracts, transforms it into native Dataset items, registers or
+    updates search-eval Scorers, and reuses or updates stable native records
+    instead of duplicating them.
+  - **Outcome:** Studio shows real native search-eval Datasets and Scorers for
+    the chosen environment.
+  - **Covered by:** R1, R2, R3, R4, R5, R11
+
+- F2. Native experiment run
+  - **Trigger:** An operator runs an offline search eval after native records
+    exist.
+  - **Actors:** A1, A3, A4
+  - **Steps:** Mastra runs the eval against Admin search, records sanitized item
+    results as a native Experiment, transforms pairwise search quality outcomes
+    into native scores and reasons, and attaches safe search-specific summary
+    metadata.
+  - **Outcome:** Studio's Experiments and Overview areas communicate the run's
+    quality signal without requiring a JSON artifact as the starting point.
+  - **Covered by:** R6, R7, R8, R9, R10, R12
+
+- F3. Local reproduction
+  - **Trigger:** A developer needs to verify feat-142 outside production.
+  - **Actors:** A2, A3, A4
+  - **Steps:** The developer starts local Admin and Mastra with local URLs,
+    bearer keys, storage, database, and artifact configuration, runs the same
+    sync and experiment path, and inspects the resulting records in Studio.
+  - **Outcome:** Local verification proves the same operator experience and
+    idempotency behavior expected in staging and production.
+  - **Covered by:** R11, R12, R13, R14
+
+---
+
+## Requirements
+
+**Native operator surface**
+
+- R1. Mastra Studio's native Evaluation area must be the canonical operator
+  surface for the search eval suite.
+- R2. Operators must be able to understand and use a search eval run inside
+  Studio without opening a custom JSON artifact first.
+- R3. Seed prompt sets and human-promoted regression prompts must become native
+  Dataset items when they are safe to expose.
+- R4. Generated, trace-derived, user-submitted, pending, rejected, archived, or
+  unsanitized candidates must not enter durable native Datasets.
+- R5. Native record names and metadata must clearly distinguish local, staging,
+  and production records.
+
+**Scoring and experiments**
+
+- R6. Offline search eval runs must create native Experiments where Mastra can
+  represent the run without misleading operators.
+- R7. Pairwise search quality outcomes should be transformed into native Scorer
+  output, including enough score, reason, and safe metadata for operators to
+  distinguish wins, losses, ties, both-irrelevant cases, judge disagreements,
+  judge failures, and search failures.
+- R8. Native Experiments must preserve the search-eval context operators need:
+  baseline identity, prompt source, locale mix, search configuration, generated
+  or promoted state, cost, timing, calibration status, and report linkage when
+  applicable.
+- R9. Native comparison and overview signals should be used when they preserve
+  the search-eval meaning.
+- R10. If native Mastra fields cannot express a search-specific detail cleanly,
+  the native record must still expose a meaning-preserving summary and point to
+  the sanitized backing detail.
+
+**Reproducibility and idempotency**
+
+- R11. Native Evaluation sync and experiment creation must be idempotent:
+  rerunning sync should update or reuse stable records rather than duplicating
+  Datasets, Scorers, Experiments, or items.
+- R12. Local, staging, and production must use the same code path, changing only
+  environment-specific configuration such as Admin URLs, bearer keys, Mastra
+  storage, database URLs, artifact roots, and environment labels.
+- R13. A fresh local developer environment must be able to create and inspect
+  the expected native Evaluation records in Studio without manual database
+  writes or hand-edited native records.
+- R14. The local development path must document required Admin and Mastra
+  configuration, commands, expected native records, and the idempotency check.
+
+**Safety boundaries**
+
+- R15. Mastra must not move into the live search request path.
+- R16. Live query embedding generation and live search orchestration must remain
+  Admin-owned.
+- R17. Mastra must read and mutate Admin-owned search-eval state only through
+  authenticated Admin HTTP contracts.
+- R18. Native Evaluation records must not expose raw sensitive trace text,
+  vectors, provider secrets, bearer tokens, unsanitized source payloads, or raw
+  production trace details.
+- R19. Existing leaf workflows for eval query generation, candidate review, and
+  offline search eval should remain independently usable unless implementation
+  evidence proves a safer and clearer consolidation.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R6, R8.** Given a native search eval run has completed,
+  when an operator opens Mastra Studio's Evaluation area, they can identify the
+  Dataset, Scorer, Experiment, headline result, failure categories, and backing
+  report reference without opening filesystem JSON first.
+- AE2. **Covers R3, R4, R18.** Given Admin has seed prompts, promoted
+  candidates, pending generated candidates, and trace-derived rows, when Mastra
+  syncs native Datasets, only seed and sanitized promoted truth appear as native
+  Dataset items.
+- AE3. **Covers R7, R10.** Given a pairwise comparison produces a judge
+  disagreement or both-irrelevant result, when it is written to native
+  Evaluation, Studio does not collapse it into an ordinary tie or green score
+  without explanation.
+- AE4. **Covers R11, R12, R13.** Given a developer runs native sync twice in a
+  fresh local environment, when they inspect Studio after the second run, the
+  expected records are still singular and updated rather than duplicated.
+- AE5. **Covers R15, R16, R17.** Given a live user performs a public search,
+  when feat-142 is enabled, Admin continues to handle live search behavior and
+  Mastra's native Evaluation suite remains offline.
+
+---
+
+## Success Criteria
+
+- Operators can use native Mastra Evaluation as the first stop for search eval
+  understanding.
+- Custom JSON artifacts are useful for audit and full-fidelity backing detail,
+  but they are not the primary operator UX.
+- Native Datasets contain only seed and sanitized promoted truth.
+- Native Scorers and Experiments preserve the difference between search
+  quality, judge uncertainty, provider failure, and search failure.
+- Local reproduction proves the same sync, run, idempotency, and Studio-visible
+  record behavior expected in staging and production.
+- Feat-141 can use native Evaluation records as its primary evidence source for
+  retrieval strategy investigation.
+
+---
+
+## Scope Boundaries
+
+- Do not build a separate custom search-eval suite UI unless native Mastra
+  Evaluation cannot represent a required operator concept with meaning intact.
+- Do not make filesystem artifact paths the only way to inspect baselines,
+  reports, or comparison outcomes.
+- Do not promote generated or user-submitted candidates without feat-140 human
+  review and sanitization.
+- Do not change public search REST or GraphQL response shapes.
+- Do not query Admin's database directly from Mastra.
+- Do not treat artifact-backed reports as native Evaluation integration unless
+  real native records are created.
+
+---
+
+## Dependencies / Assumptions
+
+- Feat-140 provides sanitized promoted truth and a stable native Dataset item
+  shape for Mastra to sync.
+- The installed Mastra runtime supports native Dataset, Scorer, Experiment, and
+  comparison APIs plus Studio routes for those records.
+- Admin remains the durable owner of search-eval review, sanitization, raw trace
+  retention, and live search behavior.
+- Some search-specific report detail may remain too rich for native Evaluation,
+  but native records should carry enough summary and linkage that operators do
+  not start in JSON.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(none)
+
+### Deferred to Planning
+
+- Verify exactly how native Scorers should encode pairwise win/loss/tie,
+  both-irrelevant, judge-disagreement, judge-failure, and search-failure
+  categories without losing operator meaning.
+- Decide how stable native record keys, names, and versions should be derived
+  for local, staging, and production.
+- Confirm the smallest safe metadata payload that native Experiments should
+  carry while keeping raw trace and provider details out.
+- Verify whether native comparison and Overview APIs can express the desired
+  roll-up directly, or whether the system should attach a native summary plus
+  backing report link.
+
+---
+
+## Sources / Research
+
+- `docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`
+- `docs/roadmap/content-discovery/feat-139-mastra-offline-search-eval-runner-reports.md`
+- `docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md`
+- `docs/roadmap/content-discovery/feat-141-mastra-retrieval-strategy-investigation.md`
+- `docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md`
+- `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`
+- `apps/mastra/AGENTS.md`
+- `apps/admin/AGENTS.md`

--- a/docs/plans/2026-05-28-001-feat-search-eval-human-promotion-plan.md
+++ b/docs/plans/2026-05-28-001-feat-search-eval-human-promotion-plan.md
@@ -1,0 +1,187 @@
+---
+title: "feat: Search eval human promotion and regression gates"
+type: "feat"
+status: "completed"
+date: "2026-05-28"
+---
+
+# feat: Search eval human promotion and regression gates
+
+## Summary
+
+Build the Admin-owned review and promotion contracts that turn seed, generated, and user-submitted search eval candidates into sanitized durable regression truth, with a Mastra operator workflow that uses only authenticated Admin HTTP.
+
+---
+
+## Problem Frame
+
+Feat-139 made Mastra the owner of offline search eval runs and custom reports while keeping native Mastra Evaluation writes deferred. Generated candidates are still staged in Admin and are intentionally not regression gates. Feat-140 needs the human promotion path: operators should review safe candidate projections, edit sanitized truth fields, reject/archive poor candidates, and promote approved cases without a DB console or raw trace leakage.
+
+---
+
+## Requirements
+
+- R1. Admin exposes authenticated review-safe list/detail, sanitized-field edit, reject/archive, and promote contracts for search eval candidates.
+- R2. Promotion records reviewer identity, review timestamp, sanitization status, source anchors, expected-result notes, and Admin/Mastra run context.
+- R3. Generated, seed, and user-submitted candidates remain pending until a human promotes them.
+- R4. Promoted cases load as durable regression truth while existing hand-edited `apps/admin/eval/regressions.json` entries still load.
+- R5. Mastra review behavior uses Admin HTTP only and does not import Admin code or connect to Admin Postgres.
+- R6. Raw trace text, unsanitized trace payloads, vectors, bearer tokens, provider secrets, and source payloads stay out of review responses and artifacts.
+- R7. Feat-142 has a documented native Dataset item bridge without this ticket claiming native Dataset, Scorer, or Experiment records.
+
+---
+
+## Key Technical Decisions
+
+- **Use `search_eval_candidate` as the promoted truth ledger:** Add review/promotion fields to the existing Admin-owned table so provenance, status, and promoted sanitized truth stay atomically tied to the staged candidate.
+- **Keep pending status backward compatible:** Existing `generated` status remains the pending-review state for generated, seed, and user-submitted sources, avoiding a disruptive data migration while responses document it as pending.
+- **Expose sanitized projections, not raw rows:** Detail/list responses switch to sanitized fields after promotion and continue to suppress trace raw query text before promotion.
+- **Load promoted DB truth beside hand-edited JSON:** `loadRegressions` keeps the file-first operator flow and accepts an optional Prisma client to append promoted rows as `source: "promoted"`.
+- **Make Mastra a thin operator workflow:** Mastra owns the Studio/workflow action surface, but every read/write delegates to Admin HTTP clients with bearer auth and typed response parsing.
+- **Defer native Evaluation writes:** Document the Dataset item shape now; keep native IDs null and creation work in feat-142.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Seed, generated, or user-submitted candidate"] --> B["Admin candidate row: pending review"]
+  B --> C["Mastra review workflow"]
+  C -->|authenticated HTTP only| D["Admin review-safe list/detail"]
+  C -->|authenticated HTTP only| E["Admin sanitized edit"]
+  C -->|authenticated HTTP only| F{"Human decision"}
+  F -->|reject/archive| G["Terminal non-gate state"]
+  F -->|promote| H["Promoted sanitized regression truth"]
+  H --> I["Admin regression loader"]
+  H --> J["Feat-142 native Dataset sync bridge"]
+```
+
+---
+
+## Implementation Units
+
+### U1. Admin Candidate Review Model
+
+**Goal:** Extend candidate storage to represent seed/user-submitted sources, review state, sanitization fields, and promotion audit metadata.
+
+**Requirements:** R1, R2, R3, R6
+
+**Dependencies:** none
+
+**Files:** `apps/admin/prisma/schema.prisma`, `apps/admin/prisma/migrations/0024_search_eval_human_promotion/migration.sql`, `apps/admin/src/services/search-eval/candidates.ts`, `apps/admin/src/services/search-eval/candidates.test.ts`
+
+**Approach:** Add `seed` and `user_submitted` candidate sources, an `archived` terminal status, sanitized query/notes/anchors fields, reviewer/review timestamp fields, promotion timestamp, review notes, and safe run context JSON. Keep raw candidate fields present for existing generation writes, but require promoted reads to use sanitized fields.
+
+**Patterns to follow:** Existing `SearchEvalCandidate` validation and trace redaction in `apps/admin/src/services/search-eval/candidates.ts`; retention rules in `apps/admin/src/services/search-trace-retention.service.ts`.
+
+**Test scenarios:** Store seed and user-submitted candidates as pending; reject attempts to overwrite promoted/rejected/archived rows; promote only with sanitized query text and reviewer identity; archive and reject terminal states never enter promoted loaders; trace rows never expose raw query/source payloads in review responses.
+
+**Verification:** Service tests prove state transitions, response redaction, and schema guardrails.
+
+### U2. Admin HTTP Review Contracts
+
+**Goal:** Add bearer-gated Admin routes for review-safe list/detail, sanitized edit, reject/archive, and promote.
+
+**Requirements:** R1, R2, R3, R6
+
+**Dependencies:** U1
+
+**Files:** `apps/admin/src/app/api/internal/search-eval/candidates/route.ts`, `apps/admin/src/app/api/internal/search-eval/candidates/[id]/route.ts`, `apps/admin/src/app/api/internal/search-eval/candidates/[id]/reject/route.ts`, `apps/admin/src/app/api/internal/search-eval/candidates/[id]/archive/route.ts`, `apps/admin/src/app/api/internal/search-eval/candidates/[id]/promote/route.ts`, `apps/admin/src/app/api/internal/search-eval/candidates/route.test.ts`
+
+**Approach:** Reuse the existing dedicated search-eval bearer, JSON body caps, rate limiting, and sanitized error responses. Keep list bounded and add status/source filtering. Add narrow action routes so Mastra does not need DB access or Admin imports.
+
+**Patterns to follow:** Existing candidate and no-trace search internal routes.
+
+**Test scenarios:** Unauthorized requests fail; invalid IDs and malformed action payloads return 400/404; edit updates sanitized fields only; reject/archive/promote call service functions with reviewer/run context; trace detail is redacted.
+
+**Verification:** Route tests cover auth, validation, status mapping, and redaction.
+
+### U3. Durable Regression Loading
+
+**Goal:** Preserve committed `regressions.json` while appending promoted DB cases to regression truth.
+
+**Requirements:** R4, R6
+
+**Dependencies:** U1
+
+**Files:** `apps/admin/src/services/search-eval/regressions.ts`, `apps/admin/src/services/search-eval/regressions.test.ts`, `apps/admin/src/services/search-eval/types.ts`, `apps/admin/src/scripts/eval-search.ts`, `apps/admin/eval/README.md`
+
+**Approach:** Extend `loadRegressions` with an optional Prisma client and append promoted rows using sanitized query text, expected-result notes, source anchors, reviewer, and promotion metadata. Keep the no-Prisma path returning the existing file entries only.
+
+**Patterns to follow:** Existing hand-edited JSON validation and rebaseline composition in `apps/admin/src/scripts/eval-search.ts`.
+
+**Test scenarios:** File entries still load alone; promoted rows append when Prisma is supplied; archived/rejected/pending rows are excluded; promoted trace rows use sanitized query text only.
+
+**Verification:** Regression loader tests and the rebaseline script compile against the extended contract.
+
+### U4. Mastra HTTP-Boundary Review Workflow
+
+**Goal:** Provide an operator workflow for listing/detailing, editing, rejecting/archiving, promoting, and submitting seed/user candidates via Admin HTTP only.
+
+**Requirements:** R1, R3, R5, R6
+
+**Dependencies:** U2
+
+**Files:** `apps/mastra/src/services/admin-search-eval-client.ts`, `apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts`, `apps/mastra/src/mastra/index.ts`, `apps/mastra/src/services/admin-search-eval-client.test.ts`, `apps/mastra/src/mastra/workflows/search-eval-candidate-review.test.ts`
+
+**Approach:** Add Admin HTTP client helpers and a Studio-friendly workflow with action inputs. Seed submission packages the committed Mastra seed prompt set into Admin candidates; user submissions enter the same pending-review flow; all state changes call Admin action endpoints.
+
+**Patterns to follow:** `eval-query-generation` and `offline-search-eval` workflow route/auth patterns, plus current retrying Admin client behavior.
+
+**Test scenarios:** Workflow list/detail/edit/promote/reject/archive calls only HTTP client seams; missing Admin config fails typed and retry-safe; seed submission posts seed cases as pending candidates; no test imports Admin modules.
+
+**Verification:** Mastra tests prove action routing and HTTP-only behavior.
+
+### U5. Documentation And Native Dataset Bridge
+
+**Goal:** Document review standards, regression loading, and the native Dataset item shape for feat-142.
+
+**Requirements:** R7
+
+**Dependencies:** U1, U3, U4
+
+**Files:** `apps/admin/eval/README.md`, `docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md`, `docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`
+
+**Approach:** Update operator docs with review rules for seed, generated, user-submitted, trace-derived, and audience-intent cases. Document the future native Dataset item shape with query, locale, source, sanitized provenance, expected-result notes/anchors, and safe metadata only.
+
+**Patterns to follow:** Existing feat-139 completion notes and native Evaluation bridge solution note.
+
+**Test scenarios:** Test expectation: none -- documentation-only unit.
+
+**Verification:** Docs name the deferred native writes clearly and do not claim native records are populated.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Native Mastra Dataset, Scorer, and Experiment writes stay in feat-142.
+- A custom rich review UI is deferred unless native Mastra Evaluation cannot support the operator flow later.
+- Public search REST and GraphQL shapes remain unchanged.
+
+### Out of Scope
+
+- Mastra in the live search path.
+- Mastra database access to Admin Postgres.
+- CMS/Strapi support.
+
+---
+
+## Risks & Dependencies
+
+- **Prisma enum changes need generated client refresh:** The implementation should run Admin Prisma generate before typecheck.
+- **Trace candidates need strict projection discipline:** Tests should prove trace raw fields are not read or serialized in review-safe responses.
+- **Reviewer identity is contract-provided:** Mastra is not the human identity authority, so Admin stores reviewer identity supplied by the authenticated operator workflow instead of joining to Admin session users.
+
+---
+
+## Sources / Research
+
+- Roadmap source: `docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md`
+- Feat-139 boundary: `docs/roadmap/content-discovery/feat-139-mastra-offline-search-eval-runner-reports.md`
+- Native bridge: `docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`
+- Existing Admin candidate contract: `apps/admin/src/services/search-eval/candidates.ts`
+- Existing Mastra HTTP client and workflows: `apps/mastra/src/services/admin-search-eval-client.ts`, `apps/mastra/src/mastra/workflows/eval-query-generation.ts`, `apps/mastra/src/mastra/workflows/offline-search-eval.ts`
+- Prior pattern: `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`

--- a/docs/plans/2026-05-28-002-feat-mastra-native-evaluation-search-eval-suite-plan.md
+++ b/docs/plans/2026-05-28-002-feat-mastra-native-evaluation-search-eval-suite-plan.md
@@ -1,0 +1,305 @@
+---
+id: "2026-05-28-002"
+title: "Mastra Native Evaluation Search Eval Suite"
+status: "active"
+created: "2026-05-28"
+origin: "docs/brainstorms/2026-05-28-mastra-native-evaluation-search-eval-suite-requirements.md"
+owner: "codex"
+---
+
+# Mastra Native Evaluation Search Eval Suite Plan
+
+## Problem
+
+Feat-142 should make Mastra Studio's native Evaluation area the canonical
+operator surface for search evals. The current system can stage candidate
+prompts, capture baselines, write comparison reports, and review/promote safe
+truth, but native Datasets, Scorers, and Experiments are still not created.
+Operators therefore have to reason through workflow cards and JSON artifacts
+instead of Studio's Evaluation pages.
+
+The implementation should transform the existing safe search-eval artifacts and
+promoted truth into native Mastra Evaluation records. Custom artifacts remain
+the audit/full-fidelity backing layer; native Evaluation becomes the first stop
+for operators.
+
+## Source Requirements
+
+This plan carries forward the requirements from
+`docs/brainstorms/2026-05-28-mastra-native-evaluation-search-eval-suite-requirements.md`
+and the roadmap contract in
+`docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`.
+
+- Native Evaluation is the primary operator surface for search evals.
+- Seed prompt sets and sanitized human-promoted regression prompts become
+  native Dataset items.
+- Generated, pending, rejected, archived, unsanitized, or trace-raw candidates
+  stay out of durable native Datasets.
+- Pairwise search quality outcomes become native Scorer results without losing
+  win, loss, tie, both-irrelevant, judge-disagreement, judge-failure, and
+  search-failure meaning.
+- Offline search eval runs create native Experiments with safe metadata for
+  baseline identity, prompt source, locale mix, search configuration, report
+  linkage, cost, timing, and failure categories.
+- Local, staging, and production use the same code path with config-only
+  differences for Admin URLs, bearer keys, Mastra storage, artifact roots, and
+  environment labels.
+- Rerunning sync reuses or updates stable native records instead of duplicating
+  Datasets, Scorers, Experiments, or items.
+- Mastra remains outside the live search request path and uses authenticated
+  Admin HTTP contracts rather than Admin database access.
+
+## Investigation Findings
+
+- `apps/mastra/src/mastra/index.ts` already registers Studio-facing workflows
+  and bearer-protected service routes. New search-eval native sync should
+  follow the same workflow plus service-route pattern.
+- `apps/mastra/src/services/offline-search-eval/report.ts` already computes
+  totals, locale mix, prompt-source mix, generated-candidate behavior, timing,
+  cost, and a `mastraEvaluation` projection with null native IDs.
+- `apps/mastra/src/services/offline-search-eval/artifacts.ts` validates and
+  writes baseline/report artifacts, but it does not yet read reports by id for
+  a downstream native sync.
+- `apps/mastra/src/services/admin-search-eval-client.ts` exposes promoted
+  candidate listing through authenticated Admin HTTP. Mastra does not need
+  direct Admin database access.
+- `apps/mastra/node_modules/@mastra/core` exposes `mastra.datasets`,
+  `Dataset.addItems`, `Dataset.updateItem`, `Dataset.listItems`,
+  `Dataset.startExperiment`, `createScorer`, `mastra.addScorer`, and
+  `mastra.listScorers`.
+- Studio/API route metadata includes native Evaluation routes for datasets,
+  experiments, and scorers.
+- Local Studio should be reached through `http://localhost:4111`, with
+  devcontainer forwarding configured for port `4111`. Avoid container-private
+  `172.x` addresses.
+
+## Technical Decisions
+
+1. **Artifact producer, native projector.** Keep `offline-search-eval` as the
+   producer of safe comparison artifacts, then add a native sync workflow that
+   projects a report into native Dataset, Scorer, and Experiment records. This
+   preserves the existing audit layer while making Evaluation native.
+2. **Stable keys over generated names.** Native records should use
+   environment-aware names plus stable metadata keys derived from environment,
+   baseline, prompt-set/report id, scorer id, and source item keys. Sync finds
+   existing records by those keys before creating anything.
+3. **Function scorer with explicit category semantics.** The first scorer maps
+   pairwise categories into numeric scores for native Evaluation while keeping
+   the detailed category and explanation in the scorer reason/output metadata.
+   Native scores are a Studio signal, not a replacement for the full report.
+4. **Promoted truth via Admin HTTP only.** Promoted candidate sync reads
+   sanitized promoted rows from Admin's internal HTTP contracts. It never reads
+   Admin's database and never imports Admin modules.
+5. **Dev smoke without production data.** Add an explicit sample-data smoke
+   action for local Studio verification so a developer can prove artifact to
+   native Evaluation wiring without a Railway token or production database. The
+   action must be rejected outside local/development environments, clearly mark
+   data as sample/local, and never create promoted production truth.
+6. **Optional in-memory Mastra storage only for local smoke.** Add a local-only
+   storage backend option so native Evaluation records can be exercised when a
+   Postgres service is unavailable in the devcontainer. Production still
+   requires configured durable storage.
+
+## High-Level Design
+
+```mermaid
+flowchart LR
+  Seed["Seed prompt set"] --> Report["Offline search-eval report artifact"]
+  Admin["Admin HTTP promoted candidates"] --> Dataset["Native Dataset items"]
+  Report --> Sync["Native search-eval suite workflow"]
+  Sync --> Dataset
+  Sync --> Scorer["Native pairwise search Scorer"]
+  Sync --> Experiment["Native Experiment"]
+  Experiment --> Studio["Mastra Studio Evaluation"]
+  Report --> Backing["Sanitized backing artifact"]
+  Studio --> Backing
+```
+
+## Implementation Units
+
+### U1: Native Search Eval Domain Service
+
+Files:
+
+- `apps/mastra/src/services/offline-search-eval/native-evaluation.ts`
+- `apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts`
+- `apps/mastra/src/services/offline-search-eval/types.ts`
+- `apps/mastra/src/services/offline-search-eval/artifacts.ts`
+
+Approach:
+Create a service that accepts a validated search-eval report plus a Mastra
+runtime handle and sync options. It should register the pairwise scorer, find or
+create the target Dataset by stable metadata key, upsert Dataset items by
+`metadata.sourceKey`, and create or reuse the native Experiment for the report.
+Add report reading by report id so a workflow can transform an existing artifact
+into native records.
+
+Test scenarios:
+
+- Registers or reuses the `search-result-pairwise-judge` scorer without
+  duplicate scorer entries.
+- Creates a Dataset with stable name, target type, target id, scorer ids, and
+  environment metadata.
+- Rerunning sync updates existing Dataset items by `sourceKey` instead of adding
+  duplicates.
+- Reuses an existing Experiment when the same report id/native key has already
+  been synced.
+- Rejects or redacts unsafe native item metadata that would expose raw trace
+  text, bearer tokens, vectors, or provider payloads.
+- Reads a report artifact by id and validates malformed artifacts before sync.
+
+### U2: Report Projection Upgrade
+
+Files:
+
+- `apps/mastra/src/services/offline-search-eval/report.ts`
+- `apps/mastra/src/services/offline-search-eval/types.ts`
+- `apps/mastra/src/services/offline-search-eval/artifacts.ts`
+- `apps/mastra/src/services/offline-search-eval/report.test.ts`
+- `apps/mastra/src/services/offline-search-eval/artifacts.test.ts`
+
+Approach:
+Extend the `mastraEvaluation` projection to support both artifact-only and
+native-synced states. Artifact generation should continue to emit
+`custom_artifact_only`; native sync can return or persist native ids and statuses
+only after real records exist.
+
+Test scenarios:
+
+- Existing report finalization still emits `custom_artifact_only` with null
+  native ids before sync.
+- Native sync projection includes non-null Dataset, Scorer, and Experiment ids
+  only after native records are created or reused.
+- Artifact schema accepts valid artifact-only and native-synced projections and
+  rejects mixed states such as `native_synced` with null Dataset id.
+
+### U3: Studio Workflow And Service Route
+
+Files:
+
+- `apps/mastra/src/mastra/workflows/search-eval-native-suite.ts`
+- `apps/mastra/src/mastra/workflows/search-eval-native-suite.test.ts`
+- `apps/mastra/src/mastra/index.ts`
+
+Approach:
+Add a Studio-facing workflow with a concrete Zod object schema and
+operator-friendly defaults. It should support syncing an existing report
+artifact by report id/path and a local sample smoke action that writes a
+realistic sample report artifact before syncing it. Register a matching
+bearer-protected service route for scriptable smoke and automation.
+
+Test scenarios:
+
+- Workflow input schema rejects unknown or unsafe actions with useful errors.
+- Sample action writes a sample report artifact and creates native records from
+  that artifact.
+- Sample action is rejected outside local/development environments.
+- Sync-report action loads a real report artifact and returns native Dataset,
+  Scorer, Experiment, and report references.
+- Service route enforces bearer auth, bounded JSON parsing, and the same input
+  validation as the workflow.
+- Existing `eval-query-generation`, `offline-search-eval`, and
+  `search-eval-candidate-review` workflows remain registered.
+
+### U4: Promoted Dataset Sync
+
+Files:
+
+- `apps/mastra/src/services/offline-search-eval/native-evaluation.ts`
+- `apps/mastra/src/services/admin-search-eval-client.ts`
+- `apps/mastra/src/services/admin-search-eval-client.test.ts`
+- `apps/mastra/src/mastra/workflows/search-eval-native-suite.ts`
+
+Approach:
+Use Admin HTTP candidate listing to sync sanitized promoted candidates into a
+separate promoted-regression Dataset. Keep this optional in local smoke so
+developers are not blocked on a production token. Never sync generated,
+pending, rejected, archived, unsanitized, or trace-raw rows. If Admin's list
+contract cannot filter by sanitization status directly, request promoted rows
+through the existing status filter and apply the `sanitizationStatus ===
+"sanitized"` check inside Mastra before constructing native Dataset items.
+
+Test scenarios:
+
+- Calls Admin candidate list with promoted status filtering and applies a
+  Mastra-side sanitized-status check when Admin does not expose that query
+  filter.
+- Maps feat-140 native Dataset item shape into native Dataset `input`,
+  `groundTruth`, and safe metadata.
+- Skips unsafe or incomplete promoted rows and returns a skipped-count summary.
+- Does not call Admin when the workflow is run in sample-report-only mode.
+
+### U5: Local Runtime And Documentation
+
+Files:
+
+- `apps/mastra/src/config/env.ts`
+- `apps/mastra/src/mastra/index.ts`
+- `apps/mastra/CLAUDE.md`
+- `docs/solutions/integration-issues/mastra-eval-workflow-local-dev-contracts.md`
+- `docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`
+
+Approach:
+Add a local-only Mastra storage backend setting for smoke tests when local
+Postgres is unavailable, while keeping durable Postgres as the normal and
+production path. Update local docs with the `localhost:4111` Studio URL,
+forwarded-port expectation, sample native suite smoke path, and idempotency
+check.
+
+Test scenarios:
+
+- Production environment rejects in-memory storage.
+- Local environment can start with in-memory storage and create native
+  Evaluation records.
+- Docs describe the host-reachable Studio URL, required env vars, sample smoke
+  payload, and idempotency verification.
+
+## Sequencing
+
+1. Build U1 and U2 first so native sync has a tested service boundary and the
+   report projection can represent real native ids.
+2. Build U3 on top of the service boundary and register the workflow/route.
+3. Add U4 promoted Dataset sync after the report-to-native path is working.
+4. Add U5 local runtime/docs so the implementation can be verified through
+   Studio without production data.
+5. Run focused tests, typecheck, lint where feasible, then perform a browser
+   regression smoke through Mastra Studio.
+
+## Validation Plan
+
+- `pnpm --filter @forge/mastra test -- offline-search-eval`
+- `pnpm --filter @forge/mastra test -- search-eval-native-suite`
+- `pnpm --filter @forge/mastra typecheck`
+- `pnpm --filter @forge/mastra lint`
+- Start Mastra Studio locally at `http://localhost:4111` with local/sample
+  storage configuration.
+- In Studio, run the search-eval native suite sample action, verify it writes a
+  report artifact, and verify native Datasets, Scorers, and Experiments appear.
+- Run the same sample action twice and confirm native Datasets/items and the
+  report Experiment are reused or updated rather than duplicated.
+- Inspect the generated native records for quality: names are clear,
+  search-quality categories are not misleading, report linkage is present, and
+  sample/local data is clearly labeled.
+
+## Risks
+
+- Native Mastra experiment APIs may create a new Experiment for every run
+  without first-class upsert. Mitigation: detect existing report-native keys
+  through listed Dataset experiments before starting a duplicate experiment.
+- Native scorers require numeric scores, while search evals need categorical
+  outcomes. Mitigation: keep category and reason explicit in output metadata and
+  use numeric score only as a roll-up signal.
+- Studio behavior may differ from the lower-level API types. Mitigation: verify
+  through the browser, not only unit tests or curl.
+- Local Postgres may be unavailable in the devcontainer. Mitigation: local-only
+  in-memory storage smoke mode, with production guardrails and clear docs.
+
+## Out Of Scope
+
+- No custom artifact browser unless native Evaluation cannot represent a
+  required concept.
+- No live search REST or GraphQL response shape changes.
+- No direct Admin database access from Mastra.
+- No automatic promotion of generated or user-submitted candidates.
+- No production data access for local smoke unless a scoped token is explicitly
+  provided.

--- a/docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md
+++ b/docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md
@@ -3,7 +3,7 @@ id: "feat-140"
 title: "Search eval human promotion and regression gates"
 owner: "nisal"
 priority: "P0"
-status: "not-started"
+status: "complete"
 start_date: "2026-05-25"
 duration: 3
 depends_on:

--- a/docs/roadmap/content-discovery/feat-141-mastra-retrieval-strategy-investigation.md
+++ b/docs/roadmap/content-discovery/feat-141-mastra-retrieval-strategy-investigation.md
@@ -4,10 +4,11 @@ title: "Mastra retrieval strategy ownership investigation"
 owner: "nisal"
 priority: "P0"
 status: "not-started"
-start_date: "2026-05-25"
+start_date: "2026-05-29"
 duration: 2
 depends_on:
   - "feat-140"
+  - "feat-142"
 blocks: []
 tags:
   - "admin"
@@ -29,10 +30,11 @@ risky for latency, reliability, and public search contracts.
 This ticket is an investigation and design proof only. It should not move live
 user search orchestration into Mastra.
 
-The evidence source should be native Mastra Evaluation where available:
-promoted Datasets from feat-140 and Experiment results from feat-142. Custom
-JSON artifacts can remain supporting evidence, but they should not be the only
-operator-quality source once native Experiments are populated.
+This ticket should run after feat-142, not before it. The evidence source must
+be native Mastra Evaluation: promoted Datasets, Scorers, and Experiment results
+from feat-142. Custom JSON artifacts can remain supporting evidence, but they
+should not be the only operator-quality source once native Experiments are
+populated.
 
 ## Entry Points - Read These First
 
@@ -94,9 +96,10 @@ rg -n "Dataset|Experiment|compareExperiments|startExperiment|search-eval" apps/m
   primitives only for any offline prototype.
 - CMS/Strapi is being deleted. Do not add, preserve, or depend on CMS support in
   this ticket. Any primitive contract must be Admin/Core-owned.
-- Do not proceed without eval evidence from promoted regression gates.
-- Do not proceed using only raw artifact reports if native Dataset/Experiment
-  records are available.
+- Do not proceed before feat-142 has created native Dataset/Scorer/Experiment
+  records for search evals.
+- Do not proceed using only raw artifact reports once native
+  Dataset/Experiment records are available.
 
 ## Verification
 

--- a/docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md
+++ b/docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md
@@ -2,13 +2,14 @@
 id: "feat-142"
 title: "Mastra native Evaluation search eval suite"
 owner: "nisal"
-priority: "P1"
-status: "not-started"
+priority: "P0"
+status: "completed"
 start_date: "2026-05-27"
 duration: 2
 depends_on:
   - "feat-140"
-blocks: []
+blocks:
+  - "feat-141"
 tags:
   - "admin"
   - "mastra"
@@ -32,6 +33,19 @@ After feat-140 adds human review and promotion semantics, operators need a
 native Mastra Evaluation experience for search evals: Datasets for seed and
 promoted prompts, Scorers for pairwise/search-specific quality scoring,
 Experiments for offline search runs, and Overview for the roll-up signal.
+
+This is the payoff for the Mastra eval migration. The goal is production-native
+Mastra Evaluation for search quality: create whatever native Mastra Evaluation
+records are necessary for the search eval suite to be the canonical operator
+experience.
+
+Production-ready must also mean locally reproducible. The same sync/run code
+path should work in local development, staging, and production, with
+environment-specific Admin URLs, bearer keys, Mastra storage/database URLs, and
+artifact roots supplied through config. A developer should be able to start
+Admin and Mastra locally, run the search-eval native Evaluation sync, and see
+the same Dataset, Scorer, Experiment, and Overview shapes in Mastra Studio
+without one-off database writes or production-only setup.
 
 The suite also needs to keep feat-139 artifacts useful without making them the
 final UX. Today the offline eval workflow can create named baseline and report
@@ -66,6 +80,10 @@ a fallback only for search-specific details that native Evaluation cannot model.
     - native Scorer API.
 12. `apps/mastra/node_modules/mastra/dist/commands/api/route-metadata.generated.d.ts`
     - Studio/API routes used by native Evaluation pages.
+13. `apps/mastra/src/services/offline-search-eval/native-evaluation.ts`
+    - feat-142 native Dataset, Scorer, Experiment sync service.
+14. `apps/mastra/src/mastra/workflows/search-eval-native-suite.ts`
+    - Studio workflow and service route for native search-eval suite sync.
 
 ## Grep These
 
@@ -85,6 +103,9 @@ rg -n "Mastra search eval|native Evaluation|Datasets|Scorers|Experiments|Overvie
      can model it.
    - Experiments for offline search eval runs.
    - Overview for roll-up experiment and scoring signal where supported.
+   Create as many native Datasets, Scorers, and Experiments as the search eval
+   domain actually needs. Do not collapse distinct concepts into a single
+   record just to make the Evaluation sidebar non-empty.
 2. Keep `eval-query-generation` and `offline-search-eval` as separate leaf
    workflows unless implementation evidence proves a single workflow is clearer
    and equally safe.
@@ -123,8 +144,90 @@ rg -n "Mastra search eval|native Evaluation|Datasets|Scorers|Experiments|Overvie
     generated candidates.
 12. Add operator-friendly defaults and result summaries so the normal path does
     not require hand-writing JSON payloads.
-13. Document which search-eval concepts native Evaluation can model directly
+13. Make native Evaluation sync and experiment creation idempotent. Re-running
+    local, staging, or production sync must update or reuse stable native
+    records instead of duplicating Datasets, Scorers, Experiments, or items.
+14. Keep environment switching config-only. Local, staging, and production
+    should use the same code path with different Admin HTTP URLs, bearer keys,
+    Mastra storage/database URLs, artifact roots, and environment labels.
+15. Document the local development path for reproducing the suite in Mastra
+    Studio, including required Admin/Mastra env vars, commands, expected
+    native records, and the idempotency check.
+16. Document which search-eval concepts native Evaluation can model directly
     and which require backing artifact metadata.
+
+## Feat-140 Dataset Bridge
+
+Feat-140 leaves native Evaluation writes deferred, but promoted Admin
+regression truth now has a stable native Dataset item shape for this ticket to
+synchronize:
+
+```json
+{
+  "input": {
+    "query": "sanitized promoted query",
+    "locale": "en",
+    "source": "seed | generated_catalog | generated_locale_quality | generated_trace | user_submitted",
+    "searchOptions": {
+      "mode": "hybrid | keyword-first",
+      "contentType": "all | video | experience"
+    }
+  },
+  "groundTruth": {
+    "expectedResultNotes": "human-reviewed safe notes",
+    "sourceAnchors": [
+      {
+        "type": "video | experience | seed_prompt_set",
+        "id": "Admin/Core owned id",
+        "locale": "en"
+      }
+    ]
+  },
+  "metadata": {
+    "candidateId": "search_eval_candidate id",
+    "sanitizationStatus": "sanitized",
+    "reviewerIdentity": "operator identity string",
+    "reviewedAt": "ISO timestamp",
+    "promotedAt": "ISO timestamp",
+    "mastraRunId": "safe Mastra run id when present",
+    "promotionRunContext": "safe JSON only"
+  }
+}
+```
+
+Only `sanitized` promoted rows should be synchronized. Generated, archived,
+rejected, pending, or unsanitized rows must stay out of native Datasets.
+Trace-derived rows must use the promoted sanitized query and sanitized anchors;
+raw trace query text and raw source payloads are not native metadata.
+
+## Implemented Shape
+
+Feat-142 adds `search-eval-native-suite` as the native Evaluation convergence
+workflow. It keeps `eval-query-generation`, `search-eval-candidate-review`, and
+`offline-search-eval` as separate leaf workflows, then projects safe report and
+promoted-candidate data into native records.
+
+- Report artifacts can be synced into an environment-labeled native Dataset,
+  the `search-result-pairwise-judge` Scorer, and one report Experiment.
+- The report's `mastraEvaluation` projection now supports
+  `custom_artifact_only` and `native_synced`; synced reports carry the real
+  Dataset, Scorer, and Experiment ids.
+- Dataset items use stable `sourceKey` metadata so reruns update existing items
+  instead of duplicating them.
+- Report Experiments use stable native keys so rerunning sync for the same
+  report reuses the existing Experiment.
+- `sync-promoted` reads promoted rows through Admin HTTP and still applies a
+  Mastra-side `sanitizationStatus === "sanitized"` check before writing native
+  Dataset items.
+- `create-sample-report` provides local smoke data when Postgres/Admin
+  production data is unavailable; it is rejected for production-like
+  environment labels.
+- Local dev can use `MASTRA_STORAGE_BACKEND=memory` only outside production to
+  inspect native Evaluation records at `http://localhost:4111`.
+- Local smoke verified on 2026-05-28 created one native Dataset
+  `search-eval:local:local-smoke`, one native Experiment with 3 completed
+  items, and 3 `search-result-pairwise-judge` scores; rerunning `sync-report`
+  reused the same native Dataset, Scorer, and Experiment.
 
 ## Constraints
 
@@ -140,9 +243,13 @@ rg -n "Mastra search eval|native Evaluation|Datasets|Scorers|Experiments|Overvie
   tokens, or unsanitized source payloads in the suite UI/workflow output.
 - Do not build a custom artifact viewer unless native Mastra Evaluation cannot
   model the required search-eval concept.
+- Do not treat native Evaluation as done until required search-eval concepts
+  are represented by production records rather than custom artifacts alone.
 - Do not expose artifact filesystem paths as the only way to inspect baselines
   or reports. Paths may appear as debug metadata, but native Evaluation records
   should be the primary operator surface when available.
+- Do not require manual database writes, production-only data access, or
+  hand-edited native Evaluation records to develop or verify the suite locally.
 - Do not change public search REST or GraphQL response shapes.
 
 ## Verification
@@ -156,6 +263,14 @@ rg -n "Mastra search eval|native Evaluation|Datasets|Scorers|Experiments|Overvie
 - Native Experiments are created for offline search eval runs and contain
   sanitized item results, scores, and metadata sufficient to navigate back to
   search-specific report artifacts when needed.
+- A fresh local dev environment can sync seed and promoted search-eval truth
+  into native Mastra Evaluation records and inspect them in Studio.
+- Re-running local sync is idempotent and does not duplicate native records or
+  dataset items.
+- The same sync and experiment workflows can target local, staging, or
+  production Admin HTTP contracts by changing environment variables only.
+- Native record names, keys, versions, and metadata clearly distinguish local,
+  staging, and production runs without changing code.
 - Overview/Experiments display real native records; the PR does not claim
   visibility based only on custom JSON artifacts.
 - Search-specific categories are represented either directly in scorer

--- a/docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md
+++ b/docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md
@@ -103,9 +103,9 @@ rg -n "Mastra search eval|native Evaluation|Datasets|Scorers|Experiments|Overvie
      can model it.
    - Experiments for offline search eval runs.
    - Overview for roll-up experiment and scoring signal where supported.
-   Create as many native Datasets, Scorers, and Experiments as the search eval
-   domain actually needs. Do not collapse distinct concepts into a single
-   record just to make the Evaluation sidebar non-empty.
+     Create as many native Datasets, Scorers, and Experiments as the search eval
+     domain actually needs. Do not collapse distinct concepts into a single
+     record just to make the Evaluation sidebar non-empty.
 2. Keep `eval-query-generation` and `offline-search-eval` as separate leaf
    workflows unless implementation evidence proves a single workflow is clearer
    and equally safe.

--- a/docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md
+++ b/docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md
@@ -1,7 +1,7 @@
 ---
 title: "Mastra native Evaluation requires real Dataset Scorer and Experiment records"
 date: "2026-05-27"
-last_updated: "2026-05-27"
+last_updated: "2026-05-28"
 category: "architecture-patterns"
 module: "apps/mastra"
 problem_type: "architecture_pattern"
@@ -58,6 +58,11 @@ checks returned empty datasets, experiments, and scorers even while workflows
 were available. That means artifacts can be a backing layer, but they are not
 the native Evaluation UI.
 
+Feat-142 implements the bridge as real native sync code. The
+`search-eval-native-suite` workflow and `/forge-search-eval-native-suite`
+service route can now create a local sample report, sync an existing report by
+id, or sync human-promoted Admin candidates into native Evaluation records.
+
 ## Guidance
 
 Make the native Evaluation surface the explicit destination whenever designing
@@ -88,6 +93,28 @@ operator UI. Feat-139 reports use a `mastraEvaluation` projection with:
 
 That gives feat-142 a stable mapping without misleading operators or creating a
 custom artifact viewer as the default UX.
+
+When the native bridge is implemented, keep the same artifact projection but
+replace it with `integrationStatus: "native_synced"` only after the system has
+created or reused real native records. The synced projection should include
+environment-labeled Dataset and Experiment names, stable native keys, real
+Dataset/Scorer/Experiment ids, and per-record sync statuses.
+
+Use stable `forgeSearchEval.nativeKey` metadata for idempotency:
+
+- Dataset key: environment + baseline + prompt-set version.
+- Dataset item key: prompt-set version + case id for report seed prompts, or
+  Admin candidate id for promoted regression prompts.
+- Experiment key: Dataset key + report id.
+
+Search by those native keys across all relevant native list pages, not just the
+first page. Long-lived Studio instances can accumulate enough Datasets or
+Experiments that first-page-only idempotency creates duplicate native records.
+
+Attach the scorer through the Dataset's `scorerIds` and then rely on the
+Dataset during `startExperiment`. Do not also pass the scorer object in
+`startExperiment({ scorers: [...] })` for the same scorer id; in local smoke
+that produced duplicate score rows for each Dataset item.
 
 ## Why This Matters
 
@@ -152,25 +179,37 @@ Feat-142 can replace the null IDs only after creating real native records:
 
 ```ts
 const dataset = await mastra.datasets.create({
-  name: `search-eval:${baselineName}`,
+  name: `search-eval:${environmentLabel}:${baselineName}`,
   targetType: "workflow",
   targetIds: ["offline-search-eval"],
   scorerIds: ["search-result-pairwise-judge"],
+  metadata: {
+    forgeSearchEval: {
+      nativeKey: `search-eval:${environmentLabel}:${baselineName}:${promptSetVersion}`,
+    },
+  },
 })
 
 await dataset.addItems(seedPromptItems)
 
 const experiment = await dataset.startExperiment({
-  name: `search-eval-compare:${baselineName}:${runId}`,
+  name: `search-eval-compare:${environmentLabel}:${baselineName}:${reportId}`,
   task: runOfflineSearchEvalTask,
-  scorers: [searchResultPairwiseJudge],
   metadata: {
+    forgeSearchEval: {
+      nativeKey: `search-eval:${environmentLabel}:${baselineName}:${promptSetVersion}:report:${reportId}`,
+    },
     baselineName,
     reportId,
     reportArtifactPath,
   },
 })
 ```
+
+For local smoke, `create-sample-report` should produce multiple outcome
+classes, not a happy-path-only run. The verified sample creates a win, a tie,
+and a both-irrelevant case, resulting in three native score rows with reasons
+that preserve the search-specific categories.
 
 Before claiming Studio visibility, validate native state, not just workflow
 state:

--- a/docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md
+++ b/docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md
@@ -1,7 +1,7 @@
 ---
 title: "Mastra offline search eval orchestration boundary pattern"
 date: "2026-05-27"
-last_updated: "2026-05-27"
+last_updated: "2026-05-28"
 category: "architecture-patterns"
 module: "apps/mastra, apps/admin"
 problem_type: "architecture_pattern"
@@ -11,6 +11,7 @@ applies_when:
   - "Mastra needs to evaluate Admin search quality without entering the live request path"
   - "A first baseline must be captured before promoted regression truth exists"
   - "Generated or trace-derived eval candidates may inform reports but must remain exploratory"
+  - "Human-reviewed search eval candidates need sanitized durable regression truth"
   - "Offline reports need durable comparison artifacts without exposing raw trace text or secrets"
 related_components:
   - "apps/mastra"
@@ -53,6 +54,12 @@ Admin baseline. The older Admin eval harness is useful as reference material
 for judge calibration, pairwise comparison, search-client retry behavior, and
 report categories, but it should not define durable regression truth.
 
+Feat-140 adds the human-promotion step that turns seed, generated, trace, and
+user-submitted candidates into durable regression truth. The ownership split
+does not change: Admin owns storage, sanitization policy, retention, review
+metadata, and regression loading; Mastra owns the operator-facing workflow and
+must call Admin through authenticated HTTP only.
+
 Mastra's native Evaluation area is the intended operator destination for this
 domain. The installed Mastra packages expose Dataset, Scorer, and Experiment
 APIs and storage tables, but feat-139 artifacts remain a backing layer until a
@@ -76,12 +83,27 @@ intent prompts. Refuse to write the named baseline if any seed search has a
 transient or failed Admin search result. A partial baseline looks convenient,
 but it poisons every future comparison.
 
-Treat generated candidates as future exploratory material, not as part of the
-operator workflow yet. Feat-138 staged candidates can remain readable through
-Admin contracts for later report experiments, but the Studio-facing offline
-eval workflow should stay seed-only until feat-140 designs human review and
-promotion. They must not be written into named baselines, comparison
-denominators, or regression gates.
+Treat generated, trace-derived, seed, and user-submitted candidates as pending
+material until a human promotes them. Pending rows can be listed, inspected,
+edited with sanitized fields, rejected, or archived through Admin contracts,
+but they must not enter named baselines, comparison denominators, regression
+gates, or native Mastra Datasets before promotion.
+
+Make promotion an Admin-owned state transition, not a Mastra-side file write.
+The promoted row should carry sanitized query text, expected-result notes,
+sanitized source anchors, reviewer identity, review/promoted timestamps,
+sanitization status, and safe run context. Admin's regression loader should
+continue reading the hand-edited `apps/admin/eval/regressions.json` first, then
+append promoted DB rows as `source: "promoted"` when a Prisma client is
+available. Baseline schemas and rebaseline code must accept that promoted
+source, or the first promoted rebaseline will write a file that cannot load.
+
+Keep user-submitted source payloads out of exposed candidate provenance.
+Submitting a prompt can store the prompt text as pending review input, but
+free-form submission notes, source claims, vectors, tokens, or provider payloads
+should not be copied into `labelProvenance`, `sourceAnchors`, or any field that
+the review surface returns. Reviewers add safe anchors and expected-result
+context through the sanitized edit contract.
 
 Trace-derived generated candidates need an even stricter rule: they may
 contribute retained counts and redacted source-mix metadata, but they should
@@ -99,9 +121,15 @@ bounded Admin routes when Mastra needs new read behavior:
 
 - `POST /api/internal/search-eval/search` runs Admin search without recording a
   production trace and without changing public `/api/search` or GraphQL shapes.
-- `GET /api/internal/search-eval/candidates` returns bounded staged generated
-  candidates for future exploratory report input; do not expose this as a
-  Studio toggle until human promotion semantics are clear.
+- `GET /api/internal/search-eval/candidates` returns bounded staged candidates
+  through a review-safe projection.
+- `GET /api/internal/search-eval/candidates/:id` returns review-safe detail.
+- `PATCH /api/internal/search-eval/candidates/:id` edits sanitized review
+  fields only; server-owned status must use action routes.
+- `POST /api/internal/search-eval/candidates/:id/promote` promotes sanitized
+  truth.
+- `POST /api/internal/search-eval/candidates/:id/reject` and
+  `/archive` move bad or duplicate rows to terminal non-gate states.
 - Existing trace and catalog context contracts remain Admin-owned and
   bearer-gated.
 
@@ -120,6 +148,14 @@ Scorer, and Experiment, but keep native IDs as `null` and mark the status as
 `custom_artifact_only` until code has actually created Mastra Evaluation
 records. This gives feat-142 a stable bridge without creating a misleading
 operator experience in Studio.
+
+For promoted truth, document the future Dataset item shape but keep native
+writes deferred until feat-142 creates real records. A promoted item should map
+to workflow input (`query`, `locale`, source, search options), ground truth
+(`expectedResultNotes`, `sourceAnchors`), and safe metadata (`candidateId`,
+sanitization status, reviewer identity, reviewed/promoted timestamps, and safe
+run context). Native Dataset, Scorer, and Experiment IDs stay `null` until the
+sync job actually populates them.
 
 Validate both sides of the report contract at runtime. The workflow output
 schema should expose the report shape, and artifact writes should reject
@@ -213,6 +249,30 @@ if (candidate.source === "trace") {
 }
 ```
 
+Promotion should overwrite the raw candidate query with sanitized truth so a
+promoted trace-derived row can outlive raw-trace retention:
+
+```ts
+await prisma.searchEvalCandidate.updateMany({
+  where: {
+    id,
+    promotionStatus: "GENERATED",
+  },
+  data: {
+    promotionStatus: "PROMOTED",
+    queryText: sanitizedQueryText,
+    sanitizedQueryText,
+    sanitizedExpectedResultNotes,
+    sanitizedSourceAnchors,
+    sanitizationStatus: "SANITIZED",
+    reviewerIdentity,
+    reviewedAt: now,
+    promotedAt: now,
+    promotionRunContext: safeRunContext,
+  },
+})
+```
+
 Route body caps should protect chunked requests too. Checking only
 `Content-Length` is insufficient because chunked bodies may omit it:
 
@@ -236,6 +296,8 @@ while (true) {
 - Mastra workflow route:
   `apps/mastra/src/mastra/workflows/offline-search-eval.ts` and
   `apps/mastra/src/mastra/index.ts`.
+- Mastra candidate review workflow:
+  `apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts`.
 - Mastra eval domain:
   `apps/mastra/src/services/offline-search-eval/runner.ts`,
   `artifacts.ts`, `judge.ts`, `report.ts`, `seed-prompt-set.ts`, and
@@ -250,7 +312,13 @@ while (true) {
   `apps/admin/src/app/api/internal/search-eval/search/route.ts`.
 - Admin candidate read/write contract:
   `apps/admin/src/app/api/internal/search-eval/candidates/route.ts` and
+  `apps/admin/src/app/api/internal/search-eval/candidates/[id]/route.ts`,
+  action routes under `candidates/[id]/`, and
   `apps/admin/src/services/search-eval/candidates.ts`.
+- Admin regression truth loading:
+  `apps/admin/src/services/search-eval/regressions.ts`,
+  `apps/admin/src/services/search-eval/baseline.ts`, and
+  `apps/admin/src/scripts/eval-search.ts`.
 - Trace sampling contract:
   `apps/admin/src/app/api/internal/search-traces/sample/route.ts`.
 

--- a/docs/solutions/integration-issues/mastra-eval-workflow-local-dev-contracts.md
+++ b/docs/solutions/integration-issues/mastra-eval-workflow-local-dev-contracts.md
@@ -1,7 +1,7 @@
 ---
 title: "Mastra eval workflow local dev requires Admin contracts and browser-reachable Studio"
 date: "2026-05-27"
-last_updated: "2026-05-27"
+last_updated: "2026-05-28"
 category: "integration-issues"
 module: "apps/mastra, apps/admin, .devcontainer"
 problem_type: "integration_issue"
@@ -125,6 +125,8 @@ Minimum Mastra-side local contract:
 
 ```bash
 DATABASE_URL=postgresql://forge:forge@db:5432/forge
+MASTRA_STORAGE_BACKEND=postgres
+MASTRA_NATIVE_EVAL_ENVIRONMENT=local
 MASTRA_SERVICE_API_KEYS=local-mastra-service-key
 ADMIN_SEARCH_TRACE_SAMPLE_URL=http://127.0.0.1:3003/api/internal/search-traces/sample
 ADMIN_SEARCH_EVAL_CATALOG_CONTEXT_URL=http://127.0.0.1:3003/api/internal/search-eval/catalog-context
@@ -137,6 +139,21 @@ OPENROUTER_API_KEY=
 SEARCH_EVAL_JUDGE_MODEL=anthropic/claude-haiku-4-5
 pnpm --filter @forge/mastra dev
 ```
+
+When local Postgres is unavailable and the goal is only to smoke the native
+Evaluation projection, use local-only in-memory storage instead:
+
+```bash
+MASTRA_STORAGE_BACKEND=memory
+MASTRA_NATIVE_EVAL_ENVIRONMENT=local
+MASTRA_SERVICE_API_KEYS=local-mastra-service-key
+MASTRA_SEARCH_EVAL_ARTIFACT_DIR=.mastra/storage/search-eval
+pnpm --filter @forge/mastra dev
+```
+
+`MASTRA_STORAGE_BACKEND=memory` is rejected in production and loses records on
+process exit. It is only for proving that a report artifact can become native
+Dataset, Scorer, and Experiment records in Studio.
 
 For browser reachability, prefer a real devcontainer port mapping for `4111`.
 When the running devcontainer has not been rebuilt with that mapping, a
@@ -228,6 +245,32 @@ marks the Studio run red after writing a report artifact path into the typed
 failure result. That is intentional: a failure report is useful evidence, but a
 green workflow card would be a false signal for operators.
 
+For the feat-142 native Evaluation smoke, open **Workflows**, select
+`search-eval-native-suite`, and run the default Form values:
+
+```text
+action: create-sample-report
+baselineName: local-smoke
+environmentLabel: local
+promotedLimit: 100
+```
+
+That action writes a realistic sample comparison report artifact, syncs the
+report into native Datasets, Scorers, and Experiments, then writes the native ids
+back into the report's `mastraEvaluation` projection. After the run, open the
+native **Evaluation** area and verify records named like:
+
+```text
+Dataset: search-eval:local:local-smoke
+Scorer: Search result pairwise judge
+Experiment: search-eval-compare:local:local-smoke:<run id>
+```
+
+Run the same workflow a second time with the same report id through
+`action=sync-report` if you want to prove idempotency for a fixed artifact. The
+Dataset should stay singular, items should update by source key, and the report
+Experiment should be reused instead of duplicated.
+
 ## Why This Works
 
 Mastra does not read Admin's database directly. The eval workflow needs Admin's
@@ -275,6 +318,9 @@ same failure into clean HTTP JSON.
 - For `offline-search-eval`, smoke capture first with `{}` or the default Form
   values, then run compare only after a named baseline exists and
   `OPENROUTER_API_KEY` is configured.
+- For `search-eval-native-suite`, use `create-sample-report` with
+  `MASTRA_STORAGE_BACKEND=memory` when local Postgres or Admin data is
+  unavailable. Use `sync-promoted` only when Admin candidate env is configured.
 - Confirm `/api/workflows/eval-query-generation/runs` and
   `search_eval_candidate` rows after a Studio run. Seeing a Studio "success" row
   alone is not enough because `{ ok: false }` is still a completed workflow


### PR DESCRIPTION
## Summary

Search evals can now move from generated/pending signals to human-promoted regression truth and then into Mastra's native Evaluation surface. Operators get review-safe Admin promotion routes, a Mastra candidate-review workflow, and a native Evaluation sync workflow that writes real Datasets, Scorers, Experiments, and score rows instead of leaving reports trapped in filesystem artifacts.

## What Changed

| Area | Outcome |
| --- | --- |
| Admin promotion gates | Search eval candidates now have review/edit/detail/action routes for sanitized review, promotion, rejection, and archive flows. |
| Durable regression truth | Promoted candidates flow into regression loading without exposing raw trace text or unsafe source payloads. |
| Mastra operator workflow | `search-eval-candidate-review` wraps Admin review contracts for Studio/service callers. |
| Native Evaluation suite | `search-eval-native-suite` projects report artifacts and promoted candidates into native Mastra Datasets, Scorers, Experiments, and score records. |
| Local/production config | Mastra now supports environment-labeled native eval sync, local-only memory storage for Studio smoke, and production guardrails. |

## Design Notes

- Generated and trace-derived candidates remain exploratory until a human sanitizes and promotes them through Admin-owned state transitions.
- Native Dataset items use stable prompt-set/case keys so repeated report syncs update the same Dataset items rather than accumulating stale report-specific items.
- Report Experiments remain report-specific and idempotent by native metadata key.
- The pairwise search scorer maps search-specific categories into native numeric scores while preserving the outcome class and rationale in score reasons.
- Custom JSON reports stay as backing detail; native Mastra Evaluation is now the operator entry point when records are synced.

## Rollout Notes

- Admin includes migration `0024_search_eval_human_promotion`; deploy needs the normal Prisma migration path.
- Production Mastra should keep `MASTRA_STORAGE_BACKEND=postgres` or omit it. `memory` is rejected in production and exists only for local Studio smoke.
- Native eval names include `MASTRA_NATIVE_EVAL_ENVIRONMENT` so local/staging/production records stay separated.
- `sync-promoted` needs the existing Admin candidate URL/key config: `ADMIN_SEARCH_EVAL_CANDIDATES_URL` and `ADMIN_SEARCH_EVAL_API_KEY`.

## Validation

- `pnpm --filter @forge/admin db:generate`
- `pnpm --filter @forge/admin typecheck` after clearing stale ignored `.next/dev/types` output
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin test -- search-eval` — 211 tests passed
- `pnpm --filter @forge/admin build` — passed with existing Turbopack tracing warnings around `video-db-backup`/`next.config.ts`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/mastra lint`
- `pnpm --filter @forge/mastra test -- offline-search-eval native-evaluation search-eval-native-suite` — 74 tests passed
- `pnpm --filter @forge/mastra build` — passed; Mastra warned deploy will fall back to npm install after package-lock generation failed
- `git diff --check`
- `ce-compound` frontmatter validation for touched solution docs

## Browser Smoke

Using Chromium against local Mastra Studio at `http://localhost:4111/studio`:

- Opened `search-eval-native-suite` in Workflows.
- Clicked the Studio `Run` button twice with `create-sample-report` and `environmentLabel=local`.
- Confirmed both workflow runs showed `success` in Studio.
- Confirmed the native Dataset page showed `search-eval:local:local-smoke`.
- Confirmed the Scorers page showed the pairwise search scorer.
- Confirmed the Experiments page showed completed local-smoke experiments.
- Confirmed native API state after repeated UI runs: one Dataset, 3 Dataset items, 4 clean local Experiments total, every Experiment `3/3` succeeded and `0` failed, with score reasons for win/tie/both-irrelevant outcomes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
