### PR TITLE
feat(yt-video-mapper): sync admin catalog locally

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -41,6 +41,15 @@ Mapper Catalog rows are shaped around matchable variants: the source Video
 identity stays anchored by Core ID, while each Dub contributes the variant
 identity the mapper uses to compare uploaded media against official media.
 
+### Catalog Sync Run
+
+A durable record of one Mapper Catalog refresh from Admin into mapper-owned
+projection rows.
+
+A Catalog Sync Run tracks page progress, counts, terminal status, and safe
+failure summaries so broad catalog refreshes can be inspected and retried
+without treating Admin as the mapper's database.
+
 ### Match Job
 
 An asynchronous attribution request that owns an uploaded media input until the mapper can process it and return ranked results.

--- a/apps/yt-video-mapper-backend/README.md
+++ b/apps/yt-video-mapper-backend/README.md
@@ -16,9 +16,22 @@ From the Forge repo root:
 
 ```sh
 pnpm --filter @forge/yt-video-mapper-backend dev
+pnpm --filter @forge/yt-video-mapper-backend sync:catalog
 pnpm --filter @forge/yt-video-mapper-backend test
 pnpm --filter @forge/yt-video-mapper-backend typecheck
 ```
+
+## Catalog Sync
+
+`sync:catalog` reads Admin's `videoMapperCatalog(first, after)` GraphQL
+projection and upserts mapper-owned `CatalogVideo`, `CatalogVariant`, and
+`CatalogSyncRun` rows. It requires:
+
+- `ADMIN_GRAPHQL_URL`
+- `ADMIN_SERVICE_BEARER_TOKEN`
+
+Admin remains the catalog source of truth. The mapper tables are a local
+projection for matching and indexing.
 
 ## Current Artifacts
 

--- a/apps/yt-video-mapper-backend/docs/railway-deployment.md
+++ b/apps/yt-video-mapper-backend/docs/railway-deployment.md
@@ -50,7 +50,7 @@ Required for production:
 - `JOB_RESULT_RETENTION_HOURS=168`
 - `JOB_RUNNING_STALE_MINUTES=30`
 
-Prepared for later catalog sync, but optional until YTM-002/YTM-003:
+Required when running catalog sync:
 
 - `ADMIN_GRAPHQL_URL=<admin GraphQL URL>`
 - `ADMIN_SERVICE_BEARER_TOKEN=<admin service bearer token>`
@@ -87,6 +87,18 @@ Expected results:
 - `POST /match-jobs` without a bearer token returns `401`.
 - `POST /match-jobs` with an invalid bearer token returns `401`.
 - `POST /match-jobs` with the valid mapper token returns `202` and a `jobId`.
+
+## Catalog Sync
+
+Run one Admin-to-mapper catalog projection sync with:
+
+```bash
+pnpm --filter @forge/yt-video-mapper-backend sync:catalog
+```
+
+The command uses Admin GraphQL only. It writes mapper-owned `CatalogVideo`,
+`CatalogVariant`, and `CatalogSyncRun` rows, prints safe counters, and exits
+non-zero if the sync run records a failed status.
 
 ## 2026-06-09 Provisioning Notes
 

--- a/apps/yt-video-mapper-backend/package.json
+++ b/apps/yt-video-mapper-backend/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx src/server.ts",
     "build": "rm -rf dist && pnpm run db:generate && tsc -p tsconfig.build.json && rm -rf dist/generated/prisma && mkdir -p dist/generated && cp -R src/generated/prisma dist/generated/prisma",
     "start": "node dist/server.js",
+    "sync:catalog": "tsx src/scripts/sync-catalog.ts",
     "postinstall": "DATABASE_URL=${DATABASE_URL:-postgresql://forge:forge@localhost:5432/yt_video_mapper} prisma generate",
     "db:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://forge:forge@localhost:5432/yt_video_mapper} prisma generate",
     "db:migrate:dev": "prisma migrate dev",
@@ -18,7 +19,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@forge/admin-graphql": "workspace:*",
     "@prisma/client": "^6",
+    "graphql": "16.13.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/yt-video-mapper-backend/prisma/migrations/20260610010000_ytm003_catalog_sync_fields/migration.sql
+++ b/apps/yt-video-mapper-backend/prisma/migrations/20260610010000_ytm003_catalog_sync_fields/migration.sql
@@ -1,0 +1,27 @@
+-- AlterTable
+ALTER TABLE "mapper_catalog_variant"
+ADD COLUMN "edition_name" TEXT,
+ADD COLUMN "video_published" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "dub_published" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "video_no_index" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "video_deleted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "dub_deleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- Preserve the old ambiguous published value as the dub publication snapshot
+-- until the next Admin catalog sync refreshes both explicit fields.
+UPDATE "mapper_catalog_variant"
+SET "dub_published" = "published";
+
+-- Drop single-column identity constraints so mapper-owned rows are keyed by
+-- the Core-facing composite identity: core_id + video_variant_id.
+DROP INDEX "mapper_catalog_variant_video_variant_id_key";
+DROP INDEX "mapper_media_signature_video_variant_id_signature_type_algo_key";
+DROP INDEX "mapper_match_candidate_job_id_video_variant_id_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mapper_media_signature_variant_signature_key"
+ON "mapper_media_signature"("core_id", "video_variant_id", "signature_type", "algorithm_version", "offset_milliseconds");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mapper_match_candidate_job_variant_key"
+ON "mapper_match_candidate"("job_id", "core_id", "video_variant_id");

