### PR TITLE
fix: stabilize Smart Crop jobs and crop-worker builds

### DIFF
--- a/apps/crop-worker/railway.toml
+++ b/apps/crop-worker/railway.toml
@@ -9,13 +9,11 @@
 
 [build]
 builder = "NIXPACKS"
-# Install with NODE_ENV=development so devDependencies (husky for the repo-root
-# `prepare` script, prisma for sibling postinstalls, typescript for the build)
-# are NOT skipped. The service sets NODE_ENV=production, which applies to the
-# build too — and pnpm skips devDependencies under NODE_ENV=production, which
-# breaks the monorepo install (husky/prisma "not found"). The runtime keeps
-# NODE_ENV=production via the service variable; this override is install-only.
-buildCommand = "NODE_ENV=development pnpm install --frozen-lockfile && pnpm --filter @forge/crop-worker build"
+# The repo-root nixpacks.toml overrides the install phase with
+# NODE_ENV=development so devDependencies are present for monorepo lifecycle
+# scripts and this TypeScript build. Keep this command focused on compiling the
+# worker; Railway's Nixpacks install phase has already run by this point.
+buildCommand = "pnpm --filter @forge/crop-worker build"
 watchPatterns = [
   "/apps/crop-worker/**",
   "/package.json",

--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -13522,6 +13522,52 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
   line-height: 1.35;
 }
 
+.smart-crop-jobs-table {
+  table-layout: fixed;
+  min-width: 920px;
+}
+
+.smart-crop-jobs-table th,
+.smart-crop-jobs-table td {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.smart-crop-jobs-table .smart-crop-jobs-col-job {
+  width: 21%;
+}
+
+.smart-crop-jobs-table .smart-crop-jobs-col-kind {
+  width: 12%;
+}
+
+.smart-crop-jobs-table .smart-crop-jobs-col-asset {
+  width: 30%;
+}
+
+.smart-crop-jobs-table .smart-crop-jobs-col-language {
+  width: 8%;
+}
+
+.smart-crop-jobs-table .smart-crop-jobs-col-status {
+  width: 9%;
+}
+
+.smart-crop-jobs-table .smart-crop-jobs-col-phase {
+  width: 10%;
+}
+
+.smart-crop-jobs-table .smart-crop-jobs-col-updated {
+  width: 10%;
+}
+
+.smart-crop-jobs-id,
+.smart-crop-jobs-asset {
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
 .smart-crop-picker-backdrop {
   position: fixed;
   inset: 0;

--- a/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
@@ -798,8 +798,17 @@ export function SmartCropScreen({ initialJobs }: SmartCropScreenProps) {
             No smart-crop jobs yet. Create a canonical job to start.
           </p>
         ) : (
-          <div className="jobs-table-wrap">
-            <table className="table jobs-table">
+          <div className="jobs-table-wrap smart-crop-jobs-table-wrap">
+            <table className="table jobs-table smart-crop-jobs-table">
+              <colgroup>
+                <col className="smart-crop-jobs-col-job" />
+                <col className="smart-crop-jobs-col-kind" />
+                <col className="smart-crop-jobs-col-asset" />
+                <col className="smart-crop-jobs-col-language" />
+                <col className="smart-crop-jobs-col-status" />
+                <col className="smart-crop-jobs-col-phase" />
+                <col className="smart-crop-jobs-col-updated" />
+              </colgroup>
               <thead>
                 <tr>
                   <th>Job</th>
@@ -819,7 +828,7 @@ export function SmartCropScreen({ initialJobs }: SmartCropScreenProps) {
                     <tr key={job.id}>
                       <td>
                         <Link href={`/dashboard/smart-crop/${job.id}`}>
-                          {job.id}
+                          <span className="smart-crop-jobs-id">{job.id}</span>
                         </Link>
                       </td>
                       <td>
@@ -827,7 +836,14 @@ export function SmartCropScreen({ initialJobs }: SmartCropScreenProps) {
                           {summary.kind}
                         </span>
                       </td>
-                      <td>{summary.assetId}</td>
+                      <td>
+                        <span
+                          className="smart-crop-jobs-asset"
+                          title={summary.assetId}
+                        >
+                          {summary.assetId}
+                        </span>
+                      </td>
                       <td>{summary.language ?? "—"}</td>
                       <td>
                         <span

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,8 @@
 [phases.setup]
 nixPkgs = ["...", "ffmpeg"]
+
+# Railway runs Nixpacks' install phase before a service buildCommand. Some
+# services set NODE_ENV=production at deploy time, which otherwise makes pnpm
+# skip devDependencies needed by monorepo lifecycle scripts and TS builds.
+[phases.install]
+cmds = ["NODE_ENV=development pnpm install --frozen-lockfile"]


### PR DESCRIPTION
## Summary

Smart Crop no longer makes the Manager dashboard wider than the viewport when a failed job carries long job and Mux asset IDs. The jobs table now keeps readable columns, breaks long identifiers, and scrolls within the table wrapper on narrow screens instead of stretching the whole page.

The production failure was not missing Manager Smart Crop config: the crop-worker service could not deploy because Nixpacks installed dependencies under `NODE_ENV=production` before the service build command, skipping devDependencies needed by monorepo lifecycle scripts and the TypeScript build. The root Nixpacks install phase now installs with `NODE_ENV=development`, and the crop-worker Railway build command only runs the worker build after install.

## Validation

- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/crop-worker build`
- `pnpm --filter @forge/crop-worker typecheck`
- `pnpm --filter @forge/crop-worker test`
- `pnpm --filter @forge/manager test -- src/features/smart-crop/smart-crop-presenter.test.ts src/app/api/smart-crop/jobs/route.test.ts 'src/app/api/smart-crop/jobs/[id]/retry/route.test.ts'`
- `git diff --check origin/main...HEAD`
- Browser proof with long production-shaped IDs: desktop had no page overflow; at 390px the document stayed viewport-width and the Smart Crop table scrolled inside its wrapper. Local screenshot: `/private/tmp/smart-crop-layout-proof-mobile.png`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
