### PR TITLE
fix(admin): wire Mastra Studio access switch

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -95,6 +95,8 @@ MANAGER_TRIGGER_API_KEY=
 # Mastra, then receives final vectors through narrow ingest endpoints.
 MASTRA_BASE_URL=http://localhost:4111
 MASTRA_SERVICE_API_KEY=local-mastra-service-key
+MASTRA_GATEWAY_BASE_URL=http://localhost:3005
+MASTRA_GATEWAY_ADMIN_API_KEY=local-mastra-gateway-admin-key
 MASTRA_TRANSCRIPT_INGEST_API_KEYS=local-admin-transcript-ingest-key
 MASTRA_SCENE_INGEST_API_KEYS=local-admin-scene-ingest-key
 MASTRA_EXPERIENCE_INGEST_API_KEYS=local-admin-experience-ingest-key

--- a/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
+++ b/apps/admin/src/app/dashboard/dashboard-ui.test.tsx
@@ -379,15 +379,15 @@ vi.mock("@/app/dashboard/ops-data", () => ({
           {
             key: "mastra-studio",
             label: "Mastra Studio",
-            selectedRole: "NO_ACCESS",
+            selectedRole: "STUDIO_ACCESS",
             roleOptions: [
               { value: "NO_ACCESS", label: "No access" },
               { value: "STUDIO_ACCESS", label: "Studio access" },
             ],
-            statusTone: "muted",
-            disabled: true,
-            backed: false,
-            helperText: "Mock only",
+            statusTone: "success",
+            disabled: false,
+            backed: true,
+            helperText: "Backed",
           },
         ],
       },
@@ -436,9 +436,9 @@ vi.mock("@/app/dashboard/ops-data", () => ({
               { value: "STUDIO_ACCESS", label: "Studio access" },
             ],
             statusTone: "muted",
-            disabled: true,
-            backed: false,
-            helperText: "Mock only",
+            disabled: false,
+            backed: true,
+            helperText: "Backed",
           },
         ],
       },
@@ -1374,14 +1374,18 @@ describe("dashboard UI routes", () => {
       "Mastra Studio app access role for admin@example.com",
     )
     expect(html).toContain("Apply Manager role")
+    expect(html).toContain("Apply Mastra Studio role")
     expect(html).toContain("Status role")
-    expect(html).toContain("Mock only")
+    expect(html).not.toContain("Mock only")
     expect(html).toContain('<option value="OPERATOR" selected="">Operator')
+    expect(html).toContain(
+      '<option value="STUDIO_ACCESS" selected="">Studio access',
+    )
     expect(html).toContain('<option value="NO_ACCESS" selected="">No access')
     expect(html).toMatch(
       /aria-label="Admin app access role for admin@example\.com"[^>]*disabled=""/,
     )
-    expect(html).toMatch(
+    expect(html).not.toMatch(
       /aria-label="Mastra Studio app access role for admin@example\.com"[^>]*disabled=""/,
     )
     expect(html).not.toContain("Revoke Manager")

--- a/apps/admin/src/app/dashboard/ops-data.test.ts
+++ b/apps/admin/src/app/dashboard/ops-data.test.ts
@@ -19,6 +19,8 @@ const { queryRaw, mockEnv } = vi.hoisted(() => ({
       OPENROUTER_API_PAID_KEY: undefined as string | undefined,
       OPENROUTER_API_KEY: undefined as string | undefined,
       OPENAI_API_KEY: undefined as string | undefined,
+      MASTRA_GATEWAY_BASE_URL: undefined as string | undefined,
+      MASTRA_GATEWAY_ADMIN_API_KEY: undefined as string | undefined,
     },
   },
 }))
@@ -59,6 +61,8 @@ function resetMockEnv() {
   mockEnv.env.OPENROUTER_API_PAID_KEY = undefined
   mockEnv.env.OPENROUTER_API_KEY = undefined
   mockEnv.env.OPENAI_API_KEY = undefined
+  mockEnv.env.MASTRA_GATEWAY_BASE_URL = undefined
+  mockEnv.env.MASTRA_GATEWAY_ADMIN_API_KEY = undefined
 }
 
 function mockEmbeddingCounts({
@@ -340,7 +344,7 @@ describe("loadUsersData", () => {
           statusTone: "muted",
           disabled: true,
           backed: false,
-          helperText: "Mock only",
+          helperText: "Configure",
         },
       ],
       [
@@ -366,7 +370,7 @@ describe("loadUsersData", () => {
           statusTone: "muted",
           disabled: true,
           backed: false,
-          helperText: "Mock only",
+          helperText: "Configure",
         },
       ],
       [
@@ -392,7 +396,7 @@ describe("loadUsersData", () => {
           statusTone: "muted",
           disabled: true,
           backed: false,
-          helperText: "Mock only",
+          helperText: "Configure",
         },
       ],
     ])
@@ -463,6 +467,27 @@ describe("buildUserTableRow", () => {
         backed: false,
       },
     ])
+  })
+
+  it("maps active Mastra Studio access into a backed product control", () => {
+    expect(
+      buildUserTableRow(
+        userSourceRow({
+          mastraStudioAccess: {
+            selectedRole: "STUDIO_ACCESS",
+            disabled: false,
+            helperText: "Backed",
+          },
+        }),
+      ).productAccess[2],
+    ).toMatchObject({
+      key: "mastra-studio",
+      selectedRole: "STUDIO_ACCESS",
+      statusTone: "success",
+      disabled: false,
+      backed: true,
+      helperText: "Backed",
+    })
   })
 })
 

--- a/apps/admin/src/app/dashboard/ops-data.ts
+++ b/apps/admin/src/app/dashboard/ops-data.ts
@@ -15,6 +15,10 @@ import { generateExperienceEmbedding } from "@/services/embeddings.service"
 import { DEFAULT_SYNC_LOCK_STALE_AFTER_MS } from "@/services/core-sync/lock"
 import { getAllWatermarks } from "@/services/core-sync/watermark"
 import {
+  loadMastraStudioAccessByEmail,
+  type MastraStudioAccessRole,
+} from "@/services/mastra-studio-access.service"
+import {
   mediaAssetDownloadUrl,
   mediaAssetPreviewUrl,
 } from "@/services/media-asset.service"
@@ -111,6 +115,11 @@ export type UserAccessSourceRow = {
     role: "OPERATOR"
     revokedAt: Date | null
   } | null
+  mastraStudioAccess?: {
+    selectedRole: MastraStudioAccessRole
+    disabled: boolean
+    helperText: string
+  }
 }
 
 type UserAccessBaseRow = Omit<UserAccessSourceRow, "managerMembership">
