### PR TITLE
fix(watch): improve launch readiness metadata

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
@@ -191,26 +191,56 @@ function makeWatchVideoResult(
     name: "English",
   },
 ) {
+  const selectedVariant = {
+    documentId: "var1",
+    hls: "https://cdn.example/storyclubs.m3u8",
+    muxVideo: { playbackId: "pb1" },
+    language: variantLang,
+    published: true,
+    duration: 30,
+    downloads: [],
+  }
   return {
     video: {
       documentId: "v1",
       slug: "storyclubs",
       title: "StoryClubs",
+      snippet: "StoryClubs snippet",
+      description: "StoryClubs description",
+      noIndex: false,
       label,
-      images: [],
+      imageAlt: "StoryClubs poster",
+      images: [
+        {
+          documentId: "img-1",
+          url: null,
+          thumbnail: "https://cdn.example/storyclubs-thumb.jpg",
+          mobileCinematicHigh: null,
+          mobileCinematicLow: null,
+        },
+      ],
+      primaryLanguage: null,
+      parents: [],
       children: [],
-      variants: [],
+      childDubLanguages: [],
+      variants: [
+        selectedVariant,
+        {
+          ...selectedVariant,
+          documentId: "var-es",
+          language: {
+            slug: "spanish-castilian",
+            bcp47: "es",
+            name: "Spanish, Castilian",
+          },
+        },
+      ],
+      subtitles: [],
+      studyQuestions: [],
+      bibleCitations: [],
     },
     canonicalParent: null,
-    selectedVariant: {
-      documentId: "var1",
-      hls: "https://cdn.example/storyclubs.m3u8",
-      muxVideo: { playbackId: "pb1" },
-      language: variantLang,
-      published: true,
-      duration: 30,
-      downloads: [],
-    },
+    selectedVariant,
   }
 }
 
@@ -259,15 +289,36 @@ function makeEpisodeResult(
     name: "English",
   },
 ) {
+  const selectedVariant = {
+    documentId: "var-1",
+    hls: "https://cdn.example/ep.m3u8",
+    muxVideo: { playbackId: "pb-1" },
+    language: variantLang,
+    published: true,
+    duration: 30,
+    downloads: [],
+  }
   return {
     video: {
       documentId: "ep-1",
       slug: "wedding-in-cana",
       title: "Wedding in Cana",
+      snippet: "Wedding in Cana snippet",
+      description: "Wedding in Cana description",
+      noIndex: false,
       label: "episode",
-      images: [],
+      imageAlt: "Wedding in Cana poster",
+      images: [
+        {
+          documentId: "img-ep-1",
+          url: null,
+          thumbnail: null,
+          mobileCinematicHigh: null,
+          mobileCinematicLow: null,
+        },
+      ],
       children: [],
-      variants: [],
+      childDubLanguages: [],
       parents: [
         {
           documentId: "series-1",
@@ -278,6 +329,11 @@ function makeEpisodeResult(
           children: [],
         },
       ],
+      primaryLanguage: null,
+      variants: [selectedVariant],
+      subtitles: [],
+      studyQuestions: [],
+      bibleCitations: [],
     },
     canonicalParent: {
       documentId: "series-1",
@@ -295,15 +351,7 @@ function makeEpisodeResult(
       images: [],
       children: [],
     },
-    selectedVariant: {
-      documentId: "var-1",
-      hls: "https://cdn.example/ep.m3u8",
-      muxVideo: { playbackId: "pb-1" },
-      language: variantLang,
-      published: true,
-      duration: 30,
-      downloads: [],
-    },
+    selectedVariant,
   }
 }
 
@@ -449,6 +497,128 @@ describe("Catch-all routing — one-segment collection/home branch", () => {
   })
 })
 
