### PR TITLE
fix(web): localize remaining watch UI labels

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "جارٍ التحقق",
     "download": "تنزيل",
-    "sessionError": "تعذّر التحقق من جلستك. يُرجى المحاولة مرة أخرى."
+    "sessionError": "تعذّر التحقق من جلستك. يُرجى المحاولة مرة أخرى.",
+    "saveVideo": "حفظ الفيديو"
   },
   "DownloadModal": {
     "dialogTitle": "تنزيل الفيديو",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "جارٍ تحميل المحتوى"
+  },
+  "VideoLabels": {
+    "video": "فيديو",
+    "segment": "مقطع",
+    "episode": "حلقة",
+    "featureFilm": "فيلم طويل",
+    "shortFilm": "فيلم قصير",
+    "series": "سلسلة",
+    "collection": "مجموعة",
+    "trailer": "إعلان تشويقي",
+    "behindTheScenes": "خلف الكواليس"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "المقطع {current} من {total}",
+    "position": "{current} من {total}",
+    "chapterCount": "{count, plural, zero {# فصول} one {# فصل} two {# فصلان} few {# فصول} many {# فصلًا} other {# فصل}}",
+    "clipAriaLabel": "{title} · المقطع {current} من {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, zero {# فصول} one {# فصل} two {# فصلان} few {# فصول} many {# فصلًا} other {# فصل}}",
+    "chapter": "فصل",
+    "noImage": "لا توجد صورة",
+    "playingNow": "يتم التشغيل الآن",
+    "previousChapter": "الفصل السابق",
+    "nextChapter": "الفصل التالي"
+  },
+  "SearchResultCard": {
+    "experience": "تجربة",
+    "episodeCount": "{count, plural, zero {# حلقات} one {# حلقة} two {# حلقتان} few {# حلقات} many {# حلقة} other {# حلقة}}",
+    "thumbnailAlt": "صورة مصغرة للفيديو"
   }
 }

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Wird geprüft",
     "download": "Herunterladen",
-    "sessionError": "Sitzung konnte nicht geprüft werden. Bitte versuche es erneut."
+    "sessionError": "Sitzung konnte nicht geprüft werden. Bitte versuche es erneut.",
+    "saveVideo": "Video speichern"
   },
   "DownloadModal": {
     "dialogTitle": "Video herunterladen",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Inhalt wird geladen"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Abschnitt",
+    "episode": "Folge",
+    "featureFilm": "Spielfilm",
+    "shortFilm": "Kurzfilm",
+    "series": "Serie",
+    "collection": "Sammlung",
+    "trailer": "Trailer",
+    "behindTheScenes": "Hinter den Kulissen"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Clip {current} von {total}",
+    "position": "{current} von {total}",
+    "chapterCount": "{count, plural, one {# Kapitel} other {# Kapitel}}",
+    "clipAriaLabel": "{title} · Clip {current} von {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# Kapitel} other {# Kapitel}}",
+    "chapter": "Kapitel",
+    "noImage": "Kein Bild",
+    "playingNow": "Wird gerade abgespielt",
+    "previousChapter": "Vorheriges Kapitel",
+    "nextChapter": "Nächstes Kapitel"
+  },
+  "SearchResultCard": {
+    "experience": "Experience",
+    "episodeCount": "{count, plural, one {# Folge} other {# Folgen}}",
+    "thumbnailAlt": "Video-Miniaturbild"
   }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Checking",
     "download": "Download",
-    "sessionError": "Unable to check your session. Please try again."
+    "sessionError": "Unable to check your session. Please try again.",
+    "saveVideo": "Save Video"
   },
   "DownloadModal": {
     "dialogTitle": "Download video",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Loading content"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Segment",
+    "episode": "Episode",
+    "featureFilm": "Feature Film",
+    "shortFilm": "Short Film",
+    "series": "Series",
+    "collection": "Collection",
+    "trailer": "Trailer",
+    "behindTheScenes": "Behind the Scenes"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Clip {current} of {total}",
+    "position": "{current} of {total}",
+    "chapterCount": "{count, plural, one {# chapter} other {# chapters}}",
+    "clipAriaLabel": "{title} · Clip {current} of {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# chapter} other {# chapters}}",
+    "chapter": "Chapter",
+    "noImage": "No image",
+    "playingNow": "Playing now",
+    "previousChapter": "Previous chapter",
+    "nextChapter": "Next chapter"
+  },
+  "SearchResultCard": {
+    "experience": "Experience",
+    "episodeCount": "{count, plural, one {# episode} other {# episodes}}",
+    "thumbnailAlt": "Video thumbnail"
   }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Comprobando",
     "download": "Descargar",
-    "sessionError": "No se pudo comprobar tu sesión. Inténtalo de nuevo."
+    "sessionError": "No se pudo comprobar tu sesión. Inténtalo de nuevo.",
+    "saveVideo": "Guardar video"
   },
   "DownloadModal": {
     "dialogTitle": "Descargar video",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Cargando contenido"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Segmento",
+    "episode": "Episodio",
+    "featureFilm": "Largometraje",
+    "shortFilm": "Cortometraje",
+    "series": "Serie",
+    "collection": "Colección",
+    "trailer": "Tráiler",
+    "behindTheScenes": "Detrás de cámaras"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Fragmento {current} de {total}",
+    "position": "{current} de {total}",
+    "chapterCount": "{count, plural, one {# capítulo} other {# capítulos}}",
+    "clipAriaLabel": "{title} · fragmento {current} de {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# capítulo} other {# capítulos}}",
+    "chapter": "Capítulo",
+    "noImage": "Sin imagen",
+    "playingNow": "Reproduciendo ahora",
+    "previousChapter": "Capítulo anterior",
+    "nextChapter": "Capítulo siguiente"
+  },
+  "SearchResultCard": {
+    "experience": "Experiencia",
+    "episodeCount": "{count, plural, one {# episodio} other {# episodios}}",
+    "thumbnailAlt": "Miniatura del video"
   }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Vérification",
     "download": "Télécharger",
