### PR TITLE
fix(admin): route gateway chat agents to chat-completions (fixes 'role' 500 on tool calls + draft generation)

### DIFF
--- a/apps/admin/src/mastra/agents/default-chat-agent.ts
+++ b/apps/admin/src/mastra/agents/default-chat-agent.ts
@@ -102,7 +102,13 @@ export function buildDefaultChatAgent(): Agent {
         "User-Agent": AI_GATEWAY_USER_AGENT,
       },
     })
-    model = gateway(
+    // `.chat()` pins the chat-completions endpoint. The bare callable
+    // `gateway(id)` defaults to the Responses API (`/v1/responses`) in
+    // @ai-sdk/openai v3, which crashes the gateway's vLLM backend on
+    // multi-turn tool conversations (`KeyError: 'role'` in vLLM's
+    // `_parse_chat_message_content` — confirmed in vllm-coder logs
+    // 2026-06-05). Chat-completions handles the same tool history fine.
+    model = gateway.chat(
       env.AI_GATEWAY_CHAT_MODEL ?? "coding",
     ) as unknown as LanguageModel
   } else if (env.GOOGLE_GENERATIVE_AI_API_KEY) {
@@ -126,7 +132,10 @@ export function buildDefaultChatAgent(): Agent {
       baseURL: "https://openrouter.ai/api/v1",
       name: "openrouter",
     })
-    model = openrouter(OPENROUTER_MODEL) as unknown as LanguageModel
+    // `.chat()` pins chat-completions; the bare callable defaults to the
+    // Responses API in @ai-sdk/openai v3, which OpenRouter does not
+    // implement consistently. Same rationale as the gateway branch above.
+    model = openrouter.chat(OPENROUTER_MODEL) as unknown as LanguageModel
   } else {
     const { createOllama } =
       require("ollama-ai-provider-v2") as typeof import("ollama-ai-provider-v2")

--- a/apps/admin/src/mastra/agents/specialized-agents.ts
+++ b/apps/admin/src/mastra/agents/specialized-agents.ts
@@ -90,7 +90,14 @@ function resolveAgentModel(): any {
         "User-Agent": AI_GATEWAY_USER_AGENT,
       },
     })