--- a/apps/yt-video-mapper-backend/prisma/schema.prisma
+++ b/apps/yt-video-mapper-backend/prisma/schema.prisma
@@ -82,10 +82,11 @@ model CatalogVariant {
   id                     String          @id @default(cuid())
   coreId                 String          @map("core_id")
   catalogVideo           CatalogVideo    @relation(fields: [coreId], references: [coreId], onDelete: Cascade)
-  videoVariantId         String          @unique @map("video_variant_id")
+  videoVariantId         String          @map("video_variant_id")
   adminVideoId           String?         @map("admin_video_id")
   adminDubId             String?         @map("admin_dub_id")
   editionCoreId          String?         @map("edition_core_id")
+  editionName            String?         @map("edition_name")
   languageId             String?         @map("language_id")
   languageSlug           String?         @map("language_slug")
   locale                 String?
@@ -103,6 +104,11 @@ model CatalogVariant {
   indexable              Boolean         @default(false)
   nonIndexableReason     String?         @map("non_indexable_reason")
   published              Boolean         @default(true)
+  videoPublished         Boolean         @default(false) @map("video_published")
+  dubPublished           Boolean         @default(false) @map("dub_published")
+  videoNoIndex           Boolean         @default(false) @map("video_no_index")
+  videoDeleted           Boolean         @default(false) @map("video_deleted")
+  dubDeleted             Boolean         @default(false) @map("dub_deleted")
   deletedAt              DateTime?       @map("deleted_at")
   lastSyncedAt           DateTime?       @map("last_synced_at")
   createdAt              DateTime        @default(now()) @map("created_at")
@@ -170,7 +176,7 @@ model MediaSignature {
   sourceMediaHash      String?        @map("source_media_hash")
   createdAt            DateTime       @default(now()) @map("created_at")
 
-  @@unique([videoVariantId, signatureType, algorithmVersion, offsetMilliseconds])
+  @@unique([coreId, videoVariantId, signatureType, algorithmVersion, offsetMilliseconds], map: "mapper_media_signature_variant_signature_key")
   @@index([coreId, signatureType])
   @@map("mapper_media_signature")
 }
@@ -216,7 +222,7 @@ model MatchCandidate {
   evidence MatchEvidence[]
 
   @@unique([jobId, rank])
-  @@unique([jobId, videoVariantId])
+  @@unique([jobId, coreId, videoVariantId], map: "mapper_match_candidate_job_variant_key")
   @@unique([id, jobId])
   @@index([coreId])
   @@map("mapper_match_candidate")

--- a/apps/yt-video-mapper-backend/src/config/env.test.ts
+++ b/apps/yt-video-mapper-backend/src/config/env.test.ts
@@ -20,7 +20,7 @@ describe("runtime env", () => {
     resetProcessEnv()
   })
 
-  it("allows production startup without future admin sync vars", async () => {
+  it("allows production startup without catalog sync vars", async () => {
     const { assertRuntimeEnv, env } = await loadEnv({
       NODE_ENV: "production",
       DATABASE_URL: "postgresql://forge:forge@localhost:5432/mapper",
@@ -32,6 +32,38 @@ describe("runtime env", () => {
     expect(env.ADMIN_GRAPHQL_URL).toBeUndefined()
     expect(env.ADMIN_SERVICE_BEARER_TOKEN).toBeUndefined()
     expect(assertRuntimeEnv).not.toThrow()
+  })
+
+  it("requires the Admin GraphQL URL when running catalog sync", async () => {
+    const { assertAdminCatalogSyncEnv } = await loadEnv({
+      ADMIN_SERVICE_BEARER_TOKEN: "service-token",
+    })
+
+    expect(assertAdminCatalogSyncEnv).toThrow(
+      "ADMIN_GRAPHQL_URL is required to sync the yt-video-mapper catalog",
+    )
+  })
+
+  it("requires the Admin service bearer token when running catalog sync", async () => {
+    const { assertAdminCatalogSyncEnv } = await loadEnv({
+      ADMIN_GRAPHQL_URL: "https://admin.example.com/graphql",
+    })
+
+    expect(assertAdminCatalogSyncEnv).toThrow(
+      "ADMIN_SERVICE_BEARER_TOKEN is required to sync the yt-video-mapper catalog",
+    )
+  })
+
+  it("returns Admin catalog sync configuration when both sync vars are set", async () => {
+    const { assertAdminCatalogSyncEnv } = await loadEnv({
+      ADMIN_GRAPHQL_URL: "https://admin.example.com/graphql",
+      ADMIN_SERVICE_BEARER_TOKEN: "service-token",
+    })
+
+    expect(assertAdminCatalogSyncEnv()).toEqual({
+      adminGraphqlUrl: "https://admin.example.com/graphql",
+      adminServiceBearerToken: "service-token",
+    })
   })
 
   it("requires DATABASE_URL in production", async () => {

--- a/apps/yt-video-mapper-backend/src/config/env.ts
+++ b/apps/yt-video-mapper-backend/src/config/env.ts
@@ -64,3 +64,30 @@ export function assertRuntimeEnv(): void {
     )
   }
 }
+
+export type AdminCatalogSyncEnv = {
+  adminGraphqlUrl: string
+  adminServiceBearerToken: string
+}
+
+export function assertAdminCatalogSyncEnv(): AdminCatalogSyncEnv {
+  const missing = [
+    ["ADMIN_GRAPHQL_URL", env.ADMIN_GRAPHQL_URL],
+    ["ADMIN_SERVICE_BEARER_TOKEN", env.ADMIN_SERVICE_BEARER_TOKEN],
+  ]
+    .filter(([, value]) => !value)
+    .map(([name]) => name)
+
+  if (missing.length > 0) {
+    throw new RuntimeEnvError(
+      `${missing.join(", ")} ${
+        missing.length === 1 ? "is" : "are"
+      } required to sync the yt-video-mapper catalog`,
+    )
+  }
+
+  return {
+    adminGraphqlUrl: env.ADMIN_GRAPHQL_URL!,
+    adminServiceBearerToken: env.ADMIN_SERVICE_BEARER_TOKEN!,
+  }
+}

--- a/apps/yt-video-mapper-backend/src/db/schema.test.ts
+++ b/apps/yt-video-mapper-backend/src/db/schema.test.ts
@@ -10,13 +10,40 @@ describe("mapper Prisma schema", () => {
   it("keeps the public Core identifiers unique in the catalog map", () => {
     expect(schema).toContain('coreId       String    @unique @map("core_id")')
     expect(schema).toContain(
-      'videoVariantId         String          @unique @map("video_variant_id")',
+      'videoVariantId         String          @map("video_variant_id")',
+    )
+    expect(schema).toContain("@@unique([coreId, videoVariantId])")
+  })
+
+  it("stores Admin catalog projection state needed for sync/indexing decisions", () => {
+    expect(schema).toContain(
+      'editionName            String?         @map("edition_name")',
+    )
+    expect(schema).toContain(
+      'videoPublished         Boolean         @default(false) @map("video_published")',
+    )
+    expect(schema).toContain(
+      'dubPublished           Boolean         @default(false) @map("dub_published")',
+    )
+    expect(schema).toContain(
+      'videoNoIndex           Boolean         @default(false) @map("video_no_index")',
+    )
+    expect(schema).toContain(
+      'videoDeleted           Boolean         @default(false) @map("video_deleted")',
+    )
+    expect(schema).toContain(
+      'dubDeleted             Boolean         @default(false) @map("dub_deleted")',
+    )
+    expect(schema).toContain(
+      'nonIndexableReason     String?         @map("non_indexable_reason")',
     )
   })
 
   it("allows multiple ranked variants under the same coreId for one job", () => {
     expect(schema).toContain("@@unique([jobId, rank])")
-    expect(schema).toContain("@@unique([jobId, videoVariantId])")
+    expect(schema).toContain(
+      '@@unique([jobId, coreId, videoVariantId], map: "mapper_match_candidate_job_variant_key")',
+    )
     expect(schema).toContain("@@index([coreId])")
   })
 
@@ -32,7 +59,7 @@ describe("mapper Prisma schema", () => {
 
   it("can rerun an indexer version without duplicating timecoded signatures", () => {
     expect(schema).toContain(
-      "@@unique([videoVariantId, signatureType, algorithmVersion, offsetMilliseconds])",
+      '@@unique([coreId, videoVariantId, signatureType, algorithmVersion, offsetMilliseconds], map: "mapper_media_signature_variant_signature_key")',
     )
   })
 })

--- a/apps/yt-video-mapper-backend/src/scripts/sync-catalog.ts
+++ b/apps/yt-video-mapper-backend/src/scripts/sync-catalog.ts
@@ -1,0 +1,56 @@
+import { assertAdminCatalogSyncEnv, RuntimeEnvError } from "../config/env.js"
+import { prisma } from "../db/client.js"
+import { AdminGraphqlClient } from "../services/admin-graphql-client.js"
+import {
+  CatalogSyncService,
+  PrismaCatalogRepository,
+} from "../services/catalog-sync.js"
+
+async function main() {
+  const { adminGraphqlUrl, adminServiceBearerToken } =
+    assertAdminCatalogSyncEnv()
+  const service = new CatalogSyncService({
+    client: new AdminGraphqlClient({
+      url: adminGraphqlUrl,
+      bearerToken: adminServiceBearerToken,
+    }),
+    repository: new PrismaCatalogRepository(prisma),
+  })
+
+  const result = await service.syncCatalog()
+  console.log(
+    JSON.stringify(
+      {
+        status: result.status,
+        syncRunId: result.id,
+        cursor: result.cursor,
+        videosSeen: result.videosSeen,
+        variantsSeen: result.variantsSeen,
+        variantsIndexable: result.variantsIndexable,
+        missingVariantsMarked: result.missingVariantsMarked,
+        failureSummary: result.failureSummary,
+      },
+      null,
+      2,
+    ),
+  )
+
+  if (result.status === "failed") {
+    process.exitCode = 1
+  }
+}
+
+main()
+  .catch((error) => {
+    process.exitCode = 1
+    const message =
+      error instanceof RuntimeEnvError
+        ? error.message
+        : error instanceof Error
+          ? error.message
+          : "catalog sync failed"
+    console.error(message)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/apps/yt-video-mapper-backend/src/services/admin-graphql-client.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/admin-graphql-client.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  AdminGraphqlClient,
+  AdminGraphqlClientError,
+  type AdminCatalogItem,
+  type FetchLike,
+} from "./admin-graphql-client.js"
+
+const catalogItem: AdminCatalogItem = {
+  coreId: "core-video-1",
+  sourceTitle: "JESUS",
+  sourceTitleLocale: "en",
+  videoVariantId: "variant-en",
+  adminVideoId: "admin-video-1",
+  adminDubId: "admin-dub-1",
+  languageId: "lang-core-en",
+  languageSlug: "english",
+  locale: "en",
+  editionCoreId: "edition-core-1",
+  editionName: "Feature",
+  durationSeconds: 120,
+  lengthInMilliseconds: "120000",
+  hlsUrl: "https://media.example.com/video.m3u8",
+  dashUrl: null,
+  shareUrl: "https://share.example.com/video",
+  downloadUrl: "https://media.example.com/video.mp4",
+  downloadQuality: "1080p",
+  downloadWidth: 1920,
+  downloadHeight: 1080,
+  mediaSourceType: "DOWNLOAD",
+  mediaSourceUrl: "https://media.example.com/video.mp4",
+  videoPublished: true,
+  dubPublished: true,
+  videoNoIndex: false,
+  videoDeleted: false,
+  dubDeleted: false,
+  deletedAt: null,
+  indexable: true,
+  nonIndexableReason: null,
+}
+
+describe("AdminGraphqlClient", () => {
+  it("fetches the first catalog page without an after variable", async () => {
+    const fetchImpl = createFetch({
+      data: catalogResponse({
+        nodes: [catalogItem],
+        pageInfo: {
+          startCursor: "cursor-a",
+          endCursor: "cursor-b",
+          hasNextPage: true,
+        },
+      }),
+    })
+    const client = createClient(fetchImpl)
+
+    await expect(client.fetchCatalogPage({ first: 25 })).resolves.toEqual({
+      nodes: [catalogItem],
+      pageInfo: {
+        startCursor: "cursor-a",
+        endCursor: "cursor-b",
+        hasNextPage: true,
+      },
+    })
+
+    const [, init] = fetchImpl.mock.calls[0]
+    expect(init.headers.authorization).toBe("Bearer service-token")
+    expect(JSON.parse(init.body)).toMatchObject({
+      variables: { first: 25 },
+    })
+    expect(JSON.parse(init.body).variables).not.toHaveProperty("after")
+  })
+
+  it("passes the cursor when fetching a later page", async () => {
+    const fetchImpl = createFetch({
+      data: catalogResponse({
+        nodes: [],
+        pageInfo: {
+          startCursor: null,
+          endCursor: null,
+          hasNextPage: false,
+        },
+      }),
+    })
+    const client = createClient(fetchImpl)
+
+    await client.fetchCatalogPage({ first: 25, after: "cursor-b" })
+
+    const [, init] = fetchImpl.mock.calls[0]
+    expect(JSON.parse(init.body)).toMatchObject({
+      variables: {
+        first: 25,
+        after: "cursor-b",
+      },
+    })
+  })
+
+  it("maps GraphQL errors to a safe client error", async () => {
+    const fetchImpl = createFetch({
+      data: {
+        errors: [
+          {
+            message: "denied for service-token",
+            extensions: { authorization: "Bearer service-token" },
+          },
+        ],
+      },
+    })
+    const client = createClient(fetchImpl)
+
+    await expect(client.fetchCatalogPage({ first: 25 })).rejects.toMatchObject({
+      code: "graphql_error",
+      summary: {
+        errors: [
+          {
+            message: "denied for [redacted]",
+            extensions: {},
+          },
+        ],
+      },
+    })
+  })
+
+  it("maps HTTP failures to a bounded safe summary", async () => {
+    const fetchImpl = createFetch({
+      ok: false,
+      status: 502,
+      data: {
+        message: `upstream failed ${"x".repeat(400)} service-token`,
+      },
+    })
+    const client = createClient(fetchImpl)
+
+    await expect(client.fetchCatalogPage({ first: 25 })).rejects.toMatchObject({
+      code: "http_error",
+      summary: {
+        status: 502,
+        body: {
+          message: expect.stringContaining("upstream failed"),
+        },
+      },
+    })
+
+    try {
+      await client.fetchCatalogPage({ first: 25 })
+    } catch (error) {
+      expect(error).toBeInstanceOf(AdminGraphqlClientError)
+      const serialized = JSON.stringify(
+        (error as AdminGraphqlClientError).summary,
+      )
+      expect(serialized).not.toContain("service-token")
+      expect(serialized.length).toBeLessThan(450)
+    }
+  })
+
+  it("rejects malformed catalog payloads before returning rows", async () => {
+    const fetchImpl = createFetch({
+      data: catalogResponse({
+        nodes: [{ ...catalogItem, coreId: "" }],
+        pageInfo: {
+          startCursor: null,
+          endCursor: null,
+          hasNextPage: false,
+        },
+      }),
+    })
+    const client = createClient(fetchImpl)
+
+    await expect(client.fetchCatalogPage({ first: 25 })).rejects.toMatchObject({
+      code: "malformed_response",
+      summary: {
+        reason: "nodes[0].coreId must be a non-empty string",
+      },
+    })
+  })
+})
+
+function createClient(fetchImpl: ReturnType<typeof createFetch>) {
+  return new AdminGraphqlClient({
+    url: "https://admin.example.com/graphql",
+    bearerToken: "service-token",
+    fetchImpl,
+  })
+}
+
+function createFetch({
+  ok = true,
+  status = 200,
+  data,
+}: {
+  ok?: boolean
+  status?: number
+  data: unknown
+}) {
+  return vi.fn<FetchLike>(async () => ({
+    ok,
+    status,
+    async text() {
+      return typeof data === "string" ? data : JSON.stringify(data)
+    },
+  }))
+}
+
+function catalogResponse(page: {
+  nodes: unknown[]
+  pageInfo: {
+    startCursor: string | null
+    endCursor: string | null
+    hasNextPage: boolean
+  }
+}) {
+  return {
+    data: {
+      videoMapperCatalog: page,
+    },
+  }
+}

--- a/apps/yt-video-mapper-backend/src/services/admin-graphql-client.ts
+++ b/apps/yt-video-mapper-backend/src/services/admin-graphql-client.ts
@@ -1,0 +1,418 @@
+import { adminGraphql } from "@forge/admin-graphql"
+import { print } from "graphql"
+
+export const ADMIN_VIDEO_MAPPER_CATALOG_QUERY = adminGraphql(`
+  query VideoMapperCatalog($first: Int, $after: String) {
+    videoMapperCatalog(first: $first, after: $after) {
+      nodes {
+        coreId
+        sourceTitle
+        sourceTitleLocale
+        videoVariantId
+        adminVideoId
+        adminDubId
+        languageId
+        languageSlug
+        locale
+        editionCoreId
+        editionName
+        durationSeconds
+        lengthInMilliseconds
+        hlsUrl
+        dashUrl
+        shareUrl
+        downloadUrl
+        downloadQuality
+        downloadWidth
+        downloadHeight
+        mediaSourceType
+        mediaSourceUrl
+        videoPublished
+        dubPublished
+        videoNoIndex
+        videoDeleted
+        dubDeleted
+        deletedAt
+        indexable
+        nonIndexableReason
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`)
+
+export type AdminCatalogMediaSourceType = "DOWNLOAD" | "HLS" | "DASH" | "NONE"
+
+export type AdminCatalogItem = {
+  coreId: string
+  sourceTitle: string
+  sourceTitleLocale: string | null
+  videoVariantId: string
+  adminVideoId: string
+  adminDubId: string
+  languageId: string | null
+  languageSlug: string | null
+  locale: string | null
+  editionCoreId: string | null
+  editionName: string | null
+  durationSeconds: number | null
+  lengthInMilliseconds: string | null
+  hlsUrl: string | null
+  dashUrl: string | null
+  shareUrl: string | null
+  downloadUrl: string | null
+  downloadQuality: string | null
+  downloadWidth: number | null
+  downloadHeight: number | null
+  mediaSourceType: AdminCatalogMediaSourceType
+  mediaSourceUrl: string | null
+  videoPublished: boolean
+  dubPublished: boolean
+  videoNoIndex: boolean
+  videoDeleted: boolean
+  dubDeleted: boolean
+  deletedAt: string | null
+  indexable: boolean
+  nonIndexableReason: string | null
+}
+
+export type AdminCatalogPageInfo = {
+  startCursor: string | null
+  endCursor: string | null
+  hasNextPage: boolean
+}
+
+export type AdminCatalogPage = {
+  nodes: AdminCatalogItem[]
+  pageInfo: AdminCatalogPageInfo
+}
+
+export type AdminCatalogPageInput = {
+  first: number
+  after?: string | null
+}
+
+export type FetchLike = (
+  url: string,
+  init: {
+    method: "POST"
+    headers: Record<string, string>
+    body: string
+  },
+) => Promise<{
+  ok: boolean
+  status: number
+  text: () => Promise<string>
+}>
+
+export class AdminGraphqlClientError extends Error {
+  constructor(
+    message: string,
+    readonly code: "http_error" | "graphql_error" | "malformed_response",
+    readonly summary: Record<string, unknown>,
+  ) {
+    super(message)
+    this.name = "AdminGraphqlClientError"
+  }
+}
+
+export class AdminGraphqlClient {
+  private readonly fetchImpl: FetchLike
+
+  constructor(
+    private readonly config: {
+      url: string
+      bearerToken: string
+      fetchImpl?: FetchLike
+    },
+  ) {
+    const globalFetch = globalThis.fetch as unknown as FetchLike | undefined
+    const fetchImpl = config.fetchImpl ?? globalFetch
+    if (!fetchImpl) {
+      throw new AdminGraphqlClientError(
+        "Fetch is not available for Admin GraphQL requests",
+        "malformed_response",
+        { reason: "fetch_unavailable" },
+      )
+    }
+    this.fetchImpl = fetchImpl
+  }
+
+  async fetchCatalogPage({
+    first,
+    after,
+  }: AdminCatalogPageInput): Promise<AdminCatalogPage> {
+    const variables = {
+      first,
+      ...(after ? { after } : {}),
+    }
+    const response = await this.fetchImpl(this.config.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.config.bearerToken}`,
+      },
+      body: JSON.stringify({
+        query: print(ADMIN_VIDEO_MAPPER_CATALOG_QUERY),
+        variables,
+      }),
+    })
+
+    const body = await readJsonResponse(response, this.config.bearerToken)
+    if (!response.ok) {
+      throw new AdminGraphqlClientError(
+        `Admin GraphQL request failed with status ${response.status}`,
+        "http_error",
+        {
+          status: response.status,
+          body: summarizeValue(body, this.config.bearerToken),
+        },
+      )
+    }
+
+    if (hasGraphqlErrors(body)) {
+      throw new AdminGraphqlClientError(
+        "Admin GraphQL returned errors for videoMapperCatalog",
+        "graphql_error",
+        {
+          errors: body.errors.map((error) =>
+            summarizeValue(error, this.config.bearerToken),
+          ),
+        },
+      )
+    }
+
+    return parseCatalogPage(body)
+  }
+}
+
+async function readJsonResponse(
+  response: Awaited<ReturnType<FetchLike>>,
+  bearerToken: string,
+): Promise<unknown> {
+  const text = await response.text()
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    throw new AdminGraphqlClientError(
+      "Admin GraphQL returned a non-JSON response",
+      "malformed_response",
+      {
+        status: response.status,
+        body: truncate(redact(text, bearerToken)),
+      },
+    )
+  }
+}
+
+function hasGraphqlErrors(
+  body: unknown,
+): body is { errors: Array<Record<string, unknown>> } {
+  if (!isRecord(body)) return false
+  return Array.isArray(body.errors) && body.errors.length > 0
+}
+
+function parseCatalogPage(body: unknown): AdminCatalogPage {
+  if (!isRecord(body) || !isRecord(body.data)) {
+    throw malformedResponse("missing data.videoMapperCatalog")
+  }
+  const connection = body.data.videoMapperCatalog
+  if (!isRecord(connection)) {
+    throw malformedResponse("missing data.videoMapperCatalog")
+  }
+
+  if (!Array.isArray(connection.nodes)) {
+    throw malformedResponse("videoMapperCatalog.nodes must be an array")
+  }
+  const pageInfo = parsePageInfo(connection.pageInfo)
+
+  return {
+    nodes: connection.nodes.map((node, index) => parseCatalogItem(node, index)),
+    pageInfo,
+  }
+}
+
+function parsePageInfo(value: unknown): AdminCatalogPageInfo {
+  if (!isRecord(value)) {
+    throw malformedResponse("videoMapperCatalog.pageInfo is missing")
+  }
+  return {
+    startCursor: nullableString(value.startCursor, "pageInfo.startCursor"),
+    endCursor: nullableString(value.endCursor, "pageInfo.endCursor"),
+    hasNextPage: booleanValue(value.hasNextPage, "pageInfo.hasNextPage"),
+  }
+}
+
+function parseCatalogItem(value: unknown, index: number): AdminCatalogItem {
+  if (!isRecord(value)) {
+    throw malformedResponse(`videoMapperCatalog.nodes[${index}] is invalid`)
+  }
+
+  return {
+    coreId: requiredString(value.coreId, index, "coreId"),
+    sourceTitle: requiredString(value.sourceTitle, index, "sourceTitle"),
+    sourceTitleLocale: nullableString(
+      value.sourceTitleLocale,
+      `nodes[${index}].sourceTitleLocale`,
+    ),
+    videoVariantId: requiredString(
+      value.videoVariantId,
+      index,
+      "videoVariantId",
+    ),
+    adminVideoId: requiredString(value.adminVideoId, index, "adminVideoId"),
+    adminDubId: requiredString(value.adminDubId, index, "adminDubId"),
+    languageId: nullableString(value.languageId, `nodes[${index}].languageId`),
+    languageSlug: nullableString(
+      value.languageSlug,
+      `nodes[${index}].languageSlug`,
+    ),
+    locale: nullableString(value.locale, `nodes[${index}].locale`),
+    editionCoreId: nullableString(
+      value.editionCoreId,
+      `nodes[${index}].editionCoreId`,
+    ),
+    editionName: nullableString(
+      value.editionName,
+      `nodes[${index}].editionName`,
+    ),
+    durationSeconds: nullableNumber(
+      value.durationSeconds,
+      `nodes[${index}].durationSeconds`,
+    ),
+    lengthInMilliseconds: nullableString(
+      value.lengthInMilliseconds,
+      `nodes[${index}].lengthInMilliseconds`,
+    ),
+    hlsUrl: nullableString(value.hlsUrl, `nodes[${index}].hlsUrl`),
+    dashUrl: nullableString(value.dashUrl, `nodes[${index}].dashUrl`),
+    shareUrl: nullableString(value.shareUrl, `nodes[${index}].shareUrl`),
+    downloadUrl: nullableString(
+      value.downloadUrl,
+      `nodes[${index}].downloadUrl`,
+    ),
+    downloadQuality: nullableString(
+      value.downloadQuality,
+      `nodes[${index}].downloadQuality`,
+    ),
+    downloadWidth: nullableNumber(
+      value.downloadWidth,
+      `nodes[${index}].downloadWidth`,
+    ),
+    downloadHeight: nullableNumber(
+      value.downloadHeight,
+      `nodes[${index}].downloadHeight`,
+    ),
+    mediaSourceType: mediaSourceType(value.mediaSourceType, index),
+    mediaSourceUrl: nullableString(
+      value.mediaSourceUrl,
+      `nodes[${index}].mediaSourceUrl`,
+    ),
+    videoPublished: booleanValue(
+      value.videoPublished,
+      `nodes[${index}].videoPublished`,
+    ),
+    dubPublished: booleanValue(
+      value.dubPublished,
+      `nodes[${index}].dubPublished`,
+    ),
+    videoNoIndex: booleanValue(
+      value.videoNoIndex,
+      `nodes[${index}].videoNoIndex`,
+    ),
+    videoDeleted: booleanValue(
+      value.videoDeleted,
+      `nodes[${index}].videoDeleted`,
+    ),
+    dubDeleted: booleanValue(value.dubDeleted, `nodes[${index}].dubDeleted`),
+    deletedAt: nullableString(value.deletedAt, `nodes[${index}].deletedAt`),
+    indexable: booleanValue(value.indexable, `nodes[${index}].indexable`),
+    nonIndexableReason: nullableString(
+      value.nonIndexableReason,
+      `nodes[${index}].nonIndexableReason`,
+    ),
+  }
+}
+
+function requiredString(value: unknown, index: number, field: string): string {
+  if (typeof value === "string" && value.length > 0) return value
+  throw malformedResponse(`nodes[${index}].${field} must be a non-empty string`)
+}
+
+function nullableString(value: unknown, field: string): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === "string") return value
+  throw malformedResponse(`${field} must be a string or null`)
+}
+
+function nullableNumber(value: unknown, field: string): number | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  throw malformedResponse(`${field} must be a number or null`)
+}
+
+function booleanValue(value: unknown, field: string): boolean {
+  if (typeof value === "boolean") return value
+  throw malformedResponse(`${field} must be a boolean`)
+}
+
+function mediaSourceType(
+  value: unknown,
+  index: number,
+): AdminCatalogMediaSourceType {
+  if (
+    value === "DOWNLOAD" ||
+    value === "HLS" ||
+    value === "DASH" ||
+    value === "NONE"
+  ) {
+    return value
+  }
+  throw malformedResponse(`nodes[${index}].mediaSourceType is invalid`)
+}
+
+function malformedResponse(reason: string): AdminGraphqlClientError {
+  return new AdminGraphqlClientError(
+    "Admin GraphQL response did not match videoMapperCatalog shape",
+    "malformed_response",
+    { reason },
+  )
+}
+
+function summarizeValue(value: unknown, bearerToken: string): unknown {
+  if (typeof value === "string") return truncate(redact(value, bearerToken))
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value == null
+  ) {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 5).map((item) => summarizeValue(item, bearerToken))
+  }
+  if (!isRecord(value)) return String(value)
+
+  const summary: Record<string, unknown> = {}
+  for (const [key, item] of Object.entries(value).slice(0, 10)) {
+    if (key.toLowerCase().includes("authorization")) continue
+    summary[key] = summarizeValue(item, bearerToken)
+  }
+  return summary
+}
+
+function redact(value: string, bearerToken: string): string {
+  return bearerToken ? value.replaceAll(bearerToken, "[redacted]") : value
+}
+
+function truncate(value: string): string {
+  return value.length > 300 ? `${value.slice(0, 300)}...` : value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/apps/yt-video-mapper-backend/src/services/catalog-sync.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/catalog-sync.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from "vitest"
+import { AdminGraphqlClientError } from "./admin-graphql-client.js"
+import type {
+  AdminCatalogItem,
+  AdminCatalogPage,
+} from "./admin-graphql-client.js"
+import {
+  CatalogSyncService,
+  InMemoryCatalogRepository,
+  MISSING_FROM_ADMIN_REASON,
+  type AdminCatalogClient,
+} from "./catalog-sync.js"
+
+const syncStartedAt = new Date("2026-06-10T00:00:00.000Z")
+const syncFinishedAt = new Date("2026-06-10T00:01:00.000Z")
+
+describe("CatalogSyncService", () => {
+  it("pages through Admin catalog rows and records sync counters", async () => {
+    const repository = new InMemoryCatalogRepository()
+    const client = new StubAdminCatalogClient([
+      page({
+        nodes: [
+          item({ coreId: "core-1", videoVariantId: "variant-en" }),
+          item({
+            coreId: "core-2",
+            videoVariantId: "variant-fr",
+            indexable: false,
+            mediaSourceType: "NONE",
+            mediaSourceUrl: null,
+            nonIndexableReason: "video_unpublished",
+            videoPublished: false,
+          }),
+        ],
+        endCursor: "cursor-1",
+        hasNextPage: true,
+      }),
+      page({
+        nodes: [
+          item({
+            coreId: "core-1",
+            sourceTitle: "JESUS - Spanish",
+            sourceTitleLocale: "es",
+            videoVariantId: "variant-es",
+            adminDubId: "admin-dub-es",
+            languageSlug: "spanish",
+            locale: "es",
+          }),
+        ],
+        endCursor: "cursor-2",
+        hasNextPage: false,
+      }),
+    ])
+
+    const result = await createService({ client, repository }).syncCatalog()
+
+    expect(client.calls).toEqual([
+      { first: 2, after: null },
+      { first: 2, after: "cursor-1" },
+    ])
+    expect(result).toMatchObject({
+      status: "completed",
+      cursor: "cursor-2",
+      videosSeen: 2,
+      variantsSeen: 3,
+      variantsIndexable: 2,
+      missingVariantsMarked: 0,
+    })
+    expect(repository.videos.size).toBe(2)
+    expect(repository.variants.size).toBe(3)
+    expect(repository.variants.get("core-1:variant-es")).toMatchObject({
+      coreId: "core-1",
+      videoVariantId: "variant-es",
+      languageSlug: "spanish",
+      locale: "es",
+      indexable: true,
+    })
+  })
+
+  it("reruns idempotently without duplicating videos or variants", async () => {
+    const repository = new InMemoryCatalogRepository()
+    await createService({
+      repository,
+      client: new StubAdminCatalogClient([
+        page({
+          nodes: [item({ sourceTitle: "Original title" })],
+          endCursor: "cursor-1",
+          hasNextPage: false,
+        }),
+      ]),
+    }).syncCatalog()
+
+    await createService({
+      repository,
+      client: new StubAdminCatalogClient([
+        page({
+          nodes: [
+            item({
+              sourceTitle: "Updated title",
+              adminDubId: "admin-dub-updated",
+              downloadQuality: "720p",
+            }),
+          ],
+          endCursor: "cursor-2",
+          hasNextPage: false,
+        }),
+      ]),
+    }).syncCatalog()
+
+    expect(repository.videos.size).toBe(1)
+    expect(repository.variants.size).toBe(1)
+    expect(repository.videos.get("core-video-1")).toMatchObject({
+      title: "Updated title",
+    })
+    expect(repository.variants.get("core-video-1:variant-en")).toMatchObject({
+      adminDubId: "admin-dub-updated",
+      downloadQuality: "720p",
+    })
+  })
+
+  it("preserves Admin indexable and non-indexable state on variants", async () => {
+    const repository = new InMemoryCatalogRepository()
+    await createService({
+      repository,
+      client: new StubAdminCatalogClient([
+        page({
+          nodes: [
+            item({
+              indexable: false,
+              nonIndexableReason: "media_missing",
+              mediaSourceType: "NONE",
+              mediaSourceUrl: null,
+              videoPublished: true,
+              dubPublished: false,
+              videoNoIndex: true,
+              videoDeleted: true,
+              dubDeleted: true,
+              deletedAt: "2026-06-09T00:00:00.000Z",
+            }),
+          ],
+          endCursor: "cursor-1",
+          hasNextPage: false,
+        }),
+      ]),
+    }).syncCatalog()
+
+    expect(repository.variants.get("core-video-1:variant-en")).toMatchObject({
+      indexable: false,
+      nonIndexableReason: "media_missing",
+      mediaSourceType: "NONE",
+      mediaSourceUrl: null,
+      published: false,
+      videoPublished: true,
+      dubPublished: false,
+      videoNoIndex: true,
+      videoDeleted: true,
+      dubDeleted: true,
+      deletedAt: new Date("2026-06-09T00:00:00.000Z"),
+    })
+  })
+
+  it("records failed page summaries with the last successful cursor", async () => {
+    const repository = new InMemoryCatalogRepository()
+    const client = new StubAdminCatalogClient([
+      page({
+        nodes: [item()],
+        endCursor: "cursor-1",
+        hasNextPage: true,
+      }),
+      new AdminGraphqlClientError(
+        "Admin GraphQL returned errors for videoMapperCatalog",
+        "graphql_error",
+        { errors: [{ message: "BAD_USER_INPUT" }] },
+      ),
+    ])
+
+    const result = await createService({ client, repository }).syncCatalog()
+
+    expect(result).toMatchObject({
+      status: "failed",
+      cursor: "cursor-1",
+      videosSeen: 1,
+      variantsSeen: 1,
+      variantsIndexable: 1,
+      missingVariantsMarked: 0,
+      failureSummary: {
+        code: "graphql_error",
+        cursor: "cursor-1",
+        page: 1,
+        details: { errors: [{ message: "BAD_USER_INPUT" }] },
+      },
+    })
+  })
+
+  it("summarizes malformed rows without dumping payloads or media URLs", async () => {
+    const repository = new InMemoryCatalogRepository()
+    const client = new StubAdminCatalogClient([
+      page({
+        nodes: [
+          {
+            ...item({
+              coreId: "",
+              mediaSourceUrl: "https://media.example.com/private.mp4",
+            }),
+          } as AdminCatalogItem,
+        ],
+        endCursor: "cursor-1",
+        hasNextPage: false,
+      }),
+    ])
+
+    const result = await createService({ client, repository }).syncCatalog()
+
+    expect(result).toMatchObject({
+      status: "failed",
+      variantsSeen: 0,
+      failureSummary: {
+        code: "malformed_catalog_rows",
+        malformedRows: [
+          {
+            index: 0,
+            reason: "coreId is required",
+            videoVariantId: "variant-en",
+            adminDubId: "admin-dub-1",
+          },
+        ],
+      },
+    })
+    expect(repository.variants.size).toBe(0)
+    expect(JSON.stringify(result.failureSummary)).not.toContain(
+      "https://media.example.com/private.mp4",
+    )
+  })
+
+  it("marks variants missing from a completed Admin snapshot as non-indexable", async () => {
+    const repository = new InMemoryCatalogRepository()
+    await repository.upsertCatalogVideo({
+      coreId: "stale-core",
+      title: "Stale",
+      titleLocale: "en",
+      included: true,
+      lastSyncedAt: new Date("2026-06-09T00:00:00.000Z"),
+    })
+    await repository.upsertCatalogVariant({
+      coreId: "stale-core",
+      videoVariantId: "stale-variant",
+      adminVideoId: "admin-video-stale",
+      adminDubId: "admin-dub-stale",
+      editionCoreId: null,
+      editionName: null,
+      languageId: null,
+      languageSlug: null,
+      locale: null,
+      durationSeconds: null,
+      lengthInMilliseconds: null,
+      hlsUrl: null,
+      dashUrl: null,
+      downloadUrl: null,
+      downloadQuality: null,
+      downloadWidth: null,
+      downloadHeight: null,
+      mediaSourceType: "DOWNLOAD",
+      mediaSourceUrl: "https://media.example.com/stale.mp4",
+      indexable: true,
+      nonIndexableReason: null,
+      published: true,
+      videoPublished: true,
+      dubPublished: true,
+      videoNoIndex: false,
+      videoDeleted: false,
+      dubDeleted: false,
+      deletedAt: null,
+      lastSyncedAt: new Date("2026-06-09T00:00:00.000Z"),
+    })
+
+    const result = await createService({
+      repository,
+      client: new StubAdminCatalogClient([
+        page({ nodes: [], endCursor: null, hasNextPage: false }),
+      ]),
+    }).syncCatalog()
+
+    expect(result).toMatchObject({
+      status: "completed",
+      missingVariantsMarked: 1,
+    })
+    expect(repository.variants.get("stale-core:stale-variant")).toMatchObject({
+      indexable: false,
+      nonIndexableReason: MISSING_FROM_ADMIN_REASON,
+      published: false,
+      dubPublished: false,
+      lastSyncedAt: syncStartedAt,
+    })
+  })
+})
+
+function createService({
+  client,
+  repository = new InMemoryCatalogRepository(),
+}: {
+  client: AdminCatalogClient
+  repository?: InMemoryCatalogRepository
+}) {
+  const dates = [syncStartedAt, syncFinishedAt]
+  return new CatalogSyncService({
+    client,
+    repository,
+    pageSize: 2,
+    now: () => dates.shift() ?? syncFinishedAt,
+  })
+}
+
+class StubAdminCatalogClient implements AdminCatalogClient {
+  readonly calls: Array<{ first: number; after: string | null }> = []
+
+  constructor(
+    private readonly results: Array<AdminCatalogPage | AdminGraphqlClientError>,
+  ) {}
+
+  async fetchCatalogPage(input: {
+    first: number
+    after?: string | null
+  }): Promise<AdminCatalogPage> {
+    this.calls.push({ first: input.first, after: input.after ?? null })
+    const result = this.results.shift()
+    if (!result) throw new Error("No stub catalog page configured")
+    if (result instanceof AdminGraphqlClientError) throw result
+    return result
+  }
+}
+
+function page({
+  nodes,
+  endCursor,
+  hasNextPage,
+}: {
+  nodes: AdminCatalogItem[]
+  endCursor: string | null
+  hasNextPage: boolean
+}): AdminCatalogPage {
+  return {
+    nodes,
+    pageInfo: {
+      startCursor: nodes.length > 0 ? "start-cursor" : null,
+      endCursor,
+      hasNextPage,
+    },
+  }
+}
+
+function item(overrides: Partial<AdminCatalogItem> = {}): AdminCatalogItem {
+  return {
+    coreId: "core-video-1",
+    sourceTitle: "JESUS",
+    sourceTitleLocale: "en",
+    videoVariantId: "variant-en",
+    adminVideoId: "admin-video-1",
+    adminDubId: "admin-dub-1",
+    languageId: "lang-core-en",
+    languageSlug: "english",
+    locale: "en",
+    editionCoreId: "edition-core-1",
+    editionName: "Feature",
+    durationSeconds: 120,
+    lengthInMilliseconds: "120000",
+    hlsUrl: "https://media.example.com/video.m3u8",
+    dashUrl: null,
+    shareUrl: "https://share.example.com/video",
+    downloadUrl: "https://media.example.com/video.mp4",
+    downloadQuality: "1080p",
+    downloadWidth: 1920,
+    downloadHeight: 1080,
+    mediaSourceType: "DOWNLOAD",
+    mediaSourceUrl: "https://media.example.com/video.mp4",
+    videoPublished: true,
+    dubPublished: true,
+    videoNoIndex: false,
+    videoDeleted: false,
+    dubDeleted: false,
+    deletedAt: null,
+    indexable: true,
+    nonIndexableReason: null,
+    ...overrides,
+  }
+}

--- a/apps/yt-video-mapper-backend/src/services/catalog-sync.ts
+++ b/apps/yt-video-mapper-backend/src/services/catalog-sync.ts
@@ -1,0 +1,616 @@
+import {
+  CatalogRunStatus as PrismaCatalogRunStatus,
+  MediaSourceType as PrismaMediaSourceType,
+  Prisma,
+  type CatalogSyncRun,
+  type PrismaClient,
+} from "../generated/prisma/index.js"
+import {
+  AdminGraphqlClientError,
+  type AdminCatalogItem,
+  type AdminCatalogPage,
+  type AdminCatalogPageInput,
+  type AdminCatalogMediaSourceType,
+} from "./admin-graphql-client.js"
+
+export const MISSING_FROM_ADMIN_REASON = "missing_from_admin"
+
+export type CatalogSyncStatus = "running" | "completed" | "failed"
+
+export type CatalogSyncRunRecord = {
+  id: string
+  status: CatalogSyncStatus
+  cursor: string | null
+  videosSeen: number
+  variantsSeen: number
+  variantsIndexable: number
+  failureSummary: CatalogSyncFailureSummary | null
+  startedAt: Date
+  completedAt: Date | null
+}
+
+export type CatalogSyncFailureSummary = {
+  code: string
+  message: string
+  cursor: string | null
+  page: number
+  details?: unknown
+  malformedRows?: CatalogSyncMalformedRowSummary[]
+}
+
+export type CatalogSyncMalformedRowSummary = {
+  index: number
+  reason: string
+  coreId?: string
+  videoVariantId?: string
+  adminDubId?: string
+}
+
+export type CatalogSyncResult = CatalogSyncRunRecord & {
+  missingVariantsMarked: number
+}
+
+export type AdminCatalogClient = {
+  fetchCatalogPage(input: AdminCatalogPageInput): Promise<AdminCatalogPage>
+}
+
+export type CatalogRepository = {
+  createSyncRun(input: { startedAt: Date }): Promise<CatalogSyncRunRecord>
+  updateSyncRun(
+    id: string,
+    patch: Partial<
+      Pick<
+        CatalogSyncRunRecord,
+        | "status"
+        | "cursor"
+        | "videosSeen"
+        | "variantsSeen"
+        | "variantsIndexable"
+        | "failureSummary"
+        | "completedAt"
+      >
+    >,
+  ): Promise<CatalogSyncRunRecord>
+  upsertCatalogVideo(input: CatalogVideoSyncInput): Promise<void>
+  upsertCatalogVariant(input: CatalogVariantSyncInput): Promise<void>
+  markVariantsMissingFromSync(input: {
+    syncedAt: Date
+    reason: string
+  }): Promise<number>
+}
+
+export type CatalogVideoSyncInput = {
+  coreId: string
+  title: string
+  titleLocale: string | null
+  included: boolean
+  lastSyncedAt: Date
+}
+
+export type CatalogVariantSyncInput = {
+  coreId: string
+  videoVariantId: string
+  adminVideoId: string
+  adminDubId: string
+  editionCoreId: string | null
+  editionName: string | null
+  languageId: string | null
+  languageSlug: string | null
+  locale: string | null
+  durationSeconds: number | null
+  lengthInMilliseconds: bigint | null
+  hlsUrl: string | null
+  dashUrl: string | null
+  downloadUrl: string | null
+  downloadQuality: string | null
+  downloadWidth: number | null
+  downloadHeight: number | null
+  mediaSourceType: AdminCatalogMediaSourceType
+  mediaSourceUrl: string | null
+  indexable: boolean
+  nonIndexableReason: string | null
+  published: boolean
+  videoPublished: boolean
+  dubPublished: boolean
+  videoNoIndex: boolean
+  videoDeleted: boolean
+  dubDeleted: boolean
+  deletedAt: Date | null
+  lastSyncedAt: Date
+}
+
+export class CatalogSyncService {
+  constructor(
+    private readonly options: {
+      client: AdminCatalogClient
+      repository: CatalogRepository
+      pageSize?: number
+      now?: () => Date
+    },
+  ) {}
+
+  async syncCatalog(): Promise<CatalogSyncResult> {
+    const now = this.options.now ?? (() => new Date())
+    const syncedAt = now()
+    const run = await this.options.repository.createSyncRun({
+      startedAt: syncedAt,
+    })
+    const seenVideoCoreIds = new Set<string>()
+    let cursor: string | null = null
+    let variantsSeen = 0
+    let variantsIndexable = 0
+    let page = 0
+    let currentRun = run
+
+    try {
+      while (true) {
+        const adminPage = await this.options.client.fetchCatalogPage({
+          first: this.options.pageSize ?? 100,
+          after: cursor,
+        })
+        if (adminPage.pageInfo.hasNextPage && !adminPage.pageInfo.endCursor) {
+          throw new CatalogSyncMalformedRowsError([
+            {
+              index: -1,
+              reason: "pageInfo.endCursor is required when hasNextPage=true",
+            },
+          ])
+        }
+        const validatedRows = validateCatalogRows(adminPage.nodes)
+        const pageVideoInputs = new Map<string, CatalogVideoSyncInput>()
+        const pageVariantInputs: CatalogVariantSyncInput[] = []
+
+        for (const row of validatedRows) {
+          pageVideoInputs.set(row.coreId, {
+            coreId: row.coreId,
+            title: row.sourceTitle,
+            titleLocale: row.sourceTitleLocale,
+            included: true,
+            lastSyncedAt: syncedAt,
+          })
+          pageVariantInputs.push({
+            ...toCatalogVariantSyncInput(row),
+            lastSyncedAt: syncedAt,
+          })
+        }
+
+        await Promise.all(
+          [...pageVideoInputs.values()].map((input) =>
+            this.options.repository.upsertCatalogVideo(input),
+          ),
+        )
+        await Promise.all(
+          pageVariantInputs.map((input) =>
+            this.options.repository.upsertCatalogVariant(input),
+          ),
+        )
+
+        for (const row of validatedRows) {
+          seenVideoCoreIds.add(row.coreId)
+          if (row.indexable) variantsIndexable += 1
+        }
+        variantsSeen += validatedRows.length
+
+        cursor = adminPage.pageInfo.endCursor
+        currentRun = await this.options.repository.updateSyncRun(run.id, {
+          cursor,
+          videosSeen: seenVideoCoreIds.size,
+          variantsSeen,
+          variantsIndexable,
+        })
+
+        page += 1
+        if (!adminPage.pageInfo.hasNextPage) break
+      }
+
+      const missingVariantsMarked =
+        await this.options.repository.markVariantsMissingFromSync({
+          syncedAt,
+          reason: MISSING_FROM_ADMIN_REASON,
+        })
+      currentRun = await this.options.repository.updateSyncRun(run.id, {
+        status: "completed",
+        completedAt: now(),
+      })
+
+      return {
+        ...currentRun,
+        missingVariantsMarked,
+      }
+    } catch (error) {
+      currentRun = await this.options.repository.updateSyncRun(run.id, {
+        status: "failed",
+        cursor,
+        videosSeen: seenVideoCoreIds.size,
+        variantsSeen,
+        variantsIndexable,
+        completedAt: now(),
+        failureSummary: toFailureSummary(error, {
+          cursor,
+          page,
+        }),
+      })
+
+      return {
+        ...currentRun,
+        missingVariantsMarked: 0,
+      }
+    }
+  }
+}
+
+export class PrismaCatalogRepository implements CatalogRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async createSyncRun({
+    startedAt,
+  }: {
+    startedAt: Date
+  }): Promise<CatalogSyncRunRecord> {
+    const run = await this.db.catalogSyncRun.create({
+      data: {
+        status: PrismaCatalogRunStatus.RUNNING,
+        startedAt,
+      },
+    })
+
+    return fromPrismaSyncRun(run)
+  }
+
+  async updateSyncRun(
+    id: string,
+    patch: Parameters<CatalogRepository["updateSyncRun"]>[1],
+  ): Promise<CatalogSyncRunRecord> {
+    const run = await this.db.catalogSyncRun.update({
+      where: { id },
+      data: {
+        status: patch.status ? toPrismaRunStatus(patch.status) : undefined,
+        cursor: patch.cursor,
+        videosSeen: patch.videosSeen,
+        variantsSeen: patch.variantsSeen,
+        variantsIndexable: patch.variantsIndexable,
+        failureSummary: patch.failureSummary
+          ? (patch.failureSummary as Prisma.InputJsonValue)
+          : undefined,
+        completedAt: patch.completedAt,
+      },
+    })
+
+    return fromPrismaSyncRun(run)
+  }
+
+  async upsertCatalogVideo(input: CatalogVideoSyncInput): Promise<void> {
+    await this.db.catalogVideo.upsert({
+      where: { coreId: input.coreId },
+      create: input,
+      update: {
+        title: input.title,
+        titleLocale: input.titleLocale,
+        included: input.included,
+        lastSyncedAt: input.lastSyncedAt,
+      },
+    })
+  }
+
+  async upsertCatalogVariant(input: CatalogVariantSyncInput): Promise<void> {
+    const data = {
+      ...input,
+      mediaSourceType: toPrismaMediaSourceType(input.mediaSourceType),
+    }
+    await this.db.catalogVariant.upsert({
+      where: {
+        coreId_videoVariantId: {
+          coreId: input.coreId,
+          videoVariantId: input.videoVariantId,
+        },
+      },
+      create: data,
+      update: data,
+    })
+  }
+
+  async markVariantsMissingFromSync({
+    syncedAt,
+    reason,
+  }: {
+    syncedAt: Date
+    reason: string
+  }): Promise<number> {
+    const updated = await this.db.catalogVariant.updateMany({
+      where: {
+        OR: [{ lastSyncedAt: null }, { lastSyncedAt: { lt: syncedAt } }],
+      },
+      data: {
+        indexable: false,
+        nonIndexableReason: reason,
+        published: false,
+        dubPublished: false,
+        lastSyncedAt: syncedAt,
+      },
+    })
+
+    return updated.count
+  }
+}
+
+export class InMemoryCatalogRepository implements CatalogRepository {
+  readonly videos = new Map<string, CatalogVideoSyncInput>()
+  readonly variants = new Map<string, CatalogVariantSyncInput>()
+  readonly runs = new Map<string, CatalogSyncRunRecord>()
+  private nextRunNumber = 1
+
+  async createSyncRun({
+    startedAt,
+  }: {
+    startedAt: Date
+  }): Promise<CatalogSyncRunRecord> {
+    const run: CatalogSyncRunRecord = {
+      id: `catalog-sync-run-${this.nextRunNumber++}`,
+      status: "running",
+      cursor: null,
+      videosSeen: 0,
+      variantsSeen: 0,
+      variantsIndexable: 0,
+      failureSummary: null,
+      startedAt,
+      completedAt: null,
+    }
+    this.runs.set(run.id, cloneRun(run))
+    return cloneRun(run)
+  }
+
+  async updateSyncRun(
+    id: string,
+    patch: Parameters<CatalogRepository["updateSyncRun"]>[1],
+  ): Promise<CatalogSyncRunRecord> {
+    const run = this.runs.get(id)
+    if (!run) throw new Error(`CatalogSyncRun not found: ${id}`)
+
+    const updated = {
+      ...run,
+      ...patch,
+    }
+    this.runs.set(id, cloneRun(updated))
+    return cloneRun(updated)
+  }
+
+  async upsertCatalogVideo(input: CatalogVideoSyncInput): Promise<void> {
+    this.videos.set(input.coreId, { ...input })
+  }
+
+  async upsertCatalogVariant(input: CatalogVariantSyncInput): Promise<void> {
+    this.variants.set(variantKey(input), { ...input })
+  }
+
+  async markVariantsMissingFromSync({
+    syncedAt,
+    reason,
+  }: {
+    syncedAt: Date
+    reason: string
+  }): Promise<number> {
+    let count = 0
+    for (const [key, variant] of this.variants.entries()) {
+      if (variant.lastSyncedAt >= syncedAt) continue
+      this.variants.set(key, {
+        ...variant,
+        indexable: false,
+        nonIndexableReason: reason,
+        published: false,
+        dubPublished: false,
+        lastSyncedAt: syncedAt,
+      })
+      count += 1
+    }
+    return count
+  }
+}
+
+function validateCatalogRows(rows: AdminCatalogItem[]): AdminCatalogItem[] {
+  const malformedRows = rows.flatMap((row, index) => {
+    const reason = validateCatalogRow(row)
+    return reason == null ? [] : [summarizeMalformedRow(row, index, reason)]
+  })
+
+  if (malformedRows.length > 0) {
+    throw new CatalogSyncMalformedRowsError(malformedRows)
+  }
+
+  return rows
+}
+
+function validateCatalogRow(row: AdminCatalogItem): string | null {
+  if (!row.coreId) return "coreId is required"
+  if (!row.sourceTitle) return "sourceTitle is required"
+  if (!row.videoVariantId) return "videoVariantId is required"
+  if (!row.adminVideoId) return "adminVideoId is required"
+  if (!row.adminDubId) return "adminDubId is required"
+  if (row.durationSeconds !== null && !Number.isInteger(row.durationSeconds)) {
+    return "durationSeconds must be an integer or null"
+  }
+  if (
+    row.lengthInMilliseconds !== null &&
+    !/^\d+$/.test(row.lengthInMilliseconds)
+  ) {
+    return "lengthInMilliseconds must be a positive integer string or null"
+  }
+  if (row.indexable && row.mediaSourceUrl == null) {
+    return "indexable variants must include mediaSourceUrl"
+  }
+  if (!row.indexable && !row.nonIndexableReason) {
+    return "non-indexable variants must include nonIndexableReason"
+  }
+  if (
+    row.deletedAt !== null &&
+    Number.isNaN(new Date(row.deletedAt).getTime())
+  ) {
+    return "deletedAt must be an ISO timestamp or null"
+  }
+  return null
+}
+
+function toCatalogVariantSyncInput(
+  row: AdminCatalogItem,
+): Omit<CatalogVariantSyncInput, "lastSyncedAt"> {
+  return {
+    coreId: row.coreId,
+    videoVariantId: row.videoVariantId,
+    adminVideoId: row.adminVideoId,
+    adminDubId: row.adminDubId,
+    editionCoreId: row.editionCoreId,
+    editionName: row.editionName,
+    languageId: row.languageId,
+    languageSlug: row.languageSlug,
+    locale: row.locale,
+    durationSeconds: row.durationSeconds,
+    lengthInMilliseconds:
+      row.lengthInMilliseconds == null
+        ? null
+        : BigInt(row.lengthInMilliseconds),
+    hlsUrl: row.hlsUrl,
+    dashUrl: row.dashUrl,
+    downloadUrl: row.downloadUrl,
+    downloadQuality: row.downloadQuality,
+    downloadWidth: row.downloadWidth,
+    downloadHeight: row.downloadHeight,
+    mediaSourceType: row.mediaSourceType,
+    mediaSourceUrl: row.mediaSourceUrl,
+    indexable: row.indexable,
+    nonIndexableReason: row.nonIndexableReason,
+    published: row.dubPublished,
+    videoPublished: row.videoPublished,
+    dubPublished: row.dubPublished,
+    videoNoIndex: row.videoNoIndex,
+    videoDeleted: row.videoDeleted,
+    dubDeleted: row.dubDeleted,
+    deletedAt: row.deletedAt == null ? null : new Date(row.deletedAt),
+  }
+}
+
+function toFailureSummary(
+  error: unknown,
+  context: {
+    cursor: string | null
+    page: number
+  },
+): CatalogSyncFailureSummary {
+  if (error instanceof CatalogSyncMalformedRowsError) {
+    return {
+      code: "malformed_catalog_rows",
+      message: "Admin catalog page contained malformed rows",
+      cursor: context.cursor,
+      page: context.page,
+      malformedRows: error.rows,
+    }
+  }
+
+  if (error instanceof AdminGraphqlClientError) {
+    return {
+      code: error.code,
+      message: error.message,
+      cursor: context.cursor,
+      page: context.page,
+      details: error.summary,
+    }
+  }
+
+  return {
+    code: "catalog_sync_failed",
+    message: safeErrorMessage(error),
+    cursor: context.cursor,
+    page: context.page,
+  }
+}
+
+function summarizeMalformedRow(
+  row: AdminCatalogItem,
+  index: number,
+  reason: string,
+): CatalogSyncMalformedRowSummary {
+  return {
+    index,
+    reason,
+    ...safeIdentifier("coreId", row.coreId),
+    ...safeIdentifier("videoVariantId", row.videoVariantId),
+    ...safeIdentifier("adminDubId", row.adminDubId),
+  }
+}
+
+function safeIdentifier(key: string, value: unknown): Record<string, string> {
+  if (typeof value !== "string" || value.length === 0) return {}
+  return { [key]: value.slice(0, 120) }
+}
+
+function safeErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message.slice(0, 300)
+  return String(error).slice(0, 300)
+}
+
+class CatalogSyncMalformedRowsError extends Error {
+  constructor(readonly rows: CatalogSyncMalformedRowSummary[]) {
+    super("Admin catalog page contained malformed rows")
+    this.name = "CatalogSyncMalformedRowsError"
+  }
+}
+
+function fromPrismaSyncRun(run: CatalogSyncRun): CatalogSyncRunRecord {
+  return {
+    id: run.id,
+    status: fromPrismaRunStatus(run.status),
+    cursor: run.cursor,
+    videosSeen: run.videosSeen,
+    variantsSeen: run.variantsSeen,
+    variantsIndexable: run.variantsIndexable,
+    failureSummary: run.failureSummary as CatalogSyncFailureSummary | null,
+    startedAt: run.startedAt,
+    completedAt: run.completedAt,
+  }
+}
+
+function toPrismaRunStatus(status: CatalogSyncStatus): PrismaCatalogRunStatus {
+  const map = {
+    running: PrismaCatalogRunStatus.RUNNING,
+    completed: PrismaCatalogRunStatus.COMPLETED,
+    failed: PrismaCatalogRunStatus.FAILED,
+  } satisfies Record<CatalogSyncStatus, PrismaCatalogRunStatus>
+
+  return map[status]
+}
+
+function fromPrismaRunStatus(
+  status: PrismaCatalogRunStatus,
+): CatalogSyncStatus {
+  const map = {
+    [PrismaCatalogRunStatus.RUNNING]: "running",
+    [PrismaCatalogRunStatus.COMPLETED]: "completed",
+    [PrismaCatalogRunStatus.FAILED]: "failed",
+  } satisfies Record<PrismaCatalogRunStatus, CatalogSyncStatus>
+
+  return map[status]
+}
+
+function toPrismaMediaSourceType(
+  sourceType: AdminCatalogMediaSourceType,
+): PrismaMediaSourceType {
+  const map = {
+    DOWNLOAD: PrismaMediaSourceType.DOWNLOAD,
+    HLS: PrismaMediaSourceType.HLS,
+    DASH: PrismaMediaSourceType.DASH,
+    NONE: PrismaMediaSourceType.NONE,
+  } satisfies Record<AdminCatalogMediaSourceType, PrismaMediaSourceType>
+
+  return map[sourceType]
+}
+
+function variantKey(input: { coreId: string; videoVariantId: string }) {
+  return `${input.coreId}:${input.videoVariantId}`
+}
+
+function cloneRun(run: CatalogSyncRunRecord): CatalogSyncRunRecord {
+  return {
+    ...run,
+    failureSummary: run.failureSummary
+      ? JSON.parse(JSON.stringify(run.failureSummary))
+      : null,
+  }
+}

--- a/docs/plans/2026-06-10-001-feat-mapper-catalog-sync-plan.md
+++ b/docs/plans/2026-06-10-001-feat-mapper-catalog-sync-plan.md
@@ -1,0 +1,309 @@
+---
+title: "feat: Add mapper catalog sync"
+type: feat
+status: completed
+date: 2026-06-10
+origin: apps/yt-video-mapper-backend/docs/brainstorms/video-source-mapper-requirements.md
+ticket: docs/prototypes/yt-video-mapper/tickets/ytm-003-mapper-catalog-sync.md
+---
+
+# feat: Add mapper catalog sync
+
+## Summary
+
+Implement YTM-003 by syncing Admin's `videoMapperCatalog(first, after)` GraphQL
+projection into mapper-owned catalog tables. The mapper will keep a local,
+idempotent projection keyed by `coreId` and `coreId + videoVariantId`, record
+sync-run progress and failures, and leave official media signature generation
+for YTM-004.
+
+---
+
+## Problem Frame
+
+YTM-001 gave `apps/yt-video-mapper-backend` durable Postgres-backed state, and
+YTM-002 added the Admin projection that exposes the broad catalog through a
+bounded, service-authorized GraphQL query. The mapper now needs to consume that
+projection without direct Admin database reads so matching and indexing can
+work against local rows while Admin remains the source of truth.
+
+The current mapper schema already includes initial catalog models, but the sync
+implementation is missing and the variant rows need to preserve the Admin
+projection's publication, deletion, no-index, indexability, and diagnostic
+fields precisely enough for later indexing decisions.
+
+---
+
+## Requirements
+
+- R1. Read catalog data only through Admin `videoMapperCatalog(first, after)`.
+- R2. Validate mapper configuration for `ADMIN_GRAPHQL_URL` and
+  `ADMIN_SERVICE_BEARER_TOKEN` when a catalog sync is executed.
+- R3. Upsert `CatalogVideo` by `coreId`, storing selected title and title
+  locale for a local Core ID title map.
+- R4. Upsert `CatalogVariant` by `coreId + videoVariantId`, storing language,
+  locale, edition, duration, media source, Admin debug IDs, and indexability
+  state.
+- R5. Mark deleted, missing, or non-indexable variants safely instead of
+  hard-deleting local rows during normal sync.
+- R6. Record each `CatalogSyncRun` with status, counters, cursor,
+  started/finished timestamps, and a safe failure summary.
+- R7. Make sync repeated-run safe: no duplicate videos, variants, or sync-side
+  state when Admin returns the same rows again.
+- R8. Preserve enough cursor and row-error context to retry after failed pages
+  or malformed rows without storing secrets or large payloads.
+- R9. Cover pagination, idempotent upserts, indexability mapping, run counters,
+  safe failures, and env/config validation with focused tests.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant Job as Catalog sync service
+  participant Client as Admin GraphQL client
+  participant Admin as Admin videoMapperCatalog
+  participant DB as Mapper Postgres
+
+  Job->>DB: create CatalogSyncRun(status=RUNNING)
+  loop while pageInfo.hasNextPage
+    Job->>Client: fetch page(first, cursor)
+    Client->>Admin: GraphQL with service bearer
+    Admin-->>Client: nodes + pageInfo
+    Client-->>Job: validated page
+    Job->>DB: upsert CatalogVideo by coreId
+    Job->>DB: upsert CatalogVariant by coreId + videoVariantId
+    Job->>DB: update cursor and counters
+  end
+  Job->>DB: mark missing local variants non-indexable
+  Job->>DB: mark CatalogSyncRun COMPLETED
+```
+
+The sync boundary is service-layer code. Routes may call the service later, but
+the first YTM-003 implementation should be runnable and testable without adding
+public HTTP surface area.
+
+---
+
+## Key Technical Decisions
+
+- **Use a small local Admin GraphQL client.** The mapper app does not currently
+  consume generated Admin GraphQL packages, and YTM-003 only needs one
+  operation. A local typed client with injectable `fetch` keeps tests tight
+  while preserving the GraphQL-only boundary.
+- **Require Admin credentials at sync time, not generic server boot.** Production
+  upload/poll endpoints should not fail to start because catalog sync is not
+  configured, but running the sync without `ADMIN_GRAPHQL_URL` or
+  `ADMIN_SERVICE_BEARER_TOKEN` must fail clearly.
+- **Persist the full indexability decision from Admin.** Store both booleans
+  such as published/deleted/no-index and `nonIndexableReason` so YTM-004 can
+  skip safely without re-deriving Admin policy locally.
+- **Keep normal sync non-destructive.** Rows missing from a completed snapshot
+  are marked non-indexable with a local reason rather than deleted, preserving
+  candidate/evidence foreign keys and diagnostic history.
+- **Treat failure summaries as diagnostic envelopes.** Store error class,
+  message, cursor, page index, and a bounded set of malformed-row identifiers;
+  do not store bearer tokens, media URLs in bulk, or whole row payloads.
+
+---
+
+## Implementation Units
+
+### U1. Config and Schema Alignment
+
+**Goal:** Align mapper configuration and catalog models with the YTM-003 sync
+contract.
+
+**Requirements:** R2, R4, R5, R6, R9.
+
+**Dependencies:** None.
+
+**Files:**
+
+- `apps/yt-video-mapper-backend/prisma/schema.prisma`
+- `apps/yt-video-mapper-backend/prisma/migrations/*/migration.sql`
+- `apps/yt-video-mapper-backend/src/config/env.ts`
+- `apps/yt-video-mapper-backend/src/config/env.test.ts`
+- `apps/yt-video-mapper-backend/src/db/schema.test.ts`
+- `apps/yt-video-mapper-backend/.env.example`
+
+**Approach:** Add any catalog fields missing from the Admin projection:
+`editionName`, separate video/dub published flags, video no-index, video/dub
+deleted flags, and a sync-safe missing/non-indexable representation. Keep
+`CatalogVideo.coreId` unique and make the active variant identity the composite
+`coreId + videoVariantId`. Add a config helper that asserts Admin sync env only
+when the sync path runs.
+
+**Patterns to Follow:** Existing `RuntimeEnvError` validation in
+`src/config/env.ts`; existing schema snapshot tests in `src/db/schema.test.ts`;
+the Core-facing terminology in `CONCEPTS.md`.
+
+**Test Scenarios:**
+
+- Loading env with blank Admin sync vars leaves the regular app bootable.
+- Calling the catalog-sync env assertion without `ADMIN_GRAPHQL_URL` fails with
+  a safe missing-var message.
+- Calling the assertion without `ADMIN_SERVICE_BEARER_TOKEN` fails with a safe
+  missing-var message.
+- Schema tests assert variant rows carry Admin debug IDs, source media fields,
+  publication/deletion/no-index fields, and the composite variant key.
+
+**Verification:** Type generation reflects the updated schema, config tests pass,
+and schema assertions describe the intended catalog identity model.
+
+### U2. Admin GraphQL Client
+
+**Goal:** Add a testable client for Admin `videoMapperCatalog(first, after)`.
+
+**Requirements:** R1, R2, R8, R9.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `apps/yt-video-mapper-backend/src/services/admin-graphql-client.ts`
+- `apps/yt-video-mapper-backend/src/services/admin-graphql-client.test.ts`
+
+**Approach:** Implement one GraphQL operation with typed result parsing,
+injectable `fetch`, service bearer header injection, cursor/page-size arguments,
+and safe error normalization. Treat GraphQL errors and malformed response
+shapes as sync-safe failures with bounded messages.
+
+**Patterns to Follow:** Existing service tests use small in-memory doubles and
+safe domain errors; YTM-002 Admin field names and nullability are defined in
+`apps/admin/src/graphql/types/video.ts` and
+`apps/admin/src/services/video.service.ts`.
+
+**Test Scenarios:**
+
+- Fetching the first page sends `first` and omits `after` when no cursor exists.
+- Fetching a later page sends the previous `pageInfo.endCursor`.
+- Requests include `Authorization: Bearer <token>` without exposing the token
+  in thrown errors.
+- GraphQL error responses become safe client errors with a bounded summary.
+- Malformed Admin payloads fail before database writes.
+
+**Verification:** Client tests prove pagination arguments, auth header behavior,
+and safe error handling without making a network call.
+
+### U3. Catalog Sync Service
+
+**Goal:** Page through Admin catalog rows and upsert mapper catalog tables.
+
+**Requirements:** R1, R3, R4, R5, R6, R7, R8, R9.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+
+- `apps/yt-video-mapper-backend/src/services/catalog-sync.ts`
+- `apps/yt-video-mapper-backend/src/services/catalog-sync.test.ts`
+
+**Approach:** Create a service that opens a `CatalogSyncRun`, fetches pages until
+Admin reports no next page, validates each row's required identity fields,
+upserts `CatalogVideo` and `CatalogVariant`, updates counters and cursor after
+each successful page, and finalizes the run. Track seen variant keys during a
+completed snapshot, then mark previously local-but-missing rows non-indexable
+with a local missing reason. On page or row failure, mark the run failed with
+cursor and bounded diagnostics.
+
+**Patterns to Follow:** Durable job lifecycle in `src/services/match-job.service.ts`;
+Prisma-backed repository style in `src/db/match-job.repository.ts`; Admin
+non-indexability reason vocabulary from YTM-002.
+
+**Test Scenarios:**
+
+- Two Admin pages create one run, two catalog videos, matching variants, and a
+  completed status with final cursor.
+- Re-running the same pages updates existing rows without increasing video or
+  variant row counts.
+- Rows with `indexable=false` preserve Admin `nonIndexableReason` and become
+  unavailable to later indexing.
+- Deleted or unpublished variants remain present and non-indexable rather than
+  being deleted.
+- A client failure after page one leaves the sync run failed with the last
+  successful cursor and safe error summary.
+- A malformed row records a bounded row failure summary and does not dump the
+  full row payload.
+- A completed snapshot marks missing previous variants non-indexable with a
+  local missing reason.
+
+**Verification:** Service tests prove idempotency, state mapping, counter
+accuracy, failure summaries, and cursor preservation.
+
+### U4. Operator Entry Point and Documentation
+
+**Goal:** Provide a small internal job entry point and operator-facing notes for
+running catalog sync.
+
+**Requirements:** R1, R2, R6.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+
+- `apps/yt-video-mapper-backend/src/scripts/sync-catalog.ts`
+- `apps/yt-video-mapper-backend/package.json`
+- `apps/yt-video-mapper-backend/README.md`
+- `apps/yt-video-mapper-backend/docs/railway-deployment.md`
+
+**Approach:** Add a script command that constructs the Prisma client, Admin
+client, and sync service, runs one full catalog sync, prints safe counters, and
+sets a non-zero exit code on failure. Document the required env vars and clarify
+that sync is a local projection from Admin, not an Admin database import.
+
+**Patterns to Follow:** Existing package scripts and Railway deployment docs;
+root guidance that service boundaries stay strict.
+
+**Test Scenarios:** Test expectation: none for the script wrapper itself beyond
+service/config coverage; keep behavior in U2/U3 tests and verify script typing.
+
+**Verification:** Typecheck covers the script entry point, and docs identify the
+Admin GraphQL env contract.
+
+---
+
+## Scope Boundaries
+
+- In scope: mapper-side config, Admin GraphQL client, catalog sync service,
+  Prisma schema/client updates, tests, and operator docs.
+- Deferred to YTM-004: media signature generation, match indexing, and any
+  official media processing.
+- Deferred to later ops hardening: scheduler wiring, dashboarding, metrics, and
+  retry orchestration beyond storing retry-safe cursor/failure context.
+- Out of scope: direct Admin database reads and changes to the Admin
+  `videoMapperCatalog` contract unless implementation discovers a blocking
+  YTM-002 bug.
+
+---
+
+## Risks & Dependencies
+
+- **Admin contract drift:** The mapper client depends on YTM-002 field names and
+  nullability. Keep client tests shaped around the Admin GraphQL response, and
+  use safe malformed-response errors when fields drift.
+- **Large sync snapshots:** A full Admin catalog page sequence may be long.
+  Persist cursor and counters after each successful page so failures are
+  inspectable and retryable.
+- **Local state preservation:** Hard-deleting missing or non-indexable rows
+  could break future candidate/evidence foreign keys. Mark rows non-indexable by
+  default.
+- **Secret leakage:** GraphQL failures can include request context if handled
+  carelessly. Bound summaries and never include authorization headers.
+
+---
+
+## Sources & Research
+
+- `docs/prototypes/yt-video-mapper/tickets/ytm-003-mapper-catalog-sync.md`
+  defines the implementation slice and acceptance criteria.
+- `CONCEPTS.md` defines `coreId`, `videoVariantId`, Mapper Catalog, and local
+  projection terminology.
+- `docs/solutions/architecture-patterns/admin-mapper-catalog-projection-narrow-bearer-pattern-20260609.md`
+  defines the Admin projection and bearer boundary from YTM-002.
+- `docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md`
+  defines mapper job durability and catalog identity patterns.
+- `apps/admin/src/graphql/types/video.ts` and
+  `apps/admin/src/services/video.service.ts` define the `videoMapperCatalog`
+  GraphQL result shape and derived indexability fields.

--- a/docs/prototypes/yt-video-mapper/tickets/README.md
+++ b/docs/prototypes/yt-video-mapper/tickets/README.md
@@ -17,7 +17,7 @@ roadmap tickets broad; keep this folder practical and close to the mapper code.
 | -------------------------------------------------------------- | -------- | -------- | -------------------------------------------- |
 | [YTM-001](./ytm-001-deploy-service-and-database.md)            | complete | P1       | Deploy service and database                  |
 | [YTM-002](./ytm-002-admin-flat-catalog-projection.md)          | complete | P1       | Admin flat catalog projection                |
-| [YTM-003](./ytm-003-mapper-catalog-sync.md)                    | todo     | P1       | Mapper catalog sync                          |
+| [YTM-003](./ytm-003-mapper-catalog-sync.md)                    | complete | P1       | Mapper catalog sync                          |
 | [YTM-004](./ytm-004-official-media-signature-indexing.md)      | todo     | P1       | Official media signature indexing            |
 | [YTM-005](./ytm-005-replace-placeholders-with-real-matcher.md) | todo     | P1       | Replace placeholders with real matcher       |
 | [YTM-006](./ytm-006-evaluation-harness-and-thresholds.md)      | todo     | P1       | Evaluation harness and confidence thresholds |

--- a/docs/prototypes/yt-video-mapper/tickets/ytm-003-mapper-catalog-sync.md
+++ b/docs/prototypes/yt-video-mapper/tickets/ytm-003-mapper-catalog-sync.md
@@ -1,7 +1,7 @@
 ---
 id: YTM-003
 title: "Sync Admin catalog projection into mapper tables"
-status: todo
+status: complete
 priority: P1
 depends_on:
   - YTM-002

--- a/docs/solutions/architecture-patterns/mapper-admin-catalog-sync-local-projection-pattern.md
+++ b/docs/solutions/architecture-patterns/mapper-admin-catalog-sync-local-projection-pattern.md
@@ -1,0 +1,184 @@
+---
+title: "Mapper Admin catalog sync local projection pattern"
+date: 2026-06-10
+category: architecture-patterns
+module: "apps/yt-video-mapper-backend, packages/admin-graphql"
+problem_type: architecture_pattern
+component: service_object
+severity: medium
+applies_when:
+  - "A service needs to sync Admin-owned catalog data into local matcher/index tables"
+  - "The source catalog is exposed as a bounded GraphQL projection rather than direct database access"
+  - "Rows must be idempotently keyed by source identity plus variant identity"
+  - "Failed pages or malformed rows need retry-safe diagnostics without leaking secrets or large media payloads"
+tags:
+  - admin-graphql
+  - catalog-sync
+  - local-projection
+  - node-next
+  - prisma
+  - yt-video-mapper
+related_components:
+  - apps/admin
+  - apps/yt-video-mapper-backend
+  - packages/admin-graphql
+  - database
+---
+
+# Mapper Admin catalog sync local projection pattern
+
+## Context
+
+YTM-002 established an Admin-owned `videoMapperCatalog(first, after)` GraphQL
+projection for broad yt-video-mapper catalog reads. YTM-003 consumed that
+projection inside `apps/yt-video-mapper-backend` and populated mapper-owned
+`CatalogVideo`, `CatalogVariant`, and `CatalogSyncRun` rows for local matching
+and future signature indexing.
+
+The tempting shortcuts are to read Admin's database directly, hard-delete local
+rows that disappear from a page sequence, or define a one-off GraphQL string in
+the mapper. Those shortcuts weaken source-of-truth ownership, make retries
+destructive, and bypass the shared Admin GraphQL contract package.
+
+## Guidance
+
+Keep the mapper sync as service-layer code with three boundaries:
+
+1. A small Admin GraphQL HTTP client that sends the service bearer, calls only
+   `videoMapperCatalog(first, after)`, validates the response envelope, and
+   normalizes failures into safe summaries.
+2. A catalog sync service that owns page traversal, per-page row validation,
+   idempotent upserts, counters, cursor persistence, and terminal run status.
+3. A repository boundary that adapts those sync decisions to Prisma writes.
+
+Use Admin GraphQL as the only catalog source. The mapper tables are a local
+projection for matching, not a replacement catalog. Upsert source videos by
+`coreId`, and upsert variants by the Core-facing composite identity:
+
+```text
+CatalogVideo.coreId
+CatalogVariant.coreId + CatalogVariant.videoVariantId
+```
+
+Persist Admin's derived indexability state instead of re-deriving it locally.
+Store video/dub publication flags, deletion flags, `videoNoIndex`,
+`indexable`, and `nonIndexableReason` on the variant row. When a completed
+snapshot does not include a previously synced variant, mark it non-indexable
+with a local missing reason instead of deleting it. That preserves later
+candidate/evidence foreign keys and keeps the row inspectable.
+
+Record sync runs as first-class state. Update the run cursor and counters after
+each successful page so a failed later page leaves enough context to retry or
+diagnose. Failure summaries should include a code, message, cursor, page index,
+and bounded malformed-row identifiers such as `coreId`, `videoVariantId`, and
+Admin dub id. Do not store bearer tokens, request headers, full row payloads, or
+bulk media URLs in the failure summary.
+
+Consumer apps should define Admin operations with `@forge/admin-graphql`, even
+for backend scripts or workers. In NodeNext consumers, the shared package must
+expose NodeNext-compatible `.js` internal re-exports so importing the public
+entrypoint does not make TypeScript fail on extensionless source imports.
+
+```ts
+import { adminGraphql } from "@forge/admin-graphql"
+import { print } from "graphql"
+
+const VIDEO_MAPPER_CATALOG = adminGraphql(`
+  query VideoMapperCatalog($first: Int, $after: String) {
+    videoMapperCatalog(first: $first, after: $after) {
+      nodes {
+        coreId
+        videoVariantId
+        indexable
+        nonIndexableReason
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`)
+
+const body = JSON.stringify({
+  query: print(VIDEO_MAPPER_CATALOG),
+  variables: { first, ...(after ? { after } : {}) },
+})
+```
+
+## Why This Matters
+
+Broad catalog sync is a boundary between two ownership models. Admin owns
+editorial and Core-synced truth; the mapper owns matching state, retry state,
+and local indexes. Keeping the boundary GraphQL-only avoids coupling the mapper
+to Admin's database schema while still giving YTM-004 a queryable local map of
+`coreId`, title, and variant media state.
+
+Non-destructive sync also matters because future match results and evidence
+will reference variants by composite identity. Hard-deleting a variant because
+it is currently deleted, unpublished, no-index, media-missing, or absent from a
+later snapshot would erase diagnostic context and can break referential
+integrity. Marking it non-indexable preserves history while making indexers
+skip it.
+
+Typed Admin GraphQL operations close the contract loop. The mapper can stay a
+small backend app, but it still benefits from the shared generated
+introspection and catches field drift during typecheck instead of discovering
+it in a long-running production sync.
+
+## When to Apply
+
+- A backend service needs a local projection of Admin-owned catalog data for
+  matching, indexing, analytics, or search.
+- The source projection pages a child or variant entity and local rows need
+  idempotent upserts.
+- The consumer needs operational run state with page cursors, counters, and
+  safe failure summaries.
+- The consumer uses NodeNext TypeScript and imports shared GraphQL document
+  helpers from a package authored with bundler-style module resolution.
+
+## Examples
+
+Good sync shape:
+
+```text
+sync run starts
+  fetch Admin GraphQL page
+  validate page envelope and row identities
+  upsert unique CatalogVideo rows by coreId
+  upsert CatalogVariant rows by coreId + videoVariantId
+  persist cursor and counters
+repeat until hasNextPage=false
+mark older local variants non-indexable as missing_from_admin
+complete run
+```
+
+Avoid these shortcuts:
+
+- Reading Admin tables directly from the mapper database connection.
+- Keying local variants only by `videoVariantId` when future evidence joins
+  need the parent `coreId` too.
+- Treating deleted, unpublished, no-index, or missing variants as hard deletes.
+- Storing raw GraphQL payloads, request headers, bearer tokens, or long media
+  URL lists in failure summaries.
+- Defining Admin GraphQL operations as untyped local strings when
+  `@forge/admin-graphql` already exposes generated Admin introspection.
+
+Tests should cover both the protocol edge and the local projection edge:
+
+- Admin pagination variables and bearer header behavior.
+- Safe GraphQL, HTTP, and malformed-response errors.
+- Repeated syncs updating existing rows without increasing row counts.
+- Indexable and non-indexable state mapping from Admin to local variants.
+- Failed page summaries preserving the last successful cursor.
+- Malformed-row summaries that include bounded identifiers but omit payloads.
+- Completed snapshots marking missing variants non-indexable without deletion.
+- NodeNext consumer typecheck against `@forge/admin-graphql`.
+
+## Related
+
+- [Admin mapper catalog projection with narrow bearer access](./admin-mapper-catalog-projection-narrow-bearer-pattern-20260609.md)
+- [yt-video-mapper backend app durable match job upload poll process pattern](../platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md)
+- [Dual client gql.tada multi-schema codegen pattern](./dual-client-gql-tada-multi-schema-codegen-pattern-20260507.md)
+- [Mobile admin data-layer cutover pattern](./mobile-admin-data-layer-cutover-pattern-20260525.md)
+- [Mocked-vs-real testing discipline](../best-practices/mocked-shape-vs-real-contract-discipline-20260506.md)

--- a/packages/admin-graphql/src/admin.ts
+++ b/packages/admin-graphql/src/admin.ts
@@ -1,5 +1,5 @@
 import { initGraphQLTada } from "gql.tada"
-import type { introspection } from "./admin-graphql-env"
+import type { introspection } from "./admin-graphql-env.js"
 
 export const adminGraphql = initGraphQLTada<{
   introspection: introspection

--- a/packages/admin-graphql/src/index.ts
+++ b/packages/admin-graphql/src/index.ts
@@ -1,2 +1,6 @@
-export { adminGraphql, readFragment } from "./admin"
-export type { AdminFragmentOf, AdminResultOf, AdminVariablesOf } from "./admin"
+export { adminGraphql, readFragment } from "./admin.js"
+export type {
+  AdminFragmentOf,
+  AdminResultOf,
+  AdminVariablesOf,
+} from "./admin.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -917,9 +917,15 @@ importers:
 
   apps/yt-video-mapper-backend:
     dependencies:
+      '@forge/admin-graphql':
+        specifier: workspace:*
+        version: link:../../packages/admin-graphql
       '@prisma/client':
         specifier: ^6
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      graphql:
+        specifier: 16.13.1
+        version: 16.13.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -9151,7 +9157,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -20388,9 +20393,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
@@ -20405,8 +20410,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -20432,7 +20437,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -20443,7 +20448,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -20454,7 +20459,7 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -20467,7 +20472,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

The video mapper can now refresh its own local catalog projection from Admin's bounded `videoMapperCatalog` GraphQL API. Repeated syncs are idempotent, variant rows stay keyed by `coreId + videoVariantId`, and failures leave safe cursor/error context for retry rather than duplicating rows or dumping sensitive payloads.

## Design Notes

- Admin remains the source of truth; the mapper reads only the narrow GraphQL projection and writes mapper-owned `CatalogVideo`, `CatalogVariant`, and `CatalogSyncRun` rows.
- The sync service records durable run status, counters, cursors, timestamps, and sanitized failure summaries, while preserving missing/deleted/non-indexable variants instead of hard-deleting them.
- Mapper config now requires `ADMIN_GRAPHQL_URL` and `ADMIN_SERVICE_BEARER_TOKEN` only when catalog sync is invoked, so normal app boot stays tolerant of jobs that are not running.
- The operator entrypoint is `pnpm --filter @forge/yt-video-mapper-backend sync:catalog`.

## Validation

- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- `pnpm --filter @forge/admin-graphql typecheck`
- `pnpm exec eslint packages/admin-graphql/src/admin.ts packages/admin-graphql/src/index.ts`
- `git diff --check origin/main...HEAD`

## Post-Deploy Monitoring & Validation

After deploy, run `pnpm --filter @forge/yt-video-mapper-backend sync:catalog` with the Admin GraphQL URL and service bearer token configured. Confirm the latest `CatalogSyncRun` finishes with video, variant, and indexable variant counts, then spot-check that `CatalogVideo` is queryable by `coreId + title` and `CatalogVariant` is populated by `coreId + videoVariantId` without duplicate rows after a second run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)