### PR TITLE
feat(admin): use Qwen query embeddings via OpenRouter

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1366,8 +1366,8 @@ error_class=… message=…`. Process-local counters in
    `https://admin.jesusfilm.org/api/search/health`. Body's `status`
    field is the signal; HTTP is always 200 so infra-level liveness is
    not confused with provider reachability.
-2. Ensure `OPENROUTER_API_KEY` or `OPENAI_API_KEY` is set on the
-   `forge-admin` Railway service (already required by R1–R3).
+2. Ensure `OPENROUTER_API_KEY` is set on the `forge-admin` Railway service.
+   `OPENAI_API_KEY` does not satisfy live query embedding readiness.
 3. Canary diff vs cms: for a fixed query set × locales, compare
    `admin/api/search?q=…&locale=…` to `cms/api/search?q=…&locale=…`.
    Top-10 should overlap within ranking ±1. Drift signals either a

--- a/apps/admin/docs/v1-operational-surfaces.md
+++ b/apps/admin/docs/v1-operational-surfaces.md
@@ -37,8 +37,8 @@ version of `apps/admin`.
 - Workflow run inspection uses the Workflow runtime event log. Forge-owned
   trigger actions still live on their domain surfaces, such as Core Sync on
   `/dashboard/system-status`.
-- Semantic search requires `OPENROUTER_API_KEY` or `OPENAI_API_KEY`. Without one
-  of those, the page stays usable but reports the missing provider explicitly.
+- Semantic search requires `OPENROUTER_API_KEY`. Without it, the page stays
+  usable but reports the missing provider explicitly.
 
 ## Validation
 

--- a/apps/admin/src/app/dashboard/ops-data.test.ts
+++ b/apps/admin/src/app/dashboard/ops-data.test.ts
@@ -7,9 +7,24 @@ const { userCount, userFindMany, managerMembershipFindMany } = vi.hoisted(
     managerMembershipFindMany: vi.fn(),
   }),
 )
