### PR TITLE
feat: add subtitle scripture validation

### DIFF
--- a/apps/manager/AGENTS.md
+++ b/apps/manager/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-This app orchestrates AI video enrichment pipelines. Agents working here should understand the full enrichment lifecycle: ingest (Mux) -> transcribe -> translate -> chapters -> metadata -> source artifacts -> sync/hand off through Manager/Admin GraphQL contracts. Transcript and scene embedding generation belong to Mastra; Manager only supplies source artifacts such as transcript and scene-analysis JSON. Subtitle translation/retiming execution also belongs to Mastra; Manager owns job state, optional video context handoff, and Mux subtitle sync. Do not reintroduce Manager-side vector generation, provider-heavy subtitle execution, scripture-context detection, or CMS-specific embedding sync.
+This app orchestrates AI video enrichment pipelines. Agents working here should understand the full enrichment lifecycle: ingest (Mux) -> transcribe -> translate -> chapters -> metadata -> source artifacts -> sync/hand off through Manager/Admin GraphQL contracts. Transcript and scene embedding generation belong to Mastra; Manager only supplies source artifacts such as transcript and scene-analysis JSON. Subtitle translation/retiming execution also belongs to Mastra; Manager owns job state, optional video context handoff, validation summary display, artifact manifests, and Mux subtitle sync. Do not reintroduce Manager-side vector generation, provider-heavy subtitle execution, scripture-context detection, subtitle scripture validation, Bible-source calls, or CMS-specific embedding sync.
 
 ## Key files
 

--- a/apps/manager/CLAUDE.md
+++ b/apps/manager/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this app does
 
