### PR TITLE
fix: make localized metadata migration retry safe

### DIFF
--- a/apps/admin/prisma/migrations/0027_video_localized_language_slug_identity/migration.sql
+++ b/apps/admin/prisma/migrations/0027_video_localized_language_slug_identity/migration.sql
@@ -6,12 +6,12 @@
 -- broad locale queries continue to work.
 
 ALTER TABLE "video_locale"
-  ADD COLUMN "language_slug" TEXT,
-  ADD COLUMN "language_core_id" TEXT;
+  ADD COLUMN IF NOT EXISTS "language_slug" TEXT,
+  ADD COLUMN IF NOT EXISTS "language_core_id" TEXT;
 
 ALTER TABLE "video_study_question"
-  ADD COLUMN "language_slug" TEXT,
-  ADD COLUMN "language_core_id" TEXT;
+  ADD COLUMN IF NOT EXISTS "language_slug" TEXT,
+  ADD COLUMN IF NOT EXISTS "language_core_id" TEXT;
 
 UPDATE "video_locale" AS vl
 SET
@@ -36,27 +36,28 @@ DROP INDEX IF EXISTS "video_locale_video_id_locale_key";
 -- as a lookup index rather than a new uniqueness constraint so legacy duplicate
 -- rows cannot block deploy-time migration.
 DROP INDEX IF EXISTS "video_study_question_core_id_key";
+DROP INDEX IF EXISTS "video_study_question_video_id_core_id_language_id_key";
 
-CREATE INDEX "video_locale_video_id_locale_idx"
+CREATE INDEX IF NOT EXISTS "video_locale_video_id_locale_idx"
   ON "video_locale"("video_id", "locale");
-CREATE INDEX "video_locale_language_slug_idx"
+CREATE INDEX IF NOT EXISTS "video_locale_language_slug_idx"
   ON "video_locale"("language_slug");
-CREATE INDEX "video_locale_video_id_language_slug_idx"
+CREATE INDEX IF NOT EXISTS "video_locale_video_id_language_slug_idx"
   ON "video_locale"("video_id", "language_slug");
-CREATE INDEX "video_locale_language_core_id_idx"
+CREATE INDEX IF NOT EXISTS "video_locale_language_core_id_idx"
   ON "video_locale"("language_core_id");
-CREATE INDEX "video_locale_locale_status_deleted_at_idx"
+CREATE INDEX IF NOT EXISTS "video_locale_locale_status_deleted_at_idx"
   ON "video_locale"("locale", "status", "deleted_at");
 
-CREATE INDEX "video_study_question_language_slug_idx"
+CREATE INDEX IF NOT EXISTS "video_study_question_language_slug_idx"
   ON "video_study_question"("language_slug");
-CREATE INDEX "video_study_question_video_id_language_slug_idx"
+CREATE INDEX IF NOT EXISTS "video_study_question_video_id_language_slug_idx"
   ON "video_study_question"("video_id", "language_slug");
-CREATE INDEX "video_study_question_language_core_id_idx"
+CREATE INDEX IF NOT EXISTS "video_study_question_language_core_id_idx"
   ON "video_study_question"("language_core_id");
-CREATE INDEX "video_study_question_video_id_locale_idx"
+CREATE INDEX IF NOT EXISTS "video_study_question_video_id_locale_idx"
   ON "video_study_question"("video_id", "locale");
-CREATE INDEX "video_study_question_locale_deleted_at_idx"
+CREATE INDEX IF NOT EXISTS "video_study_question_locale_deleted_at_idx"
   ON "video_study_question"("locale", "deleted_at");
-CREATE INDEX "video_study_question_video_id_core_id_language_id_idx"
+CREATE INDEX IF NOT EXISTS "video_study_question_video_id_core_id_language_id_idx"
   ON "video_study_question"("video_id", "core_id", "language_id");


### PR DESCRIPTION
## Summary

Makes the localized watch metadata migration safe to rerun after a partially failed Railway deploy.

## What Changed

- Changed new localized metadata columns to `ADD COLUMN IF NOT EXISTS`.
- Changed migration-created indexes to `CREATE INDEX IF NOT EXISTS`.
- Drops the earlier unique composite study-question index name if a partial deploy happened to create it before the final non-unique lookup index.

## Why

Production deploy of the merged localized metadata PR failed for both `@forge/admin` and `@forge/admin/worker`. Railway logs are unavailable with the current token, but the failure shape strongly matches a partial migration retry: the prior failed deploy could leave columns/indexes present while Prisma still considers migration `0027` unapplied. This makes the migration tolerate that state and retry cleanly.

## Validation

- `git diff --check`
- `DATABASE_URL='postgresql://forge:forge@localhost:5433/forge_admin' pnpm --filter @forge/admin exec prisma validate`
