### PR TITLE
fix(manager): eagerly load coverage region images

### DIFF
--- a/apps/manager/src/features/coverage/LanguageGeoSelector.tsx
+++ b/apps/manager/src/features/coverage/LanguageGeoSelector.tsx
@@ -983,6 +983,7 @@ export function LanguageGeoSelector({
             src={theme.image}
             alt=""
             fill
+            loading="eager"
             sizes="(max-width: 767px) calc((100vw - 5.5rem) / 2), (max-width: 900px) 18rem, 22vw"
             className="object-cover transition-transform duration-200 group-hover:scale-[1.025]"
           />

--- a/docs/roadmap/platform/feat-166-manager-coverage-region-image-assets.md
+++ b/docs/roadmap/platform/feat-166-manager-coverage-region-image-assets.md
@@ -80,3 +80,7 @@ route-backed shell assets such as `/jesusfilm-sign.svg`.
 - Local Helium smoke in mock mode confirmed the open language picker renders
   region artwork and browser image `src` values reference
   `/_next/static/media/region-*.png`.
+- Follow-up Helium debugging found the deployed static image URLs were valid,
+  but Chromium could keep the visible picker card images pending because
+  `next/image` rendered them as lazy-loaded images. Region card images now use
+  eager loading so the browser requests them as soon as the picker opens.


### PR DESCRIPTION
## Summary
- eagerly load Manager coverage language-picker region card images so Chromium requests visible cards when the picker opens
- update the existing feat-166 roadmap notes with the lazy-load follow-up

## Debugging Notes
- Production fresh Helium tab loads coverage data successfully now; the stale old tab was stuck in a Next streamed fallback, but a fresh tab issued /api/languages, /api/videos, and /api/coverage-snapshots successfully.
- The region image URLs are now valid /_next/image URLs, but production Helium showed them staying pending with loading=lazy inside the picker. This follow-up removes that lazy deferral for region cards.

## Validation
- pnpm --filter @forge/manager exec eslint src/features/coverage/LanguageGeoSelector.tsx
- pnpm --filter @forge/manager typecheck
- Local Helium mock-mode smoke on http://localhost:3202/dashboard/coverage?languageId=529: opened language picker; region image requests returned 200 image/webp; visible images had loading="eager", complete=true, naturalWidth=262, naturalHeight=197, broken=[]
