### PR TITLE
fix(web): extend semantic search admin timeout

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -12,7 +12,7 @@
 - Route groups for layout boundaries: `(marketing)`, `(app)`, `(auth)`.
 - Loading states: always add `loading.tsx` for async routes.
 - Error boundaries: `error.tsx` at each route segment.
-- Data fetching: RSC async components calling resolvers in `src/lib/content.ts` / `search.ts` / `recommendations.ts` / `demo-search.ts`, which use `adminGraphql()` from `@forge/admin-graphql` + the singleton Apollo client at `src/lib/admin-client.ts`.
+- Data fetching: RSC async components calling resolvers in `src/lib/content.ts` / `recommendations.ts` / `demo-search.ts`, which use `adminGraphql()` from `@forge/admin-graphql` + the default Apollo client at `src/lib/admin-client.ts`. `src/lib/search.ts` uses the semantic-search Admin client from the same module so production semantic search gets a longer bounded timeout without widening every Admin GraphQL call.
 - Client components that need data go through a `"use server"` action (e.g. `src/lib/search-actions.ts`) — admin's bearer is server-only and must never reach the browser bundle.
 - Metadata: export `metadata` or `generateMetadata` from every page.
 
@@ -20,7 +20,7 @@
 
 Web reads from admin via the typed `adminGraphql()` factory exported from `@forge/admin-graphql`. The package consumes admin's committed SDL (`apps/admin/schema.graphql`); SDL drift breaks codegen at the package level, not at the app level.
 
-- `src/lib/admin-client.ts` — singleton Apollo client pointed at `env.ADMIN_GRAPHQL_URL` with `Authorization: Bearer ${env.WEB_ADMIN_API_KEYS.split(",")[0]}`. 15 s timeout (temporary headroom for admin's slow `videoBySlug` resolver on COLLECTION rows; see the comment in `admin-client.ts`).
+- `src/lib/admin-client.ts` — lazy Apollo clients pointed at `env.ADMIN_GRAPHQL_URL` with `Authorization: Bearer ${env.WEB_ADMIN_API_KEYS.split(",")[0]}`. The default export keeps the 15 s timeout for general Admin GraphQL calls; `semanticSearchAdminClient` uses a 45 s bounded timeout for `src/lib/search.ts` only.
 - `src/lib/content.ts` — `resolveWatchPage`, `resolveWatchVideo*`, `resolveSeriesBySlug`, plus the 6 synthetic-watch-block builders. Returns admin shapes flattened via `normalizeAdminVideo`.
 - `src/lib/fragments/watch-experience.ts` — re-exports `adminWatchExperienceFragment` from `@forge/admin-graphql/fragments` (the root composition over admin's 17 block fragments).
 - `src/lib/fragments/watch-video.ts` — local `WatchVideo` fragment + the two query operations on admin's `Video` with field aliases bridging vocab (`documentId: id`, `variants: dubs`, `value: text`).

--- a/apps/web/src/lib/admin-client.test.ts
+++ b/apps/web/src/lib/admin-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { ApolloClient } from "@apollo/client"
 
 const ORIGINAL_ENV = { ...process.env }
 
@@ -9,6 +10,46 @@ function extractBearer(fetchSpy: ReturnType<typeof vi.fn>): string | undefined {
   return headers.Authorization || headers.authorization
 }
 
+function extractSignal(
+  fetchSpy: ReturnType<typeof vi.fn>,
+  callIndex = 0,
+): AbortSignal | null | undefined {
+  const init = fetchSpy.mock.calls[callIndex]?.[1] as RequestInit | undefined
+  return init?.signal
+}
+
+function mockSuccessfulFetch() {
+  const fetchSpy = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ data: { ok: true } }), { status: 200 }),
+    ),
+  )
+  vi.stubGlobal("fetch", fetchSpy)
+  return fetchSpy
+}
+
+function mockAbortSignalTimeout() {
+  const signals: AbortSignal[] = []
+  const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => {
+    const controller = new AbortController()
+    signals.push(controller.signal)
+    return controller.signal
+  })
+  return { signals, timeoutSpy }
+}
+
+async function runQuery(client: Pick<ApolloClient, "query">) {
+  const { gql } = await import("@apollo/client")
+  await client.query({
+    query: gql`
+      {
+        ok
+      }
+    `,
+    fetchPolicy: "no-cache",
+  })
+}
+
 describe("admin-client env validation", () => {
   beforeEach(() => {
     vi.resetModules()
@@ -17,6 +58,8 @@ describe("admin-client env validation", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV }
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   it("imports cleanly when ADMIN_GRAPHQL_URL and WEB_ADMIN_API_KEYS are both set", async () => {
@@ -74,60 +117,101 @@ describe("admin-client bearer parsing", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV }
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   it("uses the first CSV entry as the outbound bearer", async () => {
     process.env.ADMIN_GRAPHQL_URL = "http://localhost:1437/admin/api/graphql"
     process.env.WEB_ADMIN_API_KEYS = "first-key,second-key,third-key"
 
-    const fetchSpy = vi.fn(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ data: { ok: true } }), { status: 200 }),
-      ),
-    )
-    vi.stubGlobal("fetch", fetchSpy)
+    const fetchSpy = mockSuccessfulFetch()
 
     const { default: client } = await import("./admin-client")
-    const { gql } = await import("@apollo/client")
-    await client.query({
-      query: gql`
-        {
-          ok
-        }
-      `,
-      fetchPolicy: "no-cache",
-    })
+    await runQuery(client)
 
     expect(fetchSpy).toHaveBeenCalledOnce()
     expect(extractBearer(fetchSpy)).toBe("Bearer first-key")
-
-    vi.unstubAllGlobals()
   })
 
   it("trims whitespace around the first CSV entry", async () => {
     process.env.ADMIN_GRAPHQL_URL = "http://localhost:1437/admin/api/graphql"
     process.env.WEB_ADMIN_API_KEYS = "  padded-key , other-key "
 
-    const fetchSpy = vi.fn(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ data: { ok: true } }), { status: 200 }),
-      ),
-    )
-    vi.stubGlobal("fetch", fetchSpy)
+    const fetchSpy = mockSuccessfulFetch()
 
     const { default: client } = await import("./admin-client")
