### PR TITLE
fix(tv): bridge D-pad focus between home top bar and hero buttons

### DIFF
--- a/apps/tv/app/index.tsx
+++ b/apps/tv/app/index.tsx
@@ -33,6 +33,7 @@ import {
 } from "../src/components/home/homeScrollState"
 import { HomeTopBar } from "../src/components/home/HomeTopBar"
 import { MissionSection } from "../src/components/home/MissionSection"
+import { TVFocusGuideView } from "../src/components/TVFocusGuideView"
 import {
   createShowcaseFocusDebouncer,
   INITIAL_SHOWCASE_STATE,
@@ -283,8 +284,16 @@ export default function HomeScreen() {
 
   // The hero CTA's native node — wired as the D-pad-up destination for EVERY
   // card in the first section rail, so Up from any card (even the rightmost)
-  // returns to the CTA rather than dead-ending under the hero artwork.
+  // returns to the CTA rather than dead-ending under the hero artwork. ALSO the
+  // destination of the hero's TVFocusGuideView (below), so Down from the top bar
+  // tabs lands on See more.
   const [ctaNode, setCtaNode] = useState<ViewType | null>(null)
+
+  // The top bar Search tab's native node — wired as the D-pad-up destination for
+  // both hero action buttons. The centered tab bar has no horizontal overlap
+  // with the left-anchored hero action row, so Up from the hero dead-ends
+  // without an explicit destination (the mirror of ctaNode's job for the rail).
+  const [searchTabNode, setSearchTabNode] = useState<ViewType | null>(null)
 
   // The top bar (brandmark · Search/Home tabs · clock). Rendered in every
   // state — including loading, error and empty — so Search stays reachable
@@ -297,6 +306,7 @@ export default function HomeScreen() {
       searchTabPreferredFocus={searchTabFocusKey > 0}
       onSearchPress={handleSearchPress}
       onChromeFocus={handleChromeFocus}
+      onSearchTabNode={setSearchTabNode}
     />
   )
 
@@ -399,17 +409,32 @@ export default function HomeScreen() {
 
         {/* The hero is a focusable carousel (replaces the passive billboard +
             the old featured rail). It owns the curated hero set; section rails
-            below stay at rowIndex 1..n and anchor-scroll up on focus. */}
+            below stay at rowIndex 1..n and anchor-scroll up on focus.
+
+            The guide bridges D-pad DOWN from the centered top bar tabs into the
+            hero: the hero's only focusables (See more + chevron) are
+            left-anchored, so Down from a centered tab has no horizontal
+            projection overlap and geometry falls straight through to the first
+            rail. nextFocusDown set on the tabs can't fix it — they live in the
+            sticky header, whose re-parented children drop nextFocus hints. This
+            is the app's established offset-focus bridge (see MissionSection):
+            a Down-entry into the hero region redirects to the See more CTA. */}
         <View onLayout={rowLayoutHandlers[0]}>
-          <HomeHeroCarousel
-            slides={model.featured}
-            index={heroIndex}
-            hasTVPreferredFocus
-            onSelect={handleCardPress}
-            onFocusChange={handleHeroFocusChange}
-            onRequestAdvance={advanceHero}
-            onCtaNode={setCtaNode}
-          />
+          <TVFocusGuideView
+            autoFocus
+            destinations={ctaNode != null ? [ctaNode] : undefined}
+          >
+            <HomeHeroCarousel
+              slides={model.featured}
+              index={heroIndex}
+              hasTVPreferredFocus
+              onSelect={handleCardPress}
+              onFocusChange={handleHeroFocusChange}
+              onRequestAdvance={advanceHero}
+              onCtaNode={setCtaNode}
+              upFocusTarget={searchTabNode}
+            />
+          </TVFocusGuideView>
         </View>
 
         {model.sections.map((section, sectionIndex) => (

--- a/apps/tv/src/components/home/HomeHeroCarousel.tsx
+++ b/apps/tv/src/components/home/HomeHeroCarousel.tsx
@@ -56,6 +56,12 @@ type HomeHeroCarouselProps = {
   /** Exposes the See more CTA's node so the first section rail can wire it as
    *  the D-pad-up destination for ALL its cards. */
   onCtaNode?: (node: ViewType | null) => void
+  /** The top bar's Search tab node — the D-pad-up destination for BOTH hero
+   *  buttons. The centered tab bar has no horizontal overlap with the
+   *  left-anchored action row, so the focus engine finds nothing directly above;
+   *  this explicit destination bridges Up from the hero to the top bar (the
+   *  mirror of how the section rail wires its cards' Up to the CTA). */
+  upFocusTarget?: ViewType | null
 }
 
 export function HomeHeroCarousel({
@@ -66,6 +72,7 @@ export function HomeHeroCarousel({
   onFocusChange,
   onRequestAdvance,
   onCtaNode,
+  upFocusTarget,
 }: HomeHeroCarouselProps) {
   const count = slides.length
   const safeIndex = count > 0 ? ((index % count) + count) % count : 0
@@ -190,6 +197,7 @@ export function HomeHeroCarousel({
                 hasTVPreferredFocus={hasTVPreferredFocus}
                 onNode={handleSeeMoreNode}
                 selfNode={seeMoreNode}
+                upFocusTarget={upFocusTarget}
               />
               <HeroChevronButton
                 onPress={() => onRequestAdvance(1)}
@@ -197,6 +205,7 @@ export function HomeHeroCarousel({
                 onBlur={handleChevronBlur}
                 onNode={setChevronNode}
                 selfNode={chevronNode}
+                upFocusTarget={upFocusTarget}
               />
             </View>
           ) : null
@@ -226,6 +235,7 @@ function HeroCtaButton({
   hasTVPreferredFocus,
   onNode,
   selfNode,
+  upFocusTarget,
 }: {
   label: string
   onPress: () => void
@@ -234,6 +244,7 @@ function HeroCtaButton({
   hasTVPreferredFocus?: boolean
   onNode?: (node: ViewType | null) => void
   selfNode: ViewType | null
+  upFocusTarget?: ViewType | null
 }) {
   const { setFocused, progress } = useFocusAnimation()
   const animatedStyle = useMemo(
@@ -260,6 +271,9 @@ function HeroCtaButton({
       // Stay on See more on Left (no real neighbour) so the capture turns Left
       // into a previous-slide instead of letting focus escape the hero.
       nextFocusLeft={selfNode ?? undefined}
+      // Up bridges to the top bar's Search tab — geometry alone dead-ends here
+      // (left-anchored button, centered tabs, no horizontal overlap).
+      nextFocusUp={upFocusTarget ?? undefined}
       hasTVPreferredFocus={hasTVPreferredFocus}
       accessibilityRole="button"
       accessibilityLabel={label}
@@ -285,12 +299,14 @@ function HeroChevronButton({
   onBlur,
   onNode,
   selfNode,
+  upFocusTarget,
 }: {
   onPress: () => void
   onFocus: () => void
   onBlur: () => void
   onNode: (node: ViewType | null) => void
   selfNode: ViewType | null
+  upFocusTarget?: ViewType | null
 }) {
   const { setFocused, progress } = useFocusAnimation()
   const ringStyle = useMemo(() => ({ opacity: progress }), [progress])
@@ -309,6 +325,9 @@ function HeroChevronButton({
       // Stay on the chevron on Right (no real neighbour) so the capture can turn
       // Right into an advance rather than letting focus escape the hero.
       nextFocusRight={selfNode ?? undefined}
+      // Up bridges to the top bar's Search tab — same offset-geometry dead-end
+      // as See more (both hero buttons share the one Up destination).
+      nextFocusUp={upFocusTarget ?? undefined}
       accessibilityRole="button"
       accessibilityLabel="Next featured title"
     >

--- a/apps/tv/src/components/home/HomeTopBar.tsx
+++ b/apps/tv/src/components/home/HomeTopBar.tsx
@@ -49,10 +49,16 @@ type HomeTopBarProps = {
   /** Any tab gaining focus pins the screen to its "top" state. */
   onChromeFocus: () => void
   /**
-   * Receives the Search tab's native node so the featured rail can wire it as
-   * its cards' `nextFocusUp` target — the centered tab bar has no horizontal
-   * overlap with the rail's edge cards, so D-pad up from them needs an
+   * Receives the Search tab's native node so the hero (or featured rail) can
+   * wire it as its `nextFocusUp` target — the centered tab bar has no horizontal
+   * overlap with the left-anchored hero buttons, so D-pad up from them needs an
    * explicit destination (the focus engine finds nothing directly above).
+   *
+   * The reverse (Down from a tab back to the hero) is NOT wired here: a
+   * `nextFocusDown` set on these tabs is dropped by the focus engine because
+   * they live in the ScrollView's sticky header (re-parented children lose
+   * nextFocus hints). The hero owns that bridge instead, via a
+   * TVFocusGuideView — see app/index.tsx.
    */
   onSearchTabNode?: (node: ViewType | null) => void
 }
@@ -167,7 +173,7 @@ type TopBarTabProps = {
   onChromeFocus: () => void
   focusable: boolean
   hasTVPreferredFocus?: boolean
-  /** Lifts this tab's native node up so a rail can target it via nextFocusUp. */
+  /** Lifts this tab's native node up so the hero can target it via nextFocusUp. */
   nodeRef?: (node: ViewType | null) => void
 }
 

--- a/docs/solutions/best-practices/tv-focus-driven-hero-patterns-20260420.md
+++ b/docs/solutions/best-practices/tv-focus-driven-hero-patterns-20260420.md
@@ -1,7 +1,7 @@
 ---
 title: TV focus-driven hero patterns — non-interactive hero, rail owns focus, poster-hold during HLS swap
 date: 2026-04-20
-last_refreshed: 2026-06-15
+last_refreshed: 2026-06-19
 category: docs/solutions/best-practices
 module: apps/tv
 problem_type: best_practice
@@ -34,6 +34,8 @@ related_components:
 ## Context
 
 > **Update (2026-06-15):** the TV home was later redesigned — the video-preview hero in `HomeHero.tsx` (now removed) became an **image-only** billboard + ambient backdrop (`HomeBillboard.tsx` + `HomeBackdrop.tsx`), so the home no longer exercises Section 2's `expo-video` poster-hold / HLS-swap patterns. Those video patterns now apply to the surviving video surfaces — the watch screen's `VideoBackdrop` and the `/experience` `VideoHeroRenderer`. The focus patterns below (non-interactive media layer, rail-owns-focus, debounce, `TVFocusGuideView` destinations, close-over-item, `collapsable={false}`) remain valid and are embodied in the redesigned home. For the image backdrop's own crossfade gotcha and the home's scroll model, see `docs/solutions/ui-bugs/tv-home-backdrop-crossfade-aba-stall-20260615.md` and `docs/solutions/design-patterns/tv-home-row-anchored-scroll-native-focus-scroll-disabled-20260615.md`.
+
+> **Update (2026-06-19):** the home hero was later **re-interactivated**. `HomeBillboard` is now driven by `HomeHeroCarousel.tsx` — a paged carousel with a focusable **See more** CTA + next-slide chevron — so the rail no longer owns 100% of home focus. Section 1's "background media-driven heroes must be fully non-interactive / rail owns 100% focus" rule now scopes to surfaces with a background `expo-video` `VideoView` (the thing that hijacks focus); the **image-only** home hero has no video to hijack, so an interactive CTA is safe. The §1 `HomeHero.tsx` snippet below is historical (that file is removed). For how the re-interactivated hero bridges D-pad Up/Down to the sticky top bar — `nextFocusUp` on the hero buttons (Up) + a `TVFocusGuideView destinations` (Down) — see `docs/solutions/design-patterns/tv-sticky-header-nextfocus-asymmetry-bridge-20260619.md`. That doc also shows Section 3's "destinations must be siblings, not descendants" is a **per-instance check, not a blanket prohibition**: the re-interactivated hero's guide uses a _descendant_ `ctaNode` destination and works single-press (matching `MissionSection`).
 
 The TV home hero (top ~55% of the screen on Apple TV + Android TV) was hardcoded to a single Experience. We reworked it so the hero tracks whichever Experience card is focused in the rail below, swapping the hero's poster, title, subtitle, and HLS video to match the focused card — a standard 10-foot "browse with a background preview" pattern.
 

--- a/docs/solutions/design-patterns/tv-rail-overhang-pad-bounce-focus-20260616.md
+++ b/docs/solutions/design-patterns/tv-rail-overhang-pad-bounce-focus-20260616.md
@@ -1,7 +1,7 @@
 ---
 title: "TV home rail — column-preserving D-pad focus with invisible pad-cell over-hang bounce"
 date: 2026-06-16
-last_refreshed: 2026-06-16
+last_refreshed: 2026-06-19
 category: docs/solutions/design-patterns
 module: apps/tv
 problem_type: design_pattern
@@ -70,6 +70,8 @@ const [searchTabNode, setSearchTabNode] = useState<ViewType | null>(null)
 ```
 
 `FocusDestination` accepts a **component instance** directly (`Pressable` forwards it via `tagForComponentOrHandle`) — no `findNodeHandle` / native-tag lookup needed. This works because the target (the top bar) is **not** inside a FlatList (see Why This Matters #1).
+
+**The reverse direction is asymmetric — do not mirror it with `nextFocusDown` on the tab.** Down from the top-bar tab back to the content below cannot be wired with `nextFocusDown` on the tab: the tab lives in the ScrollView's **sticky header** (`stickyHeaderIndices`), and re-parented sticky-header children silently lose `nextFocus*` hints (distinct from the cross-FlatList drop in #3 — this is a sticky-header _source_ constraint). Bridge Down with a `TVFocusGuideView destinations` wrapping the destination region instead (the `MissionSection` pattern). So: `nextFocusUp` on the scroll-body child for Up, a guide on the destination for Down. See [`tv-sticky-header-nextfocus-asymmetry-bridge-20260619.md`](./tv-sticky-header-nextfocus-asymmetry-bridge-20260619.md).
 
 ### 2. Column-preserving vertical nav — drop `autoFocus`
 
@@ -193,6 +195,7 @@ Aligned columns are untouched: from column 1, Down lands on the 3-card rail's ca
 ## Related
 
 - [`tv-home-row-anchored-scroll-native-focus-scroll-disabled-20260615.md`](./tv-home-row-anchored-scroll-native-focus-scroll-disabled-20260615.md) — **companion, same screen.** That doc is the row-anchored _scroll_ layer (`scrollEnabled={false}` + `handleRowFocus`); this doc is the _column-focus_ layer. Together they describe the redesigned home's navigation.
+- [`tv-sticky-header-nextfocus-asymmetry-bridge-20260619.md`](./tv-sticky-header-nextfocus-asymmetry-bridge-20260619.md) — **the reverse-direction complement.** §1 here handles Up from edge cards/hero to the centered tab via `nextFocusUp` ref-as-state; that doc handles **Down** from the sticky-header tabs back to the hero (the tabs drop `nextFocusDown`, so a `TVFocusGuideView destinations` bridges Down to the hero CTA). Same `onSearchTabNode` / `ctaNode` ref-as-state contract.
 - [`../best-practices/tv-focus-driven-hero-patterns-20260420.md`](../best-practices/tv-focus-driven-hero-patterns-20260420.md) — the prior home focus model (non-interactive hero / rail-owns-focus via `TVFocusGuideView autoFocus`). This doc **extends and partially supersedes** it: `autoFocus` is correct for first-mount initial focus but is the _wrong ongoing model_ for a multi-rail feed (it teleports columns), and its "full-width guide traps DOWN" note generalises to "a full-width `destinations` guide hijacks aligned lateral moves for sibling rails."
 - [`../best-practices/react-native-tvos-porting-pitfalls-20260414.md`](../best-practices/react-native-tvos-porting-pitfalls-20260414.md) — general tvOS catalog. **Refresh candidate:** Pitfall 4's invisible focus anchor uses `opacity: 0`; this doc establishes that `opacity:0` is unfocusable for _geometric_ catch. Whether the anchor's explicit `setNativeProps({ hasTVPreferredFocus })` claim still works on an `opacity:0` view is unverified — worth a focused check before trusting that recipe. Pitfall 3's "`nextFocus*` failed" is refined here: it fails _across FlatList boundaries_, not universally.
 - [`../best-practices/react-native-tvos-flatlist-sheet-virtualization-pitfalls.md`](../best-practices/react-native-tvos-flatlist-sheet-virtualization-pitfalls.md) — FlatList focus discipline; the one-shot `hasTVPreferredFocus` and re-render rules are cousins of the `extraData`-for-async-focus-target rule here.

--- a/docs/solutions/design-patterns/tv-sticky-header-nextfocus-asymmetry-bridge-20260619.md
+++ b/docs/solutions/design-patterns/tv-sticky-header-nextfocus-asymmetry-bridge-20260619.md
@@ -1,0 +1,120 @@
+---
+title: "tvOS sticky-header nextFocus asymmetry: bridging D-pad focus across an offset top bar"
+date: 2026-06-19
+last_refreshed: 2026-06-19
+category: design-patterns
+module: apps/tv
+problem_type: design_pattern
+component: frontend_stimulus
+severity: high
+applies_when:
+  - "A React Native ScrollView uses stickyHeaderIndices and the sticky header holds focusable nav (tabs/buttons)"
+  - "Focusable content below the sticky header is horizontally offset from the header's controls (no projection overlap)"
+  - "D-pad Up from the content or Down from the sticky-header tabs dead-ends with no visible response"
+  - "nextFocusDown set on a sticky-header tab type-checks and compiles but does nothing at runtime"
+tags:
+  - tv
+  - tvos
+  - android-tv
+  - react-native-tvos
+  - tvfocusguideview
+  - focus
+  - d-pad
+  - nextfocus
+  - sticky-header
+related_components:
+  - apps/tv/app/index.tsx
+  - apps/tv/src/components/home/HomeHeroCarousel.tsx
+  - apps/tv/src/components/home/HomeTopBar.tsx
+  - apps/tv/src/components/home/MissionSection.tsx
+---
+
+## Context
+
+The TV home screen renders one full-screen `ScrollView` whose first child is pinned with `stickyHeaderIndices={[0]}` — the top bar (centered Search / Home tabs, brandmark, clock). Below it the hero carousel's action row — the "See more" CTA and the next-slide chevron — is **left-anchored** inside the hero region.
+
+tvOS focus is purely **geometric**: pressing Up/Down, the engine projects the focused element's horizontal bounds into a vertical beam and looks for the nearest focusable inside that beam. The centered tabs and the left-anchored hero buttons share **no horizontal overlap**, so the beam finds nothing: D-pad Up from the hero dead-ends under the hero artwork, and D-pad Down from a tab falls straight through to the first content rail, skipping the hero entirely. (The previous full-width featured rail overlapped the centered tabs, so geometry worked then; the new left-anchored hero buttons don't.)
+
+The intuitive fix — set `nextFocusDown` on the tabs to point at the hero CTA — **silently does nothing**. Sticky-header children are re-parented during layout, and that re-parenting causes the focus engine to drop `nextFocus*` hints set on them. The asymmetry is real and load-bearing:
+
+- `nextFocusUp` on a **normal scroll-body child** pointing INTO the sticky header **works**.
+- `nextFocusDown` set **on a sticky-header child** pointing down is **dropped**.
+
+So one ScrollView + sticky header + horizontally offset focusables produces **two simultaneous dead-ends that need two different mechanisms**.
+
+## Guidance
+
+When a sticky-header nav sits above focusables that are horizontally offset from its controls, bridge each direction by the **source** of the D-pad press:
+
+**Up (normal scroll-body child → sticky header): `nextFocusUp` on the source.**
+
+Lift the sticky tab's native node out via a ref-as-state callback, thread it into the offset component as a target prop, and assign it to `nextFocusUp` on every focusable in the offset region. This is the same ref-as-state mechanism the section rails already use to bridge edge cards Up to the hero CTA (`upFocusTarget={ctaNode}`) — the consumer holds the node, the producer applies it.
+
+```tsx
+// app/index.tsx — capture the Search tab node out of the sticky HomeTopBar.
+// ViewType is `View` aliased from react-native: import { type View as ViewType } from "react-native"
+const [searchTabNode, setSearchTabNode] = useState<ViewType | null>(null)
+<HomeTopBar onSearchTabNode={setSearchTabNode} ... />
+<HomeHeroCarousel upFocusTarget={searchTabNode} ... />
+
+// HomeHeroCarousel.tsx — both action buttons point Up at the Search tab
+<Pressable nextFocusUp={upFocusTarget ?? undefined} ... />
+```
+
+**Down (sticky-header child → offset focusable below): `TVFocusGuideView` on the destination region.**
+
+Do **not** set `nextFocusDown` on the sticky tab — it is dropped. Instead wrap the destination region in a `TVFocusGuideView` with `autoFocus` and `destinations={[ctaNode]}`. A Down move that enters the guide's bounds is redirected to the CTA. Hold the destination in **state, not a ref**, so the component re-renders with a real destination the moment the CTA mounts (a plain ref leaves `destinations` undefined on first render).
+
+```tsx
+// app/index.tsx — guide bridges Down from the tabs into the offset CTA
+const [ctaNode, setCtaNode] = useState<ViewType | null>(null)
+<TVFocusGuideView autoFocus destinations={ctaNode != null ? [ctaNode] : undefined}>
+  <HomeHeroCarousel onCtaNode={setCtaNode} ... />
+</TVFocusGuideView>
+```
+
+**The decision rule:**
+
+| Press source                                 | Mechanism                                                       |
+| -------------------------------------------- | --------------------------------------------------------------- |
+| Normal scroll-body child                     | `nextFocusUp` / `nextFocusDown` on the source                   |
+| Sticky-header child (Down out of the header) | `TVFocusGuideView destinations` wrapping the destination region |
+
+## Why This Matters
+
+tvOS focus is geometric — when elements lack horizontal overlap there is no natural path between them, and the result is a **silent dead-end, not an error**. The trap is that `nextFocusDown` on the sticky tab type-checks and compiles, so it looks done; at runtime UIKit's sticky-header re-parenting discards the hint and the press falls through. This is platform behavior, not a fileable bug. The UX cost on a 10-foot screen is real: Down from the Search tab skips the hero and lands on the first rail; Up from the hero drops focus into a dead zone with no visible response.
+
+## When to Apply
+
+Apply the two-mechanism bridge whenever all of the following hold in `apps/tv`:
+
+1. A `ScrollView` uses `stickyHeaderIndices` to pin a nav row.
+2. The nav row contains focusable elements (tabs, buttons).
+3. Focusables below the sticky header are horizontally offset from those controls (e.g. left-anchored content under a centered nav).
+
+The same re-parenting behavior applies to any direction with no horizontal overlap: reach for a `TVFocusGuideView destinations` on the destination region for **sticky-header-sourced** moves, and `nextFocus*` only for **normal-child-sourced** moves.
+
+## Examples
+
+**Node capture for Up.** `HomeTopBar` exposes its Search tab's node through an `onSearchTabNode` callback (a ref-as-state seam it already had). `app/index.tsx` captures it into `searchTabNode` and threads it as `upFocusTarget` into `HomeHeroCarousel`; both `HeroCtaButton` and `HeroChevronButton` assign it to `nextFocusUp`. This is the vertical-Up complement of the section rail's existing `upFocusTarget={ctaNode}` bridge.
+
+**Guide for Down.** `ctaNode` is already captured from `HomeHeroCarousel` via `onCtaNode` (originally wired only for the rail's Up bridge). Wrapping the hero in `<TVFocusGuideView autoFocus destinations={[ctaNode]}>` is the only addition needed for Down — no per-tab wiring.
+
+**Precedent.** `MissionSection` ships the identical guide shape to bridge Down into its right-anchored QR tile below left-anchored rails — the canonical in-repo example of an offset-focus `TVFocusGuideView destinations` bridge.
+
+**Simulator verification (the only reliable gate — native focus is not unit-testable under jest-expo).** Drive the Apple TV remote with `idb ui key` one press at a time and screenshot after each: `82`=Up, `81`=Down, `79`=Right, `80`=Left. Confirm, on the actual build:
+
+1. Down from Search tab → lands on the See more CTA (not the first rail).
+2. Down from Home tab → lands on the See more CTA.
+3. Up from See more → lands on the Search tab.
+4. Up from the chevron → lands on the Search tab.
+5. Down from See more → continues into the first rail (the guide must **not** trap Down-leaving).
+
+Check 5 is the absorption test from [`tv-focus-driven-hero-patterns-20260420.md`](../best-practices/tv-focus-driven-hero-patterns-20260420.md) §3, which warns that a `destinations` pointing at a **descendant** (rather than a sibling) can make the guide absorb the first Down press (double-press to leave). Empirically here, single-press worked in both directions — the descendant-destination warning did **not** manifest, matching `MissionSection`'s shipped descendant-destination bridge. Treat §3 as a per-instance check to run, not a blanket prohibition: verify single-press on each new guide rather than assuming the descendant shape is broken.
+
+## Related learnings
+
+- [`tv-rail-overhang-pad-bounce-focus-20260616.md`](./tv-rail-overhang-pad-bounce-focus-20260616.md) — establishes the `nextFocusUp` → ref-as-state node mechanism (its §1) for **rail edge cards**. This doc is the same mechanism applied to the **hero buttons**, plus the new sticky-header Down finding. That doc's "do not set `nextFocusDown` on the sticky-header tab" rule should point here.
+- [`rntvos-inplace-dpad-paging-press-vs-arrival-move.md`](./rntvos-inplace-dpad-paging-press-vs-arrival-move.md) — the **horizontal** focus behavior of the same `HomeHeroCarousel` buttons (`useTVEventHandler` + self-targeted `nextFocusLeft/Right`). This doc is the vertical complement.
+- [`tv-home-row-anchored-scroll-native-focus-scroll-disabled-20260615.md`](./tv-home-row-anchored-scroll-native-focus-scroll-disabled-20260615.md) — the scroll layer of the same screen (`scrollEnabled={false}`, focus-driven `scrollTo`). Context for why focus entering the hero via the guide still pins the feed to scroll 0.
+- [`tv-focus-driven-hero-patterns-20260420.md`](../best-practices/tv-focus-driven-hero-patterns-20260420.md) — the predecessor "non-interactive hero" model and the §3 sibling-vs-descendant `destinations` caveat. The hero is interactive again here (a paged carousel), so its central thesis is partly superseded for the image-hero case.


### PR DESCRIPTION
## What

Fixes D-pad focus navigation on the TV home screen. Focus could not move between the centered top-bar tabs (Search / Home) and the left-anchored hero action buttons (**See more** + chevron) — pressing Up from the hero or Down from a tab dead-ended.

## Why

tvOS moves focus **geometrically** — Up/Down searches a vertical beam aligned to the source's x-position. The centered tabs have no horizontal projection overlap with the left-anchored hero buttons, so the search found nothing and focus dead-ended. (The previous full-width featured rail overlapped the centered tabs, so geometry worked then; the new hero carousel's left-anchored buttons don't.)

## How

Two directions, each using a pattern already established in this app:

- **Up** (See more / chevron → Search): `nextFocusUp` on both hero buttons points at the Search tab's node, captured via `HomeTopBar`'s existing `onSearchTabNode` seam and threaded through a new `upFocusTarget` prop. Mirrors the section rail's existing card → CTA up-bridge.
- **Down** (Search / Home → See more): a `TVFocusGuideView autoFocus destinations={[ctaNode]}` wraps the hero. A `nextFocusDown` set directly on the tabs is **silently dropped** by the focus engine because the tabs live in the ScrollView's sticky header (re-parented children lose `nextFocus` hints), so the guide owns this direction — the same offset-focus bridge `MissionSection` uses.

## Verification

Verified on the tvOS simulator (Apple TV 4K, tvOS 26.4):

- Up from **See more** → Search ✅
- Up from **chevron** → Search ✅
- Down from **Search** → See more (single press, no absorption) ✅
- Down from **Home** → See more (single press) ✅
- Down from See more still descends to the first rail — guide does **not** trap focus ✅
- Cold-start focus still lands on See more ✅

`tsc --noEmit` clean · `eslint .` clean · 459 jest tests pass.

Reviewed via `ce-code-review` (6 reviewers): verdict **Ready to merge** — only two low P3 advisories (one pre-existing). The one documented caveat (`tv-focus-driven-hero-patterns-20260420.md` §3, "destinations must be siblings, not descendants") was empirically refuted on the simulator — single-press in both directions, consistent with the shipped `MissionSection` precedent.

> Note: builds on the TV home hero pager already on `main` (#1315). Self-contained to `apps/tv` — independent of the offline-downloads work on the originating branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
