### PR TITLE
[codex] Add agent login handles

### DIFF
--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -38,6 +38,14 @@ AUTH_BASE_URL=http://localhost:3004
 # AUTH_MANAGER_SESSION_SERVICE_CLIENT_SECRET_STAGING=
 # AUTH_MANAGER_SESSION_SERVICE_CLIENT_SECRET_PRODUCTION=
 
+# Agent login handles. The minting key and generated handles are bearer
+# credentials for local/preview browser testing.
+# AGENT_LOGIN_MINTING_KEY=
+# AGENT_LOGIN_CLIENT_ID=jfp_admin_local
+# AGENT_LOGIN_REDIRECT_URI=http://localhost:3003/api/auth/callback
+# AGENT_LOGIN_SCOPES=openid,profile:read,email:read,admin:access
+# AGENT_LOGIN_TTL_SECONDS=1800
+
 # Firebase lazy migration. Auth uses these only to migrate existing Firebase
 # users into Better Auth after a failed Better Auth credential sign-in.
 # FIREBASE_WEB_API_KEY=

--- a/apps/auth/AGENTS.md
+++ b/apps/auth/AGENTS.md
@@ -26,3 +26,12 @@ Full context lives in `apps/auth/CLAUDE.md`. Keep both files aligned.
 - `pnpm --filter @forge/auth test`
 - `pnpm --filter @forge/auth typecheck`
 - `pnpm --filter @forge/auth lint`
+
+## Agent Login
+
+- Agent handles are Auth-owned, short-lived bearer credentials shaped like
+  email addresses for local/preview browser testing.
+- Do not add app-local auth bypasses in relying apps when this flow applies.
+- The mint helper prints the generated handle once for immediate browser use;
+  never commit it, pipe it into durable logs, or paste it into issue/PR text.
+- Never log raw `AGENT_LOGIN_MINTING_KEY` values.

