### PR TITLE
fix(web): avoid no-op watch chapter scroll

### DIFF
--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -318,7 +318,7 @@ export function WatchPageClient({
       void routeWarmPromise.finally(() => {
         if (cancelled) return
         writeWatchChapterPosterBridgeIntent(intent)
-        router.push(intent.href as Route)
+        router.push(intent.href as Route, { scroll: window.scrollY > 1 })
       })
     }, delay)
 

--- a/apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx
@@ -114,6 +114,10 @@ beforeEach(() => {
   })
   window.sessionStorage.clear()
   window.history.replaceState({}, "", "/watch/current-video.html/english.html")
+  Object.defineProperty(window, "scrollY", {
+    configurable: true,
+    value: 0,
+  })
   container = document.createElement("div")
   document.body.appendChild(container)
   root = createRoot(container)
@@ -201,6 +205,23 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
+async function clickChapterAndFlushNavigation() {
+  const renderer = () =>
+    container.querySelector('[data-testid="watch-section-renderer"]')
+
+  act(() => {
+    ;(renderer() as HTMLButtonElement).click()
+  })
+  act(() => {
+    vi.advanceTimersByTime(WATCH_CHAPTER_POSTER_BLACKOUT_MS)
+  })
+  await act(async () => {
+    vi.advanceTimersByTime(WATCH_CHAPTER_POSTER_REVEAL_MS)
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
 describe("WatchPageClient chapter navigation", () => {
   it("validates pending chapter state and self-invalidates after route commit", async () => {
     vi.useFakeTimers()
@@ -247,7 +268,9 @@ describe("WatchPageClient chapter navigation", () => {
       await Promise.resolve()
       await Promise.resolve()
     })
-    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html")
+    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html", {
+      scroll: false,
+    })
 
     window.history.replaceState({}, "", "/watch/child-2.html/english.html")
     renderWatchPage(makeVideo("child-2", "Clicked Child"))
@@ -305,6 +328,23 @@ describe("WatchPageClient chapter navigation", () => {
       await Promise.resolve()
     })
 
-    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html")
+    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html", {
+      scroll: false,
+    })
+  })
+
+  it("keeps route-change scrolling enabled for chapter clicks below the top", async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 240,
+    })
+    renderWatchPage()
+
+    await clickChapterAndFlushNavigation()
+
+    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html", {
+      scroll: true,
+    })
   })
 })


### PR DESCRIPTION
## Summary

Watch chapter switches no longer ask Next.js to scroll when the viewer is already at the top of the page, removing the subtle upward tug during top-of-page episode changes. If the viewer clicks a chapter from lower on the page, the route change still scrolls back to the hero as before.

The existing poster bridge, route warmup, and blackout/reveal sequence stay intact; only the route push's scroll option is now based on the current scroll position.

## Testing

- `pnpm --filter @forge/web test -- src/components/watch/__tests__/WatchPageClient.navigation.test.tsx`
- Local Watch smoke at `http://127.0.0.1:3000/watch/great-commission-and-ascension.html/english.html`: top-of-page chapter switch changed routes with no recorded `window.scrollTo` calls; scrolled-down switch from `scrollY: 800` returned to `scrollY: 0`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
