### PR TITLE
feat(mobile): series detail page

### DIFF
--- a/apps/mobile/.env.ci
+++ b/apps/mobile/.env.ci
@@ -1,2 +1,2 @@
 # CI placeholder values — used by GitHub Actions when Doppler is unavailable
-EXPO_PUBLIC_ADMIN_GRAPHQL_URL=http://localhost:4100/api/graphql
+EXPO_PUBLIC_ADMIN_GRAPHQL_URL=http://localhost:3003/api/graphql

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -11,4 +11,4 @@
 # ── Admin GraphQL endpoint (optional — defaults to production) ───────
 # For local dev, point at the local admin instance.
 # In EAS builds, set via EAS Environments if you need a non-default URL.
-EXPO_PUBLIC_ADMIN_GRAPHQL_URL=http://127.0.0.1:4100/api/graphql
+EXPO_PUBLIC_ADMIN_GRAPHQL_URL=http://127.0.0.1:3003/api/graphql

--- a/apps/mobile/app/(tabs)/watch.tsx
+++ b/apps/mobile/app/(tabs)/watch.tsx
@@ -17,7 +17,7 @@ import {
   type SearchResult,
 } from "../../src/lib/queries"
 import { encodeWatchSeed } from "../../src/lib/watchSeed"
-import { isSeriesLabel } from "../../src/lib/isSeriesRecord"
+import { isSeriesSearchResult } from "../../src/lib/isSeriesRecord"
 import { SearchResultCard } from "../../src/components/search/SearchResultCard"
 import { SearchResultSkeleton } from "../../src/components/search/SearchResultSkeleton"
 import { useExperienceSelection } from "../../src/contexts/ExperienceSelectionProvider"
@@ -111,10 +111,7 @@ export default function DiscoverScreen() {
       })
       // A series-shaped result (SERIES/COLLECTION label, or has children) opens
       // the series page; a single video opens the watch page.
-      const route =
-        isSeriesLabel(result.label) || (result.childCount ?? 0) > 0
-          ? "series"
-          : "watch"
+      const route = isSeriesSearchResult(result) ? "series" : "watch"
       router.push(`/${route}/${encodeURIComponent(result.slug)}?seed=${seed}`)
     },
     [selectExperience, router],

--- a/apps/mobile/app/(tabs)/watch.tsx
+++ b/apps/mobile/app/(tabs)/watch.tsx
@@ -17,6 +17,7 @@ import {
   type SearchResult,
 } from "../../src/lib/queries"
 import { encodeWatchSeed } from "../../src/lib/watchSeed"
+import { isSeriesLabel } from "../../src/lib/isSeriesRecord"
 import { SearchResultCard } from "../../src/components/search/SearchResultCard"
 import { SearchResultSkeleton } from "../../src/components/search/SearchResultSkeleton"
 import { useExperienceSelection } from "../../src/contexts/ExperienceSelectionProvider"
@@ -108,7 +109,13 @@ export default function DiscoverScreen() {
         imageUrl: result.imageUrl ?? null,
         playbackId: result.playbackId ?? null,
       })
