### PR TITLE
fix: make localized metadata backfill resumable

### DIFF
--- a/apps/admin/src/scripts/backfill-video-localized-metadata.test.ts
+++ b/apps/admin/src/scripts/backfill-video-localized-metadata.test.ts
@@ -91,6 +91,8 @@ describe("backfill-video-localized-metadata args", () => {
       "--execute",
       "--verbose",
       "--batch-size=5",
+      "--resume-after=2026-06-02T03:30:00.000Z",
+      "--transaction-timeout-ms=900000",
     ])
 
     expect(args).toMatchObject({
@@ -98,8 +100,16 @@ describe("backfill-video-localized-metadata args", () => {
       execute: true,
       verbose: true,
       batchSize: 5,
+      resumeAfter: new Date("2026-06-02T03:30:00.000Z"),
+      transactionTimeoutMs: 900000,
     })
     expect(() => validateArgs(args)).not.toThrow()
+  })
+
+  it("rejects an invalid resume cutoff", () => {
+    expect(() => parseArgs(["--resume-after=not-a-date"])).toThrow(
+      /--resume-after must be a valid ISO date/,
+    )
   })
 
   it("allows a targeted dry-run by slug", () => {
@@ -190,15 +200,16 @@ describe("backfill-video-localized-metadata args", () => {
         execute: true,
         verbose: false,
         batchSize: 1,
+        transactionTimeoutMs: 900000,
       },
       { assertLockActive, onProgress },
     )
 
     expect(prisma.$transaction).toHaveBeenCalledTimes(2)
-    expect(prisma.$transaction).toHaveBeenCalledWith(
-      expect.any(Function),
-      CORE_SYNC_TRANSACTION_OPTIONS,
-    )
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      ...CORE_SYNC_TRANSACTION_OPTIONS,
+      timeout: 900000,
+    })
     expect(coreQueryMock).toHaveBeenNthCalledWith(
       1,
       expect.any(String),
@@ -267,6 +278,37 @@ describe("backfill-video-localized-metadata args", () => {
       videoLocalesUpserted: 3,
       studyQuestionsUpserted: 4,
     })
+  })
+
+  it("can resume after a previous run by skipping recently synced Core locale rows", async () => {
+    const prisma = buildPrisma()
+    const resumeAfter = new Date("2026-06-02T03:30:00.000Z")
+    prisma.video.findMany.mockResolvedValueOnce([])
+
+    await runBackfill(prisma as never, {
+      fullCatalog: true,
+      execute: false,
+      verbose: false,
+      batchSize: 10,
+      resumeAfter,
+    })
+
+    expect(prisma.video.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          source: "CORE",
+          deletedAt: null,
+          videoLocales: {
+            none: {
+              source: "CORE",
+              deletedAt: null,
+              languageCoreId: { not: null },
+              syncedAt: { gte: resumeAfter },
+            },
+          },
+        }),
+      }),
+    )
   })
 
   it("reports localized variant coverage diagnostics after execution", async () => {

--- a/apps/admin/src/scripts/backfill-video-localized-metadata.ts
+++ b/apps/admin/src/scripts/backfill-video-localized-metadata.ts
@@ -46,6 +46,8 @@ export type BackfillVideoLocalizedMetadataArgs = {
   execute: boolean
   verbose: boolean
   batchSize: number
+  resumeAfter?: Date
+  transactionTimeoutMs?: number
 }
 
 export type BackfillVideoLocalizedMetadataProgress = {
@@ -80,6 +82,15 @@ export function parseArgs(
     }
     return parsed
   }
+  const dateFor = (name: string): Date | undefined => {
+    const raw = valueFor(name)
+    if (!raw) return undefined
+    const parsed = new Date(raw)
+    if (Number.isNaN(parsed.getTime())) {
+      throw new Error(`--${name} must be a valid ISO date`)
+    }
+    return parsed
+  }
 
   return {
     slug: valueFor("slug"),
@@ -89,6 +100,8 @@ export function parseArgs(
     execute: argv.includes("--execute"),
     verbose: argv.includes("--verbose"),
     batchSize: intFor("batch-size") ?? DEFAULT_BATCH_SIZE,
+    resumeAfter: dateFor("resume-after"),
+    transactionTimeoutMs: intFor("transaction-timeout-ms"),
   }
 }
 
@@ -124,6 +137,18 @@ export async function selectAdminVideos(
       deletedAt: null,
       ...(args.slug ? { slug: args.slug } : {}),
       ...(args.coreId ? { coreId: args.coreId } : {}),
+      ...(args.resumeAfter
+        ? {
+            videoLocales: {
+              none: {
+                source: "CORE",
+                deletedAt: null,
+                languageCoreId: { not: null },
+                syncedAt: { gte: args.resumeAfter },
+              },
+            },
+          }
+        : {}),
     },
     select: { id: true, coreId: true, source: true, publishedAt: true },
     orderBy: { updatedAt: "desc" },
@@ -302,6 +327,10 @@ export async function runBackfill(
   )
 
   const batches = Math.ceil(selected.length / args.batchSize)
+  const transactionOptions = {
+    ...CORE_SYNC_TRANSACTION_OPTIONS,
+    timeout: args.transactionTimeoutMs ?? CORE_SYNC_TRANSACTION_OPTIONS.timeout,
+  }
   for (let index = 0; index < selected.length; index += args.batchSize) {
     await options.assertLockActive?.()
     const batch = selected.slice(index, index + args.batchSize)
@@ -319,7 +348,7 @@ export async function runBackfill(
           slugByCoreId,
           complete: true,
         }),
-      CORE_SYNC_TRANSACTION_OPTIONS,
+      transactionOptions,
     )
     mergeResults(summary, result)
     options.onProgress?.({
@@ -390,6 +419,8 @@ async function main(): Promise<void> {
           coreId: args.coreId,
           limit: args.limit,
           batchSize: args.batchSize,
+          resumeAfter: args.resumeAfter?.toISOString(),
+          transactionTimeoutMs: args.transactionTimeoutMs,
         }),
       )
     }


### PR DESCRIPTION
## Summary
- add --resume-after to skip videos already committed by a prior localized metadata backfill run
- add --transaction-timeout-ms for production backfill batches that exceed the shared 300s sync timeout
- include verbose start metadata for both new knobs

## Validation
- pnpm --filter @forge/admin test -- src/scripts/backfill-video-localized-metadata.test.ts
- pnpm --filter @forge/admin lint
- pnpm --filter @forge/admin typecheck
- git diff --check