### PR TITLE
fix(web): restore mobile watch fullscreen

### DIFF
--- a/apps/web/src/components/watch/HeroPlayerControls.tsx
+++ b/apps/web/src/components/watch/HeroPlayerControls.tsx
@@ -38,6 +38,37 @@ const CHROME_INITIAL_POINTER_LOCK_MS = 5000
 
 type ChromeVisibility = "dim" | "hidden" | "bright"
 
+type WebKitFullscreenDocument = Document & {
+  webkitFullscreenElement?: Element | null
+  webkitExitFullscreen?: () => Promise<void> | void
+}
+
+type WebKitFullscreenWrapper = HTMLDivElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void
+}
+
+type WebKitFullscreenVideo = HTMLVideoElement & {
+  webkitDisplayingFullscreen?: boolean
+  webkitEnterFullscreen?: () => void
+  webkitExitFullscreen?: () => void
+}
+
+function getWebKitFullscreenVideo(
+  player: MuxPlayerRef | null,
+): WebKitFullscreenVideo | null {
+  if (!player) return null
+
+  if (player instanceof HTMLVideoElement) {
+    return player as WebKitFullscreenVideo
+  }
+
+  const host = player as unknown as { shadowRoot?: ShadowRoot | null }
+  const video = host.shadowRoot?.querySelector("video")
+  return video instanceof HTMLVideoElement
+    ? (video as WebKitFullscreenVideo)
+    : null
+}
+
 export function HeroPlayerControls({
   player,
   playerRef,
@@ -523,12 +554,12 @@ export function HeroPlayerControls({
   const toggleFullscreen = useCallback(() => {
     const wrapper = wrapperRef.current
     if (!wrapper) return
-    const doc = document as Document & {
-      webkitFullscreenElement?: Element | null
-      webkitExitFullscreen?: () => Promise<void> | undefined
-    }
-    const wrapperEl = wrapper as HTMLDivElement & {
-      webkitRequestFullscreen?: () => Promise<void> | undefined
+    const doc = document as WebKitFullscreenDocument
+    const wrapperEl = wrapper as WebKitFullscreenWrapper
+    const videoEl = getWebKitFullscreenVideo(playerRef.current)
+    if (videoEl?.webkitDisplayingFullscreen) {
+      videoEl.webkitExitFullscreen?.()
+      return
     }
     const isFs = !!(document.fullscreenElement ?? doc.webkitFullscreenElement)
     if (isFs) {
@@ -539,15 +570,20 @@ export function HeroPlayerControls({
         })
       }
     } else {
-      const req =
-        wrapperEl.requestFullscreen?.() ?? wrapperEl.webkitRequestFullscreen?.()
-      if (req && typeof req.then === "function") {
-        req.catch((err: unknown) => {
-          console.warn("[HeroPlayer] requestFullscreen rejected", err)
-        })
+      const requestFullscreen =
+        wrapperEl.requestFullscreen ?? wrapperEl.webkitRequestFullscreen
+      if (requestFullscreen) {
+        const req = requestFullscreen.call(wrapperEl)
+        if (req && typeof req.then === "function") {
+          req.catch((err: unknown) => {
+            console.warn("[HeroPlayer] requestFullscreen rejected", err)
+          })
+        }
+        return
       }
+      videoEl?.webkitEnterFullscreen?.()
     }
-  }, [wrapperRef])
+  }, [playerRef, wrapperRef])
 
   // Compute the 0..1 scrub fraction for a clientX within the timeline rect.
   // Clamped at the edges so dragging past the bar's bounds still produces a

--- a/apps/web/src/components/watch/__tests__/HeroPlayerControls.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayerControls.test.tsx
@@ -285,6 +285,137 @@ describe("HeroPlayerControls — portal target swap on fullscreen", () => {
   })
 })
 
+describe("HeroPlayerControls — fullscreen button behavior", () => {
+  function renderFullscreenFixture(player: MuxPlayerRef = makePlayer()) {
+    const wrapperEl = document.createElement("div")
+    const overlayAnchor = document.createElement("div")
+    document.body.appendChild(wrapperEl)
+    document.body.appendChild(overlayAnchor)
+    const wrapperRef = createRef<HTMLDivElement>()
+    Object.defineProperty(wrapperRef, "current", {
+      writable: true,
+      value: wrapperEl,
+    })
+    const playerRef = createRef<MuxPlayerRef | null>()
+    Object.defineProperty(playerRef, "current", {
+      writable: true,
+      value: player,
+    })
+
+    act(() => {
+      root.render(
+        <HeroPlayerControls
+          player={playerRef.current}
+          playerRef={playerRef as React.RefObject<MuxPlayerRef | null>}
+          wrapperRef={wrapperRef as React.RefObject<HTMLDivElement | null>}
+          overlayAnchor={overlayAnchor}
+        />,
+      )
+    })
+
+    const fullscreenButton = overlayAnchor.querySelector(
+      '[data-testid="hero-chrome-fullscreen"]',
+    ) as HTMLButtonElement
+
+    return { fullscreenButton, overlayAnchor, wrapperEl }
+  }
+
+  it("requests fullscreen on the wrapper when the standard API is available", async () => {
+    const requestFullscreen = vi.fn(() => Promise.resolve())
+    const { fullscreenButton, wrapperEl } = renderFullscreenFixture()
+    Object.defineProperty(wrapperEl, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    })
+
+    await act(async () => {
+      fullscreenButton.click()
+    })
+
+    expect(requestFullscreen).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fall through to video fullscreen when a wrapper API returns void", async () => {
+    const videoEl = document.createElement("video") as HTMLVideoElement & {
+      webkitEnterFullscreen?: () => void
+    }
+    const webkitRequestFullscreen = vi.fn(() => undefined)
+    const webkitEnterFullscreen = vi.fn()
+    Object.defineProperty(videoEl, "webkitEnterFullscreen", {
+      configurable: true,
+      value: webkitEnterFullscreen,
+    })
+    const { fullscreenButton, wrapperEl } = renderFullscreenFixture(
+      videoEl as unknown as MuxPlayerRef,
+    )
+    Object.defineProperty(wrapperEl, "webkitRequestFullscreen", {
+      configurable: true,
+      value: webkitRequestFullscreen,
+    })
+
+    await act(async () => {
+      fullscreenButton.click()
+    })
+
+    expect(webkitRequestFullscreen).toHaveBeenCalledTimes(1)
+    expect(webkitEnterFullscreen).not.toHaveBeenCalled()
+  })
+
+  it("falls back to native WebKit video fullscreen when wrapper fullscreen is unavailable", async () => {
+    const videoEl = document.createElement("video") as HTMLVideoElement & {
+      webkitEnterFullscreen?: () => void
+    }
+    const webkitEnterFullscreen = vi.fn()
+    Object.defineProperty(videoEl, "webkitEnterFullscreen", {
+      configurable: true,
+      value: webkitEnterFullscreen,
+    })
+    const { fullscreenButton } = renderFullscreenFixture(
+      videoEl as unknown as MuxPlayerRef,
+    )
+
+    await act(async () => {
+      fullscreenButton.click()
+    })
+
+    expect(webkitEnterFullscreen).toHaveBeenCalledTimes(1)
+  })
+
+  it("exits native WebKit video fullscreen when the video is already fullscreen", async () => {
+    const videoEl = document.createElement("video") as HTMLVideoElement & {
+      webkitDisplayingFullscreen?: boolean
+      webkitEnterFullscreen?: () => void
+      webkitExitFullscreen?: () => void
+    }
+    const webkitEnterFullscreen = vi.fn()
+    const webkitExitFullscreen = vi.fn()
+    Object.defineProperties(videoEl, {
+      webkitDisplayingFullscreen: {
+        configurable: true,
+        value: true,
+      },
+      webkitEnterFullscreen: {
+        configurable: true,
+        value: webkitEnterFullscreen,
+      },
+      webkitExitFullscreen: {
+        configurable: true,
+        value: webkitExitFullscreen,
+      },
+    })
+    const { fullscreenButton } = renderFullscreenFixture(
+      videoEl as unknown as MuxPlayerRef,
+    )
+
+    await act(async () => {
+      fullscreenButton.click()
+    })
+
+    expect(webkitExitFullscreen).toHaveBeenCalledTimes(1)
+    expect(webkitEnterFullscreen).not.toHaveBeenCalled()
+  })
+})
+
 describe("HeroPlayerControls — chrome layout", () => {
   it("lets the custom chrome span the full portal width", () => {
     const wrapperEl = document.createElement("div")

--- a/docs/plans/2026-06-15-003-fix-watch-mobile-fullscreen-plan.md
+++ b/docs/plans/2026-06-15-003-fix-watch-mobile-fullscreen-plan.md
@@ -1,0 +1,77 @@
+---
+title: Watch Mobile Fullscreen Button Fix Plan
+type: fix
+date: 2026-06-15
+origin: docs/roadmap/platform/feat-191-watch-mobile-fullscreen.md
+---
+
+# Watch Mobile Fullscreen Button Fix Plan
+
+## Summary
+
+Fix the Watch hero player's fullscreen button on mobile by preserving the
+existing wrapper fullscreen path and adding the iPhone Safari-native video
+fullscreen fallback documented in the Mux custom chrome pattern.
+
+## Problem Frame
+
+The public route
+`/watch/life-of-jesus-gospel-of-john.html/english.html` renders the custom
+`HeroPlayerControls` chrome over a bare Mux video element. The fullscreen
+button currently tries `wrapper.requestFullscreen()` or
+`wrapper.webkitRequestFullscreen()`. That works for browsers that allow
+fullscreen on arbitrary elements, but iPhone Safari only allows native
+fullscreen through the underlying video element's `webkitEnterFullscreen()`.
+
+## Requirements
+
+- R1. The fullscreen button must still request fullscreen on the hero wrapper
+  when standard or wrapper WebKit fullscreen APIs are available.
+- R2. On iPhone-style WebKit video surfaces where wrapper fullscreen is
+  unavailable, the button must call the current video element's
+  `webkitEnterFullscreen()` method.
+- R3. If native WebKit video fullscreen is already active and the control is
+  reachable, the handler should call `webkitExitFullscreen()`.
+- R4. The existing fullscreen portal-target swap, language controls, playback
+  controls, subtitles, and data fetching must remain unchanged.
+
+## Implementation Units
+
+### U1. Add Video-Element WebKit Fullscreen Fallback
+
+- **Goal:** Update `HeroPlayerControls` fullscreen handling to route to the
+  current player video element when wrapper fullscreen APIs are unavailable.
+- **Requirements:** R1, R2, R3, R4.
+- **Dependencies:** none.
+- **Files:** `apps/web/src/components/watch/HeroPlayerControls.tsx`.
+- **Approach:** Keep `document.fullscreenElement` /
+  `document.webkitFullscreenElement` as the wrapper fullscreen state source.
+  Before requesting wrapper fullscreen, derive the current media element from
+  `playerRef.current`. If it reports `webkitDisplayingFullscreen`, call
+  `webkitExitFullscreen()`. Otherwise, prefer the wrapper request path when it
+  exists; fall back synchronously to `webkitEnterFullscreen()` on the video
+  element when wrapper request APIs are missing.
+- **Patterns to follow:**
+  `docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md`,
+  `apps/web/src/lib/use-is-fullscreen.ts`.
+- **Test scenarios:**
+  - Clicking `hero-chrome-fullscreen` calls `wrapper.requestFullscreen()` when
+    available.
+  - Clicking `hero-chrome-fullscreen` calls
+    `player.webkitEnterFullscreen()` when wrapper fullscreen APIs are absent.
+  - When `player.webkitDisplayingFullscreen` is true, clicking the button calls
+    `player.webkitExitFullscreen()`.
+- **Verification:** Focused Vitest file passes.
+
+## Scope Boundaries
+
+- Do not change Watch route resolution, Admin GraphQL, subtitles, language
+  picker behavior, or player data mapping.
+- Do not change the custom chrome layout or portal-target behavior except for
+  the fullscreen request destination.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/HeroPlayerControls.test.tsx`
+- Mobile browser smoke on
+  `/watch/life-of-jesus-gospel-of-john.html/english.html`.

--- a/docs/roadmap/platform/feat-191-watch-mobile-fullscreen.md
+++ b/docs/roadmap/platform/feat-191-watch-mobile-fullscreen.md
@@ -1,0 +1,69 @@
+---
+id: "feat-191"
+title: "Watch Mobile Fullscreen Button"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-15"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "mobile"
+  - "video"
+---
+
+## Problem
+
+On mobile Watch video pages, the custom hero player's fullscreen button does
+not enter fullscreen on iPhone Safari. The chrome currently targets the hero
+wrapper with the standard Fullscreen API and WebKit wrapper fallback, but
+iPhone Safari only exposes native fullscreen through the underlying
+`HTMLVideoElement.webkitEnterFullscreen()` method.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-15-003-fix-watch-mobile-fullscreen-plan.md` -
+   implementation plan for this bug.
+2. `apps/web/src/components/watch/HeroPlayerControls.tsx` - fullscreen button
+   handler and custom chrome portal target.
+3. `apps/web/src/components/watch/__tests__/HeroPlayerControls.test.tsx` -
+   focused jsdom coverage for fullscreen control behavior.
+4. `docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md`
+   - prior note documenting iPhone's video-element fullscreen requirement.
+
+## Grep These
+
+- `toggleFullscreen`
+- `webkitEnterFullscreen`
+- `hero-chrome-fullscreen`
+- `useIsFullscreen`
+
+## What To Build
+
+1. Keep the existing wrapper fullscreen request path for browsers that support
+   fullscreening the hero wrapper.
+2. Add a fallback that calls `webkitEnterFullscreen()` on the current player
+   video element when wrapper fullscreen APIs are unavailable.
+3. Support native WebKit video fullscreen exit if the video reports that it is
+   currently displaying fullscreen.
+4. Add regression tests for the standard wrapper path and the iPhone WebKit
+   video path.
+
+## Constraints
+
+- Do not fork the mobile controls from desktop controls.
+- Do not reintroduce Mux Player native chrome.
+- Do not change subtitles, language switching, public Watch URLs, or Admin
+  data fetching.
+- Do not hand-edit generated GraphQL or locale artifacts.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/HeroPlayerControls.test.tsx`
+- Mobile browser smoke on `/watch/life-of-jesus-gospel-of-john.html/english.html`
+  confirms the fullscreen button enters fullscreen on an iPhone-sized viewport
+  or simulator.

--- a/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
+++ b/docs/solutions/design-patterns/mux-player-custom-react-chrome-pattern-20260430.md
@@ -527,6 +527,11 @@ useEffect(() => {
 
 iPhone Safari does **not** allow fullscreen on arbitrary elements like the wrapper `div` — only the inner `<video>` element via `videoEl.webkitEnterFullscreen()`. The webkit-prefixed fallbacks above cover desktop Safari and iPad, but iPhone-specific full-fullscreen still needs to delegate to the `<video>` element directly. **Verify on real device hardware** before claiming iPhone fullscreen works.
 
+When adding that video-element fallback, branch on wrapper method availability
+rather than the wrapper method's return value. Older WebKit fullscreen methods
+can return `void`; a handler that falls through on an `undefined` return may
+call both `wrapper.webkitRequestFullscreen()` and `video.webkitEnterFullscreen()`.
+
 ### Volume slider with pointer capture + lost-capture safety
 
 ```tsx


### PR DESCRIPTION
## Summary
- add iPhone/WebKit video-element fullscreen fallback for Watch hero chrome
- keep wrapper fullscreen behavior for browsers that support it
- add regression coverage for wrapper, void-return WebKit wrapper, native video enter, and native video exit paths
- add roadmap/plan artifacts and update the Mux custom chrome solution note

## Validation
- pnpm --filter @forge/web test -- src/components/watch/__tests__/HeroPlayerControls.test.tsx
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- git diff --check
- iPhone 16 Pro simulator against local branch: Watch now -> Enter fullscreen shows Exit fullscreen