-    return gateway(env.AI_GATEWAY_CHAT_MODEL ?? "coding")
+    // `.chat()` pins the OpenAI chat-completions endpoint
+    // (`/v1/chat/completions`). The bare callable `gateway(id)` defaults
+    // to the Responses API (`/v1/responses`) in @ai-sdk/openai v3, and
+    // the gateway's vLLM backend crashes converting multi-turn tool
+    // conversations on that endpoint (`KeyError: 'role'` in
+    // `_parse_chat_message_content` — confirmed in vllm-coder logs
+    // 2026-06-05). Chat-completions handles the same tool history fine.
+    return gateway.chat(env.AI_GATEWAY_CHAT_MODEL ?? "coding")
   }
   if (env.GOOGLE_GENERATIVE_AI_API_KEY) {
     const { createGoogleGenerativeAI } =

--- a/apps/admin/src/mastra/workflows/multi-step-draft-workflow.test.ts
+++ b/apps/admin/src/mastra/workflows/multi-step-draft-workflow.test.ts
@@ -1,4 +1,17 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// The workflow reads the gateway gate (AI_GATEWAY_CHAT_*) at call time
+// to decide whether draft/revise request provider-native structured
+// output. Default both to undefined so every pre-existing test runs the
+// plain text → parse-ladder path; structured-path tests flip them.
+const mockEnv = vi.hoisted(() => ({
+  env: {
+    AI_GATEWAY_CHAT_API_KEY: undefined as string | undefined,
+    AI_GATEWAY_CHAT_ENABLED: undefined as string | undefined,
+  },
+}))
+
+vi.mock("@/config/env", () => mockEnv)
 
 import {
   executeCritiqueStep,
@@ -39,8 +52,10 @@ const VALID_DRAFT: DraftExperience = {
   ],
 }
 
+type MockAgentResponse = { text: string; object?: unknown }
+
 function makeMockAgent(
-  responses: { text: string },
+  responses: MockAgentResponse,
   spy?: { calls: Array<{ prompt: string; opts: unknown }> },
 ) {
   return {
@@ -51,7 +66,7 @@ function makeMockAgent(
   }
 }
 
-function makeMockMastra(agentResponses: Record<string, { text: string }>) {
+function makeMockMastra(agentResponses: Record<string, MockAgentResponse>) {
   const callLog: Record<string, Array<{ prompt: string; opts: unknown }>> = {}
   const agentLookups: string[] = []
   const mastra = {
@@ -65,6 +80,11 @@ function makeMockMastra(agentResponses: Record<string, { text: string }>) {
 }
 
 describe("multiStepDraftWorkflow (U4 — real step bodies)", () => {
+  beforeEach(() => {
+    mockEnv.env.AI_GATEWAY_CHAT_API_KEY = undefined
+    mockEnv.env.AI_GATEWAY_CHAT_ENABLED = undefined
+  })
+
   describe("structural invariants", () => {
     it("exposes a stable workflow id", () => {
       expect(multiStepDraftWorkflow.id).toBe("multi-step-draft")
@@ -258,6 +278,87 @@ describe("multiStepDraftWorkflow (U4 — real step bodies)", () => {
         title: VALID_DRAFT.title,
         metaDescription: VALID_DRAFT.metaDescription,
       })
+    })
+  })
+
+  describe("structured output (gateway path)", () => {
+    const baseInput = {
+      prompt: "Hope page",
+      locale: "en",
+      candidates: [],
+      plan: "1. hero 2. text 3. cta",
+    }
+
+    function enableGateway() {
+      mockEnv.env.AI_GATEWAY_CHAT_API_KEY = "sk-test"
+      mockEnv.env.AI_GATEWAY_CHAT_ENABLED = "true"
+    }
+
+    it("requests structuredOutput + toolChoice none when the gateway is enabled", async () => {
+      enableGateway()
+      const { mastra, callLog } = makeMockMastra({
+        "draft-experience": { text: "", object: VALID_DRAFT },
+      })
+      await executeDraftStep({ inputData: baseInput, mastra })
+      const opts = callLog["draft-experience"][0].opts as {
+        toolChoice?: string
+        structuredOutput?: { schema?: unknown }
+      }
+      expect(opts.toolChoice).toBe("none")
+      expect(opts.structuredOutput?.schema).toBeDefined()
+    })
+
+    it("prefers the provider-validated object over text parsing", async () => {
+      enableGateway()
+      const { mastra } = makeMockMastra({
+        // text deliberately unparseable — only the object path can pass
+        "draft-experience": { text: "not json at all", object: VALID_DRAFT },
+      })
+      const result = await executeDraftStep({ inputData: baseInput, mastra })
+      expect(result.draft).toEqual(VALID_DRAFT)
+    })
+
+    it("falls back to the text ladder when the structured object misses the schema", async () => {
+      enableGateway()
+      const { mastra } = makeMockMastra({
+        "draft-experience": {
+          text: JSON.stringify(VALID_DRAFT),
+          object: { definitely: "not a draft" },
+        },
+      })
+      const result = await executeDraftStep({ inputData: baseInput, mastra })
+      expect(result.draft).toEqual(VALID_DRAFT)
+    })
+
+    it("does NOT request structured output when the gateway is disabled", async () => {
+      const { mastra, callLog } = makeMockMastra({
+        "draft-experience": { text: JSON.stringify(VALID_DRAFT) },
+      })
+      await executeDraftStep({ inputData: baseInput, mastra })
+      const opts = callLog["draft-experience"][0].opts as {
+        toolChoice?: string
+        structuredOutput?: unknown
+      }
+      expect(opts.toolChoice).toBeUndefined()
+      expect(opts.structuredOutput).toBeUndefined()
+    })
+
+    it("applies the same structured options on the revise step", async () => {
+      enableGateway()
+      const { mastra, callLog } = makeMockMastra({
+        "experience-reviser": { text: "", object: VALID_DRAFT },
+      })
+      const result = await executeReviseStep({
+        inputData: { draft: VALID_DRAFT, notes: "tighten the cta" },
+        mastra,
+      })
+      expect(result.draft).toEqual(VALID_DRAFT)
+      const opts = callLog["experience-reviser"][0].opts as {
+        toolChoice?: string
+        structuredOutput?: { schema?: unknown }
+      }
+      expect(opts.toolChoice).toBe("none")
+      expect(opts.structuredOutput?.schema).toBeDefined()
     })
   })
 

--- a/apps/admin/src/mastra/workflows/multi-step-draft-workflow.ts
+++ b/apps/admin/src/mastra/workflows/multi-step-draft-workflow.ts
@@ -27,6 +27,7 @@ import { createStep, createWorkflow } from "@mastra/core/workflows"
 import type { Mastra } from "@mastra/core"
 import { z } from "zod"
 
+import { env } from "@/config/env"
 import { TOKEN_CAPS } from "../budgets"
 import { DraftExperienceSchema } from "@/services/experience-ai/experience-ai.schemas"
 import type { DraftExperience } from "@/services/experience-ai/experience-ai.schemas"
@@ -120,8 +121,13 @@ type RevisedStepOutput = z.infer<typeof revisedSchema>
 type MastraAgent = {
   generate: (
     prompt: string,
-    opts: { abortSignal?: AbortSignal; maxOutputTokens: number },
-  ) => Promise<{ text: string }>
+    opts: {
+      abortSignal?: AbortSignal
+      maxOutputTokens: number
+      toolChoice?: "auto" | "none" | "required"
+      structuredOutput?: { schema: typeof DraftExperienceSchema }
+    },
+  ) => Promise<{ text: string; object?: unknown }>
 }
 
 type MastraSurface = {
@@ -145,6 +151,31 @@ function isAbortError(err: unknown): boolean {
   )
 }
 
+/**
+ * Whether the draft/revise steps should request provider-native
+ * structured output. Gated to the JesusFilm gateway path
+ * (same gate `resolveAgentModel` uses): vLLM guided decoding
+ * (`response_format: json_schema`) makes schema-invalid drafts
+ * impossible at the decoder level, AND `toolChoice: "none"` keeps the
+ * model out of tool round-trips — the gateway's LiteLLM translation
+ * 500s with a `'role'` KeyError on multi-tool conversations, which was
+ * failing the draft step before any output existed (smoke gate 0/8 on
+ * 2026-06-05, every failure `[draft] agent_error … "'role'"`). The
+ * workflow gets video candidates pre-loaded in its input, so the
+ * drafter does not need the search tools here. Google/OpenRouter keep
+ * the text → parse-ladder path that already works for them.
+ */
+function structuredDraftOutputEnabled(): boolean {
+  return Boolean(
+    env.AI_GATEWAY_CHAT_API_KEY && env.AI_GATEWAY_CHAT_ENABLED === "true",
+  )
+}
+
+const STRUCTURED_DRAFT_OPTS = {
+  toolChoice: "none",
+  structuredOutput: { schema: DraftExperienceSchema },
+} as const
+
 async function callAgent(
   mastra: MastraSurface,
   step: WorkflowStepName,
@@ -152,14 +183,18 @@ async function callAgent(
   prompt: string,
   maxOutputTokens: number,
   abortSignal: AbortSignal | undefined,
-): Promise<string> {
+  extraOpts: {
+    toolChoice?: "auto" | "none" | "required"
+    structuredOutput?: { schema: typeof DraftExperienceSchema }
+  } = {},
+): Promise<{ text: string; object?: unknown }> {
   const agent = mastra.getAgentById(agentId)
   try {
-    const result = await agent.generate(prompt, {
+    return await agent.generate(prompt, {
       abortSignal,
       maxOutputTokens,
+      ...extraOpts,
     })
-    return result.text
   } catch (err) {
     if (isAbortError(err)) {
       throw new WorkflowStepError(
@@ -348,6 +383,31 @@ function buildRevisePrompt(input: CritiqueStepOutput): string {
   ].join("\n")
 }
 
+/**
+ * Resolve a draft-producing step's result to a validated
+ * DraftExperience. Prefers the provider-validated `object` from
+ * structured output (already schema-enforced at decode time on the
+ * gateway path); falls back to the text → extract → jsonrepair ladder
+ * for providers that answered with plain text, or in the unexpected
+ * case where the structured object still misses the Zod schema.
+ */
+async function resolveDraft(
+  step: WorkflowStepName,
+  result: { text: string; object?: unknown },
+): Promise<DraftExperience> {
+  if (result.object !== undefined) {
+    const parsed = DraftExperienceSchema.safeParse(
+      liftToDraftExperienceShape(result.object),
+    )
+    if (parsed.success) return parsed.data
+  }
+  const text =
+    result.text.length > 0 || result.object === undefined
+      ? result.text
+      : JSON.stringify(result.object)
+  return parseDraftEnvelope(step, text)
+}
+
 // ---------------------------------------------------------------------------
 // Step executors — exported for unit-testing without a real Mastra runtime
 // ---------------------------------------------------------------------------
@@ -355,7 +415,7 @@ function buildRevisePrompt(input: CritiqueStepOutput): string {
 export async function executePlanStep(
   ctx: StepContext<WorkflowInput>,
 ): Promise<PlanStepOutput> {
-  const text = await callAgent(
+  const { text } = await callAgent(
     ctx.mastra,
     "plan",
     "experience-planner",
@@ -369,22 +429,23 @@ export async function executePlanStep(
 export async function executeDraftStep(
   ctx: StepContext<PlanStepOutput>,
 ): Promise<DraftStepOutput> {
-  const text = await callAgent(
+  const result = await callAgent(
     ctx.mastra,
     "draft",
     "draft-experience",
     buildDraftPrompt(ctx.inputData),
     TOKEN_CAPS.multiStepDraftDraft,
     ctx.abortSignal,
+    structuredDraftOutputEnabled() ? STRUCTURED_DRAFT_OPTS : {},
   )
-  const draft = await parseDraftEnvelope("draft", text)
+  const draft = await resolveDraft("draft", result)
   return { ...ctx.inputData, draft }
 }
 
 export async function executeCritiqueStep(
   ctx: StepContext<DraftStepOutput>,
 ): Promise<CritiqueStepOutput> {
-  const text = await callAgent(
+  const { text } = await callAgent(
     ctx.mastra,
     "critique",
     "experience-critic",
@@ -398,15 +459,16 @@ export async function executeCritiqueStep(
 export async function executeReviseStep(
   ctx: StepContext<CritiqueStepOutput>,
 ): Promise<RevisedStepOutput> {
-  const text = await callAgent(
+  const result = await callAgent(
     ctx.mastra,
     "revise",
     "experience-reviser",
     buildRevisePrompt(ctx.inputData),
     TOKEN_CAPS.multiStepDraftRevise,
     ctx.abortSignal,
+    structuredDraftOutputEnabled() ? STRUCTURED_DRAFT_OPTS : {},
   )
-  const draft = await parseDraftEnvelope("revise", text)
+  const draft = await resolveDraft("revise", result)
   return { draft }
 }
 


### PR DESCRIPTION
## Summary

"Generate full page" and multi-tool chat turns were failing in production through the JesusFilm AI gateway with a 500 `{"message":"'role'"}`. Root cause: **`@ai-sdk/openai` v3's default model callable targets the OpenAI Responses API (`/v1/responses`)**, and the gateway's vLLM backend crashes converting multi-turn tool conversations on that endpoint — `KeyError: 'role'` in vLLM's `_parse_chat_message_content` (confirmed in `vllm-coder` logs 2026-06-05). Chat Completions (`/v1/chat/completions`) handles the identical tool history fine.

This is an **app-side fix** — the gateway itself is unchanged.

## Changes

- **`bc284105` — pin chat-completions (root cause).** Switch the JesusFilm gateway and OpenRouter model construction from the bare callable `provider(id)` to `provider.chat(id)` in `default-chat-agent.ts` and `specialized-agents.ts`. Google (own SDK) and Ollama (already `.chat()`) are unaffected.
- **`ffb4e329` — structured output for the draft workflow (defense in depth).** On the gateway path the draft + revise steps request provider-native structured output (`response_format` → vLLM guided decoding) and `toolChoice: "none"`. The workflow already receives video candidates pre-loaded, so it needs no tools there; guided decoding makes schema-invalid drafts impossible. `resolveDraft` prefers the provider-validated object and keeps the text → `jsonrepair` ladder as fallback.

## Why both

`.chat()` alone fixes the endpoint for every surface (chat panel included). The structured-output change is complementary: it guarantees the draft workflow always returns a `DraftExperienceSchema`-valid page and avoids unnecessary tool round-trips on the page generator.

## Verification (live gateway, AI_GATEWAY_CHAT_ENABLED=true)

| Gate | Before | After |
|---|---|---|
| `smoke:draft-workflow` (8 prompts) | **0/8** — every draft step 500'd on `'role'` | **8/8** valid drafts |
| Multi-tool chat turn (2 `lookupBibleVerse` round-trips) | 500 `'role'` | completes cleanly, synthesized reply |
| Hand-built two-tool curl to `/v1/chat/completions` | n/a | 200 (endpoint confirmed healthy) |
| Admin tests / lint / typecheck | — | green (pre-commit hooks ran) |

## Diagnosis trail

The `'role'` 500 reproduced only via the SDK, never via a hand-built chat-completions curl — which is what pointed at the endpoint. The vLLM traceback (`responses/api_router.py → create_responses → _parse_chat_message_content → role = message["role"]`) confirmed the request was hitting `/v1/responses` and one converted input-item lacked a `role`.

## Notes for reviewers

- No production gateway config was changed; the Jun 3 `--tool-call-parser gemma4` setup on the gateway is fine and stays.
- Behavior with the gateway flag off (Google / OpenRouter fallback) is unchanged in shape; the OpenRouter path also moves to `.chat()` (it doesn't implement the Responses API consistently either).
- New tests cover the structured-output path (gateway-on requests structured opts + toolChoice none; object preferred over text; invalid-object fallback; gateway-off keeps the old call shape; revise parity).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
