### PR TITLE
fix: recover known admin migration failure

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -19,7 +19,7 @@
     "test:watch": "vitest",
     "db:generate": "prisma generate",
     "db:migrate:dev": "prisma migrate dev",
-    "db:migrate:deploy": "prisma migrate deploy",
+    "db:migrate:deploy": "tsx src/scripts/migrate-deploy-known-recovery.ts",
     "db:studio": "prisma studio",
     "core-sync:run": "tsx src/scripts/run-core-sync.ts",
     "core-sync:backfill-video-localized-metadata": "tsx src/scripts/backfill-video-localized-metadata.ts",

--- a/apps/admin/src/scripts/migrate-deploy-known-recovery.test.ts
+++ b/apps/admin/src/scripts/migrate-deploy-known-recovery.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  RECOVERABLE_MIGRATION,
+  deployWithKnownRecovery,
+  isKnownRecoverableP3009,
+  type CommandResult,
+} from "./migrate-deploy-known-recovery"
+
+describe("isKnownRecoverableP3009", () => {
+  it("matches only P3009 output for the localized metadata migration", () => {
+    expect(
+      isKnownRecoverableP3009(`Error code: P3009 ${RECOVERABLE_MIGRATION}`),
+    ).toBe(true)
+    expect(isKnownRecoverableP3009(`Error code: P3009 0001_init`)).toBe(false)
+    expect(
+      isKnownRecoverableP3009(`Error code: P3018 ${RECOVERABLE_MIGRATION}`),
+    ).toBe(false)
+  })
+})
+
+describe("deployWithKnownRecovery", () => {
+  const result = (code: number, output = ""): CommandResult => ({
+    code,
+    output,
+  })
+
+  it("does not run recovery when migrate deploy succeeds", async () => {
+    const runner = vi.fn().mockResolvedValueOnce(result(0))
+
+    await deployWithKnownRecovery(runner)
+
+    expect(runner).toHaveBeenCalledTimes(1)
+    expect(runner).toHaveBeenCalledWith(["migrate", "deploy"])
+  })
+
+  it("resolves the known failed migration and retries deploy", async () => {
+    const runner = vi
+      .fn()
+      .mockResolvedValueOnce(result(1, `P3009 ${RECOVERABLE_MIGRATION}`))
+      .mockResolvedValueOnce(result(0))
+      .mockResolvedValueOnce(result(0))
+
+    await deployWithKnownRecovery(runner)
+
+    expect(runner).toHaveBeenNthCalledWith(1, ["migrate", "deploy"])
+    expect(runner).toHaveBeenNthCalledWith(2, [
+      "migrate",
+      "resolve",
+      "--rolled-back",
+      RECOVERABLE_MIGRATION,
+    ])
+    expect(runner).toHaveBeenNthCalledWith(3, ["migrate", "deploy"])
+  })
+
+  it("does not resolve unrelated migration failures", async () => {
+    const runner = vi.fn().mockResolvedValueOnce(result(1, "P3018"))
+
+    await expect(deployWithKnownRecovery(runner)).rejects.toThrow(
+      /without known P3009 recovery/,
+    )
+
+    expect(runner).toHaveBeenCalledTimes(1)
+  })
+
+  it("fails when known migration resolve fails", async () => {
+    const runner = vi
+      .fn()
+      .mockResolvedValueOnce(result(1, `P3009 ${RECOVERABLE_MIGRATION}`))
+      .mockResolvedValueOnce(result(1, "resolve failed"))
+
+    await expect(deployWithKnownRecovery(runner)).rejects.toThrow(
+      /resolve --rolled-back/,
+    )
+  })
+})

--- a/apps/admin/src/scripts/migrate-deploy-known-recovery.ts
+++ b/apps/admin/src/scripts/migrate-deploy-known-recovery.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env tsx
+
+import { spawn } from "node:child_process"
+
+export const RECOVERABLE_MIGRATION =
+  "0027_video_localized_language_slug_identity"
+
+export type CommandResult = {
+  code: number
+  output: string
+}
+
+export type PrismaRunner = (args: readonly string[]) => Promise<CommandResult>
+
+export function isKnownRecoverableP3009(output: string): boolean {
+  return output.includes("P3009") && output.includes(RECOVERABLE_MIGRATION)
+}
+
+export async function runPrisma(
+  args: readonly string[],
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("prisma", args, {
+      env: process.env,
+      shell: process.platform === "win32",
+    })
+    let output = ""
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString()
+      output += text
+      process.stdout.write(text)
+    })
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString()
+      output += text
+      process.stderr.write(text)
+    })
+    child.on("error", reject)
+    child.on("close", (code) => resolve({ code: code ?? 1, output }))
+  })
+}
+
+export async function deployWithKnownRecovery(
+  runner: PrismaRunner = runPrisma,
+): Promise<void> {
+  const firstDeploy = await runner(["migrate", "deploy"])
+  if (firstDeploy.code === 0) return
+
+  if (!isKnownRecoverableP3009(firstDeploy.output)) {
+    throw new Error("prisma migrate deploy failed without known P3009 recovery")
+  }
+
+  process.stderr.write(
+    `[migrate-deploy] recovering known failed migration ${RECOVERABLE_MIGRATION}\n`,
+  )
+  const resolve = await runner([
+    "migrate",
+    "resolve",
+    "--rolled-back",
+    RECOVERABLE_MIGRATION,
+  ])
+  if (resolve.code !== 0) {
+    throw new Error(
+      `prisma migrate resolve --rolled-back ${RECOVERABLE_MIGRATION} failed`,
+    )
+  }
+
+  const secondDeploy = await runner(["migrate", "deploy"])
+  if (secondDeploy.code !== 0) {
+    throw new Error("prisma migrate deploy failed after known recovery")
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  deployWithKnownRecovery().catch((error) => {
+    process.stderr.write(
+      `[migrate-deploy] failed error=${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary

Adds a scoped deploy-time recovery wrapper for the known failed `0027_video_localized_language_slug_identity` migration.

## What Changed

- Keeps the normal `db:migrate:deploy` success path as `prisma migrate deploy`.
- If Prisma reports `P3009` for exactly `0027_video_localized_language_slug_identity`, runs the documented `prisma migrate resolve --rolled-back` recovery for that migration and retries `migrate deploy`.
- Leaves all unrelated Prisma failures untouched so genuine migration/runtime failures still fail closed.

## Why

Production `@forge/admin` and `@forge/admin/worker` still fail after the retry-safe migration SQL landed in #1099. Railway CLI/log access is unavailable with the current token, and the failure shape now strongly matches Prisma refusing to retry a previously failed migration until it is resolved. This automates the documented one-time recovery for the single reviewed migration.

## Validation

- `pnpm --filter @forge/admin test -- src/scripts/migrate-deploy-known-recovery.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `git diff --check`
