### PR TITLE
feat(web): add watch bible quotes hide flag

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -54,6 +54,7 @@ FORGE_WATCH_CTA_TEXT_COPY_DEFAULT=false
 # unauthenticated downloads available until rollout starts.
 FORGE_WATCH_DOWNLOAD_ACCOUNT_GATE_DEFAULT=false
 FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT=false
+FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=false
 FORGE_WATCH_QUESTION_PANEL_DEFAULT=false
 
 # Inline watch-player migration. Existing build-time flag; kept for dynamic

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -102,6 +102,13 @@ and skips YouVersion API calls; `true` enables the server fetch when
 `FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT=false` unless intentionally
 smoke-testing the panel locally.
 
+`forge.watch.hideBibleQuotes` is a temporary LaunchDarkly-backed release flag
+for hiding the full watch-page Bible Quotes band. `false` keeps the existing
+band, including quote cards, promo card, and section-local Share button;
+`true` hides that band on synthetic watch pages. Keep
+`FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=false` unless intentionally testing the
+hidden state locally.
+
 `forge.watch.questionPanel` is a temporary LaunchDarkly-backed release flag
 for the watch-page floating question panel. `false` hides the panel;
 `true` renders the floating input and message-type selector. Keep

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
@@ -27,6 +27,7 @@ const {
   experienceErrorMock,
   isWatchCtaTextCopyEnabledMock,
   isWatchYouVersionBibleQuotesEnabledMock,
+  isWatchHideBibleQuotesEnabledMock,
   fetchYouVersionBibleQuotePassagesMock,
   isWatchQuestionPanelEnabledMock,
 } = vi.hoisted(() => ({
@@ -53,6 +54,7 @@ const {
   experienceErrorMock: vi.fn(() => null),
   isWatchCtaTextCopyEnabledMock: vi.fn(async () => false),
   isWatchYouVersionBibleQuotesEnabledMock: vi.fn(async () => false),
+  isWatchHideBibleQuotesEnabledMock: vi.fn(async () => false),
   fetchYouVersionBibleQuotePassagesMock: vi.fn(),
   isWatchQuestionPanelEnabledMock: vi.fn(async () => false),
 }))
@@ -114,6 +116,7 @@ vi.mock("@/components/sections", () => ({
 vi.mock("@/lib/feature-flags", () => ({
   isWatchCtaTextCopyEnabled: isWatchCtaTextCopyEnabledMock,
   isWatchYouVersionBibleQuotesEnabled: isWatchYouVersionBibleQuotesEnabledMock,
+  isWatchHideBibleQuotesEnabled: isWatchHideBibleQuotesEnabledMock,
   isWatchQuestionPanelEnabled: isWatchQuestionPanelEnabledMock,
 }))
 
@@ -167,6 +170,8 @@ beforeEach(() => {
   isWatchCtaTextCopyEnabledMock.mockResolvedValue(false)
   isWatchYouVersionBibleQuotesEnabledMock.mockReset()
   isWatchYouVersionBibleQuotesEnabledMock.mockResolvedValue(false)
+  isWatchHideBibleQuotesEnabledMock.mockReset()
+  isWatchHideBibleQuotesEnabledMock.mockResolvedValue(false)
   fetchYouVersionBibleQuotePassagesMock.mockReset()
   fetchYouVersionBibleQuotePassagesMock.mockResolvedValue([])
   isWatchQuestionPanelEnabledMock.mockReset()
@@ -477,6 +482,7 @@ describe("Catch-all routing — series branch (2-seg)", () => {
     expect(watchPageClientMock).toHaveBeenCalledTimes(1)
     expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
+        hideBibleQuotes: false,
         questionPanelEnabled: false,
       }),
     )
@@ -571,6 +577,30 @@ describe("Catch-all routing — series branch (2-seg)", () => {
         reference: "JHN.3.16",
       }),
     ])
+  })
+
+  it("passes the Bible Quotes hide flag to WatchPageClient and skips YouVersion fetches when enabled", async () => {
+    isWatchHideBibleQuotesEnabledMock.mockResolvedValue(true)
+    isWatchYouVersionBibleQuotesEnabledMock.mockResolvedValue(true)
+    const watchVideoResult = makeWatchVideoResult("featureFilm")
+    const bibleCitations = makeBibleCitations()
+    ;(
+      watchVideoResult.video as { bibleCitations?: typeof bibleCitations }
+    ).bibleCitations = bibleCitations
+    resolveWatchVideoBySlugMock.mockResolvedValue(watchVideoResult)
+
+    await render2Seg("jesus.html", "english.html")
+
+    expect(isWatchHideBibleQuotesEnabledMock).toHaveBeenCalledWith({
+      custom: { route: "/watch/jesus.html/english.html" },
+    })
+    expect(isWatchYouVersionBibleQuotesEnabledMock).not.toHaveBeenCalled()
+    expect(fetchYouVersionBibleQuotePassagesMock).not.toHaveBeenCalled()
+    expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        hideBibleQuotes: true,
+      }),
+    )
   })
 
   it("passes the LaunchDarkly CTA copy label to WatchPageClient when enabled", async () => {
@@ -975,6 +1005,29 @@ describe("Catch-all routing — 3-seg episode branch", () => {
         reference: "JHN.3.16",
       }),
     ])
