### PR TITLE
fix(admin): preserve qwen migration history on revert

### DIFF
--- a/apps/admin/prisma/migrations/0032_video_embedding_qwen/migration.sql
+++ b/apps/admin/prisma/migrations/0032_video_embedding_qwen/migration.sql
@@ -1,0 +1,9 @@
+-- Superseded Qwen video embedding migration.
+--
+-- This migration name was previously introduced by the reverted Qwen rollout.
+-- Keep the migration present so Prisma can recover production migration
+-- history for 0032_video_embedding_qwen without replaying the original HNSW
+-- index build. The next migration, 0033_drop_video_embedding_qwen, removes any
+-- Qwen columns or indexes that already exist from a successful or partial 0032.
+
+SELECT 1;

--- a/apps/admin/prisma/migrations/0033_drop_video_embedding_qwen/migration.sql
+++ b/apps/admin/prisma/migrations/0033_drop_video_embedding_qwen/migration.sql
@@ -1,0 +1,18 @@
+-- Forward-only revert of 0032_video_embedding_qwen.
+--
+-- Keep 0032 in the migration chain so production databases with a recorded
+-- 0032 state can recover cleanly, then remove the Qwen-only artifacts from
+-- the live schema to match the reverted Prisma schema.
+
+DROP INDEX IF EXISTS "video_scene_locale_embedding_qwen_hnsw_fr";
+DROP INDEX IF EXISTS "video_scene_locale_embedding_qwen_hnsw_es";
+DROP INDEX IF EXISTS "video_scene_locale_embedding_qwen_hnsw_en";
+DROP INDEX IF EXISTS "video_scene_locale_embedding_qwen_hnsw";
+
+DROP INDEX IF EXISTS "video_transcript_chunk_embedding_qwen_hnsw_fr";
+DROP INDEX IF EXISTS "video_transcript_chunk_embedding_qwen_hnsw_es";
+DROP INDEX IF EXISTS "video_transcript_chunk_embedding_qwen_hnsw_en";
+DROP INDEX IF EXISTS "video_transcript_chunk_embedding_qwen_hnsw";
+
+ALTER TABLE "video_scene_locale" DROP COLUMN IF EXISTS "embedding_qwen";
+ALTER TABLE "video_transcript_chunk" DROP COLUMN IF EXISTS "embedding_qwen";


### PR DESCRIPTION
## Summary
- keep `0032_video_embedding_qwen` present as an intentional no-op so Prisma can reconcile production migration history
- add `0033_drop_video_embedding_qwen` as a forward-only cleanup of any Qwen columns and indexes from successful or partial prior attempts
- keep app code and Prisma schema reverted while avoiding an expensive replay of the original HNSW index build

## Context
Production Railway deploy for 287eb560 failed on @forge/admin and @forge/admin/worker after PR #1166 deleted the 0032 migration file. This hotfix keeps the database migration chain forward-only while preserving the feature revert.

## Verification
- DATABASE_URL=postgresql://user:pass@localhost:5432/db pnpm --filter @forge/admin exec prisma validate
- pnpm run format:check
- pnpm --filter @forge/admin run --if-present lint --max-warnings=0
- pnpm --filter @forge/admin exec vitest run src/scripts/migrate-deploy-known-recovery.test.ts

## Deployment note
No local Railway auth is available in this session, so production log inspection still depends on the Railway integration status/checks after merge.