@@ -2071,8 +2080,12 @@ export async function loadUsersData(): Promise<UsersData> {
   const managerMembershipByUserId = new Map(
     managerMemberships.map((membership) => [membership.userId, membership]),
   )
+  const mastraStudioAccess = await loadMastraStudioAccessByEmail(
+    userRows.map((row) => row.email),
+  )
   const rows = userRows.map((row): UserAccessSourceRow => {
     const managerMembership = managerMembershipByUserId.get(row.id)
+    const mastraStudioEmail = row.email.trim().toLowerCase()
     return {
       ...row,
       managerMembership: managerMembership
@@ -2081,6 +2094,13 @@ export async function loadUsersData(): Promise<UsersData> {
             revokedAt: managerMembership.revokedAt,
           }
         : null,
+      mastraStudioAccess: {
+        selectedRole:
+          mastraStudioAccess.accessByEmail.get(mastraStudioEmail) ??
+          "NO_ACCESS",
+        disabled: mastraStudioAccess.disabled,
+        helperText: mastraStudioAccess.helperText,
+      },
     }
   })
 
@@ -2128,6 +2148,13 @@ export function buildUserTableRow(row: UserAccessSourceRow): UserTableRow {
   const hasManagerAccess = Boolean(
     row.managerMembership && !row.managerMembership.revokedAt,
   )
+  const mastraStudioAccess = row.mastraStudioAccess ?? {
+    selectedRole: "NO_ACCESS" as const,
+    disabled: true,
+    helperText: "Configure",
+  }
+  const hasMastraStudioAccess =
+    mastraStudioAccess.selectedRole === "STUDIO_ACCESS"
 
   return {
     key: row.id,
@@ -2162,12 +2189,12 @@ export function buildUserTableRow(row: UserAccessSourceRow): UserTableRow {
       {
         key: "mastra-studio",
         label: "Mastra Studio",
-        selectedRole: "NO_ACCESS",
+        selectedRole: mastraStudioAccess.selectedRole,
         roleOptions: MASTRA_STUDIO_ROLE_OPTIONS,
-        statusTone: "muted",
-        disabled: true,
-        backed: false,
-        helperText: "Mock only",
+        statusTone: hasMastraStudioAccess ? "success" : "muted",
+        disabled: mastraStudioAccess.disabled,
+        backed: !mastraStudioAccess.disabled,
+        helperText: mastraStudioAccess.helperText,
       },
     ],
   }

--- a/apps/admin/src/app/dashboard/users/actions.test.ts
+++ b/apps/admin/src/app/dashboard/users/actions.test.ts
@@ -6,6 +6,7 @@ const revalidatePath = vi.fn()
 const approveUserRole = vi.fn()
 const grantManagerAccessForUser = vi.fn()
 const revokeManagerAccessForUser = vi.fn()
+const updateMastraStudioAccessByEmail = vi.fn()
 
 vi.mock("next/cache", () => ({
   revalidatePath: (...args: unknown[]) => revalidatePath(...args),
@@ -23,7 +24,16 @@ vi.mock("@/services/user-access.service", () => ({
     revokeManagerAccessForUser(...args),
 }))
 
-import { approveUser, updateManagerAccess } from "@/app/dashboard/users/actions"
+vi.mock("@/services/mastra-studio-access.service", () => ({
+  updateMastraStudioAccessByEmail: (...args: unknown[]) =>
+    updateMastraStudioAccessByEmail(...args),
+}))
+
+import {
+  approveUser,
+  updateManagerAccess,
+  updateMastraStudioAccess,
+} from "@/app/dashboard/users/actions"
 
 const adminUser = { id: "admin-user-1", role: "ADMIN" }
 
@@ -42,6 +52,7 @@ describe("dashboard users server actions", () => {
     approveUserRole.mockReset()
     grantManagerAccessForUser.mockReset()
     revokeManagerAccessForUser.mockReset()
+    updateMastraStudioAccessByEmail.mockReset()
     requireAdminSession.mockResolvedValue(adminUser)
   })
 
@@ -108,6 +119,56 @@ describe("dashboard users server actions", () => {
     await expect(
       updateManagerAccess(form({ id: "target-user-1", role: "NO_ACCESS" })),
     ).rejects.toThrow("db failed")
+
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+
+  it("grants Mastra Studio access when Studio access is selected", async () => {
+    await updateMastraStudioAccess(
+      form({ email: "target@example.com", role: "STUDIO_ACCESS" }),
+    )
+
+    expect(updateMastraStudioAccessByEmail).toHaveBeenCalledWith({
+      email: "target@example.com",
+      role: "STUDIO_ACCESS",
+      approvedBy: "admin-user-1",
+    })
+    expect(revalidatePath).toHaveBeenCalledWith("/dashboard/users")
+  })
+
+  it("revokes Mastra Studio access when No access is selected", async () => {
+    await updateMastraStudioAccess(
+      form({ email: "target@example.com", role: "NO_ACCESS" }),
+    )
+
+    expect(updateMastraStudioAccessByEmail).toHaveBeenCalledWith({
+      email: "target@example.com",
+      role: "NO_ACCESS",
+      approvedBy: "admin-user-1",
+    })
+    expect(revalidatePath).toHaveBeenCalledWith("/dashboard/users")
+  })
+
+  it("does not write or revalidate Mastra Studio access for invalid form values", async () => {
+    await updateMastraStudioAccess(new FormData())
+    await updateMastraStudioAccess(
+      form({ email: "target@example.com", role: "ADMIN" }),
+    )
+
+    expect(updateMastraStudioAccessByEmail).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+
+  it("rethrows Mastra Studio update failures", async () => {
+    updateMastraStudioAccessByEmail.mockRejectedValueOnce(
+      new Error("gateway failed"),
+    )
+
+    await expect(
+      updateMastraStudioAccess(
+        form({ email: "target@example.com", role: "STUDIO_ACCESS" }),
+      ),
+    ).rejects.toThrow("gateway failed")
 
     expect(revalidatePath).not.toHaveBeenCalled()
   })

--- a/apps/admin/src/app/dashboard/users/actions.ts
+++ b/apps/admin/src/app/dashboard/users/actions.ts
@@ -6,6 +6,7 @@ import {
   grantManagerAccess as grantManagerAccessForUser,
   revokeManagerAccess as revokeManagerAccessForUser,
 } from "@/services/user-access.service"
+import { updateMastraStudioAccessByEmail } from "@/services/mastra-studio-access.service"
 
 export async function approveUser(formData: FormData) {
   "use server"
@@ -43,5 +44,26 @@ export async function updateManagerAccess(formData: FormData) {
       throw error
     }
   }
+  revalidatePath("/dashboard/users")
+}
+
+export async function updateMastraStudioAccess(formData: FormData) {
+  "use server"
+
+  const user = await requireAdminSession()
+  const email = formData.get("email")
+  const role = formData.get("role")
+  if (
+    typeof email !== "string" ||
+    (role !== "STUDIO_ACCESS" && role !== "NO_ACCESS")
+  ) {
+    return
+  }
+
+  await updateMastraStudioAccessByEmail({
+    email,
+    role,
+    approvedBy: user.id ?? "admin",
+  })
   revalidatePath("/dashboard/users")
 }

--- a/apps/admin/src/app/dashboard/users/page.tsx
+++ b/apps/admin/src/app/dashboard/users/page.tsx
@@ -12,7 +12,11 @@ import {
   loadUsersData,
   type DashboardStatusTone,
 } from "@/app/dashboard/ops-data"
-import { approveUser, updateManagerAccess } from "@/app/dashboard/users/actions"
+import {
+  approveUser,
+  updateManagerAccess,
+  updateMastraStudioAccess,
+} from "@/app/dashboard/users/actions"
 
 type UsersRow = Awaited<ReturnType<typeof loadUsersData>>["rows"][number]
 type ProductAccessItem = UsersRow["productAccess"][number]
@@ -165,13 +169,21 @@ function ProductAccessControl({
     </select>
   )
 
-  if (access.key === "manager" && access.backed && !access.disabled) {
+  const formAction =
+    access.key === "manager"
+      ? updateManagerAccess
+      : access.key === "mastra-studio"
+        ? updateMastraStudioAccess
+        : null
+
+  if (formAction && access.backed && !access.disabled) {
     return (
       <form
-        action={updateManagerAccess}
+        action={formAction}
         className="grid grid-cols-[86px_minmax(142px,1fr)_32px] items-center gap-2"
       >
         <input type="hidden" name="id" value={userId} />
+        <input type="hidden" name="email" value={userTitle} />
         <span className="label-text text-[10px]">{access.label}</span>
         {select}
         <button

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -222,6 +222,8 @@ export const env = createEnv({
     // ingest outcomes after writing through Admin's internal ingest.
     MASTRA_BASE_URL: z.string().url().optional(),
     MASTRA_SERVICE_API_KEY: z.string().min(1).optional(),
+    MASTRA_GATEWAY_BASE_URL: z.string().url().optional(),
+    MASTRA_GATEWAY_ADMIN_API_KEY: z.string().min(1).optional(),
     MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS: z.coerce
       .number()
       .int()
@@ -434,6 +436,12 @@ export const env = createEnv({
     MASTRA_BASE_URL: emptyToUndefined(process.env.MASTRA_BASE_URL),
     MASTRA_SERVICE_API_KEY: emptyToUndefined(
       process.env.MASTRA_SERVICE_API_KEY,
+    ),
+    MASTRA_GATEWAY_BASE_URL: emptyToUndefined(
+      process.env.MASTRA_GATEWAY_BASE_URL,
+    ),
+    MASTRA_GATEWAY_ADMIN_API_KEY: emptyToUndefined(
+      process.env.MASTRA_GATEWAY_ADMIN_API_KEY,
     ),
     MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS: emptyToUndefined(
       process.env.MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS,

--- a/apps/admin/src/services/mastra-studio-access.service.test.ts
+++ b/apps/admin/src/services/mastra-studio-access.service.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: {
+    env: {
+      MASTRA_GATEWAY_BASE_URL: undefined as string | undefined,
+      MASTRA_GATEWAY_ADMIN_API_KEY: undefined as string | undefined,
+    },
+  },
+}))
+
+vi.mock("@/config/env", () => mockEnv)
+
+import {
+  loadMastraStudioAccessByEmail,
+  updateMastraStudioAccessByEmail,
+} from "./mastra-studio-access.service"
+
+function response(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+}
+
+describe("Mastra Studio access client", () => {
+  beforeEach(() => {
+    mockEnv.env.MASTRA_GATEWAY_BASE_URL = undefined
+    mockEnv.env.MASTRA_GATEWAY_ADMIN_API_KEY = undefined
+    vi.unstubAllGlobals()
+  })
+
+  it("returns a disabled fallback when gateway config is missing", async () => {
+    const lookup = await loadMastraStudioAccessByEmail(["user@example.com"])
+
+    expect(lookup.disabled).toBe(true)
+    expect(lookup.helperText).toBe("Configure")
+    expect(lookup.accessByEmail.size).toBe(0)
+  })
+
+  it("dedupes lookup emails and maps approved rows to Studio access", async () => {
+    mockEnv.env.MASTRA_GATEWAY_BASE_URL = "https://gateway.example"
+    mockEnv.env.MASTRA_GATEWAY_ADMIN_API_KEY = "gateway-key"
+    const fetchMock = vi.fn(async () =>
+      response({
+        records: [
+          {
+            email: "active@example.com",
+            status: "approved",
+            role: "editor",
+          },
+          {
+            email: "pending@example.com",
+            status: "pending",
+            role: "editor",
+          },
+        ],
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const lookup = await loadMastraStudioAccessByEmail([
+      " Active@Example.com ",
+      "active@example.com",
+      "pending@example.com",
+    ])
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example/api/admin/studio-access",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          authorization: "Bearer gateway-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          emails: ["active@example.com", "pending@example.com"],
+        }),
+      }),
+    )
+    expect(lookup).toMatchObject({
+      disabled: false,
+      helperText: "Backed",
+    })
+    expect(lookup.accessByEmail.get("active@example.com")).toBe("STUDIO_ACCESS")
+    expect(lookup.accessByEmail.get("pending@example.com")).toBe("NO_ACCESS")
+  })
+
+  it("disables the control when lookup transport fails", async () => {
+    mockEnv.env.MASTRA_GATEWAY_BASE_URL = "https://gateway.example"
+    mockEnv.env.MASTRA_GATEWAY_ADMIN_API_KEY = "gateway-key"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response({ error: "nope" }, { status: 503 })),
+    )
+
+    const lookup = await loadMastraStudioAccessByEmail(["user@example.com"])
+
+    expect(lookup.disabled).toBe(true)
+    expect(lookup.helperText).toBe("Unavailable")
+  })
+
+  it("sends grant and revoke updates through the gateway API", async () => {
+    mockEnv.env.MASTRA_GATEWAY_BASE_URL = "https://gateway.example"
+    mockEnv.env.MASTRA_GATEWAY_ADMIN_API_KEY = "gateway-key"
+    const fetchMock = vi.fn(async () => response({ record: null }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await updateMastraStudioAccessByEmail({
+      email: "User@Example.com",
+      name: "User",
+      role: "STUDIO_ACCESS",
+      approvedBy: "admin-1",
+    })
+    await updateMastraStudioAccessByEmail({
+      email: "User@Example.com",
+      role: "NO_ACCESS",
+      approvedBy: "admin-1",
+    })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://gateway.example/api/admin/studio-access",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          email: "user@example.com",
+          name: "User",
+          role: "editor",
+          approvedBy: "admin-1",
+        }),
+      }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://gateway.example/api/admin/studio-access",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          email: "user@example.com",
+          role: "none",
+          approvedBy: "admin-1",
+        }),
+      }),
+    )
+  })
+
+  it("throws on update when gateway rejects the mutation", async () => {
+    mockEnv.env.MASTRA_GATEWAY_BASE_URL = "https://gateway.example"
+    mockEnv.env.MASTRA_GATEWAY_ADMIN_API_KEY = "gateway-key"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response({ error: "unauthorized" }, { status: 401 })),
+    )
+
+    await expect(
+      updateMastraStudioAccessByEmail({
+        email: "user@example.com",
+        role: "STUDIO_ACCESS",
+        approvedBy: "admin-1",
+      }),
+    ).rejects.toThrow("status 401")
+  })
+})

--- a/apps/admin/src/services/mastra-studio-access.service.ts
+++ b/apps/admin/src/services/mastra-studio-access.service.ts
@@ -1,0 +1,188 @@
+import { env } from "@/config/env"
+
+const MASTRA_STUDIO_ACCESS_TIMEOUT_MS = 5_000
+
+export type MastraStudioAccessRole = "NO_ACCESS" | "STUDIO_ACCESS"
+
+export type MastraStudioAccessLookup = {
+  disabled: boolean
+  helperText: string
+  accessByEmail: Map<string, MastraStudioAccessRole>
+}
+
+type GatewayAccessRecord = {
+  email: string
+  status: "approved" | "pending" | "revoked"
+  role: "admin" | "editor"
+}
+
+type GatewayAccessResponse = {
+  records: GatewayAccessRecord[]
+}
+
+export async function loadMastraStudioAccessByEmail(
+  emails: readonly string[],
+): Promise<MastraStudioAccessLookup> {
+  const config = getMastraGatewayAdminConfig()
+  if (!config) {
+    return disabledLookup("Configure")
+  }
+
+  const normalizedEmails = normalizeEmailList(emails)
+  if (normalizedEmails.length === 0) {
+    return backedLookup(new Map())
+  }
+
+  let response: Response
+  try {
+    response = await fetch(config.url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${config.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ emails: normalizedEmails }),
+      signal: AbortSignal.timeout(MASTRA_STUDIO_ACCESS_TIMEOUT_MS),
+    })
+  } catch {
+    return disabledLookup("Unavailable")
+  }
+
+  if (!response.ok) {
+    return disabledLookup(
+      response.status === 401 ? "Auth failed" : "Unavailable",
+    )
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    return disabledLookup("Unavailable")
+  }
+
+  if (!isGatewayAccessResponse(payload)) {
+    return disabledLookup("Unavailable")
+  }
+
+  const accessByEmail = new Map<string, MastraStudioAccessRole>()
+  for (const record of payload.records) {
+    const email = normalizeEmail(record.email)
+    if (!email) continue
+    accessByEmail.set(
+      email,
+      record.status === "approved" ? "STUDIO_ACCESS" : "NO_ACCESS",
+    )
+  }
+
+  return backedLookup(accessByEmail)
+}
+
+export async function updateMastraStudioAccessByEmail({
+  email,
+  name,
+  role,
+  approvedBy,
+}: {
+  email: string
+  name?: string
+  role: MastraStudioAccessRole
+  approvedBy: string
+}): Promise<void> {
+  const config = getMastraGatewayAdminConfig()
+  if (!config) {
+    throw new Error("Mastra Studio gateway access API is not configured")
+  }
+
+  const normalizedEmail = normalizeEmail(email)
+  if (!normalizedEmail) {
+    throw new Error("email is required")
+  }
+
+  const response = await fetch(config.url, {
+    method: "PATCH",
+    headers: {
+      authorization: `Bearer ${config.apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      email: normalizedEmail,
+      ...(name ? { name } : {}),
+      role: role === "STUDIO_ACCESS" ? "editor" : "none",
+      approvedBy,
+    }),
+    signal: AbortSignal.timeout(MASTRA_STUDIO_ACCESS_TIMEOUT_MS),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Mastra Studio gateway access update failed with status ${response.status}`,
+    )
+  }
+}
+
+function getMastraGatewayAdminConfig() {
+  if (!env.MASTRA_GATEWAY_BASE_URL || !env.MASTRA_GATEWAY_ADMIN_API_KEY) {
+    return null
+  }
+
+  return {
+    url: new URL(
+      "/api/admin/studio-access",
+      env.MASTRA_GATEWAY_BASE_URL,
+    ).toString(),
+    apiKey: env.MASTRA_GATEWAY_ADMIN_API_KEY,
+  }
+}
+
+function backedLookup(
+  accessByEmail: Map<string, MastraStudioAccessRole>,
+): MastraStudioAccessLookup {
+  return {
+    disabled: false,
+    helperText: "Backed",
+    accessByEmail,
+  }
+}
+
+function disabledLookup(helperText: string): MastraStudioAccessLookup {
+  return {
+    disabled: true,
+    helperText,
+    accessByEmail: new Map(),
+  }
+}
+
+function normalizeEmailList(emails: readonly string[]) {
+  return Array.from(
+    new Set(
+      emails
+        .map(normalizeEmail)
+        .filter((email): email is string => Boolean(email)),
+    ),
+  )
+}
+
+function normalizeEmail(email: string | undefined) {
+  return email?.trim().toLowerCase() || undefined
+}
+
+function isGatewayAccessResponse(
+  payload: unknown,
+): payload is GatewayAccessResponse {
+  if (!payload || typeof payload !== "object") return false
+  const records = (payload as { records?: unknown }).records
+  return Array.isArray(records) && records.every(isGatewayAccessRecord)
+}
+
+function isGatewayAccessRecord(record: unknown): record is GatewayAccessRecord {
+  if (!record || typeof record !== "object") return false
+  const candidate = record as Partial<GatewayAccessRecord>
+  return (
+    typeof candidate.email === "string" &&
+    (candidate.status === "approved" ||
+      candidate.status === "pending" ||
+      candidate.status === "revoked") &&
+    (candidate.role === "admin" || candidate.role === "editor")
+  )
+}

--- a/apps/mastra-gateway/.env.example
+++ b/apps/mastra-gateway/.env.example
@@ -6,4 +6,5 @@ MASTRA_GATEWAY_BASE_URL=http://localhost:3005
 MASTRA_GATEWAY_SESSION_SECRET=change-me-change-me-change-me-32chars
 MASTRA_INTERNAL_BASE_URL=http://localhost:4111
 MASTRA_INTERNAL_API_KEY=local-mastra-service-key
+MASTRA_GATEWAY_ADMIN_API_KEYS=local-mastra-gateway-admin-key
 MASTRA_GATEWAY_BOOTSTRAP_ADMIN_EMAILS=

--- a/apps/mastra-gateway/src/app/api/admin/studio-access/route.test.ts
+++ b/apps/mastra-gateway/src/app/api/admin/studio-access/route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const isValidGatewayAdminBearer = vi.fn()
+const service = {
+  listByEmails: vi.fn(),
+  approveByEmail: vi.fn(),
+  revokeByEmail: vi.fn(),
+}
+
+vi.mock("@/auth/admin-api-bearer", () => ({
+  isValidGatewayAdminBearer: (...args: unknown[]) =>
+    isValidGatewayAdminBearer(...args),
+}))
+
+vi.mock("@/services/studio-access.factory", () => ({
+  createGatewayStudioAccessService: () => service,
+}))
+
+import { PATCH, POST } from "./route"
+
+function request(method: string, body: unknown, bearer = "valid-key") {
+  return new Request("http://gateway.test/api/admin/studio-access", {
+    method,
+    headers: {
+      authorization: `Bearer ${bearer}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+async function json(response: Response) {
+  return (await response.json()) as unknown
+}
+
+describe("gateway Studio access admin API", () => {
+  beforeEach(() => {
+    isValidGatewayAdminBearer.mockReset()
+    service.listByEmails.mockReset()
+    service.approveByEmail.mockReset()
+    service.revokeByEmail.mockReset()
+    isValidGatewayAdminBearer.mockReturnValue(true)
+  })
+
+  it("rejects missing or invalid bearer credentials", async () => {
+    isValidGatewayAdminBearer.mockReturnValue(false)
+
+    const response = await POST(request("POST", { emails: ["a@example.com"] }))
+
+    expect(response.status).toBe(401)
+    expect(service.listByEmails).not.toHaveBeenCalled()
+    expect(await json(response)).toEqual({ error: "unauthorized" })
+  })
+
+  it("looks up Studio access records by email", async () => {
+    service.listByEmails.mockResolvedValueOnce([
+      {
+        id: "access-1",
+        subject: null,
+        email: "active@example.com",
+        name: null,
+        status: "approved",
+        role: "editor",
+      },
+    ])
+
+    const response = await POST(
+      request("POST", { emails: ["active@example.com"] }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(service.listByEmails).toHaveBeenCalledWith(["active@example.com"])
+    expect(await json(response)).toEqual({
+      records: [
+        {
+          email: "active@example.com",
+          status: "approved",
+          role: "editor",
+        },
+      ],
+    })
+  })
+
+  it("grants editor access by email", async () => {
+    service.approveByEmail.mockResolvedValueOnce({
+      id: "access-1",
+      subject: null,
+      email: "active@example.com",
+      name: "Active User",
+      status: "approved",
+      role: "editor",
+    })
+
+    const response = await PATCH(
+      request("PATCH", {
+        email: "active@example.com",
+        name: "Active User",
+        role: "editor",
+        approvedBy: "admin-user",
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(service.approveByEmail).toHaveBeenCalledWith({
+      email: "active@example.com",
+      name: "Active User",
+      role: "editor",
+      approvedBy: "admin-user",
+    })
+    expect(await json(response)).toEqual({
+      record: {
+        email: "active@example.com",
+        status: "approved",
+        role: "editor",
+      },
+    })
+  })
+
+  it("revokes access by email and no-ops absent rows", async () => {
+    service.revokeByEmail.mockResolvedValueOnce(null)
+
+    const response = await PATCH(
+      request("PATCH", {
+        email: "missing@example.com",
+        role: "none",
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(service.revokeByEmail).toHaveBeenCalledWith({
+      email: "missing@example.com",
+    })
+    expect(await json(response)).toEqual({ record: null })
+  })
+
+  it("returns a generic 400 for invalid payloads", async () => {
+    const response = await PATCH(
+      request("PATCH", {
+        email: "",
+        role: "admin",
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(service.approveByEmail).not.toHaveBeenCalled()
+    expect(await json(response)).toEqual({ error: "invalid_request" })
+  })
+})

--- a/apps/mastra-gateway/src/app/api/admin/studio-access/route.ts
+++ b/apps/mastra-gateway/src/app/api/admin/studio-access/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { isValidGatewayAdminBearer } from "@/auth/admin-api-bearer"
+import { createGatewayStudioAccessService } from "@/services/studio-access.factory"
+import type { StudioAccessRecord } from "@/services/studio-access.service"
+
+const lookupSchema = z.object({
+  emails: z.array(z.string().min(1)).max(100),
+})
+
+const updateSchema = z.object({
+  email: z.string().min(1),
+  name: z.string().min(1).optional(),
+  role: z.enum(["editor", "none"]),
+  approvedBy: z.string().min(1).max(128).optional(),
+})
+
+export async function POST(request: Request) {
+  if (!isValidGatewayAdminBearer(request.headers.get("authorization"))) {
+    return unauthorized()
+  }
+
+  const body = await readJson(request)
+  const parsed = lookupSchema.safeParse(body)
+  if (!parsed.success) return invalidRequest()
+
+  const records = await createGatewayStudioAccessService().listByEmails(
+    parsed.data.emails,
+  )
+
+  return NextResponse.json({ records: records.map(toApiRecord) })
+}
+
+export async function PATCH(request: Request) {
+  if (!isValidGatewayAdminBearer(request.headers.get("authorization"))) {
+    return unauthorized()
+  }
+
+  const body = await readJson(request)
+  const parsed = updateSchema.safeParse(body)
+  if (!parsed.success) return invalidRequest()
+
+  const service = createGatewayStudioAccessService()
+  const record =
+    parsed.data.role === "none"
+      ? await service.revokeByEmail({ email: parsed.data.email })
+      : await service.approveByEmail({
+          email: parsed.data.email,
+          name: parsed.data.name,
+          role: "editor",
+          approvedBy: parsed.data.approvedBy ?? "admin-api",
+        })
+
+  return NextResponse.json({ record: record ? toApiRecord(record) : null })
+}
+
+async function readJson(request: Request): Promise<unknown> {
+  try {
+    return await request.json()
+  } catch {
+    return null
+  }
+}
+
+function toApiRecord(record: StudioAccessRecord) {
+  return {
+    email: record.email,
+    status: record.status,
+    role: record.role,
+  }
+}
+
+function unauthorized() {
+  return NextResponse.json({ error: "unauthorized" }, { status: 401 })
+}
+
+function invalidRequest() {
+  return NextResponse.json({ error: "invalid_request" }, { status: 400 })
+}

--- a/apps/mastra-gateway/src/auth/admin-api-bearer.ts
+++ b/apps/mastra-gateway/src/auth/admin-api-bearer.ts
@@ -1,0 +1,36 @@
+import { timingSafeEqual } from "node:crypto"
+
+import { env } from "@/config/env"
+
+const BEARER_PREFIX = /^Bearer\s+/i
+
+function parseAllowlist(csv: string | undefined): string[] {
+  if (!csv) return []
+  return csv
+    .split(",")
+    .map((key) => key.trim())
+    .filter((key) => key.length > 0)
+}
+
+export function isValidGatewayAdminBearer(authHeader: string | null): boolean {
+  if (!authHeader || !BEARER_PREFIX.test(authHeader)) return false
+
+  const presented = authHeader.replace(BEARER_PREFIX, "")
+  if (presented.trim().length === 0) return false
+
+  const allowlist = parseAllowlist(env.MASTRA_GATEWAY_ADMIN_API_KEYS)
+  if (allowlist.length === 0) return false
+
+  const presentedBuffer = Buffer.from(presented)
+  let matched = false
+
+  for (const key of allowlist) {
+    const keyBuffer = Buffer.from(key)
+    if (keyBuffer.length !== presentedBuffer.length) continue
+    if (timingSafeEqual(presentedBuffer, keyBuffer)) {
+      matched = true
+    }
+  }
+
+  return matched
+}

--- a/apps/mastra-gateway/src/config/env.ts
+++ b/apps/mastra-gateway/src/config/env.ts
@@ -17,6 +17,7 @@ export const env = createEnv({
     MASTRA_GATEWAY_SESSION_SECRET: z.string().min(32).optional(),
     MASTRA_INTERNAL_BASE_URL: z.string().url().optional(),
     MASTRA_INTERNAL_API_KEY: z.string().min(1).optional(),
+    MASTRA_GATEWAY_ADMIN_API_KEYS: z.string().min(1).optional(),
     MASTRA_GATEWAY_BOOTSTRAP_ADMIN_EMAILS: z.string().optional(),
   },
   runtimeEnv: {
@@ -40,6 +41,9 @@ export const env = createEnv({
     ),
     MASTRA_INTERNAL_API_KEY: emptyToUndefined(
       process.env.MASTRA_INTERNAL_API_KEY,
+    ),
+    MASTRA_GATEWAY_ADMIN_API_KEYS: emptyToUndefined(
+      process.env.MASTRA_GATEWAY_ADMIN_API_KEYS,
     ),
     MASTRA_GATEWAY_BOOTSTRAP_ADMIN_EMAILS:
       process.env.MASTRA_GATEWAY_BOOTSTRAP_ADMIN_EMAILS,

--- a/apps/mastra-gateway/src/services/studio-access.repository.ts
+++ b/apps/mastra-gateway/src/services/studio-access.repository.ts
@@ -81,6 +81,16 @@ export const studioAccessRepository: StudioAccessRepository = {
     return toRecord(row)
   },
 
+  async listByEmails({ emails }) {
+    if (emails.length === 0) return []
+
+    const rows = await prisma.studioAccess.findMany({
+      where: { email: { in: [...emails] } },
+      orderBy: { email: "asc" },
+    })
+    return rows.map(toRecord)
+  },
+
   async list() {
     const rows = await prisma.studioAccess.findMany({
       orderBy: [{ status: "asc" }, { email: "asc" }],
@@ -102,9 +112,51 @@ export const studioAccessRepository: StudioAccessRepository = {
     return toRecord(row)
   },
 
+  async approveByEmail({ email, name, role, approvedBy }) {
+    const now = new Date()
+    const nameData = name === undefined ? {} : { name }
+    const row = await prisma.studioAccess.upsert({
+      where: { email },
+      update: {
+        ...nameData,
+        status: "APPROVED",
+        role: toPrismaRole(role),
+        approvedBy,
+        approvedAt: now,
+        revokedAt: null,
+      },
+      create: {
+        email,
+        ...nameData,
+        status: "APPROVED",
+        role: toPrismaRole(role),
+        approvedBy,
+        approvedAt: now,
+      },
+    })
+    return toRecord(row)
+  },
+
   async revoke({ id }) {
     const row = await prisma.studioAccess.update({
       where: { id },
+      data: {
+        status: "REVOKED",
+        revokedAt: new Date(),
+      },
+    })
+    return toRecord(row)
+  },
+
+  async revokeByEmail({ email }) {
+    const existing = await prisma.studioAccess.findUnique({
+      where: { email },
+      select: { id: true },
+    })
+    if (!existing) return null
+
+    const row = await prisma.studioAccess.update({
+      where: { email },
       data: {
         status: "REVOKED",
         revokedAt: new Date(),

--- a/apps/mastra-gateway/src/services/studio-access.service.test.ts
+++ b/apps/mastra-gateway/src/services/studio-access.service.test.ts
@@ -26,6 +26,9 @@ function repository(
   requestAccess: ReturnType<typeof vi.fn>
   markAccessed: ReturnType<typeof vi.fn>
   upsertBootstrapAdmin: ReturnType<typeof vi.fn>
+  listByEmails: ReturnType<typeof vi.fn>
+  approveByEmail: ReturnType<typeof vi.fn>
+  revokeByEmail: ReturnType<typeof vi.fn>
 } {
   return {
     findBySubjectOrEmail: vi.fn(async () => found),
@@ -35,9 +38,16 @@ function repository(
     requestAccess: vi.fn(async (input) =>
       record({ ...input, status: "pending" }),
     ),
+    listByEmails: vi.fn(async ({ emails }) =>
+      emails.map((email: string) => record({ email })),
+    ),
     list: vi.fn(async () => []),
     approve: vi.fn(async () => record()),
+    approveByEmail: vi.fn(async (input) => record({ ...input })),
     revoke: vi.fn(async () => record({ status: "revoked" })),
+    revokeByEmail: vi.fn(async (input) =>
+      record({ ...input, status: "revoked" }),
+    ),
     updateRole: vi.fn(async () => record({ role: "admin" })),
     markAccessed: vi.fn(async () => undefined),
   }
@@ -106,5 +116,46 @@ describe("Studio access service", () => {
         repository: repository(record({ role: "editor" })),
       }).requireAdmin({ subject: "editor", email: "editor@example.com" }),
     ).resolves.toBe(false)
+  })
+
+  it("normalizes and dedupes admin API email lookups", async () => {
+    const repo = repository(null)
+    const service = createStudioAccessService({ repository: repo })
+
+    await expect(
+      service.listByEmails([
+        " FIRST@example.com ",
+        "first@example.com",
+        "",
+        "Second@Example.com",
+      ]),
+    ).resolves.toMatchObject([
+      { email: "first@example.com" },
+      { email: "second@example.com" },
+    ])
+    expect(repo.listByEmails).toHaveBeenCalledWith({
+      emails: ["first@example.com", "second@example.com"],
+    })
+  })
+
+  it("normalizes admin API grant and revoke emails", async () => {
+    const repo = repository(null)
+    const service = createStudioAccessService({ repository: repo })
+
+    await service.approveByEmail({
+      email: "User@Example.com",
+      role: "editor",
+      approvedBy: "admin-user",
+    })
+    await service.revokeByEmail({ email: "User@Example.com" })
+
+    expect(repo.approveByEmail).toHaveBeenCalledWith({
+      email: "user@example.com",
+      role: "editor",
+      approvedBy: "admin-user",
+    })
+    expect(repo.revokeByEmail).toHaveBeenCalledWith({
+      email: "user@example.com",
+    })
   })
 })

--- a/apps/mastra-gateway/src/services/studio-access.service.ts
+++ b/apps/mastra-gateway/src/services/studio-access.service.ts
@@ -31,13 +31,23 @@ export type StudioAccessRepository = {
     email: string
     name?: string
   }): Promise<StudioAccessRecord>
+  listByEmails(input: {
+    emails: readonly string[]
+  }): Promise<StudioAccessRecord[]>
   list(): Promise<StudioAccessRecord[]>
   approve(input: {
     id: string
     role: StudioAccessRole
     approvedBy: string
   }): Promise<StudioAccessRecord>
+  approveByEmail(input: {
+    email: string
+    name?: string
+    role: StudioAccessRole
+    approvedBy: string
+  }): Promise<StudioAccessRecord>
   revoke(input: { id: string }): Promise<StudioAccessRecord>
+  revokeByEmail(input: { email: string }): Promise<StudioAccessRecord | null>
   updateRole(input: {
     id: string
     role: StudioAccessRole
@@ -109,12 +119,53 @@ export function createStudioAccessService({
     return decision.allowed && decision.role === "admin"
   }
 
+  function normalizeEmailOrThrow(email: string) {
+    const normalized = normalizeEmail(email)
+    if (!normalized) {
+      throw new Error("email is required")
+    }
+    return normalized
+  }
+
+  async function listByEmails(emails: readonly string[]) {
+    const normalizedEmails = Array.from(
+      new Set(
+        emails
+          .map(normalizeEmail)
+          .filter((email): email is string => Boolean(email)),
+      ),
+    )
+    if (normalizedEmails.length === 0) return []
+    return repository.listByEmails({ emails: normalizedEmails })
+  }
+
+  async function approveByEmail(input: {
+    email: string
+    name?: string
+    role: StudioAccessRole
+    approvedBy: string
+  }) {
+    return repository.approveByEmail({
+      ...input,
+      email: normalizeEmailOrThrow(input.email),
+    })
+  }
+
+  async function revokeByEmail(input: { email: string }) {
+    return repository.revokeByEmail({
+      email: normalizeEmailOrThrow(input.email),
+    })
+  }
+
   return {
     resolve,
     requireAdmin,
+    listByEmails,
     list: repository.list,
     approve: repository.approve,
+    approveByEmail,
     revoke: repository.revoke,
+    revokeByEmail,
     updateRole: repository.updateRole,
   }
 }

--- a/docs/plans/2026-06-11-003-fix-mastra-studio-permission-switch-plan.md
+++ b/docs/plans/2026-06-11-003-fix-mastra-studio-permission-switch-plan.md
@@ -1,0 +1,132 @@
+---
+title: "Fix Mastra Studio Permission Switch"
+type: "fix"
+status: "completed"
+date: "2026-06-11"
+---
+
+# Fix Mastra Studio Permission Switch
+
+## Summary
+
+Wire the Admin Users table's Mastra Studio dropdown to the gateway-owned
+`studio_access` model so operators can grant and revoke Studio access without
+turning Admin into the Studio authorization store.
+
+---
+
+## Problem Frame
+
+`docs/roadmap/platform/feat-160-admin-user-app-access-dropdowns.md` intentionally
+left Mastra Studio as a disabled mock control because its grant model was not
+yet wired. The model now exists in `apps/mastra-gateway`, where Studio access is
+owned by email-backed `StudioAccess` rows. This plan keeps that ownership intact
+and makes the existing Admin control real through a narrow gateway API.
+
+---
+
+## Requirements
+
+- R1. `/dashboard/users` shows Mastra Studio access from gateway state: approved editor/admin rows render as `STUDIO_ACCESS`, while missing, pending, or revoked rows render as `NO_ACCESS`.
+- R2. Selecting `STUDIO_ACCESS` on the Admin Users table creates or restores an approved gateway `editor` access row for the user's normalized email.
+- R3. Selecting `NO_ACCESS` revokes the matching gateway access row by normalized email and leaves users with no row as a no-op.
+- R4. Admin never writes Mastra Studio grants to the Admin database and never imports gateway code directly.
+- R5. The gateway management API requires a dedicated bearer allowlist and does not reuse workflow, ingest, Manager, web, or internal Mastra proxy secrets.
+- R6. If the Admin-side gateway URL or key is absent or the lookup fails, the Users page still renders and clearly disables the Mastra Studio control instead of presenting a broken writable switch.
+
+---
+
+## Key Technical Decisions
+
+- **Gateway API instead of shared database access:** Admin will call an authenticated API exposed by `apps/mastra-gateway`; it will not connect to the gateway database or duplicate the grant model.
+- **Email-keyed grant operations:** The Admin Users table is keyed by Auth users and has reliable emails, while the gateway schema already treats `email` as unique and `subject` as nullable. Grant/revoke-by-email avoids needing a user to log into Studio before an operator pre-approves them.
+- **Admin grants Studio editor only:** The Admin UI's current Mastra control has one access role. It should map `STUDIO_ACCESS` to gateway `editor`; gateway `admin` remains managed in the gateway admin surface.
+- **Optional Admin client configuration:** Admin gets `MASTRA_GATEWAY_BASE_URL` and `MASTRA_GATEWAY_ADMIN_API_KEY` as optional env vars. Missing config disables only the Mastra Studio control, not the entire Users page.
+- **Dedicated gateway bearer allowlist:** Gateway receives `MASTRA_GATEWAY_ADMIN_API_KEYS` as a CSV allowlist and validates it with timing-safe comparison before any access read or mutation.
+
+---
+
+## Implementation Units
+
+### U1. Gateway internal Studio access API
+
+- **Goal:** Expose a small authenticated gateway-owned API for Admin lookup, grant, and revoke operations.
+- **Files:** Create `apps/mastra-gateway/src/auth/admin-api-bearer.ts`, create `apps/mastra-gateway/src/app/api/admin/studio-access/route.ts`, modify `apps/mastra-gateway/src/config/env.ts`, modify `apps/mastra-gateway/src/services/studio-access.service.ts`, modify `apps/mastra-gateway/src/services/studio-access.repository.ts`, add `apps/mastra-gateway/src/app/api/admin/studio-access/route.test.ts`, update `apps/mastra-gateway/src/services/studio-access.service.test.ts`.
+- **Patterns to follow:** `apps/admin/src/auth/mastra-ingest-bearer.ts` for CSV bearer validation; `apps/mastra-gateway/src/app/admin/actions.ts` for existing service operations; `apps/mastra-gateway/src/services/studio-access.repository.ts` for Prisma mapping.
+- **Test scenarios:** Reject missing or invalid bearer with 401; lookup returns normalized email records for requested emails; grant by email upserts an approved editor row; revoke by email revokes an existing row and no-ops when absent; invalid payloads return 400 without echoing secrets.
+- **Verification:** `pnpm --filter @forge/mastra-gateway test -- src/services/studio-access.service.test.ts src/app/api/admin/studio-access/route.test.ts`.
+
+### U2. Admin outbound client and data shaping
+
+- **Goal:** Load Mastra Studio access state for listed users through the gateway API and represent missing config safely.
+- **Files:** Create `apps/admin/src/services/mastra-studio-access.service.ts`, create `apps/admin/src/services/mastra-studio-access.service.test.ts`, modify `apps/admin/src/config/env.ts`, modify `apps/admin/.env.example`, modify `apps/admin/src/app/dashboard/ops-data.ts`, update `apps/admin/src/app/dashboard/ops-data.test.ts`.
+- **Patterns to follow:** `apps/admin/src/services/manager-trigger.service.ts` for optional outbound client envelopes and bounded failures; `apps/admin/src/app/dashboard/ops-data.ts` for existing Manager membership mapping and table-fallback behavior.
+- **Test scenarios:** Missing config returns disabled no-access state; lookup sends one deduped normalized email request with bearer; approved gateway rows map to `STUDIO_ACCESS`; pending/revoked/missing rows map to `NO_ACCESS`; transport or parse failures disable the Mastra control without hiding users.
+- **Verification:** `pnpm --filter @forge/admin test -- src/app/dashboard/ops-data.test.ts src/services/mastra-studio-access.service.test.ts`.
+
+### U3. Admin Users action and UI wiring
+
+- **Goal:** Make the Mastra Studio dropdown submit grant/revoke actions through the Admin outbound client.
+- **Files:** Modify `apps/admin/src/app/dashboard/users/actions.ts`, modify `apps/admin/src/app/dashboard/users/page.tsx`, update `apps/admin/src/app/dashboard/dashboard-ui.test.tsx`.
+- **Patterns to follow:** `updateManagerAccess` in `apps/admin/src/app/dashboard/users/actions.ts`; `ProductAccessControl` in `apps/admin/src/app/dashboard/users/page.tsx`.
+- **Test scenarios:** Mastra Studio renders as an enabled backed control when configured; its form posts to the Mastra action and shows the apply button; the old `Mock only` text is gone for configured rows; disabled fallback remains when gateway config is absent.
+- **Verification:** `pnpm --filter @forge/admin test -- src/app/dashboard/dashboard-ui.test.tsx`.
+
+### U4. Roadmap and rollout hygiene
+
+- **Goal:** Keep the roadmap and deployment notes aligned with the new cross-app access path.
+- **Files:** Modify `docs/roadmap/platform/feat-179-admin-mastra-studio-access-grants.md`, modify `docs/roadmap/platform/feat-160-admin-user-app-access-dropdowns.md`, consider a short solution note only if implementation reveals a reusable cross-app bearer pattern not already captured.
+- **Patterns to follow:** Roadmap YAML frontmatter and bidirectional dependencies in `docs/roadmap/platform`.
+- **Test scenarios:** Roadmap status starts `in-progress` before implementation and flips to `complete` after validation; dependency from `feat-179` to `feat-160` has the reverse `blocks` entry.
+- **Verification:** `git diff --check`.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  AdminUsers["apps/admin /dashboard/users"] --> AdminAction["updateMastraStudioAccess server action"]
+  AdminUsers --> AdminLoader["loadUsersData"]
+  AdminAction --> AdminClient["mastra-studio-access client"]
+  AdminLoader --> AdminClient
+  AdminClient --> GatewayRoute["apps/mastra-gateway /api/admin/studio-access"]
+  GatewayRoute --> GatewayAuth["dedicated bearer allowlist"]
+  GatewayRoute --> GatewayService["Studio access service"]
+  GatewayService --> GatewayDb["studio_access"]
+```
+
+The lookup path stays read-optimized: Admin sends the visible user emails once
+per Users page load, and the gateway returns only the matching access records.
+The mutation path is email-keyed and maps Admin's single `STUDIO_ACCESS` role to
+gateway `editor`.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add a generic app-grant database model to Admin.
+- This plan does not make Admin roles imply Manager or Mastra Studio access.
+- This plan does not expose gateway admin role management from Admin.
+- This plan does not change OAuth clients, login scopes, or Mastra Studio proxy authorization.
+
+---
+
+## Risks & Dependencies
+
+- Gateway API configuration has to be deployed receiver-first: set `MASTRA_GATEWAY_ADMIN_API_KEYS` on `apps/mastra-gateway`, then set Admin's matching `MASTRA_GATEWAY_BASE_URL` and `MASTRA_GATEWAY_ADMIN_API_KEY`.
+- Lookup failure must be non-fatal because `/dashboard/users` is an operational page and should still render during gateway deploys or incidents.
+- Email is the correct cross-app key for pre-approval, but subject association still happens when the user logs into Studio through the gateway.
+
+---
+
+## Sources
+
+- `docs/roadmap/platform/feat-160-admin-user-app-access-dropdowns.md`
+- `docs/roadmap/platform/feat-179-admin-mastra-studio-access-grants.md`
+- `apps/admin/src/app/dashboard/users/page.tsx`
+- `apps/admin/src/app/dashboard/ops-data.ts`
+- `apps/mastra-gateway/AGENTS.md`
+- `apps/mastra-gateway/src/services/studio-access.service.ts`
+- `apps/mastra-gateway/src/services/studio-access.repository.ts`
+- `apps/mastra-gateway/prisma/schema.prisma`

--- a/docs/roadmap/platform/feat-160-admin-user-app-access-dropdowns.md
+++ b/docs/roadmap/platform/feat-160-admin-user-app-access-dropdowns.md
@@ -8,7 +8,8 @@ start_date: "2026-06-05"
 duration: 1
 depends_on:
   - "feat-159"
-blocks: []
+blocks:
+  - "feat-179"
 tags:
   - "platform"
   - "admin"

--- a/docs/roadmap/platform/feat-179-admin-mastra-studio-access-grants.md
+++ b/docs/roadmap/platform/feat-179-admin-mastra-studio-access-grants.md
@@ -1,0 +1,67 @@
+---
+id: "feat-179"
+title: "Admin Mastra Studio access grants"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-11"
+duration: 1
+depends_on:
+  - "feat-160"
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "auth"
+  - "mastra"
+  - "access-control"
+---
+
+## Problem
+
+The Admin Users table renders a Mastra Studio product-access dropdown, but the
+control is disabled and marked mock-only. Operators need the same basic grant /
+revoke behavior they already have for Manager, while keeping Mastra Studio
+authorization owned by `apps/mastra-gateway`.
+
+## Entry Points - Read These First
+
+1. `apps/admin/src/app/dashboard/users/page.tsx` - Users screen product access controls and server actions.
+2. `apps/admin/src/app/dashboard/ops-data.ts` - Users page data loader and row access model.
+3. `apps/mastra-gateway/src/services/studio-access.service.ts` - Gateway-owned Studio access service contract.
+4. `apps/mastra-gateway/src/services/studio-access.repository.ts` - Gateway Prisma persistence for `studio_access`.
+5. `apps/mastra-gateway/prisma/schema.prisma` - `StudioAccess` table and email uniqueness.
+
+## Grep These
+
+- `MASTRA_STUDIO_ROLE_OPTIONS`
+- `ProductAccessControl`
+- `updateManagerAccess`
+- `studioAccessRepository`
+- `StudioAccessRole`
+- `MASTRA_GATEWAY_ADMIN_API`
+
+## What To Build
+
+1. Add a bearer-authenticated gateway API for Admin to look up, approve, and revoke Studio access by email.
+2. Add an Admin-side outbound client that calls that API only when gateway URL/key env is configured.
+3. Show persisted Mastra Studio access state in `/dashboard/users`.
+4. Enable the Mastra Studio dropdown to grant Studio access as gateway `editor` and revoke it back to no access.
+
+## Constraints
+
+- Do not store Mastra Studio grants in the Admin database.
+- Do not make Admin roles imply Mastra Studio access.
+- Do not expose gateway `admin` grants from the Admin Users table in this slice.
+- Do not reuse broad workflow, ingest, Manager, or web bearer keys for the gateway access API.
+- Keep the UI local to the Users table and keep Mastra gateway as the source of truth.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/app/dashboard/ops-data.test.ts src/app/dashboard/dashboard-ui.test.tsx src/services/mastra-studio-access.service.test.ts`
+- `pnpm --filter @forge/mastra-gateway test -- src/services/studio-access.service.test.ts src/app/api/admin/studio-access/route.test.ts`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/mastra-gateway typecheck`
+- `pnpm --filter @forge/admin lint`
+- `pnpm --filter @forge/mastra-gateway lint`
+- `git diff --check`


### PR DESCRIPTION
## Summary

The Users & Permissions page can now grant and revoke Mastra Studio access instead of showing a disabled mock dropdown. Admin remains only the operator surface: Studio access records still live in `apps/mastra-gateway`, and the Admin control calls a narrow gateway API that maps `Studio access` to a gateway `editor` row.

## What Changed

- Added a bearer-authenticated `apps/mastra-gateway` API for Studio access lookup, grant-by-email, and revoke-by-email.
- Added an Admin outbound client that reads gateway state for the visible Users table and safely disables the Mastra control when gateway config or lookup is unavailable.
- Wired the Mastra Studio dropdown to a server action with the same apply-button pattern as Manager access.
- Added roadmap/plan traceability for the follow-up from the previous mock-only dropdown slice.

## Validation

- `pnpm --filter @forge/admin test -- src/app/dashboard/users/actions.test.ts src/app/dashboard/dashboard-ui.test.tsx src/app/dashboard/ops-data.test.ts src/services/mastra-studio-access.service.test.ts`
- `pnpm --filter @forge/mastra-gateway test -- src/services/studio-access.service.test.ts src/app/api/admin/studio-access/route.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/mastra-gateway typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/mastra-gateway lint`
- `git diff --check`
- Browser smoke: `agent-browser` opened a rendered Users page fixture and confirmed an enabled `Mastra Studio app access role` combobox with selected `Studio access` plus `Apply Mastra Studio role`. A real authenticated local Admin preview was blocked because no local Admin Postgres was reachable in this worktree.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
