### PR TITLE
feat(search): enrich transcript semantic embeddings

### DIFF
--- a/apps/admin/prisma/migrations/0034_enriched_transcript_chunks/migration.sql
+++ b/apps/admin/prisma/migrations/0034_enriched_transcript_chunks/migration.sql
@@ -1,0 +1,30 @@
+-- Enriched transcript semantic search v2.
+--
+-- Add nullable/source-defaulted fields so existing transcript embeddings remain
+-- readable while new Mastra transcript runs can store the structured metadata
+-- that used to live only in scene evidence.
+
+ALTER TABLE "video_transcript"
+  ADD COLUMN "source_kind" TEXT,
+  ADD COLUMN "source_language_id" TEXT,
+  ADD COLUMN "source_language_slug" TEXT,
+  ADD COLUMN "source_subtitle_id" TEXT,
+  ADD COLUMN "source_format" TEXT,
+  ADD COLUMN "source_url" TEXT;
+
+ALTER TABLE "video_transcript_chunk"
+  ADD COLUMN "raw_source_text" TEXT,
+  ADD COLUMN "embedding_input_text" TEXT,
+  ADD COLUMN "felt_needs" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN "bible_verses" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN "content_summary" TEXT,
+  ADD COLUMN "tone" TEXT,
+  ADD COLUMN "demographics" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN "spiritual_context" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN "extraction_metadata" JSONB;
+
+CREATE INDEX "video_transcript_source_kind_idx"
+  ON "video_transcript"("source_kind");
+
+CREATE INDEX "video_transcript_source_language_id_idx"
+  ON "video_transcript"("source_language_id");

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -235,14 +235,14 @@ enum SearchEvalCandidateSanitizationStatus {
 
 model User {
   chatThreadsCreated ExperienceChatThread[] // experience-AI chat (additive)
-  id            String   @id
-  name          String
-  email         String
-  emailVerified Boolean  @default(false) @map("email_verified")
-  image         String?
-  role          UserRole @default(VIEWER)
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id                 String                 @id
+  name               String
+  email              String
+  emailVerified      Boolean                @default(false) @map("email_verified")
+  image              String?
+  role               UserRole               @default(VIEWER)
+  createdAt          DateTime               @default(now()) @map("created_at")
+  updatedAt          DateTime               @updatedAt @map("updated_at")
 
   mediaAssets           MediaAsset[]
   mediaFolders          MediaFolder[]
@@ -1534,7 +1534,7 @@ model Experience {
 /// discriminated union in `src/domain/blocks.ts` (Unit 4e). Reads return the
 /// JSONB column directly; mutations validate before write.
 model ExperienceLocale {
-  chatThreads ExperienceChatThread[] // experience-AI chat (additive)
+  chatThreads                ExperienceChatThread[] // experience-AI chat (additive)
   id                         String                       @id @default(cuid())
   experienceId               String                       @map("experience_id")
   experience                 Experience                   @relation(fields: [experienceId], references: [id], onDelete: Cascade)
@@ -1626,6 +1626,12 @@ model VideoTranscript {
   /// Compact provenance for Mastra-written transcript embeddings. Nullable so
   /// legacy rows from the pre-Mastra producer remain readable.
   sourceArtifactKey         String?      @map("source_artifact_key")
+  sourceKind                String?      @map("source_kind")
+  sourceLanguageId          String?      @map("source_language_id")
+  sourceLanguageSlug        String?      @map("source_language_slug")
+  sourceSubtitleId          String?      @map("source_subtitle_id")
+  sourceFormat              String?      @map("source_format")
+  sourceUrl                 String?      @map("source_url")
   sourceContentHash         String?      @map("source_content_hash")
   sourceProvider            String?      @map("source_provider")
   sourceGeneratedAt         DateTime?    @map("source_generated_at")
@@ -1656,29 +1662,42 @@ model VideoTranscript {
 /// embed/vector/similarity field leaks; and the Prisma client extension
 /// in `src/db/client.ts` strips it from default result sets).
 model VideoTranscriptChunk {
-  id           String                       @id @default(cuid())
-  transcriptId String                       @map("transcript_id")
-  transcript   VideoTranscript              @relation(fields: [transcriptId], references: [id], onDelete: Cascade)
+  id                 String                       @id @default(cuid())
+  transcriptId       String                       @map("transcript_id")
+  transcript         VideoTranscript              @relation(fields: [transcriptId], references: [id], onDelete: Cascade)
   /// Denormalized from `transcript.language`. Indexer keeps the two in sync;
   /// no DB-level CHECK (Postgres doesn't support cross-row checks cleanly).
-  language     String
+  language           String
   /// 0-based index within the transcript, stable across re-chunks.
-  chunkIndex   Int                          @map("chunk_index")
+  chunkIndex         Int                          @map("chunk_index")
   /// Opaque chunk identifier from manager's artifact (e.g. "chunk-0").
   /// Preserved for drift audits against the upstream artifact.
-  chunkId      String                       @map("chunk_id")
+  chunkId            String                       @map("chunk_id")
   /// The embedded text, verbatim from the artifact's `chunks[].text`.
-  text         String
+  text               String
+  /// Raw subtitle/transcript source text for this segment. Nullable for legacy
+  /// v1 rows where `text` was the only stored snippet.
+  rawSourceText      String?                      @map("raw_source_text")
+  /// Full vector input text. v2 rows keep this separate from user/debug
+  /// snippets so enriched metadata can be audited without replacing raw text.
+  embeddingInputText String?                      @map("embedding_input_text")
+  feltNeeds          String[]                     @default([]) @map("felt_needs")
+  bibleVerses        String[]                     @default([]) @map("bible_verses")
+  contentSummary     String?                      @map("content_summary")
+  tone               String?
+  demographics       String[]                     @default([])
+  spiritualContext   String[]                     @default([]) @map("spiritual_context")
+  extractionMetadata Json?                        @map("extraction_metadata")
   /// Estimated token count from manager's chunker.
-  tokenCount   Int                          @map("token_count")
+  tokenCount         Int                          @map("token_count")
   /// Optional timecodes when the chunk came from a segment-aware chunker.
-  startSeconds Float?                       @map("start_seconds")
-  endSeconds   Float?                       @map("end_seconds")
-  embedding    Unsupported("vector(1536)")?
-  model        String                       @default("text-embedding-3-small")
-  dimensions   Int                          @default(1536)
-  createdAt    DateTime                     @default(now()) @map("created_at")
-  updatedAt    DateTime                     @updatedAt @map("updated_at")
+  startSeconds       Float?                       @map("start_seconds")
+  endSeconds         Float?                       @map("end_seconds")
+  embedding          Unsupported("vector(1536)")?
+  model              String                       @default("text-embedding-3-small")
+  dimensions         Int                          @default(1536)
+  createdAt          DateTime                     @default(now()) @map("created_at")
+  updatedAt          DateTime                     @updatedAt @map("updated_at")
 
   @@unique([transcriptId, chunkIndex])
   @@index([language])
@@ -1695,6 +1714,7 @@ enum ExperienceChatMessageRole {
   ASSISTANT @map("assistant")
   SYSTEM    @map("system")
 }
+
 model ExperienceChatThread {
   id                 String           @id @default(cuid())
   experienceLocaleId String           @map("experience_locale_id")

--- a/apps/admin/schema.graphql
+++ b/apps/admin/schema.graphql
@@ -1013,7 +1013,7 @@ type Query {
   """List media folders ordered for tree rendering."""
   mediaFolders: [MediaFolder!]
   """
-  Per-scene cosine-similarity recommendations. PUBLIC — see published, non-deleted rows only. Either videoId or slug must be supplied.
+  Transcript-backed cosine-similarity recommendations. PUBLIC — see published, non-deleted rows only. Either videoId or slug must be supplied.
   """
   sceneRecommendations(limit: Int, locale: String!, sceneIndex: Int, slug: String, videoId: ID): [SceneRecommendation!]!
   """
@@ -1127,7 +1127,7 @@ enum SceneBackfillMode {
 }
 
 """
-A single scene-similarity recommendation. Matches cms's SceneRecommendation shape modulo the cuid-string videoId.
+A single transcript-backed recommendation. Matches cms's SceneRecommendation shape modulo the cuid-string videoId.
 """
 type SceneRecommendation {
   demographics: [String!]!

--- a/apps/admin/src/graphql/mutations/transcript-embedding.test.ts
+++ b/apps/admin/src/graphql/mutations/transcript-embedding.test.ts
@@ -33,6 +33,7 @@ const BASE_REPORT: TranscriptEmbeddingBackfillReport = {
   skipped: 0,
   failed: 0,
   missingArtifacts: [],
+  sourceGaps: [],
 }
 
 describe("dispatchTranscriptEmbeddingBackfill", () => {

--- a/apps/admin/src/graphql/queries/scene-recommendations.ts
+++ b/apps/admin/src/graphql/queries/scene-recommendations.ts
@@ -1,11 +1,13 @@
 /**
- * Public scene-recommendations GraphQL query (`sceneRecommendations`).
+ * Public transcript-backed recommendations GraphQL query
+ * (`sceneRecommendations`).
  *
  * Delegates to SceneRecommendationsService — the same service the REST
  * route at /api/scene-embedding/recommendations calls. Matches cms's
  * `sceneRecommendations` SDL shape field-for-field, modulo the
  * `videoId: Int!` → `videoId: ID!` identity delta (admin cuid strings
- * vs. cms integer ids). See plan §Key Technical Decisions #2.
+ * vs. cms integer ids). The field name stays for client parity, but
+ * feat-192 backs it with enriched transcript chunks.
  *
  * `VideoNotFoundError` is soft-swallowed to `[]` (matches cms's
  * resolver) so the recommendations block on apps/web renders an empty
@@ -32,7 +34,7 @@ const SceneRecommendationRef = builder.objectRef<SceneRecommendation>(
 
 SceneRecommendationRef.implement({
   description:
-    "A single scene-similarity recommendation. Matches cms's SceneRecommendation shape modulo the cuid-string videoId.",
+    "A single transcript-backed recommendation. Matches cms's SceneRecommendation shape modulo the cuid-string videoId.",
   fields: (t) => ({
     videoId: t.id({
       nullable: false,
@@ -65,7 +67,7 @@ builder.queryFields((t) => ({
     nullable: false,
     authScopes: { public: true },
     description:
-      "Per-scene cosine-similarity recommendations. PUBLIC — see published, non-deleted rows only. Either videoId or slug must be supplied.",
+      "Transcript-backed cosine-similarity recommendations. PUBLIC — see published, non-deleted rows only. Either videoId or slug must be supplied.",
     args: {
       videoId: t.arg.id({ required: false }),
       slug: t.arg.string({ required: false }),

--- a/apps/admin/src/scripts/run-embeds.ts
+++ b/apps/admin/src/scripts/run-embeds.ts
@@ -24,9 +24,9 @@
  *
  *   # Filters (all optional, repeatable):
  *   --pipeline=scene|transcript|experience|both|all     # required
- *                                                       # `both` = scene + transcript
- *                                                       # (back-compat)
- *                                                       # `all` = scene + transcript + experience
+ *                                                       # `scene` = explicit legacy scene backfill
+ *                                                       # `both` = transcript (legacy alias)
+ *                                                       # `all` = transcript + experience
  *   --mapping-key=admin-migrations/core-id-mapping.json # scene/transcript default
  *   --core-id=<id>                                      # scene/transcript filter (repeatable)
  *   --locale=<bcp47>                                    # scene + experience pipeline filter (repeatable)
@@ -56,17 +56,17 @@
  *
  *   stdout:
  *     - `run-embeds.start` — one line at startup with resolved config
- *     - `run-embeds.scene.preflight`       (pipeline=scene|both|all)
- *     - `run-embeds.scene.start`           (pipeline=scene|both|all)
- *     - `run-embeds.scene.complete`        (pipeline=scene|both|all)
- *     - `run-embeds.scene.error`           (pipeline=scene|both|all, on error)
+ *     - `run-embeds.scene.preflight`       (pipeline=scene only)
+ *     - `run-embeds.scene.start`           (pipeline=scene only)
+ *     - `run-embeds.scene.complete`        (pipeline=scene only)
+ *     - `run-embeds.scene.error`           (pipeline=scene only, on error)
  *     - `run-embeds.transcript.start`      (pipeline=transcript|both|all)
  *     - `run-embeds.transcript.complete`   (pipeline=transcript|both|all)
  *     - `run-embeds.transcript.error`      (pipeline=transcript|both|all, on error)
  *     - `run-embeds.experience.start`      (pipeline=experience|all)
  *     - `run-embeds.experience.complete`   (pipeline=experience|all)
  *     - `run-embeds.experience.error`      (pipeline=experience|all, on error)
- *     - `run-embeds.experience.skipped`    (pipeline=both — both = scene+transcript only;
+ *     - `run-embeds.experience.skipped`    (pipeline=both — legacy transcript-only alias;
  *                                           experience is explicitly omitted)
  *     - `run-embeds.complete` — final aggregated report (pretty-printed JSON)
  *     - `run-embeds.report_out_written` — when --report-out succeeded
@@ -1192,11 +1192,7 @@ async function main(): Promise<void> {
   const errorDetails: Record<string, PipelineErrorDetails> = {}
 
   try {
-    if (
-      pipelineArg === "scene" ||
-      pipelineArg === "both" ||
-      pipelineArg === "all"
-    ) {
+    if (pipelineArg === "scene") {
       const sceneResult = await runSceneBranch({
         mappingS3Key,
         coreIds,

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -250,7 +250,7 @@ describe("searchVideoSemantic", () => {
     expect(rows[0]!.startSeconds).toBeNull()
   })
 
-  it("queries both scene and transcript embeddings inside one semantic-video retriever", async () => {
+  it("queries transcript embeddings only inside the semantic-video retriever", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([])
 
     await searchVideoSemantic(prisma, {
@@ -260,12 +260,11 @@ describe("searchVideoSemantic", () => {
     })
 
     const sql = latestRawSql(prisma)
-    expect(sql).toContain("WITH scene_source AS")
-    expect(sql).toContain("scene_source AS")
+    expect(sql).not.toContain("scene_source AS")
     expect(sql).toContain("transcript_source AS")
-    expect(sql).toContain("FROM video_scene_locale vsl")
+    expect(sql).not.toContain("FROM video_scene_locale")
     expect(sql).toContain("FROM video_transcript_chunk vtc")
-    expect(sql).toContain("UNION ALL")
+    expect(sql).not.toContain("UNION ALL")
     expect(sql).not.toContain("semantic-transcript-video")
   })
 
@@ -279,39 +278,21 @@ describe("searchVideoSemantic", () => {
     })
 
     const sql = latestRawSql(prisma)
-    expect((sql.match(/v\.deleted_at IS NULL/g) ?? []).length).toBe(2)
-    expect((sql.match(/vl\.status = 'published'/g) ?? []).length).toBe(2)
+    expect((sql.match(/v\.deleted_at IS NULL/g) ?? []).length).toBe(1)
+    expect((sql.match(/vl\.status = 'published'/g) ?? []).length).toBe(1)
     const sqlWithFragments = latestRawSqlWithFragments(prisma)
-    expect((sqlWithFragments.match(/IS NOT NULL/g) ?? []).length).toBe(2)
-    expect(sqlWithFragments).toContain("vsl.embedding")
+    expect((sqlWithFragments.match(/IS NOT NULL/g) ?? []).length).toBe(1)
+    expect(sqlWithFragments).not.toContain("vsl.embedding")
     expect(sqlWithFragments).toContain("vtc.embedding")
-    expect(sql).toContain("vsl.locale =")
+    expect(sql).not.toContain("vsl.locale =")
     expect(sql).toContain("vtc.language =")
     expect(sql).toContain("vt.language =")
     expect(sql).toContain("requested_language AS MATERIALIZED")
 
-    const sceneSource = sqlBetween(
-      sqlWithFragments,
-      "WITH scene_source AS",
-      "transcript_source AS",
-    )
-    const sceneOrderIndex = sceneSource.indexOf("ORDER BY")
-    expect(sceneSource.indexOf("v.deleted_at IS NULL")).toBeLessThan(
-      sceneOrderIndex,
-    )
-    expect(sceneSource.indexOf("vl.status = 'published'")).toBeLessThan(
-      sceneOrderIndex,
-    )
-    expect(sceneSource.indexOf("vl.deleted_at IS NULL")).toBeLessThan(
-      sceneOrderIndex,
-    )
-    expect(sceneSource).not.toContain("LATERAL")
-    expect(sceneSource).not.toContain("embedding::text")
-
     const transcriptSource = sqlBetween(
       sqlWithFragments,
-      "transcript_source AS",
-      "semantic_evidence AS",
+      "WITH transcript_source AS",
+      "requested_language AS MATERIALIZED",
     )
     const transcriptOrderIndex = transcriptSource.indexOf("ORDER BY")
     expect(transcriptSource.indexOf("v.deleted_at IS NULL")).toBeLessThan(
@@ -333,11 +314,10 @@ describe("searchVideoSemantic", () => {
     expect(hydratedTail).toContain(
       "vd.language_id IN (SELECT id FROM requested_language)",
     )
-    expect(hydratedTail).toContain("vsl_final.embedding::text")
     expect(hydratedTail).toContain("vtc_final.embedding::text")
   })
 
-  it("selects best per-source evidence before bounding candidate windows", async () => {
+  it("selects best transcript evidence before bounding candidate windows", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([])
 
     await searchVideoSemantic(prisma, {
@@ -347,21 +327,10 @@ describe("searchVideoSemantic", () => {
     })
 
     const sql = latestRawSqlWithFragments(prisma)
-    expect(sql).toContain("SELECT DISTINCT ON (vs.video_id)")
+    expect(sql).not.toContain("SELECT DISTINCT ON (vs.video_id)")
     expect(sql).toContain("SELECT DISTINCT ON (vt.video_id)")
     expect(sql).not.toContain("WITH scene_nn AS MATERIALIZED")
     expect(sql).not.toContain("transcript_nn AS MATERIALIZED")
-
-    const sceneOrderIndex = sql.indexOf(
-      "ORDER BY",
-      sql.indexOf("SELECT DISTINCT ON (vs.video_id)"),
-    )
-    const sceneCandidateLimitIndex = sql.indexOf(
-      "LIMIT",
-      sql.indexOf("best_scene_per_video"),
-    )
-    expect(sceneOrderIndex).toBeGreaterThan(-1)
-    expect(sceneOrderIndex).toBeLessThan(sceneCandidateLimitIndex)
 
     const transcriptOrderIndex = sql.indexOf(
       "ORDER BY",
@@ -385,7 +354,7 @@ describe("searchVideoSemantic", () => {
     })
 
     const values = latestRawValues(prisma)
-    expect(values.filter((value) => value === 14)).toHaveLength(2)
+    expect(values.filter((value) => value === 14)).toHaveLength(1)
   })
 })
 
@@ -396,7 +365,7 @@ describe("searchVideoSemantic embedding column selection", () => {
     prisma = mockPrisma()
   })
 
-  it("reads vsl.embedding / vtc.embedding and never the removed qwen columns", async () => {
+  it("reads vtc.embedding and never scene or removed qwen columns", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([])
     await searchVideoSemantic(prisma, {
       queryEmbedding: "[0.1]",
@@ -405,9 +374,9 @@ describe("searchVideoSemantic embedding column selection", () => {
     })
 
     const sql = latestRawSqlWithFragments(prisma)
-    expect(sql).toContain("vsl.embedding")
+    expect(sql).not.toContain("vsl.embedding")
     expect(sql).toContain("vtc.embedding")
-    expect(sql).toContain("vsl.embedding_provider")
+    expect(sql).not.toContain("vsl.embedding_provider")
     expect(sql).toContain("vt.embedding_provider")
     expect(sql).not.toContain("embedding_qwen")
   })
@@ -430,12 +399,11 @@ describe("semantic retriever provenance gates", () => {
 
     const sql = latestRawSqlWithFragments(prisma)
     const values = latestRawValues(prisma)
-    expect(sql).toContain("vsl.embedding_provider")
     expect(sql).toContain("vt.embedding_provider")
-    expect(sql).toContain("vsl.embedding_native_dimensions")
     expect(sql).toContain("vt.embedding_native_dimensions")
-    expect(sql).toContain("vsl.embedding_transform_version IS NULL")
     expect(sql).toContain("vt.embedding_transform_version IS NULL")
+    expect(sql).not.toContain("vsl.embedding_provider")
+    expect(sql).not.toContain("video_scene_locale")
     expect(values).toContain("jesus-film-ai-gateway")
     expect(values).toContain("embeddings")
     expect(values).toContain(1536)

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -312,13 +312,6 @@ export async function searchVideoSemantic(
   const { queryEmbedding, locale, limit } = params
   const candidateLimit = Math.max(limit * 2, limit)
 
-  const sceneProvenanceFilter = Prisma.sql`
-          AND vsl.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
-          AND vsl.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
-          AND vsl.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
-          AND vsl.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
-          AND vsl.embedding_transform_version IS NULL
-        `
   const transcriptProvenanceFilter = Prisma.sql`
           AND vt.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
           AND vt.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
@@ -330,41 +323,7 @@ export async function searchVideoSemantic(
         `
 
   const evidenceRows = await prisma.$queryRaw<VideoSemanticEvidenceRow[]>`
-    WITH scene_source AS (
-      SELECT * FROM (
-        SELECT DISTINCT ON (vs.video_id)
-          vs.video_id                       AS video_id,
-          v.core_id                         AS video_core_id,
-          v.slug                            AS video_slug,
-          vl.title                          AS video_title,
-          vs.video_edition_id               AS video_edition_id,
-          vsl.id                            AS evidence_id,
-          'scene'                           AS evidence_source,
-          vsl.description                   AS scene_description,
-          vs.start_seconds                  AS start_seconds,
-          1 - (vsl.embedding <=> ${queryEmbedding}::vector) AS source_score
-        FROM video_scene_locale vsl
-        JOIN video_scene vs ON vs.id = vsl.video_scene_id
-        JOIN video v ON v.id = vs.video_id
-          AND v.deleted_at IS NULL
-        JOIN video_locale vl
-          ON vl.video_id = v.id
-          AND vl.locale = ${locale}
-          AND vl.status = 'published'
-          AND vl.deleted_at IS NULL
-        WHERE vsl.embedding IS NOT NULL
-          ${sceneProvenanceFilter}
-          AND vsl.locale = ${locale}
-        ORDER BY
-          vs.video_id,
-          vsl.embedding <=> ${queryEmbedding}::vector,
-          vs.start_seconds ASC,
-          vsl.id ASC
-      ) best_scene_per_video
-      ORDER BY source_score DESC, start_seconds ASC, evidence_id ASC
-      LIMIT ${candidateLimit}
-    ),
-    transcript_source AS (
+    WITH transcript_source AS (
       SELECT * FROM (
         SELECT DISTINCT ON (vt.video_id)
           vt.video_id                       AS video_id,
@@ -374,7 +333,11 @@ export async function searchVideoSemantic(
           vt.video_edition_id               AS video_edition_id,
           vtc.id                            AS evidence_id,
           'transcript'                      AS evidence_source,
-          vtc.text                          AS scene_description,
+          COALESCE(
+            NULLIF(vtc.content_summary, ''),
+            NULLIF(vtc.raw_source_text, ''),
+            vtc.text
+          )                                 AS scene_description,
           vtc.start_seconds                 AS start_seconds,
           1 - (vtc.embedding <=> ${queryEmbedding}::vector) AS source_score
         FROM video_transcript_chunk vtc
@@ -399,44 +362,32 @@ export async function searchVideoSemantic(
       ORDER BY source_score DESC, start_seconds ASC NULLS LAST, evidence_id ASC
       LIMIT ${candidateLimit}
     ),
-    semantic_evidence AS (
-      SELECT * FROM scene_source
-      UNION ALL
-      SELECT * FROM transcript_source
-    ),
     requested_language AS MATERIALIZED (
       SELECT id
       FROM language
       WHERE bcp47 = ${locale}
     )
     SELECT
-      se.video_id                      AS video_id,
-      se.video_core_id                 AS video_core_id,
-      se.video_slug                    AS video_slug,
-      se.video_title                   AS video_title,
+      ts.video_id                      AS video_id,
+      ts.video_core_id                 AS video_core_id,
+      ts.video_slug                    AS video_slug,
+      ts.video_title                   AS video_title,
       COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
-      se.evidence_id                   AS evidence_id,
-      se.evidence_source               AS evidence_source,
-      se.scene_description             AS scene_description,
-      se.start_seconds                 AS start_seconds,
+      ts.evidence_id                   AS evidence_id,
+      ts.evidence_source               AS evidence_source,
+      ts.scene_description             AS scene_description,
+      ts.start_seconds                 AS start_seconds,
       dub_mux.playback_id              AS playback_id,
-      se.source_score                  AS source_score,
-      CASE
-        WHEN se.evidence_source = 'scene' THEN vsl_final.embedding::text
-        ELSE vtc_final.embedding::text
-      END                              AS embedding_text
-    FROM semantic_evidence se
-    LEFT JOIN video_scene_locale vsl_final
-      ON se.evidence_source = 'scene'
-      AND vsl_final.id = se.evidence_id
+      ts.source_score                  AS source_score,
+      vtc_final.embedding::text        AS embedding_text
+    FROM transcript_source ts
     LEFT JOIN video_transcript_chunk vtc_final
-      ON se.evidence_source = 'transcript'
-      AND vtc_final.id = se.evidence_id
+      ON vtc_final.id = ts.evidence_id
     LEFT JOIN LATERAL (
       SELECT mv.playback_id
       FROM video_dub vd
       LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
-      WHERE vd.video_edition_id = se.video_edition_id
+      WHERE vd.video_edition_id = ts.video_edition_id
         AND vd.deleted_at IS NULL
         AND vd.language_id IN (SELECT id FROM requested_language)
       ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
@@ -445,7 +396,7 @@ export async function searchVideoSemantic(
     LEFT JOIN LATERAL (
       SELECT vi2.mobile_cinematic_high, vi2.url
       FROM video_image vi2
-      WHERE vi2.video_id = se.video_id
+      WHERE vi2.video_id = ts.video_id
         AND vi2.deleted_at IS NULL
       ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
       LIMIT 1

--- a/apps/admin/src/services/mastra-transcript-embedding-client.test.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.test.ts
@@ -95,6 +95,60 @@ describe("launchMastraTranscriptEmbedding", () => {
     expect(JSON.stringify(body)).not.toContain("embedding")
   })
 
+  it("posts resolved subtitle source keys instead of hardcoded Manager artifact keys", async () => {
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ result: successResult }),
+    )
+
+    await launchMastraTranscriptEmbedding(
+      {
+        target: {
+          videoId: "v-1",
+          videoEditionId: "e-1",
+          coreId: "core-1",
+        },
+        language: "en",
+        cmsVideoId: 42,
+        transcript: {
+          text: "subtitle transcript",
+          segments: [{ start: 0, end: 2, text: "subtitle transcript" }],
+          artifactKey: "admin-video-subtitle/sub-1.vtt",
+          kind: "subtitle",
+          languageId: "lang-en",
+          languageSlug: "english",
+          subtitleId: "sub-1",
+          format: "vtt",
+          url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+          provider: "admin-subtitle",
+          generatedAt: "2026-06-01T00:00:00.000Z",
+        },
+      },
+      {
+        baseUrl: "https://mastra.internal",
+        bearer: "secret",
+        fetchImpl,
+      },
+    )
+
+    const body = JSON.parse(
+      String(fetchImpl.mock.calls[0]?.[1]?.body),
+    ) as Record<string, unknown>
+    expect(body).toMatchObject({
+      transcript: {
+        artifactKey: "admin-video-subtitle/sub-1.vtt",
+        kind: "subtitle",
+        languageId: "lang-en",
+        languageSlug: "english",
+        subtitleId: "sub-1",
+        format: "vtt",
+        url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+        provider: "admin-subtitle",
+        generatedAt: "2026-06-01T00:00:00.000Z",
+      },
+    })
+  })
+
   it("returns Mastra failures and upstream auth failures safely", async () => {
     const productFailure = {
       ok: false,

--- a/apps/admin/src/services/mastra-transcript-embedding-client.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.ts
@@ -1,5 +1,4 @@
 import { env } from "@/config/env"
-import type { TranscriptSourceArtifact } from "@/services/manager-artifacts.service"
 
 export type MastraTranscriptEmbeddingMode =
   | "idempotent"
@@ -13,14 +12,30 @@ export type MastraTranscriptEmbeddingTarget = {
   coreId?: string
 }
 
+type MastraTranscriptEmbeddingSourceSegment = {
+  start: number
+  end: number
+  text: string
+}
+
 export type MastraTranscriptEmbeddingLaunchInput = {
   target: MastraTranscriptEmbeddingTarget
   language: string
   cmsVideoId: number
-  transcript: Pick<
-    TranscriptSourceArtifact,
-    "text" | "segments" | "resolvedProvider"
-  >
+  transcript: {
+    text: string
+    segments: readonly MastraTranscriptEmbeddingSourceSegment[]
+    artifactKey?: string
+    kind?: "subtitle" | "manager-transcript"
+    languageId?: string | null
+    languageSlug?: string | null
+    subtitleId?: string
+    format?: "vtt" | "srt"
+    url?: string
+    provider?: string
+    resolvedProvider?: string
+    generatedAt?: string
+  }
   mode?: MastraTranscriptEmbeddingMode
 }
 
@@ -89,7 +104,7 @@ const FAILURE_REASONS = new Set([
   "admin_ingest_failed",
 ])
 
-type TranscriptSourceSegment = TranscriptSourceArtifact["segments"][number]
+type TranscriptSourceSegment = MastraTranscriptEmbeddingSourceSegment
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -187,8 +202,16 @@ export async function launchMastraTranscriptEmbedding(
     transcript: {
       text: input.transcript.text,
       segments: normalizeSegments(input.transcript.segments),
-      artifactKey: `${input.cmsVideoId}/transcript.json`,
-      provider: input.transcript.resolvedProvider,
+      artifactKey:
+        input.transcript.artifactKey ?? `${input.cmsVideoId}/transcript.json`,
+      kind: input.transcript.kind,
+      languageId: input.transcript.languageId ?? undefined,
+      languageSlug: input.transcript.languageSlug ?? undefined,
+      subtitleId: input.transcript.subtitleId,
+      format: input.transcript.format,
+      url: input.transcript.url,
+      provider: input.transcript.provider ?? input.transcript.resolvedProvider,
+      generatedAt: input.transcript.generatedAt,
     },
     mode: input.mode ?? "idempotent",
   }

--- a/apps/admin/src/services/scene-recommendations-retriever.test.ts
+++ b/apps/admin/src/services/scene-recommendations-retriever.test.ts
@@ -43,7 +43,7 @@ describe("fetchInputEmbeddings", () => {
     prisma = mockPrisma()
   })
 
-  it("returns embeddings for a specific scene when sceneIndex is provided", async () => {
+  it("returns embeddings for a specific transcript chunk when sceneIndex is provided", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([
       { embedding_text: "[0.1,0.2]", scene_index: 3 },
     ])
@@ -51,7 +51,7 @@ describe("fetchInputEmbeddings", () => {
     expect(rows).toEqual([{ embedding: "[0.1,0.2]", sceneIndex: 3 }])
   })
 
-  it("returns every scene for the video when sceneIndex is omitted", async () => {
+  it("returns every transcript chunk for the video when sceneIndex is omitted", async () => {
     prisma.$queryRaw.mockResolvedValueOnce([
       { embedding_text: "[0.1]", scene_index: 0 },
       { embedding_text: "[0.2]", scene_index: 1 },
@@ -175,7 +175,7 @@ describe("queryScenesSimilar", () => {
     expect(await queryScenesSimilar(prisma, "[]", "zz", [], 10)).toEqual([])
   })
 
-  it("SQL invariant: DISTINCT ON (video_id) + locale filter + inner mux join + exclude-by-ALL", async () => {
+  it("SQL invariant: transcript-only + DISTINCT ON (video_id) + locale filter + inner mux join + exclude-by-ALL", async () => {
     // Scrapes the tagged-template SQL passed to $queryRaw to assert the
     // load-bearing invariants called out in apps/admin/CLAUDE.md R5
     // section. A silent regression (e.g. LEFT JOIN slipping in, locale
@@ -188,8 +188,12 @@ describe("queryScenesSimilar", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const raw = (call[0] as any).join(" ")
     const sql = String(raw)
-    expect(sql).toMatch(/DISTINCT ON\s*\(\s*vs\.video_id\s*\)/)
-    expect(sql).toMatch(/JOIN\s+video\s+v\s+ON\s+v\.id\s*=\s*vs\.video_id/)
+    expect(sql).toMatch(/DISTINCT ON\s*\(\s*vt\.video_id\s*\)/)
+    expect(sql).toMatch(/FROM video_transcript_chunk/)
+    expect(sql).toMatch(/JOIN\s+video_transcript\s+vt/)
+    expect(sql).toMatch(/JOIN\s+video\s+v\s+ON\s+v\.id\s*=\s*vt\.video_id/)
+    expect(sql).not.toMatch(/video_scene_locale/)
+    expect(sql).not.toMatch(/video_scene\b/)
     expect(sql).toMatch(/v\.deleted_at IS NULL/)
     expect(sql).toMatch(/vl\.status\s*=\s*'published'/)
     // INNER JOIN on dub/mux (not LEFT JOIN) — preserves cms's non-null
@@ -199,8 +203,10 @@ describe("queryScenesSimilar", () => {
     expect(sql).toMatch(/JOIN\s+mux_video\s+mv/)
     expect(sql).not.toMatch(/LEFT\s+JOIN\s+mux_video/)
     expect(sql).toMatch(/mv\.playback_id IS NOT NULL/)
-    expect(sql).toMatch(/vsl\.embedding IS NOT NULL/)
-    expect(sql).toMatch(/vs\.video_id\s*<>\s*ALL/)
+    expect(sql).toMatch(/vtc\.embedding IS NOT NULL/)
+    expect(sql).toMatch(/vt\.video_id\s*<>\s*ALL/)
+    expect(sql).toMatch(/vtc\.felt_needs/)
+    expect(sql).toMatch(/vtc\.spiritual_context/)
   })
 
   it("resolveSlugToVideoId SQL invariant: deleted_at filter bound to slug parameter", async () => {

--- a/apps/admin/src/services/scene-recommendations-retriever.ts
+++ b/apps/admin/src/services/scene-recommendations-retriever.ts
@@ -1,33 +1,23 @@
 /**
- * SQL layer for R5 scene-recommendations.
+ * SQL layer for the legacy `sceneRecommendations` API.
  *
- * Port of cms's `apps/cms/src/api/scene-embedding/services/recommender.ts`
- * SQL, re-derived against admin's per-locale schema. Companion plan:
- * docs/plans/2026-04-23-003-feat-admin-r5-recommendations-plan.md Unit 2.
+ * The API shape is still scene-flavoured for cms parity, but feat-192
+ * stops consuming scene embeddings. Seed and candidate vectors now come
+ * from enriched transcript chunks (`video_transcript_chunk`). The public
+ * `sceneIndex` field is populated with `chunk_index` during this
+ * transition so clients keep a stable integer anchor.
  *
- * Schema deltas from cms (see
- * docs/solutions/best-practices/dead-invariant-checks-from-sibling-port-20260422.md):
- *
- *   cms                                | admin
- *   -----------------------------------|-------------------------------
- *   scene_embeddings (single row)      | video_scene + video_scene_locale
- *   scene_embeddings.playback_id       | 3-hop VideoDub(edition, lang)
- *                                        → mux_video LATERAL lookup
- *   videos.title                       | video_locale.title
- *   video_variants publish chain       | video_locale.status='published'
- *                                        + video.deleted_at IS NULL
- *   videos_children_lnk                | video_relation
- *   video_images LATERAL               | dropped (imageUrl null; R4 parity)
- *   integer ids                        | cuid strings
- *
- * `playbackId` is kept NON-NULL via INNER JOIN on the dub+mux chain
- * (distinct from R4's hybrid-search which uses LEFT JOIN). Rationale:
- * cms's recommender guarantees `playbackId: String!` and apps/web's
- * renderer consumes it; a recommendation without a resolvable playback
- * is not actionable.
+ * `playbackId` is kept NON-NULL via INNER JOIN on the dub+mux chain.
+ * Rationale: cms's recommender guarantees `playbackId: String!` and
+ * apps/web's renderer consumes it; a recommendation without a resolvable
+ * playback is not actionable.
  */
 
 import type { PrismaClient } from "@prisma/client"
+
+const QWEN_CONTENT_EMBEDDING_PROVIDER = "jesus-film-ai-gateway"
+const QWEN_CONTENT_EMBEDDING_MODEL = "embeddings"
+const QWEN_CONTENT_EMBEDDING_DIMENSIONS = 1536
 
 /**
  * Raw shape returned by Postgres for the similarity query. `text[]`
@@ -80,8 +70,9 @@ export type SceneRecommendationSqlRow = {
 }
 
 /**
- * A single input scene — its pgvector text form and the scene_index it
- * belongs to. One or many of these feed `queryScenesSimilar`.
+ * A single input transcript chunk — its pgvector text form and the
+ * chunk_index it belongs to. One or many of these feed
+ * `queryScenesSimilar`.
  */
 export type InputSceneEmbedding = {
   embedding: string
@@ -106,14 +97,14 @@ export async function resolveSlugToVideoId(
 }
 
 /**
- * Fetch input embeddings for the seed video. `sceneIndex` optional — when
- * provided, returns at most one row per edition (admin's unique is
- * `(videoEditionId, sceneIndex)`). When omitted, returns every scene
- * across every edition that has a localized description + embedding in
- * the requested locale.
+ * Fetch input embeddings for the seed video. `sceneIndex` optional — kept
+ * for API compatibility and interpreted as transcript `chunk_index`.
+ * When omitted, returns every transcript chunk across every edition that
+ * has an embedding in the requested locale.
  *
- * Rows with NULL embedding are filtered (the locale row may exist
- * without an embedding if the R1 backfill hasn't run yet).
+ * Rows with NULL embedding are filtered. The provenance guard mirrors
+ * hybrid semantic-video so recommendations use the same enriched
+ * transcript vector space.
  */
 export async function fetchInputEmbeddings(
   prisma: PrismaClient,
@@ -126,15 +117,23 @@ export async function fetchInputEmbeddings(
       { embedding_text: string; scene_index: number }[]
     >`
       SELECT
-        vsl.embedding::text AS embedding_text,
-        vs.scene_index      AS scene_index
-      FROM video_scene_locale vsl
-      JOIN video_scene vs ON vs.id = vsl.video_scene_id
-      WHERE vs.video_id = ${videoId}
-        AND vs.scene_index = ${sceneIndex}
-        AND vsl.locale = ${locale}
-        AND vsl.embedding IS NOT NULL
-      ORDER BY vs.scene_index
+        vtc.embedding::text AS embedding_text,
+        vtc.chunk_index     AS scene_index
+      FROM video_transcript_chunk vtc
+      JOIN video_transcript vt ON vt.id = vtc.transcript_id
+      WHERE vt.video_id = ${videoId}
+        AND vt.language = ${locale}
+        AND vtc.language = ${locale}
+        AND vtc.chunk_index = ${sceneIndex}
+        AND vtc.embedding IS NOT NULL
+        AND vt.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+        AND vt.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+        AND vt.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        AND vt.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        AND vt.embedding_transform_version IS NULL
+        AND vtc.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+        AND vtc.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+      ORDER BY vtc.chunk_index
     `
     return rows.map((r) => ({
       embedding: r.embedding_text,
@@ -146,14 +145,22 @@ export async function fetchInputEmbeddings(
     { embedding_text: string; scene_index: number }[]
   >`
     SELECT
-      vsl.embedding::text AS embedding_text,
-      vs.scene_index      AS scene_index
-    FROM video_scene_locale vsl
-    JOIN video_scene vs ON vs.id = vsl.video_scene_id
-    WHERE vs.video_id = ${videoId}
-      AND vsl.locale = ${locale}
-      AND vsl.embedding IS NOT NULL
-    ORDER BY vs.scene_index
+      vtc.embedding::text AS embedding_text,
+      vtc.chunk_index     AS scene_index
+    FROM video_transcript_chunk vtc
+    JOIN video_transcript vt ON vt.id = vtc.transcript_id
+    WHERE vt.video_id = ${videoId}
+      AND vt.language = ${locale}
+      AND vtc.language = ${locale}
+      AND vtc.embedding IS NOT NULL
+      AND vt.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+      AND vt.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+      AND vt.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+      AND vt.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+      AND vt.embedding_transform_version IS NULL
+      AND vtc.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+      AND vtc.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+    ORDER BY vtc.chunk_index
   `
   return rows.map((r) => ({
     embedding: r.embedding_text,
@@ -181,15 +188,12 @@ export async function getRelatedVideoIds(
 }
 
 /**
- * The similarity query: DISTINCT ON (video_id) over VideoSceneLocale.embedding,
- * locale-filtered, consumer-visibility gated, exclusion-filtered, with
- * the playbackId resolved via the 3-hop VideoDub(edition, lang) → MuxVideo
- * LATERAL. INNER JOIN on the dub/mux chain so rows without a resolvable
- * playback are filtered out (preserves cms's non-null `playbackId` contract).
- *
- * Matches R4's semantic-video retriever shape (subquery-then-ORDER-BY-
- * similarity) so the query planner hits the HNSW index then sorts the
- * small candidate set.
+ * The similarity query: DISTINCT ON (video_id) over transcript chunk
+ * embeddings, locale-filtered, consumer-visibility gated,
+ * exclusion-filtered, with playbackId resolved via the 3-hop
+ * VideoDub(edition, lang) → MuxVideo LATERAL. INNER JOIN on the dub/mux
+ * chain so rows without a resolvable playback are filtered out
+ * (preserves cms's non-null `playbackId` contract).
  */
 export async function queryScenesSimilar(
   prisma: PrismaClient,
@@ -200,24 +204,29 @@ export async function queryScenesSimilar(
 ): Promise<SceneRecommendationSqlRow[]> {
   const rows = await prisma.$queryRaw<SceneRecommendationSqlRowRaw[]>`
     SELECT * FROM (
-      SELECT DISTINCT ON (vs.video_id)
-        vs.video_id                            AS video_id,
+      SELECT DISTINCT ON (vt.video_id)
+        vt.video_id                            AS video_id,
         v.slug                                 AS video_slug,
         vl.title                               AS video_title,
         v.core_id                              AS video_core_id,
-        vs.scene_index                         AS scene_index,
-        vsl.description                        AS description,
-        vs.start_seconds                       AS start_seconds,
-        vs.end_seconds                         AS end_seconds,
-        vsl.themes                             AS themes,
-        vsl.demographics                       AS demographics,
-        vsl.spiritual_context                  AS spiritual_context,
+        vtc.chunk_index                        AS scene_index,
+        COALESCE(
+          NULLIF(vtc.content_summary, ''),
+          NULLIF(vtc.raw_source_text, ''),
+          vtc.text
+        )                                      AS description,
+        COALESCE(vtc.start_seconds, 0)         AS start_seconds,
+        vtc.end_seconds                        AS end_seconds,
+        vtc.felt_needs                         AS themes,
+        vtc.demographics                       AS demographics,
+        vtc.spiritual_context                  AS spiritual_context,
         dub_mux.playback_id                    AS playback_id,
-        1 - (vsl.embedding <=> ${queryEmbedding}::vector) AS similarity,
-        vsl.embedding::text                    AS embedding_text
-      FROM video_scene_locale vsl
-      JOIN video_scene vs ON vs.id = vsl.video_scene_id
-      JOIN video v ON v.id = vs.video_id
+        1 - (vtc.embedding <=> ${queryEmbedding}::vector) AS similarity,
+        vtc.embedding::text                   AS embedding_text
+      FROM video_transcript_chunk vtc
+      JOIN video_transcript vt ON vt.id = vtc.transcript_id
+        AND vt.language = ${locale}
+      JOIN video v ON v.id = vt.video_id
         AND v.deleted_at IS NULL
       JOIN video_locale vl
         ON vl.video_id = v.id
@@ -231,15 +240,22 @@ export async function queryScenesSimilar(
           AND lg.bcp47 = ${locale}
         JOIN mux_video mv ON mv.id = vd.mux_video_id
           AND mv.playback_id IS NOT NULL
-        WHERE vd.video_edition_id = vs.video_edition_id
+        WHERE vd.video_edition_id = vt.video_edition_id
           AND vd.deleted_at IS NULL
         ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
         LIMIT 1
       ) dub_mux ON true
-      WHERE vsl.embedding IS NOT NULL
-        AND vsl.locale = ${locale}
-        AND vs.video_id <> ALL(${excludeIds}::text[])
-      ORDER BY vs.video_id, vsl.embedding <=> ${queryEmbedding}::vector
+      WHERE vtc.embedding IS NOT NULL
+        AND vtc.language = ${locale}
+        AND vt.video_id <> ALL(${excludeIds}::text[])
+        AND vt.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+        AND vt.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+        AND vt.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        AND vt.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        AND vt.embedding_transform_version IS NULL
+        AND vtc.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+        AND vtc.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+      ORDER BY vt.video_id, vtc.embedding <=> ${queryEmbedding}::vector
     ) sub
     ORDER BY sub.similarity DESC
     LIMIT ${limit}

--- a/apps/admin/src/services/scene-recommendations.service.ts
+++ b/apps/admin/src/services/scene-recommendations.service.ts
@@ -1,21 +1,22 @@
 /**
- * Scene-recommendations orchestrator (R5).
+ * Transcript-backed recommendations orchestrator for the legacy
+ * `sceneRecommendations` API shape.
  *
  * Shared service called by both the REST handler at
  * `/api/scene-embedding/recommendations` and the public Pothos query
- * `sceneRecommendations`. Port of cms's
- * `apps/cms/src/api/scene-embedding/services/recommender.ts#getRecommendations`.
+ * `sceneRecommendations`. The API name remains for cms/client parity, but
+ * feat-192 routes the backing signal through enriched transcript chunks.
  *
  * Two modes:
- *   - **Per-scene** (sceneIndex provided OR seed video has a single
- *     scene): run ONE similarity query against the seed embedding,
+ *   - **Per-chunk** (sceneIndex provided OR seed video has a single
+ *     transcript chunk): run ONE similarity query against the seed embedding,
  *     overfetch × `OVERFETCH_FACTOR`, dedup, slice to `limit`.
- *   - **Per-video** (sceneIndex omitted, seed video has ≥2 scenes):
- *     run one similarity query per scene, accumulate
+ *   - **Per-video** (sceneIndex omitted, seed video has ≥2 transcript chunks):
+ *     run one similarity query per chunk, accumulate
  *     best-similarity-per-candidate into a Map, sort, dedup, slice.
  *
  * `VideoNotFoundError` is thrown when the seed video cannot be resolved
- * or has no embedded scenes in the requested locale. REST maps this to
+ * or has no embedded transcript chunks in the requested locale. REST maps this to
  * 404. GraphQL soft-swallows to `[]` (matches cms's resolver).
  */
 

--- a/apps/admin/src/services/transcript-embedding-ingest.contract.test.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.contract.test.ts
@@ -31,12 +31,38 @@ type StoredChunk = {
   chunkIndex: number
   chunkId: string
   text: string
+  rawSourceText: string | null
+  embeddingInputText: string | null
+  feltNeeds: string[]
+  bibleVerses: string[]
+  contentSummary: string | null
+  tone: string | null
+  demographics: string[]
+  spiritualContext: string[]
+  extractionMetadata: Record<string, unknown> | null
   tokenCount: number
   startSeconds: number | null
   endSeconds: number | null
   model: string
   dimensions: number
   embeddingText: string
+}
+
+function parseJsonStringArray(value: string | null | undefined): string[] {
+  if (value == null) return []
+  const parsed = JSON.parse(value) as unknown
+  if (!Array.isArray(parsed)) return []
+  return parsed.map(String)
+}
+
+function parseBase64Json(
+  value: string | null | undefined,
+): Record<string, unknown> | null {
+  if (value == null) return null
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8")) as Record<
+    string,
+    unknown
+  >
 }
 
 function required(value: string | null | undefined): string {
@@ -125,7 +151,7 @@ function buildContractPrisma() {
       return [...transcripts.values()]
     }
 
-    if (sql.includes("WITH scene_source AS")) {
+    if (sql.includes("WITH transcript_source AS")) {
       return chunks.map((chunk) => {
         const transcript = transcripts.get(chunk.transcriptId)!
         return {
@@ -236,6 +262,15 @@ function buildContractPrisma() {
         chunkIndexesLiteral: string,
         chunkIdsLiteral: string,
         textsLiteral: string,
+        rawSourceTextsLiteral: string,
+        embeddingInputTextsLiteral: string,
+        feltNeedsJsonLiteral: string,
+        bibleVersesJsonLiteral: string,
+        contentSummariesLiteral: string,
+        tonesLiteral: string,
+        demographicsJsonLiteral: string,
+        spiritualContextJsonLiteral: string,
+        extractionMetadataBase64Literal: string,
         tokenCountsLiteral: string,
         startSecondsLiteral: string,
         endSecondsLiteral: string,
@@ -252,6 +287,19 @@ function buildContractPrisma() {
         const chunkIndexes = parsePgTextArray(chunkIndexesLiteral)
         const chunkIds = parsePgTextArray(chunkIdsLiteral)
         const texts = parsePgTextArray(textsLiteral)
+        const rawSourceTexts = parsePgTextArray(rawSourceTextsLiteral)
+        const embeddingInputTexts = parsePgTextArray(embeddingInputTextsLiteral)
+        const feltNeedsJson = parsePgTextArray(feltNeedsJsonLiteral)
+        const bibleVersesJson = parsePgTextArray(bibleVersesJsonLiteral)
+        const contentSummaries = parsePgTextArray(contentSummariesLiteral)
+        const tones = parsePgTextArray(tonesLiteral)
+        const demographicsJson = parsePgTextArray(demographicsJsonLiteral)
+        const spiritualContextJson = parsePgTextArray(
+          spiritualContextJsonLiteral,
+        )
+        const extractionMetadataBase64 = parsePgTextArray(
+          extractionMetadataBase64Literal,
+        )
         const tokenCounts = parsePgTextArray(tokenCountsLiteral)
         const startSeconds = parsePgTextArray(startSecondsLiteral)
         const endSeconds = parsePgTextArray(endSecondsLiteral)
@@ -267,6 +315,17 @@ function buildContractPrisma() {
             chunkIndex: Number(chunkIndexes[index]),
             chunkId: required(chunkIds[index]),
             text: required(texts[index]),
+            rawSourceText: rawSourceTexts[index] ?? null,
+            embeddingInputText: embeddingInputTexts[index] ?? null,
+            feltNeeds: parseJsonStringArray(feltNeedsJson[index]),
+            bibleVerses: parseJsonStringArray(bibleVersesJson[index]),
+            contentSummary: contentSummaries[index] ?? null,
+            tone: tones[index] ?? null,
+            demographics: parseJsonStringArray(demographicsJson[index]),
+            spiritualContext: parseJsonStringArray(spiritualContextJson[index]),
+            extractionMetadata: parseBase64Json(
+              extractionMetadataBase64[index],
+            ),
             tokenCount: Number(tokenCounts[index]),
             startSeconds:
               startSeconds[index] == null ? null : Number(startSeconds[index]),

--- a/apps/admin/src/services/transcript-embedding-ingest.service.test.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.service.test.ts
@@ -109,22 +109,94 @@ function payload(overrides?: Record<string, unknown>) {
 }
 
 function hashFor(body: ReturnType<typeof payload>): string {
+  const source = body.source as {
+    text?: string
+    segments?: unknown
+    kind?: string
+    artifactKey?: string
+    languageId?: string
+    languageSlug?: string
+    subtitleId?: string
+    format?: string
+    url?: string
+    provider?: string
+    generatedAt?: string
+  }
+  const hasV2SourceMetadata =
+    source.kind != null ||
+    source.languageId != null ||
+    source.languageSlug != null ||
+    source.subtitleId != null ||
+    source.format != null ||
+    source.url != null
+
   return _internals.sha256Json({
-    text: (body.source as { text?: string }).text ?? null,
-    segments: (body.source as { segments?: unknown }).segments ?? null,
+    text: source.text ?? null,
+    segments: source.segments ?? null,
+    ...(hasV2SourceMetadata
+      ? {
+          source: {
+            kind: source.kind ?? null,
+            artifactKey: source.artifactKey ?? null,
+            languageId: source.languageId ?? null,
+            languageSlug: source.languageSlug ?? null,
+            subtitleId: source.subtitleId ?? null,
+            format: source.format ?? null,
+            url: source.url ?? null,
+            provider: source.provider ?? null,
+            generatedAt: source.generatedAt ?? null,
+          },
+        }
+      : {}),
     chunks: (
       body.chunks as Array<{
         chunkIndex: number
         text: string
         startSeconds?: number
         endSeconds?: number
+        rawSourceText?: string
+        embeddingInputText?: string
+        feltNeeds?: string[]
+        bibleVerses?: string[]
+        contentSummary?: string
+        tone?: string
+        demographics?: string[]
+        spiritualContext?: string[]
+        extractionMetadata?: Record<string, unknown>
       }>
-    ).map((chunk) => ({
-      index: chunk.chunkIndex,
-      text: chunk.text,
-      startSeconds: chunk.startSeconds ?? null,
-      endSeconds: chunk.endSeconds ?? null,
-    })),
+    ).map((chunk) => {
+      const base = {
+        index: chunk.chunkIndex,
+        text: chunk.text,
+        startSeconds: chunk.startSeconds ?? null,
+        endSeconds: chunk.endSeconds ?? null,
+      }
+      const hasEnrichedFields =
+        chunk.rawSourceText != null ||
+        chunk.embeddingInputText != null ||
+        (chunk.feltNeeds?.length ?? 0) > 0 ||
+        (chunk.bibleVerses?.length ?? 0) > 0 ||
+        chunk.contentSummary != null ||
+        chunk.tone != null ||
+        (chunk.demographics?.length ?? 0) > 0 ||
+        (chunk.spiritualContext?.length ?? 0) > 0 ||
+        chunk.extractionMetadata != null
+
+      return hasEnrichedFields
+        ? {
+            ...base,
+            rawSourceText: chunk.rawSourceText ?? null,
+            embeddingInputText: chunk.embeddingInputText ?? null,
+            feltNeeds: chunk.feltNeeds ?? [],
+            bibleVerses: chunk.bibleVerses ?? [],
+            contentSummary: chunk.contentSummary ?? null,
+            tone: chunk.tone ?? null,
+            demographics: chunk.demographics ?? [],
+            spiritualContext: chunk.spiritualContext ?? [],
+            extractionMetadata: chunk.extractionMetadata ?? null,
+          }
+        : base
+    }),
   })
 }
 
@@ -173,6 +245,127 @@ describe("ingestTranscriptEmbeddings", () => {
         }),
       }),
     )
+  })
+
+  it("accepts and forwards v2 enriched transcript chunk fields", async () => {
+    const prisma = buildPrisma()
+    const body = payload({
+      source: {
+        text: "Jesus teaches beside the lake.",
+        segments: [
+          { start: 0, end: 2, text: "Jesus teaches beside the lake." },
+        ],
+        artifactKey: "admin-video-subtitle/sub-1.vtt",
+        kind: "subtitle",
+        languageId: "lang-en",
+        languageSlug: "english",
+        subtitleId: "sub-1",
+        format: "vtt",
+        url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+        provider: "admin-subtitle",
+        generatedAt: "2026-05-25T00:00:00.000Z",
+      },
+      chunks: [
+        {
+          chunkIndex: 0,
+          chunkId: "chunk-0",
+          text: "Jesus teaches beside the lake.",
+          rawSourceText: "Jesus teaches beside the lake.",
+          embeddingInputText:
+            "Time range: 00:00-00:02\nFelt needs: Hope\nSummary: Jesus teaches beside the lake.\nTranscript: Jesus teaches beside the lake.",
+          feltNeeds: ["Hope"],
+          bibleVerses: ["John 3:16"],
+          contentSummary: "Jesus teaches beside the lake.",
+          tone: "gentle",
+          demographics: ["seekers"],
+          spiritualContext: ["teaching"],
+          extractionMetadata: { extractor: "deterministic-test" },
+          tokenCount: 24,
+          startSeconds: 0,
+          endSeconds: 2,
+          embedding: new Array(1536).fill(0.01),
+        },
+      ],
+    })
+
+    const result = await ingestTranscriptEmbeddings(prisma as never, body)
+
+    expect(result.status).toBe("created")
+    expect(writeTranscriptEmbeddingPayloadMock).toHaveBeenCalledWith(
+      prisma,
+      expect.objectContaining({
+        chunks: [
+          expect.objectContaining({
+            rawSourceText: "Jesus teaches beside the lake.",
+            embeddingInputText: expect.stringContaining("Time range:"),
+            feltNeeds: ["Hope"],
+            bibleVerses: ["John 3:16"],
+            contentSummary: "Jesus teaches beside the lake.",
+            tone: "gentle",
+            demographics: ["seekers"],
+            spiritualContext: ["teaching"],
+            extractionMetadata: { extractor: "deterministic-test" },
+          }),
+        ],
+        provenance: expect.objectContaining({
+          sourceArtifactKey: "admin-video-subtitle/sub-1.vtt",
+          sourceKind: "subtitle",
+          sourceLanguageId: "lang-en",
+          sourceLanguageSlug: "english",
+          sourceSubtitleId: "sub-1",
+          sourceFormat: "vtt",
+          sourceUrl: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+          sourceProvider: "admin-subtitle",
+        }),
+      }),
+    )
+  })
+
+  it("rejects unsupported felt-needs values", async () => {
+    const prisma = buildPrisma()
+    const body = payload({
+      chunks: [
+        {
+          chunkIndex: 0,
+          chunkId: "chunk-0",
+          text: "Jesus teaches beside the lake.",
+          tokenCount: 6,
+          startSeconds: 0,
+          endSeconds: 2,
+          feltNeeds: ["Belonging"],
+          embedding: new Array(1536).fill(0.01),
+        },
+      ],
+    })
+
+    await expect(
+      ingestTranscriptEmbeddings(prisma as never, body),
+    ).rejects.toMatchObject({
+      code: "payload_invalid",
+    })
+    expect(writeTranscriptEmbeddingPayloadMock).not.toHaveBeenCalled()
+  })
+
+  it("includes enriched metadata in v2 source hashes", () => {
+    const base = payload({
+      source: {
+        ...(payload().source as object),
+        kind: "subtitle",
+        languageId: "lang-en",
+      },
+    })
+    const enriched = payload({
+      source: base.source as object,
+      chunks: [
+        {
+          ...((base.chunks as unknown[])[0] as object),
+          feltNeeds: ["Hope"],
+          embeddingInputText: "Felt needs: Hope\nTranscript: Jesus teaches.",
+        },
+      ],
+    })
+
+    expect(hashFor(base)).not.toEqual(hashFor(enriched))
   })
 
   it("returns unchanged and skips writes when default mode sees healthy matching provenance", async () => {

--- a/apps/admin/src/services/transcript-embedding-ingest.service.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.service.ts
@@ -38,6 +38,23 @@ const TranscriptSourceSegmentSchema = z
   })
   .strict()
 
+export const CANONICAL_FELT_NEEDS = [
+  "Acceptance",
+  "Anxiety",
+  "Depression",
+  "Fear/Power",
+  "Forgiveness",
+  "Guilt/Righteousness",
+  "Honor/Shame",
+  "Hope",
+  "Loneliness",
+  "Love",
+  "Security",
+  "Significance",
+] as const
+
+const FeltNeedSchema = z.enum(CANONICAL_FELT_NEEDS)
+
 const IngestChunkSchema = z
   .object({
     chunkIndex: z.number().int().nonnegative(),
@@ -46,6 +63,15 @@ const IngestChunkSchema = z
     tokenCount: z.number().int().nonnegative(),
     startSeconds: z.number().finite().nonnegative().optional(),
     endSeconds: z.number().finite().nonnegative().optional(),
+    rawSourceText: z.string().min(1).optional(),
+    embeddingInputText: z.string().min(1).optional(),
+    feltNeeds: z.array(FeltNeedSchema).default([]),
+    bibleVerses: z.array(z.string().min(1)).default([]),
+    contentSummary: z.string().min(1).optional(),
+    tone: z.string().min(1).optional(),
+    demographics: z.array(z.string().min(1)).default([]),
+    spiritualContext: z.array(z.string().min(1)).default([]),
+    extractionMetadata: z.record(z.string(), z.unknown()).optional(),
     embedding: z.array(z.number().finite()).min(1),
   })
   .strict()
@@ -64,6 +90,12 @@ export const TranscriptEmbeddingIngestPayloadSchema = z
         text: z.string().optional(),
         segments: z.array(TranscriptSourceSegmentSchema).optional(),
         artifactKey: z.string().min(1).optional(),
+        kind: z.enum(["subtitle", "manager-transcript"]).optional(),
+        languageId: z.string().min(1).optional(),
+        languageSlug: z.string().min(1).optional(),
+        subtitleId: z.string().min(1).optional(),
+        format: z.enum(["vtt", "srt"]).optional(),
+        url: z.string().min(1).optional(),
         provider: z.string().min(1).optional(),
         generatedAt: EmbeddingTimestampSchema.optional(),
         contentHash: z.string().min(1),
@@ -199,15 +231,65 @@ function sha256Json(value: unknown): string {
 }
 
 function sourceContentHash(payload: TranscriptEmbeddingIngestPayload): string {
+  const hasV2SourceMetadata =
+    payload.source.kind != null ||
+    payload.source.languageId != null ||
+    payload.source.languageSlug != null ||
+    payload.source.subtitleId != null ||
+    payload.source.format != null ||
+    payload.source.url != null
+
   const computed = sha256Json({
     text: payload.source.text ?? null,
     segments: payload.source.segments ?? null,
-    chunks: payload.chunks.map((chunk) => ({
-      index: chunk.chunkIndex,
-      text: chunk.text,
-      startSeconds: chunk.startSeconds ?? null,
-      endSeconds: chunk.endSeconds ?? null,
-    })),
+    ...(hasV2SourceMetadata
+      ? {
+          source: {
+            kind: payload.source.kind ?? null,
+            artifactKey: payload.source.artifactKey ?? null,
+            languageId: payload.source.languageId ?? null,
+            languageSlug: payload.source.languageSlug ?? null,
+            subtitleId: payload.source.subtitleId ?? null,
+            format: payload.source.format ?? null,
+            url: payload.source.url ?? null,
+            provider: payload.source.provider ?? null,
+            generatedAt: payload.source.generatedAt ?? null,
+          },
+        }
+      : {}),
+    chunks: payload.chunks.map((chunk) => {
+      const base = {
+        index: chunk.chunkIndex,
+        text: chunk.text,
+        startSeconds: chunk.startSeconds ?? null,
+        endSeconds: chunk.endSeconds ?? null,
+      }
+      const hasEnrichedFields =
+        chunk.rawSourceText != null ||
+        chunk.embeddingInputText != null ||
+        chunk.feltNeeds.length > 0 ||
+        chunk.bibleVerses.length > 0 ||
+        chunk.contentSummary != null ||
+        chunk.tone != null ||
+        chunk.demographics.length > 0 ||
+        chunk.spiritualContext.length > 0 ||
+        chunk.extractionMetadata != null
+
+      return hasEnrichedFields
+        ? {
+            ...base,
+            rawSourceText: chunk.rawSourceText ?? null,
+            embeddingInputText: chunk.embeddingInputText ?? null,
+            feltNeeds: chunk.feltNeeds,
+            bibleVerses: chunk.bibleVerses,
+            contentSummary: chunk.contentSummary ?? null,
+            tone: chunk.tone ?? null,
+            demographics: chunk.demographics,
+            spiritualContext: chunk.spiritualContext,
+            extractionMetadata: chunk.extractionMetadata ?? null,
+          }
+        : base
+    }),
   })
 
   if (payload.source.contentHash && payload.source.contentHash !== computed) {
@@ -495,6 +577,12 @@ async function writePayload(
         embeddingNativeDimensions: payload.model.nativeDimensions,
         embeddingTransformVersion: payload.model.transformVersion,
         sourceArtifactKey: payload.source.artifactKey,
+        sourceKind: payload.source.kind,
+        sourceLanguageId: payload.source.languageId,
+        sourceLanguageSlug: payload.source.languageSlug,
+        sourceSubtitleId: payload.source.subtitleId,
+        sourceFormat: payload.source.format,
+        sourceUrl: payload.source.url,
         sourceContentHash: hash,
         sourceProvider: payload.source.provider ?? payload.model.provider,
         sourceGeneratedAt: payload.source.generatedAt,
@@ -636,6 +724,7 @@ export async function ingestTranscriptEmbeddings(
 
 export const _internals = {
   sha256Json,
+  sourceContentHash,
   validateChunks,
   existingMatches,
 }

--- a/apps/admin/src/services/transcript-embedding.service.test.ts
+++ b/apps/admin/src/services/transcript-embedding.service.test.ts
@@ -305,6 +305,11 @@ describe("indexEditionTranscript", () => {
     ]
     const sql = strings.join("?")
     expect(sql).toContain("INSERT INTO video_transcript_chunk")
+    expect(sql).toContain("raw_source_text")
+    expect(sql).toContain("embedding_input_text")
+    expect(sql).toContain("felt_needs")
+    expect(sql).toContain("content_summary")
+    expect(sql).toContain("extraction_metadata")
     expect(sql).toContain("unnest(")
     expect(sql).toContain("::text[]")
     // Way A vector cast — per-row at the SELECT seam, NOT

--- a/apps/admin/src/services/transcript-embedding.service.ts
+++ b/apps/admin/src/services/transcript-embedding.service.ts
@@ -18,13 +18,14 @@
 // Stage 3 of the embed-backfill performance plan (feat-117) collapses
 // the per-chunk write loop into ONE bulk SQL statement per
 // `(video, edition, language)` target — `INSERT INTO
-// video_transcript_chunk … SELECT * FROM unnest(9 parallel arrays)
+// video_transcript_chunk … SELECT * FROM unnest(...) parallel arrays
 // ON CONFLICT (transcript_id, chunk_index) DO UPDATE`. Per-row Way A
 // `::vector(1536)` cast at the SELECT seam (NOT a `::vector(1536)[]`
 // parameter cast — that array-input parser is less-trodden code; Way A
 // keeps the cast at one site per row). See
 // docs/solutions/database-issues/pgvector-bulk-insert-on-conflict-pattern-20260505.md.
 
+import { Buffer } from "node:buffer"
 import { randomUUID } from "node:crypto"
 
 import { Prisma, type PrismaClient } from "@prisma/client"
@@ -100,6 +101,12 @@ export type TranscriptEmbeddingProvenance = {
   embeddingNativeDimensions?: number
   embeddingTransformVersion?: string
   sourceArtifactKey?: string
+  sourceKind?: string
+  sourceLanguageId?: string
+  sourceLanguageSlug?: string
+  sourceSubtitleId?: string
+  sourceFormat?: string
+  sourceUrl?: string
   sourceContentHash?: string
   sourceProvider?: string
   sourceGeneratedAt?: string
@@ -115,6 +122,15 @@ export type TranscriptEmbeddingPayloadChunk = {
   tokenCount: number
   startSeconds?: number
   endSeconds?: number
+  rawSourceText?: string
+  embeddingInputText?: string
+  feltNeeds?: string[]
+  bibleVerses?: string[]
+  contentSummary?: string
+  tone?: string
+  demographics?: string[]
+  spiritualContext?: string[]
+  extractionMetadata?: Record<string, unknown>
   embedding: number[]
 }
 
@@ -122,6 +138,15 @@ export type TranscriptEmbeddingArtifactChunk = {
   chunkId: string
   text: string
   embedding: number[]
+  rawSourceText?: string
+  embeddingInputText?: string
+  feltNeeds?: string[]
+  bibleVerses?: string[]
+  contentSummary?: string
+  tone?: string
+  demographics?: string[]
+  spiritualContext?: string[]
+  extractionMetadata?: Record<string, unknown>
   metadata: {
     tokenCount: number
     startTime?: number
@@ -276,6 +301,15 @@ function toEmbeddingsResult(
       chunkId: chunk.chunkId,
       text: chunk.text,
       embedding: chunk.embedding,
+      rawSourceText: chunk.rawSourceText,
+      embeddingInputText: chunk.embeddingInputText,
+      feltNeeds: chunk.feltNeeds,
+      bibleVerses: chunk.bibleVerses,
+      contentSummary: chunk.contentSummary,
+      tone: chunk.tone,
+      demographics: chunk.demographics,
+      spiritualContext: chunk.spiritualContext,
+      extractionMetadata: chunk.extractionMetadata,
       metadata: {
         tokenCount: chunk.tokenCount,
         ...(chunk.startSeconds == null
@@ -298,6 +332,10 @@ function toEmbeddingsResult(
       generatedAt: input.generatedAt,
     },
   }
+}
+
+function jsonToBase64(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64")
 }
 
 export async function writeTranscriptEmbeddingPayload(
@@ -426,6 +464,24 @@ export async function indexEditionTranscript(
             ...(input.provenance?.sourceArtifactKey
               ? { sourceArtifactKey: input.provenance.sourceArtifactKey }
               : {}),
+            ...(input.provenance?.sourceKind
+              ? { sourceKind: input.provenance.sourceKind }
+              : {}),
+            ...(input.provenance?.sourceLanguageId
+              ? { sourceLanguageId: input.provenance.sourceLanguageId }
+              : {}),
+            ...(input.provenance?.sourceLanguageSlug
+              ? { sourceLanguageSlug: input.provenance.sourceLanguageSlug }
+              : {}),
+            ...(input.provenance?.sourceSubtitleId
+              ? { sourceSubtitleId: input.provenance.sourceSubtitleId }
+              : {}),
+            ...(input.provenance?.sourceFormat
+              ? { sourceFormat: input.provenance.sourceFormat }
+              : {}),
+            ...(input.provenance?.sourceUrl
+              ? { sourceUrl: input.provenance.sourceUrl }
+              : {}),
             ...(input.provenance?.sourceContentHash
               ? { sourceContentHash: input.provenance.sourceContentHash }
               : {}),
@@ -469,6 +525,12 @@ export async function indexEditionTranscript(
             totalTokens: artifact.metadata.totalTokens,
             generatedAt: new Date(artifact.metadata.generatedAt),
             sourceArtifactKey: input.provenance?.sourceArtifactKey ?? null,
+            sourceKind: input.provenance?.sourceKind ?? null,
+            sourceLanguageId: input.provenance?.sourceLanguageId ?? null,
+            sourceLanguageSlug: input.provenance?.sourceLanguageSlug ?? null,
+            sourceSubtitleId: input.provenance?.sourceSubtitleId ?? null,
+            sourceFormat: input.provenance?.sourceFormat ?? null,
+            sourceUrl: input.provenance?.sourceUrl ?? null,
             sourceContentHash: input.provenance?.sourceContentHash ?? null,
             sourceProvider: input.provenance?.sourceProvider ?? null,
             sourceGeneratedAt: input.provenance?.sourceGeneratedAt
@@ -494,7 +556,7 @@ export async function indexEditionTranscript(
         chunksPruned = pruneResult.count
 
         // ─── Stage 3 (feat-117) — Bulk chunk INSERT … ON CONFLICT … DO UPDATE ─
-        // Build 12 parallel arrays. text[] params unfold via
+        // Build parallel arrays. text[] params unfold via
         // `u.<col>::<type>` per-row casts at the SELECT seam (Way A
         // discipline). The vector cast lives on the SELECT seam too —
         // `u.embedding_text::vector(1536)` — NOT `::vector(1536)[]` on
@@ -506,6 +568,33 @@ export async function indexEditionTranscript(
         const chunkIndexes = artifact.chunks.map((_, i) => String(i))
         const chunkIds = artifact.chunks.map((c) => c.chunkId)
         const texts = artifact.chunks.map((c) => c.text)
+        const rawSourceTexts = artifact.chunks.map(
+          (c) => c.rawSourceText ?? null,
+        )
+        const embeddingInputTexts = artifact.chunks.map(
+          (c) => c.embeddingInputText ?? null,
+        )
+        const feltNeedsJson = artifact.chunks.map((c) =>
+          JSON.stringify(c.feltNeeds ?? []),
+        )
+        const bibleVersesJson = artifact.chunks.map((c) =>
+          JSON.stringify(c.bibleVerses ?? []),
+        )
+        const contentSummaries = artifact.chunks.map(
+          (c) => c.contentSummary ?? null,
+        )
+        const tones = artifact.chunks.map((c) => c.tone ?? null)
+        const demographicsJson = artifact.chunks.map((c) =>
+          JSON.stringify(c.demographics ?? []),
+        )
+        const spiritualContextJson = artifact.chunks.map((c) =>
+          JSON.stringify(c.spiritualContext ?? []),
+        )
+        const extractionMetadataBase64 = artifact.chunks.map((c) =>
+          c.extractionMetadata == null
+            ? null
+            : jsonToBase64(c.extractionMetadata),
+        )
         const tokenCounts = artifact.chunks.map((c) =>
           String(c.metadata.tokenCount),
         )
@@ -530,6 +619,24 @@ export async function indexEditionTranscript(
             { name: "chunkIndexes", length: chunkIndexes.length },
             { name: "chunkIds", length: chunkIds.length },
             { name: "texts", length: texts.length },
+            { name: "rawSourceTexts", length: rawSourceTexts.length },
+            {
+              name: "embeddingInputTexts",
+              length: embeddingInputTexts.length,
+            },
+            { name: "feltNeedsJson", length: feltNeedsJson.length },
+            { name: "bibleVersesJson", length: bibleVersesJson.length },
+            { name: "contentSummaries", length: contentSummaries.length },
+            { name: "tones", length: tones.length },
+            { name: "demographicsJson", length: demographicsJson.length },
+            {
+              name: "spiritualContextJson",
+              length: spiritualContextJson.length,
+            },
+            {
+              name: "extractionMetadataBase64",
+              length: extractionMetadataBase64.length,
+            },
             { name: "tokenCounts", length: tokenCounts.length },
             { name: "startSeconds", length: startSeconds.length },
             { name: "endSeconds", length: endSeconds.length },
@@ -547,7 +654,10 @@ export async function indexEditionTranscript(
         const writeAffected = await tx.$executeRaw`
           INSERT INTO video_transcript_chunk (
             id, transcript_id, language, chunk_index, chunk_id,
-            text, token_count, start_seconds, end_seconds,
+            text, raw_source_text, embedding_input_text,
+            felt_needs, bible_verses, content_summary, tone,
+            demographics, spiritual_context, extraction_metadata,
+            token_count, start_seconds, end_seconds,
             model, dimensions, embedding,
             created_at, updated_at
           )
@@ -558,6 +668,18 @@ export async function indexEditionTranscript(
             u.chunk_index::int,
             u.chunk_id,
             u.text,
+            u.raw_source_text,
+            u.embedding_input_text,
+            ARRAY(SELECT jsonb_array_elements_text(u.felt_needs_json::jsonb)),
+            ARRAY(SELECT jsonb_array_elements_text(u.bible_verses_json::jsonb)),
+            u.content_summary,
+            u.tone,
+            ARRAY(SELECT jsonb_array_elements_text(u.demographics_json::jsonb)),
+            ARRAY(SELECT jsonb_array_elements_text(u.spiritual_context_json::jsonb)),
+            CASE
+              WHEN u.extraction_metadata_base64 IS NULL THEN NULL
+              ELSE convert_from(decode(u.extraction_metadata_base64, 'base64'), 'UTF8')::jsonb
+            END,
             u.token_count::int,
             u.start_seconds::double precision,
             u.end_seconds::double precision,
@@ -573,6 +695,15 @@ export async function indexEditionTranscript(
             ${toPgArray(chunkIndexes)}::text[],
             ${toPgArray(chunkIds)}::text[],
             ${toPgArray(texts)}::text[],
+            ${toPgArray(rawSourceTexts)}::text[],
+            ${toPgArray(embeddingInputTexts)}::text[],
+            ${toPgArray(feltNeedsJson)}::text[],
+            ${toPgArray(bibleVersesJson)}::text[],
+            ${toPgArray(contentSummaries)}::text[],
+            ${toPgArray(tones)}::text[],
+            ${toPgArray(demographicsJson)}::text[],
+            ${toPgArray(spiritualContextJson)}::text[],
+            ${toPgArray(extractionMetadataBase64)}::text[],
             ${toPgArray(tokenCounts)}::text[],
             ${toPgArray(startSeconds)}::text[],
             ${toPgArray(endSeconds)}::text[],
@@ -581,7 +712,10 @@ export async function indexEditionTranscript(
             ${toPgArray(vectorTexts)}::text[]
           ) AS u(
             id, transcript_id, language, chunk_index, chunk_id,
-            text, token_count, start_seconds, end_seconds,
+            text, raw_source_text, embedding_input_text,
+            felt_needs_json, bible_verses_json, content_summary, tone,
+            demographics_json, spiritual_context_json, extraction_metadata_base64,
+            token_count, start_seconds, end_seconds,
             model, dimensions, embedding_text
           )
           ON CONFLICT (transcript_id, chunk_index)
@@ -589,6 +723,15 @@ export async function indexEditionTranscript(
             language      = EXCLUDED.language,
             chunk_id      = EXCLUDED.chunk_id,
             text          = EXCLUDED.text,
+            raw_source_text = EXCLUDED.raw_source_text,
+            embedding_input_text = EXCLUDED.embedding_input_text,
+            felt_needs    = EXCLUDED.felt_needs,
+            bible_verses  = EXCLUDED.bible_verses,
+            content_summary = EXCLUDED.content_summary,
+            tone          = EXCLUDED.tone,
+            demographics  = EXCLUDED.demographics,
+            spiritual_context = EXCLUDED.spiritual_context,
+            extraction_metadata = EXCLUDED.extraction_metadata,
             token_count   = EXCLUDED.token_count,
             start_seconds = EXCLUDED.start_seconds,
             end_seconds   = EXCLUDED.end_seconds,

--- a/apps/admin/src/services/transcript-source-resolver.service.test.ts
+++ b/apps/admin/src/services/transcript-source-resolver.service.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  resolveSubtitleTranscriptSource,
+  _internals,
+} from "@/services/transcript-source-resolver.service"
+
+const target = {
+  videoId: "v-1",
+  videoEditionId: "e-1",
+  coreId: "core-1",
+  cmsVideoId: 42,
+  language: "en",
+  languageId: "lang-en",
+  languageSlug: "english",
+  hasSubtitle: true,
+  hasDub: true,
+  isPrimaryLanguage: true,
+}
+
+function prismaWithSubtitles(subtitles: unknown[]) {
+  return {
+    videoSubtitle: {
+      findMany: vi.fn(async () => subtitles),
+    },
+  }
+}
+
+describe("resolveSubtitleTranscriptSource", () => {
+  it("resolves a VTT subtitle into timed transcript source", async () => {
+    const prisma = prismaWithSubtitles([
+      {
+        id: "sub-1",
+        languageId: "lang-en",
+        primary: true,
+        vttSrc: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+        srtSrc: null,
+        syncedAt: new Date("2026-06-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-06-02T00:00:00.000Z"),
+        language: { bcp47: "en", slug: "english" },
+      },
+    ])
+    const fetchImpl = vi.fn(async () => {
+      return new Response(
+        `WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+<v Jesus>Hello &amp; peace.
+`,
+      )
+    })
+
+    const result = await resolveSubtitleTranscriptSource(
+      prisma as never,
+      target,
+      { fetchImpl },
+    )
+
+    expect(result).toMatchObject({
+      status: "resolved",
+      source: {
+        sourceKind: "subtitle",
+        transcript: {
+          text: "Hello & peace.",
+          artifactKey: "admin-video-subtitle/sub-1.vtt",
+          provider: "admin-subtitle",
+          generatedAt: "2026-06-01T00:00:00.000Z",
+        },
+        provenance: {
+          sourceKind: "subtitle",
+          sourceKey: "admin-video-subtitle/sub-1.vtt",
+          language: "en",
+          languageId: "lang-en",
+          languageSlug: "english",
+          subtitleId: "sub-1",
+          format: "vtt",
+        },
+      },
+    })
+    expect(
+      result.status === "resolved" && result.source.transcript.segments,
+    ).toEqual([{ start: 0, end: 2, text: "Hello & peace." }])
+  })
+
+  it("falls through to SRT when no VTT URL exists", async () => {
+    const prisma = prismaWithSubtitles([
+      {
+        id: "sub-2",
+        languageId: "lang-en",
+        primary: false,
+        vttSrc: null,
+        srtSrc: "https://api-media-core.jesusfilm.org/subtitles/en.srt",
+        syncedAt: null,
+        updatedAt: new Date("2026-06-02T00:00:00.000Z"),
+        language: { bcp47: "en", slug: "english" },
+      },
+    ])
+    const fetchImpl = vi.fn(async () => {
+      return new Response(`1
+00:00:01,000 --> 00:00:03,500
+Peace be with you.
+`)
+    })
+
+    const result = await resolveSubtitleTranscriptSource(
+      prisma as never,
+      target,
+      { fetchImpl },
+    )
+
+    expect(result).toMatchObject({
+      status: "resolved",
+      source: {
+        transcript: {
+          text: "Peace be with you.",
+          artifactKey: "admin-video-subtitle/sub-2.srt",
+        },
+      },
+    })
+    expect(
+      result.status === "resolved" && result.source.transcript.segments,
+    ).toEqual([{ start: 1, end: 3.5, text: "Peace be with you." }])
+  })
+
+  it("returns typed gaps for missing or empty subtitles", async () => {
+    await expect(
+      resolveSubtitleTranscriptSource(prismaWithSubtitles([]) as never, target),
+    ).resolves.toMatchObject({
+      status: "gap",
+      gap: { reason: "subtitle_missing" },
+    })
+
+    await expect(
+      resolveSubtitleTranscriptSource(
+        prismaWithSubtitles([
+          {
+            id: "sub-empty",
+            languageId: "lang-en",
+            primary: true,
+            vttSrc: "https://api-media-core.jesusfilm.org/empty.vtt",
+            srtSrc: null,
+            syncedAt: null,
+            updatedAt: new Date("2026-06-02T00:00:00.000Z"),
+            language: { bcp47: "en", slug: "english" },
+          },
+        ]) as never,
+        target,
+        { fetchImpl: vi.fn(async () => new Response("WEBVTT\n\n")) },
+      ),
+    ).resolves.toMatchObject({
+      status: "gap",
+      gap: { reason: "subtitle_empty", subtitleId: "sub-empty" },
+    })
+  })
+})
+
+describe("transcript timed-text fetch guards", () => {
+  it("allows known subtitle delivery hosts", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(`WEBVTT
+
+00:00:00.000 --> 00:00:01.000
+Peace.
+`)
+    })
+
+    await expect(
+      _internals.fetchTimedTextContent(
+        "https://stream.mux.com/playback/text/track-en.vtt",
+        { fetchImpl },
+      ),
+    ).resolves.toContain("Peace.")
+  })
+
+  it("rejects untrusted hosts and unsafe redirects", async () => {
+    await expect(
+      _internals.fetchTimedTextContent("https://evil.test/sub.vtt", {
+        fetchImpl: vi.fn(),
+      }),
+    ).rejects.toThrow(/untrusted subtitle URL/)
+
+    const fetchImpl = vi.fn(async () => {
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.test/sub.vtt" },
+      })
+    })
+
+    await expect(
+      _internals.fetchTimedTextContent(
+        "https://api-media-core.jesusfilm.org/sub.vtt",
+        { fetchImpl },
+      ),
+    ).rejects.toThrow(/untrusted subtitle URL/)
+  })
+})

--- a/apps/admin/src/services/transcript-source-resolver.service.ts
+++ b/apps/admin/src/services/transcript-source-resolver.service.ts
@@ -1,0 +1,428 @@
+import { createHash } from "node:crypto"
+import type { PrismaClient } from "@prisma/client"
+
+const SUBTITLE_FETCH_TIMEOUT_MS = 15_000
+const SUBTITLE_MAX_BYTES = 5 * 1024 * 1024
+const MAX_REDIRECTS = 3
+const TRUSTED_SUBTITLE_HOSTS = ["jesusfilm.org", "stream.mux.com"] as const
+
+export type TranscriptTimedTextFormat = "vtt" | "srt"
+
+export type TranscriptSourceResolverTarget = {
+  videoId: string
+  videoEditionId: string
+  coreId: string
+  cmsVideoId: number
+  language: string
+  languageId?: string | null
+  languageSlug?: string | null
+  hasSubtitle?: boolean
+  hasDub?: boolean
+  isPrimaryLanguage?: boolean
+}
+
+export type TranscriptSourceSegment = {
+  start: number
+  end: number
+  text: string
+}
+
+export type ResolvedTranscriptEmbeddingSource = {
+  sourceKind: "subtitle" | "manager-transcript"
+  transcript: {
+    text: string
+    segments: TranscriptSourceSegment[]
+    artifactKey: string
+    kind: "subtitle" | "manager-transcript"
+    languageId?: string | null
+    languageSlug?: string | null
+    subtitleId?: string
+    format?: TranscriptTimedTextFormat
+    url?: string
+    provider?: string
+    generatedAt?: string
+  }
+  provenance: {
+    sourceKind: "subtitle" | "manager-transcript"
+    sourceKey: string
+    contentHash?: string
+    language: string
+    languageId?: string | null
+    languageSlug?: string | null
+    subtitleId?: string
+    format?: TranscriptTimedTextFormat
+    url?: string
+  }
+}
+
+export type TranscriptSourceGapReason =
+  | "subtitle_missing"
+  | "subtitle_without_timed_text"
+  | "subtitle_fetch_failed"
+  | "subtitle_empty"
+
+export type TranscriptSourceGap = {
+  reason: TranscriptSourceGapReason
+  sourceKind: "subtitle"
+  language: string
+  languageId?: string | null
+  languageSlug?: string | null
+  subtitleId?: string
+  format?: TranscriptTimedTextFormat
+  url?: string
+  detail?: string
+}
+
+export type SubtitleTranscriptSourceResolution =
+  | { status: "resolved"; source: ResolvedTranscriptEmbeddingSource }
+  | { status: "gap"; gap: TranscriptSourceGap }
+
+export type ResolveSubtitleTranscriptSourceOptions = {
+  fetchImpl?: typeof fetch
+  timeoutMs?: number
+}
+
+class SubtitleFetchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "SubtitleFetchError"
+  }
+}
+
+function isTrustedSubtitleHost(hostname: string): boolean {
+  return TRUSTED_SUBTITLE_HOSTS.some(
+    (host) => hostname === host || hostname.endsWith(`.${host}`),
+  )
+}
+
+function assertTrustedSubtitleUrl(value: string): URL {
+  const url = new URL(value)
+  if (url.protocol !== "https:" || !isTrustedSubtitleHost(url.hostname)) {
+    throw new SubtitleFetchError(
+      `untrusted subtitle URL hostname: ${url.hostname}`,
+    )
+  }
+  return url
+}
+
+function safeUrlForStorage(value: string): string {
+  const url = new URL(value)
+  url.username = ""
+  url.password = ""
+  url.hash = ""
+  return url.toString()
+}
+
+async function fetchTimedTextContent(
+  sourceUrl: string,
+  options: ResolveSubtitleTranscriptSourceOptions,
+): Promise<string> {
+  let currentUrl = assertTrustedSubtitleUrl(sourceUrl)
+  const fetchImpl = options.fetchImpl ?? fetch
+
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+    let response: Response
+    try {
+      response = await fetchImpl(currentUrl, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(
+          options.timeoutMs ?? SUBTITLE_FETCH_TIMEOUT_MS,
+        ),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new SubtitleFetchError(`failed to fetch subtitle: ${message}`)
+    }
+
+    if (
+      response.status >= 300 &&
+      response.status < 400 &&
+      response.headers.has("location")
+    ) {
+      const location = response.headers.get("location")!
+      currentUrl = assertTrustedSubtitleUrl(
+        new URL(location, currentUrl).toString(),
+      )
+      continue
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      throw new SubtitleFetchError("subtitle redirect missing location header")
+    }
+
+    if (!response.ok) {
+      throw new SubtitleFetchError(
+        `subtitle fetch failed with status ${response.status}`,
+      )
+    }
+
+    const contentLength = response.headers.get("content-length")
+    if (contentLength && Number(contentLength) > SUBTITLE_MAX_BYTES) {
+      throw new SubtitleFetchError(
+        `subtitle response too large: ${contentLength} bytes`,
+      )
+    }
+
+    const content = await response.text()
+    if (content.length > SUBTITLE_MAX_BYTES) {
+      throw new SubtitleFetchError(
+        `subtitle content too large: ${content.length} bytes`,
+      )
+    }
+
+    return content
+  }
+
+  throw new SubtitleFetchError("subtitle redirect limit exceeded")
+}
+
+function parseTimestamp(value: string): number {
+  const parts = value.trim().replace(",", ".").split(":")
+  if (parts.length < 2 || parts.length > 3) return Number.NaN
+
+  const seconds = Number.parseFloat(parts.pop() ?? "")
+  const minutes = Number.parseInt(parts.pop() ?? "", 10)
+  const hours = parts.length === 1 ? Number.parseInt(parts.pop() ?? "", 10) : 0
+
+  if (
+    !Number.isFinite(seconds) ||
+    !Number.isFinite(minutes) ||
+    !Number.isFinite(hours)
+  ) {
+    return Number.NaN
+  }
+
+  return hours * 3600 + minutes * 60 + seconds
+}
+
+function cleanCueText(value: string): string {
+  let cleaned = value.trim()
+  let previous = ""
+  while (cleaned !== previous) {
+    previous = cleaned
+    cleaned = cleaned.replace(/<[^>]+>/g, "")
+  }
+  return cleaned
+    .replace(/\{\\[^}]+}/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function parseTimedText(
+  content: string,
+  format: TranscriptTimedTextFormat,
+): TranscriptSourceSegment[] {
+  const lines = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")
+  const segments: TranscriptSourceSegment[] = []
+  let index = 0
+  let skippingBlock = false
+
+  while (index < lines.length) {
+    const line = lines[index]?.trim() ?? ""
+
+    if (format === "vtt" && /^(NOTE|STYLE|REGION)\b/.test(line)) {
+      skippingBlock = true
+      index += 1
+      continue
+    }
+    if (skippingBlock) {
+      if (!line) skippingBlock = false
+      index += 1
+      continue
+    }
+
+    if (!line || line === "WEBVTT" || /^\d+$/.test(line)) {
+      index += 1
+      continue
+    }
+
+    if (!line.includes("-->")) {
+      index += 1
+      continue
+    }
+
+    const [rawStart, rawEnd] = line.split("-->", 2)
+    const start = parseTimestamp(rawStart ?? "")
+    const end = parseTimestamp((rawEnd ?? "").trim().split(/\s+/)[0] ?? "")
+    index += 1
+
+    const textLines: string[] = []
+    while (index < lines.length) {
+      const cueLine = lines[index]?.trim() ?? ""
+      if (!cueLine) break
+      textLines.push(cueLine)
+      index += 1
+    }
+
+    const text = cleanCueText(textLines.join(" "))
+    if (
+      text &&
+      Number.isFinite(start) &&
+      Number.isFinite(end) &&
+      end >= start
+    ) {
+      segments.push({ start, end, text })
+    }
+  }
+
+  return segments
+}
+
+function sha256Json(value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(value))
+    .digest("hex")}`
+}
+
+function gap(
+  target: TranscriptSourceResolverTarget,
+  reason: TranscriptSourceGapReason,
+  details: Partial<TranscriptSourceGap> = {},
+): SubtitleTranscriptSourceResolution {
+  return {
+    status: "gap",
+    gap: {
+      reason,
+      sourceKind: "subtitle",
+      language: target.language,
+      languageId: target.languageId,
+      languageSlug: target.languageSlug,
+      ...details,
+    },
+  }
+}
+
+function selectTimedTextSource(subtitle: {
+  vttSrc: string | null
+  srtSrc: string | null
+}): { format: TranscriptTimedTextFormat; url: string } | null {
+  const vttSrc = subtitle.vttSrc?.trim()
+  if (vttSrc) return { format: "vtt", url: vttSrc }
+
+  const srtSrc = subtitle.srtSrc?.trim()
+  if (srtSrc) return { format: "srt", url: srtSrc }
+
+  return null
+}
+
+export async function resolveSubtitleTranscriptSource(
+  prisma: PrismaClient,
+  target: TranscriptSourceResolverTarget,
+  options: ResolveSubtitleTranscriptSourceOptions = {},
+): Promise<SubtitleTranscriptSourceResolution> {
+  const languageFilter = target.languageId
+    ? { languageId: target.languageId }
+    : { language: { bcp47: target.language, deletedAt: null } }
+
+  const subtitles = await prisma.videoSubtitle.findMany({
+    where: {
+      videoEditionId: target.videoEditionId,
+      deletedAt: null,
+      ...languageFilter,
+    },
+    orderBy: [{ primary: "desc" }, { updatedAt: "desc" }, { id: "asc" }],
+    select: {
+      id: true,
+      languageId: true,
+      primary: true,
+      vttSrc: true,
+      srtSrc: true,
+      syncedAt: true,
+      updatedAt: true,
+      language: {
+        select: {
+          bcp47: true,
+          slug: true,
+        },
+      },
+    },
+  })
+
+  if (subtitles.length === 0) {
+    return gap(target, "subtitle_missing")
+  }
+
+  for (const subtitle of subtitles) {
+    const selected = selectTimedTextSource(subtitle)
+    if (!selected) continue
+
+    let content: string
+    try {
+      content = await fetchTimedTextContent(selected.url, options)
+    } catch (error) {
+      return gap(target, "subtitle_fetch_failed", {
+        subtitleId: subtitle.id,
+        format: selected.format,
+        url: safeUrlForStorage(selected.url),
+        detail: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    const segments = parseTimedText(content, selected.format)
+    const text = segments
+      .map((segment) => segment.text)
+      .join(" ")
+      .trim()
+
+    if (!text || segments.length === 0) {
+      return gap(target, "subtitle_empty", {
+        subtitleId: subtitle.id,
+        format: selected.format,
+        url: safeUrlForStorage(selected.url),
+      })
+    }
+
+    const sourceKey = `admin-video-subtitle/${subtitle.id}.${selected.format}`
+    const generatedAt =
+      subtitle.syncedAt?.toISOString() ?? subtitle.updatedAt.toISOString()
+
+    return {
+      status: "resolved",
+      source: {
+        sourceKind: "subtitle",
+        transcript: {
+          text,
+          segments,
+          artifactKey: sourceKey,
+          kind: "subtitle",
+          languageId: subtitle.languageId ?? target.languageId,
+          languageSlug: subtitle.language?.slug ?? target.languageSlug,
+          subtitleId: subtitle.id,
+          format: selected.format,
+          url: safeUrlForStorage(selected.url),
+          provider: "admin-subtitle",
+          generatedAt,
+        },
+        provenance: {
+          sourceKind: "subtitle",
+          sourceKey,
+          contentHash: sha256Json({
+            sourceKind: "subtitle",
+            subtitleId: subtitle.id,
+            format: selected.format,
+            text,
+            segments,
+          }),
+          language: subtitle.language?.bcp47 ?? target.language,
+          languageId: subtitle.languageId ?? target.languageId,
+          languageSlug: subtitle.language?.slug ?? target.languageSlug,
+          subtitleId: subtitle.id,
+          format: selected.format,
+          url: safeUrlForStorage(selected.url),
+        },
+      },
+    }
+  }
+
+  return gap(target, "subtitle_without_timed_text")
+}
+
+export const _internals = {
+  fetchTimedTextContent,
+  parseTimedText,
+}

--- a/apps/admin/src/workflows/_steps/resolve-transcript-source.ts
+++ b/apps/admin/src/workflows/_steps/resolve-transcript-source.ts
@@ -1,0 +1,20 @@
+import { prisma } from "@/db/client"
+import {
+  resolveSubtitleTranscriptSource,
+  type SubtitleTranscriptSourceResolution,
+  type TranscriptSourceResolverTarget,
+} from "@/services/transcript-source-resolver.service"
+
+/**
+ * Resolve Admin/Core subtitle timed text for one transcript embedding target.
+ *
+ * Kept outside the workflow file because the resolver performs guarded network
+ * fetches and parsing work; useworkflow should journal the resolved source or
+ * typed gap rather than replaying remote subtitle reads from workflow scope.
+ */
+export async function stepResolveSubtitleTranscriptSource(
+  target: TranscriptSourceResolverTarget,
+): Promise<SubtitleTranscriptSourceResolution> {
+  "use step"
+  return resolveSubtitleTranscriptSource(prisma, target)
+}

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
@@ -9,6 +9,9 @@ vi.mock("@/config/env", () => ({
 vi.mock("@/db/client", () => {
   const mock = {
     $queryRaw: vi.fn(async () => []),
+    videoSubtitle: {
+      findMany: vi.fn(async () => []),
+    },
   }
   return { prisma: mock, syncPrisma: mock }
 })
@@ -72,18 +75,62 @@ function row(
   editionId: string,
   coreId: string,
   bcp47: string,
+  overrides: Partial<{
+    languageId: string
+    languageSlug: string | null
+    hasSubtitle: boolean
+    hasDub: boolean
+    isPrimaryLanguage: boolean
+  }> = {},
 ) {
   return {
     video_id: videoId,
     video_edition_id: editionId,
     core_id: coreId,
+    language_id: overrides.languageId ?? `lang-${bcp47}`,
     bcp47,
+    slug: overrides.languageSlug ?? bcp47,
+    has_subtitle: overrides.hasSubtitle ?? false,
+    has_dub: overrides.hasDub ?? false,
+    is_primary_language: overrides.isPrimaryLanguage ?? true,
+  }
+}
+
+function target(
+  videoId: string,
+  editionId: string,
+  coreId: string,
+  cmsVideoId: number,
+  language: string,
+) {
+  return {
+    videoId,
+    videoEditionId: editionId,
+    coreId,
+    cmsVideoId,
+    language,
+    languageId: `lang-${language}`,
+    languageSlug: language,
+    hasSubtitle: false,
+    hasDub: false,
+    isPrimaryLanguage: true,
   }
 }
 
 describe("runTranscriptEmbeddingBackfill", () => {
   beforeEach(() => {
     ;(prisma as unknown as PrismaStub).$queryRaw.mockReset()
+    ;(
+      prisma as unknown as {
+        videoSubtitle: { findMany: ReturnType<typeof vi.fn> }
+      }
+    ).videoSubtitle.findMany.mockReset()
+    ;(
+      prisma as unknown as {
+        videoSubtitle: { findMany: ReturnType<typeof vi.fn> }
+      }
+    ).videoSubtitle.findMany.mockResolvedValue([])
+    vi.unstubAllGlobals()
     vi.mocked(readTranscriptSourceArtifact).mockReset()
     vi.mocked(readTranscriptSourceArtifact).mockResolvedValue(STUB_TRANSCRIPT)
     vi.mocked(launchMastraTranscriptEmbedding).mockReset()
@@ -122,7 +169,86 @@ describe("runTranscriptEmbeddingBackfill", () => {
       },
       language: "en",
       cmsVideoId: 1,
-      transcript: STUB_TRANSCRIPT,
+      transcript: {
+        text: STUB_TRANSCRIPT.text,
+        segments: STUB_TRANSCRIPT.segments,
+        artifactKey: "1/transcript.json",
+        kind: "manager-transcript",
+        languageId: "lang-en",
+        languageSlug: "en",
+        provider: STUB_TRANSCRIPT.resolvedProvider,
+      },
+      mode: "idempotent",
+    })
+  })
+
+  it("uses exact Admin subtitle timed text before Manager transcript fallback", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
+      row("v-a", "e-a", "core-a", "en", {
+        languageId: "lang-en",
+        languageSlug: "english",
+        hasSubtitle: true,
+        hasDub: true,
+      }),
+    ])
+    ;(
+      prisma as unknown as {
+        videoSubtitle: { findMany: ReturnType<typeof vi.fn> }
+      }
+    ).videoSubtitle.findMany.mockResolvedValueOnce([
+      {
+        id: "sub-1",
+        languageId: "lang-en",
+        primary: true,
+        vttSrc: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+        srtSrc: null,
+        syncedAt: new Date("2026-06-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-06-02T00:00:00.000Z"),
+        language: { bcp47: "en", slug: "english" },
+      },
+    ])
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(`WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+Subtitle transcript text.
+`)
+      }),
+    )
+
+    const report = await runTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.succeeded).toBe(1)
+    expect(report.outcomes[0]).toMatchObject({
+      status: "succeeded",
+      sourceKind: "subtitle",
+    })
+    expect(readTranscriptSourceArtifact).not.toHaveBeenCalled()
+    expect(launchMastraTranscriptEmbedding).toHaveBeenCalledWith({
+      target: {
+        videoId: "v-a",
+        videoEditionId: "e-a",
+        coreId: "core-a",
+      },
+      language: "en",
+      cmsVideoId: 1,
+      transcript: {
+        text: "Subtitle transcript text.",
+        segments: [{ start: 0, end: 2, text: "Subtitle transcript text." }],
+        artifactKey: "admin-video-subtitle/sub-1.vtt",
+        kind: "subtitle",
+        languageId: "lang-en",
+        languageSlug: "english",
+        subtitleId: "sub-1",
+        format: "vtt",
+        url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+        provider: "admin-subtitle",
+        generatedAt: "2026-06-01T00:00:00.000Z",
+      },
       mode: "idempotent",
     })
   })
@@ -191,6 +317,45 @@ describe("runTranscriptEmbeddingBackfill", () => {
     expect(report.missingArtifacts).toEqual([
       { assetId: 1, coreId: "core-a", kind: "transcript" },
     ])
+  })
+
+  it("reports dub-only targets without timed text as source gaps when Manager fallback is absent", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
+      row("v-a", "e-a", "core-a", "es", {
+        languageId: "lang-es",
+        languageSlug: "spanish",
+        hasDub: true,
+        hasSubtitle: false,
+        isPrimaryLanguage: false,
+      }),
+    ])
+    vi.mocked(readTranscriptSourceArtifact).mockRejectedValueOnce(
+      new ManagerArtifactError(
+        "artifact_missing",
+        "transcript artifact not found for assetId=1",
+      ),
+    )
+
+    const report = await runTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.skipped).toBe(1)
+    expect(report.sourceGaps).toEqual([
+      {
+        assetId: 1,
+        coreId: "core-a",
+        videoId: "v-a",
+        videoEditionId: "e-a",
+        language: "es",
+        languageId: "lang-es",
+        languageSlug: "spanish",
+        reason: "dub_without_timed_text",
+        subtitleReason: "subtitle_missing",
+        sourceKind: "transcript",
+      },
+    ])
+    expect(launchMastraTranscriptEmbedding).not.toHaveBeenCalled()
   })
 
   it("classifies invalid transcript source and Mastra product failures as failed outcomes", async () => {
@@ -317,27 +482,9 @@ describe("runTranscriptEmbeddingBackfill", () => {
 describe("groupTargetsByVideoEdition", () => {
   it("groups targets by (video, edition) preserving language order", () => {
     const groups = _internals.groupTargetsByVideoEdition([
-      {
-        videoId: "v-a",
-        videoEditionId: "e-a",
-        coreId: "core-a",
-        cmsVideoId: 1,
-        language: "en",
-      },
-      {
-        videoId: "v-a",
-        videoEditionId: "e-a",
-        coreId: "core-a",
-        cmsVideoId: 1,
-        language: "es",
-      },
-      {
-        videoId: "v-b",
-        videoEditionId: "e-b",
-        coreId: "core-b",
-        cmsVideoId: 2,
-        language: "en",
-      },
+      target("v-a", "e-a", "core-a", 1, "en"),
+      target("v-a", "e-a", "core-a", 1, "es"),
+      target("v-b", "e-b", "core-b", 2, "en"),
     ])
 
     expect(groups).toHaveLength(2)

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
@@ -60,12 +60,17 @@ import {
   type MastraTranscriptEmbeddingLaunchResult,
   type MastraTranscriptEmbeddingMode,
 } from "@/services/mastra-transcript-embedding-client"
+import type {
+  ResolvedTranscriptEmbeddingSource,
+  TranscriptSourceGap,
+} from "@/services/transcript-source-resolver.service"
 // The artifact-load step lives in a separate module on purpose — the
 // useworkflow build plugin treats functions imported into a workflow
 // file as workflow scope, so importing `readTranscriptSourceArtifact` here
 // would trip the Node-module reachability check even though the actual
 // call is inside `"use step"`. See `_steps/load-manager-artifact.ts`.
 import { stepLoadTranscriptSourceArtifact } from "./_steps/load-manager-artifact"
+import { stepResolveSubtitleTranscriptSource } from "./_steps/resolve-transcript-source"
 
 /**
  * Default per-group concurrency for the Mastra transcript-embedding
@@ -111,6 +116,12 @@ export type BackfillTarget = {
    * for an edition, the edition simply produces no targets.
    */
   language: string
+  /** Admin language row identity. BCP-47 is not unique enough for source selection. */
+  languageId: string
+  languageSlug: string | null
+  hasSubtitle: boolean
+  hasDub: boolean
+  isPrimaryLanguage: boolean
 }
 
 /**
@@ -122,8 +133,29 @@ export type BackfillTarget = {
  * `targets` order is preserved from enumeration; the launcher fans out
  * sequentially across that order inside the group worker.
  */
-export type BackfillGroup = Omit<BackfillTarget, "language"> & {
+export type BackfillGroup = Pick<
+  BackfillTarget,
+  "videoId" | "videoEditionId" | "coreId" | "cmsVideoId"
+> & {
   targets: readonly BackfillTarget[]
+}
+
+export type TranscriptEmbeddingSourceGap = {
+  readonly assetId: number
+  readonly coreId: string
+  readonly videoId: string
+  readonly videoEditionId: string
+  readonly language: string
+  readonly languageId: string
+  readonly languageSlug: string | null
+  readonly reason:
+    | TranscriptSourceGap["reason"]
+    | "artifact_missing"
+    | "dub_without_timed_text"
+  readonly subtitleReason?: TranscriptSourceGap["reason"]
+  readonly subtitleId?: string
+  readonly subtitleFormat?: "vtt" | "srt"
+  readonly sourceKind: "transcript"
 }
 
 export type BackfillOutcome =
@@ -131,6 +163,7 @@ export type BackfillOutcome =
       status: "succeeded"
       target: BackfillTarget
       language: string
+      sourceKind: ResolvedTranscriptEmbeddingSource["sourceKind"]
       chunksIndexed: number
       embeddingsWritten: number
       chunksPruned: number
@@ -141,6 +174,7 @@ export type BackfillOutcome =
       target: BackfillTarget
       language: string
       reason: string
+      sourceGap?: TranscriptEmbeddingSourceGap
       durationMs: number
     }
   | {
@@ -186,6 +220,7 @@ export type TranscriptEmbeddingBackfillReport = {
    * had its transcript source artifact present. See `MissingArtifact`.
    */
   missingArtifacts: ReadonlyArray<MissingArtifact>
+  sourceGaps: ReadonlyArray<TranscriptEmbeddingSourceGap>
 }
 
 export async function runTranscriptEmbeddingBackfill(
@@ -329,15 +364,25 @@ async function stepEnumerateTargets(
       video_id: string
       video_edition_id: string
       core_id: string
+      language_id: string
       bcp47: string
+      slug: string | null
+      has_subtitle: boolean
+      has_dub: boolean
+      is_primary_language: boolean
     }>
   >`
-    WITH edition_languages AS (
-      SELECT DISTINCT
+    WITH target_language_sources AS (
+      SELECT
         v.id AS video_id,
         e.id AS video_edition_id,
         v.core_id AS core_id,
-        l.bcp47 AS bcp47
+        l.id AS language_id,
+        l.bcp47 AS bcp47,
+        l.slug AS slug,
+        false AS has_subtitle,
+        false AS has_dub,
+        true AS is_primary_language
       FROM video v
       JOIN video_dub d ON d.video_id = v.id AND d.deleted_at IS NULL
       JOIN video_edition e ON e.id = d.video_edition_id AND e.deleted_at IS NULL
@@ -345,13 +390,18 @@ async function stepEnumerateTargets(
       WHERE v.deleted_at IS NULL
         AND l.bcp47 IS NOT NULL
 
-      UNION
+      UNION ALL
 
-      SELECT DISTINCT
+      SELECT
         v.id,
         e.id,
         v.core_id,
-        l.bcp47
+        l.id,
+        l.bcp47,
+        l.slug,
+        true AS has_subtitle,
+        false AS has_dub,
+        false AS is_primary_language
       FROM video v
       JOIN video_dub d ON d.video_id = v.id AND d.deleted_at IS NULL
       JOIN video_edition e ON e.id = d.video_edition_id AND e.deleted_at IS NULL
@@ -360,13 +410,18 @@ async function stepEnumerateTargets(
       WHERE v.deleted_at IS NULL
         AND l.bcp47 IS NOT NULL
 
-      UNION
+      UNION ALL
 
-      SELECT DISTINCT
+      SELECT
         v.id,
         e.id,
         v.core_id,
-        l.bcp47
+        l.id,
+        l.bcp47,
+        l.slug,
+        false AS has_subtitle,
+        true AS has_dub,
+        false AS is_primary_language
       FROM video v
       JOIN video_dub d ON d.video_id = v.id AND d.deleted_at IS NULL
       JOIN video_edition e ON e.id = d.video_edition_id AND e.deleted_at IS NULL
@@ -374,9 +429,19 @@ async function stepEnumerateTargets(
       WHERE v.deleted_at IS NULL
         AND l.bcp47 IS NOT NULL
     )
-    SELECT video_id, video_edition_id, core_id, bcp47
-    FROM edition_languages
-    ORDER BY core_id, bcp47
+    SELECT
+      video_id,
+      video_edition_id,
+      core_id,
+      language_id,
+      bcp47,
+      slug,
+      bool_or(has_subtitle) AS has_subtitle,
+      bool_or(has_dub) AS has_dub,
+      bool_or(is_primary_language) AS is_primary_language
+    FROM target_language_sources
+    GROUP BY video_id, video_edition_id, core_id, language_id, bcp47, slug
+    ORDER BY core_id, bcp47, slug
   `
 
   const targets: BackfillTarget[] = []
@@ -390,6 +455,11 @@ async function stepEnumerateTargets(
       coreId: row.core_id,
       cmsVideoId,
       language: row.bcp47,
+      languageId: row.language_id,
+      languageSlug: row.slug,
+      hasSubtitle: row.has_subtitle,
+      hasDub: row.has_dub,
+      isPrimaryLanguage: row.is_primary_language,
     })
   }
 
@@ -439,16 +509,66 @@ function groupTargetsByVideoEdition(
   return Array.from(groupMap.values(), (e) => e.group)
 }
 
+type ManagerSourceLoadState =
+  | { status: "not-attempted" }
+  | { status: "resolved"; artifact: TranscriptSourceArtifact }
+  | { status: "failed"; reason: string; missing: boolean }
+
+function managerTranscriptSourceFromArtifact(
+  target: BackfillTarget,
+  artifact: TranscriptSourceArtifact,
+): ResolvedTranscriptEmbeddingSource {
+  const sourceKey = `${target.cmsVideoId}/transcript.json`
+  return {
+    sourceKind: "manager-transcript",
+    transcript: {
+      text: artifact.text,
+      segments: artifact.segments,
+      artifactKey: sourceKey,
+      kind: "manager-transcript",
+      languageId: target.languageId,
+      languageSlug: target.languageSlug,
+      provider: artifact.resolvedProvider,
+    },
+    provenance: {
+      sourceKind: "manager-transcript",
+      sourceKey,
+      language: artifact.language || target.language,
+      languageId: target.languageId,
+      languageSlug: target.languageSlug,
+    },
+  }
+}
+
+function sourceGapForMissingManager(
+  target: BackfillTarget,
+  subtitleGap?: TranscriptSourceGap,
+): TranscriptEmbeddingSourceGap {
+  const reason =
+    target.hasDub && !target.hasSubtitle && !target.isPrimaryLanguage
+      ? "dub_without_timed_text"
+      : (subtitleGap?.reason ?? "artifact_missing")
+
+  return {
+    assetId: target.cmsVideoId,
+    coreId: target.coreId,
+    videoId: target.videoId,
+    videoEditionId: target.videoEditionId,
+    language: target.language,
+    languageId: target.languageId,
+    languageSlug: target.languageSlug,
+    reason,
+    subtitleReason: subtitleGap?.reason,
+    subtitleId: subtitleGap?.subtitleId,
+    subtitleFormat: subtitleGap?.format,
+    sourceKind: "transcript",
+  }
+}
+
 /**
- * Per-group worker. Loads the transcript source artifact ONCE, then fans out
- * per-language sequentially with the source in scope.
- *
- * Group-level artifact-load failure is cascaded to per-language
- * outcomes with the same classification the per-language path would
- * have produced (`artifact_missing` → skipped, anything else →
- * failed). This preserves Stage 1's per-target outcome shape so the
- * report's succeeded/skipped/failed triple stays meaningful even when
- * the load fault is shared.
+ * Per-group worker. Resolves subtitle timed text per language first, then
+ * lazily loads the Manager transcript source artifact ONCE if any target in
+ * the group needs fallback.
  */
 async function processGroup(
   group: BackfillGroup,
@@ -468,47 +588,79 @@ async function processGroup(
   // backfill — operators monitoring useworkflow journal size should be
   // aware.
 
-  let transcriptSource: TranscriptSourceArtifact
-  try {
-    transcriptSource = await stepLoadTranscriptSourceArtifact(group.cmsVideoId)
-  } catch (error) {
-    const durationMs = Date.now() - groupStartedAt
-    const isMissing =
-      error instanceof ManagerArtifactError && error.code === "artifact_missing"
-    const reason = isMissing
-      ? "artifact_missing"
-      : error instanceof Error
-        ? error.message
-        : String(error)
-    return group.targets.map((target) => {
-      const outcome: BackfillOutcome = isMissing
-        ? {
-            status: "skipped",
-            target,
-            language: target.language,
-            reason,
-            durationMs,
-          }
-        : {
-            status: "failed",
-            target,
-            language: target.language,
-            reason,
-            durationMs,
-          }
-      logOutcome(outcome)
-      return outcome
-    })
-  }
+  let managerSourceState: ManagerSourceLoadState = { status: "not-attempted" }
 
-  // Per-language fan-out with the loaded artifact in scope. Sequential
-  // inside the group so the artifact stays bounded to one stack frame
-  // and the per-target step's timing measurement is honest.
   const outcomes: BackfillOutcome[] = []
   for (const target of group.targets) {
+    const subtitleResolution = await stepResolveSubtitleTranscriptSource(target)
+    let source: ResolvedTranscriptEmbeddingSource | null =
+      subtitleResolution.status === "resolved"
+        ? subtitleResolution.source
+        : null
+
+    if (!source) {
+      if (managerSourceState.status === "not-attempted") {
+        try {
+          managerSourceState = {
+            status: "resolved",
+            artifact: await stepLoadTranscriptSourceArtifact(group.cmsVideoId),
+          }
+        } catch (error) {
+          const missing =
+            error instanceof ManagerArtifactError &&
+            error.code === "artifact_missing"
+          managerSourceState = {
+            status: "failed",
+            missing,
+            reason: missing
+              ? "artifact_missing"
+              : error instanceof Error
+                ? error.message
+                : String(error),
+          }
+        }
+      }
+
+      if (managerSourceState.status === "resolved") {
+        source = managerTranscriptSourceFromArtifact(
+          target,
+          managerSourceState.artifact,
+        )
+      } else if (managerSourceState.status === "failed") {
+        const durationMs = Date.now() - groupStartedAt
+        const sourceGap = sourceGapForMissingManager(
+          target,
+          subtitleResolution.status === "gap"
+            ? subtitleResolution.gap
+            : undefined,
+        )
+        const outcome: BackfillOutcome = managerSourceState.missing
+          ? {
+              status: "skipped",
+              target,
+              language: target.language,
+              reason: sourceGap.reason,
+              sourceGap,
+              durationMs,
+            }
+          : {
+              status: "failed",
+              target,
+              language: target.language,
+              reason: managerSourceState.reason,
+              durationMs,
+            }
+        logOutcome(outcome)
+        outcomes.push(outcome)
+        continue
+      } else {
+        throw new Error("internal transcript source resolver state was unset")
+      }
+    }
+
     const outcome = await _internals.stepLaunchMastraTranscriptEmbedding(
       target,
-      transcriptSource,
+      source,
       mode,
     )
     logOutcome(outcome)
@@ -519,7 +671,7 @@ async function processGroup(
 
 async function stepLaunchMastraTranscriptEmbedding(
   target: BackfillTarget,
-  transcriptSource: TranscriptSourceArtifact,
+  transcriptSource: ResolvedTranscriptEmbeddingSource,
   mode: MastraTranscriptEmbeddingMode,
 ): Promise<BackfillOutcome> {
   "use step"
@@ -535,7 +687,7 @@ async function stepLaunchMastraTranscriptEmbedding(
       },
       language: target.language,
       cmsVideoId: target.cmsVideoId,
-      transcript: transcriptSource,
+      transcript: transcriptSource.transcript,
       mode,
     })
     if (!result.ok) {
@@ -547,7 +699,12 @@ async function stepLaunchMastraTranscriptEmbedding(
         durationMs: Date.now() - startedAt,
       }
     }
-    return toSucceeded(target, result, Date.now() - startedAt)
+    return toSucceeded(
+      target,
+      transcriptSource.sourceKind,
+      result,
+      Date.now() - startedAt,
+    )
   } catch (error) {
     const durationMs = Date.now() - startedAt
     // Branch on the typed error class, not error-message regex. Only a
@@ -595,7 +752,7 @@ function deriveMissingArtifacts(
   const byAssetId = new Map<number, MissingArtifact>()
   for (const outcome of outcomes) {
     if (outcome.status !== "skipped") continue
-    if (outcome.reason !== "artifact_missing") continue
+    if (outcome.reason !== "artifact_missing" && !outcome.sourceGap) continue
     if (byAssetId.has(outcome.target.cmsVideoId)) continue
     byAssetId.set(outcome.target.cmsVideoId, {
       assetId: outcome.target.cmsVideoId,
@@ -604,6 +761,26 @@ function deriveMissingArtifacts(
     })
   }
   return Array.from(byAssetId.values()).sort((a, b) => a.assetId - b.assetId)
+}
+
+function deriveSourceGaps(
+  outcomes: readonly BackfillOutcome[],
+): TranscriptEmbeddingSourceGap[] {
+  const byKey = new Map<string, TranscriptEmbeddingSourceGap>()
+  for (const outcome of outcomes) {
+    if (outcome.status !== "skipped" || !outcome.sourceGap) continue
+    const key = [
+      outcome.sourceGap.assetId,
+      outcome.sourceGap.videoEditionId,
+      outcome.sourceGap.languageId,
+      outcome.sourceGap.reason,
+    ].join("::")
+    if (!byKey.has(key)) byKey.set(key, outcome.sourceGap)
+  }
+  return Array.from(byKey.values()).sort((a, b) => {
+    if (a.assetId !== b.assetId) return a.assetId - b.assetId
+    return a.language.localeCompare(b.language)
+  })
 }
 
 function stepReport(args: {
@@ -646,11 +823,13 @@ function stepReport(args: {
     skipped,
     failed,
     missingArtifacts: deriveMissingArtifacts(args.outcomes),
+    sourceGaps: deriveSourceGaps(args.outcomes),
   }
 }
 
 function toSucceeded(
   target: BackfillTarget,
+  sourceKind: ResolvedTranscriptEmbeddingSource["sourceKind"],
   result: Extract<MastraTranscriptEmbeddingLaunchResult, { ok: true }>,
   durationMs: number,
 ): BackfillOutcome {
@@ -658,6 +837,7 @@ function toSucceeded(
     status: "succeeded",
     target,
     language: target.language,
+    sourceKind,
     chunksIndexed: result.chunks,
     embeddingsWritten: result.status === "unchanged" ? 0 : result.chunks,
     chunksPruned: 0,

--- a/apps/manager/src/services/mastra-transcript-embeddings.ts
+++ b/apps/manager/src/services/mastra-transcript-embeddings.ts
@@ -16,6 +16,7 @@ export type MastraTranscriptEmbeddingInput = {
     text: string
     segments?: TranscriptSegment[]
     artifactKey?: string
+    kind?: "manager-transcript"
     provider?: string
     generatedAt?: string
   }
@@ -205,6 +206,7 @@ export async function launchMastraTranscriptEmbeddings(
       segments: input.transcript.segments,
       artifactKey:
         input.transcript.artifactKey ?? `${input.assetId}/transcript.json`,
+      kind: input.transcript.kind ?? "manager-transcript",
       provider: input.transcript.provider,
       generatedAt: input.transcript.generatedAt,
     },

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
@@ -92,13 +92,13 @@ describe("transcript embedding workflow", () => {
       ok: true,
       status: "created",
       chunks: 1,
-      totalTokens: 8,
+      totalTokens: expect.any(Number),
       mastraRunId: "run-segment",
       nativeDimensions: 4096,
       transformVersion: "matryoshka-truncate-1536-v1",
     })
     expect(embeddingRequester).toHaveBeenCalledWith(
-      ["Hello there. This is a transcript."],
+      [expect.stringContaining("Time range: 00:00-00:04") as unknown as string],
       expect.objectContaining({
         expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
       }),
@@ -131,6 +131,15 @@ describe("transcript embedding workflow", () => {
           expect.objectContaining({
             chunkIndex: 0,
             chunkId: "chunk-0",
+            text: "Hello there. This is a transcript.",
+            rawSourceText: "Hello there. This is a transcript.",
+            embeddingInputText: expect.stringContaining(
+              "Transcript: Hello there. This is a transcript.",
+            ),
+            feltNeeds: [],
+            bibleVerses: [],
+            contentSummary: "Hello there. This is a transcript.",
+            tone: "reflective",
             startSeconds: 0,
             endSeconds: 4,
             embedding: vector(1),
@@ -184,14 +193,17 @@ describe("transcript embedding workflow", () => {
       ok: true,
       status: "unchanged",
       chunks: 3,
-      totalTokens: 10,
+      totalTokens: expect.any(Number),
     })
     expect(embeddingRequester).toHaveBeenCalledTimes(2)
     expect(adminIngestClient).toHaveBeenCalledWith(
       expect.objectContaining({
         chunking: expect.objectContaining({ type: "plain-text" }),
         chunks: [
-          expect.objectContaining({ text: "one two three" }),
+          expect.objectContaining({
+            text: "one two three",
+            embeddingInputText: expect.stringContaining("Time range: unknown"),
+          }),
           expect.objectContaining({ text: "four five six" }),
           expect.objectContaining({ text: "seven" }),
         ],
@@ -329,8 +341,52 @@ describe("transcript embedding workflow", () => {
       },
       chunking: {
         totalChunks: 1,
-        totalTokens: 8,
+        totalTokens: expect.any(Number),
       },
+    })
+  })
+
+  it("plans v2 enriched chunks with source provenance and canonical felt needs", () => {
+    const planned = planTranscriptEmbeddingRun(
+      input({
+        transcript: {
+          text: "Jesus gives hope and love in John 3:16.",
+          segments: [
+            {
+              start: 65,
+              end: 70,
+              text: "Jesus gives hope and love in John 3:16.",
+            },
+          ],
+          artifactKey: "admin-video-subtitle/sub-1.vtt",
+          kind: "subtitle",
+          languageId: "lang-en",
+          languageSlug: "english",
+          subtitleId: "sub-1",
+          format: "vtt",
+          url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+          provider: "admin-subtitle",
+          generatedAt: "2026-05-25T00:00:00.000Z",
+        },
+      }),
+      { mastraRunId: "run-v2-plan" },
+    )
+
+    expect(planned.source).toMatchObject({
+      artifactKey: "admin-video-subtitle/sub-1.vtt",
+      kind: "subtitle",
+      languageId: "lang-en",
+      languageSlug: "english",
+      subtitleId: "sub-1",
+      format: "vtt",
+      provider: "admin-subtitle",
+      contentHash: expect.stringMatching(/^sha256:/),
+    })
+    expect(planned.chunks[0]).toMatchObject({
+      rawSourceText: "Jesus gives hope and love in John 3:16.",
+      feltNeeds: ["Hope", "Love"],
+      bibleVerses: ["John 3:16"],
+      embeddingInputText: expect.stringContaining("Time range: 01:05-01:10"),
     })
   })
 

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.ts
@@ -24,7 +24,21 @@ const DEFAULT_MAX_CHUNK_TOKENS = 500
 const DEFAULT_OVERLAP_TOKENS = 100
 const DEFAULT_MAX_BATCH_CHUNKS = 8
 const DEFAULT_MAX_BATCH_TOKENS = 20_000
-const CHUNKING_VERSION = "manager-transcript-v1"
+const CHUNKING_VERSION = "enriched-transcript-v2"
+
+type CanonicalFeltNeed =
+  | "Acceptance"
+  | "Anxiety"
+  | "Depression"
+  | "Fear/Power"
+  | "Forgiveness"
+  | "Guilt/Righteousness"
+  | "Honor/Shame"
+  | "Hope"
+  | "Loneliness"
+  | "Love"
+  | "Security"
+  | "Significance"
 
 const GenerationModeSchema = z
   .enum(["idempotent", "repair", "force", "model-upgrade"])
@@ -104,6 +118,12 @@ export const TranscriptEmbeddingWorkflowInputSchema = z
         text: z.string().optional(),
         segments: z.array(TranscriptSegmentSchema).optional(),
         artifactKey: z.string().min(1).optional(),
+        kind: z.enum(["subtitle", "manager-transcript"]).optional(),
+        languageId: z.string().min(1).optional(),
+        languageSlug: z.string().min(1).optional(),
+        subtitleId: z.string().min(1).optional(),
+        format: z.enum(["vtt", "srt"]).optional(),
+        url: z.string().min(1).optional(),
         provider: z.string().min(1).optional(),
         generatedAt: z.string().min(1).optional(),
       })
@@ -124,6 +144,11 @@ const PlannedRunSummarySchema = z
         textLength: z.number().int().nonnegative(),
         segmentCount: z.number().int().nonnegative(),
         artifactKey: z.string().min(1).optional(),
+        kind: z.enum(["subtitle", "manager-transcript"]).optional(),
+        languageId: z.string().min(1).optional(),
+        languageSlug: z.string().min(1).optional(),
+        subtitleId: z.string().min(1).optional(),
+        format: z.enum(["vtt", "srt"]).optional(),
         provider: z.string().min(1).optional(),
         generatedAt: z.string().min(1).optional(),
         contentHash: z.string().min(1),
@@ -228,6 +253,15 @@ type PlannedChunk = {
   chunkIndex: number
   chunkId: string
   text: string
+  rawSourceText?: string
+  embeddingInputText?: string
+  feltNeeds?: CanonicalFeltNeed[]
+  bibleVerses?: string[]
+  contentSummary?: string
+  tone?: string
+  demographics?: string[]
+  spiritualContext?: string[]
+  extractionMetadata?: Record<string, unknown>
   tokenCount: number
   startSeconds?: number
   endSeconds?: number
@@ -240,6 +274,12 @@ type PlannedRun = {
     text: string
     segments?: TranscriptSegment[]
     artifactKey?: string
+    kind?: "subtitle" | "manager-transcript"
+    languageId?: string
+    languageSlug?: string
+    subtitleId?: string
+    format?: "vtt" | "srt"
+    url?: string
     provider?: string
     generatedAt?: string
     contentHash: string
@@ -375,6 +415,100 @@ function estimateTokenCount(text: string): number {
   const trimmed = text.trim()
   if (!trimmed) return 0
   return Math.ceil(trimmed.split(/\s+/).length / 0.75)
+}
+
+function formatTimeRange(seconds: number | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds)) return "unknown"
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.floor(seconds % 60)
+  return `${String(minutes).padStart(2, "0")}:${String(remainingSeconds).padStart(2, "0")}`
+}
+
+function summarizeChunkText(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim()
+  if (normalized.length <= 180) return normalized
+  return `${normalized.slice(0, 177).trim()}...`
+}
+
+function extractBibleVerses(text: string): string[] {
+  const matches = text.match(
+    /\b(?:[1-3]\s*)?[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?\s+\d{1,3}:\d{1,3}(?:-\d{1,3})?\b/g,
+  )
+  return Array.from(new Set(matches ?? []))
+}
+
+function inferFeltNeeds(text: string): CanonicalFeltNeed[] {
+  const lower = text.toLowerCase()
+  const needs: CanonicalFeltNeed[] = []
+  const add = (need: CanonicalFeltNeed) => {
+    if (!needs.includes(need)) needs.push(need)
+  }
+
+  if (/\b(accept|accepted|belong|welcome|included)\b/.test(lower)) {
+    add("Acceptance")
+  }
+  if (/\b(anxious|anxiety|worry|worried)\b/.test(lower)) add("Anxiety")
+  if (/\b(depress|sad|sorrow|despair)\b/.test(lower)) add("Depression")
+  if (/\b(fear|afraid|power|deliver|oppress)\b/.test(lower)) add("Fear/Power")
+  if (/\b(forgive|forgiven|forgiveness|mercy)\b/.test(lower)) {
+    add("Forgiveness")
+  }
+  if (/\b(guilt|guilty|righteous|righteousness|sin)\b/.test(lower)) {
+    add("Guilt/Righteousness")
+  }
+  if (/\b(shame|honor|disgrace)\b/.test(lower)) add("Honor/Shame")
+  if (/\b(hope|promise|future|restore)\b/.test(lower)) add("Hope")
+  if (/\b(alone|lonely|forsaken)\b/.test(lower)) add("Loneliness")
+  if (/\b(love|beloved|compassion)\b/.test(lower)) add("Love")
+  if (/\b(safe|secure|security|protect|shelter)\b/.test(lower)) {
+    add("Security")
+  }
+  if (/\b(worth|value|significant|purpose|called)\b/.test(lower)) {
+    add("Significance")
+  }
+
+  return needs
+}
+
+function enrichChunk(chunk: PlannedChunk): PlannedChunk {
+  const rawSourceText = chunk.rawSourceText ?? chunk.text
+  const feltNeeds = inferFeltNeeds(rawSourceText)
+  const bibleVerses = extractBibleVerses(rawSourceText)
+  const contentSummary = summarizeChunkText(rawSourceText)
+  const timeRange = `${formatTimeRange(chunk.startSeconds)}-${formatTimeRange(chunk.endSeconds)}`
+  const tone = "reflective"
+  const demographics: string[] = []
+  const spiritualContext = bibleVerses.length > 0 ? ["Bible reference"] : []
+  const embeddingInputText = [
+    `Time range: ${timeRange}`,
+    `Felt needs: ${feltNeeds.length > 0 ? feltNeeds.join(", ") : "None"}`,
+    `Bible verses: ${bibleVerses.length > 0 ? bibleVerses.join(", ") : "None"}`,
+    `Summary: ${contentSummary}`,
+    `Tone: ${tone}`,
+    `Demographics: ${demographics.length > 0 ? demographics.join(", ") : "None"}`,
+    `Spiritual context: ${
+      spiritualContext.length > 0 ? spiritualContext.join(", ") : "None"
+    }`,
+    `Transcript: ${rawSourceText}`,
+  ].join("\n")
+
+  return {
+    ...chunk,
+    text: rawSourceText,
+    rawSourceText,
+    embeddingInputText,
+    feltNeeds,
+    bibleVerses,
+    contentSummary,
+    tone,
+    demographics,
+    spiritualContext,
+    extractionMetadata: {
+      strategy: "deterministic-transcript-grounded-v1",
+      source: "transcript",
+    },
+    tokenCount: estimateTokenCount(embeddingInputText),
+  }
 }
 
 function chunkText(
@@ -580,21 +714,83 @@ function sha256Json(value: unknown): string {
 function sourceContentHash({
   text,
   segments,
+  source,
   chunks,
 }: {
   text: string
   segments?: TranscriptSegment[]
+  source?: {
+    kind?: "subtitle" | "manager-transcript"
+    artifactKey?: string
+    languageId?: string
+    languageSlug?: string
+    subtitleId?: string
+    format?: "vtt" | "srt"
+    url?: string
+    provider?: string
+    generatedAt?: string
+  }
   chunks: PlannedChunk[]
 }): string {
+  const hasV2SourceMetadata =
+    source?.kind != null ||
+    source?.languageId != null ||
+    source?.languageSlug != null ||
+    source?.subtitleId != null ||
+    source?.format != null ||
+    source?.url != null
+
   return sha256Json({
     text,
     segments: segments ?? null,
-    chunks: chunks.map((chunk) => ({
-      index: chunk.chunkIndex,
-      text: chunk.text,
-      startSeconds: chunk.startSeconds ?? null,
-      endSeconds: chunk.endSeconds ?? null,
-    })),
+    ...(hasV2SourceMetadata
+      ? {
+          source: {
+            kind: source?.kind ?? null,
+            artifactKey: source?.artifactKey ?? null,
+            languageId: source?.languageId ?? null,
+            languageSlug: source?.languageSlug ?? null,
+            subtitleId: source?.subtitleId ?? null,
+            format: source?.format ?? null,
+            url: source?.url ?? null,
+            provider: source?.provider ?? null,
+            generatedAt: source?.generatedAt ?? null,
+          },
+        }
+      : {}),
+    chunks: chunks.map((chunk) => {
+      const base = {
+        index: chunk.chunkIndex,
+        text: chunk.text,
+        startSeconds: chunk.startSeconds ?? null,
+        endSeconds: chunk.endSeconds ?? null,
+      }
+      const hasEnrichedFields =
+        chunk.rawSourceText != null ||
+        chunk.embeddingInputText != null ||
+        (chunk.feltNeeds?.length ?? 0) > 0 ||
+        (chunk.bibleVerses?.length ?? 0) > 0 ||
+        chunk.contentSummary != null ||
+        chunk.tone != null ||
+        (chunk.demographics?.length ?? 0) > 0 ||
+        (chunk.spiritualContext?.length ?? 0) > 0 ||
+        chunk.extractionMetadata != null
+
+      return hasEnrichedFields
+        ? {
+            ...base,
+            rawSourceText: chunk.rawSourceText ?? null,
+            embeddingInputText: chunk.embeddingInputText ?? null,
+            feltNeeds: chunk.feltNeeds ?? [],
+            bibleVerses: chunk.bibleVerses ?? [],
+            contentSummary: chunk.contentSummary ?? null,
+            tone: chunk.tone ?? null,
+            demographics: chunk.demographics ?? [],
+            spiritualContext: chunk.spiritualContext ?? [],
+            extractionMetadata: chunk.extractionMetadata ?? null,
+          }
+        : base
+    }),
   })
 }
 
@@ -772,12 +968,25 @@ export function planTranscriptEmbeddingRun(
     input.chunking?.maxBatchTokens ?? DEFAULT_MAX_BATCH_TOKENS
 
   const usesSegments = segments != null && segments.length > 0
-  const chunks = usesSegments
+  const baseChunks = usesSegments
     ? planSegmentChunks(segments, { maxChunkTokens, overlapTokens })
     : planPlainTextChunks(sourceText, { maxChunkTokens, overlapTokens })
+  const chunks = baseChunks.map(enrichChunk)
 
   if (chunks.length === 0) {
     throw new Error("transcript embedding workflow requires at least one chunk")
+  }
+
+  const sourceMetadata = {
+    kind: input.transcript.kind,
+    artifactKey: input.transcript.artifactKey,
+    languageId: input.transcript.languageId,
+    languageSlug: input.transcript.languageSlug,
+    subtitleId: input.transcript.subtitleId,
+    format: input.transcript.format,
+    url: input.transcript.url,
+    provider: input.transcript.provider,
+    generatedAt: input.transcript.generatedAt,
   }
 
   return {
@@ -788,9 +997,20 @@ export function planTranscriptEmbeddingRun(
       text: sourceText,
       segments,
       artifactKey: input.transcript.artifactKey,
+      kind: input.transcript.kind,
+      languageId: input.transcript.languageId,
+      languageSlug: input.transcript.languageSlug,
+      subtitleId: input.transcript.subtitleId,
+      format: input.transcript.format,
+      url: input.transcript.url,
       provider: input.transcript.provider,
       generatedAt: input.transcript.generatedAt,
-      contentHash: sourceContentHash({ text: sourceText, segments, chunks }),
+      contentHash: sourceContentHash({
+        text: sourceText,
+        segments,
+        source: sourceMetadata,
+        chunks,
+      }),
     },
     model: {
       name: input.model?.name ?? providerConfig.model,
@@ -828,7 +1048,9 @@ export async function embedPlannedTranscript(
   for (let index = 0; index < batches.length; index += 1) {
     const batch = batches[index]!
     const providerConfig = getTranscriptEmbeddingProviderConfig()
-    const batchInput = batch.map((chunk) => chunk.text)
+    const batchInput = batch.map(
+      (chunk) => chunk.embeddingInputText ?? chunk.text,
+    )
     const requestContext = `Transcript embedding batch ${index + 1}/${batches.length}`
     const rawResult = options.embeddingRequester
       ? await options.embeddingRequester(batchInput, {

--- a/apps/mastra/src/services/admin-transcript-ingest-client.ts
+++ b/apps/mastra/src/services/admin-transcript-ingest-client.ts
@@ -26,6 +26,12 @@ export type AdminTranscriptEmbeddingIngestPayload = {
     text?: string
     segments?: Array<{ start: number; end: number; text: string }>
     artifactKey?: string
+    kind?: "subtitle" | "manager-transcript"
+    languageId?: string
+    languageSlug?: string
+    subtitleId?: string
+    format?: "vtt" | "srt"
+    url?: string
     provider?: string
     generatedAt?: string
     contentHash: string
@@ -55,6 +61,15 @@ export type AdminTranscriptEmbeddingIngestPayload = {
     tokenCount: number
     startSeconds?: number
     endSeconds?: number
+    rawSourceText?: string
+    embeddingInputText?: string
+    feltNeeds?: string[]
+    bibleVerses?: string[]
+    contentSummary?: string
+    tone?: string
+    demographics?: string[]
+    spiritualContext?: string[]
+    extractionMetadata?: Record<string, unknown>
     embedding: number[]
   }>
 }

--- a/docs/roadmap/content-discovery/feat-192-enriched-transcript-semantic-search.md
+++ b/docs/roadmap/content-discovery/feat-192-enriched-transcript-semantic-search.md
@@ -1,0 +1,45 @@
+---
+id: "feat-192"
+title: "Enriched Transcript Semantic Search Realignment"
+owner: "nisal"
+priority: "P0"
+status: "implemented"
+start_date: "2026-06-17"
+duration: 5
+depends_on: []
+blocks:
+  - "feat-193"
+tags:
+  - "admin"
+  - "mastra"
+  - "manager"
+  - "search"
+  - "embeddings"
+  - "content-discovery"
+---
+
+## Scope
+
+Implement the enriched transcript semantic search plan from:
+
+- `docs/plans/2026-06-17-001-feat-enriched-transcript-semantic-search-plan.md`
+
+Execution starts with subtitle-first transcript source resolution, enriched
+transcript source contracts, structured transcript chunk metadata, and removal
+of scene evidence consumption from the existing `semantic-video` retriever
+after enriched transcript rows can be produced.
+
+Implemented in this branch by keeping the public `semantic-video` and
+`sceneRecommendations` API shapes stable while moving their vector evidence to
+enriched transcript chunks. Scene ingestion/backfill code remains present for a
+later deletion pass after eval.
+
+## Key Constraints
+
+- Keep `semantic-video` as the public retrieval family.
+- Stop consuming scene retrieval before deleting scene code.
+- Prefer Admin/Core subtitles, then Manager transcript artifacts.
+- Report missing timed text or Manager fallback gaps without auto-triggering
+  Manager enrichment in v1.
+- Preserve language identity beyond BCP-47 wherever Admin can provide it.
+- Keep scene tables and historical rows intact.

--- a/docs/roadmap/content-discovery/feat-193-remove-legacy-scene-embedding-pipeline.md
+++ b/docs/roadmap/content-discovery/feat-193-remove-legacy-scene-embedding-pipeline.md
@@ -1,0 +1,60 @@
+---
+id: "feat-193"
+title: "Remove Legacy Scene Embedding Pipeline"
+owner: "nisal"
+priority: "P1"
+status: "planned"
+start_date: "2026-06-24"
+duration: 3
+depends_on:
+  - "feat-192"
+blocks: []
+tags:
+  - "admin"
+  - "mastra"
+  - "manager"
+  - "search"
+  - "embeddings"
+  - "content-discovery"
+  - "cleanup"
+---
+
+## Scope
+
+After enriched transcript search has passed eval and production backfill
+coverage is healthy, remove the legacy scene embedding pipeline that is no
+longer consumed by semantic search or recommendation lists.
+
+This is the deletion follow-up for feat-192. feat-192 stops scene embedding
+consumption while leaving the old code in place; this ticket deletes the dead
+scene-embedding path and cleans up naming/docs that still imply scene retrieval
+is active.
+
+## Cleanup Targets
+
+- Delete Admin scene embedding backfill, ingest, Mastra scene client, and
+  GraphQL mutation surfaces that only exist to populate `video_scene` /
+  `video_scene_locale` embeddings.
+- Delete or migrate Manager/Mastra scene embedding sync clients and tests that
+  only serve Admin scene embedding ingestion.
+- Remove legacy scene-table reads from content-discovery code and tests; any
+  remaining `video_scene` references should be justified by non-search product
+  behavior.
+- Clean up compatibility wording such as "scene-similarity" and
+  "scene-recommendations" where the runtime behavior is now transcript-backed.
+- Decide whether public compatibility names like `sceneRecommendations` stay as
+  aliases or get a separately planned API rename after frontend/mobile clients
+  are ready.
+- Keep historical scene tables/data until a separate data-retention migration is
+  explicitly approved.
+
+## Acceptance Criteria
+
+- Enriched transcript semantic search eval has passed the agreed promotion gate.
+- No production search or recommendation path calls scene embedding retrieval,
+  scene embedding ingestion, or scene embedding backfill code.
+- Dead scene embedding code and tests are removed, not merely bypassed.
+- Remaining scene-analysis code has an owner and a non-search reason to exist,
+  or is removed in the same cleanup.
+- Operator docs, roadmap notes, and code comments describe transcript-backed
+  search/recommendations without implying scene embeddings are still active.


### PR DESCRIPTION
## Summary

Semantic video discovery now runs from enriched transcript chunks instead of scene embeddings. Transcript embedding jobs resolve Admin/Core subtitles first, fall back to Manager transcript artifacts, persist structured enrichment metadata, and feed both `semantic-video` search and the legacy `sceneRecommendations` API shape without consuming `video_scene` embeddings.

## Design Notes

- Transcript source resolution is subtitle-first, Manager-transcript fallback second, with source-gap reporting for dub languages that have no usable timed text.
- Mastra now emits `enriched-transcript-v2` chunk inputs that include time range, raw source text, felt needs, Bible verses, content summary, tone, demographics, and spiritual context.
- Admin stores the enriched metadata as structured transcript chunk fields as well as embedding input text, so filtering/debug/display can be added without re-parsing vectors.
- Scene retrieval is removed from search and recommendation consumption, but the old scene embedding code/data is intentionally left for a later deletion pass after eval.
- `docs/roadmap/content-discovery/feat-193-remove-legacy-scene-embedding-pipeline.md` tracks that cleanup.

## Post-Merge Ops

After this deploy and DB migration, run transcript re-embeds with an explicit rewrite mode. Do not run scene re-embeds.

```bash
pnpm --filter @forge/admin run-embeds \
  --pipeline=transcript \
  --transcript-mode=model-upgrade \
  --report-out=docs/search-eval-reports/<prod-transcript-v2-backfill>.json
```

Then inspect `sourceGaps` / `missingArtifacts` and run the search eval gate before deleting legacy scene code.

## Test Plan

- `pnpm --filter @forge/admin test -- src/services/hybrid-search-retrievers.test.ts src/services/transcript-embedding-ingest.contract.test.ts src/scripts/run-embeds.test.ts src/workflows/transcriptEmbeddingBackfill.test.ts src/services/mastra-transcript-embedding-client.test.ts src/services/transcript-embedding-ingest.service.test.ts src/services/transcript-source-resolver.service.test.ts src/services/transcript-embedding.service.test.ts src/graphql/mutations/transcript-embedding.test.ts src/services/scene-recommendations-retriever.test.ts src/services/scene-recommendations.service.test.ts src/graphql/queries/scene-recommendations.test.ts src/app/api/scene-embedding/recommendations/route.test.ts src/graphql/schema.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/mastra test -- src/mastra/workflows/transcript-embedding.test.ts`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/manager test -- src/services/mastra-transcript-embeddings.test.ts src/workflows/transcriptOnlyPipeline.test.ts`
- `pnpm --filter @forge/manager typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
