### PR TITLE
feat(mastra): add transcript demographics signal

### DIFF
--- a/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
@@ -140,6 +140,7 @@ describe("transcript embedding workflow", () => {
             bibleVerses: [],
             contentSummary: "Hello there. This is a transcript.",
             tone: "reflective",
+            demographics: [],
             startSeconds: 0,
             endSeconds: 4,
             embedding: vector(1),
@@ -346,16 +347,16 @@ describe("transcript embedding workflow", () => {
     })
   })
 
-  it("plans v2 enriched chunks with source provenance and canonical felt needs", () => {
+  it("plans v2 enriched chunks with source provenance, canonical felt needs, and demographics", () => {
     const planned = planTranscriptEmbeddingRun(
       input({
         transcript: {
-          text: "Jesus gives hope and love in John 3:16.",
+          text: "Jesus gives hope and love to children and parents in the family in John 3:16.",
           segments: [
             {
               start: 65,
               end: 70,
-              text: "Jesus gives hope and love in John 3:16.",
+              text: "Jesus gives hope and love to children and parents in the family in John 3:16.",
             },
           ],
           artifactKey: "admin-video-subtitle/sub-1.vtt",
@@ -383,11 +384,16 @@ describe("transcript embedding workflow", () => {
       contentHash: expect.stringMatching(/^sha256:/),
     })
     expect(planned.chunks[0]).toMatchObject({
-      rawSourceText: "Jesus gives hope and love in John 3:16.",
+      rawSourceText:
+        "Jesus gives hope and love to children and parents in the family in John 3:16.",
       feltNeeds: ["Hope", "Love"],
       bibleVerses: ["John 3:16"],
+      demographics: ["Children", "Parents", "Families"],
       embeddingInputText: expect.stringContaining("Time range: 01:05-01:10"),
     })
+    expect(planned.chunks[0]?.embeddingInputText).toContain(
+      "Demographics: Children, Parents, Families",
+    )
   })
 
   it("preserves precise failures through the committed route launcher", async () => {

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.ts
@@ -40,6 +40,20 @@ type CanonicalFeltNeed =
   | "Security"
   | "Significance"
 
+type CanonicalDemographic =
+  | "Children"
+  | "Youth"
+  | "Young Adults"
+  | "Parents"
+  | "Families"
+  | "Women"
+  | "Men"
+  | "Religious Leaders"
+  | "Disciples"
+  | "Seekers"
+  | "Outsiders"
+  | "People in Crisis"
+
 const GenerationModeSchema = z
   .enum(["idempotent", "repair", "force", "model-upgrade"])
   .default("idempotent")
@@ -259,7 +273,7 @@ type PlannedChunk = {
   bibleVerses?: string[]
   contentSummary?: string
   tone?: string
-  demographics?: string[]
+  demographics?: CanonicalDemographic[]
   spiritualContext?: string[]
   extractionMetadata?: Record<string, unknown>
   tokenCount: number
@@ -470,6 +484,61 @@ function inferFeltNeeds(text: string): CanonicalFeltNeed[] {
   return needs
 }
 
+function inferDemographics(text: string): CanonicalDemographic[] {
+  const lower = text.toLowerCase()
+  const demographics: CanonicalDemographic[] = []
+  const add = (demographic: CanonicalDemographic) => {
+    if (!demographics.includes(demographic)) demographics.push(demographic)
+  }
+
+  if (/\b(child|children|kid|kids|little ones)\b/.test(lower)) add("Children")
+  if (/\b(youth|teen|teenager|teenagers|young people)\b/.test(lower)) {
+    add("Youth")
+  }
+  if (/\b(young man|young woman|young adult|young adults)\b/.test(lower)) {
+    add("Young Adults")
+  }
+  if (/\b(parent|parents|mother|father|mom|dad)\b/.test(lower)) add("Parents")
+  if (/\b(family|families|household|households)\b/.test(lower)) {
+    add("Families")
+  }
+  if (/\b(woman|women|wife|wives|widow|widows)\b/.test(lower)) add("Women")
+  if (/\b(man|men|husband|husbands)\b/.test(lower)) add("Men")
+  if (
+    /\b(pharisee|pharisees|priest|priests|rabbi|rabbis|teacher of the law|teachers of the law|religious leader|religious leaders)\b/.test(
+      lower,
+    )
+  ) {
+    add("Religious Leaders")
+  }
+  if (/\b(disciple|disciples|follower|followers)\b/.test(lower)) {
+    add("Disciples")
+  }
+  if (
+    /\b(seek|seeks|seeking|searched|searching|question|questions|asked him|ask him)\b/.test(
+      lower,
+    )
+  ) {
+    add("Seekers")
+  }
+  if (
+    /\b(samaritan|samaritans|gentile|gentiles|tax collector|tax collectors|foreigner|foreigners|outcast|outcasts|sinner|sinners)\b/.test(
+      lower,
+    )
+  ) {
+    add("Outsiders")
+  }
+  if (
+    /\b(sick|ill|blind|lame|leper|lepers|poor|hungry|prisoner|prisoners|mourning|grieving|possessed|oppressed)\b/.test(
+      lower,
+    )
+  ) {
+    add("People in Crisis")
+  }
+
+  return demographics
+}
+
 function enrichChunk(chunk: PlannedChunk): PlannedChunk {
   const rawSourceText = chunk.rawSourceText ?? chunk.text
   const feltNeeds = inferFeltNeeds(rawSourceText)
@@ -477,7 +546,7 @@ function enrichChunk(chunk: PlannedChunk): PlannedChunk {
   const contentSummary = summarizeChunkText(rawSourceText)
   const timeRange = `${formatTimeRange(chunk.startSeconds)}-${formatTimeRange(chunk.endSeconds)}`
   const tone = "reflective"
-  const demographics: string[] = []
+  const demographics = inferDemographics(rawSourceText)
   const spiritualContext = bibleVerses.length > 0 ? ["Bible reference"] : []
   const embeddingInputText = [
     `Time range: ${timeRange}`,
@@ -506,6 +575,7 @@ function enrichChunk(chunk: PlannedChunk): PlannedChunk {
     extractionMetadata: {
       strategy: "deterministic-transcript-grounded-v1",
       source: "transcript",
+      demographicsStrategy: "explicit-cue-taxonomy-v1",
     },
     tokenCount: estimateTokenCount(embeddingInputText),
   }

--- a/docs/solutions/runtime-errors/useworkflow-nested-group-step-event-log-corruption.md
+++ b/docs/solutions/runtime-errors/useworkflow-nested-group-step-event-log-corruption.md
@@ -1,0 +1,119 @@
+---
+title: "useworkflow group workers must be single durable steps"
+date: "2026-06-18"
+category: runtime-errors
+module: apps/admin
+problem_type: runtime_error
+component: background_job
+symptoms:
+  - "Production GraphQL trigger returned HTTP 200 with errors ['Unexpected error.'] after the transcript embedding backfill started"
+  - "Railway logs showed Workflow run failed with 1 uncommitted operation(s) for the processGroup step"
+  - "Workflow runtime reported Unconsumed event in event log and called the event log corrupted or invalid"
+  - "Local unit tests and type checks passed because they exercised the workflow body without the production event-log runtime"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components:
+  - apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
+  - apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
+  - apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
+tags:
+  - admin
+  - useworkflow
+  - workflows
+  - transcript-embeddings
+  - backfill
+  - event-log
+  - step-wrapper
+---
+
+# useworkflow group workers must be single durable steps
+
+## Problem
+
+The production transcript embedding backfill failed after it successfully started because the grouped worker was itself a `"use step"` and then called helpers that also created durable `"use step"` operations. The production workflow runtime rejected that nested step shape as an invalid event log, so a full-corpus backfill could not complete even though local checks were green.
+
+## Symptoms
+
+- Admin GraphQL returned a success-shaped HTTP response with `triggerTranscriptEmbeddingBackfill: null` and `errors: ["Unexpected error."]` after roughly 103 seconds.
+- Production logs showed the backfill start line, including `totalTargets=208073`, `groupCount=1452`, and `concurrency=1`, then some per-target skip/fail logs, then a workflow runtime failure.
+- The runtime error included `Workflow run failed with 1 uncommitted operation(s): step "step//./src/workflows/transcriptEmbeddingBackfill//processGroup"` and `Unconsumed event in event log`.
+- The earlier hotfix that coerced `TRANSCRIPT_EMBEDDING_CONCURRENCY` from string to number was necessary but separate. It fixed `p-limit` input validation, then exposed this deeper production-only workflow composition bug.
+
+## What Didn't Work
+
+- **Stopping after the env coercion hotfix.** The first failure was real: Railway env vars arrive as strings and `p-limit` requires a number. After that fix deployed, the retry reached the group-processing phase and failed for a different reason.
+- **Keeping `processGroup` as an inline step inside the workflow file.** The worker needed Node-only services such as transcript source resolution, S3 artifact reads, and Mastra launch code. Making the helper plain inside the workflow file risked dragging those imports into workflow compilation, while leaving it as a nested step corrupted the production event log.
+- **Trusting local workflow-body tests alone.** Vitest runs the function body in an inert-directive mode; it does not replay the durable event log the same way production does. The nested shape only failed once the compiled workflow runtime executed it.
+
+## Solution
+
+Move the grouped worker into one external step wrapper and make that wrapper the only durable boundary for per-group work.
+
+```ts
+// apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
+import { stepProcessTranscriptEmbeddingGroup } from "./_steps/process-transcript-embedding-group"
+
+const settled = await Promise.allSettled(
+  groups.map((group) =>
+    limit(() =>
+      stepProcessTranscriptEmbeddingGroup(group, input.mode ?? "idempotent"),
+    ),
+  ),
+)
+```
+
+```ts
+// apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
+export async function stepProcessTranscriptEmbeddingGroup(
+  group: BackfillGroup,
+  mode: MastraTranscriptEmbeddingMode,
+): Promise<BackfillOutcome[]> {
+  "use step"
+
+  const outcomes: BackfillOutcome[] = []
+  for (const target of group.targets) {
+    const subtitleResolution = await resolveSubtitleTranscriptSource(
+      prisma,
+      target,
+    )
+    // Resolve subtitle first, fall back to manager transcript source, then
+    // launch Mastra and return typed per-target outcomes.
+  }
+  return outcomes
+}
+```
+
+The guard test is intentionally simple and source-level because this is a structural workflow constraint:
+
+```ts
+it("uses one external group step so production workflow steps are not nested", async () => {
+  const source = await readFile(
+    new URL("./transcriptEmbeddingBackfill.ts", import.meta.url),
+    "utf8",
+  )
+
+  expect(source).toContain("stepProcessTranscriptEmbeddingGroup")
+  expect(source).not.toMatch(/\basync function processGroup\b/)
+})
+```
+
+## Why This Works
+
+Production sees one durable operation for each active group: `stepProcessTranscriptEmbeddingGroup`. Inside that boundary the code can call plain async helpers, load subtitle or manager transcript sources, launch Mastra, and emit typed outcomes without creating child workflow steps.
+
+The split also keeps the workflow file import graph cleaner. `transcriptEmbeddingBackfill.ts` owns orchestration, grouping, bounded parallelism, and reporting. `_steps/process-transcript-embedding-group.ts` owns Node-only group work and can import Prisma, S3-backed manager artifact readers, subtitle resolvers, and Mastra client services without forcing those details into the top-level workflow body.
+
+## Prevention
+
+- Treat grouped backfill workers as one durable step boundary. Do not create child `"use step"` functions from inside a per-group `"use step"` body.
+- If a group worker needs Node-only services, put it in an external `_steps/*` wrapper and import that single wrapper from the workflow file.
+- Add a structural guard test when fixing this class of bug. It should assert the workflow calls the external step wrapper and no longer defines the old inline grouped step.
+- Build or smoke the production workflow enough to exercise workflow manifest and step discovery. Local unit tests are still useful, but they cannot prove production event-log validity.
+
+## Related
+
+- [Workflow step bodies call plain helpers, never nested start](../best-practices/workflow-step-body-calls-service-not-sibling-workflow-20260517.md)
+- [Bounded parallelism pattern for admin per-target useworkflow loops](../best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md)
+- [useworkflow directives are inert in tests but enforced in production](../best-practices/workflow-dispatch-test-mode-divergence-20260421.md)
+- [Per-parent child memoization via loadedArtifact parameter widening](../best-practices/per-parent-child-memoization-loadedartifact-pattern-20260505.md)


### PR DESCRIPTION
## Summary

Transcript chunks now carry explicit demographic cues instead of always embedding `Demographics: None`. Mastra derives a controlled set of audience labels from the source transcript text, folds them into the vector input, and preserves them in the existing structured chunk metadata so semantic retrieval, filtering, and debugging can use the same signal after the backfill reruns.

This also compounds the production workflow hotfix learning from the transcript backfill: grouped useworkflow workers need one external durable step boundary, because nested group steps can corrupt the production event log even when local workflow-body tests are green.

## Notes

- Uses an explicit-cue taxonomy for v1: Children, Youth, Young Adults, Parents, Families, Women, Men, Religious Leaders, Disciples, Seekers, Outsiders, and People in Crisis.
- No Admin API or schema change is needed here; transcript chunk ingest already accepts and stores `demographics`.
- Existing production transcript rows still need the planned re-embed after this deploy before they contain the new demographic signal.

## Verification

- `pnpm --filter @forge/mastra test -- src/mastra/workflows/transcript-embedding.test.ts`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/mastra lint`
- `/home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.12.0/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/runtime-errors/useworkflow-nested-group-step-event-log-corruption.md`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
