### PR TITLE
chore(web): retrigger Railway deployment

### DIFF
--- a/apps/web/src/lib/locale.ts
+++ b/apps/web/src/lib/locale.ts
@@ -276,11 +276,11 @@ export function resolveUiLocaleForCatalog(
  * Examples with current catalogs:
  *   resolveUiLocale("spanish-castilian") → "es"
  *   resolveUiLocale("portuguese-mozambique") → "pt"
- *   resolveUiLocale("mandarin-china") → null  // no zh catalog yet
- *   resolveUiLocale("russian") → null         // no ru catalog yet
+ *   resolveUiLocale("mandarin-china") → "zh"
+ *   resolveUiLocale("russian") → "ru"
  *
- * Once `messages/ru.json` exists and the generated catalog list is refreshed,
- * `resolveUiLocale("russian")` resolves to "ru" without code changes.
+ * Languages without a matching generated catalog return null here; watch
+ * chrome callers fall back to `DEFAULT_LOCALE`.
  */
 export function resolveUiLocale(localeSegment: string): UiLocale | null {
   const resolved = resolveUiLocaleForCatalog(


### PR DESCRIPTION
## Summary
- correct stale locale resolver docs under apps/web
- trigger a fresh web Railway deployment after #1074

## Validation
- pnpm --filter @forge/web test src/lib/locale.test.ts src/proxy.test.ts
- pnpm --filter @forge/web lint
- pnpm --filter @forge/web check:ui-locales
- git diff --check