### PR TITLE
feat(smart-crop): surface QA markers on shot timeline

### DIFF
--- a/apps/manager/src/app/globals.css
+++ b/apps/manager/src/app/globals.css
@@ -13829,7 +13829,7 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
 .smart-crop-shot-timeline {
   position: relative;
   height: 34px;
-  overflow: hidden;
+  overflow: visible;
   background: var(--ds-panel-muted);
   border: 1px solid var(--ds-line);
   border-radius: calc(var(--ds-radius) - 4px);
@@ -13883,6 +13883,71 @@ body.studio-modal-open .studio-dashboard-shell > .design-system-shell {
 
 .smart-crop-shot-segment--center_fallback {
   color: var(--ds-soft);
+}
+
+.smart-crop-shot-qa-marker {
+  position: absolute;
+  top: 50%;
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--accent);
+  background: var(--ds-bg);
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--ds-black) 18%, transparent);
+  transform: translate(-50%, -50%);
+}
+
+.smart-crop-shot-qa-marker:hover,
+.smart-crop-shot-qa-marker:focus-visible {
+  z-index: 6;
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--ds-bg),
+    0 0 0 4px currentColor;
+}
+
+.smart-crop-shot-qa-marker--warning {
+  color: var(--warn);
+}
+
+.smart-crop-shot-qa-marker--critical {
+  color: var(--ds-brand-red);
+}
+
+.smart-crop-shot-qa-marker-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  z-index: 7;
+  width: max-content;
+  max-width: min(320px, calc(100vw - 48px));
+  padding: 7px 9px;
+  color: var(--ds-bg);
+  font-size: 0.76rem;
+  font-weight: 650;
+  line-height: 1.35;
+  text-align: left;
+  white-space: normal;
+  background: var(--ds-black);
+  border-radius: calc(var(--ds-radius) - 6px);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--ds-black) 22%, transparent);
+  opacity: 0;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  pointer-events: none;
+}
+
+.smart-crop-shot-qa-marker:hover .smart-crop-shot-qa-marker-tooltip,
+.smart-crop-shot-qa-marker:focus-visible .smart-crop-shot-qa-marker-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .smart-crop-shot-playhead {

--- a/apps/manager/src/cms/mock-seed.ts
+++ b/apps/manager/src/cms/mock-seed.ts
@@ -226,6 +226,8 @@ const DEFAULT_MOCK_JOBS: JobRecord[] = [
       "smart-crop-attempts": { kind: "downloadable" },
       "smart-crop-plan-attempt-000": { kind: "downloadable" },
       "smart-crop-plan-attempt-001": { kind: "downloadable" },
+      "smart-crop-qa-attempt-000": { kind: "downloadable" },
+      "smart-crop-qa-attempt-001": { kind: "downloadable" },
     },
     steps: [
       {
@@ -995,6 +997,56 @@ export const DEFAULT_MOCK_ARTIFACT_FILES: MockArtifactFile[] = [
         ],
         updatedAt: "2026-04-22T16:11:30.000Z",
         manifestDigest: "fnv1a:13015fa1",
+      },
+      null,
+      2,
+    ),
+  },
+  {
+    assetId: "mock_smart_crop_asset",
+    artifactType: "smart-crop-qa-9x16-attempt-000-v1",
+    ext: "json",
+    body: JSON.stringify(
+      {
+        version: 1,
+        kind: "smart-crop-qa-report",
+        assetId: "mock_smart_crop_asset",
+        renderMode: "preview",
+        verdict: "needs_repair",
+        issues: [
+          {
+            severity: "warning",
+            description:
+              "Subject drifts near the right edge during the group shot.",
+            atSeconds: 30,
+            shotId: "shot_00002",
+          },
+        ],
+        frameCount: 2,
+        model: "mock-model",
+        usage: { inputTokens: 90, outputTokens: 24 },
+        generatedAt: "2026-04-22T16:10:00.000Z",
+      },
+      null,
+      2,
+    ),
+  },
+  {
+    assetId: "mock_smart_crop_asset",
+    artifactType: "smart-crop-qa-9x16-attempt-001-v1",
+    ext: "json",
+    body: JSON.stringify(
+      {
+        version: 1,
+        kind: "smart-crop-qa-report",
+        assetId: "mock_smart_crop_asset",
+        renderMode: "preview",
+        verdict: "pass",
+        issues: [],
+        frameCount: 2,
+        model: "mock-model",
+        usage: { inputTokens: 76, outputTokens: 14 },
+        generatedAt: "2026-04-22T16:11:30.000Z",
       },
       null,
       2,

--- a/apps/manager/src/features/smart-crop/smart-crop-plan-player.test.ts
+++ b/apps/manager/src/features/smart-crop/smart-crop-plan-player.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  buildSmartCropQaMarkers,
   buildSmartCropBoxPercent,
   clampSmartCropBoxPercent,
   findActiveSmartCropSegment,
   formatSmartCropTime,
   interpolateSmartCropKeyframe,
   isSmartCropAttemptSelectableForReview,
+  parseSmartCropQaIssuesForPlayer,
   parseSmartCropPlanForPlayer,
   type SmartCropPlanForPlayer,
 } from "./smart-crop-plan-player"
@@ -171,5 +173,70 @@ describe("smart crop plan player helpers", () => {
     expect(isSmartCropAttemptSelectableForReview("planned")).toBe(false)
     expect(isSmartCropAttemptSelectableForReview("previewed")).toBe(false)
     expect(isSmartCropAttemptSelectableForReview("failed")).toBe(false)
+  })
+
+  it("parses QA report issues for the player overlay", () => {
+    expect(
+      parseSmartCropQaIssuesForPlayer({
+        kind: "smart-crop-qa-report",
+        issues: [
+          {
+            severity: "info",
+            description: "Crop is acceptable but a little tight.",
+            atSeconds: 4.5,
+            shotId: "shot_00001",
+          },
+          { severity: "debug", description: "ignored" },
+          { severity: "critical" },
+        ],
+      }),
+    ).toEqual([
+      {
+        severity: "info",
+        description: "Crop is acceptable but a little tight.",
+        atSeconds: 4.5,
+        shotId: "shot_00001",
+      },
+    ])
+  })
+
+  it("places QA markers by timestamp or shot midpoint", () => {
+    const markers = buildSmartCropQaMarkers(
+      plan.segments,
+      [
+        {
+          severity: "info",
+          description: "Shot note",
+          shotId: "shot_00001",
+        },
+        {
+          severity: "warning",
+          description: "Frame warning",
+          atSeconds: 12,
+          shotId: "shot_00002",
+        },
+        {
+          severity: "critical",
+          description: "Global issue without placement",
+        },
+      ],
+      plan.source.durationSeconds,
+    )
+
+    expect(markers).toHaveLength(2)
+    expect(markers[0]).toMatchObject({
+      severity: "info",
+      seconds: 5,
+      percent: 25,
+      shotId: "shot_00001",
+      segment: { shotId: "shot_00001" },
+    })
+    expect(markers[1]).toMatchObject({
+      severity: "warning",
+      seconds: 12,
+      percent: 60,
+      shotId: "shot_00002",
+      segment: { shotId: "shot_00002" },
+    })
   })
 })

