### PR TITLE
feat(admin): match video library reference layout

### DIFF
--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -120,9 +120,14 @@ vi.mock("@/app/dashboard/live-data", () => ({
         sourceLabel: "Mux",
         sourceTone: "info",
         dubs: "3 dubs · EN, ES, FR",
+        dubCount: 3,
+        dubLanguages: ["EN", "ES", "FR"],
+        dubOverflowCount: 0,
+        dubCoveragePercent: 1,
         updated: "10/24/2023, 14:02",
         updatedAtIso: "2023-10-24T14:02:00.000Z",
         updatedRelative: "3 years ago",
+        updatedDateShort: "10/24/2023",
         duration: "04:22",
         previewImageUrl: "https://images.example.com/neon.jpg",
         visitorUrl:
@@ -138,9 +143,14 @@ vi.mock("@/app/dashboard/live-data", () => ({
         sourceLabel: "Internal",
         sourceTone: "muted",
         dubs: "No dubs",
+        dubCount: 0,
+        dubLanguages: [],
+        dubOverflowCount: 0,
+        dubCoveragePercent: 0,
         updated: "10/24/2023, 14:03",
         updatedAtIso: "2023-10-24T14:03:00.000Z",
         updatedRelative: "3 years ago",
+        updatedDateShort: "10/24/2023",
         duration: "--:--",
         previewImageUrl: null,
         visitorUrl: null,
@@ -548,19 +558,27 @@ describe("dashboard UI routes", () => {
     expect(html).not.toContain("10/24/2023, 14:02")
   })
 
-  it("renders videos page with localized info strip and actions", async () => {
+  it("renders videos page with screenshot-style library layout", async () => {
     const html = await htmlFrom(
       VideosPage({ searchParams: Promise.resolve({ page: "2", q: " mux " }) }),
     )
-    expect(html).toContain(uiMessages.pages.videos.infoStrip.items[0])
+    expect(html).toContain(uiMessages.pages.videos.title)
+    expect(html).toContain("Review the catalog and dub coverage across")
+    expect(html).toContain("95")
     expect(html).toContain(uiMessages.pages.videos.actions.primary)
     expect(html).toContain(uiMessages.pages.videos.actions.primaryUnavailable)
     expect(html).toMatch(
-      /<button(?=[^>]*disabled="")(?=[^>]*title="Manual video creation is not available yet.")/,
+      /<button(?=[^>]*aria-disabled="true")(?=[^>]*title="Manual video creation is not available yet.")/,
     )
-    expect(html).not.toContain(
-      'hover:text-[var(--color-text-primary)]">⋯</button>',
-    )
+    expect(html).toContain(uiMessages.pages.videos.tabs.all)
+    expect(html).toContain(uiMessages.pages.videos.tabs.collections)
+    expect(html).toContain(uiMessages.pages.videos.tabs.features)
+    expect(html).toContain(uiMessages.pages.videos.tabs.shortFilms)
+    expect(html).toContain(uiMessages.pages.videos.tabs.series)
+    expect(html).toContain(uiMessages.pages.videos.sort.label)
+    expect(html).not.toContain(uiMessages.pages.videos.infoStrip.items[0])
+    expect(html).not.toContain(uiMessages.pages.videos.summary.total)
+    expect(html).not.toContain(uiMessages.pages.videos.signals.title)
     expect(html).not.toContain(uiMessages.common.operatorNotes)
     expect(vi.mocked(loadVideoLibraryPage)).toHaveBeenCalledWith(
       { id: "test-user", role: "ADMIN" },
@@ -573,9 +591,16 @@ describe("dashboard UI routes", () => {
     expect(html).toContain("Filtered by &quot;mux&quot;")
     expect(html).toContain('href="/dashboard/videos?q=mux"')
     expect(html).toContain('href="/dashboard/videos?page=3&amp;q=mux"')
-    expect(html).toContain("Collection")
+    expect(html).toContain("COLLECTION")
+    expect(html).toContain("Mux source")
+    expect(html).toContain("Internal source")
+    expect(html).toContain("languages dubbed")
+    expect(html).toContain("EN")
+    expect(html).toContain("ES")
+    expect(html).toContain("FR")
     expect(html).toContain("https://images.example.com/neon.jpg")
     expect(html).toContain("3 years ago")
+    expect(html).toContain("10/24/2023")
     expect(html).toContain('title="10/24/2023, 14:02"')
     expect(html).toContain('dateTime="2023-10-24T14:02:00.000Z"')
     expect(html).toMatch(
@@ -589,6 +614,9 @@ describe("dashboard UI routes", () => {
     expect(html).toContain("No public watch link available")
     expect(html).toMatch(
       /<span(?=[^>]*aria-disabled="true")(?=[^>]*aria-label="No public watch link available")/,
+    )
+    expect(html).toMatch(
+      /<button(?=[^>]*aria-disabled="true")(?=[^>]*aria-label="Video row actions are not available yet.")/,
     )
     expect(html).toContain("Showing 31-60 of 95")
     expect(html).toContain("Page 2 of 4")

--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -71,6 +71,9 @@ type LoadVideoRowSliceOptions = {
   includeVisitorUrls?: boolean
 }
 
+const VIDEO_LIBRARY_LANGUAGE_TARGET = 2300
+const VIDEO_LIBRARY_LANGUAGE_CHIP_LIMIT = 5
+
 function durationSecondsForDub(
   dub: Pick<VideoDubRow, "lengthInMilliseconds" | "duration">,
 ) {
@@ -117,6 +120,15 @@ function formatDateTime(value: Date) {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
+    timeZone: "UTC",
+  }).format(value)
+}
+
+function formatShortDate(value: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
     timeZone: "UTC",
   }).format(value)
 }
@@ -380,6 +392,43 @@ function dubCoverage(dubs: VideoDubRow[]): string {
   return `${label} · ${tags.join(", ")}${suffix}`
 }
 
+function dubLanguageCodes(dubs: VideoDubRow[]) {
+  return Array.from(
+    new Set(
+      dubs
+        .map(
+          (dub) =>
+            dub.language?.iso3 ?? dub.language?.bcp47 ?? dub.language?.slug,
+        )
+        .filter((tag): tag is string => !!tag)
+        .map((tag) => tag.toUpperCase()),
+    ),
+  )
+}
+
+function dubCoverageMetric(dubs: VideoDubRow[]) {
+  const allLanguages = dubLanguageCodes(dubs)
+  const count = allLanguages.length || dubs.length
+  const percent =
+    count === 0
+      ? 0
+      : Math.min(
+          100,
+          Math.max(
+            1,
+            Math.round((count / VIDEO_LIBRARY_LANGUAGE_TARGET) * 100),
+          ),
+        )
+  const languages = allLanguages.slice(0, VIDEO_LIBRARY_LANGUAGE_CHIP_LIMIT)
+
+  return {
+    dubCount: count,
+    dubLanguages: languages,
+    dubOverflowCount: Math.max(0, count - languages.length),
+    dubCoveragePercent: percent,
+  }
+}
+
 function preferredVideoImage(images: VideoImageRow[]) {
   if (images.length === 0) return null
 
@@ -636,6 +685,7 @@ async function loadVideoRowSlice({
     const title = localeRow?.title?.trim() || video.slug
     const source = sourceLabel(video.videoSource)
     const playbackDub = preferredPlaybackDub(dubRows)
+    const coverage = dubCoverageMetric(dubRows)
 
     return {
       key: video.id,
@@ -648,9 +698,11 @@ async function loadVideoRowSlice({
       sourceLabel: source.label,
       sourceTone: source.tone,
       dubs: dubCoverage(dubRows),
+      ...coverage,
       updated: formatDateTime(video.updatedAt),
       updatedAtIso: video.updatedAt.toISOString(),
       updatedRelative: formatVideoUpdatedRelative(video.updatedAt),
+      updatedDateShort: formatShortDate(video.updatedAt),
       duration: formatDuration(dubRows),
       durationSeconds: playbackDub ? durationSecondsForDub(playbackDub) : null,
       previewImageUrl: preferredVideoImage(imageRows),

--- a/apps/admin/src/app/dashboard/videos/page.tsx
+++ b/apps/admin/src/app/dashboard/videos/page.tsx
@@ -2,25 +2,20 @@ import type { ReactNode } from "react"
 import type { Route } from "next"
 import Link from "next/link"
 import {
+  ArrowUpDown,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   ExternalLink,
-  Filter,
-  ImageIcon,
+  Film,
+  Layers,
+  MoreVertical,
+  Play,
   Plus,
   Search,
   X,
 } from "lucide-react"
-import {
-  DashboardPageHeader,
-  InfoStrip,
-  InsightGrid,
-  PageSection,
-  PrimaryButton,
-  SecondaryButton,
-  StatusPill,
-  cx,
-} from "@/components/admin-ui"
+import { cx } from "@/components/admin-ui"
 import { requireSession } from "@/auth/session"
 import { loadVideoLibraryPage } from "@/app/dashboard/live-data"
 import { getAdminMessages } from "@/i18n/server"
@@ -37,6 +32,26 @@ type VideosPageProps = {
     q?: string | string[]
   }>
 }
+
+type VideoLibraryRow = Awaited<
+  ReturnType<typeof loadVideoLibraryPage>
+>["rows"][number]
+
+type VideoTone = {
+  label: string
+  icon: string
+  thumbnail: string
+  thumbnailPattern: string
+  progress: string
+}
+
+const VIDEO_TABS = [
+  { key: "all", active: true },
+  { key: "collections", active: false },
+  { key: "features", active: false },
+  { key: "shortFilms", active: false },
+  { key: "series", active: false },
+] as const
 
 function paginationHref(page: number, query: string): Route {
   return videoLibraryHref({ page, query }) as Route
@@ -68,11 +83,33 @@ function pageCountLabel(
     .replace("{count}", pagination.pageCount.toString())
 }
 
+function headerDescription(template: string, total: number) {
+  const [before, after] = template.split("{total}")
+  if (after === undefined) {
+    return template
+  }
+
+  return (
+    <>
+      {before}
+      <strong className="font-semibold text-[#f4f4f5]">
+        {total.toLocaleString("en")}
+      </strong>
+      {after}
+    </>
+  )
+}
+
+function overflowLabel(template: string, count: number) {
+  return template.replace("{count}", count.toLocaleString("en"))
+}
+
 function paginationControlClass(disabled: boolean) {
   return cx(
-    "inline-flex h-8 items-center gap-1 rounded-sm border border-[var(--color-hairline)] px-2 font-mono text-[11px] transition-all duration-[120ms] ease-out",
-    !disabled && "hover:bg-[var(--color-surface-raised)]",
-    disabled && "text-[var(--color-text-disabled)]",
+    "inline-flex h-9 items-center gap-1.5 rounded-[8px] border border-[#303039] px-3 font-mono text-[12px] transition-all duration-150 ease-out",
+    !disabled &&
+      "text-[#d8d8de] hover:border-[#4b4b57] hover:bg-[#27272e] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6dd6be]",
+    disabled && "text-[#63636f]",
   )
 }
 
@@ -100,25 +137,253 @@ function PaginationControl({
   )
 }
 
-function SummaryTile({
-  label,
-  value,
-  detail,
-}: {
-  label: string
-  value: string
-  detail: string
-}) {
+function videoTone(label: VideoLibraryRow["label"]): VideoTone {
+  if (label === "FEATURE_FILM") {
+    return {
+      label: "text-[#ff5f68]",
+      icon: "text-[#ffffff]",
+      thumbnail: "from-[#4d1019] via-[#371018] to-[#21080d]",
+      thumbnailPattern: "bg-[#ff6370]/12",
+      progress: "from-[#65cbbb] to-[#63d787]",
+    }
+  }
+
+  if (label === "SHORT_FILM" || label === "TRAILER") {
+    return {
+      label: "text-[#f0b34f]",
+      icon: "text-[#edae4d]",
+      thumbnail: "from-[#6b501f] via-[#4b3515] to-[#2c1b08]",
+      thumbnailPattern: "bg-[#f0b34f]/12",
+      progress: "from-[#63c7b9] to-[#63d787]",
+    }
+  }
+
+  return {
+    label: "text-[#6fb5ff]",
+    icon: "text-[#6fb5ff]",
+    thumbnail: "from-[#2b3f70] via-[#23335e] to-[#17233f]",
+    thumbnailPattern: "bg-[#7ab8ff]/12",
+    progress: "from-[#67c9bf] to-[#66d887]",
+  }
+}
+
+function videoTypeLabel(video: VideoLibraryRow) {
+  return (video.labelLabel ?? "Video").toUpperCase()
+}
+
+function sourceLabel(video: VideoLibraryRow) {
+  return video.sourceLabel === "Internal"
+    ? "Internal source"
+    : `${video.sourceLabel} source`
+}
+
+function coverageWidth(percent: number) {
+  if (percent <= 0) return "0%"
+  return `${Math.max(2, percent)}%`
+}
+
+function VideoThumbnail({ video }: { video: VideoLibraryRow }) {
+  const tone = videoTone(video.label)
+  const isFeature = video.label === "FEATURE_FILM"
+  const Icon =
+    video.label === "COLLECTION" || video.label === "SERIES" ? Layers : Film
+
   return (
-    <div className="rounded-sm border border-[var(--color-hairline)] bg-[color-mix(in_oklab,var(--color-surface-raised)_76%,black)] p-3">
-      <div className="label-text">{label}</div>
-      <div className="mt-2 truncate font-mono text-lg font-medium leading-6">
-        {value}
-      </div>
-      <div className="mono-meta mt-1 truncate text-[var(--color-text-muted)]">
-        {detail}
-      </div>
+    <div
+      className={cx(
+        "relative aspect-video w-full overflow-hidden rounded-[12px] border border-white/10 bg-gradient-to-br shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] sm:w-[250px]",
+        tone.thumbnail,
+      )}
+    >
+      {video.previewImageUrl ? (
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={video.previewImageUrl}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+          <span
+            aria-hidden="true"
+            className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.04),rgba(0,0,0,0.48))]"
+          />
+        </>
+      ) : (
+        <>
+          <span
+            aria-hidden="true"
+            className={cx(
+              "absolute inset-0 opacity-60 [background-image:linear-gradient(90deg,rgba(255,255,255,0.16)_1px,transparent_1px)] [background-size:22px_100%]",
+              tone.thumbnailPattern,
+            )}
+          />
+          <span className="absolute inset-0 flex items-center justify-center">
+            {isFeature ? (
+              <span className="flex h-14 w-14 items-center justify-center rounded-full bg-white text-[#111114] shadow-[0_8px_24px_rgba(0,0,0,0.28)]">
+                <Play className="ml-0.5 h-5 w-5 fill-current" />
+              </span>
+            ) : (
+              <Icon className={cx("h-7 w-7", tone.icon)} strokeWidth={1.7} />
+            )}
+          </span>
+        </>
+      )}
+      <span className="absolute bottom-2.5 right-2.5 rounded-[5px] bg-black/72 px-2 py-1 font-mono text-[12px] font-semibold leading-none text-[#eeeeef]">
+        {video.duration}
+      </span>
     </div>
+  )
+}
+
+function VideoRow({
+  page,
+  video,
+}: {
+  page: Awaited<ReturnType<typeof getAdminMessages>>["pages"]["videos"]
+  video: VideoLibraryRow
+}) {
+  const tone = videoTone(video.label)
+  const percent = video.dubCoveragePercent
+  const languages = video.dubLanguages
+
+  return (
+    <article className="grid gap-6 border-b border-[#25252b] px-5 py-7 last:border-b-0 md:px-7 xl:grid-cols-[250px_minmax(300px,1fr)_minmax(300px,520px)_142px] xl:items-center">
+      <VideoThumbnail video={video} />
+
+      <div className="min-w-0">
+        <h2 className="truncate text-[24px] font-semibold leading-8 text-[#f3f3f5]">
+          {video.title}
+        </h2>
+        <div className="mt-3 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 text-[15px] leading-5 text-[#777783]">
+          <span
+            className={cx(
+              "inline-flex items-center gap-2 font-semibold tracking-normal",
+              tone.label,
+            )}
+          >
+            {video.label === "COLLECTION" || video.label === "SERIES" ? (
+              <Layers className="h-4 w-4" strokeWidth={1.8} />
+            ) : (
+              <Film className="h-4 w-4" strokeWidth={1.8} />
+            )}
+            {videoTypeLabel(video)}
+          </span>
+          <span
+            aria-hidden="true"
+            className="h-1 w-1 rounded-full bg-[#4a4a54]"
+          />
+          <span className="max-w-[260px] truncate font-mono text-[#74747f]">
+            {video.slug || video.id}
+          </span>
+          <span
+            aria-hidden="true"
+            className="h-1 w-1 rounded-full bg-[#4a4a54]"
+          />
+          <span className="inline-flex items-center gap-2 text-[#85858e]">
+            <span className="h-2 w-2 rounded-full bg-[#57d47a]" />
+            {sourceLabel(video)}
+          </span>
+        </div>
+      </div>
+
+      <div className="min-w-0">
+        <div className="flex items-end justify-between gap-4">
+          <div className="min-w-0">
+            <span className="align-baseline text-[34px] font-semibold leading-none text-[#f4f4f6]">
+              {video.dubCount.toLocaleString("en")}
+            </span>
+            <span className="ml-3 align-baseline text-[16px] text-[#777783]">
+              {page.coverage.languagesDubbed}
+            </span>
+          </div>
+          <span className="font-mono text-[13px] font-semibold text-[#62ceb9]">
+            {percent}%
+          </span>
+        </div>
+        <div className="mt-3 h-2 overflow-hidden rounded-full bg-[#29292f]">
+          <div
+            className={cx(
+              "h-full rounded-full bg-gradient-to-r",
+              tone.progress,
+            )}
+            style={{ width: coverageWidth(percent) }}
+          />
+        </div>
+        <div className="mt-3 flex min-h-7 flex-wrap items-center gap-2">
+          {languages.length > 0 ? (
+            languages.map((language) => (
+              <span
+                key={language}
+                className="rounded-[6px] bg-[#2b2b31] px-3 py-1.5 font-mono text-[13px] font-semibold leading-none text-[#b6b6bd]"
+              >
+                {language}
+              </span>
+            ))
+          ) : (
+            <span className="text-[13px] text-[#686874]">
+              {page.coverage.noLanguages}
+            </span>
+          )}
+          {video.dubOverflowCount > 0 ? (
+            <span className="px-2 font-mono text-[14px] text-[#7c7c87]">
+              {overflowLabel(page.coverage.overflow, video.dubOverflowCount)}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-4 xl:flex-col xl:items-end">
+        <time
+          dateTime={video.updatedAtIso}
+          title={video.updated}
+          className="text-right"
+        >
+          <span className="block text-[15px] font-semibold leading-5 text-[#b4b4bd]">
+            {video.updatedRelative}
+          </span>
+          <span className="mt-1 block font-mono text-[13px] text-[#696975]">
+            {video.updatedDateShort}
+          </span>
+        </time>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            aria-label={page.actions.rowActionsUnavailable}
+            title={page.actions.rowActionsUnavailable}
+            className="inline-flex h-12 w-12 items-center justify-center rounded-[10px] border border-[#2f2f38] text-[#858590] transition-all duration-150 ease-out hover:border-[#464650] hover:bg-[#24242a] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6dd6be]"
+          >
+            <MoreVertical className="h-5 w-5" strokeWidth={1.6} />
+          </button>
+          {video.visitorUrl ? (
+            <a
+              href={video.visitorUrl}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`${page.table.openVisitorLabel}: ${video.title}`}
+              title={page.table.openVisitorLabel}
+              className="inline-flex h-12 w-12 items-center justify-center rounded-[10px] border border-[#2f2f38] text-[#858590] transition-all duration-150 ease-out hover:border-[#595965] hover:bg-[#292930] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6dd6be]"
+            >
+              <ExternalLink className="h-5 w-5" strokeWidth={1.6} />
+            </a>
+          ) : (
+            <span
+              aria-disabled="true"
+              aria-label={page.table.noVisitorLinkLabel}
+              title={page.table.noVisitorLinkLabel}
+              className="inline-flex h-12 w-12 items-center justify-center rounded-[10px] border border-[#2f2f38] text-[#555561]"
+            >
+              <ExternalLink className="h-5 w-5" strokeWidth={1.6} />
+              <span className="sr-only">{page.table.noVisitorLinkLabel}</span>
+            </span>
+          )}
+        </div>
+      </div>
+    </article>
   )
 }
 
@@ -143,282 +408,150 @@ export default async function VideosPage({
     page.table.pagination.page,
     pagination,
   )
-  const queryState = query
-    ? page.search.active.replace("{query}", query)
-    : page.summary.queryAll
 
   return (
-    <div className="flex flex-col gap-6">
-      <InfoStrip
-        items={page.infoStrip.items}
-        trailing={page.infoStrip.trailing}
-      />
-
-      <section className="overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[linear-gradient(180deg,color-mix(in_oklab,var(--color-surface)_92%,black),var(--color-surface))]">
-        <div className="grid gap-5 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] lg:p-5">
-          <DashboardPageHeader
-            eyebrow={page.eyebrow}
-            title={page.title}
-            description={page.description}
-            action={
-              <div className="flex flex-col items-start gap-1 md:items-end">
-                <PrimaryButton
-                  disabled
-                  title={page.actions.primaryUnavailable}
-                  aria-describedby="video-actions-unavailable"
-                >
-                  <Plus className="h-4 w-4" strokeWidth={1.5} />
-                  {page.actions.primary}
-                </PrimaryButton>
-                <span
-                  id="video-actions-unavailable"
-                  className="font-mono text-[10px] text-[var(--color-text-muted)]"
-                >
-                  {page.actions.primaryUnavailable}
-                </span>
-              </div>
-            }
-          />
-
-          <div className="rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-inset)] p-3">
-            <form
-              action="/dashboard/videos"
-              className="flex w-full flex-col gap-3"
-              role="search"
+    <div className="-mx-6 -my-6 min-h-full bg-[#08080a] px-6 py-8 text-[#f3f3f5]">
+      <div className="mx-auto flex w-full max-w-[1720px] flex-col gap-7">
+        <header className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_270px] xl:items-start">
+          <div>
+            <h1 className="text-[40px] font-semibold leading-tight tracking-normal text-[#f4f4f5]">
+              {page.title}
+            </h1>
+            <p className="mt-3 text-[20px] leading-7 text-[#a0a0a8]">
+              {headerDescription(page.description, pagination.total)}
+            </p>
+          </div>
+          <div className="flex xl:justify-end">
+            <button
+              type="button"
+              disabled
+              aria-disabled="true"
+              title={page.actions.primaryUnavailable}
+              className="inline-flex h-[62px] items-center gap-3 rounded-[12px] bg-[#d54f55] px-7 text-[20px] font-semibold text-white shadow-[0_12px_28px_rgba(213,79,85,0.22)] transition-all duration-150 ease-out disabled:cursor-not-allowed disabled:opacity-95"
             >
-              <label
-                htmlFor="video-library-search"
-                className="flex flex-col gap-1"
-              >
-                <span className="label-text">{page.search.label}</span>
-                <span className="relative">
-                  <Search
-                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--color-text-muted)]"
-                    strokeWidth={1.5}
-                  />
-                  <input
-                    id="video-library-search"
-                    name="q"
-                    type="search"
-                    maxLength={VIDEO_LIBRARY_MAX_QUERY_LENGTH}
-                    defaultValue={query}
-                    placeholder={page.search.placeholder}
-                    className="h-10 w-full rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] pl-9 pr-3 font-mono text-[12px] text-[var(--color-text-primary)] outline-none transition-all duration-[120ms] ease-out placeholder:text-[var(--color-text-disabled)] focus:border-[var(--color-brand)] focus:bg-[var(--color-surface-raised)]"
-                  />
-                </span>
-              </label>
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <SecondaryButton type="submit">
-                  <Search className="h-4 w-4" strokeWidth={1.5} />
-                  {page.search.submit}
-                </SecondaryButton>
-                {query ? (
-                  <Link
-                    href="/dashboard/videos"
-                    className="inline-flex h-8 items-center gap-2 rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] font-medium text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]"
-                  >
-                    <X className="h-4 w-4" strokeWidth={1.5} />
-                    {page.search.clear}
-                  </Link>
-                ) : null}
-              </div>
-            </form>
+              <Plus className="h-6 w-6" strokeWidth={1.8} />
+              {page.actions.primary}
+            </button>
           </div>
-        </div>
+        </header>
 
-        <div className="grid gap-3 border-t border-[var(--color-hairline)] p-4 md:grid-cols-2 xl:grid-cols-4">
-          <SummaryTile
-            label={page.summary.total}
-            value={pagination.total.toLocaleString("en")}
-            detail={page.table.title}
-          />
-          <SummaryTile
-            label={page.summary.visible}
-            value={videoRows.length.toLocaleString("en")}
-            detail={rangeLabel}
-          />
-          <SummaryTile
-            label={page.summary.page}
-            value={pagination.currentPage.toString()}
-            detail={currentPageLabel}
-          />
-          <SummaryTile
-            label={page.summary.query}
-            value={queryState}
-            detail={page.table.meta}
-          />
-        </div>
-      </section>
-
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
-        <PageSection
-          title={page.table.title}
-          meta={page.table.meta}
-          actions={
-            <span className="font-mono text-[11px] text-[var(--color-text-muted)]">
-              {rangeLabel}
-            </span>
-          }
+        <section
+          aria-label={page.table.title}
+          className="grid gap-4 xl:grid-cols-[minmax(320px,620px)_minmax(430px,600px)_270px]"
         >
-          <div className="hidden grid-cols-[180px_minmax(260px,1fr)_128px_96px_132px_48px] items-center gap-4 border-b border-[var(--color-hairline)] bg-[var(--color-surface-inset)] px-4 py-3 lg:grid">
-            {page.table.columns.map((column) => (
-              <div key={column} className="label-text">
-                {column}
-              </div>
-            ))}
-            <div className="label-text text-right" />
-          </div>
-          <div className="divide-y divide-[var(--color-hairline)]">
-            {videoRows.length === 0 ? (
-              <div className="px-4 py-10 text-center text-[13px] text-[var(--color-text-muted)]">
-                {query ? page.table.emptySearch : page.table.empty}
-              </div>
-            ) : (
-              videoRows.map((video) => (
-                <article
-                  key={video.key}
-                  className="grid gap-4 px-4 py-4 lg:grid-cols-[180px_minmax(260px,1fr)_128px_96px_132px_48px] lg:items-center"
+          <form action="/dashboard/videos" role="search" className="min-w-0">
+            <label htmlFor="video-library-search" className="sr-only">
+              {page.search.label}
+            </label>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-5 top-1/2 h-6 w-6 -translate-y-1/2 text-[#73737f]"
+                strokeWidth={1.6}
+              />
+              <input
+                id="video-library-search"
+                name="q"
+                type="search"
+                maxLength={VIDEO_LIBRARY_MAX_QUERY_LENGTH}
+                defaultValue={query}
+                placeholder={page.search.placeholder}
+                className="h-[62px] w-full rounded-[13px] border border-[#303039] bg-[#1c1c20] pl-16 pr-14 text-[18px] text-[#ededf0] outline-none transition-all duration-150 ease-out placeholder:text-[#777782] focus:border-[#5a5a66] focus:bg-[#222228] focus:ring-2 focus:ring-[#6dd6be]/25"
+              />
+              {query ? (
+                <Link
+                  href="/dashboard/videos"
+                  aria-label={page.search.clear}
+                  className="absolute right-4 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-[8px] text-[#94949f] transition-all duration-150 ease-out hover:bg-[#2a2a31] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6dd6be]"
                 >
-                  <div className="relative flex aspect-video w-full max-w-[240px] items-center justify-center overflow-hidden rounded-sm border border-white/10 bg-[linear-gradient(135deg,#151312,#292524)] lg:w-[180px]">
-                    {video.previewImageUrl ? (
-                      <>
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                          src={video.previewImageUrl}
-                          alt=""
-                          loading="lazy"
-                          decoding="async"
-                          className="absolute inset-0 h-full w-full object-cover"
-                        />
-                        <span
-                          aria-hidden="true"
-                          className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08),rgba(0,0,0,0.55))]"
-                        />
-                      </>
-                    ) : (
-                      <ImageIcon
-                        className="h-5 w-5 text-[var(--color-text-disabled)]"
-                        strokeWidth={1.5}
-                      />
-                    )}
-                    <span className="absolute bottom-2 right-2 rounded-[2px] bg-black/60 px-1.5 py-0.5 font-mono text-[9px]">
-                      {video.duration}
-                    </span>
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 flex-col gap-2">
-                      <div>
-                        <h3 className="truncate text-[14px] font-medium">
-                          {video.title}
-                        </h3>
-                        <div className="mono-meta truncate text-[var(--color-text-muted)]">
-                          {video.id}
-                        </div>
-                        <div className="mono-meta mt-0.5 truncate text-[var(--color-text-disabled)]">
-                          {video.slug}
-                        </div>
-                      </div>
-                      {video.labelLabel ? (
-                        <div>
-                          <StatusPill tone="muted">
-                            {video.labelLabel}
-                          </StatusPill>
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between gap-3 lg:block">
-                    <span className="label-text lg:hidden">
-                      {page.table.columns[2]}
-                    </span>
-                    <StatusPill tone={video.sourceTone}>
-                      {video.sourceLabel}
-                    </StatusPill>
-                  </div>
-                  <div className="flex items-center justify-between gap-3 lg:block">
-                    <span className="label-text lg:hidden">
-                      {page.table.columns[3]}
-                    </span>
-                    <span className="font-mono text-[12px] text-[var(--color-text-secondary)]">
-                      {video.dubs}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between gap-3 lg:block">
-                    <span className="label-text lg:hidden">
-                      {page.table.columns[4]}
-                    </span>
-                    <time
-                      dateTime={video.updatedAtIso}
-                      title={video.updated}
-                      className="mono-meta text-[var(--color-text-muted)]"
-                    >
-                      {video.updatedRelative}
-                    </time>
-                  </div>
-                  <div className="flex items-center justify-end">
-                    {video.visitorUrl ? (
-                      <a
-                        href={video.visitorUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        aria-label={`${page.table.openVisitorLabel}: ${video.title}`}
-                        title={page.table.openVisitorLabel}
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] hover:text-[var(--color-text-primary)]"
-                      >
-                        <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
-                      </a>
-                    ) : (
-                      <span
-                        aria-disabled="true"
-                        aria-label={page.table.noVisitorLinkLabel}
-                        title={page.table.noVisitorLinkLabel}
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-disabled)]"
-                      >
-                        <ExternalLink className="h-4 w-4" strokeWidth={1.5} />
-                        <span className="sr-only">
-                          {page.table.noVisitorLinkLabel}
-                        </span>
-                      </span>
-                    )}
-                  </div>
-                </article>
-              ))
-            )}
+                  <X className="h-5 w-5" strokeWidth={1.7} />
+                </Link>
+              ) : null}
+            </div>
+            <button type="submit" className="sr-only">
+              {page.search.submit}
+            </button>
+            {query ? (
+              <p className="mt-2 font-mono text-[12px] text-[#777783]">
+                {page.search.active.replace("{query}", query)}
+              </p>
+            ) : null}
+          </form>
+
+          <div
+            className="flex min-h-[62px] items-center gap-3 overflow-x-auto rounded-[13px] border border-[#303039] bg-[#1c1c20] p-2"
+            aria-label={page.actions.filter}
+          >
+            {VIDEO_TABS.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                disabled={!tab.active}
+                aria-current={tab.active ? "page" : undefined}
+                aria-disabled={tab.active ? undefined : "true"}
+                title={tab.active ? undefined : page.actions.filterUnavailable}
+                className={cx(
+                  "h-11 whitespace-nowrap rounded-[9px] px-5 text-[16px] font-semibold transition-all duration-150 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6dd6be]",
+                  tab.active
+                    ? "bg-[#36363e] text-[#f0f0f2] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+                    : "text-[#777782] hover:bg-[#25252b] hover:text-[#c8c8cf]",
+                )}
+              >
+                {page.tabs[tab.key]}
+              </button>
+            ))}
           </div>
-          <div className="hairline-strong-t flex flex-col gap-3 px-4 py-3 text-[12px] text-[var(--color-text-muted)] md:flex-row md:items-center md:justify-between">
+
+          <div className="flex xl:justify-end">
+            <button
+              type="button"
+              disabled
+              aria-disabled="true"
+              title={page.sort.unavailable}
+              className="inline-flex h-[62px] w-full items-center justify-between gap-3 rounded-[13px] border border-[#303039] bg-[#1c1c20] px-5 text-[17px] font-semibold text-[#aaaab4] transition-all duration-150 ease-out disabled:cursor-not-allowed disabled:opacity-95 xl:w-[270px]"
+            >
+              <span className="inline-flex items-center gap-3">
+                <ArrowUpDown className="h-5 w-5" strokeWidth={1.7} />
+                {page.sort.label}
+              </span>
+              <ChevronDown className="h-5 w-5" strokeWidth={1.7} />
+            </button>
+          </div>
+        </section>
+
+        <section className="overflow-hidden rounded-[18px] border border-[#303039] bg-[#1b1b1f] shadow-[0_16px_50px_rgba(0,0,0,0.28)]">
+          {videoRows.length === 0 ? (
+            <div className="px-6 py-16 text-center text-[15px] text-[#8b8b95]">
+              {query ? page.table.emptySearch : page.table.empty}
+            </div>
+          ) : (
+            videoRows.map((video) => (
+              <VideoRow key={video.key} page={page} video={video} />
+            ))
+          )}
+
+          <div className="flex flex-col gap-3 border-t border-[#25252b] px-5 py-4 text-[13px] text-[#858590] md:flex-row md:items-center md:justify-between md:px-7">
             <span className="font-mono">{rangeLabel}</span>
             <div className="flex items-center gap-2">
               <PaginationControl
                 href={paginationHref(pagination.currentPage - 1, query)}
                 disabled={!pagination.hasPrevious}
               >
-                <ChevronLeft className="h-3.5 w-3.5" strokeWidth={1.5} />
+                <ChevronLeft className="h-4 w-4" strokeWidth={1.5} />
                 {page.table.pagination.previous}
               </PaginationControl>
-              <span className="min-w-[96px] text-center font-mono text-[11px]">
-                {pageCountLabel(page.table.pagination.page, pagination)}
+              <span className="min-w-[104px] text-center font-mono text-[12px] text-[#a7a7b0]">
+                {currentPageLabel}
               </span>
               <PaginationControl
                 href={paginationHref(pagination.currentPage + 1, query)}
                 disabled={!pagination.hasNext}
               >
                 {page.table.pagination.next}
-                <ChevronRight className="h-3.5 w-3.5" strokeWidth={1.5} />
+                <ChevronRight className="h-4 w-4" strokeWidth={1.5} />
               </PaginationControl>
             </div>
           </div>
-        </PageSection>
-
-        <PageSection title={page.signals.title} meta={page.signals.meta}>
-          <div className="p-4">
-            <InsightGrid
-              items={page.signals.insights.map((item, index) => ({
-                ...item,
-                icon: index % 2 === 0 ? Filter : Plus,
-              }))}
-            />
-          </div>
-        </PageSection>
+        </section>
       </div>
     </div>
   )

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -382,7 +382,7 @@ export const adminMessages = {
         eyebrow: "Index / Videos",
         title: "Video Library",
         description:
-          "Review the media catalog, source of truth, and dub coverage in one dense table.",
+          "Review the catalog and dub coverage across {total} titles.",
         infoStrip: {
           items: ["INGESTION PIPELINE: ACTIVE", "MUX EDGE ONLINE"],
           trailing: "REGION: US-EAST-1 (PROD)",
@@ -396,11 +396,26 @@ export const adminMessages = {
         },
         search: {
           label: "Search videos",
-          placeholder:
-            "Title, Core ID, slug, source, type, language, image, or date",
+          placeholder: "Search videos, IDs, languages...",
           submit: "Search",
           clear: "Clear",
           active: 'Filtered by "{query}"',
+        },
+        tabs: {
+          all: "All",
+          collections: "Collections",
+          features: "Features",
+          shortFilms: "Short films",
+          series: "Series",
+        },
+        sort: {
+          label: "Recently updated",
+          unavailable: "Sorting is not available yet.",
+        },
+        coverage: {
+          languagesDubbed: "languages dubbed",
+          noLanguages: "No dubbed languages",
+          overflow: "+{count}",
         },
         summary: {
           total: "Active videos",

--- a/docs/plans/2026-06-02-003-feat-admin-video-library-screenshot-match-plan.md
+++ b/docs/plans/2026-06-02-003-feat-admin-video-library-screenshot-match-plan.md
@@ -1,0 +1,124 @@
+---
+title: "feat: Match admin video library reference layout"
+type: feat
+status: completed
+date: 2026-06-02
+roadmap: docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md
+---
+
+# feat: Match admin video library reference layout
+
+## Summary
+
+Bring `apps/admin` `/dashboard/videos` closer to the user-provided production
+reference screenshot: a dark operator catalog with a search/tabs/sort toolbar,
+one large list surface, visual thumbnails, prominent dub-coverage metrics, and
+compact row actions.
+
+## Problem Frame
+
+The first redesign kept too much of the older Forge dashboard framing: summary
+tiles, an info strip, and a secondary signals rail. The screenshot target is
+more focused and flatter. It treats the page as a video library, not an
+analytics dashboard, and makes dub coverage the main scannable metric per row.
+
+## Requirements
+
+- R1. Header copy reads like the reference: `Video Library` plus catalog count
+  copy using the real pagination total.
+- R2. The top controls visually match the screenshot: search on the left,
+  category tabs in the middle, sort control on the right, and the red manual
+  video action above the sort control.
+- R3. Remove the prior redesign's info strip, summary-tile grid, and right-side
+  media-signals rail from this page.
+- R4. Rows use the screenshot hierarchy: thumbnail, title/meta/source, large
+  dubbed-language count, percentage bar, language chips, updated date, kebab,
+  and visitor link.
+- R5. Preserve the existing server-rendered search, pagination, thumbnail,
+  duration, relative updated time, visitor-link, and disabled unavailable-action
+  behavior.
+- R6. Keep the Core-sourced read-only boundary. Do not add video creation,
+  editing, filters, sorting, GraphQL, Prisma, or generated type changes in this
+  visual correction.
+
+## Scope Boundaries
+
+- Category tabs and the sort control are visual placeholders for this slice;
+  they should not imply data mutation or new filtering semantics.
+- Coverage percentages are display metrics derived from current dub rows and a
+  stable catalog-language target until a richer language-total endpoint exists.
+- Browser validation may be limited by local admin auth/session setup; record
+  that honestly if it blocks visual capture.
+
+## Context & Patterns
+
+- Page: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Loader: `apps/admin/src/app/dashboard/live-data.ts`
+- URL helpers: `apps/admin/src/app/dashboard/video-library-utils.ts`
+- Copy: `apps/admin/src/i18n/messages.ts`
+- SSR tests: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Existing completed redesign plan:
+  `docs/plans/2026-06-02-002-feat-admin-video-library-redesign-plan.md`
+- Roadmap umbrella:
+  `docs/roadmap/platform/feat-100-admin-video-and-media-editorial-workflows.md`
+
+## Implementation Units
+
+### U1. Screenshot Toolbar and Page Frame
+
+**Goal:** Replace the prior dashboard-style frame with the screenshot's
+library-first composition.
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Modify: `apps/admin/src/i18n/messages.ts`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Test scenarios:**
+
+- Header renders `Video Library` and count-based catalog copy.
+- Search remains URL-backed and preserves the active query and clear action.
+- Tabs, sort, and manual-video controls render as unavailable/read-only UI
+  without changing search or pagination behavior.
+
+### U2. Dub Coverage Row Data
+
+**Goal:** Expose enough derived row data to render the screenshot's coverage
+metric without changing service contracts.
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/live-data.ts`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Test scenarios:**
+
+- Rows expose a dubbed-language count, display chips, overflow count, coverage
+  percentage, and short updated date.
+- Existing `dubs` summary remains available for compatibility and empty states.
+
+### U3. Screenshot-Style Row Layout
+
+**Goal:** Render each video as a stable media row with visual thumbnails,
+coverage bars, chips, and compact actions.
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/videos/page.tsx`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Test scenarios:**
+
+- Rows with images use lazy thumbnails and duration overlays.
+- Rows without images render polished patterned fallback thumbnails.
+- Visitor links and unavailable row actions keep accessible labels.
+- Pagination remains query-aware after the visual rewrite.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`
+- Browser smoke with Helium/browser tooling against `/dashboard/videos` when the
+  local auth/session path permits it; otherwise record the redirect/blocker.

--- a/docs/qa/admin-video-library-screenshot-match-2026-06-02.md
+++ b/docs/qa/admin-video-library-screenshot-match-2026-06-02.md
@@ -1,0 +1,36 @@
+# Admin Video Library Screenshot Match QA - 2026-06-02
+
+## Scope
+
+Validated the screenshot-match pass for `apps/admin` `/dashboard/videos`.
+
+## Automated Checks
+
+- Passed: `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`
+- Passed: `pnpm --filter @forge/admin typecheck`
+- Passed: `pnpm --filter @forge/admin lint`
+
+## Browser Smoke
+
+Started the local admin dev server on `http://127.0.0.1:3004` with the standard
+worktree preview environment values used for admin route smoke testing.
+
+Attempted to open:
+
+- `http://127.0.0.1:3004/dashboard/videos`
+
+Result:
+
+- The route redirected to `https://www.jesusfilm.org/` before the authenticated
+  admin videos page rendered.
+- `helium` was not available on PATH in this environment, so the available
+  `agent-browser` runner was used to verify and capture the redirect.
+- Redirect screenshot saved locally at
+  `output/playwright/admin-video-screenshot-auth-redirect.png`.
+
+## Notes
+
+The visual page implementation is covered by SSR assertions for the screenshot
+toolbar, list container, coverage metrics, language chips, disabled future
+actions, visitor link states, search query handling, and pagination. Pixel-level
+browser comparison still requires an authenticated admin browser session.


### PR DESCRIPTION
## Summary
- Reshape /dashboard/videos to match the provided video library screenshot: dark toolbar, tabs, sort control, red manual-video action, and one large media-list surface.
- Add derived dubbed-language display metrics for row counts, chips, overflow, coverage percent, and short updated dates.
- Remove the prior info strip, summary tile grid, and media signals rail from this page.

## Validation
- pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- Browser smoke: local /dashboard/videos redirected to https://www.jesusfilm.org/ before authenticated admin render; documented in docs/qa/admin-video-library-screenshot-match-2026-06-02.md.