### PR TITLE
fix(manager): clean audio before transcription

### DIFF
--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.test.ts
@@ -6,6 +6,7 @@ const {
   getJobMock,
   getMuxAssetMock,
   getMuxStaticRenditionSourceUrlMock,
+  isAudioCleanupConfiguredMock,
   runVideoEnrichmentMock,
   startMock,
   updateJobMock,
@@ -15,6 +16,7 @@ const {
   getJobMock: vi.fn(),
   getMuxAssetMock: vi.fn(),
   getMuxStaticRenditionSourceUrlMock: vi.fn(),
+  isAudioCleanupConfiguredMock: vi.fn(),
   runVideoEnrichmentMock: vi.fn(),
   startMock: vi.fn(),
   updateJobMock: vi.fn(),
@@ -48,6 +50,10 @@ vi.mock("@/services/mux", () => ({
   getMuxStaticRenditionSourceUrl: getMuxStaticRenditionSourceUrlMock,
 }))
 
+vi.mock("@/services/audioCleanup", () => ({
+  isAudioCleanupConfigured: isAudioCleanupConfiguredMock,
+}))
+
 vi.mock("@/workflows/videoEnrichment", () => ({
   runVideoEnrichment: runVideoEnrichmentMock,
 }))
@@ -67,6 +73,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
       await callback()
     })
     runVideoEnrichmentMock.mockResolvedValue(undefined)
+    isAudioCleanupConfiguredMock.mockReturnValue(true)
     getMuxAssetMock.mockResolvedValue({
       assetId: "mux-source-1",
       playbackId: "play-source-1",
@@ -197,6 +204,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
           },
         }),
         steps: [
+          expect.objectContaining({ name: "audio_cleanup", status: "pending" }),
           expect.objectContaining({ name: "transcription", status: "pending" }),
           expect.objectContaining({
             name: "structured_transcript",
@@ -207,7 +215,6 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
           expect.objectContaining({ name: "metadata", status: "pending" }),
           expect.objectContaining({ name: "embeddings", status: "pending" }),
           expect.objectContaining({ name: "mux_upload", status: "pending" }),
-          expect.objectContaining({ name: "audio_cleanup", status: "pending" }),
           expect.objectContaining({
             name: "theology_validation_bible_quotes",
             status: "skipped",
@@ -258,6 +265,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
           transcriptionRouting: expect.any(Object),
         }),
         requestedTranscriptionProvider: "elevenlabs",
+        runAudioCleanup: true,
       }),
     ])
     expect(dispatch.spy).toHaveBeenCalledTimes(1)
