### PR TITLE
fix(search): hydrate semantic video card metadata

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -102,6 +102,10 @@ The metadata that says which provider contract produced a stored Content Embeddi
 
 An evaluation or backfill approval artifact that binds quality evidence to a specific embedding provider contract before high-churn content vectors are rewritten. A Provider-Bound Gate needs both configuration provenance and corpus provenance: it must show what the system is configured to generate and what stored rows the evaluation actually searched.
 
+### Semantic Evidence
+
+The content fragment that explains why a search result matched a query, such as a scene description or transcript chunk. Semantic Evidence belongs to retrieval, ranking, debug context, and optional timecodes; consumer card surfaces should render display metadata unless they are intentionally showing match context.
+
 ## Known-caller auth
 
 ### Search Passport

--- a/apps/admin/schema.graphql
+++ b/apps/admin/schema.graphql
@@ -322,7 +322,7 @@ type HybridSearchResponse {
 }
 
 """
-A single hybrid-search hit. Video results may carry scene-level snippet + timecode + playback id; experience results carry experience-level data.
+A single hybrid-search hit. Video results carry video-level display metadata plus optional match timecode/playback data; experience results carry experience-level data.
 """
 type HybridSearchResult {
   """

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -50,7 +50,7 @@ const SearchModeEnum = builder.enumType("HybridSearchMode", {
 const SearchResultRef = builder.objectRef<SearchResult>("HybridSearchResult")
 SearchResultRef.implement({
   description:
-    "A single hybrid-search hit. Video results may carry scene-level snippet + timecode + playback id; experience results carry experience-level data.",
+    "A single hybrid-search hit. Video results carry video-level display metadata plus optional match timecode/playback data; experience results carry experience-level data.",
   fields: (t) => ({
     type: t.field({
       type: ContentTypeEnum,

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -524,6 +524,74 @@ describe("HybridSearchService", () => {
   })
 
   describe("card-pill hydration", () => {
+    it("hydrates video display metadata so cards use descriptions and thumbnails instead of evidence text", async () => {
+      vi.mocked(searchVideoSemantic).mockResolvedValue([
+        {
+          resultType: "video",
+          resultId: "vid-transcript",
+          videoCoreId: "1_jf",
+          videoSlug: "who-is-jesus",
+          videoTitle: "Who Is Jesus?",
+          imageUrl: "",
+          sceneDescription:
+            "<b>Following Jesus</b> <b>Who is Jesus?</b> <b>Uh yes</b>",
+          startSeconds: 17,
+          playbackId: "",
+          similarity: 0.9,
+          embeddingText: "[]",
+        },
+      ])
+
+      mockPrisma.video.findMany.mockResolvedValueOnce([
+        {
+          id: "vid-transcript",
+          label: "EPISODE",
+          primaryLanguageId: "lang-en",
+          locales: [
+            {
+              description: "A concise public description of the video.",
+              snippet: "A shorter fallback snippet.",
+            },
+          ],
+          images: [
+            {
+              mobileCinematicHigh: "https://cdn.example/cover-high.jpg",
+              mobileCinematicLow: null,
+              videoStill: null,
+              url: null,
+              thumbnail: null,
+            },
+          ],
+          dubs: [
+            {
+              languageId: "lang-en",
+              duration: 70,
+              muxVideo: { playbackId: "mux-hydrated" },
+            },
+          ],
+          _count: { children: 0 },
+        },
+      ])
+
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: successEmbedder(),
+        logger,
+      })
+
+      const result = await service.search({ query: "jesus", locale: "en" })
+
+      expect(result.results[0]).toMatchObject({
+        id: "vid-transcript",
+        snippet: "A concise public description of the video.",
+        imageUrl: "https://cdn.example/cover-high.jpg",
+        playbackId: "mux-hydrated",
+        label: "EPISODE",
+        durationSeconds: 70,
+        childCount: 0,
+      })
+    })
+
     it("populates label, durationSeconds, childCount on video rows from one batched findMany", async () => {
       vi.mocked(searchVideoSemantic).mockResolvedValue([
         {

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -181,9 +181,9 @@ export type SearchResult = {
   title: string
   imageUrl: string | null
   snippet: string
-  /** null when the match is keyword-only or for non-video results. */
+  /** null when the match has no timed evidence or for non-video results. */
   startSeconds: number | null
-  /** null when the match is keyword-only or for non-video results. */
+  /** null when no playable Mux-backed dub was found or for non-video results. */
   playbackId: string | null
   score: number
   /**
@@ -274,10 +274,11 @@ const defaultEmbedder: QueryEmbedder = async (text) => {
 /**
  * Map a fused result to the API response contract.
  *
- * Video rows may carry scene-level data (description as snippet,
- * startSeconds + playbackId for semantic matches; null for
- * keyword-only). Experience rows carry experience-level data
- * (metaDescription as snippet) with null startSeconds/playbackId.
+ * Video rows may carry evidence-level data from retrievers (scene/transcript
+ * text, startSeconds + playbackId for semantic matches; null for keyword-only).
+ * The post-fusion hydration pass below replaces the public snippet with
+ * video-level metadata when it exists. Experience rows carry experience-level
+ * data (metaDescription as snippet) with null startSeconds/playbackId.
  */
 function mapToSearchResult(result: FusedResult): SearchResult {
   const score = Math.round(result.score * 1000) / 1000
@@ -307,10 +308,9 @@ function mapToSearchResult(result: FusedResult): SearchResult {
     slug: (result.videoSlug as string) ?? "",
     title: (result.videoTitle as string) ?? "",
     imageUrl: (result.imageUrl as string | null) ?? null,
-    // Semantic-video rows carry scene-level `sceneDescription`; keyword
-    // rows carry video-level `description`. Fusion merges earlier-list
-    // properties first, so a video that hits both lists keeps the
-    // semantic scene description (the richer signal).
+    // Initial fallback only. `hydrateCardDisplayFields` replaces this
+    // evidence text with VideoLocale description/snippet for the public
+    // card surface when localized metadata exists.
     snippet:
       (result.sceneDescription as string | undefined) ??
       (result.description as string | undefined) ??
@@ -336,17 +336,23 @@ function mapToSearchResult(result: FusedResult): SearchResult {
  * the catalogue carry 200+ published dubs).
  */
 const HYDRATION_DUBS_PER_VIDEO = 5
+const HYDRATION_IMAGES_PER_VIDEO = 5
 
 /**
- * Card-pill hydration. Given the final page of video-type results,
- * batch-load `label`, primary playable dub duration, and child count
- * in ONE Prisma query and return a new array with those fields filled
- * in. Experience results pass through untouched (their card surface
- * doesn't carry a pill in the current design).
+ * Card display hydration. Given the final page of video-type results,
+ * batch-load card metadata in ONE Prisma query and return a new array
+ * with display fields filled in:
+ *
+ * - public snippet from VideoLocale description/snippet
+ * - imageUrl from VideoImage variants
+ * - playbackId fallback from a playable Mux-backed dub
+ * - label, primary playable dub duration, and child count
+ *
+ * Experience results pass through untouched.
  *
  * Why a post-mapping pass instead of fetching the data inline in each
  * retriever: the retrievers project tightly via `$queryRaw` for index
- * use; adding 3 extra fields per retriever would either duplicate the
+ * use; adding extra display fields per retriever would either duplicate the
  * LATERALs across 4+ SQL paths or force a UNION shape change. A single
  * `findMany({ where: { id: { in: [...] } } })` after pagination is
  * O(page-size) — at most ~50 rows for MAX_LIMIT — and keeps the SQL
@@ -359,19 +365,19 @@ const HYDRATION_DUBS_PER_VIDEO = 5
  * fixture to per-id hydration stubs argues against dropping; if the
  * UX of "card-then-404" becomes meaningful, switch to a drop here.
  */
-async function hydrateCardPillFields(
+async function hydrateCardDisplayFields(
   prisma: PrismaClient,
   results: SearchResult[],
+  locale: string,
   logger?: { error: (msg: string) => void },
 ): Promise<SearchResult[]> {
   const videoIds = results.filter((r) => r.type === "video").map((r) => r.id)
   if (videoIds.length === 0) return results
 
-  // Hydration data (label / durationSeconds / childCount) is cosmetic —
-  // a card renders without it. A Prisma error here must NOT take the
-  // search endpoint down. Catch, log, and pass through the pre-hydration
-  // array; consumers see a search response with null pill fields rather
-  // than HTTP 503 for the whole request.
+  // Hydration data is display-only — a card renders without it. A Prisma
+  // error here must NOT take the search endpoint down. Catch, log, and pass
+  // through the pre-hydration array; consumers see a search response with
+  // sparse card metadata rather than HTTP 503 for the whole request.
   let rows
   try {
     rows = await prisma.video.findMany({
@@ -380,6 +386,30 @@ async function hydrateCardPillFields(
         id: true,
         label: true,
         primaryLanguageId: true,
+        locales: {
+          where: {
+            locale,
+            status: "PUBLISHED",
+            deletedAt: null,
+          },
+          take: 1,
+          select: {
+            description: true,
+            snippet: true,
+          },
+        },
+        images: {
+          where: { deletedAt: null },
+          orderBy: [{ createdAt: "asc" }],
+          take: HYDRATION_IMAGES_PER_VIDEO,
+          select: {
+            mobileCinematicHigh: true,
+            mobileCinematicLow: true,
+            videoStill: true,
+            thumbnail: true,
+            url: true,
+          },
+        },
         dubs: {
           // `duration: { gt: 0 }` excludes sync-glitch rows (Core
           // occasionally returns a published dub with duration=0; the
@@ -401,7 +431,11 @@ async function hydrateCardPillFields(
           // widen `take` (cost is bounded at 50 × N rows per request).
           orderBy: [{ duration: "desc" }],
           take: HYDRATION_DUBS_PER_VIDEO,
-          select: { languageId: true, duration: true },
+          select: {
+            languageId: true,
+            duration: true,
+            muxVideo: { select: { playbackId: true } },
+          },
         },
         // `_count.children` mirrors the consumer-facing ABAC at
         // videoChildrenFilter (apps/admin/src/graphql/types/video.ts):
@@ -439,6 +473,9 @@ async function hydrateCardPillFields(
   const hydration = new Map<
     string,
     {
+      snippet: string | null
+      imageUrl: string | null
+      playbackId: string | null
       label: VideoLabel | null
       durationSeconds: number | null
       childCount: number
@@ -453,10 +490,19 @@ async function hydrateCardPillFields(
     const primaryDub = row.primaryLanguageId
       ? row.dubs.find((d) => d.languageId === row.primaryLanguageId)
       : undefined
-    const dub = primaryDub ?? row.dubs[0] ?? null
+    const durationDub = primaryDub ?? row.dubs[0] ?? null
+    const playbackDub =
+      (nonEmptyString(primaryDub?.muxVideo?.playbackId) != null
+        ? primaryDub
+        : undefined) ??
+      row.dubs.find((d) => nonEmptyString(d.muxVideo?.playbackId) != null) ??
+      durationDub
     hydration.set(row.id, {
+      snippet: pickLocalizedSnippet(row.locales),
+      imageUrl: pickImageUrl(row.images),
+      playbackId: nonEmptyString(playbackDub?.muxVideo?.playbackId),
       label: row.label,
-      durationSeconds: dub?.duration ?? null,
+      durationSeconds: durationDub?.duration ?? null,
       childCount: row._count.children,
     })
   }
@@ -467,11 +513,60 @@ async function hydrateCardPillFields(
     if (h == null) return r
     return {
       ...r,
+      snippet: h.snippet ?? r.snippet,
+      imageUrl: nonEmptyString(r.imageUrl) ?? h.imageUrl,
+      playbackId: nonEmptyString(r.playbackId) ?? h.playbackId,
       label: h.label,
       durationSeconds: h.durationSeconds,
       childCount: h.childCount,
     }
   })
+}
+
+function pickLocalizedSnippet(
+  locales:
+    | readonly ({
+        description?: string | null
+        snippet?: string | null
+      } | null)[]
+    | undefined,
+): string | null {
+  const locale = locales?.[0]
+  return nonEmptyString(locale?.description) ?? nonEmptyString(locale?.snippet)
+}
+
+function pickImageUrl(
+  images:
+    | readonly ({
+        mobileCinematicHigh?: string | null
+        mobileCinematicLow?: string | null
+        videoStill?: string | null
+        thumbnail?: string | null
+        url?: string | null
+      } | null)[]
+    | undefined,
+): string | null {
+  const priorities = [
+    "mobileCinematicHigh",
+    "mobileCinematicLow",
+    "videoStill",
+    "thumbnail",
+    "url",
+  ] as const
+
+  for (const field of priorities) {
+    for (const image of images ?? []) {
+      const value = nonEmptyString(image?.[field])
+      if (value != null) return value
+    }
+  }
+  return null
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
 }
 
 export type HybridSearchServiceDeps = {
@@ -720,14 +815,12 @@ export class HybridSearchService {
       return { ...base, debug: trace }
     })
 
-    // Hydrate card-pill fields (label, durationSeconds, childCount) for
-    // video results in one batched query. Experience rows are left as
-    // (null, null, null) by the mapper; this pass only touches videos
-    // and returns a fresh array — soft-deleted-mid-search rows are
-    // filtered out rather than surfaced with stale title + null pill.
-    const results = await hydrateCardPillFields(
+    // Hydrate card display fields for video results in one batched query.
+    // Experience rows pass through untouched.
+    const results = await hydrateCardDisplayFields(
       this.prisma,
       mapped,
+      locale,
       this.logger,
     )
 

--- a/apps/web/src/components/search/VideoCard.tsx
+++ b/apps/web/src/components/search/VideoCard.tsx
@@ -61,11 +61,9 @@ function gradientForSlug(slug: string): string {
   return EXPERIENCE_PLACEHOLDER_GRADIENTS[index]
 }
 
-// Admin's hybrid-search response sets `imageUrl: null` until R8 wires
-// real ogImage / VideoImage; `playbackId` is reliably populated for
-// video results (INNER JOIN on dub/mux at the retriever), so the Mux
-// thumbnail endpoint gives us a frame-accurate poster — and when the
-// match is scene-level, `startSeconds` lets us land on the matched scene.
+// Admin hybrid search can return a curated `imageUrl`; when it cannot,
+// `playbackId` lets the card fall back to a Mux poster. Scene-level
+// matches can also use `startSeconds` to land near the matched moment.
 function muxSearchThumbnail(
   playbackId: string,
   startSeconds: number | null,

--- a/docs/plans/2026-06-14-001-fix-semantic-search-video-card-display-metadata-plan.md
+++ b/docs/plans/2026-06-14-001-fix-semantic-search-video-card-display-metadata-plan.md
@@ -1,0 +1,91 @@
+---
+title: Semantic Search Video Card Display Metadata Fix Plan
+type: fix
+date: 2026-06-14
+---
+
+# Semantic Search Video Card Display Metadata Fix Plan
+
+## Summary
+
+Fix semantic-search video cards so the public card surface uses video-level display metadata instead of raw semantic evidence. The implementation should hydrate missing thumbnails and playback ids for the final result page while preserving semantic ranking, match timecodes, and existing experience-result behavior.
+
+---
+
+## Problem Frame
+
+The web Semantic Search surface shows some video tiles without cover images and renders transcript-like text with literal markup under the title. The web `VideoCard` component is mostly a presenter: it renders `imageUrl`, `playbackId`, and `snippet` from the search-result contract. The likely fix belongs at the admin hybrid-search result boundary, where fused semantic evidence is currently exposed as card display text and sparse retriever projections are not hydrated into final card fields.
+
+---
+
+## Requirements
+
+- R1. Video search cards must prefer localized video description metadata for `snippet` when a published locale row exists.
+- R2. Semantic evidence such as scene descriptions or transcript chunks may remain available as fallback text, but it must not override video-level display metadata.
+- R3. Video search cards must receive a cover image when one exists on the video image records, even when the semantic retriever row did not project an image.
+- R4. Video search cards must receive a playable Mux `playbackId` when one exists on a published playable dub, even when the semantic retriever row did not project it.
+- R5. Existing card pill fields, including label, duration, and child count, must keep their current behavior.
+- R6. Experience search results must continue to use experience-level metadata and must not be affected by video hydration.
+- R7. The fix must be covered by a focused regression test that reproduces transcript-like evidence text, missing image data, and missing playback data.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Hydrate display fields after fusion and pagination: the final page is already batched for video card pill data, so extending that pass avoids duplicating lateral joins across semantic and keyword retrievers.
+- KTD2. Treat semantic text as match evidence, not primary card copy: retrievers can continue using transcript or scene evidence for ranking and `startSeconds`, while the public `snippet` contract prefers video locale metadata.
+- KTD3. Preserve sparse-result resilience: hydration is display-only, so failures should keep returning search results with sparse fields rather than failing the full search endpoint.
+- KTD4. Keep the web card component contract stable: the web app should not need to infer whether a snippet is display metadata or evidence text.
+
+---
+
+## Implementation Units
+
+### U1. Admin Hybrid-Search Display Hydration
+
+- **Goal:** Extend the existing post-fusion video hydration pass to fill video-level `snippet`, `imageUrl`, and `playbackId` along with existing pill fields.
+- **Files:** `apps/admin/src/services/hybrid-search.service.ts`.
+- **Patterns:** Follow the current batched `prisma.video.findMany` hydration used for label, duration, and child count.
+- **Test scenarios:** A semantic video row with transcript-like evidence and null media fields is returned with localized description, image URL, Mux playback id, label, duration, and child count after hydration. A row without locale/image/playback metadata keeps the retriever fallback fields.
+- **Verification:** Unit tests cover hydrated and fallback paths without requiring a real database.
+
+### U2. Search Contract and Documentation
+
+- **Goal:** Align the public search-result contract wording with the display metadata behavior.
+- **Files:** `apps/admin/src/graphql/queries/hybrid-search.ts`, `apps/admin/schema.graphql`, `docs/search-api-guide.md`.
+- **Patterns:** Keep generated schema output in sync with Pothos field descriptions and keep docs focused on consumer-visible behavior.
+- **Test scenarios:** Schema tests pass after the description update, and docs describe `snippet` as display metadata with fallback evidence only when video metadata is unavailable.
+- **Verification:** GraphQL schema tests and diff review confirm the generated schema matches the source description.
+
+### U3. Web Contract Regression Coverage
+
+- **Goal:** Verify the web search/card layer remains compatible with the improved admin result contract.
+- **Files:** `apps/web/src/lib/search-actions.test.ts`, `apps/web/src/components/search/VideoCard.test.tsx`.
+- **Patterns:** Reuse existing tests for result mapping and card rendering rather than changing presentation behavior.
+- **Test scenarios:** Existing web tests continue to pass with hydrated `snippet`, `imageUrl`, and `playbackId` values, showing no web-side contract break.
+- **Verification:** Focused web tests and web typecheck pass.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a semantic match whose evidence text is a transcript fragment with markup, when the matching video has a published locale description, then the card snippet is the description rather than the transcript fragment.
+- AE2. Given a semantic match with no projected image URL, when the video has usable image variants, then the card receives an image URL.
+- AE3. Given a semantic match with no projected playback id, when a published playable dub has a Mux playback id, then the card receives the playback id.
+- AE4. Given an experience search result, when display hydration runs, then its metadata remains unchanged.
+
+---
+
+## Scope Boundaries
+
+- This plan does not redesign search ranking, fusion, or semantic evidence selection.
+- This plan does not change the web card layout or image rendering policy.
+- This plan does not add a browser screenshot requirement because the fix is at the admin search-result contract boundary and can be verified with focused contract tests.
+
+---
+
+## Sources and Research
+
+- `apps/web/src/components/search/VideoCard.tsx` renders card display fields from the `SearchResult` contract.
+- `apps/admin/src/services/hybrid-search.service.ts` maps fused retriever rows into public search results and performs post-fusion video hydration.
+- `docs/roadmap/content-discovery/feat-172-forge-algolia-search-modal.md` identifies the Forge modal as the active web search surface and keeps semantic search as the flag-off path.

--- a/docs/search-api-guide.md
+++ b/docs/search-api-guide.md
@@ -1,6 +1,6 @@
 # Semantic Search API — Agent Integration Guide
 
-The JesusFilm Semantic Search API lets AI agents find video content by meaning, not just keywords. It combines vector similarity over scene-level embeddings with PostgreSQL full-text search, merged via Reciprocal Rank Fusion (RRF). Results include scene-level timestamps, themes, bible verses, and Mux playback IDs for deep-linking.
+The JesusFilm Semantic Search API lets AI agents find video content by meaning, not just keywords. It combines vector similarity over scene-level embeddings with PostgreSQL full-text search, merged via Reciprocal Rank Fusion (RRF). Results include video-level display metadata plus optional scene timestamps and Mux playback IDs for deep-linking.
 
 ## Endpoints
 
@@ -70,7 +70,7 @@ Both endpoints are public — no authentication required.
       "slug": "easter-explained",
       "title": "Easter Explained",
       "imageUrl": "https://imagedelivery.net/.../f=jpg,w=1280,h=600,q=95",
-      "snippet": "Themes: new life, awe, meaning.\nBible verses: 2 Corinthians 5:17, Revelation 21:5, John 3:3-7.\nContent: The speaker observes how Easter symbols like bunnies, eggs, and spring flowers represent new life...",
+      "snippet": "A short video explaining the meaning of Easter and the hope of new life.",
       "startSeconds": 0,
       "playbackId": "x3XKV1Yi01z7dyF6f8ZLBMNrHtNWS02iHoQw6vIcf4hBw",
       "score": 0.488
@@ -91,9 +91,9 @@ Both endpoints are public — no authentication required.
 | `slug`         | string                         | URL-safe identifier for linking.                                                                                                                                                                                                                                                             |
 | `title`        | string                         | Display title.                                                                                                                                                                                                                                                                               |
 | `imageUrl`     | string or null                 | Thumbnail URL. Null when no image is available.                                                                                                                                                                                                                                              |
-| `snippet`      | string                         | For video results: scene-level description with themes, bible verses, content summary, tone, and demographics. For experience results: meta description.                                                                                                                                     |
+| `snippet`      | string                         | For video results: localized video description or snippet for display. For experience results: meta description.                                                                                                                                                                             |
 | `startSeconds` | number or null                 | Scene timestamp in seconds. Null for experience results and keyword-only video matches with no scene-level data. Use this to deep-link into a video at the matching moment.                                                                                                                  |
-| `playbackId`   | string or null                 | Mux playback ID. Null for experiences and keyword-only matches. Use to construct thumbnail URLs or playback URLs via Mux.                                                                                                                                                                    |
+| `playbackId`   | string or null                 | Mux playback ID. Null for experiences or when no playable Mux-backed dub is available. Use to construct thumbnail URLs or playback URLs via Mux.                                                                                                                                             |
 | `score`        | number (0-1)                   | RRF-normalized relevance score. Higher is better. Scores are relative within a result set, not absolute.                                                                                                                                                                                     |
 | `hasMore`      | boolean                        | True when more results exist beyond the current page.                                                                                                                                                                                                                                        |
 | `searchMode`   | `"hybrid"` or `"keyword-only"` | Which retrieval paths contributed. `"hybrid"` means semantic + keyword both ran (normal operation). `"keyword-only"` means the embedding service was unavailable and results are from keyword matching only — thematic and felt-need queries will return poor or empty results in this mode. |
@@ -168,7 +168,7 @@ GET /api/search?q=hope&locale=en&limit=10&offset=10
 When `searchMode` is `"keyword-only"`, the embedding service is temporarily unavailable. The API still returns results, but:
 
 - Thematic/felt-need queries may return empty or irrelevant results
-- Scene-level data (`startSeconds`, `playbackId`, rich snippets) will be absent
+- Scene-level match timestamps (`startSeconds`) will be absent
 - Only title/description keyword matches contribute to ranking
 
 Agents should check `searchMode` and adjust behavior accordingly — e.g., fall back to broader keyword queries, or surface a notice that semantic search is temporarily limited.

--- a/docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md
+++ b/docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md
@@ -1,0 +1,116 @@
+---
+title: "Semantic search video cards need display metadata hydration after evidence fusion"
+date: "2026-06-14"
+category: integration-issues
+module: "apps/admin/src/services/hybrid-search.service.ts"
+problem_type: integration_issue
+component: service_object
+symptoms:
+  - "Web Semantic Search video tiles rendered transcript-like text with literal markup under the title"
+  - "Some video tiles showed dark placeholders even when the video had usable cover imagery or a playable Mux dub"
+  - "Experience cards rendered normally, which made the issue look like a web card problem instead of a search-result contract problem"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+related_components:
+  - "apps/web/src/components/search/VideoCard.tsx"
+  - "apps/admin/src/graphql/queries/hybrid-search.ts"
+  - "docs/search-api-guide.md"
+tags:
+  - admin
+  - web
+  - search
+  - semantic-search
+  - video-card
+  - hydration
+  - graphql
+---
+
+# Semantic search video cards need display metadata hydration after evidence fusion
+
+## Problem
+
+The Forge web Semantic Search surface showed video tiles with missing cover images and subtitle text that looked like transcript fragments instead of video descriptions. The bug crossed an admin-to-web contract boundary: the web `VideoCard` rendered the `SearchResult` fields it received, but admin hybrid search exposed semantic match evidence as public card metadata and did not hydrate sparse video media fields after fusion.
+
+## Symptoms
+
+- Video cards displayed text such as highlighted transcript snippets with literal markup under the title.
+- Some cards rendered the dark play-icon fallback even though the video had image records or playable Mux-backed dubs.
+- Experience cards were unaffected because they already used experience-level metadata.
+- The issue reproduced on semantic or mixed semantic results where retrievers returned `sceneDescription`, `imageUrl: null`, or `playbackId: null`.
+
+## What Didn't Work
+
+- **Fixing the web card first.** `apps/web/src/components/search/VideoCard.tsx` already follows the contract: it renders `imageUrl`, falls back to a Mux thumbnail from `playbackId`, and prints `snippet`. Adding transcript/description heuristics there would duplicate backend knowledge in the UI.
+- **Changing retriever SQL inline.** The semantic and keyword retrievers are tuned projections for indexed search paths. Fetching locale descriptions, image variants, and dub playback data in every retriever would duplicate joins across multiple SQL paths.
+- **Treating transcript evidence as richer card copy.** Transcript and scene text are useful for ranking and timecodes, but they are not the same product surface as a localized video description.
+
+## Solution
+
+Keep retriever evidence as the initial fallback, then hydrate final video rows after fusion and pagination. The existing video card-pill hydration already performs one batched `prisma.video.findMany` for the final page; extend that pass to select published localized copy, image variants, and Mux playback data.
+
+The service-level pattern is:
+
+```ts
+const results = await hydrateCardDisplayFields(
+  prisma,
+  mappedSearchResults,
+  locale,
+  logger,
+)
+```
+
+Inside the hydration pass:
+
+- prefer `VideoLocale.description`, then `VideoLocale.snippet`, for public `snippet`;
+- pick a usable image variant for `imageUrl`;
+- pick a playable Mux-backed dub for `playbackId`;
+- preserve existing label, duration, and child-count behavior;
+- leave experience results untouched;
+- treat blank strings as missing so an empty retriever value cannot block a hydrated fallback.
+
+The regression test should model the bad shape directly:
+
+```ts
+vi.mocked(searchVideoSemantic).mockResolvedValue([
+  {
+    resultType: "video",
+    resultId: "vid-transcript",
+    imageUrl: "",
+    sceneDescription: "<b>Following Jesus</b> <b>Who is Jesus?</b>",
+    playbackId: "",
+    // ...
+  },
+])
+
+expect(result.results[0]).toMatchObject({
+  snippet: "A concise public description of the video.",
+  imageUrl: "https://cdn.example/cover-high.jpg",
+  playbackId: "mux-hydrated",
+})
+```
+
+## Why This Works
+
+Fusion and ranking still use the evidence row that matched the query, including `startSeconds` for deep-linking. The public card surface, however, receives video-level display metadata from the canonical video relations after the final page is known.
+
+That keeps the search API boundary clean:
+
+- retrievers answer "why did this result match?";
+- hydration answers "how should this result render as a card?";
+- the web card remains a presenter instead of a semantic-search policy layer.
+
+The batched post-fusion query is also bounded by page size, so it avoids N+1 card lookups without making every retriever carry the same display joins.
+
+## Prevention
+
+- Add a regression test whenever retriever evidence is promoted into the public `SearchResult` contract.
+- In card-facing APIs, distinguish evidence fields from display fields in comments, schema descriptions, and docs.
+- Treat empty strings as missing when overlaying hydrated media fields; otherwise `""` can block a valid fallback just like a bad URL.
+- Keep `docs/search-api-guide.md` examples aligned with the contract so future agents do not reintroduce scene evidence as card copy.
+
+## Related Issues
+
+- `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md` documents the retrieval-side rule that scene and transcript evidence should stay inside `semantic-video`.
+- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md` documents the broader admin hybrid-search port invariants.
+- GitHub issue search for `semantic search video card snippet thumbnail` returned no related issues.


### PR DESCRIPTION
## Summary

Semantic Search video cards no longer have to render transcript fragments as their public subtitle or fall back to dark placeholders when video metadata exists. Admin hybrid search now hydrates the final video result page with localized video descriptions, image variants, and Mux playback ids after fusion, so the web card can stay a presenter while ranking and timecodes still use semantic evidence.

## What Changed

- Hydrates video-level display metadata in the final admin hybrid-search result pass: description/snippet, image URL, Mux playback id, label, duration, and child count.
- Treats blank retriever media strings as missing so empty values cannot block hydrated fallbacks.
- Updates the GraphQL/search docs contract and the stale web card comment to distinguish semantic evidence from display metadata.
- Adds a focused regression test plus formal CE plan/solution artifacts for the search-card hydration pattern.

## Testing

- `pnpm --filter @forge/admin exec vitest run src/services/hybrid-search.service.test.ts src/graphql/schema.test.ts`
- `pnpm --filter @forge/web exec vitest run src/lib/search-actions.test.ts src/components/search/VideoCard.test.tsx`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `pnpm --filter @forge/admin-graphql generate`
- `git diff --check`

No screenshot evidence is attached because this worktree does not have the production-like semantic-search data/env needed to reproduce the exact card set locally.

## Post-Deploy Monitoring & Validation

- **Validation window:** first 24 hours after deploy.
- **Owner:** PR owner / search surface owner.
- **Manual validation:** search for transcript-heavy terms such as `jesus` and `easter` in the web Semantic Search surface. Video cards should show localized video descriptions/snippets, not `<b>` transcript fragments, and cards with available images or playable Mux dubs should show thumbnails.
- **Logs to watch:** search service logs for `event=hydration_failed` and any increase in GraphQL `semanticSearch` errors.
- **Healthy signals:** search responses remain 200/GraphQL-successful; card subtitles are readable display copy; no visible raw markup in card snippets; thumbnail fallbacks resolve through `imageUrl` or Mux playback ids.
- **Failure signals:** widespread blank video tiles, raw transcript markup returning in card subtitles, elevated `hydration_failed` logs, or a spike in search response errors.
- **Mitigation:** revert this PR if display hydration causes broad regressions; the code path is isolated to final result hydration and leaves retriever ranking/fusion intact.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
