### PR TITLE
fix(auth): preserve admin login routing on provider errors

### DIFF
--- a/apps/admin/src/app/access-request/access-request-page-client.tsx
+++ b/apps/admin/src/app/access-request/access-request-page-client.tsx
@@ -53,14 +53,18 @@ export function AccessRequestPageClient({
   }
 
   function continueWithAuth() {
+    window.location.assign(buildAdminLoginUrl(window.location.origin))
+  }
+
+  function signInAgain() {
     window.location.assign(
-      `/api/auth/login?returnTo=${encodeURIComponent(`${window.location.origin}/dashboard`)}`,
+      buildAdminLoginUrl(window.location.origin, { prompt: "login" }),
     )
   }
 
   function tryDifferentAccount() {
     window.location.assign(
-      `/api/auth/login?prompt=login&returnTo=${encodeURIComponent(`${window.location.origin}/dashboard`)}`,
+      buildAdminLoginUrl(window.location.origin, { prompt: "login" }),
     )
   }
 
@@ -173,7 +177,7 @@ export function AccessRequestPageClient({
             ) : (
               <button
                 type="button"
-                onClick={continueWithAuth}
+                onClick={signInAgain}
                 className="flex h-10 w-full items-center justify-center gap-2 rounded-sm bg-[var(--color-brand)] text-[13px] font-medium text-white transition-all duration-[120ms] ease-out hover:bg-[var(--color-brand-pressed)]"
               >
                 {messages.login.actions.signInAgain}
@@ -193,4 +197,18 @@ export function AccessRequestPageClient({
       </section>
     </main>
   )
+}
+
+export function buildAdminLoginUrl(
+  origin: string,
+  options: { prompt?: "login" | "select_account" } = {},
+) {
+  const params = new URLSearchParams({
+    returnTo: `${origin}/dashboard`,
+  })
+  if (options.prompt) {
+    params.set("prompt", options.prompt)
+  }
+
+  return `/api/auth/login?${params.toString()}`
 }

--- a/apps/admin/src/app/access-request/page.ui.test.tsx
+++ b/apps/admin/src/app/access-request/page.ui.test.tsx
@@ -9,7 +9,10 @@ vi.mock("@/i18n/client", () => ({
   }),
 }))
 
-import { AccessRequestPageClient } from "./access-request-page-client"
+import {
+  AccessRequestPageClient,
+  buildAdminLoginUrl,
+} from "./access-request-page-client"
 
 describe("access request UI", () => {
   it("renders the request action when a signed request is available", () => {
@@ -54,5 +57,31 @@ describe("access request UI", () => {
     expect(html).toContain(adminMessages.es.login.actions.signInAgain)
     expect(html).toContain(adminMessages.es.login.actions.tryDifferentAccount)
     expect(html).not.toContain(adminMessages.es.login.actions.requestAccess)
+  })
+
+  it("forces a fresh login prompt for the sign-in-again URL", () => {
+    const url = new URL(
+      buildAdminLoginUrl("http://localhost:3003", { prompt: "login" }),
+      "http://localhost:3003",
+    )
+
+    expect(url.pathname).toBe("/api/auth/login")
+    expect(url.searchParams.get("prompt")).toBe("login")
+    expect(url.searchParams.get("returnTo")).toBe(
+      "http://localhost:3003/dashboard",
+    )
+  })
+
+  it("keeps the approved continue URL as a silent auth check", () => {
+    const url = new URL(
+      buildAdminLoginUrl("http://localhost:3003"),
+      "http://localhost:3003",
+    )
+
+    expect(url.pathname).toBe("/api/auth/login")
+    expect(url.searchParams.has("prompt")).toBe(false)
+    expect(url.searchParams.get("returnTo")).toBe(
+      "http://localhost:3003/dashboard",
+    )
   })
 })

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -170,7 +170,7 @@ export const adminMessages = {
         okta: "Okta",
       },
       errors: {
-        forbidden: "Your account does not have access to the admin dashboard.",
+        forbidden: "You're signed in, but Admin access has not been approved.",
         invalidCredentials: "Invalid email or password",
         requestAccessFailed: "Access request failed. Try signing in again.",
       },
@@ -179,11 +179,11 @@ export const adminMessages = {
         approved:
           "Access has been approved. Continue to sign in again and enter the dashboard.",
         available:
-          "Request access and an administrator will review your account.",
+          "You're signed in, but Admin access has not been approved. Request access and an administrator will review your account.",
         description:
           "This account is authenticated, but it has not been approved for Forge Admin.",
         pending:
-          "Access has been requested and is waiting for an administrator to approve it.",
+          "You're signed in, but Admin access has not been approved. An administrator still needs to approve your account.",
         requested:
           "Access requested. An administrator must approve your account before you can enter the dashboard.",
         title: "Admin access required",
@@ -1261,7 +1261,8 @@ export const adminMessages = {
         okta: "Okta",
       },
       errors: {
-        forbidden: "Tu cuenta no tiene acceso al panel de administracion.",
+        forbidden:
+          "Iniciaste sesion, pero el acceso de administrador aun no fue aprobado.",
         invalidCredentials: "Correo o contrasena no validos",
         requestAccessFailed:
           "No se pudo solicitar acceso. Intenta iniciar sesion de nuevo.",
@@ -1270,11 +1271,12 @@ export const adminMessages = {
         accountLabel: "Iniciaste sesion como",
         approved:
           "El acceso fue aprobado. Continua para iniciar sesion de nuevo y entrar al panel.",
-        available: "Solicita acceso y un administrador revisara tu cuenta.",
+        available:
+          "Iniciaste sesion, pero el acceso de administrador aun no fue aprobado. Solicita acceso y un administrador revisara tu cuenta.",
         description:
           "Esta cuenta esta autenticada, pero aun no tiene aprobacion para Forge Admin.",
         pending:
-          "El acceso fue solicitado y esta esperando la aprobacion de un administrador.",
+          "Iniciaste sesion, pero el acceso de administrador aun no fue aprobado. Un administrador aun debe aprobar tu cuenta.",
         requested:
           "Acceso solicitado. Un administrador debe aprobar tu cuenta antes de que puedas entrar al panel.",
         title: "Se requiere acceso de administrador",

--- a/apps/auth/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.test.ts
@@ -233,8 +233,47 @@ describe("Auth route wrapper", () => {
     await expect(forwardedRequest.json()).resolves.toMatchObject({
       callbackURL:
         "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&sig=signed",
+      errorCallbackURL:
+        "http://localhost:3004/login?client_id=jfp_admin_local&sig=signed",
       provider: "google",
     })
+  })
+
+  it("returns OAuth social failures to login without exposing method hints", async () => {
+    authPost.mockResolvedValueOnce(
+      Response.json({ url: "https://google.test" }),
+    )
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-in/social", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email: "USER@example.com",
+          expected_login_method: "google",
+          oauth_query: "client_id=jfp_admin_local&sig=signed",
+          provider: "google",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["sign-in", "social"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    const forwardedRequest = authPost.mock.calls[0]?.[0] as Request
+    const forwardedBody = (await forwardedRequest.json()) as Record<
+      string,
+      unknown
+    >
+    expect(forwardedBody).toMatchObject({
+      callbackURL:
+        "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&sig=signed",
+      errorCallbackURL:
+        "http://localhost:3004/login?client_id=jfp_admin_local&sig=signed",
+      provider: "google",
+    })
+    expect(forwardedBody).not.toHaveProperty("email")
+    expect(forwardedBody).not.toHaveProperty("expected_login_method")
+    expect(forwardedBody).not.toHaveProperty("oauth_query")
   })
 
   it("forwards valid web watch callbacks through social sign-in", async () => {

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -243,6 +243,14 @@ function buildOAuthContinuationURL(oauthQuery: string | undefined) {
   return url.toString()
 }
 
+function buildOAuthLoginURL(oauthQuery: string | undefined) {
+  if (!oauthQuery) return undefined
+
+  const url = new URL("/login", getAuthBaseUrl())
+  url.search = oauthQuery
+  return url.toString()
+}
+
 async function parseSocialSignInRequest(request: Request): Promise<{
   body: Record<string, unknown>
   callbackURL?: string
@@ -271,14 +279,20 @@ async function handleSocialSignIn(request: Request): Promise<Response> {
     oauthQuery,
   } = await parseSocialSignInRequest(request)
   const callbackURL = webCallbackURL ?? buildOAuthContinuationURL(oauthQuery)
+  const errorCallbackURL = webCallbackURL
+    ? undefined
+    : buildOAuthLoginURL(oauthQuery)
   const betterAuthBody = { ...body }
   delete betterAuthBody.callbackURL
+  delete betterAuthBody.email
+  delete betterAuthBody.expected_login_method
   delete betterAuthBody.oauth_query
 
   return authRouteHandlers.POST(
     toJsonRequest(request, {
       ...betterAuthBody,
       ...(callbackURL ? { callbackURL } : {}),
+      ...(errorCallbackURL ? { errorCallbackURL } : {}),
     }),
   )
 }

--- a/apps/auth/src/app/login/login-page-client.tsx
+++ b/apps/auth/src/app/login/login-page-client.tsx
@@ -3,8 +3,15 @@
 import Image from "next/image"
 import Link from "next/link"
 import type { Route } from "next"
-import { useRef, useState, useSyncExternalStore, type FormEvent } from "react"
 import {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type FormEvent,
+} from "react"
+import {
+  isLoginProviderId,
   providerLabels,
   type LoginMethodId,
   type LoginProviderId,
@@ -14,23 +21,23 @@ import { WatchFilmCollageBackground } from "./watch-film-collage-background"
 export type LoginErrorCode = "account_not_linked" | "credentials" | "forbidden"
 
 type LoginStep = "email" | "password"
+type PendingSocialSignIn = {
+  email: string
+  provider: LoginProviderId
+}
 
 const providerIds = Object.keys(providerLabels) as LoginProviderId[]
 const lastLoginMethodCookieName = "forge_auth_last_login_method"
+const pendingSocialSignInKey = "forge_auth_pending_social_sign_in"
 
 const loginErrors = {
-  account_not_linked: {
-    title: "This login method is not linked yet.",
-    detail:
-      "Log in with the method you used before, then connect this provider from your account settings.",
-  },
   forbidden: {
     title: "Access has not been approved.",
     detail:
       "Your account signed in successfully, but it is not approved for this application.",
   },
 } satisfies Record<
-  Exclude<LoginErrorCode, "credentials">,
+  Exclude<LoginErrorCode, "account_not_linked" | "credentials">,
   { title: string; detail: string }
 >
 
@@ -60,6 +67,8 @@ export function LoginPageClient({
   )
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isRedirecting, setIsRedirecting] = useState(false)
+  const [pendingSocialSignIn, setPendingSocialSignIn] =
+    useState<PendingSocialSignIn | null>(null)
   const isRedirectingRef = useRef(false)
   const formRef = useRef<HTMLFormElement>(null)
   const lastLoginMethod = useSyncExternalStore(
@@ -67,6 +76,16 @@ export function LoginPageClient({
     readLastLoginMethod,
     getServerLastLoginMethod,
   )
+
+  useEffect(() => {
+    if (initialError !== "account_not_linked") return
+
+    const attempt = readPendingSocialSignIn()
+    if (!attempt) return
+
+    setPendingSocialSignIn(attempt)
+    setEmail((current) => current || attempt.email)
+  }, [initialError])
 
   const alert =
     error === "credentials"
@@ -81,12 +100,18 @@ export function LoginPageClient({
           }
         : error === "lookup"
           ? {
-              title: "We could not check that email.",
-              detail: "Refresh the page and try again.",
+              title: "We could not route this sign-in automatically.",
+              detail:
+                "Try Continue again, or use a sign-in option below if you know which one belongs to this account.",
             }
-          : error
-            ? loginErrors[error]
-            : null
+          : error === "account_not_linked"
+            ? accountNotLinkedError({
+                email,
+                provider: pendingSocialSignIn?.provider,
+              })
+            : error
+              ? loginErrors[error]
+              : null
   const isBusy = isSubmitting || isRedirecting
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
@@ -159,6 +184,11 @@ export function LoginPageClient({
 
   async function startSocialSignIn(providerId: LoginProviderId) {
     setIsSubmitting(true)
+    rememberPendingSocialSignIn({
+      email,
+      provider: providerId,
+    })
+
     try {
       const res = await fetch("/api/auth/sign-in/social", {
         method: "POST",
@@ -182,6 +212,7 @@ export function LoginPageClient({
     } catch {
       setError("start")
     }
+    forgetPendingSocialSignIn()
     isRedirectingRef.current = false
     setIsRedirecting(false)
     setIsSubmitting(false)
@@ -242,36 +273,6 @@ export function LoginPageClient({
                 .
               </p>
             ) : null}
-
-            <div className="mt-5 grid gap-3">
-              {providerIds.map((providerId) => {
-                const enabled = enabledProviders.includes(providerId)
-
-                return (
-                  <button
-                    key={providerId}
-                    className="relative flex h-[46px] w-full cursor-pointer items-center justify-start gap-3 rounded border border-white/10 bg-transparent px-4 text-left font-medium leading-none text-[#f5f5f4] transition-[background-color,border-color,box-shadow] duration-150 hover:border-white/25 hover:bg-white/[0.04] hover:shadow-[0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:border-[#ef3340] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(239,51,64,0.18)] disabled:cursor-not-allowed disabled:border-white/5 disabled:text-[#78716c] disabled:opacity-70"
-                    disabled={!enabled || isBusy}
-                    type="button"
-                    onClick={() => void startSocialSignIn(providerId)}
-                  >
-                    <span className="flex size-5 shrink-0 items-center justify-center leading-none">
-                      <ProviderLogo providerId={providerId} />
-                    </span>
-                    <span className="leading-none">
-                      Continue with {providerLabels[providerId]}
-                    </span>
-                    {lastLoginMethod === providerId ? <LastUsedBadge /> : null}
-                  </button>
-                )
-              })}
-            </div>
-
-            <div className="my-7 flex items-center gap-4 text-xs font-bold uppercase tracking-[0.08em] text-[#a8a29e]">
-              <span className="h-px flex-1 bg-white/10" />
-              <span>OR</span>
-              <span className="h-px flex-1 bg-white/10" />
-            </div>
 
             <form
               ref={formRef}
@@ -356,6 +357,36 @@ export function LoginPageClient({
                 {lastLoginMethod === "email" ? <LastUsedBadge /> : null}
               </button>
             </form>
+
+            <div className="my-7 flex items-center gap-4 text-xs font-bold uppercase tracking-[0.08em] text-[#a8a29e]">
+              <span className="h-px flex-1 bg-white/10" />
+              <span>OR</span>
+              <span className="h-px flex-1 bg-white/10" />
+            </div>
+
+            <div className="grid gap-3">
+              {providerIds.map((providerId) => {
+                const enabled = enabledProviders.includes(providerId)
+
+                return (
+                  <button
+                    key={providerId}
+                    className="relative flex h-[46px] w-full cursor-pointer items-center justify-start gap-3 rounded border border-white/10 bg-transparent px-4 text-left font-medium leading-none text-[#f5f5f4] transition-[background-color,border-color,box-shadow] duration-150 hover:border-white/25 hover:bg-white/[0.04] hover:shadow-[0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:border-[#ef3340] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(239,51,64,0.18)] disabled:cursor-not-allowed disabled:border-white/5 disabled:text-[#78716c] disabled:opacity-70"
+                    disabled={!enabled || isBusy}
+                    type="button"
+                    onClick={() => void startSocialSignIn(providerId)}
+                  >
+                    <span className="flex size-5 shrink-0 items-center justify-center leading-none">
+                      <ProviderLogo providerId={providerId} />
+                    </span>
+                    <span className="leading-none">
+                      Continue with {providerLabels[providerId]}
+                    </span>
+                    {lastLoginMethod === providerId ? <LastUsedBadge /> : null}
+                  </button>
+                )
+              })}
+            </div>
 
             {callbackURL && flow === "login" ? null : (
               <p className="font-noto-serif mb-0 mt-6 text-center text-[13px] leading-5 text-[#a8a29e]">
@@ -494,6 +525,72 @@ function buildModeSwitchHref({
 
   const path = flow === "signup" ? "/login" : "/signup"
   return `${path}${oauthQuery ? `?${oauthQuery}` : ""}` as Route
+}
+
+function accountNotLinkedError({
+  email,
+  provider,
+}: {
+  email: string
+  provider?: LoginProviderId
+}) {
+  if (!provider) {
+    return {
+      title: "Use the login method for this account.",
+      detail:
+        "Enter your email and press Continue. We will send you to the right sign-in method.",
+    }
+  }
+
+  const providerName = providerLabels[provider]
+  const accountTarget = email ? email : "the matching account"
+
+  return {
+    title: `Use the same ${providerName} account.`,
+    detail: `${providerName} did not return the account expected for this sign-in. Try again and choose ${accountTarget} in the ${providerName} account picker.`,
+  }
+}
+
+function rememberPendingSocialSignIn(attempt: PendingSocialSignIn) {
+  if (typeof window === "undefined") return
+
+  window.sessionStorage.setItem(
+    pendingSocialSignInKey,
+    JSON.stringify({
+      email: attempt.email.trim().toLowerCase(),
+      provider: attempt.provider,
+    }),
+  )
+}
+
+function readPendingSocialSignIn(): PendingSocialSignIn | null {
+  if (typeof window === "undefined") return null
+
+  const value = window.sessionStorage.getItem(pendingSocialSignInKey)
+  window.sessionStorage.removeItem(pendingSocialSignInKey)
+  if (!value) return null
+
+  try {
+    const parsed = JSON.parse(value) as {
+      email?: unknown
+      provider?: unknown
+    }
+    const email = typeof parsed.email === "string" ? parsed.email : ""
+    const provider =
+      typeof parsed.provider === "string" && isLoginProviderId(parsed.provider)
+        ? parsed.provider
+        : null
+
+    return provider ? { email, provider } : null
+  } catch {
+    return null
+  }
+}
+
+function forgetPendingSocialSignIn() {
+  if (typeof window === "undefined") return
+
+  window.sessionStorage.removeItem(pendingSocialSignInKey)
 }
 
 function readLastLoginMethod(): LoginMethodId | null {

--- a/apps/auth/src/app/login/login-page-data.ts
+++ b/apps/auth/src/app/login/login-page-data.ts
@@ -40,7 +40,9 @@ export function parseLoginError(
 export function toOAuthQuery(params: LoginSearchParams) {
   const oauthQuery = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
-    if (key === "email" || key === "error") continue
+    if (key === "email" || key === "error" || key === "expected_login_method") {
+      continue
+    }
     if (Array.isArray(value)) {
       for (const item of value) oauthQuery.append(key, item)
     } else if (value) {

--- a/apps/auth/src/app/login/page.ui.test.tsx
+++ b/apps/auth/src/app/login/page.ui.test.tsx
@@ -13,17 +13,19 @@ describe("auth login UI", () => {
     const html = renderToStaticMarkup(
       <LoginPageClient
         enabledProviders={["google"]}
+        initialEmail="user@example.com"
         initialError="account_not_linked"
         oauthQuery="client_id=jfp_admin_local&sig=signed"
         requestingAppName="Jesus Film Admin"
       />,
     )
 
-    expect(html).toContain("This login method is not linked yet.")
-    expect(html).toContain("Log in with the method you used before")
+    expect(html).toContain("Use the login method for this account.")
+    expect(html).toContain("We will send you to the right sign-in method.")
     expect(html).toContain("Continue with Google")
     expect(html).toContain("Email address")
     expect(html).not.toContain("Password")
+    expect(html).toContain('value="user@example.com"')
     expect(html).toContain(
       'name="oauth_query" value="client_id=jfp_admin_local&amp;sig=signed"',
     )
@@ -77,7 +79,7 @@ describe("auth login UI", () => {
     expect(html.match(/disabled=""/g)).toHaveLength(3)
   })
 
-  it("places provider buttons before the email form divider", () => {
+  it("places the email form before direct provider buttons", () => {
     const html = renderToStaticMarkup(
       <LoginPageClient
         enabledProviders={["google"]}
@@ -86,10 +88,10 @@ describe("auth login UI", () => {
       />,
     )
 
-    expect(html.indexOf("Continue with Google")).toBeLessThan(
-      html.indexOf("OR"),
+    expect(html.indexOf("Email address")).toBeLessThan(html.indexOf("OR"))
+    expect(html.indexOf("OR")).toBeLessThan(
+      html.indexOf("Continue with Google"),
     )
-    expect(html.indexOf("OR")).toBeLessThan(html.indexOf("Email address"))
     expect(html).not.toContain("Password")
     expect(html).not.toContain('name="password"')
     expect(html).not.toContain('autoComplete="current-password"')
@@ -111,6 +113,7 @@ describe("auth login UI", () => {
         client_id: "jfp_admin_local",
         email: "user@example.com",
         error: "credentials",
+        expected_login_method: "google",
         sig: "signed",
       }),
     ).toBe("client_id=jfp_admin_local&sig=signed")


### PR DESCRIPTION
## Summary

Admin OAuth login failures now return users to the same signed login request instead of dropping them back at a generic login page. The login page starts from email first, routes known provider accounts through their configured provider, and keeps direct provider buttons available as a fallback.

## What Changed

- Preserve OAuth authorize params on social sign-in failures by passing `errorCallbackURL` and stripping login-only hints before Better Auth sees the body.
- Store pending provider attempts in session storage so `account_not_linked` can explain mismatched provider/account picker cases without leaking email or provider hints into URLs.
- Move the login form above provider buttons and update admin no-access copy to distinguish signed-in/no-approved-admin-access from wrong-login-method confusion.
- Add UI and route tests covering provider-failure redirects, sanitized OAuth query params, email-first ordering, and admin forced-login URLs.

## Testing

- `pnpm --filter @forge/auth test -- 'src/app/api/auth/[...all]/route.test.ts' src/app/login/page.ui.test.tsx`
- `pnpm --filter @forge/admin test -- src/app/access-request/page.ui.test.tsx`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
