### PR TITLE
fix(web): stop watch resolver over-fetching the multi-language dub tree

### DIFF
--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -447,27 +447,6 @@ function pickLocalizedName(value: unknown): string | null {
   return null
 }
 
-function normalizeChildVariant(
-  dub: NonNullable<
-    NonNullable<NonNullable<AdminVideoRaw["children"]>[number]["child"]>["dubs"]
-  >[number],
-): WatchChildVariant | null {
-  if (!dub.documentId) return null
-  return {
-    documentId: dub.documentId,
-    published: dub.published ?? null,
-    hls: dub.hls ?? null,
-    duration: dub.duration ?? null,
-    language: dub.language
-      ? {
-          slug: dub.language.slug ?? null,
-          name: pickLocalizedName(dub.language.name),
-          bcp47: dub.language.bcp47 ?? null,
-        }
-      : null,
-  }
-}
-
 function normalizeChild(
   rel: NonNullable<AdminVideoRaw["children"]>[number],
 ): WatchChild | null {
@@ -480,9 +459,12 @@ function normalizeChild(
     title: localeRow?.title ?? null,
     label: child.label ?? null,
     images: normalizeImages(child.images),
-    variants: (child.dubs ?? [])
-      .map(normalizeChildVariant)
-      .filter((v): v is WatchChildVariant => v != null),
+    // `child.dubs` is no longer fetched (see watch-video.ts fragment note):
+    // a 61-chapter × 2,200-language fan-out blew the resolved payload past
+    // Next's 2MB unstable_cache limit. The only consumer was the chapter
+    // duration pill, which is now omitted. Empty until a cheap server-side
+    // duration scalar exists.
+    variants: [],
   }
 }
 
@@ -975,15 +957,21 @@ async function fetchWatchVideoRecord(
   return normalized
 }
 
-// Strip the heavy fields (`downloads`, `muxVideo`) from every variant in
-// `record.variants` *except* the one matching `selectedDocumentId`.
+// Strip the heavy fields (`downloads`, `muxVideo`, `videoEdition`) from every
+// variant in `record.variants` *except* the one matching `selectedDocumentId`.
 // Each non-selected variant retains documentId, slug, published, hls, and
 // language only — enough to power the language picker and the URL/locale
-// guards without shipping per-quality download metadata × 240+ variants.
+// guards without shipping per-quality download metadata OR per-variant
+// subtitle lists × 2,200+ variants. The page-level subtitle list is sourced
+// separately (`normalizeSubtitles` reads variant[0]) and the language picker
+// reads the top-level `subtitles` prop, so dropping per-variant `videoEdition`
+// on non-selected variants is invisible to consumers. Leaving subtitles on
+// every variant inflated JESUS's resolved payload by ~10MB — over Next's
+// unstable_cache 2MB limit.
 //
 // Runtime-only narrowing: the `WatchVideoRecord` type still claims those
 // fields are present on every variant, so the stripped objects keep the
-// same shape with empty `downloads: []` and `muxVideo: null`.
+// same shape with empty `downloads: []`, `muxVideo: null`, `videoEdition: null`.
 function stripNonSelectedVariantFields(
   record: WatchVideoRecord,
   selectedDocumentId: string | null,
@@ -995,6 +983,7 @@ function stripNonSelectedVariantFields(
       ...variant,
       downloads: [] as WatchVariantDownload[],
       muxVideo: null,
+      videoEdition: null,
     }
   })
   return { ...record, variants }

