### PR TITLE
fix(web): localize visible watch chrome

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -152,5 +152,42 @@
     "loading": "جارٍ تحميل النص…",
     "unavailable": "النص غير متاح لمسار الترجمة هذا.",
     "empty": "لم يتم العثور على أسطر نصية."
+  },
+  "FloatingSearch": {
+    "placeholder": "ابحث أو تصفح المواضيع…",
+    "openSearch": "البحث عن فيديوهات",
+    "searchRegion": "البحث عن فيديوهات",
+    "clearSearch": "مسح البحث",
+    "changeAudioLanguage": "تغيير لغة الصوت",
+    "home": "صفحة JesusFilm الرئيسية"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "البحث عن الفيديوهات وتصفحها",
+    "home": "صفحة JesusFilm الرئيسية",
+    "placeholder": "ابحث أو تصفح المواضيع…",
+    "inputLabel": "البحث عن فيديوهات بالكلمات المفتاحية",
+    "searchFailed": "تعذر البحث. حاول مرة أخرى.",
+    "loadMoreFailed": "تعذر تحميل المزيد من النتائج.",
+    "searching": "جارٍ البحث...",
+    "connectionHint": "تحقق من اتصالك وحاول مرة أخرى.",
+    "retrySearch": "إعادة البحث",
+    "retry": "إعادة المحاولة",
+    "noResults": "لا توجد نتائج لـ “{query}”",
+    "tryDifferentKeywords": "جرّب كلمات مفتاحية أخرى أو تصفح الفئات",
+    "loading": "جارٍ التحميل...",
+    "loadMore": "تحميل المزيد",
+    "categoryBibleStories": "قصص الكتاب المقدس",
+    "categoryParables": "الأمثال",
+    "categoryAnimated": "رسوم متحركة",
+    "categoryStudy": "دراسة",
+    "categoryFamily": "العائلة",
+    "categoryChristmas": "عيد الميلاد"
+  },
+  "HeroPlayer": {
+    "playWithSound": "تشغيل مع الصوت",
+    "tapToUnmute": "تشغيل الصوت"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "جارٍ تحميل المحتوى"
   }
 }

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -152,5 +152,42 @@
     "loading": "Transkript wird geladen…",
     "unavailable": "Transkript für diese Untertitelspur nicht verfügbar.",
     "empty": "Keine Transkriptzeilen gefunden."
+  },
+  "FloatingSearch": {
+    "placeholder": "Suchen oder Themen entdecken…",
+    "openSearch": "Videos suchen",
+    "searchRegion": "Videos suchen",
+    "clearSearch": "Suche löschen",
+    "changeAudioLanguage": "Audiosprache ändern",
+    "home": "JesusFilm-Startseite"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Videos suchen und entdecken",
+    "home": "JesusFilm-Startseite",
+    "placeholder": "Suchen oder Themen entdecken…",
+    "inputLabel": "Videos nach Stichwort suchen",
+    "searchFailed": "Die Suche ist fehlgeschlagen. Bitte erneut versuchen.",
+    "loadMoreFailed": "Weitere Ergebnisse konnten nicht geladen werden.",
+    "searching": "Suche läuft...",
+    "connectionHint": "Bitte Verbindung prüfen und erneut versuchen.",
+    "retrySearch": "Suche erneut starten",
+    "retry": "Erneut versuchen",
+    "noResults": "Keine Ergebnisse für „{query}“",
+    "tryDifferentKeywords": "Andere Stichwörter versuchen oder Kategorien durchsuchen",
+    "loading": "Wird geladen...",
+    "loadMore": "Mehr laden",
+    "categoryBibleStories": "Biblische Geschichten",
+    "categoryParables": "Gleichnisse",
+    "categoryAnimated": "Animiert",
+    "categoryStudy": "Studium",
+    "categoryFamily": "Familie",
+    "categoryChristmas": "Weihnachten"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Mit Ton abspielen",
+    "tapToUnmute": "Ton einschalten"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Inhalt wird geladen"
   }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -152,5 +152,42 @@
     "loading": "Loading transcript…",
     "unavailable": "Transcript unavailable for this subtitle track.",
     "empty": "No transcript lines found."
+  },
+  "FloatingSearch": {
+    "placeholder": "Search or browse topics…",
+    "openSearch": "Search videos",
+    "searchRegion": "Search videos",
+    "clearSearch": "Clear search",
+    "changeAudioLanguage": "Change audio language",
+    "home": "JesusFilm home"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Search and browse videos",
+    "home": "JesusFilm home",
+    "placeholder": "Search or browse topics…",
+    "inputLabel": "Search videos by keyword",
+    "searchFailed": "Search failed. Please try again.",
+    "loadMoreFailed": "Failed to load more results.",
+    "searching": "Searching...",
+    "connectionHint": "Please check your connection and try again.",
+    "retrySearch": "Retry search",
+    "retry": "Retry",
+    "noResults": "No results for \"{query}\"",
+    "tryDifferentKeywords": "Try different keywords or browse categories",
+    "loading": "Loading...",
+    "loadMore": "Load more",
+    "categoryBibleStories": "Bible Stories",
+    "categoryParables": "Parables",
+    "categoryAnimated": "Animated",
+    "categoryStudy": "Study",
+    "categoryFamily": "Family",
+    "categoryChristmas": "Christmas"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Play with Sound",
+    "tapToUnmute": "Tap to Unmute"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Loading content"
   }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -152,5 +152,42 @@
     "loading": "Cargando transcripción…",
     "unavailable": "Transcripción no disponible para esta pista de subtítulos.",
     "empty": "No se encontraron líneas de transcripción."
+  },
+  "FloatingSearch": {
+    "placeholder": "Busca o explora temas…",
+    "openSearch": "Buscar videos",
+    "searchRegion": "Buscar videos",
+    "clearSearch": "Borrar búsqueda",
+    "changeAudioLanguage": "Cambiar idioma de audio",
+    "home": "Inicio de JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Buscar y explorar videos",
+    "home": "Inicio de JesusFilm",
+    "placeholder": "Busca o explora temas…",
+    "inputLabel": "Buscar videos por palabra clave",
+    "searchFailed": "No se pudo buscar. Inténtalo de nuevo.",
+    "loadMoreFailed": "No se pudieron cargar más resultados.",
+    "searching": "Buscando...",
+    "connectionHint": "Revisa tu conexión e inténtalo de nuevo.",
+    "retrySearch": "Reintentar búsqueda",
+    "retry": "Reintentar",
+    "noResults": "No hay resultados para “{query}”",
+    "tryDifferentKeywords": "Prueba otras palabras clave o explora categorías",
+    "loading": "Cargando...",
+    "loadMore": "Cargar más",
+    "categoryBibleStories": "Historias bíblicas",
+    "categoryParables": "Parábolas",
+    "categoryAnimated": "Animados",
+    "categoryStudy": "Estudio",
+    "categoryFamily": "Familia",
+    "categoryChristmas": "Navidad"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Reproducir con sonido",
+    "tapToUnmute": "Activar sonido"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Cargando contenido"
   }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -152,5 +152,42 @@
     "loading": "Chargement de la transcription…",
     "unavailable": "Transcription indisponible pour cette piste de sous-titres.",
     "empty": "Aucune ligne de transcription trouvée."
