### PR TITLE
fix: use Core ids filter for localized metadata backfill

### DIFF
--- a/apps/admin/src/scripts/backfill-video-localized-metadata.test.ts
+++ b/apps/admin/src/scripts/backfill-video-localized-metadata.test.ts
@@ -189,6 +189,24 @@ describe("backfill-video-localized-metadata args", () => {
       expect.any(Function),
       CORE_SYNC_TRANSACTION_OPTIONS,
     )
+    expect(coreQueryMock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        offset: 0,
+        limit: 1,
+        where: { published: true, ids: ["core-video-1"] },
+      }),
+    )
+    expect(coreQueryMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        offset: 0,
+        limit: 1,
+        where: { published: true, ids: ["core-video-2"] },
+      }),
+    )
     expect(assertLockActive).toHaveBeenCalledTimes(4)
     expect(syncVideoLocalizedMetadataMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/admin/src/scripts/backfill-video-localized-metadata.ts
+++ b/apps/admin/src/scripts/backfill-video-localized-metadata.ts
@@ -124,7 +124,7 @@ async function fetchCoreLocalizedMetadata(
       limit: coreIds.length,
       where: {
         published: true,
-        id: { in: [...coreIds] },
+        ids: [...coreIds],
       },
     },
   )


### PR DESCRIPTION
## Summary
- fix the localized metadata backfill Core video lookup to use VideosFilter.ids
- add regression coverage for the batched Core query variables

## Why
The production targeted execute for parable-of-the-pharisee-and-tax-collector failed with Core API 400 because the backfill sent where: { id: { in: [...] } }. The existing Core filter shape is where: { ids: [...] }.

## Validation
- pnpm --filter @forge/admin test -- src/scripts/backfill-video-localized-metadata.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- git diff --check