### PR TITLE
Move Watch hreflang to sitemap manifest

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -276,6 +276,44 @@ and `video-dub-downloads`. When any of those phases run, admin emits a broad
 `model: "video"` webhook with no slug so web clears video, series, child-dub,
 and home resolver caches even when the manifest itself does not need refreshing.
 
+### Watch SEO sitemap manifest snapshot
+
+Admin owns the Watch sitemap-only hreflang manifest at
+`GET /api/watch-seo-manifest`. The route requires the normal consumer bearer
+and returns the latest persisted snapshot with `ETag` support; if no snapshot
+exists, it returns a controlled 503 instead of generating on demand.
+
+This manifest is deliberately separate from the route manifest. The route
+manifest stays a compact route-admission contract; the SEO manifest carries
+only sitemap rendering data for public Watch video and episode URLs.
+
+Snapshot fields the web branch can rely on:
+
+- `videoRouteGroups` — public two-segment Watch content slugs and valid
+  Google-supported hreflang alternates with their public audio language slugs.
+- `episodeRouteGroups` — parent/child Watch episode slug pairs and valid
+  Google-supported hreflang alternates with their public audio language slugs.
+- `skippedHreflangValues` — aggregate counts for duplicate, missing, or
+  unsupported language tags skipped during generation.
+- `version` and `generatedAt` — stable cache/revalidation metadata.
+
+Refresh triggers:
+
+- Core sync phases `languages`, `videos`, and `video-dubs`.
+- Operator refresh script:
+
+```bash
+DATABASE_URL='postgresql://forge:forge@localhost:5433/forge_admin' \
+pnpm --filter @forge/admin watch-seo-manifest:generate
+```
+
+The script prints summary-only JSON by default: version, generated timestamp,
+payload size, counts, and duration. Use `--print` only for local debugging when
+the full manifest payload is intentionally needed. Like the route-manifest
+script, it refuses production-like `DATABASE_URL` hosts (`*.railway.app`,
+`*.jesusfilm.org`, and unparseable URLs) so operators do not accidentally mutate
+production snapshots from a workstation.
+
 ### Video database backup and clone
 
 Production backup is automated only. Do not add or use an operator

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -32,6 +32,7 @@
     "seed-easter": "tsx --env-file=.env src/scripts/seed-easter.ts",
     "seed-web-fixtures": "tsx --env-file=.env src/scripts/seed-web-fixtures.ts",
     "watch-route-manifest:generate": "tsx --env-file=.env src/scripts/generate-watch-route-manifest.ts",
+    "watch-seo-manifest:generate": "tsx --env-file=.env src/scripts/generate-watch-seo-manifest.ts",
     "manager:grant-operator": "tsx --env-file=.env src/scripts/grant-manager-operator.ts",
     "trigger-enrichment": "tsx src/scripts/trigger-enrichment.ts",
     "workflow:setup:postgres": "workflow-postgres-setup",

--- a/apps/admin/prisma/migrations/0026_watch_seo_manifest_snapshot/migration.sql
+++ b/apps/admin/prisma/migrations/0026_watch_seo_manifest_snapshot/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "watch_seo_manifest_snapshot" (
+    "key" TEXT PRIMARY KEY,
+    "version" TEXT NOT NULL,
+    "generated_at" timestamp(3) NOT NULL,
+    "payload" JSONB NOT NULL,
+    "payload_size_bytes" INTEGER NOT NULL,
+    "created_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX "watch_seo_manifest_snapshot_generated_at_idx"
+    ON "watch_seo_manifest_snapshot"("generated_at");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -576,6 +576,22 @@ model WatchRouteManifestSnapshot {
   @@map("watch_route_manifest_snapshot")
 }
 
+/// Latest admin-owned Watch hreflang sitemap manifest. This singleton
+/// snapshot lets apps/web generate sitemap XML without recomputing the full
+/// video-language alternate graph in page render paths.
+model WatchSeoManifestSnapshot {
+  key              String   @id
+  version          String
+  generatedAt      DateTime @map("generated_at")
+  payload          Json
+  payloadSizeBytes Int      @map("payload_size_bytes")
+  createdAt        DateTime @default(now()) @map("created_at")
+  updatedAt        DateTime @updatedAt @map("updated_at")
+
+  @@index([generatedAt])
+  @@map("watch_seo_manifest_snapshot")
+}
+
 /// Admin-owned persistence for Manager enrichment jobs. Field names mirror the
 /// existing Manager JobRecord so Manager can move transport without UI churn.
 model ManagerEnrichmentJob {

--- a/apps/admin/src/app/api/watch-seo-manifest/route.test.ts
+++ b/apps/admin/src/app/api/watch-seo-manifest/route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const isValidConsumerBearerMock = vi.fn()
+const getLatestMock = vi.fn()
+
+vi.mock("@/auth/consumer-bearer", () => ({
+  isValidConsumerBearer: isValidConsumerBearerMock,
+}))
+
+vi.mock("@/db/client", () => ({
+  prisma: {},
+}))
+
+vi.mock("@/services/watch-seo-manifest-store", () => ({
+  WatchSeoManifestStore: vi.fn(() => ({
+    getLatest: getLatestMock,
+  })),
+}))
+
+const { GET } = await import("./route")
+
+const manifest = {
+  version: "version-1",
+  generatedAt: "2026-06-12T12:00:00.000Z",
+  videoRouteGroups: [
+    {
+      contentSlug: "jesus",
+      alternates: [{ hreflang: "en", languageSlug: "english" }],
+    },
+  ],
+  episodeRouteGroups: [],
+  skippedHreflangValues: {},
+}
+
+function request(headers: HeadersInit = {}) {
+  return new Request("http://admin.test/api/watch-seo-manifest", {
+    method: "GET",
+    headers,
+  })
+}
+
+describe("GET /api/watch-seo-manifest", () => {
+  beforeEach(() => {
+    isValidConsumerBearerMock.mockReset()
+    getLatestMock.mockReset()
+    isValidConsumerBearerMock.mockReturnValue({
+      valid: true,
+      bucketKey: "web-key",
+    })
+    getLatestMock.mockResolvedValue({
+      key: "latest",
+      version: manifest.version,
+      generatedAt: new Date(manifest.generatedAt),
+      payload: manifest,
+      payloadSizeBytes: 123,
+      createdAt: new Date("2026-06-12T12:00:01.000Z"),
+      updatedAt: new Date("2026-06-12T12:00:02.000Z"),
+    })
+  })
+
+  it("returns the latest manifest for a valid consumer bearer", async () => {
+    const response = await GET(
+      request({ authorization: "Bearer test-consumer-key" }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("etag")).toBe('"version-1"')
+    expect(response.headers.get("cache-control")).toBe(
+      "private, max-age=0, must-revalidate",
+    )
+    await expect(response.json()).resolves.toEqual(manifest)
+    expect(isValidConsumerBearerMock).toHaveBeenCalledWith(
+      "Bearer test-consumer-key",
+    )
+  })
+
+  it("returns 304 when the caller already has the current version", async () => {
+    const response = await GET(
+      request({
+        authorization: "Bearer test-consumer-key",
+        "if-none-match": '"version-1"',
+      }),
+    )
+
+    expect(response.status).toBe(304)
+    expect(await response.text()).toBe("")
+  })
+
+  it("rejects missing or invalid bearer without revealing snapshot state", async () => {
+    isValidConsumerBearerMock.mockReturnValue({
+      valid: false,
+      bucketKey: null,
+    })
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get("www-authenticate")).toBe(
+      'Bearer realm="watch-seo-manifest"',
+    )
+    await expect(response.json()).resolves.toEqual({
+      error: "Authorization required",
+    })
+    expect(getLatestMock).not.toHaveBeenCalled()
+  })
+
+  it("returns a clear 503 when no snapshot exists", async () => {
+    getLatestMock.mockResolvedValueOnce(null)
+
+    const response = await GET(request({ authorization: "Bearer key" }))
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      error: "Watch SEO manifest unavailable",
+      reason: "missing_snapshot",
+    })
+  })
+
+  it("returns a controlled 500 when the store read fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    getLatestMock.mockRejectedValueOnce(new Error("database secret detail"))
+
+    const response = await GET(request({ authorization: "Bearer key" }))
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: "Watch SEO manifest read failed",
+      reason: "read_failed",
+    })
+    expect(warn.mock.calls[0][0]).toContain("watch_seo_manifest.read.failed")
+    warn.mockRestore()
+  })
+})

--- a/apps/admin/src/app/api/watch-seo-manifest/route.ts
+++ b/apps/admin/src/app/api/watch-seo-manifest/route.ts
@@ -1,0 +1,66 @@
+import { isValidConsumerBearer } from "@/auth/consumer-bearer"
+import { prisma } from "@/db/client"
+import { WatchSeoManifestStore } from "@/services/watch-seo-manifest-store"
+
+const CACHE_CONTROL = "private, max-age=0, must-revalidate"
+
+function unauthorized(): Response {
+  return Response.json(
+    { error: "Authorization required" },
+    {
+      status: 401,
+      headers: { "WWW-Authenticate": 'Bearer realm="watch-seo-manifest"' },
+    },
+  )
+}
+
+export async function GET(request: Request): Promise<Response> {
+  if (!isValidConsumerBearer(request.headers.get("authorization")).valid) {
+    return unauthorized()
+  }
+
+  const store = new WatchSeoManifestStore(prisma)
+
+  try {
+    const snapshot = await store.getLatest()
+    if (!snapshot) {
+      return Response.json(
+        {
+          error: "Watch SEO manifest unavailable",
+          reason: "missing_snapshot",
+        },
+        {
+          status: 503,
+          headers: { "Cache-Control": "private, no-store" },
+        },
+      )
+    }
+
+    const etag = `"${snapshot.version}"`
+    const headers = {
+      "Cache-Control": CACHE_CONTROL,
+      ETag: etag,
+    }
+
+    if (request.headers.get("if-none-match") === etag) {
+      return new Response(null, { status: 304, headers })
+    }
+
+    return Response.json(snapshot.payload, { status: 200, headers })
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "watch_seo_manifest.read.failed",
+        detail:
+          error instanceof Error ? error.message.slice(0, 500) : String(error),
+      }),
+    )
+    return Response.json(
+      {
+        error: "Watch SEO manifest read failed",
+        reason: "read_failed",
+      },
+      { status: 500, headers: { "Cache-Control": "private, no-store" } },
+    )
+  }
+}

--- a/apps/admin/src/scripts/generate-watch-seo-manifest.test.ts
+++ b/apps/admin/src/scripts/generate-watch-seo-manifest.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  assertNotProdUrl,
+  CliConfigError,
+  parseGenerateWatchSeoManifestArgs,
+  runGenerateWatchSeoManifest,
+} from "./generate-watch-seo-manifest"
+
+const manifest = {
+  version: "version-1",
+  generatedAt: "2026-06-12T12:00:00.000Z",
+  videoRouteGroups: [
+    {
+      contentSlug: "great-commission-and-ascension",
+      alternates: [
+        { hreflang: "en", languageSlug: "english" },
+        { hreflang: "es", languageSlug: "spanish" },
+      ],
+    },
+  ],
+  episodeRouteGroups: [
+    {
+      parentSlug: "jesus",
+      childSlug: "great-commission-and-ascension",
+      alternates: [{ hreflang: "en", languageSlug: "english" }],
+    },
+  ],
+  skippedHreflangValues: { "zh-Hans": 1 },
+}
+
+function makeSnapshot() {
+  return {
+    key: "latest",
+    version: manifest.version,
+    generatedAt: new Date(manifest.generatedAt),
+    payload: manifest,
+    payloadSizeBytes: 512,
+    createdAt: new Date("2026-06-12T12:00:01.000Z"),
+    updatedAt: new Date("2026-06-12T12:00:02.000Z"),
+  }
+}
+
+function makeStdout() {
+  const chunks: string[] = []
+  return {
+    stream: {
+      write(chunk: string) {
+        chunks.push(chunk)
+      },
+    },
+    lines() {
+      return chunks.join("").trim().split("\n").filter(Boolean)
+    },
+  }
+}
+
+describe("parseGenerateWatchSeoManifestArgs", () => {
+  it("defaults to summary-only output", () => {
+    expect(parseGenerateWatchSeoManifestArgs([])).toEqual({
+      printManifest: false,
+    })
+  })
+
+  it("enables explicit print mode", () => {
+    expect(parseGenerateWatchSeoManifestArgs(["--print"])).toEqual({
+      printManifest: true,
+    })
+  })
+
+  it("rejects unknown arguments", () => {
+    expect(() => parseGenerateWatchSeoManifestArgs(["--verbose"])).toThrow(
+      CliConfigError,
+    )
+  })
+})
+
+describe("assertNotProdUrl", () => {
+  it("refuses production-like and unparseable URLs", () => {
+    expect(() =>
+      assertNotProdUrl("postgresql://user:pass@some-host.railway.app:5432/db"),
+    ).toThrow(/railway\.app/)
+    expect(() =>
+      assertNotProdUrl("postgresql://user:pass@admin.jesusfilm.org:5432/db"),
+    ).toThrow(/jesusfilm\.org/)
+    expect(() => assertNotProdUrl("not a url")).toThrow(/parseable URL/i)
+    expect(() => assertNotProdUrl(undefined)).toThrow(/required/i)
+  })
+
+  it("allows local database hosts", () => {
+    expect(() =>
+      assertNotProdUrl("postgresql://forge:forge@localhost:5432/forge_admin"),
+    ).not.toThrow()
+    expect(() =>
+      assertNotProdUrl("postgresql://forge:forge@127.0.0.1:5432/forge_admin"),
+    ).not.toThrow()
+    expect(() =>
+      assertNotProdUrl("postgresql://forge:forge@db:5432/forge_admin"),
+    ).not.toThrow()
+  })
+})
+
+describe("runGenerateWatchSeoManifest", () => {
+  it("refreshes the snapshot and prints a summary without the manifest payload", async () => {
+    const stdout = makeStdout()
+    const refreshWatchSeoManifest = vi.fn().mockResolvedValue({
+      status: "refreshed",
+      reason: "operator-script",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 512,
+      counts: {
+        videoRouteGroups: 1,
+        episodeRouteGroups: 1,
+        alternateLinks: 3,
+        skippedHreflangValues: 1,
+      },
+      durationMs: 42,
+    })
+    const getLatestSnapshot = vi.fn().mockResolvedValue(makeSnapshot())
+
+    await runGenerateWatchSeoManifest(
+      { printManifest: false },
+      {
+        prisma: {} as never,
+        refreshWatchSeoManifest,
+        getLatestSnapshot,
+        stdout: stdout.stream,
+      },
+    )
+
+    expect(refreshWatchSeoManifest).toHaveBeenCalledWith({
+      prisma: {},
+      reason: "operator-script",
+    })
+    const lines = stdout.lines()
+    expect(lines).toHaveLength(1)
+    expect(JSON.parse(lines[0]!)).toEqual({
+      event: "watch_seo_manifest.generate.complete",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 512,
+      counts: {
+        videoRouteGroups: 1,
+        episodeRouteGroups: 1,
+        alternateLinks: 3,
+        skippedHreflangValues: 1,
+      },
+      durationMs: 42,
+    })
+  })
+
+  it("prints the full manifest only when --print was requested", async () => {
+    const stdout = makeStdout()
+    const refreshWatchSeoManifest = vi.fn().mockResolvedValue({
+      status: "refreshed",
+      reason: "operator-script",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 512,
+      counts: {
+        videoRouteGroups: 1,
+        episodeRouteGroups: 1,
+        alternateLinks: 3,
+        skippedHreflangValues: 1,
+      },
+      durationMs: 42,
+    })
+
+    await runGenerateWatchSeoManifest(
+      { printManifest: true },
+      {
+        prisma: {} as never,
+        refreshWatchSeoManifest,
+        getLatestSnapshot: vi.fn().mockResolvedValue(makeSnapshot()),
+        stdout: stdout.stream,
+      },
+    )
+
+    const lines = stdout.lines()
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[1]!)).toEqual({
+      event: "watch_seo_manifest.generate.manifest",
+      manifest,
+    })
+  })
+
+  it("does not print a stale success summary when refresh fails", async () => {
+    const stdout = makeStdout()
+    const getLatestSnapshot = vi.fn()
+
+    await expect(
+      runGenerateWatchSeoManifest(
+        { printManifest: false },
+        {
+          prisma: {} as never,
+          refreshWatchSeoManifest: vi.fn().mockResolvedValue({
+            status: "failed",
+            reason: "operator-script",
+            detail: "db unavailable",
+            durationMs: 12,
+          }),
+          getLatestSnapshot,
+          stdout: stdout.stream,
+        },
+      ),
+    ).rejects.toThrow(/db unavailable/)
+
+    expect(getLatestSnapshot).not.toHaveBeenCalled()
+    expect(stdout.lines()).toEqual([])
+  })
+})

