### PR TITLE
fix(watch): ignore digit-only localized download titles

### DIFF
--- a/apps/web/src/components/watch/__tests__/download-link.test.ts
+++ b/apps/web/src/components/watch/__tests__/download-link.test.ts
@@ -52,6 +52,19 @@ describe("buildDownloadFilename", () => {
     ).toBe("bp-plot-episode-5_Bangla_ben_270p.mp4")
   })
 
+  it("uses the video slug when the localized title only contributes digits", () => {
+    expect(
+      buildDownloadFilename({
+        videoTitle: "Плот (серия 5)",
+        videoSlug: "bp-plot-episode-5",
+        languageName: "Russian",
+        languageCode: "rus",
+        renditionHeight: 270,
+        tier: "low",
+      }),
+    ).toBe("bp-plot-episode-5_Russian_rus_270p.mp4")
+  })
+
   it("distinguishes same-name languages by code", () => {
     const common = {
       videoTitle: "Jesus Film",

--- a/apps/web/src/components/watch/download-link.ts
+++ b/apps/web/src/components/watch/download-link.ts
@@ -58,13 +58,23 @@ function textSegment(
   return asciiWords(fallback).join("-") || "Unknown"
 }
 
+function hasAsciiLetter(words: string[]): boolean {
+  return words.some((word) => /[A-Za-z]/.test(word))
+}
+
 function textSegmentFrom(
   candidates: (string | null | undefined)[],
   fallback: string,
+  options: { requireAsciiLetter?: boolean } = {},
 ): string {
   for (const candidate of candidates) {
     const words = asciiWords(candidate)
-    if (words.length > 0) return words.join("-")
+    if (
+      words.length > 0 &&
+      (!options.requireAsciiLetter || hasAsciiLetter(words))
+    ) {
+      return words.join("-")
+    }
   }
   return asciiWords(fallback).join("-") || "Unknown"
 }
@@ -97,7 +107,9 @@ export function buildDownloadFilename({
   videoTitle,
 }: BuildDownloadFilenameParams): string {
   const segments = [
-    textSegmentFrom([videoTitle, videoSlug], "Video"),
+    textSegmentFrom([videoTitle, videoSlug], "Video", {
+      requireAsciiLetter: true,
+    }),
     textSegment(languageName, "Language"),
     codeSegment(languageCode, languageSlug, languageName),
     renditionSegment(renditionHeight, tier),


### PR DESCRIPTION
## Summary

Follow-up to #1299: localized titles that only contribute digits now fall back to the route slug instead of producing filenames like `5_Russian_rus_270p.mp4`. The Russian plot episode case should now download as `bp-plot-episode-5_Russian_rus_270p.mp4` while preserving the compatible ASCII filename rules.

## Validation

- `pnpm --filter @forge/web test -- src/components/watch/__tests__/download-link.test.ts` (10 tests)
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
