### PR TITLE
feat(admin): add watch route manifest

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -225,6 +225,45 @@ Reversing the order produces a dead minute where admin's first call 401s
 against an unconfigured web. The webhook itself swallows the 401, so the
 symptom is "web pages don't update after publish" with no error surface.
 
+### Watch route manifest snapshot
+
+Admin owns the public watch-route admission manifest at
+`GET /api/watch-route-manifest`. The route requires the normal consumer
+bearer and returns the latest persisted snapshot with `ETag` support; if no
+snapshot exists, it returns a controlled 503 instead of generating on demand.
+
+Snapshot fields the web branch can rely on:
+
+- `contentSlugs` — all public two-segment content slugs: playable videos,
+  parent videos with playable children, and published one-segment
+  experiences.
+- `oneSegmentSlugs` — published non-template, non-homepage experiences whose
+  public route is exactly one segment.
+- `episodePairsByParent` — compact parent slug to playable child slugs map for
+  three-segment episode routes.
+- `audioLanguageSlugs` — language slugs that have at least one published HLS
+  dub on a non-deleted video.
+- `version` and `generatedAt` — stable cache/revalidation metadata.
+
+Refresh triggers:
+
+- Core sync phases `languages`, `videos`, and `video-dubs`.
+- Experience locale publish/update/archive flows that can change public route
+  visibility.
+- Operator refresh script:
+
+```bash
+DATABASE_URL='postgresql://forge:forge@localhost:5433/forge_admin' \
+pnpm --filter @forge/admin watch-route-manifest:generate
+```
+
+The script prints summary-only JSON by default: version, generated timestamp,
+payload size, counts, and duration. Use `--print` only for local debugging when
+the full manifest payload is intentionally needed. Like `seed-web-fixtures`, it
+refuses production-like `DATABASE_URL` hosts (`*.railway.app`,
+`*.jesusfilm.org`, and unparseable URLs) so operators do not accidentally mutate
+production snapshots from a workstation.
+
 ### Video database backup and clone
 
 Production backup is automated only. Do not add or use an operator

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -30,6 +30,7 @@
     "schema:print": "tsx src/scripts/print-schema.ts",
     "seed-easter": "tsx --env-file=.env src/scripts/seed-easter.ts",
     "seed-web-fixtures": "tsx --env-file=.env src/scripts/seed-web-fixtures.ts",
+    "watch-route-manifest:generate": "tsx --env-file=.env src/scripts/generate-watch-route-manifest.ts",
     "manager:grant-operator": "tsx --env-file=.env src/scripts/grant-manager-operator.ts",
     "trigger-enrichment": "tsx src/scripts/trigger-enrichment.ts",
     "eval:search": "tsx src/scripts/eval-search.ts run",

--- a/apps/admin/prisma/migrations/0025_watch_route_manifest_snapshot/migration.sql
+++ b/apps/admin/prisma/migrations/0025_watch_route_manifest_snapshot/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "watch_route_manifest_snapshot" (
+    "key" TEXT PRIMARY KEY,
+    "version" TEXT NOT NULL,
+    "generated_at" timestamp(3) NOT NULL,
+    "payload" JSONB NOT NULL,
+    "payload_size_bytes" INTEGER NOT NULL,
+    "created_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX "watch_route_manifest_snapshot_generated_at_idx"
+    ON "watch_route_manifest_snapshot"("generated_at");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -559,6 +559,22 @@ model ManagerCoverageSnapshot {
   @@map("manager_coverage_snapshot")
 }
 
+/// Latest admin-owned watch route-admission manifest. This singleton snapshot
+/// lets apps/web fetch compact public route sets without asking admin to
+/// recompute large aggregate queries per request.
+model WatchRouteManifestSnapshot {
+  key              String   @id
+  version          String
+  generatedAt      DateTime @map("generated_at")
+  payload          Json
+  payloadSizeBytes Int      @map("payload_size_bytes")
+  createdAt        DateTime @default(now()) @map("created_at")
+  updatedAt        DateTime @updatedAt @map("updated_at")
+
+  @@index([generatedAt])
+  @@map("watch_route_manifest_snapshot")
+}
+
 /// Admin-owned persistence for Manager enrichment jobs. Field names mirror the
 /// existing Manager JobRecord so Manager can move transport without UI churn.
 model ManagerEnrichmentJob {

--- a/apps/admin/src/app/api/watch-route-manifest/route.test.ts
+++ b/apps/admin/src/app/api/watch-route-manifest/route.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const isValidConsumerBearerMock = vi.fn()
+const getLatestMock = vi.fn()
+
+vi.mock("@/auth/consumer-bearer", () => ({
+  isValidConsumerBearer: isValidConsumerBearerMock,
+}))
+
+vi.mock("@/db/client", () => ({
+  prisma: {},
+}))
+
+vi.mock("@/services/watch-route-manifest-store", () => ({
+  WatchRouteManifestStore: vi.fn(() => ({
+    getLatest: getLatestMock,
+  })),
+}))
+
+const { GET } = await import("./route")
+
+const manifest = {
+  version: "version-1",
+  generatedAt: "2026-05-29T12:00:00.000Z",
+  contentSlugs: ["jesus"],
+  oneSegmentSlugs: ["easter"],
+  episodePairsByParent: { series: ["episode"] },
+  audioLanguageSlugs: ["english"],
+}
+
+function request(headers: HeadersInit = {}) {
+  return new Request("http://admin.test/api/watch-route-manifest", {
+    method: "GET",
+    headers,
+  })
+}
+
+describe("GET /api/watch-route-manifest", () => {
+  beforeEach(() => {
+    isValidConsumerBearerMock.mockReset()
+    getLatestMock.mockReset()
+    isValidConsumerBearerMock.mockReturnValue({
+      valid: true,
+      bucketKey: "web-key",
+    })
+    getLatestMock.mockResolvedValue({
+      key: "latest",
+      version: manifest.version,
+      generatedAt: new Date(manifest.generatedAt),
+      payload: manifest,
+      payloadSizeBytes: 123,
+      createdAt: new Date("2026-05-29T12:00:01.000Z"),
+      updatedAt: new Date("2026-05-29T12:00:02.000Z"),
+    })
+  })
+
+  it("returns the latest manifest for a valid consumer bearer", async () => {
+    const response = await GET(
+      request({ authorization: "Bearer test-consumer-key" }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("etag")).toBe('"version-1"')
+    expect(response.headers.get("cache-control")).toBe(
+      "private, max-age=0, must-revalidate",
+    )
+    await expect(response.json()).resolves.toEqual(manifest)
+    expect(isValidConsumerBearerMock).toHaveBeenCalledWith(
+      "Bearer test-consumer-key",
+    )
+  })
+
+  it("returns 304 when the caller already has the current version", async () => {
+    const response = await GET(
+      request({
+        authorization: "Bearer test-consumer-key",
+        "if-none-match": '"version-1"',
+      }),
+    )
+
+    expect(response.status).toBe(304)
+    expect(await response.text()).toBe("")
+  })
+
+  it("rejects missing or invalid bearer without revealing snapshot state", async () => {
+    isValidConsumerBearerMock.mockReturnValue({
+      valid: false,
+      bucketKey: null,
+    })
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get("www-authenticate")).toBe(
+      'Bearer realm="watch-route-manifest"',
+    )
+    await expect(response.json()).resolves.toEqual({
+      error: "Authorization required",
+    })
+    expect(getLatestMock).not.toHaveBeenCalled()
+  })
+
+  it("returns a clear 503 when no snapshot exists", async () => {
+    getLatestMock.mockResolvedValueOnce(null)
+
+    const response = await GET(request({ authorization: "Bearer key" }))
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      error: "Watch route manifest unavailable",
+      reason: "missing_snapshot",
+    })
+  })
+
+  it("returns a controlled 500 when the store read fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    getLatestMock.mockRejectedValueOnce(new Error("database secret detail"))
+
+    const response = await GET(request({ authorization: "Bearer key" }))
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: "Watch route manifest read failed",
+      reason: "read_failed",
+    })
+    expect(warn.mock.calls[0][0]).toContain("watch_route_manifest.read.failed")
+    warn.mockRestore()
+  })
+})

--- a/apps/admin/src/app/api/watch-route-manifest/route.ts
+++ b/apps/admin/src/app/api/watch-route-manifest/route.ts
@@ -1,0 +1,66 @@
+import { isValidConsumerBearer } from "@/auth/consumer-bearer"
+import { prisma } from "@/db/client"
+import { WatchRouteManifestStore } from "@/services/watch-route-manifest-store"
+
+const CACHE_CONTROL = "private, max-age=0, must-revalidate"
+
+function unauthorized(): Response {
+  return Response.json(
+    { error: "Authorization required" },
+    {
+      status: 401,
+      headers: { "WWW-Authenticate": 'Bearer realm="watch-route-manifest"' },
+    },
+  )
+}
+
+export async function GET(request: Request): Promise<Response> {
+  if (!isValidConsumerBearer(request.headers.get("authorization")).valid) {
+    return unauthorized()
+  }
+
+  const store = new WatchRouteManifestStore(prisma)
+
+  try {
+    const snapshot = await store.getLatest()
+    if (!snapshot) {
+      return Response.json(
+        {
+          error: "Watch route manifest unavailable",
+          reason: "missing_snapshot",
+        },
+        {
+          status: 503,
+          headers: { "Cache-Control": "private, no-store" },
+        },
+      )
+    }
+
+    const etag = `"${snapshot.version}"`
+    const headers = {
+      "Cache-Control": CACHE_CONTROL,
+      ETag: etag,
+    }
+
+    if (request.headers.get("if-none-match") === etag) {
+      return new Response(null, { status: 304, headers })
+    }
+
+    return Response.json(snapshot.payload, { status: 200, headers })
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "watch_route_manifest.read.failed",
+        detail:
+          error instanceof Error ? error.message.slice(0, 500) : String(error),
+      }),
+    )
+    return Response.json(
+      {
+        error: "Watch route manifest read failed",
+        reason: "read_failed",
+      },
+      { status: 500, headers: { "Cache-Control": "private, no-store" } },
+    )
+  }
+}

--- a/apps/admin/src/scripts/generate-watch-route-manifest.test.ts
+++ b/apps/admin/src/scripts/generate-watch-route-manifest.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  assertNotProdUrl,
+  CliConfigError,
+  parseGenerateWatchRouteManifestArgs,
+  runGenerateWatchRouteManifest,
+} from "./generate-watch-route-manifest"
+
+const manifest = {
+  version: "version-1",
+  generatedAt: "2026-05-29T12:00:00.000Z",
+  contentSlugs: ["jesus"],
+  oneSegmentSlugs: ["easter"],
+  episodePairsByParent: { series: ["episode-1", "episode-2"] },
+  audioLanguageSlugs: ["english"],
+}
+
+function makeSnapshot() {
+  return {
+    key: "latest",
+    version: manifest.version,
+    generatedAt: new Date(manifest.generatedAt),
+    payload: manifest,
+    payloadSizeBytes: 256,
+    createdAt: new Date("2026-05-29T12:00:01.000Z"),
+    updatedAt: new Date("2026-05-29T12:00:02.000Z"),
+  }
+}
+
+function makeStdout() {
+  const chunks: string[] = []
+  return {
+    stream: {
+      write(chunk: string) {
+        chunks.push(chunk)
+      },
+    },
+    lines() {
+      return chunks.join("").trim().split("\n").filter(Boolean)
+    },
+  }
+}
+
+describe("parseGenerateWatchRouteManifestArgs", () => {
+  it("defaults to summary-only output", () => {
+    expect(parseGenerateWatchRouteManifestArgs([])).toEqual({
+      printManifest: false,
+    })
+  })
+
+  it("enables explicit print mode", () => {
+    expect(parseGenerateWatchRouteManifestArgs(["--print"])).toEqual({
+      printManifest: true,
+    })
+  })
+
+  it("rejects unknown arguments", () => {
+    expect(() => parseGenerateWatchRouteManifestArgs(["--verbose"])).toThrow(
+      CliConfigError,
+    )
+  })
+})
+
+describe("assertNotProdUrl", () => {
+  it("refuses production-like and unparseable URLs", () => {
+    expect(() =>
+      assertNotProdUrl("postgresql://user:pass@some-host.railway.app:5432/db"),
+    ).toThrow(/railway\.app/)
+    expect(() =>
+      assertNotProdUrl("postgresql://user:pass@admin.jesusfilm.org:5432/db"),
+    ).toThrow(/jesusfilm\.org/)
+    expect(() => assertNotProdUrl("not a url")).toThrow(/parseable URL/i)
+    expect(() => assertNotProdUrl(undefined)).toThrow(/required/i)
+  })
+
+  it("allows local database hosts", () => {
+    expect(() =>
+      assertNotProdUrl("postgresql://forge:forge@localhost:5432/forge_admin"),
+    ).not.toThrow()
+    expect(() =>
+      assertNotProdUrl("postgresql://forge:forge@127.0.0.1:5432/forge_admin"),
+    ).not.toThrow()
+    expect(() =>
+      assertNotProdUrl("postgresql://forge:forge@db:5432/forge_admin"),
+    ).not.toThrow()
+  })
+})
+
+describe("runGenerateWatchRouteManifest", () => {
+  it("refreshes the snapshot and prints a summary without the manifest payload", async () => {
+    const stdout = makeStdout()
+    const refreshWatchRouteManifest = vi.fn().mockResolvedValue({
+      status: "refreshed",
+      reason: "operator-script",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 256,
+      counts: {
+        contentSlugs: 1,
+        oneSegmentSlugs: 1,
+        parentSlugs: 1,
+        parentChildPairs: 2,
+        audioLanguageSlugs: 1,
+      },
+      durationMs: 42,
+    })
+    const getLatestSnapshot = vi.fn().mockResolvedValue(makeSnapshot())
+
+    await runGenerateWatchRouteManifest(
+      { printManifest: false },
+      {
+        prisma: {} as never,
+        refreshWatchRouteManifest,
+        getLatestSnapshot,
+        stdout: stdout.stream,
+      },
+    )
+
+    expect(refreshWatchRouteManifest).toHaveBeenCalledWith({
+      prisma: {},
+      reason: "operator-script",
+    })
+    const lines = stdout.lines()
+    expect(lines).toHaveLength(1)
+    expect(JSON.parse(lines[0]!)).toEqual({
+      event: "watch_route_manifest.generate.complete",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 256,
+      counts: {
+        contentSlugs: 1,
+        oneSegmentSlugs: 1,
+        parentSlugs: 1,
+        parentChildPairs: 2,
+        audioLanguageSlugs: 1,
+      },
+      durationMs: 42,
+    })
+  })
+
+  it("prints the full manifest only when --print was requested", async () => {
+    const stdout = makeStdout()
+    const refreshWatchRouteManifest = vi.fn().mockResolvedValue({
+      status: "refreshed",
+      reason: "operator-script",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 256,
+      counts: {
+        contentSlugs: 1,
+        oneSegmentSlugs: 1,
+        parentSlugs: 1,
+        parentChildPairs: 2,
+        audioLanguageSlugs: 1,
+      },
+      durationMs: 42,
+    })
+
+    await runGenerateWatchRouteManifest(
+      { printManifest: true },
+      {
+        prisma: {} as never,
+        refreshWatchRouteManifest,
+        getLatestSnapshot: vi.fn().mockResolvedValue(makeSnapshot()),
+        stdout: stdout.stream,
+      },
+    )
+
+    const lines = stdout.lines()
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[1]!)).toEqual({
+      event: "watch_route_manifest.generate.manifest",
+      manifest,
+    })
+  })
+
+  it("does not print a stale success summary when refresh fails", async () => {
+    const stdout = makeStdout()
+    const getLatestSnapshot = vi.fn()
+
+    await expect(
+      runGenerateWatchRouteManifest(
+        { printManifest: false },
+        {
+          prisma: {} as never,
+          refreshWatchRouteManifest: vi.fn().mockResolvedValue({
+            status: "failed",
+            reason: "operator-script",
+            detail: "db unavailable",
+            durationMs: 12,
+          }),
+          getLatestSnapshot,
+          stdout: stdout.stream,
+        },
+      ),
+    ).rejects.toThrow(/db unavailable/)
+
+    expect(getLatestSnapshot).not.toHaveBeenCalled()
+    expect(stdout.lines()).toEqual([])
+  })
+})

