### PR TITLE
fix(web): pass watch locale messages to intl provider

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/layout.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/layout.tsx
@@ -13,6 +13,10 @@ import {
 import { montserrat } from "@/lib/watch-font"
 import { FloatingSearchProvider } from "@/components/FloatingSearchProvider"
 
+async function loadMessages(locale: UiLocale) {
+  return (await import(`../../../../messages/${locale}.json`)).default
+}
+
 function boundedUiLocale(locale: string): UiLocale {
   return hasUiLocale(locale) ? (locale as UiLocale) : DEFAULT_LOCALE
 }
@@ -67,6 +71,7 @@ export default async function RootLayout({
   const htmlLang =
     htmlLangIdentity.locale === locale ? htmlLangIdentity.htmlLang : locale
   setRequestLocale(locale)
+  const messages = await loadMessages(locale)
   return (
     <html
       lang={htmlLang}
@@ -83,7 +88,7 @@ export default async function RootLayout({
         <link rel="dns-prefetch" href="https://imagedelivery.net" />
       </head>
       <body className="overflow-x-clip bg-black">
-        <NextIntlClientProvider>
+        <NextIntlClientProvider locale={locale} messages={messages}>
           <FloatingSearchProvider>{children}</FloatingSearchProvider>
         </NextIntlClientProvider>
       </body>

--- a/apps/web/src/components/ExperienceSkeleton.tsx
+++ b/apps/web/src/components/ExperienceSkeleton.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useTranslations } from "next-intl"
 
 export function ExperienceSkeleton() {


### PR DESCRIPTION
## Summary
- Load the resolved watch UI catalog in the locale layout and pass it directly to NextIntlClientProvider
- Render the loading skeleton as a client component so it reads the same provider messages

## Validation
- pnpm --filter @forge/web lint
- pnpm --filter @forge/web test -- src/i18n/__tests__/messages-parity.test.ts
- pnpm --filter @forge/web build
- local production smoke: /watch/parable-of-the-pharisee-and-tax-collector.html/russian.html emits Russian chrome and no matched English fallback strings