### PR TITLE
feat(web): add Datadog RUM for Watch

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -38,6 +38,18 @@ WEB_AUTH_BASE_URL=http://localhost:3004
 # https://www.jesusfilm.org/watch/...
 NEXT_PUBLIC_CANONICAL_ORIGIN=https://www.jesusfilm.org
 
+## Datadog RUM ##
+# Optional browser RUM. Initialization is disabled unless application id and
+# client token are both configured. Site defaults to datadoghq.com; env/version
+# fall back to Railway/Vercel/Git envs when present.
+NEXT_PUBLIC_DATADOG_APPLICATION_ID=
+NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=
+NEXT_PUBLIC_DATADOG_SITE=datadoghq.com
+NEXT_PUBLIC_DATADOG_ENV=development
+NEXT_PUBLIC_DATADOG_VERSION=
+# Required only when running `pnpm datadog:sourcemaps` after a production build.
+DATADOG_API_KEY=
+
 ## Feature flags ##
 # Optional LaunchDarkly server-side SDK key. When unset, web falls back to the
 # local defaults below and existing NEXT_PUBLIC_* build-time flags.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -23,6 +23,9 @@ const nextConfig = {
   compress: true,
   // typedRoutes moved to top-level in Next 16 (stable).
   typedRoutes: true,
