### PR TITLE
fix(admin): show loading feedback for slow routes

### DIFF
--- a/apps/admin/docs/worktree-preview-setup.md
+++ b/apps/admin/docs/worktree-preview-setup.md
@@ -158,6 +158,10 @@ curl -I -sS "http://localhost:${PORT}/dashboard/workflows" | sed -n '1,20p'
 curl -I -sS "http://localhost:${PORT}/dashboard/system-status" | sed -n '1,20p'
 ```
 
+For UI smoke checks, click between `/dashboard/videos` and
+`/dashboard/languages` after sign-in so the persistent shell, route loading
+states, and dashboard data boundaries all run through the browser.
+
 If Workflow Postgres World has runtime rows, open
 `/dashboard/workflows/<runId>` in the browser to smoke the embedded
 `@workflow/web-shared` trace/detail view.

--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -556,6 +556,9 @@ import UsersPage from "./users/page"
 import SettingsPage from "./settings/page"
 import LanguagesPage from "./languages/page"
 import MediaPage from "./media/page"
+import DashboardLoading from "./loading"
+import VideosLoading from "./videos/loading"
+import LanguagesLoading from "./languages/loading"
 import { ExperiencesActions } from "./experiences/experiences-actions"
 import {
   DataTable,
@@ -569,6 +572,19 @@ async function htmlFrom(component: Promise<ReactNode>) {
 }
 
 describe("dashboard UI routes", () => {
+  it("renders dashboard and priority route loading fallbacks", () => {
+    const dashboard = renderToStaticMarkup(<DashboardLoading />)
+    const videos = renderToStaticMarkup(<VideosLoading />)
+    const languages = renderToStaticMarkup(<LanguagesLoading />)
+
+    expect(dashboard).toContain('role="status"')
+    expect(dashboard).toContain('aria-label="Loading dashboard"')
+    expect(videos).toContain('aria-label="Loading video library"')
+    expect(videos).toContain("Loading video library")
+    expect(languages).toContain('aria-label="Loading language diagnostics"')
+    expect(languages).toContain("Loading language diagnostics")
+  })
+
   it("renders primary buttons with explicit enabled and disabled affordances", () => {
     const enabled = renderToStaticMarkup(
       <PrimaryButton>Enabled primary</PrimaryButton>,

--- a/apps/admin/src/app/dashboard/languages/loading.tsx
+++ b/apps/admin/src/app/dashboard/languages/loading.tsx
@@ -1,0 +1,88 @@
+import { LoaderCircle } from "lucide-react"
+
+function SkeletonLine({ className = "" }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`block rounded-sm bg-[var(--color-surface-raised)] ${className}`}
+    />
+  )
+}
+
+export default function LanguagesLoading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading language diagnostics"
+      className="flex flex-col gap-6"
+    >
+      <div className="flex items-center gap-2 font-mono text-[11px] font-semibold uppercase text-[var(--color-success)]">
+        <LoaderCircle
+          aria-hidden="true"
+          className="h-3.5 w-3.5 animate-spin"
+          strokeWidth={1.5}
+        />
+        Loading language diagnostics
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <SkeletonLine className="h-3 w-28" />
+        <SkeletonLine className="h-7 w-64 max-w-full" />
+        <SkeletonLine className="h-4 w-[460px] max-w-full" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {Array.from({ length: 3 }, (_, index) => (
+          <div key={index} className="app-card flex flex-col gap-3 p-4">
+            <SkeletonLine className="h-3 w-28" />
+            <SkeletonLine className="h-7 w-16" />
+            <SkeletonLine className="h-3 w-24" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(340px,0.75fr)]">
+        <div className="flex flex-col gap-6">
+          <section className="app-card overflow-hidden">
+            <div className="hairline-strong-b flex items-center justify-between px-4 py-3">
+              <SkeletonLine className="h-3 w-40" />
+              <SkeletonLine className="h-3 w-32" />
+            </div>
+            <div className="space-y-3 p-4">
+              <SkeletonLine className="h-10 w-full" />
+              {Array.from({ length: 6 }, (_, index) => (
+                <div
+                  key={index}
+                  className="grid gap-3 rounded-sm border border-[var(--color-hairline)] p-3 md:grid-cols-[minmax(0,1fr)_160px_120px]"
+                >
+                  <SkeletonLine className="h-5 w-64 max-w-full" />
+                  <SkeletonLine className="h-5 w-32" />
+                  <SkeletonLine className="h-5 w-24" />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="app-card overflow-hidden">
+            <div className="hairline-strong-b px-4 py-3">
+              <SkeletonLine className="h-3 w-32" />
+            </div>
+            <div className="grid gap-3 p-4 md:grid-cols-3">
+              {Array.from({ length: 3 }, (_, index) => (
+                <SkeletonLine key={index} className="h-24 w-full" />
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <aside className="app-card flex flex-col gap-3 p-4">
+          <SkeletonLine className="h-3 w-32" />
+          <SkeletonLine className="h-20 w-full" />
+          <SkeletonLine className="h-7 w-28" />
+          <SkeletonLine className="h-7 w-36" />
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -1749,71 +1749,86 @@ async function loadVideoRowSlice({
     throw error
   }
 
+  if (videos.length === 0) {
+    return []
+  }
+
   const ids = videos.map((item) => item.id)
+  const routeManifestPromise = includeVisitorUrls
+    ? loadLatestWatchRouteManifest()
+    : Promise.resolve(null)
   let videoLocales: VideoLocaleRow[] = []
   let videoDubs: VideoDubRow[] = []
   let videoImages: VideoImageRow[] = []
   let videoChildRelations: Array<{ parentId: string }> = []
+  let routeManifest: Awaited<ReturnType<typeof loadLatestWatchRouteManifest>> =
+    null
   try {
-    ;[videoLocales, videoDubs, videoImages, videoChildRelations] =
-      await Promise.all([
-        prisma.videoLocale.findMany({
-          where: { videoId: { in: ids }, deletedAt: null },
-          select: {
-            videoId: true,
-            locale: true,
-            title: true,
-            description: true,
-            updatedAt: true,
-          },
-          orderBy: { updatedAt: "desc" },
-        }),
-        prisma.videoDub.findMany({
-          where: { videoId: { in: ids }, deletedAt: null },
-          include: {
-            language: {
-              select: {
-                bcp47: true,
-                countryLanguages: {
-                  where: { deletedAt: null },
-                  select: {
-                    order: true,
-                    primary: true,
-                    speakers: true,
-                    suggested: true,
-                    country: {
-                      select: {
-                        flagPngSrc: true,
-                        flagWebpSrc: true,
-                      },
+    ;[
+      videoLocales,
+      videoDubs,
+      videoImages,
+      videoChildRelations,
+      routeManifest,
+    ] = await Promise.all([
+      prisma.videoLocale.findMany({
+        where: { videoId: { in: ids }, deletedAt: null },
+        select: {
+          videoId: true,
+          locale: true,
+          title: true,
+          description: true,
+          updatedAt: true,
+        },
+        orderBy: { updatedAt: "desc" },
+      }),
+      prisma.videoDub.findMany({
+        where: { videoId: { in: ids }, deletedAt: null },
+        include: {
+          language: {
+            select: {
+              bcp47: true,
+              countryLanguages: {
+                where: { deletedAt: null },
+                select: {
+                  order: true,
+                  primary: true,
+                  speakers: true,
+                  suggested: true,
+                  country: {
+                    select: {
+                      flagPngSrc: true,
+                      flagWebpSrc: true,
                     },
                   },
                 },
-                iso3: true,
-                slug: true,
               },
+              iso3: true,
+              slug: true,
             },
           },
-          orderBy: { updatedAt: "desc" },
-        }),
-        prisma.videoImage.findMany({
-          where: { videoId: { in: ids } },
-          select: {
-            videoId: true,
-            url: true,
-            kind: true,
-            createdAt: true,
-          },
-          orderBy: { createdAt: "asc" },
-        }),
-        prisma.videoRelation.findMany({
-          where: {
-            parentId: { in: ids },
-            child: { deletedAt: null },
-          },
-          select: { parentId: true },
-        }),
-      ])
+        },
+        orderBy: { updatedAt: "desc" },
+      }),
+      prisma.videoImage.findMany({
+        where: { videoId: { in: ids } },
+        select: {
+          videoId: true,
+          url: true,
+          kind: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "asc" },
+      }),
+      prisma.videoRelation.findMany({
+        where: {
+          parentId: { in: ids },
+          child: { deletedAt: null },
+        },
+        select: { parentId: true },
+      }),
+      routeManifestPromise,
+    ])
   } catch (error) {
     if (isMissingTableError(error)) {
       return []
@@ -1852,10 +1867,6 @@ async function loadVideoRowSlice({
       (childCountByVideo.get(item.parentId) ?? 0) + 1,
     )
   }
-
-  const routeManifest = includeVisitorUrls
-    ? await loadLatestWatchRouteManifest()
-    : null
 
   return videos.map((video) => {
     const localeRows = localesByVideo.get(video.id) ?? []
@@ -1933,21 +1944,25 @@ export async function loadVideoLibraryPage(
     sort?: VideoLibrarySort
   },
 ) {
-  const [total, languageOptions, collectionSummary] = await Promise.all([
-    countActiveVideos({ category, collection, language, query }),
-    loadVideoLibraryLanguageOptions(language),
-    loadVideoCollectionSummary(collection),
-  ])
+  const totalPromise = countActiveVideos({
+    category,
+    collection,
+    language,
+    query,
+  })
+  const languageOptionsPromise = loadVideoLibraryLanguageOptions(language)
+  const collectionSummaryPromise = loadVideoCollectionSummary(collection)
+  const total = await totalPromise
   const pagination = createVideoLibraryPagination({
     total,
     requestedPage: page,
     pageSize,
   })
 
-  const rows =
+  const rowsPromise =
     total === 0
-      ? []
-      : await loadVideoRowSlice({
+      ? Promise.resolve([])
+      : loadVideoRowSlice({
           category,
           collection,
           language,
@@ -1958,6 +1973,11 @@ export async function loadVideoLibraryPage(
           sort,
           includeVisitorUrls: true,
         })
+  const [rows, languageOptions, collectionSummary] = await Promise.all([
+    rowsPromise,
+    languageOptionsPromise,
+    collectionSummaryPromise,
+  ])
 
   return { rows, pagination, languageOptions, collectionSummary }
 }

--- a/apps/admin/src/app/dashboard/loading.tsx
+++ b/apps/admin/src/app/dashboard/loading.tsx
@@ -1,0 +1,73 @@
+import { LoaderCircle } from "lucide-react"
+
+function SkeletonLine({ className = "" }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`block rounded-sm bg-[var(--color-surface-raised)] ${className}`}
+    />
+  )
+}
+
+export default function DashboardLoading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading dashboard"
+      className="flex min-w-0 flex-col gap-6"
+    >
+      <div className="flex items-center gap-2 font-mono text-[11px] font-semibold uppercase text-[var(--color-success)]">
+        <LoaderCircle
+          aria-hidden="true"
+          className="h-3.5 w-3.5 animate-spin"
+          strokeWidth={1.5}
+        />
+        Loading dashboard
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <SkeletonLine className="h-3 w-28" />
+        <SkeletonLine className="h-7 w-64 max-w-full" />
+        <SkeletonLine className="h-4 w-[420px] max-w-full" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-5">
+        {Array.from({ length: 5 }, (_, index) => (
+          <div key={index} className="app-card flex flex-col gap-3 p-4">
+            <SkeletonLine className="h-3 w-24" />
+            <SkeletonLine className="h-7 w-20" />
+            <SkeletonLine className="h-3 w-28" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <section className="app-card overflow-hidden">
+          <div className="hairline-strong-b flex items-center justify-between px-4 py-3">
+            <SkeletonLine className="h-3 w-32" />
+            <SkeletonLine className="h-3 w-20" />
+          </div>
+          <div className="divide-y divide-[var(--color-hairline)]">
+            {Array.from({ length: 5 }, (_, index) => (
+              <div key={index} className="grid gap-3 px-4 py-4 md:grid-cols-4">
+                <SkeletonLine className="h-4 w-40 md:col-span-2" />
+                <SkeletonLine className="h-4 w-24" />
+                <SkeletonLine className="h-4 w-28" />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <aside className="app-card flex flex-col gap-3 p-4">
+          <SkeletonLine className="h-3 w-28" />
+          <SkeletonLine className="h-20 w-full" />
+          <div className="flex flex-wrap gap-2">
+            <SkeletonLine className="h-7 w-24" />
+            <SkeletonLine className="h-7 w-28" />
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/videos/loading.tsx
+++ b/apps/admin/src/app/dashboard/videos/loading.tsx
@@ -1,0 +1,89 @@
+import { LoaderCircle } from "lucide-react"
+
+function SkeletonLine({ className = "" }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`block rounded-sm bg-[var(--color-surface-raised)] ${className}`}
+    />
+  )
+}
+
+function VideoSkeletonRow({ index }: { index: number }) {
+  return (
+    <article className="grid gap-4 border-b border-[var(--color-hairline)] px-4 py-4 last:border-b-0 lg:grid-cols-[168px_minmax(0,1fr)_minmax(220px,300px)_104px] lg:items-center">
+      <div className="aspect-video w-full rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] sm:w-[168px]" />
+      <div className="min-w-0 space-y-3">
+        <SkeletonLine className="h-5 w-[min(260px,80%)]" />
+        <SkeletonLine className="h-3 w-[min(360px,92%)]" />
+      </div>
+      <div className="min-w-0 space-y-3">
+        <div className="flex items-end justify-between gap-3">
+          <SkeletonLine className="h-7 w-28" />
+          <SkeletonLine className="h-3 w-10" />
+        </div>
+        <SkeletonLine className="h-1.5 w-full rounded-full" />
+        <div className="flex gap-1.5">
+          {Array.from({ length: 4 }, (_, chipIndex) => (
+            <SkeletonLine key={`${index}-${chipIndex}`} className="h-6 w-14" />
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-3 lg:flex-col lg:items-end">
+        <SkeletonLine className="h-4 w-20" />
+        <div className="flex gap-2">
+          <SkeletonLine className="h-8 w-8" />
+          <SkeletonLine className="h-8 w-8" />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export default function VideosLoading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading video library"
+      className="flex min-w-0 flex-col gap-5"
+    >
+      <div className="flex items-center gap-2 font-mono text-[11px] font-semibold uppercase text-[var(--color-success)]">
+        <LoaderCircle
+          aria-hidden="true"
+          className="h-3.5 w-3.5 animate-spin"
+          strokeWidth={1.5}
+        />
+        Loading video library
+      </div>
+
+      <header className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+        <div className="min-w-0 space-y-3">
+          <SkeletonLine className="h-3 w-28" />
+          <SkeletonLine className="h-7 w-56 max-w-full" />
+          <SkeletonLine className="h-4 w-[420px] max-w-full" />
+        </div>
+        <SkeletonLine className="h-8 w-40" />
+      </header>
+
+      <section className="flex min-w-0 flex-col gap-3">
+        <SkeletonLine className="h-10 w-full" />
+        <div className="flex gap-2 overflow-hidden">
+          <SkeletonLine className="h-10 w-[168px] shrink-0" />
+          <SkeletonLine className="h-10 w-[190px] shrink-0" />
+          <SkeletonLine className="h-10 w-[210px] shrink-0" />
+        </div>
+      </section>
+
+      <section className="app-card min-w-0 overflow-hidden">
+        {Array.from({ length: 5 }, (_, index) => (
+          <VideoSkeletonRow key={index} index={index} />
+        ))}
+        <div className="flex items-center justify-between border-t border-[var(--color-hairline)] px-4 py-3">
+          <SkeletonLine className="h-4 w-40" />
+          <SkeletonLine className="h-8 w-48" />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/videos/video-library-toolbar.tsx
+++ b/apps/admin/src/app/dashboard/videos/video-library-toolbar.tsx
@@ -21,6 +21,7 @@ import {
   X,
 } from "lucide-react"
 import type { getAdminMessages } from "@/i18n/server"
+import { ADMIN_NAVIGATION_PENDING_EVENT } from "@/components/admin-shell"
 import {
   parseVideoLibraryCategory,
   parseVideoLibraryLanguage,
@@ -368,6 +369,7 @@ export function VideoLibraryToolbar({
     }
 
     setIsSubmitting(true)
+    window.dispatchEvent(new Event(ADMIN_NAVIGATION_PENDING_EVENT))
     router.push(href as Route)
   }
 

--- a/apps/admin/src/components/admin-shell.test.tsx
+++ b/apps/admin/src/components/admin-shell.test.tsx
@@ -1,11 +1,15 @@
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it, vi } from "vitest"
-import { AdminShell } from "@/components/admin-shell"
+import {
+  AdminShell,
+  shouldStartAdminNavigationFeedback,
+} from "@/components/admin-shell"
 import { adminMessages } from "@/i18n/messages"
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/dashboard",
   useRouter: () => ({ refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }))
 
 vi.mock("@/i18n/client", () => ({
@@ -38,6 +42,7 @@ describe("admin shell", () => {
         `<button(?=[^>]*disabled="")(?=[^>]*aria-label="${adminMessages.es.common.helpUnavailable}")`,
       ),
     )
+    expect(html).not.toContain('data-admin-navigation-feedback="pending"')
   })
 
   it("hides admin-only routes for editor principals", () => {
@@ -49,5 +54,65 @@ describe("admin shell", () => {
 
     expect(html).not.toContain(adminMessages.es.nav.items.users.label)
     expect(html).not.toContain(adminMessages.es.nav.items.settings.label)
+  })
+
+  it("recognizes internal dashboard navigation that should show pending feedback", () => {
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref: "http://localhost:3003/dashboard",
+        href: "http://localhost:3003/dashboard/videos",
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref: "http://localhost:3003/dashboard/videos?page=1",
+        href: "http://localhost:3003/dashboard/videos?page=2",
+      }),
+    ).toBe(true)
+  })
+
+  it("ignores links that should not start route feedback", () => {
+    const currentHref = "http://localhost:3003/dashboard/videos?page=1"
+
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref,
+        href: "http://localhost:3003/dashboard/videos?page=1",
+      }),
+    ).toBe(false)
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref,
+        href: "https://www.jesusfilm.org/watch/easter.html",
+      }),
+    ).toBe(false)
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref,
+        href: "http://localhost:3003/dashboard-preview",
+      }),
+    ).toBe(false)
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref,
+        href: "http://localhost:3003/dashboard/languages",
+        modified: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref,
+        href: "http://localhost:3003/dashboard/languages",
+        target: "_blank",
+      }),
+    ).toBe(false)
+    expect(
+      shouldStartAdminNavigationFeedback({
+        currentHref,
+        disabled: true,
+        href: "http://localhost:3003/dashboard/languages",
+      }),
+    ).toBe(false)
   })
 })

--- a/apps/admin/src/components/admin-shell.tsx
+++ b/apps/admin/src/components/admin-shell.tsx
@@ -3,12 +3,13 @@
 import type { Role } from "@/auth/principal"
 import type { Route } from "next"
 import Link from "next/link"
-import { usePathname, useRouter } from "next/navigation"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import {
   Command,
   Globe,
   HelpCircle,
+  LoaderCircle,
   Menu,
   Search,
   Sparkles,
@@ -33,6 +34,86 @@ type ProfileView = {
   name: string | null
   email: string | null
   image: string | null
+}
+
+type NavigationFeedbackCheck = {
+  button?: number
+  currentHref: string
+  disabled?: boolean
+  download?: boolean
+  href: string
+  modified?: boolean
+  target?: string | null
+}
+
+const ADMIN_ROUTE_PENDING_TIMEOUT_MS = 8000
+export const ADMIN_NAVIGATION_PENDING_EVENT = "admin:navigation-pending"
+
+function isDashboardPathname(pathname: string) {
+  return pathname === "/dashboard" || pathname.startsWith("/dashboard/")
+}
+
+export function shouldStartAdminNavigationFeedback({
+  button = 0,
+  currentHref,
+  disabled = false,
+  download = false,
+  href,
+  modified = false,
+  target = null,
+}: NavigationFeedbackCheck) {
+  if (disabled || download || modified || button !== 0) {
+    return false
+  }
+
+  if (target && target !== "_self") {
+    return false
+  }
+
+  try {
+    const destination = new URL(href, currentHref)
+    const current = new URL(currentHref)
+
+    if (destination.origin !== current.origin) {
+      return false
+    }
+
+    if (!isDashboardPathname(destination.pathname)) {
+      return false
+    }
+
+    return (
+      destination.pathname !== current.pathname ||
+      destination.search !== current.search
+    )
+  } catch {
+    return false
+  }
+}
+
+function isElementDisabled(element: Element) {
+  return (
+    element.hasAttribute("disabled") ||
+    element.getAttribute("aria-disabled") === "true" ||
+    Boolean(element.closest("[aria-disabled='true'],[disabled]"))
+  )
+}
+
+function routeChangingFormHref(form: HTMLFormElement, currentHref: string) {
+  const method = (form.getAttribute("method") ?? "get").toLowerCase()
+  if (method !== "get") {
+    return null
+  }
+
+  const url = new URL(form.getAttribute("action") || currentHref, currentHref)
+  const searchParams = new URLSearchParams()
+  for (const [key, value] of new FormData(form)) {
+    if (typeof value === "string") {
+      searchParams.append(key, value)
+    }
+  }
+  url.search = searchParams.toString()
+  return url.href
 }
 
 function isActive(pathname: string, href: string) {
@@ -81,11 +162,14 @@ export function AdminShell({
   children: ReactNode
 }) {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const router = useRouter()
   const { locale, messages } = useAdminI18n()
   const [isPaletteOpen, setPaletteOpen] = useState(false)
   const [isNavOpen, setNavOpen] = useState(false)
   const [isSwitchingLocale, setIsSwitchingLocale] = useState(false)
+  const [navigationPending, setNavigationPending] = useState(false)
+  const routeKey = `${pathname}?${searchParams.toString()}`
   const activeItem = getNavItem(pathname)
   const isFullCanvasRoute =
     (pathname.startsWith("/dashboard/experiences/") &&
@@ -129,6 +213,92 @@ export function AdminShell({
   useEffect(() => {
     setNavOpen(false)
   }, [pathname])
+
+  useEffect(() => {
+    setNavigationPending(false)
+  }, [routeKey])
+
+  useEffect(() => {
+    if (!navigationPending) {
+      return
+    }
+
+    const timeout = window.setTimeout(
+      () => setNavigationPending(false),
+      ADMIN_ROUTE_PENDING_TIMEOUT_MS,
+    )
+
+    return () => window.clearTimeout(timeout)
+  }, [navigationPending])
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+
+      const anchor = target.closest("a[href]")
+      if (!(anchor instanceof HTMLAnchorElement)) {
+        return
+      }
+
+      if (
+        shouldStartAdminNavigationFeedback({
+          button: event.button,
+          currentHref: window.location.href,
+          disabled: isElementDisabled(anchor),
+          download: anchor.hasAttribute("download"),
+          href: anchor.href,
+          modified:
+            event.altKey || event.ctrlKey || event.metaKey || event.shiftKey,
+          target: anchor.target,
+        })
+      ) {
+        setNavigationPending(true)
+      }
+    }
+
+    function handlePendingEvent() {
+      setNavigationPending(true)
+    }
+
+    function handleSubmit(event: SubmitEvent) {
+      const target = event.target
+      if (!(target instanceof HTMLFormElement)) {
+        return
+      }
+
+      const href = routeChangingFormHref(target, window.location.href)
+      if (!href) {
+        return
+      }
+
+      if (
+        shouldStartAdminNavigationFeedback({
+          currentHref: window.location.href,
+          disabled: isElementDisabled(target),
+          href,
+          target: target.target,
+        })
+      ) {
+        setNavigationPending(true)
+      }
+    }
+
+    document.addEventListener("click", handleClick, true)
+    document.addEventListener("submit", handleSubmit, true)
+    window.addEventListener(ADMIN_NAVIGATION_PENDING_EVENT, handlePendingEvent)
+
+    return () => {
+      document.removeEventListener("click", handleClick, true)
+      document.removeEventListener("submit", handleSubmit, true)
+      window.removeEventListener(
+        ADMIN_NAVIGATION_PENDING_EVENT,
+        handlePendingEvent,
+      )
+    }
+  }, [])
 
   async function handleLocaleChange(nextLocale: string) {
     if (nextLocale === locale) {
@@ -272,6 +442,28 @@ export function AdminShell({
             </div>
           </div>
         </header>
+        {navigationPending ? (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            data-admin-navigation-feedback="pending"
+            className="sticky top-12 z-20 flex h-8 items-center gap-2 border-b border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-6 font-mono text-[11px] font-semibold uppercase text-[var(--color-success)] shadow-[0_8px_18px_rgba(0,0,0,0.18)]"
+          >
+            <LoaderCircle
+              className="h-3.5 w-3.5 animate-spin"
+              strokeWidth={1.6}
+              aria-hidden="true"
+            />
+            {messages.common.navigationLoading}
+            <span
+              aria-hidden="true"
+              className="ml-auto h-px w-24 overflow-hidden rounded-full bg-[var(--color-hairline-strong)]"
+            >
+              <span className="block h-full w-1/2 animate-pulse rounded-full bg-[var(--color-success)]" />
+            </span>
+          </div>
+        ) : null}
         <main className="flex-1 bg-[var(--color-bg)]">
           <div
             className={cx(

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -25,6 +25,7 @@ export const adminMessages = {
       openCommandPalette: "Open command palette",
       closeCommandPalette: "Close command palette",
       helpUnavailable: "Help is not available yet",
+      navigationLoading: "Loading route...",
       context: "Context",
       paletteContext:
         "This palette is shared across the entire dashboard shell and uses the same route registry as the sidebar so future pages stay synchronized automatically.",
@@ -1142,6 +1143,7 @@ export const adminMessages = {
       openCommandPalette: "Abrir paleta de comandos",
       closeCommandPalette: "Cerrar paleta de comandos",
       helpUnavailable: "La ayuda aun no esta disponible",
+      navigationLoading: "Cargando ruta...",
       context: "Contexto",
       paletteContext:
         "Esta paleta se comparte en todo el panel y usa el mismo registro de rutas que la barra lateral para que las futuras páginas permanezcan sincronizadas automáticamente.",

--- a/docs/brainstorms/2026-06-04-admin-loading-feedback-requirements.md
+++ b/docs/brainstorms/2026-06-04-admin-loading-feedback-requirements.md
@@ -1,0 +1,188 @@
+---
+date: 2026-06-04
+topic: admin-loading-feedback
+---
+
+# Admin Loading Feedback And Slow Route UX
+
+## Summary
+
+Improve Forge Admin so route changes acknowledge clicks immediately and slow
+dashboard pages show purposeful loading states while targeted performance work
+reduces the heaviest videos and languages waits.
+
+---
+
+## Problem Frame
+
+Operators using Forge Admin can click into data-heavy screens such as
+`/dashboard/videos` and `/dashboard/languages` and see the current window stay
+visually still while the next server-rendered route loads. The delay makes it
+unclear whether the click was registered, which undermines trust even when the
+route eventually succeeds.
+
+---
+
+## Actors
+
+- A1. Admin operator: uses the dashboard to browse videos, language diagnostics,
+  and other operational screens.
+- A2. Implementing agent: plans and ships a scoped admin UX/performance slice
+  without widening into unrelated admin redesign work.
+
+---
+
+## Key Flows
+
+- F1. Navigation click feedback
+  - **Trigger:** An operator clicks an internal dashboard link, sidebar item,
+    command-palette route, pagination control, or row link.
+  - **Actors:** A1
+  - **Steps:** The click receives immediate visual acknowledgement; the current
+    route remains understandable while the next route resolves; the pending
+    state clears when the new route is ready.
+  - **Outcome:** The operator can tell the click was accepted even when server
+    rendering or data loading takes noticeable time.
+  - **Covered by:** R1, R2, R3, R5
+
+- F2. Slow page load fallback
+  - **Trigger:** An operator navigates to `/dashboard/videos`,
+    `/dashboard/languages`, or another dashboard route whose server work does
+    not resolve instantly.
+  - **Actors:** A1
+  - **Steps:** The dashboard shell stays stable; the content area shows a
+    Forge Editorial loading surface; videos and languages use skeletons that
+    match their final information architecture; the final content replaces the
+    fallback without layout shock.
+  - **Outcome:** The slow route feels like active loading rather than a frozen
+    browser window.
+  - **Covered by:** R2, R4, R5, R6, R8
+
+- F3. Performance follow-through
+  - **Trigger:** Implementation identifies obvious route work that can be made
+    cheaper without changing product behavior.
+  - **Actors:** A2
+  - **Steps:** The implementing agent measures or characterizes the heavy path,
+    applies targeted improvements, and preserves route behavior with tests.
+  - **Outcome:** The first PR improves perceived speed everywhere and reduces
+    confirmed slow work on priority routes where safe.
+  - **Covered by:** R7, R8, R9, R10
+
+---
+
+## Requirements
+
+**Navigation Feedback**
+
+- R1. Internal admin navigation must show immediate feedback after a click or
+  route-changing submission starts, including sidebar links, command-palette
+  route links, video row links, and pagination links.
+- R2. Pending feedback must preserve the current dashboard shell and make the
+  loading state visible without hiding or scrambling existing context.
+- R3. Pending feedback must clear when the destination route or URL state has
+  resolved, including query-string-only changes such as video filters or
+  pagination.
+- R4. Route-level loading fallbacks must use the existing Forge Editorial visual
+  grammar and must not introduce a separate visual system.
+
+**Priority Routes**
+
+- R5. `/dashboard/videos` must have a loading fallback shaped like the video
+  library page so operators see that catalog data is loading.
+- R6. `/dashboard/languages` must have a loading fallback shaped like the
+  language diagnostics page so operators see that diagnostics are loading.
+- R7. Video and language route performance improvements should be targeted to
+  confirmed heavy work and must preserve existing read-only behavior,
+  URL-backed filters, pagination, diagnostics, and empty states.
+
+**Quality And Boundaries**
+
+- R8. Loading states must be accessible to keyboard and assistive-technology
+  users through appropriate status semantics or live announcements.
+- R9. The implementation must not change Prisma schema, Pothos schema,
+  GraphQL SDL, generated clients, auth/session semantics, or public consumer
+  app behavior unless a measured bottleneck proves such a change is required.
+- R10. Tests and browser proof must cover both the visible route feedback and
+  the priority slow-route loading surfaces.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3.** Given an operator is on `/dashboard`, when they
+  click the sidebar Videos link, the shell immediately shows a route-changing
+  status and the status clears after `/dashboard/videos` is active.
+- AE2. **Covers R1, R3.** Given an operator is on `/dashboard/videos`, when
+  they click pagination or submit a filter that changes only the query string,
+  pending feedback appears and clears when the updated URL state is rendered.
+- AE3. **Covers R5, R6.** Given `/dashboard/videos` or `/dashboard/languages`
+  server data is still loading during navigation, the content area shows a
+  page-shaped loading surface rather than leaving the old route looking idle.
+- AE4. **Covers R7, R9.** Given a performance improvement is made to a priority
+  route, existing filters, diagnostics, read-only boundaries, and generated
+  GraphQL outputs remain unchanged.
+
+---
+
+## Success Criteria
+
+- Operators can tell within one interaction beat that a dashboard click or
+  filter submission was accepted.
+- Slow videos and languages navigations feel active and intentional instead of
+  frozen.
+- The first implementation slice improves perceived loading across admin and
+  includes targeted route-speed work only where the codebase shows a safe,
+  confirmed opportunity.
+- The handoff to planning is concrete enough that implementation does not need
+  to invent loading behavior, scope boundaries, or validation expectations.
+
+---
+
+## Scope Boundaries
+
+- Do not redesign the admin navigation, dashboard layout system, or Forge
+  Editorial token palette.
+- Do not build new video creation, editing, language editing, or bulk action
+  workflows.
+- Do not add saved views, advanced search syntax, or broader dashboard
+  performance rewrites.
+- Do not change Prisma, Pothos, GraphQL generated outputs, or public app
+  contracts unless profiling proves a narrow contract change is necessary.
+- Do not attempt to solve every admin route's data-loading cost in one PR.
+
+---
+
+## Key Decisions
+
+- Use a staged approach: immediate route feedback comes first, then targeted
+  slow-route improvements.
+- Make the loading pattern shared at the admin shell/route level so the fix is
+  not limited to videos.
+- Treat `/dashboard/videos` and `/dashboard/languages` as priority proof
+  points because they are the screens called out by the user and already have
+  heavy server-owned data loaders.
+- Preserve the existing dense, operational admin design language; loading UI
+  should feel native to Forge Editorial rather than decorative.
+
+---
+
+## Dependencies / Assumptions
+
+- The dashboard remains a Next.js App Router surface with a persistent admin
+  shell and server-rendered route content.
+- Current video filters, pagination, and language diagnostics are expected to
+  continue working without schema changes.
+- Browser validation should use the repo's configured admin local-dev path and
+  Helium/in-app browser availability for local smoke proof.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R7][Needs research] Which route-load work is actually the safest
+  first performance win after inspecting current videos and languages data
+  paths?
+- [Affects R10][Needs research] Which local browser surface is available in the
+  current Codex environment for the required admin smoke proof?

--- a/docs/plans/2026-06-04-002-feat-admin-loading-feedback-plan.md
+++ b/docs/plans/2026-06-04-002-feat-admin-loading-feedback-plan.md
@@ -1,0 +1,476 @@
+---
+title: "feat: Admin loading feedback and slow route UX"
+type: feat
+status: completed
+date: 2026-06-04
+origin: docs/brainstorms/2026-06-04-admin-loading-feedback-requirements.md
+roadmap: docs/roadmap/platform/feat-158-admin-loading-feedback-and-slow-route-ux.md
+---
+
+# feat: Admin loading feedback and slow route UX
+
+## Summary
+
+Add a shared admin navigation-pending layer, page-shaped loading fallbacks, and
+targeted videos/languages route improvements so slow server-rendered dashboard
+transitions feel acknowledged and intentional.
+
+---
+
+## Problem Frame
+
+The origin document describes an operator trust problem: slow admin routes can
+leave the old screen visually still after a click, making it unclear whether the
+action registered.
+
+---
+
+## Requirements
+
+- R1. Internal admin navigation shows immediate feedback after route-changing
+  clicks or submissions.
+- R2. Pending feedback preserves the current dashboard shell and existing
+  context.
+- R3. Pending feedback clears after destination pathname or query state is
+  rendered.
+- R4. Loading fallbacks use Forge Editorial visual grammar.
+- R5. `/dashboard/videos` has a video-library-shaped loading fallback.
+- R6. `/dashboard/languages` has a language-diagnostics-shaped loading
+  fallback.
+- R7. Priority-route performance improvements are targeted to confirmed heavy
+  work and preserve existing behavior.
+- R8. Loading states are accessible through status semantics or live
+  announcements.
+- R9. No Prisma, Pothos, GraphQL SDL, generated client, auth/session, or public
+  app contract changes unless a measured bottleneck requires it.
+- R10. Tests and browser proof cover visible route feedback and priority
+  loading surfaces.
+
+**Origin actors:** A1 Admin operator, A2 Implementing agent
+**Origin flows:** F1 Navigation click feedback, F2 Slow page load fallback, F3
+Performance follow-through
+**Origin acceptance examples:** AE1, AE2, AE3, AE4
+
+---
+
+## Scope Boundaries
+
+- Do not redesign the admin navigation, dashboard layout system, or token
+  palette.
+- Do not build new video creation, editing, language editing, or bulk action
+  workflows.
+- Do not add saved views, advanced search syntax, or broad dashboard
+  performance rewrites.
+- Do not change Prisma, Pothos, GraphQL generated outputs, auth/session
+  semantics, or public app contracts.
+- Do not attempt to solve every admin route's data-loading cost in this PR.
+
+### Deferred to Follow-Up Work
+
+- Deeper backend route decomposition or new data contracts for videos/languages
+  should be filed separately if browser or profiling evidence shows the first
+  slice cannot make the wait acceptable.
+- Full admin performance instrumentation, route timing dashboards, and
+  production RUM are outside this PR-sized UX fix.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/components/admin-shell.tsx` is a client component that owns
+  the persistent shell, sidebar, command palette, and content wrapper. It can
+  provide cross-route navigation feedback without touching every page.
+- `apps/admin/src/app/dashboard/layout.tsx` keeps the shell persistent and
+  renders route children inside it after `requireSession`.
+- `apps/admin/src/app/dashboard/videos/page.tsx` renders server-owned video
+  library content, row links, visitor links, and pagination links.
+- `apps/admin/src/app/dashboard/videos/video-library-toolbar.tsx` already uses
+  local pending state for filter submissions, which this plan should preserve
+  and complement rather than replace.
+- `apps/admin/src/app/dashboard/languages/page.tsx` blocks on
+  `loadLanguagesData()` before rendering metrics, diagnostics, and locale
+  signals.
+- `apps/admin/src/app/dashboard/ops-data.ts` loads a complete active language
+  diagnostic dataset with relation counts/previews.
+- `apps/admin/src/app/dashboard/live-data.ts` loads video library totals,
+  language options, collection summaries, rows, and visitor URLs.
+- `apps/admin/src/components/admin-ui.tsx` contains the shared token grammar,
+  cards, tables, status pills, and button primitives to mirror in loading UI.
+- `apps/admin/src/components/admin-shell.test.tsx`,
+  `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`, and
+  `apps/admin/src/app/dashboard/languages/language-diagnostics.test.tsx`
+  provide focused test surfaces for this work.
+
+### Institutional Learnings
+
+- `docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md`
+  established the rule that admin controls must communicate clickability and
+  disabled state clearly.
+- `docs/plans/2026-06-01-001-fix-admin-interaction-affordances-plan.md`
+  documents the prior affordance pass and the need to keep disabled or
+  unavailable controls visually honest.
+- `docs/plans/2026-06-02-003-feat-admin-language-diagnostics-plan.md`
+  explains why the languages page intentionally hydrates the active language
+  corpus for diagnostics.
+- `docs/plans/2026-06-03-001-feat-admin-video-library-controls-plan.md`
+  documents the existing video toolbar pending state and URL-backed filters.
+
+### External References
+
+- External research skipped. The repo already uses Next.js App Router,
+  server-rendered dashboard pages, client shell components, and local pending
+  UI patterns sufficient for this slice.
+
+---
+
+## Key Technical Decisions
+
+- Put the first feedback layer in the persistent admin shell: this catches
+  sidebar, command-palette, pagination, and row-link navigation without a
+  route-by-route retrofit.
+- Detect internal dashboard links and route-changing form submissions at the
+  shell boundary, then clear pending state on pathname or search-param changes.
+  This is broad enough for current admin navigation while avoiding external
+  links, downloads, modified-click new tabs, and disabled controls.
+- Add route-level `loading.tsx` fallbacks so the content area can switch to
+  purposeful loading UI while server routes resolve.
+- Keep videos' existing toolbar pending feedback in place. The shared shell
+  indicator complements it for route-level navigation and links.
+- Treat performance work as opportunistic and evidence-driven inside the first
+  PR: apply narrow improvements that preserve existing behavior, and defer any
+  deeper data-contract change.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the first slice prioritize feedback or speed? The user selected the
+  staged option: both, with immediate feedback first and targeted performance
+  follow-through.
+- Should this be videos-only? No. Videos and languages are proof points, but
+  the click acknowledgement belongs to the shared admin shell.
+- Should this change GraphQL or Prisma contracts? No known need in the current
+  plan; keep performance improvements inside existing contracts.
+
+### Deferred to Implementation
+
+- Exact loading skeleton component boundaries can be tuned once the route files
+  are edited.
+- Exact performance improvement should be selected after re-reading the current
+  loader code and choosing the safest behavior-preserving change.
+- Exact local browser driver depends on the available Codex/Helium surface in
+  this environment.
+
+---
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should treat
+> it as context, not code to reproduce._
+
+```mermaid
+flowchart LR
+  A["Operator clicks internal dashboard link or submits route-changing form"]
+  B["Admin shell sets pending navigation state immediately"]
+  C["Next.js App Router starts server route transition"]
+  D["Dashboard loading fallback renders when route segment is suspended"]
+  E["Destination pathname/search state commits"]
+  F["Admin shell clears pending state"]
+
+  A --> B --> C --> D --> E --> F
+```
+
+---
+
+## Implementation Units
+
+### U1. Shared Admin Navigation Feedback
+
+**Goal:** Add shell-level pending feedback for internal admin navigation and
+route-changing submissions.
+
+**Requirements:** R1, R2, R3, R8
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/admin/src/components/admin-shell.tsx`
+- Test: `apps/admin/src/components/admin-shell.test.tsx`
+
+**Approach:**
+
+- Add a compact route-pending indicator to the existing sticky header or main
+  content boundary using current admin tokens.
+- Detect same-origin internal dashboard anchors in a shell-level event listener
+  and ignore external links, new-tab modifier clicks, downloads, disabled
+  controls, and current-URL no-ops.
+- Detect route-changing form submissions that target internal dashboard paths.
+- Clear pending state whenever the committed pathname or search params change,
+  with a defensive timeout so stale feedback cannot linger forever after a
+  same-URL or interrupted transition.
+- Include accessible status semantics or a live region without making the
+  indicator noisy.
+
+**Patterns to follow:**
+
+- `apps/admin/src/components/admin-shell.tsx` for shell state and mobile nav
+  interaction patterns.
+- `apps/admin/src/app/dashboard/videos/video-library-toolbar.tsx` for concise
+  pending status treatment.
+
+**Test scenarios:**
+
+- Happy path: rendering the shell includes an accessible navigation loading
+  status surface that is initially inactive.
+- Happy path: a sidebar or command-palette internal dashboard link can activate
+  pending feedback.
+- Edge case: external links or new-tab modifier clicks do not activate pending
+  feedback.
+- Edge case: pending feedback clears when pathname or search params change.
+
+**Verification:**
+
+- Shell tests prove the indicator is accessible and route-state driven without
+  changing existing navigation rendering.
+
+---
+
+### U2. Dashboard And Route-Shaped Loading Fallbacks
+
+**Goal:** Add App Router loading fallbacks that keep the admin shell stable and
+show page-shaped skeletons for slow dashboard routes.
+
+**Requirements:** R2, R4, R5, R6, R8
+
+**Dependencies:** U1
+
+**Files:**
+
+- Create: `apps/admin/src/app/dashboard/loading.tsx`
+- Create: `apps/admin/src/app/dashboard/videos/loading.tsx`
+- Create: `apps/admin/src/app/dashboard/languages/loading.tsx`
+- Modify as needed: `apps/admin/src/components/admin-ui.tsx`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+
+**Approach:**
+
+- Create a general dashboard fallback for routes without bespoke loading UI.
+- Create a video-library-shaped skeleton that mirrors the header, toolbar, list
+  rows, coverage column, and pagination density.
+- Create a language-diagnostics-shaped skeleton that mirrors metrics,
+  diagnostics, insights, and operator rail structure.
+- Reuse existing admin card, hairline, mono-label, and muted text styles rather
+  than adding decorative loaders.
+
+**Patterns to follow:**
+
+- `apps/admin/src/app/dashboard/videos/page.tsx` for video page composition.
+- `apps/admin/src/app/dashboard/languages/page.tsx` for language page
+  composition.
+- `apps/admin/src/components/admin-ui.tsx` for shared page/card grammar.
+
+**Test scenarios:**
+
+- Happy path: dashboard loading fallback renders a visible status and stable
+  skeleton structure.
+- Happy path: videos loading fallback renders video-library-shaped placeholder
+  rows.
+- Happy path: languages loading fallback renders language-diagnostics-shaped
+  placeholder sections.
+- Accessibility: loading fallbacks expose a status label that screen readers can
+  announce.
+
+**Verification:**
+
+- Route loading components are covered by focused render tests and visually
+  match the final page hierarchy closely enough for no-jump perception.
+
+---
+
+### U3. Targeted Videos And Languages Load Improvements
+
+**Goal:** Apply behavior-preserving route-load improvements where the current
+loaders show safe confirmed waste.
+
+**Requirements:** R7, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/live-data.ts`
+- Modify as needed: `apps/admin/src/app/dashboard/ops-data.ts`
+- Test: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Test as needed: `apps/admin/src/app/dashboard/languages/language-diagnostics.test.tsx`
+
+**Approach:**
+
+- Re-read the video loader and remove or defer unnecessary work when route
+  state does not need it, while keeping totals, rows, language options,
+  collection summaries, visitor links, and filters truthful.
+- Re-read the language loader for obvious avoidable serial work or repeated
+  derivations, while preserving the complete active diagnostics dataset.
+- Prefer parallelization, conditional loading, bounded fallbacks, and cheap
+  memoization over schema or contract changes.
+- If no safe performance change is available without changing behavior, keep U3
+  to characterization notes and do not invent a risky rewrite.
+
+**Patterns to follow:**
+
+- Existing `Promise.all` use in `loadVideoLibraryPage` and
+  `loadLanguagesData`.
+- Existing missing-table fallback behavior in `ops-data.ts` and
+  `live-data.ts`.
+
+**Test scenarios:**
+
+- Regression: video page still renders totals, rows, filters, pagination, and
+  visitor link states after loader changes.
+- Regression: languages diagnostics still renders complete diagnostic rows and
+  summary counts after loader changes.
+- Edge case: missing-table fallbacks continue to produce controlled empty data
+  rather than throwing.
+
+**Verification:**
+
+- The route data behavior remains equivalent under tests, and any performance
+  change is explainable from reduced or better-sequenced loader work.
+
+---
+
+### U4. Validation And Browser Smoke Proof
+
+**Goal:** Prove the implemented loading behavior with focused tests and a local
+browser smoke pass.
+
+**Requirements:** R10
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+
+- Modify: `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`
+- Modify: `apps/admin/src/components/admin-shell.test.tsx`
+- Modify as needed: `apps/admin/docs/worktree-preview-setup.md`
+
+**Approach:**
+
+- Extend existing render tests instead of introducing a new test harness.
+- Run admin typecheck and targeted tests for shell, dashboard, videos, and
+  languages.
+- Start the admin local dev server using the package's worktree preview
+  instructions when browser proof is needed.
+- Use the available Helium/in-app browser surface to click through dashboard,
+  videos, a videos query transition, and languages.
+
+**Patterns to follow:**
+
+- `apps/admin/docs/worktree-preview-setup.md` for local admin server setup.
+- Existing `apps/admin/src/app/dashboard/dashboard-ui.test.tsx` test style.
+
+**Test scenarios:**
+
+- Integration: clicking a dashboard navigation link shows visible loading
+  feedback during the transition in browser smoke.
+- Integration: videos route can load and a filter or pagination action provides
+  pending feedback.
+- Integration: languages route shows the diagnostics surface and remains
+  navigable from the shell.
+
+**Verification:**
+
+- Targeted tests, typecheck, and browser smoke all pass before commit/PR.
+
+---
+
+### U5. Roadmap And Handoff Closure
+
+**Goal:** Keep the roadmap and planning artifacts aligned with the shipped
+slice.
+
+**Requirements:** R10
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+
+- Modify: `docs/roadmap/platform/feat-158-admin-loading-feedback-and-slow-route-ux.md`
+- Modify as needed: `docs/plans/2026-06-04-002-feat-admin-loading-feedback-plan.md`
+
+**Approach:**
+
+- Keep the roadmap ticket `in-progress` while implementation and validation are
+  underway.
+- Mark the roadmap ticket complete only after code, tests, browser proof,
+  commit, and PR preparation are done.
+- Record any deeper route performance follow-up discovered during U3 as a
+  follow-up ticket rather than expanding this PR.
+
+**Patterns to follow:**
+
+- Roadmap format in `CLAUDE.md`.
+- Prior platform tickets such as
+  `docs/roadmap/platform/feat-153-admin-interaction-affordance-polish.md`.
+
+**Test scenarios:**
+
+- Test expectation: none -- documentation/roadmap state only.
+
+**Verification:**
+
+- Roadmap status reflects the actual implementation state at handoff.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The persistent admin shell gains awareness of internal
+  navigation events; route pages keep owning their data and page-specific
+  behavior.
+- **Error propagation:** Loading feedback must not swallow navigation errors;
+  existing Next.js route error behavior remains unchanged.
+- **State lifecycle risks:** Pending state can become stale if a same-URL or
+  interrupted transition never commits; U1 includes clear-on-route-change and a
+  defensive timeout.
+- **API surface parity:** No API, GraphQL, Prisma, or generated client surface
+  should change.
+- **Integration coverage:** Browser smoke is required because route loading and
+  perceived feedback are cross-component behaviors.
+- **Unchanged invariants:** Admin auth, permissions, video read-only state,
+  language read-only diagnostics, URL-backed video filters, and existing
+  disabled-placeholder affordances remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                               | Mitigation                                                                                                                           |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Shell-level event detection could show pending feedback for non-navigation clicks. | Restrict detection to same-origin dashboard links/forms and ignore external, modified, download, disabled, and current-URL events.   |
+| Loading skeletons could feel like a redesign.                                      | Mirror final page hierarchy and existing admin tokens rather than introducing new decoration.                                        |
+| Performance work could accidentally change data semantics.                         | Keep U3 behavior-preserving, covered by existing page/diagnostic tests, and defer deeper data-contract changes.                      |
+| Browser smoke may be blocked by local auth or dev database setup.                  | Follow `apps/admin/docs/worktree-preview-setup.md`; if unavailable, report the blocker and keep automated tests as primary evidence. |
+
+---
+
+## Documentation / Operational Notes
+
+- No operator runbook changes are expected.
+- Any deeper route performance issue discovered during U3 should become a
+  separate roadmap ticket with measured evidence.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-04-admin-loading-feedback-requirements.md](../brainstorms/2026-06-04-admin-loading-feedback-requirements.md)
+- **Roadmap:** [docs/roadmap/platform/feat-158-admin-loading-feedback-and-slow-route-ux.md](../roadmap/platform/feat-158-admin-loading-feedback-and-slow-route-ux.md)
+- Related plan: [docs/plans/2026-06-01-001-fix-admin-interaction-affordances-plan.md](2026-06-01-001-fix-admin-interaction-affordances-plan.md)
+- Related plan: [docs/plans/2026-06-02-003-feat-admin-language-diagnostics-plan.md](2026-06-02-003-feat-admin-language-diagnostics-plan.md)
+- Related plan: [docs/plans/2026-06-03-001-feat-admin-video-library-controls-plan.md](2026-06-03-001-feat-admin-video-library-controls-plan.md)