-    "sessionError": "Impossible de vérifier votre session. Veuillez réessayer."
+    "sessionError": "Impossible de vérifier votre session. Veuillez réessayer.",
+    "saveVideo": "Enregistrer la vidéo"
   },
   "DownloadModal": {
     "dialogTitle": "Télécharger la vidéo",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Chargement du contenu"
+  },
+  "VideoLabels": {
+    "video": "Vidéo",
+    "segment": "Segment",
+    "episode": "Épisode",
+    "featureFilm": "Long métrage",
+    "shortFilm": "Court métrage",
+    "series": "Série",
+    "collection": "Collection",
+    "trailer": "Bande-annonce",
+    "behindTheScenes": "Coulisses"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Extrait {current} sur {total}",
+    "position": "{current} sur {total}",
+    "chapterCount": "{count, plural, one {# chapitre} other {# chapitres}}",
+    "clipAriaLabel": "{title} · extrait {current} sur {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# chapitre} other {# chapitres}}",
+    "chapter": "Chapitre",
+    "noImage": "Aucune image",
+    "playingNow": "Lecture en cours",
+    "previousChapter": "Chapitre précédent",
+    "nextChapter": "Chapitre suivant"
+  },
+  "SearchResultCard": {
+    "experience": "Expérience",
+    "episodeCount": "{count, plural, one {# épisode} other {# épisodes}}",
+    "thumbnailAlt": "Miniature de la vidéo"
   }
 }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Memeriksa",
     "download": "Unduh",
-    "sessionError": "Tidak dapat memeriksa sesi Anda. Coba lagi."
+    "sessionError": "Tidak dapat memeriksa sesi Anda. Coba lagi.",
+    "saveVideo": "Simpan video"
   },
   "DownloadModal": {
     "dialogTitle": "Unduh video",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Memuat konten"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Segmen",
+    "episode": "Episode",
+    "featureFilm": "Film panjang",
+    "shortFilm": "Film pendek",
+    "series": "Serial",
+    "collection": "Koleksi",
+    "trailer": "Trailer",
+    "behindTheScenes": "Di balik layar"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Klip {current} dari {total}",
+    "position": "{current} dari {total}",
+    "chapterCount": "{count, plural, one {# bab} other {# bab}}",
+    "clipAriaLabel": "{title} · klip {current} dari {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# bab} other {# bab}}",
+    "chapter": "Bab",
+    "noImage": "Tidak ada gambar",
+    "playingNow": "Sedang diputar",
+    "previousChapter": "Bab sebelumnya",
+    "nextChapter": "Bab berikutnya"
+  },
+  "SearchResultCard": {
+    "experience": "Pengalaman",
+    "episodeCount": "{count, plural, one {# episode} other {# episode}}",
+    "thumbnailAlt": "Gambar mini video"
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "確認中",
     "download": "ダウンロード",
-    "sessionError": "セッションを確認できませんでした。もう一度お試しください。"
+    "sessionError": "セッションを確認できませんでした。もう一度お試しください。",
+    "saveVideo": "動画を保存"
   },
   "DownloadModal": {
     "dialogTitle": "ビデオをダウンロード",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "コンテンツを読み込み中"
+  },
+  "VideoLabels": {
+    "video": "動画",
+    "segment": "セグメント",
+    "episode": "エピソード",
+    "featureFilm": "長編映画",
+    "shortFilm": "短編映画",
+    "series": "シリーズ",
+    "collection": "コレクション",
+    "trailer": "予告編",
+    "behindTheScenes": "舞台裏"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "クリップ {current}/{total}",
+    "position": "{current}/{total}",
+    "chapterCount": "{count, plural, other {# チャプター}}",
+    "clipAriaLabel": "{title} · クリップ {current}/{total}",
+    "chaptersAriaLabel": "{title} · {count, plural, other {# チャプター}}",
+    "chapter": "チャプター",
+    "noImage": "画像なし",
+    "playingNow": "再生中",
+    "previousChapter": "前のチャプター",
+    "nextChapter": "次のチャプター"
+  },
+  "SearchResultCard": {
+    "experience": "体験",
+    "episodeCount": "{count, plural, other {# エピソード}}",
+    "thumbnailAlt": "動画サムネイル"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "확인 중",
     "download": "다운로드",
-    "sessionError": "세션을 확인할 수 없습니다. 다시 시도하세요."
+    "sessionError": "세션을 확인할 수 없습니다. 다시 시도하세요.",
+    "saveVideo": "동영상 저장"
   },
   "DownloadModal": {
     "dialogTitle": "비디오 다운로드",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "콘텐츠 불러오는 중"
+  },
+  "VideoLabels": {
+    "video": "동영상",
+    "segment": "세그먼트",
+    "episode": "에피소드",
+    "featureFilm": "장편 영화",
+    "shortFilm": "단편 영화",
+    "series": "시리즈",
+    "collection": "컬렉션",
+    "trailer": "예고편",
+    "behindTheScenes": "비하인드 스토리"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "{total}개 중 {current}번째 클립",
+    "position": "{current}/{total}",
+    "chapterCount": "{count, plural, other {#개 챕터}}",
+    "clipAriaLabel": "{title} · {total}개 중 {current}번째 클립",
+    "chaptersAriaLabel": "{title} · {count, plural, other {#개 챕터}}",
+    "chapter": "챕터",
+    "noImage": "이미지 없음",
+    "playingNow": "재생 중",
+    "previousChapter": "이전 챕터",
+    "nextChapter": "다음 챕터"
+  },
+  "SearchResultCard": {
+    "experience": "체험",
+    "episodeCount": "{count, plural, other {#개 에피소드}}",
+    "thumbnailAlt": "동영상 썸네일"
   }
 }

