### PR TITLE
chore(manager): retrigger Railway deployment

### DIFF
--- a/apps/manager/src/instrumentation.ts
+++ b/apps/manager/src/instrumentation.ts
@@ -1,7 +1,7 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     // Warm read-heavy caches before first request arrives.
-    // Railway rolling deploys give us a few seconds before traffic routes here.
+    // Railway rolling deploys give Manager a few seconds before traffic routes here.
     const { videoCache } = await import("@/app/api/videos/cache")
     const { languageCache } = await import("@/app/api/languages/cache")
     const { latestCoverageSnapshotCache } =


### PR DESCRIPTION
## Summary
- touch apps/manager with a behavior-neutral comment change
- retrigger Railway Manager deployment so merged PR #1132 reaches production

## Why
- PR #1132 is merged into main, but live manager.jesusfilm.org still serves the old login error/logout behavior
- Railway showed the Manager deployment as skipped/cancelled after the merge commit check suite was cancelled

## Verification
- pnpm --filter @forge/manager lint
- git diff --check