-      router.push(`/watch/${encodeURIComponent(result.slug)}?seed=${seed}`)
+      // A series-shaped result (SERIES/COLLECTION label, or has children) opens
+      // the series page; a single video opens the watch page.
+      const route =
+        isSeriesLabel(result.label) || (result.childCount ?? 0) > 0
+          ? "series"
+          : "watch"
+      router.push(`/${route}/${encodeURIComponent(result.slug)}?seed=${seed}`)
     },
     [selectExperience, router],
   )

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -266,6 +266,10 @@ export default function RootLayout() {
                       name="watch"
                       options={{ headerShown: false }}
                     />
+                    <Stack.Screen
+                      name="series"
+                      options={{ headerShown: false }}
+                    />
                   </Stack>
                 </ExperienceShell>
               </WatchPreferencesProvider>

--- a/apps/mobile/app/series/[slug].tsx
+++ b/apps/mobile/app/series/[slug].tsx
@@ -1,0 +1,46 @@
+import { useEffect, useMemo } from "react"
+import { ScrollView, View } from "react-native"
+import { useLocalSearchParams } from "expo-router"
+import { useQuery } from "@apollo/client/react"
+
+import { GET_SERIES_BY_SLUG } from "../../src/lib/queries"
+import { normalizeSeries } from "../../src/lib/normalizeVideo"
+import { useSeriesSession } from "../../src/contexts/SeriesSessionProvider"
+import { layout } from "../../src/styles/shared"
+
+// Series detail screen — skeleton (U2): resolves the series, publishes it to the
+// SeriesSessionProvider so the language sheet can read it. The hero (trailer or
+// poster), metadata, description, and actions land in U3; the episode grid in
+// U4. cache-first + returnPartialData mirrors the watch screen's payload posture.
+export default function SeriesScreen() {
+  const { slug } = useLocalSearchParams<{ slug: string; seed?: string }>()
+  const decodedSlug = slug ? decodeURIComponent(slug) : ""
+  const { setSeries } = useSeriesSession()
+
+  const { data } = useQuery(GET_SERIES_BY_SLUG, {
+    variables: { slug: decodedSlug, locale: "en" },
+    skip: !decodedSlug,
+    fetchPolicy: "cache-first",
+    returnPartialData: true,
+  })
+
+  const series = useMemo(
+    // returnPartialData widens videoBySlug to a deep-partial type; normalizeSeries
+    // tolerates missing fields (returns null without a documentId).
+    () =>
+      normalizeSeries(
+        (data?.videoBySlug ?? null) as Parameters<typeof normalizeSeries>[0],
+      ),
+    [data],
+  )
+
+  useEffect(() => {
+    setSeries(series)
+  }, [series, setSeries])
+
+  return (
+    <View style={layout.screenContainer}>
+      <ScrollView />
+    </View>
+  )
+}

--- a/apps/mobile/app/series/[slug].tsx
+++ b/apps/mobile/app/series/[slug].tsx
@@ -21,6 +21,7 @@ import { decodeWatchSeed, encodeWatchSeed } from "../../src/lib/watchSeed"
 import { resolveImageUrl } from "../../src/lib/resolveImageUrl"
 import { ACCENT, SURFACE_COLOR } from "../../src/lib/color"
 import { layout, text } from "../../src/styles/shared"
+import { useTypography } from "../../src/hooks/useTypography"
 import { VideoPlayer } from "../../src/components/watch/VideoPlayer"
 import {
   enterFullscreenLandscape,
@@ -51,6 +52,7 @@ export default function SeriesScreen() {
   const router = useRouter()
   const [isFullscreen, setIsFullscreen] = useState(false)
   const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), [])
+  const typography = useTypography()
 
   const { series, setSeries, selectedLanguageSlug } = useSeriesSession()
 
@@ -245,7 +247,13 @@ export default function SeriesScreen() {
                 />
                 <VideoDescription description={series.description} />
                 {series.episodes.length > 0 && (
-                  <Text style={[text.sectionHeading, styles.gridHeading]}>
+                  <Text
+                    style={[
+                      text.sectionHeadingPadded,
+                      typography.titleLarge,
+                      styles.gridHeading,
+                    ]}
+                  >
                     Videos
                   </Text>
                 )}
@@ -283,8 +291,7 @@ const styles = StyleSheet.create({
     backgroundColor: SURFACE_COLOR,
   },
   gridHeading: {
-    paddingHorizontal: 16,
-    marginTop: 8,
+    marginTop: 12,
     marginBottom: 2,
   },
   inlineError: {

--- a/apps/mobile/app/series/[slug].tsx
+++ b/apps/mobile/app/series/[slug].tsx
@@ -1,30 +1,62 @@
-import { useEffect, useMemo } from "react"
-import { ScrollView, View } from "react-native"
-import { useLocalSearchParams } from "expo-router"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  AppState,
+  BackHandler,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native"
+import { Image } from "expo-image"
+import { StatusBar } from "expo-status-bar"
+import { useLocalSearchParams, useNavigation, useRouter } from "expo-router"
 import { useQuery } from "@apollo/client/react"
 
 import { GET_SERIES_BY_SLUG } from "../../src/lib/queries"
 import { normalizeSeries } from "../../src/lib/normalizeVideo"
+import { decodeWatchSeed } from "../../src/lib/watchSeed"
+import { resolveImageUrl } from "../../src/lib/resolveImageUrl"
+import { ACCENT, SURFACE_COLOR } from "../../src/lib/color"
+import { layout, text } from "../../src/styles/shared"
+import { VideoPlayer } from "../../src/components/watch/VideoPlayer"
+import {
+  enterFullscreenLandscape,
+  exitToPortrait,
+} from "../../src/lib/orientation"
+import { VideoDetailSkeleton } from "../../src/components/watch/VideoDetailSkeleton"
+import { VideoMetadata } from "../../src/components/watch/VideoMetadata"
+import { VideoDescription } from "../../src/components/watch/VideoDescription"
+import { SeriesActionRow } from "../../src/components/watch/SeriesActionRow"
 import { useSeriesSession } from "../../src/contexts/SeriesSessionProvider"
-import { layout } from "../../src/styles/shared"
 
-// Series detail screen — skeleton (U2): resolves the series, publishes it to the
-// SeriesSessionProvider so the language sheet can read it. The hero (trailer or
-// poster), metadata, description, and actions land in U3; the episode grid in
-// U4. cache-first + returnPartialData mirrors the watch screen's payload posture.
+// Series detail screen. The hero is pinned at the route root (outside the
+// ScrollView), mirroring the watch screen: with a playable trailer it's the
+// reused VideoPlayer (custom fullscreen needs to never be reparented); without
+// one it's a plain poster image — no player mounted. Either way the hero holds
+// the only decoder slot on the screen; the episode grid (U4) is static images.
 export default function SeriesScreen() {
-  const { slug } = useLocalSearchParams<{ slug: string; seed?: string }>()
+  const { slug, seed: seedParam } = useLocalSearchParams<{
+    slug: string
+    seed?: string
+  }>()
   const decodedSlug = slug ? decodeURIComponent(slug) : ""
-  const { setSeries } = useSeriesSession()
 
-  const { data } = useQuery(GET_SERIES_BY_SLUG, {
+  const navigation = useNavigation()
+  const router = useRouter()
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), [])
+
+  const { series, setSeries, selectedLanguageSlug } = useSeriesSession()
+
+  const { data, loading, error, refetch } = useQuery(GET_SERIES_BY_SLUG, {
     variables: { slug: decodedSlug, locale: "en" },
     skip: !decodedSlug,
     fetchPolicy: "cache-first",
     returnPartialData: true,
   })
 
-  const series = useMemo(
+  const normalized = useMemo(
     // returnPartialData widens videoBySlug to a deep-partial type; normalizeSeries
     // tolerates missing fields (returns null without a documentId).
     () =>
@@ -35,12 +67,195 @@ export default function SeriesScreen() {
   )
 
   useEffect(() => {
-    setSeries(series)
-  }, [series, setSeries])
+    if (normalized) setSeries(normalized)
+  }, [normalized, setSeries])
+
+  const seed = useMemo(() => decodeWatchSeed(seedParam), [seedParam])
+
+  // Fullscreen side-effects — the same three the watch screen runs, so the
+  // reused player's custom fullscreen rotates and toggles the header in step.
+  useEffect(() => {
+    navigation.setOptions({
+      headerShown: !isFullscreen,
+      gestureEnabled: !isFullscreen,
+      orientation: isFullscreen ? "landscape" : "portrait",
+    })
+    if (isFullscreen) void enterFullscreenLandscape()
+    else void exitToPortrait()
+  }, [isFullscreen, navigation])
+
+  useEffect(() => {
+    if (!isFullscreen) return
+    const back = BackHandler.addEventListener("hardwareBackPress", () => {
+      setIsFullscreen(false)
+      return true
+    })
+    const app = AppState.addEventListener("change", (s) => {
+      if (s === "active") void enterFullscreenLandscape()
+    })
+    return () => {
+      back.remove()
+      app.remove()
+    }
+  }, [isFullscreen])
+
+  useEffect(() => {
+    return () => {
+      void exitToPortrait()
+    }
+  }, [])
+
+  const displayTitle = series?.title ?? seed?.title ?? null
+  const displayPoster = resolveImageUrl(
+    series?.posterUrl ?? seed?.imageUrl ?? null,
+  )
+
+  // The trailer follows the selected language: the series' own dub for that
+  // language, else its first playable dub. Resolved only from the loaded series
+  // — never the seed — so a series that turns out to have no trailer never
+  // mounts a player.
+  const trailerHls = useMemo(() => {
+    if (!series) return null
+    const forLanguage = series.variants.find(
+      (v) => v.languageSlug === selectedLanguageSlug && v.hls != null,
+    )
+    return forLanguage?.hls ?? series.streamingUrl
+  }, [series, selectedLanguageSlug])
+
+  const hasSeries = series != null
+  const hasTrailer = trailerHls != null
+
+  const handleShare = useCallback(() => {
+    if (!series) return
+    // The public watch URL is two .html segments — a bare /watch/{slug} 404s.
+    const base = `https://www.jesusfilm.org/${series.slug}.html`
+    const shareUrl = selectedLanguageSlug
+      ? `${base}/${selectedLanguageSlug}.html`
+      : base
+    Share.share({ message: shareUrl, title: series.title ?? undefined })
+  }, [series, selectedLanguageSlug])
+
+  // Cold deep link with nothing to paint yet → skeleton, not a blank spinner.
+  if (!hasSeries && seed == null && loading) {
+    return (
+      <View style={layout.screenContainer}>
+        <VideoDetailSkeleton />
+      </View>
+    )
+  }
+
+  // No series, no seed, not loading → genuinely nothing to show.
+  if (!hasSeries && seed == null) {
+    return (
+      <View style={layout.centered}>
+        <Text style={text.errorTitle}>Series Not Found</Text>
+        <Text style={text.errorMessage}>
+          {error?.message ?? "This series could not be loaded."}
+        </Text>
+        <Text
+          style={styles.retryLink}
+          onPress={() => void refetch()}
+          accessibilityRole="button"
+        >
+          Retry
+        </Text>
+      </View>
+    )
+  }
 
   return (
     <View style={layout.screenContainer}>
-      <ScrollView />
+      <StatusBar style="light" hidden={isFullscreen} />
+
+      {hasSeries && hasTrailer ? (
+        <VideoPlayer
+          streamingUrl={trailerHls}
+          posterUrl={displayPoster}
+          fullscreen={isFullscreen}
+          onToggleFullscreen={toggleFullscreen}
+        />
+      ) : (
+        <View
+          style={styles.posterHero}
+          accessibilityRole="image"
+          accessibilityLabel={
+            displayTitle ? `${displayTitle} poster` : "Series poster"
+          }
+        >
+          {displayPoster != null && (
+            <Image
+              source={{ uri: displayPoster }}
+              style={StyleSheet.absoluteFill}
+              contentFit="cover"
+              recyclingKey={series?.documentId ?? decodedSlug}
+            />
+          )}
+        </View>
+      )}
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <VideoMetadata
+          label={series?.label ?? "SERIES"}
+          title={displayTitle}
+          subtitle={null}
+        />
+
+        {hasSeries ? (
+          <>
+            <SeriesActionRow
+              onLanguage={() => router.push("/series/language")}
+              onShare={handleShare}
+            />
+            <VideoDescription description={series.description} />
+            {/* Episode grid lands in U4. */}
+          </>
+        ) : (
+          <>
+            {error != null && (
+              <View style={styles.inlineError}>
+                <Text style={text.errorMessage}>
+                  Couldn&apos;t load full details.
+                </Text>
+                <Text
+                  style={styles.retryLink}
+                  onPress={() => void refetch()}
+                  accessibilityRole="button"
+                >
+                  Retry
+                </Text>
+              </View>
+            )}
+            <VideoDetailSkeleton variant="sections" />
+          </>
+        )}
+      </ScrollView>
     </View>
   )
 }
+
+const styles = StyleSheet.create({
+  scroll: { flex: 1 },
+  scrollContent: { paddingBottom: 80 },
+  posterHero: {
+    width: "100%",
+    aspectRatio: 16 / 9,
+    backgroundColor: SURFACE_COLOR,
+  },
+  inlineError: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  retryLink: {
+    color: ACCENT,
+    fontFamily: "System",
+    fontSize: 15,
+    fontWeight: "600",
+    marginTop: 12,
+    textAlign: "center",
+  },
+})

--- a/apps/mobile/app/series/[slug].tsx
+++ b/apps/mobile/app/series/[slug].tsx
@@ -122,7 +122,10 @@ export default function SeriesScreen() {
   const trailerHls = useMemo(() => {
     if (!series) return null
     const forLanguage = series.variants.find(
-      (v) => v.languageSlug === selectedLanguageSlug && v.hls != null,
+      (v) =>
+        v.languageSlug === selectedLanguageSlug &&
+        v.hls != null &&
+        v.hls !== "",
     )
     return forLanguage?.hls ?? series.streamingUrl
   }, [series, selectedLanguageSlug])
@@ -132,12 +135,18 @@ export default function SeriesScreen() {
 
   const handleShare = useCallback(() => {
     if (!series) return
-    // The public watch URL is two .html segments — a bare /watch/{slug} 404s.
-    const base = `https://www.jesusfilm.org/${series.slug}.html`
+    // Public watch URL is /watch/{slug}.html/{language}.html (verified 200);
+    // the bare /{slug}.html form without /watch/ 404s.
+    const base = `https://www.jesusfilm.org/watch/${series.slug}.html`
     const shareUrl = selectedLanguageSlug
       ? `${base}/${selectedLanguageSlug}.html`
       : base
-    Share.share({ message: shareUrl, title: series.title ?? undefined })
+    // Share.share rejects when the OS share sheet is dismissed/unavailable;
+    // swallow it so it never surfaces as an unhandled rejection.
+    void Share.share({
+      message: shareUrl,
+      title: series.title ?? undefined,
+    }).catch(() => {})
   }, [series, selectedLanguageSlug])
 
   // Tap an episode → its video detail page. The selected language carries via
@@ -200,6 +209,7 @@ export default function SeriesScreen() {
       ) : (
         <View
           style={styles.posterHero}
+          accessible={true}
           accessibilityRole="image"
           accessibilityLabel={
             displayTitle ? `${displayTitle} poster` : "Series poster"

--- a/apps/mobile/app/series/[slug].tsx
+++ b/apps/mobile/app/series/[slug].tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   AppState,
   BackHandler,
-  ScrollView,
   Share,
   StyleSheet,
   Text,
@@ -14,8 +13,11 @@ import { useLocalSearchParams, useNavigation, useRouter } from "expo-router"
 import { useQuery } from "@apollo/client/react"
 
 import { GET_SERIES_BY_SLUG } from "../../src/lib/queries"
-import { normalizeSeries } from "../../src/lib/normalizeVideo"
-import { decodeWatchSeed } from "../../src/lib/watchSeed"
+import {
+  normalizeSeries,
+  type WatchEpisode,
+} from "../../src/lib/normalizeVideo"
+import { decodeWatchSeed, encodeWatchSeed } from "../../src/lib/watchSeed"
 import { resolveImageUrl } from "../../src/lib/resolveImageUrl"
 import { ACCENT, SURFACE_COLOR } from "../../src/lib/color"
 import { layout, text } from "../../src/styles/shared"
@@ -28,7 +30,10 @@ import { VideoDetailSkeleton } from "../../src/components/watch/VideoDetailSkele
 import { VideoMetadata } from "../../src/components/watch/VideoMetadata"
 import { VideoDescription } from "../../src/components/watch/VideoDescription"
 import { SeriesActionRow } from "../../src/components/watch/SeriesActionRow"
+import { SeriesEpisodesGrid } from "../../src/components/series/SeriesEpisodesGrid"
 import { useSeriesSession } from "../../src/contexts/SeriesSessionProvider"
+
+const EMPTY_EPISODES: WatchEpisode[] = []
 
 // Series detail screen. The hero is pinned at the route root (outside the
 // ScrollView), mirroring the watch screen: with a playable trailer it's the
@@ -135,6 +140,24 @@ export default function SeriesScreen() {
     Share.share({ message: shareUrl, title: series.title ?? undefined })
   }, [series, selectedLanguageSlug])
 
+  // Tap an episode → its video detail page. The selected language carries via
+  // the persisted WatchPreferences audio slug (set when the user picks a
+  // language in the sheet), which the watch screen resolves its dub from — so no
+  // language is threaded through the nav params. The seed paints the episode
+  // hero instantly.
+  const handleSelectEpisode = useCallback(
+    (episode: WatchEpisode) => {
+      const seed = encodeWatchSeed({
+        slug: episode.slug,
+        title: episode.title,
+        imageUrl: episode.posterUrl,
+        playbackId: null,
+      })
+      router.push(`/watch/${encodeURIComponent(episode.slug)}?seed=${seed}`)
+    },
+    [router],
+  )
+
   // Cold deep link with nothing to paint yet → skeleton, not a blank spinner.
   if (!hasSeries && seed == null && loading) {
     return (
@@ -193,57 +216,66 @@ export default function SeriesScreen() {
         </View>
       )}
 
-      <ScrollView
-        style={styles.scroll}
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={false}
-      >
-        <VideoMetadata
-          label={series?.label ?? "SERIES"}
-          title={displayTitle}
-          subtitle={null}
-        />
-
-        {hasSeries ? (
+      <SeriesEpisodesGrid
+        episodes={hasSeries ? series.episodes : EMPTY_EPISODES}
+        onSelect={handleSelectEpisode}
+        header={
           <>
-            <SeriesActionRow
-              onLanguage={() => router.push("/series/language")}
-              onShare={handleShare}
+            <VideoMetadata
+              label={series?.label ?? "SERIES"}
+              title={displayTitle}
+              subtitle={null}
             />
-            <VideoDescription description={series.description} />
-            {/* Episode grid lands in U4. */}
-          </>
-        ) : (
-          <>
-            {error != null && (
-              <View style={styles.inlineError}>
-                <Text style={text.errorMessage}>
-                  Couldn&apos;t load full details.
-                </Text>
-                <Text
-                  style={styles.retryLink}
-                  onPress={() => void refetch()}
-                  accessibilityRole="button"
-                >
-                  Retry
-                </Text>
-              </View>
+
+            {hasSeries ? (
+              <>
+                <SeriesActionRow
+                  onLanguage={() => router.push("/series/language")}
+                  onShare={handleShare}
+                />
+                <VideoDescription description={series.description} />
+                {series.episodes.length > 0 && (
+                  <Text style={[text.sectionHeading, styles.gridHeading]}>
+                    Videos
+                  </Text>
+                )}
+              </>
+            ) : (
+              <>
+                {error != null && (
+                  <View style={styles.inlineError}>
+                    <Text style={text.errorMessage}>
+                      Couldn&apos;t load full details.
+                    </Text>
+                    <Text
+                      style={styles.retryLink}
+                      onPress={() => void refetch()}
+                      accessibilityRole="button"
+                    >
+                      Retry
+                    </Text>
+                  </View>
+                )}
+                <VideoDetailSkeleton variant="sections" />
+              </>
             )}
-            <VideoDetailSkeleton variant="sections" />
           </>
-        )}
-      </ScrollView>
+        }
+      />
     </View>
   )
 }
 
 const styles = StyleSheet.create({
-  scroll: { flex: 1 },
-  scrollContent: { paddingBottom: 80 },
   posterHero: {
     width: "100%",
     aspectRatio: 16 / 9,
     backgroundColor: SURFACE_COLOR,
+  },
+  gridHeading: {
+    paddingHorizontal: 16,
+    marginTop: 8,
+    marginBottom: 2,
   },
   inlineError: {
     paddingHorizontal: 16,

--- a/apps/mobile/app/series/_layout.tsx
+++ b/apps/mobile/app/series/_layout.tsx
@@ -1,0 +1,45 @@
+import { Stack, useRouter } from "expo-router"
+import { Pressable } from "react-native"
+import Ionicons from "@expo/vector-icons/Ionicons"
+
+import { ACCENT, BG_COLOR } from "../../src/lib/color"
+import { SeriesSessionProvider } from "../../src/contexts/SeriesSessionProvider"
+
+// Mirrors app/watch/_layout.tsx: the series screen + its language sheet share a
+// session context, so the Stack is wrapped in SeriesSessionProvider. The
+// `language` formSheet route is registered in U5 when the sheet lands.
+export default function SeriesLayout() {
+  const router = useRouter()
+
+  return (
+    <SeriesSessionProvider>
+      <Stack
+        screenOptions={{
+          contentStyle: { backgroundColor: BG_COLOR },
+        }}
+      >
+        <Stack.Screen
+          name="[slug]"
+          options={{
+            headerShown: true,
+            headerTintColor: ACCENT,
+            headerTitle: "",
+            headerStyle: { backgroundColor: BG_COLOR },
+            headerShadowVisible: false,
+            headerTitleAlign: "center",
+            headerLeft: () => (
+              <Pressable
+                onPress={() => router.back()}
+                accessibilityRole="button"
+                accessibilityLabel="Go back"
+                hitSlop={12}
+              >
+                <Ionicons name="chevron-back" size={28} color={ACCENT} />
+              </Pressable>
+            ),
+          }}
+        />
+      </Stack>
+    </SeriesSessionProvider>
+  )
+}

--- a/apps/mobile/app/series/_layout.tsx
+++ b/apps/mobile/app/series/_layout.tsx
@@ -4,10 +4,27 @@ import Ionicons from "@expo/vector-icons/Ionicons"
 
 import { ACCENT, BG_COLOR } from "../../src/lib/color"
 import { SeriesSessionProvider } from "../../src/contexts/SeriesSessionProvider"
+import { LIST_SHEET_DETENTS } from "../../src/styles/shared"
+
+const SHEET_BASE_OPTIONS = {
+  headerShown: false,
+  presentation: "formSheet",
+  sheetInitialDetentIndex: 0,
+  sheetGrabberVisible: true,
+  sheetCornerRadius: 16,
+} as const
+
+// Long, scrollable language list → opt out of scroll-expands-to-edge so the
+// first scroll at the smaller detent doesn't snap the sheet to full (same as
+// the watch language/subtitle sheets).
+const LIST_SHEET_OPTIONS = {
+  ...SHEET_BASE_OPTIONS,
+  sheetAllowedDetents: [...LIST_SHEET_DETENTS],
+  sheetExpandsWhenScrolledToEdge: false,
+}
 
 // Mirrors app/watch/_layout.tsx: the series screen + its language sheet share a
-// session context, so the Stack is wrapped in SeriesSessionProvider. The
-// `language` formSheet route is registered in U5 when the sheet lands.
+// session context, so the Stack is wrapped in SeriesSessionProvider.
 export default function SeriesLayout() {
   const router = useRouter()
 
@@ -39,6 +56,7 @@ export default function SeriesLayout() {
             ),
           }}
         />
+        <Stack.Screen name="language" options={LIST_SHEET_OPTIONS} />
       </Stack>
     </SeriesSessionProvider>
   )

--- a/apps/mobile/app/series/language.tsx
+++ b/apps/mobile/app/series/language.tsx
@@ -1,0 +1,31 @@
+import { useCallback } from "react"
+import { useRouter } from "expo-router"
+
+import { SeriesLanguageSheet } from "../../src/components/series/SeriesLanguageSheet"
+import { useSeriesSession } from "../../src/contexts/SeriesSessionProvider"
+
+// formSheet route for the series language picker. Reads the series' language
+// union + current selection from the shared session and writes the pick back —
+// the screen's hero swaps its trailer dub (best-effort) and the choice persists
+// as the audio preference that the tapped episode opens in.
+export default function SeriesLanguageRoute() {
+  const router = useRouter()
+  const { series, languages, selectedLanguageSlug, setSelectedLanguageSlug } =
+    useSeriesSession()
+
+  const handleLanguageChange = useCallback(
+    (slug: string) => setSelectedLanguageSlug(slug),
+    [setSelectedLanguageSlug],
+  )
+
+  if (!series) return null
+
+  return (
+    <SeriesLanguageSheet
+      languages={languages}
+      activeLanguageSlug={selectedLanguageSlug ?? ""}
+      onLanguageChange={handleLanguageChange}
+      onClose={() => router.back()}
+    />
+  )
+}

--- a/apps/mobile/app/watch/[slug].tsx
+++ b/apps/mobile/app/watch/[slug].tsx
@@ -23,6 +23,7 @@ import {
   normalizeVideo,
   type WatchBibleCitation,
 } from "../../src/lib/normalizeVideo"
+import { isSeriesRecord } from "../../src/lib/isSeriesRecord"
 import { decodeWatchSeed } from "../../src/lib/watchSeed"
 import { muxHlsUrlFromPlaybackId } from "../../src/lib/muxThumbnail"
 import { ACCENT } from "../../src/lib/color"
@@ -152,6 +153,22 @@ export default function WatchVideoPage() {
       ),
     [data],
   )
+
+  // A series reached via /watch (deep link, recommendation, or a stale search
+  // entry) redirects to the dedicated series page. Detection is label-based —
+  // the lean watch fragment doesn't fetch the video's own children. Fires once
+  // per resolved slug (a ref guard) so it can't loop, and as early as the record
+  // resolves to minimize the brief watch-screen flash (the seed's playbackId is
+  // null for a series, so no stream loads in that window).
+  const redirectedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!normalized) return
+    if (redirectedRef.current === decodedSlug) return
+    if (!isSeriesRecord(normalized)) return
+    redirectedRef.current = decodedSlug
+    const seedSuffix = seedParam ? `?seed=${seedParam}` : ""
+    router.replace(`/series/${encodeURIComponent(decodedSlug)}${seedSuffix}`)
+  }, [normalized, decodedSlug, seedParam, router])
 
   // Seed carried from the list surface (search / Up Next) so the screen paints
   // instantly from data already in hand, before the query resolves.

--- a/apps/mobile/src/components/series/SeriesEpisodeCard.tsx
+++ b/apps/mobile/src/components/series/SeriesEpisodeCard.tsx
@@ -1,0 +1,104 @@
+import { Pressable, StyleSheet, Text, View } from "react-native"
+import { Image } from "expo-image"
+import { LinearGradient } from "expo-linear-gradient"
+
+import type { WatchEpisode } from "../../lib/normalizeVideo"
+import { BLACK, SURFACE_COLOR, hexToRgba } from "../../lib/color"
+import { resolveImageUrl } from "../../lib/resolveImageUrl"
+
+type SeriesEpisodeCardProps = {
+  episode: WatchEpisode
+  onSelect: (episode: WatchEpisode) => void
+}
+
+// A single video in the series grid. 4:3 thumbnail + title, mirroring
+// SearchResultCard. A static image — never a player — so the grid holds no
+// hardware decoder slots (only the hero does).
+export function SeriesEpisodeCard({
+  episode,
+  onSelect,
+}: SeriesEpisodeCardProps) {
+  const imageUrl = resolveImageUrl(episode.posterUrl)
+
+  return (
+    <View style={styles.cardOuter}>
+      <Pressable
+        onPress={() => onSelect(episode)}
+        accessibilityRole="button"
+        accessibilityLabel={episode.title ?? "Episode"}
+        style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      >
+        <View style={styles.thumb}>
+          {imageUrl ? (
+            <Image
+              source={imageUrl}
+              style={StyleSheet.absoluteFill}
+              contentFit="cover"
+              recyclingKey={episode.documentId}
+            />
+          ) : (
+            <View style={[StyleSheet.absoluteFill, styles.placeholder]}>
+              <Text style={styles.placeholderIcon}>▶</Text>
+            </View>
+          )}
+
+          <LinearGradient
+            colors={[hexToRgba(BLACK, 0), "rgba(0,0,0,0.25)", BLACK]}
+            locations={[0, 0.5, 1]}
+            style={StyleSheet.absoluteFill}
+          />
+
+          {episode.title ? (
+            <View style={styles.titleOverlay}>
+              <Text style={styles.title} numberOfLines={2}>
+                {episode.title}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+      </Pressable>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  cardOuter: {
+    flex: 1,
+    margin: 6,
+  },
+  card: {
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  cardPressed: {
+    opacity: 0.85,
+  },
+  thumb: {
+    aspectRatio: 4 / 3,
+    width: "100%",
+    backgroundColor: SURFACE_COLOR,
+  },
+  placeholder: {
+    backgroundColor: SURFACE_COLOR,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  placeholderIcon: {
+    fontSize: 32,
+    color: "rgba(255,255,255,0.3)",
+  },
+  titleOverlay: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: 10,
+  },
+  title: {
+    color: "#ffffff",
+    fontFamily: "System",
+    fontWeight: "700",
+    fontSize: 13,
+    lineHeight: 17,
+  },
+})

--- a/apps/mobile/src/components/series/SeriesEpisodesGrid.tsx
+++ b/apps/mobile/src/components/series/SeriesEpisodesGrid.tsx
@@ -1,0 +1,54 @@
+import { useCallback } from "react"
+import { FlatList, StyleSheet, type ListRenderItemInfo } from "react-native"
+import type { ReactElement } from "react"
+
+import type { WatchEpisode } from "../../lib/normalizeVideo"
+import { SeriesEpisodeCard } from "./SeriesEpisodeCard"
+
+type SeriesEpisodesGridProps = {
+  episodes: WatchEpisode[]
+  header: ReactElement
+  onSelect: (episode: WatchEpisode) => void
+}
+
+// The series screen's scroll container: a 2-column grid of episode cards with
+// the hero-adjacent content (metadata, actions, description) in the list header.
+// Using the grid AS the scroll container avoids a vertical FlatList nested in a
+// ScrollView (the nested-VirtualizedList warning). With no episodes the header
+// still renders and no grid or placeholder shows.
+export function SeriesEpisodesGrid({
+  episodes,
+  header,
+  onSelect,
+}: SeriesEpisodesGridProps) {
+  // renderItem/keyExtractor memoized — Android is the primary device tier.
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<WatchEpisode>) => (
+      <SeriesEpisodeCard episode={item} onSelect={onSelect} />
+    ),
+    [onSelect],
+  )
+  const keyExtractor = useCallback((item: WatchEpisode) => item.documentId, [])
+
+  return (
+    <FlatList
+      data={episodes}
+      numColumns={2}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      ListHeaderComponent={header}
+      columnWrapperStyle={styles.column}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  column: {
+    paddingHorizontal: 10,
+  },
+  content: {
+    paddingBottom: 80,
+  },
+})

--- a/apps/mobile/src/components/series/SeriesLanguageSheet.tsx
+++ b/apps/mobile/src/components/series/SeriesLanguageSheet.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useMemo, useRef, useState } from "react"
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  useWindowDimensions,
+  View,
+} from "react-native"
+import { FlashList } from "@shopify/flash-list"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import Ionicons from "@expo/vector-icons/Ionicons"
+
+import { useTypography } from "../../hooks/useTypography"
+import { useSheetListHeight } from "../../hooks/useSheetListHeight"
+import { ACCENT, TEXT_PRIMARY, TEXT_SECONDARY } from "../../lib/color"
+import { feedback, HORIZONTAL_PADDING } from "../../styles/shared"
+import type { WatchChildLanguage } from "../../lib/normalizeVideo"
+
+// Series language sheet. A near-twin of the watch LanguageSheetContent, but over
+// the series' childDubLanguages (the episode language union) instead of the
+// trailer's own dubs. Two reasons it's a separate component, not a reuse:
+//   - identity is the unique `slug` (keyExtractor + selection), never bcp47
+//     (`ko` collides with `ko-kmr`);
+//   - there's no `hls`/`documentId` to guard on — every listed language is a
+//     real, selectable episode language.
+function displayName(lang: WatchChildLanguage): string {
+  return lang.name ?? lang.slug
+}
+
+function sortByName(languages: WatchChildLanguage[]): WatchChildLanguage[] {
+  return [...languages].sort((a, b) =>
+    displayName(a).toLowerCase().localeCompare(displayName(b).toLowerCase()),
+  )
+}
+
+export type SeriesLanguageSheetProps = {
+  languages: WatchChildLanguage[]
+  activeLanguageSlug: string
+  onLanguageChange: (slug: string) => void
+  onClose: () => void
+}
+
+export function SeriesLanguageSheet({
+  languages,
+  activeLanguageSlug,
+  onLanguageChange,
+  onClose,
+}: SeriesLanguageSheetProps) {
+  const insets = useSafeAreaInsets()
+  const { height: windowHeight } = useWindowDimensions()
+  const typography = useTypography()
+  const [query, setQuery] = useState("")
+  // FlashList virtualizes but needs an explicit height inside the formSheet.
+  const listHeight = useSheetListHeight(windowHeight)
+  // Debounce so a fast double-tap can't pop the route twice.
+  const lastSelectRef = useRef(0)
+
+  const sorted = useMemo(() => sortByName(languages), [languages])
+  const active = useMemo(
+    () => sorted.find((l) => l.slug === activeLanguageSlug) ?? null,
+    [sorted, activeLanguageSlug],
+  )
+  const filtered = useMemo(() => {
+    let list = sorted
+    if (query.trim()) {
+      const lower = query.toLowerCase()
+      list = sorted.filter((l) => displayName(l).toLowerCase().includes(lower))
+    }
+    return list.filter((l) => l.slug !== activeLanguageSlug)
+  }, [sorted, query, activeLanguageSlug])
+
+  const handleSelect = useCallback(
+    (lang: WatchChildLanguage) => {
+      const now = Date.now()
+      if (now - lastSelectRef.current < 500) return
+      lastSelectRef.current = now
+      // Exact slug match — never bcp47.
+      onLanguageChange(lang.slug)
+      onClose()
+    },
+    [onLanguageChange, onClose],
+  )
+
+  const renderItem = useCallback(
+    ({ item }: { item: WatchChildLanguage }) => (
+      <Pressable
+        style={({ pressed }) => [styles.listRow, pressed && feedback.pressed]}
+        onPress={() => handleSelect(item)}
+        accessibilityRole="radio"
+        accessibilityState={{ selected: false }}
+        accessibilityLabel={displayName(item)}
+      >
+        <View style={styles.nameColumn}>
+          <Text style={[styles.listRowText, typography.body]} numberOfLines={1}>
+            {displayName(item)}
+          </Text>
+        </View>
+      </Pressable>
+    ),
+    [handleSelect, typography],
+  )
+
+  const keyExtractor = useCallback((item: WatchChildLanguage) => item.slug, [])
+
+  const header = (
+    <View style={styles.header}>
+      <View style={styles.searchContainer}>
+        <Ionicons name="search-outline" size={18} color={TEXT_SECONDARY} />
+        <TextInput
+          style={[styles.searchInput, typography.body]}
+          placeholder="Search languages..."
+          placeholderTextColor={TEXT_SECONDARY}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+          accessibilityLabel="Search languages"
+        />
+        {query.length > 0 && (
+          <Pressable
+            onPress={() => setQuery("")}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="Clear search"
+          >
+            <Ionicons name="close-circle" size={18} color={TEXT_SECONDARY} />
+          </Pressable>
+        )}
+      </View>
+
+      {active && (
+        <View style={styles.currentSection}>
+          <Text style={[styles.currentLabel, typography.bodySmall]}>
+            Current
+          </Text>
+          <View style={[styles.listRow, styles.listRowActive]}>
+            <Ionicons name="checkmark" size={18} color={ACCENT} />
+            <View style={styles.nameColumn}>
+              <Text
+                style={[
+                  styles.listRowText,
+                  typography.body,
+                  styles.listRowTextActive,
+                ]}
+                numberOfLines={1}
+              >
+                {displayName(active)}
+              </Text>
+            </View>
+          </View>
+        </View>
+      )}
+    </View>
+  )
+
+  return (
+    <View style={styles.container}>
+      <View style={{ height: listHeight }}>
+        <FlashList
+          data={filtered}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          keyboardShouldPersistTaps="handled"
+          // Off by intent: FlashList v2 enables maintainVisibleContentPosition by
+          // default; here the data swaps wholesale as the user types/clears the
+          // search, so anchoring makes the list jump.
+          maintainVisibleContentPosition={{ disabled: true }}
+          ListHeaderComponent={header}
+          contentContainerStyle={{
+            paddingHorizontal: HORIZONTAL_PADDING,
+            paddingBottom: insets.bottom + 24,
+          }}
+          showsVerticalScrollIndicator={false}
+          ListEmptyComponent={
+            <View style={styles.emptySearch}>
+              <Text style={[styles.emptySearchText, typography.body]}>
+                No languages found
+              </Text>
+            </View>
+          }
+        />
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    paddingTop: 36,
+  },
+  searchContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: "rgba(255, 255, 255, 0.06)",
+  },
+  searchInput: {
+    flex: 1,
+    color: TEXT_PRIMARY,
+    fontFamily: "System",
+    padding: 0,
+  },
+  currentSection: {
+    marginBottom: 12,
+  },
+  currentLabel: {
+    color: TEXT_SECONDARY,
+    fontFamily: "System",
+    marginBottom: 6,
+  },
+  listRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    minHeight: 48,
+  },
+  listRowActive: {
+    backgroundColor: "rgba(255, 255, 255, 0.06)",
+  },
+  nameColumn: {
+    flex: 1,
+    minWidth: 0,
+  },
+  listRowText: {
+    color: TEXT_PRIMARY,
+    fontFamily: "System",
+  },
+  listRowTextActive: {
+    fontWeight: "600",
+  },
+  emptySearch: {
+    alignItems: "center",
+    paddingVertical: 24,
+  },
+  emptySearchText: {
+    color: TEXT_SECONDARY,
+    fontFamily: "System",
+  },
+})

--- a/apps/mobile/src/components/watch/SeriesActionRow.tsx
+++ b/apps/mobile/src/components/watch/SeriesActionRow.tsx
@@ -9,7 +9,7 @@ import { useTypography } from "../../hooks/useTypography"
 // to download or caption, so the video page's Download/Subtitles buttons don't
 // carry over (ActionButtonRow is a fixed four-button row, hence a separate
 // component rather than a prop on it).
-export interface SeriesActionRowProps {
+export type SeriesActionRowProps = {
   onLanguage: () => void
   onShare: () => void
 }

--- a/apps/mobile/src/components/watch/SeriesActionRow.tsx
+++ b/apps/mobile/src/components/watch/SeriesActionRow.tsx
@@ -1,0 +1,77 @@
+import { Pressable, StyleSheet, Text, View } from "react-native"
+import Ionicons from "@expo/vector-icons/Ionicons"
+
+import { TEXT_SECONDARY } from "../../lib/color"
+import { feedback } from "../../styles/shared"
+import { useTypography } from "../../hooks/useTypography"
+
+// The series action row is Language + Share only. A series has no single asset
+// to download or caption, so the video page's Download/Subtitles buttons don't
+// carry over (ActionButtonRow is a fixed four-button row, hence a separate
+// component rather than a prop on it).
+export interface SeriesActionRowProps {
+  onLanguage: () => void
+  onShare: () => void
+}
+
+type ActionItem = {
+  icon: React.ComponentProps<typeof Ionicons>["name"]
+  label: string
+  onPress: () => void
+}
+
+export function SeriesActionRow({ onLanguage, onShare }: SeriesActionRowProps) {
+  const typography = useTypography()
+
+  const actions: ActionItem[] = [
+    { icon: "globe-outline", label: "Language", onPress: onLanguage },
+    { icon: "share-outline", label: "Share", onPress: onShare },
+  ]
+
+  return (
+    <View style={styles.row}>
+      {actions.map((action) => (
+        <Pressable
+          key={action.label}
+          onPress={action.onPress}
+          style={({ pressed }) => [
+            styles.actionButton,
+            pressed && feedback.pressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={action.label}
+        >
+          <Ionicons name={action.icon} size={24} color={TEXT_SECONDARY} />
+          <Text style={[styles.actionLabel, typography.caption]}>
+            {action.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 64,
+    paddingHorizontal: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "rgba(255, 255, 255, 0.1)",
+    marginTop: 4,
+    paddingTop: 8,
+  },
+  actionButton: {
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: 48,
+    minHeight: 48,
+    paddingVertical: 8,
+  },
+  actionLabel: {
+    color: TEXT_SECONDARY,
+    fontFamily: "System",
+    marginTop: 4,
+  },
+})

--- a/apps/mobile/src/components/watch/VideoDescription.tsx
+++ b/apps/mobile/src/components/watch/VideoDescription.tsx
@@ -16,12 +16,15 @@ export function VideoDescription({ description }: VideoDescriptionProps) {
   const typography = useTypography()
   const [expanded, setExpanded] = useState(false)
 
-  if (description == null || description.length === 0) return null
-
   const handleToggle = useCallback(() => {
     animateLayout()
     setExpanded((prev) => !prev)
   }, [])
+
+  // Guard AFTER all hooks — a description that goes null -> non-null on a mounted
+  // instance (the series screen republishes partial -> full under cache-first)
+  // would otherwise change the hook count between renders and crash.
+  if (description == null || description.length === 0) return null
 
   return (
     <View style={[layout.sectionOuter, styles.localContainer]}>

--- a/apps/mobile/src/contexts/SeriesSessionProvider.tsx
+++ b/apps/mobile/src/contexts/SeriesSessionProvider.tsx
@@ -1,0 +1,148 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+
+import type {
+  WatchChildLanguage,
+  WatchVideoRecord,
+} from "../lib/normalizeVideo"
+import { resolveDefaultSlug } from "../lib/resolveDefaultLanguage"
+import { useWatchPreferences } from "./WatchPreferencesProvider"
+
+/**
+ * Shared selection state for the series detail screen and its language sheet.
+ *
+ * The language sheet is a separate formSheet route, so it can't receive props
+ * from the screen — both read/write the selected language through this context
+ * (context, not router params: passing a language through nav params has bitten
+ * the watch surface before). Deliberately lightweight vs WatchSessionProvider:
+ * a series page has no per-dub downloads/subtitles/snackbar machinery, only a
+ * trailer, an episode grid, and a language choice.
+ */
+type SeriesSessionContextValue = {
+  series: WatchVideoRecord | null
+  setSeries: (series: WatchVideoRecord | null) => void
+  /** The languages the series' episodes are available in — the sheet's feed. */
+  languages: WatchChildLanguage[]
+  /** The selected audio language slug, or null before resolution. */
+  selectedLanguageSlug: string | null
+  /**
+   * Set the selected language. Persists it as the app-wide audio preference so
+   * it carries into an episode opened from the grid — the watch screen resolves
+   * its default dub from the same `WatchPreferences` slug. App-wide + persisted
+   * is the deliberate trade-off (resolved during planning): picking a series
+   * language changes the default audio for later videos until changed again.
+   */
+  setSelectedLanguageSlug: (slug: string) => void
+}
+
+const SeriesSessionContext = createContext<SeriesSessionContextValue | null>(
+  null,
+)
+
+// Module-level stable empty so the context value memo doesn't thrash when a
+// series has no language union (or none yet).
+const EMPTY_LANGUAGES: WatchChildLanguage[] = []
+
+export function SeriesSessionProvider({ children }: { children: ReactNode }) {
+  const {
+    audioLanguageSlug: preferredAudioSlug,
+    isReady: preferencesReady,
+    setPreferredAudioLanguage,
+  } = useWatchPreferences()
+
+  const [series, setSeries] = useState<WatchVideoRecord | null>(null)
+  const [selectedLanguageSlug, setSelectedLanguageSlugState] = useState<
+    string | null
+  >(null)
+
+  // series.languages is referentially stable for a given series (normalizeSeries
+  // memoizes on the raw reference), so this is stable across renders.
+  const languages = series?.languages ?? EMPTY_LANGUAGES
+
+  // Whether the user explicitly picked a language for this series, so the
+  // default-resolution effect never overrides a deliberate choice when partial→
+  // full data republishes the same series. Reset per series identity.
+  const userChoseRef = useRef(false)
+  const resolvedForRef = useRef<string | null>(null)
+
+  const setSelectedLanguageSlug = useCallback(
+    (slug: string) => {
+      userChoseRef.current = true
+      setSelectedLanguageSlugState(slug)
+      // Carry-through: persist by unique slug so the tapped episode opens in it.
+      if (slug) setPreferredAudioLanguage(slug)
+    },
+    [setPreferredAudioLanguage],
+  )
+
+  // New series identity → reset choice tracking + selection, so a prior series'
+  // language never leaks into the next.
+  useEffect(() => {
+    userChoseRef.current = false
+    resolvedForRef.current = null
+    setSelectedLanguageSlugState(null)
+  }, [series?.documentId])
+
+  // Default the language once per series, as soon as the language union is
+  // available, unless the user already chose. Resolution order (resolveDefaultSlug):
+  // persisted preference → device locale → series primary → English → first.
+  useEffect(() => {
+    if (!preferencesReady) return
+    if (!series || series.languages.length === 0) return
+    if (userChoseRef.current) return
+    if (resolvedForRef.current === series.documentId) return
+    resolvedForRef.current = series.documentId
+    const options = series.languages.map((l) => ({
+      slug: l.slug,
+      bcp47: l.bcp47,
+      languageSlug: l.slug,
+    }))
+    const best = resolveDefaultSlug(
+      options,
+      series.primaryLanguageBcp47,
+      preferredAudioSlug,
+    )
+    setSelectedLanguageSlugState(best ?? series.languages[0].slug)
+  }, [
+    series?.documentId,
+    series?.languages.length,
+    series?.primaryLanguageBcp47,
+    preferencesReady,
+    preferredAudioSlug,
+  ])
+
+  const value = useMemo<SeriesSessionContextValue>(
+    () => ({
+      series,
+      setSeries,
+      languages,
+      selectedLanguageSlug,
+      setSelectedLanguageSlug,
+    }),
+    [series, languages, selectedLanguageSlug, setSelectedLanguageSlug],
+  )
+
+  return (
+    <SeriesSessionContext.Provider value={value}>
+      {children}
+    </SeriesSessionContext.Provider>
+  )
+}
+
+export function useSeriesSession() {
+  const ctx = useContext(SeriesSessionContext)
+  if (!ctx) {
+    throw new Error(
+      "useSeriesSession must be used within SeriesSessionProvider",
+    )
+  }
+  return ctx
+}

--- a/apps/mobile/src/lib/__tests__/isSeriesRecord.test.ts
+++ b/apps/mobile/src/lib/__tests__/isSeriesRecord.test.ts
@@ -1,0 +1,35 @@
+import { isSeriesLabel, isSeriesRecord } from "../isSeriesRecord"
+
+describe("isSeriesLabel", () => {
+  it("matches SERIES and COLLECTION case-insensitively", () => {
+    expect(isSeriesLabel("SERIES")).toBe(true)
+    expect(isSeriesLabel("COLLECTION")).toBe(true)
+    expect(isSeriesLabel("series")).toBe(true)
+    expect(isSeriesLabel("Collection")).toBe(true)
+  })
+
+  it("rejects single-video labels and absent labels", () => {
+    expect(isSeriesLabel("EPISODE")).toBe(false)
+    expect(isSeriesLabel("SEGMENT")).toBe(false)
+    expect(isSeriesLabel("FEATURE_FILM")).toBe(false)
+    expect(isSeriesLabel(null)).toBe(false)
+    expect(isSeriesLabel(undefined)).toBe(false)
+  })
+})
+
+describe("isSeriesRecord", () => {
+  it("is true for a SERIES/COLLECTION label", () => {
+    expect(isSeriesRecord({ label: "SERIES", episodes: [] })).toBe(true)
+    expect(isSeriesRecord({ label: "COLLECTION", episodes: [] })).toBe(true)
+  })
+
+  it("is true for an unlabeled record that has children", () => {
+    expect(isSeriesRecord({ label: null, episodes: [{}, {}] })).toBe(true)
+    expect(isSeriesRecord({ label: "EPISODE", episodes: [{}] })).toBe(true)
+  })
+
+  it("is false for a single video with no children", () => {
+    expect(isSeriesRecord({ label: "EPISODE", episodes: [] })).toBe(false)
+    expect(isSeriesRecord({ label: null, episodes: [] })).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/isSeriesRecord.test.ts
+++ b/apps/mobile/src/lib/__tests__/isSeriesRecord.test.ts
@@ -1,4 +1,8 @@
-import { isSeriesLabel, isSeriesRecord } from "../isSeriesRecord"
+import {
+  isSeriesLabel,
+  isSeriesRecord,
+  isSeriesSearchResult,
+} from "../isSeriesRecord"
 
 describe("isSeriesLabel", () => {
   it("matches SERIES and COLLECTION case-insensitively", () => {
@@ -31,5 +35,30 @@ describe("isSeriesRecord", () => {
   it("is false for a single video with no children", () => {
     expect(isSeriesRecord({ label: "EPISODE", episodes: [] })).toBe(false)
     expect(isSeriesRecord({ label: null, episodes: [] })).toBe(false)
+  })
+})
+
+describe("isSeriesSearchResult", () => {
+  it("is true for a SERIES/COLLECTION label regardless of childCount", () => {
+    expect(isSeriesSearchResult({ label: "SERIES", childCount: 0 })).toBe(true)
+    expect(
+      isSeriesSearchResult({ label: "COLLECTION", childCount: null }),
+    ).toBe(true)
+  })
+
+  it("is true for a non-series label with a positive childCount", () => {
+    // The childCount branch — distinct from the redirect's episodes.length path.
+    expect(isSeriesSearchResult({ label: "EPISODE", childCount: 3 })).toBe(true)
+    expect(isSeriesSearchResult({ label: null, childCount: 1 })).toBe(true)
+  })
+
+  it("is false for a single video (no series label, zero/absent childCount)", () => {
+    expect(isSeriesSearchResult({ label: "SHORT_FILM", childCount: 0 })).toBe(
+      false,
+    )
+    expect(isSeriesSearchResult({ label: "SEGMENT", childCount: null })).toBe(
+      false,
+    )
+    expect(isSeriesSearchResult({ label: null })).toBe(false)
   })
 })

--- a/apps/mobile/src/lib/__tests__/normalizeVideo.test.ts
+++ b/apps/mobile/src/lib/__tests__/normalizeVideo.test.ts
@@ -1,4 +1,8 @@
-import { normalizeVideo, normalizeDubMedia } from "../normalizeVideo"
+import {
+  normalizeVideo,
+  normalizeDubMedia,
+  normalizeSeries,
+} from "../normalizeVideo"
 
 // A single dub's raw shape as returned by GET_VIDEO_DUB (the lazy per-dub media
 // query). Downloads + subtitles now live here, not on the bulk WatchVideo dubs.
@@ -523,5 +527,162 @@ describe("normalizeVideo — partial data (returnPartialData)", () => {
     expect(result.streamingUrl).toBeNull()
     expect(result.posterUrl).toBeNull()
     expect(result.title).toBeNull()
+  })
+})
+
+function makeRawSeries(overrides: Record<string, unknown> = {}) {
+  const child = (
+    n: number,
+    extra: Record<string, unknown> = {},
+  ): { order: number; child: Record<string, unknown> } => ({
+    order: n,
+    child: {
+      documentId: `ep-${n}`,
+      slug: `episode-${n}`,
+      label: "EPISODE",
+      locales: [
+        {
+          documentId: `eploc-${n}`,
+          languageSlug: "english",
+          title: `Episode ${n}`,
+        },
+      ],
+      images: [
+        {
+          documentId: `epimg-${n}`,
+          url: `https://img.example.com/ep${n}.jpg`,
+          thumbnail: `https://img.example.com/ep${n}-thumb.jpg`,
+          mobileCinematicHigh: `https://img.example.com/ep${n}-cine.jpg`,
+          mobileCinematicLow: null,
+        },
+      ],
+      ...extra,
+    },
+  })
+  return {
+    documentId: "series-1",
+    slug: "storyclubs",
+    label: "SERIES",
+    images: [
+      {
+        documentId: "simg-1",
+        url: "https://img.example.com/series-poster.jpg",
+        thumbnail: "https://img.example.com/series-thumb.jpg",
+        mobileCinematicHigh: "https://img.example.com/series-cine.jpg",
+        mobileCinematicLow: null,
+      },
+    ],
+    primaryLanguage: { coreId: "529", bcp47: "en" },
+    locales: [
+      {
+        documentId: "sloc-1",
+        languageSlug: "english",
+        title: "StoryClubs",
+        description: "Bible lessons for kids.",
+        snippet: "Kids around the world",
+        imageAlt: "StoryClubs",
+      },
+    ],
+    parents: [],
+    variants: [
+      {
+        documentId: "trailer-dub",
+        slug: "storyclubs-trailer-english",
+        published: true,
+        hls: "https://stream.mux.com/trailer.m3u8",
+        duration: 45,
+        language: {
+          coreId: "529",
+          bcp47: "en",
+          slug: "english",
+          name: { en: "English" },
+        },
+        muxVideo: { playbackId: "trailer123" },
+      },
+    ],
+    // Deliberately out of order to prove sort-by-`order`.
+    children: [child(2), child(1), child(3)],
+    childDubLanguages: [
+      { slug: "english", name: { en: "English" }, bcp47: "en" },
+      { slug: "spanish", name: { en: "Spanish", es: "Español" }, bcp47: "es" },
+      // Duplicate slug to prove dedupe.
+      { slug: "english", name: { en: "English" }, bcp47: "en" },
+    ],
+    studyQuestions: [],
+    bibleCitations: [],
+    ...overrides,
+  } as unknown as Parameters<typeof normalizeSeries>[0]
+}
+
+describe("normalizeSeries", () => {
+  it("returns null for null / undefined / identity-less input", () => {
+    expect(normalizeSeries(null)).toBeNull()
+    expect(normalizeSeries(undefined)).toBeNull()
+    expect(
+      normalizeSeries(makeRawSeries({ documentId: "" }) as never),
+    ).toBeNull()
+  })
+
+  it("maps children to episodes sorted by order", () => {
+    const result = normalizeSeries(makeRawSeries())!
+    expect(result.episodes.map((e) => e.slug)).toEqual([
+      "episode-1",
+      "episode-2",
+      "episode-3",
+    ])
+    expect(result.episodes[0].title).toBe("Episode 1")
+    expect(result.episodes[0].posterUrl).toBe(
+      "https://img.example.com/ep1-cine.jpg",
+    )
+  })
+
+  it("deduplicates episodes by documentId", () => {
+    const raw = makeRawSeries()
+    raw!.children = [...raw!.children!, raw!.children![0]]
+    const result = normalizeSeries(raw)!
+    expect(result.episodes.filter((e) => e.documentId === "ep-2")).toHaveLength(
+      1,
+    )
+  })
+
+  it("builds the language union, localized and deduped by slug", () => {
+    const result = normalizeSeries(makeRawSeries())!
+    expect(result.languages.map((l) => l.slug)).toEqual(["english", "spanish"])
+    expect(result.languages[1].name).toBe("Spanish")
+    expect(result.languages[1].bcp47).toBe("es")
+  })
+
+  it("exposes the series' own playable dub as the trailer", () => {
+    const result = normalizeSeries(makeRawSeries())!
+    expect(result.streamingUrl).toBe("https://stream.mux.com/trailer.m3u8")
+    expect(result.muxPlaybackId).toBe("trailer123")
+    expect(result.variants).toHaveLength(1)
+  })
+
+  it("has no trailer streamingUrl when no dub is playable", () => {
+    const result = normalizeSeries(
+      makeRawSeries({
+        variants: [
+          {
+            documentId: "d",
+            slug: "d",
+            published: true,
+            hls: null,
+            duration: null,
+            language: null,
+            muxVideo: null,
+          },
+        ],
+      }),
+    )!
+    expect(result.streamingUrl).toBeNull()
+  })
+
+  it("yields empty episodes/languages for a series with none", () => {
+    const result = normalizeSeries(
+      makeRawSeries({ children: [], childDubLanguages: [] }),
+    )!
+    expect(result.episodes).toEqual([])
+    expect(result.languages).toEqual([])
   })
 })

--- a/apps/mobile/src/lib/__tests__/normalizeVideo.test.ts
+++ b/apps/mobile/src/lib/__tests__/normalizeVideo.test.ts
@@ -685,4 +685,48 @@ describe("normalizeSeries", () => {
     expect(result.episodes).toEqual([])
     expect(result.languages).toEqual([])
   })
+
+  it("drops a null child relation from the episode list", () => {
+    const result = normalizeSeries(
+      makeRawSeries({
+        children: [
+          { order: 1, child: null },
+          {
+            order: 2,
+            child: {
+              documentId: "ep-2",
+              slug: "episode-2",
+              label: "EPISODE",
+              locales: [
+                {
+                  documentId: "l",
+                  languageSlug: "english",
+                  title: "Episode 2",
+                },
+              ],
+              images: [],
+            },
+          },
+        ],
+      }),
+    )!
+    expect(result.episodes.map((e) => e.slug)).toEqual(["episode-2"])
+  })
+
+  it("drops an empty-string language slug from the union", () => {
+    const result = normalizeSeries(
+      makeRawSeries({
+        childDubLanguages: [
+          { slug: "", name: { en: "Blank" }, bcp47: "xx" },
+          { slug: "english", name: { en: "English" }, bcp47: "en" },
+        ],
+      }),
+    )!
+    expect(result.languages.map((l) => l.slug)).toEqual(["english"])
+  })
+
+  it("memoizes on the raw reference (cache-first re-entry returns same record)", () => {
+    const raw = makeRawSeries()
+    expect(normalizeSeries(raw)).toBe(normalizeSeries(raw))
+  })
 })

--- a/apps/mobile/src/lib/isSeriesRecord.ts
+++ b/apps/mobile/src/lib/isSeriesRecord.ts
@@ -19,3 +19,12 @@ export function isSeriesRecord(record: {
 }): boolean {
   return isSeriesLabel(record.label) || record.episodes.length > 0
 }
+
+// Search-result form: a SearchResult carries `label` + `childCount` (a number),
+// not a children array. Used by the search screen's routing branch.
+export function isSeriesSearchResult(result: {
+  label?: string | null
+  childCount?: number | null
+}): boolean {
+  return isSeriesLabel(result.label) || (result.childCount ?? 0) > 0
+}

--- a/apps/mobile/src/lib/isSeriesRecord.ts
+++ b/apps/mobile/src/lib/isSeriesRecord.ts
@@ -1,0 +1,21 @@
+// Series detection, mirroring web's apps/web/src/lib/content.ts isSeriesRecord:
+// a record is series-shaped when its label is SERIES/COLLECTION, or it has
+// children. The two call sites carry different shapes, so the label test is
+// shared and each site supplies its own "has children" signal:
+//   - search: a SearchResult has `label` + `childCount` (a number) — inline.
+//   - the /watch redirect: a normalized record has `label` + `episodes`. The
+//     lean watch fragment doesn't fetch the video's own children, so `episodes`
+//     is [] there and this resolves to a label check (the search entry's
+//     `childCount` covers the unlabeled-but-has-children case).
+const SERIES_LABELS = new Set(["series", "collection"])
+
+export function isSeriesLabel(label: string | null | undefined): boolean {
+  return label != null && SERIES_LABELS.has(label.toLowerCase())
+}
+
+export function isSeriesRecord(record: {
+  label: string | null
+  episodes: { length: number }
+}): boolean {
+  return isSeriesLabel(record.label) || record.episodes.length > 0
+}

--- a/apps/mobile/src/lib/normalizeVideo.ts
+++ b/apps/mobile/src/lib/normalizeVideo.ts
@@ -1,4 +1,4 @@
-import type { WatchVideoData, WatchDubData } from "./queries"
+import type { WatchVideoData, WatchDubData, SeriesVideoData } from "./queries"
 import { pickLocalizedName } from "./pickLocalizedName"
 
 // ── Consumer types ─────────────────────────────────────────────────
@@ -50,6 +50,19 @@ export type WatchSibling = {
   posterUrl: string | null
 }
 
+// A child video of a series, rendered as a card in the episode grid. Same shape
+// as a sibling — a related video reduced to what a card needs.
+export type WatchEpisode = WatchSibling
+
+// One language the series' episodes are available in (server-aggregated union),
+// the feed for the series language sheet. Identity is the unique `slug`, never
+// bcp47 — `ko` collides with `ko-kmr`.
+export type WatchChildLanguage = {
+  slug: string
+  name: string | null
+  bcp47: string | null
+}
+
 export type WatchStudyQuestion = {
   documentId: string
   value: string
@@ -83,6 +96,9 @@ export type WatchVideoRecord = {
   variants: WatchVariant[]
   studyQuestions: WatchStudyQuestion[]
   bibleCitations: WatchBibleCitation[]
+  // Series-only: empty for a single video; populated by normalizeSeries.
+  episodes: WatchEpisode[]
+  languages: WatchChildLanguage[]
 }
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -321,5 +337,69 @@ function buildWatchVideoRecord(raw: RawVideo): WatchVideoRecord {
     variants,
     studyQuestions,
     bibleCitations,
+    episodes: [],
+    languages: [],
   }
+}
+
+// ── Series normalizer ──────────────────────────────────────────────
+
+type RawSeriesVideo = NonNullable<SeriesVideoData["videoBySlug"]>
+
+function buildEpisodes(raw: RawSeriesVideo): WatchEpisode[] {
+  const episodes = (raw.children ?? [])
+    .filter(
+      (rel): rel is typeof rel & { child: NonNullable<typeof rel.child> } =>
+        rel.child != null,
+    )
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .map((rel) => ({
+      documentId: rel.child.documentId ?? "",
+      slug: rel.child.slug ?? "",
+      label: rel.child.label ?? null,
+      title: pickFirstLocale(rel.child.locales).title,
+      posterUrl: pickPosterUrl(rel.child.images),
+    }))
+  return dedupeByDocumentId(episodes)
+}
+
+function buildLanguages(raw: RawSeriesVideo): WatchChildLanguage[] {
+  const seen = new Set<string>()
+  const languages: WatchChildLanguage[] = []
+  for (const lang of raw.childDubLanguages ?? []) {
+    const slug = lang.slug
+    if (slug == null || slug === "" || seen.has(slug)) continue
+    seen.add(slug)
+    languages.push({
+      slug,
+      name: lang.name ? (pickLocalizedName(lang.name) ?? null) : null,
+      bcp47: lang.bcp47 ?? null,
+    })
+  }
+  return languages
+}
+
+// Memoize on the raw reference like normalizeVideo, so a cache-first re-entry
+// doesn't re-walk children/languages.
+const normalizeSeriesCache = new WeakMap<object, WatchVideoRecord | null>()
+
+// Normalize a series Video: the shared video record (trailer = the series' own
+// playable dub, exposed as streamingUrl/variants) plus the series-only episode
+// grid and the language union that feeds the language sheet.
+export function normalizeSeries(
+  raw: RawSeriesVideo | null | undefined,
+): WatchVideoRecord | null {
+  if (raw == null || !raw.documentId) return null
+  const cached = normalizeSeriesCache.get(raw)
+  if (cached !== undefined) return cached
+  // RawSeriesVideo is a structural superset of RawVideo (it spreads WatchVideo),
+  // so the shared builder maps the common fields; episodes + languages attach on
+  // top.
+  const result: WatchVideoRecord = {
+    ...buildWatchVideoRecord(raw),
+    episodes: buildEpisodes(raw),
+    languages: buildLanguages(raw),
+  }
+  normalizeSeriesCache.set(raw, result)
+  return result
 }

--- a/apps/mobile/src/lib/queries.ts
+++ b/apps/mobile/src/lib/queries.ts
@@ -65,6 +65,8 @@ export const SEARCH = adminGraphql(`
         startSeconds
         playbackId
         score
+        label
+        childCount
       }
     }
   }
@@ -210,6 +212,58 @@ export const GET_VIDEO_BY_SLUG = adminGraphql(
 )
 
 export type WatchVideoData = AdminResultOf<typeof GET_VIDEO_BY_SLUG>
+
+// ── Series detail query ─────────────────────────────────────────────
+//
+// A series is a Video whose label is SERIES/COLLECTION (or which has children).
+// The series detail page needs three things the single-video query doesn't:
+//   1. the series' OWN `children` (the episode grid) — distinct from the
+//      `parents.parent.children` siblings the WatchVideo fragment carries;
+//   2. `childDubLanguages` — the server-aggregated union of languages the
+//      episodes are available in, which drives the language sheet;
+//   3. (already in WatchVideo) the series' own `variants`/dubs — a playable one
+//      is the trailer.
+// These series-only selections live HERE, on a dedicated operation, NOT on the
+// shared `watchVideoFragment` — keeping the single-video query lean (see the
+// payload note above). gql.tada infers the types from admin's introspection;
+// no admin schema change is needed (the fields already exist).
+export const GET_SERIES_BY_SLUG = adminGraphql(
+  `
+    query GetSeriesBySlug($locale: String!, $slug: String!) {
+      videoBySlug(slug: $slug) {
+        ...WatchVideo
+        children {
+          order
+          child {
+            documentId: id
+            slug
+            label
+            locales(locale: $locale) {
+              documentId: id
+              languageSlug
+              title
+            }
+            images {
+              documentId: id
+              url
+              thumbnail
+              mobileCinematicHigh
+              mobileCinematicLow
+            }
+          }
+        }
+        childDubLanguages {
+          slug
+          name
+          bcp47
+        }
+      }
+    }
+  `,
+  [watchVideoFragment],
+)
+
+export type SeriesVideoData = AdminResultOf<typeof GET_SERIES_BY_SLUG>
 
 // ── Per-dub media (lazy) ────────────────────────────────────────────
 //

--- a/docs/brainstorms/2026-06-08-mobile-series-detail-page-requirements.md
+++ b/docs/brainstorms/2026-06-08-mobile-series-detail-page-requirements.md
@@ -1,0 +1,240 @@
+---
+date: 2026-06-08
+topic: mobile-series-detail-page
+---
+
+# Mobile Series Detail Page — Requirements
+
+## Summary
+
+Add a dedicated series detail page to the mobile app, matching the web app's
+series experience. Reached from search, it shows the series trailer up top
+(reusing the existing video-detail player) or a plain poster image when there
+is no trailer, then the series title, a "Read more" description, a Language +
+Share action row, and a scrollable grid of the series' videos that each open in
+the normal video detail page.
+
+---
+
+## Problem Frame
+
+A series is a `Video` with `label: SERIES`/`COLLECTION` (or any record with
+children). The web app renders these on a purpose-built series page. Mobile has
+no such page, so tapping a series in search routes it through the single-video
+detail screen (`apps/mobile/app/watch/[slug].tsx`). The result is the broken
+state in the reference screenshot: a series shown with a single-video layout —
+a chrome-heavy player, an "Up Next" sibling carousel, Bible Quotes, and a
+Download/Subtitles action row — none of which fit a collection. When a series
+has no trailer at all, the same screen has no image-only fallback to show.
+
+---
+
+## Key Decisions
+
+- **Series discriminator stays label-based.** A record is series-shaped when
+  its `label` is `SERIES` or `COLLECTION`, or it has children. No new type,
+  no schema change — this mirrors web's `isSeriesRecord`.
+
+- **Trailer reuses the existing player; image-only when absent.** When the
+  series has a playable trailer (its own dub with a non-null `hls`), the hero
+  reuses the video-detail `VideoPlayer` as-is, chrome and all. The "no player
+  chrome / just an image" rule applies only to the trailer-absent case, where
+  no player is mounted at all.
+
+- **One series page for every entry point.** Rather than branching only in
+  search, `apps/mobile/app/watch/[slug].tsx` redirects to the series page when
+  the resolved record is series-shaped. Deep links, recommendations, and search
+  all land on the same page.
+
+- **Language sets the carry-through audio language.** Selecting a language on
+  the series page swaps the trailer dub and becomes the language an episode
+  opens in when tapped. Re-translating the grid's episode titles on language
+  change is deferred.
+
+- **Language + Share only.** A series has no single downloadable or captionable
+  asset, so the video page's Download and Subtitles actions do not carry over.
+
+- **Mobile-side query change only.** Admin's `HybridSearchResult` already
+  exposes `label` and `childCount`, and `Video` already exposes the series'
+  own dubs, `children`, `childDubLanguages`, and images. The work is additive
+  field selection in mobile's own operations — zero `apps/admin` edits.
+
+---
+
+## Requirements
+
+**Entry and routing**
+
+- R1. A series-shaped record (label `SERIES`/`COLLECTION`, or any record with
+  children) renders the series detail page, not the single-video detail page.
+- R2. Mobile search routes a series-shaped result to the series page. Mobile's
+  search query selects `label` and `childCount`; no `apps/admin` change.
+- R3. Any navigation that resolves to a series slug lands on the series page:
+  `watch/[slug]` redirects to the series page when the resolved record is
+  series-shaped, so deep links and non-search entry points behave identically.
+
+**Hero**
+
+- R4. When the series has a playable trailer (its own dub with a non-null
+  `hls`), the hero reuses the existing video-detail `VideoPlayer`, with the
+  same chrome and controls as the video page.
+- R5. When the series has no playable trailer, the hero shows the series poster
+  as a plain image — no player is mounted and no player chrome appears.
+- R6. The poster falls back through the series images in the app's existing
+  precedence (`mobileCinematicHigh` → … → `url`).
+
+**Title, description, actions**
+
+- R7. The page shows a "SERIES" label and the series title.
+- R8. The page shows the series description with a collapsed "Read more"
+  expansion, matching the video page's description behavior.
+- R9. The action row has exactly two actions: Language and Share.
+- R10. Share invokes the native share sheet with the series' shareable link and
+  title.
+
+**Language**
+
+- R11. Language opens the existing language selection sheet.
+- R12. Selecting a language swaps the trailer dub when a matching dub exists.
+- R13. The selected language is carried into an episode when it is tapped — the
+  episode opens in that language.
+
+**Video grid**
+
+- R14. The page shows a scrollable grid of the series' videos (its children, in
+  their defined order). There is no in-grid search or filter input.
+- R15. Each grid card shows the video thumbnail and title.
+- R16. Tapping a grid card pushes to that video's existing detail page,
+  carrying the selected language and a seed for instant paint.
+
+---
+
+## Key Flows
+
+- F1. Open a series from search
+  - **Trigger:** User taps a series-shaped result in mobile search.
+  - **Steps:** Search detects the series via `label`/`childCount` and pushes the
+    series page → page resolves the series, its trailer, children, and dub
+    languages → hero paints from the seed image, then the trailer (if any).
+  - **Outcome:** The series detail page, not the single-video page.
+  - **Covered by:** R1, R2.
+
+- F2. Series with a trailer
+  - **Trigger:** Resolved series has a dub with a non-null `hls`.
+  - **Steps:** Hero mounts the existing `VideoPlayer` with the trailer stream
+    and series poster.
+  - **Outcome:** A normal, chrome-bearing player at the top of the page.
+  - **Covered by:** R4.
+
+- F3. Series without a trailer
+  - **Trigger:** Resolved series has no playable dub.
+  - **Steps:** Hero renders the series poster image only.
+  - **Outcome:** A static image — no player, no chrome.
+  - **Covered by:** R5, R6.
+
+- F4. Change language
+  - **Trigger:** User taps Language and selects a language.
+  - **Steps:** Sheet sets the selected language → trailer dub swaps if available
+    → the selection persists for episode taps.
+  - **Outcome:** Trailer plays in the chosen language; episodes will open in it.
+  - **Covered by:** R11, R12, R13.
+
+- F5. Open an episode from the grid
+  - **Trigger:** User taps a card in the video grid.
+  - **Steps:** Push the video detail page with the tapped slug, the selected
+    language, and a seed.
+  - **Outcome:** The standard single-video detail page for that episode.
+  - **Covered by:** R14, R15, R16.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R4.** Given a series with a playable trailer, when the page
+  opens, then the hero is the existing `VideoPlayer` showing the trailer.
+- AE2. **Covers R5, R6.** Given a series with no playable trailer, when the page
+  opens, then the hero is a plain poster image and no player is mounted.
+- AE3. **Covers R1, R2.** Given a search result whose `label` is `SERIES`, when
+  tapped, then the series page opens; given a result that is a single video,
+  when tapped, then the single-video page opens.
+- AE4. **Covers R3.** Given a deep link to a series slug routed through
+  `watch/[slug]`, when it resolves to a series-shaped record, then it redirects
+  to the series page.
+- AE5. **Covers R13.** Given a language selected on the series page, when an
+  episode is tapped, then the episode detail page opens in that language.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later**
+
+- Re-translating grid episode titles when the language changes (the trailer dub
+  and episode carry-through still swap; only the grid labels stay in their
+  fetched locale).
+- An in-grid search/filter input over the series' videos.
+- Series-level Download and Subtitles actions.
+
+**Outside this page's identity**
+
+- The single-video page's "Up Next" sibling carousel, Bible Quotes, and
+  related-questions blocks. The series page is trailer/image + title +
+  description + grid.
+- Any `apps/admin` or schema change. The required `label`, `childCount`,
+  `children`, series dubs, `childDubLanguages`, and images already exist on the
+  admin surface.
+
+---
+
+## Dependencies / Assumptions
+
+- The language sheet is a cross-route `formSheet` (separate Expo Router route,
+  no props). The series page therefore needs shared cross-route state so the
+  sheet's selection reaches the page — either reusing `WatchSessionProvider`
+  configured for a series, or a lightweight series-scoped equivalent.
+- Mobile's video-by-slug query already fetches the series' own variants (the
+  trailer) and `children`. `childDubLanguages` must be added to the series
+  query selection to populate the language sheet.
+- The series page reads the trailer from the series' own playable dub, the grid
+  from `children`, the language list from the dub-language union, and the poster
+  from the series images.
+
+---
+
+## Outstanding Questions
+
+**Deferred to Planning**
+
+- Language list source for the sheet: `childDubLanguages` (union across
+  episodes, matching web) vs. the trailer's own dub languages. Lean
+  `childDubLanguages`.
+- Whether to reuse `WatchSessionProvider` in a series mode or introduce a
+  smaller series-scoped session context for the hero + language sheet.
+- Grid card content beyond thumbnail + title (episode index, duration pill).
+- The exact shareable URL shape for a series (web uses
+  `/{slug}.html/{language}.html`).
+
+---
+
+## Sources / Research
+
+- `apps/web/src/components/watch/SeriesPageClient.tsx`,
+  `SeriesHero.tsx`, `SeriesEpisodesGrid.tsx`, `SeriesEpisodeCard.tsx`,
+  `LanguagePickerModal.tsx` — the web series page being ported.
+- `apps/web/src/lib/content.ts` (`resolveSeriesBySlug`, `isSeriesRecord`),
+  `apps/web/src/lib/fragments/watch-video.ts` — series resolution and the
+  `childDubLanguages` fetch.
+- `apps/mobile/app/watch/[slug].tsx`, `apps/mobile/app/watch/_layout.tsx`,
+  `apps/mobile/app/watch/language.tsx` — the single-video page and the
+  `formSheet` sheet routes to mirror.
+- `apps/mobile/src/components/watch/VideoPlayer.tsx`,
+  `VideoDescription.tsx`, `LanguageSheet.tsx`,
+  `apps/mobile/src/contexts/WatchSessionProvider.tsx` — components and
+  cross-route state to reuse.
+- `apps/mobile/app/(tabs)/watch.tsx`,
+  `apps/mobile/src/components/search/SearchResultCard.tsx`,
+  `apps/mobile/src/lib/queries.ts` (`SEARCH`) — search screen, result card, and
+  the query that needs `label`/`childCount` added.
+- `apps/admin/schema.graphql` — `HybridSearchResult.label` + `.childCount`
+  (lines ~329–345) and `Video` `children` / dubs / `childDubLanguages` / images
+  already exposed; no admin change needed.

--- a/docs/plans/2026-06-08-002-feat-mobile-series-detail-page-plan.md
+++ b/docs/plans/2026-06-08-002-feat-mobile-series-detail-page-plan.md
@@ -1,0 +1,615 @@
+---
+title: "feat: Mobile Series Detail Page"
+type: feat
+status: active
+date: 2026-06-08
+origin: docs/brainstorms/2026-06-08-mobile-series-detail-page-requirements.md
+---
+
+# feat: Mobile Series Detail Page
+
+## Summary
+
+Add a dedicated series detail page to `apps/mobile`, porting the web series
+experience. Reached from search (and any deep link), it shows the series
+trailer by reusing the existing video-detail `VideoPlayer` — or a plain poster
+image when there is no trailer — then the series title, a "Read more"
+description, a Language + Share action row, and a scrollable grid of the
+series' videos that each open in the normal video detail page.
+
+The work is mobile-only: every admin field it needs (`label`, `childCount`,
+`children`, `childDubLanguages`, the series' own dubs, images) is already
+exposed, so there are zero `apps/admin` edits and no deploy-ordering coupling.
+
+---
+
+## Problem Frame
+
+A series is a `Video` with `label: SERIES`/`COLLECTION` (or any record with
+children). Web renders these on a purpose-built page; mobile has none, so
+tapping a series in search routes it through `apps/mobile/app/watch/[slug].tsx`
+and renders a collection as a single video — a chrome-heavy player, an "Up
+Next" sibling carousel, Bible Quotes, and a Download/Subtitles row, none of
+which fit a series. When a series has no trailer, that screen has no image-only
+fallback.
+
+---
+
+## Requirements
+
+Carried from origin (`docs/brainstorms/2026-06-08-mobile-series-detail-page-requirements.md`).
+
+**Entry and routing**
+
+- R1. A series-shaped record (label `SERIES`/`COLLECTION`, or any record with
+  children) renders the series detail page, not the single-video page.
+- R2. Mobile search routes a series-shaped result to the series page; the
+  search query selects `label` and `childCount`. No `apps/admin` change.
+- R3. Any navigation resolving to a series slug lands on the series page:
+  `watch/[slug]` redirects when the resolved record is series-shaped, so deep
+  links and non-search entry points behave identically.
+
+**Hero**
+
+- R4. With a playable trailer (the series' own dub with a non-null `hls`), the
+  hero reuses the existing `VideoPlayer`, same chrome and controls as the video
+  page.
+- R5. With no playable trailer, the hero is a plain poster image — no player is
+  mounted, no player chrome appears.
+- R6. The poster falls back through the series images in the app's existing
+  precedence (`mobileCinematicHigh` → … → `url`).
+
+**Title, description, actions**
+
+- R7. The page shows a "SERIES" label and the series title.
+- R8. The page shows the series description with a collapsed "Read more"
+  expansion, matching the video page.
+- R9. The action row has exactly two actions: Language and Share.
+- R10. Share invokes the native share sheet with the series' shareable link and
+  title.
+
+**Language**
+
+- R11. Language opens a language selection sheet.
+- R12. Selecting a language swaps the trailer dub when a matching dub exists.
+- R13. The selected language is carried into an episode when tapped — the
+  episode opens in that language.
+
+**Video grid**
+
+- R14. The page shows a scrollable grid of the series' videos (its children, in
+  defined order). No in-grid search or filter.
+- R15. Each grid card shows the video thumbnail and title.
+- R16. Tapping a grid card pushes to that video's existing detail page,
+  carrying the selected language and a seed for instant paint.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Series is a label-based discriminator, fetched as a standalone
+  slug route.** `isSeriesRecord` = label in `{series, collection}`
+  (case-insensitive) OR `children.length > 0`, mirroring web's
+  `apps/web/src/lib/content.ts` `isSeriesRecord`. The page is an independent
+  slug-fetched route like `apps/mobile/app/watch/[slug].tsx`, not an
+  Experience block-index lookup (that path loses parent/child siblings — see
+  `docs/solutions/mobile/sdui-experience-provider-block-index-parent-child-loss.md`).
+
+- KTD2. **Only the hero holds a live video; everything else is an image.**
+  With a trailer, reuse `VideoPlayer` and its frozen-source + `replaceAsync`
+  contract verbatim (see `docs/solutions/best-practices/mobile-video-detail-page-patterns-20260527.md`).
+  With no trailer, render `expo-image` only — absence of a player _is_ the
+  mode (R5). Grid cells are static posters, never players, because mid-range
+  Android has only 3–5 hardware decoder slots
+  (`docs/solutions/mobile/android-lazy-section-viewport-gating-oom-fix.md`).
+
+- KTD3. **Cross-route state via a lightweight `SeriesSessionProvider`.**
+  Mounted above the series screen and its language sheet route so the sheet's
+  selection reaches the page through context, not router params (the pattern a
+  prior bug demanded — `docs/solutions/design-patterns/lean-bulk-lazy-per-item-graphql-fetch-20260604.md`).
+  A new provider rather than reusing `WatchSessionProvider` sheds the
+  download/subtitle/snackbar/lazy-media machinery the series page never touches.
+
+- KTD4. **Language list is `childDubLanguages`; matching is slug-keyed.** The
+  picker lists the languages the _episodes_ are available in (the series-level
+  union), per origin. Selection persists and re-applies by `languageSlug`
+  exact-match — never bcp47, which mis-selects `ko` → `ko-kmr`
+  (`docs/solutions/best-practices/language-identity-on-slug-not-bcp47-20260605.md`).
+  The trailer dub swap is best-effort: swap when the trailer has a dub for the
+  selected slug, otherwise leave the trailer playing its current dub.
+
+- KTD5. **A new 2-button `SeriesActionRow`; Share uses the two-segment public
+  URL.** `ActionButtonRow` is a fixed four-button component, so the Language +
+  Share row (R9) is a new small component. Share targets
+  `{slug}.html/{language}.html` — a bare `/watch/{slug}` 404s in production
+  (`docs/solutions/conventions/public-watch-url-two-segment-contract-20260608.md`).
+
+- KTD6. **Entry wiring lands last.** The search branch and the `/watch`
+  redirect (U6) ship after the page is fully built (U3–U5), so nothing routes
+  users to a half-built screen.
+
+- KTD7. **Image and route hygiene.** All poster/thumbnail URLs go through
+  `resolveImageUrl` (expo-image silently drops relative paths —
+  `docs/solutions/integration-issues/mobile-relative-image-url-no-base-origin-20260408.md`);
+  slugs are `encodeURIComponent`-encoded in route params (Expo Router splits on
+  `/` — `docs/solutions/mobile/expo-router-slash-in-dynamic-route-params.md`).
+
+---
+
+## High-Level Technical Design
+
+Four views of the same feature: how a tap resolves to the right page, how data
+flows into it, how the hero behaves, and how a language choice travels to an
+episode.
+
+#### Entry & routing — one page for every entry point
+
+```mermaid
+flowchart TB
+  Tap[Search result tapped] -->|label SERIES/COLLECTION or childCount > 0| SeriesRoute[series/slug route]
+  Tap -->|single video| WatchRoute[watch/slug route]
+  WatchRoute -->|resolved record is series-shaped| Redirect[router.replace series/slug] --> SeriesRoute
+  Deep[Deep link or recommendation to a series slug] --> WatchRoute
+  SeriesRoute --> Resolve[Query series by slug, publish to SeriesSessionProvider]
+  Resolve --> Hero{Series has a playable trailer dub?}
+  Hero -->|yes| Player[Reuse VideoPlayer: trailer hls plus poster, full chrome]
+  Hero -->|no| Image[expo-image poster only, no VideoView]
+  Resolve --> Grid[Scrollable 2-col grid of children]
+  Resolve --> Lang[Language sheet over childDubLanguages]
+```
+
+Search detection uses `label`/`childCount`; the `/watch` redirect uses `label`
+on the lean fragment. Both land on one `series/[slug]` page, so deep links and
+recommendations behave identically (R1–R3).
+
+#### Data flow — admin fields already exist; mobile only adds selections
+
+```mermaid
+flowchart LR
+  subgraph admin[admin GraphQL - already deployed, no edits]
+    SQ[SEARCH plus label, childCount]
+    GS[GET_SERIES_BY_SLUG: children, childDubLanguages, own dubs]
+  end
+  SQ --> SR[SearchResult with label/childCount]
+  GS --> NV[normalizeVideo: episodes, languages, trailer dub]
+  NV --> SP[(SeriesSessionProvider)]
+  SP --> HeroD[Hero: trailer or image]
+  SP --> GridD[Episodes grid]
+  SP --> SheetD[Language sheet]
+  SR -.series-shaped routes to.-> SP
+```
+
+The shared `watchVideoFragment` stays lean; series-only fields live on
+`GET_SERIES_BY_SLUG` (U1, KTD2).
+
+#### Hero states — only this surface holds a decoder slot
+
+```mermaid
+stateDiagram-v2
+  [*] --> Resolving
+  Resolving --> Trailer: own dub has hls
+  Resolving --> Poster: no playable dub
+  Trailer --> Fullscreen: tap expand
+  Fullscreen --> Trailer: exit
+  Trailer --> Paused: scrolled off-screen
+  Paused --> Trailer: scrolled back
+  Poster --> [*]
+```
+
+Grid cells are always static images, so the hero is the only live `VideoView`
+(KTD2).
+
+#### Language carry-through — slug-keyed, across the route boundary
+
+```mermaid
+sequenceDiagram
+  actor U as User
+  participant Sheet as SeriesLanguageSheet
+  participant S as SeriesSessionProvider
+  participant P as Hero VideoPlayer
+  participant W as Episode (watch)
+  U->>Sheet: pick language (slug)
+  Sheet->>S: setSelectedLanguageSlug(slug)
+  S-->>P: swap trailer dub if slug has one (replaceAsync)
+  U->>S: tap an episode card
+  S->>W: push /watch/slug, carry languageSlug
+  W-->>U: episode opens in that language
+```
+
+Selection matches on `languageSlug` exact equality, never bcp47 (KTD4).
+
+#### Route tree (mirrors the existing `app/watch` group)
+
+```text
+app/_layout.tsx                 → registers `series` (defensive require)
+app/series/_layout.tsx          → Stack wrapped in <SeriesSessionProvider>
+  app/series/[slug].tsx         → series screen (hero + meta + desc + actions + grid)
+  app/series/language.tsx       → language sheet (formSheet route)
+```
+
+---
+
+## Implementation Units
+
+### U1. GraphQL selections + normalizer for series data
+
+- **Goal:** Surface what the series page needs — search results that flag a
+  series, and the series' own children + dub-language union — with no admin
+  change.
+- **Requirements:** R1 (children fallback for detection), R2, R11, R14, R15.
+- **Dependencies:** none.
+- **Files:**
+  - `apps/mobile/src/lib/queries.ts` — add `label`, `childCount` to
+    `SEARCH.results`; add a series-scoped `GET_SERIES_BY_SLUG` operation that
+    composes `watchVideoFragment` plus `children { child { … } }` (with `order`)
+    and `childDubLanguages { bcp47, name, slug }`. Do **not** widen the shared
+    `watchVideoFragment` — the single-video query stays lean, and the U6 redirect
+    detects a series by `label` (already on the fragment), not children.
+  - `apps/mobile/src/lib/normalizeVideo.ts` — extend `WatchVideoRecord` with an
+    `episodes` array (from the video's own `children`) and a `languages` array
+    (from `childDubLanguages`).
+  - `apps/mobile/src/lib/__tests__/normalizeVideo.test.ts`
+- **Approach:** `SearchResult` widens automatically when `label`/`childCount`
+  are added (gql.tada infers from existing admin introspection — no codegen).
+  In `GET_SERIES_BY_SLUG`, each `children.child` selects `documentId: id, slug,
+label, locales(locale:$locale){ title }, images{ url, thumbnail,
+mobileCinematicHigh, mobileCinematicLow }`, ordered by `order`. Normalize
+  children → episodes (slug, title from locales, poster via the existing
+  `pickPosterUrl` precedence) and `childDubLanguages` → languages (slug, name via
+  `pickLocalizedName`, bcp47). Keep the lean posture — do **not** project
+  `downloads`/`videoEdition.subtitles` across children, and keep these fields off
+  the shared `watchVideoFragment`
+  (`docs/solutions/design-patterns/lean-bulk-lazy-per-item-graphql-fetch-20260604.md`).
+- **Patterns to follow:** existing sibling mapping + `pickPosterUrl` in
+  `normalizeVideo.ts`; `pickLocalizedName` for `name: JSON` locale maps.
+- **Test scenarios:**
+  - Children map in `order`, title from `locales`, poster precedence
+    `mobileCinematicHigh → url → thumbnail` (the existing `pickPosterUrl` order;
+    it does not consult `mobileCinematicLow`).
+  - `childDubLanguages` map to `{ slug, name (localized), bcp47 }`.
+  - Empty `children` → empty episodes array (no throw).
+  - Child with null `locales` → title null, card still normalizes.
+  - `SearchResult` type exposes `label` and `childCount` after the selection
+    change (typecheck).
+- **Verification:** normalizer unit tests green; a series-slug query returns
+  populated `episodes` + `languages`; `pnpm --filter @forge/mobile typecheck`
+  passes with the widened `SearchResult`.
+
+### U2. SeriesSessionProvider + series route registration
+
+- **Goal:** A lightweight cross-route context and the route skeleton so the
+  series screen and its language sheet share selection state.
+- **Requirements:** R3, R11, R12, R13.
+- **Dependencies:** U1.
+- **Files:**
+  - `apps/mobile/src/contexts/SeriesSessionProvider.tsx`
+  - `apps/mobile/app/series/_layout.tsx`
+  - `apps/mobile/app/_layout.tsx` — register the `series` screen.
+  - `apps/mobile/src/contexts/__tests__/SeriesSessionProvider.test.tsx`
+- **Approach:** Provider exposes `{ series, setSeries, languages,
+selectedLanguageSlug, setSelectedLanguageSlug }`. `languages` derives from
+  `series.languages`; `selectedLanguageSlug` defaults to the series' primary /
+  first available language and **resets when `series.documentId` changes** so a
+  prior series' selection never leaks (KTD3). `useSeriesSession()` throws
+  outside the provider. `app/series/_layout.tsx` mirrors
+  `apps/mobile/app/watch/_layout.tsx`: a `<Stack>` wrapped in
+  `<SeriesSessionProvider>`, a `[slug]` screen with the custom chevron-back
+  header (ACCENT tint, copied from the `video`/`collection` header block in
+  `app/_layout.tsx`), and a `language` sheet screen using `LIST_SHEET_OPTIONS`.
+  Register `<Stack.Screen name="series" options={{ headerShown: false }} />` in
+  the root layout using its defensive `require()` import pattern.
+- **Patterns to follow:** `app/watch/_layout.tsx` (provider-wraps-Stack +
+  `SHEET_BASE_OPTIONS`/`LIST_SHEET_OPTIONS`); `WatchSessionProvider`
+  reset-on-id-change; defensive `require()` in `app/_layout.tsx`.
+- **Test scenarios:**
+  - Provider exposes and updates `selectedLanguageSlug`.
+  - `useSeriesSession()` throws when consumed outside the provider.
+  - Selection resets when `series.documentId` changes.
+  - `languages` derives from the series' `childDubLanguages`.
+  - Default `selectedLanguageSlug` chosen when none set.
+- **Verification:** navigating to `/series/<slug>` mounts an (empty) screen
+  inside the provider; `useSeriesSession` resolves in both the screen and the
+  sheet route.
+
+### U3. Series detail screen — hero, metadata, description, actions
+
+- **Goal:** Resolve the series and render the trailer-or-image hero, the SERIES
+  label/title, the Read-more description, and a Language + Share row.
+- **Requirements:** R4, R5, R6, R7, R8, R9, R10.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `apps/mobile/app/series/[slug].tsx`
+  - `apps/mobile/src/components/series/SeriesActionRow.tsx`
+  - reuse `apps/mobile/src/components/watch/VideoPlayer.tsx`,
+    `VideoMetadata.tsx`, `VideoDescription.tsx`.
+  - `apps/mobile/app/series/__tests__/series-screen.test.tsx`
+- **Approach:** Read `{ slug, seed }`, decode the slug, `decodeWatchSeed(seed)`
+  for instant hero paint (F1). Run `GET_SERIES_BY_SLUG` `cache-first` with
+  `returnPartialData` (match the watch screen's payload posture). Normalize and
+  publish via `setSeries`. Derive the trailer = the series' own playable dub
+  (`variants.find(published && hls)`) for `selectedLanguageSlug` when present,
+  else the primary/first playable. Hero branch: a playable trailer →
+  `<VideoPlayer streamingUrl={trailerHls} posterUrl={poster} fullscreen
+onToggleFullscreen … />`, owning `isFullscreen` state and replicating the
+  orientation/header effects from `app/watch/[slug].tsx`; no trailer →
+  `expo-image` `<Image>` at 16:9 with the poster, no `VideoPlayer` mounted
+  (KTD2). `VideoMetadata` with `label="SERIES"`, `title={seriesTitle}`;
+  `VideoDescription({ description: series.description })`. `SeriesActionRow`
+  with `onLanguage={() => router.push('/series/language')}` and
+  `onShare={handleShare}`. `handleShare` uses `Share.share` with
+  `https://www.jesusfilm.org/${slug}.html/${selectedLanguageSlug}.html` (KTD5).
+  Poster through `resolveImageUrl` (KTD7). Mirror the watch screen's resolution
+  states: the seed image paints first; a spinner shows while the query is in
+  flight with no seed; a query failure renders the watch screen's error view with
+  a back affordance, never a blank dead-end. Pause/release the trailer when it
+  scrolls off-screen so the grid below never holds a second decoder slot (KTD2);
+  do not bridge scroll position to the player via `Animated.Value.addListener`
+  under the native driver
+  (`docs/solutions/mobile/full-bleed-video-hero-with-scroll-over-content.md`).
+  Give the hero, action buttons, and grid cards accessibility roles/labels and
+  ≥44pt targets, mirroring `ActionButtonRow`/`SearchResultCard`.
+- **Patterns to follow:** `app/watch/[slug].tsx` (params/seed/query/normalize/
+  publish, fullscreen effects, `handleShare`); `VideoPlayer` frozen-source
+  contract; `expo-image` + `resolveImageUrl`.
+- **Test scenarios:**
+  - Covers AE1. Trailer present → `VideoPlayer` mounted with the trailer `hls`.
+  - Covers AE2. No trailer → `expo-image` poster, `VideoPlayer` not mounted.
+  - Label renders "SERIES"; title renders.
+  - Description collapses to 3 lines and expands on "Read more".
+  - Share invokes with the two-`.html`-segment URL and the selected language.
+  - Poster resolves through `resolveImageUrl`; relative path → no blank-image.
+  - Seed paints the hero before the query resolves; query-in-flight with no seed
+    shows a spinner; query failure shows the error view, not a blank screen.
+  - Trailer pauses/releases when scrolled off-screen.
+  - Hero, action buttons, and grid cards expose accessibility labels/roles.
+- **Verification:** a series with a trailer shows the chrome-bearing player; one
+  without shows a static image; the action row shows only Language + Share.
+
+### U4. Series episodes grid + episode navigation
+
+- **Goal:** The scrollable 2-column grid of the series' children; tapping pushes
+  to the video page in the selected language.
+- **Requirements:** R14, R15, R16.
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `apps/mobile/app/series/[slug].tsx` — add the grid section.
+  - `apps/mobile/src/components/series/SeriesEpisodesGrid.tsx`
+  - `apps/mobile/src/components/series/SeriesEpisodeCard.tsx`
+  - colocated tests for the grid and card.
+- **Approach:** Render `series.episodes` as a 2-column grid (`FlatList
+numColumns={2}` with `columnWrapperStyle`, mirroring search results, or
+  `FlashList numColumns`; screen-level, so the formSheet-height workaround does
+  not apply). Each card = `expo-image` thumbnail + 2-line title at 4:3 (matching
+  `SearchResultCard`), title-only — no episode-index or duration pill in v1.
+  When the series has zero children, omit the grid section entirely (no empty
+  placeholder). No search input (R14). Tap:
+  `encodeWatchSeed({ slug, title, imageUrl: poster, playbackId: null })` then
+  `router.push('/watch/${encodeURIComponent(childSlug)}?seed=…')`, carrying the
+  selected language so the episode opens in it (R15/F5). Carry-through is
+  slug-keyed (KTD4); see Open Questions for the param-vs-preference mechanism.
+  Grid cells are static images only (KTD2). `renderItem`/derived values
+  memoized (Android is the primary tier).
+- **Patterns to follow:** `SearchResultCard` (thumbnail + title card);
+  `app/(tabs)/watch.tsx` `FlatList numColumns` + `columnWrapperStyle`;
+  `UpNextCarousel` `handlePress` (`encodeWatchSeed` + `router.push`);
+  `shared.ts` card styles.
+- **Test scenarios:**
+  - Grid renders all children in `order`.
+  - Card shows thumbnail (through `resolveImageUrl`) + title.
+  - Covers AE5. Tap navigates to `/watch/<childSlug>?seed=<encoded>` carrying the
+    seed and the selected language, so the episode opens in that language with
+    instant paint.
+  - Zero children → the grid section is omitted, no crash.
+  - Child slug containing `/` is encoded at navigation.
+- **Verification:** the grid lists every episode; tapping opens the episode's
+  video page in the selected language.
+
+### U5. Series language sheet + language carry-through
+
+- **Goal:** A language sheet over the series' `childDubLanguages`; selection
+  updates the session, swaps the trailer dub best-effort, and sets the
+  carry-through language.
+- **Requirements:** R11, R12, R13.
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `apps/mobile/app/series/language.tsx`
+  - `apps/mobile/src/components/series/SeriesLanguageSheet.tsx`
+  - colocated test.
+- **Approach:** The sheet route reads `{ languages, selectedLanguageSlug,
+setSelectedLanguageSlug }` from `useSeriesSession`. Render a searchable
+  `FlashList` over `languages` (`{ slug, name, bcp47 }`), names via
+  `pickLocalizedName`. Build a dedicated `SeriesLanguageSheet` rather than reusing
+  `LanguageSheetContent`: that component hard-returns on `!variant.hls` and keys
+  `keyExtractor` on `documentId`, neither of which a `ChildDubLanguage` row has —
+  reusing it verbatim makes every row unselectable and breaks key extraction.
+  `SeriesLanguageSheet` keys on `slug` and drops the `hls` guard. On select:
+  `setSelectedLanguageSlug(slug)`
+  (exact slug match — KTD4), write the slug-keyed audio preference for
+  carry-through, best-effort swap the trailer dub when the series' own
+  `variants` contain a dub with that `languageSlug` (the player swaps via
+  `replaceAsync`), then `router.back()`. Disable
+  `maintainVisibleContentPosition` on the filtered list
+  (`docs/solutions/best-practices/flashlist-v2-maintainvisiblecontentposition-default-20260605.md`).
+  Native formSheet via the layout's `LIST_SHEET_OPTIONS`; no gesture-handler
+  (`docs/solutions/best-practices/bottom-sheet-migration-expo-sdk54-pitfalls-20260527.md`).
+- **Patterns to follow:** `LanguageSheet.tsx` (search box, sort, debounce,
+  `useSheetListHeight`); `app/watch/language.tsx` (thin route reading the
+  session); `LIST_SHEET_OPTIONS`.
+- **Test scenarios:**
+  - Sheet lists `childDubLanguages`, sorted, with localized names.
+  - Search filters the list; `maintainVisibleContentPosition` disabled (no
+    scroll jump on filter).
+  - Select sets `selectedLanguageSlug` by exact slug — `ko` does not match
+    `ko-kmr`.
+  - Trailer dub swaps when a matching dub exists.
+  - No matching trailer dub → selection still set, trailer unchanged, no crash.
+  - Sheet dismisses after select.
+- **Verification:** Language opens the sheet; picking a language updates the
+  selection, swaps the trailer when available, and the next episode tap opens in
+  that language.
+
+### U6. Series detection + search/watch routing (entry wiring)
+
+- **Goal:** Route series-shaped records to the series page from search and from
+  any `/watch` resolution. Lands last so the destination is complete.
+- **Requirements:** R1, R2, R3.
+- **Dependencies:** U1, U3, U4, U5.
+- **Files:**
+  - `apps/mobile/src/lib/isSeriesRecord.ts`
+  - `apps/mobile/app/(tabs)/watch.tsx` — branch `handleSelectResult`.
+  - `apps/mobile/app/watch/[slug].tsx` — add the redirect effect.
+  - colocated tests.
+- **Approach:** The two call sites carry different shapes, so split the check.
+  `isSeriesRecord({ label, children })` → `label.toLowerCase()` in
+  `{ "series", "collection" }` OR `(children?.length ?? 0) > 0`, mirroring web
+  `content.ts`, runs on the normalized record in the `app/watch/[slug].tsx`
+  redirect (the lean fragment carries `label`; `children` is absent there, so it
+  resolves as a label check). The search branch has no children array — a
+  `SearchResult` carries `childCount` — so `handleSelectResult` (after the
+  `EXPERIENCE` check) uses an inline guard: `label.toLowerCase()` in
+  `{ "series", "collection" }` OR `(childCount ?? 0) > 0` →
+  `router.push('/series/<slug>?seed=…')` with the same `encodeWatchSeed`. On the
+  watch screen, after `normalized` resolves, an effect: if
+  `isSeriesRecord(normalized)`, `router.replace('/series/<slug>?seed=…')`
+  carrying the same seed — covers deep links and any non-search entry (R3).
+  Guard the effect to fire **once** per resolution (a ref keyed on the resolved
+  slug) and only after the record resolves. Encode the slug in the param (KTD7).
+- **Patterns to follow:** web `isSeriesRecord` (`apps/web/src/lib/content.ts`);
+  `app/(tabs)/watch.tsx` `handleSelectResult`; `useRouter` already in scope in
+  `app/watch/[slug].tsx`.
+- **Test scenarios:**
+  - Covers AE3. Search result `label=SERIES` → `/series` route; single video →
+    `/watch` route.
+  - `childCount > 0` with no `label` → series route.
+  - Covers AE4. `/watch/<seriesSlug>` resolving series-shaped →
+    `router.replace` to `/series`.
+  - `/watch/<videoSlug>` non-series → no redirect.
+  - Redirect fires once (no loop) and only after resolution.
+- **Verification:** tapping a series in search opens the series page; a deep
+  link or direct `/watch` to a series slug redirects to it; single videos are
+  unaffected.
+
+---
+
+## Acceptance Examples
+
+Carried from origin; referenced by the `Covers AE<N>` test scenarios above.
+
+- AE1. Given a series with a playable trailer, when the page opens, the hero is
+  the reused `VideoPlayer` showing the trailer. (R4)
+- AE2. Given a series with no playable trailer, when the page opens, the hero is
+  a plain poster image and no player is mounted. (R5, R6)
+- AE3. Given a search result whose `label` is `SERIES`, tapping opens the series
+  page; a single-video result opens the video page. (R1, R2)
+- AE4. Given a deep link to a series slug routed through `watch/[slug]`, when it
+  resolves series-shaped, it redirects to the series page. (R3)
+- AE5. Given a language selected on the series page, tapping an episode opens its
+  detail page in that language, with an encoded seed for instant paint. (R13, R16)
+
+---
+
+## Scope Boundaries
+
+**Deferred for later** (origin)
+
+- Re-translating grid episode titles when the language changes — the trailer dub
+  and episode carry-through still swap; the grid labels stay in their fetched
+  locale.
+- An in-grid search/filter input over the series' videos.
+- Series-level Download and Subtitles actions.
+
+**Outside this page's identity** (origin)
+
+- The single-video page's "Up Next" carousel, Bible Quotes, and
+  related-questions blocks. The series page is trailer/image + title +
+  description + grid.
+- Any `apps/admin` or schema change — the required fields already exist.
+
+---
+
+## System-Wide Impact
+
+- **Search result routing.** `handleSelectResult` gains a series branch, so
+  every search tap is affected. Additive and low-risk — experiences and single
+  videos are unchanged.
+- **`/watch` redirect.** Every navigation to a series-shaped slug now redirects
+  to `/series`, covering deep links, recommendations, and future entry points.
+  Must fire once per resolution to avoid a redirect loop.
+- **Decoder-slot posture.** The hero is the only live `VideoView`; grid cells
+  are static images, preserving the Android decoder-slot budget.
+
+---
+
+## Risks & Dependencies
+
+- **No deploy-ordering coupling.** Unlike the dub-payload work, this needs no
+  admin field — `label`, `childCount`, `children`, `childDubLanguages` are
+  already in prod admin. Mobile ships standalone via EAS.
+- **Trailer dub may not cover the selected language.** Accepted: the swap is
+  best-effort (KTD4); the trailer keeps its current dub, the episodes (the real
+  payload) still open in the selected language.
+- **Redirect loop.** The `/watch` → `/series` effect must be single-fire and
+  post-resolution; a careless dependency array re-triggers it.
+- **Reused `VideoPlayer` fullscreen.** The series screen must own `isFullscreen`
+  and copy the watch screen's orientation/header effects verbatim (~40 lines:
+  `setOptions` orientation, enter/exit landscape, the BackHandler/AppState
+  handler, the unmount portrait reset), or fullscreen desyncs from orientation.
+- **Redirect flash.** During the `/watch` → `/series` window the watch screen
+  briefly mounts for a series; fire `router.replace` as soon as
+  `isSeriesRecord(normalized)` is true (its seed has `playbackId: null`, so no
+  stream loads) to minimize it.
+
+---
+
+## Open Questions
+
+Deferred to implementation — none block planning.
+
+- **Carry-through mechanism (U4/U5).** Set the slug-keyed `WatchPreferences`
+  audio language vs. pass an explicit nav param the watch screen honors. Lean
+  preference, since the infra exists and the watch screen already resolves its
+  default dub from it. The trade-off to confirm: the preference is app-wide and
+  persisted, so picking a series language changes the default audio for every
+  future video until changed again. Settle this before U4/U5 are built so the
+  write side and read side agree on the same slug-keyed mechanism.
+
+---
+
+## Documentation / Operational Notes
+
+After this lands, two gotchas the learnings search relied on live only in the
+author's auto-memory, not in `docs/solutions/` — worth capturing via
+`ce-compound` so other agents see them: looped `Animated.sequence` runs once on
+Fabric, and FlashList-in-a-formSheet needs an explicit height from the detent
+index. Neither blocks this work (the grid is screen-level; the hero uses no
+looped pulse), but both are adjacent to this surface.
+
+---
+
+## Sources / Research
+
+- Origin: `docs/brainstorms/2026-06-08-mobile-series-detail-page-requirements.md`
+- Port source: `apps/web/src/components/watch/SeriesPageClient.tsx`,
+  `SeriesHero.tsx`, `SeriesEpisodesGrid.tsx`;
+  `apps/web/src/lib/content.ts` (`isSeriesRecord`, `resolveSeriesBySlug`).
+- Mobile patterns to mirror: `apps/mobile/app/watch/[slug].tsx`,
+  `app/watch/_layout.tsx`, `app/watch/language.tsx`,
+  `src/components/watch/VideoPlayer.tsx`, `LanguageSheet.tsx`,
+  `VideoDescription.tsx`, `VideoMetadata.tsx`, `ActionButtonRow.tsx`;
+  `src/contexts/WatchSessionProvider.tsx`; `app/(tabs)/watch.tsx`;
+  `src/components/search/SearchResultCard.tsx`; `src/lib/queries.ts`,
+  `normalizeVideo.ts`, `watchSeed.ts`, `pickLocalizedName.ts`, `validateUrl.ts`,
+  `src/styles/shared.ts`, `src/lib/color.ts`.
+- Admin surface (read-only, already deployed): `apps/admin/schema.graphql`
+  `HybridSearchResult.label` + `.childCount`, `Video.children` / dubs /
+  `childDubLanguages` / images.
+- Learnings: `docs/solutions/best-practices/mobile-video-detail-page-patterns-20260527.md`,
+  `docs/solutions/design-patterns/lean-bulk-lazy-per-item-graphql-fetch-20260604.md`,
+  `docs/solutions/best-practices/language-identity-on-slug-not-bcp47-20260605.md`,
+  `docs/solutions/mobile/android-lazy-section-viewport-gating-oom-fix.md`,
+  `docs/solutions/best-practices/flashlist-v2-maintainvisiblecontentposition-default-20260605.md`,
+  `docs/solutions/best-practices/bottom-sheet-migration-expo-sdk54-pitfalls-20260527.md`,
+  `docs/solutions/integration-issues/mobile-relative-image-url-no-base-origin-20260408.md`,
+  `docs/solutions/conventions/public-watch-url-two-segment-contract-20260608.md`,
+  `docs/solutions/mobile/expo-router-slash-in-dynamic-route-params.md`,
+  `docs/solutions/mobile/sdui-experience-provider-block-index-parent-child-loss.md`.

--- a/docs/solutions/developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md
+++ b/docs/solutions/developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md
@@ -72,6 +72,10 @@ shell `export` won't take effect and Metro must be **restarted** to pick up the
 edit. (This same `:1337` → `:3003` trap exists on `apps/tv` — it generalizes to
 both Expo apps.) (auto memory [claude])
 
+The canonical local admin port is `:3003` — admin's `pnpm dev` binds it
+(hardcoded in `apps/admin/package.json`), and `apps/mobile/.env.example` /
+`.env.ci` point there too.
+
 ### 2. Verify the worktree non-disruptively with a second Metro
 
 The installed iOS build (`org.jesusfilm.forgewatch`) is a **debug build

--- a/docs/solutions/developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md
+++ b/docs/solutions/developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md
@@ -1,0 +1,178 @@
+---
+title: Verifying mobile (Expo) worktree changes in the iOS simulator
+date: 2026-06-08
+category: developer-experience
+module: apps/mobile
+problem_type: developer_experience
+component: development_workflow
+severity: medium
+applies_when:
+  - "Verifying apps/mobile (or apps/tv) Expo changes in the iOS simulator from a git worktree"
+  - "A worktree's mobile app shows 'Search failed' or renders no data despite correct code"
+  - "Another Metro is already running for the main checkout or another app"
+  - "An on-disk style/JS change doesn't appear in the running Expo Go app"
+related_components:
+  - apps/tv
+  - packages/admin-graphql
+tags:
+  - expo
+  - simulator
+  - metro
+  - worktree
+  - env
+  - admin-graphql
+  - idb
+  - expo-go
+---
+
+# Verifying mobile (Expo) worktree changes in the iOS simulator
+
+## Context
+
+Mobile changes must be verified in the simulator before they're called done —
+typecheck + jest are not a substitute. Doing that from a **git worktree** (the
+isolated copy `ce-work`/`ce-worktree` create) hits four traps that waste a lot
+of time and silently produce a wrong or stale verification:
+
+1. A fresh worktree has **no `.env.local`** (it's gitignored, so it isn't copied
+   into the worktree), and the one in the main checkout points at the **retired
+   Strapi endpoint**. The app then can't reach a backend — search fails.
+2. A Metro is usually already running for the main checkout (and another for the
+   TV app), so naively starting Metro collides on ports or, worse, you verify
+   the wrong checkout's code.
+3. Editing a file does **not** reliably hot-apply to an already-loaded Expo Go
+   bundle — you can stare at stale UI and conclude your change didn't work.
+4. Driving the sim with `idb` taps on virtualized lists (FlashList, grids,
+   formSheet rows) is flaky, so a "the button doesn't do anything" reading is
+   often a missed tap, not a bug.
+
+## Guidance
+
+### 1. Point the worktree at the running admin, not stale Strapi
+
+The mobile app resolves its GraphQL endpoint in `apps/mobile/src/lib/config.ts`
+via `getGraphQLUrl()` → `env.EXPO_PUBLIC_ADMIN_GRAPHQL_URL ?? DEFAULT_…`. The
+**`EXPO_PUBLIC_GRAPHQL_URL_IOS=http://localhost:1337/graphql`** you'll see in the
+main checkout's `.env.local` is the **retired Strapi CMS** endpoint and is a red
+herring — the app no longer reads it. Symptom of getting this wrong:
+**"Search failed. Please try again."** (search needs a live admin; many other
+reads are anonymous-public and may still render, masking the problem).
+
+Fix — set the admin endpoint in the worktree's `.env.local`, then restart Metro:
+
+```bash
+# admin dev server runs on :3003 (pnpm --filter @forge/admin dev)
+printf '\nEXPO_PUBLIC_ADMIN_GRAPHQL_URL=http://127.0.0.1:3003/api/graphql\n' \
+  >> apps/mobile/.env.local
+```
+
+Use `127.0.0.1`, **not** `localhost` — `localhost` loops through admin's
+auth-host proxy. `EXPO_PUBLIC_*` vars are inlined by Metro at bundle time, so a
+shell `export` won't take effect and Metro must be **restarted** to pick up the
+edit. (This same `:1337` → `:3003` trap exists on `apps/tv` — it generalizes to
+both Expo apps.) (auto memory [claude])
+
+### 2. Verify the worktree non-disruptively with a second Metro
+
+The installed iOS build (`org.jesusfilm.forgewatch`) is a **debug build
+hardcoded to Metro on `:8081`** — it can only show the main checkout. To run the
+_worktree's_ code without killing the main checkout's Metro, use **Expo Go +
+its own Metro on a free port** (Expo Go is also installed on the sim):
+
+```bash
+# main checkout owns 8081, the TV app owns 8082 — pick a free port
+cd apps/mobile && npx expo start --port 8090
+# load THIS bundle in Expo Go (iPhone udid from `xcrun simctl list devices booted`)
+xcrun simctl openurl <iphone-udid> "exp://127.0.0.1:8090"
+```
+
+This leaves the user's main (8081) and TV (8082) Metros untouched. When done,
+`xcrun simctl openurl <udid> "exp://127.0.0.1:8081"` restores Expo Go to the
+main checkout.
+
+### 3. Force a full reload — fast-refresh lies
+
+A style/JS edit often does **not** apply to an already-loaded Expo Go bundle
+(an incremental `Bundled … (1 module)` may not re-render the mounted tree).
+Force a clean reload and **confirm a full ~2386-module rebundle** in the Metro
+log before trusting the screen:
+
+```bash
+# restart Metro fresh, then relaunch Expo Go (don't just openurl an already-open app)
+npx expo start --port 8090 --clear
+xcrun simctl terminate <udid> host.exp.Exponent
+xcrun simctl openurl <udid> "exp://127.0.0.1:8090"
+# wait for: iOS Bundled NNNNms ... (2386 modules)   <- full, not "(1 module)"
+```
+
+### 4. Drive + measure with idb (taps are flaky; measure to confirm)
+
+`idb ui tap` on a virtualized list row (FlashList, the episode grid, formSheet
+rows) frequently doesn't register. **Retry until confirmed** via the a11y tree,
+and **measure rendered geometry** to prove a style change landed instead of
+eyeballing a screenshot:
+
+```bash
+# get exact tap coords from labels, not pixel guesses
+idb ui describe-all --udid <udid>   # → AXLabel + frame for each element
+# tap, then VERIFY navigation/state via describe-all before screenshotting
+# confirm a font-size change applied by comparing frame heights:
+#   "Videos" h=17 (body) -> h=32 (titleLarge), matching the page title
+```
+
+## Why This Matters
+
+Three of these are invisible to typecheck/lint/jest and to a casual screenshot:
+a worktree that silently talks to a dead Strapi endpoint, a fast-refresh that
+shows stale UI, and an idb tap that quietly misses. Each one produces a
+_confident wrong conclusion_ ("search is broken", "my change didn't work", "the
+button is dead") that costs a debugging detour. The endpoint trap in particular
+had only ever lived as a per-app MEMORY note; capturing the worktree workflow
+here makes the whole verification loop reproducible for the next person.
+
+## When to Apply
+
+- Before reporting any `apps/mobile` (or `apps/tv`) change as done — the
+  standing "verify in the simulator" rule, executed from a worktree.
+- Whenever a worktree's app shows no data / "Search failed" despite correct code.
+- Whenever an on-disk change refuses to appear in the running Expo Go app.
+
+## Examples
+
+End-to-end, the loop that verified the series detail page from a worktree:
+
+```bash
+# 1. endpoint
+printf '\nEXPO_PUBLIC_ADMIN_GRAPHQL_URL=http://127.0.0.1:3003/api/graphql\n' >> apps/mobile/.env.local
+# 2. second Metro (free port) + Expo Go
+cd apps/mobile && npx expo start --port 8090 --clear &
+xcrun simctl terminate <udid> host.exp.Exponent
+xcrun simctl openurl <udid> "exp://127.0.0.1:8090"     # wait for full 2386-module bundle
+# 3. drive + verify
+idb ui describe-all --udid <udid> | grep -i <label>    # exact coords
+idb ui tap --udid <udid> <x> <y>                       # retry until describe-all confirms
+# 4. confirm + restore
+xcrun simctl openurl <udid> "exp://127.0.0.1:8081"     # back to main checkout
+```
+
+A real catch from this loop: the admin search returned data only after the
+`:3003` endpoint was set, and the series page rendered a poster (no player)
+exactly because the series had 0 playable trailer dubs — both facts were
+invisible without the running backend.
+
+## Related
+
+- `docs/solutions/architecture-patterns/mobile-admin-data-layer-cutover-pattern-20260525.md`
+  — the Strapi → admin cutover that introduced `EXPO_PUBLIC_ADMIN_GRAPHQL_URL`
+  (root cause of trap #1). Its "production default fallback" is a _prod_ URL —
+  locally you still must override to `127.0.0.1:3003`.
+- `docs/solutions/mobile/expo-env-file-handling.md` — `.env.local` priority +
+  Metro-inlining mechanics. Note: its `…:1337/graphql` examples are
+  **pre-cutover**; the live var is `EXPO_PUBLIC_ADMIN_GRAPHQL_URL`.
+- `docs/solutions/best-practices/mobile-video-detail-page-patterns-20260527.md`
+  — earlier (buried) record of the `127.0.0.1:3003` + search-needs-bearer fact.
+- `docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md`
+  — `xcrun simctl openurl` deep-link precedent (TV side).
+- `docs/solutions/developer-experience/measurement-driven-layout-iteration-chrome-mcp-20260505.md`
+  — the web (Chrome MCP) analog of "measure rendered geometry to confirm a style
+  change applied"; idb is the RN/simulator equivalent.

--- a/docs/solutions/mobile/eas-update-stakeholder-preview-setup.md
+++ b/docs/solutions/mobile/eas-update-stakeholder-preview-setup.md
@@ -16,8 +16,9 @@ module: apps/mobile
 related_issues:
   - ".env.ci gitignored by .env.* glob — required !.env.ci exemption"
   - "resolveImageUrl.ts bypassed env validation with raw process.env"
-  - "fetchWithTimeout silently dropped caller AbortSignal — fixed with AbortSignal.any()"
-  - "Silent empty-string fallback chain for missing GraphQL URL — now throws explicitly"
+  - "fetchWithTimeout silently dropped caller AbortSignal — fixed by composing signals"
+  - "Silent empty-string fallback chain for missing GraphQL URL — replaced with an explicit production-default fallback"
+last_updated: 2026-06-08
 ---
 
 # EAS Update for Stakeholder Previews via Expo Go
@@ -105,23 +106,26 @@ import { z } from "zod"
 export const env = createEnv({
   clientPrefix: "EXPO_PUBLIC_",
   client: {
-    EXPO_PUBLIC_GRAPHQL_URL_IOS: z.string().url(),
-    EXPO_PUBLIC_GRAPHQL_URL_ANDROID: z.string().url(),
-    EXPO_PUBLIC_STRAPI_TOKEN: z.string().optional(),
-    EXPO_PUBLIC_WEB_BASE_URL: z.string().optional(),
+    // Optional + a production default in config.ts (see §4). A required `.url()`
+    // here would brick CI/EAS environments that haven't set the var.
+    EXPO_PUBLIC_ADMIN_GRAPHQL_URL: z.string().url().optional(),
+    EXPO_PUBLIC_FORGE_CACHE_PERSIST: z.string().optional(),
   },
   runtimeEnvStrict: {
-    EXPO_PUBLIC_GRAPHQL_URL_IOS: process.env.EXPO_PUBLIC_GRAPHQL_URL_IOS,
-    EXPO_PUBLIC_GRAPHQL_URL_ANDROID:
-      process.env.EXPO_PUBLIC_GRAPHQL_URL_ANDROID,
-    EXPO_PUBLIC_STRAPI_TOKEN: process.env.EXPO_PUBLIC_STRAPI_TOKEN,
-    EXPO_PUBLIC_WEB_BASE_URL: process.env.EXPO_PUBLIC_WEB_BASE_URL,
+    EXPO_PUBLIC_ADMIN_GRAPHQL_URL: process.env.EXPO_PUBLIC_ADMIN_GRAPHQL_URL,
+    EXPO_PUBLIC_FORGE_CACHE_PERSIST:
+      process.env.EXPO_PUBLIC_FORGE_CACHE_PERSIST,
   },
   isServer: false,
   emptyStringAsUndefined: true,
   skipValidation: !!process.env.CI && !process.env.EAS_BUILD,
 })
 ```
+
+> The app moved from Strapi to admin GraphQL: the old platform-split
+> `EXPO_PUBLIC_GRAPHQL_URL_IOS`/`_ANDROID` + `EXPO_PUBLIC_STRAPI_TOKEN` were
+> replaced by a single `EXPO_PUBLIC_ADMIN_GRAPHQL_URL`. See the
+> [mobile admin data-layer cutover](../architecture-patterns/mobile-admin-data-layer-cutover-pattern-20260525.md).
 
 | Setting                  | Why                                                                                                                                                                     |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -138,35 +142,33 @@ Refactored from module-scope instantiation to defer initialization until first c
 let _client: ApolloClient | undefined
 
 export function getApolloClient(): ApolloClient {
-  if (!_client) {
-    const uri = config.graphqlUrl
-    const headers: Record<string, string> = {}
-    if (config.strapiToken) {
-      headers.Authorization = `Bearer ${config.strapiToken}`
-    }
-    const link = new HttpLink({ uri, headers, fetch: fetchWithTimeout })
-    _client = new ApolloClient({ link, cache: new InMemoryCache() })
-  }
+  if (_client) return _client
+
+  const link = new HttpLink({
+    uri: getGraphQLUrl(), // env var ?? production default — see §4
+    fetch: fetchWithTimeout,
+  })
+  _client = new ApolloClient({ link, cache: new InMemoryCache() })
   return _client
 }
 ```
 
-### 4. Config — Fail Fast on Missing URL
+The admin GraphQL endpoint serves the app's reads anonymously, so there's no
+`Authorization` header — the old Strapi bearer token is gone.
 
-Replaced silent fallback chain (`?? "" || "http://localhost:1337/graphql"`) with explicit error:
+### 4. Config — fall back to the production default, never to empty/localhost
+
+The original silent chain (`?? "" || "http://localhost:1337/graphql"`) hid misconfig behind a dead localhost URL. The current resolver returns the env var **or a real production default** — never an empty string, and no `Platform.OS` split:
 
 ```typescript
-get graphqlUrl(): string {
-  const url =
-    Platform.OS === "android"
-      ? env.EXPO_PUBLIC_GRAPHQL_URL_ANDROID
-      : env.EXPO_PUBLIC_GRAPHQL_URL_IOS
-  if (!url) {
-    throw new Error(`Missing EXPO_PUBLIC_GRAPHQL_URL for platform: ${Platform.OS}`)
-  }
-  return url
+// config.ts
+export function getGraphQLUrl(): string {
+  return env.EXPO_PUBLIC_ADMIN_GRAPHQL_URL ?? DEFAULT_ADMIN_GRAPHQL_URL
 }
+// env.ts:  const DEFAULT_ADMIN_GRAPHQL_URL = "https://admin.jesusfilm.org/api/graphql"
 ```
+
+This intentionally moved **away** from the earlier "throw on missing URL" posture: the var is now `.optional()` with a production default so default builds and un-provisioned CI/EAS environments need zero new env vars. See [required env var without default broke Railway deploy](../runtime-errors/required-env-var-without-default-broke-railway-deploy-20260511.md) for why opt-in vars must be optional.
 
 ### 5. Fixed AbortSignal Override in fetchWithTimeout
 
@@ -215,7 +217,7 @@ The `groupId` changes with each update — extract it from the `eas update` comm
 
 4. **Raw `process.env` bypass:** `resolveImageUrl.ts` read `EXPO_PUBLIC_WEB_BASE_URL` directly, bypassing env validation. All `EXPO_PUBLIC_*` access must go through `env.ts`.
 
-5. **Silent URL fallback chain:** Missing URL → `""` → localhost fallback hid real errors in production. Removed all silent fallbacks.
+5. **Silent URL fallback chain:** Missing URL → `""` → dead-`localhost` fallback hid real errors. Now resolves to a real production default (`https://admin.jesusfilm.org/api/graphql`), never an empty string — see §4.
 
 6. **Doppler is dev-only:** Staging/production secrets are managed in EAS Environments dashboard, not Doppler. The `fetch-secrets` script stays hardcoded to `--config dev`.
 
@@ -259,11 +261,13 @@ The `groupId` changes with each update — extract it from the `eas update` comm
 1. **Lint against raw `process.env` access:** Add ESLint rule forbidding `process.env.EXPO_PUBLIC_*` outside `env.ts`.
 2. **Audit `.gitignore` after adding `.env.*` files:** Run `git check-ignore -v <file>` before committing.
 3. **Compose AbortSignals, never replace:** Use `AbortSignal.any()` when adding timeout to existing fetch wrappers.
-4. **No silent URL fallbacks:** Required env vars should throw on missing, not fall back to empty string or localhost.
+4. **No silent fallback to empty/localhost:** A missing URL must resolve to a real default (the production admin endpoint) or throw — never to `""` or a dead `localhost`. Opt-in vars use a production default so un-provisioned environments still boot (see §4).
 5. **Log resolved config at startup:** `console.info("Config:", { graphqlUrl })` makes misconfig visible in EAS build logs.
 
 ## Related Documentation
 
+- [Mobile admin data-layer cutover](../architecture-patterns/mobile-admin-data-layer-cutover-pattern-20260525.md) — replaced the Strapi env vars/endpoint this doc's snippets used to show
+- [Verifying mobile Expo worktree changes in the simulator](../developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md) — local admin endpoint (`:3003`) + simulator verification loop
 - [Lazy SDK Initialization Pattern](../platform/new-app-ci-and-deployment-patterns.md) — Core pattern for `skipValidation` + lazy getter
 - [Adding New Apps Checklist](../platform/adding-new-apps.md) — Monorepo onboarding including `@t3-oss/env` setup
 - [Expo GraphQL Schema Drift](../integration-issues/expo-graphql-schema-drift-and-fragment-validation.md) — Mobile app's local GraphQL queries (not codegen)

--- a/docs/solutions/mobile/expo-env-file-handling.md
+++ b/docs/solutions/mobile/expo-env-file-handling.md
@@ -7,11 +7,12 @@ module: apps/mobile
 symptom: "Network Request Failed or Aborted on real iOS devices; app works on simulators"
 root_cause: "@expo/env loads .env.production over .env when NODE_ENV=production (set by Metro for device builds); real devices cannot reach localhost"
 severity: high
+last_updated: 2026-06-08
 ---
 
 ## Problem
 
-Real iOS devices showed "Network Request Failed" or "Aborted" when connecting to local Strapi, while simulators worked fine. Multiple cascading issues were discovered:
+Real iOS devices showed "Network Request Failed" or "Aborted" when connecting to the local admin GraphQL API, while simulators worked fine. Multiple cascading issues were discovered:
 
 1. `.env.production` overrode local dev secrets due to Expo's env file priority
 2. Real devices can't reach `localhost` — they need the computer's LAN IP
@@ -32,11 +33,11 @@ Real iOS devices showed "Network Request Failed" or "Aborted" when connecting to
 .env                                                 ← LOWEST
 ```
 
-When Metro bundles for real devices, it sets `NODE_ENV=production`, causing `.env.production` (with production CMS URLs) to override `.env` (with local dev URLs). The old `fetch-secrets` script wrote to `.env`, which lost to `.env.production`.
+When Metro bundles for real devices, it sets `NODE_ENV=production`, causing `.env.production` (with production GraphQL URLs) to override `.env` (with local dev URLs). The old `fetch-secrets` script wrote to `.env`, which lost to `.env.production`.
 
 ### Localhost vs LAN IP
 
-Simulators share the host's network stack (`localhost` works), but a physical phone is a separate device on the WiFi network. It needs the computer's actual LAN IP (e.g., `192.168.x.x`) to reach local Strapi.
+Simulators share the host's network stack (`localhost` works), but a physical phone is a separate device on the WiFi network. It needs the computer's actual LAN IP (e.g., `192.168.x.x`) to reach the local admin GraphQL API.
 
 ### Shell Env Vars vs Metro
 
@@ -54,21 +55,26 @@ Simulators share the host's network stack (`localhost` works), but a physical ph
 - Atomic write: temp file + `mv` prevents empty `.env.local` on Doppler failure
 - `rm -f .env` cleans up stale files from the old convention
 
-### 2. `pnpm device` writes `.env.development.local` with LAN IP
+### 2. Real device: write `.env.development.local` with your LAN IP
 
-```json
-"device": "IP=$(ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}') && [ -n \"$IP\" ] || { echo 'ERROR: Could not detect local IP.'; exit 1; } && printf 'EXPO_PUBLIC_GRAPHQL_URL_ANDROID=http://%s:1337/graphql\\nEXPO_PUBLIC_GRAPHQL_URL_IOS=http://%s:1337/graphql\\n' \"$IP\" \"$IP\" > .env.development.local && node scripts/device.mjs"
+A physical phone can't reach `localhost`/`127.0.0.1` — point it at the host's LAN IP. `.env.development.local` has the HIGHEST priority, overriding everything, and is gitignored:
+
+```bash
+IP=$(ipconfig getifaddr en0) && [ -n "$IP" ] || { echo 'ERROR: no LAN IP'; exit 1; }
+printf 'EXPO_PUBLIC_ADMIN_GRAPHQL_URL=http://%s:3003/api/graphql\n' "$IP" > .env.development.local
 ```
 
-`.env.development.local` has the HIGHEST priority, overriding everything. The IP validation prevents silently writing empty URLs.
+The app reads a single `EXPO_PUBLIC_ADMIN_GRAPHQL_URL` (admin dev runs on `:3003`), not the old platform-split `EXPO_PUBLIC_GRAPHQL_URL_IOS`/`_ANDROID`. Validate the IP before writing so you never silently emit an empty URL.
 
-### 3. `pnpm emulator` cleans up device overrides
+> Earlier revisions shipped `pnpm device` / `pnpm emulator` npm scripts that automated this against the retired Strapi `:1337` endpoint. Both scripts were removed in the admin cutover — the manual technique here is the current path.
 
-```json
-"emulator": "rm -f .env.development.local && expo start"
+### 3. Back to the simulator: remove the device override
+
+```bash
+rm -f .env.development.local && npx expo start --clear
 ```
 
-Removes `.env.development.local` so simulators use localhost/10.0.2.2 from `.env.local`.
+Deleting `.env.development.local` lets the simulator fall back to the `127.0.0.1:3003` admin endpoint in `.env.local`. Simulators share the host network stack, so `127.0.0.1` reaches local admin — use `127.0.0.1`, not `localhost`, which loops through admin's auth-host proxy.
 
 ### 4. iOS ATS exception for local networking
 
@@ -115,7 +121,9 @@ Added to `app.json` infoPlist. Allows HTTP to LAN IPs on real devices. Scoped to
 
 ## Related
 
-- [EAS Update Stakeholder Preview Setup](../mobile/eas-update-stakeholder-preview-setup.md) — **NOTE: references `.env` which is now `.env.local`**
+- [Mobile admin data-layer cutover](../architecture-patterns/mobile-admin-data-layer-cutover-pattern-20260525.md) — the Strapi → admin migration that replaced platform-split `EXPO_PUBLIC_GRAPHQL_URL_*` (+ `:1337`) with the single `EXPO_PUBLIC_ADMIN_GRAPHQL_URL`
+- [Verifying mobile Expo worktree changes in the simulator](../developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md) — the local admin endpoint trap (`:3003`) and the second-Metro / full-reload verification loop
+- [EAS Update Stakeholder Preview Setup](../mobile/eas-update-stakeholder-preview-setup.md) — references `.env` which is now `.env.local`
 - [New App CI and Deployment Patterns](../platform/new-app-ci-and-deployment-patterns.md) — `skipValidation` guard and `EAS_BUILD` explanation
 - [Adding New Apps](../platform/adding-new-apps.md) — env validation convention
 - `@expo/env` source: `node_modules/.pnpm/@expo+env@2.0.8/node_modules/@expo/env/build/index.js`


### PR DESCRIPTION
## What

Adds a dedicated **series detail page** to `apps/mobile`, porting the web series experience. Today, tapping a series in mobile search opens it through the single-video screen — a chrome-heavy player, an "Up Next" carousel, Bible Quotes, and a Download/Subtitles row that don't fit a collection, with no image fallback when the series has no trailer.

Now a series gets its own `/series/[slug]` page:
- **Hero** — reuses the existing `VideoPlayer` for the series' own trailer dub, or a **plain poster image** when there's no playable trailer (no player mounted).
- **SERIES** label + title, a **Read-more** description.
- **Language + Share** only (no Download/Subtitles — a series has no single asset).
- A scrollable **2-column grid** of the series' videos; tapping one opens the normal video page in the selected language.
- A **language sheet** over the episode-language union (`childDubLanguages`).

Reached from search and from any `/watch` deep link (which redirects when the resolved record is series-shaped). **Mobile-only — zero `apps/admin` changes**; every field already exists on the admin surface.

## How it's built (6 units, dependency-ordered)

| Unit | Change |
|------|--------|
| U1 | `GET_SERIES_BY_SLUG` + `label`/`childCount` on search; `normalizeSeries` (episodes + language union); shared video fragment stays lean |
| U2 | Lightweight `SeriesSessionProvider` + `/series` route group |
| U3 | Pinned hero (trailer or poster), metadata, Read-more, `SeriesActionRow` |
| U4 | Episode grid (static images — only the hero holds a decoder slot) + navigation |
| U5 | `SeriesLanguageSheet` over `childDubLanguages` (slug-keyed); language carries via the persisted audio preference |
| U6 | `isSeriesRecord` + search/watch routing (lands last) |

## Verification

- `tsc --noEmit` clean, `eslint` clean, **156 jest tests pass** (new: `normalizeSeries`, `isSeriesRecord`, `isSeriesSearchResult`).
- **Verified end-to-end in the iOS simulator** against real admin data: searched **StoryClubs** → routed to `/series` → SERIES label + title, poster hero (correctly no player — 0 playable trailer dubs), Language + Share, Read-more, 13-episode grid, language sheet listing all 191 episode languages.
- **Tier-2 multi-agent code review** run; 7 fixes applied (notably: the public share URL needed the `/watch/` prefix — curl-verified `/watch/{slug}.html/{lang}.html` returns 200, the bare form 404s; an iOS-a11y-tree `accessible` prop; a `VideoDescription` hooks-order hardening).

## Deferred follow-ups (from review, non-blocking)

- A series whose child is *itself* a series: stacked `/series` screens share one provider — deep back-nav could show the wrong series. Fix = slug-gate screen reads + `useFocusEffect` re-publish.
- A series language pick persists the **app-wide** audio preference (the resolved plan decision) — a deliberate cross-content behavior worth confirming.
- `/series/<single-video>` deep link → add the mirror redirect to `/watch`.

Brainstorm + plan: `docs/brainstorms/2026-06-08-mobile-series-detail-page-requirements.md`, `docs/plans/2026-06-08-002-feat-mobile-series-detail-page-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
