### PR TITLE
fix(mastra): exclude commentary in Instagram discovery

### DIFF
--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -396,7 +396,10 @@ markdown hydration for each search hit, slower), `maxResults` (50),
 `persistArtifact` (true). The
 workflow searches each query (tolerant to per-query failures), parses Instagram
 permalinks, dedupes by shortcode, and keeps only posts whose caption/hashtags
-signal **both** AI-generation and Christian content.
+signal **both** AI-generation and Christian content **and** do not read as
+commentary/news/tutorial (a conservative `COMMENTARY_KEYWORDS` exclusion in
+`classifier.ts`, e.g. "should we", "here's my", "tutorial", "went viral"). The
+report's `totals.excludedCommentary` counts posts dropped by that filter.
 
 Results are returned in the response and, by default, written to a validated
 JSON artifact under `INSTAGRAM_DISCOVERY_ARTIFACT_DIR`
@@ -405,8 +408,9 @@ JSON artifact under `INSTAGRAM_DISCOVERY_ARTIFACT_DIR`
 Limitations to keep in mind:
 
 - **Keyword classification is heuristic and noisy.** It flags keyword signals,
-  not verified AI-generation or Christian intent. An optional LLM confirmation
-  step is deferred follow-up work.
+  not verified AI-generation or Christian intent. The commentary exclusion filter
+  removes obvious news/tutorial/reaction posts, but a meaning-aware LLM relevance
+  check is deferred follow-up work.
 - **`publishedAt` is best-effort.** Instagram rarely exposes a reliable
   timestamp through search snippets, so it is frequently `null` unless scrape
   metadata includes it.

--- a/apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.test.ts
+++ b/apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.test.ts
@@ -64,6 +64,11 @@ const aiOnlyHit = {
   description: "Made with Midjourney, neon city",
 }
 const nonInstagramHit = { url: "https://youtube.com/watch?v=1" }