+  },
+  "FloatingSearch": {
+    "placeholder": "Rechercher ou explorer des thèmes…",
+    "openSearch": "Rechercher des vidéos",
+    "searchRegion": "Rechercher des vidéos",
+    "clearSearch": "Effacer la recherche",
+    "changeAudioLanguage": "Changer la langue audio",
+    "home": "Accueil JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Rechercher et explorer des vidéos",
+    "home": "Accueil JesusFilm",
+    "placeholder": "Rechercher ou explorer des thèmes…",
+    "inputLabel": "Rechercher des vidéos par mot-clé",
+    "searchFailed": "La recherche a échoué. Réessayez.",
+    "loadMoreFailed": "Impossible de charger plus de résultats.",
+    "searching": "Recherche...",
+    "connectionHint": "Vérifiez votre connexion et réessayez.",
+    "retrySearch": "Relancer la recherche",
+    "retry": "Réessayer",
+    "noResults": "Aucun résultat pour « {query} »",
+    "tryDifferentKeywords": "Essayez d’autres mots-clés ou explorez les catégories",
+    "loading": "Chargement...",
+    "loadMore": "Charger plus",
+    "categoryBibleStories": "Histoires bibliques",
+    "categoryParables": "Paraboles",
+    "categoryAnimated": "Animation",
+    "categoryStudy": "Étude",
+    "categoryFamily": "Famille",
+    "categoryChristmas": "Noël"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Lire avec le son",
+    "tapToUnmute": "Activer le son"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Chargement du contenu"
   }
 }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -152,5 +152,42 @@
     "loading": "Memuat transkrip…",
     "unavailable": "Transkrip tidak tersedia untuk trek teks ini.",
     "empty": "Tidak ada baris transkrip ditemukan."
+  },
+  "FloatingSearch": {
+    "placeholder": "Cari atau jelajahi topik…",
+    "openSearch": "Cari video",
+    "searchRegion": "Cari video",
+    "clearSearch": "Hapus pencarian",
+    "changeAudioLanguage": "Ubah bahasa audio",
+    "home": "Beranda JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Cari dan jelajahi video",
+    "home": "Beranda JesusFilm",
+    "placeholder": "Cari atau jelajahi topik…",
+    "inputLabel": "Cari video berdasarkan kata kunci",
+    "searchFailed": "Pencarian gagal. Coba lagi.",
+    "loadMoreFailed": "Gagal memuat hasil lainnya.",
+    "searching": "Mencari...",
+    "connectionHint": "Periksa koneksi Anda lalu coba lagi.",
+    "retrySearch": "Coba cari lagi",
+    "retry": "Coba lagi",
+    "noResults": "Tidak ada hasil untuk “{query}”",
+    "tryDifferentKeywords": "Coba kata kunci lain atau jelajahi kategori",
+    "loading": "Memuat...",
+    "loadMore": "Muat lagi",
+    "categoryBibleStories": "Kisah Alkitab",
+    "categoryParables": "Perumpamaan",
+    "categoryAnimated": "Animasi",
+    "categoryStudy": "Pembelajaran",
+    "categoryFamily": "Keluarga",
+    "categoryChristmas": "Natal"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Putar dengan suara",
+    "tapToUnmute": "Aktifkan suara"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Memuat konten"
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -152,5 +152,42 @@
     "loading": "トランスクリプトを読み込み中…",
     "unavailable": "この字幕トラックのトランスクリプトは利用できません。",
     "empty": "トランスクリプト行が見つかりません。"
+  },
+  "FloatingSearch": {
+    "placeholder": "検索またはトピックを閲覧…",
+    "openSearch": "動画を検索",
+    "searchRegion": "動画を検索",
+    "clearSearch": "検索をクリア",
+    "changeAudioLanguage": "音声言語を変更",
+    "home": "JesusFilm ホーム"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "動画を検索・閲覧",
+    "home": "JesusFilm ホーム",
+    "placeholder": "検索またはトピックを閲覧…",
+    "inputLabel": "キーワードで動画を検索",
+    "searchFailed": "検索できませんでした。もう一度お試しください。",
+    "loadMoreFailed": "さらに結果を読み込めませんでした。",
+    "searching": "検索中...",
+    "connectionHint": "接続を確認して、もう一度お試しください。",
+    "retrySearch": "もう一度検索",
+    "retry": "再試行",
+    "noResults": "「{query}」の結果はありません",
+    "tryDifferentKeywords": "別のキーワードを試すか、カテゴリを閲覧してください",
+    "loading": "読み込み中...",
+    "loadMore": "さらに読み込む",
+    "categoryBibleStories": "聖書の物語",
+    "categoryParables": "たとえ話",
+    "categoryAnimated": "アニメーション",
+    "categoryStudy": "学び",
+    "categoryFamily": "家族",
+    "categoryChristmas": "クリスマス"
+  },
+  "HeroPlayer": {
+    "playWithSound": "音声付きで再生",
+    "tapToUnmute": "ミュートを解除"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "コンテンツを読み込み中"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -152,5 +152,42 @@
     "loading": "대본 불러오는 중…",
     "unavailable": "이 자막 트랙의 대본을 사용할 수 없습니다.",
     "empty": "대본 줄을 찾을 수 없습니다."
+  },
+  "FloatingSearch": {
+    "placeholder": "검색하거나 주제 둘러보기…",
+    "openSearch": "동영상 검색",
+    "searchRegion": "동영상 검색",
+    "clearSearch": "검색 지우기",
+    "changeAudioLanguage": "오디오 언어 변경",
+    "home": "JesusFilm 홈"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "동영상 검색 및 둘러보기",
+    "home": "JesusFilm 홈",
+    "placeholder": "검색하거나 주제 둘러보기…",
+    "inputLabel": "키워드로 동영상 검색",
+    "searchFailed": "검색에 실패했습니다. 다시 시도하세요.",
+    "loadMoreFailed": "추가 결과를 불러오지 못했습니다.",
+    "searching": "검색 중...",
+    "connectionHint": "연결 상태를 확인한 후 다시 시도하세요.",
+    "retrySearch": "다시 검색",
+    "retry": "다시 시도",
+    "noResults": "“{query}”에 대한 결과가 없습니다",
+    "tryDifferentKeywords": "다른 키워드를 사용하거나 카테고리를 둘러보세요",
+    "loading": "불러오는 중...",
+    "loadMore": "더 보기",
+    "categoryBibleStories": "성경 이야기",
+    "categoryParables": "비유",
+    "categoryAnimated": "애니메이션",
+    "categoryStudy": "공부",
+    "categoryFamily": "가족",
+    "categoryChristmas": "크리스마스"
+  },
+  "HeroPlayer": {
+    "playWithSound": "소리 켜고 재생",
+    "tapToUnmute": "음소거 해제"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "콘텐츠 불러오는 중"
   }
 }

