### PR TITLE
fix(manager): accept Shorts workflow steps in jobs

### DIFF
--- a/apps/manager/src/app/dashboard/jobs/page.test.ts
+++ b/apps/manager/src/app/dashboard/jobs/page.test.ts
@@ -118,4 +118,40 @@ describe("dashboard jobs page", () => {
       languageLabelsById: { 529: "English" },
     })
   })
+
+  it("passes Shorts jobs from the admin gateway to the jobs table", async () => {
+    const shortsJob = makeJobRecord({
+      id: "job-shorts",
+      languages: [],
+      options: {
+        shorts: {
+          assetId: "asset-1-short-1234abcd",
+          sourceMuxAssetId: "asset-1",
+          sourcePlaybackId: "playback-1",
+          clip: { startSec: 10, endSec: 40 },
+          language: { bcp47: "en", whisper: "en" },
+        },
+      },
+      currentStep: "shorts_prepare",
+      steps: [{ name: "shorts_prepare", status: "running", retries: 0 }],
+    })
+
+    getCmsGatewayMock.mockReturnValue({
+      mode: "admin",
+      getLanguageGeo: vi.fn(async () => ({
+        continents: [],
+        countries: [],
+        languages: [],
+      })),
+    })
+    listJobsMock.mockResolvedValue([shortsJob])
+
+    const element = await JobsPage()
+    const table = element.props.children
+
+    expect(table.props).toMatchObject({
+      initialJobs: [shortsJob],
+      languageLabelsById: {},
+    })
+  })
 })

--- a/apps/manager/src/backend/admin-client.test.ts
+++ b/apps/manager/src/backend/admin-client.test.ts
@@ -3,6 +3,24 @@ import { AdminGraphqlClient } from "./admin-client"
 
 const fetchMock = vi.fn()
 
