### PR TITLE
fix(admin): clarify interaction affordances

### DIFF
--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -404,17 +404,74 @@ import UsersPage from "./users/page"
 import SettingsPage from "./settings/page"
 import LanguagesPage from "./languages/page"
 import MediaPage from "./media/page"
+import { ExperiencesActions } from "./experiences/experiences-actions"
+import {
+  DataTable,
+  PrimaryButton,
+  SecondaryButton,
+} from "@/components/admin-ui"
+import { requireSession } from "@/auth/session"
 
 async function htmlFrom(component: Promise<ReactNode>) {
   return renderToStaticMarkup(await component)
 }
 
 describe("dashboard UI routes", () => {
+  it("renders primary buttons with explicit enabled and disabled affordances", () => {
+    const enabled = renderToStaticMarkup(
+      <PrimaryButton>Enabled primary</PrimaryButton>,
+    )
+    const disabled = renderToStaticMarkup(
+      <PrimaryButton disabled>Disabled primary</PrimaryButton>,
+    )
+
+    expect(enabled).toContain("cursor-pointer")
+    expect(enabled).toContain("hover:bg-[var(--color-brand-pressed)]")
+    expect(enabled).not.toContain('disabled=""')
+    expect(disabled).toContain('disabled=""')
+    expect(disabled).toContain("disabled:cursor-not-allowed")
+    expect(disabled).toContain("disabled:opacity-55")
+  })
+
+  it("renders secondary buttons with explicit enabled and disabled affordances", () => {
+    const enabled = renderToStaticMarkup(
+      <SecondaryButton>Enabled secondary</SecondaryButton>,
+    )
+    const disabled = renderToStaticMarkup(
+      <SecondaryButton disabled>Disabled secondary</SecondaryButton>,
+    )
+
+    expect(enabled).toContain("cursor-pointer")
+    expect(enabled).toContain("hover:bg-[var(--color-surface-raised)]")
+    expect(enabled).not.toContain('disabled=""')
+    expect(disabled).toContain('disabled=""')
+    expect(disabled).toContain("disabled:cursor-not-allowed")
+    expect(disabled).toContain("disabled:opacity-50")
+  })
+
+  it("renders read-only data tables without default row actions", () => {
+    const html = renderToStaticMarkup(
+      <DataTable columns={["Name"]} rows={[[<span key="row">Row</span>]]} />,
+    )
+
+    expect(html).toContain("Row")
+    expect(html.match(/<th[\s>]/g)).toHaveLength(1)
+    expect(html.match(/<td[\s>]/g)).toHaveLength(1)
+    expect(html).not.toContain("<svg")
+    expect(html).not.toContain("hover:bg-[var(--color-surface-raised)]")
+    expect(html).not.toContain("Quick Actions")
+  })
+
   it("renders overview page with translated shared chrome", async () => {
     const html = await htmlFrom(DashboardPage())
 
     expect(html).toContain(uiMessages.pages.dashboard.title)
     expect(html).toContain(uiMessages.pages.dashboard.action)
+    expect(html).toContain(uiMessages.pages.dashboard.actionUnavailable)
+    expect(html).toMatch(
+      /<button(?=[^>]*disabled="")(?=[^>]*aria-describedby="dashboard-sync-action-unavailable")/,
+    )
+    expect(html).toContain('disabled=""')
     expect(html).toContain(uiMessages.common.operatorNotes)
   })
 
@@ -436,6 +493,25 @@ describe("dashboard UI routes", () => {
     const html = await htmlFrom(VideosPage())
     expect(html).toContain(uiMessages.pages.videos.infoStrip.items[0])
     expect(html).toContain(uiMessages.pages.videos.actions.primary)
+    expect(html).toContain(uiMessages.pages.videos.actions.filterUnavailable)
+    expect(html).toContain(uiMessages.pages.videos.actions.primaryUnavailable)
+    expect(html).toContain(
+      uiMessages.pages.videos.actions.rowActionsUnavailable,
+    )
+    expect(html).toMatch(
+      /<button(?=[^>]*disabled="")(?=[^>]*title="Video filters are not available yet.")/,
+    )
+    expect(html).toMatch(
+      /<button(?=[^>]*disabled="")(?=[^>]*title="Manual video creation is not available yet.")/,
+    )
+    expect(html).toMatch(
+      new RegExp(
+        `<button(?=[^>]*disabled="")(?=[^>]*aria-label="${uiMessages.common.quickActions}: ${uiMessages.pages.videos.actions.rowActionsUnavailable}")`,
+      ),
+    )
+    expect(html).not.toContain(
+      'hover:text-[var(--color-text-primary)]">⋯</button>',
+    )
     expect(html).toContain(uiMessages.common.operatorNotes)
   })
 
@@ -445,6 +521,61 @@ describe("dashboard UI routes", () => {
     expect(html).toContain("Core Sync is healthy")
     expect(html).toContain("Sync State")
     expect(html).toContain("Needs Attention")
+  })
+
+  it("renders read-only core sync state for principals without trigger permission", async () => {
+    vi.mocked(requireSession).mockResolvedValueOnce({
+      id: "viewer-user",
+      role: "VIEWER",
+    })
+
+    const html = await htmlFrom(SystemStatusPage())
+
+    expect(html).toContain(uiMessages.common.readOnly)
+    expect(html).toMatch(
+      new RegExp(
+        `<button(?=[^>]*disabled="")[^>]*>${uiMessages.common.readOnly}</button>`,
+      ),
+    )
+    expect(html).not.toContain("Start Sync")
+  })
+
+  it("renders blocked experience creation as unavailable before click", () => {
+    const html = renderToStaticMarkup(
+      <ExperiencesActions
+        canCreate={false}
+        createAction={vi.fn(async () => ({
+          ok: false as const,
+          error: "forbidden" as const,
+        }))}
+        labels={{
+          filter: uiMessages.pages.experiences.actions.filter,
+          filterUnavailable:
+            uiMessages.pages.experiences.actions.filterUnavailable,
+          primary: uiMessages.pages.experiences.actions.primary,
+          modalTitle: uiMessages.pages.experiences.modal.title,
+          modalDescription: uiMessages.pages.experiences.modal.description,
+          titleLabel: uiMessages.pages.experiences.modal.titleLabel,
+          localeLabel: uiMessages.pages.experiences.modal.localeLabel,
+          slugLabel: uiMessages.pages.experiences.modal.slugLabel,
+          routeTemplateLabel:
+            uiMessages.pages.experiences.modal.routeTemplateLabel,
+          routeTemplateHelp:
+            uiMessages.pages.experiences.modal.routeTemplateHelp,
+          cancel: uiMessages.pages.experiences.modal.cancel,
+          submit: uiMessages.pages.experiences.modal.submit,
+          localeHelp: uiMessages.pages.experiences.modal.localeHelp,
+          noPermission: uiMessages.pages.experiences.modal.noPermission,
+          createFailed: uiMessages.pages.experiences.modal.createFailed,
+        }}
+      />,
+    )
+
+    expect(html).toContain(uiMessages.pages.experiences.modal.noPermission)
+    expect(html).toMatch(
+      /<button(?=[^>]*disabled="")(?=[^>]*title="You do not have permission to create experiences\.)/,
+    )
+    expect(html).not.toContain(uiMessages.pages.experiences.modal.title)
   })
 
   it("renders operational secondary routes", async () => {

--- a/apps/admin/src/app/dashboard/embeddings/page.tsx
+++ b/apps/admin/src/app/dashboard/embeddings/page.tsx
@@ -20,6 +20,11 @@ export default async function EmbeddingsPage() {
   const principal = await requireSession()
   const data = await loadEmbeddingsData()
   const canTrigger = hasPermission(principal, "write:experiences")
+  const triggerDisabledReason = !canTrigger
+    ? "You do not have permission to run embedding workflows. Contact an administrator to grant access."
+    : !data.providerReady
+      ? "Embedding provider env is missing, so manual dispatch is currently disabled."
+      : "Dispatches the existing experience embedding workflow for a specific locale row."
 
   async function triggerEmbeddingAction(formData: FormData) {
     "use server"
@@ -79,19 +84,22 @@ export default async function EmbeddingsPage() {
                   name="localeId"
                   placeholder="clocale_..."
                   disabled={!canTrigger || !data.providerReady}
-                  className="h-10 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none"
+                  aria-describedby="embedding-trigger-status"
+                  className="h-10 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)] disabled:cursor-not-allowed disabled:opacity-50"
                 />
               </label>
               <div className="flex items-center justify-between gap-4">
-                <p className="text-[12px] text-[var(--color-text-secondary)]">
-                  {data.providerReady
-                    ? "Dispatches the existing experience embedding workflow for a specific locale row."
-                    : "Embedding provider env is missing, so manual dispatch is currently disabled."}
+                <p
+                  id="embedding-trigger-status"
+                  className="text-[12px] text-[var(--color-text-secondary)]"
+                >
+                  {triggerDisabledReason}
                 </p>
                 <button
                   type="submit"
                   disabled={!canTrigger || !data.providerReady}
-                  className="inline-flex h-8 items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)] disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-describedby="embedding-trigger-status"
+                  className="inline-flex h-8 cursor-pointer items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-[var(--color-brand)]"
                 >
                   Run Embedding
                 </button>

--- a/apps/admin/src/app/dashboard/experiences/experiences-actions.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experiences-actions.tsx
@@ -2,17 +2,10 @@
 
 import { useState } from "react"
 import { Filter, Plus, X } from "lucide-react"
-import { SecondaryButton } from "@/components/admin-ui"
+import { PrimaryButton, SecondaryButton } from "@/components/admin-ui"
 
 function SubmitButton({ label }: { label: string }) {
-  return (
-    <button
-      type="submit"
-      className="inline-flex h-8 items-center rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)]"
-    >
-      {label}
-    </button>
-  )
+  return <PrimaryButton type="submit">{label}</PrimaryButton>
 }
 
 function slugFromTitle(value: string) {
@@ -31,6 +24,7 @@ export function ExperiencesActions({
 }: {
   labels: {
     filter: string
+    filterUnavailable: string
     primary: string
     modalTitle: string
     modalDescription: string
@@ -58,26 +52,38 @@ export function ExperiencesActions({
   return (
     <>
       <div className="flex items-center gap-3">
-        <SecondaryButton>
+        <SecondaryButton
+          disabled
+          title={labels.filterUnavailable}
+          aria-describedby="experience-filter-unavailable"
+        >
           <Filter className="h-4 w-4" strokeWidth={1.5} />
           {labels.filter}
         </SecondaryButton>
-        <button
+        <PrimaryButton
           type="button"
+          disabled={!canCreate}
+          title={canCreate ? undefined : labels.noPermission}
           onClick={() => {
-            if (canCreate) {
-              setError("")
-              setOpen(true)
-              return
-            }
-            setError(labels.noPermission)
+            setError("")
+            setOpen(true)
           }}
-          className="inline-flex h-8 items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)]"
         >
           <Plus className="h-4 w-4" strokeWidth={1.5} />
           {labels.primary}
-        </button>
+        </PrimaryButton>
       </div>
+      <p
+        id="experience-filter-unavailable"
+        className="text-[12px] text-[var(--color-text-muted)]"
+      >
+        {labels.filterUnavailable}
+      </p>
+      {!canCreate ? (
+        <p className="text-[12px] text-[var(--color-text-muted)]">
+          {labels.noPermission}
+        </p>
+      ) : null}
       {error ? (
         <p className="text-[12px] text-[var(--color-danger)]">{error}</p>
       ) : null}
@@ -97,7 +103,7 @@ export function ExperiencesActions({
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="rounded-sm border border-[var(--color-hairline)] p-1.5 text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                className="cursor-pointer rounded-sm border border-[var(--color-hairline)] p-1.5 text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
                 aria-label={labels.cancel}
               >
                 <X className="h-4 w-4" strokeWidth={1.5} />
@@ -177,7 +183,7 @@ export function ExperiencesActions({
                 <button
                   type="button"
                   onClick={() => setOpen(false)}
-                  className="inline-flex h-8 items-center rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] text-[var(--color-text-secondary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                  className="inline-flex h-8 cursor-pointer items-center rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] text-[var(--color-text-secondary)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
                 >
                   {labels.cancel}
                 </button>

--- a/apps/admin/src/app/dashboard/experiences/page.tsx
+++ b/apps/admin/src/app/dashboard/experiences/page.tsx
@@ -71,6 +71,7 @@ export default async function ExperiencesPage() {
             createAction={createExperienceAction}
             labels={{
               filter: page.actions.filter,
+              filterUnavailable: page.actions.filterUnavailable,
               primary: page.actions.primary,
               modalTitle: page.modal.title,
               modalDescription: page.modal.description,

--- a/apps/admin/src/app/dashboard/page.tsx
+++ b/apps/admin/src/app/dashboard/page.tsx
@@ -12,8 +12,8 @@ import {
   MetricCard,
   OperatorRail,
   PageSection,
-  PrimaryButton,
   QueueList,
+  SecondaryButton,
   StatusPill,
 } from "@/components/admin-ui"
 import { loadDashboardOpsData } from "@/app/dashboard/ops-data"
@@ -30,10 +30,22 @@ export default async function DashboardPage() {
         title={page.title}
         description={page.description}
         action={
-          <PrimaryButton>
-            <RefreshCcw className="h-4 w-4" strokeWidth={1.5} />
-            {page.action}
-          </PrimaryButton>
+          <div className="flex flex-col items-start gap-1 md:items-end">
+            <SecondaryButton
+              disabled
+              title={page.actionUnavailable}
+              aria-describedby="dashboard-sync-action-unavailable"
+            >
+              <RefreshCcw className="h-4 w-4" strokeWidth={1.5} />
+              {page.action}
+            </SecondaryButton>
+            <span
+              id="dashboard-sync-action-unavailable"
+              className="font-mono text-[10px] text-[var(--color-text-muted)]"
+            >
+              {page.actionUnavailable}
+            </span>
+          </div>
         }
       />
 
@@ -73,10 +85,7 @@ export default async function DashboardPage() {
               </thead>
               <tbody>
                 {data.activity.map((entry) => (
-                  <tr
-                    key={entry.key}
-                    className="hairline-b h-10 transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
-                  >
+                  <tr key={entry.key} className="hairline-b h-10">
                     <td className="px-4 text-[13px]">{entry.title}</td>
                     <td className="px-4">
                       <StatusPill tone={entry.statusTone}>
@@ -146,12 +155,8 @@ export default async function DashboardPage() {
                   </div>
                   <div className="mt-4 flex items-center justify-between">
                     <span className="label-text">
-                      {page.syncSection.drilldown}
+                      {messages.common.readOnly}
                     </span>
-                    <ArrowUpRight
-                      className="h-4 w-4 text-[var(--color-text-muted)]"
-                      strokeWidth={1.5}
-                    />
                   </div>
                 </div>
               ))}

--- a/apps/admin/src/app/dashboard/search/page.tsx
+++ b/apps/admin/src/app/dashboard/search/page.tsx
@@ -5,6 +5,7 @@ import {
   InsightGrid,
   OperatorRail,
   PageSection,
+  PrimaryButton,
 } from "@/components/admin-ui"
 import { requireSession } from "@/auth/session"
 import { getAdminMessages } from "@/i18n/server"
@@ -64,24 +65,23 @@ export default async function SearchPage({
               <input
                 type="text"
                 name="q"
+                aria-label="Search query"
                 defaultValue={data.queryText}
                 placeholder="forgiveness and restoration"
-                className="h-10 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 text-[13px] text-[var(--color-text-primary)] outline-none"
+                className="h-10 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 text-[13px] text-[var(--color-text-primary)] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)]"
               />
               <input
                 type="text"
                 name="locale"
+                aria-label="Locale"
                 defaultValue={data.locale}
                 placeholder="en"
-                className="h-10 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none"
+                className="h-10 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)]"
               />
-              <button
-                type="submit"
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-sm bg-[var(--color-brand)] px-4 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)]"
-              >
+              <PrimaryButton type="submit" className="h-10 justify-center px-4">
                 <Search className="h-4 w-4" strokeWidth={1.5} />
                 Search
-              </button>
+              </PrimaryButton>
             </form>
             <div className="px-4 pb-4 text-[12px] text-[var(--color-text-secondary)]">
               {data.unavailableReason

--- a/apps/admin/src/app/dashboard/system-status/page.tsx
+++ b/apps/admin/src/app/dashboard/system-status/page.tsx
@@ -2,8 +2,8 @@ import { Activity } from "lucide-react"
 import {
   DashboardPageHeader,
   PageSection,
-  PrimaryButton,
   QueueList,
+  SecondaryButton,
   StatusPill,
 } from "@/components/admin-ui"
 import { loadSystemStatusData } from "@/app/dashboard/ops-data"
@@ -62,7 +62,9 @@ export default async function SystemStatusPage() {
           canTriggerSync ? (
             <CoreSyncTriggerButton />
           ) : (
-            <PrimaryButton className="opacity-60">Read-only</PrimaryButton>
+            <SecondaryButton disabled>
+              {messages.common.readOnly}
+            </SecondaryButton>
           )
         }
       />
@@ -113,7 +115,7 @@ export default async function SystemStatusPage() {
               {data.matrix.map((row) => (
                 <tr
                   key={`${row.entity}-${row.source}`}
-                  className="hairline-b h-12 transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                  className="hairline-b h-12"
                 >
                   <td className="px-4 text-[13px] font-medium">{row.entity}</td>
                   <td className="px-4">

--- a/apps/admin/src/app/dashboard/videos/page.tsx
+++ b/apps/admin/src/app/dashboard/videos/page.tsx
@@ -31,15 +31,31 @@ export default async function VideosPage() {
         title={page.title}
         description={page.description}
         action={
-          <div className="flex items-center gap-3">
-            <SecondaryButton>
-              <Filter className="h-4 w-4" strokeWidth={1.5} />
-              {page.actions.filter}
-            </SecondaryButton>
-            <PrimaryButton>
-              <Plus className="h-4 w-4" strokeWidth={1.5} />
-              {page.actions.primary}
-            </PrimaryButton>
+          <div className="flex flex-col items-start gap-1 md:items-end">
+            <div className="flex items-center gap-3">
+              <SecondaryButton
+                disabled
+                title={page.actions.filterUnavailable}
+                aria-describedby="video-actions-unavailable"
+              >
+                <Filter className="h-4 w-4" strokeWidth={1.5} />
+                {page.actions.filter}
+              </SecondaryButton>
+              <PrimaryButton
+                disabled
+                title={page.actions.primaryUnavailable}
+                aria-describedby="video-actions-unavailable"
+              >
+                <Plus className="h-4 w-4" strokeWidth={1.5} />
+                {page.actions.primary}
+              </PrimaryButton>
+            </div>
+            <span
+              id="video-actions-unavailable"
+              className="font-mono text-[10px] text-[var(--color-text-muted)]"
+            >
+              {page.actions.filterUnavailable} {page.actions.primaryUnavailable}
+            </span>
           </div>
         }
       />
@@ -60,10 +76,7 @@ export default async function VideosPage() {
               </thead>
               <tbody>
                 {videoRows.map((video) => (
-                  <tr
-                    key={video.id}
-                    className="hairline-b transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
-                  >
+                  <tr key={video.id} className="hairline-b">
                     <td className="p-4 align-middle">
                       <div className="flex aspect-video w-[180px] items-end justify-end rounded-sm border border-white/5 bg-[linear-gradient(135deg,#151312,#292524)] p-2">
                         <span className="rounded-[2px] bg-black/50 px-1.5 py-0.5 font-mono text-[9px]">
@@ -97,8 +110,10 @@ export default async function VideosPage() {
                     <td className="px-4 py-3 text-right align-middle">
                       <button
                         type="button"
-                        aria-label={messages.common.quickActions}
-                        className="font-mono text-[14px] text-[var(--color-text-disabled)] transition-all duration-[120ms] ease-out hover:text-[var(--color-text-primary)]"
+                        disabled
+                        aria-label={`${messages.common.quickActions}: ${page.actions.rowActionsUnavailable}`}
+                        title={page.actions.rowActionsUnavailable}
+                        className="font-mono text-[14px] text-[var(--color-text-disabled)] opacity-50"
                       >
                         ⋯
                       </button>

--- a/apps/admin/src/app/dashboard/workflows/core-sync-trigger-button.tsx
+++ b/apps/admin/src/app/dashboard/workflows/core-sync-trigger-button.tsx
@@ -62,7 +62,7 @@ export function CoreSyncTriggerButton() {
         type="button"
         disabled={disabled}
         onClick={startSync}
-        className="inline-flex h-8 cursor-pointer items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)] disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex h-8 cursor-pointer items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[var(--color-brand)]"
       >
         <RefreshCcw
           className={isPending ? "h-4 w-4 animate-spin" : "h-4 w-4"}

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -63,6 +63,7 @@ body {
 
 a {
   color: inherit;
+  cursor: pointer;
   text-decoration: none;
 }
 
@@ -72,6 +73,16 @@ textarea,
 select {
   font-family: inherit;
   color: inherit;
+}
+
+button:not(:disabled),
+[role="button"]:not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+
+button:disabled,
+[aria-disabled="true"] {
+  cursor: not-allowed;
 }
 
 select {
@@ -143,6 +154,17 @@ optgroup {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   background: transparent;
+}
+
+button.status-pill:not(:disabled) {
+  transition:
+    border-color 120ms ease-out,
+    color 120ms ease-out,
+    background-color 120ms ease-out;
+}
+
+button.status-pill:not(:disabled):hover {
+  background-color: var(--color-surface-raised);
 }
 
 .workflow-trace-shell {

--- a/apps/admin/src/components/admin-shell.test.tsx
+++ b/apps/admin/src/components/admin-shell.test.tsx
@@ -26,6 +26,18 @@ describe("admin shell", () => {
     expect(html).toContain(adminMessages.es.nav.sections.overview)
     expect(html).toContain(adminMessages.es.nav.items.dashboard.label)
     expect(html).toContain(adminMessages.es.common.locales.es)
+    expect(html).toContain(
+      `aria-label="${adminMessages.es.common.openCommandPalette}"`,
+    )
+    expect(html).toContain(
+      `aria-label="${adminMessages.es.common.helpUnavailable}"`,
+    )
+    expect(html).toContain('aria-current="true"')
+    expect(html).toMatch(
+      new RegExp(
+        `<button(?=[^>]*disabled="")(?=[^>]*aria-label="${adminMessages.es.common.helpUnavailable}")`,
+      ),
+    )
   })
 
   it("hides admin-only routes for editor principals", () => {

--- a/apps/admin/src/components/admin-shell.tsx
+++ b/apps/admin/src/components/admin-shell.tsx
@@ -170,7 +170,7 @@ export function AdminShell({
         <button
           type="button"
           className={cx(
-            "absolute inset-0 bg-black/55 backdrop-blur-[3px] transition-opacity duration-200 ease-out",
+            "absolute inset-0 cursor-pointer bg-black/55 backdrop-blur-[3px] transition-opacity duration-200 ease-out",
             isNavOpen ? "opacity-100" : "opacity-0",
           )}
           aria-label="Close navigation"
@@ -200,7 +200,7 @@ export function AdminShell({
             <button
               type="button"
               onClick={() => setNavOpen(true)}
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)] xl:hidden"
+              className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)] xl:hidden"
               aria-label="Open navigation"
               aria-expanded={isNavOpen}
             >
@@ -223,14 +223,19 @@ export function AdminShell({
           <div className="ml-auto flex items-center gap-4">
             <button
               type="button"
-              className="text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:text-[var(--color-text-primary)]"
+              className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
               onClick={() => setPaletteOpen(true)}
+              aria-label={messages.common.openCommandPalette}
+              title={messages.common.openCommandPalette}
             >
               <Command className="h-4 w-4" strokeWidth={1.5} />
             </button>
             <button
               type="button"
-              className="text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:text-[var(--color-text-primary)]"
+              disabled
+              className="inline-flex h-8 w-8 items-center justify-center rounded-sm text-[var(--color-text-muted)] opacity-45 transition-all duration-[120ms] ease-out disabled:cursor-not-allowed"
+              aria-label={messages.common.helpUnavailable}
+              title={messages.common.helpUnavailable}
             >
               <HelpCircle className="h-4 w-4" strokeWidth={1.5} />
             </button>
@@ -242,23 +247,28 @@ export function AdminShell({
               </span>
             </div>
             <div className="flex items-center gap-1 rounded-sm border border-[var(--color-hairline)] p-1">
-              {supportedAdminLocales.map((supportedLocale) => (
-                <button
-                  key={supportedLocale}
-                  type="button"
-                  disabled={isSwitchingLocale}
-                  onClick={() => handleLocaleChange(supportedLocale)}
-                  aria-label={`${messages.common.localeLabel}: ${messages.common.locales[supportedLocale]}`}
-                  className={cx(
-                    "rounded-[2px] px-2 py-1 text-[11px] transition-all duration-[120ms] ease-out",
-                    supportedLocale === locale
-                      ? "bg-[var(--color-surface-raised)] text-[var(--color-text-primary)]"
-                      : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-raised)]",
-                  )}
-                >
-                  {messages.common.locales[supportedLocale]}
-                </button>
-              ))}
+              {supportedAdminLocales.map((supportedLocale) => {
+                const activeLocale = supportedLocale === locale
+                return (
+                  <button
+                    key={supportedLocale}
+                    type="button"
+                    disabled={isSwitchingLocale || activeLocale}
+                    onClick={() => handleLocaleChange(supportedLocale)}
+                    aria-current={activeLocale ? "true" : undefined}
+                    aria-label={`${messages.common.localeLabel}: ${messages.common.locales[supportedLocale]}`}
+                    className={cx(
+                      "rounded-[2px] px-2 py-1 text-[11px] transition-all duration-[120ms] ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]",
+                      activeLocale
+                        ? "bg-[var(--color-surface-raised)] text-[var(--color-text-primary)]"
+                        : "cursor-pointer text-[var(--color-text-muted)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]",
+                      isSwitchingLocale && !activeLocale && "opacity-45",
+                    )}
+                  >
+                    {messages.common.locales[supportedLocale]}
+                  </button>
+                )
+              })}
             </div>
           </div>
         </header>
@@ -278,16 +288,26 @@ export function AdminShell({
 
       {isPaletteOpen ? (
         <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/55 px-6 pt-24">
-          <div className="w-full max-w-2xl rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] shadow-[0_8px_24px_rgba(0,0,0,0.4)]">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="admin-command-palette-title"
+            className="w-full max-w-2xl rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] shadow-[0_8px_24px_rgba(0,0,0,0.4)]"
+          >
             <div className="hairline-strong-b flex items-center gap-3 px-4 py-3">
               <Search className="h-4 w-4 text-[var(--color-text-muted)]" />
-              <span className="font-mono text-[12px] text-[var(--color-text-muted)]">
+              <span
+                id="admin-command-palette-title"
+                className="font-mono text-[12px] text-[var(--color-text-muted)]"
+              >
                 {messages.common.searchPalettePrompt}
               </span>
               <button
                 type="button"
+                autoFocus
                 onClick={() => setPaletteOpen(false)}
-                className="ml-auto rounded-sm border border-[var(--color-hairline)] px-2 py-1 font-mono text-[10px] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                className="ml-auto cursor-pointer rounded-sm border border-[var(--color-hairline)] px-2 py-1 font-mono text-[10px] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
+                aria-label={messages.common.closeCommandPalette}
               >
                 {messages.common.escape}
               </button>
@@ -308,7 +328,7 @@ export function AdminShell({
                         href={item.href as Route}
                         onClick={() => setPaletteOpen(false)}
                         className={cx(
-                          "flex items-start gap-3 rounded-sm border px-3 py-3 transition-all duration-[120ms] ease-out",
+                          "flex cursor-pointer items-start gap-3 rounded-sm border px-3 py-3 transition-all duration-[120ms] ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]",
                           active
                             ? "border-[var(--color-hairline-strong)] bg-[var(--color-surface-raised)]"
                             : "border-[var(--color-hairline)] hover:bg-[var(--color-surface-raised)]",
@@ -342,7 +362,7 @@ export function AdminShell({
                         key={item.href}
                         href={item.href as Route}
                         onClick={() => setPaletteOpen(false)}
-                        className="flex items-center justify-between rounded-sm border border-[var(--color-hairline)] px-3 py-2 text-[13px] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                        className="flex cursor-pointer items-center justify-between rounded-sm border border-[var(--color-hairline)] px-3 py-2 text-[13px] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
                       >
                         <span>{messages.nav.items[item.id].label}</span>
                         <span className="font-mono text-[10px] text-[var(--color-text-muted)]">
@@ -410,7 +430,7 @@ function ShellSidebarContent({
           <button
             type="button"
             onClick={onClose}
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]"
+            className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
             aria-label="Close navigation"
           >
             <X className="h-4 w-4" strokeWidth={1.5} />
@@ -434,7 +454,7 @@ function ShellSidebarContent({
                     href={item.href as Route}
                     onClick={onClose}
                     className={cx(
-                      "flex h-8 items-center gap-3 rounded-sm px-3 transition-all duration-[120ms] ease-out",
+                      "flex h-8 cursor-pointer items-center gap-3 rounded-sm px-3 transition-all duration-[120ms] ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]",
                       active
                         ? "border-l-2 border-[var(--color-text-primary)] bg-[var(--color-surface-raised)] text-[var(--color-text-primary)]"
                         : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]",

--- a/apps/admin/src/components/admin-ui.tsx
+++ b/apps/admin/src/components/admin-ui.tsx
@@ -1,10 +1,5 @@
-import type { ReactNode } from "react"
-import {
-  ChevronRight,
-  MoreHorizontal,
-  Search,
-  type LucideIcon,
-} from "lucide-react"
+import type { ButtonHTMLAttributes, ReactNode } from "react"
+import { ChevronRight, Search, type LucideIcon } from "lucide-react"
 
 type StatusTone = "success" | "warning" | "danger" | "info" | "muted"
 
@@ -61,17 +56,19 @@ export function DashboardPageHeader({
 export function PrimaryButton({
   children,
   className,
-}: {
+  type = "button",
+  ...buttonProps
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode
-  className?: string
 }) {
   return (
     <button
-      type="button"
+      type={type}
       className={cx(
-        "inline-flex h-8 items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)]",
+        "inline-flex h-8 cursor-pointer items-center gap-2 rounded-sm bg-[var(--color-brand)] px-3 text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:bg-[var(--color-brand)]",
         className,
       )}
+      {...buttonProps}
     >
       {children}
     </button>
@@ -81,17 +78,19 @@ export function PrimaryButton({
 export function SecondaryButton({
   children,
   className,
-}: {
+  type = "button",
+  ...buttonProps
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode
-  className?: string
 }) {
   return (
     <button
-      type="button"
+      type={type}
       className={cx(
-        "inline-flex h-8 items-center gap-2 rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] font-medium text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]",
+        "inline-flex h-8 cursor-pointer items-center gap-2 rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] font-medium text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-[var(--color-hairline)] disabled:hover:bg-transparent",
         className,
       )}
+      {...buttonProps}
     >
       {children}
     </button>
@@ -196,7 +195,7 @@ export function SearchPillButton({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-8 w-full max-w-[320px] items-center gap-3 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 text-left transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)]"
+      className="flex h-8 w-full max-w-[320px] cursor-pointer items-center gap-3 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3 text-left transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-overlay)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
     >
       <Search
         className="h-4 w-4 text-[var(--color-text-muted)]"
@@ -231,7 +230,6 @@ export function DataTable({
                 {column}
               </th>
             ))}
-            <th className="w-10 px-4" />
           </tr>
         </thead>
         <tbody>
@@ -239,7 +237,7 @@ export function DataTable({
             <tr
               key={rowIndex}
               className={cx(
-                "hairline-b h-[52px] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]",
+                "hairline-b h-[52px]",
                 rowIndex === selectedRow &&
                   "border-l-2 border-[var(--color-brand)] bg-[var(--color-brand-soft)]",
               )}
@@ -249,12 +247,6 @@ export function DataTable({
                   {cell}
                 </td>
               ))}
-              <td className="px-4 text-right">
-                <MoreHorizontal
-                  className="ml-auto h-4 w-4 text-[var(--color-text-disabled)]"
-                  strokeWidth={1.5}
-                />
-              </td>
             </tr>
           ))}
         </tbody>

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -17,10 +17,14 @@ export const adminMessages = {
       operatorNotes: "Operator Notes",
       premiumStubLabel: "Premium stub wired for future data",
       fieldGuide: "FIELD_GUIDE",
-      searchPlaceholder: "Search or ⌘K",
-      searchPalettePrompt: "Search routes, tools, and editorial surfaces",
+      searchPlaceholder: "Open route palette",
+      searchPalettePrompt: "Navigate routes, tools, and editorial surfaces",
       navigate: "Navigate",
       quickActions: "Quick Actions",
+      readOnly: "Read-only",
+      openCommandPalette: "Open command palette",
+      closeCommandPalette: "Close command palette",
+      helpUnavailable: "Help is not available yet",
       context: "Context",
       paletteContext:
         "This palette is shared across the entire dashboard shell and uses the same route registry as the sidebar so future pages stay synchronized automatically.",
@@ -192,6 +196,7 @@ export const adminMessages = {
         title: "System Overview",
         description: "Real-time status of content delivery and sync pipelines.",
         action: "Run Manual Sync",
+        actionUnavailable: "Manual sync starts from Core Sync.",
         metrics: [
           {
             label: "Experiences",
@@ -345,7 +350,11 @@ export const adminMessages = {
         title: "Experiences",
         description:
           "Manage interactive spiritual journeys and storytelling sequences.",
-        actions: { filter: "Filter", primary: "New Experience" },
+        actions: {
+          filter: "Filter",
+          filterUnavailable: "Experience filters are not available yet.",
+          primary: "New Experience",
+        },
         modal: {
           title: "Create Experience",
           description:
@@ -378,7 +387,13 @@ export const adminMessages = {
           items: ["INGESTION PIPELINE: ACTIVE", "MUX EDGE ONLINE"],
           trailing: "REGION: US-EAST-1 (PROD)",
         },
-        actions: { filter: "Filter", primary: "Add manual video" },
+        actions: {
+          filter: "Filter",
+          filterUnavailable: "Video filters are not available yet.",
+          primary: "Add manual video",
+          primaryUnavailable: "Manual video creation is not available yet.",
+          rowActionsUnavailable: "Video row actions are not available yet.",
+        },
         table: {
           title: "Video Library",
           meta: "ROW_THUMBNAILS / SOURCE_BADGES",
@@ -1050,11 +1065,15 @@ export const adminMessages = {
       operatorNotes: "Notas del operador",
       premiumStubLabel: "Superficie premium lista para datos futuros",
       fieldGuide: "GUIA_DE_CAMPO",
-      searchPlaceholder: "Buscar o ⌘K",
+      searchPlaceholder: "Abrir paleta de rutas",
       searchPalettePrompt:
-        "Buscar rutas, herramientas y superficies editoriales",
+        "Navegar rutas, herramientas y superficies editoriales",
       navigate: "Navegar",
       quickActions: "Acciones rápidas",
+      readOnly: "Solo lectura",
+      openCommandPalette: "Abrir paleta de comandos",
+      closeCommandPalette: "Cerrar paleta de comandos",
+      helpUnavailable: "La ayuda aun no esta disponible",
       context: "Contexto",
       paletteContext:
         "Esta paleta se comparte en todo el panel y usa el mismo registro de rutas que la barra lateral para que las futuras páginas permanezcan sincronizadas automáticamente.",

--- a/docs/plans/2026-06-01-001-fix-admin-interaction-affordances-plan.md
+++ b/docs/plans/2026-06-01-001-fix-admin-interaction-affordances-plan.md
@@ -1,0 +1,348 @@
+---
+title: Admin Interaction Affordance Polish
+type: fix
+status: active
+date: 2026-06-01
+---
+
+# Admin Interaction Affordance Polish
+
+## Summary
+
+This plan tightens the Forge Admin dashboard's interaction affordances so live controls look and behave clickable, unfinished controls are visibly unavailable, and read-only operational surfaces stop implying hidden actions. The implementation will extend the existing admin UI primitives and then audit the current dashboard routes that surfaced inert or misleading controls during the usability pass.
+
+---
+
+## Problem Frame
+
+The production admin panel mixes real operational controls, read-only diagnostics, and future workflow affordances. Several controls currently look active but do nothing, while shared table and button patterns imply clickability even on static information surfaces. That makes the admin panel feel less trustworthy, especially around sync and editorial actions.
+
+---
+
+## Assumptions
+
+_This plan was authored without synchronous user confirmation. The items below are agent inferences that fill gaps in the input -- un-validated bets that should be reviewed before implementation proceeds._
+
+- Treat this as a focused interaction-affordance fix, not a redesign of the Forge Editorial visual language.
+- Disable or demote unimplemented controls instead of building the missing workflows in this PR.
+- Preserve implemented operational actions, including Core Sync dispatch, semantic search, workflow filtering, and experience creation where permissions allow it.
+- Keep scope inside `apps/admin` plus the required roadmap and plan documentation.
+
+---
+
+## Requirements
+
+- R1. Every enabled clickable admin control has an explicit pointer cursor and a clear hover state.
+- R2. Disabled or unimplemented controls render semi-transparent, non-clickable, and without an enabled hover affordance.
+- R3. Static read-only table rows and cards do not show row hover or action icons unless they actually navigate or open an action surface.
+- R4. Icon-only controls have accessible names and a visible affordance; icon controls with no implemented action are disabled or hidden.
+- R5. Existing implemented dashboard flows continue to work and retain their existing permission checks.
+- R6. Side-effect actions, especially sync-related actions, must not appear as live buttons unless they are wired to a real implementation and user feedback.
+- R7. Shared UI primitives make correct affordance behavior the default for future admin pages.
+- R8. The finished work is verified with targeted admin tests and a Helium browser smoke pass over representative dashboard routes.
+
+---
+
+## Scope Boundaries
+
+- Do not add new GraphQL fields, Prisma models, service-layer mutations, or generated schema outputs.
+- Do not build the missing video filter, manual video creation, row quick-action menus, or top-bar help surface in this pass.
+- Do not redesign the dashboard layout, navigation structure, card information hierarchy, or visual token palette.
+- Do not change auth/session behavior or cross-app imports.
+
+### Deferred to Follow-Up Work
+
+- Implementing the disabled video workflow actions as real product workflows should be planned against the video and media editorial roadmap.
+- Turning the command palette into a real searchable command input can be handled separately if route navigation alone is no longer sufficient.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/components/admin-ui.tsx` owns shared `PrimaryButton`, `SecondaryButton`, `SearchPillButton`, and `DataTable` primitives.
+- `apps/admin/src/components/admin-shell.tsx` owns the top-bar icon buttons, command palette, locale controls, and mobile nav trigger.
+- `apps/admin/src/app/dashboard/page.tsx` renders the dashboard `Run Manual Sync` CTA without a handler.
+- `apps/admin/src/app/dashboard/videos/page.tsx` renders active-looking `Filter`, `Add manual video`, and row quick-action controls that do not currently implement those workflows.
+- `apps/admin/src/app/dashboard/workflows/core-sync-trigger-button.tsx` already demonstrates the desired enabled/disabled affordance pattern for a real side-effect action.
+- `apps/admin/src/app/dashboard/dashboard-ui.test.tsx` and `apps/admin/src/components/admin-shell.test.tsx` provide existing render-level coverage for the touched UI surface.
+
+### Institutional Learnings
+
+- `docs/handoffs/2026-04-14-admin-ui-codex-handoff.md` defines the Forge Editorial admin UI as dense, hairline-led, token-based, and conservative with brand-red primary actions.
+- `docs/roadmap/platform/feat-091-admin-dashboard-ui.md` established the original dashboard shell and called out the need to replace placeholder admin scaffolding with operational surfaces.
+- `docs/roadmap/platform/feat-097-admin-v1-pr-hardening.md` confirms that operator-visible placeholders are release-quality issues in the admin UI.
+- `docs/roadmap/platform/feat-108-admin-experiences-dashboard-card-refinement.md` established that clickable experience cards should stay visibly led and direct, which should be preserved while improving disabled/permission states.
+
+### External References
+
+- None. Local patterns and live admin behavior are sufficient for this fix.
+
+---
+
+## Key Technical Decisions
+
+- Extend existing primitives rather than introducing a second button system: the current admin UI already centralizes repeated button and table styling in `admin-ui.tsx`.
+- Make disabled/unimplemented state explicit at the JSX/component boundary: placeholder actions should not depend on copy alone to signal that they are unavailable.
+- Split static and interactive table affordances: read-only tables should avoid hover and action icons by default, while pages with real row actions can opt in.
+- Keep the dashboard overview sync CTA non-operational unless it uses the real Core Sync trigger pattern: a production-looking primary button with no action is worse than a disabled placeholder.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this implement missing workflows or disable placeholders? Resolve by disabling/demoting placeholders; workflow implementation is outside this PR-sized fix.
+- Should the fix be route-by-route or primitive-led? Resolve by updating shared primitives first, then auditing route-specific one-offs.
+
+### Deferred to Implementation
+
+- Exact wording for disabled placeholder hints: choose concise admin-local labels that fit existing messages and avoid expanding the i18n surface unless necessary.
+- Whether each read-only `DataTable` caller needs an explicit `interactive` option or whether a default static table plus opt-in actions is cleaner after inspecting all current call sites.
+
+---
+
+## Implementation Units
+
+### U1. Roadmap Ticket And Shared Affordance Primitives
+
+**Goal:** Create the required roadmap ticket and make the shared admin controls encode pointer, hover, focus, and disabled behavior consistently.
+
+**Requirements:** R1, R2, R7
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md`
+- Modify: `apps/admin/src/components/admin-ui.tsx`
+- Modify: `apps/admin/src/app/globals.css`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Add a platform roadmap ticket with `status: "in-progress"` before UI implementation.
+- Extend shared button primitives to accept disabled state and native button props while preserving existing visual defaults.
+- Add explicit pointer, focus-visible, and disabled styles to shared interactive controls.
+- Introduce a shared disabled/placeholder affordance only if it reduces repetition across the audited routes.
+
+**Patterns to follow:**
+
+- `apps/admin/src/app/dashboard/workflows/core-sync-trigger-button.tsx`
+- `docs/handoffs/2026-04-14-admin-ui-codex-handoff.md`
+
+**Test scenarios:**
+
+- Happy path: rendering a shared enabled primary or secondary action includes pointer and hover affordance classes.
+- Edge case: rendering a disabled shared action includes disabled cursor and opacity classes while preserving accessible disabled semantics.
+- Regression: existing dashboard render tests still include translated dashboard content after primitive changes.
+
+**Verification:**
+
+- Shared buttons have correct enabled and disabled affordance classes in render output.
+
+---
+
+### U2. Disable Placeholder Actions On Dashboard And Videos
+
+**Goal:** Remove misleading enabled affordances from dashboard and video actions that do not yet implement a workflow.
+
+**Requirements:** R2, R4, R6
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Modify: `apps/admin/src/i18n/messages.ts`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Render dashboard `Run Manual Sync` as an unavailable/read-only action unless it is intentionally replaced with the existing real Core Sync trigger.
+- Render video `Filter`, `Add manual video`, and row quick actions as unavailable placeholders or remove the action chrome when no action is implemented.
+- Keep any explanatory copy short and in the same operational voice as existing admin labels.
+
+**Patterns to follow:**
+
+- Disabled button treatment in `apps/admin/src/app/dashboard/workflows/core-sync-trigger-button.tsx`
+- Existing message organization in `apps/admin/src/i18n/messages.ts`
+
+**Test scenarios:**
+
+- Happy path: dashboard overview no longer renders an enabled-looking inert sync button.
+- Happy path: video header placeholder actions render disabled/unavailable.
+- Edge case: video row quick actions do not expose an enabled click target when no row menu exists.
+
+**Verification:**
+
+- Helium smoke pass confirms placeholder actions are visibly disabled and do not show enabled hover/pointer behavior.
+
+---
+
+### U3. Remove False Table And Row Affordances
+
+**Goal:** Ensure static operational tables do not imply clickability and interactive rows remain intentionally opt-in.
+
+**Requirements:** R1, R3, R5, R7
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/components/admin-ui.tsx`
+- Modify: `apps/admin/src/app/dashboard/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/system-status/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/embeddings/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/languages/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/users/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/settings/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/partner-keys/page.tsx`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Make `DataTable` static by default and only render hover/action affordances when the caller supplies real row actions or marks rows interactive.
+- Remove hover styling from dashboard/system-status static rows that are not links or buttons.
+- Preserve existing real navigation or action affordances in workflow and experience surfaces.
+
+**Patterns to follow:**
+
+- Read-only operational surfaces in `apps/admin/src/app/dashboard/partner-keys/page.tsx`
+- Clickable experience cards in `apps/admin/src/app/dashboard/experiences/page.tsx`
+
+**Test scenarios:**
+
+- Happy path: read-only `DataTable` render output omits the trailing action icon by default.
+- Happy path: static activity and sync-state rows do not include hover affordance classes.
+- Regression: existing read-only dashboard pages still render their data rows and status pills.
+
+**Verification:**
+
+- Representative read-only pages show no row hover or action icon unless a real action exists.
+
+---
+
+### U4. Top-Bar And Permission-State Polish
+
+**Goal:** Make shell icon controls and permission-gated actions communicate their state clearly to mouse, keyboard, and assistive-technology users.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/components/admin-shell.tsx`
+- Modify: `apps/admin/src/components/admin-shell.test.tsx`
+- Modify: `apps/admin/src/app/dashboard/experiences/experiences-actions.tsx`
+- Modify: `apps/admin/src/app/dashboard/embeddings/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/system-status/page.tsx`
+- Test: `apps/admin/src/components/admin-shell.test.tsx`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Add accessible labels and consistent pointer/focus affordances to implemented shell icon controls.
+- Disable or hide the top-bar help button until it has an implemented destination or panel.
+- Render permission-blocked create actions and read-only fallbacks as disabled upfront rather than requiring a click to discover the blocked state.
+- Add disabled styling to form fields that can be unavailable, matching the existing button disabled pattern.
+
+**Patterns to follow:**
+
+- `CoreSyncTriggerButton` for real action feedback and disabled behavior.
+- Existing `AdminShell` tests for render-level shell coverage.
+
+**Test scenarios:**
+
+- Happy path: command button has an accessible label and remains available.
+- Edge case: help button is disabled/unavailable and named, not an unlabeled live icon button.
+- Edge case: permission-blocked experience creation renders unavailable without opening the modal.
+- Regression: locale controls still render and route refresh behavior remains unchanged.
+
+**Verification:**
+
+- Helium accessibility tree shows named shell icon controls and no live unlabeled help button.
+
+---
+
+### U5. Validation And Browser Smoke
+
+**Goal:** Prove the affordance changes from tests and the live admin surface.
+
+**Requirements:** R8
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Test: `apps/admin/src/components/admin-shell.test.tsx`
+
+**Approach:**
+
+- Run targeted admin render tests for dashboard and shell behavior.
+- Run admin typecheck if the primitive prop shape changes shared TypeScript surfaces.
+- Start or reuse the admin local server only after following the worktree preview guidance.
+- Use Helium for browser verification, checking hover/disabled/accessible states on dashboard, videos, system-status, embeddings, and experiences.
+
+**Patterns to follow:**
+
+- `apps/admin/docs/worktree-preview-setup.md`
+- Existing admin package scripts in `apps/admin/package.json`
+
+**Test scenarios:**
+
+- Integration: targeted dashboard and shell tests pass after the component API changes.
+- Browser smoke: enabled controls show pointer/hover, disabled placeholders look unavailable, and read-only rows do not imply action.
+
+**Verification:**
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx src/components/admin-shell.test.tsx`
+- `pnpm --filter @forge/admin typecheck`
+- Helium smoke proof against representative dashboard routes.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Shared button and table primitives affect most dashboard pages, so route-specific static/action states need review.
+- **Error propagation:** No new error propagation is introduced; existing server actions and API calls remain unchanged.
+- **State lifecycle risks:** Disabling inert actions should reduce accidental production-action confusion; real side-effect actions must retain their existing pending/success/error feedback.
+- **API surface parity:** No GraphQL, REST, Prisma, or generated type surfaces should change.
+- **Integration coverage:** Render tests prove class/semantic output; Helium smoke proof is required for real cursor/hover/disabled perception.
+- **Unchanged invariants:** Auth, permissions, data loading, service ownership, schema generation, and route availability stay unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                        | Mitigation                                                                                                                                  |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| A broad primitive change accidentally disables a real action                | Audit all modified call sites and add render assertions for enabled versus disabled behavior                                                |
+| Disabled placeholders hide useful future intent too aggressively            | Keep labels visible but unavailable, with concise disabled styling rather than deleting all controls                                        |
+| Table defaults remove affordances from a route that is actually interactive | Make interactivity explicit and preserve clickable cards/links where they already exist                                                     |
+| Browser proof is hard against production auth or local auth loops           | Prefer the already-authenticated Helium production session for read-only smoke; use local server only when the route can be safely verified |
+
+---
+
+## Documentation / Operational Notes
+
+- Update the new roadmap ticket to `status: "complete"` when the implementation and validation are finished.
+- Do not record disabled placeholders as completed workflows; they remain intentionally deferred product work.
+
+---
+
+## Sources & References
+
+- Related code: `apps/admin/src/components/admin-ui.tsx`
+- Related code: `apps/admin/src/components/admin-shell.tsx`
+- Related code: `apps/admin/src/app/dashboard/page.tsx`
+- Related code: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Related roadmap: `docs/roadmap/platform/feat-091-admin-dashboard-ui.md`
+- Related roadmap: `docs/roadmap/platform/feat-097-admin-v1-pr-hardening.md`
+- Related roadmap: `docs/roadmap/platform/feat-108-admin-experiences-dashboard-card-refinement.md`
+- Design handoff: `docs/handoffs/2026-04-14-admin-ui-codex-handoff.md`

--- a/docs/plans/2026-06-01-001-fix-admin-interaction-affordances-plan.md
+++ b/docs/plans/2026-06-01-001-fix-admin-interaction-affordances-plan.md
@@ -1,7 +1,7 @@
 ---
 title: Admin Interaction Affordance Polish
 type: fix
-status: active
+status: completed
 date: 2026-06-01
 ---
 

--- a/docs/roadmap/platform/feat-091-admin-dashboard-ui.md
+++ b/docs/roadmap/platform/feat-091-admin-dashboard-ui.md
@@ -8,7 +8,8 @@ start_date: "2026-04-14"
 duration: 2
 depends_on:
   - "feat-086"
-blocks: []
+blocks:
+  - "feat-153"
 tags:
   - "platform"
   - "admin"

--- a/docs/roadmap/platform/feat-097-admin-v1-pr-hardening.md
+++ b/docs/roadmap/platform/feat-097-admin-v1-pr-hardening.md
@@ -11,7 +11,8 @@ depends_on:
   - "feat-091"
   - "feat-092"
   - "feat-093"
-blocks: []
+blocks:
+  - "feat-153"
 tags:
   - "platform"
   - "admin"

--- a/docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md
+++ b/docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md
@@ -1,0 +1,78 @@
+---
+id: "feat-153"
+title: "Admin interaction affordance polish"
+owner: "tataihono"
+priority: "P1"
+status: "in-progress"
+start_date: "2026-06-01"
+duration: 1
+tags:
+  - "platform"
+  - "admin"
+  - "ui"
+  - "ux"
+  - "accessibility"
+depends_on:
+  - "feat-091"
+  - "feat-097"
+blocks: []
+---
+
+## Problem
+
+The admin dashboard contains a mix of live controls, read-only operational data,
+and future workflow placeholders. Some controls look enabled even when they do
+nothing, while some read-only rows show hover or action affordances. Operators
+need the panel to make clickability, disabled state, and unfinished workflows
+obvious.
+
+## Entry Points — Read These First
+
+- `docs/plans/2026-06-01-001-fix-admin-interaction-affordances-plan.md`
+- `apps/admin/src/components/admin-ui.tsx`
+- `apps/admin/src/components/admin-shell.tsx`
+- `apps/admin/src/app/dashboard/page.tsx`
+- `apps/admin/src/app/dashboard/videos/page.tsx`
+- `apps/admin/src/app/dashboard/experiences/experiences-actions.tsx`
+- `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+## Grep These
+
+- `PrimaryButton|SecondaryButton|SearchPillButton|DataTable` in
+  `apps/admin/src/components/admin-ui.tsx`
+- `Open command palette|Help is not available yet|searchPalettePrompt` in
+  `apps/admin/src/components/admin-shell.tsx` and
+  `apps/admin/src/i18n/messages.ts`
+- `Run Manual Sync|Add manual video|Quick Actions|Filter` in
+  `apps/admin/src/app/dashboard/`
+- `hover:bg-[var(--color-surface-raised)]` in
+  `apps/admin/src/app/dashboard/`
+
+## What To Build
+
+1. Give enabled clickable controls explicit pointer, hover, and focus-visible
+   affordances.
+2. Render unimplemented or permission-blocked controls as disabled,
+   semi-transparent, non-clickable controls.
+3. Remove hover/action affordances from static read-only table rows.
+4. Add accessible labels and disabled state to top-bar icon controls.
+5. Preserve existing implemented workflows such as Core Sync, semantic search,
+   workflow filtering, and permitted experience creation.
+
+## Constraints
+
+- Keep scope inside `apps/admin` and admin roadmap/plan docs.
+- Do not change Prisma schema, Pothos schema, service-layer mutations, or
+  generated GraphQL outputs.
+- Do not implement deferred video filter/manual-video/row-action workflows in
+  this pass.
+- Use existing Forge Editorial tokens and component grammar.
+- Use Helium browser for smoke verification.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx src/components/admin-shell.test.tsx`
+- `pnpm --filter @forge/admin typecheck`
+- Helium browser smoke for `/dashboard`, `/dashboard/videos`,
+  `/dashboard/system-status`, `/dashboard/embeddings`, and
+  `/dashboard/experiences`.

--- a/docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md
+++ b/docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md
@@ -3,7 +3,7 @@ id: "feat-153"
 title: "Admin interaction affordance polish"
 owner: "tataihono"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-06-01"
 duration: 1
 tags:


### PR DESCRIPTION
## Summary

Admin controls now communicate whether they are live actions, read-only diagnostics, or intentionally unavailable placeholders. This keeps operators from chasing inert controls while preserving implemented flows such as command navigation, semantic search, Core Sync, and permitted experience creation.

## What Changed

- Added shared pointer, hover, focus-visible, and disabled styling defaults for admin buttons, links, and table primitives.
- Disabled unfinished controls such as dashboard manual sync, videos filter/manual video, help, row quick-actions, and unavailable embedding triggers with labels, helper copy, and `aria-describedby` where useful.
- Removed read-only table and row affordances that implied hidden actions, and localized new affordance copy through the admin message catalog.
- Added a roadmap ticket and CE plan for the interaction-affordance pass.

## Validation

- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx src/components/admin-shell.test.tsx` passed: 12 tests.
- `pnpm --filter @forge/admin typecheck` passed.
- `pnpm --filter @forge/admin lint` passed.
- `pnpm --filter @forge/admin build` passed against a disposable local Postgres preview. It still emits the existing Turbopack NFT warnings from `video-db-backup.ts`.
- `git diff --check` passed.
- Browser proof: `agent-browser` and Helium both loaded `http://localhost:3003/dashboard/videos` with a temporary local admin cookie; verified disabled Filter/Add manual video helper copy, command-palette route dialog, pointer hover state, and disabled cursors/opacities. Also smoked `/dashboard`, `/dashboard/experiences`, `/dashboard/embeddings`, and `/dashboard/system-status`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
