### PR TITLE
fix(web): keep watch language switcher during loading

### DIFF
--- a/apps/web/src/components/FloatingSearchProvider.tsx
+++ b/apps/web/src/components/FloatingSearchProvider.tsx
@@ -34,6 +34,7 @@ import {
   type WatchPlayerChromeVisibilityDetail,
   type WatchPlayerPlaybackStateDetail,
 } from "@/lib/watch-player-chrome-events"
+import { WATCH_BASE_PATH } from "../../watch-base-path.mjs"
 
 export {
   useFloatingSearch,
@@ -45,6 +46,29 @@ export type {
 } from "./FloatingSearchContext"
 
 const HEADER_HOVER_HEIGHT_PX = 144
+
+function stripWatchBasePath(pathname: string): string {
+  if (pathname === WATCH_BASE_PATH) return "/"
+  if (pathname.startsWith(`${WATCH_BASE_PATH}/`)) {
+    return pathname.slice(WATCH_BASE_PATH.length) || "/"
+  }
+  return pathname
+}
+
+function isWatchMediaPathname(pathname: string): boolean {
+  const segments = stripWatchBasePath(pathname).split("/").filter(Boolean)
+  if (segments.length === 2) {
+    return Boolean(
+      segments[0]?.endsWith(".html") && segments[1]?.endsWith(".html"),
+    )
+  }
+  if (segments.length === 3) {
+    return Boolean(
+      segments[0]?.endsWith(".html") && segments[2]?.endsWith(".html"),
+    )
+  }
+  return false
+}
 
 const LazyFloatingSearchController = dynamic<FloatingSearchControllerProps>(
   () =>
@@ -210,6 +234,14 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
       const detail = (event as CustomEvent<WatchHeaderLanguageSwitcherDetail>)
         .detail
       if (typeof detail?.visible !== "boolean") return
+      const currentPathname =
+        typeof window !== "undefined" ? window.location.pathname : pathname
+      if (
+        detail.reason === "cleanup" &&
+        isWatchMediaPathname(currentPathname)
+      ) {
+        return
+      }
       setHeaderLanguageSwitcher({
         visible: detail.visible && typeof detail.onClick === "function",
         onClick: typeof detail.onClick === "function" ? detail.onClick : null,
@@ -226,7 +258,7 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
         handleLanguageSwitcherChange,
       )
     }
-  }, [])
+  }, [pathname])
 
   useLayoutEffect(() => {
     if (typeof window === "undefined") return
@@ -265,7 +297,9 @@ export function FloatingSearchProvider({ children }: { children: ReactNode }) {
       setPlayerChromeVisible(true)
       setPlayerChromeOpacity(1)
       setPlayerPlaybackState({ playing: false, muted: true, preview: false })
-      setHeaderLanguageSwitcher({ visible: false, onClick: null })
+      if (!isWatchMediaPathname(pathname)) {
+        setHeaderLanguageSwitcher({ visible: false, onClick: null })
+      }
       setHeaderHovered(false)
     })
     return () => window.cancelAnimationFrame(frame)

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -27,8 +27,12 @@ import {
   type WatchPlayerPlaybackStateDetail,
 } from "@/lib/watch-player-chrome-events"
 
+const navigationMockState = vi.hoisted(() => ({
+  pathname: "/",
+}))
+
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/",
+  usePathname: () => navigationMockState.pathname,
   useRouter: () => ({
     replace: vi.fn(),
   }),
@@ -55,6 +59,7 @@ let root: Root
 
 beforeEach(() => {
   vi.clearAllMocks()
+  navigationMockState.pathname = "/"
   window.history.replaceState(null, "", "/")
   container = document.createElement("div")
   document.body.appendChild(container)
@@ -98,6 +103,11 @@ function dispatchLanguageSwitcher(detail: WatchHeaderLanguageSwitcherDetail) {
       { detail },
     ),
   )
+}
+
+function setMockPathname(pathname: string) {
+  navigationMockState.pathname = pathname
+  window.history.replaceState(null, "", pathname)
 }
 
 function searchResult(
@@ -914,6 +924,107 @@ describe("FloatingSearchProvider — language switcher chrome", () => {
     expect(languageButton?.className).not.toContain("pointer-events-none")
     expect(logo?.className).toContain("opacity-30")
     expect(logo?.className).not.toContain("pointer-events-none")
+  })
+
+  it("retains the previous language globe through watch media cleanup during route loading", () => {
+    const onLanguageClick = vi.fn()
+    setMockPathname("/watch/death-of-jesus.html/english.html")
+    act(() => {
+      root.render(
+        <FloatingSearchProvider>
+          <main>Page</main>
+        </FloatingSearchProvider>,
+      )
+    })
+
+    act(() => {
+      dispatchLanguageSwitcher({
+        visible: true,
+        onClick: onLanguageClick,
+        reason: "state",
+      })
+    })
+    act(() => {
+      dispatchLanguageSwitcher({
+        visible: false,
+        onClick: null,
+        reason: "cleanup",
+      })
+    })
+
+    const languageButton = document.querySelector(
+      '[data-testid="floating-header-language-button"]',
+    ) as HTMLButtonElement | null
+    expect(languageButton).not.toBeNull()
+
+    act(() => {
+      languageButton?.click()
+    })
+
+    expect(onLanguageClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("lets loaded watch media state hide a stale language globe", () => {
+    setMockPathname("/watch/death-of-jesus.html/english.html")
+    act(() => {
+      root.render(
+        <FloatingSearchProvider>
+          <main>Page</main>
+        </FloatingSearchProvider>,
+      )
+    })
+
+    act(() => {
+      dispatchLanguageSwitcher({
+        visible: true,
+        onClick: vi.fn(),
+        reason: "state",
+      })
+    })
+    act(() => {
+      dispatchLanguageSwitcher({
+        visible: false,
+        onClick: null,
+        reason: "state",
+      })
+    })
+
+    expect(
+      document.querySelector('[data-testid="floating-header-language-button"]'),
+    ).toBeNull()
+  })
+
+  it("clears the stale language globe when cleanup happens off a watch media route", () => {
+    const onLanguageClick = vi.fn()
+    setMockPathname("/watch/death-of-jesus.html/english.html")
+    act(() => {
+      root.render(
+        <FloatingSearchProvider>
+          <main>Page</main>
+        </FloatingSearchProvider>,
+      )
+    })
+
+    act(() => {
+      dispatchLanguageSwitcher({
+        visible: true,
+        onClick: onLanguageClick,
+        reason: "state",
+      })
+    })
+
+    setMockPathname("/watch/videos")
+    act(() => {
+      dispatchLanguageSwitcher({
+        visible: false,
+        onClick: null,
+        reason: "cleanup",
+      })
+    })
+
+    expect(
+      document.querySelector('[data-testid="floating-header-language-button"]'),
+    ).toBeNull()
   })
 })
 

--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -912,6 +912,7 @@ export function HeroPlayer({
           detail: {
             visible: showTopLanguageSwitch,
             onClick: showTopLanguageSwitch ? (onLanguageClick ?? null) : null,
+            reason: "state",
           },
         },
       ),
@@ -920,7 +921,7 @@ export function HeroPlayer({
       window.dispatchEvent(
         new CustomEvent<WatchHeaderLanguageSwitcherDetail>(
           WATCH_HEADER_LANGUAGE_SWITCHER_EVENT,
-          { detail: { visible: false, onClick: null } },
+          { detail: { visible: false, onClick: null, reason: "cleanup" } },
         ),
       )
     }

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -2382,6 +2382,7 @@ describe("HeroPlayer — language switch button", () => {
       )
     })
     expect(listener.updates.at(-1)?.visible).toBe(false)
+    expect(listener.updates.at(-1)?.reason).toBe("state")
     listener.cleanup()
   })
 
@@ -2400,8 +2401,36 @@ describe("HeroPlayer — language switch button", () => {
     const latest = listener.updates.at(-1)
     expect(latest?.visible).toBe(true)
     expect(latest?.onClick).toBe(onLanguageClick)
+    expect(latest?.reason).toBe("state")
     latest?.onClick?.()
     expect(onLanguageClick).toHaveBeenCalledTimes(1)
+    listener.cleanup()
+  })
+
+  it("publishes a cleanup hide when the hero unmounts", () => {
+    const onLanguageClick = vi.fn()
+    const listener = listenForLanguageSwitcher()
+    act(() => {
+      root.render(
+        <HeroPlayer
+          block={makeBlock()}
+          onLanguageClick={onLanguageClick}
+          playableLanguageCount={2}
+        />,
+      )
+    })
+
+    expect(listener.updates.at(-1)?.visible).toBe(true)
+
+    act(() => {
+      root.render(<div />)
+    })
+
+    expect(listener.updates.at(-1)).toMatchObject({
+      visible: false,
+      onClick: null,
+      reason: "cleanup",
+    })
     listener.cleanup()
   })
 
@@ -2435,6 +2464,7 @@ describe("HeroPlayer — language switch button", () => {
     })
 
     expect(listener.updates.at(-1)?.visible).toBe(false)
+    expect(listener.updates.at(-1)?.reason).toBe("state")
 
     // Reset jsdom state for subsequent tests
     Object.defineProperty(document, "fullscreenElement", {

--- a/apps/web/src/lib/watch-player-chrome-events.ts
+++ b/apps/web/src/lib/watch-player-chrome-events.ts
@@ -23,4 +23,5 @@ export const WATCH_HEADER_LANGUAGE_SWITCHER_EVENT =
 export type WatchHeaderLanguageSwitcherDetail = {
   visible: boolean
   onClick: (() => void) | null
+  reason?: "state" | "cleanup"
 }

--- a/docs/plans/2026-06-11-003-fix-watch-header-language-switcher-loading-plan.md
+++ b/docs/plans/2026-06-11-003-fix-watch-header-language-switcher-loading-plan.md
@@ -1,0 +1,113 @@
+---
+title: "fix: Watch Header Language Switcher During Loading"
+type: "fix"
+status: "completed"
+date: "2026-06-11"
+roadmap: "docs/roadmap/platform/feat-179-watch-header-language-switcher-loading.md"
+origin: "user bug report: globe language switch disappears after episode carousel click during muted preview"
+---
+
+# fix: Watch Header Language Switcher During Loading
+
+## Summary
+
+Keep the floating header language globe visible during watch-to-watch client
+loading transitions, while preserving loaded-page authority for whether the
+current hero actually supports language switching.
+
+## Problem Frame
+
+`FloatingSearchProvider` owns the global header and resets its language switcher
+state on pathname changes. `HeroPlayer` publishes the language switcher callback
+while mounted, then publishes `visible:false` during cleanup. When a user clicks
+an episode carousel item during muted preview, the old hero cleanup and provider
+pathname reset run before the next watch page has loaded, so the globe
+disappears during the loading stage.
+
+## Requirements
+
+- R1. On watch video and episode routes, an unmount cleanup from the previous
+  hero must not clear the last valid language switcher during route loading.
+- R2. A mounted/loaded hero state remains authoritative; if it reports no
+  language switcher, the header must hide the globe.
+- R3. Leaving watch video/episode routes still clears the stale switcher.
+- R4. The event contract remains client-safe and does not load staged modal
+  code early.
+
+## Key Technical Decisions
+
+- **KTD1. Distinguish cleanup from state.** Add a narrow optional reason to
+  the language-switcher event detail so cleanup events can be treated
+  differently from loaded hero state.
+- **KTD2. Retain only on watch media routes.** The provider may ignore cleanup
+  clears only when the browser remains on a watch video or episode pathname;
+  non-watch routes clear immediately.
+- **KTD3. Let loaded false win.** A `reason:"state"` event with
+  `visible:false` clears the button, preventing stale controls on single-
+  language or fullscreen loaded pages.
+
+## Implementation Units
+
+### U1. Language Switcher Event Contract
+
+- **Goal:** Let the provider tell unmount cleanup apart from authoritative
+  mounted state.
+- **Requirements:** R1, R2, R4.
+- **Files:** `apps/web/src/lib/watch-player-chrome-events.ts`,
+  `apps/web/src/components/watch/HeroPlayer.tsx`,
+  `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`.
+- **Approach:** Add an optional `reason` field to
+  `WatchHeaderLanguageSwitcherDetail`. Publish `reason:"state"` from the main
+  hero effect body and `reason:"cleanup"` from the effect cleanup.
+- **Test scenarios:**
+  - Hero emits visible state updates with `reason:"state"`.
+  - Hero cleanup emits `visible:false` with `reason:"cleanup"`.
+- **Verification:** Focused HeroPlayer tests cover the emitted details.
+
+### U2. Floating Header Retention
+
+- **Goal:** Preserve the previous language button through watch media loading
+  transitions without leaking it to non-watch pages.
+- **Requirements:** R1, R2, R3.
+- **Files:** `apps/web/src/components/FloatingSearchProvider.tsx`,
+  `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`.
+- **Approach:** Add a small pathname classifier that strips the `/watch`
+  basePath and recognizes canonical video/episode routes. On cleanup-only
+  hide events, retain the current switcher when the current browser pathname is
+  still a watch media route. On pathname changes, clear only when the new path
+  is not a watch media route.
+- **Test scenarios:**
+  - A cleanup hide event on `/watch/death-of-jesus.html/english.html` keeps
+    the existing button clickable.
+  - A loaded state hide event on that route removes the button.
+  - Navigating to `/watch/videos` clears the stale button.
+- **Verification:** Focused provider tests cover retention and clearing.
+
+## Scope Boundaries
+
+- Do not change language picker modal loading, language option fetching, or
+  language-switch URL construction.
+- Do not change player playback state, muted preview activation, or carousel
+  routing.
+- Do not alter global search behavior.
+
+## Risks and Dependencies
+
+- **Pathname shape:** `usePathname()` may include Next's `/watch` basePath in
+  the browser, while internal route helpers operate on basePath-stripped
+  paths. The classifier should handle both.
+- **Stale callback:** Retaining a callback during loading is intentional; the
+  next mounted hero replaces it. Loaded false states must still clear it.
+
+## Documentation and Operational Notes
+
+- Mark `docs/roadmap/platform/feat-179-watch-header-language-switcher-loading.md`
+  complete after code review and browser proof.
+- This is a follow-up to `feat-178` staged client loading and should remain a
+  small regression fix.
+
+## Sources and Research
+
+- `docs/roadmap/platform/feat-178-watch-staged-client-loading.md`
+- `docs/plans/2026-06-11-002-perf-watch-staged-client-loading-plan.md`
+- `apps/web/CLAUDE.md`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (June 4, 2026)
 
-- **Total tickets:** 190
-- **Complete:** 115
+- **Total tickets:** 191
+- **Complete:** 116
 - **In progress:** 9
 - **Not started:** 21
 - **Blocked:** 43
@@ -182,6 +182,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-175](platform/feat-175-watch-cold-path-performance-follow-up.md)           | Watch cold-path performance follow-up                        | vlad      | P1       | 2026-06-10 | 1    | 2026-06-10 | complete    |
 | [feat-176](platform/feat-176-watch-hero-poster-idle-autoplay.md)                 | Watch hero poster-first idle autoplay                        | vlad      | P1       | 2026-06-10 | 1    | 2026-06-10 | complete    |
 | [feat-178](platform/feat-178-watch-staged-client-loading.md)                     | Watch staged client interaction loading                      | vlad      | P1       | 2026-06-11 | 2    | 2026-06-12 | complete    |
+| [feat-179](platform/feat-179-watch-header-language-switcher-loading.md)          | Watch header language switcher during route loading          | vlad      | P1       | 2026-06-11 | 1    | 2026-06-11 | complete    |
 | [feat-040](platform/feat-040-partner-activation-network.md)                      | Partner Activation Network                                   | urim      | P1       | 2026-06-16 | 28   | 2026-07-13 | blocked     |
 | [feat-042](platform/feat-042-video-contests-and-inspiration-feed.md)             | Video Contests and Inspiration Feed                          | urim      | P1       | 2026-06-30 | 28   | 2026-07-27 | blocked     |
 | [feat-088](platform/feat-088-internal-tools-branding.md)                         | Internal Tools Branding                                      | vlad      | P2       | 2026-03-30 | 14   | 2026-04-12 | complete    |

--- a/docs/roadmap/platform/feat-178-watch-staged-client-loading.md
+++ b/docs/roadmap/platform/feat-178-watch-staged-client-loading.md
@@ -9,7 +9,8 @@ duration: 2
 depends_on:
   - "feat-177"
   - "feat-169"
-blocks: []
+blocks:
+  - "feat-179"
 tags:
   - "platform"
   - "web"

--- a/docs/roadmap/platform/feat-179-watch-header-language-switcher-loading.md
+++ b/docs/roadmap/platform/feat-179-watch-header-language-switcher-loading.md
@@ -1,0 +1,91 @@
+---
+id: "feat-179"
+title: "Watch header language switcher during route loading"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-11"
+duration: 1
+depends_on:
+  - "feat-178"
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "regression"
+---
+
+## Problem
+
+On watch video pages with the muted hero preview running, clicking an episode
+carousel item starts a client-side watch route transition. During the loading
+stage, the floating header globe language switch disappears even though the
+page is still a watch video context where language switching should remain
+available. The switch returns only after the loaded page publishes the next
+hero state.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-11-003-fix-watch-header-language-switcher-loading-plan.md`
+   - implementation plan for this regression.
+2. `apps/web/src/components/FloatingSearchProvider.tsx` - floating header
+   chrome state, pathname resets, and language globe rendering.
+3. `apps/web/src/components/watch/HeroPlayer.tsx` - hero-owned language
+   switcher event publisher and cleanup.
+4. `apps/web/src/lib/watch-player-chrome-events.ts` - shared event contract.
+5. `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx` -
+   header chrome and language switcher tests.
+
+## Grep These
+
+- `WATCH_HEADER_LANGUAGE_SWITCHER_EVENT`
+- `headerLanguageSwitcher`
+- `floating-header-language-button`
+- `usePathname`
+- `watch-player-chrome-events`
+
+## What To Build
+
+1. Preserve the last valid floating header language switcher during
+   watch-video to watch-video loading transitions.
+2. Keep loaded-page state authoritative so a new watch page without a language
+   switch can still hide the globe.
+3. Continue clearing the globe when leaving watch video/episode routes.
+4. Add focused tests for the watch loading retention and non-watch clearing
+   behavior.
+
+## Constraints
+
+- Do not change public watch URL shape or language-switch navigation.
+- Do not make language modal code part of the initial client bundle.
+- Do not keep a stale switcher visible after a loaded hero explicitly reports
+  that no switcher is available.
+- Keep search, share, download, subtitles, and player chrome behavior
+  unchanged.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx`
+- `pnpm --filter @forge/web typecheck`
+- Helium smoke on a watch route confirms the language globe remains visible
+  while navigating from the muted preview episode carousel loading state to the
+  loaded page.
+
+## Completion Evidence
+
+- Focused tests passed: `FloatingSearchProvider.test.tsx` and
+  `HeroPlayer.test.tsx` (92 passed, 2 todo).
+- `@forge/web` typecheck and lint passed.
+- Helium/agent-browser local smoke at
+  `http://127.0.0.1:4911/watch/death-of-jesus.html/english.html` clicked the
+  `Burial of Jesus` chapter rail item, landed on
+  `/watch/burial-of-jesus.html/english.html`, and recorded `missingCount: 0`
+  for the floating header language globe during the transition.
+- Screenshot:
+  `.tmp/watch-header-globe-after-episode-click.png`.
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-11-003-fix-watch-header-language-switcher-loading-plan.md`


### PR DESCRIPTION
## Summary
- keep the floating header language globe visible through watch-to-watch loading transitions
- distinguish HeroPlayer language-switcher state events from unmount cleanup events
- add a follow-up roadmap ticket and implementation plan for the regression

## Verification
- pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- git diff --check
- Helium/agent-browser local smoke: clicked Burial of Jesus from /watch/death-of-jesus.html/english.html; observer recorded missingCount: 0 for the floating header language button during the transition, and the loaded page kept the globe visible

## Browser Evidence
- Screenshot: .tmp/watch-header-globe-after-episode-click.png