### PR TITLE
chore(manager): retrigger public asset deploy

### DIFF
--- a/apps/manager/src/instrumentation.ts
+++ b/apps/manager/src/instrumentation.ts
@@ -1,7 +1,7 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     // Warm read-heavy caches before first request arrives.
-    // Railway rolling deploys give Manager a few seconds before traffic routes here.
+    // Railway rolling deploys give the Manager service a few seconds before traffic routes here.
     const { videoCache } = await import("@/app/api/videos/cache")
     const { languageCache } = await import("@/app/api/languages/cache")
     const { latestCoverageSnapshotCache } =


### PR DESCRIPTION
## Summary
- touch a Manager source path so Railway deploys the already-merged standalone public asset packaging fix from #1135

## Context
- #1135 fixed the build command to copy apps/manager/public into standalone output
- Railway did not create a @forge/manager deployment for the #1135 merge commit because only railway.toml/docs changed
- this PR is behavior-neutral and exists to trigger the Manager watched paths

## Verification
- pnpm --filter @forge/manager lint
- git diff --check