### PR TITLE
Redesign Smart Crop video search modal

### DIFF
--- a/apps/manager/src/app/api/auth/mock-login/route.test.ts
+++ b/apps/manager/src/app/api/auth/mock-login/route.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+describe("GET /api/auth/mock-login", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+
+    vi.stubEnv("MANAGER_DATA_MODE", "mock")
+    vi.stubEnv("MANAGER_BACKEND_MODE", "mock")
+    vi.stubEnv("MANAGER_MOCK_SESSION_SECRET", "mock-session-secret")
+    vi.stubEnv("MUX_TOKEN_ID", "mux-token-id")
+    vi.stubEnv("MUX_TOKEN_SECRET", "mux-token-secret")
+    vi.stubEnv("OPENROUTER_API_KEY", "openrouter-key")
+    vi.stubEnv(
+      "MANAGER_SESSION_SECRET",
+      "manager-session-secret-change-me-000000",
+    )
+    vi.stubEnv("MANAGER_BASE_URL", "http://localhost:3002")
+  })
+
+  it("sets a local Manager session and redirects to the requested local path", async () => {
+    const { GET } = await import("./route")
+    const { readManagerSessionCookie } =
+      await import("@/lib/manager-session-cookie")
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3002/api/auth/mock-login?returnTo=/dashboard/smart-crop",
+      ),
+    )
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3002/dashboard/smart-crop",
+    )
+
+    const setCookie = response.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain("manager-session=")
+    expect(setCookie).toContain("HttpOnly")
+    expect(setCookie).toContain("Path=/")
+
+    const token = setCookie.match(/manager-session=([^;]+)/)?.[1]
+    expect(token).toBeTruthy()
+    await expect(readManagerSessionCookie(token)).resolves.toMatchObject({
+      id: "mock-manager-1",
+      email: "manager@forge.test",
+      managerRole: "OPERATOR",
+    })
+  })
+
+  it("does not allow cross-origin returnTo redirects", async () => {
+    const { GET } = await import("./route")
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3002/api/auth/mock-login?returnTo=https://evil.test/path",
+      ),
+    )
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3002/dashboard/coverage",
+    )
+  })
+
+  it("is unavailable outside local mock Manager mode", async () => {
+    vi.stubEnv("MANAGER_DATA_MODE", "admin")
+    vi.stubEnv("MANAGER_BACKEND_MODE", "admin")
+
+    const { GET } = await import("./route")
+    const response = await GET(
+      new Request("http://localhost:3002/api/auth/mock-login"),
+    )
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/apps/manager/src/app/api/auth/mock-login/route.ts
+++ b/apps/manager/src/app/api/auth/mock-login/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server"
+
+import {
+  isLocalMockManagerLoginEnabled,
+  LOCAL_MOCK_MANAGER_SESSION,
+} from "@/lib/mock-manager-login"
+import {
+  createManagerSessionCookie,
+  MANAGER_SESSION_COOKIE,
+  managerSessionCookieOptions,
+} from "@/lib/manager-session-cookie"
+import { getManagerBaseUrl } from "@/lib/oauth-client"
+
+export async function GET(request: Request) {
+  if (!isLocalMockManagerLoginEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const managerBaseUrl = getManagerBaseUrl()
+  const requestUrl = new URL(request.url)
+  const returnTo = resolveManagerReturnToURL(
+    requestUrl.searchParams.get("returnTo") ?? undefined,
+    `${managerBaseUrl}/dashboard/coverage`,
+    managerBaseUrl,
+  )
+
+  const response = NextResponse.redirect(returnTo)
+  response.cookies.set(
+    MANAGER_SESSION_COOKIE,
+    await createManagerSessionCookie(LOCAL_MOCK_MANAGER_SESSION),
+    managerSessionCookieOptions(),
+  )
+
+  return response
+}
+
+export const POST = GET
+
+function resolveManagerReturnToURL(
+  returnTo: string | undefined,
+  fallbackURL: string,
+  managerBaseUrl: string,
+): string {
+  if (!returnTo) return fallbackURL
+
+  try {
+    const parsed = new URL(returnTo, fallbackURL)
+    return parsed.origin === new URL(managerBaseUrl).origin
+      ? parsed.toString()
+      : fallbackURL
+  } catch {
+    return fallbackURL
+  }
+}

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -13455,52 +13455,304 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
   background: var(--ds-line, #e7dfd2);
 }
 
-.smart-crop-video-search {
-  max-width: 520px;
+.smart-crop-video-select-field {
+  max-width: 560px;
 }
 
-.smart-crop-video-search-icon {
-  vertical-align: -1px;
-}
-
-.smart-crop-picker-results {
-  max-height: 280px;
-  overflow: auto;
-}
-
-.smart-crop-picker-results .jobs-table {
-  min-width: 680px;
-}
-
-.smart-crop-picker-row-issue {
-  opacity: 0.65;
-}
-
-.smart-crop-picker-video-button {
+.smart-crop-video-select {
+  display: flex;
   align-items: center;
+  width: 100%;
+  min-height: 74px;
+  gap: 14px;
+  padding: 14px;
+  color: var(--ds-ink);
+  text-align: left;
+  background: var(--ds-panel);
+  border: 1px solid var(--ds-line);
+  border-radius: var(--ds-radius);
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.smart-crop-video-select:hover,
+.smart-crop-video-select:focus-visible {
+  background: var(--ds-hover);
+  border-color: var(--ds-line-strong);
+  box-shadow: 0 0 0 3px var(--ds-focus-ring);
+  outline: none;
+}
+
+.smart-crop-video-select.is-selected {
+  border-color: var(--ds-line-strong);
+}
+
+.smart-crop-video-select-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--ds-line);
+  border-radius: calc(var(--ds-radius) - 2px);
+  background: var(--ds-bg);
+  color: var(--ds-muted);
+}
+
+.smart-crop-video-select-copy {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.smart-crop-video-select-title {
+  overflow-wrap: anywhere;
+  color: var(--ds-ink);
+  font-weight: 700;
+}
+
+.smart-crop-video-select-meta {
+  overflow-wrap: anywhere;
+  color: var(--ds-muted);
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.smart-crop-picker-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 96;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(255, 254, 250, 0.52);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  animation: smart-crop-picker-fade 140ms ease-out;
+}
+
+.smart-crop-picker-modal {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  width: min(900px, calc(100vw - 48px));
+  max-height: calc(100vh - 52px);
+  overflow: hidden;
+  border: 1px solid var(--ds-line);
+  border-radius: 20px;
+  background: rgba(255, 254, 250, 0.97);
+  box-shadow:
+    0 28px 80px rgba(17, 17, 17, 0.14),
+    0 4px 14px rgba(17, 17, 17, 0.05);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  animation: smart-crop-picker-enter 160ms ease-out;
+}
+
+.smart-crop-picker-modal-header {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 22px 74px 16px 22px;
+}
+
+.smart-crop-picker-modal-title {
+  margin: 0;
+  color: var(--ds-ink);
+  font-size: 1.35rem;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.smart-crop-picker-search-panel {
+  padding: 0 22px 18px;
+  border-bottom: 1px solid var(--ds-line);
+}
+
+.smart-crop-picker-search-field {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 58px;
+  padding: 0 16px;
+  color: var(--ds-muted);
+  background: var(--ds-panel);
+  border: 1px solid var(--ds-line);
+  border-radius: var(--ds-radius);
+}
+
+.smart-crop-picker-search-field:focus-within {
+  border-color: var(--ds-line-strong);
+  box-shadow: 0 0 0 3px var(--ds-focus-ring);
+}
+
+.smart-crop-picker-search-field input {
+  flex: 1;
+  min-width: 0;
+  height: 56px;
+  color: var(--ds-ink);
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font: inherit;
+}
+
+.smart-crop-picker-modal-body {
+  min-height: 260px;
+  overflow: auto;
+  padding: 14px;
+}
+
+.smart-crop-picker-list {
+  display: grid;
+  gap: 8px;
+}
+
+.smart-crop-picker-result {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) auto;
+  align-items: center;
+  width: 100%;
+  gap: 14px;
+  padding: 10px;
+  color: var(--ds-ink);
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: calc(var(--ds-radius) + 2px);
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    opacity 150ms ease;
+}
+
+.smart-crop-picker-result:hover:not(:disabled),
+.smart-crop-picker-result:focus-visible:not(:disabled) {
+  background: var(--ds-hover);
+  border-color: var(--ds-line);
+  outline: none;
+}
+
+.smart-crop-picker-result:disabled {
+  cursor: wait;
+}
+
+.smart-crop-picker-result.has-issue {
+  opacity: 0.72;
 }
 
 .smart-crop-picker-thumb {
-  display: inline-block;
-  flex-shrink: 0;
-  width: 48px;
-  height: 27px;
-  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 42px;
+  border: 1px solid var(--ds-line);
+  border-radius: calc(var(--ds-radius) - 4px);
   object-fit: cover;
-  background: var(--ds-line);
+  background: var(--ds-bg);
+  color: var(--ds-muted);
 }
 
-.smart-crop-picker-title {
+.smart-crop-picker-result-main {
   display: grid;
-  gap: 2px;
-  justify-items: start;
+  min-width: 0;
+  gap: 4px;
 }
 
-.smart-crop-picker-slug {
+.smart-crop-picker-result-title {
   overflow-wrap: anywhere;
+  color: var(--ds-ink);
+  font-weight: 700;
+  line-height: 1.25;
 }
 
-.smart-crop-selected-video {
+.smart-crop-picker-result-meta {
+  overflow-wrap: anywhere;
+  color: var(--ds-muted);
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.smart-crop-picker-result-side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 126px;
+  gap: 10px;
+  color: var(--ds-muted);
+}
+
+.smart-crop-picker-empty {
+  display: grid;
+  place-items: center;
+  min-height: 220px;
+  gap: 10px;
+  padding: 24px;
+  color: var(--ds-muted);
+  text-align: center;
+}
+
+.smart-crop-picker-empty p {
   margin: 0;
-  overflow-wrap: anywhere;
+}
+
+@keyframes smart-crop-picker-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes smart-crop-picker-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+}
+
+@media (max-width: 720px) {
+  .smart-crop-picker-backdrop {
+    padding: 12px;
+  }
+
+  .smart-crop-picker-modal {
+    width: calc(100vw - 24px);
+    max-height: calc(100vh - 24px);
+    border-radius: calc(var(--ds-radius) + 8px);
+  }
+
+  .smart-crop-picker-modal-header {
+    padding: 18px 64px 14px 18px;
+  }
+
+  .smart-crop-picker-search-panel {
+    padding: 0 18px 16px;
+  }
+
+  .smart-crop-picker-modal-body {
+    padding: 10px;
+  }
+
+  .smart-crop-picker-result {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+
+  .smart-crop-picker-thumb {
+    width: 56px;
+    height: 34px;
+  }
+
+  .smart-crop-picker-result-side {
+    grid-column: 2;
+    justify-content: flex-start;
+    min-width: 0;
+  }
 }

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -13571,6 +13571,34 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
   letter-spacing: 0;
 }
 
+.smart-crop-picker-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ds-muted);
+  cursor: pointer;
+}
+
+.smart-crop-picker-close:hover,
+.smart-crop-picker-close:focus-visible {
+  outline: none;
+  background: rgba(236, 234, 229, 0.72);
+  color: var(--ds-ink);
+}
+
+.smart-crop-picker-close:active {
+  background: rgba(226, 222, 215, 0.9);
+}
+
 .smart-crop-picker-search-panel {
   padding: 0 22px 18px;
   border-bottom: 1px solid var(--ds-line);

--- a/apps/manager/src/app/login/page.test.ts
+++ b/apps/manager/src/app/login/page.test.ts
@@ -1,5 +1,5 @@
 import React from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const { studioAuthShellMock } = vi.hoisted(() => ({
   studioAuthShellMock: vi.fn(
@@ -13,6 +13,10 @@ const { redirectMock } = vi.hoisted(() => ({
   }),
 }))
 
+const { isLocalMockManagerLoginEnabledMock } = vi.hoisted(() => ({
+  isLocalMockManagerLoginEnabledMock: vi.fn(() => false),
+}))
+
 vi.mock("next/navigation", () => ({
   redirect: redirectMock,
 }))
@@ -22,6 +26,7 @@ vi.mock("@/features/shell/studio-auth-shell", () => ({
 }))
 
 vi.mock("@/lib/oauth-client", () => ({
+  getManagerBaseUrl: vi.fn(() => "http://localhost:3002"),
   getManagerOAuthConfig: vi.fn(() => ({
     issuerUrl: "https://auth.jesusfilm.org",
     clientId: "jfp_manager_local",
@@ -29,9 +34,19 @@ vi.mock("@/lib/oauth-client", () => ({
   })),
 }))
 
+vi.mock("@/lib/mock-manager-login", () => ({
+  isLocalMockManagerLoginEnabled: isLocalMockManagerLoginEnabledMock,
+}))
+
 import LoginPage from "./page"
 
 describe("login page", () => {
+  beforeEach(() => {
+    redirectMock.mockClear()
+    isLocalMockManagerLoginEnabledMock.mockReset()
+    isLocalMockManagerLoginEnabledMock.mockReturnValue(false)
+  })
+
   it("redirects directly into Manager OAuth login by default", async () => {
     await expect(
       LoginPage({
@@ -52,6 +67,20 @@ describe("login page", () => {
       }),
     ).rejects.toThrow(
       "NEXT_REDIRECT:http://localhost:3002/api/auth/login?returnTo=%2Fdashboard%2Fjobs%2Fjob-1%3FlanguageId%3D529",
+    )
+  })
+
+  it("uses the local mock login route when mock Manager login is enabled", async () => {
+    isLocalMockManagerLoginEnabledMock.mockReturnValue(true)
+
+    await expect(
+      LoginPage({
+        searchParams: Promise.resolve({
+          returnTo: "/dashboard/smart-crop",
+        }),
+      }),
+    ).rejects.toThrow(
+      "NEXT_REDIRECT:http://localhost:3002/api/auth/mock-login?returnTo=%2Fdashboard%2Fsmart-crop",
     )
   })
 

--- a/apps/manager/src/app/login/page.tsx
+++ b/apps/manager/src/app/login/page.tsx
@@ -2,7 +2,8 @@ import { redirect } from "next/navigation"
 import { LogOut } from "lucide-react"
 
 import { StudioAuthShell } from "@/features/shell/studio-auth-shell"
-import { getManagerOAuthConfig } from "@/lib/oauth-client"
+import { isLocalMockManagerLoginEnabled } from "@/lib/mock-manager-login"
+import { getManagerBaseUrl } from "@/lib/oauth-client"
 
 export default async function LoginPage({
   searchParams,
@@ -10,13 +11,13 @@ export default async function LoginPage({
   searchParams: Promise<{ error?: string; expired?: string; returnTo?: string }>
 }) {
   const params = await searchParams
-  const managerBaseUrl = getManagerOAuthConfig().managerBaseUrl.replace(
-    /\/$/,
-    "",
-  )
+  const managerBaseUrl = getManagerBaseUrl()
 
   if (!params.error) {
-    const loginUrl = new URL(`${managerBaseUrl}/api/auth/login`)
+    const loginPath = isLocalMockManagerLoginEnabled()
+      ? "/api/auth/mock-login"
+      : "/api/auth/login"
+    const loginUrl = new URL(`${managerBaseUrl}${loginPath}`)
     if (params.returnTo) {
       loginUrl.searchParams.set("returnTo", params.returnTo)
     }

--- a/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
@@ -3,9 +3,19 @@
 // Smart Crop dashboard screen: two creation forms (canonical / localized) and
 // a polling jobs table. Plan 2026-06-09-002 "UI".
 
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
-import { Crop, Languages, RefreshCw, Search } from "lucide-react"
+import {
+  ArrowRight,
+  Check,
+  Crop,
+  Film,
+  Languages,
+  RefreshCw,
+  Search,
+  X,
+} from "lucide-react"
+import { createPortal } from "react-dom"
 import { apiFetch } from "@/lib/api-fetch"
 import type { SmartCropVideoResolution } from "@/app/api/smart-crop/videos/[coreId]/route"
 import type { JobRecord, SmartCropCropMode } from "@/types/job"
@@ -171,10 +181,188 @@ function FormStatus({ status }: { status: RequestStatus }) {
   )
 }
 
+function SmartCropVideoThumb({ imageUrl }: { imageUrl: string | null }) {
+  const [canShowImage, setCanShowImage] = useState(Boolean(imageUrl))
+
+  useEffect(() => {
+    setCanShowImage(Boolean(imageUrl))
+  }, [imageUrl])
+
+  if (canShowImage && imageUrl) {
+    return (
+      // Keep admin-sourced URLs in an img src, not CSS.
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        className="smart-crop-picker-thumb"
+        src={imageUrl}
+        alt=""
+        aria-hidden="true"
+        loading="lazy"
+        onError={() => setCanShowImage(false)}
+      />
+    )
+  }
+
+  return (
+    <span className="smart-crop-picker-thumb" aria-hidden="true">
+      <Film className="icon" aria-hidden="true" />
+    </span>
+  )
+}
+
+function SmartCropVideoPickerModal({
+  videos,
+  loadFailed,
+  query,
+  filteredVideos,
+  resolvingId,
+  rowIssues,
+  onClose,
+  onQueryChange,
+  onResolve,
+}: {
+  videos: VideoPickerItem[] | null
+  loadFailed: boolean
+  query: string
+  filteredVideos: VideoPickerItem[]
+  resolvingId: string | null
+  rowIssues: Record<string, string>
+  onClose: () => void
+  onQueryChange: (query: string) => void
+  onResolve: (video: VideoPickerItem) => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const trimmedQuery = query.trim()
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  return (
+    <div
+      className="smart-crop-picker-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <section
+        className="smart-crop-picker-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="smart-crop-picker-title"
+      >
+        <header className="smart-crop-picker-modal-header">
+          <div>
+            <p className="studio-page-eyebrow">Source video</p>
+            <h3
+              id="smart-crop-picker-title"
+              className="smart-crop-picker-modal-title"
+            >
+              Search by title or slug
+            </h3>
+          </div>
+          <button
+            type="button"
+            className="agents-modal-close"
+            aria-label="Close video search"
+            title="Close video search"
+            onClick={onClose}
+          >
+            <X className="icon" aria-hidden="true" />
+          </button>
+        </header>
+
+        <div className="smart-crop-picker-search-panel">
+          <label className="smart-crop-picker-search-field">
+            <Search className="icon" aria-hidden="true" />
+            <span className="sr-only">Search videos by title or slug</span>
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder="Type a title or slug"
+            />
+          </label>
+        </div>
+
+        <div className="smart-crop-picker-modal-body">
+          {loadFailed ? (
+            <div className="smart-crop-picker-empty" role="status">
+              <Film className="icon" aria-hidden="true" />
+              <p>Video library did not load.</p>
+            </div>
+          ) : trimmedQuery.length === 0 ? (
+            <div className="smart-crop-picker-empty" role="status">
+              <Search className="icon" aria-hidden="true" />
+              <p>Start typing to find a source video.</p>
+            </div>
+          ) : videos === null ? (
+            <div className="smart-crop-picker-empty" role="status">
+              <RefreshCw className="icon is-spinning" aria-hidden="true" />
+              <p>Loading video library...</p>
+            </div>
+          ) : filteredVideos.length === 0 ? (
+            <div className="smart-crop-picker-empty" role="status">
+              <Film className="icon" aria-hidden="true" />
+              <p>No videos match {trimmedQuery}.</p>
+            </div>
+          ) : (
+            <div
+              className="smart-crop-picker-list"
+              role="list"
+              aria-label="Video search results"
+            >
+              {filteredVideos.map((video) => {
+                const issue = rowIssues[video.id]
+                const isResolving = resolvingId === video.id
+                return (
+                  <button
+                    type="button"
+                    key={video.id}
+                    className={`smart-crop-picker-result${issue ? " has-issue" : ""}`}
+                    disabled={resolvingId !== null}
+                    onClick={() => onResolve(video)}
+                  >
+                    <SmartCropVideoThumb imageUrl={video.imageUrl} />
+                    <span className="smart-crop-picker-result-main">
+                      <span className="smart-crop-picker-result-title">
+                        {video.title}
+                      </span>
+                      <span className="smart-crop-picker-result-meta">
+                        {video.slug ?? "No slug"} /{" "}
+                        {video.coreId ?? "No Core ID"}
+                      </span>
+                    </span>
+                    <span className="smart-crop-picker-result-side">
+                      <span className="jobs-language-badge">{video.label}</span>
+                      {isResolving ? (
+                        <RefreshCw
+                          className="icon is-spinning"
+                          aria-hidden="true"
+                        />
+                      ) : issue ? (
+                        <span className="jobs-error-text small">{issue}</span>
+                      ) : (
+                        <ArrowRight className="icon" aria-hidden="true" />
+                      )}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
 function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
   const [videos, setVideos] = useState<VideoPickerItem[] | null>(null)
   const [loadFailed, setLoadFailed] = useState(false)
   const [query, setQuery] = useState("")
+  const [isPickerOpen, setIsPickerOpen] = useState(false)
   const [resolvingId, setResolvingId] = useState<string | null>(null)
   const [rowIssues, setRowIssues] = useState<Record<string, string>>({})
   const [selectedVideo, setSelectedVideo] = useState<{
@@ -189,6 +377,7 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
   const [cropMode, setCropMode] = useState<SmartCropCropMode>("auto")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [status, setStatus] = useState<RequestStatus>({ type: "idle" })
+  const modalRoot = typeof document === "undefined" ? null : document.body
 
   useEffect(() => {
     const controller = new AbortController()
@@ -209,6 +398,24 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
     })()
     return () => controller.abort()
   }, [])
+
+  useEffect(() => {
+    if (!isPickerOpen) return
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") setIsPickerOpen(false)
+    }
+
+    window.addEventListener("keydown", closeOnEscape)
+    return () => window.removeEventListener("keydown", closeOnEscape)
+  }, [isPickerOpen])
+
+  useEffect(() => {
+    document.body.classList.toggle("studio-modal-open", isPickerOpen)
+    return () => {
+      document.body.classList.remove("studio-modal-open")
+    }
+  }, [isPickerOpen])
 
   const filteredVideos = useMemo(() => {
     if (!videos) return []
@@ -271,6 +478,7 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
         muxAssetId: resolution.muxAssetId,
       })
       setQuery("")
+      setIsPickerOpen(false)
       setStatus({ type: "idle" })
       setRowIssues((current) => {
         const next = { ...current }
@@ -318,119 +526,52 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
       <div className="jobs-card-header">
         <h2 className="jobs-card-title">Canonical crop plan</h2>
       </div>
-      <label className="jobs-field smart-crop-video-search">
-        <div className="small jobs-field-label">
-          <Search
-            size={12}
-            aria-hidden="true"
-            className="smart-crop-video-search-icon"
-          />{" "}
-          Video search
-        </div>
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          className="jobs-input"
-          placeholder="Title or slug"
-        />
-      </label>
+      <div className="jobs-field smart-crop-video-select-field">
+        <div className="small jobs-field-label">Source video</div>
+        <button
+          type="button"
+          className={`smart-crop-video-select${selectedVideo ? " is-selected" : ""}`}
+          onClick={() => setIsPickerOpen(true)}
+        >
+          <span className="smart-crop-video-select-icon" aria-hidden="true">
+            {selectedVideo ? (
+              <Check className="icon" aria-hidden="true" />
+            ) : (
+              <Search className="icon" aria-hidden="true" />
+            )}
+          </span>
+          <span className="smart-crop-video-select-copy">
+            <span className="smart-crop-video-select-title">
+              {selectedVideo?.title ?? "Search by title or slug"}
+            </span>
+            <span className="smart-crop-video-select-meta">
+              {selectedVideo
+                ? `${selectedVideo.slug ?? selectedVideo.coreId} / ${selectedVideo.muxAssetId}`
+                : "Choose a source video from the Manager library"}
+            </span>
+          </span>
+        </button>
+        {loadFailed ? (
+          <p className="jobs-error-text">Could not load the video library.</p>
+        ) : null}
+      </div>
 
-      {loadFailed ? (
-        <p className="jobs-error-text">Could not load the video library.</p>
-      ) : query.trim().length > 0 && videos === null ? (
-        <p className="small jobs-empty-state">Loading video library...</p>
-      ) : query.trim().length > 0 && filteredVideos.length === 0 ? (
-        <p className="small jobs-empty-state">
-          No videos match <span>{query.trim()}</span>.
-        </p>
-      ) : query.trim().length > 0 ? (
-        <div className="jobs-table-wrap smart-crop-picker-results">
-          <table className="table jobs-table">
-            <thead>
-              <tr>
-                <th>Video</th>
-                <th>Type</th>
-                <th>Core ID</th>
-                <th aria-label="Resolution" />
-              </tr>
-            </thead>
-            <tbody>
-              {filteredVideos.map((video) => {
-                const issue = rowIssues[video.id]
-                const isResolving = resolvingId === video.id
-                return (
-                  <tr
-                    key={video.id}
-                    className={
-                      issue ? "smart-crop-picker-row-issue" : undefined
-                    }
-                  >
-                    <td>
-                      <button
-                        type="button"
-                        className="jobs-step-artifact-link smart-crop-picker-video-button"
-                        disabled={resolvingId !== null}
-                        onClick={() => void resolveVideo(video)}
-                        title={issue ?? `Use ${video.title}`}
-                      >
-                        {video.imageUrl ? (
-                          // Keep admin-sourced URLs in an img src, not CSS.
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img
-                            className="smart-crop-picker-thumb"
-                            src={video.imageUrl}
-                            alt=""
-                            aria-hidden="true"
-                            loading="lazy"
-                          />
-                        ) : (
-                          <span
-                            className="smart-crop-picker-thumb"
-                            aria-hidden="true"
-                          />
-                        )}
-                        <span className="smart-crop-picker-title">
-                          <span className="jobs-step-artifact-label">
-                            {video.title}
-                          </span>
-                          {video.slug ? (
-                            <span className="small smart-crop-picker-slug">
-                              {video.slug}
-                            </span>
-                          ) : null}
-                        </span>
-                      </button>
-                    </td>
-                    <td>
-                      <span className="jobs-language-badge">{video.label}</span>
-                    </td>
-                    <td>{video.coreId ?? "n/a"}</td>
-                    <td>
-                      {isResolving ? (
-                        <RefreshCw
-                          className="icon is-spinning"
-                          aria-hidden="true"
-                          size={14}
-                        />
-                      ) : issue ? (
-                        <span className="jobs-error-text small">{issue}</span>
-                      ) : null}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
-      ) : null}
-
-      {selectedVideo ? (
-        <p className="small smart-crop-selected-video">
-          Selected {selectedVideo.title}
-          {selectedVideo.slug ? ` / ${selectedVideo.slug}` : ""} /{" "}
-          {selectedVideo.muxAssetId}
-        </p>
-      ) : null}
+      {modalRoot && isPickerOpen
+        ? createPortal(
+            <SmartCropVideoPickerModal
+              videos={videos}
+              loadFailed={loadFailed}
+              query={query}
+              filteredVideos={filteredVideos}
+              resolvingId={resolvingId}
+              rowIssues={rowIssues}
+              onClose={() => setIsPickerOpen(false)}
+              onQueryChange={setQuery}
+              onResolve={(video) => void resolveVideo(video)}
+            />,
+            modalRoot,
+          )
+        : null}
 
       <div className="grid cols-2 jobs-form-grid">
         <label className="jobs-field">

--- a/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
@@ -264,7 +264,7 @@ function SmartCropVideoPickerModal({
           </div>
           <button
             type="button"
-            className="agents-modal-close"
+            className="smart-crop-picker-close"
             aria-label="Close video search"
             title="Close video search"
             onClick={onClose}
@@ -378,6 +378,9 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [status, setStatus] = useState<RequestStatus>({ type: "idle" })
   const modalRoot = typeof document === "undefined" ? null : document.body
+  const openPicker = useCallback(() => {
+    setIsPickerOpen(true)
+  }, [])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -531,7 +534,19 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
         <button
           type="button"
           className={`smart-crop-video-select${selectedVideo ? " is-selected" : ""}`}
-          onClick={() => setIsPickerOpen(true)}
+          aria-haspopup="dialog"
+          aria-expanded={isPickerOpen}
+          onPointerDown={(event) => {
+            event.preventDefault()
+            openPicker()
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault()
+              openPicker()
+            }
+          }}
+          onClick={openPicker}
         >
           <span className="smart-crop-video-select-icon" aria-hidden="true">
             {selectedVideo ? (

--- a/apps/manager/src/lib/mock-manager-login.ts
+++ b/apps/manager/src/lib/mock-manager-login.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_MOCK_MANAGER_CREDENTIALS } from "@/cms/mock-seed"
+import { env } from "@/config/env"
+import type { ManagerSessionPrincipal } from "@/lib/manager-session-cookie"
+
+export const LOCAL_MOCK_MANAGER_SESSION: ManagerSessionPrincipal = {
+  id: "mock-manager-1",
+  subject: "mock-manager-1",
+  email: DEFAULT_MOCK_MANAGER_CREDENTIALS.email,
+  name: "Mock Manager",
+  managerRole: "OPERATOR",
+  scopes: ["manager:access"],
+}
+
+export function isLocalMockManagerLoginEnabled() {
+  const managerMode = env.MANAGER_BACKEND_MODE ?? env.MANAGER_DATA_MODE
+  return managerMode === "mock" && env.NODE_ENV !== "production"
+}

--- a/docs/plans/2026-06-13-001-feat-manager-smart-crop-video-search-plan.md
+++ b/docs/plans/2026-06-13-001-feat-manager-smart-crop-video-search-plan.md
@@ -33,7 +33,7 @@ contract.
   catalogue or the lookup is unavailable.
 - R4. Search results expose enough identity to disambiguate similar titles:
   title, slug, label/type, and core ID.
-- R5. Videos without an admin-resolved Mux asset surface an inline, per-row
+- R5. Videos without an admin-resolved Mux asset surface a modal row-level
   reason and do not fill the canonical form.
 - R6. The Smart Crop job creation API contract stays unchanged:
   `/api/smart-crop/jobs` still receives `kind`, `muxAssetId`, optional
@@ -59,6 +59,9 @@ contract.
 - Use client-side filtering for the first slice: `/api/videos` is already a
   bounded, cached dashboard list. Client-side title/slug/core-ID filtering
   matches the Shorts picker precedent and avoids a new query shape.
+- Keep search in a modal, not the form card: the canonical form should stay
+  compact, and the video library needs enough width for thumbnail, title, slug,
+  type, and resolution state.
 
 ## Implementation Units
 
@@ -99,17 +102,19 @@ contract.
 - **Patterns:** Reuse the Shorts picker flow in
   `apps/manager/src/features/shorts/shorts-create-screen.tsx`: load
   `/api/videos`, flatten collections plus standalone rows, filter client-side,
-  keep per-row resolution issues, and use existing table/button styles.
-- **Test Scenarios:** Search matches by title and slug; selecting an eligible
-  result fills `Mux Asset ID`; ineligible or failed rows show a row-level reason;
-  manual Mux ID editing remains possible and keeps the submit button behavior
-  tied to the field value.
+  keep per-row resolution issues, and render results in a Studio-style modal
+  list rather than an inline table.
+- **Test Scenarios:** Clicking the source-video search trigger opens a focused
+  modal; search matches by title and slug; selecting an eligible result fills
+  `Mux Asset ID`; ineligible or failed rows show a row-level reason; manual Mux
+  ID editing remains possible and keeps the submit button behavior tied to the
+  field value.
 
 ## Acceptance Examples
 
 - AE1. Given the canonical form has loaded the video library, when an operator
-  searches `a-new-beginning`, then the standalone video with that slug appears
-  and can be selected.
+  clicks `Search by title or slug` and searches `a-new-beginning`, then the
+  standalone video with that slug appears in a modal and can be selected.
 - AE2. Given a selected video resolves to `mux-1`, when the operator clicks the
   row, then `Mux Asset ID` becomes `mux-1` and the canonical job button enables.
 - AE3. Given admin returns a video with no Mux asset, when the operator selects


### PR DESCRIPTION
## Summary

Smart Crop source selection now opens as a focused modal instead of the broken inline search list that squeezed titles and thumbnails into the canonical form. Operators can search by title or slug in a dialog, scan readable result rows, select a video to populate the canonical Mux asset, and still fall back to manual Mux entry when needed.

Local mock testing now stays inside Manager instead of falling through the external Auth flow to `jesusfilm.org`. In mock mode, `/login?returnTo=...` issues the same local `manager-session` shape the real callback uses, guarded to non-production mock deployments and protected against cross-origin `returnTo` values.

The picker interaction is also tighter after the follow-up pass: the trigger exposes dialog state for assistive tech, pointer and keyboard activation both open the modal reliably, broken or missing thumbnails fall back to the film icon, and the close control is now a quiet icon button without the heavy outlined box.

## Validation

- `pnpm --filter @forge/manager test -- src/app/api/videos/route.mock.test.ts 'src/app/api/smart-crop/videos/[coreId]/route.test.ts' src/features/smart-crop/smart-crop-presenter.test.ts`
- `pnpm --filter @forge/manager test -- --run src/app/login/page.test.ts src/app/api/auth/mock-login/route.test.ts`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager typecheck`
- `git diff --check`
- In-app browser smoke on `http://localhost:3002/dashboard/smart-crop`: confirmed the local mock-login route lands on Manager, opened the modal, typed `storm`, and verified the close button computes with no border or outline.
- Helium smoke on `http://localhost:3002/dashboard/smart-crop`: clicked the source-video trigger, confirmed it flips to `expanded=true`, and saw the modal heading plus search textbox.
- GitHub checks after push: `commit-lint`, `format`, `affected`, `lint (@forge/manager)`, `test (@forge/manager)`, `build (@forge/manager)`, and CodeQL completed successfully.

## Context

Follow-up to #1243, which added the initial Smart Crop video search entry point. This PR keeps that capability but makes the operator experience usable, testable locally, and polished enough for the Manager surface.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
