### PR TITLE
fix(admin): green main + make AI chat draft apply survive microsecond updated_at

### DIFF
--- a/apps/admin/src/mastra/budgets.test.ts
+++ b/apps/admin/src/mastra/budgets.test.ts
@@ -73,8 +73,11 @@ describe("budgets (U11)", () => {
       )
     })
 
-    it("uses sensible defaults (30s chat / 180s workflow / 300s background)", () => {
-      expect(TIME_BUDGET_MS.chatTurn).toBe(30_000)
+    it("uses sensible defaults (90s chat / 180s workflow / 300s background)", () => {
+      // chatTurn raised 30s -> 90s: a from-scratch draft on the gateway
+      // model runs ~37-45s, past the old 30s ceiling. See the abort guard
+      // in experience-ai-chat.service.ts and TIME_BUDGET_MS.chatTurn doc.
+      expect(TIME_BUDGET_MS.chatTurn).toBe(90_000)
       expect(TIME_BUDGET_MS.multiStepWorkflow).toBe(180_000)
       expect(TIME_BUDGET_MS.backgroundAutoEnrich).toBe(300_000)
     })
@@ -86,7 +89,7 @@ describe("budgets (U11)", () => {
 
   describe("getTimeBudgetMs", () => {
     it("returns the cap for a named shape", () => {
-      expect(getTimeBudgetMs("chatTurn")).toBe(30_000)
+      expect(getTimeBudgetMs("chatTurn")).toBe(90_000)
       expect(getTimeBudgetMs("multiStepWorkflow")).toBe(180_000)
       expect(getTimeBudgetMs("backgroundAutoEnrich")).toBe(300_000)
     })

--- a/apps/admin/src/services/experience-ai/experience-ai-chat.service.test.ts
+++ b/apps/admin/src/services/experience-ai/experience-ai-chat.service.test.ts
@@ -118,23 +118,29 @@ function makeFakePrisma(opts: FakePrismaOpts = {}) {
     updatedAt: new Date("2026-04-15T12:00:00.000Z"),
   }
   const locale = {
-    // applyChatMutation reads the pre-image once (outside tx), then
-    // re-fetches the updated row once (inside tx after updateMany).
+    // applyChatMutation reads the pre-image once (outside tx), then writes
+    // via a plain `update` inside the locked tx (the FOR UPDATE + text
+    // guard replaced the old updateMany-on-updatedAt path).
     findUniqueOrThrow: vi
       .fn()
       .mockResolvedValueOnce(preImage)
       .mockResolvedValue(afterRow),
-    // Optimistic-concurrency guard write — matches one row by default.
     updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     update: vi.fn().mockResolvedValue(afterRow),
   }
 
   const contentRevision = { create: vi.fn() }
+  // applyChatMutation's optimistic-concurrency token: a full-precision
+  // `updated_at::text` read (baseline outside tx, then the FOR UPDATE
+  // locked read inside tx). Both resolve to the same value by default so
+  // the guard passes.
+  const $queryRaw = vi.fn().mockResolvedValue([{ u: "2026-04-15 12:00:00+00" }])
   const $transaction = vi.fn(async (fn: unknown) =>
     typeof fn === "function"
       ? (fn as (txc: unknown) => Promise<unknown>)({
           experienceLocale: locale,
           contentRevision,
+          $queryRaw,
         })
       : fn,
   )
@@ -144,6 +150,7 @@ function makeFakePrisma(opts: FakePrismaOpts = {}) {
     experienceChatMessage: message,
     experienceLocale: locale,
     contentRevision,
+    $queryRaw,
     $transaction,
   } as unknown as PrismaClient & {
     experienceChatThread: typeof thread

--- a/apps/admin/src/services/experience.service.test.ts
+++ b/apps/admin/src/services/experience.service.test.ts
@@ -29,12 +29,17 @@ function mockPrisma() {
     findMany: vi.fn(),
     update: vi.fn(),
   }
+  // Shared across the top-level client and the transaction client so the
+  // applyChatMutation baseline read and the FOR UPDATE locked read both
+  // resolve through the same mock (call order: baseline, then locked).
+  const $queryRaw = vi.fn()
   return {
     contentRevision,
     experience,
     experienceLocale,
+    $queryRaw,
     $transaction: vi.fn((fn: (tx: unknown) => Promise<unknown>) =>
-      fn({ contentRevision, experience, experienceLocale }),
+      fn({ contentRevision, experience, experienceLocale, $queryRaw }),
     ),
   } as unknown as Parameters<
     (typeof ExperienceService)["prototype"]["list"]
@@ -536,11 +541,22 @@ describe("ExperienceService", () => {
       experience: { ownerId: "alice", archivedAt: null, isTemplate: false },
     }
 
+    // Full-precision (microsecond) updated_at text — the value Postgres
+    // returns from `updated_at::text` for a bare TIMESTAMPTZ column. The
+    // guard must compare this verbatim, never a millisecond-truncated Date.
+    const MICRO_TS = "2026-04-15 12:00:00.336275+00"
+
     it("creates a HISTORICAL contentRevision + updates the locale in one $transaction (happy path)", async () => {
-      prisma.experienceLocale.findUniqueOrThrow
-        .mockResolvedValueOnce(baseRow) // pre-image read
-        .mockResolvedValueOnce({ ...baseRow, title: "Chat Title" }) // re-fetch
-      prisma.experienceLocale.updateMany.mockResolvedValueOnce({ count: 1 })
+      prisma.experienceLocale.findUniqueOrThrow.mockResolvedValueOnce(baseRow) // pre-image read
+      // Baseline read, then the FOR UPDATE locked read — same full-precision
+      // text, so the optimistic guard passes.
+      prisma.$queryRaw
+        .mockResolvedValueOnce([{ u: MICRO_TS }])
+        .mockResolvedValueOnce([{ u: MICRO_TS }])
+      prisma.experienceLocale.update.mockResolvedValueOnce({
+        ...baseRow,
+        title: "Chat Title",
+      })
 
       const result = await service.applyChatMutation({
         input: { id: "loc-1", title: "Chat Title" },
@@ -560,14 +576,17 @@ describe("ExperienceService", () => {
           }),
         }),
       )
-      // The write went through the conditional updateMany (concurrency
-      // guard), keyed on the pre-image updatedAt.
-      expect(prisma.experienceLocale.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: "loc-1", updatedAt: baseRow.updatedAt },
-        }),
+      // The write is a plain update keyed only on id — the row is already
+      // locked + version-verified by the FOR UPDATE guard, and a `updatedAt`
+      // predicate would re-introduce the millisecond-truncation mismatch.
+      expect(prisma.experienceLocale.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "loc-1" } }),
       )
-      expect(prisma.experienceLocale.update).not.toHaveBeenCalled()
+      const updateArg = prisma.experienceLocale.update.mock.calls[0][0] as {
+        where: Record<string, unknown>
+      }
+      expect(updateArg.where).not.toHaveProperty("updatedAt")
+      expect(prisma.experienceLocale.updateMany).not.toHaveBeenCalled()
     })
 
     it("throws ForbiddenError when the principal cannot edit the locale", async () => {
@@ -581,14 +600,15 @@ describe("ExperienceService", () => {
         }),
       ).rejects.toThrow("Forbidden")
       // No write attempted on a forbidden mutation.
-      expect(prisma.experienceLocale.updateMany).not.toHaveBeenCalled()
+      expect(prisma.experienceLocale.update).not.toHaveBeenCalled()
     })
 
     it("strips slug from the update payload (slug is not chat-writable)", async () => {
-      prisma.experienceLocale.findUniqueOrThrow
-        .mockResolvedValueOnce(baseRow)
-        .mockResolvedValueOnce(baseRow)
-      prisma.experienceLocale.updateMany.mockResolvedValueOnce({ count: 1 })
+      prisma.experienceLocale.findUniqueOrThrow.mockResolvedValueOnce(baseRow)
+      prisma.$queryRaw
+        .mockResolvedValueOnce([{ u: MICRO_TS }])
+        .mockResolvedValueOnce([{ u: MICRO_TS }])
+      prisma.experienceLocale.update.mockResolvedValueOnce(baseRow)
 
       await service.applyChatMutation({
         // `slug` is not on ChatMutationInput; the Zod parse must strip it
@@ -598,18 +618,23 @@ describe("ExperienceService", () => {
         reason: "Chat-driven mutation",
       })
 
-      const call = prisma.experienceLocale.updateMany.mock.calls[0][0] as {
+      const call = prisma.experienceLocale.update.mock.calls[0][0] as {
         data: Record<string, unknown>
       }
       expect(call.data).not.toHaveProperty("slug")
       expect(call.data).toHaveProperty("title", "Keep slug")
     })
 
-    it("throws ConcurrentModificationError when the row was modified concurrently (no orphan revision)", async () => {
-      // Pre-image read succeeds, but the conditional updateMany matches 0
-      // rows because updatedAt no longer matches → lost-update guard fires.
+    it("throws ConcurrentModificationError when the row changed concurrently (full-precision text mismatch, no orphan revision)", async () => {
+      // Pre-image read succeeds, but the FOR UPDATE locked read returns a
+      // DIFFERENT full-precision updated_at than the baseline → a concurrent
+      // writer changed the row → lost-update guard fires. (Crucially, this
+      // is a real text difference, NOT the old millisecond-truncation false
+      // positive that fired on every microsecond-stamped row.)
       prisma.experienceLocale.findUniqueOrThrow.mockResolvedValueOnce(baseRow)
-      prisma.experienceLocale.updateMany.mockResolvedValueOnce({ count: 0 })
+      prisma.$queryRaw
+        .mockResolvedValueOnce([{ u: MICRO_TS }]) // baseline
+        .mockResolvedValueOnce([{ u: "2026-04-15 12:00:05.111222+00" }]) // locked (changed)
 
       await expect(
         service.applyChatMutation({
@@ -619,9 +644,11 @@ describe("ExperienceService", () => {
         }),
       ).rejects.toMatchObject({ name: "ConcurrentModificationError" })
 
-      // The throw rolls back the $transaction, so the re-fetch never runs.
-      // (findUniqueOrThrow called once for the pre-image only.)
-      expect(prisma.experienceLocale.findUniqueOrThrow).toHaveBeenCalledTimes(1)
+      // Guard runs BEFORE the revision insert and the write, so the throw
+      // rolls back a transaction that never touched either — no orphan
+      // HISTORICAL revision, no partial update.
+      expect(prisma.contentRevision.create).not.toHaveBeenCalled()
+      expect(prisma.experienceLocale.update).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/admin/src/services/experience.service.ts
+++ b/apps/admin/src/services/experience.service.ts
@@ -660,8 +660,41 @@ export class ExperienceService {
       throw new ForbiddenError()
     }
 
+    // Full-precision optimistic-concurrency token. `experience_locale.
+    // updated_at` is a bare TIMESTAMPTZ (microsecond precision), but Prisma
+    // reads it into a JS Date (millisecond precision) — so comparing
+    // `where updated_at = <Date>` silently fails for any row whose stored
+    // value carries sub-millisecond digits (set by a non-Prisma writer:
+    // now()/raw SQL/import/background enrich), tripping the guard on every
+    // apply. Capture the value as text to preserve full precision; the
+    // guard below compares text-to-text inside the locked transaction.
+    const baselineRows = await this.prisma.$queryRaw<{ u: string }[]>(
+      Prisma.sql`SELECT updated_at::text AS u FROM experience_locale WHERE id = ${parsed.id}`,
+    )
+    const baselineUpdatedAtText = baselineRows[0]?.u ?? null
+
     const { id, ...data } = parsed
     const result = await this.prisma.$transaction(async (tx) => {
+      // Optimistic-concurrency guard with a row lock. `SELECT ... FOR
+      // UPDATE` locks the row for the rest of this transaction so no
+      // writer can slip in between the check and the write. We compare the
+      // CURRENT full-precision `updated_at::text` against the baseline
+      // captured above (full precision, same `::text` form): if they
+      // differ, a concurrent manual save or chat turn changed the row
+      // since we read it, so we throw — surfacing "reload and retry"
+      // instead of clobbering the other writer (lost update). Throwing
+      // rolls back the transaction, so no orphan HISTORICAL revision row
+      // is left behind.
+      const lockedRows = await tx.$queryRaw<{ u: string }[]>(
+        Prisma.sql`SELECT updated_at::text AS u FROM experience_locale WHERE id = ${id} FOR UPDATE`,
+      )
+      if (
+        lockedRows.length === 0 ||
+        lockedRows[0]?.u !== baselineUpdatedAtText
+      ) {
+        throw new ConcurrentModificationError("ExperienceLocale", id)
+      }
+
       await tx.contentRevision.create({
         data: {
           entityType: "ExperienceLocale",
@@ -674,26 +707,12 @@ export class ExperienceService {
         },
       })
 
-      // Optimistic-concurrency guard: the write only lands if the row's
-      // `updatedAt` still matches the pre-image we snapshotted above. A
-      // concurrent manual save (or another chat turn) between read and
-      // write bumps `updatedAt`, the conditional match returns count 0,
-      // and we throw so the chat turn surfaces "reload and retry" instead
-      // of silently clobbering the other writer's change (lost update).
-      // Throwing rolls back the transaction, so no orphan HISTORICAL
-      // revision row is left behind.
-      const { count } = await tx.experienceLocale.updateMany({
-        where: { id, updatedAt: existing.updatedAt },
-        data: data as Prisma.ExperienceLocaleUncheckedUpdateInput,
-      })
-      if (count === 0) {
-        throw new ConcurrentModificationError("ExperienceLocale", id)
-      }
-
-      // Re-fetch the freshly-updated row for the return value
-      // (`updateMany` returns a count, not the row).
-      const updated = await tx.experienceLocale.findUniqueOrThrow({
+      // Row is locked and version-verified above, so a plain update is
+      // safe — no `updatedAt` predicate (which would re-introduce the
+      // millisecond-truncation mismatch).
+      const updated = await tx.experienceLocale.update({
         where: { id },
+        data: data as Prisma.ExperienceLocaleUncheckedUpdateInput,
       })
 
       return { before: existing, after: updated }


### PR DESCRIPTION
Two follow-ups to #1284 (the AI-chat draft timeout fix). Together they green `main` and make AI chat generation actually apply end-to-end.

## 1. Green `main` — budgets test pin

#1284 raised `TIME_BUDGET_MS.chatTurn` 30s → 90s but didn't update `budgets.test.ts`, which pinned the default + `getTimeBudgetMs` accessor to `30_000`. Those two assertions are red on `main` (`forge-ci` `test (@forge/admin)`). Aligned to `90_000`.

## 2. Fix "PAGE CHANGED" — microsecond `updated_at` vs Prisma millisecond Date

After #1284 deployed, AI chat generation produced a valid draft but failed to apply with **"PAGE CHANGED — reload and try again"** on every turn. Production logs:

```
[mastra-chat] event=stream_done buffer_length=3061
[mastra-chat] event=envelope_parsed translated_keys=mutations,localesAffected,reason
[mastra-chat] event=apply_failed name=ConcurrentModificationError ... block_count=7
```

**Root cause.** `ExperienceService.applyChatMutation` guarded its write with `updateMany({ where: { id, updatedAt: existing.updatedAt } })`. `experience_locale.updated_at` is a bare `TIMESTAMPTZ` (microsecond precision), but Prisma reads it into a JS `Date` (millisecond precision). For any row whose stored `updated_at` carries sub-millisecond digits (set by a non-Prisma writer — `now()`, raw SQL, import, background enrich), the truncated JS Date never matches → `count=0` → `ConcurrentModificationError` on **every** apply. (Prisma-written rows are ms-aligned and match, so the bug was intermittent per-locale.) Exposed now because turns finally reach the apply step — before #1284 they timed out at 30s.

Reproduced locally: stored `...336275` → Prisma reads `...336` → `updateMany` `count=0`.

**Fix.** Capture the optimistic token as full-precision `updated_at::text`, and guard inside the transaction with `SELECT ... FOR UPDATE` + a text-to-text compare, then a plain `update` (no `updatedAt` predicate). The row lock closes the check→write race; the text compare is microsecond-safe.

## Tests
- `budgets.test.ts` aligned to 90s.
- `experience.service.test.ts` `applyChatMutation` tests rewritten for the lock + full-precision-text guard (happy path, slug-strip, and a real text-mismatch concurrency case that asserts no orphan revision).
- `experience-ai-chat.service.test.ts` fake prisma updated with `$queryRaw`.
- Full admin suite green (233 files, 3465 tests); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)