### PR TITLE
Add bearer input to keyword search canary

### DIFF
--- a/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
+++ b/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
@@ -69,6 +69,8 @@ export function DemoSearchClient() {
   const [algoliaPane, setAlgoliaPane] = useState<AlgoliaPaneState>({
     status: "idle",
   })
+  const [bearerTokenInput, setBearerTokenInput] = useState("")
+  const [submittedBearerToken, setSubmittedBearerToken] = useState("")
 
   // Fire on URL change (effective query). Empty q skips.
   useEffect(() => {
@@ -97,12 +99,14 @@ export function DemoSearchClient() {
         locale: urlLocale,
         limit: urlLimit,
         mode: "hybrid",
+        bearerToken: submittedBearerToken,
       }),
       runSearch({
         q: trimmed,
         locale: urlLocale,
         limit: urlLimit,
         mode: "keyword-first",
+        bearerToken: submittedBearerToken,
       }),
       searchAlgolia({ q: trimmed, locale: urlLocale, limit: urlLimit }),
     ]).then((settled) => {
@@ -123,7 +127,7 @@ export function DemoSearchClient() {
     return () => {
       cancelled = true
     }
-  }, [urlQ, urlLocale, urlLimit])
+  }, [urlQ, urlLocale, urlLimit, submittedBearerToken])
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -136,6 +140,7 @@ export function DemoSearchClient() {
     )
     next.set("limit", String(form.get("limit") ?? DEFAULTS.limit))
     next.set("k", String(form.get("k") ?? DEFAULTS.k))
+    setSubmittedBearerToken(bearerTokenInput.trim())
     router.push(`?${next.toString()}`)
   }
 
@@ -213,7 +218,8 @@ export function DemoSearchClient() {
         onSubmit={handleSubmit}
         style={{
           display: "grid",
-          gridTemplateColumns: "1fr 120px 100px 100px auto",
+          gridTemplateColumns:
+            "minmax(220px, 1fr) 120px 100px 100px minmax(220px, 0.7fr) auto",
           gap: 8,
           alignItems: "end",
           marginBottom: 16,
@@ -252,6 +258,18 @@ export function DemoSearchClient() {
             min={1}
             max={50}
             defaultValue={urlK}
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Bearer token">
+          <input
+            name="bearerToken"
+            type="password"
+            value={bearerTokenInput}
+            onChange={(e) => setBearerTokenInput(e.currentTarget.value)}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="optional"
             style={inputStyle}
           />
         </Field>
@@ -304,10 +322,13 @@ async function runSearch(args: {
   locale: string
   limit: number
   mode: ModeKey
+  bearerToken: string
 }): Promise<SearchResponse> {
-  const result = await executeGraphQL<DemoSearchData, typeof args>(
+  const { bearerToken, ...variables } = args
+  const result = await executeGraphQL<DemoSearchData, typeof variables>(
     SEARCH_OPERATION,
-    args,
+    variables,
+    { bearerToken },
   )
   if (!result.ok) {
     throw new Error(result.errors.map((e) => e.message).join("; "))

--- a/apps/admin/src/app/watch/demo-keyword-search/graphql-client.test.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/graphql-client.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { executeGraphQL } from "./graphql-client"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function mockGraphQLResponse() {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(
+      new Response(JSON.stringify({ data: { ok: true } }), { status: 200 }),
+    )
+}
+
+function lastFetchHeaders(fetchMock: ReturnType<typeof mockGraphQLResponse>) {
+  const init = fetchMock.mock.calls.at(-1)?.[1]
+  expect(init).toBeDefined()
+  return init?.headers as Record<string, string>
+}
+
+describe("executeGraphQL", () => {
+  it("does not send an Authorization header without a bearer token", async () => {
+    const fetchMock = mockGraphQLResponse()
+
+    await executeGraphQL<{ ok: boolean }, { q: string }>("query", {
+      q: "jesus",
+    })
+
+    expect(lastFetchHeaders(fetchMock)).toEqual({
+      "Content-Type": "application/json",
+    })
+  })
+
+  it("sends a raw bearer token as an Authorization header", async () => {
+    const fetchMock = mockGraphQLResponse()
+
+    await executeGraphQL<{ ok: boolean }, { q: string }>(
+      "query",
+      { q: "jesus" },
+      { bearerToken: "search-token" },
+    )
+
+    expect(lastFetchHeaders(fetchMock).Authorization).toBe(
+      "Bearer search-token",
+    )
+  })
+
+  it("preserves an already-prefixed bearer token", async () => {
+    const fetchMock = mockGraphQLResponse()
+
+    await executeGraphQL<{ ok: boolean }, { q: string }>(
+      "query",
+      { q: "jesus" },
+      { bearerToken: "Bearer search-token" },
+    )
+
+    expect(lastFetchHeaders(fetchMock).Authorization).toBe(
+      "Bearer search-token",
+    )
+  })
+})

--- a/apps/admin/src/app/watch/demo-keyword-search/graphql-client.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/graphql-client.ts
@@ -14,15 +14,33 @@ export type GraphQLResult<T> =
   | { ok: true; data: T }
   | { ok: false; errors: Array<{ message: string }> }
 
+export type ExecuteGraphQLOptions = {
+  bearerToken?: string
+}
+
+function authorizationHeaderValue(token: string | undefined): string | null {
+  const trimmed = token?.trim()
+  if (!trimmed) return null
+  return /^Bearer\s+/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`
+}
+
 export async function executeGraphQL<
   TData,
   TVars extends Record<string, unknown>,
->(query: string, variables: TVars): Promise<GraphQLResult<TData>> {
+>(
+  query: string,
+  variables: TVars,
+  options: ExecuteGraphQLOptions = {},
+): Promise<GraphQLResult<TData>> {
   let response: Response
+  const authorization = authorizationHeaderValue(options.bearerToken)
   try {
     response = await fetch("/api/graphql", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(authorization ? { Authorization: authorization } : {}),
+      },
       body: JSON.stringify({ query, variables }),
     })
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add a password-style bearer token input to `/watch/demo-keyword-search`.
- Send the submitted token as an optional `Authorization` header for both canary GraphQL search calls.
- Keep the token out of URL params, GraphQL variables, and storage.
- Add route-local coverage for raw and already-prefixed bearer values.

## Validation
- `pnpm --filter @forge/admin test -- src/app/watch/demo-keyword-search/graphql-client.test.ts`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin typecheck`
- `git diff --check`

## Notes
- No secret or Railway key is committed; operators paste a valid search bearer into the canary page at runtime.
