### PR TITLE
feat(admin): Qwen re-embed backfill script for embedding_qwen (U4)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -26,6 +26,7 @@
     "refresh:core-id-mapping": "tsx src/scripts/refresh-core-id-mapping.ts",
     "partner-keys": "tsx src/scripts/partner-keys.ts",
     "pull:mapping": "tsx src/scripts/pull-mapping-from-prod.ts",
+    "backfill-qwen-video-embeddings": "tsx --env-file=.env src/scripts/backfill-qwen-video-embeddings.ts",
     "run-embeds": "tsx src/scripts/run-embeds.ts",
     "run-sync": "tsx src/scripts/run-sync.ts",
     "schema:print": "tsx src/scripts/print-schema.ts",

--- a/apps/admin/src/scripts/backfill-qwen-video-embeddings.test.ts
+++ b/apps/admin/src/scripts/backfill-qwen-video-embeddings.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it, vi } from "vitest"
+
+// The script lazy-imports `@/db/client` + `@/services/embeddings.service`
+// inside main(); the exported helpers under test take prisma + embed as
+// injected dependencies, so no module mock is needed for the unit surface.
+// We still stub `@/config/env` defensively in case the embeddings.service
+// import graph is pulled transitively by tsx during collection.
+vi.mock("@/config/env", () => ({ env: {} }))
+
+import {
+  QWEN_BACKFILL_CONFIGS,
+  backfillQwenTable,
+  fetchQwenBackfillPage,
+  parsePositiveInt,
+  writeQwenBatch,
+  type QwenBackfillRow,
+} from "./backfill-qwen-video-embeddings"
+
+/**
+ * A `Prisma.sql` template object exposes parameterized `.sql` text (with
+ * `$N` placeholders) plus `.values`. The helpers call `$queryRaw` /
+ * `$executeRaw` with ONE composed `Prisma.Sql` argument, so we read
+ * `call[0].sql` to assert query shape.
+ */
+function sqlOf(call: unknown[]): string {
+  const arg = call[0] as { sql?: string }
+  return typeof arg?.sql === "string" ? arg.sql : ""
+}
+
+function valuesOf(call: unknown[]): unknown[] {
+  const arg = call[0] as { values?: unknown[] }
+  return Array.isArray(arg?.values) ? arg.values : []
+}
+
+function nullLogger() {
+  return { stdout: vi.fn(), stderr: vi.fn() }
+}
+
+function rows(n: number, prefix = "row"): QwenBackfillRow[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `${prefix}-${String(i).padStart(3, "0")}`,
+    text: `text ${i}`,
+  }))
+}
+
+describe("fetchQwenBackfillPage", () => {
+  it("selects only rows with non-null text AND null embedding_qwen, ordered by id (resumability)", async () => {
+    const $queryRaw = vi.fn(async () => [])
+    const prisma = { $queryRaw } as never
+
+    await fetchQwenBackfillPage({
+      prisma,
+      config: QWEN_BACKFILL_CONFIGS.scene,
+      coreIds: [],
+      lastId: null,
+      take: 64,
+    })
+
+    const sql = sqlOf($queryRaw.mock.calls[0]!)
+    // Reads the scene text column verbatim.
+    expect(sql).toContain('"source_text"')
+    // Resumability WHERE shape: non-null text AND null target column.
+    expect(sql).toMatch(/"source_text"\s+IS NOT NULL/)
+    expect(sql).toMatch(/"embedding_qwen"\s+IS NULL/)
+    // Deterministic paging order.
+    expect(sql).toMatch(/ORDER BY t\."id" ASC/)
+    // No core-id JOIN when no filter requested.
+    expect(sql).not.toContain('JOIN "video"')
+    // No cursor predicate on the first page.
+    expect(sql).not.toMatch(/t\."id" >/)
+  })
+
+  it("adds the cursor predicate and core-id JOIN when filtering", async () => {
+    const $queryRaw = vi.fn(async () => [])
+    const prisma = { $queryRaw } as never
+
+    await fetchQwenBackfillPage({
+      prisma,
+      config: QWEN_BACKFILL_CONFIGS.transcript,
+      coreIds: ["1_Jesus", "2_GoodNews"],
+      lastId: "row-042",
+      take: 32,
+    })
+
+    const sql = sqlOf($queryRaw.mock.calls[0]!)
+    expect(sql).toContain('"text"')
+    // Transcript core-id JOIN chain reaches video.
+    expect(sql).toContain('JOIN "video_transcript"')
+    expect(sql).toContain('JOIN "video"')
+    expect(sql).toMatch(/v\."core_id" IN/)
+    expect(sql).toMatch(/t\."id" >/)
+    // Bound values: the two coreIds, the cursor id, and the LIMIT take.
+    expect(valuesOf($queryRaw.mock.calls[0]!)).toEqual([
+      "1_Jesus",
+      "2_GoodNews",
+      "row-042",
+      32,
+    ])
+  })
+})
+
+describe("writeQwenBatch", () => {
+  it("updates embedding_qwen (NOT embedding) per row with a ::vector cast inside one transaction", async () => {
+    const executed: unknown[][] = []
+    const $executeRaw = vi.fn((...args: unknown[]) => {
+      executed.push(args)
+      return Promise.resolve(1)
+    })
+    // $transaction receives an array of pending $executeRaw promises.
+    const $transaction = vi.fn(async (ops: Promise<unknown>[]) => {
+      await Promise.all(ops)
+      return ops
+    })
+    const prisma = { $executeRaw, $transaction } as never
+
+    await writeQwenBatch({
+      prisma,
+      config: QWEN_BACKFILL_CONFIGS.scene,
+      rows: [
+        { id: "scene-1", text: "a" },
+        { id: "scene-2", text: "b" },
+      ],
+      embeddings: [
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ],
+    })
+
+    expect($transaction).toHaveBeenCalledTimes(1)
+    expect($executeRaw).toHaveBeenCalledTimes(2)
+
+    for (const call of executed) {
+      const sql = sqlOf(call)
+      expect(sql).toContain('"embedding_qwen"')
+      // Critically: never touches the live `embedding` column.
+      expect(sql).not.toMatch(/SET "embedding" /)
+      expect(sql).toMatch(/::vector\b/)
+      // Per-row cast — NOT the ::vector[] array-parameter form.
+      expect(sql).not.toContain("::vector[]")
+      expect(sql).toContain('"video_scene_locale"')
+      expect(sql).toMatch(/WHERE "id" =/)
+    }
+
+    // Vectors are formatted as pgvector text literals and bound as values.
+    expect(valuesOf(executed[0]!)).toContain("[0.1,0.2]")
+    expect(valuesOf(executed[0]!)).toContain("scene-1")
+    expect(valuesOf(executed[1]!)).toContain("[0.3,0.4]")
+    expect(valuesOf(executed[1]!)).toContain("scene-2")
+  })
+})
+
+describe("backfillQwenTable", () => {
+  /**
+   * Build a prisma stub that returns `pages` from successive
+   * `fetchQwenBackfillPage` (`$queryRaw`) calls and records write batches.
+   */
+  function buildPrisma(pages: QwenBackfillRow[][]) {
+    let pageIdx = 0
+    const writtenIds: string[][] = []
+    // Honor the bound LIMIT (`take`, the last bound value) the way the real
+    // DB would — otherwise a `--limit` smaller than the preloaded page can't
+    // be exercised.
+    const $queryRaw = vi.fn(async (sqlArg: { values?: unknown[] }) => {
+      const page = pages[pageIdx] ?? []
+      pageIdx += 1
+      const take = sqlArg?.values?.at(-1)
+      return typeof take === "number" ? page.slice(0, take) : page
+    })
+    const $executeRaw = vi.fn(() => Promise.resolve(1))
+    const $transaction = vi.fn(async (ops: Promise<unknown>[]) => {
+      await Promise.all(ops)
+      return ops
+    })
+    return {
+      prisma: { $queryRaw, $executeRaw, $transaction } as never,
+      $queryRaw,
+      $transaction,
+      writtenIds,
+    }
+  }
+
+  it("calls the embedder once per batch with the batch texts and source:gateway", async () => {
+    // 5 rows, batch size 2 → 3 batches (2 + 2 + 1).
+    const all = rows(5)
+    const { prisma } = buildPrisma([
+      all.slice(0, 2),
+      all.slice(2, 4),
+      all.slice(4, 5),
+      [],
+    ])
+    const embed = vi.fn(
+      async (inputs: readonly string[], _opts: { source: string }) => ({
+        embeddings: inputs.map(() => [0.1, 0.2]),
+      }),
+    )
+
+    const report = await backfillQwenTable({
+      prisma,
+      embed,
+      config: QWEN_BACKFILL_CONFIGS.scene,
+      coreIds: [],
+      batchSize: 2,
+      logger: nullLogger(),
+    })
+
+    expect(embed).toHaveBeenCalledTimes(3)
+    expect(embed.mock.calls[0]![0]).toEqual(["text 0", "text 1"])
+    expect(embed.mock.calls[0]![1]).toEqual({ source: "gateway" })
+    expect(embed.mock.calls[2]![0]).toEqual(["text 4"])
+    expect(report).toMatchObject({
+      table: "video_scene_locale",
+      succeeded: 5,
+      failed: 0,
+    })
+  })
+
+  it("caps total processed rows at --limit", async () => {
+    const all = rows(100)
+    const { prisma, $queryRaw } = buildPrisma([
+      all.slice(0, 10),
+      all.slice(10, 20),
+      all.slice(20, 30),
+    ])
+    const embed = vi.fn(async (inputs: readonly string[]) => ({
+      embeddings: inputs.map(() => [0.1]),
+    }))
+
+    const report = await backfillQwenTable({
+      prisma,
+      embed,
+      config: QWEN_BACKFILL_CONFIGS.transcript,
+      coreIds: [],
+      batchSize: 10,
+      limit: 15,
+      logger: nullLogger(),
+    })
+
+    // 15 rows total: first page (10) + a second page capped to take=5.
+    expect(report.succeeded).toBe(15)
+    expect($queryRaw).toHaveBeenCalledTimes(2)
+    // Second fetch requests only the remaining 5 rows.
+    expect(valuesOf($queryRaw.mock.calls[1]!).at(-1)).toBe(5)
+  })
+
+  it("skips blank/whitespace-only text rows without sending them to the embedder, batch continues", async () => {
+    const page = [
+      { id: "row-0", text: "real text" },
+      { id: "row-1", text: "   " },
+      { id: "row-2", text: "" },
+      { id: "row-3", text: "more text" },
+    ]
+    const { prisma } = buildPrisma([page, []])
+    const embed = vi.fn(async (inputs: readonly string[]) => ({
+      embeddings: inputs.map(() => [0.9]),
+    }))
+
+    const report = await backfillQwenTable({
+      prisma,
+      embed,
+      config: QWEN_BACKFILL_CONFIGS.scene,
+      coreIds: [],
+      batchSize: 10,
+      logger: nullLogger(),
+    })
+
+    // Blank rows never reach the embedder.
+    expect(embed).toHaveBeenCalledTimes(1)
+    expect(embed.mock.calls[0]![0]).toEqual(["real text", "more text"])
+    expect(report.succeeded).toBe(2)
+    expect(report.failed).toBe(0)
+  })
+
+  it("isolates a failed batch: logs, increments failure counter, continues, and the run reports failures", async () => {
+    const all = rows(4)
+    const { prisma, $transaction } = buildPrisma([
+      all.slice(0, 2),
+      all.slice(2, 4),
+      [],
+    ])
+    const logger = nullLogger()
+    let call = 0
+    const embed = vi.fn(async (inputs: readonly string[]) => {
+      call += 1
+      if (call === 1) {
+        throw new Error("gateway 503")
+      }
+      return { embeddings: inputs.map(() => [0.5]) }
+    })
+
+    const report = await backfillQwenTable({
+      prisma,
+      embed,
+      config: QWEN_BACKFILL_CONFIGS.scene,
+      coreIds: [],
+      batchSize: 2,
+      logger,
+    })
+
+    // First batch failed (no write), second succeeded.
+    expect(embed).toHaveBeenCalledTimes(2)
+    expect($transaction).toHaveBeenCalledTimes(1)
+    expect(report.failed).toBe(2)
+    expect(report.succeeded).toBe(2)
+
+    // A structured error event was logged for the failed batch.
+    const errLines = logger.stderr.mock.calls.map((c) => String(c[0]))
+    const errEvent = errLines
+      .map((l) => JSON.parse(l))
+      .find((e) => e.event === "backfill-qwen.error")
+    expect(errEvent).toMatchObject({
+      table: "video_scene_locale",
+      idRange: { from: "row-000", to: "row-001" },
+    })
+  })
+})
+
+describe("parsePositiveInt", () => {
+  it("returns undefined when unset", () => {
+    expect(parsePositiveInt(undefined, "--limit")).toBeUndefined()
+  })
+
+  it("parses a positive integer", () => {
+    expect(parsePositiveInt("64", "--batch-size")).toBe(64)
+  })
+
+  it("throws on zero, negative, or non-integer", () => {
+    expect(() => parsePositiveInt("0", "--batch-size")).toThrow(/positive/)
+    expect(() => parsePositiveInt("-3", "--limit")).toThrow(/positive/)
+    expect(() => parsePositiveInt("1.5", "--limit")).toThrow(/positive/)
+    expect(() => parsePositiveInt("abc", "--limit")).toThrow(/positive/)
+  })
+})

