### PR TITLE
feat(manager): add smart crop plan player

### DIFF
--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -13649,6 +13649,205 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
   overflow-wrap: anywhere;
 }
 
+.smart-crop-plan-review-card {
+  display: grid;
+  gap: 14px;
+}
+
+.smart-crop-plan-player-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 3px 10px;
+  color: var(--ds-muted);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1;
+  text-transform: capitalize;
+  background: var(--ds-panel-muted);
+  border: 1px solid var(--ds-line);
+  border-radius: 999px;
+}
+
+.smart-crop-plan-player-empty {
+  display: grid;
+  gap: 6px;
+  min-height: 120px;
+  align-content: center;
+  justify-items: start;
+  color: var(--ds-muted);
+}
+
+.smart-crop-plan-player-empty strong {
+  color: var(--ds-ink);
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.smart-crop-plan-player-empty p {
+  margin: 0;
+  font-size: 0.92rem;
+}
+
+.smart-crop-plan-player {
+  display: grid;
+  gap: 14px;
+  width: min(100%, 1040px);
+}
+
+.smart-crop-plan-player-stage {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  background: var(--ds-black);
+  border: 1px solid var(--ds-line-strong);
+  border-radius: var(--ds-radius);
+}
+
+.smart-crop-plan-player-video-shell,
+.smart-crop-plan-player-video-shell .video-js,
+.smart-crop-plan-player-video-shell .vjs-tech {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.smart-crop-plan-player-video-shell .vjs-tech {
+  object-fit: contain;
+}
+
+.smart-crop-plan-crop-box {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  place-items: start end;
+  min-width: 24px;
+  min-height: 24px;
+  border: 2px solid var(--ds-brand-red);
+  box-shadow:
+    0 0 0 9999px color-mix(in srgb, var(--ds-black) 42%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--ds-bg) 70%, transparent);
+  pointer-events: none;
+}
+
+.smart-crop-plan-crop-box span {
+  margin: 6px;
+  padding: 2px 6px;
+  color: var(--ds-bg);
+  font-size: 0.72rem;
+  font-weight: 750;
+  line-height: 1;
+  background: color-mix(in srgb, var(--ds-black) 74%, transparent);
+  border-radius: 999px;
+}
+
+.smart-crop-shot-summary {
+  display: grid;
+  gap: 12px;
+}
+
+.smart-crop-shot-readout {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.smart-crop-shot-readout div {
+  min-width: 0;
+}
+
+.smart-crop-shot-readout dd {
+  margin: 3px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--ds-ink);
+  font-size: 0.92rem;
+}
+
+.smart-crop-shot-timeline-wrap {
+  display: grid;
+  gap: 6px;
+}
+
+.smart-crop-shot-timeline {
+  position: relative;
+  height: 34px;
+  overflow: hidden;
+  background: var(--ds-panel-muted);
+  border: 1px solid var(--ds-line);
+  border-radius: calc(var(--ds-radius) - 4px);
+}
+
+.smart-crop-shot-segment {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  min-width: 2px;
+  padding: 0;
+  color: var(--ds-muted);
+  background: color-mix(in srgb, currentColor 34%, var(--ds-bg));
+  border: 0;
+  border-right: 1px solid color-mix(in srgb, var(--ds-bg) 74%, transparent);
+  border-radius: 0;
+  opacity: 0.72;
+}
+
+.smart-crop-shot-segment:hover,
+.smart-crop-shot-segment:focus-visible,
+.smart-crop-shot-segment.is-active {
+  outline: none;
+  opacity: 1;
+  filter: saturate(1.18);
+}
+
+.smart-crop-shot-segment:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--ds-black);
+}
+
+.smart-crop-shot-segment--speaker {
+  color: var(--accent);
+}
+
+.smart-crop-shot-segment--group {
+  color: var(--ds-success);
+}
+
+.smart-crop-shot-segment--object {
+  color: var(--warn);
+}
+
+.smart-crop-shot-segment--slide_aware {
+  color: var(--ds-muted);
+}
+
+.smart-crop-shot-segment--action {
+  color: var(--ds-brand-red);
+}
+
+.smart-crop-shot-segment--center_fallback {
+  color: var(--ds-soft);
+}
+
+.smart-crop-shot-playhead {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  z-index: 3;
+  width: 2px;
+  background: var(--ds-black);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ds-bg) 74%, transparent);
+  transform: translateX(-1px);
+  pointer-events: none;
+}
+
+.smart-crop-shot-timeline-labels {
+  display: flex;
+  justify-content: space-between;
+  color: var(--ds-muted);
+  font-size: 0.78rem;
+}
+
 .smart-crop-picker-backdrop {
   position: fixed;
   inset: 0;
@@ -13909,5 +14108,15 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
     grid-column: 2;
     justify-content: flex-start;
     min-width: 0;
+  }
+
+  .smart-crop-shot-readout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .smart-crop-shot-readout {
+    grid-template-columns: 1fr;
   }
 }

