### PR TITLE
fix(admin): preview experiences on the watch host, not the www host

### DIFF
--- a/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
@@ -626,7 +626,7 @@ export default async function ExperienceEditorPage({
       canPublish={selectedLocale.status !== "PUBLISHED"}
       hasPublishedVersion={selectedLocale.publishedAt !== null}
       calendarDate={new Date().toISOString().slice(0, 10)}
-      watchOrigin={env.WEB_CANONICAL_ORIGIN}
+      watchOrigin={env.WATCH_CANONICAL_ORIGIN}
       initialValues={{
         localeId: selectedLocale.id,
         title: selectedLocale.title ?? "",

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.tsx
@@ -964,7 +964,7 @@ export function ExperienceEditor({
   videoLibrary: VideoLibraryItem[]
   mediaLibrary: MediaLibraryItem[]
   calendarDate: string
-  /** Public watch-site origin (env.WEB_CANONICAL_ORIGIN) for preview links. */
+  /** Forge watch-app origin (env.WATCH_CANONICAL_ORIGIN) for preview links. */
   watchOrigin: string
   initialValues: {
     localeId: string

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -7,15 +7,25 @@ import { z } from "zod"
 const emptyToUndefined = (v: string | undefined) => (v === "" ? undefined : v)
 
 export const DEFAULT_WEB_CANONICAL_ORIGIN = "https://www.jesusfilm.org"
+export const DEFAULT_WATCH_CANONICAL_ORIGIN = "https://watch.jesusfilm.org"
 
-export const webCanonicalOriginEnvSchema = z
-  .string()
-  .url()
-  .refine((value) => {
-    const protocol = new URL(value).protocol
-    return protocol === "http:" || protocol === "https:"
-  }, "WEB_CANONICAL_ORIGIN must be an HTTP(S) URL")
-  .transform((value) => new URL(value).origin)
+const httpOriginEnvSchema = (varName: string) =>
+  z
+    .string()
+    .url()
+    .refine((value) => {
+      const protocol = new URL(value).protocol
+      return protocol === "http:" || protocol === "https:"
+    }, `${varName} must be an HTTP(S) URL`)
+    .transform((value) => new URL(value).origin)
+
+export const webCanonicalOriginEnvSchema = httpOriginEnvSchema(
+  "WEB_CANONICAL_ORIGIN",
+)
+
+export const watchCanonicalOriginEnvSchema = httpOriginEnvSchema(
+  "WATCH_CANONICAL_ORIGIN",
+)
 
 /**
  * Shared schema fragment for env vars representing a positive-int
@@ -72,6 +82,12 @@ export const env = createEnv({
     WEB_CANONICAL_ORIGIN: webCanonicalOriginEnvSchema
       .optional()
       .default(DEFAULT_WEB_CANONICAL_ORIGIN),
+    // Forge watch-app origin for experience preview links. Experiences only
+    // render on the forge watch site, so this defaults to the watch host —
+    // distinct from the indexed www host WEB_CANONICAL_ORIGIN targets.
+    WATCH_CANONICAL_ORIGIN: watchCanonicalOriginEnvSchema
+      .optional()
+      .default(DEFAULT_WATCH_CANONICAL_ORIGIN),
     MANAGER_ADMIN_API_KEY: z.string().min(1).optional(),
     REDIS_HOST: z.string().min(1).optional(),
     REDIS_PORT: z.coerce.number().int().positive().optional(),
@@ -310,6 +326,9 @@ export const env = createEnv({
     WEB_CANONICAL_ORIGIN:
       emptyToUndefined(process.env.WEB_CANONICAL_ORIGIN) ??
       DEFAULT_WEB_CANONICAL_ORIGIN,
+    WATCH_CANONICAL_ORIGIN:
+      emptyToUndefined(process.env.WATCH_CANONICAL_ORIGIN) ??
+      DEFAULT_WATCH_CANONICAL_ORIGIN,
     MANAGER_ADMIN_API_KEY: emptyToUndefined(process.env.MANAGER_ADMIN_API_KEY),
     REDIS_HOST: emptyToUndefined(process.env.REDIS_HOST),
     REDIS_PORT: emptyToUndefined(process.env.REDIS_PORT),


### PR DESCRIPTION
## Problem

Follow-up to #1204. The preview link's origin came from `WEB_CANONICAL_ORIGIN`, which deliberately targets the indexed `www.jesusfilm.org` host (the video library's visitor links). Experiences only render on the forge watch app, so previews landed on `https://www.jesusfilm.org/watch/{slug}.html/english.html` — a host with no experience routes — instead of `https://watch.jesusfilm.org/...`.

## Fix

New `WATCH_CANONICAL_ORIGIN` env var (same HTTP(S)-origin validation, **default `https://watch.jesusfilm.org`**) threaded into the experience editor's preview link. `WEB_CANONICAL_ORIGIN` and the video library links are untouched.

Because the default is baked in, no environment needs new configuration — production, PR environments, and local dev all produce the right origin out of the box (localhost still infers the `:3000` dev watch site).

## Testing

- `vitest run src/config src/app/dashboard/experiences/experience-editor.test.tsx`: 51/51 green
- eslint + prettier via pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)