### PR TITLE
feat(web): add /watch URL cutover probe harness (Phase 6)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify:categories": "tsx scripts/verify-categories.ts"
+    "verify:categories": "tsx scripts/verify-categories.ts",
+    "probe:watch-urls": "tsx scripts/probe-watch-urls.ts"
   },
   "dependencies": {
     "@apollo/client": "^4.1.4",

--- a/apps/web/scripts/probe-watch-urls.ts
+++ b/apps/web/scripts/probe-watch-urls.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env tsx
+/**
+ * Cutover-verification probe for the /watch URL space (Phase 6).
+ *
+ * Runs the §5 URL matrix (docs/research/jesusfilm-watch-url-patterns.md,
+ * encoded in src/lib/watch-url-probe.ts) against a production baseline AND a
+ * rewrite preview, then diffs the two per URL into regression buckets.
+ *
+ * Gate: 0 hard regressions, ≤2% soft regressions. Exits non-zero if the gate
+ * fails so it can run in CI / a pre-cutover check.
+ *
+ * Run:
+ *   pnpm --filter @forge/web probe:watch-urls \
+ *     --production https://www.jesusfilm.org \
+ *     --preview    https://<railway-preview-url>
+ *
+ * Optional: --json <path> writes the full per-URL comparison report.
+ *
+ * Intentionally imports only the pure probe lib (no app module graph).
+ */
+
+import { writeFileSync } from "node:fs"
+
+import {
+  WATCH_URL_FIXTURES,
+  classifyProbe,
+  probeUrl,
+  type ProbeComparison,
+} from "../src/lib/watch-url-probe"
+
+const SOFT_REGRESSION_BUDGET = 0.02 // ≤2% soft regressions allowed
+
+type Args = { production: string; preview: string; jsonOut?: string }
+
+function parseArgs(argv: readonly string[]): Args | Error {
+  let production: string | undefined
+  let preview: string | undefined
+  let jsonOut: string | undefined
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i]
+    const value = argv[i + 1]
+    if (flag === "--production") {
+      production = value
+      i += 1
+    } else if (flag === "--preview") {
+      preview = value
+      i += 1
+    } else if (flag === "--json") {
+      jsonOut = value
+      i += 1
+    }
+  }
+  if (!production || !preview) {
+    return new Error(
+      "Usage: probe:watch-urls --production <origin> --preview <origin> [--json <path>]",
+    )
+  }
+  const stripTrailing = (s: string) => s.replace(/\/$/, "")
+  return {
+    production: stripTrailing(production),
+    preview: stripTrailing(preview),
+    jsonOut,
+  }
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2))
+  if (parsed instanceof Error) {
+    console.error(parsed.message)
+    process.exit(2)
+  }
+  const { production, preview, jsonOut } = parsed
+
+  console.log(
+    `Probing ${WATCH_URL_FIXTURES.length} /watch URLs\n  production: ${production}\n  preview:    ${preview}\n`,
+  )
+
+  const comparisons: ProbeComparison[] = []
+  for (const fixture of WATCH_URL_FIXTURES) {
+    // Sequential to avoid hammering either origin / tripping rate limits.
+    const [prodResult, previewResult] = await Promise.all([
+      probeUrl(production, fixture.path),
+      probeUrl(preview, fixture.path),
+    ])
+    const { outcome, note } = classifyProbe(prodResult, previewResult)
+    comparisons.push({
+      path: fixture.path,
+      group: fixture.group,
+      production: prodResult,
+      preview: previewResult,
+      outcome,
+      note,
+    })
+  }
+
+  const tally = {
+    match: 0,
+    acceptable: 0,
+    "soft-regression": 0,
+    "hard-regression": 0,
+    error: 0,
+  }
+  for (const c of comparisons) tally[c.outcome] += 1
+
+  // Print every non-clean outcome (hard first, then soft, then error).
+  const order = ["hard-regression", "soft-regression", "error"] as const
+  for (const bucket of order) {
+    const rows = comparisons.filter((c) => c.outcome === bucket)
+    if (rows.length === 0) continue
+    console.log(`\n${bucket.toUpperCase()} (${rows.length}):`)
+    for (const r of rows) {
+      console.log(`  [${r.group}] ${r.path}`)
+      console.log(
+        `      prod ${r.production.status} (${r.production.finalPath}) | preview ${r.preview.status} (${r.preview.finalPath})`,
+      )
+      console.log(`      ${r.note}`)
+    }
+  }
+
+  if (jsonOut) {
+    writeFileSync(
+      jsonOut,
+      JSON.stringify({ production, preview, tally, comparisons }, null, 2),
+    )
+    console.log(`\nFull report written to ${jsonOut}`)
+  }
+
+  const total = comparisons.length
+  const softRate = tally["soft-regression"] / total
+  console.log(
+    `\nSummary: ${total} URLs — ${tally.match} match, ${tally.acceptable} acceptable, ` +
+      `${tally["soft-regression"]} soft (${(softRate * 100).toFixed(1)}%), ` +
+      `${tally["hard-regression"]} hard, ${tally.error} error`,
+  )
+
+  const hardFail = tally["hard-regression"] > 0
+  const softFail = softRate > SOFT_REGRESSION_BUDGET
+  if (hardFail || softFail || tally.error > 0) {
+    console.error(
+      `\n❌ Cutover gate FAILED — ${tally["hard-regression"]} hard regression(s), ` +
+        `${(softRate * 100).toFixed(1)}% soft (budget ${(SOFT_REGRESSION_BUDGET * 100).toFixed(0)}%), ` +
+        `${tally.error} error(s). Review the buckets above before cutover.`,
+    )
+    process.exit(1)
+  }
+  console.log(
+    `\n✅ Cutover gate PASSED — 0 hard regressions, soft within ${(SOFT_REGRESSION_BUDGET * 100).toFixed(0)}% budget.`,
+  )
+}
+
+void main()

