### PR TITLE
fix(docs): format mapper catalog learning

### DIFF
--- a/docs/solutions/architecture-patterns/admin-mapper-catalog-projection-narrow-bearer-pattern-20260609.md
+++ b/docs/solutions/architecture-patterns/admin-mapper-catalog-projection-narrow-bearer-pattern-20260609.md
@@ -125,7 +125,9 @@ permission and bearer role instead of widening an existing shared principal:
 const VIDEO_MAPPER_PERMISSIONS = new Set(["read:video-mapper-catalog"])
 
 // apps/admin/src/graphql/types/video.ts
-authScopes: { hasPermission: "read:video-mapper-catalog" }
+authScopes: {
+  hasPermission: "read:video-mapper-catalog"
+}
 ```
 
 Back the bearer with an optional env-CSV keyring such as
@@ -215,6 +217,7 @@ Tests should cover both the public contract and the implementation boundary:
   ```
 
   It is skipped unless `VIDEO_MAPPER_CATALOG_DB_TEST=1` is set.
+
 - Auth tests proving the mapper bearer mints `VIDEO_MAPPER`, only grants
   `read:video-mapper-catalog`, stays disjoint from other env CSVs, and uses a
   service-specific rate-limit bucket.


### PR DESCRIPTION
## Summary

Formats the YTM-002 compound learning with Prettier so the already-merged mapper catalog work can pass the main `format` gate.

## Verification

- `pnpm run format:check`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.11.2/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/architecture-patterns/admin-mapper-catalog-projection-narrow-bearer-pattern-20260609.md`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
