### PR TITLE
fix(admin): stop AI chat draft timing out and reporting DRAFT REJECTED

### DIFF
--- a/apps/admin/src/mastra/budgets.ts
+++ b/apps/admin/src/mastra/budgets.ts
@@ -110,8 +110,22 @@ export const STEP_CAPS = {
  * bridge classifies the resulting AbortError as `timeout`.
  */
 export const TIME_BUDGET_MS = {
-  /** Single-turn chat (draft / add-section / rewrite-copy). */
-  chatTurn: 30_000,
+  /**
+   * Single-turn chat (draft / add-section / rewrite-copy).
+   *
+   * A from-scratch full-Experience draft on the production gateway
+   * model ("coding"/Qwen) measures ~37-45s end to end (tool round-trips
+   * + a ~3k-token envelope emission). The previous 30s ceiling aborted
+   * generate() mid-emission; because the AI SDK RESOLVES an aborted
+   * generate() with empty text (it does not reject), the chat path then
+   * misreported the empty completion as "agent returned text without a
+   * JSON object" / DRAFT REJECTED (see the abort guard in
+   * `experience-ai-chat.service.ts`). 90s clears the observed draft
+   * time with headroom while staying under the ~100s Cloudflare 524
+   * proxy ceiling that fronts admin. Add-section / rewrite-copy turns
+   * are much faster and finish well inside this budget.
+   */
+  chatTurn: 90_000,
   /**
    * Multi-step workflow's full chain (plan → skeleton → fill →
    * critique → revise after the U3 two-phase rebuild) — wall-clock cap.

--- a/apps/admin/src/services/experience-ai/experience-ai-chat.service.test.ts
+++ b/apps/admin/src/services/experience-ai/experience-ai-chat.service.test.ts
@@ -531,6 +531,44 @@ describe("streamChatTurn — Mastra integration", () => {
     expect(seenSignal!.aborted).toBe(true)
   })
 
+  it("classifies an aborted-but-resolved-empty generate() as timeout (not provider_validation_failed)", async () => {
+    // Production root cause: a from-scratch draft on the gateway model
+    // runs ~37-45s, past the chat-turn budget. When the budget signal
+    // fires, the AI SDK RESOLVES generate() with empty text rather than
+    // rejecting — so the run reaches the success path with an empty
+    // buffer. Without the abort guard this was misreported as
+    // `provider_validation_failed` ("returned text without a JSON
+    // object"; prod logs showed `stream_done buffer_length=0` +
+    // `no_json_object head="" tail=""`). The guard must classify it as a
+    // `timeout` instead. Here AbortSignal.timeout is faked to return an
+    // already-aborted signal and generate() resolves with empty text.
+    const realTimeout = AbortSignal.timeout
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation(() => {
+        const c = new AbortController()
+        c.abort(new DOMException("timed out", "TimeoutError"))
+        return c.signal
+      })
+    try {
+      mastraGenerateMock.mockResolvedValue({ text: "" })
+      const prisma = makeFakePrisma()
+
+      const events = await collect(
+        streamChatTurn(
+          { threadId: "thread-1", prompt: "draft a full page" },
+          { prisma, user: EDITOR },
+        ),
+      )
+
+      const err = events.find((e) => e.type === "error")
+      expect(err).toMatchObject({ type: "error", code: "timeout" })
+    } finally {
+      timeoutSpy.mockRestore()
+      expect(AbortSignal.timeout).toBe(realTimeout)
+    }
+  })
+
   it("emits a timeout-classified error event when the chat-turn budget fires", async () => {
     // generate() waits on its (composed) abortSignal; we inject a tiny
     // budget by faking AbortSignal.timeout to abort synchronously, then

--- a/apps/admin/src/services/experience-ai/experience-ai-chat.service.ts
+++ b/apps/admin/src/services/experience-ai/experience-ai-chat.service.ts
@@ -25,7 +25,7 @@ import type { PrismaClient } from "@prisma/client"
 
 import { canEditExperienceLocale } from "@/auth/permissions"
 import type { Principal } from "@/auth/principal"
-import { TIME_BUDGET_MS } from "@/mastra/budgets"
+import { STEP_CAPS, TIME_BUDGET_MS } from "@/mastra/budgets"
 import { ExperienceService } from "@/services/experience.service"
 import {
   computeDiff,
@@ -180,8 +180,55 @@ async function runMastraChat({
     // tool-call cycle. generate() returns the final text synchronously
     // which is sufficient for the demo; true token streaming requires
     // wiring the full UIMessageStream (the U3 bridge).
-    const result = await agent.generate(prompt, { abortSignal: composedSignal })
-    const buffer = typeof result.text === "string" ? result.text : ""
+    //
+    // `maxSteps` bounds tool-call recursion: `experience-default-chat`
+    // is a tool-calling agent (searchVideos / lookupBibleVerse /
+    // fetchVideoImage). `STEP_CAPS.toolCallingTurn` caps the
+    // tool→observe→respond loop so a misbehaving turn can't recurse
+    // without bound. (It is NOT what fixes the empty-buffer bug — that
+    // is the abort guard below.)
+    const result = await agent.generate(prompt, {
+      abortSignal: composedSignal,
+      maxSteps: STEP_CAPS.toolCallingTurn,
+    })
+    // Abort-resolves-empty guard. When the budget (or user-cancel)
+    // signal fires mid-generation, the AI SDK RESOLVES `generate()` with
+    // empty text rather than rejecting — so an aborted turn never enters
+    // the catch block's timeout/cancel classification, and an empty
+    // `result.text` would otherwise be misreported downstream as
+    // "agent returned text without a JSON object" / DRAFT REJECTED. A
+    // full from-scratch draft on the gateway model runs ~37-45s, so the
+    // 30s+ budget abort was the real production failure (logs:
+    // `stream_done buffer_length=0` + `no_json_object head="" tail=""`,
+    // with NO `chat_turn_timeout`). Classify the abort honestly here,
+    // before any empty-buffer handling.
+    if (budgetSignal.aborted) {
+      console.warn(
+        "[mastra-chat] event=chat_turn_timeout source=generate_resolved_empty budget_ms=" +
+          TIME_BUDGET_MS.chatTurn,
+      )
+      return {
+        kind: "error",
+        code: "timeout",
+        message: "The AI took too long to respond and the request timed out.",
+      }
+    }
+    if (abortSignal?.aborted) {
+      return {
+        kind: "error",
+        code: "cancelled",
+        message: "The request was cancelled.",
+      }
+    }
+    // Prefer `result.text`; fall back to a serialized `result.object`
+    // (mirrors the draft workflow's resolveDraft) so a structured-output
+    // turn still yields a parseable buffer instead of an empty string.
+    const buffer =
+      typeof result.text === "string" && result.text.length > 0
+        ? result.text
+        : result.object !== undefined
+          ? JSON.stringify(result.object)
+          : ""
     if (buffer.length > 0) onToken(buffer)
     console.warn(
       "[mastra-chat] event=stream_done buffer_length=" + buffer.length,


### PR DESCRIPTION
## Problem

Generating an experience from scratch via the AI chat fails with **DRAFT REJECTED**. Production logs (admin, prod env) show the exact signature:

```
[mastra-chat] event=stream_done buffer_length=0
[mastra-chat] event=no_json_object head="" tail=""
```

Notably **no** `chat_turn_timeout` is logged.

## Root cause

A from-scratch full-Experience draft on the production gateway model (`coding`/Qwen) takes **~37–45s** (measured against the live gateway). The chat turn wraps `generate()` in a **30s** abort budget (`TIME_BUDGET_MS.chatTurn`).

When that budget fires, the AI SDK **resolves `generate()` with empty text instead of rejecting**. So `runMastraChat` reaches its *success* path with an empty buffer, the timeout branch (in the `catch`) never runs, and the empty completion is misreported as "agent returned text without a JSON object" → `provider_validation_failed` → DRAFT REJECTED.

This was verified by reproduction: `generate()` aborted at 30s returns `text_length=0 threw=null`; given the full ~39s it returns a complete ~3k-char envelope.

## Fix

- **Raise `TIME_BUDGET_MS.chatTurn` 30s → 90s** — clears the observed draft time with headroom, stays under the ~100s Cloudflare 524 ceiling fronting admin.
- **Abort-resolves-empty guard** in `runMastraChat`: after `generate()` resolves, classify a fired budget/cancel signal as `timeout`/`cancelled` *before* the empty buffer hits the no-JSON path — so an aborted turn reports honestly instead of as a model failure.
- Wire `STEP_CAPS.toolCallingTurn` as `maxSteps` to bound tool-call recursion on the tool-calling chat agent (defensive; this was defined for exactly this agent but never wired — **not** the cause of this bug).
- Prefer `result.text`, fall back to `JSON.stringify(result.object)`.

## Tests

- New regression test: an aborted-but-resolved-empty `generate()` now classifies as a `timeout` error, not `provider_validation_failed`.
- Full chat-service suite green (18 tests); `tsc --noEmit` clean.

## Notes

The proper long-term fix is true token streaming (the U3 `UIMessageStream` bridge) so the connection never idles during a long draft — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)