### PR TITLE
Add Smart Crop video search

### DIFF
--- a/apps/manager/src/app/api/smart-crop/videos/[coreId]/route.test.ts
+++ b/apps/manager/src/app/api/smart-crop/videos/[coreId]/route.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { authenticateRequestMock, getCmsGatewayMock, lookupVideosMock } =
+  vi.hoisted(() => ({
+    authenticateRequestMock: vi.fn(),
+    getCmsGatewayMock: vi.fn(),
+    lookupVideosMock: vi.fn(),
+  }))
+
+vi.mock("@/lib/auth", () => ({
+  authenticateRequest: authenticateRequestMock,
+}))
+
+vi.mock("@/lib/admin-video-lookup", () => ({
+  lookupVideosByCoreIdFromAdmin: lookupVideosMock,
+}))
+
+vi.mock("@/cms/gateway", () => ({
+  getCmsGateway: getCmsGatewayMock,
+}))
+
+const { GET } = await import("@/app/api/smart-crop/videos/[coreId]/route")
+
+function adminVideo(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "video-1",
+    coreId: "1_jf-0-0",
+    label: "JESUS",
+    primaryLanguageBcp47: "en",
+    muxAssetId: "mux-1",
+    subtitleUrl: null,
+    ...overrides,
+  }
+}
+
+function getRequest(): Request {
+  return new Request("http://example.test/api/smart-crop/videos/1_jf-0-0")
+}
+
+const routeParams = { params: Promise.resolve({ coreId: "1_jf-0-0" }) }
+
+beforeEach(() => {
+  authenticateRequestMock.mockReset()
+  getCmsGatewayMock.mockReset()
+  lookupVideosMock.mockReset()
+
+  authenticateRequestMock.mockResolvedValue(null)
+  getCmsGatewayMock.mockImplementation(() => {
+    throw new Error("mock gateway not configured")
+  })
+  lookupVideosMock.mockResolvedValue({
+    ok: true,
+    data: new Map([["1_jf-0-0", adminVideo()]]),
+  })
+})
+
+describe("GET /api/smart-crop/videos/[coreId]", () => {
+  it("rejects unauthorized callers", async () => {
+    authenticateRequestMock.mockResolvedValue(
+      Response.json({ error: "Authentication required" }, { status: 401 }),
+    )
+
+    const response = await GET(getRequest(), routeParams)
+    expect(response.status).toBe(401)
+  })
+
+  it("rejects malformed coreIds before any lookup", async () => {
+    const response = await GET(getRequest(), {
+      params: Promise.resolve({ coreId: "core%2F..%2Fevil" }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(lookupVideosMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 404 video_not_found for unknown coreIds", async () => {
+    lookupVideosMock.mockResolvedValue({ ok: true, data: new Map() })
+
+    const response = await GET(getRequest(), routeParams)
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toMatchObject({
+      reason: "video_not_found",
+    })
+  })
+
+  it("maps lookup config_missing to 503 and transport failures to 502", async () => {
+    lookupVideosMock.mockResolvedValue({
+      ok: false,
+      reason: "config_missing",
+      messages: ["ADMIN_GRAPHQL_URL unset"],
+      retryable: false,
+    })
+    expect((await GET(getRequest(), routeParams)).status).toBe(503)
+
+    lookupVideosMock.mockResolvedValue({
+      ok: false,
+      reason: "network_error",
+      messages: ["timeout"],
+      retryable: true,
+    })
+    const unreachable = await GET(getRequest(), routeParams)
+    expect(unreachable.status).toBe(502)
+    await expect(unreachable.json()).resolves.toMatchObject({
+      reason: "admin_unreachable",
+    })
+  })
+
+  it("returns ineligible missing_mux_asset without requiring manual entry", async () => {
+    lookupVideosMock.mockResolvedValue({
+      ok: true,
+      data: new Map([["1_jf-0-0", adminVideo({ muxAssetId: null })]]),
+    })
+
+    const response = await GET(getRequest(), routeParams)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      coreId: "1_jf-0-0",
+      title: "JESUS",
+      muxAssetId: null,
+      eligible: false,
+      reason: "missing_mux_asset",
+    })
+  })
+
+  it("uses mock Manager state when admin lookup is unconfigured in mock mode", async () => {
+    lookupVideosMock.mockResolvedValue({
+      ok: false,
+      reason: "config_missing",
+      messages: ["ADMIN_GRAPHQL_URL unset"],
+      retryable: false,
+    })
+    getCmsGatewayMock.mockReturnValue({
+      mode: "mock",
+      readMockState: vi.fn(async () => ({
+        readModels: {
+          videoCoverage: [
+            {
+              documentId: "video-doc-standalone-1",
+              coreId: "1_jf-0-0",
+              title: "A New Beginning",
+              slug: "a-new-beginning",
+            },
+          ],
+          jobs: [
+            {
+              videoDocumentId: "video-doc-standalone-1",
+              muxAssetId: "mock_asset_2",
+            },
+          ],
+        },
+      })),
+    })
+
+    const response = await GET(getRequest(), routeParams)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      coreId: "1_jf-0-0",
+      title: "A New Beginning",
+      muxAssetId: "mock_asset_2",
+      eligible: true,
+      reason: null,
+    })
+  })
+
+  it("does not fill invalid admin Mux asset IDs", async () => {
+    lookupVideosMock.mockResolvedValue({
+      ok: true,
+      data: new Map([["1_jf-0-0", adminVideo({ muxAssetId: "mux/evil" })]]),
+    })
+
+    const response = await GET(getRequest(), routeParams)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      coreId: "1_jf-0-0",
+      title: "JESUS",
+      muxAssetId: null,
+      eligible: false,
+      reason: "invalid_mux_asset",
+    })
+  })
+
+  it("returns an eligible Mux asset resolution", async () => {
+    const response = await GET(getRequest(), routeParams)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      coreId: "1_jf-0-0",
+      title: "JESUS",
+      muxAssetId: "mux-1",
+      eligible: true,
+      reason: null,
+    })
+  })
+})

