### PR TITLE
docs(roadmap): add watch search readiness tickets

### DIFF
--- a/docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md
+++ b/docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md
@@ -1,0 +1,91 @@
+---
+id: "feat-193"
+title: "Watch search readiness eval suite"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-06-16"
+duration: 4
+depends_on:
+  - "feat-148"
+blocks:
+  - "feat-194"
+  - "feat-196"
+tags:
+  - "admin"
+  - "mastra"
+  - "search"
+  - "evals"
+  - "algolia"
+  - "launch-readiness"
+---
+
+## Problem
+
+The team needs a concrete launch-readiness answer for Watch search, not just
+ad hoc spot checks. The current search work has multiple possible execution
+modes: keyword-first, hybrid, semantic, and Algolia fallback. Without a shared
+eval set and a readable report, humans and AI agents cannot confidently decide
+whether the current implementation is ready to launch.
+
+Roadmap window: this week, June 16-19, 2026.
+
+## Entry Points - Read These First
+
+1. `docs/roadmap/content-discovery/feat-138-mastra-eval-query-generation.md`
+   - historical query-generation workflow context.
+2. `docs/roadmap/content-discovery/feat-139-mastra-offline-search-eval-runner-reports.md`
+   - offline eval runner and report context.
+3. `docs/roadmap/content-discovery/feat-148-search-eval-orchestrator-workflow.md`
+   - current orchestrator entry point for eval workflows.
+4. `docs/roadmap/content-discovery/feat-154-production-search-eval-seed-baseline.md`
+   - production baseline capture context.
+5. `apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts`
+   - Mastra search eval orchestration.
+6. `apps/mastra/src/services/offline-search-eval/`
+   - runner, report, judge, and seed prompt support.
+7. `apps/admin/src/services/hybrid-search.service.ts`
+   - Admin search execution surface.
+8. `apps/admin/src/app/watch/demo-keyword-search/algolia-action.ts`
+   - Algolia parity/fallback comparison surface.
+9. `docs/search-eval-baselines/` and `docs/search-eval-reports/`
+   - existing baseline and report artifacts.
+
+## What To Build
+
+1. Create or refresh a reusable eval dataset with 50-100 realistic Watch search
+   queries.
+2. Seed the dataset from real Algolia query data where available.
+3. Generate additional representative queries across:
+   - product titles;
+   - felt needs;
+   - Bible topics;
+   - misspellings;
+   - synonyms;
+   - confusing or ambiguous searches;
+   - multilingual queries;
+   - scene-like queries.
+4. Run the same dataset against keyword, hybrid, semantic, and Algolia-backed
+   result modes.
+5. Produce a report that includes ranked results, relevance scores, obvious
+   failures, no-result cases, and summary metrics.
+6. Make the report structured enough that both team members and AI agents can
+   use it to decide whether the current search implementation is launch-ready.
+
+## Acceptance Criteria
+
+- 50-100 representative queries exist in a reusable eval dataset.
+- Queries include product titles, felt needs, Bible topics, misspellings,
+  synonyms, confusing queries, multilingual queries, and scene-like queries.
+- Real Algolia-derived queries are included where available.
+- Eval compares keyword, hybrid, semantic, and Algolia-backed results.
+- Output includes scored/ranked results, obvious failures, and summary metrics.
+- Team members and AI agents can use the generated report to decide whether the
+  current search implementation is launch-ready.
+
+## Verification
+
+- Run the Mastra search eval workflow against the curated query set.
+- Confirm the report includes enough per-query detail to diagnose failures.
+- Confirm the report includes a summary that can support a launch/no-launch
+  recommendation without rereading every raw result.

