### PR TITLE
feat(yt-video-mapper): deploy backend service

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -27,6 +27,24 @@ A cut/edition of a Video that owns the subtitle tracks. Subtitles hang off the E
 
 A language a Video is offered in: every Dub is for one Language, and subtitle tracks are per-Language. A Language has two identifiers that are easy to conflate — a unique, stable slug that is its identity (e.g. korean, kurmanji-standard), and a BCP-47 tag that is a locale label (e.g. ko, ko-kmr) and is deliberately not unique per language, so distinct Languages can share a tag or its prefix. Identity comparisons — persisting or re-selecting a user's chosen language — key on the slug; the BCP-47 tag is only for best-effort device-locale matching.
 
+## Video source mapper
+
+### Video Source Mapper
+
+A prototype attribution service that accepts an externally uploaded or reuploaded video and maps it back to the official source Video and likely Dub it came from.
+
+### Mapper Catalog
+
+A mapper-owned projection of official Forge/Admin media records and matchable media signals used for attribution. The Mapper Catalog is an index for matching, not the source of truth for Videos, Dubs, or Video Editions.
+
+### Match Job
+
+An asynchronous attribution request that owns an uploaded media input until the mapper can process it and return ranked results.
+
+### Match Candidate
+
+A ranked possible attribution produced by a Match Job, pairing a source Video with its likely Dub and a confidence judgment.
+
 ## Search & embeddings
 
 ### Content Embedding

--- a/apps/yt-video-mapper-backend/docs/railway-deployment.md
+++ b/apps/yt-video-mapper-backend/docs/railway-deployment.md
@@ -1,0 +1,106 @@
+# Railway Deployment
+
+`apps/yt-video-mapper-backend` deploys as a standalone Railway backend service
+for the yt-video-mapper prototype.
+
+## Service Shape
+
+- Service name: `@forge/yt-video-mapper-backend`
+- Railway service ID: `b120d4c6-ed62-4b86-a491-87de0dd4a00f`
+- Railway database service: `@forge/yt-video-mapper-backend/db`
+- Railway database service ID: `2e6958c3-2949-45ba-a923-1e7452e4d0eb`
+- Railway project: `forge`
+- Railway environment: `production`
+- App path: `apps/yt-video-mapper-backend`
+- Healthcheck path: `/health`
+- Local port: `3010`
+- Railway service domain:
+  `https://forgeyt-video-mapper-backend-production.up.railway.app`
+
+## Build And Start
+
+This service is intended to use config-as-code. Set the Railway service's
+Config-as-code Path to `apps/yt-video-mapper-backend/railway.toml`.
+
+The committed config declares:
+
+- Build command:
+  `pnpm install --frozen-lockfile && pnpm --filter @forge/yt-video-mapper-backend build`
+- Start command:
+  `pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy && pnpm --filter @forge/yt-video-mapper-backend start`
+- Healthcheck path:
+  `/health`
+- Healthcheck timeout:
+  `60s`
+
+If Railway dashboard settings are used instead, mirror those values exactly and
+document the dashboard as canonical. Do not rely on the app-local
+`railway.toml` unless the deployment record shows it was honored.
+
+## Env Vars
+
+Required for production:
+
+- `DATABASE_URL=<Railway Postgres DATABASE_URL reference>`
+- `MAPPER_API_TOKEN=<runtime secret, at least 32 characters>`
+- `UPLOAD_STORAGE_DIR=/tmp/yt-video-mapper/uploads`
+- `MAX_UPLOAD_BYTES=100000000`
+- `MATCH_RESULT_LIMIT=3`
+- `JOB_RESULT_RETENTION_HOURS=168`
+- `JOB_RUNNING_STALE_MINUTES=30`
+
+Prepared for later catalog sync, but optional until YTM-002/YTM-003:
+
+- `ADMIN_GRAPHQL_URL=<admin GraphQL URL>`
+- `ADMIN_SERVICE_BEARER_TOKEN=<admin service bearer token>`
+
+Do not hard-code any secret values in the repo.
+
+## Initial Verification
+
+After the Railway service and database are provisioned:
+
+```bash
+pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy
+pnpm --filter @forge/yt-video-mapper-backend build
+```
+
+Then verify the deployed service:
+
+```bash
+curl "$MAPPER_BASE_URL/health"
+curl -i -X POST "$MAPPER_BASE_URL/match-jobs"
+curl -i -X POST "$MAPPER_BASE_URL/match-jobs" \
+  -H "Authorization: Bearer invalid"
+```
+
+Expected results:
+
+- `GET /health` returns `{ "ok": true, "service": "yt-video-mapper-backend" }`.
+- `POST /match-jobs` without a bearer token returns `401`.
+- `POST /match-jobs` with an invalid bearer token returns `401`.
+
+## 2026-06-09 Provisioning Notes
+
+- Railway config is intended to be config-as-code via
+  `apps/yt-video-mapper-backend/railway.toml`.
+- Railway production is configured as config-as-code. Deployment
+  `b1108157-a875-49e4-8b44-1048dc3e9e32` recorded
+  `configFile: /apps/yt-video-mapper-backend/railway.toml`; the build command,
+  start command, and `/health` healthcheck came from that file.
+- Created Postgres service `@forge/yt-video-mapper-backend/db` from Railway's
+  SSL-enabled Postgres 18 image with a persistent volume mounted at
+  `/var/lib/postgresql/data` in `us-west2`.
+- Set app service env vars for `DATABASE_URL`, `MAPPER_API_TOKEN`,
+  `UPLOAD_STORAGE_DIR`, `MAX_UPLOAD_BYTES`, `MATCH_RESULT_LIMIT`,
+  `JOB_RESULT_RETENTION_HOURS`, and `JOB_RUNNING_STALE_MINUTES`.
+- Added empty Railway placeholders for `ADMIN_GRAPHQL_URL` and
+  `ADMIN_SERVICE_BEARER_TOKEN`; catalog sync can populate them later without
+  code changes.
+- Startup ran `pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy`
+  against the Railway private Postgres URL. The successful deployment logs show
+  one migration present and no pending migrations.
+- Verified public `GET /health` returns
+  `{ "ok": true, "service": "yt-video-mapper-backend" }`.
+- Verified public `POST /match-jobs` returns `401` for both missing and invalid
+  bearer tokens.

