### PR TITLE
fix(web): use watch overlay asset paths

### DIFF
--- a/apps/web/src/components/home/WatchHomePromo.tsx
+++ b/apps/web/src/components/home/WatchHomePromo.tsx
@@ -43,7 +43,7 @@ const highlights = [
 export function WatchHomePromo() {
   return (
     <section className="relative overflow-hidden bg-[linear-gradient(135deg,rgba(69,10,29,0.6),rgba(88,28,135,0.2),rgba(234,88,12,0.1))] py-[4.5rem] text-white">
-      <div className="absolute inset-0 bg-[url(/assets/overlay.svg)] bg-repeat opacity-45 mix-blend-multiply" />
+      <div className="absolute inset-0 bg-[url(/watch/images/overlay.svg)] bg-repeat opacity-45 mix-blend-multiply" />
       <div className="relative mx-auto max-w-[1920px] px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-14">
           <div className="max-w-3xl space-y-4">

--- a/apps/web/src/components/home/WatchHomeSection.tsx
+++ b/apps/web/src/components/home/WatchHomeSection.tsx
@@ -86,7 +86,7 @@ export function WatchHomeSection({ section }: WatchHomeSectionProps) {
       <div
         aria-hidden
         className={cn(
-          "absolute inset-0 z-[1] bg-[url(/assets/overlay.svg)] bg-repeat mix-blend-multiply",
+          "absolute inset-0 z-[1] bg-[url(/watch/images/overlay.svg)] bg-repeat mix-blend-multiply",
           isRail ? "opacity-70" : "opacity-45",
         )}
       />

--- a/apps/web/src/components/home/__tests__/WatchHomePage.test.tsx
+++ b/apps/web/src/components/home/__tests__/WatchHomePage.test.tsx
@@ -179,6 +179,19 @@ describe("WatchHomePage", () => {
     expect(
       container.querySelectorAll("a[href='/jesus.html/english.html']"),
     ).toHaveLength(4)
+    const textureClassNames = Array.from(
+      container.querySelectorAll("[class*='overlay.svg']"),
+    ).map((element) => element.getAttribute("class") ?? "")
+    expect(textureClassNames).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("bg-[url(/watch/images/overlay.svg)]"),
+      ]),
+    )
+    expect(
+      textureClassNames.some((className) =>
+        className.includes("/assets/overlay.svg"),
+      ),
+    ).toBe(false)
     expect(
       JSON.parse(window.localStorage.getItem("carousel-played-ids") ?? "{}")
         .ids,

--- a/apps/web/src/components/sections/QuizButton.tsx
+++ b/apps/web/src/components/sections/QuizButton.tsx
@@ -28,7 +28,7 @@ export function QuizButton({ data }: QuizButtonProps): ReactElement {
           type="button"
         >
           <div className="flex cursor-pointer items-center justify-between p-4 xl:p-6">
-            <div className="absolute inset-0 bg-[url(/assets/overlay.svg)] bg-repeat opacity-50 mix-blend-multiply" />
+            <div className="absolute inset-0 bg-[url(/watch/assets/overlay.svg)] bg-repeat opacity-50 mix-blend-multiply" />
             <div className="relative z-1 flex w-full items-center leading-[1.2] font-semibold md:text-xl xl:text-2xl">
               <span className="mr-4 flex-none rounded-lg border-2 border-white px-2 py-1 text-xs font-extrabold tracking-wider uppercase">
                 Quiz


### PR DESCRIPTION
## Summary

Watch homepage texture layers no longer request the basePath-less `/assets/overlay.svg`, which returns 404 on `watch.jesusfilm.org`. The home promo and section overlays now use the served Core-era overlay at `/watch/images/overlay.svg`, while the quiz CTA uses the served `/watch/assets/overlay.svg` texture path.

The homepage regression test now checks that rendered overlay classes include the `/watch/images/overlay.svg` path and do not reintroduce `/assets/overlay.svg`.

## Validation

- `pnpm --filter @forge/web test -- WatchHomePage.test.tsx`
- `pnpm --filter @forge/web lint`
- `git diff --check`
- Helium sweep of `/watch` plus representative inner pages confirmed the live homepage was the source of the missing `/assets/overlay.svg` request; checked inner pages loaded their image/font/script/style assets without additional missing-asset findings.
- Direct live probes confirmed `/watch/images/overlay.svg`, `/watch/assets/overlay.svg`, Watch favicons, flags, and font assets return 200.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
