### PR TITLE
feat(admin): add legacy OpenAI embedding cleanup CLI

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -106,6 +106,22 @@ An evaluation or backfill approval artifact that binds quality evidence to a spe
 
 The content fragment that explains why a search result matched a query, such as a scene description or transcript chunk. Semantic Evidence belongs to retrieval, ranking, debug context, and optional timecodes; consumer card surfaces should render display metadata unless they are intentionally showing match context.
 
+### Manager Artifact
+
+A source-side output from Manager's media-processing pipelines that Admin can consume to build or rebuild search indexes.
+
+Manager artifacts are repair inputs, not the same thing as Admin's searchable vector rows.
+
+### Transcript Chunk
+
+A searchable segment of a video transcript stored separately from the transcript parent so retrieval and embedding workflows can operate at segment granularity.
+
+Deleting transcript chunks removes Admin's transcript search index for those segments but does not delete the transcript identity or Manager's source artifacts.
+
+### Embedding Backfill
+
+A controlled batch process that generates or regenerates vectors for existing content without changing the underlying source content.
+
 ## Known-caller auth
 
 ### Search Passport

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1918,6 +1918,44 @@ The new solutions doc
 captures the architectural pattern (local-fallback storage trick,
 direct-invoke shape, prod-mapping-pull rationale).
 
+### Legacy OpenAI embedding cleanup
+
+Use this only after confirming the target database and backup posture. The CLI
+dry-runs by default and writes a JSON report under
+`.tmp/legacy-openai-embedding-cleanup/` unless `--report-out` is provided.
+
+```bash
+DATABASE_URL='postgresql://forge:forge@db:5432/forge_admin' \
+pnpm --filter @forge/admin cleanup:legacy-openai-embeddings -- \
+  --target-env=development
+```
+
+The cleanup targets only known legacy OpenAI embeddings:
+`openai/text-embedding-3-small`, `text-embedding-3-small`, or OpenAI provider
+provenance where this schema stores it. It clears legacy scene and experience
+vectors in place, deletes transcript chunks whose parent transcript uses the
+legacy OpenAI model, and verifies or drops reverted `embedding_qwen`
+columns/indexes if a target database still has them. It does not use
+`chunking_version` as a selector and does not delete transcript parent rows,
+Manager artifacts, S3 objects, source media, or source transcript artifacts.
+
+Production execution is intentionally noisy and requires both an explicit
+production unlock and backup evidence:
+
+```bash
+DATABASE_URL='<production-admin-db-url>' \
+pnpm --filter @forge/admin cleanup:legacy-openai-embeddings -- \
+  --target-env=production \
+  --execute \
+  --allow-production-target \
+  --backup-evidence='<backup key or recovery point id>' \
+  --report-out=.tmp/legacy-openai-embedding-cleanup/prod-cleanup.json
+```
+
+Run a production dry-run first, inspect the report for ambiguous rows or
+blocked Qwen migration state, and only then execute. Re-embedding is a
+separate `run-embeds` operation after cleanup.
+
 ## Triggering embeds from manager
 
 Manager exposes thin REST proxies that forward to admin's existing

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -26,6 +26,7 @@
     "refresh:core-id-mapping": "tsx src/scripts/refresh-core-id-mapping.ts",
     "partner-keys": "tsx src/scripts/partner-keys.ts",
     "pull:mapping": "tsx src/scripts/pull-mapping-from-prod.ts",
+    "cleanup:legacy-openai-embeddings": "tsx src/scripts/cleanup-legacy-openai-embeddings.ts",
     "run-embeds": "tsx src/scripts/run-embeds.ts",
     "run-sync": "tsx src/scripts/run-sync.ts",
     "schema:print": "tsx src/scripts/print-schema.ts",

