### PR TITLE
feat(admin): manage user product access

### DIFF
--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -347,6 +347,33 @@ vi.mock("@/app/dashboard/ops-data", () => ({
         statusLabel: "ADMIN",
         statusTone: "success",
         meta: "10/24/2023, 14:02",
+        productAccess: [
+          {
+            key: "manager",
+            label: "Manager",
+            active: true,
+            statusLabel: "Enabled",
+            statusTone: "success",
+            roleLabel: "OPERATOR",
+          },
+        ],
+      },
+      {
+        key: "user2",
+        title: "viewer@example.com",
+        detail: "auth_user_456",
+        statusLabel: "VIEWER",
+        statusTone: "warning",
+        meta: "10/24/2023, 14:03",
+        productAccess: [
+          {
+            key: "manager",
+            label: "Manager",
+            active: false,
+            statusLabel: "Disabled",
+            statusTone: "muted",
+          },
+        ],
       },
     ],
     insights: [
@@ -1268,5 +1295,15 @@ describe("dashboard UI routes", () => {
     expect(pages[6].html).toContain("Media Library")
     expect(pages[6].html).toContain("Library")
     expect(pages[6].html).toContain("Campaigns")
+  })
+
+  it("renders user product access controls", async () => {
+    const html = await htmlFrom(UsersPage())
+
+    expect(html).toContain("Product Access")
+    expect(html).toContain("Manager: Enabled / OPERATOR")
+    expect(html).toContain("Revoke Manager")
+    expect(html).toContain("Manager: Disabled")
+    expect(html).toContain("Enable Manager")
   })
 })

--- a/apps/admin/src/app/dashboard/ops-data.ts
+++ b/apps/admin/src/app/dashboard/ops-data.ts
@@ -48,6 +48,16 @@ type TableRow = {
   statusLabel: string
   statusTone: "success" | "warning" | "danger" | "info" | "muted"
   meta: string
+  productAccess?: ProductAccess[]
+}
+
+type ProductAccess = {
+  key: "manager"
+  label: string
+  active: boolean
+  statusLabel: string
+  statusTone: "success" | "warning" | "danger" | "info" | "muted"
+  roleLabel?: string
 }
 
 export type LanguageDiagnosticTone =
@@ -1978,6 +1988,12 @@ export async function loadUsersData(): Promise<UsersData> {
             role: true,
             emailVerified: true,
             updatedAt: true,
+            managerMembership: {
+              select: {
+                role: true,
+                revokedAt: true,
+              },
+            },
           },
           orderBy: { updatedAt: "desc" },
           take: 8,
@@ -1988,6 +2004,10 @@ export async function loadUsersData(): Promise<UsersData> {
         role: string
         emailVerified: boolean
         updatedAt: Date
+        managerMembership: {
+          role: "OPERATOR"
+          revokedAt: Date | null
+        } | null
       }>,
     ),
   ])
@@ -2010,15 +2030,33 @@ export async function loadUsersData(): Promise<UsersData> {
         footer: "PENDING_APPROVAL",
       },
     ],
