### PR TITLE
feat(tv): column-preserving home rail D-pad focus navigation

### DIFF
--- a/apps/tv/app/index.tsx
+++ b/apps/tv/app/index.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   View,
   type LayoutChangeEvent,
+  type View as ViewType,
 } from "react-native"
 
 import { HomeBackdrop } from "../src/components/home/HomeBackdrop"
@@ -22,7 +23,6 @@ import { HomeBillboard } from "../src/components/home/HomeBillboard"
 import { resolveHomeCardPath } from "../src/components/home/homeCardRouting"
 import { HomeRail } from "../src/components/home/HomeRail"
 import {
-  areHeroActionsGhosted,
   isTopBarHidden,
   resolveBrowseState,
   resolveRowScrollTarget,
@@ -54,7 +54,7 @@ import {
  * sections web /watch and mobile home use — from useWatchHome's lean bulk
  * fetch (R8). A full-screen ambient backdrop (HomeBackdrop) paints the
  * focused card's artwork behind everything; the billboard hero
- * (HomeBillboard) carries that card's copy plus Play / More Info actions;
+ * (HomeBillboard) carries that card's copy (non-interactive);
  * the top bar (HomeTopBar) holds the brandmark, Search/Home tabs, and clock.
  * Rails drive the showcase via the debounced reducer (R10/R11), and ALSO
  * drive the screen's browse state: row 0 = "browse" (light scrim), rows >= 1
@@ -109,11 +109,11 @@ export default function HomeScreen() {
   // ── Showcase state ──
   // First model seeds the showcase (modelResolved); later models — background
   // refetches — re-reconcile (modelRefreshed keeps the current pick when its
-  // id survives). Only CARDS dispatch focus events: the top bar tabs, hero
-  // actions, and Retry never do, so the showcase retains across non-card
-  // focus automatically (AE4) and across stack push/pop (state lives up
-  // here, not in the rails). The committed card now drives BOTH the
-  // billboard copy and the full-screen backdrop.
+  // id survives). Only CARDS dispatch focus events: the top bar tabs and
+  // Retry never do, so the showcase retains across non-card focus
+  // automatically (AE4) and across stack push/pop (state lives up here, not
+  // in the rails). The committed card now drives BOTH the billboard copy and
+  // the full-screen backdrop.
   const [showcase, dispatchShowcase] = useReducer(
     showcaseReducer,
     INITIAL_SHOWCASE_STATE,
@@ -154,13 +154,12 @@ export default function HomeScreen() {
 
   // ── Browse state + row-anchored scrolling ──
   // Focused row index → "top" | "browse" | "deep" (homeScrollState.ts) drives
-  // the backdrop's deep scrim, the top bar's hide, and the hero actions'
-  // ghosting. Scrolling is row-anchored, not free: each shelf reports its
-  // content y via onLayout; focusing a card in row r >= 1 pins that shelf
-  // near the viewport top, while row 0 / hero actions / tabs pin the feed to
-  // 0 (the old featured-rail scroll-to-top behavior folds in here). The
-  // scroll is immediate (not debounced) — it must track the traversal, not
-  // the settled card.
+  // the backdrop's deep scrim and the top bar's hide. Scrolling is
+  // row-anchored, not free: each shelf reports its content y via onLayout;
+  // focusing a card in row r >= 1 pins that shelf near the viewport top, while
+  // row 0 / the top bar tabs pin the feed to 0 (the old featured-rail
+  // scroll-to-top behavior folds in here). The scroll is immediate (not
+  // debounced) — it must track the traversal, not the settled card.
   const [browseState, setBrowseState] = useState<HomeBrowseState>("top")
   const scrollRef = useRef<ScrollView | null>(null)
   const rowYsRef = useRef<number[]>([])
@@ -201,7 +200,7 @@ export default function HomeScreen() {
     [scrollToRow],
   )
 
-  // Tab bar / hero actions focus: pin to the top state.
+  // Top bar tab focus: pin to the top state.
   const handleChromeFocus = useCallback(() => {
     setBrowseState(resolveBrowseState(null))
     scrollRef.current?.scrollTo({ y: 0, animated: true })
@@ -241,7 +240,6 @@ export default function HomeScreen() {
 
   // Shape-based routing (R13): series-shaped → /series, leaf → /watch, both
   // seeded for instant first paint. Null path (no slug) is a no-op press.
-  // The billboard's Play and More Info actions route the same way.
   const handleCardPress = useCallback(
     (card: WatchHomeCard) => {
       const path = resolveHomeCardPath(card)
@@ -254,6 +252,14 @@ export default function HomeScreen() {
     router.push("/search")
   }, [router])
 
+  // The Search tab's native node, lifted from HomeTopBar so the featured rail
+  // can target it via nextFocusUp: the tab bar is centered, so the rail's
+  // left/right-most cards have no focusable directly above them and D-pad up
+  // dead-ends there (the focus engine finds nothing in the up projection).
+  // State (not a ref) so the rail re-renders once the node mounts — the same
+  // ref-as-state contract MissionSection uses for its QR destination.
+  const [searchTabNode, setSearchTabNode] = useState<ViewType | null>(null)
+
   // The top bar (brandmark · Search/Home tabs · clock). Rendered in every
   // state — including loading, error and empty — so Search stays reachable
   // while the home model resolves; in the content state it is the sticky
@@ -265,6 +271,7 @@ export default function HomeScreen() {
       searchTabPreferredFocus={searchTabFocusKey > 0}
       onSearchPress={handleSearchPress}
       onChromeFocus={handleChromeFocus}
+      onSearchTabNode={setSearchTabNode}
     />
   )
 
@@ -329,10 +336,10 @@ export default function HomeScreen() {
   // ── Content ──
   // The non-focusable backdrop sits absolutely behind ONE full-screen
   // ScrollView whose sticky first child is the top bar: the tvOS focus
-  // engine cannot traverse a parent-View boundary, so tab↔hero↔rail D-pad
-  // traversal relies on the top bar, billboard actions, and rails being
-  // siblings in the same scroll container — the structure the previous home
-  // shipped with (R14/AE6). If traversal ever proves unreliable, the
+  // engine cannot traverse a parent-View boundary, so tab↔rail D-pad
+  // traversal relies on the top bar and rails being siblings in the same
+  // scroll container — the structure the previous home shipped with
+  // (R14/AE6). If traversal ever proves unreliable, the
   // documented fallback is TVFocusGuideView destinations in both directions
   // (tv-focus-driven-hero-patterns-20260420.md §3).
   return (
@@ -354,12 +361,7 @@ export default function HomeScreen() {
       >
         <View>{topBar}</View>
 
-        <HomeBillboard
-          card={showcase.current}
-          actionsGhosted={areHeroActionsGhosted(browseState)}
-          onChromeFocus={handleChromeFocus}
-          onCardPress={handleCardPress}
-        />
+        <HomeBillboard card={showcase.current} />
 
         <View onLayout={rowLayoutHandlers[0]}>
           <HomeRail
@@ -370,6 +372,9 @@ export default function HomeScreen() {
             onCardFocus={handleCardFocus}
             onRowFocus={handleRowFocus}
             onCardPress={handleCardPress}
+            // Only the featured rail sits under the top bar; section rails
+            // (rows >= 1) reach the full-width rail above them natively.
+            upFocusTarget={searchTabNode}
           />
         </View>
 

--- a/apps/tv/src/components/home/HomeBillboard.tsx
+++ b/apps/tv/src/components/home/HomeBillboard.tsx
@@ -1,32 +1,21 @@
-// The Home billboard hero — copy block + actions for whichever card the
-// showcase reducer last committed, laid over the full-screen HomeBackdrop.
-// Replaces ShowcaseCanvas: same non-focusable copy, but the actions row
-// (Play / More Info) is focusable chrome that routes to the focused card.
+// The Home billboard hero — a NON-INTERACTIVE copy block (eyebrow + title +
+// description + meta) for whichever card the showcase reducer last committed,
+// laid over the full-screen HomeBackdrop. Purely presentational: focus on the
+// home screen lives entirely on the top bar tabs and the rails — the rail owns
+// selection (press Select on a card to open it), so the hero carries no
+// focusable chrome (tv-focus-driven-hero-patterns-20260420.md: non-interactive
+// hero / rail owns focus).
 //
 // Layout: the hero region is the design's 700/1080 of the screen minus the
 // in-flow top bar, with the billboard bottom-anchored via flexbox
-// (justifyContent flex-end — never position:absolute on a subtree containing
-// focusables). The description is clamped to EXACTLY two lines with a fixed
-// height so the layout never jumps as cards swap.
-//
-// While focus is in the rails the actions GHOST (opacity 0, ~300ms) but stay
-// mounted and focusable, so D-pad up from row 0 lands on Play and fades the
-// row back in.
+// (justifyContent flex-end). The description is clamped to EXACTLY two lines
+// with a fixed height so the layout never jumps as cards swap.
 
-import { memo, useEffect, useMemo, useRef } from "react"
-import Ionicons from "@expo/vector-icons/Ionicons"
-import {
-  Animated,
-  Dimensions,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native"
+import { memo } from "react"
+import { Dimensions, StyleSheet, Text, View } from "react-native"
 
 import { scale } from "../../lib/scale"
 import type { WatchHomeCard } from "../../lib/watchHome/model"
-import { focusTransform, useFocusAnimation } from "../watch/useFocusAnimation"
 import { WATCH_THEME } from "../watch/watchDetailTheme"
 import { TOP_BAR_HEIGHT } from "./HomeTopBar"
 
@@ -42,203 +31,42 @@ const HERO_REGION_HEIGHT =
   Math.round(Dimensions.get("window").height * HERO_DESIGN_RATIO) -
   TOP_BAR_HEIGHT
 
-const ACTIONS_GHOST_MS = 300
-
 /** Description line metrics: fontSize 25 × 1.45 line-height, two lines. */
 const DESCRIPTION_LINE_HEIGHT = Math.round(scale(36))
 
 type HomeBillboardProps = {
   /** Null only for the first frame before the showcase seeds. */
   card: WatchHomeCard | null
-  /** True while focus is in the rails — actions fade out but stay focusable. */
-  actionsGhosted: boolean
-  /** Either action gaining focus pins the screen to its "top" state. */
-  onChromeFocus: () => void
-  /** Both actions route via the existing resolveHomeCardPath at the caller. */
-  onCardPress: (card: WatchHomeCard) => void
 }
 
 export const HomeBillboard = memo(function HomeBillboard({
   card,
-  actionsGhosted,
-  onChromeFocus,
-  onCardPress,
 }: HomeBillboardProps) {
-  const ghostProgress = useRef(
-    new Animated.Value(actionsGhosted ? 1 : 0),
-  ).current
-  useEffect(() => {
-    const animation = Animated.timing(ghostProgress, {
-      toValue: actionsGhosted ? 1 : 0,
-      duration: ACTIONS_GHOST_MS,
-      useNativeDriver: true,
-    })
-    animation.start()
-    return () => animation.stop()
-  }, [actionsGhosted, ghostProgress])
-  const ghostStyle = useMemo(
-    () => ({
-      opacity: ghostProgress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [1, 0],
-      }),
-    }),
-    [ghostProgress],
-  )
-
   return (
     <View style={styles.hero}>
       {card != null ? (
-        <View style={styles.billboard}>
-          <View pointerEvents="none" collapsable={false}>
-            <Text style={styles.eyebrow} numberOfLines={1}>
-              {card.label}
-            </Text>
-            <Text style={styles.title} numberOfLines={2}>
-              {card.title}
-            </Text>
-            {/* Fixed two-line block (empty when no description) so the
-                actions row never jumps as the showcase swaps cards. */}
-            <Text style={styles.description} numberOfLines={2}>
-              {card.description ?? ""}
-            </Text>
-            <Text style={styles.meta} numberOfLines={1}>
-              {card.metaLabel ?? ""}
-            </Text>
-          </View>
-
-          <Animated.View style={[styles.actions, ghostStyle]}>
-            <PlayButton
-              card={card}
-              onPress={onCardPress}
-              onChromeFocus={onChromeFocus}
-            />
-            <MoreInfoButton
-              card={card}
-              onPress={onCardPress}
-              onChromeFocus={onChromeFocus}
-            />
-          </Animated.View>
+        // The whole hero is non-focusable: collapsable={false} keeps it a
+        // discrete native view above the backdrop's media on Android TV.
+        <View style={styles.billboard} pointerEvents="none" collapsable={false}>
+          <Text style={styles.eyebrow} numberOfLines={1}>
+            {card.label}
+          </Text>
+          <Text style={styles.title} numberOfLines={2}>
+            {card.title}
+          </Text>
+          {/* Fixed two-line block (empty when no description) so the layout
+              never jumps as the showcase swaps cards. */}
+          <Text style={styles.description} numberOfLines={2}>
+            {card.description ?? ""}
+          </Text>
+          <Text style={styles.meta} numberOfLines={1}>
+            {card.metaLabel ?? ""}
+          </Text>
         </View>
       ) : null}
     </View>
   )
 })
-
-// ── Actions ─────────────────────────────────────────────────────────
-//
-// Focus eases in via useFocusAnimation's 0→1 `progress`: lift -4 + magnify
-// 1.06. Play gains a white ring (constant-width transparent border →
-// animated borderColor, no layout shift) over a deepened accent shadow; More
-// Info inverts glass → white fill with dark ink (tvOS HIG, same scheme as
-// the watch screen's SecondaryPill).
-
-const PLAY_ICON_SIZE = Math.round(scale(30))
-
-type ActionButtonProps = {
-  card: WatchHomeCard
-  onPress: (card: WatchHomeCard) => void
-  onChromeFocus: () => void
-}
-
-function PlayButton({ card, onPress, onChromeFocus }: ActionButtonProps) {
-  const { setFocused, progress } = useFocusAnimation()
-  // Memoized: progress is a stable ref, so the interpolations are built once
-  // rather than on every focus/blur re-render.
-  const animatedStyle = useMemo(
-    () => ({
-      borderColor: progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: ["rgba(255,255,255,0)", "rgba(255,255,255,0.85)"],
-      }),
-      shadowOpacity: progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0.45, 0.75],
-      }),
-      transform: focusTransform(progress, { lift: scale(4), magnify: 1.06 }),
-    }),
-    [progress],
-  )
-  return (
-    <Pressable
-      onPress={() => onPress(card)}
-      onFocus={() => {
-        setFocused(true)
-        onChromeFocus()
-      }}
-      onBlur={() => setFocused(false)}
-      testID="home-billboard-play"
-      accessibilityRole="button"
-      accessibilityLabel={`Play, ${card.title}`}
-    >
-      <Animated.View style={[styles.playButton, animatedStyle]}>
-        <Ionicons
-          name="play"
-          size={PLAY_ICON_SIZE}
-          color={WATCH_THEME.accentText}
-        />
-        <View style={styles.playCaption}>
-          <Text style={styles.playLabel}>Play</Text>
-          <Text style={styles.playSub} numberOfLines={1}>
-            {card.label}
-          </Text>
-        </View>
-      </Animated.View>
-    </Pressable>
-  )
-}
-
-function MoreInfoButton({ card, onPress, onChromeFocus }: ActionButtonProps) {
-  const { setFocused, progress } = useFocusAnimation()
-  const ink = useMemo(
-    () =>
-      progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [WATCH_THEME.text, WATCH_THEME.focusInk],
-      }),
-    [progress],
-  )
-  const animatedStyle = useMemo(
-    () => ({
-      backgroundColor: progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [WATCH_THEME.pillGlass, WATCH_THEME.focusFill],
-      }),
-      borderColor: progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: ["rgba(255,255,255,0.06)", "rgba(255,255,255,0.16)"],
-      }),
-      shadowOpacity: progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, 0.5],
-      }),
-      transform: focusTransform(progress, { lift: scale(4), magnify: 1.06 }),
-    }),
-    [progress],
-  )
-  return (
-    <Pressable
-      onPress={() => onPress(card)}
-      onFocus={() => {
-        setFocused(true)
-        onChromeFocus()
-      }}
-      onBlur={() => setFocused(false)}
-      testID="home-billboard-more-info"
-      accessibilityRole="button"
-      accessibilityLabel={`More info, ${card.title}`}
-    >
-      <Animated.View style={[styles.infoPill, animatedStyle]}>
-        <Animated.Text style={[styles.infoLabel, { color: ink }]}>
-          More Info
-        </Animated.Text>
-      </Animated.View>
-    </Pressable>
-  )
-}
-
-const BUTTON_HEIGHT = scale(76)
-const BUTTON_RADIUS = scale(18)
 
 const styles = StyleSheet.create({
   hero: {
@@ -290,65 +118,5 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "rgba(255,255,255,0.55)",
     marginTop: scale(12),
-  },
-
-  // ── Actions ──
-  actions: {
-    flexDirection: "row",
-    alignItems: "stretch",
-    gap: scale(18),
-    marginTop: scale(30),
-  },
-  playButton: {
-    height: BUTTON_HEIGHT,
-    paddingLeft: scale(32),
-    paddingRight: scale(40),
-    borderRadius: BUTTON_RADIUS,
-    backgroundColor: WATCH_THEME.accent,
-    // Constant-width transparent border becomes the white focus ring
-    // (animating borderColor avoids any layout shift).
-    borderWidth: scale(5),
-    flexDirection: "row",
-    alignItems: "center",
-    gap: scale(16),
-    shadowColor: WATCH_THEME.accent,
-    shadowRadius: scale(20),
-    shadowOffset: { width: 0, height: scale(10) },
-  },
-  playCaption: {
-    alignItems: "flex-start",
-    justifyContent: "center",
-  },
-  playLabel: {
-    fontFamily: "System",
-    fontSize: Math.round(scale(28)),
-    lineHeight: Math.round(scale(29)),
-    fontWeight: "700",
-    color: WATCH_THEME.accentText,
-  },
-  playSub: {
-    fontFamily: "System",
-    fontSize: Math.round(scale(15)),
-    fontWeight: "600",
-    color: "rgba(255,255,255,0.82)",
-    marginTop: scale(2),
-    letterSpacing: scale(0.1),
-  },
-  infoPill: {
-    height: BUTTON_HEIGHT,
-    paddingHorizontal: scale(30),
-    borderRadius: BUTTON_RADIUS,
-    borderWidth: scale(1),
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    shadowColor: "#000000",
-    shadowRadius: scale(22),
-    shadowOffset: { width: 0, height: scale(14) },
-  },
-  infoLabel: {
-    fontFamily: "System",
-    fontSize: Math.round(scale(23)),
-    fontWeight: "600",
   },
 })

