### PR TITLE
fix: harden watch cache invalidation

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -225,7 +225,7 @@ reason=config_missing`).
    such as `/watch/jesus.html/english.html`, and confirm refresh. Tail admin logs for
    `event=web_revalidate.sent httpStatus=200`. Web's receiver invalidates
    route paths with `revalidatePath` and resolver Data Cache entries with
-   `revalidateTag(tag, "max")`.
+   `revalidateTag(tag, { expire: 0 })`.
 
 Reversing the order produces a dead minute where admin's first call 401s
 against an unconfigured web. The webhook itself swallows the 401, so the

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -198,7 +198,8 @@ not in the script.
 ### Web ISR revalidation webhook (U21)
 
 `apps/admin/src/services/revalidate-webhook.ts` emits ISR refresh hints
-to web on Experience publish / update / archive. Best-effort:
+to web on Experience publish / update / archive and broad watch video-data
+changes from Core sync. Best-effort:
 `emitRevalidateWebhook` catches every failure mode (config missing, 5xx,
 network, timeout) and is called via `void` so admin's publish UX never
 blocks on web. Wired into `ExperienceService.publishLocale`,
@@ -220,9 +221,11 @@ Deploy ordering (receiver-first, per
    Until both are set, `emitRevalidateWebhook` silently no-ops with a
    structured log per attempt (`event=web_revalidate.skipped
 reason=config_missing`).
-3. Verify end-to-end: publish an Experience, fetch the matching
-   `/[slug]/[locale]` on web within 30 s, confirm refresh. Tail admin
-   logs for `event=web_revalidate.sent httpStatus=200`.
+3. Verify end-to-end: publish an Experience, fetch the matching public watch URL
+   such as `/watch/jesus.html/english.html`, and confirm refresh. Tail admin logs for
+   `event=web_revalidate.sent httpStatus=200`. Web's receiver invalidates
+   route paths with `revalidatePath` and resolver Data Cache entries with
+   `revalidateTag(tag, "max")`.
 
 Reversing the order produces a dead minute where admin's first call 401s
 against an unconfigured web. The webhook itself swallows the 401, so the
@@ -266,6 +269,12 @@ the full manifest payload is intentionally needed. Like `seed-web-fixtures`, it
 refuses production-like `DATABASE_URL` hosts (`*.railway.app`,
 `*.jesusfilm.org`, and unparseable URLs) so operators do not accidentally mutate
 production snapshots from a workstation.
+
+Core sync also has a broader watch-render invalidation set: `languages`,
+`videos`, `video-images`, `video-editions`, `video-subtitles`, `video-dubs`,
+and `video-dub-downloads`. When any of those phases run, admin emits a broad
+`model: "video"` webhook with no slug so web clears video, series, child-dub,
+and home resolver caches even when the manifest itself does not need refreshing.
 
 ### Video database backup and clone
 

--- a/apps/admin/src/services/watch-route-manifest-refresh.service.test.ts
+++ b/apps/admin/src/services/watch-route-manifest-refresh.service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   refreshWatchRouteManifest,
   refreshWatchRouteManifestAfterCoreSync,
+  shouldInvalidateWatchRenderDataAfterCoreSync,
   shouldRefreshWatchRouteManifestAfterCoreSync,
 } from "./watch-route-manifest-refresh.service"
 
@@ -114,15 +115,152 @@ describe("watch route manifest refresh", () => {
     ).toBe(true)
   })
 
+  it("detects changed render-relevant Core sync phases separately from route manifest phases", () => {
+    const renderRelevantPhases = [
+      "languages",
+      "videos",
+      "video-images",
+      "video-editions",
+      "video-subtitles",
+      "video-dubs",
+      "video-dub-downloads",
+    ]
+
+    for (const phase of renderRelevantPhases) {
+      expect(
+        shouldInvalidateWatchRenderDataAfterCoreSync([
+          { phase, created: 0, updated: 1, softDeleted: 0 },
+        ]),
+      ).toBe(true)
+    }
+
+    expect(
+      shouldInvalidateWatchRenderDataAfterCoreSync([
+        { phase: "video-images", created: 0, updated: 0, softDeleted: 0 },
+      ]),
+    ).toBe(false)
+    expect(
+      shouldInvalidateWatchRenderDataAfterCoreSync([
+        { phase: "countries", created: 1, updated: 0, softDeleted: 0 },
+      ]),
+    ).toBe(false)
+  })
+
   it("skips Core sync refresh when no route-relevant phases ran", async () => {
+    const emitWebhook = vi.fn()
     const outcome = await refreshWatchRouteManifestAfterCoreSync({
       prisma: {} as never,
       phases: [{ phase: "keywords" }],
+      emitWebhook,
     })
 
     expect(outcome).toEqual({
       status: "skipped",
       reason: "no-route-relevant-core-sync-phases",
     })
+    expect(emitWebhook).not.toHaveBeenCalled()
+  })
+
+  it("emits broad video invalidation for render-only Core sync phases without refreshing the manifest", async () => {
+    const emitWebhook = vi
+      .fn()
+      .mockResolvedValue({ status: "sent", httpStatus: 200 })
+
+    const outcome = await refreshWatchRouteManifestAfterCoreSync({
+      prisma: {} as never,
+      phases: [{ phase: "video-images", created: 1, updated: 0 }],
+      emitWebhook,
+    })
+
+    expect(outcome).toEqual({
+      status: "skipped",
+      reason: "no-route-relevant-core-sync-phases",
+    })
+    expect(generateMock).not.toHaveBeenCalled()
+    expect(upsertLatestMock).not.toHaveBeenCalled()
+    expect(emitWebhook).toHaveBeenCalledWith({
+      model: "video",
+      slug: null,
+      locale: null,
+    })
+  })
+
+  it("does not emit broad video invalidation for no-op scheduled Core sync phases", async () => {
+    const emitWebhook = vi.fn()
+
+    const outcome = await refreshWatchRouteManifestAfterCoreSync({
+      prisma: {} as never,
+      phases: [
+        { phase: "video-images", created: 0, updated: 0, softDeleted: 0 },
+      ],
+      emitWebhook,
+    })
+
+    expect(outcome).toEqual({
+      status: "skipped",
+      reason: "no-route-relevant-core-sync-phases",
+    })
+    expect(emitWebhook).not.toHaveBeenCalled()
+  })
+
+  it("refreshes the manifest before broad video invalidation for route-and-render-relevant Core sync phases", async () => {
+    generateMock.mockResolvedValueOnce(manifest)
+    upsertLatestMock.mockResolvedValueOnce({
+      version: manifest.version,
+      payload: manifest,
+      payloadSizeBytes: 128,
+    })
+    const emitWebhook = vi
+      .fn()
+      .mockResolvedValue({ status: "sent", httpStatus: 200 })
+
+    const outcome = await refreshWatchRouteManifestAfterCoreSync({
+      prisma: {} as never,
+      phases: [{ phase: "video-dubs", updated: 1 }],
+      emitWebhook,
+    })
+
+    expect(outcome).toMatchObject({
+      status: "refreshed",
+      reason: "core-sync",
+    })
+    expect(emitWebhook).toHaveBeenNthCalledWith(1, {
+      model: "watch-route-manifest",
+      slug: null,
+      locale: null,
+    })
+    expect(emitWebhook).toHaveBeenNthCalledWith(2, {
+      model: "video",
+      slug: null,
+      locale: null,
+    })
+  })
+
+  it("keeps the Core sync outcome when broad video invalidation throws", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const emitWebhook = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("web unavailable"))
+
+    try {
+      const outcome = await refreshWatchRouteManifestAfterCoreSync({
+        prisma: {} as never,
+        phases: [{ phase: "video-images", updated: 1 }],
+        emitWebhook,
+      })
+
+      expect(outcome).toEqual({
+        status: "skipped",
+        reason: "no-route-relevant-core-sync-phases",
+      })
+      expect(emitWebhook).toHaveBeenCalledWith({
+        model: "video",
+        slug: null,
+        locale: null,
+      })
+      expect(warnSpy).toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 })

--- a/apps/admin/src/services/watch-route-manifest-refresh.service.test.ts
+++ b/apps/admin/src/services/watch-route-manifest-refresh.service.test.ts
@@ -185,6 +185,36 @@ describe("watch route manifest refresh", () => {
     })
   })
 
+  it("emits broad video invalidation for soft-deleted render data", async () => {
+    const emitWebhook = vi
+      .fn()
+      .mockResolvedValue({ status: "sent", httpStatus: 200 })
+
+    const phases = [
+      { phase: "video-subtitles", created: 0, updated: 0, softDeleted: 1 },
+    ]
+
+    expect(shouldInvalidateWatchRenderDataAfterCoreSync(phases)).toBe(true)
+
+    const outcome = await refreshWatchRouteManifestAfterCoreSync({
+      prisma: {} as never,
+      phases,
+      emitWebhook,
+    })
+
+    expect(outcome).toEqual({
+      status: "skipped",
+      reason: "no-route-relevant-core-sync-phases",
+    })
+    expect(generateMock).not.toHaveBeenCalled()
+    expect(upsertLatestMock).not.toHaveBeenCalled()
+    expect(emitWebhook).toHaveBeenCalledWith({
+      model: "video",
+      slug: null,
+      locale: null,
+    })
+  })
+
   it("does not emit broad video invalidation for no-op scheduled Core sync phases", async () => {
     const emitWebhook = vi.fn()
 

--- a/apps/admin/src/services/watch-route-manifest-refresh.service.ts
+++ b/apps/admin/src/services/watch-route-manifest-refresh.service.ts
@@ -13,6 +13,16 @@ const ROUTE_RELEVANT_CORE_SYNC_PHASES = new Set([
   "video-dubs",
 ])
 
+const WATCH_RENDER_RELEVANT_CORE_SYNC_PHASES = new Set([
+  "languages",
+  "videos",
+  "video-images",
+  "video-editions",
+  "video-subtitles",
+  "video-dubs",
+  "video-dub-downloads",
+])
+
 export type WatchRouteManifestRefreshReason =
   | "core-sync"
   | "experience.archive"
@@ -43,6 +53,9 @@ export type WatchRouteManifestRefreshOutcome =
 
 type CoreSyncPhaseSummary = {
   phase: string
+  created?: number
+  updated?: number
+  softDeleted?: number
 }
 
 export function shouldRefreshWatchRouteManifestAfterCoreSync(
@@ -51,6 +64,43 @@ export function shouldRefreshWatchRouteManifestAfterCoreSync(
   return phases.some((phase) =>
     ROUTE_RELEVANT_CORE_SYNC_PHASES.has(phase.phase),
   )
+}
+
+export function shouldInvalidateWatchRenderDataAfterCoreSync(
+  phases: readonly CoreSyncPhaseSummary[],
+): boolean {
+  return phases.some(
+    (phase) =>
+      WATCH_RENDER_RELEVANT_CORE_SYNC_PHASES.has(phase.phase) &&
+      ((phase.created ?? 0) > 0 ||
+        (phase.updated ?? 0) > 0 ||
+        (phase.softDeleted ?? 0) > 0),
+  )
+}
+
+async function emitWatchRenderDataRevalidationAfterCoreSync({
+  phases,
+  emitWebhook,
+}: {
+  phases: readonly CoreSyncPhaseSummary[]
+  emitWebhook: typeof emitRevalidateWebhook
+}): Promise<void> {
+  if (!shouldInvalidateWatchRenderDataAfterCoreSync(phases)) return
+  try {
+    await emitWebhook({
+      model: "video",
+      slug: null,
+      locale: null,
+    })
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "watch_render_data.revalidate.failed",
+        detail:
+          error instanceof Error ? error.message.slice(0, 500) : String(error),
+      }),
+    )
+  }
 }
 
 export async function refreshWatchRouteManifest({
@@ -117,15 +167,23 @@ export async function refreshWatchRouteManifest({
 export async function refreshWatchRouteManifestAfterCoreSync({
   prisma,
   phases,
+  emitWebhook = emitRevalidateWebhook,
 }: {
   prisma: PrismaClient
   phases: readonly CoreSyncPhaseSummary[]
+  emitWebhook?: typeof emitRevalidateWebhook
 }): Promise<WatchRouteManifestRefreshOutcome> {
-  if (!shouldRefreshWatchRouteManifestAfterCoreSync(phases)) {
-    return {
-      status: "skipped",
-      reason: "no-route-relevant-core-sync-phases",
-    }
-  }
-  return refreshWatchRouteManifest({ prisma, reason: "core-sync" })
+  const outcome = shouldRefreshWatchRouteManifestAfterCoreSync(phases)
+    ? await refreshWatchRouteManifest({
+        prisma,
+        reason: "core-sync",
+        emitWebhook,
+      })
+    : ({
+        status: "skipped",
+        reason: "no-route-relevant-core-sync-phases",
+      } satisfies WatchRouteManifestRefreshOutcome)
+
+  await emitWatchRenderDataRevalidationAfterCoreSync({ phases, emitWebhook })
+  return outcome
 }

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -39,7 +39,7 @@ Required env vars (both flipped from `.optional()` in U13):
 - `'use client'` is a boundary — everything imported below it is also client.
 - The admin bearer (`WEB_ADMIN_API_KEYS`) is in the server-only env block. Never reference it from a client component or `NEXT_PUBLIC_*` var.
 - For browser-initiated data calls, write a `"use server"` action that wraps the resolver — see `src/lib/search-actions.ts`. The browser hits the action; the action hits admin with the bearer.
-- ISR cache: static watch routes under `src/app/[locale]/[htmlLang]/**` currently use route-level `revalidate = 60`. Watch resolver `unstable_cache` wrappers in `src/lib/content.ts` / `src/lib/watch-home.ts` keep short data TTLs (`60` seconds, except child dub languages at `1h`) and attach coarse tags from `src/lib/watch-cache-tags.ts`. `/api/revalidate` must invalidate both layers: `revalidatePath` for route output and `revalidateTag(tag, "max")` for resolver data. Raise route-level TTL toward `3600` only after preview/topology proof; do not raise resolver TTLs until production cache topology and webhook reliability are proven.
+- ISR cache: static watch routes under `src/app/[locale]/[htmlLang]/**` currently use route-level `revalidate = 60`. Watch resolver `unstable_cache` wrappers in `src/lib/content.ts` / `src/lib/watch-home.ts` keep short data TTLs (`60` seconds, except child dub languages at `1h`) and attach coarse tags from `src/lib/watch-cache-tags.ts`. `/api/revalidate` must invalidate both layers: `revalidatePath` for route output and `revalidateTag(tag, { expire: 0 })` for resolver data so webhook-triggered renders do not serve stale Data Cache first. Raise route-level TTL toward `3600` only after preview/topology proof; do not raise resolver TTLs until production cache topology and webhook reliability are proven.
 - 15 orphaned Strapi block fragment files remain at `src/lib/fragments/*` because section components in `src/components/sections/*.tsx` still derive prop types via `FragmentOf<typeof strapiFragment>`. Runtime data is admin-shape via the renderer's `as unknown as` cast bridge. Migrating section components to admin fragment imports is a clean follow-up bundle.
 - **Static locale root layout**: cacheable watch surfaces live under the internal route tree `src/app/[locale]/[htmlLang]/**`. `src/proxy.ts` rewrites public `/watch` URLs into that tree, so the root layout gets static params for both the next-intl message catalog key (`[locale]`) and `<html lang>` (`[htmlLang]`) without calling `headers()` or `cookies()`. Keep request-time dynamic APIs out of this tree unless the route is intentionally dynamic.
 
@@ -60,8 +60,8 @@ The receiver maps each semantic model to both paths and Data Cache tags:
 
 - `watch-setting` invalidates home/settings/experience/video/series/child-dub tags plus the watch layouts and homepage paths.
 - `experience` invalidates experience/home tags plus the current slug matrix.
-- `video` invalidates video/series/child-dub/home tags; slug-less payloads are valid broad invalidations for Core sync.
-- `watch-route-manifest` clears the receiving process's in-memory manifest cache and invalidates the route-manifest tag.
+- `video` invalidates video/series/child-dub/home tags; slug-less payloads are valid broad invalidations for Core sync and revalidate the watch layouts.
+- `watch-route-manifest` clears the receiving process's in-memory manifest cache, invalidates the route-manifest tag, and revalidates the watch layouts.
 
 The route manifest cache in `src/lib/watch-route-manifest.ts` is process-local. The webhook clears only the process that receives it; other web instances rely on the 60 second manifest TTL unless production uses shared cache storage or all-instance webhook fan-out.
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -39,7 +39,7 @@ Required env vars (both flipped from `.optional()` in U13):
 - `'use client'` is a boundary — everything imported below it is also client.
 - The admin bearer (`WEB_ADMIN_API_KEYS`) is in the server-only env block. Never reference it from a client component or `NEXT_PUBLIC_*` var.
 - For browser-initiated data calls, write a `"use server"` action that wraps the resolver — see `src/lib/search-actions.ts`. The browser hits the action; the action hits admin with the bearer.
-- ISR cache: `unstable_cache` wrappers in `src/lib/content.ts` use `revalidate: 60`. `revalidatePath` from `/api/revalidate` does NOT invalidate `unstable_cache` entries — tag-based invalidation is a known follow-up. Today the worst-case staleness is 60 s after a publish.
+- ISR cache: static watch routes under `src/app/[locale]/[htmlLang]/**` currently use route-level `revalidate = 60`. Watch resolver `unstable_cache` wrappers in `src/lib/content.ts` / `src/lib/watch-home.ts` keep short data TTLs (`60` seconds, except child dub languages at `1h`) and attach coarse tags from `src/lib/watch-cache-tags.ts`. `/api/revalidate` must invalidate both layers: `revalidatePath` for route output and `revalidateTag(tag, "max")` for resolver data. Raise route-level TTL toward `3600` only after preview/topology proof; do not raise resolver TTLs until production cache topology and webhook reliability are proven.
 - 15 orphaned Strapi block fragment files remain at `src/lib/fragments/*` because section components in `src/components/sections/*.tsx` still derive prop types via `FragmentOf<typeof strapiFragment>`. Runtime data is admin-shape via the renderer's `as unknown as` cast bridge. Migrating section components to admin fragment imports is a clean follow-up bundle.
 - **Static locale root layout**: cacheable watch surfaces live under the internal route tree `src/app/[locale]/[htmlLang]/**`. `src/proxy.ts` rewrites public `/watch` URLs into that tree, so the root layout gets static params for both the next-intl message catalog key (`[locale]`) and `<html lang>` (`[htmlLang]`) without calling `headers()` or `cookies()`. Keep request-time dynamic APIs out of this tree unless the route is intentionally dynamic.
 
@@ -52,6 +52,18 @@ Public watch links must always use the raw audio language slug, never the messag
 Adding a UI locale: drop `messages/{locale}.json`, then run `pnpm --filter @forge/web generate:ui-locales` or any build/test script that runs it. The generated edge-safe catalog module drives middleware, route helpers, and next-intl catalog membership without a manual TypeScript whitelist. CI runs `check:ui-locales` during lint before build/test scripts can regenerate the file, and the drift gate in `src/i18n/__tests__/messages-parity.test.ts` verifies the generated list matches filesystem catalogs. The structural-parity test also enforces every namespace key exists in every catalog.
 
 Critical: `src/i18n/generated-ui-locales.ts` is the only catalog list safe to import from middleware, route helpers, and client-reachable modules. Do NOT copy filesystem discovery into request-path modules (filesystem I/O in the request path is a regression), and do NOT import `src/i18n/locales.ts` into middleware or client-safe helpers because it is a server-only re-export for next-intl request configuration. Keep the internal `[locale]` segment bounded to generated message catalogs; use `[htmlLang]` only for the static HTML language tag.
+
+## Watch cache invalidation
+
+Admin sends semantic revalidation webhooks to `src/app/api/revalidate/route.ts`.
+The receiver maps each semantic model to both paths and Data Cache tags:
+
+- `watch-setting` invalidates home/settings/experience/video/series/child-dub tags plus the watch layouts and homepage paths.
+- `experience` invalidates experience/home tags plus the current slug matrix.
+- `video` invalidates video/series/child-dub/home tags; slug-less payloads are valid broad invalidations for Core sync.
+- `watch-route-manifest` clears the receiving process's in-memory manifest cache and invalidates the route-manifest tag.
+
+The route manifest cache in `src/lib/watch-route-manifest.ts` is process-local. The webhook clears only the process that receives it; other web instances rely on the 60 second manifest TTL unless production uses shared cache storage or all-instance webhook fan-out.
 
 See `docs/plans/2026-05-28-001-feat-i18n-migration-next-intl-plan.md`.
 

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -49,11 +49,12 @@ import {
 } from "@/lib/url-shape"
 import { fetchYouVersionBibleQuotePassages } from "@/lib/youversion-passage"
 
-// ISR: pages cached for 60s. Cookie-driven language redirect lives in
+// ISR: pages cached for 60 seconds. Cookie-driven language redirect lives in
 // apps/web/src/proxy.ts (middleware) — keeping cookies() out of this page
 // route preserves ISR for the majority of traffic without the preference
-// cookie. Keep the build output clean so runtime ISR artifacts from old
-// deploys cannot be packaged as fresh pages. See
+// cookie. Admin revalidation clears both route paths and tagged resolver data.
+// Keep the build output clean so runtime ISR artifacts from old deploys cannot
+// be packaged as fresh pages. See
 // docs/solutions/web/nextjs-headers-defeats-route-cache.md.
 export const revalidate = 60
 export const dynamic = "force-static"

--- a/apps/web/src/app/api/revalidate/route.test.ts
+++ b/apps/web/src/app/api/revalidate/route.test.ts
@@ -94,14 +94,24 @@ describe("POST /api/revalidate", () => {
     expect(revalidatePathMock).toHaveBeenCalledWith("/en/en/english.html")
     expect(revalidatePathMock).toHaveBeenCalledWith("/english")
     expect(revalidatePathMock).not.toHaveBeenCalledWith("/en.html")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:settings", "max")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:experience", "max")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", "max")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", {
+      expire: 0,
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:settings", {
+      expire: 0,
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:experience", {
+      expire: 0,
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", {
+      expire: 0,
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", {
+      expire: 0,
+    })
     expect(revalidateTagMock).toHaveBeenCalledWith(
       "watch:child-dub-languages",
-      "max",
+      { expire: 0 },
     )
   })
 
@@ -177,8 +187,12 @@ describe("POST /api/revalidate", () => {
     expect(revalidatePathMock).not.toHaveBeenCalledWith(
       "/en/en/jesus.html/en.html",
     )
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:experience", "max")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:experience", {
+      expire: 0,
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", {
+      expire: 0,
+    })
   })
 
   it("keeps path invalidation working when tag invalidation fails", async () => {
@@ -274,13 +288,19 @@ describe("POST /api/revalidate", () => {
     expect(revalidatePathMock).not.toHaveBeenCalledWith(
       "/jesus.html/german.html",
     )
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", "max")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", {
+      expire: 0,
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", {
+      expire: 0,
+    })
     expect(revalidateTagMock).toHaveBeenCalledWith(
       "watch:child-dub-languages",
-      "max",
+      { expire: 0 },
     )
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", {
+      expire: 0,
+    })
   })
 
   it("supports broad video data invalidation without a slug", async () => {
@@ -303,7 +323,7 @@ describe("POST /api/revalidate", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
       revalidated: true,
-      paths: [],
+      paths: ["/[locale]/[htmlLang] (layout)", "/ (layout)"],
       tags: [
         "watch:video",
         "watch:series",
@@ -311,14 +331,24 @@ describe("POST /api/revalidate", () => {
         "watch:home",
       ],
     })
-    expect(revalidatePathMock).not.toHaveBeenCalled()
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", "max")
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", "max")
+    expect(revalidatePathMock).toHaveBeenCalledWith(
+      "/[locale]/[htmlLang]",
+      "layout",
+    )
+    expect(revalidatePathMock).toHaveBeenCalledWith("/", "layout")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", {
+      expire: 0,
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", {
+      expire: 0,
+    })
     expect(revalidateTagMock).toHaveBeenCalledWith(
       "watch:child-dub-languages",
-      "max",
+      { expire: 0 },
     )
-    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", {
+      expire: 0,
+    })
   })
 
   it("infers public audio slugs for generated catalog locales outside the original core set", async () => {
@@ -413,15 +443,18 @@ describe("POST /api/revalidate", () => {
     await expect(response.json()).resolves.toEqual({
       revalidated: true,
       manifestCacheCleared: true,
-      paths: [],
+      paths: ["/[locale]/[htmlLang] (layout)", "/ (layout)"],
       tags: ["watch:route-manifest"],
     })
     expect(clearWatchRouteManifestCacheMock).toHaveBeenCalledTimes(1)
-    expect(revalidatePathMock).not.toHaveBeenCalled()
-    expect(revalidateTagMock).toHaveBeenCalledWith(
-      "watch:route-manifest",
-      "max",
+    expect(revalidatePathMock).toHaveBeenCalledWith(
+      "/[locale]/[htmlLang]",
+      "layout",
     )
+    expect(revalidatePathMock).toHaveBeenCalledWith("/", "layout")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:route-manifest", {
+      expire: 0,
+    })
   })
 
   it("rejects requests with no auth header", async () => {

--- a/apps/web/src/app/api/revalidate/route.test.ts
+++ b/apps/web/src/app/api/revalidate/route.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-const { clearWatchRouteManifestCacheMock, revalidatePathMock } = vi.hoisted(
-  () => ({
-    clearWatchRouteManifestCacheMock: vi.fn(),
-    revalidatePathMock: vi.fn(),
-  }),
-)
+const {
+  clearWatchRouteManifestCacheMock,
+  revalidatePathMock,
+  revalidateTagMock,
+} = vi.hoisted(() => ({
+  clearWatchRouteManifestCacheMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  revalidateTagMock: vi.fn(),
+}))
 
 vi.mock("@/lib/watch-route-manifest", () => ({
   clearWatchRouteManifestCache: clearWatchRouteManifestCacheMock,
@@ -13,12 +16,14 @@ vi.mock("@/lib/watch-route-manifest", () => ({
 
 vi.mock("next/cache", () => ({
   revalidatePath: revalidatePathMock,
+  revalidateTag: revalidateTagMock,
 }))
 
 describe("POST /api/revalidate", () => {
   afterEach(() => {
     clearWatchRouteManifestCacheMock.mockReset()
     revalidatePathMock.mockReset()
+    revalidateTagMock.mockReset()
     vi.doUnmock("@/i18n/generated-ui-locales")
     vi.resetModules()
   })
@@ -45,6 +50,14 @@ describe("POST /api/revalidate", () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body).toMatchObject({ revalidated: true })
+    expect(body.tags).toEqual([
+      "watch:home",
+      "watch:settings",
+      "watch:experience",
+      "watch:video",
+      "watch:series",
+      "watch:child-dub-languages",
+    ])
     expect(body.paths).toEqual(
       expect.arrayContaining([
         "/[locale]/[htmlLang] (layout)",
@@ -81,6 +94,15 @@ describe("POST /api/revalidate", () => {
     expect(revalidatePathMock).toHaveBeenCalledWith("/en/en/english.html")
     expect(revalidatePathMock).toHaveBeenCalledWith("/english")
     expect(revalidatePathMock).not.toHaveBeenCalledWith("/en.html")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:settings", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:experience", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith(
+      "watch:child-dub-languages",
+      "max",
+    )
   })
 
   it("revalidates slug and localized variants for experience updates (Bearer)", async () => {
@@ -106,6 +128,7 @@ describe("POST /api/revalidate", () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body).toMatchObject({ revalidated: true })
+    expect(body.tags).toEqual(["watch:experience", "watch:home"])
     expect(body.paths).toEqual(
       expect.arrayContaining([
         "/jesus.html/english.html",
@@ -154,6 +177,59 @@ describe("POST /api/revalidate", () => {
     expect(revalidatePathMock).not.toHaveBeenCalledWith(
       "/en/en/jesus.html/en.html",
     )
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:experience", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
+  })
+
+  it("keeps path invalidation working when tag invalidation fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    revalidateTagMock
+      .mockImplementationOnce(() => {
+        throw new Error("tag cache unavailable")
+      })
+      .mockImplementation(() => undefined)
+
+    try {
+      const { POST } = await import("./route")
+
+      const response = await POST(
+        new Request("http://example.test/api/revalidate", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            Authorization: "Bearer test-revalidation-secret",
+          },
+          body: JSON.stringify({
+            model: "experience",
+            entry: {
+              slug: "jesus",
+              locale: "en",
+            },
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body).toMatchObject({
+        revalidated: true,
+        tags: ["watch:home"],
+        tagErrors: ["watch:experience"],
+      })
+      expect(body.paths).toEqual(
+        expect.arrayContaining([
+          "/jesus.html/english.html",
+          "/en/en/jesus.html/english.html",
+          "/jesus/english",
+        ]),
+      )
+      expect(revalidatePathMock).toHaveBeenCalledWith(
+        "/jesus.html/english.html",
+      )
+      expect(warnSpy).toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it("uses the canonical public audio slug for non-English localized content", async () => {
@@ -184,6 +260,12 @@ describe("POST /api/revalidate", () => {
         "/de/de/jesus.html/german-standard.html",
         "/jesus/german-standard",
       ],
+      tags: [
+        "watch:video",
+        "watch:series",
+        "watch:child-dub-languages",
+        "watch:home",
+      ],
     })
     expect(revalidatePathMock).toHaveBeenCalledWith(
       "/jesus.html/german-standard.html",
@@ -192,6 +274,51 @@ describe("POST /api/revalidate", () => {
     expect(revalidatePathMock).not.toHaveBeenCalledWith(
       "/jesus.html/german.html",
     )
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith(
+      "watch:child-dub-languages",
+      "max",
+    )
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
+  })
+
+  it("supports broad video data invalidation without a slug", async () => {
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://example.test/api/revalidate", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer test-revalidation-secret",
+        },
+        body: JSON.stringify({
+          model: "video",
+          entry: {},
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      revalidated: true,
+      paths: [],
+      tags: [
+        "watch:video",
+        "watch:series",
+        "watch:child-dub-languages",
+        "watch:home",
+      ],
+    })
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:video", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:series", "max")
+    expect(revalidateTagMock).toHaveBeenCalledWith(
+      "watch:child-dub-languages",
+      "max",
+    )
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:home", "max")
   })
 
   it("infers public audio slugs for generated catalog locales outside the original core set", async () => {
@@ -230,6 +357,12 @@ describe("POST /api/revalidate", () => {
         "/jesus.html/russian.html",
         "/ru/ru/jesus.html/russian.html",
         "/jesus/russian",
+      ],
+      tags: [
+        "watch:video",
+        "watch:series",
+        "watch:child-dub-languages",
+        "watch:home",
       ],
     })
     expect(revalidatePathMock).toHaveBeenCalledWith("/jesus.html/russian.html")
@@ -281,9 +414,14 @@ describe("POST /api/revalidate", () => {
       revalidated: true,
       manifestCacheCleared: true,
       paths: [],
+      tags: ["watch:route-manifest"],
     })
     expect(clearWatchRouteManifestCacheMock).toHaveBeenCalledTimes(1)
     expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).toHaveBeenCalledWith(
+      "watch:route-manifest",
+      "max",
+    )
   })
 
   it("rejects requests with no auth header", async () => {
@@ -302,6 +440,7 @@ describe("POST /api/revalidate", () => {
 
     expect(response.status).toBe(401)
     expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
   })
 
   it("rejects requests with a wrong Bearer token", async () => {
@@ -323,6 +462,30 @@ describe("POST /api/revalidate", () => {
 
     expect(response.status).toBe(401)
     expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects wrong non-ASCII bearer tokens without throwing", async () => {
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://example.test/api/revalidate", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer tést-revalidation-secret",
+        },
+        body: JSON.stringify({
+          model: "experience",
+          entry: { slug: "jesus", locale: "en" },
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+    expect(clearWatchRouteManifestCacheMock).not.toHaveBeenCalled()
   })
 
   it("rejects malformed JSON with 400", async () => {
@@ -340,6 +503,32 @@ describe("POST /api/revalidate", () => {
     )
 
     expect(response.status).toBe(400)
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+    expect(clearWatchRouteManifestCacheMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects non-object JSON payloads with 400 and no cache side effects", async () => {
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://example.test/api/revalidate", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer test-revalidation-secret",
+        },
+        body: "null",
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_payload",
+    })
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+    expect(clearWatchRouteManifestCacheMock).not.toHaveBeenCalled()
   })
 
   it("rejects malformed slug with 400", async () => {
@@ -360,5 +549,57 @@ describe("POST /api/revalidate", () => {
     )
 
     expect(response.status).toBe(400)
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+    expect(clearWatchRouteManifestCacheMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects non-string slug payloads with 400", async () => {
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://example.test/api/revalidate", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer test-revalidation-secret",
+        },
+        body: JSON.stringify({
+          model: "experience",
+          entry: { slug: 123, locale: "en" },
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_payload",
+    })
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+    expect(clearWatchRouteManifestCacheMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid locale payloads with 400 and no cache side effects", async () => {
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://example.test/api/revalidate", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer test-revalidation-secret",
+        },
+        body: JSON.stringify({
+          model: "experience",
+          entry: { slug: "jesus", locale: "not-a-locale" },
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+    expect(clearWatchRouteManifestCacheMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -1,5 +1,5 @@
 import { timingSafeEqual } from "node:crypto"
-import { revalidatePath } from "next/cache"
+import { revalidatePath, revalidateTag } from "next/cache"
 import { NextResponse } from "next/server"
 import { env } from "@/env"
 import { AVAILABLE_UI_LOCALES } from "@/i18n/generated-ui-locales"
@@ -11,22 +11,84 @@ import {
   resolveWatchLocaleIdentity,
 } from "@/lib/locale"
 import { appendHtmlSuffix } from "@/lib/url-shape"
+import {
+  WATCH_CACHE_TAG_GROUPS,
+  type WatchCacheTag,
+} from "@/lib/watch-cache-tags"
 import { clearWatchRouteManifestCache } from "@/lib/watch-route-manifest"
 
 const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
 const BEARER_PREFIX = "Bearer "
 
 interface RevalidateWebhookPayload {
-  model?: string
-  entry?: {
+  model: RevalidateModel
+  entry: {
     slug?: string
     locale?: string
   }
 }
 
+type RevalidateModel =
+  | "experience"
+  | "video"
+  | "watch-route-manifest"
+  | "watch-setting"
+
+const REVALIDATE_MODELS = new Set<RevalidateModel>([
+  "experience",
+  "video",
+  "watch-route-manifest",
+  "watch-setting",
+])
+const REVALIDATE_MODEL_VALUES: ReadonlySet<string> = REVALIDATE_MODELS
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isRevalidateModel(value: unknown): value is RevalidateModel {
+  return typeof value === "string" && REVALIDATE_MODEL_VALUES.has(value)
+}
+
+function parsePayload(
+  value: unknown,
+):
+  | { ok: true; payload: RevalidateWebhookPayload }
+  | { ok: false; reason: "unhandled" | "invalid_payload" } {
+  if (!isRecord(value)) return { ok: false, reason: "invalid_payload" }
+  if (!isRevalidateModel(value.model) || value.entry === undefined) {
+    return { ok: false, reason: "unhandled" }
+  }
+  if (!isRecord(value.entry)) {
+    return { ok: false, reason: "invalid_payload" }
+  }
+
+  const { slug, locale } = value.entry
+  if (slug != null && typeof slug !== "string") {
+    return { ok: false, reason: "invalid_payload" }
+  }
+  if (locale != null && typeof locale !== "string") {
+    return { ok: false, reason: "invalid_payload" }
+  }
+
+  return {
+    ok: true,
+    payload: {
+      model: value.model,
+      entry: {
+        ...(slug !== undefined && slug !== null ? { slug } : {}),
+        ...(locale !== undefined && locale !== null ? { locale } : {}),
+      },
+    },
+  }
+}
+
 function isValidSecret(provided: string | null, expected: string): boolean {
-  if (!provided || provided.length !== expected.length) return false
-  return timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
+  if (!provided) return false
+  const providedBuffer = Buffer.from(provided)
+  const expectedBuffer = Buffer.from(expected)
+  if (providedBuffer.length !== expectedBuffer.length) return false
+  return timingSafeEqual(providedBuffer, expectedBuffer)
 }
 
 function extractToken(request: Request): string | null {
@@ -47,38 +109,39 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 })
   }
 
-  let body: RevalidateWebhookPayload
+  let parsedJson: unknown
   try {
-    body = (await request.json()) as RevalidateWebhookPayload
+    parsedJson = await request.json()
   } catch {
     return NextResponse.json({ error: "invalid_json" }, { status: 400 })
   }
 
-  const { model, entry } = body
-
-  if (
-    !entry ||
-    !["experience", "video", "watch-route-manifest", "watch-setting"].includes(
-      model ?? "",
-    )
-  ) {
+  const parsedPayload = parsePayload(parsedJson)
+  if (!parsedPayload.ok && parsedPayload.reason === "invalid_payload") {
+    return NextResponse.json({ error: "invalid_payload" }, { status: 400 })
+  }
+  if (!parsedPayload.ok) {
     return NextResponse.json(
       { revalidated: false, reason: "unhandled model or missing entry" },
       { status: 200 },
     )
   }
 
+  const { model, entry } = parsedPayload.payload
   const { slug, locale } = entry
 
-  if (slug && !SLUG_PATTERN.test(slug)) {
+  if (slug !== undefined && !SLUG_PATTERN.test(slug)) {
     return NextResponse.json({ error: "invalid_slug" }, { status: 400 })
   }
-  if (locale && !isLocale(locale)) {
+  if (locale !== undefined && !isLocale(locale)) {
     return NextResponse.json({ error: "invalid_locale" }, { status: 400 })
   }
 
   const revalidated: string[] = []
   const seen = new Set<string>()
+  const revalidatedTags: WatchCacheTag[] = []
+  const seenTags = new Set<WatchCacheTag>()
+  const tagErrors: string[] = []
 
   const push = (path: string) => {
     if (seen.has(path)) return
@@ -99,6 +162,33 @@ export async function POST(request: Request) {
     const identity = resolveWatchLocaleIdentity(rawLocale)
     const suffix = publicPath === "/" ? "" : publicPath
     push(`/${identity.locale}/${identity.htmlLang}${suffix}`)
+  }
+
+  const pushTag = (tag: WatchCacheTag) => {
+    if (seenTags.has(tag)) return
+    seenTags.add(tag)
+    try {
+      revalidateTag(tag, "max")
+      revalidatedTags.push(tag)
+    } catch (error) {
+      tagErrors.push(tag)
+      console.warn(
+        JSON.stringify({
+          event: "watch_revalidate.tag.failed",
+          tag,
+          detail:
+            error instanceof Error
+              ? error.message.slice(0, 500)
+              : String(error),
+        }),
+      )
+    }
+  }
+
+  const pushTags = (tags: readonly WatchCacheTag[]) => {
+    for (const tag of tags) {
+      pushTag(tag)
+    }
   }
 
   // Emit BOTH the canonical public `.html` shape and the internal rewritten
@@ -155,19 +245,37 @@ export async function POST(request: Request) {
     }
   }
 
+  const responsePayload = (extra: Record<string, unknown> = {}) => ({
+    revalidated: true,
+    paths: revalidated,
+    tags: revalidatedTags,
+    ...(tagErrors.length ? { tagErrors } : {}),
+    ...extra,
+  })
+
   if (model === "watch-route-manifest") {
+    pushTags(WATCH_CACHE_TAG_GROUPS.watchRouteManifest)
     clearWatchRouteManifestCache()
-    return NextResponse.json({
-      revalidated: true,
-      manifestCacheCleared: true,
-      paths: revalidated,
-    })
+    return NextResponse.json(
+      responsePayload({
+        manifestCacheCleared: true,
+      }),
+    )
   }
 
   if (model === "watch-setting") {
+    pushTags(WATCH_CACHE_TAG_GROUPS.watchSetting)
     revalidateAllWatchPages()
     revalidateHomepagePaths()
-    return NextResponse.json({ revalidated: true, paths: revalidated })
+    return NextResponse.json(responsePayload())
+  }
+
+  if (model === "experience") {
+    pushTags(WATCH_CACHE_TAG_GROUPS.experience)
+  }
+
+  if (model === "video") {
+    pushTags(WATCH_CACHE_TAG_GROUPS.video)
   }
 
   revalidateSlugPaths()
@@ -177,5 +285,5 @@ export async function POST(request: Request) {
     revalidateHomepagePaths()
   }
 
-  return NextResponse.json({ revalidated: true, paths: revalidated })
+  return NextResponse.json(responsePayload())
 }

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -19,6 +19,7 @@ import { clearWatchRouteManifestCache } from "@/lib/watch-route-manifest"
 
 const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
 const BEARER_PREFIX = "Bearer "
+const REVALIDATE_TAG_PROFILE = { expire: 0 } as const
 
 interface RevalidateWebhookPayload {
   model: RevalidateModel
@@ -168,19 +169,16 @@ export async function POST(request: Request) {
     if (seenTags.has(tag)) return
     seenTags.add(tag)
     try {
-      revalidateTag(tag, "max")
+      revalidateTag(tag, REVALIDATE_TAG_PROFILE)
       revalidatedTags.push(tag)
     } catch (error) {
       tagErrors.push(tag)
+      const detail =
+        error instanceof Error
+          ? error.message.slice(0, 500)
+          : String(error).slice(0, 500)
       console.warn(
-        JSON.stringify({
-          event: "watch_revalidate.tag.failed",
-          tag,
-          detail:
-            error instanceof Error
-              ? error.message.slice(0, 500)
-              : String(error),
-        }),
+        `[revalidate] event=watch_revalidate.tag.failed tag=${tag} detail=${detail}`,
       )
     }
   }
@@ -256,6 +254,7 @@ export async function POST(request: Request) {
   if (model === "watch-route-manifest") {
     pushTags(WATCH_CACHE_TAG_GROUPS.watchRouteManifest)
     clearWatchRouteManifestCache()
+    revalidateAllWatchPages()
     return NextResponse.json(
       responsePayload({
         manifestCacheCleared: true,
@@ -276,6 +275,9 @@ export async function POST(request: Request) {
 
   if (model === "video") {
     pushTags(WATCH_CACHE_TAG_GROUPS.video)
+    if (!slug) {
+      revalidateAllWatchPages()
+    }
   }
 
   revalidateSlugPaths()

--- a/apps/web/src/lib/__tests__/watch-home.test.ts
+++ b/apps/web/src/lib/__tests__/watch-home.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-const { queryMock } = vi.hoisted(() => ({
+const { queryMock, unstableCacheCalls } = vi.hoisted(() => ({
   queryMock: vi.fn(),
+  unstableCacheCalls: [] as {
+    keyParts: unknown[]
+    options: { revalidate?: unknown; tags?: unknown }
+  }[],
 }))
 
 vi.mock("next/cache", () => ({
-  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(
+    fn: T,
+    keyParts: unknown[],
+    options?: { revalidate?: unknown; tags?: unknown },
+  ) => {
+    unstableCacheCalls.push({ keyParts, options: options ?? {} })
+    return fn
+  },
 }))
 
 vi.mock("react", async () => {
@@ -117,6 +128,24 @@ function makeVideo(overrides: Record<string, unknown> = {}) {
 }
 
 describe("buildWatchHomeModelFromVideos", () => {
+  afterEach(() => {
+    queryMock.mockReset()
+    unstableCacheCalls.length = 0
+    vi.resetModules()
+  })
+
+  it("declares tags on the cached watch home model", async () => {
+    await import("../watch-home")
+
+    expect(unstableCacheCalls).toContainEqual({
+      keyParts: ["watch-home", "v3-carousel-sequence"],
+      options: {
+        revalidate: 60,
+        tags: ["watch:home", "watch:video"],
+      },
+    })
+  })
+
   it("maps admin videos into hero slides and configured sections with safe watch URLs", async () => {
     const { buildWatchHomeModelFromVideos } = await import("../watch-home")
 
@@ -329,6 +358,7 @@ describe("buildWatchHomeModelFromVideos", () => {
 describe("resolveWatchHome", () => {
   afterEach(() => {
     queryMock.mockReset()
+    unstableCacheCalls.length = 0
     vi.resetModules()
   })
 

--- a/apps/web/src/lib/content.test.ts
+++ b/apps/web/src/lib/content.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-const { queryMock } = vi.hoisted(() => ({
+const { queryMock, unstableCacheCalls } = vi.hoisted(() => ({
   queryMock: vi.fn(),
+  unstableCacheCalls: [] as {
+    keyParts: unknown[]
+    options: { revalidate?: unknown; tags?: unknown }
+  }[],
 }))
 
 vi.mock("next/cache", () => ({
-  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(
+    fn: T,
+    keyParts: unknown[],
+    options?: { revalidate?: unknown; tags?: unknown },
+  ) => {
+    unstableCacheCalls.push({ keyParts, options: options ?? {} })
+    return fn
+  },
 }))
 
 vi.mock("react", async () => {
@@ -74,7 +85,55 @@ function makeAdminVideo(
 describe("resolveWatchPage", () => {
   afterEach(() => {
     queryMock.mockReset()
+    unstableCacheCalls.length = 0
     vi.resetModules()
+  })
+
+  it("declares tags on every watch resolver cache", async () => {
+    await import("./content")
+
+    expect(unstableCacheCalls).toEqual(
+      expect.arrayContaining([
+        {
+          keyParts: ["watch-page"],
+          options: {
+            revalidate: 60,
+            tags: [
+              "watch:home",
+              "watch:settings",
+              "watch:experience",
+              "watch:video",
+            ],
+          },
+        },
+        {
+          keyParts: ["watch-experience-page"],
+          options: { revalidate: 60, tags: ["watch:experience"] },
+        },
+        {
+          keyParts: ["watch-video"],
+          options: { revalidate: 60, tags: ["watch:video"] },
+        },
+        {
+          keyParts: ["video-child-dub-languages"],
+          options: {
+            revalidate: 3600,
+            tags: ["watch:child-dub-languages"],
+          },
+        },
+        {
+          keyParts: ["watch-video-by-slug"],
+          options: { revalidate: 60, tags: ["watch:video"] },
+        },
+        {
+          keyParts: ["series-by-slug"],
+          options: {
+            revalidate: 60,
+            tags: ["watch:series", "watch:video"],
+          },
+        },
+      ]),
+    )
   })
 
   it("returns the homepage Experience from watchSetting", async () => {

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -17,6 +17,7 @@ import {
   watchVideoFragment,
 } from "@/lib/fragments"
 import { slugToBcp47Tag } from "@/lib/locale"
+import { WATCH_CACHE_TAGS } from "@/lib/watch-cache-tags"
 
 // Keep gql.tada introspection types live for the watch-page fragment.
 void watchVideoFragment
@@ -872,7 +873,15 @@ const fetchResolvedWatchPage = unstable_cache(
     }
   },
   ["watch-page"],
-  { revalidate: 60 },
+  {
+    revalidate: 60,
+    tags: [
+      WATCH_CACHE_TAGS.home,
+      WATCH_CACHE_TAGS.settings,
+      WATCH_CACHE_TAGS.experience,
+      WATCH_CACHE_TAGS.video,
+    ],
+  },
 )
 
 /** Shared watch-page resolver for page rendering and metadata generation. */
