### PR TITLE
feat(yt-video-mapper): match uploads with media signatures

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -76,6 +76,24 @@ An asynchronous attribution request that owns an uploaded media input until the 
 
 A ranked possible attribution produced by a Match Job, pairing a source Video with its likely Dub and a confidence judgment.
 
+### Source Anchor Evidence
+
+Match evidence that supports which source Video an uploaded media input came
+from, before deciding which Dub or language-specific variant is most likely.
+
+Visual or structural media evidence usually acts as Source Anchor Evidence
+because re-upload metadata, audio language, and transcript text can drift while
+the underlying source footage stays recognizable.
+
+### Variant-Ranking Evidence
+
+Match evidence that helps choose the likely `videoVariantId` after Source
+Anchor Evidence has narrowed the source Video.
+
+Audio, text, language, and subtitle signals are usually Variant-Ranking
+Evidence: they can distinguish Dubs under the same source, but should not create
+a high-strength source attribution on their own.
+
 ## Search & embeddings
 
 ### Search Pipeline Mode

--- a/apps/yt-video-mapper-backend/README.md
+++ b/apps/yt-video-mapper-backend/README.md
@@ -54,6 +54,30 @@ Optional runtime settings:
 - `MEDIA_INDEX_RESUME_AFTER_VARIANT_ID` resumes after a stored
   `CatalogVariant.id` cursor
 
+## Matching
+
+`/match-jobs` uses local mapper state only. The default server extracts
+deterministic uploaded-video signals, retrieves against `MediaSignature` rows
+for the configured `MEDIA_SIGNATURE_ALGORITHM_VERSION`, joins active
+`CatalogVariant` metadata, and returns public candidates with:
+
+- `coreId`
+- `videoVariantId`
+- `confidence`
+- `matchStrength`
+
+The first matcher uses deterministic structural byte-sample evidence as the
+source-video anchor, plus duration and optional text/audio evidence when real
+source data exists. It does not synthesize audio fingerprints.
+
+Before production smoke tests can return non-empty candidates, run:
+
+```sh
+pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy
+pnpm --filter @forge/yt-video-mapper-backend sync:catalog
+pnpm --filter @forge/yt-video-mapper-backend index:media
+```
+
 ## Current Artifacts
 
 - `docs/brainstorms/video-source-mapper-requirements.md`

--- a/apps/yt-video-mapper-backend/docs/railway-deployment.md
+++ b/apps/yt-video-mapper-backend/docs/railway-deployment.md
@@ -100,6 +100,60 @@ The command uses Admin GraphQL only. It writes mapper-owned `CatalogVideo`,
 `CatalogVariant`, and `CatalogSyncRun` rows, prints safe counters, and exits
 non-zero if the sync run records a failed status.
 
+## Media Indexing
+
+After catalog sync has populated indexable `CatalogVariant` rows, run:
+
+```bash
+pnpm --filter @forge/yt-video-mapper-backend index:media
+```
+
+The command writes versioned `MediaSignature` rows for the configured
+`MEDIA_SIGNATURE_ALGORITHM_VERSION`. Optional tuning vars are:
+
+- `MEDIA_INDEX_ALLOWED_HOSTS`
+- `MEDIA_INDEX_PAGE_SIZE`
+- `MEDIA_INDEX_MAX_FETCH_BYTES`
+- `MEDIA_INDEX_FETCH_TIMEOUT_MS`
+- `MEDIA_INDEX_RESUME_AFTER_VARIANT_ID`
+
+Keep `MEDIA_INDEX_ALLOWED_HOSTS` unset unless production media hosts are known,
+or set it to exact hostnames only. Do not store signed media URLs or secret
+values in docs, logs, or shell history.
+
+## Match Job Smoke After Deploy
+
+After a code deploy that includes matcher changes, the production data sequence
+is:
+
+```bash
+pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy
+pnpm --filter @forge/yt-video-mapper-backend sync:catalog
+pnpm --filter @forge/yt-video-mapper-backend index:media
+```
+
+Then submit an authenticated `/match-jobs` upload using a sample expected to
+overlap indexed official media, process the job, and poll it:
+
+```bash
+MAPPER_BASE_URL="https://forgeyt-video-mapper-backend-production.up.railway.app"
+
+curl -sS -X POST "$MAPPER_BASE_URL/match-jobs" \
+  -H "Authorization: Bearer $MAPPER_API_TOKEN" \
+  -H "Content-Type: video/mp4" \
+  --data-binary "@sample.mp4"
+
+curl -sS -X POST "$MAPPER_BASE_URL/match-jobs/$JOB_ID/process" \
+  -H "Authorization: Bearer $MAPPER_API_TOKEN"
+
+curl -sS "$MAPPER_BASE_URL/match-jobs/$JOB_ID" \
+  -H "Authorization: Bearer $MAPPER_API_TOKEN"
+```
+
+The public response must contain only `coreId`, `videoVariantId`, `confidence`,
+and `matchStrength` for each candidate. Do not paste bearer tokens, signed URLs,
+or large media payloads into tickets or commits.
+
 ## 2026-06-09 Provisioning Notes
 
 - Railway config is intended to be config-as-code via

--- a/apps/yt-video-mapper-backend/src/routes/match-jobs.test.ts
+++ b/apps/yt-video-mapper-backend/src/routes/match-jobs.test.ts
@@ -7,6 +7,12 @@ import {
   MatchJobService,
   type Matcher,
 } from "../services/match-job.service.js"
+import {
+  InMemoryMediaSignatureMatchRepository,
+  MediaSignatureMatcher,
+  type MatchableMediaSignature,
+} from "../services/media-signature-matcher.js"
+import { DeterministicUploadSignalExtractor } from "../services/upload-signal-extraction.js"
 import type {
   UploadSignalExtractor,
   UploadSignals,
@@ -111,6 +117,35 @@ describe("match jobs route", () => {
     })
   })
 
