### PR TITLE
feat(admin): improve video library browsing

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -51,6 +51,9 @@ AUTH_ADMIN_CLIENT_ID=jfp_admin_local
 # admin client is public + PKCE, so local dev can omit this.
 # AUTH_ADMIN_CLIENT_SECRET=
 ADMIN_BASE_URL=http://localhost:3003
+# Optional visitor-facing web origin for admin "open on web" actions.
+# Override to http://localhost:3000 when running apps/web locally.
+WEB_CANONICAL_ORIGIN=https://www.jesusfilm.org
 
 # Manager -> Admin session validation. Admin accepts this Auth-issued OAuth
 # service credential during the dual-accept migration, with MANAGER_ADMIN_API_KEY

--- a/apps/admin/docs/cms-operational-vs-deferred.md
+++ b/apps/admin/docs/cms-operational-vs-deferred.md
@@ -11,7 +11,8 @@
 
 ## Operational But Still Read-Heavy
 
-- `/dashboard/videos`
+- `/dashboard/videos` — paginated browsing, labels, thumbnails, and public
+  watch-page handoff links are operational; editing remains deferred.
 - `/dashboard/media`
 - `/dashboard/embeddings`
 - `/dashboard/search`

--- a/apps/admin/docs/v1-operational-surfaces.md
+++ b/apps/admin/docs/v1-operational-surfaces.md
@@ -14,7 +14,9 @@ version of `apps/admin`.
 - `/dashboard/experiences/[id]` now supports direct locale editing, publish
   actions, locale switching, and revision/audit visibility for experience
   locales.
-- `/dashboard/videos` reads real video catalog rows and associated dub coverage.
+- `/dashboard/videos` reads paginated video catalog rows with type labels,
+  thumbnails, dub coverage, and visitor-facing watch-page handoff links when a
+  safe public URL can be resolved.
 - `/dashboard/workflows` lists real Workflow runtime runs; each
   `/dashboard/workflows/[runId]` route embeds the `@workflow/web-shared`
   trace/detail UI for runtime events.

