### PR TITLE
fix(web): align watch carousel initial snap

### DIFF
--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -55,6 +55,7 @@ export function SiblingCarousel({
   // compete with the LCP poster fetch on the critical chain.
 
   const [api, setApi] = useState<CarouselApi | null>(null)
+  const initialCarouselIndex = activeIndex >= 0 ? activeIndex : 0
 
   // Snap to the active item whenever it changes (or when `api` first
   // becomes available). Re-keying on `activeIndex` covers variant-switch
@@ -106,18 +107,15 @@ export function SiblingCarousel({
       </header>
 
       <Carousel
-        opts={{ align: "start", containScroll: "trimSnaps" }}
+        opts={{
+          align: "start",
+          containScroll: "trimSnaps",
+          startIndex: initialCarouselIndex,
+        }}
         setApi={setApi}
         className="w-full"
       >
-        <CarouselContent
-          className={cn(
-            "pl-10 md:pl-0",
-            activeIndex > 0 && activeIndex < children.length - 1
-              ? "translate-x-14 md:translate-x-0"
-              : "",
-          )}
-        >
+        <CarouselContent className="pl-10 md:pl-0">
           {children.map((child, index) => {
             const isActive = index === activeIndex
             // `resolvePosterUrl` codifies the editorial-cinematic priority

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -170,8 +170,8 @@ describe("SiblingCarousel — happy path", () => {
     )
     expect(content?.className).toContain("pl-10")
     expect(content?.className).toContain("md:pl-0")
-    expect(content?.className).toContain("translate-x-14")
-    expect(content?.className).toContain("md:translate-x-0")
+    expect(content?.className).not.toContain("translate-x-14")
+    expect(content?.className).not.toContain("md:translate-x-0")
     const endSpacer = container.querySelector(
       "[data-testid='sibling-carousel-end-spacer']",
     )


### PR DESCRIPTION
## Summary

Describe the scoped change and reason. PR title must use `type(scope): description` (e.g. `feat(web): add validation`).

## Work Loop

- [ ] `ce:plan` done
- [ ] `ce:work` done
- [ ] `ce:review` done
- [ ] `ce:compound` done

## Notes

Optional links (plan docs, solutions docs, related context).
