### PR TITLE
fix(web): page watch search results by ten

### DIFF
--- a/apps/web/src/components/FloatingSearchProvider.tsx
+++ b/apps/web/src/components/FloatingSearchProvider.tsx
@@ -37,6 +37,7 @@ import { FloatingSearchBar } from "./FloatingSearchBar"
 import { SearchOverlay } from "./SearchOverlay"
 
 const HEADER_HOVER_HEIGHT_PX = 144
+const SEARCH_PAGE_SIZE = 10
 
 export type FloatingSearchContextValue = {
   open: boolean
@@ -369,7 +370,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
       try {
         const data = await runSearch({
           query: trimmed.slice(0, 200),
-          limit: 20,
+          limit: SEARCH_PAGE_SIZE,
           offset: 0,
         })
 
@@ -409,7 +410,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
     try {
       const data = await runSearch({
         query: query.trim().slice(0, 200),
-        limit: 20,
+        limit: SEARCH_PAGE_SIZE,
         offset: results.length,
       })
       if (requestIdRef.current !== thisRequest) return

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -6,6 +6,8 @@ import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { FloatingSearchProvider } from "@/components/FloatingSearchProvider"
+import { runSearch } from "@/lib/search-actions"
+import type { SearchResult } from "@/lib/search"
 import {
   WATCH_HEADER_LANGUAGE_SWITCHER_EVENT,
   WATCH_PLAYER_CHROME_REVEAL_EVENT,
@@ -42,7 +44,11 @@ afterEach(() => {
   })
   container.remove()
   document.body.innerHTML = ""
+  vi.clearAllMocks()
+  vi.useRealTimers()
 })
+
+const mockedRunSearch = vi.mocked(runSearch)
 
 function dispatchChromeVisibility(visible: boolean, opacity?: number) {
   window.dispatchEvent(
@@ -69,6 +75,88 @@ function dispatchLanguageSwitcher(detail: WatchHeaderLanguageSwitcherDetail) {
       { detail },
     ),
   )
+}
+
+function makeSearchResult(id: string, title: string): SearchResult {
+  return {
+    type: "video",
+    id,
+    slug: `${id}-slug`,
+    title,
+    imageUrl: null,
+    snippet: `${title} snippet`,
+    startSeconds: null,
+    playbackId: `playback-${id}`,
+    score: 1,
+    label: null,
+    durationSeconds: 120,
+    childCount: 0,
+  }
+}
+
+function makeSearchResponse(results: SearchResult[], hasMore: boolean) {
+  return {
+    results,
+    hasMore,
+    query: "the bible project",
+    searchMode: "hybrid",
+    latencyMs: 12,
+  }
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set
+  valueSetter?.call(input, value)
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+async function openSearchOverlay(): Promise<HTMLInputElement> {
+  act(() => {
+    root.render(
+      <FloatingSearchProvider>
+        <main>Page</main>
+      </FloatingSearchProvider>,
+    )
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  const searchButton = document.querySelector(
+    '[aria-label="Search videos"]',
+  ) as HTMLButtonElement
+  act(() => {
+    searchButton.click()
+  })
+
+  const input = document.querySelector(
+    'input[aria-label="Search videos by keyword"]',
+  ) as HTMLInputElement | null
+  if (input === null) {
+    throw new Error("Expected search overlay input to render")
+  }
+  return input
+}
+
+async function submitDebouncedSearch(input: HTMLInputElement, query: string) {
+  act(() => {
+    setInputValue(input, query)
+  })
+  await act(async () => {
+    vi.advanceTimersByTime(300)
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function flushResolvedSearch() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
 }
 
 function PlaybackStatePublisher({
@@ -539,5 +627,72 @@ describe("FloatingSearchProvider — search overlay chrome", () => {
     expect(close?.className).toContain("z-[60]")
     expect(close?.querySelector("svg")?.getAttribute("class")).toContain("h-6")
     expect(close?.querySelector("svg")?.getAttribute("class")).toContain("w-6")
+  })
+})
+
+describe("FloatingSearchProvider — search pagination", () => {
+  it("requests the initial Watch search page with limit 10 and offset 0", async () => {
+    vi.useFakeTimers()
+    mockedRunSearch.mockResolvedValueOnce(
+      makeSearchResponse(
+        [makeSearchResult("first-result", "The Bible Project Result")],
+        false,
+      ),
+    )
+
+    const input = await openSearchOverlay()
+    await submitDebouncedSearch(input, "the bible project")
+
+    expect(mockedRunSearch).toHaveBeenCalledTimes(1)
+    expect(mockedRunSearch).toHaveBeenCalledWith({
+      query: "the bible project",
+      limit: 10,
+      offset: 0,
+    })
+    expect(document.body.textContent).toContain("The Bible Project Result")
+  })
+
+  it("loads the next Watch search page with limit 10, current offset, and appends results", async () => {
+    vi.useFakeTimers()
+    const initialResults = Array.from({ length: 7 }, (_, index) =>
+      makeSearchResult(
+        `initial-${index + 1}`,
+        `Initial Bible Project Result ${index + 1}`,
+      ),
+    )
+    const nextResults = [
+      makeSearchResult("next-1", "Next Bible Project Result 1"),
+    ]
+    mockedRunSearch
+      .mockResolvedValueOnce(makeSearchResponse(initialResults, true))
+      .mockResolvedValueOnce(makeSearchResponse(nextResults, false))
+
+    const input = await openSearchOverlay()
+    await submitDebouncedSearch(input, "the bible project")
+
+    const loadMore = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Load more",
+    )
+    expect(loadMore).not.toBeUndefined()
+
+    act(() => {
+      loadMore?.click()
+    })
+    await flushResolvedSearch()
+
+    expect(mockedRunSearch).toHaveBeenNthCalledWith(1, {
+      query: "the bible project",
+      limit: 10,
+      offset: 0,
+    })
+    expect(mockedRunSearch).toHaveBeenNthCalledWith(2, {
+      query: "the bible project",
+      limit: 10,
+      offset: 7,
+    })
+    expect(document.body.textContent).toContain(
+      "Initial Bible Project Result 1",
+    )
+    expect(document.body.textContent).toContain("Next Bible Project Result 1")
   })
 })

--- a/docs/plans/2026-06-10-002-fix-watch-search-page-size-plan.md
+++ b/docs/plans/2026-06-10-002-fix-watch-search-page-size-plan.md
@@ -1,0 +1,84 @@
+---
+title: "Watch Search Page Size Plan"
+type: "fix"
+status: "completed"
+date: "2026-06-10"
+---
+
+# Watch Search Page Size Plan
+
+## Summary
+
+Change the Watch floating search overlay to fetch results in pages of 10 while preserving the shared web keyword-first search mode. The work is limited to the overlay/provider request sizing and focused tests; Admin ranking, canary/demo search, and infrastructure stay unchanged.
+
+## Problem Frame
+
+Web search already opts into Admin's `keyword-first` pipeline at `apps/web/src/lib/search.ts`, but the Watch overlay asks for `limit: 20`. Admin and web-shaped calls match ranking behavior when the page size is `10`, so the Watch overlay needs to request the same initial candidate pool and paginate by 10 on load more.
+
+## Requirements
+
+- R1. The Watch search overlay initial request calls `runSearch` with `limit: 10` and `offset: 0`.
+- R2. The Watch overlay Load more path calls `runSearch` with `limit: 10` and `offset` equal to the current result count.
+- R3. Load more appends newly fetched results to existing results.
+- R4. The shared keyword-first mode in `apps/web/src/lib/search.ts` remains unchanged.
+- R5. Admin search ranking, demo/canary search pages, and Railway or auth infrastructure are not changed.
+- R6. Focused tests prove the initial request, paginated request, and append behavior.
+
+## Key Technical Decisions
+
+- **Keep page size local to the overlay provider:** `FloatingSearchProvider` owns the Watch overlay request calls, so a named `SEARCH_PAGE_SIZE = 10` constant near that provider is the smallest clear change.
+- **Continue deriving pagination offset from rendered result state:** The current `results.length` offset matches the user's visible result count and avoids adding separate offset state.
+- **Do not change the shared search data boundary:** `apps/web/src/lib/search.ts` already sends `mode: "keyword-first"` for all web callers. This task changes caller page size, not the Admin GraphQL operation or server action shape.
+- **Leave `components/search/SearchResults.tsx` alone:** The only current import is the `/demo-search` surface, which disables visible load more with `showLoadMore={false}` and is outside the Watch search bar acceptance criteria.
+
+## Scope Boundaries
+
+- In scope: `apps/web/src/components/FloatingSearchProvider.tsx` and its component test.
+- Out of scope: Admin resolver ranking, Admin GraphQL schema, canary/demo pages, auth, Railway configuration, and generated GraphQL artifacts.
+
+## Implementation Units
+
+### U1. Track the follow-up ticket
+
+- **Goal:** Capture the page-size follow-up against the content-discovery search work.
+- **Requirements:** R1, R2, R3, R4, R5, R6
+- **Dependencies:** None
+- **Files:** `docs/roadmap/content-discovery/feat-174-watch-search-page-size.md`, `docs/roadmap/README.md`
+- **Approach:** Add a focused roadmap ticket in the content-discovery lane, marked in progress during implementation and completed once validation passes.
+- **Patterns to follow:** `docs/roadmap/content-discovery/feat-172-web-search-keyword-first-opt-in.md`
+- **Test scenarios:** Test expectation: none -- roadmap documentation only.
+- **Verification:** The roadmap ticket names the provider, tests, constraints, and plan path.
+
+### U2. Apply the Watch overlay page size
+
+- **Goal:** Use a named page-size constant for both initial search and load more calls.
+- **Requirements:** R1, R2, R4, R5
+- **Dependencies:** U1
+- **Files:** `apps/web/src/components/FloatingSearchProvider.tsx`
+- **Approach:** Define `SEARCH_PAGE_SIZE = 10` near the provider constants and replace both hard-coded `limit: 20` values in `search` and `loadMore`. Keep `offset: 0` for initial searches and `offset: results.length` for load more.
+- **Patterns to follow:** Existing `runSearch` calls in `FloatingSearchProvider` and the fixed `WEB_SEARCH_MODE` boundary in `apps/web/src/lib/search.ts`.
+- **Test scenarios:** Initial Watch overlay search for a non-empty query calls `runSearch` with the trimmed query, `limit: 10`, and `offset: 0`; load more calls `runSearch` with the same query, `limit: 10`, and `offset` equal to the current result count.
+- **Verification:** Provider code has one named page-size constant and no remaining `limit: 20` in the Watch overlay request path.
+
+### U3. Prove pagination and append behavior
+
+- **Goal:** Add regression coverage for the request shape and state behavior.
+- **Requirements:** R1, R2, R3, R6
+- **Dependencies:** U2
+- **Files:** `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`
+- **Approach:** Mock `runSearch`, render the provider and overlay, trigger a search through the visible input, then click Load more after the first response. Assert the first and second `runSearch` calls and verify the DOM contains both original and appended results.
+- **Patterns to follow:** Existing jsdom `FloatingSearchProvider` tests and `SearchOverlay` load-more button behavior.
+- **Test scenarios:** A query such as `the bible project` sends `limit: 10, offset: 0`; with 10 existing results and `hasMore: true`, Load more sends `limit: 10, offset: 10`; after the second response, original and appended titles are both rendered.
+- **Verification:** The focused component test passes alongside the relevant web typecheck.
+
+## Sources
+
+- `apps/web/AGENTS.md`
+- `apps/web/CLAUDE.md`
+- `CONCEPTS.md`
+- `apps/web/src/components/FloatingSearchProvider.tsx`
+- `apps/web/src/components/SearchOverlay.tsx`
+- `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`
+- `apps/web/src/lib/search.ts`
+- `docs/roadmap/content-discovery/feat-172-web-search-keyword-first-opt-in.md`
+- `docs/solutions/web/web-search-admin-keyword-first-opt-in.md`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (June 4, 2026)
 
-- **Total tickets:** 188
-- **Complete:** 113
+- **Total tickets:** 189
+- **Complete:** 114
 - **In progress:** 9
 - **Not started:** 21
 - **Blocked:** 43
@@ -69,6 +69,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-170](content-discovery/feat-170-yt-video-mapper-backend-scaffold.md)                                     | YouTube video mapper backend scaffold                                                           | nisal     | P1       | 2026-06-08 | 1    | 2026-06-08 | complete    |
 | [feat-171](content-discovery/feat-171-yt-video-mapper-broad-catalog-prototype.md)                              | YouTube video mapper broad-catalog prototype                                                    | nisal     | P1       | 2026-06-08 | 10   | 2026-06-17 | in-progress |
 | [feat-172](content-discovery/feat-172-web-search-keyword-first-opt-in.md)                                      | Web search keyword-first opt-in                                                                 | nisal     | P1       | 2026-06-09 | 1    | 2026-06-09 | complete    |
+| [feat-174](content-discovery/feat-174-watch-search-page-size.md)                                               | Watch search page size                                                                          | nisal     | P1       | 2026-06-10 | 1    | 2026-06-10 | complete    |
 | [feat-058](content-discovery/feat-058-deploy-semantic-search-architecture.md)                                  | Deploy Semantic Search Architecture                                                             | tataihono | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-080](content-discovery/feat-080-transcript-embedding-table-rename.md)                                    | Transcript Embedding Table Rename                                                               | nisal     | P2       | 2026-04-10 | 2    | 2026-04-11 | complete    |
 | [feat-119](content-discovery/feat-119-embed-backfill-artifact-missing-classification-and-opt-in-enrichment.md) | Embed Backfill — Classify NoSuchKey + emit missingArtifacts list + decoupled enrichment trigger | nisal     | P2       | 2026-05-06 | 4    | 2026-05-09 | complete    |

--- a/docs/roadmap/content-discovery/feat-172-web-search-keyword-first-opt-in.md
+++ b/docs/roadmap/content-discovery/feat-172-web-search-keyword-first-opt-in.md
@@ -8,7 +8,8 @@ start_date: "2026-06-09"
 duration: 1
 depends_on:
   - "feat-109"
-blocks: []
+blocks:
+  - "feat-174"
 tags:
   - "web"
   - "search"

--- a/docs/roadmap/content-discovery/feat-174-watch-search-page-size.md
+++ b/docs/roadmap/content-discovery/feat-174-watch-search-page-size.md
@@ -1,0 +1,58 @@
+---
+id: "feat-174"
+title: "Watch search page size"
+owner: "nisal"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-10"
+duration: 1
+depends_on:
+  - "feat-172"
+blocks: []
+tags:
+  - "web"
+  - "watch"
+  - "search"
+---
+
+## Problem
+
+The Watch floating search overlay already uses web's keyword-first search mode, but it requests `limit: 20`. Admin and web-shaped search calls align at `limit: 10`, so the Watch overlay needs a 10-result initial request and 10-result load-more pages.
+
+## What To Build
+
+- [x] Add a named page-size constant near the Watch search provider code.
+- [x] Change initial Watch overlay searches to call `runSearch` with `limit: 10` and `offset: 0`.
+- [x] Change Load more to call `runSearch` with `limit: 10` and `offset` equal to the current result count.
+- [x] Preserve `mode: "keyword-first"` in `apps/web/src/lib/search.ts`.
+- [x] Add focused tests for initial request shape, load-more request shape, and append behavior.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/FloatingSearchProvider.tsx` - Watch overlay search state and `runSearch` calls.
+2. `apps/web/src/components/SearchOverlay.tsx` - Load more button surface.
+3. `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx` - jsdom coverage for provider and overlay behavior.
+4. `apps/web/src/lib/search.ts` - shared web search boundary that already sends keyword-first mode.
+
+## Grep These
+
+- `runSearch` - provider and shared search action call sites.
+- `limit:` - search page-size arguments to verify the Watch overlay changed without touching other search surfaces.
+- `SEARCH_PAGE_SIZE` - named page-size constant for the Watch overlay.
+- `loadMore` - pagination path that must use the current result count as the next offset.
+
+## Constraints
+
+- Do not change Admin search ranking or schema behavior.
+- Do not change demo/canary search pages.
+- Do not change auth, Railway, or infrastructure files.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx`
+- `pnpm --filter @forge/web typecheck`
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-10-002-fix-watch-search-page-size-plan.md`

--- a/docs/solutions/logic-errors/watch-search-overlay-page-size-mismatch.md
+++ b/docs/solutions/logic-errors/watch-search-overlay-page-size-mismatch.md
@@ -1,0 +1,103 @@
+---
+title: "Watch search overlay page size mismatch"
+date: "2026-06-10"
+category: "logic-errors"
+module: "apps/web search"
+problem_type: "logic_error"
+component: "frontend_stimulus"
+symptoms:
+  - "Watch floating search overlay initial requests used a 20-result page instead of the 10-result page size needed for Admin/web search alignment."
+  - "Watch overlay Load more requests needed to keep the same 10-result page size while deriving offset from the current rendered result count."
+root_cause: "logic_error"
+resolution_type: "code_fix"
+severity: "medium"
+related_components:
+  - "apps/web/src/components/FloatingSearchProvider.tsx"
+  - "apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx"
+  - "apps/web/src/lib/search.ts"
+tags:
+  - "web"
+  - "watch"
+  - "search"
+  - "pagination"
+  - "page-size"
+  - "keyword-first"
+  - "floating-search"
+---
+
+# Watch search overlay page size mismatch
+
+## Problem
+
+The Watch floating search overlay already used Admin keyword-first mode through the shared web search boundary, but the overlay itself requested `limit: 20`. Admin and web-shaped ranking matched at `limit: 10`, so the Watch overlay needed a smaller initial candidate pool and matching 10-result Load more pages.
+
+## Symptoms
+
+- Searching from the Watch search bar requested 20 results even though the desired first page was 10 keyword-first results.
+- Load more used the current result count for `offset`, but still requested another 20 results.
+- The mismatch lived in the UI caller, not in Admin ranking or the shared `mode: "keyword-first"` GraphQL boundary.
+
+## What Didn't Work
+
+- **Changing Admin search ranking.** The backend candidate pool was already correct when the caller used the right `limit`, so ranking changes would have moved the fix to the wrong owner.
+- **Changing `apps/web/src/lib/search.ts`.** That file owns the shared web Admin search contract, including `WEB_SEARCH_MODE = "keyword-first"`. Moving Watch-specific page size there would make demo/search helper callers inherit a Watch UI choice.
+- **Testing only for `offset: 10`.** A test with exactly 10 initial results cannot distinguish `offset: results.length` from a hard-coded page size. The regression test needs a current result count that differs from the page size.
+
+## Solution
+
+Keep the page-size decision local to `FloatingSearchProvider` and use the same constant in both request paths:
+
+```ts
+const SEARCH_PAGE_SIZE = 10
+
+await runSearch({
+  query: trimmed.slice(0, 200),
+  limit: SEARCH_PAGE_SIZE,
+  offset: 0,
+})
+
+await runSearch({
+  query: query.trim().slice(0, 200),
+  limit: SEARCH_PAGE_SIZE,
+  offset: results.length,
+})
+```
+
+The focused component test should drive the real overlay flow: open the provider UI, type a debounced query, assert the initial `runSearch` payload, return `hasMore: true`, click Load more, assert the second payload, and verify old plus new result titles both render.
+
+Use an initial result count that is not equal to the page size:
+
+```ts
+const initialResults = Array.from({ length: 7 }, (_, index) =>
+  makeSearchResult(`initial-${index + 1}`, `Initial Result ${index + 1}`),
+)
+
+expect(mockedRunSearch).toHaveBeenNthCalledWith(2, {
+  query: "the bible project",
+  limit: 10,
+  offset: 7,
+})
+```
+
+That catches regressions to `offset: SEARCH_PAGE_SIZE`, `offset: 10`, or a separate offset counter that drifts from rendered results.
+
+## Why This Works
+
+Search page size affects the request's candidate pool and pagination boundary. Search pipeline mode affects how Admin retrieves and fuses candidates. Keeping those decisions in different layers prevents a Watch-specific page-size fix from changing the shared keyword-first contract.
+
+The provider already owns local search state, stale-response guards, Load more append behavior, and the rendered result count. Using `results.length` preserves the existing offset contract while making the requested page size explicit.
+
+## Prevention
+
+- Put product-specific search page-size constants near the UI provider that owns the request, not in the shared search helper, unless every caller should inherit the same page size.
+- When testing Load more offsets, make the existing result count differ from the page size so the assertion proves `offset` follows state.
+- Assert both request shape and append behavior: `limit`, `offset`, and rendered original plus appended results.
+- Keep `mode` and `searchMode` concepts separate: input `mode` selects the Admin search pipeline; response `searchMode` reports runtime degradation.
+
+## Related Issues
+
+- `docs/solutions/web/web-search-admin-keyword-first-opt-in.md` — shared web keyword-first boundary that this fix deliberately leaves unchanged.
+- `docs/solutions/best-practices/nextjs-search-overlay-ui-patterns-20260415.md` — overlay state, request freshness, and portal patterns.
+- `docs/solutions/best-practices/mobile-search-ui-patterns-20260416.md` — client-side pagination, append behavior, and stale guard considerations.
+- `docs/solutions/best-practices/hybrid-semantic-search-api-strapi-v5-pgvector.md` — backend `limit` / `offset` / `hasMore` contract behind Load more.
+- `docs/solutions/design-patterns/watch-language-player-chrome-layout-20260609.md` — adjacent `FloatingSearchProvider` surface ownership.

--- a/docs/solutions/web/web-search-admin-keyword-first-opt-in.md
+++ b/docs/solutions/web/web-search-admin-keyword-first-opt-in.md
@@ -95,6 +95,8 @@ expect(options.variables).toEqual({
 })
 ```
 
+The `limit: 20` example describes the shared helper default. Do not copy it into Watch overlay pagination when the product surface needs a different page size; `apps/web/src/components/FloatingSearchProvider.tsx` owns its local `SEARCH_PAGE_SIZE` instead.
+
 Add a response mapping assertion beside the request-mode assertions:
 
 ```ts
@@ -111,6 +113,7 @@ That keeps the two mode concepts from collapsing into each other during later re
 ## Related
 
 - [Admin hybrid search keyword-first mode](../platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md)
+- [Watch search overlay page size mismatch](../logic-errors/watch-search-overlay-page-size-mismatch.md)
 - [Admin hybrid search R4 pattern](../platform/admin-hybrid-search-r4-pattern.md)
 - [Dual-client gql.tada multi-schema codegen pattern](../architecture-patterns/dual-client-gql-tada-multi-schema-codegen-pattern-20260507.md)
 - [Codegen strips optional GraphQL variable definitions from DocumentNode AST](../cms/codegen-strips-optional-graphql-variables.md)


### PR DESCRIPTION
## Summary

Watch search now opens with the same 10-result keyword-first page size as the admin-shaped web search path, avoiding the larger candidate pool that was changing backend ranking for the first page. Loading more fetches the next 10 results at `offset: results.length`, so pagination extends the current list instead of re-querying from a different window.

The existing `mode: "keyword-first"` behavior remains unchanged in `apps/web/src/lib/search.ts`; this PR only corrects the Watch overlay page size and pagination contract.

## Validation

- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `git diff --check HEAD -- .`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