--- a/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts
+++ b/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts
@@ -1,0 +1,437 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  type CleanupAudit,
+  type CleanupDb,
+  LegacyEmbeddingCleanupError,
+  buildCleanupAudit,
+  executeLegacyCleanup,
+  parseArgs,
+  readQwenAudit,
+  runCleanup,
+  writeReportToPath,
+} from "./cleanup-legacy-openai-embeddings"
+
+const fixedNow = new Date("2026-06-14T12:00:00.000Z")
+
+class FakeCleanupDb implements CleanupDb {
+  queries: string[] = []
+  executes: string[] = []
+  executeResults: number[] = []
+  transactionCalls = 0
+
+  constructor(
+    private readonly queryResponder: (query: string) => unknown[] = () => [],
+  ) {}
+
+  async $queryRawUnsafe<T = unknown>(query: string): Promise<T> {
+    this.queries.push(query)
+    return this.queryResponder(query) as T
+  }
+
+  async $executeRawUnsafe(query: string): Promise<number> {
+    this.executes.push(query)
+    return this.executeResults.shift() ?? 0
+  }
+
+  async $transaction<T>(fn: (tx: CleanupDb) => Promise<T>): Promise<T> {
+    this.transactionCalls += 1
+    return fn(this)
+  }
+
+  async $disconnect(): Promise<void> {}
+}
+
+function baseAudit(overrides: Partial<CleanupAudit> = {}): CleanupAudit {
+  return {
+    scenes: {
+      legacyTargets: 3,
+      preservedRows: 10,
+      ambiguousRows: 0,
+      metadataOnlyLegacyModelRows: 2,
+    },
+    experiences: {
+      legacyTargets: 2,
+      preservedRows: 8,
+      ambiguousRows: 1,
+      metadataOnlyLegacyModelRows: 0,
+    },
+    transcripts: {
+      legacyParents: 1,
+      legacyChunks: 4,
+      preservedParents: 3,
+      preservedChunks: 9,
+      ambiguousParents: 0,
+      ambiguousChunks: 0,
+    },
+    qwen: {
+      action: "verified_absent",
+      safeToDrop: true,
+      blockedReasons: [],
+      columns: [],
+      indexes: [],
+      migrations: [],
+    },
+    ...overrides,
+  }
+}
+
+function auditQueryResponder(query: string): unknown[] {
+  if (
+    query.includes("FROM video_scene_locale") &&
+    query.includes("COUNT(*) FILTER")
+  ) {
+    return [
+      {
+        legacyTargets: 3,
+        preservedRows: 10,
+        ambiguousRows: 0,
+        metadataOnlyLegacyModelRows: 2,
+      },
+    ]
+  }
+  if (
+    query.includes("FROM experience_locale") &&
+    query.includes("COUNT(*) FILTER")
+  ) {
+    return [
+      {
+        legacyTargets: "2",
+        preservedRows: "8",
+        ambiguousRows: "1",
+        metadataOnlyLegacyModelRows: "0",
+      },
+    ]
+  }
+  if (
+    query.includes("FROM video_transcript t") &&
+    query.includes("COUNT(DISTINCT t.id)")
+  ) {
+    return [
+      {
+        legacyParents: 1n,
+        legacyChunks: 4n,
+        preservedParents: 3n,
+        preservedChunks: 9n,
+        ambiguousParents: 0n,
+        ambiguousChunks: 0n,
+      },
+    ]
+  }
+  if (query.includes("information_schema.columns")) {
+    return [
+      { tableName: "video_scene_locale", columnName: "embedding_qwen" },
+      { tableName: "video_transcript_chunk", columnName: "embedding_qwen" },
+    ]
+  }
+  if (query.includes('FROM "video_scene_locale"')) {
+    return [{ count: 6 }]
+  }
+  if (query.includes('FROM "video_transcript_chunk"')) {
+    return [{ count: "7" }]
+  }
+  if (query.includes("FROM pg_indexes")) {
+    return [
+      {
+        tableName: "video_scene_locale",
+        indexName: "video_scene_locale_embedding_qwen_hnsw",
+      },
+    ]
+  }
+  if (query.includes("FROM _prisma_migrations")) {
+    return [
+      {
+        migrationName: "0033_drop_video_embedding_qwen",
+        finishedAt: new Date("2026-06-08T00:00:00.000Z"),
+        rolledBackAt: null,
+        logs: null,
+      },
+    ]
+  }
+  return []
+}
+
+describe("parseArgs", () => {
+  it("requires an explicit target env", () => {
+    expect(() => parseArgs([], fixedNow)).toThrow(
+      "--target-env=development|staging|production is required",
+    )
+  })
+
+  it("defaults to dry-run and resolves a report path", () => {
+    const args = parseArgs(["--target-env=local"], fixedNow)
+
+    expect(args.targetEnv).toBe("development")
+    expect(args.execute).toBe(false)
+    expect(args.reportOutPath).toBe(
+      resolve(
+        process.cwd(),
+        ".tmp/legacy-openai-embedding-cleanup/2026-06-14T12-00-00-000Z.json",
+      ),
+    )
+  })
+
+  it("refuses production execute without the production unlock", () => {
+    expect(() =>
+      parseArgs(
+        [
+          "--target-env=production",
+          "--execute",
+          "--backup-evidence=admin-video-db-backups/video-search/prod.dump",
+        ],
+        fixedNow,
+      ),
+    ).toThrow("Refusing production cleanup")
+  })
+
+  it("refuses production execute without backup evidence", () => {
+    expect(() =>
+      parseArgs(
+        ["--target-env=production", "--execute", "--allow-production-target"],
+        fixedNow,
+      ),
+    ).toThrow("backup-evidence")
+  })
+
+  it("accepts production execute only with both explicit safeguards", () => {
+    const args = parseArgs(
+      [
+        "--target-env=production",
+        "--execute",
+        "--allow-production-target",
+        "--backup-evidence=admin-video-db-backups/video-search/prod.dump",
+      ],
+      fixedNow,
+    )
+
+    expect(args.execute).toBe(true)
+    expect(args.targetEnv).toBe("production")
+    expect(args.backupEvidence).toBe(
+      "admin-video-db-backups/video-search/prod.dump",
+    )
+  })
+})
+
+describe("buildCleanupAudit", () => {
+  it("aggregates legacy, preserved, ambiguous, and Qwen counts", async () => {
+    const db = new FakeCleanupDb(auditQueryResponder)
+
+    const audit = await buildCleanupAudit(db)
+
+    expect(audit.scenes).toEqual({
+      legacyTargets: 3,
+      preservedRows: 10,
+      ambiguousRows: 0,
+      metadataOnlyLegacyModelRows: 2,
+    })
+    expect(audit.experiences.legacyTargets).toBe(2)
+    expect(audit.transcripts).toEqual({
+      legacyParents: 1,
+      legacyChunks: 4,
+      preservedParents: 3,
+      preservedChunks: 9,
+      ambiguousParents: 0,
+      ambiguousChunks: 0,
+    })
+    expect(audit.qwen.action).toBe("would_drop")
+    expect(audit.qwen.columns).toEqual([
+      {
+        tableName: "video_scene_locale",
+        columnName: "embedding_qwen",
+        nonNullValues: 6,
+      },
+      {
+        tableName: "video_transcript_chunk",
+        columnName: "embedding_qwen",
+        nonNullValues: 7,
+      },
+    ])
+    expect(JSON.stringify(audit)).not.toContain("[0.")
+  })
+
+  it("does not use chunking_version as a transcript target predicate", async () => {
+    const db = new FakeCleanupDb(auditQueryResponder)
+
+    await buildCleanupAudit(db)
+
+    const transcriptQuery = db.queries.find((query) =>
+      query.includes("FROM video_transcript t"),
+    )
+    expect(transcriptQuery).toContain("t.model IN")
+    expect(transcriptQuery).not.toContain("chunking_version")
+  })
+})
+
+describe("readQwenAudit", () => {
+  it("blocks Qwen cleanup when migration state is failed or unresolved", async () => {
+    const db = new FakeCleanupDb((query) => {
+      if (query.includes("information_schema.columns")) {
+        return [
+          { tableName: "video_scene_locale", columnName: "embedding_qwen" },
+        ]
+      }
+      if (query.includes('FROM "video_scene_locale"')) return [{ count: 1 }]
+      if (query.includes("FROM pg_indexes")) return []
+      if (query.includes("FROM _prisma_migrations")) {
+        return [
+          {
+            migrationName: "0032_video_embedding_qwen",
+            finishedAt: null,
+            rolledBackAt: null,
+            logs: "failed",
+          },
+        ]
+      }
+      return []
+    })
+
+    const audit = await readQwenAudit(db)
+
+    expect(audit.action).toBe("blocked")
+    expect(audit.safeToDrop).toBe(false)
+    expect(audit.blockedReasons[0]).toContain("0032_video_embedding_qwen")
+  })
+
+  it("blocks unresolved Qwen migration state even without schema artifacts", async () => {
+    const db = new FakeCleanupDb((query) => {
+      if (query.includes("FROM _prisma_migrations")) {
+        return [
+          {
+            migrationName: "0032_video_embedding_qwen",
+            finishedAt: null,
+            rolledBackAt: null,
+            logs: "failed",
+          },
+        ]
+      }
+      return []
+    })
+
+    const audit = await readQwenAudit(db)
+
+    expect(audit.action).toBe("blocked")
+    expect(audit.safeToDrop).toBe(false)
+    expect(audit.columns).toEqual([])
+    expect(audit.indexes).toEqual([])
+  })
+})
+
+describe("executeLegacyCleanup", () => {
+  it("clears legacy vectors, deletes legacy chunks, and drops Qwen artifacts", async () => {
+    const args = parseArgs(["--target-env=staging", "--execute"], fixedNow)
+    const db = new FakeCleanupDb()
+    db.executeResults = [3, 2, 4]
+    const audit = baseAudit({
+      qwen: {
+        action: "would_drop",
+        safeToDrop: true,
+        blockedReasons: [],
+        columns: [
+          {
+            tableName: "video_scene_locale",
+            columnName: "embedding_qwen",
+            nonNullValues: 6,
+          },
+          {
+            tableName: "video_transcript_chunk",
+            columnName: "embedding_qwen",
+            nonNullValues: 7,
+          },
+        ],
+        indexes: [
+          {
+            tableName: "video_scene_locale",
+            indexName: "video_scene_locale_embedding_qwen_hnsw",
+          },
+        ],
+        migrations: [],
+      },
+    })
+
+    const summary = await executeLegacyCleanup(db, args, audit)
+
+    expect(summary).toEqual({
+      sceneLocalesCleared: 3,
+      experienceLocalesCleared: 2,
+      transcriptChunksDeleted: 4,
+      qwenIndexesDropped: 1,
+      qwenColumnsDropped: 2,
+    })
+    expect(db.transactionCalls).toBe(1)
+    const transcriptDelete = db.executes.find((query) =>
+      query.includes("DELETE FROM video_transcript_chunk"),
+    )
+    expect(transcriptDelete).toContain("JOIN video_transcript t")
+    expect(transcriptDelete).toContain("t.model IN")
+    expect(transcriptDelete).not.toContain("chunking_version")
+  })
+
+  it("fails before mutation when Qwen cleanup is blocked", async () => {
+    const args = parseArgs(["--target-env=staging", "--execute"], fixedNow)
+    const db = new FakeCleanupDb()
+    const audit = baseAudit({
+      qwen: {
+        action: "blocked",
+        safeToDrop: false,
+        blockedReasons: ["migration 0032_video_embedding_qwen is failed"],
+        columns: [],
+        indexes: [],
+        migrations: [],
+      },
+    })
+
+    await expect(executeLegacyCleanup(db, args, audit)).rejects.toThrow(
+      LegacyEmbeddingCleanupError,
+    )
+    expect(db.executes).toHaveLength(0)
+  })
+})
+
+describe("runCleanup and report writing", () => {
+  let tmpDir: string | undefined
+
+  afterEach(async () => {
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true })
+    tmpDir = undefined
+  })
+
+  it("dry-runs without executing mutations", async () => {
+    const db = new FakeCleanupDb(auditQueryResponder)
+    const args = parseArgs(["--target-env=development"], fixedNow)
+
+    const report = await runCleanup(db, args, fixedNow)
+
+    expect(report.event).toBe(
+      "cleanup-legacy-openai-embeddings.dry-run-complete",
+    )
+    expect(report.dryRun).toBe(true)
+    expect(report.mutations).toBeUndefined()
+    expect(db.executes).toHaveLength(0)
+  })
+
+  it("writes redacted report JSON to disk", async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "legacy-embedding-cleanup-"))
+    const path = join(tmpDir, "report.json")
+    const db = new FakeCleanupDb(auditQueryResponder)
+    const args = parseArgs(
+      ["--target-env=development", `--report-out=${path}`],
+      fixedNow,
+    )
+    const report = await runCleanup(db, args, fixedNow)
+
+    const result = await writeReportToPath(path, report)
+
+    expect(result.ok).toBe(true)
+    const contents = await readFile(path, "utf8")
+    expect(JSON.parse(contents)).toMatchObject({
+      event: "cleanup-legacy-openai-embeddings.dry-run-complete",
+      targetEnv: "development",
+    })
+    expect(contents).not.toContain("postgresql://")
+    expect(contents).not.toContain("Bearer ")
+    expect(contents).not.toContain("[0.")
+  })
+})

