### PR TITLE
fix(admin): retry transient workflow startup saturation

### DIFF
--- a/apps/admin/src/instrumentation.test.ts
+++ b/apps/admin/src/instrumentation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockEnv = vi.hoisted(() => ({
   env: {
@@ -31,10 +31,29 @@ vi.mock("@/services/search-trace-retention/job", () => ({
 
 describe("workflow instrumentation", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.useRealTimers()
+    vi.resetModules()
+    worldStart.mockReset()
+    getWorld.mockReset()
+    getWorld.mockImplementation(() => ({ start: worldStart }))
+    startWorkflowWorkerHeartbeat.mockReset()
+    ensureVideoDbBackupSchedulerStarted.mockReset()
+    ensureSearchTraceRetentionSchedulerStarted.mockReset()
+    delete (
+      globalThis as typeof globalThis & {
+        __forgeAdminWorkflowStartup?: unknown
+      }
+    ).__forgeAdminWorkflowStartup
     process.env.NEXT_RUNTIME = "nodejs"
     mockEnv.env.WORKFLOW_RUNNER_ENABLED = "false"
     mockEnv.env.WORKFLOW_TARGET_WORLD = undefined
+    delete process.env.WORKFLOW_STARTUP_TRANSIENT_ATTEMPTS
+    delete process.env.WORKFLOW_STARTUP_TRANSIENT_DELAY_MS
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
   })
 
   it("does not start a world when Postgres World is not selected", async () => {
@@ -98,5 +117,46 @@ describe("workflow instrumentation", () => {
     expect(startWorkflowWorkerHeartbeat).toHaveBeenCalledTimes(1)
     expect(ensureVideoDbBackupSchedulerStarted).toHaveBeenCalledTimes(1)
     expect(ensureSearchTraceRetentionSchedulerStarted).toHaveBeenCalledTimes(1)
+  })
+
+  it("schedules a retry instead of throwing on transient startup saturation", async () => {
+    process.env.WORKFLOW_STARTUP_TRANSIENT_DELAY_MS = "1"
+    const saturationError = Object.assign(
+      new Error("sorry, too many clients already"),
+      { code: "53300" },
+    )
+    worldStart
+      .mockRejectedValueOnce(saturationError)
+      .mockResolvedValueOnce(null)
+    mockEnv.env.WORKFLOW_RUNNER_ENABLED = "true"
+    mockEnv.env.WORKFLOW_TARGET_WORLD = "@workflow/world-postgres"
+    const { register, isTransientWorkflowStartupError } =
+      await import("./instrumentation")
+
+    expect(isTransientWorkflowStartupError(saturationError)).toBe(true)
+    await expect(register()).resolves.toBeUndefined()
+    expect(worldStart).toHaveBeenCalledTimes(1)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(worldStart).toHaveBeenCalledTimes(2)
+    expect(startWorkflowWorkerHeartbeat).toHaveBeenCalledTimes(1)
+    expect(ensureVideoDbBackupSchedulerStarted).toHaveBeenCalledTimes(1)
+    expect(ensureSearchTraceRetentionSchedulerStarted).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws non-transient startup errors", async () => {
+    const configError = new Error("workflow secret missing")
+    worldStart.mockRejectedValueOnce(configError)
+    mockEnv.env.WORKFLOW_RUNNER_ENABLED = "true"
+    mockEnv.env.WORKFLOW_TARGET_WORLD = "@workflow/world-postgres"
+    const { register, isTransientWorkflowStartupError } =
+      await import("./instrumentation")
+
+    expect(isTransientWorkflowStartupError(configError)).toBe(false)
+    await expect(register()).rejects.toThrow("workflow secret missing")
+
+    expect(worldStart).toHaveBeenCalledTimes(1)
+    expect(startWorkflowWorkerHeartbeat).not.toHaveBeenCalled()
   })
 })

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -1,5 +1,66 @@
 import { env } from "@/config/env"
 
+type WorkflowStartupState = {
+  retryTimer?: ReturnType<typeof setTimeout>
+  started: boolean
+  starting: boolean
+}
+
+const TRANSIENT_WORKFLOW_STARTUP_PATTERNS = [
+  /too many clients already/i,
+  /remaining connection slots are reserved/i,
+  /connection limit exceeded/i,
+] as const
+
+function workflowStartupGlobal() {
+  return globalThis as typeof globalThis & {
+    __forgeAdminWorkflowStartup?: WorkflowStartupState
+  }
+}
+
+function workflowStartupState() {
+  const current = workflowStartupGlobal().__forgeAdminWorkflowStartup
+  if (current) return current
+
+  const state: WorkflowStartupState = {
+    started: false,
+    starting: false,
+  }
+  workflowStartupGlobal().__forgeAdminWorkflowStartup = state
+  return state
+}
+
+function positiveIntegerEnv(name: string, fallback: number) {
+  const value = Number.parseInt(process.env[name] ?? "", 10)
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function maxTransientWorkflowStartupAttempts() {
+  return positiveIntegerEnv("WORKFLOW_STARTUP_TRANSIENT_ATTEMPTS", 12)
+}
+
+function transientWorkflowStartupDelayMs() {
+  return positiveIntegerEnv("WORKFLOW_STARTUP_TRANSIENT_DELAY_MS", 10_000)
+}
+
+function errorText(error: unknown) {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+export function isTransientWorkflowStartupError(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error != null && "code" in error
+      ? String(error.code)
+      : undefined
+  return (
+    code === "53300" ||
+    TRANSIENT_WORKFLOW_STARTUP_PATTERNS.some((pattern) =>
+      pattern.test(errorText(error)),
+    )
+  )
+}
+
 export function shouldStartWorkflowWorld(): boolean {
   return (
     process.env.NEXT_RUNTIME === "nodejs" &&
@@ -8,9 +69,7 @@ export function shouldStartWorkflowWorld(): boolean {
   )
 }
 
-export async function register(): Promise<void> {
-  if (!shouldStartWorkflowWorld()) return
-
+async function startWorkflowWorld(): Promise<void> {
   const { getWorld } = await import("workflow/runtime")
   const { startWorkflowWorkerHeartbeat } =
     await import("@/services/workflow-worker-heartbeat.service")
@@ -23,4 +82,47 @@ export async function register(): Promise<void> {
   await startWorkflowWorkerHeartbeat()
   await ensureVideoDbBackupSchedulerStarted()
   await ensureSearchTraceRetentionSchedulerStarted()
+}
+
+function scheduleWorkflowStartupRetry(attempt: number) {
+  const state = workflowStartupState()
+  const delayMs = transientWorkflowStartupDelayMs()
+
+  state.retryTimer = setTimeout(() => {
+    void startWorkflowWorldWithTransientRetry(attempt)
+  }, delayMs)
+  state.retryTimer.unref?.()
+}
+
+async function startWorkflowWorldWithTransientRetry(
+  attempt = 1,
+): Promise<void> {
+  const state = workflowStartupState()
+  if (state.started || state.starting) return
+
+  state.starting = true
+  try {
+    await startWorkflowWorld()
+    state.started = true
+  } catch (error) {
+    const isTransient = isTransientWorkflowStartupError(error)
+    const maxAttempts = maxTransientWorkflowStartupAttempts()
+
+    if (!isTransient || attempt >= maxAttempts) {
+      throw error
+    }
+
+    process.stderr.write(
+      `[workflow-startup] transient startup failure; retrying attempt ${attempt + 1}/${maxAttempts} error=${errorText(error)}\n`,
+    )
+    scheduleWorkflowStartupRetry(attempt + 1)
+  } finally {
+    state.starting = false
+  }
+}
+
+export async function register(): Promise<void> {
+  if (!shouldStartWorkflowWorld()) return
+
+  await startWorkflowWorldWithTransientRetry()
 }


### PR DESCRIPTION
## Summary
- treat Postgres connection saturation during workflow instrumentation startup as transient
- schedule background retries instead of failing the Next instrumentation hook before healthcheck can pass
- keep non-transient workflow startup errors strict

## Production context
The retry deploy for `7370c4b7` got past build, but `@forge/admin/worker` failed healthcheck with instrumentation startup errors:

```
error: An error occurred while loading instrumentation hook: sorry, too many clients already
code: 53300
```

This patch lets the service boot and continue retrying workflow startup while Postgres connection pressure clears.

## Verification
- pnpm --filter @forge/admin exec vitest run src/instrumentation.test.ts src/scripts/migrate-deploy-known-recovery.test.ts
- pnpm run format:check
- pnpm --filter @forge/admin run --if-present lint --max-warnings=0