### PR TITLE
feat(admin): Qwen-1536 video-search capability for AI experience generation (parallel columns, flag-gated)

### DIFF
--- a/apps/admin/prisma/migrations/0032_video_embedding_qwen/migration.sql
+++ b/apps/admin/prisma/migrations/0032_video_embedding_qwen/migration.sql
@@ -1,0 +1,71 @@
+-- Content embeddings gateway migration (U2).
+--
+-- Adds a PARALLEL `embedding_qwen vector(1536)` column to the two
+-- video-content embedding tables — `video_scene_locale` and
+-- `video_transcript_chunk` — alongside the existing `embedding` column.
+-- This is purely additive and forward-only: the existing `embedding`
+-- column and its HNSW indexes are untouched, so the live OpenAI-vector
+-- search path keeps working while the Jesus Film AI Gateway (Qwen) vectors
+-- are backfilled into the new column behind a source toggle.
+--
+-- The new per-locale (en/es/fr) + global-fallback partial HNSW indexes
+-- mirror the existing `embedding` indexes EXACTLY (same `vector_cosine_ops`
+-- ops class, same per-locale/per-language WHERE predicates, same
+-- NULL-exclusion) so the Qwen retrieval path inherits the same planner
+-- behavior — including the per-locale guard against pgvector's
+-- "HNSW + WHERE locale = ?" planner bypass.
+-- See docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md.
+--
+-- `experience_locale` is deliberately OUT OF SCOPE for this migration.
+-- The `vector` extension is already installed (the existing `embedding`
+-- columns use it); do NOT re-create it.
+
+-- =============================================================================
+-- video_scene_locale — parallel Qwen embedding column + per-locale HNSW
+-- =============================================================================
+
+ALTER TABLE "video_scene_locale" ADD COLUMN "embedding_qwen" vector(1536);
+
+-- HNSW partial indexes — NULL embeddings excluded. Global fallback for
+-- locales outside Phase 1 (en/es/fr); per-locale indexes accelerate
+-- `WHERE locale = ? ORDER BY embedding_qwen <=> ?` at scale.
+CREATE INDEX IF NOT EXISTS "video_scene_locale_embedding_qwen_hnsw"
+    ON "video_scene_locale" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "video_scene_locale_embedding_qwen_hnsw_en"
+    ON "video_scene_locale" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL AND "locale" = 'en';
+
+CREATE INDEX IF NOT EXISTS "video_scene_locale_embedding_qwen_hnsw_es"
+    ON "video_scene_locale" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL AND "locale" = 'es';
+
+CREATE INDEX IF NOT EXISTS "video_scene_locale_embedding_qwen_hnsw_fr"
+    ON "video_scene_locale" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL AND "locale" = 'fr';
+
+-- =============================================================================
+-- video_transcript_chunk — parallel Qwen embedding column + per-language HNSW
+-- =============================================================================
+
+ALTER TABLE "video_transcript_chunk" ADD COLUMN "embedding_qwen" vector(1536);
+
+-- HNSW partial indexes — NULL embeddings excluded. Global fallback for
+-- languages outside Phase 1 (en/es/fr); per-language indexes accelerate
+-- `WHERE language = ? ORDER BY embedding_qwen <=> ?` at scale.
+CREATE INDEX IF NOT EXISTS "video_transcript_chunk_embedding_qwen_hnsw"
+    ON "video_transcript_chunk" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "video_transcript_chunk_embedding_qwen_hnsw_en"
+    ON "video_transcript_chunk" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL AND "language" = 'en';
+
+CREATE INDEX IF NOT EXISTS "video_transcript_chunk_embedding_qwen_hnsw_es"
+    ON "video_transcript_chunk" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL AND "language" = 'es';
+
+CREATE INDEX IF NOT EXISTS "video_transcript_chunk_embedding_qwen_hnsw_fr"
+    ON "video_transcript_chunk" USING hnsw ("embedding_qwen" vector_cosine_ops)
+    WHERE "embedding_qwen" IS NOT NULL AND "language" = 'fr';

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -1458,6 +1458,7 @@ model VideoSceneLocale {
   demographics              String[]                     @default([])
   spiritualContext          String[]                     @default([]) @map("spiritual_context")
   embedding                 Unsupported("vector(1536)")?
+  embedding_qwen            Unsupported("vector(1536)")?
   model                     String                       @default("text-embedding-3-small")
   dimensions                Int                          @default(1536)
   embeddingProvider         String?                      @map("embedding_provider")
@@ -1659,6 +1660,7 @@ model VideoTranscriptChunk {
   startSeconds Float?                       @map("start_seconds")
   endSeconds   Float?                       @map("end_seconds")
   embedding    Unsupported("vector(1536)")?
+  embedding_qwen Unsupported("vector(1536)")?
   model        String                       @default("text-embedding-3-small")
   dimensions   Int                          @default(1536)
   createdAt    DateTime                     @default(now()) @map("created_at")

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -260,6 +260,17 @@ export const env = createEnv({
     AI_GATEWAY_EMBEDDINGS_BASE_URL: z.string().url().optional(),
     AI_GATEWAY_EMBEDDINGS_API_KEY: z.string().min(1).optional(),
     AI_GATEWAY_EMBEDDINGS_MODEL: z.string().min(1).optional(),
+    // Embedding source for the admin AI experience generator's video search
+    // (the Mastra `searchVideos` tool). "openai" (default) keeps that search
+    // on the OpenAI `embedding` column; "gateway" routes it to Qwen + the
+    // `embedding_qwen` column. Default "openai" so this PR is behavior-neutral
+    // until the `embedding_qwen` backfill exists — the operator flips it to
+    // "gateway" only after the backfill completes (one-line reversible switch).
+    // Enum-of-strings (not boolean) so a stray value can't silently flip it.
+    AI_VIDEO_SEARCH_EMBEDDING_SOURCE: z
+      .enum(["openai", "gateway"])
+      .optional()
+      .default("openai"),
     MASTRA_STORAGE_URL: z.string().url().optional(),
     MASTRA_DEFAULT_PROVIDER: z
       .enum([
@@ -441,6 +452,9 @@ export const env = createEnv({
     ),
     AI_GATEWAY_EMBEDDINGS_MODEL: emptyToUndefined(
       process.env.AI_GATEWAY_EMBEDDINGS_MODEL,
+    ),
+    AI_VIDEO_SEARCH_EMBEDDING_SOURCE: emptyToUndefined(
+      process.env.AI_VIDEO_SEARCH_EMBEDDING_SOURCE,
     ),
     MASTRA_STORAGE_URL: emptyToUndefined(process.env.MASTRA_STORAGE_URL),
     MASTRA_DEFAULT_PROVIDER: emptyToUndefined(

--- a/apps/admin/src/mastra/tools/search-videos.test.ts
+++ b/apps/admin/src/mastra/tools/search-videos.test.ts
@@ -11,6 +11,15 @@ function assertOk<T>(value: T): Exclude<T, { error: unknown }> {
 
 const searchMock = vi.hoisted(() => vi.fn())
 
+// AI_VIDEO_SEARCH_EMBEDDING_SOURCE controls which embedding source the tool
+// passes; defaults to "openai" (behavior-neutral until the embedding_qwen
+// backfill exists). Tests flip it to exercise both paths.
+const mockEnv = vi.hoisted(() => ({
+  env: { AI_VIDEO_SEARCH_EMBEDDING_SOURCE: "openai" as "openai" | "gateway" },
+}))
+
+vi.mock("@/config/env", () => mockEnv)
+
 vi.mock("@/services/hybrid-search.service", () => ({
   HybridSearchService: class {
     search = searchMock
@@ -24,6 +33,7 @@ vi.mock("@/db/client", () => ({
 describe("searchVideosTool", () => {
   beforeEach(() => {
     searchMock.mockReset()
+    mockEnv.env.AI_VIDEO_SEARCH_EMBEDDING_SOURCE = "openai"
     vi.resetModules()
   })
 
@@ -82,8 +92,8 @@ describe("searchVideosTool", () => {
       locale: "en",
       limit: 5,
       contentTypes: ["video"],
-      // AI experience-gen opts into the Qwen vector space (U3).
-      embeddingSource: "gateway",
+      // Default flag → OpenAI source (behavior-neutral until backfill).
+      embeddingSource: "openai",
     })
     expect(result.videos).toEqual([
       {
@@ -101,6 +111,24 @@ describe("searchVideosTool", () => {
         imageUrl: null,
       },
     ])
+  })
+
+  it("passes embeddingSource=gateway when AI_VIDEO_SEARCH_EMBEDDING_SOURCE is set", async () => {
+    mockEnv.env.AI_VIDEO_SEARCH_EMBEDDING_SOURCE = "gateway"
+    searchMock.mockResolvedValue({
+      results: [],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "hybrid",
+    })
+    const { searchVideosTool } = await import("./search-videos")
+    await searchVideosTool.execute!(
+      { q: "jesus", locale: "en", limit: 5 },
+      undefined as never,
+    )
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ embeddingSource: "gateway" }),
+    )
   })
 
   it("returns an empty array when the service returns no video results", async () => {

--- a/apps/admin/src/mastra/tools/search-videos.test.ts
+++ b/apps/admin/src/mastra/tools/search-videos.test.ts
@@ -82,6 +82,8 @@ describe("searchVideosTool", () => {
       locale: "en",
       limit: 5,
       contentTypes: ["video"],
+      // AI experience-gen opts into the Qwen vector space (U3).
+      embeddingSource: "gateway",
     })
     expect(result.videos).toEqual([
       {

--- a/apps/admin/src/mastra/tools/search-videos.ts
+++ b/apps/admin/src/mastra/tools/search-videos.ts
@@ -21,6 +21,7 @@
 import { createTool } from "@mastra/core/tools"
 import { z } from "zod"
 
+import { env } from "@/config/env"
 import { prisma } from "@/db/client"
 import { HybridSearchService } from "@/services/hybrid-search.service"
 
@@ -68,13 +69,15 @@ export const searchVideosTool = createTool({
       locale: inputData.locale,
       limit: inputData.limit,
       contentTypes: ["video"],
-      // AI experience-gen searches the Qwen vector space: the query is
-      // embedded via the gateway (Qwen 1536) and matched against the
-      // `embedding_qwen` column — no paid-API dependency. U3 of the
-      // content-embeddings-gateway-migration pilot. Public search omits
-      // this arg and stays on OpenAI + `embedding`. See
+      // AI experience-gen video search source, operator-controlled via
+      // AI_VIDEO_SEARCH_EMBEDDING_SOURCE (default "openai"). Flip to
+      // "gateway" — Qwen 1536 query + `embedding_qwen` column, no paid-API
+      // dependency — only AFTER the embedding_qwen backfill exists, else the
+      // search hits an empty column. One-line reversible switch. Public
+      // search omits this arg entirely and stays on OpenAI + `embedding`.
+      // U3 of the content-embeddings-gateway-migration pilot; see
       // docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md.
-      embeddingSource: "gateway",
+      embeddingSource: env.AI_VIDEO_SEARCH_EMBEDDING_SOURCE,
     })
 
     const videos = response.results

--- a/apps/admin/src/mastra/tools/search-videos.ts
+++ b/apps/admin/src/mastra/tools/search-videos.ts
@@ -68,6 +68,13 @@ export const searchVideosTool = createTool({
       locale: inputData.locale,
       limit: inputData.limit,
       contentTypes: ["video"],
+      // AI experience-gen searches the Qwen vector space: the query is
+      // embedded via the gateway (Qwen 1536) and matched against the
+      // `embedding_qwen` column — no paid-API dependency. U3 of the
+      // content-embeddings-gateway-migration pilot. Public search omits
+      // this arg and stays on OpenAI + `embedding`. See
+      // docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md.
+      embeddingSource: "gateway",
     })
 
     const videos = response.results

--- a/apps/admin/src/services/embeddings.service.test.ts
+++ b/apps/admin/src/services/embeddings.service.test.ts
@@ -90,6 +90,124 @@ describe("generateExperienceEmbedding", () => {
   })
 })
 
+describe("generateExperienceEmbedding (gateway source)", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+    // OpenRouter still set so we can prove the default path is NOT the
+    // gateway even when both are configured.
+    process.env.OPENROUTER_API_KEY = "test-openrouter-key"
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+    process.env.AI_GATEWAY_EMBEDDINGS_API_KEY = "test-gateway-key"
+    process.env.AI_GATEWAY_EMBEDDINGS_BASE_URL =
+      "https://ai-gateway.jesusfilm.org/v1"
+    process.env.AI_GATEWAY_EMBEDDINGS_MODEL = "embeddings"
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.OPENROUTER_API_KEY
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.AI_GATEWAY_EMBEDDINGS_API_KEY
+    delete process.env.AI_GATEWAY_EMBEDDINGS_BASE_URL
+    delete process.env.AI_GATEWAY_EMBEDDINGS_MODEL
+  })
+
+  it("source='gateway' calls the gateway URL with the User-Agent header and gateway bearer", async () => {
+    const vector = Array.from({ length: 1536 }, () => 0.42)
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: vector }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { generateExperienceEmbedding, GATEWAY_EMBEDDING_MODEL } =
+      await import("./embeddings.service")
+
+    const result = await generateExperienceEmbedding("hope and peace", {
+      source: "gateway",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe("https://ai-gateway.jesusfilm.org/v1/embeddings")
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers.authorization).toBe("Bearer test-gateway-key")
+    expect(headers["User-Agent"]).toBe(
+      "forge-admin-mastra/1.0 (+https://admin.jesusfilm.org)",
+    )
+    expect(result.embedding).toEqual(vector)
+    expect(result.dimensions).toBe(1536)
+    expect(result.model).toBe(GATEWAY_EMBEDDING_MODEL)
+  })
+
+  it("default source (no opts) uses OpenRouter — NOT the gateway URL", async () => {
+    const vector = Array.from({ length: 1536 }, () => 0.1)
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: vector }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { generateExperienceEmbedding } = await import("./embeddings.service")
+
+    await generateExperienceEmbedding("hope and peace")
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe("https://openrouter.ai/api/v1/embeddings")
+    expect(url).not.toBe("https://ai-gateway.jesusfilm.org/v1/embeddings")
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers.authorization).toBe("Bearer test-openrouter-key")
+    // No gateway UA leaks onto the default path.
+    expect(headers["User-Agent"]).toBeUndefined()
+  })
+
+  it("source='gateway' with no AI_GATEWAY_EMBEDDINGS_API_KEY throws EmbeddingsBatchError(missing_credentials)", async () => {
+    delete process.env.AI_GATEWAY_EMBEDDINGS_API_KEY
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { generateExperienceEmbedding, EmbeddingsBatchError } =
+      await import("./embeddings.service")
+
+    const thrown = await generateExperienceEmbedding("hi", {
+      source: "gateway",
+    }).catch((e) => e)
+    expect(thrown).toBeInstanceOf(EmbeddingsBatchError)
+    expect((thrown as { code: string }).code).toBe("missing_credentials")
+    // Fail-fast before any network call.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("source='gateway' returning a non-1536 vector throws EmbeddingsBatchError(dimension_mismatch)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ embedding: Array.from({ length: 4096 }, () => 0.2) }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { generateExperienceEmbedding, EmbeddingsBatchError } =
+      await import("./embeddings.service")
+
+    const thrown = await generateExperienceEmbedding("hi", {
+      source: "gateway",
+    }).catch((e) => e)
+    expect(thrown).toBeInstanceOf(EmbeddingsBatchError)
+    expect((thrown as { code: string }).code).toBe("dimension_mismatch")
+  })
+})
+
 describe("generateExperienceEmbeddings (batched)", () => {
   beforeEach(() => {
     vi.resetModules()

--- a/apps/admin/src/services/embeddings.service.ts
+++ b/apps/admin/src/services/embeddings.service.ts
@@ -6,10 +6,26 @@ import type { Principal } from "@/auth/principal"
 import { env } from "@/config/env"
 import { BlockSchema } from "@/domain/blocks"
 import { toPgVector } from "@/db/pgvector"
+import {
+  AI_GATEWAY_USER_AGENT,
+  DEFAULT_AI_GATEWAY_CHAT_BASE_URL,
+} from "@/mastra/gateway-constants"
 
 export const EXPERIENCE_EMBEDDING_DIMENSIONS = 1536
 export const OPENROUTER_EMBEDDING_MODEL = "openai/text-embedding-3-small"
 export const OPENAI_EMBEDDING_MODEL = "text-embedding-3-small"
+export const GATEWAY_EMBEDDING_MODEL = "embeddings"
+
+/**
+ * Per-call embedding source. `"openai"` (the default) keeps the existing
+ * OpenRouter → OpenAI precedence byte-identical to today. `"gateway"`
+ * routes through the self-hosted JesusFilm AI gateway (Qwen → 1536-dim)
+ * so the admin AI experience generator can search Qwen-embedded video
+ * vectors without a paid-API dependency. Selected per call — public
+ * search / recommendations never pass it, so they are structurally
+ * incapable of being affected.
+ */
+export type EmbeddingSource = "openai" | "gateway"
 
 /**
  * Hard timeout for provider requests. Node's default fetch has no
@@ -203,9 +219,32 @@ type EmbeddingProvider = {
   apiKey: string
   model: string
   url: string
+  /**
+   * Extra request headers merged into the fetch call alongside the
+   * standard authorization + content-type. The gateway provider sets a
+   * descriptive User-Agent here because Cloudflare fronts the gateway and
+   * 403s on missing/odd UAs.
+   */
+  headers?: Record<string, string>
 }
 
-function selectProvider(): EmbeddingProvider {
+function selectProvider(source: EmbeddingSource = "openai"): EmbeddingProvider {
+  if (source === "gateway") {
+    if (!env.AI_GATEWAY_EMBEDDINGS_API_KEY) {
+      throw new EmbeddingsBatchError(
+        "missing_credentials",
+        "AI_GATEWAY_EMBEDDINGS_API_KEY is required for gateway embedding generation",
+      )
+    }
+    return {
+      apiKey: env.AI_GATEWAY_EMBEDDINGS_API_KEY,
+      model: env.AI_GATEWAY_EMBEDDINGS_MODEL ?? GATEWAY_EMBEDDING_MODEL,
+      url: embeddingEndpointFromBase(
+        env.AI_GATEWAY_EMBEDDINGS_BASE_URL ?? DEFAULT_AI_GATEWAY_CHAT_BASE_URL,
+      ),
+      headers: { "User-Agent": AI_GATEWAY_USER_AGENT },
+    }
+  }
   if (env.OPENROUTER_API_KEY) {
     return {
       apiKey: env.OPENROUTER_API_KEY,
@@ -244,6 +283,7 @@ function selectProvider(): EmbeddingProvider {
  */
 export async function generateExperienceEmbeddings(
   inputs: readonly string[],
+  opts?: { source?: EmbeddingSource },
 ): Promise<GeneratedEmbeddings> {
   if (inputs.length === 0) {
     throw new EmbeddingsBatchError(
@@ -264,7 +304,7 @@ export async function generateExperienceEmbeddings(
     normalized.push(line)
   }
 
-  const provider = selectProvider()
+  const provider = selectProvider(opts?.source)
 
   const controller = new AbortController()
   const timeoutHandle = setTimeout(
@@ -278,6 +318,7 @@ export async function generateExperienceEmbeddings(
       headers: {
         authorization: `Bearer ${provider.apiKey}`,
         "content-type": "application/json",
+        ...provider.headers,
       },
       body: JSON.stringify({
         model: provider.model,
@@ -355,12 +396,15 @@ export async function generateExperienceEmbeddings(
  */
 export async function generateExperienceEmbedding(
   text: string,
+  opts?: { source?: EmbeddingSource },
 ): Promise<GeneratedEmbedding> {
   const normalizedText = normalizeLine(text)
   if (!normalizedText) {
     throw new Error("Embedding input must not be empty")
   }
-  const result = await generateExperienceEmbeddings([normalizedText])
+  const result = await generateExperienceEmbeddings([normalizedText], {
+    source: opts?.source,
+  })
   return {
     model: result.model,
     dimensions: result.dimensions,

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest"
 import {
   calculateVideoSemanticMixedScore,
   mixVideoSemanticEvidenceRows,
+  resolveSemanticEmbeddingColumn,
   searchVideoSemantic,
   searchVideoKeyword,
   searchExperienceSemantic,
@@ -33,6 +34,32 @@ function latestRawSql(prisma: ReturnType<typeof mockPrisma>): string {
 function latestRawValues(prisma: ReturnType<typeof mockPrisma>): unknown[] {
   const call = prisma.$queryRaw.mock.calls.at(-1)
   return call?.slice(1) ?? []
+}
+
+/**
+ * Renders the full SQL of the latest `$queryRaw` call INCLUDING any
+ * interpolated `Prisma.raw(...)` fragments. `latestRawSql` above joins
+ * only the static template strings (`call[0]`); a `Prisma.raw` value is
+ * passed as an interpolated argument (in `call.slice(1)`), carrying its
+ * literal text on `.sql`. The U3 column injection (`vsl.embedding_qwen`
+ * etc.) flows through that path, so column-selection assertions must
+ * fold the raw fragments back in.
+ */
+function latestRawSqlWithFragments(
+  prisma: ReturnType<typeof mockPrisma>,
+): string {
+  const strings = latestRawSql(prisma)
+  const fragments = latestRawValues(prisma)
+    .map((value) =>
+      value != null &&
+      typeof value === "object" &&
+      "sql" in (value as Record<string, unknown>) &&
+      typeof (value as { sql: unknown }).sql === "string"
+        ? (value as { sql: string }).sql
+        : "",
+    )
+    .join(" ")
+  return `${strings} ${fragments}`
 }
 
 describe("searchVideoSemantic", () => {
@@ -237,9 +264,14 @@ describe("searchVideoSemantic", () => {
     const sql = latestRawSql(prisma)
     expect((sql.match(/v\.deleted_at IS NULL/g) ?? []).length).toBe(2)
     expect((sql.match(/vl\.status = 'published'/g) ?? []).length).toBe(2)
-    expect(sql).toContain("vsl.embedding IS NOT NULL")
+    // The `<col> IS NOT NULL` gate's column is now a Prisma.raw fragment
+    // (U3), so fold the fragments back in. The default column is
+    // `embedding` and the `IS NOT NULL` gate is present for both sources.
+    const sqlWithFragments = latestRawSqlWithFragments(prisma)
+    expect((sqlWithFragments.match(/IS NOT NULL/g) ?? []).length).toBe(2)
+    expect(sqlWithFragments).toContain("vsl.embedding")
+    expect(sqlWithFragments).toContain("vtc.embedding")
     expect(sql).toContain("vsl.locale =")
-    expect(sql).toContain("vtc.embedding IS NOT NULL")
     expect(sql).toContain("vtc.language =")
     expect(sql).toContain("vt.language =")
   })
@@ -273,6 +305,93 @@ describe("searchVideoSemantic", () => {
 
     const values = latestRawValues(prisma)
     expect(values).toContain(14)
+  })
+})
+
+describe("resolveSemanticEmbeddingColumn (U3 allowlist)", () => {
+  it("maps 'gateway' to embedding_qwen", () => {
+    expect(resolveSemanticEmbeddingColumn("gateway")).toBe("embedding_qwen")
+  })
+
+  it("maps 'openai' to embedding", () => {
+    expect(resolveSemanticEmbeddingColumn("openai")).toBe("embedding")
+  })
+
+  it("maps undefined to embedding (fail-safe default)", () => {
+    expect(resolveSemanticEmbeddingColumn(undefined)).toBe("embedding")
+  })
+
+  it("maps any unknown value to embedding (closed allowlist)", () => {
+    expect(
+      resolveSemanticEmbeddingColumn("../../etc; DROP TABLE" as never),
+    ).toBe("embedding")
+  })
+})
+
+describe("searchVideoSemantic embeddingSource column selection (U3)", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("reads vsl.embedding / vtc.embedding by default (no source)", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 5,
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    expect(sql).toContain("vsl.embedding")
+    expect(sql).toContain("vtc.embedding")
+    expect(sql).not.toContain("embedding_qwen")
+  })
+
+  it("reads vsl.embedding / vtc.embedding when source='openai'", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 5,
+      embeddingSource: "openai",
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    expect(sql).toContain("vsl.embedding")
+    expect(sql).toContain("vtc.embedding")
+    expect(sql).not.toContain("embedding_qwen")
+  })
+
+  it("reads vsl.embedding_qwen / vtc.embedding_qwen when source='gateway'", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 5,
+      embeddingSource: "gateway",
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    expect(sql).toContain("vsl.embedding_qwen")
+    expect(sql).toContain("vtc.embedding_qwen")
+  })
+
+  it("falls back to the embedding column for an unknown source (allowlist guard)", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 5,
+      embeddingSource: "../../injection" as never,
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    expect(sql).toContain("vsl.embedding")
+    expect(sql).toContain("vtc.embedding")
+    expect(sql).not.toContain("embedding_qwen")
+    expect(sql).not.toContain("injection")
   })
 })
 

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -30,6 +30,29 @@ import {
   EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR,
 } from "./hybrid-search-sql"
 import type { RankedItem } from "./hybrid-search-fusion"
+import type { EmbeddingSource } from "./embeddings.service"
+
+/**
+ * Closed allowlist mapping an embedding source to the physical pgvector
+ * COLUMN the semantic-video retriever reads. This is the SQL-injection
+ * guard for the `Prisma.raw(column)` interpolation below: the column
+ * name NEVER comes from caller input directly — it is always one of
+ * these two compile-time string literals, selected by the source.
+ *
+ * - `"gateway"` → `"embedding_qwen"` (Qwen 1536-dim vectors, U2 column;
+ *   read by the admin AI experience-gen path only).
+ * - anything else (including `"openai"`) → `"embedding"` (the existing
+ *   OpenAI column; the public default, byte-identical to today).
+ *
+ * The matching per-locale partial HNSW index on the chosen column is
+ * selected by the planner automatically — the WHERE locale predicate
+ * in the query is unchanged.
+ */
+export function resolveSemanticEmbeddingColumn(
+  source: EmbeddingSource | undefined,
+): "embedding" | "embedding_qwen" {
+  return source === "gateway" ? "embedding_qwen" : "embedding"
+}
 
 // -----------------------------------------------------------------------------
 // Shared parameter shapes
@@ -42,6 +65,15 @@ export type SemanticSearchParams = {
   queryEmbedding: string
   locale: string
   limit: number
+  /**
+   * Per-call embedding source. Selects which stored vector COLUMN the
+   * video semantic retriever reads via the `resolveSemanticEmbeddingColumn`
+   * closed allowlist (`"gateway"` → `embedding_qwen`, else `embedding`).
+   * Absent / unknown → `embedding` (the public default). Consumed only by
+   * `searchVideoSemantic`; the experience retriever ignores it (experience
+   * vectors are out of the U3 pilot and always read `embedding`).
+   */
+  embeddingSource?: EmbeddingSource
 }
 
 export const VIDEO_SEMANTIC_MAX_AGREEMENT_BONUS = 0.01
@@ -308,6 +340,14 @@ export async function searchVideoSemantic(
   const { queryEmbedding, locale, limit } = params
   const candidateLimit = Math.max(limit * 2, limit)
 
+  // Resolve the read column from the CLOSED two-literal allowlist BEFORE
+  // touching Prisma.raw — the source value never reaches raw SQL
+  // unvalidated (SQL-injection guard). `vsl.<col>` is the scene column,
+  // `vtc.<col>` the transcript column; both move together per call.
+  const column = resolveSemanticEmbeddingColumn(params.embeddingSource)
+  const sceneEmbeddingCol = Prisma.raw(`vsl.${column}`)
+  const transcriptEmbeddingCol = Prisma.raw(`vtc.${column}`)
+
   const evidenceRows = await prisma.$queryRaw<VideoSemanticEvidenceRow[]>`
     WITH scene_source AS (
       SELECT * FROM (
@@ -322,8 +362,8 @@ export async function searchVideoSemantic(
           vsl.description                   AS scene_description,
           vs.start_seconds                  AS start_seconds,
           dub_mux.playback_id               AS playback_id,
-          1 - (vsl.embedding <=> ${queryEmbedding}::vector) AS source_score,
-          vsl.embedding::text               AS embedding_text
+          1 - (${sceneEmbeddingCol} <=> ${queryEmbedding}::vector) AS source_score,
+          ${sceneEmbeddingCol}::text        AS embedding_text
         FROM video_scene_locale vsl
         JOIN video_scene vs ON vs.id = vsl.video_scene_id
         JOIN video v ON v.id = vs.video_id
@@ -353,11 +393,11 @@ export async function searchVideoSemantic(
           ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
           LIMIT 1
         ) vi ON true
-        WHERE vsl.embedding IS NOT NULL
+        WHERE ${sceneEmbeddingCol} IS NOT NULL
           AND vsl.locale = ${locale}
         ORDER BY
           vs.video_id,
-          vsl.embedding <=> ${queryEmbedding}::vector,
+          ${sceneEmbeddingCol} <=> ${queryEmbedding}::vector,
           vs.start_seconds ASC,
           vsl.id ASC
       ) best_scene_per_video
@@ -377,8 +417,8 @@ export async function searchVideoSemantic(
           vtc.text                          AS scene_description,
           vtc.start_seconds                 AS start_seconds,
           dub_mux.playback_id               AS playback_id,
-          1 - (vtc.embedding <=> ${queryEmbedding}::vector) AS source_score,
-          vtc.embedding::text               AS embedding_text
+          1 - (${transcriptEmbeddingCol} <=> ${queryEmbedding}::vector) AS source_score,
+          ${transcriptEmbeddingCol}::text   AS embedding_text
         FROM video_transcript_chunk vtc
         JOIN video_transcript vt ON vt.id = vtc.transcript_id
         JOIN video v ON v.id = vt.video_id
@@ -408,12 +448,12 @@ export async function searchVideoSemantic(
           ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
           LIMIT 1
         ) vi ON true
-        WHERE vtc.embedding IS NOT NULL
+        WHERE ${transcriptEmbeddingCol} IS NOT NULL
           AND vtc.language = ${locale}
           AND vt.language = ${locale}
         ORDER BY
           vt.video_id,
-          vtc.embedding <=> ${queryEmbedding}::vector,
+          ${transcriptEmbeddingCol} <=> ${queryEmbedding}::vector,
           vtc.start_seconds ASC NULLS LAST,
           vtc.id ASC
       ) best_transcript_per_video

--- a/apps/admin/src/services/hybrid-search.regression.test.ts
+++ b/apps/admin/src/services/hybrid-search.regression.test.ts
@@ -199,6 +199,29 @@ describe("HybridSearchService default-mode regression snapshot", () => {
     }
   })
 
+  it("default path resolves embeddingSource to 'openai' (public byte-identity / U3)", async () => {
+    for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
+      vi.clearAllMocks()
+      setupRetrieverFixtures()
+      mockPrisma.video.findMany.mockResolvedValue([])
+      const embedder = successEmbedder()
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder,
+        logger: { warn: vi.fn(), error: vi.fn() },
+      })
+      // No embeddingSource passed — the public contract. Both the query
+      // embedder and the semantic-video retriever must see "openai" so
+      // the read column stays `embedding` (never the Qwen column).
+      await service.search({ query: "jesus", locale: "en", mode })
+      expect(embedder).toHaveBeenCalledWith("jesus", "openai")
+      expect(searchVideoSemantic).toHaveBeenCalledWith(
+        mockPrisma,
+        expect.objectContaining({ embeddingSource: "openai" }),
+      )
+    }
+  })
+
   it("NEVER calls keyword-first retrievers on the default path", async () => {
     for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
       vi.clearAllMocks()

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -105,11 +105,14 @@ describe("HybridSearchService", () => {
       locale: "en",
     })
 
-    // All 4 retrievers were invoked with overfetch = DEFAULT_LIMIT * 3 = 60
+    // All 4 retrievers were invoked with overfetch = DEFAULT_LIMIT * 3 = 60.
+    // The default path resolves embeddingSource to "openai" (→ `embedding`
+    // column in the retriever).
     expect(searchVideoSemantic).toHaveBeenCalledWith(mockPrisma, {
       queryEmbedding: "[0.1,0.2,0.3]",
       locale: "en",
       limit: 60,
+      embeddingSource: "openai",
     })
     expect(searchVideoKeyword).toHaveBeenCalledWith(mockPrisma, {
       query: "forgiveness",
@@ -282,6 +285,47 @@ describe("HybridSearchService", () => {
     expect(traced.trace.traceClass).toBe("retrieval_failure")
     expect(traced.trace.failedRetrievers).toEqual(["keyword-video"])
     expect(traced.trace.contributingRetrievers).toEqual(["semantic-video"])
+  })
+
+  describe("embeddingSource threading (U3)", () => {
+    it("defaults to 'openai' for the embedder and semantic retriever when unset", async () => {
+      const embedder = successEmbedder()
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder,
+        logger,
+      })
+
+      await service.search({ query: "test", locale: "en" })
+
+      // Embedder receives the resolved source as its 2nd arg.
+      expect(embedder).toHaveBeenCalledWith("test", "openai")
+      expect(searchVideoSemantic).toHaveBeenCalledWith(
+        mockPrisma,
+        expect.objectContaining({ embeddingSource: "openai" }),
+      )
+    })
+
+    it("threads 'gateway' to both the embedder and the semantic retriever", async () => {
+      const embedder = successEmbedder()
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder,
+        logger,
+      })
+
+      await service.search({
+        query: "test",
+        locale: "en",
+        embeddingSource: "gateway",
+      })
+
+      expect(embedder).toHaveBeenCalledWith("test", "gateway")
+      expect(searchVideoSemantic).toHaveBeenCalledWith(
+        mockPrisma,
+        expect.objectContaining({ embeddingSource: "gateway" }),
+      )
+    })
   })
 
   it("restricts to video corpus when contentTypes=['video']", async () => {

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -18,7 +18,10 @@
  */
 
 import type { PrismaClient, VideoLabel } from "@prisma/client"
-import { generateExperienceEmbedding } from "./embeddings.service"
+import {
+  generateExperienceEmbedding,
+  type EmbeddingSource,
+} from "./embeddings.service"
 import {
   fuseRankedLists,
   deduplicateResults,
@@ -67,6 +70,19 @@ export function isDilutionCapEnabled(): boolean {
   return process.env.SEARCH_DILUTION_CAP_ENABLED !== "false"
 }
 
+/**
+ * Normalize the per-call embedding source to a known value. Absent or
+ * any non-`"gateway"` value resolves to `"openai"` — the fail-safe
+ * public path. This keeps the resolution in ONE place so the query
+ * model and the read column can never diverge: only an explicit
+ * `"gateway"` opts into the Qwen vector space.
+ */
+export function resolveEmbeddingSource(
+  source: EmbeddingSource | undefined,
+): EmbeddingSource {
+  return source === "gateway" ? "gateway" : "openai"
+}
+
 export type ContentType = "video" | "experience"
 
 export const ALL_CONTENT_TYPES: readonly ContentType[] = ["video", "experience"]
@@ -110,6 +126,25 @@ export type SearchParams = {
    * via `isDebugAllowedForOrigin`; the service trusts the boolean.
    */
   debug?: boolean
+  /**
+   * Per-call embedding source. Selects BOTH the query-embedding model
+   * AND the stored vector column the semantic-video retriever reads, so
+   * the two can never cross-compare across embedding spaces:
+   *
+   * - `"openai"` (default, also for unset / unknown) — OpenRouter →
+   *   OpenAI query embed against the `embedding` column. This is the
+   *   public path: REST `/api/search`, GraphQL `Query.search`, and
+   *   scene-recommendations never pass this arg, so they are
+   *   structurally incapable of being affected (locked by
+   *   hybrid-search.regression.test.ts).
+   * - `"gateway"` — JesusFilm AI gateway (Qwen → 1536-dim) query embed
+   *   against the parallel `embedding_qwen` column. Only the Mastra
+   *   `searchVideos` tool (admin AI experience generation) opts in.
+   *
+   * U3 of the content-embeddings-gateway-migration pilot; see
+   * docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md.
+   */
+  embeddingSource?: EmbeddingSource
 }
 
 /**
@@ -262,12 +297,18 @@ function toPgvectorText(embedding: number[]): string {
 
 /**
  * Injectable embedder signature so tests can stub the provider call
- * without mocking the module import.
+ * without mocking the module import. The optional `source` selects the
+ * embedding model per call (default `"openai"` — see SearchParams
+ * `embeddingSource`); the default embedder forwards it to
+ * `generateExperienceEmbedding`.
  */
-export type QueryEmbedder = (text: string) => Promise<number[]>
+export type QueryEmbedder = (
+  text: string,
+  source?: EmbeddingSource,
+) => Promise<number[]>
 
-const defaultEmbedder: QueryEmbedder = async (text) => {
-  const result = await generateExperienceEmbedding(text)
+const defaultEmbedder: QueryEmbedder = async (text, source = "openai") => {
+  const result = await generateExperienceEmbedding(text, { source })
   return result.embedding
 }
 
@@ -517,6 +558,11 @@ export class HybridSearchService {
     // surface to clients. Computed once per call so the warn log fires
     // at most once.
     const pipelineMode = normalizeMode(params.mode, this.logger)
+    // Resolve the per-call embedding source. Absent / unknown values
+    // fail-safe to "openai" — the known-good public path — so the
+    // query model and the stored column the semantic-video retriever
+    // reads always move together (never cross an embedding space).
+    const embeddingSource = resolveEmbeddingSource(params.embeddingSource)
     const limit = Math.min(
       Math.max(1, params.limit ?? DEFAULT_LIMIT),
       MAX_LIMIT,
@@ -542,7 +588,7 @@ export class HybridSearchService {
     let embeddingFailed = false
     recordAttempt()
     try {
-      const vector = await this.embedder(query)
+      const vector = await this.embedder(query, embeddingSource)
       queryEmbeddingText = toPgvectorText(vector)
     } catch (error) {
       embeddingFailed = true
@@ -576,6 +622,7 @@ export class HybridSearchService {
                 queryEmbedding: queryEmbeddingText,
                 locale,
                 limit: overfetchLimit,
+                embeddingSource,
               }) as Promise<RankedItem[]>)
             : Promise.resolve([]),
       })

--- a/docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md
+++ b/docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md
@@ -1,0 +1,294 @@
+---
+title: "feat: Qwen-1536 video search for admin AI experience generation (parallel columns, per-call source)"
+type: feat
+status: active
+date: 2026-06-05
+---
+
+# feat: Qwen-1536 video search for admin AI experience generation (parallel columns, per-call source)
+
+## Summary
+
+Give the admin **AI experience generator** its own video search powered by the self-hosted JesusFilm gateway (`Qwen3-Embedding-8B` → 1536-dim), so it stops depending on the (currently out-of-budget) paid OpenRouter embeddings. Do it as a **scoped pilot, not the full migration**: add parallel `embedding_qwen` columns on the two video tables, backfill them with Qwen, and route **only the Mastra `searchVideos` path** through Qwen (query) + the new column (stored) via a per-call `embeddingSource` parameter. Public `/api/search` and scene-recommendations are **not touched** — they keep using OpenAI on the existing `embedding` column, so there is zero risk to the live consumer surface.
+
+---
+
+## Problem Frame
+
+When the AI generates an Experience page it calls the Mastra `searchVideos` tool to find relevant videos. That tool wraps admin's `HybridSearchService`, which embeds the query through `embeddings.service.ts` (OpenAI `text-embedding-3-small` via OpenRouter). The prod OpenRouter key is **out of budget** (`403 "Key limit exceeded"`) and there's no `OPENAI_API_KEY` fallback, so the AI's video search fails and the chat returns empty/rejected drafts. The org runs Qwen3-Embedding on its own GPU for free — routing just this feature there fixes it without paid-API exposure.
+
+Compatibility rule that shapes the design: two embedding models are never interchangeable, even at the same 1536 width. So the AI's Qwen query must search **Qwen-embedded** video vectors — hence parallel columns, not reuse of the OpenAI column. And pgvector 0.8.2 caps HNSW at 2000 dims (verified on prod), so 1536 is the fixed, indexable width.
+
+---
+
+## Requirements
+
+- R1. The Mastra `searchVideos` tool (used by admin AI experience generation) embeds its query via the gateway (Qwen 1536) and searches **Qwen-embedded** video vectors — no paid-API dependency on this path.
+- R2. Public `/api/search`, `Query.search`, and `sceneRecommendations` are **unchanged** — same query model, same `embedding` column, byte-identical behavior.
+- R3. The two video corpora the AI searches are backfilled into the new column with Qwen: `video_scene_locale` (~173,267) and `video_transcript_chunk` (~4,348).
+- R4. The AI path's query model and the column it reads are always consistent (Qwen↔`embedding_qwen`); they can never cross-compare with OpenAI vectors.
+- R5. The change is reversible: the Mastra tool can drop back to the default OpenAI source with a one-line revert; the existing `embedding` column and all public behavior remain intact throughout.
+
+---
+
+## Scope Boundaries
+
+- **Not** changing public search / recommendations — they stay OpenAI + `embedding`. This is the entire safety story.
+- **Not** migrating `experience_locale` embeddings (the public experience-search vectors) — out of this pilot; only the AI's _video_ search is in scope.
+- **Not** a global flip — the source is a per-call parameter, defaulting to `openai`. Only the Mastra tool opts into `gateway`.
+- **Not** introducing >1536 widths (HNSW ceiling) or `halfvec`.
+- **Not** the chat-provider path (fixed in PR #1145) or Mastra semantic-recall memory.
+
+### Deferred to Follow-Up Work
+
+- **Full public-search migration to Qwen** (query + all consumers + `experience_locale`, global flip, eval gate, legacy-column drop): the larger project this pilot de-risks. Revisit once the pilot proves Qwen-1536 video relevance in production.
+- **Immediate OpenRouter stop-gap** (top up the key, or set `OPENAI_API_KEY` on prod): keeps public search + any non-piloted embedding alive until/independent of this work. Do separately/now.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/admin/src/mastra/tools/search-videos.ts` — the AI's video search; constructs `new HybridSearchService({ prisma })` and calls `.search(...)` (line ~65). This is the **only** consumer that should pass `embeddingSource: "gateway"`.
+- `apps/admin/src/services/hybrid-search.service.ts` — `search(params)`; embeds the query via `generateExperienceEmbedding(text)` (line ~270). Add an `embeddingSource` to params, thread it to both the query embed and the retrievers.
+- `apps/admin/src/services/hybrid-search-retrievers.ts` — `searchVideoSemantic` reads `vsl.embedding` / `vtc.embedding` via `<=> ${queryEmbedding}::vector` (lines ~325, 356, 380). Parameterize the column on the source.
+- `apps/admin/src/services/embeddings.service.ts` — `selectProvider()` (~208) + `generateExperienceEmbedding()` (~356). Add a gateway branch selectable per call; default unchanged.
+- `apps/mastra/src/mastra/workflows/{scene,transcript}-embedding.ts` — produce the stored scene/transcript vectors. Their embedding provider must be able to emit Qwen 1536 for the backfill into the new column.
+- `apps/admin/src/scripts/run-embeds.ts` + scene/transcript backfill services — the backfill harness; extend to target the new column when source=gateway.
+- Existing per-locale HNSW index migrations for `video_scene_locale` / `video_transcript_chunk` — template for the `embedding_qwen` indexes.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/provider-bound-content-embedding-backfill-gate-pattern.md` — provider-bound backfill discipline (the AI path is internal, so a full eval gate is optional here, but the provenance/contract hygiene still applies).
+- `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md` — build the new HNSW indexes with/after the backfill, not over a cold column on the hot table.
+- Root `CLAUDE.md` — embeddings must not mix across vector spaces; 1536 width is fixed.
+
+### External References
+
+- pgvector HNSW limit verified on prod (0.8.2): `vector` ≤ 2000 dims.
+- Gateway already emits 1536 server-side (vLLM MRL `--hf-overrides`/`--pooler-config`), verified (norm 1.0).
+
+---
+
+## Key Technical Decisions
+
+- **Per-call `embeddingSource` parameter, not a global flag.** `HybridSearchService.search({ ..., embeddingSource })` selects the query model AND the read column together. Public callers omit it (default `"openai"`); the Mastra `searchVideos` tool passes `"gateway"`. Public search is structurally incapable of being affected. (Full-migration global flip is deferred.)
+- **Parallel `embedding_qwen` column on the two video tables only.** Scene + transcript are what `searchVideos` queries. `experience_locale` is excluded (not video search). New column is additive; existing `embedding` untouched.
+- **Backfill via the existing `run-embeds` harness**, targeting the new column, source=gateway. Reuse the resumable engine; no new backfill machinery.
+- **One embedding entry point per app, source-parameterized.** Admin `generateExperienceEmbedding(text, { source })`; Mastra a shared embed helper. Keeps "which model" decisions in one place each side.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- How to isolate the AI path from public search: **per-call `embeddingSource` param** (above).
+- Which tables get the new column: **`video_scene_locale` + `video_transcript_chunk`** (what `searchVideos` reads).
+- Truncation: **server-side 1536** (gateway already emits it; clients never truncate).
+
+### Deferred to Implementation
+
+- Flag/param plumbing detail (where `embeddingSource` is validated; enum default `openai`).
+- Whether the full 173k backfill runs up front or incrementally — the AI only "sees" backfilled scenes, so coverage vs. time is a tuning call at execution (U4/U5).
+- HNSW build params for the new indexes — mirror existing unless backfill timing argues otherwise.
+
+---
+
+## Implementation Units
+
+### U1. Gateway embedding branch in admin's embedder (per-call)
+
+**Goal:** `generateExperienceEmbedding(text, { source })` can return Qwen-1536 via the gateway when `source: "gateway"`; default `"openai"` is unchanged.
+
+**Requirements:** R1, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/admin/src/services/embeddings.service.ts` (gateway branch in/around `selectProvider()`; `generateExperienceEmbedding` accepts an optional source; assert 1536)
+- Modify: `apps/admin/src/config/env.ts` (`AI_GATEWAY_EMBEDDINGS_BASE_URL/_API_KEY/_MODEL`, all `.optional()`)
+- Test: `apps/admin/src/services/embeddings.service.test.ts`
+
+**Approach:**
+
+- Source selection is per-call, not key-presence: explicit `"gateway"` → gateway provider (base URL/model from env, User-Agent header); default → existing OpenRouter→OpenAI precedence.
+- Guard returned dimension === 1536; throw on mismatch.
+
+**Patterns to follow:** existing `selectProvider()` records; gateway client construction in `apps/admin/src/mastra/memory.ts` `buildGatewayEmbedder()`.
+
+**Test scenarios:**
+
+- Happy path: `source:"gateway"` → gateway URL, 1536 vector.
+- Edge case: no source → byte-identical to today.
+- Error path: gateway returns ≠1536 → typed dimension-mismatch throw.
+- Error path: gateway 5xx/timeout → typed embedding error.
+
+**Verification:** gateway call returns a 1536 unit vector; default path tests unchanged.
+
+---
+
+### U2. Parallel `embedding_qwen` columns + HNSW indexes (scene + transcript)
+
+**Goal:** additive 1536 columns on the two video tables, with per-locale HNSW indexes mirroring the existing ones; `embedding` untouched.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `apps/admin/prisma/migrations/<next>_video_embedding_qwen/migration.sql`
+- Modify: `apps/admin/prisma/schema.prisma` (`embedding_qwen Unsupported("vector(1536)")?` on `VideoSceneLocale`, `VideoTranscriptChunk`)
+- Test: additive — covered by `prisma migrate status` probe + existing schema tests
+
+**Approach:**
+
+- `ADD COLUMN embedding_qwen vector(1536)` (nullable) on both tables.
+- Add per-locale (`en`/`es`/`fr`) + NULL-excluded fallback HNSW indexes for the new column. On the 173k-row `video_scene_locale`, build the index with/after the backfill (U4) to avoid a slow build over a cold column on a hot table.
+- Forward-only, additive.
+
+**Patterns to follow:** existing scene/transcript HNSW index migrations; admin Migrations runbook in `apps/admin/CLAUDE.md`.
+
+**Test scenarios:**
+
+- Test expectation: none (additive schema/index). Verify via migrate-status probe and `\d` showing the new column/indexes.
+
+**Verification:** migration applies on a copy; new column + indexes present; `embedding` unchanged.
+
+---
+
+### U3. Source-parameterized search service + retrievers; Mastra tool opts into gateway
+
+**Goal:** `HybridSearchService.search` accepts `embeddingSource`; query model and read column move together; the Mastra `searchVideos` tool passes `"gateway"`; public callers unchanged.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: `apps/admin/src/services/hybrid-search.service.ts` (thread `embeddingSource` → query embed + retriever column; default `"openai"`)
+- Modify: `apps/admin/src/services/hybrid-search-retrievers.ts` (`searchVideoSemantic` reads `embedding` vs `embedding_qwen` from a closed two-literal allowlist via `Prisma.raw`)
+- Modify: `apps/admin/src/mastra/tools/search-videos.ts` (pass `embeddingSource: "gateway"`)
+- Test: `apps/admin/src/services/hybrid-search.regression.test.ts` (public default byte-identical), retriever tests, `search-videos` tool test
+
+**Approach:**
+
+- One resolved value drives both sides per call — no divergence possible.
+- Column injected via `Prisma.raw` on a fixed allowlist (never user input); unknown/absent → `openai`.
+- Public REST/GraphQL/scene-recs never pass the param → no change.
+
+**Patterns to follow:** `normalizeMode()` tolerant-flag + `hybrid-search.regression.test.ts` byte-identity guard; existing `Prisma.raw` discipline.
+
+**Test scenarios:**
+
+- Happy path (default): retriever SQL uses `embedding`, OpenAI query — regression test byte-identical.
+- Happy path (gateway): retriever SQL uses `embedding_qwen`, gateway query.
+- Edge case: unknown source → `openai` fallback + one warn log.
+- Integration: `searchVideos` tool issues a gateway query against seeded `embedding_qwen` and returns matching videos; public `/api/search` test path unaffected.
+
+**Verification:** the Mastra tool searches Qwen-space; public search tests unchanged.
+
+---
+
+### U4. Backfill scene + transcript vectors into `embedding_qwen` (Qwen)
+
+**Goal:** the video corpora the AI searches have Qwen-1536 vectors in the new column; live `embedding` untouched.
+
+**Requirements:** R3
+
+**Dependencies:** U2, plus Mastra-side gateway embedding for the workflows
+
+**Files:**
+
+- Modify: `apps/mastra/src/mastra/workflows/{scene,transcript}-embedding.ts` (emit Qwen 1536 when source=gateway) + `apps/mastra/src/config/env.ts`
+- Modify: `apps/admin/src/scripts/run-embeds.ts` + scene/transcript backfill services (target `embedding_qwen` when source=gateway)
+- Test: colocated workflow tests; `run-embeds.test.ts`; service write tests asserting writes land in `embedding_qwen`
+
+**Approach:**
+
+- Run `run-embeds --pipeline=scene` then `--pipeline=transcript` (gateway source) from the admin worker, writing the new column. Resumable; tune batch/concurrency to the single GPU. Build the U2 indexes during/after.
+- Live `embedding` column never written by this path.
+
+**Execution note:** long-running; run under `tmux`/`nohup`, watch `run-embeds.*` events; safe to resume. Coverage is incremental — the AI sees only backfilled scenes, so a full run is preferred before relying on it.
+
+**Patterns to follow:** `run-embeds` resumable backfill; local-embed-pipeline runbook in `apps/admin/CLAUDE.md`.
+
+**Test scenarios:**
+
+- Happy path: writes land in `embedding_qwen` only; `embedding` untouched.
+- Edge case: re-run idempotent.
+- Error path: per-target gateway failure isolated/retryable.
+- Integration: post-backfill `count(embedding_qwen)` approaches `count(embedding)` on both tables.
+
+**Verification:** `SELECT count(embedding_qwen) FROM video_scene_locale` (and transcript) grows to ~parity; new indexes used in `EXPLAIN`.
+
+---
+
+### U5. Enable + verify the AI video-search pilot
+
+**Goal:** in prod, AI experience generation finds videos via Qwen with no OpenRouter dependency; public search verified unchanged; documented revert.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** U3, U4
+
+**Files:**
+
+- Config: ensure `AI_GATEWAY_EMBEDDINGS_*` set on `@forge/admin` (+ worker) and Mastra.
+- Docs: add a short "AI video-search on Qwen (pilot)" runbook to `apps/admin/CLAUDE.md` (how it's scoped, how to revert the tool to `openai`).
+
+**Approach:**
+
+- With the tool passing `gateway` and the backfill complete, run a "Generate full page" in prod and confirm real video candidates appear (no `403`, no empty response).
+- Confirm public `/api/search` still returns its usual results (OpenAI path).
+- **Revert:** change the tool's `embeddingSource` back to `"openai"` (one line) — instantly restores the prior behavior; new column stays for retry.
+
+**Test scenarios:**
+
+- Test expectation: none (config + ops). Verification below.
+
+**Verification:** AI experience generation returns non-empty drafts with real videos; public search unchanged; reverting the tool param restores prior AI behavior.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** only `searchVideos` → `HybridSearchService.search(gateway)` changes; public REST/GraphQL/scene-recs call the same service without the param and are unaffected.
+- **Error propagation:** gateway-unreachable / wrong-dim → typed errors; the AI candidate search already degrades to token ranking, so failure is non-fatal to chat.
+- **State lifecycle risks:** backfill writes only the new column; the live column is never mid-mutation; build new-column indexes off the hot path.
+- **API surface parity:** none — no public response shape changes.
+- **Unchanged invariants:** `embedding` column, its indexes, and every public search/recs behavior remain exactly as today (R2/R5) — that is the rollback guarantee.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                             | Mitigation                                                                                |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Partial backfill → AI sees only some videos      | Prefer a full scene/transcript backfill before relying on the pilot; it's resumable       |
+| Single-GPU gateway throughput slow for 173k      | Resumable `run-embeds`; runs off the live path; can proceed incrementally                 |
+| Accidental leak of the param into public search  | Default `openai`; only the Mastra tool sets it; regression test pins public byte-identity |
+| New-column index build locks hot scene table     | Build on the new column, with/after backfill                                              |
+| OpenRouter still out of budget for public search | Deferred stop-gap (top up / `OPENAI_API_KEY`) — independent of this pilot                 |
+
+---
+
+## Documentation / Operational Notes
+
+- Add the pilot runbook to `apps/admin/CLAUDE.md`: the `embeddingSource` param, that only `searchVideos` uses `gateway`, the backfill commands, and the one-line revert.
+- Record the gateway 1536 config (vLLM `--hf-overrides`/`--pooler-config`; backup `docker-compose.yml.bak.pre-mrl1536`).
+- After it lands, capture a `ce-compound` learning: "per-call embeddingSource — piloting a new embedding model on one consumer via a parallel column without touching public search."
+
+---
+
+## Sources & References
+
+- Pattern: `docs/solutions/architecture-patterns/provider-bound-content-embedding-backfill-gate-pattern.md`
+- pgvector indexing: `docs/solutions/best-practices/pgvector-embedding-indexing-strapi-v5.md`
+- Admin runbooks: `apps/admin/CLAUDE.md` (Scene/Transcript embeddings, Hybrid search, Running embeds locally)
+- Sibling fix already merged: chat-path provider routing PR #1145
+- Deferred larger effort: full public-search Qwen migration (this pilot de-risks it)


### PR DESCRIPTION
## Summary

First, **behavior-neutral** slice of the [Qwen-1536 video-search pilot](docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md): give the admin **AI experience generator** the *capability* to run its video search on the self-hosted JesusFilm gateway (Qwen3-Embedding-8B → 1536) instead of paid OpenAI/OpenRouter embeddings — without touching public search and without changing any current behavior.

Merging this PR changes nothing in production: the new `AI_VIDEO_SEARCH_EMBEDDING_SOURCE` flag defaults to `openai`. It only adds the columns, the per-call gateway embedding path, and the wiring so the source can be flipped **after** the `embedding_qwen` backfill exists (a follow-up PR + an ops run).

## Why

The AI's `searchVideos` tool embeds through OpenRouter `text-embedding-3-small`; that key is out of budget (`403`) with no OpenAI fallback, so AI experience generation returns empty drafts. The org runs Qwen on its own GPU for free. Two embedding models can't share a vector space even at the same 1536 width — so the AI's Qwen query needs **Qwen-embedded** video vectors in a parallel column, not the existing OpenAI column. pgvector HNSW caps at 2000 dims (verified on prod), so 1536 is the fixed, indexable width.

## What's in this PR (U1–U3 + flag)

- **U1** — `embeddings.service.ts` gains a per-call `embeddingSource: "openai" | "gateway"`. `gateway` routes to the gateway (Qwen 1536) with the Cloudflare-dodging User-Agent; the existing 1536 dimension guard validates the response. Default `openai` is byte-identical.
- **U2** — additive migration `0032`: `embedding_qwen vector(1536)` on `video_scene_locale` + `video_transcript_chunk`, with per-locale (en/es/fr) + fallback HNSW indexes mirroring the existing ones. The `embedding` column is untouched; `experience_locale` is out of scope.
- **U3** — `HybridSearchService.search` threads `embeddingSource` to the query embedder **and** the semantic-video retriever, which picks `embedding` vs `embedding_qwen` via a **closed two-literal allowlist** before `Prisma.raw` (no injection path). Public `/api/search`, `Query.search`, and scene-recommendations omit the arg and stay byte-identical (regression test guards this).
- **Flag** — the `searchVideos` tool reads `AI_VIDEO_SEARCH_EMBEDDING_SOURCE` (default `openai`). Flip to `gateway` only after the backfill; one-line reversible (plan R5).

## Deliberately deferred (follow-ups, not this PR)

- **U4 — backfill write path:** Mastra workflows emit Qwen via the gateway + admin ingest writes the `embedding_qwen` column (column-targeted bulk-INSERT). Its own PR, paired with:
- **Backfill run (ops):** re-embed ~173k scene + ~4.3k transcript rows into `embedding_qwen` via `run-embeds` from the worker.
- **Enable (ops):** set `AI_VIDEO_SEARCH_EMBEDDING_SOURCE=gateway` on `@forge/admin` once the backfill is complete; verify AI generation finds videos; revert = flip back.
- **Stop-gap (independent):** public search still needs the OpenRouter key topped up (or `OPENAI_API_KEY` set) — unrelated to this pilot.

## Verification

| Gate | Result |
|---|---|
| Touched-file tests (5 files) | 102 passed |
| Public-search byte-identity regression | green |
| Admin lint (`eslint .`) | 0 warnings |
| Admin typecheck | clean |
| Migration | additive, forward-only; `prisma validate` ✓ |

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
