### PR TITLE
fix(admin): extend legacy cleanup transaction timeout

### DIFF
--- a/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts
+++ b/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest"
 import {
   type CleanupAudit,
   type CleanupDb,
+  EXECUTE_TRANSACTION_OPTIONS,
   LegacyEmbeddingCleanupError,
   buildCleanupAudit,
   executeLegacyCleanup,
@@ -22,6 +23,7 @@ class FakeCleanupDb implements CleanupDb {
   executes: string[] = []
   executeResults: number[] = []
   transactionCalls = 0
+  transactionOptions: unknown[] = []
 
   constructor(
     private readonly queryResponder: (query: string) => unknown[] = () => [],
@@ -37,8 +39,12 @@ class FakeCleanupDb implements CleanupDb {
     return this.executeResults.shift() ?? 0
   }
 
-  async $transaction<T>(fn: (tx: CleanupDb) => Promise<T>): Promise<T> {
+  async $transaction<T>(
+    fn: (tx: CleanupDb) => Promise<T>,
+    options?: unknown,
+  ): Promise<T> {
     this.transactionCalls += 1
+    this.transactionOptions.push(options)
     return fn(this)
   }
 
@@ -361,6 +367,7 @@ describe("executeLegacyCleanup", () => {
       qwenColumnsDropped: 2,
     })
     expect(db.transactionCalls).toBe(1)
+    expect(db.transactionOptions).toEqual([EXECUTE_TRANSACTION_OPTIONS])
     const transcriptDelete = db.executes.find((query) =>
       query.includes("DELETE FROM video_transcript_chunk"),
     )

--- a/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts
+++ b/apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts
@@ -31,6 +31,11 @@ export const QWEN_COLUMN_TABLES = [
   "video_transcript_chunk",
 ] as const
 
+export const EXECUTE_TRANSACTION_OPTIONS = {
+  maxWait: 30000,
+  timeout: 600000,
+} as const
+
 export type TargetEnvironment = "development" | "staging" | "production"
 
 export type CleanupArgs = {
@@ -122,7 +127,10 @@ export type CleanupDb = {
   $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>
   $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>
   $disconnect?: () => Promise<void>
-  $transaction?: <T>(fn: (tx: CleanupDb) => Promise<T>) => Promise<T>
+  $transaction?: <T>(
+    fn: (tx: CleanupDb) => Promise<T>,
+    options?: typeof EXECUTE_TRANSACTION_OPTIONS,
+  ) => Promise<T>
 }
 
 type ContentAuditRow = {
@@ -529,7 +537,9 @@ async function executeContentMutations(
       transcriptChunksDeleted,
     }
   }
-  return db.$transaction ? db.$transaction(run) : run(db)
+  return db.$transaction
+    ? db.$transaction(run, EXECUTE_TRANSACTION_OPTIONS)
+    : run(db)
 }
 
 async function dropQwenArtifacts(


### PR DESCRIPTION
## Summary
- Extends the legacy OpenAI cleanup CLI interactive transaction timeout for large production updates.
- Adds a unit assertion that execute mode passes the explicit transaction options.

## Context
Production execution against the verified cleanup target exceeded Prisma's default 5s interactive transaction timeout before any mutations committed. A follow-up dry-run confirmed the failed attempt rolled back cleanly, then the fixed local CLI completed production cleanup successfully using backup evidence `postgres-schema:legacy_openai_cleanup_backup_20260615t003533z`.

## Verification
- `pnpm --filter @forge/admin exec vitest run src/scripts/cleanup-legacy-openai-embeddings.test.ts`
- `pnpm exec prettier --check apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts`
- `git diff --check -- apps/admin/src/scripts/cleanup-legacy-openai-embeddings.ts apps/admin/src/scripts/cleanup-legacy-openai-embeddings.test.ts`
- `pnpm --filter @forge/admin typecheck`
