### PR TITLE
fix(watch): use slug fallback for non-ascii download titles

### DIFF
--- a/apps/web/src/components/watch/DownloadModal.tsx
+++ b/apps/web/src/components/watch/DownloadModal.tsx
@@ -317,6 +317,7 @@ export function DownloadModal({
       languageSlug,
       renditionHeight: selected.download.height,
       tier: selected.tier,
+      videoSlug,
       videoTitle,
     })
 

--- a/apps/web/src/components/watch/WatchPageClient.tsx
+++ b/apps/web/src/components/watch/WatchPageClient.tsx
@@ -475,6 +475,7 @@ export function WatchPageClient({
         languageSlug: variant.language?.slug ?? null,
         renditionHeight: fallbackTier.download.height,
         tier: fallbackTier.tier,
+        videoSlug,
         videoTitle: video.title,
       }),
       variantId: variant.documentId,

--- a/apps/web/src/components/watch/__tests__/download-link.test.ts
+++ b/apps/web/src/components/watch/__tests__/download-link.test.ts
@@ -39,6 +39,19 @@ describe("buildDownloadFilename", () => {
     ).toBe("Jesus-Film_English_eng_low.mp4")
   })
 
+  it("uses the video slug when the localized title has no ASCII-safe words", () => {
+    expect(
+      buildDownloadFilename({
+        videoTitle: "প্লট (পর্ব ৫)",
+        videoSlug: "bp-plot-episode-5",
+        languageName: "Bangla",
+        languageCode: "ben",
+        renditionHeight: 270,
+        tier: "low",
+      }),
+    ).toBe("bp-plot-episode-5_Bangla_ben_270p.mp4")
+  })
+
   it("distinguishes same-name languages by code", () => {
     const common = {
       videoTitle: "Jesus Film",

--- a/apps/web/src/components/watch/download-link.ts
+++ b/apps/web/src/components/watch/download-link.ts
@@ -33,6 +33,7 @@ export type BuildDownloadFilenameParams = {
   languageSlug?: string | null
   renditionHeight?: number | null
   tier?: DownloadTier | null
+  videoSlug?: string | null
   videoTitle?: string | null
 }
 
@@ -54,6 +55,17 @@ function textSegment(
 ): string {
   const words = asciiWords(value)
   if (words.length > 0) return words.join("-")
+  return asciiWords(fallback).join("-") || "Unknown"
+}
+
+function textSegmentFrom(
+  candidates: (string | null | undefined)[],
+  fallback: string,
+): string {
+  for (const candidate of candidates) {
+    const words = asciiWords(candidate)
+    if (words.length > 0) return words.join("-")
+  }
   return asciiWords(fallback).join("-") || "Unknown"
 }
 
@@ -81,10 +93,11 @@ export function buildDownloadFilename({
   languageSlug,
   renditionHeight,
   tier,
+  videoSlug,
   videoTitle,
 }: BuildDownloadFilenameParams): string {
   const segments = [
-    textSegment(videoTitle, "Video"),
+    textSegmentFrom([videoTitle, videoSlug], "Video"),
     textSegment(languageName, "Language"),
     codeSegment(languageCode, languageSlug, languageName),
     renditionSegment(renditionHeight, tier),


### PR DESCRIPTION
## Summary

Follow-up to #1297: non-ASCII Watch titles now fall back to the route slug before using the generic `Video` label. A Bangla page like `/watch/bp-plot-episode-5.html/bangla-2.html` should now download as `bp-plot-episode-5_Bangla_ben_270p.mp4` while keeping the filename limited to broadly compatible ASCII-safe characters.

## Validation

- `pnpm --filter @forge/web test -- src/components/watch/__tests__/download-link.test.ts src/components/watch/__tests__/DownloadModal.test.tsx src/components/watch/__tests__/WatchPageClient.download.test.tsx` (3 files, 45 tests)
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
