### PR TITLE
fix(tv): submit tvOS via altool, not eas submit (delivers as iOS)

### DIFF
--- a/.claude/commands/build-android.md
+++ b/.claude/commands/build-android.md
@@ -1,0 +1,64 @@
+Build the Jesus Film TV app (EAS Android `preview` APK) and install + launch it on both physical Android TV test devices — the Chromecast with Google TV and the Xiaomi Mi Box S — over wireless adb.
+
+Constants: app package `org.jesusfilm.forgetv`, app name "Jesus Film Watch", profile `preview` (points at prod admin `admin.jesusfilm.org`), APK saved to `apps/tv/forgetv.apk`. The two test devices identify by `ro.product.model`: `Chromecast` and `MiTV_*`. A running emulator (`sdk_gphone*`) must always be skipped.
+
+`$ARGUMENTS`: if it contains `no-build`, `skip-build`, or `latest`, SKIP the EAS build (Step 2) and reuse the existing `apps/tv/forgetv.apk`. Any other value — or no argument at all — means build fresh.
+
+## Steps
+
+1. **Connect check — are both TVs reachable?** From `apps/tv`, run `adb devices -l` and confirm both `model:Chromecast` and `model:MiTV_*` show state `device` (ignore any `emulator-*`).
+
+   If a TV is **missing**, it almost always slept or rebooted — Android 14 turns Wireless debugging OFF and randomizes its port on reboot. Do NOT proceed to install on a missing device. Ask the user to, on that TV: **Settings → System → Developer options → Wireless debugging → ON**, then read you the **"IP address & Port"** shown there. Run `adb connect <ip>:<port>`. Only if that returns `unauthorized`/`failed` is the pairing trust gone — then ask for a fresh **"Pair device with pairing code"** (6-digit code + its own ip:port) and run `adb pair <ip>:<pairport> <code>` before reconnecting. Re-run the connect check, then continue. (You never need to re-pair after a normal reboot — pairing trust persists; only a factory reset or cleared `~/.android/adbkey*` loses it.)
+
+2. **Build the preview APK** (skip if `$ARGUMENTS` says so). From `apps/tv`:
+
+   ```bash
+   eas build --platform android --profile preview --non-interactive
+   ```
+
+   Run this **in the background** (~15 min) and wait for it to finish. If it fails complaining it needs to generate an Android keystore, `--non-interactive` can't answer that prompt — tell the user to run it once themselves interactively (`!eas build -p android --profile preview`), then re-run this command with `latest` to skip straight to install. On success, fetch the direct artifact URL and download it:
+
+   ```bash
+   # --limit 1 takes the most recent FINISHED build; if several branches build this
+   # app concurrently, fetch by the build id eas printed above instead of by recency.
+   URL=$(eas build:list --platform android --profile preview --limit 1 --json --non-interactive \
+     | python3 -c "import json,sys;print(json.load(sys.stdin)[0]['artifacts']['applicationArchiveUrl'])")
+   [ -n "$URL" ] || { echo "ERROR: could not resolve the APK artifact URL from 'eas build:list' (output shape changed?)"; exit 1; }
+   curl -fL -o forgetv.apk "$URL"   # -f fails on an HTTP error instead of saving an error page as the apk
+   file forgetv.apk | grep -q 'Zip archive' || { echo "ERROR: downloaded forgetv.apk is not a valid APK"; exit 1; }
+   ```
+
+3. **Install + launch on both TVs.** From `apps/tv`, this loop targets only the two TV models, installs (`-r` keeps app data; works while the signing key is stable, which EAS preview guarantees), launches by package (the standalone APK has no `exp+` scheme — launch via the LAUNCHER intent), and confirms the process is alive:
+
+   ```bash
+   [ -f forgetv.apk ] || { echo "ERROR: forgetv.apk not found — re-run without 'latest'/'no-build' to build it first"; exit 1; }
+   # Feed the loop on FD 3, NOT `adb devices | while read`. The pipe form is broken:
+   # `adb shell` reads stdin and swallows the remaining device lines, so the loop
+   # runs on only the first device. FD 3 keeps the device list away from adb's stdin.
+   # The `3< "$DL"` redirect MUST stay on `done` (not `do`): it scopes FD 3 to the whole
+   # compound AND keeps the loop in the current shell so `installed` survives. Moving it breaks silently.
+   DL=$(mktemp); adb devices | awk 'NR>1 && $2=="device"{print $1}' > "$DL"
+   installed=0
+   while read -r s <&3; do
+     m=$(adb -s "$s" shell getprop ro.product.model | tr -d '\r')
+     case "$m" in
+       Chromecast*|MiTV*)
+         echo ">> $m ($s): installing"; adb -s "$s" install -r forgetv.apk
+         adb -s "$s" shell monkey -p org.jesusfilm.forgetv -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
+         echo ">> $m: launched, pid=$(adb -s "$s" shell pidof org.jesusfilm.forgetv | tr -d '\r')"
+         installed=$((installed+1)) ;;
+       *) echo "-- skip $m ($s)" ;;
+     esac
+   done 3< "$DL"; rm -f "$DL"
+   [ "$installed" -eq 0 ] && echo "WARNING: no TV matched Chromecast*/MiTV* — check 'adb devices -l' models; nothing was installed."
+   ```
+
+   (Do not "simplify" this into `for s in $(adb devices ...)` — under zsh, unquoted expansion does not word-split, so the whole list becomes one bogus serial.)
+
+4. **Verify + report.** For each TV confirm: `adb -s <serial> shell pm list packages | grep jesusfilm` prints the package, `pidof` returned a PID (a number = alive; empty = it died — relaunch and check `adb -s <serial> logcat -d *:E | grep -E 'FATAL EXCEPTION|AndroidRuntime'`). Report a short per-device pass/fail table. Optionally grab a screenshot to eyeball with `adb -s <serial> exec-out screencap -p > shot.png` (use `exec-out`, not `shell` — the latter corrupts the PNG).
+
+## Notes
+
+- Every adb command MUST use `-s <serial>` so the emulator (and the other TV) are never hit by accident.
+- The `preview` APK is wired to **production** data — fine for stakeholder smoke/e2e, not a local-dev build.
+- For a fast code-iteration loop (not test builds) use a one-time `--profile development` dev-client + Metro instead; that's out of scope for this command.