--- a/apps/yt-video-mapper-backend/docs/railway-deployment.md
+++ b/apps/yt-video-mapper-backend/docs/railway-deployment.md
@@ -43,7 +43,8 @@ Required for production:
 
 - `DATABASE_URL=<Railway Postgres DATABASE_URL reference>`
 - `MAPPER_API_TOKEN=<runtime secret, at least 32 characters>`
-- `UPLOAD_STORAGE_DIR=/tmp/yt-video-mapper/uploads`
+- `NODE_ENV=production`
+- `UPLOAD_STORAGE_DIR=/data/yt-video-mapper/uploads`
 - `MAX_UPLOAD_BYTES=100000000`
 - `MATCH_RESULT_LIMIT=3`
 - `JOB_RESULT_RETENTION_HOURS=168`
@@ -68,10 +69,16 @@ pnpm --filter @forge/yt-video-mapper-backend build
 Then verify the deployed service:
 
 ```bash
+MAPPER_BASE_URL="https://forgeyt-video-mapper-backend-production.up.railway.app"
+
 curl "$MAPPER_BASE_URL/health"
 curl -i -X POST "$MAPPER_BASE_URL/match-jobs"
 curl -i -X POST "$MAPPER_BASE_URL/match-jobs" \
   -H "Authorization: Bearer invalid"
+curl -i -X POST "$MAPPER_BASE_URL/match-jobs" \
+  -H "Authorization: Bearer $MAPPER_API_TOKEN" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary "smoke-video"
 ```
 
 Expected results:
@@ -79,18 +86,22 @@ Expected results:
 - `GET /health` returns `{ "ok": true, "service": "yt-video-mapper-backend" }`.
 - `POST /match-jobs` without a bearer token returns `401`.
 - `POST /match-jobs` with an invalid bearer token returns `401`.
+- `POST /match-jobs` with the valid mapper token returns `202` and a `jobId`.
 
 ## 2026-06-09 Provisioning Notes
 
 - Railway config is intended to be config-as-code via
   `apps/yt-video-mapper-backend/railway.toml`.
 - Railway production is configured as config-as-code. Deployment
