### PR TITLE
fix(manager): include public assets in standalone deploy

### DIFF
--- a/apps/manager/CLAUDE.md
+++ b/apps/manager/CLAUDE.md
@@ -267,4 +267,4 @@ where admin's first call 401s.
 
 ## Standalone smoke
 
-The Railway standalone build copies `apps/manager/.next/static` into `apps/manager/.next/standalone/apps/manager/.next/static` before starting `server.js`. Follow that same shape for local standalone smoke tests; without the copied static assets the login page HTML renders but the client JS does not hydrate.
+The Railway standalone build copies `apps/manager/.next/static` into `apps/manager/.next/standalone/apps/manager/.next/static` and `apps/manager/public` into `apps/manager/.next/standalone/apps/manager/public` before starting `server.js`. Follow that same shape for local standalone smoke tests; without the copied static assets the login page HTML renders but the client JS does not hydrate, and without the copied public assets `/jesusfilm-sign.svg`, `/favicon.svg`, and regional images 404 in production.

--- a/apps/manager/railway.toml
+++ b/apps/manager/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/manager... build && cp -r apps/manager/.next/static apps/manager/.next/standalone/apps/manager/.next/static"
+buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/manager... build && cp -r apps/manager/.next/static apps/manager/.next/standalone/apps/manager/.next/static && cp -r apps/manager/public apps/manager/.next/standalone/apps/manager/public"
 
 [deploy]
 # Audio cleanup needs ffmpeg at runtime for original-audio extraction.


### PR DESCRIPTION
## Summary
- copy apps/manager/public into the Manager standalone runtime during Railway builds
- document the standalone smoke shape for both .next/static and public assets

## Root cause
- production login HTML references /jesusfilm-sign.svg
- https://manager.jesusfilm.org/jesusfilm-sign.svg currently returns 404
- Manager has apps/manager/public/jesusfilm-sign.svg in git, but the Railway standalone build only copied .next/static next to server.js

## Verification
- set -a; source apps/manager/.env.ci; set +a; pnpm --filter @forge/manager build
- cp -r apps/manager/.next/static apps/manager/.next/standalone/apps/manager/.next/static
- cp -r apps/manager/public apps/manager/.next/standalone/apps/manager/public
- find apps/manager/.next/standalone/apps/manager/public -maxdepth 1 -type f \( -name 'jesusfilm-sign.svg' -o -name 'favicon.svg' -o -name 'region-asia.png' \) -print
- pnpm --filter @forge/manager lint
- git diff --check