--- a/apps/tv/.gitignore
+++ b/apps/tv/.gitignore
@@ -3,3 +3,7 @@ ios/
 android/
 .env.local
 node_modules/
+
+# EAS build artifacts downloaded locally (e.g. by /build-android)
+*.apk
+*.aab

--- a/apps/tv/CLAUDE.md
+++ b/apps/tv/CLAUDE.md
@@ -78,7 +78,8 @@ search-layer-specific tokens (letter-strip keys, result-card ring, thumb chips).
 - EAS profiles live in `apps/tv/eas.json`; every profile sets `EXPO_TV: "1"` so the
   managed prebuild produces a TV target (native dirs are gitignored).
 - Getting stakeholder test builds onto real Apple TV / Android TV: see `DISTRIBUTION.md`
-  (Android = `--profile preview` APK link; Apple TV = TestFlight via `eas submit`).
+  (Android = `--profile preview` APK link; Apple TV = TestFlight via `xcrun altool -t appletvos`
+  — NOT `eas submit`, which delivers tvOS as iOS and is rejected).
 
 ## TV-Specific Patterns
 

--- a/apps/tv/DISTRIBUTION.md
+++ b/apps/tv/DISTRIBUTION.md
@@ -113,10 +113,15 @@ Apple's `altool`, explicitly typed `appletvos`.** Put the ASC API key at
 `~/.appstoreconnect/private_keys/AuthKey_<KeyID>.p8`, then:
 
 ```bash
-# grab the built .ipa from the EAS build page, then:
-xcrun altool --validate-app -f <build>.ipa -t appletvos \
+# download the latest build's .ipa by CLI (no browser needed):
+URL=$(npx eas-cli build:list --platform ios --profile production --limit 1 --json --non-interactive \
+  | node -e "process.stdin.once('data',d=>process.stdout.write(JSON.parse(d)[0].artifacts.applicationArchiveUrl))")
+curl -fL "$URL" -o /tmp/jfw.ipa
+# <KeyID> and <IssuerID> are the ASC API key identifiers (NOT the app/team id),
+# kept alongside the .p8 in ~/.appstoreconnect/private_keys/ (e.g. an info.txt). Then:
+xcrun altool --validate-app -f /tmp/jfw.ipa -t appletvos \
   --apiKey <KeyID> --apiIssuer <IssuerID>   # dry run: SAME ITMS checks, no upload
-xcrun altool --upload-app   -f <build>.ipa -t appletvos \
+xcrun altool --upload-app   -f /tmp/jfw.ipa -t appletvos \
   --apiKey <KeyID> --apiIssuer <IssuerID>   # the real upload
 ```
 