-AI video enrichment pipeline dashboard. Ingests video assets via Mux, runs enrichment workflows (transcription, translation, chapters, metadata, and source-artifact generation), stores artifacts in Railway S3-compatible Object Storage, and syncs results through Manager/Admin GraphQL contracts. Background transcript, scene, and experience embedding generation belongs to Mastra; subtitle translation/retiming execution also belongs to Mastra. Manager supplies source artifacts and optional video context, owns job state, and keeps Mux subtitle sync. Scripture-context detection and gospel-aware subtitle prompt guidance stay in Mastra.
+AI video enrichment pipeline dashboard. Ingests video assets via Mux, runs enrichment workflows (transcription, translation, chapters, metadata, and source-artifact generation), stores artifacts in Railway S3-compatible Object Storage, and syncs results through Manager/Admin GraphQL contracts. Background transcript, scene, and experience embedding generation belongs to Mastra; subtitle translation/retiming execution also belongs to Mastra. Manager supplies source artifacts and optional video context, owns job state, displays returned validation summaries, records validation artifacts in manifests, and keeps Mux subtitle sync. Scripture-context detection, gospel-aware subtitle prompt guidance, subtitle scripture accuracy validation, and optional Bible-source calls stay in Mastra.
 
 ## Source
 

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
@@ -78,6 +78,9 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
       artifacts: {
         transcript: { kind: "downloadable" },
         subtitles: { kind: "downloadable" },
+        "subtitles-fr": { kind: "downloadable" },
+        "translation-fr": { kind: "downloadable" },
+        "subtitle-validation-fr": { kind: "downloadable" },
         chapters: { kind: "downloadable" },
         metadata: { kind: "downloadable" },
         embeddings: { kind: "downloadable" },
@@ -187,6 +190,9 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
     expect(updatedArtifacts).not.toHaveProperty("metadata")
     expect(updatedArtifacts).not.toHaveProperty("embeddings")
     expect(updatedArtifacts).not.toHaveProperty("muxSync")
+    expect(updatedArtifacts).not.toHaveProperty("subtitles-fr")
+    expect(updatedArtifacts).not.toHaveProperty("translation-fr")
+    expect(updatedArtifacts).not.toHaveProperty("subtitle-validation-fr")
     expect(updatedArtifacts).not.toHaveProperty(
       "transcriptionRouting.data.finalProvider",
     )

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
@@ -42,7 +42,11 @@ function pruneArtifactsForTranscriptionRerun(
   delete nextArtifacts.muxSync
 
   for (const key of Object.keys(nextArtifacts)) {
-    if (key.startsWith("subtitles-") || key.startsWith("translation-")) {
+    if (
+      key.startsWith("subtitles-") ||
+      key.startsWith("translation-") ||
+      key.startsWith("subtitle-validation-")
+    ) {
       delete nextArtifacts[key]
     }
   }

--- a/apps/manager/src/features/jobs/live-job-steps-table.tsx
+++ b/apps/manager/src/features/jobs/live-job-steps-table.tsx
@@ -27,6 +27,7 @@ import type {
   MuxSyncComparison,
   RequestedTranscriptionProvider,
   StepStatus,
+  SubtitleValidationStepSummary,
   TranscriptionRoutingReport,
   WorkflowStepName,
 } from "@/types/job"
@@ -197,6 +198,67 @@ function getMastraInlineSummary(
   return mastra.status
     ? `Mastra run ${mastra.runId} (${mastra.status}).`
     : `Mastra run ${mastra.runId}.`
+}
+
+function getSubtitleValidationInlineSummary(
+  validation: SubtitleValidationStepSummary | undefined,
+): string | null {
+  if (!validation || validation.languagesChecked === 0) {
+    return null
+  }
+
+  if (validation.needsReviewCount > 0) {
+    return `${validation.needsReviewCount} scripture validation finding${
+      validation.needsReviewCount === 1 ? "" : "s"
+    } need review.`
+  }
+
+  if (validation.warningCount > 0) {
+    return `${validation.warningCount} scripture validation warning${
+      validation.warningCount === 1 ? "" : "s"
+    }.`
+  }
+
+  if (validation.unavailableLanguages.length > 0) {
+    return `Scripture validation unavailable for ${validation.unavailableLanguages.join(", ")}.`
+  }
+
+  if (validation.modelOnlyLanguages.length > 0) {
+    return `Scripture validation passed with model knowledge for ${validation.modelOnlyLanguages.join(", ")}.`
+  }
+
+  return "Scripture validation passed."
+}
+
+function SubtitleValidationInlineDetails({
+  validation,
+}: {
+  validation: SubtitleValidationStepSummary
+}) {
+  return (
+    <>
+      <p className="jobs-step-detail-summary">Subtitle scripture validation</p>
+      <ul className="jobs-step-detail-list">
+        {validation.results.map((result) => (
+          <li
+            key={`subtitle-validation-${result.lang}`}
+            className="jobs-step-detail-item"
+          >
+            <strong>{result.lang}</strong>
+            {`: ${result.verdict} (${result.basis}, confidence ${Math.round(
+              result.confidence * 100,
+            )}%)`}
+            {result.fallbackReason
+              ? `; fallback ${result.fallbackReason}`
+              : null}
+            {result.unavailableReason
+              ? `; unavailable ${result.unavailableReason}`
+              : null}
+          </li>
+        ))}
+      </ul>
+    </>
+  )
 }
 
 function MastraStepInlineDetails({
@@ -760,6 +822,10 @@ export function LiveJobStepsTable({
                 step.name === "translation" || step.name === "embeddings"
                   ? step.details?.mastra
                   : undefined
+              const subtitleValidation =
+                step.name === "translation"
+                  ? step.details?.subtitleValidation
+                  : undefined
               const hasMastraDetails = mastraCorrelation != null
               const hasSceneEmbeddingDetails = hasSceneEmbeddingSyncIssue(
                 sceneEmbeddingSyncReport,
@@ -769,7 +835,9 @@ export function LiveJobStepsTable({
                 (hasSceneEmbeddingDetails || hasMastraDetails)
               const hasTranslationDetails =
                 step.name === "translation" &&
-                (translationFailures.length > 0 || hasMastraDetails)
+                (translationFailures.length > 0 ||
+                  hasMastraDetails ||
+                  subtitleValidation != null)
               const hasTranscriptionDetails =
                 step.name === "transcription" &&
                 (transcriptionRoutingReport != null || rerunError != null)
@@ -780,6 +848,8 @@ export function LiveJobStepsTable({
               const translationFailureSummary =
                 getTranslationFailureSummary(translationFailures)
               const mastraSummary = getMastraInlineSummary(mastraCorrelation)
+              const subtitleValidationSummary =
+                getSubtitleValidationInlineSummary(subtitleValidation)
               const transcriptionSummary =
                 transcriptionRoutingReport != null
                   ? `Final provider: ${
@@ -826,6 +896,17 @@ export function LiveJobStepsTable({
                   <span className="jobs-step-inline-summary-note">
                     {translationFailureSummary}
                   </span>
+                ) : subtitleValidationSummary ? (
+                  <span
+                    className={
+                      subtitleValidation?.highestVerdict === "needs_review" ||
+                      subtitleValidation?.highestVerdict === "warning"
+                        ? "jobs-step-inline-summary-text"
+                        : "jobs-step-inline-summary-note"
+                    }
+                  >
+                    {subtitleValidationSummary}
+                  </span>
                 ) : mastraSummary ? (
                   <span className="jobs-step-inline-summary-note">
                     {mastraSummary}
@@ -835,6 +916,11 @@ export function LiveJobStepsTable({
                   <>
                     {mastraCorrelation ? (
                       <MastraStepInlineDetails mastra={mastraCorrelation} />
+                    ) : null}
+                    {subtitleValidation ? (
+                      <SubtitleValidationInlineDetails
+                        validation={subtitleValidation}
+                      />
                     ) : null}
                     {translationFailureSummary ? (
                       <>

--- a/apps/manager/src/features/jobs/review-player/load-job-review-context.test.ts
+++ b/apps/manager/src/features/jobs/review-player/load-job-review-context.test.ts
@@ -147,6 +147,99 @@ describe("loadJobReviewContext", () => {
     })
   })
 
+  it("exposes subtitle validation summaries and artifacts for review automation", async () => {
+    const result = await loadJobReviewContext(
+      buildJob({
+        artifacts: {
+          metadata: { kind: "downloadable" },
+          chapters: { kind: "downloadable" },
+          "subtitles-fr": { kind: "downloadable" },
+          "subtitle-validation-fr": { kind: "downloadable" },
+        },
+        steps: [
+          {
+            name: "translation",
+            status: "completed",
+            retries: 0,
+            details: {
+              subtitleValidation: {
+                highestVerdict: "needs_review",
+                languagesChecked: 1,
+                modelOnlyLanguages: ["fr"],
+                unavailableLanguages: [],
+                warningCount: 0,
+                needsReviewCount: 1,
+                results: [
+                  {
+                    lang: "fr",
+                    verdict: "needs_review",
+                    basis: "model_knowledge",
+                    confidence: 0.82,
+                    checkedReferenceCount: 1,
+                    warningCount: 0,
+                    needsReviewCount: 1,
+                    fallbackReason: "provider_config_missing",
+                    unavailableReason: "artifact_write_failed",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }),
+      {
+        loadVideoReviewSource: async () => ({
+          subtitles: [],
+        }),
+        loadMuxSubtitleTracks: async () => [],
+        readArtifactJson: async (_assetId, artifactKey) => {
+          if (artifactKey === "metadata") return { title: "Generated title" }
+          if (artifactKey === "chapters") return { chapters: [] }
+          throw new Error(`Unexpected artifact ${artifactKey}`)
+        },
+        buildArtifactHref: (jobId, artifactKey) =>
+          `/api/jobs/${jobId}/artifacts/${artifactKey}`,
+      },
+    )
+
+    expect(result.status).toBe("ready")
+    if (result.status !== "ready") {
+      throw new Error("expected ready result")
+    }
+
+    expect(result.context.after.validation).toEqual({
+      status: "available",
+      summary: {
+        highestVerdict: "needs_review",
+        languagesChecked: 1,
+        modelOnlyLanguages: ["fr"],
+        unavailableLanguages: [],
+        warningCount: 0,
+        needsReviewCount: 1,
+        results: [
+          {
+            lang: "fr",
+            verdict: "needs_review",
+            basis: "model_knowledge",
+            confidence: 0.82,
+            checkedReferenceCount: 1,
+            warningCount: 0,
+            needsReviewCount: 1,
+            fallbackReason: "provider_config_missing",
+            unavailableReason: "artifact_write_failed",
+          },
+        ],
+      },
+      artifacts: [
+        {
+          key: "subtitle-validation-fr",
+          href: "/api/jobs/job-1/artifacts/subtitle-validation-fr",
+          languageCode: "fr",
+        },
+      ],
+    })
+  })
+
   it("loads mock review sources without calling live CMS or Mux", async () => {
     const mockState = cloneMockCmsSeed(DEFAULT_MOCK_CMS_SEED)
 

--- a/apps/manager/src/features/jobs/review-player/load-job-review-context.ts
+++ b/apps/manager/src/features/jobs/review-player/load-job-review-context.ts
@@ -10,6 +10,8 @@ import type {
   ReviewChapterTrack,
   ReviewMetadataDomain,
   ReviewMetadataValue,
+  ReviewSubtitleValidationArtifact,
+  ReviewSubtitleValidationDomain,
   ReviewTextTrack,
 } from "./review-player-types"
 
@@ -193,6 +195,51 @@ function buildGeneratedChapterTrack(
   }
 }
 
+function getSubtitleValidationArtifacts(
+  job: JobRecord,
+  buildArtifactHref: (jobId: string, artifactKey: string) => string,
+): ReviewSubtitleValidationArtifact[] {
+  return Object.entries(job.artifacts)
+    .filter(
+      ([key, value]) =>
+        value.kind === "downloadable" && key.startsWith("subtitle-validation-"),
+    )
+    .map(([key]) => {
+      const languageCode = key
+        .slice("subtitle-validation-".length)
+        .toLowerCase()
+
+      return {
+        key,
+        href: buildArtifactHref(job.id, key),
+        languageCode,
+      }
+    })
+    .sort((left, right) => left.languageCode.localeCompare(right.languageCode))
+}
+
+function getSubtitleValidationDomain(
+  job: JobRecord,
+  buildArtifactHref: (jobId: string, artifactKey: string) => string,
+): ReviewSubtitleValidationDomain {
+  const summary = job.steps.find((step) => step.name === "translation")?.details
+    ?.subtitleValidation
+  const artifacts = getSubtitleValidationArtifacts(job, buildArtifactHref)
+
+  if (!summary) {
+    return {
+      status: "unavailable",
+      reason: artifacts.length > 0 ? "summary_missing" : "artifact_missing",
+    }
+  }
+
+  return {
+    status: "available",
+    summary,
+    artifacts,
+  }
+}
+
 function buildMetadataDomain(value: unknown): ReviewMetadataDomain {
   if (!isRecord(value)) {
     return {
@@ -331,6 +378,7 @@ export async function loadJobReviewContext(
   )
   const afterTracks = buildGeneratedSubtitleTracks(job, buildArtifactHref)
   const afterChapterTrack = buildGeneratedChapterTrack(job, buildArtifactHref)
+  const afterValidation = getSubtitleValidationDomain(job, buildArtifactHref)
 
   let afterMetadata: ReviewMetadataDomain
   if (job.artifacts.metadata?.kind !== "downloadable") {
@@ -447,6 +495,7 @@ export async function loadJobReviewContext(
               },
         metadata: afterMetadata,
         chapters: afterChapters,
+        validation: afterValidation,
       },
       compare: {},
     },

--- a/apps/manager/src/features/jobs/review-player/review-context-refresh-key.test.ts
+++ b/apps/manager/src/features/jobs/review-player/review-context-refresh-key.test.ts
@@ -101,6 +101,47 @@ describe("getReviewContextRefreshKey", () => {
     )
   })
 
+  it("changes when subtitle validation artifacts or summaries change", () => {
+    const before = buildJob()
+    const after = buildJob({
+      artifacts: {
+        "subtitle-validation-fr": { kind: "downloadable" },
+      },
+      steps: [
+        {
+          name: "translation",
+          status: "completed",
+          retries: 0,
+          details: {
+            subtitleValidation: {
+              highestVerdict: "warning",
+              languagesChecked: 1,
+              modelOnlyLanguages: ["fr"],
+              unavailableLanguages: [],
+              warningCount: 1,
+              needsReviewCount: 0,
+              results: [
+                {
+                  lang: "fr",
+                  verdict: "warning",
+                  basis: "model_knowledge",
+                  confidence: 0.73,
+                  checkedReferenceCount: 1,
+                  warningCount: 1,
+                  needsReviewCount: 0,
+                },
+              ],
+            },
+          },
+        },
+      ],
+    })
+
+    expect(getReviewContextRefreshKey(after)).not.toBe(
+      getReviewContextRefreshKey(before),
+    )
+  })
+
   it("changes when playback identity or terminal status changes", () => {
     const before = buildJob()
     const after = buildJob({

--- a/apps/manager/src/features/jobs/review-player/review-context-refresh-key.ts
+++ b/apps/manager/src/features/jobs/review-player/review-context-refresh-key.ts
@@ -5,6 +5,7 @@ const REVIEW_RELEVANT_STEPS = new Set<WorkflowStepName>([
   "subtitle_post_process",
   "chapters",
   "metadata",
+  "translation",
   "mux_upload",
 ])
 
@@ -40,6 +41,7 @@ function getRelevantArtifactKey(job: JobRecord): string {
         artifactKey === "chapters-vtt" ||
         artifactKey === "muxSync" ||
         artifactKey === "subtitles" ||
+        artifactKey.startsWith("subtitle-validation-") ||
         artifactKey.startsWith("subtitles-")
       )
     })
@@ -63,6 +65,7 @@ function getRelevantStepKey(job: JobRecord): string {
         step.startedAt ?? "",
         step.finishedAt ?? "",
         step.error ?? "",
+        getStableValueKey(step.details),
       ].join(":"),
     )
     .join("|")

--- a/apps/manager/src/features/jobs/review-player/review-player-types.ts
+++ b/apps/manager/src/features/jobs/review-player/review-player-types.ts
@@ -1,4 +1,8 @@
-import type { MuxSyncComparison, SceneEmbeddingSyncReport } from "@/types/job"
+import type {
+  MuxSyncComparison,
+  SceneEmbeddingSyncReport,
+  SubtitleValidationStepSummary,
+} from "@/types/job"
 
 export type ReviewMode = "after" | "before"
 
@@ -81,10 +85,28 @@ export type ReviewChaptersDomain =
       message: string
     }
 
+export type ReviewSubtitleValidationArtifact = {
+  key: string
+  href: string
+  languageCode: string
+}
+
+export type ReviewSubtitleValidationDomain =
+  | {
+      status: "available"
+      summary: SubtitleValidationStepSummary
+      artifacts: ReviewSubtitleValidationArtifact[]
+    }
+  | {
+      status: "unavailable"
+      reason: string
+    }
+
 export type JobReviewSnapshot = {
   subtitles: ReviewSubtitleDomain
   metadata: ReviewMetadataDomain
   chapters: ReviewChaptersDomain
+  validation?: ReviewSubtitleValidationDomain
 }
 
 export type JobReviewContext = {

--- a/apps/manager/src/lib/job-artifacts.test.ts
+++ b/apps/manager/src/lib/job-artifacts.test.ts
@@ -34,6 +34,11 @@ describe("job artifact helpers", () => {
       ext: "json",
       contentType: "application/json",
     })
+    expect(resolveJobArtifactDescriptor("subtitle-validation-ja")).toEqual({
+      artifactType: "subtitle-validation-ja",
+      ext: "json",
+      contentType: "application/json",
+    })
   })
 
   it("resolves audio review artifact descriptors", () => {
@@ -82,6 +87,7 @@ describe("job artifact helpers", () => {
       getArtifactsForStep("translation", "job-1", {
         "translation-es": { kind: "downloadable" },
         "subtitles-es": { kind: "downloadable" },
+        "subtitle-validation-es": { kind: "downloadable" },
         "translation-ar": { kind: "downloadable" },
         materialization: {
           kind: "metadata",
@@ -93,6 +99,11 @@ describe("job artifact helpers", () => {
         key: "subtitles-es",
         label: "Subtitles es",
         url: "/api/jobs/job-1/artifacts/subtitles-es",
+      },
+      {
+        key: "subtitle-validation-es",
+        label: "Subtitle validation es",
+        url: "/api/jobs/job-1/artifacts/subtitle-validation-es",
       },
       {
         key: "translation-ar",

--- a/apps/manager/src/lib/job-artifacts.ts
+++ b/apps/manager/src/lib/job-artifacts.ts
@@ -162,6 +162,10 @@ function buildDynamicArtifactLabel(logicalKey: string): string {
     return `Translation ${logicalKey.slice("translation-".length)}`
   }
 
+  if (logicalKey.startsWith("subtitle-validation-")) {
+    return `Subtitle validation ${logicalKey.slice("subtitle-validation-".length)}`
+  }
+
   if (SMART_CROP_PREVIEW_FRAME_PATTERN.test(logicalKey)) {
     return `Smart Crop preview frame ${logicalKey.slice(-3)}`
   }
@@ -195,6 +199,14 @@ function buildTranslationArtifactDescriptor(
     }
   }
 
+  if (logicalKey.startsWith("subtitle-validation-")) {
+    return {
+      artifactType: logicalKey,
+      ext: "json",
+      contentType: "application/json",
+    }
+  }
+
   return null
 }
 
@@ -220,6 +232,22 @@ export function resolveJobArtifactDescriptor(
     buildTranslationArtifactDescriptor(logicalKey) ??
     buildSmartCropPreviewFrameDescriptor(logicalKey)
   )
+}
+
+function getTranslationArtifactSortRank(logicalKey: string): number {
+  if (logicalKey.startsWith("subtitles-")) {
+    return 0
+  }
+
+  if (logicalKey.startsWith("subtitle-validation-")) {
+    return 1
+  }
+
+  if (logicalKey.startsWith("translation-")) {
+    return 2
+  }
+
+  return 3
 }
 
 export function buildJobArtifactHref(
@@ -267,9 +295,16 @@ export function getArtifactsForStep(
           value.kind === "downloadable" &&
           (key.startsWith("subtitles-") ||
             key.startsWith("translation-") ||
+            key.startsWith("subtitle-validation-") ||
             key === "translations"),
       )
-      .sort(([left], [right]) => left.localeCompare(right))
+      .sort(([left], [right]) => {
+        const leftRank = getTranslationArtifactSortRank(left)
+        const rightRank = getTranslationArtifactSortRank(right)
+        return leftRank === rightRank
+          ? left.localeCompare(right)
+          : leftRank - rightRank
+      })
       .map(([key]) => ({
         key,
         label: formatJobArtifactLabel(key),

--- a/apps/manager/src/lib/state.test.ts
+++ b/apps/manager/src/lib/state.test.ts
@@ -531,6 +531,80 @@ describe("toJobRecord", () => {
     })
   })
 
+  it("preserves subtitle validation summaries on read-back", () => {
+    const record = toJobRecord({
+      documentId: "job-validation",
+      muxAssetId: "asset-1",
+      muxPlaybackId: "playback-1",
+      languages: ["es"],
+      status: "completed",
+      currentStep: null,
+      retries: 0,
+      createdAt: "2026-06-16T00:00:00.000Z",
+      updatedAt: "2026-06-16T00:01:00.000Z",
+      startedAt: "2026-06-16T00:00:10.000Z",
+      completedAt: "2026-06-16T00:00:20.000Z",
+      artifacts: {},
+      errors: [],
+      steps: [
+        {
+          name: "translation",
+          status: "completed",
+          retries: 0,
+          startedAt: "2026-06-16T00:00:10.000Z",
+          finishedAt: "2026-06-16T00:00:20.000Z",
+          error: null,
+          details: {
+            subtitleValidation: {
+              highestVerdict: "needs_review",
+              languagesChecked: 1,
+              modelOnlyLanguages: ["es"],
+              unavailableLanguages: [],
+              warningCount: 0,
+              needsReviewCount: 1,
+              results: [
+                {
+                  lang: "es",
+                  verdict: "needs_review",
+                  basis: "model_knowledge",
+                  confidence: 0.72,
+                  checkedReferenceCount: 1,
+                  warningCount: 0,
+                  needsReviewCount: 1,
+                  fallbackReason: "provider_config_missing",
+                  unsafePassageText: "must not round-trip",
+                },
+              ],
+            },
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof toJobRecord>[0])
+
+    expect(record.steps[0]?.details).toEqual({
+      subtitleValidation: {
+        highestVerdict: "needs_review",
+        languagesChecked: 1,
+        modelOnlyLanguages: ["es"],
+        unavailableLanguages: [],
+        warningCount: 0,
+        needsReviewCount: 1,
+        results: [
+          {
+            lang: "es",
+            verdict: "needs_review",
+            basis: "model_knowledge",
+            confidence: 0.72,
+            checkedReferenceCount: 1,
+            warningCount: 0,
+            needsReviewCount: 1,
+            fallbackReason: "provider_config_missing",
+          },
+        ],
+      },
+    })
+  })
+
   it("promotes the related CMS video document id when present", () => {
     expect(
       toJobRecord({

--- a/apps/manager/src/lib/state.ts
+++ b/apps/manager/src/lib/state.ts
@@ -14,6 +14,7 @@ import {
   mergeShortsReport,
   type ShortsReportPatch,
 } from "@/lib/shorts-report"
+import { normalizeSubtitleValidationStepSummary } from "@/lib/subtitle-validation"
 import { buildInitialSteps } from "@/lib/workflow-steps"
 import type {
   JobArtifactEntry,
@@ -439,6 +440,7 @@ function normalizeStepDetails(raw: unknown): JobStepDetails | undefined {
 
   const candidate = raw as {
     languageResults?: unknown
+    subtitleValidation?: unknown
     mastra?: unknown
     progress?: unknown
     message?: unknown
@@ -453,9 +455,13 @@ function normalizeStepDetails(raw: unknown): JobStepDetails | undefined {
   const message =
     typeof candidate.message === "string" ? candidate.message : undefined
   const mastra = normalizeMastraStepCorrelation(candidate.mastra)
+  const subtitleValidation = normalizeSubtitleValidationStepSummary(
+    candidate.subtitleValidation,
+  )
 
   if (
     languageResults.length === 0 &&
+    subtitleValidation === undefined &&
     mastra === undefined &&
     progress === undefined &&
     !message
@@ -465,6 +471,7 @@ function normalizeStepDetails(raw: unknown): JobStepDetails | undefined {
 
   return {
     ...(languageResults.length > 0 ? { languageResults } : {}),
+    ...(subtitleValidation !== undefined ? { subtitleValidation } : {}),
     ...(mastra !== undefined ? { mastra } : {}),
     ...(progress !== undefined ? { progress } : {}),
     ...(message !== undefined ? { message } : {}),

--- a/apps/manager/src/lib/subtitle-validation.ts
+++ b/apps/manager/src/lib/subtitle-validation.ts
@@ -1,0 +1,142 @@
+import { z } from "zod"
+
+export const SUBTITLE_VALIDATION_VERDICTS = [
+  "pass",
+  "warning",
+  "needs_review",
+  "unavailable",
+] as const
+
+export const SUBTITLE_VALIDATION_BASES = [
+  "model_knowledge",
+  "target_bible_text",
+  "unavailable",
+] as const
+
+export const SUBTITLE_VALIDATION_FALLBACK_REASONS = [
+  "provider_config_missing",
+  "provider_auth_failed",
+  "provider_failed",
+  "provider_invalid_output",
+  "bible_mapping_missing",
+  "reference_unsupported",
+  "provider_rate_limited",
+] as const
+
+export const SubtitleValidationSummarySchema = z
+  .object({
+    verdict: z.enum(SUBTITLE_VALIDATION_VERDICTS),
+    basis: z.enum(SUBTITLE_VALIDATION_BASES),
+    confidence: z.number().min(0).max(1),
+    checkedReferenceCount: z.number().int().nonnegative(),
+    warningCount: z.number().int().nonnegative(),
+    needsReviewCount: z.number().int().nonnegative(),
+    fallbackReason: z.enum(SUBTITLE_VALIDATION_FALLBACK_REASONS).optional(),
+    unavailableReason: z.string().min(1).max(80).optional(),
+  })
+  .strict()
+
+export type SubtitleValidationSummary = z.infer<
+  typeof SubtitleValidationSummarySchema
+>
+export type SubtitleValidationVerdict =
+  (typeof SUBTITLE_VALIDATION_VERDICTS)[number]
+export type SubtitleValidationBasis = (typeof SUBTITLE_VALIDATION_BASES)[number]
+
+export type SubtitleValidationLanguageSummary = SubtitleValidationSummary & {
+  lang: string
+}
+
+export type SubtitleValidationStepSummary = {
+  highestVerdict: SubtitleValidationVerdict
+  languagesChecked: number
+  modelOnlyLanguages: string[]
+  unavailableLanguages: string[]
+  warningCount: number
+  needsReviewCount: number
+  results: SubtitleValidationLanguageSummary[]
+}
+
+function normalizeSubtitleValidationLanguageSummary(
+  raw: unknown,
+): SubtitleValidationLanguageSummary | null {
+  if (typeof raw !== "object" || raw == null || Array.isArray(raw)) {
+    return null
+  }
+  const candidate = raw as { lang?: unknown }
+  if (typeof candidate.lang !== "string") {
+    return null
+  }
+  const source = raw as Record<string, unknown>
+  const summary = {
+    verdict: source.verdict,
+    basis: source.basis,
+    confidence: source.confidence,
+    checkedReferenceCount: source.checkedReferenceCount,
+    warningCount: source.warningCount,
+    needsReviewCount: source.needsReviewCount,
+    fallbackReason: source.fallbackReason,
+    unavailableReason: source.unavailableReason,
+  }
+  const parsed = SubtitleValidationSummarySchema.safeParse(summary)
+  if (!parsed.success) {
+    return null
+  }
+
+  return {
+    lang: candidate.lang,
+    ...parsed.data,
+  }
+}
+
+export function normalizeSubtitleValidationStepSummary(
+  raw: unknown,
+): SubtitleValidationStepSummary | undefined {
+  if (typeof raw !== "object" || raw == null || Array.isArray(raw)) {
+    return undefined
+  }
+  const candidate = raw as {
+    highestVerdict?: unknown
+    languagesChecked?: unknown
+    modelOnlyLanguages?: unknown
+    unavailableLanguages?: unknown
+    warningCount?: unknown
+    needsReviewCount?: unknown
+    results?: unknown
+  }
+  const results = Array.isArray(candidate.results)
+    ? candidate.results
+        .map(normalizeSubtitleValidationLanguageSummary)
+        .filter(
+          (result): result is SubtitleValidationLanguageSummary =>
+            result != null,
+        )
+    : []
+  if (
+    !SUBTITLE_VALIDATION_VERDICTS.includes(
+      candidate.highestVerdict as SubtitleValidationVerdict,
+    ) ||
+    typeof candidate.languagesChecked !== "number" ||
+    !Array.isArray(candidate.modelOnlyLanguages) ||
+    !Array.isArray(candidate.unavailableLanguages) ||
+    typeof candidate.warningCount !== "number" ||
+    typeof candidate.needsReviewCount !== "number" ||
+    results.length === 0
+  ) {
+    return undefined
+  }
+
+  return {
+    highestVerdict: candidate.highestVerdict as SubtitleValidationVerdict,
+    languagesChecked: candidate.languagesChecked,
+    modelOnlyLanguages: candidate.modelOnlyLanguages.filter(
+      (language): language is string => typeof language === "string",
+    ),
+    unavailableLanguages: candidate.unavailableLanguages.filter(
+      (language): language is string => typeof language === "string",
+    ),
+    warningCount: candidate.warningCount,
+    needsReviewCount: candidate.needsReviewCount,
+    results,
+  }
+}

--- a/apps/manager/src/services/mastra-subtitle-enrichment.test.ts
+++ b/apps/manager/src/services/mastra-subtitle-enrichment.test.ts
@@ -138,6 +138,51 @@ describe("launchMastraSubtitleEnrichment", () => {
     })
   })
 
+  it("parses optional subtitle validation artifacts and summaries", async () => {
+    const withValidation = {
+      ...successResult,
+      languages: [
+        {
+          lang: "es",
+          status: "completed",
+          artifactKeys: {
+            vtt: "asset-1/subtitles-es.vtt",
+            json: "asset-1/translation-es.json",
+            validation: "asset-1/subtitle-validation-es.json",
+          },
+          validationSummary: {
+            verdict: "needs_review",
+            basis: "model_knowledge",
+            confidence: 0.72,
+            checkedReferenceCount: 1,
+            warningCount: 0,
+            needsReviewCount: 1,
+            fallbackReason: "provider_config_missing",
+          },
+        },
+      ],
+    }
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ result: withValidation }),
+    )
+
+    await expect(
+      launchMastraSubtitleEnrichment(
+        {
+          assetId: "asset-1",
+          sourceLanguage: "en",
+          targetLanguages: ["es"],
+        },
+        {
+          baseUrl: "https://mastra.internal",
+          bearer: "secret",
+          fetchImpl,
+        },
+      ),
+    ).resolves.toEqual(withValidation)
+  })
+
   it("treats unknown workflow enum values as parse errors", async () => {
     const malformedStatus = vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>

--- a/apps/manager/src/services/mastra-subtitle-enrichment.ts
+++ b/apps/manager/src/services/mastra-subtitle-enrichment.ts
@@ -1,12 +1,17 @@
 import { z } from "zod"
 
 import { env } from "@/config/env"
+import {
+  SubtitleValidationSummarySchema,
+  type SubtitleValidationSummary,
+} from "@/lib/subtitle-validation"
 
 export type LanguageResult = {
   lang: string
   status: "completed" | "failed"
   error?: string
-  artifactKeys?: { vtt: string; json: string }
+  artifactKeys?: { vtt: string; json: string; validation?: string }
+  validationSummary?: SubtitleValidationSummary
 }
 
 export type MastraSubtitleTranslationContext = {
@@ -64,9 +69,11 @@ const LanguageResultSchema = z
       .object({
         vtt: z.string().min(1),
         json: z.string().min(1),
+        validation: z.string().min(1).optional(),
       })
       .strict()
       .optional(),
+    validationSummary: SubtitleValidationSummarySchema.optional(),
   })
   .strict()
 

--- a/apps/manager/src/types/job.ts
+++ b/apps/manager/src/types/job.ts
@@ -5,6 +5,13 @@
 
 export type JobStatus = "pending" | "running" | "completed" | "failed"
 
+import type {
+  SubtitleValidationBasis,
+  SubtitleValidationLanguageSummary,
+  SubtitleValidationStepSummary,
+  SubtitleValidationVerdict,
+} from "@/lib/subtitle-validation"
+
 export type StepStatus =
   | "pending"
   | "running"
@@ -196,6 +203,13 @@ export type TranslationLanguageResult = {
   error?: string
 }
 
+export type {
+  SubtitleValidationBasis,
+  SubtitleValidationLanguageSummary,
+  SubtitleValidationStepSummary,
+  SubtitleValidationVerdict,
+}
+
 export type MastraStepCorrelation = {
   runId: string
   status?: string
@@ -308,6 +322,7 @@ export type TranscriptionRoutingReport = {
 
 export type JobStepDetails = {
   languageResults?: TranslationLanguageResult[]
+  subtitleValidation?: SubtitleValidationStepSummary
   mastra?: MastraStepCorrelation
   // Live crop-worker render progress (0..1) + human-readable message,
   // written throttled by the smart-crop workflow steps.

--- a/apps/manager/src/workflows/videoEnrichment.test.ts
+++ b/apps/manager/src/workflows/videoEnrichment.test.ts
@@ -101,7 +101,17 @@ function subtitleSuccess(
     lang: string
     status: "completed" | "failed"
     error?: string
-    artifactKeys?: { vtt: string; json: string }
+    artifactKeys?: { vtt: string; json: string; validation?: string }
+    validationSummary?: {
+      verdict: "pass" | "warning" | "needs_review" | "unavailable"
+      basis: "model_knowledge" | "target_bible_text" | "unavailable"
+      confidence: number
+      checkedReferenceCount: number
+      warningCount: number
+      needsReviewCount: number
+      fallbackReason?: string
+      unavailableReason?: string
+    }
   }>,
 ) {
   return {
@@ -545,7 +555,24 @@ describe("runVideoEnrichment", () => {
     })
     mastraSubtitleEnrichmentMock.mockResolvedValue(
       subtitleSuccess([
-        { lang: "en", status: "completed" },
+        {
+          lang: "en",
+          status: "completed",
+          artifactKeys: {
+            vtt: "asset-1/subtitles-en.vtt",
+            json: "asset-1/translation-en.json",
+            validation: "asset-1/subtitle-validation-en.json",
+          },
+          validationSummary: {
+            verdict: "needs_review",
+            basis: "model_knowledge",
+            confidence: 0.72,
+            checkedReferenceCount: 1,
+            warningCount: 0,
+            needsReviewCount: 1,
+            fallbackReason: "provider_config_missing",
+          },
+        },
         { lang: "fr", status: "failed", error: "bad glossary" },
       ]),
     )
@@ -696,6 +723,7 @@ describe("runVideoEnrichment", () => {
             transcript: { kind: "downloadable" },
             subtitles: { kind: "downloadable" },
             "subtitles-en": { kind: "downloadable" },
+            "subtitle-validation-en": { kind: "downloadable" },
             chapters: { kind: "downloadable" },
             "chapters-vtt": { kind: "downloadable" },
             metadata: { kind: "downloadable" },
@@ -725,6 +753,7 @@ describe("runVideoEnrichment", () => {
         {
           "subtitles-en": { kind: "downloadable" },
           "translation-en": { kind: "downloadable" },
+          "subtitle-validation-en": { kind: "downloadable" },
         },
       ],
       [
@@ -752,6 +781,26 @@ describe("runVideoEnrichment", () => {
           { lang: "en", status: "completed", error: undefined },
           { lang: "fr", status: "failed", error: "bad glossary" },
         ],
+        subtitleValidation: {
+          highestVerdict: "needs_review",
+          languagesChecked: 1,
+          modelOnlyLanguages: ["en"],
+          unavailableLanguages: [],
+          warningCount: 0,
+          needsReviewCount: 1,
+          results: [
+            {
+              lang: "en",
+              verdict: "needs_review",
+              basis: "model_knowledge",
+              confidence: 0.72,
+              checkedReferenceCount: 1,
+              warningCount: 0,
+              needsReviewCount: 1,
+              fallbackReason: "provider_config_missing",
+            },
+          ],
+        },
         mastra: {
           runId: "subtitle-run-1",
           status: "completed",
@@ -781,10 +830,10 @@ describe("runVideoEnrichment", () => {
         jobId: "job-1",
         assetId: "asset-1",
         muxAssetId: "mux-1",
-        translationResults: [
-          { lang: "en", status: "completed" },
+        translationResults: expect.arrayContaining([
+          expect.objectContaining({ lang: "en", status: "completed" }),
           { lang: "fr", status: "failed", error: "bad glossary" },
-        ],
+        ]),
       }),
     )
     expect(mastraTranscriptEmbeddingsMock).toHaveBeenCalledWith({

--- a/apps/manager/src/workflows/videoEnrichment.ts
+++ b/apps/manager/src/workflows/videoEnrichment.ts
@@ -21,6 +21,8 @@ import type {
   JobStepDetails,
   MuxSyncReport,
   RequestedTranscriptionProvider,
+  SubtitleValidationStepSummary,
+  SubtitleValidationVerdict,
   TranscriptionRoutingReport,
   TranslationLanguageResult,
 } from "@/types/job"
@@ -77,6 +79,10 @@ function buildMastraFailureStepDetails(input: {
       status: result.status,
       error: result.error,
     }))
+    const subtitleValidation = getSubtitleValidationStepSummary(input.languages)
+    if (subtitleValidation) {
+      details.subtitleValidation = subtitleValidation
+    }
   }
 
   return details.mastra || details.languageResults ? details : undefined
@@ -289,12 +295,81 @@ function getTranslationArtifactManifest({
   languages,
 }: SubtitleTranslationStepResult): JobArtifactManifest {
   return buildDownloadableArtifactManifest(
-    languages.flatMap((result) =>
-      result.status === "completed"
-        ? [`subtitles-${result.lang}`, `translation-${result.lang}`]
-        : [],
-    ),
+    languages.flatMap((result) => {
+      if (result.status !== "completed") {
+        return []
+      }
+      return [
+        `subtitles-${result.lang}`,
+        `translation-${result.lang}`,
+        ...(result.artifactKeys?.validation
+          ? [`subtitle-validation-${result.lang}`]
+          : []),
+      ]
+    }),
   )
+}
+
+const VALIDATION_VERDICT_RANK: Record<SubtitleValidationVerdict, number> = {
+  pass: 0,
+  unavailable: 1,
+  warning: 2,
+  needs_review: 3,
+}
+
+function highestSubtitleValidationVerdict(
+  verdicts: SubtitleValidationVerdict[],
+): SubtitleValidationVerdict {
+  return verdicts.reduce<SubtitleValidationVerdict>(
+    (highest, verdict) =>
+      VALIDATION_VERDICT_RANK[verdict] > VALIDATION_VERDICT_RANK[highest]
+        ? verdict
+        : highest,
+    "pass",
+  )
+}
+
+function getSubtitleValidationStepSummary(
+  languages: LanguageResult[],
+): SubtitleValidationStepSummary | undefined {
+  const results = languages.flatMap((result) =>
+    result.validationSummary
+      ? [
+          {
+            lang: result.lang,
+            ...result.validationSummary,
+          },
+        ]
+      : [],
+  )
+  if (results.length === 0) {
+    return undefined
+  }
+
+  return {
+    highestVerdict: highestSubtitleValidationVerdict(
+      results.map((result) => result.verdict),
+    ),
+    languagesChecked: results.length,
+    modelOnlyLanguages: results
+      .filter((result) => result.basis === "model_knowledge")
+      .map((result) => result.lang),
+    unavailableLanguages: results
+      .filter(
+        (result) =>
+          result.basis === "unavailable" || result.verdict === "unavailable",
+      )
+      .map((result) => result.lang),
+    warningCount: results.reduce(
+      (total, result) => total + result.warningCount,
+      0,
+    ),
+    needsReviewCount: results.reduce(
+      (total, result) => total + result.needsReviewCount,
+      0,
+    ),
+    results,
+  }
 }
 
 function getTranslationStepDetails(
@@ -307,9 +382,11 @@ function getTranslationStepDetails(
       error: result.error,
     }),
   )
+  const subtitleValidation = getSubtitleValidationStepSummary(result.languages)
 
   return {
     ...(languageResults.length > 0 ? { languageResults } : {}),
+    ...(subtitleValidation ? { subtitleValidation } : {}),
     mastra: {
       runId: result.mastraRunId,
       status: "completed",

--- a/apps/mastra/AGENTS.md
+++ b/apps/mastra/AGENTS.md
@@ -26,6 +26,10 @@ Full context lives in `apps/mastra/CLAUDE.md`. Keep both files aligned.
 - Owns subtitle enrichment execution through `/forge-subtitle-enrichment`:
   reads Manager transcript artifacts, translates and retimes subtitles, and
   writes Manager-compatible subtitle/translation artifacts to shared storage.
+- Owns subtitle scripture accuracy validation for Bible-story results:
+  runs model-knowledge checks by default, can optionally compare against a
+  configured target-language Bible text source, and writes sanitized
+  Manager-compatible validation artifacts.
 - All embedding workflows share provider-result validation for count alignment,
   finite vector values, and configured dimensions before calling Admin.
 - AI Gateway content embeddings request the normal OpenAI-compatible
@@ -75,6 +79,9 @@ Full context lives in `apps/mastra/CLAUDE.md`. Keep both files aligned.
   Manager may send optional title, label, and Bible-reference context, but
   Mastra owns scripture-context detection, translation prompt guidance, and
   sanitized subtitle artifact provenance.
+- Subtitle scripture accuracy validation also belongs in this runtime. Missing
+  Bible-source configuration must fall back to `model_knowledge` validation,
+  not fail translation or require Manager-side scripture logic.
 - Firecrawl MCP is not the product runtime path. Revisit MCP only for local
   operator/coding-agent convenience or after a clear multi-tool server need.
 - Studio-facing workflows need structured Zod object input schemas on both the

--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -64,6 +64,12 @@ Origin documents:
   runtime. Manager may send optional title, label, and Bible-reference context,
   but Mastra owns scripture-context detection, prompt guidance for Christian
   gospel/Bible-story content, and sanitized subtitle artifact provenance.
+- Subtitle scripture accuracy validation is Mastra-owned too. For translated
+  Bible-story subtitles it should run from model knowledge by default, upgrade
+  to a configured target-language Bible text source when available, and fall
+  back to `basis=model_knowledge` when that source is missing or fails. Store
+  only sanitized validation findings and provenance, never full external Bible
+  passage text.
 - Do not import from `apps/admin`, `apps/manager`, or `apps/auth`; workflow
   contracts are HTTP payloads plus local Zod schemas.
 - Keep service-bearer auth receiver-side. Callers present a bearer; this app
@@ -114,6 +120,11 @@ pnpm --filter @forge/mastra lint
 | `SUBTITLE_ENRICHMENT_MODEL`               | OpenRouter chat model stamp for subtitle translation/retiming. Defaults to `google/gemini-2.5-flash`.                      |
 | `SUBTITLE_ENRICHMENT_TIMEOUT_MS`          | Per-provider-call timeout for subtitle enrichment. Defaults to `120000`, max `300000`.                                     |
 | `SUBTITLE_ENRICHMENT_CONCURRENCY`         | Max concurrent target languages per subtitle enrichment run. Defaults to `10`, max `25`.                                   |
+| `SUBTITLE_VALIDATION_BIBLE_PROVIDER`      | Optional subtitle validation Bible text provider. Supported value: `api_bible`; unset keeps model-knowledge validation.    |
+| `SUBTITLE_VALIDATION_BIBLE_MAP_JSON`      | Optional JSON map from target language code to provider Bible id, for example `{"en":"de4e12af7f28f599-02"}`.              |
+| `API_BIBLE_API_KEY`                       | Optional API.Bible key used only when subtitle validation is configured to fetch target-language Bible passage text.       |
+| `API_BIBLE_BASE_URL`                      | Optional API.Bible-compatible base URL. Defaults to `https://api.scripture.api.bible/v1`.                                  |
+| `API_BIBLE_ALLOWED_HOSTS`                 | Production allowlist for API.Bible credential egress. Defaults to `api.scripture.api.bible`.                               |
 | `RAILWAY_S3_ENDPOINT`                     | Railway Object Storage endpoint used for Manager-compatible subtitle artifacts when `RAILWAY_S3_BUCKET` is set.            |
 | `RAILWAY_S3_REGION`                       | Railway Object Storage region. Defaults to `auto`.                                                                         |
 | `RAILWAY_S3_BUCKET`                       | Shared artifact bucket. Required with access keys for production subtitle enrichment.                                      |

--- a/apps/mastra/src/config/env.ts
+++ b/apps/mastra/src/config/env.ts
@@ -29,6 +29,8 @@ const DEFAULT_FIRECRAWL_MAX_MARKDOWN_CHARS = 16_000
 const DEFAULT_SUBTITLE_ENRICHMENT_MODEL = "google/gemini-2.5-flash"
 const DEFAULT_SUBTITLE_ENRICHMENT_TIMEOUT_MS = 120_000
 const DEFAULT_SUBTITLE_ENRICHMENT_CONCURRENCY = 10
+const DEFAULT_API_BIBLE_BASE_URL = "https://api.scripture.api.bible/v1"
+const DEFAULT_API_BIBLE_ALLOWED_HOSTS = "api.scripture.api.bible"
 const AI_GATEWAY_FINAL_EMBEDDING_DIMENSIONS =
   EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS
 const AI_GATEWAY_TRANSFORM_VERSION = DEFAULT_EMBEDDING_TRANSFORM_VERSION
@@ -186,6 +188,14 @@ const envSchema = z.object({
     .positive()
     .max(25)
     .default(DEFAULT_SUBTITLE_ENRICHMENT_CONCURRENCY),
+  SUBTITLE_VALIDATION_BIBLE_PROVIDER: z.string().min(1).optional(),
+  SUBTITLE_VALIDATION_BIBLE_MAP_JSON: z.string().min(2).optional(),
+  API_BIBLE_API_KEY: z.string().min(1).optional(),
+  API_BIBLE_BASE_URL: z.string().min(1).default(DEFAULT_API_BIBLE_BASE_URL),
+  API_BIBLE_ALLOWED_HOSTS: z
+    .string()
+    .min(1)
+    .default(DEFAULT_API_BIBLE_ALLOWED_HOSTS),
   SMART_CROP_IMAGE_URL_ALLOWED_HOSTS: z.string().min(1).optional(),
   SMART_CROP_PLAN_MODEL: z.string().min(1).optional(),
   SMART_CROP_QA_MODEL: z.string().min(1).optional(),
@@ -333,6 +343,17 @@ export const env = envSchema.parse({
   ),
   SUBTITLE_ENRICHMENT_CONCURRENCY: emptyToUndefined(
     process.env.SUBTITLE_ENRICHMENT_CONCURRENCY,
+  ),
+  SUBTITLE_VALIDATION_BIBLE_PROVIDER: emptyToUndefined(
+    process.env.SUBTITLE_VALIDATION_BIBLE_PROVIDER,
+  ),
+  SUBTITLE_VALIDATION_BIBLE_MAP_JSON: emptyToUndefined(
+    process.env.SUBTITLE_VALIDATION_BIBLE_MAP_JSON,
+  ),
+  API_BIBLE_API_KEY: emptyToUndefined(process.env.API_BIBLE_API_KEY),
+  API_BIBLE_BASE_URL: emptyToUndefined(process.env.API_BIBLE_BASE_URL),
+  API_BIBLE_ALLOWED_HOSTS: emptyToUndefined(
+    process.env.API_BIBLE_ALLOWED_HOSTS,
   ),
   SMART_CROP_IMAGE_URL_ALLOWED_HOSTS: emptyToUndefined(
     process.env.SMART_CROP_IMAGE_URL_ALLOWED_HOSTS,

--- a/apps/mastra/src/services/subtitle-enrichment/bible-source.test.ts
+++ b/apps/mastra/src/services/subtitle-enrichment/bible-source.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  loadConfiguredBiblePassage,
+  normalizeApiBibleReference,
+  _internals,
+} from "./bible-source"
+
+describe("Bible source adapter", () => {
+  it("normalizes supported references to API.Bible passage ids", () => {
+    expect(normalizeApiBibleReference("Luke 2")).toBe("LUK.2")
+    expect(normalizeApiBibleReference("Luke 1-2")).toBe("LUK.1-LUK.2")
+    expect(normalizeApiBibleReference("Luke 1:26-2:20")).toBe(
+      "LUK.1.26-LUK.2.20",
+    )
+    expect(normalizeApiBibleReference("John 3:16")).toBe("JHN.3.16")
+    expect(normalizeApiBibleReference("1 Corinthians 13:4-7")).toBe(
+      "1CO.13.4-1CO.13.7",
+    )
+  })
+
+  it("returns undefined for unsupported reference shapes", () => {
+    expect(normalizeApiBibleReference("Birth of Jesus")).toBeUndefined()
+    expect(normalizeApiBibleReference("Luke")).toBeUndefined()
+  })
+
+  it("builds API.Bible URLs without leaking config into callers", () => {
+    expect(
+      _internals
+        .apiBibleUrl("https://api.example.test/v1/", "bible-1", "LUK.2")
+        ?.toString(),
+    ).toBe(
+      "https://api.example.test/v1/bibles/bible-1/passages/LUK.2?content-type=text&include-notes=false&include-titles=false&include-chapter-numbers=false&include-verse-numbers=false",
+    )
+  })
+
+  it("falls back when provider config is absent", async () => {
+    await expect(
+      loadConfiguredBiblePassage({
+        targetLanguage: "es",
+        references: ["Luke 2"],
+        timeoutMs: 30_000,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider_config_missing",
+    })
+  })
+
+  it("loads every configured reference before using target Bible text", async () => {
+    const fetchImpl = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+      const url = new URL(String(input))
+      return Response.json({
+        data: {
+          reference: url.pathname.endsWith("LUK.2") ? "Luke 2" : "Matthew 2",
+          content: url.pathname.endsWith("LUK.2")
+            ? "Mary gave birth to her firstborn son."
+            : "Wise men came from the east.",
+          copyright: "Public domain test text.",
+        },
+      })
+    })
+
+    await expect(
+      loadConfiguredBiblePassage({
+        targetLanguage: "en-US",
+        references: ["Luke 2", "Matthew 2"],
+        timeoutMs: 30_000,
+        fetchImpl,
+        config: {
+          SUBTITLE_VALIDATION_BIBLE_PROVIDER: "api_bible",
+          SUBTITLE_VALIDATION_BIBLE_MAP_JSON: JSON.stringify({
+            en: "bible-1",
+          }),
+          API_BIBLE_API_KEY: "api-key",
+          API_BIBLE_BASE_URL: "https://api.example.test/v1",
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      passage: {
+        referenceCount: 2,
+        provider: {
+          bibleId: "bible-1",
+          reference: "Luke 2, Matthew 2",
+        },
+        text: expect.stringContaining("[Luke 2]"),
+      },
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain("LUK.2")
+    expect(String(fetchImpl.mock.calls[1]?.[0])).toContain("MAT.2")
+  })
+
+  it("falls back when optional provider configuration is invalid", async () => {
+    await expect(
+      loadConfiguredBiblePassage({
+        targetLanguage: "en",
+        references: ["Luke 2"],
+        timeoutMs: 30_000,
+        config: {
+          SUBTITLE_VALIDATION_BIBLE_PROVIDER: "typo",
+          SUBTITLE_VALIDATION_BIBLE_MAP_JSON: JSON.stringify({
+            en: "bible-1",
+          }),
+          API_BIBLE_API_KEY: "api-key",
+          API_BIBLE_BASE_URL: "not a url",
+        },
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider_config_missing",
+    })
+  })
+
+  it("does not send API keys to non-allowlisted production Bible URLs", async () => {
+    const fetchImpl = vi.fn()
+
+    await expect(
+      loadConfiguredBiblePassage({
+        targetLanguage: "en",
+        references: ["Luke 2"],
+        timeoutMs: 30_000,
+        fetchImpl,
+        config: {
+          NODE_ENV: "production",
+          SUBTITLE_VALIDATION_BIBLE_PROVIDER: "api_bible",
+          SUBTITLE_VALIDATION_BIBLE_MAP_JSON: JSON.stringify({
+            en: "bible-1",
+          }),
+          API_BIBLE_API_KEY: "api-key",
+          API_BIBLE_BASE_URL: "http://api.scripture.api.bible/v1",
+          API_BIBLE_ALLOWED_HOSTS: "api.scripture.api.bible",
+        },
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider_config_missing",
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it("does not use partial target Bible text when one reference is unsupported", async () => {
+    const fetchImpl = vi.fn()
+
+    await expect(
+      loadConfiguredBiblePassage({
+        targetLanguage: "en",
+        references: ["Luke 2", "Birth of Jesus"],
+        timeoutMs: 30_000,
+        fetchImpl,
+        config: {
+          SUBTITLE_VALIDATION_BIBLE_PROVIDER: "api_bible",
+          SUBTITLE_VALIDATION_BIBLE_MAP_JSON: JSON.stringify({
+            en: "bible-1",
+          }),
+          API_BIBLE_API_KEY: "api-key",
+          API_BIBLE_BASE_URL: "https://api.example.test/v1",
+        },
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "reference_unsupported",
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it("maps provider status failures to fallback reasons", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 429 }))
+
+    await expect(
+      loadConfiguredBiblePassage({
+        targetLanguage: "en",
+        references: ["Luke 2"],
+        timeoutMs: 30_000,
+        fetchImpl,
+        config: {
+          SUBTITLE_VALIDATION_BIBLE_PROVIDER: "api_bible",
+          SUBTITLE_VALIDATION_BIBLE_MAP_JSON: JSON.stringify({
+            en: "bible-1",
+          }),
+          API_BIBLE_API_KEY: "api-key",
+          API_BIBLE_BASE_URL: "https://api.example.test/v1",
+        },
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider_rate_limited",
+    })
+  })
+})

--- a/apps/mastra/src/services/subtitle-enrichment/bible-source.ts
+++ b/apps/mastra/src/services/subtitle-enrichment/bible-source.ts
@@ -1,0 +1,363 @@
+import { env } from "../../config/env"
+import type { SubtitleScriptureValidationFallbackReason } from "./types"
+
+export type SubtitleBiblePassage = {
+  provider: {
+    name: "api_bible"
+    bibleId: string
+    language: string
+    reference: string
+    versionLabel?: string
+    copyright?: string
+  }
+  referenceCount: number
+  text: string
+}
+
+export type BiblePassageLookupResult =
+  | { ok: true; passage: SubtitleBiblePassage }
+  | { ok: false; reason: SubtitleScriptureValidationFallbackReason }
+
+export type LoadBiblePassageInput = {
+  targetLanguage: string
+  references: string[]
+  timeoutMs: number
+  fetchImpl?: typeof fetch
+  config?: BibleSourceConfig
+}
+
+const MAX_PASSAGE_TEXT_CHARS = 12_000
+
+type BibleSourceConfig = {
+  NODE_ENV?: string
+  SUBTITLE_VALIDATION_BIBLE_PROVIDER?: string
+  SUBTITLE_VALIDATION_BIBLE_MAP_JSON?: string
+  API_BIBLE_API_KEY?: string
+  API_BIBLE_BASE_URL: string
+  API_BIBLE_ALLOWED_HOSTS?: string
+}
+
+const API_BIBLE_BOOK_IDS: Record<string, string> = {
+  genesis: "GEN",
+  exodus: "EXO",
+  leviticus: "LEV",
+  numbers: "NUM",
+  deuteronomy: "DEU",
+  joshua: "JOS",
+  judges: "JDG",
+  ruth: "RUT",
+  "1samuel": "1SA",
+  "2samuel": "2SA",
+  "1kings": "1KI",
+  "2kings": "2KI",
+  "1chronicles": "1CH",
+  "2chronicles": "2CH",
+  ezra: "EZR",
+  nehemiah: "NEH",
+  esther: "EST",
+  job: "JOB",
+  psalm: "PSA",
+  psalms: "PSA",
+  proverbs: "PRO",
+  ecclesiastes: "ECC",
+  songofsolomon: "SNG",
+  songofsongs: "SNG",
+  isaiah: "ISA",
+  jeremiah: "JER",
+  lamentations: "LAM",
+  ezekiel: "EZK",
+  daniel: "DAN",
+  hosea: "HOS",
+  joel: "JOL",
+  amos: "AMO",
+  obadiah: "OBA",
+  jonah: "JON",
+  micah: "MIC",
+  nahum: "NAM",
+  habakkuk: "HAB",
+  zephaniah: "ZEP",
+  haggai: "HAG",
+  zechariah: "ZEC",
+  malachi: "MAL",
+  matthew: "MAT",
+  mark: "MRK",
+  luke: "LUK",
+  john: "JHN",
+  acts: "ACT",
+  romans: "ROM",
+  "1corinthians": "1CO",
+  "2corinthians": "2CO",
+  galatians: "GAL",
+  ephesians: "EPH",
+  philippians: "PHP",
+  colossians: "COL",
+  "1thessalonians": "1TH",
+  "2thessalonians": "2TH",
+  "1timothy": "1TI",
+  "2timothy": "2TI",
+  titus: "TIT",
+  philemon: "PHM",
+  hebrews: "HEB",
+  james: "JAS",
+  "1peter": "1PE",
+  "2peter": "2PE",
+  "1john": "1JN",
+  "2john": "2JN",
+  "3john": "3JN",
+  jude: "JUD",
+  revelation: "REV",
+}
+
+function normalizeBookKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "")
+}
+
+export function normalizeApiBibleReference(
+  reference: string,
+): string | undefined {
+  const match = reference
+    .trim()
+    .replace(/\s+/g, " ")
+    .match(
+      /^(.+?)\s+(\d{1,3})(?::(\d{1,3}))?(?:\s*[-–]\s*(\d{1,3})(?::(\d{1,3}))?)?$/,
+    )
+  if (!match) return undefined
+
+  const bookId = API_BIBLE_BOOK_IDS[normalizeBookKey(match[1] ?? "")]
+  if (!bookId) return undefined
+
+  const chapter = match[2]
+  const verseStart = match[3]
+  const rangeStart = match[4]
+  const rangeVerse = match[5]
+  if (!chapter) return undefined
+  if (!rangeStart) {
+    return verseStart
+      ? `${bookId}.${chapter}.${verseStart}`
+      : `${bookId}.${chapter}`
+  }
+  if (!verseStart) {
+    return rangeVerse
+      ? `${bookId}.${chapter}-${bookId}.${rangeStart}.${rangeVerse}`
+      : `${bookId}.${chapter}-${bookId}.${rangeStart}`
+  }
+  return rangeVerse
+    ? `${bookId}.${chapter}.${verseStart}-${bookId}.${rangeStart}.${rangeVerse}`
+    : `${bookId}.${chapter}.${verseStart}-${bookId}.${chapter}.${rangeStart}`
+}
+
+function parseBibleMap(
+  raw: string | undefined,
+): Record<string, string> | undefined {
+  if (!raw) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+  if (typeof parsed !== "object" || parsed == null || Array.isArray(parsed)) {
+    return undefined
+  }
+  return Object.fromEntries(
+    Object.entries(parsed).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "string" &&
+        entry[1].trim().length > 0,
+    ),
+  )
+}
+
+function lookupBibleId(
+  bibleMap: Record<string, string>,
+  targetLanguage: string,
+): string | undefined {
+  const normalized = targetLanguage.trim().toLowerCase()
+  const baseLanguage = normalized.split("-")[0]
+  return (
+    bibleMap[targetLanguage] ?? bibleMap[normalized] ?? bibleMap[baseLanguage]
+  )
+}
+
+function cleanPassageText(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_PASSAGE_TEXT_CHARS)
+}
+
+function apiBibleUrl(
+  baseUrl: string,
+  bibleId: string,
+  passageId: string,
+): URL | undefined {
+  let url: URL
+  try {
+    url = new URL(
+      `${baseUrl.replace(/\/$/, "")}/bibles/${encodeURIComponent(
+        bibleId,
+      )}/passages/${encodeURIComponent(passageId)}`,
+    )
+  } catch {
+    return undefined
+  }
+  url.searchParams.set("content-type", "text")
+  url.searchParams.set("include-notes", "false")
+  url.searchParams.set("include-titles", "false")
+  url.searchParams.set("include-chapter-numbers", "false")
+  url.searchParams.set("include-verse-numbers", "false")
+  return url
+}
+
+function csvSet(value: string | undefined): ReadonlySet<string> {
+  return new Set(
+    (value ?? "api.scripture.api.bible")
+      .split(",")
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean),
+  )
+}
+
+function isApiBibleUrlAllowed(config: BibleSourceConfig, url: URL): boolean {
+  if (config.NODE_ENV !== "production") {
+    return true
+  }
+
+  const allowedHosts = csvSet(config.API_BIBLE_ALLOWED_HOSTS)
+  return url.protocol === "https:" && allowedHosts.has(url.hostname)
+}
+
+export async function loadConfiguredBiblePassage({
+  targetLanguage,
+  references,
+  timeoutMs,
+  fetchImpl = fetch,
+  config = env,
+}: LoadBiblePassageInput): Promise<BiblePassageLookupResult> {
+  if (config.SUBTITLE_VALIDATION_BIBLE_PROVIDER !== "api_bible") {
+    return { ok: false, reason: "provider_config_missing" }
+  }
+
+  if (!config.API_BIBLE_API_KEY) {
+    return { ok: false, reason: "provider_config_missing" }
+  }
+
+  const bibleMap = parseBibleMap(config.SUBTITLE_VALIDATION_BIBLE_MAP_JSON)
+  if (!bibleMap) {
+    return { ok: false, reason: "bible_mapping_missing" }
+  }
+
+  const bibleId = lookupBibleId(bibleMap, targetLanguage)
+  if (!bibleId) {
+    return { ok: false, reason: "bible_mapping_missing" }
+  }
+
+  const requestedReferences = references
+    .map((reference) => reference.trim())
+    .filter(Boolean)
+  const normalizedReferences = requestedReferences.map(
+    normalizeApiBibleReference,
+  )
+  if (
+    normalizedReferences.length === 0 ||
+    normalizedReferences.some((reference) => reference == null)
+  ) {
+    return { ok: false, reason: "reference_unsupported" }
+  }
+  const uniqueReferences = Array.from(new Set(normalizedReferences)) as string[]
+  const passages: Array<{
+    reference: string
+    text: string
+    copyright?: string
+  }> = []
+
+  for (const normalizedReference of uniqueReferences) {
+    const url = apiBibleUrl(
+      config.API_BIBLE_BASE_URL,
+      bibleId,
+      normalizedReference,
+    )
+    if (!url) {
+      return { ok: false, reason: "provider_config_missing" }
+    }
+    if (!isApiBibleUrlAllowed(config, url)) {
+      return { ok: false, reason: "provider_config_missing" }
+    }
+
+    let response: Response
+    try {
+      response = await fetchImpl(url, {
+        headers: { "api-key": config.API_BIBLE_API_KEY },
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+    } catch {
+      return { ok: false, reason: "provider_failed" }
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      return { ok: false, reason: "provider_auth_failed" }
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: "reference_unsupported" }
+    }
+    if (response.status === 429) {
+      return { ok: false, reason: "provider_rate_limited" }
+    }
+    if (!response.ok) {
+      return { ok: false, reason: "provider_failed" }
+    }
+
+    const body = (await response.json().catch(() => null)) as {
+      data?: {
+        content?: unknown
+        reference?: unknown
+        copyright?: unknown
+      }
+    } | null
+    const content = body?.data?.content
+    if (typeof content !== "string" || !content.trim()) {
+      return { ok: false, reason: "provider_invalid_output" }
+    }
+    passages.push({
+      reference:
+        typeof body?.data?.reference === "string"
+          ? body.data.reference
+          : normalizedReference,
+      text: cleanPassageText(content),
+      ...(typeof body?.data?.copyright === "string"
+        ? { copyright: body.data.copyright.slice(0, 240) }
+        : {}),
+    })
+  }
+  const copyright = Array.from(
+    new Set(passages.map((passage) => passage.copyright).filter(Boolean)),
+  ).join("; ")
+
+  return {
+    ok: true,
+    passage: {
+      provider: {
+        name: "api_bible",
+        bibleId,
+        language: targetLanguage,
+        reference: passages.map((passage) => passage.reference).join(", "),
+        ...(copyright ? { copyright: copyright.slice(0, 240) } : {}),
+      },
+      referenceCount: passages.length,
+      text: passages
+        .map((passage) => `[${passage.reference}]\n${passage.text}`)
+        .join("\n\n")
+        .slice(0, MAX_PASSAGE_TEXT_CHARS),
+    },
+  }
+}
+
+export const _internals = {
+  normalizeBookKey,
+  parseBibleMap,
+  lookupBibleId,
+  apiBibleUrl,
+  cleanPassageText,
+}

--- a/apps/mastra/src/services/subtitle-enrichment/run.test.ts
+++ b/apps/mastra/src/services/subtitle-enrichment/run.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { chunkSegments } from "./chunker"
 import { deterministicRetime, validateRetimingOutput } from "./retimer"
 import { runSubtitleEnrichment } from "./run"
-import type { Chunk, LanguageConfig, SubtitleScriptureContext } from "./types"
+import type {
+  Chunk,
+  LanguageConfig,
+  SubtitleScriptureContext,
+  SubtitleScriptureValidationResult,
+} from "./types"
 
 const emptyUsage = {
   promptTokens: 0,
@@ -104,6 +109,8 @@ describe("runSubtitleEnrichment", () => {
   const retime = vi.fn()
   const loadConfig = vi.fn()
   const detectScriptureContext = vi.fn()
+  const loadBiblePassage = vi.fn()
+  const validateScripture = vi.fn()
   const written: Array<{ artifactType: string; body: string | Uint8Array }> = []
 
   beforeEach(() => {
@@ -113,6 +120,8 @@ describe("runSubtitleEnrichment", () => {
     retime.mockReset()
     loadConfig.mockReset()
     detectScriptureContext.mockReset()
+    loadBiblePassage.mockReset()
+    validateScripture.mockReset()
     written.length = 0
 
     readArtifact.mockResolvedValue(
@@ -133,7 +142,30 @@ describe("runSubtitleEnrichment", () => {
     )
     loadConfig.mockResolvedValue(undefined)
     detectScriptureContext.mockResolvedValue(undefined)
+    loadBiblePassage.mockResolvedValue({
+      ok: false,
+      reason: "provider_config_missing",
+    })
   })
+
+  function validationResult(
+    overrides: Partial<SubtitleScriptureValidationResult> = {},
+  ): SubtitleScriptureValidationResult {
+    return {
+      targetLanguage: "en",
+      contentDomain: "bible_story",
+      likelyBibleReferences: ["Luke 2"],
+      verdict: "pass",
+      basis: "model_knowledge",
+      confidence: 0.8,
+      checkedReferenceCount: 1,
+      warningCount: 0,
+      needsReviewCount: 0,
+      fallbackReason: "provider_config_missing",
+      findings: [],
+      ...overrides,
+    }
+  }
 
   it("returns partial success when at least one target language completes", async () => {
     translate.mockImplementation(
@@ -324,6 +356,7 @@ describe("runSubtitleEnrichment", () => {
       rationale: "Birth narrative.",
     }
     detectScriptureContext.mockResolvedValue(scriptureContext)
+    validateScripture.mockResolvedValue(validationResult())
     translate.mockResolvedValue({ text: "Hello.", usage: emptyUsage })
     retime.mockResolvedValue({
       segments: [{ start: 0, end: 2, text: "Hello." }],
@@ -351,6 +384,8 @@ describe("runSubtitleEnrichment", () => {
         retime,
         loadConfig,
         detectScriptureContext,
+        loadBiblePassage,
+        validateScripture,
       },
     )
 
@@ -381,11 +416,19 @@ describe("runSubtitleEnrichment", () => {
       },
     })
     expect(String(jsonWrite?.body)).not.toContain("Birth narrative")
+    expect(validateScripture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetLanguage: "en",
+        scriptureContext,
+        fallbackReason: "provider_config_missing",
+      }),
+    )
   })
 
   it("logs detector failures and continues with sanitized fallback context", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
     detectScriptureContext.mockRejectedValue(new Error("provider down"))
+    validateScripture.mockResolvedValue(validationResult())
     translate.mockResolvedValue({ text: "Hello.", usage: emptyUsage })
     retime.mockResolvedValue({
       segments: [{ start: 0, end: 2, text: "Hello." }],
@@ -414,6 +457,8 @@ describe("runSubtitleEnrichment", () => {
             retime,
             loadConfig,
             detectScriptureContext,
+            loadBiblePassage,
+            validateScripture,
           },
         ),
       ).resolves.toEqual([
@@ -423,6 +468,16 @@ describe("runSubtitleEnrichment", () => {
           artifactKeys: {
             vtt: "qa-asset/subtitles-en.vtt",
             json: "qa-asset/translation-en.json",
+            validation: "qa-asset/subtitle-validation-en.json",
+          },
+          validationSummary: {
+            verdict: "pass",
+            basis: "model_knowledge",
+            confidence: 0.8,
+            checkedReferenceCount: 1,
+            warningCount: 0,
+            needsReviewCount: 0,
+            fallbackReason: "provider_config_missing",
           },
         },
       ])
@@ -444,6 +499,316 @@ describe("runSubtitleEnrichment", () => {
           confidence: 0.65,
         },
       })
+      const validationWrite = written.find(
+        (write) => write.artifactType === "subtitle-validation-en",
+      )
+      expect(JSON.parse(String(validationWrite?.body))).toMatchObject({
+        basis: "model_knowledge",
+        verdict: "pass",
+        fallbackReason: "provider_config_missing",
+      })
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it("uses an available Bible passage to produce target-text validation", async () => {
+    const scriptureContext: SubtitleScriptureContext = {
+      contentDomain: "bible_story",
+      likelyBibleReferences: ["Luke 2"],
+      confidence: 0.91,
+    }
+    const targetBibleValidation: SubtitleScriptureValidationResult = {
+      targetLanguage: "en",
+      contentDomain: "bible_story",
+      likelyBibleReferences: ["Luke 2"],
+      verdict: "pass",
+      basis: "target_bible_text",
+      confidence: 0.8,
+      checkedReferenceCount: 1,
+      warningCount: 0,
+      needsReviewCount: 0,
+      provider: {
+        name: "api_bible",
+        bibleId: "spa-rvr",
+        language: "en",
+        reference: "Luke 2",
+      },
+      findings: [],
+    }
+    detectScriptureContext.mockResolvedValue(scriptureContext)
+    loadBiblePassage.mockResolvedValue({
+      ok: true,
+      passage: {
+        provider: {
+          name: "api_bible",
+          bibleId: "spa-rvr",
+          language: "en",
+          reference: "Luke 2",
+        },
+        referenceCount: 1,
+        text: "Mary gave birth to her firstborn son.",
+      },
+    })
+    validateScripture.mockResolvedValue(targetBibleValidation)
+    translate.mockResolvedValue({ text: "Hello.", usage: emptyUsage })
+    retime.mockResolvedValue({
+      segments: [{ start: 0, end: 2, text: "Hello." }],
+      usage: emptyUsage,
+      fallbackUsed: false,
+    })
+
+    const results = await runSubtitleEnrichment(
+      {
+        assetId: "qa-asset",
+        sourceLanguage: "es",
+        targetLanguages: ["en"],
+        model: "test-model",
+        apiKey: "openrouter-key",
+        timeoutMs: 30_000,
+      },
+      {
+        readArtifact,
+        writeArtifact,
+        translate,
+        retime,
+        loadConfig,
+        detectScriptureContext,
+        loadBiblePassage,
+        validateScripture,
+      },
+    )
+
+    expect(validateScripture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        biblePassage: expect.objectContaining({
+          text: "Mary gave birth to her firstborn son.",
+        }),
+        fallbackReason: undefined,
+      }),
+    )
+    expect(results[0]).toMatchObject({
+      artifactKeys: {
+        validation: "qa-asset/subtitle-validation-en.json",
+      },
+      validationSummary: {
+        basis: "target_bible_text",
+        verdict: "pass",
+      },
+    })
+  })
+
+  it("validates referenced gospel teaching contexts", async () => {
+    const scriptureContext: SubtitleScriptureContext = {
+      contentDomain: "gospel_teaching",
+      likelyBibleReferences: ["Matthew 6:14-15"],
+      confidence: 0.82,
+    }
+    detectScriptureContext.mockResolvedValue(scriptureContext)
+    validateScripture.mockResolvedValue(
+      validationResult({
+        contentDomain: "gospel_teaching",
+        likelyBibleReferences: ["Matthew 6:14-15"],
+      }),
+    )
+    translate.mockResolvedValue({ text: "Hello.", usage: emptyUsage })
+    retime.mockResolvedValue({
+      segments: [{ start: 0, end: 2, text: "Hello." }],
+      usage: emptyUsage,
+      fallbackUsed: false,
+    })
+
+    await runSubtitleEnrichment(
+      {
+        assetId: "qa-asset",
+        sourceLanguage: "es",
+        targetLanguages: ["en"],
+        model: "test-model",
+        apiKey: "openrouter-key",
+        timeoutMs: 30_000,
+      },
+      {
+        readArtifact,
+        writeArtifact,
+        translate,
+        retime,
+        loadConfig,
+        detectScriptureContext,
+        loadBiblePassage,
+        validateScripture,
+      },
+    )
+
+    expect(validateScripture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scriptureContext,
+        fallbackReason: "provider_config_missing",
+      }),
+    )
+    expect(
+      written.some((write) => write.artifactType === "subtitle-validation-en"),
+    ).toBe(true)
+  })
+
+  it("records validation unavailable without failing completed translation", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    detectScriptureContext.mockResolvedValue({
+      contentDomain: "bible_story",
+      likelyBibleReferences: ["Luke 2"],
+      confidence: 0.91,
+    })
+    validateScripture.mockRejectedValue(new Error("validator offline"))
+    translate.mockResolvedValue({ text: "Hello.", usage: emptyUsage })
+    retime.mockResolvedValue({
+      segments: [{ start: 0, end: 2, text: "Hello." }],
+      usage: emptyUsage,
+      fallbackUsed: false,
+    })
+
+    try {
+      await expect(
+        runSubtitleEnrichment(
+          {
+            assetId: "qa-asset",
+            sourceLanguage: "es",
+            targetLanguages: ["en"],
+            model: "test-model",
+            apiKey: "openrouter-key",
+            timeoutMs: 30_000,
+          },
+          {
+            readArtifact,
+            writeArtifact,
+            translate,
+            retime,
+            loadConfig,
+            detectScriptureContext,
+            loadBiblePassage,
+            validateScripture,
+          },
+        ),
+      ).resolves.toEqual([
+        {
+          lang: "en",
+          status: "completed",
+          artifactKeys: {
+            vtt: "qa-asset/subtitles-en.vtt",
+            json: "qa-asset/translation-en.json",
+            validation: "qa-asset/subtitle-validation-en.json",
+          },
+          validationSummary: {
+            verdict: "unavailable",
+            basis: "unavailable",
+            confidence: 0,
+            checkedReferenceCount: 0,
+            warningCount: 0,
+            needsReviewCount: 0,
+            unavailableReason: "provider_failed",
+          },
+        },
+      ])
+      expect(warnSpy).toHaveBeenCalledWith(
+        JSON.stringify({
+          event: "subtitle_scripture_validation_failed",
+          assetId: "qa-asset",
+          targetLanguage: "en",
+          errorName: "Error",
+        }),
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it("keeps validation summary visible when validation artifact writing fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    detectScriptureContext.mockResolvedValue({
+      contentDomain: "bible_story",
+      likelyBibleReferences: ["Luke 2"],
+      confidence: 0.91,
+    })
+    validateScripture.mockResolvedValue(
+      validationResult({
+        verdict: "needs_review",
+        needsReviewCount: 1,
+        findings: [
+          {
+            severity: "needs_review",
+            category: "meaning_drift",
+            message: "Meaning drift.",
+          },
+        ],
+      }),
+    )
+    writeArtifact.mockImplementation(
+      async (options: { artifactType: string; ext: string; body: string }) => {
+        if (options.artifactType === "subtitle-validation-en") {
+          throw new Error("storage offline")
+        }
+        written.push({
+          artifactType: options.artifactType,
+          body: options.body,
+        })
+        return `qa-asset/${options.artifactType}.${options.ext}`
+      },
+    )
+    translate.mockResolvedValue({ text: "Hello.", usage: emptyUsage })
+    retime.mockResolvedValue({
+      segments: [{ start: 0, end: 2, text: "Hello." }],
+      usage: emptyUsage,
+      fallbackUsed: false,
+    })
+
+    try {
+      await expect(
+        runSubtitleEnrichment(
+          {
+            assetId: "qa-asset",
+            sourceLanguage: "es",
+            targetLanguages: ["en"],
+            model: "test-model",
+            apiKey: "openrouter-key",
+            timeoutMs: 30_000,
+          },
+          {
+            readArtifact,
+            writeArtifact,
+            translate,
+            retime,
+            loadConfig,
+            detectScriptureContext,
+            loadBiblePassage,
+            validateScripture,
+          },
+        ),
+      ).resolves.toEqual([
+        {
+          lang: "en",
+          status: "completed",
+          artifactKeys: {
+            vtt: "qa-asset/subtitles-en.vtt",
+            json: "qa-asset/translation-en.json",
+          },
+          validationSummary: {
+            verdict: "needs_review",
+            basis: "model_knowledge",
+            confidence: 0.8,
+            checkedReferenceCount: 1,
+            warningCount: 0,
+            needsReviewCount: 1,
+            fallbackReason: "provider_config_missing",
+            unavailableReason: "artifact_write_failed",
+          },
+        },
+      ])
+      expect(warnSpy).toHaveBeenCalledWith(
+        JSON.stringify({
+          event: "subtitle_scripture_validation_artifact_write_failed",
+          assetId: "qa-asset",
+          targetLanguage: "en",
+          errorName: "Error",
+        }),
+      )
     } finally {
       warnSpy.mockRestore()
     }

--- a/apps/mastra/src/services/subtitle-enrichment/run.ts
+++ b/apps/mastra/src/services/subtitle-enrichment/run.ts
@@ -2,6 +2,10 @@ import { chunkSegments } from "./chunker"
 import { loadLanguageConfig } from "./language-config"
 import { retimeChunk, type RetimeChunkResult } from "./retimer"
 import {
+  loadConfiguredBiblePassage,
+  type SubtitleBiblePassage,
+} from "./bible-source"
+import {
   detectSubtitleScriptureContext,
   fallbackSubtitleScriptureContext,
   sanitizeSubtitleScriptureContext,
@@ -17,11 +21,19 @@ import {
   type Chunk,
   type LanguageConfig,
   type SubtitleScriptureContext,
+  type SubtitleScriptureValidationFallbackReason,
+  type SubtitleScriptureValidationResult,
+  type SubtitleScriptureValidationSummary,
   type SubtitleTranslationContext,
   type SubtitleLanguageResult,
   type TranscriptSegment,
 } from "./types"
 import { translateChunk, type TranslateChunkResult } from "./translator"
+import {
+  buildUnavailableSubtitleScriptureValidationResult,
+  validateSubtitleScriptureAccuracy,
+  type ValidateSubtitleScriptureAccuracyInput,
+} from "./scripture-validation"
 import { segmentsToVtt } from "./vtt"
 
 const DEFAULT_CONCURRENCY_LIMIT = 10
@@ -62,6 +74,10 @@ export type RunSubtitleEnrichmentDeps = {
   detectScriptureContext?: (
     input: DetectSubtitleScriptureContextInput,
   ) => Promise<SubtitleScriptureContext>
+  loadBiblePassage?: typeof loadConfiguredBiblePassage
+  validateScripture?: (
+    input: ValidateSubtitleScriptureAccuracyInput,
+  ) => Promise<SubtitleScriptureValidationResult>
   loadConfig?: typeof loadLanguageConfig
 }
 
@@ -110,6 +126,44 @@ function detectorErrorDetails(error: unknown) {
   }
 }
 
+function providerFallbackReason(
+  error: unknown,
+): SubtitleScriptureValidationFallbackReason {
+  if (error instanceof SubtitleProviderError) {
+    return error.reason
+  }
+  return "provider_failed"
+}
+
+function validationSummaryFromResult(
+  result: SubtitleScriptureValidationResult,
+): SubtitleScriptureValidationSummary {
+  return {
+    verdict: result.verdict,
+    basis: result.basis,
+    confidence: result.confidence,
+    checkedReferenceCount: result.checkedReferenceCount,
+    warningCount: result.warningCount,
+    needsReviewCount: result.needsReviewCount,
+    ...(result.fallbackReason ? { fallbackReason: result.fallbackReason } : {}),
+    ...(result.unavailableReason
+      ? { unavailableReason: result.unavailableReason }
+      : {}),
+  }
+}
+
+function shouldValidateScripture(
+  context: SubtitleScriptureContext | undefined,
+): context is SubtitleScriptureContext {
+  if (!context) {
+    return false
+  }
+  if (context.likelyBibleReferences.length > 0) {
+    return true
+  }
+  return context.contentDomain === "bible_story" && context.confidence >= 0.5
+}
+
 async function mapWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
@@ -141,6 +195,9 @@ export async function runSubtitleEnrichment(
   const retime = deps.retime ?? retimeChunk
   const detectScriptureContext =
     deps.detectScriptureContext ?? detectSubtitleScriptureContext
+  const loadBiblePassage = deps.loadBiblePassage ?? loadConfiguredBiblePassage
+  const validateScripture =
+    deps.validateScripture ?? validateSubtitleScriptureAccuracy
   const loadConfig = deps.loadConfig ?? loadLanguageConfig
 
   const transcript = parseTranscriptArtifact(
@@ -195,6 +252,8 @@ export async function runSubtitleEnrichment(
         scriptureContext,
         translate,
         retime,
+        loadBiblePassage,
+        validateScripture,
         writeArtifact,
         loadConfig,
       }),
@@ -213,6 +272,8 @@ async function translateLanguage(input: {
   scriptureContext?: SubtitleScriptureContext
   translate: NonNullable<RunSubtitleEnrichmentDeps["translate"]>
   retime: NonNullable<RunSubtitleEnrichmentDeps["retime"]>
+  loadBiblePassage: NonNullable<RunSubtitleEnrichmentDeps["loadBiblePassage"]>
+  validateScripture: NonNullable<RunSubtitleEnrichmentDeps["validateScripture"]>
   writeArtifact: (options: WriteSubtitleArtifactOptions) => Promise<string>
   loadConfig: typeof loadLanguageConfig
 }): Promise<SubtitleLanguageResult> {
@@ -254,6 +315,11 @@ async function translateLanguage(input: {
       segments: allSegments,
       translated: true,
       scriptureContext: input.scriptureContext,
+      model: input.model,
+      apiKey: input.apiKey,
+      timeoutMs: input.timeoutMs,
+      loadBiblePassage: input.loadBiblePassage,
+      validateScripture: input.validateScripture,
       writeArtifact: input.writeArtifact,
     })
   } catch (error) {
@@ -293,6 +359,13 @@ async function writeCompletedTranslationArtifacts(input: {
   segments: TranscriptSegment[]
   translated: boolean
   scriptureContext?: SubtitleScriptureContext
+  model?: string
+  apiKey?: string
+  timeoutMs?: number
+  loadBiblePassage?: NonNullable<RunSubtitleEnrichmentDeps["loadBiblePassage"]>
+  validateScripture?: NonNullable<
+    RunSubtitleEnrichmentDeps["validateScripture"]
+  >
   writeArtifact: (options: WriteSubtitleArtifactOptions) => Promise<string>
 }): Promise<SubtitleLanguageResult> {
   const vttContent = segmentsToVtt(input.segments, {
@@ -336,14 +409,132 @@ async function writeCompletedTranslationArtifacts(input: {
     contentType: "application/json",
   })
 
+  const validation = await writeScriptureValidationArtifact(input)
+
   return {
     lang: input.targetLanguage,
     status: "completed",
-    artifactKeys: { vtt: vttKey, json: jsonKey },
+    artifactKeys: {
+      vtt: vttKey,
+      json: jsonKey,
+      ...(validation?.artifactKey
+        ? { validation: validation.artifactKey }
+        : {}),
+    },
+    ...(validation?.summary ? { validationSummary: validation.summary } : {}),
+  }
+}
+
+async function writeScriptureValidationArtifact(input: {
+  assetId: string
+  targetLanguage: string
+  segments: TranscriptSegment[]
+  translated: boolean
+  scriptureContext?: SubtitleScriptureContext
+  model?: string
+  apiKey?: string
+  timeoutMs?: number
+  loadBiblePassage?: NonNullable<RunSubtitleEnrichmentDeps["loadBiblePassage"]>
+  validateScripture?: NonNullable<
+    RunSubtitleEnrichmentDeps["validateScripture"]
+  >
+  writeArtifact: (options: WriteSubtitleArtifactOptions) => Promise<string>
+}): Promise<
+  | { artifactKey?: string; summary: SubtitleScriptureValidationSummary }
+  | undefined
+> {
+  if (
+    !input.translated ||
+    !shouldValidateScripture(input.scriptureContext) ||
+    !input.model ||
+    !input.timeoutMs ||
+    !input.validateScripture
+  ) {
+    return undefined
+  }
+
+  let biblePassage: SubtitleBiblePassage | undefined
+  let fallbackReason: SubtitleScriptureValidationFallbackReason | undefined
+  const references = input.scriptureContext.likelyBibleReferences
+  if (references.length > 0 && input.loadBiblePassage) {
+    try {
+      const lookup = await input.loadBiblePassage({
+        targetLanguage: input.targetLanguage,
+        references,
+        timeoutMs: input.timeoutMs,
+      })
+      if (lookup.ok) {
+        biblePassage = lookup.passage
+      } else {
+        fallbackReason = lookup.reason
+      }
+    } catch (error) {
+      fallbackReason = providerFallbackReason(error)
+    }
+  }
+
+  let result: SubtitleScriptureValidationResult
+  try {
+    result = await input.validateScripture({
+      targetLanguage: input.targetLanguage,
+      segments: input.segments,
+      scriptureContext: input.scriptureContext,
+      model: input.model,
+      apiKey: input.apiKey,
+      timeoutMs: input.timeoutMs,
+      biblePassage,
+      fallbackReason,
+    })
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "subtitle_scripture_validation_failed",
+        assetId: input.assetId,
+        targetLanguage: input.targetLanguage,
+        ...detectorErrorDetails(error),
+      }),
+    )
+    result = buildUnavailableSubtitleScriptureValidationResult({
+      targetLanguage: input.targetLanguage,
+      scriptureContext: input.scriptureContext,
+      unavailableReason:
+        error instanceof SubtitleProviderError
+          ? error.reason
+          : "provider_failed",
+    })
+  }
+
+  const summary = validationSummaryFromResult(result)
+  try {
+    const artifactKey = await input.writeArtifact({
+      assetId: input.assetId,
+      artifactType: `subtitle-validation-${input.targetLanguage}`,
+      ext: "json",
+      body: JSON.stringify(result, null, 2),
+      contentType: "application/json",
+    })
+    return { artifactKey, summary }
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "subtitle_scripture_validation_artifact_write_failed",
+        assetId: input.assetId,
+        targetLanguage: input.targetLanguage,
+        errorName: error instanceof Error ? error.name : typeof error,
+      }),
+    )
+    return {
+      summary: {
+        ...summary,
+        unavailableReason: "artifact_write_failed",
+      },
+    }
   }
 }
 
 export const _internals = {
   parseTranscriptArtifact,
   mapWithConcurrency,
+  shouldValidateScripture,
+  validationSummaryFromResult,
 }

--- a/apps/mastra/src/services/subtitle-enrichment/scripture-validation.test.ts
+++ b/apps/mastra/src/services/subtitle-enrichment/scripture-validation.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  buildUnavailableSubtitleScriptureValidationResult,
+  validateSubtitleScriptureAccuracy,
+  _internals,
+} from "./scripture-validation"
+import type { SubtitleScriptureContext } from "./types"
+
+const scriptureContext: SubtitleScriptureContext = {
+  contentDomain: "bible_story",
+  likelyBibleReferences: ["Luke 2"],
+  confidence: 0.87,
+}
+
+function openRouterJson(value: unknown) {
+  return Response.json({
+    choices: [{ message: { content: JSON.stringify(value) } }],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  })
+}
+
+describe("validateSubtitleScriptureAccuracy", () => {
+  it("returns model-knowledge validation when no Bible passage is supplied", async () => {
+    const fetchImpl = vi.fn(async () =>
+      openRouterJson({
+        verdict: "pass",
+        confidence: 0.74,
+        likelyBibleReferences: ["Luke 2"],
+        findings: [],
+      }),
+    )
+
+    await expect(
+      validateSubtitleScriptureAccuracy({
+        targetLanguage: "es",
+        segments: [{ start: 0, end: 2, text: "Maria dio a luz a Jesus." }],
+        scriptureContext,
+        model: "test-model",
+        apiKey: "openrouter-key",
+        timeoutMs: 30_000,
+        fallbackReason: "provider_config_missing",
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({
+      targetLanguage: "es",
+      basis: "model_knowledge",
+      verdict: "pass",
+      confidence: 0.74,
+      checkedReferenceCount: 1,
+      fallbackReason: "provider_config_missing",
+      likelyBibleReferences: ["Luke 2"],
+      findings: [],
+    })
+  })
+
+  it("returns target-Bible-text validation with provider provenance", async () => {
+    const fetchImpl = vi.fn(async () =>
+      openRouterJson({
+        verdict: "needs_review",
+        confidence: 0.91,
+        likelyBibleReferences: ["Luke 2"],
+        findings: [
+          {
+            severity: "needs_review",
+            category: "addition",
+            message: "Adds a detail not supported by the passage.",
+            reference: "Luke 2",
+            segmentIndexes: [0],
+            evidence: "king in the stable",
+          },
+        ],
+      }),
+    )
+
+    await expect(
+      validateSubtitleScriptureAccuracy({
+        targetLanguage: "es",
+        segments: [
+          {
+            start: 0,
+            end: 2,
+            text: "Un rey llego al establo antes que los pastores.",
+          },
+        ],
+        scriptureContext,
+        model: "test-model",
+        apiKey: "openrouter-key",
+        timeoutMs: 30_000,
+        biblePassage: {
+          provider: {
+            name: "api_bible",
+            bibleId: "spa-rvr",
+            language: "es",
+            reference: "Lucas 2",
+          },
+          referenceCount: 1,
+          text: "Maria dio a luz a su hijo primogenito.",
+        },
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({
+      basis: "target_bible_text",
+      verdict: "needs_review",
+      confidence: 0.91,
+      checkedReferenceCount: 1,
+      needsReviewCount: 1,
+      provider: {
+        name: "api_bible",
+        bibleId: "spa-rvr",
+        reference: "Lucas 2",
+      },
+    })
+  })
+
+  it("promotes the verdict when findings are more severe than the model verdict", async () => {
+    const fetchImpl = vi.fn(async () =>
+      openRouterJson({
+        verdict: "pass",
+        confidence: 0.82,
+        likelyBibleReferences: ["Luke 2"],
+        findings: [
+          {
+            severity: "needs_review",
+            category: "meaning_drift",
+            message: "Changes the birth narrative meaning.",
+          },
+        ],
+      }),
+    )
+
+    await expect(
+      validateSubtitleScriptureAccuracy({
+        targetLanguage: "es",
+        segments: [{ start: 0, end: 2, text: "Jose dio a luz." }],
+        scriptureContext,
+        model: "test-model",
+        apiKey: "openrouter-key",
+        timeoutMs: 30_000,
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({
+      verdict: "needs_review",
+      needsReviewCount: 1,
+      warningCount: 0,
+    })
+  })
+
+  it("anchors non-pass verdicts with a bounded finding when the model omits details", async () => {
+    const fetchImpl = vi.fn(async () =>
+      openRouterJson({
+        verdict: "warning",
+        confidence: 0.66,
+        likelyBibleReferences: ["Luke 2"],
+        findings: [],
+      }),
+    )
+
+    await expect(
+      validateSubtitleScriptureAccuracy({
+        targetLanguage: "es",
+        segments: [{ start: 0, end: 2, text: "Maria dio a luz." }],
+        scriptureContext,
+        model: "test-model",
+        apiKey: "openrouter-key",
+        timeoutMs: 30_000,
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({
+      verdict: "warning",
+      warningCount: 1,
+      findings: [
+        expect.objectContaining({
+          severity: "warning",
+          category: "uncertain_reference",
+          reference: "Luke 2",
+        }),
+      ],
+    })
+  })
+
+  it("builds unavailable validation without provider text or findings", () => {
+    expect(
+      buildUnavailableSubtitleScriptureValidationResult({
+        targetLanguage: "es",
+        scriptureContext,
+        unavailableReason: "provider_failed",
+      }),
+    ).toEqual({
+      targetLanguage: "es",
+      contentDomain: "bible_story",
+      likelyBibleReferences: ["Luke 2"],
+      verdict: "unavailable",
+      basis: "unavailable",
+      confidence: 0,
+      checkedReferenceCount: 0,
+      warningCount: 0,
+      needsReviewCount: 0,
+      unavailableReason: "provider_failed",
+      findings: [],
+    })
+  })
+
+  it("keeps validation prompts compact and labeled by basis", () => {
+    const messages = _internals.buildValidationMessages({
+      targetLanguage: "en",
+      segments: [{ start: 0, end: 2, text: "Jesus was born." }],
+      scriptureContext,
+      model: "test-model",
+      timeoutMs: 30_000,
+    })
+
+    expect(messages.system).toContain("No target-language Bible passage")
+    expect(messages.user).toContain("[0] 0.00-2.00 Jesus was born.")
+  })
+})

--- a/apps/mastra/src/services/subtitle-enrichment/scripture-validation.ts
+++ b/apps/mastra/src/services/subtitle-enrichment/scripture-validation.ts
@@ -1,0 +1,212 @@
+import { requestOpenRouterChat } from "./openrouter"
+import { cleanBibleReferences } from "./scripture-context"
+import type { SubtitleBiblePassage } from "./bible-source"
+import {
+  SubtitleScriptureValidationModelOutputJsonSchema,
+  SubtitleScriptureValidationModelOutputSchema,
+  type SubtitleScriptureContext,
+  type SubtitleScriptureValidationFallbackReason,
+  type SubtitleScriptureValidationFinding,
+  type SubtitleScriptureValidationModelOutput,
+  type SubtitleScriptureValidationResult,
+  type TranscriptSegment,
+} from "./types"
+
+export type ValidateSubtitleScriptureAccuracyInput = {
+  targetLanguage: string
+  segments: TranscriptSegment[]
+  scriptureContext: SubtitleScriptureContext
+  model: string
+  apiKey?: string
+  timeoutMs: number
+  biblePassage?: SubtitleBiblePassage
+  fallbackReason?: SubtitleScriptureValidationFallbackReason
+  fetchImpl?: typeof fetch
+}
+
+const MAX_VALIDATION_TEXT_CHARS = 8_000
+
+function compactSegments(segments: TranscriptSegment[]): string {
+  let text = ""
+  for (const [index, segment] of segments.entries()) {
+    const next = `${text}${text ? "\n" : ""}[${index}] ${segment.start.toFixed(
+      2,
+    )}-${segment.end.toFixed(2)} ${segment.text.trim()}`
+    if (next.length > MAX_VALIDATION_TEXT_CHARS) {
+      return next.slice(0, MAX_VALIDATION_TEXT_CHARS)
+    }
+    text = next
+  }
+  return text
+}
+
+function validationBasis(input: ValidateSubtitleScriptureAccuracyInput) {
+  return input.biblePassage ? "target_bible_text" : "model_knowledge"
+}
+
+function buildValidationMessages(
+  input: ValidateSubtitleScriptureAccuracyInput,
+) {
+  const knownReferences = cleanBibleReferences(
+    input.scriptureContext.likelyBibleReferences,
+  )
+  const basis = validationBasis(input)
+
+  const system = [
+    "You validate translated subtitles for Christian gospel and Bible-story videos.",
+    "Return compact JSON matching the schema.",
+    "Do not include hidden reasoning, long Bible quotations, or commentary.",
+    "Flag risky scripture drift: changed meaning, omitted key details, invented details, changed names, shifted theological terms, or unsupported story details.",
+    "Treat faithful natural-language adaptation as acceptable when meaning is preserved.",
+    basis === "target_bible_text"
+      ? "A target-language Bible passage is supplied. Use it as the audit source, especially for direct quotes and version-specific phrasing."
+      : "No target-language Bible passage is supplied. Use model knowledge to identify the likely Bible story/reference and obvious drift, but lower confidence when exact wording or version-specific phrasing cannot be audited.",
+  ].join(" ")
+
+  const user = [
+    `Target language: ${input.targetLanguage}`,
+    `Detected content domain: ${input.scriptureContext.contentDomain}`,
+    `Detected confidence: ${input.scriptureContext.confidence}`,
+    knownReferences.length > 0
+      ? `Known likely references: ${knownReferences.join(", ")}`
+      : "Known likely references: none",
+    input.fallbackReason
+      ? `External Bible text fallback reason: ${input.fallbackReason}`
+      : null,
+    input.biblePassage
+      ? [
+          "Target-language Bible source:",
+          `Provider: ${input.biblePassage.provider.name}`,
+          `Bible id: ${input.biblePassage.provider.bibleId}`,
+          `Reference: ${input.biblePassage.provider.reference}`,
+          "Passage text:",
+          input.biblePassage.text,
+        ].join("\n")
+      : null,
+    "Translated subtitle segments:",
+    compactSegments(input.segments) || "(empty)",
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join("\n\n")
+
+  return { system, user }
+}
+
+function countFindings(
+  findings: SubtitleScriptureValidationResult["findings"],
+  severity: "warning" | "needs_review",
+): number {
+  return findings.filter((finding) => finding.severity === severity).length
+}
+
+function verdictFromFindings(
+  requestedVerdict: SubtitleScriptureValidationModelOutput["verdict"],
+  findings: SubtitleScriptureValidationFinding[],
+): SubtitleScriptureValidationModelOutput["verdict"] {
+  if (findings.some((finding) => finding.severity === "needs_review")) {
+    return "needs_review"
+  }
+  if (findings.some((finding) => finding.severity === "warning")) {
+    return "warning"
+  }
+  return requestedVerdict
+}
+
+function findingsWithVerdictAnchor(
+  result: SubtitleScriptureValidationModelOutput,
+  references: string[],
+): SubtitleScriptureValidationFinding[] {
+  if (result.verdict === "pass" || result.findings.length > 0) {
+    return result.findings
+  }
+
+  const severity =
+    result.verdict === "needs_review" ? "needs_review" : "warning"
+  return [
+    {
+      severity,
+      category: "uncertain_reference",
+      message: `Model returned ${result.verdict} without a specific finding; manual scripture review is recommended.`,
+      ...(references[0] ? { reference: references[0] } : {}),
+    },
+  ]
+}
+
+export function buildUnavailableSubtitleScriptureValidationResult(input: {
+  targetLanguage: string
+  scriptureContext: SubtitleScriptureContext
+  unavailableReason: string
+}): SubtitleScriptureValidationResult {
+  return {
+    targetLanguage: input.targetLanguage,
+    contentDomain: input.scriptureContext.contentDomain,
+    likelyBibleReferences: cleanBibleReferences(
+      input.scriptureContext.likelyBibleReferences,
+    ),
+    verdict: "unavailable",
+    basis: "unavailable",
+    confidence: 0,
+    checkedReferenceCount: 0,
+    warningCount: 0,
+    needsReviewCount: 0,
+    unavailableReason: input.unavailableReason.slice(0, 80),
+    findings: [],
+  }
+}
+
+export async function validateSubtitleScriptureAccuracy(
+  input: ValidateSubtitleScriptureAccuracyInput,
+): Promise<SubtitleScriptureValidationResult> {
+  const messages = buildValidationMessages(input)
+  const result = await requestOpenRouterChat({
+    apiKey: input.apiKey,
+    model: input.model,
+    timeoutMs: input.timeoutMs,
+    fetchImpl: input.fetchImpl,
+    messages: [
+      { role: "system", content: messages.system },
+      { role: "user", content: messages.user },
+    ],
+    responseFormat: {
+      name: "subtitle_scripture_validation",
+      schema: SubtitleScriptureValidationModelOutputJsonSchema,
+      validator: SubtitleScriptureValidationModelOutputSchema,
+    },
+  })
+
+  const likelyBibleReferences = cleanBibleReferences([
+    ...input.scriptureContext.likelyBibleReferences,
+    ...result.value.likelyBibleReferences,
+  ])
+  const findings = findingsWithVerdictAnchor(
+    result.value,
+    likelyBibleReferences,
+  )
+  const verdict = verdictFromFindings(result.value.verdict, findings)
+  const basis = validationBasis(input)
+
+  return {
+    targetLanguage: input.targetLanguage,
+    contentDomain: input.scriptureContext.contentDomain,
+    likelyBibleReferences,
+    verdict,
+    basis,
+    confidence: result.value.confidence,
+    checkedReferenceCount: input.biblePassage
+      ? input.biblePassage.referenceCount
+      : Math.max(likelyBibleReferences.length, 0),
+    warningCount: countFindings(findings, "warning"),
+    needsReviewCount: countFindings(findings, "needs_review"),
+    ...(input.fallbackReason ? { fallbackReason: input.fallbackReason } : {}),
+    ...(input.biblePassage ? { provider: input.biblePassage.provider } : {}),
+    findings,
+  }
+}
+
+export const _internals = {
+  compactSegments,
+  buildValidationMessages,
+  countFindings,
+  verdictFromFindings,
+  findingsWithVerdictAnchor,
+}

--- a/apps/mastra/src/services/subtitle-enrichment/types.ts
+++ b/apps/mastra/src/services/subtitle-enrichment/types.ts
@@ -53,6 +53,170 @@ export type SubtitleScriptureContext = z.infer<
   typeof SubtitleScriptureContextSchema
 >
 
+export const SubtitleScriptureValidationBasisSchema = z.enum([
+  "model_knowledge",
+  "target_bible_text",
+  "unavailable",
+])
+
+export type SubtitleScriptureValidationBasis = z.infer<
+  typeof SubtitleScriptureValidationBasisSchema
+>
+
+export const SubtitleScriptureValidationVerdictSchema = z.enum([
+  "pass",
+  "warning",
+  "needs_review",
+  "unavailable",
+])
+
+export type SubtitleScriptureValidationVerdict = z.infer<
+  typeof SubtitleScriptureValidationVerdictSchema
+>
+
+export const SubtitleScriptureValidationFallbackReasonSchema = z.enum([
+  "provider_config_missing",
+  "provider_auth_failed",
+  "provider_failed",
+  "provider_invalid_output",
+  "bible_mapping_missing",
+  "reference_unsupported",
+  "provider_rate_limited",
+])
+
+export type SubtitleScriptureValidationFallbackReason = z.infer<
+  typeof SubtitleScriptureValidationFallbackReasonSchema
+>
+
+export const SubtitleScriptureValidationFindingSchema = z
+  .object({
+    severity: z.enum(["warning", "needs_review"]),
+    category: z.enum([
+      "meaning_drift",
+      "omission",
+      "addition",
+      "proper_name",
+      "theological_term",
+      "unsupported_detail",
+      "uncertain_reference",
+    ]),
+    message: z.string().min(1).max(240),
+    reference: z.string().min(1).max(80).optional(),
+    segmentIndexes: z.array(z.number().int().nonnegative()).max(20).optional(),
+    evidence: z.string().min(1).max(240).optional(),
+  })
+  .strict()
+
+export type SubtitleScriptureValidationFinding = z.infer<
+  typeof SubtitleScriptureValidationFindingSchema
+>
+
+export const SubtitleScriptureValidationSummarySchema = z
+  .object({
+    verdict: SubtitleScriptureValidationVerdictSchema,
+    basis: SubtitleScriptureValidationBasisSchema,
+    confidence: z.number().min(0).max(1),
+    checkedReferenceCount: z.number().int().nonnegative(),
+    warningCount: z.number().int().nonnegative(),
+    needsReviewCount: z.number().int().nonnegative(),
+    fallbackReason: SubtitleScriptureValidationFallbackReasonSchema.optional(),
+    unavailableReason: z.string().min(1).max(80).optional(),
+  })
+  .strict()
+
+export type SubtitleScriptureValidationSummary = z.infer<
+  typeof SubtitleScriptureValidationSummarySchema
+>
+
+export const SubtitleScriptureValidationResultSchema =
+  SubtitleScriptureValidationSummarySchema.extend({
+    targetLanguage: z.string().min(1),
+    contentDomain: SubtitleContentDomainSchema,
+    likelyBibleReferences: z.array(z.string().min(1).max(80)).max(10),
+    provider: z
+      .object({
+        name: z.string().min(1).max(80),
+        bibleId: z.string().min(1).max(120),
+        language: z.string().min(1).max(40),
+        reference: z.string().min(1).max(120),
+        versionLabel: z.string().min(1).max(120).optional(),
+        copyright: z.string().min(1).max(240).optional(),
+      })
+      .strict()
+      .optional(),
+    findings: z.array(SubtitleScriptureValidationFindingSchema).max(20),
+  }).strict()
+
+export type SubtitleScriptureValidationResult = z.infer<
+  typeof SubtitleScriptureValidationResultSchema
+>
+
+export const SubtitleScriptureValidationModelOutputSchema = z
+  .object({
+    verdict: z.enum(["pass", "warning", "needs_review"]),
+    confidence: z.number().min(0).max(1),
+    likelyBibleReferences: z.array(z.string().min(1).max(80)).max(10),
+    findings: z.array(SubtitleScriptureValidationFindingSchema).max(20),
+  })
+  .strict()
+
+export type SubtitleScriptureValidationModelOutput = z.infer<
+  typeof SubtitleScriptureValidationModelOutputSchema
+>
+
+export const SubtitleScriptureValidationModelOutputJsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    verdict: {
+      type: "string",
+      enum: ["pass", "warning", "needs_review"],
+    },
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+    likelyBibleReferences: {
+      type: "array",
+      items: { type: "string", minLength: 1, maxLength: 80 },
+      maxItems: 10,
+    },
+    findings: {
+      type: "array",
+      maxItems: 20,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["warning", "needs_review"],
+          },
+          category: {
+            type: "string",
+            enum: [
+              "meaning_drift",
+              "omission",
+              "addition",
+              "proper_name",
+              "theological_term",
+              "unsupported_detail",
+              "uncertain_reference",
+            ],
+          },
+          message: { type: "string", minLength: 1, maxLength: 240 },
+          reference: { type: "string", minLength: 1, maxLength: 80 },
+          segmentIndexes: {
+            type: "array",
+            items: { type: "integer", minimum: 0 },
+            maxItems: 20,
+          },
+          evidence: { type: "string", minLength: 1, maxLength: 240 },
+        },
+        required: ["severity", "category", "message"],
+      },
+    },
+  },
+  required: ["verdict", "confidence", "likelyBibleReferences", "findings"],
+} as const
+
 export const SubtitleScriptureContextJsonSchema = {
   type: "object",
   additionalProperties: false,
@@ -118,9 +282,11 @@ export const SubtitleLanguageResultSchema = z
       .object({
         vtt: z.string().min(1),
         json: z.string().min(1),
+        validation: z.string().min(1).optional(),
       })
       .strict()
       .optional(),
+    validationSummary: SubtitleScriptureValidationSummarySchema.optional(),
   })
   .strict()
 

--- a/docs/plans/2026-06-16-002-feat-subtitle-scripture-accuracy-validation-plan.md
+++ b/docs/plans/2026-06-16-002-feat-subtitle-scripture-accuracy-validation-plan.md
@@ -1,0 +1,450 @@
+---
+type: feat
+status: completed
+created: 2026-06-16
+updated: 2026-06-16
+owner: media-generation
+---
+
+# feat: Add subtitle scripture accuracy validation
+
+## Summary
+
+Add a report-first subtitle scripture accuracy validation pass after Mastra completes subtitle translation and retiming. When a subtitle translation has a known or confidently inferred Bible-story reference, Mastra should use model knowledge to detect likely scripture drift, optionally compare against a configured target-language Bible text source when one is available, write a reviewable validation artifact, and return advisory risk signals to Manager.
+
+This is intentionally not a blocking publish or Mux-sync gate. Translation remains usable, and validation can still run in model-only mode, when Bible-source coverage, licensing, credentials, or rate limits are missing. The first slice should make risky scripture drift visible without creating a full doctrinal approval product.
+
+## Problem Frame
+
+The existing biblical subtitle translation context plan improves translation prompts by telling the model that many videos are Christian gospel or Bible-story content. That helps the model translate closer to scripture-aware wording, but it does not validate the translated result after the fact.
+
+Operators need a way to see whether a translated subtitle has likely drifted from the Bible story or passage it is based on. Examples include omitted details, invented details, changed names, shifted theological terms, or target-language phrasing that diverges from a known Bible text when a direct scripture story is being translated.
+
+The current workflow already has the right ownership split:
+
+- Mastra owns translation, retiming, scripture-context detection, provider prompts, and subtitle artifacts.
+- Manager owns orchestration, job state, artifact presentation, and Mux subtitle sync.
+- Mux sync should continue to depend on translation success, not on this advisory validation result.
+
+## Goals
+
+- Validate translated subtitles for Bible-story/scripture-sensitive videos after translation completes.
+- Run a useful model-knowledge validation pass even when no Bible API or target-language Bible source is configured.
+- Use target-language Bible text to improve confidence and auditability when a configured provider and Bible/version mapping are available.
+- Produce structured advisory results that Manager can show to operators.
+- Keep translation and Mux sync resilient when validation is model-only, unavailable, or inconclusive.
+- Avoid storing provider secrets, raw prompts, or full copyrighted Bible text unless a configured license explicitly permits it.
+
+## Non-Goals
+
+- Do not validate source transcription or generated source-language subtitles in this slice.
+- Do not block publish, Mux sync, or job completion based on validation results.
+- Do not build a human review queue or doctrinal approval workflow.
+- Do not implement broad theology validation beyond scripture-passage comparison for subtitle translation.
+- Do not require a Bible API before scripture-drift validation can run.
+- Do not hard-code one Bible provider as the permanent source of truth.
+- Do not change Admin GraphQL contracts unless implementation discovers an unavoidable dependency.
+
+## Requirements
+
+### Validation Basis And Reference Handling
+
+- R1. Mastra must attempt scripture validation when scripture context identifies one or more Bible references, or when the validator can confidently infer a Bible story/reference from the translated subtitle content and translation context.
+- R2. Mastra must support a model-knowledge validation basis that can run without any Bible API, using the model's knowledge of Bible stories, likely references, names, sequence, and meaning.
+- R3. Mastra must support a provider-agnostic Bible text adapter as an optional evidence upgrade, with provider choice and Bible/version mapping configured outside Manager.
+- R4. Target-language Bible/version selection must be explicit per language or language family when external Bible text is used. Missing mapping should fall back to model-knowledge validation, not make validation unavailable.
+- R5. Provider errors, missing credentials, licensing gaps, unsupported languages, and rate limits must degrade to model-knowledge validation when the validation model is available.
+- R6. Validation artifacts must record the validation basis, such as `model_knowledge`, `target_bible_text`, or `unavailable`.
+- R7. Provider metadata in artifacts must include enough provenance for review when external Bible text is used: provider name, bible/version id or label, reference, language, and retrieval status.
+
+### Validation Behavior
+
+- R8. Validation must run after translation artifacts are generated, using the translated subtitle text and either model knowledge alone or the resolved target-language Bible passage text when available.
+- R9. Validation must produce structured advisory verdicts per language and reference: `pass`, `warning`, `needs_review`, or `unavailable`.
+- R10. Findings must be bounded and reviewable: severity, category, rationale, affected subtitle segment ids or time ranges when available, short evidence snippets, and confidence.
+- R11. The validator must distinguish between faithful natural-language adaptation and risky scripture drift. It should not require exact word-for-word matching unless the content appears to be a direct quote and a target Bible text source is available.
+- R12. Model-only validation must communicate lower auditability than target-Bible-text validation, especially for exact target-language phrasing or Bible-version wording.
+- R13. Same-language no-op results and non-Bible contexts must skip validation unless future requirements explicitly broaden the feature.
+
+### Manager And Operator Surfacing
+
+- R14. Manager must accept optional validation artifact keys and compact validation summaries from Mastra without breaking existing translation result parsing.
+- R15. Manager must add validation artifacts to translation-step artifact links when present.
+- R16. Manager job step details must expose an advisory validation summary per language without changing Mux sync behavior.
+- R17. Existing successful translated subtitles must still sync to Mux even when validation is `warning`, `needs_review`, `model_knowledge`-only, or `unavailable`.
+
+### Safety And Observability
+
+- R18. Logs must be sanitized. Do not log provider keys, raw prompts, or full copyrighted Bible passage text.
+- R19. Validation artifacts must not store full provider passage text unless the selected provider/license allows it. Prefer short snippets, hashes, provider ids, and structured findings.
+- R20. Mastra must emit enough status information to separate provider/config fallback from actual `needs_review` scripture findings.
+- R21. Validation latency and cost must be controlled by running only for languages and contexts where Bible-story signals or references are present.
+
+## High-Level Design
+
+```mermaid
+flowchart TD
+  A["Manager video enrichment workflow"] --> B["Mastra subtitle enrichment route"]
+  B --> C["Translate and retime subtitles"]
+  C --> D{"Bible story/reference known or confidently inferred?"}
+  D -- "no" --> E["Write VTT and translation JSON only"]
+  D -- "yes" --> F["Run model-knowledge scripture validation"]
+  F --> G{"Target Bible source configured and available?"}
+  G -- "no" --> H["Write validation artifact: model_knowledge basis"]
+  G -- "yes" --> I["Compare with target-language Bible passage"]
+  I --> J["Write validation artifact: target_bible_text basis"]
+  E --> K["Return language results to Manager"]
+  H --> K
+  J --> K
+  K --> L["Manager artifact links and step details"]
+  K --> M["Mux subtitle sync unchanged"]
+```
+
+## Key Technical Decisions
+
+### KTD-1: Report-first validation
+
+The first slice should be advisory. Model-only validation is useful but not definitive, and Bible-source coverage, licensing, and language/version mapping will be incomplete at first, so blocking publish would create false operational failures. `needs_review` should make risk visible, while Mux sync remains tied to translated subtitle success.
+
+### KTD-2: Model knowledge is the baseline
+
+The validator should work even when no Bible API is configured. The model can often identify Bible stories, likely references, obvious omissions, invented details, changed names, and meaning drift. Those results should be labeled with `basis: "model_knowledge"` and a confidence value so operators understand the finding is model-grounded rather than source-text-grounded.
+
+### KTD-3: Mastra owns validation and optional Bible-provider access
+
+Model validation prompts, optional Bible-provider credentials, reference resolution, and provider calls belong in `apps/mastra`. Manager should only receive sanitized artifact keys and summary data. This matches the existing boundary where Mastra owns translation, retiming, provider prompts, and scripture-context detection.
+
+### KTD-4: Provider-agnostic adapter with API.Bible as an optional candidate
+
+Implement a small internal provider interface rather than binding workflow code directly to a single API. API.Bible is a plausible optional candidate because its official docs cover Bible catalog lookup, passage retrieval, licensing/access, rate limits, and DBL/USX-oriented metadata. Provider approval and exact Bible/version mapping are prerequisites for enabling the `target_bible_text` basis in production, not prerequisites for validation overall.
+
+### KTD-5: Validation happens after translation, not inside translation
+
+The translation prompt should still use scripture context, but validation should inspect the completed translated subtitles as a separate step. This makes the result auditable and avoids hiding corrections inside the translation call.
+
+### KTD-6: Additive result contract
+
+Extend language artifact keys with an optional validation key, for example `artifactKeys.validation`, and add an optional compact validation summary on each language result. The summary should include verdict, basis, confidence, checked reference count, warning count, needs-review count, and unavailable reason when applicable. Existing `artifactKeys.vtt` and `artifactKeys.json` behavior should remain unchanged, and consumers that only care about subtitles continue to ignore validation.
+
+### KTD-7: Provider unavailable usually falls back, not fails
+
+Provider/config/licensing/rate-limit issues should not become language translation failures. When the validation model is available, these issues should produce `basis: "model_knowledge"` with source fallback reasons such as `provider_config_missing`, `bible_mapping_missing`, `reference_unsupported`, `provider_rate_limited`, or `provider_failed`. Reserve `unavailable` for cases where validation cannot run at all.
+
+### KTD-8: Do not store full copyrighted passage text by default
+
+The validation artifact should store basis, provenance, short evidence snippets, segment references, confidence, and structured findings. Full passage text should only be stored when the selected Bible source and license explicitly permit it.
+
+## Implementation Units
+
+### U1. Roadmap And Contract Shape
+
+Create the roadmap entry for this feature and define the additive Mastra/Manager result shape before implementation.
+
+Likely files:
+
+- `docs/roadmap/media-generation/feat-193-subtitle-scripture-accuracy-validation.md`
+- `docs/roadmap/README.md`
+- `apps/mastra/src/services/subtitle-enrichment/types.ts`
+- `apps/mastra/src/mastra/workflows/subtitle-enrichment.ts`
+- `apps/manager/src/services/mastra-subtitle-enrichment.ts`
+- `apps/manager/src/types/job.ts`
+
+Implementation notes:
+
+- Add a `SubtitleScriptureValidationResult` or similarly named shared local schema in Mastra.
+- Extend `SubtitleLanguageResultSchema.artifactKeys` with optional `validation`.
+- Add an optional compact language-level validation summary with verdict, basis, confidence, checked reference count, needs-review count, warning count, fallback reason, and unavailable reason when applicable.
+- Mirror the optional validation artifact key and compact summary in Manager parsing.
+- Keep existing success/failure envelope semantics unchanged.
+
+Tests:
+
+- Mastra accepts and returns language results with optional validation artifact keys.
+- Manager parses old Mastra responses without validation keys.
+- Manager parses new responses with validation keys, basis, confidence, and compact validation summaries.
+- Translation success status is independent from validation verdict.
+
+### U2. Optional Bible Source Adapter And Reference Resolver
+
+Add a Mastra-owned adapter that resolves configured target-language Bible text for detected references when an external Bible source is enabled. This adapter upgrades validation basis from `model_knowledge` to `target_bible_text`; it is not required for validation to run.
+
+Likely files:
+
+- `apps/mastra/src/services/subtitle-enrichment/bible-source.ts`
+- `apps/mastra/src/services/subtitle-enrichment/bible-source.test.ts`
+- `apps/mastra/src/services/subtitle-enrichment/scripture-context.ts`
+- `apps/mastra/src/env.ts` or the existing Mastra config surface
+- `apps/mastra/AGENTS.md`
+- `apps/mastra/CLAUDE.md`
+
+Implementation notes:
+
+- Define a provider interface that returns passage text plus provenance metadata.
+- Keep API.Bible-specific URL/id logic behind one adapter implementation.
+- Configure provider choice, API key, base URL, and target-language Bible/version mapping through Mastra env/config.
+- Normalize detected Bible references into provider-compatible ids only when confidence is high enough.
+- Use model-knowledge fallback for unsupported external references, unsupported provider languages, missing mapping, missing credentials, and provider failures when the validation model is available.
+- Include fallback reasons in validation summaries so operators can tell when external Bible text was not used.
+
+Tests:
+
+- Missing provider config falls back to `model_knowledge` and does not throw through translation.
+- Missing target-language Bible mapping falls back to `model_knowledge`.
+- Provider success returns passage text with provenance.
+- Provider 401/403/404/429/5xx are mapped to structured fallback reasons.
+- Reference normalization handles book/chapter/verse ranges used by scripture context.
+
+### U3. Scripture Accuracy Validator
+
+Add a validator that compares translated subtitle text against model knowledge and, when available, target-language Bible passage text. It returns structured findings either way and labels the basis used.
+
+Likely files:
+
+- `apps/mastra/src/services/subtitle-enrichment/scripture-validation.ts`
+- `apps/mastra/src/services/subtitle-enrichment/scripture-validation.test.ts`
+- `apps/mastra/src/services/subtitle-enrichment/openrouter.ts`
+- `apps/mastra/src/services/subtitle-enrichment/types.ts`
+
+Implementation notes:
+
+- Use deterministic guards first: empty text, missing references, unsupported context, and unavailable validation model.
+- Use a structured LLM comparison for both model-only and target-Bible-text modes.
+- Include the translated subtitle full text and relevant segment/timing data in the validator input.
+- In model-only mode, ask the validator to identify likely Bible story, likely reference, risky meaning drift, omissions, additions, changed names, theological term shifts, and unsupported details from model knowledge.
+- In target-Bible-text mode, ask the validator to compare against the supplied passage text and be stricter about direct quotes and version-specific phrasing.
+- Return bounded evidence snippets and segment ids/time ranges rather than full passage dumps.
+- Return `basis` and `confidence` on every validation result.
+- Treat faithful natural-language adaptation as acceptable when meaning is preserved.
+
+Tests:
+
+- Faithful adaptation produces `pass` in model-only mode.
+- Faithful adaptation produces `pass` in target-Bible-text mode.
+- Minor model-only uncertainty produces `warning` with lower confidence.
+- Invented scripture detail produces `needs_review`.
+- Missing external passage falls back to model-only validation.
+- Missing validation model produces `unavailable`.
+- Validator output schema rejects unbounded or malformed findings.
+
+### U4. Integrate Validation Into Mastra Subtitle Run
+
+Run validation after each translated language completes and write validation artifacts alongside existing subtitle artifacts.
+
+Likely files:
+
+- `apps/mastra/src/services/subtitle-enrichment/run.ts`
+- `apps/mastra/src/services/subtitle-enrichment/run.test.ts`
+- `apps/mastra/src/mastra/workflows/subtitle-enrichment.ts`
+- `apps/mastra/src/services/subtitle-enrichment/types.ts`
+
+Implementation notes:
+
+- Preserve current same-language no-op behavior.
+- Only run validation for translated languages when scripture context contains references or strong Bible-story signals.
+- Write a JSON artifact such as `subtitle-validation-${targetLanguage}` or `scripture-validation-${targetLanguage}`.
+- Include validation artifact key in `artifactKeys.validation` when writing succeeds.
+- Include a compact validation summary on the language result whenever validation is attempted, including basis, confidence, and fallback reason when external Bible text is not used.
+- If optional Bible-source lookup fails after translation succeeds, fall back to model-only validation.
+- If validation itself fails after translation succeeds, return the language as completed and record validation `unavailable` when possible.
+- Avoid adding validation data to VTT artifacts.
+
+Tests:
+
+- Bible-story translation with a known or confidently inferred reference writes VTT, translation JSON, and validation JSON.
+- Non-Bible translation writes only existing VTT and translation JSON.
+- Same-language result skips validation.
+- Optional Bible provider failure does not mark the language failed and falls back to model-only validation.
+- Validation storage failure is logged and does not break completed subtitle translation unless existing storage guarantees require otherwise.
+
+### U5. Surface Validation In Manager
+
+Teach Manager to expose validation artifacts and advisory summaries in the translation step.
+
+Likely files:
+
+- `apps/manager/src/services/mastra-subtitle-enrichment.ts`
+- `apps/manager/src/workflows/videoEnrichment.ts`
+- `apps/manager/src/lib/job-artifacts.ts`
+- `apps/manager/src/types/job.ts`
+- Existing Manager tests around translation result parsing and artifact manifests
+
+Implementation notes:
+
+- Accept optional `artifactKeys.validation` and compact validation summaries from Mastra.
+- Add dynamic artifact labels/descriptors for subtitle scripture validation artifacts.
+- Include validation artifacts in the translation step artifact manifest when present.
+- Use Mastra's compact validation summaries to populate `JobStepDetails`, such as highest verdict, basis, confidence, languages checked, languages using model-only fallback, languages unavailable, and needs-review count.
+- Keep `syncTranslatedSubtitlesToMux` unchanged except for ignoring validation metadata.
+
+Tests:
+
+- Translation artifact manifest includes validation JSON when Mastra returns it.
+- Translation artifact manifest remains unchanged for old Mastra results.
+- Job step details summarize advisory validation basis and results from compact Mastra summaries without changing language completion.
+- Mux sync still receives the same completed language VTT/JSON inputs as before.
+
+### U6. Documentation And Operational Guardrails
+
+Document how to enable, operate, and interpret the validation pass.
+
+Likely files:
+
+- `apps/mastra/AGENTS.md`
+- `apps/mastra/CLAUDE.md`
+- `apps/manager/AGENTS.md`
+- `apps/manager/CLAUDE.md`
+- `docs/roadmap/media-generation/feat-193-subtitle-scripture-accuracy-validation.md`
+
+Implementation notes:
+
+- Document that model-knowledge validation is the default baseline and Bible-source provider access is optional.
+- Document required Mastra env/config for enabling the optional Bible-source provider path.
+- Document that validation is advisory and non-blocking in this slice.
+- Document that provider licensing and target-language Bible/version mapping must be approved before production use.
+- Document what `pass`, `warning`, `needs_review`, and `unavailable` mean for operators.
+- Document what `model_knowledge` and `target_bible_text` bases mean for operators.
+- Document artifact privacy rules: no secrets, no raw prompts, no full copyrighted passage text unless license permits.
+
+Tests:
+
+- Documentation names the exact config keys introduced by implementation.
+- Documentation explains model-only fallback behavior for missing provider/config/license coverage.
+- Roadmap status and dependencies are updated at implementation completion.
+
+## Acceptance Examples
+
+### AE-1: Bible story with configured target Bible source
+
+Input: English source subtitles for a Bible-story video, target language configured with a Bible/version mapping, and scripture context resolving to a known reference.
+
+Expected:
+
+- Translation completes.
+- VTT and translation JSON artifacts are written.
+- Validation JSON artifact is written.
+- Manager translation step links all three artifacts.
+- Job details show advisory verdict, `target_bible_text` basis, confidence, and summary.
+- Mux sync uploads the translated VTT as before.
+
+### AE-2: Bible story with no Bible provider config
+
+Input: Same as AE-1, but Mastra has no Bible provider key or no target-language Bible mapping.
+
+Expected:
+
+- Translation completes.
+- Existing subtitle artifacts are written.
+- Validation still runs using `model_knowledge` basis.
+- Validation artifact is written when validation completes.
+- Job does not fail because external Bible text is unavailable.
+- Manager summary shows model-only basis, confidence, and any fallback reason.
+
+### AE-3: Non-Bible or low-confidence scripture context
+
+Input: A generic video or a gospel-adjacent video with no confident Bible reference.
+
+Expected:
+
+- Translation completes as it does today.
+- Validation is skipped.
+- No validation artifact is required.
+- Manager and Mux behavior remain unchanged.
+
+### AE-4: Risky scripture drift in model-only mode
+
+Input: A Bible-story translation that adds unsupported details or changes a key name/meaning, with no external Bible text configured.
+
+Expected:
+
+- Translation still completes.
+- Validation artifact verdict is `needs_review` with `basis: "model_knowledge"`.
+- Findings identify the likely story/reference, issue category, confidence, and affected segments/time ranges.
+- Manager surfaces advisory risk with model-only basis.
+- Mux sync is not blocked in this slice.
+
+### AE-5: Risky scripture drift with target Bible text
+
+Input: A Bible-story translation that adds unsupported details or changes a key name/meaning relative to the target-language Bible passage.
+
+Expected:
+
+- Translation still completes.
+- Validation artifact verdict is `needs_review` with `basis: "target_bible_text"`.
+- Findings identify the issue category and affected segments/time ranges.
+- Manager surfaces advisory risk.
+- Mux sync is not blocked in this slice.
+
+## System-Wide Impact
+
+### Mastra
+
+- Adds a model-knowledge validation module to subtitle enrichment.
+- Adds an optional Bible-source adapter for higher-confidence source-text validation.
+- Adds optional provider credentials/config only for the external Bible-source path.
+- Adds one optional artifact per validated target language.
+- Adds extra model calls only for scripture-context translations, and provider calls only when optional external Bible text is configured.
+
+### Manager
+
+- Parses an additive validation artifact key.
+- Adds validation artifacts and summaries to translation step details.
+- Leaves existing workflow step ordering and Mux subtitle sync unchanged.
+
+### Admin
+
+- No planned Admin schema changes.
+- No generated Admin GraphQL type changes expected.
+
+### Mux
+
+- No planned Mux contract changes.
+- Translated VTT sync remains based on successful translated language results.
+
+## Risks And Mitigations
+
+- Model-memory risk: model-only validation can miss subtle passage/version differences or assert uncertain details too confidently. Mitigation: label basis and confidence, keep results advisory, and use target Bible text when exactness matters.
+- Licensing risk: Bible providers may restrict display/storage of passage text. Mitigation: make external Bible text optional, store metadata and bounded snippets by default, and require provider/license approval before production enablement.
+- Coverage risk: target-language Bible mappings may be incomplete. Mitigation: fall back to `model_knowledge` instead of failing validation.
+- False-positive risk: subtitles may be faithful adaptations rather than direct Bible quotes. Mitigation: validator instructions should preserve meaning rather than demand exact wording, and direct-quote strictness should apply only when the content appears to quote scripture.
+- Latency/cost risk: validation adds model calls, and optional provider calls when external Bible text is configured. Mitigation: run only when scripture references or strong Bible-story signals are present.
+- Operator trust risk: advisory verdicts could be treated as definitive. Mitigation: label results as validation assistance and keep human review language in docs.
+- Storage/privacy risk: artifacts could accidentally contain secrets, prompts, or too much Bible text. Mitigation: schema-level artifact constraints and tests for sanitized output.
+
+## Validation Plan
+
+- Mastra unit tests for model-only validation, optional Bible source adapter, reference normalization, provider fallback mapping, validation verdict schema, and subtitle run integration.
+- Manager unit tests for Mastra response parsing, basis/confidence propagation, artifact manifest generation, job step detail summaries, and unchanged Mux sync inputs.
+- Existing subtitle enrichment workflow tests for translated and same-language paths.
+- Typecheck/lint for touched Mastra and Manager packages.
+- Focused local workflow fixtures for one scripture-context translation in model-only mode and one with a mocked Bible provider.
+
+## Dependencies
+
+- No Bible provider is required for the first model-only validation slice.
+- A provider and licensing decision is required only before enabling production `target_bible_text` validation.
+- Mastra secret/config management is required only for optional provider credentials and language-to-Bible mapping.
+- Agreement on artifact naming, recommended default: `subtitle-validation-${targetLanguage}`.
+- Agreement that this slice remains advisory and non-blocking.
+
+## Deferred Follow-Ups
+
+- Blocking publish/Mux-sync gate for high-risk scripture drift.
+- Human review queue and approval UI.
+- Full doctrinal validation integration with `docs/roadmap/platform/feat-067-doctrinal-validation-engine.md`.
+- Validation of generated source subtitles or transcription accuracy.
+- Provider/version selection UI for operators.
+- Translation feedback loop that re-runs translation after validation findings.
+
+## Sources And Research
+
+- Existing plan: `docs/plans/2026-06-16-001-feat-biblical-subtitle-translation-context-plan.md`
+- Mastra subtitle run and types: `apps/mastra/src/services/subtitle-enrichment/run.ts`, `apps/mastra/src/services/subtitle-enrichment/types.ts`
+- Mastra workflow route: `apps/mastra/src/mastra/workflows/subtitle-enrichment.ts`
+- Manager Mastra client: `apps/manager/src/services/mastra-subtitle-enrichment.ts`
+- Manager artifact handling: `apps/manager/src/lib/job-artifacts.ts`, `apps/manager/src/workflows/videoEnrichment.ts`
+- Existing broad doctrinal roadmap: `docs/roadmap/platform/feat-067-doctrinal-validation-engine.md`
+- API.Bible docs: `https://docs.api.bible/`
+- API.Bible working with Bibles: `https://docs.api.bible/quick-start/working-with-bibles/`
+- API.Bible passages guide: `https://docs.api.bible/guides/passages/`
+- API.Bible licensing/access: `https://docs.api.bible/quick-start/licensing-and-access/`
+- API.Bible rate limiting: `https://docs.api.bible/quick-start/rate-limiting/`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,8 +6,8 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 
 ## Status (June 4, 2026)
 
-- **Total tickets:** 191
-- **Complete:** 116
+- **Total tickets:** 192
+- **Complete:** 117
 - **In progress:** 9
 - **Not started:** 21
 - **Blocked:** 43
@@ -110,6 +110,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-188](media-generation/feat-188-manager-job-state-mastra-correlation.md)             | Manager job state and Mastra correlation hardening        | vlad  | P1       | 2026-06-13 | 1    | 2026-06-13 | complete    |
 | [feat-189](media-generation/feat-189-watch-caption-language-availability.md)              | Watch caption language availability                       | vlad  | P1       | 2026-06-15 | 1    | 2026-06-15 | complete    |
 | [feat-192](media-generation/feat-192-biblical-subtitle-translation-context.md)            | Biblical subtitle translation context                     | vlad  | P1       | 2026-06-16 | 1    | 2026-06-16 | complete    |
+| [feat-193](media-generation/feat-193-subtitle-scripture-accuracy-validation.md)           | Subtitle scripture accuracy validation                    | vlad  | P1       | 2026-06-16 | 1    | 2026-06-16 | complete    |
 | [feat-056](media-generation/feat-056-ai-video-template-system.md)                         | AI Video Template System                                  | vlad  | P1       | 2026-07-01 | 31   | 2026-07-31 | not-started |
 | [feat-057](media-generation/feat-057-automated-video-rendering-engine.md)                 | Automated Video Rendering Engine                          | vlad  | P1       | 2026-08-01 | 31   | 2026-08-31 | blocked     |
 | [feat-060](media-generation/feat-060-on-demand-personalized-video-generation.md)          | On-Demand Personalized Video Generation                   | vlad  | P1       | 2026-09-01 | 30   | 2026-09-30 | blocked     |

--- a/docs/roadmap/media-generation/feat-192-biblical-subtitle-translation-context.md
+++ b/docs/roadmap/media-generation/feat-192-biblical-subtitle-translation-context.md
@@ -8,7 +8,8 @@ start_date: "2026-06-16"
 duration: 1
 depends_on:
   - "feat-184"
-blocks: []
+blocks:
+  - "feat-193"
 tags:
   - "manager"
   - "mastra"

--- a/docs/roadmap/media-generation/feat-193-subtitle-scripture-accuracy-validation.md
+++ b/docs/roadmap/media-generation/feat-193-subtitle-scripture-accuracy-validation.md
@@ -1,0 +1,84 @@
+---
+id: "feat-193"
+title: "Subtitle scripture accuracy validation"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-16"
+duration: 1
+depends_on:
+  - "feat-192"
+blocks: []
+tags:
+  - "manager"
+  - "mastra"
+  - "subtitle-enrichment"
+  - "gospel-content"
+  - "validation"
+---
+
+## Problem
+
+Biblical subtitle translation now receives gospel-aware context, but operators
+still need a lightweight accuracy signal after translation. For Bible-story
+videos, the system should compare translated subtitles against the likely
+Scripture reference and flag risky paraphrases or doctrinally important drift.
+
+## Entry Points - Read These First
+
+1. `docs/plans/2026-06-16-002-feat-subtitle-scripture-accuracy-validation-plan.md`
+   - implementation plan and scope boundary.
+2. `docs/roadmap/media-generation/feat-192-biblical-subtitle-translation-context.md`
+   - prior scripture-context detection and translation prompt steering.
+3. `apps/mastra/src/services/subtitle-enrichment/`
+   - Mastra-owned scripture detection, translation, retiming, validation, and
+     subtitle artifact writes.
+4. `apps/manager/src/services/mastra-subtitle-enrichment.ts`
+   - Manager-side service contract parser for Mastra subtitle results.
+5. `apps/manager/src/workflows/videoEnrichment.ts`
+   - job state and artifact manifest projection for translated subtitles.
+6. `apps/manager/src/features/jobs/live-job-steps-table.tsx`
+   - live operator display for translation and validation summaries.
+
+## Grep These
+
+- `SubtitleScriptureValidation`
+- `validateSubtitleScriptureAccuracy`
+- `loadConfiguredBiblePassage`
+- `validationSummary`
+- `subtitleValidation`
+- `subtitle-validation-`
+
+## What To Build
+
+- Add a Mastra-owned subtitle scripture validation pass for translated
+  Bible-story subtitles.
+- Use model knowledge as the default validation basis so validation still runs
+  without a Bible API.
+- Support an optional target-language Bible text source for stronger checks
+  when `SUBTITLE_VALIDATION_BIBLE_PROVIDER=api_bible`,
+  `SUBTITLE_VALIDATION_BIBLE_MAP_JSON`, and `API_BIBLE_API_KEY` are configured.
+- Fall back from missing or failing Bible source configuration to
+  `basis=model_knowledge` instead of marking validation unavailable.
+- Write sanitized per-language validation artifacts and return compact
+  validation summaries in Mastra language results.
+- Preserve Manager's existing subtitle translation and Mux sync behavior while
+  adding validation artifacts to job artifact manifests and live job details.
+
+## Constraints
+
+- Do not store full external Bible passage text in durable artifacts.
+- Do not make Bible API availability a blocker for subtitle translation.
+- Do not use validation to publish, reject, or block Mux subtitle sync in this
+  slice; it is operator-visible advisory signal only.
+- Do not move scripture detection, model validation, or Bible-source calls into
+  Manager.
+- Do not expose raw prompts, provider keys, hidden model reasoning, or
+  sensitive request metadata in validation artifacts.
+
+## Verification
+
+- `pnpm --filter @forge/mastra test -- subtitle-enrichment`
+- `pnpm --filter @forge/mastra typecheck`
+- `pnpm --filter @forge/manager test -- mastra-subtitle-enrichment job-artifacts state videoEnrichment`
+- `pnpm --filter @forge/manager typecheck`


### PR DESCRIPTION
## Summary
Subtitle translation jobs now leave behind a reviewable scripture-accuracy signal when content appears to be a Bible story or carries explicit Bible references. Mastra checks completed translated subtitle artifacts against model scripture knowledge by default, can optionally use a configured target-language Bible source for supported references, and falls back visibly instead of blocking translation when provider, artifact, or write paths are unavailable.

Manager now carries validation summaries and artifacts through job state, artifact manifests, live step details, and review context, so reviewers and agents can see which languages passed, need review, used model-only evidence, or could not be validated. Rerunning transcription also prunes stale scripture-validation reports with the old subtitle artifacts, keeping review state tied to the current generation.

## Design Notes
| Area | Decision |
|---|---|
| Validation source | Model knowledge is the default so the workflow works without a Bible API; API.Bible is optional and only used when configured safely. |
| Safety | Production API.Bible calls require HTTPS plus an allowlisted host before credentials are sent. |
| Failure behavior | Translation stays complete; validation writes a bounded unavailable summary when checks cannot run. |
| Review surface | Validation artifacts flow through the normal job manifest and review-context API instead of a separate UI path. |

## Validation
- `pnpm --filter @forge/mastra test -- subtitle-enrichment`
- `pnpm --filter @forge/manager test -- transcription/rerun load-job-review-context review-context-refresh-key mastra-subtitle-enrichment job-artifacts state videoEnrichment`
- `pnpm --filter @forge/mastra lint`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/manager typecheck`
- `git diff --check c12228ccea909d97ec5287543ec39c4aa62f82c9`

Browser smoke was not run because this validation path needs an authenticated Manager job with Mastra-generated artifacts; the changed UI/API surfaces are covered by the targeted state, artifact, review-context, and workflow tests above.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