-    const { gql } = await import("@apollo/client")
-    await client.query({
-      query: gql`
-        {
-          ok
-        }
-      `,
-      fetchPolicy: "no-cache",
-    })
+    await runQuery(client)
 
     expect(extractBearer(fetchSpy)).toBe("Bearer padded-key")
+  })
+})
 
+describe("admin-client timeout budgets", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...ORIGINAL_ENV }
+    process.env.ADMIN_GRAPHQL_URL = "http://localhost:1437/admin/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "test-admin-bearer-key"
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("keeps the default Admin GraphQL client on the 15 second timeout", async () => {
+    const fetchSpy = mockSuccessfulFetch()
+    const { signals, timeoutSpy } = mockAbortSignalTimeout()
+
+    const { default: client } = await import("./admin-client")
+    await runQuery(client)
+
+    expect(timeoutSpy).toHaveBeenCalledWith(15_000)
+    expect(extractSignal(fetchSpy)).toBe(signals[0])
+  })
+
+  it("uses a longer bounded timeout for semantic search Admin GraphQL calls", async () => {
+    const fetchSpy = mockSuccessfulFetch()
+    const { signals, timeoutSpy } = mockAbortSignalTimeout()
+
+    const { semanticSearchAdminClient } = await import("./admin-client")
+    await runQuery(semanticSearchAdminClient)
+
+    expect(timeoutSpy).toHaveBeenCalledWith(45_000)
+    expect(extractSignal(fetchSpy)).toBe(signals[0])
+  })
+
+  it("keeps default and semantic search clients on independent timeouts", async () => {
+    const fetchSpy = mockSuccessfulFetch()
+    const { signals, timeoutSpy } = mockAbortSignalTimeout()
+
+    const { default: client, semanticSearchAdminClient } =
+      await import("./admin-client")
+    await runQuery(client)
+    await runQuery(semanticSearchAdminClient)
+
+    expect(timeoutSpy.mock.calls.map(([timeoutMs]) => timeoutMs)).toEqual([
+      15_000, 45_000,
+    ])
+    expect(extractSignal(fetchSpy, 0)).toBe(signals[0])
+    expect(extractSignal(fetchSpy, 1)).toBe(signals[1])
+  })
+
+  it("keeps independent timeouts when semantic search is touched first", async () => {
+    const fetchSpy = mockSuccessfulFetch()
+    const { signals, timeoutSpy } = mockAbortSignalTimeout()
+
+    const { default: client, semanticSearchAdminClient } =
+      await import("./admin-client")
+    await runQuery(semanticSearchAdminClient)
+    await runQuery(client)
+
+    expect(timeoutSpy.mock.calls.map(([timeoutMs]) => timeoutMs)).toEqual([
+      45_000, 15_000,
+    ])
+    expect(extractSignal(fetchSpy, 0)).toBe(signals[0])
+    expect(extractSignal(fetchSpy, 1)).toBe(signals[1])
   })
 })

