### PR TITLE
fix(admin): rekey seed-web-fixtures to VideoLocale (videoId, languageId) identity

### DIFF
--- a/apps/admin/src/scripts/seed-web-fixtures.test.ts
+++ b/apps/admin/src/scripts/seed-web-fixtures.test.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path"
 import { describe, expect, it, beforeEach } from "vitest"
 import {
   assertNotProdUrl,
+  DuplicateLanguageCoreIdError,
   loadFixtures,
   seedWebFixtures,
   UnknownLanguageCoreIdError,
@@ -352,6 +353,62 @@ describe("seedWebFixtures", () => {
     await expect(seedWebFixtures(prisma, fixtures)).rejects.toThrow(
       /not-a-real-core-id/,
     )
+  })
+
+  it("throws DuplicateLanguageCoreIdError when one video lists the same languageCoreId twice", async () => {
+    const prisma = makePrisma()
+    const fixtures: WebFixtures = {
+      ...FIXTURES,
+      videos: [
+        {
+          coreId: "fixt-dup-lang",
+          slug: "fixt-dup-lang",
+          label: "SHORT_FILM",
+          publishedAt: "2026-01-07T00:00:00.000Z",
+          locales: [
+            {
+              languageCoreId: "529",
+              title: "First English Entry",
+              description: "First entry.",
+            },
+            {
+              languageCoreId: "529",
+              title: "Second English Entry",
+              description: "Would silently overwrite the first.",
+            },
+          ],
+        },
+      ],
+    }
+    await expect(seedWebFixtures(prisma, fixtures)).rejects.toThrow(
+      DuplicateLanguageCoreIdError,
+    )
+  })
+
+  it("refreshes derived columns on rerun when a fixture language changes (update branch)", async () => {
+    const prisma = makePrisma()
+    await seedWebFixtures(prisma, FIXTURES)
+
+    // Simulate a fixture edit between runs: the English language's slug and
+    // bcp47 change. The rerun must push the new derived values onto the
+    // EXISTING videoLocale rows via the upsert's update branch — stale
+    // derived columns on pre-seeded DBs are an idempotence divergence the
+    // count-based test above cannot see.
+    const english = FIXTURES.languages.find((l) => l.coreId === "529")
+    expect(english).toBeDefined()
+    if (!english) return
+    english.slug = "english-us"
+    english.bcp47 = "en-US"
+    await seedWebFixtures(prisma, FIXTURES)
+
+    const englishRows = [...prisma.videoLocale.store.values()].filter(
+      (r) => r.languageCoreId === "529",
+    )
+    expect(englishRows.length).toBeGreaterThan(0)
+    for (const row of englishRows) {
+      expect(row.languageSlug).toBe("english-us")
+      expect(row.locale).toBe("en-US")
+    }
   })
 
   it("seeds at least one Video reachable via slug (videoBySlug coverage)", async () => {

--- a/apps/admin/src/scripts/seed-web-fixtures.test.ts
+++ b/apps/admin/src/scripts/seed-web-fixtures.test.ts
@@ -4,16 +4,18 @@ import {
   assertNotProdUrl,
   loadFixtures,
   seedWebFixtures,
+  UnknownLanguageCoreIdError,
   type WebFixtures,
 } from "./seed-web-fixtures"
 
 // ---------------------------------------------------------------------------
 // In-memory Prisma fake. Models the unique-key behavior the seed relies
 // on (`coreId` UNIQUE on Language/Country/Keyword/Video;
-// `(videoId, locale)` UNIQUE on VideoLocale; `(parentId, childId)`
-// UNIQUE on VideoRelation; `(experienceId, locale)` UNIQUE on
-// ExperienceLocale). Insufficient for full Prisma semantics but
-// exercises the seed's idempotence + coverage contracts.
+// `(videoId, languageId)` UNIQUE on VideoLocale — the post-0026/0027
+// Language-FK identity; `(parentId, childId)` UNIQUE on VideoRelation;
+// `(experienceId, locale)` UNIQUE on ExperienceLocale). Insufficient for
+// full Prisma semantics but exercises the seed's idempotence + coverage
+// contracts.
 // ---------------------------------------------------------------------------
 
 type Row = Record<string, unknown>
@@ -92,9 +94,9 @@ function makePrisma() {
   const video = makeKeyedTable<"coreId">((r) =>
     JSON.stringify({ coreId: r.coreId }),
   )
-  const videoLocale = makeKeyedTable<"videoId_locale">((r) =>
+  const videoLocale = makeKeyedTable<"videoId_languageId">((r) =>
     JSON.stringify({
-      videoId_locale: { videoId: r.videoId, locale: r.locale },
+      videoId_languageId: { videoId: r.videoId, languageId: r.languageId },
     }),
   )
   const videoRelation = makeKeyedTable<"parentId_childId">((r) =>
@@ -296,6 +298,60 @@ describe("seedWebFixtures", () => {
       experienceLocales: prisma.experienceLocale.store.size,
     }
     expect(second).toEqual(first)
+  })
+
+  // Contract assertions (mocked-shape-vs-real-contract remedy): the fake's
+  // storage key proves the upsert SHAPE; these prove the stored rows carry
+  // the derived columns the real read path filters on (`videoLocalesFilter`
+  // orders/filters by `languageSlug`).
+  it("stores videoLocale rows with a resolved languageId + derived locale/languageSlug/languageCoreId", async () => {
+    const prisma = makePrisma()
+    await seedWebFixtures(prisma, FIXTURES)
+
+    const languagesByCoreId = new Map(
+      [...prisma.language.store.values()].map((l) => [l.coreId as string, l]),
+    )
+    const rows = [...prisma.videoLocale.store.values()]
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(row.languageId).toBeTruthy()
+      expect(row.languageSlug).toBeTruthy()
+      expect(row.languageCoreId).toBeTruthy()
+      const lang = languagesByCoreId.get(row.languageCoreId as string)
+      expect(lang).toBeDefined()
+      expect(row.languageId).toBe(lang?.id)
+      expect(row.locale).toBe(lang?.bcp47)
+      expect(row.languageSlug).toBe(lang?.slug)
+    }
+  })
+
+  it("throws UnknownLanguageCoreIdError when a video locale references an unknown languageCoreId", async () => {
+    const prisma = makePrisma()
+    const fixtures: WebFixtures = {
+      ...FIXTURES,
+      videos: [
+        {
+          coreId: "fixt-bad-lang",
+          slug: "fixt-bad-lang",
+          label: "SHORT_FILM",
+          publishedAt: "2026-01-06T00:00:00.000Z",
+          locales: [
+            {
+              languageCoreId: "not-a-real-core-id",
+              title: "Bad Language",
+              description:
+                "References a languageCoreId outside the fixture set.",
+            },
+          ],
+        },
+      ],
+    }
+    await expect(seedWebFixtures(prisma, fixtures)).rejects.toThrow(
+      UnknownLanguageCoreIdError,
+    )
+    await expect(seedWebFixtures(prisma, fixtures)).rejects.toThrow(
+      /not-a-real-core-id/,
+    )
   })
 
   it("seeds at least one Video reachable via slug (videoBySlug coverage)", async () => {

--- a/apps/admin/src/scripts/seed-web-fixtures.ts
+++ b/apps/admin/src/scripts/seed-web-fixtures.ts
@@ -37,6 +37,12 @@
 import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { dirname, resolve } from "node:path"
+// Type-only import — erased at runtime, so the PrismaLike seam below still
+// accepts the test fake. The `satisfies` checks on the videoLocale upsert
+// payloads keep the literals aligned with the GENERATED client types, so an
+// identity-migration rename (the bug class this script was broken by) fails
+// `tsc` instead of failing at runtime against a real DB.
+import type { Prisma } from "@prisma/client"
 
 // ---------------------------------------------------------------------------
 // Prod-URL guard — fail-closed.
@@ -173,6 +179,26 @@ export class UnknownLanguageCoreIdError extends Error {
   }
 }
 
+/**
+ * Two locale entries on one video fixture resolve to the same language.
+ * Under the `(videoId, languageId)` identity the second entry would silently
+ * UPDATE the first (one row in the DB, two counted in the summary) — fail
+ * fast on the authoring bug instead.
+ */
+export class DuplicateLanguageCoreIdError extends Error {
+  constructor(
+    readonly languageCoreId: string,
+    readonly videoCoreId: string,
+  ) {
+    super(
+      `[seed-web-fixtures] Video fixture "${videoCoreId}" lists ` +
+        `languageCoreId "${languageCoreId}" more than once. Each video ` +
+        `locale must reference a distinct language.`,
+    )
+    this.name = "DuplicateLanguageCoreIdError"
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Seeding — exposed for tests.
 //
@@ -282,7 +308,12 @@ export async function seedWebFixtures(
     videoIdByCoreId.set(v.coreId, video.id)
     summary.videos += 1
 
+    const seenLanguageCoreIds = new Set<string>()
     for (const loc of v.locales) {
+      if (seenLanguageCoreIds.has(loc.languageCoreId)) {
+        throw new DuplicateLanguageCoreIdError(loc.languageCoreId, v.coreId)
+      }
+      seenLanguageCoreIds.add(loc.languageCoreId)
       const lang = languageByCoreId.get(loc.languageCoreId)
       if (!lang) {
         throw new UnknownLanguageCoreIdError(loc.languageCoreId, v.coreId)
@@ -290,7 +321,17 @@ export async function seedWebFixtures(
       // `locale` / `languageSlug` / `languageCoreId` are derived from the
       // resolved Language row (core-sync's `toVideoLocales` convention) —
       // `videoLocalesFilter` filters and orders by `languageSlug`, so rows
-      // missing it would vanish from languageSlug-filtered queries.
+      // missing it would vanish from languageSlug-filtered queries. One
+      // shared payload feeds both upsert branches so they cannot drift.
+      const localePayload = {
+        locale: lang.bcp47,
+        languageSlug: lang.slug,
+        languageCoreId: lang.coreId,
+        title: loc.title,
+        description: loc.description,
+        status: "PUBLISHED",
+        publishedAt: new Date(v.publishedAt),
+      } satisfies Prisma.VideoLocaleUncheckedUpdateInput
       // NOTE: `languageId` must be explicit in `create` — Prisma's upsert
       // `create` does NOT inherit fields from the compound `where`, and a
       // NULL languageId row would break idempotence (Postgres treats NULLs
@@ -298,27 +339,13 @@ export async function seedWebFixtures(
       await prisma.videoLocale.upsert({
         where: {
           videoId_languageId: { videoId: video.id, languageId: lang.id },
-        },
+        } satisfies Prisma.VideoLocaleWhereUniqueInput,
         create: {
           videoId: video.id,
           languageId: lang.id,
-          locale: lang.bcp47,
-          languageSlug: lang.slug,
-          languageCoreId: lang.coreId,
-          title: loc.title,
-          description: loc.description,
-          status: "PUBLISHED",
-          publishedAt: new Date(v.publishedAt),
-        },
-        update: {
-          locale: lang.bcp47,
-          languageSlug: lang.slug,
-          languageCoreId: lang.coreId,
-          title: loc.title,
-          description: loc.description,
-          status: "PUBLISHED",
-          publishedAt: new Date(v.publishedAt),
-        },
+          ...localePayload,
+        } satisfies Prisma.VideoLocaleUncheckedCreateInput,
+        update: localePayload,
       })
       summary.videoLocales += 1
     }

--- a/apps/admin/src/scripts/seed-web-fixtures.ts
+++ b/apps/admin/src/scripts/seed-web-fixtures.ts
@@ -10,7 +10,13 @@
  * Idempotent: rerun against the same DB produces no duplicates.
  *  - Reference rows keyed by `coreId` (UNIQUE in schema).
  *  - Videos keyed by `coreId` (UNIQUE) → upsert by coreId.
- *  - VideoLocale keyed by `(videoId, locale)` (UNIQUE).
+ *  - VideoLocale keyed by `(videoId, languageId)` (UNIQUE since migration
+ *    0027 dropped the old `(videoId, locale)` key). Fixtures reference the
+ *    language by `languageCoreId`; `locale` / `languageSlug` /
+ *    `languageCoreId` are derived from the resolved Language row, mirroring
+ *    core-sync's `toVideoLocales` convention. Reruns against DBs seeded
+ *    before 0026 still converge: 0026's backfill populated `language_id`
+ *    from the bcp47 join, so legacy fixture rows match the new upsert key.
  *  - VideoRelation keyed by `(parentId, childId)` (UNIQUE).
  *  - Experiences keyed by the FIRST locale's `(slug, locale)` — that
  *    pair uniquely identifies a fixture experience and lets a rerun
@@ -100,7 +106,7 @@ type KeywordFixture = {
 }
 
 type VideoLocaleFixture = {
-  locale: string
+  languageCoreId: string
   title: string
   description: string
 }
@@ -148,6 +154,25 @@ export type SeedSummary = {
   experienceLocales: number
 }
 
+/**
+ * A video-locale fixture references a `languageCoreId` that has no matching
+ * entry in the fixture `languages` array. Fixtures are a closed set, so a
+ * miss is a fixture-authoring bug — fail fast rather than skip.
+ */
+export class UnknownLanguageCoreIdError extends Error {
+  constructor(
+    readonly languageCoreId: string,
+    readonly videoCoreId: string,
+  ) {
+    super(
+      `[seed-web-fixtures] Video fixture "${videoCoreId}" references ` +
+        `languageCoreId "${languageCoreId}", which is not in the fixture ` +
+        `languages array. Add the language to web-fixtures.json.`,
+    )
+    this.name = "UnknownLanguageCoreIdError"
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Seeding — exposed for tests.
 //
@@ -182,8 +207,15 @@ export async function seedWebFixtures(
   }
 
   // ── Languages ──────────────────────────────────────────────────────
+  // Keyed by coreId (UNIQUE in schema — no dup-check needed). VideoLocale
+  // seeding below resolves languages from this map to derive the
+  // `locale` / `languageSlug` / `languageCoreId` columns.
+  const languageByCoreId = new Map<
+    string,
+    { id: string; coreId: string; bcp47: string; slug: string }
+  >()
   for (const lang of fixtures.languages) {
-    await prisma.language.upsert({
+    const row = await prisma.language.upsert({
       where: { coreId: lang.coreId },
       create: {
         coreId: lang.coreId,
@@ -198,6 +230,12 @@ export async function seedWebFixtures(
         slug: lang.slug,
         name: lang.name,
       },
+    })
+    languageByCoreId.set(lang.coreId, {
+      id: row.id,
+      coreId: lang.coreId,
+      bcp47: lang.bcp47,
+      slug: lang.slug,
     })
     summary.languages += 1
   }
@@ -245,17 +283,37 @@ export async function seedWebFixtures(
     summary.videos += 1
 
     for (const loc of v.locales) {
+      const lang = languageByCoreId.get(loc.languageCoreId)
+      if (!lang) {
+        throw new UnknownLanguageCoreIdError(loc.languageCoreId, v.coreId)
+      }
+      // `locale` / `languageSlug` / `languageCoreId` are derived from the
+      // resolved Language row (core-sync's `toVideoLocales` convention) —
+      // `videoLocalesFilter` filters and orders by `languageSlug`, so rows
+      // missing it would vanish from languageSlug-filtered queries.
+      // NOTE: `languageId` must be explicit in `create` — Prisma's upsert
+      // `create` does NOT inherit fields from the compound `where`, and a
+      // NULL languageId row would break idempotence (Postgres treats NULLs
+      // as distinct in unique indexes).
       await prisma.videoLocale.upsert({
-        where: { videoId_locale: { videoId: video.id, locale: loc.locale } },
+        where: {
+          videoId_languageId: { videoId: video.id, languageId: lang.id },
+        },
         create: {
           videoId: video.id,
-          locale: loc.locale,
+          languageId: lang.id,
+          locale: lang.bcp47,
+          languageSlug: lang.slug,
+          languageCoreId: lang.coreId,
           title: loc.title,
           description: loc.description,
           status: "PUBLISHED",
           publishedAt: new Date(v.publishedAt),
         },
         update: {
+          locale: lang.bcp47,
+          languageSlug: lang.slug,
+          languageCoreId: lang.coreId,
           title: loc.title,
           description: loc.description,
           status: "PUBLISHED",

--- a/apps/admin/src/scripts/web-fixtures.json
+++ b/apps/admin/src/scripts/web-fixtures.json
@@ -53,12 +53,12 @@
       "publishedAt": "2026-01-01T00:00:00.000Z",
       "locales": [
         {
-          "locale": "en",
+          "languageCoreId": "529",
           "title": "The Jesus Collection",
           "description": "An overview of the life of Jesus."
         },
         {
-          "locale": "es",
+          "languageCoreId": "496",
           "title": "La Colección de Jesús",
           "description": "Una visión general de la vida de Jesús."
         }
@@ -71,12 +71,12 @@
       "publishedAt": "2026-01-02T00:00:00.000Z",
       "locales": [
         {
-          "locale": "en",
+          "languageCoreId": "529",
           "title": "Jesus Feature Film",
           "description": "The feature-length film about the life of Jesus."
         },
         {
-          "locale": "es",
+          "languageCoreId": "496",
           "title": "Película Jesús",
           "description": "La película sobre la vida de Jesús."
         }
@@ -90,7 +90,7 @@
       "publishedAt": "2026-01-03T00:00:00.000Z",
       "locales": [
         {
-          "locale": "en",
+          "languageCoreId": "529",
           "title": "Jesus Trailer",
           "description": "Trailer for the Jesus feature film."
         }
@@ -104,12 +104,12 @@
       "publishedAt": "2026-01-04T00:00:00.000Z",
       "locales": [
         {
-          "locale": "en",
+          "languageCoreId": "529",
           "title": "Easter Explained",
           "description": "What Easter really means."
         },
         {
-          "locale": "fr",
+          "languageCoreId": "21028",
           "title": "Pâques Expliqué",
           "description": "Ce que Pâques signifie vraiment."
         }
@@ -122,7 +122,7 @@
       "publishedAt": "2026-01-05T00:00:00.000Z",
       "locales": [
         {
-          "locale": "en",
+          "languageCoreId": "529",
           "title": "My Last Day",
           "description": "The final hours of Jesus' life from a criminal's point of view."
         }


### PR DESCRIPTION
## Problem

`pnpm --filter @forge/admin seed-web-fixtures` crashes on any database migrated to the current schema:

```
Unknown argument `videoId_locale`.
    at async seedWebFixtures (apps/admin/src/scripts/seed-web-fixtures.ts:248)
```

Migrations `0026_video_locale_language_identity` and `0027_video_localized_language_slug_identity` (PR #1089) reworked `VideoLocale` identity from a BCP-47 locale string to a Language FK: the unique key is now `@@unique([videoId, languageId])`, `0027` explicitly dropped `video_locale_video_id_locale_key`, and the generated Prisma client only exposes the `videoId_languageId` compound key. The seed script (last touched in PR #941, pre-migration) still upserted by `videoId_locale`. The colocated test didn't catch it because its in-memory Prisma fake hard-coded `videoId_locale` as its storage key — the mock certified the retired contract (the repo's mocked-shape-vs-real-contract trap).

## Fix

- **`web-fixtures.json`** — video-locale entries reference languages by `languageCoreId` (en→529, es→496, fr→21028, matching the fixture `languages` array). Experience locale entries keep `locale` — that model's identity genuinely still is `(experienceId, locale)` and is intentionally untouched.
- **`seed-web-fixtures.ts`** — mirrors core-sync's convention (`core-sync/video-localized-metadata.ts` resolves by language coreId, never bcp47, since `Language.bcp47` is nullable and non-unique):
  - Resolves each fixture language into a coreId-keyed map during the languages pass.
  - Upserts by `videoId_languageId`, with `languageId` **explicitly in the `create` payload** — Prisma's upsert `create` does not inherit fields from the compound `where`; omitting it would create a NULL-languageId row and break idempotence (Postgres treats NULLs as distinct in unique indexes).
  - Derives `locale` (bcp47), `languageSlug`, and `languageCoreId` from the resolved language in both `create` and `update` — `videoLocalesFilter` / `videoStudyQuestionsFilter` filter and order by `languageSlug`, so rows missing it would vanish from languageSlug-filtered variant queries.
  - Unknown `languageCoreId` throws the typed `UnknownLanguageCoreIdError` (fixtures are a closed set; a miss is a fixture-authoring bug).
  - Header comment updated, including a note on rerun-convergence against pre-0026-seeded DBs (0026's backfill populated `language_id` from the bcp47 join, so legacy fixture rows match the new upsert key).
- **`seed-web-fixtures.test.ts`** — rekeyed the fake's storage key to `videoId_languageId` **and** hardened the contract so the mock can't certify a retired contract again:
  - Every stored videoLocale row asserts non-null `languageId` / `languageSlug` / `languageCoreId`, `locale === <resolved language>.bcp47`, and `languageSlug === <resolved language>.slug` (resolved via the language store).
  - A throw-test for an unknown `languageCoreId` rejecting with the typed error.

No schema changes, no migration changes, no core-sync changes.

## Validation

- **Unit tests:** `pnpm --filter @forge/admin test -- seed-web-fixtures` — 21/21 green.
- **Typecheck + lint:** both clean.
- **Real-DB seed** (local Postgres `db:5432/forge_admin`, migrations through 0028 applied):
  - First run: clean `seed-web-fixtures.complete` with `videoLocales: 8` (= fixture locale total).
  - SQL checks: 8 `video_locale` rows for the fixture videos; zero NULL `language_id` / `language_slug` / `language_core_id`; `locale` matches the resolved language's bcp47 and `language_slug` its slug on every row; zero duplicates per `(video_id, language_id)`.
  - Second run: identical summary, still exactly 8 rows (idempotent).
- **Local admin + web smoke:**
  - Admin GraphQL: `videoBySlug(slug: "jesus-feature-film")` returns both seeded locales with titles, and `locales(languageSlug: "english")` returns exactly the en row — the read path NULL `languageSlug` would have broken.
  - Web homepage (`/watch`) renders from the seeded homepage Experience (`Watch — Jesus Film`, hero subheading present).
  - **Honest caveat:** the two-segment video page (`/watch/jesus-feature-film.html/english.html`) does not render locally — after regenerating the watch-route manifest it 404s at the manifest admission gate because the fixtures seed no `video_dub` rows, so `audioLanguageSlugs` is empty. That's a pre-existing fixture-data limitation orthogonal to this fix (the manifest's `audioLanguageSlugs` derive from `video_dub`→`language`, and its `video_locale` joins gate only on status/deleted_at — which the seeded rows pass where applicable: `contentSlugs` carries the parent fixture videos (`jesus-collection`, `jesus-feature-film`) plus the three one-segment experience slugs; non-parent videos are absent because playability also derives from dubs). Extending fixtures with dubs is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