--- a/apps/web/messages/ms.json
+++ b/apps/web/messages/ms.json
@@ -152,5 +152,42 @@
     "loading": "Memuatkan transkrip…",
     "unavailable": "Transkrip tidak tersedia untuk trek sari kata ini.",
     "empty": "Tiada baris transkrip ditemui."
+  },
+  "FloatingSearch": {
+    "placeholder": "Cari atau teroka topik…",
+    "openSearch": "Cari video",
+    "searchRegion": "Cari video",
+    "clearSearch": "Kosongkan carian",
+    "changeAudioLanguage": "Tukar bahasa audio",
+    "home": "Laman utama JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Cari dan teroka video",
+    "home": "Laman utama JesusFilm",
+    "placeholder": "Cari atau teroka topik…",
+    "inputLabel": "Cari video mengikut kata kunci",
+    "searchFailed": "Carian gagal. Cuba lagi.",
+    "loadMoreFailed": "Gagal memuatkan lagi hasil.",
+    "searching": "Mencari...",
+    "connectionHint": "Semak sambungan anda dan cuba lagi.",
+    "retrySearch": "Cuba carian lagi",
+    "retry": "Cuba lagi",
+    "noResults": "Tiada hasil untuk “{query}”",
+    "tryDifferentKeywords": "Cuba kata kunci lain atau teroka kategori",
+    "loading": "Memuatkan...",
+    "loadMore": "Muatkan lagi",
+    "categoryBibleStories": "Kisah Alkitab",
+    "categoryParables": "Perumpamaan",
+    "categoryAnimated": "Animasi",
+    "categoryStudy": "Kajian",
+    "categoryFamily": "Keluarga",
+    "categoryChristmas": "Krismas"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Mainkan dengan bunyi",
+    "tapToUnmute": "Nyahredam"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Memuatkan kandungan"
   }
 }

--- a/apps/web/messages/ne.json
+++ b/apps/web/messages/ne.json
@@ -152,5 +152,42 @@
     "loading": "ट्रान्सक्रिप्ट लोड हुँदैछ…",
     "unavailable": "यस उपशीर्षक ट्र्याकका लागि ट्रान्सक्रिप्ट उपलब्ध छैन।",
     "empty": "ट्रान्सक्रिप्ट पंक्तिहरू भेटिएनन्।"
+  },
+  "FloatingSearch": {
+    "placeholder": "खोज्नुहोस् वा विषयहरू हेर्नुहोस्…",
+    "openSearch": "भिडियो खोज्नुहोस्",
+    "searchRegion": "भिडियो खोज्नुहोस्",
+    "clearSearch": "खोज खाली गर्नुहोस्",
+    "changeAudioLanguage": "अडियो भाषा परिवर्तन गर्नुहोस्",
+    "home": "JesusFilm गृहपृष्ठ"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "भिडियो खोज्नुहोस् र हेर्नुहोस्",
+    "home": "JesusFilm गृहपृष्ठ",
+    "placeholder": "खोज्नुहोस् वा विषयहरू हेर्नुहोस्…",
+    "inputLabel": "किवर्डबाट भिडियो खोज्नुहोस्",
+    "searchFailed": "खोज असफल भयो। फेरि प्रयास गर्नुहोस्।",
+    "loadMoreFailed": "थप नतिजा लोड गर्न सकिएन।",
+    "searching": "खोजिँदै...",
+    "connectionHint": "आफ्नो जडान जाँचेर फेरि प्रयास गर्नुहोस्।",
+    "retrySearch": "खोज फेरि प्रयास गर्नुहोस्",
+    "retry": "फेरि प्रयास गर्नुहोस्",
+    "noResults": "“{query}” का लागि कुनै नतिजा छैन",
+    "tryDifferentKeywords": "अर्का किवर्ड प्रयास गर्नुहोस् वा श्रेणीहरू हेर्नुहोस्",
+    "loading": "लोड हुँदै...",
+    "loadMore": "थप लोड गर्नुहोस्",
+    "categoryBibleStories": "बाइबलका कथाहरू",
+    "categoryParables": "दृष्टान्तहरू",
+    "categoryAnimated": "एनिमेटेड",
+    "categoryStudy": "अध्ययन",
+    "categoryFamily": "परिवार",
+    "categoryChristmas": "क्रिसमस"
+  },
+  "HeroPlayer": {
+    "playWithSound": "आवाजसहित चलाउनुहोस्",
+    "tapToUnmute": "आवाज खोल्नुहोस्"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "सामग्री लोड हुँदैछ"
   }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -152,5 +152,42 @@
     "loading": "Carregando transcrição…",
     "unavailable": "Transcrição indisponível para esta faixa de legendas.",
     "empty": "Nenhuma linha de transcrição encontrada."
+  },
+  "FloatingSearch": {
+    "placeholder": "Pesquise ou explore temas…",
+    "openSearch": "Pesquisar vídeos",
+    "searchRegion": "Pesquisar vídeos",
+    "clearSearch": "Limpar pesquisa",
+    "changeAudioLanguage": "Alterar idioma do áudio",
+    "home": "Início do JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Pesquisar e explorar vídeos",
+    "home": "Início do JesusFilm",
+    "placeholder": "Pesquise ou explore temas…",
+    "inputLabel": "Pesquisar vídeos por palavra-chave",
+    "searchFailed": "A pesquisa falhou. Tente novamente.",
+    "loadMoreFailed": "Não foi possível carregar mais resultados.",
+    "searching": "Pesquisando...",
+    "connectionHint": "Verifique sua conexão e tente novamente.",
+    "retrySearch": "Tentar pesquisa novamente",
+    "retry": "Tentar novamente",
+    "noResults": "Nenhum resultado para “{query}”",
+    "tryDifferentKeywords": "Tente outras palavras-chave ou explore categorias",
+    "loading": "Carregando...",
+    "loadMore": "Carregar mais",
+    "categoryBibleStories": "Histórias bíblicas",
+    "categoryParables": "Parábolas",
+    "categoryAnimated": "Animações",
+    "categoryStudy": "Estudo",
+    "categoryFamily": "Família",
+    "categoryChristmas": "Natal"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Reproduzir com som",
+    "tapToUnmute": "Ativar som"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Carregando conteúdo"
   }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -152,5 +152,42 @@
     "loading": "Загрузка расшифровки…",
     "unavailable": "Расшифровка для этой дорожки субтитров недоступна.",
     "empty": "Строки расшифровки не найдены."