@@ -904,7 +913,7 @@ const fetchResolvedWatchExperiencePage = unstable_cache(
     }
   },
   ["watch-experience-page"],
-  { revalidate: 60 },
+  { revalidate: 60, tags: [WATCH_CACHE_TAGS.experience] },
 )
 
 /**
@@ -1319,7 +1328,7 @@ async function tryResolveWatchVideo(
 const fetchResolvedWatchVideo = unstable_cache(
   tryResolveWatchVideo,
   ["watch-video"],
-  { revalidate: 60 },
+  { revalidate: 60, tags: [WATCH_CACHE_TAGS.video] },
 )
 
 /**
@@ -1406,7 +1415,10 @@ const fetchVideoChildDubLanguages = unstable_cache(
       .filter((v): v is WatchChildLanguage => v != null)
   },
   ["video-child-dub-languages"],
-  { revalidate: CHILD_DUB_LANGUAGES_REVALIDATE_SECONDS },
+  {
+    revalidate: CHILD_DUB_LANGUAGES_REVALIDATE_SECONDS,
+    tags: [WATCH_CACHE_TAGS.childDubLanguages],
+  },
 )
 
 // Sentinel thrown by the cached inner so unstable_cache never persists a
@@ -1492,7 +1504,7 @@ async function tryResolveWatchVideoBySlug(
 const fetchResolvedWatchVideoBySlug = unstable_cache(
   tryResolveWatchVideoBySlug,
   ["watch-video-by-slug"],
-  { revalidate: 60 },
+  { revalidate: 60, tags: [WATCH_CACHE_TAGS.video] },
 )
 
 // Returns null when the slug doesn't match a record OR the video has no
@@ -1642,7 +1654,7 @@ async function tryResolveSeriesBySlug(
 const fetchResolvedSeriesBySlug = unstable_cache(
   tryResolveSeriesBySlug,
   ["series-by-slug"],
-  { revalidate: 60 },
+  { revalidate: 60, tags: [WATCH_CACHE_TAGS.series, WATCH_CACHE_TAGS.video] },
 )
 
 // Returns null when the slug doesn't match a record OR the record is not

--- a/apps/web/src/lib/watch-cache-tags.test.ts
+++ b/apps/web/src/lib/watch-cache-tags.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import {
+  WATCH_CACHE_TAG_GROUPS,
+  WATCH_CACHE_TAGS,
+  uniqueWatchCacheTags,
+} from "./watch-cache-tags"
+
+describe("watch cache tags", () => {
+  it("exports stable coarse tags for watch caches", () => {
+    expect(WATCH_CACHE_TAGS).toEqual({
+      home: "watch:home",
+      settings: "watch:settings",
+      experience: "watch:experience",
+      video: "watch:video",
+      series: "watch:series",
+      childDubLanguages: "watch:child-dub-languages",
+      routeManifest: "watch:route-manifest",
+    })
+  })
+
+  it("dedupes grouped tag lists while preserving order", () => {
+    expect(
+      uniqueWatchCacheTags([
+        WATCH_CACHE_TAGS.video,
+        WATCH_CACHE_TAGS.series,
+        WATCH_CACHE_TAGS.video,
+      ]),
+    ).toEqual([WATCH_CACHE_TAGS.video, WATCH_CACHE_TAGS.series])
+  })
+
+  it("groups semantic webhook models into the caches they can affect", () => {
+    expect(WATCH_CACHE_TAG_GROUPS.watchSetting).toEqual([
+      WATCH_CACHE_TAGS.home,
+      WATCH_CACHE_TAGS.settings,
+      WATCH_CACHE_TAGS.experience,
+      WATCH_CACHE_TAGS.video,
+      WATCH_CACHE_TAGS.series,
+      WATCH_CACHE_TAGS.childDubLanguages,
+    ])
+    expect(WATCH_CACHE_TAG_GROUPS.experience).toEqual([
+      WATCH_CACHE_TAGS.experience,
+      WATCH_CACHE_TAGS.home,
+    ])
+    expect(WATCH_CACHE_TAG_GROUPS.video).toEqual([
+      WATCH_CACHE_TAGS.video,
+      WATCH_CACHE_TAGS.series,
+      WATCH_CACHE_TAGS.childDubLanguages,
+      WATCH_CACHE_TAGS.home,
+    ])
+    expect(WATCH_CACHE_TAG_GROUPS.watchRouteManifest).toEqual([
+      WATCH_CACHE_TAGS.routeManifest,
+    ])
+  })
+})

--- a/apps/web/src/lib/watch-cache-tags.ts
+++ b/apps/web/src/lib/watch-cache-tags.ts
@@ -1,0 +1,40 @@
+export const WATCH_CACHE_TAGS = {
+  home: "watch:home",
+  settings: "watch:settings",
+  experience: "watch:experience",
+  video: "watch:video",
+  series: "watch:series",
+  childDubLanguages: "watch:child-dub-languages",
+  routeManifest: "watch:route-manifest",
+} as const
+
+export type WatchCacheTag =
+  (typeof WATCH_CACHE_TAGS)[keyof typeof WATCH_CACHE_TAGS]
+
+export function uniqueWatchCacheTags(
+  tags: readonly WatchCacheTag[],
+): WatchCacheTag[] {
+  return [...new Set(tags)]
+}
+
+export const WATCH_CACHE_TAG_GROUPS = {
+  watchSetting: uniqueWatchCacheTags([
+    WATCH_CACHE_TAGS.home,
+    WATCH_CACHE_TAGS.settings,
+    WATCH_CACHE_TAGS.experience,
+    WATCH_CACHE_TAGS.video,
+    WATCH_CACHE_TAGS.series,
+    WATCH_CACHE_TAGS.childDubLanguages,
+  ]),
+  experience: uniqueWatchCacheTags([
+    WATCH_CACHE_TAGS.experience,
+    WATCH_CACHE_TAGS.home,
+  ]),
+  video: uniqueWatchCacheTags([
+    WATCH_CACHE_TAGS.video,
+    WATCH_CACHE_TAGS.series,
+    WATCH_CACHE_TAGS.childDubLanguages,
+    WATCH_CACHE_TAGS.home,
+  ]),
+  watchRouteManifest: uniqueWatchCacheTags([WATCH_CACHE_TAGS.routeManifest]),
+} as const

--- a/apps/web/src/lib/watch-home.ts
+++ b/apps/web/src/lib/watch-home.ts
@@ -29,6 +29,7 @@ import type {
   WatchHomeTvCarouselVideoSlide,
 } from "@/lib/watch-home-carousel-sequence"
 import { getWatchHomeVideosOperation } from "@/lib/fragments/watch-home"
+import { WATCH_CACHE_TAGS } from "@/lib/watch-cache-tags"
 
 type WatchHomeVideosData = AdminResultOf<typeof getWatchHomeVideosOperation>
 type AdminHomeVideo = WatchHomeVideosData["watchHomeVideos"][number]
@@ -705,7 +706,7 @@ async function fetchWatchHomeModel(
 const getCachedWatchHomeModel = unstable_cache(
   fetchWatchHomeModel,
   ["watch-home", WATCH_HOME_CACHE_VERSION],
-  { revalidate: 60 },
+  { revalidate: 60, tags: [WATCH_CACHE_TAGS.home, WATCH_CACHE_TAGS.video] },
 )
 
 export const resolveWatchHome = cache(

--- a/docs/plans/2026-06-10-001-fix-watch-cache-invalidation-plan.md
+++ b/docs/plans/2026-06-10-001-fix-watch-cache-invalidation-plan.md
@@ -58,7 +58,7 @@ There is no production `emitRevalidateWebhook({ model: "video", ... })` call for
 1. Keep the public watch URL contract unchanged; cache fixes must work with the internal `/{locale}/{htmlLang}` rewrite and the existing `.html` public URLs.
 2. Preserve current `revalidatePath` coverage for Full Route Cache invalidation across public, internal, generated-UI-locale, and legacy path shapes.
 3. Add tag invalidation for every `unstable_cache` entry that can feed watch home, watch experience, collection, video, episode, series, and child-dub language UI.
-4. Use the supported Route Handler API: `revalidateTag(tag, "max")`, not `updateTag`, because `updateTag` is server-action-only.
+4. Use the supported Route Handler API: `revalidateTag(tag, { expire: 0 })`, not `updateTag`, because `updateTag` is server-action-only and `profile="max"` serves stale data before background refresh.
 5. Ensure Admin Experience publishing, Watch settings changes, watch route manifest refreshes, and render-relevant Core sync phases all invalidate both route output and resolver data.
 6. Treat webhook delivery as best-effort but observable. Failures may still be swallowed to avoid blocking Admin writes, but logs/tests must make it obvious what was attempted.
 7. Do not increase data-cache TTLs in the first correctness slice. Longer data TTLs are only safe after tag coverage and production cache topology are confirmed.
@@ -86,7 +86,7 @@ There is no production `emitRevalidateWebhook({ model: "video", ... })` call for
 
 Official Next.js docs shape the implementation:
 
-- [`revalidateTag`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) invalidates cached data by tag. In current docs, `profile="max"` is recommended for stale-while-revalidate semantics; calling without the second argument is deprecated.
+- [`revalidateTag`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) invalidates cached data by tag. `profile="max"` is stale-while-revalidate; webhook-driven watch invalidation uses `{ expire: 0 }` so the first render after the webhook does not rehydrate the route from stale resolver data. Calling without the second argument is deprecated.
 - [`revalidatePath`](https://nextjs.org/docs/app/api-reference/functions/revalidatePath) revalidates route output and can be called from Route Handlers. In Route Handlers, it marks a path for revalidation and regeneration happens on the next visit.
 - [`unstable_cache`](https://nextjs.org/docs/app/api-reference/functions/unstable_cache) supports a `tags` option; tags are not part of the cache key but are used for invalidation.
 - [`updateTag`](https://nextjs.org/docs/app/api-reference/functions/updateTag) is server-action-only, so it should not be used in `/api/revalidate`.
@@ -112,9 +112,9 @@ flowchart LR
   C --> D["validate shared secret"]
   D --> E["clearWatchRouteManifestCache when needed"]
   D --> F["revalidatePath for Full Route Cache"]
-  D --> G["revalidateTag profile=max for Data Cache"]
+  D --> G["revalidateTag expire=0 for Data Cache"]
   F --> H["next visit regenerates route output"]
-  G --> I["next read refreshes stale resolver data"]
+  G --> I["next read recomputes expired resolver data"]
   E --> J["local process manifest cache cleared; other processes rely on TTL/shared cache"]
 ```
 
@@ -203,24 +203,24 @@ Keep the existing `revalidate` values unchanged:
 
 **Approach**
 
-Import `revalidateTag` from `next/cache`. Keep the existing path push helpers, then add tag push helpers that dedupe tag names and call `revalidateTag(tag, "max")`.
+Import `revalidateTag` from `next/cache`. Keep the existing path push helpers, then add tag push helpers that dedupe tag names and call `revalidateTag(tag, { expire: 0 })`.
 
 Map semantic models to tags:
 
 - `watch-setting`: `watch:home`, `watch:settings`, and broad experience/video tags if homepage composition can include either.
 - `experience`: broad experience tag, plus home/settings tags if homepage changes are indicated by payload.
 - `video`: broad video, series, and child-dub tags.
-- `watch-route-manifest`: clear process manifest cache and invalidate `watch:route-manifest`; consider broad video/experience/home tags only when the Admin payload says render-relevant Core sync phases ran.
+- `watch-route-manifest`: clear process manifest cache, invalidate `watch:route-manifest`, and revalidate watch layouts; consider broad video/experience/home tags only when the Admin payload says render-relevant Core sync phases ran.
 
-Support `video` payloads without a slug as broad invalidations. The current path logic can stay no-op for missing slug, but tag logic must still run.
+Support `video` payloads without a slug as broad invalidations. Missing-slug video events must still invalidate broad tags and the watch layouts.
 
 **Test scenarios**
 
-- Authorized `experience` payload calls both `revalidatePath` for the existing path matrix and `revalidateTag(..., "max")` for broad experience tags.
+- Authorized `experience` payload calls both `revalidatePath` for the existing path matrix and `revalidateTag(..., { expire: 0 })` for broad experience tags.
 - Authorized `video` payload with slug/language calls the existing path matrix and broad video tags.
-- Authorized `video` payload without slug calls broad tags and does not throw.
+- Authorized `video` payload without slug calls broad tags, revalidates watch layouts, and does not throw.
 - Authorized `watch-setting` payload invalidates home/settings tags and existing homepage/layout paths.
-- Authorized `watch-route-manifest` payload clears the manifest cache and invalidates the manifest tag.
+- Authorized `watch-route-manifest` payload clears the manifest cache, invalidates the manifest tag, and revalidates watch layouts.
 - Unauthorized, invalid secret, and invalid JSON requests call neither `revalidatePath` nor `revalidateTag`.
 - Repeated path/tag candidates are deduped before invoking Next cache APIs.
 
@@ -287,7 +287,7 @@ Do not increase resolver/data-cache TTLs in this unit. The Data Cache should sta
 Document the exact cache contract:
 
 - Route paths are invalidated with `revalidatePath`.
-- Resolver data is invalidated with `revalidateTag(tag, "max")`.
+- Resolver data is invalidated with `revalidateTag(tag, { expire: 0 })`.
 - Admin webhooks are best-effort and require matching `REVALIDATION_SECRET`.
 - In-process route manifest caches clear only in the process that receives the webhook; other processes rely on TTL unless production uses a shared cache/instance fan-out.
 - If Railway runs more than one Next instance, instant global invalidation requires a shared cache handler or all-instance webhook delivery.
@@ -345,7 +345,7 @@ Then run a preview smoke:
 
 ## Acceptance Criteria
 
-- `/api/revalidate` calls `revalidateTag(tag, "max")` for all relevant semantic models while preserving existing `revalidatePath` behavior.
+- `/api/revalidate` calls `revalidateTag(tag, { expire: 0 })` for all relevant semantic models while preserving existing `revalidatePath` behavior.
 - Watch resolver `unstable_cache` declarations include tags that correspond to the route-handler invalidation map.
 - Broad `video` invalidation works even when Admin/Core sync cannot provide a slug.
 - Core sync emits watch-render invalidation for render-relevant phases, including at least `video-images`, `video-editions`, `video-subtitles`, and `video-dub-downloads`.

--- a/docs/plans/2026-06-10-001-fix-watch-cache-invalidation-plan.md
+++ b/docs/plans/2026-06-10-001-fix-watch-cache-invalidation-plan.md
@@ -1,0 +1,366 @@
+---
+title: "fix: Harden watch cache invalidation"
+type: fix
+status: planned
+date: 2026-06-10
+---
+
+# Harden Watch Cache Invalidation
+
+## Overview
+
+The watch pages are now static/ISR-style routes after the internal locale rewrite work. They are a good fit for longer cache lifetimes because the product is a video catalog, not a news surface, and most page content changes only when Admin publishes an Experience, Watch settings change, or Core sync brings in updated video/dub/language data.
+
+The blocker is not whether these pages can be cached. They can. The blocker is that the current invalidation only clears the Full Route Cache via `revalidatePath`, while the watch resolvers also sit behind `unstable_cache` entries that have no tags. If we simply raise `revalidate` / `s-maxage` from 60 seconds to 1 hour or 1 day, stale resolver data can survive until its own TTL expires, and some Core sync updates do not currently emit any video-page invalidation at all.
+
+This plan fixes cache correctness first, then cautiously raises route TTLs once the invalidation path is provably coherent.
+
+## Problem Statement
+
+### Current cache shape
+
+The public watch route renders through `apps/web/src/app/[locale]/[htmlLang]/**` with route-level ISR:
+
+- `apps/web/src/app/[locale]/[htmlLang]/page.tsx`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+
+Both page routes currently export `revalidate = 60`, `dynamic = "force-static"`, and `dynamicParams = true`. Live probing earlier in this thread showed `x-nextjs-prerender: 1`, a stale-then-hit `x-nextjs-cache` pattern, and compressed HTML around 43 KB for the Gospel of John URL, which matches the intended ISR behavior.
+
+The render tree then calls resolver helpers in:
+
+- `apps/web/src/lib/content.ts`
+- `apps/web/src/lib/watch-home.ts`
+- `apps/web/src/lib/watch-route-manifest.ts`
+
+Most watch resolver helpers use `unstable_cache(..., { revalidate: 60 })`; `fetchVideoChildDubLanguages` uses 1 hour; the route manifest has its own 60 second process-local memory cache and an explicit `clearWatchRouteManifestCache()` helper.
+
+### Current invalidation gap
+
+`apps/web/src/app/api/revalidate/route.ts` accepts Admin webhooks for:
+
+- `experience`
+- `video`
+- `watch-route-manifest`
+- `watch-setting`
+
+It currently calls `revalidatePath` for relevant public, internal, and legacy paths. It does not import or call `revalidateTag`. `apps/web/CLAUDE.md` already calls this out: `revalidatePath` from `/api/revalidate` does not invalidate `unstable_cache` entries, and tag-based invalidation is a known follow-up.
+
+That means a path can be regenerated while still reading stale data from the Data Cache. With 60 second data TTLs the bug is usually small. With 1 hour or 1 day data TTLs it becomes very visible.
+
+### Current emitter gap
+
+Admin Experience publishing has explicit revalidation emitters in `apps/admin/src/services/experience.service.ts`. Core sync currently refreshes the watch route manifest after route-relevant phases through `apps/admin/src/services/watch-route-manifest-refresh.service.ts`, and that service emits only `model: "watch-route-manifest"`.
+
+There is no production `emitRevalidateWebhook({ model: "video", ... })` call for actual video metadata/dub/subtitle/image updates. `apps/admin/src/services/video.service.ts` is read-only in v1; writes come through Core sync. So the `video` model exists in the revalidation contract, but current Core sync does not use it for rendered video page data.
+
+## Requirements
+
+1. Keep the public watch URL contract unchanged; cache fixes must work with the internal `/{locale}/{htmlLang}` rewrite and the existing `.html` public URLs.
+2. Preserve current `revalidatePath` coverage for Full Route Cache invalidation across public, internal, generated-UI-locale, and legacy path shapes.
+3. Add tag invalidation for every `unstable_cache` entry that can feed watch home, watch experience, collection, video, episode, series, and child-dub language UI.
+4. Use the supported Route Handler API: `revalidateTag(tag, "max")`, not `updateTag`, because `updateTag` is server-action-only.
+5. Ensure Admin Experience publishing, Watch settings changes, watch route manifest refreshes, and render-relevant Core sync phases all invalidate both route output and resolver data.
+6. Treat webhook delivery as best-effort but observable. Failures may still be swallowed to avoid blocking Admin writes, but logs/tests must make it obvious what was attempted.
+7. Do not increase data-cache TTLs in the first correctness slice. Longer data TTLs are only safe after tag coverage and production cache topology are confirmed.
+8. Keep route-level `revalidate` at 60 seconds for the first correctness PR; raise it toward 1 hour only after preview/topology proof, rather than jumping straight to 1 day.
+9. Document the remaining multi-instance/self-hosted cache risk before declaring invalidation "instant" in production.
+
+## Context & Research
+
+### Repo findings
+
+- `apps/web/src/app/api/revalidate/route.ts` clears paths only. It already knows the relevant public/internal/legacy path matrix, so the path logic should be extended, not replaced.
+- `apps/web/src/app/api/revalidate/route.test.ts` mocks only `revalidatePath`; tests should be extended to mock and assert `revalidateTag`.
+- `apps/web/src/lib/content.ts` defines watch resolver caches without tags: `watch-page`, `watch-experience-page`, `watch-video`, `watch-video-by-slug`, and `series-by-slug`.
+- `apps/web/src/lib/watch-home.ts` caches the homepage model behind `["watch-home", WATCH_HOME_CACHE_VERSION]`.
+- `apps/web/src/lib/watch-route-manifest.ts` keeps a 60 second in-process manifest cache and exposes `clearWatchRouteManifestCache()`.
+- `apps/admin/src/services/revalidate-webhook.ts` already supports `model: "video"` but does not throw on webhook failure.
+- `apps/admin/src/services/watch-route-manifest-refresh.service.ts` emits `model: "watch-route-manifest"` after route-relevant Core sync phases: `languages`, `videos`, and `video-dubs`.
+- Core sync has more render-relevant phases than route-relevant phases: `video-images`, `video-editions`, `video-subtitles`, and `video-dub-downloads` can change visible watch page content without necessarily changing the route manifest.
+- `docs/solutions/web/nextjs16-cachecomponents-isr.md` records the earlier route-level ISR decision.
+- `docs/solutions/web/nextjs-headers-defeats-route-cache.md` explains why dynamic APIs must stay out of the render path.
+- `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md` explains why the manifest is Admin-owned and refreshed after languages/videos/video-dubs changes.
+- `docs/roadmap/platform/feat-163-admin-experience-watch-revalidation.md` is complete and covers a narrower precursor: Admin Experience Watch Revalidation.
+
+### External framework findings
+
+Official Next.js docs shape the implementation:
+
+- [`revalidateTag`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) invalidates cached data by tag. In current docs, `profile="max"` is recommended for stale-while-revalidate semantics; calling without the second argument is deprecated.
+- [`revalidatePath`](https://nextjs.org/docs/app/api-reference/functions/revalidatePath) revalidates route output and can be called from Route Handlers. In Route Handlers, it marks a path for revalidation and regeneration happens on the next visit.
+- [`unstable_cache`](https://nextjs.org/docs/app/api-reference/functions/unstable_cache) supports a `tags` option; tags are not part of the cache key but are used for invalidation.
+- [`updateTag`](https://nextjs.org/docs/app/api-reference/functions/updateTag) is server-action-only, so it should not be used in `/api/revalidate`.
+- [`Self-Hosting`](https://nextjs.org/docs/app/guides/self-hosting) warns that App Router cache assets are local to the Next server by default. Multi-instance deployments need shared cache/tag coordination if they require immediate global invalidation.
+
+Context7 could not be used during research because its OAuth token was expired, so the plan uses official Next.js web docs directly.
+
+## Key Technical Decisions
+
+1. **Keep path invalidation and add tags.** `revalidatePath` and `revalidateTag` solve different cache layers. Path invalidation should continue to clear rendered route output; tag invalidation should clear resolver data.
+2. **Use a small tag helper module in web.** Add a single web-owned helper such as `apps/web/src/lib/watch-cache-tags.ts` so cache declarations and `/api/revalidate` use the same tag names.
+3. **Use coarse tags in the first PR.** The existing `unstable_cache` wrappers are module-level declarations, so their `tags` options should be treated as static. Coarse tags guarantee correctness for broad Core sync events without reshaping cache wrappers. Scoped tags can be a later optimization if the implementation deliberately moves to a cache-factory pattern or a newer dynamic tagging API.
+4. **Treat Core sync render relevance separately from manifest route relevance.** The manifest only needs refreshing for route admission changes, but rendered page data changes for more phases. Core sync should emit a broad watch-data invalidation whenever render-relevant phases ran, even if the manifest did not change.
+5. **Do not lengthen TTLs in the same correctness slice.** Leave route-level `revalidate` at 60 seconds and leave `unstable_cache` `revalidate` values at 60 seconds / 1 hour initially. After tag invalidation is tested in preview and production topology is understood, route-level `revalidate` can move to 3600 seconds.
+6. **Production multi-instance behavior is an ops decision, not a code assumption.** If Railway runs multiple isolated Next instances without a shared cache handler, tag invalidation may not fan out immediately everywhere. The plan must document that limitation and keep a TTL fallback.
+
+## High-Level Technical Design
+
+```mermaid
+flowchart LR
+  A["Admin Experience publish / Watch setting change / Core sync"] --> B["emitRevalidateWebhook"]
+  B --> C["apps/web /api/revalidate"]
+  C --> D["validate shared secret"]
+  D --> E["clearWatchRouteManifestCache when needed"]
+  D --> F["revalidatePath for Full Route Cache"]
+  D --> G["revalidateTag profile=max for Data Cache"]
+  F --> H["next visit regenerates route output"]
+  G --> I["next read refreshes stale resolver data"]
+  E --> J["local process manifest cache cleared; other processes rely on TTL/shared cache"]
+```
+
+The web route handler remains the single public invalidation surface. Admin continues to send semantic models rather than raw Next cache details. Web maps those semantic models to paths and tags.
+
+## Proposed Tag Taxonomy
+
+Use constants rather than ad hoc strings. Final naming can change during implementation, but the first PR should keep to coarse tags that existing module-level `unstable_cache` wrappers can attach statically:
+
+- `watch:home` for `getCachedWatchHomeModel`
+- `watch:settings` for watch homepage/template settings dependencies
+- `watch:experience` for all experience/collection resolver data
+- `watch:video` for all video/episode resolver data
+- `watch:series` for series/child episode data
+- `watch:child-dub-languages` for the 1 hour child-dub language cache
+- `watch:route-manifest` for manifest/admission dependencies when represented in Next's Data Cache
+
+Future scoped tags such as `watch:video:{slug}` or `watch:experience:{locale}:{slug}` are useful only if the cache declaration can reliably attach that same scoped tag. Do not emit scoped invalidations in the first PR unless a matching scoped cache tag exists.
+
+## Scope Boundaries
+
+### In scope
+
+- Web cache tag helper and watch resolver tag coverage.
+- `/api/revalidate` tag mapping and tests.
+- Admin/Core sync invalidation emission for render-relevant watch data.
+- Route-level TTL recommendation and implementation after correctness proof.
+- Documentation of remaining production cache-topology risks.
+
+### Out of scope
+
+- Cloudflare HTML caching rules or CDN cache-control changes.
+- A custom shared Next cache handler or Redis-backed tag store.
+- Rebuilding the watch route manifest architecture.
+- New comments, ratings, personalization, auth-aware UI, or player feature work.
+- Moving from `unstable_cache` to Cache Components/cacheTag in this PR.
+
+## Implementation Units
+
+### U1. Add web watch cache tag helpers
+
+**Files**
+
+- `apps/web/src/lib/watch-cache-tags.ts` (new)
+- `apps/web/src/lib/watch-cache-tags.test.ts` (new, if the repo's test layout accepts sibling lib tests)
+
+**Approach**
+
+Define a small set of constants for coarse watch tags. The helper should be boring and deterministic; no access to request state, env, GraphQL, or Next APIs.
+
+**Test scenarios**
+
+- Exported tag constants match the documented names.
+- Group helpers, if added, return deduped tag arrays for `watch-setting`, `experience`, `video`, and `watch-route-manifest`.
+- No helper can produce `undefined`-suffixed strings.
+
+### U2. Tag every watch resolver cache
+
+**Files**
+
+- `apps/web/src/lib/content.ts`
+- `apps/web/src/lib/watch-home.ts`
+- `apps/web/src/lib/watch-route-manifest.ts` only if a Next Data Cache wrapper is introduced later; otherwise keep the process cache explicit.
+
+**Approach**
+
+Add `tags` to each `unstable_cache` options object. Keep tags coarse for the first implementation because the current wrappers are module-level declarations. Do not move cache wrapper construction into hot code just to get scoped tags unless a later performance measurement proves broad invalidation is too expensive.
+
+Keep the existing `revalidate` values unchanged:
+
+- 60 seconds for the main watch resolvers.
+- 1 hour for child-dub language data.
+
+**Test scenarios**
+
+- Existing watch resolver tests remain green.
+- Where cache options are directly testable, assert that each watch cache includes at least one coarse watch tag.
+- Manual smoke in development can still render home, experience, video, episode, and series pages.
+
+### U3. Extend `/api/revalidate` to invalidate tags
+
+**Files**
+
+- `apps/web/src/app/api/revalidate/route.ts`
+- `apps/web/src/app/api/revalidate/route.test.ts`
+
+**Approach**
+
+Import `revalidateTag` from `next/cache`. Keep the existing path push helpers, then add tag push helpers that dedupe tag names and call `revalidateTag(tag, "max")`.
+
+Map semantic models to tags:
+
+- `watch-setting`: `watch:home`, `watch:settings`, and broad experience/video tags if homepage composition can include either.
+- `experience`: broad experience tag, plus home/settings tags if homepage changes are indicated by payload.
+- `video`: broad video, series, and child-dub tags.
+- `watch-route-manifest`: clear process manifest cache and invalidate `watch:route-manifest`; consider broad video/experience/home tags only when the Admin payload says render-relevant Core sync phases ran.
+
+Support `video` payloads without a slug as broad invalidations. The current path logic can stay no-op for missing slug, but tag logic must still run.
+
+**Test scenarios**
+
+- Authorized `experience` payload calls both `revalidatePath` for the existing path matrix and `revalidateTag(..., "max")` for broad experience tags.
+- Authorized `video` payload with slug/language calls the existing path matrix and broad video tags.
+- Authorized `video` payload without slug calls broad tags and does not throw.
+- Authorized `watch-setting` payload invalidates home/settings tags and existing homepage/layout paths.
+- Authorized `watch-route-manifest` payload clears the manifest cache and invalidates the manifest tag.
+- Unauthorized, invalid secret, and invalid JSON requests call neither `revalidatePath` nor `revalidateTag`.
+- Repeated path/tag candidates are deduped before invoking Next cache APIs.
+
+### U4. Wire Admin/Core sync render-relevant invalidation
+
+**Files**
+
+- `apps/admin/src/services/revalidate-webhook.ts`
+- `apps/admin/src/services/watch-route-manifest-refresh.service.ts`
+- `apps/admin/src/services/core-sync/orchestrator.ts` if the phase summary must be carried farther than the manifest service currently receives it.
+- `apps/admin/src/services/watch-route-manifest-refresh.service.test.ts`
+- `apps/admin/src/services/revalidate-webhook.test.ts`
+
+**Approach**
+
+Keep the Admin webhook semantic and best-effort. Add a render-relevant phase set distinct from the existing route-manifest phase set:
+
+- Route-manifest relevant: `languages`, `videos`, `video-dubs`.
+- Watch-render relevant: `languages`, `videos`, `video-images`, `video-editions`, `video-subtitles`, `video-dubs`, `video-dub-downloads`.
+
+When render-relevant phases ran, emit a broad watch video invalidation. The lowest-risk contract is `model: "video", slug: null, locale: null`, because web can interpret missing slug as "all watch video data". If the implementation can cheaply derive changed slugs from Core sync outputs, add scoped payloads as a follow-up, not as a prerequisite.
+
+If route-manifest and render-relevant phases overlap, send both semantic events or a single richer event only if the web contract remains simple and tests cover both effects. Prefer explicit events over overloading `watch-route-manifest` to mean all rendered video data.
+
+**Test scenarios**
+
+- Core sync with only `countries` or `keywords` does not emit watch-render invalidation.
+- Core sync with `video-images` emits watch-render invalidation even though the route manifest does not need refreshing.
+- Core sync with `videos` refreshes the route manifest and emits watch-render invalidation.
+- Webhook failure remains non-blocking and logged.
+- Existing Experience publish/update/archive revalidation tests remain green.
+
+### U5. Follow-up: raise route-level TTL after preview/topology proof
+
+**Files**
+
+- `apps/web/src/app/[locale]/[htmlLang]/page.tsx`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+- `apps/web/src/app/[locale]/[htmlLang]/videos/page.tsx` if it declares its own route-level revalidate.
+- `apps/web/CLAUDE.md`
+
+**Approach**
+
+After U1-U4 pass and preview/topology proof is collected, change route-level `revalidate` from 60 to 3600 seconds for the static watch page routes. This targets fast repeat loads while keeping a 1 hour fallback if a webhook is missed or a process does not receive tag invalidation.
+
+Do not increase resolver/data-cache TTLs in this unit. The Data Cache should stay short until production invalidation evidence is collected.
+
+**Test scenarios**
+
+- Build/typecheck verifies the route exports still compile.
+- Existing route tests pass.
+- Manual or scripted curl against a deployed preview shows first request may regenerate, repeat request is a HIT within the 3600 second window, and Admin revalidation still causes a new render on next visit.
+
+### U6. Document production topology and rollout proof
+
+**Files**
+
+- `apps/web/CLAUDE.md`
+- `apps/admin/CLAUDE.md`
+- Optional follow-up solution doc under `docs/solutions/web/` after implementation proves the behavior.
+
+**Approach**
+
+Document the exact cache contract:
+
+- Route paths are invalidated with `revalidatePath`.
+- Resolver data is invalidated with `revalidateTag(tag, "max")`.
+- Admin webhooks are best-effort and require matching `REVALIDATION_SECRET`.
+- In-process route manifest caches clear only in the process that receives the webhook; other processes rely on TTL unless production uses a shared cache/instance fan-out.
+- If Railway runs more than one Next instance, instant global invalidation requires a shared cache handler or all-instance webhook delivery.
+
+**Test expectation**
+
+Documentation-only; no automated test required beyond keeping existing docs links and names accurate.
+
+## Validation Plan
+
+Run focused validation before raising TTL:
+
+```bash
+pnpm --filter @forge/web test -- src/app/api/revalidate/route.test.ts
+pnpm --filter @forge/web test -- src/lib/watch-cache-tags.test.ts
+pnpm --filter @forge/admin test -- src/services/watch-route-manifest-refresh.service.test.ts
+pnpm --filter @forge/admin test -- src/services/revalidate-webhook.test.ts
+pnpm --filter @forge/web typecheck
+pnpm --filter @forge/admin typecheck
+```
+
+Then run a preview smoke:
+
+1. Request a known video URL twice and confirm the second request is served from the Next cache.
+2. Send an authorized `experience` revalidation payload and confirm the next request regenerates route output and refreshes resolver data.
+3. Send an authorized broad `video` revalidation payload and confirm video resolver data is not held by the old cache entry.
+4. Send a `watch-route-manifest` payload and confirm the receiving process clears `clearWatchRouteManifestCache()`.
+5. Confirm unauthorized revalidation attempts do not touch paths or tags.
+
+## Rollout Plan
+
+1. Ship U1-U4 with route TTL still at 60 seconds.
+2. Deploy to preview/staging and verify path + tag invalidation with real webhook payloads.
+3. Check production topology: number of web instances, whether Next cache storage is shared, whether Railway can fan out webhooks, and whether Cloudflare is caching HTML or only proxying.
+4. If topology is single-instance or shared-cache enough for current expectations, ship the TTL follow-up and raise route-level `revalidate` to 3600.
+5. Watch logs for revalidation failures and unexpected route regeneration volume.
+6. Consider a later PR for 6 hour or 24 hour route TTL only after missed-webhook behavior and multi-instance cache behavior are understood.
+
+## Risks & Mitigations
+
+- **Risk: broad Core sync invalidation causes many pages to regenerate after sync.** Mitigation: start with correctness; measure regeneration volume; add scoped slug derivation later if needed.
+- **Risk: broad tags regenerate more content than strictly necessary.** Mitigation: measure regeneration volume before adding scoped tags; correctness is more important than fine-grained invalidation in the first PR.
+- **Risk: webhook failure remains silent to editors.** Mitigation: keep non-blocking writes, but improve structured logs and optionally add an ops follow-up for failed invalidation alerts.
+- **Risk: multi-instance Next caches do not all receive tag invalidation.** Mitigation: keep TTL fallback, document the limitation, and defer shared cache handler/fan-out until production topology proves it is needed.
+- **Risk: stale route manifest survives in another process.** Mitigation: keep the 60 second process cache TTL and do not claim manifest invalidation is globally instant without shared cache support.
+- **Risk: data TTL is raised too early.** Mitigation: explicitly leave resolver TTLs unchanged in this plan's first implementation slice.
+
+## Open Questions
+
+1. How many `apps/web` instances run in production, and do they share Next cache storage? This affects whether invalidation is instant globally or only eventually consistent by TTL.
+2. Does Cloudflare currently cache any watch HTML, or is it only proxying dynamic responses? Earlier probing showed `cf-cache-status: DYNAMIC`, but production edge rules should be checked before rollout.
+3. Can Core sync cheaply report changed video slugs per phase, or should the first implementation intentionally stay broad?
+4. Should `watch-route-manifest` remain admission-only, or should Admin send a second broad `video` event whenever manifest-relevant phases also changed rendered data? This plan recommends the second event for clarity.
+5. After route TTL moves to 3600, what stale-content SLO is acceptable for a missed webhook: 1 hour, 6 hours, or 24 hours?
+
+## Acceptance Criteria
+
+- `/api/revalidate` calls `revalidateTag(tag, "max")` for all relevant semantic models while preserving existing `revalidatePath` behavior.
+- Watch resolver `unstable_cache` declarations include tags that correspond to the route-handler invalidation map.
+- Broad `video` invalidation works even when Admin/Core sync cannot provide a slug.
+- Core sync emits watch-render invalidation for render-relevant phases, including at least `video-images`, `video-editions`, `video-subtitles`, and `video-dub-downloads`.
+- Unauthorized revalidation calls do not invalidate paths or tags.
+- Route-level `revalidate` is not raised in the first correctness PR; it remains gated on path + tag invalidation tests, preview smoke, and topology proof.
+- When route-level `revalidate` is raised, the initial target is 3600 seconds.
+- Documentation names the residual multi-instance/process-local manifest cache limitation.
+
+## Recommended TTL Policy
+
+For the current product shape:
+
+- **Now:** keep route-level `revalidate = 60` until tag invalidation lands.
+- **After U1-U4 plus preview/topology proof:** move route-level watch pages to `revalidate = 3600`.
+- **Data caches:** keep main resolver `unstable_cache` TTLs at 60 seconds for the first correctness rollout; keep child-dub language data at 1 hour.
+- **Later:** consider 6 to 24 hour route TTLs after production invalidation evidence, not before.
+
+This gives fast repeat loads while preserving a reasonable fallback if an Admin webhook is missed.

--- a/docs/roadmap/platform/feat-149-watch-route-manifest-admin.md
+++ b/docs/roadmap/platform/feat-149-watch-route-manifest-admin.md
@@ -8,7 +8,8 @@ start_date: "2026-05-29"
 duration: 2
 depends_on:
   - "feat-148"
-blocks: []
+blocks:
+  - "feat-172"
 tags:
   - "platform"
   - "admin"

--- a/docs/roadmap/platform/feat-163-admin-experience-watch-revalidation.md
+++ b/docs/roadmap/platform/feat-163-admin-experience-watch-revalidation.md
@@ -8,7 +8,8 @@ start_date: "2026-05-11"
 duration: 1
 depends_on:
   - "feat-101"
-blocks: []
+blocks:
+  - "feat-172"
 tags:
   - "platform"
   - "admin"

--- a/docs/roadmap/platform/feat-172-watch-cache-invalidation-hardening.md
+++ b/docs/roadmap/platform/feat-172-watch-cache-invalidation-hardening.md
@@ -1,0 +1,94 @@
+---
+id: "feat-172"
+title: "Watch cache invalidation hardening"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-10"
+duration: 2
+depends_on:
+  - "feat-149"
+  - "feat-163"
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "admin"
+  - "watch-page"
+  - "revalidation"
+  - "performance"
+---
+
+## Problem
+
+Watch pages are route-level ISR, but the revalidation endpoint only clears
+rendered route paths. The page resolvers also use `unstable_cache` without
+tags, so a regenerated route can still read stale Data Cache entries. Core sync
+also refreshes the watch route manifest without emitting a broad video-data
+invalidation for visible video/dub/subtitle/image changes.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-10-001-fix-watch-cache-invalidation-plan.md` - full
+   implementation plan and rollout policy.
+2. `apps/web/src/app/api/revalidate/route.ts` - token-gated receiver that maps
+   semantic Admin webhooks to Next cache invalidation calls.
+3. `apps/web/src/app/api/revalidate/route.test.ts` - route-handler contract
+   tests for paths, auth, malformed payloads, and manifest cache clearing.
+4. `apps/web/src/lib/content.ts` - watch resolver `unstable_cache` wrappers.
+5. `apps/web/src/lib/watch-home.ts` - cached watch home model.
+6. `apps/web/src/lib/watch-route-manifest.ts` - process-local manifest cache and
+   clearing helper.
+7. `apps/admin/src/services/revalidate-webhook.ts` - best-effort Admin-to-web
+   webhook client.
+8. `apps/admin/src/services/watch-route-manifest-refresh.service.ts` - Core
+   sync manifest refresh and webhook emission.
+
+## Grep These
+
+- `revalidatePath`
+- `revalidateTag`
+- `unstable_cache`
+- `watch-route-manifest`
+- `emitRevalidateWebhook`
+- `ROUTE_RELEVANT_CORE_SYNC_PHASES`
+- `fetchResolvedWatchVideo`
+- `fetchVideoChildDubLanguages`
+
+## What To Build
+
+1. Add a web-owned watch cache tag helper with coarse tags for home, settings,
+   experience, video, series, child-dub languages, and the route manifest.
+2. Add matching `tags` arrays to every watch `unstable_cache` wrapper.
+3. Extend `/api/revalidate` to call `revalidateTag(tag, "max")` while preserving
+   the existing public/internal/legacy `revalidatePath` matrix.
+4. Support broad `video` invalidation payloads with no slug so Core sync can
+   refresh rendered watch video data even without per-slug change summaries.
+5. Distinguish route-manifest-relevant Core sync phases from watch-render-
+   relevant phases and emit broad video invalidation for render-relevant phases.
+6. Keep route-level watch `revalidate` at 60 seconds in this correctness slice;
+   raise it toward 3600 seconds in a follow-up only after preview/topology proof.
+7. Update web/admin docs with the cache contract and remaining multi-instance
+   cache-topology limitation.
+
+## Constraints
+
+- Do not change the public `/watch` URL shape.
+- Do not remove existing `revalidatePath` coverage.
+- Do not introduce scoped data tags unless matching scoped cache declarations
+  exist.
+- Do not raise resolver/data-cache TTLs in this ticket.
+- Do not block Admin publish or Core sync jobs on web revalidation success.
+- Do not add Cloudflare HTML caching rules or a custom shared Next cache
+  handler in this ticket.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/app/api/revalidate/route.test.ts`
+- `pnpm --filter @forge/web test -- src/lib/watch-cache-tags.test.ts`
+- `pnpm --filter @forge/admin test -- src/services/watch-route-manifest-refresh.service.test.ts`
+- `pnpm --filter @forge/admin test -- src/services/revalidate-webhook.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/admin typecheck`
+- Preview smoke: request a watch video twice, trigger authorized revalidation,
+  and confirm the next request no longer serves stale resolver data.

--- a/docs/roadmap/platform/feat-172-watch-cache-invalidation-hardening.md
+++ b/docs/roadmap/platform/feat-172-watch-cache-invalidation-hardening.md
@@ -60,8 +60,8 @@ invalidation for visible video/dub/subtitle/image changes.
 1. Add a web-owned watch cache tag helper with coarse tags for home, settings,
    experience, video, series, child-dub languages, and the route manifest.
 2. Add matching `tags` arrays to every watch `unstable_cache` wrapper.
-3. Extend `/api/revalidate` to call `revalidateTag(tag, "max")` while preserving
-   the existing public/internal/legacy `revalidatePath` matrix.
+3. Extend `/api/revalidate` to call `revalidateTag(tag, { expire: 0 })` while
+   preserving the existing public/internal/legacy `revalidatePath` matrix.
 4. Support broad `video` invalidation payloads with no slug so Core sync can
    refresh rendered watch video data even without per-slug change summaries.
 5. Distinguish route-manifest-relevant Core sync phases from watch-render-


### PR DESCRIPTION
## Summary

Watch revalidation now clears both rendered route output and the resolver Data Cache entries those routes read from, so an Admin publish or Core sync update cannot regenerate a page from stale `unstable_cache` data. The first rollout keeps route-level `revalidate = 60`; the longer 3600 second TTL is documented as a follow-up after preview and production cache-topology proof.

This adds a small coarse tag taxonomy for watch home, settings, experience, video, series, child dub languages, and the route manifest. `/watch/api/revalidate` now maps semantic Admin webhooks to `revalidatePath` plus `revalidateTag(tag, { expire: 0 })`, validates payload shapes at runtime, contains tag invalidation failures so path invalidation still runs, and supports broad video invalidation with no slug.

Core sync now distinguishes route-manifest relevance from rendered-watch-data relevance. Changed video/image/edition/subtitle/dub phases emit a best-effort broad video-data invalidation, while no-op scheduled phases no longer churn the watch Data Cache. Slugless video and watch-route-manifest invalidations also revalidate the watch layouts so broad Core sync events clear route output as well as resolver tags.

## Notes

- Route-level TTL stays at 60 seconds in this PR.
- Resolver TTLs stay unchanged: 60 seconds for the main watch resolvers and 1 hour for child dub languages.
- The remaining multi-instance limitation is documented: process-local manifest cache clears only in the web process that receives the webhook unless production uses shared cache storage or webhook fan-out.

## Tests

- `pnpm --filter @forge/web test -- src/lib/watch-cache-tags.test.ts src/app/api/revalidate/route.test.ts src/lib/content.test.ts src/lib/__tests__/watch-home.test.ts`
- `pnpm --filter @forge/admin test -- src/services/watch-route-manifest-refresh.service.test.ts src/services/revalidate-webhook.test.ts`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/web lint`
- `pnpm --filter @forge/admin lint`
- Browser/API smoke: `agent-browser open http://127.0.0.1:4910/watch/jesus.html/english.html` reached the local route; full render was data-env limited without local Admin GraphQL credentials. Runtime API smoke against `/watch/api/revalidate` returned `200` with `["watch:video","watch:series","watch:child-dub-languages","watch:home"]`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
