### PR TITLE
fix(admin): retry transient migrate deploy saturation

### DIFF
--- a/apps/admin/src/scripts/migrate-deploy-known-recovery.test.ts
+++ b/apps/admin/src/scripts/migrate-deploy-known-recovery.test.ts
@@ -6,6 +6,7 @@ import {
   deployWithKnownRecovery,
   getKnownRecoverableP3009Migration,
   isKnownRecoverableP3009,
+  isTransientPrismaDeployFailure,
   type CommandResult,
 } from "./migrate-deploy-known-recovery"
 
@@ -31,6 +32,22 @@ describe("getKnownRecoverableP3009Migration", () => {
         `Error code: P3009 ${RECOVERABLE_MIGRATIONS[1]}`,
       ),
     ).toBe(RECOVERABLE_MIGRATIONS[1])
+  })
+})
+
+describe("isTransientPrismaDeployFailure", () => {
+  it("matches database connection saturation from the schema engine", () => {
+    expect(
+      isTransientPrismaDeployFailure(
+        "Error: Schema engine error:\nFATAL: sorry, too many clients already",
+      ),
+    ).toBe(true)
+    expect(
+      isTransientPrismaDeployFailure(
+        "FATAL: remaining connection slots are reserved for roles with privileges",
+      ),
+    ).toBe(true)
+    expect(isTransientPrismaDeployFailure("Error code: P3018")).toBe(false)
   })
 })
 
@@ -67,6 +84,54 @@ describe("deployWithKnownRecovery", () => {
       migration,
     ])
     expect(runner).toHaveBeenNthCalledWith(3, ["migrate", "deploy"])