--- a/apps/admin/src/scripts/generate-watch-route-manifest.ts
+++ b/apps/admin/src/scripts/generate-watch-route-manifest.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env tsx
+/**
+ * Generate and persist the admin-owned watch route manifest snapshot.
+ *
+ * Usage:
+ *   DATABASE_URL='postgresql://forge:forge@localhost:5433/forge_admin' \
+ *   pnpm --filter @forge/admin watch-route-manifest:generate
+ *
+ * Optional:
+ *   --print   Also print the full manifest payload after the summary.
+ *
+ * Safety: refuses production-like DATABASE_URL values. This script
+ * mutates the snapshot table and is intended for local/operator refresh
+ * workflows, not ad-hoc production pokes.
+ */
+
+import { fileURLToPath } from "node:url"
+import { resolve } from "node:path"
+import type { PrismaClient } from "@prisma/client"
+import type { refreshWatchRouteManifest } from "@/services/watch-route-manifest-refresh.service"
+import type { WatchRouteManifestSnapshotRecord } from "@/services/watch-route-manifest-store"
+
+const PROD_HOST_DENY_SET = new Set<string>([
+  "admin.jesusfilm.org",
+  "www.jesusfilm.org",
+  "jesusfilm.org",
+  "manager.jesusfilm.org",
+  "web.jesusfilm.org",
+])
+
+export type GenerateWatchRouteManifestOptions = {
+  printManifest: boolean
+}
+
+export class CliConfigError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: 2 = 2,
+  ) {
+    super(message)
+    this.name = "CliConfigError"
+  }
+}
+
+export function parseGenerateWatchRouteManifestArgs(
+  argv: readonly string[],
+): GenerateWatchRouteManifestOptions {
+  const unknown = argv.filter((arg) => arg !== "--print")
+  if (unknown.length > 0) {
+    throw new CliConfigError(
+      `[generate-watch-route-manifest] unknown argument(s): ${unknown.join(", ")}`,
+    )
+  }
+  return { printManifest: argv.includes("--print") }
+}
+
+function isProdDatabaseUrl(rawUrl: string): {
+  isProd: boolean
+  reason: string
+} {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return { isProd: true, reason: "DATABASE_URL is not a parseable URL" }
+  }
+
+  const host = parsed.hostname.toLowerCase()
+  if (host.endsWith(".railway.app")) {
+    return { isProd: true, reason: `host ${host} ends with .railway.app` }
+  }
+  if (host.endsWith(".jesusfilm.org")) {
+    return { isProd: true, reason: `host ${host} ends with .jesusfilm.org` }
+  }
+  if (PROD_HOST_DENY_SET.has(host)) {
+    return { isProd: true, reason: `host ${host} is on the prod deny set` }
+  }
+  return { isProd: false, reason: "" }
+}
+
+export function assertNotProdUrl(rawUrl: string | undefined): void {
+  if (!rawUrl) {
+    throw new Error("DATABASE_URL is required (no value set).")
+  }
+  const verdict = isProdDatabaseUrl(rawUrl)
+  if (verdict.isProd) {
+    throw new Error(
+      `[generate-watch-route-manifest] Refusing to run: ${verdict.reason}. ` +
+        `Point DATABASE_URL at a local or reviewed non-production Postgres and try again.`,
+    )
+  }
+}
+
+type RefreshWatchRouteManifest = typeof refreshWatchRouteManifest
+
+type OutputStream = {
+  write(chunk: string): unknown
+}
+
+type RunDeps = {
+  prisma: PrismaClient
+  refreshWatchRouteManifest: RefreshWatchRouteManifest
+  getLatestSnapshot: () => Promise<WatchRouteManifestSnapshotRecord | null>
+  stdout?: OutputStream
+}
+
+export async function runGenerateWatchRouteManifest(
+  options: GenerateWatchRouteManifestOptions,
+  deps: RunDeps,
+): Promise<void> {
+  const stdout = deps.stdout ?? process.stdout
+  const outcome = await deps.refreshWatchRouteManifest({
+    prisma: deps.prisma,
+    reason: "operator-script",
+  })
+
+  if (outcome.status !== "refreshed") {
+    const detail =
+      outcome.status === "failed"
+        ? outcome.detail
+        : "refresh skipped unexpectedly"
+    throw new Error(`[generate-watch-route-manifest] refresh failed: ${detail}`)
+  }
+
+  const snapshot = await deps.getLatestSnapshot()
+  if (!snapshot) {
+    throw new Error(
+      "[generate-watch-route-manifest] refresh completed but no latest snapshot was found",
+    )
+  }
+
+  stdout.write(
+    JSON.stringify({
+      event: "watch_route_manifest.generate.complete",
+      version: snapshot.version,
+      generatedAt: snapshot.payload.generatedAt,
+      payloadSizeBytes: snapshot.payloadSizeBytes,
+      counts: outcome.counts,
+      durationMs: outcome.durationMs,
+    }) + "\n",
+  )
+
+  if (options.printManifest) {
+    stdout.write(
+      JSON.stringify({
+        event: "watch_route_manifest.generate.manifest",
+        manifest: snapshot.payload,
+      }) + "\n",
+    )
+  }
+}
+
+async function main(argv: readonly string[] = process.argv.slice(2)) {
+  const options = parseGenerateWatchRouteManifestArgs(argv)
+  assertNotProdUrl(process.env.DATABASE_URL)
+
+  const { prisma } = await import("@/db/client")
+  const { refreshWatchRouteManifest } =
+    await import("@/services/watch-route-manifest-refresh.service")
+  const { WatchRouteManifestStore } =
+    await import("@/services/watch-route-manifest-store")
+  const store = new WatchRouteManifestStore(prisma)
+
+  try {
+    await runGenerateWatchRouteManifest(options, {
+      prisma,
+      refreshWatchRouteManifest,
+      getLatestSnapshot: () => store.getLatest(),
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+const isDirectInvoke =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+
+if (isDirectInvoke) {
+  main().catch((error) => {
+    const exitCode = error instanceof CliConfigError ? error.exitCode : 1
+    process.stderr.write(
+      `[generate-watch-route-manifest] fatal: ${
+        error instanceof Error ? (error.stack ?? error.message) : String(error)
+      }\n`,
+    )
+    process.exit(exitCode)
+  })
+}

--- a/apps/admin/src/services/core-sync/orchestrator.test.ts
+++ b/apps/admin/src/services/core-sync/orchestrator.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from "vitest"
 import { resolveScope } from "./orchestrator"
 
+const refreshAfterCoreSyncMock = vi.hoisted(() => vi.fn())
+
 vi.mock("./lock", () => ({
   acquireSyncLock: vi.fn(),
   refreshSyncLock: vi.fn(),
   releaseSyncLock: vi.fn(),
+}))
+
+vi.mock("../watch-route-manifest-refresh.service", () => ({
+  refreshWatchRouteManifestAfterCoreSync: refreshAfterCoreSyncMock,
 }))
 
 vi.mock("./watermark", () => ({
@@ -115,6 +121,7 @@ describe("resolveScope", () => {
 describe("runSync", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    refreshAfterCoreSyncMock.mockResolvedValue({ status: "skipped" })
   })
 
   it("returns skipped when lock is held", async () => {
@@ -159,6 +166,16 @@ describe("runSync", () => {
       mockPrisma,
       expect.stringMatching(/^sync-\d+$/),
     )
+    expect(refreshAfterCoreSyncMock).toHaveBeenCalledWith({
+      prisma: mockPrisma,
+      phases: [
+        expect.objectContaining({
+          phase: "languages",
+          created: 5,
+          errors: 0,
+        }),
+      ],
+    })
   })
 
   it("does NOT advance watermark when phase has errors", async () => {

--- a/apps/admin/src/services/core-sync/orchestrator.ts
+++ b/apps/admin/src/services/core-sync/orchestrator.ts
@@ -36,6 +36,7 @@ import { syncVideoSubtitles } from "./phases/sync-video-subtitles"
 import { syncDubs } from "./phases/sync-dubs"
 import { syncDubDownloads } from "./phases/sync-dub-downloads"
 import { runCoverageAudit, type CoverageAudit } from "./coverage-audit"
+import { refreshWatchRouteManifestAfterCoreSync } from "../watch-route-manifest-refresh.service"
 
 const PHASE_RUNNERS: Record<SyncPhase, PhaseRunner> = {
   languages: syncLanguages,
@@ -232,6 +233,7 @@ export async function finishSyncRun(
   await releaseSyncLock(prisma, run.runId).catch(() => {})
 
   const coverageAudit = await runCoverageAudit(prisma).catch(() => undefined)
+  await refreshWatchRouteManifestAfterCoreSync({ prisma, phases })
 
   return {
     incremental: run.incremental,

--- a/apps/admin/src/services/experience.service.test.ts
+++ b/apps/admin/src/services/experience.service.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest"
 import type { Principal } from "@/auth/principal"
 import { ExperienceService } from "./experience.service"
+import { refreshWatchRouteManifest } from "./watch-route-manifest-refresh.service"
+
+vi.mock("./watch-route-manifest-refresh.service", () => ({
+  refreshWatchRouteManifest: vi.fn().mockResolvedValue({ status: "refreshed" }),
+}))
 
 // Mock Prisma client with chained methods
 function mockPrisma() {
@@ -57,6 +62,7 @@ describe("ExperienceService", () => {
   beforeEach(() => {
     prisma = mockPrisma()
     service = new ExperienceService(prisma)
+    vi.mocked(refreshWatchRouteManifest).mockClear()
   })
 
   // ---------------------------------------------------------------------------
@@ -442,6 +448,39 @@ describe("ExperienceService", () => {
       expect(prisma.experience.update).not.toHaveBeenCalled()
     })
 
+    it("requests manifest refresh after updating a published locale", async () => {
+      const publishedLocale = { ...localeRow, status: "PUBLISHED" }
+      prisma.experienceLocale.findUniqueOrThrow.mockResolvedValueOnce(
+        publishedLocale,
+      )
+      prisma.experienceLocale.update.mockResolvedValueOnce({
+        ...publishedLocale,
+        title: "Published update",
+      })
+
+      await service.updateLocale({
+        input: { id: "loc-1", title: "Published update" },
+        user: EDITOR_ALICE,
+      })
+
+      expect(refreshWatchRouteManifest).toHaveBeenCalledWith({
+        prisma,
+        reason: "experience.update",
+      })
+    })
+
+    it("does not request manifest refresh for draft-only locale updates", async () => {
+      prisma.experienceLocale.findUniqueOrThrow.mockResolvedValueOnce(localeRow)
+      prisma.experienceLocale.update.mockResolvedValueOnce(localeRow)
+
+      await service.updateLocale({
+        input: { id: "loc-1", title: "Draft update" },
+        user: EDITOR_ALICE,
+      })
+
+      expect(refreshWatchRouteManifest).not.toHaveBeenCalled()
+    })
+
     it("SYSTEM cannot update locale (editorial isolation)", async () => {
       prisma.experienceLocale.findUniqueOrThrow.mockResolvedValueOnce(localeRow)
 
@@ -517,6 +556,10 @@ describe("ExperienceService", () => {
           }),
         }),
       )
+      expect(refreshWatchRouteManifest).toHaveBeenCalledWith({
+        prisma,
+        reason: "experience.publish",
+      })
     })
 
     it("VIEWER cannot publish", async () => {
@@ -698,6 +741,10 @@ describe("ExperienceService", () => {
       })
 
       expect(result.archivedAt).not.toBeNull()
+      expect(refreshWatchRouteManifest).toHaveBeenCalledWith({
+        prisma,
+        reason: "experience.archive",
+      })
     })
 
     it("EDITOR cannot archive another editor's experience", async () => {

--- a/apps/admin/src/services/experience.service.ts
+++ b/apps/admin/src/services/experience.service.ts
@@ -16,6 +16,7 @@ import { start } from "workflow/api"
 import { ForbiddenError, NotFoundError } from "./errors"
 import { runExperienceEmbedding } from "@/workflows/experienceEmbedding"
 import { emitRevalidateWebhook } from "./revalidate-webhook"
+import { refreshWatchRouteManifest } from "./watch-route-manifest-refresh.service"
 import {
   CreateExperienceInput,
   CreateExperienceLocaleInput,
@@ -313,6 +314,10 @@ export class ExperienceService {
           locale: updated.locale,
         })
       }
+      void refreshWatchRouteManifest({
+        prisma: this.prisma,
+        reason: "experience.update",
+      })
     }
     return updated
   }
@@ -390,6 +395,10 @@ export class ExperienceService {
         locale: published.locale,
       })
     }
+    void refreshWatchRouteManifest({
+      prisma: this.prisma,
+      reason: "experience.publish",
+    })
     return published
   }
 
@@ -543,6 +552,10 @@ export class ExperienceService {
       model: "watch-setting",
       slug: null,
       locale: null,
+    })
+    void refreshWatchRouteManifest({
+      prisma: this.prisma,
+      reason: "experience.archive",
     })
     return archived
   }

--- a/apps/admin/src/services/revalidate-webhook.test.ts
+++ b/apps/admin/src/services/revalidate-webhook.test.ts
@@ -59,9 +59,9 @@ describe("emitRevalidateWebhook", () => {
     fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }))
 
     await emitRevalidateWebhook({
-      model: "watch-setting",
+      model: "watch-route-manifest",
       slug: null,
-      locale: "en",
+      locale: null,
     })
 
     const [, init] = fetchSpy.mock.calls[0]
@@ -70,8 +70,8 @@ describe("emitRevalidateWebhook", () => {
       entry: Record<string, unknown>
     }
     expect(body).toEqual({
-      model: "watch-setting",
-      entry: { locale: "en" },
+      model: "watch-route-manifest",
+      entry: {},
     })
   })
 

--- a/apps/admin/src/services/revalidate-webhook.ts
+++ b/apps/admin/src/services/revalidate-webhook.ts
@@ -26,7 +26,11 @@ import { env } from "@/config/env"
 
 const WEB_REVALIDATE_TIMEOUT_MS = 5_000
 
-export type RevalidateModel = "experience" | "video" | "watch-setting"
+export type RevalidateModel =
+  | "experience"
+  | "video"
+  | "watch-route-manifest"
+  | "watch-setting"
 
 export type RevalidateWebhookInput = {
   model: RevalidateModel

--- a/apps/admin/src/services/watch-route-manifest-refresh.service.test.ts
+++ b/apps/admin/src/services/watch-route-manifest-refresh.service.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  refreshWatchRouteManifest,
+  refreshWatchRouteManifestAfterCoreSync,
+  shouldRefreshWatchRouteManifestAfterCoreSync,
+} from "./watch-route-manifest-refresh.service"
+
+const generateMock = vi.hoisted(() => vi.fn())
+const upsertLatestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("./watch-route-manifest.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("./watch-route-manifest.service")
+  >("./watch-route-manifest.service")
+  return {
+    ...actual,
+    WatchRouteManifestService: vi.fn(() => ({
+      generate: generateMock,
+    })),
+  }
+})
+
+vi.mock("./watch-route-manifest-store", () => ({
+  WatchRouteManifestStore: vi.fn(() => ({
+    upsertLatest: upsertLatestMock,
+  })),
+}))
+
+const manifest = {
+  version: "version-1",
+  generatedAt: "2026-05-29T12:00:00.000Z",
+  contentSlugs: ["jesus"],
+  oneSegmentSlugs: [],
+  episodePairsByParent: {},
+  audioLanguageSlugs: ["english"],
+}
+
+describe("watch route manifest refresh", () => {
+  beforeEach(() => {
+    generateMock.mockReset()
+    upsertLatestMock.mockReset()
+  })
+
+  it("refreshes the snapshot and emits a manifest webhook after persistence", async () => {
+    generateMock.mockResolvedValueOnce(manifest)
+    upsertLatestMock.mockResolvedValueOnce({
+      version: manifest.version,
+      payload: manifest,
+      payloadSizeBytes: 128,
+    })
+    const emitWebhook = vi
+      .fn()
+      .mockResolvedValue({ status: "sent", httpStatus: 200 })
+
+    const outcome = await refreshWatchRouteManifest({
+      prisma: {} as never,
+      reason: "experience.publish",
+      emitWebhook,
+    })
+
+    expect(outcome).toMatchObject({
+      status: "refreshed",
+      reason: "experience.publish",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 128,
+      counts: {
+        contentSlugs: 1,
+        audioLanguageSlugs: 1,
+      },
+    })
+    expect(emitWebhook).toHaveBeenCalledWith({
+      model: "watch-route-manifest",
+      slug: null,
+      locale: null,
+    })
+  })
+
+  it("swallows generation or persistence failures", async () => {
+    generateMock.mockRejectedValueOnce(new Error("db unavailable"))
+
+    const outcome = await refreshWatchRouteManifest({
+      prisma: {} as never,
+      reason: "experience.update",
+      emitWebhook: vi.fn(),
+    })
+
+    expect(outcome).toMatchObject({
+      status: "failed",
+      reason: "experience.update",
+      detail: "db unavailable",
+    })
+  })
+
+  it("detects route-relevant Core sync phases", () => {
+    expect(
+      shouldRefreshWatchRouteManifestAfterCoreSync([
+        { phase: "countries" },
+        { phase: "video-images" },
+      ]),
+    ).toBe(false)
+    expect(
+      shouldRefreshWatchRouteManifestAfterCoreSync([
+        { phase: "countries" },
+        { phase: "videos" },
+      ]),
+    ).toBe(true)
+    expect(
+      shouldRefreshWatchRouteManifestAfterCoreSync([{ phase: "video-dubs" }]),
+    ).toBe(true)
+  })
+
+  it("skips Core sync refresh when no route-relevant phases ran", async () => {
+    const outcome = await refreshWatchRouteManifestAfterCoreSync({
+      prisma: {} as never,
+      phases: [{ phase: "keywords" }],
+    })
+
+    expect(outcome).toEqual({
+      status: "skipped",
+      reason: "no-route-relevant-core-sync-phases",
+    })
+  })
+})

--- a/apps/admin/src/services/watch-route-manifest-refresh.service.ts
+++ b/apps/admin/src/services/watch-route-manifest-refresh.service.ts
@@ -1,0 +1,131 @@
+import type { PrismaClient } from "@prisma/client"
+import { emitRevalidateWebhook } from "./revalidate-webhook"
+import {
+  WatchRouteManifestService,
+  summarizeWatchRouteManifest,
+  type WatchRouteManifestCounts,
+} from "./watch-route-manifest.service"
+import { WatchRouteManifestStore } from "./watch-route-manifest-store"
+
+const ROUTE_RELEVANT_CORE_SYNC_PHASES = new Set([
+  "languages",
+  "videos",
+  "video-dubs",
+])
+
+export type WatchRouteManifestRefreshReason =
+  | "core-sync"
+  | "experience.archive"
+  | "experience.publish"
+  | "experience.update"
+  | "operator-script"
+
+export type WatchRouteManifestRefreshOutcome =
+  | {
+      status: "refreshed"
+      reason: WatchRouteManifestRefreshReason
+      version: string
+      generatedAt: string
+      payloadSizeBytes: number
+      counts: WatchRouteManifestCounts
+      durationMs: number
+    }
+  | {
+      status: "skipped"
+      reason: "no-route-relevant-core-sync-phases"
+    }
+  | {
+      status: "failed"
+      reason: WatchRouteManifestRefreshReason
+      detail: string
+      durationMs: number
+    }
+
+type CoreSyncPhaseSummary = {
+  phase: string
+}
+
+export function shouldRefreshWatchRouteManifestAfterCoreSync(
+  phases: readonly CoreSyncPhaseSummary[],
+): boolean {
+  return phases.some((phase) =>
+    ROUTE_RELEVANT_CORE_SYNC_PHASES.has(phase.phase),
+  )
+}
+
+export async function refreshWatchRouteManifest({
+  prisma,
+  reason,
+  emitWebhook = emitRevalidateWebhook,
+}: {
+  prisma: PrismaClient
+  reason: WatchRouteManifestRefreshReason
+  emitWebhook?: typeof emitRevalidateWebhook
+}): Promise<WatchRouteManifestRefreshOutcome> {
+  const startedAt = Date.now()
+  try {
+    const service = new WatchRouteManifestService(prisma)
+    const store = new WatchRouteManifestStore(prisma)
+    const manifest = await service.generate()
+    const snapshot = await store.upsertLatest(manifest)
+    const counts = summarizeWatchRouteManifest(snapshot.payload)
+
+    await emitWebhook({
+      model: "watch-route-manifest",
+      slug: null,
+      locale: null,
+    })
+
+    const outcome: WatchRouteManifestRefreshOutcome = {
+      status: "refreshed",
+      reason,
+      version: snapshot.version,
+      generatedAt: snapshot.payload.generatedAt,
+      payloadSizeBytes: snapshot.payloadSizeBytes,
+      counts,
+      durationMs: Date.now() - startedAt,
+    }
+    console.log(
+      JSON.stringify({
+        event: "watch_route_manifest.refresh.refreshed",
+        reason,
+        version: snapshot.version,
+        ...counts,
+        durationMs: outcome.durationMs,
+      }),
+    )
+    return outcome
+  } catch (error) {
+    const outcome: WatchRouteManifestRefreshOutcome = {
+      status: "failed",
+      reason,
+      detail: error instanceof Error ? error.message : String(error),
+      durationMs: Date.now() - startedAt,
+    }
+    console.warn(
+      JSON.stringify({
+        event: "watch_route_manifest.refresh.failed",
+        reason,
+        detail: outcome.detail.slice(0, 500),
+        durationMs: outcome.durationMs,
+      }),
+    )
+    return outcome
+  }
+}
+
+export async function refreshWatchRouteManifestAfterCoreSync({
+  prisma,
+  phases,
+}: {
+  prisma: PrismaClient
+  phases: readonly CoreSyncPhaseSummary[]
+}): Promise<WatchRouteManifestRefreshOutcome> {
+  if (!shouldRefreshWatchRouteManifestAfterCoreSync(phases)) {
+    return {
+      status: "skipped",
+      reason: "no-route-relevant-core-sync-phases",
+    }
+  }
+  return refreshWatchRouteManifest({ prisma, reason: "core-sync" })
+}

--- a/apps/admin/src/services/watch-route-manifest-store.test.ts
+++ b/apps/admin/src/services/watch-route-manifest-store.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  WATCH_ROUTE_MANIFEST_SNAPSHOT_KEY,
+  WatchRouteManifestStore,
+} from "./watch-route-manifest-store"
+import type { WatchRouteManifest } from "./watch-route-manifest.service"
+
+function mockPrisma() {
+  return {
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    $queryRaw: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+const manifest: WatchRouteManifest = {
+  version: "abc123",
+  generatedAt: "2026-05-29T12:00:00.000Z",
+  contentSlugs: ["easter", "jesus"],
+  oneSegmentSlugs: ["easter"],
+  episodePairsByParent: { series: ["episode-1"] },
+  audioLanguageSlugs: ["english"],
+}
+
+describe("WatchRouteManifestStore", () => {
+  it("returns null when no latest snapshot exists", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const store = new WatchRouteManifestStore(prisma)
+
+    await expect(store.getLatest()).resolves.toBeNull()
+  })
+
+  it("upserts the latest manifest and returns the stored snapshot", async () => {
+    const prisma = mockPrisma()
+    const payloadSizeBytes = Buffer.byteLength(JSON.stringify(manifest), "utf8")
+    const generatedAt = new Date(manifest.generatedAt)
+    const createdAt = new Date("2026-05-29T12:00:01.000Z")
+    const updatedAt = new Date("2026-05-29T12:00:02.000Z")
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        key: WATCH_ROUTE_MANIFEST_SNAPSHOT_KEY,
+        version: manifest.version,
+        generatedAt,
+        payload: manifest,
+        payloadSizeBytes,
+        createdAt,
+        updatedAt,
+      },
+    ])
+    const store = new WatchRouteManifestStore(prisma)
+
+    const snapshot = await store.upsertLatest(manifest)
+
+    expect(prisma.$executeRaw).toHaveBeenCalledOnce()
+    expect(snapshot).toEqual({
+      key: WATCH_ROUTE_MANIFEST_SNAPSHOT_KEY,
+      version: manifest.version,
+      generatedAt,
+      payload: manifest,
+      payloadSizeBytes,
+      createdAt,
+      updatedAt,
+    })
+  })
+
+  it("parses string JSON payloads from raw SQL reads", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        key: WATCH_ROUTE_MANIFEST_SNAPSHOT_KEY,
+        version: manifest.version,
+        generatedAt: new Date(manifest.generatedAt),
+        payload: JSON.stringify(manifest),
+        payloadSizeBytes: BigInt(Buffer.byteLength(JSON.stringify(manifest))),
+        createdAt: new Date("2026-05-29T12:00:01.000Z"),
+        updatedAt: new Date("2026-05-29T12:00:02.000Z"),
+      },
+    ])
+    const store = new WatchRouteManifestStore(prisma)
+
+    const snapshot = await store.getLatest()
+
+    expect(snapshot?.payload).toEqual(manifest)
+    expect(snapshot?.payloadSizeBytes).toBe(
+      Buffer.byteLength(JSON.stringify(manifest)),
+    )
+  })
+
+  it("fails if an upsert does not produce a readable latest snapshot", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const store = new WatchRouteManifestStore(prisma)
+
+    await expect(store.upsertLatest(manifest)).rejects.toThrow(
+      "watch route manifest snapshot missing after upsert",
+    )
+  })
+})

