### PR TITLE
chore(web): retrigger watch deploy

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -50,7 +50,9 @@ import { fetchYouVersionBibleQuotePassages } from "@/lib/youversion-passage"
 // ISR: pages cached for 60s. Cookie-driven language redirect lives in
 // apps/web/src/proxy.ts (middleware) — keeping cookies() out of this page
 // route preserves ISR for the majority of traffic without the preference
-// cookie. See docs/solutions/web/nextjs-headers-defeats-route-cache.md.
+// cookie. Keep the build output clean so runtime ISR artifacts from old
+// deploys cannot be packaged as fresh pages. See
+// docs/solutions/web/nextjs-headers-defeats-route-cache.md.
 export const revalidate = 60
 export const dynamic = "force-static"
 export const dynamicParams = true


### PR DESCRIPTION
## Summary
- touch the watch catch-all source near the ISR notes so Railway's @forge/web path filter redeploys the service
- keep the clean-build cache note close to the route config

## Verification
- pnpm --filter @forge/web lint