### PR TITLE
feat(mastra): add Firecrawl web data tools

### DIFF
--- a/apps/mastra/AGENTS.md
+++ b/apps/mastra/AGENTS.md
@@ -20,6 +20,9 @@ Full context lives in `apps/mastra/CLAUDE.md`. Keep both files aligned.
 - Owns a thin search eval orchestrator that coordinates those leaf workflows
   for baseline capture, comparison, native Evaluation sync, and release-gate
   summaries without moving leaf logic into one mega-workflow.
+- Owns Firecrawl web data access for agents and operator workflows through
+  bounded search/scrape tools, a dedicated web research agent, and the
+  `/forge-firecrawl-web-data` service route.
 - All embedding workflows share provider-result validation for count alignment,
   finite vector values, and configured dimensions before calling Admin.
 - AI Gateway content embeddings request the normal OpenAI-compatible
@@ -59,6 +62,11 @@ Full context lives in `apps/mastra/CLAUDE.md`. Keep both files aligned.
 - The search eval orchestrator must not promote generated, trace-derived, seed,
   or user-submitted candidates. Candidate generation and seed submission are
   opt-in staging steps; human promotion stays behind Admin review contracts.
+- Firecrawl access belongs in this runtime. Do not add Firecrawl SDK/API calls
+  to Admin or Manager; expose typed Mastra tools/workflows and HTTP contracts
+  from here when other apps need web data.
+- Firecrawl MCP is not the product runtime path. Revisit MCP only for local
+  operator/coding-agent convenience or after a clear multi-tool server need.
 - Studio-facing workflows need structured Zod object input schemas on both the
   workflow and first step. Avoid `z.unknown()` for operator-run workflows, and
   prefer defaults/optional fields that render usable Studio forms.

--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -51,6 +51,10 @@ Origin documents:
   payload parsing. Do not replace them with a generic embedding blob route.
 - Generation mode semantics are shared across embedding workflows: omitted means
   idempotent; explicit `repair`, `force`, and `model-upgrade` request rewrites.
+- Firecrawl web data access is Mastra-owned through bounded search/scrape
+  tools, `webResearchAgent`, the `firecrawl-web-data` workflow, and the
+  `/forge-firecrawl-web-data` service route. Keep direct Firecrawl credentials
+  and API calls out of Admin and Manager.
 - Do not import from `apps/admin`, `apps/manager`, or `apps/auth`; workflow
   contracts are HTTP payloads plus local Zod schemas.
 - Keep service-bearer auth receiver-side. Callers present a bearer; this app
@@ -111,6 +115,13 @@ pnpm --filter @forge/mastra lint
 | `MASTRA_SEARCH_EVAL_ARTIFACT_DIR`         | Optional directory for Mastra-owned offline search eval baseline and report JSON artifacts. Defaults under Mastra storage. |
 | `MASTRA_SEARCH_EVAL_ALLOW_PROD_IMPORT`    | Set to `true` only for an intentional production import override. Defaults to `false`; local imports do not need it.       |
 | `SEARCH_EVAL_JUDGE_MODEL`                 | OpenRouter chat model stamp for offline search eval judging. Defaults to `anthropic/claude-haiku-4-5`.                     |
+| `FIRECRAWL_API_KEY`                       | Firecrawl bearer key for Mastra-owned web search/scrape tools. Required in production runtime.                             |
+| `FIRECRAWL_API_URL`                       | Firecrawl API base URL. Defaults to `https://api.firecrawl.dev`; production must use HTTPS and an allowlisted host.        |
+| `FIRECRAWL_ALLOWED_HOSTS`                 | CSV host allowlist for production Firecrawl egress. Defaults to `api.firecrawl.dev`.                                       |
+| `FIRECRAWL_USER_AGENT`                    | Non-default user agent for Firecrawl requests. Defaults to `forge-mastra-firecrawl/1.0`.                                   |
+| `FIRECRAWL_TIMEOUT_MS`                    | Default Firecrawl request timeout. Defaults to `60000`.                                                                    |
+| `FIRECRAWL_MAX_SEARCH_RESULTS`            | Runtime cap for Firecrawl search results exposed to agents/workflows. Defaults to `5`, max `20`.                           |
+| `FIRECRAWL_MAX_MARKDOWN_CHARS`            | Runtime cap for markdown returned by Firecrawl search hydration and scrape. Defaults to `16000`.                           |
 | `PORT`                                    | Railway-provided runtime port. Mastra defaults to `4111` locally.                                                          |
 | `MASTRA_STUDIO_PATH`                      | Set to `.mastra/output/studio` when starting the built server with Studio assets.                                          |
 
