### PR TITLE
feat(web): gate watch question panel behind LaunchDarkly

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -39,6 +39,7 @@ LAUNCHDARKLY_SDK_KEY=
 FORGE_WATCH_PLAYER_MIGRATION_DEFAULT=false
 FORGE_WATCH_HERO_MUX_VIDEO_DEFAULT=false
 FORGE_WATCH_CTA_TEXT_COPY_DEFAULT=false
+FORGE_WATCH_QUESTION_PANEL_DEFAULT=false
 
 # Inline watch-player migration. Existing build-time flag; kept for dynamic
 # import dead-code elimination until those callsites are intentionally migrated.

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -92,4 +92,10 @@ flag for the watch-page Download CTA copy. `false` keeps `Download`; `true`
 renders `Save Video`. Keep `FORGE_WATCH_CTA_TEXT_COPY_DEFAULT=false` in local
 and Railway envs unless intentionally testing the fallback path.
 
+`forge.watch.questionPanel` is a temporary LaunchDarkly-backed release flag
+for the watch-page floating question panel. `false` hides the panel;
+`true` renders the floating input and message-type selector. Keep
+`FORGE_WATCH_QUESTION_PANEL_DEFAULT=false` in local and Railway envs unless
+intentionally testing the panel.
+
 See root `CLAUDE.md` for cross-app patterns and the broader data-layer-flip plan reference.

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -86,6 +86,29 @@
     "chatWithPerson": "Mit einer Person chatten",
     "askBibleQuestion": "Eine Bibelfrage stellen"
   },
+  "WatchQuestionPanel": {
+    "messageType": "Nachrichtentyp",
+    "fieldLabel": "Eine Frage zu diesem Video stellen",
+    "send": "Frage senden",
+    "prompts": {
+      "bibleQuestion": {
+        "label": "Eine Bibelfrage stellen",
+        "description": "Sofortige Antworten aus der Bibel mit KI-Suche"
+      },
+      "prayerRequest": {
+        "label": "Gebet anfragen",
+        "description": "Teilen Sie mit, wofür Sie Gebet möchten"
+      },
+      "comment": {
+        "label": "Kommentar hinterlassen",
+        "description": "Gedanken zu diesem Video senden"
+      },
+      "personChat": {
+        "label": "Mit einer Person chatten",
+        "description": "Sprechen Sie jetzt mit jemandem"
+      }
+    }
+  },
   "ShareModal": {
     "dialogTitle": "Video teilen",
     "heading": "Dieses Video teilen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -86,6 +86,29 @@
     "chatWithPerson": "Chat with a person",
     "askBibleQuestion": "Ask a Bible question"
   },
+  "WatchQuestionPanel": {
+    "messageType": "Message type",
+    "fieldLabel": "Ask a question about this video",
+    "send": "Send question",
+    "prompts": {
+      "bibleQuestion": {
+        "label": "Ask a Bible question",
+        "description": "Instant answers from the Bible using AI search"
+      },
+      "prayerRequest": {
+        "label": "Request a prayer",
+        "description": "Share what you want prayer for"
+      },
+      "comment": {
+        "label": "Leave a comment",
+        "description": "Send thoughts about this video"
+      },
+      "personChat": {
+        "label": "Chat with a person",
+        "description": "Talk with someone now"
+      }
+    }
+  },
   "ShareModal": {
     "dialogTitle": "Share video",
     "heading": "Share this video",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -86,6 +86,29 @@
     "chatWithPerson": "Chatear con una persona",
     "askBibleQuestion": "Hacer una pregunta bíblica"
   },
+  "WatchQuestionPanel": {
+    "messageType": "Tipo de mensaje",
+    "fieldLabel": "Haz una pregunta sobre este video",
+    "send": "Enviar pregunta",
+    "prompts": {
+      "bibleQuestion": {
+        "label": "Haz una pregunta bíblica",
+        "description": "Respuestas instantáneas de la Biblia con búsqueda de IA"
+      },
+      "prayerRequest": {
+        "label": "Solicita oración",
+        "description": "Comparte por qué quieres oración"
+      },
+      "comment": {
+        "label": "Deja un comentario",
+        "description": "Envía tus pensamientos sobre este video"
+      },
+      "personChat": {
+        "label": "Chatea con una persona",
+        "description": "Habla con alguien ahora"
+      }
+    }
+  },
   "ShareModal": {
     "dialogTitle": "Compartir video",
     "heading": "Comparte este video",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -86,6 +86,29 @@
     "chatWithPerson": "Discuter avec une personne",
     "askBibleQuestion": "Poser une question biblique"
   },
+  "WatchQuestionPanel": {
+    "messageType": "Type de message",
+    "fieldLabel": "Posez une question sur cette vidéo",
+    "send": "Envoyer la question",
+    "prompts": {
+      "bibleQuestion": {
+        "label": "Poser une question biblique",
+        "description": "Réponses instantanées de la Bible avec la recherche IA"
+      },
+      "prayerRequest": {
+        "label": "Demander une prière",
+        "description": "Partagez ce pour quoi vous voulez une prière"
+      },
+      "comment": {
+        "label": "Laisser un commentaire",
+        "description": "Envoyez vos pensées sur cette vidéo"
+      },
+      "personChat": {
+        "label": "Discuter avec une personne",
+        "description": "Parlez avec quelqu'un maintenant"
+      }
+    }
+  },
   "ShareModal": {
     "dialogTitle": "Partager la vidéo",
     "heading": "Partagez cette vidéo",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -86,6 +86,29 @@
     "chatWithPerson": "Conversar com uma pessoa",
     "askBibleQuestion": "Fazer uma pergunta bíblica"
   },