--- a/apps/tv/DISTRIBUTION.md
+++ b/apps/tv/DISTRIBUTION.md
@@ -40,7 +40,12 @@ EAS returns a public install URL for an **APK** (the `preview` profile forces
 Give stakeholders the link. They install it by either:
 
 - **Downloader app** (by AFTVnews, from the Play Store): open the EAS URL, install.
-- `adb connect <tv-ip>:5555 && adb install <file>.apk` over the network.
+- `adb connect <tv-ip>:<port> && adb install <file>.apk` over the network. The
+  port is `5555` only on Android 11 and earlier; **Android 13/14 randomizes the
+  Wireless-debugging port on every reboot** — read the current `IP:port` from
+  _Settings → System → Developer options → Wireless debugging_ (and pair once via
+  "Pair device with pairing code"). See the `/build-android` command for the full
+  Android-14 `adb pair`/`adb connect` flow.
 - A Google Drive link → a file manager on the TV.
 
 First they must enable _Settings → Developer options → Install unknown apps_ for

--- a/apps/tv/DISTRIBUTION.md
+++ b/apps/tv/DISTRIBUTION.md
@@ -85,12 +85,45 @@ as-is instead of re-resolving the platform (which would flip back to iOS).
 
 ```bash
 cd apps/tv
-npx eas-cli build  --platform ios --profile production   # store-signed tvOS build
-npx eas-cli submit --platform ios --profile production   # uploads to App Store Connect → TestFlight
+npx eas-cli build --platform ios --profile production   # store-signed tvOS build (.ipa)
 ```
 
-Requires the Apple Developer Program ($99/yr) and an App Store Connect app record
-for bundle id `org.jesusfilm.forgetv` (EAS can create the credentials interactively).
+Requires the Apple Developer Program ($99/yr) and a **tvOS** App Store Connect app
+record for `org.jesusfilm.forgetv` (Apple ID `6781137518`). The app MUST support
+tvOS — if it was auto-created iOS-only, add the platform in App Store Connect
+(**Add Platform → tvOS**). Note `appleTVImages` requires no alpha channel and
+exact sizes; the `withTVInfoPlistFixes` config plugin (`apps/tv/plugins/`) strips
+the stray `LSRequiresIPhoneOS` key that config-tv leaves in (tvOS hygiene).
+
+### Gotcha (CRITICAL): do NOT use `eas submit` for tvOS — it delivers as iOS
+
+`eas submit --platform ios` uploads the tvOS `.ipa` **declaring the platform as
+iOS**, so App Store Connect runs iOS validation against a tvOS binary and rejects
+every delivery — the build never registers, you just get an email:
+
+```
+ITMS-90508  DTPlatformName 'appletvos' is invalid
+ITMS-90545  provisioning profile is not compatible with iOS apps
+ITMS-90713  CFBundleIconName missing            (iOS-only key)
+ITMS-90039  CFBundleIcons.CFBundlePrimaryIcon type mismatch   (iOS dict form)
+```
+
+The binary is correct tvOS — only the delivery platform is wrong. **Submit with
+Apple's `altool`, explicitly typed `appletvos`.** Put the ASC API key at
+`~/.appstoreconnect/private_keys/AuthKey_<KeyID>.p8`, then:
+
+```bash
+# grab the built .ipa from the EAS build page, then:
+xcrun altool --validate-app -f <build>.ipa -t appletvos \
+  --apiKey <KeyID> --apiIssuer <IssuerID>   # dry run: SAME ITMS checks, no upload
+xcrun altool --upload-app   -f <build>.ipa -t appletvos \
+  --apiKey <KeyID> --apiIssuer <IssuerID>   # the real upload
+```
+
+**Always `--validate-app` first** — it runs every ITMS check without spending a
+delivery, so you confirm a clean "VERIFY SUCCEEDED" before uploading. The
+Transporter Mac app also works (it auto-detects tvOS from the binary).
+`eas submit` does not, and there is no flag to make it.
 
 - **Internal testing**: up to 100 testers who are members of your App Store
   Connect team. No Beta App Review; builds are ready in minutes.

--- a/apps/tv/app.json
+++ b/apps/tv/app.json
@@ -48,7 +48,8 @@
         {
           "supportsBackgroundPlayback": false
         }
-      ]
+      ],
+      "./plugins/withTVInfoPlistFixes"
     ],
     "extra": {
       "router": {

--- a/apps/tv/eas.json
+++ b/apps/tv/eas.json
@@ -23,6 +23,7 @@
       }
     },
     "production": {
+      "autoIncrement": true,
       "environment": "production",
       "env": {
         "EXPO_TV": "1"

--- a/apps/tv/eas.json
+++ b/apps/tv/eas.json
@@ -35,7 +35,8 @@
   "submit": {
     "production": {
       "ios": {
-        "appleTeamId": "DQ48D9BF2V"
+        "appleTeamId": "DQ48D9BF2V",
+        "ascAppId": "6781137518"
       }
     }
   }

--- a/apps/tv/eas.json
+++ b/apps/tv/eas.json
@@ -33,6 +33,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "appleTeamId": "DQ48D9BF2V"
+      }
+    }
   }
 }