@@ -251,6 +262,35 @@ explicit seed-only payload:
   "syncPromoted": false
 }
 ```
+
+## Firecrawl web data
+
+Firecrawl web data access is Mastra-owned. The runtime exposes:
+
+- `webResearchAgent`, with `firecrawlSearch` and `firecrawlScrape` tools.
+- `firecrawl-web-data`, a Studio-friendly workflow for either `search` or
+  `scrape` actions.
+- `POST /forge-firecrawl-web-data`, protected by `MASTRA_SERVICE_API_KEYS`, for
+  internal service callers that need bounded web data without direct Firecrawl
+  credentials.
+
+Default route payloads:
+
+```json
+{ "action": "search", "query": "firecrawl mastra tools", "limit": 5 }
+```
+
+```json
+{ "action": "scrape", "url": "https://docs.firecrawl.dev" }
+```
+
+The integration uses Firecrawl API v2 search and scrape over HTTPS, returns
+bounded markdown, and maps upstream failures into safe structured result
+objects. Keep direct Firecrawl calls out of Admin and Manager; those apps should
+use this runtime's tools/workflow/route if they need web data. Do not add
+Firecrawl MCP as the production path unless a later plan proves a real
+multi-tool MCP server need; MCP can be useful for local operator convenience but
+is not the deterministic product contract here.
 
 ## Search eval baseline portability
 

--- a/apps/mastra/src/config/env.test.ts
+++ b/apps/mastra/src/config/env.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 describe("Mastra env", () => {
+  beforeEach(() => {
+    vi.stubEnv("FIRECRAWL_API_KEY", "firecrawl-key")
+  })
+
   afterEach(() => {
     vi.doUnmock("../services/embedding-provider")
     vi.unstubAllEnvs()
@@ -156,6 +160,13 @@ describe("Mastra env", () => {
     vi.stubEnv("AI_GATEWAY_EMBEDDINGS_PROVIDER", "")
     vi.stubEnv("AI_GATEWAY_EMBEDDINGS_TIMEOUT_MS", "")
     vi.stubEnv("AI_GATEWAY_EMBEDDINGS_USER_AGENT", "")
+    vi.stubEnv("FIRECRAWL_ALLOWED_HOSTS", "")
+    vi.stubEnv("FIRECRAWL_API_KEY", "")
+    vi.stubEnv("FIRECRAWL_API_URL", "")
+    vi.stubEnv("FIRECRAWL_MAX_MARKDOWN_CHARS", "")
+    vi.stubEnv("FIRECRAWL_MAX_SEARCH_RESULTS", "")
+    vi.stubEnv("FIRECRAWL_TIMEOUT_MS", "")
+    vi.stubEnv("FIRECRAWL_USER_AGENT", "")
     vi.stubEnv("MASTRA_CONTENT_EMBEDDINGS_PROVIDER_MODE", "")
     vi.stubEnv("TRANSCRIPT_EMBEDDING_MODEL", "")
     vi.stubEnv("TRANSCRIPT_EMBEDDING_PROVIDER", "")
@@ -188,6 +199,13 @@ describe("Mastra env", () => {
     expect(env.AI_GATEWAY_EMBEDDINGS_USER_AGENT).toBe(
       "forge-mastra-content-embeddings/1.0",
     )
+    expect(env.FIRECRAWL_ALLOWED_HOSTS).toBe("api.firecrawl.dev")
+    expect(env.FIRECRAWL_API_KEY).toBeUndefined()
+    expect(env.FIRECRAWL_API_URL).toBe("https://api.firecrawl.dev")
+    expect(env.FIRECRAWL_MAX_MARKDOWN_CHARS).toBe(16_000)
+    expect(env.FIRECRAWL_MAX_SEARCH_RESULTS).toBe(5)
+    expect(env.FIRECRAWL_TIMEOUT_MS).toBe(60_000)
+    expect(env.FIRECRAWL_USER_AGENT).toBe("forge-mastra-firecrawl/1.0")
     expect(env.OPENAI_EMBEDDINGS_BASE_URL).toBe("https://api.openai.com/v1")
     expect(env.OPENROUTER_EMBEDDINGS_BASE_URL).toBe(
       "https://openrouter.ai/api/v1",
@@ -205,6 +223,27 @@ describe("Mastra env", () => {
     expect(getSceneEmbeddingProviderConfig()).toMatchObject({
       provider: "jesus-film-ai-gateway",
       timeoutMs: 90_000,
+    })
+  })
+
+  it("passes Firecrawl settings through provider config", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("FIRECRAWL_API_KEY", "custom-firecrawl-key")
+    vi.stubEnv("FIRECRAWL_API_URL", "https://firecrawl.internal")
+    vi.stubEnv("FIRECRAWL_TIMEOUT_MS", "45000")
+    vi.stubEnv("FIRECRAWL_USER_AGENT", "forge-test-firecrawl/1.0")
+    vi.stubEnv("FIRECRAWL_MAX_SEARCH_RESULTS", "7")
+    vi.stubEnv("FIRECRAWL_MAX_MARKDOWN_CHARS", "9000")
+
+    const { getFirecrawlConfig } = await import("./env")
+
+    expect(getFirecrawlConfig()).toEqual({
+      apiKey: "custom-firecrawl-key",
+      apiUrl: "https://firecrawl.internal",
+      timeoutMs: 45_000,
+      userAgent: "forge-test-firecrawl/1.0",
+      maxSearchResults: 7,
+      maxMarkdownCharacters: 9000,
     })
   })
 
@@ -236,6 +275,107 @@ describe("Mastra env", () => {
 
     expect(() => assertMastraRuntimeEnv()).toThrow(
       "AI_GATEWAY_EMBEDDINGS_API_KEY required for Mastra production",
+    )
+  })
+
+  it("requires Firecrawl credentials in production runtime", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("ADMIN_MASTRA_EXPERIENCE_INGEST_API_KEY", "admin-exp-key")
+    vi.stubEnv("ADMIN_MASTRA_TRANSCRIPT_INGEST_API_KEY", "admin-ingest-key")
+    vi.stubEnv("ADMIN_MASTRA_SCENE_INGEST_API_KEY", "admin-scene-key")
+    vi.stubEnv(
+      "ADMIN_EXPERIENCE_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/experience-embeddings",
+    )
+    vi.stubEnv(
+      "ADMIN_TRANSCRIPT_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/transcript-embeddings",
+    )
+    vi.stubEnv(
+      "ADMIN_SCENE_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/scene-embeddings",
+    )
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://postgres:postgres@localhost:5432/forge_mastra_gateway",
+    )
+    vi.stubEnv("FIRECRAWL_API_KEY", "")
+    vi.stubEnv("MASTRA_SERVICE_API_KEYS", "test-service-key")
+    vi.stubEnv("MASTRA_CONTENT_EMBEDDINGS_PROVIDER_MODE", "legacy")
+    vi.stubEnv("OPENROUTER_API_KEY", "openrouter-key")
+
+    const { assertMastraRuntimeEnv } = await import("./env")
+
+    expect(() => assertMastraRuntimeEnv()).toThrow(
+      "FIRECRAWL_API_KEY required for Mastra production",
+    )
+  })
+
+  it("rejects unsafe Firecrawl API URLs in production", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("ADMIN_MASTRA_EXPERIENCE_INGEST_API_KEY", "admin-exp-key")
+    vi.stubEnv("ADMIN_MASTRA_TRANSCRIPT_INGEST_API_KEY", "admin-ingest-key")
+    vi.stubEnv("ADMIN_MASTRA_SCENE_INGEST_API_KEY", "admin-scene-key")
+    vi.stubEnv(
+      "ADMIN_EXPERIENCE_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/experience-embeddings",
+    )
+    vi.stubEnv(
+      "ADMIN_TRANSCRIPT_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/transcript-embeddings",
+    )
+    vi.stubEnv(
+      "ADMIN_SCENE_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/scene-embeddings",
+    )
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://postgres:postgres@localhost:5432/forge_mastra_gateway",
+    )
+    vi.stubEnv("FIRECRAWL_API_URL", "http://evil.test")
+    vi.stubEnv("FIRECRAWL_ALLOWED_HOSTS", "api.firecrawl.dev")
+    vi.stubEnv("MASTRA_SERVICE_API_KEYS", "test-service-key")
+    vi.stubEnv("MASTRA_CONTENT_EMBEDDINGS_PROVIDER_MODE", "legacy")
+    vi.stubEnv("OPENROUTER_API_KEY", "openrouter-key")
+
+    const { assertMastraRuntimeEnv } = await import("./env")
+
+    expect(() => assertMastraRuntimeEnv()).toThrow(
+      "FIRECRAWL_API_URL must use https and a host listed in FIRECRAWL_ALLOWED_HOSTS for Mastra production",
+    )
+  })
+
+  it("rejects non-allowlisted Firecrawl API hosts in production", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("ADMIN_MASTRA_EXPERIENCE_INGEST_API_KEY", "admin-exp-key")
+    vi.stubEnv("ADMIN_MASTRA_TRANSCRIPT_INGEST_API_KEY", "admin-ingest-key")
+    vi.stubEnv("ADMIN_MASTRA_SCENE_INGEST_API_KEY", "admin-scene-key")
+    vi.stubEnv(
+      "ADMIN_EXPERIENCE_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/experience-embeddings",
+    )
+    vi.stubEnv(
+      "ADMIN_TRANSCRIPT_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/transcript-embeddings",
+    )
+    vi.stubEnv(
+      "ADMIN_SCENE_INGEST_URL",
+      "https://admin.internal/api/internal/mastra/scene-embeddings",
+    )
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://postgres:postgres@localhost:5432/forge_mastra_gateway",
+    )
+    vi.stubEnv("FIRECRAWL_API_URL", "https://other.test")
+    vi.stubEnv("FIRECRAWL_ALLOWED_HOSTS", "api.firecrawl.dev")
+    vi.stubEnv("MASTRA_SERVICE_API_KEYS", "test-service-key")
+    vi.stubEnv("MASTRA_CONTENT_EMBEDDINGS_PROVIDER_MODE", "legacy")
+    vi.stubEnv("OPENROUTER_API_KEY", "openrouter-key")
+
+    const { assertMastraRuntimeEnv } = await import("./env")
+
+    expect(() => assertMastraRuntimeEnv()).toThrow(
+      "FIRECRAWL_API_URL must use https and a host listed in FIRECRAWL_ALLOWED_HOSTS for Mastra production",
     )
   })
 

--- a/apps/mastra/src/config/env.ts
+++ b/apps/mastra/src/config/env.ts
@@ -20,6 +20,12 @@ const DEFAULT_AI_GATEWAY_EMBEDDINGS_USER_AGENT =
 const DEFAULT_AI_GATEWAY_EMBEDDINGS_MODEL = "embeddings"
 const DEFAULT_AI_GATEWAY_EMBEDDINGS_PROVIDER = "jesus-film-ai-gateway"
 const DEFAULT_AI_GATEWAY_EMBEDDINGS_TIMEOUT_MS = 60_000
+const DEFAULT_FIRECRAWL_API_URL = "https://api.firecrawl.dev"
+const DEFAULT_FIRECRAWL_ALLOWED_HOSTS = "api.firecrawl.dev"
+const DEFAULT_FIRECRAWL_USER_AGENT = "forge-mastra-firecrawl/1.0"
+const DEFAULT_FIRECRAWL_TIMEOUT_MS = 60_000
+const DEFAULT_FIRECRAWL_MAX_SEARCH_RESULTS = 5
+const DEFAULT_FIRECRAWL_MAX_MARKDOWN_CHARS = 16_000
 const AI_GATEWAY_FINAL_EMBEDDING_DIMENSIONS =
   EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS
 const AI_GATEWAY_TRANSFORM_VERSION = DEFAULT_EMBEDDING_TRANSFORM_VERSION
@@ -39,6 +45,15 @@ export type ContentEmbeddingProviderConfig = {
   expectedNativeDimensions?: number
   truncateToDimensions?: number
   transformVersion?: string
+}
+
+export type FirecrawlConfig = {
+  apiKey?: string
+  apiUrl: string
+  timeoutMs: number
+  userAgent: string
+  maxSearchResults: number
+  maxMarkdownCharacters: number
 }
 
 const envSchema = z.object({
@@ -116,6 +131,31 @@ const envSchema = z.object({
     .string()
     .min(1)
     .default("anthropic/claude-haiku-4-5"),
+  FIRECRAWL_ALLOWED_HOSTS: z
+    .string()
+    .min(1)
+    .default(DEFAULT_FIRECRAWL_ALLOWED_HOSTS),
+  FIRECRAWL_API_KEY: z.string().min(1).optional(),
+  FIRECRAWL_API_URL: z.string().url().default(DEFAULT_FIRECRAWL_API_URL),
+  FIRECRAWL_MAX_MARKDOWN_CHARS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(100_000)
+    .default(DEFAULT_FIRECRAWL_MAX_MARKDOWN_CHARS),
+  FIRECRAWL_MAX_SEARCH_RESULTS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(20)
+    .default(DEFAULT_FIRECRAWL_MAX_SEARCH_RESULTS),
+  FIRECRAWL_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(300_000)
+    .default(DEFAULT_FIRECRAWL_TIMEOUT_MS),
+  FIRECRAWL_USER_AGENT: z.string().min(1).default(DEFAULT_FIRECRAWL_USER_AGENT),
   SEARCH_EVAL_JUDGE_MODEL: z
     .string()
     .min(1)
@@ -225,6 +265,19 @@ export const env = envSchema.parse({
   EVAL_QUERY_GENERATION_MODEL: emptyToUndefined(
     process.env.EVAL_QUERY_GENERATION_MODEL,
   ),
+  FIRECRAWL_ALLOWED_HOSTS: emptyToUndefined(
+    process.env.FIRECRAWL_ALLOWED_HOSTS,
+  ),
+  FIRECRAWL_API_KEY: emptyToUndefined(process.env.FIRECRAWL_API_KEY),
+  FIRECRAWL_API_URL: emptyToUndefined(process.env.FIRECRAWL_API_URL),
+  FIRECRAWL_MAX_MARKDOWN_CHARS: emptyToUndefined(
+    process.env.FIRECRAWL_MAX_MARKDOWN_CHARS,
+  ),
+  FIRECRAWL_MAX_SEARCH_RESULTS: emptyToUndefined(
+    process.env.FIRECRAWL_MAX_SEARCH_RESULTS,
+  ),
+  FIRECRAWL_TIMEOUT_MS: emptyToUndefined(process.env.FIRECRAWL_TIMEOUT_MS),
+  FIRECRAWL_USER_AGENT: emptyToUndefined(process.env.FIRECRAWL_USER_AGENT),
   SEARCH_EVAL_JUDGE_MODEL: emptyToUndefined(
     process.env.SEARCH_EVAL_JUDGE_MODEL,
   ),
@@ -255,6 +308,16 @@ function assertGatewayBaseUrlAllowedForProduction() {
   if (baseUrl.protocol !== "https:" || !allowedHosts.has(baseUrl.hostname)) {
     throw new Error(
       "AI_GATEWAY_EMBEDDINGS_BASE_URL must use https and a host listed in AI_GATEWAY_EMBEDDINGS_ALLOWED_HOSTS for Mastra production",
+    )
+  }
+}
+
+function assertFirecrawlApiUrlAllowedForProduction() {
+  const apiUrl = new URL(env.FIRECRAWL_API_URL)
+  const allowedHosts = csvSet(env.FIRECRAWL_ALLOWED_HOSTS)
+  if (apiUrl.protocol !== "https:" || !allowedHosts.has(apiUrl.hostname)) {
+    throw new Error(
+      "FIRECRAWL_API_URL must use https and a host listed in FIRECRAWL_ALLOWED_HOSTS for Mastra production",
     )
   }
 }
@@ -310,8 +373,10 @@ export function assertMastraRuntimeEnv() {
     ["ADMIN_SCENE_INGEST_URL", env.ADMIN_SCENE_INGEST_URL],
     ["ADMIN_TRANSCRIPT_INGEST_URL", env.ADMIN_TRANSCRIPT_INGEST_URL],
     ["DATABASE_URL", env.DATABASE_URL],
+    ["FIRECRAWL_API_KEY", env.FIRECRAWL_API_KEY],
     ["MASTRA_SERVICE_API_KEYS", env.MASTRA_SERVICE_API_KEYS],
   ]
+  assertFirecrawlApiUrlAllowedForProduction()
 
   if (getContentEmbeddingsProviderMode() === "gateway") {
     missing.push([
@@ -346,6 +411,17 @@ export function getMastraStorageDir() {
     return `${env.RAILWAY_VOLUME_MOUNT_PATH.replace(/\/$/, "")}/mastra`
   }
   return ".mastra/storage"
+}
+
+export function getFirecrawlConfig(): FirecrawlConfig {
+  return {
+    apiKey: env.FIRECRAWL_API_KEY,
+    apiUrl: env.FIRECRAWL_API_URL,
+    timeoutMs: env.FIRECRAWL_TIMEOUT_MS,
+    userAgent: env.FIRECRAWL_USER_AGENT,
+    maxSearchResults: env.FIRECRAWL_MAX_SEARCH_RESULTS,
+    maxMarkdownCharacters: env.FIRECRAWL_MAX_MARKDOWN_CHARS,
+  }
 }
 
 function getLegacyEmbeddingProviderConfig(

--- a/apps/mastra/src/mastra/agents/web-research-agent.ts
+++ b/apps/mastra/src/mastra/agents/web-research-agent.ts
@@ -1,0 +1,23 @@
+import { Agent } from "@mastra/core/agent"
+
+import { firecrawlScrapeTool, firecrawlSearchTool } from "../tools/firecrawl"
+
+export const webResearchAgent = new Agent({
+  id: "webResearchAgent",
+  name: "Web Research Agent",
+  description:
+    "Researches current public web pages through Firecrawl search and scrape tools.",
+  instructions: [
+    "You research current public web information for Forge workflows.",
+    "Use firecrawlSearch when you need to discover URLs from a query.",
+    "Use firecrawlScrape when the user or workflow already has a specific URL, or after selecting a search result.",
+    "Keep source URLs visible in answers and distinguish what Firecrawl returned from your own synthesis.",
+    "Do not request private, authenticated, or personal data through Firecrawl.",
+    "If a Firecrawl tool returns ok=false, explain the safe reason and whether retrying may help.",
+  ].join("\n"),
+  model: "openai/gpt-5.4-mini",
+  tools: {
+    firecrawlSearchTool,
+    firecrawlScrapeTool,
+  },
+})

--- a/apps/mastra/src/mastra/index.ts
+++ b/apps/mastra/src/mastra/index.ts
@@ -21,6 +21,7 @@ import {
   getMastraStorageDir,
 } from "../config/env"
 import { smokeAgent, createSmokeResponse } from "./agents/smoke-agent"
+import { webResearchAgent } from "./agents/web-research-agent"
 import {
   handleTranscriptEmbeddingRouteRequest,
   transcriptEmbeddingWorkflow,
@@ -59,6 +60,10 @@ import {
   searchEvalBaselinePortabilityWorkflow,
 } from "./workflows/search-eval-baseline-portability"
 import {
+  firecrawlWebDataWorkflow,
+  handleFirecrawlWebDataRouteRequest,
+} from "./workflows/firecrawl-web-data"
+import {
   isValidServiceBearer,
   parseServiceApiKeys,
 } from "../server/service-bearer"
@@ -95,7 +100,7 @@ const redactPromptBodies: SpanOutputProcessor = {
 }
 
 export const mastra = new Mastra({
-  agents: { smokeAgent },
+  agents: { smokeAgent, webResearchAgent },
   workflows: {
     transcriptEmbeddingWorkflow,
     sceneEmbeddingWorkflow,
@@ -106,6 +111,7 @@ export const mastra = new Mastra({
     searchEvalNativeSuiteWorkflow,
     searchEvalOrchestratorWorkflow,
     searchEvalBaselinePortabilityWorkflow,
+    firecrawlWebDataWorkflow,
   },
   logger: new PinoLogger({
     name: "ForgeMastra",
@@ -168,6 +174,21 @@ export const mastra = new Mastra({
         method: "POST",
         handler: async (c) => {
           const outcome = await handleTranscriptEmbeddingRouteRequest({
+            authHeader: c.req.header("authorization"),
+            serviceKeys,
+            readJson: () => c.req.json(),
+          })
+
+          return new Response(JSON.stringify(outcome.body), {
+            status: outcome.status,
+            headers: { "content-type": "application/json" },
+          })
+        },
+      }),
+      registerApiRoute("/forge-firecrawl-web-data", {
+        method: "POST",
+        handler: async (c) => {
+          const outcome = await handleFirecrawlWebDataRouteRequest({
             authHeader: c.req.header("authorization"),
             serviceKeys,
             readJson: () => c.req.json(),

--- a/apps/mastra/src/mastra/tools/firecrawl.test.ts
+++ b/apps/mastra/src/mastra/tools/firecrawl.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  executeFirecrawlScrapeTool,
+  executeFirecrawlSearchTool,
+  firecrawlScrapeToolInputSchema,
+  firecrawlSearchToolInputSchema,
+} from "./firecrawl"
+
+describe("Firecrawl Mastra tools", () => {
+  it("searches through the Firecrawl client with bounded tool input", async () => {
+    const search = vi.fn(async () => ({
+      ok: true as const,
+      result: {
+        query: "mastra firecrawl",
+        creditsUsed: 2,
+        results: [
+          {
+            title: "Firecrawl",
+            url: "https://www.firecrawl.dev",
+            description: "Web data API",
+            markdown: null,
+            markdownTruncated: false,
+          },
+        ],
+      },
+    }))
+
+    const result = await executeFirecrawlSearchTool(
+      {
+        query: "  mastra firecrawl  ",
+        limit: 3,
+        includeMarkdown: true,
+      },
+      { search },
+    )
+
+    expect(search).toHaveBeenCalledWith({
+      query: "mastra firecrawl",
+      limit: 3,
+      includeMarkdown: true,
+    })
+    expect(result).toEqual({
+      ok: true,
+      query: "mastra firecrawl",
+      creditsUsed: 2,
+      results: [
+        {
+          title: "Firecrawl",
+          url: "https://www.firecrawl.dev",
+          description: "Web data API",
+          markdown: null,
+          markdownTruncated: false,
+        },
+      ],
+    })
+  })
+
+  it("scrapes a known URL through the Firecrawl client", async () => {
+    const scrape = vi.fn(async () => ({
+      ok: true as const,
+      result: {
+        url: "https://docs.firecrawl.dev",
+        markdown: "# Docs",
+        markdownTruncated: false,
+        title: "Docs",
+        description: null,
+        statusCode: 200,
+        contentType: "text/html",
+      },
+    }))
+
+    const result = await executeFirecrawlScrapeTool(
+      {
+        url: "https://docs.firecrawl.dev",
+        onlyMainContent: false,
+        timeoutMs: 5000,
+      },
+      { scrape },
+    )
+
+    expect(scrape).toHaveBeenCalledWith({
+      url: "https://docs.firecrawl.dev",
+      onlyMainContent: false,
+      timeoutMs: 5000,
+    })
+    expect(result).toEqual({
+      ok: true,
+      url: "https://docs.firecrawl.dev",
+      markdown: "# Docs",
+      markdownTruncated: false,
+      title: "Docs",
+      description: null,
+      statusCode: 200,
+      contentType: "text/html",
+    })
+  })
+
+  it("returns safe client failures for agent context", async () => {
+    const result = await executeFirecrawlSearchTool(
+      { query: "news" },
+      {
+        search: vi.fn(async () => ({
+          ok: false as const,
+          reason: "rate_limited" as const,
+          retryable: true,
+          status: 429,
+          upstreamReason: "plan limit reached",
+        })),
+      },
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "rate_limited",
+      retryable: true,
+      status: 429,
+      upstreamReason: "plan limit reached",
+    })
+  })
+
+  it("validates user-facing search and scrape input", () => {
+    expect(
+      firecrawlSearchToolInputSchema.safeParse({ query: "" }).success,
+    ).toBe(false)
+    expect(
+      firecrawlScrapeToolInputSchema.safeParse({ url: "not-a-url" }).success,
+    ).toBe(false)
+  })
+})

--- a/apps/mastra/src/mastra/tools/firecrawl.ts
+++ b/apps/mastra/src/mastra/tools/firecrawl.ts
@@ -1,0 +1,209 @@
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+
+import {
+  scrapeFirecrawl,
+  searchFirecrawl,
+  type FirecrawlClientFailure,
+  type FirecrawlScrapeInput,
+  type FirecrawlSearchInput,
+} from "../../services/firecrawl-client"
+
+export const firecrawlFailureReasonSchema = z.enum([
+  "config_missing",
+  "auth_failed",
+  "network_error",
+  "rate_limited",
+  "rejected",
+  "parse_error",
+  "invalid_response",
+])
+
+export const firecrawlFailureSchema = z
+  .object({
+    ok: z.literal(false),
+    reason: firecrawlFailureReasonSchema,
+    retryable: z.boolean(),
+    status: z.number().int().optional(),
+    upstreamReason: z.string().optional(),
+  })
+  .strict()
+
+export const firecrawlSearchToolInputSchema = z
+  .object({
+    query: z
+      .string()
+      .trim()
+      .min(1)
+      .max(500)
+      .describe("Search query for current public web data."),
+    limit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(20)
+      .default(5)
+      .describe("Maximum web results to return."),
+    includeMarkdown: z
+      .boolean()
+      .default(false)
+      .describe("Also hydrate search results with bounded markdown content."),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1000)
+      .max(300_000)
+      .optional()
+      .describe("Optional Firecrawl request timeout in milliseconds."),
+  })
+  .strict()
+
+const firecrawlSearchResultSchema = z
+  .object({
+    title: z.string().nullable(),
+    url: z.string().url(),
+    description: z.string().nullable(),
+    markdown: z.string().nullable(),
+    markdownTruncated: z.boolean(),
+  })
+  .strict()
+
+export const firecrawlSearchToolOutputSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      query: z.string(),
+      results: z.array(firecrawlSearchResultSchema),
+      creditsUsed: z.number().nullable(),
+    })
+    .strict(),
+  firecrawlFailureSchema,
+])
+
+export const firecrawlScrapeToolInputSchema = z
+  .object({
+    url: z.string().url().describe("Public page URL to scrape."),
+    onlyMainContent: z
+      .boolean()
+      .default(true)
+      .describe("Filter boilerplate before returning markdown."),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1000)
+      .max(300_000)
+      .optional()
+      .describe("Optional Firecrawl request timeout in milliseconds."),
+  })
+  .strict()
+
+export const firecrawlScrapeToolOutputSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      url: z.string().url(),
+      markdown: z.string(),
+      markdownTruncated: z.boolean(),
+      title: z.string().nullable(),
+      description: z.string().nullable(),
+      statusCode: z.number().int().nullable(),
+      contentType: z.string().nullable(),
+    })
+    .strict(),
+  firecrawlFailureSchema,
+])
+
+export type FirecrawlSearchToolInput = z.input<
+  typeof firecrawlSearchToolInputSchema
+>
+export type FirecrawlSearchToolOutput = z.output<
+  typeof firecrawlSearchToolOutputSchema
+>
+
+export type FirecrawlScrapeToolInput = z.input<
+  typeof firecrawlScrapeToolInputSchema
+>
+export type FirecrawlScrapeToolOutput = z.output<
+  typeof firecrawlScrapeToolOutputSchema
+>
+
+function failureOutput(
+  failure: FirecrawlClientFailure,
+): z.output<typeof firecrawlFailureSchema> {
+  return {
+    ok: false,
+    reason: failure.reason,
+    retryable: failure.retryable,
+    ...(failure.status == null ? {} : { status: failure.status }),
+    ...(failure.upstreamReason == null
+      ? {}
+      : { upstreamReason: failure.upstreamReason }),
+  }
+}
+
+export async function executeFirecrawlSearchTool(
+  input: FirecrawlSearchToolInput,
+  options: {
+    search?: (input: FirecrawlSearchInput) => ReturnType<typeof searchFirecrawl>
+  } = {},
+): Promise<FirecrawlSearchToolOutput> {
+  const parsed = firecrawlSearchToolInputSchema.parse(input)
+  const response = await (options.search ?? searchFirecrawl)({
+    query: parsed.query,
+    limit: parsed.limit,
+    includeMarkdown: parsed.includeMarkdown,
+    ...(parsed.timeoutMs == null ? {} : { timeoutMs: parsed.timeoutMs }),
+  })
+
+  if (!response.ok) return failureOutput(response)
+  return {
+    ok: true,
+    query: response.result.query,
+    results: response.result.results,
+    creditsUsed: response.result.creditsUsed,
+  }
+}
+
+export async function executeFirecrawlScrapeTool(
+  input: FirecrawlScrapeToolInput,
+  options: {
+    scrape?: (input: FirecrawlScrapeInput) => ReturnType<typeof scrapeFirecrawl>
+  } = {},
+): Promise<FirecrawlScrapeToolOutput> {
+  const parsed = firecrawlScrapeToolInputSchema.parse(input)
+  const response = await (options.scrape ?? scrapeFirecrawl)({
+    url: parsed.url,
+    onlyMainContent: parsed.onlyMainContent,
+    ...(parsed.timeoutMs == null ? {} : { timeoutMs: parsed.timeoutMs }),
+  })
+
+  if (!response.ok) return failureOutput(response)
+  return {
+    ok: true,
+    url: response.result.url,
+    markdown: response.result.markdown,
+    markdownTruncated: response.result.markdownTruncated,
+    title: response.result.title,
+    description: response.result.description,
+    statusCode: response.result.statusCode,
+    contentType: response.result.contentType,
+  }
+}
+
+export const firecrawlSearchTool = createTool({
+  id: "firecrawlSearch",
+  description:
+    "Search the public web through Firecrawl. Use this when the agent needs to discover current URLs before reading pages. Returns bounded results with source URLs.",
+  inputSchema: firecrawlSearchToolInputSchema,
+  outputSchema: firecrawlSearchToolOutputSchema,
+  execute: async (inputData) => executeFirecrawlSearchTool(inputData),
+})
+
+export const firecrawlScrapeTool = createTool({
+  id: "firecrawlScrape",
+  description:
+    "Scrape a known public URL through Firecrawl and return bounded markdown plus safe metadata. Use this after a URL is known or selected from search results.",
+  inputSchema: firecrawlScrapeToolInputSchema,
+  outputSchema: firecrawlScrapeToolOutputSchema,
+  execute: async (inputData) => executeFirecrawlScrapeTool(inputData),
+})

--- a/apps/mastra/src/mastra/workflows/firecrawl-web-data.test.ts
+++ b/apps/mastra/src/mastra/workflows/firecrawl-web-data.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  handleFirecrawlWebDataRouteRequest,
+  runFirecrawlWebDataWorkflow,
+  _internal,
+  type FirecrawlWebDataResult,
+} from "./firecrawl-web-data"
+
+describe("firecrawl web data workflow", () => {
+  it("runs a search action through the tool executor", async () => {
+    const search = vi.fn(async () => ({
+      ok: true as const,
+      query: "firecrawl mastra",
+      creditsUsed: 1,
+      results: [
+        {
+          title: "Firecrawl Docs",
+          url: "https://docs.firecrawl.dev",
+          description: "Docs",
+          markdown: null,
+          markdownTruncated: false,
+        },
+      ],
+    }))
+
+    const result = await runFirecrawlWebDataWorkflow(
+      {
+        action: "search",
+        query: " firecrawl mastra ",
+        limit: 2,
+      },
+      { runId: "run-search", search },
+    )
+
+    expect(search).toHaveBeenCalledWith({
+      query: "firecrawl mastra",
+      limit: 2,
+      includeMarkdown: false,
+    })
+    expect(result).toEqual({
+      ok: true,
+      action: "search",
+      mastraRunId: "run-search",
+      search: {
+        query: "firecrawl mastra",
+        creditsUsed: 1,
+        results: [
+          {
+            title: "Firecrawl Docs",
+            url: "https://docs.firecrawl.dev",
+            description: "Docs",
+            markdown: null,
+            markdownTruncated: false,
+          },
+        ],
+      },
+    })
+  })
+
+  it("runs a scrape action through the tool executor", async () => {
+    const scrape = vi.fn(async () => ({
+      ok: true as const,
+      url: "https://www.firecrawl.dev",
+      markdown: "# Firecrawl",
+      markdownTruncated: false,
+      title: "Firecrawl",
+      description: "Web data API",
+      statusCode: 200,
+      contentType: "text/html",
+    }))
+
+    const result = await runFirecrawlWebDataWorkflow(
+      {
+        action: "scrape",
+        url: "https://www.firecrawl.dev",
+        onlyMainContent: false,
+        timeoutMs: 5000,
+      },
+      { runId: "run-scrape", scrape },
+    )
+
+    expect(scrape).toHaveBeenCalledWith({
+      url: "https://www.firecrawl.dev",
+      onlyMainContent: false,
+      timeoutMs: 5000,
+    })
+    expect(result).toEqual({
+      ok: true,
+      action: "scrape",
+      mastraRunId: "run-scrape",
+      scrape: {
+        url: "https://www.firecrawl.dev",
+        markdown: "# Firecrawl",
+        markdownTruncated: false,
+        title: "Firecrawl",
+        description: "Web data API",
+        statusCode: 200,
+        contentType: "text/html",
+      },
+    })
+  })
+
+  it("rejects action-specific missing inputs before calling tools", async () => {
+    const search = vi.fn()
+
+    const result = await runFirecrawlWebDataWorkflow(
+      { action: "search" },
+      { search },
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "invalid_input",
+      retryable: false,
+    })
+    expect(search).not.toHaveBeenCalled()
+  })
+
+  it("maps Firecrawl failures into workflow failures", async () => {
+    const result = await runFirecrawlWebDataWorkflow(
+      {
+        action: "scrape",
+        url: "https://docs.firecrawl.dev",
+      },
+      {
+        scrape: vi.fn(async () => ({
+          ok: false as const,
+          reason: "config_missing" as const,
+          retryable: false,
+        })),
+      },
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      action: "scrape",
+      reason: "config_missing",
+      retryable: false,
+    })
+  })
+
+  it("requires service bearer auth on the service route", async () => {
+    const outcome = await handleFirecrawlWebDataRouteRequest({
+      authHeader: undefined,
+      serviceKeys: ["service-key"],
+      readJson: async () => ({ action: "search", query: "firecrawl" }),
+    })
+
+    expect(outcome).toEqual({
+      status: 401,
+      body: { error: "Service bearer required" },
+    })
+  })
+
+  it("launches the workflow from a valid service route request", async () => {
+    const result: FirecrawlWebDataResult = {
+      ok: true,
+      action: "search",
+      mastraRunId: "run-route",
+      search: {
+        query: "firecrawl",
+        creditsUsed: null,
+        results: [],
+      },
+    }
+    const launch = vi.fn(async () => result)
+
+    const outcome = await handleFirecrawlWebDataRouteRequest({
+      authHeader: "Bearer service-key",
+      serviceKeys: ["service-key"],
+      readJson: async () => ({ action: "search", query: "firecrawl" }),
+      launch,
+    })
+
+    expect(outcome).toEqual({ status: 200, body: { result } })
+    expect(launch).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "search", query: "firecrawl" }),
+      { runId: expect.any(String) },
+    )
+  })
+
+  it("maps invalid route input and upstream rate limits to route statuses", async () => {
+    const invalidJson = await handleFirecrawlWebDataRouteRequest({
+      authHeader: "Bearer service-key",
+      serviceKeys: ["service-key"],
+      readJson: async () => {
+        throw new Error("invalid json")
+      },
+    })
+    expect(invalidJson).toEqual({
+      status: 400,
+      body: {
+        result: {
+          ok: false,
+          reason: "invalid_input",
+          retryable: false,
+        },
+        error: "Invalid JSON",
+      },
+    })
+
+    const invalid = await handleFirecrawlWebDataRouteRequest({
+      authHeader: "Bearer service-key",
+      serviceKeys: ["service-key"],
+      readJson: async () => ({ action: "search" }),
+    })
+    expect(invalid.status).toBe(400)
+    expect(invalid.body.result).toEqual({
+      ok: false,
+      reason: "invalid_input",
+      retryable: false,
+    })
+
+    const rateLimited = await handleFirecrawlWebDataRouteRequest({
+      authHeader: "Bearer service-key",
+      serviceKeys: ["service-key"],
+      readJson: async () => ({ action: "search", query: "firecrawl" }),
+      launch: vi.fn(async () => ({
+        ok: false as const,
+        action: "search" as const,
+        reason: "rate_limited" as const,
+        retryable: true,
+        status: 429,
+      })),
+    })
+    expect(rateLimited.status).toBe(429)
+  })
+
+  it("extracts workflow failures from wrapped Mastra run errors", () => {
+    const failure: FirecrawlWebDataResult = {
+      ok: false,
+      action: "scrape",
+      reason: "auth_failed",
+      retryable: false,
+      status: 401,
+    }
+    const wrapped = new Error(
+      `Step failed: FIRECRAWL_WEB_DATA_WORKFLOW_FAILED:${JSON.stringify(
+        failure,
+      )}`,
+    )
+
+    expect(_internal.workflowFailureFromUnknown(wrapped)).toEqual(failure)
+    expect(_internal.workflowFailureFromRunResult({ error: wrapped })).toEqual(
+      failure,
+    )
+  })
+})

--- a/apps/mastra/src/mastra/workflows/firecrawl-web-data.ts
+++ b/apps/mastra/src/mastra/workflows/firecrawl-web-data.ts
@@ -1,0 +1,422 @@
+import { randomUUID } from "node:crypto"
+
+import { createStep, createWorkflow } from "@mastra/core/workflows"
+import { z } from "zod"
+
+import { isValidServiceBearer } from "../../server/service-bearer"
+import {
+  executeFirecrawlScrapeTool,
+  executeFirecrawlSearchTool,
+  type FirecrawlScrapeToolInput,
+  type FirecrawlScrapeToolOutput,
+  type FirecrawlSearchToolInput,
+  type FirecrawlSearchToolOutput,
+} from "../tools/firecrawl"
+
+const WORKFLOW_FAILURE_ERROR_PREFIX = "FIRECRAWL_WEB_DATA_WORKFLOW_FAILED:"
+
+export const FirecrawlWebDataInputSchema = z
+  .object({
+    action: z
+      .enum(["search", "scrape"])
+      .default("search")
+      .describe("Firecrawl action to run."),
+    query: z
+      .string()
+      .trim()
+      .min(1)
+      .max(500)
+      .optional()
+      .describe("Search query. Required when action is search."),
+    url: z
+      .string()
+      .url()
+      .optional()
+      .describe("Public page URL. Required when action is scrape."),
+    limit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(20)
+      .default(5)
+      .describe("Maximum search results to return."),
+    includeMarkdown: z
+      .boolean()
+      .default(false)
+      .describe("Hydrate search results with bounded markdown."),
+    onlyMainContent: z
+      .boolean()
+      .default(true)
+      .describe("Scrape only the main content region when possible."),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1000)
+      .max(300_000)
+      .optional()
+      .describe("Optional Firecrawl request timeout in milliseconds."),
+  })
+  .strict()
+  .superRefine((input, ctx) => {
+    if (input.action === "search" && !input.query) {
+      ctx.addIssue({
+        code: "custom",
+        message: "query is required when action is search",
+        path: ["query"],
+      })
+    }
+    if (input.action === "scrape" && !input.url) {
+      ctx.addIssue({
+        code: "custom",
+        message: "url is required when action is scrape",
+        path: ["url"],
+      })
+    }
+  })
+
+export type FirecrawlWebDataWorkflowInput = z.output<
+  typeof FirecrawlWebDataInputSchema
+>
+
+const FirecrawlWebDataFailureReasonSchema = z.enum([
+  "invalid_input",
+  "config_missing",
+  "auth_failed",
+  "network_error",
+  "rate_limited",
+  "rejected",
+  "parse_error",
+  "invalid_response",
+])
+
+const FirecrawlSearchResultSchema = z
+  .object({
+    title: z.string().nullable(),
+    url: z.string().url(),
+    description: z.string().nullable(),
+    markdown: z.string().nullable(),
+    markdownTruncated: z.boolean(),
+  })
+  .strict()
+
+const FirecrawlSearchSuccessSchema = z
+  .object({
+    query: z.string(),
+    results: z.array(FirecrawlSearchResultSchema),
+    creditsUsed: z.number().nullable(),
+  })
+  .strict()
+
+const FirecrawlScrapeSuccessSchema = z
+  .object({
+    url: z.string().url(),
+    markdown: z.string(),
+    markdownTruncated: z.boolean(),
+    title: z.string().nullable(),
+    description: z.string().nullable(),
+    statusCode: z.number().int().nullable(),
+    contentType: z.string().nullable(),
+  })
+  .strict()
+
+export const FirecrawlWebDataResultSchema = z.union([
+  z
+    .object({
+      ok: z.literal(true),
+      action: z.literal("search"),
+      mastraRunId: z.string(),
+      search: FirecrawlSearchSuccessSchema,
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(true),
+      action: z.literal("scrape"),
+      mastraRunId: z.string(),
+      scrape: FirecrawlScrapeSuccessSchema,
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      action: z.enum(["search", "scrape"]).optional(),
+      reason: FirecrawlWebDataFailureReasonSchema,
+      retryable: z.boolean(),
+      status: z.number().int().optional(),
+      upstreamReason: z.string().optional(),
+    })
+    .strict(),
+])
+
+export type FirecrawlWebDataResult = z.output<
+  typeof FirecrawlWebDataResultSchema
+>
+type FirecrawlWebDataFailure = Extract<FirecrawlWebDataResult, { ok: false }>
+
+type RouteHandlerInput = {
+  authHeader: string | null | undefined
+  serviceKeys: readonly string[]
+  readJson: () => Promise<unknown>
+  launch?: (
+    input: FirecrawlWebDataWorkflowInput,
+    options: { runId: string },
+  ) => Promise<FirecrawlWebDataResult>
+}
+
+export type FirecrawlWebDataRouteOutcome = {
+  status: number
+  body: { result?: FirecrawlWebDataResult; error?: string }
+}
+
+function invalidInput(): FirecrawlWebDataFailure {
+  return { ok: false, reason: "invalid_input", retryable: false }
+}
+
+function failureFromTool(
+  action: "search" | "scrape",
+  output: Extract<
+    FirecrawlSearchToolOutput | FirecrawlScrapeToolOutput,
+    { ok: false }
+  >,
+): FirecrawlWebDataFailure {
+  return {
+    ok: false,
+    action,
+    reason: output.reason,
+    retryable: output.retryable,
+    ...(output.status == null ? {} : { status: output.status }),
+    ...(output.upstreamReason == null
+      ? {}
+      : { upstreamReason: output.upstreamReason }),
+  }
+}
+
+class FirecrawlWebDataWorkflowFailureError extends Error {
+  constructor(readonly result: FirecrawlWebDataFailure) {
+    super(`${WORKFLOW_FAILURE_ERROR_PREFIX}${JSON.stringify(result)}`)
+    this.name = "FirecrawlWebDataWorkflowFailureError"
+  }
+}
+
+function throwWorkflowFailure(result: FirecrawlWebDataResult): never {
+  if (result.ok) {
+    throw new Error("Cannot throw a successful Firecrawl web data result")
+  }
+  throw new FirecrawlWebDataWorkflowFailureError(result)
+}
+
+function parseWorkflowFailurePayload(value: unknown) {
+  const parsed = FirecrawlWebDataResultSchema.safeParse(value)
+  return parsed.success && !parsed.data.ok ? parsed.data : null
+}
+
+function workflowFailureFromUnknown(
+  value: unknown,
+): FirecrawlWebDataFailure | null {
+  if (value instanceof FirecrawlWebDataWorkflowFailureError) {
+    return value.result
+  }
+
+  const direct = parseWorkflowFailurePayload(value)
+  if (direct) return direct
+
+  const message = value instanceof Error ? value.message : String(value ?? "")
+  const prefixIndex = message.indexOf(WORKFLOW_FAILURE_ERROR_PREFIX)
+  if (prefixIndex === -1) return null
+
+  try {
+    const parsed = FirecrawlWebDataResultSchema.safeParse(
+      JSON.parse(
+        message.slice(prefixIndex + WORKFLOW_FAILURE_ERROR_PREFIX.length),
+      ),
+    )
+    return parsed.success && !parsed.data.ok ? parsed.data : null
+  } catch {
+    return null
+  }
+}
+
+function workflowFailureFromRunResult(
+  value: unknown,
+): FirecrawlWebDataFailure | null {
+  const direct = workflowFailureFromUnknown(value)
+  if (direct) return direct
+  if (typeof value !== "object" || value === null) return null
+  const record = value as {
+    error?: unknown
+    result?: unknown
+    snapshot?: unknown
+  }
+  return (
+    workflowFailureFromUnknown(record.error) ??
+    workflowFailureFromUnknown(record.result) ??
+    workflowFailureFromUnknown(record.snapshot)
+  )
+}
+
+export async function runFirecrawlWebDataWorkflow(
+  rawInput: unknown,
+  options: {
+    runId?: string
+    search?: (
+      input: FirecrawlSearchToolInput,
+    ) => Promise<FirecrawlSearchToolOutput>
+    scrape?: (
+      input: FirecrawlScrapeToolInput,
+    ) => Promise<FirecrawlScrapeToolOutput>
+  } = {},
+): Promise<FirecrawlWebDataResult> {
+  const parsed = FirecrawlWebDataInputSchema.safeParse(rawInput)
+  if (!parsed.success) return invalidInput()
+
+  const mastraRunId = options.runId ?? randomUUID()
+  const input = parsed.data
+  if (input.action === "search") {
+    const output = await (options.search ?? executeFirecrawlSearchTool)({
+      query: input.query ?? "",
+      limit: input.limit,
+      includeMarkdown: input.includeMarkdown,
+      ...(input.timeoutMs == null ? {} : { timeoutMs: input.timeoutMs }),
+    })
+    if (!output.ok) return failureFromTool("search", output)
+    return {
+      ok: true,
+      action: "search",
+      mastraRunId,
+      search: {
+        query: output.query,
+        results: output.results,
+        creditsUsed: output.creditsUsed,
+      },
+    }
+  }
+
+  const output = await (options.scrape ?? executeFirecrawlScrapeTool)({
+    url: input.url ?? "",
+    onlyMainContent: input.onlyMainContent,
+    ...(input.timeoutMs == null ? {} : { timeoutMs: input.timeoutMs }),
+  })
+  if (!output.ok) return failureFromTool("scrape", output)
+  return {
+    ok: true,
+    action: "scrape",
+    mastraRunId,
+    scrape: {
+      url: output.url,
+      markdown: output.markdown,
+      markdownTruncated: output.markdownTruncated,
+      title: output.title,
+      description: output.description,
+      statusCode: output.statusCode,
+      contentType: output.contentType,
+    },
+  }
+}
+
+const firecrawlWebDataStep = createStep({
+  id: "run-firecrawl-web-data",
+  description: "Search or scrape current public web data through Firecrawl.",
+  inputSchema: FirecrawlWebDataInputSchema,
+  outputSchema: FirecrawlWebDataResultSchema,
+  execute: async ({ inputData, runId }) => {
+    const result = await runFirecrawlWebDataWorkflow(inputData, { runId })
+    if (!result.ok) throwWorkflowFailure(result)
+    return result
+  },
+})
+
+export const firecrawlWebDataWorkflow = createWorkflow({
+  id: "firecrawl-web-data",
+  description:
+    "Run bounded Firecrawl search and scrape requests for Mastra agents and operator workflows.",
+  inputSchema: FirecrawlWebDataInputSchema,
+  outputSchema: FirecrawlWebDataResultSchema,
+})
+  .then(firecrawlWebDataStep)
+  .commit()
+
+export async function launchFirecrawlWebDataWorkflow(
+  rawInput: FirecrawlWebDataWorkflowInput,
+  options: { runId?: string } = {},
+): Promise<FirecrawlWebDataResult> {
+  const runId = options.runId ?? randomUUID()
+  const run = await firecrawlWebDataWorkflow.createRun({ runId })
+  let result: Awaited<ReturnType<typeof run.start>>
+  try {
+    result = await run.start({ inputData: rawInput })
+  } catch (error) {
+    return (
+      workflowFailureFromUnknown(error) ?? {
+        ok: false,
+        reason: "network_error",
+        retryable: true,
+      }
+    )
+  }
+  if (result?.status === "success")
+    return result.result as FirecrawlWebDataResult
+  return (
+    workflowFailureFromRunResult(result) ?? {
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+    }
+  )
+}
+
+function routeStatusForResult(result: FirecrawlWebDataResult) {
+  if (result.ok) return 200
+  if (result.reason === "invalid_input") return 400
+  if (result.reason === "config_missing") return 503
+  if (result.reason === "rate_limited") return 429
+  if (result.reason === "auth_failed") return 502
+  return result.retryable ? 503 : 502
+}
+
+export async function handleFirecrawlWebDataRouteRequest({
+  authHeader,
+  serviceKeys,
+  readJson,
+  launch = launchFirecrawlWebDataWorkflow,
+}: RouteHandlerInput): Promise<FirecrawlWebDataRouteOutcome> {
+  if (!isValidServiceBearer({ authHeader, allowlist: serviceKeys })) {
+    return {
+      status: 401,
+      body: { error: "Service bearer required" },
+    }
+  }
+
+  const runId = randomUUID()
+  let body: unknown
+  try {
+    body = await readJson()
+  } catch {
+    return {
+      status: 400,
+      body: { result: invalidInput(), error: "Invalid JSON" },
+    }
+  }
+
+  const parsed = FirecrawlWebDataInputSchema.safeParse(body)
+  let result: FirecrawlWebDataResult
+  if (parsed.success) {
+    try {
+      result = await launch(parsed.data, { runId })
+    } catch {
+      result = { ok: false, reason: "network_error", retryable: true }
+    }
+  } else {
+    result = invalidInput()
+  }
+
+  return {
+    status: routeStatusForResult(result),
+    body: { result },
+  }
+}
+
+export const _internal = {
+  FirecrawlWebDataInputSchema,
+  workflowFailureFromUnknown,
+  workflowFailureFromRunResult,
+}

--- a/apps/mastra/src/services/firecrawl-client.test.ts
+++ b/apps/mastra/src/services/firecrawl-client.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  scrapeFirecrawl,
+  searchFirecrawl,
+  type FirecrawlConfig,
+} from "./firecrawl-client"
+
+const testConfig: FirecrawlConfig = {
+  apiKey: "firecrawl-key",
+  apiUrl: "https://api.firecrawl.dev",
+  timeoutMs: 60_000,
+  userAgent: "forge-test-firecrawl/1.0",
+  maxSearchResults: 2,
+  maxMarkdownCharacters: 12,
+}
+
+function jsonResponse(
+  body: unknown,
+  init: ResponseInit = {},
+): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status: init.status ?? 200,
+      headers: {
+        "content-type": "application/json",
+        ...Object.fromEntries(new Headers(init.headers).entries()),
+      },
+    }),
+  )
+}
+
+describe("Firecrawl client", () => {
+  it("searches with bounded limits and truncates hydrated markdown", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      jsonResponse({
+        success: true,
+        data: {
+          web: [
+            {
+              title: "One",
+              description: "First result",
+              url: "https://example.com/one",
+              markdown: "abcdefghijklmnop",
+            },
+            {
+              title: "Two",
+              description: null,
+              url: "https://example.com/two",
+            },
+            {
+              title: "Three",
+              description: "Third result",
+              url: "https://example.com/three",
+            },
+          ],
+        },
+        creditsUsed: 3,
+      }),
+    )
+
+    const result = await searchFirecrawl({
+      query: "firecrawl mastra",
+      limit: 10,
+      includeMarkdown: true,
+      config: testConfig,
+      fetchImpl,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      result: {
+        query: "firecrawl mastra",
+        creditsUsed: 3,
+        results: [
+          {
+            title: "One",
+            description: "First result",
+            url: "https://example.com/one",
+            markdown: "abcdefghi...",
+            markdownTruncated: true,
+          },
+          {
+            title: "Two",
+            description: null,
+            url: "https://example.com/two",
+            markdown: null,
+            markdownTruncated: false,
+          },
+        ],
+      },
+    })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL("https://api.firecrawl.dev/v2/search"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: "Bearer firecrawl-key",
+          "user-agent": "forge-test-firecrawl/1.0",
+        }),
+        body: JSON.stringify({
+          query: "firecrawl mastra",
+          limit: 2,
+          sources: ["web"],
+          timeout: 60_000,
+          ignoreInvalidURLs: true,
+          scrapeOptions: {
+            formats: ["markdown"],
+            onlyMainContent: true,
+            timeout: 60_000,
+          },
+        }),
+      }),
+    )
+  })
+
+  it("scrapes a known URL into bounded markdown and safe metadata", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      jsonResponse({
+        success: true,
+        data: {
+          markdown: "long page markdown",
+          metadata: {
+            title: "Example",
+            description: "Example description",
+            sourceURL: "https://example.com/source",
+            statusCode: 200,
+            contentType: "text/html",
+          },
+        },
+      }),
+    )
+
+    const result = await scrapeFirecrawl({
+      url: "https://example.com",
+      config: testConfig,
+      fetchImpl,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      result: {
+        url: "https://example.com/source",
+        markdown: "long page...",
+        markdownTruncated: true,
+        title: "Example",
+        description: "Example description",
+        statusCode: 200,
+        contentType: "text/html",
+      },
+    })
+  })
+
+  it("returns config_missing without making a request when the key is absent", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    const result = await searchFirecrawl({
+      query: "firecrawl",
+      config: { ...testConfig, apiKey: undefined },
+      fetchImpl,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "config_missing",
+      retryable: false,
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it("retries rate limits using retry-after before returning success", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(() =>
+        jsonResponse(
+          { error: "rate limited" },
+          { status: 429, headers: { "retry-after": "1" } },
+        ),
+      )
+      .mockImplementationOnce(() =>
+        jsonResponse({ success: true, data: { web: [] }, creditsUsed: 1 }),
+      )
+    const sleep = vi.fn(async () => {})
+
+    const result = await searchFirecrawl({
+      query: "firecrawl",
+      config: testConfig,
+      fetchImpl,
+      sleep,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      result: { query: "firecrawl", results: [], creditsUsed: 1 },
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(1000)
+  })
+
+  it("returns retryable network_error when 5xx retries are exhausted", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      jsonResponse({ error: "upstream down" }, { status: 503 }),
+    )
+    const sleep = vi.fn(async () => {})
+
+    const result = await scrapeFirecrawl({
+      url: "https://example.com",
+      config: testConfig,
+      fetchImpl,
+      maxAttempts: 2,
+      sleep,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+      status: 503,
+      upstreamReason: "upstream down",
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(500)
+  })
+
+  it("does not retry credential failures", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      jsonResponse({ error: "bad key" }, { status: 401 }),
+    )
+
+    const result = await scrapeFirecrawl({
+      url: "https://example.com",
+      config: testConfig,
+      fetchImpl,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "auth_failed",
+      retryable: false,
+      status: 401,
+      upstreamReason: "bad key",
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps tiny markdown caps exact", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      jsonResponse({
+        success: true,
+        data: {
+          markdown: "abcdef",
+          metadata: {
+            sourceURL: "https://example.com",
+          },
+        },
+      }),
+    )
+
+    const result = await scrapeFirecrawl({
+      url: "https://example.com",
+      config: { ...testConfig, maxMarkdownCharacters: 2 },
+      fetchImpl,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        markdown: "..",
+        markdownTruncated: true,
+      },
+    })
+  })
+
+  it("maps invalid JSON to a retryable parse failure", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      Promise.resolve(
+        new Response("not-json", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    )
+
+    const result = await searchFirecrawl({
+      query: "firecrawl",
+      config: testConfig,
+      fetchImpl,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "parse_error",
+      retryable: true,
+      status: 200,
+    })
+  })
+})

--- a/apps/mastra/src/services/firecrawl-client.ts
+++ b/apps/mastra/src/services/firecrawl-client.ts
@@ -1,0 +1,462 @@
+import { z } from "zod"
+
+import { getFirecrawlConfig, type FirecrawlConfig } from "../config/env"
+
+export type { FirecrawlConfig } from "../config/env"
+
+export type FirecrawlClientFailure = {
+  ok: false
+  reason:
+    | "config_missing"
+    | "auth_failed"
+    | "network_error"
+    | "rate_limited"
+    | "rejected"
+    | "parse_error"
+    | "invalid_response"
+  retryable: boolean
+  status?: number
+  upstreamReason?: string
+}
+
+export type FirecrawlClientResult<TResult> =
+  | { ok: true; result: TResult }
+  | FirecrawlClientFailure
+
+export type FirecrawlSearchResult = {
+  title: string | null
+  url: string
+  description: string | null
+  markdown: string | null
+  markdownTruncated: boolean
+}
+
+export type FirecrawlSearchResponse = {
+  query: string
+  results: FirecrawlSearchResult[]
+  creditsUsed: number | null
+}
+
+export type FirecrawlScrapeResponse = {
+  url: string
+  markdown: string
+  markdownTruncated: boolean
+  title: string | null
+  description: string | null
+  statusCode: number | null
+  contentType: string | null
+}
+
+export type FirecrawlSearchInput = {
+  query: string
+  limit?: number
+  includeMarkdown?: boolean
+  timeoutMs?: number
+  config?: FirecrawlConfig
+  fetchImpl?: typeof fetch
+  maxAttempts?: number
+  sleep?: (ms: number) => Promise<void>
+}
+
+export type FirecrawlScrapeInput = {
+  url: string
+  onlyMainContent?: boolean
+  timeoutMs?: number
+  config?: FirecrawlConfig
+  fetchImpl?: typeof fetch
+  maxAttempts?: number
+  sleep?: (ms: number) => Promise<void>
+}
+
+const SearchResultSchema = z
+  .object({
+    title: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    url: z.string().url(),
+    markdown: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+const SearchDataSchema = z
+  .object({
+    web: z.array(SearchResultSchema).default([]),
+  })
+  .passthrough()
+
+const SearchResponseSchema = z.union([
+  z
+    .object({
+      success: z.boolean().optional(),
+      data: SearchDataSchema,
+      creditsUsed: z.number().nullable().optional(),
+    })
+    .passthrough()
+    .transform((body) => ({
+      success: body.success,
+      web: body.data.web,
+      creditsUsed: body.creditsUsed ?? null,
+    })),
+  z
+    .object({
+      success: z.boolean().optional(),
+      web: z.array(SearchResultSchema).default([]),
+      creditsUsed: z.number().nullable().optional(),
+    })
+    .passthrough()
+    .transform((body) => ({
+      success: body.success,
+      web: body.web,
+      creditsUsed: body.creditsUsed ?? null,
+    })),
+])
+
+const ScrapeMetadataSchema = z
+  .object({
+    title: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    sourceURL: z.string().nullable().optional(),
+    url: z.string().nullable().optional(),
+    statusCode: z.number().nullable().optional(),
+    contentType: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+const ScrapeDataSchema = z
+  .object({
+    markdown: z.string().nullable().optional(),
+    metadata: ScrapeMetadataSchema.nullable().optional(),
+  })
+  .passthrough()
+
+const ScrapeResponseSchema = z.union([
+  z
+    .object({
+      success: z.boolean().optional(),
+      data: ScrapeDataSchema,
+    })
+    .passthrough()
+    .transform((body) => ({
+      success: body.success,
+      markdown: body.data.markdown ?? "",
+      metadata: body.data.metadata ?? null,
+    })),
+  z
+    .object({
+      success: z.boolean().optional(),
+      markdown: z.string().nullable().optional(),
+      metadata: ScrapeMetadataSchema.nullable().optional(),
+    })
+    .passthrough()
+    .transform((body) => ({
+      success: body.success,
+      markdown: body.markdown ?? "",
+      metadata: body.metadata ?? null,
+    })),
+])
+
+function clampLimit(value: number | undefined, max: number): number {
+  if (value == null) return max
+  return Math.max(1, Math.min(value, max))
+}
+
+function endpoint(apiUrl: string, path: string): URL {
+  const normalized = apiUrl.endsWith("/") ? apiUrl : `${apiUrl}/`
+  return new URL(path, normalized)
+}
+
+function retryAfterMs(value: string | null): number | null {
+  if (value == null) return null
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, 60_000)
+  }
+  return null
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(500 * 2 ** (attempt - 1), 30_000)
+}
+
+function truncateText(
+  value: string | null | undefined,
+  maxCharacters: number,
+): { text: string; truncated: boolean } {
+  const text = value ?? ""
+  const codepoints = Array.from(text)
+  if (codepoints.length <= maxCharacters) {
+    return { text, truncated: false }
+  }
+  if (maxCharacters <= 3) {
+    return {
+      text: "...".slice(0, maxCharacters),
+      truncated: true,
+    }
+  }
+  return {
+    text: `${codepoints.slice(0, Math.max(0, maxCharacters - 3)).join("")}...`,
+    truncated: true,
+  }
+}
+
+function safeReason(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined
+  const codepoints = Array.from(value)
+  return codepoints.length <= 300
+    ? value
+    : `${codepoints.slice(0, 297).join("")}...`
+}
+
+async function readUpstreamReason(
+  response: Response,
+): Promise<string | undefined> {
+  const body = await response.json().catch(() => undefined)
+  if (!body || typeof body !== "object" || Array.isArray(body)) return undefined
+  const record = body as { error?: unknown; message?: unknown }
+  return safeReason(record.error) ?? safeReason(record.message)
+}
+
+function failureForStatus(
+  status: number,
+  upstreamReason?: string,
+): FirecrawlClientFailure {
+  if (status === 401 || status === 403) {
+    return {
+      ok: false,
+      reason: "auth_failed",
+      retryable: false,
+      status,
+      upstreamReason,
+    }
+  }
+  if (status === 429) {
+    return {
+      ok: false,
+      reason: "rate_limited",
+      retryable: true,
+      status,
+      upstreamReason,
+    }
+  }
+  return {
+    ok: false,
+    reason: status >= 400 && status < 500 ? "rejected" : "network_error",
+    retryable: status >= 500,
+    status,
+    upstreamReason,
+  }
+}
+
+async function postFirecrawlJson<TResult>({
+  path,
+  payload,
+  schema,
+  config,
+  timeoutMs,
+  fetchImpl,
+  maxAttempts,
+  sleep,
+}: {
+  path: string
+  payload: unknown
+  schema: z.ZodType<TResult>
+  config: FirecrawlConfig
+  timeoutMs?: number
+  fetchImpl: typeof fetch
+  maxAttempts: number
+  sleep: (ms: number) => Promise<void>
+}): Promise<FirecrawlClientResult<TResult>> {
+  if (!config.apiKey) {
+    return { ok: false, reason: "config_missing", retryable: false }
+  }
+
+  let lastFailure: FirecrawlClientFailure | null = null
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let response: Response
+    try {
+      response = await fetchImpl(endpoint(config.apiUrl, path), {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${config.apiKey}`,
+          "content-type": "application/json",
+          "user-agent": config.userAgent,
+        },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(timeoutMs ?? config.timeoutMs),
+      })
+    } catch {
+      lastFailure = { ok: false, reason: "network_error", retryable: true }
+      if (attempt < maxAttempts) {
+        await sleep(backoffMs(attempt))
+        continue
+      }
+      return lastFailure
+    }
+
+    if (response.status === 429) {
+      lastFailure = failureForStatus(
+        response.status,
+        await readUpstreamReason(response),
+      )
+      if (attempt < maxAttempts) {
+        await sleep(
+          retryAfterMs(response.headers.get("retry-after")) ??
+            backoffMs(attempt),
+        )
+        continue
+      }
+      return lastFailure
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      return failureForStatus(
+        response.status,
+        await readUpstreamReason(response),
+      )
+    }
+
+    if (!response.ok) {
+      const failure = failureForStatus(
+        response.status,
+        await readUpstreamReason(response),
+      )
+      if (failure.retryable && attempt < maxAttempts) {
+        await sleep(backoffMs(attempt))
+        continue
+      }
+      return failure
+    }
+
+    const body = await response.json().catch(() => undefined)
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return {
+        ok: false,
+        reason: "parse_error",
+        retryable: true,
+        status: response.status,
+      }
+    }
+    const parsedRecord = parsed.data as { success?: boolean }
+    if (parsedRecord.success === false) {
+      return {
+        ok: false,
+        reason: "invalid_response",
+        retryable: true,
+        status: response.status,
+      }
+    }
+
+    return { ok: true, result: parsed.data }
+  }
+
+  return lastFailure ?? { ok: false, reason: "network_error", retryable: true }
+}
+
+export async function searchFirecrawl({
+  query,
+  limit,
+  includeMarkdown = false,
+  timeoutMs,
+  config = getFirecrawlConfig(),
+  fetchImpl = fetch,
+  maxAttempts = 3,
+  sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+}: FirecrawlSearchInput): Promise<
+  FirecrawlClientResult<FirecrawlSearchResponse>
+> {
+  const effectiveLimit = clampLimit(limit, config.maxSearchResults)
+  const response = await postFirecrawlJson({
+    path: "v2/search",
+    payload: {
+      query,
+      limit: effectiveLimit,
+      sources: ["web"],
+      timeout: timeoutMs ?? config.timeoutMs,
+      ignoreInvalidURLs: true,
+      ...(includeMarkdown
+        ? {
+            scrapeOptions: {
+              formats: ["markdown"],
+              onlyMainContent: true,
+              timeout: timeoutMs ?? config.timeoutMs,
+            },
+          }
+        : {}),
+    },
+    schema: SearchResponseSchema,
+    config,
+    timeoutMs,
+    fetchImpl,
+    maxAttempts,
+    sleep,
+  })
+  if (!response.ok) return response
+
+  return {
+    ok: true,
+    result: {
+      query,
+      creditsUsed: response.result.creditsUsed,
+      results: response.result.web.slice(0, effectiveLimit).map((item) => {
+        const markdown = truncateText(
+          item.markdown,
+          config.maxMarkdownCharacters,
+        )
+        return {
+          title: item.title ?? null,
+          url: item.url,
+          description: item.description ?? null,
+          markdown: item.markdown == null ? null : markdown.text,
+          markdownTruncated: item.markdown == null ? false : markdown.truncated,
+        }
+      }),
+    },
+  }
+}
+
+export async function scrapeFirecrawl({
+  url,
+  onlyMainContent = true,
+  timeoutMs,
+  config = getFirecrawlConfig(),
+  fetchImpl = fetch,
+  maxAttempts = 3,
+  sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+}: FirecrawlScrapeInput): Promise<
+  FirecrawlClientResult<FirecrawlScrapeResponse>
+> {
+  const response = await postFirecrawlJson({
+    path: "v2/scrape",
+    payload: {
+      url,
+      formats: ["markdown"],
+      onlyMainContent,
+      timeout: timeoutMs ?? config.timeoutMs,
+    },
+    schema: ScrapeResponseSchema,
+    config,
+    timeoutMs,
+    fetchImpl,
+    maxAttempts,
+    sleep,
+  })
+  if (!response.ok) return response
+
+  const markdown = truncateText(
+    response.result.markdown,
+    config.maxMarkdownCharacters,
+  )
+  const metadata = response.result.metadata
+  return {
+    ok: true,
+    result: {
+      url: metadata?.sourceURL ?? metadata?.url ?? url,
+      markdown: markdown.text,
+      markdownTruncated: markdown.truncated,
+      title: metadata?.title ?? null,
+      description: metadata?.description ?? null,
+      statusCode: metadata?.statusCode ?? null,
+      contentType: metadata?.contentType ?? null,
+    },
+  }
+}

