### PR TITLE
fix(graphql): restore bundler-safe imports in admin-graphql (unbreak main CI)

### DIFF
--- a/packages/admin-graphql/src/admin.ts
+++ b/packages/admin-graphql/src/admin.ts
@@ -1,14 +1,9 @@
-import { initGraphQLTada } from "gql.tada"
-import type { introspection } from "./admin-graphql-env.js"
-
-export const adminGraphql = initGraphQLTada<{
-  introspection: introspection
-}>()
-
-export { readFragment } from "gql.tada"
-
-export type {
-  FragmentOf as AdminFragmentOf,
-  ResultOf as AdminResultOf,
-  VariablesOf as AdminVariablesOf,
-} from "gql.tada"
+// Internal shim for the fragments tree, which imports "../../admin"
+// extensionless (bundler-style). The real implementation lives in index.ts.
+// The extensionless re-export below is safe because NodeNext consumers
+// (apps/yt-video-mapper-backend) only ever pull the "." entry (index.ts),
+// which does not import this file — so this file never enters a NodeNext
+// program and TS2835 cannot fire. Bundler consumers (web/tv/mobile) resolve
+// extensionless imports natively. Do NOT add a `.js` extension here.
+export { adminGraphql, readFragment } from "./index"
+export type { AdminFragmentOf, AdminResultOf, AdminVariablesOf } from "./index"

--- a/packages/admin-graphql/src/index.ts
+++ b/packages/admin-graphql/src/index.ts
@@ -1,6 +1,20 @@
-export { adminGraphql, readFragment } from "./admin.js"
+import { initGraphQLTada } from "gql.tada"
+// Type-only import: erased at compile/bundle time, so the NodeNext-style
+// `.js` extension is safe for bundler consumers (web Turbopack, tv Jest,
+// mobile Metro) while satisfying NodeNext consumers' typecheck (TS2835).
+// Do NOT add value-level relative imports with `.js` extensions here —
+// Turbopack and Jest resolve this package as TS source and cannot map
+// `./x.js` → `./x.ts` (broke web build + tv tests on 2026-06-10).
+import type { introspection } from "./admin-graphql-env.js"
+
+export const adminGraphql = initGraphQLTada<{
+  introspection: introspection
+}>()
+
+export { readFragment } from "gql.tada"
+
 export type {
-  AdminFragmentOf,
-  AdminResultOf,
-  AdminVariablesOf,
-} from "./admin.js"
+  FragmentOf as AdminFragmentOf,
+  ResultOf as AdminResultOf,
+  VariablesOf as AdminVariablesOf,
+} from "gql.tada"


### PR DESCRIPTION
## Summary

Main's CI has been red since [#1187](https://github.com/JesusFilm/forge/pull/1187) merged: `build (@forge/web)` and `test (@forge/tv)` both fail with `Cannot resolve './admin.js'` from `packages/admin-graphql/src/index.ts`.

#1187 added ESM `.js` extensions to the package's **value-level** relative imports (to satisfy yt-video-mapper-backend's NodeNext typecheck, TS2835). But this package ships TS source consumed under **bundler** resolution by web (Turbopack), tv (Jest), and mobile (Metro) — none of which map `./admin.js` → `admin.ts`.

## Fix — keeps both consumer families green

- `index.ts` now holds the real implementation with only a **type-only** `./admin-graphql-env.js` import: erased at build time so bundlers never resolve it, while the `.js` extension still satisfies NodeNext's TS2835 for yt-video-mapper-backend.
- `admin.ts` becomes an extensionless shim for the package-internal `fragments/` tree (which imports `../../admin` from 21 files). It never enters a NodeNext program — yt-video-mapper only consumes the `"."` entry — so TS2835 cannot fire on it.
- Guard comments in both files explain the constraint so the next NodeNext consumer doesn't re-break bundlers.

## Verified locally

- `pnpm --filter @forge/admin-graphql typecheck && lint` ✓
- `pnpm --filter @forge/yt-video-mapper-backend typecheck && test` ✓ (the consumer #1187 was fixing)
- `pnpm --filter @forge/tv test` ✓ (previously failing)
- `CI=1 pnpm --filter @forge/web build` ✓ (previously failing)

Note: the same fix rides on [#1189](https://github.com/JesusFilm/forge/pull/1189) (Smart Crop) which inherited the breakage by merging main; merging either makes the other a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)