### PR TITLE
fix: tolerate admin migration recovery race

### DIFF
--- a/apps/admin/src/scripts/migrate-deploy-known-recovery.test.ts
+++ b/apps/admin/src/scripts/migrate-deploy-known-recovery.test.ts
@@ -68,9 +68,22 @@ describe("deployWithKnownRecovery", () => {
       .fn()
       .mockResolvedValueOnce(result(1, `P3009 ${RECOVERABLE_MIGRATION}`))
       .mockResolvedValueOnce(result(1, "resolve failed"))
+      .mockResolvedValueOnce(result(1, "still failed"))
 
     await expect(deployWithKnownRecovery(runner)).rejects.toThrow(
       /resolve --rolled-back/,
     )
+  })
+
+  it("tolerates another replica resolving the migration first", async () => {
+    const runner = vi
+      .fn()
+      .mockResolvedValueOnce(result(1, `P3009 ${RECOVERABLE_MIGRATION}`))
+      .mockResolvedValueOnce(result(1, "migration is not failed"))
+      .mockResolvedValueOnce(result(0))
+
+    await deployWithKnownRecovery(runner)
+
+    expect(runner).toHaveBeenNthCalledWith(3, ["migrate", "deploy"])
   })
 })

--- a/apps/admin/src/scripts/migrate-deploy-known-recovery.ts
+++ b/apps/admin/src/scripts/migrate-deploy-known-recovery.ts
@@ -61,6 +61,9 @@ export async function deployWithKnownRecovery(
     RECOVERABLE_MIGRATION,
   ])
   if (resolve.code !== 0) {
+    const retryAfterResolveFailure = await runner(["migrate", "deploy"])
+    if (retryAfterResolveFailure.code === 0) return
+
     throw new Error(
       `prisma migrate resolve --rolled-back ${RECOVERABLE_MIGRATION} failed`,
     )


### PR DESCRIPTION
## Summary
- retry Prisma migrate deploy when the known P3009 resolve step loses a race to another deploy replica
- keep recovery scoped to 0027_video_localized_language_slug_identity and fail closed if deploy still fails
- add coverage for the concurrent admin/worker recovery case

## Validation
- pnpm --filter @forge/admin test -- src/scripts/migrate-deploy-known-recovery.test.ts
- pnpm --filter @forge/admin lint
- pnpm --filter @forge/admin typecheck
- git diff --check