### PR TITLE
Fix keyword search canary auth

### DIFF
--- a/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
+++ b/apps/admin/src/app/watch/demo-keyword-search/demo-search-client.tsx
@@ -2,13 +2,8 @@
 
 import { useRouter, useSearchParams } from "next/navigation"
 import { useEffect, useMemo, useState, type FormEvent } from "react"
-import { executeGraphQL } from "./graphql-client"
-import {
-  SEARCH_OPERATION,
-  type DemoSearchData,
-  type SearchResponse,
-  type SearchResult,
-} from "./search-operation"
+import { type SearchResponse, type SearchResult } from "./search-operation"
+import { searchAdminGraphQL } from "./search-action"
 import {
   buildProvenanceMap,
   computeThreeWayDiff,
@@ -69,8 +64,6 @@ export function DemoSearchClient() {
   const [algoliaPane, setAlgoliaPane] = useState<AlgoliaPaneState>({
     status: "idle",
   })
-  const [bearerTokenInput, setBearerTokenInput] = useState("")
-  const [submittedBearerToken, setSubmittedBearerToken] = useState("")
 
   // Fire on URL change (effective query). Empty q skips.
   useEffect(() => {
@@ -99,14 +92,12 @@ export function DemoSearchClient() {
         locale: urlLocale,
         limit: urlLimit,
         mode: "hybrid",
-        bearerToken: submittedBearerToken,
       }),
       runSearch({
         q: trimmed,
         locale: urlLocale,
         limit: urlLimit,
         mode: "keyword-first",
-        bearerToken: submittedBearerToken,
       }),
       searchAlgolia({ q: trimmed, locale: urlLocale, limit: urlLimit }),
     ]).then((settled) => {
@@ -127,7 +118,7 @@ export function DemoSearchClient() {
     return () => {
       cancelled = true
     }
-  }, [urlQ, urlLocale, urlLimit, submittedBearerToken])
+  }, [urlQ, urlLocale, urlLimit])
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -140,7 +131,6 @@ export function DemoSearchClient() {
     )
     next.set("limit", String(form.get("limit") ?? DEFAULTS.limit))
     next.set("k", String(form.get("k") ?? DEFAULTS.k))
-    setSubmittedBearerToken(bearerTokenInput.trim())
     router.push(`?${next.toString()}`)
   }
 
