### PR TITLE
fix(admin): harden user product access grants

### DIFF
--- a/apps/admin/src/app/dashboard/ops-data.test.ts
+++ b/apps/admin/src/app/dashboard/ops-data.test.ts
@@ -1,7 +1,38 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { userCount, userFindMany, managerMembershipFindMany } = vi.hoisted(
+  () => ({
+    userCount: vi.fn(),
+    userFindMany: vi.fn(),
+    managerMembershipFindMany: vi.fn(),
+  }),
+)
+
+vi.mock("@/db/client", () => ({
+  prisma: {
+    user: {
+      count: (...args: unknown[]) => userCount(...args),
+      findMany: (...args: unknown[]) => userFindMany(...args),
+    },
+    managerMembership: {
+      findMany: (...args: unknown[]) => managerMembershipFindMany(...args),
+    },
+  },
+}))
+
+vi.mock("@/config/env", () => ({
+  env: {
+    AUTH_ISSUER_URL: "https://auth.example",
+    CORS_ALLOWED_ORIGINS: "",
+  },
+}))
+
 import {
+  buildUserTableRow,
   buildLanguageDiagnosticRow,
+  loadUsersData,
   type LanguageDiagnosticSourceRow,
+  type UserAccessSourceRow,
 } from "@/app/dashboard/ops-data"
 
 function sourceRow(
@@ -71,6 +102,163 @@ function sourceRow(
     ...overrides,
   }
 }
