### PR TITLE
Opt web search into keyword-first mode

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -47,6 +47,18 @@ A ranked possible attribution produced by a Match Job, pairing a source Video wi
 
 ## Search & embeddings
 
+### Search Pipeline Mode
+
+A request-side selector that chooses which retrieval pipeline Admin search should run for a caller. A Search Pipeline Mode changes how candidates are gathered and fused; it is not a health signal.
+
+### Keyword-First Search
+
+A Search Pipeline Mode that keeps semantic retrieval available while strengthening lexical and title-driven retrieval so exact or near-title matches are not diluted by broad semantic similarity.
+
+### Search Degradation Signal
+
+The response-side state that says whether semantic retrieval actually contributed to a search response. It reflects runtime embedding availability, not the requested Search Pipeline Mode.
+
 ### Content Embedding
 
 A vector representation of localized content used for semantic retrieval across videos, scenes, transcripts, and experiences. Content Embeddings are only comparable when the query vector and stored document vectors come from the same provider contract and transform behavior.

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -1,0 +1,86 @@
+import { print, type DocumentNode } from "graphql"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import client from "@/lib/admin-client"
+import { searchVideos } from "./search"
+
+vi.mock("@/lib/admin-client", () => ({
+  default: {
+    query: vi.fn(),
+  },
+}))
+
+const queryMock = vi.mocked(client.query)
+
+type SearchQueryCall = {
+  query: DocumentNode
+  variables: Record<string, unknown>
+  fetchPolicy?: unknown
+}
+
+function lastSearchQueryCall(): SearchQueryCall {
+  const call = queryMock.mock.calls.at(-1)?.[0]
+  if (call == null) throw new Error("Expected Admin search query to run")
+  return call as SearchQueryCall
+}
+
+function mockSearchResponse(searchMode: "HYBRID" | "KEYWORD_ONLY" = "HYBRID") {
+  queryMock.mockResolvedValue({
+    data: {
+      search: {
+        hasMore: false,
+        query: "jesus",
+        searchMode,
+        results: [],
+      },
+    },
+  } as Awaited<ReturnType<typeof client.query>>)
+}
+
+describe("searchVideos", () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+    mockSearchResponse()
+  })
+
+  it("declares and forwards the keyword-first mode argument", async () => {
+    await searchVideos("jesus")
+
+    const options = lastSearchQueryCall()
+    const printed = print(options.query)
+
+    expect(printed).toMatch(/\$mode:\s*String\b/)
+    expect(printed).toMatch(/search\([^)]*mode:\s*\$mode/)
+    expect(options.variables).toEqual({
+      q: "jesus",
+      locale: "en",
+      limit: 20,
+      offset: 0,
+      type: undefined,
+      mode: "keyword-first",
+    })
+    expect(options.fetchPolicy).toBe("no-cache")
+  })
+
+  it("keeps content type filtering while sending keyword-first mode", async () => {
+    await searchVideos("jesus", 10, 5, "video")
+
+    expect(lastSearchQueryCall().variables).toEqual({
+      q: "jesus",
+      locale: "en",
+      limit: 10,
+      offset: 5,
+      type: "VIDEO",
+      mode: "keyword-first",
+    })
+  })
+
+  it("keeps response searchMode degradation separate from input mode", async () => {
+    mockSearchResponse("KEYWORD_ONLY")
+
+    const data = await searchVideos("jesus")
+
+    expect(data.searchMode).toBe("keyword-only")
+    expect(lastSearchQueryCall().variables.mode).toBe("keyword-first")
+  })
+})

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -19,15 +19,18 @@ import client from "@/lib/admin-client"
 // keyring rotation documented at
 // docs/solutions/architecture-patterns/consumer-bearer-rate-limit-identity-pattern-20260513.md
 
