### PR TITLE
feat(roadmap): show delivery actual timeline

### DIFF
--- a/apps/roadmap/components/PlannedRoadmapTimeline.tsx
+++ b/apps/roadmap/components/PlannedRoadmapTimeline.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react"
 
 import {
-  PLANNED_MILESTONES,
   PLANNED_PHASES,
   PLANNED_START_ISO,
   PLANNED_TIMELINE_ROWS,
@@ -11,7 +10,6 @@ import {
   PLANNED_TRACKS,
   PLANNED_WEEK_COUNT,
   PLANNED_WEEKS,
-  type PlannedMilestone,
   type PlannedPhase,
   type PlannedTrackId,
   type PlannedTimelineRow,
@@ -29,6 +27,7 @@ const TRACK_ROW_VERTICAL_INSET_PX = 10
 const TRACK_SUBLANE_GAP_PX = 8
 const TRACK_ROW_HEIGHT_PX = 116
 const STACKED_TRACK_ROW_HEIGHT_PX = 168
+const ACTUAL_DELIVERY_ROW_HEIGHT_PX = 144
 
 const TONE_STYLES: Record<
   PlannedTone,
@@ -97,14 +96,6 @@ const TONE_STYLES: Record<
     card: "border-red-500/30 bg-red-500/8",
     accent: "text-red-200",
   },
-}
-
-function dateToPct(date: string): number {
-  const start = new Date(`${PLANNED_START_ISO}T00:00:00`)
-  const target = new Date(`${date}T00:00:00`)
-  const totalDays = PLANNED_WEEK_COUNT * 7
-  const offsetDays = (target.getTime() - start.getTime()) / DAY_MS
-  return (offsetDays / totalDays) * 100
 }
 
 function weekLeftPct(startWeek: number): number {
@@ -180,6 +171,16 @@ function getTimelineTargetId(item: PlannedPhase | PlannedTrackBar) {
     : getTrackSectionId(item.id)
 }
 
+function getOverdueLeftPct(item: PlannedPhase | PlannedTrackBar) {
+  if (!("overdueStartWeek" in item) || item.overdueStartWeek === undefined) {
+    return null
+  }
+
+  const overdueOffsetWeeks = item.overdueStartWeek - item.startWeek
+
+  return Math.max(0, Math.min(100, (overdueOffsetWeeks / item.spanWeeks) * 100))
+}
+
 function TimelineBar({
   item,
   topPx,
@@ -193,6 +194,8 @@ function TimelineBar({
   const leftPct = weekLeftPct(item.startWeek)
   const widthPct = Math.max(weekWidthPct(item.spanWeeks), 8)
   const isCompact = heightPx <= 52
+  const isActualDelivery = item.track.startsWith("actual-")
+  const overdueLeftPct = getOverdueLeftPct(item)
   const showBadge = Boolean(item.badge) && !isCompact
   const targetId = getTimelineTargetId(item)
   return (
@@ -200,7 +203,7 @@ function TimelineBar({
       href={`#${targetId}`}
       className={`absolute overflow-hidden rounded-xl shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-sm transition-[transform,filter,box-shadow] duration-150 hover:-translate-y-0.5 hover:brightness-125 hover:saturate-140 hover:shadow-[0_16px_34px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.1)] focus:outline-none focus:ring-2 focus:ring-white/30 ${tone.bar} ${
         isCompact ? "px-4 py-1.5" : "px-3 py-2"
-      }`}
+      } ${isActualDelivery ? "flex items-center" : ""}`}
       style={{
         left: `calc(${leftPct}% + ${TIMELINE_BAR_GAP_PX / 2}px)`,
         width: `calc(${widthPct}% - ${TIMELINE_BAR_GAP_PX}px)`,
@@ -210,6 +213,20 @@ function TimelineBar({
       aria-label={`Jump to ${item.title} details`}
     >
       <div className="pointer-events-none absolute inset-x-4 top-0 h-px bg-white/6" />
+      {overdueLeftPct !== null && (
+        <div
+          className="pointer-events-none absolute top-0 right-0 bottom-0"
+          style={{
+            left: `${overdueLeftPct}%`,
+            backgroundImage:
+              "repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0 1px, transparent 1px 5px)",
+          }}
+        >
+          <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[9px] font-semibold tracking-[0.18em] whitespace-nowrap text-white/45">
+            DELAYED
+          </span>
+        </div>
+      )}
       {showBadge && (
         <div className="flex items-center gap-2">
           <span
@@ -220,61 +237,26 @@ function TimelineBar({
         </div>
       )}
       <div
-        className={`truncate font-semibold text-white ${
-          isCompact ? "text-[13px] leading-4" : "mt-1 text-sm leading-5"
+        className={`relative z-10 truncate font-semibold text-white ${
+          isCompact || isActualDelivery
+            ? "text-[13px] leading-4"
+            : "mt-1 text-sm leading-5"
         }`}
       >
         {item.title}
       </div>
-      <div
-        className={`text-stone-300 ${
-          isCompact
-            ? "mt-0.5 line-clamp-2 text-[10px] leading-3.5"
-            : "line-clamp-2 text-[11px] leading-4"
-        }`}
-      >
-        {item.summary}
-      </div>
+      {!isActualDelivery && (
+        <div
+          className={`relative z-10 text-stone-300 ${
+            isCompact
+              ? "mt-0.5 line-clamp-2 text-[10px] leading-3.5"
+              : "line-clamp-2 text-[11px] leading-4"
+          }`}
+        >
+          {item.summary}
+        </div>
+      )}
     </a>
-  )
-}
-
-function MilestoneMarker({ milestone }: { milestone: PlannedMilestone }) {
-  return (
-    <div className="group relative">
-      <div
-        className="pointer-events-auto whitespace-nowrap rounded bg-red-500 px-1 py-px text-[9px] font-medium text-white"
-        tabIndex={0}
-      >
-        {milestone.label}
-      </div>
-      <div className="pointer-events-none absolute left-1/2 top-14 z-40 hidden w-72 -translate-x-1/2 rounded-xl border border-stone-700 bg-stone-950/96 p-3 text-left shadow-2xl group-hover:block group-focus-within:block">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-stone-500">
-          {milestone.dateLabel}
-        </div>
-        <div className="mt-2 text-sm font-semibold text-white">
-          {milestone.label}
-        </div>
-        <p className="mt-2 text-sm leading-relaxed text-stone-300">
-          {milestone.description}
-        </p>
-        {milestone.items && milestone.items.length > 0 && (
-          <>
-            <div className="mt-3 text-[11px] font-semibold uppercase tracking-wide text-stone-500">
-              Show only
-            </div>
-            <ul className="mt-2 space-y-1.5 text-sm text-stone-300">
-              {milestone.items.map((item) => (
-                <li key={`${milestone.id}-${item}`}>- {item}</li>
-              ))}
-            </ul>
-          </>
-        )}
-        {milestone.quote && (
-          <div className="mt-3 text-sm text-rose-100">"{milestone.quote}"</div>
-        )}
-      </div>
-    </div>
   )
 }
 
@@ -298,8 +280,13 @@ function TrackRow({
         bars: getBarsForTrackIds(sublane.trackIds),
       }))
     : [{ id: row.id, bars: getBarsForTrackIds(row.trackIds) }]
+  const isActualDeliveryRow = row.id === "delivery-actual"
   const rowHeightPx =
-    lanes.length > 1 ? STACKED_TRACK_ROW_HEIGHT_PX : TRACK_ROW_HEIGHT_PX
+    lanes.length > 1
+      ? isActualDeliveryRow
+        ? ACTUAL_DELIVERY_ROW_HEIGHT_PX
+        : STACKED_TRACK_ROW_HEIGHT_PX
+      : TRACK_ROW_HEIGHT_PX
   const laneHeightPx =
     (rowHeightPx -
       TRACK_ROW_VERTICAL_INSET_PX * 2 -
@@ -316,13 +303,16 @@ function TrackRow({
       <div className="flex items-center gap-3 px-4 py-4">
         <div>
           <div className="text-sm font-semibold text-white">{row.label}</div>
-          <div className="text-xs text-stone-500">{row.description}</div>
+          {row.description && (
+            <div className="text-xs text-stone-500">{row.description}</div>
+          )}
         </div>
       </div>
       <div className="relative" style={{ height: `${rowHeightPx}px` }}>
         <div className="absolute inset-0">{renderWeekGuides()}</div>
         <div className="absolute top-0 right-0 bottom-0 border-r border-stone-800" />
         {lanes.length > 1 &&
+          !isActualDeliveryRow &&
           lanes.slice(0, -1).map((lane, index) => (
             <div
               key={`${row.id}-${lane.id}-divider`}
@@ -479,24 +469,6 @@ export default function PlannedRoadmapTimeline() {
                     />
                   </div>
                 )}
-                {PLANNED_MILESTONES.map((milestone) => (
-                  <div
-                    key={`header-${milestone.id}`}
-                    className="absolute inset-y-0 z-20 w-px"
-                    style={{ left: `${dateToPct(milestone.date)}%` }}
-                  >
-                    <div
-                      className="absolute left-1/2 w-px -translate-x-1/2 bg-red-500/70"
-                      style={{
-                        top: `${TIMELINE_HEADER_MARKER_BAND_PX - 2}px`,
-                        bottom: "0px",
-                      }}
-                    />
-                    <div className="absolute left-1/2 top-0 -translate-x-1/2">
-                      <MilestoneMarker milestone={milestone} />
-                    </div>
-                  </div>
-                ))}
               </div>
 
               <div

--- a/apps/roadmap/lib/plannedRoadmap.ts
+++ b/apps/roadmap/lib/plannedRoadmap.ts
@@ -12,6 +12,10 @@ export type PlannedTrackId =
   | "foundation"
   | "surface"
   | "search"
+  | "actual-foundation"
+  | "actual-player"
+  | "actual-surface"
+  | "actual-search"
   | "agentic-framework"
   | "mobile-tv"
 
@@ -61,6 +65,7 @@ export type PlannedTrackBar = {
   spanWeeks: number
   badge?: string
   details?: string[]
+  overdueStartWeek?: number
 }
 
 export type PlannedMilestone = {
@@ -104,7 +109,7 @@ function formatDateRangeLabel(startDate: Date, endDate: Date): string {
   return `${startMonth} ${startDay}-${endMonth} ${endDay}`
 }
 
-export const PLANNED_WEEK_COUNT = 14
+export const PLANNED_WEEK_COUNT = 15
 export const PLANNED_START_ISO = "2026-04-28"
 
 export const PLANNED_WEEKS: PlannedWeek[] = Array.from(
@@ -124,7 +129,7 @@ export const PLANNED_WEEKS: PlannedWeek[] = Array.from(
 
 export const PLANNED_TITLE = "FORGE ROADMAP - Next 3 Months"
 export const PLANNED_SUBTITLE = "Starting Apr 28, 2026"
-export const PLANNED_RANGE_LABEL = "Apr 28 - Aug 3, 2026"
+export const PLANNED_RANGE_LABEL = "Apr 28 - Aug 10, 2026"
 export const PLANNED_GOAL =
   "Migrate to Forge while shipping real user value, prepare Demo Day, and set up the future AI and creator ecosystem."
 
@@ -156,6 +161,26 @@ export const PLANNED_TRACKS: PlannedTrack[] = [
     description: "Hybrid and multilingual search",
   },
   {
+    id: "actual-foundation",
+    label: "Actual Foundation",
+    description: "Actual CMS, data, stability, shutdown delivery",
+  },
+  {
+    id: "actual-player",
+    label: "Actual Player",
+    description: "Actual player page delivery",
+  },
+  {
+    id: "actual-surface",
+    label: "Actual Surface",
+    description: "Actual experiences and homepage delivery",
+  },
+  {
+    id: "actual-search",
+    label: "Actual Search",
+    description: "Actual hybrid and multilingual search delivery",
+  },
+  {
     id: "agentic-framework",
     label: "Agentic Framework",
     description: "R&D with Mastra AI, non-blocking",
@@ -169,10 +194,35 @@ export const PLANNED_TRACKS: PlannedTrack[] = [
 
 export const PLANNED_TIMELINE_ROWS: PlannedTimelineRow[] = [
   {
-    id: "migration",
-    label: "Delivery",
-    description: "Core migration, product releases, search",
+    id: "delivery-planned",
+    label: "Delivery Planned",
+    description: "Original migration release plan",
     trackIds: ["foundation", "surface", "search"],
+  },
+  {
+    id: "delivery-actual",
+    label: "Delivery Actual",
+    description: "Current delivery reality and shifted forecast",
+    trackIds: [
+      "actual-foundation",
+      "actual-player",
+      "actual-surface",
+      "actual-search",
+    ],
+    sublanes: [
+      {
+        id: "actual-foundation",
+        trackIds: ["actual-foundation"],
+      },
+      {
+        id: "actual-player",
+        trackIds: ["actual-player"],
+      },
+      {
+        id: "actual-follow-on",
+        trackIds: ["actual-surface", "actual-search"],
+      },
+    ],
   },
   {
     id: "experimentation",
@@ -364,6 +414,109 @@ export const PLANNED_PHASES: PlannedPhase[] = [
 ]
 
 export const PLANNED_TRACK_BARS: PlannedTrackBar[] = [
+  {
+    id: "actual-foundation-track",
+    title: "Foundation",
+    summary: "Actual foundation work extended from W1 through the end of W5.",
+    track: "actual-foundation",
+    tone: "stone",
+    startWeek: 0,
+    spanWeeks: 5,
+    badge: "Actual W1-5",
+    overdueStartWeek: 2,
+    details: [
+      "Foundation work ran from W1 through the end of W5",
+      "Kept CMS, data, infrastructure, stability, and migration base visible as actual delivery",
+    ],
+  },
+  {
+    id: "actual-player-track",
+    title: "Replace Player Page",
+    summary: "Actual player replacement work spans W3 through W6.",
+    track: "actual-player",
+    tone: "amber",
+    startWeek: 2,
+    spanWeeks: 4,
+    badge: "Actual W3-6",
+    overdueStartWeek: 4,
+    details: [
+      "Player page replacement moved from the planned W3-W4 window to W3-W6",
+      "Keeps the player release connected to the extended foundation work",
+    ],
+  },
+  {
+    id: "actual-experiences-track",
+    title: "Experiences Rollout",
+    summary:
+      "Actual experiences rollout starts in W6 and keeps the same duration.",
+    track: "actual-surface",
+    tone: "amber",
+    startWeek: 5,
+    spanWeeks: 2,
+    badge: "Actual W6-7",
+    overdueStartWeek: 6,
+    details: ["Experiences rollout starts in W6", "Duration remains two weeks"],
+  },
+  {
+    id: "actual-search-track",
+    title: "Search Rollout",
+    summary: "Shifted two-week search rollout after the experiences block.",
+    track: "actual-search",
+    tone: "sky",
+    startWeek: 7,
+    spanWeeks: 2,
+    badge: "Actual W8-9",
+    overdueStartWeek: 8,
+    details: [
+      "Search rollout keeps the planned two-week duration",
+      "Starts after the shifted experiences rollout",
+    ],
+  },
+  {
+    id: "actual-homepage-track",
+    title: "Watch Homepage",
+    summary: "Shifted two-week homepage rollout after search.",
+    track: "actual-surface",
+    tone: "amber",
+    startWeek: 9,
+    spanWeeks: 2,
+    badge: "Actual W10-11",
+    overdueStartWeek: 10,
+    details: [
+      "Homepage rollout keeps the planned two-week duration",
+      "Follows the shifted search rollout",
+    ],
+  },
+  {
+    id: "actual-stability-track",
+    title: "i18n + Stability",
+    summary: "Shifted two-week stability block before shutdown.",
+    track: "actual-foundation",
+    tone: "stone",
+    startWeek: 11,
+    spanWeeks: 2,
+    badge: "Actual W12-13",
+    overdueStartWeek: 12,
+    details: [
+      "Internationalization and stability keep the planned two-week duration",
+      "Moves with the shifted delivery forecast",
+    ],
+  },
+  {
+    id: "actual-shutdown-track",
+    title: "Old Watch Shutdown",
+    summary: "Shifted two-week old Watch shutdown block.",
+    track: "actual-foundation",
+    tone: "stone",
+    startWeek: 13,
+    spanWeeks: 2,
+    badge: "Actual W14-15",
+    overdueStartWeek: 14,
+    details: [
+      "Old Watch shutdown keeps the planned two-week duration",
+      "Moves to W14-W15 after the shifted stability block",
+    ],
+  },
   {
     id: "agentic-track",
     title: "Agentic Framework",


### PR DESCRIPTION
## Summary

The roadmap now separates the original delivery plan from the current delivery reality, so the migration sequence can show slipped work without losing the planned baseline.

This adds a `Delivery Actual` row with compact title-only blocks, extends the roadmap to W15, and marks delayed portions with a low-opacity diagonal hatch plus a centered `DELAYED` label. The old launch/deadline milestone markers are removed from the timeline while the Today marker remains.

## Validation

- `pnpm --filter roadmap lint`
- `pnpm --filter roadmap build`
- Browser smoke on `http://localhost:3100/roadmap`

Build completed with existing warnings for Turbopack tracing and draft roadmap docs missing frontmatter.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
