### PR TITLE
chore(web): format watch search hydration fix

### DIFF
--- a/apps/web/src/components/FloatingSearchController.tsx
+++ b/apps/web/src/components/FloatingSearchController.tsx
@@ -49,7 +49,9 @@ function buildCurrentSearchUrl(
   currentParams: URLSearchParams,
 ): string {
   const serializedParams = currentParams.toString()
-  return serializedParams.length > 0 ? `${pathname}?${serializedParams}` : pathname
+  return serializedParams.length > 0
+    ? `${pathname}?${serializedParams}`
+    : pathname
 }
 
 export type FloatingSearchControllerProps = {

--- a/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
+++ b/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
@@ -58,7 +58,9 @@ function buildCurrentSearchUrl(
   currentParams: URLSearchParams,
 ): string {
   const serializedParams = currentParams.toString()
-  return serializedParams.length > 0 ? `${pathname}?${serializedParams}` : pathname
+  return serializedParams.length > 0
+    ? `${pathname}?${serializedParams}`
+    : pathname
 }
 
 const nextUrl = buildSearchUrl(pathname, currentParams, trimmed)


### PR DESCRIPTION
## Summary

Formats the Watch search hydration fix that already merged in #1261 so the merge-commit `format` job can pass and deployment can continue.

No behavior changes; this only wraps the long helper ternary in the controller and the matching solution-doc snippet.

## Test Plan

- `pnpm run format:check`
- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5_Codex](https://img.shields.io/badge/GPT_5_Codex-000000)