--- a/apps/auth/CLAUDE.md
+++ b/apps/auth/CLAUDE.md
@@ -42,6 +42,20 @@ pnpm --filter @forge/auth lint
 pnpm --filter @forge/auth typecheck
 ```
 
+## Agent login handles
+
+Trusted developer environments can mint short-lived email-like login handles
+for local/preview browser testing. Set `AGENT_LOGIN_MINTING_KEY` in Auth for
+the API endpoint, then mint a handle:
+
+```bash
+pnpm --filter @forge/auth mint:agent-handle
+```
+
+Paste the printed handle into the normal Auth email field and click Continue.
+The raw `AGENT_LOGIN_MINTING_KEY` and printed handles are bearer credentials; do
+not commit them, pipe them into durable logs, or paste them into issue/PR text.
+
 ## Deployment
 
 Auth deploys as its own Railway service. `auth.jesusfilm.org` should point to

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "seed:first-party-apps": "tsx src/scripts/seed-first-party-apps.ts"
+    "seed:first-party-apps": "tsx src/scripts/seed-first-party-apps.ts",
+    "mint:agent-handle": "tsx src/scripts/mint-agent-login-handle.ts"
   },
   "dependencies": {
     "@better-auth/oauth-provider": "1.6.2",

--- a/apps/auth/prisma/migrations/0002_agent_login_users/migration.sql
+++ b/apps/auth/prisma/migrations/0002_agent_login_users/migration.sql
@@ -1,0 +1,7 @@
+CREATE TYPE "UserActorType" AS ENUM ('human', 'agent');
+
+ALTER TABLE "user" ADD COLUMN "actor_type" "UserActorType" NOT NULL DEFAULT 'human';
+ALTER TABLE "user" ADD COLUMN "expires_at" TIMESTAMP(3);
+
+CREATE INDEX "user_actor_type_idx" ON "user"("actor_type");
+CREATE INDEX "user_expires_at_idx" ON "user"("expires_at");

--- a/apps/auth/prisma/schema.prisma
+++ b/apps/auth/prisma/schema.prisma
@@ -69,13 +69,20 @@ enum AuditEventSeverity {
   CRITICAL @map("critical")
 }
 
+enum UserActorType {
+  HUMAN @map("human")
+  AGENT @map("agent")
+}
+
 model User {
   id               String           @id
   name             String
   email            String
   emailVerified    Boolean          @default(false) @map("email_verified")
   image            String?
+  actorType        UserActorType     @default(HUMAN) @map("actor_type")
   membershipStatus MembershipStatus @default(INVITED) @map("membership_status")
+  expiresAt        DateTime?        @map("expires_at")
   createdAt        DateTime         @default(now()) @map("created_at")
   updatedAt        DateTime         @updatedAt @map("updated_at")
 
@@ -90,6 +97,8 @@ model User {
   auditEvents AuthAuditEvent[]
 
   @@unique([email])
+  @@index([actorType])
+  @@index([expiresAt])
   @@index([membershipStatus])
   @@map("user")
 }

--- a/apps/auth/src/app/api/agent-login/mint/route.test.ts
+++ b/apps/auth/src/app/api/agent-login/mint/route.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mintAgentLoginHandle = vi.fn()
+
+vi.mock("@/db/client", () => ({
+  prisma: {},
+}))
+
+vi.mock("@/config/env", () => ({
+  env: { AGENT_LOGIN_MINTING_KEY: "dev-key" },
+}))
+
+vi.mock("@/services/agent-login.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/services/agent-login.service")
+  >("@/services/agent-login.service")
+
+  return {
+    ...actual,
+    mintAgentLoginHandle: (...args: unknown[]) => mintAgentLoginHandle(...args),
+  }
+})
+
+describe("POST /api/agent-login/mint", () => {
+  beforeEach(() => {
+    mintAgentLoginHandle.mockReset()
+  })
+
+  it("returns a minted agent login handle", async () => {
+    const expiresAt = new Date("2026-06-11T12:30:00.000Z")
+    mintAgentLoginHandle.mockResolvedValueOnce({
+      handle: "agent+jfp-admin-local.abc@agent-login.jesusfilm.internal",
+      expiresAt,
+      clientId: "jfp_admin_local",
+      redirectUri: "http://localhost:3003/api/auth/callback",
+      scopes: ["openid", "email:read", "admin:access"],
+    })
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/agent-login/mint", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer dev-key",
+          "content-type": "application/json",
+          "user-agent": "vitest",
+        },
+        body: JSON.stringify({
+          clientId: "jfp_admin_local",
+          redirectUri: "http://localhost:3003/api/auth/callback",
+          scopes: ["openid", "email:read", "admin:access"],
+          ttlSeconds: 600,
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      handle: "agent+jfp-admin-local.abc@agent-login.jesusfilm.internal",
+      clientId: "jfp_admin_local",
+      scopes: ["openid", "email:read", "admin:access"],
+    })
+    expect(mintAgentLoginHandle).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        clientId: "jfp_admin_local",
+        redirectUri: "http://localhost:3003/api/auth/callback",
+        requestedScopes: ["openid", "email:read", "admin:access"],
+        ttlSeconds: 600,
+        userAgent: "vitest",
+      }),
+    )
+  })
+
+  it("rejects missing bearer credentials", async () => {
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/agent-login/mint", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "jfp_admin_local",
+          redirectUri: "http://localhost:3003/api/auth/callback",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(mintAgentLoginHandle).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid bearer credentials", async () => {
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/agent-login/mint", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer wrong-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          clientId: "jfp_admin_local",
+          redirectUri: "http://localhost:3003/api/auth/callback",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(mintAgentLoginHandle).not.toHaveBeenCalled()
+  })
+
+  it("keeps invalid requests out of the service layer", async () => {
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/agent-login/mint", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer dev-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ clientId: "jfp_admin_local" }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mintAgentLoginHandle).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed scopes instead of falling back to defaults", async () => {
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/agent-login/mint", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer dev-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          clientId: "jfp_admin_local",
+          redirectUri: "http://localhost:3003/api/auth/callback",
+          scopes: "openid,email:read",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mintAgentLoginHandle).not.toHaveBeenCalled()
+  })
+})

--- a/apps/auth/src/app/api/agent-login/mint/route.ts
+++ b/apps/auth/src/app/api/agent-login/mint/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server"
+
+import { env } from "@/config/env"
+import { prisma } from "@/db/client"
+import {
+  mintAgentLoginHandle,
+  AgentLoginError,
+} from "@/services/agent-login.service"
+
+const BEARER_PREFIX = /^Bearer\s+/i
+
+type MintRequestBody = {
+  clientId?: unknown
+  redirectUri?: unknown
+  scopes?: unknown
+  ttlSeconds?: unknown
+}
+
+export async function POST(request: Request) {
+  const mintingKey = getBearerToken(request.headers.get("authorization"))
+  if (
+    !env.AGENT_LOGIN_MINTING_KEY ||
+    mintingKey !== env.AGENT_LOGIN_MINTING_KEY
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  let body: MintRequestBody
+  try {
+    body = (await request.json()) as MintRequestBody
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+  }
+
+  if (
+    typeof body.clientId !== "string" ||
+    typeof body.redirectUri !== "string"
+  ) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+  }
+  const requestedScopes = parseScopes(body.scopes)
+  if (!requestedScopes.valid) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+  }
+
+  try {
+    return NextResponse.json(
+      await mintAgentLoginHandle(prisma, {
+        clientId: body.clientId,
+        redirectUri: body.redirectUri,
+        requestedScopes: requestedScopes.value,
+        ttlSeconds:
+          typeof body.ttlSeconds === "number" ? body.ttlSeconds : undefined,
+        ipAddress:
+          request.headers.get("x-forwarded-for") ??
+          request.headers.get("x-real-ip"),
+        userAgent: request.headers.get("user-agent"),
+      }),
+    )
+  } catch (error) {
+    if (error instanceof AgentLoginError) {
+      return NextResponse.json(
+        {
+          error:
+            error.code === "invalid_minting_key" ? "Unauthorized" : "Forbidden",
+        },
+        { status: error.code === "invalid_minting_key" ? 401 : 403 },
+      )
+    }
+
+    throw error
+  }
+}
+
+function getBearerToken(header: string | null) {
+  if (!header || !BEARER_PREFIX.test(header)) return undefined
+  return header.replace(BEARER_PREFIX, "").trim()
+}
+
+function parseScopes(value: unknown) {
+  if (value === undefined) return { valid: true, value: undefined }
+  if (!Array.isArray(value)) return { valid: false, value: undefined }
+  if (!value.every((scope) => typeof scope === "string")) {
+    return { valid: false, value: undefined }
+  }
+  return { valid: true, value }
+}

--- a/apps/auth/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.test.ts
@@ -7,10 +7,15 @@ const rateLimitAuthRoute = vi.fn(async (_input: unknown) => ({
   source: "local",
 }))
 const signUpEmail = vi.fn()
+const getSession = vi.fn()
+const canRedeemAgentLoginHandle = vi.fn(
+  async (_prisma: unknown, _input: unknown) => false,
+)
 
 vi.mock("@/auth/config", () => ({
   auth: {
     api: {
+      getSession: (input: unknown) => getSession(input),
       signUpEmail: (...args: unknown[]) => signUpEmail(...args),
     },
   },
@@ -38,12 +43,23 @@ vi.mock("@/db/client", () => ({
     ),
     user: {
       findFirst: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    appEnvironment: {
+      findUnique: vi.fn(),
     },
   },
 }))
 
 vi.mock("@/auth/rate-limit", () => ({
   rateLimitAuthRoute: (input: unknown) => rateLimitAuthRoute(input),
+}))
+
+vi.mock("@/services/agent-login.service", () => ({
+  canRedeemAgentLoginHandle: (prisma: unknown, input: unknown) =>
+    canRedeemAgentLoginHandle(prisma, input),
+  isAgentLoginHandle: (value: string) =>
+    value.trim().toLowerCase().endsWith("@agent-login.jesusfilm.internal"),
 }))
 
 vi.mock("@/auth/firebase-rest", () => ({
@@ -60,6 +76,10 @@ describe("Auth route wrapper", () => {
     authGet.mockReset()
     authGet.mockResolvedValue(Response.json({ ok: true }))
     authPost.mockReset()
+    getSession.mockReset()
+    getSession.mockResolvedValue(null)
+    canRedeemAgentLoginHandle.mockReset()
+    canRedeemAgentLoginHandle.mockResolvedValue(false)
     rateLimitAuthRoute.mockReset()
     rateLimitAuthRoute.mockResolvedValue({ allowed: true, source: "local" })
     signUpEmail.mockReset()
@@ -386,6 +406,55 @@ describe("Auth route wrapper", () => {
     await expect(response.json()).resolves.toEqual({ method: "password" })
   })
 
+  it("returns agent-handle for a valid agent login handle", async () => {
+    canRedeemAgentLoginHandle.mockResolvedValueOnce(true)
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/login-method", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email: "agent+jfp-admin-local.abc@agent-login.jesusfilm.internal",
+          oauth_query:
+            "client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["login-method"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ method: "agent-handle" })
+    expect(canRedeemAgentLoginHandle).toHaveBeenCalledWith(expect.anything(), {
+      handle: "agent+jfp-admin-local.abc@agent-login.jesusfilm.internal",
+      oauthQuery:
+        "client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+    })
+  })
+
+  it("falls back generically for an invalid agent login handle", async () => {
+    canRedeemAgentLoginHandle.mockResolvedValueOnce(false)
+    const { prisma } = await import("@/db/client")
+
+    const { POST } = await import("./route")
+    const response = await POST(
+      new Request("http://localhost:3004/api/auth/login-method", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email: "agent+jfp-admin-local.bad@agent-login.jesusfilm.internal",
+          oauth_query:
+            "client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+        }),
+      }),
+      { params: Promise.resolve({ all: ["login-method"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ method: "password" })
+    expect(prisma.user.findFirst).not.toHaveBeenCalled()
+  })
+
   it("does not expose provider lookup failures when rate limited", async () => {
     rateLimitAuthRoute.mockResolvedValueOnce({
       allowed: false,
@@ -405,6 +474,7 @@ describe("Auth route wrapper", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ method: "password" })
     expect(authPost).not.toHaveBeenCalled()
+    expect(canRedeemAgentLoginHandle).not.toHaveBeenCalled()
   })
 
   it("forwards OAuth continuation as callbackURL through email sign-in", async () => {
@@ -696,5 +766,55 @@ describe("Auth route wrapper", () => {
     expect(response.headers.get("set-cookie") ?? "").not.toContain(
       "forge_auth_last_login_method",
     )
+  })
+
+  it("allows agent sessions to authorize approved local clients", async () => {
+    const { prisma } = await import("@/db/client")
+    getSession.mockResolvedValueOnce({ user: { id: "agent_user_1" } })
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+      actorType: "AGENT",
+    } as never)
+    vi.mocked(prisma.appEnvironment.findUnique).mockResolvedValueOnce({
+      kind: "LOCAL",
+      status: "APPROVED",
+      app: { status: "ACTIVE" },
+      grants: [{ id: "grant_1" }],
+    } as never)
+
+    const { GET } = await import("./route")
+    const response = await GET(
+      new Request(
+        "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+      ),
+      { params: Promise.resolve({ all: ["oauth2", "authorize"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(authGet).toHaveBeenCalled()
+  })
+
+  it("blocks agent sessions from authorizing production clients", async () => {
+    const { prisma } = await import("@/db/client")
+    getSession.mockResolvedValueOnce({ user: { id: "agent_user_1" } })
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+      actorType: "AGENT",
+    } as never)
+    vi.mocked(prisma.appEnvironment.findUnique).mockResolvedValueOnce({
+      kind: "PRODUCTION",
+      status: "APPROVED",
+      app: { status: "ACTIVE" },
+      grants: [{ id: "grant_1" }],
+    } as never)
+
+    const { GET } = await import("./route")
+    const response = await GET(
+      new Request(
+        "http://localhost:3004/api/auth/oauth2/authorize?client_id=jfp_admin_production&redirect_uri=https%3A%2F%2Fadmin.jesusfilm.org%2Fapi%2Fauth%2Fcallback",
+      ),
+      { params: Promise.resolve({ all: ["oauth2", "authorize"] }) },
+    )
+
+    expect(response.status).toBe(403)
+    expect(authGet).not.toHaveBeenCalled()
   })
 })

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -12,6 +12,10 @@ import { resolveWebWatchCallbackURL } from "@/auth/web-callback"
 import { getAuthBaseUrl } from "@/config/env"
 import { prisma } from "@/db/client"
 import { ensureDynamicPreviewRedirectUriRegistered } from "@/services/dynamic-preview-redirect.service"
+import {
+  canRedeemAgentLoginHandle,
+  isAgentLoginHandle,
+} from "@/services/agent-login.service"
 
 type RouteContext = {
   params: Promise<{ all?: string[] }>
@@ -153,12 +157,17 @@ async function parseEmailPasswordRequest(request: Request): Promise<{
 
 async function parseLoginMethodRequest(request: Request): Promise<{
   email: string
+  oauthQuery?: string
 }> {
   const contentType = request.headers.get("content-type") ?? ""
   if (contentType.includes("application/json")) {
-    const body = (await request.json()) as { email?: string }
+    const body = (await request.json()) as {
+      email?: string
+      oauth_query?: string
+    }
     return {
       email: body.email?.trim().toLowerCase() ?? "",
+      oauthQuery: body.oauth_query,
     }
   }
 
@@ -171,6 +180,10 @@ async function parseLoginMethodRequest(request: Request): Promise<{
     email: String(body.get("email") ?? "")
       .trim()
       .toLowerCase(),
+    oauthQuery:
+      typeof body.get("oauth_query") === "string"
+        ? String(body.get("oauth_query"))
+        : undefined,
   }
 }
 
@@ -347,10 +360,26 @@ async function handleLoginMethod(request: Request): Promise<Response> {
     return Response.json({ method: "password" })
   }
 
-  const { email } = await parseLoginMethodRequest(request)
+  const { email, oauthQuery } = await parseLoginMethodRequest(request)
   if (!email) {
     audit("auth.login_method.password")
     return Response.json({ method: "password" })
+  }
+
+  if (isAgentLoginHandle(email)) {
+    const canRedeem = await canRedeemAgentLoginHandle(prisma, {
+      handle: email,
+      oauthQuery,
+    })
+    audit(
+      canRedeem
+        ? "auth.login_method.agent_handle"
+        : "auth.login_method.password",
+      email,
+    )
+    return Response.json(
+      canRedeem ? { method: "agent-handle" } : { method: "password" },
+    )
   }
 
   const enabledProviders = enabledProviderIds()
@@ -379,6 +408,52 @@ async function handleLoginMethod(request: Request): Promise<Response> {
 
   audit("auth.login_method.password", email)
   return Response.json({ method: "password" })
+}
+
+async function enforceAgentOAuthAuthorizePolicy(
+  request: Request,
+): Promise<Response | undefined> {
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session?.user?.id) return undefined
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { actorType: true },
+  })
+  if (user?.actorType !== "AGENT") return undefined
+
+  const clientId = new URL(request.url).searchParams.get("client_id")
+  if (!clientId) return new Response("Forbidden", { status: 403 })
+
+  const environment = await prisma.appEnvironment.findUnique({
+    where: { clientId },
+    select: {
+      kind: true,
+      status: true,
+      app: { select: { status: true } },
+      grants: {
+        where: {
+          status: "APPROVED",
+          subjectType: "USER",
+          userId: session.user.id,
+        },
+        select: { id: true },
+        take: 1,
+      },
+    },
+  })
+
+  if (
+    !environment ||
+    environment.kind === "PRODUCTION" ||
+    environment.status !== "APPROVED" ||
+    environment.app.status !== "ACTIVE" ||
+    environment.grants.length === 0
+  ) {
+    return new Response("Forbidden", { status: 403 })
+  }
+
+  return undefined
 }
 
 async function handleEmailSignUp(request: Request): Promise<Response> {
@@ -602,6 +677,8 @@ export async function GET(
       clientId: url.searchParams.get("client_id"),
       redirectUri: url.searchParams.get("redirect_uri"),
     })
+    const agentPolicyResponse = await enforceAgentOAuthAuthorizePolicy(request)
+    if (agentPolicyResponse) return agentPolicyResponse
   }
 
   const response = await authRouteHandlers.GET(request)

--- a/apps/auth/src/app/dashboard/audit/page.tsx
+++ b/apps/auth/src/app/dashboard/audit/page.tsx
@@ -15,7 +15,7 @@ export default async function AuditPage() {
     orderBy: { createdAt: "desc" },
     take: 100,
     include: {
-      actorUser: { select: { email: true, name: true } },
+      actorUser: { select: { actorType: true, email: true, name: true } },
       app: { select: { displayName: true, key: true } },
     },
   })
@@ -48,7 +48,11 @@ export default async function AuditPage() {
               <tr key={event.id}>
                 <DashboardTd>{event.eventType}</DashboardTd>
                 <DashboardTd>{event.severity.toLowerCase()}</DashboardTd>
-                <DashboardTd>{event.actorUser?.email ?? "system"}</DashboardTd>
+                <DashboardTd>
+                  {event.actorUser
+                    ? `${event.actorUser.email} (${event.actorUser.actorType.toLowerCase()})`
+                    : "system"}
+                </DashboardTd>
                 <DashboardTd>{event.app?.displayName ?? "none"}</DashboardTd>
                 <DashboardTd>
                   <code className="whitespace-normal break-words">

--- a/apps/auth/src/app/dashboard/users/page.tsx
+++ b/apps/auth/src/app/dashboard/users/page.tsx
@@ -19,6 +19,7 @@ export default async function UsersPage() {
       name: true,
       email: true,
       membershipStatus: true,
+      actorType: true,
       emailVerified: true,
       createdAt: true,
       grants: {
@@ -51,6 +52,7 @@ export default async function UsersPage() {
             <tr>
               <DashboardTh>User</DashboardTh>
               <DashboardTh>Status</DashboardTh>
+              <DashboardTh>Actor</DashboardTh>
               <DashboardTh>Email</DashboardTh>
               <DashboardTh>Grants</DashboardTh>
               <DashboardTh>Created</DashboardTh>
@@ -64,6 +66,7 @@ export default async function UsersPage() {
                   <small className="block text-[#78716c]">{user.email}</small>
                 </DashboardTd>
                 <DashboardTd>{user.membershipStatus.toLowerCase()}</DashboardTd>
+                <DashboardTd>{user.actorType.toLowerCase()}</DashboardTd>
                 <DashboardTd>
                   {user.emailVerified ? "verified" : "unverified"}
                 </DashboardTd>

--- a/apps/auth/src/app/login/login-page-client.tsx
+++ b/apps/auth/src/app/login/login-page-client.tsx
@@ -144,7 +144,14 @@ export function LoginPageClient({
 
       const data = (await res.json()) as
         | { method: "password" }
+        | { method: "agent-handle" }
         | { method: "provider"; provider: LoginProviderId }
+
+      if (data.method === "agent-handle") {
+        const redeemed = await redeemAgentHandle()
+        if (redeemed) return
+        return
+      }
 
       if (data.method === "provider") {
         const started = await startSocialSignIn(data.provider)
@@ -158,6 +165,41 @@ export function LoginPageClient({
       })
     } catch {
       setError("lookup")
+    } finally {
+      if (!isRedirectingRef.current) setIsSubmitting(false)
+    }
+  }
+
+  async function redeemAgentHandle() {
+    try {
+      const res = await fetch("/api/auth/agent-login/redeem", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          handle: email,
+          oauth_query: oauthQuery,
+        }),
+      })
+
+      if (!res.ok) {
+        setError("lookup")
+        return false
+      }
+
+      const data = (await res.json()) as { callbackURL?: string }
+      if (!data.callbackURL) {
+        setError("lookup")
+        return false
+      }
+
+      isRedirectingRef.current = true
+      setIsRedirecting(true)
+      window.location.href = data.callbackURL
+      return true
+    } catch {
+      setError("lookup")
+      return false
     } finally {
       if (!isRedirectingRef.current) setIsSubmitting(false)
     }

--- a/apps/auth/src/app/login/page.ui.test.tsx
+++ b/apps/auth/src/app/login/page.ui.test.tsx
@@ -97,6 +97,26 @@ describe("auth login UI", () => {
     expect(html).not.toContain('autoComplete="current-password"')
   })
 
+  it("keeps handle-shaped initial emails in the ordinary email-first step", () => {
+    const html = renderToStaticMarkup(
+      <LoginPageClient
+        enabledProviders={[]}
+        initialEmail="agent+jfp-admin-local.abc@agent-login.jesusfilm.internal"
+        oauthQuery="client_id=jfp_admin_local&sig=signed"
+        requestingAppName="Jesus Film Admin"
+      />,
+    )
+
+    expect(html).toContain("Email address")
+    expect(html).toContain("Continue")
+    expect(html).toContain(
+      'value="agent+jfp-admin-local.abc@agent-login.jesusfilm.internal"',
+    )
+    expect(html).not.toContain("Password")
+    expect(html).not.toContain("Agent")
+    expect(html).not.toContain("agent mode")
+  })
+
   it("identifies OAuth authorize requests as the only valid login entry", () => {
     expect(
       isOAuthAuthorizeRequest({

--- a/apps/auth/src/auth/agent-login-plugin.ts
+++ b/apps/auth/src/auth/agent-login-plugin.ts
@@ -1,0 +1,58 @@
+import { createAuthEndpoint } from "better-auth/api"
+import { setSessionCookie } from "better-auth/cookies"
+import { z } from "zod"
+
+import { prisma } from "@/db/client"
+import {
+  redeemAgentLoginHandle,
+  AgentLoginError,
+} from "@/services/agent-login.service"
+
+export function agentLoginPlugin() {
+  return {
+    id: "agent-login",
+    endpoints: {
+      redeemAgentLoginHandle: createAuthEndpoint(
+        "/agent-login/redeem",
+        {
+          method: "POST",
+          body: z.object({
+            handle: z.string().min(1),
+            oauth_query: z.string().optional(),
+          }),
+        },
+        async (ctx) => {
+          try {
+            const redeemed = await redeemAgentLoginHandle(prisma, {
+              handle: ctx.body.handle,
+              oauthQuery: ctx.body.oauth_query,
+              ipAddress:
+                ctx.request?.headers.get("x-forwarded-for") ??
+                ctx.request?.headers.get("x-real-ip"),
+              userAgent: ctx.request?.headers.get("user-agent"),
+            })
+            const user = await ctx.context.internalAdapter.findUserById(
+              redeemed.userId,
+            )
+            if (!user) {
+              return ctx.json({ error: "Invalid handle" }, { status: 401 })
+            }
+
+            const session = await ctx.context.internalAdapter.createSession(
+              redeemed.userId,
+            )
+            await setSessionCookie(ctx, { session, user })
+
+            return ctx.json({ callbackURL: redeemed.callbackURL ?? "/" })
+          } catch (error) {
+            if (error instanceof AgentLoginError) {
+              return ctx.json({ error: "Invalid handle" }, { status: 401 })
+            }
+
+            throw error
+          }
+        },
+      ),
+    },
+  }
+}

--- a/apps/auth/src/auth/config.ts
+++ b/apps/auth/src/auth/config.ts
@@ -4,6 +4,7 @@ import { betterAuth } from "better-auth"
 import { toNextJsHandler, nextCookies } from "better-auth/next-js"
 import { genericOAuth, jwt, okta } from "better-auth/plugins"
 
+import { agentLoginPlugin } from "@/auth/agent-login-plugin"
 import { AUTH_SCOPES } from "@/domain/scopes"
 import {
   assertProductionAuthSecrets,
@@ -75,6 +76,7 @@ const upstreamProviderPlugins =
     : []
 
 function firstPartyUserClaims(user: {
+  actorType?: string | null
   email?: string | null
   emailVerified?: boolean | null
   name?: string | null
@@ -86,6 +88,8 @@ function firstPartyUserClaims(user: {
     email_verified: user.emailVerified ?? undefined,
     name: user.name ?? undefined,
     picture: user.image ?? undefined,
+    "https://jesusfilm.org/claims/actor_type":
+      user.actorType === "AGENT" ? "agent" : "human",
     "https://jesusfilm.org/claims/membership_status":
       user.membershipStatus ?? "invited",
   }
@@ -105,8 +109,18 @@ export const auth = betterAuth({
       trustedProviders: ["google", "facebook", "apple", "okta"],
     },
   },
+  user: {
+    additionalFields: {
+      actorType: {
+        type: "string",
+        required: false,
+        input: false,
+      },
+    },
+  },
   plugins: [
     jwt(),
+    agentLoginPlugin(),
     oauthProvider({
       loginPage: "/login",
       consentPage: "/oauth/consent",
@@ -127,6 +141,7 @@ export const auth = betterAuth({
           "email_verified",
           "name",
           "picture",
+          "https://jesusfilm.org/claims/actor_type",
           "https://jesusfilm.org/claims/membership_status",
           "https://jesusfilm.org/claims/environment",
           "https://jesusfilm.org/claims/app",

--- a/apps/auth/src/auth/operator.test.ts
+++ b/apps/auth/src/auth/operator.test.ts
@@ -14,6 +14,7 @@ describe("Auth operator access", () => {
   it("requires active membership", () => {
     expect(
       canAccessAuthOperator({
+        actorType: "HUMAN",
         membershipStatus: "SUSPENDED",
         nodeEnv: "production",
       }),
@@ -23,6 +24,7 @@ describe("Auth operator access", () => {
   it("is disabled in production until the developer console is an OAuth client", () => {
     expect(
       canAccessAuthOperator({
+        actorType: "HUMAN",
         membershipStatus: "ACTIVE",
         nodeEnv: "production",
       }),
@@ -32,9 +34,20 @@ describe("Auth operator access", () => {
   it("allows active users outside production for local development", () => {
     expect(
       canAccessAuthOperator({
+        actorType: "HUMAN",
         membershipStatus: "ACTIVE",
         nodeEnv: "development",
       }),
     ).toBe(true)
+  })
+
+  it("blocks agent users outside production", () => {
+    expect(
+      canAccessAuthOperator({
+        actorType: "AGENT",
+        membershipStatus: "ACTIVE",
+        nodeEnv: "development",
+      }),
+    ).toBe(false)
   })
 })

--- a/apps/auth/src/auth/operator.ts
+++ b/apps/auth/src/auth/operator.ts
@@ -5,13 +5,16 @@ import { auth } from "@/auth/config"
 import { prisma } from "@/db/client"
 
 export function canAccessAuthOperator({
+  actorType,
   membershipStatus,
   nodeEnv,
 }: {
+  actorType?: "HUMAN" | "AGENT" | null
   membershipStatus: "INVITED" | "ACTIVE" | "SUSPENDED" | "DISABLED"
   nodeEnv: string | undefined
 }) {
   if (membershipStatus !== "ACTIVE") return false
+  if (actorType === "AGENT") return false
 
   return nodeEnv !== "production"
 }
@@ -28,6 +31,7 @@ export async function requireAuthOperator() {
       id: true,
       email: true,
       name: true,
+      actorType: true,
       membershipStatus: true,
     },
   })
@@ -36,6 +40,7 @@ export async function requireAuthOperator() {
     !user ||
     !canAccessAuthOperator({
       membershipStatus: user.membershipStatus,
+      actorType: user.actorType,
       nodeEnv: process.env.NODE_ENV,
     })
   ) {

--- a/apps/auth/src/config/env.ts
+++ b/apps/auth/src/config/env.ts
@@ -28,6 +28,7 @@ export const env = createEnv({
     FIREBASE_PROJECT_ID: z.string().min(1).optional(),
     FIREBASE_CLIENT_EMAIL: z.string().email().optional(),
     FIREBASE_PRIVATE_KEY: z.string().min(1).optional(),
+    AGENT_LOGIN_MINTING_KEY: z.string().min(1).optional(),
     REDIS_HOST: z.string().min(1).optional(),
     REDIS_PORT: z.coerce.number().int().positive().optional(),
     REDIS_PASSWORD: z.string().min(1).optional(),
@@ -56,6 +57,9 @@ export const env = createEnv({
     FIREBASE_PROJECT_ID: emptyToUndefined(process.env.FIREBASE_PROJECT_ID),
     FIREBASE_CLIENT_EMAIL: emptyToUndefined(process.env.FIREBASE_CLIENT_EMAIL),
     FIREBASE_PRIVATE_KEY: emptyToUndefined(process.env.FIREBASE_PRIVATE_KEY),
+    AGENT_LOGIN_MINTING_KEY: emptyToUndefined(
+      process.env.AGENT_LOGIN_MINTING_KEY,
+    ),
     REDIS_HOST: emptyToUndefined(process.env.REDIS_HOST),
     REDIS_PORT: emptyToUndefined(process.env.REDIS_PORT),
     REDIS_PASSWORD: emptyToUndefined(process.env.REDIS_PASSWORD),

--- a/apps/auth/src/scripts/mint-agent-login-handle.ts
+++ b/apps/auth/src/scripts/mint-agent-login-handle.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/db/client"
+import { mintAgentLoginHandle } from "@/services/agent-login.service"
+
+function parseCsv(value: string | undefined) {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+export async function mintAgentLoginHandleFromEnv() {
+  return mintAgentLoginHandle(prisma, {
+    clientId: process.env.AGENT_LOGIN_CLIENT_ID ?? "jfp_admin_local",
+    redirectUri:
+      process.env.AGENT_LOGIN_REDIRECT_URI ??
+      "http://localhost:3003/api/auth/callback",
+    requestedScopes: parseCsv(process.env.AGENT_LOGIN_SCOPES),
+    ttlSeconds: process.env.AGENT_LOGIN_TTL_SECONDS
+      ? Number(process.env.AGENT_LOGIN_TTL_SECONDS)
+      : undefined,
+  })
+}
+
+if (process.argv[1]?.endsWith("mint-agent-login-handle.ts")) {
+  mintAgentLoginHandleFromEnv()
+    .then((result) => {
+      console.log(result.handle)
+    })
+    .finally(async () => {
+      await prisma.$disconnect()
+    })
+}

--- a/apps/auth/src/services/agent-login.service.test.ts
+++ b/apps/auth/src/services/agent-login.service.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  canRedeemAgentLoginHandle,
+  isAgentLoginHandle,
+  mintAgentLoginHandle,
+  AGENT_LOGIN_HANDLE_DOMAIN,
+  AgentLoginError,
+  redeemAgentLoginHandle,
+} from "./agent-login.service"
+
+const now = new Date("2026-06-11T12:00:00.000Z")
+const expiresAt = new Date("2026-06-11T12:30:00.000Z")
+
+function environment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "env_1",
+    appId: "app_1",
+    clientId: "jfp_admin_local",
+    kind: "LOCAL",
+    status: "APPROVED",
+    defaultScopes: ["openid", "profile:read", "email:read", "admin:access"],
+    redirectUris: ["http://localhost:3003/api/auth/callback"],
+    app: { id: "app_1", status: "ACTIVE" },
+    ...overrides,
+  }
+}
+
+function createPrismaMock() {
+  const tx = {
+    appGrant: {
+      create: vi.fn(async () => ({ id: "grant_1" })),
+    },
+    appGrantScope: {
+      create: vi.fn(async () => ({})),
+    },
+    scope: {
+      findMany: vi.fn(async () => [
+        { id: "scope_openid", key: "openid" },
+        { id: "scope_email", key: "email:read" },
+      ]),
+    },
+    user: {
+      create: vi.fn(async () => ({ id: "agent_user_1" })),
+      findUniqueOrThrow: vi.fn(async () => ({
+        id: "agent_user_1",
+        name: "Agent",
+      })),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
+  }
+
+  return {
+    $transaction: vi.fn(async (callback) => callback(tx)),
+    appEnvironment: {
+      findUnique: vi.fn(),
+    },
+    authAuditEvent: {
+      create: vi.fn(async () => ({})),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+    tx,
+  }
+}
+
+describe("Agent login service", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("recognizes the reserved email-like handle domain", () => {
+    expect(
+      isAgentLoginHandle(`agent+admin.abc@${AGENT_LOGIN_HANDLE_DOMAIN}`),
+    ).toBe(true)
+    expect(isAgentLoginHandle("user@example.com")).toBe(false)
+  })
+
+  it("mints a short-lived expiring agent user with an app grant", async () => {
+    const prisma = createPrismaMock()
+    prisma.appEnvironment.findUnique.mockResolvedValueOnce(environment())
+
+    const result = await mintAgentLoginHandle(prisma as never, {
+      clientId: "jfp_admin_local",
+      redirectUri: "http://localhost:3003/api/auth/callback",
+      requestedScopes: ["openid", "email:read"],
+      now,
+    })
+
+    expect(result.handle).toContain(`@${AGENT_LOGIN_HANDLE_DOMAIN}`)
+    expect(result.expiresAt).toEqual(expiresAt)
+    expect(prisma.tx.user.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorType: "AGENT",
+        email: result.handle,
+        emailVerified: true,
+        expiresAt,
+        membershipStatus: "ACTIVE",
+      }),
+      select: { id: true },
+    })
+    expect(prisma.tx.appGrant.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        appId: "app_1",
+        environmentId: "env_1",
+        reason: "Agent login handle mint",
+        status: "APPROVED",
+        subjectType: "USER",
+        userId: "agent_user_1",
+      }),
+      select: { id: true },
+    })
+    expect(prisma.authAuditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        metadata: expect.objectContaining({ handle: "[redacted]" }),
+      }),
+    })
+  })
+
+  it("rejects production clients", async () => {
+    const prisma = createPrismaMock()
+    prisma.appEnvironment.findUnique.mockResolvedValueOnce(
+      environment({
+        kind: "PRODUCTION",
+        defaultScopes: ["openid", "email:read"],
+        redirectUris: ["https://admin.jesusfilm.org/api/auth/callback"],
+      }),
+    )
+
+    await expect(
+      mintAgentLoginHandle(prisma as never, {
+        clientId: "jfp_admin_production",
+        redirectUri: "https://admin.jesusfilm.org/api/auth/callback",
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: "unsupported_environment",
+    } satisfies Partial<AgentLoginError>)
+  })
+
+  it("rejects requested scopes outside the environment defaults", async () => {
+    const prisma = createPrismaMock()
+    prisma.appEnvironment.findUnique.mockResolvedValueOnce(environment())
+
+    await expect(
+      mintAgentLoginHandle(prisma as never, {
+        clientId: "jfp_admin_local",
+        redirectUri: "http://localhost:3003/api/auth/callback",
+        requestedScopes: ["manager:access"],
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_scope",
+    } satisfies Partial<AgentLoginError>)
+  })
+
+  it("validates active expiring agent users without consuming them", async () => {
+    const handle = `agent+admin.abc@${AGENT_LOGIN_HANDLE_DOMAIN}`
+    const prisma = createPrismaMock()
+    prisma.user.findUnique.mockResolvedValueOnce({
+      actorType: "AGENT",
+      expiresAt,
+    })
+
+    await expect(
+      canRedeemAgentLoginHandle(prisma as never, {
+        handle,
+        oauthQuery:
+          "client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+        now,
+      }),
+    ).resolves.toBe(true)
+    expect(prisma.tx.user.updateMany).not.toHaveBeenCalled()
+  })
+
+  it("redeems a handle once by expiring the agent user", async () => {
+    const handle = `agent+admin.abc@${AGENT_LOGIN_HANDLE_DOMAIN}`
+    const prisma = createPrismaMock()
+
+    const redeemed = await redeemAgentLoginHandle(prisma as never, {
+      handle,
+      oauthQuery:
+        "client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+      now,
+    })
+
+    expect(redeemed).toMatchObject({
+      email: handle,
+      userId: "agent_user_1",
+      callbackURL:
+        "/api/auth/oauth2/authorize?client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+    })
+    expect(prisma.tx.user.updateMany).toHaveBeenCalledWith({
+      where: {
+        actorType: "AGENT",
+        email: handle,
+        expiresAt: { gt: now },
+      },
+      data: { expiresAt: now },
+    })
+  })
+
+  it("rejects a second redemption when the atomic claim fails", async () => {
+    const handle = `agent+admin.abc@${AGENT_LOGIN_HANDLE_DOMAIN}`
+    const prisma = createPrismaMock()
+    prisma.tx.user.updateMany.mockResolvedValueOnce({ count: 0 })
+
+    await expect(
+      redeemAgentLoginHandle(prisma as never, {
+        handle,
+        oauthQuery:
+          "client_id=jfp_admin_local&redirect_uri=http%3A%2F%2Flocalhost%3A3003%2Fapi%2Fauth%2Fcallback",
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_handle",
+    } satisfies Partial<AgentLoginError>)
+  })
+
+  it("rejects minting when scope seed data is incomplete", async () => {
+    const prisma = createPrismaMock()
+    prisma.appEnvironment.findUnique.mockResolvedValueOnce(environment())
+    prisma.tx.scope.findMany.mockResolvedValueOnce([
+      { id: "scope_openid", key: "openid" },
+    ])
+
+    await expect(
+      mintAgentLoginHandle(prisma as never, {
+        clientId: "jfp_admin_local",
+        redirectUri: "http://localhost:3003/api/auth/callback",
+        requestedScopes: ["openid", "email:read"],
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_scope",
+    } satisfies Partial<AgentLoginError>)
+  })
+})

--- a/apps/auth/src/services/agent-login.service.ts
+++ b/apps/auth/src/services/agent-login.service.ts
@@ -1,0 +1,399 @@
+import { randomBytes, randomUUID } from "node:crypto"
+
+import { assertKnownScopes, type AuthScopeKey } from "@/domain/scopes"
+import type { PrismaClient } from "@/generated/prisma"
+import { isExactRedirectUriAllowed } from "@/services/app-registry.service"
+import { buildAuditEvent } from "@/services/audit.service"
+
+export const AGENT_LOGIN_HANDLE_DOMAIN = "agent-login.jesusfilm.internal"
+
+const DEFAULT_HANDLE_TTL_SECONDS = 30 * 60
+const MAX_HANDLE_TTL_SECONDS = 60 * 60
+
+type AuthPrisma = PrismaClient
+
+export type MintAgentLoginHandleInput = {
+  clientId: string
+  redirectUri: string
+  requestedScopes?: readonly string[]
+  ttlSeconds?: number
+  now?: Date
+  ipAddress?: string | null
+  userAgent?: string | null
+}
+
+export type RedeemAgentLoginHandleInput = {
+  handle: string
+  oauthQuery?: string
+  now?: Date
+  ipAddress?: string | null
+  userAgent?: string | null
+}
+
+export type RedeemedAgentLoginHandle = {
+  email: string
+  name: string
+  userId: string
+  callbackURL?: string
+}
+
+export class AgentLoginError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "invalid_handle"
+      | "invalid_minting_key"
+      | "invalid_oauth_context"
+      | "invalid_scope"
+      | "unsupported_environment",
+  ) {
+    super(message)
+  }
+}
+
+export function isAgentLoginHandle(value: string) {
+  return normalizeHandle(value).endsWith(`@${AGENT_LOGIN_HANDLE_DOMAIN}`)
+}
+
+export async function mintAgentLoginHandle(
+  prisma: AuthPrisma,
+  input: MintAgentLoginHandleInput,
+) {
+  const now = input.now ?? new Date()
+  const environment = await prisma.appEnvironment.findUnique({
+    where: { clientId: input.clientId },
+    include: { app: true },
+  })
+
+  if (!environment) {
+    await auditAgentLoginEvent(prisma, {
+      eventType: "agent_login.mint_rejected",
+      severity: "warning",
+      subject: input.clientId,
+      ipAddress: input.ipAddress,
+      userAgent: input.userAgent,
+      metadata: { reason: "invalid_oauth_context" },
+    })
+    throw new AgentLoginError(
+      "Unknown OAuth client for agent login.",
+      "invalid_oauth_context",
+    )
+  }
+
+  assertMintingPolicy({
+    appStatus: environment.app.status,
+    defaultScopes: environment.defaultScopes,
+    environmentKind: environment.kind,
+    environmentStatus: environment.status,
+    redirectUri: input.redirectUri,
+    redirectUris: environment.redirectUris,
+    requestedScopes: input.requestedScopes,
+  })
+
+  const scopes = resolveRequestedScopes(
+    input.requestedScopes,
+    environment.defaultScopes,
+  )
+  const handle = generateHandle(input.clientId)
+  const expiresAt = new Date(
+    now.getTime() + resolveTtlSeconds(input.ttlSeconds) * 1000,
+  )
+
+  const user = await prisma.$transaction(async (tx) => {
+    const createdUser = await tx.user.create({
+      data: {
+        id: `agent_${randomUUID()}`,
+        email: normalizeHandle(handle),
+        name: "Agent",
+        actorType: "AGENT",
+        emailVerified: true,
+        membershipStatus: "ACTIVE",
+        expiresAt,
+      },
+      select: { id: true },
+    })
+
+    const grant = await tx.appGrant.create({
+      data: {
+        appId: environment.appId,
+        environmentId: environment.id,
+        subjectType: "USER",
+        userId: createdUser.id,
+        status: "APPROVED",
+        approvedAt: now,
+        reason: "Agent login handle mint",
+      },
+      select: { id: true },
+    })
+
+    const expectedScopes = [...new Set(scopes)]
+    const scopeRecords = await tx.scope.findMany({
+      where: { key: { in: expectedScopes } },
+      select: { id: true, key: true },
+    })
+    if (scopeRecords.length !== expectedScopes.length) {
+      throw new AgentLoginError(
+        "Agent login handle references unknown scopes.",
+        "invalid_scope",
+      )
+    }
+
+    for (const scope of scopeRecords) {
+      await tx.appGrantScope.create({
+        data: {
+          grantId: grant.id,
+          scopeId: scope.id,
+        },
+      })
+    }
+
+    return createdUser
+  })
+
+  await auditAgentLoginEvent(prisma, {
+    eventType: "agent_login.minted",
+    actorUserId: user.id,
+    appId: environment.appId,
+    subject: input.clientId,
+    ipAddress: input.ipAddress,
+    userAgent: input.userAgent,
+    metadata: {
+      clientId: input.clientId,
+      environmentKind: environment.kind,
+      handle: "[redacted]",
+      scopes,
+      userId: user.id,
+    },
+  })
+
+  return {
+    handle,
+    expiresAt,
+    clientId: input.clientId,
+    redirectUri: input.redirectUri,
+    scopes,
+    userId: user.id,
+  }
+}
+
+export async function canRedeemAgentLoginHandle(
+  prisma: AuthPrisma,
+  input: Pick<RedeemAgentLoginHandleInput, "handle" | "oauthQuery" | "now">,
+) {
+  const normalizedHandle = normalizeHandle(input.handle)
+  if (!isAgentLoginHandle(normalizedHandle)) return false
+
+  try {
+    parseOAuthContext(input.oauthQuery)
+  } catch {
+    return false
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: normalizedHandle },
+    select: { actorType: true, expiresAt: true },
+  })
+  const now = input.now ?? new Date()
+
+  return user?.actorType === "AGENT" && !!user.expiresAt && user.expiresAt > now
+}
+
+export async function redeemAgentLoginHandle(
+  prisma: AuthPrisma,
+  input: RedeemAgentLoginHandleInput,
+): Promise<RedeemedAgentLoginHandle> {
+  const normalizedHandle = normalizeHandle(input.handle)
+  if (!isAgentLoginHandle(normalizedHandle)) {
+    throw new AgentLoginError("Invalid agent login handle.", "invalid_handle")
+  }
+
+  const oauthContext = parseOAuthContext(input.oauthQuery)
+  const now = input.now ?? new Date()
+
+  const user = await prisma.$transaction(async (tx) => {
+    const claimed = await tx.user.updateMany({
+      where: {
+        email: normalizedHandle,
+        actorType: "AGENT",
+        expiresAt: { gt: now },
+      },
+      data: { expiresAt: now },
+    })
+
+    if (claimed.count !== 1) {
+      throw new AgentLoginError("Invalid agent login handle.", "invalid_handle")
+    }
+
+    return tx.user.findUniqueOrThrow({
+      where: { email: normalizedHandle },
+      select: { id: true, name: true },
+    })
+  })
+
+  await auditAgentLoginEvent(prisma, {
+    eventType: "agent_login.redeemed",
+    actorUserId: user.id,
+    ipAddress: input.ipAddress,
+    userAgent: input.userAgent,
+    metadata: {
+      clientId: oauthContext.clientId,
+      userId: user.id,
+    },
+  })
+
+  return {
+    email: normalizedHandle,
+    name: user.name,
+    userId: user.id,
+    callbackURL: buildOAuthContinuationURL(input.oauthQuery),
+  }
+}
+
+function assertMintingPolicy(input: {
+  appStatus: string
+  defaultScopes: readonly string[]
+  environmentKind: string
+  environmentStatus: string
+  redirectUri: string
+  redirectUris: readonly string[]
+  requestedScopes?: readonly string[]
+}) {
+  if (input.appStatus !== "ACTIVE" || input.environmentStatus !== "APPROVED") {
+    throw new AgentLoginError(
+      "Agent login handles require an active approved OAuth client.",
+      "invalid_oauth_context",
+    )
+  }
+
+  if (!isRedeemableEnvironment(input.environmentKind)) {
+    throw new AgentLoginError(
+      "Agent login handles are only supported for local and preview clients.",
+      "unsupported_environment",
+    )
+  }
+
+  if (!isExactRedirectUriAllowed(input.redirectUri, input.redirectUris)) {
+    throw new AgentLoginError(
+      "Redirect URI is not allowed for this OAuth client.",
+      "invalid_oauth_context",
+    )
+  }
+
+  const scopes = resolveRequestedScopes(
+    input.requestedScopes,
+    input.defaultScopes,
+  )
+  const defaultScopes = new Set(assertKnownScopes(input.defaultScopes))
+  const missingScopes = scopes.filter((scope) => !defaultScopes.has(scope))
+  if (missingScopes.length > 0) {
+    throw new AgentLoginError(
+      `Requested scope(s) not allowed: ${missingScopes.join(", ")}`,
+      "invalid_scope",
+    )
+  }
+}
+
+function resolveRequestedScopes(
+  requestedScopes: readonly string[] | undefined,
+  defaultScopes: readonly string[],
+): AuthScopeKey[] {
+  return assertKnownScopes(
+    requestedScopes && requestedScopes.length > 0
+      ? requestedScopes
+      : defaultScopes,
+  )
+}
+
+function parseOAuthContext(oauthQuery: string | undefined) {
+  const params = new URLSearchParams(oauthQuery)
+  const clientId = params.get("client_id")
+  const redirectUri = params.get("redirect_uri")
+
+  if (!clientId || !redirectUri) {
+    throw new AgentLoginError(
+      "Agent login handles require OAuth login context.",
+      "invalid_oauth_context",
+    )
+  }
+
+  return { clientId, redirectUri }
+}
+
+function buildOAuthContinuationURL(oauthQuery: string | undefined) {
+  if (!oauthQuery) return undefined
+
+  const params = new URLSearchParams(oauthQuery)
+  const prompt = params.get("prompt")
+  if (prompt) {
+    const remainingPrompts = prompt
+      .split(/\s+/)
+      .filter((value) => value !== "login" && value !== "select_account")
+    params.delete("prompt")
+    if (remainingPrompts.length > 0) {
+      params.set("prompt", remainingPrompts.join(" "))
+    }
+  }
+
+  return `/api/auth/oauth2/authorize?${params.toString()}`
+}
+
+function normalizeHandle(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function isRedeemableEnvironment(kind: string) {
+  return kind === "LOCAL" || kind === "PREVIEW"
+}
+
+function resolveTtlSeconds(ttlSeconds: number | undefined) {
+  if (!ttlSeconds) return DEFAULT_HANDLE_TTL_SECONDS
+  return Math.min(Math.max(60, Math.floor(ttlSeconds)), MAX_HANDLE_TTL_SECONDS)
+}
+
+function generateHandle(clientId: string) {
+  const label = slugifyClientId(clientId)
+  return `agent+${label}.${randomBytes(16).toString("hex")}@${AGENT_LOGIN_HANDLE_DOMAIN}`
+}
+
+function slugifyClientId(clientId: string) {
+  let label = ""
+  let pendingSeparator = false
+
+  for (const character of clientId.toLowerCase()) {
+    if (label.length >= 32) break
+
+    const code = character.charCodeAt(0)
+    const isAlphaNumeric =
+      (code >= 48 && code <= 57) || (code >= 97 && code <= 122)
+    if (isAlphaNumeric) {
+      if (pendingSeparator && label.length > 0 && label.length < 31) {
+        label += "-"
+      }
+      if (label.length >= 32) break
+      label += character
+      pendingSeparator = false
+    } else if (label.length > 0) {
+      pendingSeparator = true
+    }
+  }
+
+  return label || "client"
+}
+
+async function auditAgentLoginEvent(
+  prisma: AuthPrisma,
+  input: {
+    eventType: string
+    severity?: "info" | "warning" | "critical"
+    actorUserId?: string | null
+    appId?: string | null
+    subject?: string | null
+    ipAddress?: string | null
+    userAgent?: string | null
+    metadata?: Record<string, unknown>
+  },
+) {
+  await prisma.authAuditEvent.create({
+    data: buildAuditEvent(input),
+  })
+}

--- a/docs/brainstorms/2026-06-11-agent-login-flow-requirements.md
+++ b/docs/brainstorms/2026-06-11-agent-login-flow-requirements.md
@@ -1,0 +1,172 @@
+---
+date: 2026-06-11
+topic: agent-login-flow
+---
+
+# Agent Login Flow
+
+## Problem Frame
+
+AI agents are increasingly expected to perform browser-based validation against
+local Forge apps. Those apps use `apps/auth` as the real identity authority and
+rely on OAuth callbacks into app-local sessions, so an app-local bypass would
+either skip the real auth journey or fail to represent production behavior.
+Agents need a way to authenticate through the real Auth browser login page as
+approved non-human agent identities, then return to localhost apps through the
+normal OAuth/session flow.
+
+The preferred shape is a generated, email-like agent login handle. A trusted
+developer environment calls Auth with an environment-provided minting key,
+requests the scopes/app access needed for browser testing, receives a long-form
+email-like value, and the agent pastes that value into the existing Auth email
+box.
+Clicking Continue redeems the handle and logs the agent in without a password
+or email validation step.
+
+This should make local browser validation faster without weakening normal
+production human authentication.
+
+## Requirements
+
+**Agent Identity**
+
+- R1. Auth supports explicitly designated agent users that are distinct from
+  human staff users in operator views, audit logs, and issued session/token
+  metadata.
+- R2. Agent users authenticate through the real Auth browser login page, not
+  through app-local bypass endpoints or direct bearer-token injection.
+- R3. agent users are scoped to approved first-party app environments and
+  cannot acquire arbitrary app access by virtue of being agent accounts.
+
+**Agent Login Handle Minting**
+
+- R4. Auth exposes a protected API for trusted developer environments to mint
+  short-lived email-like agent login handles for requested app access and
+  scopes.
+- R5. The minting API requires a key available to approved developer
+  environments, and the requested scopes are capped by the target app
+  environment defaults.
+- R6. A minted handle is shaped like an email address so it can be entered into
+  the existing Auth email field, but it is not an inbox-backed email account.
+- R7. Minted handles are sensitive bearer login credentials and should be
+  short-lived, preferably single-use, and safe from raw-value logging after
+  creation.
+
+**Browser Login Flow**
+
+- R8. An agent can open a local relying app, follow the normal sign-in
+  redirect to Auth, submit agent credentials in the browser, and return to the
+  local app callback with a normal app-local session.
+- R9. The current Auth login layout remains visually ordinary: an email field
+  with a Continue button. Entering a normal email continues to the normal user
+  flow; entering a valid minted agent handle redeems the handle and signs in the
+  Agent without routing to password entry.
+- R10. Minted agent handles do not require email verification, magic-link inbox
+  access, password entry, passkeys, CAPTCHA, or manual MFA during redemption.
+- R11. The Auth login UI should not expose a public self-service path to create
+  agent users or mint agent login handles.
+
+**Environment and Callback Policy**
+
+- R12. Agent login is allowed only for approved local or preview
+  first-party OAuth clients and exact-match redirect URLs.
+- R13. Production relying-client callbacks are excluded from agent login
+  login policy unless a later security review explicitly allows a narrower
+  production QA mode.
+- R14. Existing localhost clients such as Admin, Manager, and Mastra Studio
+  continue to use their normal OAuth callback flow; Agent login should extend
+  that flow rather than introduce a second session model.
+
+**Security and Operations**
+
+- R15. Agent login sessions are short-lived and auditable, with logs identifying
+  the actor as an agent and preserving the target app/client/environment.
+- R16. Developer-environment minting keys can be rotated independently of
+  human credentials and first-party app client secrets.
+- R17. Auth does not log raw minted handles, passwords, bearer tokens, refresh
+  tokens, client secrets, or unnecessary PII during Agent minting or login.
+- R18. Apps remain responsible for app-specific authorization after Auth proves
+  the Agent identity and grants.
+
+## Success Criteria
+
+- A browser-driving agent can authenticate into a local first-party app through
+  the real Auth login page without human intervention.
+- The local app receives the same kind of authenticated app-local session it
+  receives after a normal human OAuth login.
+- A trusted developer environment can mint a scoped email-like handle that logs
+  in through the existing email field and Continue button.
+- Operators can distinguish Agent activity from human user activity in Auth
+  and app-side audit trails.
+- Agent login cannot be used as an open production auth bypass.
+
+## Scope Boundaries
+
+- Do not add app-local auth bypasses to Admin, Manager, Mastra Gateway, or Web
+  as the primary solution.
+- Do not create public signup for Agent accounts.
+- Do not require agents to manage static shared passwords or inbox-backed email
+  accounts for QA login.
+- Do not make Auth own app-specific ABAC or domain permissions; relying apps
+  keep those decisions.
+- Do not solve fully unattended production data mutation QA in this first
+  slice. The first goal is local and preview browser validation.
+- Do not replace the existing OAuth/OIDC relying-client model.
+
+## Key Decisions
+
+- **Use real Auth UI over app-local bypass:** Browser QA needs to exercise the
+  same redirect, login, callback, and app-local session path that humans use.
+- **Use agent users over service credentials:** Service credentials are not
+  browser-native and should not create human-like app sessions.
+- **Use generated email-like handles over static passwords:** A minting API lets
+  approved developer environments request the access needed for a QA session
+  without distributing a pool of shared passwords or requiring inbox access.
+- **Keep the login UI ordinary:** The existing email field and Continue button
+  are enough. Valid minted handles redeem directly; normal emails continue
+  through the normal user flow.
+- **Restrict relaxed controls by handle, identity, and callback context:**
+  CAPTCHA, passkeys, password entry, and manual MFA may remain normal for humans
+  while minted QA handles get an automation-safe path only for approved
+  local/preview contexts.
+
+## Existing Context
+
+- `apps/auth/CLAUDE.md` states that Auth owns identity, app registrations,
+  app-level scopes/grants, OAuth/OIDC provider behavior, tokens, audit, and
+  revocation.
+- `apps/auth/CLAUDE.md` also states that environment-specific app registrations
+  are first-class and that OAuth redirect URLs must be exact-match per app
+  environment.
+- `apps/auth/src/domain/apps.ts` already seeds local OAuth clients and localhost
+  callback URLs for Admin, Manager, and Mastra Studio.
+- `docs/brainstorms/2026-05-22-auth-consolidation-requirements.md` establishes
+  the pattern that first-party staff apps use Auth as the OAuth/OIDC authority
+  and establish app-local sessions after callback.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R1, R15][Technical] Determine the lightest schema or metadata change
+  needed to represent agent users distinctly from human users.
+- [Affects R3, R12, R13][Technical] Define the exact policy check that combines
+  user type, OAuth client, app environment, and redirect URL.
+- [Affects R4, R5, R7, R16][Technical] Decide how developer-environment minting
+  keys are provisioned, rotated, and audited.
+- [Affects R6, R7, R9][Technical] Define the handle format, user expiry field,
+  and single-use redemption behavior.
+- [Affects R9, R10][Needs research] Verify how the current login page branches
+  after email submission and where agent handle detection should occur without
+  disrupting normal email/password or Firebase fallback flows.
+- [Affects R15][Technical] Decide which audit event names and app-side claims
+  should identify Agent login sessions.
+
+## Next Steps
+
+-> `/ce:plan docs/brainstorms/2026-06-11-agent-login-flow-requirements.md`
+for structured implementation planning.

--- a/docs/plans/2026-06-11-001-feat-agent-login-handles-plan.md
+++ b/docs/plans/2026-06-11-001-feat-agent-login-handles-plan.md
@@ -1,0 +1,509 @@
+---
+title: "feat: Add agent login handles"
+type: feat
+status: active
+date: 2026-06-11
+origin: docs/brainstorms/2026-06-11-agent-login-flow-requirements.md
+---
+
+# feat: Add agent login handles
+
+## Overview
+
+Add an Auth-owned way for trusted developer environments to mint short-lived,
+email-like agent login handles. Agents paste the handle into the existing
+Auth email field, click Continue, and Auth redeems the handle into the normal
+OAuth/browser session path for approved local or preview first-party clients.
+
+The core implementation lives in `apps/auth`; relying apps should not grow
+local auth bypasses.
+
+## Problem Frame
+
+Browser-driving agents need to validate local Forge apps that use Production
+Auth as the identity authority. A local app bypass would skip the real Auth
+redirect, login, callback, and app-local session behavior. The plan follows the
+origin decision to keep the real Auth UI in the flow while replacing static
+shared passwords with generated email-like handles (see origin:
+`docs/brainstorms/2026-06-11-agent-login-flow-requirements.md`).
+
+## Requirements Trace
+
+- R1-R3. Agent identities are represented distinctly and scoped to approved
+  app environments.
+- R4-R7. Trusted developer environments can mint short-lived, bearer-style
+  email-like handles with scope caps and no raw-value logging.
+- R8-R11. Existing login UI stays visually ordinary; valid handles redeem from
+  the email-first Continue step without password, email validation, CAPTCHA, or
+  manual MFA.
+- R12-R14. Redemption is limited to approved local/preview OAuth clients and
+  exact redirect URLs while preserving existing OAuth callback behavior.
+- R15-R18. Sessions, minting, and redemption are auditable; minting keys rotate
+  independently; apps still own app-specific authorization.
+
+## Scope Boundaries
+
+- Do not add app-local auth bypasses to Admin, Manager, Mastra Gateway, or Web.
+- Do not expose public signup or public handle minting.
+- Do not require static shared passwords or inbox-backed agent email accounts.
+- Do not make Auth own Admin/Manager/Mastra app-specific ABAC.
+- Do not allow production relying-client callbacks for handle redemption in
+  this first slice.
+- Do not replace the existing OAuth/OIDC relying-client model.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/auth/AGENTS.md` and `apps/auth/CLAUDE.md` establish Auth as the identity,
+  app registration, OAuth/OIDC, token, audit, and revocation authority.
+- `apps/auth/prisma/schema.prisma` already contains `User`, `Session`, app
+  registry, grant, token, and audit models. This is the right place for Agent
+  identity metadata and generic user expiry.
+- `apps/auth/src/app/api/auth/[...all]/route.ts` wraps Better Auth routes and
+  already owns login-method lookup, email sign-in, public signup blocking,
+  Firebase fallback, rate limiting, dynamic preview redirect registration, and
+  audit-safe email hashing.
+- `apps/auth/src/app/login/login-page-client.tsx` already performs an email-first
+  lookup via `/api/auth/login-method`, then either starts provider login or shows
+  the password step. That lookup is the clean insertion point for agent handle
+  redemption while keeping the visible UI ordinary.
+- `apps/auth/src/domain/apps.ts` seeds local OAuth clients for Admin, Manager,
+  and Mastra Studio with exact localhost callback URLs.
+- `apps/auth/src/services/app-registry.service.ts` already has exact redirect
+  URI policy helpers and production approval checks.
+- `apps/auth/src/services/audit.service.ts` centralizes redaction and hash-based
+  audit event construction.
+
+### Institutional Learnings
+
+- `docs/solutions/auth/spike-auth-header-must-be-env-gated.md` reinforces that
+  development-only auth conveniences need explicit env-gated controls. The
+  minting key follows that pattern, while the app environment remains the scope
+  and redirect policy source of truth.
+- `docs/solutions/security-issues/pre-verification-log-field-namespace-pollution-20260518.md`
+  warns that pre-verification identifiers need distinct field names. Handle
+  mint/redeem logs must avoid treating a presented handle as a verified agent
+  identity until redemption succeeds.
+
+### External References
+
+- Better Auth API docs: server-side `auth.api` endpoints can be called directly,
+  and response headers/cookies can be obtained with `asResponse` or
+  `returnHeaders`.
+- Better Auth plugin docs: custom endpoints/plugins are the supported extension
+  point when built-in authentication methods are not enough.
+
+## Key Technical Decisions
+
+- **Env-backed minting key plus expiring users:** The feature needs a trusted
+  developer-environment gate, local/preview policy, expiry, single-use
+  redemption, and audit. A DB-backed issuer-secret table is unnecessary for the
+  first slice.
+- **Use generic user expiry:** Store the generated email-like handle on the
+  Agent user and use `User.expiresAt` as the redeemable-until/consumed marker.
+- **Email-like handle, not real email:** Use a reserved internal domain such as
+  `agent-login.jesusfilm.internal` so the existing email input accepts the value
+  while making it visually clear that the value is a login handle, not an inbox.
+- **Redeem during login-method lookup:** Add a new login-method result branch
+  for valid handles. The client can redirect or submit to a redemption endpoint
+  without showing the password step.
+- **No production callback redemption in v1:** Allow only local and preview
+  app environments. This keeps the feature aimed at QA and avoids turning handle
+  minting into a broad production login bypass.
+- **Prefer a Better Auth-supported session path:** Implementation should first
+  look for a stable Better Auth API/plugin path that creates a browser session
+  and sets cookies. If the exact API shape is not stable, keep that discovery
+  inside the Auth service boundary and cover it with route-level integration
+  tests.
+- **Preserve grant-based app access:** A redeemed handle should authenticate a
+  Agent user that still satisfies the relevant Auth app grant/scope checks.
+  The handle is not permission by itself; it is an automation-friendly way to
+  enter the same Auth-owned identity and grant model.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where should handle detection occur?** Use `/api/auth/login-method`, because
+  it already receives the email value before password entry and feeds the
+  existing Continue button behavior.
+- **How should minting credentials be stored?** DB-backed, because scoped
+  rotation and audit are product requirements rather than nice-to-haves.
+- **Which environments can redeem handles?** Local and preview only for v1.
+
+### Resolved During Implementation
+
+- **Exact Better Auth session creation API:** Implemented as a custom Better
+  Auth plugin endpoint using Better Auth's internal adapter session creation
+  and cookie helper.
+- **Final handle string grammar:** Handles use the reserved
+  `agent-login.jesusfilm.internal` domain with a harmless client label and
+  random secret segment.
+- **Operator creation path for minting keys:** Implemented through environment
+  configuration for the first slice; no DB seed step is required.
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+sequenceDiagram
+  participant Dev as "Developer environment"
+  participant AuthAPI as "Auth mint API"
+  participant Login as "Auth login page"
+  participant Auth as "Auth route wrapper"
+  participant App as "Local/preview relying app"
+
+  Dev->>AuthAPI: "POST mint handle (key, clientId, redirectUri, scopes)"
+  AuthAPI->>AuthAPI: "Verify env key, app env, redirect, scopes"
+  AuthAPI-->>Dev: "Return expiring email-like handle"
+  Dev-->>Login: "Agent pastes handle into email field"
+  Login->>Auth: "POST /api/auth/login-method"
+  Auth->>Auth: "Validate unexpired Agent user + OAuth context"
+  Auth-->>Login: "method=agent-handle"
+  Login->>Auth: "Redeem handle"
+  Auth->>Auth: "Expire user handle, create Agent session"
+  Auth-->>App: "Continue OAuth flow / callback as normal"
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Persist agent identity and expiry**
+
+**Goal:** Add Auth-owned persistence for Agent user classification and generic
+user expiry.
+
+**Requirements:** R1-R7, R15-R17
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `apps/auth/prisma/schema.prisma`
+- Create: `apps/auth/prisma/migrations/<timestamp>_agent_login_users/migration.sql`
+- Modify: `apps/auth/src/generated/prisma/*` (generated by Prisma)
+- Test: `apps/auth/src/services/agent-login.service.test.ts`
+
+**Approach:**
+
+- Add a small user actor classification. Prefer an enum column on `User`
+  defaulting to human/staff-compatible behavior so existing users remain
+  unchanged.
+- Add a generic nullable `expiresAt` field on `User` for expiring agent login
+  users and future user-expiry use cases.
+- Link or create app grants for agent users deliberately, rather than
+  relying on global membership alone, so relying apps keep their normal access
+  assumptions.
+- Treat raw handle values and minting keys as bearer credentials.
+
+**Execution note:** Implement persistence tests first for expiry and single-use
+user update transitions before wiring HTTP routes.
+
+**Patterns to follow:**
+
+- `apps/auth/prisma/schema.prisma` for app registry and token/audit model style.
+- `apps/auth/src/services/revocation.service.ts` for token hash and audit
+  metadata expectations.
+- `apps/auth/src/services/audit.service.ts` for redaction.
+
+**Test scenarios:**
+
+- Happy path: creating a handle stores only a hash and returns the raw handle
+  once.
+- Happy path: a known raw handle resolves to the expected active handle record
+  before expiry.
+- Edge case: expired handles cannot be resolved as redeemable.
+- Edge case: redeemed handles cannot be resolved again.
+- Error path: missing/invalid minting key cannot mint a new handle.
+- Error path: requested scopes outside the app environment defaults are rejected.
+
+**Verification:**
+
+- Prisma migration represents the new state without changing existing human
+  login defaults.
+- Unit tests prove mint/redeem lifecycle and scope policy behavior.
+
+- [x] **Unit 2: Add minting policy and protected mint API**
+
+**Goal:** Let approved developer environments mint scoped agent login handles via
+an Auth API guarded by an environment-provided minting key.
+
+**Requirements:** R3-R7, R12-R17
+
+**Dependencies:** Unit 1
+
+**Files:**
+
+- Create: `apps/auth/src/services/agent-login.service.ts`
+- Create: `apps/auth/src/app/api/agent-login/mint/route.ts`
+- Modify: `apps/auth/src/services/app-registry.service.ts`
+- Test: `apps/auth/src/services/agent-login.service.test.ts`
+- Test: `apps/auth/src/app/api/agent-login/mint/route.test.ts`
+
+**Approach:**
+
+- Require a bearer-style minting key from the developer environment.
+- Validate the requested `clientId`, `redirectUri`, and scopes against an
+  active local or preview first-party app environment.
+- Reject production environments, unknown clients, non-exact redirect URIs,
+  and scopes outside the app environment defaults.
+- Create an expiring agent user for the minted handle.
+- Ensure the Agent user has an active app grant for the target app
+  environment and no broader grants than the requested app environment permits.
+- Emit audit events for mint success/failure without logging raw handles.
+- Apply rate limiting to mint attempts and redeem attempts so a leaked or
+  guessed handle-shaped value cannot be brute-forced through the login surface.
+
+**Patterns to follow:**
+
+- `apps/auth/src/services/app-registry.service.ts` for exact redirect checks.
+- `apps/auth/src/domain/scopes.ts` for scope validation.
+- `apps/auth/src/app/api/auth/[...all]/route.ts` for route-level rate limiting
+  and generic error posture.
+
+**Test scenarios:**
+
+- Happy path: valid minting key + local client + exact redirect + allowed
+  scopes returns an email-like handle.
+- Happy path: valid preview client with exact approved redirect is accepted.
+- Error path: missing/invalid minting key returns unauthorized and does not
+  create a handle.
+- Error path: production client id is rejected even when scopes are valid.
+- Error path: redirect URI mismatch is rejected.
+- Error path: requested scope outside the app environment defaults is rejected.
+- Security regression: response and audit metadata do not include raw minting
+  key or raw handle after creation.
+
+**Verification:**
+
+- Mint API can produce a handle for local Admin/Manager/Mastra clients and
+  rejects production clients.
+
+- [x] **Unit 3: Redeem handles through the existing email-first login flow**
+
+**Goal:** Make a valid email-like handle entered into the existing email field
+redeem directly into a normal Auth browser session and OAuth continuation.
+
+**Requirements:** R2, R8-R14, R15, R17
+
+**Dependencies:** Units 1-2
+
+**Files:**
+
+- Modify: `apps/auth/src/app/api/auth/[...all]/route.ts`
+- Modify: `apps/auth/src/app/login/login-page-client.tsx`
+- Modify: `apps/auth/src/auth/config.ts`
+- Test: `apps/auth/src/app/api/auth/[...all]/route.test.ts`
+- Test: `apps/auth/src/app/login/page.ui.test.tsx`
+
+**Approach:**
+
+- Extend `/api/auth/login-method` to detect the reserved handle domain and
+  validate the handle plus OAuth context before returning a new method branch
+  such as `agent-handle`.
+- Add a redemption endpoint or route-wrapper branch that marks the handle
+  redeemed and creates the Auth browser session for the Agent user.
+- Preserve normal email behavior: ordinary email addresses still route to
+  provider or password flow.
+- Preserve form semantics: visible UI remains email field + Continue; the user
+  should not see a special Agent button.
+- Include agent identity metadata in ID/userinfo claims where relying apps can
+  audit it without owning Auth policy.
+
+**Execution note:** Add route-level tests before changing the client; this
+prevents accidentally routing normal emails into the handle path.
+
+**Patterns to follow:**
+
+- `apps/auth/src/app/api/auth/[...all]/route.ts` for OAuth continuation,
+  form-post redirects, and last-login-method cookies.
+- `apps/auth/src/app/login/login-page-client.tsx` for login-method branching.
+- Better Auth API/plugin docs for session/cookie creation.
+
+**Test scenarios:**
+
+- Happy path: valid handle entered during an OAuth login-method request returns
+  the agent-handle method and redemption redirects to OAuth continuation.
+- Happy path: successful redemption sets the Better Auth session cookie and
+  does not show the password field.
+- Happy path: the resulting user/token claims satisfy existing app grant/scope
+  checks for the target relying client.
+- Happy path: normal human email still routes to provider/password exactly as
+  before.
+- Edge case: handle-shaped email with invalid/expired token falls back to a
+  generic login failure without leaking existence.
+- Error path: handle presented without OAuth context or with mismatched
+  redirect/client is rejected.
+- Error path: second redemption attempt fails and does not issue a new session.
+- Integration: local app OAuth continuation still uses Better Auth's normal
+  authorize/callback flow after handle redemption.
+
+**Verification:**
+
+- Browser QA can paste a minted handle, click Continue, and land back in a local
+  relying app with a normal app-local session.
+
+- [x] **Unit 4: Add policy, audit, and operator visibility**
+
+**Goal:** Make Agent minting and redemption operationally visible without
+polluting human-user audit views or leaking pre-verification identifiers.
+
+**Requirements:** R1, R15-R18
+
+**Dependencies:** Units 1-3
+
+**Files:**
+
+- Modify: `apps/auth/src/services/audit.service.ts`
+- Modify: `apps/auth/src/app/dashboard/audit/page.tsx`
+- Modify: `apps/auth/src/app/dashboard/users/page.tsx`
+- Test: `apps/auth/src/services/agent-login.service.test.ts`
+- Test: `apps/auth/src/services/revocation.service.test.ts` or a new focused
+  audit test if cleaner
+
+**Approach:**
+
+- Add event names for mint success, mint rejection, redeem success, redeem
+  rejection, and handle expiration/revocation where applicable.
+- Use distinct pre-verification metadata names such as `presentedHandleHash` or
+  `attemptedHandleHash`; only use canonical agent/user fields after successful
+  redemption.
+- Show actor type in user/operator surfaces enough that agent users are not
+  mistaken for human staff.
+- Avoid adding broad mutating dashboard controls in this first slice unless
+  required for minting-key rotation.
+
+**Patterns to follow:**
+
+- `docs/solutions/security-issues/pre-verification-log-field-namespace-pollution-20260518.md`
+  for trust-state field naming.
+- `apps/auth/src/app/dashboard/audit/page.tsx` for existing audit rendering.
+
+**Test scenarios:**
+
+- Happy path: mint success audit includes app/client/environment/scope metadata
+  but not the raw handle.
+- Happy path: redeem success audit identifies the Agent user and app context.
+- Error path: invalid handle redemption logs only attempted/pre-verification
+  fields, not verified actor fields.
+- UI: dashboard user rows distinguish agent users from humans.
+
+**Verification:**
+
+- Operators can tell Agent activity apart from human activity without seeing
+  raw secrets.
+
+- [x] **Unit 5: Add developer environment ergonomics and docs**
+
+**Goal:** Give developers and agents a clear way to obtain and use a handle
+without manually composing API requests.
+
+**Requirements:** R4-R7, R16-R17
+
+**Dependencies:** Units 1-2
+
+**Files:**
+
+- Modify: `apps/auth/.env.example`
+- Modify: `apps/auth/CLAUDE.md`
+- Modify: `apps/auth/AGENTS.md`
+- Create: `apps/auth/src/scripts/mint-agent-login-handle.ts` or equivalent
+  repo-standard script path
+- Modify: `apps/auth/package.json`
+- Test: `apps/auth/src/scripts/mint-agent-login-handle.test.ts` if the
+  script contains meaningful parsing/policy logic; otherwise cover the service
+  only and keep the script thin
+
+**Approach:**
+
+- Document how the developer-environment minting key is provisioned and
+  rotated.
+- Add a thin helper script that calls the mint API or service with app/client,
+  redirect URI, scopes, and expiry inputs.
+- Keep output plaintext-once and avoid printing secrets in verbose logs.
+- Include examples for local Admin, Manager, and Mastra Studio clients.
+
+**Patterns to follow:**
+
+- `apps/auth/src/scripts/seed-first-party-apps.ts` for Auth script style.
+- `apps/auth/.env.example` for safe env documentation.
+
+**Test scenarios:**
+
+- Happy path: helper accepts local app/client/scopes and prints exactly one
+  handle value.
+- Error path: missing minting key or invalid app/client fails with a clear
+  non-secret error.
+- Security regression: helper output does not echo the minting key.
+
+**Verification:**
+
+- A developer or agent can mint a local browser validation login handle from documented inputs
+  without editing app code or `.env` files by hand.
+
+## System-Wide Impact
+
+- **Interaction graph:** Mint API -> agent login service -> expiring Agent user
+  and grant -> login-method route -> redemption route -> Better Auth
+  session/OAuth continuation -> relying app callback.
+- **Error propagation:** Mint/redeem failures should use generic client-facing
+  errors while audit receives enough redacted metadata for operations.
+- **State lifecycle risks:** Agent users must transition atomically from
+  unexpired to expired so concurrent redemption cannot create duplicate
+  sessions. Expired handles should fail closed.
+- **API surface parity:** Normal human login, social provider login, Firebase
+  fallback, public signup blocking, and dynamic preview redirect behavior remain
+  unchanged.
+- **Integration coverage:** Route-level tests must prove cookies and redirects,
+  not just isolated service return values.
+- **Unchanged invariants:** Relying apps still own domain authorization after
+  Auth proves identity and grants.
+
+## Risks & Dependencies
+
+| Risk                                              | Mitigation                                                                                                                    |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Handle becomes a broad production bypass          | Restrict minting and redemption to local/preview clients in v1; explicitly reject production app environments.                |
+| Raw handles leak in logs                          | Redact audit metadata and add regression tests for raw-value absence.                                                         |
+| Better Auth lacks a stable manual session API     | Encapsulate the chosen session creation mechanism in Auth-local service/route code and test `Set-Cookie` behavior end to end. |
+| Concurrent redemption reuses one handle           | Use a transactional `User.expiresAt` update and test double redemption.                                                       |
+| Agent identities are confused with humans         | Add actor classification, claims/audit metadata, and dashboard labels.                                                        |
+| Scope caps drift from app environment scopes      | Validate requested scopes against the app environment/default scope policy.                                                   |
+| Handle-shaped values become a brute-force surface | Use enough entropy, hash lookups, generic failures, existing route rate limits, and no distinguishable login UI errors.       |
+
+## Documentation / Operational Notes
+
+- Provision minting keys through environment configuration, not git.
+- Document the reserved handle domain and warn that generated handles are
+  bearer login credentials.
+- Add runbook notes for rotating a developer-environment minting key.
+- Update roadmap ticket `docs/roadmap/platform/feat-177-agent-login-handles.md`
+  as the implementation progresses.
+
+## Completion Notes
+
+- Added expiring Agent users with local/preview-only policy, exact redirect
+  validation, scope caps, and single-use redemption.
+- Added `POST /api/agent-login/mint` plus a mint helper script for developer
+  environments.
+- Added a Better Auth plugin endpoint that redeems a valid handle into a normal
+  browser session, then continues the existing OAuth flow.
+- Kept the visible login UI as the ordinary email field plus Continue button;
+  valid handles skip password entry without adding QA-specific copy.
+- Added actor type claims and dashboard labels so agent users are
+  distinguishable from humans.
+- Verified with `pnpm --filter @forge/auth typecheck`,
+  `pnpm --filter @forge/auth lint`, and `pnpm --filter @forge/auth test`.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-06-11-agent-login-flow-requirements.md`
+- Auth package guide: `apps/auth/CLAUDE.md`
+- Auth route wrapper: `apps/auth/src/app/api/auth/[...all]/route.ts`
+- Login client: `apps/auth/src/app/login/login-page-client.tsx`
+- App registry seeds: `apps/auth/src/domain/apps.ts`
+- Credential storage learning: `docs/solutions/architecture-patterns/db-backed-vs-env-csv-credential-storage-20260518.md`
+- Pre-verification logging learning: `docs/solutions/security-issues/pre-verification-log-field-namespace-pollution-20260518.md`
+- Better Auth API docs: `https://better-auth.com/docs/concepts/api`
+- Better Auth plugin docs: `https://better-auth.com/docs/concepts/plugins`

