### PR TITLE
fix(auth): consume login prompt after social sign-in

### DIFF
--- a/apps/auth/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.test.ts
@@ -239,6 +239,35 @@ describe("Auth route wrapper", () => {
     })
   })
 
+  it("consumes interactive OAuth prompts after social sign-in", async () => {
+    authPost.mockResolvedValueOnce(
+      Response.json({ url: "https://google.test" }),
+    )
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/sign-in/social", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          oauth_query:
+            "client_id=jfp_manager_production&prompt=login&sig=signed",
+          provider: "google",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["sign-in", "social"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    const forwardedRequest = authPost.mock.calls[0]?.[0] as Request
+    await expect(forwardedRequest.json()).resolves.toMatchObject({
+      callbackURL:
+        "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_manager_production&sig=signed",
+      errorCallbackURL:
+        "http://localhost:3004/login?client_id=jfp_manager_production&prompt=login&sig=signed",
+      provider: "google",
+    })
+  })
+
   it("returns OAuth social failures to login without exposing method hints", async () => {
     authPost.mockResolvedValueOnce(
       Response.json({ url: "https://google.test" }),

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -240,6 +240,7 @@ function buildOAuthContinuationURL(oauthQuery: string | undefined) {
 
   const url = new URL("/api/auth/oauth2/authorize", getAuthBaseUrl())
   url.search = oauthQuery
+  consumeInteractivePrompt(url.searchParams)
   return url.toString()
 }
 
@@ -249,6 +250,20 @@ function buildOAuthLoginURL(oauthQuery: string | undefined) {
   const url = new URL("/login", getAuthBaseUrl())
   url.search = oauthQuery
   return url.toString()
+}
+
+function consumeInteractivePrompt(params: URLSearchParams) {
+  const prompt = params.get("prompt")
+  if (!prompt) return
+
+  const remainingPrompts = prompt
+    .split(/\s+/)
+    .filter((value) => value !== "login" && value !== "select_account")
+
+  params.delete("prompt")
+  if (remainingPrompts.length > 0) {
+    params.set("prompt", remainingPrompts.join(" "))
+  }
 }
 
 async function parseSocialSignInRequest(request: Request): Promise<{

--- a/docs/roadmap/platform/feat-158-manager-login-error-signout.md
+++ b/docs/roadmap/platform/feat-158-manager-login-error-signout.md
@@ -68,3 +68,18 @@ choose another Auth account.
   account" with `href="/api/auth/logout"`.
 - Local smoke: `GET /api/auth/logout` clears Manager/Auth cookies and redirects
   to `/api/auth/login?prompt=login` on the configured Manager origin.
+
+## Follow-up: Auth prompt consumption
+
+Manager's sign-out recovery intentionally adds `prompt=login` to the first
+OAuth authorize hop so Auth does not silently reuse the currently forbidden
+account. After the user completes an interactive Auth sign-in, Auth must treat
+that prompt as consumed before resuming the relying-client OAuth authorize URL.
+Otherwise Better Auth sees `prompt=login` again on
+`/api/auth/oauth2/authorize` and sends the user back to `/login` immediately
+after a successful Google callback.
+
+Auth owns this continuation behavior in
+`apps/auth/src/app/api/auth/[...all]/route.ts`; keep the prompt on the login
+retry URL, but strip interactive prompt values from the post-sign-in
+continuation URL.


### PR DESCRIPTION
## Summary
- consume interactive OAuth prompt values before Auth resumes the post-sign-in authorize continuation
- keep prompt=login on the login retry URL so Manager sign-out recovery still forces account choice on retry
- document the follow-up behavior on the Manager login error recovery roadmap ticket

## Root Cause
Manager sign-out recovery redirects through Auth with prompt=login so a forbidden Auth account is not silently reused. Auth forwarded that same prompt into the callbackURL used after Google sign-in. After Google succeeded, Better Auth hit /api/auth/oauth2/authorize with prompt=login again and redirected the user back to /login with the Manager OAuth query preserved.

## Validation
- pnpm --filter @forge/auth test -- 'src/app/api/auth/[...all]/route.test.ts'
- pnpm --filter @forge/auth lint
- pnpm --filter @forge/auth typecheck
- git diff --check