### PR TITLE
fix(manager): add signout from login errors

### DIFF
--- a/apps/manager/src/app/api/auth/logout/route.test.ts
+++ b/apps/manager/src/app/api/auth/logout/route.test.ts
@@ -22,6 +22,24 @@ describe("Manager logout route", () => {
     expect(setCookie).toContain("strapi-jwt=;")
     expect(setCookie).toContain("Expires=Thu, 01 Jan 1970")
   })
+
+  it("redirects GET logout through the configured Manager origin without Auth client env", async () => {
+    stubMockEnv()
+    const { GET } = await import("./route")
+    const response = GET()
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toBe(
+      "https://manager.jesusfilm.org/api/auth/login?prompt=login",
+    )
+
+    const setCookie = response.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain("manager-session=;")
+    expect(setCookie).toContain("manager-oauth-state=;")
+    expect(setCookie).toContain("manager-oauth-verifier=;")
+    expect(setCookie).toContain("manager-oauth-return-to=;")
+    expect(setCookie).toContain("strapi-jwt=;")
+  })
 })
 
 function stubMockEnv() {
@@ -30,4 +48,5 @@ function stubMockEnv() {
   vi.stubEnv("MUX_TOKEN_ID", "mux-token-id")
   vi.stubEnv("MUX_TOKEN_SECRET", "mux-token-secret")
   vi.stubEnv("OPENROUTER_API_KEY", "openrouter-key")
+  vi.stubEnv("MANAGER_BASE_URL", "https://manager.jesusfilm.org")
 }

--- a/apps/manager/src/app/api/auth/logout/route.ts
+++ b/apps/manager/src/app/api/auth/logout/route.ts
@@ -6,6 +6,7 @@ import {
   MANAGER_OAUTH_VERIFIER_COOKIE,
   MANAGER_SESSION_COOKIE,
 } from "@/lib/manager-session-cookie"
+import { getManagerBaseUrl } from "@/lib/oauth-client"
 
 export function POST() {
   const response = NextResponse.json({ success: true })
@@ -13,9 +14,9 @@ export function POST() {
   return response
 }
 
-export function GET(request: Request) {
+export function GET() {
   const response = NextResponse.redirect(
-    new URL("/api/auth/login?prompt=login", request.url),
+    new URL("/api/auth/login?prompt=login", getManagerBaseUrl()),
   )
   clearManagerSession(response)
   return response

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -11224,6 +11224,32 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
   border-radius: calc(var(--ds-radius) + 2px);
 }
 
+.login-button-secondary {
+  margin-top: 0;
+  color: var(--ds-ink);
+  background: rgba(255, 254, 250, 0.64);
+  border-color: rgba(17, 17, 17, 0.14);
+}
+
+.login-button-secondary:hover:not(:disabled),
+.login-button-secondary:focus-visible:not(:disabled) {
+  color: var(--ds-ink);
+  background: rgba(255, 254, 250, 0.86);
+  border-color: rgba(17, 17, 17, 0.24);
+}
+
+.login-button-secondary:active:not(:disabled) {
+  color: var(--surface);
+  background: var(--ds-black);
+  border-color: var(--ds-black);
+}
+
+.login-button-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 .collection-cache-clear,
 .load-more-button,
 .jobs-transcription-rerun-button,

--- a/apps/manager/src/app/login/page.test.ts
+++ b/apps/manager/src/app/login/page.test.ts
@@ -1,4 +1,4 @@
-import type React from "react"
+import React from "react"
 import { describe, expect, it, vi } from "vitest"
 
 const { studioAuthShellMock } = vi.hoisted(() => ({
@@ -69,8 +69,23 @@ describe("login page", () => {
     })
     expect(element.type).toBe(studioAuthShellMock)
     expect(element.props.title).toBe("Manager access unavailable")
-    expect(element.props.children.props.children.props.children).toBe(
+
+    const card = element.props.children
+    const [error, signOut] = React.Children.toArray(
+      card.props.children,
+    ) as React.ReactElement<{
+      children: React.ReactNode
+      href?: string
+    }>[]
+
+    expect(error.props.children).toBe(
       "This account is not approved for Manager access.",
     )
+    expect(signOut.props.href).toBe("/api/auth/logout")
+    expect(
+      React.Children.toArray(signOut.props.children).some(
+        (child) => child === "Sign out and try another account",
+      ),
+    ).toBe(true)
   })
 })

--- a/apps/manager/src/app/login/page.tsx
+++ b/apps/manager/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation"
+import { LogOut } from "lucide-react"
 
 import { StudioAuthShell } from "@/features/shell/studio-auth-shell"
 import { getManagerOAuthConfig } from "@/lib/oauth-client"
@@ -31,6 +32,13 @@ export default async function LoginPage({
         <div className="login-error" role="alert">
           {formatLoginError(params.error)}
         </div>
+        <a
+          className="login-button login-button-secondary"
+          href="/api/auth/logout"
+        >
+          <LogOut className="login-button-icon" aria-hidden="true" />
+          Sign out and try another account
+        </a>
       </div>
     </StudioAuthShell>
   )

--- a/apps/manager/src/lib/oauth-client.ts
+++ b/apps/manager/src/lib/oauth-client.ts
@@ -19,6 +19,10 @@ export type VerifiedManagerToken = {
   claims: JWTPayload
 }
 
+export function getManagerBaseUrl() {
+  return (env.MANAGER_BASE_URL ?? "http://localhost:3002").replace(/\/$/, "")
+}
+
 export function getManagerOAuthConfig(): ManagerOAuthConfig {
   if (!env.AUTH_ISSUER_URL) {
     throw new Error("AUTH_ISSUER_URL is required for Manager OAuth")
@@ -31,7 +35,7 @@ export function getManagerOAuthConfig(): ManagerOAuthConfig {
     issuerUrl: env.AUTH_ISSUER_URL.replace(/\/$/, ""),
     clientId: env.AUTH_MANAGER_CLIENT_ID,
     clientSecret: env.AUTH_MANAGER_CLIENT_SECRET,
-    managerBaseUrl: env.MANAGER_BASE_URL ?? "http://localhost:3002",
+    managerBaseUrl: getManagerBaseUrl(),
   }
 }
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (June 4, 2026)
 
-- **Total tickets:** 183
-- **Complete:** 109
+- **Total tickets:** 184
+- **Complete:** 110
 - **In progress:** 8
 - **Not started:** 21
 - **Blocked:** 43
@@ -167,6 +167,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-149](platform/feat-149-watch-route-manifest-admin.md)                      | Admin Watch Route Manifest                                   | vlad      | P1       | 2026-05-29 | 2    | 2026-05-30 | complete    |
 | [feat-153](platform/feat-153-admin-interaction-affordance-polish.md)             | Admin interaction affordance polish                          | tataihono | P1       | 2026-06-01 | 1    | 2026-06-01 | complete    |
 | [feat-155](platform/feat-155-admin-language-diagnostics.md)                      | Admin language diagnostics browser                           | tataihono | P1       | 2026-06-02 | 2    | 2026-06-03 | complete    |
+| [feat-158](platform/feat-158-manager-login-error-signout.md)                     | Manager login error sign-out recovery                        | vlad      | P1       | 2026-06-04 | 1    | 2026-06-04 | complete    |
 | [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                                   | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
 | [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                          | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                      | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |

--- a/docs/roadmap/platform/feat-158-manager-login-error-signout.md
+++ b/docs/roadmap/platform/feat-158-manager-login-error-signout.md
@@ -1,0 +1,70 @@
+---
+id: "feat-158"
+title: "Manager login error sign-out recovery"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-04"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "manager"
+  - "auth"
+  - "oauth"
+  - "ux"
+---
+
+## Problem
+
+When a user reaches the Manager login error page with `error=forbidden` or
+another OAuth callback failure, the page explains that Manager access is
+unavailable but does not give the user a way to clear the current session and
+choose another Auth account.
+
+## Entry Points - Read These First
+
+1. `apps/manager/src/app/login/page.tsx` - login and access-error page
+   composition.
+2. `apps/manager/src/app/api/auth/logout/route.ts` - local Manager session and
+   OAuth cookie clearing.
+3. `apps/manager/src/lib/oauth-client.ts` - configured public Manager origin
+   used for OAuth redirects.
+4. `apps/manager/src/app/globals.css` - existing login button and auth shell
+   styling.
+
+## Grep These
+
+- `formatLoginError` in `apps/manager/src/app/login/page.tsx`
+- `login-button` in `apps/manager/src/app/globals.css`
+- `prompt=login` in `apps/manager/src/app/api/auth`
+- `managerBaseUrl` in `apps/manager/src/lib/oauth-client.ts`
+
+## What To Build
+
+1. Add a visible sign-out affordance on login error states that points to the
+   Manager logout endpoint.
+2. Ensure GET logout clears Manager/Auth cookies and redirects back through the
+   configured public Manager origin with `prompt=login`.
+3. Keep the existing login shell and error copy intact.
+4. Cover both the rendered error-page affordance and the logout redirect/cookie
+   behavior with focused tests.
+
+## Constraints
+
+- Do not change which accounts are approved for Manager access.
+- Do not weaken Manager membership enforcement.
+- Do not build logout redirects from the incoming request host in production;
+  Railway can surface internal hosts such as `0.0.0.0:8080`.
+- Do not add new environment variables.
+
+## Verification
+
+- `pnpm --filter @forge/manager test -- src/app/login/page.test.ts src/app/api/auth/logout/route.test.ts`
+- `pnpm --filter @forge/manager typecheck`
+- `pnpm --filter @forge/manager lint`
+- `git diff --check`
+- Local smoke: `GET /login?error=forbidden` renders "Sign out and try another
+  account" with `href="/api/auth/logout"`.
+- Local smoke: `GET /api/auth/logout` clears Manager/Auth cookies and redirects
+  to `/api/auth/login?prompt=login` on the configured Manager origin.


### PR DESCRIPTION
## Summary
- add a sign-out option to Manager login error states so users can switch Auth accounts
- route GET logout through the configured Manager origin and clear Manager/OAuth/legacy cookies
- add roadmap ticket feat-158 and focused regression coverage

## Verification
- pnpm --filter @forge/manager test -- src/app/login/page.test.ts src/app/api/auth/logout/route.test.ts src/lib/oauth-client.test.ts
- pnpm --filter @forge/manager typecheck
- pnpm --filter @forge/manager lint
- git diff --check
- local smoke: /login?error=forbidden renders the sign-out link
- local smoke: /api/auth/logout redirects to /api/auth/login?prompt=login and expires Manager/Auth cookies