### PR TITLE
fix(manager): persist enrichment source metadata

### DIFF
--- a/apps/admin/src/services/manager-job.service.test.ts
+++ b/apps/admin/src/services/manager-job.service.test.ts
@@ -11,6 +11,9 @@ function mockPrisma() {
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    video: {
+      findMany: vi.fn(),
+    },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
 }
@@ -131,6 +134,48 @@ describe("ManagerJobService", () => {
       orderBy: { createdAt: "desc" },
       take: 250,
       skip: 125,
+    })
+  })
+
+  it("hydrates missing source titles from the related video when listing jobs", async () => {
+    prisma.managerEnrichmentJob.findMany.mockResolvedValueOnce([
+      {
+        ...JOB_ROW,
+        sourceCollectionTitle: null,
+        sourceMediaTitle: null,
+      },
+    ])
+    prisma.video.findMany.mockResolvedValueOnce([
+      {
+        id: "video-1",
+        locales: [
+          { locale: "fr", title: "Titre français" },
+          { locale: "en", title: "Recovered video title" },
+        ],
+        parents: [
+          {
+            parent: {
+              locales: [{ locale: "en", title: "Recovered collection" }],
+            },
+          },
+        ],
+      },
+    ])
+
+    const result = await service.list({
+      user: MANAGER_BACKEND_PRINCIPAL,
+      limit: 50,
+      offset: 0,
+    })
+
+    expect(prisma.video.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["video-1"] }, deletedAt: null },
+      }),
+    )
+    expect(result[0]).toMatchObject({
+      sourceCollectionTitle: "Recovered collection",
+      sourceMediaTitle: "Recovered video title",
     })
   })
 

--- a/apps/admin/src/services/manager-job.service.ts
+++ b/apps/admin/src/services/manager-job.service.ts
@@ -101,6 +101,26 @@ type ManagerJobRow = {
   errors: unknown
 }
 