--- a/apps/tv/src/components/home/HomeCard.tsx
+++ b/apps/tv/src/components/home/HomeCard.tsx
@@ -20,6 +20,7 @@
 import { memo, useMemo } from "react"
 import { Image } from "expo-image"
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native"
+import type { View as ViewType } from "react-native"
 
 import { isSeriesSearchResult } from "../../lib/isSeriesRecord"
 import { resolveImageUrl } from "../../lib/resolveImageUrl"
@@ -39,6 +40,19 @@ type HomeCardProps = {
   onFocus: (card: WatchHomeCard) => void
   onPress: (card: WatchHomeCard) => void
   index: number
+  /**
+   * Forced D-pad-up destination (the featured rail wires the Search tab here
+   * so edge cards reach the centered top bar, which has no horizontal overlap
+   * above them). Pressable forwards this to its host View via
+   * tagForComponentOrHandle, so a node instance works directly.
+   */
+  nextFocusUp?: ViewType | null
+  /**
+   * Exposes this card's native node. The rail captures its LAST real card's
+   * node so the invisible over-hang pad cards can bounce focus to it via
+   * requestTVFocus(). Ref-as-state in the rail, like MissionSection.
+   */
+  nodeRef?: (node: ViewType | null) => void
 }
 
 export const HomeCard = memo(function HomeCard({
@@ -46,6 +60,8 @@ export const HomeCard = memo(function HomeCard({
   onFocus,
   onPress,
   index,
+  nextFocusUp,
+  nodeRef,
 }: HomeCardProps) {
   const { focused, setFocused, progress } = useFocusAnimation()
   // CMS-sourced URL is untrusted — sanitize before it reaches expo-image.
@@ -81,12 +97,14 @@ export const HomeCard = memo(function HomeCard({
 
   return (
     <Pressable
+      ref={nodeRef}
       onPress={() => onPress(card)}
       onFocus={() => {
         setFocused(true)
         onFocus(card)
       }}
       onBlur={() => setFocused(false)}
+      nextFocusUp={nextFocusUp}
       accessibilityRole="button"
       accessibilityLabel={card.title}
       accessibilityHint={

--- a/apps/tv/src/components/home/HomeRail.tsx
+++ b/apps/tv/src/components/home/HomeRail.tsx
@@ -11,37 +11,92 @@
 // screen can drive its row-anchored scroll + deep/browse chrome state. The
 // onCardFocus(card) contract is unchanged.
 
-import { memo, useCallback } from "react"
+import { memo, useCallback, useMemo, useState } from "react"
 import {
+  Dimensions,
   FlatList,
+  Pressable,
   StyleSheet,
   Text,
   View,
   type ListRenderItemInfo,
+  type View as ViewType,
 } from "react-native"
 
 import { scale } from "../../lib/scale"
 import type { WatchHomeCard } from "../../lib/watchHome/model"
 import { TVFocusGuideView } from "../TVFocusGuideView"
 import { WATCH_THEME } from "../watch/watchDetailTheme"
-import { HOME_CARD_WIDTH, HomeCard } from "./HomeCard"
+import { HOME_CARD_THUMB_HEIGHT, HOME_CARD_WIDTH, HomeCard } from "./HomeCard"
+import { buildRailItems, type RailItem } from "./homeRailItems"
 
 const ITEM_GAP = scale(28)
+const COLUMN_WIDTH = HOME_CARD_WIDTH + ITEM_GAP
+const RAIL_PADDING_LEFT = scale(80)
 
-const keyExtractor = (item: WatchHomeCard, index: number) =>
-  `home-card-${item.id}-${index}`
+// How many card columns span the visible width. A rail with fewer cards than
+// this leaves empty columns on the right, which the tvOS focus engine treats
+// as "nothing there" — a vertical move from an over-hanging column SKIPS the
+// rail to a longer one below/above. We pad such rails up to this many columns
+// with invisible focusable cards so every visible column has a focus target.
+const VISIBLE_COLUMNS = Math.ceil(
+  (Dimensions.get("window").width - RAIL_PADDING_LEFT) / COLUMN_WIDTH,
+)
+
+const keyExtractor = (item: RailItem, index: number) =>
+  item.kind === "card"
+    ? `home-card-${item.card.id}-${index}`
+    : `home-pad-${index}`
 
 // Fixed card dims → no measuring pass. The last item has no trailing gap, so
 // its length is overstated by ITEM_GAP — harmless for virtualization and
 // scrollToIndex (same note as EpisodeRail). Module-scope: pure function of
 // module constants.
 const getItemLayout = (
-  _: ArrayLike<WatchHomeCard> | null | undefined,
+  _: ArrayLike<RailItem> | null | undefined,
   index: number,
 ) => ({
-  length: HOME_CARD_WIDTH + ITEM_GAP,
-  offset: (HOME_CARD_WIDTH + ITEM_GAP) * index,
+  length: COLUMN_WIDTH,
+  offset: COLUMN_WIDTH * index,
   index,
+})
+
+// react-native-tvos host nodes expose requestTVFocus() (NativeMethods), absent
+// from the bundled View type. Encapsulate the cast in one helper so it stays
+// out of render code; no-ops safely on a null/detached node.
+function requestTVFocus(node: ViewType | null): void {
+  ;(node as { requestTVFocus?: () => void } | null)?.requestTVFocus?.()
+}
+
+/**
+ * Invisible over-hang catcher: a focusable, transparent, accessibility-hidden
+ * cell in the rail's empty right columns. When a vertical D-pad move lands here
+ * (because the source column over-hangs this shorter rail), it instantly
+ * bounces focus to the rail's last REAL card via requestTVFocus() — a
+ * same-rail move, which works where cross-FlatList nextFocus does not. It is
+ * inert: dispatches no card/row focus, so the showcase/scroll only react to the
+ * real card it redirects to. Non-focusable until the target node is known, so
+ * focus is never stranded on an invisible cell.
+ */
+const RailPad = memo(function RailPad({
+  targetNode,
+}: {
+  targetNode: ViewType | null
+}) {
+  return (
+    <Pressable
+      focusable={targetNode != null}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      onFocus={() => {
+        // Bounce focus to the rail's last real card (same-rail move — works
+        // where cross-FlatList nextFocus doesn't). Synchronous is reliable
+        // here; no defer needed.
+        requestTVFocus(targetNode)
+      }}
+      style={styles.pad}
+    />
+  )
 })
 
 type HomeRailProps = {
@@ -56,6 +111,13 @@ type HomeRailProps = {
    *  screen's row-anchored scrolling and deep/browse chrome state. */
   onRowFocus?: (rowIndex: number) => void
   onCardPress: (card: WatchHomeCard) => void
+  /**
+   * D-pad-up destination for this rail's cards. The featured rail passes the
+   * Search tab's node so its edge cards (no focusable directly above the
+   * centered tab bar) can still reach the top bar; section rails leave it
+   * undefined and rely on the full-width rail above them.
+   */
+  upFocusTarget?: ViewType | null
 }
 
 export const HomeRail = memo(function HomeRail({
@@ -66,7 +128,12 @@ export const HomeRail = memo(function HomeRail({
   onCardFocus,
   onRowFocus,
   onCardPress,
+  upFocusTarget,
 }: HomeRailProps) {
+  // This rail's last real card node — the bounce target for the pad cards.
+  // State (not a ref) so the pads re-render with it once it mounts.
+  const [lastCardNode, setLastCardNode] = useState<ViewType | null>(null)
+
   const handleCardFocus = useCallback(
     (card: WatchHomeCard) => {
       onRowFocus?.(rowIndex)
@@ -75,23 +142,46 @@ export const HomeRail = memo(function HomeRail({
     [onCardFocus, onRowFocus, rowIndex],
   )
 
+  // Real cards + invisible over-hang pads (see homeRailItems.buildRailItems).
+  const items = useMemo(() => buildRailItems(cards, VISIBLE_COLUMNS), [cards])
+
   const renderItem = useCallback(
-    ({ item, index }: ListRenderItemInfo<WatchHomeCard>) => (
-      <View
-        style={[styles.itemWrapper, index < cards.length - 1 && styles.itemGap]}
-      >
-        {/* HomeCard re-emits its `card` prop from onFocus/onPress —
-            never re-index into `data` from an async focus callback
-            (the array can shrink under it). */}
-        <HomeCard
-          card={item}
-          index={index}
-          onFocus={handleCardFocus}
-          onPress={onCardPress}
-        />
-      </View>
-    ),
-    [cards.length, handleCardFocus, onCardPress],
+    ({ item, index }: ListRenderItemInfo<RailItem>) => {
+      const isLastColumn = index === items.length - 1
+      if (item.kind === "pad") {
+        return (
+          <View style={[styles.itemWrapper, !isLastColumn && styles.itemGap]}>
+            <RailPad targetNode={lastCardNode} />
+          </View>
+        )
+      }
+      return (
+        <View style={[styles.itemWrapper, !isLastColumn && styles.itemGap]}>
+          {/* HomeCard re-emits its `card` prop from onFocus/onPress —
+              never re-index into `data` from an async focus callback
+              (the array can shrink under it). */}
+          <HomeCard
+            card={item.card}
+            index={index}
+            onFocus={handleCardFocus}
+            onPress={onCardPress}
+            // Coalesce null -> undefined: a null nextFocusUp (search node not
+            // captured yet) should fall back to geometry, not wire to nothing.
+            nextFocusUp={upFocusTarget ?? undefined}
+            // Capture the last REAL card — the pads' bounce target.
+            nodeRef={index === cards.length - 1 ? setLastCardNode : undefined}
+          />
+        </View>
+      )
+    },
+    [
+      cards.length,
+      items.length,
+      handleCardFocus,
+      onCardPress,
+      upFocusTarget,
+      lastCardNode,
+    ],
   )
 
   if (cards.length === 0) return null
@@ -107,9 +197,19 @@ export const HomeRail = memo(function HomeRail({
         </Text>
       </View>
 
-      <TVFocusGuideView autoFocus>
+      {/* No autoFocus: autoFocus restores each rail's LAST-focused card on
+          re-entry, which teleported focus horizontally between rails. Without
+          it the tvOS focus engine uses spatial geometry — up/down lands on the
+          card nearest the leaving card's on-screen x (column-preserving). The
+          skip into shorter rails is handled by the invisible RailPad cards
+          (see `items`), not the guide.
+          extraData={lastCardNode}: FlatList re-renders rows on data/extraData
+          change only — the pads need to re-render once the bounce target is
+          captured. */}
+      <TVFocusGuideView>
         <FlatList
-          data={cards}
+          data={items}
+          extraData={lastCardNode}
           horizontal
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.listContent}
@@ -157,5 +257,14 @@ const styles = StyleSheet.create({
   },
   itemGap: {
     marginRight: ITEM_GAP,
+  },
+  // Invisible over-hang catcher: a card-sized focusable in the rail's empty
+  // right columns. Transparent (no background/content) rather than opacity:0 —
+  // the tvOS focus engine skips alpha-0 views, so opacity:0 made the pad
+  // unfocusable. Matches the thumb height so its focus frame lines up with the
+  // real cards' band for vertical (up/down) geometry.
+  pad: {
+    width: HOME_CARD_WIDTH,
+    height: HOME_CARD_THUMB_HEIGHT,
   },
 })

--- a/apps/tv/src/components/home/HomeTopBar.tsx
+++ b/apps/tv/src/components/home/HomeTopBar.tsx
@@ -13,6 +13,7 @@
 
 import { memo, useEffect, useMemo, useRef, useState } from "react"
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native"
+import type { View as ViewType } from "react-native"
 
 import { scale } from "../../lib/scale"
 import { AnimatedFocusIcon } from "../watch/AnimatedFocusIcon"
@@ -47,6 +48,13 @@ type HomeTopBarProps = {
   onSearchPress: () => void
   /** Any tab gaining focus pins the screen to its "top" state. */
   onChromeFocus: () => void
+  /**
+   * Receives the Search tab's native node so the featured rail can wire it as
+   * its cards' `nextFocusUp` target — the centered tab bar has no horizontal
+   * overlap with the rail's edge cards, so D-pad up from them needs an
+   * explicit destination (the focus engine finds nothing directly above).
+   */
+  onSearchTabNode?: (node: ViewType | null) => void
 }
 
 export const HomeTopBar = memo(function HomeTopBar({
@@ -54,6 +62,7 @@ export const HomeTopBar = memo(function HomeTopBar({
   searchTabPreferredFocus,
   onSearchPress,
   onChromeFocus,
+  onSearchTabNode,
 }: HomeTopBarProps) {
   // ── Hide animation ──
   const hideProgress = useRef(new Animated.Value(hidden ? 1 : 0)).current
@@ -114,6 +123,7 @@ export const HomeTopBar = memo(function HomeTopBar({
           onChromeFocus={onChromeFocus}
           focusable={!hidden}
           hasTVPreferredFocus={searchTabPreferredFocus}
+          nodeRef={onSearchTabNode}
         />
         <TopBarTab
           testID="home-topbar-home-tab"
@@ -157,6 +167,8 @@ type TopBarTabProps = {
   onChromeFocus: () => void
   focusable: boolean
   hasTVPreferredFocus?: boolean
+  /** Lifts this tab's native node up so a rail can target it via nextFocusUp. */
+  nodeRef?: (node: ViewType | null) => void
 }
 
 function TopBarTab({
@@ -170,6 +182,7 @@ function TopBarTab({
   onChromeFocus,
   focusable,
   hasTVPreferredFocus,
+  nodeRef,
 }: TopBarTabProps) {
   const { setFocused, progress } = useFocusAnimation()
 
@@ -213,6 +226,7 @@ function TopBarTab({
 
   return (
     <Pressable
+      ref={nodeRef}
       onPress={onPress}
       onFocus={() => {
         setFocused(true)

--- a/apps/tv/src/components/home/homeRailItems.test.ts
+++ b/apps/tv/src/components/home/homeRailItems.test.ts
@@ -1,0 +1,38 @@
+import { buildRailItems } from "./homeRailItems"
+import type { WatchHomeCard } from "../../lib/watchHome/model"
+
+const card = (id: string) => ({ id }) as unknown as WatchHomeCard
+
+describe("buildRailItems", () => {
+  it("pads a short rail up to visibleColumns", () => {
+    const items = buildRailItems([card("a"), card("b"), card("c")], 5)
+    expect(items).toHaveLength(5)
+    expect(items.slice(0, 3).map((i) => i.kind)).toEqual([
+      "card",
+      "card",
+      "card",
+    ])
+    expect(items.slice(3).map((i) => i.kind)).toEqual(["pad", "pad"])
+  })
+
+  it("adds no pads when the rail exactly fills the columns", () => {
+    const items = buildRailItems([card("a"), card("b")], 2)
+    expect(items.map((i) => i.kind)).toEqual(["card", "card"])
+  })
+
+  it("adds no pads when the rail exceeds the columns (clamp at 0)", () => {
+    const items = buildRailItems([card("a"), card("b"), card("c")], 2)
+    expect(items.map((i) => i.kind)).toEqual(["card", "card", "card"])
+  })
+
+  it("returns nothing for an empty rail", () => {
+    expect(buildRailItems([], 5)).toEqual([])
+  })
+
+  it("preserves card order and identity", () => {
+    const cards = [card("a"), card("b")]
+    const items = buildRailItems(cards, 4)
+    expect(items[0]).toEqual({ kind: "card", card: cards[0] })
+    expect(items[1]).toEqual({ kind: "card", card: cards[1] })
+  })
+})

--- a/apps/tv/src/components/home/homeRailItems.ts
+++ b/apps/tv/src/components/home/homeRailItems.ts
@@ -1,0 +1,29 @@
+// Pure rail-item builder for HomeRail, extracted so the over-hang pad math is
+// unit-testable (jest-expo can't load .tsx — same reason homeScrollState.ts /
+// homeCardRouting.ts are split out).
+
+import type { WatchHomeCard } from "../../lib/watchHome/model"
+
+// A rail item is either a real card or a trailing invisible pad (over-hang
+// catcher). Pads share the card's column footprint so getItemLayout stays
+// uniform and columns line up across rails.
+export type RailItem = { kind: "card"; card: WatchHomeCard } | { kind: "pad" }
+
+/**
+ * Real cards, then invisible pads filling the rail out to `visibleColumns`, so
+ * an over-hanging vertical D-pad move always finds a focusable cell here (a
+ * shorter rail is otherwise SKIPPED by the tvOS focus engine). A rail already
+ * at/over the column count gets no pads. An empty rail gets nothing — pads
+ * with no real card to bounce to are pointless (and HomeRail renders null for
+ * an empty rail anyway).
+ */
+export function buildRailItems(
+  cards: WatchHomeCard[],
+  visibleColumns: number,
+): RailItem[] {
+  if (cards.length === 0) return []
+  const items: RailItem[] = cards.map((card) => ({ kind: "card", card }))
+  const padCount = Math.max(0, visibleColumns - cards.length)
+  for (let i = 0; i < padCount; i++) items.push({ kind: "pad" })
+  return items
+}

--- a/apps/tv/src/components/home/homeScrollState.test.ts
+++ b/apps/tv/src/components/home/homeScrollState.test.ts
@@ -1,5 +1,4 @@
 import {
-  areHeroActionsGhosted,
   deepScrimOpacity,
   isTopBarHidden,
   resolveBrowseState,
@@ -94,13 +93,5 @@ describe("isTopBarHidden", () => {
     expect(isTopBarHidden("top")).toBe(false)
     expect(isTopBarHidden("browse")).toBe(false)
     expect(isTopBarHidden("deep")).toBe(true)
-  })
-})
-
-describe("areHeroActionsGhosted", () => {
-  it("ghosts whenever focus is in a row", () => {
-    expect(areHeroActionsGhosted("top")).toBe(false)
-    expect(areHeroActionsGhosted("browse")).toBe(true)
-    expect(areHeroActionsGhosted("deep")).toBe(true)
   })
 })

--- a/apps/tv/src/components/home/homeScrollState.ts
+++ b/apps/tv/src/components/home/homeScrollState.ts
@@ -1,15 +1,15 @@
 // Pure state for the redesigned Home screen's row-anchored scrolling and
-// ambient chrome (deep scrim, top bar, hero actions). React-free .ts module
+// ambient chrome (deep scrim, top bar). React-free .ts module
 // (like showcaseState.ts) so it is unit-testable under jest-expo, which
 // cannot load .tsx.
 //
 // The screen has three visual states driven by WHERE focus sits:
-//   "top"    — focus on chrome (tab bar / hero actions): feed pinned to 0,
-//              no deep scrim, top bar and hero actions fully visible.
+//   "top"    — focus on the top bar tabs: feed pinned to 0, no deep scrim,
+//              top bar fully visible.
 //   "browse" — focus on a row-0 (featured) card: feed stays at 0, deep scrim
-//              at 0.22, top bar visible, hero actions ghosted.
+//              at 0.22, top bar visible.
 //   "deep"   — focus in rows >= 1: the row anchors near the viewport top,
-//              deep scrim fully on, top bar hidden, hero actions ghosted.
+//              deep scrim fully on, top bar hidden.
 
 export type HomeBrowseState = "top" | "browse" | "deep"
 
@@ -22,7 +22,7 @@ export const ROW_ANCHOR_OFFSET = 120
 
 /**
  * Map a focused row index to the screen's visual state. `null` means focus
- * sits on chrome (tab bar / hero actions), not in any rail.
+ * sits on the top bar tabs, not in any rail.
  */
 export function resolveBrowseState(rowIndex: number | null): HomeBrowseState {
   if (rowIndex == null) return "top"
@@ -68,12 +68,4 @@ export function deepScrimOpacity(state: HomeBrowseState): number {
 /** The top bar hides only when focus is deep in the feed (rows >= 1). */
 export function isTopBarHidden(state: HomeBrowseState): boolean {
   return state === "deep"
-}
-
-/**
- * Hero actions ghost (opacity 0 but still mounted/focusable) while focus is
- * in ANY row, so D-pad up from row 0 lands on Play and fades them back in.
- */
-export function areHeroActionsGhosted(state: HomeBrowseState): boolean {
-  return state !== "top"
 }

--- a/apps/tv/src/types/react-native-tv.d.ts
+++ b/apps/tv/src/types/react-native-tv.d.ts
@@ -1,0 +1,22 @@
+// react-native-tvos ships the D-pad `nextFocus*` props only inside a
+// `declare module 'react-native'` block (types/public/ReactNativeTVTypes.d.ts)
+// that does NOT merge into the `ViewProps` interface our build resolves
+// (Libraries/Components/View/ViewPropTypes.d.ts) — so the props are missing
+// from View/Pressable types, even though Pressable forwards them to its host
+// View at runtime (Pressable.js: `nextFocusUp={tagForComponentOrHandle(...)}`,
+// which accepts a node handle OR a component instance).
+//
+// Re-augment `ViewProps` locally so the directional next-focus props are
+// type-valid app-wide. A component instance (e.g. a Pressable/View captured
+// via ref-as-state) is a valid destination, the same shape MissionSection
+// already passes to `TVFocusGuideView`'s `destinations`.
+import "react-native"
+
+declare module "react-native" {
+  interface ViewProps {
+    nextFocusUp?: number | View | null | undefined
+    nextFocusDown?: number | View | null | undefined
+    nextFocusLeft?: number | View | null | undefined
+    nextFocusRight?: number | View | null | undefined
+  }
+}

--- a/docs/solutions/best-practices/react-native-tvos-porting-pitfalls-20260414.md
+++ b/docs/solutions/best-practices/react-native-tvos-porting-pitfalls-20260414.md
@@ -131,6 +131,7 @@ Key constraints:
 - `setNativeProps` is the react-native-tvos imperative API for moving focus. The ref target must be a mounted `Pressable`.
 - Anchors need `accessible={false}` to be invisible to screen readers.
 - Anchor height must be >= 48px for the focus engine to recognize it.
+- This anchor is focused by an **explicit** `setNativeProps({ hasTVPreferredFocus })` claim, not by geometric D-pad discovery — which is why `opacity: 0` works here. The opposite case — a cell that must be caught by a _directional_ D-pad move (e.g. an over-hang catcher inside a rail) — cannot use `opacity: 0`: alpha-0 views are skipped by the geometric focus engine, so it must be transparent at alpha 1. See [`../design-patterns/tv-rail-overhang-pad-bounce-focus-20260616.md`](../design-patterns/tv-rail-overhang-pad-bounce-focus-20260616.md).
 
 Scope: this anchor technique is for `ScrollView`. A virtualized `FlatList`
 scrolls programmatically with `scrollToIndex` + `getItemLayout` instead (no

--- a/docs/solutions/design-patterns/tv-rail-overhang-pad-bounce-focus-20260616.md
+++ b/docs/solutions/design-patterns/tv-rail-overhang-pad-bounce-focus-20260616.md
@@ -1,0 +1,200 @@
+---
+title: "TV home rail — column-preserving D-pad focus with invisible pad-cell over-hang bounce"
+date: 2026-06-16
+last_refreshed: 2026-06-16
+category: docs/solutions/design-patterns
+module: apps/tv
+problem_type: design_pattern
+component: frontend_stimulus
+severity: high
+applies_when:
+  - "Rendering multiple horizontal FlatList rails of unequal length on a tvOS / Android TV home screen"
+  - "A shorter rail is skipped entirely when the focused column over-hangs its last card"
+  - "D-pad Up/Down must land on the same column position across rails instead of replaying each rail's last-focused card"
+  - "TVFocusGuideView autoFocus is teleporting focus unpredictably between stacked rails"
+  - "An edge card has no focusable directly above/below it (e.g. a centered top bar over the rail's edge columns)"
+tags:
+  - tv
+  - tvos
+  - android-tv
+  - react-native-tvos
+  - tvfocusguideview
+  - focus
+  - d-pad
+  - requesttvfocus
+  - flatlist
+related_components:
+  - apps/tv/src/components/home/HomeRail.tsx
+  - apps/tv/src/components/home/HomeCard.tsx
+  - apps/tv/src/components/home/HomeTopBar.tsx
+  - apps/tv/src/components/home/homeRailItems.ts
+---
+
+# TV home rail — column-preserving D-pad focus with invisible pad-cell over-hang bounce
+
+## Context
+
+The TV home screen (`apps/tv`, react-native-tvos 0.81.5) stacks several horizontal "rails" (FlatList carousels of cards) vertically. Three D-pad focus problems surfaced, and the over-hang one in particular only yielded after two intuitive fixes hit hard tvOS focus-engine limitations:
+
+1. **Edge-card up-focus dead-end** — D-pad Up from the leftmost/rightmost card of the first rail did nothing, because the centered top bar has no focusable directly above those columns.
+2. **Per-rail focus "memory"** — `TVFocusGuideView autoFocus` restored each rail's _last-focused_ card on re-entry, so Up/Down teleported focus horizontally between rails instead of preserving the column.
+3. **Shorter rails skipped** — once nav was column-preserving (pure geometry), the focus engine _skips a shorter neighbour rail entirely_ when the entering column over-hangs its card count (e.g. column 4 over a 3-card rail), jumping to a longer rail beyond it.
+
+Shipped in [PR #1274](https://github.com/JesusFilm/forge/pull/1274). The headline reusable pattern is #3: invisible "pad" cells that catch the over-hang and bounce focus to the rail's last real card.
+
+## Guidance
+
+### 1. Edge-card up-focus — `nextFocusUp` to a node lifted via ref-as-state
+
+The Search/Home tab bar is centered, so edge cards have no focusable in their up-projection. Set `nextFocusUp` on the card's `Pressable`, targeting the Search tab's node. Lift that node out of `HomeTopBar` with ref-as-state (the same contract `MissionSection` uses for its QR destination):
+
+```tsx
+// app/index.tsx
+const [searchTabNode, setSearchTabNode] = useState<ViewType | null>(null)
+
+<HomeTopBar onSearchTabNode={setSearchTabNode} />
+
+// Only the featured rail (row 0) sits under the top bar:
+<HomeRail upFocusTarget={searchTabNode} ... />
+```
+
+```tsx
+// HomeTopBar.tsx — the Search TopBarTab forwards its node:
+<Pressable ref={nodeRef} ... />
+```
+
+```tsx
+// HomeRail.tsx — coalesce null -> undefined so a not-yet-captured node
+// falls back to spatial geometry rather than wiring up to a null destination:
+<HomeCard nextFocusUp={upFocusTarget ?? undefined} ... />
+```
+
+`FocusDestination` accepts a **component instance** directly (`Pressable` forwards it via `tagForComponentOrHandle`) — no `findNodeHandle` / native-tag lookup needed. This works because the target (the top bar) is **not** inside a FlatList (see Why This Matters #1).
+
+### 2. Column-preserving vertical nav — drop `autoFocus`
+
+`autoFocus` on a rail's guide restores the last-focused card on re-entry. Remove it so the tvOS spatial-geometry engine lands on the card whose on-screen x is nearest the leaving card's column:
+
+```tsx
+// before — teleports to each rail's remembered card
+<TVFocusGuideView autoFocus>
+  <FlatList ... />
+</TVFocusGuideView>
+
+// after — column-preserving (spatial geometry)
+<TVFocusGuideView>
+  <FlatList ... />
+</TVFocusGuideView>
+```
+
+Keep `autoFocus` only where restoring the last horizontal position is the desired UX (a single-rail detail page), not on a vertically stacked multi-rail feed.
+
+### 3. Over-hang skip — invisible pad cells that bounce via `requestTVFocus()`
+
+**Failed approach A — per-card `nextFocusDown`/`nextFocusUp` to the neighbour rail's last card.** The obvious fix, and completely ineffective: tvOS **silently ignores** per-view `nextFocus*` when the destination is inside a _different_ FlatList. Verified twice with the override confirmed present via logs; the rail was still skipped.
+
+**Failed approach B — full-width `TVFocusGuideView destinations`.** `destinations` _does_ cross FlatList boundaries (it reaches the target), but a full-width guide intercepts **every** inbound vertical move and redirects it to the destination — not only the over-hanging ones. This hijacks aligned moves and breaks column-preservation. Reverted. (The belief that "destinations only fires when there's no aligned competitor" is false for stacked rails.)
+
+**Working solution — invisible pad cells.** Append transparent, focusable, inert placeholder cells to the _end_ of each rail, out to the visible column count. Geometry lands the over-hanging move on a pad (no skip); the pad's `onFocus` immediately bounces to the rail's last real card via `requestTVFocus()` — a **same-rail** move, which works where cross-FlatList `nextFocus` does not.
+
+```ts
+// homeRailItems.ts — pure, unit-tested (jest-expo can't load .tsx)
+export type RailItem = { kind: "card"; card: WatchHomeCard } | { kind: "pad" }
+
+export function buildRailItems(
+  cards: WatchHomeCard[],
+  visibleColumns: number,
+): RailItem[] {
+  if (cards.length === 0) return []
+  const items: RailItem[] = cards.map((card) => ({ kind: "card", card }))
+  const padCount = Math.max(0, visibleColumns - cards.length)
+  for (let i = 0; i < padCount; i++) items.push({ kind: "pad" })
+  return items
+}
+```
+
+```tsx
+// HomeRail.tsx — the pad and the bounce
+function requestTVFocus(node: ViewType | null): void {
+  // requestTVFocus() is a react-native-tvos NativeMethods extension absent
+  // from the bundled View type; no-ops safely on a null/detached node.
+  ;(node as { requestTVFocus?: () => void } | null)?.requestTVFocus?.()
+}
+
+const RailPad = memo(function RailPad({ targetNode }: { targetNode: ViewType | null }) {
+  return (
+    <Pressable
+      focusable={targetNode != null}          // never strand focus on an uncaptured pad
+      accessibilityElementsHidden               // VoiceOver skips it
+      importantForAccessibility="no-hide-descendants"
+      onFocus={() => requestTVFocus(targetNode)}
+      style={styles.pad}                        // see the critical style note below
+    />
+  )
+})
+
+// style — CRITICAL: transparent, NOT opacity:0 (see Why This Matters #3)
+pad: { width: HOME_CARD_WIDTH, height: HOME_CARD_THUMB_HEIGHT }
+```
+
+The rail captures its last real card's node via ref-as-state and feeds the FlatList `extraData` so the pads re-render once the target arrives:
+
+```tsx
+const [lastCardNode, setLastCardNode] = useState<ViewType | null>(null)
+
+// in renderItem — only the last real card reports its node:
+<HomeCard nodeRef={index === cards.length - 1 ? setLastCardNode : undefined} ... />
+// ...and the pad consumes it:
+<RailPad targetNode={lastCardNode} />
+
+<FlatList data={items} extraData={lastCardNode} ... />  // required — see #4
+```
+
+## Why This Matters
+
+Five tvOS / React Native constraints are load-bearing — get any wrong and the pattern silently fails:
+
+1. **Cross-FlatList `nextFocus*` is silently ignored.** Per-view `nextFocusDown`/`nextFocusUp` only fire when the destination is in the _same_ FlatList. To a non-FlatList sibling (the top bar) they work fine — which is why #1 above succeeds and #3's approach A fails. No error either way; it just doesn't move.
+2. **A full-width `TVFocusGuideView destinations` guide hijacks all inbound vertical moves**, aligned ones included — it does not check for a spatial competitor first. Only a guide/focusable scoped to the empty over-hang region avoids the hijack, which is exactly what the pad cells are.
+3. **Alpha-0 views are unfocusable to the geometric focus engine.** `opacity: 0` makes the pad un-catchable, so it must be transparent via _absence of background and content_, alpha 1. (Note: this was established for geometric/directional catch. Whether an explicit `hasTVPreferredFocus` claim can still target an `opacity:0` view — as some older anchor patterns assume — was not tested here; see Related.)
+4. **FlatList re-renders rows only on `data`/`extraData` change, not on `renderItem` closure change.** The bounce target arrives asynchronously (ref-as-state, after mount), so without `extraData={lastCardNode}` the pads keep their initial `null` target forever and never bounce.
+5. **`useEffect` runs after the commit-phase ref callbacks.** Resetting the captured-node state in an effect (e.g. "clear on data change") wipes the nodes the refs just populated in the same commit, and stable refs never re-fire to restore them. Let ref detach/attach handle the lifecycle on remount.
+
+`requestTVFocus()` is synchronous in `onFocus` and needs no `setTimeout`/`requestAnimationFrame` deferral on tvOS. **Verified on the tvOS simulator only — confirm on a physical Android TV device before relying on it there.**
+
+## When to Apply
+
+Use the **invisible-pad over-hang bounce** when all hold:
+
+- react-native-tvos, tvOS (and verify on Android TV)
+- multiple horizontally-scrolling FlatList rails stacked vertically
+- rails of differing card counts (shorter rails create over-hanging columns)
+- column-preservation on vertical D-pad nav is a product requirement
+
+Use **`nextFocusUp`/`Down` ref-as-state** when the vertical target is geometrically offset from the source (e.g. a centered tab bar above edge cards) **and** the target is a non-FlatList `Pressable`.
+
+**Drop `TVFocusGuideView autoFocus`** whenever column-preserving vertical nav is wanted; keep it only for single-rail surfaces where restoring the last horizontal position is desired.
+
+## Examples
+
+**Over-hang catch — 5-card rail above a 3-card rail, 5 visible columns.**
+`buildRailItems` yields `[card0, card1, card2, pad, pad]` for the 3-card rail.
+User on card4 (column 4) of the upper rail presses **Down**:
+
+1. Geometry projects down from column 4.
+2. The 3-card rail has no real card at column 4 — _without_ pads, tvOS skips it and jumps to a longer rail below.
+3. _With_ pads, the pad at index 4 is present and focusable (`lastCardNode` was captured when card2 mounted) → focus lands on the pad.
+4. `onFocus` → `requestTVFocus(lastCardNode)` → focus bounces to card2 (the last real card), which dispatches `onRowFocus` so the screen scrolls and the showcase updates.
+
+Aligned columns are untouched: from column 1, Down lands on the 3-card rail's card1 directly by geometry — no pad involved (the pads only sit in the empty right columns).
+
+**Edge up-focus — Down/Up symmetry from a corner card.** From card0 (leftmost) of the featured rail, Up with `nextFocusUp={searchTabNode}` routes to the Search tab regardless of geometry (the centered tab bar doesn't overlap column 0). Without it, the press is a dead-end.
+
+## Related
+
+- [`tv-home-row-anchored-scroll-native-focus-scroll-disabled-20260615.md`](./tv-home-row-anchored-scroll-native-focus-scroll-disabled-20260615.md) — **companion, same screen.** That doc is the row-anchored _scroll_ layer (`scrollEnabled={false}` + `handleRowFocus`); this doc is the _column-focus_ layer. Together they describe the redesigned home's navigation.
+- [`../best-practices/tv-focus-driven-hero-patterns-20260420.md`](../best-practices/tv-focus-driven-hero-patterns-20260420.md) — the prior home focus model (non-interactive hero / rail-owns-focus via `TVFocusGuideView autoFocus`). This doc **extends and partially supersedes** it: `autoFocus` is correct for first-mount initial focus but is the _wrong ongoing model_ for a multi-rail feed (it teleports columns), and its "full-width guide traps DOWN" note generalises to "a full-width `destinations` guide hijacks aligned lateral moves for sibling rails."
+- [`../best-practices/react-native-tvos-porting-pitfalls-20260414.md`](../best-practices/react-native-tvos-porting-pitfalls-20260414.md) — general tvOS catalog. **Refresh candidate:** Pitfall 4's invisible focus anchor uses `opacity: 0`; this doc establishes that `opacity:0` is unfocusable for _geometric_ catch. Whether the anchor's explicit `setNativeProps({ hasTVPreferredFocus })` claim still works on an `opacity:0` view is unverified — worth a focused check before trusting that recipe. Pitfall 3's "`nextFocus*` failed" is refined here: it fails _across FlatList boundaries_, not universally.
+- [`../best-practices/react-native-tvos-flatlist-sheet-virtualization-pitfalls.md`](../best-practices/react-native-tvos-flatlist-sheet-virtualization-pitfalls.md) — FlatList focus discipline; the one-shot `hasTVPreferredFocus` and re-render rules are cousins of the `extraData`-for-async-focus-target rule here.
+- [`../design-patterns/rntvos-dpad-player-chrome-patterns.md`](./rntvos-dpad-player-chrome-patterns.md) — notes `nextFocusUp`/`nextFocusDown` quirks on `Pressable`; refined here to "works to non-FlatList targets, ignored across FlatList boundaries."
+- [PR #1274](https://github.com/JesusFilm/forge/pull/1274) — the implementation.


### PR DESCRIPTION
## What

TV home (`apps/tv`) D-pad focus navigation polish — four related changes:

- **Edge-card up-focus** — the leftmost/rightmost featured cards now reach the top-bar Search tab (`nextFocusUp` wired to the tab's lifted node). They previously dead-ended: the centered tab bar has no focusable directly above the edge columns, so the tvOS focus engine found nothing in the up projection.
- **Non-interactive billboard** — removed the hero Play / More Info buttons. Both routed to the same destination as pressing the card itself (no unique capability lost), and as focusable chrome they complicated the focus graph. The hero is now presentational copy only — the standard 10-foot pattern (rail owns selection).
- **Column-preserving vertical nav** — dropped `autoFocus` from each rail's `TVFocusGuideView`. `autoFocus` restored a rail's *last-focused* card on re-entry, so up/down teleported focus horizontally between rails. Without it the focus engine uses spatial geometry — a vertical move lands on the card nearest the leaving card's on-screen x.
- **Over-hang bridging** — a shorter neighbour rail is no longer skipped when entered from an over-hanging column (e.g. column 4 over a 3-card rail). Each rail appends transparent, focusable "pad" cells out to the visible column count; on focus a pad bounces to the rail's last real card via `requestTVFocus()` — a *same-rail* redirect (cross-`FlatList` `nextFocus` is silently ignored by tvOS, and a full-width `destinations` guide hijacks aligned moves).

## Notes

- tvOS-specific gotcha: the pad must be **transparent (alpha-1)**, not `opacity:0` — the focus engine skips alpha-0 views.
- Focus behaviour isn't unit-testable; verified manually in the Apple TV 4K simulator (edge up-focus, column-preserving up/down, over-hang catch into shorter rails, no flicker). The pure pad-list logic is extracted to a tested helper (`homeRailItems.ts` + 5 tests).
- `ce-code-review`: **ready to merge** — correctness clean; advisory cleanups applied. Residual: confirm the synchronous `requestTVFocus` bounce on an **Android TV** device (verified on tvOS only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)