### PR TITLE
fix(manager): recover stale Shorts launches

### DIFF
--- a/apps/manager/src/app/api/shorts/jobs/[id]/retry/route.test.ts
+++ b/apps/manager/src/app/api/shorts/jobs/[id]/retry/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { JobRecord, JobStepState, ShortsPhase } from "@/types/job"
 
 const {
@@ -125,6 +125,8 @@ const sessionActor = {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] })
+  vi.setSystemTime(new Date("2026-06-11T00:04:00.000Z"))
   authenticateManagerOverrideRequestMock.mockReset()
   getJobMock.mockReset()
   updateJobMock.mockReset()
@@ -138,6 +140,10 @@ beforeEach(() => {
 
   envMutable.SHORTS_WORKER_BASE_URL = "https://shorts-worker.internal"
   envMutable.SHORTS_WORKER_API_KEY = "shorts-key"
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 describe("POST /api/shorts/jobs/[id]/retry", () => {
@@ -237,6 +243,36 @@ describe("POST /api/shorts/jobs/[id]/retry", () => {
       kind: "prepare",
     })
     expect(launchShortsMock).toHaveBeenCalledWith("prepare", "job-1")
+  })
+
+  it("relaunches prepare for a stale queued launch", async () => {
+    getJobMock.mockResolvedValue(
+      buildShortsJob("queued", { status: "pending" }),
+    )
+    vi.setSystemTime(new Date("2026-06-11T00:10:00.000Z"))
+
+    const response = await POST(postRequest(), routeParams)
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toEqual({
+      launched: true,
+      kind: "prepare",
+    })
+    expect(launchShortsMock).toHaveBeenCalledWith("prepare", "job-1")
+  })
+
+  it("relaunches render for a stale render phase", async () => {
+    getJobMock.mockResolvedValue(
+      buildShortsJob("rendering", { status: "running" }),
+    )
+    vi.setSystemTime(new Date("2026-06-11T01:30:00.000Z"))
+
+    const response = await POST(postRequest(), routeParams)
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toEqual({
+      launched: true,
+      kind: "render",
+    })
+    expect(launchShortsMock).toHaveBeenCalledWith("render", "job-1")
   })
 
   it("does not claim a workflow is running when rejecting a non-running phase", async () => {

--- a/apps/manager/src/app/api/shorts/jobs/[id]/retry/route.ts
+++ b/apps/manager/src/app/api/shorts/jobs/[id]/retry/route.ts
@@ -25,6 +25,7 @@ import {
   releaseShortsLaunchSlot,
 } from "@/lib/shorts-claim"
 import { requireShortsWorkerConfig } from "@/lib/shorts-config"
+import { getShortsActiveStall } from "@/lib/shorts-stale"
 import { readShortsReport } from "@/lib/shorts-report"
 import { resetShortsStepsForLaunch } from "@/lib/workflow-steps"
 import { getJob, updateJob } from "@/lib/state"
@@ -135,6 +136,8 @@ export async function POST(
 
   const report = readShortsReport(job)
   const phase = report?.phase ?? "queued"
+  const activeStall =
+    job.status === "failed" ? null : getShortsActiveStall(job, report)
 
   // Resolve the dispatch per the lifecycle contract.
   let kind: "prepare" | "render"
@@ -147,6 +150,8 @@ export async function POST(
     forcePrepare = true
   } else if (RETRY_PREPARE_PHASES.has(phase)) {
     kind = "prepare"
+  } else if (activeStall) {
+    kind = activeStall.retryKind
   } else if (phase === "queued" && job.status === "failed") {
     // The create route's workflow launch failed before any phase transition
     // (todo 010): no workflow ever ran, so a prepare from scratch is the

--- a/apps/manager/src/features/shorts/shorts-job-detail.tsx
+++ b/apps/manager/src/features/shorts/shorts-job-detail.tsx
@@ -322,10 +322,11 @@ export function ShortsJobDetail({ initialJob }: ShortsJobDetailProps) {
   const summary = getShortsJobSummary(job)
   const phase = summary?.phase ?? "queued"
   const isLaunchFailed = summary?.isLaunchFailed ?? false
+  const activeStall = summary?.activeStall ?? null
   // A launch-failed job (phase "queued" + status "failed") is NOT active:
   // nothing is running, so skip the progress section and phase polling
   // (recentLaunch covers the window right after a retry 202).
-  const isActive = isActiveShortsPhase(phase) && !isLaunchFailed
+  const isActive = isActiveShortsPhase(phase) && !isLaunchFailed && !activeStall
   const isEditor = isEditorShortsPhase(phase)
 
   // -------------------------------------------------------------------
@@ -635,7 +636,10 @@ export function ShortsJobDetail({ initialJob }: ShortsJobDetailProps) {
   // Launch-failed (queued + failed) surfaces the same failure card: a plain
   // retry POST relaunches prepare from scratch (todo 010).
   const isFailed =
-    phase === "prepare_failed" || phase === "render_failed" || isLaunchFailed
+    phase === "prepare_failed" ||
+    phase === "render_failed" ||
+    isLaunchFailed ||
+    activeStall !== null
   // Stale detection prefers the local draftVersion (polling is stopped in
   // editor phases, so the report mirror may lag the latest save).
   const effectiveDraftVersion = Math.max(
@@ -737,11 +741,13 @@ export function ShortsJobDetail({ initialJob }: ShortsJobDetailProps) {
         <section className="collection-card jobs-card">
           <div className="jobs-card-header">
             <h3 className="jobs-section-title">
-              {phase === "prepare_failed"
-                ? "Prepare failed"
-                : phase === "render_failed"
-                  ? "Render failed"
-                  : "Launch failed"}
+              {activeStall
+                ? activeStall.label
+                : phase === "prepare_failed"
+                  ? "Prepare failed"
+                  : phase === "render_failed"
+                    ? "Render failed"
+                    : "Launch failed"}
             </h3>
             <div className="studio-page-intro-actions">
               <button
@@ -772,7 +778,9 @@ export function ShortsJobDetail({ initialJob }: ShortsJobDetailProps) {
               ) : null}
             </div>
           </div>
-          {latestError ? (
+          {activeStall ? (
+            <p className="small jobs-empty-state">{activeStall.message}</p>
+          ) : latestError ? (
             <>
               <p className="jobs-error-text">{latestError.message}</p>
               {latestError.operatorHint ? (

--- a/apps/manager/src/features/shorts/shorts-presenter.test.ts
+++ b/apps/manager/src/features/shorts/shorts-presenter.test.ts
@@ -339,12 +339,27 @@ describe("getShortsJobSummary", () => {
   it("keeps a genuinely queued job presented as queued", () => {
     const summary = getShortsJobSummary(
       buildJob({ artifacts: {}, status: "pending" }),
+      { now: new Date("2026-06-11T00:01:00.000Z") },
     )
     expect(summary).toMatchObject({
       phase: "queued",
       phaseLabel: "Queued",
       phaseTone: "pending",
       isLaunchFailed: false,
+    })
+  })
+
+  it("presents stale queued work as launch stalled", () => {
+    const summary = getShortsJobSummary(
+      buildJob({ artifacts: {}, status: "pending" }),
+      { now: new Date("2026-06-11T00:10:00.000Z") },
+    )
+    expect(summary).toMatchObject({
+      phase: "queued",
+      phaseLabel: "Launch stalled",
+      phaseTone: "failed",
+      isLaunchFailed: false,
+      activeStall: expect.objectContaining({ retryKind: "prepare" }),
     })
   })
 

--- a/apps/manager/src/features/shorts/shorts-presenter.ts
+++ b/apps/manager/src/features/shorts/shorts-presenter.ts
@@ -4,6 +4,10 @@
 // smart-crop-presenter.ts.
 
 import { SHORT_CLIP_DURATION } from "@forge/shorts-compositions/schema"
+import {
+  getShortsActiveStall,
+  type ShortsActiveStall,
+} from "@/lib/shorts-stale"
 import { getShortsReport } from "@/lib/shorts-report"
 import type { JobRecord, ShortsJobReport, ShortsPhase } from "@/types/job"
 
@@ -258,12 +262,16 @@ export type ShortsJobSummary = {
   phaseTone: ShortsPhaseTone
   /** Phase "queued" + job status "failed": the create launch never ran. */
   isLaunchFailed: boolean
+  activeStall: ShortsActiveStall | null
   annotationLabel: string | null
   isStale: boolean
   report: ShortsJobReport | null
 }
 
-export function getShortsJobSummary(job: JobRecord): ShortsJobSummary | null {
+export function getShortsJobSummary(
+  job: JobRecord,
+  options: { now?: Date } = {},
+): ShortsJobSummary | null {
   const shorts = job.options.shorts
   if (!shorts) {
     return null
@@ -277,6 +285,10 @@ export function getShortsJobSummary(job: JobRecord): ShortsJobSummary | null {
   // a workflow that is about to run.
   const phase = report?.phase ?? "queued"
   const isLaunchFailed = isShortsLaunchFailed(phase, job.status)
+  const activeStall =
+    isLaunchFailed || job.status === "failed"
+      ? null
+      : getShortsActiveStall(job, report, options.now)
 
   return {
     assetId: shorts.assetId,
@@ -286,9 +298,15 @@ export function getShortsJobSummary(job: JobRecord): ShortsJobSummary | null {
     clip: shorts.clip,
     clipRangeLabel: formatClipRange(shorts.clip),
     phase,
-    phaseLabel: isLaunchFailed ? "Launch failed" : formatShortsPhase(phase),
-    phaseTone: isLaunchFailed ? "failed" : shortsPhaseTone(phase),
+    phaseLabel: isLaunchFailed
+      ? "Launch failed"
+      : activeStall
+        ? activeStall.label
+        : formatShortsPhase(phase),
+    phaseTone:
+      isLaunchFailed || activeStall ? "failed" : shortsPhaseTone(phase),
     isLaunchFailed,
+    activeStall,
     annotationLabel: formatShortsAnnotation(report?.annotation ?? null),
     isStale: isShortsDraftStale(report),
     report,

--- a/apps/manager/src/lib/shorts-stale.ts
+++ b/apps/manager/src/lib/shorts-stale.ts
@@ -1,0 +1,92 @@
+import type { JobRecord, ShortsJobReport, ShortsPhase } from "@/types/job"
+
+export const SHORTS_ACTIVE_STALL_GRACE_MS = 5 * 60_000
+export const SHORTS_QUEUED_STALL_AFTER_MS = SHORTS_ACTIVE_STALL_GRACE_MS
+export const SHORTS_PREPARING_STALL_AFTER_MS =
+  50 * 60_000 + SHORTS_ACTIVE_STALL_GRACE_MS
+export const SHORTS_RENDERING_STALL_AFTER_MS =
+  80 * 60_000 + SHORTS_ACTIVE_STALL_GRACE_MS
+export const SHORTS_MUX_PROCESSING_STALL_AFTER_MS =
+  60 * 60_000 + SHORTS_ACTIVE_STALL_GRACE_MS
+
+const ACTIVE_STALL_LIMITS: Partial<Record<ShortsPhase, number>> = {
+  queued: SHORTS_QUEUED_STALL_AFTER_MS,
+  preparing: SHORTS_PREPARING_STALL_AFTER_MS,
+  rendering: SHORTS_RENDERING_STALL_AFTER_MS,
+  mux_processing: SHORTS_MUX_PROCESSING_STALL_AFTER_MS,
+}
+
+export type ShortsActiveStall = {
+  phase: Extract<
+    ShortsPhase,
+    "queued" | "preparing" | "rendering" | "mux_processing"
+  >
+  elapsedMs: number
+  retryKind: "prepare" | "render"
+  label: string
+  message: string
+}
+
+function parseTime(value: string | undefined | null): number | null {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function retryKindForPhase(
+  phase: ShortsActiveStall["phase"],
+): "prepare" | "render" {
+  return phase === "queued" || phase === "preparing" ? "prepare" : "render"
+}
+
+function labelForPhase(phase: ShortsActiveStall["phase"]): string {
+  switch (phase) {
+    case "queued":
+      return "Launch stalled"
+    case "preparing":
+      return "Prepare stalled"
+    case "rendering":
+      return "Render stalled"
+    case "mux_processing":
+      return "Mux publish stalled"
+  }
+}
+
+export function getShortsActiveStall(
+  job: Pick<JobRecord, "createdAt" | "updatedAt">,
+  report: Pick<ShortsJobReport, "phase" | "updatedAt"> | null,
+  now: Date = new Date(),
+): ShortsActiveStall | null {
+  const phase = report?.phase ?? "queued"
+  const limitMs = ACTIVE_STALL_LIMITS[phase]
+  if (limitMs === undefined) {
+    return null
+  }
+
+  const activeSince =
+    parseTime(report?.updatedAt) ??
+    parseTime(job.updatedAt) ??
+    parseTime(job.createdAt)
+  if (activeSince === null) {
+    return null
+  }
+
+  const elapsedMs = now.getTime() - activeSince
+  if (elapsedMs < limitMs) {
+    return null
+  }
+
+  const activePhase = phase as ShortsActiveStall["phase"]
+  const retryKind = retryKindForPhase(activePhase)
+
+  return {
+    phase: activePhase,
+    elapsedMs,
+    retryKind,
+    label: labelForPhase(activePhase),
+    message:
+      retryKind === "prepare"
+        ? "The prepare workflow has not updated this short within its expected window. Retry will relaunch prepare."
+        : "The render workflow has not updated this short within its expected window. Retry will relaunch render.",
+  }
+}


### PR DESCRIPTION
## Summary

Operators no longer get stranded on a Shorts detail page that says `Queued` while the progress card keeps saying `Preparing` / `Working...` forever. When an active Shorts phase has gone past its expected worker window, Manager now surfaces it as a stalled, retryable state and the Retry button relaunches the right workflow instead of rejecting the job as still in flight.

This uses the existing Shorts lifecycle ceilings as the recovery boundary: launch/prepare stalls relaunch prepare, and render/Mux stalls relaunch render. Fresh in-flight work still keeps the existing protection against duplicate workflow launches.

## Verification

- `pnpm --filter @forge/manager test -- shorts-presenter`
- `pnpm --filter @forge/manager test -- retry/route`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `git diff --cached --check`
- Local mock browser smoke: `http://localhost:3102/dashboard/shorts/mock-shorts-stale` showed `Launch stalled` with a `Retry` button and no endless `Working...` progress card; screenshot captured at `/private/tmp/manager-shorts-launch-stalled.png`.

## Notes

Production Railway logs were not readable with the available project token, but the public checks were healthy: Manager `/api/health` returned 200, the Shorts worker `/health` returned 200, and a bogus worker bearer returned 401, confirming the worker auth gate was active.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