+  })
+
+  it("retries transient deploy saturation before succeeding", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const runner = vi
+      .fn()
+      .mockResolvedValueOnce(
+        result(
+          1,
+          "Schema engine error: FATAL: sorry, too many clients already",
+        ),
+      )
+      .mockResolvedValueOnce(
+        result(1, "FATAL: remaining connection slots are reserved"),
+      )
+      .mockResolvedValueOnce(result(0))
+
+    await deployWithKnownRecovery(runner, {
+      sleep,
+      transientDeployAttempts: 3,
+      transientDeployDelayMs: 0,
+    })
+
+    expect(runner).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenCalledTimes(2)
+  })
+
+  it("fails after exhausting transient deploy retries", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const runner = vi
+      .fn()
+      .mockResolvedValue(
+        result(
+          1,
+          "Schema engine error: FATAL: sorry, too many clients already",
+        ),
+      )
+
+    await expect(
+      deployWithKnownRecovery(runner, {
+        sleep,
+        transientDeployAttempts: 2,
+        transientDeployDelayMs: 0,
+      }),
+    ).rejects.toThrow(/without known P3009 recovery/)
+
+    expect(runner).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledTimes(1)
   })
 
   it("does not resolve unrelated migration failures", async () => {

--- a/apps/admin/src/scripts/migrate-deploy-known-recovery.ts
+++ b/apps/admin/src/scripts/migrate-deploy-known-recovery.ts
@@ -16,11 +16,47 @@ export type CommandResult = {
 
 export type PrismaRunner = (args: readonly string[]) => Promise<CommandResult>
 
+type DeployRecoveryOptions = {
+  transientDeployAttempts?: number
+  transientDeployDelayMs?: number
+  sleep?: (ms: number) => Promise<void>
+}
+
+const TRANSIENT_DEPLOY_FAILURE_PATTERNS = [
+  /too many clients already/i,
+  /remaining connection slots are reserved/i,
+  /connection limit exceeded/i,
+] as const
+
+function positiveIntegerEnv(name: string, fallback: number) {
+  const value = Number.parseInt(process.env[name] ?? "", 10)
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+const DEFAULT_TRANSIENT_DEPLOY_ATTEMPTS = positiveIntegerEnv(
+  "MIGRATE_DEPLOY_TRANSIENT_ATTEMPTS",
+  8,
+)
+const DEFAULT_TRANSIENT_DEPLOY_DELAY_MS = positiveIntegerEnv(
+  "MIGRATE_DEPLOY_TRANSIENT_DELAY_MS",
+  10_000,
+)
+
+function defaultSleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
 export function getKnownRecoverableP3009Migration(
   output: string,
 ): (typeof RECOVERABLE_MIGRATIONS)[number] | undefined {
   if (!output.includes("P3009")) return undefined
   return RECOVERABLE_MIGRATIONS.find((migration) => output.includes(migration))
+}
+
+export function isTransientPrismaDeployFailure(output: string): boolean {
+  return TRANSIENT_DEPLOY_FAILURE_PATTERNS.some((pattern) =>
+    pattern.test(output),
+  )
 }
 
 export function isKnownRecoverableP3009(output: string): boolean {
@@ -52,10 +88,41 @@ export async function runPrisma(
   })
 }
 
+async function runMigrateDeployWithTransientRetry(
+  runner: PrismaRunner,
+  options: DeployRecoveryOptions,
+): Promise<CommandResult> {
+  const attempts =
+    options.transientDeployAttempts ?? DEFAULT_TRANSIENT_DEPLOY_ATTEMPTS
+  const delayMs =
+    options.transientDeployDelayMs ?? DEFAULT_TRANSIENT_DEPLOY_DELAY_MS
+  const sleep = options.sleep ?? defaultSleep
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await runner(["migrate", "deploy"])
+    if (result.code === 0) return result
+
+    if (
+      !isTransientPrismaDeployFailure(result.output) ||
+      attempt === attempts
+    ) {
+      return result
+    }
+
+    process.stderr.write(
+      `[migrate-deploy] transient prisma migrate deploy failure; retrying attempt ${attempt + 1}/${attempts}\n`,
+    )
+    await sleep(delayMs)
+  }
+
+  return runner(["migrate", "deploy"])
+}
+
 export async function deployWithKnownRecovery(
   runner: PrismaRunner = runPrisma,
+  options: DeployRecoveryOptions = {},
 ): Promise<void> {
-  const firstDeploy = await runner(["migrate", "deploy"])
+  const firstDeploy = await runMigrateDeployWithTransientRetry(runner, options)
   if (firstDeploy.code === 0) return
 
   const recoverableMigration = getKnownRecoverableP3009Migration(
@@ -76,7 +143,10 @@ export async function deployWithKnownRecovery(
     recoverableMigration,
   ])
   if (resolve.code !== 0) {
-    const retryAfterResolveFailure = await runner(["migrate", "deploy"])
+    const retryAfterResolveFailure = await runMigrateDeployWithTransientRetry(
+      runner,
+      options,
+    )
     if (retryAfterResolveFailure.code === 0) return
 
     throw new Error(
@@ -84,7 +154,7 @@ export async function deployWithKnownRecovery(
     )
   }
 
-  const secondDeploy = await runner(["migrate", "deploy"])
+  const secondDeploy = await runMigrateDeployWithTransientRetry(runner, options)
   if (secondDeploy.code !== 0) {
     throw new Error("prisma migrate deploy failed after known recovery")
   }


### PR DESCRIPTION
## Summary
- retry Prisma `migrate deploy` when the schema engine hits transient Postgres connection saturation
- keep known P3009 recovery and unrelated migration failure behavior unchanged
- add regression tests for `too many clients already` and reserved connection slot errors

## Production context
The main deploy for `6a2700eb` reached production Postgres, but `@forge/admin` failed during `pnpm --filter @forge/admin db:migrate:deploy` with:

```
FATAL: sorry, too many clients already
[migrate-deploy] failed error=prisma migrate deploy failed without known P3009 recovery
```

This is a transient capacity/saturation error during rollout, not a migration-shape error. The wrapper now waits and retries before classifying the output as a real migration failure.

## Verification
- pnpm --filter @forge/admin exec vitest run src/scripts/migrate-deploy-known-recovery.test.ts
- pnpm run format:check
- pnpm --filter @forge/admin run --if-present lint --max-warnings=0