@@ -218,8 +208,7 @@ export function DemoSearchClient() {
         onSubmit={handleSubmit}
         style={{
           display: "grid",
-          gridTemplateColumns:
-            "minmax(220px, 1fr) 120px 100px 100px minmax(220px, 0.7fr) auto",
+          gridTemplateColumns: "minmax(220px, 1fr) 120px 100px 100px auto",
           gap: 8,
           alignItems: "end",
           marginBottom: 16,
@@ -258,18 +247,6 @@ export function DemoSearchClient() {
             min={1}
             max={50}
             defaultValue={urlK}
-            style={inputStyle}
-          />
-        </Field>
-        <Field label="Bearer token">
-          <input
-            name="bearerToken"
-            type="password"
-            value={bearerTokenInput}
-            onChange={(e) => setBearerTokenInput(e.currentTarget.value)}
-            autoComplete="off"
-            spellCheck={false}
-            placeholder="optional"
             style={inputStyle}
           />
         </Field>
@@ -322,18 +299,8 @@ async function runSearch(args: {
   locale: string
   limit: number
   mode: ModeKey
-  bearerToken: string
 }): Promise<SearchResponse> {
-  const { bearerToken, ...variables } = args
-  const result = await executeGraphQL<DemoSearchData, typeof variables>(
-    SEARCH_OPERATION,
-    variables,
-    { bearerToken },
-  )
-  if (!result.ok) {
-    throw new Error(result.errors.map((e) => e.message).join("; "))
-  }
-  return result.data.search
+  return await searchAdminGraphQL(args)
 }
 
 function toPaneState(settled: PromiseSettledResult<SearchResponse>): PaneState {

--- a/apps/admin/src/app/watch/demo-keyword-search/graphql-client.test.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/graphql-client.test.ts
@@ -60,4 +60,26 @@ describe("executeGraphQL", () => {
       "Bearer search-token",
     )
   })
+
+  it("supports server-side endpoint and origin options", async () => {
+    const fetchMock = mockGraphQLResponse()
+
+    await executeGraphQL<{ ok: boolean }, { q: string }>(
+      "query",
+      { q: "jesus" },
+      {
+        endpoint: "https://admin.example/api/graphql",
+        bearerToken: "search-token",
+        origin: "https://admin.example",
+      },
+    )
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe("https://admin.example/api/graphql")
+    expect((init as RequestInit).cache).toBe("no-store")
+    expect(lastFetchHeaders(fetchMock)).toMatchObject({
+      Authorization: "Bearer search-token",
+      Origin: "https://admin.example",
+    })
+  })
 })

--- a/apps/admin/src/app/watch/demo-keyword-search/graphql-client.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/graphql-client.ts
@@ -1,7 +1,8 @@
 /**
  * Thin fetch wrapper for admin's own GraphQL endpoint at /api/graphql.
  *
- * Same-origin POST from the browser. Returns a discriminated outcome:
+ * Defaults to same-origin browser POST; server actions may pass an
+ * absolute endpoint and server-side bearer. Returns a discriminated outcome:
  * - { ok: true, data } when the response carries data with no errors
  * - { ok: false, errors } when GraphQL returned errors[]
  * - { ok: false, errors: [{ message: ... }] } on network / parse failure
@@ -16,6 +17,8 @@ export type GraphQLResult<T> =
 
 export type ExecuteGraphQLOptions = {
   bearerToken?: string
+  endpoint?: string
+  origin?: string | null
 }
 
 function authorizationHeaderValue(token: string | undefined): string | null {
@@ -34,14 +37,17 @@ export async function executeGraphQL<
 ): Promise<GraphQLResult<TData>> {
   let response: Response
   const authorization = authorizationHeaderValue(options.bearerToken)
+  const origin = options.origin?.trim()
   try {
-    response = await fetch("/api/graphql", {
+    response = await fetch(options.endpoint ?? "/api/graphql", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...(authorization ? { Authorization: authorization } : {}),
+        ...(origin ? { Origin: origin } : {}),
       },
       body: JSON.stringify({ query, variables }),
+      cache: "no-store",
     })
   } catch (error) {
     return {

--- a/apps/admin/src/app/watch/demo-keyword-search/page.tsx
+++ b/apps/admin/src/app/watch/demo-keyword-search/page.tsx
@@ -6,9 +6,10 @@
  * and a top-K overlap/divergence panel.
  *
  * Public route — no requireSession() gate. Public-shape data only.
- * The `debug` payload is origin-gated server-side; same-origin
- * requests pass the gate by default in dev/preview, and prod
- * requires SEARCH_DEBUG_ALLOWED_ORIGINS to include admin's origin.
+ * The browser calls a server action, and that action attaches the
+ * configured server-side search bearer before hitting Admin GraphQL.
+ * The `debug` payload is still origin-gated server-side; prod requires
+ * SEARCH_DEBUG_ALLOWED_ORIGINS to include admin's origin.
  *
  * See docs/plans/2026-04-29-005-feat-admin-keyword-search-demo-route-plan.md
  */

--- a/apps/admin/src/app/watch/demo-keyword-search/search-action.test.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/search-action.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const headersMock = vi.hoisted(() => vi.fn())
+
+vi.mock("next/headers", () => ({
+  headers: headersMock,
+}))
+
+vi.mock("@/config/env", () => ({
+  env: {
+    ADMIN_BASE_URL: "https://admin.example",
+    WEB_ADMIN_API_KEYS: " first-key , second-key ",
+  },
+}))
+
+import { env } from "@/config/env"
+import { searchAdminGraphQL } from "./search-action"
+
+const ENV = env as {
+  ADMIN_BASE_URL: string | undefined
+  WEB_ADMIN_API_KEYS: string | undefined
+}
+
+describe("searchAdminGraphQL", () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    headersMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+    ENV.ADMIN_BASE_URL = "https://admin.example"
+    ENV.WEB_ADMIN_API_KEYS = " first-key , second-key "
+    headersMock.mockResolvedValue(
+      new Headers({
+        origin: "https://admin.example",
+        "x-forwarded-host": "ignored.example",
+        "x-forwarded-proto": "https",
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function searchResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        data: {
+          search: {
+            hasMore: false,
+            query: "jesus",
+            searchMode: "HYBRID",
+            results: [],
+          },
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    )
+  }
+
+  it("calls admin GraphQL with the first configured WEB_ADMIN_API_KEYS bearer", async () => {
+    fetchMock.mockResolvedValueOnce(searchResponse())
+
+    await expect(
+      searchAdminGraphQL({
+        q: "jesus",
+        locale: "en",
+        limit: 3,
+        mode: "keyword-first",
+      }),
+    ).resolves.toMatchObject({ query: "jesus", searchMode: "HYBRID" })
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe("https://admin.example/api/graphql")
+    expect((init as RequestInit).method).toBe("POST")
+    expect((init as RequestInit).cache).toBe("no-store")
+    expect((init as RequestInit).headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer first-key",
+      Origin: "https://admin.example",
+    })
+    expect(JSON.parse(String((init as RequestInit).body)).variables).toEqual({
+      q: "jesus",
+      locale: "en",
+      limit: 3,
+      mode: "keyword-first",
+      debug: true,
+    })
+  })
+
+  it("infers the GraphQL endpoint from request headers when ADMIN_BASE_URL is unset", async () => {
+    ENV.ADMIN_BASE_URL = undefined
+    headersMock.mockResolvedValueOnce(
+      new Headers({
+        "x-forwarded-host": "preview.example",
+        "x-forwarded-proto": "https",
+      }),
+    )
+    fetchMock.mockResolvedValueOnce(searchResponse())
+
+    await searchAdminGraphQL({
+      q: "jesus",
+      locale: "en",
+      limit: 3,
+      mode: "hybrid",
+    })
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://preview.example/api/graphql",
+    )
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toMatchObject(
+      {
+        Origin: "https://preview.example",
+      },
+    )
+  })
+
+  it("fails before fetch when WEB_ADMIN_API_KEYS is missing", async () => {
+    ENV.WEB_ADMIN_API_KEYS = undefined
+
+    await expect(
+      searchAdminGraphQL({
+        q: "jesus",
+        locale: "en",
+        limit: 3,
+        mode: "hybrid",
+      }),
+    ).rejects.toThrow("demo_search_bearer_not_configured")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("surfaces GraphQL errors from the server-side call", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          errors: [{ message: "Authentication required" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+
+    await expect(
+      searchAdminGraphQL({
+        q: "jesus",
+        locale: "en",
+        limit: 3,
+        mode: "hybrid",
+      }),
+    ).rejects.toThrow("Authentication required")
+  })
+})

--- a/apps/admin/src/app/watch/demo-keyword-search/search-action.ts
+++ b/apps/admin/src/app/watch/demo-keyword-search/search-action.ts
@@ -1,0 +1,109 @@
+"use server"
+
+/**
+ * Server-side GraphQL proxy for the keyword-search canary.
+ *
+ * The canary runs in an operator browser, but the search bearer must
+ * stay server-side. This action calls Admin's own GraphQL endpoint
+ * with a bearer sourced from WEB_ADMIN_API_KEYS, so production canary
+ * searches work without copying secrets into the page.
+ */
+
+import { headers as nextHeaders } from "next/headers"
+import { env } from "@/config/env"
+import { executeGraphQL } from "./graphql-client"
+import {
+  SEARCH_OPERATION,
+  type DemoSearchData,
+  type SearchResponse,
+} from "./search-operation"
+
+type SearchMode = "hybrid" | "keyword-first"
+
+type SearchVariables = {
+  q: string
+  locale: string
+  limit: number
+  mode: SearchMode
+  debug: boolean
+}
+
+export async function searchAdminGraphQL(args: {
+  q: string
+  locale: string
+  limit: number
+  mode: SearchMode
+}): Promise<SearchResponse> {
+  const requestHeaders = await nextHeaders()
+  const origin = requestOrigin(requestHeaders)
+  const result = await executeGraphQL<DemoSearchData, SearchVariables>(
+    SEARCH_OPERATION,
+    {
+      q: args.q,
+      locale: args.locale,
+      limit: args.limit,
+      mode: args.mode,
+      debug: true,
+    },
+    {
+      endpoint: adminGraphQLEndpoint(origin),
+      bearerToken: serverSearchBearer(),
+      origin,
+    },
+  )
+
+  if (!result.ok) {
+    throw new Error(result.errors.map((e) => e.message).join("; "))
+  }
+  return result.data.search
+}
+
+function serverSearchBearer(): string {
+  const token = firstCsvValue(env.WEB_ADMIN_API_KEYS)
+  if (!token) {
+    throw new Error(
+      "demo_search_bearer_not_configured: set WEB_ADMIN_API_KEYS on admin",
+    )
+  }
+  return token
+}
+
+function adminGraphQLEndpoint(requestOriginValue: string | null): string {
+  const baseUrl = env.ADMIN_BASE_URL ?? requestOriginValue
+  if (!baseUrl) {
+    throw new Error(
+      "demo_search_base_url_not_configured: set ADMIN_BASE_URL on admin",
+    )
+  }
+  return `${baseUrl.replace(/\/+$/, "")}/api/graphql`
+}
+
+function requestOrigin(headers: Headers): string | null {
+  const explicitOrigin = firstHeaderValue(headers.get("origin"))
+  if (explicitOrigin) return explicitOrigin
+
+  const host =
+    firstHeaderValue(headers.get("x-forwarded-host")) ??
+    firstHeaderValue(headers.get("host"))
+  if (!host) return null
+  const proto =
+    firstHeaderValue(headers.get("x-forwarded-proto")) ??
+    (host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https")
+  return `${proto}://${host}`
+}
+
+function firstCsvValue(value: string | undefined): string | null {
+  return (
+    value
+      ?.split(",")
+      .map((part) => part.trim())
+      .find(Boolean) ?? null
+  )
+}
+
+function firstHeaderValue(value: string | null): string | null {
+  const first = value?.split(",")[0]?.trim()
+  return first && first.length > 0 ? first : null
+}


### PR DESCRIPTION
## Summary

- routes the keyword search canary GraphQL calls through a server action
- sources the search bearer from server-side `WEB_ADMIN_API_KEYS`
- removes the browser bearer-token input so the canary website can work without exposing or pasting secrets
- keeps `debug: true` on the canary call and forwards the request origin for the existing debug-origin gate

## Why

Production Admin GraphQL correctly requires a bearer for `Query.search`. The canary page was still making browser-originated GraphQL calls, so adding the key to Railway made the API accept the bearer but did not make the canary website send it. This moves that credential attachment server-side.

## Verification

- `pnpm --filter @forge/admin test -- src/app/watch/demo-keyword-search/graphql-client.test.ts src/app/watch/demo-keyword-search/search-action.test.ts src/app/watch/demo-keyword-search/algolia-action.test.ts`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin typecheck`
- `DATABASE_URL='postgresql://forge:forge@localhost:5432/forge_admin?connection_limit=10&pool_timeout=20' DATABASE_URL_SYNC='postgresql://forge:forge@localhost:5432/forge_admin?connection_limit=5&pool_timeout=60' ADMIN_SESSION_SECRET='forge-admin-local-dev-secret-change-me-before-production-00' AUTH_ISSUER_URL='https://auth.jesusfilm.org/api/auth' AUTH_ADMIN_CLIENT_ID='jfp_admin_local' ADMIN_BASE_URL='http://localhost:3003' WEB_ADMIN_API_KEYS='local-build-search-key' pnpm --filter @forge/admin build`

Note: the local build still emits existing Turbopack Edge-runtime warnings from backup/workflow imports, but completed successfully.