--- a/apps/manager/src/features/smart-crop/smart-crop-plan-player.ts
+++ b/apps/manager/src/features/smart-crop/smart-crop-plan-player.ts
@@ -26,6 +26,20 @@ export type SmartCropPlanForPlayer = {
   segments: SmartCropPlanSegment[]
 }
 
+export type SmartCropQaIssueForPlayer = {
+  severity: "info" | "warning" | "critical"
+  description: string
+  atSeconds?: number
+  shotId?: string
+}
+
+export type SmartCropQaMarkerForPlayer = SmartCropQaIssueForPlayer & {
+  markerId: string
+  seconds: number
+  percent: number
+  segment?: SmartCropPlanSegment
+}
+
 export type CropBoxPercent = {
   left: number
   top: number
@@ -47,6 +61,33 @@ function asFiniteNumber(value: unknown): number | null {
 
 function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null
+}
+
+function parseQaIssue(value: unknown): SmartCropQaIssueForPlayer | null {
+  if (!isRecord(value)) return null
+  if (
+    value.severity !== "info" &&
+    value.severity !== "warning" &&
+    value.severity !== "critical"
+  ) {
+    return null
+  }
+  if (typeof value.description !== "string") return null
+
+  return {
+    severity: value.severity,
+    description: value.description,
+    atSeconds: asFiniteNumber(value.atSeconds) ?? undefined,
+    shotId: asString(value.shotId) ?? undefined,
+  }
+}
+
+export function parseSmartCropQaIssuesForPlayer(
+  value: unknown,
+): SmartCropQaIssueForPlayer[] {
+  if (!isRecord(value) || !Array.isArray(value.issues)) return []
+
+  return value.issues.map(parseQaIssue).filter((issue) => issue != null)
 }
 
 function parseKeyframe(value: unknown): SmartCropPlanKeyframe | null {
@@ -162,6 +203,43 @@ export function findActiveSmartCropSegment(
   }
 
   return segments[segments.length - 1]!
+}
+
+export function buildSmartCropQaMarkers(
+  segments: readonly SmartCropPlanSegment[],
+  issues: readonly SmartCropQaIssueForPlayer[],
+  durationSeconds: number,
+): SmartCropQaMarkerForPlayer[] {
+  if (segments.length === 0 || durationSeconds <= 0) return []
+
+  return issues
+    .map((issue, index): SmartCropQaMarkerForPlayer | null => {
+      const explicitSeconds = asFiniteNumber(issue.atSeconds)
+      const shotSegment = issue.shotId
+        ? segments.find((segment) => segment.shotId === issue.shotId)
+        : undefined
+      const seconds =
+        explicitSeconds ??
+        (shotSegment
+          ? (shotSegment.canonicalStart + shotSegment.canonicalEnd) / 2
+          : null)
+
+      if (seconds == null) return null
+
+      const clampedSeconds = Math.min(durationSeconds, Math.max(0, seconds))
+      const activeSegment =
+        shotSegment ?? findActiveSmartCropSegment(segments, clampedSeconds)
+
+      return {
+        ...issue,
+        markerId: `${issue.shotId ?? "time"}-${index}-${issue.severity}`,
+        seconds: clampedSeconds,
+        percent: (clampedSeconds / durationSeconds) * 100,
+        ...(activeSegment ? { segment: activeSegment } : {}),
+      }
+    })
+    .filter((marker) => marker != null)
+    .sort((left, right) => left.seconds - right.seconds)
 }
 
 function interpolate(start: number, end: number, progress: number): number {

--- a/apps/manager/src/features/smart-crop/smart-crop-plan-review-player.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-plan-review-player.tsx
@@ -9,18 +9,23 @@ import React, {
   type CSSProperties,
 } from "react"
 import { useVideoPlayerCore } from "@forge/video-player"
+import { CircleAlert, Info, TriangleAlert, type LucideIcon } from "lucide-react"
 import type Player from "video.js/dist/types/player"
 import { apiFetch } from "@/lib/api-fetch"
 import { buildJobArtifactHref } from "@/lib/job-artifacts"
 import type { JobRecord } from "@/types/job"
 import {
+  buildSmartCropQaMarkers,
   buildSmartCropBoxPercent,
   clampSmartCropBoxPercent,
   findActiveSmartCropSegment,
   formatSmartCropTime,
   interpolateSmartCropKeyframe,
   isSmartCropAttemptSelectableForReview,
+  parseSmartCropQaIssuesForPlayer,
   parseSmartCropPlanForPlayer,
+  type SmartCropQaIssueForPlayer,
+  type SmartCropQaMarkerForPlayer,
   type SmartCropPlanForPlayer,
   type SmartCropPlanSegment,
 } from "./smart-crop-plan-player"
@@ -36,12 +41,7 @@ export type SmartCropAttemptSelection = {
   manifestDigest: string
 }
 
-type SmartCropAttemptIssue = {
-  severity: "info" | "warning" | "critical"
-  description: string
-  atSeconds?: number
-  shotId?: string
-}
+type SmartCropAttemptIssue = SmartCropQaIssueForPlayer
 
 type SmartCropAttemptForReview = {
   attemptIndex: number
@@ -70,12 +70,20 @@ type AttemptsLoadState =
     }
   | { status: "failed"; message: string }
 
+type QaIssuesLoadState = {
+  status: "ready" | "loading" | "failed"
+  logicalKey: string
+  issues: readonly SmartCropAttemptIssue[]
+}
+
 type SmartCropPlanReviewPlayerProps = {
   job: JobRecord
   onSelectedAttemptChange?: (
     selection: SmartCropAttemptSelection | null,
   ) => void
 }
+
+const EMPTY_QA_ISSUES: readonly SmartCropAttemptIssue[] = []
 
 function buildMuxPlaybackUrl(playbackId: string): string {
   return `https://stream.mux.com/${playbackId}.m3u8`
@@ -225,7 +233,58 @@ function formatAttemptTitle(attempt: SmartCropAttemptForReview): string {
   return `${label} · ${attempt.status.replace(/_/g, " ")}`
 }
 
-function SmartCropPlanVideo({ plan }: { plan: SmartCropPlanForPlayer }) {
+function formatQaSeverityLabel(
+  severity: SmartCropAttemptIssue["severity"],
+): string {
+  switch (severity) {
+    case "critical":
+      return "Fail"
+    case "warning":
+      return "Warning"
+    case "info":
+      return "Message"
+  }
+}
+
+function getQaSeverityIcon(
+  severity: SmartCropAttemptIssue["severity"],
+): LucideIcon {
+  switch (severity) {
+    case "critical":
+      return CircleAlert
+    case "warning":
+      return TriangleAlert
+    case "info":
+      return Info
+  }
+}
+
+function formatQaIssueMeta(issue: SmartCropAttemptIssue): string {
+  return [
+    issue.shotId,
+    issue.atSeconds != null ? formatSmartCropTime(issue.atSeconds) : null,
+  ]
+    .filter(Boolean)
+    .join(" · ")
+}
+
+function formatQaMarkerLabel(marker: SmartCropQaMarkerForPlayer): string {
+  return [
+    `${formatQaSeverityLabel(marker.severity)}: ${marker.description}`,
+    marker.shotId ?? marker.segment?.shotId,
+    formatSmartCropTime(marker.seconds),
+  ]
+    .filter(Boolean)
+    .join(" · ")
+}
+
+function SmartCropPlanVideo({
+  plan,
+  qaIssues = EMPTY_QA_ISSUES,
+}: {
+  plan: SmartCropPlanForPlayer
+  qaIssues?: readonly SmartCropAttemptIssue[]
+}) {
   const playerRef = useRef<Player | null>(null)
   const [player, setPlayer] = useState<Player | null>(null)
   const [currentTime, setCurrentTime] = useState(0)
@@ -288,6 +347,10 @@ function SmartCropPlanVideo({ plan }: { plan: SmartCropPlanForPlayer }) {
     : undefined
   const timelineDuration = plan.source.durationSeconds
   const playheadPercent = clampPercent((currentTime / timelineDuration) * 100)
+  const qaMarkers = useMemo(
+    () => buildSmartCropQaMarkers(plan.segments, qaIssues, timelineDuration),
+    [plan.segments, qaIssues, timelineDuration],
+  )
 
   const seekTo = useCallback((seconds: number) => {
     const currentPlayer = playerRef.current
@@ -377,6 +440,30 @@ function SmartCropPlanVideo({ plan }: { plan: SmartCropPlanForPlayer }) {
                 />
               )
             })}
+            {qaMarkers.map((marker) => {
+              const Icon = getQaSeverityIcon(marker.severity)
+              const label = formatQaMarkerLabel(marker)
+
+              return (
+                <button
+                  key={marker.markerId}
+                  type="button"
+                  className={`smart-crop-shot-qa-marker smart-crop-shot-qa-marker--${marker.severity}`}
+                  style={{ left: `${clampPercent(marker.percent)}%` }}
+                  title={label}
+                  aria-label={label}
+                  onClick={() => seekTo(marker.seconds)}
+                >
+                  <Icon size={13} aria-hidden="true" />
+                  <span
+                    className="smart-crop-shot-qa-marker-tooltip"
+                    role="tooltip"
+                  >
+                    {label}
+                  </span>
+                </button>
+              )
+            })}
             <span
               className="smart-crop-shot-playhead"
               style={{ left: `${playheadPercent}%` }}
@@ -413,6 +500,11 @@ export function SmartCropPlanReviewPlayer({
           message: "Crop plan artifact unavailable.",
         },
   )
+  const [qaIssuesState, setQaIssuesState] = useState<QaIssuesLoadState>({
+    status: "ready",
+    logicalKey: "smart-crop-qa",
+    issues: EMPTY_QA_ISSUES,
+  })
 
   useEffect(() => {
     let cancelled = false
@@ -479,10 +571,18 @@ export function SmartCropPlanReviewPlayer({
   const selectedPlanKey = selectedAttempt?.planLogicalKey ?? "smart-crop-plan"
   const selectedPreviewKey =
     selectedAttempt?.previewLogicalKey ?? "smart-crop-preview"
+  const selectedQaKey = selectedAttempt?.qaLogicalKey ?? "smart-crop-qa"
+  const fallbackQaIssues = selectedAttempt?.triggerIssues ?? EMPTY_QA_ISSUES
   const hasSelectedPlanArtifact =
     job.artifacts[selectedPlanKey]?.kind === "downloadable"
   const hasSelectedPreviewArtifact =
     job.artifacts[selectedPreviewKey]?.kind === "downloadable"
+  const hasSelectedQaArtifact =
+    job.artifacts[selectedQaKey]?.kind === "downloadable"
+  const qaIssuesForReview =
+    qaIssuesState.logicalKey === selectedQaKey
+      ? qaIssuesState.issues
+      : fallbackQaIssues
 
   useEffect(() => {
     if (
@@ -498,6 +598,78 @@ export function SmartCropPlanReviewPlayer({
     }
     onSelectedAttemptChange?.(null)
   }, [attemptsState, onSelectedAttemptChange, selectedAttempt])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadQaIssues() {
+      if (hasAttemptManifest && attemptsState.status === "loading") {
+        return
+      }
+
+      if (!hasSelectedQaArtifact) {
+        setQaIssuesState({
+          status: "ready",
+          logicalKey: selectedQaKey,
+          issues: fallbackQaIssues,
+        })
+        return
+      }
+
+      setQaIssuesState({
+        status: "loading",
+        logicalKey: selectedQaKey,
+        issues: fallbackQaIssues,
+      })
+
+      try {
+        const response = await apiFetch(
+          buildJobArtifactHref(job.id, selectedQaKey),
+          { cache: "no-store" },
+        )
+        if (!response.ok) {
+          if (!cancelled) {
+            setQaIssuesState({
+              status: "failed",
+              logicalKey: selectedQaKey,
+              issues: fallbackQaIssues,
+            })
+          }
+          return
+        }
+
+        const issues = parseSmartCropQaIssuesForPlayer(await response.json())
+        if (!cancelled) {
+          setQaIssuesState({
+            status: "ready",
+            logicalKey: selectedQaKey,
+            issues,
+          })
+        }
+      } catch {
+        if (!cancelled) {
+          setQaIssuesState({
+            status: "failed",
+            logicalKey: selectedQaKey,
+            issues: fallbackQaIssues,
+          })
+        }
+      }
+    }
+
+    void loadQaIssues()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    attemptsState.status,
+    fallbackQaIssues,
+    hasAttemptManifest,
+    hasSelectedQaArtifact,
+    job.id,
+    selectedQaKey,
+  ])
 
   useEffect(() => {
     let cancelled = false
@@ -607,7 +779,10 @@ export function SmartCropPlanReviewPlayer({
 
       {planState.status === "ready" ? (
         <>
-          <SmartCropPlanVideo plan={planState.plan} />
+          <SmartCropPlanVideo
+            plan={planState.plan}
+            qaIssues={qaIssuesForReview}
+          />
           <div className="smart-crop-attempt-review-grid">
             {hasSelectedPreviewArtifact ? (
               <div className="smart-crop-attempt-preview">
@@ -636,27 +811,18 @@ export function SmartCropPlanReviewPlayer({
                     <dd>{selectedAttempt.qa?.repairTriggerCount ?? 0}</dd>
                   </div>
                 </dl>
-                {selectedAttempt.triggerIssues.length > 0 ? (
+                {qaIssuesForReview.length > 0 ? (
                   <ul>
-                    {selectedAttempt.triggerIssues.map((issue, index) => (
+                    {qaIssuesForReview.map((issue, index) => (
                       <li key={`${issue.description}-${index}`}>
-                        <strong>{issue.severity}</strong>
+                        <strong>{formatQaSeverityLabel(issue.severity)}</strong>
                         <span>{issue.description}</span>
-                        <small>
-                          {[
-                            issue.shotId,
-                            issue.atSeconds != null
-                              ? formatSmartCropTime(issue.atSeconds)
-                              : null,
-                          ]
-                            .filter(Boolean)
-                            .join(" · ")}
-                        </small>
+                        <small>{formatQaIssueMeta(issue)}</small>
                       </li>
                     ))}
                   </ul>
                 ) : (
-                  <p>No repair-triggering QA issues for this attempt.</p>
+                  <p>No QA issues for this attempt.</p>
                 )}
               </div>
             ) : null}


### PR DESCRIPTION
## Summary

Smart Crop reviewers can now see QA findings directly on the shot timeline they use to inspect crop paths. Selecting an attempt loads its QA report, maps issue severities into message, warning, or fail marker buttons by issue timestamp or shot midpoint, and shows the QA message on hover or keyboard focus while clicking the marker seeks to that moment.

The review panel prefers the full attempt QA artifact when available and falls back to the attempt manifest's trigger issues when it is not, so existing repair attempts still surface the issues that drove the crop change. Mock mode now includes attempt QA artifacts so the demo job exercises the same artifact path as real jobs.

## Validation

- `pnpm --filter @forge/manager test -- smart-crop-plan-player.test.ts`
- `pnpm --filter @forge/manager lint`
- `pnpm --filter @forge/manager exec tsc --noEmit --pretty false`
- `git diff --check`
- Browser smoke on `http://localhost:3002/dashboard/smart-crop/mock-smart-crop-1`: selected the initial attempt and confirmed the warning marker label `Warning: Subject drifts near the right edge during the group shot. · shot_00002 · 0:30`.

## Demo

Local browser proof was captured but is not embedded in the PR: `output/playwright/smart-crop-qa-marker-tooltip-timeline.png`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