--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -566,13 +566,76 @@ describe("dashboard UI routes", () => {
     )
     expect(html).toContain("Collection")
     expect(html).toContain("https://images.example.com/neon.jpg")
+    expect(html).toMatch(
+      /<img(?=[^>]*src="https:\/\/images\.example\.com\/neon\.jpg")(?=[^>]*loading="lazy")(?=[^>]*decoding="async")/,
+    )
     expect(html).toContain(
       "https://www.jesusfilm.org/watch/neon-genesis-the-digital-divide.html/english.html",
     )
     expect(html).toContain('target="_blank"')
+    expect(html).toContain("--:--")
     expect(html).toContain("No public watch link available")
+    expect(html).toMatch(
+      /<span(?=[^>]*aria-disabled="true")(?=[^>]*aria-label="No public watch link available")/,
+    )
     expect(html).toContain("Showing 31-60 of 95")
     expect(html).toContain("Page 2 of 4")
+  })
+
+  it("renders first-page pagination with previous disabled and next linked", async () => {
+    vi.mocked(loadVideoLibraryPage).mockResolvedValueOnce({
+      rows: [],
+      pagination: {
+        total: 95,
+        currentPage: 1,
+        pageSize: 30,
+        pageCount: 4,
+        hasPrevious: false,
+        hasNext: true,
+        offset: 0,
+        rangeStart: 1,
+        rangeEnd: 30,
+      },
+    })
+
+    const html = await htmlFrom(
+      VideosPage({ searchParams: Promise.resolve({ page: "1" }) }),
+    )
+
+    expect(html).toContain("Showing 1-30 of 95")
+    expect(html).toContain("Page 1 of 4")
+    expect(html).toMatch(
+      /<span(?=[^>]*aria-disabled="true")[^>]*>[\s\S]*Previous/,
+    )
+    expect(html).toContain('href="/dashboard/videos?page=2"')
+    expect(html).not.toContain('href="/dashboard/videos?page=0"')
+  })
+
+  it("renders final-page pagination with next disabled and previous linked", async () => {
+    vi.mocked(loadVideoLibraryPage).mockResolvedValueOnce({
+      rows: [],
+      pagination: {
+        total: 95,
+        currentPage: 4,
+        pageSize: 30,
+        pageCount: 4,
+        hasPrevious: true,
+        hasNext: false,
+        offset: 90,
+        rangeStart: 91,
+        rangeEnd: 95,
+      },
+    })
+
+    const html = await htmlFrom(
+      VideosPage({ searchParams: Promise.resolve({ page: "999" }) }),
+    )
+
+    expect(html).toContain("Showing 91-95 of 95")
+    expect(html).toContain("Page 4 of 4")
+    expect(html).toContain('href="/dashboard/videos?page=3"')
+    expect(html).toMatch(/Next[\s\S]*<\/span>/)
+    expect(html).not.toContain('href="/dashboard/videos?page=5"')
   })
 
   it("renders core sync page around current sync state", async () => {

--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -93,13 +93,65 @@ vi.mock("@/app/dashboard/live-data", () => ({
       key: "vid_1",
       title: "Neon Genesis: The Digital Divide",
       id: "vid_8829_x_alpha_92",
+      slug: "neon-genesis-the-digital-divide",
+      label: "FEATURE_FILM",
+      labelLabel: "Feature Film",
       sourceLabel: "Mux",
       sourceTone: "info",
       dubs: "3 dubs · EN, ES, FR",
       updated: "10/24/2023, 14:02",
       duration: "04:22",
+      previewImageUrl: "https://images.example.com/neon.jpg",
+      visitorUrl:
+        "https://www.jesusfilm.org/watch/neon-genesis-the-digital-divide.html/english.html",
     },
   ]),
+  loadVideoLibraryPage: vi.fn(async () => ({
+    rows: [
+      {
+        key: "vid_1",
+        title: "Neon Genesis: The Digital Divide",
+        id: "vid_8829_x_alpha_92",
+        slug: "neon-genesis-the-digital-divide",
+        label: "COLLECTION",
+        labelLabel: "Collection",
+        sourceLabel: "Mux",
+        sourceTone: "info",
+        dubs: "3 dubs · EN, ES, FR",
+        updated: "10/24/2023, 14:02",
+        duration: "04:22",
+        previewImageUrl: "https://images.example.com/neon.jpg",
+        visitorUrl:
+          "https://www.jesusfilm.org/watch/neon-genesis-the-digital-divide.html/english.html",
+      },
+      {
+        key: "vid_2",
+        title: "No Public Link",
+        id: "vid_no_public_link",
+        slug: "no-public-link",
+        label: null,
+        labelLabel: null,
+        sourceLabel: "Internal",
+        sourceTone: "muted",
+        dubs: "No dubs",
+        updated: "10/24/2023, 14:03",
+        duration: "--:--",
+        previewImageUrl: null,
+        visitorUrl: null,
+      },
+    ],
+    pagination: {
+      total: 95,
+      currentPage: 2,
+      pageSize: 30,
+      pageCount: 4,
+      hasPrevious: true,
+      hasNext: true,
+      offset: 30,
+      rangeStart: 31,
+      rangeEnd: 60,
+    },
+  })),
 }))
 
 vi.mock("@/app/dashboard/ops-data", () => ({
@@ -394,6 +446,7 @@ vi.mock("@/services/workflow-worker-heartbeat.service", () => ({
 }))
 
 import DashboardPage from "./page"
+import { loadVideoLibraryPage } from "@/app/dashboard/live-data"
 import SystemStatusPage from "./system-status/page"
 import ExperiencesPage from "./experiences/page"
 import VideosPage from "./videos/page"
@@ -433,10 +486,25 @@ describe("dashboard UI routes", () => {
   })
 
   it("renders videos page with localized info strip and actions", async () => {
-    const html = await htmlFrom(VideosPage())
+    const html = await htmlFrom(
+      VideosPage({ searchParams: Promise.resolve({ page: "2" }) }),
+    )
     expect(html).toContain(uiMessages.pages.videos.infoStrip.items[0])
     expect(html).toContain(uiMessages.pages.videos.actions.primary)
     expect(html).toContain(uiMessages.common.operatorNotes)
+    expect(vi.mocked(loadVideoLibraryPage)).toHaveBeenCalledWith(
+      { id: "test-user", role: "ADMIN" },
+      { page: 2 },
+    )
+    expect(html).toContain("Collection")
+    expect(html).toContain("https://images.example.com/neon.jpg")
+    expect(html).toContain(
+      "https://www.jesusfilm.org/watch/neon-genesis-the-digital-divide.html/english.html",
+    )
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain("No public watch link available")
+    expect(html).toContain("Showing 31-60 of 95")
+    expect(html).toContain("Page 2 of 4")
   })
 
   it("renders core sync page around current sync state", async () => {

--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -9,6 +9,13 @@ import {
 } from "@/domain/blocks"
 import { getAdminLocale } from "@/i18n/server"
 import { createServices } from "@/services"
+import { env } from "@/config/env"
+import { WatchRouteManifestStore } from "@/services/watch-route-manifest-store"
+import {
+  createVideoLibraryPagination,
+  resolveVideoVisitorUrl,
+  VIDEO_LIBRARY_PAGE_SIZE,
+} from "./video-library-utils"
 
 function isMissingTableError(error: unknown) {
   return (
@@ -52,6 +59,13 @@ type VideoImageRow = {
   url: string | null
   kind: string | null
   createdAt: Date
+}
+
+type LoadVideoRowSliceOptions = {
+  principal: Principal
+  limit: number
+  offset: number
+  includeVisitorUrls?: boolean
 }
 
 function durationSecondsForDub(
@@ -375,6 +389,30 @@ function preferredVideoImage(images: VideoImageRow[]) {
   return images.find((image) => image.url)?.url ?? null
 }
 
+async function countActiveVideos() {
+  try {
+    return await prisma.video.count({ where: { deletedAt: null } })
+  } catch (error) {
+    if (isMissingTableError(error)) {
+      return 0
+    }
+    throw error
+  }
+}
+
+async function loadLatestWatchRouteManifest() {
+  try {
+    return (
+      (await new WatchRouteManifestStore(prisma).getLatest())?.payload ?? null
+    )
+  } catch (error) {
+    if (isMissingTableError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
 export async function loadExperienceRows(principal: Principal) {
   const services = createServices(prisma)
   const locale = await getAdminLocale()
@@ -486,7 +524,12 @@ export async function loadExperienceRows(principal: Principal) {
   })
 }
 
-export async function loadVideoRows(principal: Principal) {
+async function loadVideoRowSlice({
+  principal,
+  limit,
+  offset,
+  includeVisitorUrls = false,
+}: LoadVideoRowSliceOptions) {
   const services = createServices(prisma)
   const locale = await getAdminLocale()
   let videos: Awaited<ReturnType<typeof services.video.list>>
@@ -494,7 +537,7 @@ export async function loadVideoRows(principal: Principal) {
     // U2: VideoService.list dropped its `user` param. Route is gated by requireSession().
     void principal
     videos = await services.video.list({
-      input: { limit: 30, offset: 0 },
+      input: { limit, offset },
       query: {},
     })
   } catch (error) {
@@ -573,6 +616,10 @@ export async function loadVideoRows(principal: Principal) {
     imagesByVideo.set(item.videoId, current)
   }
 
+  const routeManifest = includeVisitorUrls
+    ? await loadLatestWatchRouteManifest()
+    : null
+
   return videos.map((video) => {
     const localeRows = localesByVideo.get(video.id) ?? []
     const dubRows = dubsByVideo.get(video.id) ?? []
@@ -587,6 +634,7 @@ export async function loadVideoRows(principal: Principal) {
       title,
       description: localeRow?.description?.trim() || null,
       id: video.coreId,
+      slug: video.slug,
       label: video.label ?? null,
       labelLabel: localizedVideoLabel(video.label ?? null, locale),
       sourceLabel: source.label,
@@ -598,6 +646,49 @@ export async function loadVideoRows(principal: Principal) {
       previewImageUrl: preferredVideoImage(imageRows),
       previewStreamUrl:
         playbackDub?.hls ?? playbackDub?.dash ?? playbackDub?.share ?? null,
+      visitorUrl: includeVisitorUrls
+        ? resolveVideoVisitorUrl({
+            contentSlug: video.slug,
+            dubs: dubRows,
+            manifest: routeManifest,
+            webOrigin: env.WEB_CANONICAL_ORIGIN,
+          })
+        : null,
     }
   })
+}
+
+export async function loadVideoRows(principal: Principal) {
+  return loadVideoRowSlice({
+    principal,
+    limit: VIDEO_LIBRARY_PAGE_SIZE,
+    offset: 0,
+  })
+}
+
+export async function loadVideoLibraryPage(
+  principal: Principal,
+  {
+    page,
+    pageSize = VIDEO_LIBRARY_PAGE_SIZE,
+  }: { page: number; pageSize?: number },
+) {
+  const total = await countActiveVideos()
+  const pagination = createVideoLibraryPagination({
+    total,
+    requestedPage: page,
+    pageSize,
+  })
+
+  const rows =
+    total === 0
+      ? []
+      : await loadVideoRowSlice({
+          principal,
+          limit: pagination.pageSize,
+          offset: pagination.offset,
+          includeVisitorUrls: true,
+        })
+
+  return { rows, pagination }
 }

--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -390,8 +390,9 @@ function preferredVideoImage(images: VideoImageRow[]) {
 }
 
 async function countActiveVideos() {
+  const services = createServices(prisma)
   try {
-    return await prisma.video.count({ where: { deletedAt: null } })
+    return await services.video.countActive()
   } catch (error) {
     if (isMissingTableError(error)) {
       return 0
@@ -649,7 +650,6 @@ async function loadVideoRowSlice({
       visitorUrl: includeVisitorUrls
         ? resolveVideoVisitorUrl({
             contentSlug: video.slug,
-            dubs: dubRows,
             manifest: routeManifest,
             webOrigin: env.WEB_CANONICAL_ORIGIN,
           })

--- a/apps/admin/src/app/dashboard/video-library-utils.test.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.test.ts
@@ -98,58 +98,72 @@ describe("video-library-utils", () => {
     ).toBe("https://www.jesusfilm.org/watch/jesus.html/english.html")
   })
 
+  it("normalizes visitor URL origins before appending watch paths", () => {
+    expect(
+      buildVideoVisitorUrl({
+        contentSlug: "jesus",
+        languageSlug: "english",
+        webOrigin: "https://example.com/root?ignored=true",
+      }),
+    ).toBe("https://example.com/watch/jesus.html/english.html")
+  })
+
+  it("does not emit visitor URLs from non-HTTP origins", () => {
+    expect(
+      buildVideoVisitorUrl({
+        contentSlug: "jesus",
+        languageSlug: "english",
+        webOrigin: "ftp://example.com",
+      }),
+    ).toBeNull()
+  })
+
   it("prefers manifest-backed public language slugs", () => {
     expect(
       resolveVideoVisitorUrl({
         contentSlug: "jesus",
         manifest,
         webOrigin: "https://www.jesusfilm.org",
-        dubs: [
-          {
-            hls: "https://stream.example.com/spanish.m3u8",
-            published: true,
-            language: { slug: "spanish-castilian" },
-          },
-        ],
       }),
     ).toBe("https://www.jesusfilm.org/watch/jesus.html/english.html")
   })
 
-  it("falls back to playable row-level dub slugs when manifest data is missing", () => {
+  it("does not fall back to row-level dubs when manifest data is missing", () => {
     expect(
       resolveVideoVisitorUrl({
         contentSlug: "missing-from-manifest",
         manifest,
         webOrigin: "http://localhost:3000",
-        dubs: [
-          {
-            hls: "https://stream.example.com/french.m3u8",
-            published: true,
-            language: { slug: "french" },
-          },
-        ],
       }),
-    ).toBe("http://localhost:3000/watch/missing-from-manifest.html/french.html")
+    ).toBeNull()
   })
 
-  it("does not emit links from internal locale keys or unplayable dubs", () => {
+  it("does not emit visitor URLs when the manifest is unavailable", () => {
+    expect(
+      resolveVideoVisitorUrl({
+        contentSlug: "jesus",
+        manifest: null,
+        webOrigin: "http://localhost:3000",
+      }),
+    ).toBeNull()
+  })
+
+  it("only emits visitor URLs for manifest-backed language pairs", () => {
+    expect(
+      resolveVideoVisitorUrl({
+        contentSlug: "jesus",
+        manifest,
+        webOrigin: "http://localhost:3000",
+      }),
+    ).toBe("http://localhost:3000/watch/jesus.html/english.html")
+  })
+
+  it("does not emit links from internal locale keys", () => {
     expect(
       resolveVideoVisitorUrl({
         contentSlug: "collection",
         manifest,
         webOrigin: "https://www.jesusfilm.org",
-        dubs: [
-          {
-            hls: "https://stream.example.com/en.m3u8",
-            published: true,
-            language: { slug: "en" },
-          },
-          {
-            hls: null,
-            published: true,
-            language: { slug: "english" },
-          },
-        ],
       }),
     ).toBeNull()
   })

--- a/apps/admin/src/app/dashboard/video-library-utils.test.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest"
+import type { WatchRouteManifest } from "@/services/watch-route-manifest.service"
+import {
+  buildVideoVisitorUrl,
+  createVideoLibraryPagination,
+  isPublicAudioLanguageSlug,
+  parseVideoLibraryPage,
+  resolveVideoVisitorUrl,
+} from "./video-library-utils"
+
+const manifest: WatchRouteManifest = {
+  version: "test",
+  generatedAt: "2026-06-01T00:00:00.000Z",
+  contentSlugs: ["jesus", "collection"],
+  oneSegmentSlugs: [],
+  episodePairsByParent: {},
+  audioLanguageSlugs: ["spanish-castilian", "english", "en"],
+  audioLanguageIndexesByContent: {
+    jesus: [0, 1],
+    collection: [2],
+  },
+  audioLanguageIndexesByEpisode: {},
+}
+
+describe("video-library-utils", () => {
+  it("parses invalid, empty, and negative page params as page 1", () => {
+    expect(parseVideoLibraryPage(undefined)).toBe(1)
+    expect(parseVideoLibraryPage("abc")).toBe(1)
+    expect(parseVideoLibraryPage("0")).toBe(1)
+    expect(parseVideoLibraryPage("-2")).toBe(1)
+  })
+
+  it("clamps pagination beyond the final page", () => {
+    expect(
+      createVideoLibraryPagination({
+        total: 61,
+        requestedPage: 99,
+        pageSize: 30,
+      }),
+    ).toMatchObject({
+      currentPage: 3,
+      pageCount: 3,
+      offset: 60,
+      rangeStart: 61,
+      rangeEnd: 61,
+      hasNext: false,
+      hasPrevious: true,
+    })
+  })
+
+  it("keeps zero-result pagination safe", () => {
+    expect(
+      createVideoLibraryPagination({
+        total: 0,
+        requestedPage: 2,
+        pageSize: 30,
+      }),
+    ).toMatchObject({
+      currentPage: 1,
+      pageCount: 1,
+      offset: 0,
+      rangeStart: 0,
+      rangeEnd: 0,
+      hasNext: false,
+      hasPrevious: false,
+    })
+  })
+
+  it("keeps non-finite direct pagination callers on page 1", () => {
+    expect(
+      createVideoLibraryPagination({
+        total: 90,
+        requestedPage: Number.NaN,
+        pageSize: 30,
+      }),
+    ).toMatchObject({
+      currentPage: 1,
+      offset: 0,
+      rangeStart: 1,
+      rangeEnd: 30,
+    })
+  })
+
+  it("rejects BCP-47-like values as public audio language slugs", () => {
+    expect(isPublicAudioLanguageSlug("en")).toBe(false)
+    expect(isPublicAudioLanguageSlug("pt-br")).toBe(false)
+    expect(isPublicAudioLanguageSlug("english")).toBe(true)
+    expect(isPublicAudioLanguageSlug("spanish-castilian")).toBe(true)
+  })
+
+  it("builds absolute visitor URLs from public watch slugs", () => {
+    expect(
+      buildVideoVisitorUrl({
+        contentSlug: "jesus",
+        languageSlug: "english",
+        webOrigin: "https://www.jesusfilm.org/",
+      }),
+    ).toBe("https://www.jesusfilm.org/watch/jesus.html/english.html")
+  })
+
+  it("prefers manifest-backed public language slugs", () => {
+    expect(
+      resolveVideoVisitorUrl({
+        contentSlug: "jesus",
+        manifest,
+        webOrigin: "https://www.jesusfilm.org",
+        dubs: [
+          {
+            hls: "https://stream.example.com/spanish.m3u8",
+            published: true,
+            language: { slug: "spanish-castilian" },
+          },
+        ],
+      }),
+    ).toBe("https://www.jesusfilm.org/watch/jesus.html/english.html")
+  })
+
+  it("falls back to playable row-level dub slugs when manifest data is missing", () => {
+    expect(
+      resolveVideoVisitorUrl({
+        contentSlug: "missing-from-manifest",
+        manifest,
+        webOrigin: "http://localhost:3000",
+        dubs: [
+          {
+            hls: "https://stream.example.com/french.m3u8",
+            published: true,
+            language: { slug: "french" },
+          },
+        ],
+      }),
+    ).toBe("http://localhost:3000/watch/missing-from-manifest.html/french.html")
+  })
+
+  it("does not emit links from internal locale keys or unplayable dubs", () => {
+    expect(
+      resolveVideoVisitorUrl({
+        contentSlug: "collection",
+        manifest,
+        webOrigin: "https://www.jesusfilm.org",
+        dubs: [
+          {
+            hls: "https://stream.example.com/en.m3u8",
+            published: true,
+            language: { slug: "en" },
+          },
+          {
+            hls: null,
+            published: true,
+            language: { slug: "english" },
+          },
+        ],
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/admin/src/app/dashboard/video-library-utils.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.ts
@@ -18,14 +18,6 @@ export type VideoLibraryPagination = {
   rangeEnd: number
 }
 
-export type VisitorVideoDub = {
-  hls?: string | null
-  published?: boolean | null
-  language?: {
-    slug?: string | null
-  } | null
-}
-
 export function firstSearchParam(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value
 }
@@ -94,6 +86,16 @@ function preferredPublicLanguageSlug(slugs: Array<string | null | undefined>) {
   return candidates.find((slug) => slug === "english") ?? candidates[0] ?? null
 }
 
+function cleanWebOrigin(value: string) {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null
+    return url.origin
+  } catch {
+    return null
+  }
+}
+
 function manifestLanguageSlugsForContent(
   manifest: WatchRouteManifest | null | undefined,
   contentSlug: string,
@@ -118,20 +120,20 @@ export function buildVideoVisitorUrl({
 }) {
   const normalizedContentSlug = cleanSlug(contentSlug)
   const normalizedLanguageSlug = cleanSlug(languageSlug)
-  if (!normalizedContentSlug || !normalizedLanguageSlug) return null
+  const normalizedWebOrigin = cleanWebOrigin(webOrigin)
+  if (!normalizedContentSlug || !normalizedLanguageSlug || !normalizedWebOrigin)
+    return null
   if (!isPublicAudioLanguageSlug(normalizedLanguageSlug)) return null
 
-  return `${webOrigin.replace(/\/+$/, "")}/watch/${normalizedContentSlug}.html/${normalizedLanguageSlug}.html`
+  return `${normalizedWebOrigin}/watch/${normalizedContentSlug}.html/${normalizedLanguageSlug}.html`
 }
 
 export function resolveVideoVisitorUrl({
   contentSlug,
-  dubs,
   manifest,
   webOrigin,
 }: {
   contentSlug: string
-  dubs: readonly VisitorVideoDub[]
   manifest?: WatchRouteManifest | null
   webOrigin: string
 }) {
@@ -149,16 +151,5 @@ export function resolveVideoVisitorUrl({
     })
   }
 
-  const playableDubLanguage = preferredPublicLanguageSlug(
-    dubs
-      .filter((dub) => dub.published && dub.hls)
-      .map((dub) => dub.language?.slug),
-  )
-  if (!playableDubLanguage) return null
-
-  return buildVideoVisitorUrl({
-    contentSlug: normalizedContentSlug,
-    languageSlug: playableDubLanguage,
-    webOrigin,
-  })
+  return null
 }

--- a/apps/admin/src/app/dashboard/video-library-utils.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.ts
@@ -1,0 +1,164 @@
+import type { WatchRouteManifest } from "@/services/watch-route-manifest.service"
+
+export const VIDEO_LIBRARY_PAGE_SIZE = 30
+export const VIDEO_LIBRARY_MAX_PAGE_SIZE = 200
+
+const SLUG_PATTERN = /^[a-z0-9-]+$/
+const BCP47_TAG_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/i
+
+export type VideoLibraryPagination = {
+  total: number
+  currentPage: number
+  pageSize: number
+  pageCount: number
+  hasPrevious: boolean
+  hasNext: boolean
+  offset: number
+  rangeStart: number
+  rangeEnd: number
+}
+
+export type VisitorVideoDub = {
+  hls?: string | null
+  published?: boolean | null
+  language?: {
+    slug?: string | null
+  } | null
+}
+
+export function firstSearchParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export function parseVideoLibraryPage(value: string | string[] | undefined) {
+  const parsed = Number(firstSearchParam(value))
+  if (!Number.isFinite(parsed)) return 1
+  return Math.max(1, Math.trunc(parsed))
+}
+
+export function normalizeVideoLibraryPageSize(value: number | undefined) {
+  if (!Number.isFinite(value)) return VIDEO_LIBRARY_PAGE_SIZE
+  return Math.min(
+    Math.max(Math.trunc(value ?? VIDEO_LIBRARY_PAGE_SIZE), 1),
+    VIDEO_LIBRARY_MAX_PAGE_SIZE,
+  )
+}
+
+export function createVideoLibraryPagination({
+  total,
+  requestedPage,
+  pageSize,
+}: {
+  total: number
+  requestedPage: number
+  pageSize?: number
+}): VideoLibraryPagination {
+  const normalizedTotal = Math.max(0, Math.trunc(total))
+  const normalizedPageSize = normalizeVideoLibraryPageSize(pageSize)
+  const pageCount = Math.max(1, Math.ceil(normalizedTotal / normalizedPageSize))
+  const normalizedRequestedPage = Number.isFinite(requestedPage)
+    ? Math.max(1, Math.trunc(requestedPage))
+    : 1
+  const currentPage = Math.min(normalizedRequestedPage, pageCount)
+  const offset = (currentPage - 1) * normalizedPageSize
+
+  return {
+    total: normalizedTotal,
+    currentPage,
+    pageSize: normalizedPageSize,
+    pageCount,
+    hasPrevious: currentPage > 1,
+    hasNext: currentPage < pageCount,
+    offset,
+    rangeStart: normalizedTotal === 0 ? 0 : offset + 1,
+    rangeEnd: Math.min(normalizedTotal, offset + normalizedPageSize),
+  }
+}
+
+function cleanSlug(value: string | null | undefined) {
+  const slug = value?.trim().toLowerCase() ?? ""
+  return SLUG_PATTERN.test(slug) ? slug : null
+}
+
+export function isPublicAudioLanguageSlug(value: string | null | undefined) {
+  const slug = cleanSlug(value)
+  if (!slug) return false
+  return !BCP47_TAG_PATTERN.test(slug)
+}
+
+function preferredPublicLanguageSlug(slugs: Array<string | null | undefined>) {
+  const candidates = Array.from(
+    new Set(slugs.map(cleanSlug).filter((slug): slug is string => !!slug)),
+  ).filter(isPublicAudioLanguageSlug)
+
+  return candidates.find((slug) => slug === "english") ?? candidates[0] ?? null
+}
+
+function manifestLanguageSlugsForContent(
+  manifest: WatchRouteManifest | null | undefined,
+  contentSlug: string,
+) {
+  if (!manifest?.contentSlugs.includes(contentSlug)) return []
+
+  const languageIndexes =
+    manifest.audioLanguageIndexesByContent?.[contentSlug] ?? []
+  return languageIndexes
+    .map((index) => manifest.audioLanguageSlugs[index])
+    .filter((slug): slug is string => !!slug)
+}
+
+export function buildVideoVisitorUrl({
+  contentSlug,
+  languageSlug,
+  webOrigin,
+}: {
+  contentSlug: string
+  languageSlug: string
+  webOrigin: string
+}) {
+  const normalizedContentSlug = cleanSlug(contentSlug)
+  const normalizedLanguageSlug = cleanSlug(languageSlug)
+  if (!normalizedContentSlug || !normalizedLanguageSlug) return null
+  if (!isPublicAudioLanguageSlug(normalizedLanguageSlug)) return null
+
+  return `${webOrigin.replace(/\/+$/, "")}/watch/${normalizedContentSlug}.html/${normalizedLanguageSlug}.html`
+}
+
+export function resolveVideoVisitorUrl({
+  contentSlug,
+  dubs,
+  manifest,
+  webOrigin,
+}: {
+  contentSlug: string
+  dubs: readonly VisitorVideoDub[]
+  manifest?: WatchRouteManifest | null
+  webOrigin: string
+}) {
+  const normalizedContentSlug = cleanSlug(contentSlug)
+  if (!normalizedContentSlug) return null
+
+  const manifestLanguage = preferredPublicLanguageSlug(
+    manifestLanguageSlugsForContent(manifest, normalizedContentSlug),
+  )
+  if (manifestLanguage) {
+    return buildVideoVisitorUrl({
+      contentSlug: normalizedContentSlug,
+      languageSlug: manifestLanguage,
+      webOrigin,
+    })
+  }
+
+  const playableDubLanguage = preferredPublicLanguageSlug(
+    dubs
+      .filter((dub) => dub.published && dub.hls)
+      .map((dub) => dub.language?.slug),
+  )
+  if (!playableDubLanguage) return null
+
+  return buildVideoVisitorUrl({
+    contentSlug: normalizedContentSlug,
+    languageSlug: playableDubLanguage,
+    webOrigin,
+  })
+}

--- a/apps/admin/src/app/dashboard/videos/page.tsx
+++ b/apps/admin/src/app/dashboard/videos/page.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from "react"
+import type { ReactNode } from "react"
 import type { Route } from "next"
 import Link from "next/link"
 import {
@@ -35,14 +35,6 @@ function paginationHref(page: number): Route {
   return (
     page <= 1 ? "/dashboard/videos" : `/dashboard/videos?page=${page}`
   ) as Route
-}
-
-function thumbnailStyle(url: string | null): CSSProperties | undefined {
-  if (!url) return undefined
-  const safeUrl = url.replaceAll('"', "%22")
-  return {
-    backgroundImage: `linear-gradient(180deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.55)), url("${safeUrl}")`,
-  }
 }
 
 function paginationSummary(
@@ -189,11 +181,23 @@ export default async function VideosPage({
                         className="hairline-b transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
                       >
                         <td className="p-4 align-middle">
-                          <div
-                            className="relative flex aspect-video w-[150px] items-center justify-center rounded-sm border border-white/10 bg-[linear-gradient(135deg,#151312,#292524)] bg-cover bg-center"
-                            style={thumbnailStyle(video.previewImageUrl)}
-                          >
-                            {video.previewImageUrl ? null : (
+                          <div className="relative flex aspect-video w-[150px] items-center justify-center overflow-hidden rounded-sm border border-white/10 bg-[linear-gradient(135deg,#151312,#292524)]">
+                            {video.previewImageUrl ? (
+                              <>
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={video.previewImageUrl}
+                                  alt=""
+                                  loading="lazy"
+                                  decoding="async"
+                                  className="absolute inset-0 h-full w-full object-cover"
+                                />
+                                <span
+                                  aria-hidden="true"
+                                  className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08),rgba(0,0,0,0.55))]"
+                                />
+                              </>
+                            ) : (
                               <ImageIcon
                                 className="h-5 w-5 text-[var(--color-text-disabled)]"
                                 strokeWidth={1.5}
@@ -255,6 +259,7 @@ export default async function VideosPage({
                             </a>
                           ) : (
                             <span
+                              aria-disabled="true"
                               aria-label={page.table.noVisitorLinkLabel}
                               title={page.table.noVisitorLinkLabel}
                               className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-disabled)]"
@@ -263,6 +268,9 @@ export default async function VideosPage({
                                 className="h-4 w-4"
                                 strokeWidth={1.5}
                               />
+                              <span className="sr-only">
+                                {page.table.noVisitorLinkLabel}
+                              </span>
                             </span>
                           )}
                         </td>

--- a/apps/admin/src/app/dashboard/videos/page.tsx
+++ b/apps/admin/src/app/dashboard/videos/page.tsx
@@ -1,4 +1,14 @@
-import { Filter, Plus } from "lucide-react"
+import type { CSSProperties, ReactNode } from "react"
+import type { Route } from "next"
+import Link from "next/link"
+import {
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  Filter,
+  ImageIcon,
+  Plus,
+} from "lucide-react"
 import {
   DashboardPageHeader,
   InfoStrip,
@@ -8,16 +18,103 @@ import {
   PrimaryButton,
   SecondaryButton,
   StatusPill,
+  cx,
 } from "@/components/admin-ui"
 import { requireSession } from "@/auth/session"
-import { loadVideoRows } from "@/app/dashboard/live-data"
+import { loadVideoLibraryPage } from "@/app/dashboard/live-data"
 import { getAdminMessages } from "@/i18n/server"
+import { parseVideoLibraryPage } from "../video-library-utils"
 
-export default async function VideosPage() {
+type VideosPageProps = {
+  searchParams?: Promise<{
+    page?: string | string[]
+  }>
+}
+
+function paginationHref(page: number): Route {
+  return (
+    page <= 1 ? "/dashboard/videos" : `/dashboard/videos?page=${page}`
+  ) as Route
+}
+
+function thumbnailStyle(url: string | null): CSSProperties | undefined {
+  if (!url) return undefined
+  const safeUrl = url.replaceAll('"', "%22")
+  return {
+    backgroundImage: `linear-gradient(180deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.55)), url("${safeUrl}")`,
+  }
+}
+
+function paginationSummary(
+  template: string,
+  pagination: {
+    rangeStart: number
+    rangeEnd: number
+    total: number
+  },
+) {
+  return template
+    .replace("{start}", pagination.rangeStart.toString())
+    .replace("{end}", pagination.rangeEnd.toString())
+    .replace("{total}", pagination.total.toString())
+}
+
+function pageCountLabel(
+  template: string,
+  pagination: {
+    currentPage: number
+    pageCount: number
+  },
+) {
+  return template
+    .replace("{current}", pagination.currentPage.toString())
+    .replace("{count}", pagination.pageCount.toString())
+}
+
+function paginationControlClass(disabled: boolean) {
+  return cx(
+    "inline-flex h-8 items-center gap-1 rounded-sm border border-[var(--color-hairline)] px-2 font-mono text-[11px] transition-all duration-[120ms] ease-out",
+    !disabled && "hover:bg-[var(--color-surface-raised)]",
+    disabled && "text-[var(--color-text-disabled)]",
+  )
+}
+
+function PaginationControl({
+  children,
+  disabled,
+  href,
+}: {
+  children: ReactNode
+  disabled: boolean
+  href: Route
+}) {
+  if (disabled) {
+    return (
+      <span aria-disabled="true" className={paginationControlClass(true)}>
+        {children}
+      </span>
+    )
+  }
+
+  return (
+    <Link href={href} className={paginationControlClass(false)}>
+      {children}
+    </Link>
+  )
+}
+
+export default async function VideosPage({
+  searchParams,
+}: VideosPageProps = {}) {
   const messages = await getAdminMessages()
   const page = messages.pages.videos
   const principal = await requireSession()
-  const videoRows = await loadVideoRows(principal)
+  const params = (await searchParams) ?? {}
+  const requestedPage = parseVideoLibraryPage(params.page)
+  const { rows: videoRows, pagination } = await loadVideoLibraryPage(
+    principal,
+    { page: requestedPage },
+  )
 
   return (
     <div className="flex flex-col gap-6">
@@ -47,66 +144,142 @@ export default async function VideosPage() {
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(340px,0.75fr)]">
         <div className="flex flex-col gap-6">
           <PageSection title={page.table.title} meta={page.table.meta}>
-            <table className="w-full border-collapse text-left">
-              <thead className="hairline-strong-b bg-[var(--color-surface-inset)]">
-                <tr>
-                  {page.table.columns.map((column) => (
-                    <th key={column} className="label-text px-4 py-3">
-                      {column}
-                    </th>
-                  ))}
-                  <th className="label-text px-4 py-3" />
-                </tr>
-              </thead>
-              <tbody>
-                {videoRows.map((video) => (
-                  <tr
-                    key={video.id}
-                    className="hairline-b transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
-                  >
-                    <td className="p-4 align-middle">
-                      <div className="flex aspect-video w-[180px] items-end justify-end rounded-sm border border-white/5 bg-[linear-gradient(135deg,#151312,#292524)] p-2">
-                        <span className="rounded-[2px] bg-black/50 px-1.5 py-0.5 font-mono text-[9px]">
-                          {video.duration}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 align-middle">
-                      <div className="text-[13px] font-medium">
-                        {video.title}
-                      </div>
-                      <div className="mono-meta text-[var(--color-text-muted)]">
-                        {video.id}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 align-middle">
-                      <StatusPill tone={video.sourceTone}>
-                        {video.sourceLabel}
-                      </StatusPill>
-                    </td>
-                    <td className="px-4 py-3 align-middle">
-                      <span className="font-mono text-[12px] text-[var(--color-text-secondary)]">
-                        {video.dubs}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 align-middle">
-                      <span className="mono-meta text-[var(--color-text-muted)]">
-                        {video.updated}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-right align-middle">
-                      <button
-                        type="button"
-                        aria-label={messages.common.quickActions}
-                        className="font-mono text-[14px] text-[var(--color-text-disabled)] transition-all duration-[120ms] ease-out hover:text-[var(--color-text-primary)]"
-                      >
-                        ⋯
-                      </button>
-                    </td>
+            <div className="overflow-x-auto">
+              <table className="min-w-[820px] w-full border-collapse text-left">
+                <thead className="hairline-strong-b bg-[var(--color-surface-inset)]">
+                  <tr>
+                    {page.table.columns.map((column) => (
+                      <th key={column} className="label-text px-4 py-3">
+                        {column}
+                      </th>
+                    ))}
+                    <th className="label-text w-12 px-4 py-3" />
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {videoRows.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={page.table.columns.length + 1}
+                        className="px-4 py-10 text-center text-[13px] text-[var(--color-text-muted)]"
+                      >
+                        {page.table.empty}
+                      </td>
+                    </tr>
+                  ) : (
+                    videoRows.map((video) => (
+                      <tr
+                        key={video.key}
+                        className="hairline-b transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+                      >
+                        <td className="p-4 align-middle">
+                          <div
+                            className="relative flex aspect-video w-[150px] items-center justify-center rounded-sm border border-white/10 bg-[linear-gradient(135deg,#151312,#292524)] bg-cover bg-center"
+                            style={thumbnailStyle(video.previewImageUrl)}
+                          >
+                            {video.previewImageUrl ? null : (
+                              <ImageIcon
+                                className="h-5 w-5 text-[var(--color-text-disabled)]"
+                                strokeWidth={1.5}
+                              />
+                            )}
+                            <span className="absolute bottom-2 right-2 rounded-[2px] bg-black/60 px-1.5 py-0.5 font-mono text-[9px]">
+                              {video.duration}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 align-middle">
+                          <div className="flex max-w-[280px] flex-col gap-2">
+                            <div>
+                              <div className="truncate text-[13px] font-medium">
+                                {video.title}
+                              </div>
+                              <div className="mono-meta truncate text-[var(--color-text-muted)]">
+                                {video.id}
+                              </div>
+                            </div>
+                            {video.labelLabel ? (
+                              <div>
+                                <StatusPill tone="muted">
+                                  {video.labelLabel}
+                                </StatusPill>
+                              </div>
+                            ) : null}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 align-middle">
+                          <StatusPill tone={video.sourceTone}>
+                            {video.sourceLabel}
+                          </StatusPill>
+                        </td>
+                        <td className="px-4 py-3 align-middle">
+                          <span className="font-mono text-[12px] text-[var(--color-text-secondary)]">
+                            {video.dubs}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 align-middle">
+                          <span className="mono-meta text-[var(--color-text-muted)]">
+                            {video.updated}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-right align-middle">
+                          {video.visitorUrl ? (
+                            <a
+                              href={video.visitorUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              aria-label={`${page.table.openVisitorLabel}: ${video.title}`}
+                              title={page.table.openVisitorLabel}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]"
+                            >
+                              <ExternalLink
+                                className="h-4 w-4"
+                                strokeWidth={1.5}
+                              />
+                            </a>
+                          ) : (
+                            <span
+                              aria-label={page.table.noVisitorLinkLabel}
+                              title={page.table.noVisitorLinkLabel}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-disabled)]"
+                            >
+                              <ExternalLink
+                                className="h-4 w-4"
+                                strokeWidth={1.5}
+                              />
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <div className="hairline-strong-t flex flex-col gap-3 px-4 py-3 text-[12px] text-[var(--color-text-muted)] md:flex-row md:items-center md:justify-between">
+              <span className="font-mono">
+                {paginationSummary(page.table.pagination.summary, pagination)}
+              </span>
+              <div className="flex items-center gap-2">
+                <PaginationControl
+                  href={paginationHref(pagination.currentPage - 1)}
+                  disabled={!pagination.hasPrevious}
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" strokeWidth={1.5} />
+                  {page.table.pagination.previous}
+                </PaginationControl>
+                <span className="min-w-[96px] text-center font-mono text-[11px]">
+                  {pageCountLabel(page.table.pagination.page, pagination)}
+                </span>
+                <PaginationControl
+                  href={paginationHref(pagination.currentPage + 1)}
+                  disabled={!pagination.hasNext}
+                >
+                  {page.table.pagination.next}
+                  <ChevronRight className="h-3.5 w-3.5" strokeWidth={1.5} />
+                </PaginationControl>
+              </div>
+            </div>
           </PageSection>
 
           <PageSection title={page.signals.title} meta={page.signals.meta}>

--- a/apps/admin/src/config/env.test.ts
+++ b/apps/admin/src/config/env.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest"
 import {
   assertBearerCsvsDisjoint,
   concurrencyEnvSchema,
+  DEFAULT_WEB_CANONICAL_ORIGIN,
   env,
   searchTraceRawRetentionDaysEnvSchema,
 } from "@/config/env"
@@ -12,6 +13,10 @@ import {
 describe("env", () => {
   it("loads with placeholder defaults in CI mode", () => {
     expect(env.DATABASE_URL).toContain("forge_admin")
+  })
+
+  it("defaults visitor-facing web links to the canonical www watch origin", () => {
+    expect(env.WEB_CANONICAL_ORIGIN).toBe(DEFAULT_WEB_CANONICAL_ORIGIN)
   })
 
   // `createEnv` is bypassed under CI (`skipValidation`), so we test

--- a/apps/admin/src/config/env.test.ts
+++ b/apps/admin/src/config/env.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_WEB_CANONICAL_ORIGIN,
   env,
   searchTraceRawRetentionDaysEnvSchema,
+  webCanonicalOriginEnvSchema,
 } from "@/config/env"
 
 describe("env", () => {
@@ -17,6 +18,28 @@ describe("env", () => {
 
   it("defaults visitor-facing web links to the canonical www watch origin", () => {
     expect(env.WEB_CANONICAL_ORIGIN).toBe(DEFAULT_WEB_CANONICAL_ORIGIN)
+  })
+
+  describe("webCanonicalOriginEnvSchema", () => {
+    it("normalizes HTTP(S) URLs to origins", () => {
+      expect(
+        webCanonicalOriginEnvSchema.parse(
+          "https://example.com/some/path?x=1#top",
+        ),
+      ).toBe("https://example.com")
+      expect(webCanonicalOriginEnvSchema.parse("http://localhost:3000/")).toBe(
+        "http://localhost:3000",
+      )
+    })
+
+    it("rejects non-HTTP visitor link origins", () => {
+      expect(() =>
+        webCanonicalOriginEnvSchema.parse("ftp://example.com"),
+      ).toThrow(/HTTP\(S\)/)
+      expect(() =>
+        webCanonicalOriginEnvSchema.parse("javascript:alert(1)"),
+      ).toThrow(/HTTP\(S\)|Invalid/)
+    })
   })
 
   // `createEnv` is bypassed under CI (`skipValidation`), so we test

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -6,6 +6,8 @@ import { z } from "zod"
 // `undefined` before validation.
 const emptyToUndefined = (v: string | undefined) => (v === "" ? undefined : v)
 
+export const DEFAULT_WEB_CANONICAL_ORIGIN = "https://www.jesusfilm.org"
+
 /**
  * Shared schema fragment for env vars representing a positive-int
  * concurrency cap (e.g. `SCENE_EMBEDDING_CONCURRENCY`,
@@ -54,6 +56,14 @@ export const env = createEnv({
       .enum(["local", "preview", "staging", "production"])
       .optional(),
     ADMIN_BASE_URL: z.string().url().optional(),
+    // Public web origin used only for outbound visitor-facing watch links
+    // from admin. Optional so local/admin-only deployments do not need a new
+    // env var; production defaults to the indexed www host.
+    WEB_CANONICAL_ORIGIN: z
+      .string()
+      .url()
+      .optional()
+      .default(DEFAULT_WEB_CANONICAL_ORIGIN),
     MANAGER_ADMIN_API_KEY: z.string().min(1).optional(),
     REDIS_HOST: z.string().min(1).optional(),
     REDIS_PORT: z.coerce.number().int().positive().optional(),
@@ -284,6 +294,9 @@ export const env = createEnv({
       process.env.AUTH_MANAGER_SERVICE_ENVIRONMENT,
     ),
     ADMIN_BASE_URL: emptyToUndefined(process.env.ADMIN_BASE_URL),
+    WEB_CANONICAL_ORIGIN:
+      emptyToUndefined(process.env.WEB_CANONICAL_ORIGIN) ??
+      DEFAULT_WEB_CANONICAL_ORIGIN,
     MANAGER_ADMIN_API_KEY: emptyToUndefined(process.env.MANAGER_ADMIN_API_KEY),
     REDIS_HOST: emptyToUndefined(process.env.REDIS_HOST),
     REDIS_PORT: emptyToUndefined(process.env.REDIS_PORT),

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -8,6 +8,15 @@ const emptyToUndefined = (v: string | undefined) => (v === "" ? undefined : v)
 
 export const DEFAULT_WEB_CANONICAL_ORIGIN = "https://www.jesusfilm.org"
 
+export const webCanonicalOriginEnvSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    const protocol = new URL(value).protocol
+    return protocol === "http:" || protocol === "https:"
+  }, "WEB_CANONICAL_ORIGIN must be an HTTP(S) URL")
+  .transform((value) => new URL(value).origin)
+
 /**
  * Shared schema fragment for env vars representing a positive-int
  * concurrency cap (e.g. `SCENE_EMBEDDING_CONCURRENCY`,
@@ -59,9 +68,7 @@ export const env = createEnv({
     // Public web origin used only for outbound visitor-facing watch links
     // from admin. Optional so local/admin-only deployments do not need a new
     // env var; production defaults to the indexed www host.
-    WEB_CANONICAL_ORIGIN: z
-      .string()
-      .url()
+    WEB_CANONICAL_ORIGIN: webCanonicalOriginEnvSchema
       .optional()
       .default(DEFAULT_WEB_CANONICAL_ORIGIN),
     MANAGER_ADMIN_API_KEY: z.string().min(1).optional(),

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -381,8 +381,17 @@ export const adminMessages = {
         actions: { filter: "Filter", primary: "Add manual video" },
         table: {
           title: "Video Library",
-          meta: "ROW_THUMBNAILS / SOURCE_BADGES",
+          meta: "PAGINATED_ROWS / TYPE_LABELS / VISITOR_LINKS",
           columns: ["Thumbnail", "Video Details", "Source", "Dubs", "Updated"],
+          empty: "No active videos found.",
+          openVisitorLabel: "Open visitor-facing video page",
+          noVisitorLinkLabel: "No public watch link available",
+          pagination: {
+            summary: "Showing {start}-{end} of {total}",
+            page: "Page {current} of {count}",
+            previous: "Previous",
+            next: "Next",
+          },
           rows: [
             {
               title: "Neon Genesis: The Digital Divide",

--- a/apps/admin/src/services/video.service.test.ts
+++ b/apps/admin/src/services/video.service.test.ts
@@ -16,6 +16,7 @@ function mockPrisma() {
     video: {
       findMany: vi.fn(),
       findFirst: vi.fn(),
+      count: vi.fn(),
     },
     videoDub: {
       findMany: vi.fn(),
@@ -92,6 +93,17 @@ describe("VideoService", () => {
       await expect(
         service.list({ input: {}, query: {} }),
       ).resolves.not.toThrow()
+    })
+  })
+
+  describe("countActive", () => {
+    it("counts the same non-deleted video scope used by list", async () => {
+      prisma.video.count.mockResolvedValueOnce(12)
+
+      await expect(service.countActive()).resolves.toBe(12)
+      expect(prisma.video.count).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+      })
     })
   })
 

--- a/apps/admin/src/services/video.service.ts
+++ b/apps/admin/src/services/video.service.ts
@@ -91,6 +91,10 @@ export class VideoService {
     })
   }
 
+  async countActive() {
+    return this.prisma.video.count({ where: { deletedAt: null } })
+  }
+
   async getById({ id, query }: { id: string; query: object }) {
     return this.prisma.video.findFirst({
       ...query,

--- a/docs/plans/2026-06-01-001-feat-admin-video-library-pagination-plan.md
+++ b/docs/plans/2026-06-01-001-feat-admin-video-library-pagination-plan.md
@@ -1,0 +1,512 @@
+---
+title: "feat: Improve admin video library browsing"
+type: feat
+status: completed
+date: 2026-06-01
+---
+
+# feat: Improve admin video library browsing
+
+## Summary
+
+Improve `/dashboard/videos` from a fixed first-page preview into a usable
+operator catalog: paginate the Core-synced video rows, show the content type
+label, render the existing Core thumbnail imagery, and add a visitor-facing
+open-link action when a valid public watch URL can be resolved.
+
+---
+
+## Problem Frame
+
+The current admin video library reads live catalog data, but it only renders the
+first 30 newest active rows with no pagination controls. It also hides the
+`VideoLabel` distinction between collections, series, episodes, shorts, and
+feature films, ignores the `previewImageUrl` already returned by the loader,
+and offers no direct handoff to the public watch page.
+
+---
+
+## Assumptions
+
+_This plan was authored without synchronous user confirmation. The items below
+are agent inferences that fill gaps in the input and should be reviewed before
+implementation proceeds._
+
+- The work should stay read-oriented and inside `apps/admin`; full video editing
+  remains out of scope for this slice.
+- Pagination can be URL-query based so operators can refresh, share, and use
+  browser navigation without client-side state management.
+- Visitor-facing links should be hidden or disabled when a valid public audio
+  language slug cannot be resolved, rather than emitting likely-broken links.
+
+---
+
+## Requirements
+
+- R1. `/dashboard/videos` paginates beyond the current fixed first 30 rows and
+  reflects the active page in the URL.
+- R2. The video library displays each row's `VideoLabel` in a human-readable
+  form so collections, series, episodes, shorts, films, trailers, and segments
+  are distinguishable at scan time.
+- R3. The table thumbnail cell renders available Core video imagery from the
+  existing `previewImageUrl` priority chain, with a polished fallback when no
+  image exists.
+- R4. Each row exposes an icon-only action that opens the matching public watch
+  page in a new tab when a valid visitor URL can be derived.
+- R5. Public watch URLs use the web app's audio-language slug shape, not admin
+  locale keys or BCP-47 language codes.
+- R6. The changes preserve the existing read-only Core authority boundary:
+  admin is browsing synced video data, not editing Core-sourced videos.
+- R7. Visitor links are absolute web-origin URLs, never relative admin-origin
+  paths.
+
+---
+
+## Scope Boundaries
+
+- Do not add full video editing, creation, or mutation behavior.
+- Do not change the admin GraphQL `videos` schema unless implementation finds a
+  narrow need that cannot be met from the admin dashboard loader.
+- Do not import `apps/web` internals into `apps/admin`; duplicate only the small
+  public URL formatting rule needed for outbound links, and document why.
+- Do not add search, filters, sort controls, or bulk actions in this slice.
+- Do not change public watch route behavior in `apps/web`.
+
+### Deferred to Follow-Up Work
+
+- Video-detail/editor workflow for locale inspection and editorial updates
+  remains part of the broader `feat-100` follow-up work.
+- Search/filter controls can build on the pagination data shape later.
+- Public-link handling for three-segment episode routes can be added once the
+  admin list intentionally distinguishes parent/episode navigation targets.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md`
+  marks video/media workflows as the next admin CMS parity area while preserving
+  Core-sourced video authority.
+- `apps/admin/docs/v1-operational-surfaces.md` states that `/dashboard/videos`
+  already reads real video catalog rows and dub coverage.
+- `apps/admin/docs/cms-operational-vs-deferred.md` classifies
+  `/dashboard/videos` as operational but still read-heavy.
+- `apps/admin/src/app/dashboard/videos/page.tsx` renders the table directly
+  from `loadVideoRows`.
+- `apps/admin/src/app/dashboard/live-data.ts` currently calls
+  `services.video.list({ input: { limit: 30, offset: 0 } })`, enriches rows
+  with locales, dubs, images, and returns `labelLabel`, `previewImageUrl`, and
+  playback metadata that the page only partially uses.
+- `apps/admin/src/services/video.service.ts` already supports `limit` and
+  `offset`, orders active videos by most recent update, and caps list size.
+- `apps/admin/prisma/schema.prisma` defines `VideoLabel` and the
+  `VideoRelation` parent/child model used for collections and series.
+- `apps/admin/src/services/watch-route-manifest.service.ts` and
+  `apps/admin/src/services/watch-route-manifest-store.ts` provide the current
+  admin-owned source for valid public watch slugs and audio-language indexes.
+- `apps/web/AGENTS.md` requires visible `/watch` links to use public audio
+  language slugs such as `english.html`, not internal locale keys like
+  `en.html`.
+- `apps/web/src/lib/routes.ts` documents the public two-segment video URL shape
+  as `/{slug}.html/{lang}.html` under the `/watch` base path.
+- `apps/web/src/env.ts` and `apps/web/.env.example` identify
+  `NEXT_PUBLIC_CANONICAL_ORIGIN` as web's canonical watch origin; production
+  web URLs should use `https://www.jesusfilm.org`.
+- `apps/admin/src/config/env.ts` currently has admin/self and revalidation URL
+  config, but no dedicated public web origin value.
+
+### Institutional Learnings
+
+- Prior watch-route work made the admin route manifest the contract for public
+  route admission. Admin-side visitor links should prefer that existing
+  validity source over inventing separate routability rules.
+- Watch-route performance learnings emphasize lazy, bounded image loading for
+  non-hero thumbnails. The admin library should render thumbnails without
+  introducing eager preloads or extra public-watch bundle work.
+
+### External References
+
+- None. Existing admin/web contracts and local docs are sufficient.
+
+---
+
+## Key Technical Decisions
+
+- Introduce a video-library-specific dashboard data shape rather than changing
+  the shared picker API in place: `loadVideoRows` is also used by the experience
+  editor, so pagination should not break the editor's expectation that it gets
+  a simple video array.
+- Use server-rendered URL pagination: page number and page size stay visible in
+  the route query, and the dashboard page can render controls without adding a
+  client component unless implementation discovers a UX need.
+- Keep thumbnails as CSS background imagery or equivalent unoptimized rendering
+  inside the admin table: this follows existing admin/editor preview patterns
+  and avoids introducing Next image remote-host configuration for this small
+  operational surface.
+- Display labels in the video details area or a compact adjacent column, not as
+  a replacement for source/dub status. Type, source, and dub coverage answer
+  different operator questions.
+- Resolve visitor URLs from row slug plus a public audio-language slug. Prefer a
+  route-manifest-backed language when available; fall back only to a known
+  playable direct dub language for the row. Do not emit `en.html`.
+- Build visitor links with a dedicated admin-side public web origin value:
+  introduce optional `WEB_CANONICAL_ORIGIN` in admin config, default it to
+  `https://www.jesusfilm.org`, and use it only for outbound public watch URLs.
+  Keep the `apps/web` `NEXT_PUBLIC_CANONICAL_ORIGIN` naming as web-owned rather
+  than importing or reusing web internals from admin.
+- Use an icon-only external-link button with an accessible label and
+  `target="_blank"` semantics so the admin session remains in place while the
+  public page opens separately.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should pagination be client-side or URL/server-side? Use URL/server-side
+  pagination to preserve refresh/share behavior and match the current server
+  page shape.
+- Should the public link always point at English? No. It must use a public audio
+  language slug resolved from manifest or playable dub data; English can be a
+  candidate only when it is actually the resolved public slug.
+- Should the plan include video editing? No. This slice improves browsing and
+  handoff only.
+
+### Deferred to Implementation
+
+- Exact page size options: start with the current 30-row page size for parity;
+  choose whether to expose a page-size selector only if implementation shows a
+  clean existing pattern.
+- Missing route-manifest behavior: decide during implementation whether a
+  missing manifest disables visitor links globally or falls back to row-level
+  playable dub data.
+- Exact public origin: use the existing configured admin/web environment values
+  if present; otherwise choose the smallest local helper that keeps production
+  links correct without importing `apps/web`.
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should treat
+> it as context, not code to reproduce._
+
+```mermaid
+flowchart LR
+  route["/dashboard/videos?page=N"] --> loader["Video library dashboard loader"]
+  loader --> service["VideoService.list limit/offset"]
+  loader --> count["Active video count"]
+  loader --> enrich["Locales + dubs + images"]
+  loader --> manifest["Latest watch route manifest"]
+  enrich --> rows["Rows with label, thumbnail, dubs, duration"]
+  manifest --> links["Visitor URL resolver"]
+  rows --> page["Server-rendered table"]
+  links --> page
+  count --> pager["Pagination controls"]
+  pager --> route
+```
+
+---
+
+## Implementation Units
+
+### U1. Video Library Pagination Data
+
+**Goal:** Add a dashboard-specific data loader that returns paged rows plus
+page metadata without breaking the existing video picker loader.
+
+**Requirements:** R1, R6
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/live-data.ts`
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Test: new focused test file if implementation extracts loader helpers from
+  `live-data.ts`
+
+**Approach:**
+
+- Keep `loadVideoRows(principal)` array-compatible for existing experience
+  editor call sites.
+- Add a video-library-oriented loader or wrapper that accepts page parameters,
+  calculates `limit`/`offset`, fetches the current row slice, and returns
+  `total`, `currentPage`, `pageSize`, `pageCount`, `hasPrevious`, and `hasNext`.
+- Parse `searchParams` in `apps/admin/src/app/dashboard/videos/page.tsx` with
+  defensive handling for missing, non-numeric, negative, or too-large page
+  values.
+- Count only active videos using the same `deletedAt: null` boundary as
+  `VideoService.list`.
+- Preserve the current 30-row page size unless implementation finds a stronger
+  existing admin convention.
+
+**Execution note:** Start with characterization coverage for the current
+first-page behavior, then add page-boundary scenarios.
+
+**Patterns to follow:**
+
+- `apps/admin/src/services/video.service.ts` for `limit`/`offset` and active
+  video ordering.
+- Existing dashboard route tests in
+  `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`.
+
+**Test scenarios:**
+
+- Happy path: no query params renders page 1 and calls the loader with the
+  first-page offset.
+- Happy path: `?page=2` renders the second page metadata and next/previous
+  controls reflect the second-page state.
+- Edge case: `?page=0`, `?page=-1`, `?page=abc`, and page values beyond the
+  final page clamp or normalize to a safe page without throwing.
+- Edge case: zero active videos renders an empty table state and no broken
+  pagination controls.
+- Integration: existing experience editor video picker call sites still receive
+  an array from `loadVideoRows`.
+
+**Verification:**
+
+- The video dashboard can navigate between at least the first two pages of a
+  local or production-like catalog.
+- The experience editor still opens its video picker with available videos.
+
+### U2. Labels and Thumbnail Rendering
+
+**Goal:** Make each row visually communicate video type and render real Core
+thumbnail imagery when available.
+
+**Requirements:** R2, R3, R6
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Modify: `apps/admin/src/app/dashboard/live-data.ts`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Test: new focused test file if label/thumbnail helper extraction is useful
+
+**Approach:**
+
+- Use the loader's existing `labelLabel` output for human-readable labels and
+  keep the raw `label` available for tests or future filtering.
+- Render a compact label pill near the title or in a narrow type column so
+  collections, series, episodes, shorts, films, trailers, and segments can be
+  scanned without opening a row.
+- Render `previewImageUrl` in the thumbnail cell using the current admin preview
+  visual pattern, with a dark gradient fallback when no image exists.
+- Ensure image rendering does not stretch table rows unpredictably; keep the
+  aspect-ratio thumbnail box stable.
+- Keep source and dub coverage visible; labels should augment, not replace,
+  those columns.
+
+**Patterns to follow:**
+
+- Existing background-image preview patterns in
+  `apps/admin/src/app/dashboard/experiences/page.tsx` and
+  `apps/admin/src/app/dashboard/experiences/experience-editor.tsx`.
+- `StatusPill` and dashboard table styling from
+  `apps/admin/src/components/admin-ui.tsx`.
+
+**Test scenarios:**
+
+- Happy path: a row with `labelLabel: "Collection"` renders a visible
+  collection label alongside the video title.
+- Happy path: a row with `previewImageUrl` includes that URL in the rendered
+  thumbnail markup.
+- Edge case: a row with no label omits the label pill without leaving awkward
+  empty text.
+- Edge case: a row with no `previewImageUrl` renders the fallback thumbnail
+  state and still displays duration if available.
+- Visual: at desktop and screenshot-width viewports, thumbnail, label, title,
+  source, dubs, updated time, and action column do not overlap.
+
+**Verification:**
+
+- Operators can distinguish collections/series/episodes/singles at a glance.
+- Video thumbnails render for rows with Core image data and fall back cleanly
+  when absent.
+
+### U3. Visitor-Facing Open Link Action
+
+**Goal:** Add an icon-only action that opens the matching public watch page in a
+new tab when the admin can resolve a valid public watch URL.
+
+**Requirements:** R4, R5, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/live-data.ts`
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Modify: `apps/admin/src/config/env.ts`
+- Modify: `apps/admin/.env.example`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Test: new focused test file if visitor URL resolution is extracted
+
+**Approach:**
+
+- Extend the video-library row shape with the video slug and an optional
+  `visitorUrl`.
+- Resolve the public language slug from the latest watch route manifest when
+  possible, using row slug and manifest audio-language indexes to avoid broken
+  links for collection or series-like rows.
+- Fall back to a playable row-level dub language slug only when it produces the
+  public audio slug shape.
+- Format the public URL with the watch base path and `.html` segments matching
+  `apps/web/src/lib/routes.ts`, without importing `apps/web` internals.
+- Add optional `WEB_CANONICAL_ORIGIN` to admin env/config with a safe
+  production default of `https://www.jesusfilm.org`, plus local example
+  guidance for pointing at a local web dev server when both apps are running.
+- Render an icon-only link button using a lucide external-link style icon,
+  accessible label text, `target="_blank"`, and `rel="noreferrer"`.
+- Disable or omit the link when no visitor URL can be safely resolved.
+
+**Patterns to follow:**
+
+- Public watch-link rules in `apps/web/AGENTS.md`.
+- URL shape documented by `apps/web/src/lib/routes.ts`.
+- Watch route manifest store/service in `apps/admin/src/services/`.
+- Existing icon-button treatment in admin dashboard tables and workflow pages.
+
+**Test scenarios:**
+
+- Happy path: a row with a resolvable manifest language emits a link to
+  `https://www.jesusfilm.org/watch/{slug}.html/{language}.html` with
+  `target="_blank"` and an accessible label.
+- Happy path: a direct playable video with a row-level public language slug
+  emits a visitor URL when the manifest is missing or not useful.
+- Happy path: overriding `WEB_CANONICAL_ORIGIN` points generated links at that
+  origin without changing the `/watch/{slug}.html/{language}.html` path shape.
+- Edge case: a row with only BCP-47 data such as `en` does not emit
+  `/en.html`; it either resolves the public slug elsewhere or disables the
+  action.
+- Edge case: no visitor link renders as a disabled/omitted action rather than a
+  relative `/watch/...` link on the admin origin.
+- Edge case: collection or series rows without a resolvable public language
+  slug do not render a broken external link.
+- Integration: the external action does not replace the existing quick-actions
+  affordance unless implementation intentionally removes the placeholder
+  action as unused.
+
+**Verification:**
+
+- Clicking the external-link icon opens a public watch URL in a new tab for
+  rows with valid visitor links.
+- Rows without safe visitor links remain readable and do not expose broken
+  anchors.
+
+### U4. Copy, Documentation, and Visual Proof
+
+**Goal:** Update route copy/docs and verify the final UI behaves as a usable
+admin catalog surface.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+
+- Modify: `apps/admin/src/i18n/messages.ts`
+- Modify: `apps/admin/docs/v1-operational-surfaces.md`
+- Modify: `apps/admin/docs/cms-operational-vs-deferred.md`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Adjust video page copy only where it now promises paginated browsing,
+  visible type labels, thumbnails, and visitor handoff.
+- Keep docs honest that the surface is still read-heavy and not a full editor.
+- Update dashboard UI tests to assert the new visible signals and link shape.
+- Use Helium/in-app browser visual verification against local dev because the
+  change is user-facing and layout-sensitive.
+
+**Patterns to follow:**
+
+- Existing admin operational-surface docs.
+- Current dashboard UI route snapshot-style assertions in
+  `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`.
+- Forge AGENTS guidance to use Helium browser for browser testing.
+
+**Test scenarios:**
+
+- Happy path: localized video page copy and table header/action text still
+  render after adding pagination and external-link controls.
+- Happy path: docs describe the improved browsing/handoff surface without
+  claiming edit parity.
+- Visual: local browser proof captures a paginated video library page showing
+  thumbnails, labels, pagination controls, and an external-link action.
+
+**Verification:**
+
+- Unit/route tests cover the updated static output.
+- Browser proof confirms no obvious overflow, broken thumbnail boxes, or
+  unusable pagination/action controls at desktop and narrow admin-shell widths.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `/dashboard/videos` remains a server-rendered admin
+  route. It reads via dashboard loader, `VideoService.list`, Prisma enrichment
+  queries, and optionally the latest watch route manifest snapshot.
+- **Error propagation:** Loader failures should preserve existing table fallback
+  behavior for missing tables, while unexpected database or manifest errors
+  should fail loudly enough for admin dev/prod monitoring to catch.
+- **State lifecycle risks:** URL pagination must not persist server state.
+  Visitor-link resolution should tolerate stale or missing route-manifest data
+  by omitting links rather than emitting broken URLs.
+- **API surface parity:** Admin GraphQL can remain unchanged because this is an
+  internal dashboard loader enhancement.
+- **Integration coverage:** Browser verification is required because the table
+  now has more columns and row content, and thumbnail rendering is visual.
+- **Unchanged invariants:** Core-sourced videos remain read-only at the GraphQL
+  and service layer; public watch routing remains owned by `apps/web`.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                                        | Mitigation                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Visitor links use the wrong language segment and leak `en.html`-style internal locale keys. | Resolve from public language slugs only and add tests that reject BCP-47-only output.                                                                                    |
+| Pagination changes break the experience editor video picker, which reuses `loadVideoRows`.  | Add a separate library-page loader or preserve the existing array-returning function as a compatibility wrapper.                                                         |
+| Thumbnails introduce layout shift or broken remote-image behavior.                          | Use the existing stable aspect-ratio preview box and CSS-background pattern instead of a new image optimization path.                                                    |
+| Visitor links accidentally point at the admin host.                                         | Generate absolute URLs from admin's optional `WEB_CANONICAL_ORIGIN`, defaulting to `https://www.jesusfilm.org`, and add a test that rejects relative `/watch/...` hrefs. |
+| Route manifest is stale or absent in local/dev environments.                                | Treat manifest data as a validity aid, not a hard requirement; omit unsafe links or fall back to row-level playable language slugs when appropriate.                     |
+| The table becomes too dense at the new thinner admin shell width.                           | Include narrow-width browser verification and adjust column layout before implementation is considered complete.                                                         |
+
+---
+
+## Documentation / Operational Notes
+
+- Update admin docs to say `/dashboard/videos` supports paginated browsing,
+  type labels, thumbnails, and visitor-page handoff, while staying read-heavy.
+- PR validation should include the admin typecheck, lint, focused dashboard UI
+  tests, and local browser verification with the admin dev server.
+- Add `WEB_CANONICAL_ORIGIN` as optional admin config only; do not make deploys
+  depend on a new required env var.
+- No Prisma migration, GraphQL SDL regeneration, or `packages/admin-graphql`
+  generation is expected unless implementation deliberately changes admin
+  GraphQL.
+
+---
+
+## Sources & References
+
+- Roadmap: `docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md`
+- Operational docs: `apps/admin/docs/v1-operational-surfaces.md`
+- Operational boundary docs: `apps/admin/docs/cms-operational-vs-deferred.md`
+- Admin route: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Admin dashboard data loader: `apps/admin/src/app/dashboard/live-data.ts`
+- Video service: `apps/admin/src/services/video.service.ts`
+- Video schema: `apps/admin/prisma/schema.prisma`
+- Watch route manifest: `apps/admin/src/services/watch-route-manifest.service.ts`
+- Web public URL guidance: `apps/web/AGENTS.md`
+- Web route builders: `apps/web/src/lib/routes.ts`


### PR DESCRIPTION
## Summary

- Adds URL-based pagination for `/dashboard/videos` while preserving the existing first-page video picker loader.
- Renders Core thumbnails, video type labels, visitor-facing external watch links, and safe no-link states.
- Adds admin `WEB_CANONICAL_ORIGIN` config for absolute public watch URLs and documents the browsing surface.
- Merges current `origin/main` interaction-affordance changes so the PR is based on the latest main.

## Testing

- `pnpm --filter @forge/admin test -- --run src/app/dashboard/video-library-utils.test.ts src/app/dashboard/dashboard-ui.test.tsx src/config/env.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `git diff --check`

## Manual / Visual Verification

- Local admin dev server is running at `http://localhost:3003`.
- Helium / in-app browser opened `http://localhost:3003/dashboard/videos`; the route redirects to Jesus Film Auth, so dashboard visual inspection could not complete without an authenticated admin session.

## Post-Deploy Monitoring & Validation

- Validation window: first 24 hours after deploy.
- Owner: admin app on-call / PR owner.
- Watch logs for `admin.oauth.callback.forbidden`, dashboard route render errors, Prisma `video.count`, `video.findMany`, `videoLocale.findMany`, `videoDub.findMany`, `videoImage.findMany`, and watch-route manifest load errors.
- Healthy signals: `/dashboard/videos?page=1` and deeper page numbers render without 500s, external links only appear when a manifest-backed or playable public language slug exists, and no spike in missing-table fallback logs.
- Failure signals: dashboard 500s, repeated route-manifest load failures, unexpected `en.html` / BCP-47 visitor URLs, or Prisma query latency/regression on videos browsing.
- Mitigation: revert this PR or temporarily remove visitor-link rendering while keeping the existing read-only table path available.