--- a/apps/manager/src/app/api/smart-crop/videos/[coreId]/route.ts
+++ b/apps/manager/src/app/api/smart-crop/videos/[coreId]/route.ts
@@ -1,0 +1,163 @@
+// GET /api/smart-crop/videos/[coreId] - resolve an admin video selected from
+// the Smart Crop picker to the source Mux asset ID. Unlike Shorts Studio, Smart
+// Crop keeps playback resolution in the create-job route and does not impose a
+// public-playback-only gate here.
+
+import { NextResponse } from "next/server"
+import { authenticateRequest } from "@/lib/auth"
+
+const CORE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/
+const ASSET_ID_PATTERN = /^[a-zA-Z0-9_-]+$/
+
+export type SmartCropVideoIneligibilityReason =
+  | "missing_mux_asset"
+  | "invalid_mux_asset"
+
+export type SmartCropVideoResolution = {
+  coreId: string
+  title: string | null
+  muxAssetId: string | null
+  eligible: boolean
+  reason: SmartCropVideoIneligibilityReason | null
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ coreId: string }> },
+) {
+  const authError = await authenticateRequest(request)
+  if (authError) return authError
+
+  const { coreId: rawCoreId } = await params
+  const coreId = decodeURIComponent(rawCoreId)
+  if (!CORE_ID_PATTERN.test(coreId)) {
+    return NextResponse.json(
+      {
+        error:
+          "coreId must contain only alphanumeric characters, hyphens, and underscores",
+      },
+      { status: 400 },
+    )
+  }
+
+  const { lookupVideosByCoreIdFromAdmin } =
+    await import("@/lib/admin-video-lookup")
+  const envelope = await lookupVideosByCoreIdFromAdmin([coreId])
+  if (!envelope.ok) {
+    if (envelope.reason === "config_missing") {
+      const mockResponse = await resolveMockVideo(coreId)
+      if (mockResponse) return mockResponse
+    }
+
+    const status = envelope.reason === "config_missing" ? 503 : 502
+    return NextResponse.json(
+      {
+        error: "admin video lookup failed",
+        reason:
+          envelope.reason === "config_missing"
+            ? "config_missing"
+            : "admin_unreachable",
+        upstreamReason: envelope.reason,
+        messages: envelope.messages,
+        retryable: envelope.retryable,
+      },
+      { status },
+    )
+  }
+
+  const video = envelope.data.get(coreId)
+  if (!video) {
+    return NextResponse.json(
+      {
+        error: `No admin video found for coreId ${coreId}`,
+        reason: "video_not_found",
+      },
+      { status: 404 },
+    )
+  }
+
+  if (!video.muxAssetId) {
+    return NextResponse.json({
+      coreId,
+      title: video.label,
+      muxAssetId: null,
+      eligible: false,
+      reason: "missing_mux_asset",
+    } satisfies SmartCropVideoResolution)
+  }
+
+  if (!ASSET_ID_PATTERN.test(video.muxAssetId)) {
+    return NextResponse.json({
+      coreId,
+      title: video.label,
+      muxAssetId: null,
+      eligible: false,
+      reason: "invalid_mux_asset",
+    } satisfies SmartCropVideoResolution)
+  }
+
+  return NextResponse.json({
+    coreId,
+    title: video.label,
+    muxAssetId: video.muxAssetId,
+    eligible: true,
+    reason: null,
+  } satisfies SmartCropVideoResolution)
+}
+
+async function resolveMockVideo(coreId: string): Promise<NextResponse | null> {
+  try {
+    const { getCmsGateway } = await import("@/cms/gateway")
+    const gateway = getCmsGateway()
+    if (gateway.mode !== "mock" || !gateway.readMockState) {
+      return null
+    }
+
+    const state = await gateway.readMockState()
+    const video = state.readModels.videoCoverage.find(
+      (candidate) => candidate.coreId === coreId,
+    )
+    if (!video) {
+      return NextResponse.json(
+        {
+          error: `No mock video found for coreId ${coreId}`,
+          reason: "video_not_found",
+        },
+        { status: 404 },
+      )
+    }
+
+    const job = state.readModels.jobs.find(
+      (candidate) => candidate.videoDocumentId === video.documentId,
+    )
+    if (!job?.muxAssetId) {
+      return NextResponse.json({
+        coreId,
+        title: video.title ?? video.slug,
+        muxAssetId: null,
+        eligible: false,
+        reason: "missing_mux_asset",
+      } satisfies SmartCropVideoResolution)
+    }
+
+    if (!ASSET_ID_PATTERN.test(job.muxAssetId)) {
+      return NextResponse.json({
+        coreId,
+        title: video.title ?? video.slug,
+        muxAssetId: null,
+        eligible: false,
+        reason: "invalid_mux_asset",
+      } satisfies SmartCropVideoResolution)
+    }
+
+    return NextResponse.json({
+      coreId,
+      title: video.title ?? video.slug,
+      muxAssetId: job.muxAssetId,
+      eligible: true,
+      reason: null,
+    } satisfies SmartCropVideoResolution)
+  } catch {
+    return null
+  }
+}

