### PR TITLE
feat(web): add Watch availability incident tracking

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-metadata.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  resolveWatchVideoBySlugMock,
+  resolveSeriesBySlugMock,
+  resolveSeriesEpisodeBySlugMock,
+  resolveWatchPageMock,
+} = vi.hoisted(() => ({
+  resolveWatchVideoBySlugMock: vi.fn(),
+  resolveSeriesBySlugMock: vi.fn(),
+  resolveSeriesEpisodeBySlugMock: vi.fn(),
+  resolveWatchPageMock: vi.fn(),
+}))
+
+vi.mock("@/lib/admin-client", () => ({
+  default: { query: vi.fn() },
+}))
+
+vi.mock("@/lib/content", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/content")>("@/lib/content")
+  return {
+    ...actual,
+    resolveWatchVideoBySlug: resolveWatchVideoBySlugMock,
+    resolveSeriesBySlug: resolveSeriesBySlugMock,
+    resolveSeriesEpisodeBySlug: resolveSeriesEpisodeBySlugMock,
+    resolveWatchPage: resolveWatchPageMock,
+  }
+})
+
+vi.mock("@/lib/watch-home", () => ({
+  resolveWatchHome: vi.fn(),
+}))
+
+vi.mock("@/lib/watch-transcript", () => ({
+  getInitialSubtitleTranscript: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+  redirect: vi.fn(),
+}))
+
+vi.mock("@/components/watch/SeriesPageClient", () => ({
+  SeriesPageClient: vi.fn(),
+}))
+
+vi.mock("@/components/watch/WatchPageClient", () => ({
+  WatchPageClient: vi.fn(),
+}))
+
+vi.mock("@/components/home/WatchHomePage", () => ({
+  WatchHomePage: vi.fn(),
+}))
+
+vi.mock("@/components/watch/WatchQuestionPanel", () => ({
+  WatchQuestionPanel: vi.fn(),
+}))
+
+vi.mock("@/components/ExperienceEmpty", () => ({
+  ExperienceEmpty: vi.fn(),
+}))
+
+vi.mock("@/components/ExperienceError", () => ({
+  ExperienceError: vi.fn(),
+}))
+
+vi.mock("@/components/sections", () => ({
+  ExperienceSectionRenderer: vi.fn(),
+}))
+
+vi.mock("@/lib/feature-flags", () => ({
+  isWatchCtaTextCopyEnabled: vi.fn(),
+  isWatchYouVersionBibleQuotesEnabled: vi.fn(),
+  isWatchHideBibleQuotesEnabled: vi.fn(),
+  isWatchQuestionPanelEnabled: vi.fn(),
+}))
+
+vi.mock("@/lib/youversion-passage", () => ({
+  fetchYouVersionBibleQuotePassages: vi.fn(),
+}))
+
+import { generateMetadata } from "@/app/[locale]/[htmlLang]/[...rest]/page"
+
+beforeEach(() => {
+  resolveWatchVideoBySlugMock.mockReset()
+  resolveSeriesBySlugMock.mockReset()
+  resolveSeriesEpisodeBySlugMock.mockReset()
+  resolveWatchPageMock.mockReset()
+  resolveWatchPageMock.mockResolvedValue({
+    data: null,
+    error: new Error("No experience found"),
+  })
+})
+
+describe("Watch metadata fallback observability", () => {
+  it("logs video metadata resolver fallbacks in the Watch event format", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    resolveWatchVideoBySlugMock.mockRejectedValue(
+      new Error("Apollo resolver failed"),
+    )
+
+    try {
+      const metadata = await generateMetadata({
+        params: Promise.resolve({
+          locale: "en",
+          htmlLang: "en",
+          rest: ["storyclubs.html", "english.html"],
+        }),
+      })
+
+      expect(metadata.alternates?.canonical).toBe(
+        "https://www.jesusfilm.org/watch/storyclubs.html/english.html",
+      )
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[watch] event=watch_metadata.video.fallback slug=storyclubs rawLocale=english detail=Apollo_resolver_failed",
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it("logs episode metadata resolver fallbacks in the Watch event format", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    resolveSeriesEpisodeBySlugMock.mockRejectedValue(
+      new Error("episode timeout"),
+    )
+
+    try {
+      const metadata = await generateMetadata({
+        params: Promise.resolve({
+          locale: "en",
+          htmlLang: "en",
+          rest: [
+            "lumo-the-gospel-of-john.html",
+            "wedding-in-cana",
+            "english.html",
+          ],
+        }),
+      })
+
+      expect(metadata.alternates?.canonical).toBe(
+        "https://www.jesusfilm.org/watch/wedding-in-cana.html/english.html",
+      )
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[watch] event=watch_metadata.episode.fallback seriesSlug=lumo-the-gospel-of-john episodeSlug=wedding-in-cana rawLocale=english detail=episode_timeout",
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -54,6 +54,7 @@ import {
   stripHtmlSuffix,
 } from "@/lib/url-shape"
 import { watchVideoStructuredDataJson } from "@/lib/watch-structured-data"
+import { logWatchServerEvent } from "@/lib/watch-observability"
 import { getInitialSubtitleTranscript } from "@/lib/watch-transcript"
 import { fetchYouVersionBibleQuotePassages } from "@/lib/youversion-passage"
 
@@ -282,7 +283,12 @@ export async function generateMetadata({
           pathLocale: rawLocale,
         })
       }
-    } catch {
+    } catch (error) {
+      logWatchServerEvent("watch_metadata.video.fallback", {
+        slug,
+        rawLocale,
+        detail: error instanceof Error ? error : String(error),
+      })
       // Fall through to getWatchPageMetadata.
     }
     return getWatchPageMetadata(locale, {
@@ -310,7 +316,13 @@ export async function generateMetadata({
           seriesSlug,
         })
       }
-    } catch {
+    } catch (error) {
+      logWatchServerEvent("watch_metadata.episode.fallback", {
+        seriesSlug,
+        episodeSlug,
+        rawLocale,
+        detail: error instanceof Error ? error : String(error),
+      })
       // Fall through to the safe template metadata path.
     }
     return getWatchPageMetadata(locale, {

--- a/apps/web/src/lib/watch-observability.test.ts
+++ b/apps/web/src/lib/watch-observability.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  formatWatchServerLogLine,
+  logWatchServerEvent,
+} from "./watch-observability"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("formatWatchServerLogLine", () => {
+  it("emits a deterministic Watch event line with key-value fields", () => {
+    expect(
+      formatWatchServerLogLine("watch_route_manifest.fetch.failed", {
+        status: 503,
+        url: "https://admin.test/api/watch-route-manifest",
+      }),
+    ).toBe(
+      "[watch] event=watch_route_manifest.fetch.failed status=503 url=https://admin.test/api/watch-route-manifest",
+    )
+  })
+
+  it("sanitizes whitespace and skips empty values", () => {
+    expect(
+      formatWatchServerLogLine(" watch bad event ", {
+        detail: "Apollo error\nwith spaces",
+        empty: "",
+        missing: undefined,
+      }),
+    ).toBe("[watch] event=watch_bad_event detail=Apollo_error_with_spaces")
+  })
+
+  it("bounds long values", () => {
+    const detail = "x".repeat(600)
+
+    const line = formatWatchServerLogLine("watch.long", { detail })
+
+    expect(line).toHaveLength("[watch] event=watch.long detail=".length + 500)
+    expect(line.endsWith("...")).toBe(true)
+  })
+})
+
+describe("logWatchServerEvent", () => {
+  it("logs warnings by default", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    logWatchServerEvent("watch_route_manifest.fetch.failed", { status: 503 })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[watch] event=watch_route_manifest.fetch.failed status=503",
+    )
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it("can log errors when requested", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    logWatchServerEvent(
+      "watch_metadata.video.fallback",
+      { detail: new Error("metadata failed") },
+      { level: "error" },
+    )
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[watch] event=watch_metadata.video.fallback detail=metadata_failed",
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/watch-observability.ts
+++ b/apps/web/src/lib/watch-observability.ts
@@ -1,0 +1,62 @@
+type WatchServerLogLevel = "warn" | "error"
+
+type WatchServerLogFieldValue =
+  | string
+  | number
+  | boolean
+  | Error
+  | null
+  | undefined
+
+type WatchServerLogFields = Record<string, WatchServerLogFieldValue>
+
+const MAX_LOG_VALUE_LENGTH = 500
+
+function sanitizeToken(value: string, fallback: string): string {
+  const sanitized = value.trim().replace(/[^A-Za-z0-9_.:-]+/g, "_")
+  return sanitized || fallback
+}
+
+function sanitizeFieldValue(value: WatchServerLogFieldValue): string | null {
+  if (value === null || value === undefined) return null
+
+  const rawValue = value instanceof Error ? value.message : String(value)
+  const normalized = rawValue.trim().replace(/\s+/g, "_")
+  if (!normalized) return null
+
+  const sanitized = normalized.replace(/["'\\]+/g, "_")
+  return sanitized.length > MAX_LOG_VALUE_LENGTH
+    ? `${sanitized.slice(0, MAX_LOG_VALUE_LENGTH - 3)}...`
+    : sanitized
+}
+
+export function formatWatchServerLogLine(
+  event: string,
+  fields: WatchServerLogFields = {},
+): string {
+  const parts = [`[watch] event=${sanitizeToken(event, "unknown")}`]
+
+  for (const [key, value] of Object.entries(fields)) {
+    const sanitizedValue = sanitizeFieldValue(value)
+    if (sanitizedValue === null) continue
+
+    parts.push(`${sanitizeToken(key, "field")}=${sanitizedValue}`)
+  }
+
+  return parts.join(" ")
+}
+
+export function logWatchServerEvent(
+  event: string,
+  fields: WatchServerLogFields = {},
+  options: { level?: WatchServerLogLevel } = {},
+): void {
+  const line = formatWatchServerLogLine(event, fields)
+
+  if (options.level === "error") {
+    console.error(line)
+    return
+  }
+
+  console.warn(line)
+}

--- a/apps/web/src/lib/watch-route-manifest.test.ts
+++ b/apps/web/src/lib/watch-route-manifest.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
+  clearWatchRouteManifestCache,
+  getWatchRouteManifest,
   isWatchRouteAdmittedByManifest,
   parseWatchRouteManifest,
   type WatchRouteManifest,
@@ -25,6 +27,16 @@ const manifest: WatchRouteManifest = {
     },
   },
 }
+
+const originalEnv = { ...process.env }
+
+afterEach(() => {
+  process.env.ADMIN_GRAPHQL_URL = originalEnv.ADMIN_GRAPHQL_URL
+  process.env.WEB_ADMIN_API_KEYS = originalEnv.WEB_ADMIN_API_KEYS
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  clearWatchRouteManifestCache()
+})
 
 describe("parseWatchRouteManifest", () => {
   it("accepts the admin manifest contract", () => {
@@ -56,6 +68,55 @@ describe("parseWatchRouteManifest", () => {
         audioLanguageIndexesByEpisode: { jesus: { "the-beginning": [null] } },
       }),
     ).toBeNull()
+  })
+})
+
+describe("getWatchRouteManifest", () => {
+  it("logs a Datadog-visible breadcrumb when the admin manifest fetch fails", async () => {
+    process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "key-one"
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("nope", { status: 503 })),
+    )
+
+    await expect(getWatchRouteManifest()).resolves.toBeNull()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[watch] event=watch_route_manifest.fetch.failed status=503 url=https://admin.test/api/watch-route-manifest",
+    )
+  })
+
+  it("logs a Datadog-visible breadcrumb when the admin manifest fetch throws", async () => {
+    process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "key-one"
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout now")))
+
+    await expect(getWatchRouteManifest()).resolves.toBeNull()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[watch] event=watch_route_manifest.fetch.error detail=timeout_now url=https://admin.test/api/watch-route-manifest",
+    )
+  })
+
+  it("logs a Datadog-visible breadcrumb when the admin manifest payload is invalid", async () => {
+    process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "key-one"
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
+    )
+
+    await expect(getWatchRouteManifest()).resolves.toBeNull()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[watch] event=watch_route_manifest.fetch.invalid_payload url=https://admin.test/api/watch-route-manifest",
+    )
   })
 })
 

--- a/apps/web/src/lib/watch-route-manifest.ts
+++ b/apps/web/src/lib/watch-route-manifest.ts
@@ -1,3 +1,5 @@
+import { logWatchServerEvent } from "./watch-observability"
+
 export type WatchRouteManifest = {
   version: string
   generatedAt: string
@@ -328,35 +330,26 @@ async function fetchWatchRouteManifest(): Promise<WatchRouteManifest | null> {
       return manifestCache.manifest
     }
     if (!response.ok) {
-      console.warn(
-        JSON.stringify({
-          event: "watch_route_manifest.fetch.failed",
-          status: response.status,
-        }),
-      )
+      logWatchServerEvent("watch_route_manifest.fetch.failed", {
+        status: response.status,
+        url,
+      })
       return manifestCache.manifest
     }
 
     const parsed = parseWatchRouteManifest(await response.json())
     if (!parsed) {
-      console.warn(
-        JSON.stringify({
-          event: "watch_route_manifest.fetch.invalid_payload",
-        }),
-      )
+      logWatchServerEvent("watch_route_manifest.fetch.invalid_payload", { url })
       return manifestCache.manifest
     }
 
     manifestCache.etag = response.headers.get("etag")
     return parsed
   } catch (error) {
-    console.warn(
-      JSON.stringify({
-        event: "watch_route_manifest.fetch.error",
-        detail:
-          error instanceof Error ? error.message.slice(0, 500) : String(error),
-      }),
-    )
+    logWatchServerEvent("watch_route_manifest.fetch.error", {
+      detail: error instanceof Error ? error : String(error),
+      url,
+    })
     return manifestCache.manifest
   }
 }

