### PR TITLE
fix(crop-worker): unbreak production build under NODE_ENV=production

### DIFF
--- a/apps/crop-worker/railway.toml
+++ b/apps/crop-worker/railway.toml
@@ -9,7 +9,13 @@
 
 [build]
 builder = "NIXPACKS"
-buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/crop-worker build"
+# Install with NODE_ENV=development so devDependencies (husky for the repo-root
+# `prepare` script, prisma for sibling postinstalls, typescript for the build)
+# are NOT skipped. The service sets NODE_ENV=production, which applies to the
+# build too — and pnpm skips devDependencies under NODE_ENV=production, which
+# breaks the monorepo install (husky/prisma "not found"). The runtime keeps
+# NODE_ENV=production via the service variable; this override is install-only.
+buildCommand = "NODE_ENV=development pnpm install --frozen-lockfile && pnpm --filter @forge/crop-worker build"
 watchPatterns = [
   "/apps/crop-worker/**",
   "/package.json",

--- a/apps/crop-worker/src/config/env.test.ts
+++ b/apps/crop-worker/src/config/env.test.ts
@@ -46,6 +46,12 @@ describe("parseEnv", () => {
     expect(env.PORT).toBe(3011)
   })
 
+  it("falls back to the NODE_ENV default when given an empty string", () => {
+    // Railway provides NODE_ENV as "" rather than leaving it unset; the enum
+    // default only fires on undefined, so an unwrapped "" used to crash boot.
+    expect(parseEnv({ NODE_ENV: "" }).NODE_ENV).toBe("development")
+  })
+
   it("coerces numeric overrides", () => {
     const env = parseEnv({
       PORT: "4001",

--- a/apps/crop-worker/src/config/env.ts
+++ b/apps/crop-worker/src/config/env.ts
@@ -73,7 +73,10 @@ export type EnvSource = Partial<Record<keyof Env, string | undefined>>
 
 export function parseEnv(source: EnvSource): Env {
   return envSchema.parse({
-    NODE_ENV: source.NODE_ENV,
+    // emptyToUndefined so an empty-string NODE_ENV (Railway provides "" rather
+    // than leaving it unset) falls through to the schema default instead of
+    // failing the enum and crashing boot before the server can listen.
+    NODE_ENV: emptyToUndefined(source.NODE_ENV),
     PORT: emptyToUndefined(source.PORT),
     CROP_WORKER_API_KEYS: emptyToUndefined(source.CROP_WORKER_API_KEYS),
     RAILWAY_S3_ENDPOINT: emptyToUndefined(source.RAILWAY_S3_ENDPOINT),


### PR DESCRIPTION
## Problem

Standing up `@forge/crop-worker` in Railway production (feat-173 Smart Crop rollout): the service needs `NODE_ENV=production` at **runtime** — its required-env enforcement, ffmpeg `-protocol_whitelist`, and https source check all gate on `NODE_ENV === "production"`. But a Railway **service variable applies during the build too**, and `pnpm install` skips devDependencies when `NODE_ENV=production`. That broke the monorepo install:

```
devDependencies: skipped because NODE_ENV is set to production
. prepare$ husky → sh: husky: not found → ELIFECYCLE
apps/mastra-gateway postinstall$ prisma generate → prisma: Permission denied
Build Failed
```

(Sibling services don't hit this because they were last built before their `NODE_ENV` var existed.)

There was also a latent crash: before the var was set, the container's `NODE_ENV` was an empty string (Railway provides `""`, not unset), and `z.enum([...]).default()` only fires on `undefined` — so boot died with a `ZodError` on `NODE_ENV` before the server could listen.

## Fix

- **`railway.toml`** — prefix the build install with `NODE_ENV=development` so devDependencies install (husky/prisma/tsc present); the runtime keeps `NODE_ENV=production` via the service variable. Install-only override.
- **`config/env.ts`** — wrap `NODE_ENV` in `emptyToUndefined` so an empty-string value falls through to the schema default instead of failing the enum and crashing boot.

## Verified

`pnpm --filter @forge/crop-worker typecheck && test && lint` green — 130 tests (+1 empty-`NODE_ENV` regression pinning the boot-crash fix).

After merge, crop-worker rebuilds from `main`: install gets devDeps → build passes → runtime starts with `NODE_ENV=production` → `/health` should go green. Then the remaining rollout step is manager's `CROP_WORKER_BASE_URL` + `CROP_WORKER_API_KEY` (receiver-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)