### PR TITLE
Hide transcript when subtitles do not match audio

### DIFF
--- a/apps/web/src/components/watch/SubtitleTranscript.tsx
+++ b/apps/web/src/components/watch/SubtitleTranscript.tsx
@@ -141,6 +141,14 @@ function pickInitialSubtitleSlug(
   return subtitles[0]!.language.slug
 }
 
+export function filterTranscriptSubtitlesForAudio(
+  subtitles: WatchSubtitle[],
+  audioSlug: string | null | undefined,
+): WatchSubtitle[] {
+  if (!audioSlug) return subtitles
+  return subtitles.filter((s) => s.language.slug === audioSlug)
+}
+
 type SubtitleTranscriptProps = {
   subtitles: WatchSubtitle[]
   playerRef: RefObject<MuxPlayerRef | null>
@@ -161,20 +169,28 @@ export function SubtitleTranscript({
   durationSeconds,
 }: SubtitleTranscriptProps) {
   const t = useTranslations("SubtitleTranscript")
-  const initialSlug = useMemo(
-    () => pickInitialSubtitleSlug(subtitles, audioSlug ?? null),
+  const transcriptSubtitles = useMemo(
+    () => filterTranscriptSubtitlesForAudio(subtitles, audioSlug),
     [subtitles, audioSlug],
   )
+  const initialSlug = useMemo(
+    () => pickInitialSubtitleSlug(transcriptSubtitles, audioSlug ?? null),
+    [transcriptSubtitles, audioSlug],
+  )
   const [selectedSlug, setSelectedSlug] = useState<string | null>(initialSlug)
+
+  useEffect(() => {
+    setSelectedSlug(initialSlug)
+  }, [initialSlug])
 
   const activeSubtitle = useMemo(() => {
     if (!selectedSlug) return null
     return (
-      subtitles.find((s) => s.language.slug === selectedSlug) ??
-      subtitles[0] ??
+      transcriptSubtitles.find((s) => s.language.slug === selectedSlug) ??
+      transcriptSubtitles[0] ??
       null
     )
-  }, [selectedSlug, subtitles])
+  }, [selectedSlug, transcriptSubtitles])
 
   const [loaded, setLoaded] = useState<{
     vttSrc: string
@@ -305,7 +321,7 @@ export function SubtitleTranscript({
     [playerRef],
   )
 
-  if (subtitles.length === 0) return null
+  if (transcriptSubtitles.length === 0) return null
 
   const languageLabel = (s: WatchSubtitle) =>
     s.language.nativeName && s.language.nativeName !== s.language.name
@@ -331,7 +347,7 @@ export function SubtitleTranscript({
               <p className="mt-1 text-sm text-stone-400">{t("subheading")}</p>
             </div>
             <div className="flex items-center gap-3">
-              {subtitles.length > 1 ? (
+              {transcriptSubtitles.length > 1 ? (
                 <label className="flex items-center gap-2 text-sm text-stone-300">
                   <span className="sr-only">{t("subtitleLanguage")}</span>
                   <select
@@ -340,7 +356,7 @@ export function SubtitleTranscript({
                     onChange={(e) => setSelectedSlug(e.target.value)}
                     className={`appearance-none rounded-full bg-stone-900/80 px-4 py-2 text-sm font-medium text-stone-100 ${GLASS_OUTLINE_CLASS} focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2`}
                   >
-                    {subtitles.map((s) => (
+                    {transcriptSubtitles.map((s) => (
                       <option key={s.documentId} value={s.language.slug}>
                         {languageLabel(s)}
                         {s.aiGenerated ? t("aiSuffix") : ""}

--- a/apps/web/src/components/watch/__tests__/SubtitleTranscript.render.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SubtitleTranscript.render.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createRef } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { act } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { MuxPlayerRef } from "@forge/video-player"
+
+import { SubtitleTranscript } from "@/components/watch/SubtitleTranscript"
+import type { WatchSubtitle } from "@/lib/content"
+
+vi.mock("next-intl", () => ({
+  useTranslations:
+    () =>
+    (key: string): string =>
+      key,
+}))
+
+const amharicSubtitle: WatchSubtitle = {
+  documentId: "subtitle-am",
+  language: {
+    slug: "amharic",
+    name: "Amharic",
+    nativeName: null,
+    bcp47: "am",
+  },
+  vttSrc: "https://example.com/am.vtt",
+  primary: false,
+  aiGenerated: true,
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  document.body.innerHTML = ""
+})
+
+describe("SubtitleTranscript rendering", () => {
+  it("does not render the transcript section when subtitles do not match the selected audio language", () => {
+    act(() => {
+      root.render(
+        <SubtitleTranscript
+          subtitles={[amharicSubtitle]}
+          audioSlug="english"
+          playerRef={createRef<MuxPlayerRef | null>()}
+        />,
+      )
+    })
+
+    expect(
+      container.querySelector('[data-testid="watch-subtitle-transcript"]'),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx
@@ -10,10 +10,61 @@
 
 import { describe, expect, test } from "vitest"
 
+import type { WatchSubtitle } from "@/lib/content"
 import {
+  filterTranscriptSubtitlesForAudio,
   normalizeCueOffset,
   parseVtt,
 } from "@/components/watch/SubtitleTranscript"
+
+const englishSubtitle: WatchSubtitle = {
+  documentId: "subtitle-en",
+  language: {
+    slug: "english",
+    name: "English",
+    nativeName: null,
+    bcp47: "en",
+  },
+  vttSrc: "https://example.com/en.vtt",
+  primary: true,
+  aiGenerated: false,
+}
+
+const amharicSubtitle: WatchSubtitle = {
+  documentId: "subtitle-am",
+  language: {
+    slug: "amharic",
+    name: "Amharic",
+    nativeName: null,
+    bcp47: "am",
+  },
+  vttSrc: "https://example.com/am.vtt",
+  primary: false,
+  aiGenerated: true,
+}
+
+describe("filterTranscriptSubtitlesForAudio", () => {
+  test("keeps only subtitles that match the selected audio language", () => {
+    expect(
+      filterTranscriptSubtitlesForAudio(
+        [englishSubtitle, amharicSubtitle],
+        "english",
+      ),
+    ).toEqual([englishSubtitle])
+  })
+
+  test("returns no subtitles when the selected audio language has no matching subtitle track", () => {
+    expect(
+      filterTranscriptSubtitlesForAudio([amharicSubtitle], "english"),
+    ).toEqual([])
+  })
+
+  test("preserves existing subtitle fallback behavior when no audio language is known", () => {
+    const subtitles = [englishSubtitle, amharicSubtitle]
+
+    expect(filterTranscriptSubtitlesForAudio(subtitles, null)).toBe(subtitles)
+  })
+})
 
 describe("parseVtt", () => {
   test("parses a happy-path cue", () => {

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (May 25, 2026)
 
-- **Total tickets:** 154
-- **Complete:** 85
+- **Total tickets:** 155
+- **Complete:** 86
 - **In progress:** 9
 - **Not started:** 20
 - **Blocked:** 40
@@ -83,6 +83,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-037](media-generation/feat-037-playback-qa-feedback-loop.md)                        | Playback QA and Feedback Loop                             | vlad  | P1       | 2026-05-19 | 21   | 2026-06-08 | blocked     |
 | [feat-041](media-generation/feat-041-alternative-report-sections.md)                      | Alternative Report Sections                               | vlad  | P1       | 2026-05-26 | 14   | 2026-06-08 | blocked     |
 | [feat-145](media-generation/feat-145-watch-mobile-player-controls-width.md)               | Watch Mobile Player Controls Width                        | vlad  | P1       | 2026-05-28 | 1    | 2026-05-28 | complete    |
+| [feat-146](media-generation/feat-146-watch-transcript-audio-language-match.md)            | Watch Transcript Audio Language Match                     | vlad  | P1       | 2026-05-29 | 1    | 2026-05-29 | complete    |
 | [feat-056](media-generation/feat-056-ai-video-template-system.md)                         | AI Video Template System                                  | vlad  | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-057](media-generation/feat-057-automated-video-rendering-engine.md)                 | Automated Video Rendering Engine                          | vlad  | P1       | 2026-08-01 | 31   | 2026-08-31 | blocked     |
 | [feat-060](media-generation/feat-060-on-demand-personalized-video-generation.md)          | On-Demand Personalized Video Generation                   | vlad  | P1       | 2026-09-01 | 30   | 2026-09-30 | blocked     |

--- a/docs/roadmap/media-generation/feat-146-watch-transcript-audio-language-match.md
+++ b/docs/roadmap/media-generation/feat-146-watch-transcript-audio-language-match.md
@@ -1,0 +1,56 @@
+---
+id: "feat-146"
+title: "Watch Transcript Audio Language Match"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-05-29"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "web"
+  - "video"
+  - "subtitles"
+---
+
+## Problem
+
+The watch page transcript section can render a subtitle track whose language
+does not match the selected audio language. This makes the transcript panel
+look authoritative even when it belongs to a different dub.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/watch/SubtitleTranscript.tsx` - transcript panel
+   selection and rendering logic.
+2. `apps/web/src/components/watch/WatchPageClient.tsx` - passes the selected
+   audio language slug and subtitle list into the transcript panel.
+3. `apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx` -
+   pure transcript parser coverage and regression home for transcript helpers.
+
+## Grep These
+
+- `watch-subtitle-transcript`
+- `pickInitialSubtitleSlug`
+- `audioSlug`
+- `subtitles.length === 0`
+
+## What To Build
+
+1. Only allow transcript subtitles whose `language.slug` matches the selected
+   audio language slug.
+2. Render no transcript/subtitle section when the selected audio language has
+   no matching subtitle track.
+3. Preserve the existing fallback behavior only when no audio slug is known.
+4. Add focused regression coverage for the mismatch case.
+
+## Constraints
+
+- Do not change subtitle overlay preference storage.
+- Do not change video/audio variant selection.
+- Do not change VTT parsing or cue offset normalization.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/SubtitleTranscript.test.tsx src/components/watch/__tests__/SubtitleTranscript.render.test.tsx`


### PR DESCRIPTION
## Summary
- Hide the watch transcript section unless subtitle tracks match the selected audio language.
- Reset transcript selection against the audio-filtered subtitle set so stale/mismatched selections cannot render.
- Add helper and jsdom regression coverage, plus the scoped roadmap ticket.

## Tests
- pnpm --filter @forge/web test -- src/components/watch/__tests__/SubtitleTranscript.test.tsx src/components/watch/__tests__/SubtitleTranscript.render.test.tsx
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- pnpm exec prettier --check apps/web/src/components/watch/SubtitleTranscript.tsx apps/web/src/components/watch/__tests__/SubtitleTranscript.test.tsx apps/web/src/components/watch/__tests__/SubtitleTranscript.render.test.tsx docs/roadmap/README.md docs/roadmap/media-generation/feat-146-watch-transcript-audio-language-match.md