### PR TITLE
fix(manager): serve shell svg assets from app routes

### DIFF
--- a/apps/manager/CLAUDE.md
+++ b/apps/manager/CLAUDE.md
@@ -267,4 +267,6 @@ where admin's first call 401s.
 
 ## Standalone smoke
 
-The Railway standalone build copies `apps/manager/.next/static` into `apps/manager/.next/standalone/apps/manager/.next/static` and `apps/manager/public` into `apps/manager/.next/standalone/apps/manager/public` before starting `server.js`. Follow that same shape for local standalone smoke tests; without the copied static assets the login page HTML renders but the client JS does not hydrate, and without the copied public assets `/jesusfilm-sign.svg`, `/favicon.svg`, and regional images 404 in production.
+The Railway standalone build copies `apps/manager/.next/static` into `apps/manager/.next/standalone/apps/manager/.next/static` and `apps/manager/public` into `apps/manager/.next/standalone/apps/manager/public` before starting `server.js`. Follow that same shape for local standalone smoke tests; without the copied static assets the login page HTML renders but the client JS does not hydrate, and without the copied public assets regional images 404 in standalone mode.
+
+Production Manager may still be governed by Railway dashboard-level overrides instead of `apps/manager/railway.toml`; verify the effective Railway config before assuming this file is honored. The shell brand assets `/jesusfilm-sign.svg` and `/favicon.svg` are also served by app route handlers so the login shell keeps rendering if the runtime image omits `apps/manager/public`.

--- a/apps/manager/src/app/favicon.svg/route.ts
+++ b/apps/manager/src/app/favicon.svg/route.ts
@@ -1,0 +1,16 @@
+const FAVICON_SVG = `<svg width="64" height="64" viewBox="0 0 36 36" fill="#EF3340" xmlns="http://www.w3.org/2000/svg">
+  <title>Language</title>
+  <polygon points="11,16.5 10,19.6 12,19.6 11,16.5"/>
+  <path d="M30.3,3h-16v5h4v2h-13c-1.7,0-3,1.3-3,3v11c0,1.7,1.3,3,3,3h1v5.1l6.3-5.1h6.7v-7h11c1.7,0,3-1.3,3-3V6C33.3,4.3,32,3,30.3,3z M13.1,22.9l-0.5-1.6H9.5l-0.6,1.6H6.5L9.8,14h2.4l3.3,8.9L13.1,22.9z M28.3,15v2c-1.3,0-2.7-0.4-3.9-1c-1.2,0.6-2.6,0.9-4,1l-0.1-2c0.7,0,1.4-0.1,2.1-0.3c-0.9-0.9-1.5-2-1.8-3.2h2.1c0.3,0.9,0.9,1.6,1.6,2.2c1.1-0.9,1.8-2.2,1.9-3.7h-6V8h3V6h2v2h3.3l0.1,1c0.1,2.1-0.7,4.2-2.2,5.7C27.1,14.9,27.7,15,28.3,15z"/>
+  <rect width="36" height="36" fill-opacity="0"/>
+</svg>
+`
+
+export function GET() {
+  return new Response(FAVICON_SVG, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Content-Type": "image/svg+xml; charset=utf-8",
+    },
+  })
+}

--- a/apps/manager/src/app/jesusfilm-sign.svg/route.ts
+++ b/apps/manager/src/app/jesusfilm-sign.svg/route.ts
@@ -1,0 +1,13 @@
+const JESUSFILM_SIGN_SVG = `<svg width="49" height="36" viewBox="0 0 49 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M45.854 -0.000301361H2.34C1.048 -0.000301361 0 1.0467 0 2.3397V20.2427C0 21.2917 0.699 22.2137 1.709 22.4957L47.072 35.2077C47.636 35.3657 48.194 34.9417 48.194 34.3567V2.3397C48.194 1.0467 47.147 -0.000301361 45.854 -0.000301361Z" fill="#EF3340"/>
+</svg>
+`
+
+export function GET() {
+  return new Response(JESUSFILM_SIGN_SVG, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Content-Type": "image/svg+xml; charset=utf-8",
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- serve /jesusfilm-sign.svg and /favicon.svg from Manager app route handlers
- document that Manager production may be governed by Railway dashboard overrides instead of apps/manager/railway.toml

## Root cause
- production login HTML references /jesusfilm-sign.svg
- production /jesusfilm-sign.svg and /favicon.svg still return 404 even after the standalone public-copy deploy
- local standalone serves those files when public is copied, so the app path is correct
- repo docs already note Manager Railway dashboard overrides can shadow apps/manager/railway.toml, so production is not guaranteed to use the committed standalone buildCommand

## Verification
- pnpm --filter @forge/manager lint
- git diff --check
- set -a; source apps/manager/.env.ci; set +a; pnpm --filter @forge/manager build
- temporarily moved apps/manager/public aside, ran next start on 127.0.0.1:4912, and verified both /jesusfilm-sign.svg and /favicon.svg returned HTTP 200 from app routes