--- a/apps/web/src/lib/watch-url-probe.test.ts
+++ b/apps/web/src/lib/watch-url-probe.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  WATCH_URL_FIXTURES,
+  classifyProbe,
+  probeUrl,
+  type ProbeResult,
+} from "./watch-url-probe"
+
+const result = (over: Partial<ProbeResult> = {}): ProbeResult => ({
+  status: 200,
+  finalPath: "/watch/jesus.html/english.html",
+  redirectHops: 0,
+  ms: 1,
+  ...over,
+})
+
+describe("classifyProbe", () => {
+  it("match: 200 → 200 same final path", () => {
+    const { outcome } = classifyProbe(result(), result())
+    expect(outcome).toBe("match")
+  })
+
+  it("hard-regression: prod 200 → preview 404 (broken link)", () => {
+    const { outcome, note } = classifyProbe(
+      result({ status: 200 }),
+      result({ status: 404 }),
+    )
+    expect(outcome).toBe("hard-regression")
+    expect(note).toMatch(/BROKEN LINK/)
+  })
+
+  it("soft-regression: 200 on both but different final path", () => {
+    const { outcome } = classifyProbe(
+      result({ finalPath: "/watch/jesus.html/english.html" }),
+      result({ finalPath: "/watch/jesus.html/spanish.html" }),
+    )
+    expect(outcome).toBe("soft-regression")
+  })
+
+  it("acceptable: prod 307 → preview 200 direct (skipped redundant redirect)", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 307, finalPath: "/watch/jesus.html/english.html" }),
+      result({ status: 200, finalPath: "/watch/jesus.html/english.html" }),
+    )
+    expect(outcome).toBe("acceptable")
+  })
+
+  it("match: redirect → redirect, same final path", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 308, finalPath: "/watch/jesus.html" }),
+      result({ status: 308, finalPath: "/watch/jesus.html" }),
+    )
+    expect(outcome).toBe("match")
+  })
+
+  it("soft-regression: redirect target differs", () => {
+    const { outcome } = classifyProbe(
+      result({
+        status: 307,
+        finalPath: "/watch/jesus.html/mandarin-china.html",
+      }),
+      result({ status: 307, finalPath: "/watch/jesus.html/chinese.html" }),
+    )
+    expect(outcome).toBe("soft-regression")
+  })
+
+  it("hard-regression: redirect became error", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 307 }),
+      result({ status: 500 }),
+    )
+    expect(outcome).toBe("hard-regression")
+  })
+
+  it("match: expected 404 stays 404", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 404 }),
+      result({ status: 404 }),
+    )
+    expect(outcome).toBe("match")
+  })
+
+  it("hard-regression: expected 404 now resolves 200 (§5.6 contract break)", () => {
+    const { outcome, note } = classifyProbe(
+      result({ status: 404 }),
+      result({ status: 200 }),
+    )
+    expect(outcome).toBe("hard-regression")
+    expect(note).toMatch(/EXPECTED-404/)
+  })
+
+  it("hard-regression: expected 404 now 301 (§5.6: must not become 301)", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 404 }),
+      result({ status: 301 }),
+    )
+    expect(outcome).toBe("hard-regression")
+  })
+
+  it("error: transport error on either side", () => {
+    expect(
+      classifyProbe(result({ error: "ETIMEDOUT" }), result()).outcome,
+    ).toBe("error")
+    expect(
+      classifyProbe(result(), result({ error: "ECONNREFUSED" })).outcome,
+    ).toBe("error")
+  })
+
+  it("error: production 5xx cannot baseline", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 503 }),
+      result({ status: 200 }),
+    )
+    expect(outcome).toBe("error")
+  })
+})
+
+describe("WATCH_URL_FIXTURES integrity", () => {
+  it("every path is /watch-prefixed and non-empty", () => {
+    for (const f of WATCH_URL_FIXTURES) {
+      expect(f.path.startsWith("/watch")).toBe(true)
+      expect(f.group.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("covers all seven §5 groups", () => {
+    const groups = new Set(WATCH_URL_FIXTURES.map((f) => f.group))
+    expect(groups).toEqual(
+      new Set([
+        "5.1 roots",
+        "5.2 two-segment",
+        "5.3 episodes",
+        "5.4 normalization redirects",
+        "5.5 query params",
+        "5.6 expected 404s",
+        "5.7 asset/framework subtrees",
+      ]),
+    )
+  })
+
+  it("contains the flagship jesus/english fixture", () => {
+    expect(
+      WATCH_URL_FIXTURES.some(
+        (f) => f.path === "/watch/jesus.html/english.html",
+      ),
+    ).toBe(true)
+  })
+
+  it("has no duplicate paths", () => {
+    const paths = WATCH_URL_FIXTURES.map((f) => f.path)
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+})
+
+describe("probeUrl (mocked fetch)", () => {
+  it("returns final status + origin-stripped path for a direct 200", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(null, { status: 200 }),
+      ) as unknown as typeof fetch
+    const r = await probeUrl(
+      "https://www.jesusfilm.org",
+      "/watch/jesus.html/english.html",
+      { fetchImpl },
+    )
+    expect(r.status).toBe(200)
+    expect(r.finalPath).toBe("/watch/jesus.html/english.html")
+    expect(r.redirectHops).toBe(0)
+  })
+
+  it("follows redirects and reports the final path + hop count", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { location: "/watch/jesus.html/english.html" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, { status: 200 }),
+      ) as unknown as typeof fetch
+    const r = await probeUrl(
+      "https://preview.test",
+      "/watch/jesus.html/english",
+      {
+        fetchImpl,
+      },
+    )
+    expect(r.status).toBe(200)
+    expect(r.finalPath).toBe("/watch/jesus.html/english.html")
+    expect(r.redirectHops).toBe(1)
+  })
+
+  it("stops following after MAX_REDIRECT_HOPS and reports the 3xx", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 308,
+        headers: { location: "/watch/loop" },
+      }),
+    ) as unknown as typeof fetch
+    const r = await probeUrl("https://preview.test", "/watch/loop", {
+      fetchImpl,
+    })
+    expect(r.status).toBe(308)
+    expect(r.redirectHops).toBe(5)
+  })
+
+  it("captures transport errors as a result with error set", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof fetch
+    const r = await probeUrl("https://preview.test", "/watch/jesus.html", {
+      fetchImpl,
+    })
+    expect(r.error).toBe("ECONNREFUSED")
+    expect(r.status).toBe(0)
+  })
+})

