### PR TITLE
fix(web): prevent watch search hydration hangs

### DIFF
--- a/apps/web/src/components/FloatingSearchController.tsx
+++ b/apps/web/src/components/FloatingSearchController.tsx
@@ -44,6 +44,14 @@ type ActiveSearchSignature = {
   nextOffset: number
 }
 
+function buildCurrentSearchUrl(
+  pathname: string,
+  currentParams: URLSearchParams,
+): string {
+  const serializedParams = currentParams.toString()
+  return serializedParams.length > 0 ? `${pathname}?${serializedParams}` : pathname
+}
+
 export type FloatingSearchControllerProps = {
   open: boolean
   closing: boolean
@@ -227,6 +235,16 @@ export function FloatingSearchController({
     [],
   )
 
+  const clearLoadingForRequest = useCallback((requestId: number): void => {
+    if (requestIdRef.current !== requestId) return
+    if (skeletonTimerRef.current) {
+      clearTimeout(skeletonTimerRef.current)
+      skeletonTimerRef.current = null
+    }
+    setShowSkeleton(false)
+    setLoading(false)
+  }, [])
+
   const search = useCallback(
     async (
       q: string,
@@ -255,7 +273,9 @@ export function FloatingSearchController({
           ? new URLSearchParams(window.location.search)
           : new URLSearchParams()
       const nextUrl = buildSearchUrl(pathname, currentParams, trimmed)
-      router.replace(nextUrl as Route)
+      if (nextUrl !== buildCurrentSearchUrl(pathname, currentParams)) {
+        router.replace(nextUrl as Route)
+      }
 
       if (!trimmed) {
         if (displayResultsRef.current.length > 0) {
@@ -272,6 +292,7 @@ export function FloatingSearchController({
         setError(null)
         setResultSource(null)
         activeSearchSignatureRef.current = null
+        clearLoadingForRequest(thisRequest)
         return
       }
 
@@ -359,14 +380,11 @@ export function FloatingSearchController({
       } finally {
         // Only clear loading state for the winning request — otherwise a
         // stale response's finally would drop the active spinner mid-fetch.
-        if (requestIdRef.current === thisRequest) {
-          if (skeletonTimerRef.current) clearTimeout(skeletonTimerRef.current)
-          setShowSkeleton(false)
-          setLoading(false)
-        }
+        clearLoadingForRequest(thisRequest)
       }
     },
     [
+      clearLoadingForRequest,
       languageFacets,
       maybeSetLanguageFacets,
       pathname,

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -27,10 +27,14 @@ import {
   type WatchPlayerPlaybackStateDetail,
 } from "@/lib/watch-player-chrome-events"
 
+const navigationMocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+}))
+
 vi.mock("next/navigation", () => ({
   usePathname: () => "/",
   useRouter: () => ({
-    replace: vi.fn(),
+    replace: navigationMocks.replace,
   }),
 }))
 
@@ -252,8 +256,10 @@ function SearchModeHarness() {
     displayResults,
     error,
     loadMore,
+    loading,
     search,
     setOpen,
+    showSkeleton,
   } = useFloatingSearch()
 
   return (
@@ -263,6 +269,8 @@ function SearchModeHarness() {
       </span>
       <span data-testid="search-result-count">{displayResults.length}</span>
       <span data-testid="search-error">{error ?? ""}</span>
+      <span data-testid="search-loading">{String(loading)}</span>
+      <span data-testid="search-skeleton">{String(showSkeleton)}</span>
       <button
         type="button"
         data-testid="search-mode-harness-open-button"
@@ -276,6 +284,13 @@ function SearchModeHarness() {
         onClick={() => void search("jesus")}
       >
         Search
+      </button>
+      <button
+        type="button"
+        data-testid="search-mode-harness-clear-button"
+        onClick={() => void search("")}
+      >
+        Clear
       </button>
       <button
         type="button"
@@ -609,6 +624,154 @@ describe("FloatingSearchProvider — search mode", () => {
       }),
     )
     expect(error?.textContent).toBe("Failed to load more results.")
+  })
+
+  it("clears loading state when an in-flight search is reset before it resolves", async () => {
+    vi.useFakeTimers()
+    mockedRunSearch.mockReturnValueOnce(new Promise(() => {}))
+
+    act(() => {
+      root.render(
+        <SearchControllerTestShell>
+          <SearchModeHarness />
+        </SearchControllerTestShell>,
+      )
+    })
+
+    const searchButton = document.querySelector(
+      '[data-testid="search-mode-harness-button"]',
+    ) as HTMLButtonElement
+    const clearButton = document.querySelector(
+      '[data-testid="search-mode-harness-clear-button"]',
+    ) as HTMLButtonElement
+    const loading = document.querySelector('[data-testid="search-loading"]')
+    const skeleton = document.querySelector('[data-testid="search-skeleton"]')
+
+    await act(async () => {
+      searchButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(loading?.textContent).toBe("true")
+    expect(skeleton?.textContent).toBe("true")
+
+    await act(async () => {
+      clearButton.click()
+      await Promise.resolve()
+    })
+
+    expect(loading?.textContent).toBe("false")
+    expect(skeleton?.textContent).toBe("false")
+  })
+
+  it("keeps the active loading state when a stale search resolves", async () => {
+    vi.useFakeTimers()
+    let resolveFirstSearch: (value: SearchActionResult) => void = () => {}
+    const firstSearch = new Promise<SearchActionResult>((resolve) => {
+      resolveFirstSearch = resolve
+    })
+    mockedRunSearch
+      .mockReturnValueOnce(firstSearch)
+      .mockReturnValueOnce(new Promise(() => {}))
+
+    act(() => {
+      root.render(
+        <SearchControllerTestShell>
+          <SearchModeHarness />
+        </SearchControllerTestShell>,
+      )
+    })
+
+    const searchButton = document.querySelector(
+      '[data-testid="search-mode-harness-button"]',
+    ) as HTMLButtonElement
+    const loading = document.querySelector('[data-testid="search-loading"]')
+    const skeleton = document.querySelector('[data-testid="search-skeleton"]')
+
+    await act(async () => {
+      searchButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    await act(async () => {
+      searchButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockedRunSearch).toHaveBeenCalledTimes(2)
+    expect(loading?.textContent).toBe("true")
+    expect(skeleton?.textContent).toBe("true")
+
+    await act(async () => {
+      resolveFirstSearch(searchResult("semantic"))
+      await firstSearch
+      await Promise.resolve()
+    })
+
+    expect(loading?.textContent).toBe("true")
+    expect(skeleton?.textContent).toBe("true")
+  })
+
+  it("syncs the URL when the submitted search query changes", async () => {
+    mockedRunSearch.mockResolvedValueOnce(searchResult("semantic"))
+    window.history.replaceState(null, "", "/?utm=campaign")
+
+    act(() => {
+      root.render(
+        <SearchControllerTestShell>
+          <SearchModeHarness />
+        </SearchControllerTestShell>,
+      )
+    })
+
+    window.history.replaceState(null, "", "/?q=bible&utm=campaign")
+
+    const searchButton = document.querySelector(
+      '[data-testid="search-mode-harness-button"]',
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      searchButton.click()
+      await Promise.resolve()
+    })
+
+    expect(navigationMocks.replace).toHaveBeenCalledWith(
+      "/?q=jesus&utm=campaign",
+    )
+  })
+
+  it("removes the query param from the URL when search is cleared", async () => {
+    window.history.replaceState(null, "", "/?utm=campaign")
+
+    act(() => {
+      root.render(
+        <SearchControllerTestShell>
+          <SearchModeHarness />
+        </SearchControllerTestShell>,
+      )
+    })
+
+    window.history.replaceState(null, "", "/?q=jesus&utm=campaign")
+
+    const clearButton = document.querySelector(
+      '[data-testid="search-mode-harness-clear-button"]',
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      clearButton.click()
+      await Promise.resolve()
+    })
+
+    expect(navigationMocks.replace).toHaveBeenCalledWith("/?utm=campaign")
+    expect(mockedRunSearch).not.toHaveBeenCalled()
   })
 })
 
@@ -986,6 +1149,7 @@ describe("FloatingSearchProvider — search overlay chrome", () => {
     expect(runSearch).toHaveBeenCalledWith(
       expect.objectContaining({ query: "jesus" }),
     )
+    expect(navigationMocks.replace).not.toHaveBeenCalled()
   })
 
   it("aligns the search overlay close button with the watch modal close control", async () => {

--- a/docs/plans/2026-06-15-001-fix-watch-search-web-page-reliability-plan.md
+++ b/docs/plans/2026-06-15-001-fix-watch-search-web-page-reliability-plan.md
@@ -1,0 +1,103 @@
+---
+title: Watch Search Web Page Reliability Fix Plan
+type: fix
+date: 2026-06-15
+origin: docs/brainstorms/2026-06-10-forge-algolia-search-modal-requirements.md
+---
+
+# Watch Search Web Page Reliability Fix Plan
+
+## Summary
+
+Fix the floating Watch search modal so query URLs and repeated front-end searches reliably reach the real search action and leave loading state. The fix should target the client search controller, preserving the existing modal, URL sync, semantic search, Algolia flag path, language metadata, and result rendering contracts.
+
+---
+
+## Problem Frame
+
+The production page can open at `?q=jesus` with the search modal focused and skeleton cards visible, but never issue the real `runSearch` action. A browser trace of the page showed the first hydrated request only called `getSearchLanguageOptions`; the modal stayed skeletoned with no result links. Later typed searches can recover, proving the search backend and result rendering path are available, but the page-level client state machine can strand an initial or superseded search.
+
+This plan carries forward the modal reliability requirement from the Algolia search modal requirements: typed queries, query URL hydration, loading states, and modal close behavior must continue to work in the modal.
+
+---
+
+## Requirements
+
+- R1. Query URL hydration must issue the real search action for the hydrated query unless a newer user search supersedes it.
+- R2. URL synchronization must not dispatch a same-URL navigation when the current `q` parameter already matches the intended query.
+- R3. Empty-query reset paths must clear any current loading and skeleton state even when they invalidate an in-flight request.
+- R4. Stale request cleanup must not hide the active spinner for a newer request.
+- R5. Typed query transitions from one non-empty query to another must continue to update `?q=`, show loading feedback, and render the winning result set.
+- R6. The fix must preserve the existing semantic and Algolia search action contracts, including language metadata refresh behavior.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Guard no-op URL replacement in `FloatingSearchController`: same-URL `router.replace()` during query hydration can trigger an RSC navigation that interrupts the initial search flow before `runSearch` is called. Comparing the current params to the target params keeps real URL sync while avoiding the no-op navigation.
+- KTD2. Centralize loading cleanup by request id: the controller already protects active requests with `requestIdRef`; a shared cleanup helper keeps the stale-request guard while making empty-query resets clear the active loading state.
+- KTD3. Test the controller behavior, not backend latency: the production trace proves backend search can return and result links can prefetch. The brittle surface is the browser-side state transition, so regression coverage belongs in the floating search provider/controller tests.
+
+---
+
+## Implementation Units
+
+### U1. Query URL Sync Guard
+
+- **Goal:** Prevent query hydration and same-query searches from dispatching `router.replace()` when the browser URL already has the desired `q` state.
+- **Files:** `apps/web/src/components/FloatingSearchController.tsx`.
+- **Patterns:** Follow the existing `buildSearchUrl` boundary and keep `usePathname()` as the app-relative path source.
+- **Test Scenarios:** Direct URL hydration from `?q=jesus` calls `runSearch` with `query: "jesus"` and does not call `router.replace()` for the already-synced URL.
+- **Verification:** `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx` passes.
+
+### U2. Loading-State Cleanup Hardening
+
+- **Goal:** Ensure the active request clears `loading` and `showSkeleton` across both normal search completion and empty-query reset completion.
+- **Files:** `apps/web/src/components/FloatingSearchController.tsx`.
+- **Patterns:** Preserve the existing request-id freshness check so stale responses cannot clear a newer request's spinner.
+- **Test Scenarios:** Start a search that remains unresolved, allow skeletons to show, then reset the query; loading and skeleton state are both false after reset.
+- **Verification:** `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx` passes.
+
+### U3. Focused Search Provider Regression Coverage
+
+- **Goal:** Extend the existing floating search tests with observable loading state and router mock assertions.
+- **Files:** `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`.
+- **Patterns:** Reuse the current `SearchModeHarness`, mocked server actions, and direct query URL hydration test.
+- **Test Scenarios:** Covered by U1 and U2; no new browser automation fixture is required for this plan.
+- **Verification:** Focused test run, web typecheck, and diff whitespace check pass.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given the browser opens `/watch?q=jesus`, when the search controller hydrates, then it does not replace the URL with the same URL and proceeds to call the search action for `jesus`.
+- AE2. Given the modal is showing skeletons for an unresolved search, when the active search is reset to an empty query, then skeletons disappear and loading is false.
+- AE3. Given the viewer searches `bible` and then `jesus`, when the later `jesus` action completes, then the modal renders `jesus` result cards and no stale cleanup hides the active loading state early.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change search ranking, Algolia configuration, LaunchDarkly flag evaluation, Admin GraphQL search behavior, or result card layout.
+- This plan does not add a new search destination or route; the existing floating modal remains canonical.
+- This plan does not attempt to optimize result-link RSC prefetch latency, which can be slow after results render but is not the cause of the initial skeleton hang.
+
+---
+
+## Risks & Dependencies
+
+- The `URLSearchParams.toString()` comparison treats param order as meaningful. This is acceptable here because the controller builds from the live current params and only mutates `q`, but future URL-sync code should preserve the same pattern.
+- Browser-level validation against production remains observational until the patch is deployed. Unit tests cover the controller transitions directly.
+
+---
+
+## Sources / Research
+
+- `docs/brainstorms/2026-06-10-forge-algolia-search-modal-requirements.md`
+- `apps/web/src/components/FloatingSearchController.tsx`
+- `apps/web/src/components/FloatingSearchProvider.tsx`
+- `apps/web/src/components/SearchOverlay.tsx`
+- `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`
+- `apps/web/src/lib/search-actions.ts`
+- `apps/web/src/lib/search-language-actions.ts`
+- `apps/web/src/lib/search-url.ts`

--- a/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
+++ b/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
@@ -1,0 +1,126 @@
+---
+title: "Watch search URL hydration can strand the overlay in loading"
+date: "2026-06-15"
+category: "ui-bugs"
+module: "apps/web watch search"
+problem_type: "ui_bug"
+component: "frontend_stimulus"
+symptoms:
+  - "Opening `/watch?q=jesus` can show the search overlay and skeleton cards indefinitely."
+  - "Production `/watch` server-action POSTs can return 200 while the UI never renders result cards."
+  - "Typed searches from the already-open overlay can recover, proving the backend search path is not the only failure point."
+root_cause: "async_timing"
+resolution_type: "code_fix"
+severity: "high"
+related_components:
+  - "apps/web/src/components/FloatingSearchController.tsx"
+  - "apps/web/src/components/FloatingSearchProvider.tsx"
+  - "apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx"
+  - "apps/web/src/lib/search-url.ts"
+tags:
+  - "web"
+  - "watch"
+  - "search"
+  - "url-hydration"
+  - "router-replace"
+  - "loading-state"
+  - "skeleton"
+  - "app-router"
+---
+
+# Watch search URL hydration can strand the overlay in loading
+
+## Problem
+
+The Watch search page could open directly at a query URL, such as `/watch?q=jesus`, display the modal with skeleton result cards, and never show results. The backend was not simply timing out: browser-level production tracing showed the page-level client flow could call language metadata, dispatch an App Router navigation for an already-synced URL, and fail to reach the real `runSearch` action for the hydrated query.
+
+## Symptoms
+
+- The page showed the search overlay, focused input, and pulsing skeleton cards for many minutes.
+- Server-action POSTs returned HTTP 200, but the initial direct URL path only called `getSearchLanguageOptions`.
+- Typing a new query in the overlay later issued `runSearch` and rendered result cards.
+- Clearing or superseding a pending search could leave `loading` and `showSkeleton` latched if the stale request was invalidated before its cleanup ran.
+
+## What Didn't Work
+
+- **Endpoint-only probing.** Calling isolated server actions showed they could return successfully, but it missed the App Router and client state transition that stranded the web page.
+- **Waiting longer.** The observed failure could sit for 10 minutes because the UI was stuck in client state, not waiting for a normal request timeout.
+- **Blaming search ranking or Algolia fallback.** Later typed searches returned results, so ranking and backend result rendering were not the primary blocker.
+- **Checking only HTTP status.** The relevant question was not whether a server-action POST returned 200, but whether the page-level hydration flow reached `runSearch` and cleared the active skeleton state.
+
+## Solution
+
+Keep URL synchronization in the search controller, but skip `router.replace()` when the target URL is identical to the current browser URL. Compare the canonical search URL built by the shared helper with the current app-relative URL:
+
+```ts
+function buildCurrentSearchUrl(
+  pathname: string,
+  currentParams: URLSearchParams,
+): string {
+  const serializedParams = currentParams.toString()
+  return serializedParams.length > 0 ? `${pathname}?${serializedParams}` : pathname
+}
+
+const nextUrl = buildSearchUrl(pathname, currentParams, trimmed)
+if (nextUrl !== buildCurrentSearchUrl(pathname, currentParams)) {
+  router.replace(nextUrl as Route)
+}
+```
+
+Then make loading cleanup request-id-scoped and reusable so both normal completion and empty-query resets clear the active spinner without letting stale requests affect newer searches:
+
+```ts
+const clearLoadingForRequest = useCallback((requestId: number): void => {
+  if (requestIdRef.current !== requestId) return
+  if (skeletonTimerRef.current) {
+    clearTimeout(skeletonTimerRef.current)
+    skeletonTimerRef.current = null
+  }
+  setShowSkeleton(false)
+  setLoading(false)
+}, [])
+
+if (!trimmed) {
+  // clear results and reset search state...
+  clearLoadingForRequest(thisRequest)
+  return
+}
+
+try {
+  // run search...
+} finally {
+  clearLoadingForRequest(thisRequest)
+}
+```
+
+Lock the behavior with provider/controller tests:
+
+- Direct `?q=jesus` hydration calls `runSearch` and does not call `router.replace` for the same URL.
+- Changed queries still call `router.replace` and preserve unrelated params.
+- Clearing search removes `q` without calling `runSearch`.
+- Resetting an in-flight search clears `loading` and `showSkeleton`.
+- A stale search resolving after a newer search starts does not clear the active loading state.
+
+## Why This Works
+
+In a Next.js App Router page, `router.replace()` is not a harmless assignment. Even a same-URL replacement can start client navigation and RSC work around the same time the lazily mounted search controller is hydrating from `?q=`.
+
+The direct query URL already contains the intended search state, so replacing it with itself gives the router a chance to interrupt the flow without adding any user value. Guarding the no-op replacement lets the hydration search continue to `runSearch`.
+
+The loading fix follows the controller's existing request-id model. Every search increments `requestIdRef`; only the currently winning request can clear `loading`, `showSkeleton`, and the skeleton timer. Empty-query reset is also a valid winning request, so it must run the same cleanup instead of invalidating the older request and returning with skeletons still visible.
+
+## Prevention
+
+- Reproduce search bugs through the web page, not just one-off server-action probes. For App Router UI bugs, network success can coexist with broken client state.
+- Treat `router.replace()` as a navigation side effect. Before calling it from a hydrated overlay or modal, prove the target URL differs from the current URL.
+- Keep delayed skeleton timers paired with request-id cleanup. A reset path that increments the request id must also clear the active timer and loading flags.
+- Test both sides of URL sync guards: no-op URLs must not navigate, changed URLs still must navigate.
+- Isolate URL-sync tests from mount hydration by mounting without `q`, then changing `window.history` immediately before the user action being tested.
+
+## Related Issues
+
+- [Forge Algolia Search Modal Pattern](../architecture-patterns/forge-algolia-search-modal-20260610.md)
+- [Watch search overlay page size mismatch](../logic-errors/watch-search-overlay-page-size-mismatch.md)
+- [Watch Staged Client Loading](../performance-issues/watch-staged-client-loading-20260611.md)
+- [Next.js search overlay UI patterns](../best-practices/nextjs-search-overlay-ui-patterns-20260415.md)
+- [Queueing a user action across a Suspense boundary re-key in Next.js App Router](../best-practices/nextjs-cross-suspense-action-queue-with-url-params-20260421.md)


### PR DESCRIPTION
## Summary

Direct Watch search URLs like `/watch?q=jesus` now proceed to the real search action instead of getting stranded in the overlay skeleton state. The controller skips same-URL `router.replace()` calls during hydration, while still syncing real query changes and `q` removal.

Loading cleanup is now request-id scoped across normal completion, empty-query reset, and stale search completion, so an invalidated request cannot leave the active overlay permanently loading or hide a newer request's spinner.

This also documents the investigation with a formal plan and a `docs/solutions/` note so the App Router URL-sync failure mode is easier to recognize next time.

## Test Plan

- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `git diff --check -- apps/web/src/components/FloatingSearchController.tsx apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx docs/plans/2026-06-15-001-fix-watch-search-web-page-reliability-plan.md docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.12.0/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5_Codex](https://img.shields.io/badge/GPT_5_Codex-000000)
