### PR TITLE
fix(manager): show only videos in shorts picker

### DIFF
--- a/apps/manager/src/features/shorts/shorts-create-screen.tsx
+++ b/apps/manager/src/features/shorts/shorts-create-screen.tsx
@@ -32,27 +32,13 @@ import {
   parseClipTime,
   validateClipSelection,
 } from "./shorts-presenter"
+import {
+  flattenPickerVideos,
+  type PickerVideo,
+  type VideosApiResponse,
+} from "./shorts-picker"
 
 const PICKER_RESULT_LIMIT = 60
-
-type PickerVideo = {
-  id: string
-  title: string
-  imageUrl: string | null
-  label: string
-}
-
-type VideosApiItem = {
-  id: string
-  title: string
-  imageUrl: string | null
-  label: string
-}
-
-type VideosApiResponse = {
-  collections: Array<VideosApiItem & { videos: VideosApiItem[] }>
-  standalone: VideosApiItem[]
-}
 
 export type ShortsCreatePrefill = {
   coreId?: string
@@ -100,34 +86,6 @@ function describeCreateFailure(payload: {
     default:
       return payload.error ?? "Failed to create the short."
   }
-}
-
-function flattenPickerVideos(payload: VideosApiResponse): PickerVideo[] {
-  const byId = new Map<string, PickerVideo>()
-  const add = (item: VideosApiItem) => {
-    if (!byId.has(item.id)) {
-      byId.set(item.id, {
-        id: item.id,
-        title: item.title,
-        imageUrl: item.imageUrl,
-        label: item.label,
-      })
-    }
-  }
-
-  for (const collection of payload.collections ?? []) {
-    add(collection)
-    for (const video of collection.videos ?? []) {
-      add(video)
-    }
-  }
-  for (const video of payload.standalone ?? []) {
-    add(video)
-  }
-
-  return [...byId.values()].sort((left, right) =>
-    left.title.localeCompare(right.title),
-  )
 }
 
 function ClipScrubber({

--- a/apps/manager/src/features/shorts/shorts-picker.test.ts
+++ b/apps/manager/src/features/shorts/shorts-picker.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+import { flattenPickerVideos } from "./shorts-picker"
+
+describe("flattenPickerVideos", () => {
+  it("keeps source videos while dropping collection groups", () => {
+    expect(
+      flattenPickerVideos({
+        collections: [
+          {
+            id: "nua-series",
+            title: "NUA",
+            imageUrl: null,
+            label: "SERIES",
+            videos: [
+              {
+                id: "nua-easter-trailer",
+                title: "NUA Easter Trailer",
+                imageUrl: "https://example.test/trailer.jpg",
+                label: "EPISODE",
+              },
+              {
+                id: "nua-collection",
+                title: "NUA Fresh Perspective",
+                imageUrl: null,
+                label: "COLLECTION",
+              },
+            ],
+          },
+        ],
+        standalone: [
+          {
+            id: "standalone-video",
+            title: "Standalone Video",
+            imageUrl: null,
+            label: "shortFilm",
+          },
+          {
+            id: "standalone-collection",
+            title: "Standalone Collection",
+            imageUrl: null,
+            label: "collection",
+          },
+        ],
+      }).map((video) => video.id),
+    ).toEqual(["nua-easter-trailer", "standalone-video"])
+  })
+
+  it("deduplicates videos already present in a collection", () => {
+    expect(
+      flattenPickerVideos({
+        collections: [
+          {
+            id: "collection-1",
+            title: "Collection",
+            imageUrl: null,
+            label: "collection",
+            videos: [
+              {
+                id: "video-1",
+                title: "Video",
+                imageUrl: null,
+                label: "episode",
+              },
+            ],
+          },
+        ],
+        standalone: [
+          {
+            id: "video-1",
+            title: "Video",
+            imageUrl: null,
+            label: "episode",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "video-1",
+        title: "Video",
+        imageUrl: null,
+        label: "episode",
+      },
+    ])
+  })
+})

--- a/apps/manager/src/features/shorts/shorts-picker.ts
+++ b/apps/manager/src/features/shorts/shorts-picker.ts
@@ -1,0 +1,49 @@
+export type PickerVideo = {
+  id: string
+  title: string
+  imageUrl: string | null
+  label: string
+}
+
+export type VideosApiItem = {
+  id: string
+  title: string
+  imageUrl: string | null
+  label: string
+}
+
+export type VideosApiResponse = {
+  collections: Array<VideosApiItem & { videos: VideosApiItem[] }>
+  standalone: VideosApiItem[]
+}
+
+function isSelectableSourceVideo(item: VideosApiItem): boolean {
+  return item.label.trim().toLowerCase() !== "collection"
+}
+
+export function flattenPickerVideos(payload: VideosApiResponse): PickerVideo[] {
+  const byId = new Map<string, PickerVideo>()
+  const add = (item: VideosApiItem) => {
+    if (!isSelectableSourceVideo(item) || byId.has(item.id)) return
+
+    byId.set(item.id, {
+      id: item.id,
+      title: item.title,
+      imageUrl: item.imageUrl,
+      label: item.label,
+    })
+  }
+
+  for (const collection of payload.collections ?? []) {
+    for (const video of collection.videos ?? []) {
+      add(video)
+    }
+  }
+  for (const video of payload.standalone ?? []) {
+    add(video)
+  }
+
+  return [...byId.values()].sort((left, right) =>
+    left.title.localeCompare(right.title),
+  )
+}


### PR DESCRIPTION
## Summary

Shorts source selection no longer shows collection/group rows as clip candidates. Searching the picker now returns only real source videos, while collection children and standalone videos still appear normally.

The picker transform now treats `/api/videos` collections as grouping structure, not selectable media, and defensively drops collection-labeled rows before the UI can send them through Shorts eligibility resolution.

## Validation

- `pnpm --filter @forge/manager test -- shorts-picker`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `pnpm exec prettier --check apps/manager/src/features/shorts/shorts-create-screen.tsx apps/manager/src/features/shorts/shorts-picker.ts apps/manager/src/features/shorts/shorts-picker.test.ts`
- `git diff --check`
- Local mock browser snapshot on `/dashboard/shorts/new`: picker rows were `A New Beginning`, `Episode 1`, and `Episode 2`; no collection row appeared. Screenshot capture timed out in the browser tool, but the DOM/accessibility snapshot verified the visible row set.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