--- a/apps/manager/src/app/api/videos/route.mock.test.ts
+++ b/apps/manager/src/app/api/videos/route.mock.test.ts
@@ -51,11 +51,30 @@ describe("GET /api/videos in mock mode", () => {
     await expect(response.json()).resolves.toMatchObject({
       collections: [
         {
+          coreId: "collection-1",
+          slug: "hope-stories",
           title: "Hope Stories",
-          videos: [{ title: "Episode 1" }, { title: "Episode 2" }],
+          videos: [
+            {
+              coreId: "ep-1",
+              slug: "hope-stories-episode-1",
+              title: "Episode 1",
+            },
+            {
+              coreId: "ep-2",
+              slug: "hope-stories-episode-2",
+              title: "Episode 2",
+            },
+          ],
         },
       ],
-      standalone: [{ title: "A New Beginning" }],
+      standalone: [
+        {
+          coreId: "standalone-1",
+          slug: "a-new-beginning",
+          title: "A New Beginning",
+        },
+      ],
     })
   })
 
@@ -120,7 +139,7 @@ describe("GET /api/videos in mock mode", () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toMatchObject({
-      standalone: [{ title: "stable-video-slug" }],
+      standalone: [{ slug: "stable-video-slug", title: "stable-video-slug" }],
     })
   })
 })