--- a/apps/web/messages/ms.json
+++ b/apps/web/messages/ms.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Menyemak",
     "download": "Muat turun",
-    "sessionError": "Tidak dapat menyemak sesi anda. Cuba lagi."
+    "sessionError": "Tidak dapat menyemak sesi anda. Cuba lagi.",
+    "saveVideo": "Simpan video"
   },
   "DownloadModal": {
     "dialogTitle": "Muat turun video",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Memuatkan kandungan"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Segmen",
+    "episode": "Episod",
+    "featureFilm": "Filem cereka",
+    "shortFilm": "Filem pendek",
+    "series": "Siri",
+    "collection": "Koleksi",
+    "trailer": "Treler",
+    "behindTheScenes": "Di sebalik tabir"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Klip {current} daripada {total}",
+    "position": "{current} daripada {total}",
+    "chapterCount": "{count, plural, one {# bab} other {# bab}}",
+    "clipAriaLabel": "{title} · klip {current} daripada {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# bab} other {# bab}}",
+    "chapter": "Bab",
+    "noImage": "Tiada imej",
+    "playingNow": "Sedang dimainkan",
+    "previousChapter": "Bab sebelumnya",
+    "nextChapter": "Bab seterusnya"
+  },
+  "SearchResultCard": {
+    "experience": "Pengalaman",
+    "episodeCount": "{count, plural, one {# episod} other {# episod}}",
+    "thumbnailAlt": "Imej kecil video"
   }
 }

--- a/apps/web/messages/ne.json
+++ b/apps/web/messages/ne.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "जाँच गर्दै",
     "download": "डाउनलोड गर्नुहोस्",
-    "sessionError": "तपाईंको सत्र जाँच गर्न सकिएन। फेरि प्रयास गर्नुहोस्।"
+    "sessionError": "तपाईंको सत्र जाँच गर्न सकिएन। फेरि प्रयास गर्नुहोस्।",
+    "saveVideo": "भिडियो सुरक्षित गर्नुहोस्"
   },
   "DownloadModal": {
     "dialogTitle": "भिडियो डाउनलोड गर्नुहोस्",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "सामग्री लोड हुँदैछ"
+  },
+  "VideoLabels": {
+    "video": "भिडियो",
+    "segment": "खण्ड",
+    "episode": "एपिसोड",
+    "featureFilm": "फिचर फिल्म",
+    "shortFilm": "छोटो फिल्म",
+    "series": "श्रृंखला",
+    "collection": "संग्रह",
+    "trailer": "ट्रेलर",
+    "behindTheScenes": "पर्दा पछाडि"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "क्लिप {current} / {total}",
+    "position": "{current} / {total}",
+    "chapterCount": "{count, plural, one {# अध्याय} other {# अध्याय}}",
+    "clipAriaLabel": "{title} · क्लिप {current} / {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# अध्याय} other {# अध्याय}}",
+    "chapter": "अध्याय",
+    "noImage": "तस्बिर छैन",
+    "playingNow": "अहिले चलिरहेको",
+    "previousChapter": "अघिल्लो अध्याय",
+    "nextChapter": "अर्को अध्याय"
+  },
+  "SearchResultCard": {
+    "experience": "अनुभव",
+    "episodeCount": "{count, plural, one {# एपिसोड} other {# एपिसोड}}",
+    "thumbnailAlt": "भिडियो थम्बनेल"
   }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Verificando",
     "download": "Baixar",
-    "sessionError": "Não foi possível verificar sua sessão. Tente novamente."
+    "sessionError": "Não foi possível verificar sua sessão. Tente novamente.",
+    "saveVideo": "Salvar vídeo"
   },
   "DownloadModal": {
     "dialogTitle": "Baixar vídeo",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Carregando conteúdo"
+  },
+  "VideoLabels": {
+    "video": "Vídeo",
+    "segment": "Segmento",
+    "episode": "Episódio",
+    "featureFilm": "Longa-metragem",
+    "shortFilm": "Curta-metragem",
+    "series": "Série",
+    "collection": "Coleção",
+    "trailer": "Trailer",
+    "behindTheScenes": "Bastidores"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Clipe {current} de {total}",
+    "position": "{current} de {total}",
+    "chapterCount": "{count, plural, one {# capítulo} other {# capítulos}}",
+    "clipAriaLabel": "{title} · clipe {current} de {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# capítulo} other {# capítulos}}",
+    "chapter": "Capítulo",
+    "noImage": "Sem imagem",
+    "playingNow": "Reproduzindo agora",
+    "previousChapter": "Capítulo anterior",
+    "nextChapter": "Próximo capítulo"
+  },
+  "SearchResultCard": {
+    "experience": "Experiência",
+    "episodeCount": "{count, plural, one {# episódio} other {# episódios}}",
+    "thumbnailAlt": "Miniatura do vídeo"
   }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Проверяем",
     "download": "Скачать",
