### PR TITLE
fix(admin): harden core sync video pool handling

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -12,9 +12,11 @@
 # Unit 2 — Prisma / Postgres
 # Main pool: connection_limit=10 + pool_timeout=20
 DATABASE_URL=postgresql://forge:forge@localhost:5432/forge_admin?connection_limit=10&pool_timeout=20
-# Optional dedicated pool for Core sync workflow (connection_limit=2).
+# Optional dedicated pool for Core sync workflow.
+# Production starting point: connection_limit=5 + pool_timeout=60, tuned
+# against total Postgres capacity and active admin/web/worker replicas.
 # Falls back to DATABASE_URL if unset.
-DATABASE_URL_SYNC=postgresql://forge:forge@localhost:5432/forge_admin?connection_limit=2&pool_timeout=20
+DATABASE_URL_SYNC=postgresql://forge:forge@localhost:5432/forge_admin?connection_limit=5&pool_timeout=60
 
 # Workflow runtime
 # Local development can omit this to use the bundled local world.

--- a/apps/admin/docs/core-sync-recurring-job.md
+++ b/apps/admin/docs/core-sync-recurring-job.md
@@ -7,8 +7,11 @@ calls `runSync(syncPrisma, ...)`.
 ## Required Env
 
 - `DATABASE_URL` - admin app database.
-- `DATABASE_URL_SYNC` - dedicated Prisma pool for Core Sync. Use a small pool,
-  for example `connection_limit=2`.
+- `DATABASE_URL_SYNC` - dedicated Prisma pool for Core Sync. Production should
+  not reuse the failed tiny full-sync posture (`connection_limit=2` with a
+  short acquire timeout). Start around `connection_limit=5&pool_timeout=60`,
+  then tune against total Postgres capacity, admin web replica count, workflow
+  runtime pool usage, and expected operator access.
 - `WORKFLOW_TARGET_WORLD` - set to `@workflow/world-postgres` in Railway.
 - `WORKFLOW_RUNNER_ENABLED` - set to `true` only on the dedicated admin worker
   service that should execute Postgres World jobs. Leave unset or `false` on
@@ -80,6 +83,26 @@ calls `runSync(syncPrisma, ...)`.
 9. Confirm `/dashboard/workflows` lists Postgres World runtime rows.
 10. Open `/dashboard/workflows/<runId>` for a recent run and confirm the
     embedded `@workflow/web-shared` trace/detail view shows runtime events.
+
+## Full-Sync Pool Resilience Notes
+
+Before rerunning a production full sync after a pool-timeout incident, verify
+the worker's effective sync URL shape without printing the URL or credentials.
+Record only the sanitized facts operators need:
+
+- whether `DATABASE_URL_SYNC` is set on the worker service,
+- the sync `connection_limit`,
+- the sync `pool_timeout`,
+- worker process count and `WORKFLOW_POSTGRES_WORKER_CONCURRENCY`,
+- admin web replica count and main `DATABASE_URL` pool size,
+- and the remaining database connection headroom.
+
+The `videos` phase is the longest Core-owned write phase. During a full run,
+watch for `core-sync.phase.progress` and `prisma_pool_retry` signals in logs
+and for workflow ledger progress on `/dashboard/workflows` when the run was
+dispatched through the workflow endpoint. Do not continue to all-content
+embedding replacement until the Core Sync run succeeds, the video-phase
+watermarks are fresh, the lock is clear, and the coverage audit passes.
 
 ## Local Benchmark Plan
 

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -46,8 +46,9 @@ export const env = createEnv({
     // Unit 2 — Prisma / Postgres
     //
     // DATABASE_URL: main pool. Recommend `?connection_limit=10&pool_timeout=20`.
-    // DATABASE_URL_SYNC: dedicated pool for Core sync workflow at
-    // `?connection_limit=2` — see src/db/client.ts.
+    // DATABASE_URL_SYNC: dedicated pool for Core sync workflow. Production
+    // should start around `?connection_limit=5&pool_timeout=60`, then tune
+    // against total Postgres capacity — see src/db/client.ts.
     DATABASE_URL: z.string().url(),
     DATABASE_URL_SYNC: z.string().url().optional(),
     ADMIN_SESSION_SECRET: z.string().min(32),

--- a/apps/admin/src/db/client.ts
+++ b/apps/admin/src/db/client.ts
@@ -4,8 +4,9 @@
 //   - `prisma`       — the main client for GraphQL + mutations
 //                      (connection_limit=10, pool_timeout=20 via DATABASE_URL)
 //   - `syncPrisma`   — dedicated client for Core sync background workflow
-//                      (connection_limit=2 via DATABASE_URL_SYNC) so sync
-//                      cannot starve read traffic.
+//                      (for production, start around connection_limit=5 and
+//                      pool_timeout=60 via DATABASE_URL_SYNC) so sync cannot
+//                      starve read traffic.
 //
 // Both use the Next.js HMR-safe singleton pattern: dev reloads reuse the
 // existing client from `globalThis` instead of spawning new pools.
@@ -94,9 +95,10 @@ export const prisma =
   })
 
 /**
- * Dedicated Prisma client for Core sync background workflow.
- * Isolated pool (`DATABASE_URL_SYNC` with `?connection_limit=2`) so a stalled
- * sync transaction cannot starve connections from the main pool.
+ * Dedicated Prisma client for Core sync background workflow. Production should
+ * use an isolated `DATABASE_URL_SYNC` pool sized against total Postgres
+ * capacity; a conservative starting point is
+ * `?connection_limit=5&pool_timeout=60`.
  */
 export const syncPrisma =
   globalForPrisma.syncPrisma ??

--- a/apps/admin/src/scripts/run-core-sync.ts
+++ b/apps/admin/src/scripts/run-core-sync.ts
@@ -1,5 +1,5 @@
 import { syncPrisma } from "@/db/client"
