### PR TITLE
fix(web): prevent edited watch search hangs

### DIFF
--- a/apps/web/src/components/FloatingSearchController.tsx
+++ b/apps/web/src/components/FloatingSearchController.tsx
@@ -9,8 +9,7 @@ import {
   type ReactNode,
 } from "react"
 import { createPortal } from "react-dom"
-import type { Route } from "next"
-import { usePathname, useRouter } from "next/navigation"
+import { usePathname } from "next/navigation"
 import { useTranslations } from "next-intl"
 
 import { runSearch } from "@/lib/search-actions"
@@ -54,6 +53,10 @@ function buildCurrentSearchUrl(
     : pathname
 }
 
+function replaceBrowserSearchUrl(nextUrl: string): void {
+  window.history.replaceState(window.history.state, "", nextUrl)
+}
+
 export type FloatingSearchControllerProps = {
   open: boolean
   closing: boolean
@@ -74,12 +77,10 @@ export function FloatingSearchController({
   children,
 }: FloatingSearchControllerProps) {
   const tSearchOverlay = useTranslations("SearchOverlay")
-  const router = useRouter()
-  // usePathname() returns the app-relative path (no basePath prefix). The
-  // router.replace() call auto-prefixes basePath, so feeding it
-  // window.location.pathname (which includes basePath) would double-prefix
-  // on every search. usePathname() does NOT force the Full Route Cache
-  // deopt that useSearchParams() would.
+  // usePathname() does NOT force the Full Route Cache deopt that
+  // useSearchParams() would. Keep it for route-language parsing, but use the
+  // browser pathname when mutating the visible ?q= URL below so deployments
+  // with a basePath keep their public path intact.
   const pathname = usePathname()
 
   // Whether the modal was opened via URL hydration (vs user click). Gates a
@@ -267,16 +268,19 @@ export function FloatingSearchController({
       activeSearchSignatureRef.current = null
       setLoadingMore(false)
 
-      // URL sync — preserves any existing params (utm_*, etc.) and strips ?q=
-      // when the query is empty. Use usePathname() (app-relative) so
-      // router.replace's auto basePath prefix isn't applied twice.
       const currentParams =
         typeof window !== "undefined"
           ? new URLSearchParams(window.location.search)
           : new URLSearchParams()
-      const nextUrl = buildSearchUrl(pathname, currentParams, trimmed)
-      if (nextUrl !== buildCurrentSearchUrl(pathname, currentParams)) {
-        router.replace(nextUrl as Route)
+      const browserPathname =
+        typeof window !== "undefined" ? window.location.pathname : pathname
+      const nextUrl = buildSearchUrl(browserPathname, currentParams, trimmed)
+      if (nextUrl !== buildCurrentSearchUrl(browserPathname, currentParams)) {
+        // The search modal owns ?q= as client-side UI state. Using
+        // router.replace() here dispatches an App Router/RSC navigation, which
+        // can remount the overlay and clear a newer debounced search while the
+        // viewer is still typing.
+        replaceBrowserSearchUrl(nextUrl)
       }
 
       if (!trimmed) {
@@ -392,7 +396,6 @@ export function FloatingSearchController({
       pathname,
       refreshLanguageOptions,
       routeLanguageSlug,
-      router,
       setQuery,
       tSearchOverlay,
     ],

--- a/apps/web/src/components/FloatingSearchController.tsx
+++ b/apps/web/src/components/FloatingSearchController.tsx
@@ -53,10 +53,6 @@ function buildCurrentSearchUrl(
     : pathname
 }
 
-function replaceBrowserSearchUrl(nextUrl: string): void {
-  window.history.replaceState(window.history.state, "", nextUrl)
-}
-
 export type FloatingSearchControllerProps = {
   open: boolean
   closing: boolean
@@ -280,7 +276,7 @@ export function FloatingSearchController({
         // router.replace() here dispatches an App Router/RSC navigation, which
         // can remount the overlay and clear a newer debounced search while the
         // viewer is still typing.
-        replaceBrowserSearchUrl(nextUrl)
+        window.history.replaceState(window.history.state, "", nextUrl)
       }
 
       if (!trimmed) {

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -720,7 +720,7 @@ describe("FloatingSearchProvider — search mode", () => {
     expect(skeleton?.textContent).toBe("true")
   })
 
-  it("syncs the URL when the submitted search query changes", async () => {
+  it("syncs the URL with browser history when the submitted search query changes", async () => {
     mockedRunSearch.mockResolvedValueOnce(searchResult("semantic"))
     window.history.replaceState(null, "", "/?utm=campaign")
 
@@ -743,9 +743,9 @@ describe("FloatingSearchProvider — search mode", () => {
       await Promise.resolve()
     })
 
-    expect(navigationMocks.replace).toHaveBeenCalledWith(
-      "/?q=jesus&utm=campaign",
-    )
+    expect(window.location.pathname).toBe("/")
+    expect(window.location.search).toBe("?q=jesus&utm=campaign")
+    expect(navigationMocks.replace).not.toHaveBeenCalled()
   })
 
   it("removes the query param from the URL when search is cleared", async () => {
@@ -770,7 +770,9 @@ describe("FloatingSearchProvider — search mode", () => {
       await Promise.resolve()
     })
 
-    expect(navigationMocks.replace).toHaveBeenCalledWith("/?utm=campaign")
+    expect(window.location.pathname).toBe("/")
+    expect(window.location.search).toBe("?utm=campaign")
+    expect(navigationMocks.replace).not.toHaveBeenCalled()
     expect(mockedRunSearch).not.toHaveBeenCalled()
   })
 })
@@ -1256,6 +1258,64 @@ describe("FloatingSearchProvider — search pagination", () => {
       }),
     )
     expect(document.body.textContent).toContain("The Bible Project Result")
+  })
+
+  it("keeps the final edited query search after an intermediate debounce syncs the URL", async () => {
+    vi.useFakeTimers()
+    mockedRunSearch.mockImplementation(({ query }) => {
+      if (query === "jesus") {
+        return Promise.resolve(
+          makeSearchResponse(
+            [makeSearchResult("jesus", "Jesus Result")],
+            false,
+          ),
+        )
+      }
+      if (query === "the bible project") {
+        return Promise.resolve(
+          makeSearchResponse(
+            [makeSearchResult("bible-project", "Bible Project Result")],
+            false,
+          ),
+        )
+      }
+      return new Promise(() => {})
+    })
+
+    try {
+      const input = await openSearchOverlay()
+      await submitDebouncedSearch(input, "jesus")
+      expect(document.body.textContent).toContain("Jesus Result")
+
+      act(() => {
+        setInputValue(input, "the bible proj")
+        vi.advanceTimersByTime(360)
+      })
+
+      expect(window.location.search).toBe("?q=the+bible+proj")
+
+      await act(async () => {
+        setInputValue(input, "the bible project")
+        vi.advanceTimersByTime(300)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(250)
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(mockedRunSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ query: "the bible project" }),
+      )
+      expect(window.location.search).toBe("?q=the+bible+project")
+      expect(navigationMocks.replace).not.toHaveBeenCalled()
+      expect(document.body.textContent).toContain("Bible Project Result")
+    } finally {
+      mockedRunSearch.mockReset()
+    }
   })
 
   it("loads the next Watch search page with limit 10, current offset, and appends results", async () => {

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -722,7 +722,7 @@ describe("FloatingSearchProvider — search mode", () => {
 
   it("syncs the URL with browser history when the submitted search query changes", async () => {
     mockedRunSearch.mockResolvedValueOnce(searchResult("semantic"))
-    window.history.replaceState(null, "", "/?utm=campaign")
+    window.history.replaceState({ next: "initial" }, "", "/watch?utm=campaign")
 
     act(() => {
       root.render(
@@ -732,7 +732,8 @@ describe("FloatingSearchProvider — search mode", () => {
       )
     })
 
-    window.history.replaceState(null, "", "/?q=bible&utm=campaign")
+    const historyState = { next: "preserve" }
+    window.history.replaceState(historyState, "", "/watch?q=bible&utm=campaign")
 
     const searchButton = document.querySelector(
       '[data-testid="search-mode-harness-button"]',
@@ -743,13 +744,14 @@ describe("FloatingSearchProvider — search mode", () => {
       await Promise.resolve()
     })
 
-    expect(window.location.pathname).toBe("/")
+    expect(window.location.pathname).toBe("/watch")
     expect(window.location.search).toBe("?q=jesus&utm=campaign")
+    expect(window.history.state).toEqual(historyState)
     expect(navigationMocks.replace).not.toHaveBeenCalled()
   })
 
   it("removes the query param from the URL when search is cleared", async () => {
-    window.history.replaceState(null, "", "/?utm=campaign")
+    window.history.replaceState({ next: "initial" }, "", "/watch?utm=campaign")
 
     act(() => {
       root.render(
@@ -759,7 +761,8 @@ describe("FloatingSearchProvider — search mode", () => {
       )
     })
 
-    window.history.replaceState(null, "", "/?q=jesus&utm=campaign")
+    const historyState = { next: "preserve" }
+    window.history.replaceState(historyState, "", "/watch?q=jesus&utm=campaign")
 
     const clearButton = document.querySelector(
       '[data-testid="search-mode-harness-clear-button"]',
@@ -770,8 +773,9 @@ describe("FloatingSearchProvider — search mode", () => {
       await Promise.resolve()
     })
 
-    expect(window.location.pathname).toBe("/")
+    expect(window.location.pathname).toBe("/watch")
     expect(window.location.search).toBe("?utm=campaign")
+    expect(window.history.state).toEqual(historyState)
     expect(navigationMocks.replace).not.toHaveBeenCalled()
     expect(mockedRunSearch).not.toHaveBeenCalled()
   })
@@ -1313,6 +1317,7 @@ describe("FloatingSearchProvider — search pagination", () => {
       expect(window.location.search).toBe("?q=the+bible+project")
       expect(navigationMocks.replace).not.toHaveBeenCalled()
       expect(document.body.textContent).toContain("Bible Project Result")
+      expect(document.querySelector(".animate-pulse")).toBeNull()
     } finally {
       mockedRunSearch.mockReset()
     }

--- a/apps/web/src/lib/search-url.ts
+++ b/apps/web/src/lib/search-url.ts
@@ -1,10 +1,7 @@
 /**
- * Build a URL string for router.replace() calls that sync the current search
- * query to the ?q= param. Preserves any other search params already on the URL
- * (e.g., utm_*, locale flags) rather than wiping them.
- *
- * Returns a plain string. The caller is responsible for the `as Route` cast
- * required by next.config.mjs's `experimental.typedRoutes: true` setting.
+ * Build a URL string that syncs the current search query to the ?q= param.
+ * Preserves any other search params already on the URL (e.g., utm_*, locale
+ * flags) rather than wiping them.
  */
 export function buildSearchUrl(
   pathname: string,

--- a/docs/plans/2026-06-15-002-fix-watch-search-edited-query-hang-plan.md
+++ b/docs/plans/2026-06-15-002-fix-watch-search-edited-query-hang-plan.md
@@ -1,0 +1,56 @@
+---
+title: Watch Search Edited Query Hang Fix Plan
+type: fix
+date: 2026-06-15
+origin: docs/plans/2026-06-15-001-fix-watch-search-web-page-reliability-plan.md
+---
+
+# Watch Search Edited Query Hang Fix Plan
+
+## Summary
+
+Fix the remaining Watch search modal hang when a viewer completes one search, edits the active query, pauses briefly, and continues typing. The first hydration fix stopped same-URL navigations, but changed-query URL sync still uses Next router navigation and can interrupt the modal's debounced search flow.
+
+## Problem Frame
+
+Production repro on 2026-06-15:
+
+1. Open `watch.jesusfilm.org/watch`.
+2. Search `jesus`; results render.
+3. Clear/edit the input, type `the bible proj`, pause long enough for debounce, then type `ect`.
+4. The URL stays at `?q=the+bible+proj`, the input shows `the bible project`, skeleton cards remain, and no result cards render.
+
+The browser trace showed a server-action POST for language metadata at the partial query URL, but no `runSearch` POST for either the partial query or the final query. This points to client-side navigation/remount interruption, not search backend latency.
+
+## Requirements
+
+- R1. Editing a non-empty completed search into another non-empty query must render the winning final result set.
+- R2. Query URL sync must keep `?q=` shareable without triggering a Next App Router/RSC navigation for modal-only search typing.
+- R3. Existing direct `?q=` hydration must continue to search on initial mount.
+- R4. Empty-query reset, stale request guards, language filters, and load-more behavior must remain unchanged.
+
+## Implementation Units
+
+### U1. Modal URL Sync Without Next Navigation
+
+- **Goal:** Replace changed-query `router.replace()` calls with `window.history.replaceState()` for search modal `?q=` updates.
+- **Files:** `apps/web/src/components/FloatingSearchController.tsx`.
+- **Rationale:** `?q=` is client modal state. Updating it through Next navigation can remount the overlay while debounced input is still active, clearing pending searches.
+- **Test Scenarios:** Changed-query sync updates `window.location.search` and does not call `router.replace`.
+
+### U2. Edited Query Regression Coverage
+
+- **Goal:** Cover the exact interaction invariant: a completed search can be edited through an intermediate debounced query and then a final query without losing the final search.
+- **Files:** `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`.
+- **Test Scenarios:** Search `jesus`, type `the bible proj`, let debounce fire, type `the bible project`, let debounce fire, and assert the final `runSearch` call is made while no Next router replace occurs.
+
+## Verification
+
+- Focused Vitest file: `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`.
+- Web typecheck.
+- Browser smoke reproducing the post-success edit path.
+
+## Scope Boundaries
+
+- Do not change search ranking, Admin GraphQL, Algolia flag behavior, result cards, or route structure.
+- Do not introduce a new search page; the floating modal remains the search surface.

--- a/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
+++ b/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
@@ -1,14 +1,16 @@
 ---
-title: "Watch search URL hydration can strand the overlay in loading"
+title: "Watch search URL sync can strand the overlay in loading"
 date: "2026-06-15"
+last_updated: "2026-06-15"
 category: "ui-bugs"
 module: "apps/web watch search"
 problem_type: "ui_bug"
 component: "frontend_stimulus"
 symptoms:
   - "Opening `/watch?q=jesus` can show the search overlay and skeleton cards indefinitely."
+  - "Editing a successful search into a second query can leave the URL behind the input and keep skeleton cards visible."
   - "Production `/watch` server-action POSTs can return 200 while the UI never renders result cards."
-  - "Typed searches from the already-open overlay can recover, proving the backend search path is not the only failure point."
+  - "The browser can post language metadata for the partial query without ever posting the final `runSearch` payload."
 root_cause: "async_timing"
 resolution_type: "code_fix"
 severity: "high"
@@ -23,22 +25,26 @@ tags:
   - "search"
   - "url-hydration"
   - "router-replace"
+  - "history-replace-state"
   - "loading-state"
   - "skeleton"
   - "app-router"
 ---
 
-# Watch search URL hydration can strand the overlay in loading
+# Watch search URL sync can strand the overlay in loading
 
 ## Problem
 
-The Watch search page could open directly at a query URL, such as `/watch?q=jesus`, display the modal with skeleton result cards, and never show results. The backend was not simply timing out: browser-level production tracing showed the page-level client flow could call language metadata, dispatch an App Router navigation for an already-synced URL, and fail to reach the real `runSearch` action for the hydrated query.
+The Watch search page could open directly at a query URL, such as `/watch?q=jesus`, display the modal with skeleton result cards, and never show results. A second production path showed the same class of failure after a successful search: search `jesus`, edit the active input to `the bible proj`, pause past debounce, then type `ect`. The input showed `the bible project`, the URL stayed at `?q=the+bible+proj`, skeleton cards remained, and no final results rendered.
+
+The backend was not simply timing out. Browser-level production tracing showed page-level client flow could post language metadata and return HTTP 200 while failing to reach the real `runSearch` action for the user-visible final query.
 
 ## Symptoms
 
 - The page showed the search overlay, focused input, and pulsing skeleton cards for many minutes.
 - Server-action POSTs returned HTTP 200, but the initial direct URL path only called `getSearchLanguageOptions`.
 - Typing a new query in the overlay later issued `runSearch` and rendered result cards.
+- After a successful first search, an intermediate edited query could update the URL and start skeletons while the final input value never reached `runSearch`.
 - Clearing or superseding a pending search could leave `loading` and `showSkeleton` latched if the stale request was invalidated before its cleanup ran.
 
 ## What Didn't Work
@@ -47,10 +53,11 @@ The Watch search page could open directly at a query URL, such as `/watch?q=jesu
 - **Waiting longer.** The observed failure could sit for 10 minutes because the UI was stuck in client state, not waiting for a normal request timeout.
 - **Blaming search ranking or Algolia fallback.** Later typed searches returned results, so ranking and backend result rendering were not the primary blocker.
 - **Checking only HTTP status.** The relevant question was not whether a server-action POST returned 200, but whether the page-level hydration flow reached `runSearch` and cleared the active skeleton state.
+- **Testing only direct `?q=` hydration.** That proved the first URL-open path, but missed the post-success edit path where a changed-query navigation could remount the overlay and clear a newer debounce timer.
 
 ## Solution
 
-Keep URL synchronization in the search controller, but skip `router.replace()` when the target URL is identical to the current browser URL. Compare the canonical search URL built by the shared helper with the current app-relative URL:
+Keep URL synchronization in the search controller, but do not use Next App Router navigation for modal-owned `?q=` edits. The search modal uses `?q=` as client UI state, so update the visible URL with `window.history.replaceState()` while preserving Next's existing history state:
 
 ```ts
 function buildCurrentSearchUrl(
@@ -63,9 +70,15 @@ function buildCurrentSearchUrl(
     : pathname
 }
 
-const nextUrl = buildSearchUrl(pathname, currentParams, trimmed)
-if (nextUrl !== buildCurrentSearchUrl(pathname, currentParams)) {
-  router.replace(nextUrl as Route)
+function replaceBrowserSearchUrl(nextUrl: string): void {
+  window.history.replaceState(window.history.state, "", nextUrl)
+}
+
+const browserPathname =
+  typeof window !== "undefined" ? window.location.pathname : pathname
+const nextUrl = buildSearchUrl(browserPathname, currentParams, trimmed)
+if (nextUrl !== buildCurrentSearchUrl(browserPathname, currentParams)) {
+  replaceBrowserSearchUrl(nextUrl)
 }
 ```
 
@@ -98,25 +111,27 @@ try {
 Lock the behavior with provider/controller tests:
 
 - Direct `?q=jesus` hydration calls `runSearch` and does not call `router.replace` for the same URL.
-- Changed queries still call `router.replace` and preserve unrelated params.
+- Changed queries update `window.location.search`, preserve unrelated params, and do not call `router.replace`.
 - Clearing search removes `q` without calling `runSearch`.
+- Editing from a completed `jesus` search through an intermediate debounced query to `the bible project` still calls `runSearch` for the final query.
 - Resetting an in-flight search clears `loading` and `showSkeleton`.
 - A stale search resolving after a newer search starts does not clear the active loading state.
 
 ## Why This Works
 
-In a Next.js App Router page, `router.replace()` is not a harmless assignment. Even a same-URL replacement can start client navigation and RSC work around the same time the lazily mounted search controller is hydrating from `?q=`.
+In a Next.js App Router page, `router.replace()` is not a harmless assignment. It can start client navigation and RSC work around the same time the search overlay is hydrating, exiting previous result cards, or holding a pending debounce for the user's next keystrokes.
 
-The direct query URL already contains the intended search state, so replacing it with itself gives the router a chance to interrupt the flow without adding any user value. Guarding the no-op replacement lets the hydration search continue to `runSearch`.
+The direct query URL already contains the intended search state, so replacing it with itself gives the router a chance to interrupt the flow without adding any user value. For changed queries, the URL update is still useful, but it does not need a server navigation because the modal's input and results are controlled client-side. Native `replaceState()` keeps the address bar shareable without remounting the overlay or clearing pending debounce timers.
 
 The loading fix follows the controller's existing request-id model. Every search increments `requestIdRef`; only the currently winning request can clear `loading`, `showSkeleton`, and the skeleton timer. Empty-query reset is also a valid winning request, so it must run the same cleanup instead of invalidating the older request and returning with skeletons still visible.
 
 ## Prevention
 
 - Reproduce search bugs through the web page, not just one-off server-action probes. For App Router UI bugs, network success can coexist with broken client state.
-- Treat `router.replace()` as a navigation side effect. Before calling it from a hydrated overlay or modal, prove the target URL differs from the current URL.
+- Treat `router.replace()` as a navigation side effect. Before calling it from a hydrated overlay or modal, prove that a server navigation is actually needed.
+- For modal-owned URL state, prefer `window.history.replaceState(window.history.state, "", nextUrl)` so Next history metadata is preserved without dispatching RSC navigation.
 - Keep delayed skeleton timers paired with request-id cleanup. A reset path that increments the request id must also clear the active timer and loading flags.
-- Test both sides of URL sync guards: no-op URLs must not navigate, changed URLs still must navigate.
+- Test both sides of URL sync: no-op URLs must not navigate, changed modal query URLs must update browser history without App Router navigation.
 - Isolate URL-sync tests from mount hydration by mounting without `q`, then changing `window.history` immediately before the user action being tested.
 
 ## Related Issues

--- a/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
+++ b/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
@@ -23,12 +23,11 @@ tags:
   - "web"
   - "watch"
   - "search"
-  - "url-hydration"
+  - "url-sync"
+  - "app-router"
   - "router-replace"
   - "history-replace-state"
   - "loading-state"
-  - "skeleton"
-  - "app-router"
 ---
 
 # Watch search URL sync can strand the overlay in loading
@@ -57,7 +56,7 @@ The backend was not simply timing out. Browser-level production tracing showed p
 
 ## Solution
 
-Keep URL synchronization in the search controller, but do not use Next App Router navigation for modal-owned `?q=` edits. The search modal uses `?q=` as client UI state, so update the visible URL with `window.history.replaceState()` while preserving Next's existing history state:
+Keep URL synchronization in the search controller, but do not use Next App Router navigation for modal-owned `?q=` edits. The search modal uses `?q=` as client UI state, so update the visible URL with `window.history.replaceState()` while passing through `window.history.state`. That preserves Next's existing App Router history metadata instead of replacing it with `null`.
 
 ```ts
 function buildCurrentSearchUrl(
@@ -70,17 +69,15 @@ function buildCurrentSearchUrl(
     : pathname
 }
 
-function replaceBrowserSearchUrl(nextUrl: string): void {
-  window.history.replaceState(window.history.state, "", nextUrl)
-}
-
 const browserPathname =
   typeof window !== "undefined" ? window.location.pathname : pathname
 const nextUrl = buildSearchUrl(browserPathname, currentParams, trimmed)
 if (nextUrl !== buildCurrentSearchUrl(browserPathname, currentParams)) {
-  replaceBrowserSearchUrl(nextUrl)
+  window.history.replaceState(window.history.state, "", nextUrl)
 }
 ```
+
+Use `window.location.pathname` for the browser-visible path so non-root public routes such as `/watch` stay intact when the query string changes.
 
 Then make loading cleanup request-id-scoped and reusable so both normal completion and empty-query resets clear the active spinner without letting stale requests affect newer searches:
 
@@ -111,9 +108,9 @@ try {
 Lock the behavior with provider/controller tests:
 
 - Direct `?q=jesus` hydration calls `runSearch` and does not call `router.replace` for the same URL.
-- Changed queries update `window.location.search`, preserve unrelated params, and do not call `router.replace`.
+- Changed queries sync `/watch?utm=campaign` to `/watch?q=jesus&utm=campaign`, preserve unrelated params, preserve a non-null `window.history.state`, and do not call `router.replace`.
 - Clearing search removes `q` without calling `runSearch`.
-- Editing from a completed `jesus` search through an intermediate debounced query to `the bible project` still calls `runSearch` for the final query.
+- Editing from a completed `jesus` search through an intermediate debounced query to `the bible project` still calls `runSearch` for the final query and clears the pulsing skeleton cards.
 - Resetting an in-flight search clears `loading` and `showSkeleton`.
 - A stale search resolving after a newer search starts does not clear the active loading state.
 
@@ -131,8 +128,9 @@ The loading fix follows the controller's existing request-id model. Every search
 - Treat `router.replace()` as a navigation side effect. Before calling it from a hydrated overlay or modal, prove that a server navigation is actually needed.
 - For modal-owned URL state, prefer `window.history.replaceState(window.history.state, "", nextUrl)` so Next history metadata is preserved without dispatching RSC navigation.
 - Keep delayed skeleton timers paired with request-id cleanup. A reset path that increments the request id must also clear the active timer and loading flags.
-- Test both sides of URL sync: no-op URLs must not navigate, changed modal query URLs must update browser history without App Router navigation.
+- Test both sides of URL sync: no-op URLs must not navigate, changed modal query URLs must update browser history without App Router navigation, and edited-query regressions must prove skeletons are gone after final results render.
 - Isolate URL-sync tests from mount hydration by mounting without `q`, then changing `window.history` immediately before the user action being tested.
+- Keep URL helper comments transport-neutral. A helper used by native history updates should describe browser search URL sync, not `router.replace()` calls.
 
 ## Related Issues
 


### PR DESCRIPTION
## Summary

After a successful Watch search, editing the input into a second query could strand the modal in skeleton loading. In the reproduced prod flow, `jesus` rendered results, then `the bible proj` updated the URL, the input continued to `the bible project`, and the final visible query never reached `runSearch`.

This keeps the search URL shareable without dispatching App Router navigation for modal-only query edits. The modal now updates `?q=` with `window.history.replaceState(window.history.state, "", nextUrl)`, so an intermediate debounce cannot remount the overlay and clear the pending final search.

## Root Cause

`router.replace()` was still used for changed `?q=` values. That starts a Next App Router/RSC navigation, and during active typing it can interrupt the overlay after language metadata posts but before the final search action posts. Native history sync is enough here because `?q=` is client-owned modal state.

## CE Review + Compound

- Ran `compound-engineering:ce-code-review` with correctness, testing, maintainability, project-standards, frontend-races, adversarial, agent-native, and learnings reviewers.
- Applied the review follow-up: inline the single-use history wrapper, preserve non-null `window.history.state`, test non-root `/watch` URL sync, assert edited-query skeletons clear, and make the search URL helper comment transport-neutral.
- Ran `compound-engineering:ce-compound`; overlap was high with the existing Watch search solution note, so this updates `docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md` instead of creating a duplicate.
- `CONCEPTS.md`: scanned, no qualifying new domain term.
- Instruction-file discoverability: no edit needed; root instructions already surface `docs/solutions/` and `CONCEPTS.md`.

## Validation

- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `pnpm run format:check`
- `git diff --check`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.12.0/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md`
- Production repro captured before the fix: URL stayed at `?q=the+bible+proj`, input showed `the bible project`, skeletons stayed visible, and no `runSearch` POST occurred for the final query.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