+  it("processes a queued job through real extraction and matching", async () => {
+    const { request } = createHarness({
+      service: createRealMatcherService(),
+    })
+    const created = await request(
+      "POST",
+      "/match-jobs",
+      Buffer.from([1, 2, 3, 4]),
+    )
+    const jobId = String(created.body.jobId)
+
+    const response = await request("POST", `/match-jobs/${jobId}/process`)
+
+    expect(response).toEqual({
+      statusCode: 200,
+      body: {
+        candidates: [
+          {
+            coreId: "core-jesus-film",
+            videoVariantId: "variant-en",
+            confidence: 1,
+            matchStrength: "high",
+          },
+        ],
+      },
+    })
+    expect(JSON.stringify(response.body)).not.toContain("evidence")
+  })
+
   it("rejects oversized uploads safely", async () => {
     const { request } = createHarness({ maxUploadBytes: 3 })
 
@@ -164,29 +199,33 @@ describe("match jobs route", () => {
 function createHarness({
   maxUploadBytes = 1_000,
   apiToken,
+  service,
 }: {
   maxUploadBytes?: number
   apiToken?: string
+  service?: MatchJobService
 } = {}) {
-  const service = new MatchJobService(
-    new InMemoryMatchJobRepository(),
-    new InMemoryUploadStorage(),
-    new StubExtractor({
-      visualHashes: ["frame-a"],
-      audioFingerprints: ["audio-a"],
-    }),
-    new StubMatcher([candidate]),
-    () => new Date("2026-06-08T00:00:00.000Z"),
-  )
+  const matchJobService =
+    service ??
+    new MatchJobService(
+      new InMemoryMatchJobRepository(),
+      new InMemoryUploadStorage(),
+      new StubExtractor({
+        visualHashes: ["frame-a"],
+        audioFingerprints: ["audio-a"],
+      }),
+      new StubMatcher([candidate]),
+      () => new Date("2026-06-08T00:00:00.000Z"),
+    )
   const handleRequest = createHandleRequest({
-    matchJobService: service,
+    matchJobService,
     autoProcessMatchJobs: false,
     maxUploadBytes,
     apiToken,
   })
 
   return {
-    service,
+    service: matchJobService,
     async request(
       method: string,
       url: string,
@@ -211,6 +250,25 @@ function createHarness({
   }
 }
 
+function createRealMatcherService(): MatchJobService {
+  return new MatchJobService(
+    new InMemoryMatchJobRepository(),
+    new InMemoryUploadStorage(),
+    new DeterministicUploadSignalExtractor(4),
+    new MediaSignatureMatcher(
+      new InMemoryMediaSignatureMatchRepository([
+        structuralSignature({
+          coreId: "core-jesus-film",
+          videoVariantId: "variant-en",
+          sha256:
+            "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+        }),
+      ]),
+    ),
+    () => new Date("2026-06-08T00:00:00.000Z"),
+  )
+}
+
 class StubExtractor implements UploadSignalExtractor {
   constructor(private readonly signals: UploadSignals) {}
 
@@ -224,5 +282,39 @@ class StubMatcher implements Matcher {
 
   async match(): Promise<PublicMatchCandidate[]> {
     return this.candidates
+  }
+}
+
+function structuralSignature({
+  coreId,
+  videoVariantId,
+  sha256,
+}: {
+  coreId: string
+  videoVariantId: string
+  sha256: string
+}): MatchableMediaSignature {
+  return {
+    coreId,
+    videoVariantId,
+    signatureType: "STRUCTURAL_HINT",
+    offsetMilliseconds: 0,
+    durationMilliseconds: 120_000,
+    signature: {
+      kind: "structural_hint_v1",
+      byteSample: {
+        sha256,
+        byteLength: 4,
+        rangeStart: 0,
+        rangeEnd: 3,
+        complete: true,
+      },
+    },
+    catalogVariant: {
+      durationSeconds: 120,
+      lengthInMilliseconds: null,
+      languageSlug: "english",
+      locale: "en",
+    },
   }
 }

--- a/apps/yt-video-mapper-backend/src/server.ts
+++ b/apps/yt-video-mapper-backend/src/server.ts
@@ -8,9 +8,13 @@ import { prisma } from "./db/client.js"
 import { PrismaMatchJobRepository } from "./db/match-job.repository.js"
 import { sendJson } from "./http.js"
 import { createMatchJobsRoute } from "./routes/match-jobs.js"
-import { MatchJobService, NoopMatcher } from "./services/match-job.service.js"
+import { MatchJobService } from "./services/match-job.service.js"
+import {
+  MediaSignatureMatcher,
+  PrismaMediaSignatureMatchRepository,
+} from "./services/media-signature-matcher.js"
 import { FileSystemUploadStorage } from "./services/upload-storage.js"
-import { PlaceholderUploadSignalExtractor } from "./services/upload-signal-extraction.js"
+import { DeterministicUploadSignalExtractor } from "./services/upload-signal-extraction.js"
 
 export type ServerDependencies = {
   matchJobService?: MatchJobService
@@ -66,12 +70,14 @@ export function startServer(port = env.PORT): void {
   })
 }
 
-function createDefaultMatchJobService(): MatchJobService {
+export function createDefaultMatchJobService(): MatchJobService {
   return new MatchJobService(
     new PrismaMatchJobRepository(prisma),
     new FileSystemUploadStorage(env.UPLOAD_STORAGE_DIR),
-    new PlaceholderUploadSignalExtractor(),
-    new NoopMatcher(),
+    new DeterministicUploadSignalExtractor(),
+    new MediaSignatureMatcher(new PrismaMediaSignatureMatchRepository(prisma), {
+      algorithmVersion: env.MEDIA_SIGNATURE_ALGORITHM_VERSION,
+    }),
   )
 }
 

--- a/apps/yt-video-mapper-backend/src/services/match-job.service.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/match-job.service.test.ts
@@ -6,6 +6,12 @@ import {
   SafeMatchJobError,
   type Matcher,
 } from "./match-job.service.js"
+import {
+  InMemoryMediaSignatureMatchRepository,
+  MediaSignatureMatcher,
+  type MatchableMediaSignature,
+} from "./media-signature-matcher.js"
+import { DeterministicUploadSignalExtractor } from "./upload-signal-extraction.js"
 import type {
   UploadSignalExtractor,
   UploadSignals,
@@ -45,6 +51,42 @@ describe("MatchJobService", () => {
     expect(storage.has(job.uploadStorageKey!)).toBe(false)
     await expect(service.getJobResult(job.id)).resolves.toEqual({
       candidates: [candidate],
+    })
+  })
+
+  it("processes a job through real upload extraction and media signature matching", async () => {
+    const service = new MatchJobService(
+      new InMemoryMatchJobRepository(),
+      new InMemoryUploadStorage(),
+      new DeterministicUploadSignalExtractor(4),
+      new MediaSignatureMatcher(
+        new InMemoryMediaSignatureMatchRepository([
+          structuralSignature({
+            coreId: "core-jesus-film",
+            videoVariantId: "variant-en",
+            sha256:
+              "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+          }),
+        ]),
+      ),
+      () => new Date("2026-06-08T00:00:00.000Z"),
+    )
+    const job = await service.createUploadJob({
+      bytes: Buffer.from([1, 2, 3, 4]),
+      contentType: "video/mp4",
+    })
+
+    await service.processJob(job.id)
+
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      candidates: [
+        {
+          coreId: "core-jesus-film",
+          videoVariantId: "variant-en",
+          confidence: 1,
+          matchStrength: "high",
+        },
+      ],
     })
   })
 
@@ -263,5 +305,39 @@ class FailingCreateRepository extends InMemoryMatchJobRepository {
   ): Promise<never> {
     this.storedKey = job.uploadStorageKey
     throw new RepositoryCreateTestError()
+  }
+}
+
+function structuralSignature({
+  coreId,
+  videoVariantId,
+  sha256,
+}: {
+  coreId: string
+  videoVariantId: string
+  sha256: string
+}): MatchableMediaSignature {
+  return {
+    coreId,
+    videoVariantId,
+    signatureType: "STRUCTURAL_HINT",
+    offsetMilliseconds: 0,
+    durationMilliseconds: 120_000,
+    signature: {
+      kind: "structural_hint_v1",
+      byteSample: {
+        sha256,
+        byteLength: 4,
+        rangeStart: 0,
+        rangeEnd: 3,
+        complete: true,
+      },
+    },
+    catalogVariant: {
+      durationSeconds: 120,
+      lengthInMilliseconds: null,
+      languageSlug: "english",
+      locale: "en",
+    },
   }
 }

--- a/apps/yt-video-mapper-backend/src/services/match-job.service.ts
+++ b/apps/yt-video-mapper-backend/src/services/match-job.service.ts
@@ -77,12 +77,6 @@ export class SafeMatchJobError extends Error {
   }
 }
 
-export class NoopMatcher implements Matcher {
-  async match(): Promise<PublicMatchCandidate[]> {
-    return []
-  }
-}
-
 export class MatchJobService {
   constructor(
     private readonly repository: MatchJobRepository,
@@ -154,6 +148,7 @@ export class MatchJobService {
       await cleanupStoredUpload(this.storage, job.uploadStorageKey)
       await this.repository.update(job.id, {
         status: "complete",
+        inputDurationMilliseconds: signals.durationMilliseconds,
         completedAt: this.now(),
       })
     } catch (error) {

--- a/apps/yt-video-mapper-backend/src/services/media-signature-matcher.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/media-signature-matcher.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest"
+import {
+  InMemoryMediaSignatureMatchRepository,
+  MediaSignatureMatcher,
+  type MatchableMediaSignature,
+} from "./media-signature-matcher.js"
+import type { UploadSignals } from "./upload-signal-extraction.js"
+
+const matchingSampleHash =
+  "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a"
+const otherSampleHash =
+  "55e5509f8052998294266ee5b50cb592938191fb5d67f73cac2e60b0276b1bdd"
+
+describe("MediaSignatureMatcher", () => {
+  it("retrieves candidates from seeded structural MediaSignature rows", async () => {
+    const matcher = createMatcher([
+      structuralSignature({
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-en",
+        sha256: matchingSampleHash,
+      }),
+      structuralSignature({
+        coreId: "core-other",
+        videoVariantId: "variant-other",
+        sha256: otherSampleHash,
+      }),
+    ])
+
+    await expect(
+      matcher.match(
+        uploadSignals({ sampledByteHashes: [matchingSampleHash] }),
+        {
+          limit: 3,
+        },
+      ),
+    ).resolves.toEqual([
+      {
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-en",
+        confidence: 1,
+        matchStrength: "high",
+      },
+    ])
+  })
+
+  it("uses source-anchor evidence to rank the correct variant under the same coreId", async () => {
+    const matcher = createMatcher([
+      structuralSignature({
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-en",
+        sha256: matchingSampleHash,
+      }),
+      textSignature({
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-es",
+        text: "paz sea contigo",
+      }),
+    ])
+
+    await expect(
+      matcher.match(
+        uploadSignals({
+          sampledByteHashes: [matchingSampleHash],
+          transcriptText: "paz sea contigo",
+        }),
+        { limit: 3 },
+      ),
+    ).resolves.toEqual([
+      {
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-es",
+        confidence: 1,
+        matchStrength: "high",
+      },
+    ])
+  })
+
+  it("keeps visual or structural source evidence ahead when text points elsewhere", async () => {
+    const matcher = createMatcher([
+      structuralSignature({
+        coreId: "core-visual",
+        videoVariantId: "variant-visual",
+        sha256: matchingSampleHash,
+      }),
+      textSignature({
+        coreId: "core-text-only",
+        videoVariantId: "variant-text-only",
+        text: "peace be with you",
+      }),
+    ])
+
+    await expect(
+      matcher.match(
+        uploadSignals({
+          sampledByteHashes: [matchingSampleHash],
+          transcriptText: "peace be with you",
+        }),
+        { limit: 3 },
+      ),
+    ).resolves.toEqual([
+      {
+        coreId: "core-visual",
+        videoVariantId: "variant-visual",
+        confidence: 1,
+        matchStrength: "high",
+      },
+    ])
+  })
+
+  it("does not let weak variant evidence replace an exact source fallback", async () => {
+    const matcher = createMatcher([
+      structuralSignature({
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-en",
+        sha256: matchingSampleHash,
+      }),
+      textSignature({
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-es",
+        text: "peace be with you amen",
+      }),
+    ])
+
+    await expect(
+      matcher.match(
+        uploadSignals({
+          sampledByteHashes: [matchingSampleHash],
+          transcriptText: "peace unrelated words",
+        }),
+        { limit: 2 },
+      ),
+    ).resolves.toEqual([
+      {
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-en",
+        confidence: 1,
+        matchStrength: "high",
+      },
+      {
+        coreId: "core-jesus-film",
+        videoVariantId: "variant-es",
+        confidence: 0.802,
+        matchStrength: "medium",
+      },
+    ])
+  })
+
+  it("does not merge shared videoVariantId values across different coreIds", async () => {
+    const matcher = createMatcher([
+      structuralSignature({
+        coreId: "core-a",
+        videoVariantId: "shared-variant",
+        sha256: matchingSampleHash,
+      }),
+      structuralSignature({
+        coreId: "core-b",
+        videoVariantId: "shared-variant",
+        sha256: otherSampleHash,
+      }),
+    ])
+
+    await expect(
+      matcher.match(
+        uploadSignals({ sampledByteHashes: [matchingSampleHash] }),
+        {
+          limit: 3,
+        },
+      ),
+    ).resolves.toEqual([
+      {
+        coreId: "core-a",
+        videoVariantId: "shared-variant",
+        confidence: 1,
+        matchStrength: "high",
+      },
+    ])
+  })
+
+  it("caps text-only evidence below high strength without source-anchor evidence", async () => {
+    const matcher = createMatcher([
+      textSignature({
+        coreId: "core-text",
+        videoVariantId: "variant-text",
+        text: "peace be with you",
+      }),
+    ])
+
+    await expect(
+      matcher.match(
+        uploadSignals({
+          sampledByteHashes: [],
+          transcriptText: "peace be with you",
+        }),
+        { limit: 3 },
+      ),
+    ).resolves.toEqual([
+      {
+        coreId: "core-text",
+        videoVariantId: "variant-text",
+        confidence: 0.84,
+        matchStrength: "medium",
+      },
+    ])
+  })
+
+  it("uses audio evidence only when uploaded audio fingerprints exist", async () => {
+    const matcher = createMatcher([
+      audioSignature({
+        coreId: "core-audio",
+        videoVariantId: "variant-audio",
+        fingerprint: "voice-a",
+      }),
+    ])
+
+    await expect(
+      matcher.match(uploadSignals({ audioFingerprints: [] }), { limit: 3 }),
+    ).resolves.toEqual([])
+    await expect(
+      matcher.match(uploadSignals({ audioFingerprints: ["voice-a"] }), {
+        limit: 3,
+      }),
+    ).resolves.toEqual([
+      {
+        coreId: "core-audio",
+        videoVariantId: "variant-audio",
+        confidence: 0.84,
+        matchStrength: "medium",
+      },
+    ])
+  })
+})
+
+function createMatcher(signatures: MatchableMediaSignature[]) {
+  return new MediaSignatureMatcher(
+    new InMemoryMediaSignatureMatchRepository(signatures),
+  )
+}
+
+function uploadSignals(overrides: Partial<UploadSignals> = {}): UploadSignals {
+  const sampledByteHashes = overrides.sampledByteHashes ?? []
+
+  return {
+    visualHashes: sampledByteHashes,
+    audioFingerprints: [],
+    sampledByteHashes,
+    byteSamples: [],
+    byteLength: 4,
+    contentType: "video/mp4",
+    algorithmVersion: "official-media-signature-v1",
+    ...overrides,
+  }
+}
+
+function structuralSignature({
+  coreId,
+  videoVariantId,
+  sha256,
+  durationMilliseconds = 120_000,
+}: {
+  coreId: string
+  videoVariantId: string
+  sha256: string
+  durationMilliseconds?: number
+}): MatchableMediaSignature {
+  return signature({
+    coreId,
+    videoVariantId,
+    signatureType: "STRUCTURAL_HINT",
+    durationMilliseconds,
+    signature: {
+      kind: "structural_hint_v1",
+      durationMilliseconds,
+      byteSample: {
+        sha256,
+        byteLength: 4,
+        rangeStart: 0,
+        rangeEnd: 3,
+        complete: false,
+      },
+    },
+  })
+}
+
+function textSignature({
+  coreId,
+  videoVariantId,
+  text,
+}: {
+  coreId: string
+  videoVariantId: string
+  text: string
+}): MatchableMediaSignature {
+  return signature({
+    coreId,
+    videoVariantId,
+    signatureType: "TEXT_SEGMENT",
+    signature: {
+      kind: "text_segment_v1",
+      text,
+      tokenCount: text.split(/\s+/).length,
+    },
+  })
+}
+
+function audioSignature({
+  coreId,
+  videoVariantId,
+  fingerprint,
+}: {
+  coreId: string
+  videoVariantId: string
+  fingerprint: string
+}): MatchableMediaSignature {
+  return signature({
+    coreId,
+    videoVariantId,
+    signatureType: "AUDIO_FINGERPRINT",
+    signature: {
+      kind: "audio_fingerprint_v1",
+      fingerprint,
+    },
+  })
+}
+
+function signature({
+  coreId,
+  videoVariantId,
+  signatureType,
+  durationMilliseconds = null,
+  signature,
+}: {
+  coreId: string
+  videoVariantId: string
+  signatureType: MatchableMediaSignature["signatureType"]
+  durationMilliseconds?: number | null
+  signature: unknown
+}): MatchableMediaSignature {
+  return {
+    coreId,
+    videoVariantId,
+    signatureType,
+    offsetMilliseconds: 0,
+    durationMilliseconds,
+    signature,
+    catalogVariant: {
+      durationSeconds: 120,
+      lengthInMilliseconds: null,
+      languageSlug: null,
+      locale: null,
+    },
+  }
+}

--- a/apps/yt-video-mapper-backend/src/services/media-signature-matcher.ts
+++ b/apps/yt-video-mapper-backend/src/services/media-signature-matcher.ts
@@ -1,0 +1,406 @@
+import {
+  SignatureType as PrismaSignatureType,
+  type PrismaClient,
+} from "../generated/prisma/index.js"
+import type { PublicMatchCandidate } from "../domain/match.js"
+import { fuseRankedCandidates } from "./fusion-scorer.js"
+import {
+  OFFICIAL_MEDIA_SIGNATURE_ALGORITHM_VERSION,
+  type MediaSignatureType,
+} from "./media-signature-extraction.js"
+import type { Matcher } from "./match-job.service.js"
+import { retrieveAudioCandidates } from "./retrieval/audio-retriever.js"
+import { retrieveTextCandidates } from "./retrieval/text-retriever.js"
+import {
+  retrievalSignalKey,
+  type RetrievalSignal,
+  type TimecodedStringSignature,
+} from "./retrieval/types.js"
+import { retrieveVisualCandidates } from "./retrieval/visual-retriever.js"
+import type { UploadSignals } from "./upload-signal-extraction.js"
+
+const MINIMUM_DURATION_SCORE = 0.85
+const VARIANT_EVIDENCE_FALLBACK_THRESHOLD = 0.65
+
+export type MatchableCatalogVariant = {
+  durationSeconds: number | null
+  lengthInMilliseconds: bigint | null
+  languageSlug: string | null
+  locale: string | null
+}
+
+export type MatchableMediaSignature = {
+  coreId: string
+  videoVariantId: string
+  signatureType: MediaSignatureType
+  offsetMilliseconds: number
+  durationMilliseconds: number | null
+  signature: unknown
+  catalogVariant: MatchableCatalogVariant
+}
+
+export type MediaSignatureMatchRepository = {
+  listSignatures(input: {
+    algorithmVersion: string
+  }): Promise<MatchableMediaSignature[]>
+}
+
+export type MediaSignatureMatcherOptions = {
+  algorithmVersion?: string
+}
+
+export class MediaSignatureMatcher implements Matcher {
+  constructor(
+    private readonly repository: MediaSignatureMatchRepository,
+    private readonly options: MediaSignatureMatcherOptions = {},
+  ) {}
+
+  async match(
+    signals: UploadSignals,
+    { limit }: { limit: number },
+  ): Promise<PublicMatchCandidate[]> {
+    const signatures = await this.repository.listSignatures({
+      algorithmVersion:
+        this.options.algorithmVersion ??
+        signals.algorithmVersion ??
+        OFFICIAL_MEDIA_SIGNATURE_ALGORITHM_VERSION,
+    })
+
+    const visualSignals = retrieveSourceAnchorSignals(signals, signatures)
+    const audioSignals = retrieveAudioSignals(signals, signatures)
+    const textSignals = retrieveTextSignals(signals, signatures)
+    const durationSignals = retrieveDurationSignals(signals, signatures)
+    const anchoredVariantSignals = applySourceAnchors(visualSignals, [
+      ...audioSignals,
+      ...textSignals,
+    ])
+    const fallbackVisualSignals = sourceAnchorFallbackSignals(
+      visualSignals,
+      anchoredVariantSignals,
+    )
+
+    return fuseRankedCandidates(
+      [...fallbackVisualSignals, ...anchoredVariantSignals, ...durationSignals],
+      { limit },
+    )
+  }
+}
+
+export class PrismaMediaSignatureMatchRepository implements MediaSignatureMatchRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async listSignatures({
+    algorithmVersion,
+  }: {
+    algorithmVersion: string
+  }): Promise<MatchableMediaSignature[]> {
+    const signatures = await this.db.mediaSignature.findMany({
+      where: {
+        algorithmVersion,
+        catalogVariant: {
+          is: {
+            indexable: true,
+            deletedAt: null,
+          },
+        },
+      },
+      select: {
+        coreId: true,
+        videoVariantId: true,
+        signatureType: true,
+        offsetMilliseconds: true,
+        durationMilliseconds: true,
+        signature: true,
+        catalogVariant: {
+          select: {
+            durationSeconds: true,
+            lengthInMilliseconds: true,
+            languageSlug: true,
+            locale: true,
+          },
+        },
+      },
+    })
+
+    return signatures.map((signature) => ({
+      coreId: signature.coreId,
+      videoVariantId: signature.videoVariantId,
+      signatureType: fromPrismaSignatureType(signature.signatureType),
+      offsetMilliseconds: signature.offsetMilliseconds,
+      durationMilliseconds: signature.durationMilliseconds,
+      signature: signature.signature,
+      catalogVariant: signature.catalogVariant,
+    }))
+  }
+}
+
+export class InMemoryMediaSignatureMatchRepository implements MediaSignatureMatchRepository {
+  constructor(private readonly signatures: MatchableMediaSignature[] = []) {}
+
+  async listSignatures(): Promise<MatchableMediaSignature[]> {
+    return this.signatures.map((signature) => ({ ...signature }))
+  }
+}
+
+function sourceAnchorFallbackSignals(
+  sourceSignals: RetrievalSignal[],
+  anchoredVariantSignals: RetrievalSignal[],
+): RetrievalSignal[] {
+  const coreIdsWithVariantEvidence = new Set(
+    anchoredVariantSignals
+      .filter(
+        (signal) =>
+          signal.visualScore !== undefined &&
+          ((signal.audioScore ?? 0) >= VARIANT_EVIDENCE_FALLBACK_THRESHOLD ||
+            (signal.textScore ?? 0) >= VARIANT_EVIDENCE_FALLBACK_THRESHOLD),
+      )
+      .map((signal) => signal.coreId),
+  )
+
+  return sourceSignals.filter(
+    (signal) => !coreIdsWithVariantEvidence.has(signal.coreId),
+  )
+}
+
+function retrieveSourceAnchorSignals(
+  uploadSignals: UploadSignals,
+  officialSignatures: MatchableMediaSignature[],
+): RetrievalSignal[] {
+  const uploadHashes = uniqueStrings([
+    ...(uploadSignals.sampledByteHashes ?? []),
+    ...uploadSignals.visualHashes,
+  ])
+  if (uploadHashes.length === 0) return []
+
+  const officialSourceAnchors = officialSignatures.flatMap((signature) =>
+    sourceAnchorSignature(signature),
+  )
+  if (officialSourceAnchors.length === 0) return []
+
+  return retrieveVisualCandidates({
+    uploadFrameHashes: uploadHashes,
+    officialFrameSignatures: officialSourceAnchors,
+  })
+}
+
+function retrieveAudioSignals(
+  uploadSignals: UploadSignals,
+  officialSignatures: MatchableMediaSignature[],
+): RetrievalSignal[] {
+  if (uploadSignals.audioFingerprints.length === 0) return []
+
+  const officialAudioSignatures = officialSignatures.flatMap((signature) =>
+    timecodedStringSignature(signature, audioSignatureValue),
+  )
+  if (officialAudioSignatures.length === 0) return []
+
+  return retrieveAudioCandidates({
+    uploadAudioFingerprints: uploadSignals.audioFingerprints,
+    officialAudioSignatures,
+  })
+}
+
+function retrieveTextSignals(
+  uploadSignals: UploadSignals,
+  officialSignatures: MatchableMediaSignature[],
+): RetrievalSignal[] {
+  if (!uploadSignals.transcriptText) return []
+
+  const officialTextSignatures = officialSignatures.flatMap((signature) =>
+    timecodedStringSignature(signature, textSignatureValue),
+  )
+  if (officialTextSignatures.length === 0) return []
+
+  return retrieveTextCandidates({
+    uploadTranscriptText: uploadSignals.transcriptText,
+    officialTextSignatures,
+  })
+}
+
+function retrieveDurationSignals(
+  uploadSignals: UploadSignals,
+  officialSignatures: MatchableMediaSignature[],
+): RetrievalSignal[] {
+  if (!uploadSignals.durationMilliseconds) return []
+
+  const byVariant = new Map<string, RetrievalSignal>()
+  for (const signature of officialSignatures) {
+    const officialDuration = officialDurationMilliseconds(signature)
+    if (!officialDuration) continue
+
+    const score = durationScore(
+      uploadSignals.durationMilliseconds,
+      officialDuration,
+    )
+    if (score < MINIMUM_DURATION_SCORE) continue
+
+    const signal = {
+      coreId: signature.coreId,
+      videoVariantId: signature.videoVariantId,
+      durationScore: score,
+    }
+    const key = retrievalSignalKey(signal)
+    const existing = byVariant.get(key)
+    if (!existing || (existing.durationScore ?? 0) < score) {
+      byVariant.set(key, signal)
+    }
+  }
+
+  return [...byVariant.values()].sort(
+    (left, right) => (right.durationScore ?? 0) - (left.durationScore ?? 0),
+  )
+}
+
+function applySourceAnchors(
+  sourceSignals: RetrievalSignal[],
+  variantSignals: RetrievalSignal[],
+): RetrievalSignal[] {
+  const sourceAnchorByCoreId = new Map<string, number>()
+  for (const signal of sourceSignals) {
+    const score = signal.visualScore ?? 0
+    const existing = sourceAnchorByCoreId.get(signal.coreId) ?? 0
+    sourceAnchorByCoreId.set(signal.coreId, Math.max(score, existing))
+  }
+
+  return variantSignals.map((signal) => {
+    const sourceAnchor = sourceAnchorByCoreId.get(signal.coreId)
+    return sourceAnchor === undefined
+      ? signal
+      : { ...signal, visualScore: sourceAnchor }
+  })
+}
+
+function sourceAnchorSignature(
+  signature: MatchableMediaSignature,
+): TimecodedStringSignature[] {
+  if (
+    signature.signatureType !== "STRUCTURAL_HINT" &&
+    signature.signatureType !== "VISUAL_FRAME"
+  ) {
+    return []
+  }
+
+  return timecodedStringSignature(signature, sourceAnchorSignatureValue)
+}
+
+function timecodedStringSignature(
+  signature: MatchableMediaSignature,
+  valueExtractor: (signature: MatchableMediaSignature) => string | undefined,
+): TimecodedStringSignature[] {
+  const value = valueExtractor(signature)
+  if (!value) return []
+
+  return [
+    {
+      coreId: signature.coreId,
+      videoVariantId: signature.videoVariantId,
+      offsetMilliseconds: signature.offsetMilliseconds,
+      value,
+    },
+  ]
+}
+
+function sourceAnchorSignatureValue(
+  signature: MatchableMediaSignature,
+): string | undefined {
+  const payload = asRecord(signature.signature)
+  if (!payload) return undefined
+
+  const byteSample = asRecord(payload.byteSample)
+  return (
+    stringField(byteSample, "sha256") ??
+    stringField(payload, "sha256") ??
+    stringField(payload, "hash") ??
+    stringField(payload, "value")
+  )
+}
+
+function audioSignatureValue(
+  signature: MatchableMediaSignature,
+): string | undefined {
+  if (signature.signatureType !== "AUDIO_FINGERPRINT") return undefined
+
+  const payload = asRecord(signature.signature)
+  return (
+    stringField(payload, "fingerprint") ??
+    stringField(payload, "hash") ??
+    stringField(payload, "value")
+  )
+}
+
+function textSignatureValue(
+  signature: MatchableMediaSignature,
+): string | undefined {
+  if (signature.signatureType !== "TEXT_SEGMENT") return undefined
+
+  const payload = asRecord(signature.signature)
+  return stringField(payload, "text") ?? stringField(payload, "value")
+}
+
+function officialDurationMilliseconds(
+  signature: MatchableMediaSignature,
+): number | undefined {
+  if (signature.durationMilliseconds != null) {
+    return signature.durationMilliseconds
+  }
+
+  const lengthInMilliseconds = signature.catalogVariant.lengthInMilliseconds
+  if (lengthInMilliseconds != null) {
+    const asNumber = Number(lengthInMilliseconds)
+    if (Number.isSafeInteger(asNumber) && asNumber > 0) return asNumber
+  }
+
+  const durationSeconds = signature.catalogVariant.durationSeconds
+  return durationSeconds != null && durationSeconds > 0
+    ? durationSeconds * 1_000
+    : undefined
+}
+
+function durationScore(
+  uploadDurationMilliseconds: number,
+  officialDurationMilliseconds: number,
+): number {
+  const difference = Math.abs(
+    uploadDurationMilliseconds - officialDurationMilliseconds,
+  )
+  if (difference <= 1_000) return 1
+
+  const longest = Math.max(
+    uploadDurationMilliseconds,
+    officialDurationMilliseconds,
+  )
+  if (longest <= 0) return 0
+
+  return Math.max(0, 1 - difference / longest)
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function stringField(
+  record: Record<string, unknown> | undefined,
+  field: string,
+): string | undefined {
+  const value = record?.[field]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))]
+}
+
+function fromPrismaSignatureType(
+  signatureType: PrismaSignatureType,
+): MediaSignatureType {
+  const map = {
+    [PrismaSignatureType.VISUAL_FRAME]: "VISUAL_FRAME",
+    [PrismaSignatureType.AUDIO_FINGERPRINT]: "AUDIO_FINGERPRINT",
+    [PrismaSignatureType.TEXT_SEGMENT]: "TEXT_SEGMENT",
+    [PrismaSignatureType.STRUCTURAL_HINT]: "STRUCTURAL_HINT",
+  } satisfies Record<PrismaSignatureType, MediaSignatureType>
+
+  return map[signatureType]
+}

--- a/apps/yt-video-mapper-backend/src/services/retrieval/audio-retriever.ts
+++ b/apps/yt-video-mapper-backend/src/services/retrieval/audio-retriever.ts
@@ -1,5 +1,6 @@
 import {
   jaccardScore,
+  retrievalSignalKey,
   type RetrievalSignal,
   type TimecodedStringSignature,
 } from "./types.js"
@@ -18,9 +19,10 @@ export function retrieveAudioCandidates({
   const byVariant = new Map<string, TimecodedStringSignature[]>()
 
   for (const signature of officialAudioSignatures) {
-    const existing = byVariant.get(signature.videoVariantId) ?? []
+    const key = retrievalSignalKey(signature)
+    const existing = byVariant.get(key) ?? []
     existing.push(signature)
-    byVariant.set(signature.videoVariantId, existing)
+    byVariant.set(key, existing)
   }
 
   return Array.from(byVariant.values())

--- a/apps/yt-video-mapper-backend/src/services/retrieval/retrievers.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/retrieval/retrievers.test.ts
@@ -59,6 +59,24 @@ describe("retrievers", () => {
     ])
   })
 
+  it("keeps retrieval keyed by coreId and videoVariantId together", () => {
+    expect(
+      retrieveVisualCandidates({
+        uploadFrameHashes: ["a"],
+        officialFrameSignatures: [
+          signature("core-a", "shared-variant", "a"),
+          signature("core-b", "shared-variant", "z"),
+        ],
+      }),
+    ).toEqual([
+      {
+        coreId: "core-a",
+        videoVariantId: "shared-variant",
+        visualScore: 1,
+      },
+    ])
+  })
+
   it("scores audio fingerprint overlap by variant", () => {
     expect(
       retrieveAudioCandidates({

--- a/apps/yt-video-mapper-backend/src/services/retrieval/text-retriever.ts
+++ b/apps/yt-video-mapper-backend/src/services/retrieval/text-retriever.ts
@@ -1,5 +1,6 @@
 import {
   jaccardScore,
+  retrievalSignalKey,
   type RetrievalSignal,
   type TimecodedStringSignature,
 } from "./types.js"
@@ -19,9 +20,10 @@ export function retrieveTextCandidates({
   const byVariant = new Map<string, TimecodedStringSignature[]>()
 
   for (const signature of officialTextSignatures) {
-    const existing = byVariant.get(signature.videoVariantId) ?? []
+    const key = retrievalSignalKey(signature)
+    const existing = byVariant.get(key) ?? []
     existing.push(signature)
-    byVariant.set(signature.videoVariantId, existing)
+    byVariant.set(key, existing)
   }
 
   return Array.from(byVariant.values())

--- a/apps/yt-video-mapper-backend/src/services/retrieval/types.ts
+++ b/apps/yt-video-mapper-backend/src/services/retrieval/types.ts
@@ -35,7 +35,7 @@ export function mergeSignals(signals: RetrievalSignal[]): RetrievalSignal[] {
   const byVariant = new Map<string, RetrievalSignal>()
 
   for (const signal of signals) {
-    const key = `${signal.coreId}:${signal.videoVariantId}`
+    const key = retrievalSignalKey(signal)
     const existing = byVariant.get(key)
 
     if (!existing) {
@@ -53,6 +53,12 @@ export function mergeSignals(signals: RetrievalSignal[]): RetrievalSignal[] {
   }
 
   return Array.from(byVariant.values())
+}
+
+export function retrievalSignalKey(
+  signal: Pick<RetrievalSignal, "coreId" | "videoVariantId">,
+): string {
+  return `${signal.coreId}:${signal.videoVariantId}`
 }
 
 function maxOptional(

--- a/apps/yt-video-mapper-backend/src/services/retrieval/visual-retriever.ts
+++ b/apps/yt-video-mapper-backend/src/services/retrieval/visual-retriever.ts
@@ -1,5 +1,6 @@
 import {
   jaccardScore,
+  retrievalSignalKey,
   type RetrievalSignal,
   type TimecodedStringSignature,
 } from "./types.js"
@@ -18,9 +19,10 @@ export function retrieveVisualCandidates({
   const byVariant = new Map<string, TimecodedStringSignature[]>()
 
   for (const signature of officialFrameSignatures) {
-    const existing = byVariant.get(signature.videoVariantId) ?? []
+    const key = retrievalSignalKey(signature)
+    const existing = byVariant.get(key) ?? []
     existing.push(signature)
-    byVariant.set(signature.videoVariantId, existing)
+    byVariant.set(key, existing)
   }
 
   return Array.from(byVariant.values())

--- a/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.test.ts
@@ -94,6 +94,21 @@ Amen`),
     expect(signals.transcriptText).toBe("Peace be with you Amen")
     expect(binarySignals.transcriptText).toBeUndefined()
   })
+
+  it("normalizes subtitle markup without preserving tag delimiters", async () => {
+    const signals = await new DeterministicUploadSignalExtractor().extract({
+      bytes: Buffer.from(`WEBVTT
+
+00:00:01.000 --!> 00:00:03.000
+<v Speaker> Peace <script>alert(1)</script> be with you
+<unclosed Amen`),
+      contentType: "text/vtt",
+    })
+
+    expect(signals.transcriptText).toBe("Peace alert(1) be with you")
+    expect(signals.transcriptText).not.toContain("<")
+    expect(signals.transcriptText).not.toContain(">")
+  })
 })
 
 function mp4WithMvhd({

--- a/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest"
+import {
+  DeterministicUploadSignalExtractor,
+  UPLOAD_SIGNAL_ALGORITHM_VERSION,
+} from "./upload-signal-extraction.js"
+
+describe("DeterministicUploadSignalExtractor", () => {
+  it("emits deterministic byte sample hashes compatible with structural signatures", async () => {
+    const extractor = new DeterministicUploadSignalExtractor(4)
+    const first = await extractor.extract({
+      bytes: Buffer.from([1, 2, 3, 4, 5, 6]),
+      contentType: "video/mp4",
+    })
+    const second = await extractor.extract({
+      bytes: Buffer.from([1, 2, 3, 4, 9, 9]),
+      contentType: "video/mp4",
+    })
+
+    expect(first.sampledByteHashes).toEqual([
+      "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+    ])
+    expect(first.visualHashes).toEqual(first.sampledByteHashes)
+    expect(second.sampledByteHashes).toEqual(first.sampledByteHashes)
+    expect(first.byteSamples).toEqual([
+      {
+        kind: "byte_sample_v1",
+        sha256:
+          "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+        byteLength: 4,
+        rangeStart: 0,
+        rangeEnd: 3,
+        contentType: "video/mp4",
+        complete: false,
+      },
+    ])
+    expect(first.algorithmVersion).toBe(UPLOAD_SIGNAL_ALGORITHM_VERSION)
+  })
+
+  it("changes byte sample hashes when the sampled bytes differ", async () => {
+    const extractor = new DeterministicUploadSignalExtractor(4)
+
+    const first = await extractor.extract({
+      bytes: Buffer.from([1, 2, 3, 4]),
+      contentType: "video/mp4",
+    })
+    const second = await extractor.extract({
+      bytes: Buffer.from([4, 3, 2, 1]),
+      contentType: "video/mp4",
+    })
+
+    expect(second.sampledByteHashes).not.toEqual(first.sampledByteHashes)
+  })
+
+  it("extracts MP4 mvhd duration when present", async () => {
+    const signals = await new DeterministicUploadSignalExtractor().extract({
+      bytes: mp4WithMvhd({ timescale: 1_000, duration: 12_345 }),
+      contentType: "video/mp4; charset=binary",
+    })
+
+    expect(signals.durationMilliseconds).toBe(12_345)
+  })
+
+  it("emits structural fingerprints for unsupported binary content without fake audio", async () => {
+    const signals = await new DeterministicUploadSignalExtractor().extract({
+      bytes: Buffer.from("opaque-video-bytes"),
+      contentType: "application/octet-stream",
+    })
+
+    expect(signals.sampledByteHashes).toHaveLength(1)
+    expect(signals.durationMilliseconds).toBeUndefined()
+    expect(signals.transcriptText).toBeUndefined()
+    expect(signals.audioFingerprints).toEqual([])
+  })
+
+  it("extracts normalized transcript text only for subtitle inputs", async () => {
+    const signals = await new DeterministicUploadSignalExtractor().extract({
+      bytes: Buffer.from(`WEBVTT
+
+1
+00:00:01.000 --> 00:00:03.000
+<v Speaker> Peace   be with you
+
+NOTE hidden cue
+00:00:04.000 --> 00:00:05.000
+Amen`),
+      contentType: "text/vtt",
+    })
+    const binarySignals =
+      await new DeterministicUploadSignalExtractor().extract({
+        bytes: Buffer.from("Peace be with you"),
+        contentType: "video/mp4",
+      })
+
+    expect(signals.transcriptText).toBe("Peace be with you Amen")
+    expect(binarySignals.transcriptText).toBeUndefined()
+  })
+})
+
+function mp4WithMvhd({
+  timescale,
+  duration,
+}: {
+  timescale: number
+  duration: number
+}): Buffer {
+  const mvhdPayload = Buffer.alloc(100)
+  mvhdPayload.writeUInt8(0, 0)
+  mvhdPayload.writeUInt32BE(timescale, 12)
+  mvhdPayload.writeUInt32BE(duration, 16)
+
+  return Buffer.concat([
+    box("ftyp", Buffer.from("isom")),
+    box("moov", box("mvhd", mvhdPayload)),
+  ])
+}
+
+function box(type: string, payload: Buffer): Buffer {
+  const header = Buffer.alloc(8)
+  header.writeUInt32BE(payload.byteLength + header.byteLength, 0)
+  header.write(type, 4, 4, "ascii")
+  return Buffer.concat([header, payload])
+}

--- a/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.ts
+++ b/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.ts
@@ -1,8 +1,28 @@
+import { createHash } from "node:crypto"
+
+export const UPLOAD_SIGNAL_ALGORITHM_VERSION = "official-media-signature-v1"
+const DEFAULT_SAMPLE_BYTES = 262_144
+
+export type UploadByteSample = {
+  kind: "byte_sample_v1"
+  sha256: string
+  byteLength: number
+  rangeStart: number
+  rangeEnd: number
+  contentType?: string
+  complete: boolean
+}
+
 export type UploadSignals = {
   visualHashes: string[]
   audioFingerprints: string[]
+  sampledByteHashes?: string[]
+  byteSamples?: UploadByteSample[]
   transcriptText?: string
   durationMilliseconds?: number
+  byteLength?: number
+  contentType?: string
+  algorithmVersion?: string
 }
 
 export type UploadSignalExtractionInput = {
@@ -14,11 +34,194 @@ export type UploadSignalExtractor = {
   extract(input: UploadSignalExtractionInput): Promise<UploadSignals>
 }
 
-export class PlaceholderUploadSignalExtractor implements UploadSignalExtractor {
-  async extract(): Promise<UploadSignals> {
+export class DeterministicUploadSignalExtractor implements UploadSignalExtractor {
+  constructor(private readonly sampleBytes = DEFAULT_SAMPLE_BYTES) {}
+
+  async extract({
+    bytes,
+    contentType,
+  }: UploadSignalExtractionInput): Promise<UploadSignals> {
+    const byteSamples = buildByteSamples(bytes, contentType, this.sampleBytes)
+    const sampledByteHashes = byteSamples.map((sample) => sample.sha256)
+
     return {
-      visualHashes: [],
+      visualHashes: sampledByteHashes,
       audioFingerprints: [],
+      sampledByteHashes,
+      byteSamples,
+      transcriptText: extractTranscriptText(bytes, contentType),
+      durationMilliseconds: extractDurationMilliseconds(bytes, contentType),
+      byteLength: bytes.byteLength,
+      contentType,
+      algorithmVersion: UPLOAD_SIGNAL_ALGORITHM_VERSION,
     }
   }
+}
+
+function buildByteSamples(
+  bytes: Buffer,
+  contentType: string,
+  sampleBytes: number,
+): UploadByteSample[] {
+  if (bytes.byteLength === 0 || sampleBytes <= 0) return []
+
+  const endExclusive = Math.min(bytes.byteLength, sampleBytes)
+  const sample = bytes.subarray(0, endExclusive)
+
+  return [
+    {
+      kind: "byte_sample_v1",
+      sha256: sha256Hex(sample),
+      byteLength: sample.byteLength,
+      rangeStart: 0,
+      rangeEnd: sample.byteLength - 1,
+      contentType,
+      complete: sample.byteLength === bytes.byteLength,
+    },
+  ]
+}
+
+function extractDurationMilliseconds(
+  bytes: Buffer,
+  contentType: string,
+): number | undefined {
+  if (!isMp4ContentType(contentType)) return undefined
+
+  return parseMp4DurationMilliseconds(bytes)
+}
+
+function parseMp4DurationMilliseconds(bytes: Buffer): number | undefined {
+  const mvhd = findMp4Box(bytes, "mvhd", 0, bytes.byteLength)
+  if (!mvhd) return undefined
+
+  const version = bytes.readUInt8(mvhd.start)
+  if (version === 0) {
+    if (mvhd.end - mvhd.start < 20) return undefined
+    const timescale = bytes.readUInt32BE(mvhd.start + 12)
+    const duration = bytes.readUInt32BE(mvhd.start + 16)
+    return durationToMilliseconds(duration, timescale)
+  }
+
+  if (version === 1) {
+    if (mvhd.end - mvhd.start < 32) return undefined
+    const timescale = bytes.readUInt32BE(mvhd.start + 20)
+    const duration = bytes.readBigUInt64BE(mvhd.start + 24)
+    return durationToMilliseconds(duration, timescale)
+  }
+
+  return undefined
+}
+
+function findMp4Box(
+  bytes: Buffer,
+  wantedType: string,
+  start: number,
+  end: number,
+): { start: number; end: number } | undefined {
+  let offset = start
+
+  while (offset + 8 <= end) {
+    const size = bytes.readUInt32BE(offset)
+    const type = bytes.toString("ascii", offset + 4, offset + 8)
+    let headerBytes = 8
+    let boxEnd: number
+
+    if (size === 1) {
+      if (offset + 16 > end) return undefined
+      const largeSize = bytes.readBigUInt64BE(offset + 8)
+      if (largeSize > BigInt(Number.MAX_SAFE_INTEGER)) return undefined
+      headerBytes = 16
+      boxEnd = offset + Number(largeSize)
+    } else if (size === 0) {
+      boxEnd = end
+    } else {
+      boxEnd = offset + size
+    }
+
+    if (boxEnd <= offset + headerBytes || boxEnd > end) return undefined
+
+    const payload = { start: offset + headerBytes, end: boxEnd }
+    if (type === wantedType) return payload
+
+    if (isMp4ContainerBox(type)) {
+      const nested = findMp4Box(bytes, wantedType, payload.start, payload.end)
+      if (nested) return nested
+    }
+
+    offset = boxEnd
+  }
+
+  return undefined
+}
+
+function isMp4ContainerBox(type: string): boolean {
+  return new Set(["moov", "trak", "mdia", "minf", "stbl", "edts"]).has(type)
+}
+
+function durationToMilliseconds(
+  duration: number | bigint,
+  timescale: number,
+): number | undefined {
+  if (timescale <= 0) return undefined
+
+  const durationNumber =
+    typeof duration === "bigint" ? Number(duration) : duration
+  if (!Number.isSafeInteger(durationNumber) || durationNumber <= 0) {
+    return undefined
+  }
+
+  return Math.round((durationNumber / timescale) * 1_000)
+}
+
+function extractTranscriptText(
+  bytes: Buffer,
+  contentType: string,
+): string | undefined {
+  if (!isSubtitleContentType(contentType)) return undefined
+
+  const normalized = normalizeSubtitleText(bytes.toString("utf8"))
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function normalizeSubtitleText(value: string): string {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !/^WEBVTT(?:\s|$)/i.test(line))
+    .filter((line) => !/^\d+$/.test(line))
+    .filter((line) => !/-->/.test(line))
+    .filter((line) => !/^NOTE(?:\s|$)/i.test(line))
+    .map((line) => line.replace(/<[^>]*>/g, ""))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 4_000)
+}
+
+function isMp4ContentType(contentType: string): boolean {
+  const normalized = normalizeContentType(contentType)
+  return (
+    normalized === "video/mp4" ||
+    normalized === "audio/mp4" ||
+    normalized === "application/mp4"
+  )
+}
+
+function isSubtitleContentType(contentType: string): boolean {
+  const normalized = normalizeContentType(contentType)
+  return (
+    normalized === "text/vtt" ||
+    normalized === "application/x-subrip" ||
+    normalized === "application/srt" ||
+    normalized === "text/srt"
+  )
+}
+
+function normalizeContentType(contentType: string): string {
+  return contentType.split(";")[0]?.trim().toLowerCase() ?? ""
+}
+
+function sha256Hex(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex")
 }

--- a/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.ts
+++ b/apps/yt-video-mapper-backend/src/services/upload-signal-extraction.ts
@@ -190,13 +190,42 @@ function normalizeSubtitleText(value: string): string {
     .filter((line) => line.length > 0)
     .filter((line) => !/^WEBVTT(?:\s|$)/i.test(line))
     .filter((line) => !/^\d+$/.test(line))
-    .filter((line) => !/-->/.test(line))
+    .filter((line) => !isCueTimingLine(line))
     .filter((line) => !/^NOTE(?:\s|$)/i.test(line))
-    .map((line) => line.replace(/<[^>]*>/g, ""))
+    .map(removeSubtitleMarkup)
     .join(" ")
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, 4_000)
+}
+
+function isCueTimingLine(line: string): boolean {
+  return line.includes("-->") || line.includes("--!>")
+}
+
+function removeSubtitleMarkup(line: string): string {
+  let plainText = ""
+  let insideMarkup = false
+
+  for (const character of line) {
+    if (character === "<") {
+      insideMarkup = true
+      plainText += " "
+      continue
+    }
+
+    if (insideMarkup) {
+      if (character === ">") {
+        insideMarkup = false
+        plainText += " "
+      }
+      continue
+    }
+
+    plainText += character
+  }
+
+  return plainText
 }
 
 function isMp4ContentType(contentType: string): boolean {

--- a/docs/plans/2026-06-11-002-feat-ytm-005-real-matcher-plan.md
+++ b/docs/plans/2026-06-11-002-feat-ytm-005-real-matcher-plan.md
@@ -1,0 +1,250 @@
+---
+title: "feat: Replace mapper placeholder matching with real matcher"
+type: feat
+date: 2026-06-11
+origin: apps/yt-video-mapper-backend/docs/brainstorms/video-source-mapper-requirements.md
+ticket: docs/prototypes/yt-video-mapper/tickets/ytm-005-replace-placeholders-with-real-matcher.md
+---
+
+# feat: Replace mapper placeholder matching with real matcher
+
+## Summary
+
+Replace the YTM prototype placeholder path with a deterministic first matcher
+that extracts uploaded-video signals, retrieves against local mapper
+`MediaSignature` and `CatalogVariant` rows, fuses evidence by
+`coreId + videoVariantId`, and keeps the public `/match-jobs` response limited
+to ranked candidates.
+
+---
+
+## Problem Frame
+
+YTM-003 and YTM-004 made Admin catalog metadata and official media signatures
+available inside the mapper database. The public Railway service still cannot
+attribute uploads because the default server wires `PlaceholderUploadSignalExtractor`
+and `NoopMatcher`. YTM-005 should make the production path use real local
+catalog and index data while staying modest: no YTM-006 evaluation harness, no
+fake audio fingerprints, no evidence fields in the public API, and no metadata
+search as the matching foundation.
+
+---
+
+## Requirements
+
+- R1. The default production server no longer wires `PlaceholderUploadSignalExtractor`
+  or `NoopMatcher`.
+- R2. Upload signal extraction is deterministic, versioned, and compatible with
+  YTM-004 `official-media-signature-v1` structural and text payloads.
+- R3. Uploaded signal extraction records duration and structural hints when the
+  bytes or content type make that feasible.
+- R4. Uploaded signal extraction emits sampled byte/media fingerprints, and
+  transcript text only when source text exists.
+- R5. The matcher retrieves candidates from mapper-owned `MediaSignature` rows
+  joined to active `CatalogVariant` rows.
+- R6. Candidate fusion remains keyed by `coreId + videoVariantId`.
+- R7. Visual or structural source evidence remains the source-video anchor;
+  audio, text, language, and duration evidence rank variants without overriding
+  weak source evidence.
+- R8. Weak or missing visual/structural evidence cannot produce
+  `matchStrength: high` without an intentional threshold change.
+- R9. Public match results expose only `coreId`, `videoVariantId`, `confidence`,
+  and `matchStrength`.
+- R10. Tests cover extraction, seeded official signature retrieval,
+  visual/audio/text disagreement, correct fused composite-variant ranking, weak
+  evidence thresholds, and route/service integration using the real matcher.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Reuse the YTM-004 v1 signature contract as the first matcher surface.
+  The official index currently emits honest structural byte-sample signatures
+  and optional text signatures; YTM-005 should compare against those instead of
+  pretending to have frame or audio fingerprints.
+- KTD2. Treat byte-sample and duration overlap as the v1 source anchor. The
+  existing fusion scorer already uses `visualScore` as the source anchor, so the
+  real matcher may feed structural byte-sample agreement into that anchor while
+  naming the internal evidence as structural.
+- KTD3. Keep audio optional and absent by default. `audioFingerprints` stay in
+  the type for future real extractors and for tests with seeded data, but the
+  default upload extractor must not synthesize audio.
+- KTD4. Put production retrieval behind a service/repository boundary. Server
+  wiring should compose `MatchJobService`, upload storage, extractor, and a
+  Prisma-backed matcher; route handlers should remain thin.
+- KTD5. Keep detailed evidence internal. Retrieval signals and evidence details
+  may be returned inside service-layer types for future debugging, but
+  `MatchJobRepository.replaceCandidates` and route responses continue storing
+  and returning only public candidates in this slice.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  upload["Uploaded media bytes"] --> extract["Deterministic upload signal extractor"]
+  extract --> signals["UploadSignals: byte samples, duration, optional text/audio"]
+  signatures["MediaSignature rows"] --> repo["Matcher repository"]
+  variants["CatalogVariant rows"] --> repo
+  repo --> retrieval["Structural / audio / text / duration retrieval"]
+  signals --> retrieval
+  retrieval --> fusion["Fusion scorer keyed by coreId + videoVariantId"]
+  fusion --> public["Public candidates only"]
+```
+
+The first production matcher compares uploaded signals to local mapper data.
+The route still owns upload buffering and job polling, the service owns job
+state transitions, and the matcher owns retrieval plus fusion.
+
+---
+
+## Implementation Units
+
+### U1. Ticket State And Extractor Contract
+
+- **Goal:** Replace placeholder extraction with a deterministic upload signal
+  contract aligned to YTM-004.
+- **Requirements:** R2, R3, R4.
+- **Files:** `docs/prototypes/yt-video-mapper/tickets/ytm-005-replace-placeholders-with-real-matcher.md`, `apps/yt-video-mapper-backend/src/services/upload-signal-extraction.ts`, `apps/yt-video-mapper-backend/src/services/upload-signal-extraction.test.ts`.
+- **Approach:** Rename or replace the placeholder class with a real extractor
+  that hashes bounded byte samples, records upload byte length and content type
+  as structural hints, parses duration only where a lightweight local parser can
+  do so safely, and extracts transcript text only for text subtitle inputs such
+  as VTT/SRT. Keep the extractor version constant near the official signature
+  version. Do not emit audio fingerprints without a real audio extractor.
+- **Test scenarios:** identical bytes produce identical sample hashes; different
+  bytes produce different hashes; MP4 or supported fixture bytes produce a
+  duration when parseable; unsupported binary bytes still produce structural
+  fingerprints; text subtitle content produces normalized transcript text;
+  default extraction emits no fake audio fingerprints.
+- **Verification:** Unit tests prove deterministic extraction without external
+  media binaries.
+
+### U2. Repository-Backed Signature Retrieval
+
+- **Goal:** Load comparable official signatures and catalog variant metadata
+  from mapper-owned data.
+- **Requirements:** R5, R6, R7.
+- **Files:** `apps/yt-video-mapper-backend/src/services/retrieval/types.ts`, `apps/yt-video-mapper-backend/src/services/retrieval/visual-retriever.ts`, `apps/yt-video-mapper-backend/src/services/retrieval/audio-retriever.ts`, `apps/yt-video-mapper-backend/src/services/retrieval/text-retriever.ts`, `apps/yt-video-mapper-backend/src/services/retrieval/retrievers.test.ts`, `apps/yt-video-mapper-backend/src/services/media-signature-matcher.ts`, `apps/yt-video-mapper-backend/src/services/media-signature-matcher.test.ts`.
+- **Approach:** Add a matcher repository interface that returns active
+  `MediaSignature` rows for the configured algorithm version with their
+  `coreId`, `videoVariantId`, signature type, offset, duration, payload, and
+  variant duration/language metadata. Project structural byte-sample payloads
+  into source-anchor retrieval signals, project optional text/audio signatures
+  through existing retrievers, and compute duration score from upload duration
+  versus signature or variant duration.
+- **Test scenarios:** seeded structural `MediaSignature` rows retrieve the
+  correct composite candidate; text signatures rank the matching variant under
+  the same source; audio signatures participate only when both upload and
+  official data exist; retrieval does not merge candidates that share
+  `videoVariantId` under different `coreId` values; non-indexable or deleted
+  variants are skipped.
+- **Verification:** Retriever and matcher tests use production-shaped signature
+  fixtures instead of ad hoc placeholder arrays.
+
+### U3. Real Matcher And Fusion Guardrails
+
+- **Goal:** Fuse retrieved signals into the existing public candidate shape with
+  source-anchor guardrails intact.
+- **Requirements:** R6, R7, R8, R9, R10.
+- **Files:** `apps/yt-video-mapper-backend/src/services/media-signature-matcher.ts`, `apps/yt-video-mapper-backend/src/services/fusion-scorer.ts`, `apps/yt-video-mapper-backend/src/services/fusion-scorer.test.ts`, `apps/yt-video-mapper-backend/src/services/match-job.service.test.ts`.
+- **Approach:** Implement a `MediaSignatureMatcher` that calls the retrieval
+  repository, builds retrieval signals, delegates confidence and strength to
+  `fuseRankedCandidates`, and returns only `PublicMatchCandidate[]`. Preserve
+  the existing non-visual cap unless tests expose a threshold bug. Add focused
+  disagreement tests where source-anchor evidence points to one candidate while
+  audio/text points elsewhere; the anchored candidate should win or the
+  unanchored candidate should remain below high strength.
+- **Test scenarios:** visual/structural and text/audio agreement returns the
+  expected top `coreId + videoVariantId`; disagreement favors the candidate
+  with source-anchor evidence; weak text-only or audio-only evidence cannot
+  return `high`; output keys are exactly the public four-field shape.
+- **Verification:** Fusion tests and matcher tests cover the threshold behavior
+  before route integration.
+
+### U4. Production Server Wiring And Integration
+
+- **Goal:** Make `/match-jobs` use the real extractor and matcher by default.
+- **Requirements:** R1, R5, R9, R10.
+- **Files:** `apps/yt-video-mapper-backend/src/server.ts`, `apps/yt-video-mapper-backend/src/services/match-job.service.ts`, `apps/yt-video-mapper-backend/src/routes/match-jobs.test.ts`, `apps/yt-video-mapper-backend/src/server.test.ts`.
+- **Approach:** Replace default server construction with
+  `DeterministicUploadSignalExtractor` and a Prisma-backed
+  `MediaSignatureMatcher`. Keep dependency injection for tests and custom
+  callers. Add an integration test that creates a job with the real extractor
+  and matcher over seeded official data, processes it, and observes non-empty
+  public candidates. Add a server-level regression that the default production
+  factory no longer imports or instantiates `NoopMatcher`.
+- **Test scenarios:** processing an uploaded sample returns candidates from
+  seeded official signatures; route responses still omit evidence; worker
+  process endpoint completes with the real matcher; default wiring references
+  the real classes.
+- **Verification:** Route/service integration proves the placeholder path is no
+  longer the default path.
+
+### U5. Operational Documentation And Production Steps
+
+- **Goal:** Document required deployment data steps without leaking secrets or
+  adding unnecessary env requirements.
+- **Requirements:** R1, R5.
+- **Files:** `apps/yt-video-mapper-backend/docs/railway-deployment.md`, `apps/yt-video-mapper-backend/README.md`, `docs/prototypes/yt-video-mapper/tickets/ytm-005-replace-placeholders-with-real-matcher.md`.
+- **Approach:** Document that after merge/deploy operators should run
+  `db:migrate:deploy`, `sync:catalog`, `index:media`, and an authenticated
+  `/match-jobs` smoke against indexed data. Use the Railway project-scoped
+  reference only if production env vars need to be set or verified. Do not print
+  or commit `ADMIN_SERVICE_BEARER_TOKEN`, mapper tokens, signed URLs, or large
+  media payloads.
+- **Test scenarios:** Documentation-only updates have no direct unit tests.
+- **Verification:** Final verification commands pass, and any unrun production
+  data steps are documented explicitly.
+
+---
+
+## Scope Boundaries
+
+- In scope: upload signal extraction, repository-backed retrieval, real matcher
+  wiring, fusion guardrails, tests, ticket state, and operator notes.
+- Deferred to YTM-006: labeled evaluation harness, threshold calibration
+  against a validation set, precision/recall reporting, and broad confidence
+  tuning.
+- Deferred to later work: real audio fingerprint libraries, real visual frame
+  extraction through ffmpeg or another selected local media library, queue
+  workers, evidence-debugging public or operator APIs, and long-term uploaded
+  media retention.
+- Out of scope: Admin catalog schema changes, direct Admin database reads,
+  Core API calls from the mapper, and public evidence response expansion.
+
+---
+
+## Risks & Dependencies
+
+- **Sparse v1 signatures:** The official v1 index is intentionally structural
+  and may only return matches for uploads whose byte samples overlap indexed
+  media samples. Keep confidence guarded and avoid overclaiming.
+- **Duration parsing limits:** Lightweight binary parsing may fail on many
+  media files. Treat duration as optional evidence, not a required input.
+- **Catalog/index freshness:** Real matching depends on `sync:catalog` and
+  `index:media` having populated mapper tables after deployment.
+- **Secret leakage:** Match and indexing errors must continue redacting bearer
+  tokens, signed URL query strings, and large payloads.
+
+---
+
+## Sources & Research
+
+- `apps/yt-video-mapper-backend/docs/brainstorms/video-source-mapper-requirements.md`
+  defines the source-first, Core-facing matcher behavior.
+- `docs/prototypes/yt-video-mapper/tickets/ytm-005-replace-placeholders-with-real-matcher.md`
+  defines YTM-005 scope and acceptance.
+- `docs/plans/2026-06-10-005-feat-official-media-signature-indexing-plan.md`
+  defers final matching from YTM-004 into this slice.
+- `docs/solutions/architecture-patterns/mapper-official-media-signature-indexing-pattern.md`
+  establishes the honest v1 signature contract and safe media indexing posture.
+- `docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md`
+  establishes the async job surface, public candidate shape, and visual-anchor
+  fusion guardrail.
+- `apps/yt-video-mapper-backend/src/server.ts`,
+  `apps/yt-video-mapper-backend/src/services/match-job.service.ts`,
+  `apps/yt-video-mapper-backend/src/services/upload-signal-extraction.ts`, and
+  `apps/yt-video-mapper-backend/src/services/fusion-scorer.ts` contain the
+  placeholder path and existing fusion boundary to replace.

--- a/docs/prototypes/yt-video-mapper/tickets/ytm-005-replace-placeholders-with-real-matcher.md
+++ b/docs/prototypes/yt-video-mapper/tickets/ytm-005-replace-placeholders-with-real-matcher.md
@@ -1,7 +1,7 @@
 ---
 id: YTM-005
 title: "Replace placeholder extraction and NoopMatcher with real matcher"
-status: todo
+status: complete
 priority: P1
 depends_on:
   - YTM-003

--- a/docs/solutions/architecture-patterns/mapper-real-match-job-signature-retrieval-pattern.md
+++ b/docs/solutions/architecture-patterns/mapper-real-match-job-signature-retrieval-pattern.md
@@ -1,0 +1,155 @@
+---
+title: "Mapper real match job signature retrieval pattern"
+date: 2026-06-11
+category: architecture-patterns
+module: "apps/yt-video-mapper-backend"
+problem_type: architecture_pattern
+component: service_object
+severity: medium
+applies_when:
+  - "Replacing a placeholder mapper with real local signature retrieval"
+  - "Uploaded media signals need to be compared against mapper-owned MediaSignature rows"
+  - "A matcher must keep source-video evidence separate from variant-ranking evidence"
+  - "Public candidates must stay limited while internal evidence can evolve"
+tags:
+  - yt-video-mapper
+  - media-signatures
+  - match-jobs
+  - retrieval
+  - fusion-scoring
+  - source-anchor
+related_components:
+  - database
+  - background_job
+  - testing_framework
+---
+
+# Mapper real match job signature retrieval pattern
+
+## Context
+
+YTM-005 replaced the prototype `NoopMatcher` and placeholder upload extractor
+with a deterministic matcher over local mapper data. Earlier slices already
+created the Mapper Catalog projection and official `MediaSignature` index, so
+the missing step was the live bridge from uploaded media bytes to ranked
+`coreId + videoVariantId` candidates.
+
+The tempting shortcut is to treat every matching signal as variant evidence and
+let fusion choose the highest single row. That breaks the product model:
+visual or structural evidence usually proves the source video, while audio,
+text, and language evidence choose the likely variant under that source.
+
+## Guidance
+
+Wire production matching as service-layer composition:
+
+```text
+uploaded bytes
+  -> deterministic upload signal extraction
+  -> repository-backed MediaSignature retrieval
+  -> source-anchor and variant-ranking signal projection
+  -> fusion keyed by coreId + videoVariantId
+  -> public candidates only
+```
+
+Keep the upload extractor honest and version-aligned with the official
+signature algorithm. For the first deterministic slice, bounded byte-sample
+hashes and parseable duration are real structural evidence. Subtitle text is
+real evidence only when the uploaded source is text. Audio fingerprints should
+remain absent until a real local extractor or library is selected.
+
+Retrieve official signatures through a repository that has already filtered by
+algorithm version and active `CatalogVariant` rows. Project structural
+byte-sample signatures into source-anchor retrieval. Project text and audio
+signatures into variant-ranking retrieval only when the upload also has that
+signal family. Compute duration as supporting structure, not as a source proof.
+
+Use `coreId + videoVariantId` everywhere a signal, signature, candidate, or
+fusion row is grouped. `videoVariantId` alone is not enough because the matcher
+must never merge evidence from two source videos that happen to expose the same
+variant-looking identifier.
+
+When source-anchor evidence identifies a `coreId`, propagate that source anchor
+to strong text or audio evidence under the same `coreId` so the variant can win.
+Do not propagate the anchor across source videos. Do not let weak same-source
+variant evidence suppress an exact source-only fallback; keep a threshold before
+variant evidence replaces the fallback row.
+
+Keep the public boundary narrow. Matchers may calculate or retain detailed
+evidence internally for future debugging surfaces, but route responses and
+stored public candidates should expose only:
+
+```json
+{
+  "coreId": "core-video-id",
+  "videoVariantId": "core-video-variant-id",
+  "confidence": 0.913,
+  "matchStrength": "high"
+}
+```
+
+## Why This Matters
+
+The mapper's answer has two levels. The source video is the analytics anchor,
+and the variant is the likely Dub or language-specific media row. If the matcher
+lets text-only or audio-only evidence create high-strength candidates without
+source support, it can confidently attribute to the wrong source. If it treats
+visual evidence as variant-only, it can miss the correct variant when dialogue
+or subtitles point to another Dub under the same source.
+
+Keeping retrieval local to mapper-owned catalog and signature rows also
+preserves the source-of-truth boundary. Admin remains authoritative for catalog
+metadata, while the mapper owns the match index, match jobs, and confidence
+logic.
+
+## When to Apply
+
+- Replacing a placeholder matcher with a first production matcher over local
+  signatures.
+- Adding a new signal family to the video mapper and deciding whether it is
+  source-anchor evidence or variant-ranking evidence.
+- Reviewing matcher code that groups, merges, or fuses candidates.
+- Testing disagreement cases where visual or structural evidence conflicts with
+  text or audio.
+
+## Examples
+
+Good matcher shape:
+
+```text
+source anchors:
+  structural byte sample -> core-a / variant-en
+
+variant evidence:
+  transcript overlap -> core-a / variant-es
+
+fusion:
+  propagate core-a source anchor to variant-es
+  rank core-a / variant-es above the source-only fallback
+```
+
+Good guardrail test cases:
+
+- An uploaded sample with matching structural signatures returns a non-empty
+  candidate from seeded official signatures.
+- Shared `videoVariantId` values under different `coreId` values do not merge.
+- Text or audio from a different `coreId` cannot outrank strong source-anchor
+  evidence.
+- Text-only or audio-only evidence is capped below high strength.
+- Weak same-source variant evidence does not replace an exact source fallback.
+
+Avoid these shortcuts:
+
+- Defaulting the production server to a no-op matcher or placeholder extractor.
+- Treating metadata search as the source of attribution.
+- Generating fake audio fingerprints to make a sparse matcher look multimodal.
+- Grouping retrieval or fusion by `videoVariantId` without `coreId`.
+- Exposing internal evidence in the public response before the API contract
+  calls for it.
+
+## Related
+
+- [Mapper official media signature indexing pattern](./mapper-official-media-signature-indexing-pattern.md)
+- [Mapper Admin catalog sync local projection pattern](./mapper-admin-catalog-sync-local-projection-pattern.md)
+- [yt-video-mapper backend app durable match job upload poll process pattern](../platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md)
+- [Mocked-vs-real testing discipline](../best-practices/mocked-shape-vs-real-contract-discipline-20260506.md)


### PR DESCRIPTION
## Summary
YTM-005 makes `/match-jobs` rank candidates from real mapper catalog and media signature data instead of the prototype placeholder path. Uploaded samples now produce deterministic structural/source-anchor signals that can retrieve indexed `MediaSignature` rows, while text, audio, and language evidence remain variant-ranking signals behind the source-anchor guard.

## Design Notes
- The production server default now wires `DeterministicUploadSignalExtractor` and `MediaSignatureMatcher`, replacing both `PlaceholderUploadSignalExtractor` and `NoopMatcher`.
- The first extractor version emits compatible byte sample hashes, structural metadata, optional MP4 duration hints, and transcript text only when subtitle-like source data exists. It does not invent audio fingerprints.
- Retrieval reads real `MediaSignature` plus indexable `CatalogVariant` data and fuses candidates by `coreId + videoVariantId`.
- Weak or missing visual/structural evidence cannot accidentally produce a high-strength match; audio/text/language evidence can refine variant ranking only after the source anchor is strong enough.
- The public candidate response remains limited to `coreId`, `videoVariantId`, `confidence`, and `matchStrength`; detailed evidence stays internal for later debugging surfaces.

## Production Follow-Up
After merge/deploy, run the normal production data steps: migrate deploy, `sync:catalog`, `index:media`, then an authenticated `/match-jobs` smoke against indexed official data. The public unauthenticated API probe passed health and auth checks, but no authenticated smoke was run because no local `MAPPER_API_TOKEN` was present.

## Verification
- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- `pnpm --filter @forge/yt-video-mapper-backend build`
- `git diff --check`
- `ce-code-review`: no findings after the review-time threshold/fallback fix
- `ce-compound`: added the real match job signature retrieval pattern note

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