--- a/docs/roadmap/platform/feat-158-admin-loading-feedback-and-slow-route-ux.md
+++ b/docs/roadmap/platform/feat-158-admin-loading-feedback-and-slow-route-ux.md
@@ -1,0 +1,92 @@
+---
+id: "feat-158"
+title: "Admin loading feedback and slow route UX"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-04"
+duration: 2
+depends_on:
+  - "feat-153"
+  - "feat-155"
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "ui"
+  - "ux"
+  - "performance"
+---
+
+## Problem
+
+Admin dashboard routes such as `/dashboard/videos` and `/dashboard/languages`
+can take long enough to server-render that the current browser view appears
+still after a user click. Operators need immediate confirmation that navigation
+or filtering was accepted, and the slowest screens should show page-shaped
+loading states while safe route-level performance wins are applied.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-06-04-admin-loading-feedback-requirements.md` -
+   product scope, accepted staged approach, and acceptance examples.
+2. `docs/plans/2026-06-04-002-feat-admin-loading-feedback-plan.md` -
+   implementation plan and validation strategy.
+3. `apps/admin/src/components/admin-shell.tsx` - persistent dashboard shell,
+   sidebar links, command palette, and content wrapper.
+4. `apps/admin/src/app/dashboard/videos/page.tsx` - server-rendered video
+   library route and row/pagination links.
+5. `apps/admin/src/app/dashboard/videos/video-library-toolbar.tsx` - existing
+   URL-backed filter pending feedback for videos.
+6. `apps/admin/src/app/dashboard/languages/page.tsx` - server-rendered language
+   diagnostics route.
+7. `apps/admin/src/app/dashboard/ops-data.ts` and
+   `apps/admin/src/app/dashboard/live-data.ts` - route data loaders for
+   languages and videos.
+
+## Grep These
+
+- `AdminShell|ShellSidebarContent|Command palette|visibleNavItems` in
+  `apps/admin/src/components/admin-shell.tsx`
+- `loading.tsx|Suspense|role="status"|aria-live` in `apps/admin/src/app`
+- `loadVideoLibraryPage|loadVideoLibraryLanguageOptions|includeVisitorUrls` in
+  `apps/admin/src/app/dashboard/live-data.ts`
+- `loadLanguagesData|diagnosticRows|LanguageDiagnostics` in
+  `apps/admin/src/app/dashboard/ops-data.ts` and
+  `apps/admin/src/app/dashboard/languages/`
+- `dashboard-ui.test|admin-shell.test|language-diagnostics.test` in
+  `apps/admin/src`
+
+## What To Build
+
+1. Add shared admin navigation feedback that activates immediately for internal
+   dashboard route clicks and route-changing submissions, then clears when the
+   destination pathname or query state is rendered.
+2. Add dashboard loading fallbacks that preserve the shell and show
+   Forge Editorial skeletons, with route-shaped states for videos and
+   languages.
+3. Improve the safest confirmed heavy route behavior for videos/languages
+   without changing their product contracts.
+4. Add focused tests proving feedback semantics, loading surfaces, and preserved
+   existing behavior.
+5. Verify with local browser smoke using the configured admin dev setup and the
+   available Helium/in-app browser surface.
+
+## Constraints
+
+- Keep scope inside `apps/admin` plus roadmap/brainstorm/plan docs.
+- Do not change Prisma schema, Pothos schema, GraphQL SDL, generated clients,
+  auth/session behavior, or public consumer app contracts.
+- Do not build video editing, video creation, language editing, bulk actions,
+  advanced search syntax, or saved views.
+- Keep the existing Forge Editorial visual language and dense operator layout.
+- Use Helium browser when browser testing is needed, falling back only if the
+  current Codex environment exposes a different local browser surface.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/components/admin-shell.test.tsx src/app/dashboard/dashboard-ui.test.tsx src/app/dashboard/languages/language-diagnostics.test.tsx`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`
+- Local browser smoke for `/dashboard`, `/dashboard/videos`, video filter or
+  pagination transition, and `/dashboard/languages`.


### PR DESCRIPTION
## Summary

Slow admin route transitions now acknowledge the click immediately instead of leaving operators staring at a still window. The persistent admin shell shows a compact route-pending status for internal dashboard links and GET form submissions, Videos dispatches the same signal for its URL-backed filter pushes, and Dashboard, Videos, and Languages now have page-shaped App Router loading fallbacks.

The performance slice is intentionally narrow: the video library starts independent total/filter/summary work earlier, skips row relation work when the result page is empty, and overlaps visitor route manifest loading with relation queries without changing the data contract.

## What Changed

- Added shared admin navigation feedback that ignores external links, modified clicks, downloads, disabled controls, current-URL no-ops, and non-dashboard lookalike paths.
- Added accessible loading skeletons for `/dashboard`, `/dashboard/videos`, and `/dashboard/languages` that preserve the Forge Editorial shell and page hierarchy.
- Kept the existing Videos toolbar pending state while wiring it into the shell-level route feedback.
- Added focused tests for shell route-feedback semantics and the new loading fallbacks.
- Documented the Videos/Languages click-through smoke path in the admin worktree preview guide.
- Added the accepted brainstorm, implementation plan, and completed roadmap ticket for the slice.

## Testing

- `pnpm --filter @forge/admin test -- src/components/admin-shell.test.tsx src/app/dashboard/dashboard-ui.test.tsx src/app/dashboard/languages/language-diagnostics.test.tsx`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `git diff --check`
- Local browser smoke with the available `agent-browser` fallback: `/dashboard`, `/dashboard/videos`, Videos search transition, and `/dashboard/languages`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
