### PR TITLE
fix(manager): keep auth callback errors on public origin

### DIFF
--- a/apps/manager/src/app/api/auth/callback/route.test.ts
+++ b/apps/manager/src/app/api/auth/callback/route.test.ts
@@ -64,6 +64,19 @@ describe("Manager OAuth callback route", () => {
     expect(setCookie).toContain("Expires=Thu, 01 Jan 1970")
   })
 
+  it("uses the configured Manager origin for callback error redirects", async () => {
+    cookieGet.mockReturnValue(undefined)
+
+    const { GET } = await import("./route")
+    const response = await GET(
+      new Request("https://0.0.0.0:8080/api/auth/callback?code=c&state=s"),
+    )
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3002/login?error=invalid_state",
+    )
+  })
+
   it("sets a Manager-local session after Auth token and Admin membership validation", async () => {
     cookieGet.mockImplementation((name: string) => {
       const values: Record<string, string> = {

--- a/apps/manager/src/app/api/auth/callback/route.ts
+++ b/apps/manager/src/app/api/auth/callback/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: Request) {
     state !== expectedState ||
     !codeVerifier
   ) {
-    return redirectToLogin(request, "invalid_state")
+    return redirectToLogin(config.managerBaseUrl, "invalid_state")
   }
 
   try {
@@ -59,7 +59,7 @@ export async function GET(request: Request) {
     })
 
     if (!adminSession) {
-      return redirectToLogin(request, "forbidden")
+      return redirectToLogin(config.managerBaseUrl, "forbidden")
     }
 
     const response = NextResponse.redirect(new URL(returnTo, request.url))
@@ -87,13 +87,16 @@ export async function GET(request: Request) {
       message: error instanceof Error ? error.message : "unknown",
     })
 
-    return redirectToLogin(request, "callback_failed")
+    return redirectToLogin(config.managerBaseUrl, "callback_failed")
   }
 }
 
-function redirectToLogin(request: Request, reason: string) {
+function redirectToLogin(managerBaseUrl: string, reason: string) {
   const response = NextResponse.redirect(
-    new URL(`/login?error=${encodeURIComponent(reason)}`, request.url),
+    new URL(
+      `/login?error=${encodeURIComponent(reason)}`,
+      managerBaseUrl.replace(/\/$/, ""),
+    ),
   )
   response.cookies.delete(MANAGER_SESSION_COOKIE)
   response.cookies.delete(MANAGER_OAUTH_STATE_COOKIE)


### PR DESCRIPTION
## Summary

Manager OAuth callback failures now redirect back to the configured public Manager origin instead of the incoming request origin. On Railway, callback error paths can see the request URL as the internal standalone bind host (`https://0.0.0.0:8080`), which leaked into `Location` headers for `invalid_state`, `forbidden`, and `callback_failed` responses.

This keeps all callback error redirects anchored to `MANAGER_BASE_URL`, matching the successful OAuth login/callback configuration.

## Validation

- `pnpm --filter @forge/manager test -- src/app/api/auth/callback/route.test.ts`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-10a37f?logo=openai&logoColor=white)
