### PR TITLE
fix(web): make watch-url probe classifier expect-aware

### DIFF
--- a/apps/web/scripts/probe-watch-urls.ts
+++ b/apps/web/scripts/probe-watch-urls.ts
@@ -82,7 +82,11 @@ async function main() {
       probeUrl(production, fixture.path),
       probeUrl(preview, fixture.path),
     ])
-    const { outcome, note } = classifyProbe(prodResult, previewResult)
+    const { outcome, note } = classifyProbe(
+      prodResult,
+      previewResult,
+      fixture.expect,
+    )
     comparisons.push({
       path: fixture.path,
       group: fixture.group,

--- a/apps/web/src/lib/watch-url-probe.test.ts
+++ b/apps/web/src/lib/watch-url-probe.test.ts
@@ -81,21 +81,57 @@ describe("classifyProbe", () => {
     expect(outcome).toBe("match")
   })
 
-  it("hard-regression: expected 404 now resolves 200 (§5.6 contract break)", () => {
+  it("hard-regression: notfound fixture now resolves 200 (§5.6 contract break)", () => {
     const { outcome, note } = classifyProbe(
       result({ status: 404 }),
       result({ status: 200 }),
+      "notfound",
     )
     expect(outcome).toBe("hard-regression")
     expect(note).toMatch(/EXPECTED-404/)
   })
 
-  it("hard-regression: expected 404 now 301 (§5.6: must not become 301)", () => {
+  it("hard-regression: notfound fixture now 301 (§5.6: must not become 301)", () => {
     const { outcome } = classifyProbe(
       result({ status: 404 }),
       result({ status: 301 }),
+      "notfound",
     )
     expect(outcome).toBe("hard-regression")
+  })
+
+  it("defaults expect to notfound (strict §5.6) when omitted", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 404 }),
+      result({ status: 200 }),
+    )
+    expect(outcome).toBe("hard-regression")
+  })
+
+  it("acceptable: prod 404 → preview 200 on an `ok` fixture (legacy baseline gap)", () => {
+    const { outcome, note } = classifyProbe(
+      result({ status: 404 }),
+      result({ status: 200 }),
+      "ok",
+    )
+    expect(outcome).toBe("acceptable")
+    expect(note).toMatch(/legacy baseline gap/)
+  })
+
+  it("acceptable: prod 404 → preview 308 on a `redirect` fixture (preview adds the redirect)", () => {
+    const { outcome } = classifyProbe(
+      result({ status: 404 }),
+      result({ status: 308 }),
+      "redirect",
+    )
+    expect(outcome).toBe("acceptable")
+  })
+
+  it("match: prod 404 → preview 404 regardless of expect", () => {
+    expect(
+      classifyProbe(result({ status: 404 }), result({ status: 404 }), "ok")
+        .outcome,
+    ).toBe("match")
   })
 
   it("error: transport error on either side", () => {

--- a/apps/web/src/lib/watch-url-probe.ts
+++ b/apps/web/src/lib/watch-url-probe.ts
@@ -220,15 +220,27 @@ const statusClass = (status: number): number => Math.floor(status / 100)
  *                        404 that now resolves/redirects (prod 4xx → preview
  *                        non-4xx — §5.6 contract violation).
  * - `acceptable`       — prod 3xx → preview 2xx (preview skips a redundant
- *                        redirect and serves directly).
+ *                        redirect and serves directly), OR prod 4xx →
+ *                        preview resolves/redirects on a fixture that is NOT
+ *                        `expect: "notfound"` (the production baseline simply
+ *                        lacked content the rewrite now serves — a superset,
+ *                        not a regression).
  * - `soft-regression`  — same status class but a DIFFERENT final path (canonical
  *                        / SEO drift; needs stakeholder review), or prod 2xx →
  *                        preview 3xx.
  * - `match`            — same status class + same final path.
+ *
+ * `expect` is the fixture's nominal §5 outcome. It ONLY modulates the prod-4xx
+ * case: a `notfound` fixture (§5.6) MUST stay 404 on preview, so prod-4xx →
+ * preview-non-4xx is a hard regression; for any other fixture a prod-4xx
+ * baseline just means production didn't serve it, so the preview serving it is
+ * an acceptable superset. Default `"notfound"` keeps the strict §5.6 reading
+ * when a caller omits it.
  */
 export function classifyProbe(
   production: ProbeResult,
   preview: ProbeResult,
+  expect: ProbeExpect = "notfound",
 ): { outcome: ProbeOutcome; note: string } {
   if (production.error || preview.error) {
     return {
@@ -292,13 +304,22 @@ export function classifyProbe(
     }
   }
 
-  // pc === 4 — production 404 (or other 4xx). §5.6: must STAY 404.
+  // pc === 4 — production 4xx.
   if (vc === 4) {
     return { outcome: "match", note: `404 preserved (${preview.status})` }
   }
+  // Preview resolves/redirects where prod 404'd. Only a §5.6 "must-stay-404"
+  // fixture treats this as a hard contract break; otherwise the production
+  // baseline simply lacked content the rewrite now serves (a superset).
+  if (expect === "notfound") {
+    return {
+      outcome: "hard-regression",
+      note: `EXPECTED-404 CONTRACT BROKEN: prod ${production.status} → preview ${preview.status} (must not resolve or redirect)`,
+    }
+  }
   return {
-    outcome: "hard-regression",
-    note: `EXPECTED-404 CONTRACT BROKEN: prod ${production.status} → preview ${preview.status} (must not resolve or redirect)`,
+    outcome: "acceptable",
+    note: `preview serves content prod ${production.status}'d (legacy baseline gap, not a regression): preview ${preview.status} → ${preview.finalPath}`,
   }
 }
 


### PR DESCRIPTION
## Summary

The first live cutover run (`probe:watch-urls` www vs watch) reported **14 hard regressions** — but 7 were false positives. The classifier treated every `prod 4xx → preview 2xx` as a §5.6 "expected-404 contract break", which wrongly flagged URLs where the **legacy production baseline 404s** and forge legitimately serves content: `/watch/search` (forge adds it), the german/swahili language homes, and two lumo episodes.

`classifyProbe` now takes the fixture's `expect`:
- `prod 4xx → preview resolves/redirects` is **`hard`** only for `expect: "notfound"` (§5.6) fixtures (those MUST stay 404).
- For any other fixture it's **`acceptable`** — the production baseline simply lacked content the rewrite now serves (a superset, not a regression).
- Defaults to `"notfound"` so an omitted arg keeps the strict §5.6 reading.

## Re-run result (www vs watch.jesusfilm.org)

| | before | after |
|--|--|--|
| match | 96 | 96 |
| acceptable | 0 | **7** |
| soft | 0 | 0 |
| **hard** | **14** | **7** |

The 7 remaining hard regressions are **genuine §5.6 violations** — forge serves `200` for `uppercase` / `non-ASCII` / `bcp47-locale` / `empty-slug` / `bad-locale-on-collection` / `single-video-no-locale` shapes that must `404`. Confirmed by direct curl. That content-resolution hardening is a separate PR (the real cutover blocker).

## Test plan
- [x] `watch-url-probe.test.ts` — 24 tests incl. new expect-aware cases (notfound→hard, ok/redirect→acceptable, default-notfound, 404→404 match)
- [x] live re-run: 7 hard (all genuine §5.6), 7 false positives reclassified `acceptable`
- [x] lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)