### PR TITLE
fix(mobile): watch player audit follow-ups (a11y, scrubber perf, fullscreen safe-area)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,69 @@
+# Product
+
+> Scope: the **consumer watch experience** — `apps/mobile` (forge-watch), and by extension the
+> `apps/web` and `apps/tv` watch surfaces that share the admin content layer. `apps/admin` and
+> the manager app are internal operator tools with a different register and are out of scope here.
+
+## Register
+
+product
+
+## Users
+
+JesusFilm's global audience: people seeking faith content — feature films, segments, and series —
+offered in thousands of languages and audio dubs. They arrive on a phone (often a low-end Android
+device) over constrained, low-bandwidth cellular networks. The job to be done is simple from their
+side: find something to watch in my language, watch it without friction, and discover what's next.
+Many will not have fast hardware or a reliable connection, so "works on the worst phone on the
+worst network" is a first-class requirement, not an edge case.
+
+## Product Purpose
+
+forge-watch is the consumer app for watching JesusFilm content. It renders a server-driven home
+feed (admin controls the content blocks and order), lets a viewer pick a language from a large dub
+catalog, plays HLS video with custom controls and CMS subtitles, and surrounds the player with
+related content — Up Next siblings, study questions, Bible quotes — that invite the viewer deeper.
+Success: a viewer reliably finds and plays content on any device or network, then keeps exploring
+the content below the video instead of leaving.
+
+## Brand Personality
+
+Warm, welcoming, and modern. Approachable and human, not clinical or corporate. The craft of the
+player should feel on par with a polished mainstream streaming app, but the surface is inviting
+rather than aggressive — it draws the viewer toward the content rather than demanding attention.
+Voice: clear, plain, and human. No jargon, no hype, no pressure.
+
+## Anti-references
+
+- **Cluttered / ad-heavy streaming apps.** No autoplay traps, nagging overlays, engagement dark
+  patterns, or controls competing for attention. The chrome serves the content, then gets out of
+  the way.
+- **Cold, corporate, sterile tools.** No gray, impersonal enterprise look. Warmth is carried by the
+  palette, typography, and imagery.
+
+## Design Principles
+
+1. **Controls serve the content, then recede.** The player chrome appears on demand, fades when
+   idle, and never fights the footage. The film leads; the UI supports.
+2. **Invite exploration.** The watch screen is a doorway, not a dead end. Up Next, study questions,
+   and Bible quotes below the player are part of the experience, not afterthoughts.
+3. **Works on the worst phone on the worst network.** Low-end Android and low-bandwidth cellular are
+   the design center, not a fallback. Fast first frame, bounded work on the JS thread, no jank
+   during interaction.
+4. **Accessible by default, not retrofit.** Reduce-motion, screen-reader operability, and
+   gesture-free control paths are built in from the start, not bolted on.
+5. **Warm, never cluttered.** Every affordance earns its place. Warmth through tone and craft;
+   restraint through what we leave out.
+
+## Accessibility & Inclusion
+
+- **Floor: WCAG 2.1 AA.** Text contrast >= 4.5:1 (>= 3:1 large), non-text/UI contrast >= 3:1,
+  touch targets >= 44x44, every control labeled and operable without a precise gesture.
+- **Reduced motion** is honored everywhere: fades snap, lifts snap, no motion is required to use a
+  control.
+- **Screen readers** (VoiceOver / TalkBack): auto-hide is suspended while a screen reader is active,
+  chrome force-reveals, and the seek bar is operable via increment/decrement actions rather than a
+  drag.
+- **Low-end Android / low bandwidth** is an inclusion concern: a concurrent-decoder budget, a
+  fast-first-frame buffering profile, and cache-first re-entry keep the app usable on weak hardware
+  and slow networks.

--- a/apps/mobile/app/watch/[slug].tsx
+++ b/apps/mobile/app/watch/[slug].tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
+  AccessibilityInfo,
   Animated,
   AppState,
   BackHandler,
@@ -25,7 +26,13 @@ import {
 } from "../../src/lib/normalizeVideo"
 import { decodeWatchSeed } from "../../src/lib/watchSeed"
 import { muxHlsUrlFromPlaybackId } from "../../src/lib/muxThumbnail"