--- a/apps/manager/src/app/api/videos/route.ts
+++ b/apps/manager/src/app/api/videos/route.ts
@@ -54,8 +54,10 @@ export async function GET(request: Request) {
     function toVideoItem(video: CmsVideoCoverage) {
       return {
         id: String(video.coreId ?? video.documentId),
+        coreId: video.coreId ?? null,
         title:
           video.title ?? video.slug ?? String(video.coreId ?? video.documentId),
+        slug: video.slug ?? null,
         imageUrl: video.imageUrl,
         label: video.label ?? "unknown",
         coverage: {
@@ -86,7 +88,9 @@ export async function GET(request: Request) {
 
     const collections: Array<{
       id: string
+      coreId: string | null
       title: string
+      slug: string | null
       imageUrl: string | null
       label: string
       labelDisplay: string
@@ -106,7 +110,9 @@ export async function GET(request: Request) {
 
       collections.push({
         id: parentItem.id,
+        coreId: parentItem.coreId,
         title: parentItem.title,
+        slug: parentItem.slug,
         imageUrl: parentItem.imageUrl,
         label: parentItem.label,
         labelDisplay:

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -13454,3 +13454,53 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
   object-fit: cover;
   background: var(--ds-line, #e7dfd2);
 }
+
+.smart-crop-video-search {
+  max-width: 520px;
+}
+
+.smart-crop-video-search-icon {
+  vertical-align: -1px;
+}
+
+.smart-crop-picker-results {
+  max-height: 280px;
+  overflow: auto;
+}
+
+.smart-crop-picker-results .jobs-table {
+  min-width: 680px;
+}
+
+.smart-crop-picker-row-issue {
+  opacity: 0.65;
+}
+
+.smart-crop-picker-video-button {
+  align-items: center;
+}
+
+.smart-crop-picker-thumb {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 48px;
+  height: 27px;
+  border-radius: 4px;
+  object-fit: cover;
+  background: var(--ds-line);
+}
+
+.smart-crop-picker-title {
+  display: grid;
+  gap: 2px;
+  justify-items: start;
+}
+
+.smart-crop-picker-slug {
+  overflow-wrap: anywhere;
+}
+
+.smart-crop-selected-video {
+  margin: 0;
+  overflow-wrap: anywhere;
+}

--- a/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
@@ -3,14 +3,16 @@
 // Smart Crop dashboard screen: two creation forms (canonical / localized) and
 // a polling jobs table. Plan 2026-06-09-002 "UI".
 
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
-import { Crop, Languages, RefreshCw } from "lucide-react"
+import { Crop, Languages, RefreshCw, Search } from "lucide-react"
 import { apiFetch } from "@/lib/api-fetch"
+import type { SmartCropVideoResolution } from "@/app/api/smart-crop/videos/[coreId]/route"
 import type { JobRecord, SmartCropCropMode } from "@/types/job"
 import { getSmartCropJobSummary } from "./smart-crop-presenter"
 
 const SMART_CROP_POLL_INTERVAL_MS = 5_000
+const VIDEO_PICKER_RESULT_LIMIT = 40
 
 const CROP_MODES: SmartCropCropMode[] = [
   "auto",
@@ -27,6 +29,67 @@ type RequestStatus =
 
 type SmartCropScreenProps = {
   initialJobs: JobRecord[]
+}
+
+type VideoPickerItem = {
+  id: string
+  coreId: string | null
+  title: string
+  slug: string | null
+  imageUrl: string | null
+  label: string
+}
+
+type VideosApiItem = VideoPickerItem
+
+type VideosApiResponse = {
+  collections: Array<VideosApiItem & { videos: VideosApiItem[] }>
+  standalone: VideosApiItem[]
+}
+
+function flattenVideoPickerItems(
+  payload: VideosApiResponse,
+): VideoPickerItem[] {
+  const byId = new Map<string, VideoPickerItem>()
+  const add = (item: VideosApiItem) => {
+    if (!byId.has(item.id)) {
+      byId.set(item.id, {
+        id: item.id,
+        coreId: item.coreId,
+        title: item.title,
+        slug: item.slug,
+        imageUrl: item.imageUrl,
+        label: item.label,
+      })
+    }
+  }
+
+  for (const collection of payload.collections ?? []) {
+    add(collection)
+    for (const video of collection.videos ?? []) {
+      add(video)
+    }
+  }
+  for (const video of payload.standalone ?? []) {
+    add(video)
+  }
+
+  return [...byId.values()].sort((left, right) =>
+    left.title.localeCompare(right.title),
+  )
+}
+
+function describeVideoResolutionIssue(
+  reason: SmartCropVideoResolution["reason"],
+): string {
+  switch (reason) {
+    case "missing_mux_asset":
+      return "No Mux asset"
+    case "invalid_mux_asset":
+      return "Invalid Mux asset"
+    default:
+      return "Cannot use this video"
+  }
 }
 
 function formatUpdatedAt(iso: string): string {
@@ -109,12 +172,120 @@ function FormStatus({ status }: { status: RequestStatus }) {
 }
 
 function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
+  const [videos, setVideos] = useState<VideoPickerItem[] | null>(null)
+  const [loadFailed, setLoadFailed] = useState(false)
+  const [query, setQuery] = useState("")
+  const [resolvingId, setResolvingId] = useState<string | null>(null)
+  const [rowIssues, setRowIssues] = useState<Record<string, string>>({})
+  const [selectedVideo, setSelectedVideo] = useState<{
+    coreId: string
+    title: string
+    slug: string | null
+    muxAssetId: string
+  } | null>(null)
   const [muxAssetId, setMuxAssetId] = useState("")
   const [assetId, setAssetId] = useState("")
   const [playbackId, setPlaybackId] = useState("")
   const [cropMode, setCropMode] = useState<SmartCropCropMode>("auto")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [status, setStatus] = useState<RequestStatus>({ type: "idle" })
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void (async () => {
+      try {
+        const response = await apiFetch("/api/videos", {
+          signal: controller.signal,
+        })
+        if (!response.ok) {
+          setLoadFailed(true)
+          return
+        }
+        const payload = (await response.json()) as VideosApiResponse
+        setVideos(flattenVideoPickerItems(payload))
+      } catch {
+        if (!controller.signal.aborted) setLoadFailed(true)
+      }
+    })()
+    return () => controller.abort()
+  }, [])
+
+  const filteredVideos = useMemo(() => {
+    if (!videos) return []
+    const needle = query.trim().toLowerCase()
+    if (needle.length === 0) return []
+
+    return videos
+      .filter((video) =>
+        [video.title, video.slug ?? "", video.coreId ?? "", video.id].some(
+          (value) => value.toLowerCase().includes(needle),
+        ),
+      )
+      .slice(0, VIDEO_PICKER_RESULT_LIMIT)
+  }, [query, videos])
+
+  const resolveVideo = useCallback(async (video: VideoPickerItem) => {
+    if (!video.coreId) {
+      setRowIssues((current) => ({
+        ...current,
+        [video.id]: "No Core ID",
+      }))
+      return
+    }
+
+    setResolvingId(video.id)
+    try {
+      const response = await apiFetch(
+        `/api/smart-crop/videos/${encodeURIComponent(video.coreId)}`,
+        { cache: "no-store" },
+      )
+      const payload = (await response.json().catch(() => ({}))) as
+        | SmartCropVideoResolution
+        | { error?: string; reason?: string }
+
+      if (!response.ok) {
+        const failure = payload as { error?: string; reason?: string }
+        setRowIssues((current) => ({
+          ...current,
+          [video.id]:
+            failure.error ??
+            `Could not resolve video (${failure.reason ?? response.status}).`,
+        }))
+        return
+      }
+
+      const resolution = payload as SmartCropVideoResolution
+      if (!resolution.eligible || !resolution.muxAssetId) {
+        setRowIssues((current) => ({
+          ...current,
+          [video.id]: describeVideoResolutionIssue(resolution.reason),
+        }))
+        return
+      }
+
+      setMuxAssetId(resolution.muxAssetId)
+      setSelectedVideo({
+        coreId: resolution.coreId,
+        title: video.title,
+        slug: video.slug,
+        muxAssetId: resolution.muxAssetId,
+      })
+      setQuery("")
+      setStatus({ type: "idle" })
+      setRowIssues((current) => {
+        const next = { ...current }
+        delete next[video.id]
+        return next
+      })
+    } catch {
+      setRowIssues((current) => ({
+        ...current,
+        [video.id]: "Could not resolve video",
+      }))
+    } finally {
+      setResolvingId(null)
+    }
+  }, [])
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -147,12 +318,129 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
       <div className="jobs-card-header">
         <h2 className="jobs-card-title">Canonical crop plan</h2>
       </div>
+      <label className="jobs-field smart-crop-video-search">
+        <div className="small jobs-field-label">
+          <Search
+            size={12}
+            aria-hidden="true"
+            className="smart-crop-video-search-icon"
+          />{" "}
+          Video search
+        </div>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="jobs-input"
+          placeholder="Title or slug"
+        />
+      </label>
+
+      {loadFailed ? (
+        <p className="jobs-error-text">Could not load the video library.</p>
+      ) : query.trim().length > 0 && videos === null ? (
+        <p className="small jobs-empty-state">Loading video library...</p>
+      ) : query.trim().length > 0 && filteredVideos.length === 0 ? (
+        <p className="small jobs-empty-state">
+          No videos match <span>{query.trim()}</span>.
+        </p>
+      ) : query.trim().length > 0 ? (
+        <div className="jobs-table-wrap smart-crop-picker-results">
+          <table className="table jobs-table">
+            <thead>
+              <tr>
+                <th>Video</th>
+                <th>Type</th>
+                <th>Core ID</th>
+                <th aria-label="Resolution" />
+              </tr>
+            </thead>
+            <tbody>
+              {filteredVideos.map((video) => {
+                const issue = rowIssues[video.id]
+                const isResolving = resolvingId === video.id
+                return (
+                  <tr
+                    key={video.id}
+                    className={
+                      issue ? "smart-crop-picker-row-issue" : undefined
+                    }
+                  >
+                    <td>
+                      <button
+                        type="button"
+                        className="jobs-step-artifact-link smart-crop-picker-video-button"
+                        disabled={resolvingId !== null}
+                        onClick={() => void resolveVideo(video)}
+                        title={issue ?? `Use ${video.title}`}
+                      >
+                        {video.imageUrl ? (
+                          // Keep admin-sourced URLs in an img src, not CSS.
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            className="smart-crop-picker-thumb"
+                            src={video.imageUrl}
+                            alt=""
+                            aria-hidden="true"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span
+                            className="smart-crop-picker-thumb"
+                            aria-hidden="true"
+                          />
+                        )}
+                        <span className="smart-crop-picker-title">
+                          <span className="jobs-step-artifact-label">
+                            {video.title}
+                          </span>
+                          {video.slug ? (
+                            <span className="small smart-crop-picker-slug">
+                              {video.slug}
+                            </span>
+                          ) : null}
+                        </span>
+                      </button>
+                    </td>
+                    <td>
+                      <span className="jobs-language-badge">{video.label}</span>
+                    </td>
+                    <td>{video.coreId ?? "n/a"}</td>
+                    <td>
+                      {isResolving ? (
+                        <RefreshCw
+                          className="icon is-spinning"
+                          aria-hidden="true"
+                          size={14}
+                        />
+                      ) : issue ? (
+                        <span className="jobs-error-text small">{issue}</span>
+                      ) : null}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {selectedVideo ? (
+        <p className="small smart-crop-selected-video">
+          Selected {selectedVideo.title}
+          {selectedVideo.slug ? ` / ${selectedVideo.slug}` : ""} /{" "}
+          {selectedVideo.muxAssetId}
+        </p>
+      ) : null}
+
       <div className="grid cols-2 jobs-form-grid">
         <label className="jobs-field">
           <div className="small jobs-field-label">Mux Asset ID</div>
           <input
             value={muxAssetId}
-            onChange={(e) => setMuxAssetId(e.target.value)}
+            onChange={(e) => {
+              setMuxAssetId(e.target.value)
+              setSelectedVideo(null)
+            }}
             required
             className="jobs-input"
           />

--- a/docs/plans/2026-06-13-001-feat-manager-smart-crop-video-search-plan.md
+++ b/docs/plans/2026-06-13-001-feat-manager-smart-crop-video-search-plan.md
@@ -1,0 +1,151 @@
+---
+title: "Manager Smart Crop video title and slug search"
+type: "feat"
+status: "completed"
+date: "2026-06-13"
+origin: "docs/roadmap/media-generation/feat-173-smart-crop-video-reframing.md"
+---
+
+# Manager Smart Crop video title and slug search
+
+## Summary
+
+Add a searchable source-video picker to the Smart Crop canonical crop plan form
+so operators can find a video by title or slug and fill the Mux asset ID without
+leaving Manager. Keep manual Mux asset entry as the escape hatch.
+
+## Problem Frame
+
+The Smart Crop canonical form currently requires operators to paste a raw Mux
+asset ID. That is correct for the job API but slow at the UI boundary, because
+operators usually know a video title or public slug first. Manager already has a
+video coverage read model and an admin video dispatch lookup used by Shorts
+Studio; Smart Crop should reuse those instead of adding a separate catalogue
+contract.
+
+## Requirements
+
+- R1. The canonical Smart Crop form lets an operator search videos by title or
+  slug.
+- R2. Selecting a search result resolves the admin video to the source Mux asset
+  ID and fills the existing `Mux Asset ID` field.
+- R3. Manual Mux asset entry continues to work when a video is not in the
+  catalogue or the lookup is unavailable.
+- R4. Search results expose enough identity to disambiguate similar titles:
+  title, slug, label/type, and core ID.
+- R5. Videos without an admin-resolved Mux asset surface an inline, per-row
+  reason and do not fill the canonical form.
+- R6. The Smart Crop job creation API contract stays unchanged:
+  `/api/smart-crop/jobs` still receives `kind`, `muxAssetId`, optional
+  `assetId`, optional `playbackId`, and `cropMode`.
+- R7. The implementation remains local to Manager UI/read-model code and does
+  not change Admin schema, generated GraphQL outputs, crop-worker, or Mastra.
+
+## Key Technical Decisions
+
+- Reuse `/api/videos` as the picker list source: This endpoint already
+  authenticates Manager callers and caches the Manager video coverage read
+  model. It needs to include `slug` and `coreId` in each item so clients can
+  search by slug and resolve by core ID.
+- Add a Smart Crop-specific resolution route: A new
+  `GET /api/smart-crop/videos/{coreId}` should call
+  `lookupVideosByCoreIdFromAdmin` and return `muxAssetId` eligibility. Reusing
+  `/api/shorts/videos/{coreId}` would couple Smart Crop to Shorts' public
+  playback restriction and duration logic.
+- Keep playback resolution in the existing Smart Crop create route: The
+  canonical form only needs to fill `muxAssetId`. The create route already calls
+  `getMuxAsset` when `playbackId` is absent, preserving today's validation and
+  error behavior.
+- Use client-side filtering for the first slice: `/api/videos` is already a
+  bounded, cached dashboard list. Client-side title/slug/core-ID filtering
+  matches the Shorts picker precedent and avoids a new query shape.
+
+## Implementation Units
+
+### U1. Extend the Manager video list response
+
+- **Goal:** Return stable searchable identity from `/api/videos` without
+  breaking existing consumers.
+- **Files:** `apps/manager/src/app/api/videos/route.ts`,
+  `apps/manager/src/app/api/videos/route.mock.test.ts`,
+  `apps/manager/src/features/shorts/shorts-create-screen.tsx`.
+- **Patterns:** Follow the current `toVideoItem` mapper in
+  `apps/manager/src/app/api/videos/route.ts` and keep extra fields additive.
+- **Test Scenarios:** `/api/videos` includes `slug` and `coreId` for collection,
+  child, and standalone rows; slug fallback for title still works; Shorts picker
+  continues to compile against the additive response.
+
+### U2. Add Smart Crop video resolution API
+
+- **Goal:** Resolve a selected core ID to the source Mux asset ID using the
+  existing admin lookup envelope.
+- **Files:** `apps/manager/src/app/api/smart-crop/videos/[coreId]/route.ts`,
+  `apps/manager/src/app/api/smart-crop/videos/[coreId]/route.test.ts`.
+- **Patterns:** Mirror auth, core ID shape validation, admin lookup error
+  mapping, and `missing_mux_asset` handling from
+  `apps/manager/src/app/api/shorts/videos/[coreId]/route.ts`, but omit Shorts
+  duration/public-playback checks.
+- **Test Scenarios:** Unauthorized callers are rejected; malformed core IDs are
+  rejected before admin lookup; missing videos return `video_not_found`; admin
+  config/network failures map to 503/502; videos without Mux assets return an
+  ineligible resolution; videos with Mux assets return an eligible resolution.
+
+### U3. Add the canonical-form search picker
+
+- **Goal:** Let operators search and select videos while preserving raw Mux ID
+  entry.
+- **Files:** `apps/manager/src/features/smart-crop/smart-crop-screen.tsx`,
+  `apps/manager/src/app/globals.css`.
+- **Patterns:** Reuse the Shorts picker flow in
+  `apps/manager/src/features/shorts/shorts-create-screen.tsx`: load
+  `/api/videos`, flatten collections plus standalone rows, filter client-side,
+  keep per-row resolution issues, and use existing table/button styles.
+- **Test Scenarios:** Search matches by title and slug; selecting an eligible
+  result fills `Mux Asset ID`; ineligible or failed rows show a row-level reason;
+  manual Mux ID editing remains possible and keeps the submit button behavior
+  tied to the field value.
+
+## Acceptance Examples
+
+- AE1. Given the canonical form has loaded the video library, when an operator
+  searches `a-new-beginning`, then the standalone video with that slug appears
+  and can be selected.
+- AE2. Given a selected video resolves to `mux-1`, when the operator clicks the
+  row, then `Mux Asset ID` becomes `mux-1` and the canonical job button enables.
+- AE3. Given admin returns a video with no Mux asset, when the operator selects
+  it, then the row shows a missing-Mux reason and the existing Mux field is not
+  overwritten.
+- AE4. Given the library search fails, when the operator knows the Mux ID, then
+  they can still type it directly and start the canonical job.
+
+## Scope Boundaries
+
+- No localized-job picker in this slice. The user pointed at the canonical crop
+  plan form, and localized jobs need different identity: localized Mux asset,
+  approved canonical asset, and language.
+- No Smart Crop job API shape change. This is a UI lookup improvement above the
+  existing create route.
+- No Admin schema or generated `packages/admin-graphql` changes.
+- No server-side search endpoint until the cached coverage payload becomes too
+  large for the dashboard.
+
+## Verification
+
+- `pnpm --filter @forge/manager test -- src/app/api/videos/route.mock.test.ts src/app/api/smart-crop/videos/[coreId]/route.test.ts`
+- `pnpm --filter @forge/manager test -- src/features/smart-crop/smart-crop-presenter.test.ts`
+- `pnpm --filter @forge/manager typecheck`
+- Browser smoke with Helium/agent-browser against `/dashboard/smart-crop` in
+  mock mode: search a seeded slug, select it, confirm the Mux field fills, and
+  confirm manual entry still works.
+
+## Sources
+
+- `docs/roadmap/media-generation/feat-173-smart-crop-video-reframing.md`
+- `docs/plans/2026-06-09-002-feat-smart-crop-plan.md`
+- `apps/manager/AGENTS.md`
+- `apps/manager/CLAUDE.md`
+- `apps/manager/src/features/smart-crop/smart-crop-screen.tsx`
+- `apps/manager/src/features/shorts/shorts-create-screen.tsx`
+- `apps/manager/src/app/api/videos/route.ts`
+- `apps/manager/src/app/api/shorts/videos/[coreId]/route.ts`
+- `apps/manager/src/lib/admin-video-lookup.ts`


### PR DESCRIPTION
## Summary

- Add Smart Crop canonical video search by title, slug, core ID, or item ID using the existing Manager video list.
- Add `GET /api/smart-crop/videos/[coreId]` to resolve a selected video to its source Mux asset ID without changing the Smart Crop job API.
- Preserve manual Mux Asset ID entry and show row-level resolution issues for videos that cannot be used.

## Validation

- `pnpm --filter @forge/manager test -- src/app/api/videos/route.mock.test.ts 'src/app/api/smart-crop/videos/[coreId]/route.test.ts' src/features/smart-crop/smart-crop-presenter.test.ts`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager typecheck`
- `git diff --check`
- Browser smoke with `agent-browser` against Manager mock mode: searched `a-new-beginning`, resolved `/api/smart-crop/videos/standalone-1`, filled `mock_asset_2`, and verified manual Mux entry remains editable.

## Notes

- `pnpm --filter @forge/manager build` was attempted with mock env values but stayed silent in `next build` optimization for about two minutes, so I stopped that optional check; no tracked files were left behind.