--- a/apps/web/src/lib/watch-seo-manifest.test.ts
+++ b/apps/web/src/lib/watch-seo-manifest.test.ts
@@ -36,6 +36,7 @@ afterEach(() => {
   process.env.ADMIN_GRAPHQL_URL = originalEnv.ADMIN_GRAPHQL_URL
   process.env.WEB_ADMIN_API_KEYS = originalEnv.WEB_ADMIN_API_KEYS
   vi.unstubAllGlobals()
+  vi.restoreAllMocks()
   clearWatchSeoManifestCache()
 })
 
@@ -116,6 +117,7 @@ describe("getWatchSeoManifest", () => {
     process.env.WEB_ADMIN_API_KEYS = "key-one"
     let now = 1_000
     const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => now)
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -134,6 +136,9 @@ describe("getWatchSeoManifest", () => {
       await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
       now += 61_000
       await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[watch] event=watch_seo_manifest.fetch.failed status=503 url=https://admin.test/api/watch-seo-manifest",
+      )
     } finally {
       dateSpy.mockRestore()
     }
@@ -144,6 +149,7 @@ describe("getWatchSeoManifest", () => {
     process.env.WEB_ADMIN_API_KEYS = "key-one"
     let now = 1_000
     const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => now)
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(new Error("timeout"))
@@ -160,8 +166,29 @@ describe("getWatchSeoManifest", () => {
       now += 6_000
       await expect(getWatchSeoManifest()).resolves.toEqual(manifest)
       expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[watch] event=watch_seo_manifest.fetch.error detail=timeout url=https://admin.test/api/watch-seo-manifest",
+      )
     } finally {
       dateSpy.mockRestore()
     }
+  })
+
+  it("logs invalid payloads in the Watch event format", async () => {
+    process.env.ADMIN_GRAPHQL_URL = "https://admin.test/api/graphql"
+    process.env.WEB_ADMIN_API_KEYS = "key-one"
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
+    )
+
+    await expect(getWatchSeoManifest()).resolves.toBeNull()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[watch] event=watch_seo_manifest.fetch.invalid_payload url=https://admin.test/api/watch-seo-manifest",
+    )
   })
 })