+  // Datadog RUM source-map uploads need production browser maps available
+  // after `next build`; uploads stay opt-in via `pnpm datadog:sourcemaps`.
+  productionBrowserSourceMaps: true,
   async rewrites() {
     return {
       beforeFiles: [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "pnpm run generate:ui-locales && tsc --noEmit",
     "test": "pnpm run generate:ui-locales && vitest run",
     "test:watch": "pnpm run generate:ui-locales && vitest",
+    "datadog:sourcemaps": "pnpm dlx @datadog/datadog-ci@5.8.0 sourcemaps upload .next/static --service=watch --release-version=${DATADOG_RELEASE_VERSION:-${NEXT_PUBLIC_DATADOG_VERSION:-${RAILWAY_GIT_COMMIT_SHA:-${VERCEL_GIT_COMMIT_SHA:-$GIT_COMMIT_SHA}}}} --minified-path-prefix=/watch/_next/static/",
     "prune:next-isr": "node scripts/prune-next-isr-output.mjs",
     "generate:provisional-ui-catalogs": "node scripts/generate-provisional-ui-catalogs.mjs",
     "check:provisional-ui-catalogs": "node scripts/generate-provisional-ui-catalogs.mjs --check",
@@ -22,6 +23,8 @@
   "dependencies": {
     "@apollo/client": "^4.1.4",
     "@base-ui/react": "^1.2.0",
+    "@datadog/browser-rum": "^7.2.0",
+    "@datadog/browser-rum-react": "^7.2.0",
     "@forge/admin-graphql": "workspace:*",
     "@forge/feature-flags": "workspace:*",
     "@forge/video-player": "workspace:*",

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/error.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react"
 
+import { reportDatadogRumError } from "@/components/DatadogRum"
 import { ExperienceError } from "@/components/ExperienceError"
 
 // Last-line fallback for unexpected render-time errors. Resolver errors are
@@ -14,6 +15,7 @@ export default function WatchPageError({
   reset: () => void
 }) {
   useEffect(() => {
+    reportDatadogRumError(error, { boundary: "watch-page" })
     if (process.env.NODE_ENV !== "production") {
       console.error("[watch-page] error boundary caught:", error)
     }

--- a/apps/web/src/app/[locale]/[htmlLang]/error.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react"
 
+import { reportDatadogRumError } from "@/components/DatadogRum"
 import { ExperienceError } from "@/components/ExperienceError"
 
 // Segment-level fallback for unexpected root/home/videos render errors.
@@ -14,6 +15,7 @@ export default function WatchLocaleError({
   reset: () => void
 }) {
   useEffect(() => {
+    reportDatadogRumError(error, { boundary: "watch-locale" })
     if (process.env.NODE_ENV !== "production") {
       console.error("[watch-locale] error boundary caught:", error)
     }

--- a/apps/web/src/app/[locale]/[htmlLang]/layout.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/layout.tsx
@@ -11,6 +11,7 @@ import {
   type UiLocale,
 } from "@/lib/locale"
 import { montserrat } from "@/lib/watch-font"
+import DatadogRum from "@/components/DatadogRum"
 import { FloatingSearchProvider } from "@/components/FloatingSearchProvider"
 
 async function loadMessages(locale: UiLocale) {
@@ -89,6 +90,7 @@ export default async function RootLayout({
       </head>
       <body className="overflow-x-clip bg-black">
         <NextIntlClientProvider locale={locale} messages={messages}>
+          <DatadogRum />
           <FloatingSearchProvider>{children}</FloatingSearchProvider>
         </NextIntlClientProvider>
       </body>

--- a/apps/web/src/components/DatadogRum.tsx
+++ b/apps/web/src/components/DatadogRum.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { datadogRum, type RumInitConfiguration } from "@datadog/browser-rum"
+import { reactPlugin } from "@datadog/browser-rum-react"
+import { useEffect, useRef } from "react"
+
+import { env } from "@/env"
+
+const DATADOG_SERVICE = "watch"
+
+const DATADOG_ALLOWED_TRACING_URLS = [
+  {
+    match: "https://api-gateway.central.jesusfilm.org/",
+    propagatorTypes: ["tracecontext"],
+  },
+  {
+    match: "https://api-gateway.stage.central.jesusfilm.org/",
+    propagatorTypes: ["tracecontext"],
+  },
+  {
+    match: "https://admin.jesusfilm.org/api/graphql",
+    propagatorTypes: ["tracecontext"],
+  },
+] satisfies NonNullable<RumInitConfiguration["allowedTracingUrls"]>
+
+export function getDatadogRumInitConfig(): RumInitConfiguration | null {
+  const applicationId = env.NEXT_PUBLIC_DATADOG_APPLICATION_ID
+  const clientToken = env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN
+
+  if (!applicationId || !clientToken) return null
+
+  return {
+    applicationId,
+    clientToken,
+    site: env.NEXT_PUBLIC_DATADOG_SITE,
+    service: DATADOG_SERVICE,
+    env: env.NEXT_PUBLIC_DATADOG_ENV,
+    version: env.NEXT_PUBLIC_DATADOG_VERSION,
+    sessionSampleRate: 50,
+    sessionReplaySampleRate: 10,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: "mask-user-input",
+    allowedTracingUrls: DATADOG_ALLOWED_TRACING_URLS,
+    plugins: [reactPlugin()],
+  }
+}
+
+export function reportDatadogRumError(
+  error: unknown,
+  context: Record<string, unknown>,
+) {
+  try {
+    datadogRum.addError(error, context)
+  } catch (reportError) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[datadog-rum] failed to report error:", reportError)
+    }
+  }
+}
+
+export default function DatadogRum() {
+  const isInitialized = useRef(false)
+
+  useEffect(() => {
+    if (isInitialized.current) return
+
+    const config = getDatadogRumInitConfig()
+    if (config == null) return
+
+    try {
+      datadogRum.init(config)
+      isInitialized.current = true
+    } catch (error) {
+      console.error("[datadog-rum] failed to initialize:", error)
+    }
+  }, [])
+
+  return null
+}

--- a/apps/web/src/components/__tests__/DatadogRum.test.tsx
+++ b/apps/web/src/components/__tests__/DatadogRum.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { datadogRumMock, mockEnv, reactPluginMock } = vi.hoisted(() => {
+  const datadogRumMock = {
+    addError: vi.fn(),
+    init: vi.fn(),
+  }
+  const reactPlugin = { name: "react-plugin" }
+  const reactPluginMock = vi.fn(() => reactPlugin)
+  const mockEnv = {
+    NEXT_PUBLIC_DATADOG_APPLICATION_ID: undefined as string | undefined,
+    NEXT_PUBLIC_DATADOG_CLIENT_TOKEN: undefined as string | undefined,
+    NEXT_PUBLIC_DATADOG_SITE: "datadoghq.com",
+    NEXT_PUBLIC_DATADOG_ENV: "development",
+    NEXT_PUBLIC_DATADOG_VERSION: undefined as string | undefined,
+  }
+
+  return { datadogRumMock, mockEnv, reactPluginMock }
+})
+
+vi.mock("@datadog/browser-rum", () => ({
+  datadogRum: datadogRumMock,
+}))
+
+vi.mock("@datadog/browser-rum-react", () => ({
+  reactPlugin: reactPluginMock,
+}))
+
+vi.mock("@/env", () => ({
+  env: mockEnv,
+}))
+
+import DatadogRum, {
+  getDatadogRumInitConfig,
+  reportDatadogRumError,
+} from "@/components/DatadogRum"
+
+let container: HTMLDivElement
+let root: Root
+
+function resetMockEnv() {
+  mockEnv.NEXT_PUBLIC_DATADOG_APPLICATION_ID = undefined
+  mockEnv.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN = undefined
+  mockEnv.NEXT_PUBLIC_DATADOG_SITE = "datadoghq.com"
+  mockEnv.NEXT_PUBLIC_DATADOG_ENV = "development"
+  mockEnv.NEXT_PUBLIC_DATADOG_VERSION = undefined
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetMockEnv()
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  document.body.innerHTML = ""
+  vi.clearAllMocks()
+})
+
+describe("DatadogRum", () => {
+  it("does not initialize RUM when credentials are absent", async () => {
+    act(() => {
+      root.render(<DatadogRum />)
+    })
+    await flushEffects()
+
+    expect(datadogRumMock.init).not.toHaveBeenCalled()
+    expect(reactPluginMock).not.toHaveBeenCalled()
+  })
+
+  it("initializes RUM with Watch config when credentials are present", async () => {
+    mockEnv.NEXT_PUBLIC_DATADOG_APPLICATION_ID = "rum-app-id"
+    mockEnv.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN = "rum-client-token"
+    mockEnv.NEXT_PUBLIC_DATADOG_ENV = "prod"
+    mockEnv.NEXT_PUBLIC_DATADOG_VERSION = "abc123"
+
+    act(() => {
+      root.render(<DatadogRum />)
+    })
+    await flushEffects()
+
+    expect(datadogRumMock.init).toHaveBeenCalledTimes(1)
+    expect(datadogRumMock.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: "rum-app-id",
+        clientToken: "rum-client-token",
+        site: "datadoghq.com",
+        service: "watch",
+        env: "prod",
+        version: "abc123",
+        sessionSampleRate: 50,
+        sessionReplaySampleRate: 10,
+        trackUserInteractions: true,
+        trackResources: true,
+        trackLongTasks: true,
+        defaultPrivacyLevel: "mask-user-input",
+        plugins: [{ name: "react-plugin" }],
+      }),
+    )
+    expect(datadogRumMock.init.mock.calls[0]?.[0].allowedTracingUrls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          match: "https://api-gateway.central.jesusfilm.org/",
+          propagatorTypes: ["tracecontext"],
+        }),
+        expect.objectContaining({
+          match: "https://admin.jesusfilm.org/api/graphql",
+          propagatorTypes: ["tracecontext"],
+        }),
+      ]),
+    )
+  })
+
+  it("does not initialize twice on rerender", async () => {
+    mockEnv.NEXT_PUBLIC_DATADOG_APPLICATION_ID = "rum-app-id"
+    mockEnv.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN = "rum-client-token"
+
+    act(() => {
+      root.render(<DatadogRum />)
+    })
+    await flushEffects()
+    act(() => {
+      root.render(<DatadogRum />)
+    })
+    await flushEffects()
+
+    expect(datadogRumMock.init).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns null config when the application id or client token is missing", () => {
+    expect(getDatadogRumInitConfig()).toBeNull()
+
+    mockEnv.NEXT_PUBLIC_DATADOG_APPLICATION_ID = "rum-app-id"
+    expect(getDatadogRumInitConfig()).toBeNull()
+
+    mockEnv.NEXT_PUBLIC_DATADOG_APPLICATION_ID = undefined
+    mockEnv.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN = "rum-client-token"
+    expect(getDatadogRumInitConfig()).toBeNull()
+  })
+
+  it("reports caught segment-boundary errors to RUM", () => {
+    const error = new Error("render failed")
+
+    reportDatadogRumError(error, { boundary: "watch-page" })
+
+    expect(datadogRumMock.addError).toHaveBeenCalledWith(error, {
+      boundary: "watch-page",
+    })
+  })
+
+  it("does not let Datadog reporting failures cascade", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    datadogRumMock.addError.mockImplementationOnce(() => {
+      throw new Error("sdk failed")
+    })
+
+    expect(() =>
+      reportDatadogRumError(new Error("render failed"), {
+        boundary: "watch-locale",
+      }),
+    ).not.toThrow()
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[datadog-rum] failed to report error:",
+      expect.any(Error),
+    )
+    consoleError.mockRestore()
+  })
+})

--- a/apps/web/src/env.test.ts
+++ b/apps/web/src/env.test.ts
@@ -9,6 +9,16 @@ function useBaseEnv() {
   delete process.env.YOUVERSION_APP_KEY
   delete process.env.YOUVERSION_DEFAULT_VERSION_ID
   delete process.env.FORGE_WATCH_YOUVERSION_BIBLE_QUOTES_DEFAULT
+  delete process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID
+  delete process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN
+  delete process.env.NEXT_PUBLIC_DATADOG_SITE
+  delete process.env.NEXT_PUBLIC_DATADOG_ENV
+  delete process.env.NEXT_PUBLIC_DATADOG_VERSION
+  delete process.env.RAILWAY_ENVIRONMENT_NAME
+  delete process.env.RAILWAY_GIT_COMMIT_SHA
+  delete process.env.VERCEL_ENV
+  delete process.env.VERCEL_GIT_COMMIT_SHA
+  delete process.env.GIT_COMMIT_SHA
 }
 
 describe("web env — YouVersion server config", () => {
@@ -66,4 +76,52 @@ describe("web env — YouVersion server config", () => {
       expect(env.YOUVERSION_DEFAULT_VERSION_ID).toBe(3034)
     },
   )
+})
+
+describe("web env — Datadog RUM config", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...ORIGINAL_ENV }
+    useBaseEnv()
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it("imports cleanly without optional Datadog config", async () => {
+    const { env } = await import("./env")
+
+    expect(env.NEXT_PUBLIC_DATADOG_APPLICATION_ID).toBeUndefined()
+    expect(env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN).toBeUndefined()
+    expect(env.NEXT_PUBLIC_DATADOG_SITE).toBe("datadoghq.com")
+    expect(env.NEXT_PUBLIC_DATADOG_ENV).toBe("test")
+    expect(env.NEXT_PUBLIC_DATADOG_VERSION).toBeUndefined()
+  })
+
+  it("reads explicit Datadog config", async () => {
+    process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID = "rum-app-id"
+    process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN = "rum-client-token"
+    process.env.NEXT_PUBLIC_DATADOG_SITE = "us5.datadoghq.com"
+    process.env.NEXT_PUBLIC_DATADOG_ENV = "stage"
+    process.env.NEXT_PUBLIC_DATADOG_VERSION = "release-1"
+
+    const { env } = await import("./env")
+
+    expect(env.NEXT_PUBLIC_DATADOG_APPLICATION_ID).toBe("rum-app-id")
+    expect(env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN).toBe("rum-client-token")
+    expect(env.NEXT_PUBLIC_DATADOG_SITE).toBe("us5.datadoghq.com")
+    expect(env.NEXT_PUBLIC_DATADOG_ENV).toBe("stage")
+    expect(env.NEXT_PUBLIC_DATADOG_VERSION).toBe("release-1")
+  })
+
+  it("normalizes deployment env and release fallbacks for Datadog", async () => {
+    process.env.RAILWAY_ENVIRONMENT_NAME = "production"
+    process.env.RAILWAY_GIT_COMMIT_SHA = "railway-sha"
+
+    const { env } = await import("./env")
+
+    expect(env.NEXT_PUBLIC_DATADOG_ENV).toBe("prod")
+    expect(env.NEXT_PUBLIC_DATADOG_VERSION).toBe("railway-sha")
+  })
 })

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -62,6 +62,47 @@ function productionDefault(
   return process.env.NODE_ENV === "production" ? productionValue : localValue
 }
 