+type SourceTitleFallback = {
+  sourceCollectionTitle?: string
+  sourceMediaTitle?: string
+}
+
+type VideoTitleLocale = {
+  locale: string | null
+  title: string | null
+}
+
+type VideoTitleFallbackRow = {
+  id: string
+  locales: VideoTitleLocale[]
+  parents: Array<{
+    parent: {
+      locales: VideoTitleLocale[]
+    } | null
+  }>
+}
+
 function assertManagerJobAccess(user: Principal | null) {
   if (!hasPermission(user, "write:manager-jobs")) {
     throw new ForbiddenError()
@@ -115,7 +135,110 @@ function toJobSteps(value: unknown): ManagerJobStep[] {
   return Array.isArray(value) ? (value as ManagerJobStep[]) : []
 }
 
-function toJobRecord(row: ManagerJobRow): ManagerJobRecord {
+function trimNonBlank(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function titleFromLocales(locales: VideoTitleLocale[]): string | undefined {
+  const titledLocales = locales
+    .map((locale) => ({
+      locale: locale.locale,
+      title: trimNonBlank(locale.title),
+    }))
+    .filter(
+      (locale): locale is { locale: string | null; title: string } =>
+        locale.title != null,
+    )
+
+  return (
+    titledLocales.find((locale) => locale.locale === "en")?.title ??
+    titledLocales[0]?.title
+  )
+}
+
+function sourceTitleFallbackFromVideo(
+  video: VideoTitleFallbackRow,
+): SourceTitleFallback {
+  const parentTitles = Array.from(
+    new Set(
+      video.parents
+        .map((relation) =>
+          relation.parent
+            ? titleFromLocales(relation.parent.locales)
+            : undefined,
+        )
+        .filter((title): title is string => title != null),
+    ),
+  )
+
+  return {
+    sourceMediaTitle: titleFromLocales(video.locales),
+    sourceCollectionTitle:
+      parentTitles.length > 0 ? parentTitles.join(", ") : undefined,
+  }
+}
+
+async function loadSourceTitleFallbacks(
+  prisma: PrismaClient,
+  rows: ManagerJobRow[],
+): Promise<Map<string, SourceTitleFallback>> {
+  const videoIds = Array.from(
+    new Set(
+      rows
+        .filter((row) => !row.sourceMediaTitle || !row.sourceCollectionTitle)
+        .map((row) => trimNonBlank(row.videoDocumentId))
+        .filter((id): id is string => id != null),
+    ),
+  )
+
+  if (videoIds.length === 0) {
+    return new Map()
+  }
+
+  const videos = await prisma.video.findMany({
+    where: { id: { in: videoIds }, deletedAt: null },
+    include: {
+      locales: {
+        where: { deletedAt: null, title: { not: null } },
+        select: { locale: true, title: true },
+        orderBy: [{ locale: "asc" }, { updatedAt: "desc" }],
+      },
+      parents: {
+        orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+        include: {
+          parent: {
+            include: {
+              locales: {
+                where: { deletedAt: null, title: { not: null } },
+                select: { locale: true, title: true },
+                orderBy: [{ locale: "asc" }, { updatedAt: "desc" }],
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  return new Map(
+    videos.map((video) => [
+      video.id,
+      sourceTitleFallbackFromVideo(video as VideoTitleFallbackRow),
+    ]),
+  )
+}
+
+function toJobRecord(
+  row: ManagerJobRow,
+  sourceTitleFallback: SourceTitleFallback = {},
+): ManagerJobRecord {
+  const sourceCollectionTitle =
+    trimNonBlank(row.sourceCollectionTitle) ??
+    sourceTitleFallback.sourceCollectionTitle
+  const sourceMediaTitle =
+    trimNonBlank(row.sourceMediaTitle) ?? sourceTitleFallback.sourceMediaTitle
+
   return {
     id: row.id,
     muxAssetId: row.muxAssetId,
@@ -136,10 +259,8 @@ function toJobRecord(row: ManagerJobRow): ManagerJobRecord {
         }
       : {}),
     resolvedTargetLanguageCodes: row.resolvedTargetLanguageCodes,
-    ...(row.sourceCollectionTitle
-      ? { sourceCollectionTitle: row.sourceCollectionTitle }
-      : {}),
-    ...(row.sourceMediaTitle ? { sourceMediaTitle: row.sourceMediaTitle } : {}),
+    ...(sourceCollectionTitle ? { sourceCollectionTitle } : {}),
+    ...(sourceMediaTitle ? { sourceMediaTitle } : {}),
     requestedLanguageAbbreviations: row.requestedLanguageAbbreviations,
     options: row.options,
     status: row.status as ManagerJobStatus,
@@ -184,7 +305,18 @@ export class ManagerJobService {
       take: Math.max(1, limit),
       skip: Math.max(0, offset),
     })
-    return rows.map((row) => toJobRecord(row))
+    const titleFallbacksByVideoId = await loadSourceTitleFallbacks(
+      this.prisma,
+      rows,
+    )
+    return rows.map((row) =>
+      toJobRecord(
+        row,
+        row.videoDocumentId
+          ? (titleFallbacksByVideoId.get(row.videoDocumentId) ?? {})
+          : {},
+      ),
+    )
   }
 
   async count({ user }: { user: Principal | null }) {
@@ -200,7 +332,16 @@ export class ManagerJobService {
     if (!row) {
       throw new NotFoundError("Manager enrichment job", id)
     }
-    return toJobRecord(row)
+    const titleFallbacksByVideoId = await loadSourceTitleFallbacks(
+      this.prisma,
+      [row],
+    )
+    return toJobRecord(
+      row,
+      row.videoDocumentId
+        ? (titleFallbacksByVideoId.get(row.videoDocumentId) ?? {})
+        : {},
+    )
   }
 
   async create({

--- a/apps/manager/src/app/api/enrich/route.test.ts
+++ b/apps/manager/src/app/api/enrich/route.test.ts
@@ -217,6 +217,7 @@ describe("buildMaterializationMetadata", () => {
         sourceLanguageCode: "en",
         sourceMuxAssetId: "source-asset-1",
         sourceMuxPlaybackId: "source-playback-1",
+        sourceInputUrl: "https://stream.mux.com/source-playback-1/480p.mp4",
         sourceInputType: "mux_asset",
         sourceSelectionReason: "fallback-en",
         sourceSelectionAttemptedCodes: ["ru", "en", "es", "fr"],
@@ -232,12 +233,13 @@ describe("buildMaterializationMetadata", () => {
 
     expect(metadata).toMatchObject({
       mode: "direct_mux_asset_reuse",
+      sourceInputHost: "stream.mux.com",
       sourceInputType: "mux_asset",
       targetEnvironment: "mux-production",
       reusedMuxAssetId: "source-asset-1",
       reusedMuxPlaybackId: "source-playback-1",
     })
-    expect(metadata).not.toHaveProperty("sourceInputHost")
+    expect(metadata).not.toHaveProperty("sourceInputUrl")
     expect(metadata).not.toHaveProperty("stageMuxAssetId")
   })
 })
@@ -265,6 +267,7 @@ describe("createEnrichmentJobs", () => {
       sourceLanguageCode: "en",
       sourceMuxAssetId: "mux-source-1",
       sourceMuxPlaybackId: "mux-source-playback-1",
+      sourceInputUrl: "https://stream.mux.com/mux-source-playback-1/480p.mp4",
       sourceInputType: "mux_asset",
       sourceSelectionReason: "fallback-en",
       sourceSelectionAttemptedCodes: ["fr", "en"],
@@ -272,25 +275,22 @@ describe("createEnrichmentJobs", () => {
       targetMuxPlaybackId: "mux-target-playback-1",
     })
     ensureGeneratedSubtitlesForAssetMock.mockResolvedValue(undefined)
-    createJobMock.mockResolvedValue({
-      id: "job-1",
-      muxAssetId: "mux-target-1",
-      muxPlaybackId: "mux-target-playback-1",
-      languages: ["en"],
-      options: {},
-      status: "pending",
-      retries: 0,
-      createdAt: "",
-      updatedAt: "",
-      artifacts: {
-        transcriptionRouting: {
-          kind: "metadata",
-          data: { attempts: [] },
-        },
-      },
-      steps: [],
-      errors: [],
-    })
+    createJobMock.mockImplementation(
+      async (_assetId, _playbackId, languages, options) => ({
+        id: "job-1",
+        muxAssetId: "mux-target-1",
+        muxPlaybackId: "mux-target-playback-1",
+        languages,
+        options: {},
+        status: "pending",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: options?.initialArtifacts ?? {},
+        steps: [],
+        errors: [],
+      }),
+    )
     updateJobMock.mockImplementation(async (_id, updates) => ({
       id: "job-1",
       muxAssetId: "mux-target-1",
@@ -358,6 +358,18 @@ describe("createEnrichmentJobs", () => {
       ["en"],
       expect.objectContaining({
         videoDocumentId: "video-doc-1",
+        sourceMediaTitle: "Jesus Film",
+        initialArtifacts: expect.objectContaining({
+          transcriptionRouting: expect.objectContaining({
+            kind: "metadata",
+            data: expect.objectContaining({
+              sourceInputUrl:
+                "https://stream.mux.com/mux-source-playback-1/480p.mp4",
+              sourceInputHost: "stream.mux.com",
+              attempts: [],
+            }),
+          }),
+        }),
       }),
     )
     dispatch.expectDispatched(runVideoEnrichment, [
@@ -373,6 +385,15 @@ describe("createEnrichmentJobs", () => {
         videoTitle: "Jesus Film",
         videoLabel: "JESUS_FILM",
         requestedTranscriptionProvider: "automatic",
+        initialArtifacts: expect.objectContaining({
+          transcriptionRouting: expect.objectContaining({
+            kind: "metadata",
+            data: expect.objectContaining({
+              sourceInputUrl:
+                "https://stream.mux.com/mux-source-playback-1/480p.mp4",
+            }),
+          }),
+        }),
       }),
     ])
     expect(runVideoEnrichment).not.toHaveBeenCalled()
@@ -473,6 +494,7 @@ describe("POST /api/enrich", () => {
       sourceLanguageCode: "en",
       sourceMuxAssetId: "mux-source-1",
       sourceMuxPlaybackId: "mux-source-playback-1",
+      sourceInputUrl: "https://stream.mux.com/mux-source-playback-1/480p.mp4",
       sourceInputType: "mux_asset",
       sourceSelectionReason: "fallback-en",
       sourceSelectionAttemptedCodes: ["en"],
@@ -480,25 +502,22 @@ describe("POST /api/enrich", () => {
       targetMuxPlaybackId: "mux-target-playback-1",
     })
     ensureGeneratedSubtitlesForAssetMock.mockResolvedValue(undefined)
-    createJobMock.mockResolvedValue({
-      id: "job-1",
-      muxAssetId: "mux-target-1",
-      muxPlaybackId: "mux-target-playback-1",
-      languages: ["en"],
-      options: {},
-      status: "pending",
-      retries: 0,
-      createdAt: "",
-      updatedAt: "",
-      artifacts: {
-        transcriptionRouting: {
-          kind: "metadata",
-          data: { attempts: [] },
-        },
-      },
-      steps: [],
-      errors: [],
-    })
+    createJobMock.mockImplementation(
+      async (_assetId, _playbackId, languages, options) => ({
+        id: "job-1",
+        muxAssetId: "mux-target-1",
+        muxPlaybackId: "mux-target-playback-1",
+        languages,
+        options: {},
+        status: "pending",
+        retries: 0,
+        createdAt: "",
+        updatedAt: "",
+        artifacts: options?.initialArtifacts ?? {},
+        steps: [],
+        errors: [],
+      }),
+    )
     updateJobMock.mockImplementation(async (_id, updates) => ({
       id: "job-1",
       muxAssetId: "mux-target-1",

--- a/apps/manager/src/app/api/enrich/route.ts
+++ b/apps/manager/src/app/api/enrich/route.ts
@@ -213,6 +213,9 @@ export function buildMaterializationMetadata(params: {
     requestedTargetLanguageIds,
     resolvedTargetLanguageCodes,
   } = params
+  const sourceInputMetadata = materialization.sourceInputUrl
+    ? redactSourceUrlForMetadata(materialization.sourceInputUrl)
+    : {}
 
   const baseMetadata = {
     mode: materialization.materializationMode,
@@ -236,9 +239,7 @@ export function buildMaterializationMetadata(params: {
 
   if (materialization.materializationMode === "snapshot_to_stage_clone") {
     return {
-      ...(materialization.sourceInputUrl
-        ? redactSourceUrlForMetadata(materialization.sourceInputUrl)
-        : {}),
+      ...sourceInputMetadata,
       ...baseMetadata,
       targetEnvironment: "mux-stage",
       stageMuxAssetId: materialization.targetMuxAssetId,
@@ -247,6 +248,7 @@ export function buildMaterializationMetadata(params: {
   }
 
   return {
+    ...sourceInputMetadata,
     ...baseMetadata,
     targetEnvironment: "mux-production",
     reusedMuxAssetId: materialization.targetMuxAssetId,
@@ -281,6 +283,7 @@ export async function createEnrichmentJobs(
         targetLanguageIds,
         {
           videoDocumentId: video.documentId,
+          sourceMediaTitle: video.title ?? undefined,
           initialArtifacts: {
             transcriptionRouting: {
               kind: "metadata",
@@ -434,6 +437,7 @@ export async function createEnrichmentJobs(
           normalizedTargets.targetLanguageCodes,
           {
             videoDocumentId: video.documentId,
+            sourceMediaTitle: video.title ?? undefined,
             initialArtifacts: {
               transcriptionRouting: {
                 kind: "metadata",

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
@@ -4,6 +4,8 @@ const {
   authenticateRequestMock,
   afterMock,
   getJobMock,
+  getMuxAssetMock,
+  getMuxStaticRenditionSourceUrlMock,
   runVideoEnrichmentMock,
   startMock,
   updateJobMock,
@@ -11,6 +13,8 @@ const {
   authenticateRequestMock: vi.fn(),
   afterMock: vi.fn(),
   getJobMock: vi.fn(),
+  getMuxAssetMock: vi.fn(),
+  getMuxStaticRenditionSourceUrlMock: vi.fn(),
   runVideoEnrichmentMock: vi.fn(),
   startMock: vi.fn(),
   updateJobMock: vi.fn(),
@@ -39,6 +43,11 @@ vi.mock("@/lib/state", () => ({
   updateJob: updateJobMock,
 }))
 
+vi.mock("@/services/mux", () => ({
+  getMuxAsset: getMuxAssetMock,
+  getMuxStaticRenditionSourceUrl: getMuxStaticRenditionSourceUrlMock,
+}))
+
 vi.mock("@/workflows/videoEnrichment", () => ({
   runVideoEnrichment: runVideoEnrichmentMock,
 }))
@@ -58,6 +67,25 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
       await callback()
     })
     runVideoEnrichmentMock.mockResolvedValue(undefined)
+    getMuxAssetMock.mockResolvedValue({
+      assetId: "mux-source-1",
+      playbackId: "play-source-1",
+      publicPlaybackId: "play-source-1",
+      status: "ready",
+      duration: 123,
+      staticRenditions: [
+        {
+          name: "480p.mp4",
+          status: "ready",
+          width: 854,
+          height: 480,
+          type: "advanced",
+        },
+      ],
+    })
+    getMuxStaticRenditionSourceUrlMock.mockReturnValue(
+      "https://stream.mux.com/play-source-1/480p.mp4",
+    )
     dispatch.mockReturnValue({
       assetId: "mux-1",
       transcript: "Transcript",
@@ -348,6 +376,87 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
 
     expect(response.status).toBe(409)
     dispatch.expectNotDispatched()
+  })
+
+  it("recovers a direct Mux static MP4 source for older ElevenLabs reruns", async () => {
+    getJobMock.mockResolvedValueOnce({
+      id: "job-1",
+      muxAssetId: "mux-1",
+      muxPlaybackId: "play-1",
+      languages: ["fr"],
+      options: {},
+      status: "completed",
+      retries: 0,
+      createdAt: "",
+      updatedAt: "",
+      sourceLanguageCode: "en",
+      artifacts: {
+        transcript: { kind: "downloadable" },
+        subtitles: { kind: "downloadable" },
+        transcriptionRouting: {
+          kind: "metadata",
+          data: {
+            attempts: [],
+          },
+        },
+        materialization: {
+          kind: "metadata",
+          data: {
+            mode: "direct_mux_asset_reuse",
+            sourceInputType: "mux_asset",
+            sourceMuxAssetId: "mux-source-1",
+            reusedMuxAssetId: "mux-1",
+          },
+        },
+      },
+      steps: [],
+      errors: [],
+    })
+
+    const response = await POST(
+      new Request("https://manager.test/api/jobs/job-1/transcription/rerun", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "elevenlabs" }),
+      }),
+      { params: Promise.resolve({ id: "job-1" }) },
+    )
+
+    expect(response.status).toBe(202)
+    expect(getMuxAssetMock).toHaveBeenCalledWith("mux-source-1")
+    expect(getMuxStaticRenditionSourceUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: "mux-source-1",
+        publicPlaybackId: "play-source-1",
+      }),
+    )
+    expect(updateJobMock).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({
+        artifacts: expect.objectContaining({
+          transcriptionRouting: {
+            kind: "metadata",
+            data: expect.objectContaining({
+              sourceInputUrl: "https://stream.mux.com/play-source-1/480p.mp4",
+              sourceInputHost: "stream.mux.com",
+              currentAttemptId: expect.any(String),
+            }),
+          },
+        }),
+      }),
+    )
+    dispatch.expectDispatched(runVideoEnrichment, [
+      expect.objectContaining({
+        requestedTranscriptionProvider: "elevenlabs",
+        initialArtifacts: expect.objectContaining({
+          transcriptionRouting: expect.objectContaining({
+            data: expect.objectContaining({
+              sourceInputUrl: "https://stream.mux.com/play-source-1/480p.mp4",
+            }),
+          }),
+        }),
+      }),
+    ])
   })
 
   it("rejects forced ElevenLabs reruns when the source language is unresolved", async () => {

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
@@ -16,6 +16,7 @@ import type {
   TranscriptionRoutingReport,
 } from "@/types/job"
 import { isSupportedElevenLabsLanguage } from "@/services/elevenlabs-transcription"
+import { getMuxAsset, getMuxStaticRenditionSourceUrl } from "@/services/mux"
 import { normalizeSourceLanguageCode } from "@/services/transcription"
 import { launchVideoEnrichment } from "@/workflows/launchVideoEnrichment"
 
@@ -27,6 +28,16 @@ function isTranscriptionActive(
   job: Awaited<ReturnType<typeof getJob>>,
 ): boolean {
   return job?.status === "running" && job.currentStep === "transcription"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value)
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined
 }
 
 function pruneArtifactsForTranscriptionRerun(
@@ -69,8 +80,20 @@ function buildRunningAttempt(
 function buildRerunRoutingReport(
   existing: TranscriptionRoutingReport | undefined,
   provider: RequestedTranscriptionProvider,
+  sourceInputUrl?: string,
 ): TranscriptionRoutingReport {
-  const baseReport = existing ?? buildInitialTranscriptionRoutingReport()
+  const sourceReport = sourceInputUrl
+    ? buildInitialTranscriptionRoutingReport({ sourceInputUrl })
+    : undefined
+  const baseReport = {
+    ...(existing ?? buildInitialTranscriptionRoutingReport()),
+    ...(sourceReport?.sourceInputUrl
+      ? { sourceInputUrl: sourceReport.sourceInputUrl }
+      : {}),
+    ...(sourceReport?.sourceInputHost
+      ? { sourceInputHost: sourceReport.sourceInputHost }
+      : {}),
+  }
   const rerunnableReport = { ...baseReport }
   delete rerunnableReport.currentAttemptId
   delete rerunnableReport.finalProvider
@@ -91,6 +114,44 @@ function resolveRerunSourceLanguageCode(
   const candidate =
     existing?.finalSourceLanguageCode ?? job.sourceLanguageCode ?? "auto"
   return normalizeSourceLanguageCode(candidate)
+}
+
+function readDirectMaterializationSourceAssetId(
+  artifacts: NonNullable<Awaited<ReturnType<typeof getJob>>>["artifacts"],
+): string | undefined {
+  const artifact = artifacts.materialization
+  if (artifact?.kind !== "metadata" || !isRecord(artifact.data)) {
+    return undefined
+  }
+
+  const mode = readString(artifact.data.mode)
+  const sourceInputType = readString(artifact.data.sourceInputType)
+  if (mode !== "direct_mux_asset_reuse" && sourceInputType !== "mux_asset") {
+    return undefined
+  }
+
+  return (
+    readString(artifact.data.sourceMuxAssetId) ??
+    readString(artifact.data.reusedMuxAssetId)
+  )
+}
+
+async function recoverDirectMuxSourceInputUrl(
+  job: NonNullable<Awaited<ReturnType<typeof getJob>>>,
+): Promise<string | undefined> {
+  const sourceMuxAssetId = readDirectMaterializationSourceAssetId(job.artifacts)
+  if (!sourceMuxAssetId) {
+    return undefined
+  }
+
+  try {
+    return (
+      getMuxStaticRenditionSourceUrl(await getMuxAsset(sourceMuxAssetId)) ??
+      undefined
+    )
+  } catch {
+    return undefined
+  }
 }
 
 export async function POST(
@@ -131,7 +192,13 @@ export async function POST(
 
   const provider = parsed.data.provider
   const existingRoutingReport = getTranscriptionRoutingReport(job.artifacts)
-  const sourceInputUrl = existingRoutingReport?.sourceInputUrl
+  const sourceInputUrl =
+    existingRoutingReport?.sourceInputUrl ??
+    (provider === "elevenlabs"
+      ? await recoverDirectMuxSourceInputUrl(
+          job as NonNullable<Awaited<ReturnType<typeof getJob>>>,
+        )
+      : undefined)
   const sourceLanguageCode = resolveRerunSourceLanguageCode(
     job as NonNullable<Awaited<ReturnType<typeof getJob>>>,
     existingRoutingReport,
@@ -173,6 +240,7 @@ export async function POST(
   const nextRoutingReport = buildRerunRoutingReport(
     existingRoutingReport,
     provider,
+    sourceInputUrl,
   )
   const nextArtifacts = setTranscriptionRoutingReport(
     pruneArtifactsForTranscriptionRerun(job.artifacts),

--- a/apps/manager/src/lib/state-create.test.ts
+++ b/apps/manager/src/lib/state-create.test.ts
@@ -48,6 +48,8 @@ describe("createJob", () => {
 
     const job = await createJob("asset-1", "playback-1", ["529"], {
       videoDocumentId: "video-doc-1",
+      sourceCollectionTitle: "Collection A",
+      sourceMediaTitle: "Main feature",
       initialArtifacts: {
         transcriptionRouting: {
           kind: "metadata",
@@ -62,6 +64,8 @@ describe("createJob", () => {
         muxPlaybackId: "playback-1",
         languages: ["529"],
         videoDocumentId: "video-doc-1",
+        sourceCollectionTitle: "Collection A",
+        sourceMediaTitle: "Main feature",
       }),
     )
     expect(job).toBe(createdJob)

--- a/apps/manager/src/lib/state.ts
+++ b/apps/manager/src/lib/state.ts
@@ -481,6 +481,8 @@ export async function createJob(
   languages: string[] = [],
   options?: {
     videoDocumentId?: string
+    sourceCollectionTitle?: string
+    sourceMediaTitle?: string
     initialArtifacts?: JobArtifactManifest
     // Persisted JobOptions (e.g. options.smartCrop discriminator) and a
     // custom step inventory (smart-crop jobs persist smart_crop_* steps
@@ -553,6 +555,8 @@ export async function createJob(
       muxPlaybackId,
       languages,
       videoDocumentId: options?.videoDocumentId,
+      sourceCollectionTitle: options?.sourceCollectionTitle,
+      sourceMediaTitle: options?.sourceMediaTitle,
       options: jobOptions,
       artifacts: initialArtifacts,
       errors: [],

--- a/apps/manager/src/services/mux.test.ts
+++ b/apps/manager/src/services/mux.test.ts
@@ -3,6 +3,7 @@ import {
   buildMuxAssetCreateParams,
   ensureGeneratedSubtitlesForAsset,
   getSceneThumbnailUrls,
+  getMuxStaticRenditionSourceUrl,
   getThumbnailUrl,
   normalizeGeneratedSubtitleLanguage,
 } from "@/services/mux"
@@ -257,5 +258,55 @@ describe("ensureGeneratedSubtitlesForAsset", () => {
         generateSubtitles: async () => [],
       }),
     ).rejects.toThrow("Mux asset asset-1 has no audio track")
+  })
+})
+
+describe("getMuxStaticRenditionSourceUrl", () => {
+  it("chooses the highest ready public MP4 rendition", () => {
+    expect(
+      getMuxStaticRenditionSourceUrl({
+        publicPlaybackId: "public-playback",
+        staticRenditions: [
+          {
+            name: "360p.mp4",
+            status: "ready",
+            width: 640,
+            height: 360,
+            type: "advanced",
+          },
+          {
+            name: "480p.mp4",
+            status: "ready",
+            width: 854,
+            height: 480,
+            type: "advanced",
+          },
+          {
+            name: "720p.mp4",
+            status: "preparing",
+            width: 1280,
+            height: 720,
+            type: "advanced",
+          },
+        ],
+      }),
+    ).toBe("https://stream.mux.com/public-playback/480p.mp4")
+  })
+
+  it("does not build an unauthenticated URL for signed-only playback", () => {
+    expect(
+      getMuxStaticRenditionSourceUrl({
+        publicPlaybackId: null,
+        staticRenditions: [
+          {
+            name: "480p.mp4",
+            status: "ready",
+            width: 854,
+            height: 480,
+            type: "advanced",
+          },
+        ],
+      }),
+    ).toBeNull()
   })
 })

--- a/apps/manager/src/services/mux.ts
+++ b/apps/manager/src/services/mux.ts
@@ -28,17 +28,39 @@ export type CreateAssetOptions = {
 export type MuxAssetInfo = {
   assetId: string
   playbackId: string
+  publicPlaybackId?: string | null
   status: string
   duration: number | null
+  staticRenditions?: MuxStaticRenditionInfo[]
 }
 
 export { normalizeGeneratedSubtitleLanguage }
 
 export type MuxPlaybackPolicy = "public" | "signed" | "drm"
 
+export type MuxStaticRenditionInfo = {
+  name: string
+  status: string | null
+  width: number | null
+  height: number | null
+  type: string | null
+}
+
 type MuxPlaybackId = {
   id?: string | null
   policy?: MuxPlaybackPolicy | null
+}
+
+type MuxStaticRenditionFile = {
+  name?: string | null
+  status?: string | null
+  width?: number | null
+  height?: number | null
+  type?: string | null
+}
+
+type MuxStaticRenditionsSnapshot = {
+  files?: MuxStaticRenditionFile[] | null
 }
 
 type MuxTrackInfo = {
@@ -134,6 +156,69 @@ function choosePlaybackId(
     available.find((playbackId) => playbackId.policy === "drm") ??
     null
   )
+}
+
+function choosePublicPlaybackId(
+  playbackIds: MuxPlaybackId[] | null | undefined,
+): string | null {
+  return (
+    (playbackIds ?? []).find(
+      (playbackId) => playbackId.policy === "public" && Boolean(playbackId.id),
+    )?.id ?? null
+  )
+}
+
+function normalizeStaticRenditions(
+  staticRenditions: MuxStaticRenditionsSnapshot | null | undefined,
+): MuxStaticRenditionInfo[] {
+  return (staticRenditions?.files ?? []).flatMap((file) => {
+    const name = file.name?.trim()
+    if (!name) {
+      return []
+    }
+
+    return [
+      {
+        name,
+        status: file.status ?? null,
+        width: file.width ?? null,
+        height: file.height ?? null,
+        type: file.type ?? null,
+      },
+    ]
+  })
+}
+
+function scoreStaticRendition(file: MuxStaticRenditionInfo): number {
+  const nameHeight = file.name.match(/(\d{3,4})p\.mp4$/i)?.[1]
+  const height =
+    file.height ?? (nameHeight != null ? Number(nameHeight) : undefined)
+
+  return height ?? 0
+}
+
+export function getMuxStaticRenditionSourceUrl(
+  asset: Pick<MuxAssetInfo, "publicPlaybackId" | "staticRenditions">,
+): string | null {
+  if (!asset.publicPlaybackId) {
+    return null
+  }
+
+  const readyMp4Renditions = (asset.staticRenditions ?? [])
+    .filter(
+      (file) =>
+        file.status === "ready" && file.name.toLowerCase().endsWith(".mp4"),
+    )
+    .sort(
+      (left, right) => scoreStaticRendition(right) - scoreStaticRendition(left),
+    )
+
+  const rendition = readyMp4Renditions[0]
+  if (!rendition) {
+    return null
+  }
+
+  return `https://stream.mux.com/${asset.publicPlaybackId}/${rendition.name}`
 }
 
 export async function buildMuxTextTrackUrl(
@@ -314,12 +399,15 @@ export async function createMuxAsset(
   )
 
   const playbackId = asset.playback_ids?.[0]?.id ?? ""
+  const publicPlaybackId = choosePublicPlaybackId(asset.playback_ids)
 
   return {
     assetId: asset.id,
     playbackId,
+    publicPlaybackId,
     status: asset.status ?? "preparing",
     duration: asset.duration ?? null,
+    staticRenditions: normalizeStaticRenditions(asset.static_renditions),
   }
 }
 
@@ -333,8 +421,10 @@ export async function getMuxAsset(assetId: string): Promise<MuxAssetInfo> {
   return {
     assetId: asset.id,
     playbackId,
+    publicPlaybackId: choosePublicPlaybackId(asset.playback_ids),
     status: asset.status ?? "unknown",
     duration: asset.duration ?? null,
+    staticRenditions: normalizeStaticRenditions(asset.static_renditions),
   }
 }
 

--- a/apps/manager/src/services/stageClone.test.ts
+++ b/apps/manager/src/services/stageClone.test.ts
@@ -339,7 +339,31 @@ describe("stageClone", () => {
     })
   })
 
-  it("reuses the existing mux asset directly when clone mode is disabled", async () => {
+  it("reuses the existing mux asset directly and preserves a static MP4 source when clone mode is disabled", async () => {
+    const getAsset = vi.fn().mockResolvedValue({
+      assetId: "mux-ru",
+      playbackId: "play-ru",
+      publicPlaybackId: "play-ru",
+      status: "ready",
+      duration: 123,
+      staticRenditions: [
+        {
+          name: "360p.mp4",
+          status: "ready",
+          width: 640,
+          height: 360,
+          type: "advanced",
+        },
+        {
+          name: "480p.mp4",
+          status: "ready",
+          width: 854,
+          height: 480,
+          type: "advanced",
+        },
+      ],
+    })
+
     const result = await materializeEnrichmentTargetForJob(
       {
         coreId: "video-1",
@@ -355,6 +379,7 @@ describe("stageClone", () => {
         sourceLanguagePriorityCodes: buildMuxSourceLanguagePriority("ru"),
         requestedTargetLanguageCode: "ru",
       },
+      { getAsset },
     )
 
     expect(result).toEqual({
@@ -366,19 +391,31 @@ describe("stageClone", () => {
       sourceMuxAssetId: "mux-ru",
       sourceMuxPlaybackId: "play-ru",
       sourceInputType: "mux_asset",
+      sourceInputUrl: "https://stream.mux.com/play-ru/480p.mp4",
       sourceSelectionReason: "requested",
       sourceSelectionAttemptedCodes: buildMuxSourceLanguagePriority("ru"),
       targetMuxAssetId: "mux-ru",
       targetMuxPlaybackId: "play-ru",
     })
+    expect(getAsset).toHaveBeenCalledWith("mux-ru")
   })
 
   it("recovers a missing playback id from live mux state for direct reuse", async () => {
     const getAsset = vi.fn().mockResolvedValue({
       assetId: "mux-en",
       playbackId: "play-en",
+      publicPlaybackId: "play-en",
       status: "ready",
       duration: 123,
+      staticRenditions: [
+        {
+          name: "270p.mp4",
+          status: "ready",
+          width: 480,
+          height: 270,
+          type: "basic",
+        },
+      ],
     })
 
     await expect(
@@ -408,6 +445,7 @@ describe("stageClone", () => {
       sourceMuxAssetId: "mux-en",
       sourceMuxPlaybackId: "play-en",
       sourceInputType: "mux_asset",
+      sourceInputUrl: "https://stream.mux.com/play-en/270p.mp4",
       sourceSelectionReason: "requested",
       sourceSelectionAttemptedCodes: buildMuxSourceLanguagePriority("en"),
       targetMuxAssetId: "mux-en",
@@ -415,6 +453,43 @@ describe("stageClone", () => {
     })
 
     expect(getAsset).toHaveBeenCalledWith("mux-en")
+  })
+
+  it("keeps direct reuse available when static rendition lookup fails but playback is known", async () => {
+    const getAsset = vi.fn().mockRejectedValue(new Error("Mux lookup failed"))
+
+    await expect(
+      materializeEnrichmentTargetForJob(
+        {
+          coreId: "video-1",
+          variants: [
+            {
+              language: { coreId: "529", bcp47: "en", iso3: "eng" },
+              muxVideo: { assetId: "mux-en", playbackId: "play-en" },
+            },
+          ],
+        },
+        {
+          materializationTarget: "direct",
+          sourceLanguagePriorityCodes: buildMuxSourceLanguagePriority("en"),
+          requestedTargetLanguageCode: "en",
+        },
+        { getAsset },
+      ),
+    ).resolves.toEqual({
+      status: "ready",
+      materializationMode: "direct_mux_asset_reuse",
+      sourceVideoCoreId: "video-1",
+      sourceLanguage: { coreId: "529", bcp47: "en", iso3: "eng" },
+      sourceLanguageCode: "en",
+      sourceMuxAssetId: "mux-en",
+      sourceMuxPlaybackId: "play-en",
+      sourceInputType: "mux_asset",
+      sourceSelectionReason: "requested",
+      sourceSelectionAttemptedCodes: buildMuxSourceLanguagePriority("en"),
+      targetMuxAssetId: "mux-en",
+      targetMuxPlaybackId: "play-en",
+    })
   })
 
   it("surfaces direct-mode unsupported results when no reusable mux asset exists", async () => {

--- a/apps/manager/src/services/stageClone.ts
+++ b/apps/manager/src/services/stageClone.ts
@@ -1,4 +1,9 @@
-import { createMuxAsset, getMuxAsset, type MuxAssetInfo } from "@/services/mux"
+import {
+  createMuxAsset,
+  getMuxAsset,
+  getMuxStaticRenditionSourceUrl,
+  type MuxAssetInfo,
+} from "@/services/mux"
 import {
   buildMuxSourceLanguagePriority,
   type SupportedMuxGeneratedSubtitleLanguage,
@@ -319,10 +324,15 @@ export async function materializeEnrichmentTargetForJob(
     const getAsset = deps.getAsset ?? getMuxAsset
 
     try {
-      const liveAsset =
-        candidate.sourceMuxPlaybackId != null
-          ? null
-          : await getAsset(candidate.sourceMuxAssetId!)
+      let liveAsset: MuxAssetInfo | null = null
+      try {
+        liveAsset = await getAsset(candidate.sourceMuxAssetId!)
+      } catch (error) {
+        if (!candidate.sourceMuxPlaybackId) {
+          throw error
+        }
+      }
+
       const resolvedPlaybackId =
         candidate.sourceMuxPlaybackId ?? liveAsset?.playbackId
 
@@ -332,10 +342,15 @@ export async function materializeEnrichmentTargetForJob(
         )
       }
 
+      const sourceInputUrl = liveAsset
+        ? (getMuxStaticRenditionSourceUrl(liveAsset) ?? undefined)
+        : undefined
+
       return {
         status: "ready",
         ...candidate,
         sourceMuxPlaybackId: resolvedPlaybackId,
+        ...(sourceInputUrl ? { sourceInputUrl } : {}),
         materializationMode: "direct_mux_asset_reuse",
         targetMuxAssetId: candidate.sourceMuxAssetId!,
         targetMuxPlaybackId: resolvedPlaybackId,


### PR DESCRIPTION
## Summary

Manager jobs now carry the source metadata needed after the handoff from the collection grid into an individual job. Direct-Mux enrichment records the downloadable static MP4 input when Mux exposes one, so automatic transcription and forced ElevenLabs reruns no longer fall back to Mux solely because the job lost its input URL.

Jobs created from video sources now persist the media title at creation time, and Admin hydrates titles for older jobs from the related video and collection locales when those persisted fields are missing. Existing jobs with enough video linkage can therefore stop showing as "Untitled source" without a one-off backfill.

## Testing

- `pnpm --filter @forge/manager test -- src/app/api/enrich/route.test.ts src/lib/state-create.test.ts src/services/mux.test.ts src/services/stageClone.test.ts 'src/app/api/jobs/[id]/transcription/rerun/route.test.ts'`
- `pnpm --filter @forge/admin test -- src/services/manager-job.service.test.ts`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/admin lint`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
