### PR TITLE
fix(admin): only offer playable videos to AI experience generation

### DIFF
--- a/apps/admin/src/mastra/tools/search-videos.test.ts
+++ b/apps/admin/src/mastra/tools/search-videos.test.ts
@@ -27,7 +27,7 @@ describe("searchVideosTool", () => {
     vi.resetModules()
   })
 
-  it("calls HybridSearchService.search with the input query+locale+limit and returns trimmed videos", async () => {
+  it("calls HybridSearchService.search with the input query+locale+limit and returns trimmed playable videos, dropping playbackId-null rows", async () => {
     searchMock.mockResolvedValue({
       results: [
         {
@@ -83,14 +83,9 @@ describe("searchVideosTool", () => {
       limit: 5,
       contentTypes: ["video"],
     })
+    // vid-1 has playbackId null (no playable dub in the locale) — agents
+    // write returned videoIds into blocks verbatim, so it must be dropped.
     expect(result.videos).toEqual([
-      {
-        videoId: "vid-1",
-        title: "Jesus",
-        snippet: "About Jesus.",
-        slug: "jesus",
-        imageUrl: "https://cdn/img.png",
-      },
       {
         videoId: "vid-2",
         title: "Easter",

--- a/apps/admin/src/mastra/tools/search-videos.ts
+++ b/apps/admin/src/mastra/tools/search-videos.ts
@@ -71,7 +71,10 @@ export const searchVideosTool = createTool({
     })
 
     const videos = response.results
-      .filter((result) => result.type === "video")
+      // playbackId === null means no playable dub resolved for the locale
+      // (the R4 retrievers keep such rows); agents write these videoIds into
+      // blocks verbatim, so unplayable results must never reach them.
+      .filter((result) => result.type === "video" && result.playbackId !== null)
       .map((result) => ({
         videoId: result.id,
         title: result.title,

--- a/apps/admin/src/services/experience-ai/experience-ai.service.test.ts
+++ b/apps/admin/src/services/experience-ai/experience-ai.service.test.ts
@@ -216,6 +216,59 @@ describe("loadExperienceAiVideoCandidates", () => {
     })
   })
 
+  it("requires playable, non-container videos in the catalog query", async () => {
+    const prisma = makePrisma()
+    seedCatalog(prisma)
+
+    await loadExperienceAiVideoCandidates(prisma, {
+      locale: "en",
+      prompt: "hope",
+      limit: 2,
+    })
+
+    const where = prisma.video.findMany.mock.calls[0]?.[0]?.where
+    expect(where).toMatchObject({
+      deletedAt: null,
+      OR: [{ label: null }, { label: { notIn: ["COLLECTION", "SERIES"] } }],
+      dubs: { some: { deletedAt: null, published: true } },
+    })
+  })
+
+  it("falls back to any playable dub when the locale dub has no stream", async () => {
+    const prisma = makePrisma()
+    seedCatalog(prisma)
+    prisma.videoDub.findMany.mockResolvedValue([
+      {
+        videoId: "video-1",
+        published: true,
+        hls: null,
+        dash: null,
+        share: null,
+        language: { bcp47: "en", iso3: "eng", slug: "english" },
+        updatedAt: new Date("2026-04-23T10:00:00Z"),
+      },
+      {
+        videoId: "video-1",
+        published: true,
+        hls: "https://example.com/french.m3u8",
+        dash: null,
+        share: null,
+        language: { bcp47: "fr", iso3: "fra", slug: "french" },
+        updatedAt: new Date("2026-04-22T10:00:00Z"),
+      },
+    ])
+
+    const candidates = await loadExperienceAiVideoCandidates(prisma, {
+      locale: "en",
+      prompt: "hope",
+      limit: 1,
+    })
+
+    expect(candidates[0]?.previewStreamUrl).toBe(
+      "https://example.com/french.m3u8",
+    )
+  })
+
   it("uses a matching-language dub for preview streams", async () => {
     const prisma = makePrisma()
     seedCatalog(prisma)
@@ -278,10 +331,11 @@ describe("loadExperienceAiVideoCandidates", () => {
     )
     expect(prisma.video.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
+        where: expect.objectContaining({
           id: { in: ["video-2", "video-1"] },
           deletedAt: null,
-        },
+          dubs: { some: expect.objectContaining({ published: true }) },
+        }),
       }),
     )
     expect(candidates.map((candidate) => candidate.videoId)).toEqual([

--- a/apps/admin/src/services/experience-ai/experience-ai.service.ts
+++ b/apps/admin/src/services/experience-ai/experience-ai.service.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "@prisma/client"
+import { Prisma, VideoLabel, type PrismaClient } from "@prisma/client"
 
 import { toPgVector } from "@/db/pgvector"
 import { generateExperienceEmbedding } from "@/services/embeddings.service"
@@ -14,6 +14,41 @@ export {
 const DEFAULT_CANDIDATE_LIMIT = 12
 const CANDIDATE_FETCH_WINDOW = 80
 const VECTOR_SEARCH_EF_SEARCH = 80
+
+// Web's videoHero plays only the HLS streamingUrl baked into the block at
+// authoring time (apps/web VideoHero hides the player when src is empty), so
+// AI candidates must carry at least one playable dub — published with a
+// non-empty HLS URL, mirroring web's isPlayableWatchVariant — and must not be
+// container entries (collections/series have nothing to play).
+const PLAYABLE_CANDIDATE_VIDEO_WHERE = {
+  deletedAt: null,
+  OR: [
+    { label: null },
+    { label: { notIn: [VideoLabel.COLLECTION, VideoLabel.SERIES] } },
+  ],
+  dubs: {
+    some: {
+      deletedAt: null,
+      published: true,
+      AND: [{ hls: { not: null } }, { NOT: { hls: "" } }],
+    },
+  },
+} satisfies Prisma.VideoWhereInput
+
+// Raw-SQL twin of PLAYABLE_CANDIDATE_VIDEO_WHERE for the semantic candidate
+// queries (alias `v` = video; enum literals are the lowercase DB values).
+// Keep both predicates in sync.
+const PLAYABLE_CANDIDATE_VIDEO_SQL = `
+          AND (v.label IS NULL OR v.label NOT IN ('collection', 'series'))
+          AND EXISTS (
+            SELECT 1
+            FROM video_dub pvd
+            WHERE pvd.video_id = v.id
+              AND pvd.deleted_at IS NULL
+              AND pvd.published = TRUE
+              AND pvd.hls IS NOT NULL
+              AND pvd.hls <> ''
+          )`
 
 type RankedCandidate = VideoCandidate & {
   score: number
@@ -115,8 +150,8 @@ export async function loadExperienceAiVideoCandidates(
   const videos = await prisma.video.findMany({
     where:
       semanticVideoIds.length > 0
-        ? { id: { in: semanticVideoIds }, deletedAt: null }
-        : { deletedAt: null },
+        ? { id: { in: semanticVideoIds }, ...PLAYABLE_CANDIDATE_VIDEO_WHERE }
+        : PLAYABLE_CANDIDATE_VIDEO_WHERE,
     select: {
       id: true,
       slug: true,
@@ -151,6 +186,7 @@ export async function loadExperienceAiVideoCandidates(
       where: { videoId: { in: videoIds }, deletedAt: null },
       select: {
         videoId: true,
+        published: true,
         hls: true,
         dash: true,
         share: true,
@@ -212,16 +248,23 @@ export async function loadExperienceAiVideoCandidates(
 
     const previewImageUrl =
       imagesByVideo.get(video.id)?.find((row) => row.url)?.url ?? null
+    const dubRows = dubsByVideo.get(video.id) ?? []
+    const localeMatches = (row: (typeof dubRows)[number]) =>
+      row.language?.bcp47 === locale ||
+      row.language?.iso3 === locale ||
+      row.language?.slug === locale
+    // Prefer a playable (published + HLS) dub in the request locale, then any
+    // locale-matched stream, then any playable dub — the last leg guarantees
+    // a non-empty streamingUrl for every candidate that passed
+    // PLAYABLE_CANDIDATE_VIDEO_WHERE, so generated videoHero blocks always
+    // bake a URL web can play.
     const preferredDub =
-      dubsByVideo
-        .get(video.id)
-        ?.find(
-          (row) =>
-            (row.hls || row.dash || row.share) &&
-            (row.language?.bcp47 === locale ||
-              row.language?.iso3 === locale ||
-              row.language?.slug === locale),
-        ) ?? null
+      dubRows.find((row) => row.published && row.hls && localeMatches(row)) ??
+      dubRows.find(
+        (row) => (row.hls || row.dash || row.share) && localeMatches(row),
+      ) ??
+      dubRows.find((row) => row.published && row.hls) ??
+      null
 
     const candidate = {
       ref: "",
@@ -319,7 +362,7 @@ async function loadSemanticVideoCandidateIds(
         JOIN video v ON v.id = vs.video_id
         WHERE vsl.embedding IS NOT NULL
           AND vsl.locale = ${locale}
-          AND v.deleted_at IS NULL
+          AND v.deleted_at IS NULL${Prisma.raw(PLAYABLE_CANDIDATE_VIDEO_SQL)}
         GROUP BY vs.video_id
       ),
       transcript_hits AS (
@@ -331,7 +374,7 @@ async function loadSemanticVideoCandidateIds(
         JOIN video v ON v.id = vt.video_id
         WHERE vtc.embedding IS NOT NULL
           AND vtc.language = ${locale}
-          AND v.deleted_at IS NULL
+          AND v.deleted_at IS NULL${Prisma.raw(PLAYABLE_CANDIDATE_VIDEO_SQL)}
         GROUP BY vt.video_id
       ),
       combined AS (
@@ -390,7 +433,7 @@ async function loadLocalOllamaVideoCandidateIds(
       JOIN video v ON v.id = vce.video_id
       WHERE vce.embedding IS NOT NULL
         AND vce.locale = ${locale}
-        AND v.deleted_at IS NULL
+        AND v.deleted_at IS NULL${Prisma.raw(PLAYABLE_CANDIDATE_VIDEO_SQL)}
       ORDER BY distance ASC
       LIMIT ${safeLimit}
     `


### PR DESCRIPTION
## Problem

AI-generated Experience video heroes were frequently **invisible in preview** on the watch site, while manually picked videos worked fine.

Root cause chain (traced end-to-end):
- `loadExperienceAiVideoCandidates`'s only video filter was `deleted_at IS NULL` — semantic top-hits could be **collections** (containers with nothing to play) or videos with **no published HLS dub**. Reproduced in a real catalog: a `collection` with an English dub but zero playable streams ranked v01 for a "hope" prompt and landed in the generated `videoHero`.
- Web never re-resolves `videoId` at render time — the hero plays only the `streamingUrl` baked into the block at authoring time (`VideoHero` hides the player when `src` is empty). An unplayable candidate therefore bakes no stream, producing a full-height `stone-900` section on a `stone-900` page: an "invisible" hero.
- Manual picking only worked by human affordance — the picker preview makes dead videos obvious, so editors avoid them.

## Fix

- **Candidate loader** (`experience-ai.service.ts`): require non-container videos (`label NOT IN (collection, series)`, null label allowed) with ≥1 playable dub (published + non-empty HLS — mirrors web's `isPlayableWatchVariant`). Applied to the Prisma catalog query **and** both semantic vector queries (shared SQL fragment), so the fetch window isn't consumed by ineligible videos. This single chokepoint covers both the workflow draft path and the chat prompt path.
- **Preview stream preference**: locale playable dub → any locale stream → any playable dub. Combined with the filter, every surviving candidate bakes a playable `streamingUrl` into generated blocks.
- **`searchVideos` tool**: drop `playbackId === null` results (the R4 retrievers deliberately keep such rows for the public search surface — untouched here). Agents write returned videoIds into blocks verbatim, so unplayable rows must never reach them.

## Testing

- New unit tests: catalog query requires the playability/label predicate; playable-dub fallback chain; tool drops playbackId-null rows (15/15 green)
- **Real-DB smoke** (mocked tests can't catch SQL-resolution issues): against a populated local catalog, the previously-selected unplayable collection is excluded and all 12 returned candidates carry stream URLs
- eslint + prettier via pre-commit hooks; no new typecheck errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)