@@ -465,6 +473,7 @@ describe("POST /api/jobs/[id]/transcription/rerun", () => {
     dispatch.expectDispatched(runVideoEnrichment, [
       expect.objectContaining({
         requestedTranscriptionProvider: "elevenlabs",
+        runAudioCleanup: true,
         initialArtifacts: expect.objectContaining({
           transcriptionRouting: expect.objectContaining({
             data: expect.objectContaining({

--- a/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
+++ b/apps/manager/src/app/api/jobs/[id]/transcription/rerun/route.ts
@@ -16,6 +16,7 @@ import type {
   TranscriptionRoutingReport,
 } from "@/types/job"
 import { isSupportedElevenLabsLanguage } from "@/services/elevenlabs-transcription"
+import { isAudioCleanupConfigured } from "@/services/audioCleanup"
 import { getMuxAsset, getMuxStaticRenditionSourceUrl } from "@/services/mux"
 import { normalizeSourceLanguageCode } from "@/services/transcription"
 import { launchVideoEnrichment } from "@/workflows/launchVideoEnrichment"
@@ -282,6 +283,8 @@ export async function POST(
       translateTo: job.languages,
       initialArtifacts: updatedJob.artifacts,
       requestedTranscriptionProvider: provider,
+      runAudioCleanup:
+        provider === "elevenlabs" ? isAudioCleanupConfigured() : false,
     })
   } catch (error) {
     console.error(`Transcription rerun failed for job ${updatedJob.id}:`, error)

--- a/apps/manager/src/features/jobs/live-job-steps-table.tsx
+++ b/apps/manager/src/features/jobs/live-job-steps-table.tsx
@@ -70,7 +70,8 @@ export const STEP_DESCRIPTION_BY_NAME: Record<WorkflowStepName, string> = {
   metadata: "Extracts summary, tags, and structured content metadata.",
   embeddings: "Creates semantic vectors for search and retrieval.",
   translation: "Translates transcript content into target languages.",
-  audio_cleanup: "Prepares original and cleaned audio for manager review.",
+  audio_cleanup:
+    "Cleans source audio before transcription and stores review artifacts.",
   voiceover: "Synthesizes voiceover audio from generated text.",
   artifact_upload: "Uploads generated artifacts and writes the manifest.",
   mux_upload: "Publishes translated subtitle tracks to Mux when needed.",

--- a/apps/manager/src/lib/workflow-steps.test.ts
+++ b/apps/manager/src/lib/workflow-steps.test.ts
@@ -12,6 +12,7 @@ import type { JobStepState } from "@/types/job"
 describe("buildInitialSteps", () => {
   it("uses the canonical persisted Forge workflow step inventory", () => {
     expect(FORGE_WORKFLOW_STEPS).toEqual([
+      "audio_cleanup",
       "transcription",
       "structured_transcript",
       "translation",
@@ -19,7 +20,6 @@ describe("buildInitialSteps", () => {
       "metadata",
       "embeddings",
       "mux_upload",
-      "audio_cleanup",
       "theology_validation_bible_quotes",
       "seo_improvements",
     ])

--- a/apps/manager/src/lib/workflow-steps.ts
+++ b/apps/manager/src/lib/workflow-steps.ts
@@ -3,6 +3,7 @@ import type { JobStepState, WorkflowStepName } from "@/types/job"
 // These steps are persisted at job creation and must stay aligned with the
 // Manager job read/write contracts.
 export const FORGE_WORKFLOW_STEPS: WorkflowStepName[] = [
+  "audio_cleanup",
   "transcription",
   "structured_transcript",
   "translation",
@@ -10,7 +11,6 @@ export const FORGE_WORKFLOW_STEPS: WorkflowStepName[] = [
   "metadata",
   "embeddings",
   "mux_upload",
-  "audio_cleanup",
   "theology_validation_bible_quotes",
   "seo_improvements",
 ]

--- a/apps/manager/src/services/elevenlabs-transcription.test.ts
+++ b/apps/manager/src/services/elevenlabs-transcription.test.ts
@@ -136,6 +136,51 @@ describe("elevenlabs transcription", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it("sends provided isolated audio directly to Scribe", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        language_code: "en",
+        text: "Clean audio transcript.",
+        words: [
+          {
+            text: "Clean",
+            start: 0,
+            end: 0.4,
+            type: "word",
+            speaker_id: "speaker_0",
+          },
+          {
+            text: " audio transcript.",
+            start: 0.4,
+            end: 1.2,
+            type: "word",
+            speaker_id: "speaker_0",
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await transcribeViaElevenLabs({
+      isolatedAudio: new Blob(["isolated"], { type: "audio/mpeg" }),
+      languageCode: "en",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.elevenlabs.io/v1/speech-to-text",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(FormData),
+      }),
+    )
+    expect(result).toMatchObject({
+      text: "Clean audio transcript.",
+      language: "en",
+    })
+  })
+
   it("fails clearly when ElevenLabs rejects the transcription request", async () => {
     const fetchMock = vi
       .fn()

--- a/apps/manager/src/services/elevenlabs-transcription.ts
+++ b/apps/manager/src/services/elevenlabs-transcription.ts
@@ -549,13 +549,26 @@ async function createTranscript(params: {
 }
 
 export async function transcribeViaElevenLabs(input: {
-  sourceUrl: string
+  sourceUrl?: string
+  isolatedAudio?: Blob
   languageCode?: string
   keyterms?: string[]
 }): Promise<ElevenLabsTranscriptionResult> {
   const apiKey = ensureApiKey()
-  const sourceBlob = await downloadSourceMedia(input.sourceUrl)
-  const isolatedAudio = await isolateAudio(sourceBlob, input.sourceUrl, apiKey)
+  const isolatedAudio =
+    input.isolatedAudio ??
+    (input.sourceUrl
+      ? await isolateAudio(
+          await downloadSourceMedia(input.sourceUrl),
+          input.sourceUrl,
+          apiKey,
+        )
+      : undefined)
+  if (!isolatedAudio) {
+    throw new Error(
+      "ElevenLabs transcription requires a source URL or isolated audio input.",
+    )
+  }
   const response = await createTranscript({
     isolatedAudio,
     languageCode: input.languageCode,

--- a/apps/manager/src/services/transcription.test.ts
+++ b/apps/manager/src/services/transcription.test.ts
@@ -3,12 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const {
   ensureGeneratedSubtitlesForAssetMock,
   retrieveAssetMock,
+  readArtifactMock,
   signPlaybackIdMock,
   transcribeViaElevenLabsMock,
   writeArtifactMock,
 } = vi.hoisted(() => ({
   ensureGeneratedSubtitlesForAssetMock: vi.fn(),
   retrieveAssetMock: vi.fn(),
+  readArtifactMock: vi.fn(),
   signPlaybackIdMock: vi.fn(),
   transcribeViaElevenLabsMock: vi.fn(),
   writeArtifactMock: vi.fn(),
@@ -34,6 +36,7 @@ vi.mock("@/services/mux", async (importOriginal) => {
 })
 
 vi.mock("@/services/storage", () => ({
+  readArtifact: readArtifactMock,
   writeArtifact: writeArtifactMock,
 }))
 
@@ -55,10 +58,12 @@ describe("transcription", () => {
   beforeEach(() => {
     ensureGeneratedSubtitlesForAssetMock.mockReset()
     retrieveAssetMock.mockReset()
+    readArtifactMock.mockReset()
     signPlaybackIdMock.mockReset()
     transcribeViaElevenLabsMock.mockReset()
     writeArtifactMock.mockReset()
     ensureGeneratedSubtitlesForAssetMock.mockResolvedValue(undefined)
+    readArtifactMock.mockResolvedValue(new Uint8Array([1, 2, 3]))
     writeArtifactMock.mockResolvedValue("artifact-key")
   })
 
@@ -380,6 +385,52 @@ describe("transcription", () => {
     })
   })
 
+  it("uses cleaned audio artifacts as the ElevenLabs transcription input", async () => {
+    transcribeViaElevenLabsMock.mockResolvedValue({
+      text: "Clean input transcript.",
+      segments: [{ start: 0, end: 1.2, text: "Clean input transcript." }],
+      language: "en",
+    })
+
+    const result = await transcribe("asset-1", "mux-asset-1", "en", {
+      requestedProvider: "automatic",
+      cleanedAudioArtifact: {
+        assetId: "asset-1",
+        artifactType: "cleaned-audio",
+        ext: "mp3",
+      },
+    })
+
+    expect(readArtifactMock).toHaveBeenCalledWith(
+      "asset-1",
+      "cleaned-audio",
+      "mp3",
+    )
+    expect(transcribeViaElevenLabsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isolatedAudio: expect.any(Blob),
+        languageCode: "en",
+      }),
+    )
+    expect(transcribeViaElevenLabsMock.mock.calls[0]?.[0]).not.toHaveProperty(
+      "sourceUrl",
+    )
+    expect(result).toMatchObject({
+      text: "Clean input transcript.",
+      language: "en",
+      resolvedProvider: "elevenlabs",
+      routingReport: {
+        finalProvider: "elevenlabs",
+        attempts: [
+          expect.objectContaining({
+            decisionReason:
+              "Automatic routing chose ElevenLabs for the resolved source language using cleaned audio from audio_cleanup.",
+          }),
+        ],
+      },
+    })
+  })
+
   it("uses Mux when automatic routing does not have a supported source language", async () => {
     retrieveAssetMock.mockResolvedValue({
       duration: 12,
@@ -498,7 +549,7 @@ describe("transcription", () => {
 
     expect(error).toMatchObject({
       message:
-        "ElevenLabs transcription requires a persisted source input URL.",
+        "ElevenLabs transcription requires a persisted source input URL or cleaned audio artifact.",
       routingReport: {
         attempts: [
           expect.objectContaining({
@@ -506,7 +557,7 @@ describe("transcription", () => {
             resolvedProvider: "elevenlabs",
             status: "failed",
             fallbackReason:
-              "ElevenLabs transcription requires a persisted source input URL.",
+              "ElevenLabs transcription requires a persisted source input URL or cleaned audio artifact.",
           }),
         ],
       },

--- a/apps/manager/src/services/transcription.ts
+++ b/apps/manager/src/services/transcription.ts
@@ -14,7 +14,7 @@ import {
   getMux,
   type MuxPlaybackPolicy,
 } from "@/services/mux"
-import { writeArtifact } from "@/services/storage"
+import { readArtifact, writeArtifact } from "@/services/storage"
 import { parseVTT, segmentsToVTT, type TranscriptSegment } from "@/lib/vtt"
 import type {
   RequestedTranscriptionProvider,
@@ -42,6 +42,12 @@ export type TranscriptionResult = {
 }
 
 type RawTranscriptionResult = Omit<TranscriptionResult, "artifactKeys">
+
+export type CleanedAudioTranscriptionSource = {
+  assetId: string
+  artifactType: "cleaned-audio"
+  ext: "mp3"
+}
 
 export class TranscriptionExecutionError extends Error {
   routingReport: TranscriptionRoutingReport
@@ -352,6 +358,7 @@ export async function transcribe(
   options?: {
     requestedProvider?: RequestedTranscriptionProvider
     sourceInputUrl?: string
+    cleanedAudioArtifact?: CleanedAudioTranscriptionSource
     keyterms?: string[]
     priorRoutingReport?: TranscriptionRoutingReport
   },
@@ -588,6 +595,7 @@ async function resolveTranscriptionResult(
   options?: {
     requestedProvider?: RequestedTranscriptionProvider
     sourceInputUrl?: string
+    cleanedAudioArtifact?: CleanedAudioTranscriptionSource
     keyterms?: string[]
     priorRoutingReport?: TranscriptionRoutingReport
   },
@@ -596,6 +604,10 @@ async function resolveTranscriptionResult(
   const sourceLanguageCode = normalizeSourceLanguageCode(language)
   const sourceInputUrl =
     options?.sourceInputUrl ?? options?.priorRoutingReport?.sourceInputUrl
+  const cleanedAudioArtifact = options?.cleanedAudioArtifact
+  const hasElevenLabsMediaInput = Boolean(
+    sourceInputUrl || cleanedAudioArtifact,
+  )
   const baseReport: TranscriptionRoutingReport = {
     ...(options?.priorRoutingReport ??
       buildInitialTranscriptionRoutingReport(
@@ -649,7 +661,7 @@ async function resolveTranscriptionResult(
     return runMuxDirectly("Operator explicitly requested Mux transcription.")
   }
 
-  if (!sourceInputUrl) {
+  if (!hasElevenLabsMediaInput) {
     if (requestedProvider === "elevenlabs") {
       failAttemptWithRoutingReport(baseReport, {
         requestedProvider,
@@ -658,7 +670,7 @@ async function resolveTranscriptionResult(
         decisionReason:
           "Operator explicitly requested ElevenLabs transcription.",
         message:
-          "ElevenLabs transcription requires a persisted source input URL.",
+          "ElevenLabs transcription requires a persisted source input URL or cleaned audio artifact.",
       })
     }
 
@@ -705,15 +717,33 @@ async function resolveTranscriptionResult(
     requestedProvider,
     resolvedProvider: "elevenlabs",
     sourceLanguageCode,
-    decisionReason:
-      requestedProvider === "automatic"
+    decisionReason: cleanedAudioArtifact
+      ? requestedProvider === "automatic"
+        ? "Automatic routing chose ElevenLabs for the resolved source language using cleaned audio from audio_cleanup."
+        : "Operator explicitly requested ElevenLabs transcription using cleaned audio from audio_cleanup."
+      : requestedProvider === "automatic"
         ? "Automatic routing chose ElevenLabs for the resolved source language."
         : "Operator explicitly requested ElevenLabs transcription.",
   })
 
   try {
+    const isolatedAudio = cleanedAudioArtifact
+      ? new Blob(
+          [
+            Buffer.from(
+              await readArtifact(
+                cleanedAudioArtifact.assetId,
+                cleanedAudioArtifact.artifactType,
+                cleanedAudioArtifact.ext,
+              ),
+            ),
+          ],
+          { type: "audio/mpeg" },
+        )
+      : undefined
     const elevenlabsResult = await transcribeViaElevenLabs({
-      sourceUrl: sourceInputUrl,
+      ...(sourceInputUrl ? { sourceUrl: sourceInputUrl } : {}),
+      ...(isolatedAudio ? { isolatedAudio } : {}),
       languageCode: sourceLanguageCode,
       keyterms: options?.keyterms,
     })

--- a/apps/manager/src/workflows/videoEnrichment.test.ts
+++ b/apps/manager/src/workflows/videoEnrichment.test.ts
@@ -328,6 +328,21 @@ describe("runVideoEnrichment", () => {
       assetId: "asset-1",
       sourceVideoUrl: "https://stream.mux.com/play-1.m3u8",
     })
+    expect(runAudioCleanupMock.mock.invocationCallOrder[0]).toBeLessThan(
+      transcribeMock.mock.invocationCallOrder[0],
+    )
+    expect(transcribeMock).toHaveBeenCalledWith(
+      "asset-1",
+      "mux-1",
+      "en",
+      expect.objectContaining({
+        cleanedAudioArtifact: {
+          assetId: "asset-1",
+          artifactType: "cleaned-audio",
+          ext: "mp3",
+        },
+      }),
+    )
     expect(audioCleanupMock).not.toHaveBeenCalled()
     expect(mergeJobArtifactsMock.mock.calls).toContainEqual([
       "job-1",
@@ -348,7 +363,7 @@ describe("runVideoEnrichment", () => {
     ])
   })
 
-  it("records audio cleanup failure without failing the completed core enrichment job", async () => {
+  it("fails before transcription when required audio cleanup fails", async () => {
     transcribeMock.mockResolvedValue({
       text: "hello world",
       segments: [],
@@ -395,10 +410,7 @@ describe("runVideoEnrichment", () => {
         runAudioCleanup: true,
         playbackId: "play-1",
       }),
-    ).resolves.toMatchObject({
-      assetId: "asset-1",
-      language: "en",
-    })
+    ).rejects.toThrow("ElevenLabs offline")
 
     expect(updateStepStatusMock.mock.calls).toContainEqual([
       "job-1",
@@ -412,10 +424,11 @@ describe("runVideoEnrichment", () => {
         "original-audio": { kind: "downloadable" },
       },
     ])
+    expect(transcribeMock).not.toHaveBeenCalled()
     expect(updateJobMock.mock.calls).toContainEqual([
       "job-1",
       expect.objectContaining({
-        status: "completed",
+        status: "failed",
         currentStep: undefined,
       }),
     ])
@@ -484,7 +497,7 @@ describe("runVideoEnrichment", () => {
     ])
   })
 
-  it("keeps partial audio artifact persistence failure from failing the core job", async () => {
+  it("fails before transcription when partial audio artifact persistence fails", async () => {
     transcribeMock.mockResolvedValue({
       text: "hello world",
       segments: [],
@@ -538,10 +551,7 @@ describe("runVideoEnrichment", () => {
         translateTo: ["en"],
         runAudioCleanup: true,
       }),
-    ).resolves.toMatchObject({
-      assetId: "asset-1",
-      language: "en",
-    })
+    ).rejects.toThrow("ElevenLabs offline")
 
     expect(updateStepStatusMock.mock.calls).toContainEqual([
       "job-1",
@@ -549,10 +559,11 @@ describe("runVideoEnrichment", () => {
       "failed",
       "ElevenLabs offline",
     ])
+    expect(transcribeMock).not.toHaveBeenCalled()
     expect(updateJobMock.mock.calls).toContainEqual([
       "job-1",
       expect.objectContaining({
-        status: "completed",
+        status: "failed",
         currentStep: undefined,
       }),
     ])
@@ -1594,6 +1605,7 @@ describe("runVideoEnrichment", () => {
     ).rejects.toThrow("subtitle fetch failed")
 
     expect(updateStepStatusMock.mock.calls).toEqual([
+      ["job-1", "audio_cleanup", "skipped"],
       ["job-1", "transcription", "running"],
       ["job-1", "transcription", "failed", "subtitle fetch failed"],
     ])

--- a/apps/manager/src/workflows/videoEnrichment.ts
+++ b/apps/manager/src/workflows/videoEnrichment.ts
@@ -32,7 +32,10 @@ import type {
   MastraSubtitleTranslationContext,
 } from "@/services/mastra-subtitle-enrichment"
 import type { MastraTranscriptEmbeddingResult } from "@/services/mastra-transcript-embeddings"
-import type { TranscriptionResult } from "@/services/transcription"
+import type {
+  CleanedAudioTranscriptionSource,
+  TranscriptionResult,
+} from "@/services/transcription"
 import type { TranscriptScriptureCorrectionStepSummary } from "@/lib/transcript-scripture-correction"
 import {
   stepGetJob,
@@ -463,6 +466,80 @@ export async function runVideoEnrichment(
   })
 
   try {
+    async function runAudioCleanupStep(): Promise<CleanedAudioTranscriptionSource> {
+      try {
+        await markStepRunning(input.jobId, "audio_cleanup")
+        const audioCleanupResult = await stepAudioCleanup({
+          assetId: input.assetId,
+          muxAssetId: input.muxAssetId,
+          playbackId: input.playbackId,
+        })
+        await persistMergedArtifacts(
+          input.jobId,
+          buildDownloadableArtifactManifest(audioCleanupResult.artifactKeys),
+        )
+        await markStepComplete(input.jobId, "audio_cleanup")
+        return {
+          assetId: input.assetId,
+          artifactType: "cleaned-audio",
+          ext: "mp3",
+        }
+      } catch (audioError) {
+        const audioCleanupArtifactKeys =
+          getPersistedAudioCleanupArtifactKeys(audioError)
+
+        try {
+          await persistMergedArtifacts(
+            input.jobId,
+            buildDownloadableArtifactManifest(audioCleanupArtifactKeys),
+          )
+        } catch (persistError) {
+          console.error(
+            JSON.stringify({
+              event: "audio_cleanup_artifact_manifest_failed",
+              jobId: input.jobId,
+              error:
+                persistError instanceof Error
+                  ? persistError.message
+                  : "Unknown artifact persistence error",
+            }),
+          )
+        }
+
+        const msg =
+          audioError instanceof Error ? audioError.message : "Unknown error"
+        try {
+          await markStepFailed(input.jobId, "audio_cleanup", msg)
+        } catch (statusError) {
+          console.error(
+            JSON.stringify({
+              event: "audio_cleanup_status_update_failed",
+              jobId: input.jobId,
+              error:
+                statusError instanceof Error
+                  ? statusError.message
+                  : "Unknown status update error",
+            }),
+          )
+        }
+        console.error(
+          JSON.stringify({
+            event: "audio_cleanup_failed_before_transcription",
+            jobId: input.jobId,
+            error: msg,
+          }),
+        )
+        throw audioError
+      }
+    }
+
+    const cleanedAudioArtifact = input.runAudioCleanup
+      ? await runAudioCleanupStep()
+      : undefined
+    if (!input.runAudioCleanup) {
+      await markStepSkipped(input.jobId, "audio_cleanup")
+    }
+
     // Step 1: Transcription
     await markStepRunning(input.jobId, "transcription")
     let transcription: Awaited<ReturnType<typeof stepTranscribe>>
@@ -473,6 +550,7 @@ export async function runVideoEnrichment(
         language,
         input.requestedTranscriptionProvider,
         artifactManifest,
+        cleanedAudioArtifact,
       )
       const transcriptionArtifacts = transcription.routingReport
         ? mergeArtifactEntries(
@@ -577,71 +655,6 @@ export async function runVideoEnrichment(
       }
     }
 
-    async function runAudioCleanupStep(): Promise<void> {
-      try {
-        await markStepRunning(input.jobId, "audio_cleanup")
-        const audioCleanupResult = await stepAudioCleanup({
-          assetId: input.assetId,
-          muxAssetId: input.muxAssetId,
-          playbackId: input.playbackId,
-        })
-        await persistMergedArtifacts(
-          input.jobId,
-          buildDownloadableArtifactManifest(audioCleanupResult.artifactKeys),
-        )
-        await markStepComplete(input.jobId, "audio_cleanup")
-      } catch (audioError) {
-        const audioCleanupArtifactKeys =
-          getPersistedAudioCleanupArtifactKeys(audioError)
-
-        try {
-          await persistMergedArtifacts(
-            input.jobId,
-            buildDownloadableArtifactManifest(audioCleanupArtifactKeys),
-          )
-        } catch (persistError) {
-          console.error(
-            JSON.stringify({
-              event: "audio_cleanup_artifact_manifest_failed",
-              jobId: input.jobId,
-              error:
-                persistError instanceof Error
-                  ? persistError.message
-                  : "Unknown artifact persistence error",
-            }),
-          )
-        }
-
-        const msg =
-          audioError instanceof Error ? audioError.message : "Unknown error"
-        try {
-          await markStepFailed(input.jobId, "audio_cleanup", msg)
-        } catch (statusError) {
-          console.error(
-            JSON.stringify({
-              event: "audio_cleanup_status_update_failed",
-              jobId: input.jobId,
-              error:
-                statusError instanceof Error
-                  ? statusError.message
-                  : "Unknown status update error",
-            }),
-          )
-        }
-        console.error(
-          JSON.stringify({
-            event: "audio_cleanup_failed_in_enrichment",
-            jobId: input.jobId,
-            error: msg,
-          }),
-        )
-      }
-    }
-
-    const audioCleanupPromise = input.runAudioCleanup
-      ? runAudioCleanupStep()
-      : undefined
-
     const translationPromise = runParallelStep(
       "translation",
       () =>
@@ -705,19 +718,15 @@ export async function runVideoEnrichment(
     ])
 
     if (translationResult.status === "rejected") {
-      await audioCleanupPromise
       throw translationResult.reason
     }
     if (chaptersResult.status === "rejected") {
-      await audioCleanupPromise
       throw chaptersResult.reason
     }
     if (metadataResult.status === "rejected") {
-      await audioCleanupPromise
       throw metadataResult.reason
     }
     if (embeddingsResult.status === "rejected") {
-      await audioCleanupPromise
       throw embeddingsResult.reason
     }
 
@@ -760,14 +769,7 @@ export async function runVideoEnrichment(
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Unknown error"
       await markStepFailed(input.jobId, "mux_upload", msg)
-      await audioCleanupPromise
       throw err
-    }
-
-    if (audioCleanupPromise) {
-      await audioCleanupPromise
-    } else {
-      await markStepSkipped(input.jobId, "audio_cleanup")
     }
 
     // Optional: Scene analysis (chapters → scene boundaries → OpenRouter + stills)
@@ -869,6 +871,7 @@ async function stepTranscribe(
   language: string,
   requestedProvider: RequestedTranscriptionProvider | undefined,
   artifacts: JobArtifactManifest,
+  cleanedAudioArtifact?: CleanedAudioTranscriptionSource,
 ) {
   "use step"
   const { getTranscriptionRoutingReport } =
@@ -878,6 +881,7 @@ async function stepTranscribe(
   return transcribe(assetId, muxAssetId, language, {
     requestedProvider,
     sourceInputUrl: priorRoutingReport?.sourceInputUrl,
+    cleanedAudioArtifact,
     priorRoutingReport,
   })
 }


### PR DESCRIPTION
## Summary
Manager enrichment jobs now treat audio cleanup as a transcription prerequisite when cleanup is configured. Instead of generating a transcript from raw media and creating cleaned audio only for review later, the workflow now creates the cleaned-audio artifact first and feeds that isolated audio into ElevenLabs Scribe.

This also changes failure behavior intentionally: if required audio cleanup fails, the job stops before transcription instead of silently continuing with lower-quality input. Manual ElevenLabs transcription reruns carry the same cleanup-before-transcription contract, and the job step order now reflects the actual pipeline.

## Tests
- `pnpm --filter @forge/manager test -- src/workflows/videoEnrichment.test.ts src/services/transcription.test.ts src/services/elevenlabs-transcription.test.ts src/lib/workflow-steps.test.ts 'src/app/api/jobs/[id]/transcription/rerun/route.test.ts'`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `git diff --check`

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