--- a/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
+++ b/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
@@ -48,13 +48,16 @@ describe("WatchVideoFragment", () => {
 
     // parents / children come through VideoRelation in admin — the
     // fragment projects `parent { ... }` / `child { ... }`. Assert both
-    // joins are present and surface their nested locales/images/dubs.
+    // joins are present and surface their nested locales/images.
     expect(printed).toMatch(/parents\s*\{[\s\S]*?parent\s*\{/)
     expect(printed).toMatch(/children\s*\{[\s\S]*?child\s*\{/)
     expect(printed).toMatch(/child\s*\{[\s\S]*?locales\(locale:\s*\$locale\)/)
-    expect(printed).toMatch(
-      /child\s*\{[\s\S]*?dubs\s*\{[\s\S]*?published[\s\S]*?\bhls\b/,
-    )
+    // `child.dubs` is intentionally NOT projected — a 61-chapter ×
+    // 2,200-language fan-out blew the resolved payload past Next's 2MB
+    // unstable_cache limit and broke the watch page. The only `dubs {`
+    // selection that remains is the top-level `variants: dubs` alias, so
+    // exactly one occurrence must be present. Guards the regression.
+    expect(printed.match(/\bdubs\s*\{/g) ?? []).toHaveLength(1)
 
     // variants: dubs alias on Video; nested fields keep the consumer
     // vocabulary intact.

--- a/apps/web/src/lib/fragments/watch-video.ts
+++ b/apps/web/src/lib/fragments/watch-video.ts
@@ -113,17 +113,15 @@ export const watchVideoFragment = adminGraphql(`
           mobileCinematicHigh
           mobileCinematicLow
         }
-        dubs {
-          documentId: id
-          published
-          hls
-          duration
-          language {
-            slug
-            name
-            bcp47
-          }
-        }
+        # NOTE: child.dubs is deliberately NOT projected. A parent/collection
+        # video (e.g. JESUS) has 61 chapters, each dubbed in ~2,200 languages —
+        # fetching every chapter's full dub list inflated the resolved payload
+        # to ~45MB, which Next's unstable_cache rejects (over its 2MB limit),
+        # throwing an unhandled rejection that broke the whole watch page. The
+        # only consumer was the per-chapter duration pill in SeriesEpisodeCard;
+        # that pill is now omitted. Restoring it needs a cheap server-side
+        # duration scalar on Video (like HybridSearchResult.durationSeconds),
+        # NOT a full dub fetch. See content.ts normalizeChild.
       }
     }
     variants: dubs {


### PR DESCRIPTION
## Problem

`/watch/jesus.html/english.html` (and other large collections like `/watch/easter.html`) failed to load with **"Failed to load experience: Something went wrong loading this page."**

Root cause: `resolveWatchVideoBySlug` (`apps/web/src/lib/content.ts`) returns a **~45 MB** payload for the Jesus film — it fetches every top-level language variant (**2,276** dubs) *plus* every chapter's full dub list (`children[].child.dubs` ≈ **137,771** records across 61 chapters). Next's `unstable_cache` rejects anything over **2 MB**, throwing an unhandled rejection that breaks the page render and trips the error boundary.

Evidence from the dev log:
```
Failed to set Next.js data cache for unstable_cache /jesus.html/english.html
tryResolveWatchVideoBySlug, items over 2MB can not be cached (45246998 bytes)
```

## Fix

Trim the over-fetch so the resolved payload fits under the cache limit:

- **`watch-video.ts` fragment** — drop `children[].child.dubs` (the ~33 MB bulk). Its only consumer was the per-chapter duration pill in `SeriesEpisodeCard`.
- **`stripNonSelectedVariantFields`** — also strip `videoEdition` (subtitles) from non-selected variants (the other ~10 MB). Page-level subtitles come from `variant[0]` and the language picker reads the top-level `subtitles` prop, so per-variant `videoEdition` on non-selected variants was unused.
- **`normalizeChild`** — `variants` now empty; removed the dead `normalizeChildVariant`.

**Resolved payload for `/watch/jesus.html`: ~45 MB → ~1 MB** (measured).

## Verification

- `pnpm tsc --noEmit` ✅ · `pnpm vitest` (145 tests) ✅ · `eslint` ✅
- Live dev render of `jesus.html/english.html`, `easter.html/english.html`, and `*/es.html`: full watch page renders (VideoHero + mux player, `<title>Jesus</title>`), **no error boundary**, no `unstable_cache > 2MB` rejection in logs.

## Known tradeoff / follow-up

Chapter cards in the sibling carousel temporarily lose their **duration pill** (the only consumer of `child.dubs`; `Video` has no cheap duration scalar). Follow-up: add a `Video.durationSeconds` resolver in admin (mirroring `HybridSearchResult.durationSeconds`) and read that instead of refetching every dub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)