### PR TITLE
docs(yt-video-mapper): sync prototype ticket index

### DIFF
--- a/docs/prototypes/yt-video-mapper/tickets/README.md
+++ b/docs/prototypes/yt-video-mapper/tickets/README.md
@@ -18,8 +18,8 @@ roadmap tickets broad; keep this folder practical and close to the mapper code.
 | [YTM-001](./ytm-001-deploy-service-and-database.md)            | complete | P1       | Deploy service and database                  |
 | [YTM-002](./ytm-002-admin-flat-catalog-projection.md)          | complete | P1       | Admin flat catalog projection                |
 | [YTM-003](./ytm-003-mapper-catalog-sync.md)                    | complete | P1       | Mapper catalog sync                          |
-| [YTM-004](./ytm-004-official-media-signature-indexing.md)      | todo     | P1       | Official media signature indexing            |
-| [YTM-005](./ytm-005-replace-placeholders-with-real-matcher.md) | todo     | P1       | Replace placeholders with real matcher       |
+| [YTM-004](./ytm-004-official-media-signature-indexing.md)      | complete | P1       | Official media signature indexing            |
+| [YTM-005](./ytm-005-replace-placeholders-with-real-matcher.md) | complete | P1       | Replace placeholders with real matcher       |
 | [YTM-006](./ytm-006-evaluation-harness-and-thresholds.md)      | todo     | P1       | Evaluation harness and confidence thresholds |
 | [YTM-007](./ytm-007-ops-hardening.md)                          | todo     | P2       | Operations hardening                         |
 | [YTM-008](./ytm-008-model-assisted-review-research.md)         | backlog  | P3       | Model-assisted review research               |


### PR DESCRIPTION
## Summary
- mark YTM-004 and YTM-005 complete in the prototype ticket index
- align README status rows with the already-complete ticket files

## Verification
- pnpm prettier --check docs/prototypes/yt-video-mapper/tickets/README.md
- git diff --check