-const SEARCH_QUERY = adminGraphql(`
+const WEB_SEARCH_MODE = "keyword-first"
+
+const searchVideosOperation = adminGraphql(`
   query Search(
     $q: String!
     $locale: String!
     $limit: Int
     $offset: Int
     $type: HybridSearchContentType
+    $mode: String
   ) {
-    search(q: $q, locale: $locale, limit: $limit, offset: $offset, type: $type) {
+    search(q: $q, locale: $locale, limit: $limit, offset: $offset, type: $type, mode: $mode) {
       hasMore
       query
       searchMode
@@ -51,13 +54,13 @@ const SEARCH_QUERY = adminGraphql(`
 
 export type SearchContentType = "video" | "experience"
 
-// Derived from the gql.tada introspection of the actual SEARCH_QUERY
+// Derived from the gql.tada introspection of the actual search operation
 // result. When admin adds a new VideoLabel value and the package
 // regenerates `admin-graphql-env.d.ts`, this union widens automatically
 // — no hand-mirrored string list to drift out of sync with the SDL.
 export type AdminVideoLabel = NonNullable<
   NonNullable<
-    AdminResultOf<typeof SEARCH_QUERY>["search"]
+    AdminResultOf<typeof searchVideosOperation>["search"]
   >["results"][number]["label"]
 >
 
@@ -132,13 +135,14 @@ export async function searchVideos(
 
   const startedAt = performance.now()
   const result = await client.query({
-    query: SEARCH_QUERY,
+    query: searchVideosOperation,
     variables: {
       q: truncatedQuery,
       locale: "en",
       limit,
       offset,
       type: toAdminContentType(type),
+      mode: WEB_SEARCH_MODE,
     },
     fetchPolicy: "no-cache",
   })

--- a/docs/plans/2026-06-09-001-feat-web-search-keyword-first-plan.md
+++ b/docs/plans/2026-06-09-001-feat-web-search-keyword-first-plan.md
@@ -1,0 +1,65 @@
+---
+title: "Web Search Keyword-First Opt-In Plan"
+type: "feat"
+status: "completed"
+date: "2026-06-09"
+---
+
+# Web Search Keyword-First Opt-In Plan
+
+## Summary
+
+Opt the web search data boundary into Admin's existing `mode="keyword-first"` search pipeline so the floating web search bar and shared paginated search results use the title-weighted lexical stack while preserving the current UI and degraded `searchMode` response handling.
+
+## Problem Frame
+
+Admin already exposes keyword-first as an opt-in request mode, but `apps/web` omits the `mode` argument and therefore receives the default hybrid pipeline. The user wants the web search bar to use keyword-first by changing the query parameters in the Admin GraphQL call, not by adding a new UI mode selector or altering search result rendering.
+
+## Requirements
+
+- R1. Web search requests pass `mode: "keyword-first"` to Admin's public `Query.search` resolver.
+- R2. Existing web callers keep their current API shape so `FloatingSearchProvider`, demo search, and load-more flows do not need per-call changes.
+- R3. The response `searchMode` degradation signal remains normalized and returned unchanged.
+- R4. The change is covered by a focused test that proves the GraphQL operation declares and sends `mode`.
+
+## Key Technical Decisions
+
+- **Centralize the opt-in in `apps/web/src/lib/search.ts`:** All current web search paths call `searchVideos` directly or via `runSearch`, so a default `mode` at this boundary changes the floating search bar without duplicating arguments across client components.
+- **Keep `mode` as a fixed internal constant:** The request is a product cutover for the web app, not a user-selectable setting. A constant avoids widening server action input shapes before a caller needs override behavior.
+- **Assert the GraphQL contract, not ranking:** Web cannot cheaply verify Admin's ranking behavior in unit tests. The app-side responsibility is to send the correct nullable `mode` argument and preserve existing response mapping.
+
+## Implementation Units
+
+### U1. Add the roadmap ticket
+
+- **Goal:** Track the web consumer opt-in separately from the completed Admin keyword-first implementation.
+- **Files:** `docs/roadmap/content-discovery/feat-172-web-search-keyword-first-opt-in.md`, `docs/roadmap/README.md`
+- **Test Scenarios:** Documentation-only; verify the ticket references `feat-109`, marks current work in progress during implementation, and is completed when validation passes.
+
+### U2. Opt web search into keyword-first
+
+- **Goal:** Add `$mode: String` to the web Admin GraphQL operation and pass `mode: "keyword-first"` in `searchVideos`.
+- **Files:** `apps/web/src/lib/search.ts`
+- **Patterns:** Follow the existing `type` argument plumbing in `SEARCH_QUERY` and the variable object inside `searchVideos`.
+- **Test Scenarios:** `searchVideos("jesus")` calls the Admin client with `variables.mode === "keyword-first"` while preserving `q`, `locale`, `limit`, `offset`, and optional content `type`.
+
+### U3. Add a query contract test
+
+- **Goal:** Guard against accidentally dropping the `mode` variable or reverting to Admin's default hybrid pipeline.
+- **Files:** `apps/web/src/lib/search.test.ts`
+- **Patterns:** Follow query-printing assertions from `apps/web/src/lib/fragments/__tests__/watch-video.test.ts` and mock the Admin client at the module boundary.
+- **Test Scenarios:** The printed operation declares `$mode: String` and calls `search(... mode: $mode ...)`; the Admin client receives `mode: "keyword-first"` for normal and content-type-filtered searches.
+
+## Risks & Dependencies
+
+- Admin must already have `Query.search.mode` in the deployed schema before this web branch ships. The field is present in `apps/admin/schema.graphql` and documented by `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`.
+- Keyword-first still uses embeddings when available. If embeddings are unavailable, Admin will continue to return `searchMode: "keyword-only"` and the web normalization path should remain unchanged.
+
+## Sources
+
+- `apps/web/src/lib/search.ts`
+- `apps/web/src/lib/search-actions.ts`
+- `apps/web/src/components/FloatingSearchProvider.tsx`
+- `apps/admin/schema.graphql`
+- `docs/roadmap/content-discovery/feat-109-search-keyword-first-mode.md`
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (June 4, 2026)
 
-- **Total tickets:** 187
-- **Complete:** 112
+- **Total tickets:** 188
+- **Complete:** 113
 - **In progress:** 9
 - **Not started:** 21
 - **Blocked:** 43
@@ -68,6 +68,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-046](content-discovery/feat-046-recommendations-demo-experience.md)                                      | Video Vectorization — Recommendations Demo Experience                                           | nisal     | P1       | 2026-06-04 | 7    | 2026-06-10 | complete    |
 | [feat-170](content-discovery/feat-170-yt-video-mapper-backend-scaffold.md)                                     | YouTube video mapper backend scaffold                                                           | nisal     | P1       | 2026-06-08 | 1    | 2026-06-08 | complete    |
 | [feat-171](content-discovery/feat-171-yt-video-mapper-broad-catalog-prototype.md)                              | YouTube video mapper broad-catalog prototype                                                    | nisal     | P1       | 2026-06-08 | 10   | 2026-06-17 | in-progress |
+| [feat-172](content-discovery/feat-172-web-search-keyword-first-opt-in.md)                                      | Web search keyword-first opt-in                                                                 | nisal     | P1       | 2026-06-09 | 1    | 2026-06-09 | complete    |
 | [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)                                  | Deploy Semantic Search Architecture                                                             | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-080](content-discovery/feat-080-transcript-embedding-table-rename.md)                                    | Transcript Embedding Table Rename                                                               | nisal     | P2       | 2026-04-10 | 2    | 2026-04-11 | complete    |
 | [feat-119](content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md) | Embed Backfill — Classify NoSuchKey + emit missingArtifacts list + decoupled enrichment trigger | nisal     | P2       | 2026-05-06 | 4    | 2026-05-09 | complete    |

--- a/docs/roadmap/content-discovery/feat-109-search-keyword-first-mode.md
+++ b/docs/roadmap/content-discovery/feat-109-search-keyword-first-mode.md
@@ -7,7 +7,8 @@ status: "complete"
 start_date: "2026-04-28"
 duration: 3
 depends_on: []
-blocks: []
+blocks:
+  - "feat-172"
 tags:
   - "cms"
   - "search"

--- a/docs/roadmap/content-discovery/feat-172-web-search-keyword-first-opt-in.md
+++ b/docs/roadmap/content-discovery/feat-172-web-search-keyword-first-opt-in.md
@@ -1,0 +1,53 @@
+---
+id: "feat-172"
+title: "Web search keyword-first opt-in"
+owner: "nisal"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-09"
+duration: 1
+depends_on:
+  - "feat-109"
+blocks: []
+tags:
+  - "web"
+  - "search"
+---
+
+## Problem
+
+`apps/web` currently omits Admin search's `mode` argument, so the floating search bar and shared search result pagination use Admin's default hybrid pipeline. Admin's keyword-first mode is complete and available as an opt-in; web should now opt into it at the shared search data boundary.
+
+## What To Build
+
+- [x] Add `mode: "keyword-first"` to the Admin GraphQL search operation used by `apps/web/src/lib/search.ts`.
+- [x] Keep client-facing search action and UI props unchanged.
+- [x] Add a focused web test proving the query declares/sends the keyword-first mode.
+
+## Entry Points — Read These First
+
+1. `apps/web/src/lib/search.ts` — shared web Admin search query and mapper.
+2. `apps/web/src/lib/search-actions.ts` — server action wrapper used by client components.
+3. `apps/web/src/components/FloatingSearchProvider.tsx` — floating search bar request path.
+
+## Grep These
+
+- `searchVideos` — shared web search resolver used by the floating search bar, demo search, and shared result pagination.
+- `mode: $mode` — GraphQL query contract for the Admin keyword-first opt-in.
+- `searchMode` — response degradation signal that remains separate from input `mode`.
+
+## Constraints
+
+- Do not add a user-visible search-mode selector or a new route; this ticket is a web app opt-in at the Admin GraphQL boundary.
+- Do not change `runSearch` input shape unless a caller needs runtime mode selection.
+- Admin `Query.search.mode` must already be deployed before this web consumer ships.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/lib/search.test.ts`
+- `pnpm --filter @forge/web lint`
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-09-001-feat-web-search-keyword-first-plan.md`

--- a/docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md
+++ b/docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md
@@ -236,8 +236,9 @@ and `dilutionCapApplied`. The retriever labels are explicitly
 - **Real-DB integration tests** gated on R0 (Core sync entity coverage):
   EXPLAIN-based GIN verification, Bible Project headline against seeded
   data, canary diff vs cms keyword-first.
-- **R8 cutover** — apps/web / mobile / tv keep calling cms's search
-  during the R3 → R8 window. R8 is a separate one-shot.
+- **Consumer opt-ins** — apps/web now opts into Admin keyword-first at
+  its shared search boundary; mobile and TV cutovers remain separate
+  consumer-surface decisions.
 - **Deprecating cms keyword-first** — happens at R8 alongside the rest
   of cms search deprecation. This work does NOT delete cms code.
 - **`statement_timeout` for SQL retrievers** — pre-existing R4 concern;
@@ -253,6 +254,7 @@ and `dilutionCapApplied`. The retriever labels are explicitly
 - `apps/cms` source-side: feat-109 (PR #852).
 - Plan: `docs/plans/2026-04-29-002-feat-search-cms-to-admin-keyword-first-port-plan.md`.
 - R4 sibling: `docs/solutions/platform/admin-hybrid-search-r4-pattern.md`.
+- Web consumer opt-in: `docs/solutions/web/web-search-admin-keyword-first-opt-in.md`.
 - Workflow miss this corrects:
   `docs/solutions/workflow-issues/check-migration-playbook-before-extending-source-side-20260429.md`.
 - Inherited-assumption discipline:

--- a/docs/solutions/web/web-search-admin-keyword-first-opt-in.md
+++ b/docs/solutions/web/web-search-admin-keyword-first-opt-in.md
@@ -1,0 +1,117 @@
+---
+title: "Web search Admin keyword-first opt-in"
+date: "2026-06-09"
+category: "web"
+module: "apps/web search"
+problem_type: "architecture_pattern"
+component: "service_object"
+severity: "medium"
+applies_when:
+  - "A consumer app should opt into a provider-owned GraphQL or API mode at a shared data boundary."
+  - "Input strategy selection must remain separate from response degradation or health signals."
+  - "Multiple UI callers share one search helper and should inherit the same product-level search behavior."
+related_components:
+  - "apps/web/src/lib/search.ts"
+  - "apps/web/src/lib/search.test.ts"
+  - "apps/admin/src/graphql/queries/hybrid-search.ts"
+tags:
+  - "web"
+  - "search"
+  - "keyword-first"
+  - "admin-graphql"
+  - "boundary-contract"
+---
+
+# Web search Admin keyword-first opt-in
+
+## Context
+
+`apps/web` search called Admin `Query.search` without `mode`, so Admin used its default hybrid pipeline. Admin already supported `mode: "keyword-first"` as a nullable `String` argument, while response `searchMode` still meant the degradation signal (`"hybrid"` or `"keyword-only"`).
+
+The web product cutover needed all web search callers to move together: floating search, shared load-more results, and demo search. It did not need a visible mode selector or a wider server-action input.
+
+## Guidance
+
+Opt in at the shared data boundary. In `apps/web/src/lib/search.ts`, define a private consumer-level constant, add `$mode: String` to the typed `adminGraphql` operation, pass `mode: $mode` to `search`, and include `mode: WEB_SEARCH_MODE` in the Apollo variables.
+
+```ts
+const WEB_SEARCH_MODE = "keyword-first"
+
+const searchVideosOperation = adminGraphql(`
+  query Search(
+    $q: String!
+    $locale: String!
+    $limit: Int
+    $offset: Int
+    $type: HybridSearchContentType
+    $mode: String
+  ) {
+    search(q: $q, locale: $locale, limit: $limit, offset: $offset, type: $type, mode: $mode) {
+      searchMode
+      results {
+        id
+        title
+      }
+    }
+  }
+`)
+```
+
+Keep `searchVideos(query, limit, offset, type?)` and `runSearch(input)` unchanged unless callers need runtime mode selection. A fixed app-level constant is enough for a product cutover and avoids leaking Admin pipeline details into UI components.
+
+Keep input `mode` separate from response `searchMode`. `mode` selects the retrieval pipeline; `searchMode` reports whether Admin degraded from semantic plus keyword retrieval to keyword-only.
+
+## Why This Matters
+
+Omitting a nullable GraphQL argument fails silently: the request remains valid, but behavior falls back to the provider default. A boundary constant makes web's chosen behavior explicit and ensures every web search caller moves together.
+
+The app-side test should prove the wire contract, not Admin ranking. Web owns "did we send the right operation and variables?" Admin owns "did keyword-first rank correctly?"
+
+## When to Apply
+
+- A backend exposes a forward-compatible nullable `mode` or behavior flag.
+- Existing default behavior must remain stable for other consumers.
+- One consumer app is ready to opt in globally.
+- The mode should not be user-visible or caller-configurable yet.
+- A similarly named response field already exists and must keep its own meaning.
+
+## Examples
+
+The regression test should print the captured GraphQL document from the mocked client call and assert both `$mode: String` and `mode: $mode` are present. It should also assert exact variables, including `type: undefined` for unfiltered search and the content-type enum for filtered search.
+
+```ts
+const options = lastSearchQueryCall()
+const printed = print(options.query)
+
+expect(printed).toMatch(/\$mode:\s*String\b/)
+expect(printed).toMatch(/search\([^)]*mode:\s*\$mode/)
+expect(options.variables).toEqual({
+  q: "jesus",
+  locale: "en",
+  limit: 20,
+  offset: 0,
+  type: undefined,
+  mode: "keyword-first",
+})
+```
+
+Add a response mapping assertion beside the request-mode assertions:
+
+```ts
+mockSearchResponse("KEYWORD_ONLY")
+
+const data = await searchVideos("jesus")
+
+expect(data.searchMode).toBe("keyword-only")
+expect(lastSearchQueryCall().variables.mode).toBe("keyword-first")
+```
+
+That keeps the two mode concepts from collapsing into each other during later refactors.
+
+## Related
+
+- [Admin hybrid search keyword-first mode](../platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md)
+- [Admin hybrid search R4 pattern](../platform/admin-hybrid-search-r4-pattern.md)
+- [Dual-client gql.tada multi-schema codegen pattern](../architecture-patterns/dual-client-gql-tada-multi-schema-codegen-pattern-20260507.md)
+- [Codegen strips optional GraphQL variable definitions from DocumentNode AST](../cms/codegen-strips-optional-graphql-variables.md)
+- [GraphQL callsite inventory dual-pattern sweep](../best-practices/graphql-callsite-inventory-dual-pattern-sweep-20260507.md)


### PR DESCRIPTION
## Summary
- Opt apps/web Admin search calls into `mode: "keyword-first"` at the shared `searchVideos` boundary.
- Add focused contract coverage for the GraphQL mode argument, variables, type filtering, and `searchMode` degradation normalization.
- Add CE plan, roadmap, and solution docs for the web consumer opt-in.

## Validation
- `pnpm --filter @forge/web test -- src/lib/search.test.ts`
- `pnpm --filter @forge/web lint`
- `pnpm --filter @forge/web typecheck`
- `git diff --check`
- Python stdlib frontmatter safety check for new plan/ticket/solution docs

## Notes
- Admin `Query.search.mode` already exists; this is a web consumer opt-in only.