+  "WatchQuestionPanel": {
+    "messageType": "Tipo de mensagem",
+    "fieldLabel": "Faça uma pergunta sobre este vídeo",
+    "send": "Enviar pergunta",
+    "prompts": {
+      "bibleQuestion": {
+        "label": "Fazer uma pergunta bíblica",
+        "description": "Respostas instantâneas da Bíblia com busca por IA"
+      },
+      "prayerRequest": {
+        "label": "Pedir oração",
+        "description": "Compartilhe pelo que você quer oração"
+      },
+      "comment": {
+        "label": "Deixar um comentário",
+        "description": "Envie pensamentos sobre este vídeo"
+      },
+      "personChat": {
+        "label": "Conversar com uma pessoa",
+        "description": "Fale com alguém agora"
+      }
+    }
+  },
   "ShareModal": {
     "dialogTitle": "Compartilhar vídeo",
     "heading": "Compartilhe este vídeo",

--- a/apps/web/src/app/[slug]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[slug]/[...rest]/__tests__/page-routing.test.tsx
@@ -20,9 +20,11 @@ const {
   redirectMock,
   seriesPageClientMock,
   watchPageClientMock,
+  watchQuestionPanelMock,
   experienceEmptyMock,
   experienceErrorMock,
   isWatchCtaTextCopyEnabledMock,
+  isWatchQuestionPanelEnabledMock,
 } = vi.hoisted(() => ({
   resolveWatchVideoBySlugMock: vi.fn(),
   resolveSeriesBySlugMock: vi.fn(),
@@ -39,9 +41,11 @@ const {
       null,
   ),
   watchPageClientMock: vi.fn((_props: unknown) => null),
+  watchQuestionPanelMock: vi.fn((_props: unknown) => null),
   experienceEmptyMock: vi.fn(() => null),
   experienceErrorMock: vi.fn(() => null),
   isWatchCtaTextCopyEnabledMock: vi.fn(async () => false),
+  isWatchQuestionPanelEnabledMock: vi.fn(async () => false),
 }))
 
 vi.mock("@/lib/admin-client", () => ({
@@ -73,6 +77,10 @@ vi.mock("@/components/watch/WatchPageClient", () => ({
   WatchPageClient: watchPageClientMock,
 }))
 
+vi.mock("@/components/watch/WatchQuestionPanel", () => ({
+  WatchQuestionPanel: watchQuestionPanelMock,
+}))
+
 vi.mock("@/components/ExperienceEmpty", () => ({
   ExperienceEmpty: experienceEmptyMock,
 }))
@@ -87,6 +95,7 @@ vi.mock("@/components/sections", () => ({
 
 vi.mock("@/lib/feature-flags", () => ({
   isWatchCtaTextCopyEnabled: isWatchCtaTextCopyEnabledMock,
+  isWatchQuestionPanelEnabled: isWatchQuestionPanelEnabledMock,
 }))
 
 import SlugRestPage from "@/app/[slug]/[...rest]/page"
@@ -108,10 +117,13 @@ beforeEach(() => {
   })
   seriesPageClientMock.mockClear()
   watchPageClientMock.mockClear()
+  watchQuestionPanelMock.mockClear()
   experienceEmptyMock.mockClear()
   experienceErrorMock.mockClear()
   isWatchCtaTextCopyEnabledMock.mockReset()
   isWatchCtaTextCopyEnabledMock.mockResolvedValue(false)
+  isWatchQuestionPanelEnabledMock.mockReset()
+  isWatchQuestionPanelEnabledMock.mockResolvedValue(false)
   container = document.createElement("div")
   document.body.appendChild(container)
   root = createRoot(container)
@@ -277,6 +289,11 @@ describe("Catch-all routing — series branch (2-seg)", () => {
     )
     await render2Seg("jesus", "en")
     expect(watchPageClientMock).toHaveBeenCalledTimes(1)
+    expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        questionPanelEnabled: false,
+      }),
+    )
     expect(seriesPageClientMock).not.toHaveBeenCalled()
   })
 
@@ -294,6 +311,24 @@ describe("Catch-all routing — series branch (2-seg)", () => {
     expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         downloadButtonLabel: "Save Video",
+      }),
+    )
+  })
+
+  it("passes the LaunchDarkly question panel flag to WatchPageClient when enabled", async () => {
+    isWatchQuestionPanelEnabledMock.mockResolvedValue(true)
+    resolveWatchVideoBySlugMock.mockResolvedValue(
+      makeWatchVideoResult("featureFilm"),
+    )
+
+    await render2Seg("jesus.html", "english.html")
+
+    expect(isWatchQuestionPanelEnabledMock).toHaveBeenCalledWith({
+      custom: { route: "/watch/jesus.html/english.html" },
+    })
+    expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        questionPanelEnabled: true,
       }),
     )
   })
@@ -318,6 +353,37 @@ describe("Catch-all routing — Experience precedence (2-seg)", () => {
     )
     await render2Seg("easter", "en")
     expect(seriesPageClientMock).not.toHaveBeenCalled()
+    expect(watchPageClientMock).not.toHaveBeenCalled()
+    expect(watchQuestionPanelMock).not.toHaveBeenCalled()
+    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
+  })
+
+  it("renders the gated question panel for curated watch experiences when enabled", async () => {
+    isWatchQuestionPanelEnabledMock.mockResolvedValue(true)
+    resolveWatchPageMock.mockResolvedValue({
+      data: {
+        kind: "experience",
+        experience: {
+          id: "exp-1",
+          slug: "easter",
+          title: "Easter",
+          blocks: [{ __typename: "TextBlock", id: "blk-1", text: "Hello" }],
+        },
+      },
+      error: null,
+    })
+
+    await render2Seg("easter.html", "english.html")
+
+    expect(isWatchQuestionPanelEnabledMock).toHaveBeenCalledWith({
+      custom: { route: "/watch/easter.html/english.html" },
+    })
+    expect(watchQuestionPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+      }),
+      undefined,
+    )
     expect(watchPageClientMock).not.toHaveBeenCalled()
     expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
   })
