### PR TITLE
feat(web): add watch home carousel sequence parity

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
@@ -145,7 +145,12 @@ beforeEach(() => {
     error: new Error("No experience found"),
   })
   resolveWatchHomeMock.mockResolvedValue({
-    data: { heroSlides: [], sections: [], missingData: [] },
+    data: {
+      heroSlides: [],
+      sections: [],
+      carousel: { pools: [], muxInserts: [] },
+      missingData: [],
+    },
     error: null,
   })
   resolveWatchExperiencePageMock.mockResolvedValue({
@@ -367,6 +372,7 @@ describe("Catch-all routing — one-segment collection/home branch", () => {
       data: {
         heroSlides: [{ id: "hero-es" }],
         sections: [],
+        carousel: { pools: [], muxInserts: [] },
         missingData: [],
       },
       error: null,

--- a/apps/web/src/components/home/WatchHomePage.tsx
+++ b/apps/web/src/components/home/WatchHomePage.tsx
@@ -56,7 +56,10 @@ export function WatchHomePage({ model }: WatchHomePageProps) {
         </div>
 
         <div className="relative z-10 mx-auto -mt-[100vh] max-w-[1920px] overflow-hidden">
-          <WatchHomeTvCarousel slides={model.heroSlides} />
+          <WatchHomeTvCarousel
+            slides={model.heroSlides}
+            sequence={model.carousel}
+          />
           {model.sections.map((section) => (
             <WatchHomeSection key={section.id} section={section} />
           ))}

--- a/apps/web/src/components/home/WatchHomeTvCarousel.tsx
+++ b/apps/web/src/components/home/WatchHomeTvCarousel.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/carousel"
 import { Button } from "@/components/ui/button"
 import type { WatchHomeHeroSlide } from "@/lib/watch-home"
+import type { WatchHomeCarouselSequenceData } from "@/lib/watch-home-carousel-sequence"
 import { cn } from "@/lib/utils"
 import {
   useWatchHomeTvCarousel,
@@ -21,6 +22,7 @@ import {
 
 type WatchHomeTvCarouselProps = {
   slides: WatchHomeHeroSlide[]
+  sequence?: WatchHomeCarouselSequenceData | null
 }
 
 function muxStreamUrl(playbackId: string | null) {
@@ -41,7 +43,8 @@ export function watchHomeHeroSlidesToTvCarouselSlides(
     const posterUrl = slide.imageUrl ?? muxThumbnail
 
     return {
-      id: slide.id,
+      kind: "video",
+      id: slide.coreId,
       title: slide.title,
       description: slide.description,
       label: slide.eyebrow || slide.label,
@@ -52,18 +55,28 @@ export function watchHomeHeroSlidesToTvCarouselSlides(
       imageAlt: slide.imageAlt,
       src: slide.hls ?? muxStreamUrl(slide.playbackId),
       playbackId: slide.playbackId,
+      durationSeconds: slide.durationSeconds,
     }
   })
 }
 
 function PrimaryAction({ slide }: { slide: WatchHomeTvCarouselSlide }) {
+  const className =
+    "inline-flex h-14 max-w-full items-center gap-3 rounded-full bg-brand-red px-5 text-lg font-bold text-white shadow-[0_14px_32px_rgba(0,0,0,0.34)] transition hover:bg-brand-red/90 focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none sm:h-16 sm:px-7 sm:text-xl"
+
+  if (slide.kind === "mux" && slide.action) {
+    return (
+      <a href={slide.action.url} className={className}>
+        <Play className="h-5 w-5 shrink-0 fill-current" aria-hidden />
+        <span className="truncate">{slide.action.label}</span>
+      </a>
+    )
+  }
+
   if (!slide.href) return null
 
   return (
-    <Link
-      href={slide.href as Route}
-      className="inline-flex h-14 max-w-full items-center gap-3 rounded-full bg-brand-red px-5 text-lg font-bold text-white shadow-[0_14px_32px_rgba(0,0,0,0.34)] transition hover:bg-brand-red/90 focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none sm:h-16 sm:px-7 sm:text-xl"
-    >
+    <Link href={slide.href as Route} className={className}>
       <Play className="h-5 w-5 shrink-0 fill-current" aria-hidden />
       <span className="truncate">Watch Now</span>
     </Link>
@@ -285,7 +298,10 @@ function WatchHomeTvRail({
   )
 }
 
-export function WatchHomeTvCarousel({ slides }: WatchHomeTvCarouselProps) {
+export function WatchHomeTvCarousel({
+  sequence = null,
+  slides,
+}: WatchHomeTvCarouselProps) {
   const carouselSlides = useMemo(
     () => watchHomeHeroSlidesToTvCarouselSlides(slides),
     [slides],
@@ -300,9 +316,10 @@ export function WatchHomeTvCarousel({ slides }: WatchHomeTvCarouselProps) {
     isMuted,
     progress,
     selectSlide,
+    slides: displaySlides,
     toggleMuted,
     videoRef,
-  } = useWatchHomeTvCarousel(carouselSlides)
+  } = useWatchHomeTvCarousel(carouselSlides, sequence)
 
   if (!activeSlide) return null
 
@@ -355,7 +372,7 @@ export function WatchHomeTvCarousel({ slides }: WatchHomeTvCarouselProps) {
           </Button>
         </div>
         <WatchHomeTvRail
-          slides={carouselSlides}
+          slides={displaySlides}
           activeSlideId={activeSlide.id}
           progress={progress}
           onSelect={selectSlide}

--- a/apps/web/src/components/home/__tests__/WatchHomePage.test.tsx
+++ b/apps/web/src/components/home/__tests__/WatchHomePage.test.tsx
@@ -5,7 +5,9 @@
 import { act, type ReactNode } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { WatchHomeMuxInsertConfig } from "@/lib/watch-home-config"
 import type { WatchHomeModel } from "@/lib/watch-home"
+import type { WatchHomeTvCarouselVideoSlide } from "@/lib/watch-home-carousel-sequence"
 import { WatchHomePage } from "@/components/home/WatchHomePage"
 
 vi.mock("next/image", () => ({
@@ -76,6 +78,10 @@ function makeModel(overrides: Partial<WatchHomeModel> = {}): WatchHomeModel {
   const hero = { ...makeCard(), eyebrow: "Featured" }
   return {
     heroSlides: [hero],
+    carousel: {
+      pools: [],
+      muxInserts: [],
+    },
     sections: [
       {
         id: "home-video-gospels",
@@ -93,10 +99,47 @@ function makeModel(overrides: Partial<WatchHomeModel> = {}): WatchHomeModel {
   }
 }
 
+function makeCarouselSlide(
+  overrides: Partial<WatchHomeTvCarouselVideoSlide> = {},
+): WatchHomeTvCarouselVideoSlide {
+  return {
+    kind: "video",
+    id: "queued-1",
+    title: "Queued One",
+    description: "Queued from the playlist pool",
+    label: "Short film",
+    href: "/queued-one.html/english.html",
+    posterUrl: "https://cdn.example/queued-one.jpg",
+    thumbnailUrl: "https://cdn.example/queued-one-thumb.jpg",
+    imageAlt: "Queued One still",
+    src: "https://stream.example/queued-one.m3u8",
+    playbackId: "mux-queued-one",
+    durationSeconds: 10,
+    ...overrides,
+  }
+}
+
+const muxInsert = {
+  id: "welcome-start",
+  enabled: true,
+  playbackIds: ["mux-welcome"],
+  durationSeconds: 9,
+  label: "Faith & Scripture",
+  title: "Daily Start",
+  collectionTitle: null,
+  description: "A Mux intro",
+  action: null,
+  logo: true,
+  posterOverride: null,
+  trigger: { type: "sequence-start" },
+} satisfies WatchHomeMuxInsertConfig
+
 let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
+  window.localStorage.clear()
+  window.sessionStorage.clear()
   container = document.createElement("div")
   document.body.appendChild(container)
   root = createRoot(container)
@@ -136,6 +179,10 @@ describe("WatchHomePage", () => {
     expect(
       container.querySelectorAll("a[href='/jesus.html/english.html']"),
     ).toHaveLength(4)
+    expect(
+      JSON.parse(window.localStorage.getItem("carousel-played-ids") ?? "{}")
+        .ids,
+    ).toEqual(["1_jf-0-0"])
   })
 
   it("renders an unlinked fallback card when href is missing", async () => {
@@ -165,5 +212,39 @@ describe("WatchHomePage", () => {
       container.querySelector("a[href='/jesus.html/english.html']"),
     ).toBeNull()
     expect(container.textContent).toContain("Fallback Cards")
+  })
+
+  it("renders the sequenced Mux and playlist slides in the rail", async () => {
+    await act(async () => {
+      root.render(
+        <WatchHomePage
+          model={makeModel({
+            carousel: {
+              pools: [
+                {
+                  id: "pool-a",
+                  collectionIds: ["pool-a"],
+                  videos: [
+                    makeCarouselSlide(),
+                    makeCarouselSlide({
+                      id: "queued-2",
+                      title: "Queued Two",
+                      href: "/queued-two.html/english.html",
+                    }),
+                  ],
+                },
+              ],
+              muxInserts: [muxInsert],
+            },
+          })}
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain("Daily Start")
+    expect(container.textContent).toContain("Queued One")
+    expect(
+      container.querySelectorAll('[data-testid="watch-home-tv-carousel-card"]'),
+    ).toHaveLength(3)
   })
 })

--- a/apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts
+++ b/apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts
@@ -16,6 +16,7 @@ const currentMonth = new Date().toISOString().slice(0, 7)
 
 function slide(id: string, src = `${id}.m3u8`): WatchHomeTvCarouselSlide {
   return {
+    kind: "video",
     id,
     title: id,
     description: null,
@@ -26,6 +27,7 @@ function slide(id: string, src = `${id}.m3u8`): WatchHomeTvCarouselSlide {
     imageAlt: id,
     src,
     playbackId: id,
+    durationSeconds: 10,
   }
 }
 

--- a/apps/web/src/components/home/useWatchHomeTvCarousel.ts
+++ b/apps/web/src/components/home/useWatchHomeTvCarousel.ts
@@ -8,28 +8,32 @@ import {
   useState,
   useSyncExternalStore,
 } from "react"
+import {
+  WATCH_HOME_TV_ADVANCE_THRESHOLD,
+  WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY,
+  addWatchHomeTvPlayedId,
+  buildWatchHomeVideoQueue,
+  loadWatchHomeCurrentVideoSession,
+  markWatchHomeVideoPlayed,
+  mergeWatchHomeMuxInserts,
+  readWatchHomeTvPlayedIds,
+  resetWatchHomeTvPlayedIds,
+  saveWatchHomeCurrentVideoSession,
+  type WatchHomeCarouselSequenceData,
+  type WatchHomeTvCarouselSlide,
+  type WatchHomeTvCarouselVideoSlide,
+} from "@/lib/watch-home-carousel-sequence"
 
-export type WatchHomeTvCarouselSlide = {
-  id: string
-  title: string
-  description: string | null
-  label: string
-  href: string | null
-  posterUrl: string | null
-  thumbnailUrl: string | null
-  imageAlt: string
-  src: string | null
-  playbackId: string | null
+export {
+  WATCH_HOME_TV_ADVANCE_THRESHOLD,
+  WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY,
+  addWatchHomeTvPlayedId,
+  readWatchHomeTvPlayedIds,
+  resetWatchHomeTvPlayedIds,
 }
+export type { WatchHomeCarouselSequenceData, WatchHomeTvCarouselSlide }
 
-export const WATCH_HOME_TV_ADVANCE_THRESHOLD = 95
-export const WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY = "carousel-played-ids"
 const IMAGE_SLIDE_ADVANCE_MS = 7000
-
-type PlayedIdsStorageValue = {
-  month?: unknown
-  ids?: unknown
-}
 
 function subscribeToHydrationStore() {
   return () => undefined
@@ -65,59 +69,6 @@ export function shouldAdvanceWatchHomeTvCarousel(
   threshold = WATCH_HOME_TV_ADVANCE_THRESHOLD,
 ) {
   return previousProgress < threshold && currentProgress >= threshold
-}
-
-function currentStorageMonth() {
-  return new Date().toISOString().slice(0, 7)
-}
-
-export function readWatchHomeTvPlayedIds(): string[] {
-  if (typeof window === "undefined") return []
-
-  try {
-    const stored = localStorage.getItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY)
-    if (!stored) return []
-
-    const data = JSON.parse(stored) as PlayedIdsStorageValue
-    if (data.month !== currentStorageMonth()) {
-      localStorage.removeItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY)
-      return []
-    }
-
-    return Array.isArray(data.ids)
-      ? data.ids.filter((id): id is string => typeof id === "string")
-      : []
-  } catch {
-    return []
-  }
-}
-
-export function resetWatchHomeTvPlayedIds() {
-  if (typeof window === "undefined") return
-
-  try {
-    localStorage.removeItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY)
-  } catch {
-    // Ignore storage errors from private browsing or disabled storage.
-  }
-}
-
-export function addWatchHomeTvPlayedId(slideId: string) {
-  if (typeof window === "undefined") return
-
-  try {
-    const current = readWatchHomeTvPlayedIds()
-    const ids = current.includes(slideId) ? current : [...current, slideId]
-    localStorage.setItem(
-      WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY,
-      JSON.stringify({
-        month: currentStorageMonth(),
-        ids,
-      }),
-    )
-  } catch {
-    // Ignore storage errors from private browsing or disabled storage.
-  }
 }
 
 function firstPlayableIndex(slides: readonly WatchHomeTvCarouselSlide[]) {
@@ -178,51 +129,107 @@ export function nextUnplayedWatchHomeTvCarouselIndex(
 
 export function useWatchHomeTvCarousel(
   slides: readonly WatchHomeTvCarouselSlide[],
+  sequence: WatchHomeCarouselSequenceData | null = null,
 ) {
   const hasHydrated = useSyncExternalStore(
     subscribeToHydrationStore,
     getClientHydrationSnapshot,
     getServerHydrationSnapshot,
   )
-  const [activeIndex, setActiveIndex] = useState<number | null>(null)
+  const [activeSlideId, setActiveSlideId] = useState<string | null>(null)
+  const [prefetchedQueue, setPrefetchedQueue] = useState<{
+    sequenceKey: string
+    videos: WatchHomeTvCarouselVideoSlide[]
+    nextPoolIndex: number
+  } | null>(null)
   const [isMuted, setIsMuted] = useState(true)
   const [progress, setProgress] = useState(0)
   const isMutedRef = useRef(isMuted)
   const previousProgressRef = useRef(0)
   const imageSlideStartedAtRef = useRef<number | null>(null)
   const videoRef = useRef<HTMLVideoElement | null>(null)
+  const isSequenced = hasHydrated && sequence != null
+  const sequenceKey = useMemo(
+    () =>
+      sequence
+        ? sequence.pools
+            .map(
+              (pool) =>
+                `${pool.id}:${pool.videos.map((video) => video.id).join(",")}`,
+            )
+            .join("|")
+        : "fallback",
+    [sequence],
+  )
+  const initialQueue = useMemo(() => {
+    if (!isSequenced || !sequence) {
+      return { videos: [], nextPoolIndex: 0 }
+    }
+
+    const session = loadWatchHomeCurrentVideoSession()
+    return buildWatchHomeVideoQueue({
+      pools: sequence.pools,
+      startPoolIndex: session?.poolIndex ?? 0,
+      targetVideoCount: 7,
+    })
+  }, [isSequenced, sequence])
+  const activePrefetchedQueue =
+    prefetchedQueue?.sequenceKey === sequenceKey ? prefetchedQueue : null
+  const videoQueue = activePrefetchedQueue?.videos ?? initialQueue.videos
+  const nextPoolIndex =
+    activePrefetchedQueue?.nextPoolIndex ?? initialQueue.nextPoolIndex
+
+  const sequencedSlides = useMemo(() => {
+    if (!isSequenced || videoQueue.length === 0 || !sequence) return null
+    return mergeWatchHomeMuxInserts(videoQueue, sequence.muxInserts)
+  }, [isSequenced, sequence, videoQueue])
+
+  const displaySlides = sequencedSlides ?? slides
 
   const defaultActiveIndex = hasHydrated
-    ? firstUnplayedWatchHomeTvCarouselIndex(slides)
-    : firstPlayableIndex(slides)
-  const safeActiveIndex =
-    activeIndex != null && activeIndex < slides.length
-      ? activeIndex
-      : defaultActiveIndex
-  const activeSlide = slides[safeActiveIndex] ?? slides[0] ?? null
+    ? firstUnplayedWatchHomeTvCarouselIndex(displaySlides)
+    : firstPlayableIndex(displaySlides)
+  const activeSlide =
+    (activeSlideId != null
+      ? displaySlides.find((slide) => slide.id === activeSlideId)
+      : null) ??
+    displaySlides[defaultActiveIndex] ??
+    displaySlides[0] ??
+    null
+  const safeActiveIndex = activeSlide
+    ? Math.max(
+        0,
+        displaySlides.findIndex((slide) => slide.id === activeSlide.id),
+      )
+    : 0
 
   const selectIndex = useCallback(
     (index: number) => {
-      if (index < 0 || index >= slides.length) return
+      if (index < 0 || index >= displaySlides.length) return
       imageSlideStartedAtRef.current = null
       previousProgressRef.current = 0
       setProgress(0)
-      setActiveIndex(index)
+      setActiveSlideId(displaySlides[index]?.id ?? null)
     },
-    [slides.length],
+    [displaySlides],
   )
 
   const selectSlide = useCallback(
     (slideId: string) => {
-      const index = slides.findIndex((slide) => slide.id === slideId)
+      const index = displaySlides.findIndex((slide) => slide.id === slideId)
       selectIndex(index)
     },
-    [selectIndex, slides],
+    [displaySlides, selectIndex],
   )
 
   const advance = useCallback(() => {
-    selectIndex(nextUnplayedWatchHomeTvCarouselIndex(safeActiveIndex, slides))
-  }, [safeActiveIndex, selectIndex, slides])
+    const nextIndex = isSequenced
+      ? safeActiveIndex + 1 < displaySlides.length
+        ? safeActiveIndex + 1
+        : 0
+      : nextUnplayedWatchHomeTvCarouselIndex(safeActiveIndex, displaySlides)
+    selectIndex(nextIndex)
+  }, [displaySlides, isSequenced, safeActiveIndex, selectIndex])
 
   const toggleMuted = useCallback(() => {
     setIsMuted((current) => {
@@ -275,12 +282,62 @@ export function useWatchHomeTvCarousel(
   useEffect(() => {
     imageSlideStartedAtRef.current = null
     previousProgressRef.current = 0
-    if (hasHydrated && activeSlide?.id) addWatchHomeTvPlayedId(activeSlide.id)
+    if (hasHydrated) {
+      if (isSequenced) {
+        markWatchHomeVideoPlayed(activeSlide)
+        saveWatchHomeCurrentVideoSession(activeSlide)
+      } else if (activeSlide?.id) {
+        addWatchHomeTvPlayedId(activeSlide.id)
+      }
+    }
     const video = videoRef.current
     if (!video) return
     video.muted = isMutedRef.current
     video.currentTime = 0
-  }, [activeSlide?.id, hasHydrated])
+  }, [activeSlide, activeSlide?.id, hasHydrated, isSequenced])
+
+  useEffect(() => {
+    if (!isSequenced || !sequence || videoQueue.length === 0) return
+    const activeVideoIndex =
+      activeSlide?.kind === "video"
+        ? videoQueue.findIndex((video) => video.id === activeSlide.id)
+        : -1
+    const targetVideoCount =
+      videoQueue.length < 7
+        ? 7
+        : activeVideoIndex >= 0
+          ? activeVideoIndex + 2
+          : videoQueue.length
+
+    if (targetVideoCount <= videoQueue.length) return
+
+    const built = buildWatchHomeVideoQueue({
+      pools: sequence.pools,
+      existingVideos: videoQueue,
+      startPoolIndex: nextPoolIndex,
+      targetVideoCount,
+    })
+    if (built.videos.length === videoQueue.length) return
+
+    const timeout = window.setTimeout(() => {
+      setPrefetchedQueue({
+        sequenceKey,
+        videos: built.videos,
+        nextPoolIndex: built.nextPoolIndex,
+      })
+    }, 0)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [
+    activeSlide,
+    isSequenced,
+    nextPoolIndex,
+    sequence,
+    sequenceKey,
+    videoQueue,
+  ])
 
   useEffect(() => {
     if (!activeSlide || activeSlide.src) return
@@ -323,6 +380,7 @@ export function useWatchHomeTvCarousel(
       isMuted,
       progress,
       selectSlide,
+      slides: displaySlides,
       toggleMuted,
       videoRef,
     }),
@@ -333,6 +391,7 @@ export function useWatchHomeTvCarousel(
       handleCanPlay,
       handleLoadedMetadata,
       handleTimeUpdate,
+      displaySlides,
       isMuted,
       progress,
       selectSlide,

--- a/apps/web/src/lib/__tests__/watch-home.test.ts
+++ b/apps/web/src/lib/__tests__/watch-home.test.ts
@@ -59,6 +59,11 @@ function makeChild(overrides: Record<string, unknown> = {}) {
     slug: "episode-one",
     label: "EPISODE",
     durationSeconds: 87,
+    primaryLanguage: {
+      coreId: "529",
+      bcp47: "en",
+      slug: "english",
+    },
     images: [makeImage({ mobileCinematicHigh: "https://cdn.example/ep1.jpg" })],
     locales: [
       {
@@ -69,6 +74,14 @@ function makeChild(overrides: Record<string, unknown> = {}) {
         snippet: "The first episode",
         imageAlt: "Episode One still",
       },
+    ],
+    variants: [
+      makeVariant({
+        documentId: "child-variant-1",
+        hls: "https://stream.example/episode-one.m3u8",
+        duration: 87,
+        muxVideo: { playbackId: "mux-episode-one" },
+      }),
     ],
     ...overrides,
   }
@@ -146,6 +159,19 @@ describe("buildWatchHomeModelFromVideos", () => {
     expect(gospelRail?.cards.map((card) => card.coreId)).toEqual([
       "1_jf-0-0",
       "2_GOJ-0-0",
+    ])
+    expect(model.carousel.pools[0]).toMatchObject({
+      collectionIds: ["1_jf-0-0"],
+    })
+    expect(model.carousel.pools[0]?.videos[0]).toMatchObject({
+      kind: "video",
+      title: "Jesus",
+      src: "https://stream.example/jesus.m3u8",
+    })
+    expect(model.carousel.muxInserts.map((insert) => insert.id)).toEqual([
+      "welcome-start",
+      "join-us",
+      "telling-the-story-of-jesus",
     ])
   })
 
@@ -229,6 +255,47 @@ describe("buildWatchHomeModelFromVideos", () => {
     )
     expect(course?.cards[0]?.parentCoreId).toBe("8_NBC")
     expect(course?.cards.some((card) => card.coreId === "8_NBC")).toBe(false)
+  })
+
+  it("filters blacklisted child videos from carousel pools", async () => {
+    const { buildWatchHomeModelFromVideos } = await import("../watch-home")
+
+    const model = buildWatchHomeModelFromVideos({
+      locale: "en",
+      languageSlug: "english",
+      videos: [
+        makeVideo({
+          documentId: "origins",
+          coreId: "7_Origins",
+          slug: "origins",
+          label: "COLLECTION",
+          children: [
+            {
+              child: makeChild({
+                documentId: "blacklisted",
+                coreId: "7_Origins4Connect",
+                slug: "connect",
+              }),
+            },
+            {
+              child: makeChild({
+                documentId: "allowed",
+                coreId: "7_OriginsAllowed",
+                slug: "allowed",
+              }),
+            },
+          ],
+        }),
+      ] as never,
+    })
+
+    const originsPool = model.carousel.pools.find((pool) =>
+      pool.collectionIds.includes("7_Origins"),
+    )
+
+    expect(originsPool?.videos.map((video) => video.id)).toEqual([
+      "7_OriginsAllowed",
+    ])
   })
 
   it("uses Mux thumbnails when admin images are missing and records the image gap", async () => {

--- a/apps/web/src/lib/watch-home-carousel-sequence.test.ts
+++ b/apps/web/src/lib/watch-home-carousel-sequence.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it } from "vitest"
+import type { WatchHomeMuxInsertConfig } from "@/lib/watch-home-config"
+import {
+  WATCH_HOME_TV_CURRENT_VIDEO_STORAGE_KEY,
+  WATCH_HOME_TV_MUX_SELECTIONS_STORAGE_KEY,
+  WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY,
+  addWatchHomeTvPlayedId,
+  buildWatchHomeVideoQueue,
+  getWatchHomeDeterministicOffset,
+  loadWatchHomeCurrentVideoSession,
+  mergeWatchHomeMuxInserts,
+  poolFailuresStorageKey,
+  poolVideosStorageKey,
+  readWatchHomeTvPlayedIds,
+  saveWatchHomeCurrentVideoSession,
+  type WatchHomeCarouselPool,
+  type WatchHomeTvCarouselVideoSlide,
+} from "./watch-home-carousel-sequence"
+
+const currentMonth = new Date().toISOString().slice(0, 7)
+
+function video(id: string): WatchHomeTvCarouselVideoSlide {
+  return {
+    kind: "video",
+    id,
+    title: id,
+    description: null,
+    label: "Short film",
+    href: `/${id}.html/english.html`,
+    posterUrl: `${id}.jpg`,
+    thumbnailUrl: `${id}-thumb.jpg`,
+    imageAlt: id,
+    src: `${id}.m3u8`,
+    playbackId: `mux-${id}`,
+    durationSeconds: 10,
+  }
+}
+
+function pool(id: string, videos: string[]): WatchHomeCarouselPool {
+  return {
+    id,
+    collectionIds: [id],
+    videos: videos.map(video),
+  }
+}
+
+const muxInsert = {
+  id: "welcome-start",
+  enabled: true,
+  playbackIds: ["playback-a"],
+  durationSeconds: 9,
+  label: "Faith & Scripture",
+  title: "Today's Video Picks",
+  collectionTitle: "Daily Inspirations",
+  description: "A welcome insert.",
+  action: null,
+  logo: true,
+  posterOverride: null,
+  trigger: { type: "sequence-start" },
+} satisfies WatchHomeMuxInsertConfig
+
+describe("watch home carousel sequence helpers", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
+
+  it("uses deterministic daily offsets for pool selection", () => {
+    const now = new Date("2026-06-04T12:00:00.000Z")
+
+    expect(
+      getWatchHomeDeterministicOffset("pool-a", 12, {
+        now,
+        poolIndex: 0,
+        totalVideosLoaded: 0,
+      }),
+    ).toBe(
+      getWatchHomeDeterministicOffset("pool-a", 12, {
+        now,
+        poolIndex: 0,
+        totalVideosLoaded: 0,
+      }),
+    )
+    expect(getWatchHomeDeterministicOffset("pool-a", 0, { now })).toBe(0)
+  })
+
+  it("stores and expires persistent played ids in the Core monthly shape", () => {
+    addWatchHomeTvPlayedId("video-1")
+
+    expect(readWatchHomeTvPlayedIds()).toEqual(["video-1"])
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY) ??
+          "{}",
+      ),
+    ).toEqual({
+      month: currentMonth,
+      ids: ["video-1"],
+    })
+
+    window.localStorage.setItem(
+      WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY,
+      JSON.stringify({ month: "2000-01", ids: ["old"] }),
+    )
+
+    expect(readWatchHomeTvPlayedIds()).toEqual([])
+    expect(
+      window.localStorage.getItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY),
+    ).toBeNull()
+  })
+
+  it("builds a progressive queue from playlist pools while avoiding played videos", () => {
+    addWatchHomeTvPlayedId("video-a")
+    window.sessionStorage.setItem(
+      poolVideosStorageKey("pool-b"),
+      JSON.stringify(["video-c"]),
+    )
+
+    const result = buildWatchHomeVideoQueue({
+      pools: [
+        pool("pool-a", ["video-a", "video-b"]),
+        pool("pool-b", ["video-c", "video-d"]),
+      ],
+      targetVideoCount: 2,
+      now: new Date("2026-06-04T12:00:00.000Z"),
+    })
+
+    expect(result.videos.map((item) => item.id)).toEqual(["video-b", "video-d"])
+    expect(result.videos.map((item) => item.poolId)).toEqual([
+      "pool-a",
+      "pool-b",
+    ])
+    expect(result.nextPoolIndex).toBe(2)
+  })
+
+  it("tracks repeated pool failures and marks depleted pools exhausted", () => {
+    addWatchHomeTvPlayedId("video-a")
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      buildWatchHomeVideoQueue({
+        pools: [pool("pool-a", ["video-a"])],
+        targetVideoCount: 1,
+        now: new Date("2026-06-04T12:00:00.000Z"),
+      })
+    }
+
+    expect(
+      window.sessionStorage.getItem(poolFailuresStorageKey("pool-a")),
+    ).toBe("3")
+    expect(
+      JSON.parse(
+        window.sessionStorage.getItem(poolVideosStorageKey("pool-a")) ?? "[]",
+      ),
+    ).toEqual(["exhausted-0"])
+  })
+
+  it("resets monthly played memory after fifty loaded videos so cycling can continue", () => {
+    addWatchHomeTvPlayedId("video-a")
+
+    const result = buildWatchHomeVideoQueue({
+      existingVideos: Array.from({ length: 50 }, (_, index) =>
+        video(`existing-${index}`),
+      ),
+      pools: [pool("pool-a", ["video-a"])],
+      targetVideoCount: 51,
+      now: new Date("2026-06-04T12:00:00.000Z"),
+    })
+
+    expect(readWatchHomeTvPlayedIds()).toEqual([])
+    expect(result.videos.at(-1)?.id).toBe("video-a")
+  })
+
+  it("persists current video session for 24 hours", () => {
+    const selected = {
+      ...video("video-session"),
+      poolId: "pool-a",
+      poolIndex: 2,
+    }
+    saveWatchHomeCurrentVideoSession(selected)
+
+    expect(loadWatchHomeCurrentVideoSession()).toMatchObject({
+      videoId: "video-session",
+      videoTitle: "video-session",
+      poolId: "pool-a",
+      poolIndex: 2,
+    })
+
+    window.sessionStorage.setItem(
+      WATCH_HOME_TV_CURRENT_VIDEO_STORAGE_KEY,
+      JSON.stringify({
+        videoId: "old",
+        videoTitle: "Old",
+        poolId: "pool-a",
+        poolIndex: 0,
+        timestamp: 0,
+      }),
+    )
+
+    expect(loadWatchHomeCurrentVideoSession(new Date("2026-06-04"))).toBeNull()
+  })
+
+  it("merges Mux inserts with date prefix and session-stable playback ids", () => {
+    const slides = mergeWatchHomeMuxInserts(
+      [video("video-1"), video("video-2")],
+      [
+        muxInsert,
+        {
+          ...muxInsert,
+          id: "join-us",
+          playbackIds: ["join-a", "join-b"],
+          title: "Join Us",
+          trigger: { type: "after-count", count: 1 },
+          action: { label: "Join Us", url: "https://example.com" },
+        },
+      ],
+      new Date("2026-06-04T12:00:00.000Z"),
+    )
+
+    expect(slides.map((slide) => slide.id)).toEqual([
+      "mux-welcome-start",
+      "video-1",
+      "mux-join-us",
+      "video-2",
+    ])
+    expect(slides[0]).toMatchObject({
+      kind: "mux",
+      title: "Jun 4: Today's Video Picks",
+      playbackId: "playback-a",
+    })
+    const stored = JSON.parse(
+      window.sessionStorage.getItem(WATCH_HOME_TV_MUX_SELECTIONS_STORAGE_KEY) ??
+        "{}",
+    )
+    expect(["join-a", "join-b"]).toContain(stored["join-us"])
+  })
+})

--- a/apps/web/src/lib/watch-home-carousel-sequence.ts
+++ b/apps/web/src/lib/watch-home-carousel-sequence.ts
@@ -1,0 +1,621 @@
+import type { WatchHomeMuxInsertConfig } from "@/lib/watch-home-config"
+
+export const WATCH_HOME_TV_ADVANCE_THRESHOLD = 95
+export const WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY = "carousel-played-ids"
+export const WATCH_HOME_TV_CURRENT_VIDEO_STORAGE_KEY = "carousel-current-video"
+export const WATCH_HOME_TV_MUX_SELECTIONS_STORAGE_KEY = "mux-insert-selections"
+export const WATCH_HOME_TV_MUX_SELECTIONS_SEED_STORAGE_KEY =
+  "mux-insert-selections-seed"
+
+export type WatchHomeTvCarouselVideoSlide = {
+  kind: "video"
+  id: string
+  title: string
+  description: string | null
+  label: string
+  href: string | null
+  posterUrl: string | null
+  thumbnailUrl: string | null
+  imageAlt: string
+  src: string | null
+  playbackId: string | null
+  durationSeconds: number | null
+  poolId?: string
+  poolIndex?: number
+}
+
+export type WatchHomeTvCarouselMuxSlide = {
+  kind: "mux"
+  id: string
+  title: string
+  description: string | null
+  label: string
+  href: string | null
+  action: { label: string; url: string } | null
+  posterUrl: string | null
+  thumbnailUrl: string | null
+  imageAlt: string
+  src: string | null
+  playbackId: string | null
+  durationSeconds: number | null
+  logo: boolean
+  playbackIndex: number
+}
+
+export type WatchHomeTvCarouselSlide =
+  | WatchHomeTvCarouselVideoSlide
+  | WatchHomeTvCarouselMuxSlide
+
+export type WatchHomeCarouselPool = {
+  id: string
+  collectionIds: readonly string[]
+  videos: readonly WatchHomeTvCarouselVideoSlide[]
+}
+
+export type WatchHomeCarouselSequenceData = {
+  pools: readonly WatchHomeCarouselPool[]
+  muxInserts: readonly WatchHomeMuxInsertConfig[]
+}
+
+export type WatchHomeCurrentVideoSession = {
+  videoId: string
+  videoTitle: string
+  poolIndex: number
+  poolId: string
+  timestamp: number
+}
+
+type PlayedIdsStorageValue = {
+  month?: unknown
+  ids?: unknown
+}
+
+type QueueBuildInput = {
+  pools: readonly WatchHomeCarouselPool[]
+  existingVideos?: readonly WatchHomeTvCarouselVideoSlide[]
+  playedIds?: readonly string[]
+  startPoolIndex?: number
+  targetVideoCount: number
+  now?: Date
+}
+
+function simpleHash(value: string): number {
+  let hash = 0
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i)
+    hash &= hash
+  }
+  return Math.abs(hash)
+}
+
+function safeParseJson<T>(value: string | null, fallback: T): T {
+  if (value == null) return fallback
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+function currentStorageMonth(now = new Date()) {
+  return now.toISOString().slice(0, 7)
+}
+
+function businessDate(now: Date) {
+  return now.toLocaleDateString("en-CA", {
+    timeZone: "America/New_York",
+  })
+}
+
+export function getWatchHomeDeterministicOffset(
+  poolId: string,
+  videoCount: number,
+  options: {
+    now?: Date
+    poolIndex?: number
+    totalVideosLoaded?: number
+  } = {},
+): number {
+  if (videoCount <= 0) return 0
+
+  const now = options.now ?? new Date()
+  let seed = `${businessDate(now)}${poolId}`
+
+  if (options.poolIndex != null) {
+    seed += `-cycle${Math.floor(options.poolIndex / 15)}`
+  }
+  if (options.totalVideosLoaded != null) {
+    seed += `-prog${Math.floor(options.totalVideosLoaded / 10)}`
+  }
+
+  return simpleHash(seed) % videoCount
+}
+
+export function readWatchHomeTvPlayedIds(now = new Date()): string[] {
+  if (typeof window === "undefined") return []
+
+  try {
+    const stored = localStorage.getItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY)
+    if (!stored) return []
+
+    const data = JSON.parse(stored) as PlayedIdsStorageValue
+    if (data.month !== currentStorageMonth(now)) {
+      localStorage.removeItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY)
+      return []
+    }
+
+    return Array.isArray(data.ids)
+      ? data.ids.filter((id): id is string => typeof id === "string")
+      : []
+  } catch {
+    return []
+  }
+}
+
+export function resetWatchHomeTvPlayedIds() {
+  if (typeof window === "undefined") return
+
+  try {
+    localStorage.removeItem(WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY)
+  } catch {
+    // Ignore storage errors from private browsing or disabled storage.
+  }
+}
+
+export function addWatchHomeTvPlayedId(slideId: string, now = new Date()) {
+  if (typeof window === "undefined") return
+
+  try {
+    const current = readWatchHomeTvPlayedIds(now)
+    const ids = current.includes(slideId) ? current : [...current, slideId]
+    localStorage.setItem(
+      WATCH_HOME_TV_PLAYED_IDS_STORAGE_KEY,
+      JSON.stringify({
+        month: currentStorageMonth(now),
+        ids,
+      }),
+    )
+  } catch {
+    // Ignore storage errors from private browsing or disabled storage.
+  }
+}
+
+export function poolVideosStorageKey(poolId: string) {
+  return `pool-${poolId}-videos`
+}
+
+export function poolFailuresStorageKey(poolId: string) {
+  return `pool-${poolId}-failures`
+}
+
+export function readWatchHomePoolPlayedIds(poolId: string): string[] {
+  if (typeof window === "undefined") return []
+
+  try {
+    const value = sessionStorage.getItem(poolVideosStorageKey(poolId))
+    return safeParseJson<string[]>(value, []).filter(
+      (id): id is string => typeof id === "string",
+    )
+  } catch {
+    return []
+  }
+}
+
+function readWatchHomePoolFailures(poolId: string): number {
+  if (typeof window === "undefined") return 0
+
+  try {
+    const value = sessionStorage.getItem(poolFailuresStorageKey(poolId))
+    const failures = Number.parseInt(value ?? "0", 10)
+    return Number.isFinite(failures) ? failures : 0
+  } catch {
+    return 0
+  }
+}
+
+function resetWatchHomePoolFailures(poolId: string) {
+  if (typeof window === "undefined") return
+
+  try {
+    sessionStorage.removeItem(poolFailuresStorageKey(poolId))
+  } catch {
+    // Ignore storage errors from private browsing or disabled storage.
+  }
+}
+
+function markWatchHomePoolFailure(poolId: string, videoCount: number) {
+  if (typeof window === "undefined") return
+
+  try {
+    const failures = readWatchHomePoolFailures(poolId) + 1
+    sessionStorage.setItem(poolFailuresStorageKey(poolId), String(failures))
+
+    if (failures < 3) return
+
+    const played = readWatchHomePoolPlayedIds(poolId)
+    const exhausted = [...played]
+    for (let index = exhausted.length; index < videoCount; index++) {
+      exhausted.push(`exhausted-${index}`)
+    }
+    sessionStorage.setItem(
+      poolVideosStorageKey(poolId),
+      JSON.stringify(exhausted),
+    )
+  } catch {
+    // Ignore storage errors from private browsing or disabled storage.
+  }
+}
+
+export function isWatchHomePoolExhausted(poolId: string, videoCount: number) {
+  if (videoCount <= 0) return true
+  return new Set(readWatchHomePoolPlayedIds(poolId)).size >= videoCount
+}
+
+export function markWatchHomePoolVideoPlayed(poolId: string, videoId: string) {
+  if (typeof window === "undefined") return
+
+  try {
+    const current = readWatchHomePoolPlayedIds(poolId)
+    if (current.includes(videoId)) return
+    sessionStorage.setItem(
+      poolVideosStorageKey(poolId),
+      JSON.stringify([...current, videoId]),
+    )
+  } catch {
+    // Ignore storage errors from private browsing or disabled storage.
+  }
+}
+
+export function markWatchHomeVideoPlayed(
+  slide: WatchHomeTvCarouselSlide | null,
+) {
+  if (!slide || slide.kind !== "video") return
+
+  addWatchHomeTvPlayedId(slide.id)
+  if (slide.poolId) {
+    markWatchHomePoolVideoPlayed(slide.poolId, slide.id)
+  }
+}
+
+export function saveWatchHomeCurrentVideoSession(
+  slide: WatchHomeTvCarouselSlide | null,
+) {
+  if (typeof window === "undefined" || !slide || slide.kind !== "video") {
+    return
+  }
+
+  try {
+    const session: WatchHomeCurrentVideoSession = {
+      videoId: slide.id,
+      videoTitle: slide.title,
+      poolIndex: slide.poolIndex ?? 0,
+      poolId: slide.poolId ?? "unknown",
+      timestamp: Date.now(),
+    }
+    sessionStorage.setItem(
+      WATCH_HOME_TV_CURRENT_VIDEO_STORAGE_KEY,
+      JSON.stringify(session),
+    )
+  } catch {
+    // Ignore storage errors from private browsing or disabled storage.
+  }
+}
+
+export function loadWatchHomeCurrentVideoSession(
+  now = new Date(),
+): WatchHomeCurrentVideoSession | null {
+  if (typeof window === "undefined") return null
+
+  try {
+    const stored = sessionStorage.getItem(
+      WATCH_HOME_TV_CURRENT_VIDEO_STORAGE_KEY,
+    )
+    const parsed = safeParseJson<WatchHomeCurrentVideoSession | null>(
+      stored,
+      null,
+    )
+    if (!parsed || typeof parsed.videoId !== "string") return null
+
+    const ageMs = now.getTime() - parsed.timestamp
+    if (ageMs > 24 * 60 * 60 * 1000) {
+      sessionStorage.removeItem(WATCH_HOME_TV_CURRENT_VIDEO_STORAGE_KEY)
+      return null
+    }
+
+    return parsed
+  } catch {
+    try {
+      sessionStorage.removeItem(WATCH_HOME_TV_CURRENT_VIDEO_STORAGE_KEY)
+    } catch {
+      // Ignore storage errors from private browsing or disabled storage.
+    }
+    return null
+  }
+}
+
+export function buildWatchHomeVideoQueue({
+  existingVideos = [],
+  now = new Date(),
+  playedIds,
+  pools,
+  startPoolIndex = 0,
+  targetVideoCount,
+}: QueueBuildInput): {
+  videos: WatchHomeTvCarouselVideoSlide[]
+  nextPoolIndex: number
+} {
+  if (targetVideoCount <= existingVideos.length || pools.length === 0) {
+    return { videos: [...existingVideos], nextPoolIndex: startPoolIndex }
+  }
+
+  if (existingVideos.length > 0 && existingVideos.length % 50 === 0) {
+    resetWatchHomeTvPlayedIds()
+  }
+
+  const videos = [...existingVideos]
+  const seen = new Set(videos.map((video) => video.id))
+  const persistentPlayed = new Set(playedIds ?? readWatchHomeTvPlayedIds(now))
+  let poolIndex = Math.max(0, startPoolIndex)
+  let attempts = 0
+  const maxAttempts = Math.max(pools.length * 4, targetVideoCount * 6)
+
+  while (videos.length < targetVideoCount && attempts < maxAttempts) {
+    const pool = pools[poolIndex % pools.length]
+    attempts += 1
+
+    if (!pool || isWatchHomePoolExhausted(pool.id, pool.videos.length)) {
+      poolIndex += 1
+      continue
+    }
+
+    const poolPlayed = new Set(readWatchHomePoolPlayedIds(pool.id))
+    const candidates = pool.videos.filter(
+      (video) =>
+        Boolean(video.src) &&
+        !seen.has(video.id) &&
+        !persistentPlayed.has(video.id) &&
+        !poolPlayed.has(video.id),
+    )
+
+    if (candidates.length === 0) {
+      markWatchHomePoolFailure(pool.id, pool.videos.length)
+      poolIndex += 1
+      continue
+    }
+
+    const offset = getWatchHomeDeterministicOffset(pool.id, candidates.length, {
+      now,
+      poolIndex,
+      totalVideosLoaded: videos.length,
+    })
+    const candidate = candidates[offset]
+    if (candidate) {
+      const video = {
+        ...candidate,
+        poolId: pool.id,
+        poolIndex,
+      }
+      videos.push(video)
+      seen.add(video.id)
+      resetWatchHomePoolFailures(pool.id)
+    }
+
+    poolIndex += 1
+  }
+
+  return { videos, nextPoolIndex: poolIndex }
+}
+
+function muxStreamUrl(playbackId: string) {
+  return `https://stream.mux.com/${playbackId}.m3u8`
+}
+
+function muxPosterUrl(playbackId: string, width = 1280) {
+  return `https://image.mux.com/${playbackId}/thumbnail.jpg?width=${width}&height=720&fit_mode=smartcrop`
+}
+
+function datePrefix(now: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "America/New_York",
+  }).format(now)
+}
+
+function timeRangeMatches(start: number, end: number, hour: number) {
+  if (start === end) return true
+  if (start < end) return hour >= start && hour < end
+  return hour >= start || hour < end
+}
+
+function currentEasternHour(now: Date) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    hour12: false,
+    timeZone: "America/New_York",
+  }).formatToParts(now)
+  const hour = parts.find((part) => part.type === "hour")?.value
+  return hour ? Number(hour) : now.getHours()
+}
+
+function overlayForInsert(insert: WatchHomeMuxInsertConfig, now: Date) {
+  const overlays = insert.conditionalOverlays ?? []
+  const hour = currentEasternHour(now)
+  const selected = overlays
+    .filter((overlay) =>
+      overlay.conditions.every((condition) =>
+        condition.type === "time-range"
+          ? timeRangeMatches(condition.range.start, condition.range.end, hour)
+          : false,
+      ),
+    )
+    .sort((a, b) => b.priority - a.priority)[0]
+
+  if (!selected) {
+    return {
+      label: insert.label,
+      title: insert.title,
+      collectionTitle: insert.collectionTitle,
+      description: insert.description,
+      action: insert.action,
+    }
+  }
+
+  return {
+    label: selected.overlay.label,
+    title: selected.overlay.title,
+    collectionTitle: selected.overlay.collectionTitle,
+    description: selected.overlay.description,
+    action: selected.overlay.action ?? insert.action,
+  }
+}
+
+function readMuxSelections(): Record<string, string> {
+  if (typeof window === "undefined") return {}
+
+  try {
+    return safeParseJson<Record<string, string>>(
+      sessionStorage.getItem(WATCH_HOME_TV_MUX_SELECTIONS_STORAGE_KEY),
+      {},
+    )
+  } catch {
+    return {}
+  }
+}
+
+function writeMuxSelection(insertId: string, playbackId: string) {
+  if (typeof window === "undefined") return
+
+  try {
+    const selections = readMuxSelections()
+    sessionStorage.setItem(
+      WATCH_HOME_TV_MUX_SELECTIONS_STORAGE_KEY,
+      JSON.stringify({ ...selections, [insertId]: playbackId }),
+    )
+  } catch {
+    // Ignore storage errors from private browsing or disabled storage.
+  }
+}
+
+function getMuxSessionSeed(): string | undefined {
+  if (typeof window === "undefined") return undefined
+
+  try {
+    const existing = sessionStorage.getItem(
+      WATCH_HOME_TV_MUX_SELECTIONS_SEED_STORAGE_KEY,
+    )
+    if (existing) return existing
+    const seed =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    sessionStorage.setItem(WATCH_HOME_TV_MUX_SELECTIONS_SEED_STORAGE_KEY, seed)
+    return seed
+  } catch {
+    return undefined
+  }
+}
+
+function selectMuxPlaybackId(insert: WatchHomeMuxInsertConfig): {
+  playbackId: string | null
+  playbackIndex: number
+} {
+  const playbackIds = insert.playbackIds.filter(Boolean)
+  if (playbackIds.length === 0) return { playbackId: null, playbackIndex: -1 }
+
+  const stored = readMuxSelections()[insert.id]
+  if (stored && playbackIds.includes(stored)) {
+    return { playbackId: stored, playbackIndex: playbackIds.indexOf(stored) }
+  }
+
+  const seed = getMuxSessionSeed()
+  const index =
+    simpleHash(`${seed ?? "watch-home"}:${insert.id}`) % playbackIds.length
+  const playbackId = playbackIds[index]
+  if (!playbackId) return { playbackId: null, playbackIndex: -1 }
+
+  writeMuxSelection(insert.id, playbackId)
+  return { playbackId, playbackIndex: index }
+}
+
+function muxInsertToSlide(
+  insert: WatchHomeMuxInsertConfig,
+  options: { now: Date; prefixTitleWithDate?: boolean },
+): WatchHomeTvCarouselMuxSlide | null {
+  const { playbackId, playbackIndex } = selectMuxPlaybackId(insert)
+  if (!playbackId) return null
+
+  const overlay = overlayForInsert(insert, options.now)
+  const title = options.prefixTitleWithDate
+    ? `${datePrefix(options.now)}: ${overlay.title}`
+    : overlay.title
+  const posterUrl = insert.posterOverride ?? muxPosterUrl(playbackId)
+
+  return {
+    kind: "mux",
+    id: `mux-${insert.id}`,
+    title,
+    description: overlay.description,
+    label: overlay.label,
+    href: null,
+    action: overlay.action,
+    posterUrl,
+    thumbnailUrl: muxPosterUrl(playbackId, 640),
+    imageAlt: title,
+    src: muxStreamUrl(playbackId),
+    playbackId,
+    durationSeconds: insert.durationSeconds,
+    logo: insert.logo,
+    playbackIndex,
+  }
+}
+
+export function mergeWatchHomeMuxInserts(
+  videos: readonly WatchHomeTvCarouselVideoSlide[],
+  inserts: readonly WatchHomeMuxInsertConfig[],
+  now = new Date(),
+): WatchHomeTvCarouselSlide[] {
+  const enabled = inserts.filter((insert) => insert.enabled)
+  if (enabled.length === 0) return [...videos]
+
+  const sequenceStart = enabled.filter(
+    (insert) => insert.trigger.type === "sequence-start",
+  )
+  const afterCount = enabled.filter(
+    (
+      insert,
+    ): insert is WatchHomeMuxInsertConfig & {
+      trigger: { type: "after-count"; count: number }
+    } => insert.trigger.type === "after-count",
+  )
+  const inserted = new Set<string>()
+  const slides: WatchHomeTvCarouselSlide[] = []
+  const firstStartId = sequenceStart[0]?.id
+
+  for (const insert of sequenceStart) {
+    const slide = muxInsertToSlide(insert, {
+      now,
+      prefixTitleWithDate: insert.id === firstStartId,
+    })
+    if (slide) {
+      slides.push(slide)
+      inserted.add(insert.id)
+    }
+  }
+
+  videos.forEach((video, index) => {
+    slides.push(video)
+
+    for (const insert of afterCount) {
+      if (inserted.has(insert.id)) continue
+      if (index + 1 < insert.trigger.count) continue
+      const slide = muxInsertToSlide(insert, { now })
+      if (slide) {
+        slides.push(slide)
+        inserted.add(insert.id)
+      }
+    }
+  })
+
+  return slides
+}

--- a/apps/web/src/lib/watch-home-config.ts
+++ b/apps/web/src/lib/watch-home-config.ts
@@ -3,6 +3,39 @@ export type WatchHomeSourceConfig = {
   limitChildren?: number
 }
 
+export type WatchHomePlaylistGroup = readonly string[]
+
+export type WatchHomeMuxInsertConfig = {
+  id: string
+  enabled: boolean
+  playbackIds: readonly string[]
+  durationSeconds: number | null
+  label: string
+  title: string
+  collectionTitle: string | null
+  description: string | null
+  action: { label: string; url: string } | null
+  logo: boolean
+  posterOverride: string | null
+  trigger: { type: "sequence-start" } | { type: "after-count"; count: number }
+  conditionalOverlays?: readonly WatchHomeConditionalOverlay[]
+}
+
+export type WatchHomeConditionalOverlay = {
+  priority: number
+  conditions: readonly {
+    type: "time-range"
+    range: { start: number; end: number }
+  }[]
+  overlay: {
+    label: string
+    title: string
+    collectionTitle: string | null
+    description: string | null
+    action?: { label: string; url: string } | null
+  }
+}
+
 export type WatchHomeSectionConfig = {
   id: string
   eyebrow: string
@@ -16,7 +49,7 @@ export type WatchHomeSectionConfig = {
   childLimit?: number
 }
 
-export const WATCH_HOME_CACHE_VERSION = "v2-course-children"
+export const WATCH_HOME_CACHE_VERSION = "v3-carousel-sequence"
 
 export const collectionShowcaseSources = [
   { id: "1_jf-0-0", limitChildren: 0 },
@@ -61,6 +94,121 @@ export const WATCH_HOME_HERO_SOURCE_IDS = [
   "2_GOJ-0-0",
   "GOMattCollection",
   "LUMOCollection",
+] as const
+
+// Ported from JesusFilm/core apps/watch/config/video-playlist.json.
+// These are Core/Arclight ids, stored in admin as Video.coreId.
+export const WATCH_HOME_PLAYLIST_SEQUENCE: readonly WatchHomePlaylistGroup[] = [
+  ["1_jf-0-0"],
+  ["JFP-Featured"],
+  ["8_NBC"],
+  [
+    "GOJohnCollection",
+    "GOLukeCollection",
+    "GOMarkCollection",
+    "GOMattCollection",
+  ],
+  ["7_Origins", "Nua", "2_ElCamWaySJEN"],
+  ["MAG1"],
+  ["11_Sermon", "11_Shema", "11_ReadBible", "11_Advent"],
+  ["2_GOJ-0-0"],
+  ["CS1"],
+  ["9_CreationtoChrist"],
+  ["2_FileZero-0-0"],
+  ["10_DarkroomFaith"],
+] as const
+
+export const WATCH_HOME_COLLECTION_BLACKLIST = new Set(["7_Origins4Connect"])
+
+// Ported from JesusFilm/core apps/watch/config/video-inserts.mux.json.
+// Keep this as Forge fallback data until admin owns insert editorial metadata.
+export const WATCH_HOME_MUX_INSERTS: readonly WatchHomeMuxInsertConfig[] = [
+  {
+    id: "welcome-start",
+    enabled: true,
+    playbackIds: ["34eG2PxlcRu3L4wU5XlKVna2vN3BAI02Tjrq28dazn3Y"],
+    durationSeconds: 9,
+    label: "Faith & Scripture",
+    title: "Today's Video Picks",
+    collectionTitle: "Daily Inspirations",
+    description:
+      "Faith-centered video content from our library to inspire, challenge, and spark reflection.",
+    action: null,
+    logo: true,
+    posterOverride: null,
+    trigger: { type: "sequence-start" },
+    conditionalOverlays: [
+      {
+        priority: 10,
+        conditions: [{ type: "time-range", range: { start: 5, end: 9 } }],
+        overlay: {
+          label: "Morning Inspiration",
+          title: "Good Morning! Today's Bible Moments Await.",
+          collectionTitle: "Morning Moments",
+          description:
+            "Begin your day with encouraging Bible moments designed to inspire and uplift your spirit.",
+        },
+      },
+      {
+        priority: 10,
+        conditions: [{ type: "time-range", range: { start: 12, end: 17 } }],
+        overlay: {
+          label: "Afternoon Inspiration",
+          title: "Good Afternoon! Bible Moments for Your Day.",
+          collectionTitle: "Afternoon Moments",
+          description:
+            "Encouraging Bible content perfect for your afternoon break or continued inspiration.",
+        },
+      },
+      {
+        priority: 10,
+        conditions: [{ type: "time-range", range: { start: 17, end: 21 } }],
+        overlay: {
+          label: "Evening Inspiration",
+          title: "Good Evening! Wind Down with Bible Moments.",
+          collectionTitle: "Evening Moments",
+          description:
+            "Peaceful Bible moments to help you reflect and find comfort as your day comes to a close.",
+        },
+      },
+    ],
+  },
+  {
+    id: "join-us",
+    enabled: true,
+    playbackIds: ["VN4b95KOO3JtLg3x019dH2mzMHPL4le65vRmXFONyzZ8"],
+    durationSeconds: null,
+    label: "Join Us",
+    title: "Billions are searching",
+    collectionTitle: "Highlights",
+    description:
+      "The harvest is here. Join us as we share the gospel with the world using digital media.",
+    action: {
+      label: "Join Us",
+      url: "https://your.nextstep.is/joinus",
+    },
+    logo: false,
+    posterOverride: null,
+    trigger: { type: "after-count", count: 1 },
+  },
+  {
+    id: "telling-the-story-of-jesus",
+    enabled: true,
+    playbackIds: ["W00xXnOS4kU8VVMgx4M6AdzZE63OnKk300HdEDeUYZqlQ"],
+    durationSeconds: null,
+    label: "Let's go together",
+    title: "Telling the Story of Jesus, Together",
+    collectionTitle: "Highlights",
+    description:
+      "So they can hear and see the love of Jesus in their own language right where they are.",
+    action: {
+      label: "Share in Our Mission",
+      url: "https://www.jesusfilm.org/partners/",
+    },
+    logo: false,
+    posterOverride: null,
+    trigger: { type: "after-count", count: 3 },
+  },
 ] as const
 
 export const WATCH_HOME_SECTIONS: readonly WatchHomeSectionConfig[] = [
@@ -144,7 +292,10 @@ export function getWatchHomeCoreIds(): string[] {
       section.primaryCollectionId,
       ...(section.sources ?? []).map((source) => source.id),
     ]),
-  ].filter((id): id is string => typeof id === "string")
+  ].filter(
+    (id): id is string =>
+      typeof id === "string" && !WATCH_HOME_COLLECTION_BLACKLIST.has(id),
+  )
 
   return [...new Set(ids)]
 }

--- a/apps/web/src/lib/watch-home.ts
+++ b/apps/web/src/lib/watch-home.ts
@@ -13,13 +13,21 @@ import {
   watchVideoPath,
 } from "@/lib/routes"
 import {
+  WATCH_HOME_MUX_INSERTS,
+  WATCH_HOME_PLAYLIST_SEQUENCE,
   getWatchHomeCoreIds,
   WATCH_HOME_CACHE_VERSION,
+  WATCH_HOME_COLLECTION_BLACKLIST,
   WATCH_HOME_HERO_SOURCE_IDS,
   WATCH_HOME_SECTIONS,
   type WatchHomeSectionConfig,
   type WatchHomeSourceConfig,
 } from "@/lib/watch-home-config"
+import type {
+  WatchHomeCarouselPool,
+  WatchHomeCarouselSequenceData,
+  WatchHomeTvCarouselVideoSlide,
+} from "@/lib/watch-home-carousel-sequence"
 import { getWatchHomeVideosOperation } from "@/lib/fragments/watch-home"
 
 type WatchHomeVideosData = AdminResultOf<typeof getWatchHomeVideosOperation>
@@ -84,6 +92,7 @@ export type WatchHomeSection = {
 export type WatchHomeModel = {
   heroSlides: WatchHomeHeroSlide[]
   sections: WatchHomeSection[]
+  carousel: WatchHomeCarouselSequenceData
   missingData: WatchHomeMissingData[]
 }
 
@@ -428,6 +437,147 @@ function buildSections(args: {
   }).filter((section) => section.cards.length > 0)
 }
 
+function cardToCarouselSlide(
+  card: WatchHomeCard,
+): WatchHomeTvCarouselVideoSlide | null {
+  if (!card.hls) return null
+  if (WATCH_HOME_COLLECTION_BLACKLIST.has(card.coreId)) return null
+
+  return {
+    kind: "video",
+    id: card.coreId,
+    title: card.title,
+    description: card.description,
+    label: card.label,
+    href: card.href,
+    posterUrl: card.imageUrl,
+    thumbnailUrl: card.imageUrl,
+    imageAlt: card.imageAlt,
+    src: card.hls,
+    playbackId: card.playbackId,
+    durationSeconds: card.durationSeconds,
+  }
+}
+
+function playableSlidesForSource(args: {
+  sectionId: string
+  sourceId: string
+  videoByCoreId: Map<string, AdminHomeVideo>
+  languageSlug: string
+  missingData: WatchHomeMissingData[]
+}): WatchHomeTvCarouselVideoSlide[] {
+  if (WATCH_HOME_COLLECTION_BLACKLIST.has(args.sourceId)) return []
+
+  const parent = args.videoByCoreId.get(args.sourceId)
+  if (!parent) {
+    args.missingData.push(
+      missingEntry({
+        sectionId: args.sectionId,
+        sourceId: args.sourceId,
+        field: "record",
+        detail: `Admin watchHomeVideos did not return carousel pool source Core id ${args.sourceId}.`,
+        fallback: "Pool skipped",
+        followUp:
+          "Verify the Core id exists in admin sync or replace the carousel playlist source.",
+      }),
+    )
+    return []
+  }
+
+  const childSlides = (parent.children ?? [])
+    .map((rel) =>
+      rel.child
+        ? normalizeCard({
+            sectionId: args.sectionId,
+            sourceId: args.sourceId,
+            video: rel.child,
+            parent,
+            languageSlug: args.languageSlug,
+          })
+        : null,
+    )
+    .filter((card): card is WatchHomeCard => card != null)
+    .map(cardToCarouselSlide)
+    .filter((slide): slide is WatchHomeTvCarouselVideoSlide => slide != null)
+
+  if (childSlides.length > 0) return childSlides
+
+  const card = normalizeCard({
+    sectionId: args.sectionId,
+    sourceId: args.sourceId,
+    video: parent,
+    languageSlug: args.languageSlug,
+  })
+  const slide = card ? cardToCarouselSlide(card) : null
+  return slide ? [slide] : []
+}
+
+function buildCarouselPools(args: {
+  videoByCoreId: Map<string, AdminHomeVideo>
+  languageSlug: string
+  missingData: WatchHomeMissingData[]
+}): WatchHomeCarouselPool[] {
+  const pools = WATCH_HOME_PLAYLIST_SEQUENCE.map((group, index) => {
+    const collectionIds = group.filter(
+      (id) => !WATCH_HOME_COLLECTION_BLACKLIST.has(id),
+    )
+    const videos = collectionIds.flatMap((sourceId) =>
+      playableSlidesForSource({
+        sectionId: "home-carousel",
+        sourceId,
+        videoByCoreId: args.videoByCoreId,
+        languageSlug: args.languageSlug,
+        missingData: args.missingData,
+      }),
+    )
+
+    return {
+      id: `playlist-${index}-${collectionIds.join("|")}`,
+      collectionIds,
+      videos,
+    }
+  }).filter((pool) => pool.videos.length > 0)
+
+  const shortFilmById = new Map<string, WatchHomeTvCarouselVideoSlide>()
+  for (const video of args.videoByCoreId.values()) {
+    const cards: WatchHomeCard[] = []
+    const parentCard = normalizeCard({
+      sectionId: "home-carousel-short-films",
+      sourceId: video.coreId ?? video.documentId ?? "unknown",
+      video,
+      languageSlug: args.languageSlug,
+    })
+    if (parentCard) cards.push(parentCard)
+    for (const rel of video.children ?? []) {
+      if (!rel.child || rel.child.label !== "SHORT_FILM") continue
+      const childCard = normalizeCard({
+        sectionId: "home-carousel-short-films",
+        sourceId: video.coreId ?? video.documentId ?? "unknown",
+        video: rel.child,
+        parent: video,
+        languageSlug: args.languageSlug,
+      })
+      if (childCard) cards.push(childCard)
+    }
+
+    for (const card of cards) {
+      if (card.label !== "Short film") continue
+      const slide = cardToCarouselSlide(card)
+      if (slide) shortFilmById.set(slide.id, slide)
+    }
+  }
+
+  if (shortFilmById.size > 0) {
+    pools.push({
+      id: "shortFilms",
+      collectionIds: ["shortFilms"],
+      videos: [...shortFilmById.values()],
+    })
+  }
+
+  return pools
+}
+
 function dedupeMissingData(
   missingData: readonly WatchHomeMissingData[],
 ): WatchHomeMissingData[] {
@@ -507,6 +657,10 @@ export function buildWatchHomeModelFromVideos(args: {
   })
 
   const sections = buildSections({ videoByCoreId, languageSlug, missingData })
+  const carousel = {
+    pools: buildCarouselPools({ videoByCoreId, languageSlug, missingData }),
+    muxInserts: WATCH_HOME_MUX_INSERTS,
+  }
   const cardMissing = [
     ...heroSlides.flatMap((card) => card.missingData),
     ...sections.flatMap((section) =>
@@ -517,6 +671,7 @@ export function buildWatchHomeModelFromVideos(args: {
   return {
     heroSlides,
     sections,
+    carousel,
     missingData: dedupeMissingData([...missingData, ...cardMissing]),
   }
 }

--- a/docs/plans/2026-06-05-002-feat-watch-home-carousel-sequence-parity-plan.md
+++ b/docs/plans/2026-06-05-002-feat-watch-home-carousel-sequence-parity-plan.md
@@ -1,0 +1,418 @@
+---
+title: Source-parity watch home carousel sequence
+type: feat
+status: complete
+date: "2026-06-05"
+roadmap: docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md
+source_plan: docs/plans/2026-06-04-003-feat-watch-home-modernization-plan.md
+---
+
+# Source-parity watch home carousel sequence
+
+## Summary
+
+Implement the full Core watch-home carousel behavior on top of the merged Forge carousel: source data remains admin-backed, the current home page sections stay intact, and the client gains the original sequence engine semantics for progressive loading, played-video memory, pool exhaustion, current-session state, and Mux insert handling.
+
+---
+
+## Problem Frame
+
+`feat-159` delivered the portable TV-like carousel and admin-backed slide data, but it still behaves like a bounded flat carousel. The original Core experience is stateful: it progressively picks videos from playlist pools, remembers what the viewer has already seen, avoids repeating videos, inserts Mux editorial clips at defined positions, and keeps playback moving as the user skips, completes, or manually selects items.
+
+---
+
+## Requirements
+
+- R1. Preserve the existing Forge `/watch` home page composition: only the intro carousel behavior should change, and below-the-fold admin sections must continue to render.
+- R2. Match Core's playlist pool sequence, including grouped collection pools, the injected `shortFilms` pool after each playlist cycle, blacklist filtering, and deterministic daily selection.
+- R3. Match Core's browser storage contract: monthly persistent played-video memory, session pool exhaustion/failure tracking, and 24-hour current-video session state.
+- R4. Match Core's progressive loading behavior: initial prefetch target of seven videos, then one video ahead during playback, with one in-flight load at a time.
+- R5. Match Core's active-slide behavior: progress threshold advance near 95 percent, ended advance, explicit skip, manual card selection, and Mux insert completion handoff.
+- R6. Match Core's Mux insert behavior where data is available: sequence-start inserts, after-count inserts, session-stable playback selection, first start insert date prefix, and conditional time-of-day overlays.
+- R7. Keep all runtime video, collection, language, image, title, and route data flowing through admin GraphQL and `@forge/admin-graphql`; do not add Core, Arclight, or Algolia runtime dependencies to `apps/web`.
+- R8. Build public watch links with the existing route helpers and active/fallback audio-language slugs, never with message-catalog locale keys.
+- R9. Keep the carousel hydration-safe and resilient when `localStorage`/`sessionStorage` is unavailable, corrupt, stale, or blocked.
+- R10. Document any admin/source-data gaps that remain after implementation as follow-up work, not hidden behavior differences.
+- R11. Verify visually against the live New Design experience on `https://www.jesusfilm.org/watch` and local `/watch` on desktop and mobile.
+
+---
+
+## Scope Boundaries
+
+- This plan does not replace the rest of the current Forge home page or re-port Core's full below-the-fold `CollectionsRail`.
+- This plan does not add upstream `apps/watch-modern` or `apps/watch` package imports; Core source is a behavior reference only.
+- This plan does not introduce a new global search UI or Algolia search path.
+- This plan does not rewrite the watch-page player surface; the home carousel should stay local to `apps/web/src/components/home`.
+- This plan does not make playlist or Mux insert editing fully admin-configurable unless the required admin model already exists cheaply enough to reuse.
+
+### Deferred to Follow-Up Work
+
+- Admin-owned editorial management for playlist order, pool groups, blacklists, Mux insert records, conditional overlays, action links, and logo flags.
+- Admin media-asset parity for upstream local poster/thumbnail overrides, blurhash placeholders, and dominant-color placeholders.
+- Bounded admin pool/count endpoints for playlist-only carousel sources; the current broad `watchHomeVideos` payload times out when every upstream playlist Core ID is requested at once.
+- Full admin-backed below-the-fold Core `CollectionsRail` parity.
+- Stronger editorial tooling for language-specific fallbacks when a requested language has too few playable videos.
+- Analytics instrumentation for carousel sequence events, unless an existing home-carousel event surface is discovered during implementation.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/web/src/components/home/WatchHomePage.tsx` wraps the TV carousel above the existing Forge home sections, promo, and footer.
+- `apps/web/src/components/home/WatchHomeTvCarousel.tsx` owns the visual shell, media layer, overlay controls, and Embla thumbnail rail.
+- `apps/web/src/components/home/useWatchHomeTvCarousel.ts` currently handles simple active index, mute, progress, image-slide fallback timing, and monthly localStorage played IDs.
+- `apps/web/src/lib/watch-home.ts` currently fetches static configured admin home records, normalizes hero slides/sections, and reports missing data.
+- `apps/web/src/lib/watch-home-config.ts` currently defines static hero and section Core IDs for the merged home page.
+- `apps/admin/src/services/video.service.ts` supports list/count filters for category, collection, language, search, sort, limit, and offset.
+- `apps/admin/src/graphql/types/video.ts` exposes the public `videos(...)` resolver and can be extended if the carousel needs a narrower pool contract.
+- `apps/web/AGENTS.md` and `apps/web/CLAUDE.md` require admin GraphQL data access, server-only admin credentials, RSC boundaries, and correct public audio-language slugs.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md` establishes the pattern for compact admin-owned read contracts consumed by web when request-time rediscovery would be expensive.
+- `docs/solutions/design-patterns/embla-carousel-bleed-alignment-port-pattern-20260508.md` documents the Embla rail alignment and test-polyfill pitfalls to preserve if the thumbnail rail is adjusted.
+- `docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md` already tracks data gaps from the first carousel PR, including collection count/pool endpoints and admin-owned insert metadata.
+
+### External References
+
+- Core `useWatchHeroCarousel`: `https://github.com/JesusFilm/core/blob/main/apps/watch/src/components/PageMain/useWatchHeroCarousel.ts`
+- Core `useCarouselVideos`: `https://github.com/JesusFilm/core/blob/main/apps/watch/src/components/VideoHero/libs/useCarouselVideos/useCarouselVideos.ts`
+- Core carousel storage/selection utilities: `https://github.com/JesusFilm/core/blob/main/apps/watch/src/components/VideoHero/libs/useCarouselVideos/utils.ts`
+- Core Mux insert merge logic: `https://github.com/JesusFilm/core/blob/main/apps/watch/src/components/VideoHero/libs/useCarouselVideos/insertMux.ts`
+- Core playlist config: `https://github.com/JesusFilm/core/blob/main/apps/watch/config/video-playlist.json`
+- Core Mux insert config: `https://github.com/JesusFilm/core/blob/main/apps/watch/config/video-inserts.mux.json`
+
+---
+
+## Key Technical Decisions
+
+- Build a Forge-native sequence engine rather than importing Core code: Core uses Apollo/Arclight, generated Core types, and app-specific player context that would violate Forge's admin-backed web boundary.
+- Keep server and client responsibilities separate: server-side Forge resolves admin-backed pool candidates and metadata; the client owns browser storage, active sequence state, and progressive loading decisions.
+- Preserve Core storage key semantics unless implementation discovers an unavoidable collision: using `carousel-played-ids`, `carousel-current-video`, and `mux-insert-selections` keeps behavior closest to source and makes manual QA against Core easier.
+- Add a narrow admin pool contract only if the current `videos(...)` query cannot support source-parity selection without broad overfetch. The preferred shape is an admin-owned count/children read model, following the route-manifest pattern, rather than moving relation walking into the browser.
+- Treat static Forge playlist/Mux configs as migration fallback data for this behavior PR. Admin editorialization is a follow-up unless an existing admin block or media model can represent the data without widening scope.
+- Characterize behavior before refactoring the hook. The current tests are flat-carousel tests; source parity needs storage, sequence, duplicate, pool-exhaustion, and insert tests before the UI wiring changes.
+
+---
+
+## High-Level Technical Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```mermaid
+flowchart LR
+  A["WatchHomePage server route"] --> B["resolveWatchHome(locale)"]
+  B --> C["Admin GraphQL pool data"]
+  B --> D["Serializable carousel seed data"]
+  D --> E["WatchHomeTvCarousel"]
+  E --> F["useWatchHomeTvCarousel"]
+  F --> G["Sequence engine"]
+  G --> H["localStorage: monthly played ids"]
+  G --> I["sessionStorage: pool failures, pool videos, current video, mux choices"]
+  G --> J["Active slides: Mux inserts + video slides"]
+  J --> K["MuxVideo media layer and thumbnail rail"]
+```
+
+The target design keeps all privileged/admin calls server-side. The client receives enough admin-derived pool metadata and video candidates to reproduce Core's sequence semantics without knowing admin credentials or Core APIs.
+
+---
+
+## Implementation Units
+
+### U1. Characterize Core Sequence Semantics
+
+**Goal:** Add focused behavior tests and fixtures that make Core parity executable before changing the current flat-carousel hook.
+
+**Requirements:** R2, R3, R4, R5, R6, R9.
+
+**Dependencies:** None.
+
+**Files:**
+
+- `apps/web/src/lib/watch-home-carousel-sequence.test.ts`
+- `apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts`
+- `apps/web/src/lib/__tests__/watch-home.test.ts`
+- `apps/web/vitest.setup.ts`
+
+**Approach:** Create small Forge-shaped fixtures for playlist groups, short films, video slides, and Mux inserts. Tests should cover the behavior contract rather than Core implementation details: deterministic daily offsets, monthly played-id reset, corrupt storage recovery, pool exhaustion, duplicate avoidance, initial prefetch count, playback prefetch count, manual jump tracking, and insert merge order.
+
+**Execution note:** Add characterization coverage first. The source behavior is complex enough that implementation should be guided by failing behavior tests, not visual checking alone.
+
+**Patterns to follow:** Existing helper tests in `apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts`; storage-safe helper style from Core `utils.ts`; Embla/jsdom polyfill guidance in `apps/web/vitest.setup.ts`.
+
+**Test scenarios:**
+
+- Happy path: empty storage plus available pools yields the first playable video from the configured pool order and records it as played.
+- Happy path: initial load keeps adding videos until seven playable video slides are available.
+- Happy path: after playback begins, only one playable video ahead is prefetched.
+- Edge case: `carousel-played-ids` from a previous month is ignored and removed.
+- Edge case: corrupt `localStorage` or `sessionStorage` values do not throw and fall back to empty state.
+- Edge case: a pool whose played count reaches its available count is skipped until cycling resets.
+- Edge case: a duplicate video returned from a small pool is not appended and marks the pool as temporarily played.
+- Integration scenario: selecting a video manually updates current index, pool index, persistent played IDs, and pool played IDs.
+- Integration scenario: selecting a Mux insert does not mark a video played but keeps the active slide stable.
+
+**Verification:** Tests fail against the current flat implementation for the missing source-parity behaviors and pass after later units.
+
+### U2. Add or Confirm Admin Pool Read Contract
+
+**Goal:** Ensure Forge can query the admin data needed for Core-like pool selection without falling back to broad overfetch or Core runtime APIs.
+
+**Requirements:** R2, R4, R7, R10.
+
+**Dependencies:** U1 for expected behavior boundaries.
+
+**Files:**
+
+- `apps/admin/src/services/video.service.ts`
+- `apps/admin/src/services/video.service.test.ts`
+- `apps/admin/src/graphql/types/video.ts`
+- `apps/admin/src/graphql/types/video.principal-filter.test.ts`
+- `apps/admin/src/graphql/public-resolvers.regression.test.ts`
+- `apps/admin/schema.graphql`
+- `packages/admin-graphql/src/admin-graphql-env.d.ts`
+- `apps/web/src/lib/watch-home.ts`
+- `apps/web/src/lib/__tests__/watch-home.test.ts`
+
+**Approach:** First verify whether existing `videos(...)`, `Video.children`, `Video.childrenCount`, and `VideoService.countActive(...)` can provide the same inputs as Core's collection count, collection children, and short-film queries with bounded payloads. If they cannot, add the smallest public admin GraphQL contract needed for carousel pools, such as count-by-pool and children-by-parent queries that reuse `VideoService` visibility, language, and playable-dub filters.
+
+**Patterns to follow:** Public resolver posture in `apps/admin/src/graphql/types/video.ts`; compact producer-owned contract pattern from `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md`; existing service tests for category, collection, and language filters.
+
+**Test scenarios:**
+
+- Happy path: count contract returns the same count scope as `videos(collection, language)` for a collection pool.
+- Happy path: children contract returns only non-deleted, publicly visible, playable active-language children.
+- Happy path: short-film pool contract returns playable short films bounded by the configured limit.
+- Edge case: unknown collection returns zero count/empty children without throwing.
+- Edge case: requested language with no playable dubs excludes those videos from the playable candidate count.
+- Failure path: public resolver does not expose privileged or deleted rows.
+- Integration scenario: generated admin GraphQL types allow `apps/web` operations to compile without inline web operations or hand-edited env outputs.
+
+**Verification:** Admin SDL and `packages/admin-graphql` generated types are updated only if schema changes are needed; web resolver tests prove the selected admin contract supports source-parity pool behavior.
+
+### U3. Refactor Web Carousel Data Into Pool Seeds
+
+**Goal:** Replace the current broad flat slide resolver with an admin-backed pool seed model that the client sequence engine can consume progressively.
+
+**Requirements:** R2, R4, R7, R8, R10.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+
+- `apps/web/src/lib/watch-home.ts`
+- `apps/web/src/lib/watch-home-config.ts`
+- `apps/web/src/lib/watch-home-carousel-sequence.ts`
+- `apps/web/src/lib/__tests__/watch-home.test.ts`
+- `apps/web/src/lib/watch-home-carousel-sequence.test.ts`
+
+**Approach:** Split normalization from sequencing. Keep server-only admin fetching in `watch-home.ts`, but return a compact serializable model that includes playlist groups, available counts, initial candidate windows, short-film candidates, blacklist data, language slug, missing-data report, and Mux insert config alongside the existing home sections. Move pure sequence helpers into `watch-home-carousel-sequence.ts` so tests can exercise them without React.
+
+**Patterns to follow:** Current `normalizeCard` for route-safe video card shape; `tryAsContentSlug`, `tryAsLocaleSlug`, `watchVideoPath`, and `watchEpisodePath` for links; existing missing-data report shape in `WatchHomeMissingData`.
+
+**Test scenarios:**
+
+- Happy path: resolver emits pool seed data in playlist order and includes the injected short-film pool metadata.
+- Happy path: normalized video slides use active or fallback audio language slug in `href`.
+- Edge case: missing slug, title, playable variant, or invalid language slug records a skipped-video reason and does not emit a playable slide.
+- Edge case: missing configured collection is reported in `missingData.missingCollections`.
+- Edge case: active-language shortage records fallback usage without breaking the page.
+- Integration scenario: resolver payload is serializable and safe to pass from a Server Component into `WatchHomeTvCarousel`.
+
+**Verification:** The web data layer no longer needs to flatten all pools into the final slide order before the client runs sequence state.
+
+### U4. Implement Browser Storage and Progressive Sequence Engine
+
+**Goal:** Port Core's sequence lifecycle into Forge's client hook while preserving hydration safety and current visual component APIs.
+
+**Requirements:** R2, R3, R4, R5, R9.
+
+**Dependencies:** U1, U3.
+
+**Files:**
+
+- `apps/web/src/lib/watch-home-carousel-sequence.ts`
+- `apps/web/src/lib/watch-home-carousel-sequence.test.ts`
+- `apps/web/src/components/home/useWatchHomeTvCarousel.ts`
+- `apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts`
+- `apps/web/src/components/home/WatchHomeTvCarousel.tsx`
+
+**Approach:** Introduce a storage adapter that reads/writes Core-compatible keys only after mount and catches all browser-storage failures. The sequence engine should track videos, current index, pool index, loading queue, and pool exhaustion; choose deterministic offsets using the New York business date; save the current video session for 24 hours; honor the stored pool/current-video state when the data is available; and expose stable actions for next, previous, skip, jump, and progress-driven advance.
+
+**Patterns to follow:** Current hook's `progressPercent` and threshold helpers; Core `utils.ts` storage semantics; hydration-safe client-state patterns already used in the merged carousel work.
+
+**Test scenarios:**
+
+- Happy path: first available video is marked played in local and session pool storage.
+- Happy path: moving next records the next video and updates pool index.
+- Happy path: current video session less than 24 hours old seeds the pool/current-video state when the referenced video exists in loaded seed data.
+- Edge case: current video session older than 24 hours is cleared and ignored.
+- Edge case: storage unavailable behaves like empty storage and never prevents rendering.
+- Edge case: exhaustion reset after repeated cycling prevents the carousel from dead-ending.
+- Integration scenario: progress crossing 95 percent advances exactly once per active media item.
+- Integration scenario: skip at the end requests another video rather than wrapping to stale slides.
+
+**Verification:** The hook returns stable active-slide state, slide list, progress, mute state, and handlers consumed by `WatchHomeTvCarousel` without reintroducing SSR/client mismatches.
+
+### U5. Bring Mux Inserts to Source Parity
+
+**Goal:** Match Core's Mux insert sequencing and session-stable playback selection while documenting admin metadata still missing from Forge.
+
+**Requirements:** R5, R6, R9, R10.
+
+**Dependencies:** U1, U3, U4.
+
+**Files:**
+
+- `apps/web/src/lib/watch-home-config.ts`
+- `apps/web/src/lib/watch-home-carousel-sequence.ts`
+- `apps/web/src/lib/watch-home-carousel-sequence.test.ts`
+- `apps/web/src/components/home/useWatchHomeTvCarousel.ts`
+- `apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts`
+- `docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md`
+
+**Approach:** Expand the existing Forge insert config to represent Core's enabled flag, multiple playback IDs, conditional overlays, poster override, logo, action, sequence-start trigger, and after-count trigger. Use `sessionStorage` to store `mux-insert-selections` and `mux-insert-selections-seed`, select playback IDs deterministically per session, prefix only the first sequence-start insert title with the date, and advance from inserts into the next video with the same guard behavior as Core.
+
+**Patterns to follow:** Current `watchHomeHeroSlidesToTvCarouselSlides` adapter, Core `insertMux.ts`, and existing missing-data follow-up list in `docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md`.
+
+**Test scenarios:**
+
+- Happy path: sequence-start insert appears before videos and first start title receives the date prefix once.
+- Happy path: after-count inserts appear after the first and third video counts and are inserted only once.
+- Happy path: a stored playback ID is reused for the same insert in the same session.
+- Edge case: corrupt `mux-insert-selections` storage falls back to a new stable choice without throwing.
+- Edge case: conditional time-range overlays select the highest-priority matching overlay.
+- Integration scenario: completing a Mux insert advances to the next slide and does not mark a video as played.
+
+**Verification:** Mux insert behavior is source-compatible for all config data present in Forge, and any missing admin ownership is visible in the roadmap follow-up.
+
+### U6. Preserve Home UI, Player Controls, and Mobile Behavior
+
+**Goal:** Wire the source-parity sequence engine into the existing TV-like component without regressing layout, scroll, controls, or below-the-fold rendering.
+
+**Requirements:** R1, R5, R8, R9, R11.
+
+**Dependencies:** U3, U4, U5.
+
+**Files:**
+
+- `apps/web/src/components/home/WatchHomeTvCarousel.tsx`
+- `apps/web/src/components/home/WatchHomePage.tsx`
+- `apps/web/src/components/home/__tests__/WatchHomePage.test.tsx`
+- `apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts`
+- `apps/web/src/app/[locale]/[htmlLang]/page.tsx`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+
+**Approach:** Keep the component API centered on the merged home model, but update the TV carousel to render dynamic sequence slides from the hook rather than a static hero-only array. Keep next/mute controls icon-based, keep the CTA tied to the active video route or Mux action, and preserve the existing home sections, promo, footer, and vertical scrolling. Ensure mobile height, rail sizing, and overlay text remain stable as the dynamic slide list grows.
+
+**Patterns to follow:** Current merged `WatchHomeTvCarousel`; Embla carousel primitive in `@/components/ui/carousel`; route integration from the previous `feat-159` plan; `apps/web/AGENTS.md` watch-link guidance.
+
+**Test scenarios:**
+
+- Happy path: `/watch` renders the carousel followed by non-intro below-fold blocks.
+- Happy path: active video slide CTA links to `/watch/{video}.html/{language}.html` using an audio-language slug.
+- Happy path: active Mux slide CTA renders the external action when configured and no watch link when not configured.
+- Edge case: empty or all-skipped carousel data does not remove below-the-fold home sections.
+- Edge case: dynamic slide append does not reset the active slide or progress unexpectedly.
+- Integration scenario: thumbnail click selects that slide and updates the active hero media/overlay.
+- Integration scenario: mute toggles the underlying media element and persists through active slide changes during the current mount.
+
+**Verification:** Component tests cover the page composition and handler wiring; local visual smoke confirms desktop and mobile do not overlap text, controls, rail, or below-fold content.
+
+### U7. Document Gaps and Complete Visual Proof
+
+**Goal:** Make the implementation reviewable by explicitly proving source parity, local behavior, and remaining data gaps.
+
+**Requirements:** R10, R11.
+
+**Dependencies:** U1, U2, U3, U4, U5, U6.
+
+**Files:**
+
+- `docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md`
+- `docs/plans/2026-06-05-002-feat-watch-home-carousel-sequence-parity-plan.md`
+- `apps/web/src/lib/__tests__/watch-home.test.ts`
+- `apps/web/src/components/home/__tests__/useWatchHomeTvCarousel.test.ts`
+- `apps/web/src/lib/watch-home-carousel-sequence.test.ts`
+
+**Approach:** Update the roadmap ticket with the final missing-data list discovered during implementation. Capture visual QA against local `/watch` and the live New Design reference, explicitly noting that `https://www.jesusfilm.org/watch` must be switched to the New Design experience before comparison. Keep screenshots or notes in the PR body rather than committing generated browser artifacts unless the repo has an existing artifact convention.
+
+**Patterns to follow:** `feat-159` verification notes; project instruction to use Helium for browser testing; `apps/web/AGENTS.md` route/link guidance.
+
+**Test scenarios:**
+
+- Manual desktop proof: local `/watch` first viewport visually matches the live New Design reference in layout, media scale, overlay, controls, rail behavior, and preserved below-fold home sections.
+- Manual mobile proof: local `/watch` around a phone viewport keeps CTA, title, next/mute controls, and rail usable without overlap.
+- Manual storage proof: with `carousel-played-ids` prefilled, local `/watch` starts on a different available video than a clean profile.
+- Manual session proof: after navigating away/back within 24 hours, local `/watch` honors the remembered current-video/pool state or documents an intentional source-matching fallback.
+- Manual old/new reference guard: live comparison confirms the New Design experience is active before screenshots are treated as source parity.
+
+**Verification:** PR handoff includes targeted test commands, visual proof notes, source-parity notes, and the follow-up data-gap list.
+
+---
+
+## System-Wide Impact
+
+- **End users:** The watch home page should feel less repetitive across visits and should continue playing a curated stream instead of cycling a small fixed list.
+- **Editors:** Runtime content still comes from admin video data, but playlist and insert editorial controls remain a documented follow-up unless implemented through an existing admin surface.
+- **Web developers:** Carousel logic becomes more stateful and needs dedicated sequence/storage tests to avoid future regressions.
+- **Admin/API maintainers:** A narrow pool count/children contract may be added; if so, admin SDL and `packages/admin-graphql` outputs must be regenerated together.
+- **QA/reviewers:** Live reference comparison must explicitly use the New Design experience cookie/state on `https://www.jesusfilm.org/watch`.
+
+---
+
+## Phased Delivery
+
+- Phase 1: Characterize behavior, confirm/admin-fill the pool read contract, and refactor web data into pool seed data.
+- Phase 2: Implement browser storage, progressive loading, deterministic pool selection, and active-slide actions.
+- Phase 3: Complete Mux insert parity, wire the UI, preserve below-fold sections, and run visual proof.
+
+The recommended PR shape is one coherent PR for sequence behavior parity. If U2 requires a larger admin schema/read-model addition than expected, split the admin contract into a first PR and the client sequence engine into a second PR, with the first PR landing generated GraphQL artifacts.
+
+---
+
+## Risk Analysis & Mitigation
+
+- **Risk: broad admin overfetch hurts `/watch` performance.** Mitigation: prefer count/children contracts and keep client seed payload bounded; avoid fetching every child in large collections.
+- **Risk: browser storage causes hydration mismatch or private-mode crashes.** Mitigation: all storage reads happen after mount through guarded adapters; server payload remains deterministic and serializable.
+- **Risk: source parity conflicts with Forge route/language rules.** Mitigation: normalize every playable video through existing route helpers and test active/fallback language slugs.
+- **Risk: sequence can dead-end when pools are exhausted or language coverage is sparse.** Mitigation: implement pool exhaustion/failure fallback, short-film injection, and documented fallback behavior.
+- **Risk: visual regressions repeat earlier page-restoration issues.** Mitigation: keep `WatchHomePage` below-fold block tests in scope and manually smoke vertical scrolling.
+- **Risk: live reference comparison accidentally uses the old design.** Mitigation: QA checklist requires proving the New Design experience is active before comparison.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this reopen the old full-page replacement approach? No. The current home sections stay, and the carousel is treated as the portable intro component.
+- Should Forge import Core carousel/player code directly? No. Core source is a behavior reference only; Forge must stay admin-backed and design-system-native.
+- Should playlist/Mux configs be admin-editable in this same behavior PR? Not by default. The behavior PR can use Forge config as fallback data and keep admin editorialization as follow-up unless existing models cover it cleanly.
+
+### Deferred to Implementation
+
+- Exact admin contract shape for pool counts/children: resolve after trying the existing `videos(...)`, `Video.children`, and `countActive(...)` paths against the needed payload size.
+- Exact fallback language policy when active language has sparse playable coverage: start with current resolver behavior, then document any divergence discovered in tests.
+- Exact visual tolerances against the live reference: settle during Helium screenshots after behavior is in place.
+
+---
+
+## Sources & References
+
+- `docs/plans/2026-06-04-003-feat-watch-home-modernization-plan.md`
+- `docs/roadmap/platform/feat-159-watch-home-modernization.md`
+- `docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md`
+- `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md`
+- `docs/solutions/design-patterns/embla-carousel-bleed-alignment-port-pattern-20260508.md`
+- `apps/web/AGENTS.md`
+- `apps/web/CLAUDE.md`
+- `apps/web/src/components/home/WatchHomeTvCarousel.tsx`
+- `apps/web/src/components/home/useWatchHomeTvCarousel.ts`
+- `apps/web/src/lib/watch-home.ts`
+- `apps/web/src/lib/watch-home-config.ts`
+- `apps/admin/src/services/video.service.ts`
+- `apps/admin/src/graphql/types/video.ts`
+- Core source links listed in Context & Research.

--- a/docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md
+++ b/docs/roadmap/platform/feat-160-watch-home-carousel-data-parity.md
@@ -1,0 +1,50 @@
+---
+id: feat-160
+title: Watch home carousel admin data parity
+owner: urim
+priority: medium
+status: "in-progress"
+start_date: "2026-06-05"
+duration: "3d"
+depends_on:
+  - feat-159
+blocks: []
+tags:
+  - web
+  - watch
+  - admin-graphql
+  - editorial
+---
+
+# Watch home carousel admin data parity
+
+## Problem
+
+`feat-159` ports the beta watch home carousel with a Forge-owned static playlist/insert config and admin-backed video data. Several upstream sources still have no admin-owned equivalent, so follow-up PRs should move those editorial decisions into admin and close the remaining design/data parity gaps.
+
+## Missing Data And Follow-Up Work
+
+- Admin-owned watch home playlist ordering, collection groups, blacklist, and per-language fallbacks.
+- Admin-owned Mux insert records, including playback IDs, trigger rules, action links, logo flags, overlay labels, and descriptions.
+- Conditional insert overlays for time-of-day copy from the upstream Mux insert config.
+- Local thumbnail/poster override parity for upstream watch carousel cards.
+- Blurhash or dominant-color placeholders for cards while images load.
+- Collection count and pool endpoints so the carousel can preserve upstream daily/random selection without broad overfetch.
+- Bounded admin carousel pool query so upstream playlist-only sources can load without the current broad `watchHomeVideos` child/dub payload timing out.
+- Full admin-backed below-the-fold `CollectionsRail` parity.
+- Stronger language fallback rules when an active language has too few playable videos.
+
+## Starting Points
+
+- Implementation plan: `docs/plans/2026-06-05-002-feat-watch-home-carousel-sequence-parity-plan.md`
+- Static Forge config from `feat-159`: `apps/web/src/lib/watch-home-config.ts`
+- Resolver gap reporting from `feat-159`: `apps/web/src/lib/watch-home.ts`
+- Admin video service filters: `apps/admin/src/services/video.service.ts`
+- Admin experience editor patterns: `apps/admin/src/app/dashboard/experiences/experience-editor.tsx`
+
+## Verification
+
+- Admin can configure the carousel without code changes.
+- Web renders the same first viewport from admin-owned playlist/insert records.
+- Existing static config can be removed or reduced to migration fallback data.
+- Mobile and desktop visual smoke still pass for `/watch` and localized home routes.


### PR DESCRIPTION
## Summary

- Adds a Forge-native watch home carousel sequence engine matching Core browser-storage semantics: monthly played IDs, per-pool session tracking/failure exhaustion, current-video session state, deterministic pool offsets, 50-video cycling reset, and session-stable Mux inserts.
- Wires the current home hero carousel to admin-backed sequence pools plus the source Mux insert config while preserving the rest of the existing home page sections.
- Keeps the broad home admin fetch bounded to current home programming; playlist-only upstream sources remain documented follow-up work until admin exposes a narrower pool/count query.

## Validation

- `pnpm --filter @forge/web test -- src/lib/watch-home-carousel-sequence.test.ts src/lib/__tests__/watch-home.test.ts src/components/home/__tests__/useWatchHomeTvCarousel.test.ts src/components/home/__tests__/WatchHomePage.test.tsx 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx'`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `pnpm exec prettier --check ...touched files...`
- Browser smoke on `http://127.0.0.1:3011/watch` using `agent-browser` fallback because Helium was not installed:
  - desktop sequence rail includes `Jun 5: Today's Video Picks`, `JESUS`, `Billions are searching`, and additional playlist cards
  - storage proof writes `carousel-played-ids`, `carousel-current-video`, and `mux-insert-selections`
  - vertical scroll verified to lower sections at `scrollY=5000`
  - mobile viewport `390x844` verified sequenced rail, Core ID storage, and `overflow-x: clip`

## Follow-Up

- Admin-owned playlist/pool/count and child playable-video query is still needed for the upstream playlist-only sources without broad child/dub overfetch.
- Admin-owned Mux insert metadata, local poster overrides, blurhash/dominant colors, and full Core below-fold `CollectionsRail` parity remain tracked in `feat-160`.