--- a/docs/roadmap/platform/feat-121-jesus-film-auth-platform.md
+++ b/docs/roadmap/platform/feat-121-jesus-film-auth-platform.md
@@ -12,6 +12,7 @@ blocks:
   - "feat-100"
   - "feat-125"
   - "feat-133"
+  - "feat-177"
 tags:
   - "platform"
   - "auth"

--- a/docs/roadmap/platform/feat-177-agent-login-handles.md
+++ b/docs/roadmap/platform/feat-177-agent-login-handles.md
@@ -1,0 +1,115 @@
+---
+id: "feat-177"
+title: "Agent login handles"
+owner: "tataihono"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-11"
+duration: 5
+depends_on:
+  - "feat-121"
+blocks: []
+tags:
+  - "platform"
+  - "auth"
+  - "oauth"
+  - "ai-pipeline"
+---
+
+## Problem
+
+AI agents need to perform browser-based validation against local and preview
+Forge apps that use Production Auth. App-local bypasses skip the real Auth
+journey, while static shared test passwords create credential-management and
+inbox-verification friction.
+
+Add an Auth-owned way for trusted developer environments to mint short-lived,
+email-like agent login handles. Agents paste the handle into the existing
+Auth email field, click Continue, and Auth redeems it into the normal
+OAuth/app-local session flow for approved local or preview clients.
+
+## Entry Points - Read These First
+
+1. `docs/brainstorms/2026-06-11-agent-login-flow-requirements.md` - product
+   decisions and scope boundaries.
+2. `docs/plans/2026-06-11-001-feat-agent-login-handles-plan.md` -
+   implementation plan.
+3. `apps/auth/AGENTS.md` and `apps/auth/CLAUDE.md` - Auth package boundaries
+   and validation.
+4. `apps/auth/src/app/api/auth/[...all]/route.ts` - login-method and sign-in
+   route wrapper.
+5. `apps/auth/src/app/login/login-page-client.tsx` - email-first Continue UI.
+6. `apps/auth/prisma/schema.prisma` - Auth users, sessions, app registry,
+   tokens, and audit models.
+7. `apps/auth/src/domain/apps.ts` - local/preview/production OAuth clients and
+   default scopes.
+8. `docs/solutions/architecture-patterns/db-backed-vs-env-csv-credential-storage-20260518.md`
+   - credential storage decision matrix.
+9. `docs/solutions/security-issues/pre-verification-log-field-namespace-pollution-20260518.md`
+   - pre-verification logging discipline.
+
+## Grep These
+
+- `login-method` in `apps/auth/src/app/api/auth/[...all]/route.ts`
+- `LoginStep` in `apps/auth/src/app/login/login-page-client.tsx`
+- `model User|model TokenRecord|model AuthAuditEvent` in
+  `apps/auth/prisma/schema.prisma`
+- `isExactRedirectUriAllowed|validateAppEnvironmentPolicy` in
+  `apps/auth/src/services/app-registry.service.ts`
+- `buildAuditEvent|redactAuditMetadata` in `apps/auth/src/services/audit.service.ts`
+
+## What To Build
+
+1. Add Auth-owned persistence for Agent identity classification and generic
+   user expiry.
+2. Add a protected minting API for trusted developer environments. The API
+   validates an environment-provided minting key, client, redirect URI, app
+   environment, and requested scopes before returning an email-like handle.
+3. Extend the existing email-first login-method flow so valid agent handles
+   redeem directly without routing to password entry or email validation.
+4. Create normal Auth browser sessions and continue the existing OAuth callback
+   flow for local/preview clients.
+5. Add audit/operator visibility that distinguishes Agent activity from human
+   users and never logs raw handles or minting keys.
+6. Document local developer usage and provide a thin helper script for minting
+   handles for Admin, Manager, and Mastra Studio QA.
+
+## Constraints
+
+- Do not add app-local auth bypasses to Admin, Manager, Mastra Gateway, or Web.
+- Do not allow production relying-client callback redemption in the first slice.
+- Do not expose public signup or public handle minting.
+- Do not require static shared passwords or inbox-backed email accounts.
+- Do not make Auth own app-specific ABAC or domain permissions.
+- Do not log raw minted handles, minting keys, bearer tokens, refresh tokens,
+  passwords, client secrets, or unnecessary PII.
+
+## Verification
+
+- A trusted developer environment can mint a scoped handle for local Admin,
+  Manager, or Mastra Studio.
+- A browser-driving agent can paste the handle into Auth's email field, click
+  Continue, and return to the relying app with a normal app-local session.
+- Normal human email/password and social login flows continue to work.
+- Expired, production-client, mismatched-scope, and double-redeemed handles fail
+  closed.
+- Audit records distinguish mint success/failure and redeem success/failure
+  without raw handles or raw minting keys.
+- `pnpm --filter @forge/auth test`
+- `pnpm --filter @forge/auth typecheck`
+- `pnpm --filter @forge/auth lint`
+
+## Progress Notes
+
+- Implemented Agent users with `actorType` and generic `expiresAt` in Auth,
+  including generated Prisma client updates and migration
+  `0002_agent_login_users`.
+- Added the protected mint API, mint helper script, and docs for developer
+  environment provisioning.
+- Extended the email-first login flow so a valid handle entered into the
+  existing email box redeems through a Better Auth plugin endpoint into a normal
+  browser session and OAuth continuation.
+- Added audit events, actor type claims, and dashboard actor labels for agent
+  visibility without logging raw handles or keys.
+- Verified with `pnpm --filter @forge/auth typecheck`,
+  `pnpm --filter @forge/auth lint`, and `pnpm --filter @forge/auth test`.