--- a/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts
+++ b/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts
@@ -1,0 +1,690 @@
+#!/usr/bin/env tsx
+/**
+ * Audit and remove legacy OpenAI content embeddings from an Admin database.
+ *
+ * Dry-run is the default. Execute mode mutates only rows that can be
+ * classified as known legacy OpenAI by the model/provider columns present in
+ * this checkout's schema.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, isAbsolute, resolve } from "node:path"
+
+export const LEGACY_OPENAI_MODELS = [
+  "openai/text-embedding-3-small",
+  "text-embedding-3-small",
+] as const
+
+export const QWEN_INDEX_NAMES = [
+  "video_scene_locale_embedding_qwen_hnsw_fr",
+  "video_scene_locale_embedding_qwen_hnsw_es",
+  "video_scene_locale_embedding_qwen_hnsw_en",
+  "video_scene_locale_embedding_qwen_hnsw",
+  "video_transcript_chunk_embedding_qwen_hnsw_fr",
+  "video_transcript_chunk_embedding_qwen_hnsw_es",
+  "video_transcript_chunk_embedding_qwen_hnsw_en",
+  "video_transcript_chunk_embedding_qwen_hnsw",
+] as const
+
+export const QWEN_COLUMN_TABLES = [
+  "video_scene_locale",
+  "video_transcript_chunk",
+] as const
+
+export type TargetEnvironment = "development" | "staging" | "production"
+
+export type CleanupArgs = {
+  targetEnv: TargetEnvironment
+  execute: boolean
+  allowProductionTarget: boolean
+  backupEvidence?: string
+  reportOutPath: string
+  batchSize: number
+}
+
+type CountRow = { count: number | bigint | string | null }
+
+export type ContentStorageAudit = {
+  legacyTargets: number
+  preservedRows: number
+  ambiguousRows: number
+  metadataOnlyLegacyModelRows?: number
+}
+
+export type TranscriptAudit = {
+  legacyParents: number
+  legacyChunks: number
+  preservedParents: number
+  preservedChunks: number
+  ambiguousParents: number
+  ambiguousChunks: number
+}
+
+export type QwenColumnArtifact = {
+  tableName: string
+  columnName: string
+  nonNullValues: number
+}
+
+export type QwenIndexArtifact = {
+  tableName: string
+  indexName: string
+}
+
+export type QwenMigrationState = {
+  migrationName: string
+  finishedAt: string | Date | null
+  rolledBackAt: string | Date | null
+  logs?: string | null
+}
+
+export type QwenAudit = {
+  action: "verified_absent" | "would_drop" | "blocked"
+  safeToDrop: boolean
+  blockedReasons: string[]
+  columns: QwenColumnArtifact[]
+  indexes: QwenIndexArtifact[]
+  migrations: QwenMigrationState[]
+}
+
+export type CleanupAudit = {
+  scenes: ContentStorageAudit
+  experiences: ContentStorageAudit
+  transcripts: TranscriptAudit
+  qwen: QwenAudit
+}
+
+export type MutationSummary = {
+  sceneLocalesCleared: number
+  experienceLocalesCleared: number
+  transcriptChunksDeleted: number
+  qwenIndexesDropped: number
+  qwenColumnsDropped: number
+}
+
+export type CleanupReport = {
+  event:
+    | "cleanup-legacy-openai-embeddings.dry-run-complete"
+    | "cleanup-legacy-openai-embeddings.complete"
+  targetEnv: TargetEnvironment
+  dryRun: boolean
+  execute: boolean
+  startedAt: string
+  completedAt: string
+  batchSize: number
+  backupEvidence?: string
+  auditBefore: CleanupAudit
+  mutations?: MutationSummary
+  auditAfter?: CleanupAudit
+}
+
+export type CleanupDb = {
+  $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>
+  $disconnect?: () => Promise<void>
+  $transaction?: <T>(fn: (tx: CleanupDb) => Promise<T>) => Promise<T>
+}
+
+type ContentAuditRow = {
+  legacyTargets: number | bigint | string | null
+  preservedRows: number | bigint | string | null
+  ambiguousRows: number | bigint | string | null
+  metadataOnlyLegacyModelRows: number | bigint | string | null
+}
+
+type TranscriptAuditRow = {
+  legacyParents: number | bigint | string | null
+  legacyChunks: number | bigint | string | null
+  preservedParents: number | bigint | string | null
+  preservedChunks: number | bigint | string | null
+  ambiguousParents: number | bigint | string | null
+  ambiguousChunks: number | bigint | string | null
+}
+
+type QwenColumnRow = {
+  tableName: string
+  columnName: string
+}
+
+type QwenIndexRow = {
+  tableName: string
+  indexName: string
+}
+
+export class LegacyEmbeddingCleanupError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "LegacyEmbeddingCleanupError"
+  }
+}
+
+function readFlag(args: readonly string[], name: string): string | undefined {
+  const prefix = `--${name}=`
+  const match = args.find((arg) => arg.startsWith(prefix))
+  return match?.slice(prefix.length)
+}
+
+function hasFlag(args: readonly string[], name: string): boolean {
+  return args.includes(`--${name}`)
+}
+
+export function parseTargetEnv(raw: string | undefined): TargetEnvironment {
+  if (raw === "local" || raw === "development") return "development"
+  if (raw === "staging" || raw === "production") return raw
+  if (raw == null || raw === "") {
+    throw new LegacyEmbeddingCleanupError(
+      "--target-env=development|staging|production is required",
+    )
+  }
+  throw new LegacyEmbeddingCleanupError(
+    `Unknown target env ${JSON.stringify(raw)}. Use development, staging, or production.`,
+  )
+}
+
+export function resolveReportOutPath(
+  arg: string | undefined,
+  now: Date = new Date(),
+): string {
+  const raw =
+    arg && arg.length > 0
+      ? arg
+      : `.tmp/legacy-openai-embedding-cleanup/${timestamp(now)}.json`
+  return isAbsolute(raw) ? raw : resolve(process.cwd(), raw)
+}
+
+function parseBatchSize(raw: string | undefined): number {
+  if (raw == null || raw === "") return 5000
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100000) {
+    throw new LegacyEmbeddingCleanupError(
+      "--batch-size must be an integer between 1 and 100000",
+    )
+  }
+  return parsed
+}
+
+export function parseArgs(
+  args: readonly string[],
+  now: Date = new Date(),
+): CleanupArgs {
+  const normalizedArgs = args.filter((arg) => arg !== "--")
+  const execute = hasFlag(normalizedArgs, "execute")
+  const parsed: CleanupArgs = {
+    targetEnv: parseTargetEnv(readFlag(normalizedArgs, "target-env")),
+    execute,
+    allowProductionTarget: hasFlag(normalizedArgs, "allow-production-target"),
+    backupEvidence: readFlag(normalizedArgs, "backup-evidence") || undefined,
+    reportOutPath: resolveReportOutPath(
+      readFlag(normalizedArgs, "report-out"),
+      now,
+    ),
+    batchSize: parseBatchSize(readFlag(normalizedArgs, "batch-size")),
+  }
+  validateExecutionSafety(parsed)
+  return parsed
+}
+
+export function validateExecutionSafety(args: CleanupArgs): void {
+  if (!args.execute || args.targetEnv !== "production") return
+  if (!args.allowProductionTarget) {
+    throw new LegacyEmbeddingCleanupError(
+      "Refusing production cleanup without --allow-production-target",
+    )
+  }
+  if (!args.backupEvidence) {
+    throw new LegacyEmbeddingCleanupError(
+      "Refusing production cleanup without --backup-evidence=<backup key or recovery point>",
+    )
+  }
+}
+
+function timestamp(now: Date): string {
+  return now.toISOString().replace(/[:.]/g, "-")
+}
+
+function sqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+function countValue(
+  value: number | bigint | string | null | undefined,
+): number {
+  if (value == null) return 0
+  return Number(value)
+}
+
+function rowCount(rows: readonly CountRow[]): number {
+  return countValue(rows[0]?.count)
+}
+
+const LEGACY_MODEL_SQL = LEGACY_OPENAI_MODELS.map(sqlString).join(", ")
+const SCENE_LEGACY_CONDITION = `model IN (${LEGACY_MODEL_SQL})`
+const EXPERIENCE_LEGACY_CONDITION = `(embedding_provider = 'openai' OR embedding_model IN (${LEGACY_MODEL_SQL}))`
+const EXPERIENCE_AMBIGUOUS_CONDITION = `(embedding_provider IS NULL AND embedding_model IS NULL)`
+const TRANSCRIPT_LEGACY_CONDITION = `t.model IN (${LEGACY_MODEL_SQL})`
+
+async function readSceneAudit(db: CleanupDb): Promise<ContentStorageAudit> {
+  const rows = await db.$queryRawUnsafe<ContentAuditRow[]>(`
+    SELECT
+      COUNT(*) FILTER (
+        WHERE embedding IS NOT NULL AND ${SCENE_LEGACY_CONDITION}
+      ) AS "legacyTargets",
+      COUNT(*) FILTER (
+        WHERE embedding IS NOT NULL AND NOT ${SCENE_LEGACY_CONDITION}
+      ) AS "preservedRows",
+      0::int AS "ambiguousRows",
+      COUNT(*) FILTER (
+        WHERE embedding IS NULL AND ${SCENE_LEGACY_CONDITION}
+      ) AS "metadataOnlyLegacyModelRows"
+    FROM video_scene_locale
+  `)
+  const row = rows[0]
+  return {
+    legacyTargets: countValue(row?.legacyTargets),
+    preservedRows: countValue(row?.preservedRows),
+    ambiguousRows: countValue(row?.ambiguousRows),
+    metadataOnlyLegacyModelRows: countValue(row?.metadataOnlyLegacyModelRows),
+  }
+}
+
+async function readExperienceAudit(
+  db: CleanupDb,
+): Promise<ContentStorageAudit> {
+  const rows = await db.$queryRawUnsafe<ContentAuditRow[]>(`
+    SELECT
+      COUNT(*) FILTER (
+        WHERE embedding IS NOT NULL AND ${EXPERIENCE_LEGACY_CONDITION}
+      ) AS "legacyTargets",
+      COUNT(*) FILTER (
+        WHERE embedding IS NOT NULL
+          AND NOT ${EXPERIENCE_LEGACY_CONDITION}
+          AND NOT ${EXPERIENCE_AMBIGUOUS_CONDITION}
+      ) AS "preservedRows",
+      COUNT(*) FILTER (
+        WHERE embedding IS NOT NULL
+          AND NOT ${EXPERIENCE_LEGACY_CONDITION}
+          AND ${EXPERIENCE_AMBIGUOUS_CONDITION}
+      ) AS "ambiguousRows",
+      COUNT(*) FILTER (
+        WHERE embedding IS NULL AND ${EXPERIENCE_LEGACY_CONDITION}
+      ) AS "metadataOnlyLegacyModelRows"
+    FROM experience_locale
+  `)
+  const row = rows[0]
+  return {
+    legacyTargets: countValue(row?.legacyTargets),
+    preservedRows: countValue(row?.preservedRows),
+    ambiguousRows: countValue(row?.ambiguousRows),
+    metadataOnlyLegacyModelRows: countValue(row?.metadataOnlyLegacyModelRows),
+  }
+}
+
+async function readTranscriptAudit(db: CleanupDb): Promise<TranscriptAudit> {
+  const rows = await db.$queryRawUnsafe<TranscriptAuditRow[]>(`
+    SELECT
+      COUNT(DISTINCT t.id) FILTER (
+        WHERE ${TRANSCRIPT_LEGACY_CONDITION}
+      ) AS "legacyParents",
+      COUNT(c.id) FILTER (
+        WHERE ${TRANSCRIPT_LEGACY_CONDITION}
+      ) AS "legacyChunks",
+      COUNT(DISTINCT t.id) FILTER (
+        WHERE NOT ${TRANSCRIPT_LEGACY_CONDITION}
+      ) AS "preservedParents",
+      COUNT(c.id) FILTER (
+        WHERE NOT ${TRANSCRIPT_LEGACY_CONDITION}
+      ) AS "preservedChunks",
+      0::int AS "ambiguousParents",
+      0::int AS "ambiguousChunks"
+    FROM video_transcript t
+    LEFT JOIN video_transcript_chunk c ON c.transcript_id = t.id
+  `)
+  const row = rows[0]
+  return {
+    legacyParents: countValue(row?.legacyParents),
+    legacyChunks: countValue(row?.legacyChunks),
+    preservedParents: countValue(row?.preservedParents),
+    preservedChunks: countValue(row?.preservedChunks),
+    ambiguousParents: countValue(row?.ambiguousParents),
+    ambiguousChunks: countValue(row?.ambiguousChunks),
+  }
+}
+
+async function readQwenColumns(db: CleanupDb): Promise<QwenColumnArtifact[]> {
+  const columns = await db.$queryRawUnsafe<QwenColumnRow[]>(`
+    SELECT
+      table_name AS "tableName",
+      column_name AS "columnName"
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name IN (${QWEN_COLUMN_TABLES.map(sqlString).join(", ")})
+      AND column_name = 'embedding_qwen'
+    ORDER BY table_name
+  `)
+
+  const withCounts: QwenColumnArtifact[] = []
+  for (const column of columns) {
+    if (!QWEN_COLUMN_TABLES.includes(column.tableName as never)) continue
+    const rows = await db.$queryRawUnsafe<CountRow[]>(`
+      SELECT COUNT(*) AS count
+      FROM "${column.tableName}"
+      WHERE "embedding_qwen" IS NOT NULL
+    `)
+    withCounts.push({
+      tableName: column.tableName,
+      columnName: column.columnName,
+      nonNullValues: rowCount(rows),
+    })
+  }
+  return withCounts
+}
+
+async function readQwenIndexes(db: CleanupDb): Promise<QwenIndexArtifact[]> {
+  return db.$queryRawUnsafe<QwenIndexRow[]>(`
+    SELECT
+      tablename AS "tableName",
+      indexname AS "indexName"
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname LIKE '%embedding_qwen%'
+    ORDER BY tablename, indexname
+  `)
+}
+
+async function readQwenMigrations(
+  db: CleanupDb,
+): Promise<QwenMigrationState[]> {
+  return db.$queryRawUnsafe<QwenMigrationState[]>(`
+    SELECT
+      migration_name AS "migrationName",
+      finished_at AS "finishedAt",
+      rolled_back_at AS "rolledBackAt",
+      logs
+    FROM _prisma_migrations
+    WHERE migration_name IN (
+      '0032_video_embedding_qwen',
+      '0033_drop_video_embedding_qwen'
+    )
+    ORDER BY started_at
+  `)
+}
+
+export async function readQwenAudit(db: CleanupDb): Promise<QwenAudit> {
+  const [columns, indexes, migrations] = await Promise.all([
+    readQwenColumns(db),
+    readQwenIndexes(db),
+    readQwenMigrations(db),
+  ])
+  const failedMigrations = migrations.filter(
+    (migration) =>
+      migration.finishedAt == null && migration.rolledBackAt == null,
+  )
+  const blockedReasons = failedMigrations.map(
+    (migration) =>
+      `migration ${migration.migrationName} is not finished or rolled back`,
+  )
+  const hasArtifacts = columns.length > 0 || indexes.length > 0
+  const safeToDrop = blockedReasons.length === 0
+  return {
+    action: !safeToDrop
+      ? "blocked"
+      : hasArtifacts
+        ? "would_drop"
+        : "verified_absent",
+    safeToDrop,
+    blockedReasons,
+    columns,
+    indexes,
+    migrations,
+  }
+}
+
+export async function buildCleanupAudit(db: CleanupDb): Promise<CleanupAudit> {
+  const [scenes, experiences, transcripts, qwen] = await Promise.all([
+    readSceneAudit(db),
+    readExperienceAudit(db),
+    readTranscriptAudit(db),
+    readQwenAudit(db),
+  ])
+  return { scenes, experiences, transcripts, qwen }
+}
+
+async function clearLegacySceneLocales(db: CleanupDb): Promise<number> {
+  return db.$executeRawUnsafe(`
+    UPDATE video_scene_locale
+    SET
+      embedding = NULL,
+      source_artifact_key = NULL,
+      source_artifact_version = NULL,
+      source_content_hash = NULL,
+      source_provider = NULL,
+      source_generated_at = NULL,
+      generation_mode = NULL,
+      mastra_run_id = NULL,
+      generated_at = NULL,
+      updated_at = NOW()
+    WHERE embedding IS NOT NULL
+      AND ${SCENE_LEGACY_CONDITION}
+  `)
+}
+
+async function clearLegacyExperienceLocales(db: CleanupDb): Promise<number> {
+  return db.$executeRawUnsafe(`
+    UPDATE experience_locale
+    SET
+      embedding = NULL,
+      embedding_source_content_hash = NULL,
+      embedding_source_summary = NULL,
+      embedding_model = NULL,
+      embedding_dimensions = NULL,
+      embedding_provider = NULL,
+      embedding_generation_mode = NULL,
+      embedding_mastra_run_id = NULL,
+      embedding_generated_at = NULL,
+      updated_at = NOW()
+    WHERE embedding IS NOT NULL
+      AND ${EXPERIENCE_LEGACY_CONDITION}
+  `)
+}
+
+async function deleteLegacyTranscriptChunks(
+  db: CleanupDb,
+  batchSize: number,
+): Promise<number> {
+  let totalDeleted = 0
+
+  for (;;) {
+    const deleted = await db.$executeRawUnsafe(`
+      WITH doomed AS (
+        SELECT c.id
+        FROM video_transcript_chunk c
+        JOIN video_transcript t ON t.id = c.transcript_id
+        WHERE ${TRANSCRIPT_LEGACY_CONDITION}
+        ORDER BY c.transcript_id, c.chunk_index
+        LIMIT ${batchSize}
+      )
+      DELETE FROM video_transcript_chunk c
+      USING doomed
+      WHERE c.id = doomed.id
+    `)
+    totalDeleted += deleted
+    if (deleted < batchSize) return totalDeleted
+  }
+}
+
+async function executeContentMutations(
+  db: CleanupDb,
+  args: CleanupArgs,
+): Promise<Omit<MutationSummary, "qwenIndexesDropped" | "qwenColumnsDropped">> {
+  const run = async (tx: CleanupDb) => {
+    const sceneLocalesCleared = await clearLegacySceneLocales(tx)
+    const experienceLocalesCleared = await clearLegacyExperienceLocales(tx)
+    const transcriptChunksDeleted = await deleteLegacyTranscriptChunks(
+      tx,
+      args.batchSize,
+    )
+    return {
+      sceneLocalesCleared,
+      experienceLocalesCleared,
+      transcriptChunksDeleted,
+    }
+  }
+  return db.$transaction ? db.$transaction(run) : run(db)
+}
+
+async function dropQwenArtifacts(
+  db: CleanupDb,
+  qwen: QwenAudit,
+): Promise<Pick<MutationSummary, "qwenIndexesDropped" | "qwenColumnsDropped">> {
+  if (qwen.action === "verified_absent") {
+    return { qwenIndexesDropped: 0, qwenColumnsDropped: 0 }
+  }
+  if (!qwen.safeToDrop) {
+    throw new LegacyEmbeddingCleanupError(
+      `Refusing Qwen cleanup: ${qwen.blockedReasons.join("; ")}`,
+    )
+  }
+
+  let qwenIndexesDropped = 0
+  for (const indexName of QWEN_INDEX_NAMES) {
+    await db.$executeRawUnsafe(`DROP INDEX IF EXISTS "${indexName}"`)
+    if (qwen.indexes.some((index) => index.indexName === indexName)) {
+      qwenIndexesDropped += 1
+    }
+  }
+
+  let qwenColumnsDropped = 0
+  for (const tableName of QWEN_COLUMN_TABLES) {
+    await db.$executeRawUnsafe(
+      `ALTER TABLE "${tableName}" DROP COLUMN IF EXISTS "embedding_qwen"`,
+    )
+    if (qwen.columns.some((column) => column.tableName === tableName)) {
+      qwenColumnsDropped += 1
+    }
+  }
+
+  return { qwenIndexesDropped, qwenColumnsDropped }
+}
+
+export async function executeLegacyCleanup(
+  db: CleanupDb,
+  args: CleanupArgs,
+  audit: CleanupAudit,
+): Promise<MutationSummary> {
+  if (audit.qwen.action === "blocked") {
+    throw new LegacyEmbeddingCleanupError(
+      `Refusing execute while Qwen cleanup is blocked: ${audit.qwen.blockedReasons.join("; ")}`,
+    )
+  }
+
+  const content = await executeContentMutations(db, args)
+  const qwen = await dropQwenArtifacts(db, audit.qwen)
+  return { ...content, ...qwen }
+}
+
+export async function runCleanup(
+  db: CleanupDb,
+  args: CleanupArgs,
+  now: Date = new Date(),
+): Promise<CleanupReport> {
+  const startedAt = now.toISOString()
+  const auditBefore = await buildCleanupAudit(db)
+
+  if (!args.execute) {
+    return {
+      event: "cleanup-legacy-openai-embeddings.dry-run-complete",
+      targetEnv: args.targetEnv,
+      dryRun: true,
+      execute: false,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      batchSize: args.batchSize,
+      backupEvidence: args.backupEvidence,
+      auditBefore,
+    }
+  }
+
+  const mutations = await executeLegacyCleanup(db, args, auditBefore)
+  const auditAfter = await buildCleanupAudit(db)
+  return {
+    event: "cleanup-legacy-openai-embeddings.complete",
+    targetEnv: args.targetEnv,
+    dryRun: false,
+    execute: true,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    batchSize: args.batchSize,
+    backupEvidence: args.backupEvidence,
+    auditBefore,
+    mutations,
+    auditAfter,
+  }
+}
+
+export async function writeReportToPath(
+  reportOutPath: string,
+  report: CleanupReport,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await mkdir(dirname(reportOutPath), { recursive: true })
+    await writeFile(reportOutPath, JSON.stringify(report, null, 2) + "\n")
+    return { ok: true }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function databaseUrlFromEnv(): string {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    throw new LegacyEmbeddingCleanupError("DATABASE_URL is required")
+  }
+  return databaseUrl
+}
+
+export async function main(
+  argv: readonly string[] = process.argv.slice(2),
+): Promise<void> {
+  const args = parseArgs(argv)
+  databaseUrlFromEnv()
+
+  const { prisma } = await import("@/db/client")
+  try {
+    const report = await runCleanup(prisma as unknown as CleanupDb, args)
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n")
+
+    const writeResult = await writeReportToPath(args.reportOutPath, report)
+    if (!writeResult.ok) {
+      throw new LegacyEmbeddingCleanupError(
+        `failed to write report: ${writeResult.error}`,
+      )
+    }
+    process.stdout.write(
+      JSON.stringify({
+        event: "cleanup-legacy-openai-embeddings.report_out_written",
+        path: args.reportOutPath,
+      }) + "\n",
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+if (
+  typeof process.argv[1] === "string" &&
+  import.meta.url === `file://${process.argv[1]}`
+) {
+  main().catch((err) => {
+    process.stderr.write(
+      JSON.stringify({
+        event: "cleanup-legacy-openai-embeddings.fatal",
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      }) + "\n",
+    )
+    process.exit(1)
+  })
+}

--- a/docs/plans/2026-06-14-001-feat-legacy-openai-embedding-cleanup-cli-plan.md
+++ b/docs/plans/2026-06-14-001-feat-legacy-openai-embedding-cleanup-cli-plan.md
@@ -1,0 +1,131 @@
+---
+title: "feat: Legacy OpenAI embedding cleanup CLI"
+type: feat
+status: active
+date: 2026-06-14
+origin: "user request"
+---
+
+# feat: Legacy OpenAI Embedding Cleanup CLI
+
+## Summary
+
+Add an Admin repo CLI that dry-runs by default, audits legacy OpenAI content
+embeddings, and removes only rows that this checkout's schema can confidently
+classify as old OpenAI vectors. The tool clears scene and experience vectors in
+place, deletes transcript chunks whose parent transcript uses the old OpenAI
+model, verifies or drops reverted `embedding_qwen` artifacts if they exist in a
+target database, and preserves Manager artifacts and transcript parents.
+
+---
+
+## Requirements
+
+- R1. Add an Admin package command for local, staging, and production targets.
+- R2. Require `--target-env=development|staging|production`; dry-run by default.
+- R3. Production execute must require `--execute`, `--allow-production-target`,
+  and non-secret `--backup-evidence`.
+- R4. Mutate only known legacy OpenAI embeddings:
+  `openai/text-embedding-3-small`, `text-embedding-3-small`, or OpenAI provider
+  provenance where this schema stores it.
+- R5. Do not use `chunking_version` as a selector.
+- R6. Delete legacy transcript chunks, not transcript parent rows.
+- R7. Do not delete Manager artifacts, S3 objects, source media, or source
+  transcript artifacts.
+- R8. Audit and remove or verify absence of reverted `embedding_qwen`
+  columns/indexes without serializing raw vectors.
+- R9. Reports must avoid database URLs, bearer tokens, raw vectors, raw source
+  text, and full transcript chunk text.
+
+---
+
+## Key Technical Decisions
+
+- **Schema-bounded targeting:** This checkout does not have native-dimension or
+  transform-version columns for scene/transcript rows, so the runnable cleanup
+  targets only the old model strings and experience provider provenance.
+- **Preserve non-legacy rows:** Rows that do not match the known legacy OpenAI
+  predicates are counted as preserved or ambiguous, not mutated.
+- **Transcript chunks are the deletion unit:** The searchable transcript text
+  and vectors live in `video_transcript_chunk`; parent transcript rows remain
+  for later model-upgrade or force backfills.
+- **Qwen is schema cleanup:** `embedding_qwen` leftovers are columns/indexes,
+  not content rows. The CLI verifies live schema and migration state before
+  dropping those artifacts.
+
+---
+
+## Implementation Units
+
+### U1. CLI Safety Contract
+
+- **Files:**
+  - Create: `apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts`
+  - Create: `apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts`
+  - Modify: `apps/admin/package.json`
+- **Test scenarios:**
+  - Missing target env fails before connecting.
+  - Dry-run is the default.
+  - Production execute is refused without explicit unlock and backup evidence.
+  - Report paths resolve to a repo-local `.tmp` location by default.
+
+### U2. Audit And Mutation Predicates
+
+- **Files:**
+  - Modify: `apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts`
+  - Modify: `apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts`
+- **Test scenarios:**
+  - Scene and transcript predicates use legacy model strings.
+  - Experience predicates use legacy model strings or OpenAI provider
+    provenance.
+  - Transcript predicates do not include `chunking_version`.
+  - Reports count preserved and ambiguous rows without leaking vector values.
+
+### U3. Qwen Artifact Handling
+
+- **Files:**
+  - Modify: `apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts`
+  - Modify: `apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts`
+- **Test scenarios:**
+  - Missing `embedding_qwen` columns/indexes report verified absence.
+  - Present artifacts report would-drop in dry-run.
+  - Failed or unresolved Qwen migration state blocks execute.
+
+### U4. Operator Docs And Verification
+
+- **Files:**
+  - Modify: `apps/admin/CLAUDE.md`
+- **Verification commands:**
+  - `pnpm --filter @forge/admin exec vitest run src/scripts/cleanup-legacy-openai-embeddings.test.ts`
+  - `pnpm --filter @forge/admin typecheck`
+
+---
+
+## Scope Boundaries
+
+- No Manager artifacts, source transcript artifacts, S3 objects, source media,
+  videos, scenes, experiences, or transcript parent rows are deleted.
+- No re-embedding is performed by this CLI.
+- No public GraphQL, search response, or live query embedding code changes.
+- No historical migration files are rewritten.
+
+---
+
+## Risks
+
+- Production cleanup is destructive and depends on the operator selecting the
+  right database and confirming a usable backup or recovery point.
+- Scene/transcript current-provider provenance is not represented in this
+  schema, so the CLI must not guess. Only known OpenAI legacy predicates are
+  destructive.
+- Large transcript chunk deletes may need conservative batching to avoid long
+  locks.
+
+---
+
+## Sources
+
+- `apps/admin/prisma/schema.prisma`
+- `apps/admin/src/scripts/run-embeds.ts`
+- `apps/admin/src/scripts/video-db-backup.ts`
+- `apps/admin/CLAUDE.md`

--- a/docs/solutions/tooling-decisions/destructive-embedding-cleanup-cli-safety-contract.md
+++ b/docs/solutions/tooling-decisions/destructive-embedding-cleanup-cli-safety-contract.md
@@ -1,0 +1,135 @@
+---
+title: "Destructive embedding cleanup CLIs need model-provenance targeting"
+date: 2026-06-15
+category: tooling-decisions
+module: admin
+problem_type: tooling_decision
+component: database
+severity: high
+applies_when:
+  - "Removing legacy vectors from Admin-owned pgvector tables"
+  - "Cleaning production data after an embedding model or chunking strategy changes"
+  - "Auditing reverted vector columns or indexes that may exist in some deployed databases"
+tags:
+  - admin
+  - embeddings
+  - pgvector
+  - cleanup
+  - production-safety
+  - transcripts
+  - manager-artifacts
+---
+
+# Destructive Embedding Cleanup CLIs Need Model-Provenance Targeting
+
+## Context
+
+Admin needed a production-safe way to remove legacy OpenAI embeddings after
+newer embedding and chunking code had already shipped. The operator intent was
+specific: delete old OpenAI vectors, delete old transcript chunks, preserve
+recently re-embedded rows, and do not touch Manager artifacts or source media.
+
+The risky part is that this cleanup is destructive inside Admin's database.
+Transcript chunks are separate searchable rows with both text and embeddings,
+while Manager artifacts are source-side inputs used to rebuild Admin indexes.
+A cleanup tool that confuses those layers can either leave stale search rows
+behind or delete the material needed for repair.
+
+## Guidance
+
+Build destructive embedding cleanup tools as dry-run-first repo CLIs with an
+explicit target environment and a model/provenance predicate. The selector
+should answer "was this row embedded by the old model?" rather than "does this
+row look old by chunking shape?"
+
+For the legacy OpenAI cleanup, the destructive predicates were bounded to
+model/provider fields that exist in the checked-out schema:
+
+```ts
+const LEGACY_OPENAI_MODELS = [
+  "openai/text-embedding-3-small",
+  "text-embedding-3-small",
+] as const
+```
+
+Scene and transcript rows use the stored model string. Experience rows also
+have provider/model provenance, so the cleanup can target `embedding_provider =
+'openai'` or one of the old model strings. Do not use `chunking_version` as a
+selector when the requirement is "only old embedding model output."
+
+Use different mutation shapes for different ownership layers:
+
+- Clear Admin-owned scene and experience vector/provenance columns in place.
+- Delete Admin transcript chunk rows for legacy transcript parents.
+- Preserve transcript parent rows so later backfills can rebuild chunks.
+- Preserve Manager artifacts, source transcript artifacts, S3 objects, source
+  media, videos, scenes, and experiences.
+
+Production execution should require extra explicitness beyond `--execute`:
+
+```bash
+DATABASE_URL='<production-admin-db-url>' \
+pnpm --filter @forge/admin cleanup:legacy-openai-embeddings -- \
+  --target-env=production \
+  --execute \
+  --allow-production-target \
+  --backup-evidence='<backup key or recovery point id>'
+```
+
+For reverted parallel-vector experiments such as `embedding_qwen`, treat
+leftovers as schema artifacts, not content rows. Audit live columns, indexes,
+and migration state first. If migration metadata is unresolved or failed, block
+execution even when the physical columns are absent; a failed migration state is
+evidence the database needs operator attention before destructive cleanup.
+
+Reports should contain counts and safety state only. Do not serialize database
+URLs, bearer tokens, raw vectors, raw source text, or full transcript chunk text.
+
+## Why This Matters
+
+Embedding cleanup is not a normal backfill retry. It removes search index data
+that may currently power product behavior. Dry-run counts give operators a
+chance to verify blast radius before mutation, while model-provenance targeting
+keeps newly re-embedded rows out of the cleanup path.
+
+Keeping Manager artifacts untouched preserves the forward repair path. If Admin
+search rows are cleared or transcript chunks are deleted, the source artifacts
+can feed a fresh `run-embeds` pass using current chunking and model code.
+
+## When to Apply
+
+- Use this for one-off or rare destructive cleanup of Admin-owned embedding
+  storage.
+- Use this when old and new embeddings may coexist and the distinction must be
+  based on provider/model provenance.
+- Use this when cleanup should make later re-embedding possible rather than
+  attempting to re-embed in the same script.
+- Avoid this pattern for ordinary additive backfills; use the normal workflow or
+  `run-embeds` path instead.
+
+## Examples
+
+Local dry-run:
+
+```bash
+DATABASE_URL='postgresql://forge:forge@db:5432/forge_admin' \
+pnpm --filter @forge/admin cleanup:legacy-openai-embeddings -- \
+  --target-env=development
+```
+
+Targeted transcript chunk deletion keeps transcript parents:
+
+```sql
+DELETE FROM video_transcript_chunk c
+USING doomed
+WHERE c.id = doomed.id;
+```
+
+The `doomed` set should be selected by joining parent transcripts and checking
+the legacy embedding model, not by checking chunking version or chunk text.
+
+## Related
+
+- [Local embed pipeline + manager-trigger parity pattern](../platform/local-embed-pipeline-pattern-20260429.md)
+- [Admin transcript embeddings vector reuse pattern](../platform/admin-transcript-embeddings-vector-reuse-pattern.md)
+- [pgvector bulk INSERT pattern](../database-issues/pgvector-bulk-insert-on-conflict-pattern-20260505.md)


### PR DESCRIPTION
## Summary

Admin can now audit and remove legacy OpenAI embedding data without touching Manager artifacts, source media, or transcript parent rows. The cleanup is dry-run-first, targets only old OpenAI model/provider provenance, and requires explicit production unlock plus backup evidence before it will mutate production.

## Safety Shape

| Concern | Handling |
|---|---|
| Recently re-embedded rows | Preserved unless they still carry the known legacy OpenAI model/provider provenance |
| Transcript cleanup | Deletes legacy transcript chunks only; transcript parent rows remain for rebuilds |
| Manager/source artifacts | Not touched, so `run-embeds` remains the forward repair path |
| Reverted Qwen leftovers | Audits columns, indexes, and migration state; unresolved migration state blocks execute |
| Reports | Counts and safety state only; no DB URLs, bearer tokens, raw vectors, or transcript text |

## Validation

- `pnpm --filter @forge/admin exec vitest run src/scripts/cleanup-legacy-openai-embeddings.test.ts`
- `pnpm --filter @forge/admin db:generate`
- `pnpm --filter @forge/admin typecheck`
- `git diff --check --`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.12.0/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/tooling-decisions/destructive-embedding-cleanup-cli-safety-contract.md`

## Production Note

Run the production dry-run and inspect the JSON report before executing. Production execute still needs `--execute`, `--allow-production-target`, and `--backup-evidence=<backup key or recovery point id>`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
