### PR TITLE
fix(admin): show relative video update times

### DIFF
--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -100,6 +100,8 @@ vi.mock("@/app/dashboard/live-data", () => ({
       sourceTone: "info",
       dubs: "3 dubs · EN, ES, FR",
       updated: "10/24/2023, 14:02",
+      updatedAtIso: "2023-10-24T14:02:00.000Z",
+      updatedRelative: "3 years ago",
       duration: "04:22",
       previewImageUrl: "https://images.example.com/neon.jpg",
       visitorUrl:
@@ -119,6 +121,8 @@ vi.mock("@/app/dashboard/live-data", () => ({
         sourceTone: "info",
         dubs: "3 dubs · EN, ES, FR",
         updated: "10/24/2023, 14:02",
+        updatedAtIso: "2023-10-24T14:02:00.000Z",
+        updatedRelative: "3 years ago",
         duration: "04:22",
         previewImageUrl: "https://images.example.com/neon.jpg",
         visitorUrl:
@@ -135,6 +139,8 @@ vi.mock("@/app/dashboard/live-data", () => ({
         sourceTone: "muted",
         dubs: "No dubs",
         updated: "10/24/2023, 14:03",
+        updatedAtIso: "2023-10-24T14:03:00.000Z",
+        updatedRelative: "3 years ago",
         duration: "--:--",
         previewImageUrl: null,
         visitorUrl: null,
@@ -566,6 +572,9 @@ describe("dashboard UI routes", () => {
     )
     expect(html).toContain("Collection")
     expect(html).toContain("https://images.example.com/neon.jpg")
+    expect(html).toContain("3 years ago")
+    expect(html).toContain('title="10/24/2023, 14:02"')
+    expect(html).toContain('dateTime="2023-10-24T14:02:00.000Z"')
     expect(html).toMatch(
       /<img(?=[^>]*src="https:\/\/images\.example\.com\/neon\.jpg")(?=[^>]*loading="lazy")(?=[^>]*decoding="async")/,
     )

--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -13,6 +13,7 @@ import { env } from "@/config/env"
 import { WatchRouteManifestStore } from "@/services/watch-route-manifest-store"
 import {
   createVideoLibraryPagination,
+  formatVideoUpdatedRelative,
   normalizeVideoThumbnailUrl,
   resolveVideoVisitorUrl,
   VIDEO_LIBRARY_PAGE_SIZE,
@@ -646,6 +647,8 @@ async function loadVideoRowSlice({
       sourceTone: source.tone,
       dubs: dubCoverage(dubRows),
       updated: formatDateTime(video.updatedAt),
+      updatedAtIso: video.updatedAt.toISOString(),
+      updatedRelative: formatVideoUpdatedRelative(video.updatedAt),
       duration: formatDuration(dubRows),
       durationSeconds: playbackDub ? durationSecondsForDub(playbackDub) : null,
       previewImageUrl: preferredVideoImage(imageRows),

--- a/apps/admin/src/app/dashboard/video-library-utils.test.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.test.ts
@@ -3,6 +3,7 @@ import type { WatchRouteManifest } from "@/services/watch-route-manifest.service
 import {
   buildVideoVisitorUrl,
   createVideoLibraryPagination,
+  formatVideoUpdatedRelative,
   isPublicAudioLanguageSlug,
   normalizeVideoThumbnailUrl,
   parseVideoLibraryPage,
@@ -80,6 +81,20 @@ describe("video-library-utils", () => {
       rangeStart: 1,
       rangeEnd: 30,
     })
+  })
+
+  it("formats updated timestamps as relative ago labels", () => {
+    const now = new Date("2026-06-02T12:00:00.000Z")
+
+    expect(
+      formatVideoUpdatedRelative(new Date("2026-06-02T11:59:30.000Z"), now),
+    ).toBe("just now")
+    expect(
+      formatVideoUpdatedRelative(new Date("2026-06-02T10:00:00.000Z"), now),
+    ).toBe("2 hours ago")
+    expect(
+      formatVideoUpdatedRelative(new Date("2026-05-22T21:29:00.000Z"), now),
+    ).toBe("11 days ago")
   })
 
   it("rejects BCP-47-like values as public audio language slugs", () => {

--- a/apps/admin/src/app/dashboard/video-library-utils.ts
+++ b/apps/admin/src/app/dashboard/video-library-utils.ts
@@ -6,6 +6,10 @@ export const VIDEO_LIBRARY_MAX_PAGE_SIZE = 200
 const SLUG_PATTERN = /^[a-z0-9-]+$/
 const BCP47_TAG_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/i
 const CLOUDFLARE_IMAGE_DELIVERY_HOST = "imagedelivery.net"
+const SECOND_MS = 1000
+const MINUTE_MS = 60 * SECOND_MS
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
 
 export type VideoLibraryPagination = {
   total: number
@@ -95,6 +99,52 @@ export function normalizeVideoThumbnailUrl(value: string | null | undefined) {
   } catch {
     return trimmed
   }
+}
+
+export function formatVideoUpdatedRelative(value: Date, now = new Date()) {
+  const diffMs = value.getTime() - now.getTime()
+  const absDiffMs = Math.abs(diffMs)
+  const formatter = new Intl.RelativeTimeFormat("en", { numeric: "always" })
+
+  if (absDiffMs < 45 * SECOND_MS) return "just now"
+
+  if (absDiffMs < 90 * SECOND_MS) {
+    return formatter.format(Math.sign(diffMs), "minute")
+  }
+
+  if (absDiffMs < 45 * MINUTE_MS) {
+    return formatter.format(Math.round(diffMs / MINUTE_MS), "minute")
+  }
+
+  if (absDiffMs < 90 * MINUTE_MS) {
+    return formatter.format(Math.sign(diffMs), "hour")
+  }
+
+  if (absDiffMs < 22 * HOUR_MS) {
+    return formatter.format(Math.round(diffMs / HOUR_MS), "hour")
+  }
+
+  if (absDiffMs < 36 * HOUR_MS) {
+    return formatter.format(Math.sign(diffMs), "day")
+  }
+
+  if (absDiffMs < 26 * DAY_MS) {
+    return formatter.format(Math.round(diffMs / DAY_MS), "day")
+  }
+
+  if (absDiffMs < 45 * DAY_MS) {
+    return formatter.format(Math.sign(diffMs), "month")
+  }
+
+  if (absDiffMs < 320 * DAY_MS) {
+    return formatter.format(Math.round(diffMs / (30 * DAY_MS)), "month")
+  }
+
+  if (absDiffMs < 548 * DAY_MS) {
+    return formatter.format(Math.sign(diffMs), "year")
+  }
+
+  return formatter.format(Math.round(diffMs / (365 * DAY_MS)), "year")
 }
 
 function preferredPublicLanguageSlug(slugs: Array<string | null | undefined>) {

--- a/apps/admin/src/app/dashboard/videos/page.tsx
+++ b/apps/admin/src/app/dashboard/videos/page.tsx
@@ -236,9 +236,13 @@ export default async function VideosPage({
                         </span>
                       </td>
                       <td className="px-4 py-3 align-middle">
-                        <span className="mono-meta text-[var(--color-text-muted)]">
-                          {video.updated}
-                        </span>
+                        <time
+                          dateTime={video.updatedAtIso}
+                          title={video.updated}
+                          className="mono-meta text-[var(--color-text-muted)]"
+                        >
+                          {video.updatedRelative}
+                        </time>
                       </td>
                       <td className="px-4 py-3 text-right align-middle">
                         {video.visitorUrl ? (


### PR DESCRIPTION
## Summary
- show relative ago labels in the admin videos Updated column
- preserve the exact timestamp in the time element title on hover
- add ISO dateTime metadata for the updated timestamp

## Validation
- pnpm --filter @forge/admin test -- --run src/app/dashboard/video-library-utils.test.ts src/app/dashboard/dashboard-ui.test.tsx
- pnpm --filter @forge/admin lint
- pnpm --filter @forge/admin db:generate
- pnpm --filter @forge/admin typecheck
- git diff --check HEAD~1..HEAD