-import { runSync } from "@/services/core-sync/orchestrator"
+import { runSync, type RunSyncOptions } from "@/services/core-sync/orchestrator"
 
 function parseArgs(argv: string[]) {
   const full = argv.includes("--full")
@@ -21,7 +21,10 @@ function parseArgs(argv: string[]) {
 async function main() {
   const options = parseArgs(process.argv.slice(2))
   const startedAt = Date.now()
-  const result = await runSync(syncPrisma, options)
+  const result = await runSync(syncPrisma, {
+    ...options,
+    onProgress: logProgress,
+  })
 
   console.log(
     JSON.stringify(
@@ -32,6 +35,12 @@ async function main() {
       null,
       2,
     ),
+  )
+}
+
+const logProgress: NonNullable<RunSyncOptions["onProgress"]> = (progress) => {
+  console.log(
+    `[core-sync] event=core-sync.phase.progress phase=${progress.phase} completed=${progress.completed} total=${progress.total} elapsedMs=${progress.elapsedMs}`,
   )
 }
 

--- a/apps/admin/src/scripts/run-sync.ts
+++ b/apps/admin/src/scripts/run-sync.ts
@@ -21,7 +21,7 @@
  */
 
 import { PrismaClient } from "@prisma/client"
-import { runSync } from "@/services/core-sync/orchestrator"
+import { runSync, type RunSyncOptions } from "@/services/core-sync/orchestrator"
 
 function parseArg(name: string, fallback: string): string {
   const flag = `--${name}=`
@@ -61,7 +61,11 @@ async function main(): Promise<void> {
   const startedAt = Date.now()
 
   try {
-    const result = await runSync(prisma, { scope, incremental })
+    const result = await runSync(prisma, {
+      scope,
+      incremental,
+      onProgress: logProgress,
+    })
 
     const phasesSummary = result.phases.map((p) => ({
       phase: p.phase,
@@ -91,6 +95,12 @@ async function main(): Promise<void> {
   } finally {
     await prisma.$disconnect()
   }
+}
+
+const logProgress: NonNullable<RunSyncOptions["onProgress"]> = (progress) => {
+  console.log(
+    `[core-sync] event=core-sync.phase.progress phase=${progress.phase} completed=${progress.completed} total=${progress.total} elapsedMs=${progress.elapsedMs}`,
+  )
 }
 
 main().catch((err) => {

--- a/apps/admin/src/services/core-sync/job.test.ts
+++ b/apps/admin/src/services/core-sync/job.test.ts
@@ -6,12 +6,14 @@ import { runCoreSync } from "@/workflows/coreSync"
 
 const syncPrisma = vi.hoisted(() => ({ name: "sync-prisma" }))
 const runSync = vi.hoisted(() => vi.fn())
+const runSyncPhase = vi.hoisted(() => vi.fn())
 const start = vi.hoisted(() => vi.fn())
 const workflowRunLog = vi.hoisted(() => ({
   createWorkflowRunLog: vi.fn(),
   attachWorkflowRuntimeRunId: vi.fn(),
   markWorkflowRunFailed: vi.fn(),
   markWorkflowRunStarted: vi.fn(),
+  recordCoreSyncPhaseProgress: vi.fn(),
   recordCoreSyncRunResult: vi.fn(),
 }))
 
@@ -24,6 +26,7 @@ vi.mock("@/services/core-sync/orchestrator", async (importOriginal) => {
   return {
     ...actual,
     runSync,
+    runSyncPhase,
   }
 })
 
@@ -36,6 +39,7 @@ describe("core sync job", () => {
     workflowRunLog.attachWorkflowRuntimeRunId.mockResolvedValue(undefined)
     workflowRunLog.markWorkflowRunFailed.mockResolvedValue(undefined)
     workflowRunLog.markWorkflowRunStarted.mockResolvedValue(undefined)
+    workflowRunLog.recordCoreSyncPhaseProgress.mockResolvedValue(undefined)
     workflowRunLog.recordCoreSyncRunResult.mockResolvedValue(undefined)
   })
 
@@ -226,5 +230,61 @@ describe("core sync job", () => {
       coverageAudit,
       trigger: "manual",
     })
+  })
+
+  it("records ledger progress for workflow phase jobs", async () => {
+    const phaseResult = {
+      phase: "videos",
+      created: 0,
+      updated: 25,
+      softDeleted: 0,
+      errors: 0,
+      durationMs: 100,
+    }
+    runSyncPhase.mockImplementationOnce(async (_prisma, _run, _phase, opts) => {
+      opts.onProgress({
+        phase: "videos",
+        completed: 25,
+        total: 50,
+        elapsedMs: 75,
+      })
+      return phaseResult
+    })
+    const { runCoreSyncPhaseJob } = await import("./job")
+
+    await expect(
+      runCoreSyncPhaseJob(
+        {
+          skipped: false,
+          run: {
+            runId: "sync-run-1",
+            incremental: true,
+            phasesToRun: ["videos"],
+            startedAtMs: Date.now(),
+          },
+          scope: ["videos"],
+          incremental: true,
+          trigger: "scheduled",
+          ledgerRunId: "ledger-run-1",
+        },
+        "videos",
+      ),
+    ).resolves.toEqual(phaseResult)
+
+    expect(runSyncPhase).toHaveBeenCalledWith(
+      syncPrisma as unknown as PrismaClient,
+      expect.objectContaining({ runId: "sync-run-1" }),
+      "videos",
+      expect.objectContaining({ onProgress: expect.any(Function) }),
+    )
+    expect(workflowRunLog.recordCoreSyncPhaseProgress).toHaveBeenCalledWith(
+      "ledger-run-1",
+      {
+        phase: "videos",
+        completed: 25,
+        total: 50,
+        elapsedMs: 75,
+      },
+    )
   })
 })

--- a/apps/admin/src/services/core-sync/job.ts
+++ b/apps/admin/src/services/core-sync/job.ts
@@ -17,6 +17,7 @@ import {
   createWorkflowRunLog,
   markWorkflowRunFailed,
   markWorkflowRunStarted,
+  recordCoreSyncPhaseProgress,
   recordCoreSyncRunResult,
 } from "@/services/workflow-run-log.service"
 import { runCoreSync } from "@/workflows/coreSync"
@@ -184,7 +185,18 @@ export async function runCoreSyncPhaseJob(
   start: Exclude<CoreSyncJobStart, { skipped: true }>,
   phase: SyncPhase,
 ): Promise<PhaseResult> {
-  return runSyncPhase(syncPrisma, start.run, phase)
+  return runSyncPhase(syncPrisma, start.run, phase, {
+    onProgress: start.ledgerRunId
+      ? (progress) => {
+          console.log(
+            `[core-sync] event=core-sync.phase.progress phase=${progress.phase} completed=${progress.completed} total=${progress.total} elapsedMs=${progress.elapsedMs}`,
+          )
+          void recordCoreSyncPhaseProgress(start.ledgerRunId!, progress).catch(
+            () => {},
+          )
+        }
+      : undefined,
+  })
 }
 
 export async function finishCoreSyncJob(

--- a/apps/admin/src/services/core-sync/orchestrator.test.ts
+++ b/apps/admin/src/services/core-sync/orchestrator.test.ts
@@ -238,4 +238,52 @@ describe("runSync", () => {
     )
     expect(result.phases[0].errors).toBe(1)
   })
+
+  it("reports throttled phase progress while a phase runs", async () => {
+    const { refreshSyncLock } = await import("./lock")
+    const { getWatermark, advanceWatermark } = await import("./watermark")
+    const { syncVideos } = await import("./phases/sync-videos")
+
+    ;(refreshSyncLock as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true)
+    ;(getWatermark as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null)
+    ;(syncVideos as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async ({ progress }) => {
+        progress.setTotal(50)
+        progress.increment(25)
+        return {
+          created: 0,
+          updated: 25,
+          softDeleted: 0,
+          errors: 0,
+        }
+      },
+    )
+
+    const mockPrisma = {
+      $executeRawUnsafe: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Parameters<typeof import("./orchestrator").runSyncPhase>[0]
+    const onProgress = vi.fn()
+
+    const { runSyncPhase } = await import("./orchestrator")
+    await runSyncPhase(
+      mockPrisma,
+      {
+        runId: "sync-run-1",
+        incremental: true,
+        phasesToRun: ["videos"],
+        startedAtMs: Date.now(),
+      },
+      "videos",
+      { onProgress },
+    )
+
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "videos",
+        completed: 0,
+        total: 50,
+      }),
+    )
+    expect(advanceWatermark).toHaveBeenCalled()
+  })
 })

--- a/apps/admin/src/services/core-sync/orchestrator.ts
+++ b/apps/admin/src/services/core-sync/orchestrator.ts
@@ -16,6 +16,7 @@ import {
   type SyncStats,
   type ProgressReporter,
   type PhaseRunner,
+  type SyncPhaseProgress,
   emptySyncStats,
 } from "./types"
 import { acquireSyncLock, refreshSyncLock, releaseSyncLock } from "./lock"
@@ -66,6 +67,7 @@ const PHASE_TABLES: Record<SyncPhase, string[]> = {
 }
 
 const LOCK_HEARTBEAT_INTERVAL_MS = 60_000
+const PROGRESS_REPORT_INTERVAL_MS = 30_000
 
 export type PhaseResult = SyncStats & { phase: string; durationMs: number }
 
@@ -87,6 +89,16 @@ export type SyncRunContext = {
 export type SyncRunStart =
   | { skipped: true; result: SyncResult }
   | { skipped: false; run: SyncRunContext }
+
+export type RunSyncPhaseOptions = {
+  onProgress?: (progress: SyncPhaseProgress) => void
+}
+
+export type RunSyncOptions = {
+  scope?: string | string[]
+  incremental?: boolean
+  onProgress?: (progress: SyncPhaseProgress) => void
+}
 
 export function resolveScope(input?: string | string[]): SyncPhase[] {
   if (!input) return [...PHASE_ORDER]
@@ -147,6 +159,7 @@ export async function runSyncPhase(
   prisma: PrismaClient,
   run: SyncRunContext,
   phase: SyncPhase,
+  options: RunSyncPhaseOptions = {},
 ): Promise<PhaseResult> {
   const ownsLock = await refreshSyncLock(prisma, run.runId)
   if (!ownsLock) {
@@ -160,10 +173,11 @@ export async function runSyncPhase(
   heartbeat.unref?.()
 
   try {
-    const progress: ProgressReporter = {
-      setTotal: () => {},
-      increment: () => {},
-    }
+    const progress = createProgressReporter({
+      phase,
+      phaseStart,
+      onProgress: options.onProgress,
+    })
 
     let since: string | undefined
     if (run.incremental) {
@@ -225,6 +239,54 @@ export async function runSyncPhase(
   }
 }
 
+function createProgressReporter({
+  phase,
+  phaseStart,
+  onProgress,
+}: {
+  phase: SyncPhase
+  phaseStart: number
+  onProgress?: (progress: SyncPhaseProgress) => void
+}): ProgressReporter {
+  let completed = 0
+  let total = 0
+  let lastReportedAt = 0
+  let hasReported = false
+
+  function report(force = false) {
+    if (!onProgress) return
+
+    const now = Date.now()
+    if (
+      !force &&
+      hasReported &&
+      now - lastReportedAt < PROGRESS_REPORT_INTERVAL_MS
+    ) {
+      return
+    }
+
+    hasReported = true
+    lastReportedAt = now
+    onProgress({
+      phase,
+      completed,
+      total,
+      elapsedMs: now - phaseStart,
+    })
+  }
+
+  return {
+    setTotal: (nextTotal) => {
+      total = Math.max(total, nextTotal)
+      report(!hasReported)
+    },
+    increment: (count = 1) => {
+      completed += count
+      report()
+    },
+  }
+}
+
 export async function finishSyncRun(
   prisma: PrismaClient,
   run: SyncRunContext,
@@ -252,7 +314,7 @@ export async function abortSyncRun(
 
 export async function runSync(
   prisma: PrismaClient,
-  options?: { scope?: string | string[]; incremental?: boolean },
+  options?: RunSyncOptions,
 ): Promise<SyncResult> {
   const start = await startSyncRun(prisma, options)
   if (start.skipped) return start.result
@@ -262,7 +324,11 @@ export async function runSync(
 
   try {
     for (const phase of start.run.phasesToRun) {
-      phases.push(await runSyncPhase(prisma, start.run, phase))
+      phases.push(
+        await runSyncPhase(prisma, start.run, phase, {
+          onProgress: options?.onProgress,
+        }),
+      )
     }
 
     const result = await finishSyncRun(prisma, start.run, phases)

--- a/apps/admin/src/services/core-sync/phases/sync-videos.test.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-videos.test.ts
@@ -112,7 +112,8 @@ describe("syncVideos", () => {
         findUnique: vi.fn().mockResolvedValueOnce(null),
         findMany: vi
           .fn()
-          .mockResolvedValue([{ id: "child-1", coreId: "child-core-1" }]),
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([{ id: "child-1", coreId: "child-core-1" }]),
         upsert: vi.fn().mockResolvedValue({ id: "video-1" }),
         updateMany: vi.fn().mockResolvedValue({ count: 0 }),
       },
@@ -164,6 +165,16 @@ describe("syncVideos", () => {
         findMany: vi
           .fn()
           .mockResolvedValue([{ id: "origin-1", coreId: "origin-1" }]),
+      },
+      keyword: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([{ id: "keyword-1", coreId: "keyword-1" }]),
+      },
+      bibleBook: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([{ id: "book-1", coreId: "book-1" }]),
       },
       $transaction: vi.fn(async (fn: (trx: typeof tx) => Promise<void>) =>
         fn(tx),
@@ -237,5 +248,98 @@ describe("syncVideos", () => {
       where: { parentId: { in: ["video-1"] } },
     })
     expect(tx.$executeRaw).toHaveBeenCalledTimes(2)
+  })
+
+  it("retries a page transaction when Prisma reports P2024 pool pressure", async () => {
+    mockedCoreQuery
+      .mockResolvedValueOnce({ data: { bibleBooks: [] } } as never)
+      .mockResolvedValueOnce({
+        data: {
+          videos: [
+            {
+              id: "video-core-1",
+              slug: "video",
+              label: null,
+              publishedAt: null,
+              primaryLanguageId: null,
+              source: null,
+              origin: null,
+              title: [
+                {
+                  value: "Unmapped title",
+                  language: { id: "lang-missing" },
+                },
+              ],
+              description: [],
+              snippet: [],
+              imageAlt: [],
+              studyQuestions: [],
+              bibleCitations: [],
+              keywords: [],
+              children: [],
+              locked: false,
+              noIndex: false,
+              updatedAt: "2026-01-02T00:00:00.000Z",
+            },
+          ],
+        },
+      } as never)
+      .mockResolvedValueOnce({ data: { videos: [] } } as never)
+
+    const tx = {
+      video: {
+        findMany: vi.fn().mockResolvedValue([]),
+        upsert: vi.fn().mockResolvedValue({ id: "video-1" }),
+      },
+      videoLocale: {
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      videoStudyQuestion: {
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      bibleCitation: {
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      videoKeyword: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      videoRelation: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    }
+    const prisma = {
+      language: { findMany: vi.fn().mockResolvedValue([]) },
+      videoOrigin: { findMany: vi.fn().mockResolvedValue([]) },
+      keyword: { findMany: vi.fn().mockResolvedValue([]) },
+      bibleBook: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: vi
+        .fn()
+        .mockImplementationOnce(
+          async (fn: (trx: typeof tx) => Promise<void>) => {
+            await fn(tx)
+            throw Object.assign(new Error("pool exhausted"), { code: "P2024" })
+          },
+        )
+        .mockImplementationOnce(async (fn: (trx: typeof tx) => Promise<void>) =>
+          fn(tx),
+        ),
+      video: {
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    }
+
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined)
+
+    const stats = await syncVideos({
+      prisma: prisma as never,
+      progress: { setTotal: vi.fn(), increment: vi.fn() },
+    })
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2)
+    expect(stats.updated).toBe(1)
+    expect(stats.errors).toBe(1)
+    warnSpy.mockRestore()
   })
 })

--- a/apps/admin/src/services/core-sync/phases/sync-videos.ts
+++ b/apps/admin/src/services/core-sync/phases/sync-videos.ts
@@ -14,6 +14,7 @@ import { CORE_SYNC_TRANSACTION_OPTIONS } from "../transaction-options"
 import { toPgArray } from "@/db/pgvector"
 import { mapVideoLabel, mapVideoSource, toNameMap } from "../transforms"
 import { syncVideoLocalizedMetadata } from "../video-localized-metadata"
+import { withPrismaPoolTimeoutRetry } from "../pool-timeout-retry"
 
 const BIBLE_BOOKS_QUERY = `
   query BibleBooks {
@@ -258,29 +259,42 @@ export async function syncVideos({
         }),
       )
     } else if (parsedBooks.data.length > 0) {
-      await bulkUpsertBibleBooks(
-        prisma,
-        parsedBooks.data.map((book) => ({
-          id: randomUUID(),
-          coreId: book.id,
-          nameBase64: encodeJsonForPgArray(
-            toNameMap(book.name, { bcp47ByCoreId }),
+      await withPrismaPoolTimeoutRetry(
+        () =>
+          bulkUpsertBibleBooks(
+            prisma,
+            parsedBooks.data.map((book) => ({
+              id: randomUUID(),
+              coreId: book.id,
+              nameBase64: encodeJsonForPgArray(
+                toNameMap(book.name, { bcp47ByCoreId }),
+              ),
+              osisId: book.osisId,
+              alternateName: book.alternateName,
+              paratextAbbreviation: book.paratextAbbreviation,
+              isNewTestament: book.isNewTestament,
+              testament:
+                book.isNewTestament == null
+                  ? null
+                  : book.isNewTestament
+                    ? "NT"
+                    : "OT",
+              order: book.order,
+            })),
           ),
-          osisId: book.osisId,
-          alternateName: book.alternateName,
-          paratextAbbreviation: book.paratextAbbreviation,
-          isNewTestament: book.isNewTestament,
-          testament:
-            book.isNewTestament == null
-              ? null
-              : book.isNewTestament
-                ? "NT"
-                : "OT",
-          order: book.order,
-        })),
+        { operation: "core-sync.videos.bible-books" },
       )
     }
   }
+
+  const keywords = await prisma.keyword.findMany({
+    select: { id: true, coreId: true },
+  })
+  const keywordMap = new Map(keywords.map((k) => [k.coreId, k.id]))
+  const bibleBooks = await prisma.bibleBook.findMany({
+    select: { id: true, coreId: true },
+  })
+  const bibleBookMap = new Map(bibleBooks.map((b) => [b.coreId, b.id]))
 
   const PAGE_SIZE = 25
   let offset = 0
@@ -330,249 +344,257 @@ export async function syncVideos({
     progress.setTotal(offset + videos.length)
 
     try {
-      let pageUpdated = 0
-      await prisma.$transaction(async (tx) => {
-        const keywords = await tx.keyword.findMany({
-          select: { id: true, coreId: true },
-        })
-        const keywordMap = new Map(keywords.map((k) => [k.coreId, k.id]))
-        const bibleBooks = await tx.bibleBook.findMany({
-          select: { id: true, coreId: true },
-        })
-        const bibleBookMap = new Map(bibleBooks.map((b) => [b.coreId, b.id]))
-        const touchedVideoIds: string[] = []
-        const videoKeywordRows: Array<{ videoId: string; keywordId: string }> =
-          []
-        const pendingRelations: Array<{
-          parentId: string
-          childCoreId: string
-        }> = []
-
-        for (const video of videos) {
-          const primaryLanguageId = video.primaryLanguageId
-            ? (langMap.get(video.primaryLanguageId) ?? null)
-            : null
-          const originId = video.origin
-            ? (originMap.get(video.origin.id) ?? null)
-            : null
-
-          const existing = await tx.video.findUnique({
-            where: { coreId: video.id },
-            select: { source: true },
-          })
-          if (existing?.source === "MANAGER") {
-            continue
-          }
-
-          const videoRow = await tx.video.upsert({
-            where: { coreId: video.id },
-            create: {
-              coreId: video.id,
-              slug: video.slug,
-              label: mapVideoLabel(video.label),
-              videoSource: mapVideoSource(video.source),
-              publishedAt: video.publishedAt
-                ? new Date(video.publishedAt)
-                : null,
-              locked: video.locked,
-              noIndex: video.noIndex,
-              aiMetadata: false,
-              source: "CORE",
-              primaryLanguageId,
-              originId,
-              updatedAt: new Date(video.updatedAt),
-              syncedAt: new Date(),
-            },
-            update: {
-              slug: video.slug,
-              label: mapVideoLabel(video.label),
-              videoSource: mapVideoSource(video.source),
-              publishedAt: video.publishedAt
-                ? new Date(video.publishedAt)
-                : null,
-              locked: video.locked,
-              noIndex: video.noIndex,
-              primaryLanguageId,
-              originId,
-              updatedAt: new Date(video.updatedAt),
-              syncedAt: new Date(),
-              deletedAt: null,
-            },
-          })
-          touchedVideoIds.push(videoRow.id)
-
-          const localizedResult = await syncVideoLocalizedMetadata({
-            prisma: tx,
-            adminVideos: [
-              {
-                id: videoRow.id,
-                coreId: video.id,
-                source: "CORE",
-                publishedAt: video.publishedAt,
-              },
-            ],
-            coreVideos: [video],
-            languageIdByCoreId: langMap,
-            bcp47ByCoreId,
-            slugByCoreId,
-          })
-          stats.errors +=
-            localizedResult.errors + localizedResult.skippedLanguages
-          if (localizedResult.skippedLanguages > 0) {
-            console.warn(
-              JSON.stringify({
-                event: "core-sync.video-localized-metadata.skipped-languages",
-                videoCoreId: video.id,
-                skippedLanguages: localizedResult.skippedLanguages,
-                diagnostics: localizedResult.diagnostics,
-              }),
+      const pageResult = await withPrismaPoolTimeoutRetry(
+        async () => {
+          let pageUpdated = 0
+          let pageErrors = 0
+          await prisma.$transaction(async (tx) => {
+            const pageCoreIds = videos.map((video) => video.id)
+            const existingVideos = await tx.video.findMany({
+              where: { coreId: { in: pageCoreIds } },
+              select: { coreId: true, source: true },
+            })
+            const existingSourceByCoreId = new Map(
+              existingVideos.map((video) => [video.coreId, video.source]),
             )
-          }
+            const touchedVideoIds: string[] = []
+            const videoKeywordRows: Array<{
+              videoId: string
+              keywordId: string
+            }> = []
+            const pendingRelations: Array<{
+              parentId: string
+              childCoreId: string
+            }> = []
 
-          const seenCitationIds = new Set(
-            video.bibleCitations.map((citation) => citation.id),
-          )
-          for (const citation of video.bibleCitations) {
-            const bibleBookId = bibleBookMap.get(citation.bibleBook.id)
-            if (!bibleBookId) {
-              stats.errors++
-              console.warn(
-                JSON.stringify({
-                  event: "core-sync.video-citation.missing-bible-book",
-                  videoCoreId: video.id,
-                  citationCoreId: citation.id,
-                  bibleBookCoreId: citation.bibleBook.id,
-                }),
+            for (const video of videos) {
+              const primaryLanguageId = video.primaryLanguageId
+                ? (langMap.get(video.primaryLanguageId) ?? null)
+                : null
+              const originId = video.origin
+                ? (originMap.get(video.origin.id) ?? null)
+                : null
+
+              if (existingSourceByCoreId.get(video.id) === "MANAGER") {
+                continue
+              }
+
+              const videoRow = await tx.video.upsert({
+                where: { coreId: video.id },
+                create: {
+                  coreId: video.id,
+                  slug: video.slug,
+                  label: mapVideoLabel(video.label),
+                  videoSource: mapVideoSource(video.source),
+                  publishedAt: video.publishedAt
+                    ? new Date(video.publishedAt)
+                    : null,
+                  locked: video.locked,
+                  noIndex: video.noIndex,
+                  aiMetadata: false,
+                  source: "CORE",
+                  primaryLanguageId,
+                  originId,
+                  updatedAt: new Date(video.updatedAt),
+                  syncedAt: new Date(),
+                },
+                update: {
+                  slug: video.slug,
+                  label: mapVideoLabel(video.label),
+                  videoSource: mapVideoSource(video.source),
+                  publishedAt: video.publishedAt
+                    ? new Date(video.publishedAt)
+                    : null,
+                  locked: video.locked,
+                  noIndex: video.noIndex,
+                  primaryLanguageId,
+                  originId,
+                  updatedAt: new Date(video.updatedAt),
+                  syncedAt: new Date(),
+                  deletedAt: null,
+                },
+              })
+              touchedVideoIds.push(videoRow.id)
+
+              const localizedResult = await syncVideoLocalizedMetadata({
+                prisma: tx,
+                adminVideos: [
+                  {
+                    id: videoRow.id,
+                    coreId: video.id,
+                    source: "CORE",
+                    publishedAt: video.publishedAt,
+                  },
+                ],
+                coreVideos: [video],
+                languageIdByCoreId: langMap,
+                bcp47ByCoreId,
+                slugByCoreId,
+              })
+              pageErrors +=
+                localizedResult.errors + localizedResult.skippedLanguages
+              if (localizedResult.skippedLanguages > 0) {
+                console.warn(
+                  JSON.stringify({
+                    event:
+                      "core-sync.video-localized-metadata.skipped-languages",
+                    videoCoreId: video.id,
+                    skippedLanguages: localizedResult.skippedLanguages,
+                    diagnostics: localizedResult.diagnostics,
+                  }),
+                )
+              }
+
+              const seenCitationIds = new Set(
+                video.bibleCitations.map((citation) => citation.id),
               )
-              continue
-            }
-            await tx.bibleCitation.upsert({
-              where: { coreId: citation.id },
-              create: {
-                coreId: citation.id,
-                videoId: videoRow.id,
-                bibleBookId,
-                osisId: citation.osisId,
-                order: citation.order,
-                chapterStart: citation.chapterStart,
-                chapterEnd: citation.chapterEnd,
-                verseStart: citation.verseStart,
-                verseEnd: citation.verseEnd,
-                syncedAt: new Date(),
-              },
-              update: {
-                videoId: videoRow.id,
-                bibleBookId,
-                osisId: citation.osisId,
-                order: citation.order,
-                chapterStart: citation.chapterStart,
-                chapterEnd: citation.chapterEnd,
-                verseStart: citation.verseStart,
-                verseEnd: citation.verseEnd,
-                syncedAt: new Date(),
-                deletedAt: null,
-              },
-            })
-          }
-          await tx.bibleCitation.updateMany({
-            where: {
-              videoId: videoRow.id,
-              source: "CORE",
-              coreId: { notIn: [...seenCitationIds] },
-              deletedAt: null,
-            },
-            data: { deletedAt: new Date() },
-          })
-
-          for (const keyword of video.keywords) {
-            const keywordId = keywordMap.get(keyword.id)
-            if (!keywordId) continue
-            videoKeywordRows.push({ videoId: videoRow.id, keywordId })
-          }
-
-          for (const child of video.children) {
-            pendingRelations.push({
-              parentId: videoRow.id,
-              childCoreId: child.id,
-            })
-          }
-
-          pageUpdated++
-        }
-
-        if (touchedVideoIds.length > 0) {
-          await tx.videoKeyword.deleteMany({
-            where: { videoId: { in: touchedVideoIds } },
-          })
-          if (videoKeywordRows.length > 0) {
-            await tx.$executeRaw`
-              INSERT INTO "video_keyword" (
-                "video_id",
-                "keyword_id",
-                "created_at"
-              )
-              SELECT
-                input."video_id",
-                input."keyword_id",
-                NOW()
-              FROM unnest(
-                ${toPgArray(videoKeywordRows.map((row) => row.videoId))}::text[],
-                ${toPgArray(videoKeywordRows.map((row) => row.keywordId))}::text[]
-              ) AS input("video_id", "keyword_id")
-              ON CONFLICT ("video_id", "keyword_id") DO NOTHING
-            `
-          }
-
-          await tx.videoRelation.deleteMany({
-            where: { parentId: { in: touchedVideoIds } },
-          })
-
-          const childCoreIds = [
-            ...new Set(
-              pendingRelations.map((relation) => relation.childCoreId),
-            ),
-          ]
-          const childVideos =
-            childCoreIds.length > 0
-              ? await tx.video.findMany({
-                  where: { coreId: { in: childCoreIds } },
-                  select: { id: true, coreId: true },
+              for (const citation of video.bibleCitations) {
+                const bibleBookId = bibleBookMap.get(citation.bibleBook.id)
+                if (!bibleBookId) {
+                  pageErrors++
+                  console.warn(
+                    JSON.stringify({
+                      event: "core-sync.video-citation.missing-bible-book",
+                      videoCoreId: video.id,
+                      citationCoreId: citation.id,
+                      bibleBookCoreId: citation.bibleBook.id,
+                    }),
+                  )
+                  continue
+                }
+                await tx.bibleCitation.upsert({
+                  where: { coreId: citation.id },
+                  create: {
+                    coreId: citation.id,
+                    videoId: videoRow.id,
+                    bibleBookId,
+                    osisId: citation.osisId,
+                    order: citation.order,
+                    chapterStart: citation.chapterStart,
+                    chapterEnd: citation.chapterEnd,
+                    verseStart: citation.verseStart,
+                    verseEnd: citation.verseEnd,
+                    syncedAt: new Date(),
+                  },
+                  update: {
+                    videoId: videoRow.id,
+                    bibleBookId,
+                    osisId: citation.osisId,
+                    order: citation.order,
+                    chapterStart: citation.chapterStart,
+                    chapterEnd: citation.chapterEnd,
+                    verseStart: citation.verseStart,
+                    verseEnd: citation.verseEnd,
+                    syncedAt: new Date(),
+                    deletedAt: null,
+                  },
                 })
-              : []
-          const childIdByCoreId = new Map(
-            childVideos.map((child) => [child.coreId, child.id]),
-          )
-          const videoRelationRows = pendingRelations.flatMap((relation) => {
-            const childId = childIdByCoreId.get(relation.childCoreId)
-            return childId
-              ? [{ id: randomUUID(), parentId: relation.parentId, childId }]
-              : []
-          })
+              }
+              await tx.bibleCitation.updateMany({
+                where: {
+                  videoId: videoRow.id,
+                  source: "CORE",
+                  coreId: { notIn: [...seenCitationIds] },
+                  deletedAt: null,
+                },
+                data: { deletedAt: new Date() },
+              })
 
-          if (videoRelationRows.length > 0) {
-            await tx.$executeRaw`
-              INSERT INTO "video_relation" (
-                "id",
-                "parent_id",
-                "child_id",
-                "created_at"
+              for (const keyword of video.keywords) {
+                const keywordId = keywordMap.get(keyword.id)
+                if (!keywordId) continue
+                videoKeywordRows.push({ videoId: videoRow.id, keywordId })
+              }
+
+              for (const child of video.children) {
+                pendingRelations.push({
+                  parentId: videoRow.id,
+                  childCoreId: child.id,
+                })
+              }
+
+              pageUpdated++
+            }
+
+            if (touchedVideoIds.length > 0) {
+              await tx.videoKeyword.deleteMany({
+                where: { videoId: { in: touchedVideoIds } },
+              })
+              if (videoKeywordRows.length > 0) {
+                await tx.$executeRaw`
+                  INSERT INTO "video_keyword" (
+                    "video_id",
+                    "keyword_id",
+                    "created_at"
+                  )
+                  SELECT
+                    input."video_id",
+                    input."keyword_id",
+                    NOW()
+                  FROM unnest(
+                    ${toPgArray(videoKeywordRows.map((row) => row.videoId))}::text[],
+                    ${toPgArray(videoKeywordRows.map((row) => row.keywordId))}::text[]
+                  ) AS input("video_id", "keyword_id")
+                  ON CONFLICT ("video_id", "keyword_id") DO NOTHING
+                `
+              }
+
+              await tx.videoRelation.deleteMany({
+                where: { parentId: { in: touchedVideoIds } },
+              })
+
+              const childCoreIds = [
+                ...new Set(
+                  pendingRelations.map((relation) => relation.childCoreId),
+                ),
+              ]
+              const childVideos =
+                childCoreIds.length > 0
+                  ? await tx.video.findMany({
+                      where: { coreId: { in: childCoreIds } },
+                      select: { id: true, coreId: true },
+                    })
+                  : []
+              const childIdByCoreId = new Map(
+                childVideos.map((child) => [child.coreId, child.id]),
               )
-              SELECT
-                input."id",
-                input."parent_id",
-                input."child_id",
-                NOW()
-              FROM unnest(
-                ${toPgArray(videoRelationRows.map((row) => row.id))}::text[],
-                ${toPgArray(videoRelationRows.map((row) => row.parentId))}::text[],
-                ${toPgArray(videoRelationRows.map((row) => row.childId))}::text[]
-              ) AS input("id", "parent_id", "child_id")
-              ON CONFLICT ("parent_id", "child_id") DO NOTHING
-            `
-          }
-        }
-      }, CORE_SYNC_TRANSACTION_OPTIONS)
-      stats.updated += pageUpdated
+              const videoRelationRows = pendingRelations.flatMap((relation) => {
+                const childId = childIdByCoreId.get(relation.childCoreId)
+                return childId
+                  ? [{ id: randomUUID(), parentId: relation.parentId, childId }]
+                  : []
+              })
+
+              if (videoRelationRows.length > 0) {
+                await tx.$executeRaw`
+                  INSERT INTO "video_relation" (
+                    "id",
+                    "parent_id",
+                    "child_id",
+                    "created_at"
+                  )
+                  SELECT
+                    input."id",
+                    input."parent_id",
+                    input."child_id",
+                    NOW()
+                  FROM unnest(
+                    ${toPgArray(videoRelationRows.map((row) => row.id))}::text[],
+                    ${toPgArray(videoRelationRows.map((row) => row.parentId))}::text[],
+                    ${toPgArray(videoRelationRows.map((row) => row.childId))}::text[]
+                  ) AS input("id", "parent_id", "child_id")
+                  ON CONFLICT ("parent_id", "child_id") DO NOTHING
+                `
+              }
+            }
+          }, CORE_SYNC_TRANSACTION_OPTIONS)
+
+          return { errors: pageErrors, updated: pageUpdated }
+        },
+        { operation: `core-sync.videos.page.${offset}` },
+      )
+      stats.updated += pageResult.updated
+      stats.errors += pageResult.errors
     } catch (err) {
       stats.errors++
       console.error(
@@ -601,15 +623,29 @@ export async function syncVideos({
   }
 
   if (!since && stats.errors === 0 && seenCoreIds.size > 0) {
-    const result = await prisma.video.updateMany({
-      where: {
-        source: "CORE",
-        coreId: { notIn: [...seenCoreIds] },
-        deletedAt: null,
-      },
-      data: { deletedAt: new Date() },
-    })
-    stats.softDeleted += result.count
+    try {
+      const result = await withPrismaPoolTimeoutRetry(
+        () =>
+          prisma.video.updateMany({
+            where: {
+              source: "CORE",
+              coreId: { notIn: [...seenCoreIds] },
+              deletedAt: null,
+            },
+            data: { deletedAt: new Date() },
+          }),
+        { operation: "core-sync.videos.soft-delete" },
+      )
+      stats.softDeleted += result.count
+    } catch (err) {
+      stats.errors++
+      console.error(
+        JSON.stringify({
+          event: "core-sync.video.soft-delete.error",
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    }
   }
 
   return stats

--- a/apps/admin/src/services/core-sync/pool-timeout-retry.test.ts
+++ b/apps/admin/src/services/core-sync/pool-timeout-retry.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  isPrismaPoolTimeoutError,
+  withPrismaPoolTimeoutRetry,
+} from "./pool-timeout-retry"
+
+function prismaPoolTimeout(message = "pool exhausted") {
+  return Object.assign(new Error(message), { code: "P2024" })
+}
+
+describe("isPrismaPoolTimeoutError", () => {
+  it("matches Prisma P2024 typed errors", () => {
+    expect(isPrismaPoolTimeoutError(prismaPoolTimeout())).toBe(true)
+  })
+
+  it("matches the Prisma pool timeout message fallback", () => {
+    expect(
+      isPrismaPoolTimeoutError(
+        new Error(
+          "Timed out fetching a new connection from the connection pool.",
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it("does not match unrelated errors", () => {
+    expect(isPrismaPoolTimeoutError(new Error("record not found"))).toBe(false)
+  })
+})
+
+describe("withPrismaPoolTimeoutRetry", () => {
+  it("retries P2024 pool timeouts until the operation succeeds", async () => {
+    const run = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(prismaPoolTimeout())
+      .mockResolvedValueOnce("ok")
+    const sleep = vi.fn(async () => undefined)
+    const onRetry = vi.fn()
+
+    await expect(
+      withPrismaPoolTimeoutRetry(run, {
+        operation: "core-sync.test",
+        sleep,
+        onRetry,
+      }),
+    ).resolves.toBe("ok")
+
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(1_000)
+    expect(onRetry).toHaveBeenCalledWith({
+      operation: "core-sync.test",
+      attempt: 1,
+      nextAttempt: 2,
+      delayMs: 1_000,
+    })
+  })
+
+  it("rethrows the final P2024 after attempts are exhausted", async () => {
+    const finalError = prismaPoolTimeout("still exhausted")
+    const run = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(prismaPoolTimeout())
+      .mockRejectedValueOnce(finalError)
+
+    await expect(
+      withPrismaPoolTimeoutRetry(run, {
+        operation: "core-sync.test",
+        maxAttempts: 2,
+        sleep: vi.fn(async () => undefined),
+        onRetry: vi.fn(),
+      }),
+    ).rejects.toBe(finalError)
+
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not retry non-pool errors", async () => {
+    const error = new Error("validation failed")
+    const run = vi.fn<() => Promise<string>>().mockRejectedValueOnce(error)
+    const sleep = vi.fn(async () => undefined)
+
+    await expect(
+      withPrismaPoolTimeoutRetry(run, {
+        operation: "core-sync.test",
+        sleep,
+        onRetry: vi.fn(),
+      }),
+    ).rejects.toBe(error)
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/src/services/core-sync/pool-timeout-retry.ts
+++ b/apps/admin/src/services/core-sync/pool-timeout-retry.ts
@@ -1,0 +1,86 @@
+type RetryEvent = {
+  operation: string
+  attempt: number
+  nextAttempt: number
+  delayMs: number
+}
+
+export type PrismaPoolRetryOptions = {
+  operation: string
+  maxAttempts?: number
+  baseDelayMs?: number
+  sleep?: (delayMs: number) => Promise<void>
+  onRetry?: (event: RetryEvent) => void
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3
+const DEFAULT_BASE_DELAY_MS = 1_000
+
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, delayMs)
+    timer.unref?.()
+  })
+}
+
+function readErrorCode(error: unknown): unknown {
+  return error != null && typeof error === "object"
+    ? (error as { code?: unknown }).code
+    : undefined
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return typeof error === "string" ? error : ""
+}
+
+export function isPrismaPoolTimeoutError(error: unknown): boolean {
+  if (readErrorCode(error) === "P2024") return true
+
+  const message = readErrorMessage(error)
+  return (
+    message.includes("P2024") ||
+    message.includes(
+      "Timed out fetching a new connection from the connection pool",
+    )
+  )
+}
+
+export async function withPrismaPoolTimeoutRetry<T>(
+  run: () => Promise<T>,
+  {
+    operation,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    sleep = defaultSleep,
+    onRetry = defaultPoolRetryLog,
+  }: PrismaPoolRetryOptions,
+): Promise<T> {
+  let attempt = 1
+
+  while (true) {
+    try {
+      return await run()
+    } catch (error) {
+      if (!isPrismaPoolTimeoutError(error) || attempt >= maxAttempts) {
+        throw error
+      }
+
+      const delayMs = baseDelayMs * attempt
+      onRetry({ operation, attempt, nextAttempt: attempt + 1, delayMs })
+      await sleep(delayMs)
+      attempt++
+    }
+  }
+}
+
+function defaultPoolRetryLog({
+  operation,
+  attempt,
+  nextAttempt,
+  delayMs,
+}: RetryEvent) {
+  console.warn(
+    `[core-sync] event=prisma_pool_retry operation=${operation} attempt=${attempt} nextAttempt=${nextAttempt} delayMs=${delayMs}`,
+  )
+}

--- a/apps/admin/src/services/core-sync/types.ts
+++ b/apps/admin/src/services/core-sync/types.ts
@@ -37,6 +37,13 @@ export type ProgressReporter = {
   increment: (count?: number) => void
 }
 
+export type SyncPhaseProgress = {
+  phase: SyncPhase
+  completed: number
+  total: number
+  elapsedMs: number
+}
+
 export type PhaseRunner = (opts: {
   prisma: import("@prisma/client").PrismaClient
   progress: ProgressReporter

--- a/apps/admin/src/services/workflow-run-log.service.test.ts
+++ b/apps/admin/src/services/workflow-run-log.service.test.ts
@@ -6,6 +6,7 @@ import {
   createWorkflowRunLog,
   markWorkflowRunFailed,
   markWorkflowRunStarted,
+  recordCoreSyncPhaseProgress,
   recordCoreSyncRunResult,
 } from "./workflow-run-log.service"
 
@@ -13,6 +14,7 @@ function createMockClient() {
   return {
     workflowRun: {
       create: vi.fn(async (args) => ({ id: "workflow-run-1", ...args.data })),
+      findUnique: vi.fn(async () => ({ details: { scope: ["videos"] } })),
       update: vi.fn(async (args) => ({ id: args.where.id, ...args.data })),
     },
     coreSyncRun: {
@@ -171,6 +173,41 @@ describe("workflow run log service", () => {
         status: WorkflowRunStatus.FAILED,
         finishedAt: expect.any(Date),
         error: "workflow runtime down",
+      },
+    })
+  })
+
+  it("merges Core Sync progress into existing workflow details", async () => {
+    const client = createMockClient()
+
+    await recordCoreSyncPhaseProgress(
+      "workflow-run-1",
+      {
+        phase: "videos",
+        completed: 25,
+        total: 50,
+        elapsedMs: 12_345,
+      },
+      client as never,
+    )
+
+    expect(client.workflowRun.findUnique).toHaveBeenCalledWith({
+      where: { id: "workflow-run-1" },
+      select: { details: true },
+    })
+    expect(client.workflowRun.update).toHaveBeenCalledWith({
+      where: { id: "workflow-run-1" },
+      data: {
+        details: {
+          scope: ["videos"],
+          coreSyncProgress: {
+            phase: "videos",
+            completed: 25,
+            total: 50,
+            elapsedMs: 12_345,
+            updatedAt: expect.any(String),
+          },
+        },
       },
     })
   })

--- a/apps/admin/src/services/workflow-run-log.service.ts
+++ b/apps/admin/src/services/workflow-run-log.service.ts
@@ -5,6 +5,7 @@ import {
   type PrismaClient,
 } from "@prisma/client"
 import { prisma } from "@/db/client"
+import type { SyncPhaseProgress } from "@/services/core-sync/types"
 import type { SyncResult } from "@/services/core-sync/orchestrator"
 import type { CoreSyncTrigger } from "@/services/core-sync/job"
 
@@ -108,6 +109,36 @@ export async function markWorkflowRunFailed(
       status: WorkflowRunStatus.FAILED,
       finishedAt: new Date(),
       error: asErrorMessage(error),
+    },
+  })
+}
+
+export async function recordCoreSyncPhaseProgress(
+  workflowRunId: string,
+  progress: SyncPhaseProgress,
+  client: WorkflowRunClient = prisma,
+) {
+  const existing = await client.workflowRun.findUnique({
+    where: { id: workflowRunId },
+    select: { details: true },
+  })
+  const details =
+    existing?.details != null &&
+    typeof existing.details === "object" &&
+    !Array.isArray(existing.details)
+      ? { ...(existing.details as Record<string, Prisma.JsonValue>) }
+      : {}
+
+  return client.workflowRun.update({
+    where: { id: workflowRunId },
+    data: {
+      details: {
+        ...details,
+        coreSyncProgress: {
+          ...progress,
+          updatedAt: new Date().toISOString(),
+        },
+      },
     },
   })
 }

--- a/docs/plans/2026-06-04-001-fix-admin-core-sync-video-pool-resilience-plan.md
+++ b/docs/plans/2026-06-04-001-fix-admin-core-sync-video-pool-resilience-plan.md
@@ -1,0 +1,406 @@
+---
+title: "fix: Harden Admin Core Sync video phase pool resilience"
+type: fix
+status: active
+date: 2026-06-04
+roadmap: docs/roadmap/platform/feat-157-admin-core-sync-video-phase-pool-resilience.md
+---
+
+# fix: Harden Admin Core Sync Video Phase Pool Resilience
+
+## Summary
+
+Harden the Admin Core Sync `videos` phase so a full production sync can survive
+Prisma pool pressure, expose useful long-run progress, and give operators a
+clear pool configuration and rerun path before the AI Gateway content refresh
+continues.
+
+---
+
+## Problem Frame
+
+The 2026-06-03/2026-06-04 production Core Sync run failed in the `videos`
+workflow step after several hours because Prisma could not acquire a database
+connection from a sync pool configured with `connection_limit=2` and
+`pool_timeout=10`. The current code already uses a dedicated `syncPrisma`
+client, but the documented sync pool budget is still tiny and
+`syncVideos` does a large amount of per-page work inside long interactive
+transactions. A retry of the same full sync without changing pool budget,
+transaction shape, retry behavior, or progress visibility is likely to fail
+again under the same pressure.
+
+---
+
+## Assumptions
+
+- Production env inspection, deploy, Core Sync reruns, enrichment, embedding
+  backfill, and eval execution require authenticated operator access. The code
+  and docs plan will prepare those actions and define their evidence, but the
+  implementation phase must report any unavailable production access instead of
+  marking those steps as locally verified.
+- `feat-156` is still `in-progress` and blocks the downstream embedding/eval
+  refresh path. This fix can still ship the Core Sync resilience work now, but
+  the all-content AI Gateway backfill remains gated by the existing
+  `feat-156` eval criteria.
+- Admin currently uses Prisma 6.x, where `connection_limit` and `pool_timeout`
+  are URL parameters. Official Prisma docs describe `P2024` as the pool acquire
+  timeout emitted after a queued query waits longer than `pool_timeout`.
+
+---
+
+## Requirements
+
+**Pool and Worker Posture**
+
+- R1. The Admin worker uses a dedicated `DATABASE_URL_SYNC` pool for Core Sync
+  when available, and documentation no longer recommends the failed two-slot,
+  ten-second production posture.
+- R2. The recommended sync pool budget is explicit, conservative, and reasoned
+  from total production database capacity rather than blindly maximizing
+  `connection_limit`.
+- R3. Any pool diagnostics or run notes must not print raw database URLs,
+  tokens, Core API credentials, Railway variables, gateway keys, or bearers.
+
+**Videos Phase Resilience**
+
+- R4. `syncVideos` retries only safe transient Prisma pool-acquire failures,
+  including `P2024`, with bounded backoff around batch/page write boundaries.
+- R5. Non-pool data errors, parse errors, missing Core references, auth
+  failures, and malformed input remain visible as phase errors and are not
+  converted into success.
+- R6. The `videos` phase reduces avoidable long transaction work and repeated
+  lookup queries while preserving Core-sourced overwrite boundaries,
+  `MANAGER` row protection, watermark behavior, and full-sync soft-delete
+  semantics.
+
+**Progress and Operations**
+
+- R7. Long `videos` runs emit sanitized progress for page/batch movement so
+  operators can distinguish slow progress from a stuck step.
+- R8. Focused tests cover pool-timeout classification, retry exhaustion,
+  non-retryable error behavior, and video-phase progress or write-shape
+  changes.
+- R9. The production runbook documents the safe deployment, narrow rerun,
+  coverage audit, AI Gateway backfill, and eval report sequence without
+  committing secrets or raw production payloads.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Raise and document the sync pool budget instead of sharing the main
+  pool:** Core Sync should keep using `DATABASE_URL_SYNC`, but production docs
+  should move away from `connection_limit=2`. A modest dedicated pool with a
+  longer acquire timeout gives the worker room for its transaction, lock
+  heartbeat, progress writes, and post-phase maintenance without making web/API
+  traffic compete for the same tiny pool.
+- KTD2. **Retry at page and maintenance write boundaries:** The safe retry unit
+  is the current page or idempotent maintenance write. `syncVideos` already
+  uses upserts, relation replacement, and full-sync presence tracking; retrying
+  a failed page write is safer and cheaper than retrying the whole workflow
+  step after hours of progress.
+- KTD3. **Classify Prisma pool failures by typed shape first:** Match Prisma
+  client errors through `code === "P2024"` and use message matching only as a
+  narrow fallback. This follows the repo's typed-error discipline and avoids
+  treating arbitrary timeout-looking data errors as retryable pool pressure.
+- KTD4. **Shorten transactions before adding more concurrency:** The current
+  `videos` implementation is mostly sequential, so the main issue is not
+  broad `Promise.all` fan-out. The safer local improvement is to move repeated
+  lookup reads out of per-page transactions where possible and keep transaction
+  scope focused on writes.
+- KTD5. **Make progress visible with sanitized operational signals:** Progress
+  should include phase, page offset or completed count, updated count, retry
+  attempt, and elapsed time. It must avoid row payloads, Core tokens, DB URLs,
+  and raw query values.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Dedicated sync worker"] --> B["syncPrisma using DATABASE_URL_SYNC"]
+  B --> C["Core Sync workflow phases"]
+  C --> D["videos phase page loop"]
+  D --> E["Bounded retry wrapper"]
+  E --> F{"P2024 pool timeout?"}
+  F -->|yes and attempts remain| G["Backoff and retry current page"]
+  F -->|no or exhausted| H["Record phase error"]
+  G --> D
+  H --> I["Watermark stays unchanged on errors"]
+  E --> J["Successful page write"]
+  J --> K["Sanitized progress signal"]
+  K --> D
+```
+
+```mermaid
+flowchart TB
+  A["Fix merged and deployed"] --> B["Verify worker env without printing secrets"]
+  B --> C{"Phase-scoped rerun supported?"}
+  C -->|yes| D["Run videos then remaining video phases"]
+  C -->|no| E["Run full Core Sync"]
+  D --> F["Verify workflow_run, sync_locks, sync_state, coverage audit"]
+  E --> F
+  F --> G{"Core Sync succeeded?"}
+  G -->|no| H["Document follow-up ticket with evidence"]
+  G -->|yes| I["Continue enrichment and AI Gateway backfill when feat-156 gate allows"]
+  I --> J["Run Mastra eval and save report evidence"]
+```
+
+---
+
+## Implementation Units
+
+### U1. Roadmap State and Production Pool Documentation
+
+**Goal:** Mark the ticket as actively owned and update operator docs so the
+failed production sync pool posture is no longer the recommended setup.
+
+**Requirements:** R1, R2, R3, R9
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `docs/roadmap/platform/feat-157-admin-core-sync-video-phase-pool-resilience.md`
+- Modify: `apps/admin/.env.example`
+- Modify: `apps/admin/src/config/env.ts`
+- Modify: `apps/admin/src/db/client.ts`
+- Modify: `apps/admin/docs/core-sync-recurring-job.md`
+- Test expectation: none -- documentation and comments only unless the
+  implementation adds parseable pool diagnostics.
+
+**Approach:** Keep `DATABASE_URL_SYNC` optional for local compatibility, but
+make production guidance explicit: the dedicated worker should set a separate
+sync URL with a larger pool and longer acquire timeout than the failed
+`connection_limit=2&pool_timeout=10` posture. The exact production value must
+be verified against Railway/Postgres capacity during rollout; the docs should
+give a conservative starting budget and the capacity math operators need to
+adjust it safely.
+
+**Patterns to follow:** `apps/admin/docs/core-sync-recurring-job.md` required
+env style; `docs/solutions/developer-experience/admin-prod-video-snapshot-local-restore-20260521.md`
+for warnings about Prisma URL params versus libpq URLs.
+
+**Test scenarios:** Test expectation: none -- no runtime behavior if docs and
+comments are the only changes.
+
+**Verification:** The roadmap ticket is `in-progress`; docs recommend a
+dedicated sync pool with a longer timeout and explain how to verify parameters
+without exposing full URLs or secrets.
+
+### U2. Prisma Pool Timeout Retry Helper
+
+**Goal:** Add a focused retry/backoff utility for safe Core Sync writes that
+encounter Prisma pool-acquire timeouts.
+
+**Requirements:** R4, R5, R8
+
+**Dependencies:** U1
+
+**Files:**
+
+- Create: `apps/admin/src/services/core-sync/pool-timeout-retry.ts`
+- Create: `apps/admin/src/services/core-sync/pool-timeout-retry.test.ts`
+
+**Approach:** Introduce a small helper that detects retryable pool pressure
+from Prisma's typed `P2024` error shape, retries with bounded exponential or
+linear backoff, and rethrows on exhaustion. Keep the helper free of phase
+knowledge so it can wrap only operations whose caller has determined the retry
+is safe. Logs should be sanitized and include operation label plus attempt
+count, not SQL text or connection strings.
+
+**Patterns to follow:** Typed error classification guidance in
+`docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md`;
+retry-boundary guidance in
+`docs/solutions/platform/admin-manager-enrichment-trigger-endpoint-20260506.md`.
+
+**Test scenarios:**
+
+- A typed Prisma-shaped error with `code: "P2024"` retries until the operation
+  succeeds and returns the successful value.
+- Exhausted `P2024` retries rethrow the final error after the expected number
+  of attempts.
+- A non-`P2024` error does not retry and is rethrown immediately.
+- The retry delay path can be tested without making the suite wait in real
+  time.
+
+**Verification:** Focused tests prove typed pool-timeout retry behavior and
+non-retryable errors remain non-retryable.
+
+### U3. Videos Phase Transaction and Retry Boundaries
+
+**Goal:** Apply the retry helper to safe `syncVideos` batch boundaries and
+remove avoidable per-page transaction work.
+
+**Requirements:** R4, R5, R6, R8
+
+**Dependencies:** U2
+
+**Files:**
+
+- Modify: `apps/admin/src/services/core-sync/phases/sync-videos.ts`
+- Modify: `apps/admin/src/services/core-sync/phases/sync-videos.test.ts`
+
+**Approach:** Wrap the full-sync Bible book upsert, each page transaction,
+and the final full-sync soft-delete update in the pool retry helper. Keep
+page processing sequential. Move repeated keyword and Bible-book lookup reads
+outside the per-page transaction or collapse them to one page-level read so
+the transaction holds its connection for less time. Preserve manager-owned row
+skips, localized metadata writes, relation replacement, citation staling,
+keyword links, child relations, and full-sync presence tracking.
+
+**Patterns to follow:** Bulk-upsert and full-sync presence rules in
+`docs/solutions/performance-issues/admin-core-sync-high-volume-root-phase-bulk-upsert-20260507.md`;
+current `sync-dubs` and `sync-dub-downloads` high-volume phase posture for
+page-oriented writes.
+
+**Test scenarios:**
+
+- A page transaction that fails once with `P2024` is retried and the final
+  stats count the page as updated once.
+- A page transaction whose `P2024` retries exhaust increments phase errors and
+  continues to the next Core page without advancing the watermark indirectly.
+- A non-pool transaction error increments errors without retrying.
+- Manager-owned videos remain skipped after the lookup-shape change.
+- Keyword and child relation rows still bulk insert after the lookup-shape
+  change.
+
+**Verification:** The existing nested Core video entity test still passes, and
+new tests cover retry and lookup-shape behavior.
+
+### U4. Videos Phase Progress Visibility
+
+**Goal:** Emit useful, sanitized progress for long `videos` runs so operators
+can see movement before the phase finishes.
+
+**Requirements:** R3, R7, R8
+
+**Dependencies:** U3
+
+**Files:**
+
+- Modify: `apps/admin/src/services/core-sync/orchestrator.ts`
+- Modify: `apps/admin/src/services/core-sync/phases/sync-videos.ts`
+- Modify: `apps/admin/src/services/core-sync/orchestrator.test.ts`
+- Modify as needed: `apps/admin/src/services/workflow-run-log.service.ts`
+- Modify as needed: `apps/admin/src/services/workflow-run-log.service.test.ts`
+
+**Approach:** Persist throttled phase progress into `workflow_run.details`
+when the dispatched workflow has a ledger run id, and supplement it with
+sanitized progress logs. The progress path should use the normal admin Prisma
+client or another non-sync-pool route so page writes never wait on progress
+updates from the same saturated sync pool. Direct CLI/local runs without a
+ledger id can log progress only. Progress updates must be fire-and-forget,
+throttled, and safe to drop if the ledger update fails.
+
+**Patterns to follow:** Plain-string operational logging rule in
+`docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`;
+current dashboard workflow summary shape in
+`apps/admin/src/app/dashboard/ops-data.ts`.
+
+**Test scenarios:**
+
+- The progress reporter receives increments from a successful `videos` page
+  and emits a sanitized progress signal.
+- Progress signaling does not throw through `syncVideos` when the progress
+  sink fails.
+- If `workflow_run.details` is updated, repeated progress updates merge
+  current phase progress without dropping the original queued run details.
+
+**Verification:** Focused tests cover the selected progress path; docs explain
+where operators should look during a long `videos` phase.
+
+### U5. Focused Validation and Production Handoff
+
+**Goal:** Validate the local fix and prepare the production rerun and content
+refresh evidence path.
+
+**Requirements:** R8, R9
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+
+- Modify: `apps/admin/docs/core-sync-recurring-job.md`
+- Modify as needed: `docs/roadmap/platform/feat-157-admin-core-sync-video-phase-pool-resilience.md`
+- Create if production remains inaccessible:
+  `docs/roadmap/platform/feat-NNN-admin-core-sync-production-rerun-evidence.md`
+
+**Approach:** Run focused Admin tests and typechecking for the touched Core
+Sync surface. If authenticated production access is available, verify the
+deployed worker env shape without printing secrets, trigger the narrowest safe
+Core Sync scope, confirm fresh video-phase watermarks and coverage audit, and
+continue the ticket's enrichment/backfill/eval sequence when the `feat-156`
+gate permits it. If production access is unavailable in this session, leave
+the ticket in progress and document the remaining production verification as a
+follow-up instead of marking completion.
+
+**Patterns to follow:** Roadmap completion rules in `AGENTS.md`;
+AI Gateway gate/report conventions in
+`docs/roadmap/content-discovery/feat-156-mastra-ai-gateway-content-embeddings.md`.
+
+**Test scenarios:** Test expectation: none -- this unit consumes the focused
+test suites from U2 through U4 and handles operational evidence.
+
+**Verification:** Focused local validation is green. Production verification
+is either completed with sanitized evidence or explicitly left as remaining
+operator work with a follow-up roadmap ticket.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change Admin pgvector dimensions, AI Gateway vector
+  contracts, Mastra provider behavior, or live search query embedding ownership.
+- This plan does not bypass `SyncLock`, phase watermarks, Core-sourced
+  overwrite rules, `MANAGER` source protection, or the existing coverage audit.
+- This plan does not introduce PgBouncer or a database infrastructure
+  migration. If production capacity analysis shows an external pooler is
+  required, create a separate platform ticket.
+- This plan does not mark the roadmap ticket complete unless production Core
+  Sync and the downstream evidence path are actually verified.
+
+### Deferred to Follow-Up Work
+
+- A first-class `CoreSyncPhaseProgress` table or dashboard component if
+  throttled workflow-run detail updates are too risky for this fix.
+- A broader rewrite of `syncVideos` into raw bulk upsert for every localized
+  metadata and citation write. This fix may reduce transaction scope, but a
+  full bulk rewrite should be measured and reviewed separately.
+- Database pooler adoption if Railway/Postgres capacity cannot support the
+  dedicated sync and web pools with headroom.
+
+---
+
+## Risks & Dependencies
+
+- The production database has finite connection capacity. Raising the sync
+  pool without accounting for web replicas, workflow runtime storage, and
+  operator sessions can move the failure from `P2024` to database-level
+  connection exhaustion.
+- Retrying the wrong operation could hide real data issues. Keep retries
+  limited to typed pool-acquire failures at idempotent page or maintenance
+  boundaries.
+- Progress persistence can itself create pool pressure if it uses the same
+  two-slot sync pool during a long transaction. Prefer sanitized logs first
+  and only persist progress through a non-blocking, throttled path.
+- The downstream content refresh depends on `feat-156` eval gates and
+  operator credentials. Code can ship before that path completes, but the
+  roadmap ticket should reflect the true operational state.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/platform/feat-157-admin-core-sync-video-phase-pool-resilience.md`
+- `apps/admin/src/db/client.ts`
+- `apps/admin/src/services/core-sync/orchestrator.ts`
+- `apps/admin/src/services/core-sync/phases/sync-videos.ts`
+- `apps/admin/src/services/core-sync/video-localized-metadata.ts`
+- `apps/admin/src/services/core-sync/phases/sync-videos.test.ts`
+- `apps/admin/docs/core-sync-recurring-job.md`
+- `docs/solutions/performance-issues/admin-core-sync-high-volume-root-phase-bulk-upsert-20260507.md`
+- `docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md`
+- Official Prisma connection pool docs:
+  `https://www.prisma.io/docs/orm/v6/prisma-client/setup-and-configuration/databases-connections/connection-pool`

--- a/docs/roadmap/platform/feat-157-admin-core-sync-video-phase-pool-resilience.md
+++ b/docs/roadmap/platform/feat-157-admin-core-sync-video-phase-pool-resilience.md
@@ -3,7 +3,7 @@ id: "feat-157"
 title: "Admin Core Sync video phase pool resilience"
 owner: "tataihono"
 priority: "P0"
-status: "not-started"
+status: "in-progress"
 start_date: "2026-06-04"
 duration: 3
 depends_on:

--- a/docs/solutions/database-issues/admin-core-sync-video-phase-prisma-pool-timeout-resilience.md
+++ b/docs/solutions/database-issues/admin-core-sync-video-phase-prisma-pool-timeout-resilience.md
@@ -1,0 +1,115 @@
+---
+title: Admin Core Sync video phase Prisma pool timeout resilience
+date: 2026-06-04
+category: database-issues
+module: apps/admin core sync
+problem_type: database_issue
+component: background_job
+symptoms:
+  - Full Admin Core Sync fails in the video phase with Prisma P2024 pool timeout errors.
+  - Long video pages leave Workflow runs looking idle because phase progress is only visible at completion.
+  - Low production sync pool settings make one large phase contend with normal Admin traffic.
+  - Retrying a failed transaction can double-count diagnostics if stats mutate inside the retry body.
+root_cause: config_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - database
+  - service_object
+tags:
+  - admin-core-sync
+  - prisma
+  - p2024
+  - connection-pool
+  - workflow
+  - video-sync
+  - database-url-sync
+  - retries
+---
+
+# Admin Core Sync video phase Prisma pool timeout resilience
+
+## Problem
+
+Admin Core Sync can run for several minutes on the full video catalog. In production, the video phase hit Prisma P2024 connection-pool timeouts with `connection_limit=2` and `pool_timeout=10`, aborting the run before downstream AI Gateway refresh and embedding work could safely proceed.
+
+## Symptoms
+
+- Workflow run `wrun_01KT7TW5W4M10DQRFPYRXWRF2F` failed in `stepSyncVideos`.
+- The failure included Prisma's pool-timeout shape: "Timed out fetching a new connection from the connection pool".
+- The run could not advance the video watermark, so follow-on content refresh gates correctly stayed blocked.
+- Operators could see phase completion logs, but not durable per-phase progress in `workflow_run.details` during a long page loop.
+
+## What Didn't Work
+
+- **Only rerunning the full sync.** With the same low pool budget and no local retry boundary, the video phase can fail again at the next pool-pressure spike.
+- **Only increasing Prisma timeouts.** A larger `pool_timeout` gives pressure more time to clear, but it does not make the page write resilient when a single checkout still times out.
+- **Retrying too deep inside the transaction.** Retrying row-level operations makes it harder to reason about idempotency and can duplicate diagnostics, relation work, or partial counters.
+- **Advancing downstream embedding/backfill work first.** AI Gateway content refresh depends on a successful Core Sync, fresh watermarks, an unlocked sync ledger, and a passing coverage audit.
+
+## Solution
+
+Use a dedicated, production-tuned sync pool and wrap the video phase's idempotent page-sized database work in a Prisma P2024 retry helper.
+
+The retry helper should identify typed `code === "P2024"` first and fall back to Prisma's pool-timeout message for log shapes that do not preserve the code. Keep retry logs sanitized and structured:
+
+```ts
+await withPrismaPoolTimeoutRetry(
+  () =>
+    prisma.$transaction(async (tx) => {
+      // page-scoped upserts, relations, localized metadata, and cleanup
+    }, CORE_SYNC_TRANSACTION_OPTIONS),
+  { operation: `core-sync.videos.page.${offset}` },
+)
+```
+
+The page loop must not mutate run-level counters inside the retry body. Accumulate per-attempt stats locally and merge them only after the transaction has succeeded:
+
+```ts
+const pageResult = await withPrismaPoolTimeoutRetry(
+  async () => {
+    let pageUpdated = 0
+    let pageErrors = 0
+
+    await prisma.$transaction(async (tx) => {
+      // pageErrors += localizedResult.errors + localizedResult.skippedLanguages
+      // pageUpdated++ after each successfully processed Core video
+    }, CORE_SYNC_TRANSACTION_OPTIONS)
+
+    return { errors: pageErrors, updated: pageUpdated }
+  },
+  { operation: `core-sync.videos.page.${offset}` },
+)
+
+stats.updated += pageResult.updated
+stats.errors += pageResult.errors
+```
+
+For the video phase, also hoist stable lookup maps (`keyword`, `bibleBook`) outside the per-page transaction and load existing page videos with one `findMany` rather than one `findUnique` per Core video. That shortens each transaction's connection hold time while preserving the `source === "MANAGER"` skip rule.
+
+Finally, persist throttled phase progress through the workflow ledger. The orchestrator emits `{ phase, completed, total, elapsedMs }`, and the workflow job stores it under `workflow_run.details.coreSyncProgress` so operators can distinguish "stuck" from "still making page progress".
+
+## Why This Works
+
+Prisma P2024 is a checkout failure, not proof that the logical page is invalid. Retrying the whole page transaction preserves the database's rollback boundary and lets transient pressure clear without fragmenting the write path.
+
+The local page-result pattern is load-bearing. If a transaction body increments `stats.errors` and then Prisma throws P2024 before commit, the retry attempt can succeed while the run still carries phantom errors. Those phantom errors block watermark advancement and can make a healthy retry look like a partial sync. Returning page stats from the successful attempt avoids that.
+
+Moving stable reads out of the transaction reduces time spent holding a connection. Durable progress writes use the normal workflow ledger path rather than the sync transaction itself, so progress can remain visible even when the sync pool is saturated.
+
+## Prevention
+
+- Wrap Prisma pool-timeout retries around idempotent page, batch, or cleanup units, not individual row calls.
+- Keep aggregate counters, watermarks, and "success gates" outside retryable transaction bodies unless the value is committed only after the transaction returns.
+- Log retry attempts with operation, attempt, next attempt, and delay only; do not include database URLs, connection strings, or payloads.
+- Size `DATABASE_URL_SYNC` against production database capacity. A useful starting point for Admin Core Sync is `connection_limit=5&pool_timeout=60`, then tune after measuring live headroom.
+- Add a regression test where the transaction callback runs, a P2024 is thrown after the callback, and the second attempt succeeds. Assert counters reflect only the successful attempt plus legitimate final diagnostics.
+- Do not run all-content embedding replacement, backfill, or eval gates until Core Sync succeeds, watermarks are fresh, the lock/ledger is clear, and coverage audit passes.
+
+## Related Issues
+
+- Roadmap ticket: [feat-157 Admin Core Sync video phase pool resilience](../../roadmap/platform/feat-157-admin-core-sync-video-phase-pool-resilience.md)
+- [Core Sync Per-Page Upsert Pattern](../cms/core-sync-per-page-upsert-pattern.md)
+- [Admin Core Sync High-Volume Bulk Upsert Pattern](../performance-issues/admin-core-sync-high-volume-root-phase-bulk-upsert-20260507.md)
+- [Prisma bind-variable cap in Core Sync soft-delete tails](./postgres-prepared-statement-bind-variable-limit-32767-20260504.md)
+- [Bounded parallelism per target workflow pattern](../best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md)


### PR DESCRIPTION
## Summary

Full Admin Core Sync video runs can now survive transient Prisma P2024 pool pressure instead of aborting the whole workflow at the first saturated checkout. The video phase retries only idempotent page-sized database work, keeps aggregate counters retry-safe, shortens transaction hold time, and persists throttled phase progress so operators can tell a long run is still moving.

This also updates the Core Sync worker guidance: production should use a dedicated `DATABASE_URL_SYNC` with a larger sync pool and acquire timeout than the failed tiny-pool posture, starting around `connection_limit=5&pool_timeout=60` and tuning against real database capacity.

## Validation

- `pnpm --filter @forge/admin test -- src/services/core-sync/pool-timeout-retry.test.ts src/services/core-sync/phases/sync-videos.test.ts src/services/core-sync/orchestrator.test.ts src/services/core-sync/job.test.ts src/services/workflow-run-log.service.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `git diff --check origin/main..HEAD`

## Rollout Note

Before triggering the production full sync, confirm the Admin worker service has `DATABASE_URL_SYNC` set with sanitized verification of `connection_limit`, `pool_timeout`, worker concurrency, and database headroom. Do not start downstream all-content embedding replacement until Core Sync completes cleanly, the video watermark is fresh, the sync lock is clear, and coverage audit passes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
