### PR TITLE
docs: close feat-141 retrieval strategy investigation

### DIFF
--- a/docs/roadmap/content-discovery/feat-141-mastra-retrieval-strategy-investigation.md
+++ b/docs/roadmap/content-discovery/feat-141-mastra-retrieval-strategy-investigation.md
@@ -3,7 +3,7 @@ id: "feat-141"
 title: "Mastra retrieval strategy ownership investigation"
 owner: "nisal"
 priority: "P0"
-status: "not-started"
+status: "cancelled"
 start_date: "2026-05-29"
 duration: 2
 depends_on:
@@ -35,6 +35,15 @@ be native Mastra Evaluation: promoted Datasets, Scorers, and Experiment results
 from feat-142. Custom JSON artifacts can remain supporting evidence, but they
 should not be the only operator-quality source once native Experiments are
 populated.
+
+## Closure Decision
+
+Closed on 2026-06-01. The current decision is to keep live retrieval strategy
+owned by Admin and not run a separate P0 investigation now. Mastra remains on
+the offline evaluation/orchestration side of the boundary; future retrieval
+strategy experiments should be opened only when promoted native Experiments show
+a concrete quality or operator-iteration need that Admin-owned orchestration
+cannot cover.
 
 ## Entry Points - Read These First
 


### PR DESCRIPTION
## Summary
- Mark `feat-141` as cancelled.
- Add a closure decision: keep live retrieval strategy owned by Admin and avoid a separate P0 Mastra retrieval-ownership investigation for now.
- Clarify future Mastra retrieval experiments should only be reopened when promoted native Experiments show a concrete need.

## Validation
- git diff --check

Note: there is no `prod` branch on origin; this PR targets `main`, which is the current production/mainline branch in this repo.