-  `b1108157-a875-49e4-8b44-1048dc3e9e32` recorded
+  `f15835f6-2447-4a99-b336-ddabea796ccd` recorded
   `configFile: /apps/yt-video-mapper-backend/railway.toml`; the build command,
   start command, and `/health` healthcheck came from that file.
 - Created Postgres service `@forge/yt-video-mapper-backend/db` from Railway's
   SSL-enabled Postgres 18 image with a persistent volume mounted at
   `/var/lib/postgresql/data` in `us-west2`.
+- Created a persistent app volume mounted at `/data` in `us-west2` and set
+  `UPLOAD_STORAGE_DIR=/data/yt-video-mapper/uploads` so queued uploads survive
+  service restarts until a worker processes them.
 - Set app service env vars for `DATABASE_URL`, `MAPPER_API_TOKEN`,
   `UPLOAD_STORAGE_DIR`, `MAX_UPLOAD_BYTES`, `MATCH_RESULT_LIMIT`,
   `JOB_RESULT_RETENTION_HOURS`, and `JOB_RUNNING_STALE_MINUTES`.
@@ -104,3 +115,5 @@ Expected results:
   `{ "ok": true, "service": "yt-video-mapper-backend" }`.
 - Verified public `POST /match-jobs` returns `401` for both missing and invalid
   bearer tokens.
+- Verified public authenticated `POST /match-jobs` returns `202`, creates a
+  durable queued job, and the explicit process/poll path returns `200`.

--- a/apps/yt-video-mapper-backend/package.json
+++ b/apps/yt-video-mapper-backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/server.ts",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "pnpm run db:generate && tsc -p tsconfig.build.json && mkdir -p dist/generated && cp -R src/generated/prisma dist/generated/prisma",
     "start": "node dist/server.js",
     "postinstall": "DATABASE_URL=${DATABASE_URL:-postgresql://forge:forge@localhost:5432/yt_video_mapper} prisma generate",
     "db:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://forge:forge@localhost:5432/yt_video_mapper} prisma generate",

--- a/apps/yt-video-mapper-backend/package.json
+++ b/apps/yt-video-mapper-backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/server.ts",
-    "build": "pnpm run db:generate && tsc -p tsconfig.build.json && mkdir -p dist/generated && cp -R src/generated/prisma dist/generated/prisma",
+    "build": "rm -rf dist && pnpm run db:generate && tsc -p tsconfig.build.json && rm -rf dist/generated/prisma && mkdir -p dist/generated && cp -R src/generated/prisma dist/generated/prisma",
     "start": "node dist/server.js",
     "postinstall": "DATABASE_URL=${DATABASE_URL:-postgresql://forge:forge@localhost:5432/yt_video_mapper} prisma generate",
     "db:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://forge:forge@localhost:5432/yt_video_mapper} prisma generate",

--- a/apps/yt-video-mapper-backend/railway.toml
+++ b/apps/yt-video-mapper-backend/railway.toml
@@ -1,0 +1,22 @@
+# Railway only reads this file if the service's Config-as-code Path is set to
+# apps/yt-video-mapper-backend/railway.toml. Otherwise configure the same
+# commands in the Railway dashboard and treat that dashboard config as
+# canonical.
+
+[build]
+builder = "NIXPACKS"
+buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/yt-video-mapper-backend build"
+watchPatterns = [
+  "/apps/yt-video-mapper-backend/**",
+  "/package.json",
+  "/pnpm-lock.yaml",
+  "/pnpm-workspace.yaml",
+  "/turbo.json",
+]
+
+[deploy]
+startCommand = "pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy && pnpm --filter @forge/yt-video-mapper-backend start"
+healthcheckPath = "/health"
+healthcheckTimeout = 60
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/apps/yt-video-mapper-backend/src/config/env.test.ts
+++ b/apps/yt-video-mapper-backend/src/config/env.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const originalEnv = { ...process.env }
+const envKeys = [
+  "NODE_ENV",
+  "DATABASE_URL",
+  "ADMIN_GRAPHQL_URL",
+  "ADMIN_SERVICE_BEARER_TOKEN",
+  "MAPPER_API_TOKEN",
+]
+
+describe("runtime env", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    resetProcessEnv()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    resetProcessEnv()
+  })
+
+  it("allows production startup without future admin sync vars", async () => {
+    const { assertRuntimeEnv, env } = await loadEnv({
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://forge:forge@localhost:5432/mapper",
+      MAPPER_API_TOKEN: "a".repeat(32),
+      ADMIN_GRAPHQL_URL: "",
+      ADMIN_SERVICE_BEARER_TOKEN: "",
+    })
+
+    expect(env.ADMIN_GRAPHQL_URL).toBeUndefined()
+    expect(env.ADMIN_SERVICE_BEARER_TOKEN).toBeUndefined()
+    expect(assertRuntimeEnv).not.toThrow()
+  })
+
+  it("requires DATABASE_URL in production", async () => {
+    const { assertRuntimeEnv } = await loadEnv({
+      NODE_ENV: "production",
+      MAPPER_API_TOKEN: "a".repeat(32),
+    })
+
+    expect(assertRuntimeEnv).toThrow(
+      "DATABASE_URL is required for yt-video-mapper-backend production",
+    )
+  })
+
+  it("requires MAPPER_API_TOKEN in production", async () => {
+    const { assertRuntimeEnv } = await loadEnv({
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://forge:forge@localhost:5432/mapper",
+    })
+
+    expect(assertRuntimeEnv).toThrow(
+      "MAPPER_API_TOKEN is required for yt-video-mapper-backend production",
+    )
+  })
+})
+
+async function loadEnv(overrides: NodeJS.ProcessEnv) {
+  Object.assign(process.env, overrides)
+
+  return import("./env.js")
+}
+
+function resetProcessEnv() {
+  for (const key of envKeys) {
+    delete process.env[key]
+  }
+
+  Object.assign(process.env, originalEnv)
+}

