### PR TITLE
fix(admin): drop study question core id constraint

### DIFF
--- a/apps/admin/prisma/migrations/0027_video_localized_language_slug_identity/migration.sql
+++ b/apps/admin/prisma/migrations/0027_video_localized_language_slug_identity/migration.sql
@@ -35,7 +35,8 @@ DROP INDEX IF EXISTS "video_locale_video_id_locale_key";
 -- question ids being globally unique across every localized row. Keep this
 -- as a lookup index rather than a new uniqueness constraint so legacy duplicate
 -- rows cannot block deploy-time migration.
-DROP INDEX IF EXISTS "video_study_question_core_id_key";
+ALTER TABLE "video_study_question"
+  DROP CONSTRAINT IF EXISTS "video_study_question_core_id_key";
 DROP INDEX IF EXISTS "video_study_question_video_id_core_id_language_id_key";
 
 CREATE INDEX IF NOT EXISTS "video_locale_video_id_locale_idx"


### PR DESCRIPTION
## Summary
- change migration 0027 to drop the video_study_question core_id uniqueness as a table constraint
- keeps the existing retry-safe column and index operations from PR #1099

## Context
Production migrate deploy now reaches 0027 but fails with P3018 / Postgres 2BP01 because video_study_question_core_id_key is a unique constraint, not a plain index. Postgres requires ALTER TABLE ... DROP CONSTRAINT for that object.

## Validation
- git diff --check

## Recovery after merge
- mark the failed 0027 attempt rolled back in production
- rerun prisma migrate deploy against the production admin DB
- redeploy @forge/admin and @forge/admin/worker from source