### PR TITLE
fix(smart-crop): accept qa frame shot ids

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -4,6 +4,13 @@ Shared domain vocabulary for this project — entities, named processes, and sta
 
 ## Video & media
 
+### Smart Crop
+
+A Manager-orchestrated media-generation workflow that produces 9:16 vertical
+crop plans and renders from widescreen Mux videos. Manager owns durable job
+state and operator review, Mastra owns bounded AI crop decisions, and
+crop-worker owns FFmpeg fingerprint/render byte work.
+
 ### Core ID
 
 The stable identifier from the Core API for a Core-sourced entity. For source

--- a/apps/manager/CLAUDE.md
+++ b/apps/manager/CLAUDE.md
@@ -259,6 +259,10 @@ job-loss).
   `{assetId}/smart-crop-plan-progress-v1.json` (keyed to the fingerprint's
   `generatedAt`); retries resume from the first incomplete vision batch
   instead of re-paying completed LLM calls. `force` ignores the checkpoint.
+- **Face-first anchoring:** Mastra plan/repair responses may include optional
+  `faceVisible` and `faceCenter` segment metadata. Manager preserves those
+  fields for artifacts/debugging but does not calculate crop x positions; the
+  deterministic Mastra planner already emitted the final keyframes.
 - **QA is advisory:** mastra config-shaped QA failures
   (`frame_host_not_allowed`, `provider_config_missing`, `config_missing`,
   `auth_failed`, `provider_auth_failed`) degrade the QA step to `skipped` with