--- a/apps/web/src/lib/watch-seo-manifest.ts
+++ b/apps/web/src/lib/watch-seo-manifest.ts
@@ -1,3 +1,5 @@
+import { logWatchServerEvent } from "./watch-observability"
+
 export type WatchSeoManifestAlternate = {
   hreflang: string
   languageSlug: string
@@ -183,35 +185,26 @@ async function fetchWatchSeoManifest(): Promise<WatchSeoManifest | null> {
       return manifestCache.manifest
     }
     if (!response.ok) {
-      console.warn(
-        JSON.stringify({
-          event: "watch_seo_manifest.fetch.failed",
-          status: response.status,
-        }),
-      )
+      logWatchServerEvent("watch_seo_manifest.fetch.failed", {
+        status: response.status,
+        url,
+      })
       return manifestCache.manifest
     }
 
     const parsed = parseWatchSeoManifest(await response.json())
     if (!parsed) {
-      console.warn(
-        JSON.stringify({
-          event: "watch_seo_manifest.fetch.invalid_payload",
-        }),
-      )
+      logWatchServerEvent("watch_seo_manifest.fetch.invalid_payload", { url })
       return manifestCache.manifest
     }
 
     manifestCache.etag = response.headers.get("etag")
     return parsed
   } catch (error) {
-    console.warn(
-      JSON.stringify({
-        event: "watch_seo_manifest.fetch.error",
-        detail:
-          error instanceof Error ? error.message.slice(0, 500) : String(error),
-      }),
-    )
+    logWatchServerEvent("watch_seo_manifest.fetch.error", {
+      detail: error instanceof Error ? error : String(error),
+      url,
+    })
     return manifestCache.manifest
   }
 }

