### PR TITLE
[codex] Use paid OpenRouter key for search embeddings

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -102,6 +102,7 @@ MASTRA_EXPERIENCE_INGEST_API_KEYS=local-admin-experience-ingest-key
 # OpenAI / OpenRouter — Admin uses these for live query embeddings and other
 # Admin-owned model calls. Background scene/transcript/experience embeddings
 # use Mastra provider env.
+OPENROUTER_API_PAID_KEY=
 OPENROUTER_API_KEY=
 OPENROUTER_IMAGE_TEXT_MODELS=nvidia/nemotron-nano-12b-v2-vl:free,nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free,baidu/qianfan-ocr-fast:free,google/gemma-4-26b-a4b-it:free,google/gemma-4-31b-it:free,google/gemma-3-27b-it:free,openrouter/free
 # OPENROUTER_IMAGE_TEXT_MODEL=google/gemma-4-26b-a4b-it:free

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1375,8 +1375,9 @@ error_class=… message=…`. Process-local counters in
    `https://admin.jesusfilm.org/api/search/health`. Body's `status`
    field is the signal; HTTP is always 200 so infra-level liveness is
    not confused with provider reachability.
-2. Ensure `OPENROUTER_API_KEY` is set on the `forge-admin` Railway service.
-   `OPENAI_API_KEY` does not satisfy live query embedding readiness.
+2. Ensure `OPENROUTER_API_PAID_KEY` is set on the `forge-admin` Railway
+   service. `OPENROUTER_API_KEY` remains a fallback; `OPENAI_API_KEY` does not
+   satisfy live query embedding readiness.
 3. Canary diff vs cms: for a fixed query set × locales, compare
    `admin/api/search?q=…&locale=…` to `cms/api/search?q=…&locale=…`.
    Top-10 should overlap within ranking ±1. Drift signals either a

--- a/apps/admin/docs/v1-operational-surfaces.md
+++ b/apps/admin/docs/v1-operational-surfaces.md
@@ -37,8 +37,9 @@ version of `apps/admin`.
 - Workflow run inspection uses the Workflow runtime event log. Forge-owned
   trigger actions still live on their domain surfaces, such as Core Sync on
   `/dashboard/system-status`.
-- Semantic search requires `OPENROUTER_API_KEY`. Without it, the page stays
-  usable but reports the missing provider explicitly.
+- Semantic search requires `OPENROUTER_API_PAID_KEY` or the legacy
+  `OPENROUTER_API_KEY`. Without either, the page stays usable but reports the
+  missing provider explicitly.
 
 ## Validation
 

--- a/apps/admin/src/app/dashboard/ops-data.test.ts
+++ b/apps/admin/src/app/dashboard/ops-data.test.ts
@@ -16,6 +16,7 @@ const { queryRaw, mockEnv } = vi.hoisted(() => ({
       AUTH_ADMIN_CLIENT_ID: "admin-client",
       AUTH_ISSUER_URL: "https://auth.example",
       CORS_ALLOWED_ORIGINS: "",
+      OPENROUTER_API_PAID_KEY: undefined as string | undefined,
       OPENROUTER_API_KEY: undefined as string | undefined,
       OPENAI_API_KEY: undefined as string | undefined,
     },
@@ -55,6 +56,7 @@ const ADMIN_PRINCIPAL = {
 } as const satisfies Principal
 
 function resetMockEnv() {
+  mockEnv.env.OPENROUTER_API_PAID_KEY = undefined
   mockEnv.env.OPENROUTER_API_KEY = undefined
   mockEnv.env.OPENAI_API_KEY = undefined
 }
@@ -198,6 +200,26 @@ describe("embedding provider readiness", () => {
     ).toEqual(expect.objectContaining({ value: "OpenRouter" }))
   })
 
+  it("treats OPENROUTER_API_PAID_KEY as the preferred ready embedding backend", async () => {
+    mockEnv.env.OPENROUTER_API_PAID_KEY = "paid-openrouter-key"
+    mockEnv.env.OPENAI_API_KEY = "legacy-openai-key"
+    mockEmbeddingCounts({ total: 2, embedded: 2, published: 1 })
+    queryRaw.mockResolvedValueOnce([])
+
+    const embeddings = await loadEmbeddingsData()
+    const settings = await loadSettingsData()
+
+    expect(embeddings.providerReady).toBe(true)
+    expect(
+      embeddings.insights.find((insight) => insight.label === "Provider"),
+    ).toEqual(expect.objectContaining({ value: "OpenRouter" }))
+    expect(
+      settings.insights.find(
+        (insight) => insight.label === "Embedding Backend",
+      ),
+    ).toEqual(expect.objectContaining({ value: "OpenRouter" }))
+  })
+
   it("keeps semantic search unavailable when only OPENAI_API_KEY is set", async () => {
     mockEnv.env.OPENAI_API_KEY = "legacy-openai-key"
     mockEmbeddingCounts({ total: 2, embedded: 1, published: 1 })
@@ -212,7 +234,7 @@ describe("embedding provider readiness", () => {
       expect.objectContaining({ value: "Missing" }),
     )
     expect(data.unavailableReason).toBe(
-      "Semantic search requires OPENROUTER_API_KEY.",
+      "Semantic search requires OPENROUTER_API_PAID_KEY or OPENROUTER_API_KEY.",
     )
   })
 })

