### PR TITLE
chore: gitignore .claude/**/*.dev.md local dev notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ test-results/
 .claude/telemetry/
 .claude/worktrees/
 .claude/secrets.local.md
+.claude/**/*.dev.md
 
 # Compound engineering working files
 .context/


### PR DESCRIPTION
## What

Ignore machine-local `*.dev.md` files at **any depth** under `.claude/`.

```diff
 .claude/worktrees/
 .claude/secrets.local.md
+.claude/**/*.dev.md
```

## Why

Lets developers keep personal dev rules/notes (e.g. `.claude/rules.dev.md`) in the `.claude/` folder without committing them. Mirrors the existing `.claude/secrets.local.md` machine-local convention. The `**` glob matches both top-level (`.claude/rules.dev.md`) and nested (`.claude/sub/x.dev.md`) files.

## Verification

```
$ git check-ignore .claude/rules.dev.md .claude/a/b/c/deep.dev.md
.claude/rules.dev.md
.claude/a/b/c/deep.dev.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)