@@ -541,6 +607,29 @@ describe("Catch-all routing — 3-seg episode branch", () => {
     expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         downloadButtonLabel: "Save Video",
+      }),
+    )
+  })
+
+  it("passes the LaunchDarkly question panel flag to WatchPageClient when enabled", async () => {
+    isWatchQuestionPanelEnabledMock.mockResolvedValue(true)
+    resolveSeriesEpisodeBySlugMock.mockResolvedValue(makeEpisodeResult())
+
+    await render3Seg(
+      "lumo-the-gospel-of-john.html",
+      "wedding-in-cana",
+      "english.html",
+    )
+
+    expect(isWatchQuestionPanelEnabledMock).toHaveBeenCalledWith({
+      custom: {
+        route:
+          "/watch/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+      },
+    })
+    expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        questionPanelEnabled: true,
       }),
     )
   })

--- a/apps/web/src/app/[slug]/[...rest]/page.tsx
+++ b/apps/web/src/app/[slug]/[...rest]/page.tsx
@@ -7,6 +7,7 @@ import { ExperienceError } from "@/components/ExperienceError"
 import { ExperienceSectionRenderer, type Section } from "@/components/sections"
 import { SeriesPageClient } from "@/components/watch/SeriesPageClient"
 import { WatchPageClient } from "@/components/watch/WatchPageClient"
