### PR TITLE
fix(manager): hide group rows from smart crop picker

### DIFF
--- a/apps/manager/src/features/smart-crop/smart-crop-picker.test.ts
+++ b/apps/manager/src/features/smart-crop/smart-crop-picker.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import { flattenSmartCropPickerVideos } from "./smart-crop-picker"
+
+describe("flattenSmartCropPickerVideos", () => {
+  it("keeps source videos while dropping collection and series groups", () => {
+    expect(
+      flattenSmartCropPickerVideos({
+        collections: [
+          {
+            id: "nua-series",
+            coreId: "7_KnowGod",
+            title: "Know God",
+            slug: "Nua_Know_God",
+            imageUrl: null,
+            label: "SERIES",
+            videos: [
+              {
+                id: "nua-easter-trailer",
+                coreId: "7_0-EasterTrailer",
+                title: "NUA Easter Trailer",
+                slug: "nua-easter-trailer",
+                imageUrl: "https://example.test/trailer.jpg",
+                label: "EPISODE",
+              },
+              {
+                id: "nua-fresh-perspective",
+                coreId: "Nua",
+                title: "NUA Fresh Perspective",
+                slug: "nua-fresh-perspective",
+                imageUrl: null,
+                label: "COLLECTION",
+              },
+            ],
+          },
+        ],
+        standalone: [
+          {
+            id: "standalone-short",
+            coreId: "short-1",
+            title: "Standalone Short",
+            slug: "standalone-short",
+            imageUrl: null,
+            label: "shortFilm",
+          },
+          {
+            id: "standalone-series",
+            coreId: "series-1",
+            title: "Standalone Series",
+            slug: "standalone-series",
+            imageUrl: null,
+            label: "series",
+          },
+        ],
+      }).map((video) => video.id),
+    ).toEqual(["nua-easter-trailer", "standalone-short"])
+  })
+
+  it("deduplicates videos already present in a collection", () => {
+    expect(
+      flattenSmartCropPickerVideos({
+        collections: [
+          {
+            id: "collection-1",
+            coreId: "collection-core",
+            title: "Collection",
+            slug: "collection",
+            imageUrl: null,
+            label: "collection",
+            videos: [
+              {
+                id: "video-1",
+                coreId: "video-core",
+                title: "Video",
+                slug: "video",
+                imageUrl: null,
+                label: "episode",
+              },
+            ],
+          },
+        ],
+        standalone: [
+          {
+            id: "video-1",
+            coreId: "video-core",
+            title: "Video",
+            slug: "video",
+            imageUrl: null,
+            label: "episode",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "video-1",
+        coreId: "video-core",
+        title: "Video",
+        slug: "video",
+        imageUrl: null,
+        label: "episode",
+      },
+    ])
+  })
+})

--- a/apps/manager/src/features/smart-crop/smart-crop-picker.ts
+++ b/apps/manager/src/features/smart-crop/smart-crop-picker.ts
@@ -1,0 +1,54 @@
+export type SmartCropPickerVideo = {
+  id: string
+  coreId: string | null
+  title: string
+  slug: string | null
+  imageUrl: string | null
+  label: string
+}
+
+export type SmartCropVideosApiItem = SmartCropPickerVideo
+
+export type SmartCropVideosApiResponse = {
+  collections: Array<
+    SmartCropVideosApiItem & { videos: SmartCropVideosApiItem[] }
+  >
+  standalone: SmartCropVideosApiItem[]
+}
+
+const NON_SOURCE_VIDEO_LABELS = new Set(["collection", "series"])
+
+function isSelectableSourceVideo(item: SmartCropVideosApiItem): boolean {
+  return !NON_SOURCE_VIDEO_LABELS.has(item.label.trim().toLowerCase())
+}
+
+export function flattenSmartCropPickerVideos(
+  payload: SmartCropVideosApiResponse,
+): SmartCropPickerVideo[] {
+  const byId = new Map<string, SmartCropPickerVideo>()
+  const add = (item: SmartCropVideosApiItem) => {
+    if (!isSelectableSourceVideo(item) || byId.has(item.id)) return
+
+    byId.set(item.id, {
+      id: item.id,
+      coreId: item.coreId,
+      title: item.title,
+      slug: item.slug,
+      imageUrl: item.imageUrl,
+      label: item.label,
+    })
+  }
+
+  for (const collection of payload.collections ?? []) {
+    for (const video of collection.videos ?? []) {
+      add(video)
+    }
+  }
+  for (const video of payload.standalone ?? []) {
+    add(video)
+  }
+
+  return [...byId.values()].sort((left, right) =>
+    left.title.localeCompare(right.title),
+  )
+}

--- a/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
+++ b/apps/manager/src/features/smart-crop/smart-crop-screen.tsx
@@ -19,6 +19,11 @@ import { createPortal } from "react-dom"
 import { apiFetch } from "@/lib/api-fetch"
 import type { SmartCropVideoResolution } from "@/app/api/smart-crop/videos/[coreId]/route"
 import type { JobRecord, SmartCropCropMode } from "@/types/job"
+import {
+  flattenSmartCropPickerVideos,
+  type SmartCropPickerVideo,
+  type SmartCropVideosApiResponse,
+} from "./smart-crop-picker"
 import { getSmartCropJobSummary } from "./smart-crop-presenter"
 
 const SMART_CROP_POLL_INTERVAL_MS = 5_000
@@ -41,53 +46,7 @@ type SmartCropScreenProps = {
   initialJobs: JobRecord[]
 }
 
-type VideoPickerItem = {
-  id: string
-  coreId: string | null
-  title: string
-  slug: string | null
-  imageUrl: string | null
-  label: string
-}
-
-type VideosApiItem = VideoPickerItem
-
-type VideosApiResponse = {
-  collections: Array<VideosApiItem & { videos: VideosApiItem[] }>
-  standalone: VideosApiItem[]
-}
-
-function flattenVideoPickerItems(
-  payload: VideosApiResponse,
-): VideoPickerItem[] {
-  const byId = new Map<string, VideoPickerItem>()
-  const add = (item: VideosApiItem) => {
-    if (!byId.has(item.id)) {
-      byId.set(item.id, {
-        id: item.id,
-        coreId: item.coreId,
-        title: item.title,
-        slug: item.slug,
-        imageUrl: item.imageUrl,
-        label: item.label,
-      })
-    }
-  }
-
-  for (const collection of payload.collections ?? []) {
-    add(collection)
-    for (const video of collection.videos ?? []) {
-      add(video)
-    }
-  }
-  for (const video of payload.standalone ?? []) {
-    add(video)
-  }
-
-  return [...byId.values()].sort((left, right) =>
-    left.title.localeCompare(right.title),
-  )
-}
+type VideoPickerItem = SmartCropPickerVideo
 
 function describeVideoResolutionIssue(
   reason: SmartCropVideoResolution["reason"],
@@ -393,8 +352,8 @@ function CanonicalJobForm({ onCreated }: { onCreated: () => void }) {
           setLoadFailed(true)
           return
         }
-        const payload = (await response.json()) as VideosApiResponse
-        setVideos(flattenVideoPickerItems(payload))
+        const payload = (await response.json()) as SmartCropVideosApiResponse
+        setVideos(flattenSmartCropPickerVideos(payload))
       } catch {
         if (!controller.signal.aborted) setLoadFailed(true)
       }


### PR DESCRIPTION
## Summary

Smart Crop source search now returns only concrete videos that can be resolved as crop sources. Operators searching by title or slug no longer see collection or series group rows that lead to a dead-end; child episodes and standalone source videos still appear and dedupe normally.

## Testing

- `pnpm --filter @forge/manager test -- src/features/smart-crop/smart-crop-picker.test.ts`
- `pnpm --filter @forge/manager typecheck`
- `pnpm --filter @forge/manager lint`
- `git diff --check`
- Browser smoke in mock Manager: searched `hope` on `/dashboard/smart-crop`; results were `Episode 1` and `Episode 2`, with `hasSeries=false` and `hasCollection=false`. A local screenshot was captured but is not embedded.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