-    "sessionError": "Не удалось проверить сеанс. Попробуйте еще раз."
+    "sessionError": "Не удалось проверить сеанс. Попробуйте еще раз.",
+    "saveVideo": "Сохранить видео"
   },
   "DownloadModal": {
     "dialogTitle": "Скачать видео",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Загрузка контента"
+  },
+  "VideoLabels": {
+    "video": "Видео",
+    "segment": "Фрагмент",
+    "episode": "Серия",
+    "featureFilm": "Полнометражный фильм",
+    "shortFilm": "Короткометражный фильм",
+    "series": "Сериал",
+    "collection": "Коллекция",
+    "trailer": "Трейлер",
+    "behindTheScenes": "За кадром"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Фрагмент {current} из {total}",
+    "position": "{current} из {total}",
+    "chapterCount": "{count, plural, one {# глава} few {# главы} many {# глав} other {# главы}}",
+    "clipAriaLabel": "{title} · фрагмент {current} из {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# глава} few {# главы} many {# глав} other {# главы}}",
+    "chapter": "Глава",
+    "noImage": "Нет изображения",
+    "playingNow": "Сейчас воспроизводится",
+    "previousChapter": "Предыдущая глава",
+    "nextChapter": "Следующая глава"
+  },
+  "SearchResultCard": {
+    "experience": "Интерактив",
+    "episodeCount": "{count, plural, one {# серия} few {# серии} many {# серий} other {# серии}}",
+    "thumbnailAlt": "Миниатюра видео"
   }
 }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "กำลังตรวจสอบ",
     "download": "ดาวน์โหลด",
-    "sessionError": "ไม่สามารถตรวจสอบเซสชันของคุณได้ โปรดลองอีกครั้ง"
+    "sessionError": "ไม่สามารถตรวจสอบเซสชันของคุณได้ โปรดลองอีกครั้ง",
+    "saveVideo": "บันทึกวิดีโอ"
   },
   "DownloadModal": {
     "dialogTitle": "ดาวน์โหลดวิดีโอ",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "กำลังโหลดเนื้อหา"
+  },
+  "VideoLabels": {
+    "video": "วิดีโอ",
+    "segment": "ช่วง",
+    "episode": "ตอน",
+    "featureFilm": "ภาพยนตร์ขนาดยาว",
+    "shortFilm": "ภาพยนตร์สั้น",
+    "series": "ซีรีส์",
+    "collection": "คอลเลกชัน",
+    "trailer": "ตัวอย่าง",
+    "behindTheScenes": "เบื้องหลัง"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "คลิป {current} จาก {total}",
+    "position": "{current} จาก {total}",
+    "chapterCount": "{count, plural, other {# บท}}",
+    "clipAriaLabel": "{title} · คลิป {current} จาก {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, other {# บท}}",
+    "chapter": "บท",
+    "noImage": "ไม่มีรูปภาพ",
+    "playingNow": "กำลังเล่นอยู่",
+    "previousChapter": "บทก่อนหน้า",
+    "nextChapter": "บทถัดไป"
+  },
+  "SearchResultCard": {
+    "experience": "ประสบการณ์",
+    "episodeCount": "{count, plural, other {# ตอน}}",
+    "thumbnailAlt": "ภาพตัวอย่างวิดีโอ"
   }
 }

--- a/apps/web/messages/tl.json
+++ b/apps/web/messages/tl.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Tinitingnan",
     "download": "I-download",
-    "sessionError": "Hindi masuri ang iyong session. Subukan muli."
+    "sessionError": "Hindi masuri ang iyong session. Subukan muli.",
+    "saveVideo": "I-save ang video"
   },
   "DownloadModal": {
     "dialogTitle": "I-download ang video",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Naglo-load ng content"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Segmento",
+    "episode": "Episode",
+    "featureFilm": "Tampok na pelikula",
+    "shortFilm": "Maikling pelikula",
+    "series": "Serye",
+    "collection": "Koleksyon",
+    "trailer": "Trailer",
+    "behindTheScenes": "Sa likod ng mga eksena"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Klip {current} ng {total}",
+    "position": "{current} ng {total}",
+    "chapterCount": "{count, plural, one {# kabanata} other {# kabanata}}",
+    "clipAriaLabel": "{title} · klip {current} ng {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# kabanata} other {# kabanata}}",
+    "chapter": "Kabanata",
+    "noImage": "Walang larawan",
+    "playingNow": "Kasalukuyang pinapanood",
+    "previousChapter": "Nakaraang kabanata",
+    "nextChapter": "Susunod na kabanata"
+  },
+  "SearchResultCard": {
+    "experience": "Karanasan",
+    "episodeCount": "{count, plural, one {# episode} other {# episode}}",
+    "thumbnailAlt": "Thumbnail ng video"
   }
 }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Kontrol ediliyor",
     "download": "İndir",
-    "sessionError": "Oturumunuz kontrol edilemedi. Lütfen tekrar deneyin."
+    "sessionError": "Oturumunuz kontrol edilemedi. Lütfen tekrar deneyin.",
+    "saveVideo": "Videoyu kaydet"
   },
   "DownloadModal": {
     "dialogTitle": "Videoyu indir",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "İçerik yükleniyor"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Kesit",
+    "episode": "Bölüm",
+    "featureFilm": "Uzun metrajlı film",
+    "shortFilm": "Kısa film",
+    "series": "Dizi",
+    "collection": "Koleksiyon",
+    "trailer": "Fragman",
+    "behindTheScenes": "Kamera arkası"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Klip {current}/{total}",
+    "position": "{current}/{total}",
+    "chapterCount": "{count, plural, one {# bölüm} other {# bölüm}}",
+    "clipAriaLabel": "{title} · klip {current}/{total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# bölüm} other {# bölüm}}",
+    "chapter": "Bölüm",
+    "noImage": "Görsel yok",
+    "playingNow": "Şu anda oynatılıyor",
+    "previousChapter": "Önceki bölüm",
+    "nextChapter": "Sonraki bölüm"
+  },
+  "SearchResultCard": {
+    "experience": "Deneyim",
+    "episodeCount": "{count, plural, one {# bölüm} other {# bölüm}}",
+    "thumbnailAlt": "Video küçük resmi"
   }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "Đang kiểm tra",
     "download": "Tải xuống",