--- a/apps/web/src/lib/admin-client.ts
+++ b/apps/web/src/lib/admin-client.ts
@@ -12,41 +12,55 @@ import { env } from "@/env"
 // 3 s once admin's resolver fan-out is trimmed.
 // Pattern: docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md
 const REQUEST_TIMEOUT_MS = 15_000
+const SEMANTIC_SEARCH_REQUEST_TIMEOUT_MS = 45_000
 
-const timeoutFetch: typeof fetch = (input, init) =>
-  fetch(input, { ...init, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
+function createTimeoutFetch(timeoutMs: number): typeof fetch {
+  return (input, init) =>
+    fetch(input, { ...init, signal: AbortSignal.timeout(timeoutMs) })
+}
 
 // Deferred construction: types in `content.ts` are imported transitively
 // by a few `"use client"` renderers (e.g. `WatchSectionRenderer` needs
 // the `isWatchBlock` type-guard alongside block types). Reading
 // `env.WEB_ADMIN_API_KEYS` / `env.ADMIN_GRAPHQL_URL` at module-load
 // trips t3-oss/env-nextjs's client guard the moment any such client
-// chunk evaluates this file. A lazy singleton keeps module-load inert
-// on the client; server callers still hit a single shared instance.
-let realClient: ApolloClient | undefined
-
-function ensureClient(): ApolloClient {
-  if (realClient) return realClient
+// chunk evaluates this file. Lazy singletons keep module-load inert
+// on the client; server callers still hit shared instances per timeout budget.
+function createAdminClient(timeoutMs: number): ApolloClient {
   // WEB_ADMIN_API_KEYS may be a single key or a CSV mirroring admin's
   // keyring. We read the first entry as our outbound bearer so traffic
   // identifies as `consumer:<key>` at admin's rate-limit layer rather
   // than `public:<railway-egress-ip>`.
   const bearer = env.WEB_ADMIN_API_KEYS.split(",")[0]?.trim() ?? ""
-  realClient = new ApolloClient({
+  return new ApolloClient({
     link: new HttpLink({
       uri: env.ADMIN_GRAPHQL_URL,
       headers: bearer ? { Authorization: `Bearer ${bearer}` } : {},
-      fetch: timeoutFetch,
+      fetch: createTimeoutFetch(timeoutMs),
     }),
     cache: new InMemoryCache(),
   })
-  return realClient
 }
 
-const adminClient = new Proxy({} as ApolloClient, {
-  get(_target, prop, receiver) {
-    return Reflect.get(ensureClient(), prop, receiver)
-  },
-})
+function createLazyAdminClient(timeoutMs: number): ApolloClient {
+  let realClient: ApolloClient | undefined
+
+  function ensureClient(): ApolloClient {
+    realClient ??= createAdminClient(timeoutMs)
+    return realClient
+  }
+
+  return new Proxy({} as ApolloClient, {
+    get(_target, prop, receiver) {
+      return Reflect.get(ensureClient(), prop, receiver)
+    },
+  })
+}
+
+const adminClient = createLazyAdminClient(REQUEST_TIMEOUT_MS)
+
+export const semanticSearchAdminClient = createLazyAdminClient(
+  SEMANTIC_SEARCH_REQUEST_TIMEOUT_MS,
+)
 
 export default adminClient

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -1,16 +1,23 @@
 import { print, type DocumentNode } from "graphql"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import client from "@/lib/admin-client"
+import client, { semanticSearchAdminClient } from "@/lib/admin-client"
 import { searchVideos } from "./search"
+
+const defaultQueryMock = vi.hoisted(() => vi.fn())
+const semanticQueryMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/lib/admin-client", () => ({
   default: {
-    query: vi.fn(),
+    query: defaultQueryMock,
+  },
+  semanticSearchAdminClient: {
+    query: semanticQueryMock,
   },
 }))
 
-const queryMock = vi.mocked(client.query)
+const defaultClientQueryMock = vi.mocked(client.query)
+const queryMock = vi.mocked(semanticSearchAdminClient.query)
 
 type SearchQueryCall = {
   query: DocumentNode
@@ -34,13 +41,21 @@ function mockSearchResponse(searchMode: "HYBRID" | "KEYWORD_ONLY" = "HYBRID") {
         results: [],
       },
     },
-  } as Awaited<ReturnType<typeof client.query>>)
+  } as Awaited<ReturnType<typeof semanticSearchAdminClient.query>>)
 }
 
 describe("searchVideos", () => {
   beforeEach(() => {
+    defaultClientQueryMock.mockReset()
     queryMock.mockReset()
     mockSearchResponse()
+  })
+
+  it("uses the semantic-search Admin client instead of the default Admin client", async () => {
+    await searchVideos("jesus")
+
+    expect(defaultClientQueryMock).not.toHaveBeenCalled()
+    expect(queryMock).toHaveBeenCalledOnce()
   })
 
   it("declares and forwards the keyword-first mode argument", async () => {

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,5 +1,5 @@
 import { adminGraphql, type AdminResultOf } from "@forge/admin-graphql"
-import client from "@/lib/admin-client"
+import { semanticSearchAdminClient } from "@/lib/admin-client"
 import type { SearchLanguageResolution } from "./search-language"
 
 // Admin's `search(q, locale, type, limit, offset, mode, debug)` is the
@@ -164,7 +164,7 @@ export async function searchVideos(
   const truncatedQuery = query.slice(0, MAX_QUERY_LENGTH)
 
   const startedAt = performance.now()
-  const result = await client.query({
+  const result = await semanticSearchAdminClient.query({
     query: searchVideosOperation,
     variables: {
       q: truncatedQuery,

--- a/docs/plans/2026-06-12-001-fix-web-semantic-search-timeout-plan.md
+++ b/docs/plans/2026-06-12-001-fix-web-semantic-search-timeout-plan.md
@@ -1,0 +1,72 @@
+---
+title: "fix: Give Web semantic search a bounded Admin timeout"
+type: "fix"
+date: "2026-06-12"
+---
+
+# fix: Give Web semantic search a bounded Admin timeout
+
+## Summary
+
+Web semantic search should use a longer bounded Admin GraphQL timeout while other Web Admin GraphQL callers keep the existing 15 second budget.
+
+## Problem Frame
+
+Production semantic search normally returns in several seconds but can brush past the current global 15 second `AbortSignal.timeout` in `apps/web/src/lib/admin-client.ts`. The mitigation must keep the timeout finite, avoid search-quality or retriever changes, and leave the Algolia rollout path alone.
+
+## Requirements
+
+- R1. Semantic search requests from `searchVideos` use a longer bounded Admin GraphQL timeout, targeted at 45 seconds.
+- R2. Non-search Admin GraphQL callers keep the existing 15 second timeout.
+- R3. Server-only Admin GraphQL configuration remains behind the server data layer and is not exposed through client code or public environment variables.
+- R4. Algolia behavior, Admin ranking, and Admin retriever SQL stay unchanged.
+- R5. Tests prove the timeout budget selected by the default Admin client and the semantic-search Admin client.
+
+## Key Technical Decisions
+
+- KTD1. Add a second lazy Admin client rather than lengthening the singleton timeout: this keeps the mitigation limited to the semantic search adapter and avoids changing every Admin GraphQL request in Web.
+- KTD2. Keep both clients in `apps/web/src/lib/admin-client.ts`: bearer parsing, endpoint configuration, cache construction, and lazy env access stay centralized.
+- KTD3. Use a 45 second search budget: it gives production semantic search headroom above the current 15 second ceiling while remaining bounded.
+
+## Implementation Units
+
+### U1. Add a search-specific Admin client
+
+- **Goal:** Refactor `apps/web/src/lib/admin-client.ts` so it can create lazy Admin clients with distinct timeout budgets.
+- **Requirements:** R1, R2, R3.
+- **Dependencies:** None.
+- **Files:** `apps/web/src/lib/admin-client.ts`, `apps/web/src/lib/admin-client.test.ts`.
+- **Approach:** Extract timeout-fetch and lazy-client construction helpers, keep the default export on the 15 second budget, and export a named semantic-search client on the 45 second budget.
+- **Patterns to follow:** Existing lazy singleton comment in `apps/web/src/lib/admin-client.ts`; outbound timeout guidance in `docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md`.
+- **Test scenarios:** Query through the default export and assert `AbortSignal.timeout` receives 15000; query through the semantic-search client and assert `AbortSignal.timeout` receives 45000; bearer parsing still uses the first trimmed CSV key.
+- **Verification:** Tests show both client entry points remain bounded and select different budgets.
+
+### U2. Route semantic search through the search client
+
+- **Goal:** Make `searchVideos` use the longer bounded Admin client without touching Algolia dispatch or search result normalization.
+- **Requirements:** R1, R4.
+- **Dependencies:** U1.
+- **Files:** `apps/web/src/lib/search.ts`, `apps/web/src/lib/search.test.ts`, `apps/web/src/lib/search-actions.test.ts`.
+- **Approach:** Replace the generic Admin client import in `search.ts` with the semantic-search Admin client and leave `runSearch` dispatch rules unchanged.
+- **Patterns to follow:** `apps/web/src/lib/search-actions.ts` remains the server-action fork between semantic and Algolia search.
+- **Test scenarios:** Existing `runSearch` tests keep proving flag-off and type-filtered paths call `searchVideos`; `search.test.ts` proves `searchVideos` uses the search-specific Admin client; admin-client tests prove that client uses the longer timeout.
+- **Verification:** Search-action tests remain green and no Algolia adapter tests need behavior changes.
+
+## Scope Boundaries
+
+- Do not edit generated GraphQL files.
+- Do not change Admin semantic ranking, retrieval SQL, or embedding behavior.
+- Do not change Algolia request behavior, flags, result transforms, or UI controls.
+- Do not remove timeouts or make Admin GraphQL fetches unbounded.
+
+## Risks & Dependencies
+
+- A longer server-side search request can occupy a Web worker longer during Admin slowness; keeping the budget search-specific limits the blast radius.
+- Admin performance work remains the durable fix. This plan only prevents Web from aborting expected slow semantic-search requests too early.
+
+## Sources & Research
+
+- `apps/web/src/lib/admin-client.ts` owns the current 15 second Admin GraphQL fetch timeout and lazy server-only env access.
+- `apps/web/src/lib/search.ts` is the semantic search adapter used by `apps/web/src/lib/search-actions.ts`.
+- `docs/solutions/architecture-patterns/forge-algolia-search-modal-20260610.md` keeps the Algolia rollout split in the server action and preserves semantic search as the fallback path.
+- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md` and `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md` confirm this mitigation should not alter Admin retrieval topology.

--- a/docs/solutions/best-practices/operation-specific-admin-graphql-timeout.md
+++ b/docs/solutions/best-practices/operation-specific-admin-graphql-timeout.md
@@ -1,0 +1,134 @@
+---
+title: "Use operation-specific Admin GraphQL clients for exceptional timeout budgets"
+date: "2026-06-12"
+category: "best-practices"
+module: "apps/web Admin GraphQL client"
+problem_type: "best_practice"
+component: "service_object"
+severity: "medium"
+applies_when:
+  - "One Admin GraphQL operation needs materially more timeout headroom than the default Web data layer"
+  - "A production mitigation should stay bounded without globally widening every Admin GraphQL call"
+  - "A server action or adapter can route a specific operation through a named Admin client"
+tags: [admin-graphql, timeout, semantic-search, reliability, web]
+related_components: [apps/web, apps/admin, packages/admin-graphql]
+---
+
+# Use operation-specific Admin GraphQL clients for exceptional timeout budgets
+
+## Context
+
+`apps/web/src/lib/admin-client.ts` centralizes Web's Admin GraphQL Apollo client, bearer header, and fetch timeout. That default is intentionally short so ordinary server-side reads fail fast when Admin is sick.
+
+Semantic search is an exception. It can be healthy at several seconds and still exceed the general Web Admin timeout while Admin performance work is pending. The mitigation should not remove timeouts, lengthen every Admin call, or alter Admin ranking, retriever SQL, or Algolia behavior.
+
+## Guidance
+
+Keep the default Admin client on the normal timeout and add a named operation-specific client for the exceptional operation.
+
+The durable shape:
+
+1. Keep bearer parsing, endpoint config, cache construction, and lazy env access in `admin-client.ts`.
+2. Extract client construction around a timeout parameter.
+3. Preserve the default export for normal Admin GraphQL calls.
+4. Export a named client for the exceptional operation.
+5. Route only the operation adapter through that named client.
+
+Simplified example:
+
+```ts
+const REQUEST_TIMEOUT_MS = 15_000
+const SEMANTIC_SEARCH_REQUEST_TIMEOUT_MS = 45_000
+
+function createTimeoutFetch(timeoutMs: number): typeof fetch {
+  return (input, init) =>
+    fetch(input, { ...init, signal: AbortSignal.timeout(timeoutMs) })
+}
+
+function createLazyAdminClient(timeoutMs: number): ApolloClient {
+  let realClient: ApolloClient | undefined
+  return new Proxy({} as ApolloClient, {
+    get(_target, prop, receiver) {
+      realClient ??= createAdminClient(timeoutMs)
+      return Reflect.get(realClient, prop, receiver)
+    },
+  })
+}
+
+export default createLazyAdminClient(REQUEST_TIMEOUT_MS)
+export const semanticSearchAdminClient = createLazyAdminClient(
+  SEMANTIC_SEARCH_REQUEST_TIMEOUT_MS,
+)
+```
+
+Then the operation adapter makes the scope visible at the call site:
+
+```ts
+import { semanticSearchAdminClient } from "@/lib/admin-client"
+
+export async function searchVideos(...) {
+  return semanticSearchAdminClient.query({
+    query: SEARCH_QUERY,
+    variables,
+    fetchPolicy: "no-cache",
+  })
+}
+```
+
+Tests need two layers:
+
+- Admin client boundary: prove the default export still uses the default budget, the named client uses the longer budget, both clients keep independent budgets in one module instance, and the timeout signal reaches fetch.
+- Operation adapter boundary: prove the exceptional adapter calls the named client rather than the default client.
+
+The second test is easy to miss. Tests that call the named client directly still pass if the adapter later regresses to the default client.
+
+## Why This Matters
+
+A global timeout increase turns one slow operation into a system-wide resource-occupancy change. A no-timeout fetch can pin workers indefinitely. A named bounded client keeps the mitigation explicit and reversible while preserving the existing failure posture for unrelated Admin reads.
+
+The adapter-level test protects the real production promise: the semantic search path must actually select the search-specific client. The client-level tests protect the implementation detail that makes that promise safe: separate lazy clients must not share a first-touch singleton or accidentally use the same timeout.
+
+## When to Apply
+
+- Use this when one Admin GraphQL operation has a justified latency profile that differs from the rest of the Web data layer.
+- Keep the exceptional timeout lower than any outer server action, route, proxy, or platform budget with response-shaping headroom.
+- Do not use this as a substitute for fixing the slow resolver, SQL, index, or retriever when that is the real durable work.
+- Do not use this to widen browser-exposed behavior; Admin bearer access stays server-side.
+
+## Examples
+
+Good mitigation:
+
+```ts
+// Normal content, language metadata, recommendations, etc.
+import adminClient from "@/lib/admin-client"
+
+// Semantic search only.
+import { semanticSearchAdminClient } from "@/lib/admin-client"
+```
+
+Avoid:
+
+```ts
+// Every Admin GraphQL call now waits for the slowest exceptional operation.
+const REQUEST_TIMEOUT_MS = 45_000
+
+// Or worse, no timeout at all.
+fetch(input, init)
+```
+
+Review checklist:
+
+- The default client still has the original timeout.
+- The exceptional client is bounded.
+- The exceptional adapter imports the exceptional client.
+- Tests exercise both exports from one module instance.
+- Tests fail if the adapter goes back to the default client.
+- Local agent/developer guidance mentions the split so future agents choose the right client.
+
+## Related
+
+- [Outbound timeout must be shorter than the caller's upstream budget](./outbound-timeout-shorter-than-caller-budget-20260506.md)
+- [Forge Algolia Search Modal Pattern](../architecture-patterns/forge-algolia-search-modal-20260610.md)
+- [Admin hybrid search (R4) - port pattern](../platform/admin-hybrid-search-r4-pattern.md)
+- [Admin video semantic search: mix scene and transcript evidence inside one retriever](../platform/admin-mixed-video-semantic-evidence-pattern-20260521.md)


### PR DESCRIPTION
## Summary

Production semantic search can now wait up to 45 seconds for Admin GraphQL without removing the timeout or widening the default Web Admin budget. Before this, a healthy but slow semantic search could hit Web's shared 15 second abort ceiling and surface as a redacted search failure; now only `searchVideos` uses the longer bounded client while content, recommendations, downloads, and other Admin GraphQL callers stay on 15 seconds.

Algolia behavior, Admin ranking, retriever SQL, and generated GraphQL files are unchanged.

## Notes

- Added a timeout-parameterized lazy Admin client factory with a default 15 second export and a named `semanticSearchAdminClient` on 45 seconds.
- Routed the semantic search adapter through the named client so the mitigation is operation-specific.
- Added client-boundary tests for both timeout budgets and adapter-boundary coverage that fails if semantic search falls back to the default client.
- Included the formal CE plan and best-practice note for the temporary mitigation pattern.

## Production Validation

After merge/deploy, monitor `@forge/web` search failures and logs containing `[watch-search][semantic]`. Expected behavior: semantic searches that run longer than 15 seconds no longer abort at Web's previous ceiling; unrelated Admin GraphQL calls should retain their 15 second fail-fast behavior.

Rollback is a normal revert of this PR if the longer search-only budget causes worker occupancy or outer-platform budget issues.

## Tests

- `pnpm exec prettier --check apps/web/CLAUDE.md apps/web/src/lib/admin-client.ts apps/web/src/lib/admin-client.test.ts apps/web/src/lib/search.ts apps/web/src/lib/search.test.ts docs/plans/2026-06-12-001-fix-web-semantic-search-timeout-plan.md docs/solutions/best-practices/operation-specific-admin-graphql-timeout.md`
- `pnpm --filter @forge/web exec vitest run src/lib/admin-client.test.ts src/lib/search.test.ts src/lib/search-actions.test.ts src/lib/algolia-search.test.ts`
- `pnpm --filter @forge/web exec eslint src/lib/admin-client.ts src/lib/admin-client.test.ts src/lib/search.ts src/lib/search.test.ts src/lib/search-actions.test.ts`
- `pnpm --filter @forge/web typecheck`
- `git diff --check`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.12.0/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/best-practices/operation-specific-admin-graphql-timeout.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