+  })
+
+  it("passes the Bible Quotes hide flag to episode WatchPageClient when enabled", async () => {
+    isWatchHideBibleQuotesEnabledMock.mockResolvedValue(true)
+    resolveSeriesEpisodeBySlugMock.mockResolvedValue(makeEpisodeResult())
+
+    await render3Seg(
+      "lumo-the-gospel-of-john.html",
+      "wedding-in-cana",
+      "english.html",
+    )
+
+    expect(isWatchHideBibleQuotesEnabledMock).toHaveBeenCalledWith({
+      custom: {
+        route:
+          "/watch/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+      },
+    })
+    expect(watchPageClientMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        hideBibleQuotes: true,
+      }),
+    )
   })
 
   it("passes the LaunchDarkly question panel flag to WatchPageClient when enabled", async () => {

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -26,6 +26,7 @@ import {
 import { resolveWatchHome } from "@/lib/watch-home"
 import {
   isWatchCtaTextCopyEnabled,
+  isWatchHideBibleQuotesEnabled,
   isWatchQuestionPanelEnabled,
   isWatchYouVersionBibleQuotesEnabled,
 } from "@/lib/feature-flags"
@@ -185,6 +186,12 @@ async function getYouVersionBibleQuotePassages(
 
 async function getQuestionPanelEnabled(route: string): Promise<boolean> {
   return isWatchQuestionPanelEnabled({
+    custom: { route },
+  })
+}
+
+async function getHideBibleQuotesEnabled(route: string): Promise<boolean> {
+  return isWatchHideBibleQuotesEnabled({
     custom: { route },
   })
 }
@@ -364,12 +371,18 @@ async function renderEpisode(shape: {
   }
 
   const route = `/watch/${seriesSlug}.html/${episodeSlug}/${rawLocale}.html`
-  const [downloadButtonLabel, questionPanelEnabled, youVersionPassages] =
+  const [downloadButtonLabel, questionPanelEnabled, hideBibleQuotes] =
     await Promise.all([
       getDownloadButtonLabel(route, locale),
       getQuestionPanelEnabled(route),
-      getYouVersionBibleQuotePassages(route, resolved.video.bibleCitations),
+      getHideBibleQuotesEnabled(route),
     ])
+  const youVersionPassages = hideBibleQuotes
+    ? []
+    : await getYouVersionBibleQuotePassages(
+        route,
+        resolved.video.bibleCitations,
+      )
   const mergedBlocks = mergeWatchExperience({
     video: resolved.video,
     variant: resolved.selectedVariant,
@@ -396,6 +409,7 @@ async function renderEpisode(shape: {
         video={resolved.video}
         languageSlug={resolved.selectedVariant.language?.slug ?? rawLocale}
         locale={locale}
+        hideBibleQuotes={hideBibleQuotes}
         questionPanelEnabled={questionPanelEnabled}
       />
     </>
@@ -480,12 +494,18 @@ async function renderVideo(shape: {
         />
       )
     }
-    const [downloadButtonLabel, questionPanelEnabled, youVersionPassages] =
+    const [downloadButtonLabel, questionPanelEnabled, hideBibleQuotes] =
       await Promise.all([
         getDownloadButtonLabel(route, locale),
         getQuestionPanelEnabled(route),
-        getYouVersionBibleQuotePassages(route, watchVideo.video.bibleCitations),
+        getHideBibleQuotesEnabled(route),
       ])
+    const youVersionPassages = hideBibleQuotes
+      ? []
+      : await getYouVersionBibleQuotePassages(
+          route,
+          watchVideo.video.bibleCitations,
+        )
     const mergedBlocks = mergeWatchExperience({
       video: watchVideo.video,
       variant: watchVideo.selectedVariant,
@@ -511,6 +531,7 @@ async function renderVideo(shape: {
           video={watchVideo.video}
           languageSlug={watchVideo.selectedVariant.language?.slug ?? rawLocale}
           locale={locale}
+          hideBibleQuotes={hideBibleQuotes}
           questionPanelEnabled={questionPanelEnabled}
         />
       </>

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -92,6 +92,7 @@ type WatchPageClientProps = {
    * BibleGateway "Read more..." link pick the right translation.
    */
   locale?: string
+  hideBibleQuotes?: boolean
   questionPanelEnabled?: boolean
 }
 
@@ -102,6 +103,7 @@ export function WatchPageClient({
   video,
   languageSlug,
   locale,
+  hideBibleQuotes = false,
   questionPanelEnabled = false,
 }: WatchPageClientProps) {
   // Lifted so LanguagePickerModal can read `currentTime` for the `?t=` clamp
@@ -308,6 +310,7 @@ export function WatchPageClient({
         locale={locale}
         languageSlug={currentLanguageSlug}
         subtitleVttSrc={subtitleVttSrc}
+        hideBibleQuotes={hideBibleQuotes}
       />
 
       <SubtitleTranscript

--- a/apps/web/src/components/watch/WatchSectionRenderer.tsx
+++ b/apps/web/src/components/watch/WatchSectionRenderer.tsx
@@ -38,6 +38,7 @@ export function WatchSectionRenderer({
   locale,
   languageSlug,
   subtitleVttSrc,
+  hideBibleQuotes = false,
 }: {
   blocks: MergedWatchBlock[]
   downloadButtonLabel?: string
@@ -48,6 +49,7 @@ export function WatchSectionRenderer({
   locale?: string
   languageSlug?: string
   subtitleVttSrc?: string | null
+  hideBibleQuotes?: boolean
 }) {
   // WatchBody owns both columns; the standalone StudyQuestions slot
   // renders as a hidden marker to avoid double-mounting.
@@ -83,6 +85,7 @@ export function WatchSectionRenderer({
           locale={locale}
           languageSlug={languageSlug}
           subtitleVttSrc={subtitleVttSrc}
+          hideBibleQuotes={hideBibleQuotes}
         />
       ))}
       {bodyBlocks.length > 0 ? (
@@ -118,6 +121,7 @@ export function WatchSectionRenderer({
                   onPlayerReady={onPlayerReady}
                   locale={locale}
                   languageSlug={languageSlug}
+                  hideBibleQuotes={hideBibleQuotes}
                 />
               ))}
             </div>
@@ -140,6 +144,7 @@ function WatchBlockEntry({
   locale,
   languageSlug,
   subtitleVttSrc,
+  hideBibleQuotes,
 }: {
   block: MergedWatchBlock
   index: number
@@ -152,6 +157,7 @@ function WatchBlockEntry({
   locale?: string
   languageSlug?: string
   subtitleVttSrc?: string | null
+  hideBibleQuotes: boolean
 }) {
   if (isWatchBlock(block)) {
     return (
@@ -166,6 +172,7 @@ function WatchBlockEntry({
         locale={locale}
         languageSlug={languageSlug}
         subtitleVttSrc={subtitleVttSrc}
+        hideBibleQuotes={hideBibleQuotes}
       />
     )
   }
@@ -183,6 +190,7 @@ function SyntheticBlock({
   locale,
   languageSlug,
   subtitleVttSrc,
+  hideBibleQuotes,
 }: {
   block: WatchBlock
   downloadButtonLabel?: string
@@ -194,6 +202,7 @@ function SyntheticBlock({
   locale?: string
   languageSlug?: string
   subtitleVttSrc?: string | null
+  hideBibleQuotes: boolean
 }) {
   switch (block.kind) {
     case "HeroPlayer": {
@@ -238,6 +247,7 @@ function SyntheticBlock({
         />
       )
     case "BibleQuotes":
+      if (hideBibleQuotes) return null
       return (
         <BibleQuotesSection
           bibleCitations={block.bibleCitations}

--- a/apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx
@@ -391,6 +391,39 @@ describe("WatchSectionRenderer — synthetic block dispatch", () => {
     expect(content.hls).toBe("https://cdn.example/jesus.m3u8")
     expect(content.videoDocumentId).toBe("video-1")
   })
+
+  it("skips the synthetic BibleQuotes section when the watch hide flag is active", () => {
+    const video = makeVideo({
+      bibleCitations: [
+        {
+          bibleBook: { documentId: "bb-john", name: "John" },
+          chapterEnd: null,
+          chapterStart: 1,
+          documentId: "bc-1",
+          order: 1,
+          osisId: "John.1.1",
+          verseEnd: null,
+          verseStart: 1,
+        },
+      ],
+    })
+    const blocks: MergedWatchBlock[] = [
+      buildBibleQuotesBlock(
+        (video as { bibleCitations?: unknown[] }).bibleCitations as never,
+      ),
+      buildShareBlock(video),
+    ]
+
+    act(() => {
+      root.render(<WatchSectionRenderer blocks={blocks} hideBibleQuotes />)
+    })
+
+    expect(bibleQuotesSectionMock).not.toHaveBeenCalled()
+    expect(
+      container.querySelector('[data-block-type="BibleQuotes"]'),
+    ).toBeNull()
+    expect(container.querySelector('[data-block-type="Share"]')).not.toBeNull()
+  })
 })
 
 describe("WatchSectionRenderer — Strapi block delegation", () => {

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -106,6 +106,7 @@ export const env = createEnv({
     FORGE_WATCH_CTA_TEXT_COPY_DEFAULT: z.string().optional(),
     FORGE_WATCH_DOWNLOAD_ACCOUNT_GATE_DEFAULT: z.string().optional(),
     FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT: z.string().optional(),
+    FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT: z.string().optional(),
     FORGE_WATCH_QUESTION_PANEL_DEFAULT: z.string().optional(),
     // Admin GraphQL URL. Required — web's data layer reads from admin.
     ADMIN_GRAPHQL_URL: z
@@ -225,6 +226,8 @@ export const env = createEnv({
       process.env.FORGE_WATCH_DOWNLOAD_ACCOUNT_GATE_DEFAULT,
     FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT:
       process.env.FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT,
+    FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT:
+      process.env.FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT,
     FORGE_WATCH_QUESTION_PANEL_DEFAULT:
       process.env.FORGE_WATCH_QUESTION_PANEL_DEFAULT,
     ADMIN_GRAPHQL_URL: process.env.ADMIN_GRAPHQL_URL,

--- a/apps/web/src/lib/feature-flags.test.ts
+++ b/apps/web/src/lib/feature-flags.test.ts
@@ -14,6 +14,7 @@ function setRequiredWebEnv() {
   delete process.env.FORGE_WATCH_DOWNLOAD_ACCOUNT_GATE_DEFAULT
   delete process.env.FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT
   delete process.env.FORGE_WATCH_QUESTION_PANEL_DEFAULT
+  delete process.env.FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT
   delete process.env.NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION
   delete process.env.NEXT_PUBLIC_FORGE_WATCH_HERO_MUX_VIDEO
 }
@@ -108,6 +109,22 @@ describe("web feature flag helpers", () => {
     await expect(enabledWithFallback()).resolves.toBe(true)
   })
 
+  it("evaluates the watch Bible Quotes visibility flag from the server-side fallback and defaults off", async () => {
+    delete process.env.LAUNCHDARKLY_SDK_KEY
+
+    const { isWatchHideBibleQuotesEnabled } = await import("./feature-flags")
+
+    await expect(isWatchHideBibleQuotesEnabled()).resolves.toBe(false)
+
+    vi.resetModules()
+    process.env.FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT = "true"
+
+    const { isWatchHideBibleQuotesEnabled: enabledWithFallback } =
+      await import("./feature-flags")
+
+    await expect(enabledWithFallback()).resolves.toBe(true)
+  })
+
   it("keeps the watch question panel disabled by default", async () => {
     delete process.env.LAUNCHDARKLY_SDK_KEY
 
@@ -134,6 +151,7 @@ describe("web feature flag helpers", () => {
     process.env.FORGE_WATCH_DOWNLOAD_ACCOUNT_GATE_DEFAULT = "false"
     process.env.FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT = "true"
     process.env.FORGE_WATCH_QUESTION_PANEL_DEFAULT = "true"
+    process.env.FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT = "false"
     const booleanVariation = vi.fn(async () => false)
     const createFeatureFlagClient = vi.fn(() => ({ booleanVariation }))
 
@@ -160,6 +178,7 @@ describe("web feature flag helpers", () => {
           FORGE_WATCH_DOWNLOAD_ACCOUNT_GATE_DEFAULT: "false",
           FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT: "true",
           FORGE_WATCH_QUESTION_PANEL_DEFAULT: "true",
+          FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT: "false",
         },
         defaultValues: {
           "forge.watch.playerMigration": false,
@@ -168,6 +187,7 @@ describe("web feature flag helpers", () => {
           "forge.watch.downloadAccountGate": false,
           "forge.watch.youVersionBibleQuotes": false,
           "forge.watch.questionPanel": false,
+          "forge.watch.hideBibleQuotes": false,
         },
       }),
     )

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -26,6 +26,8 @@ const webFeatureFlagClient = createFeatureFlagClient({
       env.FORGE_WATCH_DOWNLOAD_ACCOUNT_GATE_DEFAULT,
     FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT:
       env.FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT,
+    FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT:
+      env.FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT,
     FORGE_WATCH_QUESTION_PANEL_DEFAULT: env.FORGE_WATCH_QUESTION_PANEL_DEFAULT,
   },
   defaultValues: {
@@ -34,6 +36,7 @@ const webFeatureFlagClient = createFeatureFlagClient({
     "forge.watch.ctaTextCopy": false,
     "forge.watch.downloadAccountGate": false,
     "forge.watch.youVersionBibleQuotes": false,
+    "forge.watch.hideBibleQuotes": false,
     "forge.watch.questionPanel": false,
   },
   timeoutSeconds: 0.25,
@@ -98,6 +101,15 @@ export async function isWatchYouVersionBibleQuotesEnabled(
 ): Promise<boolean> {
   return webFeatureFlagClient.booleanVariation(
     featureFlags.watchYouVersionBibleQuotes,
+    createWebFeatureFlagContext(context),
+  )
+}
+
+export async function isWatchHideBibleQuotesEnabled(
+  context: WebFeatureFlagContextInput = {},
+): Promise<boolean> {
+  return webFeatureFlagClient.booleanVariation(
+    featureFlags.watchHideBibleQuotes,
     createWebFeatureFlagContext(context),
   )
 }

--- a/docs/plans/2026-06-10-001-feat-watch-bible-quotes-visibility-flag-plan.md
+++ b/docs/plans/2026-06-10-001-feat-watch-bible-quotes-visibility-flag-plan.md
@@ -1,0 +1,175 @@
+---
+title: "Watch Bible Quotes Visibility Flag Plan"
+type: "feat"
+status: "complete"
+date: "2026-06-10"
+---
+
+# Watch Bible Quotes Visibility Flag Plan
+
+## Summary
+
+Add a default-off LaunchDarkly watch-page flag that can hide the entire Bible
+Quotes band on web watch pages while preserving the existing behavior when the
+flag is off.
+
+---
+
+## Problem Frame
+
+The web watch page already has `forge.watch.youVersionBibleQuotes`, but that
+flag only controls the YouVersion-backed passage panel and API fetch. Operators
+need a separate visibility switch that removes the whole Bible Quotes band from
+video watch pages, including the heading, quote cards, always-on promo card, and
+section-local share entry point.
+
+---
+
+## Requirements
+
+**Flag behavior**
+
+- R1. Add a new temporary boolean LaunchDarkly flag, defaulting off, for the
+  watch-page Bible Quotes band visibility.
+- R2. When the new flag is off, watch pages continue to render the Bible Quotes
+  band exactly as they do today.
+- R3. When the new flag is on, watch pages omit the entire Bible Quotes band,
+  including the quote cards, promo card, and share button rendered in that
+  section header.
+
+**Scope boundaries**
+
+- R4. Keep `forge.watch.youVersionBibleQuotes` focused on YouVersion passage
+  fetching and rendering; do not reuse it as a section visibility flag.
+- R5. Keep the new flag scoped to the synthetic watch-page Bible Quotes slot;
+  do not hide generic Experience-page `BibleQuotesCarousel` sections outside
+  the watch-page surface.
+- R6. Preserve server-side LaunchDarkly evaluation and local fallback behavior
+  when `LAUNCHDARKLY_SDK_KEY` is absent.
+
+**Operations and documentation**
+
+- R7. Document the new flag key, local fallback env var, default state, and
+  intended rollout behavior in the web guide and env example.
+- R8. Keep the roadmap feature status aligned with implementation progress.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. New flag instead of extending the YouVersion flag: the existing flag
+  controls API-backed passage enrichment, while this work controls section
+  visibility.
+- KTD2. Hide at the watch-block render boundary: the `BibleQuotes` slot should
+  still be representable in merged watch content, but rendering can skip it
+  when the visibility flag is active.
+- KTD3. Server-evaluate and pass plain state down: this follows the existing
+  Forge LaunchDarkly pattern and keeps SDK keys out of browser bundles.
+- KTD4. Use a negative local fallback name that matches operator intent:
+  `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=false` preserves current behavior and
+  reads naturally when flipped for smoke tests.
+
+---
+
+## Implementation Units
+
+### U1. Register the watch visibility flag
+
+- **Goal:** Add the shared flag definition and web helper path for the new
+  default-off boolean.
+- **Files:**
+  - `packages/feature-flags/src/registry.ts`
+  - `apps/web/src/env.ts`
+  - `apps/web/src/lib/feature-flags.ts`
+  - `apps/web/.env.example`
+  - `apps/web/CLAUDE.md`
+- **Patterns:** Follow `forge.watch.questionPanel` and
+  `forge.watch.youVersionBibleQuotes` for registry, fallback env, helper, and
+  docs shape.
+- **Test Scenarios:**
+  - Flag defaults to `false` when LaunchDarkly and local fallback env are both
+    absent.
+  - `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=true` makes the helper resolve
+    `true`.
+  - The shared feature flag client receives the new local fallback and
+    `false` default value.
+- **Verification:**
+  - `pnpm --filter @forge/web test -- src/lib/feature-flags.test.ts`
+
+### U2. Gate the watch-page Bible Quotes band
+
+- **Goal:** Evaluate the new flag on watch routes and skip rendering the
+  synthetic Bible Quotes band when it is enabled.
+- **Files:**
+  - `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+  - `apps/web/src/components/watch/WatchPageClient.tsx`
+  - `apps/web/src/components/watch/WatchSectionRenderer.tsx`
+  - `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+  - `apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx`
+- **Patterns:** Mirror the question panel flag threading from route to client
+  and the existing `BibleQuotes` switch branch in `WatchSectionRenderer`.
+- **Test Scenarios:**
+  - Feature-film watch route calls the new flag helper with the route context.
+  - Flag-off route props still include the `BibleQuotes` block.
+  - Flag-on route props communicate that Bible Quotes should be hidden.
+  - Renderer skips the `BibleQuotesSection` when the hide flag is active.
+  - Renderer still leaves generic Experience-page quote carousel behavior
+    untouched because this gate applies only to the synthetic watch renderer.
+- **Verification:**
+  - `pnpm --filter @forge/web test -- 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx' src/components/watch/__tests__/WatchSectionRenderer.test.tsx`
+
+### U3. Roadmap and rollout proof
+
+- **Goal:** Keep project tracking and LaunchDarkly operational notes aligned
+  with the code change.
+- **Files:**
+  - `docs/roadmap/platform/feat-169-watch-bible-quotes-visibility-flag.md`
+  - `docs/plans/2026-06-10-001-feat-watch-bible-quotes-visibility-flag-plan.md`
+- **Patterns:** Follow `docs/roadmap/platform/feat-145-watch-question-panel-flag.md`
+  for a small watch-page LaunchDarkly gate.
+- **Test Scenarios:**
+  - Roadmap ticket starts `in-progress` before implementation and flips
+    `complete` after validation.
+  - PR notes include the LaunchDarkly key, fallback env var, default targeting
+    behavior, and local validation evidence.
+- **Verification:**
+  - `git diff --check`
+
+---
+
+## Scope Boundaries
+
+- The new flag does not replace or change `forge.watch.youVersionBibleQuotes`.
+- The new flag does not globally hide every CMS-authored
+  `BibleQuotesCarouselBlock`.
+- The change does not redesign Bible Quotes cards, copy, carousel behavior, or
+  share modal behavior.
+- Creating or enabling the live LaunchDarkly flag in production requires
+  LaunchDarkly MCP access and should keep targeting off by default.
+
+---
+
+## Risks & Dependencies
+
+- The section-local share button disappears with the hidden band. This is part
+  of the requested scope, but browser proof should verify the page still has no
+  broken layout gap.
+- Detached worktree state must be moved onto a normal branch before committing.
+- LaunchDarkly remote flag creation may be blocked by unavailable MCP/OAuth
+  access. Code must still be safe with local fallback defaults.
+
+---
+
+## Sources / Research
+
+- `apps/web/CLAUDE.md` documents server-side LaunchDarkly conventions and the
+  existing YouVersion flag behavior.
+- `packages/feature-flags/src/registry.ts` contains the shared flag registry.
+- `apps/web/src/lib/feature-flags.ts` contains the web server-side flag helper
+  pattern.
+- `apps/web/src/lib/content.ts` currently always builds a `BibleQuotes` watch
+  block.
+- `apps/web/src/components/watch/WatchSectionRenderer.tsx` renders the
+  `BibleQuotes` synthetic block.
+- `docs/roadmap/platform/feat-145-watch-question-panel-flag.md` is the closest
+  completed roadmap pattern.

--- a/docs/roadmap/platform/feat-144-launchdarkly-feature-flag-foundation.md
+++ b/docs/roadmap/platform/feat-144-launchdarkly-feature-flag-foundation.md
@@ -9,6 +9,7 @@ duration: 2
 depends_on: []
 blocks:
   - "feat-146"
+  - "feat-169"
 tags:
   - platform
   - web

--- a/docs/roadmap/platform/feat-169-watch-bible-quotes-visibility-flag.md
+++ b/docs/roadmap/platform/feat-169-watch-bible-quotes-visibility-flag.md
@@ -1,0 +1,89 @@
+---
+id: "feat-169"
+title: "Watch Bible Quotes Visibility Flag"
+owner: "vlad"
+priority: "P2"
+status: "complete"
+start_date: "2026-06-10"
+duration: 1
+depends_on:
+  - "feat-144"
+blocks: []
+tags:
+  - platform
+  - web
+  - watch-page
+  - feature-flags
+---
+
+## Problem
+
+The web watch page needs an operator-controlled way to hide the full Bible
+Quotes band shown below video content. The existing
+`forge.watch.youVersionBibleQuotes` flag only controls the YouVersion passage
+panel and API fetch; it does not hide the carousel, promo card, or section-local
+share button.
+
+## Entry Points -- Read These First
+
+1. `packages/feature-flags/src/registry.ts` -- shared LaunchDarkly flag keys.
+2. `apps/web/src/lib/feature-flags.ts` -- web server-side feature flag helpers.
+3. `apps/web/src/env.ts` -- server-side fallback env schema.
+4. `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx` -- watch route
+   server flag evaluation.
+5. `apps/web/src/components/watch/WatchPageClient.tsx` -- watch-page prop
+   threading into the renderer.
+6. `apps/web/src/components/watch/WatchSectionRenderer.tsx` -- synthetic watch
+   block dispatch, including `BibleQuotes`.
+7. `apps/web/src/components/watch/BibleQuotesSection.tsx` -- rendered band,
+   quote carousel, promo card, and share entry point.
+
+## Grep These
+
+- `forge.watch.youVersionBibleQuotes`
+- `FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT`
+- `isWatchYouVersionBibleQuotesEnabled`
+- `data-block-type="BibleQuotes"`
+- `case "BibleQuotes"`
+
+## What To Build
+
+1. Add a default-off LaunchDarkly boolean flag:
+   `forge.watch.hideBibleQuotes`.
+2. Add the local fallback env var:
+   `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=false`.
+3. Evaluate the flag server-side on watch routes and pass a plain boolean into
+   the watch renderer.
+4. When the flag is enabled, hide the full synthetic watch-page Bible Quotes
+   band, including the heading, quote cards, promo card, and section-local share
+   button.
+5. Keep generic Experience-page `BibleQuotesCarousel` blocks visible; this flag
+   is scoped to the web watch-page band.
+
+## Constraints
+
+- Do not reuse `forge.watch.youVersionBibleQuotes`; it remains focused on the
+  YouVersion passage panel and API calls.
+- Do not expose LaunchDarkly SDK keys or use a client-side LaunchDarkly SDK.
+- Keep default/off behavior identical to the current watch page.
+- Do not change Bible Quotes content, card styling, carousel mechanics, or share
+  modal behavior.
+- Do not hand-edit generated GraphQL artifacts.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/lib/feature-flags.test.ts`
+- `pnpm --filter @forge/web test -- 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx' src/components/watch/__tests__/WatchSectionRenderer.test.tsx`
+- `pnpm --filter @forge/web lint`
+- `pnpm --filter @forge/web typecheck`
+- `git diff --check`
+- Local smoke: with no `LAUNCHDARKLY_SDK_KEY`,
+  `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=false` renders the Bible Quotes band
+  and `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=true` hides it.
+
+## Operational Note
+
+LaunchDarkly remote flag creation should use project `watch`, key
+`forge.watch.hideBibleQuotes`, a temporary boolean flag, targeting off in all
+environments, and default/off variation `false`. The MCP create/get step was
+blocked locally by expired LaunchDarkly connector auth (`401 invalid_token`).

--- a/packages/feature-flags/src/registry.ts
+++ b/packages/feature-flags/src/registry.ts
@@ -34,6 +34,13 @@ export const featureFlags = {
     description:
       "Runtime rollout gate for the watch-page YouVersion Bible Quotes panel.",
   },
+  watchHideBibleQuotes: {
+    key: "forge.watch.hideBibleQuotes",
+    defaultValue: false,
+    localOverrideEnv: "FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT",
+    description:
+      "Runtime rollout gate for hiding the watch-page Bible Quotes section.",
+  },
   watchQuestionPanel: {
     key: "forge.watch.questionPanel",
     defaultValue: false,


### PR DESCRIPTION
## Summary

- Add the watch-page hide flag key `forge.watch.hideBibleQuotes` with safe default `false` and local fallback env `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT`.
- Evaluate the flag server-side on video/episode watch routes and pass a plain boolean into the watch renderer.
- Hide the full synthetic watch-page Bible Quotes section when enabled, including heading, quote/promo cards, and the section-local share button, while leaving generic Experience-page quote carousels untouched.

## LaunchDarkly

- Intended project: `watch`
- Flag type: temporary boolean
- Targeting state: off in all environments
- Default/off variation: `false`
- Local fallback: `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=false`
- Remote create/get status: blocked locally by expired LaunchDarkly connector auth (`401 invalid_token`), so the remote LaunchDarkly resource was not created from this session.

## Validation

- `pnpm --filter @forge/web test -- src/lib/feature-flags.test.ts`
- `pnpm --filter @forge/web test -- 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx' src/components/watch/__tests__/WatchSectionRenderer.test.tsx`
- `pnpm --filter @forge/feature-flags test`
- `pnpm --filter @forge/feature-flags typecheck`
- `pnpm --filter @forge/web lint`
- `pnpm --filter @forge/web typecheck`
- `git diff --check`

## Browser Smoke

- Helium CDP, `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=false`: `watch-bible-quotes` section and block markers present; promo card count `1`; share button count `1`.
- Helium CDP, `FORGE_WATCH_HIDE_BIBLE_QUOTES_DEFAULT=true`: `watch-bible-quotes` section/block/text/card/promo/share markers all absent; study questions still present; no visible error text.