--- a/docs/roadmap/content-discovery/feat-194-watch-scene-embedding-ranking-evaluation.md
+++ b/docs/roadmap/content-discovery/feat-194-watch-scene-embedding-ranking-evaluation.md
@@ -1,0 +1,78 @@
+---
+id: "feat-194"
+title: "Watch scene embedding ranking evaluation"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-06-16"
+duration: 4
+depends_on: []
+blocks: []
+tags:
+  - "admin"
+  - "mastra"
+  - "search"
+  - "embeddings"
+  - "scene"
+  - "evals"
+  - "launch-readiness"
+---
+
+## Problem
+
+Scene embeddings may be skewing Watch search ranking because only a small
+subset of videos have scene vectors. When those sparse scene vectors contribute
+too strongly, videos with scene coverage can outrank more relevant videos that
+only have transcript, felt-need, or keyword evidence.
+
+The team should decide this with evals, not vibes.
+
+Roadmap window: this week, June 16-19, 2026.
+
+## Entry Points - Read These First
+
+1. `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+   - current launch-readiness eval dataset and report target.
+2. `docs/roadmap/content-discovery/feat-131-mixed-scene-transcript-video-semantic-search.md`
+   - mixed scene and transcript search history.
+3. `docs/roadmap/content-discovery/feat-191-continue-multilingual-embedding-repair-and-backfill.md`
+   - current note that scene work may become compatibility-only.
+4. `docs/roadmap/content-discovery/feat-192-brainstorm-embedding-architecture-content-gap-realignment.md`
+   - architecture question about durable retriever surfaces if scenes are
+     dropped.
+5. `apps/admin/src/services/hybrid-search-retrievers.ts`
+   - retriever composition and semantic evidence surfaces.
+6. `apps/admin/src/services/hybrid-search-fusion.ts`
+   - ranking/fusion behavior.
+7. `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+   - retriever behavior coverage.
+8. `apps/admin/src/services/scene-embedding.service.ts`
+   - scene embedding data access.
+
+## What To Build
+
+1. Run the Watch search readiness eval suite with scene embeddings enabled.
+2. Run the same eval suite with scene embeddings disabled or downweighted.
+3. Compare per-query ranking quality across both modes.
+4. Identify where scene embeddings improve relevance, harm relevance, or have
+   no meaningful effect.
+5. Document a recommendation: keep, remove, or downweight scene embeddings in
+   Watch search ranking.
+6. Implement the removal or downweighting if the eval clearly shows scene
+   evidence reduces relevance.
+
+## Acceptance Criteria
+
+- Run evals with scene embeddings enabled and disabled.
+- Compare ranking quality across both modes.
+- Identify where scene embeddings improve, harm, or do not affect relevance.
+- Document recommendation: keep, remove, or downweight scene embeddings.
+- Implement removal/downweighting if evals show they reduce relevance.
+
+## Verification
+
+- The eval report names the exact strategy variants compared.
+- The recommendation cites query examples where scene embeddings helped or
+  hurt.
+- If code changes are made, focused hybrid-search retriever and fusion tests
+  cover the new ranking behavior.