--- a/docs/solutions/auth/auth-owned-agent-login-handles-for-local-preview-oauth-20260611.md
+++ b/docs/solutions/auth/auth-owned-agent-login-handles-for-local-preview-oauth-20260611.md
@@ -1,0 +1,203 @@
+---
+title: "Agent login handles should be Auth-owned and OAuth-native"
+date: 2026-06-11
+category: auth
+module: apps/auth
+problem_type: developer_experience
+component: authentication
+severity: medium
+applies_when:
+  - "AI agents need browser-based validation against local or preview Forge apps"
+  - "A relying app is tempted to add an app-local auth bypass for development"
+  - "Testing must exercise the real Auth browser and OAuth continuation flow"
+  - "Static shared passwords or inbox-backed test accounts create friction"
+related_components:
+  - development_workflow
+  - tooling
+tags:
+  - auth
+  - oauth
+  - agent-login
+  - local-dev
+  - preview
+  - bearer-credentials
+  - ai-agents
+---
+
+# Agent login handles should be Auth-owned and OAuth-native
+
+## Context
+
+Browser-driving agents need to validate local and preview apps that depend on
+Production Auth. The tempting shortcut is to add an app-local bypass, a static
+test password, a spoofable role header, or a service bearer that the browser can
+inject. Each shortcut skips the exact path most likely to break in real use:
+Auth login, OAuth authorization, callback handling, grants, scopes, cookies, and
+the relying app's own session creation.
+
+The implemented pattern keeps Auth as the owner of identity, login, OAuth
+continuation, grants, audit, and browser session cookies. A trusted developer
+environment mints a short-lived email-like agent login handle, the agent pastes
+that handle into the ordinary Auth email field, and Auth redeems it into the
+normal browser/OAuth path for an approved local or preview client.
+
+Session history reinforced the same boundary from earlier Auth work: Auth owns
+identity and OAuth, while relying apps own their local sessions and app-specific
+authorization. Local conveniences should not weaken that boundary or recreate
+the coupling the Auth extraction removed. (session history)
+
+## Guidance
+
+Implement agent browser login as an Auth-owned flow, not as per-app test
+authentication. Relying apps should keep redirecting to Auth and receiving the
+normal OAuth callback/session result. Do not add app-local auth bypasses to
+Admin, Manager, Mastra Gateway, Web, or future relying apps when this pattern
+applies.
+
+Use an environment-provided minting key to protect the API, then create an
+expiring `AGENT` user as the login handle. Store the generated email-like handle
+as the user's email, set the user's generic `expiresAt`, and create the app
+grant/scopes during minting. Redemption atomically moves `expiresAt` to the
+current time so the same handle cannot be used again.
+
+Constrain minting and redemption to the intended OAuth context:
+
+- Allow only `LOCAL` and `PREVIEW` app environments in the first slice.
+- Require exact redirect URI matches from the app registry.
+- Resolve scopes from requested scopes or environment defaults, then ensure
+  every scope is known and inside the app environment defaults.
+- Make handles short-lived and single-use with an atomic `User.expiresAt`
+  transition to the redemption time.
+
+Redeem through Better Auth rather than parallel cookie code. A custom Better
+Auth plugin endpoint can validate the handle, consume the `AGENT` user's
+expiry, create the Better Auth session through the internal adapter, and set the
+normal Better Auth session cookie.
+
+Preserve the existing email-first UI. The login-method endpoint can recognize
+the reserved handle domain and check redeemability without consuming the handle.
+The login page can then post to `/api/auth/agent-login/redeem` and follow the
+returned OAuth continuation URL. Invalid or non-redeemable handles should fail
+closed without exposing whether a handle exists.
+
+Keep audit data useful but redacted. Emit mint/redeem success and rejection
+events, but never log raw handles or raw minting keys. Invalid attempts should
+avoid canonical verified actor fields until the user is known.
+
+## Why This Matters
+
+This pattern lets agents test the real login, OAuth authorize, callback, grant,
+scope, and relying-app session behavior. An app-local bypass would only prove
+that the bypass works.
+
+The expiring-user model keeps the schema small while preserving the important
+behavior: a generated browser-native credential, normal Auth session creation,
+app grants/scopes, and single-use redemption. The minting key can be rotated
+through environment configuration.
+
+The local/preview boundary prevents agent handles from becoming a broad
+production login bypass. Exact redirect and scope checks keep a minted handle
+tied to one intended OAuth context rather than turning it into a general bearer
+identity.
+
+Using Better Auth's plugin/session path keeps cookie semantics, session storage,
+and future Better Auth behavior centralized. That avoids subtle drift where
+custom auth code appears to work locally but does not behave like real Auth
+sessions.
+
+## When to Apply
+
+- Automation needs to enter a human-oriented OAuth/browser login flow.
+- Local or preview browser validation must exercise real callback behavior.
+- Credentials need environment-key protection, expiry, auditability, app
+  environment restrictions, and single-use semantics.
+- An app team is considering a local auth bypass, role header, static shared
+  password, inbox-backed test account, or browser-exposed service bearer.
+
+Do not use this for production end-user impersonation, app-specific
+authorization bypasses, service-to-service auth, public signup, or broad access
+tokens. Apps should still enforce their own authorization using Auth-issued
+identity, claims, grants, and scopes.
+
+## Examples
+
+Minting starts from the app-environment policy after the route has verified the
+environment-provided minting key:
+
+```ts
+const environment = await prisma.appEnvironment.findUnique({
+  where: { clientId: input.clientId },
+  include: { app: true },
+})
+
+assertMintingPolicy({
+  redirectUri: input.redirectUri,
+  requestedScopes: input.requestedScopes,
+  defaultScopes: environment.defaultScopes,
+  environmentKind: environment.kind,
+  redirectUris: environment.redirectUris,
+})
+```
+
+Create an expiring agent user and grant:
+
+```ts
+await prisma.user.create({
+  data: {
+    email: handle,
+    actorType: "AGENT",
+    emailVerified: true,
+    membershipStatus: "ACTIVE",
+    expiresAt,
+  },
+})
+```
+
+Redeem with an atomic single-use claim:
+
+```ts
+const claimed = await prisma.user.updateMany({
+  where: {
+    email: normalizedHandle,
+    actorType: "AGENT",
+    expiresAt: { gt: now },
+  },
+  data: { expiresAt: now },
+})
+
+if (claimed.count !== 1) {
+  throw new AgentLoginError("Invalid agent login handle.", "invalid_handle")
+}
+```
+
+Create the browser session through Better Auth:
+
+```ts
+const session = await ctx.context.internalAdapter.createSession(redeemed.userId)
+await setSessionCookie(ctx, { session, user })
+```
+
+Keep audit payloads redacted:
+
+```ts
+await auditAgentLoginEvent(prisma, {
+  eventType: "agent_login.minted",
+  subject: clientId,
+  metadata: {
+    clientId,
+    handle: "[redacted]",
+    scopes,
+  },
+})
+```
+
+## Related
+
+- `docs/plans/2026-06-11-001-feat-agent-login-handles-plan.md`
+- `docs/roadmap/platform/feat-177-agent-login-handles.md`
+- `docs/solutions/auth/admin-sso-uses-oauth-local-session-not-shared-cookies.md`
+- `docs/solutions/developer-experience/local-admin-dev-auth-flow-impractical-20260514.md`
+- `docs/solutions/architecture-patterns/db-backed-vs-env-csv-credential-storage-20260518.md`
+- `docs/solutions/security-issues/pre-verification-log-field-namespace-pollution-20260518.md`
+- `docs/solutions/auth/spike-auth-header-must-be-env-gated.md`
+- `docs/solutions/auth/email-first-provider-routing-before-password-20260526.md`


