### PR TITLE
fix(admin): normalize video thumbnail URLs

### DIFF
--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -13,6 +13,7 @@ import { env } from "@/config/env"
 import { WatchRouteManifestStore } from "@/services/watch-route-manifest-store"
 import {
   createVideoLibraryPagination,
+  normalizeVideoThumbnailUrl,
   resolveVideoVisitorUrl,
   VIDEO_LIBRARY_PAGE_SIZE,
 } from "./video-library-utils"
@@ -383,10 +384,10 @@ function preferredVideoImage(images: VideoImageRow[]) {
   const priority = ["videoStill", "mobileCinematicHigh", "poster", "still"]
   for (const kind of priority) {
     const match = images.find((image) => image.kind === kind && image.url)
-    if (match?.url) return match.url
+    if (match?.url) return normalizeVideoThumbnailUrl(match.url)
   }
 
-  return images.find((image) => image.url)?.url ?? null
+  return normalizeVideoThumbnailUrl(images.find((image) => image.url)?.url)
 }
 
 async function countActiveVideos() {

--- a/apps/admin/src/app/dashboard/video-library-utils.test.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.test.ts
@@ -4,6 +4,7 @@ import {
   buildVideoVisitorUrl,
   createVideoLibraryPagination,
   isPublicAudioLanguageSlug,
+  normalizeVideoThumbnailUrl,
   parseVideoLibraryPage,
   resolveVideoVisitorUrl,
 } from "./video-library-utils"
@@ -86,6 +87,29 @@ describe("video-library-utils", () => {
     expect(isPublicAudioLanguageSlug("pt-br")).toBe(false)
     expect(isPublicAudioLanguageSlug("english")).toBe(true)
     expect(isPublicAudioLanguageSlug("spanish-castilian")).toBe(true)
+  })
+
+  it("adds the public Cloudflare Image Delivery variant when one is missing", () => {
+    expect(
+      normalizeVideoThumbnailUrl(
+        "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/0ec667e3-7f67-4158-f2cb-054e665e4800",
+      ),
+    ).toBe(
+      "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/0ec667e3-7f67-4158-f2cb-054e665e4800/public",
+    )
+  })
+
+  it("keeps existing image variants and non-Cloudflare URLs unchanged", () => {
+    expect(
+      normalizeVideoThumbnailUrl(
+        "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/poster.videoStill.jpg/public",
+      ),
+    ).toBe(
+      "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/poster.videoStill.jpg/public",
+    )
+    expect(
+      normalizeVideoThumbnailUrl("https://images.example.com/neon.jpg"),
+    ).toBe("https://images.example.com/neon.jpg")
   })
 
   it("builds absolute visitor URLs from public watch slugs", () => {

--- a/apps/admin/src/app/dashboard/video-library-utils.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.ts
@@ -5,6 +5,7 @@ export const VIDEO_LIBRARY_MAX_PAGE_SIZE = 200
 
 const SLUG_PATTERN = /^[a-z0-9-]+$/
 const BCP47_TAG_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/i
+const CLOUDFLARE_IMAGE_DELIVERY_HOST = "imagedelivery.net"
 
 export type VideoLibraryPagination = {
   total: number
@@ -76,6 +77,24 @@ export function isPublicAudioLanguageSlug(value: string | null | undefined) {
   const slug = cleanSlug(value)
   if (!slug) return false
   return !BCP47_TAG_PATTERN.test(slug)
+}
+
+export function normalizeVideoThumbnailUrl(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  try {
+    const url = new URL(trimmed)
+    if (url.hostname !== CLOUDFLARE_IMAGE_DELIVERY_HOST) return trimmed
+
+    const pathParts = url.pathname.split("/").filter(Boolean)
+    if (pathParts.length === 2) {
+      url.pathname = `${url.pathname.replace(/\/+$/, "")}/public`
+    }
+    return url.toString()
+  } catch {
+    return trimmed
+  }
 }
 
 function preferredPublicLanguageSlug(slugs: Array<string | null | undefined>) {


### PR DESCRIPTION
## Summary
- Normalize Cloudflare Image Delivery thumbnail URLs that are stored without a variant by appending /public before rendering them in the admin video library.
- Keep existing Cloudflare variant URLs and non-Cloudflare image URLs unchanged.

## Root cause
After PR #1090 switched thumbnails from CSS backgrounds to real <img> elements, stored Cloudflare Image Delivery URLs like https://imagedelivery.net/<account>/<image-id> surfaced as broken images. That endpoint returns 400 unless a variant segment is present, while https://imagedelivery.net/<account>/<image-id>/public returns 200.

## Validation
- pnpm --filter @forge/admin test -- --run src/app/dashboard/video-library-utils.test.ts src/app/dashboard/dashboard-ui.test.tsx
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- git diff --check
- curl -I https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/0ec667e3-7f67-4158-f2cb-054e665e4800/public returns 200 image/png
