### PR TITLE
feat(watch): add compatible download filenames

### DIFF
--- a/apps/web/src/app/api/download/route.test.ts
+++ b/apps/web/src/app/api/download/route.test.ts
@@ -190,13 +190,15 @@ describe("GET /watch/api/download — upstream success path", () => {
     const res = await GET(
       makeRequest({
         url: "https://stream.mux.com/abc.mp4",
-        filename: "jesus-highest.mp4",
+        filename: "Jesus-Film_English_eng_360p.mp4",
       }),
     )
     expect(res.status).toBe(200)
     const cd = res.headers.get("content-disposition") ?? ""
-    expect(cd).toContain('attachment; filename="jesus-highest.mp4"')
-    expect(cd).toContain("filename*=UTF-8''jesus-highest.mp4")
+    expect(cd).toContain(
+      'attachment; filename="Jesus-Film_English_eng_360p.mp4"',
+    )
+    expect(cd).toContain("filename*=UTF-8''Jesus-Film_English_eng_360p.mp4")
     expect(res.headers.get("content-type")).toBe("video/mp4")
     expect(res.headers.get("content-length")).toBe("11")
     expect(res.headers.get("cache-control")).toContain("no-store")
@@ -355,6 +357,21 @@ describe("GET /watch/api/download — filename sanitization", () => {
     )
     const cd = res.headers.get("content-disposition") ?? ""
     expect(cd).toMatch(/filename="Adobe-Update\.mp4"/)
+  })
+
+  it("preserves an allowed extension when clamping long filenames", async () => {
+    mockUpstream(new Response("ok", { status: 200 }))
+    const res = await GET(
+      makeRequest({
+        url: "https://stream.mux.com/abc.mp4",
+        filename: `${"Jesus-Film-".repeat(30)}_English_eng_360p.mp4`,
+      }),
+    )
+    const cd = res.headers.get("content-disposition") ?? ""
+    const match = cd.match(/filename="([^"]+)"/)
+    const filename = match?.[1] ?? ""
+    expect(filename).toMatch(/\.mp4$/)
+    expect(filename.length).toBeLessThanOrEqual(200)
   })
 
   it("falls back to a `download` literal when the sanitized filename collapses to empty", async () => {

--- a/apps/web/src/app/api/download/route.ts
+++ b/apps/web/src/app/api/download/route.ts
@@ -67,6 +67,7 @@ const BIDI_CONTROL_RE = /[‪-‮⁦-⁩]/g
 // Path separators and shell-meta characters that have no business in a
 // `Content-Disposition: filename` value.
 const FILENAME_UNSAFE_RE = /[\\/;,"]/g
+const MAX_DOWNLOAD_FILENAME_LENGTH = 200
 
 function jsonError(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status })
@@ -188,17 +189,24 @@ function sanitizeFilename(raw: string): string {
     .trim()
   // After stripping, optionally trim trailing dots/spaces (Windows-hostile)
   // and clamp length to prevent absurd filenames in error logs.
-  const clamped = stripped.replace(/[.\s]+$/, "").slice(0, 200)
-  if (clamped.length === 0) return "download"
+  const trimmed = stripped.replace(/[.\s]+$/, "")
+  if (trimmed.length === 0) return "download"
+
   // Enforce extension allowlist tied to media-only payloads.
-  const lastDot = clamped.lastIndexOf(".")
-  if (lastDot > 0 && lastDot < clamped.length - 1) {
-    const ext = clamped.slice(lastDot + 1).toLowerCase()
-    if (!SAFE_DOWNLOAD_EXTENSIONS.has(ext)) {
-      return `${clamped.slice(0, lastDot)}.mp4`
-    }
-  }
-  return clamped
+  const lastDot = trimmed.lastIndexOf(".")
+  const hasExtension = lastDot > 0 && lastDot < trimmed.length - 1
+  const rawExtension = hasExtension ? trimmed.slice(lastDot) : ""
+  const normalizedExtension = rawExtension.slice(1).toLowerCase()
+  const extension = hasExtension
+    ? SAFE_DOWNLOAD_EXTENSIONS.has(normalizedExtension)
+      ? rawExtension
+      : ".mp4"
+    : ""
+  const rawBasename = hasExtension ? trimmed.slice(0, lastDot) : trimmed
+  const maxBasenameLength = MAX_DOWNLOAD_FILENAME_LENGTH - extension.length
+  const basename =
+    rawBasename.slice(0, maxBasenameLength).replace(/[.\s]+$/, "") || "download"
+  return `${basename}${extension}`
 }
 
 // Logs origin + path only; signed-URL JWTs and other secrets in query

--- a/apps/web/src/components/watch/DownloadModal.tsx
+++ b/apps/web/src/components/watch/DownloadModal.tsx
@@ -42,7 +42,9 @@ export type DownloadModalProps = {
   posterUrl?: string | null
   /** Variant duration in seconds (used for the runtime overlay on the thumbnail). */
   durationSeconds?: number | null
+  languageCode?: string | null
   languageName?: string | null
+  languageSlug?: string | null
   variantId: string
   videoSlug: string
   onClose: () => void
@@ -103,7 +105,9 @@ export function DownloadModal({
   videoTitle,
   posterUrl,
   durationSeconds,
+  languageCode,
   languageName,
+  languageSlug,
   variantId,
   videoSlug,
   onClose,
@@ -307,7 +311,14 @@ export function DownloadModal({
     }
     setAuthChecking(false)
 
-    const filename = buildDownloadFilename(videoTitle, selected.tier)
+    const filename = buildDownloadFilename({
+      languageCode,
+      languageName,
+      languageSlug,
+      renditionHeight: selected.download.height,
+      tier: selected.tier,
+      videoTitle,
+    })
 
     // Route through our same-origin streaming proxy so the browser honors
     // the `download` attribute and `Content-Disposition: attachment`. A

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -286,6 +286,10 @@ export function WatchPageClient({
   }, [])
 
   const currentLanguageSlug = languageSlug ?? variant.language?.slug ?? ""
+  const selectedLanguageCode =
+    [variant.language?.iso3, variant.language?.bcp47, variant.language?.slug]
+      .map((code) => code?.trim())
+      .find(Boolean) ?? null
   const videoSlug = video.slug ?? ""
   const tDownloadButton = useTranslations("DownloadButton")
   const routeWarmPromisesRef = useRef(new Map<string, Promise<void>>())
@@ -446,6 +450,12 @@ export function WatchPageClient({
               : null
           return {
             documentId: d.documentId,
+            height:
+              typeof d.height === "number" &&
+              Number.isFinite(d.height) &&
+              d.height > 0
+                ? d.height
+                : null,
             quality: d.quality as string,
             size: sizeNum != null && Number.isFinite(sizeNum) ? sizeNum : null,
           }
@@ -459,11 +469,26 @@ export function WatchPageClient({
     if (!fallbackTier) return undefined
     return buildDownloadProxyUrl({
       downloadId: fallbackTier.download.documentId,
-      filename: buildDownloadFilename(video.title, fallbackTier.tier),
+      filename: buildDownloadFilename({
+        languageCode: selectedLanguageCode,
+        languageName: variant.language?.name ?? null,
+        languageSlug: variant.language?.slug ?? null,
+        renditionHeight: fallbackTier.download.height,
+        tier: fallbackTier.tier,
+        videoTitle: video.title,
+      }),
       variantId: variant.documentId,
       videoSlug,
     })
-  }, [downloadsForModal, variant.documentId, video.title, videoSlug])
+  }, [
+    downloadsForModal,
+    selectedLanguageCode,
+    variant.documentId,
+    variant.language?.name,
+    variant.language?.slug,
+    video.title,
+    videoSlug,
+  ])
 
   const shareHref = useMemo(
     () =>
@@ -654,7 +679,9 @@ export function WatchPageClient({
           videoTitle={video.title ?? null}
           posterUrl={posterUrl}
           durationSeconds={variant.duration ?? null}
+          languageCode={selectedLanguageCode}
           languageName={variant.language?.name ?? null}
+          languageSlug={variant.language?.slug ?? null}
           variantId={variant.documentId}
           videoSlug={videoSlug}
           onClose={closeModal}

--- a/apps/web/src/components/watch/__tests__/DownloadModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/DownloadModal.test.tsx
@@ -483,10 +483,19 @@ describe("DownloadModal — AE4 gating (ToS only; size has a default)", () => {
       root.render(
         <TestDownloadModal
           open
-          downloads={[makeDownload({ documentId: "dl-1", quality: "fhd" })]}
+          downloads={[
+            makeDownload({
+              documentId: "dl-1",
+              height: 360,
+              quality: "fhd",
+            }),
+          ]}
+          languageCode="eng"
+          languageName="English"
+          languageSlug="english"
           variantId="variant-1"
           videoSlug="jesus"
-          videoTitle="JESUS"
+          videoTitle="Jesus Film"
           onClose={vi.fn()}
         />,
       )
@@ -526,9 +535,9 @@ describe("DownloadModal — AE4 gating (ToS only; size has a default)", () => {
     expect(a.getAttribute("href")).toContain("variantId=variant-1")
     expect(a.getAttribute("href")).toContain("videoSlug=jesus")
     expect(a.getAttribute("href")).not.toContain("stream.mux.com")
-    // Filename is derived from the video title + tier.
+    // Filename is derived from title, selected audio language, code, and height.
     const downloadAttr = a.getAttribute("download") ?? ""
-    expect(downloadAttr).toBe("jesus-highest.mp4")
+    expect(downloadAttr).toBe("Jesus-Film_English_eng_360p.mp4")
     expect(a.getAttribute("href")).toContain(
       `filename=${encodeURIComponent(downloadAttr)}`,
     )

--- a/apps/web/src/components/watch/__tests__/WatchPageClient.download.test.tsx
+++ b/apps/web/src/components/watch/__tests__/WatchPageClient.download.test.tsx
@@ -170,12 +170,18 @@ function renderWatchPage({
     downloads: [
       {
         documentId: "47420a5c-0ae1-465e-bcc9-98056566d087",
+        height: 360,
         quality: "fhd",
         size: "1048576",
         url: "https://stream.mux.com/raw-client-leak.mp4",
       },
     ],
-    language: { slug: languageSlug, name: languageSlug },
+    language: {
+      bcp47: "en",
+      iso3: "eng",
+      slug: languageSlug,
+      name: languageSlug === "english" ? "English" : languageSlug,
+    },
     muxVideo: { playbackId: "playback-1" },
   }
   const video = {
@@ -227,6 +233,11 @@ describe("WatchPageClient download boundary", () => {
     expect(renderer?.getAttribute("data-download-href")).not.toContain(
       "stream.mux.com",
     )
+    expect(renderer?.getAttribute("data-download-href")).toContain(
+      `filename=${encodeURIComponent(
+        "Jesus-Is-Brought-to-Pilate_English_eng_360p.mp4",
+      )}`,
+    )
     expect(renderer?.getAttribute("data-share-href")).toContain(
       "https://www.facebook.com/sharer/sharer.php",
     )
@@ -251,14 +262,21 @@ describe("WatchPageClient download boundary", () => {
 
     const latestProps = downloadModalProps.at(-1) as {
       downloads: Array<Record<string, unknown>>
+      languageCode: string
+      languageName: string
+      languageSlug: string
       variantId: string
       videoSlug: string
     }
     expect(latestProps.variantId).toBe("5fc705b9-1b3b-4a58-abef-755b98457de6")
     expect(latestProps.videoSlug).toBe("jesus-is-brought-to-pilate")
+    expect(latestProps.languageCode).toBe("eng")
+    expect(latestProps.languageName).toBe("English")
+    expect(latestProps.languageSlug).toBe("english")
     expect(latestProps.downloads).toEqual([
       {
         documentId: "47420a5c-0ae1-465e-bcc9-98056566d087",
+        height: 360,
         quality: "fhd",
         size: 1048576,
       },

--- a/apps/web/src/components/watch/__tests__/download-link.test.ts
+++ b/apps/web/src/components/watch/__tests__/download-link.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+
+import { buildDownloadFilename } from "@/components/watch/download-link"
+
+describe("buildDownloadFilename", () => {
+  it("uses title, audio language, ISO code, and rendition height", () => {
+    expect(
+      buildDownloadFilename({
+        videoTitle: "Jesus Film",
+        languageName: "English",
+        languageCode: "eng",
+        renditionHeight: 360,
+        tier: "low",
+      }),
+    ).toBe("Jesus-Film_English_eng_360p.mp4")
+  })
+
+  it("falls back to a stable language slug when ISO is missing", () => {
+    expect(
+      buildDownloadFilename({
+        videoTitle: "Jesus Film",
+        languageName: "Karo",
+        languageSlug: "karo-ethiopia",
+        renditionHeight: 480,
+        tier: "high",
+      }),
+    ).toBe("Jesus-Film_Karo_karo-ethiopia_480p.mp4")
+  })
+
+  it("falls back to the tier label when height is missing", () => {
+    expect(
+      buildDownloadFilename({
+        videoTitle: "Jesus Film",
+        languageName: "English",
+        languageCode: "eng",
+        renditionHeight: null,
+        tier: "low",
+      }),
+    ).toBe("Jesus-Film_English_eng_low.mp4")
+  })
+
+  it("distinguishes same-name languages by code", () => {
+    const common = {
+      videoTitle: "Jesus Film",
+      languageName: "Karo",
+      renditionHeight: 360,
+      tier: "low" as const,
+    }
+
+    expect(buildDownloadFilename({ ...common, languageCode: "kxh" })).toBe(
+      "Jesus-Film_Karo_kxh_360p.mp4",
+    )
+    expect(buildDownloadFilename({ ...common, languageCode: "arr" })).toBe(
+      "Jesus-Film_Karo_arr_360p.mp4",
+    )
+  })
+
+  it("normalizes punctuation and non-ASCII characters to safe symbols", () => {
+    expect(
+      buildDownloadFilename({
+        videoTitle: "L'Évangile: Jésus/Marie",
+        languageName: "Français & Côte d’Ivoire",
+        languageCode: "fra",
+        renditionHeight: 720,
+        tier: "high",
+      }),
+    ).toBe("L-Evangile-Jesus-Marie_Francais-Cote-d-Ivoire_fra_720p.mp4")
+  })
+
+  it("removes brackets, control characters, trailing dots, and trailing spaces", () => {
+    const filename = buildDownloadFilename({
+      videoTitle: "Jesus [Film].   ",
+      languageName: "English\t(US)\n",
+      languageCode: "e\rng",
+      renditionHeight: 360,
+      tier: "low",
+    })
+
+    expect(filename).toBe("Jesus-Film_English-US_e-ng_360p.mp4")
+    expect(filename).toMatch(/^[A-Za-z0-9_.-]+$/)
+    expect(filename.replace(/\.mp4$/, "")).not.toMatch(/[. ]$/)
+  })
+
+  it("bounds generated filenames while preserving the mp4 extension", () => {
+    const filename = buildDownloadFilename({
+      videoTitle: "Jesus Film ".repeat(40),
+      languageName: "English",
+      languageCode: "eng",
+      renditionHeight: 360,
+      tier: "low",
+    })
+
+    expect(filename.length).toBeLessThanOrEqual(200)
+    expect(filename).toMatch(/\.mp4$/)
+    expect(filename).toMatch(/^[A-Za-z0-9_.-]+$/)
+  })
+
+  it("keeps the filename non-empty when metadata is missing", () => {
+    expect(buildDownloadFilename({ tier: null })).toBe(
+      "Video_Language_unknown_unknown.mp4",
+    )
+  })
+})

--- a/apps/web/src/components/watch/download-link.ts
+++ b/apps/web/src/components/watch/download-link.ts
@@ -27,13 +27,74 @@ export function buildDownloadProxyUrl({
   return `${DOWNLOAD_PROXY_PATH}?${params.toString()}`
 }
 
-export function buildDownloadFilename(
-  videoTitle: string | null | undefined,
-  tier: DownloadTier,
+export type BuildDownloadFilenameParams = {
+  languageCode?: string | null
+  languageName?: string | null
+  languageSlug?: string | null
+  renditionHeight?: number | null
+  tier?: DownloadTier | null
+  videoTitle?: string | null
+}
+
+const DOWNLOAD_FILENAME_EXTENSION = ".mp4"
+const MAX_DOWNLOAD_FILENAME_LENGTH = 200
+
+function asciiWords(value: string | null | undefined): string[] {
+  return (
+    (value ?? "")
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .match(/[A-Za-z0-9]+/g) ?? []
+  )
+}
+
+function textSegment(
+  value: string | null | undefined,
+  fallback: string,
 ): string {
-  const slug = (videoTitle ?? "video")
-    .replace(/[^a-z0-9]+/gi, "-")
-    .replace(/^-|-$/g, "")
-    .toLowerCase()
-  return `${slug || "video"}-${tier}.mp4`
+  const words = asciiWords(value)
+  if (words.length > 0) return words.join("-")
+  return asciiWords(fallback).join("-") || "Unknown"
+}
+
+function codeSegment(...candidates: (string | null | undefined)[]): string {
+  for (const candidate of candidates) {
+    const segment = asciiWords(candidate).join("-").toLowerCase()
+    if (segment) return segment
+  }
+  return "unknown"
+}
+
+function renditionSegment(
+  height: number | null | undefined,
+  tier: DownloadTier | null | undefined,
+): string {
+  if (height != null && Number.isFinite(height) && height > 0) {
+    return `${Math.round(height)}p`
+  }
+  return codeSegment(tier, "unknown")
+}
+
+export function buildDownloadFilename({
+  languageCode,
+  languageName,
+  languageSlug,
+  renditionHeight,
+  tier,
+  videoTitle,
+}: BuildDownloadFilenameParams): string {
+  const segments = [
+    textSegment(videoTitle, "Video"),
+    textSegment(languageName, "Language"),
+    codeSegment(languageCode, languageSlug, languageName),
+    renditionSegment(renditionHeight, tier),
+  ]
+  const maxBasenameLength =
+    MAX_DOWNLOAD_FILENAME_LENGTH - DOWNLOAD_FILENAME_EXTENSION.length
+  const basename =
+    segments
+      .join("_")
+      .slice(0, maxBasenameLength)
+      .replace(/[._-]+$/g, "") || "video"
+  return `${basename}${DOWNLOAD_FILENAME_EXTENSION}`
 }

--- a/apps/web/src/components/watch/download-options.ts
+++ b/apps/web/src/components/watch/download-options.ts
@@ -1,5 +1,6 @@
 export type WatchDownloadOption = {
   documentId: string
+  height?: number | null
   quality: string
   size: number | null
 }

--- a/apps/web/src/lib/content.test.ts
+++ b/apps/web/src/lib/content.test.ts
@@ -585,7 +585,23 @@ describe("resolveWatchVideoBySlug — locale fallback", () => {
       })
       .mockResolvedValueOnce({
         data: {
-          videoDub: makeRussianDub(),
+          videoDub: makeRussianDub({
+            language: {
+              coreId: "3934",
+              bcp47: "ru",
+              iso3: "rus",
+              slug: "russian",
+              name: "Russian",
+            },
+            downloads: [
+              {
+                documentId: "download-ru-low",
+                height: 360,
+                quality: "low",
+                size: "1048576",
+              },
+            ],
+          }),
         },
       })
 
@@ -608,6 +624,15 @@ describe("resolveWatchVideoBySlug — locale fallback", () => {
     })
     expect(result?.video.title).toBe("Jesus RU")
     expect(result?.selectedVariant.language?.slug).toBe("russian")
+    expect(result?.selectedVariant.language?.iso3).toBe("rus")
+    expect(result?.selectedVariant.downloads).toEqual([
+      {
+        documentId: "download-ru-low",
+        height: 360,
+        quality: "low",
+        size: "1048576",
+      },
+    ])
   })
 
   it("uses broad BCP-47 content before English when exact languageSlug content is missing", async () => {

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -170,6 +170,7 @@ export type WatchParent = {
 export type WatchVariantLanguage = {
   coreId: string | null
   bcp47: string | null
+  iso3?: string | null
   slug: string | null
   name: string | null
   nativeName: string | null
@@ -177,6 +178,7 @@ export type WatchVariantLanguage = {
 
 export type WatchVariantDownload = {
   documentId: string
+  height?: number | null
   quality: string | null
   size: string | null
 }
@@ -435,6 +437,7 @@ type AdminImageRaw = {
 type AdminLanguageRaw = {
   coreId?: string | null
   bcp47?: string | null
+  iso3?: string | null
   slug?: string | null
   name?: unknown
 }
@@ -458,6 +461,7 @@ type AdminVideoVariantRaw = {
   downloads?:
     | {
         documentId: string | null
+        height?: number | null
         quality?: string | null
         size?: string | null
       }[]
@@ -735,6 +739,7 @@ function normalizeVariant(
       ? {
           coreId: v.language.coreId ?? null,
           bcp47: v.language.bcp47 ?? null,
+          iso3: v.language.iso3 ?? null,
           slug: v.language.slug ?? null,
           name: pickLocalizedName(v.language.name),
           nativeName: pickNativeName(v.language.name),
@@ -745,6 +750,7 @@ function normalizeVariant(
         if (!d.documentId) return null
         return {
           documentId: d.documentId,
+          height: d.height ?? null,
           quality: d.quality ?? null,
           size: d.size ?? null,
         }
@@ -763,6 +769,7 @@ function normalizeVariant(
               ? {
                   coreId: subtitle.language.coreId ?? null,
                   bcp47: subtitle.language.bcp47 ?? null,
+                  iso3: subtitle.language.iso3 ?? null,
                   slug: subtitle.language.slug ?? null,
                   name: pickLocalizedName(subtitle.language.name),
                   nativeName: pickNativeName(subtitle.language.name),

--- a/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
+++ b/apps/web/src/lib/fragments/__tests__/watch-video.test.ts
@@ -71,8 +71,12 @@ describe("WatchVideo split GraphQL operations", () => {
     expect(printed).toMatch(/documentId\s*:\s*\bid\b/)
     expect(printed).toMatch(/\bhls\b/)
     expect(printed).toMatch(/\bduration\b/)
-    expect(printed).toMatch(/\blanguage\s*\{[\s\S]*?coreId[\s\S]*?slug/)
-    expect(printed).toMatch(/\bdownloads\s*\{[\s\S]*?quality[\s\S]*?size/)
+    expect(printed).toMatch(
+      /\blanguage\s*\{[\s\S]*?coreId[\s\S]*?iso3[\s\S]*?slug/,
+    )
+    expect(printed).toMatch(
+      /\bdownloads\s*\{[\s\S]*?height[\s\S]*?quality[\s\S]*?size/,
+    )
     expect(printed).toMatch(/\bmuxVideo\s*\{[\s\S]*?playbackId/)
     expect(printed).toMatch(
       /\bvideoEdition\s*\{[\s\S]*?subtitles\s*\{[\s\S]*?vttSrc[\s\S]*?srtSrc[\s\S]*?primary[\s\S]*?aiGenerated/,

--- a/apps/web/src/lib/fragments/watch-video.ts
+++ b/apps/web/src/lib/fragments/watch-video.ts
@@ -189,11 +189,13 @@ export const watchVideoDubDetailFragment = adminGraphql(`
     language {
       coreId
       bcp47
+      iso3
       slug
       name
     }
     downloads {
       documentId: id
+      height
       quality
       size
     }

--- a/docs/brainstorms/2026-06-17-watch-compatible-download-filenames-requirements.md
+++ b/docs/brainstorms/2026-06-17-watch-compatible-download-filenames-requirements.md
@@ -1,0 +1,160 @@
+---
+date: "2026-06-17"
+topic: "watch-compatible-download-filenames"
+title: "Watch Compatible Download Filenames"
+type: "requirements"
+---
+
+# Watch Compatible Download Filenames
+
+## Summary
+
+Watch downloads should default to portable, self-identifying filenames such as `Jesus-Film_English_eng_360p.mp4`. The filename should identify the film, audio language, stable language code, and actual rendition height while staying compatible with common computer filesystems, microSD cards, and older media players.
+
+---
+
+## Problem Frame
+
+Field teams download hundreds of films each quarter and often load many languages onto microSD cards or devices for regional distribution. The current downloaded filename is too generic, so teams manually rename files after each download to avoid putting the wrong language or rendition onto a device.
+
+The manual rename step is especially error-prone when languages share a display name, when regional versions exist for the same broad language, or when quality labels such as "Low Resolution" do not reveal the actual file height. The filename needs to carry enough identifying information that a helper can sort files correctly without speaking the language or reopening the Watch page.
+
+---
+
+## Key Decisions
+
+- **Use the compatible filename format by default.** Prefer `Jesus-Film_English_eng_360p.mp4` over `Jesus Film - English [eng] 360p.mp4` because spaces and square brackets are less reliable on older DVD, USB, and embedded media players.
+- **Treat the audio language as the identity anchor.** The filename describes the selected Dub's audio language, not the UI locale or browser language.
+- **Prefer actual rendition height over tier labels.** Use `360p`, `720p`, or the closest available height-derived label when available; keep `low`, `high`, or `highest` only as fallback.
+- **Mention subtitles only when the downloaded media contains them.** Do not add subtitle language text based only on the Watch player's optional subtitle selection.
+- **Preserve the existing download security boundary.** Filename improvement must not expose raw CDN URLs or weaken the same-origin download proxy.
+
+---
+
+## Actors
+
+- A1. **Field media coordinator** - Downloads many Watch videos and prepares language sets for teams.
+- A2. **Loading helper** - Copies downloaded files onto microSD cards or devices and relies on filenames to avoid mixups.
+- A3. **Watch downloader** - Selects a language and rendition from the public Watch download flow.
+- A4. **Watch system** - Supplies safe filenames to the browser while streaming media through the existing download path.
+
+---
+
+## Requirements
+
+**Filename Content**
+
+- R1. Each Watch download filename must include a sanitized film title, selected audio language name, language code, and rendition label.
+- R2. The language code must prefer ISO 639-3 when available because it distinguishes same-name languages used in different regions.
+- R3. The rendition label must prefer actual pixel height such as `360p` or `720p` when known.
+- R4. The filename extension must match the downloaded media type, with `.mp4` remaining the expected default for current Watch video downloads.
+
+**Compatibility Format**
+
+- R5. The default filename must use only ASCII letters, ASCII digits, hyphen, underscore, and period.
+- R6. Spaces, square brackets, parentheses, apostrophes, ampersands, commas, plus signs, and non-ASCII characters must be removed or normalized from the default filename.
+- R7. Filename segments must be joined in a stable order: title, language name, language code, rendition label.
+- R8. The filename must avoid platform-hostile forms such as path separators, control characters, trailing dots, trailing spaces, and Windows reserved device names.
+
+**Fallback Behavior**
+
+- R9. Missing language code must not block download; fall back to another stable language identifier and keep the rest of the filename useful.
+- R10. Missing rendition height must not block download; fall back to the current tier label.
+- R11. Missing or empty title or language text must fall back to safe generic segments without producing an empty filename.
+- R12. Same-name language cases must remain distinguishable when their stored language codes differ.
+
+**Download Experience**
+
+- R13. The user should not need to edit the filename manually for the common case after downloading from Watch.
+- R14. The browser's final saved filename must match the generated filename for both normal clicks and direct download-proxy responses.
+- R15. Existing Terms of Use, account-gate, same-origin proxy, resumable download, and SSRF protections must remain unchanged.
+
+---
+
+## Key Flows
+
+- F1. Download a known film language
+  - **Actors:** A3, A4
+  - **Steps:** The user opens the Download modal, accepts the Terms of Use, selects a rendition, and starts the download.
+  - **Outcome:** The browser saves a file named like `Jesus-Film_English_eng_360p.mp4`.
+  - **Covered by:** R1, R2, R3, R5, R13, R14
+
+- F2. Prepare a multilingual device
+  - **Actors:** A1, A2
+  - **Steps:** A coordinator downloads several languages, then a helper copies files onto a microSD card.
+  - **Outcome:** The helper can identify title, language, language code, and rendition from each filename without reopening Watch.
+  - **Covered by:** R1, R2, R7, R12, R13
+
+- F3. Download with incomplete metadata
+  - **Actors:** A3, A4
+  - **Steps:** The user downloads a video whose selected Dub or rendition lacks one preferred metadata field.
+  - **Outcome:** The download still succeeds with safe fallback segments.
+  - **Covered by:** R9, R10, R11, R15
+
+---
+
+## Acceptance Examples
+
+- AE1. English known height
+  - **Given:** The film title is `Jesus Film`, audio language is `English`, ISO 639-3 is `eng`, and rendition height is `360`.
+  - **When:** The user downloads that rendition.
+  - **Then:** The saved filename is `Jesus-Film_English_eng_360p.mp4`.
+  - **Covers:** R1, R2, R3, R5, R7
+
+- AE2. Same display name, different language codes
+  - **Given:** Two downloadable languages share the display name `Karo` but have different stored language codes.
+  - **When:** A user downloads the same film in both languages.
+  - **Then:** The resulting filenames differ by language code.
+  - **Covers:** R2, R12
+
+- AE3. Missing height fallback
+  - **Given:** A selected rendition has a quality tier but no stored height.
+  - **When:** The user downloads it.
+  - **Then:** The filename uses the tier label in the rendition segment rather than omitting the segment.
+  - **Covers:** R10
+
+- AE4. Player subtitles enabled
+  - **Given:** The user has enabled Watch subtitles in French while downloading English audio.
+  - **When:** The downloaded MP4 does not contain embedded subtitles.
+  - **Then:** The filename names the English audio language and does not claim French subtitles.
+  - **Covers:** R1, R15
+
+---
+
+## Success Criteria
+
+- Downloaded filenames are self-identifying enough for field teams to sort files without manual renaming in the common case.
+- Filenames remain safe on macOS, Windows, Linux, FAT32, exFAT, and conservative media-player file browsers.
+- Existing Watch download tests still prove raw media URLs are not exposed to the browser.
+- Regression tests cover exact filename examples, fallback behavior, and filename sanitization edge cases.
+
+---
+
+## Scope Boundaries
+
+- Bulk download queues, ZIP packaging, and manifest export are deferred.
+- Editing the actual media file contents is out of scope.
+- Subtitle-language naming is out of scope unless the downloaded asset includes subtitle tracks.
+- Changing the visible Download modal layout is out of scope unless a small label is needed to preview the generated filename.
+- Reworking the download proxy route shape or authentication model is out of scope.
+
+---
+
+## Dependencies / Assumptions
+
+- The selected audio language has or can expose ISO 639-3, BCP-47, slug, or another stable fallback identifier.
+- Download rendition metadata has or can expose height for the selected file.
+- The browser and proxy continue to honor the generated filename through the existing `Content-Disposition` path.
+- The compatible default may be less readable than the spaced/bracketed convention, but reliability matters more for this workflow.
+
+---
+
+## Sources / Research
+
+- `apps/web/src/components/watch/download-link.ts` - current title-plus-tier filename builder.
+- `apps/web/src/components/watch/DownloadModal.tsx` - current download modal and browser anchor creation.
+- `apps/web/src/app/api/download/route.ts` - current filename sanitization and `Content-Disposition` response.
+- `apps/web/src/lib/fragments/watch-video.ts` - selected Dub detail data currently used by Watch.
+- `apps/admin/schema.graphql` - Admin exposes language and download metadata needed for richer filenames.
+- `docs/plans/2026-06-12-005-fix-watch-download-target-lookup-plan.md` - recent download-proxy hardening context.
+- `docs/roadmap/platform/feat-146-web-user-accounts-download-gate.md` - existing download gate and proxy boundary.

--- a/docs/plans/2026-06-17-002-feat-watch-compatible-download-filenames-plan.md
+++ b/docs/plans/2026-06-17-002-feat-watch-compatible-download-filenames-plan.md
@@ -1,0 +1,193 @@
+---
+title: "Watch compatible download filenames"
+type: feat
+status: completed
+date: 2026-06-17
+origin: docs/brainstorms/2026-06-17-watch-compatible-download-filenames-requirements.md
+---
+
+# Watch compatible download filenames
+
+## Summary
+
+Generate portable, self-identifying Watch download filenames such as
+`Jesus-Film_English_eng_360p.mp4` from the selected Dub and selected rendition.
+The existing same-origin download proxy remains the delivery boundary.
+
+---
+
+## Problem Frame
+
+Field teams download and copy many films across many languages. The current
+title-plus-tier filename does not identify the selected audio language, language
+code, or actual resolution, so teams manually rename files and can still confuse
+same-name or regional language variants.
+
+---
+
+## Requirements
+
+### Filename Content
+
+- R1. Watch download filenames must include sanitized title, selected audio
+  language name, language code, and rendition label segments in that order.
+- R2. Language code must prefer `Language.iso3`, then fall back to another
+  stable language identifier when ISO 639-3 is unavailable.
+- R3. Rendition label must prefer `VideoDubDownload.height` as `{height}p`,
+  then fall back to the selected download tier.
+- R4. Current MP4 downloads must keep a `.mp4` extension.
+
+### Compatibility
+
+- R5. Generated filenames must use only ASCII letters, ASCII digits, hyphen,
+  underscore, and period.
+- R6. Spaces, brackets, punctuation, path separators, control characters,
+  trailing dots, trailing spaces, and non-ASCII characters must be normalized or
+  removed from generated filenames.
+- R7. Empty or unsafe title, language, code, or rendition metadata must fall
+  back to non-empty safe segments without blocking the download.
+- R8. Same-name languages must remain distinguishable when their stored language
+  codes differ.
+
+### Download Boundary
+
+- R9. The selected Dub's audio language must drive the filename, not UI locale
+  or browser language.
+- R10. The download flow must keep the existing Terms of Use gate, account gate,
+  same-origin proxy, range behavior, and SSRF defenses unchanged.
+- R11. The client must not expose raw `VideoDubDownload.url` values.
+- R12. Subtitle language text must remain out of scope unless the downloaded
+  media file itself contains subtitle tracks.
+
+---
+
+## Key Technical Decisions
+
+- **Use one compatible default format:** The spaced/bracketed convention is more
+  readable, but `Title_Language_code_360p.mp4` with hyphenated text segments is
+  safer for conservative file browsers and microSD workflows.
+- **Extend the existing Watch data contract only with needed metadata:**
+  `Language.iso3` and `VideoDubDownload.height` already exist in Admin GraphQL,
+  so Web can select and normalize those fields without changing Admin schema.
+- **Keep filename generation client-side and proxy sanitization server-side:**
+  the browser needs the suggested filename before creating the anchor, while
+  `/watch/api/download` remains the final `Content-Disposition` sanitizer.
+- **Use selected rendition height instead of the bucket label when present:**
+  `low` and `high` remain safe fallbacks, but they no longer carry enough
+  operational meaning for downloaded-file sorting.
+- **Do not infer subtitle filenames from player state:** Watch subtitle
+  selections are player choices, not proof that the MP4 download embeds
+  subtitles.
+
+---
+
+## Implementation Units
+
+### U1. Add filename metadata to selected Watch data
+
+- **Goal:** Select and normalize the language code and download height needed by
+  the filename builder.
+- **Files:** `apps/web/src/lib/fragments/watch-video.ts`,
+  `apps/web/src/lib/fragments/__tests__/watch-video.test.ts`,
+  `apps/web/src/lib/content.ts`,
+  `apps/web/src/components/watch/download-options.ts`.
+- **Patterns:** Add `iso3` to the selected Dub language fragment and `height`
+  to download selections. Do not select or expose raw download URLs.
+- **Test Scenarios:** Fragment tests cover the added fields; normalization keeps
+  null-safe language and download metadata.
+
+### U2. Replace title-tier filename generation
+
+- **Goal:** Make `buildDownloadFilename` produce the compatible format and
+  handle unsafe or missing metadata.
+- **Files:** `apps/web/src/components/watch/download-link.ts`,
+  `apps/web/src/components/watch/__tests__/download-link.test.ts`.
+- **Patterns:** Normalize text to ASCII, join words within title/language
+  segments with hyphens, join major segments with underscores, lower-case code
+  segments, and keep only `.mp4` for current Watch video downloads.
+- **Test Scenarios:** Exact `Jesus-Film_English_eng_360p.mp4` example, missing
+  ISO fallback, missing height fallback, same-name language disambiguation,
+  non-ASCII normalization, punctuation stripping, and empty metadata fallbacks.
+
+### U3. Wire modal and fallback hrefs to selected metadata
+
+- **Goal:** Pass selected Dub and selected rendition metadata through both the
+  modal click path and the fallback download link path.
+- **Files:** `apps/web/src/components/watch/DownloadModal.tsx`,
+  `apps/web/src/components/watch/WatchPageClient.tsx`,
+  `apps/web/src/components/watch/__tests__/DownloadModal.test.tsx`,
+  `apps/web/src/components/watch/__tests__/WatchPageClient.download.test.tsx`.
+- **Patterns:** Keep the existing proxy URL shape and anchor creation behavior.
+  Only the `filename` query value and `download` attribute should change.
+- **Test Scenarios:** Modal tests assert the compatible filename in the proxy
+  URL and anchor `download`; Watch page tests assert hrefs remain same-origin.
+
+### U4. Validate proxy compatibility and roadmap state
+
+- **Goal:** Confirm route sanitization still accepts the new compatible filename
+  and mark the roadmap item complete after local validation.
+- **Files:** `apps/web/src/app/api/download/route.test.ts`,
+  `docs/roadmap/topic-experiences/feat-196-watch-compatible-download-filenames.md`.
+- **Patterns:** Add route coverage only if existing tests do not already prove
+  `Content-Disposition` preserves compatible filenames.
+- **Test Scenarios:** Direct proxy response uses the generated filename; feature
+  ticket status reflects shipped work.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given title `Jesus Film`, audio language `English`, ISO 639-3 `eng`,
+  and height `360`, the saved filename is
+  `Jesus-Film_English_eng_360p.mp4`.
+- AE2. Given two `Karo` languages with codes `kxh` and `arr`, their downloaded
+  filenames differ by the code segment.
+- AE3. Given a download without height, the rendition segment falls back to the
+  selected tier such as `low`.
+- AE4. Given a title and language with punctuation or non-ASCII characters, the
+  filename contains only ASCII letters, digits, hyphen, underscore, and period.
+- AE5. Given Watch subtitles are enabled in the player, the downloaded MP4
+  filename still names only the selected audio language unless embedded
+  subtitle metadata is available.
+
+---
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/download-link.test.ts src/components/watch/__tests__/DownloadModal.test.tsx src/components/watch/__tests__/WatchPageClient.download.test.tsx src/lib/fragments/__tests__/watch-video.test.ts src/app/api/download/route.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Browser smoke on a Watch page confirms the download href remains
+  same-origin and the `filename` parameter uses the compatible format.
+
+---
+
+## Risks & Dependencies
+
+- Existing production data may have null `iso3` or null `height`; fallbacks must
+  be tested because those cases cannot block downloads.
+- Browser `download` hints are advisory, so the proxy `Content-Disposition`
+  filename remains the source of truth for direct proxy responses.
+- If gql.tada reports missing fields after the Web fragment changes, regenerate
+  Admin GraphQL client artifacts instead of hand-editing generated outputs.
+
+---
+
+## Sources / Research
+
+- `docs/brainstorms/2026-06-17-watch-compatible-download-filenames-requirements.md`
+  defines the accepted filename convention and compatibility constraints.
+- `docs/roadmap/topic-experiences/feat-196-watch-compatible-download-filenames.md`
+  tracks this feature and its verification surface.
+- `apps/web/src/components/watch/download-link.ts` owns the current
+  `buildDownloadFilename` helper and proxy URL builder.
+- `apps/web/src/components/watch/DownloadModal.tsx` creates the browser anchor
+  used for downloads.
+- `apps/web/src/components/watch/WatchPageClient.tsx` maps selected Dub
+  downloads into modal props and fallback links.
+- `apps/web/src/lib/fragments/watch-video.ts` defines the selected Dub detail
+  data fetched from Admin GraphQL.
+- `apps/admin/schema.graphql` exposes `Language.iso3` and
+  `VideoDubDownload.height`.
+- `apps/web/src/app/api/download/route.ts` sanitizes the response filename and
+  sets `Content-Disposition`.

--- a/docs/roadmap/topic-experiences/feat-196-watch-compatible-download-filenames.md
+++ b/docs/roadmap/topic-experiences/feat-196-watch-compatible-download-filenames.md
@@ -1,0 +1,97 @@
+---
+id: "feat-196"
+title: "Watch compatible download filenames"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-17"
+duration: 2
+depends_on: []
+blocks: []
+tags:
+  - "web"
+  - "watch"
+  - "download"
+  - "ux"
+---
+
+## Problem
+
+Watch downloads currently save with filenames that identify the film title and
+quality tier too weakly for field teams preparing microSD cards and devices.
+Teams download hundreds of films, often across many languages for one region,
+then manually rename files to include language, language code, and resolution so
+helpers do not load the wrong media.
+
+Same-name languages and regional versions make title-only or tier-only naming
+unsafe. The filename should be portable across common filesystems and older
+media-player browsers while carrying enough identity to avoid manual renaming in
+the common case.
+
+## Entry Points - Read These First
+
+1. `docs/brainstorms/2026-06-17-watch-compatible-download-filenames-requirements.md` -
+   product requirements, accepted filename convention, and scope boundaries.
+2. `apps/web/src/components/watch/download-link.ts` - current
+   `buildDownloadFilename` helper and proxy URL builder.
+3. `apps/web/src/components/watch/DownloadModal.tsx` - modal download click
+   path and programmatic anchor creation.
+4. `apps/web/src/components/watch/WatchPageClient.tsx` - selected Dub and
+   download metadata mapped into the modal.
+5. `apps/web/src/lib/fragments/watch-video.ts` - selected Dub detail fragment.
+6. `apps/admin/schema.graphql` - `Language.iso3` and
+   `VideoDubDownload.height`/`width` availability.
+7. `apps/web/src/app/api/download/route.ts` - filename sanitization and
+   `Content-Disposition` behavior.
+
+## Grep These
+
+- `buildDownloadFilename`
+- `DownloadProxyParams`
+- `watchVideoDubDetailFragment`
+- `downloadsForModal`
+- `languageName`
+- `iso3`
+- `height`
+- `Content-Disposition`
+
+## What To Build
+
+1. Generate default Watch download filenames in the compatible format
+   `Title-Like-This_Language_iso3_360p.mp4`.
+2. Use the selected audio language, not the UI locale, as the language segment.
+3. Prefer ISO 639-3 for the language code, with a safe fallback when missing.
+4. Prefer actual rendition height such as `360p`; fall back to the existing
+   tier label when height is unavailable.
+5. Keep the filename character set limited to ASCII letters, ASCII digits,
+   hyphen, underscore, and period.
+6. Keep raw CDN URLs server-only and preserve the existing same-origin proxy,
+   account gate, Terms of Use flow, range behavior, and SSRF defenses.
+7. Do not include subtitle language text unless the downloaded media file truly
+   contains subtitle tracks.
+
+## Constraints
+
+- Do not expose `VideoDubDownload.url` to client-rendered markup.
+- Do not weaken filename sanitization in `/watch/api/download`.
+- Do not change Watch public route shapes.
+- Do not change the Download modal's core flow unless a filename preview is
+  explicitly needed.
+- Do not hand-edit generated GraphQL env/type outputs without the matching
+  generation command.
+- If Admin GraphQL selection changes require generated artifacts, include those
+  generated outputs in the same implementation PR.
+
+## Verification
+
+- Focused tests for `buildDownloadFilename`, including exact examples:
+  `Jesus-Film_English_eng_360p.mp4`, missing ISO fallback, missing height
+  fallback, same-name language disambiguation, and unsafe character stripping.
+- Update Watch download modal tests to assert the proxy URL `filename` parameter
+  and anchor `download` attribute use the compatible filename.
+- Update fragment/normalization tests for any added language or rendition fields.
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/DownloadModal.test.tsx src/components/watch/__tests__/WatchPageClient.download.test.tsx src/lib/fragments/__tests__/watch-video.test.ts`
+- `pnpm --filter @forge/web typecheck`
+- `pnpm --filter @forge/web lint`
+- Browser smoke on a Watch page confirms the saved/proxy filename is compatible
+  and the rendered href remains same-origin.


### PR DESCRIPTION
## Summary

Watch downloads now save as operator-readable, device-compatible filenames such as `Jesus-Film_English_eng_360p.mp4`, instead of generic names like `JESUS` or tier-only fallbacks. The filename is generated from the video title, selected audio language, preferred ISO 639-3 code, and actual rendition height while restricting characters to ASCII letters, digits, hyphen, underscore, and the `.mp4` extension.

The download proxy now preserves safe extensions when it sanitizes long filenames, so generated names stay media-shaped even after clamping. The GraphQL/content path now carries language `iso3` and download `height` through to the Watch client and modal without exposing raw CDN URLs.

## Validation

- `pnpm --filter @forge/web test -- src/components/watch/__tests__/download-link.test.ts src/components/watch/__tests__/DownloadModal.test.tsx src/components/watch/__tests__/WatchPageClient.download.test.tsx src/lib/fragments/__tests__/watch-video.test.ts src/lib/content.test.ts src/app/api/download/route.test.ts` (6 files, 98 tests)
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- Browser smoke, local Watch page with fake Admin GraphQL: `GET /watch/jesus.html/english.html?smoke=filename` returned `200 OK`, rendered `data-testid="watch-page-client"`, and the download button used `/watch/api/download?...&filename=Jesus-Film_English_eng_360p.mp4`.

## Post-Deploy Monitoring & Validation

- Open a production Watch page with downloads and confirm the first download href stays same-origin at `/watch/api/download`.
- Download one low-resolution rendition and confirm the saved filename includes title, language name, ISO code, and actual `p` height.
- Spot-check duplicate display names or regional variants by verifying the ISO code segment differs.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