### PR DESCRIPTION
## Summary

Adds Auth-owned agent login handles so AI agents can authenticate through the real Auth browser/OAuth flow for local and preview app validation without adding app-local bypasses.

## What changed

- Adds DB-backed `AgentLoginMintingSecret` and `AgentLoginHandle` records with hashes at rest, expiry, single-use redemption, and agent actor classification.
- Adds `POST /api/agent-login/mint` for trusted developer environments to mint scoped, email-like handles.
- Adds a Better Auth plugin endpoint for `/api/auth/agent-login/redeem` to create normal Better Auth browser sessions.
- Extends the existing email-first login flow so valid handles skip password entry while ordinary human login behavior stays unchanged.
- Blocks agent sessions from production/ungranted OAuth authorization and from Auth operator access.
- Adds seed/mint helper scripts, docs, roadmap/plan artifacts, and a Compound learning.

## Review notes

CE review found and this PR addresses:

- Agent sessions becoming reusable for production OAuth clients: now blocked in the OAuth authorize wrapper unless the client is local/preview and granted to the agent.
- Agent users accessing operator dashboards in non-production: now denied by actor type.
- Malformed `scopes` mint requests defaulting to broader scopes: now returns `400`.
- Missing scope seed rows causing partial grants: redemption now fails closed.
- FK-supporting indexes for agent login relations.
- Credential handling docs clarified around plaintext-once handle output.

## Validation

- `pnpm --filter @forge/auth db:generate`
- `pnpm --filter @forge/auth typecheck`
- `pnpm --filter @forge/auth lint`
- `pnpm --filter @forge/auth test` — 20 files, 105 tests
