### PR TITLE
feat(mastra): add search eval orchestrator

### DIFF
--- a/apps/mastra/AGENTS.md
+++ b/apps/mastra/AGENTS.md
@@ -17,6 +17,9 @@ Full context lives in `apps/mastra/CLAUDE.md`. Keep both files aligned.
 - Owns the offline search eval system: seed prompt sets, baseline/report
   artifacts, comparison workflows, judge orchestration, and developer/operator
   eval routes that call Admin search through authenticated HTTP.
+- Owns a thin search eval orchestrator that coordinates those leaf workflows
+  for baseline capture, comparison, native Evaluation sync, and release-gate
+  summaries without moving leaf logic into one mega-workflow.
 - All embedding workflows share provider-result validation for count alignment,
   finite vector values, and configured dimensions before calling Admin.
 - All embedding workflows use the shared Admin ingest client behavior but keep
@@ -47,6 +50,9 @@ Full context lives in `apps/mastra/CLAUDE.md`. Keep both files aligned.
   seed-prompt artifacts owned by Mastra. Keep the Studio-facing workflow
   seed-only until a later human promotion flow decides how staged generated
   candidates should become reviewable.
+- The search eval orchestrator must not promote generated, trace-derived, seed,
+  or user-submitted candidates. Candidate generation and seed submission are
+  opt-in staging steps; human promotion stays behind Admin review contracts.
 - Studio-facing workflows need structured Zod object input schemas on both the
   workflow and first step. Avoid `z.unknown()` for operator-run workflows, and
   prefer defaults/optional fields that render usable Studio forms.

--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -178,6 +178,27 @@ Open `http://localhost:4111/studio/workflows/search-eval-native-suite`, run the
 default `create-sample-report` action, then inspect Studio's native Evaluation
 Datasets, Scorers, and Experiments.
 
+## Search eval orchestrator
+
+The service route `POST /forge-search-eval-orchestrator` is protected by
+`MASTRA_SERVICE_API_KEYS` and launches the `search-eval-orchestrator` workflow.
+It is a thin coordinator over the existing search eval leaf workflows:
+`eval-query-generation`, `offline-search-eval`,
+`search-eval-candidate-review`, and `search-eval-native-suite`.
+
+Default `full` mode captures the committed seed prompt baseline named
+`seed-baseline`, then syncs the resulting report and already-promoted Admin
+candidates into native Evaluation. `compare` mode compares current search
+against an existing baseline, and `release-gate` mode adds explicit pass/fail
+thresholds for losses, search failures, judge failures, judge disagreements,
+and calibration. `resumeReportId` skips offline search execution and retries
+native report sync for an existing report artifact.
+
+Candidate generation and seed candidate submission are explicit opt-ins. The
+orchestrator must never promote generated, trace-derived, seed, or
+user-submitted candidates; promotion remains a human review action through
+Admin HTTP contracts.
+
 ## Railway Storage
 
 Production `@forge/mastra` uses the existing Mastra Postgres database through

--- a/apps/mastra/src/mastra/index.ts
+++ b/apps/mastra/src/mastra/index.ts
@@ -51,6 +51,10 @@ import {
   searchEvalNativeSuiteWorkflow,
 } from "./workflows/search-eval-native-suite"
 import {
+  handleSearchEvalOrchestratorRouteRequest,
+  searchEvalOrchestratorWorkflow,
+} from "./workflows/search-eval-orchestrator"
+import {
   isValidServiceBearer,
   parseServiceApiKeys,
 } from "../server/service-bearer"