+import { WatchQuestionPanel } from "@/components/watch/WatchQuestionPanel"
 import {
   isSeriesRecord,
   isWatchPageMissingError,
@@ -21,7 +22,10 @@ import {
   getWatchPageMetadata,
 } from "@/lib/experience-metadata"
 import { hasUiLocale } from "@/i18n/locales"
-import { isWatchCtaTextCopyEnabled } from "@/lib/feature-flags"
+import {
+  isWatchCtaTextCopyEnabled,
+  isWatchQuestionPanelEnabled,
+} from "@/lib/feature-flags"
 import { DEFAULT_LOCALE, resolveUiLocale } from "@/lib/locale"
 import {
   tryAsContentSlug,
@@ -106,6 +110,12 @@ async function getDownloadButtonLabel(route: string): Promise<string> {
     custom: { route },
   })
   return useUpdatedCtaCopy ? "Save Video" : "Download"
+}
+
+async function getQuestionPanelEnabled(route: string): Promise<boolean> {
+  return isWatchQuestionPanelEnabled({
+    custom: { route },
+  })
 }
 
 export async function generateMetadata({
@@ -222,9 +232,11 @@ async function renderEpisode(shape: {
   })
   if (!mergedBlocks.length) return <ExperienceEmpty />
 
-  const downloadButtonLabel = await getDownloadButtonLabel(
-    `/watch/${seriesSlug}.html/${episodeSlug}/${rawLocale}.html`,
-  )
+  const route = `/watch/${seriesSlug}.html/${episodeSlug}/${rawLocale}.html`
+  const [downloadButtonLabel, questionPanelEnabled] = await Promise.all([
+    getDownloadButtonLabel(route),
+    getQuestionPanelEnabled(route),
+  ])
   const lcpPlaybackId = resolved.selectedVariant.muxVideo?.playbackId ?? null
 
   return (
@@ -244,6 +256,7 @@ async function renderEpisode(shape: {
         video={resolved.video}
         languageSlug={resolved.selectedVariant.language?.slug ?? rawLocale}
         locale={locale}
+        questionPanelEnabled={questionPanelEnabled}
       />
     </>
   )
@@ -256,6 +269,7 @@ async function renderVideo(shape: {
   locale: string
 }) {
   const { slug, rawLocale, locale } = shape
+  const route = `/watch/${slug}.html/${rawLocale}.html`
 
   // Experience-first precedence: when an editor curated an Experience at
   // this slug, that's the intended landing — even when a slug-colliding
@@ -268,8 +282,15 @@ async function renderVideo(shape: {
       (b): b is Section => b !== null,
     )
     if (blocks.length) {
+      const questionPanelEnabled = await getQuestionPanelEnabled(route)
       return (
-        <main className="min-h-screen bg-stone-900">
+        <main
+          className={`min-h-screen bg-stone-900 ${
+            questionPanelEnabled
+              ? "pb-[calc(5.75rem+env(safe-area-inset-bottom,0px))] sm:pb-0"
+              : ""
+          }`}
+        >
           {blocks.map((block, i) => {
             const key =
               "id" in block && typeof block.id === "string"
@@ -283,6 +304,9 @@ async function renderVideo(shape: {
               />
             )
           })}
+          {questionPanelEnabled ? (
+            <WatchQuestionPanel enabled={questionPanelEnabled} />
+          ) : null}
         </main>
       )
     }
@@ -322,9 +346,10 @@ async function renderVideo(shape: {
       variant: watchVideo.selectedVariant,
       canonicalParent: watchVideo.canonicalParent,
     })
-    const downloadButtonLabel = await getDownloadButtonLabel(
-      `/watch/${slug}.html/${rawLocale}.html`,
-    )
+    const [downloadButtonLabel, questionPanelEnabled] = await Promise.all([
+      getDownloadButtonLabel(route),
+      getQuestionPanelEnabled(route),
+    ])
     const lcpPlaybackId =
       watchVideo.selectedVariant.muxVideo?.playbackId ?? null
     return (
@@ -344,6 +369,7 @@ async function renderVideo(shape: {
           video={watchVideo.video}
           languageSlug={watchVideo.selectedVariant.language?.slug ?? rawLocale}
           locale={locale}
+          questionPanelEnabled={questionPanelEnabled}
         />
       </>
     )
@@ -378,9 +404,16 @@ async function renderVideo(shape: {
   if (!blocks.length) {
     return <ExperienceEmpty />
   }
+  const questionPanelEnabled = await getQuestionPanelEnabled(route)
 
   return (
-    <main className="min-h-screen bg-stone-900">
+    <main
+      className={`min-h-screen bg-stone-900 ${
+        questionPanelEnabled
+          ? "pb-[calc(5.75rem+env(safe-area-inset-bottom,0px))] sm:pb-0"
+          : ""
+      }`}
+    >
       {blocks.map((block, i) => {
         const key =
           "id" in block && typeof block.id === "string"
@@ -394,6 +427,9 @@ async function renderVideo(shape: {
           />
         )
       })}
+      {questionPanelEnabled ? (
+        <WatchQuestionPanel enabled={questionPanelEnabled} />
+      ) : null}
     </main>
   )
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -18,6 +18,7 @@
   --animate-overlay-fade-out: overlay-fade-out 200ms ease-out forwards;
   --animate-card-enter: card-enter 300ms ease-out both;
   --animate-card-exit: card-exit 200ms ease-in forwards;
+  --animate-watch-panel-swap: watch-panel-swap 360ms ease-out both;
 }
 
 :root {
@@ -222,6 +223,16 @@
   to {
     opacity: 0;
     transform: translateY(-8px) scale(0.97);
+  }
+}
+@keyframes watch-panel-swap {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -31,6 +31,7 @@ const ShareModal = dynamic(
   { ssr: false },
 )
 import { SubtitleTranscript } from "@/components/watch/SubtitleTranscript"
+import { WatchQuestionPanel } from "@/components/watch/WatchQuestionPanel"
 import { WatchSectionRenderer } from "@/components/watch/WatchSectionRenderer"
 import type {
   MergedWatchBlock,
@@ -88,6 +89,7 @@ type WatchPageClientProps = {
    * BibleGateway "Read more..." link pick the right translation.
    */
   locale?: string
+  questionPanelEnabled?: boolean
 }
 
 export function WatchPageClient({
@@ -97,6 +99,7 @@ export function WatchPageClient({
   video,
   languageSlug,
   locale,
+  questionPanelEnabled = false,
 }: WatchPageClientProps) {
   // Lifted so LanguagePickerModal can read `currentTime` for the `?t=` clamp
   // on language switches.
@@ -263,7 +266,11 @@ export function WatchPageClient({
     <main
       data-testid="watch-page-client"
       data-modal-state={modalState}
-      className="min-h-screen bg-stone-900 font-sans text-stone-100 [&_button]:font-sans [&_h1]:font-sans [&_h2]:font-sans [&_h3]:font-sans [&_h4]:font-sans [&_h5]:font-sans [&_h6]:font-sans [&_p]:font-sans"
+      className={`min-h-screen bg-stone-900 font-sans text-stone-100 [&_button]:font-sans [&_h1]:font-sans [&_h2]:font-sans [&_h3]:font-sans [&_h4]:font-sans [&_h5]:font-sans [&_h6]:font-sans [&_p]:font-sans ${
+        questionPanelEnabled
+          ? "pb-[calc(5.75rem+env(safe-area-inset-bottom,0px))] sm:pb-0"
+          : ""
+      }`}
     >
       <WatchSectionRenderer
         blocks={mergedBlocks}
@@ -312,6 +319,12 @@ export function WatchPageClient({
         playbackId={variant.muxVideo?.playbackId ?? null}
         onClose={closeModal}
       />
+      {questionPanelEnabled ? (
+        <WatchQuestionPanel
+          enabled={questionPanelEnabled}
+          modalSuppressed={modalState !== "none"}
+        />
+      ) : null}
     </main>
   )
 }

--- a/apps/web/src/components/watch/WatchQuestionPanel.tsx
+++ b/apps/web/src/components/watch/WatchQuestionPanel.tsx
@@ -1,0 +1,291 @@
+"use client"
+
+import { useEffect, useRef, useState, type FormEvent } from "react"
+import {
+  BookOpenText,
+  Check,
+  HandHeart,
+  MessageSquareText,
+  MessagesSquare,
+  SendHorizontal,
+  type LucideIcon,
+} from "lucide-react"
+import { useTranslations } from "next-intl"
+
+import { useFloatingSearchPinned } from "@/components/FloatingSearchProvider"
+import { WatchModalViewportCloseButton } from "@/components/watch/WatchModalViewportCloseButton"
+import { WATCH_PAGE_CONTENT_CLASSES } from "@/lib/content-width"
+import { GLASS_OUTLINE_CLASS } from "@/lib/glass-outline"
+
+const PROMPT_ROTATION_MS = 3000
+const FIELD_BASE_CLASS = `group flex min-h-14 min-w-0 cursor-text items-center gap-3 rounded-[35px] px-6 py-3 text-left shadow-xl ${GLASS_OUTLINE_CLASS} transition-[background-color,color] duration-300 ease-out`
+const FIELD_GLASS_CLASS =
+  "bg-white/10 text-white backdrop-blur-[10px] hover:bg-white hover:text-stone-950"
+const FIELD_SOLID_CLASS = "bg-white text-stone-950"
+const COMMENT_PROMPT_INDEX = 2
+
+type PromptConfig = {
+  id: "bibleQuestion" | "prayerRequest" | "comment" | "personChat"
+  Icon: LucideIcon
+}
+
+const PROMPT_CONFIGS: PromptConfig[] = [
+  { id: "bibleQuestion", Icon: BookOpenText },
+  { id: "prayerRequest", Icon: HandHeart },
+  { id: "comment", Icon: MessageSquareText },
+  { id: "personChat", Icon: MessagesSquare },
+]
+
+type WatchQuestionPanelProps = {
+  enabled: boolean
+  modalSuppressed?: boolean
+}
+
+export function WatchQuestionPanel({
+  enabled,
+  modalSuppressed = false,
+}: WatchQuestionPanelProps) {
+  const t = useTranslations("WatchQuestionPanel")
+  const { pinned, searchOpen } = useFloatingSearchPinned()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [question, setQuestion] = useState("")
+  const [promptIndex, setPromptIndex] = useState(0)
+  const [selectedPromptIndex, setSelectedPromptIndex] =
+    useState(COMMENT_PROMPT_INDEX)
+  const [chatOpen, setChatOpen] = useState(false)
+  const hasQuestion = question.trim().length > 0
+  const currentPrompt = PROMPT_CONFIGS[promptIndex]!
+  const selectedPrompt = PROMPT_CONFIGS[selectedPromptIndex]!
+  const iconPrompt = chatOpen ? selectedPrompt : currentPrompt
+  const PromptIcon = iconPrompt.Icon
+  const visible = enabled && pinned && !searchOpen && !modalSuppressed
+  const modalOpen = visible && chatOpen
+
+  useEffect(() => {
+    if (!visible || hasQuestion || chatOpen) return
+    const timer = window.setInterval(() => {
+      setPromptIndex((current) => (current + 1) % PROMPT_CONFIGS.length)
+    }, PROMPT_ROTATION_MS)
+    return () => window.clearInterval(timer)
+  }, [chatOpen, hasQuestion, visible])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setQuestion("")
+  }
+
+  const openChatModal = () => {
+    if (!visible) return
+    setChatOpen(true)
+  }
+
+  const handlePromptSelect = (index: number) => {
+    if (!modalOpen) return
+    setSelectedPromptIndex(index)
+    setPromptIndex(index)
+    inputRef.current?.focus()
+  }
+
+  const closeChatModal = () => {
+    setChatOpen(false)
+    inputRef.current?.blur()
+  }
+
+  const promptLabel = (prompt: PromptConfig) => t(`prompts.${prompt.id}.label`)
+  const promptDescription = (prompt: PromptConfig) =>
+    t(`prompts.${prompt.id}.description`)
+
+  return (
+    <>
+      <WatchModalViewportCloseButton
+        open={modalOpen}
+        onClose={closeChatModal}
+        testId="watch-question-panel-close"
+      />
+      <div
+        aria-hidden={modalOpen ? undefined : true}
+        data-testid="watch-question-panel-modal"
+        onClick={closeChatModal}
+        className={`fixed inset-0 z-[55] transition-opacity duration-200 ease-out ${
+          modalOpen
+            ? "pointer-events-auto opacity-100"
+            : "pointer-events-none opacity-0"
+        }`}
+      >
+        <div
+          aria-hidden="true"
+          data-testid="watch-question-panel-backdrop"
+          className="absolute inset-0 bg-black/75 backdrop-blur-[12px]"
+        />
+        <div
+          data-testid="watch-question-panel-modal-content"
+          onClick={(event) => event.stopPropagation()}
+          className={`relative z-10 flex min-h-dvh items-end pb-[calc(env(safe-area-inset-bottom,0px)+6.75rem)] text-white ${WATCH_PAGE_CONTENT_CLASSES}`}
+        >
+          <section
+            aria-labelledby="watch-question-panel-intent-heading"
+            className="w-full max-w-[640px] space-y-4"
+          >
+            <h2
+              id="watch-question-panel-intent-heading"
+              className="text-xs font-semibold tracking-[0.18em] text-white/55 uppercase"
+            >
+              {t("messageType")}
+            </h2>
+            <div className="relative">
+              <div
+                data-testid="watch-question-panel-options"
+                className="divide-y divide-white/12 overflow-hidden rounded-lg border border-white/15 bg-white/[0.06]"
+              >
+                {PROMPT_CONFIGS.map((prompt, index) => {
+                  const OptionIcon = prompt.Icon
+                  const selected = selectedPromptIndex === index
+                  const label = promptLabel(prompt)
+
+                  return (
+                    <button
+                      key={prompt.id}
+                      type="button"
+                      aria-pressed={selected}
+                      data-testid={`watch-question-panel-option-${index}`}
+                      onClick={() => handlePromptSelect(index)}
+                      className={`group flex min-h-16 w-full cursor-pointer items-center gap-4 px-3 py-3 text-left transition-[background-color,color,box-shadow] duration-200 ease-out focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:outline-none ${
+                        selected
+                          ? "bg-black/[0.18] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.04),inset_0_12px_28px_rgba(0,0,0,0.34)]"
+                          : "text-white/70 hover:text-white"
+                      }`}
+                    >
+                      <span
+                        aria-hidden="true"
+                        data-testid={`watch-question-panel-option-icon-${index}`}
+                        className={`grid h-8 w-8 shrink-0 place-items-center transition-colors duration-200 ${
+                          selected ? "text-white" : "text-white/70"
+                        }`}
+                      >
+                        <OptionIcon aria-hidden className="h-6 w-6" />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-base leading-[1.08] font-medium">
+                          {label}
+                        </span>
+                        <span
+                          className={`mt-0.5 block text-xs leading-[1.1] font-light ${
+                            selected ? "text-white" : "text-white/42"
+                          }`}
+                        >
+                          {promptDescription(prompt)}
+                        </span>
+                      </span>
+                      <Check
+                        aria-hidden
+                        data-testid={`watch-question-panel-option-check-${index}`}
+                        className={`h-5 w-5 shrink-0 transition-opacity duration-200 ${
+                          selected
+                            ? "text-white opacity-100"
+                            : "text-white/40 opacity-0"
+                        }`}
+                      />
+                    </button>
+                  )
+                })}
+              </div>
+              <span
+                aria-hidden="true"
+                data-testid="watch-question-panel-tail"
+                className="absolute bottom-[-0.38rem] left-1/2 h-3 w-3 -translate-x-1/2 rotate-45 border-r border-b border-white/15 bg-white/[0.06]"
+              />
+            </div>
+          </section>
+        </div>
+      </div>
+      <form
+        aria-label={t("fieldLabel")}
+        aria-hidden={visible ? undefined : true}
+        inert={visible ? undefined : true}
+        data-testid="watch-mobile-question-panel"
+        onSubmit={handleSubmit}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") closeChatModal()
+        }}
+        className={`pointer-events-none fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom,0px)+0.875rem)] z-[57] transition-[opacity,transform] duration-200 ease-out ${
+          visible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+        }`}
+      >
+        <div
+          data-testid="watch-question-panel-rail"
+          className={WATCH_PAGE_CONTENT_CLASSES}
+        >
+          <div
+            data-testid="watch-question-panel-surface"
+            className={`${FIELD_BASE_CLASS} ${
+              chatOpen ? FIELD_SOLID_CLASS : FIELD_GLASS_CLASS
+            } ${visible ? "pointer-events-auto" : "pointer-events-none"}`}
+          >
+            <span
+              aria-hidden="true"
+              data-testid="watch-mobile-question-panel-icon"
+              data-current-prompt={promptLabel(iconPrompt)}
+              className={`grid h-6 w-6 shrink-0 place-items-center transition-colors duration-300 ${
+                chatOpen
+                  ? "text-stone-950"
+                  : "text-white/85 group-hover:text-stone-950"
+              }`}
+            >
+              <PromptIcon
+                key={iconPrompt.id}
+                aria-hidden
+                className="h-6 w-6 animate-watch-panel-swap"
+              />
+            </span>
+            <div className="relative min-w-0 flex-1">
+              <input
+                ref={inputRef}
+                type="text"
+                name="watch-question"
+                value={question}
+                onChange={(event) => setQuestion(event.target.value)}
+                onClick={openChatModal}
+                onFocus={openChatModal}
+                placeholder=""
+                aria-label={promptLabel(iconPrompt)}
+                autoComplete="off"
+                enterKeyHint="send"
+                data-testid="watch-mobile-question-panel-input"
+                className={`relative z-10 h-8 w-full min-w-0 cursor-text bg-transparent text-base leading-none outline-none transition-colors duration-300 ${
+                  chatOpen
+                    ? "text-stone-950"
+                    : "text-white group-hover:text-stone-950"
+                }`}
+              />
+              {!hasQuestion && !chatOpen ? (
+                <span
+                  key={currentPrompt.id}
+                  aria-hidden="true"
+                  data-testid="watch-mobile-question-panel-prompt"
+                  className="pointer-events-none absolute inset-y-0 left-0 z-0 flex max-w-full items-center truncate text-base leading-none text-white/90 transition-colors duration-300 animate-watch-panel-swap group-hover:text-stone-950"
+                >
+                  {promptLabel(currentPrompt)}
+                </span>
+              ) : null}
+            </div>
+            <button
+              type="submit"
+              aria-label={t("send")}
+              data-testid="watch-mobile-question-panel-send"
+              disabled={!hasQuestion}
+              className={`-mr-2 grid h-9 w-9 shrink-0 place-items-center rounded-full transition focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none ${
+                hasQuestion
+                  ? "cursor-pointer bg-brand-red text-white hover:bg-brand-red/90"
+                  : chatOpen
+                    ? "cursor-not-allowed bg-stone-950/5 text-stone-400"
+                    : "cursor-not-allowed bg-white/10 text-white/45 group-hover:bg-stone-950/5 group-hover:text-stone-400"
+              }`}
+            >
+              <SendHorizontal aria-hidden className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      </form>
+    </>
+  )
+}

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -85,6 +85,7 @@ export const env = createEnv({
     FORGE_WATCH_PLAYER_MIGRATION_DEFAULT: z.string().optional(),
     FORGE_WATCH_HERO_MUX_VIDEO_DEFAULT: z.string().optional(),
     FORGE_WATCH_CTA_TEXT_COPY_DEFAULT: z.string().optional(),
+    FORGE_WATCH_QUESTION_PANEL_DEFAULT: z.string().optional(),
     // Admin GraphQL URL. Required — web's data layer reads from admin.
     ADMIN_GRAPHQL_URL: z
       .url()
@@ -182,6 +183,8 @@ export const env = createEnv({
       process.env.FORGE_WATCH_HERO_MUX_VIDEO_DEFAULT,
     FORGE_WATCH_CTA_TEXT_COPY_DEFAULT:
       process.env.FORGE_WATCH_CTA_TEXT_COPY_DEFAULT,
+    FORGE_WATCH_QUESTION_PANEL_DEFAULT:
+      process.env.FORGE_WATCH_QUESTION_PANEL_DEFAULT,
     ADMIN_GRAPHQL_URL: process.env.ADMIN_GRAPHQL_URL,
     WEB_ADMIN_API_KEYS: process.env.WEB_ADMIN_API_KEYS,
     NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION:

--- a/apps/web/src/lib/feature-flags.test.ts
+++ b/apps/web/src/lib/feature-flags.test.ts
@@ -11,6 +11,7 @@ function setRequiredWebEnv() {
   delete process.env.FORGE_WATCH_PLAYER_MIGRATION_DEFAULT
   delete process.env.FORGE_WATCH_HERO_MUX_VIDEO_DEFAULT
   delete process.env.FORGE_WATCH_CTA_TEXT_COPY_DEFAULT
+  delete process.env.FORGE_WATCH_QUESTION_PANEL_DEFAULT
   delete process.env.NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION
   delete process.env.NEXT_PUBLIC_FORGE_WATCH_HERO_MUX_VIDEO
 }
@@ -69,12 +70,30 @@ describe("web feature flag helpers", () => {
     await expect(isWatchCtaTextCopyEnabled()).resolves.toBe(true)
   })
 
+  it("keeps the watch question panel disabled by default", async () => {
+    delete process.env.LAUNCHDARKLY_SDK_KEY
+
+    const { isWatchQuestionPanelEnabled } = await import("./feature-flags")
+
+    await expect(isWatchQuestionPanelEnabled()).resolves.toBe(false)
+  })
+
+  it("evaluates the watch question panel flag from the server-side fallback", async () => {
+    delete process.env.LAUNCHDARKLY_SDK_KEY
+    process.env.FORGE_WATCH_QUESTION_PANEL_DEFAULT = "true"
+
+    const { isWatchQuestionPanelEnabled } = await import("./feature-flags")
+
+    await expect(isWatchQuestionPanelEnabled()).resolves.toBe(true)
+  })
+
   it("passes the LaunchDarkly SDK key and local fallbacks into the shared client", async () => {
     process.env.LAUNCHDARKLY_SDK_KEY = "sdk-test"
     process.env.NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION = "false"
     process.env.NEXT_PUBLIC_FORGE_WATCH_HERO_MUX_VIDEO = "true"
     process.env.FORGE_WATCH_PLAYER_MIGRATION_DEFAULT = "true"
     process.env.FORGE_WATCH_CTA_TEXT_COPY_DEFAULT = "false"
+    process.env.FORGE_WATCH_QUESTION_PANEL_DEFAULT = "true"
     const booleanVariation = vi.fn(async () => false)
     const createFeatureFlagClient = vi.fn(() => ({ booleanVariation }))
 
@@ -98,11 +117,13 @@ describe("web feature flag helpers", () => {
           FORGE_WATCH_PLAYER_MIGRATION_DEFAULT: "true",
           FORGE_WATCH_HERO_MUX_VIDEO_DEFAULT: "true",
           FORGE_WATCH_CTA_TEXT_COPY_DEFAULT: "false",
+          FORGE_WATCH_QUESTION_PANEL_DEFAULT: "true",
         },
         defaultValues: {
           "forge.watch.playerMigration": false,
           "forge.watch.heroMuxVideo": true,
           "forge.watch.ctaTextCopy": false,
+          "forge.watch.questionPanel": false,
         },
       }),
     )

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -22,11 +22,13 @@ const webFeatureFlagClient = createFeatureFlagClient({
       env.FORGE_WATCH_HERO_MUX_VIDEO_DEFAULT ??
       String(env.NEXT_PUBLIC_FORGE_WATCH_HERO_MUX_VIDEO),
     FORGE_WATCH_CTA_TEXT_COPY_DEFAULT: env.FORGE_WATCH_CTA_TEXT_COPY_DEFAULT,
+    FORGE_WATCH_QUESTION_PANEL_DEFAULT: env.FORGE_WATCH_QUESTION_PANEL_DEFAULT,
   },
   defaultValues: {
     "forge.watch.playerMigration": env.NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION,
     "forge.watch.heroMuxVideo": env.NEXT_PUBLIC_FORGE_WATCH_HERO_MUX_VIDEO,
     "forge.watch.ctaTextCopy": false,
+    "forge.watch.questionPanel": false,
   },
   timeoutSeconds: 0.25,
   logger: console,
@@ -72,6 +74,15 @@ export async function isWatchCtaTextCopyEnabled(
 ): Promise<boolean> {
   return webFeatureFlagClient.booleanVariation(
     featureFlags.watchCtaTextCopy,
+    createWebFeatureFlagContext(context),
+  )
+}
+
+export async function isWatchQuestionPanelEnabled(
+  context: WebFeatureFlagContextInput = {},
+): Promise<boolean> {
+  return webFeatureFlagClient.booleanVariation(
+    featureFlags.watchQuestionPanel,
     createWebFeatureFlagContext(context),
   )
 }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -141,6 +141,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-130](platform/feat-130-mastra-observability-storage.md)                    | Mastra Observability Storage                            | vlad      | P1       | 2026-05-22 | 1    | 2026-05-22 | complete    |
 | [feat-132](platform/feat-132-admin-core-sync-production-error-triage.md)         | Admin Core Sync Production Error Triage                 | tataihono | P1       | 2026-05-24 | 1    | 2026-05-24 | not-started |
 | [feat-144](platform/feat-144-launchdarkly-feature-flag-foundation.md)            | LaunchDarkly Feature Flag Foundation                    | vlad      | P1       | 2026-05-27 | 2    | 2026-05-28 | complete    |
+| [feat-145](platform/feat-145-watch-question-panel-flag.md)                       | Watch Question Panel LaunchDarkly Gate                  | vlad      | P2       | 2026-05-28 | 1    | 2026-05-28 | complete    |
 | [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                              | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
 | [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                     | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                 | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |

--- a/docs/roadmap/platform/feat-145-watch-question-panel-flag.md
+++ b/docs/roadmap/platform/feat-145-watch-question-panel-flag.md
@@ -1,0 +1,56 @@
+---
+id: "feat-145"
+title: "Watch Question Panel LaunchDarkly Gate"
+owner: "vlad"
+priority: "P2"
+status: "complete"
+start_date: "2026-05-28"
+duration: 1
+depends_on:
+  - "feat-144"
+blocks: []
+tags:
+  - platform
+  - web
+  - watch-page
+  - feature-flags
+---
+
+## Problem
+
+The watch page needs a floating question/chat panel prototype, but the
+surface should stay disabled by default until the team intentionally rolls it
+out.
+
+## Entry Points -- Read These First
+
+1. `packages/feature-flags/src/registry.ts` -- shared LaunchDarkly flag keys.
+2. `apps/web/src/lib/feature-flags.ts` -- web server-side feature flag helpers.
+3. `apps/web/src/app/[slug]/[...rest]/page.tsx` -- watch route server
+   evaluation and prop passing.
+4. `apps/web/src/components/watch/WatchPageClient.tsx` -- client watch surface.
+5. `apps/web/src/components/watch/WatchQuestionPanel.tsx` -- gated floating
+   panel UI.
+
+## What To Build
+
+1. Add a default-off LaunchDarkly boolean flag:
+   `forge.watch.questionPanel`.
+2. Add the local fallback env var:
+   `FORGE_WATCH_QUESTION_PANEL_DEFAULT=false`.
+3. Evaluate the flag server-side on watch routes and pass a plain boolean into
+   the watch client.
+4. Render the floating panel only when the flag is enabled.
+
+## Constraints
+
+- Keep the default/off behavior identical to the current watch page.
+- Do not expose LaunchDarkly SDK keys or use a client-side LaunchDarkly SDK.
+- Keep the panel dummy/non-submitting beyond local input clearing.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- 'src/app/[slug]/[...rest]/__tests__/page-routing.test.tsx' src/lib/feature-flags.test.ts`
+- `pnpm --filter @forge/feature-flags test`
+- Local smoke: no `LAUNCHDARKLY_SDK_KEY` and
+  `FORGE_WATCH_QUESTION_PANEL_DEFAULT=false` hides the panel.

--- a/packages/feature-flags/src/registry.ts
+++ b/packages/feature-flags/src/registry.ts
@@ -20,6 +20,13 @@ export const featureFlags = {
     description:
       "Temporary production smoke flag for the watch-page CTA text copy.",
   },
+  watchQuestionPanel: {
+    key: "forge.watch.questionPanel",
+    defaultValue: false,
+    localOverrideEnv: "FORGE_WATCH_QUESTION_PANEL_DEFAULT",
+    description:
+      "Runtime rollout gate for the watch-page floating question panel.",
+  },
 } as const
 
 export type FeatureFlagName = keyof typeof featureFlags


### PR DESCRIPTION
## Summary

This PR adds a default-off LaunchDarkly gate for the watch-page question panel so the prototype can be tested and rolled out intentionally without changing baseline watch behavior.

It wires server-side flag evaluation through `@forge/feature-flags`, passes plain booleans into the watch render paths, and mounts the floating panel for both standard watch videos and curated watch experiences.

## Details

- Registers `forge.watch.questionPanel` with `FORGE_WATCH_QUESTION_PANEL_DEFAULT=false` as the local fallback.
- Adds `WatchQuestionPanel`, including the floating Slack-style input, rotating prompt text/icon, focused full-screen backdrop, and message-type selector.
- Threads `questionPanelEnabled` through `/watch/[slug]/[...rest]` and `WatchPageClient` without exposing LaunchDarkly client-side state or SDK keys.
- Adds localized `WatchQuestionPanel` strings across the existing web message catalogs.
- Documents the flag in `apps/web/CLAUDE.md` and tracks the scoped rollout in `docs/roadmap/platform/feat-145-watch-question-panel-flag.md`.

## Rollout

The committed default is off. To enable locally or in Railway fallback mode, set:

```text
FORGE_WATCH_QUESTION_PANEL_DEFAULT=true
```

The matching LaunchDarkly flag should be a temporary boolean flag in project `watch` with key `forge.watch.questionPanel`, targeting off by default.

## Validation

- `env TMPDIR=/private/tmp pnpm --filter @forge/web test -- 'src/app/[slug]/[...rest]/__tests__/page-routing.test.tsx' src/lib/feature-flags.test.ts src/i18n/__tests__/messages-parity.test.ts`
- `pnpm --filter @forge/web lint`
- `pnpm --filter @forge/web typecheck`
- `env TMPDIR=/private/tmp pnpm --filter @forge/feature-flags test`
- `pnpm --filter @forge/feature-flags typecheck`
- `pnpm --filter @forge/feature-flags lint`
- Browser smoke on `http://127.0.0.1:3102/watch/the-covenant.html/english.html` with `FORGE_WATCH_QUESTION_PANEL_DEFAULT=true`: scrolled the page, verified `watch-mobile-question-panel` appears, focused the field, and verified the panel modal opens with the message-type options and old composer test IDs absent.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