--- a/docs/plans/2026-06-08-001-feat-mastra-firecrawl-web-data-tools-plan.md
+++ b/docs/plans/2026-06-08-001-feat-mastra-firecrawl-web-data-tools-plan.md
@@ -1,0 +1,266 @@
+---
+title: "feat: Add Mastra Firecrawl web data tools"
+type: feat
+status: complete
+date: 2026-06-08
+roadmap: docs/roadmap/platform/feat-169-mastra-firecrawl-web-data-tools.md
+---
+
+# feat: Add Mastra Firecrawl Web Data Tools
+
+## Summary
+
+Add a governed Firecrawl integration to `apps/mastra` so Mastra agents can call
+web search/scrape tools and workflows can run deterministic Firecrawl search or
+scrape steps. Firecrawl remains Mastra-owned runtime infrastructure: Manager and
+Admin keep calling Mastra through service-bearer contracts rather than holding
+Firecrawl credentials or running ad-hoc MCP bridges.
+
+## Problem Frame
+
+The Mastra runtime is now the shared Forge agent/workflow service, but it has no
+first-party live web data capability. Firecrawl offers both a Mastra SDK/tool
+integration and an MCP server. For this repository, the production path should
+prefer Mastra-native tools backed by a local service wrapper because
+`apps/mastra` already owns runtime execution, env validation, redaction,
+service-bearer routes, and Studio-visible workflows.
+
+MCP remains useful for local exploration or exposing capabilities to external
+MCP clients, but it should not be the primary production bridge for this slice.
+
+## Requirements
+
+- R1. Mastra has a Firecrawl client/service that supports bounded web search and
+  single-page scrape operations.
+- R2. The Firecrawl integration is configured only through Mastra-owned env
+  vars, with production assertions for credentials and allowed API host.
+- R3. Agents can use Firecrawl through Mastra `createTool` tools with strict
+  input and output schemas.
+- R4. Workflows can use the same shared Firecrawl service directly through a
+  Studio-friendly workflow and a service-bearer route.
+- R5. Firecrawl errors map to safe typed failures without leaking API keys,
+  auth headers, cookies, or raw upstream bodies.
+- R6. Search and scrape outputs are bounded by configured limits and caller
+  input caps.
+- R7. Existing Mastra embedding, search-eval, and smoke behavior remains
+  unchanged except for additive registration of the new agent/workflow.
+
+## Assumptions
+
+- A dedicated `webResearchAgent` is the right first agent surface; existing
+  smoke and embedding workflows should not gain web access implicitly.
+- The initial workflow should expose only search and scrape. Crawl, batch
+  scrape, extract, browser interaction, and MCP exposure are follow-up scope.
+- Direct REST through a local service wrapper is acceptable even though
+  Firecrawl's Mastra quickstart shows the SDK; this preserves tighter response
+  validation, retries, testability, and egress checks in Forge code.
+- `FIRECRAWL_API_KEY` should be required for production Mastra runtime once this
+  capability ships because the workflow/agent will be registered in production.
+
+## Key Technical Decisions
+
+- KTD1. **Mastra service wrapper first:** Create a local Firecrawl client under
+  `apps/mastra/src/services/` that owns HTTP calls, input/output bounds, typed
+  failures, retries, and fetch injection.
+- KTD2. **Tools are thin adapters:** Mastra tools should call the shared service
+  and return bounded DTOs. They should not duplicate Firecrawl HTTP logic.
+- KTD3. **Workflow proves deterministic use:** Add a small workflow that calls
+  the shared service directly rather than asking an LLM to tool-call Firecrawl.
+  This proves workflow access and gives service callers a stable API.
+- KTD4. **Dedicated agent registration:** Add a web research agent with only the
+  Firecrawl tools. Do not attach web tools to `smokeAgent` or existing
+  embedding/search-eval workflows.
+- KTD5. **MCP deferred:** Do not add `@mastra/mcp` or Firecrawl MCP server
+  runtime configuration in this PR. If external MCP clients need Forge's tools
+  later, expose Forge-owned Mastra tools as MCP after the first-party surface is
+  proven.
+
+## Implementation Units
+
+### U1. Firecrawl Env And Package Docs
+
+**Goal:** Add Mastra-owned Firecrawl configuration and document the production
+contract.
+
+**Requirements:** R2, R5, R7
+
+**Files:**
+
+- Modify: `apps/mastra/src/config/env.ts`
+- Modify: `apps/mastra/src/config/env.test.ts`
+- Modify: `apps/mastra/AGENTS.md`
+- Modify: `apps/mastra/CLAUDE.md`
+- Modify: `apps/mastra/package.json` if an SDK dependency is still chosen
+  during implementation.
+
+**Approach:** Add Firecrawl env values for API key, API URL, allowed hosts,
+timeout, search result cap, scrape content cap, and user agent. Production
+assertions should require the key and ensure the API URL is HTTPS and on the
+allowlist. Keep local/test env optional so unit tests can mock the client.
+
+**Patterns to follow:** Gateway env validation in `apps/mastra/src/config/env.ts`
+and production assertion coverage in `apps/mastra/src/config/env.test.ts`.
+
+**Test scenarios:**
+
+- Production without `FIRECRAWL_API_KEY` fails env assertion.
+- Production rejects a non-HTTPS or non-allowlisted Firecrawl API URL.
+- Development/test can parse without a Firecrawl key.
+- Defaults are stable for timeout, user agent, and output caps.
+
+**Verification:** Focused env tests pass and docs list the new env contract.
+
+### U2. Shared Firecrawl Client
+
+**Goal:** Implement a reusable service client for Firecrawl search and scrape.
+
+**Requirements:** R1, R5, R6
+
+**Files:**
+
+- Create: `apps/mastra/src/services/firecrawl-client.ts`
+- Create: `apps/mastra/src/services/firecrawl-client.test.ts`
+
+**Approach:** Use Firecrawl's v2 REST API behind a typed local wrapper. Model
+success and failure as discriminated unions, validate response shape with Zod,
+inject `fetchImpl` and `sleep` for tests, apply timeouts, and retry only
+retryable failures such as 429 and 5xx within a small bounded attempt budget.
+Return compact search results and bounded scrape markdown/metadata rather than
+raw upstream responses.
+
+**Patterns to follow:** HTTP client/test shape in
+`apps/mastra/src/services/admin-search-eval-client.ts`; provider error safety in
+`apps/mastra/src/services/embedding-provider.ts`.
+
+**Test scenarios:**
+
+- Search posts a query and returns bounded web results with title, url,
+  description, and optional markdown.
+- Scrape posts a URL and returns bounded markdown plus safe metadata.
+- Missing key returns a config failure without attempting fetch.
+- 429 and 5xx retry, then return retryable typed failures when exhausted.
+- 401/403 return non-retryable auth failures.
+- Invalid JSON or malformed success bodies return parse/invalid-response
+  failures.
+- Returned markdown is truncated to the configured cap.
+
+**Verification:** Firecrawl client tests pass without live Firecrawl network
+access.
+
+### U3. Mastra Tools And Agent
+
+**Goal:** Make Firecrawl available to Mastra agents through typed tools and a
+dedicated web research agent.
+
+**Requirements:** R3, R5, R6, R7
+
+**Files:**
+
+- Create: `apps/mastra/src/mastra/tools/firecrawl.ts`
+- Create: `apps/mastra/src/mastra/tools/firecrawl.test.ts`
+- Create: `apps/mastra/src/mastra/agents/web-research-agent.ts`
+- Modify: `apps/mastra/src/mastra/index.ts`
+
+**Approach:** Create `firecrawlSearchTool` and `firecrawlScrapeTool` with
+strict Zod schemas and bounded caller-controlled options. The web research
+agent should explain when to search first versus scrape a known URL, and should
+avoid treating scraped page text as trusted instructions. Register it alongside
+the smoke agent without altering the smoke agent.
+
+**Patterns to follow:** Agent registration in
+`apps/mastra/src/mastra/agents/smoke-agent.ts` and Mastra tool docs.
+
+**Test scenarios:**
+
+- Tool schemas reject empty queries and invalid URLs.
+- Tool execution delegates to the shared service and returns bounded DTOs.
+- Upstream typed failures throw or return safe messages without secrets.
+- `apps/mastra/src/mastra/index.ts` registers both `smokeAgent` and
+  `webResearchAgent`.
+
+**Verification:** Tool and agent registration tests pass.
+
+### U4. Firecrawl Workflow And Service Route
+
+**Goal:** Prove workflows and service callers can use Firecrawl
+deterministically.
+
+**Requirements:** R4, R5, R6, R7
+
+**Files:**
+
+- Create: `apps/mastra/src/mastra/workflows/firecrawl-web-data.ts`
+- Create: `apps/mastra/src/mastra/workflows/firecrawl-web-data.test.ts`
+- Modify: `apps/mastra/src/mastra/index.ts`
+
+**Approach:** Add a Studio-friendly workflow with an action enum for `search`
+or `scrape`, strict input schemas, default limits, and safe typed output. Add
+a `/forge-firecrawl-web-data` API route protected by the existing
+`MASTRA_SERVICE_API_KEYS` service-bearer helper so Manager/Admin can call the
+workflow later without direct Firecrawl credentials.
+
+**Patterns to follow:** Route and workflow failure extraction in
+`apps/mastra/src/mastra/workflows/offline-search-eval.ts`; service-bearer route
+registration in `apps/mastra/src/mastra/index.ts`.
+
+**Test scenarios:**
+
+- Missing or invalid bearer receives 401 and no Firecrawl call runs.
+- Invalid request JSON returns a typed invalid-input response.
+- Search action runs the workflow/service path and returns bounded results.
+- Scrape action runs the workflow/service path and returns bounded markdown.
+- Service failures become route-safe typed failures with retryable metadata.
+- Workflow metadata exposes a structured input schema suitable for Studio.
+
+**Verification:** Workflow tests pass and the workflow is registered in Mastra.
+
+### U5. Package Validation And Roadmap Closeout
+
+**Goal:** Validate the Mastra package and mark the roadmap/plan complete.
+
+**Requirements:** R1-R7
+
+**Files:**
+
+- Modify: `docs/roadmap/platform/feat-169-mastra-firecrawl-web-data-tools.md`
+- Modify: `docs/plans/2026-06-08-001-feat-mastra-firecrawl-web-data-tools-plan.md`
+
+**Approach:** Run focused Mastra validation. Because this is internal
+runtime/API/tooling work, browser proof is expected to be a no-op unless the
+pipeline runner detects a runnable Studio surface.
+
+**Test scenarios:** Covered by U1-U4.
+
+**Verification:**
+
+- `pnpm --filter @forge/mastra test`
+- `pnpm --filter @forge/mastra typecheck`
+- `pnpm --filter @forge/mastra lint`
+
+## Scope Boundaries
+
+- No Firecrawl MCP runtime configuration in this PR.
+- No crawl, batch scrape, extract, monitor, browser-session, or deep-research
+  tools in this first slice.
+- No direct Firecrawl usage in Manager/Admin.
+- No changes to existing embedding, search-eval, or production search
+  workflows beyond additive Mastra registration.
+- No live Firecrawl integration test requiring a real API key.
+
+## Dependencies
+
+- Firecrawl API key must be provisioned in Mastra runtime env before production
+  usage.
+- Railway egress must allow the configured Firecrawl API host.
+- Existing Mastra service-bearer callers remain responsible for presenting a
+  valid `Authorization: Bearer <token>` header when invoking `/forge-*` routes.
+
+## External References
+
+- Firecrawl Mastra quickstart: `https://docs.firecrawl.dev/quickstarts/mastra`
+- Firecrawl Node.js quickstart: `https://docs.firecrawl.dev/quickstarts/nodejs`
+- Firecrawl API v2 introduction: `https://docs.firecrawl.dev/api-reference/v2-introduction`
+- Firecrawl search endpoint: `https://docs.firecrawl.dev/api-reference/endpoint/search`
+- Firecrawl scrape endpoint: `https://docs.firecrawl.dev/api-reference/endpoint/scrape`
+- Mastra tools docs: `https://mastra.ai/docs/agents/using-tools`
+- Mastra MCPServer docs: `https://mastra.ai/reference/tools/mcp-server`

