### PR TITLE
fix(web): prerender clicked watch chapter shell

### DIFF
--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -44,6 +44,7 @@ import { WATCH_PRODUCTION_PLAYER_OVERLAY_BACKGROUND } from "@/lib/watch-producti
 import { SpinnerIcon } from "@/components/ui/spinner"
 import { HeroPlayerControls } from "./HeroPlayerControls"
 import { SubtitleOverlay } from "./SubtitleOverlay"
+import type { WatchChapterOptimisticVisual } from "./chapter-navigation"
 import { MutedSpeakerIcon, PlayIcon } from "./chrome-icons"
 import { FORGE_SUBTITLE_TRACK_LABEL } from "./subtitle-track"
 import { WATCH_SECTION_EYEBROW_CLASS } from "./watch-section-styles"
@@ -168,6 +169,7 @@ export function HeroPlayer({
   darkenOverlay = false,
   overlay,
   subtitleVttSrc,
+  optimisticVisual,
 }: {
   block: WatchHeroPlayerBlock
   onPlayerReady?: (player: MuxPlayerRef | null) => void
@@ -176,6 +178,7 @@ export function HeroPlayer({
   darkenOverlay?: boolean
   overlay?: ReactNode
   subtitleVttSrc?: string | null
+  optimisticVisual?: WatchChapterOptimisticVisual | null
 }) {
   const t = useTranslations("HeroPlayer")
   const videoLabels = useTranslations("VideoLabels")
@@ -864,6 +867,23 @@ export function HeroPlayer({
 
   const loop = !chromeRevealed
   const muted = !chromeRevealed
+  const canUseOptimisticVisual = !chromeRevealed
+  const visualHeroPosterUrl = canUseOptimisticVisual
+    ? (optimisticVisual?.posterUrl ?? heroPosterUrl)
+    : heroPosterUrl
+  const visualTitle = canUseOptimisticVisual
+    ? (optimisticVisual?.title ?? video.title)
+    : video.title
+  const visualLabel = canUseOptimisticVisual
+    ? (optimisticVisual?.label ?? video.label)
+    : video.label
+  const showOptimisticPoster =
+    canUseOptimisticVisual && optimisticVisual?.posterUrl != null
+  const posterOpacityClass =
+    videoReady && !showOptimisticPoster ? "opacity-0" : "opacity-100"
+  const posterTransitionClass = showOptimisticPoster
+    ? ""
+    : "transition-opacity duration-300"
 
   // Hide the language-switch globe while the player is in fullscreen so it
   // doesn't sit on top of the playing video chrome. Restores when the user
@@ -1021,13 +1041,13 @@ export function HeroPlayer({
             />
           ) : null}
 
-          {heroPosterUrl ? (
+          {visualHeroPosterUrl ? (
             <div
-              className={`pointer-events-none absolute inset-0 transition-opacity duration-300 ${videoReady ? "opacity-0" : "opacity-100"}`}
+              className={`pointer-events-none absolute inset-0 ${posterTransitionClass} ${posterOpacityClass}`}
             >
               <Image
                 data-testid="hero-player-poster"
-                src={heroPosterUrl}
+                src={visualHeroPosterUrl}
                 alt=""
                 aria-hidden="true"
                 fill
@@ -1125,20 +1145,20 @@ export function HeroPlayer({
                 data-testid="hero-player-overlay"
                 className={`absolute right-6 bottom-0 ${WATCH_PAGE_LEFT_RAIL_CLASSES} flex flex-col items-start gap-3 pb-12 md:right-auto`}
               >
-                {video.label ? (
+                {visualLabel ? (
                   <span
                     data-testid="hero-player-overlay-label"
                     className={WATCH_SECTION_EYEBROW_CLASS}
                   >
-                    {videoLabels(videoLabelMessageKey(video.label))}
+                    {videoLabels(videoLabelMessageKey(visualLabel))}
                   </span>
                 ) : null}
-                {video.title ? (
+                {visualTitle ? (
                   <h1
                     data-testid="hero-player-overlay-title"
                     className="max-w-[calc(100vw-5rem)] text-2xl leading-[1.08] font-bold text-balance break-words text-white drop-shadow-lg sm:text-4xl md:max-w-[18ch] md:text-6xl xl:max-w-[20ch] xl:text-7xl"
                   >
-                    {video.title}
+                    {visualTitle}
                   </h1>
                 ) : null}
                 <button

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -18,13 +18,18 @@ import { cn } from "@/lib/utils"
 import type { WatchSiblingCarouselBlock } from "@/lib/content"
 import { tryAsContentSlug, tryAsLocaleSlug, watchVideoPath } from "@/lib/routes"
 import { resolvePosterUrl } from "@/lib/url"
+import type { WatchChapterNavigationIntent } from "./chapter-navigation"
 
 export function SiblingCarousel({
   block,
   languageSlug,
+  pendingNavigation,
+  onChapterNavigateIntent,
 }: {
   block: WatchSiblingCarouselBlock
   languageSlug: string
+  pendingNavigation?: WatchChapterNavigationIntent | null
+  onChapterNavigateIntent?: (intent: WatchChapterNavigationIntent) => void
 }) {
   const t = useTranslations("SiblingCarousel")
   const videoLabels = useTranslations("VideoLabels")
@@ -55,18 +60,15 @@ export function SiblingCarousel({
   // compete with the LCP poster fetch on the critical chain.
 
   const [api, setApi] = useState<CarouselApi | null>(null)
-  const [pendingNavigation, setPendingNavigation] = useState<{
-    href: string
-    languageSlug: string
-    sourceVideoDocumentId: string
-    targetVideoDocumentId: string
-  } | null>(null)
+  const [localPendingNavigation, setLocalPendingNavigation] =
+    useState<WatchChapterNavigationIntent | null>(null)
+  const effectivePendingNavigation =
+    pendingNavigation === undefined ? localPendingNavigation : pendingNavigation
 
   const handleCardClick = useCallback(
     (
       event: MouseEvent<HTMLAnchorElement>,
-      href: string,
-      targetVideoDocumentId: string,
+      intent: WatchChapterNavigationIntent,
       isActive: boolean,
     ) => {
       if (isActive) return
@@ -76,21 +78,19 @@ export function SiblingCarousel({
         return
       }
 
-      setPendingNavigation({
-        href,
-        languageSlug,
-        sourceVideoDocumentId: currentVideoDocumentId,
-        targetVideoDocumentId,
-      })
+      if (pendingNavigation === undefined) {
+        setLocalPendingNavigation(intent)
+      }
+      onChapterNavigateIntent?.(intent)
     },
-    [currentVideoDocumentId, languageSlug],
+    [onChapterNavigateIntent, pendingNavigation],
   )
 
   const validPendingNavigation =
-    pendingNavigation != null &&
-    pendingNavigation.languageSlug === languageSlug &&
-    pendingNavigation.sourceVideoDocumentId === currentVideoDocumentId
-      ? pendingNavigation
+    effectivePendingNavigation != null &&
+    effectivePendingNavigation.languageSlug === languageSlug &&
+    effectivePendingNavigation.sourceVideoDocumentId === currentVideoDocumentId
+      ? effectivePendingNavigation
       : null
   const pendingActiveIndex =
     validPendingNavigation != null
@@ -327,9 +327,22 @@ export function SiblingCarousel({
                     data-href={href}
                     aria-busy={isPending ? "true" : undefined}
                     className={cardClassName}
-                    onClick={(event) =>
-                      handleCardClick(event, href, child.documentId, isActive)
-                    }
+                    onClick={(event) => {
+                      handleCardClick(
+                        event,
+                        {
+                          href,
+                          languageSlug,
+                          sourceVideoDocumentId: currentVideoDocumentId,
+                          targetVideoDocumentId: child.documentId,
+                          title: child.title ?? null,
+                          slug: child.slug,
+                          label: child.label ?? null,
+                          posterUrl: thumb,
+                        },
+                        isActive,
+                      )
+                    }}
                   >
                     {cardInner}
                   </Link>

--- a/apps/web/src/components/watch/WatchBody.tsx
+++ b/apps/web/src/components/watch/WatchBody.tsx
@@ -11,6 +11,7 @@ export function WatchBody({
   downloadPending = false,
   studyQuestions,
   onDownloadClick,
+  optimisticTitle,
 }: {
   block: WatchBodyBlock
   downloadButtonLabel?: string
@@ -18,8 +19,10 @@ export function WatchBody({
   downloadPending?: boolean
   studyQuestions: WatchStudyQuestionsBlock | null
   onDownloadClick: () => void
+  optimisticTitle?: string | null
 }) {
   const { video, variant } = block
+  const visualTitle = optimisticTitle ?? video.title ?? ""
   const hasDownloads = (variant.downloads ?? []).length > 0
   const prompts = (studyQuestions?.studyQuestions ?? [])
     .map((q) => q.value)
@@ -53,7 +56,7 @@ export function WatchBody({
             data-testid="watch-body-title"
             className="min-w-0 flex-1 text-[27px] leading-[1.08] font-semibold text-stone-100 md:text-4xl xl:text-5xl"
           >
-            {video.title ?? ""}
+            {visualTitle}
           </h2>
           {hasDownloads ? (
             <div className="ml-auto flex shrink-0 flex-col items-end gap-2">

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -8,6 +8,7 @@ import type { MuxPlayerRef } from "@forge/video-player"
 
 import { useFloatingSearchPinned } from "@/components/FloatingSearchProvider"
 import type { LanguagePickerVariant } from "@/components/watch/LanguagePickerModal"
+import type { WatchChapterNavigationIntent } from "@/components/watch/chapter-navigation"
 // Modals are user-triggered (download / language picker / share). Split
 // them into separate chunks so they don't ship with the hero-critical
 // bundle. `ssr: false` is safe — modals are hidden on first paint.
@@ -40,10 +41,13 @@ import { redirectToAuth } from "@/components/watch/download-session-client"
 import type {
   MergedWatchBlock,
   ResolvedWatchVideo,
+  WatchSiblingCarouselBlock,
   WatchSubtitle,
 } from "@/lib/content"
+import { isWatchBlock } from "@/lib/content"
 import type { InitialSubtitleTranscript } from "@/lib/subtitle-transcript"
 import { LOCALE_RESOLVED_PARAM } from "@/lib/locale"
+import { tryAsContentSlug, tryAsLocaleSlug, watchVideoPath } from "@/lib/routes"
 import {
   readSubtitlePreference,
   writeSubtitlePreference,
@@ -81,6 +85,36 @@ export type WatchModalCallbacks = {
   openLanguage: () => void
   openShare: () => void
   closeModal: () => void
+}
+
+function isPendingChapterStillRoutable(
+  pendingChapter: WatchChapterNavigationIntent,
+  blocks: MergedWatchBlock[],
+  languageSlug: string,
+): boolean {
+  const lang = tryAsLocaleSlug(languageSlug)
+  if (!lang) return false
+
+  for (const block of blocks) {
+    if (!isWatchBlock(block) || block.kind !== "SiblingCarousel") continue
+
+    const carouselBlock: WatchSiblingCarouselBlock = block
+    for (const child of carouselBlock.canonicalParent.children ?? []) {
+      if (
+        child == null ||
+        child.documentId !== pendingChapter.targetVideoDocumentId
+      ) {
+        continue
+      }
+
+      if (typeof child.slug !== "string") return false
+      const slug = tryAsContentSlug(child.slug)
+      if (!slug) return false
+      return watchVideoPath(slug, lang) === pendingChapter.href
+    }
+  }
+
+  return false
 }
 
 type WatchPageClientProps = {
@@ -144,6 +178,19 @@ export function WatchPageClient({
 
   const currentLanguageSlug = languageSlug ?? variant.language?.slug ?? ""
   const tDownloadButton = useTranslations("DownloadButton")
+  const [pendingChapter, setPendingChapter] =
+    useState<WatchChapterNavigationIntent | null>(null)
+  const validPendingChapter =
+    pendingChapter != null &&
+    pendingChapter.languageSlug === currentLanguageSlug &&
+    pendingChapter.sourceVideoDocumentId === video.documentId &&
+    isPendingChapterStillRoutable(
+      pendingChapter,
+      mergedBlocks,
+      currentLanguageSlug,
+    )
+      ? pendingChapter
+      : null
 
   const subtitles = useMemo(() => video.subtitles ?? [], [video.subtitles])
 
@@ -365,6 +412,8 @@ export function WatchPageClient({
         languageSlug={currentLanguageSlug}
         subtitleVttSrc={subtitleVttSrc}
         hideBibleQuotes={hideBibleQuotes}
+        pendingChapter={validPendingChapter}
+        onChapterNavigateIntent={setPendingChapter}
       />
 
       <SubtitleTranscript

--- a/apps/web/src/components/watch/WatchSectionRenderer.tsx
+++ b/apps/web/src/components/watch/WatchSectionRenderer.tsx
@@ -14,6 +14,7 @@ import { HeroPlayer } from "@/components/watch/HeroPlayer"
 import { SiblingCarousel } from "@/components/watch/SiblingCarousel"
 import { WatchBody } from "@/components/watch/WatchBody"
 import type { WatchModalCallbacks } from "@/components/watch/WatchPageClient"
+import type { WatchChapterNavigationIntent } from "@/components/watch/chapter-navigation"
 import { WATCH_PAGE_CONTENT_CLASSES } from "@/lib/content-width"
 import { isPlayableLanguageVariant } from "@/lib/playable-variant"
 
@@ -39,6 +40,8 @@ export function WatchSectionRenderer({
   languageSlug,
   subtitleVttSrc,
   hideBibleQuotes = false,
+  pendingChapter,
+  onChapterNavigateIntent,
 }: {
   blocks: MergedWatchBlock[]
   downloadButtonLabel?: string
@@ -50,6 +53,8 @@ export function WatchSectionRenderer({
   languageSlug?: string
   subtitleVttSrc?: string | null
   hideBibleQuotes?: boolean
+  pendingChapter?: WatchChapterNavigationIntent | null
+  onChapterNavigateIntent?: (intent: WatchChapterNavigationIntent) => void
 }) {
   // WatchBody owns both columns; the standalone StudyQuestions slot
   // renders as a hidden marker to avoid double-mounting.
@@ -86,6 +91,8 @@ export function WatchSectionRenderer({
           languageSlug={languageSlug}
           subtitleVttSrc={subtitleVttSrc}
           hideBibleQuotes={hideBibleQuotes}
+          pendingChapter={pendingChapter}
+          onChapterNavigateIntent={onChapterNavigateIntent}
         />
       ))}
       {bodyBlocks.length > 0 ? (
@@ -122,6 +129,8 @@ export function WatchSectionRenderer({
                   locale={locale}
                   languageSlug={languageSlug}
                   hideBibleQuotes={hideBibleQuotes}
+                  pendingChapter={pendingChapter}
+                  onChapterNavigateIntent={onChapterNavigateIntent}
                 />
               ))}
             </div>
@@ -145,6 +154,8 @@ function WatchBlockEntry({
   languageSlug,
   subtitleVttSrc,
   hideBibleQuotes,
+  pendingChapter,
+  onChapterNavigateIntent,
 }: {
   block: MergedWatchBlock
   index: number
@@ -158,6 +169,8 @@ function WatchBlockEntry({
   languageSlug?: string
   subtitleVttSrc?: string | null
   hideBibleQuotes: boolean
+  pendingChapter?: WatchChapterNavigationIntent | null
+  onChapterNavigateIntent?: (intent: WatchChapterNavigationIntent) => void
 }) {
   if (isWatchBlock(block)) {
     return (
@@ -173,6 +186,8 @@ function WatchBlockEntry({
         languageSlug={languageSlug}
         subtitleVttSrc={subtitleVttSrc}
         hideBibleQuotes={hideBibleQuotes}
+        pendingChapter={pendingChapter}
+        onChapterNavigateIntent={onChapterNavigateIntent}
       />
     )
   }
@@ -191,6 +206,8 @@ function SyntheticBlock({
   languageSlug,
   subtitleVttSrc,
   hideBibleQuotes,
+  pendingChapter,
+  onChapterNavigateIntent,
 }: {
   block: WatchBlock
   downloadButtonLabel?: string
@@ -203,7 +220,18 @@ function SyntheticBlock({
   languageSlug?: string
   subtitleVttSrc?: string | null
   hideBibleQuotes: boolean
+  pendingChapter?: WatchChapterNavigationIntent | null
+  onChapterNavigateIntent?: (intent: WatchChapterNavigationIntent) => void
 }) {
+  const optimisticVisual =
+    pendingChapter != null
+      ? {
+          title: pendingChapter.title,
+          label: pendingChapter.label,
+          posterUrl: pendingChapter.posterUrl,
+        }
+      : null
+
   switch (block.kind) {
     case "HeroPlayer": {
       const playableLanguageCount =
@@ -216,11 +244,19 @@ function SyntheticBlock({
           onLanguageClick={modalCallbacks?.openLanguage}
           playableLanguageCount={playableLanguageCount}
           subtitleVttSrc={subtitleVttSrc}
+          optimisticVisual={optimisticVisual}
         />
       )
     }
     case "SiblingCarousel":
-      return <SiblingCarousel block={block} languageSlug={languageSlug ?? ""} />
+      return (
+        <SiblingCarousel
+          block={block}
+          languageSlug={languageSlug ?? ""}
+          pendingNavigation={pendingChapter ?? null}
+          onChapterNavigateIntent={onChapterNavigateIntent}
+        />
+      )
 
     case "WatchBody":
       return (
@@ -231,6 +267,7 @@ function SyntheticBlock({
           downloadPending={downloadPending}
           studyQuestions={studyQuestionsBlock}
           onDownloadClick={modalCallbacks?.openDownload ?? noop}
+          optimisticTitle={pendingChapter?.title ?? null}
         />
       )
     case "StudyQuestions":

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -336,6 +336,78 @@ describe("HeroPlayer — initial mount", () => {
     ).toBeNull()
   })
 
+  it("renders optimistic title and poster on the pre-reveal shell only", () => {
+    act(() => {
+      root.render(
+        <HeroPlayer
+          block={makeBlock()}
+          optimisticVisual={{
+            title: "Clicked Chapter",
+            label: "SEGMENT",
+            posterUrl: "https://cdn.test/clicked.jpg",
+          }}
+        />,
+      )
+    })
+
+    const poster = container.querySelector(
+      '[data-testid="hero-player-poster"]',
+    ) as HTMLImageElement
+    expect(poster).not.toBeNull()
+    expect(poster.getAttribute("src")).toBe("https://cdn.test/clicked.jpg")
+    expect(poster.parentElement?.className).not.toContain("transition-opacity")
+    expect(poster.parentElement?.className).toContain("opacity-100")
+    expect(
+      container.querySelector('[data-testid="hero-player-overlay-title"]')
+        ?.textContent,
+    ).toBe("Clicked Chapter")
+    expect(
+      container.querySelector('[data-testid="hero-player-overlay-label"]')
+        ?.textContent,
+    ).toBe("Segment")
+    expect(muxVideoMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps an optimistic poster visible after the muted preview is ready", async () => {
+    const idle = installIdleCallbackStub()
+    const block = makeBlock()
+    try {
+      act(() => {
+        root.render(<HeroPlayer block={block} />)
+      })
+      await idle.runNext()
+      await fireCanPlay()
+
+      const routePoster = container.querySelector(
+        '[data-testid="hero-player-poster"]',
+      )
+      expect(routePoster?.parentElement?.className).toContain("opacity-0")
+
+      act(() => {
+        root.render(
+          <HeroPlayer
+            block={block}
+            optimisticVisual={{
+              title: "Clicked Chapter",
+              label: "SEGMENT",
+              posterUrl: "https://cdn.test/clicked.jpg",
+            }}
+          />,
+        )
+      })
+
+      const optimisticPoster = container.querySelector(
+        '[data-testid="hero-player-poster"]',
+      ) as HTMLImageElement
+      expect(optimisticPoster.getAttribute("src")).toBe(
+        "https://cdn.test/clicked.jpg",
+      )
+      expect(optimisticPoster.parentElement?.className).toContain("opacity-100")
+    } finally {
+      idle.restore()
+    }
+  })
+
   it("mounts MuxVideo with LCP poster, bounded HLS config, and Mux Data after idle activation", async () => {
     await activateMutedPreviewFromIdle()
 

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -380,11 +380,103 @@ describe("SiblingCarousel — happy path", () => {
     expect(desktopLabel?.textContent).toBe("Clip 2 of 4")
   })
 
-  it("does not show pending feedback for modified chapter clicks", () => {
+  it("emits full pending chapter metadata for a normal inactive click", () => {
+    const block = makeBlock(4, 0)
+    const onChapterNavigateIntent = vi.fn()
+
+    act(() => {
+      root.render(
+        <SiblingCarousel
+          block={block}
+          languageSlug="english"
+          onChapterNavigateIntent={onChapterNavigateIntent}
+        />,
+      )
+    })
+
+    const target = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-href='/child-2-slug.html/english.html']",
+    )
+
+    act(() => {
+      target!.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      )
+    })
+
+    expect(onChapterNavigateIntent).toHaveBeenCalledTimes(1)
+    expect(onChapterNavigateIntent).toHaveBeenCalledWith({
+      href: "/child-2-slug.html/english.html",
+      languageSlug: "english",
+      sourceVideoDocumentId: "child-1",
+      targetVideoDocumentId: "child-2",
+      title: "Child 2",
+      slug: "child-2-slug",
+      label: "Label 2",
+      posterUrl: "https://cdn.test/2.jpg",
+    })
+  })
+
+  it("uses controlled pending state when the parent supplies it", () => {
     const block = makeBlock(4, 0)
 
     act(() => {
-      root.render(<SiblingCarousel block={block} languageSlug="english" />)
+      root.render(
+        <SiblingCarousel
+          block={block}
+          languageSlug="english"
+          pendingNavigation={{
+            href: "/child-3-slug.html/english.html",
+            languageSlug: "english",
+            sourceVideoDocumentId: "child-1",
+            targetVideoDocumentId: "child-3",
+            title: "Child 3",
+            slug: "child-3-slug",
+            label: null,
+            posterUrl: "https://cdn.test/3.jpg",
+          }}
+        />,
+      )
+    })
+
+    const previousCurrent = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-href='/child-1-slug.html/english.html']",
+    )
+    const target = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-href='/child-3-slug.html/english.html']",
+    )
+
+    expect(previousCurrent!.getAttribute("data-active")).toBe("false")
+    expect(target!.getAttribute("data-active")).toBe("true")
+    expect(target!.getAttribute("data-pending")).toBe("true")
+    expect(target!.getAttribute("aria-busy")).toBe("true")
+    expect(
+      target!.querySelector("[data-testid='sibling-carousel-loading-icon']"),
+    ).not.toBeNull()
+
+    const label = container.querySelector(
+      "[data-testid='sibling-carousel-label']",
+    )
+    expect(label?.textContent).toContain("3 of 4")
+    expect(label?.textContent).toContain("Clip 3 of 4")
+  })
+
+  it("does not show pending feedback for modified chapter clicks", () => {
+    const block = makeBlock(4, 0)
+    const onChapterNavigateIntent = vi.fn()
+
+    act(() => {
+      root.render(
+        <SiblingCarousel
+          block={block}
+          languageSlug="english"
+          onChapterNavigateIntent={onChapterNavigateIntent}
+        />,
+      )
     })
 
     const target = container.querySelector(
@@ -403,10 +495,44 @@ describe("SiblingCarousel — happy path", () => {
     })
 
     expect(target!.getAttribute("data-pending")).toBe("false")
+    expect(onChapterNavigateIntent).not.toHaveBeenCalled()
     expect(target!.getAttribute("aria-busy")).toBeNull()
     expect(
       target!.querySelector("[data-testid='sibling-carousel-loading-icon']"),
     ).toBeNull()
+  })
+
+  it("does not emit pending feedback for the already-current chapter", () => {
+    const block = makeBlock(4, 0)
+    const onChapterNavigateIntent = vi.fn()
+
+    act(() => {
+      root.render(
+        <SiblingCarousel
+          block={block}
+          languageSlug="english"
+          onChapterNavigateIntent={onChapterNavigateIntent}
+        />,
+      )
+    })
+
+    const current = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-href='/child-1-slug.html/english.html']",
+    )
+
+    act(() => {
+      current!.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      )
+    })
+
+    expect(onChapterNavigateIntent).not.toHaveBeenCalled()
+    expect(current!.getAttribute("data-pending")).toBe("false")
+    expect(current!.getAttribute("aria-busy")).toBeNull()
   })
 
   it("renders an in-app href without the /watch/ basePath prefix", () => {

--- a/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchBody.test.tsx
@@ -106,6 +106,29 @@ function makeStudyQuestions(values: string[]): WatchStudyQuestionsBlock {
 }
 
 describe("WatchBody — two-column layout", () => {
+  it("renders an optimistic title without replacing route-owned description", () => {
+    const block = makeBlock({ title: "Current Video" })
+
+    act(() => {
+      root.render(
+        <WatchBody
+          block={block}
+          studyQuestions={null}
+          onDownloadClick={vi.fn()}
+          optimisticTitle="Clicked Video"
+        />,
+      )
+    })
+
+    expect(
+      container.querySelector('[data-testid="watch-body-title"]')?.textContent,
+    ).toBe("Clicked Video")
+    expect(
+      container.querySelector('[data-testid="watch-body-description"]')
+        ?.textContent,
+    ).toBe("A description.")
+  })
+
   it("happy path: video with 3 study questions + 5 downloads renders two columns, bullet list, and Download button", () => {
     const block = makeBlock({ downloadCount: 5 })
     const sq = makeStudyQuestions(["Q1?", "Q2?", "Q3?"])

--- a/apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}))
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+vi.mock("@/components/FloatingSearchProvider", () => ({
+  useFloatingSearchPinned: () => ({ searchOpen: false }),
+}))
+
+vi.mock("@/components/watch/SubtitleTranscript", () => ({
+  SubtitleTranscript: () => null,
+}))
+
+vi.mock("@/components/watch/WatchQuestionPanel", () => ({
+  WatchQuestionPanel: () => null,
+}))
+
+vi.mock("@/components/watch/WatchSectionRenderer", () => ({
+  WatchSectionRenderer: ({
+    pendingChapter,
+    onChapterNavigateIntent,
+  }: {
+    pendingChapter?: {
+      targetVideoDocumentId: string
+      title: string | null
+      posterUrl: string | null
+    } | null
+    onChapterNavigateIntent?: (intent: {
+      href: string
+      languageSlug: string
+      sourceVideoDocumentId: string
+      targetVideoDocumentId: string
+      title: string | null
+      slug: string
+      label: string | null
+      posterUrl: string | null
+    }) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="watch-section-renderer"
+      data-pending-target={pendingChapter?.targetVideoDocumentId ?? ""}
+      data-pending-title={pendingChapter?.title ?? ""}
+      data-pending-poster={pendingChapter?.posterUrl ?? ""}
+      onClick={() => {
+        onChapterNavigateIntent?.({
+          href: "/child-2.html/english.html",
+          languageSlug: "english",
+          sourceVideoDocumentId: "video-1",
+          targetVideoDocumentId: "child-2",
+          title: "Clicked Child",
+          slug: "child-2",
+          label: "SEGMENT",
+          posterUrl: "https://cdn.test/clicked.jpg",
+        })
+      }}
+    >
+      Renderer
+    </button>
+  ),
+}))
+
+vi.mock("@/lib/watch-interaction-loader", () => ({
+  getCachedWatchLanguageOptions: () => null,
+  loadWatchInteraction: vi.fn(async () => undefined),
+  loadWatchLanguageOptionsForVideo: vi.fn(async () => []),
+  scheduleWatchInteractionWarmup: vi.fn(() => vi.fn()),
+}))
+
+import { WatchPageClient } from "@/components/watch/WatchPageClient"
+import type { MergedWatchBlock } from "@/lib/content"
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function makeVariant() {
+  return {
+    documentId: "variant-1",
+    duration: 60,
+    downloads: [],
+    language: { slug: "english", name: "English" },
+    muxVideo: { playbackId: "playback-1" },
+  } as never
+}
+
+function makeVideo(documentId = "video-1", title = "Current Video") {
+  return {
+    documentId,
+    slug: "current-video",
+    title,
+    snippet: null,
+    description: null,
+    images: [],
+    variants: [],
+    subtitles: [],
+  } as never
+}
+
+function makeBlocks(): MergedWatchBlock[] {
+  return [
+    {
+      kind: "SiblingCarousel",
+      currentVideoDocumentId: "video-1",
+      canonicalParent: {
+        documentId: "parent-1",
+        slug: "parent",
+        title: "Parent",
+        children: [
+          {
+            documentId: "video-1",
+            slug: "current-video",
+            title: "Current Video",
+            label: "SEGMENT",
+            images: [],
+          },
+          {
+            documentId: "child-2",
+            slug: "child-2",
+            title: "Clicked Child",
+            label: "SEGMENT",
+            images: [{ thumbnail: "https://cdn.test/clicked.jpg" }],
+          },
+        ],
+      },
+    } as never,
+  ]
+}
+
+function renderWatchPage(video = makeVideo()) {
+  act(() => {
+    root.render(
+      <WatchPageClient
+        mergedBlocks={makeBlocks()}
+        variant={makeVariant()}
+        video={video}
+        languageSlug="english"
+      />,
+    )
+  })
+}
+
+describe("WatchPageClient chapter navigation", () => {
+  it("validates pending chapter state and self-invalidates after route commit", () => {
+    renderWatchPage()
+
+    const renderer = () =>
+      container.querySelector('[data-testid="watch-section-renderer"]')
+
+    expect(renderer()?.getAttribute("data-pending-title")).toBe("")
+
+    act(() => {
+      ;(renderer() as HTMLButtonElement).click()
+    })
+
+    expect(renderer()?.getAttribute("data-pending-target")).toBe("child-2")
+    expect(renderer()?.getAttribute("data-pending-title")).toBe("Clicked Child")
+    expect(renderer()?.getAttribute("data-pending-poster")).toBe(
+      "https://cdn.test/clicked.jpg",
+    )
+
+    renderWatchPage(makeVideo("child-2", "Clicked Child"))
+
+    expect(renderer()?.getAttribute("data-pending-target")).toBe("")
+    expect(renderer()?.getAttribute("data-pending-title")).toBe("")
+    expect(renderer()?.getAttribute("data-pending-poster")).toBe("")
+  })
+})

--- a/apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx
@@ -40,6 +40,7 @@ const {
   heroPlayerMock: vi.fn(
     ({
       block,
+      optimisticVisual,
     }: {
       block: {
         variant: {
@@ -48,6 +49,11 @@ const {
         }
         video: { documentId: string }
       }
+      optimisticVisual?: {
+        title: string | null
+        label: string | null
+        posterUrl: string | null
+      } | null
     }) => {
       // Mirror the original placeholder's data attributes so the renderer
       // contract assertions below (data-block-type + data-content JSON
@@ -56,6 +62,7 @@ const {
         videoDocumentId: block.video.documentId,
         playbackId: block.variant.muxVideo?.playbackId ?? null,
         hls: block.variant.hls ?? null,
+        optimisticVisual: optimisticVisual ?? null,
       })
       return (
         <div data-block-type="HeroPlayer" data-content={content}>
@@ -72,6 +79,7 @@ const {
     ({
       block,
       languageSlug,
+      pendingNavigation,
     }: {
       block: {
         canonicalParent: {
@@ -81,12 +89,15 @@ const {
         currentVideoDocumentId: string
       }
       languageSlug?: string
+      pendingNavigation?: { targetVideoDocumentId: string } | null
     }) => {
       const content = JSON.stringify({
         parentSlug: block.canonicalParent.slug,
         currentVideoDocumentId: block.currentVideoDocumentId,
         childCount: (block.canonicalParent.children ?? []).length,
         languageSlug: languageSlug ?? null,
+        pendingTargetVideoDocumentId:
+          pendingNavigation?.targetVideoDocumentId ?? null,
       })
       return (
         <div data-block-type="SiblingCarousel" data-content={content}>
@@ -104,13 +115,16 @@ const {
     ({
       block,
       studyQuestions,
+      optimisticTitle,
     }: {
       block: { video: { documentId: string; title?: string | null } }
       studyQuestions: { studyQuestions: Array<unknown> } | null
+      optimisticTitle?: string | null
     }) => {
       const content = JSON.stringify({
         videoDocumentId: block.video.documentId,
         title: block.video.title ?? null,
+        optimisticTitle: optimisticTitle ?? null,
         studyQuestionCount: studyQuestions?.studyQuestions.length ?? 0,
       })
       return (
@@ -390,6 +404,63 @@ describe("WatchSectionRenderer — synthetic block dispatch", () => {
     expect(content.playbackId).toBe("playback-id-123")
     expect(content.hls).toBe("https://cdn.example/jesus.m3u8")
     expect(content.videoDocumentId).toBe("video-1")
+  })
+
+  it("passes a pending chapter projection to hero, carousel, and body surfaces", () => {
+    const video = makeVideo()
+    const variant = makeVariant()
+    const parent = makeParent(3)
+    const blocks: MergedWatchBlock[] = [
+      buildHeroBlock(video, variant),
+      buildSiblingCarouselBlock(parent, video)!,
+      buildWatchBodyBlock(video, variant),
+    ]
+    const pendingChapter = {
+      href: "/child-2.html/english.html",
+      languageSlug: "english",
+      sourceVideoDocumentId: "video-1",
+      targetVideoDocumentId: "child-2",
+      title: "Clicked Child",
+      slug: "child-2",
+      label: "SEGMENT",
+      posterUrl: "https://cdn.test/clicked.jpg",
+    }
+
+    act(() => {
+      root.render(
+        <WatchSectionRenderer
+          blocks={blocks}
+          languageSlug="english"
+          pendingChapter={pendingChapter}
+          onChapterNavigateIntent={vi.fn()}
+        />,
+      )
+    })
+
+    const heroContent = JSON.parse(
+      container
+        .querySelector('[data-block-type="HeroPlayer"]')
+        ?.getAttribute("data-content") ?? "{}",
+    )
+    const carouselContent = JSON.parse(
+      container
+        .querySelector('[data-block-type="SiblingCarousel"]')
+        ?.getAttribute("data-content") ?? "{}",
+    )
+    const bodyContent = JSON.parse(
+      container
+        .querySelector('[data-block-type="WatchBody"]')
+        ?.getAttribute("data-content") ?? "{}",
+    )
+
+    expect(heroContent.optimisticVisual).toEqual({
+      title: "Clicked Child",
+      label: "SEGMENT",
+      posterUrl: "https://cdn.test/clicked.jpg",
+    })
+    expect(carouselContent.pendingTargetVideoDocumentId).toBe("child-2")
+    expect(bodyContent.optimisticTitle).toBe("Clicked Child")
+    expect(bodyContent.title).toBe("Jesus")
   })
 
   it("skips the synthetic BibleQuotes section when the watch hide flag is active", () => {

--- a/apps/web/src/components/watch/chapter-navigation.ts
+++ b/apps/web/src/components/watch/chapter-navigation.ts
@@ -1,0 +1,16 @@
+export type WatchChapterNavigationIntent = {
+  href: string
+  languageSlug: string
+  sourceVideoDocumentId: string
+  targetVideoDocumentId: string
+  title: string | null
+  slug: string
+  label: string | null
+  posterUrl: string | null
+}
+
+export type WatchChapterOptimisticVisual = {
+  title: string | null
+  label: string | null
+  posterUrl: string | null
+}

--- a/docs/plans/2026-06-11-003-fix-watch-chapter-optimistic-hero-prerender-plan.md
+++ b/docs/plans/2026-06-11-003-fix-watch-chapter-optimistic-hero-prerender-plan.md
@@ -1,0 +1,312 @@
+---
+title: "fix: Watch chapter optimistic hero prerender"
+type: "fix"
+status: "completed"
+date: "2026-06-11"
+roadmap: "docs/roadmap/platform/feat-180-watch-chapter-optimistic-hero-prerender.md"
+---
+
+# fix: Watch chapter optimistic hero prerender
+
+## Summary
+
+Complete the Watch chapter navigation feedback work by lifting clicked-chapter
+metadata into `WatchPageClient` and rendering an optimistic hero title, hero
+poster, body title, and carousel current state before the destination route
+finishes loading.
+
+---
+
+## Problem Frame
+
+The shipped `feat-179` slice made `SiblingCarousel` acknowledge normal chapter
+clicks immediately. Deployed proof on
+`https://watch.jesusfilm.org/watch/death-of-jesus.html/english.html` showed
+the clicked carousel card became current in the next animation frame, but the
+hero title/poster and body title remained on `Death of Jesus` until navigation
+settled on `Burial of Jesus`. The user expectation from the conversation was
+broader: the clicked video should become the visible current video immediately
+using the title and poster already present in the carousel, while the rest of
+the route continues to load.
+
+---
+
+## Requirements
+
+**Immediate visual acceptance**
+
+- R1. A normal left-click on a non-current chapter card immediately makes that
+  chapter the visible current chapter in the carousel.
+- R2. The hero overlay title and visible hero poster immediately switch to the
+  clicked chapter title and poster while the URL still points at the previous
+  route.
+- R3. The repeated body title below the carousel immediately switches to the
+  clicked chapter title so first-viewport title surfaces do not disagree.
+- R4. The clicked card exposes pending affordances until the destination route
+  commits.
+
+**Navigation and data integrity**
+
+- R5. Chapter cards remain `next/link` navigations built from the public audio
+  language slug and existing route builders.
+- R6. Modified clicks, non-left clicks, already-prevented clicks, and active
+  card clicks preserve browser behavior and do not trigger optimistic UI.
+- R7. Optimistic hero/body rendering uses only metadata already present in the
+  carousel payload; playback, downloads, language options, questions, Bible
+  quotes, and share/download modal inputs stay route-owned until navigation
+  settles.
+- R8. Pending state self-invalidates when `currentVideoDocumentId`,
+  `languageSlug`, or the destination href no longer matches, without an
+  effect-based pending clear.
+
+**Proof**
+
+- R9. Component tests cover normal-click optimism, invalidation, and modified
+  click behavior across carousel, hero, and body title surfaces.
+- R10. Browser smoke captures before-click, immediate-after-click, and settled
+  evidence proving title, poster, and carousel behavior.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1. Lift click intent to the page client:** `SiblingCarousel` currently
+  owns pending state privately, which prevents hero/body surfaces from seeing
+  the clicked chapter. Move the normal-click intent callback to
+  `WatchPageClient`, make the carousel controlled by that page-level pending
+  payload on Watch pages, and keep visual state derived from that one source.
+- **KTD2. Optimistically render the visual shell, not playback:** The clicked
+  carousel child has title, slug, document id, label, and images, but not the
+  selected Dub, playback id, HLS source, downloads, subtitles, or lower-page
+  editorial data. Update title/poster/current-card surfaces only; let route
+  data own playable and lower-page content.
+- **KTD3. Keep `next/link` as the navigation primitive:** Immediate feedback
+  should not trade away App Router prefetching, basePath handling, canonical
+  public language URLs, or browser link semantics.
+- **KTD4. Derive validity instead of clearing in effects:** Store pending
+  source and target identifiers, then derive whether that pending state is
+  still valid from current props. This follows the React Compiler pattern in
+  `docs/solutions/design-patterns/react-compiler-ref-and-setstate-patterns-20260513.md`.
+- **KTD5. Pass optimistic block overrides through the renderer:** Keep
+  `HeroPlayer`, `WatchBody`, and `SiblingCarousel` narrowly focused by giving
+  them effective block data or small visual override props from
+  `WatchSectionRenderer`, rather than making each component rediscover pending
+  navigation independently.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["User normal-clicks chapter card"] --> B["SiblingCarousel validates browser click"]
+  B --> C["WatchPageClient stores pending chapter metadata"]
+  C --> D["WatchSectionRenderer derives effective watch blocks"]
+  D --> E["HeroPlayer shows optimistic title and poster"]
+  D --> F["WatchBody shows optimistic title"]
+  D --> G["SiblingCarousel marks target current and pending"]
+  G --> H["Next Link navigation continues"]
+  H --> I["Route payload commits"]
+  I --> J["Pending state no longer validates"]
+  J --> K["Server-derived hero/body/carousel data becomes source of truth"]
+```
+
+The pending payload is a visual bridge. It should not change the active
+player source, subtitle state, download modal payload, study questions, Bible
+quotes, or share metadata before the route commit.
+
+---
+
+## Implementation Units
+
+### U1. Page-Level Pending Chapter Contract
+
+- **Goal:** Move normal-click pending chapter state from private carousel state
+  to a page-level contract that every first-viewport Watch surface can read.
+- **Requirements:** R1, R4, R5, R6, R8.
+- **Dependencies:** None.
+- **Files:** `apps/web/src/components/watch/WatchPageClient.tsx`,
+  `apps/web/src/components/watch/WatchSectionRenderer.tsx`,
+  `apps/web/src/components/watch/SiblingCarousel.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx`,
+  `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx`.
+- **Approach:** Add a small client-only pending chapter type carrying source
+  video id, target video id, target href, language slug, title, slug, label,
+  and resolved poster URL. `SiblingCarousel` should still perform click
+  validation because it owns the anchor event, but Watch pages should pass
+  `pendingChapter` and `onChapterNavigateIntent` props so the page client owns
+  the source of truth. `WatchPageClient` derives `validPendingChapter` from
+  the current video id and language slug.
+- **Execution note:** Start with characterization coverage around the current
+  `SiblingCarousel` click guards, then move state upward.
+- **Patterns to follow:** Existing normal-click guard in `SiblingCarousel`;
+  derived pending state pattern in
+  `docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md`.
+- **Test scenarios:**
+  - Given a normal left-click on an inactive chapter, the callback receives
+    target href, document id, title, slug, label, language slug, and poster URL.
+  - Given a modified click, middle click, already-prevented event, or active
+    card click, the callback is not called and no pending state is shown.
+  - Given pending source video id or language slug no longer matches current
+    props, `WatchPageClient` treats the pending payload as invalid.
+  - Given `WatchPageClient` receives new route props for the clicked video,
+    pending state no longer drives visual overrides.
+  - Given an inactive chapter has no routable href, it does not emit pending
+    state.
+- **Verification:** Focused carousel and renderer tests prove click guards and
+  parent callback behavior without changing link hrefs.
+
+### U2. Optimistic Hero and Body Title Rendering
+
+- **Goal:** Render the clicked chapter title and poster immediately in the
+  first viewport while keeping playable media and route-owned content stable.
+- **Requirements:** R2, R3, R7, R8, R9.
+- **Dependencies:** U1.
+- **Files:** `apps/web/src/components/watch/HeroPlayer.tsx`,
+  `apps/web/src/components/watch/WatchBody.tsx`,
+  `apps/web/src/components/watch/WatchSectionRenderer.tsx`,
+  `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchBody.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx`.
+- **Approach:** Thread an optimistic visual override from
+  `WatchSectionRenderer` into hero and body surfaces. `HeroPlayer` should use
+  the optimistic title for `hero-player-overlay-title` and the optimistic
+  poster for the visible pre-reveal poster layer while leaving `block.video`,
+  `block.variant`, Mux metadata, playback source, subtitle handling, and
+  language-switch controls untouched. `WatchBody` should use the optimistic
+  title for `watch-body-title` only; description, downloads, and right-column
+  content remain current-route data until navigation settles.
+- **Patterns to follow:** `HeroPlayer`'s existing poster-first overlay and
+  `WatchBody`'s title-only visual hierarchy; do not widen server data or add a
+  browser data fetch for this transition.
+- **Test scenarios:**
+  - Given an optimistic title/poster override, `HeroPlayer` renders that title
+    and poster while the underlying block still carries the previous video id.
+  - Given no optimistic override, `HeroPlayer` renders the route-derived title
+    and poster exactly as today.
+  - Given an optimistic title, `WatchBody` renders that title while preserving
+    route-derived description and download visibility.
+  - Given the player is already chrome-revealed, optimistic poster/title
+    overrides do not replace active playback controls or media source.
+- **Verification:** Hero/body tests prove visual overrides affect only the
+  intended title/poster surfaces.
+
+### U3. Effective Block Derivation and Carousel Current State
+
+- **Goal:** Make hero, body, and carousel consume one coherent pending chapter
+  projection so first-viewport surfaces agree immediately.
+- **Requirements:** R1, R2, R3, R4, R7, R8, R9.
+- **Dependencies:** U1, U2.
+- **Files:** `apps/web/src/components/watch/WatchPageClient.tsx`,
+  `apps/web/src/components/watch/WatchSectionRenderer.tsx`,
+  `apps/web/src/components/watch/SiblingCarousel.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx`,
+  `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`.
+- **Approach:** Derive effective visual block state near the renderer boundary:
+  hero/body receive optimistic visual overrides, and carousel receives the
+  same valid pending payload it used to compute locally. Keep the pending
+  document id as the single visual active id so the old card loses current
+  state and the clicked card gains current/pending state in the same render.
+  Avoid mutating `mergedBlocks` in place; use derived values during render.
+- **Patterns to follow:** Existing `WatchSectionRenderer` synthetic-block
+  dispatch tests and the `buildHeroBlock` / `buildWatchBodyBlock` shape in
+  `apps/web/src/lib/content.ts`.
+- **Test scenarios:**
+  - Given pending chapter metadata, renderer passes optimistic title/poster to
+    `HeroPlayer`, optimistic title to `WatchBody`, and pending state to
+    `SiblingCarousel`.
+  - Given pending state invalidates after route commit, renderer passes no
+    optimistic override and all components use route-derived block data.
+  - Given the current route is a parent page with no active child, pending
+    child state still produces a valid visual current child.
+  - Given an Experience override supplies non-watch blocks for lower slots,
+    optimistic chapter state does not affect those blocks.
+- **Verification:** Renderer tests prove the derived projection is coherent
+  and lower slots remain route-owned.
+
+### U4. Immediate and Settled Browser Proof
+
+- **Goal:** Prove the deployed behavior requested in the conversation:
+  clicked title, poster, and carousel change immediately, then the destination
+  route settles with matching server data.
+- **Requirements:** R10.
+- **Dependencies:** U1, U2, U3.
+- **Files:** `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`,
+  `apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchBody.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchSectionRenderer.test.tsx`.
+- **Approach:** Keep automated component coverage as the durable guard and use
+  Helium/`agent-browser` as proof for the integrated user journey. The smoke
+  should sample DOM state before click, on the first animation frame after
+  click, and after URL settle. Store screenshots and a JSON/timeline proof
+  artifact under `output/playwright/`.
+- **Patterns to follow:** The deployed QA proof from this conversation and the
+  local browser-smoke preference in Forge instructions.
+- **Test scenarios:**
+  - Before click: hero title/poster, body title, URL, clip count, and active
+    card all reference the original video.
+  - Immediate after click: URL still references the original video while hero
+    title/poster, body title, clip count, active card, and pending affordance
+    reference the clicked video.
+  - Settled: URL, hero title/poster, body title, clip count, and active card
+    all reference the clicked video with pending cleared.
+  - Modified click smoke: open-in-new-tab style input does not change current
+    page state.
+- **Verification:** Browser proof earns `PASS` only when the immediate sample
+  shows title, poster, and carousel current state on the clicked video before
+  route settle.
+
+---
+
+## Scope Boundaries
+
+- Do not add a new browser fetch for clicked chapter data; use metadata already
+  present in the carousel.
+- Do not optimistically change video playback source, Mux metadata, subtitle
+  state, downloads, study questions, Bible quotes, share metadata, or language
+  options.
+- Do not replace `next/link` with imperative routing.
+- Do not change public Watch URL shape, canonical URL ownership, hreflang,
+  route manifest behavior, or cache invalidation policy.
+
+### Deferred to Follow-Up Work
+
+- Full page snapshot caching for every chapter, including route-owned lower
+  sections before navigation settle, is a larger prefetch/snapshot system and
+  should be planned separately if needed.
+- Mobile-specific proof can follow desktop once the first-viewport optimistic
+  contract is passing.
+
+---
+
+## Risks & Dependencies
+
+- The carousel child payload may lack a Mux playback id, so hero poster
+  optimism must use the resolved carousel image rather than Mux thumbnail
+  metadata.
+- A too-broad override could make the page appear to play one video while the
+  underlying player still has another source. Keep optimistic state visual
+  only.
+- React Compiler lint can reject effect-based pending cleanup. Use derived
+  validity from source/target identifiers.
+- Curated Experience watch routes may share the same client renderer; include
+  them in implementation review so the normal Watch path and Experience path
+  do not drift.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/platform/feat-179-watch-chapter-navigation-feedback.md` -
+  completed carousel-only feedback ticket.
+- `docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md`
+  - current local pattern for normal-click pending state.
+- `docs/solutions/design-patterns/react-compiler-ref-and-setstate-patterns-20260513.md`
+  - derived-state guard against `set-state-in-effect`.
+- `apps/web/CLAUDE.md` - public audio-language URL contract and Watch
+  chapter/sibling carousel guidance.
+- `apps/web/src/components/watch/WatchPageClient.tsx` and
+  `apps/web/src/components/watch/WatchSectionRenderer.tsx` - page-level and
+  renderer-level seams for sharing pending chapter state.

--- a/docs/roadmap/platform/feat-180-watch-chapter-optimistic-hero-prerender.md
+++ b/docs/roadmap/platform/feat-180-watch-chapter-optimistic-hero-prerender.md
@@ -1,0 +1,66 @@
+---
+id: "feat-180"
+title: "Watch chapter optimistic hero prerender"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-11"
+duration: 1
+depends_on:
+  - "feat-179"
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "navigation"
+  - "optimistic-ui"
+---
+
+## Problem
+
+Deployed proof for `feat-179` confirms the chapter carousel immediately marks
+the clicked card current, but the hero title/poster and body title remain on
+the previous video until the new route payload renders. Users need the whole
+first-viewport Watch identity to acknowledge the clicked chapter immediately.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-11-003-fix-watch-chapter-optimistic-hero-prerender-plan.md`
+   - implementation plan for this follow-up.
+2. `docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md`
+   - existing carousel-only optimistic-navigation pattern.
+3. `apps/web/src/components/watch/WatchPageClient.tsx` - page-level client
+   owner for watch blocks and modal state.
+4. `apps/web/src/components/watch/WatchSectionRenderer.tsx` - dispatches
+   synthetic watch blocks to hero, carousel, body, and lower sections.
+5. `apps/web/src/components/watch/SiblingCarousel.tsx` - normal-click
+   detection and clicked-card metadata source.
+6. `apps/web/src/components/watch/HeroPlayer.tsx` - hero poster/title shell.
+7. `apps/web/src/components/watch/WatchBody.tsx` - repeated body title.
+
+## What To Build
+
+1. Lift normal chapter-click intent from `SiblingCarousel` to `WatchPageClient`.
+2. Build a validated page-level pending chapter state from metadata already in
+   the carousel: target href, document id, title, slug, label, and poster image.
+3. Render optimistic hero title/poster, body title, and carousel current state
+   from that pending state while the route still shows the previous URL.
+4. Preserve `next/link`, public audio-language URL builders, and modified-click
+   browser behavior.
+5. Let route commit invalidate pending state without effect-based cleanup.
+
+## Verification
+
+- Focused component tests prove normal chapter click immediately updates hero
+  title/poster, body title, carousel current card, clip count, and pending
+  affordance.
+- Modified clicks and active-card clicks do not trigger optimistic UI.
+- `@forge/web` typecheck and lint pass.
+- Helium/`agent-browser` smoke captures before-click, immediate-after-click,
+  and settled screenshots on a deployed or local Watch route.
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-11-003-fix-watch-chapter-optimistic-hero-prerender-plan.md`


### PR DESCRIPTION
## Summary

Watch chapter clicks now update the visible first-viewport identity immediately: the clicked chapter becomes current in the carousel, the hero title and poster switch to that chapter, and the repeated body title follows while the old URL is still on screen.

The optimistic state is deliberately visual-only. Playback source, Mux metadata, downloads, share data, questions, and Bible quote content remain owned by the committed destination route, and the pending state invalidates when the source video/language/href no longer matches.

## Verification

- `pnpm --filter @forge/web test -- src/components/watch/__tests__/SiblingCarousel.test.tsx src/components/watch/__tests__/WatchPageClient.navigation.test.tsx src/components/watch/__tests__/WatchSectionRenderer.test.tsx src/components/watch/__tests__/HeroPlayer.test.tsx src/components/watch/__tests__/WatchBody.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `git diff --check HEAD`
- Helium/`agent-browser` local proof on `http://127.0.0.1:3011/watch/death-of-jesus.html/english.html`

## Browser Proof

| Phase | URL | Hero/body title | Carousel state |
| --- | --- | --- | --- |
| Before click | `/watch/death-of-jesus.html/english.html` | `Death of Jesus` | `Death of Jesus`, clip 55 |
| Immediate after click | still `/watch/death-of-jesus.html/english.html` | `Burial of Jesus`; poster opacity `1` | `Burial of Jesus`, `data-active=true`, `data-pending=true`, `aria-busy=true`, clip 56 |
| Settled | `/watch/burial-of-jesus.html/english.html` | `Burial of Jesus` | `Burial of Jesus`, pending cleared, clip 56 |

Screenshots/proof artifacts were captured locally under:

- `output/playwright/watch-prerender-before-click.png`
- `output/playwright/watch-prerender-immediate-after-click.png`
- `output/playwright/watch-prerender-settled.png`
- `output/playwright/watch-prerender-proof.json`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