--- a/apps/admin/src/app/dashboard/ops-data.ts
+++ b/apps/admin/src/app/dashboard/ops-data.ts
@@ -1647,7 +1647,10 @@ export async function loadEmbeddingsData(): Promise<EmbeddingsData> {
     insights: [
       {
         label: "Provider",
-        value: env.OPENROUTER_API_KEY ? "OpenRouter" : "Missing",
+        value:
+          (env.OPENROUTER_API_PAID_KEY ?? env.OPENROUTER_API_KEY)
+            ? "OpenRouter"
+            : "Missing",
         detail:
           "Embedding generation backend currently configured for admin workflows.",
       },
@@ -1665,7 +1668,9 @@ export async function loadEmbeddingsData(): Promise<EmbeddingsData> {
         detail: "Published locales participating in retrieval once embedded.",
       },
     ],
-    providerReady: Boolean(env.OPENROUTER_API_KEY),
+    providerReady: Boolean(
+      env.OPENROUTER_API_PAID_KEY ?? env.OPENROUTER_API_KEY,
+    ),
   }
 }
 
@@ -2247,7 +2252,10 @@ export async function loadSettingsData(): Promise<SettingsData> {
       },
       {
         label: "Embedding Backend",
-        value: env.OPENROUTER_API_KEY ? "OpenRouter" : "Missing",
+        value:
+          (env.OPENROUTER_API_PAID_KEY ?? env.OPENROUTER_API_KEY)
+            ? "OpenRouter"
+            : "Missing",
         detail: "Provider used for admin-side semantic embedding generation.",
       },
     ],