+describe("Catch-all routing — metadata for playable watch pages", () => {
+  it("uses resolved video data for two-segment metadata before falling back to the template resolver", async () => {
+    resolveWatchVideoBySlugMock.mockResolvedValue(
+      makeWatchVideoResult("featureFilm"),
+    )
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        locale: "en",
+        htmlLang: "en",
+        rest: ["storyclubs.html", "english.html"],
+      }),
+    })
+
+    expect(metadata.title).toBe("StoryClubs | Jesus Film Project")
+    expect(metadata.description).toBe("StoryClubs description")
+    expect(metadata.openGraph).toMatchObject({
+      title: "StoryClubs | Jesus Film Project",
+      url: "https://www.jesusfilm.org/watch/storyclubs.html/english.html",
+      images: [
+        {
+          url: "https://cdn.example/storyclubs-thumb.jpg",
+          alt: "StoryClubs poster",
+        },
+      ],
+    })
+    expect(metadata.twitter).toMatchObject({
+      title: "StoryClubs | Jesus Film Project",
+      images: [
+        {
+          url: "https://cdn.example/storyclubs-thumb.jpg",
+          alt: "StoryClubs poster",
+        },
+      ],
+    })
+    expect(metadata.alternates).toMatchObject({
+      canonical: "https://www.jesusfilm.org/watch/storyclubs.html/english.html",
+      languages: {
+        en: "https://www.jesusfilm.org/watch/storyclubs.html/english.html",
+        es: "https://www.jesusfilm.org/watch/storyclubs.html/spanish-castilian.html",
+      },
+    })
+    expect(resolveWatchPageMock).toHaveBeenCalledWith("en", "storyclubs")
+    expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith(
+      "storyclubs",
+      "english",
+    )
+  })
+
+  it("keeps curated Experience metadata ahead of same-slug video metadata", async () => {
+    resolveWatchPageMock.mockResolvedValue({
+      data: {
+        kind: "experience",
+        experience: {
+          id: "exp-1",
+          slug: "easter",
+          title: "Easter Watch",
+          metaDescription: "Curated Easter page.",
+          ogTitle: "Easter OG",
+          ogDescription: "Curated Easter OG.",
+          ogImageUrl: "https://cdn.example/easter-og.jpg",
+          blocks: [{ __typename: "TextBlock", id: "blk-1", text: "Hello" }],
+        },
+      },
+      error: null,
+    })
+    resolveWatchVideoBySlugMock.mockResolvedValue(
+      makeWatchVideoResult("featureFilm"),
+    )
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        locale: "en",
+        htmlLang: "en",
+        rest: ["easter.html", "english.html"],
+      }),
+    })
+
+    expect(metadata.title).toBe("Easter Watch")
+    expect(metadata.openGraph).toMatchObject({
+      title: "Easter OG",
+      url: "https://www.jesusfilm.org/watch/easter.html/english.html",
+      images: [
+        {
+          url: "https://cdn.example/easter-og.jpg",
+        },
+      ],
+    })
+    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
+  })
+
+  it("uses the three-segment production URL for episode metadata", async () => {
+    resolveSeriesEpisodeBySlugMock.mockResolvedValue(makeEpisodeResult())
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        locale: "en",
+        htmlLang: "en",
+        rest: [
+          "lumo-the-gospel-of-john.html",
+          "wedding-in-cana",
+          "english.html",
+        ],
+      }),
+    })
+
+    expect(metadata.title).toBe("Wedding in Cana | Jesus Film Project")
+    expect(metadata.openGraph).toMatchObject({
+      url: "https://www.jesusfilm.org/watch/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+      images: [
+        {
+          url: "https://image.mux.com/pb-1/thumbnail.jpg?width=448&height=252&fit_mode=smartcrop",
+          alt: "Wedding in Cana poster",
+        },
+      ],
+    })
+    expect(metadata.alternates?.canonical).toBe(
+      "https://www.jesusfilm.org/watch/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+    )
+  })
+})
+
 describe("Catch-all routing — series branch (2-seg)", () => {
   it("renders SeriesPageClient when video resolver returns a COLLECTION-labeled record", async () => {
     resolveWatchVideoBySlugMock.mockResolvedValue(
@@ -481,6 +651,27 @@ describe("Catch-all routing — series branch (2-seg)", () => {
       }),
     )
     expect(seriesPageClientMock).not.toHaveBeenCalled()
+  })
+
+  it("renders a sanitized VideoObject JSON-LD script for playable videos", async () => {
+    const watchVideoResult = makeWatchVideoResult("featureFilm")
+    watchVideoResult.video.title = "Story < Clubs"
+    watchVideoResult.video.description = "Story < Clubs description"
+    resolveWatchVideoBySlugMock.mockResolvedValue(watchVideoResult)
+
+    await render2Seg("storyclubs", "english")
+
+    const script = container.querySelector('script[type="application/ld+json"]')
+    expect(script?.textContent).not.toContain("<")
+    expect(JSON.parse(script?.textContent ?? "{}")).toMatchObject({
+      "@type": "VideoObject",
+      name: "Story < Clubs",
+      description: "Story < Clubs description",
+      url: "https://www.jesusfilm.org/watch/storyclubs.html/english.html",
+      thumbnailUrl: ["https://cdn.example/storyclubs-thumb.jpg"],
+      inLanguage: "en",
+      duration: "PT30S",
+    })
   })
 
   it("404s bcp47 catalog keys in public audio slots", async () => {

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -20,7 +20,9 @@ import {
   resolveWatchVideoBySlug,
 } from "@/lib/content"
 import {
+  buildWatchVideoMetadataModel,
   generateSeriesMetadata,
+  generateWatchVideoMetadata,
   getWatchPageMetadata,
 } from "@/lib/experience-metadata"
 import { resolveWatchHome } from "@/lib/watch-home"
@@ -47,6 +49,7 @@ import {
   SAFE_SLUG_PATTERN,
   stripHtmlSuffix,
 } from "@/lib/url-shape"
+import { watchVideoStructuredDataJson } from "@/lib/watch-structured-data"
 import { fetchYouVersionBibleQuotePassages } from "@/lib/youversion-passage"
 
 // ISR: pages cached for 60s. Cookie-driven language redirect lives in
@@ -212,10 +215,26 @@ export async function generateMetadata({
     // doesn't drop metadata entirely. Next silently skips metadata when
     // generateMetadata throws; the page body has its own error boundary.
     try {
+      const watchPage = await resolveWatchPage(locale, slug)
+      if (watchPage.data?.kind === "experience") {
+        return getWatchPageMetadata(locale, {
+          slug,
+          pathLocale: rawLocale,
+        })
+      }
+
       const watchVideo = await resolveWatchVideoBySlug(slug, rawLocale)
       if (watchVideo && isSeriesRecord(watchVideo.video)) {
         return generateSeriesMetadata(locale, {
           series: watchVideo.video,
+          pathLocale: rawLocale,
+        })
+      }
+      if (watchVideo) {
+        return generateWatchVideoMetadata(locale, {
+          video: watchVideo.video,
+          selectedVariant: watchVideo.selectedVariant,
+          routeSlug: slug,
           pathLocale: rawLocale,
         })
       }
@@ -238,9 +257,27 @@ export async function generateMetadata({
   }
 
   if (shape.kind === "episode") {
-    const { episodeSlug, rawLocale, locale } = shape
-    // The episode IS the playable video; OG/canonical metadata follows
-    // the episode's slug. Series-context enrichment is Phase 5 work.
+    const { seriesSlug, episodeSlug, rawLocale, locale } = shape
+    // The episode IS the playable video; keep metadata on the verified
+    // three-segment public URL when the series parent resolves.
+    try {
+      const resolved = await resolveSeriesEpisodeBySlug(
+        seriesSlug,
+        episodeSlug,
+        rawLocale,
+      )
+      if (resolved) {
+        return generateWatchVideoMetadata(locale, {
+          video: resolved.video,
+          selectedVariant: resolved.selectedVariant,
+          routeSlug: episodeSlug,
+          pathLocale: rawLocale,
+          seriesSlug,
+        })
+      }
+    } catch {
+      // Fall through to the safe template metadata path.
+    }
     return getWatchPageMetadata(locale, {
       slug: episodeSlug,
       pathLocale: rawLocale,
@@ -248,6 +285,21 @@ export async function generateMetadata({
   }
 
   return {}
+}
+
+function WatchVideoStructuredData({
+  model,
+}: {
+  model: ReturnType<typeof buildWatchVideoMetadataModel>
+}) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: watchVideoStructuredDataJson(model),
+      }}
+    />
+  )
 }
 
 export default async function SlugRestPage({ params }: PageProps) {
@@ -378,9 +430,17 @@ async function renderEpisode(shape: {
   })
   if (!mergedBlocks.length) return <ExperienceEmpty />
   const lcpPlaybackId = resolved.selectedVariant.muxVideo?.playbackId ?? null
+  const metadataModel = buildWatchVideoMetadataModel({
+    video: resolved.video,
+    selectedVariant: resolved.selectedVariant,
+    routeSlug: episodeSlug,
+    pathLocale: rawLocale,
+    seriesSlug,
+  })
 
   return (
     <>
+      <WatchVideoStructuredData model={metadataModel} />
       {lcpPlaybackId ? (
         <link
           rel="preload"
@@ -494,8 +554,15 @@ async function renderVideo(shape: {
     })
     const lcpPlaybackId =
       watchVideo.selectedVariant.muxVideo?.playbackId ?? null
+    const metadataModel = buildWatchVideoMetadataModel({
+      video: watchVideo.video,
+      selectedVariant: watchVideo.selectedVariant,
+      routeSlug: slug,
+      pathLocale: rawLocale,
+    })
     return (
       <>
+        <WatchVideoStructuredData model={metadataModel} />
         {lcpPlaybackId ? (
           <link
             rel="preload"

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -141,6 +141,9 @@ export function SiblingCarousel({
             const slug = tryAsContentSlug(child.slug)
             const lang = tryAsLocaleSlug(languageSlug)
             const href = slug && lang ? watchVideoPath(slug, lang) : undefined
+            const thumbnailAlt = child.title
+              ? `${child.title} thumbnail`
+              : "Related video thumbnail"
 
             const cardClassName = cn(
               "group relative block aspect-video cursor-pointer overflow-hidden rounded-lg bg-stone-900 transition shadow-[0_2px_6px_rgba(0,0,0,0.35),0_14px_32px_-12px_rgba(0,0,0,0.6)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80",
@@ -156,7 +159,7 @@ export function SiblingCarousel({
                 {thumb ? (
                   <Image
                     src={thumb}
-                    alt={child.title ?? ""}
+                    alt={thumbnailAlt}
                     fill
                     sizes="(max-width: 640px) 48vw, (max-width: 768px) 36vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, (max-width: 1536px) 20vw, 16vw"
                     className="object-cover transition-transform duration-300 group-hover:scale-105"

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -516,6 +516,22 @@ describe("SiblingCarousel — image priority (resolvePosterUrl)", () => {
     const img = activeImage()
     expect(img).not.toBeNull()
     expect(img!.getAttribute("data-src")).toBe("https://cdn.test/high.jpg")
+    expect(img!.getAttribute("data-alt")).toBe("Child 1 thumbnail")
+  })
+
+  it("uses a non-empty fallback alt for informative thumbnails without titles", () => {
+    const block = singleChildBlock({
+      thumbnail: "https://cdn.test/thumb.jpg",
+    })
+    block.canonicalParent.children[0]!.title = null
+
+    act(() => {
+      root.render(<SiblingCarousel languageSlug="english" block={block} />)
+    })
+
+    expect(activeImage()!.getAttribute("data-alt")).toBe(
+      "Related video thumbnail",
+    )
   })
 
   it("falls through to mobileCinematicLow when mobileCinematicHigh is absent", () => {

--- a/apps/web/src/lib/experience-metadata.test.ts
+++ b/apps/web/src/lib/experience-metadata.test.ts
@@ -99,4 +99,176 @@ describe("getWatchPageMetadata", () => {
     // behaviour from this diff — was previously absent when noIndex=false).
     expect(metadata.robots).toEqual({ index: true, follow: true })
   })
+
+  it("generates resolved video metadata with Twitter parity and hreflang alternates", async () => {
+    const { generateWatchVideoMetadata } = await import("./experience-metadata")
+    const selectedVariant = {
+      documentId: "dub-en",
+      slug: null,
+      published: true,
+      hls: "https://cdn.example/jesus-en.m3u8",
+      duration: 7200,
+      language: {
+        slug: "english",
+        bcp47: "en",
+        coreId: "529",
+        name: "English",
+        nativeName: "English",
+      },
+      downloads: [],
+      muxVideo: { playbackId: "mux-en" },
+    }
+
+    const metadata = generateWatchVideoMetadata("en", {
+      routeSlug: "life-of-jesus-gospel-of-john",
+      pathLocale: "english",
+      selectedVariant,
+      video: {
+        documentId: "video-1",
+        slug: "life-of-jesus-gospel-of-john",
+        title: "Life of Jesus (Gospel of John)",
+        snippet: "A feature film about Jesus.",
+        description: "Watch the life of Jesus from the Gospel of John.",
+        noIndex: false,
+        label: "featureFilm",
+        imageAlt: "Jesus speaks to a crowd",
+        images: [
+          {
+            documentId: "img-1",
+            url: "https://bad.example/raw",
+            thumbnail: "https://cdn.example/thumb.jpg",
+            mobileCinematicHigh: "https://cdn.example/still-high.jpg",
+            mobileCinematicLow: "https://cdn.example/still-low.jpg",
+          },
+        ],
+        primaryLanguage: null,
+        parents: [],
+        children: [],
+        childDubLanguages: [],
+        variants: [
+          selectedVariant,
+          {
+            ...selectedVariant,
+            documentId: "dub-es",
+            language: {
+              slug: "spanish-castilian",
+              bcp47: "es",
+              coreId: "21028",
+              name: "Spanish, Castilian",
+              nativeName: "Espanol",
+            },
+          },
+          {
+            ...selectedVariant,
+            documentId: "dub-es-duplicate",
+            language: {
+              slug: "spanish-latin-american",
+              bcp47: "es",
+              coreId: "21046",
+              name: "Spanish, Latin American",
+              nativeName: "Espanol",
+            },
+          },
+          {
+            ...selectedVariant,
+            documentId: "dub-no-tag",
+            language: {
+              slug: "aari",
+              bcp47: null,
+              coreId: "1",
+              name: "Aari",
+              nativeName: "Aari",
+            },
+          },
+        ],
+        subtitles: [],
+        studyQuestions: [],
+        bibleCitations: [],
+      },
+    })
+
+    expect(metadata.title).toBe(
+      "Life of Jesus (Gospel of John) | Jesus Film Project",
+    )
+    expect(metadata.openGraph).toMatchObject({
+      title: "Life of Jesus (Gospel of John) | Jesus Film Project",
+      url: "https://www.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html",
+      images: [
+        {
+          url: "https://cdn.example/still-high.jpg",
+          alt: "Jesus speaks to a crowd",
+        },
+      ],
+    })
+    expect(metadata.twitter).toMatchObject({
+      title: "Life of Jesus (Gospel of John) | Jesus Film Project",
+      description: "Watch the life of Jesus from the Gospel of John.",
+      images: [
+        {
+          url: "https://cdn.example/still-high.jpg",
+          alt: "Jesus speaks to a crowd",
+        },
+      ],
+    })
+    expect(metadata.alternates).toMatchObject({
+      canonical:
+        "https://www.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html",
+      languages: {
+        en: "https://www.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html",
+        es: "https://www.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/spanish-castilian.html",
+      },
+    })
+  })
+
+  it("uses a Mux thumbnail before the generic image for playable videos", async () => {
+    const { generateWatchVideoMetadata } = await import("./experience-metadata")
+    const selectedVariant = {
+      documentId: "dub-en",
+      slug: null,
+      published: true,
+      hls: "https://cdn.example/jesus-en.m3u8",
+      duration: null,
+      language: {
+        slug: "english",
+        bcp47: "en",
+        coreId: "529",
+        name: "English",
+        nativeName: "English",
+      },
+      downloads: [],
+      muxVideo: { playbackId: "mux-playback-id" },
+    }
+
+    const metadata = generateWatchVideoMetadata("en", {
+      routeSlug: "jesus",
+      pathLocale: "english",
+      selectedVariant,
+      video: {
+        documentId: "video-1",
+        slug: "jesus",
+        title: "Jesus",
+        snippet: null,
+        description: null,
+        noIndex: false,
+        label: "featureFilm",
+        imageAlt: null,
+        images: [],
+        primaryLanguage: null,
+        parents: [],
+        children: [],
+        childDubLanguages: [],
+        variants: [selectedVariant],
+        subtitles: [],
+        studyQuestions: [],
+        bibleCitations: [],
+      },
+    })
+
+    expect(metadata.openGraph?.images).toEqual([
+      expect.objectContaining({
+        url: "https://image.mux.com/mux-playback-id/thumbnail.jpg?width=448&height=252&fit_mode=smartcrop",
+        alt: "Jesus",
+      }),
+    ])
+  })
 })

--- a/apps/web/src/lib/experience-metadata.ts
+++ b/apps/web/src/lib/experience-metadata.ts
@@ -4,6 +4,8 @@ import {
   resolveWatchPage,
   type ResolvedSeriesBySlug,
   type ResolvedWatchPage,
+  type WatchVariant,
+  type WatchVideoRecord,
 } from "@/lib/content"
 import {
   WATCH_BASE_PATH,
@@ -11,6 +13,7 @@ import {
   localizedHomePath,
   tryAsContentSlug,
   tryAsLocaleSlug,
+  watchEpisodePath,
   watchVideoPath,
 } from "@/lib/routes"
 import { getSocialConfig } from "@/lib/social-config"
@@ -67,6 +70,26 @@ function buildCanonicalUrl(slug?: string, pathLocale?: string): string {
   return root
 }
 
+function buildEpisodeCanonicalUrl(
+  seriesSlug: string,
+  episodeSlug: string,
+  pathLocale: string,
+): string {
+  const root = `${WATCH_PUBLIC_METADATA_ORIGIN}${WATCH_BASE_PATH}`
+  const series = stripHtmlSuffix(seriesSlug)
+  const episode = stripHtmlSuffix(episodeSlug)
+  const locale = stripHtmlSuffix(pathLocale)
+
+  const seriesContentSlug = tryAsContentSlug(series)
+  const episodeContentSlug = tryAsContentSlug(episode)
+  const localeSlug = tryAsLocaleSlug(locale)
+  if (seriesContentSlug && episodeContentSlug && localeSlug) {
+    return `${root}${watchEpisodePath(seriesContentSlug, episodeContentSlug, localeSlug)}`
+  }
+
+  return `${root}/${series}/${episode}/${locale}`
+}
+
 const OG_LOCALE_OVERRIDES: Record<string, string> = {
   en: "en_US",
   pt: "pt_BR",
@@ -84,6 +107,144 @@ const DEFAULT_OG_IMAGE = {
   height: 933,
   alt: "Jesus Film Project",
   type: "image/jpeg" as const,
+}
+
+type WatchMetadataImage = {
+  url: string
+  width: number
+  height: number
+  alt: string
+  type: "image/jpeg"
+}
+
+export type WatchVideoMetadataModel = {
+  title: string
+  videoTitle: string
+  description: string
+  canonicalUrl: string
+  image: WatchMetadataImage
+  noIndex: boolean
+  inLanguage: string | null
+  durationSeconds: number | null
+  alternatesLanguages?: Record<string, string>
+}
+
+type WatchVideoMetadataOptions = {
+  video: WatchVideoRecord
+  selectedVariant: WatchVariant
+  routeSlug: string
+  pathLocale: string
+  seriesSlug?: string
+}
+
+function buildWatchVideoAlternateLanguages(
+  options: WatchVideoMetadataOptions,
+): Record<string, string> | undefined {
+  const languages: Record<string, string> = {}
+  const episodeSlug = options.video.slug ?? options.routeSlug
+
+  for (const variant of options.video.variants ?? []) {
+    if (variant.published !== true || !variant.hls) continue
+    const slug = variant.language?.slug
+    const bcp47 = variant.language?.bcp47
+    if (!slug || !bcp47 || languages[bcp47]) continue
+
+    languages[bcp47] = options.seriesSlug
+      ? buildEpisodeCanonicalUrl(options.seriesSlug, episodeSlug, slug)
+      : buildCanonicalUrl(options.routeSlug, slug)
+  }
+
+  return Object.keys(languages).length ? languages : undefined
+}
+
+export function buildWatchVideoMetadataModel(
+  options: WatchVideoMetadataOptions,
+): WatchVideoMetadataModel {
+  const episodeSlug = options.video.slug ?? options.routeSlug
+  const canonicalUrl = options.seriesSlug
+    ? buildEpisodeCanonicalUrl(
+        options.seriesSlug,
+        episodeSlug,
+        options.pathLocale,
+      )
+    : buildCanonicalUrl(options.routeSlug, options.pathLocale)
+  const videoTitle = options.video.title || options.routeSlug || "Watch"
+  const title = `${videoTitle} ${TITLE_SUFFIX}`
+  const description = options.video.description ?? options.video.snippet ?? ""
+  const posterUrl = resolvePosterUrl(
+    options.video.images?.[0],
+    options.selectedVariant.muxVideo?.playbackId,
+  )
+  const image = posterUrl
+    ? {
+        url: posterUrl,
+        width: DEFAULT_OG_IMAGE.width,
+        height: DEFAULT_OG_IMAGE.height,
+        alt:
+          options.video.imageAlt ?? options.video.title ?? DEFAULT_OG_IMAGE.alt,
+        type: "image/jpeg" as const,
+      }
+    : DEFAULT_OG_IMAGE
+
+  return {
+    title,
+    videoTitle,
+    description,
+    canonicalUrl,
+    image,
+    noIndex: options.video.noIndex ?? false,
+    inLanguage:
+      options.selectedVariant.language?.bcp47 ??
+      options.selectedVariant.language?.slug ??
+      null,
+    durationSeconds: options.selectedVariant.duration ?? null,
+    alternatesLanguages: buildWatchVideoAlternateLanguages(options),
+  }
+}
+
+export function generateWatchVideoMetadata(
+  locale: string,
+  options: WatchVideoMetadataOptions,
+): Metadata {
+  const model = buildWatchVideoMetadataModel(options)
+  const { fbAppId } = getSocialConfig()
+
+  return {
+    title: model.title,
+    description: model.description || undefined,
+    openGraph: {
+      title: model.title,
+      description: model.description || undefined,
+      url: model.canonicalUrl,
+      siteName: "Jesus Film Project",
+      locale: getOgLocale(locale),
+      type: "website" as const,
+      images: [model.image],
+    },
+    twitter: {
+      card: "summary_large_image" as const,
+      site: "@JesusFilm",
+      creator: "@JesusFilm",
+      title: model.title,
+      description: model.description || undefined,
+      images: [
+        {
+          url: model.image.url,
+          alt: model.image.alt,
+        },
+      ],
+    },
+    robots: model.noIndex
+      ? { index: false, follow: false }
+      : { index: true, follow: true },
+    ...(fbAppId && { other: { "fb:app_id": fbAppId } }),
+    alternates: {
+      canonical: model.canonicalUrl,
+      ...(model.alternatesLanguages && {
+        languages: model.alternatesLanguages,
+      }),
+    },
+  }
 }
 
 function toMetadata(
@@ -139,6 +300,14 @@ function toMetadata(
         card: "summary_large_image" as const,
         site: "@JesusFilm",
         creator: "@JesusFilm",
+        title,
+        description: description || undefined,
+        images: [
+          {
+            url: ogImage.url,
+            alt: ogImage.alt,
+          },
+        ],
       },
       robots: resolvedPage.routeVideo.noIndex
         ? { index: false, follow: false }
@@ -190,6 +359,14 @@ function toMetadata(
       card: "summary_large_image" as const,
       site: "@JesusFilm",
       creator: "@JesusFilm",
+      title: ogTitle,
+      description: ogDescription || undefined,
+      images: [
+        {
+          url: ogImage.url,
+          alt: ogImage.alt,
+        },
+      ],
     },
     // Explicit index/follow default. Without this, no <meta name="robots">
     // is emitted — Google still defaults to index,follow, but explicit is
@@ -260,6 +437,14 @@ export function generateSeriesMetadata(
       card: "summary_large_image" as const,
       site: "@JesusFilm",
       creator: "@JesusFilm",
+      title,
+      description: description || undefined,
+      images: [
+        {
+          url: ogImage.url,
+          alt: ogImage.alt,
+        },
+      ],
     },
     robots: series.noIndex
       ? { index: false, follow: false }

--- a/apps/web/src/lib/watch-structured-data.test.ts
+++ b/apps/web/src/lib/watch-structured-data.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import { watchVideoStructuredDataJson } from "@/lib/watch-structured-data"
+
+describe("watchVideoStructuredDataJson", () => {
+  it("serializes sanitized VideoObject JSON-LD from the metadata model", () => {
+    const json = watchVideoStructuredDataJson({
+      title: "Life < Jesus | Jesus Film Project",
+      videoTitle: "Life < Jesus",
+      description: "A story with <script> content.",
+      canonicalUrl: "https://www.jesusfilm.org/watch/life.html/english.html",
+      image: {
+        url: "https://image.mux.com/pb/thumbnail.jpg",
+        width: 1400,
+        height: 933,
+        alt: "Poster",
+        type: "image/jpeg",
+      },
+      noIndex: false,
+      inLanguage: "en",
+      durationSeconds: 91.4,
+      alternatesLanguages: {
+        en: "https://www.jesusfilm.org/watch/life.html/english.html",
+      },
+    })
+
+    expect(json).not.toContain("<")
+    expect(JSON.parse(json)).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "VideoObject",
+      name: "Life < Jesus",
+      description: "A story with <script> content.",
+      url: "https://www.jesusfilm.org/watch/life.html/english.html",
+      thumbnailUrl: ["https://image.mux.com/pb/thumbnail.jpg"],
+      inLanguage: "en",
+      duration: "PT91S",
+    })
+  })
+})

--- a/apps/web/src/lib/watch-structured-data.ts
+++ b/apps/web/src/lib/watch-structured-data.ts
@@ -1,0 +1,27 @@
+import type { WatchVideoMetadataModel } from "@/lib/experience-metadata"
+
+function secondsToIsoDuration(seconds: number | null): string | undefined {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) {
+    return undefined
+  }
+  return `PT${Math.round(seconds)}S`
+}
+
+export function watchVideoStructuredDataJson(
+  model: WatchVideoMetadataModel,
+): string {
+  const payload = {
+    "@context": "https://schema.org",
+    "@type": "VideoObject",
+    name: model.videoTitle,
+    ...(model.description && { description: model.description }),
+    url: model.canonicalUrl,
+    thumbnailUrl: [model.image.url],
+    ...(model.inLanguage && { inLanguage: model.inLanguage }),
+    ...(secondsToIsoDuration(model.durationSeconds) && {
+      duration: secondsToIsoDuration(model.durationSeconds),
+    }),
+  }
+
+  return JSON.stringify(payload).replace(/</g, "\\u003c")
+}

--- a/docs/plans/2026-06-10-001-fix-watch-dev-launch-readiness-plan.md
+++ b/docs/plans/2026-06-10-001-fix-watch-dev-launch-readiness-plan.md
@@ -1,0 +1,419 @@
+---
+title: "fix: Watch Dev Launch Readiness"
+type: "fix"
+status: "active"
+date: "2026-06-10"
+roadmap: "docs/roadmap/platform/feat-173-watch-dev-launch-readiness-audit.md"
+---
+
+# fix: Watch Dev Launch Readiness
+
+## Summary
+
+Fix the Watch dev-server audit regressions that matter before the redesigned
+Watch app can replace production: readable video metadata, film-relevant social
+images, hreflang and structured data, server-rendered language semantics,
+single-H1 and image-alt hygiene, and a targeted mobile LCP recheck. The plan
+keeps canonical URLs pointed at production `www.jesusfilm.org`; that is the
+right contract for a dev server.
+
+---
+
+## Problem Frame
+
+The June 9 audit of
+`https://watch.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html`
+showed a strong base: Lighthouse SEO was high, accessibility was 96, CLS was 0,
+and the page already emitted canonical, robots, Open Graph locale, and Twitter
+card metadata. The remaining issues are launch-blocking polish rather than a
+rewrite: slug-based titles in social metadata, a generic stock image, missing
+hreflang and JSON-LD, a WAVE language warning, empty-alt and duplicate-H1
+warnings, and mobile LCP around 10.9 s.
+
+The user clarified that `watch.jesusfilm.org` is the dev server and
+`www.jesusfilm.org` is production. Existing roadmap ticket
+`docs/roadmap/platform/feat-160-watch-public-metadata-origin.md` and the current
+`WATCH_PUBLIC_METADATA_ORIGIN` code establish that SEO metadata from dev,
+preview, or watch-only deployments should still name the indexed production
+host.
+
+---
+
+## Requirements
+
+**SEO and Social Metadata**
+
+- R1. Video and episode metadata uses the resolved video title, not the URL
+  slug, for `<title>`, Open Graph title, and Twitter title.
+- R2. Open Graph and Twitter images use a film-relevant still from the resolved
+  video or selected Dub before falling back to generic Watch imagery.
+- R3. Canonical and `og:url` continue to point at
+  `https://www.jesusfilm.org/watch/...` on dev, preview, and watch-only hosts.
+- R4. Video pages emit hreflang alternates for playable language variants using
+  public audio-language URL slugs and BCP-47 tags.
+- R5. Playable video pages emit sanitized JSON-LD structured data that
+  describes the watchable video page.
+
+**Accessibility and Semantics**
+
+- R6. Raw server-rendered HTML includes a valid `<html lang>` before client
+  JavaScript runs.
+- R7. The watch page has exactly one semantic H1 for the playable title.
+- R8. Empty image alt attributes are reserved for decorative images; informative
+  thumbnails, posters, and social/modal previews have meaningful alt text.
+
+**Performance**
+
+- R9. The LCP poster preload remains discoverable in initial HTML and matches
+  the hero poster URL exactly.
+- R10. Mobile LCP remediation stays targeted to the hero/player and known
+  unused-JavaScript contributors surfaced by the audit.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given the English Gospel of John dev URL, when metadata is rendered, then
+  title, Open Graph title, and Twitter title read as a human video title plus
+  the brand suffix, not `life-of-jesus-gospel-of-john`.
+- AE2. Given the same URL on the dev server, when canonical and `og:url` are
+  inspected, then both point at the matching `www.jesusfilm.org/watch/...`
+  production URL.
+- AE3. Given a playable video with English and Spanish Dubs, when metadata is
+  rendered, then hreflang links include the English and Spanish public watch
+  URLs with BCP-47 language tags.
+- AE4. Given a playable video with a Mux playback id but no curated still, when
+  social metadata and JSON-LD are rendered, then the fallback image is a Mux
+  video thumbnail rather than the generic Unsplash image.
+- AE5. Given raw server HTML for the dev URL, when an accessibility crawler
+  reads it before hydration, then it can detect a valid page language and one
+  H1.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Canonical production host stays pinned:** `watch.jesusfilm.org` is a
+  dev server, so canonical and `og:url` must continue using
+  `WATCH_PUBLIC_METADATA_ORIGIN` instead of the request host or
+  `NEXT_PUBLIC_CANONICAL_ORIGIN`.
+- KTD2. **Video-route metadata should reuse the richer watch-video resolution
+  path:** The page body already resolves the selected video and Dub for
+  rendering. Metadata for two- and three-segment video routes should consume
+  the same normalized title, description, image, language, and selected Dub
+  source instead of falling through to a separate slug/template fallback that
+  can expose raw slugs.
+- KTD3. **Social image fallback follows the Watch poster chain:** Use the same
+  `resolvePosterUrl` priority as the visible Watch page so curated cinematic
+  stills win, thumbnail crops are acceptable fallbacks, and Mux thumbnails are
+  the final video-specific fallback.
+- KTD4. **Hreflang is generated from playable Dubs, not UI catalogs:** The
+  public URL language segment is the audio language slug, while the hreflang
+  value is the Dub language's BCP-47 tag. UI message catalog availability does
+  not decide whether a playable audio page is an alternate.
+- KTD5. **JSON-LD renders as a native script in the route tree:** Next.js does
+  not put arbitrary scripts inside the Metadata API; structured data should be
+  rendered from the page/layout component with JSON output sanitized for `<`.
+- KTD6. **Accessibility fixes distinguish bugs from decorative intent:** Empty
+  alt text is correct for decorative overlays or atmospheric Bible quote cards
+  when they are hidden from assistive technology. Content-bearing posters and
+  thumbnails should use the title or authored alt text fallback.
+- KTD7. **Performance work starts from the existing Watch LCP playbook:** The
+  page already has Mux preconnects, a matching LCP preload, MuxVideo path, HLS
+  buffer caps, and lazy sibling thumbnails. The implementation should first
+  verify those are active in the dev build before adding new bundle work.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Public dev URL"] --> B["Proxy resolves UI locale and htmlLang"]
+  B --> C["Catch-all route classifies one/two/three segment shape"]
+  C --> D["Resolve playable video, selected Dub, and variants"]
+  D --> E["Metadata adapter builds title, description, image, canonical URL"]
+  E --> F["Next Metadata emits title, OG, Twitter, canonical, hreflang"]
+  D --> G["Structured-data helper builds sanitized VideoObject JSON-LD"]
+  D --> H["Page render emits LCP preload and WatchPageClient"]
+  B --> I["Layout renders html lang before hydration"]
+```
+
+The metadata adapter is the center of the change. It should accept already
+resolved video data when the route has it, fall back to existing
+`getWatchPageMetadata` behavior for experience pages, and keep canonical URL
+construction inside the established route builders.
+
+---
+
+## Scope Boundaries
+
+- In scope: the audited video and episode metadata path, social image fallback,
+  hreflang, structured data, raw HTML language semantics, H1/alt verification,
+  and targeted LCP remediation.
+- In scope: regression tests that preserve production canonical ownership while
+  fixing dev-server metadata content.
+- Out of scope: switching indexed ownership from `www.jesusfilm.org` to
+  `watch.jesusfilm.org`.
+- Out of scope: a broad redesign of the Watch page, search, recommendations,
+  language picker, or download flow.
+
+### Deferred to Follow-Up Work
+
+- A full sitemap-level hreflang matrix can follow if implementation proves
+  page-head hreflang for high-Dub-count videos is too large for reliable
+  crawler or runtime behavior.
+- Removing the hero MuxPlayer flag-off branch can follow after the MuxVideo path
+  has been enabled and stable for a release.
+- Replacing generic imagery in non-video Bible quote or editorial blocks can
+  follow if the audit confirms those images are content-bearing rather than
+  decorative.
+
+---
+
+## Implementation Units
+
+### U1. Video Metadata Source Alignment
+
+- **Goal:** Make video and episode metadata use the same resolved video and Dub
+  data that the page body renders.
+- **Requirements:** R1, R2, R3, AE1, AE2, AE4.
+- **Dependencies:** None.
+- **Files:** `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`,
+  `apps/web/src/lib/experience-metadata.ts`,
+  `apps/web/src/lib/content.ts`,
+  `apps/web/src/lib/fragments/watch-video.ts`,
+  `apps/web/src/lib/experience-metadata.test.ts`,
+  `apps/web/src/lib/__tests__/experience-metadata-watch-page.test.ts`,
+  `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`.
+- **Approach:** Add a route-video metadata path that accepts the resolved
+  playable video, selected Dub, and public path language slug. Use it in the
+  two-segment video route and three-segment episode route before falling back to
+  the existing template/experience metadata helper. Preserve the completed
+  production-origin contract by continuing to build absolute metadata URLs from
+  `WATCH_PUBLIC_METADATA_ORIGIN`.
+- **Execution note:** Add characterization coverage for the current canonical
+  contract before changing title or image behavior.
+- **Patterns to follow:** `generateSeriesMetadata` in
+  `apps/web/src/lib/experience-metadata.ts`; public URL builders in
+  `apps/web/src/lib/routes.ts`; canonical origin tests in
+  `apps/web/src/lib/__tests__/experience-metadata-watch-page.test.ts`.
+- **Test scenarios:**
+  - Covers AE1. A two-segment video route with a resolved title renders title,
+    Open Graph title, and Twitter title from that title.
+  - Covers AE2. The same route renders canonical and `openGraph.url` on
+    `https://www.jesusfilm.org/watch/...` even when the app is served from the
+    dev host.
+  - A route whose video resolver throws still returns safe fallback metadata
+    rather than dropping metadata entirely.
+  - An episode route uses the playable episode title and selected language,
+    while keeping the episode production URL shape.
+  - A series route still delegates to `generateSeriesMetadata` and does not
+    regress series poster behavior.
+- **Verification:** Metadata snapshots show no slug fallback when resolved video
+  title data is present, and canonical-origin tests keep passing.
+
+### U2. Social Image and Twitter Metadata Parity
+
+- **Goal:** Ensure shared links show readable video titles and film-relevant
+  imagery across Open Graph and Twitter cards.
+- **Requirements:** R1, R2, R8, AE1, AE4.
+- **Dependencies:** U1.
+- **Files:** `apps/web/src/lib/experience-metadata.ts`,
+  `apps/web/src/lib/url.ts`,
+  `apps/web/src/lib/experience-metadata.test.ts`,
+  `apps/web/src/components/watch/__tests__/ShareModal.test.tsx`.
+- **Approach:** Reuse `resolvePosterUrl` for metadata image selection and set
+  Twitter title, description, and image from the same values used by Open Graph.
+  Keep `DEFAULT_OG_IMAGE` as a last resort for non-video or data-missing pages,
+  not for playable videos with posters or Mux playback ids.
+- **Patterns to follow:** `WatchPageClient` poster selection in
+  `apps/web/src/components/watch/WatchPageClient.tsx`; `resolvePosterUrl` in
+  `apps/web/src/lib/url.ts`.
+- **Test scenarios:**
+  - Covers AE4. A playable video with `mobileCinematicHigh` uses that URL for
+    Open Graph and Twitter images.
+  - A playable video without curated images but with a Mux playback id uses the
+    Mux thumbnail fallback rather than `DEFAULT_OG_IMAGE`.
+  - Twitter metadata includes the same title and image as Open Graph for the
+    resolved video.
+  - A video with authored image alt uses it; a video without authored alt uses
+    the resolved title fallback.
+  - A non-video experience without imagery still uses the existing generic
+    fallback image.
+- **Verification:** Share metadata tests fail if a playable video falls back to
+  the Unsplash default while a poster or Mux thumbnail is available.
+
+### U3. Hreflang and Structured Data
+
+- **Goal:** Add crawler-facing language alternates and structured data for
+  playable watch pages.
+- **Requirements:** R4, R5, AE3, AE4.
+- **Dependencies:** U1, U2.
+- **Files:** `apps/web/src/lib/experience-metadata.ts`,
+  `apps/web/src/lib/routes.ts`,
+  `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`,
+  `apps/web/src/lib/watch-structured-data.ts`,
+  `apps/web/src/lib/experience-metadata.test.ts`,
+  `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`.
+- **Approach:** Generate `alternates.languages` from playable Dubs that have a
+  public language slug and BCP-47 tag, de-duping duplicate tags by first
+  playable URL. Render a sanitized native `application/ld+json` script for
+  video and episode pages using the same title, description, canonical URL, and
+  thumbnail source as metadata. Use no new dependency unless implementation
+  reveals typing value that outweighs the extra package.
+- **Technical design:** Directional only: a metadata candidate should carry
+  `title`, `description`, `canonicalUrl`, `image`, `selectedLanguage`, and
+  `alternateLanguages`; structured data should consume that candidate rather
+  than rebuilding URLs independently.
+- **Patterns to follow:** Next.js Metadata API `alternates.languages`; Next.js
+  JSON-LD guide for native script rendering and `<` escaping; existing route
+  builders in `apps/web/src/lib/routes.ts`.
+- **Test scenarios:**
+  - Covers AE3. English and Spanish playable Dubs produce English and Spanish
+    hreflang links with production absolute URLs.
+  - Duplicate BCP-47 tags do not produce duplicate hreflang keys.
+  - A Dub missing a public slug or BCP-47 tag is omitted from alternates without
+    breaking metadata for the selected page.
+  - Covers AE4. JSON-LD uses the same Mux fallback thumbnail when no curated
+    image exists.
+  - JSON-LD sanitizes `<` in title or description before it reaches the script
+    body.
+- **Verification:** Rendered head includes canonical plus alternate hreflang
+  links for playable Dubs, and the page body contains one JSON-LD script that
+  validates structurally in tests.
+
+### U4. Server-Rendered Accessibility Semantics
+
+- **Goal:** Resolve or guard the WAVE language, duplicate-H1, and image-alt
+  findings without changing visual design.
+- **Requirements:** R6, R7, R8, AE5.
+- **Dependencies:** U1.
+- **Files:** `apps/web/src/app/[locale]/[htmlLang]/layout.tsx`,
+  `apps/web/src/proxy.ts`,
+  `apps/web/src/lib/locale.ts`,
+  `apps/web/src/components/watch/HeroPlayer.tsx`,
+  `apps/web/src/components/watch/WatchBody.tsx`,
+  `apps/web/src/components/watch/BibleQuotesSection.tsx`,
+  `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchBody.test.tsx`,
+  `apps/web/src/components/watch/__tests__/BibleQuotesSection.test.tsx`,
+  `apps/web/src/proxy.test.ts`.
+- **Approach:** First prove whether raw server HTML already carries
+  `<html lang>` for the public dev URL; patch the locale rewrite/layout only if
+  the raw HTML is missing or mismatched. Keep `HeroPlayer` as the single H1
+  owner, keep body title copies as H2 or lower, and classify each empty-alt
+  image in the audited page as decorative or informative. Decorative images
+  should stay empty-alt with assistive-tech-hidden semantics; informative
+  images should use authored alt or title fallback.
+- **Execution note:** Treat the duplicate-H1 finding as characterization-first
+  because `WatchBody` already appears to render the repeated body title as H2
+  on this branch.
+- **Patterns to follow:** The H2 comment in `WatchBody`; `SeriesHero` decorative
+  poster treatment; the locale identity separation documented in
+  `apps/web/CLAUDE.md`.
+- **Test scenarios:**
+  - Covers AE5. The public English route resolves to a server-rendered
+    `<html lang="en">` before hydration.
+  - Rendering `HeroPlayer` plus `WatchBody` for the same video produces one H1
+    and one repeated body heading below H1 level.
+  - Decorative Bible quote images are hidden from assistive technology and keep
+    empty alt.
+  - Informative poster/modal images use authored alt when present and title
+    fallback otherwise.
+  - Non-English public audio slug routes keep content-language and UI-locale
+    identities separate while still producing a valid HTML lang tag.
+- **Verification:** Raw HTML and component tests explain the WAVE finding: fixed
+  if real, documented as decorative/false-positive if already correct.
+
+### U5. Mobile LCP and Unused-JavaScript Readiness Check
+
+- **Goal:** Reduce the reported mobile LCP risk with targeted Watch hero/player
+  checks rather than a broad bundle rewrite.
+- **Requirements:** R9, R10.
+- **Dependencies:** U1, U2.
+- **Files:** `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`,
+  `apps/web/src/app/[locale]/[htmlLang]/layout.tsx`,
+  `apps/web/src/components/watch/HeroPlayer.tsx`,
+  `apps/web/src/components/watch/SiblingCarousel.tsx`,
+  `apps/web/src/components/sections/index.tsx`,
+  `apps/web/src/env.ts`,
+  `packages/video-player/package.json`,
+  `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`.
+- **Approach:** Verify the dev deployment has the existing LCP improvements
+  active: Mux preconnects, exactly one hero poster preload, matching
+  `thumbnail.webp?width=1280` poster URL, MuxVideo flag path where expected,
+  HLS buffer caps, lazy sibling thumbnails, and dynamic section renderer
+  splitting. If the MuxVideo flag is off on the dev server, treat enabling it
+  as the first remediation before adding code. If unused JavaScript remains the
+  dominant issue after that, inspect whether section players still pull legacy
+  player code through barrel imports and apply the existing subpath-export
+  pattern.
+- **Patterns to follow:**
+  `docs/solutions/performance-issues/web-watch-route-lighthouse-perf-campaign-lcp-bundle-fonts-20260527.md`;
+  `docs/solutions/performance-issues/watch-hero-muxplayer-to-muxvideo-swap-20260526.md`.
+- **Test scenarios:**
+  - The HeroPlayer MuxVideo path still receives the exact poster URL emitted by
+    the server preload.
+  - The hero path keeps HLS buffer caps at the previously tuned values.
+  - The MuxVideo path does not fetch or depend on MuxPlayer chrome props.
+  - Sibling carousel images do not emit priority/eager preloads that compete
+    with the hero poster.
+  - Build output inspection after implementation confirms no obvious loser
+    backend or video.js chunk enters the audited route when the intended flag is
+    enabled.
+- **Verification:** Lighthouse or Helium-assisted smoke compares LCP, Speed
+  Index, Total Blocking Time, script transfer, and preload count against the
+  June 9 report baseline.
+
+---
+
+## System-Wide Impact
+
+This change affects crawler-visible metadata, social sharing previews,
+accessibility semantics, and mobile performance posture for Watch video pages.
+It should not change user-visible route shapes, canonical ownership, admin data
+ownership, or Watch page layout. The highest blast-radius area is metadata:
+wrong canonical or hreflang output can fragment indexing even when the page
+renders correctly.
+
+---
+
+## Risks & Dependencies
+
+- **Canonical drift:** Accidentally using the dev request host would undo
+  `feat-160`. Keep production-origin tests beside every metadata change.
+- **Hreflang volume:** Some videos may have many playable Dubs. If page-head
+  alternates become too large, move the full matrix to sitemap follow-up and
+  keep a bounded page-head strategy.
+- **Data sparsity:** Some admin records may lack localized title, image alt, or
+  curated stills. The plan must preserve graceful fallbacks without reverting to
+  raw slugs when a better page-body title is available.
+- **Performance false positives:** The report is lab-only for the dev subdomain.
+  Treat Lighthouse deltas as directional until the dev build's flags and cache
+  state are confirmed.
+- **Framework API shape:** Next.js supports `alternates.languages` in Metadata,
+  but JSON-LD is still rendered from the route tree as a script, not as a
+  metadata field.
+
+---
+
+## Sources & Research
+
+- User-provided June 9 Watch dev-server audit report: baseline findings for
+  slug title, generic social image, missing hreflang/JSON-LD, language warning,
+  H1/alt issues, and mobile LCP.
+- `apps/web/CLAUDE.md`: Next.js App Router, admin GraphQL, static locale layout,
+  and public audio-language slug conventions.
+- `docs/roadmap/platform/feat-160-watch-public-metadata-origin.md`: completed
+  production-origin canonical contract.
+- `docs/roadmap/platform/feat-148-watch-static-render-locale-rewrite.md` and
+  `docs/solutions/performance-issues/watch-static-locale-rewrite-route-manifest-admission-20260529.md`:
+  public route, internal locale, and HTML language separation.
+- `docs/solutions/performance-issues/web-watch-route-lighthouse-perf-campaign-lcp-bundle-fonts-20260527.md`:
+  existing Watch LCP playbook and prevention rules.
+- Next.js `generateMetadata` docs:
+  `https://nextjs.org/docs/app/api-reference/functions/generate-metadata` for
+  `alternates.languages`, metadata URL composition, and resource hint limits.
+- Next.js JSON-LD guide: `https://nextjs.org/docs/app/guides/json-ld` for
+  native script rendering and JSON escaping guidance.

--- a/docs/plans/2026-06-10-001-fix-watch-dev-launch-readiness-plan.md
+++ b/docs/plans/2026-06-10-001-fix-watch-dev-launch-readiness-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Watch Dev Launch Readiness"
 type: "fix"
-status: "active"
+status: "completed"
 date: "2026-06-10"
 roadmap: "docs/roadmap/platform/feat-173-watch-dev-launch-readiness-audit.md"
 ---

--- a/docs/roadmap/platform/feat-173-watch-dev-launch-readiness-audit.md
+++ b/docs/roadmap/platform/feat-173-watch-dev-launch-readiness-audit.md
@@ -1,0 +1,108 @@
+---
+id: "feat-173"
+title: "Watch dev launch-readiness audit fixes"
+owner: "vlad"
+priority: "P1"
+status: "in-progress"
+start_date: "2026-06-10"
+duration: 2
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "seo"
+  - "accessibility"
+  - "performance"
+---
+
+## Problem
+
+The Watch dev server page at
+`https://watch.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html`
+is close to production parity, but the June 9 audit found launch-readiness
+gaps before the redesigned app can replace the production
+`https://www.jesusfilm.org/watch/...` surface. The canonical URL pointing at
+`www.jesusfilm.org` is expected because `watch.jesusfilm.org` is the dev
+server, but the page still showed slug-based social titles, a generic stock
+social image, missing hreflang and structured data, an accessibility language
+warning, empty image-alt warnings, duplicate-H1 risk, and slow mobile LCP.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-10-001-fix-watch-dev-launch-readiness-plan.md` -
+   implementation plan for this audit slice.
+2. `apps/web/src/lib/experience-metadata.ts` - shared watch metadata builder
+   for canonical, Open Graph, Twitter, robots, and future alternates.
+3. `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx` - two-segment
+   and three-segment watch route metadata, LCP preload, and page rendering.
+4. `apps/web/src/app/[locale]/[htmlLang]/layout.tsx` - server-rendered
+   `<html lang>` and watch resource hints.
+5. `apps/web/src/lib/content.ts` and `apps/web/src/lib/fragments/watch-video.ts`
+   - admin-backed video, Dub, image, and localized metadata shapes.
+6. `apps/web/src/components/watch/HeroPlayer.tsx` and
+   `apps/web/src/components/watch/WatchBody.tsx` - H1/title semantics and
+   hero LCP behavior.
+7. `docs/roadmap/platform/feat-160-watch-public-metadata-origin.md` - completed
+   public-origin contract that keeps dev metadata canonicalized to production.
+8. `docs/solutions/performance-issues/web-watch-route-lighthouse-perf-campaign-lcp-bundle-fonts-20260527.md`
+   - prior Watch route LCP and bundle findings.
+
+## Grep These
+
+- `getWatchPageMetadata`
+- `generateSeriesMetadata`
+- `resolveWatchVideoBySlug`
+- `DEFAULT_OG_IMAGE`
+- `alternates:`
+- `application/ld+json`
+- `hero-player-overlay-title`
+- `watch-body-title`
+- `NEXT_PUBLIC_FORGE_WATCH_HERO_MUX_VIDEO`
+- `thumbnail.webp?width=1280`
+
+## What To Build
+
+1. Make two- and three-segment video metadata use the resolved watch video
+   title, description, language, image, and selected Dub instead of falling
+   back to route slugs or generic imagery.
+2. Keep canonical and `og:url` on `https://www.jesusfilm.org/watch/...` for
+   dev, preview, and watch-only deployments, with regression tests.
+3. Populate Open Graph and Twitter title, description, and image fields from
+   the same resolved metadata source so shared links show readable titles and
+   film-relevant stills.
+4. Add page-level structured data for playable watch videos and episodes using
+   sanitized native JSON-LD script output.
+5. Add hreflang alternates from playable Dubs using public audio-language URL
+   slugs and BCP-47 language tags, with duplicate-language and unsupported-row
+   handling.
+6. Verify server-rendered `<html lang>` for the public dev URL path and patch
+   only if the raw HTML misses it.
+7. Lock the page to one semantic H1, classify empty-alt images as decorative or
+   informative, and add focused regression coverage.
+8. Recheck mobile LCP on the dev server and apply targeted remediation from the
+   existing Watch performance playbook rather than starting a broad bundle
+   rewrite.
+
+## Constraints
+
+- Do not change the public `/watch/{slug}.html/{language}.html` URL contract.
+- Do not switch canonical ownership from production `www.jesusfilm.org` to the
+  dev `watch.jesusfilm.org` host.
+- Do not import Core, Algolia, or legacy watch-app code into `apps/web`.
+- Do not use request-time dynamic APIs in cacheable Watch render trees.
+- Do not hand-edit generated GraphQL env or introspection output.
+- Keep decorative images decorative; only add visible alt text for
+  content-bearing images.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/lib/experience-metadata.test.ts src/lib/__tests__/experience-metadata-watch-page.test.ts src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx src/components/watch/__tests__/WatchBody.test.tsx`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Helium smoke on the dev server URL confirms readable title/OG/Twitter tags,
+  production canonical URL, one H1, raw server-rendered `<html lang>`, JSON-LD,
+  hreflang entries, and no regression in the LCP preload.
+- Lighthouse mobile smoke records LCP, Speed Index, Total Blocking Time, and
+  request/chunk changes against the June 9 audit baseline.

--- a/docs/roadmap/platform/feat-173-watch-dev-launch-readiness-audit.md
+++ b/docs/roadmap/platform/feat-173-watch-dev-launch-readiness-audit.md
@@ -3,7 +3,7 @@ id: "feat-173"
 title: "Watch dev launch-readiness audit fixes"
 owner: "vlad"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-06-10"
 duration: 2
 depends_on: []


### PR DESCRIPTION
## Summary

Watch video pages now build crawler and social metadata from the resolved playable video instead of the fallback slug/template path, so shared cards can show the human title, a film-relevant still, Twitter parity, hreflang alternates, and VideoObject JSON-LD while canonical and OG URLs stay pinned to `www.jesusfilm.org`.

The route keeps curated Experience metadata ahead of same-slug videos, so editorial landing pages do not get overwritten by video metadata. Episode pages now use their three-segment production canonical URL, and informative sibling thumbnails no longer emit empty alt text.

## Validation

- `pnpm --filter @forge/web test -- src/lib/experience-metadata.test.ts src/lib/watch-structured-data.test.ts 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx' src/components/watch/__tests__/SiblingCarousel.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- Helium smoke against `https://watch.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html`

Helium smoke exercised the currently deployed dev server, not this un-deployed branch. It confirmed the page loads with `html lang="en"`, one H1, production canonical/OG URL, and an LCP poster preload; it also confirmed the deployed dev server still shows the report baseline for slug social title, stock social image, missing hreflang, and missing JSON-LD until this PR ships.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
