### PR TITLE
Fix Manager coverage thumbnail URLs

### DIFF
--- a/apps/admin/src/services/manager-read-model.service.test.ts
+++ b/apps/admin/src/services/manager-read-model.service.test.ts
@@ -186,6 +186,79 @@ describe("ManagerReadModelService", () => {
     })
   })
 
+  it("normalizes coverage image URLs for Manager browser thumbnails", async () => {
+    prisma.video.findMany.mockResolvedValueOnce([
+      {
+        id: "video-cloudflare-bare",
+        coreId: "core-cloudflare-bare",
+        slug: "cloudflare-bare",
+        label: "EPISODE",
+        aiMetadata: false,
+        locales: [],
+        images: [
+          {
+            url: "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/0ec667e3-7f67-4158-f2cb-054e665e4800",
+          },
+        ],
+        parents: [],
+      },
+      {
+        id: "video-cloudflare-variant",
+        coreId: "core-cloudflare-variant",
+        slug: "cloudflare-variant",
+        label: "EPISODE",
+        aiMetadata: false,
+        locales: [],
+        images: [
+          {
+            url: "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/poster.videoStill.jpg/public",
+          },
+        ],
+        parents: [],
+      },
+      {
+        id: "video-other-host",
+        coreId: "core-other-host",
+        slug: "other-host",
+        label: "EPISODE",
+        aiMetadata: false,
+        locales: [],
+        images: [{ url: " https://images.example.com/neon.jpg " }],
+        parents: [],
+      },
+      {
+        id: "video-blank",
+        coreId: "core-blank",
+        slug: "blank",
+        label: "EPISODE",
+        aiMetadata: false,
+        locales: [],
+        images: [{ url: "   " }],
+        parents: [],
+      },
+    ])
+    prisma.videoSubtitle.groupBy.mockResolvedValueOnce([])
+    prisma.videoDub.groupBy.mockResolvedValueOnce([])
+
+    const result = await service.getVideoCoverage({
+      user: MANAGER_BACKEND_PRINCIPAL,
+    })
+
+    const imageUrlsById = new Map(
+      result.map((video) => [video.documentId, video.imageUrl]),
+    )
+    expect(imageUrlsById.get("video-cloudflare-bare")).toBe(
+      "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/0ec667e3-7f67-4158-f2cb-054e665e4800/public",
+    )
+    expect(imageUrlsById.get("video-cloudflare-variant")).toBe(
+      "https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/poster.videoStill.jpg/public",
+    )
+    expect(imageUrlsById.get("video-other-host")).toBe(
+      "https://images.example.com/neon.jpg",
+    )
+    expect(imageUrlsById.get("video-blank")).toBeNull()
+  })
+
   it("builds enrichment video metadata from selected Admin or Core IDs", async () => {
     prisma.video.findMany.mockResolvedValueOnce([
       {

--- a/apps/admin/src/services/manager-read-model.service.ts
+++ b/apps/admin/src/services/manager-read-model.service.ts
@@ -87,6 +87,7 @@ type VideoTitleLocale = {
 }
 
 const MANAGER_ENRICHMENT_VIDEO_MAX_IDS = 100
+const CLOUDFLARE_IMAGE_DELIVERY_HOST = "imagedelivery.net"
 
 function assertManagerReadAccess(user: Principal | null) {
   if (!hasPermission(user, "read:manager-read-models")) {
@@ -136,6 +137,26 @@ function countsForVideo(
   videoId: string,
 ): ManagerCoverageCounts {
   return countsByVideoId.get(videoId) ?? { human: 0, ai: 0 }
+}
+
+function normalizeManagerVideoImageUrl(
+  value: string | null | undefined,
+): string | null {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  try {
+    const url = new URL(trimmed)
+    if (url.hostname !== CLOUDFLARE_IMAGE_DELIVERY_HOST) return trimmed
+
+    const pathParts = url.pathname.split("/").filter(Boolean)
+    if (pathParts.length === 2) {
+      url.pathname = `${url.pathname.replace(/\/+$/, "")}/public`
+    }
+    return url.toString()
+  } catch {
+    return trimmed
+  }
 }
 
 function titleFrom(
@@ -425,7 +446,7 @@ export class ManagerReadModelService {
       label: video.label ?? null,
       slug: video.slug ?? null,
       aiMetadata: video.aiMetadata ?? null,
-      imageUrl: video.images[0]?.url ?? null,
+      imageUrl: normalizeManagerVideoImageUrl(video.images[0]?.url),
       parentDocumentIds: video.parents.map((parent) => parent.parentId),
       coverage: {
         subtitles: countsForVideo(subtitleCountsByVideoId, video.id),

--- a/docs/plans/2026-06-13-002-fix-manager-coverage-thumbnail-url-plan.md
+++ b/docs/plans/2026-06-13-002-fix-manager-coverage-thumbnail-url-plan.md
@@ -1,0 +1,104 @@
+---
+title: "Fix Manager coverage thumbnail URLs"
+type: fix
+status: completed
+date: 2026-06-13
+origin: docs/roadmap/platform/feat-187-manager-coverage-thumbnail-url-normalization.md
+---
+
+# Fix Manager Coverage Thumbnail URLs
+
+## Summary
+
+Restore Manager Coverage hover/detail thumbnails by normalizing Admin-provided
+video image URLs before they cross the Manager read-model boundary. The UI
+already renders `imageUrl` in the hover panel, selected stack, and flyer
+animation; the issue is that some Admin image rows contain bare Cloudflare Image
+Delivery URLs without a variant suffix.
+
+## Problem Frame
+
+The visible symptom is a broken image icon and alt text inside the Coverage
+hover panel for episode rows. Admin dashboard code already uses
+`normalizeVideoThumbnailUrl()` to append `/public` to bare
+`imagedelivery.net/<account>/<image-id>` URLs, but
+`ManagerReadModelService.getVideoCoverage()` currently returns
+`video.images[0]?.url` directly.
+
+## Requirements
+
+- Manager coverage payloads expose browser-loadable thumbnail URLs.
+- Bare Cloudflare Image Delivery URLs gain `/public`.
+- Already-variant Cloudflare URLs and other absolute URLs stay unchanged.
+- Missing or blank image values stay `null`.
+- No GraphQL schema, generated type, or Manager UI payload shape changes.
+
+## Scope Boundaries
+
+In scope:
+
+- Admin Manager read-model `imageUrl` behavior.
+- Focused Admin service regression coverage.
+- Manager Coverage browser smoke when local auth/mock setup allows it.
+
+Out of scope:
+
+- Coverage layout redesign.
+- Coverage count aggregation changes.
+- Manager-side fallback image generation.
+- Core sync image ingestion changes.
+
+## Implementation Units
+
+### 1. Normalize Read-Model Image URLs
+
+Touch:
+
+- `apps/admin/src/services/manager-read-model.service.ts`
+- `apps/admin/src/services/manager-read-model.service.test.ts`
+
+Add or reuse a small normalization helper in the Admin service layer that
+matches the existing dashboard behavior: trim, return `null` for blanks, append
+`/public` only for bare `imagedelivery.net` paths with two path parts, and
+leave all other URLs untouched. Apply it when building
+`ManagerVideoCoverage.imageUrl`.
+
+Tests:
+
+- A bare Cloudflare URL becomes `.../public`.
+- A URL with an existing variant remains unchanged.
+- A non-Cloudflare URL remains unchanged.
+- A blank image URL becomes `null`.
+
+## Verification Plan
+
+Run:
+
+- `pnpm --filter @forge/admin test -- --run src/services/manager-read-model.service.test.ts`
+- `pnpm --filter @forge/admin typecheck`
+
+Then run Manager locally and use Helium/browser smoke on
+`/dashboard/coverage?languageId=529`: hover an episode tile or row and verify
+the preview panel image loads instead of showing broken alt text. If local auth
+or mock image hosts block visual proof, record the blocker and rely on the
+service regression plus generated payload inspection.
+
+Completed verification:
+
+- `pnpm --filter @forge/admin test -- --run src/services/manager-read-model.service.test.ts`
+- `pnpm --filter @forge/admin exec eslint src/services/manager-read-model.service.ts src/services/manager-read-model.service.test.ts`
+- `pnpm --filter @forge/admin typecheck`
+- Helium/`agent-browser` local smoke loaded Manager Coverage at
+  `http://localhost:3002/dashboard/coverage?languageId=529`, hovered an
+  episode tile, and confirmed the hover panel renders the API-provided
+  thumbnail element. The default mock image host returns a broken demo asset
+  (`https://images.jesusfilm.org/mock/episode-1.jpg`), so image loading itself
+  is covered by the Admin read-model URL normalization regression.
+
+## Risks And Defaults
+
+- Keep the normalization server-side so all Manager consumers benefit from the
+  same fixed read model.
+- Avoid importing from `apps/admin/src/app/dashboard/video-library-utils.ts`
+  unless it is already an accepted service dependency; a tiny service-local
+  helper is safer than coupling a read model to dashboard route utilities.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (June 4, 2026)
 
-- **Total tickets:** 190
-- **Complete:** 115
+- **Total tickets:** 191
+- **Complete:** 116
 - **In progress:** 9
 - **Not started:** 21
 - **Blocked:** 43
@@ -180,6 +180,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-166](platform/feat-166-manager-coverage-region-image-assets.md)            | Manager coverage region image assets                         | vlad      | P1       | 2026-06-05 | 1    | 2026-06-05 | complete    |
 | [feat-167](platform/feat-167-manager-coverage-video-aggregation.md)              | Manager coverage video aggregation                           | vlad      | P1       | 2026-06-05 | 1    | 2026-06-05 | complete    |
 | [feat-168](platform/feat-168-manager-coverage-title-locale-preference.md)        | Manager coverage title locale preference                     | vlad      | P1       | 2026-06-05 | 1    | 2026-06-05 | complete    |
+| [feat-187](platform/feat-187-manager-coverage-thumbnail-url-normalization.md)    | Manager coverage thumbnail URL normalization                 | vlad      | P1       | 2026-06-13 | 1    | 2026-06-13 | complete    |
 | [feat-169](platform/feat-169-watch-language-picker-search-ranking.md)            | Watch language picker search ranking                         | vlad      | P1       | 2026-06-10 | 1    | 2026-06-10 | complete    |
 | [feat-175](platform/feat-175-watch-cold-path-performance-follow-up.md)           | Watch cold-path performance follow-up                        | vlad      | P1       | 2026-06-10 | 1    | 2026-06-10 | complete    |
 | [feat-176](platform/feat-176-watch-hero-poster-idle-autoplay.md)                 | Watch hero poster-first idle autoplay                        | vlad      | P1       | 2026-06-10 | 1    | 2026-06-10 | complete    |

--- a/docs/roadmap/platform/feat-187-manager-coverage-thumbnail-url-normalization.md
+++ b/docs/roadmap/platform/feat-187-manager-coverage-thumbnail-url-normalization.md
@@ -1,0 +1,68 @@
+---
+id: "feat-187"
+title: "Manager coverage thumbnail URL normalization"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-13"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "manager"
+  - "coverage"
+  - "images"
+---
+
+## Problem
+
+The Manager Studio Coverage page shows broken episode thumbnails in the
+hover/detail panel. The Admin-backed Manager coverage read model passes the
+latest `VideoImage.url` through directly, so bare Cloudflare Image Delivery
+URLs that omit a variant suffix reach Manager unchanged and fail in browser
+image elements and CSS background images.
+
+## Entry Points - Read These First
+
+1. `apps/admin/src/services/manager-read-model.service.ts` - Admin-owned
+   Manager coverage read model and current `imageUrl` mapping.
+2. `apps/admin/src/services/manager-read-model.service.test.ts` - focused
+   service regression tests for coverage payloads.
+3. `apps/admin/src/app/dashboard/video-library-utils.ts` - existing
+   `normalizeVideoThumbnailUrl` behavior used by Admin dashboard surfaces.
+4. `apps/manager/src/features/coverage/coverage-report-client.tsx` - hover
+   panel and selected thumbnail stack consumers of `imageUrl`.
+
+## Grep These
+
+- `imageUrl: video.images[0]?.url`
+- `normalizeVideoThumbnailUrl`
+- `detail-thumb`
+- `selected-video-stack-thumb`
+- `--detail-bg-image`
+
+## What To Build
+
+1. Normalize Manager coverage image URLs before returning
+   `ManagerVideoCoverage.imageUrl`.
+2. Preserve existing absolute non-Cloudflare URLs unchanged.
+3. Preserve missing/blank image URLs as `null`.
+4. Add a regression test that proves a bare Cloudflare Image Delivery URL gets
+   a public variant suffix before Manager receives it.
+
+## Constraints
+
+- Do not change the GraphQL payload shape.
+- Do not hand-edit generated GraphQL artifacts; this is field behavior only.
+- Do not add Manager-side URL guessing when Admin already owns the read model.
+- Do not change coverage count aggregation, language filtering, title
+  selection, or selection behavior.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- --run src/services/manager-read-model.service.test.ts`
+- `pnpm --filter @forge/admin typecheck`
+- Helium/browser smoke on Manager Coverage hover details to confirm episode
+  thumbnails render inside the preview panel.


### PR DESCRIPTION
## Summary
- normalize Admin Manager coverage image URLs before returning them to Manager
- append /public for bare Cloudflare Image Delivery URLs while preserving existing variants and other hosts
- add roadmap ticket and implementation plan for the thumbnail follow-up

## Validation
- pnpm --filter @forge/admin test -- --run src/services/manager-read-model.service.test.ts
- pnpm --filter @forge/admin exec eslint src/services/manager-read-model.service.ts src/services/manager-read-model.service.test.ts
- pnpm --filter @forge/admin typecheck
- Helium/agent-browser local smoke loaded Manager Coverage, hovered an episode tile, and confirmed the hover panel renders the API-provided thumbnail element. Local mock seed image URL itself is broken, so actual image loading is covered by the Admin URL-normalization regression.

## Notes
- No GraphQL schema shape changed; generated artifacts were not touched.