@@ -2262,7 +2270,9 @@ export async function runSemanticSearch(params: {
   const queryText = params.queryText?.trim() ?? ""
   const locale = params.locale?.trim() ?? "en"
   const embeddingCounts = await getEmbeddingCounts()
-  const providerReady = Boolean(env.OPENROUTER_API_KEY)
+  const providerReady = Boolean(
+    env.OPENROUTER_API_PAID_KEY ?? env.OPENROUTER_API_KEY,
+  )
 
   const metrics: Metric[] = [
     {
@@ -2320,7 +2330,8 @@ export async function runSemanticSearch(params: {
       results: [],
       queryText,
       locale,
-      unavailableReason: "Semantic search requires OPENROUTER_API_KEY.",
+      unavailableReason:
+        "Semantic search requires OPENROUTER_API_PAID_KEY or OPENROUTER_API_KEY.",
     }
   }
 

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -99,6 +99,7 @@ export const env = createEnv({
     CORE_API_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
     CORE_API_RETRIES: z.coerce.number().int().min(0).optional(),
     CORE_SYNC_CRON_SECRET: z.string().min(1).optional(),
+    OPENROUTER_API_PAID_KEY: z.string().min(1).optional(),
     OPENROUTER_API_KEY: z.string().min(1).optional(),
     OPENROUTER_IMAGE_TEXT_MODEL: z.string().min(1).optional(),
     OPENROUTER_IMAGE_TEXT_MODELS: z.string().min(1).optional(),
@@ -342,6 +343,9 @@ export const env = createEnv({
     CORE_API_TIMEOUT_MS: emptyToUndefined(process.env.CORE_API_TIMEOUT_MS),
     CORE_API_RETRIES: emptyToUndefined(process.env.CORE_API_RETRIES),
     CORE_SYNC_CRON_SECRET: emptyToUndefined(process.env.CORE_SYNC_CRON_SECRET),
+    OPENROUTER_API_PAID_KEY: emptyToUndefined(
+      process.env.OPENROUTER_API_PAID_KEY,
+    ),
     OPENROUTER_API_KEY: emptyToUndefined(process.env.OPENROUTER_API_KEY),
     OPENROUTER_IMAGE_TEXT_MODEL: emptyToUndefined(
       process.env.OPENROUTER_IMAGE_TEXT_MODEL,

--- a/apps/admin/src/services/embeddings.service.test.ts
+++ b/apps/admin/src/services/embeddings.service.test.ts
@@ -46,6 +46,7 @@ describe("generateExperienceEmbedding", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllGlobals()
+    delete process.env.OPENROUTER_API_PAID_KEY
     process.env.OPENROUTER_API_KEY = "test-openrouter-key"
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -53,6 +54,7 @@ describe("generateExperienceEmbedding", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    delete process.env.OPENROUTER_API_PAID_KEY
     delete process.env.OPENROUTER_API_KEY
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -111,12 +113,39 @@ describe("generateExperienceEmbedding", () => {
     expect(body.model).toBe("qwen/qwen3-embedding-8b")
     expect(body.dimensions).toBe(1536)
   })
+
+  it("prefers OPENROUTER_API_PAID_KEY over the legacy OpenRouter key", async () => {
+    process.env.OPENROUTER_API_PAID_KEY = "test-paid-openrouter-key"
+    process.env.OPENROUTER_API_KEY = "test-legacy-openrouter-key"
+    const vector = Array.from({ length: 1536 }, () => 0.1)
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: vector }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { generateExperienceEmbedding } = await import("./embeddings.service")
+
+    await generateExperienceEmbedding("hope and peace")
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/embeddings",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer test-paid-openrouter-key",
+        }),
+      }),
+    )
+  })
 })
 
 describe("generateExperienceEmbeddings (batched)", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllGlobals()
+    delete process.env.OPENROUTER_API_PAID_KEY
     process.env.OPENROUTER_API_KEY = "test-openrouter-key"
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -124,6 +153,7 @@ describe("generateExperienceEmbeddings (batched)", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    delete process.env.OPENROUTER_API_PAID_KEY
     delete process.env.OPENROUTER_API_KEY
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -277,6 +307,7 @@ describe("generateExperienceEmbeddings (batched)", () => {
 
   it("surfaces missing credentials with EmbeddingsBatchError(missing_credentials)", async () => {
     delete process.env.OPENROUTER_API_KEY
+    delete process.env.OPENROUTER_API_PAID_KEY
     delete process.env.OPENAI_API_KEY
     const { generateExperienceEmbeddings, EmbeddingsBatchError } =
       await import("./embeddings.service")
@@ -287,6 +318,7 @@ describe("generateExperienceEmbeddings (batched)", () => {
 
   it("does not fall back to OpenAI credentials when OpenRouter is missing", async () => {
     delete process.env.OPENROUTER_API_KEY
+    delete process.env.OPENROUTER_API_PAID_KEY
     process.env.OPENAI_API_KEY = "test-openai-key"
     process.env.OPENAI_BASE_URL = "https://api.openai.example/v1"
     const fetchMock = vi.fn()
@@ -349,6 +381,7 @@ describe("generateExperienceEmbedding (singular) — back-compat error contract"
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllGlobals()
+    delete process.env.OPENROUTER_API_PAID_KEY
     process.env.OPENROUTER_API_KEY = "test-openrouter-key"
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -356,6 +389,7 @@ describe("generateExperienceEmbedding (singular) — back-compat error contract"
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    delete process.env.OPENROUTER_API_PAID_KEY
     delete process.env.OPENROUTER_API_KEY
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL

--- a/apps/admin/src/services/embeddings.service.ts
+++ b/apps/admin/src/services/embeddings.service.ts
@@ -202,9 +202,10 @@ type EmbeddingProvider = {
 }
 
 function selectProvider(): EmbeddingProvider {
-  if (env.OPENROUTER_API_KEY) {
+  const openRouterApiKey = env.OPENROUTER_API_PAID_KEY ?? env.OPENROUTER_API_KEY
+  if (openRouterApiKey) {
     return {
-      apiKey: env.OPENROUTER_API_KEY,
+      apiKey: openRouterApiKey,
       model: OPENROUTER_EMBEDDING_MODEL,
       url: "https://openrouter.ai/api/v1/embeddings",
       dimensions: EXPERIENCE_EMBEDDING_DIMENSIONS,
@@ -212,7 +213,7 @@ function selectProvider(): EmbeddingProvider {
   }
   throw new EmbeddingsBatchError(
     "missing_credentials",
-    "OPENROUTER_API_KEY is required for embedding generation",
+    "OPENROUTER_API_PAID_KEY or OPENROUTER_API_KEY is required for embedding generation",
   )
 }
 

--- a/apps/admin/src/services/search-trace-query-classifier.test.ts
+++ b/apps/admin/src/services/search-trace-query-classifier.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const envMock = vi.hoisted(() => ({
   env: {
+    OPENROUTER_API_PAID_KEY: undefined as string | undefined,
     OPENROUTER_API_KEY: undefined as string | undefined,
     OPENROUTER_QUERY_CLASSIFIER_MODEL: undefined as string | undefined,
   },
@@ -57,6 +58,7 @@ const ambiguousInput = {
 describe("search trace query classifier", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    envMock.env.OPENROUTER_API_PAID_KEY = undefined
     envMock.env.OPENROUTER_API_KEY = undefined
     envMock.env.OPENROUTER_QUERY_CLASSIFIER_MODEL = undefined
   })
@@ -132,6 +134,33 @@ describe("search trace query classifier", () => {
     expect(classifier.source).toBe("openrouter:openrouter/test-classifier")
     const body = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body))
     expect(body.model).toBe("openrouter/test-classifier")
+  })
+
+  it("prefers OPENROUTER_API_PAID_KEY from env when no explicit key is passed", async () => {
+    envMock.env.OPENROUTER_API_PAID_KEY = "paid-openrouter-key"
+    envMock.env.OPENROUTER_API_KEY = "legacy-openrouter-key"
+    const fetchImpl = vi.fn().mockResolvedValue(
+      buildOpenRouterResponse({
+        queryQualityLabel: "valid_viewer_intent",
+        abuseLabel: "none",
+        confidence: "high",
+        reasonCode: "felt_need",
+      }),
+    )
+    const classifier = createSearchTraceQueryClassifier({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    await classifier.classify(ambiguousInput)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/chat/completions",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer paid-openrouter-key",
+        }),
+      }),
+    )
   })
 
   it("parses OpenRouter text content returned as array parts", async () => {

--- a/apps/admin/src/services/search-trace-query-classifier.ts
+++ b/apps/admin/src/services/search-trace-query-classifier.ts
@@ -164,11 +164,12 @@ export function isLlmClassificationCandidate(
 export function createSearchTraceQueryClassifier(
   options: SearchTraceQueryClassifierOptions = {},
 ): SearchTraceQueryClassifier {
-  const apiKey = options.apiKey ?? env.OPENROUTER_API_KEY
+  const apiKey =
+    options.apiKey ?? env.OPENROUTER_API_PAID_KEY ?? env.OPENROUTER_API_KEY
   if (!apiKey) {
     throw new SearchTraceQueryClassifierError(
       "missing_credentials",
-      "OPENROUTER_API_KEY is required to classify search trace queries",
+      "OPENROUTER_API_PAID_KEY or OPENROUTER_API_KEY is required to classify search trace queries",
     )
   }
   const model =

--- a/apps/mastra/.env.example
+++ b/apps/mastra/.env.example
@@ -14,6 +14,7 @@ ADMIN_SEARCH_EVAL_SEARCH_URL=http://localhost:3003/api/internal/search-eval/sear
 ADMIN_SEARCH_EVAL_API_KEY=local-search-eval-key
 MASTRA_SEARCH_EVAL_ARTIFACT_DIR=.mastra/storage/search-eval
 MASTRA_SEARCH_EVAL_ALLOW_PROD_IMPORT=false
+OPENROUTER_API_PAID_KEY=
 OPENROUTER_API_KEY=
 OPENROUTER_EMBEDDINGS_BASE_URL=https://openrouter.ai/api/v1
 OPENAI_API_KEY=

--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -90,7 +90,8 @@ pnpm --filter @forge/mastra lint
 | `AI_GATEWAY_EMBEDDINGS_PROVIDER`          | Provider provenance label sent through Admin ingest metadata. Defaults to `jesus-film-ai-gateway`.                         |
 | `MASTRA_STORAGE_DIR`                      | Optional directory for Studio-visible observability/log files. Defaults to `$RAILWAY_VOLUME_MOUNT_PATH/mastra` on Railway. |
 | `MASTRA_STORAGE_BACKEND`                  | Mastra runtime storage backend. Use `postgres` normally; `memory` is local/test-only and rejected in production.           |
-| `OPENROUTER_API_KEY`                      | OpenRouter key for locale-quality eval query generation and offline compare judging. Required for compare mode.            |
+| `OPENROUTER_API_PAID_KEY`                 | Preferred OpenRouter key for eval generation, offline judging, and legacy embedding mode.                                  |
+| `OPENROUTER_API_KEY`                      | Legacy OpenRouter fallback for those paths when `OPENROUTER_API_PAID_KEY` is absent.                                       |
 | `OPENROUTER_EMBEDDINGS_BASE_URL`          | Optional OpenRouter-compatible embedding base URL. Defaults to OpenRouter's `/api/v1` endpoint.                            |
 | `OPENAI_API_KEY`                          | Fallback model provider key for smoke agent/model-routed calls and transcript embeddings when OpenRouter is unavailable.   |
 | `OPENAI_EMBEDDINGS_BASE_URL`              | Optional OpenAI-compatible embedding provider base URL. Defaults to OpenAI's `/v1` endpoint.                               |

--- a/apps/mastra/src/config/env.test.ts
+++ b/apps/mastra/src/config/env.test.ts
@@ -412,6 +412,26 @@ describe("Mastra env", () => {
     })
   })
 
+  it("prefers OPENROUTER_API_PAID_KEY for legacy OpenRouter embedding config", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("AI_GATEWAY_EMBEDDINGS_API_KEY", "")
+    vi.stubEnv("MASTRA_CONTENT_EMBEDDINGS_PROVIDER_MODE", "legacy")
+    vi.stubEnv("OPENAI_API_KEY", "openai-key")
+    vi.stubEnv("OPENROUTER_API_PAID_KEY", "paid-openrouter-key")
+    vi.stubEnv("OPENROUTER_API_KEY", "legacy-openrouter-key")
+
+    const { getOpenRouterApiKey, getTranscriptEmbeddingProviderConfig } =
+      await import("./env")
+
+    expect(getOpenRouterApiKey()).toBe("paid-openrouter-key")
+    expect(getTranscriptEmbeddingProviderConfig()).toEqual({
+      apiKey: "paid-openrouter-key",
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "openai/text-embedding-3-small",
+      provider: "openai",
+    })
+  })
+
   it("prefers AI Gateway config for content embedding provider config", async () => {
     vi.stubEnv("NODE_ENV", "development")
     vi.stubEnv("AI_GATEWAY_EMBEDDINGS_API_KEY", "gateway-key")

--- a/apps/mastra/src/config/env.ts
+++ b/apps/mastra/src/config/env.ts
@@ -116,6 +116,7 @@ const envSchema = z.object({
     .url()
     .default("https://api.openai.com/v1"),
   OPENAI_API_KEY: z.string().min(1).optional(),
+  OPENROUTER_API_PAID_KEY: z.string().min(1).optional(),
   OPENROUTER_API_KEY: z.string().min(1).optional(),
   OPENROUTER_EMBEDDINGS_BASE_URL: z
     .string()
@@ -253,6 +254,9 @@ export const env = envSchema.parse({
     process.env.OPENAI_EMBEDDINGS_BASE_URL,
   ),
   OPENAI_API_KEY: emptyToUndefined(process.env.OPENAI_API_KEY),
+  OPENROUTER_API_PAID_KEY: emptyToUndefined(
+    process.env.OPENROUTER_API_PAID_KEY,
+  ),
   OPENROUTER_API_KEY: emptyToUndefined(process.env.OPENROUTER_API_KEY),
   OPENROUTER_EMBEDDINGS_BASE_URL: emptyToUndefined(
     process.env.OPENROUTER_EMBEDDINGS_BASE_URL,
@@ -399,8 +403,8 @@ export function assertMastraRuntimeEnv() {
     assertGatewayProviderContractAllowedForProduction()
   } else {
     missing.push([
-      "OPENROUTER_API_KEY or OPENAI_API_KEY",
-      env.OPENROUTER_API_KEY ?? env.OPENAI_API_KEY,
+      "OPENROUTER_API_PAID_KEY, OPENROUTER_API_KEY, or OPENAI_API_KEY",
+      getOpenRouterApiKey() ?? env.OPENAI_API_KEY,
     ])
   }
 
@@ -425,6 +429,10 @@ export function getMastraStorageDir() {
   return ".mastra/storage"
 }
 
+export function getOpenRouterApiKey(): string | undefined {
+  return env.OPENROUTER_API_PAID_KEY ?? env.OPENROUTER_API_KEY
+}
+
 export function getFirecrawlConfig(): FirecrawlConfig {
   return {
     apiKey: env.FIRECRAWL_API_KEY,
@@ -440,9 +448,10 @@ function getLegacyEmbeddingProviderConfig(
   model: string,
   provider: string,
 ): ContentEmbeddingProviderConfig {
-  if (env.OPENROUTER_API_KEY) {
+  const openRouterApiKey = getOpenRouterApiKey()
+  if (openRouterApiKey) {
     return {
-      apiKey: env.OPENROUTER_API_KEY,
+      apiKey: openRouterApiKey,
       baseUrl: env.OPENROUTER_EMBEDDINGS_BASE_URL,
       model,
       provider,

--- a/apps/mastra/src/mastra/workflows/eval-query-generation.ts
+++ b/apps/mastra/src/mastra/workflows/eval-query-generation.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto"
 import { createStep, createWorkflow } from "@mastra/core/workflows"
 import { z } from "zod"
 
-import { env } from "../../config/env"
+import { env, getOpenRouterApiKey } from "../../config/env"
 import { isValidServiceBearer } from "../../server/service-bearer"
 import {
   callAdminCandidateStore,
@@ -303,7 +303,7 @@ function generatorFor(
   if (options.generator) return options.generator
   if (options.generatorFactory) return options.generatorFactory()
   return createEvalQueryGenerator({
-    apiKey: env.OPENROUTER_API_KEY,
+    apiKey: getOpenRouterApiKey(),
     model: env.EVAL_QUERY_GENERATION_MODEL,
     timeoutMs: options.timeoutMs,
     fetchImpl: options.fetchImpl,

--- a/apps/mastra/src/services/eval-query-generator.ts
+++ b/apps/mastra/src/services/eval-query-generator.ts
@@ -197,7 +197,7 @@ export function createEvalQueryGenerator(
   if (!apiKey) {
     throw new EvalQueryGeneratorError(
       "missing_credentials",
-      "OPENROUTER_API_KEY is required for locale-quality eval query generation",
+      "OPENROUTER_API_PAID_KEY or OPENROUTER_API_KEY is required for locale-quality eval query generation",
     )
   }
   const model = options.model ?? "anthropic/claude-haiku-4-5"

--- a/apps/mastra/src/services/offline-search-eval/judge.ts
+++ b/apps/mastra/src/services/offline-search-eval/judge.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { env } from "../../config/env"
+import { env, getOpenRouterApiKey } from "../../config/env"
 import type { JudgeVerdict, SearchEvalResult } from "./types"
 
 const OPENROUTER_CHAT_COMPLETIONS_URL =
@@ -162,11 +162,11 @@ export function createOfflineSearchEvalJudge(
     sleep?: (ms: number) => Promise<void>
   } = {},
 ): OfflineSearchEvalJudge {
-  const apiKey = options.apiKey ?? env.OPENROUTER_API_KEY
+  const apiKey = options.apiKey ?? getOpenRouterApiKey()
   if (!apiKey) {
     throw new OfflineSearchEvalJudgeError(
       "missing_credentials",
-      "OPENROUTER_API_KEY is required for offline search eval judging",
+      "OPENROUTER_API_PAID_KEY or OPENROUTER_API_KEY is required for offline search eval judging",
     )
   }
   const model = options.model ?? env.SEARCH_EVAL_JUDGE_MODEL


### PR DESCRIPTION
## Summary

- Add `OPENROUTER_API_PAID_KEY` as the preferred OpenRouter credential for Admin semantic query embeddings.
- Keep `OPENROUTER_API_KEY` as a legacy fallback so existing environments do not break.
- Route related Admin readiness/classifier checks and Mastra eval generation/judging helpers through the same paid-key-first lookup.
- Update env examples, runbook docs, and focused regression coverage.

## Why

The semantic search query embedding path and Mastra eval flows can fail when the legacy OpenRouter key is unavailable or invalid. This lets Railway environments use the new paid OpenRouter key without committing secret values.

## Validation

- `pnpm --filter @forge/admin test -- src/services/embeddings.service.test.ts src/services/search-trace-query-classifier.test.ts src/app/dashboard/ops-data.test.ts`
- `pnpm --filter @forge/mastra test -- src/config/env.test.ts src/services/offline-search-eval/judge.test.ts src/services/eval-query-generator.test.ts src/mastra/workflows/eval-query-generation.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/mastra typecheck`
- `git diff --check`
- secret scan of the PR diff for the provided token/key patterns