--- a/apps/web/src/lib/watch-url-probe.ts
+++ b/apps/web/src/lib/watch-url-probe.ts
@@ -1,0 +1,364 @@
+// Cutover-verification probe for the /watch URL space (Phase 6).
+//
+// The fixtures below are the §5 URL matrix from
+// docs/research/jesusfilm-watch-url-patterns.md — the minimum set of public
+// URL shapes that MUST keep resolving after the .html-shape migration. The
+// CLI (apps/web/scripts/probe-watch-urls.ts) hits each path against BOTH a
+// production baseline and a rewrite preview, then `classifyProbe` diffs the
+// two into regression buckets. The gate: 0 hard regressions, ≤2% soft.
+//
+// This module is pure + network-isolated except `probeUrl` (the one fetch
+// boundary), so `classifyProbe` + the fixtures are unit-tested directly.
+
+/** Nominal expected outcome per §5 section — used for self-test + reporting, NOT the prod-vs-preview gate. */
+export type ProbeExpect = "ok" | "redirect" | "notfound" | "passthrough"
+
+export type WatchUrlFixture = {
+  /** Full path including the `/watch` basePath (e.g. `/watch/jesus.html/english.html`). */
+  path: string
+  /** §5 section label for grouped reporting. */
+  group: string
+  expect: ProbeExpect
+}
+
+const ROOTS: readonly string[] = [
+  "/watch",
+  // NOTE: `/watch/` (trailing slash) lives in REDIRECTS — it 308s to `/watch`
+  // per §5.4, so it is probed as a redirect, not a root 200.
+  "/watch/videos",
+  "/watch/search",
+  "/watch/english.html",
+  "/watch/russian.html",
+  "/watch/portuguese-brazil.html",
+  "/watch/portuguese-portugal.html",
+  "/watch/spanish-castilian.html",
+  "/watch/spanish-latin-american.html",
+  "/watch/mandarin-china.html",
+  "/watch/arabic-modern-standard.html",
+  "/watch/french.html",
+  "/watch/german.html",
+  "/watch/japanese.html",
+  "/watch/korean.html",
+  "/watch/hindi.html",
+  "/watch/tamil.html",
+  "/watch/turkish.html",
+  "/watch/swahili.html",
+]
+
+const TWO_SEGMENT: readonly string[] = [
+  "/watch/jesus.html/english.html",
+  "/watch/jesus.html/spanish-castilian.html",
+  "/watch/jesus.html/spanish-latin-american.html",
+  "/watch/jesus.html/portuguese-brazil.html",
+  "/watch/jesus.html/portuguese-portugal.html",
+  "/watch/jesus.html/arabic-modern-standard.html",
+  "/watch/jesus.html/french.html",
+  "/watch/jesus.html/mandarin-china.html",
+  "/watch/jesus.html/cantonese.html",
+  "/watch/jesus.html/japanese.html",
+  "/watch/jesus.html/korean.html",
+  "/watch/jesus.html/hindi.html",
+  "/watch/jesus.html/tamil.html",
+  "/watch/jesus.html/zulu.html",
+  "/watch/jesus.html/swahili.html",
+  "/watch/magdalena-2.html/english.html",
+  "/watch/magdalena.html/russian.html",
+  "/watch/chosen-witness.html/english.html",
+  "/watch/fallingplates.html/english.html",
+  "/watch/the-savior.html/russian.html",
+  "/watch/birth-of-jesus.html/english.html",
+  "/watch/wedding-in-cana.html/english.html",
+  "/watch/jesus-calms-the-storm.html/english.html",
+  "/watch/paul-and-silas-in-prison.html/english.html",
+  "/watch/peter-miraculous-escape-from-prison.html/english.html",
+  "/watch/the-woman-with-the-issue-of-blood.html/english.html",
+  "/watch/day-6-jesus-died-for-me.html/english.html",
+  "/watch/8-days-with-jesus-who-is-jesus.html/english.html",
+  "/watch/storyclubs-jesus-and-zacchaeus.html/english.html",
+  // Series landings
+  "/watch/lumo-the-gospel-of-john.html/english.html",
+  "/watch/lumo-the-gospel-of-luke.html/english.html",
+  "/watch/lumo-the-gospel-of-mark.html/english.html",
+  "/watch/lumo-the-gospel-of-matthew.html/english.html",
+  "/watch/lumo-the-gospel-of-john.html/russian.html",
+  "/watch/lumo-the-gospel-of-luke.html/russian.html",
+  "/watch/lumo-the-gospel-of-mark.html/russian.html",
+  "/watch/lumo-the-gospel-of-matthew.html/russian.html",
+  "/watch/life-of-jesus-gospel-of-john.html/english.html",
+  "/watch/life-of-jesus-gospel-of-john.html/russian.html",
+  "/watch/book-of-acts.html/english.html",
+  "/watch/book-of-acts.html/russian.html",
+  "/watch/reflections-of-hope.html/english.html",
+  "/watch/new-believer-course.html/english.html",
+  "/watch/pilgrims-progress.html/russian.html",
+  // Curated collections / Experiences
+  "/watch/women-resources.html/english.html",
+  "/watch/women-resources.html/russian.html",
+  "/watch/discipleship.html/english.html",
+  "/watch/discipleship.html/russian.html",
+  "/watch/conversation-starters.html/english.html",
+  "/watch/conversation-starters.html/russian.html",
+  "/watch/easter.html/english.html",
+  "/watch/easter.html/russian.html",
+  "/watch/evangelism.html/russian.html",
+  "/watch/family.html/russian.html",
+  "/watch/relationships.html/russian.html",
+  "/watch/love-your-neighbor.html/russian.html",
+  "/watch/student-resources.html/russian.html",
+  "/watch/storyclubs.html/russian.html",
+  "/watch/jfm-collection.html/russian.html",
+  "/watch/world-youth-day.html/russian.html",
+  "/watch/anticipate-the-resurrection.html/russian.html",
+]
+
+const EPISODES: readonly string[] = [
+  "/watch/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+  "/watch/lumo-the-gospel-of-luke.html/birth-of-jesus/english.html",
+  "/watch/lumo-the-gospel-of-luke.html/birth-of-jesus/spanish-castilian.html",
+  "/watch/lumo-the-gospel-of-mark.html/jesus-baptism/english.html",
+  "/watch/jesus.html/the-beginning/english.html",
+  "/watch/jesus.html/the-beginning/spanish-castilian.html",
+  "/watch/jesus.html/the-beginning/russian.html",
+]
+
+// §5.3 legacy 4-segment + §5.4 normalization — must REDIRECT (3xx), not 404.
+const REDIRECTS: readonly string[] = [
+  "/watch/lumo-the-gospel-of-john/wedding-in-cana.html/english.html",
+  "/watch/jesus/the-beginning.html/english.html",
+  "/watch/",
+  "/watch/jesus.html/",
+  "/watch/jesus.html/english.html/",
+  "/watch/jesus.HTML/english.html",
+  "/watch/jesus.html/english",
+  "/watch/jesus.html/chinese-mandarin.html",
+]
+
+// §5.5 — query params / fragment must still 200 (same final content URL).
+const QUERY_PARAMS: readonly string[] = [
+  "/watch/jesus.html/english.html?t=120",
+  "/watch/jesus.html/english.html?autoplay=1",
+  "/watch/jesus.html/english.html?utm_source=campaign&utm_medium=email",
+]
+
+// §5.6 — must STAY 404 (must NOT become 200 or 301).
+const EXPECTED_404S: readonly string[] = [
+  "/watch/jesus.html",
+  "/watch/JESUS.html/english.html",
+  "/watch/jesus.html/fran%C3%A7ais.html",
+  "/watch/.html",
+  "/watch/jesus.html/en.html",
+  "/watch/jesus.html/pt-br.html",
+  "/watch/easter.html/non-existent.html",
+]
+
+// §5.7 — asset / framework subtrees must resolve normally (NO wildcard catch).
+const PASSTHROUGH: readonly string[] = [
+  "/watch/assets/favicon-180.png",
+  "/watch/assets/favicon-32.png",
+  "/watch/assets/footer/facebook.svg",
+  "/watch/api/preview",
+  "/watch/api/revalidate",
+]
+
+function fixturesOf(
+  paths: readonly string[],
+  group: string,
+  expect: ProbeExpect,
+): WatchUrlFixture[] {
+  return paths.map((path) => ({ path, group, expect }))
+}
+
+/** The full §5 probe matrix. */
+export const WATCH_URL_FIXTURES: readonly WatchUrlFixture[] = [
+  ...fixturesOf(ROOTS, "5.1 roots", "ok"),
+  ...fixturesOf(TWO_SEGMENT, "5.2 two-segment", "ok"),
+  ...fixturesOf(EPISODES, "5.3 episodes", "ok"),
+  ...fixturesOf(REDIRECTS, "5.4 normalization redirects", "redirect"),
+  ...fixturesOf(QUERY_PARAMS, "5.5 query params", "ok"),
+  ...fixturesOf(EXPECTED_404S, "5.6 expected 404s", "notfound"),
+  ...fixturesOf(PASSTHROUGH, "5.7 asset/framework subtrees", "passthrough"),
+]
+
+/** One side's probe result for a single URL. */
+export type ProbeResult = {
+  /** Final HTTP status after following up to MAX_REDIRECT_HOPS redirects. */
+  status: number
+  /** Final pathname (origin-stripped) after redirects — the comparable key across hosts. */
+  finalPath: string
+  redirectHops: number
+  ms: number
+  /** Set when the request failed at the transport layer (DNS, timeout, etc.). */
+  error?: string
+}
+
+export type ProbeOutcome =
+  | "match" // same status class + same final path
+  | "acceptable" // prod redirected, preview served 200 directly (skipped redundant hop)
+  | "soft-regression" // same status class, different final path (SEO/canonical drift)
+  | "hard-regression" // broken contract: 2xx→4xx, expected-404 now resolves, redirect→error
+  | "error" // transport error on one side; cannot compare
+
+export type ProbeComparison = {
+  path: string
+  group: string
+  production: ProbeResult
+  preview: ProbeResult
+  outcome: ProbeOutcome
+  note: string
+}
+
+const statusClass = (status: number): number => Math.floor(status / 100)
+
+/**
+ * Diff a production baseline against a rewrite-preview result for ONE URL.
+ * Pure — the heart of the cutover gate. Compares status CLASS + final path.
+ *
+ * Buckets:
+ * - `error`            — either side failed at transport; cannot baseline.
+ * - `hard-regression`  — prod 2xx → preview 4xx/5xx (broken link), prod 3xx →
+ *                        preview 4xx/5xx (redirect now errors), OR an expected
+ *                        404 that now resolves/redirects (prod 4xx → preview
+ *                        non-4xx — §5.6 contract violation).
+ * - `acceptable`       — prod 3xx → preview 2xx (preview skips a redundant
+ *                        redirect and serves directly).
+ * - `soft-regression`  — same status class but a DIFFERENT final path (canonical
+ *                        / SEO drift; needs stakeholder review), or prod 2xx →
+ *                        preview 3xx.
+ * - `match`            — same status class + same final path.
+ */
+export function classifyProbe(
+  production: ProbeResult,
+  preview: ProbeResult,
+): { outcome: ProbeOutcome; note: string } {
+  if (production.error || preview.error) {
+    return {
+      outcome: "error",
+      note: production.error
+        ? `production transport error: ${production.error}`
+        : `preview transport error: ${preview.error}`,
+    }
+  }
+
+  const pc = statusClass(production.status)
+  const vc = statusClass(preview.status)
+  const samePath = production.finalPath === preview.finalPath
+
+  if (pc === 5) {
+    return {
+      outcome: "error",
+      note: `production returned ${production.status}; cannot baseline`,
+    }
+  }
+
+  if (pc === 2) {
+    if (vc === 2) {
+      return samePath
+        ? { outcome: "match", note: "200 → 200, same final path" }
+        : {
+            outcome: "soft-regression",
+            note: `200 on both but final path differs: prod ${production.finalPath} vs preview ${preview.finalPath}`,
+          }
+    }
+    if (vc === 3) {
+      return {
+        outcome: "soft-regression",
+        note: `prod 200 but preview ${preview.status} → ${preview.finalPath}`,
+      }
+    }
+    return {
+      outcome: "hard-regression",
+      note: `BROKEN LINK: prod ${production.status} → preview ${preview.status}`,
+    }
+  }
+
+  if (pc === 3) {
+    if (vc === 2) {
+      return {
+        outcome: "acceptable",
+        note: `prod ${production.status} → preview served 200 directly (skipped redundant redirect)`,
+      }
+    }
+    if (vc === 3) {
+      return samePath
+        ? { outcome: "match", note: "redirect → same final path" }
+        : {
+            outcome: "soft-regression",
+            note: `redirect target differs: prod ${production.finalPath} vs preview ${preview.finalPath}`,
+          }
+    }
+    return {
+      outcome: "hard-regression",
+      note: `redirect became error: prod ${production.status} → preview ${preview.status}`,
+    }
+  }
+
+  // pc === 4 — production 404 (or other 4xx). §5.6: must STAY 404.
+  if (vc === 4) {
+    return { outcome: "match", note: `404 preserved (${preview.status})` }
+  }
+  return {
+    outcome: "hard-regression",
+    note: `EXPECTED-404 CONTRACT BROKEN: prod ${production.status} → preview ${preview.status} (must not resolve or redirect)`,
+  }
+}
+
+/** Outcomes that fail the cutover gate outright (any count > 0 fails). */
+export const HARD_FAIL_OUTCOMES: ReadonlySet<ProbeOutcome> = new Set([
+  "hard-regression",
+])
+
+export const MAX_REDIRECT_HOPS = 5
+const DEFAULT_TIMEOUT_MS = 10_000
+
+/**
+ * Fetch `${origin}${path}`, manually following up to MAX_REDIRECT_HOPS
+ * redirects so we can capture the full chain length + the final
+ * origin-stripped pathname (the cross-host comparable key). The single
+ * network boundary in this module; everything else is pure.
+ */
+export async function probeUrl(
+  origin: string,
+  path: string,
+  options: { timeoutMs?: number; fetchImpl?: typeof fetch } = {},
+): Promise<ProbeResult> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const start = Date.now()
+  let currentUrl = `${origin}${path}`
+  let hops = 0
+
+  try {
+    for (;;) {
+      const res = await fetchImpl(currentUrl, {
+        method: "GET",
+        redirect: "manual",
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      const sc = statusClass(res.status)
+      const location = res.headers.get("location")
+
+      if (sc === 3 && location && hops < MAX_REDIRECT_HOPS) {
+        hops += 1
+        // Location may be relative or absolute; resolve against the current URL.
+        currentUrl = new URL(location, currentUrl).toString()
+        continue
+      }
+
+      return {
+        status: res.status,
+        finalPath: new URL(currentUrl).pathname,
+        redirectHops: hops,
+        ms: Date.now() - start,
+      }
+    }
+  } catch (err) {
+    return {
+      status: 0,
+      finalPath: new URL(currentUrl).pathname,
+      redirectHops: hops,
+      ms: Date.now() - start,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Final phase of the /watch URL restructure — the empirical cutover gate. Encodes the §5 URL matrix from `docs/research/jesusfilm-watch-url-patterns.md` (110 URLs across all 7 groups: roots, two-segment content, episodes, normalization redirects, query params, expected 404s, asset/framework subtrees) and diffs a **production baseline** against a **rewrite preview**, classifying each URL into regression buckets.

- **`src/lib/watch-url-probe.ts`** — §5 fixtures + pure `classifyProbe` (match / acceptable / soft-regression / hard-regression / error) + `probeUrl` (single fetch boundary: manual redirect follow ≤5 hops, origin-stripped final path for cross-host comparison).
- **`src/lib/watch-url-probe.test.ts`** — 20 self-tests: every `classifyProbe` branch (incl. §5.6 "expected-404 must stay 404" contract break, "skipped redundant redirect" = acceptable), fixtures integrity (all `/watch`-prefixed, 7 groups, no dups), mocked-fetch `probeUrl` (direct / redirect chain / hop cap / transport error).
- **`scripts/probe-watch-urls.ts`** — CLI (`--production` / `--preview` / `--json`). Gate: **0 hard regressions + ≤2% soft**; exits non-zero on failure for CI / a pre-cutover check.

### Bucket semantics
| Outcome | Meaning |
|---------|---------|
| hard-regression | prod 2xx→preview 4xx/5xx (broken link); redirect→error; expected-404 now resolves/redirects (§5.6 break) |
| soft-regression | same status class, different final path (canonical/SEO drift — needs review) |
| acceptable | prod 3xx → preview 2xx direct (skipped redundant redirect) |
| match | same status class + same final path |

## Run at cutover (operational)
```
pnpm --filter @forge/web probe:watch-urls \
  --production https://www.jesusfilm.org --preview https://<railway-preview>
```
The harness ships here; the live prod-vs-preview run is a cutover-time activity (needs a real preview URL). It also empirically verifies the canonical-host work from Phase 5 (todo 026).

## Test plan
- [x] `pnpm --filter @forge/web test -- --run` — 875 pass (incl. 20 new probe self-tests)
- [x] `lint` + `typecheck` clean
- [x] CLI smoke: runs under tsx, prints usage + exits 2 on missing args

🤖 Generated with [Claude Code](https://claude.com/claude-code)