### PR TITLE
fix(chat): per-conversation pending state + /ce-code-review hardening (feat-192)

### DIFF
--- a/apps/chat/AGENTS.md
+++ b/apps/chat/AGENTS.md
@@ -21,7 +21,9 @@ Scope: `apps/chat`.
 - Do not wire real agents, auth, or a database without a roadmap ticket —
   this app is stub-only by design (feat-174).
 - Do not add API routes, server actions, or streaming.
-- Do not add a conversation sidebar or persistence.
+- Do not add conversation persistence (a database, or storage that survives a
+  refresh) without a roadmap ticket. The multi-conversation sidebar (feat-192)
+  is intentionally client-only and resets on refresh.
 - Do not import internals from other apps; no app may import from
   `apps/chat`.
 - Do not assign a `jesusfilm.org` DNS entry to the deployed service.

--- a/apps/chat/CLAUDE.md
+++ b/apps/chat/CLAUDE.md
@@ -29,9 +29,9 @@ src/
     brand/
       brand-lockup.tsx   Inlined JFP flag mark + "jesusfilm.ai" wordmark
   lib/
-    chat-stub.ts         Reply-generation seam (Message type) — the Mastra wiring replaces THIS file
-    conversations.ts     Conversation type + createConversation / deriveTitle helpers
-    use-conversations.ts Client hook: send + reply timer + pending double-send guard + new/select conversation
+    chat-stub.ts         Reply-generation seam — the Mastra wiring replaces THIS file
+    conversations.ts     Message + Conversation types + createConversation / deriveTitle helpers
+    use-conversations.ts Client hook: send + per-conversation reply timers + per-conversation pending + double-send guard + new/select conversation
 public/                  Static assets served by URL (Next.js convention, matches apps/web)
   brand/
     jfp-sign.svg         JFP flag mark — canonical source (the mark is inlined in brand-lockup.tsx)
@@ -43,9 +43,11 @@ public/                  Static assets served by URL (Next.js convention, matche
   — `chat.tsx` does not own state. Data flows one way:
   `useConversations` → `AppShell` → `Sidebar` / `Chat` → leaf components.
 - **The stub seam:** reply generation is isolated in `lib/chat-stub.ts`. The
-  hook only orchestrates timing, the pending guard, and which conversation a
-  reply lands in. The `Message` shape (`id`/`role`/`content`) is AI-SDK-aligned
-  so the eventual swap renames nothing.
+  hook only orchestrates timing, the per-conversation pending/double-send guard,
+  and which conversation a reply lands in. The `Message` type lives in
+  `lib/conversations.ts` (NOT in the stub seam) so it survives the seam's
+  deletion; its `id`/`role`/`content` shape is AI-SDK-aligned so the eventual
+  swap renames nothing.
 - **Sidebar is our own addition**, not from the design system — the Vigil
   system as handed to us is single-surface (it lists no conversation sidebar),
   so the rail was built from its tokens rather than copied from it. This too may
@@ -80,8 +82,9 @@ admin's `MASTRA_BASE_URL` pattern) vs through the existing
 see `docs/solutions/platform/mastra-studio-gateway-auth-railway-pattern-20260522.md`).
 Do not wire either without a roadmap ticket that settles the path.
 
-`src/lib/chat-stub.ts` is the seam the real wiring replaces: the `Message`
-shape (`id`/`role`/`content`) is AI-SDK-aligned so the swap renames nothing.
+`src/lib/chat-stub.ts` is the seam the real wiring replaces. The `Message` type
+lives in `src/lib/conversations.ts` (so it outlives the seam); its
+`id`/`role`/`content` shape is AI-SDK-aligned so the swap renames nothing.
 
 ## Intentionally Absent
 
@@ -95,8 +98,11 @@ shape (`id`/`role`/`content`) is AI-SDK-aligned so the swap renames nothing.
 ## Key Conventions
 
 - Server Components by default. Client components are the interactive ones:
-  `shell/app-shell.tsx`, `shell/sidebar.tsx`, and `chat/*`. `brand/*` and the
-  `app/` entry files stay server.
+  `shell/app-shell.tsx`, `shell/sidebar.tsx`, `chat/chat.tsx`,
+  `chat/composer.tsx`, and `chat/empty-state.tsx`. `chat/message-list.tsx` is a
+  pure presentational render (no hooks/handlers) so it carries no `'use client'`
+  and inherits its parent's client context. `brand/*` and the `app/` entry files
+  stay server.
 - Strict TypeScript, `src/` layout, `@/*` path alias — config mirrors
   `apps/web` (the CI-proven template).
 - Tailwind v4, CSS-first (`@import "tailwindcss"` in `src/app/globals.css`;

--- a/apps/chat/src/components/chat/message-list.tsx
+++ b/apps/chat/src/components/chat/message-list.tsx
@@ -1,6 +1,4 @@
-"use client"
-
-import { type Message } from "@/lib/chat-stub"
+import { type Message } from "@/lib/conversations"
 
 type MessageListProps = {
   messages: Message[]

--- a/apps/chat/src/components/shell/app-shell.test.tsx
+++ b/apps/chat/src/components/shell/app-shell.test.tsx
@@ -4,7 +4,9 @@ import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import * as chatStub from "@/lib/chat-stub"
 import { buildStubReply, STUB_REPLY_DELAY_MS } from "@/lib/chat-stub"
+import { deriveTitle } from "@/lib/conversations"
 import { AppShell } from "./app-shell"
 
 // Quiet React's "not configured to support act" warnings (same flag the
@@ -108,6 +110,41 @@ function messageTexts(): string[] {
 
 function isPending(): boolean {
   return getLog().querySelector("[data-pending]") !== null
+}
+
+function getConversationNav(): HTMLElement {
+  const el = container.querySelector<HTMLElement>(
+    'nav[aria-label="Conversations"]',
+  )
+  if (!el) throw new Error("conversation nav not found")
+  return el
+}
+
+function clickNewConversation() {
+  act(() => {
+    const newButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
+    ).find((b) => b.textContent?.includes("New conversation"))
+    if (!newButton) throw new Error("New conversation button not found")
+    newButton.click()
+  })
+}
+
+// Click a conversation in the sidebar rail by its visible title. Scoped to the
+// nav so the "New conversation" action is never matched.
+function selectSidebarConversation(title: string) {
+  act(() => {
+    const btn = Array.from(
+      getConversationNav().querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.includes(title))
+    if (!btn) throw new Error(`sidebar conversation "${title}" not found`)
+    btn.click()
+  })
+}
+
+// How many sidebar rows show the per-conversation "replying" pulse.
+function sidebarReplyingCount(): number {
+  return getConversationNav().querySelectorAll("[data-replying]").length
 }
 
 describe("AppShell", () => {
@@ -276,5 +313,118 @@ describe("AppShell", () => {
     expect(messageTexts()).toHaveLength(0)
     expect(container.textContent).toContain("What would you like to ask?")
     expect(container.textContent).toContain("keep me")
+  })
+
+  it("auto-titles the prior conversation in the rail from its first message", () => {
+    sendMessage("keep me titled")
+    awaitReply()
+
+    const titles = Array.from(
+      getConversationNav().querySelectorAll<HTMLButtonElement>("button"),
+    ).map((b) => b.textContent ?? "")
+    // Explicit: the rail row shows the derived title, not the default
+    // "New conversation" placeholder (the message-list text is excluded
+    // because we only read the sidebar nav).
+    expect(titles).toContain(deriveTitle("keep me titled"))
+    expect(titles).not.toContain("New conversation")
+  })
+
+  it("keeps a reply routed to its originating conversation when the user switches mid-reply", () => {
+    sendMessage("question in A")
+    // Switch to a fresh conversation before A's stub reply fires.
+    clickNewConversation()
+
+    // The new conversation is genuinely idle: empty, not pending, composer live.
+    expect(messageTexts()).toHaveLength(0)
+    expect(isPending()).toBe(false)
+    expect(getTextarea().disabled).toBe(false)
+
+    awaitReply()
+
+    // The reply landed in A, not the conversation that was active when it fired.
+    selectSidebarConversation(deriveTitle("question in A"))
+    const texts = messageTexts()
+    expect(texts).toHaveLength(2)
+    expect(texts[0]).toBe("question in A")
+    expect(texts[1]).toBe(buildStubReply("question in A"))
+  })
+
+  it("attaches the pending pulse to the awaiting conversation, not whichever is active", () => {
+    sendMessage("first")
+    expect(sidebarReplyingCount()).toBe(1)
+
+    clickNewConversation()
+    // Active pane (the new, empty conversation) shows no pending cursor...
+    expect(isPending()).toBe(false)
+    expect(getTextarea().disabled).toBe(false)
+    // ...but the rail still marks the original conversation as replying.
+    expect(sidebarReplyingCount()).toBe(1)
+
+    awaitReply()
+    expect(sidebarReplyingCount()).toBe(0)
+  })
+
+  it("allows sending in a second conversation while the first is still pending", () => {
+    sendMessage("alpha")
+    clickNewConversation()
+    // This send must NOT be swallowed by a cross-conversation lock.
+    sendMessage("beta")
+
+    expect(messageTexts()).toContain("beta")
+    expect(sidebarReplyingCount()).toBe(2)
+
+    awaitReply()
+    expect(sidebarReplyingCount()).toBe(0)
+
+    // Each reply landed in its own conversation.
+    expect(messageTexts()).toEqual(["beta", buildStubReply("beta")])
+    selectSidebarConversation(deriveTitle("alpha"))
+    expect(messageTexts()).toEqual(["alpha", buildStubReply("alpha")])
+  })
+
+  it("restores a prior conversation's messages when reselected from the rail", () => {
+    sendMessage("conv one")
+    awaitReply()
+    clickNewConversation()
+    sendMessage("conv two")
+    awaitReply()
+
+    selectSidebarConversation(deriveTitle("conv one"))
+    expect(messageTexts()).toEqual(["conv one", buildStubReply("conv one")])
+  })
+
+  it("releases the pending slot when reply generation throws, so the conversation can send again", () => {
+    // Latent with the pure stub, but this is the slot-leak guard that matters
+    // once the real (rejectable) Mastra call replaces buildStubReply: the
+    // finally must clear the timer/pending slot even on a throw.
+    const spy = vi
+      .spyOn(chatStub, "buildStubReply")
+      .mockImplementationOnce(() => {
+        throw new Error("reply boom")
+      })
+
+    sendMessage("trigger throw")
+    expect(isPending()).toBe(true)
+
+    // The thrown reply propagates out of the timer, but the finally already
+    // ran clearTimer, freeing the per-conversation slot.
+    expect(() => awaitReply()).toThrow("reply boom")
+
+    // Proof the slot was released: a fresh send is accepted (not swallowed by
+    // the double-send guard) and resolves cleanly, leaving the pane idle.
+    spy.mockRestore()
+    sendMessage("after throw")
+    expect(messageTexts()).toContain("after throw")
+    awaitReply()
+    expect(isPending()).toBe(false)
+    expect(getTextarea().disabled).toBe(false)
+  })
+
+  it("treats reselecting the active conversation as a no-op and keeps the draft", () => {
+    // The sole conversation starts active with the default title. Reselecting
+    // it must hit the early-return guard (no draft reset).
+    typeDraft("draft in progress")
+    selectSidebarConversation("New conversation")
+    expect(getTextarea().value).toBe("draft in progress")
   })
 })

--- a/apps/chat/src/components/shell/app-shell.tsx
+++ b/apps/chat/src/components/shell/app-shell.tsx
@@ -15,6 +15,7 @@ export function AppShell() {
     activeConversation,
     draft,
     pending,
+    pendingIds,
     setDraft,
     send,
     newConversation,
@@ -26,6 +27,7 @@ export function AppShell() {
       <Sidebar
         conversations={conversations}
         activeId={activeId}
+        pendingIds={pendingIds}
         onNew={newConversation}
         onSelect={selectConversation}
       />

--- a/apps/chat/src/components/shell/sidebar.tsx
+++ b/apps/chat/src/components/shell/sidebar.tsx
@@ -6,6 +6,7 @@ import { type Conversation } from "@/lib/conversations"
 type SidebarProps = {
   conversations: Conversation[]
   activeId: string
+  pendingIds: ReadonlySet<string>
   onNew: () => void
   onSelect: (id: string) => void
 }
@@ -17,6 +18,7 @@ type SidebarProps = {
 export function Sidebar({
   conversations,
   activeId,
+  pendingIds,
   onNew,
   onSelect,
 }: SidebarProps) {
@@ -49,20 +51,33 @@ export function Sidebar({
         <ul className="flex flex-col gap-0.5">
           {conversations.map((conversation) => {
             const active = conversation.id === activeId
+            const replying = pendingIds.has(conversation.id)
             return (
               <li key={conversation.id}>
                 <button
                   type="button"
                   aria-current={active ? "true" : undefined}
                   onClick={() => onSelect(conversation.id)}
-                  className={`w-full truncate rounded-lg px-3.5 py-2.5 text-left text-sm transition-colors duration-300 ${
+                  className={`flex w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left text-sm transition-colors duration-300 ${
                     active
                       ? "bg-linen/[0.06] text-linen"
                       : "text-ash hover:bg-linen/[0.03] hover:text-linen"
                   }`}
                   title={conversation.title}
                 >
-                  {conversation.title}
+                  <span className="min-w-0 flex-1 truncate">
+                    {conversation.title}
+                  </span>
+                  {replying ? (
+                    <>
+                      <span
+                        aria-hidden="true"
+                        data-replying="true"
+                        className="size-1.5 shrink-0 rounded-full bg-lamplight [animation:vigil-pulse_2s_var(--ease-vigil)_infinite]"
+                      />
+                      <span className="sr-only">Replying</span>
+                    </>
+                  ) : null}
                 </button>
               </li>
             )

--- a/apps/chat/src/lib/chat-stub.ts
+++ b/apps/chat/src/lib/chat-stub.ts
@@ -1,12 +1,7 @@
 // Client-side stub for assistant replies. This module is the seam the
 // eventual Mastra wiring replaces — keep the UI free of reply-generation
-// logic so the swap stays contained here.
-
-export type Message = {
-  id: string
-  role: "user" | "assistant"
-  content: string
-}
+// logic so the swap stays contained here. The Message type lives in
+// conversations.ts (not here) so it survives this file's deletion.
 
 export const STUB_REPLY_DELAY_MS = 800
 

--- a/apps/chat/src/lib/conversations.test.ts
+++ b/apps/chat/src/lib/conversations.test.ts
@@ -39,6 +39,12 @@ describe("deriveTitle", () => {
     expect(result).toHaveLength(40)
   })
 
+  it("truncates a very long unbroken string to the 40-char ceiling", () => {
+    const result = deriveTitle("x".repeat(200))
+    expect(result).toBe(`${"x".repeat(39)}…`)
+    expect(result).toHaveLength(40)
+  })
+
   it("does not leave a trailing space before the ellipsis", () => {
     // Index 38 (the char the 39-char slice ends on) is a space, so trimEnd
     // must drop it before the ellipsis is appended.

--- a/apps/chat/src/lib/conversations.ts
+++ b/apps/chat/src/lib/conversations.ts
@@ -1,9 +1,16 @@
 // Stub conversation model. Lives entirely in the client and resets on refresh
-// — no persistence until users + a database land. The Message shape is owned
-// by chat-stub.ts (the Mastra wiring seam); a Conversation is just a titled
-// list of those messages.
+// — no persistence until users + a database land. A Conversation is just a
+// titled list of messages.
 
-import { type Message } from "./chat-stub"
+// The message shape. Owned here (not in chat-stub.ts) so it survives the
+// eventual deletion of the stub seam — both this file and the UI keep
+// importing it from a module that outlives the Mastra swap. The
+// `id`/`role`/`content` shape is AI-SDK-aligned so that swap renames nothing.
+export type Message = {
+  id: string
+  role: "user" | "assistant"
+  content: string
+}
 
 export type Conversation = {
   id: string

--- a/apps/chat/src/lib/use-conversations.ts
+++ b/apps/chat/src/lib/use-conversations.ts
@@ -2,11 +2,12 @@
 
 import { useEffect, useRef, useState } from "react"
 
-import { buildStubReply, STUB_REPLY_DELAY_MS, type Message } from "./chat-stub"
+import { buildStubReply, STUB_REPLY_DELAY_MS } from "./chat-stub"
 import {
   createConversation,
   deriveTitle,
   type Conversation,
+  type Message,
 } from "./conversations"
 
 export type UseConversations = {
@@ -15,6 +16,7 @@ export type UseConversations = {
   activeConversation: Conversation
   draft: string
   pending: boolean
+  pendingIds: ReadonlySet<string>
   setDraft: (value: string) => void
   send: (text: string) => void
   newConversation: () => void
@@ -23,8 +25,14 @@ export type UseConversations = {
 
 // Owns all conversation + reply state so the components stay presentational.
 // The reply-generation seam is still buildStubReply() in chat-stub.ts; this
-// hook only orchestrates timing, the pending guard, and which conversation a
-// reply lands in.
+// hook only orchestrates timing and which conversation a reply lands in.
+//
+// In-flight replies are tracked PER CONVERSATION (an id set for rendering + a
+// timer map keyed by id), not as one global flag. Each conversation owns its
+// own pending reply, so the pulse cursor and disabled composer attach to the
+// conversation that is actually waiting — never to whichever one happens to be
+// active when the user switches mid-reply — and a slow reply in one
+// conversation never locks sending in another.
 export function useConversations(): UseConversations {
   const [conversations, setConversations] = useState<Conversation[]>(() => [
     createConversation(),
@@ -33,19 +41,56 @@ export function useConversations(): UseConversations {
     () => conversations[0]?.id ?? "",
   )
   const [draft, setDraft] = useState("")
-  const [pending, setPending] = useState(false)
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  )
 
-  // Mirrors `pending` so the synchronous guard in send() reads the current
-  // value before the next render commits — a second Enter landing before
-  // React re-renders must not double-send.
-  const pendingRef = useRef(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The SINGLE source of truth for in-flight replies, keyed by conversation
+  // id. Read synchronously in send() before the next render commits so a second
+  // submit into the same conversation can't double-send. `pendingIds` above is
+  // a derived snapshot of this map's keys (kept in sync via syncPendingIds), so
+  // rendering and the guard can never drift. The map is mutated but never
+  // reassigned — the unmount cleanup below relies on that.
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  )
+
+  // Mirror of activeId that updates synchronously when the conversation
+  // changes, so send() captures the right target even if a switch and a send
+  // land in the same React batch (a render-closure read of activeId could be
+  // stale there).
+  const activeIdRef = useRef(activeId)
 
   useEffect(() => {
+    // Capturing timersRef.current is safe because the map is mutated, never
+    // reassigned, so this local stays the live instance for the component's
+    // lifetime.
+    const timers = timersRef.current
     return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current)
+      for (const timer of timers.values()) clearTimeout(timer)
+      timers.clear()
     }
   }, [])
+
+  // pendingIds is derived from the timer map's keys — recomputed on every
+  // start/clear so the two never diverge. Both write paths (start + the
+  // finally below) go through these two helpers; nothing else touches the map.
+  function syncPendingIds() {
+    setPendingIds(new Set(timersRef.current.keys()))
+  }
+
+  function startTimer(
+    conversationId: string,
+    timer: ReturnType<typeof setTimeout>,
+  ) {
+    timersRef.current.set(conversationId, timer)
+    syncPendingIds()
+  }
+
+  function clearTimer(conversationId: string) {
+    timersRef.current.delete(conversationId)
+    syncPendingIds()
+  }
 
   function appendMessage(conversationId: string, message: Message) {
     setConversations((prev) =>
@@ -66,41 +111,56 @@ export function useConversations(): UseConversations {
 
   function send(text: string) {
     const trimmed = text.trim()
-    if (!trimmed || pendingRef.current) return
-    pendingRef.current = true
-    setPending(true)
+    // Capture the target up front (from the synchronous ref, not the render
+    // closure) so the reply lands in the conversation that was active at send
+    // time even if the user switches while the stub is "thinking".
+    const targetId = activeIdRef.current
+    // One in-flight reply per conversation: a second submit into the same
+    // conversation before it resolves is a no-op. Other conversations stay
+    // free to send in parallel.
+    if (!trimmed || timersRef.current.has(targetId)) return
     setDraft("")
 
-    // Capture the target so a reply still lands here even if the user switches
-    // conversations while the stub is "thinking".
-    const targetId = activeId
     appendMessage(targetId, {
       id: crypto.randomUUID(),
       role: "user",
       content: trimmed,
     })
 
-    timerRef.current = setTimeout(() => {
-      appendMessage(targetId, {
-        id: crypto.randomUUID(),
-        role: "assistant",
-        content: buildStubReply(trimmed),
-      })
-      pendingRef.current = false
-      timerRef.current = null
-      setPending(false)
+    const timer = setTimeout(() => {
+      // Release the slot in finally so a throw in reply generation can never
+      // leave the conversation wedged (stuck pulse + double-send lock). Latent
+      // with the pure stub, but load-bearing once the Mastra call — which can
+      // reject — replaces buildStubReply. See the fire-and-forget slot-leak
+      // guard pattern in the root CLAUDE.md known-patterns list.
+      try {
+        appendMessage(targetId, {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: buildStubReply(trimmed),
+        })
+      } finally {
+        clearTimer(targetId)
+      }
     }, STUB_REPLY_DELAY_MS)
+    startTimer(targetId, timer)
   }
 
   function newConversation() {
     const conversation = createConversation()
+    // Keep the synchronous mirror in lockstep with the state update so a send
+    // batched with this switch targets the new conversation.
+    activeIdRef.current = conversation.id
     setConversations((prev) => [conversation, ...prev])
     setActiveId(conversation.id)
     setDraft("")
   }
 
   function selectConversation(id: string) {
-    if (id === activeId) return
+    // Guard on the synchronous mirror (not the render-closure activeId) so it
+    // stays consistent with how send() reads the active id.
+    if (id === activeIdRef.current) return
+    activeIdRef.current = id
     setActiveId(id)
     setDraft("")
   }
@@ -114,7 +174,10 @@ export function useConversations(): UseConversations {
     activeId,
     activeConversation,
     draft,
-    pending,
+    // Pending state for the active pane is derived from the per-conversation
+    // set, so it is true only when the active conversation itself is waiting.
+    pending: pendingIds.has(activeConversation.id),
+    pendingIds,
     setDraft,
     send,
     newConversation,

--- a/docs/roadmap/ai-chat/LANE-DECISION-RECORD-WEB.md
+++ b/docs/roadmap/ai-chat/LANE-DECISION-RECORD-WEB.md
@@ -119,6 +119,65 @@ outcomes only decide the lane's **registration** and the renumber.
 
 ---
 
+## Frontmatter vocabulary additions (apply with outcome A)
+
+Code review of #1277 (feat-192) flagged frontmatter values outside the
+vocabularies declared in root `CLAUDE.md` → "Feature File Format". Where a value
+is an **intended addition**, the ticket keeps it (tracked deviation, same gated
+posture as the provisional tags noted in problem 2) and root `CLAUDE.md` is
+extended **when the lane decision lands** (outcome A), in the same atomic pass as
+the renumber. Where a value is **wrong** (borrowed from another app, or a one-off
+descriptor), the renumber pass corrects the ticket instead of extending the
+vocabulary.
+
+### Add to the allowed vocabulary
+
+1. **Owner `jianwei`.** Not in the allowed owner set
+   (`tataihono, vlad, ekkasit, nisal, urim`). `jianwei` owns the chat web-app
+   line and will own more tickets on this trunk — **add `jianwei` to the allowed
+   owner set** in root `CLAUDE.md` "Feature File Format" rather than reassigning
+   the ticket. (Owner is a one-line change under any outcome; doing it at
+   decision time avoids a churny pre-merge edit on a gated trunk.)
+
+2. **Tag `ai-chat` (only).** Not in the allowed tag vocabulary
+   (`cms, manager, web, mobile, tv, graphql, ai-pipeline, search, pgvector, infrastructure, i18n`).
+   **Add exactly one tag — `ai-chat`** — as part of registering the lane. It is
+   the lane's domain/capability tag (sibling to `ai-pipeline`), and it is the
+   umbrella that spans BOTH this `apps/chat` web line AND the Mastra/seeker
+   backend work — one concept, one name, mirroring the lane directory.
+
+### Do NOT add (correct the tickets instead, at the renumber pass)
+
+- **`chat` tag — rejected.** Too generic, and it collides semantically with the
+  unrelated admin AI-chat work (experience-editor chat panel, four-channel
+  providers, thumb-rating scorer — see `docs/brainstorms/2026-05-*`). A flat
+  searchable vocabulary should not carry both `chat` and `ai-chat`; `ai-chat` is
+  the specific, non-colliding name. Tickets currently carrying `chat` drop it for
+  `ai-chat`.
+- **`web` tag — wrong app; remove.** In this repo `web` is the **`apps/web`**
+  app tag (the watch/search/experience consumer app), parallel to `mobile` / `tv`
+  / `manager` / `cms`. `apps/chat` is a separate deployable that does not touch
+  `apps/web`, so `web` on a chat ticket mis-files it. Remove `web` from the chat
+  tickets (do not treat it as an addition).
+- **`scaffold` tag — rejected.** A one-off activity descriptor, not a durable
+  searchable facet. `infrastructure` already covers standing up a new app's
+  skeleton + deploy config. Drop `scaffold`; keep `infrastructure`.
+
+### Resulting ticket tags (apply at the renumber pass)
+
+- **feat-192** (Vigil re-skin): `["web", "chat", "ai-chat"]` → **`["ai-chat"]`**.
+- **feat-174** (scaffold): `["infrastructure", "chat", "scaffold"]` →
+  **`["infrastructure", "ai-chat"]`**.
+
+> No app-scoped tag is minted for `apps/chat` (the obvious name `chat` is the one
+> rejected above, and the `ai-chat/` lane directory already provides the app
+> grouping). Introduce one later only if a concrete need appears.
+
+Under outcome **C** (drop the tickets), no vocabulary addition is needed — the
+tickets are deleted and the vocabularies stay as-is.
+
+---
+
 ## Reference inventory — files to update on renumber/relocate
 
 Generated from `git grep -lE 'feat-174'` + `chat-app-scaffold` on
@@ -183,9 +242,12 @@ record).
 4. Apply the change across every IN-SCOPE file (rename the roadmap ticket file,
    update frontmatter `id`/`depends_on`/`blocks`, update all ID + path + plan-seq
    strings).
-5. For outcome A: apply the canonical lane edits (per the seeker record) and add
-   the lane to `docs/roadmap/README.md`. For outcome C: delete the chat roadmap
-   ticket and repoint inbound references to the plan docs / PRs.
+5. For outcome A: apply the canonical lane edits (per the seeker record), add
+   the lane to `docs/roadmap/README.md`, apply the **Frontmatter vocabulary
+   additions** above (owner `jianwei`; the single tag `ai-chat`) to root
+   `CLAUDE.md` "Feature File Format", AND correct the ticket tags per "Resulting
+   ticket tags" above (drop `web` / `chat` / `scaffold`). For outcome C: delete
+   the chat roadmap ticket and repoint inbound references to the plan docs / PRs.
 6. Update PR #1276's body + this record (mark complete).
 7. **Verify zero stale references** before merging the renumber:
 

--- a/docs/roadmap/ai-chat/feat-192-chat-app-vigil-reskin.md
+++ b/docs/roadmap/ai-chat/feat-192-chat-app-vigil-reskin.md
@@ -104,3 +104,22 @@ In-browser smoke (headless Chromium via chrome-devtools MCP): empty state shows
 the Newsreader prompt + starters; clicking a starter sends → Embersoot user
 bubble + stub reply; sidebar item auto-retitles; "+ New conversation" opens a
 fresh empty conversation while the prior one persists in the rail.
+
+## What was shipped
+
+Delivered via **#1277** (squash-merged into trunk **#1276**). A follow-up pass
+with `/ce-code-review` (three rounds) hardened the shipped UI — same scope, no
+new requirements — landed in **#<follow-up PR>**:
+
+- Pending state moved from one global flag to **per-conversation** (single
+  source of truth): the pulse cursor + disabled composer attach to the
+  conversation actually awaiting a reply, and one slow reply no longer locks the
+  others.
+- Reply-slot release wrapped in `try/finally` (fire-and-forget slot-leak guard),
+  ahead of the eventual Mastra async swap.
+- `Message` type moved to `conversations.ts` so it survives the stub seam's
+  deletion.
+- Behavioral tests added for mid-reply switching, parallel sends, and the
+  slot-leak guard.
+
+Recorded here in lieu of a separate ticket.

--- a/docs/roadmap/ai-chat/feat-192-chat-app-vigil-reskin.md
+++ b/docs/roadmap/ai-chat/feat-192-chat-app-vigil-reskin.md
@@ -109,7 +109,7 @@ fresh empty conversation while the prior one persists in the rail.
 
 Delivered via **#1277** (squash-merged into trunk **#1276**). A follow-up pass
 with `/ce-code-review` (three rounds) hardened the shipped UI — same scope, no
-new requirements — landed in **#<follow-up PR>**:
+new requirements — landed in **#1294**:
 
 - Pending state moved from one global flag to **per-conversation** (single
   source of truth): the pulse cursor + disabled composer attach to the


### PR DESCRIPTION
## What

Review-hardening follow-ups for the **feat-192 Vigil re-skin + conversation shell** (shipped in #1277, on the `apps/chat` web trunk #1276). Targets the trunk `feature/ai-chat-web-app`, **not `main`**. Same scope as feat-192 — no new requirements; this resolves findings from three `/ce-code-review` passes over the #1277 diff.

## Why

The re-skin centralized N-conversation state behind single global slots (`pending` boolean + one `timerRef`). Review surfaced that this mis-attributes the pending pulse / disabled composer to whichever conversation is *active* (not the one awaiting a reply), serializes sending across conversations, and ties the reply-slot release to the success path only — latent today with the 800ms stub, but a real wedge once the Mastra async call replaces it.

## Changes

**Behavior (`use-conversations.ts`)**
- Pending tracked **per conversation**: `timersRef: Map<id, timeout>` is the single source of truth; `pendingIds` is its derived snapshot (via `startTimer`/`clearTimer`/`syncPendingIds`). Pulse + disabled composer attach to the conversation actually waiting; a slow reply in one no longer locks others.
- Reply-slot release moved into a **`try/finally`** (fire-and-forget slot-leak guard), ahead of the Mastra async swap.
- `activeIdRef` mirrors `activeId` synchronously; `selectConversation` guards on it.
- Sidebar shows a per-conversation "replying" indicator.

**Structure / docs**
- `Message` type moved `chat-stub.ts` → `conversations.ts` so it survives the stub seam's deletion.
- `message-list.tsx` drops an unnecessary `'use client'`.
- `apps/chat/AGENTS.md` retires the "no conversation sidebar" guard (keeps the persistence guard); `apps/chat/CLAUDE.md` carves out `message-list.tsx` in the client-component list.
- `LANE-DECISION-RECORD-WEB.md`: records owner `jianwei` + a single `ai-chat` tag as outcome-A vocabulary additions, and `web`/`chat`/`scaffold` as removals (with reasoning).
- `feat-192` gains a "What was shipped" note.

**Tests** — added coverage for mid-reply conversation switching, reply routing to the originating conversation, parallel sends across conversations, the slot-leak guard (reply-gen throw → slot released), and the `selectConversation` no-op guard. **30 tests pass** (was 22).

## Verification

```bash
pnpm --filter @forge/chat typecheck   # clean
pnpm --filter @forge/chat lint        # clean
pnpm --filter @forge/chat test        # 30 pass
```

## Deferred to the Mastra-wiring ticket

When `buildStubReply` becomes a rejectable async call: migrate `Map<id, timeout>` → `Map<id, {timer, controller}>`, `abort()` on unmount + check `signal.aborted` after each `await`, and add an async-reject release test. Flagged in code comments + CLAUDE.md known-patterns.

## Gated

Inherits the same gate as the trunk — see `docs/roadmap/ai-chat/LANE-DECISION-RECORD-WEB.md`. Draft until the lane-registration/renumber decision lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)