--- a/docs/roadmap/platform/feat-129-mastra-railway-workflow-runtime.md
+++ b/docs/roadmap/platform/feat-129-mastra-railway-workflow-runtime.md
@@ -10,6 +10,7 @@ depends_on:
   - "feat-121"
 blocks:
   - "feat-132"
+  - "feat-169"
 tags:
   - "platform"
   - "manager"

--- a/docs/roadmap/platform/feat-169-mastra-firecrawl-web-data-tools.md
+++ b/docs/roadmap/platform/feat-169-mastra-firecrawl-web-data-tools.md
@@ -1,0 +1,73 @@
+---
+id: "feat-169"
+title: "Mastra Firecrawl web data tools"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-08"
+duration: 2
+depends_on:
+  - "feat-129"
+blocks: []
+tags:
+  - "platform"
+  - "mastra"
+  - "agents"
+  - "ai-pipeline"
+  - "external-api"
+---
+
+## Problem
+
+Forge's Mastra runtime can run agents and workflows, but it has no governed way
+to search or scrape live web pages. Operators and future Manager-driven
+workflows need Firecrawl-backed web data access without putting Firecrawl
+credentials in Manager/Admin, bypassing Mastra's service-bearer boundary, or
+depending on an ad-hoc MCP bridge for production behavior.
+
+## Entry Points - Read These First
+
+1. `apps/mastra/AGENTS.md` - Mastra ownership boundaries and validation commands.
+2. `apps/mastra/src/mastra/index.ts` - registered agents, workflows, and
+   service-bearer API routes.
+3. `apps/mastra/src/config/env.ts` - Mastra runtime env parsing and production
+   assertions.
+4. `apps/mastra/src/services/admin-search-eval-client.ts` - local HTTP client
+   pattern for typed failures, retries, and injectable fetch.
+5. `apps/mastra/src/mastra/agents/smoke-agent.ts` - current agent registration
+   baseline.
+6. `docs/roadmap/platform/feat-129-mastra-railway-workflow-runtime.md` -
+   service-bearer and Studio gateway constraints.
+
+## What To Build
+
+1. Add Mastra-owned Firecrawl configuration for API key, optional API URL,
+   timeout, result caps, and production egress validation.
+2. Add a shared Firecrawl client service with typed search and scrape contracts,
+   response validation, safe error mapping, and injectable fetch for tests.
+3. Expose Firecrawl search and scrape as Mastra tools that agents can use.
+4. Register a dedicated web research agent with those tools, keeping the smoke
+   agent isolated.
+5. Add a small Studio-friendly workflow and service-bearer route so workflows
+   and non-browser callers can exercise deterministic Firecrawl search/scrape.
+6. Document env vars and boundaries in the Mastra package guide.
+
+## Constraints
+
+- Do not import from `apps/admin`, `apps/manager`, or `apps/auth`.
+- Do not log Firecrawl API keys, raw auth headers, cookies, or unnecessary page
+  content.
+- Do not make Firecrawl MCP the production runtime dependency for this slice.
+- Do not add Firecrawl calls to existing embedding or search-eval workflows in
+  this PR.
+- Do not expose Firecrawl service routes without Mastra service-bearer checks.
+- Keep output bounded so Studio/tool responses cannot return unbounded page
+  content.
+
+## Verification
+
+- `pnpm --filter @forge/mastra test`
+- `pnpm --filter @forge/mastra typecheck`
+- `pnpm --filter @forge/mastra lint`
+- Mastra Studio lists the Firecrawl workflow and the web research agent when
+  local env enables the runtime.


### PR DESCRIPTION
## Summary

- add Mastra-owned Firecrawl env/config, production egress checks, and a typed v2 REST client for search/scrape
- expose `firecrawlSearch` and `firecrawlScrape` as Mastra tools plus a dedicated `webResearchAgent`
- add the `firecrawl-web-data` workflow and `/forge-firecrawl-web-data` service-bearer route for deterministic workflow/service access
- document the "tools/workflow first, MCP deferred" runtime decision and close the roadmap ticket

## Validation

- `pnpm --filter @forge/mastra test -- src/config/env.test.ts src/services/firecrawl-client.test.ts src/mastra/tools/firecrawl.test.ts src/mastra/workflows/firecrawl-web-data.test.ts src/mastra/agents/smoke-agent.test.ts`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/mastra lint`
- `pnpm --filter @forge/mastra test`
- `pnpm --filter @forge/mastra build`
- Local Mastra Studio/API smoke:
  - `/api/agents` includes `webResearchAgent`
  - `/api/tools` includes `firecrawlSearchTool` and `firecrawlScrapeTool`
  - `/api/workflows` includes `firecrawlWebDataWorkflow`
  - `POST /forge-firecrawl-web-data` with service bearer and invalid search input returns typed `invalid_input`