+const { queryRaw, mockEnv } = vi.hoisted(() => ({
+  queryRaw: vi.fn(),
+  mockEnv: {
+    env: {
+      ADMIN_BASE_URL: "https://admin.example",
+      ADMIN_SESSION_SECRET: "x".repeat(32),
+      AUTH_ADMIN_CLIENT_ID: "admin-client",
+      AUTH_ISSUER_URL: "https://auth.example",
+      CORS_ALLOWED_ORIGINS: "",
+      OPENROUTER_API_KEY: undefined as string | undefined,
+      OPENAI_API_KEY: undefined as string | undefined,
+    },
+  },
+}))
 
 vi.mock("@/db/client", () => ({
   prisma: {
+    $queryRaw: (...args: unknown[]) => queryRaw(...args),
     user: {
       count: (...args: unknown[]) => userCount(...args),
       findMany: (...args: unknown[]) => userFindMany(...args),
@@ -20,20 +35,52 @@ vi.mock("@/db/client", () => ({
   },
 }))
 
-vi.mock("@/config/env", () => ({
-  env: {
-    AUTH_ISSUER_URL: "https://auth.example",
-    CORS_ALLOWED_ORIGINS: "",
-  },
-}))
+vi.mock("@/config/env", () => mockEnv)
 
 import {
   buildUserTableRow,
   buildLanguageDiagnosticRow,
+  loadEmbeddingsData,
+  loadSettingsData,
   loadUsersData,
+  runSemanticSearch,
   type LanguageDiagnosticSourceRow,
   type UserAccessSourceRow,
 } from "@/app/dashboard/ops-data"
+import type { Principal } from "@/auth/principal"
+
+const ADMIN_PRINCIPAL = {
+  id: "admin-1",
+  role: "ADMIN",
+} as const satisfies Principal
+
+function resetMockEnv() {
+  mockEnv.env.OPENROUTER_API_KEY = undefined
+  mockEnv.env.OPENAI_API_KEY = undefined
+}
+
+function mockEmbeddingCounts({
+  total = 0,
+  embedded = 0,
+  published = 0,
+}: {
+  total?: number
+  embedded?: number
+  published?: number
+} = {}) {
+  queryRaw.mockResolvedValueOnce([
+    {
+      total: BigInt(total),
+      embedded: BigInt(embedded),
+      published: BigInt(published),
+    },
+  ])
+}
+
+beforeEach(() => {
+  queryRaw.mockReset()
+  resetMockEnv()
+})
 
 function sourceRow(
   overrides: Partial<LanguageDiagnosticSourceRow> = {},
@@ -116,6 +163,59 @@ function userSourceRow(
     ...overrides,
   }
 }
+
+describe("embedding provider readiness", () => {
+  it("does not treat OPENAI_API_KEY alone as configured for embeddings", async () => {
+    mockEnv.env.OPENAI_API_KEY = "legacy-openai-key"
+    mockEmbeddingCounts({ total: 2, embedded: 1, published: 1 })
+    queryRaw.mockResolvedValueOnce([])
+
+    const data = await loadEmbeddingsData()
+
+    expect(data.providerReady).toBe(false)
+    expect(
+      data.insights.find((insight) => insight.label === "Provider"),
+    ).toEqual(expect.objectContaining({ value: "Missing" }))
+  })
+
+  it("reports OpenRouter as the only ready embedding backend", async () => {
+    mockEnv.env.OPENROUTER_API_KEY = "openrouter-key"
+    mockEnv.env.OPENAI_API_KEY = "legacy-openai-key"
+    mockEmbeddingCounts({ total: 2, embedded: 2, published: 1 })
+    queryRaw.mockResolvedValueOnce([])
+
+    const embeddings = await loadEmbeddingsData()
+    const settings = await loadSettingsData()
+
+    expect(embeddings.providerReady).toBe(true)
+    expect(
+      embeddings.insights.find((insight) => insight.label === "Provider"),
+    ).toEqual(expect.objectContaining({ value: "OpenRouter" }))
+    expect(
+      settings.insights.find(
+        (insight) => insight.label === "Embedding Backend",
+      ),
+    ).toEqual(expect.objectContaining({ value: "OpenRouter" }))
+  })
+
+  it("keeps semantic search unavailable when only OPENAI_API_KEY is set", async () => {
+    mockEnv.env.OPENAI_API_KEY = "legacy-openai-key"
+    mockEmbeddingCounts({ total: 2, embedded: 1, published: 1 })
+
+    const data = await runSemanticSearch({
+      queryText: "hope",
+      locale: "en",
+      user: ADMIN_PRINCIPAL,
+    })
+
+    expect(data.metrics.find((metric) => metric.label === "Provider")).toEqual(
+      expect.objectContaining({ value: "Missing" }),
+    )
+    expect(data.unavailableReason).toBe(
+      "Semantic search requires OPENROUTER_API_KEY.",
+    )
+  })
+})
 
 describe("loadUsersData", () => {
   beforeEach(() => {

--- a/apps/admin/src/app/dashboard/ops-data.ts
+++ b/apps/admin/src/app/dashboard/ops-data.ts
@@ -1647,11 +1647,7 @@ export async function loadEmbeddingsData(): Promise<EmbeddingsData> {
     insights: [
       {
         label: "Provider",
-        value: env.OPENROUTER_API_KEY
-          ? "OpenRouter"
-          : env.OPENAI_API_KEY
-            ? "OpenAI"
-            : "Missing",
+        value: env.OPENROUTER_API_KEY ? "OpenRouter" : "Missing",
         detail:
           "Embedding generation backend currently configured for admin workflows.",
       },
@@ -1669,7 +1665,7 @@ export async function loadEmbeddingsData(): Promise<EmbeddingsData> {
         detail: "Published locales participating in retrieval once embedded.",
       },
     ],
-    providerReady: Boolean(env.OPENROUTER_API_KEY || env.OPENAI_API_KEY),
+    providerReady: Boolean(env.OPENROUTER_API_KEY),
   }
 }
 
@@ -2251,11 +2247,7 @@ export async function loadSettingsData(): Promise<SettingsData> {
       },
       {
         label: "Embedding Backend",
-        value: env.OPENROUTER_API_KEY
-          ? "OpenRouter"
-          : env.OPENAI_API_KEY
-            ? "OpenAI"
-            : "Missing",
+        value: env.OPENROUTER_API_KEY ? "OpenRouter" : "Missing",
         detail: "Provider used for admin-side semantic embedding generation.",
       },
     ],
@@ -2270,7 +2262,7 @@ export async function runSemanticSearch(params: {
   const queryText = params.queryText?.trim() ?? ""
   const locale = params.locale?.trim() ?? "en"
   const embeddingCounts = await getEmbeddingCounts()
-  const providerReady = Boolean(env.OPENROUTER_API_KEY || env.OPENAI_API_KEY)
+  const providerReady = Boolean(env.OPENROUTER_API_KEY)
 
   const metrics: Metric[] = [
     {
@@ -2328,8 +2320,7 @@ export async function runSemanticSearch(params: {
       results: [],
       queryText,
       locale,
-      unavailableReason:
-        "Semantic search requires OPENROUTER_API_KEY or OPENAI_API_KEY.",
+      unavailableReason: "Semantic search requires OPENROUTER_API_KEY.",
     }
   }
 

--- a/apps/admin/src/config/env.test.ts
+++ b/apps/admin/src/config/env.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest"
 import {
   assertBearerCsvsDisjoint,
+  aiVideoSearchEmbeddingSourceEnvSchema,
   concurrencyEnvSchema,
   DEFAULT_WEB_CANONICAL_ORIGIN,
   env,
@@ -84,6 +85,32 @@ describe("env", () => {
       expect(() => searchTraceRawRetentionDaysEnvSchema.parse("1.5")).toThrow()
       expect(() => searchTraceRawRetentionDaysEnvSchema.parse("-1")).toThrow()
       expect(() => searchTraceRawRetentionDaysEnvSchema.parse("30")).toThrow()
+    })
+  })
+
+  describe("aiVideoSearchEmbeddingSourceEnvSchema", () => {
+    it("defaults to openrouter", () => {
+      expect(aiVideoSearchEmbeddingSourceEnvSchema.parse(undefined)).toBe(
+        "openrouter",
+      )
+    })
+
+    it("accepts gateway as the explicit alternate vector column", () => {
+      expect(aiVideoSearchEmbeddingSourceEnvSchema.parse("gateway")).toBe(
+        "gateway",
+      )
+    })
+
+    it("normalizes the legacy openai value to openrouter", () => {
+      expect(aiVideoSearchEmbeddingSourceEnvSchema.parse("openai")).toBe(
+        "openrouter",
+      )
+    })
+
+    it("rejects unknown source values", () => {
+      expect(() =>
+        aiVideoSearchEmbeddingSourceEnvSchema.parse("qwen"),
+      ).toThrow()
     })
   })
 

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -39,6 +39,12 @@ export const searchTraceRawRetentionDaysEnvSchema = z.coerce
   .optional()
   .default(29)
 
+export const aiVideoSearchEmbeddingSourceEnvSchema = z
+  .enum(["openrouter", "gateway", "openai"])
+  .optional()
+  .default("openrouter")
+  .transform((value) => (value === "openai" ? "openrouter" : value))
+
 // Unit 1 scaffolding shipped a minimal env. Each later unit appends the
 // vars it owns here and in runtimeEnv. Never read process.env directly.
 export const env = createEnv({
@@ -261,16 +267,12 @@ export const env = createEnv({
     AI_GATEWAY_EMBEDDINGS_API_KEY: z.string().min(1).optional(),
     AI_GATEWAY_EMBEDDINGS_MODEL: z.string().min(1).optional(),
     // Embedding source for the admin AI experience generator's video search
-    // (the Mastra `searchVideos` tool). "openai" (default) keeps that search
-    // on the OpenAI `embedding` column; "gateway" routes it to Qwen + the
-    // `embedding_qwen` column. Default "openai" so this PR is behavior-neutral
-    // until the `embedding_qwen` backfill exists — the operator flips it to
-    // "gateway" only after the backfill completes (one-line reversible switch).
-    // Enum-of-strings (not boolean) so a stray value can't silently flip it.
-    AI_VIDEO_SEARCH_EMBEDDING_SOURCE: z
-      .enum(["openai", "gateway"])
-      .optional()
-      .default("openai"),
+    // (the Mastra `searchVideos` tool). "openrouter" (default) uses the
+    // Qwen-backed OpenRouter query path + `embedding` column; "gateway" routes
+    // through the JesusFilm AI Gateway + `embedding_qwen` column. The legacy
+    // "openai" value is accepted as a deploy-safe alias for "openrouter" but
+    // never re-enables the removed OpenAI embedding fallback.
+    AI_VIDEO_SEARCH_EMBEDDING_SOURCE: aiVideoSearchEmbeddingSourceEnvSchema,
     MASTRA_STORAGE_URL: z.string().url().optional(),
     MASTRA_DEFAULT_PROVIDER: z
       .enum([

--- a/apps/admin/src/mastra/tools/search-videos.test.ts
+++ b/apps/admin/src/mastra/tools/search-videos.test.ts
@@ -12,10 +12,11 @@ function assertOk<T>(value: T): Exclude<T, { error: unknown }> {
 const searchMock = vi.hoisted(() => vi.fn())
 
 // AI_VIDEO_SEARCH_EMBEDDING_SOURCE controls which embedding source the tool
-// passes; defaults to "openai" (behavior-neutral until the embedding_qwen
-// backfill exists). Tests flip it to exercise both paths.
+// passes; defaults to "openrouter". Tests flip it to exercise both paths.
 const mockEnv = vi.hoisted(() => ({
-  env: { AI_VIDEO_SEARCH_EMBEDDING_SOURCE: "openai" as "openai" | "gateway" },
+  env: {
+    AI_VIDEO_SEARCH_EMBEDDING_SOURCE: "openrouter" as "openrouter" | "gateway",
+  },
 }))
 
 vi.mock("@/config/env", () => mockEnv)
@@ -33,7 +34,7 @@ vi.mock("@/db/client", () => ({
 describe("searchVideosTool", () => {
   beforeEach(() => {
     searchMock.mockReset()
-    mockEnv.env.AI_VIDEO_SEARCH_EMBEDDING_SOURCE = "openai"
+    mockEnv.env.AI_VIDEO_SEARCH_EMBEDDING_SOURCE = "openrouter"
     vi.resetModules()
   })
 
@@ -92,8 +93,8 @@ describe("searchVideosTool", () => {
       locale: "en",
       limit: 5,
       contentTypes: ["video"],
-      // Default flag → OpenAI source (behavior-neutral until backfill).
-      embeddingSource: "openai",
+      // Default flag → OpenRouter source.
+      embeddingSource: "openrouter",
     })
     expect(result.videos).toEqual([
       {

--- a/apps/admin/src/mastra/tools/search-videos.ts
+++ b/apps/admin/src/mastra/tools/search-videos.ts
@@ -70,11 +70,11 @@ export const searchVideosTool = createTool({
       limit: inputData.limit,
       contentTypes: ["video"],
       // AI experience-gen video search source, operator-controlled via
-      // AI_VIDEO_SEARCH_EMBEDDING_SOURCE (default "openai"). Flip to
-      // "gateway" — Qwen 1536 query + `embedding_qwen` column, no paid-API
-      // dependency — only AFTER the embedding_qwen backfill exists, else the
-      // search hits an empty column. One-line reversible switch. Public
-      // search omits this arg entirely and stays on OpenAI + `embedding`.
+      // AI_VIDEO_SEARCH_EMBEDDING_SOURCE (default "openrouter"). Flip to
+      // "gateway" to route through the JesusFilm AI Gateway +
+      // `embedding_qwen` column only after that backfill exists, else the
+      // search hits an empty column. Public search omits this arg entirely
+      // and stays on the default OpenRouter + `embedding` path.
       // U3 of the content-embeddings-gateway-migration pilot; see
       // docs/plans/2026-06-05-001-feat-content-embeddings-gateway-migration-plan.md.
       embeddingSource: env.AI_VIDEO_SEARCH_EMBEDDING_SOURCE,

--- a/apps/admin/src/services/embeddings.service.test.ts
+++ b/apps/admin/src/services/embeddings.service.test.ts
@@ -88,6 +88,29 @@ describe("generateExperienceEmbedding", () => {
       embedding: vector,
     })
   })
+
+  it("requests Qwen through OpenRouter at 1536 dimensions", async () => {
+    const vector = Array.from({ length: 1536 }, () => 0.1)
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: vector }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { generateExperienceEmbedding } = await import("./embeddings.service")
+
+    await generateExperienceEmbedding("hope and peace")
+
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      model: string
+      dimensions: number
+    }
+    expect(body.model).toBe("qwen/qwen3-embedding-8b")
+    expect(body.dimensions).toBe(1536)
+  })
 })
 
 describe("generateExperienceEmbedding (gateway source)", () => {
@@ -258,10 +281,12 @@ describe("generateExperienceEmbeddings (batched)", () => {
       input: string[]
       model: string
       encoding_format: string
+      dimensions: number
     }
     expect(body.input).toEqual(["first input", "second input", "third input"])
     expect(body.model).toBe(OPENROUTER_EMBEDDING_MODEL)
     expect(body.encoding_format).toBe("float")
+    expect(body.dimensions).toBe(1536)
 
     // Position-stable: embeddings[i] aligns with inputs[i].
     expect(result.embeddings).toEqual([v0, v1, v2])
@@ -378,6 +403,22 @@ describe("generateExperienceEmbeddings (batched)", () => {
     expect((thrown as { code: string }).code).toBe("missing_credentials")
   })
 
+  it("does not fall back to OpenAI credentials when OpenRouter is missing", async () => {
+    delete process.env.OPENROUTER_API_KEY
+    process.env.OPENAI_API_KEY = "test-openai-key"
+    process.env.OPENAI_BASE_URL = "https://api.openai.example/v1"
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { generateExperienceEmbeddings, EmbeddingsBatchError } =
+      await import("./embeddings.service")
+
+    const thrown = await generateExperienceEmbeddings(["hi"]).catch((e) => e)
+    expect(thrown).toBeInstanceOf(EmbeddingsBatchError)
+    expect((thrown as { code: string }).code).toBe("missing_credentials")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it("surfaces an AbortError as EmbeddingsBatchError(request_timed_out)", async () => {
     // Simulate the AbortController firing inside the timeout window.
     // Vitest doesn't ship an easy way to fast-forward the real
@@ -475,9 +516,9 @@ describe("writeExperienceEmbeddingPayloadInTransaction", () => {
     return {
       sourceContentHash: "sha256:source",
       sourceSummary: "chars=10;lines=1;title=present;meta=absent;og=absent",
-      model: "openai/text-embedding-3-small",
+      model: "qwen/qwen3-embedding-8b",
       dimensions: 1536,
-      provider: "openai",
+      provider: "openrouter",
       generationMode: "idempotent" as const,
       mastraRunId: "run-1",
       generatedAt: "2026-05-26T00:00:00.000Z",

--- a/apps/admin/src/services/embeddings.service.ts
+++ b/apps/admin/src/services/embeddings.service.ts
@@ -12,20 +12,17 @@ import {
 } from "@/mastra/gateway-constants"
 
 export const EXPERIENCE_EMBEDDING_DIMENSIONS = 1536
-export const OPENROUTER_EMBEDDING_MODEL = "openai/text-embedding-3-small"
-export const OPENAI_EMBEDDING_MODEL = "text-embedding-3-small"
+export const OPENROUTER_EMBEDDING_MODEL = "qwen/qwen3-embedding-8b"
 export const GATEWAY_EMBEDDING_MODEL = "embeddings"
 
 /**
- * Per-call embedding source. `"openai"` (the default) keeps the existing
- * OpenRouter → OpenAI precedence byte-identical to today. `"gateway"`
- * routes through the self-hosted JesusFilm AI gateway (Qwen → 1536-dim)
- * so the admin AI experience generator can search Qwen-embedded video
- * vectors without a paid-API dependency. Selected per call — public
- * search / recommendations never pass it, so they are structurally
- * incapable of being affected.
+ * Per-call embedding source. `"openrouter"` (the default) routes query
+ * embedding through OpenRouter's Qwen3 Embedding 8B model at 1536
+ * dimensions. `"gateway"` routes through the self-hosted JesusFilm AI
+ * gateway so the admin AI experience generator can search the parallel
+ * Qwen-embedded video vectors.
  */
-export type EmbeddingSource = "openai" | "gateway"
+export type EmbeddingSource = "openrouter" | "gateway"
 
 /**
  * Hard timeout for provider requests. Node's default fetch has no
@@ -226,9 +223,12 @@ type EmbeddingProvider = {
    * 403s on missing/odd UAs.
    */
   headers?: Record<string, string>
+  dimensions?: number
 }
 
-function selectProvider(source: EmbeddingSource = "openai"): EmbeddingProvider {
+function selectProvider(
+  source: EmbeddingSource = "openrouter",
+): EmbeddingProvider {
   if (source === "gateway") {
     if (!env.AI_GATEWAY_EMBEDDINGS_API_KEY) {
       throw new EmbeddingsBatchError(
@@ -250,20 +250,12 @@ function selectProvider(source: EmbeddingSource = "openai"): EmbeddingProvider {
       apiKey: env.OPENROUTER_API_KEY,
       model: OPENROUTER_EMBEDDING_MODEL,
       url: "https://openrouter.ai/api/v1/embeddings",
-    }
-  }
-  if (env.OPENAI_API_KEY) {
-    return {
-      apiKey: env.OPENAI_API_KEY,
-      model: OPENAI_EMBEDDING_MODEL,
-      url: embeddingEndpointFromBase(
-        env.OPENAI_BASE_URL ?? "https://api.openai.com/v1",
-      ),
+      dimensions: EXPERIENCE_EMBEDDING_DIMENSIONS,
     }
   }
   throw new EmbeddingsBatchError(
     "missing_credentials",
-    "OPENROUTER_API_KEY or OPENAI_API_KEY is required for embedding generation",
+    "OPENROUTER_API_KEY is required for embedding generation",
   )
 }
 
@@ -324,6 +316,7 @@ export async function generateExperienceEmbeddings(
         model: provider.model,
         input: normalized,
         encoding_format: "float",
+        ...(provider.dimensions ? { dimensions: provider.dimensions } : {}),
       }),
       signal: controller.signal,
     })

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -33,7 +33,17 @@ function latestRawSql(prisma: ReturnType<typeof mockPrisma>): string {
 
 function latestRawValues(prisma: ReturnType<typeof mockPrisma>): unknown[] {
   const call = prisma.$queryRaw.mock.calls.at(-1)
-  return call?.slice(1) ?? []
+  return (call?.slice(1) ?? []).flatMap((value: unknown) => {
+    if (
+      value != null &&
+      typeof value === "object" &&
+      "values" in (value as Record<string, unknown>) &&
+      Array.isArray((value as { values: unknown }).values)
+    ) {
+      return [value, ...(value as { values: unknown[] }).values]
+    }
+    return [value]
+  })
 }
 
 /**
@@ -313,8 +323,8 @@ describe("resolveSemanticEmbeddingColumn (U3 allowlist)", () => {
     expect(resolveSemanticEmbeddingColumn("gateway")).toBe("embedding_qwen")
   })
 
-  it("maps 'openai' to embedding", () => {
-    expect(resolveSemanticEmbeddingColumn("openai")).toBe("embedding")
+  it("maps 'openrouter' to embedding", () => {
+    expect(resolveSemanticEmbeddingColumn("openrouter")).toBe("embedding")
   })
 
   it("maps undefined to embedding (fail-safe default)", () => {
@@ -346,21 +356,25 @@ describe("searchVideoSemantic embeddingSource column selection (U3)", () => {
     const sql = latestRawSqlWithFragments(prisma)
     expect(sql).toContain("vsl.embedding")
     expect(sql).toContain("vtc.embedding")
+    expect(sql).toContain("vsl.embedding_provider")
+    expect(sql).toContain("vt.embedding_provider")
     expect(sql).not.toContain("embedding_qwen")
   })
 
-  it("reads vsl.embedding / vtc.embedding when source='openai'", async () => {
+  it("reads vsl.embedding / vtc.embedding when source='openrouter'", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([])
     await searchVideoSemantic(prisma, {
       queryEmbedding: "[0.1]",
       locale: "en",
       limit: 5,
-      embeddingSource: "openai",
+      embeddingSource: "openrouter",
     })
 
     const sql = latestRawSqlWithFragments(prisma)
     expect(sql).toContain("vsl.embedding")
     expect(sql).toContain("vtc.embedding")
+    expect(sql).toContain("vsl.embedding_provider")
+    expect(sql).toContain("vt.embedding_provider")
     expect(sql).not.toContain("embedding_qwen")
   })
 
@@ -376,6 +390,8 @@ describe("searchVideoSemantic embeddingSource column selection (U3)", () => {
     const sql = latestRawSqlWithFragments(prisma)
     expect(sql).toContain("vsl.embedding_qwen")
     expect(sql).toContain("vtc.embedding_qwen")
+    expect(sql).not.toContain("vsl.embedding_provider")
+    expect(sql).not.toContain("vt.embedding_provider")
   })
 
   it("falls back to the embedding column for an unknown source (allowlist guard)", async () => {
@@ -390,8 +406,61 @@ describe("searchVideoSemantic embeddingSource column selection (U3)", () => {
     const sql = latestRawSqlWithFragments(prisma)
     expect(sql).toContain("vsl.embedding")
     expect(sql).toContain("vtc.embedding")
+    expect(sql).toContain("vsl.embedding_provider")
+    expect(sql).toContain("vt.embedding_provider")
     expect(sql).not.toContain("embedding_qwen")
     expect(sql).not.toContain("injection")
+  })
+})
+
+describe("semantic retriever provenance gates", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("requires the approved Qwen-compatible content provenance for video semantic rows", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 5,
+      embeddingSource: "openrouter",
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    const values = latestRawValues(prisma)
+    expect(sql).toContain("vsl.embedding_provider")
+    expect(sql).toContain("vt.embedding_provider")
+    expect(sql).toContain("vsl.embedding_native_dimensions")
+    expect(sql).toContain("vt.embedding_native_dimensions")
+    expect(sql).toContain("vsl.embedding_transform_version IS NULL")
+    expect(sql).toContain("vt.embedding_transform_version IS NULL")
+    expect(values).toContain("jesus-film-ai-gateway")
+    expect(values).toContain("embeddings")
+    expect(values).toContain(1536)
+  })
+
+  it("requires the approved Qwen-compatible content provenance for experience semantic rows", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    await searchExperienceSemantic(prisma, {
+      queryEmbedding: "[0.1]",
+      locale: "en",
+      limit: 5,
+      embeddingSource: "openrouter",
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    const values = latestRawValues(prisma)
+    expect(sql).toContain("el.embedding_provider")
+    expect(sql).toContain("el.embedding_model")
+    expect(sql).toContain("el.embedding_dimensions")
+    expect(sql).toContain("el.embedding_native_dimensions")
+    expect(sql).toContain("el.embedding_transform_version IS NULL")
+    expect(values).toContain("jesus-film-ai-gateway")
+    expect(values).toContain("embeddings")
+    expect(values).toContain(1536)
   })
 })
 

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -32,6 +32,10 @@ import {
 import type { RankedItem } from "./hybrid-search-fusion"
 import type { EmbeddingSource } from "./embeddings.service"
 
+const QWEN_CONTENT_EMBEDDING_PROVIDER = "jesus-film-ai-gateway"
+const QWEN_CONTENT_EMBEDDING_MODEL = "embeddings"
+const QWEN_CONTENT_EMBEDDING_DIMENSIONS = 1536
+
 /**
  * Closed allowlist mapping an embedding source to the physical pgvector
  * COLUMN the semantic-video retriever reads. This is the SQL-injection
@@ -41,8 +45,10 @@ import type { EmbeddingSource } from "./embeddings.service"
  *
  * - `"gateway"` → `"embedding_qwen"` (Qwen 1536-dim vectors, U2 column;
  *   read by the admin AI experience-gen path only).
- * - anything else (including `"openai"`) → `"embedding"` (the existing
- *   OpenAI column; the public default, byte-identical to today).
+ * - anything else (including `"openrouter"`) → `"embedding"` (the
+ *   public default column). Semantic SQL also requires the row-level
+ *   Qwen-compatible content provenance below, so legacy OpenAI vectors in
+ *   the same column fail closed instead of being cross-compared.
  *
  * The matching per-locale partial HNSW index on the chosen column is
  * selected by the planner automatically — the WHERE locale predicate
@@ -52,6 +58,12 @@ export function resolveSemanticEmbeddingColumn(
   source: EmbeddingSource | undefined,
 ): "embedding" | "embedding_qwen" {
   return source === "gateway" ? "embedding_qwen" : "embedding"
+}
+
+function requiresSharedColumnQwenProvenance(
+  source: EmbeddingSource | undefined,
+): boolean {
+  return source !== "gateway"
 }
 
 // -----------------------------------------------------------------------------
@@ -69,7 +81,7 @@ export type SemanticSearchParams = {
    * Per-call embedding source. Selects which stored vector COLUMN the
    * video semantic retriever reads via the `resolveSemanticEmbeddingColumn`
    * closed allowlist (`"gateway"` → `embedding_qwen`, else `embedding`).
-   * Absent / unknown → `embedding` (the public default). Consumed only by
+   * Absent / unknown → `embedding` (the OpenRouter default). Consumed only by
    * `searchVideoSemantic`; the experience retriever ignores it (experience
    * vectors are out of the U3 pilot and always read `embedding`).
    */
@@ -345,6 +357,29 @@ export async function searchVideoSemantic(
   // unvalidated (SQL-injection guard). `vsl.<col>` is the scene column,
   // `vtc.<col>` the transcript column; both move together per call.
   const column = resolveSemanticEmbeddingColumn(params.embeddingSource)
+  const requireProvenance = requiresSharedColumnQwenProvenance(
+    params.embeddingSource,
+  )
+  const sceneProvenanceFilter = requireProvenance
+    ? Prisma.sql`
+          AND vsl.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+          AND vsl.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+          AND vsl.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+          AND vsl.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+          AND vsl.embedding_transform_version IS NULL
+        `
+    : Prisma.empty
+  const transcriptProvenanceFilter = requireProvenance
+    ? Prisma.sql`
+          AND vt.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+          AND vt.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+          AND vt.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+          AND vt.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+          AND vt.embedding_transform_version IS NULL
+          AND vtc.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+          AND vtc.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        `
+    : Prisma.empty
   const sceneEmbeddingCol = Prisma.raw(`vsl.${column}`)
   const transcriptEmbeddingCol = Prisma.raw(`vtc.${column}`)
 
@@ -394,6 +429,7 @@ export async function searchVideoSemantic(
           LIMIT 1
         ) vi ON true
         WHERE ${sceneEmbeddingCol} IS NOT NULL
+          ${sceneProvenanceFilter}
           AND vsl.locale = ${locale}
         ORDER BY
           vs.video_id,
@@ -449,6 +485,7 @@ export async function searchVideoSemantic(
           LIMIT 1
         ) vi ON true
         WHERE ${transcriptEmbeddingCol} IS NOT NULL
+          ${transcriptProvenanceFilter}
           AND vtc.language = ${locale}
           AND vt.language = ${locale}
         ORDER BY
@@ -601,6 +638,11 @@ export async function searchExperienceSemantic(
     JOIN experience e ON e.id = el.experience_id
       AND e.archived_at IS NULL
     WHERE el.embedding IS NOT NULL
+      AND el.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+      AND el.embedding_model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+      AND el.embedding_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+      AND el.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+      AND el.embedding_transform_version IS NULL
       AND el.locale = ${locale}
       AND el.status = 'published'
     ORDER BY el.embedding <=> ${queryEmbedding}::vector

--- a/apps/admin/src/services/hybrid-search.regression.test.ts
+++ b/apps/admin/src/services/hybrid-search.regression.test.ts
@@ -199,7 +199,7 @@ describe("HybridSearchService default-mode regression snapshot", () => {
     }
   })
 
-  it("default path resolves embeddingSource to 'openai' (public byte-identity / U3)", async () => {
+  it("default path resolves embeddingSource to 'openrouter' (public default / U3)", async () => {
     for (const { mode } of DEFAULT_EQUIVALENT_MODES) {
       vi.clearAllMocks()
       setupRetrieverFixtures()
@@ -211,13 +211,13 @@ describe("HybridSearchService default-mode regression snapshot", () => {
         logger: { warn: vi.fn(), error: vi.fn() },
       })
       // No embeddingSource passed — the public contract. Both the query
-      // embedder and the semantic-video retriever must see "openai" so
-      // the read column stays `embedding` (never the Qwen column).
+      // embedder and the semantic-video retriever must see "openrouter" so
+      // the read column stays `embedding` (never the gateway column).
       await service.search({ query: "jesus", locale: "en", mode })
-      expect(embedder).toHaveBeenCalledWith("jesus", "openai")
+      expect(embedder).toHaveBeenCalledWith("jesus", "openrouter")
       expect(searchVideoSemantic).toHaveBeenCalledWith(
         mockPrisma,
-        expect.objectContaining({ embeddingSource: "openai" }),
+        expect.objectContaining({ embeddingSource: "openrouter" }),
       )
     }
   })

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -106,13 +106,13 @@ describe("HybridSearchService", () => {
     })
 
     // All 4 retrievers were invoked with overfetch = DEFAULT_LIMIT * 3 = 60.
-    // The default path resolves embeddingSource to "openai" (→ `embedding`
+    // The default path resolves embeddingSource to "openrouter" (→ `embedding`
     // column in the retriever).
     expect(searchVideoSemantic).toHaveBeenCalledWith(mockPrisma, {
       queryEmbedding: "[0.1,0.2,0.3]",
       locale: "en",
       limit: 60,
-      embeddingSource: "openai",
+      embeddingSource: "openrouter",
     })
     expect(searchVideoKeyword).toHaveBeenCalledWith(mockPrisma, {
       query: "forgiveness",
@@ -288,7 +288,7 @@ describe("HybridSearchService", () => {
   })
 
   describe("embeddingSource threading (U3)", () => {
-    it("defaults to 'openai' for the embedder and semantic retriever when unset", async () => {
+    it("defaults to 'openrouter' for the embedder and semantic retriever when unset", async () => {
       const embedder = successEmbedder()
       const service = new HybridSearchService({
         prisma: mockPrisma,
@@ -299,10 +299,10 @@ describe("HybridSearchService", () => {
       await service.search({ query: "test", locale: "en" })
 
       // Embedder receives the resolved source as its 2nd arg.
-      expect(embedder).toHaveBeenCalledWith("test", "openai")
+      expect(embedder).toHaveBeenCalledWith("test", "openrouter")
       expect(searchVideoSemantic).toHaveBeenCalledWith(
         mockPrisma,
-        expect.objectContaining({ embeddingSource: "openai" }),
+        expect.objectContaining({ embeddingSource: "openrouter" }),
       )
     })
 

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -72,15 +72,15 @@ export function isDilutionCapEnabled(): boolean {
 
 /**
  * Normalize the per-call embedding source to a known value. Absent or
- * any non-`"gateway"` value resolves to `"openai"` — the fail-safe
+ * any non-`"gateway"` value resolves to `"openrouter"` — the default
  * public path. This keeps the resolution in ONE place so the query
  * model and the read column can never diverge: only an explicit
- * `"gateway"` opts into the Qwen vector space.
+ * `"gateway"` opts into the gateway vector column.
  */
 export function resolveEmbeddingSource(
   source: EmbeddingSource | undefined,
 ): EmbeddingSource {
-  return source === "gateway" ? "gateway" : "openai"
+  return source === "gateway" ? "gateway" : "openrouter"
 }
 
 export type ContentType = "video" | "experience"
@@ -131,12 +131,12 @@ export type SearchParams = {
    * AND the stored vector column the semantic-video retriever reads, so
    * the two can never cross-compare across embedding spaces:
    *
-   * - `"openai"` (default, also for unset / unknown) — OpenRouter →
-   *   OpenAI query embed against the `embedding` column. This is the
-   *   public path: REST `/api/search`, GraphQL `Query.search`, and
-   *   scene-recommendations never pass this arg, so they are
-   *   structurally incapable of being affected (locked by
-   *   hybrid-search.regression.test.ts).
+   * - `"openrouter"` (default, also for unset / unknown) — OpenRouter
+   *   Qwen query embed against rows in the `embedding` column that carry
+   *   the approved Qwen-compatible content provenance. This is the public
+   *   path: REST `/api/search`, GraphQL `Query.search`, and
+   *   scene-recommendations never pass this arg, so they consistently use
+   *   the default source (locked by hybrid-search.regression.test.ts).
    * - `"gateway"` — JesusFilm AI gateway (Qwen → 1536-dim) query embed
    *   against the parallel `embedding_qwen` column. Only the Mastra
    *   `searchVideos` tool (admin AI experience generation) opts in.
@@ -298,7 +298,7 @@ function toPgvectorText(embedding: number[]): string {
 /**
  * Injectable embedder signature so tests can stub the provider call
  * without mocking the module import. The optional `source` selects the
- * embedding model per call (default `"openai"` — see SearchParams
+ * embedding model per call (default `"openrouter"` — see SearchParams
  * `embeddingSource`); the default embedder forwards it to
  * `generateExperienceEmbedding`.
  */
@@ -307,7 +307,7 @@ export type QueryEmbedder = (
   source?: EmbeddingSource,
 ) => Promise<number[]>
 
-const defaultEmbedder: QueryEmbedder = async (text, source = "openai") => {
+const defaultEmbedder: QueryEmbedder = async (text, source = "openrouter") => {
   const result = await generateExperienceEmbedding(text, { source })
   return result.embedding
 }
@@ -559,9 +559,8 @@ export class HybridSearchService {
     // at most once.
     const pipelineMode = normalizeMode(params.mode, this.logger)
     // Resolve the per-call embedding source. Absent / unknown values
-    // fail-safe to "openai" — the known-good public path — so the
-    // query model and the stored column the semantic-video retriever
-    // reads always move together (never cross an embedding space).
+    // fail-safe to "openrouter"; semantic SQL also filters stored rows by
+    // Qwen-compatible provenance so legacy vectors fail closed during rollout.
     const embeddingSource = resolveEmbeddingSource(params.embeddingSource)
     const limit = Math.min(
       Math.max(1, params.limit ?? DEFAULT_LIMIT),

--- a/docs/solutions/best-practices/openrouter-only-embedding-provider-contract.md
+++ b/docs/solutions/best-practices/openrouter-only-embedding-provider-contract.md
@@ -1,0 +1,120 @@
+---
+title: "OpenRouter-only embedding provider contract"
+date: 2026-06-08
+category: best-practices
+module: apps/admin
+problem_type: best_practice
+component: service_object
+severity: high
+applies_when:
+  - "Removing a fallback embedding provider"
+  - "Changing the live query embedding model"
+  - "Keeping operator readiness aligned with runtime credentials"
+  - "Rolling out a provider-bound vector-space migration"
+tags: [admin, embeddings, openrouter, qwen, search, readiness]
+---
+
+# OpenRouter-only embedding provider contract
+
+## Context
+
+Admin live search owns query embedding generation. When the query embedding
+provider changes, the runtime call, the operator readiness surface, and the
+stored vector corpus all become one deployment contract. Leaving an old fallback
+in place can make local tests pass while production silently uses a different
+vector space than the one operators believe is active.
+
+## Guidance
+
+Keep provider fallback removal explicit and testable:
+
+- The embedding service should require the intended provider credential. If the
+  live query path is OpenRouter-only, `OPENAI_API_KEY` must not satisfy readiness
+  and must not trigger a fallback request.
+- The outbound embedding request should pin both model and dimensions when the
+  provider supports a dimension override.
+- Operator UI and docs should name the same required credential that runtime
+  code requires.
+- Semantic retrieval should filter stored vectors by the active provider/model
+  provenance. During a model-space rollout, old vectors in the same pgvector
+  column must fail closed instead of being cross-compared.
+- Any model-space change must carry a re-embed gate for the stored corpus before
+  semantic quality is trusted.
+
+For the OpenRouter Qwen query path, the provider body is intentionally explicit:
+
+```ts
+{
+  model: "qwen/qwen3-embedding-8b",
+  input: normalized,
+  encoding_format: "float",
+  dimensions: 1536,
+}
+```
+
+The missing-credentials regression should set only `OPENAI_API_KEY` and assert
+that query embedding still fails before `fetch` is called. That protects the
+contract from accidental fallback reintroduction.
+
+The semantic SQL should also require the approved content provenance tuple:
+
+```sql
+AND embedding_provider = 'jesus-film-ai-gateway'
+AND model = 'embeddings'
+AND dimensions = 1536
+AND embedding_native_dimensions = 1536
+AND embedding_transform_version IS NULL
+```
+
+This makes a deploy-before-backfill window degrade to keyword/partial semantic
+results instead of silently comparing Qwen query vectors against legacy OpenAI
+stored vectors.
+
+## Why This Matters
+
+Same-dimension vectors from different models are still different vector spaces.
+The database will accept the comparison, but relevance quality becomes
+untrustworthy. A hidden OpenAI fallback also makes incidents harder to reason
+about: readiness may show healthy while the intended OpenRouter/Qwen path is not
+actually configured.
+
+## When to Apply
+
+- Removing OpenAI fallback from Admin query embeddings.
+- Changing `OPENROUTER_EMBEDDING_MODEL`.
+- Adding or removing an embedding provider selector.
+- Updating `/dashboard/search`, `/dashboard/embeddings`, or docs that report
+  embedding provider readiness.
+- Running a production embedding model upgrade.
+
+## Examples
+
+Before:
+
+```ts
+if (env.OPENROUTER_API_KEY) return openrouterProvider
+if (env.OPENAI_API_KEY) return openaiProvider
+```
+
+After:
+
+```ts
+if (env.OPENROUTER_API_KEY) return openrouterProvider
+
+throw new EmbeddingsBatchError(
+  "missing_credentials",
+  "OPENROUTER_API_KEY is required for embedding generation",
+)
+```
+
+Readiness should make the same distinction:
+
+```ts
+const providerReady = Boolean(env.OPENROUTER_API_KEY)
+```
+
+## Related
+
+- [Provider-bound content embedding backfill gate pattern](../architecture-patterns/provider-bound-content-embedding-backfill-gate-pattern.md)
+- [Batched provider input position-stable contract](./batched-provider-input-position-stable-contract-20260505.md)
+- [Silent semantic search degradation from a missing OpenRouter key](../runtime-errors/silent-semantic-search-degradation-missing-openrouter-key-20260415.md)


### PR DESCRIPTION
## Summary

- Switch Admin query embeddings from OpenAI text-embedding-3-small to OpenRouter `qwen/qwen3-embedding-8b` with `dimensions: 1536`.
- Remove the OpenAI embedding fallback/readiness path; `OPENROUTER_API_KEY` is now required for Admin query embedding.
- Rename the default embedding source to `openrouter`, keep `gateway` as the explicit parallel-column path, and accept legacy `AI_VIDEO_SEARCH_EMBEDDING_SOURCE=openai` as a deploy-safe alias to `openrouter` without re-enabling OpenAI.
- Add shared-column provenance gates so Qwen query vectors only search rows stamped with the approved Qwen-compatible content tuple (`jesus-film-ai-gateway` / `embeddings` / 1536 / null transform), preventing silent mixed-vector comparisons during rollout.
- Add CE compound documentation for the OpenRouter-only embedding provider contract.

## Review + rollout notes

Ran the Compound Engineering review workflow. Initial reviewers flagged the mixed-vector-space risk as merge-blocking; this PR now fails closed by filtering semantic retrieval to approved stored-vector provenance on the shared `embedding` column. Before the production re-embed completes, semantic results may degrade to keyword/partial results rather than comparing Qwen query vectors against legacy OpenAI vectors.

Post-backfill rollback is not code-only: if production `embedding` columns are rewritten, restoring old search behavior requires restoring old embedding data from backup/snapshot or re-embedding with the old model.

## Verification

- `pnpm --filter @forge/admin test -- src/services/embeddings.service.test.ts src/services/hybrid-search.service.test.ts src/services/hybrid-search.regression.test.ts src/services/hybrid-search-retrievers.test.ts src/mastra/tools/search-videos.test.ts src/config/env.test.ts src/app/dashboard/ops-data.test.ts`
  - 7 files / 148 tests passed
- `pnpm --filter @forge/admin typecheck`
- `git diff --check`

## Post-merge deployment gate

1. Confirm production Admin has `OPENROUTER_API_KEY`.
2. Confirm Mastra content embeddings are the approved gateway tuple: `jesus-film-ai-gateway` / `embeddings` / native 1536 / final 1536 / null transform.
3. Take a fresh production DB backup before re-embedding.
4. Run the provider-bound Mastra gate and save the docs report under `docs/search-eval-reports/`.
5. Run Admin prod re-embed with `--pipeline=all --scene-mode=model-upgrade --transcript-mode=model-upgrade --experience-mode=model-upgrade --gate-report=...`.
6. Run post-backfill provenance SQL and require bad-row counts to be zero.
7. Run post-backfill Mastra eval against the deployed SHA and save the report.