@@ -96,6 +100,7 @@ export const mastra = new Mastra({
     offlineSearchEvalWorkflow,
     searchEvalCandidateReviewWorkflow,
     searchEvalNativeSuiteWorkflow,
+    searchEvalOrchestratorWorkflow,
   },
   logger: new PinoLogger({
     name: "ForgeMastra",
@@ -248,6 +253,21 @@ export const mastra = new Mastra({
         method: "POST",
         handler: async (c) => {
           const outcome = await handleSearchEvalNativeSuiteRouteRequest({
+            authHeader: c.req.header("authorization"),
+            serviceKeys,
+            request: c.req.raw,
+          })
+
+          return new Response(JSON.stringify(outcome.body), {
+            status: outcome.status,
+            headers: { "content-type": "application/json" },
+          })
+        },
+      }),
+      registerApiRoute("/forge-search-eval-orchestrator", {
+        method: "POST",
+        handler: async (c) => {
+          const outcome = await handleSearchEvalOrchestratorRouteRequest({
             authHeader: c.req.header("authorization"),
             serviceKeys,
             request: c.req.raw,

--- a/apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts
@@ -1,0 +1,974 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  _internal,
+  handleSearchEvalOrchestratorRouteRequest,
+  runSearchEvalOrchestratorWorkflow,
+  searchEvalOrchestratorWorkflow,
+} from "./search-eval-orchestrator"
+import type { SearchEvalReport } from "../../services/offline-search-eval/types"
+
+function customArtifactProjection(
+  kind: SearchEvalReport["kind"],
+  reportId: string,
+): SearchEvalReport["mastraEvaluation"] {
+  const baselineName = "seed-baseline"
+  const mode = kind === "baseline-report" ? "baseline_capture" : "comparison"
+  const verb = kind === "baseline-report" ? "baseline" : "compare"
+  return {
+    integrationStatus: "custom_artifact_only",
+    dataset: {
+      name: `search-eval:${baselineName}`,
+      datasetId: null,
+      source: "seed_prompt_set",
+      version: "seed:v1",
+      itemCount: 1,
+      targetType: "workflow",
+      targetId: "offline-search-eval",
+    },
+    scorers: [
+      {
+        id: "search-result-pairwise-judge",
+        scorerId: null,
+        status: "not_registered",
+        kind: "pairwise_search_results",
+      },
+    ],
+    experiment: {
+      name: `search-eval-${verb}:${baselineName}:${reportId}`,
+      experimentId: null,
+      status: "not_created",
+      mode,
+      reportId,
+      baselineName,
+    },
+  }
+}
+
+function nativeSyncedProjection(
+  kind: SearchEvalReport["kind"],
+  reportId: string,
+): SearchEvalReport["mastraEvaluation"] {
+  const baselineName = "seed-baseline"
+  const mode = kind === "baseline-report" ? "baseline_capture" : "comparison"
+  const verb = kind === "baseline-report" ? "baseline" : "compare"
+  return {
+    integrationStatus: "native_synced",
+    dataset: {
+      name: `search-eval:local:${baselineName}`,
+      datasetId: "dataset-1",
+      source: "seed_prompt_set",
+      version: "seed:v1",
+      itemCount: 1,
+      targetType: "workflow",
+      targetId: "offline-search-eval",
+      environmentLabel: "local",
+      nativeKey: `search-eval:local:${baselineName}:seed:v1`,
+      status: "reused",
+    },
+    scorers: [
+      {
+        id: "search-result-pairwise-judge",
+        scorerId: "scorer-1",
+        status: "reused",
+        kind: "pairwise_search_results",
+      },
+    ],
+    experiment: {
+      name: `search-eval-${verb}:local:${baselineName}:${reportId}`,
+      experimentId: "experiment-1",
+      status: "reused",
+      mode,
+      reportId,
+      baselineName,
+      environmentLabel: "local",
+      nativeKey: `search-eval:local:${baselineName}:seed:v1:report:${reportId}`,
+    },
+  }
+}
+
+function report(
+  options: {
+    kind?: SearchEvalReport["kind"]
+    reportId?: string
+    losses?: number
+    searchFailures?: number
+    judgeFailures?: number
+    judgeDisagreements?: number
+    calibrationPassed?: boolean
+    calibrationSkipped?: boolean
+  } = {},
+): SearchEvalReport {
+  const kind = options.kind ?? "baseline-report"
+  const reportId = options.reportId ?? "report-1"
+  return {
+    schemaVersion: "1",
+    kind,
+    reportId,
+    metadata: {
+      mastraRunId: "offline-run",
+      startedAt: "2026-05-30T00:00:00.000Z",
+      finishedAt: "2026-05-30T00:01:00.000Z",
+      baselineName: "seed-baseline",
+      promptSetVersion: "seed:v1",
+      adminSearchUrl: "https://admin.internal/api/internal/search-eval/search",
+      judgeModel: "judge-model",
+      search: {
+        limit: 20,
+        mode: "hybrid",
+        contentType: null,
+      },
+    },
+    mastraEvaluation: customArtifactProjection(kind, reportId),
+    baseline: {
+      name: "seed-baseline",
+      capturedAt: "2026-05-30T00:00:00.000Z",
+      caseCount: 1,
+      search: {
+        limit: 20,
+        mode: "hybrid",
+        contentType: null,
+      },
+    },
+    calibration: {
+      passed: options.calibrationPassed ?? true,
+      matched: 1,
+      total: 1,
+      skipped: options.calibrationSkipped ?? false,
+    },
+    totals: {
+      queries: 1,
+      wins: 0,
+      losses: options.losses ?? 0,
+      ties: 1,
+      bothIrrelevant: 0,
+      judgeDisagreements: options.judgeDisagreements ?? 0,
+      judgeFailures: options.judgeFailures ?? 0,
+      searchFailures: options.searchFailures ?? 0,
+      netWinRate: 0,
+    },
+    localeMix: { en: 1 },
+    promptSourceMix: { seed: 1 },
+    generatedCandidateBehavior: {
+      included: 0,
+      searched: 0,
+      traceDerived: 0,
+      skippedTraceDerived: 0,
+      searchFailures: 0,
+    },
+    cost: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalUsd: null,
+      pricingModel: null,
+      estimated: true,
+    },
+    timings: {
+      searchMs: 10,
+      judgeMs: 5,
+      totalMs: 15,
+    },
+    judgeFailures: [],
+    outcomes: [],
+    exploratoryGenerated: [],
+  }
+}
+
+function offlineSuccess(
+  mode: "capture-baseline" | "compare",
+  outputReport = report({
+    kind: mode === "capture-baseline" ? "baseline-report" : "comparison-report",
+  }),
+) {
+  return {
+    ok: true as const,
+    mode,
+    mastraRunId: "offline-run",
+    baselineName: "seed-baseline",
+    baselinePath: "/tmp/search-eval/baselines/seed-baseline.json",
+    reportPath: `/tmp/search-eval/reports/${outputReport.reportId}.json`,
+    report: outputReport,
+  }
+}
+
+function nativeReportSuccess(outputReport = report()) {
+  return {
+    ok: true as const,
+    action: "sync-report" as const,
+    mastraRunId: "native-report-run",
+    environmentLabel: "local",
+    reportId: outputReport.reportId,
+    reportPath: `/tmp/search-eval/reports/${outputReport.reportId}.json`,
+    report: {
+      ...outputReport,
+      mastraEvaluation: nativeSyncedProjection(
+        outputReport.kind,
+        outputReport.reportId,
+      ),
+    },
+    dataset: {
+      datasetId: "dataset-1",
+      name: "search-eval:local:seed-baseline",
+      status: "reused",
+      itemCount: 1,
+      createdItems: 0,
+      updatedItems: 1,
+    },
+    scorer: {
+      scorerId: "scorer-1",
+      status: "reused",
+    },
+    experiment: {
+      experimentId: "experiment-1",
+      status: "reused",
+    },
+  }
+}
+
+function promotedSyncSuccess() {
+  return {
+    ok: true as const,
+    action: "sync-promoted" as const,
+    mastraRunId: "native-promoted-run",
+    environmentLabel: "local",
+    dataset: {
+      datasetId: "dataset-promoted",
+      name: "search-eval:local:promoted-regression",
+      status: "reused",
+      itemCount: 2,
+      createdItems: 0,
+      updatedItems: 2,
+    },
+    scorer: {
+      scorerId: "scorer-1",
+      status: "reused",
+    },
+    promoted: { received: 2 },
+    skipped: [],
+  }
+}
+
+describe("search eval orchestrator workflow", () => {
+  it("defaults to a full seed-baseline capture without candidate generation", () => {
+    expect(
+      _internal.SearchEvalOrchestratorWorkflowInputSchema.parse({}),
+    ).toEqual({
+      mode: "full",
+      baselineName: "seed-baseline",
+      locales: ["en", "es", "fr"],
+      searchLimit: 20,
+      searchMode: "hybrid",
+      contentType: "all",
+      nativeSync: true,
+      syncPromoted: true,
+      promotedLimit: 100,
+      generateCandidates: false,
+      traceLimit: 25,
+      catalogLimit: 30,
+      localeQueryCount: 2,
+      submitSeedCandidates: false,
+      gateMaxLosses: 0,
+      gateMaxSearchFailures: 0,
+      gateMaxJudgeFailures: 0,
+      gateMaxJudgeDisagreements: 0,
+      gateRequireCalibration: true,
+    })
+    expect(searchEvalOrchestratorWorkflow.inputSchema).toBe(
+      _internal.SearchEvalOrchestratorWorkflowInputSchema,
+    )
+  })
+
+  it("runs full mode as offline baseline capture plus native report and promoted sync", async () => {
+    const outputReport = report()
+    const launchOffline = vi.fn(async (input) =>
+      offlineSuccess(input.mode, outputReport),
+    )
+    const launchNative = vi.fn(async (input) =>
+      input.action === "sync-report"
+        ? nativeReportSuccess(outputReport)
+        : promotedSyncSuccess(),
+    )
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {},
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: launchOffline,
+        launchNativeSuite: launchNative,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      mastraRunId: "run-orchestrator",
+      summary: {
+        artifacts: {
+          baselineName: "seed-baseline",
+          reportId: "report-1",
+          reportPath: "/tmp/search-eval/reports/report-1.json",
+        },
+        nativeEvaluation: {
+          reportSync: {
+            datasetId: "dataset-1",
+            scorerIds: ["scorer-1"],
+            experimentId: "experiment-1",
+            integrationStatus: "native_synced",
+          },
+          promotedSync: {
+            datasetId: "dataset-promoted",
+            scorerIds: ["scorer-1"],
+          },
+        },
+        counts: {
+          reportQueries: 1,
+          promotedReceived: 2,
+          nativeCreatedItems: 0,
+          nativeUpdatedItems: 1,
+        },
+        passFail: { state: "not_applicable", reasons: [] },
+      },
+    })
+    expect(launchOffline).toHaveBeenCalledWith(
+      {
+        mode: "capture-baseline",
+        baselineName: "seed-baseline",
+        locales: ["en", "es", "fr"],
+        searchLimit: 20,
+        searchMode: "hybrid",
+        contentType: "all",
+      },
+      { runId: "run-orchestrator-offline-search-eval" },
+    )
+    expect(launchNative).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: "sync-report",
+        reportId: "report-1",
+      }),
+      { runId: "run-orchestrator-native-report-sync" },
+    )
+    expect(launchNative).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: "sync-promoted",
+        promotedLimit: 100,
+      }),
+      { runId: "run-orchestrator-native-promoted-sync" },
+    )
+  })
+
+  it("resumes native report sync by report id without rerunning offline eval", async () => {
+    const launchOffline = vi.fn()
+    const launchNative = vi.fn(async () => nativeReportSuccess(report()))
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {
+        resumeReportId: "report-1",
+        syncPromoted: false,
+      },
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: launchOffline,
+        launchNativeSuite: launchNative,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      summary: {
+        childWorkflowRuns: expect.arrayContaining([
+          expect.objectContaining({
+            workflowId: "offline-search-eval",
+            status: "skipped",
+            action: "resume-report",
+          }),
+        ]),
+        resume: { reportId: "report-1", action: "sync-report" },
+      },
+    })
+    expect(launchOffline).not.toHaveBeenCalled()
+    expect(launchNative).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sync-report",
+        reportId: "report-1",
+      }),
+      { runId: "run-orchestrator-native-report-sync" },
+    )
+  })
+
+  it("evaluates release-gate thresholds from a resumed synced report", async () => {
+    const outputReport = report({
+      kind: "comparison-report",
+      reportId: "report-pass",
+    })
+    const launchOffline = vi.fn()
+    const launchNative = vi.fn(async () => nativeReportSuccess(outputReport))
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {
+        mode: "release-gate",
+        resumeReportId: "report-pass",
+        syncPromoted: false,
+      },
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: launchOffline,
+        launchNativeSuite: launchNative,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      summary: {
+        artifacts: {
+          reportId: "report-pass",
+          reportPath: "/tmp/search-eval/reports/report-pass.json",
+        },
+        counts: {
+          reportQueries: 1,
+          losses: 0,
+          searchFailures: 0,
+        },
+        passFail: { state: "passed", reasons: [] },
+      },
+    })
+    expect(launchOffline).not.toHaveBeenCalled()
+  })
+
+  it("fails release-gate mode when comparison losses exceed the threshold", async () => {
+    const outputReport = report({
+      kind: "comparison-report",
+      losses: 1,
+      reportId: "report-loss",
+    })
+    const launchOffline = vi.fn(async (input) =>
+      offlineSuccess(input.mode, outputReport),
+    )
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {
+        mode: "release-gate",
+        nativeSync: false,
+        syncPromoted: false,
+      },
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: launchOffline,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "release_gate_failed",
+      retryable: false,
+      summary: {
+        artifacts: {
+          reportId: "report-loss",
+          reportPath: "/tmp/search-eval/reports/report-loss.json",
+        },
+        passFail: {
+          state: "failed",
+          reasons: ["losses 1 exceeded max 0"],
+        },
+        resume: {
+          reportId: "report-loss",
+          reportPath: "/tmp/search-eval/reports/report-loss.json",
+          action: "sync-report",
+        },
+      },
+    })
+    expect(launchOffline).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "compare" }),
+      { runId: "run-orchestrator-offline-search-eval" },
+    )
+  })
+
+  it.each([
+    [
+      "calibration",
+      { calibrationPassed: false },
+      "judge calibration did not pass",
+    ],
+    [
+      "skipped calibration",
+      { calibrationSkipped: true },
+      "judge calibration did not pass",
+    ],
+    [
+      "search failures",
+      { searchFailures: 1 },
+      "search failures 1 exceeded max 0",
+    ],
+    ["judge failures", { judgeFailures: 1 }, "judge failures 1 exceeded max 0"],
+    [
+      "judge disagreements",
+      { judgeDisagreements: 1 },
+      "judge disagreements 1 exceeded max 0",
+    ],
+  ] as const)(
+    "fails release-gate mode when %s violates the gate",
+    async (_name, reportOptions, expectedReason) => {
+      const outputReport = report({
+        kind: "comparison-report",
+        reportId: "report-gate",
+        ...reportOptions,
+      })
+
+      const result = await runSearchEvalOrchestratorWorkflow(
+        {
+          mode: "release-gate",
+          nativeSync: false,
+          syncPromoted: false,
+        },
+        {
+          runId: "run-orchestrator",
+          launchOfflineSearchEval: vi.fn(async (input) =>
+            offlineSuccess(input.mode, outputReport),
+          ),
+        },
+      )
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "release_gate_failed",
+        summary: {
+          passFail: {
+            state: "failed",
+            reasons: [expectedReason],
+          },
+        },
+      })
+    },
+  )
+
+  it("passes release-gate mode when comparison report stays within thresholds", async () => {
+    const outputReport = report({
+      kind: "comparison-report",
+      reportId: "report-pass",
+    })
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {
+        mode: "release-gate",
+        nativeSync: false,
+        syncPromoted: false,
+      },
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: vi.fn(async (input) =>
+          offlineSuccess(input.mode, outputReport),
+        ),
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      summary: {
+        passFail: { state: "passed", reasons: [] },
+      },
+    })
+  })
+
+  it("preserves report resume details when native report sync fails", async () => {
+    const outputReport = report({ reportId: "report-sync" })
+    const launchOffline = vi.fn(async (input) =>
+      offlineSuccess(input.mode, outputReport),
+    )
+    const launchNative = vi.fn(async () => ({
+      ok: false as const,
+      reason: "native_sync_failed" as const,
+      retryable: true,
+    }))
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      { syncPromoted: false },
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: launchOffline,
+        launchNativeSuite: launchNative,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "native_report_sync_failed",
+      retryable: true,
+      summary: {
+        artifacts: {
+          reportId: "report-sync",
+          reportPath: "/tmp/search-eval/reports/report-sync.json",
+        },
+        resume: {
+          reportId: "report-sync",
+          reportPath: "/tmp/search-eval/reports/report-sync.json",
+          action: "sync-report",
+        },
+      },
+    })
+  })
+
+  it("preserves report resume details when offline eval writes a partial report before failing", async () => {
+    const launchOffline = vi.fn(async () => ({
+      ok: false as const,
+      reason: "judge_failed" as const,
+      retryable: true,
+      reportPath: "/tmp/search-eval/reports/report-partial.json",
+    }))
+    const launchNative = vi.fn()
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {},
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: launchOffline,
+        launchNativeSuite: launchNative,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "offline_eval_failed",
+      retryable: true,
+      summary: {
+        childWorkflowRuns: [
+          expect.objectContaining({
+            workflowId: "offline-search-eval",
+            status: "failed",
+            action: "capture-baseline",
+            reason: "judge_failed",
+            retryable: true,
+          }),
+        ],
+        artifacts: {
+          reportId: "report-partial",
+          reportPath: "/tmp/search-eval/reports/report-partial.json",
+        },
+        resume: {
+          reportId: "report-partial",
+          reportPath: "/tmp/search-eval/reports/report-partial.json",
+          action: "sync-report",
+        },
+      },
+    })
+    expect(launchNative).not.toHaveBeenCalled()
+  })
+
+  it("preserves report resume details when promoted native sync fails", async () => {
+    const outputReport = report({ reportId: "report-promoted" })
+    const launchNative = vi.fn(async (input) =>
+      input.action === "sync-report"
+        ? nativeReportSuccess(outputReport)
+        : {
+            ok: false as const,
+            reason: "runtime_unavailable" as const,
+            retryable: true,
+          },
+    )
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {},
+      {
+        runId: "run-orchestrator",
+        launchOfflineSearchEval: vi.fn(async (input) =>
+          offlineSuccess(input.mode, outputReport),
+        ),
+        launchNativeSuite: launchNative,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "promoted_sync_failed",
+      retryable: true,
+      summary: {
+        childWorkflowRuns: expect.arrayContaining([
+          expect.objectContaining({
+            workflowId: "search-eval-native-suite",
+            status: "failed",
+            action: "sync-promoted",
+            reason: "runtime_unavailable",
+          }),
+        ]),
+        artifacts: {
+          reportId: "report-promoted",
+          reportPath: "/tmp/search-eval/reports/report-promoted.json",
+        },
+        resume: {
+          reportId: "report-promoted",
+          reportPath: "/tmp/search-eval/reports/report-promoted.json",
+          action: "sync-report",
+        },
+      },
+    })
+  })
+
+  it("short-circuits with child metadata when candidate generation fails", async () => {
+    const launchOffline = vi.fn()
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      { generateCandidates: true },
+      {
+        runId: "run-orchestrator",
+        launchEvalQueryGeneration: vi.fn(async () => ({
+          ok: false as const,
+          reason: "generation_config_missing" as const,
+          retryable: false,
+        })),
+        launchOfflineSearchEval: launchOffline,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "candidate_generation_failed",
+      retryable: false,
+      summary: {
+        childWorkflowRuns: [
+          {
+            workflowId: "eval-query-generation",
+            runId: "run-orchestrator-eval-query-generation",
+            status: "failed",
+            reason: "generation_config_missing",
+            retryable: false,
+          },
+        ],
+      },
+    })
+    expect(launchOffline).not.toHaveBeenCalled()
+  })
+
+  it("short-circuits with child metadata when seed candidate submission fails", async () => {
+    const launchOffline = vi.fn()
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      { submitSeedCandidates: true },
+      {
+        runId: "run-orchestrator",
+        launchCandidateReview: vi.fn(async () => ({
+          ok: false as const,
+          reason: "admin_store_rejected" as const,
+          retryable: false,
+        })),
+        launchOfflineSearchEval: launchOffline,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "seed_submit_failed",
+      retryable: false,
+      summary: {
+        childWorkflowRuns: [
+          {
+            workflowId: "search-eval-candidate-review",
+            runId: "run-orchestrator-submit-seed-candidates",
+            status: "failed",
+            action: "submit-seed",
+            reason: "admin_store_rejected",
+            retryable: false,
+          },
+        ],
+      },
+    })
+    expect(launchOffline).not.toHaveBeenCalled()
+  })
+
+  it("stages generated and seed candidates without calling promote", async () => {
+    const launchGeneration = vi.fn(async () => ({
+      ok: true as const,
+      mastraRunId: "generation-run",
+      storedCount: 2,
+      skippedCount: 1,
+      generatedCount: 3,
+      sourceCounts: { catalog: 1, locale_quality: 1, trace: 1 },
+    }))
+    const launchCandidateReview = vi.fn(async (input) => ({
+      ok: true as const,
+      action: input.action,
+      mastraRunId: "seed-run",
+      storeResult: {
+        storedCount: 3,
+        skippedCount: 0,
+        candidates: [],
+        skipped: [],
+      },
+      nativeDatasetItemShape: {},
+    }))
+    const launchOffline = vi.fn(async (input) => offlineSuccess(input.mode))
+
+    const result = await runSearchEvalOrchestratorWorkflow(
+      {
+        generateCandidates: true,
+        submitSeedCandidates: true,
+        nativeSync: false,
+        syncPromoted: false,
+      },
+      {
+        runId: "run-orchestrator",
+        launchEvalQueryGeneration: launchGeneration,
+        launchCandidateReview,
+        launchOfflineSearchEval: launchOffline,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      summary: {
+        counts: {
+          generatedCandidates: 3,
+          storedCandidates: 5,
+          skippedCandidates: 1,
+        },
+      },
+    })
+    expect(launchCandidateReview).toHaveBeenCalledWith(
+      { action: "submit-seed", seedLocales: ["en", "es", "fr"] },
+      { runId: "run-orchestrator-submit-seed-candidates" },
+    )
+    expect(
+      launchCandidateReview.mock.calls.some(
+        ([input]) => input.action === "promote",
+      ),
+    ).toBe(false)
+  })
+
+  it("requires service bearer auth before launching from the route", async () => {
+    const launch = vi.fn()
+    const response = await handleSearchEvalOrchestratorRouteRequest({
+      authHeader: "Bearer wrong",
+      serviceKeys: ["service-key"],
+      readJson: async () => ({}),
+      launch,
+    })
+
+    expect(response).toEqual({
+      status: 401,
+      body: { error: "Service bearer required" },
+    })
+    expect(launch).not.toHaveBeenCalled()
+  })
+
+  it("launches parsed default input for a valid service bearer", async () => {
+    const launch = vi.fn(async (input, { runId }) => ({
+      ok: true as const,
+      mastraRunId: runId,
+      summary: {
+        mode: input.mode,
+        baselineName: input.baselineName,
+        childWorkflowRuns: [],
+        artifacts: { baselineName: input.baselineName },
+        nativeEvaluation: {},
+        counts: {},
+        passFail: { state: "not_applicable" as const, reasons: [] },
+      },
+    }))
+
+    const response = await handleSearchEvalOrchestratorRouteRequest({
+      authHeader: "Bearer service-key",
+      serviceKeys: ["service-key"],
+      readJson: async () => ({}),
+      launch,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.body.result).toMatchObject({ ok: true })
+    expect(launch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "full",
+        baselineName: "seed-baseline",
+        nativeSync: true,
+        syncPromoted: true,
+      }),
+      { runId: expect.any(String) },
+    )
+  })
+
+  it.each([
+    [
+      "offline missing baseline",
+      "offline_eval_failed",
+      "artifact_not_found",
+      404,
+    ],
+    [
+      "native runtime unavailable",
+      "native_report_sync_failed",
+      "runtime_unavailable",
+      503,
+    ],
+    ["seed submit rejected", "seed_submit_failed", "admin_store_rejected", 409],
+  ] as const)(
+    "maps %s child failure to HTTP %i",
+    async (_name, reason, childReason, status) => {
+      const launch = vi.fn(async (input, { runId }) => ({
+        ok: false as const,
+        reason,
+        retryable: childReason !== "admin_store_rejected",
+        mastraRunId: runId,
+        summary: {
+          mode: input.mode,
+          baselineName: input.baselineName,
+          childWorkflowRuns: [
+            {
+              workflowId: "offline-search-eval" as const,
+              runId: `${runId}-offline-search-eval`,
+              status: "failed" as const,
+              reason: childReason,
+              retryable: childReason !== "admin_store_rejected",
+            },
+          ],
+          artifacts: { baselineName: input.baselineName },
+          nativeEvaluation: {},
+          counts: {},
+          passFail: { state: "not_applicable" as const, reasons: [] },
+        },
+      }))
+
+      const response = await handleSearchEvalOrchestratorRouteRequest({
+        authHeader: "Bearer service-key",
+        serviceKeys: ["service-key"],
+        readJson: async () => ({}),
+        launch,
+      })
+
+      expect(response.status).toBe(status)
+      expect(response.body.result).toMatchObject({
+        ok: false,
+        reason,
+        summary: {
+          childWorkflowRuns: [expect.objectContaining({ reason: childReason })],
+        },
+      })
+    },
+  )
+
+  it("rejects oversized route bodies before launching", async () => {
+    const launch = vi.fn()
+    const response = await handleSearchEvalOrchestratorRouteRequest({
+      authHeader: "Bearer service-key",
+      serviceKeys: ["service-key"],
+      request: new Request(
+        "https://mastra.test/forge-search-eval-orchestrator",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          duplex: "half",
+          body: new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(12289))
+              controller.close()
+            },
+          }),
+        } as RequestInit & { duplex: "half" },
+      ),
+      launch,
+    })
+
+    expect(response.status).toBe(413)
+    expect(response.body.result).toMatchObject({
+      ok: false,
+      reason: "invalid_input",
+    })
+    expect(launch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts
@@ -942,6 +942,61 @@ describe("search eval orchestrator workflow", () => {
     },
   )
 
+  it("extracts Mastra-wrapped workflow failures with trailing stack text", () => {
+    const failure = {
+      ok: false as const,
+      reason: "offline_eval_failed" as const,
+      retryable: false,
+      mastraRunId: "run-real-data",
+      summary: {
+        mode: "full" as const,
+        baselineName: "real-world-smoke",
+        childWorkflowRuns: [
+          {
+            workflowId: "offline-search-eval" as const,
+            runId: "run-real-data-offline-search-eval",
+            status: "failed" as const,
+            action: "capture-baseline",
+            reason: "admin_config_missing",
+            retryable: false,
+          },
+        ],
+        artifacts: { baselineName: "real-world-smoke" },
+        nativeEvaluation: {},
+        counts: {},
+        passFail: { state: "not_applicable" as const, reasons: [] },
+      },
+    }
+    const wrapped = new Error(
+      `Error executing step workflow.search-eval-orchestrator: ` +
+        `SearchEvalOrchestratorWorkflowFailureError: ` +
+        `SEARCH_EVAL_ORCHESTRATOR_FAILED:${JSON.stringify(failure)}\n` +
+        "    at executeStep (chunk.js:1:1)",
+    )
+
+    expect(_internal.workflowFailureFromUnknown(wrapped)).toEqual(failure)
+    expect(_internal.routeStatusForResult(failure)).toBe(503)
+
+    const stackWrapped = new Error("Error executing workflow step")
+    stackWrapped.stack =
+      `Error: Error executing workflow step\n` +
+      `Caused by: SearchEvalOrchestratorWorkflowFailureError: ` +
+      `SEARCH_EVAL_ORCHESTRATOR_FAILED:${JSON.stringify(failure)}\n` +
+      "    at executeStep (chunk.js:1:1)"
+
+    expect(_internal.workflowFailureFromUnknown(stackWrapped)).toEqual(failure)
+    expect(
+      _internal.workflowFailureFromRunResult({
+        status: "failed",
+        error: {
+          message: `SEARCH_EVAL_ORCHESTRATOR_FAILED:${JSON.stringify(failure)}`,
+          name: "SearchEvalOrchestratorWorkflowFailureError",
+          result: failure,
+        },
+      }),
+    ).toEqual(failure)
+  })
+
   it("rejects oversized route bodies before launching", async () => {
     const launch = vi.fn()
     const response = await handleSearchEvalOrchestratorRouteRequest({

--- a/apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts
@@ -309,6 +309,51 @@ class OrchestratorRouteBodyError extends Error {
   }
 }
 
+function parseFirstJsonObjectAfterPrefix(
+  message: string,
+  prefix: string,
+): unknown | null {
+  const prefixIndex = message.indexOf(prefix)
+  if (prefixIndex < 0) return null
+
+  const startIndex = message.indexOf("{", prefixIndex + prefix.length)
+  if (startIndex < 0) return null
+
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let index = startIndex; index < message.length; index += 1) {
+    const char = message[index]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (char === "\\") {
+        escaped = true
+      } else if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+    } else if (char === "{") {
+      depth += 1
+    } else if (char === "}") {
+      depth -= 1
+      if (depth === 0) {
+        try {
+          return JSON.parse(message.slice(startIndex, index + 1))
+        } catch {
+          return null
+        }
+      }
+    }
+  }
+
+  return null
+}
+
 function childRunId(parentRunId: string, suffix: string): string {
   return `${parentRunId}-${suffix}`.replace(/[^a-zA-Z0-9._-]/g, "-")
 }
@@ -804,27 +849,37 @@ function throwWorkflowFailure(result: SearchEvalOrchestratorFailure): never {
 function workflowFailureFromUnknown(
   value: unknown,
 ): SearchEvalOrchestratorFailure | null {
+  const directParsed = SearchEvalOrchestratorResultSchema.safeParse(value)
+  if (directParsed.success && !directParsed.data.ok) return directParsed.data
+
   if (value instanceof SearchEvalOrchestratorWorkflowFailureError) {
     return value.result
   }
-  const message =
+  const texts =
     value instanceof Error
-      ? value.message
+      ? [value.message, value.stack].filter((text): text is string =>
+          Boolean(text),
+        )
       : typeof value === "string"
-        ? value
-        : ""
-  const prefixIndex = message.indexOf(WORKFLOW_FAILURE_ERROR_PREFIX)
-  if (prefixIndex < 0) return null
-  let payload: unknown
-  try {
-    payload = JSON.parse(
-      message.slice(prefixIndex + WORKFLOW_FAILURE_ERROR_PREFIX.length),
+        ? [value]
+        : []
+  for (const text of texts) {
+    const payload = parseFirstJsonObjectAfterPrefix(
+      text,
+      WORKFLOW_FAILURE_ERROR_PREFIX,
     )
-  } catch {
-    return null
+    if (payload == null) continue
+    const parsed = SearchEvalOrchestratorResultSchema.safeParse(payload)
+    if (parsed.success && !parsed.data.ok) return parsed.data
   }
-  const parsed = SearchEvalOrchestratorResultSchema.safeParse(payload)
-  return parsed.success && !parsed.data.ok ? parsed.data : null
+
+  const valueRecord = record(value)
+  if (!valueRecord) return null
+  return (
+    workflowFailureFromUnknown(valueRecord.result) ??
+    workflowFailureFromUnknown(valueRecord.cause) ??
+    workflowFailureFromUnknown(valueRecord.error)
+  )
 }
 
 function workflowFailureFromRunResult(

--- a/apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts
@@ -1,0 +1,1047 @@
+import { basename, extname } from "node:path"
+import { randomUUID } from "node:crypto"
+
+import { createStep, createWorkflow } from "@mastra/core/workflows"
+import { z } from "zod"
+
+import { isValidServiceBearer } from "../../server/service-bearer"
+import { SEARCH_EVAL_SEED_PROMPT_LOCALES } from "../../services/offline-search-eval/seed-prompt-set"
+import type { SearchEvalReport } from "../../services/offline-search-eval/types"
+import {
+  launchEvalQueryGenerationWorkflow,
+  type EvalQueryGenerationWorkflowResult,
+} from "./eval-query-generation"
+import { launchOfflineSearchEvalWorkflow } from "./offline-search-eval"
+import {
+  launchSearchEvalCandidateReviewWorkflow,
+  type SearchEvalCandidateReviewWorkflowResult,
+} from "./search-eval-candidate-review"
+import {
+  launchSearchEvalNativeSuiteWorkflow,
+  type SearchEvalNativeSuiteWorkflowResult,
+} from "./search-eval-native-suite"
+
+export const SEARCH_EVAL_ORCHESTRATOR_MAX_BODY_BYTES = 12288
+const WORKFLOW_FAILURE_ERROR_PREFIX = "SEARCH_EVAL_ORCHESTRATOR_FAILED:"
+const DEFAULT_BASELINE_NAME = "seed-baseline"
+const DEFAULT_SEARCH_MODE = "hybrid"
+const DEFAULT_CONTENT_TYPE = "all"
+
+const SafeNameSchema = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/)
+
+const SourceSchema = z.enum(["catalog", "locale_quality", "trace"])
+
+export const SearchEvalOrchestratorWorkflowInputSchema = z
+  .object({
+    mode: z
+      .enum(["full", "compare", "release-gate"])
+      .default("full")
+      .describe(
+        "full captures a seed baseline; compare compares against a baseline; release-gate compares and evaluates thresholds.",
+      ),
+    baselineName: SafeNameSchema.default(DEFAULT_BASELINE_NAME).describe(
+      "Named baseline artifact to capture or compare against.",
+    ),
+    locales: z
+      .array(z.string().min(1).max(32))
+      .min(1)
+      .max(30)
+      .default(() => [...SEARCH_EVAL_SEED_PROMPT_LOCALES])
+      .describe("Locales to evaluate. Defaults to every seeded locale."),
+    searchLimit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(50)
+      .default(20)
+      .describe("Admin search result limit per prompt."),
+    searchMode: z
+      .enum(["hybrid", "keyword-first"])
+      .default(DEFAULT_SEARCH_MODE)
+      .describe("Admin search pipeline to evaluate."),
+    contentType: z
+      .enum(["all", "video", "experience"])
+      .default(DEFAULT_CONTENT_TYPE)
+      .describe("Content filter. all searches videos and experiences."),
+    environmentLabel: z
+      .string()
+      .min(1)
+      .max(64)
+      .optional()
+      .describe("Native Evaluation environment label."),
+    nativeSync: z
+      .boolean()
+      .default(true)
+      .describe("Sync the resulting report into native Evaluation."),
+    syncPromoted: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Sync already-promoted Admin candidates into native Evaluation.",
+      ),
+    promotedLimit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(100)
+      .default(100)
+      .describe("Maximum promoted candidates to sync."),
+    generateCandidates: z
+      .boolean()
+      .default(false)
+      .describe("Optionally stage generated candidates before running eval."),
+    generationSources: z
+      .array(SourceSchema)
+      .min(1)
+      .max(3)
+      .optional()
+      .describe("Candidate-generation sources when generation is enabled."),
+    traceLimit: z.coerce.number().int().positive().max(100).default(25),
+    catalogLimit: z.coerce.number().int().positive().max(100).default(30),
+    localeQueryCount: z.coerce.number().int().positive().max(10).default(2),
+    submitSeedCandidates: z
+      .boolean()
+      .default(false)
+      .describe("Submit committed seed prompts as pending Admin candidates."),
+    resumeReportId: SafeNameSchema.optional().describe(
+      "Existing report id to sync without rerunning offline search eval.",
+    ),
+    gateMaxLosses: z.coerce.number().int().nonnegative().max(100).default(0),
+    gateMaxSearchFailures: z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .max(100)
+      .default(0),
+    gateMaxJudgeFailures: z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .max(100)
+      .default(0),
+    gateMaxJudgeDisagreements: z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .max(100)
+      .default(0),
+    gateRequireCalibration: z.boolean().default(true),
+  })
+  .strict()
+
+export type SearchEvalOrchestratorWorkflowInput = z.output<
+  typeof SearchEvalOrchestratorWorkflowInputSchema
+>
+
+const ChildWorkflowRunSchema = z
+  .object({
+    workflowId: z.enum([
+      "eval-query-generation",
+      "search-eval-candidate-review",
+      "offline-search-eval",
+      "search-eval-native-suite",
+    ]),
+    runId: z.string(),
+    status: z.enum(["succeeded", "failed", "skipped"]),
+    action: z.string().optional(),
+    reason: z.string().optional(),
+    retryable: z.boolean().optional(),
+  })
+  .strict()
+
+const CountsSchema = z
+  .object({
+    generatedCandidates: z.number().int().nonnegative().optional(),
+    storedCandidates: z.number().int().nonnegative().optional(),
+    skippedCandidates: z.number().int().nonnegative().optional(),
+    baselineCases: z.number().int().nonnegative().optional(),
+    reportQueries: z.number().int().nonnegative().optional(),
+    wins: z.number().int().nonnegative().optional(),
+    losses: z.number().int().nonnegative().optional(),
+    ties: z.number().int().nonnegative().optional(),
+    bothIrrelevant: z.number().int().nonnegative().optional(),
+    judgeDisagreements: z.number().int().nonnegative().optional(),
+    judgeFailures: z.number().int().nonnegative().optional(),
+    searchFailures: z.number().int().nonnegative().optional(),
+    promotedReceived: z.number().int().nonnegative().optional(),
+    promotedSkipped: z.number().int().nonnegative().optional(),
+    nativeCreatedItems: z.number().int().nonnegative().optional(),
+    nativeUpdatedItems: z.number().int().nonnegative().optional(),
+  })
+  .strict()
+
+const NativeSummarySchema = z
+  .object({
+    reportSync: z
+      .object({
+        datasetId: z.string().optional(),
+        datasetName: z.string().optional(),
+        scorerIds: z.array(z.string()),
+        experimentId: z.string().optional(),
+        integrationStatus: z
+          .enum(["custom_artifact_only", "native_synced"])
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    promotedSync: z
+      .object({
+        datasetId: z.string().optional(),
+        datasetName: z.string().optional(),
+        scorerIds: z.array(z.string()),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const PassFailSchema = z
+  .object({
+    state: z.enum(["passed", "failed", "not_applicable"]),
+    reasons: z.array(z.string()),
+  })
+  .strict()
+
+const ResumeSchema = z
+  .object({
+    reportId: z.string().optional(),
+    reportPath: z.string().optional(),
+    action: z.enum(["sync-report"]).optional(),
+  })
+  .strict()
+
+const SummarySchema = z
+  .object({
+    mode: SearchEvalOrchestratorWorkflowInputSchema.shape.mode,
+    baselineName: z.string(),
+    childWorkflowRuns: z.array(ChildWorkflowRunSchema),
+    artifacts: z
+      .object({
+        baselineName: z.string(),
+        baselinePath: z.string().optional(),
+        reportId: z.string().optional(),
+        reportPath: z.string().optional(),
+      })
+      .strict(),
+    nativeEvaluation: NativeSummarySchema,
+    counts: CountsSchema,
+    passFail: PassFailSchema,
+    resume: ResumeSchema.optional(),
+  })
+  .strict()
+
+const FailureReasonSchema = z.enum([
+  "invalid_input",
+  "candidate_generation_failed",
+  "seed_submit_failed",
+  "offline_eval_failed",
+  "native_report_sync_failed",
+  "promoted_sync_failed",
+  "release_gate_failed",
+  "orchestration_failed",
+])
+
+const SearchEvalOrchestratorResultSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      mastraRunId: z.string(),
+      summary: SummarySchema,
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      reason: FailureReasonSchema,
+      retryable: z.boolean(),
+      mastraRunId: z.string(),
+      summary: SummarySchema,
+    })
+    .strict(),
+])
+
+export type SearchEvalOrchestratorWorkflowResult = z.infer<
+  typeof SearchEvalOrchestratorResultSchema
+>
+type SearchEvalOrchestratorFailure = Extract<
+  SearchEvalOrchestratorWorkflowResult,
+  { ok: false }
+>
+type OfflineSearchEvalWorkflowResult = Awaited<
+  ReturnType<typeof launchOfflineSearchEvalWorkflow>
+>
+
+type WorkflowOptions = {
+  runId?: string
+  launchEvalQueryGeneration?: typeof launchEvalQueryGenerationWorkflow
+  launchCandidateReview?: typeof launchSearchEvalCandidateReviewWorkflow
+  launchOfflineSearchEval?: typeof launchOfflineSearchEvalWorkflow
+  launchNativeSuite?: typeof launchSearchEvalNativeSuiteWorkflow
+}
+
+type RouteHandlerInput = {
+  authHeader: string | null | undefined
+  serviceKeys: readonly string[]
+  request?: Request
+  readJson?: () => Promise<unknown>
+  launch?: (
+    input: SearchEvalOrchestratorWorkflowInput,
+    options: { runId: string },
+  ) => Promise<SearchEvalOrchestratorWorkflowResult>
+}
+
+export type SearchEvalOrchestratorRouteOutcome = {
+  status: number
+  body: { result?: SearchEvalOrchestratorWorkflowResult; error?: string }
+}
+
+class SearchEvalOrchestratorWorkflowFailureError extends Error {
+  constructor(readonly result: SearchEvalOrchestratorFailure) {
+    super(`${WORKFLOW_FAILURE_ERROR_PREFIX}${JSON.stringify(result)}`)
+    this.name = "SearchEvalOrchestratorWorkflowFailureError"
+  }
+}
+
+class OrchestratorRouteBodyError extends Error {
+  constructor(readonly code: "payload_too_large" | "invalid_json") {
+    super(code)
+    this.name = "OrchestratorRouteBodyError"
+  }
+}
+
+function childRunId(parentRunId: string, suffix: string): string {
+  return `${parentRunId}-${suffix}`.replace(/[^a-zA-Z0-9._-]/g, "-")
+}
+
+function reportIdFromPath(reportPath: string | undefined): string | undefined {
+  if (!reportPath) return undefined
+  const name = basename(reportPath)
+  return extname(name) === ".json" ? name.slice(0, -5) : undefined
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function stringField(value: unknown, field: string): string | undefined {
+  const container = record(value)
+  const fieldValue = container?.[field]
+  return typeof fieldValue === "string" ? fieldValue : undefined
+}
+
+function numberField(value: unknown, field: string): number | undefined {
+  const container = record(value)
+  const fieldValue = container?.[field]
+  return typeof fieldValue === "number" ? fieldValue : undefined
+}
+
+function childFailureReason(result: { ok: false; reason: string }) {
+  return result.reason
+}
+
+function childRetryable(result: { ok: false; retryable: boolean }) {
+  return result.retryable
+}
+
+function initialSummary(
+  input: SearchEvalOrchestratorWorkflowInput,
+): z.infer<typeof SummarySchema> {
+  return {
+    mode: input.mode,
+    baselineName: input.baselineName,
+    childWorkflowRuns: [],
+    artifacts: { baselineName: input.baselineName },
+    nativeEvaluation: {},
+    counts: {},
+    passFail: { state: "not_applicable", reasons: [] },
+  }
+}
+
+function failure(
+  reason: z.infer<typeof FailureReasonSchema>,
+  options: {
+    retryable: boolean
+    mastraRunId: string
+    summary: z.infer<typeof SummarySchema>
+  },
+): SearchEvalOrchestratorFailure {
+  return {
+    ok: false,
+    reason,
+    retryable: options.retryable,
+    mastraRunId: options.mastraRunId,
+    summary: options.summary,
+  }
+}
+
+function addFailedChild(
+  summary: z.infer<typeof SummarySchema>,
+  child: {
+    workflowId: z.infer<typeof ChildWorkflowRunSchema>["workflowId"]
+    runId: string
+    action?: string
+    result: { ok: false; reason: string; retryable: boolean }
+  },
+) {
+  summary.childWorkflowRuns.push({
+    workflowId: child.workflowId,
+    runId: child.runId,
+    status: "failed",
+    action: child.action,
+    reason: childFailureReason(child.result),
+    retryable: childRetryable(child.result),
+  })
+}
+
+function updateCountsFromCandidateGeneration(
+  summary: z.infer<typeof SummarySchema>,
+  result: Extract<EvalQueryGenerationWorkflowResult, { ok: true }>,
+) {
+  summary.counts.generatedCandidates = result.generatedCount
+  summary.counts.storedCandidates = result.storedCount
+  summary.counts.skippedCandidates = result.skippedCount
+}
+
+function updateCountsFromCandidateStore(
+  summary: z.infer<typeof SummarySchema>,
+  result: Extract<SearchEvalCandidateReviewWorkflowResult, { ok: true }>,
+) {
+  const storeResult = record(result.storeResult)
+  const stored = numberField(storeResult, "storedCount")
+  const skipped = numberField(storeResult, "skippedCount")
+  if (stored != null) {
+    summary.counts.storedCandidates =
+      (summary.counts.storedCandidates ?? 0) + stored
+  }
+  if (skipped != null) {
+    summary.counts.skippedCandidates =
+      (summary.counts.skippedCandidates ?? 0) + skipped
+  }
+}
+
+function updateFromOfflineResult(
+  summary: z.infer<typeof SummarySchema>,
+  result: Extract<OfflineSearchEvalWorkflowResult, { ok: true }>,
+) {
+  summary.artifacts.baselineName = result.baselineName
+  summary.artifacts.baselinePath = result.baselinePath
+  summary.artifacts.reportId = result.report.reportId
+  summary.artifacts.reportPath = result.reportPath
+  updateFromReport(summary, result.report)
+}
+
+function updateFromReport(
+  summary: z.infer<typeof SummarySchema>,
+  report: SearchEvalReport,
+) {
+  summary.counts.baselineCases = report.baseline?.caseCount
+  summary.counts.reportQueries = report.totals.queries
+  summary.counts.wins = report.totals.wins
+  summary.counts.losses = report.totals.losses
+  summary.counts.ties = report.totals.ties
+  summary.counts.bothIrrelevant = report.totals.bothIrrelevant
+  summary.counts.judgeDisagreements = report.totals.judgeDisagreements
+  summary.counts.judgeFailures = report.totals.judgeFailures
+  summary.counts.searchFailures = report.totals.searchFailures
+}
+
+function scorerIdsFrom(result: SearchEvalNativeSuiteWorkflowResult): string[] {
+  const scorerId = stringField(
+    result.ok ? result.scorer : undefined,
+    "scorerId",
+  )
+  return scorerId ? [scorerId] : []
+}
+
+function updateFromNativeReportSync(
+  summary: z.infer<typeof SummarySchema>,
+  result: Extract<SearchEvalNativeSuiteWorkflowResult, { ok: true }>,
+) {
+  const report = record(result.report)
+  const projection = record(report?.mastraEvaluation)
+  if (result.report) {
+    summary.artifacts.reportId = result.report.reportId
+    updateFromReport(summary, result.report)
+  }
+  if (result.reportPath) {
+    summary.artifacts.reportPath = result.reportPath
+  }
+  summary.nativeEvaluation.reportSync = {
+    datasetId: stringField(result.dataset, "datasetId"),
+    datasetName: stringField(result.dataset, "name"),
+    scorerIds: scorerIdsFrom(result),
+    experimentId: stringField(result.experiment, "experimentId"),
+    integrationStatus:
+      projection?.integrationStatus === "custom_artifact_only" ||
+      projection?.integrationStatus === "native_synced"
+        ? projection.integrationStatus
+        : undefined,
+  }
+  summary.counts.nativeCreatedItems = numberField(
+    result.dataset,
+    "createdItems",
+  )
+  summary.counts.nativeUpdatedItems = numberField(
+    result.dataset,
+    "updatedItems",
+  )
+}
+
+function updateFromPromotedSync(
+  summary: z.infer<typeof SummarySchema>,
+  result: Extract<SearchEvalNativeSuiteWorkflowResult, { ok: true }>,
+) {
+  const promoted = record(result.promoted)
+  summary.nativeEvaluation.promotedSync = {
+    datasetId: stringField(result.dataset, "datasetId"),
+    datasetName: stringField(result.dataset, "name"),
+    scorerIds: scorerIdsFrom(result),
+  }
+  summary.counts.promotedReceived = numberField(promoted, "received")
+  summary.counts.promotedSkipped = result.skipped?.length
+}
+
+function evaluateReleaseGate(
+  input: SearchEvalOrchestratorWorkflowInput,
+  report: SearchEvalReport | undefined,
+): z.infer<typeof PassFailSchema> {
+  if (input.mode !== "release-gate") {
+    return { state: "not_applicable", reasons: [] }
+  }
+  if (!report) {
+    return { state: "failed", reasons: ["comparison report was not produced"] }
+  }
+  if (report.kind !== "comparison-report") {
+    return {
+      state: "failed",
+      reasons: ["release gate requires a comparison report"],
+    }
+  }
+
+  const reasons: string[] = []
+  if (
+    input.gateRequireCalibration &&
+    (!report.calibration.passed || report.calibration.skipped)
+  ) {
+    reasons.push("judge calibration did not pass")
+  }
+  if (report.totals.losses > input.gateMaxLosses) {
+    reasons.push(
+      `losses ${report.totals.losses} exceeded max ${input.gateMaxLosses}`,
+    )
+  }
+  if (report.totals.searchFailures > input.gateMaxSearchFailures) {
+    reasons.push(
+      `search failures ${report.totals.searchFailures} exceeded max ${input.gateMaxSearchFailures}`,
+    )
+  }
+  if (report.totals.judgeFailures > input.gateMaxJudgeFailures) {
+    reasons.push(
+      `judge failures ${report.totals.judgeFailures} exceeded max ${input.gateMaxJudgeFailures}`,
+    )
+  }
+  if (report.totals.judgeDisagreements > input.gateMaxJudgeDisagreements) {
+    reasons.push(
+      `judge disagreements ${report.totals.judgeDisagreements} exceeded max ${input.gateMaxJudgeDisagreements}`,
+    )
+  }
+
+  return {
+    state: reasons.length === 0 ? "passed" : "failed",
+    reasons,
+  }
+}
+
+function offlineInputFor(input: SearchEvalOrchestratorWorkflowInput) {
+  return {
+    mode:
+      input.mode === "full"
+        ? ("capture-baseline" as const)
+        : ("compare" as const),
+    baselineName: input.baselineName,
+    locales: input.locales,
+    searchLimit: input.searchLimit,
+    searchMode: input.searchMode,
+    contentType: input.contentType,
+  }
+}
+
+function generationInputFor(input: SearchEvalOrchestratorWorkflowInput) {
+  return {
+    sources: input.generationSources,
+    locales: input.locales,
+    traceLimit: input.traceLimit,
+    catalogLimit: input.catalogLimit,
+    localeQueryCount: input.localeQueryCount,
+  }
+}
+
+function resume(summary: z.infer<typeof SummarySchema>) {
+  const reportId = summary.artifacts.reportId
+  const reportPath = summary.artifacts.reportPath
+  if (!reportId && !reportPath) return
+  summary.resume = {
+    reportId,
+    reportPath,
+    action: reportId ? "sync-report" : undefined,
+  }
+}
+
+export async function runSearchEvalOrchestratorWorkflow(
+  rawInput: unknown,
+  options: WorkflowOptions = {},
+): Promise<SearchEvalOrchestratorWorkflowResult> {
+  const parsed = SearchEvalOrchestratorWorkflowInputSchema.safeParse(rawInput)
+  const mastraRunId = options.runId ?? randomUUID()
+  if (!parsed.success) {
+    return failure("invalid_input", {
+      retryable: false,
+      mastraRunId,
+      summary: initialSummary(
+        SearchEvalOrchestratorWorkflowInputSchema.parse({}),
+      ),
+    })
+  }
+
+  const input = parsed.data
+  const summary = initialSummary(input)
+  const launchGeneration =
+    options.launchEvalQueryGeneration ?? launchEvalQueryGenerationWorkflow
+  const launchCandidateReview =
+    options.launchCandidateReview ?? launchSearchEvalCandidateReviewWorkflow
+  const launchOffline =
+    options.launchOfflineSearchEval ?? launchOfflineSearchEvalWorkflow
+  const launchNative =
+    options.launchNativeSuite ?? launchSearchEvalNativeSuiteWorkflow
+
+  if (input.generateCandidates) {
+    const runId = childRunId(mastraRunId, "eval-query-generation")
+    const result = await launchGeneration(generationInputFor(input), { runId })
+    if (!result.ok) {
+      addFailedChild(summary, {
+        workflowId: "eval-query-generation",
+        runId,
+        result,
+      })
+      return failure("candidate_generation_failed", {
+        retryable: result.retryable,
+        mastraRunId,
+        summary,
+      })
+    }
+    summary.childWorkflowRuns.push({
+      workflowId: "eval-query-generation",
+      runId,
+      status: "succeeded",
+    })
+    updateCountsFromCandidateGeneration(summary, result)
+  }
+
+  if (input.submitSeedCandidates) {
+    const runId = childRunId(mastraRunId, "submit-seed-candidates")
+    const result = await launchCandidateReview(
+      { action: "submit-seed", seedLocales: input.locales },
+      { runId },
+    )
+    if (!result.ok) {
+      addFailedChild(summary, {
+        workflowId: "search-eval-candidate-review",
+        runId,
+        action: "submit-seed",
+        result,
+      })
+      return failure("seed_submit_failed", {
+        retryable: result.retryable,
+        mastraRunId,
+        summary,
+      })
+    }
+    summary.childWorkflowRuns.push({
+      workflowId: "search-eval-candidate-review",
+      runId,
+      status: "succeeded",
+      action: "submit-seed",
+    })
+    updateCountsFromCandidateStore(summary, result)
+  }
+
+  let report: SearchEvalReport | undefined
+  if (input.resumeReportId) {
+    summary.artifacts.reportId = input.resumeReportId
+    summary.resume = { reportId: input.resumeReportId, action: "sync-report" }
+    summary.childWorkflowRuns.push({
+      workflowId: "offline-search-eval",
+      runId: childRunId(mastraRunId, "offline-search-eval"),
+      status: "skipped",
+      action: "resume-report",
+    })
+  } else {
+    const runId = childRunId(mastraRunId, "offline-search-eval")
+    const result = await launchOffline(offlineInputFor(input), { runId })
+    if (!result.ok) {
+      summary.artifacts.reportPath = result.reportPath
+      summary.artifacts.reportId = reportIdFromPath(result.reportPath)
+      addFailedChild(summary, {
+        workflowId: "offline-search-eval",
+        runId,
+        action: offlineInputFor(input).mode,
+        result,
+      })
+      resume(summary)
+      return failure("offline_eval_failed", {
+        retryable: result.retryable,
+        mastraRunId,
+        summary,
+      })
+    }
+    summary.childWorkflowRuns.push({
+      workflowId: "offline-search-eval",
+      runId,
+      status: "succeeded",
+      action: result.mode,
+    })
+    updateFromOfflineResult(summary, result)
+    report = result.report
+  }
+
+  if (input.nativeSync && summary.artifacts.reportId) {
+    const runId = childRunId(mastraRunId, "native-report-sync")
+    const result = await launchNative(
+      {
+        action: "sync-report",
+        reportId: summary.artifacts.reportId,
+        baselineName: input.baselineName,
+        promotedLimit: input.promotedLimit,
+        ...(input.environmentLabel
+          ? { environmentLabel: input.environmentLabel }
+          : {}),
+      },
+      { runId },
+    )
+    if (!result.ok) {
+      addFailedChild(summary, {
+        workflowId: "search-eval-native-suite",
+        runId,
+        action: "sync-report",
+        result,
+      })
+      resume(summary)
+      return failure("native_report_sync_failed", {
+        retryable: result.retryable,
+        mastraRunId,
+        summary,
+      })
+    }
+    summary.childWorkflowRuns.push({
+      workflowId: "search-eval-native-suite",
+      runId,
+      status: "succeeded",
+      action: "sync-report",
+    })
+    updateFromNativeReportSync(summary, result)
+    if (result.report) report = result.report
+  }
+
+  if (input.syncPromoted) {
+    const runId = childRunId(mastraRunId, "native-promoted-sync")
+    const result = await launchNative(
+      {
+        action: "sync-promoted",
+        baselineName: input.baselineName,
+        promotedLimit: input.promotedLimit,
+        ...(input.environmentLabel
+          ? { environmentLabel: input.environmentLabel }
+          : {}),
+      },
+      { runId },
+    )
+    if (!result.ok) {
+      addFailedChild(summary, {
+        workflowId: "search-eval-native-suite",
+        runId,
+        action: "sync-promoted",
+        result,
+      })
+      resume(summary)
+      return failure("promoted_sync_failed", {
+        retryable: result.retryable,
+        mastraRunId,
+        summary,
+      })
+    }
+    summary.childWorkflowRuns.push({
+      workflowId: "search-eval-native-suite",
+      runId,
+      status: "succeeded",
+      action: "sync-promoted",
+    })
+    updateFromPromotedSync(summary, result)
+  }
+
+  summary.passFail = evaluateReleaseGate(input, report)
+  if (summary.passFail.state === "failed") {
+    resume(summary)
+    return failure("release_gate_failed", {
+      retryable: false,
+      mastraRunId,
+      summary,
+    })
+  }
+
+  return {
+    ok: true,
+    mastraRunId,
+    summary,
+  }
+}
+
+function throwWorkflowFailure(result: SearchEvalOrchestratorFailure): never {
+  throw new SearchEvalOrchestratorWorkflowFailureError(result)
+}
+
+function workflowFailureFromUnknown(
+  value: unknown,
+): SearchEvalOrchestratorFailure | null {
+  if (value instanceof SearchEvalOrchestratorWorkflowFailureError) {
+    return value.result
+  }
+  const message =
+    value instanceof Error
+      ? value.message
+      : typeof value === "string"
+        ? value
+        : ""
+  const prefixIndex = message.indexOf(WORKFLOW_FAILURE_ERROR_PREFIX)
+  if (prefixIndex < 0) return null
+  let payload: unknown
+  try {
+    payload = JSON.parse(
+      message.slice(prefixIndex + WORKFLOW_FAILURE_ERROR_PREFIX.length),
+    )
+  } catch {
+    return null
+  }
+  const parsed = SearchEvalOrchestratorResultSchema.safeParse(payload)
+  return parsed.success && !parsed.data.ok ? parsed.data : null
+}
+
+function workflowFailureFromRunResult(
+  value: unknown,
+): SearchEvalOrchestratorFailure | null {
+  const direct = workflowFailureFromUnknown(value)
+  if (direct) return direct
+  const valueRecord = record(value)
+  if (!valueRecord) return null
+  return (
+    workflowFailureFromUnknown(valueRecord.error) ??
+    workflowFailureFromUnknown(valueRecord.result) ??
+    workflowFailureFromUnknown(valueRecord.snapshot)
+  )
+}
+
+const orchestratorStep = createStep({
+  id: "run-search-eval-orchestrator",
+  description:
+    "Coordinate search eval baseline capture, comparison, native sync, and release-gate summaries.",
+  inputSchema: SearchEvalOrchestratorWorkflowInputSchema,
+  outputSchema: SearchEvalOrchestratorResultSchema,
+  execute: async ({ inputData, runId }) => {
+    const result = await runSearchEvalOrchestratorWorkflow(inputData, { runId })
+    if (!result.ok) throwWorkflowFailure(result)
+    return result
+  },
+})
+
+export const searchEvalOrchestratorWorkflow = createWorkflow({
+  id: "search-eval-orchestrator",
+  description:
+    "Coordinate Forge search eval artifacts and native Evaluation sync without entering the live search path.",
+  inputSchema: SearchEvalOrchestratorWorkflowInputSchema,
+  outputSchema: SearchEvalOrchestratorResultSchema,
+})
+  .then(orchestratorStep)
+  .commit()
+
+export async function launchSearchEvalOrchestratorWorkflow(
+  rawInput: SearchEvalOrchestratorWorkflowInput,
+  options: { runId?: string } = {},
+): Promise<SearchEvalOrchestratorWorkflowResult> {
+  const parsed = SearchEvalOrchestratorWorkflowInputSchema.safeParse(rawInput)
+  const runId = options.runId ?? randomUUID()
+  if (!parsed.success) {
+    return failure("invalid_input", {
+      retryable: false,
+      mastraRunId: runId,
+      summary: initialSummary(
+        SearchEvalOrchestratorWorkflowInputSchema.parse({}),
+      ),
+    })
+  }
+  const run = await searchEvalOrchestratorWorkflow.createRun({ runId })
+  let result: Awaited<ReturnType<typeof run.start>>
+  try {
+    result = await run.start({ inputData: parsed.data })
+  } catch (error) {
+    return (
+      workflowFailureFromUnknown(error) ??
+      failure("orchestration_failed", {
+        retryable: true,
+        mastraRunId: runId,
+        summary: initialSummary(parsed.data),
+      })
+    )
+  }
+  if (result?.status === "success") {
+    return result.result as SearchEvalOrchestratorWorkflowResult
+  }
+  return (
+    workflowFailureFromRunResult(result) ??
+    failure("orchestration_failed", {
+      retryable: true,
+      mastraRunId: runId,
+      summary: initialSummary(parsed.data),
+    })
+  )
+}
+
+async function readBoundedJson(request: Request): Promise<unknown> {
+  const contentLength = request.headers.get("content-length")
+  if (contentLength != null) {
+    const declaredBytes = Number(contentLength)
+    if (
+      !Number.isFinite(declaredBytes) ||
+      declaredBytes < 0 ||
+      declaredBytes > SEARCH_EVAL_ORCHESTRATOR_MAX_BODY_BYTES
+    ) {
+      throw new OrchestratorRouteBodyError("payload_too_large")
+    }
+  }
+
+  const body = request.body
+  if (body == null) throw new OrchestratorRouteBodyError("invalid_json")
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    totalBytes += value.byteLength
+    if (totalBytes > SEARCH_EVAL_ORCHESTRATOR_MAX_BODY_BYTES) {
+      await reader.cancel().catch(() => undefined)
+      throw new OrchestratorRouteBodyError("payload_too_large")
+    }
+    chunks.push(value)
+  }
+
+  const bytes = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes))
+  } catch {
+    throw new OrchestratorRouteBodyError("invalid_json")
+  }
+}
+
+function invalidInput(runId = randomUUID()): SearchEvalOrchestratorFailure {
+  return failure("invalid_input", {
+    retryable: false,
+    mastraRunId: runId,
+    summary: initialSummary(
+      SearchEvalOrchestratorWorkflowInputSchema.parse({}),
+    ),
+  })
+}
+
+function childFailureStatus(reason: string): number | null {
+  if (reason === "invalid_input") return 400
+  if (reason === "artifact_invalid") return 400
+  if (reason === "sample_not_allowed") return 403
+  if (reason === "artifact_not_found") return 404
+  if (reason.endsWith("_rejected")) return 409
+  if (
+    reason === "admin_config_missing" ||
+    reason === "generation_config_missing" ||
+    reason === "judge_config_missing" ||
+    reason === "runtime_unavailable" ||
+    reason === "artifact_read_failed" ||
+    reason === "artifact_write_failed"
+  ) {
+    return 503
+  }
+  return null
+}
+
+function routeStatusForResult(result: SearchEvalOrchestratorWorkflowResult) {
+  if (result.ok) return 200
+  if (result.reason === "invalid_input") return 400
+  if (result.reason === "release_gate_failed") return 409
+  const failedChild = result.summary.childWorkflowRuns.find(
+    (child) => child.status === "failed" && child.reason,
+  )
+  const childStatus = failedChild?.reason
+    ? childFailureStatus(failedChild.reason)
+    : null
+  if (childStatus != null) return childStatus
+  return 502
+}
+
+export async function handleSearchEvalOrchestratorRouteRequest({
+  authHeader,
+  serviceKeys,
+  request,
+  readJson,
+  launch = launchSearchEvalOrchestratorWorkflow,
+}: RouteHandlerInput): Promise<SearchEvalOrchestratorRouteOutcome> {
+  if (!isValidServiceBearer({ authHeader, allowlist: serviceKeys })) {
+    return {
+      status: 401,
+      body: { error: "Service bearer required" },
+    }
+  }
+
+  const runId = randomUUID()
+  let body: unknown
+  try {
+    body = request ? await readBoundedJson(request) : await readJson?.()
+  } catch (error) {
+    return {
+      status:
+        error instanceof OrchestratorRouteBodyError &&
+        error.code === "payload_too_large"
+          ? 413
+          : 400,
+      body: { result: invalidInput(runId) },
+    }
+  }
+  const parsed = SearchEvalOrchestratorWorkflowInputSchema.safeParse(body)
+  const result = parsed.success
+    ? await launch(parsed.data, { runId }).catch(() =>
+        failure("orchestration_failed", {
+          retryable: true,
+          mastraRunId: runId,
+          summary: initialSummary(parsed.data),
+        }),
+      )
+    : invalidInput(runId)
+
+  return {
+    status: routeStatusForResult(result),
+    body: { result },
+  }
+}
+
+export const _internal = {
+  SearchEvalOrchestratorWorkflowInputSchema,
+  SearchEvalOrchestratorResultSchema,
+  workflowFailureFromUnknown,
+  workflowFailureFromRunResult,
+  evaluateReleaseGate,
+  reportIdFromPath,
+  routeStatusForResult,
+}

--- a/docs/brainstorms/2026-05-30-search-eval-orchestrator-requirements.md
+++ b/docs/brainstorms/2026-05-30-search-eval-orchestrator-requirements.md
@@ -1,0 +1,100 @@
+---
+date: "2026-05-30"
+topic: "search-eval-orchestrator"
+---
+
+# Search Eval Orchestrator Requirements
+
+## Summary
+
+Add a thin Mastra search eval orchestrator that runs the existing leaf
+workflows in safe operator modes, summarizes their outputs, and keeps baseline
+capture, comparison, native Evaluation sync, and release gating resumable.
+
+---
+
+## Problem Frame
+
+The search eval leaf workflows are intentionally separate because they own
+different safety boundaries: generated candidates are exploratory, offline
+reports are artifact-backed, candidate review is human-gated, and native
+Evaluation sync must be idempotent. Operators still need one workflow for the
+normal evaluation path so production baseline capture and local baseline seeding
+can build on a single production/local entry point instead of hand-coordinating
+leaves.
+
+---
+
+## Requirements
+
+- R1. The orchestrator coordinates existing leaf workflows without moving their
+  implementation logic into the orchestrator.
+- R2. The normal `full` mode captures a named seed baseline with production-safe
+  defaults, then can sync that report and promoted truth into native Evaluation.
+- R3. The `compare` mode compares current search behavior against an existing
+  named baseline, then can sync the resulting report into native Evaluation.
+- R4. The `release-gate` mode runs a comparison and returns a pass/fail state
+  from explicit thresholds for losses, search failures, judge failures, judge
+  disagreements, and calibration.
+- R5. Every result returns a single operator summary with child workflow run ids,
+  baseline/report ids, artifact paths, native Dataset/Scorer/Experiment ids,
+  counts, and pass/fail state.
+- R6. Partial failures remain legible and resumable, especially when an offline
+  report exists but native sync or promoted sync fails.
+- R7. The orchestrator never promotes generated, trace-derived, seed, or
+  user-submitted candidates. It may submit seed or generated candidates only as
+  pending/staged material when explicitly requested.
+- R8. Defaults must make production baseline capture and local baseline seeding
+  straightforward for follow-up tickets without implementing those tickets.
+
+---
+
+## Key Decisions
+
+- **Thin coordinator:** The orchestrator calls leaf launch functions and reports
+  their child run ids. Leaf workflows keep their Studio cards, service routes,
+  validation, and independent tests.
+- **Safe defaults:** Candidate generation and seed candidate submission are
+  opt-in. Baseline capture and native sync are available by default because
+  they operate on committed seed prompts and idempotent native sync contracts.
+- **Resume by report id:** Operators can retry native report sync with a known
+  report id instead of rerunning Admin search and judge calls after a late sync
+  failure.
+
+---
+
+## Scope Boundaries
+
+- Build the orchestrator workflow and protected service route in `apps/mastra`.
+- Update roadmap and local Mastra docs for the new operator entry point.
+- Do not add production scheduling, production data capture automation, or local
+  seed scripts here; those remain follow-up work.
+- Do not change Admin public search REST or GraphQL response shapes.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given default input, when an operator runs the orchestrator in `full`
+  mode, then it captures `seed-baseline`, returns baseline/report artifact
+  details, and does not generate or promote any candidates.
+- AE2. Given `resumeReportId`, when native report sync is retried, then the
+  orchestrator skips offline search execution and calls `sync-report` for that
+  report id.
+- AE3. Given `release-gate` mode and a comparison report with one loss, when
+  the default maximum loss threshold is zero, then the workflow returns a
+  failed pass/fail state with the report id/path preserved.
+- AE4. Given candidate generation is enabled, when generation succeeds, then
+  generated candidates remain staged and no candidate review `promote` action
+  is called.
+
+---
+
+## Sources
+
+- `docs/roadmap/content-discovery/feat-138-mastra-eval-query-generation.md`
+- `docs/roadmap/content-discovery/feat-139-mastra-offline-search-eval-runner-reports.md`
+- `docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md`
+- `docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`
+- `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`
+- `docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md`

--- a/docs/plans/2026-05-30-001-feat-search-eval-orchestrator-plan.md
+++ b/docs/plans/2026-05-30-001-feat-search-eval-orchestrator-plan.md
@@ -1,0 +1,201 @@
+---
+title: "Search eval artifact and Evaluation orchestrator"
+type: "feat"
+status: "completed"
+date: "2026-05-30"
+origin: "docs/brainstorms/2026-05-30-search-eval-orchestrator-requirements.md"
+---
+
+# Search Eval Artifact and Evaluation Orchestrator
+
+## Summary
+
+Add a thin Mastra workflow and service route that coordinates the existing
+search eval leaves for baseline capture, comparison, native Evaluation sync,
+and release-gate summaries without changing the live search path or bypassing
+human review.
+
+---
+
+## Problem Frame
+
+Search eval capability now exists in separate Mastra leaves:
+`eval-query-generation`, `offline-search-eval`,
+`search-eval-candidate-review`, and `search-eval-native-suite`. That separation
+is the safety model, but operators need a single workflow summary that ties a
+baseline/report artifact to native Evaluation ids, child run ids, counts, and
+pass/fail state. The production baseline capture and local baseline seeding
+follow-ups should build on this orchestrator instead of reassembling the
+sequence independently.
+
+---
+
+## Requirements
+
+**Orchestration**
+
+- R1. Coordinate existing search eval leaf workflows by calling their launch
+  functions with explicit child run ids.
+- R2. Keep every leaf workflow independently runnable through its existing
+  workflow export and service route.
+- R3. Provide `full`, `compare`, and `release-gate` modes with Studio-friendly
+  defaults.
+
+**Operator Summary**
+
+- R4. Return child workflow run ids, baseline/report ids, artifact paths, native
+  Dataset/Scorer/Experiment ids, counts, and pass/fail state in one result.
+- R5. Preserve report ids and paths in failure output whenever a later stage
+  fails after an artifact exists.
+- R6. Support `resumeReportId` so native sync can be retried without rerunning
+  search/judge work.
+
+**Safety**
+
+- R7. Do not auto-promote generated, trace-derived, seed, or user-submitted
+  candidates.
+- R8. Do not add Mastra to the live public search request path.
+- R9. Reuse native-suite idempotency so reruns update/reuse Dataset, Scorer,
+  and Experiment records rather than duplicating them.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Orchestrator as caller, not container: implement a new workflow that
+  imports leaf launch functions and passes deterministic child run ids. This
+  keeps leaf schemas, routes, and tests independent while giving operators one
+  run summary.
+- KTD2. `full` means seed-baseline capture by default: default mode captures
+  the committed seed prompt baseline, then performs native report sync and
+  promoted-candidate sync when enabled. Candidate generation and seed candidate
+  submission remain explicit opt-ins.
+- KTD3. Resume report sync through `resumeReportId`: when a report already
+  exists, skip `offline-search-eval` and call `search-eval-native-suite` with
+  `action=sync-report`. This is the recovery path for sync failures and a
+  useful bridge for local baseline seeding.
+- KTD4. Release gates are report-threshold checks: use report totals and
+  calibration fields already produced by `offline-search-eval`; do not invent
+  new scoring state in the orchestrator.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  O["search-eval-orchestrator"]
+  G["eval-query-generation"]
+  C["search-eval-candidate-review"]
+  E["offline-search-eval"]
+  N["search-eval-native-suite"]
+  A["Admin internal HTTP contracts"]
+  F["Mastra artifact files"]
+  V["Native Evaluation records"]
+
+  O -->|"optional staged candidates"| G
+  O -->|"optional submit seed as pending"| C
+  O -->|"capture-baseline or compare"| E
+  O -->|"sync-report by reportId"| N
+  O -->|"sync-promoted"| N
+  G --> A
+  C --> A
+  E --> A
+  E --> F
+  N --> F
+  N --> V
+```
+
+The orchestrator result should carry a normalized child summary per attempted
+leaf stage. `release-gate` computes pass/fail from `report.totals` and
+`report.calibration` after a successful comparison.
+
+---
+
+## Implementation Units
+
+### U1. Roadmap and requirements artifacts
+
+- **Goal:** Make the requested search-eval orchestrator ticket traceable and capture the
+  brainstorm requirements used by the plan.
+- **Files:** `docs/roadmap/content-discovery/feat-148-search-eval-orchestrator-workflow.md`,
+  `docs/brainstorms/2026-05-30-search-eval-orchestrator-requirements.md`,
+  `docs/plans/2026-05-30-001-feat-search-eval-orchestrator-plan.md`.
+- **Verification:** Roadmap ticket has `status: "in-progress"` and references
+  production baseline capture and local baseline seeding only as follow-ups.
+
+### U2. Orchestrator workflow
+
+- **Goal:** Add `search-eval-orchestrator` with structured input/output,
+  child-run coordination, resumable failure summaries, and release-gate state.
+- **Files:** `apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts`.
+- **Patterns:** Mirror route handling and launch/run structure in
+  `apps/mastra/src/mastra/workflows/offline-search-eval.ts` and
+  `apps/mastra/src/mastra/workflows/search-eval-native-suite.ts`.
+- **Test scenarios:** default full mode calls offline capture and native sync;
+  `resumeReportId` skips offline execution; release gate fails on losses; native
+  sync failure preserves report id/path; candidate generation does not trigger
+  promotion.
+- **Verification:** Focused orchestrator workflow tests pass.
+
+### U3. Runtime registration and docs
+
+- **Goal:** Register the workflow and protected service route, and document the
+  operator mode semantics in the Mastra guide.
+- **Files:** `apps/mastra/src/mastra/index.ts`, `apps/mastra/CLAUDE.md`.
+- **Patterns:** Follow existing `registerApiRoute` service-bearer route
+  patterns.
+- **Test scenarios:** route rejects missing service bearer, parses default
+  input, enforces body size, and maps failure reasons to HTTP status.
+- **Verification:** Route tests and Mastra typecheck pass.
+
+### U4. Regression coverage and validation
+
+- **Goal:** Add focused tests for the orchestrator while preserving existing
+  leaf test coverage.
+- **Files:** `apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts`.
+- **Patterns:** Follow existing workflow tests colocated in
+  `apps/mastra/src/mastra/workflows`.
+- **Test scenarios:** cover success, resumability, gate failure, safety
+  boundary, auth, and invalid input.
+- **Verification:** Run the required filtered workflow tests, Mastra
+  typecheck, and lint.
+
+---
+
+## Scope Boundaries
+
+- Do not implement production baseline scheduling or production-data capture
+  automation.
+- Do not implement local production-baseline seed scripts.
+- Do not change Admin public search REST or GraphQL contracts.
+- Do not add candidate promotion behavior to the orchestrator.
+- Do not query Admin Postgres from Mastra.
+
+---
+
+## Risks & Dependencies
+
+- Native sync idempotency depends on `search-eval-native-suite` and
+  `native-evaluation.ts`; orchestrator should treat those leaves as the source
+  of truth rather than duplicating native record logic.
+- `release-gate` can only be as strict as current report totals allow. More
+  nuanced multilingual gates belong in later multilingual work.
+- The requested roadmap ticket was absent on `origin/main`, and `feat-144` was
+  already globally allocated in another lane, so this plan creates the next
+  unique content-discovery ticket id from the provided scope.
+
+---
+
+## Sources
+
+- `docs/roadmap/content-discovery/feat-138-mastra-eval-query-generation.md`
+- `docs/roadmap/content-discovery/feat-139-mastra-offline-search-eval-runner-reports.md`
+- `docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md`
+- `docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`
+- `apps/mastra/src/mastra/workflows/eval-query-generation.ts`
+- `apps/mastra/src/mastra/workflows/offline-search-eval.ts`
+- `apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts`
+- `apps/mastra/src/mastra/workflows/search-eval-native-suite.ts`
+- `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`
+- `docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md`

--- a/docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md
+++ b/docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md
@@ -10,6 +10,7 @@ depends_on:
   - "feat-140"
 blocks:
   - "feat-141"
+  - "feat-148"
 tags:
   - "admin"
   - "mastra"

--- a/docs/roadmap/content-discovery/feat-148-search-eval-orchestrator-workflow.md
+++ b/docs/roadmap/content-discovery/feat-148-search-eval-orchestrator-workflow.md
@@ -1,0 +1,123 @@
+---
+id: "feat-148"
+title: "Search eval artifact and Evaluation orchestrator"
+owner: "nisal"
+priority: "P0"
+status: "complete"
+start_date: "2026-05-30"
+duration: 2
+depends_on:
+  - "feat-142"
+blocks: []
+tags:
+  - "admin"
+  - "mastra"
+  - "search"
+  - "ai-pipeline"
+  - "observability"
+  - "evals"
+  - "developer-experience"
+---
+
+## Problem
+
+The search eval system now has separate Mastra leaf workflows for staged query
+generation, offline baseline/report artifacts, human candidate review, and
+native Evaluation synchronization. Those leaves should remain independently
+runnable, but operators need one thin workflow that coordinates the normal
+search-eval sequence and returns a single useful summary.
+
+This work was requested as the content-discovery `feat-144` search eval
+orchestrator scope, but the current roadmap already uses `feat-144` globally in
+the platform lane. This ticket therefore uses the next unique roadmap id while
+preserving the requested scope and sequencing.
+
+The next two search-eval tickets depend on this orchestration surface:
+
+- production search eval baseline capture needs this common orchestration path.
+- local production-baseline seeding needs the same resumable report/native-sync
+  handoff.
+
+This orchestrator should land first so those tickets can use the same
+operator-facing defaults and resumable report/native sync handoff.
+
+## Entry Points - Read These First
+
+1. `docs/roadmap/content-discovery/feat-138-mastra-eval-query-generation.md`
+   - staged generated candidate workflow and promotion boundary.
+2. `docs/roadmap/content-discovery/feat-139-mastra-offline-search-eval-runner-reports.md`
+   - baseline and comparison artifact workflow.
+3. `docs/roadmap/content-discovery/feat-140-search-eval-human-promotion-regression-gates.md`
+   - human review, sanitization, and durable regression truth.
+4. `docs/roadmap/content-discovery/feat-142-mastra-search-eval-suite-operator-workflow.md`
+   - native Dataset, Scorer, and Experiment synchronization.
+5. `apps/mastra/src/mastra/workflows/eval-query-generation.ts`
+   - staged candidate-generation leaf workflow.
+6. `apps/mastra/src/mastra/workflows/offline-search-eval.ts`
+   - baseline capture and comparison leaf workflow.
+7. `apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts`
+   - human-review and seed/user candidate submission leaf workflow.
+8. `apps/mastra/src/mastra/workflows/search-eval-native-suite.ts`
+   - native Evaluation sync leaf workflow.
+9. `apps/mastra/src/mastra/index.ts`
+   - workflow and protected service route registration.
+10. `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`
+    - search eval ownership and safety boundary.
+11. `docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md`
+    - native Evaluation idempotency and artifact bridge pattern.
+
+## Grep These
+
+```bash
+rg -n "eval-query-generation|offline-search-eval|search-eval-native-suite|search-eval-candidate-review" apps/mastra/src
+rg -n "writeBaseline|writeReport|readReport|mastraEvaluation|native_synced" apps/mastra/src/services/offline-search-eval
+rg -n "promotionStatus|sanitizationStatus|submit-seed|submit-user|promote" apps/mastra/src apps/admin/src
+rg -n "registerApiRoute|createWorkflow|createStep" apps/mastra/src/mastra
+```
+
+## What To Build
+
+1. Add a thin Mastra workflow that coordinates existing search eval leaf
+   workflows without moving their logic into a mega-workflow.
+2. Keep all leaf workflows independently runnable through Studio and their
+   existing service routes.
+3. Support operator-friendly modes:
+   - `full` for production baseline capture plus optional native/promoted sync;
+   - `compare` for comparing current search against a named baseline;
+   - `release-gate` for comparison plus explicit pass/fail thresholds.
+4. Return one summary with child workflow ids, baseline/report ids, artifact
+   paths, native Dataset/Scorer/Experiment ids, counts, and pass/fail state.
+5. Make partial failures legible and resumable. A native sync failure after a
+   successful report should return the report id/path so operators can retry
+   sync without rerunning the search eval.
+6. Preserve the human-review boundary. Generated, trace-derived, seed, or
+   user-submitted candidates must not be auto-promoted.
+7. Add defaults that make production baseline capture and local
+   production-baseline seeding straightforward follow-ups.
+
+## Constraints
+
+- Do not put Mastra in the live public search request path.
+- Do not collapse `eval-query-generation`, `offline-search-eval`,
+  `search-eval-candidate-review`, or `search-eval-native-suite` into one
+  mega-workflow.
+- Do not duplicate native Evaluation records on rerun; use the existing
+  native-suite idempotency contracts and support resume by report id.
+- Do not silently promote generated, trace-derived, seed, or user-submitted
+  candidates.
+- Do not implement production baseline capture or local baseline seeding; only
+  leave clear affordances for those follow-ups.
+- Do not query Admin's database from Mastra or import Admin app code.
+
+## Verification
+
+At minimum:
+
+```bash
+pnpm --filter @forge/mastra test -- eval-query-generation offline-search-eval search-eval-native-suite search-eval-candidate-review
+pnpm --filter @forge/mastra test
+pnpm --filter @forge/mastra typecheck
+pnpm --filter @forge/mastra lint
+```
+
+Also add focused tests for the new orchestrator workflow and route.


### PR DESCRIPTION
## Summary

Search eval operators now have one Mastra workflow that can capture a seed baseline, compare against an existing baseline, sync native Evaluation records, and return a single run summary with child workflow ids, artifact ids/paths, native ids, counts, and release-gate state. The existing leaf workflows remain independently runnable, and candidate generation or seed submission stays opt-in staging only, with no auto-promotion path.

## Design Notes

- Adds `search-eval-orchestrator` plus `/forge-search-eval-orchestrator` as a service-bearer route over the existing eval leaves.
- Supports `full`, `compare`, and `release-gate` modes, including `resumeReportId` for retrying native report sync without rerunning Admin search or judge work.
- Maps child workflow failures back to useful route statuses, so missing artifacts, rejected Admin operations, and runtime/config outages stay distinguishable.
- Records the requested search-eval orchestrator roadmap scope as `feat-148` because `feat-144` was already globally allocated in another roadmap lane.

## Validation

- `pnpm --filter @forge/mastra test -- eval-query-generation offline-search-eval search-eval-native-suite search-eval-candidate-review search-eval-orchestrator`
- `pnpm --filter @forge/mastra test`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/mastra lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-Codex-000000)