--- a/docs/brainstorms/2026-06-12-watch-datadog-availability-incidents-requirements.md
+++ b/docs/brainstorms/2026-06-12-watch-datadog-availability-incidents-requirements.md
@@ -1,0 +1,174 @@
+---
+date: "2026-06-12"
+topic: "watch-datadog-availability-incidents"
+title: "Watch Datadog Availability Incidents"
+tags:
+  - web
+  - watch
+  - datadog
+  - observability
+---
+
+# Watch Datadog Availability Incidents
+
+## Summary
+
+Add a production-only Datadog availability incident flow for Watch so silent 500s and timeouts are caught even when client-side RUM never loads. The v1 flow uses a small stable canary set, requires repeated canary failure plus corroborating production Watch/Railway server 5xx or timeout logs, and creates Datadog incidents for automation.
+
+---
+
+## Problem Frame
+
+The current Watch Datadog coverage is strongest after the browser application boots. That is useful for client-side errors, but it can miss a server-rendered failure where the user only receives an "Internal Server Error" response and no client app runs. The motivating example is a production Watch URL returning a 500 while Datadog Error Tracking showed no matching issue for the selected Watch application and services.
+
+The desired v1 is not a full observability suite. The goal is a balanced detection layer: outside-in production canaries catch the user-visible failure, server-side production evidence confirms that the origin is also failing, and Datadog turns that confirmed condition into an incident workflow.
+
+---
+
+## Key Decisions
+
+- **Availability-first.** V1 is optimized to catch production Watch 5xx and timeout failures, not to explain every root cause.
+- **Two signals before incident creation.** A canary failure alone is too noisy; an incident requires repeated canary failure plus a corroborating production Watch/Railway server 5xx or timeout signal.
+- **Server logs are the trusted corroborator.** RUM remains useful context, but v1 does not depend on real-user browser telemetry because server-render failures can prevent RUM from loading.
+- **Small canary set.** V1 starts with known stable production Watch URLs rather than broad crawling or rotating manifest sampling.
+- **Automation-first incidents.** The Datadog output is a Datadog incident/workflow trigger, not a human-readable dashboard or executive notification package.
+- **Production only.** Non-production environments are out of scope for v1 alerting and incident creation.
+
+---
+
+## Actors
+
+- A1. **Production viewer.** A person who requests a Watch page and may receive a server error before client telemetry runs.
+- A2. **Datadog automation.** The monitor, incident, and workflow layer that evaluates signals and opens or updates the incident.
+- A3. **Watch operator.** The engineer or automation path that responds after Datadog has created an incident.
+
+---
+
+## Requirements
+
+**Canary coverage**
+
+- R1. Production Watch has a small canary set that covers the highest-value availability surfaces: Watch home, Gospel of John English, Jesus English, and at least one stable episode or deep-link page.
+- R2. Canary checks evaluate the externally visible production response, not an internal-only health endpoint.
+- R3. Canary failure is considered actionable only after repeated failure over a short window, not from a single transient miss.
+- R4. The final canary list is verified against live production route behavior before activation.
+
+**Server corroboration**
+
+- R5. Production Watch/Railway emits server-side 5xx and timeout evidence in a form Datadog can ingest and query.
+- R6. Server corroboration includes the Watch service identity and enough route or URL context to associate the signal with the canary failure class.
+- R7. Server corroboration does not depend on browser execution or RUM.
+- R8. Server log formatting is treated as part of the requirement when the hosting/runtime pipeline would otherwise drop or hide structured logs.
+
+**Incident creation**
+
+- R9. Datadog creates or updates an incident only when a repeated canary failure and production server 5xx/timeout corroboration are both present.
+- R10. Incident metadata identifies the affected surface as production Watch availability and includes enough tags for downstream automation to route the incident.
+- R11. V1 avoids separate human-facing notification copy unless it is required by the Datadog incident workflow.
+- R12. Recovery closes or resolves the active incident path only after the canary signal and corroborating server signal have cleared.
+
+**Scope and context**
+
+- R13. Existing client-side RUM remains in place and can provide context, but it is not required for v1 incident creation.
+- R14. V1 does not require a dashboard, route-manifest coverage report, or root-cause breadcrumb trail.
+- R15. V1 is production-only; staging, previews, and local development do not create incidents.
+
+---
+
+## Key Flows
+
+- F1. Confirmed availability incident
+  - **Trigger:** A production Watch canary repeatedly receives a 5xx, timeout, or equivalent unavailable response.
+  - **Steps:** Datadog observes the canary failure -> Datadog observes production Watch/Railway server 5xx or timeout corroboration -> Datadog creates or updates a Watch availability incident -> automation receives the incident context.
+  - **Covers:** R1, R2, R3, R5, R6, R9, R10, R11.
+
+- F2. Canary-only failure does not incident
+  - **Trigger:** A production Watch canary fails once or fails repeatedly without matching production server 5xx/timeout evidence.
+  - **Steps:** Datadog records the canary condition -> the incident rule withholds incident creation -> the signal remains available for later correlation or investigation.
+  - **Covers:** R3, R5, R7, R9.
+
+- F3. Server-only failure does not incident
+  - **Trigger:** Production Watch/Railway logs show a 5xx or timeout pattern, but the canary set is healthy.
+  - **Steps:** Datadog records the server signal -> no v1 availability incident is created -> the signal can still be used by separate log monitors if the team chooses later.
+  - **Covers:** R5, R6, R9, R14.
+
+- F4. Recovery
+  - **Trigger:** A confirmed Watch availability incident is active and the failing condition clears.
+  - **Steps:** Canary checks return healthy -> corroborating server failure signal clears -> Datadog resolves or updates the active incident according to the workflow.
+  - **Covers:** R12.
+
+---
+
+## Acceptance Examples
+
+- AE1. Server-render 500 with no RUM still incidents.
+  - **Given** a production Watch canary repeatedly receives an internal server error and no client app boots, **when** production Watch/Railway server logs show matching 5xx evidence, **then** Datadog creates or updates a Watch availability incident.
+  - **Covers:** R2, R5, R7, R9.
+
+- AE2. A transient canary blip is not enough.
+  - **Given** a canary fails once and then recovers, **when** there is no repeated failure window, **then** Datadog does not create a Watch availability incident.
+  - **Covers:** R3, R9.
+
+- AE3. RUM-only errors do not drive v1 incidents.
+  - **Given** RUM reports a client-side error but the canaries are healthy and production server 5xx/timeout corroboration is absent, **when** v1 incident rules evaluate, **then** no availability incident is created by this flow.
+  - **Covers:** R9, R13, R14.
+
+- AE4. Canary failure without server corroboration stays below incident threshold.
+  - **Given** canaries repeatedly fail from one location but production Watch/Railway server 5xx or timeout evidence is absent, **when** Datadog evaluates the v1 condition, **then** no incident is created by this flow.
+  - **Covers:** R3, R5, R9.
+
+- AE5. Recovery requires both sides to clear.
+  - **Given** an active Watch availability incident, **when** canaries recover but server 5xx/timeout evidence is still present, **then** the incident does not fully resolve until the corroborating server signal also clears.
+  - **Covers:** R12.
+
+---
+
+## Success Criteria
+
+- A forced or naturally occurring production Watch 500/timeout on a canary URL creates a Datadog incident when corroborating server logs are present.
+- The same failure is caught even if RUM never loads on the affected page.
+- A one-off canary failure does not create an incident.
+- A canary-only failure without production server corroboration does not create an incident.
+- Datadog incident metadata is structured enough for automation routing without requiring a human to inspect a dashboard first.
+
+---
+
+## Scope Boundaries
+
+- Broad Watch route crawling, rotating manifest sampling, and full URL inventory checks are deferred.
+- Dashboards, investigation timelines, and root-cause hints are deferred.
+- Server APM/tracing can be considered later, but v1 does not require it if reliable production logs provide the corroborating signal.
+- Client-side RUM improvements are outside v1 except where existing RUM remains useful context.
+- Non-production alerting is outside v1.
+
+---
+
+## Dependencies / Assumptions
+
+- Production Datadog can run outside-in HTTP checks against public Watch URLs.
+- Production Watch/Railway 5xx and timeout events can be emitted in a Datadog-visible log format.
+- Datadog incident workflows can be triggered from monitor conditions and receive useful tags/metadata.
+- The initial stable URL set can be verified against live production before enabling incidents.
+- The team accepts that v1 prioritizes low-noise incident creation over exhaustive coverage.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- Finalize the exact canary URL list after checking current production route behavior.
+- Define the repeated-failure window and location threshold that balance noise against detection speed.
+- Define the production server log query that represents Watch 5xx/timeout corroboration.
+- Decide whether incident recovery should be fully automatic or require a final automation/human confirmation step.
+- Decide whether any existing log lines need format changes so Datadog can reliably ingest them.
+
+---
+
+## Sources / Research
+
+- `docs/roadmap/platform/feat-182-web-watch-datadog-rum.md` documents the completed client-side Watch RUM work and its service/application framing.
+- `docs/plans/2026-06-11-005-feat-web-watch-datadog-rum-plan.md` documents the prior RUM scope and explicitly leaves server APM, dashboards, and broader monitoring out of that work.
+- `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md` documents the Railway log visibility constraint that makes reliable server log formatting part of this requirement.
+- `apps/web/AGENTS.md` and `apps/web/CLAUDE.md` describe the Watch app routing, static route constraints, and production route surfaces that can affect canary selection.
+- Datadog documentation: [Monitor notifications](https://docs.datadoghq.com/monitors/notify/) and [HTTP API tests](https://docs.datadoghq.com/synthetics/api_tests/http_tests/) describe incident/workflow notification hooks and scheduled HTTP checks.

--- a/docs/operations/watch-datadog-availability-incidents.md
+++ b/docs/operations/watch-datadog-availability-incidents.md
@@ -1,0 +1,281 @@
+# Watch Datadog Availability Incidents
+
+This runbook defines the production-only Watch availability incident path. It is
+paired with server-side Watch breadcrumbs in `apps/web/src/lib/watch-observability.ts`.
+
+## Goal
+
+Catch Watch server-rendered 500s and timeouts even when browser RUM never loads.
+The incident gate requires both:
+
+- an outside-in Watch canary alert, and
+- a production Watch server 5xx or timeout log alert.
+
+Client-side RUM remains useful context, but it is not part of the v1 incident
+trigger.
+
+## Canary URLs
+
+These URLs were checked from this worktree on 2026-06-12 with `curl -L`:
+
+| Surface                              | URL                                                                                           | Expected |
+| ------------------------------------ | --------------------------------------------------------------------------------------------- | -------- |
+| Watch home, English                  | `https://watch.jesusfilm.org/watch/english.html`                                              | `200`    |
+| Gospel of John, English              | `https://watch.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/english.html`            | `200`    |
+| Jesus, English                       | `https://watch.jesusfilm.org/watch/jesus.html/english.html`                                   | `200`    |
+| LUMO Gospel of John episode, English | `https://watch.jesusfilm.org/watch/lumo-the-gospel-of-john.html/wedding-in-cana/english.html` | `200`    |
+
+Do not add `https://watch.jesusfilm.org/watch/reflections-of-hope.html/7-jesus-our-living-water/english.html`
+to the initial canary set without fixing or revalidating it; it returned `500`
+during the 2026-06-12 check.
+
+## Tags
+
+Use these tags on every monitor in this flow:
+
+- `service:watch`
+- `env:prod`
+- `surface:watch`
+- `feature:watch-availability`
+- `team:platform`
+
+## Synthetic HTTP Tests
+
+Create one Datadog Synthetics HTTP test per canary URL.
+
+Recommended naming:
+
+- `Watch availability canary - home English`
+- `Watch availability canary - Gospel of John English`
+- `Watch availability canary - Jesus English`
+- `Watch availability canary - LUMO John episode English`
+
+Configuration:
+
+- Method: `GET`
+- Follow redirects: enabled
+- Assertions:
+  - response status code is `200`
+  - response time is less than `10000 ms`
+- Locations: three public locations, preferably two US locations plus one
+  non-US location.
+- Alerting rule: alert if any assertion fails for `5 minutes` from at least
+  `2 of 3` locations.
+- Fast retry: `2` retries, `300 ms` interval.
+- Notifications: leave the individual canary tests quiet unless the operations
+  team wants non-incident diagnostics. The composite monitor is the incident
+  source of truth.
+
+Datadog reference: https://docs.datadoghq.com/synthetics/api_tests/http_tests/
+
+## Production Server Log Monitors
+
+Create five logs monitors:
+
+- `Watch production server 5xx or timeout logs - home English`
+- `Watch production server 5xx or timeout logs - Gospel of John English`
+- `Watch production server 5xx or timeout logs - Jesus English`
+- `Watch production server 5xx or timeout logs - LUMO John episode English`
+- `Watch production shared manifest/substrate failures`
+
+Keep a broad production 5xx query for diagnosis, but do not use the broad query
+as the incident gate. The incident gate should pair each canary with either a
+matching route-specific server log signal or the shared manifest/substrate
+signal. That avoids creating an incident from an unrelated canary failure and an
+unrelated non-canary 500 in the same window.
+
+Use this production host filter in every server-log monitor, and verify it in
+Logs Explorer before enabling:
+
+```text
+(
+  @url_host:watch.jesusfilm.org OR
+  @url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org" OR
+  host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org"
+)
+```
+
+Route-specific monitor template:
+
+```text
+service:watch
+(
+  @url_host:watch.jesusfilm.org OR
+  @url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org" OR
+  host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org"
+)
+(
+  (status:error @statusCode:[500 TO 599]) OR
+  "Internal Server Error" OR
+  ApolloError OR
+  TimeoutError OR
+  AbortError OR
+  timeout
+)
+(
+  <ROUTE_MATCH>
+)
+```
+
+Use these route matches:
+
+| Monitor                   | `<ROUTE_MATCH>`                                               |
+| ------------------------- | ------------------------------------------------------------- |
+| home English              | `"watch/english.html" OR "page: '/'"`                         |
+| Gospel of John English    | `"life-of-jesus-gospel-of-john.html/english.html"`            |
+| Jesus English             | `"jesus.html/english.html"`                                   |
+| LUMO John episode English | `"lumo-the-gospel-of-john.html/wedding-in-cana/english.html"` |
+
+Shared manifest/substrate monitor query:
+
+```text
+service:watch "[watch]"
+(
+  @url_host:watch.jesusfilm.org OR
+  @url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org" OR
+  host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org"
+)
+(
+  "event=watch_route_manifest.fetch.failed" OR
+  "event=watch_route_manifest.fetch.error" OR
+  "event=watch_route_manifest.fetch.invalid_payload" OR
+  "event=watch_seo_manifest.fetch.failed" OR
+  "event=watch_seo_manifest.fetch.error" OR
+  "event=watch_seo_manifest.fetch.invalid_payload"
+)
+```
+
+Threshold:
+
+- Alert each server-log monitor when count is `>= 1` over the last `5 minutes`.
+- Recover when count is `0` for `10 minutes`.
+
+Notes:
+
+- Read-only Datadog checks in this work found `service:watch` logs across
+  production, preview, and e2e hosts. Keep the production-host allowlist rather
+  than relying on broad `service:watch` plus exclusions.
+- Current production examples exposed `custom.statusCode`, `custom.path`, and
+  `custom.url_host`; Datadog queries those custom attributes as `@statusCode`,
+  `@path`, and `@url_host`.
+- As of 2026-06-12, the highest-volume production-looking `service:watch` host
+  in Datadog was `1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org`. Recheck
+  the `@url_host` distribution before enabling the monitor and update the
+  allowlist if production traffic moved.
+- The quoted `@url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org"`
+  filter returned known production `@statusCode:500` samples in the 2026-06-12
+  validation pass.
+- The new `[watch] event=...` manifest breadcrumbs are included only in the
+  shared substrate monitor. Metadata fallback breadcrumbs remain diagnostic
+  context and do not open incidents on their own.
+
+## Composite Incident Gate
+
+Create a composite monitor named `Watch production availability incident gate`.
+
+Use the four synthetic monitors, the four route-specific log monitors, and the
+shared manifest/substrate monitor as constituents. With Datadog monitor labels
+`a` through `i`, use:
+
+```text
+(a && (e || i)) ||
+(b && (f || i)) ||
+(c && (g || i)) ||
+(d && (h || i))
+```
+
+Where:
+
+- `a`: home English synthetic alert
+- `b`: Gospel of John English synthetic alert
+- `c`: Jesus English synthetic alert
+- `d`: LUMO John episode English synthetic alert
+- `e`: home English production server 5xx or timeout log alert
+- `f`: Gospel of John English production server 5xx or timeout log alert
+- `g`: Jesus English production server 5xx or timeout log alert
+- `h`: LUMO John episode English production server 5xx or timeout log alert
+- `i`: shared manifest/substrate failure alert
+
+Set `notify_no_data` to false on the composite. Do not base another composite
+monitor on this one.
+
+Datadog reference: https://docs.datadoghq.com/monitors/types/composite/
+
+## Incident And Workflow Notifications
+
+Attach Datadog incident creation to the composite monitor, not to the individual
+synthetic or log monitors.
+
+Monitor message template:
+
+```text
+{{#is_alert}}
+Watch production availability is failing. At least one public canary is failing
+and production Watch server logs show matching route-specific 5xx/timeout
+evidence or a shared manifest/substrate failure.
+
+Scope: production Watch availability
+Canaries: home, Gospel of John English, Jesus English, LUMO John episode English
+Logs: service:watch route-paired 5xx/timeout monitors plus shared substrate monitor
+
+@incident-watch-availability
+{{/is_alert}}
+
+{{#is_recovery}}
+Watch production availability recovered after the canary and server-log signals
+cleared.
+{{/is_recovery}}
+```
+
+Replace `@incident-watch-availability` with the actual `@incident-` option from
+Datadog Incident Settings. Datadog supports creating incidents from monitors on
+alert, warn, or no-data transitions when an `@incident-` option is added to the
+monitor notification.
+
+Datadog reference: https://docs.datadoghq.com/monitors/notify/
+
+## Verification Matrix
+
+Run these checks before treating the flow as active:
+
+| Scenario                                                                  | Expected result                                                       |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| One canary location fails briefly                                         | Synthetic test records the failure, composite stays OK                |
+| Canary monitor alerts but no production server 5xx/timeout logs exist     | Composite stays OK, no incident                                       |
+| Server log monitor alerts while all canaries stay healthy                 | Composite stays OK, no incident                                       |
+| Home canary alerts while only the Jesus route log monitor alerts          | Composite stays OK, no incident                                       |
+| Canary monitor alerts and its paired route or shared substrate log alerts | Composite alerts and creates or updates a Watch availability incident |
+| Canary recovers but server log monitor is still alerting                  | Composite remains alert-worthy or last-known until both signals clear |
+| Both canary and server log monitor recover                                | Composite recovers and the incident path receives recovery context    |
+
+## Useful Follow-Up Queries
+
+Use this to inspect the new server breadcrumbs:
+
+```text
+service:watch "[watch]" (
+  "watch_route_manifest.fetch" OR
+  "watch_seo_manifest.fetch" OR
+  "watch_metadata.video.fallback" OR
+  "watch_metadata.episode.fallback"
+)
+```
+
+Use this to inspect production Watch 500s by route:
+
+```text
+service:watch status:error
+(
+  @url_host:watch.jesusfilm.org OR
+  @url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org"
+)
+@statusCode:[500 TO 599]
+```
+
+## Boundaries
+
+- Do not page from the individual synthetic monitors in v1.
+- Do not use browser RUM as the incident trigger for this flow.
+- Do not include preview, e2e, staging, or localhost traffic.
+- Do not broaden this into route-manifest crawling or server APM without a new
+  plan.

--- a/docs/plans/2026-06-12-004-feat-watch-datadog-availability-incidents-plan.md
+++ b/docs/plans/2026-06-12-004-feat-watch-datadog-availability-incidents-plan.md
@@ -1,0 +1,234 @@
+---
+title: "feat: Add Watch Datadog availability incidents"
+type: "feat"
+status: "completed"
+date: "2026-06-12"
+origin: "docs/brainstorms/2026-06-12-watch-datadog-availability-incidents-requirements.md"
+roadmap: "docs/roadmap/platform/feat-186-watch-datadog-availability-incidents.md"
+---
+
+# feat: Add Watch Datadog Availability Incidents
+
+## Summary
+
+Add the production Watch availability incident path that catches server-rendered
+500s and timeouts even when client-side RUM never loads. The implementation
+keeps the existing RUM setup intact, adds production-visible Watch server
+failure breadcrumbs, and documents the Datadog canary, log, composite, and
+incident workflow configuration needed for a balanced two-signal alert.
+
+## Problem Frame
+
+The motivating failure is a production Watch page returning `Internal Server
+Error` while Datadog Error Tracking has no matching issue. That is expected when
+the failure happens before the browser app boots: RUM and browser Error Tracking
+cannot observe a server-rendered 500 response body that never executes the
+client. V1 should therefore use outside-in canaries to detect user-visible
+availability failures and production server logs to corroborate origin-side
+failure before creating an incident.
+
+## Requirements
+
+- R1. Emit Datadog-visible Watch server failure breadcrumbs for manifest fetch
+  failures, metadata resolver fallbacks, and other existing server-side Watch
+  catch points that can precede RUM.
+- R2. Preserve the existing client RUM and source-map behavior; do not make RUM
+  part of the v1 incident trigger.
+- R3. Define a production-only Datadog canary monitor for a small stable Watch
+  URL set.
+- R4. Define a production-only Datadog log monitor for Watch 5xx and timeout
+  corroboration, filtered to real production Watch hosts and excluding preview,
+  e2e, and local traffic.
+- R5. Define a Datadog composite monitor and incident workflow that creates or
+  updates incidents only when the canary and server-log signals agree.
+- R6. Document verification for canary-only, log-only, and both-signals
+  scenarios so future operators can audit the setup.
+
+## High-Level Technical Design
+
+```mermaid
+flowchart LR
+  user["Production viewer"] --> watch["watch.jesusfilm.org"]
+  synth["Datadog Synthetics canaries"] --> watch
+  watch --> next["Web/Watch Next.js server"]
+  next --> logs["Datadog logs service:watch"]
+  synth --> canary_monitor["Canary monitor"]
+  logs --> log_monitor["Server 5xx/timeout monitor"]
+  canary_monitor --> composite["Composite monitor: canary AND log"]
+  log_monitor --> composite
+  composite --> incident["Datadog incident workflow"]
+```
+
+The code change is intentionally small: normalize Watch server breadcrumbs into
+plain `[watch] event=... key=value` log lines that survive the production log
+pipeline and can be queried from Datadog. The Datadog side remains a reproducible
+operations artifact because the repo does not currently own Datadog monitors as
+Terraform or another monitor-as-code system.
+
+## Key Technical Decisions
+
+### KTD1: Server Breadcrumbs Use Plain String Logs
+
+Use a small Watch observability helper to emit structured-enough plain strings
+instead of JSON objects. Prior production findings show Railway logsV2 can hide
+or reshape runtime stdout/stderr in ways that make JSON log assumptions brittle.
+The helper should keep event names fixed, sanitize values, and make log lines
+easy to query in Datadog.
+
+### KTD2: The Log Monitor Is Production-Host Filtered
+
+Datadog already has `service:watch` logs, but read-only Datadog checks showed
+that this service includes production, Vercel preview, e2e, and staging-like
+hosts. The log monitor must filter to production Watch host attributes such as
+`url_host` or the Datadog-normalized equivalent and explicitly exclude preview
+and local hosts.
+
+### KTD3: Datadog Config Is A Reproducible Runbook, Not New IaC
+
+There is no existing monitor-as-code pattern in this repo. V1 should add an
+operations runbook with exact canary URLs, monitor query templates, threshold
+guidance, incident tags, and validation steps. Do not introduce Terraform, Pulumi,
+or custom Datadog API scripts in this slice.
+
+### KTD4: Incident Creation Uses A Composite Gate
+
+A canary-only failure can be a network or location blip, and a server-log-only
+failure can be a non-canary edge case. The incident path should require both the
+outside-in canary monitor and the production server 5xx/timeout log monitor.
+
+### KTD5: Server APM And Broad Route Crawling Stay Out Of V1
+
+Next/server APM, route inventory crawling, dashboards, and root-cause timelines
+are useful later work, but they are not needed for this first availability-first
+incident path.
+
+## Implementation Units
+
+### Unit 1: Watch Server Log Helper
+
+Files:
+
+- `apps/web/src/lib/watch-observability.ts`
+- `apps/web/src/lib/watch-observability.test.ts`
+
+Approach:
+
+- Add a helper that emits `[watch] event=<event> key=value ...` lines.
+- Support warn and error levels so existing call sites can preserve severity.
+- Sanitize newline, whitespace, and quote-heavy values so Datadog queries remain
+  predictable.
+- Keep the API narrow and use fixed event constants from call sites.
+
+Test Scenarios:
+
+- The helper emits a deterministic line with sorted or stable key order.
+- Values with spaces, newlines, and undefined/null fields are handled safely.
+- Warn and error paths call the expected console methods.
+
+### Unit 2: Normalize Existing Watch Server Failure Breadcrumbs
+
+Files:
+
+- `apps/web/src/lib/watch-route-manifest.ts`
+- `apps/web/src/lib/watch-route-manifest.test.ts`
+- `apps/web/src/lib/watch-seo-manifest.ts`
+- `apps/web/src/lib/watch-seo-manifest.test.ts`
+- `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx`
+
+Approach:
+
+- Replace existing JSON-shaped manifest failure logs with the Watch
+  observability helper.
+- Add breadcrumbs to existing metadata fallback catch blocks so swallowed
+  resolver failures still leave production-visible evidence.
+- Do not wrap the whole route render path just to log and rethrow. Uncaught
+  server-render failures already appear in Next/Railway logs; this unit focuses
+  on catch points that otherwise hide the failure class.
+- Keep route behavior, cache behavior, manifest schemas, and static Watch route
+  constraints unchanged.
+
+Test Scenarios:
+
+- Route manifest non-OK responses emit `watch_route_manifest.fetch.failed` with
+  status and URL context.
+- Route manifest thrown fetch errors emit `watch_route_manifest.fetch.error`.
+- SEO manifest non-OK responses emit `watch_seo_manifest.fetch.failed`.
+- SEO manifest thrown fetch errors emit `watch_seo_manifest.fetch.error`.
+- Metadata fallback catch paths emit a Watch breadcrumb before returning the
+  fallback metadata.
+
+### Unit 3: Datadog Availability Runbook
+
+Files:
+
+- `docs/operations/watch-datadog-availability-incidents.md`
+
+Approach:
+
+- Document the v1 production canary URL set after checking current public route
+  behavior.
+- Document the Synthetics HTTP assertion shape, repeated-failure window, and
+  location quorum.
+- Document the production Watch server-log query template for 5xx and timeout
+  corroboration.
+- Document the composite monitor expression and incident/workflow notification
+  handles/tags.
+- Include a verification matrix proving canary-only and log-only conditions do
+  not create incidents, while both signals together do.
+
+Test Scenarios:
+
+- The runbook names concrete URLs and monitor tags.
+- The log query documents production-host filtering and preview/local
+  exclusions.
+- The recovery rule requires both canary and server corroboration to clear.
+
+### Unit 4: Roadmap And Validation
+
+Files:
+
+- `docs/roadmap/platform/feat-186-watch-datadog-availability-incidents.md`
+
+Approach:
+
+- Link the implementation plan and runbook from the roadmap ticket.
+- Mark the ticket complete only after implementation, review, and validation.
+- Run focused Web tests for observability behavior.
+- Run browser smoke against a representative Watch route.
+
+## Risks And Boundaries
+
+- This plan does not create live Datadog monitors from code because the repo has
+  no Datadog IaC pattern and the available Datadog connector is read-only for
+  this workflow.
+- Production log attributes can drift. The runbook should name the currently
+  observed attributes and tell operators to recheck the final query before
+  enabling incidents.
+- The canary set is deliberately small. It catches high-value availability
+  failures but does not prove every Watch route is healthy.
+- Do not add dynamic request-time APIs to the static Watch route tree.
+- Do not change the existing RUM application id, client token, sourcemap upload,
+  or RUM monitor behavior in this slice.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/lib/watch-observability.test.ts src/lib/watch-route-manifest.test.ts src/lib/watch-seo-manifest.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Browser smoke a representative production-shaped Watch route in the local app
+  using the repo-approved Helium/agent-browser path.
+- Read-only Datadog checks confirm `service:watch` production 5xx logs are
+  queryable with the documented filter shape.
+
+## Sources And Research
+
+- `docs/brainstorms/2026-06-12-watch-datadog-availability-incidents-requirements.md`
+- `docs/plans/2026-06-11-005-feat-web-watch-datadog-rum-plan.md`
+- `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`
+- `apps/web/AGENTS.md`
+- `apps/web/CLAUDE.md`
+- Datadog read-only findings from this session: existing `service:watch` RUM
+  monitors, production and preview `service:watch` logs, and existing
+  incident.io monitor notification patterns.
+- Datadog documentation: HTTP API tests, monitor notifications, monitor query
+  syntax, and composite monitors.

--- a/docs/roadmap/platform/feat-186-watch-datadog-availability-incidents.md
+++ b/docs/roadmap/platform/feat-186-watch-datadog-availability-incidents.md
@@ -1,0 +1,99 @@
+---
+id: "feat-186"
+title: "Watch Datadog Availability Incidents"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-12"
+duration: 2
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "observability"
+  - "datadog"
+  - "monitoring"
+---
+
+## Problem
+
+Watch currently has client-side Datadog RUM, but a server-rendered 500 or
+timeout can return an "Internal Server Error" response before the browser app
+boots. That class of failure can miss RUM Error Tracking and can go unnoticed
+unless someone manually checks the URL. Production Watch needs an
+availability-first Datadog incident path that requires both outside-in canary
+failure and corroborating production server 5xx/timeout logs.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-06-12-watch-datadog-availability-incidents-requirements.md` -
+   requirements for the two-signal availability incident flow.
+2. `docs/plans/2026-06-11-005-feat-web-watch-datadog-rum-plan.md` -
+   completed client-side RUM plan; this work extends observability beyond RUM.
+3. `docs/plans/2026-06-12-004-feat-watch-datadog-availability-incidents-plan.md` -
+   implementation plan for the two-signal availability incident slice.
+4. `docs/operations/watch-datadog-availability-incidents.md` - Datadog
+   Synthetics, log monitor, composite monitor, and incident workflow setup.
+5. `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md` -
+   logging format constraint for production-visible server breadcrumbs.
+6. `apps/web/src/lib/watch-route-manifest.ts` and
+   `apps/web/src/lib/watch-seo-manifest.ts` - current Watch manifest fetch
+   failure logs and timeout behavior.
+7. `apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx` - server-rendered
+   Watch route branches where resolver failures can return 500 before RUM.
+
+## Grep These
+
+- `rg -n "JSON\\.stringify\\(|console\\.(warn|error|log)" apps/web/src`
+- `rg -n "Datadog|datadog|RUM|rum" apps/web docs`
+- `rg -n "watch_route_manifest|watch_seo_manifest|timeout|ApolloError" apps/web/src`
+- Datadog monitor search: `title:Watch OR tag:"service:watch"`
+- Datadog log search: `service:watch status:error @statusCode:[500 TO 599]`
+
+## What To Build
+
+1. Normalize Watch server-side failure breadcrumbs into production-visible
+   `[watch] event=... key=value` log lines where v1 incident corroboration
+   needs them.
+2. Preserve the existing client RUM behavior; do not make RUM the v1 incident
+   trigger.
+3. Define a small production Watch canary set that checks public URLs, not an
+   internal health endpoint.
+4. Configure Datadog monitor coverage for repeated canary failure, production
+   Watch 5xx/timeout logs, and a composite incident gate that requires both.
+5. Route the confirmed condition into the Datadog incident/workflow path with
+   tags that automation can use.
+6. Document the exact Datadog queries, canary URLs, and verification steps so
+   future operators can audit or recreate the setup.
+
+## Constraints
+
+- Production only; staging, previews, and local development must not create
+  incidents.
+- Avoid broad route crawling, dashboards, and root-cause timelines in v1.
+- Do not add request-time dynamic APIs to the static Watch route tree.
+- Do not rely on JSON-shaped server logs for Datadog/Railway corroboration.
+- Do not treat a canary-only failure or a server-log-only failure as enough to
+  create an incident.
+
+## Verification
+
+- Run focused tests:
+  `pnpm --filter @forge/web test -- src/lib/watch-observability.test.ts src/lib/watch-route-manifest.test.ts src/lib/watch-seo-manifest.test.ts 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx'`
+- Run PR-sensitive Web checks: `pnpm --filter @forge/web typecheck` and
+  `pnpm --filter @forge/web lint`.
+- Live-check canary URLs with `curl -sS -L -o /dev/null -w '%{http_code} %{url_effective}\n' <url>`
+  for the home English, Gospel of John English, Jesus English, and LUMO John
+  episode English URLs in `docs/operations/watch-datadog-availability-incidents.md`.
+- In Datadog Logs Explorer, validate the production host filter:
+  `service:watch @url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org" @statusCode:[500 TO 599]`.
+- In Datadog Logs Explorer, validate the shared breadcrumb query:
+  `service:watch "[watch]" ("event=watch_route_manifest.fetch" OR "event=watch_seo_manifest.fetch")`.
+- In Datadog Synthetics/Monitors, verify the composite gate behavior from the
+  runbook matrix: canary-only stays OK, log-only stays OK, mismatched route
+  pairs stay OK, and matched canary-plus-route or canary-plus-shared-substrate
+  alerts create or update a Watch availability incident.
+- Run a Helium/agent-browser smoke against a representative local Watch route
+  after starting the Web app.


### PR DESCRIPTION
## Summary

Watch server failures that happen before browser RUM loads now leave production-visible `[watch] event=...` breadcrumbs in the paths that previously swallowed or JSON-shaped important server evidence. The Datadog setup is also documented as a route-aware two-signal incident gate: a public canary must fail with either its paired route log monitor or the shared Watch manifest/substrate monitor before Datadog creates a production availability incident.

This keeps RUM as useful context, but moves availability incident creation to signals that still exist when the viewer only receives an `Internal Server Error` response.

## Design Notes

| Decision | Why |
| --- | --- |
| Plain server log lines | Railway/Datadog ingestion is more reliable with queryable plain strings than JSON-shaped console payloads for this path. |
| Route-paired composite gate | Avoids opening an incident from an unrelated canary blip plus an unrelated non-canary 500. |
| Shared manifest/substrate monitor | Captures common Watch route-manifest and SEO-manifest failures that can affect multiple canaries. |
| Runbook over new Datadog IaC | The repo does not currently own Datadog monitors as code, so this PR adds reproducible setup and validation steps without introducing a new infrastructure pattern. |

## Testing

- `pnpm --filter @forge/web test -- src/lib/watch-observability.test.ts src/lib/watch-route-manifest.test.ts src/lib/watch-seo-manifest.test.ts 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx' 'src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-metadata.test.tsx'`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- Datadog read-only validation: `service:watch @url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org" @statusCode:[500 TO 599]` returned known production Watch 500 samples.
- Live canary URL checks returned `200` for home English, Gospel of John English, Jesus English, and the LUMO John episode listed in the runbook.
- Browser smoke: `agent-browser` opened `http://127.0.0.1:3000/watch/jesus.html/english.html`, snapshot showed the `JESUS` page with chapters and controls, and a local manifest failure emitted `[watch] event=watch_route_manifest.fetch.failed ...` in the dev server log.

## Post-Deploy Monitoring & Validation

Validation window: first 24 hours after Web deploy. Owner: platform/Watch operator.

Watch Datadog logs:

```text
service:watch "[watch]" (
  "watch_route_manifest.fetch" OR
  "watch_seo_manifest.fetch" OR
  "watch_metadata.video.fallback" OR
  "watch_metadata.episode.fallback"
)
```

Expected healthy signal: low or zero volume; when present, lines are plain `[watch] event=... key=value` records with bounded details and no secrets.

Validate the production 5xx host filter before enabling monitors:

```text
service:watch @url_host:"1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org" @statusCode:[500 TO 599]
```

Expected healthy signal: query returns only production-looking Watch host traffic and excludes `watch-*.vercel.app` preview/e2e hosts.

Enable and validate the runbook monitors in this order:

1. Synthetic canaries for the four listed production Watch URLs.
2. Route-specific server log monitors plus shared manifest/substrate monitor.
3. Composite gate with route-paired expression from `docs/operations/watch-datadog-availability-incidents.md`.
4. Datadog incident notification only on the composite monitor.

Failure signals and mitigation:

- Canary-only or log-only conditions create incidents: disable the composite notification and fix the route-pair expression.
- Preview/e2e logs affect production incident monitors: tighten the production host allowlist before re-enabling.
- `[watch]` logs contain sensitive values or excessive detail: revert the logging helper/call-site change and redeploy.
- Canaries return 5xx after deploy: keep the incident path active, inspect route-paired `service:watch` logs, and roll back the Web deploy if failures correlate with the release.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5_Codex](https://img.shields.io/badge/GPT_5_Codex-000000)
