### PR TITLE
fix(web): prefer watch video routes over experiences

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
@@ -272,11 +272,11 @@ function makeBibleCitations() {
   ]
 }
 
-function makeSeriesResult() {
+function makeSeriesResult(slug = "storyclubs") {
   return {
     video: {
       documentId: "s1",
-      slug: "storyclubs",
+      slug,
       title: "StoryClubs",
       label: "collection",
       images: [],
@@ -552,14 +552,14 @@ describe("Catch-all routing — metadata for playable watch pages", () => {
         es: "https://www.jesusfilm.org/watch/storyclubs.html/spanish-castilian.html",
       },
     })
-    expect(resolveWatchPageMock).toHaveBeenCalledWith("en", "storyclubs")
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
     expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith(
       "storyclubs",
       "english",
     )
   })
 
-  it("keeps curated Experience metadata ahead of same-slug video metadata", async () => {
+  it("keeps same-slug video metadata ahead of curated Experience metadata", async () => {
     resolveWatchPageMock.mockResolvedValue({
       data: {
         kind: "experience",
@@ -588,17 +588,59 @@ describe("Catch-all routing — metadata for playable watch pages", () => {
       }),
     })
 
-    expect(metadata.title).toBe("Easter Watch")
+    expect(metadata.title).toBe("StoryClubs | Jesus Film Project")
     expect(metadata.openGraph).toMatchObject({
-      title: "Easter OG",
+      title: "StoryClubs | Jesus Film Project",
       url: "https://www.jesusfilm.org/watch/easter.html/english.html",
       images: [
         {
-          url: "https://cdn.example/easter-og.jpg",
+          url: "https://image.mux.com/pb1/thumbnail.jpg?width=1200&height=630&fit_mode=smartcrop",
         },
       ],
     })
-    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
+    expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith(
+      "easter",
+      "english",
+    )
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps same-slug trailerless series metadata ahead of curated Experience metadata", async () => {
+    resolveWatchPageMock.mockResolvedValue({
+      data: {
+        kind: "experience",
+        experience: {
+          id: "exp-1",
+          slug: "easter",
+          title: "Easter Watch",
+          metaDescription: "Curated Easter page.",
+          blocks: [{ __typename: "TextBlock", id: "blk-1", text: "Hello" }],
+        },
+      },
+      error: null,
+    })
+    resolveWatchVideoBySlugMock.mockResolvedValue(null)
+    resolveSeriesBySlugMock.mockResolvedValue(makeSeriesResult("easter"))
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        locale: "en",
+        htmlLang: "en",
+        rest: ["easter.html", "english.html"],
+      }),
+    })
+
+    expect(metadata.title).toBe("StoryClubs | Jesus Film Project")
+    expect(metadata.openGraph).toMatchObject({
+      title: "StoryClubs | Jesus Film Project",
+      url: "https://www.jesusfilm.org/watch/easter.html/english.html",
+    })
+    expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith(
+      "easter",
+      "english",
+    )
+    expect(resolveSeriesBySlugMock).toHaveBeenCalledWith("easter", "english")
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
   })
 
   it("uses the three-segment production URL for episode metadata", async () => {
@@ -875,8 +917,35 @@ describe("Catch-all routing — series branch (2-seg)", () => {
   })
 })
 
