### PR TITLE
fix(admin): extend transcript ingest transaction timeout

### DIFF
--- a/apps/admin/src/services/transcript-embedding-ingest.service.test.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.service.test.ts
@@ -225,6 +225,10 @@ describe("ingestTranscriptEmbeddings", () => {
       dimensions: 1536,
       mastraRunId: "run-1",
     })
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: "Serializable",
+      timeout: 30_000,
+    })
     expect(writeTranscriptEmbeddingPayloadMock).toHaveBeenCalledWith(
       prisma,
       expect.objectContaining({

--- a/apps/admin/src/services/transcript-embedding-ingest.service.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.service.ts
@@ -224,6 +224,8 @@ export class TranscriptEmbeddingIngestError extends Error {
   }
 }
 
+const TRANSCRIPT_INGEST_TRANSACTION_TIMEOUT_MS = 30_000
+
 function sha256Json(value: unknown): string {
   return `sha256:${createHash("sha256")
     .update(JSON.stringify(value))
@@ -718,7 +720,10 @@ export async function ingestTranscriptEmbeddings(
         mastraRunId: payload.generation.mastraRunId,
       }
     },
-    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      timeout: TRANSCRIPT_INGEST_TRANSACTION_TIMEOUT_MS,
+    },
   )
 }
 


### PR DESCRIPTION
## Summary
- Apply the 30s transcript ingest transaction timeout to the outer Mastra ingest transaction.
- Add a regression assertion so the ingest route does not fall back to Prisma's 5s interactive transaction default.

## Why
Production transcript embedding backfill is currently hitting `transcript_index_storage_error` with Prisma `P2028` messages showing `The timeout for this transaction was 5000 ms`. The lower transcript writer had a 30s timeout, but the Mastra ingest path wraps it in an outer serializable transaction without a timeout, so the lower timeout is bypassed.

## Verification
- `pnpm --filter @forge/admin test -- transcript-embedding-ingest.service.test.ts`