--- a/apps/admin/src/services/watch-route-manifest-store.ts
+++ b/apps/admin/src/services/watch-route-manifest-store.ts
@@ -1,0 +1,109 @@
+import type { PrismaClient } from "@prisma/client"
+import {
+  WatchRouteManifestSchema,
+  type WatchRouteManifest,
+} from "./watch-route-manifest.service"
+
+export const WATCH_ROUTE_MANIFEST_SNAPSHOT_KEY = "latest"
+
+export type WatchRouteManifestSnapshotRecord = {
+  key: string
+  version: string
+  generatedAt: Date
+  payload: WatchRouteManifest
+  payloadSizeBytes: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+type StorePrisma = Pick<PrismaClient, "$executeRaw" | "$queryRaw">
+
+type SnapshotRow = {
+  key: string
+  version: string
+  generatedAt: Date
+  payload: unknown
+  payloadSizeBytes: number | bigint
+  createdAt: Date
+  updatedAt: Date
+}
+
+export class WatchRouteManifestStore {
+  constructor(private readonly prisma: StorePrisma) {}
+
+  async getLatest(): Promise<WatchRouteManifestSnapshotRecord | null> {
+    const rows = await this.prisma.$queryRaw<SnapshotRow[]>`
+      SELECT
+        "key",
+        "version",
+        "generated_at" AS "generatedAt",
+        "payload",
+        "payload_size_bytes" AS "payloadSizeBytes",
+        "created_at" AS "createdAt",
+        "updated_at" AS "updatedAt"
+      FROM "watch_route_manifest_snapshot"
+      WHERE "key" = ${WATCH_ROUTE_MANIFEST_SNAPSHOT_KEY}
+      LIMIT 1
+    `
+    const row = rows[0]
+    return row ? normalizeSnapshotRow(row) : null
+  }
+
+  async upsertLatest(
+    manifest: WatchRouteManifest,
+  ): Promise<WatchRouteManifestSnapshotRecord> {
+    const payload = WatchRouteManifestSchema.parse(manifest)
+    const serializedPayload = JSON.stringify(payload)
+    const payloadSizeBytes = Buffer.byteLength(serializedPayload, "utf8")
+    const generatedAt = new Date(payload.generatedAt)
+
+    await this.prisma.$executeRaw`
+      INSERT INTO "watch_route_manifest_snapshot" (
+        "key",
+        "version",
+        "generated_at",
+        "payload",
+        "payload_size_bytes",
+        "created_at",
+        "updated_at"
+      )
+      VALUES (
+        ${WATCH_ROUTE_MANIFEST_SNAPSHOT_KEY},
+        ${payload.version},
+        ${generatedAt},
+        ${serializedPayload}::jsonb,
+        ${payloadSizeBytes},
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      )
+      ON CONFLICT ("key") DO UPDATE SET
+        "version" = EXCLUDED."version",
+        "generated_at" = EXCLUDED."generated_at",
+        "payload" = EXCLUDED."payload",
+        "payload_size_bytes" = EXCLUDED."payload_size_bytes",
+        "updated_at" = CURRENT_TIMESTAMP
+    `
+
+    const latest = await this.getLatest()
+    if (!latest) {
+      throw new Error("watch route manifest snapshot missing after upsert")
+    }
+    return latest
+  }
+}
+
+function normalizeSnapshotRow(
+  row: SnapshotRow,
+): WatchRouteManifestSnapshotRecord {
+  const rawPayload =
+    typeof row.payload === "string" ? JSON.parse(row.payload) : row.payload
+  return {
+    key: row.key,
+    version: row.version,
+    generatedAt: row.generatedAt,
+    payload: WatchRouteManifestSchema.parse(rawPayload),
+    payloadSizeBytes: Number(row.payloadSizeBytes),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}

--- a/apps/admin/src/services/watch-route-manifest.service.test.ts
+++ b/apps/admin/src/services/watch-route-manifest.service.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  WatchRouteManifestService,
+  summarizeWatchRouteManifest,
+} from "./watch-route-manifest.service"
+
+function mockPrisma() {
+  return {
+    $queryRaw: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+function sqlText(call: unknown[]): string {
+  const [strings] = call
+  return Array.isArray(strings) ? strings.join(" ") : String(strings)
+}
+
+describe("WatchRouteManifestService.generate", () => {
+  it("builds a deterministic manifest from compact slug sets", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw
+      .mockResolvedValueOnce([{ slug: "easter" }, { slug: "jesus" }])
+      .mockResolvedValueOnce([{ slug: "easter" }])
+      .mockResolvedValueOnce([
+        { parentSlug: "book-of-acts", childSlug: "pentecost" },
+        { parentSlug: "book-of-acts", childSlug: "saul" },
+      ])
+      .mockResolvedValueOnce([{ slug: "english" }, { slug: "spanish" }])
+
+    const service = new WatchRouteManifestService(prisma, {
+      now: () => new Date("2026-05-29T12:00:00.000Z"),
+    })
+
+    const first = await service.generate()
+
+    prisma.$queryRaw.mockClear()
+    prisma.$queryRaw
+      .mockResolvedValueOnce([{ slug: "easter" }, { slug: "jesus" }])
+      .mockResolvedValueOnce([{ slug: "easter" }])
+      .mockResolvedValueOnce([
+        { parentSlug: "book-of-acts", childSlug: "pentecost" },
+        { parentSlug: "book-of-acts", childSlug: "saul" },
+      ])
+      .mockResolvedValueOnce([{ slug: "english" }, { slug: "spanish" }])
+
+    const second = await service.generate()
+
+    expect(first).toEqual({
+      version: second.version,
+      generatedAt: "2026-05-29T12:00:00.000Z",
+      contentSlugs: ["easter", "jesus"],
+      oneSegmentSlugs: ["easter"],
+      episodePairsByParent: {
+        "book-of-acts": ["pentecost", "saul"],
+      },
+      audioLanguageSlugs: ["english", "spanish"],
+    })
+    expect(first.version).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it("keeps episode pair fanout separate from audio-language fanout", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw
+      .mockResolvedValueOnce([{ slug: "book-of-acts" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { parentSlug: "book-of-acts", childSlug: "episode-1" },
+        { parentSlug: "book-of-acts", childSlug: "episode-2" },
+      ])
+      .mockResolvedValueOnce([
+        { slug: "english" },
+        { slug: "spanish" },
+        { slug: "french" },
+      ])
+
+    const service = new WatchRouteManifestService(prisma)
+    const manifest = await service.generate()
+    const summary = summarizeWatchRouteManifest(manifest)
+
+    expect(summary).toMatchObject({
+      contentSlugs: 1,
+      parentSlugs: 1,
+      parentChildPairs: 2,
+      audioLanguageSlugs: 3,
+    })
+    expect(JSON.stringify(manifest)).not.toContain("episode-1/english")
+    expect(JSON.stringify(manifest)).not.toContain("episode-2/spanish")
+  })
+
+  it("encodes public-route visibility filters in the aggregate SQL", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+
+    const service = new WatchRouteManifestService(prisma)
+    await service.generate()
+
+    const allSql = prisma.$queryRaw.mock.calls.map(sqlText).join("\n")
+    expect(allSql).toContain("status = 'published'::\"LocaleStatus\"")
+    expect(allSql).toContain('"deleted_at" IS NULL')
+    expect(allSql).toContain("published = TRUE")
+    expect(allSql).toContain("hls IS NOT NULL")
+    expect(allSql).toContain('"is_template" = FALSE')
+    expect(allSql).toContain('"is_homepage" = FALSE')
+    expect(allSql).toContain('"path_segment" IS NULL')
+  })
+
+  it("rejects malformed query rows instead of emitting a partial manifest", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw
+      .mockResolvedValueOnce([{ slug: "" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+
+    const service = new WatchRouteManifestService(prisma)
+
+    await expect(service.generate()).rejects.toThrow()
+  })
+})

--- a/apps/admin/src/services/watch-route-manifest.service.ts
+++ b/apps/admin/src/services/watch-route-manifest.service.ts
@@ -1,0 +1,268 @@
+import { createHash } from "node:crypto"
+import type { PrismaClient } from "@prisma/client"
+import { z } from "zod"
+
+const SlugRowSchema = z.object({ slug: z.string().min(1) })
+const EpisodePairRowSchema = z.object({
+  parentSlug: z.string().min(1),
+  childSlug: z.string().min(1),
+})
+
+export const WatchRouteManifestSchema = z.object({
+  version: z.string().min(1),
+  generatedAt: z.string().datetime(),
+  contentSlugs: z.array(z.string().min(1)),
+  oneSegmentSlugs: z.array(z.string().min(1)),
+  episodePairsByParent: z.record(z.string().min(1), z.array(z.string().min(1))),
+  audioLanguageSlugs: z.array(z.string().min(1)),
+})
+
+export type WatchRouteManifest = z.infer<typeof WatchRouteManifestSchema>
+
+export type WatchRouteManifestCounts = {
+  contentSlugs: number
+  oneSegmentSlugs: number
+  parentSlugs: number
+  parentChildPairs: number
+  audioLanguageSlugs: number
+}
+
+type QueryablePrisma = Pick<PrismaClient, "$queryRaw">
+
+export class WatchRouteManifestService {
+  constructor(
+    private readonly prisma: QueryablePrisma,
+    private readonly options: { now?: () => Date } = {},
+  ) {}
+
+  async generate(): Promise<WatchRouteManifest> {
+    const startedAt = Date.now()
+    const [contentSlugs, oneSegmentSlugs, episodePairs, audioLanguageSlugs] =
+      await Promise.all([
+        this.loadContentSlugs(),
+        this.loadOneSegmentSlugs(),
+        this.loadEpisodePairsByParent(),
+        this.loadAudioLanguageSlugs(),
+      ])
+
+    const generatedAt = (this.options.now?.() ?? new Date()).toISOString()
+    const contentForVersion = {
+      audioLanguageSlugs,
+      contentSlugs,
+      episodePairsByParent: episodePairs,
+      oneSegmentSlugs,
+    }
+    const version = createHash("sha256")
+      .update(JSON.stringify(contentForVersion))
+      .digest("hex")
+
+    const manifest = WatchRouteManifestSchema.parse({
+      version,
+      generatedAt,
+      contentSlugs,
+      oneSegmentSlugs,
+      episodePairsByParent: episodePairs,
+      audioLanguageSlugs,
+    })
+
+    const counts = summarizeWatchRouteManifest(manifest)
+    console.log(
+      JSON.stringify({
+        event: "watch_route_manifest.generated",
+        ...counts,
+        durationMs: Date.now() - startedAt,
+      }),
+    )
+
+    return manifest
+  }
+
+  private async loadContentSlugs(): Promise<string[]> {
+    const rows = await this.prisma.$queryRaw<unknown[]>`
+      WITH playable_video_slugs AS (
+        SELECT DISTINCT v.slug
+        FROM "video" v
+        JOIN "video_locale" vl
+          ON vl."video_id" = v.id
+          AND vl.status = 'published'::"LocaleStatus"
+        JOIN "video_dub" dub
+          ON dub."video_id" = v.id
+          AND dub."deleted_at" IS NULL
+          AND dub.published = TRUE
+          AND dub.hls IS NOT NULL
+          AND dub.hls <> ''
+        JOIN "language" lang
+          ON lang.id = dub."language_id"
+          AND lang."deleted_at" IS NULL
+          AND lang.slug IS NOT NULL
+          AND lang.slug <> ''
+        WHERE v."deleted_at" IS NULL
+          AND v.slug <> ''
+      ),
+      parent_video_slugs AS (
+        SELECT DISTINCT parent.slug
+        FROM "video" parent
+        JOIN "video_locale" parent_locale
+          ON parent_locale."video_id" = parent.id
+          AND parent_locale.status = 'published'::"LocaleStatus"
+        JOIN "video_relation" relation
+          ON relation."parent_id" = parent.id
+        JOIN "video" child
+          ON child.id = relation."child_id"
+          AND child."deleted_at" IS NULL
+          AND child.slug <> ''
+        JOIN "video_locale" child_locale
+          ON child_locale."video_id" = child.id
+          AND child_locale.status = 'published'::"LocaleStatus"
+        JOIN "video_dub" child_dub
+          ON child_dub."video_id" = child.id
+          AND child_dub."deleted_at" IS NULL
+          AND child_dub.published = TRUE
+          AND child_dub.hls IS NOT NULL
+          AND child_dub.hls <> ''
+        JOIN "language" child_lang
+          ON child_lang.id = child_dub."language_id"
+          AND child_lang."deleted_at" IS NULL
+          AND child_lang.slug IS NOT NULL
+          AND child_lang.slug <> ''
+        WHERE parent."deleted_at" IS NULL
+          AND parent.slug <> ''
+      ),
+      experience_slugs AS (
+        SELECT DISTINCT locale.slug
+        FROM "experience_locale" locale
+        JOIN "experience" experience
+          ON experience.id = locale."experience_id"
+        WHERE experience."archived_at" IS NULL
+          AND experience."is_template" = FALSE
+          AND locale.status = 'published'::"LocaleStatus"
+          AND locale.slug <> ''
+          AND locale."is_homepage" = FALSE
+          AND (locale."path_segment" IS NULL OR locale."path_segment" = '')
+      )
+      SELECT slug FROM playable_video_slugs
+      UNION
+      SELECT slug FROM parent_video_slugs
+      UNION
+      SELECT slug FROM experience_slugs
+      ORDER BY slug ASC
+    `
+    return SlugRowSchema.array()
+      .parse(rows)
+      .map((row) => row.slug)
+  }
+
+  private async loadOneSegmentSlugs(): Promise<string[]> {
+    const rows = await this.prisma.$queryRaw<unknown[]>`
+      SELECT DISTINCT locale.slug
+      FROM "experience_locale" locale
+      JOIN "experience" experience
+        ON experience.id = locale."experience_id"
+      WHERE experience."archived_at" IS NULL
+        AND experience."is_template" = FALSE
+        AND locale.status = 'published'::"LocaleStatus"
+        AND locale.slug <> ''
+        AND locale."is_homepage" = FALSE
+        AND (locale."path_segment" IS NULL OR locale."path_segment" = '')
+      ORDER BY locale.slug ASC
+    `
+    return SlugRowSchema.array()
+      .parse(rows)
+      .map((row) => row.slug)
+  }
+
+  private async loadEpisodePairsByParent(): Promise<Record<string, string[]>> {
+    const rows = await this.prisma.$queryRaw<unknown[]>`
+      SELECT DISTINCT
+        parent.slug AS "parentSlug",
+        child.slug AS "childSlug"
+      FROM "video_relation" relation
+      JOIN "video" parent
+        ON parent.id = relation."parent_id"
+        AND parent."deleted_at" IS NULL
+        AND parent.slug <> ''
+      JOIN "video_locale" parent_locale
+        ON parent_locale."video_id" = parent.id
+        AND parent_locale.status = 'published'::"LocaleStatus"
+      JOIN "video" child
+        ON child.id = relation."child_id"
+        AND child."deleted_at" IS NULL
+        AND child.slug <> ''
+      JOIN "video_locale" child_locale
+        ON child_locale."video_id" = child.id
+        AND child_locale.status = 'published'::"LocaleStatus"
+      JOIN "video_dub" child_dub
+        ON child_dub."video_id" = child.id
+        AND child_dub."deleted_at" IS NULL
+        AND child_dub.published = TRUE
+        AND child_dub.hls IS NOT NULL
+        AND child_dub.hls <> ''
+      JOIN "language" child_lang
+        ON child_lang.id = child_dub."language_id"
+        AND child_lang."deleted_at" IS NULL
+        AND child_lang.slug IS NOT NULL
+        AND child_lang.slug <> ''
+      ORDER BY parent.slug ASC, child.slug ASC
+    `
+
+    const pairs = EpisodePairRowSchema.array().parse(rows)
+    const byParent = new Map<string, Set<string>>()
+    for (const pair of pairs) {
+      const children = byParent.get(pair.parentSlug) ?? new Set<string>()
+      children.add(pair.childSlug)
+      byParent.set(pair.parentSlug, children)
+    }
+
+    return Object.fromEntries(
+      [...byParent.entries()].map(([parentSlug, childSlugs]) => [
+        parentSlug,
+        [...childSlugs].sort(),
+      ]),
+    )
+  }
+
+  private async loadAudioLanguageSlugs(): Promise<string[]> {
+    const rows = await this.prisma.$queryRaw<unknown[]>`
+      SELECT DISTINCT lang.slug
+      FROM "language" lang
+      JOIN "video_dub" dub
+        ON dub."language_id" = lang.id
+        AND dub."deleted_at" IS NULL
+        AND dub.published = TRUE
+        AND dub.hls IS NOT NULL
+        AND dub.hls <> ''
+      JOIN "video" video
+        ON video.id = dub."video_id"
+        AND video."deleted_at" IS NULL
+      WHERE lang."deleted_at" IS NULL
+        AND lang.slug IS NOT NULL
+        AND lang.slug <> ''
+      ORDER BY lang.slug ASC
+    `
+    return SlugRowSchema.array()
+      .parse(rows)
+      .map((row) => row.slug)
+  }
+}
+
+export function summarizeWatchRouteManifest(
+  manifest: Pick<
+    WatchRouteManifest,
+    | "audioLanguageSlugs"
+    | "contentSlugs"
+    | "episodePairsByParent"
+    | "oneSegmentSlugs"
+  >,
+): WatchRouteManifestCounts {
+  const parentEntries = Object.entries(manifest.episodePairsByParent)
+  return {
+    contentSlugs: manifest.contentSlugs.length,
+    oneSegmentSlugs: manifest.oneSegmentSlugs.length,
+    parentSlugs: parentEntries.length,
+    parentChildPairs: parentEntries.reduce(
+      (sum, [, childSlugs]) => sum + childSlugs.length,
+      0,
+    ),
+    audioLanguageSlugs: manifest.audioLanguageSlugs.length,
+  }
+}

--- a/docs/plans/2026-05-29-002-feat-watch-route-manifest-admin-plan.md
+++ b/docs/plans/2026-05-29-002-feat-watch-route-manifest-admin-plan.md
@@ -1,463 +1,456 @@
 ---
-title: Admin-owned watch route manifest for bounded web route admission
+title: "feat: Add admin-owned watch route manifest"
 type: feat
-status: planned
+status: completed
 date: 2026-05-29
-origin:
-  - docs/plans/2026-05-29-001-perf-restore-watch-static-render-locale-rewrite-plan.md
+origin: docs/plans/2026-05-29-001-perf-restore-watch-static-render-locale-rewrite-plan.md
 ---
 
-# Admin-owned watch route manifest for bounded web route admission
-
-## Overview
-
-The static `/watch` route rewrite plan needs a route-admission source that can
-reject hostile-looking but invalid watch paths before App Router rendering,
-admin GraphQL resolution, or ISR cache entry creation. The data that decides
-whether a watch URL is valid lives in `apps/admin`: Core sync owns videos,
-video locales, video relations, languages, and dubs; admin editing owns
-Experience publish/update/archive state.
-
-This plan adds an admin-owned **watch route manifest**: a compact, generated
-contract that lists valid content slugs and parent/child route pairs without
-enumerating every language-specific public URL. `apps/web` can consume the
-manifest to answer "could this path ever be valid?" cheaply, while admin keeps
-the manifest current after import, sync, add, delete, publish, and archive
-flows.
-
-This branch is intentionally stacked on
-`perf/watch-static-locale-rewrite`. The web branch should consume the manifest
-after this contract lands, then merge the admin-manifest branch back.
-
-## Problem Statement
-
-The current web plan bounds the internal `[locale]` segment, but `params.rest`
-is still attacker-controlled. A random URL like
-`/watch/anything.html/english.html` can be syntactically safe, pass language
-validation, and reach the force-static catch-all. From there, the render path
-can issue admin lookups before returning a 404. With ISR enabled, repeated
-random paths can create compute work today and may create a storage-spray
-surface once the static route cache is active.
-
-The validity check cannot be based on hardcoded web route knowledge alone:
-
-- `Video`, `VideoLocale`, `VideoRelation`, `VideoDub`, and `Language` are
-  sourced through admin/Core sync.
-- `Experience` and `ExperienceLocale` can be published, updated, or archived
-  from admin.
-- Admin local/import/sync/delete flows can change the valid public watch
-  surface without a web code change.
-
-The manifest must scale with content growth. The local branch test snapshot has
-roughly 1k videos and more than 200k dubs, and admin already documents a single
-Jesus-film-style collection fanout of about 61 children x 2,200 dubs. A route
-manifest that enumerates `content x language` or `episode x language` will
-grow in the wrong dimension.
-
-## Goals
-
-- Give admin one service that computes the public watch route-admission
-  manifest from canonical admin data.
-- Keep manifest size proportional to slugs, episode relations, and language
-  slugs, not full public route permutations.
-- Refresh the manifest after Experience publish/update/archive and after Core
-  sync phases that can change route admission.
-- Expose a stable contract that `apps/web` can consume in proxy or pre-render
-  guards without querying admin per hostile request.
-- Include tests for deletes, soft deletes, draft/unpublished rows, playable dub
-  changes, and large fanout.
-
-## Non-goals
-
-- Do not implement the `apps/web` proxy consumer in this branch.
-- Do not change public `/watch` URL shape.
-- Do not enumerate every localized public route.
-- Do not move audio-language aliasing, UI-message locale resolution, or
-  `<html lang>` logic into admin.
-- Do not make admin publish UX depend on a synchronous web/cache refresh.
-
-## Existing Patterns
-
-- `apps/admin/prisma/schema.prisma` models the relevant data:
-  - `Language.slug`, `Language.bcp47`, and `Language.deletedAt`.
-  - `Video.slug`, `Video.deletedAt`, `Video.noIndex`, `Video.locales`,
-    `Video.dubs`, and `Video.children` / `Video.parents`.
-  - `VideoLocale.status` and `(videoId, locale)`.
-  - `VideoRelation.parentId` / `childId`.
-  - `VideoDub.published`, `VideoDub.hls`, `VideoDub.languageId`, and
-    `VideoDub.deletedAt`.
-  - `Experience.archivedAt` and `ExperienceLocale.status`, `slug`,
-    `isHomepage`, `pathSegment`.
-- `apps/admin/src/services/revalidate-webhook.ts` is the precedent for
-  best-effort web notification. It never blocks publish UX and silently no-ops
-  when env is absent.
-- `apps/admin/src/services/experience.service.ts` already calls
-  `emitRevalidateWebhook` after published Experience locale updates,
-  publishing, homepage changes, and archive.
-- `apps/admin/src/services/core-sync/orchestrator.ts` runs Core sync phases in
-  a known order and is the natural point to request a manifest refresh after
-  route-relevant phases complete.
-- `apps/admin/src/graphql/types/video.ts` exposes `childDubLanguages` as a
-  bounded distinct language set, explicitly avoiding the large
-  children-by-dubs fanout. The manifest should copy that scaling philosophy.
-- `apps/web/src/lib/content.ts` currently treats unknown watch video and
-  series misses as uncached success-path exceptions; this is correct for
-  freshness but expensive for random path spray unless the path is rejected
-  earlier.
-
-## Manifest Contract
-
-The admin service should produce a compact JSON shape:
-
-```ts
-type WatchRouteManifest = {
-  version: string
-  generatedAt: string
-  contentSlugs: string[]
-  oneSegmentSlugs: string[]
-  episodePairsByParent: Record<string, string[]>
-  audioLanguageSlugs: string[]
-}
-```
+# feat: Add admin-owned watch route manifest
 
-Field semantics:
+## Summary
 
-- `version`: stable hash of the manifest content or a monotonically changing
-  version token. Web uses it for cache replacement and logging.
-- `generatedAt`: ISO timestamp for observability.
-- `contentSlugs`: valid first-segment `.html` slugs for two-segment watch
-  paths. Include public videos/series/collections and published Experience
-  slugs that can be addressed by `/watch/{slug}.html/{audio}.html`.
-- `oneSegmentSlugs`: valid one-segment collection/experience slugs such as
-  `/watch/easter.html`. This must preserve the current web disambiguation:
-  one-segment language slugs are localized-home, non-language slugs are
-  collection/experience candidates.
-- `episodePairsByParent`: parent slug to child slug list for three-segment
-  routes such as
-  `/watch/book-of-acts.html/the-holy-spirit-comes-at-pentecost/english.html`.
-  This is the only parent/child relation the web proxy needs to admit episode
-  shapes.
-- `audioLanguageSlugs`: public audio-language slugs with at least one playable
-  dub somewhere. Web may already have language metadata; include this only if
-  it avoids a second source for "is this audio slug public and playable?"
-
-The manifest deliberately does **not** include:
+Add an admin-generated watch route-admission manifest that lets `apps/web` reject impossible public `/watch` paths before App Router rendering, admin GraphQL resolution, or ISR cache entry creation. The admin slice computes, persists, refreshes, and serves compact slug/language sets from canonical admin data while leaving the web consumer for the stacked web branch.
 
-- `{contentSlug, audioLanguageSlug}` pairs.
-- `{parentSlug, childSlug, audioLanguageSlug}` triples.
-- localized titles, block content, images, HLS URLs, subtitles, or search data.
-- admin IDs unless needed for debugging in a separate internal-only endpoint.
+---
 
-## Data Rules
-
-### Videos
+## Problem Frame
 
-Include a video slug in `contentSlugs` when:
+The static watch-route rewrite plan bounds internal locale params, but `params.rest` remains attacker-controlled. Random-looking paths such as `/watch/anything.html/english.html` can still reach the cacheable watch renderer and issue admin lookups before returning 404, creating avoidable render/GraphQL work today and a possible ISR storage-spray surface once static route caching is active.
 
-- `video.deletedAt IS NULL`.
-- `video.slug` is non-empty.
-- It has at least one `VideoLocale.status = PUBLISHED`.
-- It is either directly playable or is a collection/series that web can render
-  through its current series/collection paths.
+The data needed to decide whether a watch path could ever be valid belongs to `apps/admin`: Core sync owns videos, video locales, parent/child relations, languages, and dubs, while admin editing owns Experience publish/update/archive state. Hardcoding route admission in `apps/web` would drift from the content source of truth.
 
-For directly playable video admission, require at least one dub where:
+---
 
-- `video_dub.deletedAt IS NULL`.
-- `video_dub.published = true`.
-- `video_dub.hls IS NOT NULL`.
-- `video_dub.languageId` points at a non-deleted `Language`.
-- `language.slug IS NOT NULL`.
+## Requirements
 
-For series/collection admission, preserve existing web behavior: a parent can
-be routable even when playback lives on its children rather than on the parent
-itself. The implementation should document whether a parent needs a playable
-trailer, at least one routable child, or either. Prefer matching current web
-render semantics over inventing a stricter SEO rule.
+- R1. Admin computes the public watch route-admission manifest from canonical admin data: `Language`, `Video`, `VideoLocale`, `VideoRelation`, `VideoDub`, `Experience`, and `ExperienceLocale`.
+- R2. The manifest stays compact: payload growth is proportional to content slugs, one-segment slugs, parent/child pairs, and audio language slugs, not content-by-language route permutations.
+- R3. Manifest output is deterministic, versioned, timestamped, observable, and persisted so request-time reads do not recompute large aggregate queries.
+- R4. Route-relevant Experience publish/update/archive flows and Core sync phases refresh the manifest without blocking admin publish or sync UX.
+- R5. `apps/web` can fetch the latest manifest through an authenticated, documented service contract with explicit cache validators and missing-snapshot behavior.
+- R6. Admin emits a best-effort web revalidation/refresh hint after a successful manifest refresh using the existing admin-to-web notification pattern unless implementation discovers a hard consumer mismatch.
+- R7. Operators can refresh and inspect manifest counts locally without dumping the full payload by default or accidentally running against production.
+- R8. Tests cover draft/unpublished state, deletes and soft deletes, playable-dub gating, relation visibility, Experience route semantics, large fanout, auth, refresh hooks, and deterministic output.
 
-### Episode pairs
+---
 
-Include `parentSlug -> childSlug` when:
+## Scope Boundaries
 
-- Parent and child videos are not soft-deleted.
-- Both have non-empty slugs.
-- Public users can see the child relation under existing GraphQL visibility
-  rules.
-- The child has at least one playable dub.
-- The parent has enough public state to render a series/collection page.
+- Do not implement the `apps/web` proxy or pre-render manifest consumer in this branch.
+- Do not change the public `/watch` URL shape.
+- Do not enumerate every localized public route, `{contentSlug, audioLanguageSlug}` pair, or `{parentSlug, childSlug, audioLanguageSlug}` triple.
+- Do not move audio-language aliasing, UI message-locale resolution, or `<html lang>` logic into admin.
+- Do not make admin publish/update/archive UX depend on a synchronous web/cache refresh.
+- Do not expose draft, archived, unpublished, internal IDs, localized titles, block content, media URLs, subtitles, search data, or other rendering payloads through the manifest.
 
-Do not multiply pairs by audio language. The language slug is validated
-separately.
+### Deferred to Follow-Up Work
 
-### Experiences
+- `apps/web` route-admission consumer: implement in the stacked web branch after this admin contract lands.
+- Edge-readable storage: keep Postgres as the first persisted store; push-to-edge or cache-distribution work belongs in a later slice if web needs it.
+- Route-manifest LaunchDarkly or rollout wiring: add only when the web consumer requires runtime rollout control.
+- Dedicated manifest revalidation endpoint on web: keep the existing `/api/revalidate` extension first unless the consumer branch proves it needs a separate endpoint.
 
-Include Experience slugs when:
+---
 
-- `experience.archivedAt IS NULL`.
-- `experience_locale.status = PUBLISHED`.
-- `experience_locale.slug` is non-empty.
-- The slug/path shape maps to a public watch route in current web semantics.
+## Context & Research
 
-Homepage rows (`isHomepage = true`) should not create a content slug unless
-their slug is independently routable today. `pathSegment` must be handled
-deliberately: if watch currently ignores multi-segment Experience path segments,
-the manifest should not introduce them.
+### Relevant Code and Patterns
 
-### Languages
+- `apps/admin/prisma/schema.prisma` defines the route-relevant source tables and fields: language slugs/deletion, video slugs/deletion/locales/relations/dubs, Experience archive state, and Experience locale status/slug/path metadata.
+- `apps/admin/src/services/revalidate-webhook.ts` is the existing best-effort admin-to-web notification pattern. It is bearer-authenticated, silently no-ops when config is absent, catches network and non-2xx failures, and does not block editorial flows.
+- `apps/admin/src/services/experience.service.ts` already calls `emitRevalidateWebhook` after published Experience locale updates, publish, homepage/default template changes, and archive.
+- `apps/admin/src/services/core-sync/orchestrator.ts`, `apps/admin/src/services/core-sync/job.ts`, and `apps/admin/src/workflows/coreSync.ts` run Core sync phases in a known order. Route-relevant phases are `languages`, `videos`, and `video-dubs`; relation-bearing video sync should be treated as route-relevant.
+- `apps/admin/src/graphql/types/video.ts` exposes `childDubLanguages` as a distinct playable language set across children, explicitly avoiding the large children-by-dubs fanout. The manifest should follow that scaling philosophy.
+- `apps/admin/src/auth/consumer-bearer.ts` and `docs/solutions/architecture-patterns/consumer-bearer-rate-limit-identity-pattern-20260513.md` provide the existing service-to-service bearer identity used by `apps/web` SSR without granting editorial permissions.
+- `apps/web/src/proxy.ts` and `docs/plans/2026-05-29-001-perf-restore-watch-static-render-locale-rewrite-plan.md` define the web-side route shapes this manifest will admit before final rendering.
 
-Include an audio language slug when:
+### Institutional Learnings
 
-- `language.deletedAt IS NULL`.
-- `language.slug IS NOT NULL`.
-- At least one playable dub uses that language.
+- The existing consumer-bearer pattern gives web a stable service identity for admin reads without widening editorial permissions; new service endpoints should reuse that style when the caller is `apps/web`.
+- The web revalidation webhook is intentionally receiver-first and best-effort. Manifest refresh notifications should preserve that failure model so admin remains usable when web is unavailable.
+- Prior watch-route performance work found the expensive fanout is children-by-dubs. Any route-admission contract that multiplies parents/children by languages would reintroduce the same scaling problem in a new place.
 
-This is a public audio slug set, not a UI message-catalog locale set. It must
-not collapse `spanish-latin-american` into `es`.
+### External References
 
-## Implementation Units
+- None. Local repo contracts and existing admin/web integration patterns are sufficient for this plan.
 
-### Unit 1 - Manifest service and SQL
+---
 
-Create `apps/admin/src/services/watch-route-manifest.service.ts`.
+## Key Technical Decisions
 
-Responsibilities:
+- Persist the latest manifest in admin Postgres first: A singleton JSONB snapshot keeps request-time reads cheap without adding a second storage system to this slice. Edge storage remains deferred until the web consumer proves it needs it.
+- Shape the manifest as admission sets, not route records: Include `contentSlugs`, `oneSegmentSlugs`, `episodePairsByParent`, and `audioLanguageSlugs`, plus `version` and `generatedAt`. Do not include localized route permutations or rendering payloads.
+- Use deterministic ordering and content-derived versioning: Sorted arrays make snapshots stable, simplify tests, and let web compare versions or ETags safely.
+- Prefer raw SQL for aggregate generation when Prisma would over-fetch relation trees: The service boundary can still return typed domain data while avoiding large in-memory relation graphs.
+- Gate `audioLanguageSlugs` to languages with at least one playable dub: This gives the web prefilter a public playable-audio set rather than a UI-message locale set or every known Core language.
+- Treat the manifest as a conservative prefilter: The real web resolver still decides final rendering. False negatives are worse than false positives because they 404 valid public URLs; implementation should prefer including a candidate when current web semantics are ambiguous.
+- Reuse `WEB_ADMIN_API_KEYS` / consumer-bearer auth for the read endpoint unless implementation discovers a stronger existing route-handler helper: The endpoint serves public-admission metadata to `apps/web`, so a permissionless service identity matches the existing admin GraphQL caller contract.
+- Extend the existing revalidation webhook first: Add a manifest model to the established admin-to-web notification union before introducing a second web callback URL.
 
-- Compute the manifest from Prisma/Postgres.
-- Keep the query shape bounded and observable.
-- Prefer raw SQL for the aggregate sets if Prisma would over-fetch relation
-  trees.
-- Return sorted arrays for deterministic hashes and snapshots.
-- Log row counts and generation duration without logging full payloads.
-
-Tests:
-
-- `apps/admin/src/services/watch-route-manifest.service.test.ts`
-- Covers playable video inclusion/exclusion, draft locales, soft-deleted
-  videos/languages/dubs, parent/child pairs, one-segment Experience slugs, and
-  deterministic ordering.
-- Includes a fanout fixture with many dubs across multiple children and asserts
-  output size grows by language set plus episode pairs, not route permutations.
-
-### Unit 2 - Manifest persistence and versioning
-
-Add a small persisted store for the latest manifest.
-
-Preferred implementation:
-
-- Add a Prisma model such as `WatchRouteManifestSnapshot` with a singleton key,
-  `version`, `generatedAt`, `payload`, `payloadSizeBytes`, and `createdAt` /
-  `updatedAt`.
-- Add the corresponding migration under `apps/admin/prisma/migrations/`.
-- Store JSONB so admin can serve the current manifest without recomputing on
-  every request.
-
-Alternative if avoiding a migration in this slice:
-
-- Generate on demand behind a cached service boundary, then add persistence in
-  a follow-up before production traffic uses it. This is weaker and should only
-  be chosen if the migration risk is unacceptable for the stacked PR.
-
-Tests:
-
-- `apps/admin/src/services/watch-route-manifest-store.test.ts`
-- Verifies upsert, version replacement, stale-read behavior, and payload size
-  logging.
-
-### Unit 3 - Admin refresh hooks
-
-Wire manifest refresh requests from route-relevant admin lifecycle events.
-
-Files:
-
-- `apps/admin/src/services/experience.service.ts`
-- `apps/admin/src/services/core-sync/orchestrator.ts`
-- `apps/admin/src/services/core-sync/job.ts`
-- `apps/admin/src/workflows/coreSync.ts`
-
-Behavior:
-
-- After Experience publish/update/archive events that already emit web
-  revalidation, enqueue or fire-and-forget a manifest refresh.
-- After Core sync completes phases that can change the manifest
-  (`languages`, `videos`, `video-dubs`, and possibly relation-bearing video
-  sync), refresh once per sync run, not once per row.
-- If only unrelated phases run, skip the refresh.
-- If refresh fails, log structured failure and do not fail the admin publish or
-  sync job.
-
-Tests:
-
-- Extend `apps/admin/src/services/experience.service.test.ts` if present, or
-  add focused tests around the service method that emits refresh.
-- Extend `apps/admin/src/services/core-sync/orchestrator.test.ts` or
-  `apps/admin/src/services/core-sync/job.test.ts` to assert one refresh after
-  route-relevant phases and none after unrelated phases.
-
-### Unit 4 - Manifest read endpoint
-
-Expose the latest manifest to web.
-
-Preferred endpoint:
-
-- `apps/admin/src/app/api/watch-route-manifest/route.ts`
-
-Contract:
-
-- `GET` returns the latest manifest JSON plus `ETag` and
-  `Cache-Control: private, max-age=0, must-revalidate` or another explicitly
-  chosen service-to-service cache policy.
-- Auth uses an existing service-token/bearer pattern. Do not expose the
-  manifest anonymously unless the security review explicitly accepts it.
-- If no manifest exists, generate once or return a clear 503 with instructions
-  to run the refresh job. Prefer generation in controlled admin environments
-  and 503 in production if on-demand generation would be too expensive.
-
-Tests:
-
-- `apps/admin/src/app/api/watch-route-manifest/route.test.ts`
-- Covers auth, ETag/304 behavior if implemented, missing snapshot, and payload
-  shape.
-
-### Unit 5 - Web revalidation payload extension
-
-Extend the existing admin-to-web notification contract so web knows when the
-manifest changed.
-
-Files:
-
-- `apps/admin/src/services/revalidate-webhook.ts`
-- `apps/admin/src/services/revalidate-webhook.test.ts`
-
-Options:
-
-1. Add `model: "watch-route-manifest"` to the existing webhook union and send
-   it after a successful manifest refresh.
-2. Add a dedicated `WEB_ROUTE_MANIFEST_REFRESH_URL` if the consumer must be a
-   different endpoint than `/api/revalidate`.
-
-Prefer option 1 for the first slice: it reuses the existing bearer contract and
-lets the web branch decide how to clear or refetch its manifest cache.
-
-Tests:
-
-- Existing webhook tests should cover the new model, missing config, non-2xx,
-  and no-throw behavior.
-
-### Unit 6 - Scripts and operator workflow
-
-Add a way to generate or inspect the manifest locally.
-
-Files:
-
-- `apps/admin/package.json`
-- `apps/admin/src/scripts/generate-watch-route-manifest.ts`
-
-Behavior:
-
-- `pnpm --filter @forge/admin watch-route-manifest:generate` refreshes the
-  snapshot and prints counts, version, generatedAt, and payload size.
-- The script must refuse production URLs unless an existing safe script pattern
-  permits production operations explicitly.
-- Add an optional `--print` mode for local debugging that writes payload to
-  stdout; default should avoid dumping large JSON into logs.
-
-Tests:
-
-- If script tests are practical, add
-  `apps/admin/src/scripts/generate-watch-route-manifest.test.ts`.
-- Otherwise keep service tests as the correctness source and document the
-  command in `apps/admin/CLAUDE.md`.
-
-## Consumer Contract for the Web Branch
-
-This branch should not implement the web consumer, but it must leave enough
-contract for the current web PR to proceed:
-
-- Web can reject a two-segment route when `contentSlug` is absent or
-  `audioLanguageSlug` is absent.
-- Web can reject a three-segment route when the parent is absent, the child is
-  not listed under that parent, or the audio language slug is absent.
-- Web can preserve one-segment localized-home behavior by checking language
-  slugs first and `oneSegmentSlugs` second.
-- Web should still call the real resolver after manifest admission. The
-  manifest is an admission prefilter, not the final content renderer.
-- A manifest false negative is worse than a false positive because it 404s
-  valid public URLs. Keep data rules conservative and consumer behavior
-  observable.
-
-## Scaling Rules
-
-- Manifest generation may scan large tables, but request-time web validation
-  must be set membership only.
-- Payload growth target is:
-  - `O(contentSlugs)`.
-  - `O(oneSegmentSlugs)`.
-  - `O(parentChildPairs)`.
-  - `O(audioLanguageSlugs)`.
-- Payload must never be:
-  - `O(contentSlugs x audioLanguageSlugs)`.
-  - `O(parentChildPairs x audioLanguageSlugs)`.
-  - dependent on full `VideoDub` row projection.
-- Add size logging and tests that fail if the fanout fixture starts emitting
-  per-language route permutations.
-- If `episodePairsByParent` becomes too large for edge/proxy memory, switch the
-  wire shape to sorted arrays or a compact prefix structure before adding
-  language multiplication. Do not solve size by dropping correctness silently.
-
-## Verification
-
-Admin branch validation:
-
-- `pnpm --filter @forge/admin test -- watch-route-manifest`
-- `pnpm --filter @forge/admin typecheck`
-- `pnpm --filter @forge/admin lint`
-- `pnpm --filter @forge/admin schema:print` when GraphQL or Prisma schema
-  changes require it.
-- If a Prisma model/migration is added, run the admin migration validation path
-  used by this repo and verify a fresh local DB can migrate.
-- Run the local generate script against a restored admin snapshot and record:
-  `contentSlugs`, `oneSegmentSlugs`, `parentChildPairs`,
-  `audioLanguageSlugs`, `payloadSizeBytes`, and generation duration.
-
-Web integration validation after merge back:
-
-- Hostile two-segment paths such as `/watch/anything.html/english.html` reject
-  before admin GraphQL resolution.
-- Hostile three-segment paths such as
-  `/watch/jesus.html/anything/english.html` reject before admin GraphQL
-  resolution.
-- Known valid research-doc paths still render.
-- `/watch/easter.html` preserves one-segment collection behavior.
-- Public language slugs such as `english.html` are admitted; message keys such
-  as `en.html` remain invalid public audio segments.
-
-## Acceptance Criteria
-
-- Admin computes and stores a compact manifest with deterministic ordering and
-  versioning.
-- Manifest refresh is triggered by Experience changes and route-relevant Core
-  sync/import flows without blocking those flows.
-- Web can fetch the latest manifest through an authenticated, documented
-  contract.
-- Manifest payload does not enumerate full language-specific route
-  permutations.
-- Tests cover draft, delete, soft delete, playable dub, relation, Experience,
-  and large-fanout cases.
-- Operator docs explain how to refresh and inspect manifest counts locally.
+---
 
 ## Open Questions
 
-1. Should the latest manifest be stored only in Postgres first, or should admin
-   also push it to the eventual edge-readable store in this slice?
-2. Should `audioLanguageSlugs` include every non-deleted language slug, or only
-   languages with at least one playable dub? The stricter playable-dub set is
-   safer for admission, but may reject newly synced language routes before dub
-   sync completes in partial sync windows.
-3. Should `contentSlugs` include published Experiences independently of video
-   playability? Current web resolution tries Experience after video/series
-   misses in some shapes; the implementation must match exact current route
-   dispatch.
-4. Is `pathSegment` in `ExperienceLocale` currently part of public `/watch`
-   routing? If not, keep it out of the manifest until web supports it.
-5. Which endpoint will the web branch use to invalidate or refetch the manifest:
-   existing `/api/revalidate`, a new route, or an edge-store update outside
-   Next?
+### Resolved During Planning
+
+- Should the first persisted store be Postgres or an edge-readable store? Use Postgres singleton JSONB in this slice; defer edge distribution.
+- Should `audioLanguageSlugs` include every language or only playable languages? Use only non-deleted language slugs that have at least one published, HLS-backed, non-deleted dub.
+- Should manifest refresh block publish or sync? No. It must log failures and preserve the existing best-effort admin UX model.
+- Should the web refresh hint use the existing revalidation contract or a dedicated endpoint? Extend the existing revalidation contract first.
+- Should admin include `pathSegment` Experience routes automatically? No. Include only shapes that match current public watch dispatch; unsupported multi-segment Experience paths stay out until web supports them.
+
+### Deferred to Implementation
+
+- Exact parent routability rule: Confirm against current web `resolveWatchPage` / series rendering semantics whether a parent needs a playable trailer, at least one routable child, or either. Preserve current behavior rather than inventing a stricter SEO rule.
+- Missing snapshot behavior by environment: Decide in implementation whether local/dev can generate on demand while production returns a clear 503. The plan requires the behavior to be explicit and tested.
+- Final aggregate query shape: Choose the exact SQL/Prisma mix after inspecting performance and explainability while keeping the bounded-output invariant.
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+flowchart LR
+  core["Core sync phases"] --> refresh["Manifest refresh service"]
+  exp["Experience publish/update/archive"] --> refresh
+  refresh --> compute["Aggregate route-admission sets"]
+  compute --> snapshot["WatchRouteManifestSnapshot"]
+  snapshot --> endpoint["Authenticated admin API route"]
+  snapshot --> webhook["Best-effort web refresh hint"]
+  endpoint --> web["apps/web manifest cache"]
+  webhook --> web
+  web --> guard["Proxy/pre-render admission guard"]
+  guard --> resolver["Existing watch resolver remains final authority"]
+```
+
+Manifest field semantics:
+
+- `version`: deterministic content hash or equivalent monotonically changing token for cache replacement and logging.
+- `generatedAt`: ISO timestamp for observability.
+- `contentSlugs`: valid first-segment `.html` slugs for two-segment watch paths, including public videos/series/collections and published Experience slugs currently addressable by watch routes.
+- `oneSegmentSlugs`: valid one-segment collection/experience slugs such as `/watch/easter.html`; language slugs remain checked separately by web so localized-home behavior is preserved.
+- `episodePairsByParent`: parent slug to child slug list for three-segment episode routes.
+- `audioLanguageSlugs`: public audio-language slugs backed by at least one playable dub somewhere.
+
+---
+
+## Implementation Units
+
+### U1. Manifest Service and Bounded Data Rules
+
+**Goal:** Add the service that computes the route-admission manifest from admin data with deterministic output and bounded scaling.
+
+**Requirements:** R1, R2, R3, R8
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `apps/admin/src/services/watch-route-manifest.service.ts`
+- Test: `apps/admin/src/services/watch-route-manifest.service.test.ts`
+
+**Approach:**
+
+- Compute the four manifest sets from `Language`, `Video`, `VideoLocale`, `VideoRelation`, `VideoDub`, `Experience`, and `ExperienceLocale`.
+- Include video slugs only when the video is not soft-deleted, has a non-empty slug, and has enough public state to match current web watch rendering semantics.
+- For directly playable video admission, require at least one non-deleted, published dub with HLS and a non-deleted language slug.
+- Include parent/child pairs only when both sides are public candidates, the child has a playable dub, and the relation is visible under the same public/consumer-bearer rules as GraphQL children.
+- Include Experience slugs only when the parent is not archived, the locale is published, the slug is non-empty, and the path shape is currently routable by watch.
+- Sort arrays and child lists before versioning.
+- Log counts, payload size, and generation duration without logging the full payload.
+
+**Execution note:** Implement the service test-first around data-rule fixtures before optimizing query shape.
+
+**Patterns to follow:**
+
+- `apps/admin/src/graphql/types/video.ts` for `childDubLanguages` fanout avoidance.
+- `apps/admin/prisma/schema.prisma` for source-of-truth visibility fields.
+- Existing service tests under `apps/admin/src/services/*.test.ts`.
+
+**Test scenarios:**
+
+- Happy path: a published video locale with a published HLS dub and non-deleted language slug appears in `contentSlugs` and its language appears in `audioLanguageSlugs`.
+- Happy path: a public parent/child relation with a playable child appears once under `episodePairsByParent[parentSlug]`.
+- Happy path: a published, non-archived Experience locale with a watch-routable slug appears in the relevant slug set.
+- Edge case: output ordering is stable when fixture rows are inserted in different orders.
+- Edge case: a large fanout fixture with many child dubs emits one child pair per relation plus one language slug per distinct playable language, not route permutations.
+- Error path: draft video locales, archived Experiences, soft-deleted videos, soft-deleted dubs, soft-deleted languages, empty slugs, unpublished dubs, and dubs without HLS are excluded.
+- Integration: relation visibility uses the same public assumptions as `Video.children` / `Video.parents` rather than exposing editor-only relation state.
+
+**Verification:**
+
+- Service-level tests prove the manifest contains only public candidates, remains deterministic, and preserves the compact scaling invariant.
+- Logs expose generation counts and duration without payload leakage.
+
+### U2. Snapshot Persistence and Versioning
+
+**Goal:** Persist the latest manifest snapshot so API reads and web refresh flows do not recompute aggregate queries on every request.
+
+**Requirements:** R3, R8
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/prisma/schema.prisma`
+- Create: `apps/admin/prisma/migrations/<timestamp>_watch_route_manifest_snapshot/migration.sql`
+- Create: `apps/admin/src/services/watch-route-manifest-store.ts`
+- Test: `apps/admin/src/services/watch-route-manifest-store.test.ts`
+
+**Approach:**
+
+- Add a singleton-style Prisma model such as `WatchRouteManifestSnapshot` with a stable key, `version`, `generatedAt`, `payload`, `payloadSizeBytes`, `createdAt`, and `updatedAt`.
+- Store the manifest payload as JSONB.
+- Upsert the singleton inside a narrow transaction after generation succeeds.
+- Derive `payloadSizeBytes` from the serialized payload for monitoring and tests.
+- Keep historical snapshots out of this first slice unless implementation discovers an existing retention pattern that is nearly free.
+
+**Execution note:** Start with persistence tests around upsert and stale-read behavior before wiring lifecycle hooks.
+
+**Patterns to follow:**
+
+- Existing Prisma model naming and migration conventions in `apps/admin/prisma/schema.prisma`.
+- Service-owned persistence boundaries in `apps/admin/src/services/`.
+
+**Test scenarios:**
+
+- Happy path: the first refresh creates the singleton snapshot with version, timestamp, payload, and byte size.
+- Happy path: a later refresh replaces the singleton payload and version without creating multiple current snapshots.
+- Edge case: stale-read helper returns `null` or a typed missing result when no snapshot exists.
+- Edge case: generated timestamps and payload bytes remain consistent with the stored payload.
+- Error path: malformed persistence input fails before storing a partial snapshot.
+
+**Verification:**
+
+- The admin Prisma schema and migration introduce the snapshot table without touching generated Prisma client artifacts manually.
+- Store tests prove latest-manifest reads are cheap and deterministic.
+
+### U3. Refresh Hooks for Admin Lifecycles
+
+**Goal:** Refresh the manifest after route-relevant admin lifecycle changes while preserving non-blocking publish and sync behavior.
+
+**Requirements:** R4, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Create: `apps/admin/src/services/watch-route-manifest-refresh.service.ts`
+- Test: `apps/admin/src/services/watch-route-manifest-refresh.service.test.ts`
+- Modify: `apps/admin/src/services/experience.service.ts`
+- Modify: `apps/admin/src/services/experience.service.test.ts`
+- Modify: `apps/admin/src/services/core-sync/orchestrator.ts`
+- Modify: `apps/admin/src/services/core-sync/orchestrator.test.ts`
+- Modify: `apps/admin/src/services/core-sync/job.ts`
+- Modify: `apps/admin/src/services/core-sync/job.test.ts`
+- Modify: `apps/admin/src/workflows/coreSync.ts`
+
+**Approach:**
+
+- Add a small refresh coordinator that calls the U1/U2 generation-and-store path and logs structured success/failure.
+- Trigger refresh after route-relevant Experience publish/update/archive events that already emit web revalidation.
+- Refresh once per Core sync run when route-relevant phases ran successfully enough to affect admission: `languages`, `videos`, `video-dubs`, and relation-bearing video sync.
+- Skip refresh when only unrelated Core sync phases ran.
+- Preserve the existing failure model: refresh failure logs but does not fail publish, archive, or sync jobs.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/revalidate-webhook.ts` no-throw contract.
+- Existing Core sync phase scope and result handling in `apps/admin/src/services/core-sync/orchestrator.ts`.
+- useworkflow job entry points in `apps/admin/src/workflows/coreSync.ts`.
+
+**Test scenarios:**
+
+- Happy path: publishing an Experience locale requests exactly one manifest refresh after the write succeeds.
+- Happy path: updating a published Experience locale requests refresh; updating a draft-only locale does not refresh unless it changes a currently public route candidate.
+- Happy path: archiving an Experience requests refresh after archive succeeds.
+- Happy path: a Core sync run containing route-relevant phases requests one refresh after the run, not once per row or once per phase.
+- Edge case: a Core sync run containing only unrelated phases skips refresh.
+- Error path: refresh rejection is logged and swallowed; the publish/archive/sync method still returns its normal result.
+- Integration: refresh hooks do not duplicate existing web revalidation calls or require web config to be present.
+
+**Verification:**
+
+- Lifecycle tests prove refresh is requested at the right boundaries and remains fire-and-forget from the caller's perspective.
+- Core sync tests prove refresh frequency is once per relevant run.
+
+### U4. Authenticated Manifest Read Endpoint
+
+**Goal:** Expose the latest manifest to `apps/web` through an authenticated admin API route with explicit caching and missing-snapshot semantics.
+
+**Requirements:** R5, R8
+
+**Dependencies:** U2
+
+**Files:**
+
+- Create: `apps/admin/src/app/api/watch-route-manifest/route.ts`
+- Test: `apps/admin/src/app/api/watch-route-manifest/route.test.ts`
+
+**Approach:**
+
+- Add a `GET` route that reads the latest persisted snapshot and returns the manifest JSON.
+- Authenticate using the existing consumer-bearer / `WEB_ADMIN_API_KEYS` pattern unless a route-handler helper already centralizes that check.
+- Return an `ETag` based on the manifest version and use an explicit service-to-service cache policy such as private revalidation rather than anonymous public caching.
+- Support conditional reads if straightforward: matching `If-None-Match` returns 304 without payload.
+- Define missing-snapshot behavior clearly. Prefer controlled local generation where safe and a production 503 with operator guidance when on-demand generation would be too expensive.
+
+**Patterns to follow:**
+
+- `apps/admin/src/auth/consumer-bearer.ts` for bearer validation.
+- `apps/admin/src/app/api/search/route.ts` for route-handler auth/logging style where applicable.
+- `docs/solutions/architecture-patterns/consumer-bearer-rate-limit-identity-pattern-20260513.md`.
+
+**Test scenarios:**
+
+- Happy path: a valid consumer bearer receives the latest manifest payload, version-derived ETag, and expected cache headers.
+- Happy path: matching `If-None-Match` returns 304 with no manifest body when conditional reads are implemented.
+- Edge case: missing snapshot returns the chosen explicit missing state without falling through to an unhandled exception.
+- Error path: missing, malformed, or invalid bearer returns unauthorized without exposing whether a snapshot exists.
+- Error path: store read failure returns a controlled server error and logs without payload leakage.
+- Integration: the endpoint payload exactly matches the U1 manifest contract and does not add internal IDs or rendering data.
+
+**Verification:**
+
+- Endpoint tests cover auth, response headers, payload shape, missing snapshot, and conditional reads.
+- The endpoint is usable by the existing `apps/web` service identity without creating a new permission-bearing principal.
+
+### U5. Web Refresh Hint Extension
+
+**Goal:** Notify web when the manifest changes using the existing best-effort admin-to-web revalidation contract.
+
+**Requirements:** R4, R6, R8
+
+**Dependencies:** U2, U3
+
+**Files:**
+
+- Modify: `apps/admin/src/services/revalidate-webhook.ts`
+- Modify: `apps/admin/src/services/revalidate-webhook.test.ts`
+
+**Approach:**
+
+- Extend the revalidation model union with a manifest-specific model such as `watch-route-manifest`.
+- Emit the manifest refresh hint after a manifest snapshot is successfully replaced, not before generation/persistence succeeds.
+- Keep the payload small and avoid including the full manifest in the webhook body.
+- Preserve the current no-throw, config-missing, non-2xx, network-error, timeout, and bearer-header behavior.
+- Leave the web receiver implementation to the stacked web branch; this unit only updates the admin sender contract.
+
+**Patterns to follow:**
+
+- Existing `emitRevalidateWebhook` contract and tests.
+- Admin CLAUDE deploy-order note for receiver-first webhook changes.
+
+**Test scenarios:**
+
+- Happy path: manifest refresh emits the new model with bearer auth and minimal entry payload.
+- Edge case: absent slug/locale fields are omitted or null-handled consistently with existing webhook behavior.
+- Error path: config missing, remote non-2xx, network failure, and timeout continue to return typed outcomes and never throw.
+- Integration: Experience/video/watch-setting webhook behavior remains unchanged after extending the union.
+
+**Verification:**
+
+- Revalidation webhook tests prove the new manifest model is accepted without regressing existing models.
+- The admin sender can be deployed before web consumes the new model because missing or unknown receiver behavior remains non-blocking.
+
+### U6. Operator Script and Documentation
+
+**Goal:** Provide a safe local/operator workflow to generate, inspect, and document manifest snapshots.
+
+**Requirements:** R7, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: `apps/admin/package.json`
+- Create: `apps/admin/src/scripts/generate-watch-route-manifest.ts`
+- Test: `apps/admin/src/scripts/generate-watch-route-manifest.test.ts`
+- Modify: `apps/admin/CLAUDE.md`
+
+**Approach:**
+
+- Add an admin script entry that refreshes the manifest snapshot and prints counts, version, generated timestamp, payload size, and generation duration.
+- Default output should be summary-only. Add an explicit print mode for local debugging if useful, but avoid dumping large JSON into logs by default.
+- Reuse existing production-refusal patterns from admin scripts so accidental production mutations are fail-closed unless the repo already has an explicit safe-production override convention.
+- Document when operators should run the script locally, how to interpret counts, and which fields the web branch can rely on.
+
+**Patterns to follow:**
+
+- Safe admin script patterns listed in `apps/admin/CLAUDE.md`.
+- Existing script tests under `apps/admin/src/scripts/`.
+
+**Test scenarios:**
+
+- Happy path: against a non-production database, the script refreshes the snapshot and prints summary counts without the full manifest payload.
+- Edge case: print mode emits the manifest only when explicitly requested.
+- Error path: production-like database URLs or unparseable targets are refused according to the existing admin script safety pattern.
+- Error path: generation failure exits with a clear message and does not print a stale success summary.
+- Integration: docs identify the manifest fields, refresh triggers, and web-consumer handoff without instructing operators to edit generated artifacts.
+
+**Verification:**
+
+- Script tests or service-backed script coverage prove safe defaults and production guards.
+- `apps/admin/CLAUDE.md` documents the operator workflow and the admin-to-web contract at the same level as existing local-dev scripts.
+
+---
+
+## Consumer Contract for the Web Branch
+
+- Web can reject a two-segment route when `contentSlug` is absent or `audioLanguageSlug` is absent.
+- Web can reject a three-segment route when the parent is absent, the child is not listed under that parent, or the audio language slug is absent.
+- Web can preserve one-segment localized-home behavior by checking public language slugs first and `oneSegmentSlugs` second.
+- Web must still call the real resolver after manifest admission. The manifest is an admission prefilter, not the final content renderer.
+- Web should treat a false negative as more severe than a false positive because a false negative 404s a valid public URL.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Core sync and Experience writes feed manifest refresh; manifest refresh updates the snapshot; the snapshot feeds an authenticated admin route and a best-effort web refresh hint; web later uses the contract before its existing resolver.
+- **Error propagation:** Generation or webhook failures must be logged and swallowed from publish/sync callers. API read failures should become controlled HTTP responses, not unhandled route crashes.
+- **State lifecycle risks:** Partial refresh writes must not leave a half-updated snapshot. Snapshot replacement should be transactional, deterministic, and versioned.
+- **API surface parity:** This branch adds a new admin route-handler contract and extends the existing web revalidation sender union. It does not change admin GraphQL schema or generated `packages/admin-graphql` outputs unless implementation chooses a GraphQL surface, which this plan does not recommend.
+- **Integration coverage:** Unit tests should prove data rules; route tests should prove auth and headers; lifecycle tests should prove refresh hooks. The web branch still needs browser/proxy proof that hostile paths stop before admin GraphQL.
+- **Unchanged invariants:** Public watch URL shape, final web rendering semantics, admin publish UX, Core sync phase ordering, and consumer-bearer zero-editorial-permission semantics remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                      | Mitigation                                                                                                                      |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Manifest false negatives break valid public watch URLs                    | Preserve current web semantics, bias ambiguous route candidates toward inclusion, and keep the real resolver as final authority |
+| Fanout accidentally grows as content x language                           | Test a large fanout fixture and assert output grows by slug sets and parent/child pairs only                                    |
+| Refresh hooks make admin writes or sync brittle                           | Follow `emitRevalidateWebhook` no-throw semantics and log structured failures without blocking callers                          |
+| Auth endpoint accidentally grants editorial access or leaks internal data | Reuse consumer-bearer validation and return only route-admission metadata, no drafts, IDs, content, or media data               |
+| Postgres snapshot becomes stale after missed refresh                      | Provide operator refresh script, version/generation observability, and web-side version logging in the consumer branch          |
+| Web receiver is not ready for the new revalidation model                  | Keep sender best-effort and deploy receiver support before relying on manifest refresh hints                                    |
+| Prisma migration or JSONB model churn slows the stacked branch            | Keep persistence as a singleton model with minimal indexes and no history table in this slice                                   |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `apps/admin/CLAUDE.md` with the local refresh/inspection workflow, required env expectations, payload fields, and deploy ordering notes.
+- If admin Pothos GraphQL schema is not changed, do not regenerate `apps/admin/schema.graphql` or `packages/admin-graphql` outputs.
+- If implementation changes Prisma schema, include the migration and validate a fresh local admin database can apply it.
+- Record manifest counts from a restored admin snapshot before handing the contract to the web branch: `contentSlugs`, `oneSegmentSlugs`, parent/child pair count, `audioLanguageSlugs`, payload size, and generation duration.
+- Before `ce-work`, create or update a dedicated roadmap ticket if this work should be tracked separately from the completed `feat-148` web static-rendering ticket.
+
+---
+
+## Sources & References
+
+- Origin plan: [docs/plans/2026-05-29-001-perf-restore-watch-static-render-locale-rewrite-plan.md](2026-05-29-001-perf-restore-watch-static-render-locale-rewrite-plan.md)
+- Related roadmap: [docs/roadmap/platform/feat-148-watch-static-render-locale-rewrite.md](../roadmap/platform/feat-148-watch-static-render-locale-rewrite.md)
+- Admin guide: [apps/admin/AGENTS.md](../../apps/admin/AGENTS.md)
+- Admin conventions: [apps/admin/CLAUDE.md](../../apps/admin/CLAUDE.md)
+- Prisma source data: `apps/admin/prisma/schema.prisma`
+- Best-effort webhook pattern: `apps/admin/src/services/revalidate-webhook.ts`
+- Experience refresh precedent: `apps/admin/src/services/experience.service.ts`
+- Core sync orchestration: `apps/admin/src/services/core-sync/orchestrator.ts`, `apps/admin/src/services/core-sync/job.ts`, `apps/admin/src/workflows/coreSync.ts`
+- Consumer bearer pattern: [docs/solutions/architecture-patterns/consumer-bearer-rate-limit-identity-pattern-20260513.md](../solutions/architecture-patterns/consumer-bearer-rate-limit-identity-pattern-20260513.md)

--- a/docs/plans/2026-05-29-002-feat-watch-route-manifest-admin-plan.md
+++ b/docs/plans/2026-05-29-002-feat-watch-route-manifest-admin-plan.md
@@ -1,0 +1,463 @@
+---
+title: Admin-owned watch route manifest for bounded web route admission
+type: feat
+status: planned
+date: 2026-05-29
+origin:
+  - docs/plans/2026-05-29-001-perf-restore-watch-static-render-locale-rewrite-plan.md
+---
+
+# Admin-owned watch route manifest for bounded web route admission
+
+## Overview
+
+The static `/watch` route rewrite plan needs a route-admission source that can
+reject hostile-looking but invalid watch paths before App Router rendering,
+admin GraphQL resolution, or ISR cache entry creation. The data that decides
+whether a watch URL is valid lives in `apps/admin`: Core sync owns videos,
+video locales, video relations, languages, and dubs; admin editing owns
+Experience publish/update/archive state.
+
+This plan adds an admin-owned **watch route manifest**: a compact, generated
+contract that lists valid content slugs and parent/child route pairs without
+enumerating every language-specific public URL. `apps/web` can consume the
+manifest to answer "could this path ever be valid?" cheaply, while admin keeps
+the manifest current after import, sync, add, delete, publish, and archive
+flows.
+
+This branch is intentionally stacked on
+`perf/watch-static-locale-rewrite`. The web branch should consume the manifest
+after this contract lands, then merge the admin-manifest branch back.
+
+## Problem Statement
+
+The current web plan bounds the internal `[locale]` segment, but `params.rest`
+is still attacker-controlled. A random URL like
+`/watch/anything.html/english.html` can be syntactically safe, pass language
+validation, and reach the force-static catch-all. From there, the render path
+can issue admin lookups before returning a 404. With ISR enabled, repeated
+random paths can create compute work today and may create a storage-spray
+surface once the static route cache is active.
+
+The validity check cannot be based on hardcoded web route knowledge alone:
+
+- `Video`, `VideoLocale`, `VideoRelation`, `VideoDub`, and `Language` are
+  sourced through admin/Core sync.
+- `Experience` and `ExperienceLocale` can be published, updated, or archived
+  from admin.
+- Admin local/import/sync/delete flows can change the valid public watch
+  surface without a web code change.
+
+The manifest must scale with content growth. The local branch test snapshot has
+roughly 1k videos and more than 200k dubs, and admin already documents a single
+Jesus-film-style collection fanout of about 61 children x 2,200 dubs. A route
+manifest that enumerates `content x language` or `episode x language` will
+grow in the wrong dimension.
+
+## Goals
+
+- Give admin one service that computes the public watch route-admission
+  manifest from canonical admin data.
+- Keep manifest size proportional to slugs, episode relations, and language
+  slugs, not full public route permutations.
+- Refresh the manifest after Experience publish/update/archive and after Core
+  sync phases that can change route admission.
+- Expose a stable contract that `apps/web` can consume in proxy or pre-render
+  guards without querying admin per hostile request.
+- Include tests for deletes, soft deletes, draft/unpublished rows, playable dub
+  changes, and large fanout.
+
+## Non-goals
+
+- Do not implement the `apps/web` proxy consumer in this branch.
+- Do not change public `/watch` URL shape.
+- Do not enumerate every localized public route.
+- Do not move audio-language aliasing, UI-message locale resolution, or
+  `<html lang>` logic into admin.
+- Do not make admin publish UX depend on a synchronous web/cache refresh.
+
+## Existing Patterns
+
+- `apps/admin/prisma/schema.prisma` models the relevant data:
+  - `Language.slug`, `Language.bcp47`, and `Language.deletedAt`.
+  - `Video.slug`, `Video.deletedAt`, `Video.noIndex`, `Video.locales`,
+    `Video.dubs`, and `Video.children` / `Video.parents`.
+  - `VideoLocale.status` and `(videoId, locale)`.
+  - `VideoRelation.parentId` / `childId`.
+  - `VideoDub.published`, `VideoDub.hls`, `VideoDub.languageId`, and
+    `VideoDub.deletedAt`.
+  - `Experience.archivedAt` and `ExperienceLocale.status`, `slug`,
+    `isHomepage`, `pathSegment`.
+- `apps/admin/src/services/revalidate-webhook.ts` is the precedent for
+  best-effort web notification. It never blocks publish UX and silently no-ops
+  when env is absent.
+- `apps/admin/src/services/experience.service.ts` already calls
+  `emitRevalidateWebhook` after published Experience locale updates,
+  publishing, homepage changes, and archive.
+- `apps/admin/src/services/core-sync/orchestrator.ts` runs Core sync phases in
+  a known order and is the natural point to request a manifest refresh after
+  route-relevant phases complete.
+- `apps/admin/src/graphql/types/video.ts` exposes `childDubLanguages` as a
+  bounded distinct language set, explicitly avoiding the large
+  children-by-dubs fanout. The manifest should copy that scaling philosophy.
+- `apps/web/src/lib/content.ts` currently treats unknown watch video and
+  series misses as uncached success-path exceptions; this is correct for
+  freshness but expensive for random path spray unless the path is rejected
+  earlier.
+
+## Manifest Contract
+
+The admin service should produce a compact JSON shape:
+
+```ts
+type WatchRouteManifest = {
+  version: string
+  generatedAt: string
+  contentSlugs: string[]
+  oneSegmentSlugs: string[]
+  episodePairsByParent: Record<string, string[]>
+  audioLanguageSlugs: string[]
+}
+```
+
+Field semantics:
+
+- `version`: stable hash of the manifest content or a monotonically changing
+  version token. Web uses it for cache replacement and logging.
+- `generatedAt`: ISO timestamp for observability.
+- `contentSlugs`: valid first-segment `.html` slugs for two-segment watch
+  paths. Include public videos/series/collections and published Experience
+  slugs that can be addressed by `/watch/{slug}.html/{audio}.html`.
+- `oneSegmentSlugs`: valid one-segment collection/experience slugs such as
+  `/watch/easter.html`. This must preserve the current web disambiguation:
+  one-segment language slugs are localized-home, non-language slugs are
+  collection/experience candidates.
+- `episodePairsByParent`: parent slug to child slug list for three-segment
+  routes such as
+  `/watch/book-of-acts.html/the-holy-spirit-comes-at-pentecost/english.html`.
+  This is the only parent/child relation the web proxy needs to admit episode
+  shapes.
+- `audioLanguageSlugs`: public audio-language slugs with at least one playable
+  dub somewhere. Web may already have language metadata; include this only if
+  it avoids a second source for "is this audio slug public and playable?"
+
+The manifest deliberately does **not** include:
+
+- `{contentSlug, audioLanguageSlug}` pairs.
+- `{parentSlug, childSlug, audioLanguageSlug}` triples.
+- localized titles, block content, images, HLS URLs, subtitles, or search data.
+- admin IDs unless needed for debugging in a separate internal-only endpoint.
+
+## Data Rules
+
+### Videos
+
+Include a video slug in `contentSlugs` when:
+
+- `video.deletedAt IS NULL`.
+- `video.slug` is non-empty.
+- It has at least one `VideoLocale.status = PUBLISHED`.
+- It is either directly playable or is a collection/series that web can render
+  through its current series/collection paths.
+
+For directly playable video admission, require at least one dub where:
+
+- `video_dub.deletedAt IS NULL`.
+- `video_dub.published = true`.
+- `video_dub.hls IS NOT NULL`.
+- `video_dub.languageId` points at a non-deleted `Language`.
+- `language.slug IS NOT NULL`.
+
+For series/collection admission, preserve existing web behavior: a parent can
+be routable even when playback lives on its children rather than on the parent
+itself. The implementation should document whether a parent needs a playable
+trailer, at least one routable child, or either. Prefer matching current web
+render semantics over inventing a stricter SEO rule.
+
+### Episode pairs
+
+Include `parentSlug -> childSlug` when:
+
+- Parent and child videos are not soft-deleted.
+- Both have non-empty slugs.
+- Public users can see the child relation under existing GraphQL visibility
+  rules.
+- The child has at least one playable dub.
+- The parent has enough public state to render a series/collection page.
+
+Do not multiply pairs by audio language. The language slug is validated
+separately.
+
+### Experiences
+
+Include Experience slugs when:
+
+- `experience.archivedAt IS NULL`.
+- `experience_locale.status = PUBLISHED`.
+- `experience_locale.slug` is non-empty.
+- The slug/path shape maps to a public watch route in current web semantics.
+
+Homepage rows (`isHomepage = true`) should not create a content slug unless
+their slug is independently routable today. `pathSegment` must be handled
+deliberately: if watch currently ignores multi-segment Experience path segments,
+the manifest should not introduce them.
+
+### Languages
+
+Include an audio language slug when:
+
+- `language.deletedAt IS NULL`.
+- `language.slug IS NOT NULL`.
+- At least one playable dub uses that language.
+
+This is a public audio slug set, not a UI message-catalog locale set. It must
+not collapse `spanish-latin-american` into `es`.
+
+## Implementation Units
+
+### Unit 1 - Manifest service and SQL
+
+Create `apps/admin/src/services/watch-route-manifest.service.ts`.
+
+Responsibilities:
+
+- Compute the manifest from Prisma/Postgres.
+- Keep the query shape bounded and observable.
+- Prefer raw SQL for the aggregate sets if Prisma would over-fetch relation
+  trees.
+- Return sorted arrays for deterministic hashes and snapshots.
+- Log row counts and generation duration without logging full payloads.
+
+Tests:
+
+- `apps/admin/src/services/watch-route-manifest.service.test.ts`
+- Covers playable video inclusion/exclusion, draft locales, soft-deleted
+  videos/languages/dubs, parent/child pairs, one-segment Experience slugs, and
+  deterministic ordering.
+- Includes a fanout fixture with many dubs across multiple children and asserts
+  output size grows by language set plus episode pairs, not route permutations.
+
+### Unit 2 - Manifest persistence and versioning
+
+Add a small persisted store for the latest manifest.
+
+Preferred implementation:
+
+- Add a Prisma model such as `WatchRouteManifestSnapshot` with a singleton key,
+  `version`, `generatedAt`, `payload`, `payloadSizeBytes`, and `createdAt` /
+  `updatedAt`.
+- Add the corresponding migration under `apps/admin/prisma/migrations/`.
+- Store JSONB so admin can serve the current manifest without recomputing on
+  every request.
+
+Alternative if avoiding a migration in this slice:
+
+- Generate on demand behind a cached service boundary, then add persistence in
+  a follow-up before production traffic uses it. This is weaker and should only
+  be chosen if the migration risk is unacceptable for the stacked PR.
+
+Tests:
+
+- `apps/admin/src/services/watch-route-manifest-store.test.ts`
+- Verifies upsert, version replacement, stale-read behavior, and payload size
+  logging.
+
+### Unit 3 - Admin refresh hooks
+
+Wire manifest refresh requests from route-relevant admin lifecycle events.
+
+Files:
+
+- `apps/admin/src/services/experience.service.ts`
+- `apps/admin/src/services/core-sync/orchestrator.ts`
+- `apps/admin/src/services/core-sync/job.ts`
+- `apps/admin/src/workflows/coreSync.ts`
+
+Behavior:
+
+- After Experience publish/update/archive events that already emit web
+  revalidation, enqueue or fire-and-forget a manifest refresh.
+- After Core sync completes phases that can change the manifest
+  (`languages`, `videos`, `video-dubs`, and possibly relation-bearing video
+  sync), refresh once per sync run, not once per row.
+- If only unrelated phases run, skip the refresh.
+- If refresh fails, log structured failure and do not fail the admin publish or
+  sync job.
+
+Tests:
+
+- Extend `apps/admin/src/services/experience.service.test.ts` if present, or
+  add focused tests around the service method that emits refresh.
+- Extend `apps/admin/src/services/core-sync/orchestrator.test.ts` or
+  `apps/admin/src/services/core-sync/job.test.ts` to assert one refresh after
+  route-relevant phases and none after unrelated phases.
+
+### Unit 4 - Manifest read endpoint
+
+Expose the latest manifest to web.
+
+Preferred endpoint:
+
+- `apps/admin/src/app/api/watch-route-manifest/route.ts`
+
+Contract:
+
+- `GET` returns the latest manifest JSON plus `ETag` and
+  `Cache-Control: private, max-age=0, must-revalidate` or another explicitly
+  chosen service-to-service cache policy.
+- Auth uses an existing service-token/bearer pattern. Do not expose the
+  manifest anonymously unless the security review explicitly accepts it.
+- If no manifest exists, generate once or return a clear 503 with instructions
+  to run the refresh job. Prefer generation in controlled admin environments
+  and 503 in production if on-demand generation would be too expensive.
+
+Tests:
+
+- `apps/admin/src/app/api/watch-route-manifest/route.test.ts`
+- Covers auth, ETag/304 behavior if implemented, missing snapshot, and payload
+  shape.
+
+### Unit 5 - Web revalidation payload extension
+
+Extend the existing admin-to-web notification contract so web knows when the
+manifest changed.
+
+Files:
+
+- `apps/admin/src/services/revalidate-webhook.ts`
+- `apps/admin/src/services/revalidate-webhook.test.ts`
+
+Options:
+
+1. Add `model: "watch-route-manifest"` to the existing webhook union and send
+   it after a successful manifest refresh.
+2. Add a dedicated `WEB_ROUTE_MANIFEST_REFRESH_URL` if the consumer must be a
+   different endpoint than `/api/revalidate`.
+
+Prefer option 1 for the first slice: it reuses the existing bearer contract and
+lets the web branch decide how to clear or refetch its manifest cache.
+
+Tests:
+
+- Existing webhook tests should cover the new model, missing config, non-2xx,
+  and no-throw behavior.
+
+### Unit 6 - Scripts and operator workflow
+
+Add a way to generate or inspect the manifest locally.
+
+Files:
+
+- `apps/admin/package.json`
+- `apps/admin/src/scripts/generate-watch-route-manifest.ts`
+
+Behavior:
+
+- `pnpm --filter @forge/admin watch-route-manifest:generate` refreshes the
+  snapshot and prints counts, version, generatedAt, and payload size.
+- The script must refuse production URLs unless an existing safe script pattern
+  permits production operations explicitly.
+- Add an optional `--print` mode for local debugging that writes payload to
+  stdout; default should avoid dumping large JSON into logs.
+
+Tests:
+
+- If script tests are practical, add
+  `apps/admin/src/scripts/generate-watch-route-manifest.test.ts`.
+- Otherwise keep service tests as the correctness source and document the
+  command in `apps/admin/CLAUDE.md`.
+
+## Consumer Contract for the Web Branch
+
+This branch should not implement the web consumer, but it must leave enough
+contract for the current web PR to proceed:
+
+- Web can reject a two-segment route when `contentSlug` is absent or
+  `audioLanguageSlug` is absent.
+- Web can reject a three-segment route when the parent is absent, the child is
+  not listed under that parent, or the audio language slug is absent.
+- Web can preserve one-segment localized-home behavior by checking language
+  slugs first and `oneSegmentSlugs` second.
+- Web should still call the real resolver after manifest admission. The
+  manifest is an admission prefilter, not the final content renderer.
+- A manifest false negative is worse than a false positive because it 404s
+  valid public URLs. Keep data rules conservative and consumer behavior
+  observable.
+
+## Scaling Rules
+
+- Manifest generation may scan large tables, but request-time web validation
+  must be set membership only.
+- Payload growth target is:
+  - `O(contentSlugs)`.
+  - `O(oneSegmentSlugs)`.
+  - `O(parentChildPairs)`.
+  - `O(audioLanguageSlugs)`.
+- Payload must never be:
+  - `O(contentSlugs x audioLanguageSlugs)`.
+  - `O(parentChildPairs x audioLanguageSlugs)`.
+  - dependent on full `VideoDub` row projection.
+- Add size logging and tests that fail if the fanout fixture starts emitting
+  per-language route permutations.
+- If `episodePairsByParent` becomes too large for edge/proxy memory, switch the
+  wire shape to sorted arrays or a compact prefix structure before adding
+  language multiplication. Do not solve size by dropping correctness silently.
+
+## Verification
+
+Admin branch validation:
+
+- `pnpm --filter @forge/admin test -- watch-route-manifest`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`
+- `pnpm --filter @forge/admin schema:print` when GraphQL or Prisma schema
+  changes require it.
+- If a Prisma model/migration is added, run the admin migration validation path
+  used by this repo and verify a fresh local DB can migrate.
+- Run the local generate script against a restored admin snapshot and record:
+  `contentSlugs`, `oneSegmentSlugs`, `parentChildPairs`,
+  `audioLanguageSlugs`, `payloadSizeBytes`, and generation duration.
+
+Web integration validation after merge back:
+
+- Hostile two-segment paths such as `/watch/anything.html/english.html` reject
+  before admin GraphQL resolution.
+- Hostile three-segment paths such as
+  `/watch/jesus.html/anything/english.html` reject before admin GraphQL
+  resolution.
+- Known valid research-doc paths still render.
+- `/watch/easter.html` preserves one-segment collection behavior.
+- Public language slugs such as `english.html` are admitted; message keys such
+  as `en.html` remain invalid public audio segments.
+
+## Acceptance Criteria
+
+- Admin computes and stores a compact manifest with deterministic ordering and
+  versioning.
+- Manifest refresh is triggered by Experience changes and route-relevant Core
+  sync/import flows without blocking those flows.
+- Web can fetch the latest manifest through an authenticated, documented
+  contract.
+- Manifest payload does not enumerate full language-specific route
+  permutations.
+- Tests cover draft, delete, soft delete, playable dub, relation, Experience,
+  and large-fanout cases.
+- Operator docs explain how to refresh and inspect manifest counts locally.
+
+## Open Questions
+
+1. Should the latest manifest be stored only in Postgres first, or should admin
+   also push it to the eventual edge-readable store in this slice?
+2. Should `audioLanguageSlugs` include every non-deleted language slug, or only
+   languages with at least one playable dub? The stricter playable-dub set is
+   safer for admission, but may reject newly synced language routes before dub
+   sync completes in partial sync windows.
+3. Should `contentSlugs` include published Experiences independently of video
+   playability? Current web resolution tries Experience after video/series
+   misses in some shapes; the implementation must match exact current route
+   dispatch.
+4. Is `pathSegment` in `ExperienceLocale` currently part of public `/watch`
+   routing? If not, keep it out of the manifest until web supports it.
+5. Which endpoint will the web branch use to invalidate or refetch the manifest:
+   existing `/api/revalidate`, a new route, or an edge-store update outside
+   Next?

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -146,6 +146,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-146](platform/feat-146-web-user-accounts-download-gate.md)                 | Web User Accounts and Video Download Gate               | vlad      | P1       | 2026-05-27 | 7    | 2026-06-02 | complete    |
 | [feat-145](platform/feat-145-watch-question-panel-flag.md)                       | Watch Question Panel LaunchDarkly Gate                  | vlad      | P2       | 2026-05-28 | 1    | 2026-05-28 | complete    |
 | [feat-147](platform/feat-147-watch-public-asset-passthrough.md)                  | Watch Public Asset Passthrough                          | vlad      | P1       | 2026-05-29 | 1    | 2026-05-29 | complete    |
+| [feat-149](platform/feat-149-watch-route-manifest-admin.md)                      | Admin Watch Route Manifest                              | vlad      | P1       | 2026-05-29 | 2    | 2026-05-30 | complete    |
 | [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                              | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
 | [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                     | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                 | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |

--- a/docs/roadmap/platform/feat-149-watch-route-manifest-admin.md
+++ b/docs/roadmap/platform/feat-149-watch-route-manifest-admin.md
@@ -1,0 +1,82 @@
+---
+id: "feat-149"
+title: "Admin Watch Route Manifest"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-05-29"
+duration: 2
+depends_on:
+  - "feat-148"
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "web"
+  - "watch-page"
+  - "routing"
+  - "performance"
+---
+
+## Problem
+
+The static `/watch` route rewrite bounds internal locale params, but arbitrary
+watch content segments can still reach App Router rendering and admin lookups
+before returning 404. Once ISR is active, random route spray can create
+unnecessary render work and cache entries unless web can cheaply reject paths
+that cannot exist.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-05-29-002-feat-watch-route-manifest-admin-plan.md` - implementation plan and route-admission contract.
+2. `apps/admin/prisma/schema.prisma` - source tables and snapshot model.
+3. `apps/admin/src/services/revalidate-webhook.ts` - existing best-effort admin-to-web notification pattern.
+4. `apps/admin/src/services/experience.service.ts` - Experience publish/update/archive hooks.
+5. `apps/admin/src/services/core-sync/orchestrator.ts` - route-relevant Core sync phase orchestration.
+6. `apps/admin/src/auth/consumer-bearer.ts` - service-to-service bearer validation for web callers.
+7. `apps/web/src/proxy.ts` - future consumer location for route-admission checks.
+
+## Grep These
+
+- `watch-route-manifest`
+- `WatchRouteManifest`
+- `emitRevalidateWebhook`
+- `isValidConsumerBearer`
+- `childDubLanguages`
+- `VideoRelation`
+- `video-dubs`
+
+## What To Build
+
+1. Add an admin service that computes compact watch route-admission sets:
+   `contentSlugs`, `oneSegmentSlugs`, `episodePairsByParent`, and
+   `audioLanguageSlugs`.
+2. Persist the latest deterministic, versioned manifest snapshot in Postgres.
+3. Refresh the manifest after route-relevant Experience and Core sync changes
+   without blocking publish or sync jobs.
+4. Expose the latest manifest through an authenticated admin API route for
+   `apps/web`.
+5. Extend the existing web revalidation webhook with a manifest-refresh model.
+6. Add a safe operator script and docs for local refresh/inspection.
+
+## Constraints
+
+- Do not implement the `apps/web` route-admission consumer in this ticket.
+- Do not change public `/watch` URL shape.
+- Do not enumerate `content x language` or `parentChild x language` route
+  permutations.
+- Do not expose drafts, archived content, internal IDs, localized content,
+  media URLs, subtitles, search data, or rendering payloads through the
+  manifest.
+- Do not make admin publish/update/archive UX depend on web availability.
+- Do not hand-edit generated Prisma client or GraphQL environment outputs.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- watch-route-manifest`
+- `pnpm --filter @forge/admin test -- revalidate-webhook experience.service core-sync`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`
+- Verify the Prisma migration applies on a fresh local admin database.
+- Run the manifest generation script against local/restored admin data and
+  record slug counts, pair count, payload size, and generation duration.

--- a/docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md
+++ b/docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md
@@ -1,0 +1,138 @@
+---
+title: "Admin-Owned Watch Route Manifest"
+date: "2026-05-30"
+category: "architecture-patterns"
+module: "apps/admin watch routing"
+problem_type: "architecture_pattern"
+component: "service_object"
+severity: "medium"
+applies_when:
+  - "A public route needs cheap admission checks before expensive content lookup or ISR cache work"
+  - "Admin owns the canonical route data, but a consumer app needs a compact read contract"
+  - "The full route space would explode if content-language permutations were materialized"
+  - "Route metadata can be refreshed from publish, archive, or sync events instead of generated on request"
+related_components:
+  - "database"
+  - "authentication"
+  - "development_workflow"
+  - "testing_framework"
+tags:
+  - "admin"
+  - "watch-route"
+  - "route-manifest"
+  - "route-admission"
+  - "consumer-bearer"
+  - "jsonb-snapshot"
+  - "revalidation"
+  - "operator-smoke"
+---
+
+# Admin-Owned Watch Route Manifest
+
+## Context
+
+Forge needed a bounded admission gate for public `/watch` routes before the web app moved deeper into static route rewrites. Prior static-route work showed that random or hostile paths could otherwise create expensive admin lookups, ISR/notFound cache entries, and revalidation noise before the page renderer had enough information to reject them (session history).
+
+The route truth already lives in `apps/admin`: videos, dubs, languages, parent-child relations, and `Experience` publish/archive lifecycle all flow through admin. The reusable pattern is to let admin generate and serve a compact manifest of possible watch routes, then let consumers use that manifest as an admission contract instead of rediscovering route possibility on every request.
+
+## Guidance
+
+Use an admin-owned manifest when route validity depends on admin state but admission needs to be cheap in a consumer app.
+
+Keep the manifest as bounded sets, not URL records:
+
+```ts
+type WatchRouteManifest = {
+  version: string
+  generatedAt: string
+  contentSlugs: string[]
+  oneSegmentSlugs: string[]
+  episodePairsByParent: Record<string, string[]>
+  audioLanguageSlugs: string[]
+}
+```
+
+The implementation shape that worked:
+
+- Generate deterministic admission data in `apps/admin/src/services/watch-route-manifest.service.ts`.
+- Filter to public/playable candidates from canonical admin tables: published locales, non-deleted videos/languages, published HLS dubs, and non-archived non-template experiences.
+- Version the manifest with a stable content hash that excludes `generatedAt`, so consumers can use cache validators without churn from generation time alone.
+- Persist the latest snapshot in a singleton Postgres JSONB table through `WatchRouteManifestSnapshot`.
+- Serve the latest snapshot from `GET /api/watch-route-manifest`; do not generate the manifest in the request path.
+- Require the existing consumer bearer from `WEB_ADMIN_API_KEYS`, return `401` for missing or invalid auth, and return `503` when no snapshot exists yet.
+- Support `ETag` / `If-None-Match` so consumers can receive `304` without paying payload transfer.
+- Refresh after route-relevant Core sync phases (`languages`, `videos`, `video-dubs`) and after `Experience` publish, update, or archive mutations.
+- Treat refresh and downstream web revalidation as best effort: log or return failed refresh outcomes instead of throwing through editorial or sync flows.
+- Provide an operator script for explicit regeneration after migrations, imports, or sync repairs.
+
+The manifest should stay an admission contract. It should not include rendering payloads, localized route permutations, full video metadata, or any data that makes the API a replacement for the page resolver.
+
+## Why This Matters
+
+Without a compact admission contract, each impossible `/watch` path can fan out into the slowest parts of the system: admin lookups, high-cardinality cache keys, broad revalidation work, and repeated misses from crawlers or malicious path exploration.
+
+Centralizing admission data in admin keeps the producer/consumer boundary clean:
+
+- Admin remains the source of truth for published watch availability.
+- Web can reject impossible paths before deeper content fetching.
+- Snapshot reads avoid request-time aggregate recomputation.
+- Conditional requests make the manifest cheap to poll or reuse.
+- Operators have one deterministic regeneration path when source data changes outside normal publish flows.
+
+The compact shape also avoids the mistake of materializing every content-by-language route. Prior catalog sizing already showed enough video and dub volume that full permutation storage would be the wrong abstraction (session history).
+
+## When to Apply
+
+- A public route surface needs fast negative admission before expensive rendering or API calls.
+- Route possibility is derived from producer-owned data in another app or service.
+- The valid route space can be represented as compact sets or parent-child relations.
+- Refresh events are known, such as publish/archive hooks or sync phases.
+- The consumer can authenticate as a known internal caller.
+- Stale admission data is safer than request-time recomputation, and an operator can regenerate snapshots.
+
+Avoid this pattern when route validity is personalized, too volatile to snapshot, or so large that a manifest becomes a hidden data export. In those cases, use a narrower admission endpoint or a consumer-local index.
+
+## Examples
+
+The read contract should preserve this behavior:
+
+```text
+GET /api/watch-route-manifest without bearer token -> 401
+GET /api/watch-route-manifest with a valid WEB_ADMIN_API_KEYS bearer -> 200
+GET /api/watch-route-manifest with matching If-None-Match -> 304
+GET /api/watch-route-manifest before the first snapshot exists -> 503
+```
+
+Operator regeneration should use the package script in a configured admin checkout:
+
+```bash
+pnpm --filter @forge/admin watch-route-manifest:generate
+```
+
+In a fresh or isolated smoke environment, that package script can fail if `apps/admin/.env` is absent because it invokes `tsx --env-file=.env`. For one-off smoke tests, run the script target directly with explicit environment variables and then verify the endpoint against the isolated database.
+
+The runtime smoke that proved the pattern should remain the bar for similar changes:
+
+```text
+1. Apply the manifest migration against an isolated database.
+2. Seed route-relevant videos, dubs, languages, parent-child links, and experiences.
+3. Generate the manifest and confirm a WatchRouteManifestSnapshot row exists.
+4. Start admin with WEB_ADMIN_API_KEYS set.
+5. Confirm unauthenticated endpoint access returns 401.
+6. Confirm authenticated access returns 200 with the expected compact sets.
+7. Confirm conditional access returns 304 for a matching ETag.
+```
+
+## Related
+
+- `docs/plans/2026-05-29-002-feat-watch-route-manifest-admin-plan.md`
+- `docs/roadmap/platform/feat-149-watch-route-manifest-admin.md`
+- `apps/admin/src/services/watch-route-manifest.service.ts`
+- `apps/admin/src/services/watch-route-manifest-store.ts`
+- `apps/admin/src/services/watch-route-manifest-refresh.service.ts`
+- `apps/admin/src/app/api/watch-route-manifest/route.ts`
+- `apps/admin/src/scripts/generate-watch-route-manifest.ts`
+- `apps/admin/prisma/migrations/0025_watch_route_manifest_snapshot/migration.sql`
+- `docs/solutions/architecture-patterns/consumer-bearer-rate-limit-identity-pattern-20260513.md`
+- `docs/solutions/best-practices/watch-single-video-template-pages-strapi-nextjs-2026-04-11.md`
+- `docs/solutions/best-practices/nextjs-route-shape-migration-cross-cutting-contract-drift-20260430.md`


### PR DESCRIPTION
## Summary
- Adds admin WatchRouteManifest generation, JSONB snapshot persistence, and an authenticated GET endpoint with ETag/503 behavior.
- Refreshes after route-relevant Core sync and Experience publish/update/archive, then emits a best-effort web revalidation model.
- Adds a safe operator script and admin docs; completes feat-149.

## Validation
- pnpm --filter @forge/admin test -- watch-route-manifest generate-watch-route-manifest
- pnpm --filter @forge/admin test -- revalidate-webhook experience.service core-sync
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- pnpm --filter @forge/admin build (local attempt blocked: first missing required env; dummy-env run stayed in Turbopack optimization and was terminated)