-describe("Catch-all routing — Experience precedence (2-seg)", () => {
-  it("renders Experience and skips video resolver when Experience exists for the slug", async () => {
+describe("Catch-all routing — video precedence (2-seg)", () => {
+  it("renders video and skips Experience when both exist for the slug", async () => {
+    resolveWatchPageMock.mockResolvedValue({
+      data: {
+        kind: "experience",
+        experience: {
+          id: "exp-1",
+          slug: "easter",
+          title: "Easter",
+          blocks: [{ __typename: "TextBlock", id: "blk-1", text: "Hello" }],
+        },
+      },
+      error: null,
+    })
+    resolveWatchVideoBySlugMock.mockResolvedValue(
+      makeWatchVideoResult("featureFilm"),
+    )
+    await render2Seg("easter", "english")
+    expect(seriesPageClientMock).not.toHaveBeenCalled()
+    expect(watchPageClientMock).toHaveBeenCalledTimes(1)
+    expect(watchQuestionPanelMock).not.toHaveBeenCalled()
+    expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith(
+      "easter",
+      "english",
+    )
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
+  })
+
+  it("renders playlist/series and skips Experience when both exist for the slug", async () => {
     resolveWatchPageMock.mockResolvedValue({
       data: {
         kind: "experience",
@@ -893,14 +962,45 @@ describe("Catch-all routing — Experience precedence (2-seg)", () => {
       makeWatchVideoResult("collection"),
     )
     await render2Seg("easter", "english")
-    expect(seriesPageClientMock).not.toHaveBeenCalled()
+    expect(seriesPageClientMock).toHaveBeenCalledTimes(1)
     expect(watchPageClientMock).not.toHaveBeenCalled()
     expect(watchQuestionPanelMock).not.toHaveBeenCalled()
-    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
   })
 
-  it("renders the gated question panel for curated watch experiences when enabled", async () => {
+  it("renders trailerless series fallback before same-slug Experience", async () => {
+    resolveWatchPageMock.mockResolvedValue({
+      data: {
+        kind: "experience",
+        experience: {
+          id: "exp-1",
+          slug: "storyclubs-no-trailer",
+          title: "StoryClubs landing",
+          blocks: [{ __typename: "TextBlock", id: "blk-1", text: "Hello" }],
+        },
+      },
+      error: null,
+    })
+    resolveWatchVideoBySlugMock.mockResolvedValue(null)
+    resolveSeriesBySlugMock.mockResolvedValue(
+      makeSeriesResult("storyclubs-no-trailer"),
+    )
+
+    await render2Seg("storyclubs-no-trailer", "english")
+
+    expect(seriesPageClientMock).toHaveBeenCalledTimes(1)
+    expect(watchPageClientMock).not.toHaveBeenCalled()
+    expect(resolveSeriesBySlugMock).toHaveBeenCalledWith(
+      "storyclubs-no-trailer",
+      "english",
+    )
+    expect(resolveWatchPageMock).not.toHaveBeenCalled()
+  })
+
+  it("renders the gated question panel for curated watch experiences when no video or series resolves", async () => {
     isWatchQuestionPanelEnabledMock.mockResolvedValue(true)
+    resolveWatchVideoBySlugMock.mockResolvedValue(null)
+    resolveSeriesBySlugMock.mockResolvedValue(null)
     resolveWatchPageMock.mockResolvedValue({
       data: {
         kind: "experience",
@@ -926,10 +1026,16 @@ describe("Catch-all routing — Experience precedence (2-seg)", () => {
       undefined,
     )
     expect(watchPageClientMock).not.toHaveBeenCalled()
-    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
+    expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith(
+      "easter",
+      "english",
+    )
+    expect(resolveSeriesBySlugMock).toHaveBeenCalledWith("easter", "english")
   })
 
   it("falls through to ExperienceEmpty when Experience has no blocks", async () => {
+    resolveWatchVideoBySlugMock.mockResolvedValue(null)
+    resolveSeriesBySlugMock.mockResolvedValue(null)
     resolveWatchPageMock.mockResolvedValue({
       data: {
         kind: "experience",
@@ -939,7 +1045,8 @@ describe("Catch-all routing — Experience precedence (2-seg)", () => {
     })
     await render2Seg("x", "english")
     expect(experienceEmptyMock).toHaveBeenCalledTimes(1)
-    expect(resolveWatchVideoBySlugMock).not.toHaveBeenCalled()
+    expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith("x", "english")
+    expect(resolveSeriesBySlugMock).toHaveBeenCalledWith("x", "english")
   })
 })
 

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -260,14 +260,6 @@ export async function generateMetadata({
     // doesn't drop metadata entirely. Next silently skips metadata when
     // generateMetadata throws; the page body has its own error boundary.
     try {
-      const watchPage = await resolveWatchPage(locale, slug)
-      if (watchPage.data?.kind === "experience") {
-        return getWatchPageMetadata(locale, {
-          slug,
-          pathLocale: rawLocale,
-        })
-      }
-
       const watchVideo = await resolveWatchVideoBySlug(slug, rawLocale)
       if (watchVideo && isSeriesRecord(watchVideo.video)) {
         return generateSeriesMetadata(locale, {
@@ -283,14 +275,12 @@ export async function generateMetadata({
           pathLocale: rawLocale,
         })
       }
-      if (!watchVideo) {
-        const series = await resolveSeriesBySlug(slug, rawLocale)
-        if (series) {
-          return generateSeriesMetadata(locale, {
-            series: series.video,
-            pathLocale: rawLocale,
-          })
-        }
+      const series = await resolveSeriesBySlug(slug, rawLocale)
+      if (series) {
+        return generateSeriesMetadata(locale, {
+          series: series.video,
+          pathLocale: rawLocale,
+        })
       }
     } catch {
       // Fall through to getWatchPageMetadata.
@@ -536,52 +526,11 @@ async function renderVideo(shape: {
   const { slug, rawLocale, locale } = shape
   const route = `/watch/${slug}.html/${rawLocale}.html`
 
-  // Experience-first precedence: when an editor curated an Experience at
-  // this slug, that's the intended landing — even when a slug-colliding
-  // Video (e.g. an `easter` Video alongside an `easter` Experience) exists.
-  // `resolveWatchPage` is React `cache()`-wrapped so the tail-end call
-  // for the video-template fallback is free.
-  const watchPage = await resolveWatchPage(locale, slug)
-  if (watchPage.data?.kind === "experience") {
-    const blocks = (watchPage.data.experience.blocks ?? []).filter(
-      (b): b is Section => b !== null,
-    )
-    if (blocks.length) {
-      const questionPanelEnabled = await getQuestionPanelEnabled(route)
-      return (
-        <main
-          className={`min-h-screen bg-stone-900 ${
-            questionPanelEnabled
-              ? "pb-[calc(5.75rem+env(safe-area-inset-bottom,0px))] sm:pb-0"
-              : ""
-          }`}
-        >
-          {blocks.map((block, i) => {
-            const key =
-              "id" in block && typeof block.id === "string"
-                ? block.id
-                : `block-${i}`
-            return (
-              <ExperienceSectionRenderer
-                key={key}
-                section={block}
-                routeVideo={null}
-              />
-            )
-          })}
-          {questionPanelEnabled ? (
-            <WatchQuestionPanel enabled={questionPanelEnabled} />
-          ) : null}
-        </main>
-      )
-    }
-    return <ExperienceEmpty />
-  }
-
-  // Video-by-slug second. Pass rawLocale (not the bcp47-normalised
+  // Video-by-slug first. Pass rawLocale (not the bcp47-normalised
   // `locale`) so the resolver matches either variant.language.slug OR
   // variant.language.bcp47 — slug-form URLs like /the-call/korean need to
-  // land in the resolver as "korean", not "en".
+  // land in the resolver as "korean", not "en". A same-slug Experience is
+  // only a fallback after video and series routes fail to render.
   const watchVideo = await resolveWatchVideoBySlug(slug, rawLocale)
   if (watchVideo) {
     const actualSlug = watchVideo.selectedVariant.language?.slug ?? null

--- a/apps/web/src/lib/content.test.ts
+++ b/apps/web/src/lib/content.test.ts
@@ -231,7 +231,7 @@ describe("resolveWatchPage", () => {
     expect(result.error?.message).toBe("No experience found")
   })
 
-  it("prefers an explicit experience when the slug doesn't match the template slug", async () => {
+  it("falls back to an explicit experience when no route video exists", async () => {
     queryMock
       .mockResolvedValueOnce({
         data: {
@@ -245,6 +245,11 @@ describe("resolveWatchPage", () => {
               title: "Single Video Template",
             },
           },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          videoBySlug: null,
         },
       })
       .mockResolvedValueOnce({
@@ -262,7 +267,7 @@ describe("resolveWatchPage", () => {
 
     const result = await resolveWatchPage("en", "christmas")
 
-    expect(queryMock).toHaveBeenCalledTimes(2)
+    expect(queryMock).toHaveBeenCalledTimes(3)
     expect(result.error).toBeNull()
     expect(result.data).toMatchObject({
       kind: "experience",
@@ -272,7 +277,7 @@ describe("resolveWatchPage", () => {
     })
   })
 
-  it("falls back to the default template for plain video slugs", async () => {
+  it("uses the default template for video slugs before same-slug experience lookup", async () => {
     queryMock
       .mockResolvedValueOnce({
         data: {
@@ -286,11 +291,6 @@ describe("resolveWatchPage", () => {
               title: "Single Video Template",
             },
           },
-        },
-      })
-      .mockResolvedValueOnce({
-        data: {
-          experienceBySlug: null,
         },
       })
       .mockResolvedValueOnce({
@@ -351,6 +351,7 @@ describe("resolveWatchPage", () => {
 
     const result = await resolveWatchPage("en", "jesus")
 
+    expect(queryMock).toHaveBeenCalledTimes(3)
     expect(result.error).toBeNull()
     expect(result.data).toMatchObject({
       kind: "video-template",
@@ -380,9 +381,6 @@ describe("resolveWatchPage", () => {
             defaultTemplateExperience: null,
           },
         },
-      })
-      .mockResolvedValueOnce({
-        data: { experienceBySlug: null },
       })
       .mockResolvedValueOnce({
         data: {
@@ -419,7 +417,6 @@ describe("resolveWatchPage", () => {
           },
         },
       })
-      .mockResolvedValueOnce({ data: { experienceBySlug: null } })
       .mockResolvedValueOnce({
         data: {
           // Empty variants — selectPlayableVariant returns null, so

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -953,12 +953,24 @@ async function resolveSlugPage(
   const templateSlug =
     settings?.defaultTemplateExperience?.slug?.toLowerCase() ?? null
 
-  // watchSetting.defaultTemplateExperience is the single source of truth for
-  // "this slug is the video-template route". Any other slug resolves first
-  // as a regular Experience and falls through to a template-rendered video
-  // when no Experience matches. Admin's `experienceBySlug` returns only
-  // non-template, published locales for PUBLIC callers, so a template hit
-  // at this slug naturally falls through to the video branch.
+  const routeVideoRecord = await getVideoBySlug(locale, slug)
+  if (routeVideoRecord) {
+    const templateExperience = settings?.defaultTemplateExperience ?? null
+    if (!templateExperience) return null
+
+    const routeVideo = normalizeRouteVideo(routeVideoRecord)
+    if (!routeVideo?.streamingUrl) return null
+
+    return {
+      kind: "video-template",
+      template: templateExperience,
+      routeVideo,
+    }
+  }
+
+  // watchSetting.defaultTemplateExperience is reserved for template
+  // rendering, not a public Experience page. Any non-template slug can still
+  // fall back to a curated Experience when no route video exists.
   if (slug.toLowerCase() !== templateSlug) {
     const experience = await getExperienceBySlug(locale, slug)
     if (experience) {
@@ -966,20 +978,7 @@ async function resolveSlugPage(
     }
   }
 
-  const routeVideoRecord = await getVideoBySlug(locale, slug)
-  if (!routeVideoRecord) return null
-
-  const templateExperience = settings?.defaultTemplateExperience ?? null
-  if (!templateExperience) return null
-
-  const routeVideo = normalizeRouteVideo(routeVideoRecord)
-  if (!routeVideo?.streamingUrl) return null
-
-  return {
-    kind: "video-template",
-    template: templateExperience,
-    routeVideo,
-  }
+  return null
 }
 
 const fetchResolvedWatchPage = unstable_cache(

--- a/docs/plans/2026-06-11-002-fix-watch-video-precedence-plan.md
+++ b/docs/plans/2026-06-11-002-fix-watch-video-precedence-plan.md
@@ -1,0 +1,91 @@
+---
+title: "fix: Prefer Watch video content over slug-colliding experiences"
+type: "fix"
+status: complete
+date: 2026-06-11
+roadmap: docs/roadmap/media-generation/feat-054-video-pages-2-0.md
+---
+
+# fix: Prefer Watch Video Content Over Slug-Colliding Experiences
+
+## Summary
+
+Two-segment Watch URLs such as `/watch/jesus.html/english.html` should render the video or playlist/series content when a published video-side record exists for the slug. A curated Experience with the same slug must no longer override the video content page.
+
+## Problem Frame
+
+The current catch-all Watch route intentionally gives curated Experiences precedence on two-segment URL shapes. That older rule made topic pages win over generic video fallback, but it now conflicts with the Watch app's video-page contract: when users open a concrete video-language URL, the video or playlist is the primary content.
+
+This plan implements the new precedence rule under `feat-054`, which already tracks the Video/Experience slug-collision audit as outstanding work.
+
+## Requirements
+
+- R1. `/watch/{slug}.html/{language}.html` resolves a playable video before a same-slug Experience.
+- R2. `/watch/{slug}.html/{language}.html` resolves a playlist/series before a same-slug Experience, including trailerless series that use the `resolveSeriesBySlug` fallback.
+- R3. Same-slug Experiences remain usable only when no video or series/playlist content can render for the two-segment URL.
+- R4. One-segment curated Experience/collection pages remain unchanged.
+- R5. Metadata generation follows the same video-first precedence as page rendering so HTML, OG, Twitter, and JSON-LD surfaces do not describe a different entity from the rendered page.
+
+## Key Technical Decisions
+
+- KTD1. Keep two-segment route precedence in the catch-all page branch and the shared slug resolver. The page branch owns the distinction between video, trailerless series, and experience fallback after the `.html` URL restructuring; `resolveWatchPage` must still reflect the same video-before-experience rule for template fallback and metadata callers.
+- KTD2. Do not change Admin GraphQL or the route manifest shape. The manifest already admits published video, parent/playlist, and root-level experience slugs; the route/resolver layer can decide final precedence.
+- KTD3. Keep homepage and one-segment experience behavior separate. `resolveWatchExperiencePage` remains the one-segment curated Experience path, while two-segment slug resolution treats video-side content as authoritative.
+
+## Scope Boundaries
+
+In scope:
+
+- Update `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx` two-segment rendering and metadata precedence.
+- Update focused route tests in `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`.
+- Update any directly contradicted docs/comments near the changed behavior.
+
+Out of scope:
+
+- Admin data migration or slug de-duplication.
+- Changing one-segment `/watch/{slug}.html` experience routing.
+- Changing route manifest generation or GraphQL schema contracts.
+- Broad Watch page redesign.
+
+## Implementation Units
+
+### U1. Make two-segment render video-first
+
+- **Goal:** Ensure same-slug videos and series render before curated Experiences.
+- **Files:**
+  - Modify `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+  - Modify `apps/web/src/lib/content.ts`
+  - Modify `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+  - Modify `apps/web/src/lib/content.test.ts`
+- **Approach:** In `renderVideo`, call `resolveWatchVideoBySlug` first, keep the existing locale canonicalization and series/single-video render paths, then call `resolveSeriesBySlug`, and only after both fail call `resolveWatchPage` for experience/template fallback. In `resolveSlugPage`, check the route video record before the Experience lookup; if a route video record exists but cannot render, return the no-content path rather than falling through to a same-slug Experience.
+- **Test scenarios:**
+  - Same-slug Experience plus playable video renders `WatchPageClient` and does not render Experience blocks.
+  - Same-slug Experience plus series renders `SeriesPageClient` and does not render Experience blocks.
+  - Same-slug Experience plus trailerless series fallback renders `SeriesPageClient`.
+  - When no video/series resolves, the existing Experience fallback still renders.
+
+### U2. Align metadata precedence
+
+- **Goal:** Metadata describes the video or series when the page renders video content.
+- **Files:**
+  - Modify `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+  - Modify `apps/web/src/lib/content.ts`
+  - Modify `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+  - Modify `apps/web/src/lib/content.test.ts`
+- **Approach:** In `generateMetadata` for `shape.kind === "video"`, resolve `resolveWatchVideoBySlug` and `resolveSeriesBySlug` before falling back to `getWatchPageMetadata`.
+- **Test scenarios:**
+  - Same-slug Experience plus video uses `generateWatchVideoMetadata`.
+  - Same-slug Experience plus series uses `generateSeriesMetadata`.
+  - Missing video/series still falls back to experience metadata.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+- Optional browser smoke if local Watch dev server is running: `/watch/jesus.html/english.html`
+
+## Completion Notes
+
+- Updated the two-segment Watch route so playable videos and series/playlist content resolve before same-slug Experiences.
+- Updated `resolveWatchPage` so route-video slugs are checked before `experienceBySlug`, including the no-playable-video no-content path.
+- Added focused regression coverage for single-video, series, trailerless-series, Experience fallback, and matching metadata precedence.
+- Verified with focused route/resolver tests, `@forge/web` typecheck, and `@forge/web` lint.

--- a/docs/roadmap/media-generation/feat-054-video-pages-2-0.md
+++ b/docs/roadmap/media-generation/feat-054-video-pages-2-0.md
@@ -21,7 +21,7 @@ tags:
 > - Migration plan for any production 3-segment `/watch/[collection]/[video]/[locale]` URLs that may have indexed/inbound traffic (constraint: "Preserve existing watch-page URLs or add a clear migration plan")
 > - Body-zone wrapper extraction from `Section.tsx` (extensibility — verification criterion 4)
 > - Hardcoded English strings in `WatchStudyQuestions` / `BibleQuotesSection` (CMS-driven copy)
-> - Video/Experience slug-collision precedence audit (CMS data review)
+> - Video/Experience slug-collision precedence audit — addressed in the route layer by `docs/plans/2026-06-11-002-fix-watch-video-precedence-plan.md`: two-segment Watch video/playlist URLs now win over same-slug Experiences.
 > - Resolver / route-level test coverage
 >
 > Ownership: ticket carries `vlad`; the PR contributor is urim. Coordinate before flipping `status: complete`.

--- a/docs/roadmap/topic-experiences/feat-047-watch-template-settings-and-single-video-fallback.md
+++ b/docs/roadmap/topic-experiences/feat-047-watch-template-settings-and-single-video-fallback.md
@@ -61,7 +61,7 @@ The new watch-template settings flow adds a generic single-video fallback, but t
 - Do not remove the `WatchSetting` singleton or the `Experience.isTemplate` model introduced by the plan.
 - Do not break the GraphQL contract flow: if CMS schema changes, regenerate `apps/cms/schema.graphql` and `packages/graphql` outputs in the same work.
 - Do not introduce inline GraphQL operations in random web files; keep operations in the existing data layer and fragments.
-- Do not weaken the existing route precedence: explicit `Experience.slug` must still win before generic `Video.slug` fallback.
+- Historical precedence note: this ticket originally kept explicit `Experience.slug` ahead of generic `Video.slug` fallback. That rule was superseded for two-segment Watch video/playlist URLs by `docs/plans/2026-06-11-002-fix-watch-video-precedence-plan.md`; video-side content now wins before same-slug Experiences at `/watch/{slug}.html/{language}.html`.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- Prefer two-segment Watch video and playlist/series routes over same-slug Experiences.
- Align metadata and shared slug resolver precedence with the new video-first rule.
- Add a scoped plan and regression coverage for video, series, trailerless series, and Experience fallback paths.

## Verification
- pnpm --filter @forge/web test -- 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx' src/lib/content.test.ts
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- git diff --check
- agent-browser smoke opened http://localhost:4910/watch/jesus.html/english.html and saved output/playwright/watch-video-precedence-jesus.png