+  },
+  "FloatingSearch": {
+    "placeholder": "Ищите или выбирайте темы…",
+    "openSearch": "Поиск видео",
+    "searchRegion": "Поиск видео",
+    "clearSearch": "Очистить поиск",
+    "changeAudioLanguage": "Изменить язык аудио",
+    "home": "Главная JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Поиск и просмотр видео",
+    "home": "Главная JesusFilm",
+    "placeholder": "Ищите или выбирайте темы…",
+    "inputLabel": "Искать видео по ключевым словам",
+    "searchFailed": "Не удалось выполнить поиск. Попробуйте еще раз.",
+    "loadMoreFailed": "Не удалось загрузить еще результаты.",
+    "searching": "Идет поиск...",
+    "connectionHint": "Проверьте подключение и попробуйте еще раз.",
+    "retrySearch": "Повторить поиск",
+    "retry": "Повторить",
+    "noResults": "Нет результатов для «{query}»",
+    "tryDifferentKeywords": "Попробуйте другие слова или выберите категорию",
+    "loading": "Загрузка...",
+    "loadMore": "Загрузить еще",
+    "categoryBibleStories": "Библейские истории",
+    "categoryParables": "Притчи",
+    "categoryAnimated": "Анимация",
+    "categoryStudy": "Изучение",
+    "categoryFamily": "Семья",
+    "categoryChristmas": "Рождество"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Воспроизвести со звуком",
+    "tapToUnmute": "Включить звук"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Загрузка контента"
   }
 }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -152,5 +152,42 @@
     "loading": "กำลังโหลดถอดเสียง…",
     "unavailable": "ไม่มีถอดเสียงสำหรับแทร็กคำบรรยายนี้",
     "empty": "ไม่พบบรรทัดถอดเสียง"
+  },
+  "FloatingSearch": {
+    "placeholder": "ค้นหาหรือเลือกดูหัวข้อ…",
+    "openSearch": "ค้นหาวิดีโอ",
+    "searchRegion": "ค้นหาวิดีโอ",
+    "clearSearch": "ล้างการค้นหา",
+    "changeAudioLanguage": "เปลี่ยนภาษาเสียง",
+    "home": "หน้าแรก JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "ค้นหาและเลือกดูวิดีโอ",
+    "home": "หน้าแรก JesusFilm",
+    "placeholder": "ค้นหาหรือเลือกดูหัวข้อ…",
+    "inputLabel": "ค้นหาวิดีโอด้วยคำสำคัญ",
+    "searchFailed": "ค้นหาไม่สำเร็จ โปรดลองอีกครั้ง",
+    "loadMoreFailed": "ไม่สามารถโหลดผลลัพธ์เพิ่มเติมได้",
+    "searching": "กำลังค้นหา...",
+    "connectionHint": "โปรดตรวจสอบการเชื่อมต่อแล้วลองอีกครั้ง",
+    "retrySearch": "ค้นหาอีกครั้ง",
+    "retry": "ลองอีกครั้ง",
+    "noResults": "ไม่พบผลลัพธ์สำหรับ “{query}”",
+    "tryDifferentKeywords": "ลองใช้คำสำคัญอื่นหรือเลือกดูหมวดหมู่",
+    "loading": "กำลังโหลด...",
+    "loadMore": "โหลดเพิ่มเติม",
+    "categoryBibleStories": "เรื่องราวในพระคัมภีร์",
+    "categoryParables": "อุปมา",
+    "categoryAnimated": "แอนิเมชัน",
+    "categoryStudy": "ศึกษา",
+    "categoryFamily": "ครอบครัว",
+    "categoryChristmas": "คริสต์มาส"
+  },
+  "HeroPlayer": {
+    "playWithSound": "เล่นพร้อมเสียง",
+    "tapToUnmute": "เปิดเสียง"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "กำลังโหลดเนื้อหา"
   }
 }

--- a/apps/web/messages/tl.json
+++ b/apps/web/messages/tl.json
@@ -152,5 +152,42 @@
     "loading": "Nilo-load ang transcript…",
     "unavailable": "Hindi available ang transcript para sa subtitle track na ito.",
     "empty": "Walang nahanap na linya ng transcript."
+  },
+  "FloatingSearch": {
+    "placeholder": "Maghanap o mag-browse ng mga paksa…",
+    "openSearch": "Maghanap ng mga video",
+    "searchRegion": "Maghanap ng mga video",
+    "clearSearch": "I-clear ang paghahanap",
+    "changeAudioLanguage": "Palitan ang wika ng audio",
+    "home": "JesusFilm home"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Maghanap at mag-browse ng mga video",
+    "home": "JesusFilm home",
+    "placeholder": "Maghanap o mag-browse ng mga paksa…",
+    "inputLabel": "Maghanap ng video gamit ang keyword",
+    "searchFailed": "Hindi natuloy ang paghahanap. Subukan muli.",
+    "loadMoreFailed": "Hindi na-load ang karagdagang resulta.",
+    "searching": "Naghahanap...",
+    "connectionHint": "Pakisuri ang koneksyon at subukan muli.",
+    "retrySearch": "Ulitin ang paghahanap",
+    "retry": "Subukan muli",
+    "noResults": "Walang resulta para sa “{query}”",
+    "tryDifferentKeywords": "Subukan ang ibang keyword o mag-browse ng mga kategorya",
+    "loading": "Naglo-load...",
+    "loadMore": "Mag-load pa",
+    "categoryBibleStories": "Mga Kuwento sa Biblia",
+    "categoryParables": "Mga Talinghaga",
+    "categoryAnimated": "Animated",
+    "categoryStudy": "Pag-aaral",
+    "categoryFamily": "Pamilya",
+    "categoryChristmas": "Pasko"
+  },
+  "HeroPlayer": {
+    "playWithSound": "I-play na may tunog",
+    "tapToUnmute": "I-unmute"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Naglo-load ng content"
   }
 }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -152,5 +152,42 @@
     "loading": "Transkript yükleniyor…",
     "unavailable": "Bu altyazı parçası için transkript yok.",
     "empty": "Transkript satırı bulunamadı."
