### PR TITLE
fix(admin): point experience preview at the public watch URL contract

### DIFF
--- a/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   videoIdsFromExperienceBlocks,
 } from "@/app/dashboard/live-data"
 import { requireSession } from "@/auth/session"
+import { env } from "@/config/env"
 import { prisma } from "@/db/client"
 import { getAdminLocale } from "@/i18n/server"
 import { createServices } from "@/services"
@@ -625,6 +626,7 @@ export default async function ExperienceEditorPage({
       canPublish={selectedLocale.status !== "PUBLISHED"}
       hasPublishedVersion={selectedLocale.publishedAt !== null}
       calendarDate={new Date().toISOString().slice(0, 10)}
+      watchOrigin={env.WEB_CANONICAL_ORIGIN}
       initialValues={{
         localeId: selectedLocale.id,
         title: selectedLocale.title ?? "",

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
@@ -6,8 +6,10 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   ExperienceEditor,
+  buildPublishedWatchUrl,
   cleanLocaleCode,
   cleanRoutePart,
+  watchLanguageSlugForLocale,
 } from "./experience-editor"
 
 const { envState } = vi.hoisted(() => ({
@@ -43,6 +45,7 @@ function renderEditorElement(
       canPublish
       hasPublishedVersion={options.hasPublishedVersion ?? false}
       calendarDate="2026-04-17"
+      watchOrigin="https://watch.jesusfilm.org"
       revisionEntries={[]}
       localeEntries={[
         {
@@ -178,6 +181,29 @@ describe("ExperienceEditor", () => {
     expect(cleanLocaleCode("  ES 419  ", true)).toBe("es-419")
     expect(cleanLocaleCode("pt_BR")).toBe("pt-br")
     expect(cleanLocaleCode("fr///CA")).toBe("frca")
+  })
+
+  it("maps editor locales to public watch audio language slugs", () => {
+    expect(watchLanguageSlugForLocale("en")).toBe("english")
+    expect(watchLanguageSlugForLocale("es")).toBe("spanish-castilian")
+    expect(watchLanguageSlugForLocale("zh-Hans")).toBe("chinese-simplified")
+    // Regional variants fall back to the primary subtag mapping.
+    expect(watchLanguageSlugForLocale("en-US")).toBe("english")
+    expect(watchLanguageSlugForLocale("xx")).toBeNull()
+    expect(watchLanguageSlugForLocale("")).toBeNull()
+  })
+
+  it("builds two-segment .html watch URLs for published previews", () => {
+    // jsdom runs on localhost, so the local watch base wins over the origin.
+    expect(
+      buildPublishedWatchUrl("christmas", "en", "https://watch.jesusfilm.org"),
+    ).toBe("http://localhost:3000/watch/christmas.html/english.html")
+    expect(
+      buildPublishedWatchUrl("christmas", "xx", "https://watch.jesusfilm.org"),
+    ).toBeNull()
+    expect(
+      buildPublishedWatchUrl("", "en", "https://watch.jesusfilm.org"),
+    ).toBeNull()
   })
 
   it("renders container layout as a visual responsive grid editor", () => {
@@ -687,7 +713,7 @@ describe("ExperienceEditor", () => {
       })
 
       expect(openSpy).toHaveBeenCalledWith(
-        "http://localhost:3000/watch/experience-title/en",
+        "http://localhost:3000/watch/experience-title.html/english.html",
         "_blank",
         "noopener,noreferrer",
       )

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
@@ -863,28 +863,82 @@ function localizedVideoLabelFallback(label: string | null, localeCode: string) {
   return labels[label as keyof typeof labels] ?? ""
 }
 
-function inferWatchBaseUrl() {
-  // NEXT_PUBLIC_WATCH_URL was retired with main's web-revalidation
-  // rework; browser-side inference below covers local + deployed hosts.
-  if (typeof window === "undefined") return ""
+function inferLocalWatchBaseUrl() {
+  // Local dev runs the watch site on :3000 next to admin on :3003; on
+  // deployed hosts the server-provided watchOrigin is authoritative.
+  if (typeof window === "undefined") return null
 
-  const { protocol, hostname, origin } = window.location
+  const { protocol, hostname } = window.location
   if (hostname === "localhost" || hostname === "127.0.0.1") {
     return `${protocol}//${hostname}:3000`
   }
 
-  return origin.replace(/\/$/, "")
+  return null
 }
 
-function buildPublishedWatchUrl(slug: string, locale: string) {
-  const normalizedSlug = cleanRoutePart(slug)
-  const normalizedLocale = cleanLocaleCode(locale)
-  if (!normalizedSlug || !normalizedLocale) return null
+function cleanWatchOrigin(value: string) {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null
+    return url.origin
+  } catch {
+    return null
+  }
+}
 
-  const baseUrl = inferWatchBaseUrl()
+// SYNC: mirrors PUBLIC_WATCH_AUDIO_LANGUAGE_SLUG_BY_UI_LOCALE in
+// apps/web/src/lib/locale.ts — the watch site resolves the language path
+// segment through that table, so entries here must stay aligned with web.
+// Keys are lowercased to match cleanLocaleCode output.
+const WATCH_AUDIO_LANGUAGE_SLUG_BY_LOCALE: Readonly<Record<string, string>> = {
+  en: "english",
+  es: "spanish-castilian",
+  fr: "french",
+  pt: "portuguese-brazil",
+  de: "german-standard",
+  ar: "arabic-modern-standard",
+  id: "indonesian-isa",
+  ja: "japanese",
+  ko: "korean",
+  ms: "malay",
+  ne: "nepali",
+  ru: "russian",
+  th: "thai",
+  tl: "tagalog",
+  tr: "turkish",
+  vi: "vietnamese",
+  zh: "mandarin-china",
+  "zh-hans": "chinese-simplified",
+  "zh-hant": "chinese-traditional",
+}
+
+export function watchLanguageSlugForLocale(locale: string) {
+  const normalized = cleanLocaleCode(locale, true)
+  if (!normalized) return null
+
+  return (
+    WATCH_AUDIO_LANGUAGE_SLUG_BY_LOCALE[normalized] ??
+    WATCH_AUDIO_LANGUAGE_SLUG_BY_LOCALE[normalized.split("-")[0] ?? ""] ??
+    null
+  )
+}
+
+// Public watch URLs are always two .html segments: {slug}.html/{language}.html.
+// A bare slug expands to the broken {slug}.html/{slug}.html on the watch site.
+// See docs/solutions/conventions/public-watch-url-two-segment-contract-20260608.md.
+export function buildPublishedWatchUrl(
+  slug: string,
+  locale: string,
+  watchOrigin: string,
+) {
+  const normalizedSlug = cleanRoutePart(slug)
+  const languageSlug = watchLanguageSlugForLocale(locale)
+  if (!normalizedSlug || !languageSlug) return null
+
+  const baseUrl = inferLocalWatchBaseUrl() ?? cleanWatchOrigin(watchOrigin)
   if (!baseUrl) return null
 
-  return `${baseUrl}/watch/${normalizedSlug}/${normalizedLocale}`
+  return `${baseUrl}/watch/${normalizedSlug}.html/${languageSlug}.html`
 }
 
 export function ExperienceEditor({
@@ -895,6 +949,7 @@ export function ExperienceEditor({
   videoLibrary,
   mediaLibrary,
   calendarDate,
+  watchOrigin,
   initialValues,
   saveAction,
   publishAction,
@@ -909,6 +964,8 @@ export function ExperienceEditor({
   videoLibrary: VideoLibraryItem[]
   mediaLibrary: MediaLibraryItem[]
   calendarDate: string
+  /** Public watch-site origin (env.WEB_CANONICAL_ORIGIN) for preview links. */
+  watchOrigin: string
   initialValues: {
     localeId: string
     title: string
@@ -1328,6 +1385,7 @@ export function ExperienceEditor({
     const nextPublishedWatchUrl = buildPublishedWatchUrl(
       routeSlug,
       activeLocaleCode,
+      watchOrigin,
     )
     if (!nextPublishedWatchUrl) {
       pushToast("Unable to build the published preview URL.", "error")


### PR DESCRIPTION
## Problem

The experience editor's **Preview** button built its link from the admin page's own origin with a bare `/watch/{slug}/{locale}` path. On production that produced `https://admin.jesusfilm.org/watch/christmas/en` — a nonexistent admin route. Even on the right host, the bare-slug shape 404s: the watch site expands a bare slug into the broken `{slug}.html/{slug}.html` (same trap the roadmap demo links hit, fixed in 9fa36064).

## Fix

Preview now follows the two-segment public watch URL contract — `{watchOrigin}/watch/{slug}.html/{language}.html` (e.g. `https://watch.jesusfilm.org/watch/christmas.html/english.html`):

- **Origin**: threads in server-side as a new `watchOrigin` prop from `env.WEB_CANONICAL_ORIGIN` — the same source the video library's visitor links already use. Localhost keeps inferring the `:3000` dev watch site.
- **Language segment**: locale codes map to public audio language slugs (`en` → `english`, `es` → `spanish-castilian`, …) via a mirror of web's `PUBLIC_WATCH_AUDIO_LANGUAGE_SLUG_BY_UI_LOCALE` with a SYNC note — that table is web's routing contract for the language path segment. Regional variants fall back to the primary subtag; unmappable locales return `null` and surface the existing error toast instead of a broken link.

See `docs/solutions/conventions/public-watch-url-two-segment-contract-20260608.md`.

## Testing

- Updated the preview DOM test to the new two-segment URL shape
- New unit tests for `watchLanguageSlugForLocale` and `buildPublishedWatchUrl` (mapping, subtag fallback, null cases)
- `vitest run experience-editor.test.tsx`: 20/20 green; admin typecheck introduces no new errors; eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)