-    "sessionError": "Không thể kiểm tra phiên của bạn. Vui lòng thử lại."
+    "sessionError": "Không thể kiểm tra phiên của bạn. Vui lòng thử lại.",
+    "saveVideo": "Lưu video"
   },
   "DownloadModal": {
     "dialogTitle": "Tải video xuống",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "Đang tải nội dung"
+  },
+  "VideoLabels": {
+    "video": "Video",
+    "segment": "Phân đoạn",
+    "episode": "Tập",
+    "featureFilm": "Phim truyện",
+    "shortFilm": "Phim ngắn",
+    "series": "Loạt phim",
+    "collection": "Bộ sưu tập",
+    "trailer": "Trailer",
+    "behindTheScenes": "Hậu trường"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "Đoạn {current} trong {total}",
+    "position": "{current} trong {total}",
+    "chapterCount": "{count, plural, one {# chương} other {# chương}}",
+    "clipAriaLabel": "{title} · đoạn {current} trong {total}",
+    "chaptersAriaLabel": "{title} · {count, plural, one {# chương} other {# chương}}",
+    "chapter": "Chương",
+    "noImage": "Không có hình ảnh",
+    "playingNow": "Đang phát",
+    "previousChapter": "Chương trước",
+    "nextChapter": "Chương tiếp theo"
+  },
+  "SearchResultCard": {
+    "experience": "Trải nghiệm",
+    "episodeCount": "{count, plural, one {# tập} other {# tập}}",
+    "thumbnailAlt": "Ảnh thu nhỏ video"
   }
 }

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "正在检查",
     "download": "下载",
-    "sessionError": "无法检查你的会话。请重试。"
+    "sessionError": "无法检查你的会话。请重试。",
+    "saveVideo": "保存视频"
   },
   "DownloadModal": {
     "dialogTitle": "下载视频",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "正在加载内容"
+  },
+  "VideoLabels": {
+    "video": "视频",
+    "segment": "片段",
+    "episode": "剧集",
+    "featureFilm": "长片",
+    "shortFilm": "短片",
+    "series": "系列",
+    "collection": "合集",
+    "trailer": "预告片",
+    "behindTheScenes": "幕后"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "第 {current} 个片段，共 {total} 个",
+    "position": "{current}/{total}",
+    "chapterCount": "{count, plural, other {# 章}}",
+    "clipAriaLabel": "{title} · 第 {current} 个片段，共 {total} 个",
+    "chaptersAriaLabel": "{title} · {count, plural, other {# 章}}",
+    "chapter": "章节",
+    "noImage": "无图片",
+    "playingNow": "正在播放",
+    "previousChapter": "上一章",
+    "nextChapter": "下一章"
+  },
+  "SearchResultCard": {
+    "experience": "互动体验",
+    "episodeCount": "{count, plural, other {# 集}}",
+    "thumbnailAlt": "视频缩略图"
   }
 }

--- a/apps/web/messages/zh-Hant.json
+++ b/apps/web/messages/zh-Hant.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "正在檢查",
     "download": "下載",
-    "sessionError": "無法檢查你的工作階段。請重試。"
+    "sessionError": "無法檢查你的工作階段。請重試。",
+    "saveVideo": "儲存影片"
   },
   "DownloadModal": {
     "dialogTitle": "下載影片",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "正在載入內容"
+  },
+  "VideoLabels": {
+    "video": "影片",
+    "segment": "片段",
+    "episode": "集",
+    "featureFilm": "長片",
+    "shortFilm": "短片",
+    "series": "系列",
+    "collection": "合集",
+    "trailer": "預告片",
+    "behindTheScenes": "幕後"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "第 {current} 個片段，共 {total} 個",
+    "position": "{current}/{total}",
+    "chapterCount": "{count, plural, other {# 章}}",
+    "clipAriaLabel": "{title} · 第 {current} 個片段，共 {total} 個",
+    "chaptersAriaLabel": "{title} · {count, plural, other {# 章}}",
+    "chapter": "章節",
+    "noImage": "無圖片",
+    "playingNow": "正在播放",
+    "previousChapter": "上一章",
+    "nextChapter": "下一章"
+  },
+  "SearchResultCard": {
+    "experience": "互動體驗",
+    "episodeCount": "{count, plural, other {# 集}}",
+    "thumbnailAlt": "影片縮圖"
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -27,7 +27,8 @@
   "DownloadButton": {
     "checking": "正在检查",
     "download": "下载",
-    "sessionError": "无法检查你的会话。请重试。"
+    "sessionError": "无法检查你的会话。请重试。",
+    "saveVideo": "保存视频"
   },
   "DownloadModal": {
     "dialogTitle": "下载视频",
@@ -189,5 +190,33 @@
   },
   "ExperienceSkeleton": {
     "loadingContent": "正在加载内容"
+  },
+  "VideoLabels": {
+    "video": "视频",
+    "segment": "片段",
+    "episode": "剧集",
+    "featureFilm": "长片",
+    "shortFilm": "短片",
+    "series": "系列",
+    "collection": "合集",
+    "trailer": "预告片",
+    "behindTheScenes": "幕后"
+  },
+  "SiblingCarousel": {
+    "clipPosition": "第 {current} 个片段，共 {total} 个",
+    "position": "{current}/{total}",
+    "chapterCount": "{count, plural, other {# 章}}",
+    "clipAriaLabel": "{title} · 第 {current} 个片段，共 {total} 个",
+    "chaptersAriaLabel": "{title} · {count, plural, other {# 章}}",
+    "chapter": "章节",
+    "noImage": "无图片",
+    "playingNow": "正在播放",
+    "previousChapter": "上一章",
+    "nextChapter": "下一章"
+  },
+  "SearchResultCard": {
+    "experience": "互动体验",
+    "episodeCount": "{count, plural, other {# 集}}",
+    "thumbnailAlt": "视频缩略图"
   }
 }

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -156,11 +156,18 @@ function classify(rest: string[], internalLocale: UiLocale): Shape {
   return { kind: "unknown" }
 }
 