--- a/apps/admin/src/scripts/generate-watch-seo-manifest.ts
+++ b/apps/admin/src/scripts/generate-watch-seo-manifest.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env tsx
+/**
+ * Generate and persist the admin-owned Watch SEO sitemap manifest snapshot.
+ *
+ * Usage:
+ *   DATABASE_URL='postgresql://forge:forge@localhost:5433/forge_admin' \
+ *   pnpm --filter @forge/admin watch-seo-manifest:generate
+ *
+ * Optional:
+ *   --print   Also print the full manifest payload after the summary.
+ *
+ * Safety: refuses production-like DATABASE_URL values. This script
+ * mutates the snapshot table and is intended for local/operator refresh
+ * workflows, not ad-hoc production pokes.
+ */
+
+import { fileURLToPath } from "node:url"
+import { resolve } from "node:path"
+import type { PrismaClient } from "@prisma/client"
+import type { refreshWatchSeoManifest } from "@/services/watch-seo-manifest-refresh.service"
+import type { WatchSeoManifestSnapshotRecord } from "@/services/watch-seo-manifest-store"
+
+const PROD_HOST_DENY_SET = new Set<string>([
+  "admin.jesusfilm.org",
+  "www.jesusfilm.org",
+  "jesusfilm.org",
+  "manager.jesusfilm.org",
+  "web.jesusfilm.org",
+])
+
+export type GenerateWatchSeoManifestOptions = {
+  printManifest: boolean
+}
+
+export class CliConfigError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: 2 = 2,
+  ) {
+    super(message)
+    this.name = "CliConfigError"
+  }
+}
+
+export function parseGenerateWatchSeoManifestArgs(
+  argv: readonly string[],
+): GenerateWatchSeoManifestOptions {
+  const unknown = argv.filter((arg) => arg !== "--print")
+  if (unknown.length > 0) {
+    throw new CliConfigError(
+      `[generate-watch-seo-manifest] unknown argument(s): ${unknown.join(", ")}`,
+    )
+  }
+  return { printManifest: argv.includes("--print") }
+}
+
+function isProdDatabaseUrl(rawUrl: string): {
+  isProd: boolean
+  reason: string
+} {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return { isProd: true, reason: "DATABASE_URL is not a parseable URL" }
+  }
+
+  const host = parsed.hostname.toLowerCase()
+  if (host.endsWith(".railway.app")) {
+    return { isProd: true, reason: `host ${host} ends with .railway.app` }
+  }
+  if (host.endsWith(".jesusfilm.org")) {
+    return { isProd: true, reason: `host ${host} ends with .jesusfilm.org` }
+  }
+  if (PROD_HOST_DENY_SET.has(host)) {
+    return { isProd: true, reason: `host ${host} is on the prod deny set` }
+  }
+  return { isProd: false, reason: "" }
+}
+
+export function assertNotProdUrl(rawUrl: string | undefined): void {
+  if (!rawUrl) {
+    throw new Error("DATABASE_URL is required (no value set).")
+  }
+  const verdict = isProdDatabaseUrl(rawUrl)
+  if (verdict.isProd) {
+    throw new Error(
+      `[generate-watch-seo-manifest] Refusing to run: ${verdict.reason}. ` +
+        `Point DATABASE_URL at a local or reviewed non-production Postgres and try again.`,
+    )
+  }
+}
+
+type RefreshWatchSeoManifest = typeof refreshWatchSeoManifest
+
+type OutputStream = {
+  write(chunk: string): unknown
+}
+
+type RunDeps = {
+  prisma: PrismaClient
+  refreshWatchSeoManifest: RefreshWatchSeoManifest
+  getLatestSnapshot: () => Promise<WatchSeoManifestSnapshotRecord | null>
+  stdout?: OutputStream
+}
+
+export async function runGenerateWatchSeoManifest(
+  options: GenerateWatchSeoManifestOptions,
+  deps: RunDeps,
+): Promise<void> {
+  const stdout = deps.stdout ?? process.stdout
+  const outcome = await deps.refreshWatchSeoManifest({
+    prisma: deps.prisma,
+    reason: "operator-script",
+  })
+
+  if (outcome.status !== "refreshed") {
+    const detail =
+      outcome.status === "failed"
+        ? outcome.detail
+        : "refresh skipped unexpectedly"
+    throw new Error(`[generate-watch-seo-manifest] refresh failed: ${detail}`)
+  }
+
+  const snapshot = await deps.getLatestSnapshot()
+  if (!snapshot) {
+    throw new Error(
+      "[generate-watch-seo-manifest] refresh completed but no latest snapshot was found",
+    )
+  }
+
+  stdout.write(
+    JSON.stringify({
+      event: "watch_seo_manifest.generate.complete",
+      version: snapshot.version,
+      generatedAt: snapshot.payload.generatedAt,
+      payloadSizeBytes: snapshot.payloadSizeBytes,
+      counts: outcome.counts,
+      durationMs: outcome.durationMs,
+    }) + "\n",
+  )
+
+  if (options.printManifest) {
+    stdout.write(
+      JSON.stringify({
+        event: "watch_seo_manifest.generate.manifest",
+        manifest: snapshot.payload,
+      }) + "\n",
+    )
+  }
+}
+
+async function main(argv: readonly string[] = process.argv.slice(2)) {
+  const options = parseGenerateWatchSeoManifestArgs(argv)
+  assertNotProdUrl(process.env.DATABASE_URL)
+
+  const { prisma } = await import("@/db/client")
+  const { refreshWatchSeoManifest } =
+    await import("@/services/watch-seo-manifest-refresh.service")
+  const { WatchSeoManifestStore } =
+    await import("@/services/watch-seo-manifest-store")
+  const store = new WatchSeoManifestStore(prisma)
+
+  try {
+    await runGenerateWatchSeoManifest(options, {
+      prisma,
+      refreshWatchSeoManifest,
+      getLatestSnapshot: () => store.getLatest(),
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+const isDirectInvoke =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+
+if (isDirectInvoke) {
+  main().catch((error) => {
+    const exitCode = error instanceof CliConfigError ? error.exitCode : 1
+    process.stderr.write(
+      `[generate-watch-seo-manifest] fatal: ${
+        error instanceof Error ? (error.stack ?? error.message) : String(error)
+      }\n`,
+    )
+    process.exit(exitCode)
+  })
+}

--- a/apps/admin/src/services/core-sync/orchestrator.test.ts
+++ b/apps/admin/src/services/core-sync/orchestrator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest"
 import { resolveScope } from "./orchestrator"
 
 const refreshAfterCoreSyncMock = vi.hoisted(() => vi.fn())
+const refreshSeoAfterCoreSyncMock = vi.hoisted(() => vi.fn())
 
 vi.mock("./lock", () => ({
   acquireSyncLock: vi.fn(),
@@ -11,6 +12,10 @@ vi.mock("./lock", () => ({
 
 vi.mock("../watch-route-manifest-refresh.service", () => ({
   refreshWatchRouteManifestAfterCoreSync: refreshAfterCoreSyncMock,
+}))
+
+vi.mock("../watch-seo-manifest-refresh.service", () => ({
+  refreshWatchSeoManifestAfterCoreSync: refreshSeoAfterCoreSyncMock,
 }))
 
 vi.mock("./watermark", () => ({
@@ -122,6 +127,7 @@ describe("runSync", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     refreshAfterCoreSyncMock.mockResolvedValue({ status: "skipped" })
+    refreshSeoAfterCoreSyncMock.mockResolvedValue({ status: "skipped" })
   })
 
   it("returns skipped when lock is held", async () => {
@@ -167,6 +173,16 @@ describe("runSync", () => {
       expect.stringMatching(/^sync-\d+$/),
     )
     expect(refreshAfterCoreSyncMock).toHaveBeenCalledWith({
+      prisma: mockPrisma,
+      phases: [
+        expect.objectContaining({
+          phase: "languages",
+          created: 5,
+          errors: 0,
+        }),
+      ],
+    })
+    expect(refreshSeoAfterCoreSyncMock).toHaveBeenCalledWith({
       prisma: mockPrisma,
       phases: [
         expect.objectContaining({

--- a/apps/admin/src/services/core-sync/orchestrator.ts
+++ b/apps/admin/src/services/core-sync/orchestrator.ts
@@ -38,6 +38,7 @@ import { syncDubs } from "./phases/sync-dubs"
 import { syncDubDownloads } from "./phases/sync-dub-downloads"
 import { runCoverageAudit, type CoverageAudit } from "./coverage-audit"
 import { refreshWatchRouteManifestAfterCoreSync } from "../watch-route-manifest-refresh.service"
+import { refreshWatchSeoManifestAfterCoreSync } from "../watch-seo-manifest-refresh.service"
 
 const PHASE_RUNNERS: Record<SyncPhase, PhaseRunner> = {
   languages: syncLanguages,
@@ -296,6 +297,7 @@ export async function finishSyncRun(
 
   const coverageAudit = await runCoverageAudit(prisma).catch(() => undefined)
   await refreshWatchRouteManifestAfterCoreSync({ prisma, phases })
+  await refreshWatchSeoManifestAfterCoreSync({ prisma, phases })
 
   return {
     incremental: run.incremental,

--- a/apps/admin/src/services/revalidate-webhook.ts
+++ b/apps/admin/src/services/revalidate-webhook.ts
@@ -30,6 +30,7 @@ export type RevalidateModel =
   | "experience"
   | "video"
   | "watch-route-manifest"
+  | "watch-seo-manifest"
   | "watch-setting"
 
 export type RevalidateWebhookInput = {

--- a/apps/admin/src/services/watch-seo-manifest-refresh.service.test.ts
+++ b/apps/admin/src/services/watch-seo-manifest-refresh.service.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  refreshWatchSeoManifest,
+  refreshWatchSeoManifestAfterCoreSync,
+  shouldRefreshWatchSeoManifestAfterCoreSync,
+} from "./watch-seo-manifest-refresh.service"
+
+const generateMock = vi.hoisted(() => vi.fn())
+const upsertLatestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("./watch-seo-manifest.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("./watch-seo-manifest.service")
+  >("./watch-seo-manifest.service")
+  return {
+    ...actual,
+    WatchSeoManifestService: vi.fn(() => ({
+      generate: generateMock,
+    })),
+  }
+})
+
+vi.mock("./watch-seo-manifest-store", () => ({
+  WatchSeoManifestStore: vi.fn(() => ({
+    upsertLatest: upsertLatestMock,
+  })),
+}))
+
+const manifest = {
+  version: "version-1",
+  generatedAt: "2026-06-12T12:00:00.000Z",
+  videoRouteGroups: [
+    {
+      contentSlug: "jesus",
+      alternates: [{ hreflang: "en", languageSlug: "english" }],
+    },
+  ],
+  episodeRouteGroups: [],
+  skippedHreflangValues: {},
+}
+
+describe("watch seo manifest refresh", () => {
+  beforeEach(() => {
+    generateMock.mockReset()
+    upsertLatestMock.mockReset()
+  })
+
+  it("refreshes the snapshot and emits a sitemap-manifest webhook", async () => {
+    generateMock.mockResolvedValueOnce(manifest)
+    upsertLatestMock.mockResolvedValueOnce({
+      version: manifest.version,
+      payload: manifest,
+      payloadSizeBytes: 128,
+    })
+    const emitWebhook = vi
+      .fn()
+      .mockResolvedValue({ status: "sent", httpStatus: 200 })
+
+    const outcome = await refreshWatchSeoManifest({
+      prisma: {} as never,
+      reason: "operator-script",
+      emitWebhook,
+    })
+
+    expect(outcome).toMatchObject({
+      status: "refreshed",
+      reason: "operator-script",
+      version: manifest.version,
+      generatedAt: manifest.generatedAt,
+      payloadSizeBytes: 128,
+      counts: {
+        videoRouteGroups: 1,
+        episodeRouteGroups: 0,
+        alternateLinks: 1,
+        skippedHreflangValues: 0,
+      },
+    })
+    expect(emitWebhook).toHaveBeenCalledWith({
+      model: "watch-seo-manifest",
+      slug: null,
+      locale: null,
+    })
+  })
+
+  it("swallows generation or persistence failures", async () => {
+    generateMock.mockRejectedValueOnce(new Error("db unavailable"))
+
+    const outcome = await refreshWatchSeoManifest({
+      prisma: {} as never,
+      reason: "operator-script",
+      emitWebhook: vi.fn(),
+    })
+
+    expect(outcome).toMatchObject({
+      status: "failed",
+      reason: "operator-script",
+      detail: "db unavailable",
+    })
+  })
+
+  it("detects seo-relevant Core sync phases", () => {
+    expect(
+      shouldRefreshWatchSeoManifestAfterCoreSync([
+        { phase: "countries" },
+        { phase: "video-images" },
+      ]),
+    ).toBe(false)
+    expect(
+      shouldRefreshWatchSeoManifestAfterCoreSync([
+        { phase: "countries" },
+        { phase: "videos" },
+      ]),
+    ).toBe(true)
+    expect(
+      shouldRefreshWatchSeoManifestAfterCoreSync([{ phase: "languages" }]),
+    ).toBe(true)
+    expect(
+      shouldRefreshWatchSeoManifestAfterCoreSync([{ phase: "video-dubs" }]),
+    ).toBe(true)
+  })
+
+  it("skips Core sync refresh when no seo-relevant phases ran", async () => {
+    const emitWebhook = vi.fn()
+    const outcome = await refreshWatchSeoManifestAfterCoreSync({
+      prisma: {} as never,
+      phases: [{ phase: "keywords" }],
+      emitWebhook,
+    })
+
+    expect(outcome).toEqual({
+      status: "skipped",
+      reason: "no-seo-relevant-core-sync-phases",
+    })
+    expect(generateMock).not.toHaveBeenCalled()
+    expect(upsertLatestMock).not.toHaveBeenCalled()
+    expect(emitWebhook).not.toHaveBeenCalled()
+  })
+
+  it("refreshes the sitemap manifest after route/language Core sync phases", async () => {
+    generateMock.mockResolvedValueOnce(manifest)
+    upsertLatestMock.mockResolvedValueOnce({
+      version: manifest.version,
+      payload: manifest,
+      payloadSizeBytes: 128,
+    })
+    const emitWebhook = vi
+      .fn()
+      .mockResolvedValue({ status: "sent", httpStatus: 200 })
+
+    const outcome = await refreshWatchSeoManifestAfterCoreSync({
+      prisma: {} as never,
+      phases: [{ phase: "video-dubs", updated: 1 }],
+      emitWebhook,
+    })
+
+    expect(outcome).toMatchObject({
+      status: "refreshed",
+      reason: "core-sync",
+    })
+    expect(emitWebhook).toHaveBeenCalledWith({
+      model: "watch-seo-manifest",
+      slug: null,
+      locale: null,
+    })
+  })
+})

--- a/apps/admin/src/services/watch-seo-manifest-refresh.service.ts
+++ b/apps/admin/src/services/watch-seo-manifest-refresh.service.ts
@@ -1,0 +1,134 @@
+import type { PrismaClient } from "@prisma/client"
+import { emitRevalidateWebhook } from "./revalidate-webhook"
+import {
+  WatchSeoManifestService,
+  summarizeWatchSeoManifest,
+  type WatchSeoManifestCounts,
+} from "./watch-seo-manifest.service"
+import { WatchSeoManifestStore } from "./watch-seo-manifest-store"
+
+const SEO_RELEVANT_CORE_SYNC_PHASES = new Set([
+  "languages",
+  "videos",
+  "video-dubs",
+])
+
+export type WatchSeoManifestRefreshReason = "core-sync" | "operator-script"
+
+export type WatchSeoManifestRefreshOutcome =
+  | {
+      status: "refreshed"
+      reason: WatchSeoManifestRefreshReason
+      version: string
+      generatedAt: string
+      payloadSizeBytes: number
+      counts: WatchSeoManifestCounts
+      durationMs: number
+    }
+  | {
+      status: "skipped"
+      reason: "no-seo-relevant-core-sync-phases"
+    }
+  | {
+      status: "failed"
+      reason: WatchSeoManifestRefreshReason
+      detail: string
+      durationMs: number
+    }
+
+type CoreSyncPhaseSummary = {
+  phase: string
+  created?: number
+  updated?: number
+  softDeleted?: number
+}
+
+export function shouldRefreshWatchSeoManifestAfterCoreSync(
+  phases: readonly CoreSyncPhaseSummary[],
+): boolean {
+  return phases.some((phase) => SEO_RELEVANT_CORE_SYNC_PHASES.has(phase.phase))
+}
+
+export async function refreshWatchSeoManifest({
+  prisma,
+  reason,
+  emitWebhook = emitRevalidateWebhook,
+}: {
+  prisma: PrismaClient
+  reason: WatchSeoManifestRefreshReason
+  emitWebhook?: typeof emitRevalidateWebhook
+}): Promise<WatchSeoManifestRefreshOutcome> {
+  const startedAt = Date.now()
+  try {
+    const service = new WatchSeoManifestService(prisma)
+    const store = new WatchSeoManifestStore(prisma)
+    const manifest = await service.generate()
+    const snapshot = await store.upsertLatest(manifest)
+    const counts = summarizeWatchSeoManifest(snapshot.payload)
+
+    await emitWebhook({
+      model: "watch-seo-manifest",
+      slug: null,
+      locale: null,
+    })
+
+    const outcome: WatchSeoManifestRefreshOutcome = {
+      status: "refreshed",
+      reason,
+      version: snapshot.version,
+      generatedAt: snapshot.payload.generatedAt,
+      payloadSizeBytes: snapshot.payloadSizeBytes,
+      counts,
+      durationMs: Date.now() - startedAt,
+    }
+    console.log(
+      JSON.stringify({
+        event: "watch_seo_manifest.refresh.refreshed",
+        reason,
+        version: snapshot.version,
+        ...counts,
+        durationMs: outcome.durationMs,
+      }),
+    )
+    return outcome
+  } catch (error) {
+    const outcome: WatchSeoManifestRefreshOutcome = {
+      status: "failed",
+      reason,
+      detail: error instanceof Error ? error.message : String(error),
+      durationMs: Date.now() - startedAt,
+    }
+    console.warn(
+      JSON.stringify({
+        event: "watch_seo_manifest.refresh.failed",
+        reason,
+        detail: outcome.detail.slice(0, 500),
+        durationMs: outcome.durationMs,
+      }),
+    )
+    return outcome
+  }
+}
+
+export async function refreshWatchSeoManifestAfterCoreSync({
+  prisma,
+  phases,
+  emitWebhook = emitRevalidateWebhook,
+}: {
+  prisma: PrismaClient
+  phases: readonly CoreSyncPhaseSummary[]
+  emitWebhook?: typeof emitRevalidateWebhook
+}): Promise<WatchSeoManifestRefreshOutcome> {
+  if (!shouldRefreshWatchSeoManifestAfterCoreSync(phases)) {
+    return {
+      status: "skipped",
+      reason: "no-seo-relevant-core-sync-phases",
+    }
+  }
+
+  return refreshWatchSeoManifest({
+    prisma,
+    reason: "core-sync",
+    emitWebhook,
+  })
+}

--- a/apps/admin/src/services/watch-seo-manifest-store.test.ts
+++ b/apps/admin/src/services/watch-seo-manifest-store.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  WATCH_SEO_MANIFEST_SNAPSHOT_KEY,
+  WatchSeoManifestStore,
+} from "./watch-seo-manifest-store"
+import type { WatchSeoManifest } from "./watch-seo-manifest.service"
+
+function mockPrisma() {
+  return {
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    $queryRaw: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+const manifest: WatchSeoManifest = {
+  version: "abc123",
+  generatedAt: "2026-06-12T12:00:00.000Z",
+  videoRouteGroups: [
+    {
+      contentSlug: "jesus",
+      alternates: [{ hreflang: "en", languageSlug: "english" }],
+    },
+  ],
+  episodeRouteGroups: [
+    {
+      parentSlug: "series",
+      childSlug: "episode-1",
+      alternates: [{ hreflang: "es", languageSlug: "spanish" }],
+    },
+  ],
+  skippedHreflangValues: { "es-419": 1 },
+}
+
+describe("WatchSeoManifestStore", () => {
+  it("returns null when no latest snapshot exists", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const store = new WatchSeoManifestStore(prisma)
+
+    await expect(store.getLatest()).resolves.toBeNull()
+  })
+
+  it("upserts the latest manifest and returns the stored snapshot", async () => {
+    const prisma = mockPrisma()
+    const payloadSizeBytes = Buffer.byteLength(JSON.stringify(manifest), "utf8")
+    const generatedAt = new Date(manifest.generatedAt)
+    const createdAt = new Date("2026-06-12T12:00:01.000Z")
+    const updatedAt = new Date("2026-06-12T12:00:02.000Z")
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        key: WATCH_SEO_MANIFEST_SNAPSHOT_KEY,
+        version: manifest.version,
+        generatedAt,
+        payload: manifest,
+        payloadSizeBytes,
+        createdAt,
+        updatedAt,
+      },
+    ])
+    const store = new WatchSeoManifestStore(prisma)
+
+    const snapshot = await store.upsertLatest(manifest)
+
+    expect(prisma.$executeRaw).toHaveBeenCalledOnce()
+    expect(snapshot).toEqual({
+      key: WATCH_SEO_MANIFEST_SNAPSHOT_KEY,
+      version: manifest.version,
+      generatedAt,
+      payload: manifest,
+      payloadSizeBytes,
+      createdAt,
+      updatedAt,
+    })
+  })
+
+  it("parses string JSON payloads from raw SQL reads", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        key: WATCH_SEO_MANIFEST_SNAPSHOT_KEY,
+        version: manifest.version,
+        generatedAt: new Date(manifest.generatedAt),
+        payload: JSON.stringify(manifest),
+        payloadSizeBytes: BigInt(Buffer.byteLength(JSON.stringify(manifest))),
+        createdAt: new Date("2026-06-12T12:00:01.000Z"),
+        updatedAt: new Date("2026-06-12T12:00:02.000Z"),
+      },
+    ])
+    const store = new WatchSeoManifestStore(prisma)
+
+    const snapshot = await store.getLatest()
+
+    expect(snapshot?.payload).toEqual(manifest)
+    expect(snapshot?.payloadSizeBytes).toBe(
+      Buffer.byteLength(JSON.stringify(manifest)),
+    )
+  })
+
+  it("fails if an upsert does not produce a readable latest snapshot", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const store = new WatchSeoManifestStore(prisma)
+
+    await expect(store.upsertLatest(manifest)).rejects.toThrow(
+      "watch seo manifest snapshot missing after upsert",
+    )
+  })
+})

--- a/apps/admin/src/services/watch-seo-manifest-store.ts
+++ b/apps/admin/src/services/watch-seo-manifest-store.ts
@@ -1,0 +1,109 @@
+import type { PrismaClient } from "@prisma/client"
+import {
+  WatchSeoManifestSchema,
+  type WatchSeoManifest,
+} from "./watch-seo-manifest.service"
+
+export const WATCH_SEO_MANIFEST_SNAPSHOT_KEY = "latest"
+
+export type WatchSeoManifestSnapshotRecord = {
+  key: string
+  version: string
+  generatedAt: Date
+  payload: WatchSeoManifest
+  payloadSizeBytes: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+type StorePrisma = Pick<PrismaClient, "$executeRaw" | "$queryRaw">
+
+type SnapshotRow = {
+  key: string
+  version: string
+  generatedAt: Date
+  payload: unknown
+  payloadSizeBytes: number | bigint
+  createdAt: Date
+  updatedAt: Date
+}
+
+export class WatchSeoManifestStore {
+  constructor(private readonly prisma: StorePrisma) {}
+
+  async getLatest(): Promise<WatchSeoManifestSnapshotRecord | null> {
+    const rows = await this.prisma.$queryRaw<SnapshotRow[]>`
+      SELECT
+        "key",
+        "version",
+        "generated_at" AS "generatedAt",
+        "payload",
+        "payload_size_bytes" AS "payloadSizeBytes",
+        "created_at" AS "createdAt",
+        "updated_at" AS "updatedAt"
+      FROM "watch_seo_manifest_snapshot"
+      WHERE "key" = ${WATCH_SEO_MANIFEST_SNAPSHOT_KEY}
+      LIMIT 1
+    `
+    const row = rows[0]
+    return row ? normalizeSnapshotRow(row) : null
+  }
+
+  async upsertLatest(
+    manifest: WatchSeoManifest,
+  ): Promise<WatchSeoManifestSnapshotRecord> {
+    const payload = WatchSeoManifestSchema.parse(manifest)
+    const serializedPayload = JSON.stringify(payload)
+    const payloadSizeBytes = Buffer.byteLength(serializedPayload, "utf8")
+    const generatedAt = new Date(payload.generatedAt)
+
+    await this.prisma.$executeRaw`
+      INSERT INTO "watch_seo_manifest_snapshot" (
+        "key",
+        "version",
+        "generated_at",
+        "payload",
+        "payload_size_bytes",
+        "created_at",
+        "updated_at"
+      )
+      VALUES (
+        ${WATCH_SEO_MANIFEST_SNAPSHOT_KEY},
+        ${payload.version},
+        ${generatedAt},
+        ${serializedPayload}::jsonb,
+        ${payloadSizeBytes},
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      )
+      ON CONFLICT ("key") DO UPDATE SET
+        "version" = EXCLUDED."version",
+        "generated_at" = EXCLUDED."generated_at",
+        "payload" = EXCLUDED."payload",
+        "payload_size_bytes" = EXCLUDED."payload_size_bytes",
+        "updated_at" = CURRENT_TIMESTAMP
+    `
+
+    const latest = await this.getLatest()
+    if (!latest) {
+      throw new Error("watch seo manifest snapshot missing after upsert")
+    }
+    return latest
+  }
+}
+
+function normalizeSnapshotRow(
+  row: SnapshotRow,
+): WatchSeoManifestSnapshotRecord {
+  const rawPayload =
+    typeof row.payload === "string" ? JSON.parse(row.payload) : row.payload
+  return {
+    key: row.key,
+    version: row.version,
+    generatedAt: row.generatedAt,
+    payload: WatchSeoManifestSchema.parse(rawPayload),
+    payloadSizeBytes: Number(row.payloadSizeBytes),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}

--- a/apps/admin/src/services/watch-seo-manifest.service.test.ts
+++ b/apps/admin/src/services/watch-seo-manifest.service.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  WatchSeoManifestService,
+  normalizeGoogleHreflang,
+  summarizeWatchSeoManifest,
+} from "./watch-seo-manifest.service"
+
+function mockPrisma() {
+  return {
+    $queryRaw: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+function sqlText(call: unknown[]): string {
+  const [strings] = call
+  return Array.isArray(strings) ? strings.join(" ") : String(strings)
+}
+
+describe("normalizeGoogleHreflang", () => {
+  it("accepts language and language-region tags supported by sitemap hreflang", () => {
+    expect(normalizeGoogleHreflang("en")).toBe("en")
+    expect(normalizeGoogleHreflang("pt-br")).toBe("pt-BR")
+    expect(normalizeGoogleHreflang("en_US")).toBe("en-US")
+  })
+
+  it("rejects script, numeric-region, missing, and non-ISO language tags", () => {
+    expect(normalizeGoogleHreflang("zh-Hans")).toBeNull()
+    expect(normalizeGoogleHreflang("es-419")).toBeNull()
+    expect(normalizeGoogleHreflang("eng")).toBeNull()
+    expect(normalizeGoogleHreflang(null)).toBeNull()
+  })
+})
+
+describe("WatchSeoManifestService.generate", () => {
+  it("builds deterministic sitemap route groups and de-dupes hreflang per route", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          contentSlug: "jesus",
+          languageSlug: "english",
+          bcp47: "en",
+        },
+        {
+          contentSlug: "jesus",
+          languageSlug: "spanish-castilian",
+          bcp47: "es",
+        },
+        {
+          contentSlug: "jesus",
+          languageSlug: "spanish-latin-american",
+          bcp47: "es",
+        },
+        {
+          contentSlug: "jesus",
+          languageSlug: "bad-script",
+          bcp47: "zh-Hans",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          parentSlug: "book-of-acts",
+          childSlug: "pentecost",
+          languageSlug: "english",
+          bcp47: "en",
+        },
+        {
+          parentSlug: "book-of-acts",
+          childSlug: "pentecost",
+          languageSlug: "portuguese-brazil",
+          bcp47: "pt-BR",
+        },
+      ])
+
+    const service = new WatchSeoManifestService(prisma, {
+      now: () => new Date("2026-06-12T12:00:00.000Z"),
+    })
+
+    const manifest = await service.generate()
+
+    expect(manifest).toEqual({
+      version: expect.stringMatching(/^[a-f0-9]{64}$/),
+      generatedAt: "2026-06-12T12:00:00.000Z",
+      videoRouteGroups: [
+        {
+          contentSlug: "jesus",
+          alternates: [
+            { hreflang: "en", languageSlug: "english" },
+            { hreflang: "es", languageSlug: "spanish-castilian" },
+          ],
+        },
+      ],
+      episodeRouteGroups: [
+        {
+          parentSlug: "book-of-acts",
+          childSlug: "pentecost",
+          alternates: [
+            { hreflang: "en", languageSlug: "english" },
+            { hreflang: "pt-BR", languageSlug: "portuguese-brazil" },
+          ],
+        },
+      ],
+      skippedHreflangValues: {
+        "duplicate:es": 1,
+        "zh-Hans": 1,
+      },
+    })
+    expect(summarizeWatchSeoManifest(manifest)).toMatchObject({
+      videoRouteGroups: 1,
+      episodeRouteGroups: 1,
+      alternateLinks: 4,
+      skippedHreflangValues: 2,
+    })
+  })
+
+  it("encodes public watch route filters in aggregate SQL", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce([])
+
+    const service = new WatchSeoManifestService(prisma)
+    await service.generate()
+
+    const allSql = prisma.$queryRaw.mock.calls.map(sqlText).join("\n")
+    expect(allSql).toContain("status = 'published'::\"LocaleStatus\"")
+    expect(allSql).toContain('"deleted_at" IS NULL')
+    expect(allSql).toContain("published = TRUE")
+    expect(allSql).toContain("hls IS NOT NULL")
+    expect(allSql).toContain("parent_video_audio")
+    expect(allSql).toContain("child_lang.bcp47")
+  })
+
+  it("rejects malformed query rows instead of emitting a partial manifest", async () => {
+    const prisma = mockPrisma()
+    prisma.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          contentSlug: "",
+          languageSlug: "english",
+          bcp47: "en",
+        },
+      ])
+      .mockResolvedValueOnce([])
+
+    const service = new WatchSeoManifestService(prisma)
+
+    await expect(service.generate()).rejects.toThrow()
+  })
+})

--- a/apps/admin/src/services/watch-seo-manifest.service.ts
+++ b/apps/admin/src/services/watch-seo-manifest.service.ts
@@ -1,0 +1,337 @@
+import { createHash } from "node:crypto"
+import type { PrismaClient } from "@prisma/client"
+import { z } from "zod"
+
+const LanguageAlternateSchema = z.object({
+  hreflang: z.string().min(2),
+  languageSlug: z.string().min(1),
+})
+
+const VideoRouteGroupSchema = z.object({
+  contentSlug: z.string().min(1),
+  alternates: z.array(LanguageAlternateSchema),
+})
+
+const EpisodeRouteGroupSchema = z.object({
+  parentSlug: z.string().min(1),
+  childSlug: z.string().min(1),
+  alternates: z.array(LanguageAlternateSchema),
+})
+
+const ContentLanguageRowSchema = z.object({
+  contentSlug: z.string().min(1),
+  languageSlug: z.string().min(1),
+  bcp47: z.string().nullable(),
+})
+
+const EpisodeLanguageRowSchema = z.object({
+  parentSlug: z.string().min(1),
+  childSlug: z.string().min(1),
+  languageSlug: z.string().min(1),
+  bcp47: z.string().nullable(),
+})
+
+export const WatchSeoManifestSchema = z.object({
+  version: z.string().min(1),
+  generatedAt: z.string().datetime(),
+  videoRouteGroups: z.array(VideoRouteGroupSchema),
+  episodeRouteGroups: z.array(EpisodeRouteGroupSchema),
+  skippedHreflangValues: z.record(z.string().min(1), z.number().int().min(1)),
+})
+
+export type WatchSeoManifest = z.infer<typeof WatchSeoManifestSchema>
+export type WatchSeoManifestCounts = {
+  videoRouteGroups: number
+  episodeRouteGroups: number
+  alternateLinks: number
+  skippedHreflangValues: number
+}
+
+type QueryablePrisma = Pick<PrismaClient, "$queryRaw">
+type ContentLanguageRow = z.infer<typeof ContentLanguageRowSchema>
+type EpisodeLanguageRow = z.infer<typeof EpisodeLanguageRowSchema>
+type LanguageAlternate = z.infer<typeof LanguageAlternateSchema>
+
+export class WatchSeoManifestService {
+  constructor(
+    private readonly prisma: QueryablePrisma,
+    private readonly options: { now?: () => Date } = {},
+  ) {}
+
+  async generate(): Promise<WatchSeoManifest> {
+    const startedAt = Date.now()
+    const [contentRows, episodeRows] = await Promise.all([
+      this.loadContentLanguageRows(),
+      this.loadEpisodeLanguageRows(),
+    ])
+    const skippedHreflangValues: Record<string, number> = {}
+    const videoRouteGroups = toVideoRouteGroups(
+      contentRows,
+      skippedHreflangValues,
+    )
+    const episodeRouteGroups = toEpisodeRouteGroups(
+      episodeRows,
+      skippedHreflangValues,
+    )
+    const generatedAt = (this.options.now?.() ?? new Date()).toISOString()
+    const contentForVersion = {
+      episodeRouteGroups,
+      skippedHreflangValues,
+      videoRouteGroups,
+    }
+    const version = createHash("sha256")
+      .update(JSON.stringify(contentForVersion))
+      .digest("hex")
+
+    const manifest = WatchSeoManifestSchema.parse({
+      version,
+      generatedAt,
+      videoRouteGroups,
+      episodeRouteGroups,
+      skippedHreflangValues,
+    })
+
+    const counts = summarizeWatchSeoManifest(manifest)
+    console.log(
+      JSON.stringify({
+        event: "watch_seo_manifest.generated",
+        ...counts,
+        durationMs: Date.now() - startedAt,
+      }),
+    )
+
+    return manifest
+  }
+
+  private async loadContentLanguageRows(): Promise<ContentLanguageRow[]> {
+    const rows = await this.prisma.$queryRaw<unknown[]>`
+      WITH playable_video_audio AS (
+        SELECT DISTINCT
+          v.slug AS "contentSlug",
+          lang.slug AS "languageSlug",
+          lang.bcp47 AS "bcp47"
+        FROM "video" v
+        JOIN "video_locale" vl
+          ON vl."video_id" = v.id
+          AND vl.status = 'published'::"LocaleStatus"
+          AND vl."deleted_at" IS NULL
+        JOIN "video_dub" dub
+          ON dub."video_id" = v.id
+          AND dub."deleted_at" IS NULL
+          AND dub.published = TRUE
+          AND dub.hls IS NOT NULL
+          AND dub.hls <> ''
+        JOIN "language" lang
+          ON lang.id = dub."language_id"
+          AND lang."deleted_at" IS NULL
+          AND lang.slug IS NOT NULL
+          AND lang.slug <> ''
+        WHERE v."deleted_at" IS NULL
+          AND v.slug <> ''
+      ),
+      parent_video_audio AS (
+        SELECT DISTINCT
+          parent.slug AS "contentSlug",
+          child_lang.slug AS "languageSlug",
+          child_lang.bcp47 AS "bcp47"
+        FROM "video" parent
+        JOIN "video_locale" parent_locale
+          ON parent_locale."video_id" = parent.id
+          AND parent_locale.status = 'published'::"LocaleStatus"
+          AND parent_locale."deleted_at" IS NULL
+        JOIN "video_relation" relation
+          ON relation."parent_id" = parent.id
+        JOIN "video" child
+          ON child.id = relation."child_id"
+          AND child."deleted_at" IS NULL
+          AND child.slug <> ''
+        JOIN "video_locale" child_locale
+          ON child_locale."video_id" = child.id
+          AND child_locale.status = 'published'::"LocaleStatus"
+          AND child_locale."deleted_at" IS NULL
+        JOIN "video_dub" child_dub
+          ON child_dub."video_id" = child.id
+          AND child_dub."deleted_at" IS NULL
+          AND child_dub.published = TRUE
+          AND child_dub.hls IS NOT NULL
+          AND child_dub.hls <> ''
+        JOIN "language" child_lang
+          ON child_lang.id = child_dub."language_id"
+          AND child_lang."deleted_at" IS NULL
+          AND child_lang.slug IS NOT NULL
+          AND child_lang.slug <> ''
+        WHERE parent."deleted_at" IS NULL
+          AND parent.slug <> ''
+      )
+      SELECT "contentSlug", "languageSlug", "bcp47" FROM playable_video_audio
+      UNION
+      SELECT "contentSlug", "languageSlug", "bcp47" FROM parent_video_audio
+      ORDER BY "contentSlug" ASC, "bcp47" ASC NULLS LAST, "languageSlug" ASC
+    `
+
+    return ContentLanguageRowSchema.array().parse(rows)
+  }
+
+  private async loadEpisodeLanguageRows(): Promise<EpisodeLanguageRow[]> {
+    const rows = await this.prisma.$queryRaw<unknown[]>`
+      SELECT DISTINCT
+        parent.slug AS "parentSlug",
+        child.slug AS "childSlug",
+        child_lang.slug AS "languageSlug",
+        child_lang.bcp47 AS "bcp47"
+      FROM "video_relation" relation
+      JOIN "video" parent
+        ON parent.id = relation."parent_id"
+        AND parent."deleted_at" IS NULL
+        AND parent.slug <> ''
+      JOIN "video_locale" parent_locale
+        ON parent_locale."video_id" = parent.id
+        AND parent_locale.status = 'published'::"LocaleStatus"
+        AND parent_locale."deleted_at" IS NULL
+      JOIN "video" child
+        ON child.id = relation."child_id"
+        AND child."deleted_at" IS NULL
+        AND child.slug <> ''
+      JOIN "video_locale" child_locale
+        ON child_locale."video_id" = child.id
+        AND child_locale.status = 'published'::"LocaleStatus"
+        AND child_locale."deleted_at" IS NULL
+      JOIN "video_dub" child_dub
+        ON child_dub."video_id" = child.id
+        AND child_dub."deleted_at" IS NULL
+        AND child_dub.published = TRUE
+        AND child_dub.hls IS NOT NULL
+        AND child_dub.hls <> ''
+      JOIN "language" child_lang
+        ON child_lang.id = child_dub."language_id"
+        AND child_lang."deleted_at" IS NULL
+        AND child_lang.slug IS NOT NULL
+        AND child_lang.slug <> ''
+      ORDER BY parent.slug ASC, child.slug ASC, child_lang.bcp47 ASC NULLS LAST, child_lang.slug ASC
+    `
+
+    return EpisodeLanguageRowSchema.array().parse(rows)
+  }
+}
+
+function incrementSkipped(
+  skippedHreflangValues: Record<string, number>,
+  key: string,
+): void {
+  skippedHreflangValues[key] = (skippedHreflangValues[key] ?? 0) + 1
+}
+
+export function normalizeGoogleHreflang(value: string | null): string | null {
+  if (!value) return null
+  const parts = value.trim().replace(/_/g, "-").split("-")
+  if (parts.length !== 1 && parts.length !== 2) return null
+
+  const language = parts[0]?.toLowerCase()
+  if (!language || !/^[a-z]{2}$/.test(language)) return null
+  if (parts.length === 1) return language
+
+  const region = parts[1]?.toUpperCase()
+  if (!region || !/^[A-Z]{2}$/.test(region)) return null
+  return `${language}-${region}`
+}
+
+function toAlternates(
+  rows: Array<{ bcp47: string | null; languageSlug: string }>,
+  skippedHreflangValues: Record<string, number>,
+): LanguageAlternate[] {
+  const byHreflang = new Map<string, LanguageAlternate>()
+  for (const row of rows) {
+    const hreflang = normalizeGoogleHreflang(row.bcp47)
+    if (!hreflang) {
+      incrementSkipped(skippedHreflangValues, row.bcp47 ?? "missing_bcp47")
+      continue
+    }
+    if (byHreflang.has(hreflang)) {
+      incrementSkipped(skippedHreflangValues, `duplicate:${hreflang}`)
+      continue
+    }
+    byHreflang.set(hreflang, {
+      hreflang,
+      languageSlug: row.languageSlug,
+    })
+  }
+  return [...byHreflang.values()].sort(
+    (a, b) =>
+      a.hreflang.localeCompare(b.hreflang) ||
+      a.languageSlug.localeCompare(b.languageSlug),
+  )
+}
+
+function toVideoRouteGroups(
+  rows: ContentLanguageRow[],
+  skippedHreflangValues: Record<string, number>,
+): WatchSeoManifest["videoRouteGroups"] {
+  const byContent = new Map<string, ContentLanguageRow[]>()
+  for (const row of rows) {
+    const contentRows = byContent.get(row.contentSlug) ?? []
+    contentRows.push(row)
+    byContent.set(row.contentSlug, contentRows)
+  }
+
+  return [...byContent.entries()]
+    .map(([contentSlug, contentRows]) => ({
+      contentSlug,
+      alternates: toAlternates(contentRows, skippedHreflangValues),
+    }))
+    .filter((group) => group.alternates.length > 0)
+    .sort((a, b) => a.contentSlug.localeCompare(b.contentSlug))
+}
+
+function toEpisodeRouteGroups(
+  rows: EpisodeLanguageRow[],
+  skippedHreflangValues: Record<string, number>,
+): WatchSeoManifest["episodeRouteGroups"] {
+  const byEpisode = new Map<string, EpisodeLanguageRow[]>()
+  for (const row of rows) {
+    const key = `${row.parentSlug}\u0000${row.childSlug}`
+    const episodeRows = byEpisode.get(key) ?? []
+    episodeRows.push(row)
+    byEpisode.set(key, episodeRows)
+  }
+
+  return [...byEpisode.entries()]
+    .map(([key, episodeRows]) => {
+      const [parentSlug = "", childSlug = ""] = key.split("\u0000")
+      return {
+        parentSlug,
+        childSlug,
+        alternates: toAlternates(episodeRows, skippedHreflangValues),
+      }
+    })
+    .filter((group) => group.alternates.length > 0)
+    .sort(
+      (a, b) =>
+        a.parentSlug.localeCompare(b.parentSlug) ||
+        a.childSlug.localeCompare(b.childSlug),
+    )
+}
+
+export function summarizeWatchSeoManifest(
+  manifest: Pick<
+    WatchSeoManifest,
+    "episodeRouteGroups" | "skippedHreflangValues" | "videoRouteGroups"
+  >,
+): WatchSeoManifestCounts {
+  return {
+    videoRouteGroups: manifest.videoRouteGroups.length,
+    episodeRouteGroups: manifest.episodeRouteGroups.length,
+    alternateLinks:
+      manifest.videoRouteGroups.reduce(
+        (sum, group) => sum + group.alternates.length,
+        0,
+      ) +
+      manifest.episodeRouteGroups.reduce(
+        (sum, group) => sum + group.alternates.length,
+        0,
+      ),
+    skippedHreflangValues: Object.values(manifest.skippedHreflangValues).reduce(
+      (sum, count) => sum + count,
+      0,
+    ),
+  }
+}

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -15,6 +15,9 @@
 - Data fetching: RSC async components calling resolvers in `src/lib/content.ts` / `search.ts` / `recommendations.ts` / `demo-search.ts`, which use `adminGraphql()` from `@forge/admin-graphql` + the singleton Apollo client at `src/lib/admin-client.ts`.
 - Client components that need data go through a `"use server"` action (e.g. `src/lib/search-actions.ts`) — admin's bearer is server-only and must never reach the browser bundle.
 - Metadata: export `metadata` or `generateMetadata` from every page.
+- Watch video and episode metadata must not emit page-head hreflang alternates.
+  Canonical, Open Graph, Twitter, robots, and JSON-LD stay in page metadata;
+  localized Watch hreflang belongs to sitemap XML only.
 
 ## Data layer
 
@@ -70,8 +73,14 @@ The receiver maps each semantic model to both paths and Data Cache tags:
 - `experience` invalidates experience/home tags plus the current slug matrix.
 - `video` invalidates video/series/child-dub/home tags; slug-less payloads are valid broad invalidations for Core sync and revalidate the watch layouts.
 - `watch-route-manifest` clears the receiving process's in-memory manifest cache, invalidates the route-manifest tag, and revalidates the watch layouts.
+- `watch-seo-manifest` clears the receiving process's in-memory SEO manifest cache, invalidates the SEO manifest tag, and revalidates the sitemap index plus child sitemap routes.
 
 The route manifest cache in `src/lib/watch-route-manifest.ts` is process-local. The webhook clears only the process that receives it; other web instances rely on the 60 second manifest TTL unless production uses shared cache storage or all-instance webhook fan-out.
+
+The SEO sitemap manifest cache in `src/lib/watch-seo-manifest.ts` follows the
+same process-local pattern. Sitemap routes read the cached snapshot and return
+a controlled 503 when no valid snapshot is available; Watch page metadata does
+not depend on this manifest and continues to render without page-head hreflang.
 
 Production proof on 2026-06-10 showed `@forge/web` online in Railway US West behind Cloudflare, live watch HTML served with `cf-cache-status: DYNAMIC`, and authorized `experience`, broad `video`, and `watch-route-manifest` webhooks returning healthy first post-webhook renders. The Railway CLI path available here did not expose exact web replica count.
 

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
@@ -511,7 +511,7 @@ describe("Catch-all routing — one-segment collection/home branch", () => {
 })
 
 describe("Catch-all routing — metadata for playable watch pages", () => {
-  it("uses resolved video data for two-segment metadata before falling back to the template resolver", async () => {
+  it("uses resolved video data for two-segment metadata without page-head hreflang", async () => {
     resolveWatchVideoBySlugMock.mockResolvedValue(
       makeWatchVideoResult("featureFilm"),
     )
@@ -547,11 +547,8 @@ describe("Catch-all routing — metadata for playable watch pages", () => {
     })
     expect(metadata.alternates).toMatchObject({
       canonical: "https://www.jesusfilm.org/watch/storyclubs.html/english.html",
-      languages: {
-        en: "https://www.jesusfilm.org/watch/storyclubs.html/english.html",
-        es: "https://www.jesusfilm.org/watch/storyclubs.html/spanish-castilian.html",
-      },
     })
+    expect(metadata.alternates).not.toHaveProperty("languages")
     expect(resolveWatchPageMock).not.toHaveBeenCalled()
     expect(resolveWatchVideoBySlugMock).toHaveBeenCalledWith(
       "storyclubs",

--- a/apps/web/src/app/api/revalidate/route.test.ts
+++ b/apps/web/src/app/api/revalidate/route.test.ts
@@ -2,16 +2,22 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 const {
   clearWatchRouteManifestCacheMock,
+  clearWatchSeoManifestCacheMock,
   revalidatePathMock,
   revalidateTagMock,
 } = vi.hoisted(() => ({
   clearWatchRouteManifestCacheMock: vi.fn(),
+  clearWatchSeoManifestCacheMock: vi.fn(),
   revalidatePathMock: vi.fn(),
   revalidateTagMock: vi.fn(),
 }))
 
 vi.mock("@/lib/watch-route-manifest", () => ({
   clearWatchRouteManifestCache: clearWatchRouteManifestCacheMock,
+}))
+
+vi.mock("@/lib/watch-seo-manifest", () => ({
+  clearWatchSeoManifestCache: clearWatchSeoManifestCacheMock,
 }))
 
 vi.mock("next/cache", () => ({
@@ -22,6 +28,7 @@ vi.mock("next/cache", () => ({
 describe("POST /api/revalidate", () => {
   afterEach(() => {
     clearWatchRouteManifestCacheMock.mockReset()
+    clearWatchSeoManifestCacheMock.mockReset()
     revalidatePathMock.mockReset()
     revalidateTagMock.mockReset()
     vi.doUnmock("@/i18n/generated-ui-locales")
@@ -453,6 +460,40 @@ describe("POST /api/revalidate", () => {
     )
     expect(revalidatePathMock).toHaveBeenCalledWith("/", "layout")
     expect(revalidateTagMock).toHaveBeenCalledWith("watch:route-manifest", {
+      expire: 0,
+    })
+  })
+
+  it("clears the cached watch seo manifest and revalidates sitemap routes", async () => {
+    const { POST } = await import("./route")
+
+    const response = await POST(
+      new Request("http://example.test/api/revalidate", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer test-revalidation-secret",
+        },
+        body: JSON.stringify({
+          model: "watch-seo-manifest",
+          entry: {},
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      revalidated: true,
+      seoManifestCacheCleared: true,
+      paths: ["/sitemap.xml", "/sitemap/[id] (page)", "/sitemap (layout)"],
+      tags: ["watch:seo-manifest"],
+    })
+    expect(clearWatchSeoManifestCacheMock).toHaveBeenCalledTimes(1)
+    expect(clearWatchRouteManifestCacheMock).not.toHaveBeenCalled()
+    expect(revalidatePathMock).toHaveBeenCalledWith("/sitemap.xml")
+    expect(revalidatePathMock).toHaveBeenCalledWith("/sitemap/[id]", "page")
+    expect(revalidatePathMock).toHaveBeenCalledWith("/sitemap", "layout")
+    expect(revalidateTagMock).toHaveBeenCalledWith("watch:seo-manifest", {
       expire: 0,
     })
   })

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -16,6 +16,7 @@ import {
   type WatchCacheTag,
 } from "@/lib/watch-cache-tags"
 import { clearWatchRouteManifestCache } from "@/lib/watch-route-manifest"
+import { clearWatchSeoManifestCache } from "@/lib/watch-seo-manifest"
 
 const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
 const BEARER_PREFIX = "Bearer "
@@ -33,12 +34,14 @@ type RevalidateModel =
   | "experience"
   | "video"
   | "watch-route-manifest"
+  | "watch-seo-manifest"
   | "watch-setting"
 
 const REVALIDATE_MODELS = new Set<RevalidateModel>([
   "experience",
   "video",
   "watch-route-manifest",
+  "watch-seo-manifest",
   "watch-setting",
 ])
 const REVALIDATE_MODEL_VALUES: ReadonlySet<string> = REVALIDATE_MODELS
@@ -159,6 +162,14 @@ export async function POST(request: Request) {
     revalidated.push(key)
   }
 
+  const pushPagePattern = (path: string) => {
+    const key = `${path} (page)`
+    if (seen.has(key)) return
+    seen.add(key)
+    revalidatePath(path, "page")
+    revalidated.push(key)
+  }
+
   const pushInternal = (publicPath: string, rawLocale?: string) => {
     const identity = resolveWatchLocaleIdentity(rawLocale)
     const suffix = publicPath === "/" ? "" : publicPath
@@ -212,6 +223,12 @@ export async function POST(request: Request) {
     pushLayout("/")
   }
 
+  const revalidateWatchSitemaps = () => {
+    push("/sitemap.xml")
+    pushPagePattern("/sitemap/[id]")
+    pushLayout("/sitemap")
+  }
+
   const revalidateHomepagePaths = () => {
     push("/")
     pushInternal("/")
@@ -258,6 +275,17 @@ export async function POST(request: Request) {
     return NextResponse.json(
       responsePayload({
         manifestCacheCleared: true,
+      }),
+    )
+  }
+
+  if (model === "watch-seo-manifest") {
+    pushTags(WATCH_CACHE_TAG_GROUPS.watchSeoManifest)
+    clearWatchSeoManifestCache()
+    revalidateWatchSitemaps()
+    return NextResponse.json(
+      responsePayload({
+        seoManifestCacheCleared: true,
       }),
     )
   }

--- a/apps/web/src/app/robots.test.ts
+++ b/apps/web/src/app/robots.test.ts
@@ -16,8 +16,8 @@ describe("robots", () => {
     expect(result.host).toBeUndefined()
   })
 
-  it("emits no sitemap directive yet (sitemap deferred)", () => {
+  it("emits the watch sitemap index URL", () => {
     const result = robots()
-    expect(result.sitemap).toBeUndefined()
+    expect(result.sitemap).toBe("https://www.jesusfilm.org/watch/sitemap.xml")
   })
 })

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next"
+import { WATCH_BASE_PATH, WATCH_PUBLIC_METADATA_ORIGIN } from "@/lib/routes"
 
 // Robots policy for the /watch surface. Allows crawling and disallows the
 // framework / API subtrees (`/api/`, `/_next/`) that must never be indexed.
@@ -7,11 +8,6 @@ import type { MetadataRoute } from "next"
 //
 // No `host` directive: it's a non-standard Yandex-ism that Google/Bing
 // ignore, and pointing it at a basePath sub-path would be misleading.
-//
-// No `sitemap` directive yet: the sitemap is deferred to its own ticket
-// (no bulk video-list query exists, and a full video×language sitemap needs
-// a sitemap-index + admin bulk query — see todo 025). Add the `sitemap`
-// field here once `app/sitemap.ts` ships so crawlers discover it.
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
@@ -19,5 +15,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/api/", "/_next/"],
     },
+    sitemap: `${WATCH_PUBLIC_METADATA_ORIGIN}${WATCH_BASE_PATH}/sitemap.xml`,
   }
 }

--- a/apps/web/src/app/sitemap.test.ts
+++ b/apps/web/src/app/sitemap.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const getWatchSeoManifestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/watch-seo-manifest", () => ({
+  getWatchSeoManifest: getWatchSeoManifestMock,
+}))
+
+const manifest = {
+  version: "version-1",
+  generatedAt: "2026-06-12T12:00:00.000Z",
+  videoRouteGroups: [
+    {
+      contentSlug: "jesus",
+      alternates: [
+        { hreflang: "en", languageSlug: "english" },
+        { hreflang: "es", languageSlug: "spanish-castilian" },
+      ],
+    },
+  ],
+  episodeRouteGroups: [],
+  skippedHreflangValues: {},
+}
+
+describe("watch sitemap routes", () => {
+  beforeEach(() => {
+    getWatchSeoManifestMock.mockReset()
+    getWatchSeoManifestMock.mockResolvedValue(manifest)
+  })
+
+  it("serves a sitemap index", async () => {
+    const { GET } = await import("./sitemap.xml/route")
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("application/xml")
+    const xml = await response.text()
+    expect(xml).toContain("<sitemapindex")
+    expect(xml).toContain("https://www.jesusfilm.org/watch/sitemap/0.xml")
+  })
+
+  it("returns 503 when the sitemap manifest is unavailable", async () => {
+    getWatchSeoManifestMock.mockResolvedValueOnce(null)
+    const { GET } = await import("./sitemap.xml/route")
+
+    const response = await GET()
+
+    expect(response.status).toBe(503)
+    await expect(response.text()).resolves.toBe("Watch sitemap unavailable")
+  })
+
+  it("serves a child sitemap chunk", async () => {
+    const { GET } = await import("./sitemap/[id]/route")
+
+    const response = await GET(new Request("http://web.test/sitemap/0.xml"), {
+      params: Promise.resolve({ id: "0.xml" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("application/xml")
+    const xml = await response.text()
+    expect(xml).toContain("<urlset")
+    expect(xml).toContain(
+      "<loc>https://www.jesusfilm.org/watch/jesus.html/english.html</loc>",
+    )
+    expect(xml).toContain('hreflang="es"')
+  })
+
+  it("404s malformed and missing child sitemap chunks", async () => {
+    const { GET } = await import("./sitemap/[id]/route")
+
+    const malformed = await GET(new Request("http://web.test/sitemap/nope"), {
+      params: Promise.resolve({ id: "nope" }),
+    })
+    const missing = await GET(new Request("http://web.test/sitemap/99.xml"), {
+      params: Promise.resolve({ id: "99.xml" }),
+    })
+
+    expect(malformed.status).toBe(404)
+    expect(missing.status).toBe(404)
+  })
+})

--- a/apps/web/src/app/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemap.xml/route.ts
@@ -1,0 +1,25 @@
+import { getWatchSeoManifest } from "@/lib/watch-seo-manifest"
+import { renderWatchSitemapIndex } from "@/lib/watch-sitemap"
+
+const XML_HEADERS = {
+  "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+  "Content-Type": "application/xml; charset=utf-8",
+}
+
+export async function GET(): Promise<Response> {
+  const manifest = await getWatchSeoManifest()
+  if (!manifest) {
+    return new Response("Watch sitemap unavailable", {
+      status: 503,
+      headers: {
+        "Cache-Control": "public, max-age=60",
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    })
+  }
+
+  return new Response(renderWatchSitemapIndex(manifest), {
+    status: 200,
+    headers: XML_HEADERS,
+  })
+}

--- a/apps/web/src/app/sitemap/[id]/route.ts
+++ b/apps/web/src/app/sitemap/[id]/route.ts
@@ -1,0 +1,42 @@
+import { getWatchSeoManifest } from "@/lib/watch-seo-manifest"
+import {
+  normalizeWatchSitemapChunkId,
+  renderWatchSitemapChunk,
+} from "@/lib/watch-sitemap"
+
+const XML_HEADERS = {
+  "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+  "Content-Type": "application/xml; charset=utf-8",
+}
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id: rawId } = await context.params
+  const id = normalizeWatchSitemapChunkId(rawId)
+  if (id === null) {
+    return new Response("Sitemap chunk not found", { status: 404 })
+  }
+
+  const manifest = await getWatchSeoManifest()
+  if (!manifest) {
+    return new Response("Watch sitemap unavailable", {
+      status: 503,
+      headers: {
+        "Cache-Control": "public, max-age=60",
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    })
+  }
+
+  const xml = renderWatchSitemapChunk(manifest, id)
+  if (!xml) {
+    return new Response("Sitemap chunk not found", { status: 404 })
+  }
+
+  return new Response(xml, {
+    status: 200,
+    headers: XML_HEADERS,
+  })
+}

--- a/apps/web/src/lib/experience-metadata.test.ts
+++ b/apps/web/src/lib/experience-metadata.test.ts
@@ -100,7 +100,7 @@ describe("getWatchPageMetadata", () => {
     expect(metadata.robots).toEqual({ index: true, follow: true })
   })
 
-  it("generates resolved video metadata with Twitter parity and hreflang alternates", async () => {
+  it("generates resolved video metadata with Twitter parity and no page-head hreflang", async () => {
     const { generateWatchVideoMetadata } = await import("./experience-metadata")
     const selectedVariant = {
       documentId: "dub-en",
@@ -215,11 +215,8 @@ describe("getWatchPageMetadata", () => {
     expect(metadata.alternates).toMatchObject({
       canonical:
         "https://www.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html",
-      languages: {
-        en: "https://www.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html",
-        es: "https://www.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/spanish-castilian.html",
-      },
     })
+    expect(metadata.alternates).not.toHaveProperty("languages")
   })
 
   it("uses a 1200x630 Mux social thumbnail before the generic image for playable videos", async () => {

--- a/apps/web/src/lib/experience-metadata.ts
+++ b/apps/web/src/lib/experience-metadata.ts
@@ -144,7 +144,6 @@ export type WatchVideoMetadataModel = {
   noIndex: boolean
   inLanguage: string | null
   durationSeconds: number | null
-  alternatesLanguages?: Record<string, string>
 }
 
 type WatchVideoMetadataOptions = {
@@ -153,26 +152,6 @@ type WatchVideoMetadataOptions = {
   routeSlug: string
   pathLocale: string
   seriesSlug?: string
-}
-
-function buildWatchVideoAlternateLanguages(
-  options: WatchVideoMetadataOptions,
-): Record<string, string> | undefined {
-  const languages: Record<string, string> = {}
-  const episodeSlug = options.video.slug ?? options.routeSlug
-
-  for (const variant of options.video.variants ?? []) {
-    if (variant.published !== true || !variant.hls) continue
-    const slug = variant.language?.slug
-    const bcp47 = variant.language?.bcp47
-    if (!slug || !bcp47 || languages[bcp47]) continue
-
-    languages[bcp47] = options.seriesSlug
-      ? buildEpisodeCanonicalUrl(options.seriesSlug, episodeSlug, slug)
-      : buildCanonicalUrl(options.routeSlug, slug)
-  }
-
-  return Object.keys(languages).length ? languages : undefined
 }
 
 export function buildWatchVideoMetadataModel(
@@ -223,7 +202,6 @@ export function buildWatchVideoMetadataModel(
       options.selectedVariant.language?.slug ??
       null,
     durationSeconds: options.selectedVariant.duration ?? null,
-    alternatesLanguages: buildWatchVideoAlternateLanguages(options),
   }
 }
 
@@ -265,9 +243,6 @@ export function generateWatchVideoMetadata(
     ...(fbAppId && { other: { "fb:app_id": fbAppId } }),
     alternates: {
       canonical: model.canonicalUrl,
-      ...(model.alternatesLanguages && {
-        languages: model.alternatesLanguages,
-      }),
     },
   }
 }

--- a/apps/web/src/lib/url-shape.test.ts
+++ b/apps/web/src/lib/url-shape.test.ts
@@ -153,6 +153,7 @@ describe("RESERVED_PREFIXES", () => {
     expect(RESERVED_PREFIXES.has("_next")).toBe(true)
     expect(RESERVED_PREFIXES.has(".well-known")).toBe(true)
     expect(RESERVED_PREFIXES.has("robots.txt")).toBe(true)
+    expect(RESERVED_PREFIXES.has("sitemap")).toBe(true)
     expect(RESERVED_PREFIXES.has("sitemap.xml")).toBe(true)
   })
 })

--- a/apps/web/src/lib/url-shape.ts
+++ b/apps/web/src/lib/url-shape.ts
@@ -35,6 +35,7 @@ export const RESERVED_PREFIXES: ReadonlySet<string> = new Set([
   "images",
   "fonts",
   "favicon.ico",
+  "sitemap",
   "robots.txt",
   "sitemap.xml",
   ".well-known",

--- a/apps/web/src/lib/watch-cache-tags.test.ts
+++ b/apps/web/src/lib/watch-cache-tags.test.ts
@@ -15,6 +15,7 @@ describe("watch cache tags", () => {
       series: "watch:series",
       childDubLanguages: "watch:child-dub-languages",
       routeManifest: "watch:route-manifest",
+      seoManifest: "watch:seo-manifest",
     })
   })
 
@@ -49,6 +50,9 @@ describe("watch cache tags", () => {
     ])
     expect(WATCH_CACHE_TAG_GROUPS.watchRouteManifest).toEqual([
       WATCH_CACHE_TAGS.routeManifest,
+    ])
+    expect(WATCH_CACHE_TAG_GROUPS.watchSeoManifest).toEqual([
+      WATCH_CACHE_TAGS.seoManifest,
     ])
   })
 })

--- a/apps/web/src/lib/watch-cache-tags.ts
+++ b/apps/web/src/lib/watch-cache-tags.ts
@@ -6,6 +6,7 @@ export const WATCH_CACHE_TAGS = {
   series: "watch:series",
   childDubLanguages: "watch:child-dub-languages",
   routeManifest: "watch:route-manifest",
+  seoManifest: "watch:seo-manifest",
 } as const
 
 export type WatchCacheTag =
@@ -37,4 +38,5 @@ export const WATCH_CACHE_TAG_GROUPS = {
     WATCH_CACHE_TAGS.home,
   ]),
   watchRouteManifest: uniqueWatchCacheTags([WATCH_CACHE_TAGS.routeManifest]),
+  watchSeoManifest: uniqueWatchCacheTags([WATCH_CACHE_TAGS.seoManifest]),
 } as const

--- a/apps/web/src/lib/watch-seo-manifest.test.ts
+++ b/apps/web/src/lib/watch-seo-manifest.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  clearWatchSeoManifestCache,
+  getWatchSeoManifest,
+  parseWatchSeoManifest,
+  setWatchSeoManifestSourceForTest,
+  type WatchSeoManifest,
+} from "./watch-seo-manifest"
+
+const manifest: WatchSeoManifest = {
+  version: "version-1",
+  generatedAt: "2026-06-12T12:00:00.000Z",
+  videoRouteGroups: [
+    {
+      contentSlug: "jesus",
+      alternates: [
+        { hreflang: "en", languageSlug: "english" },
+        { hreflang: "es", languageSlug: "spanish-castilian" },
+      ],
+    },
+  ],
+  episodeRouteGroups: [
+    {
+      parentSlug: "lumo-the-gospel-of-john",
+      childSlug: "wedding-in-cana",
+      alternates: [{ hreflang: "en", languageSlug: "english" }],
+    },
+  ],
+  skippedHreflangValues: { "es-419": 1 },
+}
+
+const originalEnv = { ...process.env }
+
+afterEach(() => {
+  process.env.ADMIN_GRAPHQL_URL = originalEnv.ADMIN_GRAPHQL_URL
+  process.env.WEB_ADMIN_API_KEYS = originalEnv.WEB_ADMIN_API_KEYS
+  vi.unstubAllGlobals()
+  clearWatchSeoManifestCache()
+})
+
+describe("parseWatchSeoManifest", () => {
+  it("accepts the admin SEO manifest contract", () => {
+    expect(parseWatchSeoManifest(manifest)).toEqual(manifest)
+  })
+
+  it("rejects malformed route groups and skipped-count maps", () => {
+    expect(
+      parseWatchSeoManifest({
+        ...manifest,
+        videoRouteGroups: [{ contentSlug: "jesus", alternates: "en" }],
+      }),
+    ).toBeNull()
+    expect(
+      parseWatchSeoManifest({
+        ...manifest,
+        episodeRouteGroups: [
+          {
+            parentSlug: "series",
+            childSlug: null,
+            alternates: [],
+          },
+        ],
+      }),
+    ).toBeNull()
+    expect(
+      parseWatchSeoManifest({
+        ...manifest,
+        skippedHreflangValues: { "es-419": "1" },
+      }),
+    ).toBeNull()
+  })
+})
+
+describe("getWatchSeoManifest", () => {
+  it("uses a test source override", async () => {
+    const reset = setWatchSeoManifestSourceForTest(async () => manifest)
+
+    await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+
+    reset()
+  })
+
+  it("fetches through the admin SEO manifest endpoint with the first consumer bearer", async () => {
+    process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "key-one,key-two"
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(manifest), {
+        status: 200,
+        headers: { etag: '"version-1"' },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://admin.test/api/watch-seo-manifest",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer key-one" },
+        cache: "no-store",
+      }),
+    )
+  })
+
+  it("reuses the cached manifest on 304 and failed refreshes", async () => {
+    process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "key-one"
+    let now = 1_000
+    const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => now)
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(manifest), {
+          status: 200,
+          headers: { etag: '"version-1"' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 304 }))
+      .mockResolvedValueOnce(new Response("nope", { status: 503 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    try {
+      await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+      now += 61_000
+      await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+      now += 61_000
+      await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+    } finally {
+      dateSpy.mockRestore()
+    }
+  })
+})

--- a/apps/web/src/lib/watch-seo-manifest.ts
+++ b/apps/web/src/lib/watch-seo-manifest.ts
@@ -1,0 +1,233 @@
+export type WatchSeoManifestAlternate = {
+  hreflang: string
+  languageSlug: string
+}
+
+export type WatchSeoManifestVideoRouteGroup = {
+  contentSlug: string
+  alternates: WatchSeoManifestAlternate[]
+}
+
+export type WatchSeoManifestEpisodeRouteGroup = {
+  parentSlug: string
+  childSlug: string
+  alternates: WatchSeoManifestAlternate[]
+}
+
+export type WatchSeoManifest = {
+  version: string
+  generatedAt: string
+  videoRouteGroups: WatchSeoManifestVideoRouteGroup[]
+  episodeRouteGroups: WatchSeoManifestEpisodeRouteGroup[]
+  skippedHreflangValues: Record<string, number>
+}
+
+type WatchSeoManifestCache = {
+  etag: string | null
+  expiresAt: number
+  inFlight: Promise<WatchSeoManifest | null> | null
+  manifest: WatchSeoManifest | null
+}
+
+export type WatchSeoManifestSource = () => Promise<WatchSeoManifest | null>
+
+const WATCH_SEO_MANIFEST_CACHE_TTL_MS = 60_000
+const WATCH_SEO_MANIFEST_TIMEOUT_MS = 3_000
+
+let manifestCache: WatchSeoManifestCache = {
+  etag: null,
+  expiresAt: 0,
+  inFlight: null,
+  manifest: null,
+}
+let sourceOverride: WatchSeoManifestSource | null = null
+
+function isString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
+function isAlternate(value: unknown): value is WatchSeoManifestAlternate {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const record = value as Record<string, unknown>
+  return isString(record.hreflang) && isString(record.languageSlug)
+}
+
+function isAlternateArray(
+  value: unknown,
+): value is WatchSeoManifestAlternate[] {
+  return Array.isArray(value) && value.every(isAlternate)
+}
+
+function isVideoRouteGroup(
+  value: unknown,
+): value is WatchSeoManifestVideoRouteGroup {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const record = value as Record<string, unknown>
+  return isString(record.contentSlug) && isAlternateArray(record.alternates)
+}
+
+function isEpisodeRouteGroup(
+  value: unknown,
+): value is WatchSeoManifestEpisodeRouteGroup {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const record = value as Record<string, unknown>
+  return (
+    isString(record.parentSlug) &&
+    isString(record.childSlug) &&
+    isAlternateArray(record.alternates)
+  )
+}
+
+function isSkippedHreflangValues(
+  value: unknown,
+): value is Record<string, number> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  return Object.entries(value).every(
+    ([key, count]) =>
+      key.length > 0 && Number.isInteger(count) && Number(count) >= 0,
+  )
+}
+
+export function parseWatchSeoManifest(value: unknown): WatchSeoManifest | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (!isString(record.version)) return null
+  if (!isString(record.generatedAt)) return null
+  if (
+    !Array.isArray(record.videoRouteGroups) ||
+    !record.videoRouteGroups.every(isVideoRouteGroup)
+  ) {
+    return null
+  }
+  if (
+    !Array.isArray(record.episodeRouteGroups) ||
+    !record.episodeRouteGroups.every(isEpisodeRouteGroup)
+  ) {
+    return null
+  }
+  if (!isSkippedHreflangValues(record.skippedHreflangValues)) return null
+
+  return {
+    version: record.version,
+    generatedAt: record.generatedAt,
+    videoRouteGroups: record.videoRouteGroups,
+    episodeRouteGroups: record.episodeRouteGroups,
+    skippedHreflangValues: record.skippedHreflangValues,
+  }
+}
+
+export function clearWatchSeoManifestCache(): void {
+  manifestCache = {
+    etag: null,
+    expiresAt: 0,
+    inFlight: null,
+    manifest: null,
+  }
+}
+
+export function setWatchSeoManifestSourceForTest(
+  source: WatchSeoManifestSource | null,
+): () => void {
+  const previous = sourceOverride
+  sourceOverride = source
+  clearWatchSeoManifestCache()
+  return () => {
+    sourceOverride = previous
+    clearWatchSeoManifestCache()
+  }
+}
+
+function watchSeoManifestUrl(): string | null {
+  const adminGraphqlUrl = process.env.ADMIN_GRAPHQL_URL
+  if (!adminGraphqlUrl) return null
+  try {
+    const url = new URL(adminGraphqlUrl)
+    url.pathname = url.pathname.replace(/\/api\/graphql\/?$/, "")
+    url.pathname = `${url.pathname.replace(/\/$/, "")}/api/watch-seo-manifest`
+    url.search = ""
+    url.hash = ""
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function watchSeoManifestBearer(): string | null {
+  const bearer = process.env.WEB_ADMIN_API_KEYS?.split(",")[0]?.trim()
+  return bearer || null
+}
+
+function timeoutSignal(): AbortSignal | undefined {
+  return typeof AbortSignal.timeout === "function"
+    ? AbortSignal.timeout(WATCH_SEO_MANIFEST_TIMEOUT_MS)
+    : undefined
+}
+
+async function fetchWatchSeoManifest(): Promise<WatchSeoManifest | null> {
+  const url = watchSeoManifestUrl()
+  const bearer = watchSeoManifestBearer()
+  if (!url || !bearer) return null
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        ...(manifestCache.etag ? { "If-None-Match": manifestCache.etag } : {}),
+      },
+      cache: "no-store",
+      signal: timeoutSignal(),
+    })
+
+    if (response.status === 304) {
+      return manifestCache.manifest
+    }
+    if (!response.ok) {
+      console.warn(
+        JSON.stringify({
+          event: "watch_seo_manifest.fetch.failed",
+          status: response.status,
+        }),
+      )
+      return manifestCache.manifest
+    }
+
+    const parsed = parseWatchSeoManifest(await response.json())
+    if (!parsed) {
+      console.warn(
+        JSON.stringify({
+          event: "watch_seo_manifest.fetch.invalid_payload",
+        }),
+      )
+      return manifestCache.manifest
+    }
+
+    manifestCache.etag = response.headers.get("etag")
+    return parsed
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "watch_seo_manifest.fetch.error",
+        detail:
+          error instanceof Error ? error.message.slice(0, 500) : String(error),
+      }),
+    )
+    return manifestCache.manifest
+  }
+}
+
+export async function getWatchSeoManifest(): Promise<WatchSeoManifest | null> {
+  if (sourceOverride) return sourceOverride()
+
+  const now = Date.now()
+  if (manifestCache.expiresAt > now) return manifestCache.manifest
+  if (manifestCache.inFlight) return manifestCache.inFlight
+
+  manifestCache.inFlight = fetchWatchSeoManifest().then((manifest) => {
+    manifestCache.manifest = manifest
+    manifestCache.expiresAt = Date.now() + WATCH_SEO_MANIFEST_CACHE_TTL_MS
+    manifestCache.inFlight = null
+    return manifest
+  })
+
+  return manifestCache.inFlight
+}

--- a/apps/web/src/lib/watch-sitemap.test.ts
+++ b/apps/web/src/lib/watch-sitemap.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createWatchSitemapEntries,
+  getWatchSitemapChunks,
+  normalizeWatchSitemapChunkId,
+  renderWatchSitemapChunk,
+  renderWatchSitemapIndex,
+  watchSitemapChunkUrl,
+} from "./watch-sitemap"
+import type { WatchSeoManifest } from "./watch-seo-manifest"
+
+const manifest: WatchSeoManifest = {
+  version: "version-1",
+  generatedAt: "2026-06-12T12:00:00.000Z",
+  videoRouteGroups: [
+    {
+      contentSlug: "jesus",
+      alternates: [
+        { hreflang: "en", languageSlug: "english" },
+        { hreflang: "es", languageSlug: "spanish-castilian" },
+      ],
+    },
+    {
+      contentSlug: "bad slug",
+      alternates: [{ hreflang: "fr", languageSlug: "french" }],
+    },
+  ],
+  episodeRouteGroups: [
+    {
+      parentSlug: "lumo-the-gospel-of-john",
+      childSlug: "wedding-in-cana",
+      alternates: [{ hreflang: "en", languageSlug: "english" }],
+    },
+  ],
+  skippedHreflangValues: {},
+}
+
+describe("watch sitemap rendering", () => {
+  it("expands route groups into one self-inclusive entry per alternate URL", () => {
+    const entries = createWatchSitemapEntries(manifest)
+
+    expect(entries).toHaveLength(3)
+    expect(entries[0]).toEqual({
+      loc: "https://www.jesusfilm.org/watch/jesus.html/english.html",
+      alternates: [
+        {
+          hreflang: "en",
+          languageSlug: "english",
+          href: "https://www.jesusfilm.org/watch/jesus.html/english.html",
+        },
+        {
+          hreflang: "es",
+          languageSlug: "spanish-castilian",
+          href: "https://www.jesusfilm.org/watch/jesus.html/spanish-castilian.html",
+        },
+      ],
+    })
+    expect(entries[2]?.loc).toBe(
+      "https://www.jesusfilm.org/watch/lumo-the-gospel-of-john.html/wedding-in-cana/english.html",
+    )
+  })
+
+  it("renders a sitemap index with canonical child sitemap URLs", () => {
+    const xml = renderWatchSitemapIndex(manifest, { maxUrls: 1 })
+
+    expect(xml).toContain("<sitemapindex")
+    expect(xml).toContain(
+      "<loc>https://www.jesusfilm.org/watch/sitemap/0.xml</loc>",
+    )
+    expect(xml).toContain(
+      "<loc>https://www.jesusfilm.org/watch/sitemap/1.xml</loc>",
+    )
+    expect(xml).toContain(
+      "<loc>https://www.jesusfilm.org/watch/sitemap/2.xml</loc>",
+    )
+  })
+
+  it("renders child sitemap XML with xhtml alternate links", () => {
+    const xml = renderWatchSitemapChunk(manifest, 0)
+
+    expect(xml).toContain("<urlset")
+    expect(xml).toContain('xmlns:xhtml="http://www.w3.org/1999/xhtml"')
+    expect(xml).toContain(
+      "<loc>https://www.jesusfilm.org/watch/jesus.html/english.html</loc>",
+    )
+    expect(xml).toContain(
+      'hreflang="es" href="https://www.jesusfilm.org/watch/jesus.html/spanish-castilian.html"',
+    )
+    expect(xml).not.toContain("bad slug")
+  })
+
+  it("escapes XML attribute and text values", () => {
+    const xml = renderWatchSitemapChunk(
+      {
+        ...manifest,
+        videoRouteGroups: [
+          {
+            contentSlug: "jesus",
+            alternates: [{ hreflang: 'en"bad', languageSlug: "english" }],
+          },
+        ],
+        episodeRouteGroups: [],
+      },
+      0,
+    )
+
+    expect(xml).toContain("en&quot;bad")
+  })
+
+  it("splits chunks by URL count and serialized byte limits", () => {
+    expect(getWatchSitemapChunks(manifest, { maxUrls: 1 })).toHaveLength(3)
+    expect(getWatchSitemapChunks(manifest, { maxBytes: 350 })).toHaveLength(3)
+  })
+
+  it("shares repeated alternate XML within a route group while chunking", () => {
+    const chunks = getWatchSitemapChunks(manifest)
+    const [first, second] = chunks[0]?.entries ?? []
+
+    expect(first?.alternatesXml).toBe(second?.alternatesXml)
+  })
+
+  it("normalizes numeric chunk ids and rejects unsafe ids", () => {
+    expect(normalizeWatchSitemapChunkId("12")).toBe(12)
+    expect(normalizeWatchSitemapChunkId("12.xml")).toBe(12)
+    expect(normalizeWatchSitemapChunkId("../12.xml")).toBeNull()
+    expect(normalizeWatchSitemapChunkId("abc.xml")).toBeNull()
+  })
+
+  it("returns null for missing chunks", () => {
+    expect(renderWatchSitemapChunk(manifest, 99)).toBeNull()
+  })
+
+  it("uses the canonical sitemap child path", () => {
+    expect(watchSitemapChunkUrl(5)).toBe(
+      "https://www.jesusfilm.org/watch/sitemap/5.xml",
+    )
+  })
+})

--- a/apps/web/src/lib/watch-sitemap.ts
+++ b/apps/web/src/lib/watch-sitemap.ts
@@ -1,0 +1,270 @@
+import {
+  WATCH_BASE_PATH,
+  WATCH_PUBLIC_METADATA_ORIGIN,
+  tryAsContentSlug,
+  tryAsLocaleSlug,
+  watchEpisodePath,
+  watchVideoPath,
+} from "@/lib/routes"
+import type {
+  WatchSeoManifest,
+  WatchSeoManifestAlternate,
+} from "@/lib/watch-seo-manifest"
+
+const XML_HEADER = '<?xml version="1.0" encoding="UTF-8"?>'
+const URLSET_OPEN =
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+const URLSET_CLOSE = "</urlset>"
+const SITEMAPINDEX_OPEN =
+  '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+const SITEMAPINDEX_CLOSE = "</sitemapindex>"
+
+export const WATCH_SITEMAP_INDEX_PATH = "/sitemap.xml"
+export const WATCH_SITEMAP_CHUNK_PATH_PREFIX = "/sitemap"
+export const DEFAULT_MAX_SITEMAP_URLS = 50_000
+export const DEFAULT_MAX_SITEMAP_BYTES = 45_000_000
+
+export type WatchSitemapLimits = {
+  maxBytes?: number
+  maxUrls?: number
+}
+
+export type WatchSitemapAlternate = WatchSeoManifestAlternate & {
+  href: string
+}
+
+export type WatchSitemapEntry = {
+  loc: string
+  alternates: WatchSitemapAlternate[]
+}
+
+export type WatchSitemapChunkEntry = {
+  alternatesXml: string
+  bytes: number
+  loc: string
+}
+
+export type WatchSitemapChunk = {
+  entries: WatchSitemapChunkEntry[]
+  bytes: number
+}
+
+type ResolvedSitemapGroup = {
+  alternateLinksXml: string
+  alternateLinksBytes: number
+  locs: string[]
+}
+
+const chunkCache = new WeakMap<WatchSeoManifest, WatchSitemapChunk[]>()
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}
+
+function absoluteWatchUrl(path: string): string {
+  return `${WATCH_PUBLIC_METADATA_ORIGIN}${WATCH_BASE_PATH}${path}`
+}
+
+function videoHref(contentSlug: string, languageSlug: string): string | null {
+  const content = tryAsContentSlug(contentSlug)
+  const language = tryAsLocaleSlug(languageSlug)
+  if (!content || !language) return null
+  return absoluteWatchUrl(watchVideoPath(content, language))
+}
+
+function episodeHref(
+  parentSlug: string,
+  childSlug: string,
+  languageSlug: string,
+): string | null {
+  const parent = tryAsContentSlug(parentSlug)
+  const child = tryAsContentSlug(childSlug)
+  const language = tryAsLocaleSlug(languageSlug)
+  if (!parent || !child || !language) return null
+  return absoluteWatchUrl(watchEpisodePath(parent, child, language))
+}
+
+function renderAlternate(alternate: WatchSitemapAlternate): string {
+  return `<xhtml:link rel="alternate" hreflang="${xmlEscape(alternate.hreflang)}" href="${xmlEscape(alternate.href)}" />`
+}
+
+function renderEntryXml({
+  alternatesXml,
+  loc,
+}: Pick<WatchSitemapChunkEntry, "alternatesXml" | "loc">): string {
+  return `<url><loc>${xmlEscape(loc)}</loc>${alternatesXml}</url>`
+}
+
+function groupEntries(
+  alternates: WatchSeoManifestAlternate[],
+  hrefForLanguage: (languageSlug: string) => string | null,
+): WatchSitemapEntry[] {
+  const resolvedAlternates = alternates
+    .map((alternate) => {
+      const href = hrefForLanguage(alternate.languageSlug)
+      return href ? { ...alternate, href } : null
+    })
+    .filter(
+      (alternate): alternate is WatchSitemapAlternate => alternate !== null,
+    )
+
+  return resolvedAlternates.map((alternate) => ({
+    loc: alternate.href,
+    alternates: resolvedAlternates,
+  }))
+}
+
+function groupForAlternates(
+  alternates: WatchSeoManifestAlternate[],
+  hrefForLanguage: (languageSlug: string) => string | null,
+): ResolvedSitemapGroup | null {
+  const entries = groupEntries(alternates, hrefForLanguage)
+  if (!entries.length) return null
+  const alternateLinksXml = entries[0]?.alternates.map(renderAlternate).join("")
+  if (!alternateLinksXml) return null
+  return {
+    alternateLinksXml,
+    alternateLinksBytes: Buffer.byteLength(alternateLinksXml, "utf8"),
+    locs: entries.map((entry) => entry.loc),
+  }
+}
+
+function createWatchSitemapGroups(
+  manifest: WatchSeoManifest,
+): ResolvedSitemapGroup[] {
+  const groups: ResolvedSitemapGroup[] = []
+
+  for (const group of manifest.videoRouteGroups) {
+    const sitemapGroup = groupForAlternates(group.alternates, (languageSlug) =>
+      videoHref(group.contentSlug, languageSlug),
+    )
+    if (sitemapGroup) groups.push(sitemapGroup)
+  }
+
+  for (const group of manifest.episodeRouteGroups) {
+    const sitemapGroup = groupForAlternates(group.alternates, (languageSlug) =>
+      episodeHref(group.parentSlug, group.childSlug, languageSlug),
+    )
+    if (sitemapGroup) groups.push(sitemapGroup)
+  }
+
+  return groups
+}
+
+export function createWatchSitemapEntries(
+  manifest: WatchSeoManifest,
+): WatchSitemapEntry[] {
+  const entries: WatchSitemapEntry[] = []
+
+  for (const group of manifest.videoRouteGroups) {
+    entries.push(
+      ...groupEntries(group.alternates, (languageSlug) =>
+        videoHref(group.contentSlug, languageSlug),
+      ),
+    )
+  }
+
+  for (const group of manifest.episodeRouteGroups) {
+    entries.push(
+      ...groupEntries(group.alternates, (languageSlug) =>
+        episodeHref(group.parentSlug, group.childSlug, languageSlug),
+      ),
+    )
+  }
+
+  return entries
+}
+
+export function getWatchSitemapChunks(
+  manifest: WatchSeoManifest,
+  limits: WatchSitemapLimits = {},
+): WatchSitemapChunk[] {
+  if (!limits.maxBytes && !limits.maxUrls) {
+    const cached = chunkCache.get(manifest)
+    if (cached) return cached
+  }
+
+  const maxBytes = limits.maxBytes ?? DEFAULT_MAX_SITEMAP_BYTES
+  const maxUrls = limits.maxUrls ?? DEFAULT_MAX_SITEMAP_URLS
+  const wrapperBytes = Buffer.byteLength(
+    `${XML_HEADER}${URLSET_OPEN}${URLSET_CLOSE}`,
+    "utf8",
+  )
+  const chunks: WatchSitemapChunk[] = []
+  let current: WatchSitemapChunk = { entries: [], bytes: wrapperBytes }
+
+  for (const group of createWatchSitemapGroups(manifest)) {
+    for (const loc of group.locs) {
+      const entry: WatchSitemapChunkEntry = {
+        alternatesXml: group.alternateLinksXml,
+        bytes:
+          Buffer.byteLength("<url><loc></loc></url>", "utf8") +
+          Buffer.byteLength(xmlEscape(loc), "utf8") +
+          group.alternateLinksBytes,
+        loc,
+      }
+      const wouldExceedUrlLimit = current.entries.length >= maxUrls
+      const wouldExceedByteLimit =
+        current.entries.length > 0 && current.bytes + entry.bytes > maxBytes
+      if (wouldExceedUrlLimit || wouldExceedByteLimit) {
+        chunks.push(current)
+        current = { entries: [], bytes: wrapperBytes }
+      }
+      current.entries.push(entry)
+      current.bytes += entry.bytes
+    }
+  }
+
+  if (current.entries.length > 0 || chunks.length === 0) {
+    chunks.push(current)
+  }
+
+  if (!limits.maxBytes && !limits.maxUrls) {
+    chunkCache.set(manifest, chunks)
+  }
+  return chunks
+}
+
+export function normalizeWatchSitemapChunkId(rawId: string): number | null {
+  const id = rawId.replace(/\.xml$/i, "")
+  if (!/^\d+$/.test(id)) return null
+  const parsed = Number(id)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+export function watchSitemapChunkPath(id: number): string {
+  return `${WATCH_SITEMAP_CHUNK_PATH_PREFIX}/${id}.xml`
+}
+
+export function watchSitemapChunkUrl(id: number): string {
+  return absoluteWatchUrl(watchSitemapChunkPath(id))
+}
+
+export function renderWatchSitemapIndex(
+  manifest: WatchSeoManifest,
+  limits?: WatchSitemapLimits,
+): string {
+  const chunks = getWatchSitemapChunks(manifest, limits)
+  const entries = chunks
+    .map(
+      (_chunk, index) =>
+        `<sitemap><loc>${xmlEscape(watchSitemapChunkUrl(index))}</loc></sitemap>`,
+    )
+    .join("")
+  return `${XML_HEADER}${SITEMAPINDEX_OPEN}${entries}${SITEMAPINDEX_CLOSE}`
+}
+
+export function renderWatchSitemapChunk(
+  manifest: WatchSeoManifest,
+  id: number,
+  limits?: WatchSitemapLimits,
+): string | null {
+  const chunk = getWatchSitemapChunks(manifest, limits)[id]
+  if (!chunk) return null
+  return `${XML_HEADER}${URLSET_OPEN}${chunk.entries.map(renderEntryXml).join("")}${URLSET_CLOSE}`
+}

--- a/apps/web/src/lib/watch-structured-data.test.ts
+++ b/apps/web/src/lib/watch-structured-data.test.ts
@@ -19,9 +19,6 @@ describe("watchVideoStructuredDataJson", () => {
       noIndex: false,
       inLanguage: "en",
       durationSeconds: 91.4,
-      alternatesLanguages: {
-        en: "https://www.jesusfilm.org/watch/life.html/english.html",
-      },
     })
 
     expect(json).not.toContain("<")

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -263,11 +263,14 @@ describe("proxy config matcher — reserved first-segment exclusions", () => {
     expect(matcherRegex.test("/demo-recommendations/jesus/en")).toBe(false)
     expect(matcherRegex.test("/_next/data/build/x.json")).toBe(false)
     expect(matcherRegex.test("/.well-known/security.txt")).toBe(false)
+    expect(matcherRegex.test("/sitemap.xml")).toBe(false)
+    expect(matcherRegex.test("/sitemap/0.xml")).toBe(false)
   })
 
   it("does not exclude content routes that only start with a reserved word", async () => {
     expect(matcherRegex.test("/images-of-jesus.html/english.html")).toBe(true)
     expect(matcherRegex.test("/fonts-of-worship.html/english.html")).toBe(true)
+    expect(matcherRegex.test("/sitemap-of-jesus.html/english.html")).toBe(true)
   })
 })
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -312,6 +312,6 @@ export const config = {
     // Reserved framework + asset subtrees that must never enter the
     // canonicalize/rewrite pipeline. Demo surfaces live in a route group and
     // keep public paths such as /demo-search without the watch locale rewrite.
-    "/((?!(?:api|assets|images|fonts|demo-search|demo-recommendations|\\.well-known)(?:/|$)|_next/(?:static|image|data|webpack-hmr)(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap(?:\\.xml)?$).*)",
+    "/((?!(?:api|assets|images|fonts|sitemap|demo-search|demo-recommendations|\\.well-known)(?:/|$)|_next/(?:static|image|data|webpack-hmr)(?:/|$)|favicon\\.ico$|robots\\.txt$|sitemap(?:\\.xml)?$).*)",
   ],
 }

--- a/docs/plans/2026-06-12-002-perf-watch-hreflang-sitemap-plan.md
+++ b/docs/plans/2026-06-12-002-perf-watch-hreflang-sitemap-plan.md
@@ -1,0 +1,653 @@
+---
+title: "perf: Move Watch hreflang alternates to sitemap-only manifests"
+type: "perf"
+status: "active"
+date: "2026-06-12"
+origin: "release QA follow-up for oversized Watch HTML alternates"
+roadmap: "docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md"
+---
+
+# perf: Move Watch Hreflang Alternates to Sitemap-Only Manifests
+
+## Summary
+
+Move Watch language `hreflang` out of video page HTML entirely and into
+generated sitemap XML backed by a precomputed Admin-owned SEO manifest. Page
+HTML should emit no `rel="alternate" hreflang` links for Watch routes; it keeps
+canonical URLs, Open Graph, Twitter metadata, structured data, public
+audio-language slugs, and the existing metadata origin contract.
+
+This is the concrete follow-up to the launch-readiness plan's warning that
+high-Dub-count videos may need sitemap-level hreflang instead of full page-head
+alternates. The staging QA evidence showed that condition in the wild: one
+page produced 2,094 alternate links, roughly 270 KB of alternate tags alone,
+and a 1.23 MB HTML response. Because Google treats HTML and sitemap hreflang
+as equivalent, the release plan now chooses one annotation surface rather than
+maintaining both.
+
+---
+
+## Problem Frame
+
+Watch video pages currently build `alternates.languages` inside
+`apps/web/src/lib/experience-metadata.ts` by iterating every published playable
+Dub on the resolved `WatchVideoRecord`. That was good enough to restore
+hreflang coverage quickly, but it creates three release risks:
+
+1. The raw HTML head becomes huge on high-language videos. The audited staging
+   page shipped 2,094 alternate links and 1.23 MB of HTML before the browser
+   could render the page.
+2. The page render pays to derive an SEO alternate graph from the full
+   resolved video payload. On cold paths, this compounds existing Watch
+   manifest and resolver latency.
+3. Page-head hreflang duplicates the sitemap contract without adding Google
+   Search value once sitemap coverage exists. Maintaining two annotation
+   surfaces increases drift risk and keeps unnecessary bytes in every Watch
+   HTML response.
+
+Google treats HTML, HTTP header, and sitemap hreflang annotations as equivalent
+signals. A generated sitemap is therefore the only `hreflang` home for Watch in
+this plan, provided it is valid, split below sitemap limits, and kept in sync
+with canonical Watch URLs.
+
+---
+
+## Requirements
+
+- R1. Full playable Watch alternate coverage moves to generated sitemap XML,
+  split so every sitemap stays below 50,000 URLs and 50 MB uncompressed.
+- R2. Watch page metadata emits no page-head `hreflang` annotations. In Next
+  metadata terms, Watch video and episode metadata must not populate
+  `alternates.languages`; canonical, Open Graph, Twitter, robots, and
+  structured data remain intact.
+- R3. Watch page render must not rebuild the full 2,000+ language alternate
+  graph from `video.variants` on cold render.
+- R4. Web consumes a precomputed/cached alternate manifest with `ETag`, TTL,
+  and revalidation behavior matching the existing Admin-owned route manifest
+  pattern for sitemap generation.
+- R5. Keep public Watch URL shapes unchanged:
+  `/watch/{slug}.html/{language}.html` and
+  `/watch/{series}.html/{episode}/{language}.html`.
+- R6. Keep canonical, Open Graph, Twitter, and sitemap URLs on
+  `https://www.jesusfilm.org/watch/...`, not the staging host.
+- R7. Validate hreflang values before emitting them in sitemap XML.
+  Unsupported or duplicate tags must be skipped with observable counts instead
+  of emitted.
+- R8. Do not overload the existing route manifest with rendering or SEO
+  payloads. Route admission and SEO alternate generation stay separate
+  contracts even if they share source queries and refresh triggers.
+- R9. `robots.ts` advertises the sitemap or sitemap index only after the new
+  sitemap surface exists and has tests.
+- R10. Release verification must include HTML-size regression proof, zero
+  page-head `hreflang` proof, sitemap coverage proof, and Helium browser smoke
+  on representative Watch pages.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Add an adjacent Watch SEO manifest instead of expanding the route
+  manifest.** `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md`
+  explicitly keeps the route manifest admission-focused. The SEO manifest can
+  reuse that snapshot, store, endpoint, and refresh pattern without making
+  route admission carry sitemap-only data.
+- KTD2. **Sitemap XML becomes the only Watch hreflang source of truth.**
+  Page-head `hreflang` is removed instead of capped. This avoids duplicate
+  annotation logic and follows Google's guidance that sitemap hreflang is an
+  equivalent signal.
+- KTD3. **Do not keep a high-confidence head subset.** A small head subset
+  would still need bidirectional consistency, extra tests, and drift handling.
+  Any route that should be advertised as a localized alternate must be present
+  in the sitemap graph; Watch page HTML should not emit `hreflang`.
+- KTD4. **Use Google-supported hreflang, not arbitrary BCP-47.** Admin stores
+  BCP-47-like language values for app behavior, but Google documents stricter
+  support. Emit only tags the validator accepts, and record skipped languages.
+- KTD5. **Split by serialized XML size as well as URL count.** Next.js
+  `generateSitemaps` documents the 50,000 URL limit, but full alternate
+  clusters can hit the 50 MB uncompressed limit first. The implementation
+  should either use a custom sitemap index and chunked XML route handlers, or
+  set a conservative chunk size proven by serialized-size tests.
+- KTD6. **Use snapshot reads in sitemap request paths.** Admin generates and
+  persists the SEO manifest out of band. Web fetches the latest snapshot with
+  conditional requests and process cache; sitemap code reads the cached
+  manifest, not live admin aggregate queries.
+- KTD7. **Keep sitemap URLs canonical and absolute.** Sitemap entries use
+  `WATCH_PUBLIC_METADATA_ORIGIN` plus `WATCH_BASE_PATH` and route builders.
+  They must not use relative URLs or the request host.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Admin video, dub, and language rows"] --> B["WatchSeoManifestService"]
+  B --> C["Persist latest SEO manifest snapshot"]
+  C --> D["GET /api/watch-seo-manifest with ETag"]
+  D --> E["Web cached SEO manifest client"]
+  E --> F["Watch sitemap index and sitemap chunks"]
+  G["Watch page metadata without hreflang"]
+  H["Admin Core sync and publish events"] --> I["Refresh SEO manifest"]
+  I --> J["Emit web revalidation"]
+  J --> K["Clear web SEO manifest cache"]
+  K --> E
+```
+
+The sitemap path is the only `hreflang` path. Sitemap generation projects the
+full valid alternate graph into XML chunks. Watch page metadata does not read
+the SEO manifest for `hreflang`; it keeps canonical, social metadata,
+structured data, and visible page behavior independent of the sitemap graph.
+
+```mermaid
+flowchart LR
+  A["SEO manifest route group"] --> B["All playable public URLs"]
+  A --> C["Valid hreflang alternates"]
+  C --> D["Sitemap xhtml:link graph"]
+  E["Watch page metadata"] --> F["Canonical, OG, Twitter, JSON-LD"]
+```
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Admin-owned SEO/alternate manifest generation, persistence, endpoint, and
+  refresh wiring.
+- Web cached manifest consumption for sitemap generation.
+- Generated sitemap index and child sitemap XML for Watch alternate coverage.
+- Removal of Watch page-head `hreflang` for video and episode pages.
+- Tests and release proof for sitemap validity, canonical URL ownership,
+  zero page-head `hreflang`, smaller HTML head output, and cold-render
+  behavior.
+
+### Out of Scope
+
+- Changing public Watch URL shapes.
+- Switching canonical ownership from `www.jesusfilm.org` to
+  `watch.jesusfilm.org`.
+- Fixing the unrelated mobile header overlap, search snippet, or language
+  switch QA blockers.
+- Translating missing video metadata. This plan uses existing playable route
+  and language identity; new translation/backfill belongs to localized content
+  tickets.
+- Replacing the existing route manifest admission contract.
+- Cloudflare HTML cache rules or a custom shared Next cache handler.
+
+### Deferred to Follow-Up Work
+
+- Search Console submission and post-release indexing monitoring can happen
+  after the sitemap surface is live.
+- Video sitemap extensions (`video:video`) can follow after the basic URL plus
+  hreflang sitemap is valid.
+- More nuanced locale clustering can follow if SEO wants region-specific
+  targeting beyond the current route language identity.
+
+---
+
+## Dependencies And Prerequisites
+
+- Use the dedicated roadmap ticket
+  `docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md`.
+  Related tickets such as `feat-173`, `feat-172`, and `feat-178` are complete;
+  this is a new follow-up slice.
+- Keep `feat-154` in view. Variant-aware language identity is in progress and
+  affects public language slug identity, duplicate handling, and exact route
+  grouping.
+- Context7 lookup for Next.js docs failed in this planning run because the
+  OAuth token was expired. The plan uses official Next.js web docs directly.
+
+---
+
+## Implementation Units
+
+### U1. Roadmap Alignment And Characterization Baseline
+
+**Goal:** Keep the traceable `feat-184` roadmap item aligned and lock the
+current regression surface before changing metadata behavior.
+
+**Requirements:** R1, R2, R3, R6, R10.
+
+**Dependencies:** None.
+
+**Files:**
+
+- `docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md`
+- `docs/roadmap/README.md`
+- `apps/web/src/lib/experience-metadata.test.ts`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+
+**Approach:** Use the existing `feat-184` roadmap ticket as the implementation
+origin, update the roadmap index if the implementation workflow regenerates it,
+then add characterization tests around the current high-language metadata
+behavior. The tests should make the desired regression target explicit: page
+metadata must no longer emit any `hreflang` language alternates after the
+implementation.
+
+**Execution Note:** Start with characterization coverage for current canonical
+ownership and page-head `hreflang` count behavior before editing the metadata
+helper.
+
+**Patterns to Follow:**
+
+- Roadmap format in `CLAUDE.md`.
+- Existing metadata assertions in
+  `apps/web/src/lib/experience-metadata.test.ts`.
+- Playable route metadata tests in
+  `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`.
+
+**Test Scenarios:**
+
+- Given a video with English, Spanish, and a duplicate-BCP47 Spanish Dub, the
+  existing canonical URL remains on `https://www.jesusfilm.org/watch/...`.
+- Given a synthetic high-Dub video, the new expected behavior emits zero
+  page-head `hreflang` language alternates.
+- Given an unsupported hreflang value, metadata still emits no page-head
+  `hreflang`; unsupported-value handling belongs to sitemap XML tests.
+
+**Verification:** The roadmap ticket points at this plan, any generated roadmap
+index is updated if needed, and characterization tests fail against the old
+full-head behavior while preserving canonical URL assertions.
+
+### U2. Admin Watch SEO Manifest Snapshot
+
+**Goal:** Generate a precomputed SEO manifest that contains the route and
+language data needed by sitemap XML without live aggregate work in Web sitemap
+request paths.
+
+**Requirements:** R1, R4, R7, R8.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `apps/admin/src/services/watch-seo-manifest.service.ts`
+- `apps/admin/src/services/watch-seo-manifest.service.test.ts`
+- `apps/admin/src/services/watch-seo-manifest-store.ts`
+- `apps/admin/src/services/watch-seo-manifest-store.test.ts`
+- `apps/admin/prisma/schema.prisma`
+- `apps/admin/prisma/migrations/NEW_watch_seo_manifest_snapshot/migration.sql`
+- `apps/admin/src/scripts/generate-watch-seo-manifest.ts`
+- `apps/admin/package.json`
+
+**Approach:** Mirror the durable route-manifest pattern: service builds a
+deterministic payload, store persists the latest JSONB snapshot, version hash
+excludes `generatedAt`, and an operator script can regenerate explicitly. Keep
+the payload compact but SEO-specific. It should include route groups for
+two-segment videos and three-segment episodes, public audio language slugs,
+and validated hreflang values.
+
+Do not put full titles, descriptions, study questions, or rendering payloads in
+the manifest. The SEO manifest is a routing and alternate graph, not a page
+resolver replacement.
+
+**Patterns to Follow:**
+
+- `apps/admin/src/services/watch-route-manifest.service.ts`
+- `apps/admin/src/services/watch-route-manifest-store.ts`
+- `apps/admin/src/scripts/generate-watch-route-manifest.ts`
+- `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md`
+
+**Test Scenarios:**
+
+- Given playable published dubs for one video, the manifest includes public
+  audio slug alternates for that video.
+- Given a parent with playable child episodes, the manifest includes the
+  three-segment episode route group and child-specific language coverage.
+- Given duplicate BCP-47 values for separate language slugs, the manifest
+  preserves slug identity while exposing only one Google hreflang entry per
+  emitted alternate key.
+- Given a language tag unsupported by Google, the manifest excludes it from the
+  hreflang graph and increments a skipped-count summary.
+- Given only a playable Dub and no localized metadata, the route can still be
+  sitemap-eligible when its public URL and hreflang value are valid.
+- Given malformed query rows, manifest generation fails rather than persisting
+  a partial snapshot.
+
+**Verification:** Admin service/store tests pass, and the operator script
+prints summary counts for route groups, alternate pairs, skipped hreflang
+values, payload bytes, and duration.
+
+### U3. Admin Endpoint And Refresh Wiring
+
+**Goal:** Serve and refresh the SEO manifest through the same producer-owned
+snapshot lifecycle as the route manifest.
+
+**Requirements:** R4, R8, R9.
+
+**Dependencies:** U2.
+
+**Files:**
+
+- `apps/admin/src/app/api/watch-seo-manifest/route.ts`
+- `apps/admin/src/app/api/watch-seo-manifest/route.test.ts`
+- `apps/admin/src/services/watch-route-manifest-refresh.service.ts`
+- `apps/admin/src/services/watch-route-manifest-refresh.service.test.ts`
+- `apps/admin/src/services/revalidate-webhook.ts`
+- `apps/admin/CLAUDE.md`
+
+**Approach:** Add an authenticated `GET /api/watch-seo-manifest` endpoint with
+consumer bearer auth, `ETag`, `If-None-Match`, controlled `503` for missing
+snapshots, and private cache-control. Refresh the SEO manifest after route and
+language relevant changes: languages, videos, video-dubs, and
+publish/archive changes that affect Watch route visibility.
+
+Keep refresh best-effort so Core sync and editorial flows do not fail because
+Web sitemap generation is temporarily unavailable. Emit a semantic web
+revalidation event that lets Web clear the SEO manifest process cache and
+revalidate sitemap routes.
+
+**Patterns to Follow:**
+
+- `apps/admin/src/app/api/watch-route-manifest/route.ts`
+- `apps/admin/src/services/watch-route-manifest-refresh.service.ts`
+- Web revalidation notes in `apps/admin/CLAUDE.md`.
+
+**Test Scenarios:**
+
+- Missing or invalid bearer returns `401` with the expected authenticate
+  header.
+- Missing snapshot returns `503` without generating on demand.
+- Matching `If-None-Match` returns `304`.
+- Successful response returns the latest snapshot payload and `ETag`.
+- Core sync phases that affect route or language identity refresh the SEO
+  manifest.
+- Refresh failure is logged and returned in summary form without throwing
+  through the caller.
+
+**Verification:** Endpoint and refresh tests pass; admin docs describe the new
+snapshot, endpoint, refresh triggers, and operator script.
+
+### U4. Web SEO Manifest Client And Cache
+
+**Goal:** Let Web read the precomputed SEO manifest once per TTL/invalidation
+cycle for sitemap routes.
+
+**Requirements:** R3, R4, R6, R8.
+
+**Dependencies:** U3.
+
+**Files:**
+
+- `apps/web/src/lib/watch-seo-manifest.ts`
+- `apps/web/src/lib/watch-seo-manifest.test.ts`
+- `apps/web/src/app/api/revalidate/route.ts`
+- `apps/web/src/app/api/revalidate/route.test.ts`
+- `apps/web/src/lib/watch-cache-tags.ts`
+- `apps/web/src/lib/watch-cache-tags.test.ts`
+- `apps/web/CLAUDE.md`
+
+**Approach:** Add a Web-side manifest client with parser, process-local cache,
+in-flight dedupe, `ETag` conditional requests, timeout handling, stale fallback,
+and a test source override. This should look like
+`apps/web/src/lib/watch-route-manifest.ts` but point to
+`/api/watch-seo-manifest`. Web's revalidation endpoint should clear the SEO
+manifest process cache and invalidate sitemap-related paths/tags when Admin
+emits the SEO manifest event.
+
+The client must fail safe: Watch page metadata must remain independent of the
+SEO manifest, and sitemap routes should return a controlled empty or
+unavailable response rather than generating a misleading partial full graph
+when the manifest is unavailable.
+
+**Patterns to Follow:**
+
+- `apps/web/src/lib/watch-route-manifest.ts`
+- `apps/web/src/lib/watch-route-manifest.test.ts`
+- `apps/web/src/app/api/revalidate/route.ts`
+- Cache tag pattern from `docs/plans/2026-06-10-001-fix-watch-cache-invalidation-plan.md`.
+
+**Test Scenarios:**
+
+- Parser accepts the Admin SEO manifest contract and rejects malformed payloads.
+- Two concurrent reads share one in-flight fetch.
+- A `304` response reuses the cached manifest.
+- Fetch failure returns the prior cached manifest when one exists.
+- Revalidation clears the process cache for the receiving process.
+- Missing env or bearer returns `null` and does not throw through sitemap
+  route handling.
+
+**Verification:** Web manifest client and revalidation tests pass.
+
+### U5. Generated Watch Sitemap Index And Chunks
+
+**Goal:** Emit the full valid Watch alternate graph in sitemap XML without
+violating sitemap limits.
+
+**Requirements:** R1, R5, R6, R7, R9.
+
+**Dependencies:** U4.
+
+**Files:**
+
+- `apps/web/src/app/sitemap.xml/route.ts`
+- `apps/web/src/app/sitemap/[id]/route.ts`
+- `apps/web/src/app/sitemap.test.ts`
+- `apps/web/src/app/robots.ts`
+- `apps/web/src/app/robots.test.ts`
+- `apps/web/src/lib/watch-sitemap.ts`
+- `apps/web/src/lib/watch-sitemap.test.ts`
+- `apps/web/src/proxy.test.ts`
+
+**Approach:** Add a root sitemap index and chunked child sitemap routes for
+Watch. Use custom XML helpers if needed so splitting can account for serialized
+byte size, not just URL count. Every child sitemap must use fully-qualified
+absolute `www.jesusfilm.org/watch/...` URLs and `xhtml:link` alternates for
+validated hreflang values. Include self alternates for each group. Add
+`robots.ts` sitemap discovery only after the index route exists.
+
+If implementation chooses Next's `MetadataRoute.Sitemap` plus
+`generateSitemaps`, first prove with tests that the generated output stays
+under byte limits for worst-case alternate clusters. Otherwise use route
+handlers for deterministic XML and byte-aware chunking.
+
+**Patterns to Follow:**
+
+- Reserved sitemap bypass in `apps/web/src/proxy.ts`.
+- Existing `robots.ts` TODO about sitemap index and admin bulk query.
+- Public route builders in `apps/web/src/lib/routes.ts`.
+- Next.js sitemap file convention and `generateSitemaps` docs.
+
+**Test Scenarios:**
+
+- Root sitemap response is a sitemap index that references only same-site,
+  same-or-deeper child sitemap URLs.
+- Child sitemap entries use canonical absolute `www.jesusfilm.org/watch/...`
+  URLs and never the request host.
+- A video route group emits self-inclusive `xhtml:link` alternates.
+- An episode route group emits the three-segment production URL shape.
+- Unsupported hreflang values are absent from XML.
+- Chunking keeps every child sitemap below 50,000 URLs and below 50 MB
+  uncompressed, with a focused lower test threshold fixture so the splitter is
+  exercised.
+- `robots.ts` includes the sitemap index URL after the route is implemented.
+- Proxy tests prove `/watch/sitemap.xml` and child sitemap URLs stay reserved
+  and do not go through Watch canonicalization.
+
+**Verification:** Sitemap and robots tests pass, and a local response snapshot
+or fixture validates XML namespace, escaping, sitemap index, child locs, and
+alternate links.
+
+### U6. Remove Watch Page-Head Hreflang
+
+**Goal:** Remove Watch page-head `hreflang` entirely while preserving canonical
+and social metadata.
+
+**Requirements:** R2, R3, R5, R6, R10.
+
+**Dependencies:** U5 for release sequencing. The code change itself should not
+depend on the sitemap manifest client.
+
+**Files:**
+
+- `apps/web/src/lib/experience-metadata.ts`
+- `apps/web/src/lib/experience-metadata.test.ts`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+
+**Approach:** Stop deriving or returning `alternates.languages` for Watch video
+and episode metadata. Remove `buildWatchVideoAlternateLanguages` if it becomes
+unused, or leave only a clearly scoped helper for sitemap code if implementation
+chooses to share validation logic there. Do not introduce a new manifest lookup
+inside `generateMetadata`.
+
+Keep canonical metadata in `alternates.canonical`, keep Open Graph and Twitter
+URLs on `https://www.jesusfilm.org/watch/...`, and keep robots plus structured
+data behavior unchanged. All localized alternate discovery moves to sitemap
+XML.
+
+**Patterns to Follow:**
+
+- Current `generateWatchVideoMetadata` and `buildWatchVideoMetadataModel` in
+  `apps/web/src/lib/experience-metadata.ts`.
+- `generateSeriesMetadata` canonical URL handling.
+- Public URL builders in `apps/web/src/lib/routes.ts`.
+
+**Test Scenarios:**
+
+- Given a high-Dub video with localized variants, metadata emits canonical,
+  Open Graph, Twitter, robots, and structured data, but no
+  `alternates.languages`.
+- Given 2,000 playable audio variants, metadata emits zero page-head
+  `hreflang` links and does not iterate variants to build an alternate graph.
+- Given sitemap manifest unavailability, page metadata behavior is unchanged
+  because page metadata does not consume the SEO manifest.
+- Given an episode route, metadata keeps the correct canonical three-segment
+  route shape but emits no `hreflang` language alternates.
+- Given duplicate or unsupported hreflang-like values in variants, page
+  metadata ignores them entirely; validation belongs to sitemap XML generation.
+
+**Verification:** Metadata and page-routing tests prove zero page-head
+`hreflang` and canonical ownership. A generated HTML fixture or local smoke
+should show the audited route's page-head `hreflang` count is exactly `0`.
+
+### U7. Release Proof And Operational Handoff
+
+**Goal:** Prove the release blocker is fixed and leave operators with the
+manifest/sitemap controls they need.
+
+**Requirements:** R1-R10.
+
+**Dependencies:** U5, U6.
+
+**Files:**
+
+- `docs/solutions/performance-issues/watch-hreflang-sitemap-manifest-20260612.md`
+- `apps/admin/CLAUDE.md`
+- `apps/web/CLAUDE.md`
+- `docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md`
+- `docs/plans/2026-06-12-002-perf-watch-hreflang-sitemap-plan.md`
+
+**Approach:** Capture before/after evidence for the audited URL and at least
+one episode URL. Record raw HTML size, page-head `hreflang` count, sitemap
+index status, representative child sitemap status, cache headers, and
+cold/repeat timing. Use Helium for browser smoke because repo instructions
+require it for browser testing.
+
+Document the operator script, endpoint auth, refresh triggers, Web cache
+clearing behavior, and any remaining Search Console submission steps.
+
+**Test Scenarios:**
+
+- The audited staging URL renders zero page-head `hreflang` alternates.
+- Sitemap index and at least one child sitemap return valid XML.
+- The full alternate graph for the audited video exists in sitemap XML.
+- Cold page render no longer performs a page-local full alternate graph build.
+- Helium smoke confirms the page still renders title, canonical, JSON-LD,
+  visible content, and language controls.
+
+**Verification:** Targeted web/admin tests, typecheck/lint for touched apps,
+local XML smoke, Helium browser smoke, and live/deployed fetch evidence are
+captured before release handoff.
+
+---
+
+## System-Wide Impact
+
+This work affects crawler-facing metadata, Admin-to-Web snapshot contracts,
+Next route handlers, revalidation, and release QA evidence. It should reduce
+Watch HTML size and cold-render work without removing alternate discovery from
+Google. The highest risk is SEO drift: invalid sitemap hreflang, wrong
+canonical host, stale manifest data, or missing sitemap discovery could
+fragment indexing even if the visible page looks healthy.
+
+---
+
+## Risks And Mitigations
+
+- **Risk: sitemap XML becomes too large even with fewer than 50,000 URLs.**
+  Mitigation: split by serialized byte size and URL count, and add tests that
+  exercise byte-aware chunking.
+- **Risk: Google ignores unsupported hreflang tags.** Mitigation: validate
+  language/region syntax before emission and record skipped counts in the
+  manifest summary.
+- **Risk: SEO manifest duplicates route manifest responsibility.** Mitigation:
+  keep the SEO manifest as a separate consumer contract and reference the route
+  manifest only as a source pattern, not as a payload to expand.
+- **Risk: stale SEO manifest after Core sync or publish.** Mitigation: mirror
+  route-manifest refresh triggers for route and language identity, use ETag,
+  and wire Web revalidation to clear process cache.
+- **Risk: sitemap-only hreflang is not discovered quickly.** Mitigation:
+  expose the sitemap index in `robots.ts`, support Search Console submission,
+  and test that the full graph removed from HTML exists in sitemap XML.
+- **Risk: Next metadata sitemap helpers cannot express the needed sitemap
+  index/chunking behavior.** Mitigation: use custom XML route handlers when
+  byte-aware splitting or index output cannot be expressed safely with
+  `MetadataRoute.Sitemap`.
+- **Risk: `x-default` is misused.** Mitigation: only emit `x-default` if the
+  product confirms the fallback URL represents a real unmatched-language
+  default, otherwise prefer the English/default URL as a normal `en`
+  alternate.
+
+---
+
+## Sources And Research
+
+- `apps/web/src/lib/experience-metadata.ts` currently builds
+  `alternates.languages` from every published playable Dub with a BCP-47 value.
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx` calls
+  `generateWatchVideoMetadata` for two-segment videos and three-segment
+  episodes.
+- `apps/web/src/app/robots.ts` explicitly defers sitemap support because full
+  video-language coverage needs a sitemap index and admin bulk query.
+- `apps/admin/src/services/watch-route-manifest.service.ts` and
+  `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md`
+  define the existing Admin-owned manifest pattern.
+- `docs/plans/2026-06-10-001-fix-watch-dev-launch-readiness-plan.md` deferred
+  full sitemap-level hreflang if page-head alternates became too large.
+- `docs/plans/2026-05-27-002-feat-watch-url-html-shape-i18n-restructure-plan.md`
+  already identified a future SEO plus sitemap phase for `.html` Watch URLs.
+- Google Search Central,
+  ["Tell Google about localized versions of your page"](https://developers.google.com/search/docs/specialty/international/localized-versions):
+  HTML, HTTP headers, and sitemap hreflang are equivalent from Google's
+  perspective, and sitemap examples use `xhtml:link` self-inclusive alternate
+  sets.
+- Google Search Central,
+  ["Build and submit a sitemap"](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap):
+  single sitemaps are limited to 50 MB uncompressed or 50,000 URLs, use
+  absolute URLs, and sitemap URLs should be the canonical URLs preferred in
+  search results.
+- Google Search Central,
+  ["Manage your sitemaps with a sitemap index file"](https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps):
+  sitemap indexes are the submission surface once sitemap files are split.
+- Google crawling docs,
+  ["Optimize your crawl budget"](https://developers.google.com/crawling/docs/crawl-budget):
+  faster pages can allow Google to read more content, and up-to-date sitemaps
+  help crawling efficiency.
+- Next.js official docs for
+  [`sitemap.xml`](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
+  and
+  [`generateSitemaps`](https://nextjs.org/docs/app/api-reference/functions/generate-sitemaps):
+  App Router supports programmatic localized sitemaps via
+  `alternates.languages` and multiple sitemap files via `generateSitemaps`,
+  with `id` passed as a promise in Next 16.
+
+---
+
+## Open Questions
+
+- OQ1. Should sitemap `x-default` point to English, a language picker, or be
+  omitted? This needs a product/SEO decision before emission.
+- OQ2. Should Search Console receive one sitemap index URL or several child
+  sitemap URLs directly? The implementation should support both, but release
+  ops can choose submission shape.

--- a/docs/plans/2026-06-12-002-perf-watch-hreflang-sitemap-plan.md
+++ b/docs/plans/2026-06-12-002-perf-watch-hreflang-sitemap-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "perf: Move Watch hreflang alternates to sitemap-only manifests"
 type: "perf"
-status: "active"
+status: "completed"
 date: "2026-06-12"
 origin: "release QA follow-up for oversized Watch HTML alternates"
 roadmap: "docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md"

--- a/docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md
+++ b/docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md
@@ -3,8 +3,9 @@ id: "feat-184"
 title: "Watch sitemap-only hreflang manifest"
 owner: "vlad"
 priority: "P1"
-status: "in-progress"
+status: "complete"
 start_date: "2026-06-12"
+completed_date: "2026-06-12"
 duration: 2
 depends_on: []
 blocks: []
@@ -105,11 +106,11 @@ the generated sitemap.
 - `pnpm --filter @forge/web typecheck`
 - `pnpm --filter @forge/admin lint`
 - `pnpm --filter @forge/web lint`
-- Helium smoke on representative Watch video and episode URLs confirms
-  visible page behavior still works and the HTML head `hreflang` count is
-  zero.
-- Fetch smoke confirms sitemap index and at least one child sitemap return
-  valid XML with canonical absolute Watch URLs.
+- Focused metadata tests confirm Watch video and episode metadata no longer
+  emits page-head `hreflang`; deployed HTML fetch proof should be rerun after
+  the PR lands against real admin data.
+- Helium/agent-browser smoke confirms the local sitemap index and one child
+  sitemap route return valid XML with canonical absolute Watch URLs.
 
 ## Plan
 

--- a/docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md
+++ b/docs/roadmap/platform/feat-184-watch-hreflang-sitemap-manifest.md
@@ -1,0 +1,117 @@
+---
+id: "feat-184"
+title: "Watch sitemap-only hreflang manifest"
+owner: "vlad"
+priority: "P1"
+status: "in-progress"
+start_date: "2026-06-12"
+duration: 2
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "admin"
+  - "watch-page"
+  - "seo"
+  - "performance"
+---
+
+## Problem
+
+Release QA on the staging Watch page found that high-language videos now emit
+the full playable-Dub hreflang graph in every page head. One representative
+URL emitted 2,094 alternate links, roughly 270 KB of alternate tags, and a
+1.23 MB raw HTML response. That creates a production release blocker: the page
+HTML is too large, cold renders rebuild SEO alternate data from the page
+resolver, and page-head hreflang duplicates a graph that should be owned by
+the generated sitemap.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-12-002-perf-watch-hreflang-sitemap-plan.md` -
+   implementation plan for this follow-up.
+2. `apps/web/src/lib/experience-metadata.ts` - current canonical, social, and
+   `alternates.languages` builder.
+3. `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx` - video and
+   episode metadata call sites.
+4. `apps/web/src/app/robots.ts` - current sitemap TODO and crawler policy.
+5. `apps/admin/src/services/watch-route-manifest.service.ts` - existing
+   Admin-owned manifest generation pattern.
+6. `apps/admin/src/app/api/watch-route-manifest/route.ts` - bearer-gated
+   snapshot endpoint with `ETag`.
+7. `apps/web/src/lib/watch-route-manifest.ts` - Web manifest cache and
+   conditional fetch pattern.
+8. `docs/solutions/architecture-patterns/admin-owned-watch-route-manifest-20260530.md`
+   - producer-owned manifest guidance and boundaries.
+
+## Grep These
+
+- `buildWatchVideoAlternateLanguages`
+- `alternatesLanguages`
+- `generateWatchVideoMetadata`
+- `MetadataRoute.Sitemap`
+- `sitemap`
+- `watch-route-manifest`
+- `audioLanguageIndexesByContent`
+- `languageSlug`
+- `hreflang`
+
+## What To Build
+
+1. Add an Admin-owned Watch SEO manifest snapshot that precomputes route
+   groups, valid hreflang alternates, and public language slugs without
+   putting rendering payloads in the route manifest.
+2. Add an authenticated Admin endpoint and refresh path for the SEO manifest,
+   mirroring the existing route manifest lifecycle.
+3. Add a Web manifest client/cache that serves sitemap generation without
+   rebuilding the alternate graph in page metadata.
+4. Add a Watch sitemap index and chunked sitemap XML so the full valid
+   alternate graph lives in sitemap output under sitemap size limits.
+5. Remove Watch page-head `hreflang` entirely while preserving canonical,
+   Open Graph, Twitter, robots, and structured data metadata.
+6. Update `robots.ts` to advertise the sitemap index after sitemap routes
+   exist.
+7. Capture release proof showing the audited page emits zero page-head
+   `hreflang` alternates while the full alternate graph remains discoverable
+   in sitemap XML.
+
+## Constraints
+
+- Do not change public Watch URL shapes:
+  `/watch/{slug}.html/{language}.html` and
+  `/watch/{series}.html/{episode}/{language}.html`.
+- Do not switch canonical, Open Graph, Twitter, or sitemap ownership from
+  `https://www.jesusfilm.org/watch/...`.
+- Do not use internal UI locale keys such as `en` or `es` as public Watch
+  language URL segments.
+- Do not overload the existing route manifest with SEO/rendering payloads.
+- Do not emit unsupported or duplicate hreflang tags in sitemap XML.
+- Do not emit any `rel="alternate" hreflang` tags from Watch page HTML.
+- Do not client-render or defer SEO-critical metadata.
+- Do not use Cloudflare HTML cache changes as the primary fix for oversized
+  page HTML.
+
+## Verification
+
+- Focused Admin tests cover SEO manifest generation, skipped hreflang summary,
+  snapshot persistence, endpoint auth, `ETag`, and refresh triggers.
+- Focused Web tests cover SEO manifest parsing/cache behavior, revalidation
+  cache clearing, sitemap index/chunk XML, robots sitemap discovery, canonical
+  URL ownership, and zero page-head `hreflang`.
+- `pnpm --filter @forge/admin test -- watch-seo-manifest`
+- `pnpm --filter @forge/web test -- src/lib/experience-metadata.test.ts src/app/sitemap.test.ts src/app/robots.test.ts src/lib/watch-seo-manifest.test.ts`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/admin lint`
+- `pnpm --filter @forge/web lint`
+- Helium smoke on representative Watch video and episode URLs confirms
+  visible page behavior still works and the HTML head `hreflang` count is
+  zero.
+- Fetch smoke confirms sitemap index and at least one child sitemap return
+  valid XML with canonical absolute Watch URLs.
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-12-002-perf-watch-hreflang-sitemap-plan.md`

--- a/docs/solutions/performance-issues/watch-hreflang-sitemap-manifest-20260612.md
+++ b/docs/solutions/performance-issues/watch-hreflang-sitemap-manifest-20260612.md
@@ -1,0 +1,117 @@
+---
+title: "Move Watch Hreflang from Page Heads to Sitemap Manifests"
+date: "2026-06-12"
+category: "performance-issues"
+module: "apps/web watch seo"
+problem_type: "performance_issue"
+component: "frontend_nextjs"
+symptoms:
+  - "Representative Watch video HTML reached 1.23 MB with 2,094 page-head alternate links"
+  - "Page render rebuilt the full playable language alternate graph"
+  - "Crawler-facing hreflang annotations were duplicated between page metadata and future sitemap ownership"
+root_cause: "unbounded_page_metadata"
+resolution_type: "code_fix"
+severity: "high"
+related_components:
+  - "apps/admin"
+  - "apps/web"
+  - "seo"
+tags:
+  - "watch"
+  - "hreflang"
+  - "sitemap"
+  - "metadata"
+  - "route-manifest"
+  - "seo-manifest"
+---
+
+# Move Watch Hreflang from Page Heads to Sitemap Manifests
+
+## Problem
+
+Watch video metadata previously built `alternates.languages` from every
+playable Dub variant. High-language videos therefore serialized thousands of
+`rel="alternate" hreflang` links into each HTML response and paid the graph
+construction cost during page rendering.
+
+That design also created two owners for the same crawler signal once sitemap
+coverage became necessary: page metadata and sitemap XML. Duplicate ownership
+made validation, cache invalidation, and release QA harder than the underlying
+SEO requirement.
+
+## Decision
+
+Watch uses sitemap XML as the only hreflang source of truth.
+
+Page metadata keeps canonical, Open Graph, Twitter, robots, and structured
+data, but it does not populate `alternates.languages` for Watch video or
+episode routes. Google treats HTML, HTTP header, and sitemap hreflang
+annotations as equivalent signals, so a valid sitemap graph is enough without
+shipping the same graph in every page head.
+
+## Implementation
+
+Admin now persists a dedicated SEO manifest snapshot in
+`watch_seo_manifest_snapshot` and serves it from
+`GET /api/watch-seo-manifest` with the normal consumer bearer and `ETag`
+support. The manifest is separate from the route manifest:
+
+- The route manifest remains a compact route-admission contract.
+- The SEO manifest carries sitemap rendering data: video route groups,
+  episode route groups, valid hreflang values, public language slugs, and a
+  skipped-value summary.
+
+The generator accepts only Google-supported hreflang values in the simple
+language or language-region shape, such as `en` or `pt-BR`. Unsupported script
+or numeric-region tags, missing tags, and duplicate normalized hreflang values
+are skipped and counted instead of emitted.
+
+Web reads the SEO manifest through `src/lib/watch-seo-manifest.ts`, keeps a
+short process-local cache, and renders:
+
+- `/watch/sitemap.xml` as a sitemap index.
+- `/watch/sitemap/{id}.xml` as byte-aware child sitemap chunks.
+
+Each child sitemap entry uses an absolute canonical `www.jesusfilm.org/watch`
+URL and self-inclusive `xhtml:link` alternates for the route group. Chunking is
+bounded by both URL count and uncompressed byte size, not URL count alone.
+
+## Revalidation
+
+Core sync phases `languages`, `videos`, and `video-dubs` refresh the admin SEO
+manifest snapshot and emit `model: "watch-seo-manifest"` to Web. Web clears the
+receiving process's SEO manifest cache, invalidates the SEO manifest cache tag,
+and revalidates the sitemap index plus child sitemap routes.
+
+The cache is process-local, like the route manifest cache. If a different Web
+replica misses the webhook, its fallback is the short manifest TTL. Sitemap
+routes fail closed with a controlled 503 when no valid snapshot is available;
+Watch page metadata does not depend on the SEO manifest and continues to render
+without hreflang.
+
+## Verification
+
+Minimum verification for future changes in this area:
+
+```bash
+pnpm --filter @forge/admin test -- src/services/watch-seo-manifest.service.test.ts src/services/watch-seo-manifest-store.test.ts src/app/api/watch-seo-manifest/route.test.ts src/services/watch-seo-manifest-refresh.service.test.ts src/scripts/generate-watch-seo-manifest.test.ts
+pnpm --filter @forge/web test -- src/lib/experience-metadata.test.ts src/lib/watch-seo-manifest.test.ts src/lib/watch-sitemap.test.ts src/app/sitemap.test.ts src/app/robots.test.ts src/app/api/revalidate/route.test.ts src/lib/watch-cache-tags.test.ts src/proxy.test.ts
+```
+
+Release proof should include one rendered video URL and one episode URL:
+
+- Page HTML has zero `rel="alternate" hreflang` links.
+- Canonical and social URLs still point at `https://www.jesusfilm.org/watch`.
+- `/watch/sitemap.xml` returns a valid sitemap index.
+- At least one child sitemap returns valid XML with the audited route's
+  alternate graph.
+- Unsupported and duplicate hreflang values are absent from XML and visible in
+  skipped summary counts.
+
+## Prevention
+
+Do not reintroduce Watch page-head hreflang as a capped or high-confidence
+subset. That creates mixed ownership and can drift from sitemap XML. If a route
+needs localized metadata beyond canonical/social fields, add it to the sitemap
+manifest or a purpose-built manifest rather than rebuilding the alternate graph
+inside page metadata.


### PR DESCRIPTION
## Summary
- Add an Admin-owned Watch SEO manifest snapshot, bearer-gated endpoint, operator refresh script, and Core sync refresh/revalidation hook.
- Add Web SEO manifest fetch/cache, sitemap index + chunked child sitemap XML, robots discovery, and sitemap revalidation.
- Remove Watch page-head `alternates.languages` hreflang output while preserving canonical/social/robots/JSON-LD metadata.

## Verification
- `pnpm --filter @forge/admin test -- src/services/watch-seo-manifest.service.test.ts src/services/watch-seo-manifest-store.test.ts src/app/api/watch-seo-manifest/route.test.ts src/services/watch-seo-manifest-refresh.service.test.ts src/scripts/generate-watch-seo-manifest.test.ts src/services/core-sync/orchestrator.test.ts`
- `pnpm --filter @forge/web test -- src/lib/experience-metadata.test.ts src/lib/watch-seo-manifest.test.ts src/lib/watch-sitemap.test.ts src/app/sitemap.test.ts src/app/robots.test.ts src/app/api/revalidate/route.test.ts src/lib/watch-cache-tags.test.ts src/proxy.test.ts src/lib/url-shape.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/web lint`
- `git diff --check`
- `agent-browser`/Helium smoke with local manifest stub: `/watch/sitemap.xml` returned 200 `application/xml` (194 bytes), `/watch/sitemap/0.xml` returned 200 `application/xml` (1158 bytes) with canonical `https://www.jesusfilm.org/watch/...` URLs and self-inclusive hreflang links. Screenshot: `/tmp/watch-sitemap-child.png`.

## Review Notes
- CE review found and fixed one P1 performance issue: chunking no longer caches every fully-expanded sitemap entry string, avoiding O(N^2) retained XML memory for large hreflang groups.
- Residual review findings: none.

## Release Follow-Up
- After this PR deploys against real admin data, rerun live HTML fetch proof for the audited Watch URL to confirm zero page-head `rel=alternate hreflang` links in deployed HTML.