+const commentaryHit = {
+  url: "https://www.instagram.com/reel/COMMENT1/",
+  description:
+    "Should we be listening to AI generated Christian music? Here's my thoughts",
+}
 
 describe("runInstagramDiscovery", () => {
   it("returns only qualifying posts and writes an artifact", async () => {
@@ -93,10 +98,32 @@ describe("runInstagramDiscovery", () => {
       candidates: 3,
       instagram: 2,
       deduped: 2,
+      excludedCommentary: 0,
       qualified: 1,
     })
     expect(result.artifactPath).toBe("/tmp/fake/reports/run-1.json")
     expect(store.written).toHaveLength(1)
+  })
+
+  it("excludes commentary posts and counts them", async () => {
+    const store = fakeStore()
+    const result = await runInstagramDiscovery(
+      { queries: ["q"] },
+      {
+        runId: "run-comment",
+        firecrawlConfig: CONFIG,
+        searchQuery: async () => [aiChristianHit, commentaryHit],
+        artifactStore: store,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error("expected success")
+    expect(result.posts).toHaveLength(1)
+    expect(result.posts[0]!.shortcode).toBe("ABC123")
+    expect(result.posts.some((p) => p.shortcode === "COMMENT1")).toBe(false)
+    expect(result.totals.excludedCommentary).toBe(1)
+    expect(result.totals.qualified).toBe(1)
   })
 
   it("dedupes the same shortcode across queries", async () => {
@@ -266,14 +293,15 @@ describe("runInstagramDiscovery", () => {
       {
         runId: "run-cap",
         firecrawlConfig: CONFIG,
-        searchQuery: async () => [aiChristianHit, secondHit],
+        searchQuery: async () => [aiChristianHit, secondHit, commentaryHit],
         artifactStore: store,
       },
     )
 
     expectSuccess(result)
     expect(result.posts).toHaveLength(1)
-    expect(result.totals.deduped).toBe(2)
+    expect(result.totals.deduped).toBe(3)
+    expect(result.totals.excludedCommentary).toBe(1)
     expect(result.totals.qualified).toBe(1)
   })
 
@@ -372,7 +400,13 @@ describe("handleInstagramDiscoveryRouteRequest", () => {
   const okResult: InstagramDiscoveryWorkflowResult = {
     ok: true,
     mastraRunId: "r",
-    totals: { candidates: 0, instagram: 0, deduped: 0, qualified: 0 },
+    totals: {
+      candidates: 0,
+      instagram: 0,
+      deduped: 0,
+      excludedCommentary: 0,
+      qualified: 0,
+    },
     posts: [],
     queryFailures: [],
   }

--- a/apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.ts
+++ b/apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.ts
@@ -114,6 +114,7 @@ type DedupeCandidate = {
   post: InstagramPost
   matchedAi: string[]
   matchedChristian: string[]
+  matchedCommentary: string[]
 }
 
 // Step-boundary projection of Firecrawl results. Deliberately .strict():
@@ -372,7 +373,8 @@ export async function searchInstagramCandidates(
 /**
  * Parse Firecrawl hits into Instagram posts, drop non-Instagram results,
  * dedupe by shortcode, classify, and keep only posts that signal BOTH
- * AI-generation and Christian content (capped at `maxResults`).
+ * AI-generation and Christian content without reading as commentary
+ * (capped at `maxResults`).
  */
 export function selectQualifyingPosts(
   hits: readonly InstagramDiscoverySearchHit[],
@@ -399,34 +401,57 @@ export function selectQualifyingPosts(
               signals.matchedChristian,
               64,
             ),
+            matchedCommentary: mergeStrings(
+              existing.matchedCommentary,
+              signals.matchedCommentary,
+              64,
+            ),
           }
         : {
             post,
             matchedAi: signals.matchedAi,
             matchedChristian: signals.matchedChristian,
+            matchedCommentary: signals.matchedCommentary,
           },
     )
   }
   const deduped = [...byShortcode.values()]
 
   const qualified: InstagramPost[] = []
-  for (const { post, matchedAi, matchedChristian } of deduped) {
-    if (
-      !qualifies({
-        isAiGenerated: matchedAi.length > 0,
-        isChristian: matchedChristian.length > 0,
+  let excludedCommentary = 0
+  for (const {
+    post,
+    matchedAi,
+    matchedChristian,
+    matchedCommentary,
+  } of deduped) {
+    const signals = {
+      isAiGenerated: matchedAi.length > 0,
+      isChristian: matchedChristian.length > 0,
+      isCommentary: matchedCommentary.length > 0,
+      matchedAi,
+      matchedChristian,
+      matchedCommentary,
+    }
+
+    if (!qualifies(signals)) {
+      if (
+        signals.isAiGenerated &&
+        signals.isChristian &&
+        signals.isCommentary
+      ) {
+        excludedCommentary += 1
+      }
+      continue
+    }
+
+    if (qualified.length < input.maxResults) {
+      qualified.push({
+        ...post,
         matchedAi,
         matchedChristian,
       })
-    ) {
-      continue
     }
-    qualified.push({
-      ...post,
-      matchedAi,
-      matchedChristian,
-    })
-    if (qualified.length >= input.maxResults) break
   }
 
   return {
@@ -435,6 +460,7 @@ export function selectQualifyingPosts(
       candidates: hits.length,
       instagram: parsed.length,
       deduped: deduped.length,
+      excludedCommentary,
       qualified: qualified.length,
     },
   }

--- a/apps/mastra/src/services/instagram-discovery/artifacts.test.ts
+++ b/apps/mastra/src/services/instagram-discovery/artifacts.test.ts
@@ -21,7 +21,13 @@ function sampleReport(
     startedAt: "2026-06-08T00:00:00.000Z",
     finishedAt: "2026-06-08T00:00:05.000Z",
     queries: ["AI generated Jesus reel site:instagram.com"],
-    totals: { candidates: 3, instagram: 2, deduped: 2, qualified: 1 },
+    totals: {
+      candidates: 3,
+      instagram: 2,
+      deduped: 2,
+      excludedCommentary: 0,
+      qualified: 1,
+    },
     queryFailures: [],
     posts: [
       {
@@ -62,6 +68,31 @@ describe("instagram discovery artifact store", () => {
 
     const read = await store.readReport("run-123")
     expect(read).toEqual(report)
+  })
+
+  it("defaults excludedCommentary when reading legacy reports", async () => {
+    const store = createInstagramDiscoveryArtifactStore(rootDir)
+    const report = sampleReport()
+    const legacyReport = {
+      ...report,
+      totals: {
+        candidates: report.totals.candidates,
+        instagram: report.totals.instagram,
+        deduped: report.totals.deduped,
+        qualified: report.totals.qualified,
+      },
+    }
+
+    await mkdir(path.join(rootDir, "reports"), { recursive: true })
+    await writeFile(
+      path.join(rootDir, "reports", "legacy.json"),
+      JSON.stringify(legacyReport),
+      "utf8",
+    )
+
+    await expect(store.readReport("legacy")).resolves.toMatchObject({
+      totals: { excludedCommentary: 0 },
+    })
   })
 
   it("rejects unsafe report names", async () => {

--- a/apps/mastra/src/services/instagram-discovery/artifacts.ts
+++ b/apps/mastra/src/services/instagram-discovery/artifacts.ts
@@ -48,6 +48,7 @@ export const DiscoveryTotalsSchema = z
     candidates: z.number().int().nonnegative(),
     instagram: z.number().int().nonnegative(),
     deduped: z.number().int().nonnegative(),
+    excludedCommentary: z.number().int().nonnegative(),
     qualified: z.number().int().nonnegative(),
   })
   .strict()
@@ -149,6 +150,28 @@ function isNodeErrorCode(cause: unknown, code: string): boolean {
   )
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+}
+
+function applyLegacyReportDefaults(payload: unknown): unknown {
+  if (
+    !isRecord(payload) ||
+    !isRecord(payload.totals) ||
+    "excludedCommentary" in payload.totals
+  ) {
+    return payload
+  }
+
+  return {
+    ...payload,
+    totals: {
+      ...payload.totals,
+      excludedCommentary: 0,
+    },
+  }
+}
+
 export function createInstagramDiscoveryArtifactStore(
   rootDir = instagramDiscoveryArtifactRoot(),
 ): InstagramDiscoveryArtifactStore {
@@ -197,7 +220,9 @@ export function createInstagramDiscoveryArtifactStore(
           cause,
         )
       }
-      const parsed = DiscoveryReportSchema.safeParse(payload)
+      const parsed = DiscoveryReportSchema.safeParse(
+        applyLegacyReportDefaults(payload),
+      )
       if (!parsed.success) {
         throw new InstagramDiscoveryArtifactError(
           "invalid_artifact",

--- a/apps/mastra/src/services/instagram-discovery/classifier.test.ts
+++ b/apps/mastra/src/services/instagram-discovery/classifier.test.ts
@@ -68,6 +68,58 @@ describe("classifyPost", () => {
     expect(qualifies(signals)).toBe(true)
   })
 
+  it("excludes commentary even when AI + Christian words are present", () => {
+    const signals = classifyPost(
+      post("Should we be listening to AI generated Christian music?"),
+    )
+    expect(signals.isAiGenerated).toBe(true)
+    expect(signals.isChristian).toBe(true)
+    expect(signals.isCommentary).toBe(true)
+    expect(signals.matchedCommentary).toContain("should we")
+    expect(qualifies(signals)).toBe(false)
+  })
+
+  it("excludes tutorial/prompt walk-through posts", () => {
+    const signals = classifyPost(
+      post(
+        "Here's my EXACT ChatGPT conversation to make these Veo 3 Bible prompts",
+      ),
+    )
+    expect(signals.isCommentary).toBe(true)
+    expect(qualifies(signals)).toBe(false)
+  })
+
+  it("keeps a genuine creation that has no commentary words", () => {
+    const signals = classifyPost(
+      post(
+        "I recreated the story of Jesus' crucifixion using cinematic AI storytelling",
+      ),
+    )
+    expect(signals.isAiGenerated).toBe(true)
+    expect(signals.isChristian).toBe(true)
+    expect(signals.isCommentary).toBe(false)
+    expect(qualifies(signals)).toBe(true)
+  })
+
+  it("keeps genuine creations that use commentary-adjacent words", () => {
+    // "according to" (Gospel attribution), "explains", and "mocking" (Passion
+    // narrative) must NOT exclude real creations — these terms were removed.
+    const gospel = classifyPost(
+      post("AI animation of the Gospel according to John, made with Veo"),
+    )
+    expect(qualifies(gospel)).toBe(true)
+
+    const explainer = classifyPost(
+      post("This AI generated film explains the parable of the sower #bible"),
+    )
+    expect(qualifies(explainer)).toBe(true)
+
+    const passion = classifyPost(
+      post("AI recreation of the soldiers mocking Christ before the cross"),
+    )
+    expect(qualifies(passion)).toBe(true)
+  })
+
   it("flags nothing for an empty caption with no hashtags", () => {
     const signals = classifyPost(post(""))
     expect(signals.isAiGenerated).toBe(false)

--- a/apps/mastra/src/services/instagram-discovery/classifier.ts
+++ b/apps/mastra/src/services/instagram-discovery/classifier.ts
@@ -53,6 +53,48 @@ export const CHRISTIAN_KEYWORDS: Keyword[] = [
   "lord",
 ]
 
+/**
+ * Signals that a caption is commentary/news/tutorial ABOUT AI content rather
+ * than an actual AI-made creation. Kept conservative: only phrases that strongly
+ * indicate talking-about (not making), to avoid dropping genuine creations.
+ */
+export const COMMENTARY_KEYWORDS: Keyword[] = [
+  "reaction",
+  "my thoughts",
+  "should we",
+  "is it ok",
+  "is it okay",
+  "debate",
+  "controversy",
+  "going viral",
+  "went viral",
+  { word: "trend" },
+  "here's how",
+  "heres how",
+  "here's my",
+  "heres my",
+  "prompt to make",
+  "chatgpt conversation",
+  "conversation with chatgpt",
+  "breaking news",
+  { word: "blogger" },
+  "tutorial",
+  "how i made",
+  "how to make",
+  "react to",
+  "reacting to",
+  "expressed concern",
+  "raises concern",
+  "speaks out",
+  "speaking out",
+  "weighs in",
+  "satirical",
+  // NOTE: keep this list conservative. Terms that collide with genuine creation
+  // captions were deliberately excluded: "according to" (Gospel attributions),
+  // "mocking" (Passion narrative + "mockingbird"), "explains"/"explained"
+  // (AI explainer films are legitimate creations).
+]
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
@@ -82,15 +124,21 @@ export function classifyPost(post: InstagramPost): MatchSignals {
   const haystack = buildHaystack(post)
   const matchedAi = matchAll(AI_KEYWORDS, haystack)
   const matchedChristian = matchAll(CHRISTIAN_KEYWORDS, haystack)
+  const matchedCommentary = matchAll(COMMENTARY_KEYWORDS, haystack)
   return {
     isAiGenerated: matchedAi.length > 0,
     isChristian: matchedChristian.length > 0,
+    isCommentary: matchedCommentary.length > 0,
     matchedAi,
     matchedChristian,
+    matchedCommentary,
   }
 }
 
-/** A post qualifies only when it signals BOTH AI-generation and Christian content. */
+/**
+ * A post qualifies only when it signals BOTH AI-generation and Christian content
+ * AND does not read as commentary/news/tutorial about AI content.
+ */
 export function qualifies(signals: MatchSignals): boolean {
-  return signals.isAiGenerated && signals.isChristian
+  return signals.isAiGenerated && signals.isChristian && !signals.isCommentary
 }

--- a/apps/mastra/src/services/instagram-discovery/types.ts
+++ b/apps/mastra/src/services/instagram-discovery/types.ts
@@ -19,8 +19,11 @@ export type InstagramMediaType = "post" | "reel" | "tv"
 export type MatchSignals = {
   isAiGenerated: boolean
   isChristian: boolean
+  /** True when the caption reads as commentary/news/tutorial about AI content. */
+  isCommentary: boolean
   matchedAi: string[]
   matchedChristian: string[]
+  matchedCommentary: string[]
 }
 
 /** A normalized Instagram post discovered via Firecrawl search. */
@@ -54,6 +57,8 @@ export type DiscoveryTotals = {
   candidates: number
   instagram: number
   deduped: number
+  /** Deduped posts dropped because they read as commentary, not a creation. */
+  excludedCommentary: number
   qualified: number
 }
 

--- a/docs/brainstorms/2026-06-11-instagram-ai-christian-discovery-requirements.md
+++ b/docs/brainstorms/2026-06-11-instagram-ai-christian-discovery-requirements.md
@@ -1,0 +1,179 @@
+# Requirements: Instagram AI-Christian content discovery → website Inspiration Feed
+
+Created: 2026-06-11
+Status: ready for planning
+Owner: Lyuba (with Vlad on the website/deploy side)
+
+## Problem & Goal
+
+gospelmedialab.com has an "Inspiration Feed" that showcases AI-made Christian
+creators' work (Instagram, Pinterest, YouTube). Today that feed is curated by
+hand. We want a bot that continuously surfaces fresh **AI-generated Christian
+videos from Instagram**, so a person can quickly approve the good ones into the
+feed.
+
+**Concrete goal:** about **3-5 approved posts per day** (treat as an average
+with a buffer, not a hard daily quota — supply is finite some days).
+
+**Why Instagram first:** most of the team's curated sources are on YouTube
+because Instagram is the hardest platform to pull from. The team has chosen to
+build the **hard platform (Instagram) first**, then add YouTube and Pinterest
+later, reusing the same approval/feed machinery.
+
+## What exists today (already built and deployed)
+
+- A Mastra workflow `instagram-ai-christian-discovery` (in the Forge repo,
+  `apps/mastra`) that:
+  - searches the open web via Firecrawl for Instagram posts,
+  - keeps posts whose caption/hashtags match **both** an AI keyword and a
+    Christian keyword,
+  - dedupes by post link, and returns a list + saves a JSON report.
+- It is deployed and confirmed working on the server (real results returned).
+- Operated manually today by running it in Mastra Studio.
+
+This covers the "discover new creators" half of the vision. It is noisy by
+design (keyword matching), which is why human approval is required.
+
+## Desired end-state (the full picture)
+
+A two-mode Instagram bot feeding a human-approved website feed, with memory:
+
+1. **Priority mode — follow trusted accounts.** The user maintains a list of
+   Instagram accounts known to make good AI-Christian content. The bot pulls
+   these accounts' recent posts and prioritizes them.
+2. **Discovery mode — find new creators.** Keep the existing keyword web search
+   to surface accounts not yet on the list.
+3. **Combine → clean → queue.** Merge both sources, remove duplicates, drop
+   obvious news/tutorial posts, and place candidates in a review queue.
+4. **Memory (no repeats).** The bot skips anything already approved or rejected,
+   so each run shows genuinely new posts. Essential for a daily rhythm.
+5. **Approve.** A person reviews the queue on an admin page and approves/rejects.
+6. **Display.** Approved posts appear in the gospelmedialab.com Inspiration Feed.
+
+## Key decisions (resolved in brainstorm)
+
+- **Human approves before anything goes public.** No auto-publishing to the site.
+- **Approval lives on an admin page** on gospelmedialab.com (the team is building
+  that admin area anyway for video templates, so post-approval is one more
+  section there).
+- **Connection is automatic** via the site's database (the site already has a
+  designed-but-currently-inactive Postgres/Prisma layer with a `ContentItem`
+  table). The same database is both the approval store and the bot's "memory."
+- **Two discovery sources, not one:** trusted-account follow-list (priority) +
+  keyword discovery (new creators).
+- **Quality bar is "good enough to gather," not "perfect."** The human approval
+  click is the quality gate; do not over-invest in making raw bot output perfect.
+
+## Findings that shape scope (verified during testing)
+
+- **Web search cannot target specific accounts.** Putting `instagram.com/<handle>`
+  in a search query was tested live and returned generic trend posts, not the
+  named accounts' content; author handle came back empty. Therefore the
+  follow-list (priority mode) **cannot** be built on Firecrawl web search.
+- **Following specific Instagram accounts needs a real Instagram data source.**
+  Instagram blocks reading profiles directly. Reliably fetching a public
+  account's recent posts typically requires a dedicated third-party Instagram
+  data/scraper service. This carries a **cost** and a **terms-of-service gray
+  area** the team should accept knowingly. This is the "hard part" being
+  tackled first.
+- **Author/date/thumbnail are usually empty in search-only mode.** The website
+  shows posts by their Instagram link (an embed), which fills in image, author,
+  and caption automatically, so empty fields do not hurt display. But they do
+  limit filtering by author, which is another reason the follow-list needs a
+  proper source.
+- **Duplicates slip through** when the same video is re-posted under different
+  links (different link = the current dedupe misses it). Also, a single viral
+  trend can flood results with near-duplicates.
+- **No cross-run memory today.** Each run is independent, so repeated runs
+  re-find the same popular posts. The shared database is what fixes this.
+
+## Requirements
+
+- R1. **Follow-list (priority).** User can maintain a list of Instagram accounts;
+  the bot fetches their recent posts and prioritizes them in the queue.
+- R2. **Discovery (new creators).** Keep keyword web search for accounts not on
+  the list.
+- R3. **Merge + dedupe.** Combine both sources and remove duplicates, including
+  the same video re-posted under different links (dedupe by caption as well as
+  link), and near-duplicate trend clones where feasible.
+- R4. **Quality filtering.** Automatically drop obvious news/tutorial/commentary
+  posts; keep actual creations. (A smarter AI-based relevance check is a likely
+  later upgrade.)
+- R5. **Memory.** Skip posts already approved or rejected; only show new ones.
+- R6. **Review queue + approval.** Admin page on gospelmedialab.com to review
+  candidates (with thumbnail, caption, link, why-it-matched) and approve/reject.
+- R7. **Display.** Approved posts appear in the Inspiration Feed.
+- R8. **Runs automatically each day** (scheduled), so a fresh queue is waiting.
+- R9. **Sensible cost controls** (search count, run frequency, and any paid
+  Instagram source) agreed with the team.
+
+## Success criteria
+
+- A person can approve ~3-5 fresh posts per day from the queue, on average.
+- Repeated runs do not re-show already-decided posts.
+- Approved posts show up in the Inspiration Feed without manual copying.
+- Trusted accounts reliably appear in the queue (priority mode actually works).
+
+## Scope boundaries
+
+**In scope (now):**
+
+- Instagram, both modes (follow-list + discovery), memory, approval, feed display.
+
+**Deferred for later:**
+
+- YouTube sources (the QBIBLE playlists + Shorts channels) — easiest platform,
+  add after Instagram works.
+- Pinterest boards.
+- Smarter AI relevance check (beyond keyword + commentary filter).
+- Multi-language handling (the source list spans es/pt/ru/hi/ar/zh/en; the
+  `ContentItem` table already has a `locale` column).
+
+**Out of scope:**
+
+- Auto-publishing without human approval.
+- Building our own Instagram crawler that defeats Instagram's login wall.
+
+## Dependencies & open questions (for planning)
+
+1. **Choose an Instagram data source** for the follow-list (priority mode):
+   which third-party service, its cost, reliability, and ToS posture. This is
+   the main new technical decision.
+2. **Turn on the site's database** (set `DATABASE_URL`); confirm the
+   `ContentItem` schema fits posts + approval status + "seen" memory.
+3. **Where the bot and site connect:** bot writes candidates to the site (likely
+   a small protected endpoint), candidates land as "pending."
+4. **Scheduling:** how/where the daily run is triggered.
+5. **Cost ceiling:** agree on search volume, run frequency, and paid-source
+   budget.
+
+## Trusted Instagram accounts (initial follow-list)
+
+From the team's source list (`instagram_accounts_offline`):
+
+| Handle                 | Language | Notes                                              |
+| ---------------------- | -------- | -------------------------------------------------- |
+| `_secretosdela_biblia` | es       | Spanish Bible AI                                   |
+| `vlog.biblico`         | pt       | Brazilian Veo 3 Bible POV vlogs (Klelvem Barcelos) |
+| `ulyanasaleeva`        | ?        | —                                                  |
+| `biblewithlife`        | en       | Dezheng Yu, Christian visual Bible storytelling    |
+| `andhikaramadhian`     | en       | —                                                  |
+| `kevincardenart`       | en       | —                                                  |
+| `the_aimedialab`       | en       | the lab's own account                              |
+
+(YouTube playlists/channels and Pinterest boards from the same list are deferred
+to later platform work.)
+
+## Suggested build order
+
+1. Turn on the site database; confirm schema for candidates + approval + memory.
+2. Connect the existing discovery bot to write candidates into that database
+   (gives an end-to-end slice with what already works).
+3. Admin approval page (review queue → approve/reject, writes back to DB).
+4. Inspiration Feed reads approved posts.
+5. Memory: bot skips already-decided posts (reads DB before queueing).
+6. Quality + speed fixes in the bot (caption dedupe, drop commentary, run
+   searches in parallel with a time limit).
+7. Follow-list (priority mode): integrate the chosen Instagram data source.
+8. Daily schedule.
+9. Later: YouTube + Pinterest sources; smarter AI relevance check.

--- a/docs/plans/2026-06-11-001-feat-instagram-discovery-relevance-filter-plan.md
+++ b/docs/plans/2026-06-11-001-feat-instagram-discovery-relevance-filter-plan.md
@@ -1,0 +1,177 @@
+---
+title: "feat: Instagram discovery relevance filter (exclusion keywords + AI relevance check)"
+type: feat
+status: active
+created: 2026-06-11
+depth: standard
+---
+
+# feat: Instagram Discovery Relevance Filter
+
+## Problem & Context
+
+The deployed `instagram-ai-christian-discovery` workflow (commit `d2505c5a`,
+`apps/mastra`) uses keyword matching: a post qualifies if its caption contains
+any AI keyword AND any Christian keyword. Live runs show this surfaces a lot of
+**commentary about** AI Christian content (news, reactions, "here's my Veo 3
+prompt" tutorials, bloggers discussing AI music) rather than **actual AI-made
+Christian video creations**. Real-world precision was ~3 good out of 12.
+
+Root cause: keyword matching can't tell a _creation_ from _talk about_
+creations — both contain the same words. The fix is two added filtering stages:
+
+1. **Exclusion keyword filter** (cheap, deterministic): drop posts whose caption
+   clearly reads as commentary/news/tutorial.
+2. **AI relevance check** (the real fix): an LLM reads each surviving caption and
+   judges "actual AI-made Christian video to feature, or commentary?" — keep only
+   real creations.
+
+Both run **after** the existing AI+Christian keyword qualify, narrowing the kept
+set. The AI check is opt-in and degrades gracefully when no LLM key is present.
+
+## Requirements
+
+- R1. Add a commentary exclusion filter: a post that otherwise qualifies is
+  dropped if its caption signals commentary/news/tutorial/reaction.
+- R2. Add an AI relevance check that judges each keyword-qualified, non-excluded
+  post and keeps only genuine AI-made Christian video creations.
+- R3. The AI check is controllable: an input flag (default on) and graceful skip
+  when no OpenRouter key is configured (no crash, no failure — just behaves like
+  keyword-only).
+- R4. The run report records _why_ posts were dropped (commentary vs. AI-judged
+  not-relevant) and the relevance reason per kept post, for operator insight.
+- R5. New env vars are optional/defaulted and not added to
+  `assertMastraRuntimeEnv()`.
+
+Success criteria: on a realistic run, the kept set is dominated by actual
+creations (commentary/tutorial posts largely removed). With the AI key absent,
+the workflow still runs (keyword + exclusion only) and never crashes.
+
+## Key Technical Decisions
+
+- **Exclusion filter lives in the classifier** (`classifier.ts`), as a new
+  `COMMENTARY_KEYWORDS` list + an `isCommentary()` check folded into the qualify
+  decision. Deterministic, no cost, conservative word list to avoid dropping
+  genuine creations (e.g. don't exclude on "AI" or "video").
+- **AI relevance check is a new service** mirroring the existing OpenRouter
+  judge: `apps/mastra/src/services/offline-search-eval/judge.ts` is the pattern
+  (attempt loop, `AbortSignal.timeout`, `retry-after`, `json_schema` structured
+  output, typed error). One **batched** call per run (numbered captions in,
+  per-index verdicts out) to keep cost/latency low for ≤50 posts.
+- **Graceful opt-in**: input flag `aiRelevanceCheck` (default `true`). If the
+  flag is on but no OpenRouter key is configured, skip the AI step and continue
+  (do not fail the run). This mirrors the discovery workflow's "missing optional
+  dependency degrades, not crashes" posture.
+- **Ordering**: keyword qualify → exclusion filter → cap at `maxResults` →
+  AI relevance check on the (already small) survivor set. Running the AI step
+  last on the smallest set minimizes LLM calls/cost.
+- **Reuse `OPENROUTER_API_KEY`** (already in env) plus a new optional
+  `INSTAGRAM_DISCOVERY_RELEVANCE_MODEL` (default `anthropic/claude-haiku-4-5`,
+  matching the existing eval judge default).
+
+## Patterns To Follow
+
+- OpenRouter chat-completions client w/ retry/timeout/typed error and
+  `response_format: json_schema`: `apps/mastra/src/services/offline-search-eval/judge.ts`.
+- Keyword lists + pure matcher: `apps/mastra/src/services/instagram-discovery/classifier.ts`.
+- Workflow step wiring + discriminated-union output + injectable core
+  (`runInstagramDiscovery`): `apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.ts`.
+- Env schema + getter + `emptyToUndefined`: `apps/mastra/src/config/env.ts`.
+
+## Implementation Units
+
+### U1. Commentary exclusion filter in the classifier
+
+**Goal:** Drop otherwise-qualifying posts that read as commentary/news/tutorial.
+**Requirements:** R1.
+**Dependencies:** none.
+**Files:** `apps/mastra/src/services/instagram-discovery/classifier.ts`, `apps/mastra/src/services/instagram-discovery/classifier.test.ts`.
+**Approach:** Add `COMMENTARY_KEYWORDS` (conservative: `reaction`, `my thoughts`, `should we`, `is it ok`, `debate`, `controversy`, `going viral`, `went viral`, `trend`, `here's how`, `here's my`, `prompt to make`, `chatgpt conversation`, `explained`, `explains`, `news`, `breaking`, `blogger`, `tutorial`, `how i made`, `how to make`). Add `isCommentary(post)` returning matched terms. Export a combined decision: a post is kept only if `isAiGenerated && isChristian && !isCommentary`. Keep `classifyPost` returning the signals (now incl. `matchedCommentary`); add the commentary check to `qualifies()` or a new `qualifiesForDiscovery()`. Update `MatchSignals` type.
+**Patterns to follow:** existing keyword matching (word-boundary helper) in the same file.
+**Test scenarios:**
+
+- "Here's my EXACT ChatGPT conversation to make these Veo 3 prompts" (AI+Christian words present) → excluded as commentary.
+- "should we be listening to AI generated Christian music?" → excluded.
+- "I recreated the story of Jesus' crucifixion using cinematic AI storytelling" → NOT excluded (genuine creation).
+- A post with no commentary words → unaffected.
+- Word-boundary guard so "trends" in a normal sentence doesn't over-trigger (decide: match `trend` as a whole word).
+
+### U2. AI relevance judge service
+
+**Goal:** LLM judges which captions are genuine AI-made Christian video creations.
+**Requirements:** R2, R3.
+**Dependencies:** U4 (env getter) — can be built in parallel; uses `OPENROUTER_API_KEY`.
+**Files:** `apps/mastra/src/services/instagram-discovery/relevance-judge.ts`, `apps/mastra/src/services/instagram-discovery/relevance-judge.test.ts`.
+**Approach:** Export `class RelevanceJudgeError` (codes `missing_credentials | transport | request_failed | validation`) and `judgeInstagramRelevance(items, options)` where `items: { index, caption }[]`. One batched OpenRouter chat call: system prompt = "Keep only posts that ARE an AI-generated Christian video/creation; reject commentary, news, reactions, tutorials, prompt walk-throughs, and posts merely discussing AI." `response_format: json_schema` → `{ verdicts: [{ index, relevant: boolean, reason: string }] }`. Validate every input index has a verdict; on validation failure, treat as "keep" (fail-open, since this is an additive precision filter, not a safety gate) and record the error. Injectable `apiKey`, `model`, `timeoutMs`, `fetchImpl`, `sleep`, `maxAttempts`. Throw `missing_credentials` when no key.
+**Patterns to follow:** `offline-search-eval/judge.ts` near-verbatim (request loop, extractText, json parse, schema validate).
+**Test scenarios (inject `fetchImpl`):**
+
+- Happy path: batched response keeps the creations, drops the commentary; returns per-index verdicts.
+- Missing apiKey → throws `missing_credentials` before fetch.
+- 429 then success → retried. 5xx exhausted → `request_failed`. Malformed/ën­valid JSON → `validation`.
+- Verdict array missing an index → fail-open (that item kept) + error surfaced.
+
+### U3. Wire both filters into the workflow
+
+**Goal:** Apply exclusion + AI relevance in `runInstagramDiscovery` and the Studio workflow steps.
+**Requirements:** R2, R3, R4.
+**Dependencies:** U1, U2.
+**Files:** `apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.ts`, `apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.test.ts`, `apps/mastra/src/services/instagram-discovery/types.ts`, `apps/mastra/src/services/instagram-discovery/artifacts.ts`.
+**Approach:**
+
+- Input schema: add `aiRelevanceCheck: z.boolean().default(true)`.
+- `selectQualifyingPosts`: apply the U1 commentary exclusion (kept = AI && Christian && !commentary). Add `excludedCommentary` count to totals.
+- `runInstagramDiscovery`: after qualify+cap, if `aiRelevanceCheck` and an OpenRouter key is available (or injected `relevanceJudge`), run U2 over the survivors; keep `relevant`; annotate each kept post with `relevanceReason`. If no key → skip (log + proceed). Add `relevanceFiltered` count to totals.
+- Inject `relevanceJudge?` via `InstagramDiscoveryOptions` for tests.
+- Studio workflow: add an `ai-relevance-filter` step between `parse-and-filter-posts` and `report-and-persist` (or extend filter step) calling the same helper with real deps; graceful skip if no key.
+- Extend `DiscoveryTotalsSchema` (excludedCommentary, relevanceFiltered) and `InstagramPostSchema` (optional `relevanceReason`), and `DiscoveryTotals` / `InstagramPost` types.
+  **Patterns to follow:** existing step + `runInstagramDiscovery` composition; discriminated-union outputs; failure-prefix throw helper.
+  **Test scenarios:**
+- `runInstagramDiscovery` with injected `relevanceJudge`: commentary post excluded by U1, a "creation" kept, an AI-judged-irrelevant post dropped; totals reflect `excludedCommentary` and `relevanceFiltered`; kept posts carry `relevanceReason`.
+- `aiRelevanceCheck: false` → AI step skipped entirely (judge not called).
+- AI enabled but no key and no injected judge → skipped gracefully, run still `ok:true`.
+- Schema round-trips with the new optional fields.
+
+### U4. Env + config + docs
+
+**Goal:** Optional model env var + getter; document the new behavior.
+**Requirements:** R5.
+**Dependencies:** none.
+**Files:** `apps/mastra/src/config/env.ts`, `apps/mastra/src/config/env.test.ts`, `apps/mastra/.env.example`, `apps/mastra/CLAUDE.md`.
+**Approach:** Add `INSTAGRAM_DISCOVERY_RELEVANCE_MODEL` (`z.string().min(1).default("anthropic/claude-haiku-4-5")`). Add `getInstagramRelevanceConfig()` → `{ apiKey: env.OPENROUTER_API_KEY, baseUrl: OpenRouter chat URL, model }`. Do not add to `assertMastraRuntimeEnv()`. Update `.env.example` + the CLAUDE.md "Instagram AI/Christian discovery" section (note exclusion filter, AI relevance check, opt-in flag, graceful skip).
+**Patterns to follow:** existing optional getters (`getFirecrawlConfig`).
+**Test scenarios:**
+
+- `getInstagramRelevanceConfig()` returns the default model + the OpenRouter key when set.
+- Production assert does not require the relevance vars (regression guard).
+
+## System-Wide Impact
+
+- Additive precision filter on an existing opt-in tool; no change to required env.
+- New optional LLM dependency (OpenRouter), already present in the app for evals;
+  graceful skip keeps default behavior when absent.
+- Small per-run cost when enabled (one batched LLM call over ≤50 captions).
+- No schema/codegen changes outside `apps/mastra`.
+
+## Scope Boundaries
+
+### In scope
+
+- Exclusion keyword filter, AI relevance check, opt-in flag, report counts/reasons, env + docs.
+
+### Deferred to Follow-Up Work
+
+- Trusted-accounts follow-list (separate, larger effort; needs an Instagram data source).
+- Cross-run memory / website approval queue (separate website-side work).
+- Near-duplicate "same video re-uploaded" detection beyond exact-caption dedupe.
+
+### Non-goals
+
+- Watching/inspecting the actual video (only captions are judged).
+- Auto-publishing.
+
+## Verification
+
+- `pnpm --filter @forge/mastra test` (new suites for classifier exclusion, relevance judge with injected fetch, workflow integration), `typecheck`, `lint` all clean.
+- Local smoke: run `runInstagramDiscovery` with an injected judge over the real "3 good of 12" sample captions; confirm commentary/tutorial posts are removed and creations kept.
+- Studio smoke (if key present): run the workflow, confirm the new `ai-relevance-filter` step appears and the kept set is cleaner; with the key unset, confirm it still completes (keyword + exclusion only).

--- a/docs/plans/2026-06-11-002-feat-instagram-discovery-exclusion-filter-plan.md
+++ b/docs/plans/2026-06-11-002-feat-instagram-discovery-exclusion-filter-plan.md
@@ -1,0 +1,99 @@
+---
+title: "feat: Instagram discovery commentary exclusion filter"
+type: feat
+status: completed
+created: 2026-06-11
+depth: lightweight
+---
+
+# feat: Instagram Discovery Commentary Exclusion Filter
+
+## Problem & Context
+
+The deployed `instagram-ai-christian-discovery` workflow (`apps/mastra`) keeps a
+post when its caption contains any AI keyword AND any Christian keyword. Live
+runs show this surfaces a lot of **commentary about** AI Christian content
+(news, reactions, "here's my Veo 3 prompt" tutorials, bloggers discussing AI
+music) rather than actual AI-made Christian video creations.
+
+This change adds a cheap, deterministic **commentary exclusion filter**: a post
+that otherwise qualifies is dropped if its caption reads as
+commentary/news/tutorial. It is the first, smallest precision improvement; the
+heavier LLM-based relevance check is deliberately deferred to a separate effort.
+
+## Requirements
+
+- R1. A post that matches AI + Christian keywords is still dropped if its caption
+  signals commentary/news/tutorial/reaction.
+- R2. The keyword list is conservative — it must not drop genuine creations
+  (e.g. "I recreated ... using AI storytelling").
+- R3. The run report exposes how many posts were excluded as commentary, so the
+  operator can see the filter working.
+
+Success criteria: on a realistic run, "blogger talking about AI music" and
+"here's my ChatGPT prompt" style posts are removed, while genuine creations are
+kept; the report shows an `excludedCommentary` count.
+
+## Key Technical Decisions
+
+- Filter lives in the existing classifier (`classifier.ts`) as a
+  `COMMENTARY_KEYWORDS` list folded into `qualifies()`. No new service, no LLM,
+  no new env var. Reuses the existing word-boundary keyword matcher.
+- Conservative word list: only phrases that strongly indicate talking-about
+  (not making). Do not exclude on generic words like "AI" or "video".
+- Surface an `excludedCommentary` count in the report totals so the effect is
+  observable (mirrors the existing `candidates/instagram/deduped/qualified`).
+
+## Patterns To Follow
+
+- Keyword lists + pure matcher + `qualifies()`: `apps/mastra/src/services/instagram-discovery/classifier.ts`.
+- Totals schema + types: `apps/mastra/src/services/instagram-discovery/artifacts.ts` (`DiscoveryTotalsSchema`), `types.ts` (`DiscoveryTotals`).
+- Funnel computation: `selectQualifyingPosts` in `apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.ts`.
+
+## Implementation Units
+
+### U1. Commentary exclusion in the classifier
+
+**Goal:** Drop otherwise-qualifying posts that read as commentary.
+**Requirements:** R1, R2.
+**Files:** `apps/mastra/src/services/instagram-discovery/classifier.ts`, `apps/mastra/src/services/instagram-discovery/classifier.test.ts`, `apps/mastra/src/services/instagram-discovery/types.ts`.
+**Approach:** Add `COMMENTARY_KEYWORDS`; `classifyPost` returns `isCommentary` + `matchedCommentary`; `qualifies()` becomes `isAiGenerated && isChristian && !isCommentary`. Extend `MatchSignals`.
+**Test scenarios:**
+
+- "Should we be listening to AI generated Christian music?" → excluded.
+- "Here's my EXACT ChatGPT conversation to make these Veo 3 Bible prompts" → excluded.
+- "I recreated Jesus' crucifixion using cinematic AI storytelling" → kept.
+- No commentary words → unaffected; empty caption → nothing flagged.
+
+### U2. Surface the excludedCommentary count + docs
+
+**Goal:** Make the filter's effect observable; document it.
+**Requirements:** R3.
+**Dependencies:** U1.
+**Files:** `apps/mastra/src/services/instagram-discovery/types.ts`, `apps/mastra/src/services/instagram-discovery/artifacts.ts`, `apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.ts`, `apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.test.ts`, `apps/mastra/CLAUDE.md`.
+**Approach:** Add `excludedCommentary` to `DiscoveryTotals` + `DiscoveryTotalsSchema`. In `selectQualifyingPosts`, count deduped posts whose signals are AI+Christian but commentary-excluded. Update the CLAUDE.md discovery section to mention the exclusion filter.
+**Test scenarios:**
+
+- `runInstagramDiscovery` over a mix incl. a commentary post → that post absent from `posts`, `totals.excludedCommentary >= 1`, genuine creation kept.
+- Artifact schema round-trips with the new total field.
+
+## Scope Boundaries
+
+### In scope
+
+- Commentary keyword exclusion + observable count + docs note.
+
+### Deferred to Follow-Up Work
+
+- LLM relevance check (separate plan: `2026-06-11-001-...-relevance-filter-plan.md`).
+- Trusted-accounts follow-list; cross-run memory; website approval queue.
+
+### Non-goals
+
+- Watching the video; auto-publishing.
+
+## Verification
+
+- `pnpm --filter @forge/mastra test`, `typecheck`, `lint` clean.
+- Local: run `runInstagramDiscovery` over the real "blogger talking about AI music"
+  sample captions; confirm they are excluded and the count reflects it.

--- a/docs/residual-review-findings/claude-amazing-bell-45000a.md
+++ b/docs/residual-review-findings/claude-amazing-bell-45000a.md
@@ -1,0 +1,12 @@
+# Residual Review Findings
+
+Source: `ce-code-review mode:autofix` on the Instagram discovery commentary
+exclusion filter (plan `docs/plans/2026-06-11-002-feat-instagram-discovery-exclusion-filter-plan.md`),
+branch `claude/amazing-bell-45000a`.
+
+Most review findings were applied as autofixes (removed false-positive-prone
+keywords `according to` / `mocking` / `explains`, made `excludedCommentary`
+count accurate past the `maxResults` cap, added guard tests). One non-blocking
+finding is deferred:
+
+- **P2 (downstream-resolver)** `apps/mastra/src/services/instagram-discovery/types.ts` — `matchedCommentary` is computed in `MatchSignals` but not surfaced on `InstagramPost` or in the report. Operators can see _how many_ posts were excluded as commentary (`totals.excludedCommentary`) but not _which keywords_ triggered an exclusion, and excluded posts are not in the output at all. If the keyword filter remains the primary exclusion mechanism (before the deferred LLM relevance check lands), consider adding an optional "excluded" sample/log surface so false-positive exclusions are auditable. Deferred to avoid scope creep on the exclusion-filter-first change.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -116,6 +116,7 @@ Build trusted, scalable AI capabilities that help people discover gospel content
 | [feat-062](media-generation/feat-062-shareable-custom-video-generation.md)                | Shareable Custom Video Generation                         | vlad  | P1       | 2026-09-01 | 30   | 2026-09-30 | blocked     |
 | [feat-053](media-generation/feat-053-ai-video-inspiration-platform.md)                    | AI Video Inspiration Platform                             | vlad  | P2       | 2026-05-01 | 31   | 2026-05-31 | not-started |
 | [feat-175](media-generation/feat-175-instagram-ai-christian-discovery-workflow.md)        | Instagram AI Christian discovery workflow                 | vlad  | P2       | 2026-06-10 | 1    | 2026-06-10 | complete    |
+| [feat-193](media-generation/feat-193-instagram-discovery-commentary-exclusion-filter.md)  | Instagram discovery commentary exclusion filter           | vlad  | P2       | 2026-06-16 | 1    | 2026-06-16 | complete    |
 | [feat-065](media-generation/feat-065-full-content-translation.md)                         | Full Content Translation                                  | vlad  | P2       | 2026-10-01 | 61   | 2026-11-30 | blocked     |
 
 ### Platform

--- a/docs/roadmap/media-generation/feat-175-instagram-ai-christian-discovery-workflow.md
+++ b/docs/roadmap/media-generation/feat-175-instagram-ai-christian-discovery-workflow.md
@@ -7,7 +7,8 @@ status: "complete"
 start_date: "2026-06-10"
 duration: 1
 depends_on: []
-blocks: []
+blocks:
+  - "feat-193"
 tags:
   - "mastra"
   - "firecrawl"

--- a/docs/roadmap/media-generation/feat-193-instagram-discovery-commentary-exclusion-filter.md
+++ b/docs/roadmap/media-generation/feat-193-instagram-discovery-commentary-exclusion-filter.md
@@ -1,0 +1,72 @@
+---
+id: "feat-193"
+title: "Instagram discovery commentary exclusion filter"
+owner: "vlad"
+priority: "P2"
+status: "complete"
+start_date: "2026-06-16"
+duration: 1
+depends_on:
+  - "feat-175"
+blocks: []
+tags:
+  - "mastra"
+  - "instagram"
+  - "ai-pipeline"
+---
+
+## Problem
+
+The initial Instagram AI Christian discovery workflow is intentionally keyword
+driven, so posts that talk about AI Christian content can pass the same
+AI-generation and Christian keyword checks as actual AI-made Christian video
+creations. Operators need a cheap precision improvement before the heavier
+LLM relevance filter lands.
+
+## Entry Points - Read These First
+
+1. `apps/mastra/src/services/instagram-discovery/classifier.ts` - keyword
+   signal lists and `qualifies()`.
+2. `apps/mastra/src/mastra/workflows/instagram-ai-christian-discovery.ts` -
+   parse, dedupe, classify, cap, and report totals.
+3. `apps/mastra/src/services/instagram-discovery/artifacts.ts` - persisted
+   report schema.
+4. `docs/plans/2026-06-11-002-feat-instagram-discovery-exclusion-filter-plan.md`
+   - implementation plan and deferred relevance-filter boundary.
+
+## Grep These
+
+- `COMMENTARY_KEYWORDS` - conservative exclusion terms.
+- `excludedCommentary` - report total for filtered commentary posts.
+- `matchedCommentary` - classifier signal used for the exclusion decision.
+- `instagram-ai-christian-discovery` - workflow id and tests.
+
+## What To Build
+
+- [x] Add a conservative commentary/news/tutorial keyword filter to the
+      Instagram discovery classifier.
+- [x] Require `!isCommentary` in `qualifies()` while preserving the existing
+      AI-generation plus Christian keyword requirements.
+- [x] Merge commentary matches across duplicate shortcode variants.
+- [x] Add `totals.excludedCommentary` to the workflow result and persisted
+      artifact schema.
+- [x] Document that the LLM relevance check remains deferred follow-up work.
+
+## Constraints
+
+- Keep the filter deterministic and conservative; do not add model calls or new
+  environment variables in this feature.
+- Do not exclude broad words that collide with genuine Bible-story creations,
+  such as Gospel attributions or Passion narrative terms.
+- Preserve the existing bounded report schema and `maxResults` cap.
+
+## Verification
+
+- `pnpm --filter @forge/mastra test -- src/services/instagram-discovery/classifier.test.ts src/services/instagram-discovery/artifacts.test.ts src/mastra/workflows/instagram-ai-christian-discovery.test.ts`
+- `pnpm --filter @forge/mastra typecheck`
+- `pnpm --filter @forge/mastra lint`
+
+## Plan
+
+Implementation plan:
+`docs/plans/2026-06-11-002-feat-instagram-discovery-exclusion-filter-plan.md`


### PR DESCRIPTION
## Summary

Instagram discovery now drops obvious commentary, tutorial, reaction, and news posts instead of presenting them as candidate AI-Christian creations. Operators also get an `excludedCommentary` total, so they can see how many otherwise keyword-qualified posts were removed by the precision filter.

The filter stays deterministic and conservative: duplicate shortcode variants merge commentary matches before qualification, broad Bible-story phrases are deliberately left out of the exclusion list, and the result cap no longer prevents the workflow from counting later commentary drops. Existing persisted discovery reports remain readable; legacy reports without `excludedCommentary` are normalized to `0` on read while new reports still write the stricter schema.

The patch also records the planning context and roadmap follow-up as `feat-194`, leaving the heavier LLM relevance check as a separate deferred effort.

## Validation

- `pnpm --filter @forge/mastra test -- src/services/instagram-discovery/classifier.test.ts src/services/instagram-discovery/artifacts.test.ts src/mastra/workflows/instagram-ai-christian-discovery.test.ts`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/mastra lint`
- `git diff --check origin/main...HEAD`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
