### PR TITLE
fix(web): acknowledge watch chapter navigation

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -49,6 +49,14 @@ Locale propagation flow: public URL (`/watch/{slug}.html/{raw-audio-slug}.html`)
 
 Public watch links must always use the raw audio language slug, never the message-catalog key. Any button, card, carousel, modal, or component that emits a `/watch` href should pass `variant.language.slug`, `languageSlug`, or `currentLanguageSlug` into the route builders in `src/lib/routes.ts`. For English, the public URL is `/watch/{slug}.html/english.html`; `/watch/{slug}.html/en.html` is an internal-locale leak and should be treated as a bug.
 
+Watch chapter/sibling carousel links should keep `next/link` and the public
+audio-language href, but normal left-clicks may optimistically make the clicked
+card the visual current item while the next route resolves. Preserve modified
+click browser behavior, keep pending state scoped to the source video/language,
+and derive the visual active card from that pending payload so it self-invalidates
+when the route commits. See
+`docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md`.
+
 Adding a UI locale: drop `messages/{locale}.json`, then run `pnpm --filter @forge/web generate:ui-locales` or any build/test script that runs it. The generated edge-safe catalog module drives middleware, route helpers, and next-intl catalog membership without a manual TypeScript whitelist. CI runs `check:ui-locales` during lint before build/test scripts can regenerate the file, and the drift gate in `src/i18n/__tests__/messages-parity.test.ts` verifies the generated list matches filesystem catalogs. The structural-parity test also enforces every namespace key exists in every catalog.
 
 Critical: `src/i18n/generated-ui-locales.ts` is the only catalog list safe to import from middleware, route helpers, and client-reachable modules. Do NOT copy filesystem discovery into request-path modules (filesystem I/O in the request path is a regression), and do NOT import `src/i18n/locales.ts` into middleware or client-safe helpers because it is a server-only re-export for next-intl request configuration. Keep the internal `[locale]` segment bounded to generated message catalogs; use `[htmlLang]` only for the static HTML language tag.

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -43,8 +43,6 @@ export function SiblingCarousel({
   const activeIndex = children.findIndex(
     (child) => child.documentId === currentVideoDocumentId,
   )
-  const isParentMode = activeIndex < 0
-  const clipIndex = activeIndex >= 0 ? activeIndex + 1 : 1
   const clipTotal = children.length
   const parentTitle = canonicalParent.title ?? videoLabels("collection")
 
@@ -61,11 +59,16 @@ export function SiblingCarousel({
     href: string
     languageSlug: string
     sourceVideoDocumentId: string
+    targetVideoDocumentId: string
   } | null>(null)
-  const initialCarouselIndex = activeIndex >= 0 ? activeIndex : 0
 
   const handleCardClick = useCallback(
-    (event: MouseEvent<HTMLAnchorElement>, href: string, isActive: boolean) => {
+    (
+      event: MouseEvent<HTMLAnchorElement>,
+      href: string,
+      targetVideoDocumentId: string,
+      isActive: boolean,
+    ) => {
       if (isActive) return
       if (event.defaultPrevented) return
       if (event.button !== 0) return
@@ -77,22 +80,40 @@ export function SiblingCarousel({
         href,
         languageSlug,
         sourceVideoDocumentId: currentVideoDocumentId,
+        targetVideoDocumentId,
       })
     },
     [currentVideoDocumentId, languageSlug],
   )
 
-  // Snap to the active item whenever it changes (or when `api` first
-  // becomes available). Re-keying on `activeIndex` covers variant-switch
-  // scenarios where the same SiblingCarousel instance now has a new
-  // active child — without this, the carousel would stay scrolled to the
-  // previous chapter. The early-return guard handles parent-page mode
-  // (activeIndex === -1, no card to snap to).
+  const validPendingNavigation =
+    pendingNavigation != null &&
+    pendingNavigation.languageSlug === languageSlug &&
+    pendingNavigation.sourceVideoDocumentId === currentVideoDocumentId
+      ? pendingNavigation
+      : null
+  const pendingActiveIndex =
+    validPendingNavigation != null
+      ? children.findIndex(
+          (child) =>
+            child.documentId === validPendingNavigation.targetVideoDocumentId,
+        )
+      : -1
+  const visualActiveIndex =
+    pendingActiveIndex >= 0 ? pendingActiveIndex : activeIndex
+  const isParentMode = visualActiveIndex < 0
+  const clipIndex = visualActiveIndex >= 0 ? visualActiveIndex + 1 : 1
+  const initialCarouselIndex = visualActiveIndex >= 0 ? visualActiveIndex : 0
+
+  // Snap to the visually active item whenever it changes (or when `api`
+  // first becomes available). Pending navigation can temporarily move the
+  // active treatment to the clicked chapter before the route data catches up.
+  // The early-return guard handles parent-page mode (no card to snap to).
   useEffect(() => {
     if (!api) return
-    if (activeIndex < 0) return
-    api.scrollTo(activeIndex, true)
-  }, [api, activeIndex])
+    if (visualActiveIndex < 0) return
+    api.scrollTo(visualActiveIndex, true)
+  }, [api, visualActiveIndex])
 
   if (children.length < 2) return null
 
@@ -151,7 +172,7 @@ export function SiblingCarousel({
       >
         <CarouselContent>
           {children.map((child, index) => {
-            const isActive = index === activeIndex
+            const isActive = index === visualActiveIndex
             // `resolvePosterUrl` codifies the editorial-cinematic priority
             // chain shared with WatchPageClient. The raw `images[].url`
             // value is excluded from that chain entirely: it's a misshaped
@@ -165,12 +186,9 @@ export function SiblingCarousel({
             const lang = tryAsLocaleSlug(languageSlug)
             const href = slug && lang ? watchVideoPath(slug, lang) : undefined
             const isPending =
-              pendingNavigation != null &&
-              pendingNavigation.href === href &&
-              pendingNavigation.languageSlug === languageSlug &&
-              pendingNavigation.sourceVideoDocumentId ===
-                currentVideoDocumentId &&
-              !isActive
+              validPendingNavigation != null &&
+              validPendingNavigation.href === href &&
+              validPendingNavigation.targetVideoDocumentId === child.documentId
             const thumbnailAlt = child.title
               ? `${child.title} thumbnail`
               : "Related video thumbnail"
@@ -181,6 +199,7 @@ export function SiblingCarousel({
                 ? "border-4 border-white"
                 : "opacity-70 hover:outline-4 hover:outline-offset-[-4px] hover:outline-brand-red hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
               isPending &&
+                !isActive &&
                 "opacity-100 outline-4 outline-offset-[-4px] outline-brand-red shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
             )
 
@@ -218,10 +237,10 @@ export function SiblingCarousel({
                   className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-full bg-black/35 backdrop-blur-[14px] [mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_top,black_0%,rgba(0,0,0,0.9)_35%,rgba(0,0,0,0.35)_62%,transparent_100%)]"
                 />
 
-                {/* Hover-only play overlay on inactive cards. The active
-                    card already signals "this is what's playing" via the
-                    red border, so we don't double-mark it with a button. */}
-                {!isActive ? (
+                {/* Hover-only play overlay on inactive cards. A pending
+                    active card swaps the play glyph for a loader so the
+                    current-looking tile still communicates navigation work. */}
+                {!isActive || isPending ? (
                   <div
                     aria-hidden="true"
                     data-testid="sibling-carousel-play-overlay"
@@ -308,7 +327,9 @@ export function SiblingCarousel({
                     data-href={href}
                     aria-busy={isPending ? "true" : undefined}
                     className={cardClassName}
-                    onClick={(event) => handleCardClick(event, href, isActive)}
+                    onClick={(event) =>
+                      handleCardClick(event, href, child.documentId, isActive)
+                    }
                   >
                     {cardInner}
                   </Link>

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { type MouseEvent, useCallback, useEffect, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
-import { Play } from "lucide-react"
+import { LoaderCircle, Play } from "lucide-react"
 
 import {
   Carousel,
@@ -57,7 +57,30 @@ export function SiblingCarousel({
   // compete with the LCP poster fetch on the critical chain.
 
   const [api, setApi] = useState<CarouselApi | null>(null)
+  const [pendingNavigation, setPendingNavigation] = useState<{
+    href: string
+    languageSlug: string
+    sourceVideoDocumentId: string
+  } | null>(null)
   const initialCarouselIndex = activeIndex >= 0 ? activeIndex : 0
+
+  const handleCardClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, href: string, isActive: boolean) => {
+      if (isActive) return
+      if (event.defaultPrevented) return
+      if (event.button !== 0) return
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return
+      }
+
+      setPendingNavigation({
+        href,
+        languageSlug,
+        sourceVideoDocumentId: currentVideoDocumentId,
+      })
+    },
+    [currentVideoDocumentId, languageSlug],
+  )
 
   // Snap to the active item whenever it changes (or when `api` first
   // becomes available). Re-keying on `activeIndex` covers variant-switch
@@ -141,6 +164,13 @@ export function SiblingCarousel({
             const slug = tryAsContentSlug(child.slug)
             const lang = tryAsLocaleSlug(languageSlug)
             const href = slug && lang ? watchVideoPath(slug, lang) : undefined
+            const isPending =
+              pendingNavigation != null &&
+              pendingNavigation.href === href &&
+              pendingNavigation.languageSlug === languageSlug &&
+              pendingNavigation.sourceVideoDocumentId ===
+                currentVideoDocumentId &&
+              !isActive
             const thumbnailAlt = child.title
               ? `${child.title} thumbnail`
               : "Related video thumbnail"
@@ -150,6 +180,8 @@ export function SiblingCarousel({
               isActive
                 ? "border-4 border-white"
                 : "opacity-70 hover:outline-4 hover:outline-offset-[-4px] hover:outline-brand-red hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
+              isPending &&
+                "opacity-100 outline-4 outline-offset-[-4px] outline-brand-red shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
             )
 
             // Card contents are identical whether the card is a routable
@@ -193,10 +225,23 @@ export function SiblingCarousel({
                   <div
                     aria-hidden="true"
                     data-testid="sibling-carousel-play-overlay"
-                    className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+                    data-pending={isPending ? "true" : "false"}
+                    className={cn(
+                      "pointer-events-none absolute inset-0 z-30 flex items-center justify-center opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100",
+                      isPending && "opacity-100",
+                    )}
                   >
                     <span className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-red text-white shadow-lg ring-1 ring-black/20">
-                      <Play size={20} fill="currentColor" stroke="none" />
+                      {isPending ? (
+                        <LoaderCircle
+                          aria-hidden="true"
+                          data-testid="sibling-carousel-loading-icon"
+                          size={22}
+                          className="animate-spin"
+                        />
+                      ) : (
+                        <Play size={20} fill="currentColor" stroke="none" />
+                      )}
                     </span>
                   </div>
                 ) : null}
@@ -259,8 +304,11 @@ export function SiblingCarousel({
                     href={href}
                     data-testid="sibling-carousel-item"
                     data-active={isActive ? "true" : "false"}
+                    data-pending={isPending ? "true" : "false"}
                     data-href={href}
+                    aria-busy={isPending ? "true" : undefined}
                     className={cardClassName}
+                    onClick={(event) => handleCardClick(event, href, isActive)}
                   >
                     {cardInner}
                   </Link>

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -11,7 +11,7 @@
  * verifying U6's auto-scroll-on-mount behavior.
  */
 
-import { act } from "react"
+import { act, type MouseEventHandler, type ReactNode } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -46,6 +46,31 @@ vi.mock("next/image", () => ({
       data-alt={alt}
       className={className}
     />
+  ),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    onClick,
+    children,
+    ...props
+  }: {
+    href: string
+    onClick?: MouseEventHandler<HTMLAnchorElement>
+    children: ReactNode
+    [key: string]: unknown
+  }) => (
+    <a
+      href={href}
+      onClick={(event) => {
+        onClick?.(event)
+        event.preventDefault()
+      }}
+      {...props}
+    >
+      {children}
+    </a>
   ),
 }))
 
@@ -303,6 +328,67 @@ describe("SiblingCarousel — happy path", () => {
       "/magdalena.html/english.html",
     )
     expect(active!.getAttribute("href")).toBe("/magdalena.html/english.html")
+  })
+
+  it("marks an inactive chapter card as pending immediately after a normal click", () => {
+    const block = makeBlock(4, 0)
+
+    act(() => {
+      root.render(<SiblingCarousel block={block} languageSlug="english" />)
+    })
+
+    const target = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-href='/child-2-slug.html/english.html']",
+    )
+
+    expect(target).not.toBeNull()
+    expect(target!.getAttribute("data-pending")).toBe("false")
+    expect(target!.getAttribute("aria-busy")).toBeNull()
+
+    act(() => {
+      target!.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      )
+    })
+
+    expect(target!.getAttribute("data-pending")).toBe("true")
+    expect(target!.getAttribute("aria-busy")).toBe("true")
+    expect(
+      target!.querySelector("[data-testid='sibling-carousel-loading-icon']"),
+    ).not.toBeNull()
+  })
+
+  it("does not show pending feedback for modified chapter clicks", () => {
+    const block = makeBlock(4, 0)
+
+    act(() => {
+      root.render(<SiblingCarousel block={block} languageSlug="english" />)
+    })
+
+    const target = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-href='/child-2-slug.html/english.html']",
+    )
+
+    act(() => {
+      target!.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+          metaKey: true,
+        }),
+      )
+    })
+
+    expect(target!.getAttribute("data-pending")).toBe("false")
+    expect(target!.getAttribute("aria-busy")).toBeNull()
+    expect(
+      target!.querySelector("[data-testid='sibling-carousel-loading-icon']"),
+    ).toBeNull()
   })
 
   it("renders an in-app href without the /watch/ basePath prefix", () => {

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -330,7 +330,7 @@ describe("SiblingCarousel — happy path", () => {
     expect(active!.getAttribute("href")).toBe("/magdalena.html/english.html")
   })
 
-  it("marks an inactive chapter card as pending immediately after a normal click", () => {
+  it("makes the clicked chapter card current while navigation is pending", () => {
     const block = makeBlock(4, 0)
 
     act(() => {
@@ -340,10 +340,16 @@ describe("SiblingCarousel — happy path", () => {
     const target = container.querySelector(
       "[data-testid='sibling-carousel-item'][data-href='/child-2-slug.html/english.html']",
     )
+    const previousCurrent = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-href='/child-1-slug.html/english.html']",
+    )
 
     expect(target).not.toBeNull()
+    expect(previousCurrent).not.toBeNull()
     expect(target!.getAttribute("data-pending")).toBe("false")
+    expect(target!.getAttribute("data-active")).toBe("false")
     expect(target!.getAttribute("aria-busy")).toBeNull()
+    expect(previousCurrent!.getAttribute("data-active")).toBe("true")
 
     act(() => {
       target!.dispatchEvent(
@@ -356,10 +362,22 @@ describe("SiblingCarousel — happy path", () => {
     })
 
     expect(target!.getAttribute("data-pending")).toBe("true")
+    expect(target!.getAttribute("data-active")).toBe("true")
     expect(target!.getAttribute("aria-busy")).toBe("true")
+    expect(target!.className).toContain("border-white")
+    expect(previousCurrent!.getAttribute("data-active")).toBe("false")
+    expect(previousCurrent!.className).not.toContain("border-white")
     expect(
       target!.querySelector("[data-testid='sibling-carousel-loading-icon']"),
     ).not.toBeNull()
+
+    const label = container.querySelector(
+      "[data-testid='sibling-carousel-label']",
+    )
+    const mobileLabel = label?.querySelector(".md\\:hidden")
+    const desktopLabel = label?.querySelector(".hidden.md\\:inline")
+    expect(mobileLabel?.textContent).toBe("2 of 4")
+    expect(desktopLabel?.textContent).toBe("Clip 2 of 4")
   })
 
   it("does not show pending feedback for modified chapter clicks", () => {

--- a/docs/roadmap/platform/feat-179-watch-chapter-navigation-feedback.md
+++ b/docs/roadmap/platform/feat-179-watch-chapter-navigation-feedback.md
@@ -1,0 +1,45 @@
+---
+id: "feat-179"
+title: "Watch chapter navigation feedback"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-11"
+duration: 1
+depends_on:
+  - "feat-178"
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "navigation"
+---
+
+## Problem
+
+Watch chapter cards can feel unresponsive on slow server navigations because
+the current page remains visible while the next watch route resolves. Users
+need immediate feedback that their chapter click was accepted.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/watch/SiblingCarousel.tsx` - chapter card links.
+2. `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx` -
+   focused chapter carousel behavior coverage.
+3. `apps/web/src/lib/routes.ts` - canonical watch URL builders and basePath
+   contract.
+
+## What To Build
+
+1. Preserve canonical public audio-language watch links for chapter cards.
+2. Show an immediate pending affordance when a normal chapter-card click starts
+   navigation.
+3. Do not hijack modified clicks such as open-in-new-tab or open-in-new-window.
+
+## Verification
+
+- Focused SiblingCarousel tests cover the pending click feedback and modified
+  click behavior.
+- `@forge/web` targeted tests pass.
+- Browser smoke confirms a chapter click visibly acknowledges navigation.

--- a/docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md
+++ b/docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md
@@ -1,0 +1,194 @@
+---
+title: Watch chapter carousel optimistic navigation feedback
+date: 2026-06-11
+category: docs/solutions/design-patterns
+module: apps/web
+problem_type: design_pattern
+component: watch-page
+severity: medium
+related_components:
+  - apps/web/src/components/watch/SiblingCarousel.tsx
+  - apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+  - apps/web/src/lib/routes.ts
+tags:
+  - watch-page
+  - sibling-carousel
+  - chapter-navigation
+  - optimistic-ui
+  - next-link
+  - react-compiler
+  - browser-smoke
+applies_when:
+  - You are changing chapter, episode, sibling, or related-video navigation on public watch pages
+  - A normal click starts a slow same-app navigation and the current route remains visible while Next resolves the next payload
+  - You need click feedback without replacing canonical `next/link` behavior or breaking open-in-new-tab interactions
+---
+
+# Watch chapter carousel optimistic navigation feedback
+
+## Context
+
+Watch chapter cards are ordinary `next/link` navigations to another public
+watch route. On slow route resolution, the old page can remain visible long
+enough that a user wonders whether their click registered. The browser did not
+need a different URL contract; the page needed an immediate local
+acknowledgment using data already present in the carousel: target href, target
+title, and target thumbnail.
+
+The fix lives in `apps/web/src/components/watch/SiblingCarousel.tsx` and keeps
+the carousel server-data model unchanged. A normal click makes the clicked
+chapter the temporary visual current item, shows busy feedback on that tile,
+updates the clip counter, and removes the current treatment from the previous
+card while the next route is still loading.
+
+## Guidance
+
+Keep the chapter card as a `Link`. Do not replace it with imperative
+`router.push()` or a raw `<a>` just to get immediate feedback. The route
+builder in `apps/web/src/lib/routes.ts` still owns the canonical public watch
+href shape and base-path behavior:
+
+```tsx
+const slug = tryAsContentSlug(child.slug)
+const lang = tryAsLocaleSlug(languageSlug)
+const href = slug && lang ? watchVideoPath(slug, lang) : undefined
+```
+
+Capture only normal left-click navigations. Modified clicks must keep browser
+semantics, and active-card clicks should not create a fake pending state:
+
+```tsx
+if (isActive) return
+if (event.defaultPrevented) return
+if (event.button !== 0) return
+if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+
+setPendingNavigation({
+  href,
+  languageSlug,
+  sourceVideoDocumentId: currentVideoDocumentId,
+  targetVideoDocumentId,
+})
+```
+
+Treat pending navigation as an overlay on top of the route-derived active
+state. The pending payload stores the source video and language that produced
+it. When the route commits, `currentVideoDocumentId` changes and the pending
+payload no longer validates, so the component naturally falls back to the
+server-derived active index:
+
+```tsx
+const validPendingNavigation =
+  pendingNavigation != null &&
+  pendingNavigation.languageSlug === languageSlug &&
+  pendingNavigation.sourceVideoDocumentId === currentVideoDocumentId
+    ? pendingNavigation
+    : null
+
+const pendingActiveIndex =
+  validPendingNavigation != null
+    ? children.findIndex(
+        (child) =>
+          child.documentId === validPendingNavigation.targetVideoDocumentId,
+      )
+    : -1
+
+const visualActiveIndex =
+  pendingActiveIndex >= 0 ? pendingActiveIndex : activeIndex
+```
+
+Use that derived `visualActiveIndex` for all visible "current" surfaces:
+
+- `data-active` and `aria-current` on the clicked card.
+- The inside white border and active-card styling.
+- The header clip count (`Clip 2 of 4`, etc.).
+- The Embla `scrollTo()` target.
+- The previous card's removal of active/current styling.
+
+Use separate pending state only for "navigation is in flight" affordances on
+the clicked tile:
+
+```tsx
+const isPending =
+  validPendingNavigation != null &&
+  validPendingNavigation.href === href &&
+  validPendingNavigation.targetVideoDocumentId === child.documentId
+```
+
+That flag drives `aria-busy="true"` and swaps the hover play icon for the
+spinner. A pending card can also be the visual active card; that is intentional
+because the product expectation is "my clicked chapter is now the current one"
+while the rest of the page catches up.
+
+## Why This Matters
+
+This gives users the same feedback cadence as a classic full-page navigation
+without giving up Next's client-side route behavior. The important shift is
+that the chapter rail acknowledges intent immediately while the hero poster,
+title, video data, and rest of the page are still resolving.
+
+The React shape also avoids the `set-state-in-effect` trap. Do not clear
+pending navigation from an effect that watches the URL or current video. Encode
+the pending source and target, then derive whether it is still valid from the
+current props. This matches the React Compiler guidance in
+`docs/solutions/design-patterns/react-compiler-ref-and-setstate-patterns-20260513.md`.
+
+## When to Apply
+
+- Same-app Watch navigations where the clicked target's title, thumbnail, href,
+  and document id are already in the current payload.
+- Carousels or rails where a stale "current" highlight would make the click
+  feel ignored.
+- Navigation feedback that must preserve ordinary browser link behavior:
+  command-click, control-click, shift-click, alt-click, middle-click, and
+  already-prevented events.
+
+Do not apply this pattern when the target data is not known locally, when the
+click starts a mutation rather than route navigation, or when a full document
+navigation is the desired product behavior.
+
+## Verification
+
+Focused coverage belongs in
+`apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`:
+
+- A normal chapter click sets the clicked card to `data-active="true"` and
+  `data-pending="true"`.
+- The previous current card becomes `data-active="false"`.
+- The clicked card exposes `aria-busy="true"` and the loading icon.
+- The clip label follows the clicked card while navigation is pending.
+- Modified clicks do not set pending feedback.
+
+Run:
+
+```bash
+pnpm --filter @forge/web test -- src/components/watch/__tests__/SiblingCarousel.test.tsx
+pnpm --filter @forge/web typecheck
+pnpm --filter @forge/web lint
+```
+
+Browser smoke for the original issue used:
+
+```text
+http://127.0.0.1:3011/watch/resurrected-jesus-appears.html/english.html
+```
+
+Expected behavior:
+
+- The clicked chapter tile becomes current immediately on normal click.
+- The old current tile loses the current state immediately.
+- The clicked tile shows a pending affordance before the destination page fully
+  settles.
+- The destination route eventually renders the real hero/title/current state.
+- Modified clicks preserve browser behavior and do not show in-page pending
+  feedback.
+
+## Related
+
+- `docs/roadmap/platform/feat-179-watch-chapter-navigation-feedback.md` - the
+  ticket for this implementation.
+- `docs/solutions/design-patterns/watch-language-player-chrome-layout-20260609.md`
+  - adjacent Watch-page UX contracts for hero/player/header/episode rail work.
+- `docs/solutions/design-patterns/react-compiler-ref-and-setstate-patterns-20260513.md`
+  - derived-state pattern that explains why this implementation avoids an
+    effect-based pending clear.


### PR DESCRIPTION
## Summary
- add immediate pending state to Watch chapter cards on normal clicks
- show the red loading spinner and aria-busy while the slow destination route resolves
- preserve modified-click behavior and canonical Next/link route building
- add roadmap ticket feat-179 and focused SiblingCarousel coverage

## Verification
- pnpm --filter @forge/web test -- src/components/watch/__tests__/SiblingCarousel.test.tsx
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- agent-browser smoke on local apps/web at 127.0.0.1:3011: clicked an inactive chapter card and confirmed data-pending=true, aria-busy=true, and spinner present one frame after click
- screenshot captured: output/playwright/watch-chapter-pending.png

## Notes
- local cold chapter renders still took about 16-31s through server data resolution; this PR makes the click visibly acknowledged while that work continues