### PR TITLE
feat(admin): redesign video library page

### DIFF
--- a/apps/admin/src/app/dashboard/videos/page.tsx
+++ b/apps/admin/src/app/dashboard/videos/page.tsx
@@ -277,7 +277,7 @@ export default async function VideosPage({
               videoRows.map((video) => (
                 <article
                   key={video.key}
-                  className="grid gap-4 px-4 py-4 transition-colors duration-[120ms] ease-out hover:bg-[color-mix(in_oklab,var(--color-surface-raised)_74%,transparent)] lg:grid-cols-[180px_minmax(260px,1fr)_128px_96px_132px_48px] lg:items-center"
+                  className="grid gap-4 px-4 py-4 lg:grid-cols-[180px_minmax(260px,1fr)_128px_96px_132px_48px] lg:items-center"
                 >
                   <div className="relative flex aspect-video w-full max-w-[240px] items-center justify-center overflow-hidden rounded-sm border border-white/10 bg-[linear-gradient(135deg,#151312,#292524)] lg:w-[180px]">
                     {video.previewImageUrl ? (

--- a/apps/admin/src/app/dashboard/videos/page.tsx
+++ b/apps/admin/src/app/dashboard/videos/page.tsx
@@ -100,6 +100,28 @@ function PaginationControl({
   )
 }
 
+function SummaryTile({
+  label,
+  value,
+  detail,
+}: {
+  label: string
+  value: string
+  detail: string
+}) {
+  return (
+    <div className="rounded-sm border border-[var(--color-hairline)] bg-[color-mix(in_oklab,var(--color-surface-raised)_76%,black)] p-3">
+      <div className="label-text">{label}</div>
+      <div className="mt-2 truncate font-mono text-lg font-medium leading-6">
+        {value}
+      </div>
+      <div className="mono-meta mt-1 truncate text-[var(--color-text-muted)]">
+        {detail}
+      </div>
+    </div>
+  )
+}
+
 export default async function VideosPage({
   searchParams,
 }: VideosPageProps = {}) {
@@ -113,6 +135,17 @@ export default async function VideosPage({
     principal,
     { page: requestedPage, query },
   )
+  const rangeLabel = paginationSummary(
+    page.table.pagination.summary,
+    pagination,
+  )
+  const currentPageLabel = pageCountLabel(
+    page.table.pagination.page,
+    pagination,
+  )
+  const queryState = query
+    ? page.search.active.replace("{query}", query)
+    : page.summary.queryAll
 
   return (
     <div className="flex flex-col gap-6">
@@ -121,41 +154,41 @@ export default async function VideosPage({
         trailing={page.infoStrip.trailing}
       />
 
-      <DashboardPageHeader
-        eyebrow={page.eyebrow}
-        title={page.title}
-        description={page.description}
-        action={
-          <div className="flex flex-col items-start gap-1 md:items-end">
-            <PrimaryButton
-              disabled
-              title={page.actions.primaryUnavailable}
-              aria-describedby="video-actions-unavailable"
-            >
-              <Plus className="h-4 w-4" strokeWidth={1.5} />
-              {page.actions.primary}
-            </PrimaryButton>
-            <span
-              id="video-actions-unavailable"
-              className="font-mono text-[10px] text-[var(--color-text-muted)]"
-            >
-              {page.actions.primaryUnavailable}
-            </span>
-          </div>
-        }
-      />
+      <section className="overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[linear-gradient(180deg,color-mix(in_oklab,var(--color-surface)_92%,black),var(--color-surface))]">
+        <div className="grid gap-5 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] lg:p-5">
+          <DashboardPageHeader
+            eyebrow={page.eyebrow}
+            title={page.title}
+            description={page.description}
+            action={
+              <div className="flex flex-col items-start gap-1 md:items-end">
+                <PrimaryButton
+                  disabled
+                  title={page.actions.primaryUnavailable}
+                  aria-describedby="video-actions-unavailable"
+                >
+                  <Plus className="h-4 w-4" strokeWidth={1.5} />
+                  {page.actions.primary}
+                </PrimaryButton>
+                <span
+                  id="video-actions-unavailable"
+                  className="font-mono text-[10px] text-[var(--color-text-muted)]"
+                >
+                  {page.actions.primaryUnavailable}
+                </span>
+              </div>
+            }
+          />
 
-      <div className="flex flex-col gap-6">
-        <PageSection title={page.table.title} meta={page.table.meta}>
-          <div className="hairline-b flex flex-col gap-3 p-4 md:flex-row md:items-end md:justify-between">
+          <div className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-inset)] p-3">
             <form
               action="/dashboard/videos"
-              className="flex w-full flex-col gap-2 md:max-w-[760px] md:flex-row md:items-end"
+              className="flex w-full flex-col gap-3"
               role="search"
             >
               <label
                 htmlFor="video-library-search"
-                className="flex flex-1 flex-col gap-1"
+                className="flex flex-col gap-1"
               >
                 <span className="label-text">{page.search.label}</span>
                 <span className="relative">
@@ -170,11 +203,11 @@ export default async function VideosPage({
                     maxLength={VIDEO_LIBRARY_MAX_QUERY_LENGTH}
                     defaultValue={query}
                     placeholder={page.search.placeholder}
-                    className="h-9 w-full rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-inset)] pl-9 pr-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none transition-all duration-[120ms] ease-out placeholder:text-[var(--color-text-disabled)] focus:border-[var(--color-brand)] focus:bg-[var(--color-surface-raised)]"
+                    className="h-10 w-full rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] pl-9 pr-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none transition-all duration-[120ms] ease-out placeholder:text-[var(--color-text-disabled)] focus:border-[var(--color-brand)] focus:bg-[var(--color-surface-raised)]"
                   />
                 </span>
               </label>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <SecondaryButton type="submit">
                   <Search className="h-4 w-4" strokeWidth={1.5} />
                   {page.search.submit}
@@ -190,148 +223,170 @@ export default async function VideosPage({
                 ) : null}
               </div>
             </form>
-            {query ? (
-              <span className="font-mono text-[11px] text-[var(--color-text-muted)]">
-                {page.search.active.replace("{query}", query)}
-              </span>
-            ) : null}
           </div>
-          <div className="overflow-x-auto">
-            <table className="min-w-[820px] w-full border-collapse text-left">
-              <thead className="hairline-strong-b bg-[var(--color-surface-inset)]">
-                <tr>
-                  {page.table.columns.map((column) => (
-                    <th key={column} className="label-text px-4 py-3">
-                      {column}
-                    </th>
-                  ))}
-                  <th className="label-text w-12 px-4 py-3" />
-                </tr>
-              </thead>
-              <tbody>
-                {videoRows.length === 0 ? (
-                  <tr>
-                    <td
-                      colSpan={page.table.columns.length + 1}
-                      className="px-4 py-10 text-center text-[13px] text-[var(--color-text-muted)]"
-                    >
-                      {query ? page.table.emptySearch : page.table.empty}
-                    </td>
-                  </tr>
-                ) : (
-                  videoRows.map((video) => (
-                    <tr
-                      key={video.key}
-                      className="hairline-b transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
-                    >
-                      <td className="p-4 align-middle">
-                        <div className="relative flex aspect-video w-[150px] items-center justify-center overflow-hidden rounded-sm border border-white/10 bg-[linear-gradient(135deg,#151312,#292524)]">
-                          {video.previewImageUrl ? (
-                            <>
-                              {/* eslint-disable-next-line @next/next/no-img-element */}
-                              <img
-                                src={video.previewImageUrl}
-                                alt=""
-                                loading="lazy"
-                                decoding="async"
-                                className="absolute inset-0 h-full w-full object-cover"
-                              />
-                              <span
-                                aria-hidden="true"
-                                className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08),rgba(0,0,0,0.55))]"
-                              />
-                            </>
-                          ) : (
-                            <ImageIcon
-                              className="h-5 w-5 text-[var(--color-text-disabled)]"
-                              strokeWidth={1.5}
-                            />
-                          )}
-                          <span className="absolute bottom-2 right-2 rounded-[2px] bg-black/60 px-1.5 py-0.5 font-mono text-[9px]">
-                            {video.duration}
-                          </span>
+        </div>
+
+        <div className="grid gap-3 border-t border-[var(--color-hairline)] p-4 md:grid-cols-2 xl:grid-cols-4">
+          <SummaryTile
+            label={page.summary.total}
+            value={pagination.total.toLocaleString("en")}
+            detail={page.table.title}
+          />
+          <SummaryTile
+            label={page.summary.visible}
+            value={videoRows.length.toLocaleString("en")}
+            detail={rangeLabel}
+          />
+          <SummaryTile
+            label={page.summary.page}
+            value={pagination.currentPage.toString()}
+            detail={currentPageLabel}
+          />
+          <SummaryTile
+            label={page.summary.query}
+            value={queryState}
+            detail={page.table.meta}
+          />
+        </div>
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <PageSection
+          title={page.table.title}
+          meta={page.table.meta}
+          actions={
+            <span className="font-mono text-[11px] text-[var(--color-text-muted)]">
+              {rangeLabel}
+            </span>
+          }
+        >
+          <div className="hidden grid-cols-[180px_minmax(260px,1fr)_128px_96px_132px_48px] items-center gap-4 border-b border-[var(--color-hairline)] bg-[var(--color-surface-inset)] px-4 py-3 lg:grid">
+            {page.table.columns.map((column) => (
+              <div key={column} className="label-text">
+                {column}
+              </div>
+            ))}
+            <div className="label-text text-right" />
+          </div>
+          <div className="divide-y divide-[var(--color-hairline)]">
+            {videoRows.length === 0 ? (
+              <div className="px-4 py-10 text-center text-[13px] text-[var(--color-text-muted)]">
+                {query ? page.table.emptySearch : page.table.empty}
+              </div>
+            ) : (
+              videoRows.map((video) => (
+                <article
+                  key={video.key}
+                  className="grid gap-4 px-4 py-4 transition-colors duration-[120ms] ease-out hover:bg-[color-mix(in_oklab,var(--color-surface-raised)_74%,transparent)] lg:grid-cols-[180px_minmax(260px,1fr)_128px_96px_132px_48px] lg:items-center"
+                >
+                  <div className="relative flex aspect-video w-full max-w-[240px] items-center justify-center overflow-hidden rounded-sm border border-white/10 bg-[linear-gradient(135deg,#151312,#292524)] lg:w-[180px]">
+                    {video.previewImageUrl ? (
+                      <>
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={video.previewImageUrl}
+                          alt=""
+                          loading="lazy"
+                          decoding="async"
+                          className="absolute inset-0 h-full w-full object-cover"
+                        />
+                        <span
+                          aria-hidden="true"
+                          className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08),rgba(0,0,0,0.55))]"
+                        />
+                      </>
+                    ) : (
+                      <ImageIcon
+                        className="h-5 w-5 text-[var(--color-text-disabled)]"
+                        strokeWidth={1.5}
+                      />
+                    )}
+                    <span className="absolute bottom-2 right-2 rounded-[2px] bg-black/60 px-1.5 py-0.5 font-mono text-[9px]">
+                      {video.duration}
+                    </span>
+                  </div>
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 flex-col gap-2">
+                      <div>
+                        <h3 className="truncate text-[14px] font-medium">
+                          {video.title}
+                        </h3>
+                        <div className="mono-meta truncate text-[var(--color-text-muted)]">
+                          {video.id}
                         </div>
-                      </td>
-                      <td className="px-4 py-3 align-middle">
-                        <div className="flex max-w-[280px] flex-col gap-2">
-                          <div>
-                            <div className="truncate text-[13px] font-medium">
-                              {video.title}
-                            </div>
-                            <div className="mono-meta truncate text-[var(--color-text-muted)]">
-                              {video.id}
-                            </div>
-                          </div>
-                          {video.labelLabel ? (
-                            <div>
-                              <StatusPill tone="muted">
-                                {video.labelLabel}
-                              </StatusPill>
-                            </div>
-                          ) : null}
+                        <div className="mono-meta mt-0.5 truncate text-[var(--color-text-disabled)]">
+                          {video.slug}
                         </div>
-                      </td>
-                      <td className="px-4 py-3 align-middle">
-                        <StatusPill tone={video.sourceTone}>
-                          {video.sourceLabel}
-                        </StatusPill>
-                      </td>
-                      <td className="px-4 py-3 align-middle">
-                        <span className="font-mono text-[12px] text-[var(--color-text-secondary)]">
-                          {video.dubs}
+                      </div>
+                      {video.labelLabel ? (
+                        <div>
+                          <StatusPill tone="muted">
+                            {video.labelLabel}
+                          </StatusPill>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between gap-3 lg:block">
+                    <span className="label-text lg:hidden">
+                      {page.table.columns[2]}
+                    </span>
+                    <StatusPill tone={video.sourceTone}>
+                      {video.sourceLabel}
+                    </StatusPill>
+                  </div>
+                  <div className="flex items-center justify-between gap-3 lg:block">
+                    <span className="label-text lg:hidden">
+                      {page.table.columns[3]}
+                    </span>
+                    <span className="font-mono text-[12px] text-[var(--color-text-secondary)]">
+                      {video.dubs}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3 lg:block">
+                    <span className="label-text lg:hidden">
+                      {page.table.columns[4]}
+                    </span>
+                    <time
+                      dateTime={video.updatedAtIso}
+                      title={video.updated}
+                      className="mono-meta text-[var(--color-text-muted)]"
+                    >
+                      {video.updatedRelative}
+                    </time>
+                  </div>
+                  <div className="flex items-center justify-end">
+                    {video.visitorUrl ? (
+                      <a
+                        href={video.visitorUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label={`${page.table.openVisitorLabel}: ${video.title}`}
+                        title={page.table.openVisitorLabel}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]"
+                      >
+                        <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
+                      </a>
+                    ) : (
+                      <span
+                        aria-disabled="true"
+                        aria-label={page.table.noVisitorLinkLabel}
+                        title={page.table.noVisitorLinkLabel}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-disabled)]"
+                      >
+                        <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
+                        <span className="sr-only">
+                          {page.table.noVisitorLinkLabel}
                         </span>
-                      </td>
-                      <td className="px-4 py-3 align-middle">
-                        <time
-                          dateTime={video.updatedAtIso}
-                          title={video.updated}
-                          className="mono-meta text-[var(--color-text-muted)]"
-                        >
-                          {video.updatedRelative}
-                        </time>
-                      </td>
-                      <td className="px-4 py-3 text-right align-middle">
-                        {video.visitorUrl ? (
-                          <a
-                            href={video.visitorUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            aria-label={`${page.table.openVisitorLabel}: ${video.title}`}
-                            title={page.table.openVisitorLabel}
-                            className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]"
-                          >
-                            <ExternalLink
-                              className="h-4 w-4"
-                              strokeWidth={1.5}
-                            />
-                          </a>
-                        ) : (
-                          <span
-                            aria-disabled="true"
-                            aria-label={page.table.noVisitorLinkLabel}
-                            title={page.table.noVisitorLinkLabel}
-                            className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-disabled)]"
-                          >
-                            <ExternalLink
-                              className="h-4 w-4"
-                              strokeWidth={1.5}
-                            />
-                            <span className="sr-only">
-                              {page.table.noVisitorLinkLabel}
-                            </span>
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
+                      </span>
+                    )}
+                  </div>
+                </article>
+              ))
+            )}
           </div>
           <div className="hairline-strong-t flex flex-col gap-3 px-4 py-3 text-[12px] text-[var(--color-text-muted)] md:flex-row md:items-center md:justify-between">
-            <span className="font-mono">
-              {paginationSummary(page.table.pagination.summary, pagination)}
-            </span>
+            <span className="font-mono">{rangeLabel}</span>
             <div className="flex items-center gap-2">
               <PaginationControl
                 href={paginationHref(pagination.currentPage - 1, query)}

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -402,6 +402,13 @@ export const adminMessages = {
           clear: "Clear",
           active: 'Filtered by "{query}"',
         },
+        summary: {
+          total: "Active videos",
+          visible: "Visible rows",
+          page: "Page",
+          query: "Query",
+          queryAll: "All videos",
+        },
         table: {
           title: "Video Library",
           meta: "SEARCHABLE_ROWS / TYPE_LABELS / VISITOR_LINKS",

--- a/docs/plans/2026-06-02-002-feat-admin-video-library-redesign-plan.md
+++ b/docs/plans/2026-06-02-002-feat-admin-video-library-redesign-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Redesign admin video library page"
 type: feat
-status: active
+status: completed
 date: 2026-06-02
 roadmap: docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md
 ---

--- a/docs/plans/2026-06-02-002-feat-admin-video-library-redesign-plan.md
+++ b/docs/plans/2026-06-02-002-feat-admin-video-library-redesign-plan.md
@@ -1,0 +1,346 @@
+---
+title: "feat: Redesign admin video library page"
+type: feat
+status: active
+date: 2026-06-02
+roadmap: docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md
+---
+
+# feat: Redesign admin video library page
+
+## Summary
+
+Redesign `/dashboard/videos` so the admin video library reads like the current
+production admin reference while preserving the newly shipped server-rendered
+search, pagination, thumbnail, visitor-link, and read-only Core catalog
+behavior.
+
+---
+
+## Problem Frame
+
+The admin video library has accumulated the right data path but still presents
+as a dense operational table with older Forge shell framing. The user asked to
+redesign the page to match `https://admin.jesusfilm.org/dashboard/videos`, so
+the implementation should make the local page visually align with that
+reference without widening into video editing or new data mutations.
+
+---
+
+## Assumptions
+
+_This plan was authored without synchronous user confirmation. The items below
+are agent inferences that fill gaps in the input and should be reviewed before
+implementation proceeds._
+
+- The target is the `apps/admin` `/dashboard/videos` surface, not the public
+  web `/videos` route.
+- "Like this" means visual/layout parity with the production admin videos page
+  while keeping current local behavior intact.
+- The production reference requires an authenticated admin session; unauthenticated
+  planning-time access redirects through login, so implementation should verify
+  against the accessible local page and any browser-authenticated reference
+  available during smoke testing.
+- The redesign should remain read-oriented under `feat-100`; manual video
+  creation, row editing, bulk actions, and advanced filters stay deferred.
+
+---
+
+## Requirements
+
+- R1. `/dashboard/videos` adopts a refreshed page composition aligned with the
+  production admin reference at `https://admin.jesusfilm.org/dashboard/videos`.
+- R2. Existing search behavior remains URL-backed through `q`, with submitted
+  queries, clear action, active-query copy, and filtered empty states preserved.
+- R3. Existing pagination remains server-rendered and query-aware, including
+  truthful counts and previous/next links.
+- R4. Video rows still expose thumbnail, title, Core ID, type label, source,
+  dub coverage, relative updated time, duration, and visitor-link availability.
+- R5. The redesigned table/list is responsive: it stays dense and scannable on
+  desktop and avoids broken overflow or unreadable controls on narrow screens.
+- R6. Disabled or unavailable workflows remain visibly disabled with accessible
+  labels; the redesign must not make deferred creation, filtering, editing, or
+  row actions look operational.
+- R7. The change preserves the Core-sourced read-only boundary and does not add
+  Prisma, Pothos, GraphQL SDL, or generated type changes.
+
+---
+
+## Scope Boundaries
+
+- Do not add video creation, editing, deletion, publish, or bulk-action
+  behavior.
+- Do not replace the current server-rendered loader with client-side filtering
+  or client-owned pagination state.
+- Do not change the video service search contract unless implementation
+  discovers a narrow display data gap.
+- Do not import from `apps/web`, alter public watch routes, or change visitor
+  URL resolution behavior.
+- Do not create a one-off visual system that conflicts with existing
+  `apps/admin` shell tokens and `admin-ui` component grammar.
+
+### Deferred to Follow-Up Work
+
+- Authenticated production-reference visual capture can be attached to a later
+  QA note if Helium/browser access to the production admin session is available.
+- Manual video creation, full video editing, faceted filters, column sorting,
+  and bulk actions remain later `feat-100` slices.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/app/dashboard/videos/page.tsx` is the server-rendered route
+  that currently renders the search form, table, row actions, and pagination.
+- `apps/admin/src/app/dashboard/live-data.ts` owns `loadVideoLibraryPage` and
+  returns the row fields the page should keep displaying.
+- `apps/admin/src/app/dashboard/video-library-utils.ts` owns URL query parsing,
+  pagination helpers, thumbnail URL normalization, and visitor-link helpers.
+- `apps/admin/src/app/dashboard/dashboard-ui.test.tsx` already covers the
+  videos page SSR output, search wiring, pagination links, thumbnails, relative
+  updated time, and visitor-link states.
+- `apps/admin/src/i18n/messages.ts` owns the copy for the videos page,
+  including search, empty states, action labels, and unavailable workflow text.
+- `apps/admin/src/components/admin-ui.tsx` provides `DashboardPageHeader`,
+  `InfoStrip`, `PageSection`, `StatusPill`, and button primitives used across
+  dashboard pages.
+- `docs/plans/2026-06-01-001-feat-admin-video-library-pagination-plan.md`
+  shipped the page's pagination, thumbnail, label, and visitor-link baseline.
+- `docs/plans/2026-06-02-001-feat-admin-video-library-search-plan.md`
+  shipped the URL-backed broad search baseline this redesign must preserve.
+- `docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md`
+  is already `in-progress` and is the correct roadmap umbrella for this slice.
+
+### Institutional Learnings
+
+- `docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md`
+  completed disabled-state and clickability polish for `/dashboard/videos`;
+  the redesign should preserve those affordance rules instead of making
+  placeholders look active.
+
+### External References
+
+- `https://admin.jesusfilm.org/dashboard/videos` is the user-provided visual
+  reference. A planning-time unauthenticated request redirected to the admin
+  auth flow, so exact post-login pixels must be verified with an authenticated
+  browser if available during the browser-test phase.
+
+---
+
+## Key Technical Decisions
+
+- Keep the redesign in the page layer first: most of the work should be layout,
+  composition, copy placement, and styling in `videos/page.tsx`, reusing the
+  row data already returned by `loadVideoLibraryPage`.
+- Prefer small reusable admin UI helpers only when a layout primitive is likely
+  to benefit sibling dashboard pages; otherwise keep page-specific markup near
+  the videos route to avoid broad visual churn.
+- Preserve server rendering and URL state. The search form, pagination links,
+  and empty states should remain HTML-first and testable through SSR output.
+- Treat unavailable controls as part of the design, not as future promises:
+  disabled creation/filter/editorial affordances should remain clearly
+  non-clickable and accessible.
+- Use the current admin token palette and restrained operational density rather
+  than marketing-page composition; this is an operator catalog, not a landing
+  page.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this create a new roadmap ticket? No. `feat-100` already covers admin
+  video/media editorial workflow refinement and is in progress.
+- Should the existing search plan be reused? No. Search is already represented
+  by a separate active plan and current code; this plan is the visual redesign
+  slice that preserves search.
+- Should implementation wait for unauthenticated access to the production
+  reference? No. The URL is an authoritative visual target, but the authenticated
+  page is not readable from plain planning access; continue with local
+  implementation and browser validation.
+
+### Deferred to Implementation
+
+- Exact visual deltas from the authenticated production reference: capture or
+  inspect through Helium/browser if a logged-in session is available.
+- Whether the final presentation is still a table, a media-list table hybrid,
+  or responsive cards on small screens: choose the smallest shape that matches
+  the reference and preserves scannability.
+
+---
+
+## Implementation Units
+
+### U1. Reference-Oriented Page Structure
+
+**Goal:** Recompose the videos page around the production-reference layout
+while preserving existing page data and disabled workflow semantics.
+
+**Requirements:** R1, R2, R3, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Modify: `apps/admin/src/i18n/messages.ts`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Rework the header, status strip, search area, primary action placement, and
+  table/list section so the page feels like the current admin reference rather
+  than the older dense table composition.
+- Preserve `requireSession`, `parseVideoLibraryPage`,
+  `parseVideoLibraryQuery`, `loadVideoLibraryPage`, and
+  `videoLibraryHref` wiring.
+- Keep manual video creation and any deferred filter/action affordances
+  disabled and clearly labeled.
+
+**Patterns to follow:**
+
+- `apps/admin/src/components/admin-ui.tsx` for existing admin shell tokens,
+  buttons, sections, and status pills.
+- `docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md` for
+  disabled and read-only affordance rules.
+
+**Test scenarios:**
+
+- Happy path: the page renders the refreshed header/search/table composition
+  while calling `loadVideoLibraryPage` with the parsed page and query.
+- Edge case: disabled manual video creation remains disabled and carries the
+  unavailable label.
+- Integration: clear/search links and previous/next pagination links preserve
+  the same URL semantics as before the redesign.
+
+**Verification:**
+
+- SSR output proves existing behavior was preserved while the new copy and
+  structural landmarks render.
+
+---
+
+### U2. Responsive Video Row Presentation
+
+**Goal:** Redesign the video row/table presentation so catalog records are more
+visual and scan-friendly without losing any current row facts.
+
+**Requirements:** R1, R4, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Keep row data fields intact: thumbnail, duration, title, Core ID, label,
+  source, dubs, updated time, and visitor action state.
+- Adjust desktop and narrow-screen layout with stable dimensions so thumbnails,
+  labels, icons, and text do not resize or overlap unexpectedly.
+- Preserve lazy thumbnail loading and visitor-link accessibility.
+
+**Patterns to follow:**
+
+- Existing thumbnail rendering in `apps/admin/src/app/dashboard/videos/page.tsx`.
+- Existing status pill tone usage from the current videos and dashboard pages.
+
+**Test scenarios:**
+
+- Happy path: rows still include thumbnails, lazy image attributes, duration,
+  label, source, dubs, updated time, and visitor URL when available.
+- Edge case: rows without thumbnails or visitor URLs render polished fallback
+  states and disabled accessible controls.
+- Responsive expectation: markup and class choices avoid hard desktop-only
+  assumptions for the primary row content.
+
+**Verification:**
+
+- Unit/SSR tests continue to assert row facts and accessible action states.
+- Browser smoke confirms the redesigned rows fit without incoherent overlap on
+  desktop and mobile widths.
+
+---
+
+### U3. Visual Smoke and Regression Coverage
+
+**Goal:** Validate the redesign through targeted tests and a browser smoke of
+the real page state.
+
+**Requirements:** R1, R2, R3, R5, R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Create if useful: `docs/qa/admin-video-library-redesign-2026-06-02.md`
+
+**Approach:**
+
+- Update SSR expectations for the redesigned structure without turning tests
+  into brittle class snapshots.
+- Run the focused dashboard tests plus admin typecheck/lint.
+- Use Helium/browser smoke for `/dashboard/videos` and a queried state such as
+  `/dashboard/videos?q=mux`; capture desktop and mobile evidence if available.
+
+**Patterns to follow:**
+
+- Existing dashboard SSR tests in
+  `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`.
+- Prior Forge UI QA pattern of recording screenshots or a concise QA note when
+  visual behavior is the point of the change.
+
+**Test scenarios:**
+
+- Happy path: default videos page renders redesigned structure with current
+  row data.
+- Integration: queried videos page renders active search state and query-aware
+  pagination.
+- Accessibility: disabled controls and unavailable visitor links expose clear
+  labels/states.
+
+**Verification:**
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`
+- Helium/browser smoke for desktop and mobile `/dashboard/videos` views.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                           | Mitigation                                                                                                                     |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| The authenticated production reference cannot be inspected in this session.    | Preserve the user-provided URL as the visual target, use local browser smoke, and document any auth limitation in QA evidence. |
+| A visual redesign could accidentally regress search or pagination.             | Keep the server-rendered helpers and loader contract unchanged, and assert the current URL semantics in SSR tests.             |
+| Dense operator content can break on mobile if converted directly from a table. | Use stable thumbnail/action dimensions and verify both desktop and narrow browser widths.                                      |
+| Disabled future workflows could look active after restyling.                   | Preserve disabled button/link semantics and assert unavailable labels in tests.                                                |
+
+---
+
+## Documentation / Operational Notes
+
+- If browser smoke produces useful screenshots or authenticated-reference notes,
+  record them in `docs/qa/admin-video-library-redesign-2026-06-02.md`.
+- No GraphQL SDL, Prisma, or generated type updates are expected for this
+  redesign.
+
+---
+
+## Sources & References
+
+- Roadmap: `docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md`
+- Related plan: `docs/plans/2026-06-01-001-feat-admin-video-library-pagination-plan.md`
+- Related plan: `docs/plans/2026-06-02-001-feat-admin-video-library-search-plan.md`
+- Related roadmap note: `docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md`
+- Page entry point: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Dashboard loader: `apps/admin/src/app/dashboard/live-data.ts`
+- Tests: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- User-provided reference: `https://admin.jesusfilm.org/dashboard/videos`

--- a/docs/qa/admin-video-library-redesign-2026-06-02.md
+++ b/docs/qa/admin-video-library-redesign-2026-06-02.md
@@ -1,0 +1,28 @@
+# Admin Video Library Redesign QA
+
+Date: 2026-06-02
+
+## Automated Validation
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`
+- `git diff --check`
+
+## Browser Smoke
+
+- Command: `agent-browser --session-name admin-video-redesign open http://127.0.0.1:3004/dashboard/videos`
+- Result: blocked from rendering the local admin videos page. The route redirected
+  away from the local admin preview and landed on `https://www.jesusfilm.org/`.
+- Evidence: local ignored screenshot saved at
+  `output/playwright/admin-video-redesign-auth-redirect.png`.
+
+## Notes
+
+This matches the documented local admin UI limitation in
+`docs/solutions/developer-experience/local-admin-dev-auth-flow-impractical-20260514.md`:
+the local admin dashboard requires production-shaped auth/session behavior, and
+the repo guidance is to avoid treating the local web UI as a reliable dev
+surface when auth is involved. The redesign was therefore verified through SSR
+coverage, typecheck, lint, diff checks, and the blocked browser-smoke evidence
+above.


### PR DESCRIPTION
## Summary

Redesigns the admin `/dashboard/videos` surface into a more polished operator catalog while preserving the server-rendered search, pagination, thumbnail, status, updated-time, and visitor-link behavior that recently shipped.

The page now has a compact command header, summary tiles for the visible catalog state, and a responsive media-list presentation that keeps unavailable workflows visibly disabled. The row-level review fix keeps hover affordance off the read-only row wrapper so only the actual visitor-link action behaves like an interactive control.

## Notes

- Adds the LFG implementation plan for the redesign under `docs/plans/`.
- Records QA results and the local browser-smoke auth redirect in `docs/qa/admin-video-library-redesign-2026-06-02.md`.
- Local visual browser proof is blocked by the documented admin auth/proxy limitation; the `agent-browser` smoke redirected from the local admin route to `https://www.jesusfilm.org/`.

## Validation

- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `git diff --check`
- `agent-browser --session-name admin-video-redesign open http://127.0.0.1:3004/dashboard/videos` (blocked by documented local admin auth/proxy behavior; evidence recorded in QA note)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-10a37f?logo=openai&logoColor=white)