+  },
+  "FloatingSearch": {
+    "placeholder": "Konu ara veya keşfet…",
+    "openSearch": "Videolarda ara",
+    "searchRegion": "Videolarda ara",
+    "clearSearch": "Aramayı temizle",
+    "changeAudioLanguage": "Ses dilini değiştir",
+    "home": "JesusFilm ana sayfası"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Videolarda ara ve keşfet",
+    "home": "JesusFilm ana sayfası",
+    "placeholder": "Konu ara veya keşfet…",
+    "inputLabel": "Anahtar kelimeyle video ara",
+    "searchFailed": "Arama başarısız oldu. Lütfen tekrar deneyin.",
+    "loadMoreFailed": "Daha fazla sonuç yüklenemedi.",
+    "searching": "Aranıyor...",
+    "connectionHint": "Bağlantınızı kontrol edip tekrar deneyin.",
+    "retrySearch": "Aramayı yeniden dene",
+    "retry": "Tekrar dene",
+    "noResults": "“{query}” için sonuç yok",
+    "tryDifferentKeywords": "Farklı anahtar kelimeler deneyin veya kategorilere göz atın",
+    "loading": "Yükleniyor...",
+    "loadMore": "Daha fazla yükle",
+    "categoryBibleStories": "Kutsal Kitap Hikayeleri",
+    "categoryParables": "Benzetmeler",
+    "categoryAnimated": "Animasyon",
+    "categoryStudy": "Çalışma",
+    "categoryFamily": "Aile",
+    "categoryChristmas": "Noel"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Sesli oynat",
+    "tapToUnmute": "Sesi aç"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "İçerik yükleniyor"
   }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -152,5 +152,42 @@
     "loading": "Đang tải bản chép lời…",
     "unavailable": "Không có bản chép lời cho phụ đề này.",
     "empty": "Không tìm thấy dòng chép lời nào."
+  },
+  "FloatingSearch": {
+    "placeholder": "Tìm kiếm hoặc xem các chủ đề…",
+    "openSearch": "Tìm video",
+    "searchRegion": "Tìm video",
+    "clearSearch": "Xóa tìm kiếm",
+    "changeAudioLanguage": "Đổi ngôn ngữ âm thanh",
+    "home": "Trang chủ JesusFilm"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "Tìm kiếm và xem video",
+    "home": "Trang chủ JesusFilm",
+    "placeholder": "Tìm kiếm hoặc xem các chủ đề…",
+    "inputLabel": "Tìm video bằng từ khóa",
+    "searchFailed": "Tìm kiếm không thành công. Vui lòng thử lại.",
+    "loadMoreFailed": "Không tải được thêm kết quả.",
+    "searching": "Đang tìm...",
+    "connectionHint": "Vui lòng kiểm tra kết nối rồi thử lại.",
+    "retrySearch": "Tìm lại",
+    "retry": "Thử lại",
+    "noResults": "Không có kết quả cho “{query}”",
+    "tryDifferentKeywords": "Thử từ khóa khác hoặc xem các danh mục",
+    "loading": "Đang tải...",
+    "loadMore": "Tải thêm",
+    "categoryBibleStories": "Câu chuyện Kinh Thánh",
+    "categoryParables": "Dụ ngôn",
+    "categoryAnimated": "Hoạt hình",
+    "categoryStudy": "Học hỏi",
+    "categoryFamily": "Gia đình",
+    "categoryChristmas": "Giáng sinh"
+  },
+  "HeroPlayer": {
+    "playWithSound": "Phát có âm thanh",
+    "tapToUnmute": "Bật tiếng"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "Đang tải nội dung"
   }
 }

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -152,5 +152,42 @@
     "loading": "正在加载转录文本…",
     "unavailable": "此字幕轨道暂无转录文本。",
     "empty": "未找到转录文本行。"
+  },
+  "FloatingSearch": {
+    "placeholder": "搜索或浏览主题…",
+    "openSearch": "搜索视频",
+    "searchRegion": "搜索视频",
+    "clearSearch": "清除搜索",
+    "changeAudioLanguage": "更改音频语言",
+    "home": "JesusFilm 主页"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "搜索并浏览视频",
+    "home": "JesusFilm 主页",
+    "placeholder": "搜索或浏览主题…",
+    "inputLabel": "按关键词搜索视频",
+    "searchFailed": "搜索失败。请重试。",
+    "loadMoreFailed": "无法加载更多结果。",
+    "searching": "正在搜索...",
+    "connectionHint": "请检查网络连接后重试。",
+    "retrySearch": "重试搜索",
+    "retry": "重试",
+    "noResults": "没有找到“{query}”的结果",
+    "tryDifferentKeywords": "请尝试其他关键词或浏览分类",
+    "loading": "正在加载...",
+    "loadMore": "加载更多",
+    "categoryBibleStories": "圣经故事",
+    "categoryParables": "比喻",
+    "categoryAnimated": "动画",
+    "categoryStudy": "学习",
+    "categoryFamily": "家庭",
+    "categoryChristmas": "圣诞节"
+  },
+  "HeroPlayer": {
+    "playWithSound": "打开声音播放",
+    "tapToUnmute": "取消静音"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "正在加载内容"
   }
 }

--- a/apps/web/messages/zh-Hant.json
+++ b/apps/web/messages/zh-Hant.json
@@ -152,5 +152,42 @@
     "loading": "正在載入逐字稿…",
     "unavailable": "此字幕軌道暫無逐字稿。",
     "empty": "未找到逐字稿行。"