-async function getDownloadButtonLabel(route: string): Promise<string> {
+async function getDownloadButtonLabel(
+  route: string,
+  locale: UiLocale,
+): Promise<string | undefined> {
   const useUpdatedCtaCopy = await isWatchCtaTextCopyEnabled({
     custom: { route },
   })
-  return useUpdatedCtaCopy ? "Save Video" : "Download"
+  if (!useUpdatedCtaCopy) return undefined
+
+  const messages = (await import(`../../../../../messages/${locale}.json`))
+    .default as { DownloadButton?: { saveVideo?: string } }
+  return messages.DownloadButton?.saveVideo ?? "Save Video"
 }
 
 async function getYouVersionBibleQuotePassages(
@@ -316,7 +323,7 @@ async function renderEpisode(shape: {
   seriesSlug: string
   episodeSlug: string
   rawLocale: string
-  locale: string
+  locale: UiLocale
 }) {
   const { seriesSlug, episodeSlug, rawLocale, locale } = shape
 
@@ -348,7 +355,7 @@ async function renderEpisode(shape: {
   const route = `/watch/${seriesSlug}.html/${episodeSlug}/${rawLocale}.html`
   const [downloadButtonLabel, questionPanelEnabled, youVersionPassages] =
     await Promise.all([
-      getDownloadButtonLabel(route),
+      getDownloadButtonLabel(route, locale),
       getQuestionPanelEnabled(route),
       getYouVersionBibleQuotePassages(route, resolved.video.bibleCitations),
     ])
@@ -388,7 +395,7 @@ async function renderVideo(shape: {
   kind: "video"
   slug: string
   rawLocale: string
-  locale: string
+  locale: UiLocale
 }) {
   const { slug, rawLocale, locale } = shape
   const route = `/watch/${slug}.html/${rawLocale}.html`
@@ -464,7 +471,7 @@ async function renderVideo(shape: {
     }
     const [downloadButtonLabel, questionPanelEnabled, youVersionPassages] =
       await Promise.all([
-        getDownloadButtonLabel(route),
+        getDownloadButtonLabel(route, locale),
         getQuestionPanelEnabled(route),
         getYouVersionBibleQuotePassages(route, watchVideo.video.bibleCitations),
       ])

--- a/apps/web/src/components/search/VideoCard.tsx
+++ b/apps/web/src/components/search/VideoCard.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image"
 import Link from "next/link"
 import type { Route } from "next"
+import { useTranslations } from "next-intl"
 import { Play } from "lucide-react"
 import { formatDuration } from "@/lib/format-duration"
 import {
@@ -10,6 +11,7 @@ import {
   watchVideoPath,
 } from "@/lib/routes"
 import type { AdminVideoLabel, SearchResult } from "@/lib/search"
+import { videoLabelMessageKey } from "@/lib/video-labels"
 
 type VideoCardProps = {
   result: SearchResult
@@ -123,6 +125,8 @@ export function VideoCard({
   index = 0,
   hrefBuilder = defaultHrefBuilder,
 }: VideoCardProps) {
+  const t = useTranslations("SearchResultCard")
+  const videoLabels = useTranslations("VideoLabels")
   const thumbnailSrc =
     result.imageUrl ??
     (result.type === "video" && result.playbackId
@@ -136,7 +140,13 @@ export function VideoCard({
   // IS the surface signal. Non-experience cards use the new count /
   // duration pill at top-right and a type badge bottom-left.
   const pill = isExperience ? null : pickCardPill(result)
-  const typeBadge = isExperience ? null : formatVideoLabel(result.label)
+  const typeBadge = isExperience
+    ? null
+    : videoLabels(videoLabelMessageKey(result.label))
+  const pillText =
+    pill?.kind === "count" && result.childCount != null
+      ? t("episodeCount", { count: result.childCount })
+      : pill?.text
 
   return (
     <Link
@@ -149,7 +159,7 @@ export function VideoCard({
         {thumbnailSrc ? (
           <Image
             src={thumbnailSrc}
-            alt={result.title ?? "Video thumbnail"}
+            alt={result.title ?? t("thumbnailAlt")}
             fill
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
             className="object-cover transition-transform duration-500 group-hover:scale-110"
@@ -197,7 +207,7 @@ export function VideoCard({
             data-testid="search-card-experience-chip"
             className="absolute top-3 right-3 rounded-full bg-amber-500/90 px-2 py-0.5 text-[10px] font-semibold tracking-wider text-stone-950 uppercase shadow"
           >
-            Experience
+            {t("experience")}
           </span>
         ) : pill ? (
           <span
@@ -208,7 +218,7 @@ export function VideoCard({
             {pill.kind === "duration" ? (
               <Play size={10} fill="currentColor" stroke="none" aria-hidden />
             ) : null}
-            {pill.text}
+            {pillText}
           </span>
         ) : null}
 

--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -43,6 +43,7 @@ import type { WatchHeroPlayerBlock } from "@/lib/content"
 import { WATCH_PAGE_LEFT_RAIL_CLASSES } from "@/lib/content-width"
 import { useIsFullscreen } from "@/lib/use-is-fullscreen"
 import { getViewerId } from "@/lib/viewer-id"
+import { videoLabelMessageKey } from "@/lib/video-labels"
 import {
   WATCH_HEADER_LANGUAGE_SWITCHER_EVENT,
   WATCH_PLAYER_CHROME_VISIBILITY_EVENT,
@@ -140,6 +141,7 @@ export function HeroPlayer({
   subtitleVttSrc?: string | null
 }) {
   const t = useTranslations("HeroPlayer")
+  const videoLabels = useTranslations("VideoLabels")
   const { video, variant } = block
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const playerRef = useRef<MuxPlayerRef | null>(null)
@@ -840,7 +842,7 @@ export function HeroPlayer({
                     data-testid="hero-player-overlay-label"
                     className={WATCH_SECTION_EYEBROW_CLASS}
                   >
-                    {video.label}
+                    {videoLabels(videoLabelMessageKey(video.label))}
                   </span>
                 ) : null}
                 {video.title ? (

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
+import { useTranslations } from "next-intl"
 import { Play } from "lucide-react"
 
 import {
@@ -25,6 +26,8 @@ export function SiblingCarousel({
   block: WatchSiblingCarouselBlock
   languageSlug: string
 }) {
+  const t = useTranslations("SiblingCarousel")
+  const videoLabels = useTranslations("VideoLabels")
   const { canonicalParent, currentVideoDocumentId } = block
 
   // Drop nulls AND items missing a slug — without a slug we can't build a
@@ -43,6 +46,7 @@ export function SiblingCarousel({
   const isParentMode = activeIndex < 0
   const clipIndex = activeIndex >= 0 ? activeIndex + 1 : 1
   const clipTotal = children.length
+  const parentTitle = canonicalParent.title ?? videoLabels("collection")
 
   // All carousel thumbnails ship with `loading="lazy"`. Native browser
   // lazy-loading still fetches above-fold images immediately — it only
@@ -75,8 +79,12 @@ export function SiblingCarousel({
   // simple "{N} chapters" total instead, mirroring the change in
   // aria-label below.
   const ariaLabel = isParentMode
-    ? `${canonicalParent.title ?? "Collection"} · ${clipTotal} chapters`
-    : `${canonicalParent.title ?? "Collection"} · Clip ${clipIndex} of ${clipTotal}`
+    ? t("chaptersAriaLabel", { title: parentTitle, count: clipTotal })
+    : t("clipAriaLabel", {
+        title: parentTitle,
+        current: clipIndex,
+        total: clipTotal,
+      })
 
   return (
     <section
@@ -87,17 +95,22 @@ export function SiblingCarousel({
     >
       <header className="mb-4 px-10 md:px-0">
         <p className="text-sm font-medium text-stone-300">
-          <span className="text-stone-100">
-            {canonicalParent.title ?? "Collection"}
-          </span>
+          <span className="text-stone-100">{parentTitle}</span>
           <span className="px-2 text-stone-500">·</span>
           <span data-testid="sibling-carousel-label">
             {isParentMode ? (
-              `${clipTotal} chapters`
+              t("chapterCount", { count: clipTotal })
             ) : (
               <>
-                <span className="md:hidden">{`${clipIndex} of ${clipTotal}`}</span>
-                <span className="hidden md:inline">{`Clip ${clipIndex} of ${clipTotal}`}</span>
+                <span className="md:hidden">
+                  {t("position", { current: clipIndex, total: clipTotal })}
+                </span>
+                <span className="hidden md:inline">
+                  {t("clipPosition", {
+                    current: clipIndex,
+                    total: clipTotal,
+                  })}
+                </span>
               </>
             )}
           </span>
@@ -160,7 +173,7 @@ export function SiblingCarousel({
                     data-testid="sibling-carousel-thumb-placeholder"
                     className="flex h-full w-full items-center justify-center bg-stone-900 text-xs text-stone-600"
                   >
-                    No image
+                    {t("noImage")}
                   </div>
                 )}
 
@@ -193,7 +206,7 @@ export function SiblingCarousel({
                   className="absolute inset-x-0 bottom-0 z-20 flex h-full flex-col justify-end gap-1.5 bg-gradient-to-t from-black/68 via-black/35 to-transparent p-3 sm:p-4"
                 >
                   <span className="text-[10px] font-semibold tracking-[0.18em] text-stone-200/90 uppercase drop-shadow-md sm:text-xs">
-                    Chapter
+                    {t("chapter")}
                   </span>
                   {/* Card title rendered as <span>, not <h3>: the cards are
                       sibling-navigation Link items and don't anchor their
@@ -221,7 +234,7 @@ export function SiblingCarousel({
                     data-testid="sibling-carousel-playing-now"
                     className="sr-only"
                   >
-                    Playing now
+                    {t("playingNow")}
                   </span>
                 ) : null}
               </>
@@ -274,11 +287,11 @@ export function SiblingCarousel({
             stays legible against the light circular background. */}
         <CarouselPrevious
           className="hidden text-stone-900 hover:text-stone-900 md:inline-flex"
-          label="Previous chapter"
+          label={t("previousChapter")}
         />
         <CarouselNext
           className="hidden text-stone-900 hover:text-stone-900 md:inline-flex"
-          label="Next chapter"
+          label={t("nextChapter")}
         />
       </Carousel>
     </section>

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -91,6 +91,26 @@ vi.mock("@forge/video-player", () => ({
   MuxVideo: muxVideoMock,
 }))
 
+vi.mock("next-intl", () => ({
+  useTranslations:
+    (namespace: "HeroPlayer" | "VideoLabels") => (key: string) => {
+      const catalogs = {
+        HeroPlayer: {
+          playWithSound: "Play with Sound",
+          tapToUnmute: "Tap to Unmute",
+        },
+        VideoLabels: {
+          episode: "Episode",
+          segment: "Segment",
+          video: "Video",
+        },
+      }
+
+      const group = catalogs[namespace] as Record<string, string> | undefined
+      return group?.[key] ?? key
+    },
+}))
+
 // HeroPlayer's runtime branch wraps each backend in `next/dynamic(() =>
 // import("@forge/video-player/mux-{player,video}"), { ssr: false })` so
 // the inactive backend is build-time DCE'd out of the route chunk.

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -49,6 +49,34 @@ vi.mock("next/image", () => ({
   ),
 }))
 
+vi.mock("next-intl", () => ({
+  useTranslations:
+    (namespace: "SiblingCarousel" | "VideoLabels") =>
+    (key: string, values?: Record<string, unknown>) => {
+      const catalogs = {
+        SiblingCarousel: {
+          clipPosition: `Clip ${values?.current} of ${values?.total}`,
+          position: `${values?.current} of ${values?.total}`,
+          chapterCount: `${values?.count} chapters`,
+          clipAriaLabel: `${values?.title} · Clip ${values?.current} of ${values?.total}`,
+          chaptersAriaLabel: `${values?.title} · ${values?.count} chapters`,
+          chapter: "Chapter",
+          noImage: "No image",
+          playingNow: "Playing now",
+          previousChapter: "Previous chapter",
+          nextChapter: "Next chapter",
+        },
+        VideoLabels: {
+          video: "Video",
+          collection: "Collection",
+        },
+      }
+
+      const group = catalogs[namespace] as Record<string, string> | undefined
+      return group?.[key] ?? key
+    },
+}))
+
 import { SiblingCarousel } from "@/components/watch/SiblingCarousel"
 import type { WatchSiblingCarouselBlock } from "@/lib/content"
 

--- a/apps/web/src/lib/video-labels.ts
+++ b/apps/web/src/lib/video-labels.ts
@@ -1,0 +1,41 @@
+export type VideoLabelMessageKey =
+  | "behindTheScenes"
+  | "collection"
+  | "episode"
+  | "featureFilm"
+  | "segment"
+  | "series"
+  | "shortFilm"
+  | "trailer"
+  | "video"
+
+const VIDEO_LABEL_KEYS: Record<string, VideoLabelMessageKey> = {
+  BEHIND_THE_SCENES: "behindTheScenes",
+  COLLECTION: "collection",
+  EPISODE: "episode",
+  FEATURE_FILM: "featureFilm",
+  SEGMENT: "segment",
+  SERIES: "series",
+  SHORT_FILM: "shortFilm",
+  TRAILER: "trailer",
+}
+
+function normalizeLabel(label: string | null | undefined): string | null {
+  if (label == null) return null
+
+  const normalized = label
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[-\s]+/g, "_")
+    .toUpperCase()
+
+  return normalized.length > 0 ? normalized : null
+}
+
+export function videoLabelMessageKey(
+  label: string | null | undefined,
+): VideoLabelMessageKey {
+  const normalized = normalizeLabel(label)
+  if (normalized == null) return "video"
+  return VIDEO_LABEL_KEYS[normalized] ?? "video"
+}

--- a/docs/roadmap/platform/feat-151-watch-visible-chrome-localization.md
+++ b/docs/roadmap/platform/feat-151-watch-visible-chrome-localization.md
@@ -40,3 +40,11 @@ Keep search terms themselves stable so backend search behavior does not change.
 - `pnpm --filter @forge/web test -- src/i18n/__tests__/messages-parity.test.ts`
 - `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx`
 - Production smoke for `/watch/parable-of-the-pharisee-and-tax-collector.html/russian.html` should show `ru` HTML plus localized visible chrome.
+
+## Completion Notes
+
+- Follow-up audit found remaining app-owned English in the sibling carousel,
+  media-label badges, search result cards, and the default download CTA prop.
+- Local production smoke strips script/style hydration payloads before checking
+  text, so admin catalog data like English video titles is separated from UI
+  chrome owned by the app.


### PR DESCRIPTION
## Summary
- localize watch carousel labels, media type badges, search result chips, and download CTA override copy
- add shared admin video-label translation key mapping and message catalog entries for every UI locale
- document the follow-up visible-chrome audit on feat-151

## Verification
- pnpm --filter @forge/web test -- src/i18n/__tests__/messages-parity.test.ts src/components/watch/__tests__/SiblingCarousel.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx src/components/search/VideoCard.test.tsx 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx'
- pnpm --filter @forge/web lint
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web build
- local production smoke: script/style-stripped Russian watch page visible DOM reported appOwnedEnglishMatches=0