### PR TITLE
fix(web): avoid download modal close overlay

### DIFF
--- a/apps/web/src/components/watch/DownloadModal.tsx
+++ b/apps/web/src/components/watch/DownloadModal.tsx
@@ -110,6 +110,7 @@ export function DownloadModal({
 }: DownloadModalProps) {
   const t = useTranslations("DownloadModal")
   const fileSizeLabel = t("fileSizeLabel")
+  const tWatchModal = useTranslations("WatchModal")
   // Localized label for a quality tier. `bucketDownloads` carries an English
   // `label` for back-compat, but the rendered text is resolved here so it
   // translates.
@@ -338,6 +339,7 @@ export function DownloadModal({
         open={open}
         onClose={() => handleOpenChange(false)}
         testId="watch-download-modal-close"
+        className="hidden sm:flex"
       />
       <DialogContent
         data-testid="watch-download-modal"
@@ -348,54 +350,68 @@ export function DownloadModal({
         <DialogTitle className="sr-only">{t("dialogTitle")}</DialogTitle>
 
         <div className="flex max-h-[82vh] flex-col gap-7 overflow-y-auto pr-2 [scrollbar-color:theme(colors.stone.700)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-stone-700 [&::-webkit-scrollbar-track]:bg-transparent hover:[&::-webkit-scrollbar-thumb]:bg-stone-600">
-          {/* Header: thumbnail + metadata */}
-          <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:gap-6">
-            <div
-              data-testid="watch-download-modal-poster"
-              className="relative aspect-video w-full shrink-0 overflow-hidden rounded-2xl bg-stone-800 sm:w-56"
-            >
-              {posterUrl ? (
-                <Image
-                  src={posterUrl}
-                  alt={videoTitle ?? t("posterAlt")}
-                  fill
-                  sizes="(min-width: 640px) 224px, 100vw"
-                  className="object-cover"
-                />
-              ) : null}
-              {durationLabel ? (
-                <div
-                  data-testid="watch-download-modal-duration"
-                  className="absolute right-2 bottom-2 flex items-center gap-1 rounded-md bg-black/70 px-2 py-1 text-xs font-semibold text-stone-100"
-                >
-                  <Play size={12} fill="currentColor" />
-                  <span>{durationLabel}</span>
-                </div>
-              ) : null}
+          <div className="flex flex-col gap-4">
+            <div className="flex justify-end sm:hidden">
+              <button
+                type="button"
+                aria-label={tWatchModal("close")}
+                data-testid="watch-download-modal-mobile-close"
+                onClick={() => handleOpenChange(false)}
+                className="flex h-11 w-11 cursor-pointer items-center justify-center rounded-full bg-transparent text-stone-300 transition hover:text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none sm:hidden"
+              >
+                <XIcon aria-hidden className="h-6 w-6" />
+              </button>
             </div>
 
-            <div className="flex min-w-0 flex-1 flex-col gap-3">
-              <span
-                data-testid="watch-download-modal-eyebrow"
-                className={WATCH_SECTION_EYEBROW_CLASS}
+            {/* Header: thumbnail + metadata */}
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:gap-6">
+              <div
+                data-testid="watch-download-modal-poster"
+                className="relative aspect-video w-full shrink-0 overflow-hidden rounded-2xl bg-stone-800 sm:w-56"
               >
-                {t("eyebrow")}
-              </span>
-              <h2
-                data-testid="watch-download-modal-title"
-                className="text-2xl leading-tight font-semibold text-stone-50 sm:text-3xl"
-              >
-                {videoTitle ?? ""}
-              </h2>
-              {languageName ? (
+                {posterUrl ? (
+                  <Image
+                    src={posterUrl}
+                    alt={videoTitle ?? t("posterAlt")}
+                    fill
+                    sizes="(min-width: 640px) 224px, 100vw"
+                    className="object-cover"
+                  />
+                ) : null}
+                {durationLabel ? (
+                  <div
+                    data-testid="watch-download-modal-duration"
+                    className="absolute right-2 bottom-2 flex items-center gap-1 rounded-md bg-black/70 px-2 py-1 text-xs font-semibold text-stone-100"
+                  >
+                    <Play size={12} fill="currentColor" />
+                    <span>{durationLabel}</span>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex min-w-0 flex-1 flex-col gap-3">
                 <span
-                  data-testid="watch-download-modal-language"
-                  className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm font-semibold text-stone-100"
+                  data-testid="watch-download-modal-eyebrow"
+                  className={WATCH_SECTION_EYEBROW_CLASS}
                 >
-                  <Globe2 size={14} />
-                  <span>{languageName}</span>
+                  {t("eyebrow")}
                 </span>
-              ) : null}
+                <h2
+                  data-testid="watch-download-modal-title"
+                  className="text-2xl leading-tight font-semibold text-stone-50 sm:text-3xl"
+                >
+                  {videoTitle ?? ""}
+                </h2>
+                {languageName ? (
+                  <span
+                    data-testid="watch-download-modal-language"
+                    className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm font-semibold text-stone-100"
+                  >
+                    <Globe2 size={14} />
+                    <span>{languageName}</span>
+                  </span>
+                ) : null}
+              </div>
             </div>
           </div>
 

--- a/apps/web/src/components/watch/WatchModalViewportCloseButton.tsx
+++ b/apps/web/src/components/watch/WatchModalViewportCloseButton.tsx
@@ -4,18 +4,22 @@ import { createPortal } from "react-dom"
 import { X } from "lucide-react"
 import { useTranslations } from "next-intl"
 
+import { cn } from "@/lib/utils"
+
 export function WatchModalViewportCloseButton({
   open,
   onClose,
   testId,
   portalContainer,
   positionClassName = "top-12 right-10",
+  className,
 }: {
   open: boolean
   onClose: () => void
   testId: string
   portalContainer?: HTMLElement | null
   positionClassName?: string
+  className?: string
 }) {
   const t = useTranslations("WatchModal")
   if (!open || typeof document === "undefined") return null
@@ -26,7 +30,11 @@ export function WatchModalViewportCloseButton({
       aria-label={t("close")}
       data-testid={testId}
       onClick={onClose}
-      className={`fixed ${positionClassName} z-[60] flex h-[52px] w-12 cursor-pointer items-center justify-center rounded-full bg-transparent text-stone-300 transition hover:text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none`}
+      className={cn(
+        "fixed z-[60] flex h-[52px] w-12 cursor-pointer items-center justify-center rounded-full bg-transparent text-stone-300 transition hover:text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none",
+        positionClassName,
+        className,
+      )}
     >
       <X aria-hidden className="h-6 w-6" />
     </button>,

--- a/apps/web/src/components/watch/__tests__/DownloadModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/DownloadModal.test.tsx
@@ -834,13 +834,26 @@ describe("DownloadModal — Terms of Use nested dialog", () => {
     const close = $(
       '[data-testid="watch-download-modal-close"]',
     ) as HTMLButtonElement
+    const mobileClose = $(
+      '[data-testid="watch-download-modal-mobile-close"]',
+    ) as HTMLButtonElement
+    const poster = $(
+      '[data-testid="watch-download-modal-poster"]',
+    ) as HTMLElement
     expect(close.className).toContain("fixed")
     expect(close.className).toContain("top-12")
     expect(close.className).toContain("right-10")
+    expect(close.className).toContain("hidden")
+    expect(close.className).toContain("sm:flex")
     expect(close.className).toContain("h-[52px]")
     expect(close.className).toContain("w-12")
     expect(close.className).toContain("z-[60]")
     expect(close.querySelector("svg")?.getAttribute("class")).toContain("h-6")
+    expect(mobileClose.className).toContain("sm:hidden")
+    expect(
+      mobileClose.compareDocumentPosition(poster) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0)
 
     // Click the fullscreen close button. This mirrors the language
     // switcher-style chrome and still routes through handleOpenChange(false),

--- a/docs/roadmap/topic-experiences/feat-146-watch-download-modal-mobile-close.md
+++ b/docs/roadmap/topic-experiences/feat-146-watch-download-modal-mobile-close.md
@@ -1,0 +1,50 @@
+---
+id: "feat-146"
+title: "Watch Download Modal Mobile Close Placement"
+owner: "urim"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-13"
+duration: 1
+depends_on:
+  - "feat-023"
+blocks: []
+tags:
+  - "web"
+  - "watch"
+  - "ui"
+---
+
+## Problem
+
+On narrow mobile viewports, the Watch download modal's viewport-level X close control can visually overlap the poster thumbnail and duration badge. The close affordance needs to remain available without covering content elements.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/watch/DownloadModal.tsx` - modal layout and close controls
+2. `apps/web/src/components/watch/WatchModalViewportCloseButton.tsx` - shared viewport-level close control
+3. `apps/web/src/components/watch/__tests__/DownloadModal.test.tsx` - modal interaction and layout regression tests
+
+## Grep These
+
+- `watch-download-modal-close` in `apps/web/src/components/watch/`
+- `WatchModalViewportCloseButton` in `apps/web/src/components/watch/`
+- `watch-download-modal-poster` in `apps/web/src/components/watch/`
+
+## What To Build
+
+1. Preserve the desktop viewport-level close control used by Watch modals.
+2. On mobile, reserve layout space for the close affordance inside the download modal so it cannot overlay the poster, duration badge, title, language pill, file-size selector, terms checkbox, or action buttons.
+3. Add a regression test that locks the mobile close control inside the dialog before content.
+
+## Constraints
+
+- Keep the change scoped to `apps/web` modal presentation.
+- Do not alter download URL allowlisting, proxy behavior, or terms-of-use gating.
+- Keep existing close semantics: either close affordance must route through the same `handleOpenChange(false)` cleanup path.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- DownloadModal.test.tsx`
+- `pnpm --filter @forge/web typecheck`
+- Mobile browser smoke of the Watch download dialog


### PR DESCRIPTION
## Summary
- add a mobile-only close row inside the Watch download modal so the X is reserved above the poster instead of overlaying content
- keep the existing viewport close button for `sm` and larger screens via a reusable `className` prop
- add roadmap ticket `feat-146` and regression coverage for mobile close ordering

## Validation
- `pnpm --filter @forge/web test -- DownloadModal.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `git diff --check HEAD~1..HEAD`
- Helium/agent-browser mobile smoke before rebasing onto current `origin/main`: modal open, `mobileCloseOverlapsPoster=false`, `mobileCloseOverlapsDuration=false`; console/errors clean. After rebasing, the clean branch route returned 200 and rendered the Download button, but the local Next/Turbopack dev server entered an unrelated `/[slug]/page` endpoint panic loop before final geometry could complete.