--- a/docs/roadmap/content-discovery/feat-196-watch-multilingual-search-behavior.md
+++ b/docs/roadmap/content-discovery/feat-196-watch-multilingual-search-behavior.md
@@ -1,0 +1,77 @@
+---
+id: "feat-196"
+title: "Watch multilingual search behavior"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-06-22"
+duration: 5
+depends_on: []
+blocks: []
+tags:
+  - "admin"
+  - "watch"
+  - "search"
+  - "multilingual"
+  - "i18n"
+  - "launch-readiness"
+---
+
+## Problem
+
+Watch search currently filters by the active site language. That makes a query
+in another language, such as Russian typed while the site is in English, fail
+silently or return poor results even when matching content exists in the
+queried language.
+
+The search experience should detect likely query language and give users a
+useful path instead of a dead end.
+
+Roadmap window: next week, June 22-26, 2026.
+
+## Entry Points - Read These First
+
+1. `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+   - multilingual eval coverage that should verify this behavior.
+2. `docs/roadmap/content-discovery/feat-191-continue-multilingual-embedding-repair-and-backfill.md`
+   - current multilingual embedding repair context.
+3. `docs/roadmap/topic-experiences/feat-107-watch-language-switch-pending-feedback.md`
+   - Watch language switch feedback context.
+4. `docs/roadmap/platform/feat-169-watch-language-picker-search-ranking.md`
+   - Watch language picker search ranking context.
+5. `apps/admin/src/services/search-eval-locale-profiles.ts`
+   - locale profile/eval support.
+6. `apps/admin/src/services/hybrid-search.service.ts`
+   - search language/filter behavior.
+7. `apps/admin/src/services/search-trace-query-classifier.ts`
+   - existing query classification patterns that may be reusable.
+
+## What To Build
+
+1. Detect the likely language of the user's query.
+2. Compare detected query language with the active site language.
+3. When they differ, choose and implement the product behavior:
+   - show matching-language results;
+   - suggest switching language;
+   - expose a language selector in the search experience.
+4. Improve no-result states so users are told when results may exist in another
+   language.
+5. Add multilingual query cases to the Watch search readiness eval suite.
+
+## Acceptance Criteria
+
+- Detect likely query language.
+- If query language differs from current site language, show
+  matching-language results, suggest switching language, or expose a language
+  selector.
+- No-result states explain when results may exist in another language.
+- Multilingual behavior is covered in the search eval suite.
+
+## Verification
+
+- A Russian query on an English page no longer fails silently when Russian
+  content exists.
+- The selected behavior is covered by focused service/UI tests where the
+  affected code lives.
+- The Mastra eval report includes multilingual cases before and after the
+  change.

--- a/docs/roadmap/content-discovery/feat-197-watch-search-query-outcome-logging.md
+++ b/docs/roadmap/content-discovery/feat-197-watch-search-query-outcome-logging.md
@@ -1,0 +1,74 @@
+---
+id: "feat-197"
+title: "Watch search query and outcome logging"
+owner: "nisal"
+priority: "P2"
+status: "not-started"
+start_date: "2026-06-22"
+duration: 5
+depends_on:
+  - "feat-136"
+blocks: []
+tags:
+  - "admin"
+  - "watch"
+  - "search"
+  - "observability"
+  - "privacy"
+  - "analytics"
+---
+
+## Problem
+
+Algolia gives the team visibility into what people search for and where search
+fails. The replacement search system needs similar observability so real user
+queries, no-result cases, and clicked outcomes can feed future quality work and
+eval datasets.
+
+Roadmap window: next week, June 22-26, 2026.
+
+## Entry Points - Read These First
+
+1. `docs/roadmap/content-discovery/feat-136-admin-search-trace-storage-retention.md`
+   - Admin-owned search trace storage and privacy/retention constraints.
+2. `docs/roadmap/content-discovery/feat-137-search-query-quality-abuse-labeling.md`
+   - trace labeling and low-signal filtering.
+3. `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+   - current eval set that future logged data should improve.
+4. `apps/admin/src/services/search-trace.service.ts`
+   - search trace write path.
+5. `apps/admin/src/services/search-trace-privacy.ts`
+   - privacy handling for trace data.
+6. `apps/admin/src/services/search-trace-retention.service.ts`
+   - retention behavior.
+7. `apps/admin/src/services/hybrid-search.service.ts`
+   - search execution and trace metadata.
+
+## What To Build
+
+1. Confirm the current trace model captures the fields needed for Watch search
+   outcome analysis.
+2. Log query text, detected query language, active site language, search mode,
+   result count, and no-result searches.
+3. Log clicked result where available.
+4. Keep the implementation privacy-safe and avoid unnecessary user-identifying
+   data.
+5. Provide a review path for common searches and failures, either via an
+   existing report/export surface or a small operator query/report.
+6. Make logged data usable as input for future eval query sets.
+
+## Acceptance Criteria
+
+- Log query text, detected query language, active site language, search mode,
+  result count, and no-result searches.
+- Log clicked result where available.
+- Handle data in a privacy-safe way without unnecessary user-identifying
+  information.
+- Provide a way for the team to review common searches and failures.
+- Logged data can feed future search eval query sets.
+
+## Verification
+
+- Trace writes do not block or break live search responses.
+- No-result and clicked-result cases are visible in the review/export path.
+- Raw query retention remains within the existing privacy limits.


### PR DESCRIPTION
## Summary

The Watch search roadmap now has the narrowed work Nisal can take on this week and next week: launch-readiness evals, scene-embedding ranking validation, multilingual search behavior, and query/outcome logging.

These tickets keep the scope out of Linear and in the docs roadmap, with clear acceptance criteria and entry points for the existing Mastra/Admin search infrastructure.

## Validation

- `git diff upstream/main...HEAD --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
