### PR TITLE
fix(shorts-worker): create whisper model directory

### DIFF
--- a/apps/shorts-worker/Dockerfile
+++ b/apps/shorts-worker/Dockerfile
@@ -91,7 +91,8 @@ RUN node --input-type=module -e "import('@remotion/install-whisper-cpp').then(({
 # and update this ARG — same operational posture as WHISPER_CPP_COMMIT_SHA.
 # Rotating invalidates (and reships) the ~1.6GB model layer.
 ARG WHISPER_MODEL_SHA256=1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69
-RUN node --input-type=module -e "import('@remotion/install-whisper-cpp').then(({ downloadWhisperModel }) => downloadWhisperModel({ model: 'large-v3-turbo', folder: '/opt/whisper-models' }))" \
+RUN mkdir -p /opt/whisper-models \
+    && node --input-type=module -e "import('@remotion/install-whisper-cpp').then(({ downloadWhisperModel }) => downloadWhisperModel({ model: 'large-v3-turbo', folder: '/opt/whisper-models' }))" \
     && echo "${WHISPER_MODEL_SHA256}  /opt/whisper-models/ggml-large-v3-turbo.bin" | sha256sum -c -
 
 # chrome-headless-shell, pinned transitively by the exact @remotion/renderer


### PR DESCRIPTION
## Summary
- create /opt/whisper-models before downloading the large-v3-turbo Whisper model in the shorts-worker image

## Validation
- Railway production shorts-worker deploy f4b19248 succeeded; build verified the ggml-large-v3-turbo checksum and /health returned 200
- Manager production deploy 91d0d88f succeeded after SHORTS_WORKER_* vars were added; /api/health returned 200
- Production /api/shorts/videos eligibility checks returned 200 for real video candidates
- git diff --check