--- a/apps/yt-video-mapper-backend/src/config/env.ts
+++ b/apps/yt-video-mapper-backend/src/config/env.ts
@@ -51,8 +51,6 @@ export function assertRuntimeEnv(): void {
 
   const missing = [
     ["DATABASE_URL", env.DATABASE_URL],
-    ["ADMIN_GRAPHQL_URL", env.ADMIN_GRAPHQL_URL],
-    ["ADMIN_SERVICE_BEARER_TOKEN", env.ADMIN_SERVICE_BEARER_TOKEN],
     ["MAPPER_API_TOKEN", env.MAPPER_API_TOKEN],
   ]
     .filter(([, value]) => !value)

--- a/docs/prototypes/yt-video-mapper/tickets/README.md
+++ b/docs/prototypes/yt-video-mapper/tickets/README.md
@@ -13,13 +13,13 @@ roadmap tickets broad; keep this folder practical and close to the mapper code.
 
 ## Queue
 
-| ID                                                             | Status  | Priority | Title                                        |
-| -------------------------------------------------------------- | ------- | -------- | -------------------------------------------- |
-| [YTM-001](./ytm-001-deploy-service-and-database.md)            | todo    | P1       | Deploy service and database                  |
-| [YTM-002](./ytm-002-admin-flat-catalog-projection.md)          | todo    | P1       | Admin flat catalog projection                |
-| [YTM-003](./ytm-003-mapper-catalog-sync.md)                    | todo    | P1       | Mapper catalog sync                          |
-| [YTM-004](./ytm-004-official-media-signature-indexing.md)      | todo    | P1       | Official media signature indexing            |
-| [YTM-005](./ytm-005-replace-placeholders-with-real-matcher.md) | todo    | P1       | Replace placeholders with real matcher       |
-| [YTM-006](./ytm-006-evaluation-harness-and-thresholds.md)      | todo    | P1       | Evaluation harness and confidence thresholds |
-| [YTM-007](./ytm-007-ops-hardening.md)                          | todo    | P2       | Operations hardening                         |
-| [YTM-008](./ytm-008-model-assisted-review-research.md)         | backlog | P3       | Model-assisted review research               |
+| ID                                                             | Status   | Priority | Title                                        |
+| -------------------------------------------------------------- | -------- | -------- | -------------------------------------------- |
+| [YTM-001](./ytm-001-deploy-service-and-database.md)            | complete | P1       | Deploy service and database                  |
+| [YTM-002](./ytm-002-admin-flat-catalog-projection.md)          | todo     | P1       | Admin flat catalog projection                |
+| [YTM-003](./ytm-003-mapper-catalog-sync.md)                    | todo     | P1       | Mapper catalog sync                          |
+| [YTM-004](./ytm-004-official-media-signature-indexing.md)      | todo     | P1       | Official media signature indexing            |
+| [YTM-005](./ytm-005-replace-placeholders-with-real-matcher.md) | todo     | P1       | Replace placeholders with real matcher       |
+| [YTM-006](./ytm-006-evaluation-harness-and-thresholds.md)      | todo     | P1       | Evaluation harness and confidence thresholds |
+| [YTM-007](./ytm-007-ops-hardening.md)                          | todo     | P2       | Operations hardening                         |
+| [YTM-008](./ytm-008-model-assisted-review-research.md)         | backlog  | P3       | Model-assisted review research               |

--- a/docs/prototypes/yt-video-mapper/tickets/ytm-001-deploy-service-and-database.md
+++ b/docs/prototypes/yt-video-mapper/tickets/ytm-001-deploy-service-and-database.md
@@ -1,7 +1,7 @@
 ---
 id: YTM-001
 title: "Deploy yt-video-mapper-backend service and database"
-status: todo
+status: complete
 priority: P1
 depends_on: []
 ---

--- a/docs/solutions/workflow-issues/yt-video-mapper-railway-prisma-backend-deployment.md
+++ b/docs/solutions/workflow-issues/yt-video-mapper-railway-prisma-backend-deployment.md
@@ -1,0 +1,216 @@
+---
+title: "YTM Railway Prisma backend deployment hardening"
+date: "2026-06-09"
+category: "workflow-issues"
+module: "apps/yt-video-mapper-backend"
+problem_type: "workflow_issue"
+component: "development_workflow"
+severity: "high"
+applies_when:
+  - "Deploying a standalone Railway backend service from an app-local railway.toml"
+  - "The service owns Prisma migrations and a custom generated Prisma client output"
+  - "Uploaded files are stored before asynchronous job processing"
+  - "Production auth/env behavior must fail closed without blocking future optional integrations"
+related_components:
+  - "database"
+  - "authentication"
+  - "tooling"
+  - "documentation"
+tags:
+  - "yt-video-mapper"
+  - "railway"
+  - "prisma"
+  - "postgres"
+  - "deployment"
+  - "persistent-storage"
+  - "production-env"
+  - "auth-smoke"
+---
+
+# YTM Railway Prisma backend deployment hardening
+
+## Context
+
+YTM-001 deployed `@forge/yt-video-mapper-backend` as a standalone Railway
+service with its own Postgres database. The risky work was not creating the
+service itself; it was proving the production contract that reviewers and
+future operators would assume exists:
+
+- Railway must honor the app-local `apps/yt-video-mapper-backend/railway.toml`.
+- Prisma migrations must run against the Railway database before the server
+  starts.
+- The generated Prisma client must exist under `dist/` at runtime.
+- Upload bytes must survive a service restart while a `Match Job` is queued.
+- Production auth must fail closed without making future catalog-sync env vars
+  mandatory too early.
+
+The branch recorded the service/database shape and deployment verification in
+`apps/yt-video-mapper-backend/docs/railway-deployment.md`, then the review pass
+hardened the deployment contract around `NODE_ENV=production`, persistent
+storage, generated-client packaging, and authenticated smoke coverage.
+
+Session history search found no relevant prior sessions for this exact mapper
+deployment, so this learning is based on the verified YTM-001 run and related
+repo solution docs.
+
+## Guidance
+
+Treat Railway setup as a checked deployment contract, not a dashboard memory
+exercise. For app-local Railway config, set the service's Config-as-code Path
+to the exact file and verify the deployment record reports it:
+
+```text
+apps/yt-video-mapper-backend/railway.toml
+configFile: /apps/yt-video-mapper-backend/railway.toml
+```
+
+The committed Railway config should own the build command, start command, watch
+patterns, healthcheck path, healthcheck timeout, and restart policy:
+
+```toml
+[build]
+buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/yt-video-mapper-backend build"
+
+[deploy]
+startCommand = "pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy && pnpm --filter @forge/yt-video-mapper-backend start"
+healthcheckPath = "/health"
+healthcheckTimeout = 60
+```
+
+Package the generated Prisma client into the runtime artifact. The mapper
+schema outputs Prisma's client to `src/generated/prisma`, which is ignored by
+git. TypeScript compilation alone does not make that generated output available
+to `node dist/server.js`, so the build must regenerate and copy it:
+
+```json
+{
+  "build": "rm -rf dist && pnpm run db:generate && tsc -p tsconfig.build.json && rm -rf dist/generated/prisma && mkdir -p dist/generated && cp -R src/generated/prisma dist/generated/prisma"
+}
+```
+
+Keep required production env vars scoped to the runtime that exists today.
+`DATABASE_URL`, `MAPPER_API_TOKEN`, and `NODE_ENV=production` are load-bearing.
+`ADMIN_GRAPHQL_URL` and `ADMIN_SERVICE_BEARER_TOKEN` are prepared placeholders
+for later catalog sync and must stay optional until that sync is implemented.
+Add regression tests around that line so future placeholder vars do not brick a
+deploy before their feature ships.
+
+Use durable upload storage in production. The mapper creates a DB-backed job
+that points at a stored upload key before processing. If Railway stores those
+bytes under `/tmp`, a restart can leave a valid queued job pointing at a missing
+file. Mount a persistent app volume at `/data` and set:
+
+```text
+UPLOAD_STORAGE_DIR=/data/yt-video-mapper/uploads
+```
+
+Smoke the deployed service beyond `/health`. A useful production smoke proves
+reachability, missing-token rejection, invalid-token rejection, valid-token job
+creation, and the process/poll path:
+
+```bash
+MAPPER_BASE_URL="https://forgeyt-video-mapper-backend-production.up.railway.app"
+
+curl "$MAPPER_BASE_URL/health"
+curl -i -X POST "$MAPPER_BASE_URL/match-jobs"
+curl -i -X POST "$MAPPER_BASE_URL/match-jobs" \
+  -H "Authorization: Bearer invalid"
+curl -i -X POST "$MAPPER_BASE_URL/match-jobs" \
+  -H "Authorization: Bearer $MAPPER_API_TOKEN" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary "smoke-video"
+```
+
+Expected results:
+
+- `/health` returns `200` with the mapper service name.
+- Missing and invalid bearer tokens return `401`.
+- A valid bearer token returns `202` with a `jobId`.
+- Processing and polling that job return `200`.
+
+When `DATABASE_URL` points at Railway's private network host, verify migrations
+from inside Railway or from deployment logs. A local shell cannot assume the
+private `*.railway.internal` host will resolve. For YTM-001, the successful
+deployment logs showed `prisma migrate deploy`, one migration present, and no
+pending migrations.
+
+## Why This Matters
+
+A dead `railway.toml` is worse than no config because the repository looks
+authoritative while Railway quietly runs dashboard defaults. In a Prisma
+service, that can skip `migrate deploy` and leave code and database schema out
+of sync.
+
+Generated Prisma clients are another production-only trap. Local development
+often has `src/generated/prisma` from a previous command, while a clean Railway
+build only has what the build command creates and copies. If `dist/generated`
+is missing, TypeScript can pass and production can still fail at module import.
+
+Env validation has two opposite risks. If production allows a missing
+`MAPPER_API_TOKEN`, routes can become unauthenticated unless `NODE_ENV` is set
+correctly. If production requires future admin-sync vars too early, the service
+fails to boot for work intentionally scoped to later YTM tickets. The right
+contract is fail closed for current runtime requirements and optional for future
+integrations.
+
+Persistent upload storage matters because the database and file system are two
+halves of the same `Match Job`. A restart-safe DB row is not useful if the
+container file it references vanished with the old instance.
+
+## When to Apply
+
+- A Forge app is deployed as its own Railway backend service.
+- The service owns Prisma migrations and uses an app-local `railway.toml`.
+- Prisma's generated client is emitted outside `node_modules`.
+- The service stores uploaded files before async processing.
+- Bearer auth is required in production but allowed to be lighter in local
+  development.
+- Future integration env vars need to be staged without becoming boot-time
+  requirements.
+
+## Examples
+
+Good deployment documentation includes both the desired config and the observed
+Railway reality:
+
+```text
+Config-as-code Path: apps/yt-video-mapper-backend/railway.toml
+Deployment configFile: /apps/yt-video-mapper-backend/railway.toml
+Start command: pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy && pnpm --filter @forge/yt-video-mapper-backend start
+Healthcheck: /health
+Upload storage: /data/yt-video-mapper/uploads on a persistent app volume
+```
+
+Good env tests exercise the production boundary directly:
+
+```typescript
+await loadEnv({
+  NODE_ENV: "production",
+  DATABASE_URL: "postgresql://forge:forge@localhost:5432/mapper",
+  MAPPER_API_TOKEN: "a".repeat(32),
+  ADMIN_GRAPHQL_URL: "",
+  ADMIN_SERVICE_BEARER_TOKEN: "",
+})
+
+expect(assertRuntimeEnv).not.toThrow()
+```
+
+Avoid these shortcuts:
+
+- Stopping verification at `/health`.
+- Trusting a committed app-local `railway.toml` without checking `configFile`.
+- Storing queued job uploads under `/tmp` in production.
+- Requiring opt-in future integration vars at schema load.
+- Assuming `prisma generate` during install means the generated client exists
+  under `dist/` after TypeScript compilation.
+
+## Related
+
+- [Railway dashboard config silently shadows per-service `apps/<svc>/railway.toml`](../deployment/railway-dashboard-override-shadows-railway-toml-20260429.md) - same config-as-code pitfall; YTM-001 is the positive case where `configFile` was verified.
+- [New App CI & Deployment Patterns](../platform/new-app-ci-and-deployment-patterns.md) - broader new-app deployment checklist; YTM-001 adds a Node/Prisma backend variant.
+- [yt-video-mapper backend app durable match job upload poll process pattern](../platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md) - same module's async job and upload contract.
+- [Local admin CMS broke after pulling main - stale Prisma client + DB behind two migrations](../database-issues/admin-prisma-client-and-db-migration-drift-after-pull-20260603.md) - related two-layer Prisma drift: generated client and database schema both matter.
+- [Required Zod env var without default broke Railway deploy of opt-in scaffolding](../runtime-errors/required-env-var-without-default-broke-railway-deploy-20260511.md) - why future opt-in env vars should stay optional.
+- [Railway remote MCP config edits need `accept-deploy` to flush](../platform/railway-mcp-staged-config-never-commits-20260420.md) - relevant when Railway settings are changed through MCP tools.
+- [Verify infra writes via an independent read path](../best-practices/verify-infra-writes-via-independent-read-path-20260420.md) - the meta-pattern behind checking deployment records, logs, and live endpoints.
+- [Optional Railway S3 with local fallback storage](../platform/optional-railway-s3-local-fallback.md) - storage-path discipline adjacent to the mapper's Railway volume.


### PR DESCRIPTION
## Summary

`@forge/yt-video-mapper-backend` now has its own production Railway service and Postgres database, with the deployment contract documented and checked. The service boots through the committed app-local Railway config, runs Prisma migrations before start, stores queued upload bytes on a persistent Railway volume, and fails closed for production bearer auth.

This also hardens the scaffold after review: generated Prisma client output is copied into `dist/`, production env requirements are covered by tests, and deployment notes include health, missing/invalid token, valid job creation, process, and poll smoke checks.

## What Changed

| Area | Outcome |
| --- | --- |
| Railway service | Adds `apps/yt-video-mapper-backend/railway.toml` with build/start/healthcheck config |
| Database | Documents Railway Postgres attachment and startup `prisma migrate deploy` behavior |
| Runtime env | Requires current production vars while keeping future catalog-sync vars optional |
| Upload storage | Documents `/data/yt-video-mapper/uploads` on a persistent app volume |
| Review hardening | Adds env regression tests and packages generated Prisma client into `dist` |
| Knowledge capture | Adds a Compound learning plus mapper vocabulary in `CONCEPTS.md` |

## Deployment Notes

- Railway app service: `@forge/yt-video-mapper-backend`
- Railway database service: `@forge/yt-video-mapper-backend/db`
- Public health URL: `https://forgeyt-video-mapper-backend-production.up.railway.app/health`
- Final verified deployment: `f15835f6-2447-4a99-b336-ddabea796ccd`
- Config-as-code was verified via deployment `configFile: /apps/yt-video-mapper-backend/railway.toml`

## Verification

- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend build`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- Deployed `GET /health` returned the expected mapper service payload
- Deployed `POST /match-jobs` returned `401` for missing and invalid bearer tokens
- Deployed authenticated `POST /match-jobs` returned `202` with a `jobId`
- Deployed process/poll path returned `200`
- Compound frontmatter validation passed
- `git diff --check`

## Follow-Up Notes

- Cloudflare edge controls are still a release follow-up for this prototype Railway-generated domain.
- Startup migrations are acceptable for this initial prototype, but should be revisited if mapper migrations become long-running.
- Suggested knowledge refresh: `/ce-compound-refresh railway-dashboard-override-shadows-railway-toml-20260429.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)