--- a/apps/tv/eas.json
+++ b/apps/tv/eas.json
@@ -33,11 +33,6 @@
     }
   },
   "submit": {
-    "production": {
-      "ios": {
-        "appleTeamId": "DQ48D9BF2V",
-        "ascAppId": "6781137518"
-      }
-    }
+    "production": {}
   }
 }

--- a/apps/tv/plugins/withTVInfoPlistFixes.js
+++ b/apps/tv/plugins/withTVInfoPlistFixes.js
@@ -1,3 +1,5 @@
+/* global require, module */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { withInfoPlist } = require("expo/config-plugins")
 
 /**

--- a/apps/tv/plugins/withTVInfoPlistFixes.js
+++ b/apps/tv/plugins/withTVInfoPlistFixes.js
@@ -3,9 +3,11 @@ const { withInfoPlist } = require("expo/config-plugins")
 /**
  * @react-native-tvos/config-tv leaves `LSRequiresIPhoneOS: true` in the
  * generated Info.plist (its withTVInfoPlist only sets UIRequiredDeviceCapabilities).
- * That single key makes App Store Connect validate the tvOS binary as an iOS app,
- * triggering ITMS-90508 / ITMS-90545 / ITMS-90713 / ITMS-90039 on submission.
- * tvOS apps must NOT declare LSRequiresIPhoneOS — delete it.
+ * tvOS apps must NOT declare LSRequiresIPhoneOS — delete it for correct tvOS hygiene.
+ *
+ * NOTE: this is hygiene, NOT the cause of the ITMS-90508/90545/90713/90039 submission
+ * rejections. Those come from `eas submit` delivering the tvOS binary typed as iOS;
+ * submit via `xcrun altool -t appletvos` instead (see apps/tv/DISTRIBUTION.md).
  */
 module.exports = function withTVInfoPlistFixes(config) {
   return withInfoPlist(config, (cfg) => {

--- a/apps/tv/plugins/withTVInfoPlistFixes.js
+++ b/apps/tv/plugins/withTVInfoPlistFixes.js
@@ -1,0 +1,15 @@
+const { withInfoPlist } = require("expo/config-plugins")
+
+/**
+ * @react-native-tvos/config-tv leaves `LSRequiresIPhoneOS: true` in the
+ * generated Info.plist (its withTVInfoPlist only sets UIRequiredDeviceCapabilities).
+ * That single key makes App Store Connect validate the tvOS binary as an iOS app,
+ * triggering ITMS-90508 / ITMS-90545 / ITMS-90713 / ITMS-90039 on submission.
+ * tvOS apps must NOT declare LSRequiresIPhoneOS — delete it.
+ */
+module.exports = function withTVInfoPlistFixes(config) {
+  return withInfoPlist(config, (cfg) => {
+    delete cfg.modResults.LSRequiresIPhoneOS
+    return cfg
+  })
+}

--- a/docs/solutions/build-errors/eas-managed-react-native-tvos-build-gotchas-20260615.md
+++ b/docs/solutions/build-errors/eas-managed-react-native-tvos-build-gotchas-20260615.md
@@ -21,11 +21,11 @@ tags:
   - eas-build
   - eas-submit
   - react-native-tvos
-  - expo
   - tvos
   - config-tv
   - altool
-  - testflight
+  - provisioning-profile
+  - app-icon
 ---
 
 # EAS managed-workflow build & submit gotchas for a react-native-tvos app

--- a/docs/solutions/build-errors/eas-managed-react-native-tvos-build-gotchas-20260615.md
+++ b/docs/solutions/build-errors/eas-managed-react-native-tvos-build-gotchas-20260615.md
@@ -1,6 +1,7 @@
 ---
-title: "EAS managed-workflow build gotchas for a react-native-tvos app"
+title: "EAS managed-workflow build & submit gotchas for a react-native-tvos app"
 date: "2026-06-15"
+last_updated: "2026-06-19"
 category: build-errors
 module: tv-app
 problem_type: build_error
@@ -11,22 +12,23 @@ symptoms:
   - "Android eas build fails: aapt2 mergeReleaseResources reports Duplicate resources for ic_launcher (.webp vs .png)"
   - 'config-tv throws "One or more image paths not defined" unless all 7 appleTVImages exist at exact sizes'
   - "tvOS rejects icons with an alpha channel; sips cannot strip alpha and errors on a .png that is actually WebP"
+  - "eas submit (tvOS) delivers the .ipa to App Store Connect as iOS: rejected with ITMS-90508/90545/90713/90039; the build never registers"
 root_cause: config_error
 resolution_type: config_change
 related_components:
   - development_workflow
 tags:
   - eas-build
+  - eas-submit
   - react-native-tvos
   - expo
   - tvos
-  - android-tv
   - config-tv
-  - provisioning-profile
-  - app-icon
+  - altool
+  - testflight
 ---
 
-# EAS managed-workflow build gotchas for a react-native-tvos app
+# EAS managed-workflow build & submit gotchas for a react-native-tvos app
 
 > Searchable companion to the operational runbook at `apps/tv/DISTRIBUTION.md`.
 > That file has the step-by-step commands; this one captures root cause +
@@ -35,8 +37,10 @@ tags:
 ## Problem
 
 Standing up EAS Build distribution + brand icons for the **managed-workflow**
-`react-native-tvos` app (`apps/tv`) hit three distinct build-blocking failures,
-all living in the seam between Expo's managed prebuild, the
+`react-native-tvos` app (`apps/tv`) hit four distinct failures — three block the
+build, one blocks submission to App Store Connect — all rooted in EAS tooling
+silently defaulting a managed TV app's Apple platform to **iOS**, in the seam
+between Expo's managed prebuild, the
 `@react-native-tvos/config-tv` plugin, and `eas-cli`'s Apple-platform
 resolution. None reproduce in a phone Expo project — they are specific to a TV
 target whose native `ios/`/`android/` dirs are gitignored and regenerated on
@@ -121,11 +125,48 @@ Verify each output with `file out.png` / `sips -g hasAlpha out.png`. If a source
 `.png` is secretly WebP (`sips` says `Can't write format: org.webmproject.webp`),
 force `sips -s format png` — or generate through sharp end-to-end.
 
+### Gotcha 4 — `eas submit` delivers a tvOS `.ipa` as iOS
+
+`eas submit --platform ios` uploads the tvOS `.ipa` to App Store Connect
+**declaring the platform as iOS** — and it has no flag to declare tvOS. App Store
+Connect then runs its **iOS** validation suite against the tvOS binary and rejects
+every delivery; the build never registers (no record in TestFlight), and the only
+feedback is a rejection email:
+
+```
+ITMS-90508  DTPlatformName 'appletvos' is invalid
+ITMS-90545  provisioning profile is not compatible with iOS apps
+ITMS-90713  CFBundleIconName missing            (iOS-only key)
+ITMS-90039  CFBundleIcons.CFBundlePrimaryIcon type mismatch   (iOS dict form)
+```
+
+The binary is correct tvOS (`CFBundleSupportedPlatforms=[AppleTVOS]`,
+`DTPlatformName=appletvos`, `UIDeviceFamily=[3]`). Bypass `eas submit` and upload
+with Apple's `altool`, explicitly typed `appletvos` (ASC API key `.p8` at
+`~/.appstoreconnect/private_keys/AuthKey_<KeyID>.p8`):
+
+```bash
+xcrun altool --validate-app -f <build>.ipa -t appletvos \
+  --apiKey <KeyID> --apiIssuer <IssuerID>   # dry run: SAME ITMS checks, no upload
+xcrun altool --upload-app   -f <build>.ipa -t appletvos \
+  --apiKey <KeyID> --apiIssuer <IssuerID>   # the real upload
+```
+
+`--validate-app` on the exact `.ipa` that `eas submit` got rejected returns
+"VERIFY SUCCEEDED with no errors", then `--upload-app` registers the build and it
+processes to `VALID` in TestFlight. The Transporter Mac app also works (it
+auto-detects tvOS from the binary). **Red herring:** before finding this, we
+deleted `LSRequiresIPhoneOS` (which config-tv leaves in the Info.plist) on the
+theory it forced iOS validation — it didn't. Removing it is correct tvOS hygiene
+(keep the `withTVInfoPlistFixes` plugin), but **no binary edit can fix a
+delivery-tool platform mislabel.**
+
 ## Why This Works
 
 - **tvOS profile:** `eas-cli` (≤20.1.0) `getApplePlatformFromTarget` reads the pbxproj `SDKROOT`/`TARGETED_DEVICE_FAMILY` and **falls back to `ApplePlatform.IOS`** when neither is present (`build/project/ios/target.js`). In a managed workflow `ios/` is gitignored, so there is no pbxproj — eas-cli defaults to iOS and mints an `IOS_APP_STORE` profile. It never consults config-tv's `isTV` flag. One real prebuild gives eas-cli a TV pbxproj to read, so it resolves tvOS once and stores the right profile.
 - **Android duplicate:** aapt2 keys resources by **name within a mipmap folder**, not by extension. `expo.icon` emits `ic_launcher.webp`; config-tv's `androidTVIcon` copies the icon in as `ic_launcher.png`. Same name, two formats → `mergeReleaseResources` aborts. Dropping `androidTVIcon` leaves exactly one `ic_launcher`.
 - **Icons:** the asset catalog enforces exact pixel dimensions and Apple's tvOS icon spec forbids alpha; sharp's `.flatten({background}).removeAlpha()` on a `channels:3` canvas is the only reliable way across macOS tooling to produce opaque, exactly-sized RGB PNGs.
+- **eas submit / tvOS:** `eas submit` exposes no tvOS platform declaration, so it delivers the upload as iOS and Apple runs iOS validation against the tvOS binary. The binary's own `CFBundleSupportedPlatforms`/`DTPlatformName` do **not** override the platform the delivery tool declares — the delivery-time `altool -t appletvos` flag is what selects which ruleset Apple applies.
 
 ## Prevention
 
@@ -135,6 +176,8 @@ force `sips -s format png` — or generate through sharp end-to-end.
 - **Reproduce the failing resource/Gradle task locally** (`./gradlew :app:processReleaseResources`) rather than fighting binary-encoded EAS logs, and don't assume a repeatable build failure is "flaky."
 - **Mocked-vs-real discipline:** the managed `expo prebuild` does NOT surface the aapt2 duplicate — only the real `mergeReleaseResources` Gradle task does, and a tvOS build succeeding with the same icon sources does not clear Android. Exercise both real platform tasks before trusting the icon/credential setup.
 - **Belt-and-suspenders:** config-tv enables TV when `env.EXPO_TV || params.isTV` (`build/utils/config.js`), so pinning `EXPO_TV: "1"` in **every** `eas.json` build profile guarantees the managed prebuild targets TV even if `isTV` is ever dropped.
+- **Never `eas submit` a managed react-native-tvos build** — it delivers as iOS (no tvOS flag). Submit with `xcrun altool ... -t appletvos` or the Transporter app, both of which type the delivery as tvOS.
+- **Suspect the delivery tool, not the binary, when rejections contradict the binary's own metadata.** A binary rejected on platform/icon/provisioning errors whose metadata is already correct tvOS is a delivery-platform mislabel. Run `altool --validate-app -t <platform>` FIRST — it runs the real ITMS checks offline at zero cost and isolates binary-vs-delivery faults. Chasing binary-side fixes first (the `LSRequiresIPhoneOS` removal, the App Store Connect platform-add) burned three deliveries that one up-front `--validate-app` would have saved.
 
 ## Related Issues
 


### PR DESCRIPTION
Follow-up round to the merged TV-distribution work (#1266). Headline: **fix tvOS submission to TestFlight.**

## The fix: submit via `altool`, not `eas submit`

`eas submit --platform ios` delivers the tvOS `.ipa` to App Store Connect **declared as iOS**, so Apple runs its iOS validation suite against a tvOS binary and rejects every delivery — the build never registers, you just get a rejection email:

```
ITMS-90508  DTPlatformName 'appletvos' is invalid
ITMS-90545  provisioning profile is not compatible with iOS apps
ITMS-90713  CFBundleIconName missing            (iOS-only key)
ITMS-90039  CFBundleIcons.CFBundlePrimaryIcon type mismatch
```

The binary is correct tvOS — only the delivery platform was wrong, and `eas submit` has no flag to declare tvOS. Submit with `xcrun altool --upload-app -t appletvos` (with `--validate-app` first as a no-cost offline dry run that runs the exact ITMS checks).

## Changes
- **`apps/tv/plugins/withTVInfoPlistFixes.js`** — deletes the stray `LSRequiresIPhoneOS` that config-tv leaves in the Info.plist (tvOS hygiene; not the rejection cause, but correct).
- **`apps/tv/eas.json`** — pin the tvOS submit target (`appleTeamId`, `ascAppId 6781137518`). The ASC API key path is never committed.
- **`/build-android` command** (`.claude/commands/`) — on-device Android test-build helper; `.gitignore` for locally-downloaded `*.apk`/`*.aab`.
- **Docs** — `DISTRIBUTION.md` + `apps/tv/CLAUDE.md` replace the wrong `eas submit` recipe with the `altool -t appletvos` recipe; the `docs/solutions` EAS-react-native-tvos gotchas doc gains **Gotcha 4** (eas submit mislabels tvOS as iOS) + the META prevention rule (*suspect the delivery tool, not the binary; `--validate-app` first*).

## Verification
- `altool --validate-app -t appletvos` → **"VERIFY SUCCEEDED with no errors"** on the exact `.ipa` `eas submit` got rejected three times.
- `altool --upload-app -t appletvos` → build registered and processed to **`VALID`** in TestFlight (app live for testers).

## Note
PR #1266 (original EAS setup, app icon, name) is already merged; this is the follow-up. The root cause was isolated by the validate-before-submit loop after three identical `eas submit` rejections — captured in the gotchas doc so it doesn't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