+function managerJobPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "admin-job-test",
+    muxAssetId: "asset-test",
+    muxPlaybackId: "playback-test",
+    languages: [],
+    options: {},
+    status: "completed",
+    retries: 0,
+    createdAt: "2026-05-06T00:00:00.000Z",
+    updatedAt: "2026-05-06T00:00:00.000Z",
+    artifacts: {},
+    steps: [],
+    errors: [],
+    ...overrides,
+  }
+}
+
 describe("AdminGraphqlClient", () => {
   beforeEach(() => {
     fetchMock.mockReset()
@@ -293,25 +311,68 @@ describe("AdminGraphqlClient", () => {
     })
   })
 
-  it("rejects invalid Manager job payloads at the Admin boundary", async () => {
+  it("accepts Shorts Studio workflow steps in Manager job lists", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
           data: {
-            managerJob: {
-              id: "admin-job-bad",
-              muxAssetId: "asset-bad",
-              muxPlaybackId: "playback-bad",
-              languages: [],
-              options: {},
-              status: "queued",
-              retries: 0,
-              createdAt: "2026-05-06T00:00:00.000Z",
-              updatedAt: "2026-05-06T00:00:00.000Z",
-              artifacts: {},
-              steps: [],
-              errors: [],
-            },
+            managerJobs: [
+              managerJobPayload({
+                id: "shorts-prepare-job",
+                status: "running",
+                currentStep: "shorts_prepare",
+                options: { shorts: { assetId: "asset-short" } },
+                steps: [
+                  {
+                    name: "shorts_prepare",
+                    status: "running",
+                    retries: 0,
+                    startedAt: "2026-06-12T00:00:00.000Z",
+                  },
+                ],
+              }),
+              managerJobPayload({
+                id: "shorts-render-job",
+                status: "running",
+                currentStep: "shorts_render",
+                options: { shorts: { assetId: "asset-short" } },
+                steps: [
+                  {
+                    name: "shorts_prepare",
+                    status: "completed",
+                    retries: 0,
+                  },
+                  {
+                    name: "shorts_render",
+                    status: "running",
+                    retries: 0,
+                  },
+                  {
+                    name: "shorts_mux_output",
+                    status: "pending",
+                    retries: 0,
+                  },
+                ],
+              }),
+              managerJobPayload({
+                id: "shorts-mux-job",
+                status: "running",
+                currentStep: "shorts_mux_output",
+                options: { shorts: { assetId: "asset-short" } },
+                steps: [
+                  {
+                    name: "shorts_render",
+                    status: "completed",
+                    retries: 0,
+                  },
+                  {
+                    name: "shorts_mux_output",
+                    status: "running",
+                    retries: 0,
+                  },
+                ],
+              }),
+            ],
           },
         }),
       ),
@@ -322,6 +383,198 @@ describe("AdminGraphqlClient", () => {
       fetchImpl: fetchMock,
     })
 
+    await expect(client.listJobs()).resolves.toEqual([
+      expect.objectContaining({
+        id: "shorts-prepare-job",
+        currentStep: "shorts_prepare",
+        steps: [expect.objectContaining({ name: "shorts_prepare" })],
+      }),
+      expect.objectContaining({
+        id: "shorts-render-job",
+        currentStep: "shorts_render",
+        steps: expect.arrayContaining([
+          expect.objectContaining({ name: "shorts_render" }),
+          expect.objectContaining({ name: "shorts_mux_output" }),
+        ]),
+      }),
+      expect.objectContaining({
+        id: "shorts-mux-job",
+        currentStep: "shorts_mux_output",
+        steps: expect.arrayContaining([
+          expect.objectContaining({ name: "shorts_mux_output" }),
+        ]),
+      }),
+    ])
+  })
+
+  it("rejects unknown Manager job current steps in list and detail payloads", async () => {
+    const invalidCurrentStepPayload = managerJobPayload({
+      currentStep: "future_unknown_step",
+      steps: [
+        {
+          name: "shorts_prepare",
+          status: "running",
+          retries: 0,
+        },
+      ],
+    })
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJobs: [invalidCurrentStepPayload],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJob: invalidCurrentStepPayload,
+            },
+          }),
+        ),
+      )
+
+    const client = new AdminGraphqlClient({
+      graphqlUrl: "https://admin.example/api/graphql",
+      fetchImpl: fetchMock,
+    })
+
+    await expect(client.listJobs()).rejects.toThrow(
+      "invalid Manager job list payload",
+    )
+    await expect(client.getJob("admin-job-test")).rejects.toThrow(
+      "invalid Manager job payload",
+    )
+  })
+
+  it("rejects unknown Manager job step entries in list and detail payloads", async () => {
+    const invalidStepNamePayload = managerJobPayload({
+      currentStep: "shorts_prepare",
+      steps: [
+        {
+          name: "future_unknown_step",
+          status: "running",
+          retries: 0,
+        },
+      ],
+    })
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJobs: [invalidStepNamePayload],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJob: invalidStepNamePayload,
+            },
+          }),
+        ),
+      )
+
+    const client = new AdminGraphqlClient({
+      graphqlUrl: "https://admin.example/api/graphql",
+      fetchImpl: fetchMock,
+    })
+
+    await expect(client.listJobs()).rejects.toThrow(
+      "invalid Manager job list payload",
+    )
+    await expect(client.getJob("admin-job-test")).rejects.toThrow(
+      "invalid Manager job payload",
+    )
+  })
+
+  it("rejects invalid Manager job step statuses in list and detail payloads", async () => {
+    const invalidStepStatusPayload = managerJobPayload({
+      steps: [
+        {
+          name: "shorts_prepare",
+          status: "blocked",
+          retries: 0,
+        },
+      ],
+    })
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJobs: [invalidStepStatusPayload],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJob: invalidStepStatusPayload,
+            },
+          }),
+        ),
+      )
+
+    const client = new AdminGraphqlClient({
+      graphqlUrl: "https://admin.example/api/graphql",
+      fetchImpl: fetchMock,
+    })
+
+    await expect(client.listJobs()).rejects.toThrow(
+      "invalid Manager job list payload",
+    )
+    await expect(client.getJob("admin-job-test")).rejects.toThrow(
+      "invalid Manager job payload",
+    )
+  })
+
+  it("rejects invalid Manager job statuses in list and detail payloads", async () => {
+    const invalidJobStatusPayload = managerJobPayload({
+      id: "admin-job-bad",
+      status: "queued",
+    })
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJobs: [invalidJobStatusPayload],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              managerJob: invalidJobStatusPayload,
+            },
+          }),
+        ),
+      )
+
+    const client = new AdminGraphqlClient({
+      graphqlUrl: "https://admin.example/api/graphql",
+      fetchImpl: fetchMock,
+    })
+
+    await expect(client.listJobs()).rejects.toThrow(
+      "invalid Manager job list payload",
+    )
     await expect(client.getJob("admin-job-bad")).rejects.toThrow(
       "invalid Manager job payload",
     )