--- a/apps/manager/src/cms/mock-seed.ts
+++ b/apps/manager/src/cms/mock-seed.ts
@@ -184,6 +184,85 @@ const DEFAULT_MANAGER_USER: MockManagerUserRecord = {
 
 const DEFAULT_MOCK_JOBS: JobRecord[] = [
   {
+    id: "mock-smart-crop-1",
+    muxAssetId: "mock_smart_crop_asset",
+    muxPlaybackId: "34eG2PxlcRu3L4wU5XlKVna2vN3BAI02Tjrq28dazn3Y",
+    videoDocumentId: "video-doc-standalone-1",
+    languages: ["529"],
+    sourceLanguageId: "529",
+    sourceLanguageCode: "en",
+    primaryRequestedTargetLanguageCode: "en",
+    resolvedTargetLanguageCodes: ["en"],
+    sourceMediaTitle: "A New Beginning",
+    options: {
+      smartCrop: {
+        kind: "canonical",
+        assetId: "mock_smart_crop_asset",
+        targetAspectRatio: "9:16",
+        cropMode: "auto",
+      },
+    },
+    status: "completed",
+    currentStep: "smart_crop_mux_output",
+    retries: 0,
+    createdAt: "2026-04-22T16:00:00.000Z",
+    updatedAt: "2026-04-22T16:12:00.000Z",
+    startedAt: "2026-04-22T16:00:10.000Z",
+    completedAt: "2026-04-22T16:12:00.000Z",
+    artifacts: {
+      smartCrop: {
+        kind: "metadata",
+        data: {
+          domain: "smart_crop",
+          kind: "canonical",
+          phase: "completed",
+          plan: { segmentCount: 3, approved: true },
+          qa: { verdict: "pass" },
+          usage: { inputTokens: 1000, outputTokens: 240 },
+        },
+      },
+      "smart-crop-plan": { kind: "downloadable" },
+    },
+    steps: [
+      {
+        name: "smart_crop_fingerprint",
+        status: "completed",
+        retries: 0,
+        startedAt: "2026-04-22T16:00:10.000Z",
+        finishedAt: "2026-04-22T16:02:00.000Z",
+      },
+      {
+        name: "smart_crop_plan",
+        status: "completed",
+        retries: 0,
+        startedAt: "2026-04-22T16:02:00.000Z",
+        finishedAt: "2026-04-22T16:05:00.000Z",
+      },
+      {
+        name: "smart_crop_preview_render",
+        status: "completed",
+        retries: 0,
+        startedAt: "2026-04-22T16:05:00.000Z",
+        finishedAt: "2026-04-22T16:10:00.000Z",
+      },
+      {
+        name: "smart_crop_qa",
+        status: "completed",
+        retries: 0,
+        startedAt: "2026-04-22T16:10:00.000Z",
+        finishedAt: "2026-04-22T16:11:00.000Z",
+      },
+      {
+        name: "smart_crop_mux_output",
+        status: "completed",
+        retries: 0,
+        startedAt: "2026-04-22T16:11:00.000Z",
+        finishedAt: "2026-04-22T16:12:00.000Z",
+      },
+    ],
+    errors: [],
+  },
+  {
     id: "mock-job-2",
     muxAssetId: "mock_asset_2",
     muxPlaybackId: "mockplayback2",
@@ -678,6 +757,80 @@ export const DEFAULT_MOCK_CMS_SEED: MockCmsSeed = {
 }
 
 export const DEFAULT_MOCK_ARTIFACT_FILES: MockArtifactFile[] = [
+  {
+    assetId: "mock_smart_crop_asset",
+    artifactType: "smart-crop-plan-9x16-v1",
+    ext: "json",
+    body: JSON.stringify(
+      {
+        version: 1,
+        kind: "smart-crop-canonical-plan",
+        assetId: "mock_smart_crop_asset",
+        muxAssetId: "mock_smart_crop_asset",
+        playbackId: "34eG2PxlcRu3L4wU5XlKVna2vN3BAI02Tjrq28dazn3Y",
+        source: { width: 1920, height: 1080, durationSeconds: 60 },
+        target: { aspectRatio: "9:16", width: 1080, height: 1920 },
+        strategy: {
+          cropMode: "auto",
+          plannerVersion: "smart-crop-planner-v1",
+          model: "mock-model",
+        },
+        segments: [
+          {
+            shotId: "shot_00001",
+            canonicalStart: 0,
+            canonicalEnd: 18,
+            mode: "speaker",
+            primarySubject: "Narrator",
+            secondarySubjects: [],
+            avoidCutting: ["face"],
+            confidence: 0.92,
+            cropKeyframes: [
+              { progress: 0, x: 240, y: 0, width: 606, height: 1080 },
+              { progress: 1, x: 320, y: 0, width: 606, height: 1080 },
+            ],
+          },
+          {
+            shotId: "shot_00002",
+            canonicalStart: 18,
+            canonicalEnd: 42,
+            mode: "group",
+            primarySubject: "Two people",
+            secondarySubjects: ["background group"],
+            avoidCutting: ["faces"],
+            confidence: 0.86,
+            cropKeyframes: [
+              { progress: 0, x: 560, y: 0, width: 606, height: 1080 },
+              { progress: 1, x: 760, y: 0, width: 606, height: 1080 },
+            ],
+          },
+          {
+            shotId: "shot_00003",
+            canonicalStart: 42,
+            canonicalEnd: 60,
+            mode: "slide_aware",
+            primarySubject: "Title card",
+            secondarySubjects: [],
+            avoidCutting: ["on-screen text"],
+            confidence: 0.78,
+            cropKeyframes: [
+              { progress: 0, x: 656, y: 0, width: 606, height: 1080 },
+              { progress: 1, x: 656, y: 0, width: 606, height: 1080 },
+            ],
+          },
+        ],
+        usage: { inputTokens: 1000, outputTokens: 240 },
+        qa: {
+          status: "approved",
+          approvedBy: "mock-manager",
+          approvedAt: "2026-04-22T16:06:00.000Z",
+        },
+        generatedAt: "2026-04-22T16:05:00.000Z",
+      },
+      null,
+      2,
+    ),
+  },
   {
     assetId: "mock_asset_1",
     artifactType: "metadata",

--- a/apps/manager/src/features/smart-crop/smart-crop-job-detail.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-job-detail.tsx
@@ -19,6 +19,7 @@ import {
   hasSmartCropPreviewVideo,
   listSmartCropArtifactLinks,
 } from "./smart-crop-presenter"
+import { SmartCropPlanReviewPlayer } from "./smart-crop-plan-review-player"
 
 const SMART_CROP_POLL_INTERVAL_MS = 5_000
 
@@ -283,6 +284,8 @@ export function SmartCropJobDetail({ initialJob }: SmartCropJobDetailProps) {
           </div>
         </dl>
       </section>
+
+      <SmartCropPlanReviewPlayer job={job} />
 
       <section className="collection-card jobs-card">
         <div className="jobs-card-header">

--- a/apps/manager/src/features/smart-crop/smart-crop-plan-player.test.ts
+++ b/apps/manager/src/features/smart-crop/smart-crop-plan-player.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildSmartCropBoxPercent,
+  clampSmartCropBoxPercent,
+  findActiveSmartCropSegment,
+  formatSmartCropTime,
+  interpolateSmartCropKeyframe,
+  parseSmartCropPlanForPlayer,
+  type SmartCropPlanForPlayer,
+} from "./smart-crop-plan-player"
+
+const plan: SmartCropPlanForPlayer = {
+  playbackId: "pb_123",
+  source: {
+    width: 1920,
+    height: 1080,
+    durationSeconds: 20,
+  },
+  segments: [
+    {
+      shotId: "shot_00001",
+      canonicalStart: 0,
+      canonicalEnd: 10,
+      mode: "speaker",
+      primarySubject: "Jesus",
+      confidence: 0.94,
+      cropKeyframes: [
+        { progress: 0, x: 520, y: 0, width: 606, height: 1080 },
+        { progress: 1, x: 620, y: 0, width: 606, height: 1080 },
+      ],
+    },
+    {
+      shotId: "shot_00002",
+      canonicalStart: 10,
+      canonicalEnd: 20,
+      mode: "group",
+      primarySubject: "disciples",
+      confidence: 0.8,
+      cropKeyframes: [
+        { progress: 0, x: 100, y: 0, width: 606, height: 1080 },
+        { progress: 0.5, x: 300, y: 0, width: 606, height: 1080 },
+        { progress: 1, x: 500, y: 0, width: 606, height: 1080 },
+      ],
+    },
+  ],
+}
+
+describe("smart crop plan player helpers", () => {
+  it("parses the plan fields needed by the original crop guide", () => {
+    const parsed = parseSmartCropPlanForPlayer({
+      kind: "smart-crop-canonical-plan",
+      playbackId: "pb_123",
+      source: { width: 1920, height: 1080, durationSeconds: 20 },
+      segments: [
+        {
+          shotId: "shot_00001",
+          canonicalStart: 0,
+          canonicalEnd: 10,
+          mode: "speaker",
+          primarySubject: "Jesus",
+          confidence: 0.94,
+          cropKeyframes: [
+            { progress: 0, x: 520, y: 0, width: 606, height: 1080 },
+          ],
+        },
+      ],
+    })
+
+    expect(parsed).toMatchObject({
+      playbackId: "pb_123",
+      source: { width: 1920, height: 1080, durationSeconds: 20 },
+      segments: [
+        {
+          shotId: "shot_00001",
+          mode: "speaker",
+          primarySubject: "Jesus",
+        },
+      ],
+    })
+  })
+
+  it("rejects malformed plans instead of guessing at missing playback data", () => {
+    expect(
+      parseSmartCropPlanForPlayer({
+        source: { width: 1920, height: 1080, durationSeconds: 20 },
+        segments: plan.segments,
+      }),
+    ).toBeNull()
+  })
+
+  it("rejects segments without a usable crop keyframe", () => {
+    expect(
+      parseSmartCropPlanForPlayer({
+        playbackId: "pb_123",
+        source: { width: 1920, height: 1080, durationSeconds: 20 },
+        segments: [
+          {
+            shotId: "shot_00001",
+            canonicalStart: 0,
+            canonicalEnd: 10,
+            mode: "speaker",
+            cropKeyframes: [
+              { progress: 0, x: 520, y: 0, width: -606, height: 1080 },
+            ],
+          },
+        ],
+      }),
+    ).toBeNull()
+  })
+
+  it("finds the active shot and interpolates the crop keyframe", () => {
+    const active = findActiveSmartCropSegment(plan.segments, 5)
+
+    expect(active?.shotId).toBe("shot_00001")
+    expect(interpolateSmartCropKeyframe(active!, 5)).toMatchObject({
+      progress: 0.5,
+      x: 570,
+      y: 0,
+      width: 606,
+      height: 1080,
+    })
+  })
+
+  it("honors piecewise keyframe progress values", () => {
+    const active = findActiveSmartCropSegment(plan.segments, 12.5)
+
+    expect(active?.shotId).toBe("shot_00002")
+    expect(interpolateSmartCropKeyframe(active!, 12.5)?.x).toBe(200)
+  })
+
+  it("projects the crop box into source-video percentages", () => {
+    expect(
+      buildSmartCropBoxPercent(
+        { progress: 0, x: 480, y: 0, width: 960, height: 1080 },
+        plan.source,
+      ),
+    ).toEqual({
+      left: 25,
+      top: 0,
+      width: 50,
+      height: 100,
+    })
+  })
+
+  it("clamps crop box percentages to the visible source frame", () => {
+    expect(
+      clampSmartCropBoxPercent({
+        left: 90,
+        top: -10,
+        width: 30,
+        height: 120,
+      }),
+    ).toEqual({
+      left: 90,
+      top: 0,
+      width: 10,
+      height: 100,
+    })
+  })
+
+  it("formats timeline labels without leaking decimals", () => {
+    expect(formatSmartCropTime(65.8)).toBe("1:05")
+  })
+})

--- a/apps/manager/src/features/smart-crop/smart-crop-plan-player.ts
+++ b/apps/manager/src/features/smart-crop/smart-crop-plan-player.ts
@@ -1,0 +1,246 @@
+export type SmartCropPlanKeyframe = {
+  progress: number
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type SmartCropPlanSegment = {
+  shotId: string
+  canonicalStart: number
+  canonicalEnd: number
+  mode: string
+  primarySubject: string
+  confidence: number
+  cropKeyframes: SmartCropPlanKeyframe[]
+}
+
+export type SmartCropPlanForPlayer = {
+  playbackId: string
+  source: {
+    width: number
+    height: number
+    durationSeconds: number
+  }
+  segments: SmartCropPlanSegment[]
+}
+
+export type CropBoxPercent = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null
+}
+
+function parseKeyframe(value: unknown): SmartCropPlanKeyframe | null {
+  if (!isRecord(value)) return null
+
+  const progress = asFiniteNumber(value.progress)
+  const x = asFiniteNumber(value.x)
+  const y = asFiniteNumber(value.y)
+  const width = asFiniteNumber(value.width)
+  const height = asFiniteNumber(value.height)
+
+  if (
+    progress == null ||
+    x == null ||
+    y == null ||
+    width == null ||
+    height == null ||
+    progress < 0 ||
+    progress > 1 ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return null
+  }
+
+  return { progress, x, y, width, height }
+}
+
+function parseSegment(value: unknown): SmartCropPlanSegment | null {
+  if (!isRecord(value)) return null
+
+  const shotId = asString(value.shotId)
+  const canonicalStart = asFiniteNumber(value.canonicalStart)
+  const canonicalEnd = asFiniteNumber(value.canonicalEnd)
+  const mode = asString(value.mode)
+  const primarySubject = asString(value.primarySubject) ?? "Subject"
+  const confidence = asFiniteNumber(value.confidence) ?? 0
+  const cropKeyframes = Array.isArray(value.cropKeyframes)
+    ? value.cropKeyframes.map(parseKeyframe).filter((item) => item != null)
+    : []
+
+  if (
+    shotId == null ||
+    canonicalStart == null ||
+    canonicalEnd == null ||
+    mode == null ||
+    canonicalEnd <= canonicalStart ||
+    cropKeyframes.length === 0
+  ) {
+    return null
+  }
+
+  return {
+    shotId,
+    canonicalStart,
+    canonicalEnd,
+    mode,
+    primarySubject,
+    confidence,
+    cropKeyframes,
+  }
+}
+
+export function parseSmartCropPlanForPlayer(
+  value: unknown,
+): SmartCropPlanForPlayer | null {
+  if (!isRecord(value)) return null
+
+  const playbackId = asString(value.playbackId)
+  const source = isRecord(value.source) ? value.source : null
+  const width = source ? asFiniteNumber(source.width) : null
+  const height = source ? asFiniteNumber(source.height) : null
+  const durationSeconds = source ? asFiniteNumber(source.durationSeconds) : null
+  const segments = Array.isArray(value.segments)
+    ? value.segments.map(parseSegment).filter((item) => item != null)
+    : []
+
+  if (
+    playbackId == null ||
+    width == null ||
+    height == null ||
+    durationSeconds == null ||
+    width <= 0 ||
+    height <= 0 ||
+    durationSeconds <= 0 ||
+    segments.length === 0
+  ) {
+    return null
+  }
+
+  return {
+    playbackId,
+    source: { width, height, durationSeconds },
+    segments,
+  }
+}
+
+export function findActiveSmartCropSegment(
+  segments: readonly SmartCropPlanSegment[],
+  currentTimeSeconds: number,
+): SmartCropPlanSegment | null {
+  if (segments.length === 0) return null
+
+  const active = segments.find(
+    (segment) =>
+      currentTimeSeconds >= segment.canonicalStart &&
+      currentTimeSeconds < segment.canonicalEnd,
+  )
+  if (active) return active
+
+  if (currentTimeSeconds < segments[0]!.canonicalStart) {
+    return segments[0]!
+  }
+
+  return segments[segments.length - 1]!
+}
+
+function interpolate(start: number, end: number, progress: number): number {
+  return start + (end - start) * progress
+}
+
+export function interpolateSmartCropKeyframe(
+  segment: SmartCropPlanSegment,
+  currentTimeSeconds: number,
+): SmartCropPlanKeyframe | null {
+  const keyframes = [...segment.cropKeyframes].sort(
+    (left, right) => left.progress - right.progress,
+  )
+  const first = keyframes[0]
+  if (!first) return null
+  if (keyframes.length === 1) return first
+
+  const segmentDuration = segment.canonicalEnd - segment.canonicalStart
+  const segmentProgress =
+    segmentDuration > 0
+      ? Math.min(
+          1,
+          Math.max(
+            0,
+            (currentTimeSeconds - segment.canonicalStart) / segmentDuration,
+          ),
+        )
+      : 0
+
+  let previous = first
+  for (const next of keyframes.slice(1)) {
+    if (segmentProgress > next.progress) {
+      previous = next
+      continue
+    }
+
+    const span = next.progress - previous.progress
+    const localProgress =
+      span > 0 ? (segmentProgress - previous.progress) / span : 0
+
+    return {
+      progress: segmentProgress,
+      x: interpolate(previous.x, next.x, localProgress),
+      y: interpolate(previous.y, next.y, localProgress),
+      width: interpolate(previous.width, next.width, localProgress),
+      height: interpolate(previous.height, next.height, localProgress),
+    }
+  }
+
+  return keyframes[keyframes.length - 1]!
+}
+
+export function buildSmartCropBoxPercent(
+  keyframe: SmartCropPlanKeyframe,
+  source: SmartCropPlanForPlayer["source"],
+): CropBoxPercent {
+  return {
+    left: (keyframe.x / source.width) * 100,
+    top: (keyframe.y / source.height) * 100,
+    width: (keyframe.width / source.width) * 100,
+    height: (keyframe.height / source.height) * 100,
+  }
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value))
+}
+
+export function clampSmartCropBoxPercent(box: CropBoxPercent): CropBoxPercent {
+  const left = clampPercent(box.left)
+  const top = clampPercent(box.top)
+
+  return {
+    left,
+    top,
+    width: Math.min(clampPercent(box.width), 100 - left),
+    height: Math.min(clampPercent(box.height), 100 - top),
+  }
+}
+
+export function formatSmartCropTime(seconds: number): string {
+  const safeSeconds = Math.max(0, seconds)
+  const mins = Math.floor(safeSeconds / 60)
+  const secs = Math.floor(safeSeconds % 60)
+  return `${mins}:${secs.toString().padStart(2, "0")}`
+}

--- a/apps/manager/src/features/smart-crop/smart-crop-plan-review-player.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-plan-review-player.tsx
@@ -1,0 +1,327 @@
+"use client"
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react"
+import { useVideoPlayerCore } from "@forge/video-player"
+import type Player from "video.js/dist/types/player"
+import { apiFetch } from "@/lib/api-fetch"
+import { buildJobArtifactHref } from "@/lib/job-artifacts"
+import type { JobRecord } from "@/types/job"
+import {
+  buildSmartCropBoxPercent,
+  clampSmartCropBoxPercent,
+  findActiveSmartCropSegment,
+  formatSmartCropTime,
+  interpolateSmartCropKeyframe,
+  parseSmartCropPlanForPlayer,
+  type SmartCropPlanForPlayer,
+  type SmartCropPlanSegment,
+} from "./smart-crop-plan-player"
+
+type PlanLoadState =
+  | { status: "waiting"; message: string }
+  | { status: "loading" }
+  | { status: "ready"; plan: SmartCropPlanForPlayer }
+  | { status: "failed"; message: string }
+
+type SmartCropPlanReviewPlayerProps = {
+  job: JobRecord
+}
+
+function buildMuxPlaybackUrl(playbackId: string): string {
+  return `https://stream.mux.com/${playbackId}.m3u8`
+}
+
+function formatConfidence(confidence: number): string {
+  return `${Math.round(Math.min(1, Math.max(0, confidence)) * 100)}%`
+}
+
+function formatShotRange(segment: SmartCropPlanSegment): string {
+  return `${formatSmartCropTime(segment.canonicalStart)}-${formatSmartCropTime(
+    segment.canonicalEnd,
+  )}`
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value))
+}
+
+function getModeClass(mode: string): string {
+  return mode.replace(/[^a-z0-9_-]/gi, "-").toLowerCase()
+}
+
+function SmartCropPlanVideo({ plan }: { plan: SmartCropPlanForPlayer }) {
+  const playerRef = useRef<Player | null>(null)
+  const [player, setPlayer] = useState<Player | null>(null)
+  const [currentTime, setCurrentTime] = useState(0)
+  const sourceAspectStyle = useMemo<CSSProperties>(
+    () => ({
+      aspectRatio: `${plan.source.width} / ${plan.source.height}`,
+    }),
+    [plan.source.height, plan.source.width],
+  )
+  const textTracks = useMemo(() => [], [])
+  const handlePlayerReady = useCallback((nextPlayer: Player) => {
+    playerRef.current = nextPlayer
+    setPlayer(nextPlayer)
+  }, [])
+  const { containerRef, videoRef } = useVideoPlayerCore({
+    src: buildMuxPlaybackUrl(plan.playbackId),
+    textTracks,
+    nativeControls: true,
+    onPlayerReady: handlePlayerReady,
+  })
+
+  useEffect(() => {
+    if (!player) return
+
+    const syncTime = () => {
+      setCurrentTime(player.currentTime() ?? 0)
+    }
+
+    player.on("timeupdate", syncTime)
+    player.on("loadedmetadata", syncTime)
+    player.on("seeked", syncTime)
+    syncTime()
+
+    return () => {
+      player.off("timeupdate", syncTime)
+      player.off("loadedmetadata", syncTime)
+      player.off("seeked", syncTime)
+    }
+  }, [player])
+
+  const activeSegment = useMemo(
+    () => findActiveSmartCropSegment(plan.segments, currentTime),
+    [currentTime, plan.segments],
+  )
+  const activeKeyframe = activeSegment
+    ? interpolateSmartCropKeyframe(activeSegment, currentTime)
+    : null
+  const cropBox = activeKeyframe
+    ? clampSmartCropBoxPercent(
+        buildSmartCropBoxPercent(activeKeyframe, plan.source),
+      )
+    : null
+  const cropBoxStyle = cropBox
+    ? ({
+        left: `${cropBox.left}%`,
+        top: `${cropBox.top}%`,
+        width: `${cropBox.width}%`,
+        height: `${cropBox.height}%`,
+      } satisfies CSSProperties)
+    : undefined
+  const timelineDuration = plan.source.durationSeconds
+  const playheadPercent = clampPercent((currentTime / timelineDuration) * 100)
+
+  const seekTo = useCallback((seconds: number) => {
+    const currentPlayer = playerRef.current
+    if (!currentPlayer) return
+    currentPlayer.currentTime(seconds)
+    setCurrentTime(seconds)
+  }, [])
+
+  return (
+    <div className="smart-crop-plan-player">
+      <div className="smart-crop-plan-player-stage" style={sourceAspectStyle}>
+        <div className="smart-crop-plan-player-video-shell" ref={containerRef}>
+          <video
+            className="video-js vjs-fluid vjs-default-skin smart-crop-plan-player-video"
+            ref={videoRef}
+            playsInline
+          />
+        </div>
+        {cropBoxStyle ? (
+          <div className="smart-crop-plan-crop-box" style={cropBoxStyle}>
+            <span>9:16</span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="smart-crop-shot-summary">
+        <dl className="smart-crop-shot-readout">
+          <div>
+            <dt className="small jobs-field-label">Shot</dt>
+            <dd>
+              {activeSegment
+                ? `${activeSegment.shotId} · ${formatShotRange(activeSegment)}`
+                : "–"}
+            </dd>
+          </div>
+          <div>
+            <dt className="small jobs-field-label">Mode</dt>
+            <dd>{activeSegment?.mode ?? "–"}</dd>
+          </div>
+          <div>
+            <dt className="small jobs-field-label">Subject</dt>
+            <dd>{activeSegment?.primarySubject ?? "–"}</dd>
+          </div>
+          <div>
+            <dt className="small jobs-field-label">Confidence</dt>
+            <dd>
+              {activeSegment ? formatConfidence(activeSegment.confidence) : "–"}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="smart-crop-shot-timeline-wrap">
+          <div
+            className="smart-crop-shot-timeline"
+            aria-label="Smart Crop shot timeline"
+          >
+            {plan.segments.map((segment) => {
+              const left = clampPercent(
+                (segment.canonicalStart / timelineDuration) * 100,
+              )
+              const width = clampPercent(
+                ((segment.canonicalEnd - segment.canonicalStart) /
+                  timelineDuration) *
+                  100,
+              )
+              const isActive = segment.shotId === activeSegment?.shotId
+
+              return (
+                <button
+                  key={segment.shotId}
+                  type="button"
+                  className={`smart-crop-shot-segment smart-crop-shot-segment--${getModeClass(
+                    segment.mode,
+                  )}${isActive ? " is-active" : ""}`}
+                  style={{
+                    left: `${left}%`,
+                    width: `${width}%`,
+                  }}
+                  title={`${segment.shotId} · ${segment.mode} · ${formatShotRange(
+                    segment,
+                  )}`}
+                  aria-label={`${segment.shotId}, ${segment.mode}, ${formatShotRange(
+                    segment,
+                  )}`}
+                  aria-pressed={isActive}
+                  onClick={() => seekTo(segment.canonicalStart)}
+                />
+              )
+            })}
+            <span
+              className="smart-crop-shot-playhead"
+              style={{ left: `${playheadPercent}%` }}
+              aria-hidden="true"
+            />
+          </div>
+          <div className="smart-crop-shot-timeline-labels">
+            <span>{formatSmartCropTime(0)}</span>
+            <span>{formatSmartCropTime(timelineDuration)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function SmartCropPlanReviewPlayer({
+  job,
+}: SmartCropPlanReviewPlayerProps) {
+  const hasPlanArtifact =
+    job.artifacts["smart-crop-plan"]?.kind === "downloadable"
+  const [planState, setPlanState] = useState<PlanLoadState>(() =>
+    hasPlanArtifact
+      ? { status: "loading" }
+      : {
+          status: "waiting",
+          message: "Crop plan artifact unavailable.",
+        },
+  )
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadPlan() {
+      if (!hasPlanArtifact) {
+        setPlanState({
+          status: "waiting",
+          message: "Crop plan artifact unavailable.",
+        })
+        return
+      }
+
+      setPlanState({ status: "loading" })
+
+      try {
+        const response = await apiFetch(
+          buildJobArtifactHref(job.id, "smart-crop-plan"),
+          { cache: "no-store" },
+        )
+        if (!response.ok) {
+          if (!cancelled) {
+            setPlanState({
+              status: "failed",
+              message: "Failed to load crop plan artifact.",
+            })
+          }
+          return
+        }
+
+        const payload = await response.json()
+        const plan = parseSmartCropPlanForPlayer(payload)
+        if (!plan) {
+          if (!cancelled) {
+            setPlanState({
+              status: "failed",
+              message: "Crop plan artifact is malformed.",
+            })
+          }
+          return
+        }
+
+        if (!cancelled) {
+          setPlanState({ status: "ready", plan })
+        }
+      } catch {
+        if (!cancelled) {
+          setPlanState({
+            status: "failed",
+            message: "Failed to load crop plan artifact.",
+          })
+        }
+      }
+    }
+
+    void loadPlan()
+
+    return () => {
+      cancelled = true
+    }
+  }, [hasPlanArtifact, job.id])
+
+  return (
+    <section className="collection-card jobs-card smart-crop-plan-review-card">
+      <div className="jobs-card-header">
+        <h3 className="jobs-section-title">Original crop guide</h3>
+        <span className="smart-crop-plan-player-status">
+          {planState.status}
+        </span>
+      </div>
+
+      {planState.status === "ready" ? (
+        <SmartCropPlanVideo plan={planState.plan} />
+      ) : (
+        <div className="smart-crop-plan-player-empty" role="status">
+          <strong>
+            {planState.status === "loading" ? "Loading crop plan" : "No guide"}
+          </strong>
+          <p>
+            {planState.status === "loading"
+              ? "Loading crop plan artifact."
+              : planState.message}
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Smart Crop operators can now review the original landscape source with the planned 9:16 crop overlaid directly on the job details page. The player reads the persisted crop plan, interpolates the active crop keyframe as playback moves, and renders shot segments as clickable chapter bands under the playhead.

This also adds a mock completed Smart Crop job backed by a public Mux playback id, so local smoke testing exercises the full source-video + crop-overlay flow instead of a placeholder-only state.

## Design Notes

- Crop plan parsing is isolated and defensive: source dimensions, playback id, shot ranges, and usable keyframes are validated before the player renders.
- Crop rectangles are projected into source-video percentages and clamped to the visible frame, so malformed edge values cannot draw the guide outside the video.
- The Manager UI uses `@forge/video-player` core, keeping video playback consistent with existing Manager review surfaces.
- The shot timeline maps `canonicalStart` / `canonicalEnd` into proportional chapter bands; selecting a band seeks the source player to that shot.

## Demo

Local screenshot evidence captured at `/private/tmp/smart-crop-plan-player-final.png`. It shows the mock Smart Crop job with a landscape source video, the 9:16 crop overlay, active shot readout, and three shot chapter segments.

## Validation

- `pnpm --filter @forge/manager test -- smart-crop-plan-player.test.ts smart-crop-presenter.test.ts mock-store.test.ts`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `git diff --check`
- Browser smoke on `http://localhost:3202/dashboard/smart-crop/mock-smart-crop-1`: verified the crop box renders, 3 shot segments render, the video source is blob-backed from the Mux stream, and a clean reload produced no fresh console warnings/errors.
- Local simplify/code-review pass completed with no blocking findings.

## Post-Deploy Monitoring & Validation

- Validation window: first Manager deploy smoke after merge.
- Owner: Manager reviewer / deploy operator.
- Check a completed Smart Crop canonical job with a `smart-crop-plan` artifact and confirm the details page shows `Original crop guide` with status `ready`, a visible 9:16 crop box, and shot timeline segments.
- Watch Manager route/API logs for `/dashboard/smart-crop/*`, `/api/jobs/*`, and `/api/jobs/*/artifacts/smart-crop-plan`.
- Healthy signals: plan artifact returns 200, the crop guide reaches `ready`, and no client errors mention malformed crop plans or failed artifact loads.
- Failure signals: 4xx/5xx responses on the plan artifact route, the details page stuck in `Loading crop plan`, missing crop box/timeline, or real playback ids producing Video.js source errors.
- Rollback/mitigation: revert this UI commit if the details page regresses; existing Smart Crop orchestration/artifacts are unchanged by this slice.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
