### PR TITLE
fix(web): keep watch language switch pending

### DIFF
--- a/apps/web/src/components/watch/LanguagePickerModal.tsx
+++ b/apps/web/src/components/watch/LanguagePickerModal.tsx
@@ -63,13 +63,6 @@ export type LanguagePickerModalProps = {
   onRetryLanguageOptions?: () => void
 }
 
-// Safety cap on the in-flight navigation guard. router.push is fire-and-
-// forget; if the navigation never lands (offline, abort, cookie-driven
-// proxy redirect to a slug that doesn't match draftSlug), the modal-local
-// guard would otherwise stay set and disable Apply for the rest of the
-// session. After this timeout the guard releases so the user can retry.
-const NAVIGATING_TIMEOUT_MS = 5000
-
 const TOOLTIP_LANGUAGES = [
   { key: "english", dir: "ltr" },
   { key: "mandarin", dir: "ltr" },
@@ -416,7 +409,8 @@ export function LanguagePickerModal({
   // Track which slug we've dispatched a navigation toward. `navigating`
   // becomes false NATURALLY once the URL catches up — no setState in
   // effect required (React Compiler's anti-cascade rule is satisfied by
-  // construction). Set to null to force-release on safety timeout.
+  // construction). Keep this set while unresolved so the primary action
+  // never reverts to "Apply" before a slow route commit lands.
   const [pendingNavTo, setPendingNavTo] = useState<string | null>(null)
 
   // Synchronous double-click guard. `pendingNavTo` state alone is async
@@ -489,23 +483,10 @@ export function LanguagePickerModal({
 
   // Release the sync guard once the URL catches up. The ref-mirror effect
   // is the only path that touches `.inFlight = false` outside the open
-  // reset and timeout — fires once per slug change.
+  // reset — fires once per slug change.
   useEffect(() => {
     navigatingRef.current.inFlight = false
   }, [currentLanguageSlug])
-
-  // Safety timeout: if the navigation never lands (e.g. cookie-driven
-  // proxy redirect to a slug that doesn't match draftSlug, or router.push
-  // silently fails), release the guard and clear pendingNavTo so the user
-  // can retry. Re-armed whenever a new navigation starts.
-  useEffect(() => {
-    if (pendingNavTo === null) return
-    const timer = window.setTimeout(() => {
-      navigatingRef.current.inFlight = false
-      setPendingNavTo(null)
-    }, NAVIGATING_TIMEOUT_MS)
-    return () => window.clearTimeout(timer)
-  }, [pendingNavTo])
 
   const lastPrefetchedPathRef = useRef<string | null>(null)
   useEffect(() => {

--- a/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
@@ -928,7 +928,7 @@ describe("LanguagePickerModal — in-flight navigation guard", () => {
     expect(routerPushMock).toHaveBeenCalledWith("/the-call.html/spanish.html")
   })
 
-  it("releases the navigation guard after the safety timeout (~5s)", () => {
+  it("keeps the switching state after the old safety timeout window", () => {
     vi.useFakeTimers()
     try {
       renderModal({ open: true, variants: baseVariants })
@@ -950,18 +950,24 @@ describe("LanguagePickerModal — in-flight navigation guard", () => {
         '[data-testid="watch-language-picker-apply"]',
       ) as HTMLButtonElement
       expect(apply.disabled).toBe(true)
+      expect(apply.textContent).toContain("Switching...")
 
-      // Advance past the 5s safety timeout. With currentLanguageSlug
-      // never updating (no parent rerender simulates the cookie/redirect
-      // stuck-navigating scenario), the guard otherwise stays set.
+      // Advance past the old 5s safety-timeout window. The UI must not
+      // claim the switch is idle while the App Router transition can still
+      // commit and close the modal later.
       act(() => {
         vi.advanceTimersByTime(5001)
       })
       apply = $(
         '[data-testid="watch-language-picker-apply"]',
       ) as HTMLButtonElement
-      expect(apply.disabled).toBe(false)
-      expect(apply.textContent).toContain("Apply")
+      expect(apply.disabled).toBe(true)
+      expect(apply.textContent).toContain("Switching...")
+
+      act(() => {
+        apply.click()
+      })
+      expect(routerPushMock).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }

--- a/docs/plans/2026-06-15-003-fix-watch-language-switch-timeout-feedback-plan.md
+++ b/docs/plans/2026-06-15-003-fix-watch-language-switch-timeout-feedback-plan.md
@@ -1,0 +1,103 @@
+---
+title: Watch Language Switch Timeout Feedback Fix Plan
+type: fix
+status: completed
+date: 2026-06-15
+origin: docs/roadmap/topic-experiences/feat-191-watch-language-switch-timeout-feedback.md
+---
+
+# Watch Language Switch Timeout Feedback Fix Plan
+
+## Summary
+
+Keep the Watch language picker in a truthful pending state when language navigation takes longer than the current 5 second safety timeout. The fix narrows to modal state and tests; route generation, language identity, prefetch, and server data fetching stay unchanged.
+
+---
+
+## Problem Frame
+
+The original pending-feedback work in `feat-107` fixed the older no-feedback path by keeping the modal open and showing `Switching...` after Apply. The remaining bug is the recovery path: if the route has not committed after 5 seconds, `pendingNavTo` clears, the button says `Apply` again, and the eventual route commit makes the modal close later. Viewers interpret that idle gap as a failed apply action even though navigation is still in flight.
+
+---
+
+## Requirements
+
+- R1. A dirty-language Apply action must show `Switching...` until the target language route commits or the user intentionally closes the modal.
+- R2. The 5 second recovery path must not present `Apply` as available for the same unresolved navigation.
+- R3. Duplicate Apply clicks must remain ignored while a language navigation is unresolved.
+- R4. Existing successful navigation catch-up must still clear pending state when `currentLanguageSlug` matches the selected target language.
+- R5. Existing route, timestamp, autoplay, cookie-write, and selective-prefetch contracts must remain unchanged.
+
+---
+
+## Key Technical Decisions
+
+- **Separate visible pending from retry recovery:** The timeout can remain as a guard for internal bookkeeping only if it does not make the primary action look idle while the original navigation may still finish.
+- **Use Close as the visible escape hatch:** A stalled route should leave the user with the existing Close control rather than a misleading second Apply button.
+- **Keep the fix inside the modal:** This is a localized feedback bug; a page-level overlay or route-performance work would broaden the slice beyond the reported behavior.
+
+---
+
+## Assumptions
+
+- A route that has not committed after 5 seconds can still commit successfully, so returning to `Apply` is more misleading than keeping `Switching...`.
+- Users who want to abandon a slow switch can use the modal Close action; a separate retry affordance can be planned later if production evidence shows failed navigations are common.
+
+---
+
+## Implementation Units
+
+### U1. Keep Unresolved Navigation Visibly Pending
+
+- **Goal:** Adjust the `LanguagePickerModal` in-flight state so timeout recovery does not clear the visible `Switching...` state for the current unresolved language switch.
+- **Requirements:** R1, R2, R3, R4, R5.
+- **Dependencies:** None.
+- **Files:** `apps/web/src/components/watch/LanguagePickerModal.tsx`.
+- **Approach:** Preserve the current `pendingNavTo` catch-up model, but stop the safety timeout from resetting the UI back to a dirty, enabled Apply state while `currentLanguageSlug` still differs from the target. Keep the synchronous `navigatingRef` guard aligned with the visible pending state so duplicate clicks remain blocked.
+- **Patterns to follow:** Existing `pendingNavTo` derivation and open-state reset in `LanguagePickerModal.tsx`; existing route builders in `apps/web/src/lib/routes.ts`.
+- **Test scenarios:** Covered in U2.
+- **Verification:** Applying a changed language leaves the button disabled with `Switching...` until either the destination slug arrives or the modal is closed.
+
+### U2. Update Navigation Guard Regression Tests
+
+- **Goal:** Replace the stale safety-timeout expectation with coverage for the truthful pending behavior and keep the existing catch-up and duplicate-click tests.
+- **Requirements:** R1, R2, R3, R4, R5.
+- **Dependencies:** U1.
+- **Files:** `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`.
+- **Approach:** Update the fake-timer test that currently expects Apply to re-enable after 5 seconds so it instead asserts `Switching...` remains visible and duplicate pushes do not occur. Keep the catch-up test that re-renders with `currentLanguageSlug` equal to the target and expects pending to clear.
+- **Patterns to follow:** Current jsdom tests in `LanguagePickerModal.test.tsx` using `act`, fake timers, `routerPushMock`, and `writePreferredLanguageSlugMock`.
+- **Test scenarios:**
+  - Changed language Apply writes the cookie before `router.push`, dispatches one navigation, and shows `Switching...`.
+  - Advancing timers beyond the previous 5 second recovery window keeps the button disabled with `Switching...`.
+  - A second Apply click after the old timeout window does not dispatch a second `router.push`.
+  - Re-rendering with the target language slug clears pending state and disables Apply because the draft matches the current route language.
+  - Existing invalid-route, subtitle-only, video, series, collection-context, and prefetch tests continue to pass unchanged.
+- **Verification:** The focused LanguagePickerModal test file passes.
+
+---
+
+## Scope Boundaries
+
+- Do not change Admin GraphQL queries, generated GraphQL outputs, Watch route parsing, or language slug identity.
+- Do not introduce a global Watch loading overlay in this slice.
+- Do not change subtitles behavior except where existing combined Apply tests require compatibility.
+
+### Deferred to Follow-Up Work
+
+- Route performance work for cold/stale language pages if production evidence shows transitions remain too slow even with truthful modal feedback.
+- A dedicated retry/cancel UI if failed navigations are observed often enough that Close is not sufficient.
+
+---
+
+## Risks & Dependencies
+
+- **Risk:** If a navigation truly fails, the user may remain in `Switching...` until they close the modal. Mitigation: keep Close enabled and preserve open-state reset so reopening starts cleanly.
+- **Risk:** Changing the guard can accidentally allow duplicate `router.push` after the old timeout. Mitigation: add an explicit post-timeout duplicate-click test.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md` documents the original pending-feedback design and the 5 second safety timeout.
+- `apps/web/src/components/watch/LanguagePickerModal.tsx` owns the current pending state and Apply button rendering.
+- `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx` already pins the in-flight guard, route builders, cookie ordering, catch-up, and prefetch contracts.

--- a/docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md
+++ b/docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md
@@ -8,7 +8,8 @@ start_date: "2026-06-13"
 duration: 2
 depends_on:
   - "feat-047"
-blocks: []
+blocks:
+  - "feat-191"
 tags:
   - "web"
   - "watch"

--- a/docs/roadmap/topic-experiences/feat-191-watch-language-switch-timeout-feedback.md
+++ b/docs/roadmap/topic-experiences/feat-191-watch-language-switch-timeout-feedback.md
@@ -1,0 +1,59 @@
+---
+id: "feat-191"
+title: "Watch Language Switch Timeout Feedback"
+owner: "urim"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-15"
+duration: 1
+depends_on:
+  - "feat-107"
+blocks: []
+tags:
+  - "web"
+  - "watch"
+  - "ux"
+---
+
+## Problem
+
+The Watch language picker now keeps the modal open and shows `Switching...` after Apply, but its 5 second navigation safety timeout can clear the pending state before the App Router transition commits. On slow language switches the button returns to `Apply`, appears idle, and then the modal closes a few seconds later when the destination route finally resolves.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/watch/LanguagePickerModal.tsx` - `pendingNavTo`, `NAVIGATING_TIMEOUT_MS`, `navigating`, `handleApply`, and the Apply button rendering.
+2. `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx` - in-flight navigation guard and safety-timeout tests.
+3. `docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md` - original pending-feedback scope and constraints.
+
+## Grep These
+
+- `pendingNavTo|NAVIGATING_TIMEOUT_MS|navigatingRef|Switching` in `apps/web/src/components/watch/LanguagePickerModal.tsx`
+- `releases the navigation guard after the safety timeout` in `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+- `clears the switching state when the current language catches up` in `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+
+## What To Build
+
+1. Keep the Apply button in an honest pending state while the route can still commit.
+   - Do not let the 5 second recovery path change visible copy from `Switching...` back to `Apply` for the same unresolved navigation.
+   - Keep duplicate-submit protection active while the unresolved navigation is still represented.
+   - Keep the modal Close action available as the user escape path.
+2. Preserve existing navigation and preference contracts.
+   - Keep `writePreferredLanguageSlug` before `router.push`.
+   - Keep route construction through `watchVideoPath` / `watchEpisodePath`.
+   - Keep language-route prefetch best-effort.
+3. Preserve the successful catch-up behavior.
+   - When the parent route prop updates to the selected language, the pending state clears naturally and the modal closes/remounts through existing page state.
+
+## Constraints
+
+- Do not change Admin GraphQL fragments, generated types, route shapes, language identity, or Watch route data fetching.
+- Do not add a global page overlay in this slice.
+- Do not remove the Close affordance from the modal.
+- Do not solve cold-route latency here; this ticket fixes misleading feedback.
+
+## Verification
+
+- Update `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx`.
+- Run the focused LanguagePickerModal Vitest file.
+- Run web typecheck.
+- Browser smoke with Helium: switch the supplied Watch route from Russian to another playable language, press Apply, and confirm the button does not flash back to `Apply` before the modal closes or the page updates.


### PR DESCRIPTION
## Summary

Slow Watch language switches no longer look like they silently failed. After a viewer presses Apply, the modal keeps the primary action disabled as `Switching...` until the destination language route commits or the viewer intentionally closes the modal, so the old idle-looking gap before the modal finally closed is gone.

The duplicate-submit guard now stays aligned with that visible pending state, and the regression test covers the old 5 second timeout window so Apply cannot re-enable for the same unresolved navigation.

## Verification

- `pnpm --filter @forge/web test -- LanguagePickerModal.test.tsx`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- Helium smoke on local Watch route: Russian page loaded, selected English, pressed Apply, confirmed `SWITCHING...` immediately and again after 6.5 seconds, then confirmed the modal closed and the English page rendered after the route settled.

## Post-Deploy Monitoring & Validation

- Open `https://watch.jesusfilm.org/watch/life-of-jesus-gospel-of-john.html/russian.html?t=14.525389` after deploy.
- Switch audio from Russian to English or another playable language and confirm Apply stays in `Switching...` until the modal closes/page language changes.
- Watch for language-picker client errors or unexpected duplicate navigation events around slow `/watch` route transitions.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
