### PR TITLE
fix(admin): normalize transcript backfill concurrency

### DIFF
--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
@@ -61,6 +61,7 @@ vi.mock("@/services/mastra-transcript-embedding-client", () => ({
 }))
 
 const { prisma } = await import("@/db/client")
+const { env } = await import("@/config/env")
 const { ManagerArtifactError, readTranscriptSourceArtifact } =
   await import("@/services/manager-artifacts.service")
 const { launchMastraTranscriptEmbedding } =
@@ -119,6 +120,9 @@ function target(
 
 describe("runTranscriptEmbeddingBackfill", () => {
   beforeEach(() => {
+    ;(
+      env as unknown as { TRANSCRIPT_EMBEDDING_CONCURRENCY: unknown }
+    ).TRANSCRIPT_EMBEDDING_CONCURRENCY = 2
     ;(prisma as unknown as PrismaStub).$queryRaw.mockReset()
     ;(
       prisma as unknown as {
@@ -463,6 +467,43 @@ Subtitle transcript text.
     })
 
     expect(observedMaxInFlight).toBe(2)
+  })
+
+  it("accepts raw string concurrency from the workflow runtime env", async () => {
+    ;(
+      env as unknown as { TRANSCRIPT_EMBEDDING_CONCURRENCY: unknown }
+    ).TRANSCRIPT_EMBEDDING_CONCURRENCY = "1"
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
+      row("v-a", "e-a", "core-a", "en"),
+      row("v-b", "e-b", "core-b", "en"),
+      row("v-c", "e-c", "core-c", "en"),
+    ])
+
+    let inFlight = 0
+    let observedMaxInFlight = 0
+    vi.mocked(launchMastraTranscriptEmbedding).mockImplementation(async () => {
+      inFlight += 1
+      observedMaxInFlight = Math.max(observedMaxInFlight, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      inFlight -= 1
+      return {
+        ok: true,
+        status: "created",
+        chunks: 1,
+        totalTokens: 4,
+        model: "openai/text-embedding-3-small",
+        provider: "openai",
+        dimensions: 1536,
+        mastraRunId: "run-1",
+        sourceContentHash: "sha256:test",
+      }
+    })
+
+    await runTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(observedMaxInFlight).toBe(1)
   })
 
   it("returns an empty report when the DB has no editions", async () => {

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
@@ -86,6 +86,17 @@ import { stepResolveSubtitleTranscriptSource } from "./_steps/resolve-transcript
  */
 export const DEFAULT_TRANSCRIPT_EMBEDDING_CONCURRENCY = 5
 
+function transcriptEmbeddingConcurrency(): number {
+  const value =
+    env.TRANSCRIPT_EMBEDDING_CONCURRENCY ??
+    DEFAULT_TRANSCRIPT_EMBEDDING_CONCURRENCY
+  const concurrency = Number(value)
+
+  return Number.isInteger(concurrency) && concurrency > 0
+    ? concurrency
+    : DEFAULT_TRANSCRIPT_EMBEDDING_CONCURRENCY
+}
+
 export type TranscriptEmbeddingBackfillInput = {
   /** S3 key of the JSON mapping snapshot uploaded via the admin refresh CLI. */
   mappingS3Key: string
@@ -255,9 +266,7 @@ export async function runTranscriptEmbeddingBackfill(
   // docs/solutions/best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md
   // for the canonical HOW. feat-132's per-language step now launches
   // Mastra instead of writing Manager-produced vectors directly.
-  const concurrency =
-    env.TRANSCRIPT_EMBEDDING_CONCURRENCY ??
-    DEFAULT_TRANSCRIPT_EMBEDDING_CONCURRENCY
+  const concurrency = transcriptEmbeddingConcurrency()
   const limit = pLimit(concurrency)
 
   // Structured start log so the workflow's effective concurrency is


### PR DESCRIPTION
## Summary\n- Normalize transcript embedding backfill concurrency at the workflow call site before passing it to p-limit\n- Add regression coverage for workflow/runtime env handing concurrency through as a raw string\n\n## Production context\nThe prod transcript model-upgrade backfill trigger failed with:\n\n`Expected concurrency to be a number from 1 and up`\n\nAdmin prod has `TRANSCRIPT_EMBEDDING_CONCURRENCY="1"`; this guard keeps the intended cap while avoiding a p-limit crash if the workflow runtime hands the env value through as a string.\n\n## Testing\n- `pnpm --filter @forge/admin test -- src/workflows/transcriptEmbeddingBackfill.test.ts`\n- `pnpm --filter @forge/admin typecheck`\n- `git diff --check`