+
+function userSourceRow(
+  overrides: Partial<UserAccessSourceRow> = {},
+): UserAccessSourceRow {
+  return {
+    id: "user-1",
+    email: "viewer@example.com",
+    role: "VIEWER",
+    emailVerified: true,
+    updatedAt: new Date("2026-01-02T03:04:00.000Z"),
+    managerMembership: null,
+    ...overrides,
+  }
+}
+
+describe("loadUsersData", () => {
+  beforeEach(() => {
+    userCount.mockReset()
+    userFindMany.mockReset()
+    managerMembershipFindMany.mockReset()
+  })
+
+  it("selects Manager membership state and maps active, revoked, and missing product access", async () => {
+    userCount
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(3)
+    userFindMany.mockResolvedValueOnce([
+      userSourceRow({
+        id: "active-user",
+        email: "active@example.com",
+        role: "ADMIN",
+      }),
+      userSourceRow({
+        id: "revoked-user",
+        email: "revoked@example.com",
+      }),
+      userSourceRow({
+        id: "plain-user",
+        email: "plain@example.com",
+      }),
+    ])
+    managerMembershipFindMany.mockResolvedValueOnce([
+      {
+        userId: "active-user",
+        role: "OPERATOR",
+        revokedAt: null,
+      },
+      {
+        userId: "revoked-user",
+        role: "OPERATOR",
+        revokedAt: new Date("2026-01-03T00:00:00.000Z"),
+      },
+    ])
+
+    const data = await loadUsersData()
+
+    expect(userCount).toHaveBeenNthCalledWith(1, { where: { role: "ADMIN" } })
+    expect(userCount).toHaveBeenNthCalledWith(2, { where: { role: "EDITOR" } })
+    expect(userCount).toHaveBeenNthCalledWith(3, { where: { role: "VIEWER" } })
+    expect(userFindMany).toHaveBeenCalledWith({
+      select: {
+        id: true,
+        email: true,
+        role: true,
+        emailVerified: true,
+        updatedAt: true,
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 8,
+    })
+    expect(managerMembershipFindMany).toHaveBeenCalledWith({
+      where: {
+        userId: { in: ["active-user", "revoked-user", "plain-user"] },
+      },
+      select: {
+        userId: true,
+        role: true,
+        revokedAt: true,
+      },
+    })
+    expect(data.rows.map((row) => row.productAccess[0])).toEqual([
+      {
+        key: "manager",
+        label: "Manager",
+        active: true,
+        statusLabel: "Enabled",
+        statusTone: "success",
+        roleLabel: "OPERATOR",
+      },
+      {
+        key: "manager",
+        label: "Manager",
+        active: false,
+        statusLabel: "Disabled",
+        statusTone: "muted",
+        roleLabel: undefined,
+      },
+      {
+        key: "manager",
+        label: "Manager",
+        active: false,
+        statusLabel: "Disabled",
+        statusTone: "muted",
+        roleLabel: undefined,
+      },
+    ])
+  })
+
+  it("keeps user rows visible with Manager disabled when the Manager membership table is absent", async () => {
+    userCount
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1)
+    userFindMany.mockResolvedValueOnce([
+      userSourceRow({
+        id: "viewer-user",
+        email: "viewer@example.com",
+      }),
+    ])
+    managerMembershipFindMany.mockRejectedValueOnce({ code: "P2021" })
+
+    const data = await loadUsersData()
+
+    expect(data.rows).toHaveLength(1)
+    expect(data.rows[0]?.productAccess[0]).toMatchObject({
+      key: "manager",
+      active: false,
+      statusLabel: "Disabled",
+      statusTone: "muted",
+    })
+  })
+})
+
+describe("buildUserTableRow", () => {
+  it("requires product access on every Users row", () => {
+    expect(
+      buildUserTableRow(
+        userSourceRow({
+          managerMembership: {
+            role: "OPERATOR",
+            revokedAt: null,
+          },
+        }),
+      ).productAccess,
+    ).toEqual([
+      {
+        key: "manager",
+        label: "Manager",
+        active: true,
+        statusLabel: "Enabled",
+        statusTone: "success",
+        roleLabel: "OPERATOR",
+      },
+    ])
+  })
+})
 
 describe("buildLanguageDiagnosticRow", () => {
   it("maps active Core language metadata into a serializable diagnostics row", () => {

--- a/apps/admin/src/app/dashboard/ops-data.ts
+++ b/apps/admin/src/app/dashboard/ops-data.ts
@@ -5,6 +5,7 @@ import {
   type MediaImageEnrichmentStatus,
   type MediaAssetStatus,
   type SourceTier,
+  type UserRole,
 } from "@prisma/client"
 import type { Principal } from "@/auth/principal"
 import { env } from "@/config/env"
@@ -32,7 +33,7 @@ type QueueItem = {
   meta: string
   detail?: string
   statusLabel: string
-  statusTone: "success" | "warning" | "danger" | "info" | "muted"
+  statusTone: DashboardStatusTone
 }
 
 type Insight = {
@@ -46,26 +47,51 @@ type TableRow = {
   title: string
   detail: string
   statusLabel: string
-  statusTone: "success" | "warning" | "danger" | "info" | "muted"
+  statusTone: DashboardStatusTone
   meta: string
-  productAccess?: ProductAccess[]
 }
 
-type ProductAccess = {
-  key: "manager"
-  label: string
-  active: boolean
-  statusLabel: string
-  statusTone: "success" | "warning" | "danger" | "info" | "muted"
-  roleLabel?: string
-}
-
-export type LanguageDiagnosticTone =
+export type DashboardStatusTone =
   | "success"
   | "warning"
   | "danger"
   | "info"
   | "muted"
+
+export type UserProductAccess = {
+  key: "manager"
+  label: string
+  active: boolean
+  statusLabel: string
+  statusTone: DashboardStatusTone
+  roleLabel?: "OPERATOR"
+}
+
+export type UserTableRow = TableRow & {
+  productAccess: UserProductAccess[]
+}
+
+export type UserAccessSourceRow = {
+  id: string
+  email: string
+  role: UserRole
+  emailVerified: boolean
+  updatedAt: Date
+  managerMembership: {
+    role: "OPERATOR"
+    revokedAt: Date | null
+  } | null
+}
+
+type UserAccessBaseRow = Omit<UserAccessSourceRow, "managerMembership">
+
+type UserAccessMembershipRow = {
+  userId: string
+  role: "OPERATOR"
+  revokedAt: Date | null
+}
+
+export type LanguageDiagnosticTone = DashboardStatusTone
 
 export type LanguageDiagnosticName = {
   locale: string
@@ -233,7 +259,7 @@ type SystemStatusData = {
     entity: string
     source: string
     statusLabel: string
-    statusTone: "success" | "warning" | "danger" | "info" | "muted"
+    statusTone: DashboardStatusTone
     lastRun: string
   }>
   incidents: QueueItem[]
@@ -315,7 +341,7 @@ type MediaAssetWithEnglishLocale = Awaited<
 
 type UsersData = {
   metrics: Metric[]
-  rows: TableRow[]
+  rows: UserTableRow[]
   insights: Insight[]
 }
 
@@ -1977,7 +2003,7 @@ export async function loadMediaData(principal: Principal): Promise<MediaData> {
 }
 
 export async function loadUsersData(): Promise<UsersData> {
-  const [counts, rows] = await Promise.all([
+  const [counts, userRows] = await Promise.all([
     getUserRoleCounts(),
     withTableFallback(
       () =>
@@ -1988,29 +2014,44 @@ export async function loadUsersData(): Promise<UsersData> {
             role: true,
             emailVerified: true,
             updatedAt: true,
-            managerMembership: {
-              select: {
-                role: true,
-                revokedAt: true,
-              },
-            },
           },
           orderBy: { updatedAt: "desc" },
           take: 8,
         }),
-      [] as Array<{
-        id: string
-        email: string
-        role: string
-        emailVerified: boolean
-        updatedAt: Date
-        managerMembership: {
-          role: "OPERATOR"
-          revokedAt: Date | null
-        } | null
-      }>,
+      [] as UserAccessBaseRow[],
     ),
   ])
+  const userIds = userRows.map((row) => row.id)
+  const managerMemberships =
+    userIds.length > 0
+      ? await withTableFallback(
+          () =>
+            prisma.managerMembership.findMany({
+              where: { userId: { in: userIds } },
+              select: {
+                userId: true,
+                role: true,
+                revokedAt: true,
+              },
+            }),
+          [] as UserAccessMembershipRow[],
+        )
+      : []
+  const managerMembershipByUserId = new Map(
+    managerMemberships.map((membership) => [membership.userId, membership]),
+  )
+  const rows = userRows.map((row): UserAccessSourceRow => {
+    const managerMembership = managerMembershipByUserId.get(row.id)
+    return {
+      ...row,
+      managerMembership: managerMembership
+        ? {
+            role: managerMembership.role,
+            revokedAt: managerMembership.revokedAt,
+          }
+        : null,
+    }
+  })
 
   return {
     metrics: [
@@ -2030,33 +2071,7 @@ export async function loadUsersData(): Promise<UsersData> {
         footer: "PENDING_APPROVAL",
       },
     ],
-    rows: rows.map((row) => {
-      const hasManagerAccess = Boolean(
-        row.managerMembership && !row.managerMembership.revokedAt,
-      )
-
-      return {
-        key: row.id,
-        title: row.email,
-        detail: row.id,
-        statusLabel: row.emailVerified ? row.role : "UNVERIFIED",
-        statusTone:
-          !row.emailVerified || row.role === "VIEWER" ? "warning" : "success",
-        meta: formatDateTime(row.updatedAt),
-        productAccess: [
-          {
-            key: "manager",
-            label: "Manager",
-            active: hasManagerAccess,
-            statusLabel: hasManagerAccess ? "Enabled" : "Disabled",
-            statusTone: hasManagerAccess ? "success" : "muted",
-            roleLabel: hasManagerAccess
-              ? row.managerMembership?.role
-              : undefined,
-          },
-        ],
-      }
-    }),
+    rows: rows.map(buildUserTableRow),
     insights: [
       {
         label: "Role Mappings",
@@ -2073,6 +2088,32 @@ export async function loadUsersData(): Promise<UsersData> {
         label: "Auth Issuer",
         value: new URL(env.AUTH_ISSUER_URL).host,
         detail: "Standalone Auth service used for admin OAuth.",
+      },
+    ],
+  }
+}
+
+export function buildUserTableRow(row: UserAccessSourceRow): UserTableRow {
+  const hasManagerAccess = Boolean(
+    row.managerMembership && !row.managerMembership.revokedAt,
+  )
+
+  return {
+    key: row.id,
+    title: row.email,
+    detail: row.id,
+    statusLabel: row.emailVerified ? row.role : "UNVERIFIED",
+    statusTone:
+      !row.emailVerified || row.role === "VIEWER" ? "warning" : "success",
+    meta: formatDateTime(row.updatedAt),
+    productAccess: [
+      {
+        key: "manager",
+        label: "Manager",
+        active: hasManagerAccess,
+        statusLabel: hasManagerAccess ? "Enabled" : "Disabled",
+        statusTone: hasManagerAccess ? "success" : "muted",
+        roleLabel: hasManagerAccess ? row.managerMembership?.role : undefined,
       },
     ],
   }

--- a/apps/admin/src/app/dashboard/users/actions.test.ts
+++ b/apps/admin/src/app/dashboard/users/actions.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NotFoundError } from "@/services/errors"
+
+const requireAdminSession = vi.fn()
+const revalidatePath = vi.fn()
+const approveUserRole = vi.fn()
+const grantManagerAccessForUser = vi.fn()
+const revokeManagerAccessForUser = vi.fn()
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => revalidatePath(...args),
+}))
+
+vi.mock("@/auth/session", () => ({
+  requireAdminSession: (...args: unknown[]) => requireAdminSession(...args),
+}))
+
+vi.mock("@/services/user-access.service", () => ({
+  approveUserRole: (...args: unknown[]) => approveUserRole(...args),
+  grantManagerAccess: (...args: unknown[]) =>
+    grantManagerAccessForUser(...args),
+  revokeManagerAccess: (...args: unknown[]) =>
+    revokeManagerAccessForUser(...args),
+}))
+
+import {
+  approveUser,
+  grantManagerAccess,
+  revokeManagerAccess,
+} from "@/app/dashboard/users/actions"
+
+const adminUser = { id: "admin-user-1", role: "ADMIN" }
+
+function form(values: Record<string, string>) {
+  const formData = new FormData()
+  for (const [key, value] of Object.entries(values)) {
+    formData.set(key, value)
+  }
+  return formData
+}
+
+describe("dashboard users server actions", () => {
+  beforeEach(() => {
+    requireAdminSession.mockReset()
+    revalidatePath.mockReset()
+    approveUserRole.mockReset()
+    grantManagerAccessForUser.mockReset()
+    revokeManagerAccessForUser.mockReset()
+    requireAdminSession.mockResolvedValue(adminUser)
+  })
+
+  it("approves a valid Admin-local role and revalidates the users page", async () => {
+    await approveUser(form({ id: "target-user-1", role: "EDITOR" }))
+
+    expect(approveUserRole).toHaveBeenCalledWith({
+      user: adminUser,
+      targetUserId: "target-user-1",
+      role: "EDITOR",
+    })
+    expect(revalidatePath).toHaveBeenCalledWith("/dashboard/users")
+  })
+
+  it("ignores unsupported role approval form values", async () => {
+    await approveUser(form({ id: "target-user-1", role: "VIEWER" }))
+
+    expect(approveUserRole).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+
+  it("grants Manager access for a valid row and revalidates", async () => {
+    await grantManagerAccess(form({ id: "target-user-1" }))
+
+    expect(grantManagerAccessForUser).toHaveBeenCalledWith({
+      user: adminUser,
+      targetUserId: "target-user-1",
+    })
+    expect(revalidatePath).toHaveBeenCalledWith("/dashboard/users")
+  })
+
+  it("revokes Manager access for a valid row and revalidates", async () => {
+    await revokeManagerAccess(form({ id: "target-user-1" }))
+
+    expect(revokeManagerAccessForUser).toHaveBeenCalledWith({
+      user: adminUser,
+      targetUserId: "target-user-1",
+    })
+    expect(revalidatePath).toHaveBeenCalledWith("/dashboard/users")
+  })
+
+  it("does not write or revalidate Manager access when id is missing", async () => {
+    await grantManagerAccess(new FormData())
+    await revokeManagerAccess(new FormData())
+
+    expect(grantManagerAccessForUser).not.toHaveBeenCalled()
+    expect(revokeManagerAccessForUser).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+
+  it("swallows missing Manager grant targets and still revalidates", async () => {
+    grantManagerAccessForUser.mockRejectedValueOnce(
+      new NotFoundError("User", "missing-user"),
+    )
+
+    await grantManagerAccess(form({ id: "missing-user" }))
+
+    expect(revalidatePath).toHaveBeenCalledWith("/dashboard/users")
+  })
+
+  it("rethrows non-NotFound Manager revoke failures", async () => {
+    revokeManagerAccessForUser.mockRejectedValueOnce(new Error("db failed"))
+
+    await expect(
+      revokeManagerAccess(form({ id: "target-user-1" })),
+    ).rejects.toThrow("db failed")
+
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/src/app/dashboard/users/actions.ts
+++ b/apps/admin/src/app/dashboard/users/actions.ts
@@ -1,0 +1,57 @@
+import { revalidatePath } from "next/cache"
+import { requireAdminSession } from "@/auth/session"
+import { NotFoundError } from "@/services/errors"
+import {
+  approveUserRole,
+  grantManagerAccess as grantManagerAccessForUser,
+  revokeManagerAccess as revokeManagerAccessForUser,
+} from "@/services/user-access.service"
+
+export async function approveUser(formData: FormData) {
+  "use server"
+
+  const user = await requireAdminSession()
+  const id = formData.get("id")
+  const role = formData.get("role")
+
+  if (typeof id !== "string" || (role !== "EDITOR" && role !== "ADMIN")) {
+    return
+  }
+
+  await approveUserRole({ user, targetUserId: id, role })
+  revalidatePath("/dashboard/users")
+}
+
+export async function grantManagerAccess(formData: FormData) {
+  "use server"
+
+  const user = await requireAdminSession()
+  const id = formData.get("id")
+  if (typeof id !== "string") return
+
+  try {
+    await grantManagerAccessForUser({ user, targetUserId: id })
+  } catch (error) {
+    if (!(error instanceof NotFoundError)) {
+      throw error
+    }
+  }
+  revalidatePath("/dashboard/users")
+}
+
+export async function revokeManagerAccess(formData: FormData) {
+  "use server"
+
+  const user = await requireAdminSession()
+  const id = formData.get("id")
+  if (typeof id !== "string") return
+
+  try {
+    await revokeManagerAccessForUser({ user, targetUserId: id })
+  } catch (error) {
+    if (!(error instanceof NotFoundError)) {
+      throw error
+    }
+  }
+  revalidatePath("/dashboard/users")
+}

--- a/apps/admin/src/app/dashboard/users/page.tsx
+++ b/apps/admin/src/app/dashboard/users/page.tsx
@@ -1,5 +1,4 @@
 import { Shield } from "lucide-react"
-import { revalidatePath } from "next/cache"
 import {
   DashboardPageHeader,
   DataTable,
@@ -9,62 +8,15 @@ import {
 } from "@/components/admin-ui"
 import { requireAdminSession } from "@/auth/session"
 import { getAdminMessages } from "@/i18n/server"
-import { loadUsersData } from "@/app/dashboard/ops-data"
-import { NotFoundError } from "@/services/errors"
 import {
-  approveUserRole,
-  grantManagerAccess as grantManagerAccessForUser,
-  revokeManagerAccess as revokeManagerAccessForUser,
-} from "@/services/user-access.service"
-
-async function approveUser(formData: FormData) {
-  "use server"
-
-  const user = await requireAdminSession()
-  const id = formData.get("id")
-  const role = formData.get("role")
-
-  if (typeof id !== "string" || (role !== "EDITOR" && role !== "ADMIN")) {
-    return
-  }
-
-  await approveUserRole({ user, targetUserId: id, role })
-  revalidatePath("/dashboard/users")
-}
-
-async function grantManagerAccess(formData: FormData) {
-  "use server"
-
-  const user = await requireAdminSession()
-  const id = formData.get("id")
-  if (typeof id !== "string") return
-
-  try {
-    await grantManagerAccessForUser({ user, targetUserId: id })
-  } catch (error) {
-    if (!(error instanceof NotFoundError)) {
-      throw error
-    }
-  }
-  revalidatePath("/dashboard/users")
-}
-
-async function revokeManagerAccess(formData: FormData) {
-  "use server"
-
-  const user = await requireAdminSession()
-  const id = formData.get("id")
-  if (typeof id !== "string") return
-
-  try {
-    await revokeManagerAccessForUser({ user, targetUserId: id })
-  } catch (error) {
-    if (!(error instanceof NotFoundError)) {
-      throw error
-    }
-  }
-  revalidatePath("/dashboard/users")
-}
+  loadUsersData,
+  type DashboardStatusTone,
+} from "@/app/dashboard/ops-data"
+import {
+  approveUser,
+  grantManagerAccess,
+  revokeManagerAccess,
+} from "@/app/dashboard/users/actions"
 
 export default async function UsersPage() {
   await requireAdminSession()
@@ -143,7 +95,7 @@ export default async function UsersPage() {
                   key={`${row.key}-products`}
                   className="flex min-w-[180px] flex-wrap gap-2"
                 >
-                  {(row.productAccess ?? []).map((access) => (
+                  {row.productAccess.map((access) => (
                     <div
                       key={access.key}
                       className="flex flex-wrap items-center gap-2"
@@ -217,7 +169,7 @@ export default async function UsersPage() {
   )
 }
 
-function statusToneClass(tone: string) {
+function statusToneClass(tone: DashboardStatusTone) {
   if (tone === "success") {
     return "border-[var(--color-success-border)] text-[var(--color-success)]"
   }
@@ -226,6 +178,9 @@ function statusToneClass(tone: string) {
   }
   if (tone === "danger") {
     return "border-[var(--color-danger-border)] text-[var(--color-danger)]"
+  }
+  if (tone === "info") {
+    return "border-[var(--color-info-border)] text-[var(--color-info)]"
   }
   return "border-[var(--color-hairline-strong)] text-[var(--color-text-muted)]"
 }

--- a/apps/admin/src/services/user-access.service.test.ts
+++ b/apps/admin/src/services/user-access.service.test.ts
@@ -5,6 +5,7 @@ import {
   approveUserRole,
   grantManagerAccess,
   revokeManagerAccess,
+  type UserAccessStore,
 } from "@/services/user-access.service"
 
 const adminUser = {
@@ -27,12 +28,17 @@ function makeMockPrisma() {
       upsert: vi.fn(),
       updateMany: vi.fn(),
     },
-  } as const
+  } satisfies UserAccessStore
+}
+
+function mockCurrentAdmin(prisma: ReturnType<typeof makeMockPrisma>) {
+  prisma.user.findUnique.mockResolvedValueOnce({ role: "ADMIN" })
 }
 
 describe("user-access.service", () => {
   it("approves an admin-local user role for Admin principals", async () => {
     const prisma = makeMockPrisma()
+    mockCurrentAdmin(prisma)
     prisma.user.update.mockResolvedValueOnce({ id: "target-user-1" })
 
     await approveUserRole(
@@ -41,7 +47,7 @@ describe("user-access.service", () => {
         targetUserId: "target-user-1",
         role: "EDITOR",
       },
-      prisma as never,
+      prisma,
     )
 
     expect(prisma.user.update).toHaveBeenCalledWith({
@@ -61,7 +67,7 @@ describe("user-access.service", () => {
           targetUserId: "target-user-1",
           role: "ADMIN",
         },
-        prisma as never,
+        prisma,
       ),
     ).rejects.toBeInstanceOf(ForbiddenError)
 
@@ -70,6 +76,7 @@ describe("user-access.service", () => {
 
   it("grants Manager operator access by upserting an active membership", async () => {
     const prisma = makeMockPrisma()
+    mockCurrentAdmin(prisma)
     prisma.user.findUnique.mockResolvedValueOnce({ id: "target-user-1" })
     prisma.managerMembership.upsert.mockResolvedValueOnce({
       id: "membership-1",
@@ -80,10 +87,14 @@ describe("user-access.service", () => {
         user: adminUser,
         targetUserId: "target-user-1",
       },
-      prisma as never,
+      prisma,
     )
 
-    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+    expect(prisma.user.findUnique).toHaveBeenNthCalledWith(1, {
+      where: { id: "admin-user-1" },
+      select: { role: true },
+    })
+    expect(prisma.user.findUnique).toHaveBeenNthCalledWith(2, {
       where: { id: "target-user-1" },
       select: { id: true },
     })
@@ -110,7 +121,7 @@ describe("user-access.service", () => {
           user: editorUser,
           targetUserId: "target-user-1",
         },
-        prisma as never,
+        prisma,
       ),
     ).rejects.toBeInstanceOf(ForbiddenError)
 
@@ -120,6 +131,7 @@ describe("user-access.service", () => {
 
   it("throws NotFoundError instead of writing when the Manager grant target user is missing", async () => {
     const prisma = makeMockPrisma()
+    mockCurrentAdmin(prisma)
     prisma.user.findUnique.mockResolvedValueOnce(null)
 
     await expect(
@@ -128,15 +140,33 @@ describe("user-access.service", () => {
           user: adminUser,
           targetUserId: "missing-user",
         },
-        prisma as never,
+        prisma,
       ),
     ).rejects.toBeInstanceOf(NotFoundError)
 
     expect(prisma.managerMembership.upsert).not.toHaveBeenCalled()
   })
 
+  it("rejects Manager grants when a stale Admin session has been downgraded", async () => {
+    const prisma = makeMockPrisma()
+    prisma.user.findUnique.mockResolvedValueOnce({ role: "EDITOR" })
+
+    await expect(
+      grantManagerAccess(
+        {
+          user: adminUser,
+          targetUserId: "target-user-1",
+        },
+        prisma,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+
+    expect(prisma.managerMembership.upsert).not.toHaveBeenCalled()
+  })
+
   it("revokes only an active Manager membership", async () => {
     const prisma = makeMockPrisma()
+    mockCurrentAdmin(prisma)
     prisma.user.findUnique.mockResolvedValueOnce({ id: "target-user-1" })
     prisma.managerMembership.updateMany.mockResolvedValueOnce({ count: 1 })
 
@@ -145,7 +175,7 @@ describe("user-access.service", () => {
         user: adminUser,
         targetUserId: "target-user-1",
       },
-      prisma as never,
+      prisma,
     )
 
     expect(prisma.managerMembership.updateMany).toHaveBeenCalledTimes(1)
@@ -157,6 +187,31 @@ describe("user-access.service", () => {
     expect(arg.data.revokedAt).toBeInstanceOf(Date)
   })
 
+  it("keeps already-revoked Manager membership revokes idempotent", async () => {
+    const prisma = makeMockPrisma()
+    mockCurrentAdmin(prisma)
+    prisma.user.findUnique.mockResolvedValueOnce({ id: "target-user-1" })
+    prisma.managerMembership.updateMany.mockResolvedValueOnce({ count: 0 })
+
+    const result = await revokeManagerAccess(
+      {
+        user: adminUser,
+        targetUserId: "target-user-1",
+      },
+      prisma,
+    )
+
+    expect(result).toEqual({ count: 0 })
+    expect(prisma.managerMembership.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "target-user-1",
+          revokedAt: null,
+        },
+      }),
+    )
+  })
+
   it("rejects Manager revokes for non-Admin principals before reading users", async () => {
     const prisma = makeMockPrisma()
 
@@ -166,7 +221,7 @@ describe("user-access.service", () => {
           user: editorUser,
           targetUserId: "target-user-1",
         },
-        prisma as never,
+        prisma,
       ),
     ).rejects.toBeInstanceOf(ForbiddenError)
 

--- a/apps/admin/src/services/user-access.service.ts
+++ b/apps/admin/src/services/user-access.service.ts
@@ -6,16 +6,33 @@ import { ForbiddenError, NotFoundError } from "@/services/errors"
 
 export type AdminAssignableRole = "EDITOR" | "ADMIN"
 
-type PrismaLike = Pick<PrismaClient, "user" | "managerMembership">
+export type UserAccessStore = {
+  user: Pick<PrismaClient["user"], "findUnique" | "update">
+  managerMembership: Pick<
+    PrismaClient["managerMembership"],
+    "upsert" | "updateMany"
+  >
+}
 
-function assertAdmin(user: Principal | null) {
-  if (!hasPermission(user, "admin:all")) {
+async function assertCurrentAdmin(
+  prisma: UserAccessStore,
+  user: Principal | null,
+) {
+  if (!hasPermission(user, "admin:all") || !user?.id) {
+    throw new ForbiddenError()
+  }
+
+  const currentUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { role: true },
+  })
+  if (currentUser?.role !== "ADMIN") {
     throw new ForbiddenError()
   }
 }
 
 async function assertTargetUserExists(
-  prisma: PrismaLike,
+  prisma: UserAccessStore,
   userId: string,
 ): Promise<void> {
   const user = await prisma.user.findUnique({
@@ -38,9 +55,9 @@ export async function approveUserRole(
     targetUserId: string
     role: AdminAssignableRole
   },
-  prisma: PrismaLike = defaultPrisma,
+  prisma: UserAccessStore = defaultPrisma,
 ) {
-  assertAdmin(user)
+  await assertCurrentAdmin(prisma, user)
 
   return prisma.user.update({
     where: { id: targetUserId },
@@ -57,9 +74,9 @@ export async function grantManagerAccess(
     user: Principal | null
     targetUserId: string
   },
-  prisma: PrismaLike = defaultPrisma,
+  prisma: UserAccessStore = defaultPrisma,
 ) {
-  assertAdmin(user)
+  await assertCurrentAdmin(prisma, user)
   await assertTargetUserExists(prisma, targetUserId)
 
   return prisma.managerMembership.upsert({
@@ -84,9 +101,9 @@ export async function revokeManagerAccess(
     user: Principal | null
     targetUserId: string
   },
-  prisma: PrismaLike = defaultPrisma,
+  prisma: UserAccessStore = defaultPrisma,
 ) {
-  assertAdmin(user)
+  await assertCurrentAdmin(prisma, user)
   await assertTargetUserExists(prisma, targetUserId)
 
   return prisma.managerMembership.updateMany({

--- a/docs/roadmap/platform/feat-159-admin-user-product-access-grants.md
+++ b/docs/roadmap/platform/feat-159-admin-user-product-access-grants.md
@@ -34,6 +34,15 @@ Users page does not show which products a user can open.
 4. `apps/admin/src/app/api/manager/session/route.ts` - production Manager
    access validation path.
 
+## Grep These
+
+- `loadUsersData` - Users page data shaping.
+- `ManagerMembership` - persisted Manager product grant model.
+- `managerMembership` - runtime access checks and Prisma relation reads.
+- `grantManagerAccess` - Admin Users page grant action.
+- `revokeManagerAccess` - Admin Users page revoke action.
+- `manager:grant-operator` - existing script this UI replaces for operators.
+
 ## What To Build
 
 1. Add product-access controls to the Users page.


### PR DESCRIPTION
## Summary
- extract Admin Users product-access server actions into a testable module with grant/revoke wiring coverage
- harden user access mutations by checking the caller's current persisted Admin role before writes
- split Users data loading so missing ManagerMembership tables degrade to disabled Manager access instead of hiding users
- tighten Users row/product-access types and add roadmap grep patterns

## Review Notes
- Follow-up to merged PR #1139; this contains the CE review hardening commit only.
- Residual accepted risk: stale Enable Manager forms can still submit an authorized grant from an Admin; preventing that would require a versioned product-access form contract.

## Validation
- pnpm --filter @forge/admin test -- src/app/dashboard/ops-data.test.ts src/app/dashboard/users/actions.test.ts src/services/user-access.service.test.ts src/app/dashboard/dashboard-ui.test.tsx
- pnpm --filter @forge/admin typecheck
- pnpm --filter @forge/admin lint
- git diff --check