-import { ACCENT } from "../../src/lib/color"
+import {
+  ACCENT_ON_DARK,
+  BLACK,
+  SURFACE_COLOR,
+  TEXT_PRIMARY,
+  hexToRgba,
+} from "../../src/lib/color"
 import { layout, text } from "../../src/styles/shared"
 import { VideoPlayer } from "../../src/components/watch/VideoPlayer"
 import {
@@ -64,8 +71,30 @@ export default function WatchVideoPage() {
   const [showNavTitle, setShowNavTitle] = useState(false)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const insets = useSafeAreaInsets()
+  // Honor reduce-motion for the scroll-to-top FAB and nav-title reveals, the
+  // way the player's chrome/subtitles already do — snap instead of fading.
+  const reduceMotionRef = useRef(false)
 
   const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), [])
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then((v) => {
+      reduceMotionRef.current = v
+    })
+    const sub = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      (v) => {
+        reduceMotionRef.current = v
+      },
+    )
+    return () => {
+      try {
+        sub.remove()
+      } catch {
+        // noop
+      }
+    }
+  }, [])
 
   // Fullscreen side-effects: hide the native header + disable the iOS edge-swipe
   // back (so it can't pop the route mid-fullscreen), and drive orientation.
@@ -222,16 +251,26 @@ export default function WatchVideoPage() {
   )
 
   useEffect(() => {
+    const to = showScrollTop ? 1 : 0
+    if (reduceMotionRef.current) {
+      scrollTopOpacity.setValue(to)
+      return
+    }
     Animated.timing(scrollTopOpacity, {
-      toValue: showScrollTop ? 1 : 0,
+      toValue: to,
       duration: 200,
       useNativeDriver: true,
     }).start()
   }, [showScrollTop, scrollTopOpacity])
 
   useEffect(() => {
+    const to = showNavTitle ? 1 : 0
+    if (reduceMotionRef.current) {
+      titleOpacity.setValue(to)
+      return
+    }
     Animated.timing(titleOpacity, {
-      toValue: showNavTitle ? 1 : 0,
+      toValue: to,
       duration: 200,
       useNativeDriver: true,
     }).start()
@@ -414,7 +453,7 @@ export default function WatchVideoPage() {
             accessibilityRole="button"
             accessibilityLabel="Scroll to top"
           >
-            <Ionicons name="chevron-up" size={22} color="#f5f5f4" />
+            <Ionicons name="chevron-up" size={22} color={TEXT_PRIMARY} />
           </Pressable>
         </Animated.View>
       )}
@@ -436,7 +475,7 @@ const styles = StyleSheet.create({
     paddingBottom: 80,
   },
   navTitle: {
-    color: "#f5f5f4",
+    color: TEXT_PRIMARY,
     fontSize: 17,
     fontWeight: "600",
     fontFamily: "System",
@@ -451,7 +490,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   retryLink: {
-    color: ACCENT,
+    // ACCENT_ON_DARK, not ACCENT: 15px link text needs >= 4.5:1 on the dark bg.
+    color: ACCENT_ON_DARK,
     fontFamily: "System",
     fontSize: 15,
     fontWeight: "600",
@@ -466,10 +506,10 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: "rgba(41, 37, 36, 0.85)",
+    backgroundColor: hexToRgba(SURFACE_COLOR, 0.85),
     justifyContent: "center",
     alignItems: "center",
-    shadowColor: "#000",
+    shadowColor: BLACK,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.3,
     shadowRadius: 4,

--- a/apps/mobile/src/components/watch/PlayerControls.tsx
+++ b/apps/mobile/src/components/watch/PlayerControls.tsx
@@ -3,8 +3,9 @@ import { Pressable, StyleSheet, Text, View } from "react-native"
 import Ionicons from "@expo/vector-icons/Ionicons"
 import type { VideoPlayer } from "expo-video"
 import { useEvent } from "expo"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 
-import { TEXT_ON_OVERLAY } from "../../lib/color"
+import { BLACK, TEXT_ON_OVERLAY, hexToRgba } from "../../lib/color"
 import { useTypography } from "../../hooks/useTypography"
 import { applySkip } from "../../lib/scrubber"
 import { SKIP_SECONDS } from "../../lib/tapSeek"
@@ -36,6 +37,7 @@ export function PlayerControls({
   seekSignal,
 }: PlayerControlsProps) {
   const typography = useTypography()
+  const insets = useSafeAreaInsets()
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   const [isMuted, setIsMuted] = useState(false)
@@ -185,7 +187,12 @@ export function PlayerControls({
           accessibilityRole="button"
           accessibilityLabel={`Back ${SKIP_SECONDS} seconds`}
         >
-          <Ionicons name="play-back" size={24} color={TEXT_ON_OVERLAY} />
+          <Ionicons
+            name="play-back"
+            size={24}
+            color={TEXT_ON_OVERLAY}
+            style={styles.centerIcon}
+          />
         </Pressable>
 
         <Pressable
@@ -198,7 +205,11 @@ export function PlayerControls({
             name={ended ? "reload" : isPlaying ? "pause" : "play"}
             size={24}
             color={TEXT_ON_OVERLAY}
-            style={!ended && !isPlaying ? { marginLeft: 3 } : undefined}
+            // Ionicons' style prop takes a single object, not an array.
+            style={StyleSheet.flatten([
+              styles.centerIcon,
+              !ended && !isPlaying ? styles.playGlyphNudge : null,
+            ])}
           />
         </Pressable>
 
@@ -208,16 +219,41 @@ export function PlayerControls({
           accessibilityRole="button"
           accessibilityLabel={`Forward ${SKIP_SECONDS} seconds`}
         >
-          <Ionicons name="play-forward" size={24} color={TEXT_ON_OVERLAY} />
+          <Ionicons
+            name="play-forward"
+            size={24}
+            color={TEXT_ON_OVERLAY}
+            style={styles.centerIcon}
+          />
         </Pressable>
       </View>
 
-      <View style={styles.bottomBar}>
+      <View
+        style={[
+          styles.bottomBar,
+          // In landscape fullscreen the bar would otherwise sit under the side
+          // notch and the home indicator. Inline (16:9 box) needs no insets.
+          fullscreen && {
+            paddingBottom: Math.max(insets.bottom, 8),
+            paddingLeft: Math.max(insets.left, 12),
+            paddingRight: Math.max(insets.right, 12),
+          },
+        ]}
+      >
         <View style={styles.timeRow}>
-          <Text style={[styles.timeText, typography.caption]}>
+          <Text
+            style={[styles.timeText, typography.caption]}
+            accessibilityLabel={`Elapsed ${formatTime(displayedTime)} of ${formatTime(duration)}`}
+          >
             {formatTime(displayedTime)}
           </Text>
-          <Text style={[styles.timeText, typography.caption]}>
+          {/* The total is already spoken in the elapsed label above; hide this
+              duplicate from screen readers so the position isn't announced twice. */}
+          <Text
+            style={[styles.timeText, typography.caption]}
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+          >
             {formatTime(duration)}
           </Text>
         </View>
@@ -282,11 +318,23 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
+  // The center cluster sits above the bottom scrim, so over a bright frame the
+  // white glyphs need their own contrast. The play button carries a backplate;
+  // the skip glyphs lean on this shadow halo (same technique as the captions)
+  // to clear the WCAG 1.4.11 3:1 bar against any footage.
+  centerIcon: {
+    textShadowColor: hexToRgba(BLACK, 0.6),
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 4,
+  },
+  playGlyphNudge: {
+    marginLeft: 3,
+  },
   playButton: {
     width: 56,
     height: 56,
     borderRadius: 28,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    backgroundColor: hexToRgba(BLACK, 0.5),
     justifyContent: "center",
     alignItems: "center",
   },

--- a/apps/mobile/src/components/watch/Scrubber.tsx
+++ b/apps/mobile/src/components/watch/Scrubber.tsx
@@ -1,13 +1,17 @@
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
+  Animated,
   PanResponder,
   StyleSheet,
   View,
   type GestureResponderEvent,
+  type LayoutChangeEvent,
   type PanResponderGestureState,
 } from "react-native"
+// `useState` drives only the track-width layout value below — never the drag,
+// which is animated without re-rendering.
 
-import { ACCENT } from "../../lib/color"
+import { ACCENT, TEXT_ON_OVERLAY, hexToRgba } from "../../lib/color"
 import {
   applySkip,
   clamp,
@@ -28,16 +32,27 @@ type ScrubberProps = {
 }
 
 const THUMB = 14
+const TRACK_HEIGHT = 3
+const HIT_HEIGHT = 44
 
 /**
  * Draggable seek bar (built-in PanResponder — react-native-gesture-handler is
  * forbidden under Expo Go).
  *
+ * Position is driven by an `Animated.Value` (0..1), NOT React state: the fill
+ * uses `scaleX` (anchored left via `transformOrigin`) and the thumb uses
+ * `translateX`, both updated with `setValue` on every pan move. `setValue`
+ * pushes straight to the native view without a React re-render, so a drag never
+ * re-renders this component or its parent — the previous setState-per-frame
+ * approach re-rendered both on every touch sample, which janks on the low-end
+ * Android devices this app targets. The parent's preview-time callback (which
+ * does setState) is throttled to whole-second changes for the same reason.
+ *
  * The fraction is computed from the gesture's ABSOLUTE screen X minus the
  * track's measured left edge — NOT `nativeEvent.locationX`, which is relative
- * to whichever child view (thumb/fill) is under the finger and under-reports as
- * the thumb moves, making the thumb lag behind the finger. `measureInWindow`
- * keeps the track origin/width current across layout + rotation changes.
+ * to whichever child view is under the finger and under-reports as the thumb
+ * moves. `measureInWindow` keeps the track origin/width current across layout +
+ * rotation changes.
  */
 export function Scrubber({
   currentTime,
@@ -50,8 +65,14 @@ export function Scrubber({
   // Last fraction from grant/move. Release seeks to THIS, not a fresh read of
   // gestureState.moveX — on a tap (no move) moveX is 0, which would seek to 0.
   const lastFractionRef = useRef(0)
-  const [dragging, setDragging] = useState(false)
-  const [dragFraction, setDragFraction] = useState(0)
+  // Track width in state so the thumb's translateX interpolation has a concrete
+  // output range; set on layout/rotation only, never per drag frame.
+  const [trackWidth, setTrackWidth] = useState(0)
+
+  // Native-friendly position (0..1) and thumb grow-on-grab scale. Both updated
+  // via setValue so the gesture never triggers a React render.
+  const progress = useRef(new Animated.Value(0)).current
+  const thumbScale = useRef(new Animated.Value(1)).current
 
   // Mirror live props into refs so the PanResponder (created once) reads
   // current values instead of the closure captured on first render.
@@ -61,6 +82,10 @@ export function Scrubber({
   onSeekRef.current = onSeek
   const onScrubChangeRef = useRef(onScrubChange)
   onScrubChangeRef.current = onScrubChange
+  const draggingRef = useRef(false)
+  // Last whole second pushed to the parent label, so the preview callback fires
+  // at most ~once per displayed second instead of once per frame.
+  const lastWholeSecondRef = useRef(-1)
 
   const measure = () => {
     containerRef.current?.measureInWindow((x, _y, width) => {
@@ -71,6 +96,25 @@ export function Scrubber({
   const fractionFromAbsX = (absX: number) => {
     const { x, width } = trackRef.current
     return clamp(width > 0 ? (absX - x) / width : 0, 0, 1)
+  }
+
+  // Keep the position synced to playback whenever NOT dragging. setValue (not
+  // setState) so the 500ms poll advancing currentTime never re-renders us.
+  useEffect(() => {
+    if (draggingRef.current) return
+    progress.setValue(progressFraction(currentTime, duration))
+  }, [currentTime, duration, progress])
+
+  // Emit the preview time to the parent, but only when the displayed (whole)
+  // second changes — the label shows mm:ss, so sub-second emits are wasted
+  // setState in the parent.
+  const emitPreviewThrottled = (f: number) => {
+    const t = fractionToTime(f, durationRef.current)
+    if (t == null) return
+    const whole = Math.floor(t)
+    if (whole === lastWholeSecondRef.current) return
+    lastWholeSecondRef.current = whole
+    onScrubChangeRef.current?.(true, t)
   }
 
   const pan = useRef(
@@ -91,9 +135,13 @@ export function Scrubber({
         measure()
         const f = fractionFromAbsX(g.x0)
         lastFractionRef.current = f
-        setDragging(true)
-        setDragFraction(f)
-        onScrubChangeRef.current?.(true, fractionToTime(f, durationRef.current))
+        draggingRef.current = true
+        progress.setValue(f)
+        thumbScale.setValue(1.4)
+        // Always emit the start so the parent suppresses its poll immediately.
+        const t = fractionToTime(f, durationRef.current)
+        lastWholeSecondRef.current = t == null ? -1 : Math.floor(t)
+        onScrubChangeRef.current?.(true, t)
       },
       onPanResponderMove: (
         _e: GestureResponderEvent,
@@ -101,40 +149,59 @@ export function Scrubber({
       ) => {
         const f = fractionFromAbsX(g.moveX)
         lastFractionRef.current = f
-        setDragFraction(f)
-        onScrubChangeRef.current?.(true, fractionToTime(f, durationRef.current))
+        progress.setValue(f) // native update, no React render
+        emitPreviewThrottled(f)
       },
       onPanResponderRelease: () => {
         // Seek to the last grant/move fraction — NOT a fresh moveX read, which
         // is 0 on a tap and would reset to the start.
         const t = fractionToTime(lastFractionRef.current, durationRef.current)
-        setDragging(false)
+        draggingRef.current = false
+        thumbScale.setValue(1)
         onScrubChangeRef.current?.(false, null)
         if (t != null) onSeekRef.current(t)
       },
       onPanResponderTerminate: () => {
-        setDragging(false)
+        draggingRef.current = false
+        thumbScale.setValue(1)
         onScrubChangeRef.current?.(false, null)
       },
     }),
   ).current
 
-  const fraction = dragging
-    ? dragFraction
-    : progressFraction(currentTime, duration)
-  const pct = `${fraction * 100}%` as const
+  // 0..1 → [0, trackWidth] px. Rebuilt when the track is (re)measured, not per
+  // frame; the thumb is centered on the position via the static marginLeft.
+  const thumbTranslateX = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, trackWidth],
+  })
 
   return (
     <View
       ref={containerRef}
       style={styles.hitArea}
-      onLayout={measure}
+      onLayout={(e: LayoutChangeEvent) => {
+        measure()
+        setTrackWidth(e.nativeEvent.layout.width)
+      }}
+      // accessible MUST be set explicitly: a plain View with an
+      // accessibilityRole is NOT promoted to an accessibility element on iOS
+      // (unlike Pressable), so without this the adjustable role + the
+      // increment/decrement actions below never reach VoiceOver/Switch Control
+      // — the seek bar was silently unreachable to assistive tech.
+      accessible
       accessibilityRole="adjustable"
       accessibilityLabel="Seek bar"
       // The seek bar is drag-only by touch; expose increment/decrement so
       // VoiceOver/Switch Control (and idb automation) can operate it without a
-      // drag gesture. Swipe up/down → ±10s, matching the skip buttons.
-      accessibilityValue={{ min: 0, max: 100, now: Math.round(fraction * 100) }}
+      // drag gesture. Swipe up/down → ±10s, matching the skip buttons. `now`
+      // reads the playback position (props), which is what a screen-reader user
+      // tracks — they use the actions above rather than dragging.
+      accessibilityValue={{
+        min: 0,
+        max: 100,
+        now: Math.round(progressFraction(currentTime, duration) * 100),
+      }}
       onAccessibilityAction={(e) => {
         const delta =
           e.nativeEvent.actionName === "increment"
@@ -146,13 +213,16 @@ export function Scrubber({
       {...pan.panHandlers}
     >
       <View style={styles.track}>
-        <View style={[styles.fill, { width: pct }]} />
+        <Animated.View
+          style={[styles.fill, { transform: [{ scaleX: progress }] }]}
+        />
       </View>
-      <View
+      <Animated.View
         style={[
           styles.thumb,
-          dragging && styles.thumbActive,
-          { left: pct, marginLeft: -THUMB / 2 },
+          {
+            transform: [{ translateX: thumbTranslateX }, { scale: thumbScale }],
+          },
         ]}
       />
     </View>
@@ -160,22 +230,24 @@ export function Scrubber({
 }
 
 const styles = StyleSheet.create({
-  // Tall, transparent hit area for an easy grab; the visible track is thin.
+  // Tall (44px), transparent hit area for an easy, accessible grab; the visible
+  // track is thin and vertically centered within it.
   hitArea: {
-    height: 28,
+    height: HIT_HEIGHT,
     justifyContent: "center",
-    marginBottom: 4,
   },
   track: {
-    height: 3,
-    backgroundColor: "rgba(255, 255, 255, 0.3)",
-    borderRadius: 1.5,
+    height: TRACK_HEIGHT,
+    backgroundColor: hexToRgba(TEXT_ON_OVERLAY, 0.3),
+    borderRadius: TRACK_HEIGHT / 2,
     overflow: "hidden",
   },
   fill: {
     height: "100%",
+    width: "100%",
     backgroundColor: ACCENT,
-    borderRadius: 1.5,
+    // Scale from the left edge so scaleX = fraction fills left-to-right.
+    transformOrigin: "left center",
   },
   thumb: {
     position: "absolute",
@@ -183,9 +255,9 @@ const styles = StyleSheet.create({
     height: THUMB,
     borderRadius: THUMB / 2,
     backgroundColor: ACCENT,
-    top: 14 - THUMB / 2,
-  },
-  thumbActive: {
-    transform: [{ scale: 1.4 }],
+    // Vertically center on the track; horizontally center on the position.
+    top: (HIT_HEIGHT - THUMB) / 2,
+    left: 0,
+    marginLeft: -THUMB / 2,
   },
 })

--- a/apps/mobile/src/components/watch/Scrubber.tsx
+++ b/apps/mobile/src/components/watch/Scrubber.tsx
@@ -8,8 +8,6 @@ import {
   type LayoutChangeEvent,
   type PanResponderGestureState,
 } from "react-native"
-// `useState` drives only the track-width layout value below — never the drag,
-// which is animated without re-rendering.
 
 import { ACCENT, TEXT_ON_OVERLAY, hexToRgba } from "../../lib/color"
 import {
@@ -202,6 +200,9 @@ export function Scrubber({
         max: 100,
         now: Math.round(progressFraction(currentTime, duration) * 100),
       }}
+      // Declare the actions explicitly so TalkBack (Android — the primary
+      // audience) registers them; iOS infers them from the adjustable role.
+      accessibilityActions={[{ name: "increment" }, { name: "decrement" }]}
       onAccessibilityAction={(e) => {
         const delta =
           e.nativeEvent.actionName === "increment"
@@ -217,14 +218,24 @@ export function Scrubber({
           style={[styles.fill, { transform: [{ scaleX: progress }] }]}
         />
       </View>
-      <Animated.View
-        style={[
-          styles.thumb,
-          {
-            transform: [{ translateX: thumbTranslateX }, { scale: thumbScale }],
-          },
-        ]}
-      />
+      {/* Render the thumb only once the track is measured. With trackWidth 0
+          (every chrome reveal remounts the Scrubber), the translateX
+          interpolation collapses to [0, 0] and the thumb would sit at the left
+          edge while the fill already shows the real position — a one-frame
+          desync. The fill is immune (scaleX needs no width). */}
+      {trackWidth > 0 && (
+        <Animated.View
+          style={[
+            styles.thumb,
+            {
+              transform: [
+                { translateX: thumbTranslateX },
+                { scale: thumbScale },
+              ],
+            },
+          ]}
+        />
+      )}
     </View>
   )
 }

--- a/apps/mobile/src/components/watch/SubtitleOverlay.tsx
+++ b/apps/mobile/src/components/watch/SubtitleOverlay.tsx
@@ -9,6 +9,7 @@ import {
 import type { VideoPlayer as ExpoVideoPlayer } from "expo-video"
 import { useEvent } from "expo"
 
+import { BLACK, TEXT_ON_OVERLAY, hexToRgba } from "../../lib/color"
 import { parseVtt, type VttCue } from "../../lib/parseVtt"
 import { validateActionUrl } from "../../lib/validateUrl"
 
@@ -211,16 +212,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
   },
   text: {
-    color: "#ffffff",
+    color: TEXT_ON_OVERLAY,
     fontSize: 16,
     fontFamily: "System",
     textAlign: "center",
-    backgroundColor: "rgba(0, 0, 0, 0.7)",
+    backgroundColor: hexToRgba(BLACK, 0.7),
     paddingHorizontal: 10,
     paddingVertical: 4,
     borderRadius: 4,
     overflow: "hidden",
-    textShadowColor: "rgba(0, 0, 0, 0.9)",
+    textShadowColor: hexToRgba(BLACK, 0.9),
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 2,
   },

--- a/apps/mobile/src/components/watch/VideoPlayer.tsx
+++ b/apps/mobile/src/components/watch/VideoPlayer.tsx
@@ -459,7 +459,7 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 16,
     borderRadius: 999,
-    backgroundColor: "rgba(0, 0, 0, 0.55)",
+    backgroundColor: hexToRgba(BLACK, 0.55),
   },
   seekFlashLeft: {
     left: "14%",

--- a/apps/mobile/src/lib/color.ts
+++ b/apps/mobile/src/lib/color.ts
@@ -19,8 +19,18 @@ export const TEXT_SECONDARY = "#a8a29e"
 /** Body text (stone-300). */
 export const TEXT_BODY = "#d6d3d1"
 
-/** Brand accent (JFP red). */
+/** Brand accent (JFP red). For fills, large text, and non-text UI (3:1 bar). */
 export const ACCENT = "#CB333B"
+
+/**
+ * Brand accent tuned for legible TEXT and links on the dark palette.
+ *
+ * ACCENT (#CB333B) measures only ~3.4:1 on BG_COLOR (and ~3.2:1 on
+ * SURFACE_COLOR) — below the WCAG AA 4.5:1 floor for normal-size text. This
+ * lighter red clears 4.5:1 on both dark surfaces (~5.3:1 on BG, ~4.6:1 on
+ * surface). Use it for accent text/links; keep ACCENT for fills and large text.
+ */
+export const ACCENT_ON_DARK = "#E96067"
 
 /** Text rendered on image/gradient overlays. */
 export const TEXT_ON_OVERLAY = "#ffffff"

--- a/apps/mobile/src/styles/shared.ts
+++ b/apps/mobile/src/styles/shared.ts
@@ -12,6 +12,7 @@ import { StyleSheet } from "react-native"
 
 import {
   ACCENT,
+  ACCENT_ON_DARK,
   BG_COLOR,
   SURFACE_COLOR,
   TEXT_PRIMARY,
@@ -91,7 +92,8 @@ export const text = StyleSheet.create({
   },
   accentLinkText: {
     fontWeight: "600",
-    color: ACCENT,
+    // ACCENT_ON_DARK, not ACCENT: link text needs >= 4.5:1 on the dark bg (AA).
+    color: ACCENT_ON_DARK,
     fontFamily: "System",
   },
 })

--- a/docs/solutions/mobile/rn-view-accessible-required-for-accessibilityrole.md
+++ b/docs/solutions/mobile/rn-view-accessible-required-for-accessibilityrole.md
@@ -1,0 +1,97 @@
+---
+title: "RN View with accessibilityRole needs accessible={true} to reach the iOS a11y tree"
+date: "2026-06-08"
+category: mobile
+module: apps/mobile
+problem_type: ui_bug
+component: apps/mobile/src/components/watch/Scrubber.tsx
+severity: high
+symptoms:
+  - "Seek bar element absent from the idb describe-all accessibility tree on iOS"
+  - "VoiceOver / Switch Control skip the scrubber entirely while sibling Pressable buttons (Play, Mute, Fullscreen) are reachable"
+  - "accessibilityRole / accessibilityLabel / accessibilityValue / onAccessibilityAction set in JS but never surfaced to the native a11y layer"
+  - "increment / decrement accessibility actions never fire; no runtime error or warning (silent)"
+root_cause: wrong_api
+resolution_type: code_fix
+tags:
+  - react-native
+  - accessibility
+  - voiceover
+  - talkback
+  - scrubber
+  - video-player
+  - ios
+---
+
+# RN View with accessibilityRole needs accessible={true} to reach the iOS a11y tree
+
+## Problem
+
+A custom video seek bar built as a plain `View` (with a `PanResponder` for drag) carried a full set of accessibility props but was **completely absent from the iOS accessibility tree**. VoiceOver, Switch Control, and `idb` automation could not reach it, and its increment/decrement actions never fired — the only way to seek was a touch drag, leaving assistive-tech users with no path to the control.
+
+## Symptoms
+
+- `idb ui describe-all` on the running app returned **no "Seek bar" element**, while every sibling `Pressable`-based control (Play, Mute, Fullscreen) appeared normally.
+- VoiceOver skipped over the scrubber entirely.
+- `onAccessibilityAction` (increment/decrement = ±10s) never triggered from assistive tech or automation.
+- No runtime error or warning — the failure was silent.
+
+## What Didn't Work
+
+The static `/impeccable` design audit **and** the initial code review both _credited_ the scrubber as a positive accessibility implementation. Every prop was present and correct:
+
+```tsx
+<View
+  accessibilityRole="adjustable"
+  accessibilityLabel="Seek bar"
+  accessibilityValue={{ min: 0, max: 100, now }}
+  onAccessibilityAction={(e) => { /* increment/decrement = ±10s */ }}
+  {...pan.panHandlers}
+>
+```
+
+On paper the element looked complete, so reading the source never flagged it. **This class of defect is invisible to code review** — the iOS accessibility-element promotion is runtime behavior, not a prop-presence fact. There is nothing in the source to catch.
+
+It was found only by inspecting the **live accessibility tree** in the simulator (auto memory [claude]): `idb ui describe-all` showed the "Seek bar" simply was not in the tree, while every adjacent `Pressable` button was. The contrast — buttons present, the `View`-based slider absent — is what pinpointed the missing `accessible`.
+
+## Solution
+
+Set `accessible` on the `View` (and declare `accessibilityActions` explicitly for Android TalkBack):
+
+```tsx
+<View
+  accessible                                                       // ← promotes the View into the native a11y tree
+  accessibilityRole="adjustable"
+  accessibilityLabel="Seek bar"
+  accessibilityValue={{ min: 0, max: 100, now }}
+  accessibilityActions={[{ name: "increment" }, { name: "decrement" }]}  // TalkBack registers these; iOS infers from the adjustable role
+  onAccessibilityAction={(e) => { /* increment/decrement = ±10s */ }}
+  {...pan.panHandlers}
+>
+```
+
+After the fix, `idb ui describe-all` returned `role=AXSlider label='Seek bar' val='0%' height=44`; drag, seek, and the increment/decrement path all verified in the simulator (auto memory [claude]).
+
+## Why This Works
+
+`Pressable` and `TouchableOpacity` mark their underlying native view as an accessibility element implicitly — they are interactive by design, so React Native promotes them automatically. A plain `View` does **not** get that implicit promotion. Without `accessible={true}`, React Native writes the role/label/value/actions into the JS-side accessibility node but never flags the native view as an accessibility element, so iOS `UIAccessibility` never surfaces it to assistive technology.
+
+`accessibilityActions` is not strictly required on iOS — the `adjustable` role implies increment/decrement — but Android TalkBack needs the array to enumerate the actions, so declaring it explicitly is the cross-platform-safe choice.
+
+## Prevention
+
+- **Prop rule:** any `View` carrying `accessibilityRole`, `accessibilityLabel`, `accessibilityValue`, or `accessibilityActions` must also set `accessible`. Without it, those props are dead weight.
+- **Prefer `Pressable`** for anything interactive — it provides the implicit promotion, press feedback, and hit-slop. Reserve plain `View` + `accessible` for cases where gesture ownership (here, `PanResponder` — `react-native-gesture-handler` is forbidden under Expo Go) rules out `Pressable`.
+- **Verify the tree, not the props** (auto memory [claude]): after any a11y change, run `idb ui describe-all` against the running simulator and confirm the element appears with the expected role/label/value. Typecheck and unit tests prove the props exist; only the live a11y tree proves the native layer sees the element.
+- **Grep heuristic** for the silent-exclusion bug:
+  ```bash
+  grep -rn "accessibilityRole" apps/mobile/src | grep -v "accessible"
+  ```
+  Any `View` (not `Pressable`/`Touchable`) hit is a candidate.
+
+## Related Issues
+
+- `docs/solutions/mobile/decorative-icon-view-text-pattern.md` — the inverse concern: _hiding_ decorative `View`s from the a11y tree via `accessibilityElementsHidden` + `importantForAccessibility`. Together these cover the hide/show playbook for plain `View`s.
+- `docs/solutions/best-practices/react-native-tvos-porting-pitfalls-20260414.md` — `accessible={false}` on a Pressable to suppress focus; opposite polarity, same promotion mechanism.
+- `docs/solutions/mobile/audit-driven-video-detail-refactor.md` — removing a misleading `accessibilityRole="adjustable"` from a carousel; same role, same a11y-role-misuse theme.
+- `docs/solutions/mobile/hero-mute-button-hybrid-overlay-touch-target.md` — `Pressable` with `accessibilityRole="button"`; illustrates the implicit promotion a plain `View` lacks.


### PR DESCRIPTION
## What

Follow-up pass on the mobile watch player (PR #1157), resolving the findings from an `/impeccable` design audit and a `ce-code-review`. Player behavior is unchanged; this hardens accessibility, performance, and responsive correctness, and routes literal colors through tokens.

Verified in the iOS simulator on `birth-of-jesus` (incl. a near-white frame and landscape fullscreen). Full mobile suite green: 138/138 tests, typecheck + lint clean.

## Changes

**Accessibility**
- Add `ACCENT_ON_DARK` (#E96067) for accent text/links: `ACCENT` (#CB333B) was ~3.4:1 on the dark bg, below WCAG AA 4.5:1 for normal text. Applied to the retry link and the shared `accentLinkText`.
- Shadow halo on the center skip glyphs so they clear 3:1 (WCAG 1.4.11) over bright footage; the play button keeps its backplate.
- Scrubber hit area 28px → 44px.
- Expose the scrubber to assistive tech: a plain `View` with `accessibilityRole` is **not** promoted to an a11y element on iOS, so the adjustable role + increment/decrement actions were silently unreachable. Added `accessible` (now an `AXSlider`) and explicit `accessibilityActions` for TalkBack.
- Time label announces "Elapsed X of Y"; the duplicate is hidden from screen readers.
- Reduce-motion gating on the scroll-to-top FAB and nav-title fades.

**Performance**
- Rewrote the scrubber drag to use an `Animated.Value` (fill `scaleX` via `transformOrigin`, thumb `translateX`) updated by `setValue` instead of per-frame `setState`; the parent preview is throttled to whole-second changes. The previous code re-rendered the tree every pan frame, which janks on the low-end Android target.

**Responsive**
- Apply safe-area insets to the control bar in landscape fullscreen so the scrubber/mute/fullscreen clear the notch and home indicator.

**Theming**
- Route remaining literal colors through tokens / `hexToRgba` (seek-flash bg, play-button backplate, subtitle colors, scrubber track, nav title, chevron, scroll-top FAB bg + shadow).

**Code-review hardening** (`fix(review)`)
- Render the seek-bar thumb only once `trackWidth` is measured: on every chrome reveal the Scrubber remounts with `trackWidth=0`, collapsing the thumb's `translateX` interpolation to `[0,0]` — the thumb sat at the left edge for a frame while the fill already showed the real position. Flagged independently by two reviewers; verified fixed in-sim.

**Docs**
- Add root `PRODUCT.md` capturing the consumer watch experience (register, users, brand, anti-references, accessibility bar).

## Follow-ups (not in this PR)
- Extract a shared `useReduceMotion()` hook (the seed+subscribe block is now duplicated across 3 files).
- Sweep `color: ACCENT` → `ACCENT_ON_DARK` for small text in pre-existing sites (`DownloadSheet`, `SheetError`, `(tabs)/watch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
