### PR TITLE
fix(admin): activate video visitor links from dubs

### DIFF
--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -651,6 +651,7 @@ async function loadVideoRowSlice({
       visitorUrl: includeVisitorUrls
         ? resolveVideoVisitorUrl({
             contentSlug: video.slug,
+            languageSlugs: dubRows.map((dub) => dub.language?.slug),
             manifest: routeManifest,
             webOrigin: env.WEB_CANONICAL_ORIGIN,
           })

--- a/apps/admin/src/app/dashboard/video-library-utils.test.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.test.ts
@@ -152,14 +152,17 @@ describe("video-library-utils", () => {
     ).toBe("https://www.jesusfilm.org/watch/jesus.html/english.html")
   })
 
-  it("does not fall back to row-level dubs when manifest data is missing", () => {
+  it("falls back to row-level public language slugs when manifest data is missing", () => {
     expect(
       resolveVideoVisitorUrl({
         contentSlug: "missing-from-manifest",
+        languageSlugs: ["spanish-castilian", "english"],
         manifest,
         webOrigin: "http://localhost:3000",
       }),
-    ).toBeNull()
+    ).toBe(
+      "http://localhost:3000/watch/missing-from-manifest.html/english.html",
+    )
   })
 
   it("does not emit visitor URLs when the manifest is unavailable", () => {
@@ -170,6 +173,17 @@ describe("video-library-utils", () => {
         webOrigin: "http://localhost:3000",
       }),
     ).toBeNull()
+  })
+
+  it("falls back to row-level public language slugs when the manifest is unavailable", () => {
+    expect(
+      resolveVideoVisitorUrl({
+        contentSlug: "jesus",
+        languageSlugs: ["en", "french"],
+        manifest: null,
+        webOrigin: "http://localhost:3000",
+      }),
+    ).toBe("http://localhost:3000/watch/jesus.html/french.html")
   })
 
   it("only emits visitor URLs for manifest-backed language pairs", () => {

--- a/apps/admin/src/app/dashboard/video-library-utils.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.ts
@@ -149,10 +149,12 @@ export function buildVideoVisitorUrl({
 
 export function resolveVideoVisitorUrl({
   contentSlug,
+  languageSlugs = [],
   manifest,
   webOrigin,
 }: {
   contentSlug: string
+  languageSlugs?: Array<string | null | undefined>
   manifest?: WatchRouteManifest | null
   webOrigin: string
 }) {
@@ -170,5 +172,12 @@ export function resolveVideoVisitorUrl({
     })
   }
 
-  return null
+  const rowLanguage = preferredPublicLanguageSlug(languageSlugs)
+  return rowLanguage
+    ? buildVideoVisitorUrl({
+        contentSlug: normalizedContentSlug,
+        languageSlug: rowLanguage,
+        webOrigin,
+      })
+    : null
 }


### PR DESCRIPTION
## Summary
- keep manifest-backed visitor URLs as the first choice
- fall back to row-level public dub language slugs when the manifest has no pair for the video
- keep rows without a public language slug disabled

## Why
The videos table only rendered an active external-link button when visitorUrl was non-null. visitorUrl previously required the watch-route manifest to contain the video slug and public language pair, so rows with usable dubs but missing manifest coverage rendered the disabled icon.

## Validation
- pnpm --filter @forge/admin test -- --run src/app/dashboard/video-library-utils.test.ts src/app/dashboard/dashboard-ui.test.tsx
- pnpm --filter @forge/admin lint
- pnpm --filter @forge/admin typecheck
- git diff --check HEAD~1..HEAD