### PR TITLE
fix(web): preserve collection context in chapter routing

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
@@ -368,6 +368,38 @@ function makeEpisodeResult(
   }
 }
 
+const pilatePageChapterSlugs = [
+  "triumphal-entry",
+  "jesus-cleanses-the-temple",
+  "jesus-teaches-in-the-temple",
+  "judas-agrees-to-betray-jesus",
+  "the-last-supper",
+  "jesus-prays-in-gethsemane",
+  "jesus-is-arrested",
+  "jesus-before-caiaphas",
+  "peter-denies-jesus",
+  "jesus-is-condemned-by-the-council",
+  "judas-hangs-himself",
+  "jesus-is-brought-to-pilate",
+  "jesus-is-brought-before-herod",
+  "jesus-is-sentenced",
+  "jesus-is-scourged-and-mocked",
+  "jesus-is-brought-to-pilate-again",
+  "jesus-sentenced-to-be-crucified",
+  "jesus-carries-his-cross",
+  "jesus-is-nailed-to-the-cross",
+  "jesus-is-crucified",
+  "jesus-dies-on-the-cross",
+  "jesus-is-buried",
+  "the-tomb-is-guarded",
+  "the-tomb-is-empty",
+  "jesus-appears-to-mary",
+  "resurrected-jesus-appears",
+  "jesus-appears-to-his-disciples",
+  "jesus-commissions-his-followers",
+  "invitation-to-know-jesus-personally",
+]
+
 function internalLocaleParams(rawLocale?: string) {
   return resolveWatchLocaleIdentity(
     rawLocale ? stripHtmlSuffix(rawLocale) : null,
@@ -1234,6 +1266,79 @@ describe("Catch-all routing — 3-seg episode branch", () => {
       "wedding-in-cana",
       "english",
     )
+  })
+
+  it("keeps the requested parent collection for multi-parent chapter routes", async () => {
+    const result = makeEpisodeResult() as unknown as {
+      video: Record<string, unknown>
+      canonicalParent: Record<string, unknown>
+      series: Record<string, unknown>
+    }
+    const anticipateChildren = pilatePageChapterSlugs.map((slug, index) => ({
+      documentId: `pilate-chapter-${index + 1}`,
+      slug,
+      title: `Pilate chapter ${index + 1}`,
+      label: "clip",
+      images: [],
+      durationSeconds: null,
+      muxPlaybackId: null,
+    }))
+    const anticipateParent = {
+      documentId: "anticipate-parent",
+      slug: "anticipate-the-resurrection",
+      title: "Anticipate the Resurrection",
+      label: "collection",
+      images: [],
+      children: anticipateChildren,
+    }
+    result.video.documentId = "pilate-chapter-20"
+    result.video.slug = "jesus-is-crucified"
+    result.video.title = "Jesus is Crucified"
+    result.video.parents = [
+      {
+        documentId: "jesus-parent",
+        slug: "jesus",
+        title: "JESUS",
+        label: "collection",
+        images: [],
+        children: [],
+      },
+      anticipateParent,
+    ]
+    result.canonicalParent = anticipateParent
+    result.series = anticipateParent
+
+    resolveSeriesEpisodeBySlugMock.mockResolvedValue(result)
+
+    await render3Seg(
+      "anticipate-the-resurrection",
+      "jesus-is-crucified",
+      "english",
+    )
+
+    expect(resolveSeriesEpisodeBySlugMock).toHaveBeenCalledWith(
+      "anticipate-the-resurrection",
+      "jesus-is-crucified",
+      "english",
+    )
+    const props = watchPageClientMock.mock.calls[0]?.[0] as {
+      mergedBlocks?: Array<{
+        kind?: string
+        canonicalParent?: {
+          slug?: string | null
+          title?: string | null
+          children?: unknown[]
+        }
+        currentVideoDocumentId?: string
+      }>
+    }
+    const carousel = props.mergedBlocks?.find(
+      (block) => block.kind === "SiblingCarousel",
+    )
+    expect(carousel?.canonicalParent?.slug).toBe("anticipate-the-resurrection")
+    expect(carousel?.canonicalParent?.title).toBe("Anticipate the Resurrection")
+    expect(carousel?.canonicalParent?.children).toHaveLength(29)
+    expect(carousel?.currentVideoDocumentId).toBe("pilate-chapter-20")
   })
 
   it("passes the LaunchDarkly CTA copy label to WatchPageClient when enabled", async () => {

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -16,7 +16,12 @@ import {
 } from "@/components/ui/carousel"
 import { cn } from "@/lib/utils"
 import type { WatchSiblingCarouselBlock } from "@/lib/content"
-import { tryAsContentSlug, tryAsLocaleSlug, watchVideoPath } from "@/lib/routes"
+import {
+  tryAsContentSlug,
+  tryAsLocaleSlug,
+  watchEpisodePath,
+  watchVideoPath,
+} from "@/lib/routes"
 import { resolveMuxFrameThumbnailUrl, resolvePosterUrl } from "@/lib/url"
 import type { WatchChapterNavigationIntent } from "./chapter-navigation"
 
@@ -50,6 +55,10 @@ export function SiblingCarousel({
   )
   const clipTotal = children.length
   const parentTitle = canonicalParent.title ?? videoLabels("collection")
+  const parentSlug =
+    typeof canonicalParent.slug === "string"
+      ? tryAsContentSlug(canonicalParent.slug)
+      : null
 
   // All carousel thumbnails ship with `loading="lazy"`. Native browser
   // lazy-loading still fetches above-fold images immediately — it only
@@ -185,11 +194,14 @@ export function SiblingCarousel({
             const thumb =
               resolveMuxFrameThumbnailUrl(child.muxPlaybackId) ??
               resolvePosterUrl(child.images?.[0])
-            // The builder emits the canonical 2-segment `.html` shape
-            // (`/{slug}.html/{languageSlug}.html`).
             const slug = tryAsContentSlug(child.slug)
             const lang = tryAsLocaleSlug(languageSlug)
-            const href = slug && lang ? watchVideoPath(slug, lang) : undefined
+            const href =
+              slug && lang
+                ? parentSlug
+                  ? watchEpisodePath(parentSlug, slug, lang)
+                  : watchVideoPath(slug, lang)
+                : undefined
             const isPending =
               validPendingNavigation != null &&
               validPendingNavigation.href === href &&

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -65,6 +65,7 @@ import {
   WATCH_BASE_PATH,
   tryAsContentSlug,
   tryAsLocaleSlug,
+  watchEpisodePath,
   watchVideoPath,
 } from "@/lib/routes"
 import { buildFbShareUrl } from "@/lib/share"
@@ -123,6 +124,10 @@ function isPendingChapterStillRoutable(
     if (!isWatchBlock(block) || block.kind !== "SiblingCarousel") continue
 
     const carouselBlock: WatchSiblingCarouselBlock = block
+    const parentSlug =
+      typeof carouselBlock.canonicalParent.slug === "string"
+        ? tryAsContentSlug(carouselBlock.canonicalParent.slug)
+        : null
     for (const child of carouselBlock.canonicalParent.children ?? []) {
       if (
         child == null ||
@@ -134,7 +139,10 @@ function isPendingChapterStillRoutable(
       if (typeof child.slug !== "string") return false
       const slug = tryAsContentSlug(child.slug)
       if (!slug) return false
-      return watchVideoPath(slug, lang) === pendingChapter.href
+      const href = parentSlug
+        ? watchEpisodePath(parentSlug, slug, lang)
+        : watchVideoPath(slug, lang)
+      return href === pendingChapter.href
     }
   }
 

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -180,6 +180,38 @@ function makeBlock(
   }
 }
 
+const pilatePageChapterSlugs = [
+  "triumphal-entry",
+  "jesus-cleanses-the-temple",
+  "jesus-teaches-in-the-temple",
+  "judas-agrees-to-betray-jesus",
+  "the-last-supper",
+  "jesus-prays-in-gethsemane",
+  "jesus-is-arrested",
+  "jesus-before-caiaphas",
+  "peter-denies-jesus",
+  "jesus-is-condemned-by-the-council",
+  "judas-hangs-himself",
+  "jesus-is-brought-to-pilate",
+  "jesus-is-brought-before-herod",
+  "jesus-is-sentenced",
+  "jesus-is-scourged-and-mocked",
+  "jesus-is-brought-to-pilate-again",
+  "jesus-sentenced-to-be-crucified",
+  "jesus-carries-his-cross",
+  "jesus-is-nailed-to-the-cross",
+  "jesus-is-crucified",
+  "jesus-dies-on-the-cross",
+  "jesus-is-buried",
+  "the-tomb-is-guarded",
+  "the-tomb-is-empty",
+  "jesus-appears-to-mary",
+  "resurrected-jesus-appears",
+  "jesus-appears-to-his-disciples",
+  "jesus-commissions-his-followers",
+  "invitation-to-know-jesus-personally",
+]
+
 describe("SiblingCarousel — happy path", () => {
   it("renders one thumbnail per child with the current item highlighted", () => {
     const block = makeBlock(10, 2)
@@ -246,10 +278,11 @@ describe("SiblingCarousel — happy path", () => {
     expect(active!.className).not.toContain("after:border-4")
     expect(active!.className).toContain("focus-visible:outline-white/80")
     expect(active!.className).toContain("shadow-[0_2px_6px_rgba")
-    // Canonical 2-segment `.html` shape `/{slug}.html/{locale}.html`,
-    // emitted by the `watchVideoPath` builder.
+    // Contextual 3-segment `.html` shape
+    // `/{parent}.html/{slug}/{locale}.html`, emitted by the
+    // `watchEpisodePath` builder.
     expect(active!.getAttribute("data-href")).toBe(
-      "/child-3-slug.html/english.html",
+      "/jesus-collection.html/child-3-slug/english.html",
     )
     const caption = active!.querySelector(
       "[data-testid='sibling-carousel-caption']",
@@ -307,9 +340,10 @@ describe("SiblingCarousel — happy path", () => {
     expect(desktopLabel?.textContent).toBe("Clip 3 of 10")
   })
 
-  it("routes a child through watchVideoPath to the canonical `.html` 2-segment shape", () => {
-    // Builder contract: slug `magdalena` + locale `english` →
-    // `/magdalena.html/english.html` (no manual encodeURIComponent, no cast).
+  it("routes a child through watchEpisodePath to preserve collection context", () => {
+    // Builder contract: parent `jesus-collection` + slug `magdalena` +
+    // locale `english` → `/jesus-collection.html/magdalena/english.html`
+    // (no manual encodeURIComponent, no cast).
     const block: WatchSiblingCarouselBlock = {
       kind: "SiblingCarousel",
       canonicalParent: {
@@ -333,9 +367,76 @@ describe("SiblingCarousel — happy path", () => {
     )
     expect(active!.tagName).toBe("A")
     expect(active!.getAttribute("data-href")).toBe(
-      "/magdalena.html/english.html",
+      "/jesus-collection.html/magdalena/english.html",
     )
-    expect(active!.getAttribute("href")).toBe("/magdalena.html/english.html")
+    expect(active!.getAttribute("href")).toBe(
+      "/jesus-collection.html/magdalena/english.html",
+    )
+  })
+
+  it("falls back to the standalone watch path without a usable parent slug", () => {
+    const block = makeBlock(3, 0, "")
+
+    act(() => {
+      root.render(<SiblingCarousel block={block} languageSlug="english" />)
+    })
+
+    const active = container.querySelector(
+      "[data-testid='sibling-carousel-item'][data-active='true']",
+    )
+    expect(active!.tagName).toBe("A")
+    expect(active!.getAttribute("data-href")).toBe(
+      "/child-1-slug.html/english.html",
+    )
+    expect(active!.getAttribute("href")).toBe("/child-1-slug.html/english.html")
+  })
+
+  it("preserves the Anticipate collection segment for all 29 Pilate page chapters", () => {
+    const children = pilatePageChapterSlugs.map((slug, index) => ({
+      ...makeChild(index + 1),
+      documentId: `pilate-chapter-${index + 1}`,
+      slug,
+      title: `Pilate chapter ${index + 1}`,
+    }))
+    const block: WatchSiblingCarouselBlock = {
+      kind: "SiblingCarousel",
+      canonicalParent: {
+        documentId: "anticipate-parent",
+        slug: "anticipate-the-resurrection",
+        title: "Anticipate the Resurrection",
+        children,
+      } as never,
+      currentVideoDocumentId: "pilate-chapter-12",
+    }
+
+    act(() => {
+      root.render(<SiblingCarousel block={block} languageSlug="english" />)
+    })
+
+    const hrefs = Array.from(
+      container.querySelectorAll("[data-testid='sibling-carousel-item']"),
+      (item) => item.getAttribute("data-href"),
+    )
+    expect(hrefs).toHaveLength(29)
+    expect(hrefs).toEqual(
+      pilatePageChapterSlugs.map(
+        (slug) => `/anticipate-the-resurrection.html/${slug}/english.html`,
+      ),
+    )
+    expect(hrefs).toContain(
+      "/anticipate-the-resurrection.html/jesus-is-crucified/english.html",
+    )
+    expect(hrefs).toContain(
+      "/anticipate-the-resurrection.html/resurrected-jesus-appears/english.html",
+    )
+    expect(hrefs).toContain(
+      "/anticipate-the-resurrection.html/invitation-to-know-jesus-personally/english.html",
+    )
+    expect(hrefs).not.toContain("/jesus-is-crucified.html/english.html")
+    expect(hrefs).not.toContain("/resurrected-jesus-appears.html/english.html")
+    expect(hrefs).not.toContain(
+      "/invitation-to-know-jesus-personally.html/english.html",
+    )
   })
 
   it("makes the clicked chapter card current while navigation is pending", () => {
@@ -346,10 +447,10 @@ describe("SiblingCarousel — happy path", () => {
     })
 
     const target = container.querySelector(
-      "[data-testid='sibling-carousel-item'][data-href='/child-2-slug.html/english.html']",
+      "[data-testid='sibling-carousel-item'][data-href='/jesus-collection.html/child-2-slug/english.html']",
     )
     const previousCurrent = container.querySelector(
-      "[data-testid='sibling-carousel-item'][data-href='/child-1-slug.html/english.html']",
+      "[data-testid='sibling-carousel-item'][data-href='/jesus-collection.html/child-1-slug/english.html']",
     )
 
     expect(target).not.toBeNull()
@@ -403,7 +504,7 @@ describe("SiblingCarousel — happy path", () => {
     })
 
     const target = container.querySelector(
-      "[data-testid='sibling-carousel-item'][data-href='/child-2-slug.html/english.html']",
+      "[data-testid='sibling-carousel-item'][data-href='/jesus-collection.html/child-2-slug/english.html']",
     )
 
     const event = new MouseEvent("click", {
@@ -418,7 +519,7 @@ describe("SiblingCarousel — happy path", () => {
     expect(event.defaultPrevented).toBe(true)
     expect(onChapterNavigateIntent).toHaveBeenCalledTimes(1)
     expect(onChapterNavigateIntent).toHaveBeenCalledWith({
-      href: "/child-2-slug.html/english.html",
+      href: "/jesus-collection.html/child-2-slug/english.html",
       languageSlug: "english",
       sourceVideoDocumentId: "child-1",
       targetVideoDocumentId: "child-2",
@@ -438,7 +539,7 @@ describe("SiblingCarousel — happy path", () => {
           block={block}
           languageSlug="english"
           pendingNavigation={{
-            href: "/child-3-slug.html/english.html",
+            href: "/jesus-collection.html/child-3-slug/english.html",
             languageSlug: "english",
             sourceVideoDocumentId: "child-1",
             targetVideoDocumentId: "child-3",
@@ -452,10 +553,10 @@ describe("SiblingCarousel — happy path", () => {
     })
 
     const previousCurrent = container.querySelector(
-      "[data-testid='sibling-carousel-item'][data-href='/child-1-slug.html/english.html']",
+      "[data-testid='sibling-carousel-item'][data-href='/jesus-collection.html/child-1-slug/english.html']",
     )
     const target = container.querySelector(
-      "[data-testid='sibling-carousel-item'][data-href='/child-3-slug.html/english.html']",
+      "[data-testid='sibling-carousel-item'][data-href='/jesus-collection.html/child-3-slug/english.html']",
     )
 
     expect(previousCurrent!.getAttribute("data-active")).toBe("false")
@@ -488,7 +589,7 @@ describe("SiblingCarousel — happy path", () => {
     })
 
     const target = container.querySelector(
-      "[data-testid='sibling-carousel-item'][data-href='/child-2-slug.html/english.html']",
+      "[data-testid='sibling-carousel-item'][data-href='/jesus-collection.html/child-2-slug/english.html']",
     )
 
     act(() => {
@@ -525,7 +626,7 @@ describe("SiblingCarousel — happy path", () => {
     })
 
     const current = container.querySelector(
-      "[data-testid='sibling-carousel-item'][data-href='/child-1-slug.html/english.html']",
+      "[data-testid='sibling-carousel-item'][data-href='/jesus-collection.html/child-1-slug/english.html']",
     )
 
     act(() => {
@@ -557,9 +658,11 @@ describe("SiblingCarousel — happy path", () => {
       const href = item.getAttribute("data-href") ?? ""
       // basePath auto-prepends; in-app hrefs MUST NOT include /watch/ literal.
       expect(href.startsWith("/watch/")).toBe(false)
-      // Canonical 2-segment `.html` shape — child slug then locale, no
-      // parent segment.
-      expect(href).toMatch(/^\/child-\d+-slug\.html\/english\.html$/)
+      // Contextual 3-segment `.html` shape — parent collection, child slug,
+      // then locale.
+      expect(href).toMatch(
+        /^\/jesus-collection\.html\/child-\d+-slug\/english\.html$/,
+      )
       expect(href.endsWith("/english.html")).toBe(true)
     }
   })
@@ -681,7 +784,7 @@ describe("SiblingCarousel — edge cases", () => {
     )
     expect(active).not.toBeNull()
     expect(active!.getAttribute("data-href")).toBe(
-      "/child-12-slug.html/english.html",
+      "/jesus-collection.html/child-12-slug/english.html",
     )
     const label = container.querySelector(
       "[data-testid='sibling-carousel-label']",
@@ -703,7 +806,7 @@ describe("SiblingCarousel — edge cases", () => {
       "[data-testid='sibling-carousel-item'][data-active='true']",
     )
     expect(item).not.toBeNull()
-    // Empty languageSlug fails the slug regex, so `watchVideoPath` is never built.
+    // Empty languageSlug fails the slug regex, so no watch route is built.
     // The card still renders — as a plain <div>, not an <a> — with no href.
     expect(item!.tagName).toBe("DIV")
     expect(item!.getAttribute("href")).toBeNull()

--- a/apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx
@@ -70,7 +70,7 @@ vi.mock("@/components/watch/WatchSectionRenderer", () => ({
       data-route-poster-bridge-key={routePosterBridgeKey ?? ""}
       onClick={() => {
         onChapterNavigateIntent?.({
-          href: "/child-2.html/english.html",
+          href: "/parent.html/child-2/english.html",
           languageSlug: "english",
           sourceVideoDocumentId: "video-1",
           targetVideoDocumentId: "child-2",
@@ -239,11 +239,11 @@ describe("WatchPageClient chapter navigation", () => {
     })
 
     expect(window.fetch).toHaveBeenCalledWith(
-      "/child-2.html/english.html",
+      "/parent.html/child-2/english.html",
       expect.objectContaining({ credentials: "same-origin" }),
     )
     expect(routerPrefetchMock).toHaveBeenCalledWith(
-      "/child-2.html/english.html",
+      "/parent.html/child-2/english.html",
     )
     expect(renderer()?.getAttribute("data-pending-target")).toBe("")
     expect(renderer()?.getAttribute("data-pending-title")).toBe("")
@@ -268,11 +268,18 @@ describe("WatchPageClient chapter navigation", () => {
       await Promise.resolve()
       await Promise.resolve()
     })
-    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html", {
-      scroll: false,
-    })
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/parent.html/child-2/english.html",
+      {
+        scroll: false,
+      },
+    )
 
-    window.history.replaceState({}, "", "/watch/child-2.html/english.html")
+    window.history.replaceState(
+      {},
+      "",
+      "/watch/parent.html/child-2/english.html",
+    )
     renderWatchPage(makeVideo("child-2", "Clicked Child"))
 
     expect(renderer()?.getAttribute("data-pending-target")).toBe("")
@@ -328,9 +335,12 @@ describe("WatchPageClient chapter navigation", () => {
       await Promise.resolve()
     })
 
-    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html", {
-      scroll: false,
-    })
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/parent.html/child-2/english.html",
+      {
+        scroll: false,
+      },
+    )
   })
 
   it("keeps route-change scrolling enabled for chapter clicks below the top", async () => {
@@ -343,8 +353,11 @@ describe("WatchPageClient chapter navigation", () => {
 
     await clickChapterAndFlushNavigation()
 
-    expect(routerPushMock).toHaveBeenCalledWith("/child-2.html/english.html", {
-      scroll: true,
-    })
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/parent.html/child-2/english.html",
+      {
+        scroll: true,
+      },
+    )
   })
 })

--- a/docs/plans/2026-06-12-004-fix-watch-collection-context-routing-plan.md
+++ b/docs/plans/2026-06-12-004-fix-watch-collection-context-routing-plan.md
@@ -1,0 +1,229 @@
+---
+title: "fix: Preserve Watch collection context in chapter routing"
+type: fix
+status: completed
+date: 2026-06-12
+roadmap: "docs/roadmap/media-generation/feat-054-video-pages-2-0.md"
+---
+
+# fix: Preserve Watch collection context in chapter routing
+
+## Summary
+
+Watch chapter carousel links should preserve the current collection when moving between clips. Today the carousel emits slug-only two-segment video links. For videos that belong to multiple parents, the slug-only resolver falls back to `record.parents[0]`, which can move the user out of the source collection and into another carousel context.
+
+Fix the chapter carousel to emit existing collection-aware three-segment Watch URLs whenever the current page has a valid parent collection slug. Keep direct two-segment Watch URLs working for standalone and externally shared video pages.
+
+## Problem Frame
+
+The Pilate page is in the "Anticipate the Resurrection" collection and shows a 29-clip chapter carousel. Some cards in that carousel are also members of the broader `JESUS` collection. When those cards link to `/{video}.html/{language}.html`, route resolution uses the slug-only code path and may pick the first parent rather than the collection the user came from.
+
+The bug is not that the target video fails to render. The bug is that the target render can use the wrong parent context, so the carousel title, clip count, active index, neighboring links, and navigation continuity no longer match the user's current collection.
+
+## Requirements
+
+- Chapter carousel links from a page with a valid `canonicalParent.slug` must use the existing collection-aware route shape: `/{collection}.html/{video}/{language}.html`.
+- The destination page for a multi-parent clip must retain the source collection's title, order, active index, and 29-item carousel membership.
+- Chapter carousel links must preserve the language slug, including `.html` suffix behavior such as `english.html`.
+- In-app `href` values must remain relative to the app route and must not hard-code the `/watch` base path.
+- Standalone or parentless carousel states must retain the existing safe behavior and must not produce malformed collection-aware URLs.
+- Direct slug-only video URLs must continue to resolve, including for externally shared Watch pages.
+- Modified clicks and `next/link` behavior must still work, and the optimistic pending chapter state must use the same `href` that is rendered.
+- Add a regression for the Pilate/Anticipate carousel: all 29 chapter links should preserve the collection path, with explicit coverage for multi-parent targets that currently fall back to `JESUS`.
+- Update local Watch navigation documentation so it no longer describes chapter links as always two-segment links.
+
+## Key Technical Decisions
+
+### KTD-1: Reuse the existing three-segment Watch route
+
+Use `watchEpisodePath(collectionSlug, videoSlug, languageSlug)` for context-preserving carousel links. Do not add query parameters, session-only state, or a new route shape.
+
+Rationale: the catch-all Watch route already supports collection-aware resolution, and `apps/web/src/lib/content.ts` already has logic that selects the requested parent by slug instead of falling back to `parents[0]`.
+
+### KTD-2: Keep slug-only direct URLs
+
+Do not remove or redirect two-segment video routes as part of this fix.
+
+Rationale: existing public links, SEO metadata, and direct navigation behavior depend on slug-only URLs continuing to resolve. The fix is specifically about preserving context when the app already knows the current collection.
+
+### KTD-3: Build context-aware links at the carousel boundary
+
+Construct parent-aware child hrefs in `SiblingCarousel` from `canonicalParent.slug`, child slug, and language slug.
+
+Rationale: the carousel is the component that knows both the current parent context and every child card target. Fixing the emitted href keeps route resolution, pending navigation, and browser behavior aligned around one URL.
+
+### KTD-4: Prove the bug with deterministic fixtures
+
+Use local test fixtures for the 29-link Pilate carousel regression rather than relying on live network data in unit tests.
+
+Rationale: live Watch data can drift. The regression should encode the routing invariant: all chapter links from a known collection context include that collection slug, and multi-parent children resolve through that collection.
+
+## Technical Design
+
+```mermaid
+flowchart LR
+  A["WatchPage canonicalParent.slug"] --> B["SiblingCarousel"]
+  C["Child video slug"] --> B
+  D["Language slug"] --> B
+  B --> E["watchEpisodePath(collection, child, language)"]
+  E --> F["Three-segment Watch href"]
+  F --> G["Catch-all route episode branch"]
+  G --> H["Collection-aware resolver"]
+  H --> I["mergeWatchExperience with requested parent"]
+  I --> J["Same collection carousel, order, and active index"]
+```
+
+## Implementation Units
+
+### U1: Emit parent-aware chapter hrefs
+
+Files:
+
+- `apps/web/src/components/watch/SiblingCarousel.tsx`
+- `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`
+- `apps/web/src/lib/routes.ts`
+
+Work:
+
+- Import and use the existing collection-aware route helper for child links when `canonicalParent.slug`, child slug, and language slug all validate.
+- Keep the current slug-only route builder as the fallback when a carousel has no usable parent context.
+- Preserve current `data-href`, `onClick`, modified-click, and non-link rendering behavior.
+- Update existing tests that currently assert a two-segment child route so they assert a parent-aware route for collection pages.
+- Keep a test proving in-app hrefs do not include a `/watch` base path prefix.
+
+Acceptance Checks:
+
+- A valid parent collection with child slug `jesus-is-crucified` and language `english` renders a three-segment href.
+- Missing or invalid parent context does not render a malformed three-segment href.
+- Invalid child slug or language slug still prevents clickable output as it does today.
+- `onNavigate` receives the exact rendered href.
+
+### U2: Add collection-resolution route regression
+
+Files:
+
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+- `apps/web/src/lib/__tests__/content-watch-merge.test.ts`
+- `apps/web/src/lib/content.ts`
+
+Work:
+
+- Add or extend route tests for a multi-parent child reached through a collection-aware URL.
+- Assert that the destination uses the requested parent collection instead of the child's first parent.
+- Preserve a direct two-segment test showing slug-only routes still resolve through the existing canonical-parent behavior.
+- Cover the parent-mismatch path if existing fixtures make that cheap to express.
+
+Acceptance Checks:
+
+- Rendering `anticipate-the-resurrection.html/jesus-is-crucified/english.html` selects the "Anticipate the Resurrection" parent context.
+- Rendering `jesus-is-crucified.html/english.html` still exercises the slug-only direct URL behavior.
+- Route metadata and page rendering remain compatible with the existing `.html` route shape.
+
+### U3: Add the 29-link Pilate carousel regression
+
+Files:
+
+- `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+
+Work:
+
+- Add a deterministic Pilate/Anticipate fixture with 29 carousel children.
+- Assert every child href contains the current collection segment.
+- Include explicit multi-parent samples for links that previously drifted into the `JESUS` collection.
+- Assert active index and neighboring chapter labels stay sourced from the 29-item collection after route resolution.
+
+Acceptance Checks:
+
+- All 29 fixture links are collection-aware.
+- Representative multi-parent targets preserve the 29-item collection context.
+- The test fails if a child card regresses to a slug-only href.
+
+### U4: Keep optimistic navigation behavior aligned
+
+Files:
+
+- `apps/web/src/components/watch/WatchPageClient.tsx`
+- `apps/web/src/components/watch/SiblingCarousel.tsx`
+- `apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx`
+- `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`
+
+Work:
+
+- Verify pending chapter state and any route-poster bridge use the rendered href, not a recomputed slug-only URL.
+- Update tests only where expectations depend on the old two-segment link shape.
+- Avoid changing the current scroll or transition behavior.
+
+Acceptance Checks:
+
+- A normal chapter click records the parent-aware href as the pending target.
+- Modified clicks still avoid client-side pending state.
+- Existing active-card and disabled-card behavior remains unchanged.
+
+### U5: Documentation and browser proof
+
+Files:
+
+- `docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md`
+- `docs/roadmap/media-generation/feat-054-video-pages-2-0.md`
+
+Work:
+
+- Update the Watch chapter navigation solution note to describe collection-aware carousel links.
+- Keep the roadmap feature status unchanged unless implementation discovers a separate follow-up that needs a new ticket.
+- Run targeted automated tests for the touched Watch route and carousel files.
+- Run Helium browser smoke against the Pilate page after implementation.
+
+Acceptance Checks:
+
+- Documentation no longer says chapter cards always emit two-segment canonical links.
+- Browser smoke confirms the Pilate page's 29 chapter links include the collection route segment.
+- Browser smoke confirms multi-parent targets remain in "Anticipate the Resurrection" rather than switching to `JESUS`.
+
+## Validation Plan
+
+- `pnpm --filter web test -- apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx`
+- `pnpm --filter web test -- apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx`
+- `pnpm --filter web test -- apps/web/src/components/watch/__tests__/WatchPageClient.navigation.test.tsx`
+- `pnpm --filter web lint`
+- `pnpm --filter web typecheck`
+- Helium smoke on the local Watch page for Pilate, including multi-parent chapter links.
+
+## Scope Boundaries
+
+In scope:
+
+- Watch chapter carousel href construction.
+- Watch collection-aware route regression coverage.
+- Optimistic chapter navigation expectations tied to the rendered href.
+- Local documentation for chapter navigation behavior.
+
+Out of scope:
+
+- Reworking the Watch URL taxonomy.
+- Changing public slug-only direct URL behavior.
+- Changing canonical SEO URL policy for Watch pages.
+- Fixing unrelated QA claims such as quote copy, share domain, capitalization, or cold route latency.
+- Changing admin content ordering or parent assignment data.
+
+## Risks and Mitigations
+
+- Risk: A parent-aware href could accidentally include the deployed `/watch` base path in an in-app link.
+  Mitigation: Keep the existing no-basePath test and assert the new three-segment href shape.
+
+- Risk: Parentless or synthetic carousel data could generate broken URLs.
+  Mitigation: Validate parent, child, and language slugs before building collection-aware hrefs, and keep the existing fallback path for parentless contexts.
+
+- Risk: Tests could overfit to live production content that changes.
+  Mitigation: Encode the Pilate 29-link matrix as a deterministic local fixture focused on route invariants.
+
+- Risk: Context-aware carousel links may expose metadata or canonical-url differences on three-segment pages.
+  Mitigation: Preserve existing metadata tests for three-segment pages and avoid changing direct URL canonicalization in this fix.
+
+## Research Notes
+
+- `apps/web/src/components/watch/SiblingCarousel.tsx` currently builds child hrefs with slug-only `watchVideoPath`.
+- `apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx` currently asserts that child routes use the two-segment `.html` shape.
+- `apps/web/src/lib/content.ts` has both collection-aware and slug-only Watch resolvers; slug-only resolution falls back to the first parent.
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx` already routes three-segment Watch pages through collection-aware episode resolution.
+- `docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md` documents the current optimistic navigation behavior and needs to reflect the new href shape.

--- a/docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md
+++ b/docs/solutions/design-patterns/watch-chapter-optimistic-navigation-feedback.md
@@ -35,9 +35,9 @@ applies_when:
 Watch chapter cards are ordinary `next/link` navigations to another public
 watch route. On slow route resolution, the old page can remain visible long
 enough that a user wonders whether their click registered. The browser did not
-need a different URL contract; the page needed an immediate local
-acknowledgment using data already present in the carousel: target href, target
-title, and target thumbnail.
+need a new URL contract; the page needed an immediate local acknowledgment
+using data already present in the carousel: parent collection slug, target
+href, target title, and target thumbnail.
 
 The fix lives in `apps/web/src/components/watch/SiblingCarousel.tsx` and keeps
 the carousel server-data model unchanged. A normal click makes the clicked
@@ -50,13 +50,27 @@ card while the next route is still loading.
 Keep the chapter card as a `Link`. Do not replace it with imperative
 `router.push()` or a raw `<a>` just to get immediate feedback. The route
 builder in `apps/web/src/lib/routes.ts` still owns the canonical public watch
-href shape and base-path behavior:
+href shape and base-path behavior. In a collection carousel, preserve the
+current parent collection with the existing three-segment contextual route;
+fall back to the standalone video route only when no valid parent slug is
+available:
 
 ```tsx
+const parentSlug = tryAsContentSlug(canonicalParent.slug)
 const slug = tryAsContentSlug(child.slug)
 const lang = tryAsLocaleSlug(languageSlug)
-const href = slug && lang ? watchVideoPath(slug, lang) : undefined
+const href =
+  slug && lang
+    ? parentSlug
+      ? watchEpisodePath(parentSlug, slug, lang)
+      : watchVideoPath(slug, lang)
+    : undefined
 ```
+
+This distinction matters for multi-parent clips. A slug-only chapter href can
+resolve through a different parent, changing the carousel order and active
+index after navigation. The contextual href keeps chapter progression inside
+the collection the user is already browsing.
 
 Capture only normal left-click navigations. Modified clicks must keep browser
 semantics, and active-card clicks should not create a fake pending state:
@@ -190,6 +204,9 @@ Focused coverage belongs in
 - The clicked card exposes `aria-busy="true"` and the loading icon.
 - The clip label follows the clicked card while navigation is pending.
 - Modified clicks do not set pending feedback.
+- Collection carousels emit contextual hrefs such as
+  `/anticipate-the-resurrection.html/jesus-is-crucified/english.html`, not
+  slug-only child hrefs.
 
 Run:
 


### PR DESCRIPTION
## Summary

Chapter clicks from the Pilate page now stay inside the collection the user is already browsing instead of falling back to a slug-only route that can resolve under a different parent. Collection-backed chapter cards emit the existing three-segment Watch route, while parentless or standalone cases keep the two-segment fallback.

The pending chapter navigation path now validates against that same rendered href, so route warming, delayed push, poster bridging, and the active carousel treatment all agree on the contextual destination. The regression coverage includes a 29-link Anticipate/Pilate fixture plus a route-level multi-parent case for `jesus-is-crucified`.

## Verification

- `pnpm --filter @forge/web test -- src/components/watch/__tests__/SiblingCarousel.test.tsx 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx' src/components/watch/__tests__/WatchPageClient.navigation.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `agent-browser` local smoke on `http://localhost:3010/watch/jesus-is-brought-to-pilate.html/english.html`: verified “Anticipate the Resurrection · Clip 16 of 29”, all 29 carousel `data-href` values use `/anticipate-the-resurrection.html/.../english.html`, and clicking `Jesus is Crucified` lands on `/watch/anticipate-the-resurrection.html/jesus-is-crucified/english.html` with “Anticipate the Resurrection · Clip 20 of 29”.

## Post-Deploy Monitoring & Validation

- Window: first production deploy plus 24 hours; owner: Forge Watch/web owner.
- Validate the Pilate page and multi-parent chapter targets in production, especially `jesus-is-crucified`, `resurrected-jesus-appears`, and `invitation-to-know-jesus-personally`.
- Healthy signals: chapter anchors include the current collection segment, destination carousel label remains `Anticipate the Resurrection · Clip N of 29`, and route responses stay 200.
- Failure signals: contextual chapter links return 404/500, `PARENT_NOT_FOUND` or `VIDEO_NOT_FOUND` spikes for Watch routes, or a multi-parent click lands in the `JESUS · Clip N of 61` carousel.
- Rollback trigger: revert this PR if production contextual chapter links break or preserve the wrong collection after deploy.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