-    rows: rows.map((row) => ({
-      key: row.id,
-      title: row.email,
-      detail: row.id,
-      statusLabel: row.emailVerified ? row.role : "UNVERIFIED",
-      statusTone:
-        !row.emailVerified || row.role === "VIEWER" ? "warning" : "success",
-      meta: formatDateTime(row.updatedAt),
-    })),
+    rows: rows.map((row) => {
+      const hasManagerAccess = Boolean(
+        row.managerMembership && !row.managerMembership.revokedAt,
+      )
+
+      return {
+        key: row.id,
+        title: row.email,
+        detail: row.id,
+        statusLabel: row.emailVerified ? row.role : "UNVERIFIED",
+        statusTone:
+          !row.emailVerified || row.role === "VIEWER" ? "warning" : "success",
+        meta: formatDateTime(row.updatedAt),
+        productAccess: [
+          {
+            key: "manager",
+            label: "Manager",
+            active: hasManagerAccess,
+            statusLabel: hasManagerAccess ? "Enabled" : "Disabled",
+            statusTone: hasManagerAccess ? "success" : "muted",
+            roleLabel: hasManagerAccess
+              ? row.managerMembership?.role
+              : undefined,
+          },
+        ],
+      }
+    }),
     insights: [
       {
         label: "Role Mappings",

--- a/apps/admin/src/app/dashboard/users/page.tsx
+++ b/apps/admin/src/app/dashboard/users/page.tsx
@@ -31,6 +31,47 @@ async function approveUser(formData: FormData) {
   revalidatePath("/dashboard/users")
 }
 
+async function grantManagerAccess(formData: FormData) {
+  "use server"
+
+  await requireAdminSession()
+  const id = formData.get("id")
+  if (typeof id !== "string") return
+
+  await prisma.managerMembership.upsert({
+    where: { userId: id },
+    create: {
+      userId: id,
+      role: "OPERATOR",
+    },
+    update: {
+      role: "OPERATOR",
+      revokedAt: null,
+    },
+    select: { id: true },
+  })
+  revalidatePath("/dashboard/users")
+}
+
+async function revokeManagerAccess(formData: FormData) {
+  "use server"
+
+  await requireAdminSession()
+  const id = formData.get("id")
+  if (typeof id !== "string") return
+
+  await prisma.managerMembership.updateMany({
+    where: {
+      userId: id,
+      revokedAt: null,
+    },
+    data: {
+      revokedAt: new Date(),
+    },
+  })
+  revalidatePath("/dashboard/users")
+}
+
 export default async function UsersPage() {
   await requireAdminSession()
   const messages = await getAdminMessages()
@@ -61,7 +102,7 @@ export default async function UsersPage() {
         <div className="flex flex-col gap-6">
           <PageSection title="User Directory" meta="AUTH_SSO / ROLES">
             <DataTable
-              columns={["Principal", "Status", "Updated"]}
+              columns={["Principal", "Status", "Product Access", "Updated"]}
               rows={data.rows.map((row) => [
                 <div key={`${row.key}-title`}>
                   <div className="text-[13px] font-medium">{row.title}</div>
@@ -104,6 +145,47 @@ export default async function UsersPage() {
                     </>
                   ) : null}
                 </div>,
+                <div
+                  key={`${row.key}-products`}
+                  className="flex min-w-[180px] flex-wrap gap-2"
+                >
+                  {(row.productAccess ?? []).map((access) => (
+                    <div
+                      key={access.key}
+                      className="flex flex-wrap items-center gap-2"
+                    >
+                      <span
+                        className={`status-pill ${statusToneClass(access.statusTone)}`}
+                      >
+                        {access.label}: {access.statusLabel}
+                        {access.roleLabel ? ` / ${access.roleLabel}` : ""}
+                      </span>
+                      {access.key === "manager" ? (
+                        access.active ? (
+                          <form action={revokeManagerAccess}>
+                            <input type="hidden" name="id" value={row.key} />
+                            <button
+                              type="submit"
+                              className="status-pill border-[var(--color-warning-border)] text-[var(--color-warning)]"
+                            >
+                              Revoke Manager
+                            </button>
+                          </form>
+                        ) : (
+                          <form action={grantManagerAccess}>
+                            <input type="hidden" name="id" value={row.key} />
+                            <button
+                              type="submit"
+                              className="status-pill border-[var(--color-success-border)] text-[var(--color-success)]"
+                            >
+                              Enable Manager
+                            </button>
+                          </form>
+                        )
+                      ) : null}
+                    </div>
+                  ))}
+                </div>,
                 <span
                   key={`${row.key}-meta`}
                   className="mono-meta text-[var(--color-text-muted)]"
@@ -129,7 +211,7 @@ export default async function UsersPage() {
         <OperatorRail
           title={messages.common.operatorNotes}
           meta={messages.common.fieldGuide}
-          notes="This route reflects persisted admin user roles mapped from Auth SSO callbacks instead of a future-state permissions mockup."
+          notes="This route reflects persisted admin user roles and product grants mapped from Auth SSO identities. Manager access is explicit and does not inherit from Admin roles."
           chips={[
             { label: "Source", value: "ADMIN_DB" },
             { label: "Model", value: "ROLE_PLUS_ABAC" },
@@ -139,4 +221,17 @@ export default async function UsersPage() {
       </div>
     </div>
   )
+}
+
+function statusToneClass(tone: string) {
+  if (tone === "success") {
+    return "border-[var(--color-success-border)] text-[var(--color-success)]"
+  }
+  if (tone === "warning") {
+    return "border-[var(--color-warning-border)] text-[var(--color-warning)]"
+  }
+  if (tone === "danger") {
+    return "border-[var(--color-danger-border)] text-[var(--color-danger)]"
+  }
+  return "border-[var(--color-hairline-strong)] text-[var(--color-text-muted)]"
 }

--- a/apps/admin/src/app/dashboard/users/page.tsx
+++ b/apps/admin/src/app/dashboard/users/page.tsx
@@ -8,14 +8,19 @@ import {
   PageSection,
 } from "@/components/admin-ui"
 import { requireAdminSession } from "@/auth/session"
-import { prisma } from "@/db/client"
 import { getAdminMessages } from "@/i18n/server"
 import { loadUsersData } from "@/app/dashboard/ops-data"
+import { NotFoundError } from "@/services/errors"
+import {
+  approveUserRole,
+  grantManagerAccess as grantManagerAccessForUser,
+  revokeManagerAccess as revokeManagerAccessForUser,
+} from "@/services/user-access.service"
 
 async function approveUser(formData: FormData) {
   "use server"
 
-  await requireAdminSession()
+  const user = await requireAdminSession()
   const id = formData.get("id")
   const role = formData.get("role")
 
@@ -23,52 +28,41 @@ async function approveUser(formData: FormData) {
     return
   }
 
-  await prisma.user.update({
-    where: { id },
-    data: { role },
-    select: { id: true },
-  })
+  await approveUserRole({ user, targetUserId: id, role })
   revalidatePath("/dashboard/users")
 }
 
 async function grantManagerAccess(formData: FormData) {
   "use server"
 
-  await requireAdminSession()
+  const user = await requireAdminSession()
   const id = formData.get("id")
   if (typeof id !== "string") return
 
-  await prisma.managerMembership.upsert({
-    where: { userId: id },
-    create: {
-      userId: id,
-      role: "OPERATOR",
-    },
-    update: {
-      role: "OPERATOR",
-      revokedAt: null,
-    },
-    select: { id: true },
-  })
+  try {
+    await grantManagerAccessForUser({ user, targetUserId: id })
+  } catch (error) {
+    if (!(error instanceof NotFoundError)) {
+      throw error
+    }
+  }
   revalidatePath("/dashboard/users")
 }
 
 async function revokeManagerAccess(formData: FormData) {
   "use server"
 
-  await requireAdminSession()
+  const user = await requireAdminSession()
   const id = formData.get("id")
   if (typeof id !== "string") return
 
-  await prisma.managerMembership.updateMany({
-    where: {
-      userId: id,
-      revokedAt: null,
-    },
-    data: {
-      revokedAt: new Date(),
-    },
-  })
+  try {
+    await revokeManagerAccessForUser({ user, targetUserId: id })
+  } catch (error) {
+    if (!(error instanceof NotFoundError)) {
+      throw error
+    }
+  }
   revalidatePath("/dashboard/users")
 }
 

--- a/apps/admin/src/services/user-access.service.test.ts
+++ b/apps/admin/src/services/user-access.service.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest"
+import type { Principal } from "@/auth/principal"
+import { ForbiddenError, NotFoundError } from "@/services/errors"
+import {
+  approveUserRole,
+  grantManagerAccess,
+  revokeManagerAccess,
+} from "@/services/user-access.service"
+
+const adminUser = {
+  id: "admin-user-1",
+  role: "ADMIN",
+} as const satisfies Principal
+
+const editorUser = {
+  id: "editor-user-1",
+  role: "EDITOR",
+} as const satisfies Principal
+
+function makeMockPrisma() {
+  return {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    managerMembership: {
+      upsert: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  } as const
+}
+
+describe("user-access.service", () => {
+  it("approves an admin-local user role for Admin principals", async () => {
+    const prisma = makeMockPrisma()
+    prisma.user.update.mockResolvedValueOnce({ id: "target-user-1" })
+
+    await approveUserRole(
+      {
+        user: adminUser,
+        targetUserId: "target-user-1",
+        role: "EDITOR",
+      },
+      prisma as never,
+    )
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "target-user-1" },
+      data: { role: "EDITOR" },
+      select: { id: true },
+    })
+  })
+
+  it("rejects role approvals for non-Admin principals", async () => {
+    const prisma = makeMockPrisma()
+
+    await expect(
+      approveUserRole(
+        {
+          user: editorUser,
+          targetUserId: "target-user-1",
+          role: "ADMIN",
+        },
+        prisma as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+
+    expect(prisma.user.update).not.toHaveBeenCalled()
+  })
+
+  it("grants Manager operator access by upserting an active membership", async () => {
+    const prisma = makeMockPrisma()
+    prisma.user.findUnique.mockResolvedValueOnce({ id: "target-user-1" })
+    prisma.managerMembership.upsert.mockResolvedValueOnce({
+      id: "membership-1",
+    })
+
+    await grantManagerAccess(
+      {
+        user: adminUser,
+        targetUserId: "target-user-1",
+      },
+      prisma as never,
+    )
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: "target-user-1" },
+      select: { id: true },
+    })
+    expect(prisma.managerMembership.upsert).toHaveBeenCalledWith({
+      where: { userId: "target-user-1" },
+      create: {
+        userId: "target-user-1",
+        role: "OPERATOR",
+      },
+      update: {
+        role: "OPERATOR",
+        revokedAt: null,
+      },
+      select: { id: true },
+    })
+  })
+
+  it("rejects Manager grants for non-Admin principals before reading users", async () => {
+    const prisma = makeMockPrisma()
+
+    await expect(
+      grantManagerAccess(
+        {
+          user: editorUser,
+          targetUserId: "target-user-1",
+        },
+        prisma as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled()
+    expect(prisma.managerMembership.upsert).not.toHaveBeenCalled()
+  })
+
+  it("throws NotFoundError instead of writing when the Manager grant target user is missing", async () => {
+    const prisma = makeMockPrisma()
+    prisma.user.findUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      grantManagerAccess(
+        {
+          user: adminUser,
+          targetUserId: "missing-user",
+        },
+        prisma as never,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError)
+
+    expect(prisma.managerMembership.upsert).not.toHaveBeenCalled()
+  })
+
+  it("revokes only an active Manager membership", async () => {
+    const prisma = makeMockPrisma()
+    prisma.user.findUnique.mockResolvedValueOnce({ id: "target-user-1" })
+    prisma.managerMembership.updateMany.mockResolvedValueOnce({ count: 1 })
+
+    await revokeManagerAccess(
+      {
+        user: adminUser,
+        targetUserId: "target-user-1",
+      },
+      prisma as never,
+    )
+
+    expect(prisma.managerMembership.updateMany).toHaveBeenCalledTimes(1)
+    const arg = prisma.managerMembership.updateMany.mock.calls[0]![0]!
+    expect(arg.where).toEqual({
+      userId: "target-user-1",
+      revokedAt: null,
+    })
+    expect(arg.data.revokedAt).toBeInstanceOf(Date)
+  })
+
+  it("rejects Manager revokes for non-Admin principals before reading users", async () => {
+    const prisma = makeMockPrisma()
+
+    await expect(
+      revokeManagerAccess(
+        {
+          user: editorUser,
+          targetUserId: "target-user-1",
+        },
+        prisma as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled()
+    expect(prisma.managerMembership.updateMany).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/src/services/user-access.service.ts
+++ b/apps/admin/src/services/user-access.service.ts
@@ -1,0 +1,101 @@
+import type { PrismaClient } from "@prisma/client"
+import type { Principal } from "@/auth/principal"
+import { hasPermission } from "@/auth/permissions"
+import { prisma as defaultPrisma } from "@/db/client"
+import { ForbiddenError, NotFoundError } from "@/services/errors"
+
+export type AdminAssignableRole = "EDITOR" | "ADMIN"
+
+type PrismaLike = Pick<PrismaClient, "user" | "managerMembership">
+
+function assertAdmin(user: Principal | null) {
+  if (!hasPermission(user, "admin:all")) {
+    throw new ForbiddenError()
+  }
+}
+
+async function assertTargetUserExists(
+  prisma: PrismaLike,
+  userId: string,
+): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true },
+  })
+
+  if (!user) {
+    throw new NotFoundError("User", userId)
+  }
+}
+
+export async function approveUserRole(
+  {
+    user,
+    targetUserId,
+    role,
+  }: {
+    user: Principal | null
+    targetUserId: string
+    role: AdminAssignableRole
+  },
+  prisma: PrismaLike = defaultPrisma,
+) {
+  assertAdmin(user)
+
+  return prisma.user.update({
+    where: { id: targetUserId },
+    data: { role },
+    select: { id: true },
+  })
+}
+
+export async function grantManagerAccess(
+  {
+    user,
+    targetUserId,
+  }: {
+    user: Principal | null
+    targetUserId: string
+  },
+  prisma: PrismaLike = defaultPrisma,
+) {
+  assertAdmin(user)
+  await assertTargetUserExists(prisma, targetUserId)
+
+  return prisma.managerMembership.upsert({
+    where: { userId: targetUserId },
+    create: {
+      userId: targetUserId,
+      role: "OPERATOR",
+    },
+    update: {
+      role: "OPERATOR",
+      revokedAt: null,
+    },
+    select: { id: true },
+  })
+}
+
+export async function revokeManagerAccess(
+  {
+    user,
+    targetUserId,
+  }: {
+    user: Principal | null
+    targetUserId: string
+  },
+  prisma: PrismaLike = defaultPrisma,
+) {
+  assertAdmin(user)
+  await assertTargetUserExists(prisma, targetUserId)
+
+  return prisma.managerMembership.updateMany({
+    where: {
+      userId: targetUserId,
+      revokedAt: null,
+    },
+    data: {
+      revokedAt: new Date(),
+    },
+  })
+}

--- a/docs/plans/2026-06-04-003-feat-admin-user-product-access-grants-plan.md
+++ b/docs/plans/2026-06-04-003-feat-admin-user-product-access-grants-plan.md
@@ -1,0 +1,107 @@
+---
+title: "feat: Admin user product access grants"
+type: feat
+status: completed
+date: 2026-06-04
+origin: docs/roadmap/platform/feat-159-admin-user-product-access-grants.md
+---
+
+# feat: Admin user product access grants
+
+## Problem Frame
+
+`/dashboard/users` can approve Admin roles, but Manager access is now a
+separate Admin-owned grant (`ManagerMembership`). Operators need to see and
+toggle product access from the same user-management surface instead of running
+`apps/admin/src/scripts/grant-manager-operator.ts` manually.
+
+## Scope
+
+- In scope: add Manager product access status and grant/revoke actions to the
+  Admin Users page.
+- In scope: shape the page data as product grants so future products can join
+  the same UI pattern.
+- Out of scope: adding new product grant database models for products other
+  than Manager.
+- Out of scope: a full role-management product matrix or audit trail.
+
+## Requirements
+
+1. Users page rows show whether a user has active Manager access.
+2. Admin operators can grant Manager operator access from the row.
+3. Admin operators can revoke Manager operator access from the row.
+4. Existing Admin role approval behavior remains unchanged.
+5. The data/UI names product access generically enough to extend later, while
+   only Manager is actionable in this slice.
+
+## Existing Patterns
+
+- `apps/admin/src/app/dashboard/users/page.tsx` already uses server actions
+  and `revalidatePath("/dashboard/users")` for role approvals.
+- `apps/admin/src/app/dashboard/ops-data.ts` returns `UsersData.rows` consumed
+  by the Users table.
+- `apps/admin/src/scripts/grant-manager-operator.ts` grants by upserting
+  `managerMembership` with `role: "OPERATOR"` and `revokedAt: null`.
+- `apps/admin/src/app/api/manager/session/route.ts` treats access as active
+  when `managerMembership` exists and `revokedAt` is null.
+
+## Implementation Units
+
+### Unit 1 - Users Data Shape
+
+Files:
+
+- `apps/admin/src/app/dashboard/ops-data.ts`
+
+Plan:
+
+- Extend the private `TableRow` shape with an optional `productAccess` array.
+- Select `managerMembership.role` and `managerMembership.revokedAt` in
+  `loadUsersData()`.
+- Map each row to a Manager product access item with active/inactive status,
+  role label, and tone.
+
+Tests:
+
+- Existing Users page render coverage in
+  `apps/admin/src/app/dashboard/dashboard-ui.test.tsx` should keep compiling
+  against the updated row shape.
+
+### Unit 2 - Users Page Product Actions
+
+Files:
+
+- `apps/admin/src/app/dashboard/users/page.tsx`
+
+Plan:
+
+- Add `grantManagerAccess` and `revokeManagerAccess` server actions.
+- Require `requireAdminSession()` and return early unless the operator role is
+  `ADMIN`.
+- Grant via `prisma.managerMembership.upsert()`.
+- Revoke by setting `revokedAt` to the current time when a row exists.
+- Add a "Product Access" table column that renders product grant pills and
+  action buttons.
+
+Tests:
+
+- Add or update Users page render assertions in
+  `apps/admin/src/app/dashboard/dashboard-ui.test.tsx` to verify the Manager
+  product access column and grant/revoke labels render.
+
+### Unit 3 - Roadmap Traceability
+
+Files:
+
+- `docs/roadmap/platform/feat-159-admin-user-product-access-grants.md`
+
+Plan:
+
+- Mark the ticket complete once implementation and validation pass.
+
+## Risk Notes
+
+- Revocation should not delete historical membership rows; `revokedAt` keeps
+  the existing validation behavior and allows re-grant via upsert.
+- The first slice should not pretend other products are grantable until their
+  authorization models exist.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (June 4, 2026)
 
-- **Total tickets:** 184
-- **Complete:** 110
+- **Total tickets:** 185
+- **Complete:** 111
 - **In progress:** 8
 - **Not started:** 21
 - **Blocked:** 43
@@ -168,6 +168,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-153](platform/feat-153-admin-interaction-affordance-polish.md)             | Admin interaction affordance polish                          | tataihono | P1       | 2026-06-01 | 1    | 2026-06-01 | complete    |
 | [feat-155](platform/feat-155-admin-language-diagnostics.md)                      | Admin language diagnostics browser                           | tataihono | P1       | 2026-06-02 | 2    | 2026-06-03 | complete    |
 | [feat-158](platform/feat-158-manager-login-error-signout.md)                     | Manager login error sign-out recovery                        | vlad      | P1       | 2026-06-04 | 1    | 2026-06-04 | complete    |
+| [feat-159](platform/feat-159-admin-user-product-access-grants.md)                | Admin user product access grants                             | vlad      | P1       | 2026-06-04 | 1    | 2026-06-04 | complete    |
 | [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                                   | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
 | [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                          | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                      | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |

--- a/docs/roadmap/platform/feat-125-manager-auth-oauth-admin-backend-migration.md
+++ b/docs/roadmap/platform/feat-125-manager-auth-oauth-admin-backend-migration.md
@@ -10,6 +10,7 @@ depends_on:
   - "feat-121"
 blocks:
   - "feat-133"
+  - "feat-159"
 tags:
   - "manager"
   - "auth"

--- a/docs/roadmap/platform/feat-159-admin-user-product-access-grants.md
+++ b/docs/roadmap/platform/feat-159-admin-user-product-access-grants.md
@@ -1,0 +1,59 @@
+---
+id: "feat-159"
+title: "Admin user product access grants"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-04"
+duration: 1
+depends_on:
+  - "feat-125"
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "auth"
+  - "manager"
+  - "access-control"
+---
+
+## Problem
+
+Operators can approve Admin roles from `/dashboard/users`, but Manager access is
+now controlled by an explicit Admin-owned `ManagerMembership`. Without a UI,
+operators have to run a production script to grant Manager access, and the
+Users page does not show which products a user can open.
+
+## Entry Points - Read These First
+
+1. `apps/admin/src/app/dashboard/users/page.tsx` - Users screen and server
+   actions.
+2. `apps/admin/src/app/dashboard/ops-data.ts` - Users page data loader.
+3. `apps/admin/prisma/schema.prisma` - `ManagerMembership` and future product
+   grant model reference.
+4. `apps/admin/src/app/api/manager/session/route.ts` - production Manager
+   access validation path.
+
+## What To Build
+
+1. Add product-access controls to the Users page.
+2. Show Manager access state for each listed user.
+3. Allow Admin operators to grant and revoke Manager operator access.
+4. Keep the UI shape ready for additional products without inventing new
+   database models before those products have grant tables.
+
+## Constraints
+
+- Do not make Admin roles imply Manager access.
+- Do not create access grants for products that do not yet have a persisted
+  authorization model.
+- Do not expose this control to non-Admin dashboard users.
+- Keep the change local to the Admin Users page and existing
+  `ManagerMembership` model.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint`
+- `git diff --check`


### PR DESCRIPTION
## Summary
- add a Product Access column to Admin Users backed by the existing ManagerMembership model
- add Admin-only server actions to enable or revoke Manager operator access per user
- document feat-159 and mark the roadmap/plan complete

## Validation
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx
- pnpm --filter @forge/admin lint
- git diff --check
- Browser smoke: http://localhost:3003/dashboard/users redirects to /access-request for the unauthenticated local session; Product Access markup is covered by the server-component render test