--- a/apps/manager/src/services/mastra-smart-crop.test.ts
+++ b/apps/manager/src/services/mastra-smart-crop.test.ts
@@ -19,6 +19,11 @@ const planSegment = {
   secondarySubjects: ["disciples"],
   avoidCutting: ["faces"],
   confidence: 0.94,
+  faceVisible: true,
+  faceCenter: {
+    start: { cx: 0.72, cy: 0.24 },
+    end: { cx: 0.73, cy: 0.24 },
+  },
   cropKeyframes: [
     { progress: 0, x: 520, y: 0, width: 606, height: 1080 },
     { progress: 1, x: 560, y: 0, width: 606, height: 1080 },

--- a/apps/manager/src/services/mastra-smart-crop.ts
+++ b/apps/manager/src/services/mastra-smart-crop.ts
@@ -69,6 +69,16 @@ export type SmartCropCropKeyframe = {
   height: number
 }
 
+export type SmartCropNormalizedPoint = {
+  cx: number
+  cy: number
+}
+
+export type SmartCropFaceCenter = {
+  start: SmartCropNormalizedPoint
+  end: SmartCropNormalizedPoint
+}
+
 export type SmartCropPlanSegment = {
   shotId: string
   canonicalStart: number
@@ -78,6 +88,8 @@ export type SmartCropPlanSegment = {
   secondarySubjects?: string[]
   avoidCutting?: string[]
   confidence: number
+  faceVisible?: boolean
+  faceCenter?: SmartCropFaceCenter | null
   cropKeyframes: SmartCropCropKeyframe[]
 }
 
@@ -264,6 +276,27 @@ function parseOptionalStringArray(value: unknown): string[] | undefined {
   return strings.length === value.length ? strings : undefined
 }
 
+function parseNormalizedPoint(value: unknown): SmartCropNormalizedPoint | null {
+  const point = asRecord(value)
+  if (!point || typeof point.cx !== "number" || typeof point.cy !== "number") {
+    return null
+  }
+  return { cx: point.cx, cy: point.cy }
+}
+
+function parseFaceCenter(value: unknown): SmartCropFaceCenter | null {
+  const center = asRecord(value)
+  if (!center) {
+    return null
+  }
+  const start = parseNormalizedPoint(center.start)
+  const end = parseNormalizedPoint(center.end)
+  if (!start || !end) {
+    return null
+  }
+  return { start, end }
+}
+
 function parsePlanSegment(value: unknown): SmartCropPlanSegment | null {
   const segment = asRecord(value)
   if (
@@ -301,7 +334,23 @@ function parsePlanSegment(value: unknown): SmartCropPlanSegment | null {
     })
   }
 
-  return {
+  if (
+    segment.faceVisible !== undefined &&
+    typeof segment.faceVisible !== "boolean"
+  ) {
+    return null
+  }
+  let faceCenter: SmartCropFaceCenter | null | undefined
+  if (segment.faceCenter === null) {
+    faceCenter = null
+  } else if (segment.faceCenter !== undefined) {
+    faceCenter = parseFaceCenter(segment.faceCenter) ?? undefined
+    if (!faceCenter) {
+      return null
+    }
+  }
+
+  const parsed: SmartCropPlanSegment = {
     shotId: segment.shotId,
     canonicalStart: segment.canonicalStart,
     canonicalEnd: segment.canonicalEnd,
@@ -315,6 +364,13 @@ function parsePlanSegment(value: unknown): SmartCropPlanSegment | null {
     confidence: segment.confidence,
     cropKeyframes,
   }
+  if (typeof segment.faceVisible === "boolean") {
+    parsed.faceVisible = segment.faceVisible
+  }
+  if (segment.faceCenter !== undefined) {
+    parsed.faceCenter = faceCenter
+  }
+  return parsed
 }
 
 function parsePlanResult(value: unknown): SmartCropPlanLaunchResult | null {

--- a/apps/manager/src/services/smartCrop.test.ts
+++ b/apps/manager/src/services/smartCrop.test.ts
@@ -41,6 +41,11 @@ const SEGMENT: SmartCropPlanSegment = {
   secondarySubjects: ["disciples"],
   avoidCutting: ["faces"],
   confidence: 0.94,
+  faceVisible: true,
+  faceCenter: {
+    start: { cx: 0.72, cy: 0.24 },
+    end: { cx: 0.73, cy: 0.24 },
+  },
   cropKeyframes: [
     { progress: 0, x: 520, y: 0, width: 606, height: 1080 },
     { progress: 1, x: 560, y: 0, width: 606, height: 1080 },
@@ -428,6 +433,9 @@ describe("artifact readers", () => {
   })
 
   it("parses plan artifacts and rejects malformed qa blocks", () => {
+    const legacySegment = { ...SEGMENT }
+    delete legacySegment.faceCenter
+    delete legacySegment.faceVisible
     const plan = assemblePlanArtifact({
       assetId: "asset123",
       muxAssetId: "mux_abc",
@@ -442,6 +450,15 @@ describe("artifact readers", () => {
     expect(parsePlanArtifact(JSON.parse(JSON.stringify(plan)))).toMatchObject({
       kind: "smart-crop-canonical-plan",
       qa: { status: "draft" },
+    })
+    const legacyPlan = {
+      ...plan,
+      segments: [legacySegment],
+    }
+    expect(
+      parsePlanArtifact(JSON.parse(JSON.stringify(legacyPlan))),
+    ).toMatchObject({
+      segments: [legacySegment],
     })
     expect(parsePlanArtifact({ ...plan, qa: { status: "maybe" } })).toBeNull()
   })

--- a/apps/manager/src/services/smartCrop.ts
+++ b/apps/manager/src/services/smartCrop.ts
@@ -535,6 +535,31 @@ function parseStringArray(value: unknown): string[] | undefined {
   return strings.length === value.length ? strings : undefined
 }
 
+function parseNormalizedPoint(
+  value: unknown,
+): { cx: number; cy: number } | null {
+  const point = asRecord(value)
+  if (!point || typeof point.cx !== "number" || typeof point.cy !== "number") {
+    return null
+  }
+  return { cx: point.cx, cy: point.cy }
+}
+
+function parseFaceCenter(
+  value: unknown,
+): SmartCropPlanSegment["faceCenter"] | null {
+  const center = asRecord(value)
+  if (!center) {
+    return null
+  }
+  const start = parseNormalizedPoint(center.start)
+  const end = parseNormalizedPoint(center.end)
+  if (!start || !end) {
+    return null
+  }
+  return { start, end }
+}
+
 // Validates a plan-segment array (used by both the final plan artifact and
 // the plan-progress checkpoint). Returns null when any entry is malformed.
 export function parsePlanSegments(
@@ -583,7 +608,23 @@ export function parsePlanSegments(
       })
     }
 
-    segments.push({
+    if (
+      segment.faceVisible !== undefined &&
+      typeof segment.faceVisible !== "boolean"
+    ) {
+      return null
+    }
+    let faceCenter: SmartCropPlanSegment["faceCenter"] | undefined
+    if (segment.faceCenter === null) {
+      faceCenter = null
+    } else if (segment.faceCenter !== undefined) {
+      faceCenter = parseFaceCenter(segment.faceCenter) ?? undefined
+      if (!faceCenter) {
+        return null
+      }
+    }
+
+    const parsed: SmartCropPlanSegment = {
       shotId: segment.shotId,
       canonicalStart: segment.canonicalStart,
       canonicalEnd: segment.canonicalEnd,
@@ -596,7 +637,14 @@ export function parsePlanSegments(
       avoidCutting: parseStringArray(segment.avoidCutting),
       confidence: segment.confidence,
       cropKeyframes,
-    })
+    }
+    if (typeof segment.faceVisible === "boolean") {
+      parsed.faceVisible = segment.faceVisible
+    }
+    if (segment.faceCenter !== undefined) {
+      parsed.faceCenter = faceCenter
+    }
+    segments.push(parsed)
   }
 
   return segments

--- a/apps/mastra/CLAUDE.md
+++ b/apps/mastra/CLAUDE.md
@@ -331,7 +331,10 @@ Three bounded synchronous workflows, each with a service route protected by
   `src/services/smart-crop/planner.ts`) converts intents into 9:16 crop
   keyframes (full source height, even crop width, 8% dead zone, 240 px/s max
   pan scaled by source width, center fallback below confidence 0.5,
-  slide_aware stays static centered in MVP).
+  slide_aware stays static centered in MVP). When a primary human face/head is
+  visible, plan/repair intents carry `faceVisible: true` plus `faceCenter`; the
+  planner anchors horizontally on that face center before falling back to the
+  broader `subjectCenter`.
 - `smart-crop-align` / `POST /forge-smart-crop-align` — pure deterministic
   alignment (`src/services/smart-crop/alignment.ts`) between canonical and
   localized `smart-crop-fingerprint` artifacts: tier-1 identical-duration or

--- a/apps/mastra/src/mastra/workflows/smart-crop-plan.test.ts
+++ b/apps/mastra/src/mastra/workflows/smart-crop-plan.test.ts
@@ -55,6 +55,7 @@ const cannedIntentResponse = {
                 start: { cx: 0.1, cy: 0.5 },
                 end: { cx: 0.9, cy: 0.5 },
               },
+              faceVisible: false,
             },
             {
               shotId: "shot_00421",
@@ -66,6 +67,11 @@ const cannedIntentResponse = {
               subjectCenter: {
                 start: { cx: 0.5, cy: 0.4 },
                 end: { cx: 0.52, cy: 0.4 },
+              },
+              faceVisible: true,
+              faceCenter: {
+                start: { cx: 0.75, cy: 0.22 },
+                end: { cx: 0.76, cy: 0.22 },
               },
             },
           ],
@@ -105,9 +111,14 @@ describe("smart crop plan workflow", () => {
           secondarySubjects: ["disciples"],
           avoidCutting: ["faces"],
           confidence: 0.94,
+          faceVisible: true,
+          faceCenter: {
+            start: { cx: 0.75, cy: 0.22 },
+            end: { cx: 0.76, cy: 0.22 },
+          },
           cropKeyframes: [
-            { progress: 0, x: 656, y: 0, width: 606, height: 1080 },
-            { progress: 1, x: 656, y: 0, width: 606, height: 1080 },
+            { progress: 0, x: 1136, y: 0, width: 606, height: 1080 },
+            { progress: 1, x: 1136, y: 0, width: 606, height: 1080 },
           ],
         },
         {
@@ -119,6 +130,7 @@ describe("smart crop plan workflow", () => {
           secondarySubjects: [],
           avoidCutting: [],
           confidence: 0.9,
+          faceVisible: false,
           cropKeyframes: [
             { progress: 0, x: 0, y: 0, width: 606, height: 1080 },
             { progress: 1, x: 480, y: 0, width: 606, height: 1080 },
@@ -152,6 +164,9 @@ describe("smart crop plan workflow", () => {
     expect(textParts.map((part) => part.text)).toContain(
       "shotId shot_00421 (124.2s-139.8s):",
     )
+    expect(textParts.map((part) => String(part.text)).join("\n")).toContain(
+      "faceCenter",
+    )
     const imageParts = body.messages[0]!.content.filter(
       (part) => part.type === "image_url",
     )
@@ -177,6 +192,11 @@ describe("smart crop plan workflow", () => {
                       start: { cx: 0.5, cy: 0.4 },
                       end: { cx: 0.5, cy: 0.4 },
                     },
+                    faceVisible: true,
+                    faceCenter: {
+                      start: { cx: 0.5, cy: 0.25 },
+                      end: { cx: 0.5, cy: 0.25 },
+                    },
                   },
                 ],
               }),
@@ -198,6 +218,67 @@ describe("smart crop plan workflow", () => {
       reason: "provider_invalid_output",
       retryable: false,
       mastraRunId: "run-missing-shot",
+    })
+  })
+
+  it("fails with provider_invalid_output when a visible face center is malformed", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                shots: [
+                  {
+                    shotId: "shot_00421",
+                    mode: "speaker",
+                    primarySubject: "Jesus",
+                    secondarySubjects: [],
+                    avoidCutting: ["faces"],
+                    confidence: 0.94,
+                    subjectCenter: {
+                      start: { cx: 0.5, cy: 0.4 },
+                      end: { cx: 0.5, cy: 0.4 },
+                    },
+                    faceVisible: true,
+                    faceCenter: {
+                      start: { cx: 1.2, cy: 0.25 },
+                      end: { cx: 0.5, cy: 0.25 },
+                    },
+                  },
+                  {
+                    shotId: "shot_00422",
+                    mode: "action",
+                    primarySubject: "runner",
+                    secondarySubjects: [],
+                    avoidCutting: [],
+                    confidence: 0.9,
+                    subjectCenter: {
+                      start: { cx: 0.1, cy: 0.5 },
+                      end: { cx: 0.9, cy: 0.5 },
+                    },
+                    faceVisible: false,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+    )
+
+    const result = await runSmartCropPlanWorkflow(baseInput, {
+      runId: "run-malformed-face-center",
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "provider_invalid_output",
+      retryable: false,
+      mastraRunId: "run-malformed-face-center",
     })
   })
 

--- a/apps/mastra/src/mastra/workflows/smart-crop-plan.ts
+++ b/apps/mastra/src/mastra/workflows/smart-crop-plan.ts
@@ -106,6 +106,20 @@ const CropKeyframeSchema = z
   })
   .strict()
 
+const NormalizedPointSchema = z
+  .object({
+    cx: z.number().min(0).max(1),
+    cy: z.number().min(0).max(1),
+  })
+  .strict()
+
+const FaceCenterSchema = z
+  .object({
+    start: NormalizedPointSchema,
+    end: NormalizedPointSchema,
+  })
+  .strict()
+
 const PlanSegmentSchema = z
   .object({
     shotId: z.string(),
@@ -116,6 +130,8 @@ const PlanSegmentSchema = z
     secondarySubjects: z.array(z.string()),
     avoidCutting: z.array(z.string()),
     confidence: z.number().min(0).max(1),
+    faceVisible: z.boolean().optional(),
+    faceCenter: FaceCenterSchema.nullable().optional(),
     cropKeyframes: z.array(CropKeyframeSchema).length(2),
   })
   .strict()
@@ -208,7 +224,7 @@ export async function runSmartCropPlanWorkflow(
     const segments: SmartCropPlanSegment[] = input.shots.map((shot, index) => {
       const intent = intents.intents[index]!
       const planned = intentToKeyframes(intent, shot, input.source)
-      return {
+      const segment: SmartCropPlanSegment = {
         shotId: shot.shotId,
         canonicalStart: shot.start,
         canonicalEnd: shot.end,
@@ -217,8 +233,13 @@ export async function runSmartCropPlanWorkflow(
         secondarySubjects: intent.secondarySubjects,
         avoidCutting: intent.avoidCutting,
         confidence: intent.confidence,
+        faceVisible: intent.faceVisible,
         cropKeyframes: planned.cropKeyframes,
       }
+      if (intent.faceCenter !== undefined) {
+        segment.faceCenter = intent.faceCenter
+      }
+      return segment
     })
 
     return {

--- a/apps/mastra/src/mastra/workflows/smart-crop-qa.test.ts
+++ b/apps/mastra/src/mastra/workflows/smart-crop-qa.test.ts
@@ -13,7 +13,11 @@ const baseInput = {
   renderMode: "preview",
   planSummary: { segmentCount: 412, modes: { speaker: 250, group: 100 } },
   frames: [
-    { atSeconds: 4, url: "https://image.mux.com/pb_abc/frame-001.jpg" },
+    {
+      atSeconds: 4,
+      url: "https://image.mux.com/pb_abc/frame-001.jpg",
+      shotId: "shot_00421",
+    },
     { atSeconds: 44, url: "https://image.mux.com/pb_abc/frame-002.jpg" },
   ],
   model: QA_MODEL,
@@ -98,7 +102,10 @@ describe("smart crop qa workflow", () => {
     const textParts = body.messages[0]!.content.filter(
       (part) => part.type === "text",
     )
-    expect(textParts.map((part) => part.text)).toContain("frame at 4s:")
+    expect(textParts.map((part) => part.text)).toContain(
+      "frame at 4s (shotId shot_00421):",
+    )
+    expect(textParts.map((part) => part.text)).toContain("frame at 44s:")
     expect(String(textParts[0]!.text)).toContain('"segmentCount":412')
     const imageParts = body.messages[0]!.content.filter(
       (part) => part.type === "image_url",

--- a/apps/mastra/src/mastra/workflows/smart-crop-qa.ts
+++ b/apps/mastra/src/mastra/workflows/smart-crop-qa.ts
@@ -53,6 +53,7 @@ export const SmartCropQaInputSchema = z
           .object({
             atSeconds: z.number().min(0),
             url: z.string().url(),
+            shotId: z.string().min(1).optional(),
           })
           .strict(),
       )

--- a/apps/mastra/src/mastra/workflows/smart-crop-repair.test.ts
+++ b/apps/mastra/src/mastra/workflows/smart-crop-repair.test.ts
@@ -95,6 +95,7 @@ const cannedRepairResponse = {
                 start: { cx: 0.52, cy: 0.5 },
                 end: { cx: 0.52, cy: 0.5 },
               },
+              faceVisible: false,
             },
             {
               shotId: "shot_00421",
@@ -106,6 +107,11 @@ const cannedRepairResponse = {
               subjectCenter: {
                 start: { cx: 0.45, cy: 0.45 },
                 end: { cx: 0.4, cy: 0.45 },
+              },
+              faceVisible: true,
+              faceCenter: {
+                start: { cx: 0.7, cy: 0.24 },
+                end: { cx: 0.8, cy: 0.24 },
               },
             },
           ],
@@ -135,6 +141,11 @@ function intent(shotId: string) {
       start: { cx: 0.5, cy: 0.5 },
       end: { cx: 0.5, cy: 0.5 },
     },
+    faceVisible: true,
+    faceCenter: {
+      start: { cx: 0.5, cy: 0.25 },
+      end: { cx: 0.5, cy: 0.25 },
+    },
   }
 }
 
@@ -160,9 +171,14 @@ describe("smart crop repair workflow", () => {
           secondarySubjects: ["disciples"],
           avoidCutting: ["faces", "hands"],
           confidence: 0.92,
+          faceVisible: true,
+          faceCenter: {
+            start: { cx: 0.7, cy: 0.24 },
+            end: { cx: 0.8, cy: 0.24 },
+          },
           cropKeyframes: [
-            { progress: 0, x: 560, y: 0, width: 606, height: 1080 },
-            { progress: 1, x: 464, y: 0, width: 606, height: 1080 },
+            { progress: 0, x: 1040, y: 0, width: 606, height: 1080 },
+            { progress: 1, x: 1232, y: 0, width: 606, height: 1080 },
           ],
         },
         {
@@ -174,6 +190,7 @@ describe("smart crop repair workflow", () => {
           secondarySubjects: ["Jesus"],
           avoidCutting: ["faces"],
           confidence: 0.45,
+          faceVisible: false,
           cropKeyframes: [
             { progress: 0, x: 656, y: 0, width: 606, height: 1080 },
             { progress: 1, x: 656, y: 0, width: 606, height: 1080 },
@@ -211,6 +228,7 @@ describe("smart crop repair workflow", () => {
       .map((part) => String(part.text))
       .join("\n")
     expect(text).toContain("Return one replacement crop intent")
+    expect(text).toContain("faceCenter")
     expect(text).toContain("Subject drifts too far left")
     expect(text).toContain("previousSegment:")
     const imageParts = body.messages[0]!.content.filter(

--- a/apps/mastra/src/mastra/workflows/smart-crop-repair.ts
+++ b/apps/mastra/src/mastra/workflows/smart-crop-repair.ts
@@ -45,6 +45,20 @@ const CropKeyframeSchema = z
   })
   .strict()
 
+const NormalizedPointSchema = z
+  .object({
+    cx: z.number().min(0).max(1),
+    cy: z.number().min(0).max(1),
+  })
+  .strict()
+
+const FaceCenterSchema = z
+  .object({
+    start: NormalizedPointSchema,
+    end: NormalizedPointSchema,
+  })
+  .strict()
+
 const PlanSegmentSchema = z
   .object({
     shotId: z.string().min(1),
@@ -55,6 +69,8 @@ const PlanSegmentSchema = z
     secondarySubjects: z.array(z.string()),
     avoidCutting: z.array(z.string()),
     confidence: z.number().min(0).max(1),
+    faceVisible: z.boolean().optional(),
+    faceCenter: FaceCenterSchema.nullable().optional(),
     cropKeyframes: z.array(CropKeyframeSchema).length(2),
   })
   .strict()
@@ -281,7 +297,7 @@ function segmentFromIntent(
     source,
   )
 
-  return {
+  const segment: SmartCropRepairSegment = {
     shotId: shot.shotId,
     canonicalStart: previousSegment.canonicalStart,
     canonicalEnd: previousSegment.canonicalEnd,
@@ -290,8 +306,13 @@ function segmentFromIntent(
     secondarySubjects: intent.secondarySubjects,
     avoidCutting: intent.avoidCutting,
     confidence: intent.confidence,
+    faceVisible: intent.faceVisible,
     cropKeyframes: planned.cropKeyframes,
   }
+  if (intent.faceCenter !== undefined) {
+    segment.faceCenter = intent.faceCenter
+  }
+  return segment
 }
 
 export async function runSmartCropRepairWorkflow(

--- a/apps/mastra/src/services/smart-crop/openrouter-vision.ts
+++ b/apps/mastra/src/services/smart-crop/openrouter-vision.ts
@@ -183,6 +183,7 @@ export type SmartCropQaIssue = {
 export type SmartCropQaFrame = {
   atSeconds: number
   url: string
+  shotId?: string
 }
 
 export type RequestRenderQaReviewOptions = {
@@ -695,7 +696,11 @@ export async function requestRenderQaReview({
 
   const content: UserContentPart[] = [{ type: "text", text: instruction }]
   for (const frame of frames) {
-    content.push({ type: "text", text: `frame at ${frame.atSeconds}s:` })
+    const shotIdLabel = frame.shotId ? ` (shotId ${frame.shotId})` : ""
+    content.push({
+      type: "text",
+      text: `frame at ${frame.atSeconds}s${shotIdLabel}:`,
+    })
     content.push({ type: "image_url", image_url: { url: frame.url } })
   }
 

--- a/apps/mastra/src/services/smart-crop/openrouter-vision.ts
+++ b/apps/mastra/src/services/smart-crop/openrouter-vision.ts
@@ -10,7 +10,11 @@
 
 import { z } from "zod"
 
-import { SMART_CROP_MODES, type SmartCropMode } from "./planner"
+import {
+  SMART_CROP_MODES,
+  type SmartCropMode,
+  type SmartCropSubjectCenter,
+} from "./planner"
 
 const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions"
@@ -83,10 +87,9 @@ export type SmartCropShotIntent = {
   secondarySubjects: string[]
   avoidCutting: string[]
   confidence: number
-  subjectCenter: {
-    start: { cx: number; cy: number }
-    end: { cx: number; cy: number }
-  }
+  subjectCenter: SmartCropSubjectCenter
+  faceVisible: boolean
+  faceCenter?: SmartCropSubjectCenter | null
 }
 
 export type RequestShotCropIntentsOptions = {
@@ -123,6 +126,13 @@ const NormalizedPointSchema = z
   })
   .strict()
 
+const SubjectCenterSchema = z
+  .object({
+    start: NormalizedPointSchema,
+    end: NormalizedPointSchema,
+  })
+  .strict()
+
 const ShotIntentSchema = z
   .object({
     shotId: z.string().min(1),
@@ -131,14 +141,20 @@ const ShotIntentSchema = z
     secondarySubjects: z.array(z.string()),
     avoidCutting: z.array(z.string()),
     confidence: z.number().min(0).max(1),
-    subjectCenter: z
-      .object({
-        start: NormalizedPointSchema,
-        end: NormalizedPointSchema,
-      })
-      .strict(),
+    subjectCenter: SubjectCenterSchema,
+    faceVisible: z.boolean(),
+    faceCenter: SubjectCenterSchema.nullable().optional(),
   })
   .strict()
+  .superRefine((intent, ctx) => {
+    if (intent.faceVisible && intent.faceCenter == null) {
+      ctx.addIssue({
+        code: "custom",
+        message: "faceCenter is required when faceVisible is true",
+        path: ["faceCenter"],
+      })
+    }
+  })
 
 const ShotIntentsResponseSchema = z
   .object({
@@ -211,6 +227,16 @@ const NORMALIZED_POINT_JSON_SCHEMA = {
   required: ["cx", "cy"],
 } as const
 
+const SUBJECT_CENTER_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    start: NORMALIZED_POINT_JSON_SCHEMA,
+    end: NORMALIZED_POINT_JSON_SCHEMA,
+  },
+  required: ["start", "end"],
+} as const
+
 const SHOT_INTENTS_JSON_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -227,8 +253,10 @@ const SHOT_INTENTS_JSON_SCHEMA = {
           secondarySubjects: { type: "array", items: { type: "string" } },
           avoidCutting: { type: "array", items: { type: "string" } },
           confidence: { type: "number", minimum: 0, maximum: 1 },
-          subjectCenter: {
-            type: "object",
+          subjectCenter: SUBJECT_CENTER_JSON_SCHEMA,
+          faceVisible: { type: "boolean" },
+          faceCenter: {
+            type: ["object", "null"],
             additionalProperties: false,
             properties: {
               start: NORMALIZED_POINT_JSON_SCHEMA,
@@ -245,6 +273,8 @@ const SHOT_INTENTS_JSON_SCHEMA = {
           "avoidCutting",
           "confidence",
           "subjectCenter",
+          "faceVisible",
+          "faceCenter",
         ],
       },
     },
@@ -430,7 +460,9 @@ function buildPlanInstruction(cropMode: string): string {
     "- secondarySubjects: array of short strings for other notable subjects.",
     "- avoidCutting: array of elements the crop must not cut (faces, on-screen text, ...).",
     "- confidence: 0..1 for how certain you are about the subject placement.",
-    "- subjectCenter: start and end position of the primary subject as NORMALIZED cx, cy in [0,1] (cx from left, cy from top). Only horizontal panning matters for the crop, but cy is still required.",
+    "- subjectCenter: start and end position of the primary subject/body as NORMALIZED cx, cy in [0,1] (cx from left, cy from top). Only horizontal panning matters for the crop, but cy is still required.",
+    "- faceVisible: true when the primary human subject's face/head is visible in the shot frames; otherwise false.",
+    "- faceCenter: start and end NORMALIZED cx, cy of the visible face/head when faceVisible is true; otherwise null. Do not use the torso/body center as faceCenter.",
     "Use the shot's frames in order (start to end). Return JSON only.",
   ].join("\n")
 }
@@ -446,7 +478,9 @@ function buildRepairInstruction(): string {
     "- secondarySubjects: array of short strings for other notable subjects.",
     "- avoidCutting: array of elements the crop must not cut (faces, on-screen text, ...).",
     "- confidence: 0..1 for how certain you are about the repaired subject placement.",
-    "- subjectCenter: repaired start/end position of the primary subject as NORMALIZED cx, cy in [0,1] (cx from left, cy from top).",
+    "- subjectCenter: repaired start/end position of the primary subject/body as NORMALIZED cx, cy in [0,1] (cx from left, cy from top).",
+    "- faceVisible: true when the primary human subject's face/head is visible in the shot frames; otherwise false.",
+    "- faceCenter: repaired start/end NORMALIZED cx, cy of the visible face/head when faceVisible is true; otherwise null. Do not use the torso/body center as faceCenter.",
     "Return JSON only.",
   ].join("\n")
 }

--- a/apps/mastra/src/services/smart-crop/planner.test.ts
+++ b/apps/mastra/src/services/smart-crop/planner.test.ts
@@ -107,6 +107,49 @@ describe("smart crop planner", () => {
       expect(planned.cropKeyframes[1].x).toBe(656)
     })
 
+    it("prefers a visible face center over the broader subject center", () => {
+      const planned = intentToKeyframes(
+        intent({
+          subjectCenter: {
+            start: { cx: 0.45, cy: 0.5 },
+            end: { cx: 0.45, cy: 0.5 },
+          },
+          faceVisible: true,
+          faceCenter: {
+            start: { cx: 0.75, cy: 0.22 },
+            end: { cx: 0.76, cy: 0.22 },
+          },
+        }),
+        { start: 0, end: 10 },
+        HD_SOURCE,
+      )
+
+      // Face x0=1136, raw x1=1156, then dead zone collapses to static face x.
+      expect(planned.cropKeyframes[0].x).toBe(1136)
+      expect(planned.cropKeyframes[1].x).toBe(1136)
+    })
+
+    it("falls back to the subject center when no visible face anchor is present", () => {
+      const planned = intentToKeyframes(
+        intent({
+          subjectCenter: {
+            start: { cx: 0.5, cy: 0.5 },
+            end: { cx: 0.5, cy: 0.5 },
+          },
+          faceVisible: false,
+          faceCenter: {
+            start: { cx: 0.75, cy: 0.22 },
+            end: { cx: 0.75, cy: 0.22 },
+          },
+        }),
+        { start: 0, end: 10 },
+        HD_SOURCE,
+      )
+
+      expect(planned.cropKeyframes[0].x).toBe(656)
+      expect(planned.cropKeyframes[1].x).toBe(656)
+    })
+
     it("treats an explicit center_fallback intent as static centered", () => {
       const planned = intentToKeyframes(
         intent({

--- a/apps/mastra/src/services/smart-crop/planner.ts
+++ b/apps/mastra/src/services/smart-crop/planner.ts
@@ -46,6 +46,8 @@ export type SmartCropPlannerIntent = {
   mode: SmartCropMode
   confidence: number
   subjectCenter: SmartCropSubjectCenter
+  faceVisible?: boolean
+  faceCenter?: SmartCropSubjectCenter | null
 }
 
 export type SmartCropPlannedKeyframes = {
@@ -100,6 +102,14 @@ function staticKeyframes(
   ]
 }
 
+function cropAnchorCenter(
+  intent: SmartCropPlannerIntent,
+): SmartCropSubjectCenter {
+  return intent.faceVisible === true && intent.faceCenter
+    ? intent.faceCenter
+    : intent.subjectCenter
+}
+
 /**
  * Convert one shot's crop intent into exactly two crop keyframes.
  *
@@ -130,12 +140,9 @@ export function intentToKeyframes(
     }
   }
 
-  const x0 = xForSubjectCenter(
-    intent.subjectCenter.start.cx,
-    source,
-    window.width,
-  )
-  let x1 = xForSubjectCenter(intent.subjectCenter.end.cx, source, window.width)
+  const anchorCenter = cropAnchorCenter(intent)
+  const x0 = xForSubjectCenter(anchorCenter.start.cx, source, window.width)
+  let x1 = xForSubjectCenter(anchorCenter.end.cx, source, window.width)
 
   if (Math.abs(x1 - x0) < DEAD_ZONE_CROP_WIDTH_FRACTION * window.width) {
     x1 = x0

--- a/docs/plans/2026-06-09-002-feat-smart-crop-plan.md
+++ b/docs/plans/2026-06-09-002-feat-smart-crop-plan.md
@@ -423,12 +423,19 @@ Shared failure reasons: `invalid_input | provider_config_missing | provider_auth
     "segmentCount": 412,
     "modes": { "speaker": 250, "group": 100 }
   },
-  "frames": [{ "atSeconds": 4, "url": "https://<presigned-or-mux-url>" }],
+  "frames": [
+    {
+      "atSeconds": 4,
+      "url": "https://<presigned-or-mux-url>",
+      "shotId": "shot_00421"
+    }
+  ],
   "model": "google/gemini-2.5-flash"
 }
 ```
 
 - Success: `{ "ok": true, "verdict": "pass", "issues": [...], "usage": {...}, "model": "..." }`.
+- `frames[].shotId` is optional context for shot-scoped QA issues.
 - ≤ 8 frames per call. Same https/host allowlist as plan route (S3 endpoint
   host must be added to the allowlist in production).
 

--- a/docs/plans/2026-06-17-002-feat-smart-crop-face-anchor-plan.md
+++ b/docs/plans/2026-06-17-002-feat-smart-crop-face-anchor-plan.md
@@ -1,0 +1,172 @@
+---
+title: "Smart Crop face-first speaker anchoring"
+type: feat
+status: complete
+date: 2026-06-17
+---
+
+# Smart Crop face-first speaker anchoring
+
+## Summary
+
+Make Smart Crop anchor `speaker` and visible-person shots on the visible face/head rather than the torso when a face is present. This keeps the existing Manager-orchestrates, Mastra-decides, crop-worker-renders split while improving crop placement for shots where the current generic subject center can cut off a speaker's face.
+
+---
+
+## Problem Frame
+
+Smart Crop currently asks Mastra's vision model for one generic `subjectCenter` per shot. The deterministic planner turns that point into horizontal 9:16 crop keyframes. In speaker shots, the model can choose a body or torso center even when a face is visible, which can leave the face near or beyond the crop edge while preserving empty background.
+
+---
+
+## Requirements
+
+### Face anchoring
+
+- R1. For `speaker` and person-focused shots with a visible face, Smart Crop must calculate crop keyframes from the face/head center instead of the body center.
+- R2. When no face is visible or the model cannot identify one with confidence, Smart Crop must preserve the current `subjectCenter` fallback behavior.
+- R3. Initial plan and repair plan prompts must both instruct the vision model to prefer face/head anchors for visible people.
+
+### Compatibility
+
+- R4. The crop-worker render contract must remain unchanged because it consumes final crop keyframes, not semantic subject anchors.
+- R5. Existing Smart Crop plan artifacts without face-anchor fields must continue to parse and render.
+- R6. Manager must not import Mastra code or make AI crop decisions; it may only accept additive plan metadata and persist Mastra-computed keyframes.
+
+### Verification
+
+- R7. Unit coverage must prove that visible-face intents produce right/left-adjusted crop keyframes that keep the face centered, and face-absent intents keep the current subject-center behavior.
+- R8. Repair coverage must prove that face-aware repair output validates exactly like initial plan output and can replace affected shot segments without changing unaffected shots.
+
+---
+
+## Key Technical Decisions
+
+- **Additive face anchor contract:** Extend Mastra's shot-intent JSON with optional face visibility and face-center fields while keeping `subjectCenter` required for backwards-compatible fallback and model clarity.
+- **Planner chooses the anchor:** Keep the deterministic decision in `intentToKeyframes`: use face center only when the intent says a face is visible and both start/end face centers are valid; otherwise use `subjectCenter`.
+- **Prompt and schema change instead of crop-worker change:** crop-worker should remain semantic-free. It already renders whatever `cropKeyframes` Mastra produces.
+- **Repair uses the same anchoring rule:** Repair prompts must tell the model to move the crop to preserve visible faces/heads. The repair route should return replacement segments that have already run through the same face-aware planner.
+- **Plan metadata remains optional:** If face anchor details are persisted on segments for debugging, Manager parsers must treat them as optional and old artifacts must remain valid.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Manager samples shot frames"] --> B["Mastra vision prompt"]
+  B --> C["Shot intent: subjectCenter + optional face anchor"]
+  C --> D{"face visible?"}
+  D -->|"yes"| E["Planner uses face/head center"]
+  D -->|"no"| F["Planner uses subject center"]
+  E --> G["Crop keyframes"]
+  F --> G
+  G --> H["Manager persists plan segment"]
+  H --> I["crop-worker renders existing keyframes"]
+```
+
+The only semantic change is before keyframe generation. Once Mastra emits `cropKeyframes`, Manager and crop-worker follow the existing artifact and render paths.
+
+---
+
+## Implementation Units
+
+### U1. Face-aware intent schema and prompts
+
+- **Goal:** Teach the initial Smart Crop plan and repair model contracts to report visible-face anchoring separately from generic subject anchoring.
+- **Requirements:** R1, R2, R3, R5.
+- **Dependencies:** None.
+- **Files:** `apps/mastra/src/services/smart-crop/openrouter-vision.ts`, `apps/mastra/src/mastra/workflows/smart-crop-plan.ts`, `apps/mastra/src/mastra/workflows/smart-crop-repair.ts`, `apps/mastra/src/mastra/workflows/smart-crop-plan.test.ts`, `apps/mastra/src/mastra/workflows/smart-crop-repair.test.ts`.
+- **Approach:** Extend the local Zod response schema with `faceVisible` and optional `faceCenter` for start/end normalized points. Update both plan and repair instructions so visible people use the face/head center as the crop anchor, not the torso, while still returning `subjectCenter` for fallback. Keep the response schema strict for known fields once the contract is updated.
+- **Patterns to follow:** Existing `ShotIntentSchema`, `SHOT_INTENTS_RESPONSE_SCHEMA`, and repair validation that requires every requested `shotId` exactly once.
+- **Test scenarios:** A plan response with `faceVisible: true` and `faceCenter` parses successfully; a response with `faceVisible: false` and no `faceCenter` parses successfully; malformed face-center coordinates are rejected; repair responses follow the same rules; responses with missing or extra shot ids still fail.
+- **Verification:** Mastra Smart Crop plan and repair tests cover the new fields without changing service route auth or failure envelopes.
+
+### U2. Face-first deterministic planner
+
+- **Goal:** Convert face-aware intents into crop keyframes using the face/head center when available and the current subject center otherwise.
+- **Requirements:** R1, R2, R4, R7.
+- **Dependencies:** U1.
+- **Files:** `apps/mastra/src/services/smart-crop/planner.ts`, `apps/mastra/src/services/smart-crop/planner.test.ts`.
+- **Approach:** Add an anchor-selection helper inside the planner. The helper returns face start/end centers only when `faceVisible` is true and `faceCenter` is present; otherwise it returns `subjectCenter`. Leave the crop window, confidence fallback, dead zone, pan-speed cap, `slide_aware` centered behavior, and final keyframe format unchanged.
+- **Patterns to follow:** Existing `xForSubjectCenter`, confidence fallback, dead-zone, and pan-speed tests.
+- **Test scenarios:** A visible face at `cx=0.8` produces a crop shifted right even when body `subjectCenter.cx` is centered; visible face start/end centers produce animated keyframes; `faceVisible: false` uses `subjectCenter`; missing `faceCenter` uses `subjectCenter`; low confidence still falls back to centered crop; `slide_aware` still uses static centered crop.
+- **Verification:** Planner tests prove the face-first branch and every fallback branch.
+
+### U3. Manager additive metadata tolerance
+
+- **Goal:** Keep Manager compatible with optional face-anchor plan metadata while preserving legacy artifacts.
+- **Requirements:** R5, R6.
+- **Dependencies:** U1, U2.
+- **Files:** `apps/manager/src/services/mastra-smart-crop.ts`, `apps/manager/src/services/smartCrop.ts`, `apps/manager/src/services/mastra-smart-crop.test.ts`, `apps/manager/src/services/smartCrop.test.ts`.
+- **Approach:** If Mastra plan segments expose face-anchor metadata for operator debugging, thread the fields as optional plan-segment properties and keep duck-typed parsers tolerant. Do not make Manager recompute crop `x` positions. If implementation keeps face fields internal to Mastra and only emits keyframes, this unit reduces to type/parser no-op verification.
+- **Patterns to follow:** Existing optional `primarySubject`, `secondarySubjects`, and `avoidCutting` handling.
+- **Test scenarios:** Manager accepts current plan segments with no face fields; Manager accepts plan segments with optional face-anchor metadata if emitted; parsed crop keyframes remain the source of truth; old artifacts continue to summarize and render.
+- **Verification:** Manager service tests show additive compatibility and no cross-app imports.
+
+### U4. Real-shot repair validation and documentation
+
+- **Goal:** Cover the screenshot-shaped failure mode and document the face-first Smart Crop rule for future operators and agents.
+- **Requirements:** R3, R7, R8.
+- **Dependencies:** U1, U2, U3.
+- **Files:** `apps/mastra/src/services/smart-crop/openrouter-vision.ts`, `apps/mastra/src/services/smart-crop/planner.test.ts`, `apps/manager/CLAUDE.md`, `apps/mastra/CLAUDE.md`, `docs/roadmap/media-generation/feat-173-smart-crop-video-reframing.md`.
+- **Approach:** Add a regression fixture or test case equivalent to a speaker whose body is partly centered but whose visible face is near the right side of the frame. Document that Smart Crop anchors on visible faces for people-first shots and falls back to the full subject only when face anchoring is unavailable.
+- **Patterns to follow:** Existing package guide env/contract notes and the feat-173 roadmap entry-point style.
+- **Test scenarios:** Given a speaker intent with body center near `0.5` and face center near `0.75`, the keyframes track the face center; given a repair intent for a "face cut off" issue, replacement segments use face-aware anchoring; documentation mentions that crop-worker remains unchanged.
+- **Verification:** Focused Mastra tests pass and package docs describe the new anchoring rule without changing artifact key literals.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add a deterministic face detector or new media-analysis dependency.
+- This plan does not add manual crop editing, drag handles, or operator-authored keyframes.
+- This plan does not change scene detection sensitivity, shot segmentation, timeline alignment gates, or crop-worker rendering.
+- This plan does not change the 9:16-only, horizontal-pan MVP rule.
+
+### Deferred to Follow-Up Work
+
+- Add deterministic face detection on sampled frames if prompt/schema anchoring remains too inconsistent for production review.
+- Expose face-anchor debug overlays in the Manager UI if operators need to compare face center, body center, and final crop box.
+
+---
+
+## Risks & Dependencies
+
+- **Provider compliance risk:** Vision models may omit or misplace face anchors. Mitigation: strict schema validation plus fallback to `subjectCenter` when face anchor data is absent.
+- **Over-tight face framing:** Centering only on a face can crop hands, objects, or text in some shots. Mitigation: keep `avoidCutting`, mode, confidence fallback, dead zone, and QA/repair loop in place.
+- **Schema drift across apps:** Mastra and Manager carry local copies of plan segment shapes. Mitigation: keep face metadata optional and preserve crop keyframes as the render contract.
+- **Repair inconsistency:** Initial plan and repair could use different anchoring rules. Mitigation: route both through the same `intentToKeyframes` helper and update both prompts.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a speaker shot where the person's torso is centered but the visible face is near the right crop edge, when Mastra returns a visible face center, then the generated crop keyframes shift right to keep the face/head inside the 9:16 crop.
+- AE2. Given a person shot with no visible face, when Mastra returns no face center, then Smart Crop uses the existing subject-center keyframe behavior.
+- AE3. Given an old plan artifact without face-anchor fields, when Manager parses it, then the job detail page and crop-worker render path still use its existing crop keyframes.
+- AE4. Given a repair issue describing a cut-off face, when Mastra returns replacement intent for the affected shot, then the replacement segment is generated with the same face-first planner rule and Manager replaces only that shot.
+
+---
+
+## Verification
+
+- `pnpm --filter @forge/mastra test -- planner.test.ts smart-crop-plan.test.ts smart-crop-repair.test.ts`
+- `pnpm --filter @forge/mastra typecheck`
+- `pnpm --filter @forge/mastra lint`
+- `pnpm --filter @forge/manager test -- mastra-smart-crop.test.ts smartCrop.test.ts`
+- `pnpm --filter @forge/manager typecheck`
+- `pnpm --filter @forge/manager lint`
+- Browser smoke against an existing Smart Crop job or mock artifact where the original speaker crop box should shift toward the face after a force rerun.
+
+---
+
+## Sources / Research
+
+- `docs/roadmap/media-generation/feat-173-smart-crop-video-reframing.md` defines Smart Crop ownership and active entry points.
+- `docs/plans/2026-06-09-002-feat-smart-crop-plan.md` defines the current plan/fingerprint/render artifacts and the horizontal-only MVP crop rule.
+- `docs/plans/2026-06-16-003-feat-smart-crop-repair-loop-plan.md` defines the repair loop and attempt artifacts that must use the same anchoring semantics.
+- `docs/solutions/architecture-patterns/smart-crop-three-app-decomposition-20260610.md` preserves the Manager/Mastra/crop-worker boundary.
+- `apps/mastra/src/services/smart-crop/openrouter-vision.ts` owns the current `subjectCenter` prompt and response schema.
+- `apps/mastra/src/services/smart-crop/planner.ts` owns deterministic normalized-anchor-to-keyframe math.
+- `apps/crop-worker/src/render.ts` confirms crop-worker renders existing keyframes and should not receive semantic face data.

--- a/docs/roadmap/media-generation/feat-173-smart-crop-video-reframing.md
+++ b/docs/roadmap/media-generation/feat-173-smart-crop-video-reframing.md
@@ -65,6 +65,8 @@ asset creation from presigned artifact URLs.
 - Job/step statuses stay within existing closed enums; no admin schema changes.
 - New env vars `.optional()` at schema load; production enforcement at runtime.
 - 9:16 only in MVP; no frame-level tracking; no manual crop editor.
+- For speaker/person shots, Mastra should prefer visible face/head centers
+  over broader body centers when emitting deterministic 9:16 crop keyframes.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Smart Crop QA no longer rejects Manager preview-frame payloads that include shot context. Manager already sends `frames[].shotId` so QA issues can be tied back to a rendered shot, but Mastra's QA schema only allowed `atSeconds` and `url`, causing `invalid_input` before the QA model ran.

Mastra now accepts optional frame `shotId` values and includes them in the QA prompt text when present. The documented QA contract now shows `shotId` as optional context for shot-scoped issues.

## Validation

- `pnpm --filter @forge/mastra test -- src/mastra/workflows/smart-crop-qa.test.ts`
- `pnpm --filter @forge/manager test -- src/workflows/smartCrop.test.ts`
- `pnpm --filter @forge/mastra typecheck`
- `pnpm --filter @forge/mastra lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