--- a/apps/manager/src/backend/admin-client.ts
+++ b/apps/manager/src/backend/admin-client.ts
@@ -3,12 +3,13 @@ import type {
   MockLanguageGeo,
   MockVideoCoverage,
 } from "@/cms/mock-seed"
-import type {
-  JobRecord,
-  JobStatus,
-  JobStepDetails,
-  StepStatus,
-  WorkflowStepName,
+import {
+  WORKFLOW_STEP_NAMES,
+  type JobRecord,
+  type JobStatus,
+  type JobStepDetails,
+  type StepStatus,
+  type WorkflowStepName,
 } from "@/types/job"
 import { z } from "zod"
 
@@ -205,30 +206,7 @@ const stepStatusSchema = z.enum([
   "failed",
   "skipped",
 ])
-const workflowStepSchema = z.enum([
-  "download_video",
-  "transcription",
-  "structured_transcript",
-  "subtitle_post_process",
-  "chapters",
-  "metadata",
-  "embeddings",
-  "translation",
-  "audio_cleanup",
-  "voiceover",
-  "artifact_upload",
-  "mux_upload",
-  "theology_validation_bible_quotes",
-  "seo_improvements",
-  "cms_notify",
-  "smart_crop_fingerprint",
-  "smart_crop_plan",
-  "smart_crop_align",
-  "smart_crop_preview_render",
-  "smart_crop_qa",
-  "smart_crop_render",
-  "smart_crop_mux_output",
-])
+const workflowStepSchema = z.enum(WORKFLOW_STEP_NAMES)
 
 const optionalStringFromNullable = z
   .string()

--- a/apps/manager/src/features/jobs/jobs-table-presenter.test.ts
+++ b/apps/manager/src/features/jobs/jobs-table-presenter.test.ts
@@ -94,6 +94,29 @@ describe("displayed job status", () => {
     expect(getDisplayedJobStatus(job)).toBe("failed")
     expect(getProgressSummary(job)).toBe("Failed at Transcription")
   })
+
+  it("formats Shorts Studio progress from the current workflow step", () => {
+    const job = buildJobRecord({
+      status: "running",
+      currentStep: "shorts_render",
+      options: {
+        shorts: {
+          assetId: "mux-1-short-1234abcd",
+          sourceMuxAssetId: "mux-1",
+          sourcePlaybackId: "playback-1",
+          clip: { startSec: 10, endSec: 40 },
+          language: { bcp47: "en", whisper: "en" },
+        },
+      },
+      steps: [
+        { name: "shorts_prepare", status: "completed", retries: 0 },
+        { name: "shorts_render", status: "running", retries: 0 },
+        { name: "shorts_mux_output", status: "pending", retries: 0 },
+      ],
+    })
+
+    expect(getProgressSummary(job)).toBe("In progress at Shorts Render")
+  })
 })
 
 describe("getStepDotSymbol", () => {

--- a/apps/manager/src/types/job.ts
+++ b/apps/manager/src/types/job.ts
@@ -12,32 +12,35 @@ export type StepStatus =
   | "failed"
   | "skipped"
 
-export type WorkflowStepName =
-  | "download_video"
-  | "transcription"
-  | "structured_transcript"
-  | "subtitle_post_process"
-  | "chapters"
-  | "metadata"
-  | "embeddings"
-  | "translation"
-  | "audio_cleanup"
-  | "voiceover"
-  | "artifact_upload"
-  | "mux_upload"
-  | "theology_validation_bible_quotes"
-  | "seo_improvements"
-  | "cms_notify"
-  | "smart_crop_fingerprint"
-  | "smart_crop_plan"
-  | "smart_crop_align"
-  | "smart_crop_preview_render"
-  | "smart_crop_qa"
-  | "smart_crop_render"
-  | "smart_crop_mux_output"
-  | "shorts_prepare"
-  | "shorts_render"
-  | "shorts_mux_output"
+export const WORKFLOW_STEP_NAMES = [
+  "download_video",
+  "transcription",
+  "structured_transcript",
+  "subtitle_post_process",
+  "chapters",
+  "metadata",
+  "embeddings",
+  "translation",
+  "audio_cleanup",
+  "voiceover",
+  "artifact_upload",
+  "mux_upload",
+  "theology_validation_bible_quotes",
+  "seo_improvements",
+  "cms_notify",
+  "smart_crop_fingerprint",
+  "smart_crop_plan",
+  "smart_crop_align",
+  "smart_crop_preview_render",
+  "smart_crop_qa",
+  "smart_crop_render",
+  "smart_crop_mux_output",
+  "shorts_prepare",
+  "shorts_render",
+  "shorts_mux_output",
+] as const
+
+export type WorkflowStepName = (typeof WORKFLOW_STEP_NAMES)[number]
 
 export type SmartCropKind = "canonical" | "localized"
 

--- a/docs/plans/2026-06-15-003-fix-manager-jobs-shorts-steps-plan.md
+++ b/docs/plans/2026-06-15-003-fix-manager-jobs-shorts-steps-plan.md
@@ -1,0 +1,119 @@
+---
+title: "fix: Keep Manager jobs parsing aligned with Shorts workflow steps"
+type: fix
+status: complete
+date: 2026-06-15
+origin: docs/brainstorms/2026-06-11-manager-shorts-studio-requirements.md
+---
+
+# fix: Keep Manager jobs parsing aligned with Shorts workflow steps
+
+## Summary
+
+The Manager jobs page can fail during the Server Components render when the latest Admin-backed jobs include Shorts Studio records. Shorts writes `shorts_prepare`, `shorts_render`, and `shorts_mux_output` into persisted job state, but the Admin GraphQL adapter validates job step names with a duplicated enum that omits those values.
+
+This plan makes the Manager runtime parser derive from the same step-name source as `WorkflowStepName`, adds regression coverage for Shorts jobs in the list payload, and keeps truly invalid job payloads rejected at the Admin boundary.
+
+---
+
+## Problem Frame
+
+Shorts Studio meets the origin requirement that shorts run as durable Manager jobs with visible progress and retryable failures. The current crash comes from a local contract split: `apps/manager/src/types/job.ts` includes Shorts steps, `apps/manager/src/lib/workflow-steps.ts` persists them, and Shorts routes/workflows write them, while `apps/manager/src/backend/admin-client.ts` rejects them on read.
+
+The user-facing symptom is intermittent because `/dashboard/jobs` server-renders only the latest 50 jobs. The page works until a Shorts job enters that window, then the server component throws before `LiveJobsTable` can render.
+
+---
+
+## Requirements
+
+Requirement IDs below are plan-local. Origin requirements are referenced with
+the `origin R<N>` form when needed.
+
+**Runtime contract**
+
+- R1. Manager must parse every currently declared `WorkflowStepName` value from Admin-backed job records.
+- R2. The jobs list and job detail readers must still reject invalid job status, invalid step status, and unknown step-name values at the Admin boundary.
+- R3. Adding a future workflow step should require one canonical step-name update, not a second hidden parser update.
+
+**Operator behavior**
+
+- R4. `/dashboard/jobs` must render when the latest job window contains Shorts prepare or render jobs.
+- R5. Existing Shorts jobs must not require a data backfill.
+
+---
+
+## Key Technical Decisions
+
+- **Derive runtime validation from a tuple:** Export a `WORKFLOW_STEP_NAMES` tuple from `apps/manager/src/types/job.ts` and derive `WorkflowStepName` from it. This keeps TypeScript and Zod on one source for the step-name literal set.
+- **Keep strict status validation:** Job status and step status remain closed runtime schemas because Admin GraphQL already exposes status enums and invalid statuses are real data-contract failures.
+- **Do not change Admin schema:** Admin stores step names as strings by design, and the immediate bug is Manager-side parser drift. No generated GraphQL artifacts or database migration are needed.
+- **Test list parsing, not only detail parsing:** The reported page calls `listJobs({ limit: 50 })`; coverage must prove a list payload containing Shorts steps parses successfully.
+
+---
+
+## Implementation Units
+
+### U1. Centralize Manager workflow step names
+
+- **Goal:** Replace the duplicated hardcoded parser step list with a canonical exported literal tuple.
+- **Requirements:** R1, R3
+- **Dependencies:** None
+- **Files:** `apps/manager/src/types/job.ts`, `apps/manager/src/backend/admin-client.ts`
+- **Approach:** Add `WORKFLOW_STEP_NAMES` in `types/job.ts`, derive `WorkflowStepName` from `typeof WORKFLOW_STEP_NAMES[number]`, and build `workflowStepSchema` in `admin-client.ts` from the tuple. Keep the runtime schema typed as `WorkflowStepName` so downstream job records preserve the current type contract.
+- **Patterns to follow:** `apps/manager/src/lib/workflow-steps.ts` already treats step inventories as literal arrays; keep the canonical list near the type that all surfaces import.
+- **Test scenarios:** Covered by U2.
+- **Verification:** Manager typecheck accepts all existing step inventories and workflow calls without widening step names to plain `string`.
+
+### U2. Prove Shorts jobs parse from Admin list payloads
+
+- **Goal:** Add regression coverage for the exact page-load failure mode.
+- **Requirements:** R1, R2, R4, R5
+- **Dependencies:** U1
+- **Files:** `apps/manager/src/backend/admin-client.test.ts`
+- **Approach:** Extend `AdminGraphqlClient` list-job tests with Admin payloads containing `shorts_prepare`, `shorts_render`, and `shorts_mux_output` in `steps` and `currentStep`. Assert `listJobs` resolves and preserves those names. Keep or add negative assertions that unknown step names, invalid step statuses, and invalid job statuses still throw.
+- **Execution note:** Add the failing Shorts payload test before changing the parser so the regression is visible.
+- **Patterns to follow:** Existing `listJobs` pagination test and invalid `managerJob` payload test in the same file.
+- **Test scenarios:**
+  - Happy path: `managerJobs` returns a prepare job with `currentStep: "shorts_prepare"` and a matching step; `listJobs` resolves with that step.
+  - Happy path: `managerJobs` returns a render job with `currentStep: "shorts_render"` plus `shorts_render` and `shorts_mux_output` steps; `listJobs` resolves with both.
+  - Happy path: `managerJobs` returns a render job with `currentStep: "shorts_mux_output"` after render completion; `listJobs` resolves with that terminal Mux-output step.
+  - Failure path: a payload with an unknown step name still rejects with `invalid Manager job list payload`.
+  - Failure path: a payload with a valid step name but invalid step status still rejects for both list and detail reads.
+  - Failure path: a payload with an invalid job status still rejects.
+- **Verification:** Targeted backend tests fail before U1 and pass after U1.
+
+### U3. Validate the page data path
+
+- **Goal:** Ensure the server-render data loader can receive Shorts jobs without tripping the page boundary.
+- **Requirements:** R4, R5
+- **Dependencies:** U1, U2
+- **Files:** `apps/manager/src/app/dashboard/jobs/page.test.ts`, `apps/manager/src/features/jobs/jobs-table-presenter.test.ts`
+- **Approach:** Keep `page.test.ts` scoped to the server component data-loading and prop-handoff boundary because it mocks `LiveJobsTable`. Add presenter-level coverage for Shorts `currentStep` values so the visible jobs-table status/progress formatting accepts the same step names that the parser accepts.
+- **Patterns to follow:** Existing jobs page tests should continue to mock the state and gateway boundaries instead of requiring a live Admin GraphQL endpoint.
+- **Test scenarios:**
+  - Happy path: a Shorts job from `listJobs` is passed through the jobs page with language labels loaded.
+  - Happy path: presenter formatting for `currentStep: "shorts_render"` produces a stable in-progress label instead of throwing or falling back to an unrelated step.
+  - Edge case: a Shorts job with an empty language list still renders, matching current Shorts job creation behavior.
+- **Verification:** Page test proves the server component returns a renderable tree for a Shorts job payload.
+
+---
+
+## Scope Boundaries
+
+- Do not make unknown future step names render silently; unknown steps remain data-contract failures until intentionally added.
+- Do not change Shorts workflow phase semantics or the `ShortsPhase` metadata artifact.
+- Do not alter Admin GraphQL schema, Prisma models, or generated `packages/admin-graphql` artifacts.
+- Do not address unrelated UI alignment changes already present in the worktree.
+
+### Deferred to Follow-Up Work
+
+- If operators need the jobs page to degrade around corrupt historical rows, plan a separate resilience pass that reports or skips invalid records without hiding data-quality issues.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/media-generation/feat-178-manager-shorts-studio.md` records Shorts Studio as active work and documents `shorts_` step and artifact contracts.
+- `docs/brainstorms/2026-06-11-manager-shorts-studio-requirements.md` requires Shorts to use durable Manager jobs with visible progress and retry.
+- `docs/plans/2026-06-11-002-feat-manager-shorts-studio-plan.md` establishes the Shorts job lifecycle, including `shorts_prepare`, `shorts_render`, and `shorts_mux_output`.
+- `docs/solutions/integration-issues/manager-cleaned-audio-review-links-20260412.md` documents a prior instance of persisted Manager step-name drift causing job contract failures.


### PR DESCRIPTION
## Summary

The Manager Jobs page no longer falls over when recent Admin-backed jobs include Shorts Studio progress. Shorts step names now share one literal source with the TypeScript job type, so the Admin GraphQL parser accepts `shorts_prepare`, `shorts_render`, and `shorts_mux_output` without weakening validation for corrupt payloads.

The regression coverage now proves the exact list-page path, the presenter progress label for Shorts render jobs, and the strict rejection matrix for invalid job status, current step, step entry name, and step status across list/detail readers.

## Validation

- `pnpm --filter @forge/manager test -- --run src/backend/admin-client.test.ts src/app/dashboard/jobs/page.test.ts src/features/jobs/jobs-table-presenter.test.ts`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager test` (128 files, 1029 tests)
- Browser smoke: local mock-mode `/dashboard/jobs` returned 200, rendered the Jobs heading/table/job links, and `/api/jobs?view=count` returned 200 via `agent-browser`.

## Notes

- Unknown future workflow steps still fail closed by design; adding a new persisted step now requires updating `WORKFLOW_STEP_NAMES` once.
- Local `next build` compiled and completed TypeScript before page-data collection stopped on missing required local env in the first run; a dummy-env retry was stopped after it sat silent, so build is not listed as a passing validation gate.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