+  },
+  "FloatingSearch": {
+    "placeholder": "搜尋或瀏覽主題…",
+    "openSearch": "搜尋影片",
+    "searchRegion": "搜尋影片",
+    "clearSearch": "清除搜尋",
+    "changeAudioLanguage": "變更音訊語言",
+    "home": "JesusFilm 首頁"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "搜尋並瀏覽影片",
+    "home": "JesusFilm 首頁",
+    "placeholder": "搜尋或瀏覽主題…",
+    "inputLabel": "依關鍵字搜尋影片",
+    "searchFailed": "搜尋失敗。請再試一次。",
+    "loadMoreFailed": "無法載入更多結果。",
+    "searching": "搜尋中...",
+    "connectionHint": "請檢查網路連線後再試一次。",
+    "retrySearch": "重新搜尋",
+    "retry": "重試",
+    "noResults": "找不到「{query}」的結果",
+    "tryDifferentKeywords": "請嘗試其他關鍵字或瀏覽分類",
+    "loading": "載入中...",
+    "loadMore": "載入更多",
+    "categoryBibleStories": "聖經故事",
+    "categoryParables": "比喻",
+    "categoryAnimated": "動畫",
+    "categoryStudy": "學習",
+    "categoryFamily": "家庭",
+    "categoryChristmas": "聖誕節"
+  },
+  "HeroPlayer": {
+    "playWithSound": "開啟聲音播放",
+    "tapToUnmute": "取消靜音"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "正在載入內容"
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -152,5 +152,42 @@
     "loading": "正在加载转录文本…",
     "unavailable": "此字幕轨道暂无转录文本。",
     "empty": "未找到转录文本行。"
+  },
+  "FloatingSearch": {
+    "placeholder": "搜索或浏览主题…",
+    "openSearch": "搜索视频",
+    "searchRegion": "搜索视频",
+    "clearSearch": "清除搜索",
+    "changeAudioLanguage": "更改音频语言",
+    "home": "JesusFilm 主页"
+  },
+  "SearchOverlay": {
+    "dialogLabel": "搜索并浏览视频",
+    "home": "JesusFilm 主页",
+    "placeholder": "搜索或浏览主题…",
+    "inputLabel": "按关键词搜索视频",
+    "searchFailed": "搜索失败。请重试。",
+    "loadMoreFailed": "无法加载更多结果。",
+    "searching": "正在搜索...",
+    "connectionHint": "请检查网络连接后重试。",
+    "retrySearch": "重试搜索",
+    "retry": "重试",
+    "noResults": "没有找到“{query}”的结果",
+    "tryDifferentKeywords": "请尝试其他关键词或浏览分类",
+    "loading": "正在加载...",
+    "loadMore": "加载更多",
+    "categoryBibleStories": "圣经故事",
+    "categoryParables": "比喻",
+    "categoryAnimated": "动画",
+    "categoryStudy": "学习",
+    "categoryFamily": "家庭",
+    "categoryChristmas": "圣诞节"
+  },
+  "HeroPlayer": {
+    "playWithSound": "打开声音播放",
+    "tapToUnmute": "取消静音"
+  },
+  "ExperienceSkeleton": {
+    "loadingContent": "正在加载内容"
   }
 }

