### PR TITLE
fix(web): harden Watch download lookup

### DIFF
--- a/apps/web/src/app/api/download/route.auth.test.ts
+++ b/apps/web/src/app/api/download/route.auth.test.ts
@@ -42,6 +42,23 @@ function makeRequest(
   return new Request(url, init)
 }
 
+function adminVideoDub() {
+  return {
+    videoDub: {
+      documentId: "variant-1",
+      downloadable: true,
+      downloads: [
+        {
+          documentId: "download-1",
+          url: "https://stream.mux.com/abc.mp4",
+        },
+      ],
+      published: true,
+      slug: "jesus/english",
+    },
+  }
+}
+
 async function importRouteWithGate(enabled: boolean) {
   vi.resetModules()
   vi.stubEnv("WEB_AUTH_BASE_URL", "http://localhost:3004")
@@ -109,22 +126,7 @@ describe("GET /watch/api/download - account gate", () => {
 
   it("resolves signed-in downloads by opaque IDs instead of requiring the browser to send a CDN URL", async () => {
     queryMock.mockResolvedValueOnce({
-      data: {
-        videoBySlug: {
-          variants: [
-            {
-              documentId: "variant-1",
-              published: true,
-              downloads: [
-                {
-                  documentId: "download-1",
-                  url: "https://stream.mux.com/abc.mp4",
-                },
-              ],
-            },
-          ],
-        },
-      },
+      data: adminVideoDub(),
     })
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
@@ -154,7 +156,7 @@ describe("GET /watch/api/download - account gate", () => {
     expect(response.status).toBe(200)
     expect(queryMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: { videoSlug: "jesus" },
+        variables: { variantId: "variant-1" },
       }),
     )
     expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
@@ -180,6 +182,29 @@ describe("GET /watch/api/download - account gate", () => {
     expect(response.status).toBe(503)
     await expect(response.json()).resolves.toEqual({
       error: "Download lookup unavailable",
+    })
+    expect(dns.resolve4).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns a shaped 404 when opaque IDs do not resolve to a downloadable target", async () => {
+    queryMock.mockResolvedValueOnce({ data: { videoDub: null } })
+    const fetchMock = vi.fn(async () => new Response("should not happen"))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { GET } = await importRouteWithGate(false)
+    const response = await GET(
+      makeRequest({
+        downloadId: "download-1",
+        filename: "jesus-highest.mp4",
+        variantId: "variant-1",
+        videoSlug: "jesus",
+      }),
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error: "Download unavailable",
     })
     expect(dns.resolve4).not.toHaveBeenCalled()
     expect(fetchMock).not.toHaveBeenCalled()
@@ -230,22 +255,7 @@ describe("HEAD /watch/api/download - opaque download target", () => {
 
   it("resolves file-size probes by opaque IDs instead of requiring a browser CDN URL", async () => {
     queryMock.mockResolvedValueOnce({
-      data: {
-        videoBySlug: {
-          variants: [
-            {
-              documentId: "variant-1",
-              published: true,
-              downloads: [
-                {
-                  documentId: "download-1",
-                  url: "https://stream.mux.com/abc.mp4",
-                },
-              ],
-            },
-          ],
-        },
-      },
+      data: adminVideoDub(),
     })
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) => {
@@ -273,7 +283,7 @@ describe("HEAD /watch/api/download - opaque download target", () => {
     expect(response.headers.get("content-length")).toBe("123456")
     expect(queryMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: { videoSlug: "jesus" },
+        variables: { variantId: "variant-1" },
       }),
     )
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(

--- a/apps/web/src/components/watch/__tests__/WatchPageClient.download.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchPageClient.download.test.tsx
@@ -153,11 +153,11 @@ afterEach(() => {
 
 function renderWatchPage() {
   const variant = {
-    documentId: "variant-1",
+    documentId: "5fc705b9-1b3b-4a58-abef-755b98457de6",
     duration: 7674,
     downloads: [
       {
-        documentId: "download-1",
+        documentId: "47420a5c-0ae1-465e-bcc9-98056566d087",
         quality: "fhd",
         size: "1048576",
         url: "https://stream.mux.com/raw-client-leak.mp4",
@@ -168,8 +168,8 @@ function renderWatchPage() {
   }
   const video = {
     documentId: "video-1",
-    slug: "jesus",
-    title: "JESUS",
+    slug: "jesus-is-brought-to-pilate",
+    title: "Jesus Is Brought to Pilate",
     snippet: null,
     description: null,
     images: [],
@@ -195,7 +195,7 @@ describe("WatchPageClient download boundary", () => {
     expect(downloadModalProps).toHaveLength(0)
     expect(languageModalProps).toHaveLength(0)
     expect(scheduleWatchInteractionWarmupMock).toHaveBeenCalledWith({
-      videoSlug: "jesus",
+      videoSlug: "jesus-is-brought-to-pilate",
     })
     const renderer = document.querySelector(
       '[data-testid="watch-section-renderer"]',
@@ -204,13 +204,16 @@ describe("WatchPageClient download boundary", () => {
       "/watch/api/download?",
     )
     expect(renderer?.getAttribute("data-download-href")).toContain(
-      "downloadId=download-1",
+      "downloadId=47420a5c-0ae1-465e-bcc9-98056566d087",
     )
     expect(renderer?.getAttribute("data-download-href")).toContain(
-      "variantId=variant-1",
+      "variantId=5fc705b9-1b3b-4a58-abef-755b98457de6",
     )
     expect(renderer?.getAttribute("data-download-href")).toContain(
-      "videoSlug=jesus",
+      "videoSlug=jesus-is-brought-to-pilate",
+    )
+    expect(renderer?.getAttribute("data-download-href")).not.toContain(
+      "stream.mux.com",
     )
     expect(renderer?.getAttribute("data-share-href")).toContain(
       "https://www.facebook.com/sharer/sharer.php",
@@ -239,11 +242,11 @@ describe("WatchPageClient download boundary", () => {
       variantId: string
       videoSlug: string
     }
-    expect(latestProps.variantId).toBe("variant-1")
-    expect(latestProps.videoSlug).toBe("jesus")
+    expect(latestProps.variantId).toBe("5fc705b9-1b3b-4a58-abef-755b98457de6")
+    expect(latestProps.videoSlug).toBe("jesus-is-brought-to-pilate")
     expect(latestProps.downloads).toEqual([
       {
-        documentId: "download-1",
+        documentId: "47420a5c-0ae1-465e-bcc9-98056566d087",
         quality: "fhd",
         size: 1048576,
       },
@@ -285,7 +288,9 @@ describe("WatchPageClient download boundary", () => {
         ?.click()
     })
 
-    expect(loadWatchLanguageOptionsMock).toHaveBeenCalledWith("jesus")
+    expect(loadWatchLanguageOptionsMock).toHaveBeenCalledWith(
+      "jesus-is-brought-to-pilate",
+    )
     expect(loadWatchInteractionMock).toHaveBeenCalledWith("language")
     expect(languageModalProps.at(-1)).toEqual(
       expect.objectContaining({

--- a/apps/web/src/lib/download-target.test.ts
+++ b/apps/web/src/lib/download-target.test.ts
@@ -16,29 +16,32 @@ vi.mock("@/lib/admin-client", () => ({
 
 afterEach(() => {
   queryMock.mockReset()
+  vi.restoreAllMocks()
   vi.resetModules()
 })
 
-function adminVideo({
+function adminVideoDub({
+  downloadable = true,
   downloadId = "download-1",
   published = true,
+  slug = "jesus/english",
   url = "https://stream.mux.com/abc.mp4",
   variantId = "variant-1",
 }: {
+  downloadable?: boolean
   downloadId?: string
   published?: boolean
+  slug?: string | null
   url?: string | null
   variantId?: string
 } = {}) {
   return {
-    videoBySlug: {
-      variants: [
-        {
-          documentId: variantId,
-          published,
-          downloads: [{ documentId: downloadId, url }],
-        },
-      ],
+    videoDub: {
+      downloadable,
+      documentId: variantId,
+      downloads: [{ documentId: downloadId, url }],
+      published,
+      slug,
     },
   }
 }
@@ -59,6 +62,9 @@ describe("resolveWatchDownloadTarget", () => {
 
   it("returns unavailable when the admin lookup rejects", async () => {
     queryMock.mockRejectedValueOnce(new Error("admin down"))
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
     const { resolveWatchDownloadTarget } = await import("./download-target")
 
     await expect(
@@ -68,10 +74,85 @@ describe("resolveWatchDownloadTarget", () => {
         videoSlug: "jesus",
       }),
     ).resolves.toEqual({ ok: false, reason: "unavailable" })
+    expect(consoleError).toHaveBeenCalledWith(
+      "[watch-download-target] admin lookup failed",
+      expect.objectContaining({
+        downloadId: "download-1",
+        variantId: "variant-1",
+        videoSlug: "jesus",
+      }),
+    )
+  })
+
+  it("queries admin by variant id only", async () => {
+    queryMock.mockResolvedValueOnce({
+      data: adminVideoDub({ url: "https://stream.mux.com/abc.mp4" }),
+    })
+    const { resolveWatchDownloadTarget } = await import("./download-target")
+
+    await expect(
+      resolveWatchDownloadTarget({
+        downloadId: "download-1",
+        variantId: "variant-1",
+        videoSlug: "jesus",
+      }),
+    ).resolves.toEqual({ ok: true, url: "https://stream.mux.com/abc.mp4" })
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { variantId: "variant-1" },
+      }),
+    )
+  })
+
+  it("rejects missing dubs", async () => {
+    queryMock.mockResolvedValueOnce({
+      data: { videoDub: null },
+    })
+    const { resolveWatchDownloadTarget } = await import("./download-target")
+
+    await expect(
+      resolveWatchDownloadTarget({
+        downloadId: "download-1",
+        variantId: "variant-1",
+        videoSlug: "jesus",
+      }),
+    ).resolves.toEqual({ ok: false, reason: "not-found" })
   })
 
   it("rejects unpublished variants", async () => {
-    queryMock.mockResolvedValueOnce({ data: adminVideo({ published: false }) })
+    queryMock.mockResolvedValueOnce({
+      data: adminVideoDub({ published: false }),
+    })
+    const { resolveWatchDownloadTarget } = await import("./download-target")
+
+    await expect(
+      resolveWatchDownloadTarget({
+        downloadId: "download-1",
+        variantId: "variant-1",
+        videoSlug: "jesus",
+      }),
+    ).resolves.toEqual({ ok: false, reason: "not-found" })
+  })
+
+  it("rejects non-downloadable variants", async () => {
+    queryMock.mockResolvedValueOnce({
+      data: adminVideoDub({ downloadable: false }),
+    })
+    const { resolveWatchDownloadTarget } = await import("./download-target")
+
+    await expect(
+      resolveWatchDownloadTarget({
+        downloadId: "download-1",
+        variantId: "variant-1",
+        videoSlug: "jesus",
+      }),
+    ).resolves.toEqual({ ok: false, reason: "not-found" })
+  })
+
+  it("rejects dubs whose slug belongs to another video", async () => {
+    queryMock.mockResolvedValueOnce({
+      data: adminVideoDub({ slug: "other-video/english" }),
+    })
     const { resolveWatchDownloadTarget } = await import("./download-target")
 
     await expect(
@@ -85,7 +166,7 @@ describe("resolveWatchDownloadTarget", () => {
 
   it("rejects mismatched variants and downloads", async () => {
     queryMock.mockResolvedValueOnce({
-      data: adminVideo({ downloadId: "download-2", variantId: "variant-2" }),
+      data: adminVideoDub({ downloadId: "download-2", variantId: "variant-2" }),
     })
     const { resolveWatchDownloadTarget } = await import("./download-target")
 
@@ -99,7 +180,10 @@ describe("resolveWatchDownloadTarget", () => {
   })
 
   it("treats empty admin URLs as unavailable", async () => {
-    queryMock.mockResolvedValueOnce({ data: adminVideo({ url: "" }) })
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+    queryMock.mockResolvedValueOnce({ data: adminVideoDub({ url: "" }) })
     const { resolveWatchDownloadTarget } = await import("./download-target")
 
     await expect(
@@ -109,11 +193,19 @@ describe("resolveWatchDownloadTarget", () => {
         videoSlug: "jesus",
       }),
     ).resolves.toEqual({ ok: false, reason: "unavailable" })
+    expect(consoleError).toHaveBeenCalledWith(
+      "[watch-download-target] resolved empty download url",
+      expect.objectContaining({
+        downloadId: "download-1",
+        variantId: "variant-1",
+        videoSlug: "jesus",
+      }),
+    )
   })
 
   it("returns the server-side URL for the matching published variant download", async () => {
     queryMock.mockResolvedValueOnce({
-      data: adminVideo({ url: "https://stream.mux.com/abc.mp4" }),
+      data: adminVideoDub({ url: "https://stream.mux.com/abc.mp4" }),
     })
     const { resolveWatchDownloadTarget } = await import("./download-target")
 

--- a/apps/web/src/lib/download-target.ts
+++ b/apps/web/src/lib/download-target.ts
@@ -5,16 +5,16 @@ import { adminGraphql, type AdminResultOf } from "@forge/admin-graphql"
 import client from "@/lib/admin-client"
 
 export const getWatchDownloadTargetOperation = adminGraphql(`
-  query GetWatchDownloadTarget($videoSlug: String!) {
-    videoBySlug(slug: $videoSlug) {
-      variants: dubs {
+  query GetWatchDownloadTarget($variantId: ID!) {
+    videoDub(id: $variantId) {
+      documentId: id
+      downloadable
+      downloads {
         documentId: id
-        published
-        downloads {
-          documentId: id
-          url
-        }
+        url
       }
+      published
+      slug
     }
   }
 `)
@@ -33,6 +33,16 @@ export type WatchDownloadTargetResult =
   | { ok: true; url: string }
   | { ok: false; reason: "missing-params" | "not-found" | "unavailable" }
 
+function belongsToVideoSlug(
+  dubSlug: string | null | undefined,
+  videoSlug: string,
+): boolean {
+  if (typeof dubSlug !== "string") return false
+  const normalizedDubSlug = dubSlug.replace(/^\/+|\/+$/g, "")
+  const normalizedVideoSlug = videoSlug.replace(/^\/+|\/+$/g, "")
+  return normalizedDubSlug.startsWith(`${normalizedVideoSlug}/`)
+}
+
 export async function resolveWatchDownloadTarget({
   downloadId,
   variantId,
@@ -46,25 +56,42 @@ export async function resolveWatchDownloadTarget({
   try {
     result = await client.query<WatchDownloadTargetData>({
       query: getWatchDownloadTargetOperation,
-      variables: { videoSlug },
+      variables: { variantId },
       fetchPolicy: "no-cache",
     })
-  } catch {
+  } catch (err) {
+    console.error("[watch-download-target] admin lookup failed", {
+      downloadId,
+      err: err instanceof Error ? err.message : String(err),
+      variantId,
+      videoSlug,
+    })
     return { ok: false, reason: "unavailable" }
   }
 
-  const variants = result.data?.videoBySlug?.variants ?? []
-  const variant = variants.find((candidate) => {
-    return candidate?.documentId === variantId && candidate.published === true
-  })
-  if (!variant) return { ok: false, reason: "not-found" }
+  const variant = result.data?.videoDub
+  if (
+    variant?.documentId !== variantId ||
+    variant.published !== true ||
+    variant.downloadable !== true ||
+    !belongsToVideoSlug(variant.slug, videoSlug)
+  ) {
+    return { ok: false, reason: "not-found" }
+  }
 
   const download = (variant.downloads ?? []).find((candidate) => {
     return candidate?.documentId === downloadId
   })
   if (!download) return { ok: false, reason: "not-found" }
 
-  return typeof download.url === "string" && download.url.length > 0
-    ? { ok: true, url: download.url }
-    : { ok: false, reason: "unavailable" }
+  if (typeof download.url !== "string" || download.url.length === 0) {
+    console.error("[watch-download-target] resolved empty download url", {
+      downloadId,
+      variantId,
+      videoSlug,
+    })
+    return { ok: false, reason: "unavailable" }
+  }
+
+  return { ok: true, url: download.url }
 }

--- a/docs/plans/2026-06-11-002-feat-manager-shorts-studio-plan.md
+++ b/docs/plans/2026-06-11-002-feat-manager-shorts-studio-plan.md
@@ -555,7 +555,7 @@ build` smoke.
       config_missing; worker boots fail-fast on missing model/keys in
       production only.
 - [ ] Tests green: `pnpm --filter @forge/shorts-compositions --filter
-    @forge/shorts-worker --filter @forge/manager test` + typecheck +
+@forge/shorts-worker --filter @forge/manager test` + typecheck +
       lint + build; host smoke passes; container smoke passes.
       (Tests + host smoke pass; the CONTAINER smoke — docker build + run,
       the in-image Chromium/fonts/model/bundle proof — has not been

--- a/docs/plans/2026-06-12-005-fix-watch-download-target-lookup-plan.md
+++ b/docs/plans/2026-06-12-005-fix-watch-download-target-lookup-plan.md
@@ -1,0 +1,301 @@
+---
+title: "fix: Harden Watch download target lookup"
+type: fix
+status: completed
+date: 2026-06-12
+roadmap: "docs/roadmap/platform/feat-186-watch-download-target-lookup.md"
+origin: "QA report issue #1 - Watch Download 503 investigation"
+---
+
+# fix: Harden Watch download target lookup
+
+## Summary
+
+Replace the Watch download proxy's heavy target resolver with an id-scoped Dub
+lookup. A download click should resolve only the requested `VideoDub` and its
+downloads instead of fetching every Dub for the whole video, while preserving
+the existing same-origin proxy, opaque download IDs, account gate, and SSRF
+defenses.
+
+## Problem Frame
+
+QA reported a `503` when selecting `Download` on the Pilate Watch page. Live
+checks did not reproduce the failure: the rendered same-origin download link
+returned `200`/`206`, and the underlying Mux asset was reachable. The brittle
+part is the server-side lookup path used before streaming starts.
+
+For the Pilate page, the current resolver calls `videoBySlug` and projects all
+Dubs and their downloads for the video. The investigation measured that shape
+at 2,259 Dubs, 17,761 download rows, about 3.8 MB of GraphQL response, and about
+7.2 seconds. The same target can be resolved through the existing public
+`videoDub(id:)` query in about 1.8 KB and about 1.7 seconds. The route maps an
+Admin lookup rejection or empty target URL to `503`, so reducing the resolver's
+payload and latency is the highest-value fix for intermittent download 503s.
+
+## Requirements
+
+- R1. Resolve a Watch download target by `variantId` through the existing
+  public `videoDub(id:)` Admin GraphQL field, not by loading all Dubs through
+  `videoBySlug`.
+- R2. Keep the download API contract based on opaque `downloadId`, `variantId`,
+  and `videoSlug`; raw CDN URLs must remain server-only.
+- R3. Reject mismatched combinations: the returned Dub must be published,
+  downloadable, belong to the requested `videoSlug`, and contain the requested
+  `downloadId`.
+- R4. Preserve current route status semantics: missing params return `400`,
+  valid-but-mismatched targets return `404`, Admin lookup failures or empty
+  upstream URLs return `503`, and upstream streaming errors keep their existing
+  behavior.
+- R5. Add sanitized diagnostics for lookup failures so future `503`s can be
+  tied to the failure class and opaque IDs without logging raw CDN URLs.
+- R6. Keep the existing same-origin streaming proxy and SSRF allowlist/DNS
+  validation unchanged.
+- R7. Add regression coverage that proves the Pilate default download link
+  remains an opaque same-origin URL and the target resolver no longer needs the
+  full-video Dub graph.
+
+## Key Technical Decisions
+
+### KTD-1: Use `videoDub(id:)` as the resolver root
+
+The Admin schema already exposes `videoDub(id:)` for lazy, per-Dub media
+fetches, backed by `VideoService.getDubById`. That matches this click path: the
+download API receives one `variantId` and needs only that Dub's downloads.
+
+### KTD-2: Preserve the `videoSlug` binding in the web resolver
+
+The current `videoBySlug` query implicitly proves that the selected `variantId`
+belongs to the requested video. After switching to `videoDub(id:)`, the resolver
+must keep that protection by validating the returned Dub's slug against the
+requested video slug, for example by requiring a normalized
+`<videoSlug>/<languageSlug>` prefix match.
+
+### KTD-3: Treat non-downloadable Dubs as not found
+
+`downloadable` is exposed on `VideoDub` and is already used by Admin catalog
+queries to identify usable download media. The resolver should require
+`downloadable === true` together with `published === true` before accepting a
+download row. If implementation finds historic rows with downloads but
+`downloadable === false`, that discovery should be handled explicitly rather
+than silently weakening the server-side gate.
+
+### KTD-4: Leave proxy security behavior untouched
+
+This plan changes how the upstream URL is discovered, not how it is streamed.
+The existing `/watch/api/download` allowlist, URL reconstruction, DNS
+pre-flight, redirect handling, bounded headers, and timeout behavior stay in
+place.
+
+### KTD-5: Log failure context without leaking targets
+
+Lookup diagnostics should include safe fields such as `videoSlug`, `variantId`,
+`downloadId`, and a reason or error class. They must not include the resolved
+download URL because raw CDN URLs intentionally remain server-only.
+
+## Technical Design
+
+```mermaid
+flowchart TB
+  A["Rendered Download href with opaque IDs"] --> B["/watch/api/download"]
+  B --> C["resolveWatchDownloadTarget"]
+  C --> D["Admin videoDub(id: variantId)"]
+  D --> E["One Dub with downloads"]
+  E --> F{"published, downloadable, slug-bound, matching downloadId?"}
+  F -->|yes| G["Return upstream URL to existing proxy internals"]
+  F -->|no| H["not-found or unavailable"]
+  G --> I["Existing allowlist, DNS pre-flight, and stream response"]
+```
+
+## Implementation Units
+
+### U1: Narrow the download target query
+
+Files:
+
+- `apps/web/src/lib/download-target.ts`
+- `apps/web/src/lib/download-target.test.ts`
+
+Work:
+
+- Replace `GetWatchDownloadTarget($videoSlug: String!)` with a
+  `GetWatchDownloadTarget($variantId: ID!)` operation that reads
+  `videoDub(id: $variantId)`.
+- Select only the fields needed for the target decision: Dub id, slug,
+  published, downloadable, and download id/url rows.
+- Keep `downloadId`, `variantId`, and `videoSlug` as required inputs before any
+  Admin query is sent.
+- Validate the returned Dub id, `published`, `downloadable`, slug ownership, and
+  matching download row before returning an upstream URL.
+- Return `unavailable` for Admin query rejection and for a matching download
+  row with an empty URL.
+
+Test scenarios:
+
+- Missing `downloadId`, `variantId`, or `videoSlug` returns `missing-params`
+  and does not query Admin.
+- A published, downloadable Dub with slug
+  `jesus-is-brought-to-pilate/english` and the requested download returns
+  `{ ok: true, url }`.
+- `videoDub` returning `null` returns `not-found`.
+- An unpublished Dub returns `not-found`.
+- A non-downloadable Dub returns `not-found`.
+- A returned Dub whose slug belongs to another video returns `not-found`.
+- A Dub with no matching download id returns `not-found`.
+- A matching download with an empty URL returns `unavailable`.
+- An Admin query rejection returns `unavailable`.
+
+Patterns to follow:
+
+- `docs/solutions/design-patterns/lean-bulk-lazy-per-item-graphql-fetch-20260604.md`
+- `apps/admin/src/graphql/types/video.ts`
+- `apps/admin/src/services/video.service.ts`
+
+### U2: Preserve API route behavior and add diagnostics
+
+Files:
+
+- `apps/web/src/app/api/download/route.ts`
+- `apps/web/src/app/api/download/route.test.ts`
+- `apps/web/src/app/api/download/route.auth.test.ts`
+- `apps/web/src/lib/download-target.ts`
+
+Work:
+
+- Keep the route's existing status mapping for resolver results.
+- Add sanitized error logging either inside `resolveWatchDownloadTarget` or at
+  the route boundary when the resolver returns `unavailable`.
+- Keep authentication and terms gating before target resolution exactly as it
+  behaves today.
+- Keep all SSRF validation and upstream streaming code unchanged.
+
+Test scenarios:
+
+- Resolver `missing-params` still maps to `400`.
+- Resolver `not-found` still maps to `404`.
+- Resolver `unavailable` still maps to `503`.
+- Auth-gated requests do not attempt target resolution before the user/session
+  gate passes.
+- Logs for lookup failure contain only safe opaque context and do not include a
+  raw upstream URL.
+
+Patterns to follow:
+
+- `docs/solutions/security-issues/ssrf-defense-streaming-proxy-and-codeql-fp-20260504.md`
+- `docs/roadmap/platform/feat-146-web-user-accounts-download-gate.md`
+
+### U3: Lock the rendered Watch download href contract
+
+Files:
+
+- `apps/web/src/components/watch/WatchPageClient.tsx`
+- `apps/web/src/components/watch/__tests__/WatchPageClient.download.test.tsx`
+- `apps/web/src/components/watch/download-link.ts`
+- `apps/web/src/components/watch/download-options.ts`
+
+Work:
+
+- Keep the rendered Download CTA href as a same-origin
+  `/watch/api/download?...` URL containing `downloadId`, `variantId`,
+  `videoSlug`, and filename.
+- Verify the client still selects the default downloadable tier from the active
+  variant without exposing a raw CDN URL.
+- Add or tighten a Pilate-shaped regression around the default href, using
+  deterministic fixtures rather than live production data.
+
+Test scenarios:
+
+- A downloadable active variant renders a Download href with opaque IDs and no
+  raw `stream.mux.com` URL.
+- The Pilate fixture emits the expected `videoSlug`,
+  `jesus-is-brought-to-pilate`, and passes through the selected `variantId` and
+  `downloadId`.
+- A variant with no usable download rows does not render a malformed proxy
+  href.
+
+### U4: Add smoke criteria for production or preview retest
+
+Files:
+
+- No code files; this is deployment verification for the implemented change.
+
+Work:
+
+- Treat smoke as a deployment verification step rather than a unit test.
+- Extract the rendered Pilate Download href from a deployed page.
+- Use `HEAD` and a `Range: bytes=0-0` request against the same-origin URL to
+  verify downloadability without transferring the full MP4.
+- Confirm response headers preserve attachment semantics and avoid exposing raw
+  CDN URLs in the rendered page.
+
+Acceptance checks:
+
+- The rendered page includes an opaque `/watch/api/download` href.
+- `HEAD` against that href returns success for an authenticated/eligible path.
+- `Range: bytes=0-0` returns `206` and an attachment filename.
+- The downloaded byte range comes through the same-origin proxy.
+
+## Validation Plan
+
+- `pnpm --filter @forge/web test -- src/lib/download-target.test.ts`
+- `pnpm --filter @forge/web test -- src/app/api/download/route.test.ts src/app/api/download/route.auth.test.ts`
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/WatchPageClient.download.test.tsx`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Helium smoke on a deployed or local Watch page for the Pilate download href.
+
+## Scope Boundaries
+
+In scope:
+
+- Watch download target resolution.
+- Same-origin download API status behavior and diagnostics.
+- Regression tests for opaque download hrefs and resolver target matching.
+- Deployment smoke criteria for the Pilate page.
+
+Out of scope:
+
+- Changing the Download modal UI, Terms of Use flow, or account gate.
+- Exposing raw CDN download URLs to the client.
+- Changing SSRF allowlist, DNS pre-flight, or upstream streaming behavior.
+- Changing Admin schema or regenerating `packages/admin-graphql` types unless
+  the existing `videoDub(id:)` operation is unexpectedly unavailable to web.
+- Fixing unrelated Watch collection routing, share links, SEO metadata, or page
+  render performance issues.
+
+## Risks and Mitigations
+
+- Risk: `videoDub.slug` format could drift from the expected
+  `<videoSlug>/<languageSlug>` shape.
+  Mitigation: encode the normalized slug check in tests. If the shape is not
+  stable enough, add a narrow Admin resolver field that returns the parent video
+  slug instead of weakening the validation.
+- Risk: some historic Dubs may have download rows but `downloadable === false`.
+  Mitigation: keep the safer server-side interpretation in the first pass and
+  surface any live-data exception as a data or product decision.
+- Risk: changing the GraphQL operation could require generated type updates.
+  Mitigation: `videoDub` and `downloadable` already exist in the committed
+  Admin introspection; implementation should typecheck before considering any
+  schema or package regeneration.
+- Risk: diagnostics could accidentally log upstream targets.
+  Mitigation: keep logging at the resolver decision level and test that raw
+  URLs do not appear in unavailable-path logs.
+
+## Acceptance Examples
+
+- AE1. Given the Pilate page's rendered `downloadId`, `variantId`, and
+  `videoSlug`, when `/watch/api/download` resolves the target, then Admin is
+  queried for one `videoDub(id:)`, the matching download URL is returned to the
+  proxy internals, and the response can satisfy a one-byte range request.
+- AE2. Given a valid `variantId` from a different video with the Pilate
+  `videoSlug`, when the resolver checks the target, then it returns
+  `not-found` and the route does not stream any upstream media.
+- AE3. Given Admin rejects the `videoDub(id:)` query, when the route handles the
+  lookup result, then it returns `503` and records a sanitized lookup failure
+  without logging the raw CDN URL.
+
+## Roadmap Note
+
+This plan tracks
+`docs/roadmap/platform/feat-186-watch-download-target-lookup.md`, a follow-up
+hardening slice for the completed primary-action semantics work in
+`docs/roadmap/platform/feat-179-watch-primary-action-semantics.md`.

--- a/docs/roadmap/platform/feat-186-watch-download-target-lookup.md
+++ b/docs/roadmap/platform/feat-186-watch-download-target-lookup.md
@@ -1,0 +1,103 @@
+---
+id: "feat-186"
+title: "Watch download target lookup hardening"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-12"
+completed_date: "2026-06-12"
+duration: 1
+depends_on:
+  - "feat-179"
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "download"
+  - "reliability"
+  - "performance"
+---
+
+## Problem
+
+QA reported a `503` when selecting `Download` on the Pilate Watch page. The
+current production endpoint did not reproduce the failure during follow-up
+checks, but the lookup path before streaming is expensive and brittle: Web
+resolves one download click by querying `videoBySlug` and projecting every Dub
+and download row for the video. For Pilate, that means thousands of Dubs and
+downloads before the proxy can stream one selected MP4.
+
+The same target can be resolved through the existing public `videoDub(id:)`
+query, which fetches one Dub and its downloads. Narrowing this path should
+reduce intermittent `503` risk without changing the rendered Download CTA, the
+same-origin proxy, the account gate, or SSRF defenses.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-12-005-fix-watch-download-target-lookup-plan.md` -
+   implementation plan for this hardening slice.
+2. `apps/web/src/lib/download-target.ts` - current server-side lookup by
+   `videoBySlug`.
+3. `apps/web/src/app/api/download/route.ts` - same-origin proxy and status
+   mapping for resolver failures.
+4. `apps/web/src/components/watch/WatchPageClient.tsx` - rendered opaque
+   Download href.
+5. `apps/web/src/components/watch/__tests__/WatchPageClient.download.test.tsx`
+   - rendered href regression surface.
+6. `docs/solutions/design-patterns/lean-bulk-lazy-per-item-graphql-fetch-20260604.md`
+   - existing per-Dub lazy fetch pattern.
+7. `docs/solutions/security-issues/ssrf-defense-streaming-proxy-and-codeql-fp-20260504.md`
+   - streaming proxy security boundary.
+
+## Grep These
+
+- `resolveWatchDownloadTarget`
+- `getWatchDownloadTargetOperation`
+- `videoBySlug(slug: $videoSlug)`
+- `videoDub(id:`
+- `buildDownloadProxyUrl`
+- `Download lookup unavailable`
+- `downloadId`
+- `variantId`
+
+## What To Build
+
+1. Change the Web download target resolver to query `videoDub(id:)` by
+   `variantId` instead of loading every Dub through `videoBySlug`.
+2. Preserve the opaque `downloadId`, `variantId`, and `videoSlug` binding by
+   validating that the returned Dub is published, downloadable, belongs to the
+   requested video slug, and contains the requested download.
+3. Keep route status behavior stable: missing params `400`, mismatched target
+   `404`, Admin lookup failure or empty upstream URL `503`.
+4. Add sanitized diagnostics for lookup failures without logging raw CDN URLs.
+5. Add focused resolver, route, and rendered-href regressions, including a
+   Pilate-shaped default Download href fixture.
+6. Retest with a `HEAD` and one-byte range request against the rendered
+   same-origin Download href.
+
+## Constraints
+
+- Do not expose raw CDN download URLs in client-rendered markup.
+- Do not bypass the existing Download modal, Terms of Use flow, or account
+  gate for normal hydrated clicks.
+- Do not change the `/watch/api/download` same-origin route shape.
+- Do not weaken SSRF allowlist, DNS pre-flight, redirect, timeout, or bounded
+  header behavior.
+- Do not change Admin schema unless the existing `videoDub(id:)` field proves
+  unusable for Web.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/lib/download-target.test.ts`
+- `pnpm --filter @forge/web test -- src/app/api/download/route.test.ts src/app/api/download/route.auth.test.ts`
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/WatchPageClient.download.test.tsx`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Helium smoke on the Pilate Watch page confirms the rendered Download href is
+  same-origin and returns a successful one-byte range response.
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-12-005-fix-watch-download-target-lookup-plan.md`


### PR DESCRIPTION
## Summary
- resolve Watch download targets with the existing id-scoped `videoDub(id:)` query instead of loading all video Dubs via `videoBySlug`
- preserve opaque `downloadId`/`variantId`/`videoSlug` binding, published/downloadable checks, and same-origin proxy behavior
- add resolver, route, and Pilate-shaped rendered href regressions plus CE plan/roadmap tracking docs

## Validation
- `pnpm --filter @forge/web test -- src/lib/download-target.test.ts src/app/api/download/route.test.ts src/app/api/download/route.auth.test.ts src/components/watch/__tests__/WatchPageClient.download.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- Local smoke on `http://127.0.0.1:3010/watch/jesus-is-brought-to-pilate.html/english.html`: Download rendered as same-origin `/watch/api/download?...`, no raw Mux URL; `HEAD` returned `200` with `content-length: 92077179`; `Range: bytes=0-0` returned `206` with `content-disposition: attachment; filename="jesus-is-brought-to-pilate-highest.mp4"`

## Review
- LFG code-review pass applied one cleanup: restore console spies in `download-target.test.ts`
- Actionable findings remaining: none
