### PR TITLE
fix(web): show pending state during Watch language switches

### DIFF
--- a/apps/web/src/components/watch/LanguagePickerModal.tsx
+++ b/apps/web/src/components/watch/LanguagePickerModal.tsx
@@ -14,11 +14,13 @@ import {
 import { useTranslations } from "next-intl"
 import type { ReactNode, RefObject } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { flushSync } from "react-dom"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { SpinnerIcon } from "@/components/ui/spinner"
 import { LanguageCombobox } from "@/components/watch/LanguageCombobox"
 import type { WatchLanguagePickerVariant, WatchSubtitle } from "@/lib/content"
 import { deriveLanguageDisplay } from "@/lib/language-display"
@@ -466,6 +468,25 @@ export function LanguagePickerModal({
   const navigating =
     pendingNavTo !== null && currentLanguageSlug !== pendingNavTo
 
+  const buildTargetPath = useCallback(
+    (languageSlug: string) => {
+      const slug = tryAsContentSlug(videoSlug)
+      const lang = tryAsLocaleSlug(languageSlug)
+      if (!slug || !lang) return null
+      if (kind === "series") return watchVideoPath(slug, lang)
+
+      const rawT = playerRef.current?.currentTime
+      const t = typeof rawT === "number" && Number.isFinite(rawT) ? rawT : 0
+      const collection = collectionSlug
+        ? tryAsContentSlug(collectionSlug)
+        : null
+      return collection
+        ? watchEpisodePath(collection, slug, lang, { t, autoplay: true })
+        : watchVideoPath(slug, lang, { t, autoplay: true })
+    },
+    [collectionSlug, kind, playerRef, videoSlug],
+  )
+
   // Release the sync guard once the URL catches up. The ref-mirror effect
   // is the only path that touches `.inFlight = false` outside the open
   // reset and timeout — fires once per slug change.
@@ -486,6 +507,18 @@ export function LanguagePickerModal({
     return () => window.clearTimeout(timer)
   }, [pendingNavTo])
 
+  const lastPrefetchedPathRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!open) return
+    if (!languageDirty) return
+    const targetPath = buildTargetPath(draftSlug)
+    if (!targetPath) return
+    if (targetPath === lastPrefetchedPathRef.current) return
+
+    lastPrefetchedPathRef.current = targetPath
+    Promise.resolve(router.prefetch(targetPath)).catch(() => undefined)
+  }, [buildTargetPath, draftSlug, languageDirty, open, router])
+
   const handleApply = useCallback(() => {
     if (!isDirty) return
     if (navigatingRef.current.inFlight) return
@@ -502,41 +535,30 @@ export function LanguagePickerModal({
       // navigation — rather than poison the cookie then no-op (matches
       // SeriesPageClient's validate-before-write ordering). The rest of
       // handleApply (incl. onClose) still runs.
-      const slug = tryAsContentSlug(videoSlug)
-      const lang = tryAsLocaleSlug(draftSlug)
-      if (slug && lang) {
+      const targetPath = buildTargetPath(draftSlug)
+      if (targetPath) {
         navigatingRef.current.inFlight = true
-        setPendingNavTo(draftSlug)
+        // Commit the visible pending state before starting App Router
+        // navigation. Otherwise React may batch the state update with
+        // router.push, which is exactly the "nothing happened" feeling
+        // this modal is meant to avoid on cold language routes.
+        flushSync(() => setPendingNavTo(draftSlug))
         writePreferredLanguageSlug(draftSlug)
-        if (kind === "series") {
-          router.push(watchVideoPath(slug, lang))
-        } else {
-          const rawT = playerRef.current?.currentTime
-          const t = typeof rawT === "number" && Number.isFinite(rawT) ? rawT : 0
-          const collection = collectionSlug
-            ? tryAsContentSlug(collectionSlug)
-            : null
-          router.push(
-            collection
-              ? watchEpisodePath(collection, slug, lang, { t, autoplay: true })
-              : watchVideoPath(slug, lang, { t, autoplay: true }),
-          )
-        }
+        router.push(targetPath)
+        return
       }
     }
 
     onClose()
   }, [
+    buildTargetPath,
     draftSlug,
     draftSubtitleEnabled,
     draftSubtitleSlug,
     isDirty,
-    kind,
-    collectionSlug,
     languageDirty,
     onClose,
     onSubtitleChange,
-    playerRef,
     router,
     subtitleDirty,
     videoSlug,
@@ -854,14 +876,26 @@ export function LanguagePickerModal({
                 data-testid="watch-language-picker-apply"
                 disabled={!isDirty || navigating}
                 onClick={handleApply}
-                className="gap-1.5 bg-stone-300 px-5 py-3 text-xs text-stone-950 hover:bg-white hover:text-stone-950 disabled:bg-stone-300 disabled:text-stone-950"
+                className="inline-flex min-w-28 items-center justify-center gap-1.5 bg-stone-300 px-5 py-3 text-xs text-stone-950 hover:bg-white hover:text-stone-950 disabled:bg-stone-300 disabled:text-stone-950"
               >
-                <Check
-                  aria-hidden
-                  data-testid="watch-language-picker-apply-icon"
-                  className="size-3.5"
-                />
-                <span>{t("apply")}</span>
+                {navigating ? (
+                  <>
+                    <SpinnerIcon
+                      aria-hidden
+                      className="size-3.5 animate-spin"
+                    />
+                    <span>Switching...</span>
+                  </>
+                ) : (
+                  <>
+                    <Check
+                      aria-hidden
+                      data-testid="watch-language-picker-apply-icon"
+                      className="size-3.5"
+                    />
+                    <span>{t("apply")}</span>
+                  </>
+                )}
               </Button>
             </MultilingualTooltip>
           </div>

--- a/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
@@ -19,13 +19,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { MuxPlayerRef } from "@forge/video-player"
 
-const { routerPushMock, writePreferredLanguageSlugMock } = vi.hoisted(() => ({
-  routerPushMock: vi.fn(),
-  writePreferredLanguageSlugMock: vi.fn(),
-}))
+const { routerPrefetchMock, routerPushMock, writePreferredLanguageSlugMock } =
+  vi.hoisted(() => ({
+    routerPrefetchMock: vi.fn(),
+    routerPushMock: vi.fn(),
+    writePreferredLanguageSlugMock: vi.fn(),
+  }))
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: routerPushMock }),
+  useRouter: () => ({
+    prefetch: routerPrefetchMock,
+    push: routerPushMock,
+  }),
 }))
 
 vi.mock("@/lib/language-preference-client", () => ({
@@ -43,6 +48,7 @@ let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
+  routerPrefetchMock.mockReset()
   routerPushMock.mockReset()
   writePreferredLanguageSlugMock.mockReset()
   container = document.createElement("div")
@@ -248,7 +254,7 @@ describe("LanguagePickerModal — globe overlay", () => {
     expect(apply.disabled).toBe(false)
   })
 
-  it("Apply writes the cookie BEFORE calling router.push, then closes", () => {
+  it("Apply writes the cookie BEFORE calling router.push and keeps the modal open while switching", () => {
     const onClose = vi.fn()
     renderModal({ open: true, variants: baseVariants, onClose })
 
@@ -273,7 +279,13 @@ describe("LanguagePickerModal — globe overlay", () => {
       writePreferredLanguageSlugMock.mock.invocationCallOrder[0]!
     const pushOrder = routerPushMock.mock.invocationCallOrder[0]!
     expect(writeOrder).toBeLessThan(pushOrder)
-    expect(onClose).toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+
+    const apply = $(
+      '[data-testid="watch-language-picker-apply"]',
+    ) as HTMLButtonElement
+    expect(apply.disabled).toBe(true)
+    expect(apply.textContent).toContain("Switching...")
   })
 
   it("uses t=0 when the player ref is null", () => {
@@ -820,6 +832,39 @@ describe("LanguagePickerModal — in-flight navigation guard", () => {
     expect(writePreferredLanguageSlugMock).toHaveBeenCalledTimes(1)
   })
 
+  it("clears the switching state when the current language catches up", () => {
+    renderModal({ open: true, variants: baseVariants })
+    act(() => {
+      $('[data-testid="language-combobox-trigger"]')?.click()
+    })
+    const spanish = $$('[data-testid="language-combobox-option"]').find(
+      (el) => el.getAttribute("data-language-slug") === "spanish",
+    )!
+    act(() => {
+      spanish.click()
+    })
+    act(() => {
+      $('[data-testid="watch-language-picker-apply"]')?.click()
+    })
+
+    let apply = $(
+      '[data-testid="watch-language-picker-apply"]',
+    ) as HTMLButtonElement
+    expect(apply.textContent).toContain("Switching...")
+
+    renderModal({
+      open: true,
+      variants: baseVariants,
+      currentLanguageSlug: "spanish",
+    })
+
+    apply = $(
+      '[data-testid="watch-language-picker-apply"]',
+    ) as HTMLButtonElement
+    expect(apply.textContent).toContain("Apply")
+    expect(apply.disabled).toBe(true)
+  })
+
   it("kind='video' (default) appends ?t and autoplay=1", () => {
     renderModal({ open: true, variants: baseVariants })
     act(() => {
@@ -916,8 +961,91 @@ describe("LanguagePickerModal — in-flight navigation guard", () => {
         '[data-testid="watch-language-picker-apply"]',
       ) as HTMLButtonElement
       expect(apply.disabled).toBe(false)
+      expect(apply.textContent).toContain("Apply")
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe("LanguagePickerModal — selective language prefetch", () => {
+  it("prefetches the selected target language path once", () => {
+    renderModal({ open: true, variants: baseVariants })
+
+    act(() => {
+      $('[data-testid="language-combobox-trigger"]')?.click()
+    })
+    const spanish = $$('[data-testid="language-combobox-option"]').find(
+      (el) => el.getAttribute("data-language-slug") === "spanish",
+    )!
+    act(() => {
+      spanish.click()
+    })
+
+    expect(routerPrefetchMock).toHaveBeenCalledTimes(1)
+    expect(routerPrefetchMock).toHaveBeenCalledWith(
+      "/the-call.html/spanish.html?t=42&autoplay=1",
+    )
+
+    act(() => {
+      $('[data-testid="language-combobox-trigger"]')?.click()
+    })
+    const spanishAgain = $$('[data-testid="language-combobox-option"]').find(
+      (el) => el.getAttribute("data-language-slug") === "spanish",
+    )!
+    act(() => {
+      spanishAgain.click()
+    })
+
+    expect(routerPrefetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not prefetch the current language or invalid target paths", () => {
+    renderModal({ open: true, variants: baseVariants })
+
+    act(() => {
+      $('[data-testid="language-combobox-trigger"]')?.click()
+    })
+    const english = $$('[data-testid="language-combobox-option"]').find(
+      (el) => el.getAttribute("data-language-slug") === "english",
+    )!
+    act(() => {
+      english.click()
+    })
+    expect(routerPrefetchMock).not.toHaveBeenCalled()
+
+    renderModal({
+      open: true,
+      variants: baseVariants,
+      videoSlug: "bad slug",
+    })
+    act(() => {
+      $('[data-testid="language-combobox-trigger"]')?.click()
+    })
+    const spanish = $$('[data-testid="language-combobox-option"]').find(
+      (el) => el.getAttribute("data-language-slug") === "spanish",
+    )!
+    act(() => {
+      spanish.click()
+    })
+
+    expect(routerPrefetchMock).not.toHaveBeenCalled()
+  })
+
+  it("swallows prefetch failures", async () => {
+    routerPrefetchMock.mockRejectedValueOnce(new Error("prefetch failed"))
+    renderModal({ open: true, variants: baseVariants })
+
+    await act(async () => {
+      $('[data-testid="language-combobox-trigger"]')?.click()
+    })
+    const spanish = $$('[data-testid="language-combobox-option"]').find(
+      (el) => el.getAttribute("data-language-slug") === "spanish",
+    )!
+    await act(async () => {
+      spanish.click()
+    })
+
+    expect(routerPrefetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/docs/plans/2026-06-13-001-feat-watch-language-switch-pending-feedback-plan.md
+++ b/docs/plans/2026-06-13-001-feat-watch-language-switch-pending-feedback-plan.md
@@ -1,0 +1,220 @@
+---
+title: "feat: Add Watch language switch pending feedback"
+status: completed
+origin: docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md
+created: 2026-06-13
+---
+
+# feat: Add Watch Language Switch Pending Feedback
+
+## Problem Frame
+
+Changing language on Watch can trigger a slow App Router navigation because the destination language route may need cold server rendering and admin-backed video data. The current modal closes immediately after Apply, so the user sees the unchanged page for several seconds with no progress state.
+
+Live triage on 2026-06-13 showed the shape of the delay:
+
+- Warm language routes can return in under a second.
+- Cold per-language routes can take roughly 15 seconds before first byte.
+- The worst observed bottleneck is the admin-backed Watch video route/data work on a cold destination, not the local button handler.
+
+The fastest user-visible fix is to keep the language modal open and clearly pending while the existing navigation resolves. Selective prefetch can reduce some warm-path latency, but it should be treated as a best-effort improvement, not the primary correctness fix.
+
+## Scope Boundaries
+
+### In scope
+
+- Keep `LanguagePickerModal` open after Apply when `languageDirty` is true.
+- Show pending Apply state as `Switching...` with a spinner or equivalent progress affordance.
+- Disable duplicate Apply submits during pending navigation.
+- Clear pending state when the route resolves to the selected language or when the existing safety timeout fires.
+- Add selective `router.prefetch` for the draft destination language route.
+- Add focused tests for pending state, duplicate-submit prevention, timeout recovery, and prefetch behavior.
+
+### Out of scope
+
+- Changing admin GraphQL operations or generated gql.tada outputs.
+- Refactoring Watch route resolution or splitting video/experience data paths.
+- Adding a global Watch page loading overlay.
+- Changing route shape, language slug aliases, or cookie semantics.
+- Reworking subtitle controls beyond preserving existing behavior.
+
+### Follow-up candidates
+
+- Add a true video-first route path or typed route discriminator to avoid unnecessary experience resolution on video pages.
+- Split the large `videoBySlug` payload so language switches fetch only what the player needs first.
+- Pre-warm or cache high-traffic language route combinations after deploys.
+
+## Requirements
+
+- **R1. Pending visibility:** When Apply is clicked with a dirty language selection, the modal remains open until the destination language is reflected in props or the navigation timeout fires.
+- **R2. Button state:** While pending, Apply is disabled, displays `Switching...`, and shows a non-layout-shifting spinner/status indicator.
+- **R3. Duplicate guard:** Repeated Apply clicks during pending navigation do not rewrite cookies or call `router.push` again.
+- **R4. Timeout recovery:** If the route does not resolve, the existing safety timeout releases the pending state and lets the user retry or close.
+- **R5. Preference ordering:** `writePreferredLanguageSlug` still runs before `router.push`.
+- **R6. Non-language changes:** Applying subtitle-only or other non-route-changing dirty state keeps the current close behavior.
+- **R7. Selective prefetch:** A changed, valid draft language prefetches exactly its target Watch route and suppresses duplicate or invalid prefetches.
+- **R8. Prefetch failure safety:** `router.prefetch` errors never surface in the UI or block Apply.
+
+## Key Technical Decisions
+
+### Pending state should live in the modal
+
+`LanguagePickerModal` already owns `pendingNavTo`, the navigation in-flight ref, and `NAVIGATING_TIMEOUT_MS`. Keeping the behavior there avoids introducing a global Watch loading state and keeps the fix scoped to the control that feels broken.
+
+### Route resolution should be detected by props
+
+The modal receives `currentLanguageSlug` from the current Watch route. Treat `pendingNavTo !== null && currentLanguageSlug !== pendingNavTo` as pending, and clear the pending state when `currentLanguageSlug` catches up. This matches the existing state shape and avoids trying to subscribe to App Router internals.
+
+### Do not close the modal after route-changing Apply
+
+For a dirty language change, `handleApply` should write the preference cookie, set pending state, push the canonical route, and return without calling `onClose`. For non-route-changing changes, preserve the current close-on-Apply behavior.
+
+### Prefetch only the selected target route
+
+Prefetching every language option would create avoidable server and cache pressure. Prefetch should run only for the valid draft language target, should dedupe the last target path, and should treat failures as no-ops.
+
+## Implementation Units
+
+### U1. Keep modal open and show pending Apply state
+
+**Goal:** Make language switching visibly in progress instead of closing the modal onto an unchanged page.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+
+- `apps/web/src/components/watch/LanguagePickerModal.tsx`
+- `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+
+**Approach:**
+
+In `handleApply`, keep the existing language-dirty branch order:
+
+1. Validate the selected target language.
+2. Set `navigatingRef.current.inFlight = true`.
+3. Set `pendingNavTo` to the selected language slug.
+4. Call `writePreferredLanguageSlug`.
+5. Call `router.push(watchVideoPath(...))`.
+
+Then return without calling `onClose` for the language-dirty route transition. Keep `onClose` for branches that apply local-only settings without route navigation.
+
+Update the Apply button so pending navigation renders:
+
+- disabled state unchanged
+- visible label `Switching...`
+- spinner/status icon that does not resize the button
+- accessible pending text via the button label or an adjacent `aria-live` status if needed
+
+Keep the existing safety timeout and ensure it clears `pendingNavTo` and the in-flight ref.
+
+**Test scenarios:**
+
+- Dirty language Apply writes the cookie, calls `router.push`, and does not call `onClose` immediately.
+- Apply button displays `Switching...` while pending.
+- Double-clicking Apply while pending calls `router.push` once.
+- Updating `currentLanguageSlug` to the pending target clears the pending state.
+- Firing the safety timeout clears the pending state and allows retry.
+- Subtitle-only Apply, if dirty without language change, preserves current close behavior.
+
+**Verification:**
+
+- `pnpm --filter web test -- LanguagePickerModal.test.tsx`
+- `pnpm --filter web typecheck`
+
+### U2. Add selective draft-language prefetch
+
+**Goal:** Reduce avoidable latency when the user pauses on a target language before applying.
+
+**Requirements:** R7, R8
+
+**Dependencies:** U1 can land independently; U2 should reuse the same route-builder inputs.
+
+**Files:**
+
+- `apps/web/src/components/watch/LanguagePickerModal.tsx`
+- `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+
+**Approach:**
+
+Add a client-side effect that runs when the modal is open and the draft language changes. If the draft language differs from `currentLanguageSlug`, resolve its `WatchVariant`, build the destination with `watchVideoPath`, and call `router.prefetch(targetPath)`.
+
+Guardrails:
+
+- Skip if the modal is closed.
+- Skip if the draft slug equals `currentLanguageSlug`.
+- Skip if the draft slug cannot resolve to a variant/language.
+- Store the last prefetched path in a ref and skip repeats.
+- Wrap prefetch in `try/catch` or `Promise.resolve(...).catch(() => undefined)` so failure is silent.
+
+**Test scenarios:**
+
+- Selecting a different valid language calls `router.prefetch` with the same target path Apply will push.
+- Re-selecting the same target does not prefetch twice.
+- Selecting the current language does not prefetch.
+- Invalid target language does not prefetch.
+- Rejected prefetch promise does not throw into the component.
+
+**Verification:**
+
+- `pnpm --filter web test -- LanguagePickerModal.test.tsx`
+- `pnpm --filter web typecheck`
+
+### U3. Browser smoke and regression check
+
+**Goal:** Prove the change fixes the perceived-broken state on an actual Watch page.
+
+**Requirements:** R1, R2, R3, R4, R7
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- No new production files beyond U1/U2.
+
+**Approach:**
+
+Use Helium browser against a local web server or a preview deploy. Navigate to a Watch video route, open the language modal, pick a different audio language, and click Apply.
+
+Confirm:
+
+- The modal remains open after Apply.
+- Apply shows `Switching...` while navigation is pending.
+- A second click does not trigger repeated navigation.
+- The modal recovers if the safety timeout fires.
+- On successful route resolution, the pending state clears and the selected language is reflected.
+
+If browser proof uses production data, keep the interaction read-only except for the local language preference cookie.
+
+**Verification:**
+
+- Helium screenshot or snapshot showing the pending state.
+- No console errors related to prefetch failure or state updates after unmount.
+
+## Risks And Mitigations
+
+- **Risk:** Keeping the modal open after Apply could feel stuck if route resolution never completes.
+  - **Mitigation:** Preserve the existing safety timeout and make the button return to a retryable state.
+
+- **Risk:** Prefetching can add load without improving cold route generation.
+  - **Mitigation:** Prefetch only the single selected target and dedupe repeated paths.
+
+- **Risk:** Route prop update may not be observable if the modal unmounts during navigation.
+  - **Mitigation:** Treat unmount as acceptable success; tests should cover the state path for mounted rerenders and timeout recovery.
+
+- **Risk:** Spinner styling could resize the Apply button.
+  - **Mitigation:** Use stable button dimensions and a fixed-size icon.
+
+## Validation Checklist
+
+- [x] `pnpm --filter web test -- LanguagePickerModal.test.tsx`
+- [x] `pnpm --filter web typecheck`
+- [x] Helium smoke of Watch language switch pending state: local route `/watch/lumo-the-gospel-of-john.html/english.html` opened the modal, selected Romanian, showed disabled `SWITCHING...` after Apply, then resolved to `/watch/lumo-the-gospel-of-john.html/romanian.html`; console retained unrelated local production-backed/RSC fallback noise during the run
+- [x] Confirm no generated GraphQL or unrelated roadmap files changed
+
+## Notes From Investigation
+
+- Cold language route generation is the worst bottleneck observed during live triage; UI feedback will not remove that server wait, but it makes the action legible.
+- Selective prefetch helps only when the target route can be fetched before Apply. It will not guarantee savings on first-ever cold routes.
+- The separate performance follow-up should inspect `apps/web/src/app/[slug]/[...rest]/page.tsx` and `apps/web/src/lib/content.ts`, especially the experience-first/video-fallback flow and large Watch video payload.

--- a/docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md
+++ b/docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md
@@ -1,0 +1,84 @@
+---
+id: "feat-107"
+title: "Watch Language Switch Pending Feedback"
+owner: "urim"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-13"
+duration: 2
+depends_on:
+  - "feat-047"
+blocks: []
+tags:
+  - "web"
+  - "watch"
+  - "ux"
+  - "performance"
+---
+
+## Problem
+
+Changing the audio language on Watch can take several seconds on a cold per-language route, especially when the destination page needs fresh server rendering. Today the language modal closes immediately after Apply, leaving the old page visible with no pending feedback. Users can interpret the delay as a broken control.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/watch/LanguagePickerModal.tsx` - Apply handler, pending navigation guard, safety timeout, and Apply button state.
+2. `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx` - modal behavior tests for cookie writes, router navigation, duplicate-submit guard, and timeout recovery.
+3. `apps/web/src/components/watch/WatchPageClient.tsx` - client wrapper that owns modal open/close state and passes current route language props.
+4. `apps/web/src/lib/routes.ts` - canonical Watch URL builder used by `router.push`.
+5. `apps/web/src/app/[slug]/[...rest]/page.tsx` and `apps/web/src/lib/content.ts` - route/data path that explains why cold language transitions can be slow, but is out of scope for the first UX fix.
+
+## Grep These
+
+- `pendingNavTo|NAVIGATING_TIMEOUT_MS|handleApply|languageDirty|Switching` in `apps/web/src/components/watch/LanguagePickerModal.tsx`
+- `writePreferredLanguageSlug|router.push|onClose` in `apps/web/src/components/watch/LanguagePickerModal.tsx`
+- `watchVideoPath|router.prefetch` in `apps/web/src/`
+- `resolveWatchPage|resolveWatchVideoBySlug|fetchWatchVideoBySlug` in `apps/web/src/lib/content.ts`
+
+## What To Build
+
+1. Keep the language modal open after Apply when the language selection is dirty.
+   - Show the Apply button as `Switching...` with a spinner or equivalent progress affordance.
+   - Disable duplicate submits while navigation is in flight.
+   - Keep the existing safety timeout so the user is not trapped if the route never resolves.
+   - Close immediately only for non-language-only modal changes that do not trigger a route transition.
+
+2. Add selective target-route prefetching.
+   - Prefetch the Watch route for the currently selected draft language when the user changes the language inside the modal.
+   - Keep prefetch best-effort and client-only; failures should not block Apply.
+   - Avoid prefetching unchanged languages, invalid slugs, or repeated identical targets.
+   - Do not prefetch every available language.
+
+3. Preserve the current route and preference contracts.
+   - Keep the client cookie write before `router.push`.
+   - Keep the canonical Watch URL builder as the only route construction path.
+   - Keep subtitle-only changes behavior unchanged unless they share the final Apply button state.
+
+## Constraints
+
+- Do not change the admin GraphQL fragment or generated client types in this PR-sized slice.
+- Do not solve the deeper cold-route data bottleneck here; document it as follow-up performance work.
+- Do not introduce a new global loading overlay for the Watch page.
+- Do not remove the navigation safety timeout.
+- Keep modal copy short and local to the existing UI; the first visible fix is status, not education.
+
+## Verification
+
+- Focused unit test for dirty-language Apply:
+  - modal stays open after Apply
+  - Apply button changes to `Switching...`
+  - duplicate submits are ignored while pending
+  - modal closes or pending state clears when the destination language prop resolves
+  - safety timeout clears pending state if the route does not resolve
+- Focused unit test for selective prefetch:
+  - prefetch runs for a changed valid target language
+  - prefetch does not run for unchanged, invalid, or duplicate target paths
+  - prefetch errors are swallowed
+- `pnpm --filter web test -- LanguagePickerModal.test.tsx`
+- `pnpm --filter web typecheck`
+- Browser smoke with Helium:
+  - open a Watch video route
+  - open language modal
+  - choose a different audio language
+  - press Apply
+  - confirm modal remains visible, Apply shows pending feedback, and duplicate clicks do not trigger repeated navigation


### PR DESCRIPTION
## Summary
- keep the Watch language modal open during route-changing Apply and show a disabled `Switching...` spinner state
- guard duplicate submits while navigation is pending, with timeout recovery when the route never catches up
- prefetch only the selected destination language route and preserve collection/episode-aware routing
- supersedes #1255, which was based on stale main and became DIRTY

## Validation
- `pnpm --filter web test -- LanguagePickerModal.test.tsx`
- `pnpm --filter web test -- messages-parity.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- Helium/agent-browser smoke: opened local Watch page, selected Romanian, Apply showed disabled `SWITCHING...`, then route resolved to `/watch/lumo-the-gospel-of-john.html/romanian.html`. Console history had unrelated local production-backed/RSC fallback noise.