### PR TITLE
fix: add localized metadata backfill progress logs

### DIFF
--- a/apps/admin/src/scripts/backfill-video-localized-metadata.test.ts
+++ b/apps/admin/src/scripts/backfill-video-localized-metadata.test.ts
@@ -81,15 +81,22 @@ describe("backfill-video-localized-metadata args", () => {
     const args = parseArgs([])
 
     expect(args.execute).toBe(false)
+    expect(args.verbose).toBe(false)
     expect(() => validateArgs(args)).toThrow(/Refusing broad backfill/)
   })
 
   it("allows explicit full-catalog execution", () => {
-    const args = parseArgs(["--full-catalog", "--execute", "--batch-size=5"])
+    const args = parseArgs([
+      "--full-catalog",
+      "--execute",
+      "--verbose",
+      "--batch-size=5",
+    ])
 
     expect(args).toMatchObject({
       fullCatalog: true,
       execute: true,
+      verbose: true,
       batchSize: 5,
     })
     expect(() => validateArgs(args)).not.toThrow()
@@ -118,6 +125,7 @@ describe("backfill-video-localized-metadata args", () => {
       slug: "jesus",
       fullCatalog: false,
       execute: false,
+      verbose: false,
       batchSize: 10,
     })
 
@@ -149,6 +157,7 @@ describe("backfill-video-localized-metadata args", () => {
   it("executes in batches with the shared sync transaction options and lock checks", async () => {
     const prisma = buildPrisma()
     const assertLockActive = vi.fn().mockResolvedValue(undefined)
+    const onProgress = vi.fn()
     prisma.video.findMany.mockResolvedValueOnce([
       {
         id: "video-1",
@@ -179,9 +188,10 @@ describe("backfill-video-localized-metadata args", () => {
       {
         fullCatalog: true,
         execute: true,
+        verbose: false,
         batchSize: 1,
       },
-      { assertLockActive },
+      { assertLockActive, onProgress },
     )
 
     expect(prisma.$transaction).toHaveBeenCalledTimes(2)
@@ -208,6 +218,30 @@ describe("backfill-video-localized-metadata args", () => {
       }),
     )
     expect(assertLockActive).toHaveBeenCalledTimes(4)
+    expect(onProgress).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        batch: 1,
+        batches: 2,
+        batchSize: 1,
+        selected: 2,
+        selectedProcessed: 1,
+        coreVideosFetched: 1,
+        videosProcessed: 1,
+        videoLocalesUpserted: 2,
+      }),
+    )
+    expect(onProgress).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        batch: 2,
+        batches: 2,
+        selected: 2,
+        selectedProcessed: 2,
+        videosProcessed: 2,
+        studyQuestionsUpserted: 4,
+      }),
+    )
     expect(syncVideoLocalizedMetadataMock).toHaveBeenCalledWith(
       expect.objectContaining({
         prisma: prisma.tx,
@@ -275,6 +309,7 @@ describe("backfill-video-localized-metadata args", () => {
       slug: "jesus",
       fullCatalog: false,
       execute: true,
+      verbose: false,
       batchSize: 10,
     })
 

--- a/apps/admin/src/scripts/backfill-video-localized-metadata.ts
+++ b/apps/admin/src/scripts/backfill-video-localized-metadata.ts
@@ -44,7 +44,24 @@ export type BackfillVideoLocalizedMetadataArgs = {
   limit?: number
   fullCatalog: boolean
   execute: boolean
+  verbose: boolean
   batchSize: number
+}
+
+export type BackfillVideoLocalizedMetadataProgress = {
+  batch: number
+  batches: number
+  batchSize: number
+  selected: number
+  selectedProcessed: number
+  coreVideosFetched: number
+  videosProcessed: number
+  videoLocalesUpserted: number
+  videoLocalesStaled: number
+  studyQuestionsUpserted: number
+  studyQuestionsStaled: number
+  skippedLanguages: number
+  errors: number
 }
 
 export function parseArgs(
@@ -70,6 +87,7 @@ export function parseArgs(
     limit: intFor("limit"),
     fullCatalog: argv.includes("--full-catalog"),
     execute: argv.includes("--execute"),
+    verbose: argv.includes("--verbose"),
     batchSize: intFor("batch-size") ?? DEFAULT_BATCH_SIZE,
   }
 }
@@ -224,7 +242,10 @@ async function auditLocalizedVariantCoverage(
 export async function runBackfill(
   prisma: PrismaClient,
   args: BackfillVideoLocalizedMetadataArgs,
-  options: { assertLockActive?: () => Promise<void> } = {},
+  options: {
+    assertLockActive?: () => Promise<void>
+    onProgress?: (progress: BackfillVideoLocalizedMetadataProgress) => void
+  } = {},
 ): Promise<
   VideoLocalizedMetadataResult &
     LocalizedVariantCoverageAudit & { dryRun: boolean; selected: number }
@@ -280,6 +301,7 @@ export async function runBackfill(
     languages.map((language) => [language.coreId, language.slug]),
   )
 
+  const batches = Math.ceil(selected.length / args.batchSize)
   for (let index = 0; index < selected.length; index += args.batchSize) {
     await options.assertLockActive?.()
     const batch = selected.slice(index, index + args.batchSize)
@@ -300,6 +322,21 @@ export async function runBackfill(
       CORE_SYNC_TRANSACTION_OPTIONS,
     )
     mergeResults(summary, result)
+    options.onProgress?.({
+      batch: Math.floor(index / args.batchSize) + 1,
+      batches,
+      batchSize: args.batchSize,
+      selected: selected.length,
+      selectedProcessed: Math.min(index + batch.length, selected.length),
+      coreVideosFetched: coreVideos.length,
+      videosProcessed: summary.videosProcessed,
+      videoLocalesUpserted: summary.videoLocalesUpserted,
+      videoLocalesStaled: summary.videoLocalesStaled,
+      studyQuestionsUpserted: summary.studyQuestionsUpserted,
+      studyQuestionsStaled: summary.studyQuestionsStaled,
+      skippedLanguages: summary.skippedLanguages,
+      errors: summary.errors,
+    })
     await options.assertLockActive?.()
   }
 
@@ -343,7 +380,32 @@ async function main(): Promise<void> {
   heartbeat.unref?.()
 
   try {
-    const summary = await runBackfill(prisma, args, { assertLockActive })
+    if (args.verbose) {
+      console.log(
+        JSON.stringify({
+          event: "video-localized-metadata.backfill.start",
+          execute: args.execute,
+          fullCatalog: args.fullCatalog,
+          slug: args.slug,
+          coreId: args.coreId,
+          limit: args.limit,
+          batchSize: args.batchSize,
+        }),
+      )
+    }
+    const summary = await runBackfill(prisma, args, {
+      assertLockActive,
+      onProgress: args.verbose
+        ? (progress) => {
+            console.log(
+              JSON.stringify({
+                event: "video-localized-metadata.backfill.progress",
+                ...progress,
+              }),
+            )
+          }
+        : undefined,
+    })
     console.log(
       JSON.stringify(
         {


### PR DESCRIPTION
## Summary
- add a --verbose flag for localized metadata backfill runs
- emit structured start and per-batch progress events with cumulative row counts
- keep dry-run/write semantics unchanged and cover progress callback behavior in tests

## Why
The full-catalog production backfill can run for many minutes with no output, making it hard to distinguish healthy work from a stalled transaction.

## Validation
- pnpm --filter @forge/admin test -- src/scripts/backfill-video-localized-metadata.test.ts
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- git diff --check