--- a/apps/web/src/components/ExperienceSkeleton.tsx
+++ b/apps/web/src/components/ExperienceSkeleton.tsx
@@ -1,4 +1,7 @@
+import { useTranslations } from "next-intl"
+
 export function ExperienceSkeleton() {
+  const t = useTranslations("ExperienceSkeleton")
   // Use <div> not <main>: this is a transient Suspense fallback that can
   // coexist briefly with the resolved page's real <main> during streaming,
   // which would give the document two <main> landmarks. The real page
@@ -7,7 +10,7 @@ export function ExperienceSkeleton() {
     <div
       role="status"
       aria-busy="true"
-      aria-label="Loading content"
+      aria-label={t("loadingContent")}
       className="min-h-screen bg-stone-900"
     >
       {/* Hero placeholder */}

--- a/apps/web/src/components/FloatingSearchBar.tsx
+++ b/apps/web/src/components/FloatingSearchBar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Search } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import {
   useFloatingSearch,
@@ -9,10 +10,11 @@ import {
 import { FloatingSearchFieldButton } from "./FloatingSearchField"
 
 export function FloatingSearchBar() {
+  const t = useTranslations("FloatingSearch")
   const { open, closing, query, setOpen } = useFloatingSearch()
   const { pinned, searchChromeVisible } = useFloatingSearchPinned()
 
-  const display = query.trim().length > 0 ? query : "Search or browse topics…"
+  const display = query.trim().length > 0 ? query : t("placeholder")
   const isPlaceholder = query.trim().length === 0
   const topClass = pinned
     ? "top-[calc(env(safe-area-inset-top,0px)+1rem)]"
@@ -29,7 +31,7 @@ export function FloatingSearchBar() {
     <>
       <button
         type="button"
-        aria-label="Search videos"
+        aria-label={t("openSearch")}
         data-testid="floating-search-mobile-button"
         onClick={() => setOpen(true)}
         inert={chromeHidden || undefined}
@@ -43,7 +45,7 @@ export function FloatingSearchBar() {
         />
       </button>
       <FloatingSearchFieldButton
-        aria-label="Search videos"
+        aria-label={t("openSearch")}
         data-testid="floating-search-desktop-button"
         onClick={() => setOpen(true)}
         inert={chromeHidden || undefined}

--- a/apps/web/src/components/FloatingSearchField.tsx
+++ b/apps/web/src/components/FloatingSearchField.tsx
@@ -7,6 +7,7 @@ import {
   type MouseEventHandler,
 } from "react"
 import { Search } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { GLASS_OUTLINE_CLASS } from "@/lib/glass-outline"
 
@@ -79,12 +80,13 @@ export const FloatingSearchFieldInput = forwardRef<
   },
   ref,
 ) {
+  const t = useTranslations("FloatingSearch")
   const hasValue = value.trim().length > 0
 
   return (
     <div
       role="search"
-      aria-label="Search videos"
+      aria-label={t("searchRegion")}
       className={`${FIELD_BASE_CLASS} ${FIELD_SOLID_CLASS} ${wrapperClassName ?? ""}`}
     >
       <Search
@@ -104,7 +106,7 @@ export const FloatingSearchFieldInput = forwardRef<
         <button
           type="button"
           onClick={onClear}
-          aria-label="Clear search"
+          aria-label={t("clearSearch")}
           className="-mr-2 cursor-pointer rounded-full p-2 text-stone-500 transition hover:text-stone-950 focus-visible:outline-2 focus-visible:outline-stone-950/50 focus-visible:outline-offset-2"
         >
           <svg

--- a/apps/web/src/components/FloatingSearchProvider.tsx
+++ b/apps/web/src/components/FloatingSearchProvider.tsx
@@ -17,6 +17,7 @@ import Link from "next/link"
 import type { Route } from "next"
 import { usePathname, useRouter } from "next/navigation"
 import { Globe } from "lucide-react"
+import { useTranslations } from "next-intl"
 
 import { runSearch } from "@/lib/search-actions"
 import type { SearchResult } from "@/lib/search"
@@ -99,6 +100,8 @@ export function useFloatingSearchPinned(): FloatingSearchPinnedContextValue {
 }
 
 export function FloatingSearchProvider({ children }: { children: ReactNode }) {
+  const t = useTranslations("FloatingSearch")
+  const tSearchOverlay = useTranslations("SearchOverlay")
   const router = useRouter()
   // usePathname() returns the app-relative path (no basePath prefix). The
   // router.replace() call auto-prefixes basePath, so feeding it
@@ -367,7 +370,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
         setHasMore(data.hasMore)
       } catch {
         if (requestIdRef.current === thisRequest) {
-          setError("Search failed. Please try again.")
+          setError(tSearchOverlay("searchFailed"))
         }
       } finally {
         // Only clear loading state for the winning request — otherwise a
@@ -379,7 +382,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
         }
       }
     },
-    [pathname, router],
+    [pathname, router, tSearchOverlay],
   )
 
   const loadMore = useCallback(async (): Promise<void> => {
@@ -403,13 +406,13 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
       setHasMore(data.hasMore)
     } catch {
       if (requestIdRef.current === thisRequest) {
-        setError("Failed to load more results.")
+        setError(tSearchOverlay("loadMoreFailed"))
       }
     } finally {
       loadingMoreRef.current = false
       setLoadingMore(false)
     }
-  }, [query, results.length])
+  }, [query, results.length, tSearchOverlay])
 
   const closeAndKeepQuery = useCallback(() => {
     setOpen(false)
@@ -545,8 +548,8 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
             type="button"
             data-testid="floating-header-language-button"
             onClick={headerLanguageSwitcher.onClick}
-            aria-label="Change audio language"
-            title="Change audio language"
+            aria-label={t("changeAudioLanguage")}
+            title={t("changeAudioLanguage")}
             inert={headerChromeHidden || undefined}
             aria-hidden={headerChromeHidden || undefined}
             className={`fixed right-10 z-50 inline-flex h-[52px] w-12 cursor-pointer items-center justify-center rounded-full text-stone-100 transition-[top,opacity,color] duration-300 ease-out hover:text-white focus-visible:ring-2 focus-visible:ring-stone-300 focus-visible:outline-none ${
@@ -567,7 +570,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
         ) : null}
         <Link
           href={"/" as Route}
-          aria-label="JesusFilm home"
+          aria-label={t("home")}
           data-testid="floating-header-logo"
           inert={headerChromeHidden || undefined}
           aria-hidden={headerChromeHidden || undefined}

--- a/apps/web/src/components/SearchOverlay.tsx
+++ b/apps/web/src/components/SearchOverlay.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import type { Route } from "next"
+import { useTranslations } from "next-intl"
 
 import { useFloatingSearch } from "./FloatingSearchProvider"
 import { FloatingSearchFieldInput } from "./FloatingSearchField"
@@ -12,8 +13,27 @@ import { VideoCard } from "./search/VideoCard"
 import { SpinnerIcon } from "@/components/ui/spinner"
 import { WatchModalViewportCloseButton } from "@/components/watch/WatchModalViewportCloseButton"
 import { CATEGORIES } from "@/lib/search-categories"
+import type { CategorySearchTerm } from "@/lib/search-categories"
+
+const CATEGORY_TITLE_KEYS: Record<
+  CategorySearchTerm,
+  | "categoryBibleStories"
+  | "categoryParables"
+  | "categoryAnimated"
+  | "categoryStudy"
+  | "categoryFamily"
+  | "categoryChristmas"
+> = {
+  "bible stories": "categoryBibleStories",
+  parables: "categoryParables",
+  animated: "categoryAnimated",
+  study: "categoryStudy",
+  family: "categoryFamily",
+  christmas: "categoryChristmas",
+}
 
 export function SearchOverlay() {
+  const t = useTranslations("SearchOverlay")
   const {
     open,
     closing,
@@ -136,7 +156,7 @@ export function SearchOverlay() {
       ref={setOverlayElement}
       role="dialog"
       aria-modal="true"
-      aria-label="Search and browse videos"
+      aria-label={t("dialogLabel")}
       onClick={() => closeAndKeepQuery()}
       className={`fixed inset-0 h-dvh min-h-dvh overflow-visible ${closing ? "animate-overlay-fade-out" : "animate-overlay-fade-in"}`}
       style={{
@@ -163,7 +183,7 @@ export function SearchOverlay() {
       >
         <Link
           href={"/" as Route}
-          aria-label="JesusFilm home"
+          aria-label={t("home")}
           // stopPropagation keeps the overlay from intercepting the click as
           // a backdrop dismiss; search("") clears the query + ?q= + cached
           // results so home navigation lands on a fresh search bar.
@@ -191,8 +211,8 @@ export function SearchOverlay() {
             value={query}
             onChange={handleInputChange}
             onClear={handleClearInput}
-            placeholder="Search or browse topics…"
-            aria-label="Search videos by keyword"
+            placeholder={t("placeholder")}
+            aria-label={t("inputLabel")}
             iconTestId="search-overlay-input-icon"
             wrapperClassName="w-full"
           />
@@ -228,12 +248,13 @@ export function SearchOverlay() {
             <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
               {CATEGORIES.map((cat) => {
                 const Icon = CATEGORY_ICON_BY_SEARCH_TERM[cat.searchTerm]
+                const title = t(CATEGORY_TITLE_KEYS[cat.searchTerm])
                 return (
                   <button
                     key={cat.searchTerm}
                     type="button"
                     onClick={() => handleCategoryClick(cat.searchTerm)}
-                    aria-label={cat.title}
+                    aria-label={title}
                     data-testid={`search-overlay-category-${cat.searchTerm.replace(/\s+/g, "-")}`}
                     className="relative aspect-video w-full cursor-pointer overflow-hidden rounded-lg p-3 text-white transition-transform duration-200 active:scale-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 [@media(hover:hover)]:hover:scale-105 sm:p-6"
                     style={{ background: cat.gradient }}
@@ -254,7 +275,7 @@ export function SearchOverlay() {
                       className="absolute bottom-3 left-3 text-base font-semibold leading-tight sm:text-lg md:text-xl"
                       style={{ textShadow: "0 1px 3px rgba(0,0,0,0.4)" }}
                     >
-                      {cat.title}
+                      {title}
                     </span>
                   </button>
                 )
@@ -279,20 +300,22 @@ export function SearchOverlay() {
             </div>
           )}
 
-          {loading && !showSkeleton && <p className="sr-only">Searching...</p>}
+          {loading && !showSkeleton && (
+            <p className="sr-only">{t("searching")}</p>
+          )}
 
           {!loading && searched && displayResults.length === 0 && error && (
             <div className="flex flex-col items-center justify-center py-20 text-center">
               <h2 className="text-lg font-semibold text-stone-200">{error}</h2>
               <p className="mt-2 text-sm text-stone-500">
-                Please check your connection and try again.
+                {t("connectionHint")}
               </p>
               <button
                 type="button"
                 onClick={() => void search(query)}
                 className="mt-4 cursor-pointer rounded-lg bg-stone-700 px-4 py-2 text-sm text-stone-200 transition hover:bg-stone-600 focus-visible:outline-2 focus-visible:outline-white/80 focus-visible:outline-offset-2"
               >
-                Retry search
+                {t("retrySearch")}
               </button>
             </div>
           )}
@@ -300,10 +323,10 @@ export function SearchOverlay() {
           {!loading && searched && displayResults.length === 0 && !error && (
             <div className="flex flex-col items-center justify-center py-20 text-center">
               <h2 className="text-lg font-semibold text-stone-200">
-                No results for &apos;{query.trim()}&apos;
+                {t("noResults", { query: query.trim() })}
               </h2>
               <p className="mt-2 text-sm text-stone-500">
-                Try different keywords or browse categories
+                {t("tryDifferentKeywords")}
               </p>
             </div>
           )}
@@ -333,7 +356,7 @@ export function SearchOverlay() {
                     disabled={loadingMore}
                     className="mt-2 cursor-pointer rounded-lg bg-stone-700 px-4 py-2 text-sm text-stone-200 transition hover:bg-stone-600 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    Retry
+                    {t("retry")}
                   </button>
                 </div>
               )}
@@ -349,7 +372,7 @@ export function SearchOverlay() {
                     {loadingMore && (
                       <SpinnerIcon className="h-4 w-4 animate-spin" />
                     )}
-                    {loadingMore ? "Loading..." : "Load more"}
+                    {loadingMore ? t("loading") : t("loadMore")}
                   </button>
                 </div>
               )}

--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -12,6 +12,7 @@ import {
 } from "react"
 import { useSearchParams } from "next/navigation"
 import dynamic from "next/dynamic"
+import { useTranslations } from "next-intl"
 import type {
   MuxPlayer as MuxPlayerType,
   MuxVideo as MuxVideoType,
@@ -138,6 +139,7 @@ export function HeroPlayer({
   overlay?: ReactNode
   subtitleVttSrc?: string | null
 }) {
+  const t = useTranslations("HeroPlayer")
   const { video, variant } = block
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const playerRef = useRef<MuxPlayerRef | null>(null)
@@ -626,6 +628,8 @@ export function HeroPlayer({
   const showLanguageSwitch = hasLanguageSwitcher && !isFullscreen
   const showTopLanguageSwitch =
     showLanguageSwitch && (!chromeRevealed || controlsChromeVisible)
+  const preRevealActionLabel =
+    pillState === "tap-to-unmute" ? t("tapToUnmute") : t("playWithSound")
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -756,11 +760,7 @@ export function HeroPlayer({
           <button
             type="button"
             data-testid="hero-player-pre-reveal-click-surface"
-            aria-label={
-              pillState === "tap-to-unmute"
-                ? "Tap to Unmute"
-                : "Play with Sound"
-            }
+            aria-label={preRevealActionLabel}
             onClick={handleUnmuteClick}
             className="absolute inset-0 z-1 cursor-pointer bg-transparent focus:outline-none"
           />
@@ -855,11 +855,7 @@ export function HeroPlayer({
                   type="button"
                   data-testid="hero-player-unmute-pill"
                   data-state={pillState}
-                  aria-label={
-                    pillState === "tap-to-unmute"
-                      ? "Tap to Unmute"
-                      : "Play with Sound"
-                  }
+                  aria-label={preRevealActionLabel}
                   onClick={handleUnmuteClick}
                   className={
                     pillState === "tap-to-unmute"
@@ -872,11 +868,7 @@ export function HeroPlayer({
                   ) : (
                     <UnmutedSpeakerIcon />
                   )}
-                  <span>
-                    {pillState === "tap-to-unmute"
-                      ? "Tap to Unmute"
-                      : "Play with Sound"}
-                  </span>
+                  <span>{preRevealActionLabel}</span>
                 </button>
               </div>
             ))

--- a/docs/roadmap/platform/feat-150-watch-catalog-driven-ui-locale.md
+++ b/docs/roadmap/platform/feat-150-watch-catalog-driven-ui-locale.md
@@ -11,7 +11,8 @@ tags:
   - routing
 depends_on:
   - feat-148
-blocks: []
+blocks:
+  - feat-151
 ---
 
 ## Problem

--- a/docs/roadmap/platform/feat-151-watch-visible-chrome-localization.md
+++ b/docs/roadmap/platform/feat-151-watch-visible-chrome-localization.md
@@ -1,0 +1,42 @@
+---
+id: feat-151
+title: Localize visible watch chrome strings
+status: "complete"
+priority: high
+area: platform
+tags:
+  - web
+  - watch-page
+  - i18n
+depends_on:
+  - feat-150
+blocks: []
+---
+
+## Problem
+
+Russian watch URLs now resolve to the Russian UI catalog, but some first-screen
+chrome still renders English because the strings are hardcoded in client
+components instead of read from `next-intl`.
+
+## Entry Points
+
+- `apps/web/src/components/FloatingSearchBar.tsx`
+- `apps/web/src/components/FloatingSearchField.tsx`
+- `apps/web/src/components/FloatingSearchProvider.tsx`
+- `apps/web/src/components/SearchOverlay.tsx`
+- `apps/web/src/components/watch/HeroPlayer.tsx`
+- `apps/web/src/components/ExperienceSkeleton.tsx`
+- `apps/web/messages/*.json`
+
+## What To Build
+
+Move the visible watch chrome strings for floating search, search overlay,
+hero-player pre-reveal controls, and loading skeletons into message catalogs.
+Keep search terms themselves stable so backend search behavior does not change.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/i18n/__tests__/messages-parity.test.ts`
+- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx`
+- Production smoke for `/watch/parable-of-the-pharisee-and-tax-collector.html/russian.html` should show `ru` HTML plus localized visible chrome.


### PR DESCRIPTION
## Summary
- Localizes remaining first-screen watch chrome strings for floating search, search overlay, hero pre-reveal controls, and loading skeletons.
- Adds the new visible chrome strings to every available UI catalog, including Russian.
- Adds a follow-up roadmap ticket for the visible-chrome gap and links it back from feat-150.

## Verification
- pnpm --filter @forge/web test -- src/i18n/__tests__/messages-parity.test.ts src/components/__tests__/FloatingSearchProvider.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- pnpm --filter @forge/web build

## Notes
- Live production already rewrites the Russian public URL to /watch/ru/ru/..., but the page still exposed hardcoded English strings such as Search videos and Play with Sound. This PR wires those visible strings through next-intl.