--- a/apps/admin/src/scripts/backfill-qwen-video-embeddings.ts
+++ b/apps/admin/src/scripts/backfill-qwen-video-embeddings.ts
@@ -1,0 +1,487 @@
+#!/usr/bin/env tsx
+/**
+ * Re-embed EXISTING scene + transcript text into the parallel
+ * `embedding_qwen` column via the JesusFilm AI gateway (Qwen → 1536-dim).
+ *
+ * U4 of docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md.
+ *
+ * This is a self-contained ADMIN script — NOT a Mastra/S3 pipeline. Both
+ * target tables already store the embedded text verbatim:
+ *   - `video_scene_locale.source_text` (schema comment: "Stored so a future
+ *      model upgrade can re-embed without re-reading manager's S3 artifact").
+ *   - `video_transcript_chunk.text`.
+ * So re-embedding existing text needs no artifact re-read, no ingest
+ * contract, and no apps/mastra changes — read the text, embed it via the
+ * U1 gateway path, write the new column.
+ *
+ * Usage:
+ *   DATABASE_URL='postgresql://forge:forge@db:5432/forge_admin' \
+ *   AI_GATEWAY_EMBEDDINGS_BASE_URL=... \
+ *   AI_GATEWAY_EMBEDDINGS_API_KEY=... \
+ *   AI_GATEWAY_EMBEDDINGS_MODEL=... \
+ *   pnpm --filter @forge/admin backfill-qwen-video-embeddings
+ *
+ *   # Filters (all optional):
+ *   --table=scene|transcript|both   # default `both`
+ *   --batch-size=N                  # default 64; rows embedded per gateway call
+ *   --limit=N                       # cap total rows processed per table
+ *   --core-id=<id>                  # repeatable; restrict to specific videos
+ *                                   # (JOINs through to video.core_id)
+ *
+ * RESUMABLE + IDEMPOTENT: only rows WHERE the text column IS NOT NULL AND
+ * `embedding_qwen` IS NULL are processed, ordered by id. A failed batch
+ * leaves its rows NULL, so a re-run retries them. Live `embedding` column
+ * is NEVER written by this path.
+ *
+ * Structured stdout/stderr events (single grep target):
+ *   stdout:
+ *     - `backfill-qwen.start`    — startup config (table, batchSize, limit)
+ *     - `backfill-qwen.batch`    — periodic running totals (done, failed)
+ *     - `backfill-qwen.complete` — per-table final (succeeded, failed, durationMs)
+ *   stderr:
+ *     - `backfill-qwen.error`       — per failed batch (table, idRange)
+ *     - `backfill-qwen.interrupted` — SIGINT/SIGTERM received
+ *     - `backfill-qwen.fatal`       — unhandled error in main()
+ *
+ * NOT run against prod by default — operator must set DATABASE_URL
+ * explicitly. Mirrors run-embeds.ts / run-sync.ts posture; no in-script
+ * prod-URL guard beyond the explicit env var.
+ */
+
+import { Prisma, type PrismaClient } from "@prisma/client"
+import { toPgVector } from "@/db/pgvector"
+import type { EmbeddingSource } from "@/services/embeddings.service"
+
+export type QwenBackfillTable = "scene" | "transcript" | "both"
+
+const DEFAULT_BATCH_SIZE = 64
+
+/**
+ * One re-embeddable row: the id of the row to update and the text to embed.
+ */
+export type QwenBackfillRow = {
+  id: string
+  text: string
+}
+
+/**
+ * Per-table configuration. Each entry pins the physical table, the text
+ * column to read, and the core-id JOIN fragment so the SQL builders stay
+ * DRY across scene + transcript.
+ */
+type TableConfig = {
+  /** Physical table name (also the logical key in logs). */
+  table: string
+  /** Text column whose verbatim contents get re-embedded. */
+  textColumn: string
+  /**
+   * JOIN chain from the target table (aliased `t`) to `video` (aliased
+   * `v`) so a `--core-id` filter can constrain by `v.core_id`. Empty when
+   * no core-id filter is requested.
+   */
+  coreIdJoin: Prisma.Sql
+}
+
+const SCENE_CONFIG = {
+  table: "video_scene_locale",
+  textColumn: "source_text",
+  coreIdJoin: Prisma.sql`JOIN "video_scene" vs ON vs."id" = t."video_scene_id" JOIN "video" v ON v."id" = vs."video_id"`,
+} as const satisfies TableConfig
+
+const TRANSCRIPT_CONFIG = {
+  table: "video_transcript_chunk",
+  textColumn: "text",
+  coreIdJoin: Prisma.sql`JOIN "video_transcript" vt ON vt."id" = t."transcript_id" JOIN "video" v ON v."id" = vt."video_id"`,
+} as const satisfies TableConfig
+
+/**
+ * The two tables this script backfills, in run order. Exported for tests.
+ */
+export const QWEN_BACKFILL_CONFIGS: Readonly<
+  Record<"scene" | "transcript", TableConfig>
+> = {
+  scene: SCENE_CONFIG,
+  transcript: TRANSCRIPT_CONFIG,
+}
+
+/**
+ * Minimal Prisma surface this script needs. Narrowed so unit tests can
+ * supply a mock without standing up a full PrismaClient.
+ */
+export type QwenBackfillPrisma = Pick<
+  PrismaClient,
+  "$queryRaw" | "$executeRaw" | "$transaction"
+>
+
+/**
+ * The batched embedder. Matches `generateExperienceEmbeddings`'s shape but
+ * narrowed to what this script consumes, so tests can inject a stub.
+ */
+export type QwenBatchEmbedder = (
+  inputs: readonly string[],
+  opts: { source: EmbeddingSource },
+) => Promise<{ embeddings: number[][] }>
+
+export type QwenBackfillTableReport = {
+  table: string
+  succeeded: number
+  failed: number
+  durationMs: number
+}
+
+function isBlank(text: string): boolean {
+  return text.trim().length === 0
+}
+
+/**
+ * Fetch one page of re-embeddable rows: text column NOT NULL AND
+ * `embedding_qwen` IS NULL, ordered by id ascending, capped at `take`.
+ * When `coreIds` is non-empty, JOINs through to `video.core_id` and
+ * filters by it.
+ *
+ * The text column and JOIN are interpolated from the closed
+ * per-table config allowlist (never user input); `coreIds`, `lastId`,
+ * and `take` are bound parameters.
+ *
+ * Exported for tests — asserts the WHERE shape (resumability invariant).
+ */
+export async function fetchQwenBackfillPage(args: {
+  prisma: QwenBackfillPrisma
+  config: TableConfig
+  coreIds: readonly string[]
+  lastId: string | null
+  take: number
+}): Promise<QwenBackfillRow[]> {
+  const { prisma, config, coreIds, lastId, take } = args
+  const textCol = Prisma.raw(`t."${config.textColumn}"`)
+  const join = coreIds.length > 0 ? config.coreIdJoin : Prisma.empty
+  const coreFilter =
+    coreIds.length > 0
+      ? Prisma.sql`AND v."core_id" IN (${Prisma.join(coreIds)})`
+      : Prisma.empty
+  const afterId =
+    lastId !== null ? Prisma.sql`AND t."id" > ${lastId}` : Prisma.empty
+
+  return prisma.$queryRaw<QwenBackfillRow[]>(Prisma.sql`
+    SELECT t."id" AS "id", ${textCol} AS "text"
+    FROM ${Prisma.raw(`"${config.table}"`)} t
+    ${join}
+    WHERE ${textCol} IS NOT NULL
+      AND t."embedding_qwen" IS NULL
+      ${coreFilter}
+      ${afterId}
+    ORDER BY t."id" ASC
+    LIMIT ${take}
+  `)
+}
+
+/**
+ * Write one batch's vectors into `embedding_qwen` via per-row
+ * `$executeRaw` casts inside a single `$transaction`. Per-row `::vector`
+ * cast only — NOT the `::vector[]` array-parameter form (CLAUDE.md warns
+ * that parser is less-trodden).
+ *
+ * Caller guarantees `rows.length === embeddings.length`. Exported for
+ * tests — asserts the SQL targets `embedding_qwen` (NOT `embedding`).
+ */
+export async function writeQwenBatch(args: {
+  prisma: QwenBackfillPrisma
+  config: TableConfig
+  rows: readonly QwenBackfillRow[]
+  embeddings: readonly number[][]
+}): Promise<void> {
+  const { prisma, config, rows, embeddings } = args
+  const tableIdent = Prisma.raw(`"${config.table}"`)
+  await prisma.$transaction(
+    rows.map((row, i) => {
+      const vec = toPgVector(embeddings[i]!)
+      return prisma.$executeRaw(Prisma.sql`
+        UPDATE ${tableIdent}
+        SET "embedding_qwen" = ${vec}::vector
+        WHERE "id" = ${row.id}
+      `)
+    }),
+  )
+}
+
+export type QwenBackfillLogger = {
+  stdout: (line: string) => void
+  stderr: (line: string) => void
+}
+
+const defaultLogger: QwenBackfillLogger = {
+  stdout: (line) => process.stdout.write(line),
+  stderr: (line) => process.stderr.write(line),
+}
+
+/**
+ * Backfill one table: page through re-embeddable rows, embed each batch
+ * via the gateway, write the vectors into `embedding_qwen`. Per-batch
+ * error isolation — a failed batch logs, increments the failure counter,
+ * and continues to the next batch. Because failed rows stay NULL, a
+ * re-run retries them.
+ */
+export async function backfillQwenTable(args: {
+  prisma: QwenBackfillPrisma
+  embed: QwenBatchEmbedder
+  config: TableConfig
+  coreIds: readonly string[]
+  batchSize: number
+  limit?: number
+  logger?: QwenBackfillLogger
+}): Promise<QwenBackfillTableReport> {
+  const {
+    prisma,
+    embed,
+    config,
+    coreIds,
+    batchSize,
+    limit,
+    logger = defaultLogger,
+  } = args
+  const startedAt = Date.now()
+
+  let succeeded = 0
+  let failed = 0
+  let processed = 0
+  let batchCount = 0
+  let lastId: string | null = null
+
+  for (;;) {
+    if (limit !== undefined && processed >= limit) break
+    const remaining = limit === undefined ? batchSize : limit - processed
+    const take = Math.min(batchSize, remaining)
+    if (take <= 0) break
+
+    const page = await fetchQwenBackfillPage({
+      prisma,
+      config,
+      coreIds,
+      lastId,
+      take,
+    })
+    if (page.length === 0) break
+
+    // Advance the cursor regardless of embed outcome so a failed batch
+    // does not loop forever (failed rows stay NULL and are retried on a
+    // fresh run, not within this run).
+    lastId = page[page.length - 1]!.id
+    processed += page.length
+    batchCount += 1
+
+    // Skip blank/whitespace-only rows — the embedder rejects empty input.
+    // Log + skip, don't abort the batch.
+    const embeddable = page.filter((row) => !isBlank(row.text))
+    const skipped = page.length - embeddable.length
+    if (skipped > 0) {
+      logger.stdout(
+        JSON.stringify({
+          event: "backfill-qwen.skip_blank",
+          table: config.table,
+          skipped,
+        }) + "\n",
+      )
+    }
+    if (embeddable.length === 0) {
+      continue
+    }
+
+    try {
+      const { embeddings } = await embed(
+        embeddable.map((row) => row.text),
+        { source: "gateway" },
+      )
+      if (embeddings.length !== embeddable.length) {
+        throw new Error(
+          `embedder returned ${embeddings.length} vectors for ${embeddable.length} inputs`,
+        )
+      }
+      await writeQwenBatch({
+        prisma,
+        config,
+        rows: embeddable,
+        embeddings,
+      })
+      succeeded += embeddable.length
+    } catch (err) {
+      failed += embeddable.length
+      logger.stderr(
+        JSON.stringify({
+          event: "backfill-qwen.error",
+          table: config.table,
+          idRange: {
+            from: embeddable[0]!.id,
+            to: embeddable[embeddable.length - 1]!.id,
+          },
+          rows: embeddable.length,
+          error: err instanceof Error ? err.message : String(err),
+        }) + "\n",
+      )
+    }
+
+    if (batchCount % 10 === 0) {
+      logger.stdout(
+        JSON.stringify({
+          event: "backfill-qwen.batch",
+          table: config.table,
+          done: succeeded,
+          failed,
+        }) + "\n",
+      )
+    }
+  }
+
+  const report: QwenBackfillTableReport = {
+    table: config.table,
+    succeeded,
+    failed,
+    durationMs: Date.now() - startedAt,
+  }
+  logger.stdout(
+    JSON.stringify({
+      event: "backfill-qwen.complete",
+      ...report,
+    }) + "\n",
+  )
+  return report
+}
+
+function parseSingle(name: string): string | undefined {
+  const flag = `--${name}=`
+  const arg = process.argv.find((a) => a.startsWith(flag))
+  return arg ? arg.slice(flag.length) : undefined
+}
+
+function parseRepeated(name: string): string[] {
+  const flag = `--${name}=`
+  return process.argv
+    .filter((a) => a.startsWith(flag))
+    .map((a) => a.slice(flag.length))
+    .filter((v) => v.length > 0)
+}
+
+function isTable(v: string): v is QwenBackfillTable {
+  return v === "scene" || v === "transcript" || v === "both"
+}
+
+/**
+ * Parse `--batch-size` / `--limit` to a positive integer or throw. Shared
+ * so both CLI numeric flags get identical validation.
+ */
+export function parsePositiveInt(
+  raw: string | undefined,
+  flag: string,
+): number | undefined {
+  if (raw === undefined) return undefined
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`${flag} must be a positive integer; got "${raw}"`)
+  }
+  return n
+}
+
+async function main(): Promise<void> {
+  const tableArg = parseSingle("table") ?? "both"
+  if (!isTable(tableArg)) {
+    process.stderr.write(
+      `[backfill-qwen] invalid --table=${tableArg}; expected scene|transcript|both\n`,
+    )
+    process.exit(2)
+  }
+
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    process.stderr.write("[backfill-qwen] DATABASE_URL is required\n")
+    process.exit(2)
+  }
+
+  let batchSize: number
+  let limit: number | undefined
+  try {
+    batchSize =
+      parsePositiveInt(parseSingle("batch-size"), "--batch-size") ??
+      DEFAULT_BATCH_SIZE
+    limit = parsePositiveInt(parseSingle("limit"), "--limit")
+  } catch (err) {
+    process.stderr.write(
+      `[backfill-qwen] ${err instanceof Error ? err.message : String(err)}\n`,
+    )
+    process.exit(2)
+    return
+  }
+
+  const coreIds = parseRepeated("core-id")
+
+  // Lazy-import AFTER the DATABASE_URL guard so a missing var produces our
+  // friendly stderr line instead of zod's crash on the transitive
+  // `@/config/env` import (mirrors run-embeds.ts). The embedder import
+  // also validates the AI_GATEWAY_EMBEDDINGS_* env via @/config/env.
+  const { prisma } = await import("@/db/client")
+  const { generateExperienceEmbeddings } =
+    await import("@/services/embeddings.service")
+
+  const tables: ("scene" | "transcript")[] =
+    tableArg === "both" ? ["scene", "transcript"] : [tableArg]
+
+  process.stdout.write(
+    JSON.stringify({
+      event: "backfill-qwen.start",
+      databaseUrl: databaseUrl.replace(/:\/\/[^@]+@/, "://***:***@"),
+      tables,
+      batchSize,
+      limit: limit ?? null,
+      coreIds: coreIds.length > 0 ? coreIds : null,
+    }) + "\n",
+  )
+
+  let interrupted = false
+  const onSignal = (signal: NodeJS.Signals) => {
+    if (interrupted) return
+    interrupted = true
+    process.stderr.write(
+      JSON.stringify({ event: "backfill-qwen.interrupted", signal }) + "\n",
+    )
+    void prisma.$disconnect().finally(() => process.exit(130))
+  }
+  process.once("SIGINT", onSignal)
+  process.once("SIGTERM", onSignal)
+
+  let totalFailed = 0
+  try {
+    for (const table of tables) {
+      const report = await backfillQwenTable({
+        prisma,
+        embed: generateExperienceEmbeddings,
+        config: QWEN_BACKFILL_CONFIGS[table],
+        coreIds,
+        batchSize,
+        limit,
+      })
+      totalFailed += report.failed
+    }
+  } finally {
+    process.off("SIGINT", onSignal)
+    process.off("SIGTERM", onSignal)
+    await prisma.$disconnect()
+  }
+
+  if (totalFailed > 0) {
+    process.exit(1)
+  }
+}
+
+if (
+  typeof process.argv[1] === "string" &&
+  import.meta.url === `file://${process.argv[1]}`
+) {
+  main().catch((err) => {
+    process.stderr.write(
+      JSON.stringify({
+        event: "backfill-qwen.fatal",
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      }) + "\n",
+    )
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary

U4 of the [Qwen-1536 video-search pilot](docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md): the **backfill script** that fills the `embedding_qwen` columns (added in #1149). It re-embeds the video text already stored in the DB through the self-hosted gateway (Qwen → 1536) so the AI experience generator can search a Qwen vector space.

## Why a self-contained re-embed (not the Mastra/S3 pipeline)

The original plan sketch assumed reusing the Mastra scene-analysis pipeline. But re-embedding **existing** text needs none of that — both tables already persist the embedded text *specifically for this case*:

> `video_scene_locale.source_text` — *"The exact text that was embedded. Stored so a future model upgrade can re-embed."*

So the script reads `source_text` / `text`, embeds via the U1 gateway path (`generateExperienceEmbeddings(texts, { source: "gateway" })`), and writes `embedding_qwen`. No Mastra, no S3, no ingest round-trip — and it sidesteps the OpenRouter budget outage entirely (uses the free gateway).

## What it does

- **`pnpm --filter @forge/admin backfill-qwen-video-embeddings`** with `--table=scene|transcript|both`, `--batch-size`, `--limit`, `--core-id`.
- **Resumable + idempotent**: only rows `WHERE <text> IS NOT NULL AND embedding_qwen IS NULL`, id-cursor paged. A failed batch leaves its rows NULL, so a re-run retries them.
- **Per-row `::vector` writes** inside per-batch transactions (not the `::vector[]` array-parameter form, per the repo's pgvector guidance). Table/column from a closed allowlist; coreIds/cursor bound.
- **The live `embedding` column is never read or written** — only the parallel Qwen column.
- Per-batch error isolation, structured JSON logging, SIGINT/SIGTERM clean disconnect.

## Verification

- 10 unit tests (resumability WHERE shape, batching, writes target `embedding_qwen` not `embedding`, `::vector` not `::vector[]`, `--limit`, blank-row skip, batch-failure isolation) — all pass.
- Admin lint + typecheck clean.

## What's still operational (not in this PR)

1. **#1149's deploy must finish** — it creates the `embedding_qwen` columns on prod (in progress at time of writing).
2. **Run the backfill** — ~173k scene + ~4.3k transcript rows through the gateway (hours; resumable; run from the worker).
3. **Flip `AI_VIDEO_SEARCH_EMBEDDING_SOURCE=gateway`** — once the backfill is complete, so the AI search uses the Qwen column.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
