### PR TITLE
fix(web): harden watch seo manifest fetch

### DIFF
--- a/apps/web/src/lib/watch-seo-manifest.test.ts
+++ b/apps/web/src/lib/watch-seo-manifest.test.ts
@@ -84,6 +84,8 @@ describe("getWatchSeoManifest", () => {
   it("fetches through the admin SEO manifest endpoint with the first consumer bearer", async () => {
     process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
     process.env.WEB_ADMIN_API_KEYS = "key-one,key-two"
+    const signal = new AbortController().signal
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(signal)
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(manifest), {
         status: 200,
@@ -92,15 +94,21 @@ describe("getWatchSeoManifest", () => {
     )
     vi.stubGlobal("fetch", fetchMock)
 
-    await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+    try {
+      await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://admin.test/api/watch-seo-manifest",
-      expect.objectContaining({
-        headers: { Authorization: "Bearer key-one" },
-        cache: "no-store",
-      }),
-    )
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://admin.test/api/watch-seo-manifest",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer key-one" },
+          cache: "no-store",
+          signal,
+        }),
+      )
+      expect(timeoutSpy).toHaveBeenCalledWith(10_000)
+    } finally {
+      timeoutSpy.mockRestore()
+    }
   })
 
   it("reuses the cached manifest on 304 and failed refreshes", async () => {
@@ -126,6 +134,32 @@ describe("getWatchSeoManifest", () => {
       await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
       now += 61_000
       await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+    } finally {
+      dateSpy.mockRestore()
+    }
+  })
+
+  it("retries initial fetch failures after a short miss TTL", async () => {
+    process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "key-one"
+    let now = 1_000
+    const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => now)
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(manifest), {
+          status: 200,
+          headers: { etag: '"version-1"' },
+        }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    try {
+      await expect(getWatchSeoManifest()).resolves.toBeNull()
+      now += 6_000
+      await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
     } finally {
       dateSpy.mockRestore()
     }

--- a/apps/web/src/lib/watch-seo-manifest.ts
+++ b/apps/web/src/lib/watch-seo-manifest.ts
@@ -32,7 +32,8 @@ type WatchSeoManifestCache = {
 export type WatchSeoManifestSource = () => Promise<WatchSeoManifest | null>
 
 const WATCH_SEO_MANIFEST_CACHE_TTL_MS = 60_000
-const WATCH_SEO_MANIFEST_TIMEOUT_MS = 3_000
+const WATCH_SEO_MANIFEST_MISS_CACHE_TTL_MS = 5_000
+const WATCH_SEO_MANIFEST_TIMEOUT_MS = 10_000
 
 let manifestCache: WatchSeoManifestCache = {
   etag: null,
@@ -224,7 +225,11 @@ export async function getWatchSeoManifest(): Promise<WatchSeoManifest | null> {
 
   manifestCache.inFlight = fetchWatchSeoManifest().then((manifest) => {
     manifestCache.manifest = manifest
-    manifestCache.expiresAt = Date.now() + WATCH_SEO_MANIFEST_CACHE_TTL_MS
+    manifestCache.expiresAt =
+      Date.now() +
+      (manifest
+        ? WATCH_SEO_MANIFEST_CACHE_TTL_MS
+        : WATCH_SEO_MANIFEST_MISS_CACHE_TTL_MS)
     manifestCache.inFlight = null
     return manifest
   })

--- a/docs/plans/2026-06-12-003-fix-watch-seo-manifest-fetch-hardening-plan.md
+++ b/docs/plans/2026-06-12-003-fix-watch-seo-manifest-fetch-hardening-plan.md
@@ -1,0 +1,80 @@
+---
+title: "fix: Harden Watch SEO manifest fetch misses"
+type: "fix"
+status: "completed"
+date: "2026-06-12"
+origin: "production validation follow-up after Watch sitemap-only hreflang launch"
+roadmap: "docs/roadmap/platform/feat-185-watch-seo-manifest-fetch-hardening.md"
+---
+
+# fix: Harden Watch SEO Manifest Fetch Misses
+
+## Summary
+
+Raise the Web timeout for cold Watch SEO manifest fetches and avoid caching an
+initial failed fetch as a full-length miss. The sitemap routes should still use
+the Admin-owned SEO manifest snapshot, keep serving a stale manifest after
+refresh failures when one exists, and return a controlled 503 only when Web has
+no valid manifest available.
+
+## Problem Frame
+
+Production seeding proved the persisted Watch SEO manifest is healthy, but the
+first Web request after cache revalidation can cold-fetch roughly 3.9 MB from
+Admin. One cold Admin response took slightly longer than the current 3 second
+Web fetch timeout. When that first request times out, `getWatchSeoManifest`
+caches `null` for the same 60 second TTL used for successful manifests, turning
+a transient cold-fetch miss into a minute-long sitemap outage window.
+
+## Requirements
+
+- R1. Increase the Watch SEO manifest fetch timeout enough to cover observed
+  cold Admin responses with margin.
+- R2. Preserve the existing successful-manifest cache TTL and stale reuse
+  behavior on refresh failures.
+- R3. Cache only initial `null` misses for a short retry TTL so sitemap routes
+  can recover quickly after transient cold-fetch failures.
+- R4. Keep the Admin endpoint, bearer selection, ETag behavior, and sitemap
+  route contract unchanged.
+- R5. Add focused tests for the fetch timeout and initial-miss retry behavior.
+
+## Implementation Units
+
+### Unit 1: Web SEO Manifest Client Hardening
+
+Files:
+
+- `apps/web/src/lib/watch-seo-manifest.ts`
+- `apps/web/src/lib/watch-seo-manifest.test.ts`
+
+Approach:
+
+- Change `WATCH_SEO_MANIFEST_TIMEOUT_MS` from 3 seconds to 10 seconds.
+- Add a separate short miss cache TTL used only when no manifest was fetched.
+- Keep the 60 second TTL for successful manifests and for stale manifest reuse.
+- Assert the configured abort signal reaches `fetch`.
+
+Test Scenarios:
+
+- `getWatchSeoManifest` calls `AbortSignal.timeout` with the longer timeout
+  and passes that signal to the Admin fetch.
+- A first fetch error returns `null`, expires after the short miss TTL, and the
+  next call refetches successfully.
+- Existing 304 and failed-refresh behavior continues to reuse the cached stale
+  manifest.
+
+## Risks And Boundaries
+
+- Do not change the sitemap XML shape, manifest schema, Admin generation script,
+  or revalidation payload model.
+- A longer timeout can hold one sitemap request open longer during Admin
+  slowness, but avoids the larger operational risk of caching an avoidable
+  initial miss for 60 seconds.
+- This patch does not change production Railway env vars; those were handled
+  operationally before this follow-up.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/lib/watch-seo-manifest.test.ts src/app/sitemap.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`

--- a/docs/roadmap/platform/feat-185-watch-seo-manifest-fetch-hardening.md
+++ b/docs/roadmap/platform/feat-185-watch-seo-manifest-fetch-hardening.md
@@ -1,0 +1,45 @@
+---
+id: "feat-185"
+title: "Watch SEO Manifest Fetch Hardening"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-12"
+completed_date: "2026-06-12"
+duration: 1
+depends_on:
+  - "feat-184"
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "seo"
+  - "revalidation"
+---
+
+## Problem
+
+Production validation after `feat-184` seeded the first Watch SEO manifest
+snapshot showed the sitemap routes can briefly return 503 after web cache
+revalidation. Web clears its process-local manifest cache, performs a cold
+fetch from Admin, and aborts after 3 seconds. The current production manifest
+payload is about 3.9 MB and one cold Admin response took roughly 3.3 seconds,
+so the timeout margin is too small. The failed first fetch is then cached as
+`null` for 60 seconds, extending a transient cold-fetch miss into a visible
+sitemap outage window.
+
+## What To Build
+
+- Increase the Web Watch SEO manifest fetch timeout so cold Admin responses
+  have enough headroom.
+- Keep serving stale manifests on refresh failures when Web already has one.
+- Do not cache an initial `null` manifest for the full success TTL; retry after
+  a short miss TTL instead.
+- Add focused Web tests for the timeout and initial-miss cache behavior.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/lib/watch-seo-manifest.test.ts src/app/sitemap.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`


### PR DESCRIPTION
## Summary
- raise the Watch SEO manifest fetch timeout from 3s to 10s so cold Admin snapshot reads have margin
- cache initial null/miss results for 5s instead of the full 60s success TTL
- keep stale manifest reuse, ETag behavior, bearer selection, and sitemap route contracts unchanged
- add a CE plan and roadmap ticket for the follow-up hardening work

## Validation
- pnpm --filter @forge/web test -- src/lib/watch-seo-manifest.test.ts src/app/sitemap.test.ts
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- git diff --check

## Context
Production validation after the Watch sitemap-only hreflang launch showed that web cache revalidation could clear the process-local SEO manifest cache, then the next cold sitemap request could time out fetching the roughly 3.9 MB Admin snapshot. Before this patch, that initial null result was cached for 60s. This narrows the visible outage window while keeping successful manifest cache behavior stable.