+function normalizeDatadogEnv(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+  if (!normalized) return undefined
+
+  switch (normalized.toLowerCase()) {
+    case "production":
+    case "prod":
+      return "prod"
+    case "staging":
+    case "stage":
+      return "stage"
+    case "preview":
+      return "preview"
+    case "development":
+    case "dev":
+      return "development"
+    case "test":
+      return "test"
+    default:
+      return normalized
+  }
+}
+
+function datadogEnvFallback(): string | undefined {
+  return normalizeDatadogEnv(
+    process.env.NEXT_PUBLIC_DATADOG_ENV ??
+      process.env.RAILWAY_ENVIRONMENT_NAME ??
+      process.env.VERCEL_ENV ??
+      process.env.NODE_ENV,
+  )
+}
+
+function datadogVersionFallback(): string | undefined {
+  return (
+    emptyToUndefined(process.env.NEXT_PUBLIC_DATADOG_VERSION) ??
+    emptyToUndefined(process.env.RAILWAY_GIT_COMMIT_SHA) ??
+    emptyToUndefined(process.env.VERCEL_GIT_COMMIT_SHA) ??
+    emptyToUndefined(process.env.GIT_COMMIT_SHA)
+  )
+}
+
 const ADMIN_GRAPHQL_URL_HOST_ALLOWLIST_SUFFIXES = [
   ".jesusfilm.org",
   ".railway.app",
@@ -77,6 +118,16 @@ const ADMIN_GRAPHQL_URL_HOST_ALLOWLIST_EXACTS = [
 const ADMIN_GRAPHQL_URL_HOST_REJECT_SET = new Set<string>([
   "auth.jesusfilm.org",
 ])
+
+const DATADOG_SITE_VALUES = [
+  "datadoghq.com",
+  "us3.datadoghq.com",
+  "us5.datadoghq.com",
+  "datadoghq.eu",
+  "ddog-gov.com",
+  "ap1.datadoghq.com",
+  "ap2.datadoghq.com",
+] as const
 
 function optionalPositiveIntDefault(defaultValue: number) {
   return z.preprocess((value) => {
@@ -174,6 +225,16 @@ export const env = createEnv({
     // R19 trigger: drop `video.js` from apps/web after this has been `true`
     // in production for one stable release.
     NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION: booleanEnv(false),
+    // Optional Datadog RUM configuration. Application id + client token gate
+    // initialization; when absent, the client component no-ops so local and
+    // preview environments can boot before Datadog is provisioned.
+    NEXT_PUBLIC_DATADOG_APPLICATION_ID: z.string().optional(),
+    NEXT_PUBLIC_DATADOG_CLIENT_TOKEN: z.string().optional(),
+    NEXT_PUBLIC_DATADOG_SITE: z
+      .enum(DATADOG_SITE_VALUES)
+      .default("datadoghq.com"),
+    NEXT_PUBLIC_DATADOG_ENV: z.string().default("development"),
+    NEXT_PUBLIC_DATADOG_VERSION: z.string().optional(),
     // U5 — Mux Data env key for the watch-page Mux Player. Optional because
     // not all environments (preview / local) have Mux Data set up; when
     // unset, the player simply does not emit Mux Data beacons.
@@ -235,6 +296,13 @@ export const env = createEnv({
     YOUVERSION_DEFAULT_VERSION_ID: process.env.YOUVERSION_DEFAULT_VERSION_ID,
     NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION:
       process.env.NEXT_PUBLIC_FORGE_WATCH_PLAYER_MIGRATION,
+    NEXT_PUBLIC_DATADOG_APPLICATION_ID:
+      process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID,
+    NEXT_PUBLIC_DATADOG_CLIENT_TOKEN:
+      process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN,
+    NEXT_PUBLIC_DATADOG_SITE: process.env.NEXT_PUBLIC_DATADOG_SITE,
+    NEXT_PUBLIC_DATADOG_ENV: datadogEnvFallback(),
+    NEXT_PUBLIC_DATADOG_VERSION: datadogVersionFallback(),
     NEXT_PUBLIC_MUX_DATA_ENV_KEY: process.env.NEXT_PUBLIC_MUX_DATA_ENV_KEY,
     NEXT_PUBLIC_CANONICAL_ORIGIN: process.env.NEXT_PUBLIC_CANONICAL_ORIGIN,
   },

--- a/docs/plans/2026-06-11-005-feat-web-watch-datadog-rum-plan.md
+++ b/docs/plans/2026-06-11-005-feat-web-watch-datadog-rum-plan.md
@@ -1,0 +1,172 @@
+---
+title: "Web Watch Datadog RUM"
+status: completed
+date: "2026-06-11"
+origin: "user request: establish Datadog for web/watch, mirroring Core apps/watch-modern"
+roadmap: "docs/roadmap/platform/feat-182-web-watch-datadog-rum.md"
+---
+
+# Web Watch Datadog RUM
+
+## Problem Frame
+
+Forge `apps/web` has become the Watch surface but currently lacks the Datadog
+RUM bootstrapping and source-map upload path that existed in the previous
+Core `apps/watch-modern` app. The implementation should make Datadog available
+in production/stage when credentials are configured, while keeping local and
+preview environments bootable when Datadog env vars are absent.
+
+## Scope Boundaries
+
+- In scope: browser RUM initialization, React plugin wiring, existing error
+  boundary reporting, env validation, source-map generation/upload script,
+  `.env.example`, and focused tests.
+- Out of scope: GTM, GA4, Meta Pixel, Algolia Insights, server APM, Datadog
+  monitors/dashboards, and changing Watch analytics/event collection.
+- Preserve the cacheable Watch App Router tree; do not add `headers()`,
+  `cookies()`, or request-time dynamic APIs to `apps/web/src/app/[locale]`.
+- Preserve existing user-facing error fallback UI.
+
+## Decisions
+
+1. Use a client-only initializer component in
+   `apps/web/src/components/DatadogRum.tsx`.
+   Rationale: this mirrors the previous app's client RUM init while leaving the
+   server layout static.
+2. Use service name `watch`.
+   Rationale: the live production inventory used `service: watch`, and source
+   maps must share the same service value as emitted RUM events.
+3. Do not wrap the app in Datadog's React `ErrorBoundary`.
+   Rationale: Forge already has App Router segment error boundaries; reporting
+   those caught errors to RUM preserves current fallback behavior.
+4. Enable `productionBrowserSourceMaps: true` and add a package script for
+   Datadog source-map upload.
+   Rationale: RUM errors are much more useful when their release version has
+   matching browser source maps.
+5. Make Datadog credentials optional.
+   Rationale: local, CI, and preview environments should still boot without
+   Datadog application id/client token.
+
+## Existing Patterns
+
+- Previous app reference:
+  `https://github.com/JesusFilm/core/tree/main/apps/watch-modern`
+- Prior init component:
+  `apps/watch-modern/src/components/Datadog/Init/Init.tsx`
+- Prior source-map target:
+  `apps/watch-modern/project.json`
+- Forge env schema:
+  `apps/web/src/env.ts`
+- Forge Watch layout:
+  `apps/web/src/app/[locale]/[htmlLang]/layout.tsx`
+- Forge segment error boundaries:
+  `apps/web/src/app/[locale]/[htmlLang]/error.tsx`
+  `apps/web/src/app/[locale]/[htmlLang]/[...rest]/error.tsx`
+
+## Implementation Units
+
+### U1 - Env And Dependencies
+
+Files:
+
+- Modify `apps/web/package.json`
+- Modify `pnpm-lock.yaml`
+- Modify `apps/web/src/env.ts`
+- Modify `apps/web/.env.example`
+
+Approach:
+
+- Add `@datadog/browser-rum` and `@datadog/browser-rum-react`.
+- Add public env schema entries for application id, client token, site, env,
+  and version.
+- Default site to `datadoghq.com`, env to a normalized deployment env, and
+  version to Railway/Vercel/git commit env when present.
+- Add `datadog:sourcemaps` using `datadog-ci sourcemaps upload` with
+  `--service=watch`, release version from `DATADOG_RELEASE_VERSION` or git env,
+  and `--minified-path-prefix=/watch/_next/static/`.
+
+Test scenarios:
+
+- Missing Datadog vars does not fail env parsing.
+- Provided Datadog vars are surfaced through `env`.
+- Empty optional Datadog vars are treated as unset.
+
+### U2 - Client RUM Bootstrap
+
+Files:
+
+- Create `apps/web/src/components/DatadogRum.tsx`
+- Create `apps/web/src/components/__tests__/DatadogRum.test.tsx`
+- Modify `apps/web/src/app/[locale]/[htmlLang]/layout.tsx`
+
+Approach:
+
+- Add a `"use client"` component that checks config, guards duplicate init,
+  and calls `datadogRum.init` with the React plugin.
+- Mount it inside `NextIntlClientProvider` in the Watch layout.
+
+Test scenarios:
+
+- No application id/client token means no SDK init call.
+- Application id/client token means one init call with service `watch`, env,
+  version, privacy, sampling, and plugin config.
+- Re-render does not initialize twice.
+
+### U3 - Segment Error Reporting
+
+Files:
+
+- Modify `apps/web/src/app/[locale]/[htmlLang]/error.tsx`
+- Modify `apps/web/src/app/[locale]/[htmlLang]/[...rest]/error.tsx`
+- Extend `apps/web/src/components/__tests__/DatadogRum.test.tsx`
+
+Approach:
+
+- Export a small `reportDatadogRumError` helper from the client component
+  module.
+- Call it from both existing segment error boundary `useEffect` blocks with a
+  boundary tag, then keep the current console-in-dev and fallback UI behavior.
+
+Test scenarios:
+
+- Reporting helper calls `datadogRum.addError` with boundary context.
+- Reporting helper swallows SDK failures so error boundaries do not cascade.
+
+### U4 - Source Maps
+
+Files:
+
+- Modify `apps/web/next.config.mjs`
+- Covered by `apps/web/package.json` in U1.
+
+Approach:
+
+- Set `productionBrowserSourceMaps: true`.
+- Keep the upload command opt-in; deployment orchestration can call it after a
+  successful production build with `DATADOG_API_KEY` and release env set.
+
+Test scenarios:
+
+- `typecheck` accepts the Next config.
+- Build-oriented validation is covered by existing CI after dependency install.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/__tests__/DatadogRum.test.tsx src/env.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Browser smoke: launch `apps/web` and load a representative Watch URL to
+  confirm the page still renders with the RUM initializer mounted.
+
+## Completion Evidence
+
+- `pnpm install --frozen-lockfile --offline`
+- `pnpm --filter @forge/web test -- src/components/__tests__/DatadogRum.test.tsx src/env.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Helium/agent-browser smoke:
+  `http://127.0.0.1:4920/watch/life-of-jesus-gospel-of-john.html/english.html`
+  rendered the Watch title, chapter carousel, Download, Bible Quotes, Search,
+  and language controls.
+- Screenshot:
+  `output/playwright/web-watch-datadog-rum-smoke.png`

--- a/docs/roadmap/platform/feat-182-web-watch-datadog-rum.md
+++ b/docs/roadmap/platform/feat-182-web-watch-datadog-rum.md
@@ -1,0 +1,91 @@
+---
+id: "feat-182"
+title: "Web Watch Datadog RUM"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-11"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "observability"
+  - "datadog"
+---
+
+## Problem
+
+Forge `apps/web` now serves the redesigned Watch experience, but it does not
+yet initialize Datadog RUM or provide a source-map upload path. The previous
+Core `apps/watch-modern` app initialized Datadog RUM on the client, reported
+React errors through the RUM SDK, enabled production browser source maps, and
+had a Datadog source-map upload target. Forge Watch needs equivalent
+observability without changing the static App Router render contract.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-11-005-feat-web-watch-datadog-rum-plan.md` -
+   implementation plan for this observability slice.
+2. `apps/web/src/env.ts` - public Datadog env validation and Railway/Vercel
+   release fallback wiring.
+3. `apps/web/src/app/[locale]/[htmlLang]/layout.tsx` - cacheable Watch layout
+   where the client-only RUM initializer should mount.
+4. `apps/web/src/app/[locale]/[htmlLang]/error.tsx` and
+   `apps/web/src/app/[locale]/[htmlLang]/[...rest]/error.tsx` - existing
+   client segment error boundaries to report to Datadog without replacing
+   their fallback UI.
+5. `apps/web/next.config.mjs` and `apps/web/package.json` - production browser
+   source maps and Datadog source-map upload script.
+6. Prior app reference:
+   `https://github.com/JesusFilm/core/tree/main/apps/watch-modern`.
+
+## What To Build
+
+1. Add optional public Datadog RUM env vars for application id, client token,
+   site, environment, and release version.
+2. Add Datadog RUM browser dependencies to `@forge/web`.
+3. Add a client-only initializer that no-ops when application id or client
+   token is absent, and initializes RUM with service `watch`, resource/user
+   interaction/long-task tracking, session replay sampling, privacy masking,
+   tracecontext propagation for Jesus Film API hosts, and the React plugin.
+4. Mount the initializer inside the Watch layout without introducing
+   request-time dynamic APIs into the static route tree.
+5. Report existing Watch segment-boundary errors to RUM while preserving the
+   current fallback UI.
+6. Enable production browser source maps and add a Datadog source-map upload
+   script that uses the same service and release version as RUM.
+7. Document required env vars in `apps/web/.env.example`.
+
+## Verification
+
+- Focused tests prove the RUM initializer no-ops without credentials and calls
+  `datadogRum.init` with the expected service/env/version/sampling/plugin
+  config when credentials are present.
+- Focused tests prove segment boundary errors are reported to Datadog.
+- `pnpm --filter @forge/web test -- src/components/__tests__/DatadogRum.test.tsx src/env.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Browser smoke confirms a Watch page still renders after the initializer is
+  mounted.
+
+## Completion Notes
+
+- Added optional Datadog RUM env validation and documented the Railway/Vercel
+  env/release fallbacks in `apps/web/.env.example`.
+- Added `@datadog/browser-rum` and `@datadog/browser-rum-react`, a client-only
+  `DatadogRum` initializer mounted from the Watch layout, and RUM reporting for
+  the existing Watch segment error boundaries.
+- Enabled production browser source maps and added
+  `pnpm --filter @forge/web datadog:sourcemaps` for release uploads using
+  service `watch`.
+- Verified focused tests, typecheck, lint, frozen offline install, and Helium
+  browser smoke on
+  `http://127.0.0.1:4920/watch/life-of-jesus-gospel-of-john.html/english.html`.
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-11-005-feat-web-watch-datadog-rum-plan.md`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,12 @@ importers:
       '@base-ui/react':
         specifier: ^1.2.0
         version: 1.4.1(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@datadog/browser-rum':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@datadog/browser-rum-react':
+        specifier: ^7.2.0
+        version: 7.2.0(@datadog/browser-rum@7.2.0)(react@19.2.4)
       '@forge/admin-graphql':
         specifier: workspace:*
         version: link:../../packages/admin-graphql
@@ -2137,6 +2143,43 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@datadog/browser-core@7.2.0':
+    resolution: {integrity: sha512-/KOJiLyLP149qZTMs8W8P8MBKxmbrYYramChTDAplhbIXR+nBE+g97RRbluIBDec4GngnA1j13JWDEXBmT0AJw==}
+
+  '@datadog/browser-rum-core@7.2.0':
+    resolution: {integrity: sha512-xYgKmBzgpPdXNWxGKBGgJc/EUq6387USzM3Tq22kSD843QTzgzG2jYWkBZZ1FAel1T/0hF2FMJ8Mxo5BwxpoJQ==}
+
+  '@datadog/browser-rum-react@7.2.0':
+    resolution: {integrity: sha512-cz7cb3/lQ1vhc1/34JizU+wuHhdYrZqaLiUs8ppGt4qn72/gxwgrGcNScZnNfelcF4T36lVE5q6yvY5i8Ae6IQ==}
+    peerDependencies:
+      '@datadog/browser-rum': '*'
+      '@datadog/browser-rum-slim': '*'
+      '@tanstack/react-router': '>=1.64.0 <2'
+      react: 18 || 19
+      react-router: 6 || 7
+      react-router-dom: 6 || 7
+    peerDependenciesMeta:
+      '@datadog/browser-rum':
+        optional: true
+      '@datadog/browser-rum-slim':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      react:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
+
+  '@datadog/browser-rum@7.2.0':
+    resolution: {integrity: sha512-cPNTtSyrKSDcwtsWOq7C7662dseUoYmSqK3bJh2rJ0IPW/nVDTZrxt1a6cuGHLFjcE6KFCQJLrnC2YDdw8uJGw==}
+    peerDependencies:
+      '@datadog/browser-logs': 7.2.0
+    peerDependenciesMeta:
+      '@datadog/browser-logs':
+        optional: true
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -14163,6 +14206,25 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@datadog/browser-core@7.2.0': {}
+
+  '@datadog/browser-rum-core@7.2.0':
+    dependencies:
+      '@datadog/browser-core': 7.2.0
+
+  '@datadog/browser-rum-react@7.2.0(@datadog/browser-rum@7.2.0)(react@19.2.4)':
+    dependencies:
+      '@datadog/browser-core': 7.2.0
+      '@datadog/browser-rum-core': 7.2.0
+    optionalDependencies:
+      '@datadog/browser-rum': 7.2.0
+      react: 19.2.4
+
+  '@datadog/browser-rum@7.2.0':
+    dependencies:
+      '@datadog/browser-core': 7.2.0
+      '@datadog/browser-rum-core': 7.2.0
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## Summary
- add optional Datadog RUM env validation, docs, and dependencies for @forge/web
- mount a client-only Datadog RUM initializer in the Watch layout and report existing Watch segment-boundary errors to RUM
- enable production browser source maps and add the Datadog source-map upload script using service `watch`
- add roadmap ticket and CE plan for the observability slice

## Verification
- `pnpm install --frozen-lockfile --offline`
- `pnpm --filter @forge/web test -- src/components/__tests__/DatadogRum.test.tsx src/env.test.ts`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- Helium/agent-browser smoke on `http://127.0.0.1:4920/watch/life-of-jesus-gospel-of-john.html/english.html`
- Screenshot: `output/playwright/web-watch-datadog-rum-smoke.png`