### PR TITLE
fix(manager): align job status controls

### DIFF
--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -6223,6 +6223,14 @@ body.jobs-standalone .jobs-step-job-id {
   outline-offset: 2px;
 }
 
+.jobs-step-expand-spacer {
+  display: inline-block;
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  pointer-events: none;
+}
+
 .jobs-step-expand-icon-open {
   transform: rotate(180deg);
 }
@@ -11525,6 +11533,12 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
 
 .jobs-step-expand-button:active {
   background: #e2ded7;
+}
+
+.jobs-step-expand-spacer {
+  flex-basis: 24px;
+  width: 24px;
+  height: 24px;
 }
 
 .jobs-review-tabs,

--- a/apps/manager/src/features/jobs/collapsible-step-row.test.ts
+++ b/apps/manager/src/features/jobs/collapsible-step-row.test.ts
@@ -38,4 +38,63 @@ describe("CollapsibleStepRow", () => {
     expect(markup).toContain("Subtitles processed")
     expect(markup).toContain("Open Subtitles processed in a new tab")
   })
+
+  it("reserves the expand action slot for static rows", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        "table",
+        null,
+        React.createElement(
+          "tbody",
+          null,
+          React.createElement(CollapsibleStepRow, {
+            stepName: "transcription",
+            title: "Transcription",
+            description: "Generates transcript artifacts.",
+            icon: FileAudio2,
+            duration: "8s",
+            artifacts: [],
+            status: "completed",
+            statusIcon: React.createElement("span", null, "Complete"),
+            retries: 0,
+          }),
+        ),
+      ),
+    )
+
+    expect(markup).toContain('class="jobs-step-expand-spacer"')
+    expect(markup).toContain('aria-hidden="true"')
+    expect(markup).not.toContain("Expand Transcription details")
+  })
+
+  it("renders a disclosure button instead of a spacer for expandable rows", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        "table",
+        null,
+        React.createElement(
+          "tbody",
+          null,
+          React.createElement(CollapsibleStepRow, {
+            stepName: "transcription",
+            title: "Transcription",
+            description: "Generates transcript artifacts.",
+            icon: FileAudio2,
+            duration: "8s",
+            artifacts: [],
+            status: "completed",
+            statusIcon: React.createElement("span", null, "Complete"),
+            retries: 0,
+            isExpanded: false,
+            onToggle: () => {},
+            detailContent: React.createElement("p", null, "Details"),
+          }),
+        ),
+      ),
+    )
+
+    expect(markup).toContain("Expand Transcription details")
+    expect(markup).toContain("jobs-step-expand-button")
+    expect(markup).not.toContain("jobs-step-expand-spacer")
+  })
 })

--- a/apps/manager/src/features/jobs/collapsible-step-row.tsx
+++ b/apps/manager/src/features/jobs/collapsible-step-row.tsx
@@ -160,7 +160,9 @@ export function CollapsibleStepRow({
               >
                 <ChevronDown size={18} />
               </button>
-            ) : null}
+            ) : (
+              <span className="jobs-step-expand-spacer" aria-hidden="true" />
+            )}
           </div>
         </td>
       </tr>

--- a/docs/roadmap/platform/feat-195-manager-job-status-control-alignment.md
+++ b/docs/roadmap/platform/feat-195-manager-job-status-control-alignment.md
@@ -1,0 +1,78 @@
+---
+id: "feat-195"
+title: "Manager job status control alignment"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-16"
+duration: 1
+depends_on:
+  - "feat-114"
+blocks: []
+tags:
+  - "manager"
+  - "jobs"
+  - "ui"
+  - "design-system"
+---
+
+## Problem
+
+Manager job detail rows right-align a variable-width status control group. Rows
+with expandable details include a chevron action button, while static rows do
+not, so completed checkmarks land at different horizontal positions in the same
+Status column.
+
+## Entry Points - Read These First
+
+1. `apps/manager/src/features/jobs/collapsible-step-row.tsx` - renders the
+   status icon, retry count, and optional details chevron.
+2. `apps/manager/src/app/globals.css` - owns the `.jobs-step-status-cell` and
+   `.jobs-step-expand-button` layout rules.
+3. `apps/manager/src/features/jobs/collapsible-step-row.test.ts` - focused
+   server-rendered component regression coverage.
+4. `apps/manager/src/features/jobs/live-job-steps-table.tsx` - maps job steps
+   into static or expandable `CollapsibleStepRow` instances.
+
+## Grep These
+
+- `jobs-step-status-cell`
+- `jobs-step-expand-button`
+- `jobs-step-expand-spacer`
+- `CollapsibleStepRow`
+
+## What To Build
+
+- Reserve the same trailing action slot for static and expandable job rows.
+- Keep the reserved slot hidden from assistive technology and pointer events.
+- Preserve the existing chevron button affordance, focus state, and click
+  behavior for expandable rows.
+- Add a focused regression test that proves static rows render the reserved
+  slot and expandable rows render the real disclosure button.
+
+## Constraints
+
+- Do not redesign the Manager jobs table or introduce new color tokens.
+- Do not change job data, step expansion rules, live polling, or artifact
+  behavior.
+- Keep the fix local to Manager job detail row rendering and shared CSS.
+
+## Verification
+
+- `pnpm --filter @forge/manager test -- collapsible-step-row`
+- `pnpm --filter @forge/manager typecheck`
+- Browser smoke screenshot of a Manager job detail table showing status
+  checkmarks aligned for rows with and without the chevron action.
+
+## Completion Notes
+
+- Static job rows now render an invisible `.jobs-step-expand-spacer` so their
+  status control group reserves the same trailing action slot as expandable
+  rows.
+- The spacer is hidden from assistive technology and has pointer events
+  disabled; expandable rows still render the real disclosure button.
+- Focused component coverage verifies static rows get the spacer and
+  expandable rows get the disclosure button.
+- Local browser smoke on `/dashboard/jobs/mock-job-1` measured every visible
+  status icon at `x=1180` (`maxDeltaPx: 0`) across rows with and without the
+  chevron. Screenshot: `/private/tmp/manager-job-status-alignment.png`.


### PR DESCRIPTION
## Summary

Manager job detail rows now keep completed status checkmarks aligned whether a
step has expandable diagnostics or not. Static rows reserve the same hidden
trailing action slot as rows with a disclosure chevron, so the Status column no
longer drifts between steps.

The focused regression test covers both row shapes: static rows render the
hidden spacer, while expandable rows still render the real disclosure button.

## Verification

- `pnpm --filter @forge/manager test -- collapsible-step-row`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `git diff --check`
- Local browser smoke on `/dashboard/jobs/mock-job-1`: every visible status
  icon measured at `x=1180` (`maxDeltaPx: 0`). Screenshot saved locally at
  `/private/tmp/manager-job-status-alignment.png`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
