### PR TITLE
fix(admin): normalize Mastra launch timeout env values

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -119,6 +119,10 @@ The response-side state that says whether semantic retrieval actually contribute
 
 A vector representation of localized content used for semantic retrieval across videos, scenes, transcripts, and experiences. Content Embeddings are only comparable when the query vector and stored document vectors come from the same provider contract and transform behavior.
 
+### AI Gateway
+
+The project-owned embedding provider surface that produces vectors for Content Embeddings. AI Gateway health proves provider availability, not that Admin can launch or store a specific embedding backfill through Mastra.
+
 ### Embedding Provenance
 
 The metadata that says which provider contract produced a stored Content Embedding and how that vector was transformed before storage. Provenance is part of search correctness: it prevents legacy vectors, newly generated vectors, and future provider variants from being treated as the same embedding space.

--- a/apps/admin/src/services/mastra-experience-embedding-client.ts
+++ b/apps/admin/src/services/mastra-experience-embedding-client.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client"
 import { env } from "@/config/env"
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
 import { prisma as defaultPrisma } from "@/db/client"
 import { buildExperienceEmbeddingSource } from "@/services/embeddings.service"
 
@@ -167,9 +168,9 @@ export async function launchMastraExperienceEmbedding(
         },
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(
-          options.timeoutMs ??
-            env.MASTRA_EXPERIENCE_EMBEDDING_TIMEOUT_MS ??
-            120_000,
+          resolveMastraLaunchTimeoutMs(
+            options.timeoutMs ?? env.MASTRA_EXPERIENCE_EMBEDDING_TIMEOUT_MS,
+          ),
         ),
       },
     )

--- a/apps/admin/src/services/mastra-launch-timeout.test.ts
+++ b/apps/admin/src/services/mastra-launch-timeout.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
+
+describe("resolveMastraLaunchTimeoutMs", () => {
+  it("accepts positive integer numbers and numeric env strings", () => {
+    expect(resolveMastraLaunchTimeoutMs(300_000)).toBe(300_000)
+    expect(resolveMastraLaunchTimeoutMs("1200000")).toBe(1_200_000)
+  })
+
+  it("falls back for missing or invalid runtime values", () => {
+    expect(resolveMastraLaunchTimeoutMs(undefined)).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("")).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("5m")).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("1.5")).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("-1")).toBe(120_000)
+  })
+})

--- a/apps/admin/src/services/mastra-launch-timeout.ts
+++ b/apps/admin/src/services/mastra-launch-timeout.ts
@@ -1,0 +1,17 @@
+const DEFAULT_MASTRA_LAUNCH_TIMEOUT_MS = 120_000
+
+export function resolveMastraLaunchTimeoutMs(
+  value: number | string | undefined,
+  fallbackMs: number = DEFAULT_MASTRA_LAUNCH_TIMEOUT_MS,
+): number {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isInteger(parsed) && parsed > 0) return parsed
+  }
+
+  return fallbackMs
+}

--- a/apps/admin/src/services/mastra-scene-embedding-client.ts
+++ b/apps/admin/src/services/mastra-scene-embedding-client.ts
@@ -1,4 +1,5 @@
 import { env } from "@/config/env"
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
 import {
   sceneAnalysisArtifactKey,
   type SceneAnalysisResult,
@@ -211,7 +212,9 @@ export async function launchMastraSceneEmbedding(
         },
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(
-          options.timeoutMs ?? env.MASTRA_SCENE_EMBEDDING_TIMEOUT_MS ?? 120_000,
+          resolveMastraLaunchTimeoutMs(
+            options.timeoutMs ?? env.MASTRA_SCENE_EMBEDDING_TIMEOUT_MS,
+          ),
         ),
       },
     )

--- a/apps/admin/src/services/mastra-transcript-embedding-client.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.ts
@@ -1,4 +1,5 @@
 import { env } from "@/config/env"
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
 
 export type MastraTranscriptEmbeddingMode =
   | "idempotent"
@@ -260,9 +261,9 @@ export async function launchMastraTranscriptEmbedding(
         },
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(
-          options.timeoutMs ??
-            env.MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS ??
-            120_000,
+          resolveMastraLaunchTimeoutMs(
+            options.timeoutMs ?? env.MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS,
+          ),
         ),
       },
     )
@@ -307,4 +308,5 @@ export async function launchMastraTranscriptEmbedding(
 
 export const _internals = {
   parseWorkflowResult,
+  resolveMastraLaunchTimeoutMs,
 }

--- a/docs/solutions/runtime-errors/mastra-launch-timeout-env-string-network-error.md
+++ b/docs/solutions/runtime-errors/mastra-launch-timeout-env-string-network-error.md
@@ -1,0 +1,90 @@
+---
+title: Mastra launch timeout env strings caused instant network errors
+date: 2026-06-19
+category: runtime-errors
+module: apps/admin Mastra embedding launch clients
+problem_type: runtime_error
+component: service_object
+symptoms:
+  - Transcript embedding launch failed in about 1ms with reason network_error
+  - Admin diagnostics logged TypeError delay argument must be number
+  - Production env contained a numeric timeout value as a string
+root_cause: config_error
+resolution_type: code_fix
+severity: high
+tags: [mastra, transcript-embeddings, env, timeout]
+---
+
+# Mastra Launch Timeout Env Strings Caused Instant Network Errors
+
+## Problem
+
+The production transcript embedding smoke still failed after AI Gateway health
+was proven and Admin launch diagnostics were deployed. The new diagnostics
+showed the actual throw happened before any Mastra request was sent:
+`AbortSignal.timeout` received the string value `"1200000"` instead of a
+number.
+
+## Symptoms
+
+- The workflow report showed `reason: "network_error"` for the target.
+- The per-target duration was about 1ms, so the request was not waiting on a
+  long AI Gateway embedding call.
+- Admin logs emitted `mastra_transcript_embedding_launch_threw` with
+  `TypeError: The "delay" argument must be of type number`.
+
+## What Didn't Work
+
+- Changing production env values alone would not address the class of bug:
+  Node env vars are strings, and some runtime paths can still surface string
+  values even when schema definitions use numeric coercion.
+- Continuing the full backfill would have repeated the same instant failure
+  for every target.
+
+## Solution
+
+Normalize timeout values at the Admin to Mastra launch boundary before passing
+them into `AbortSignal.timeout`.
+
+```ts
+export function resolveMastraLaunchTimeoutMs(
+  value: number | string | undefined,
+  fallbackMs = 120_000,
+): number {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isInteger(parsed) && parsed > 0) return parsed
+  }
+
+  return fallbackMs
+}
+```
+
+Use that resolver in the transcript, scene, and experience Admin launch
+clients so all Mastra embedding launchers tolerate numeric env strings.
+
+## Why This Works
+
+`AbortSignal.timeout` validates its `delay` argument at call time. If a runtime
+env value reaches it as a string, the function throws synchronously and the
+launch client reports a retryable network error without opening a network
+connection. Coercing at the call boundary converts valid numeric env strings
+and falls back safely for invalid values.
+
+## Prevention
+
+- Treat env-derived timeout and delay values as untrusted at the boundary where
+  they enter Node timer APIs.
+- Add regression tests for production-shaped numeric strings, not only typed
+  number inputs.
+- When a target fails in 1-2ms, inspect synchronous client setup before blaming
+  the downstream provider.
+
+## Related Issues
+
+- PR #1320: `fix(admin): normalize Mastra launch timeout env values`
+- `docs/solutions/runtime-errors/mastra-transcript-launch-network-error-diagnostics.md`

--- a/docs/solutions/runtime-errors/mastra-transcript-launch-network-error-diagnostics.md
+++ b/docs/solutions/runtime-errors/mastra-transcript-launch-network-error-diagnostics.md
@@ -1,0 +1,123 @@
+---
+title: Mastra transcript launch network errors need upstream diagnostics
+date: 2026-06-19
+category: runtime-errors
+module: apps/admin transcript embedding backfill
+problem_type: runtime_error
+component: service_object
+symptoms:
+  - Production transcript embedding smoke returned failed targets with reason network_error
+  - Direct AI Gateway model and embedding probes were healthy
+  - Admin logs did not show the upstream Mastra status or response body
+root_cause: missing_tooling
+resolution_type: code_fix
+severity: high
+tags: [transcript-embeddings, mastra, ai-gateway, railway]
+---
+
+# Mastra Transcript Launch Network Errors Need Upstream Diagnostics
+
+## Problem
+
+The production transcript embedding backfill smoke failed with `network_error`
+even after direct AI Gateway probes proved the gateway could serve embedding
+requests. The Admin launch client collapsed thrown fetches and non-workflow
+Mastra responses into the same retryable result, so operators could not tell
+whether the failure was DNS, auth, route registration, a bad upstream status, or
+another handoff problem.
+
+## Symptoms
+
+- A one-target Admin GraphQL trigger returned HTTP 200 but reported the target
+  as failed with reason `network_error`.
+- Direct production probes from the Mastra environment to `/v1/models` and
+  `/v1/embeddings` returned healthy responses.
+- Mastra route logs did not show a matching transcript embedding request.
+- The Admin workflow emitted target failure logs, but the launch client did not
+  preserve thrown fetch messages or non-OK response details.
+
+## What Didn't Work
+
+- Treating `network_error` as proof that AI Gateway was down did not hold once
+  direct model and embedding probes succeeded.
+- Retrying the broad backfill would have been noisy and potentially expensive
+  because the single-target smoke still failed through the same opaque launch
+  path.
+- Checking only service-level Railway health was not enough: Admin, Admin
+  worker, Mastra, and AI Gateway could all be online while the Admin to Mastra
+  launch contract still failed.
+
+## Solution
+
+Add structured diagnostics at the Admin launch boundary in
+`apps/admin/src/services/mastra-transcript-embedding-client.ts`:
+
+```ts
+try {
+  response = await fetch(endpoint, request)
+} catch (error) {
+  console.error(
+    JSON.stringify({
+      event: "mastra_transcript_embedding_launch_threw",
+      name: error instanceof Error ? error.name : "unknown",
+      message:
+        error instanceof Error
+          ? error.message.slice(0, 240)
+          : String(error).slice(0, 240),
+    }),
+  )
+  return { ok: false, reason: "network_error", retryable: true }
+}
+```
+
+Read the response body once, parse it as a workflow result when possible, and
+log a short status/body prefix when Mastra returns a non-workflow non-OK
+response:
+
+```ts
+const responseBody = await response.text().catch(() => undefined)
+const result = parseWorkflowResult(parseJsonBody(responseBody))
+if (result) return result
+
+if (!response.ok) {
+  logMastraLaunchFailure({
+    status: response.status,
+    statusText: response.statusText,
+    contentType: response.headers.get("content-type"),
+    body: responseBody,
+  })
+  return { ok: false, reason: "network_error", retryable: true }
+}
+```
+
+The runtime result semantics stay unchanged: callers still receive
+`network_error`, `auth_failed`, or `parse_error` as before. The difference is
+that production logs now preserve enough upstream context to decide the next
+fix.
+
+## Why This Works
+
+The embedding system has multiple health boundaries. AI Gateway health proves
+the provider can embed text; it does not prove Admin can launch a Mastra
+transcript embedding workflow. Logging the launch boundary separates provider
+health from route/auth/network failures between Admin and Mastra.
+
+Keeping the caller-facing result stable avoids changing retry behavior during a
+production incident, while preserving the upstream failure details needed to
+debug safely.
+
+## Prevention
+
+- Before retrying a full transcript embedding backfill, prove the smallest
+  representative target works end to end.
+- When direct AI Gateway probes are green but Admin still reports
+  `network_error`, inspect Admin to Mastra launch diagnostics instead of
+  assuming the provider is down.
+- Keep broad backfill retries behind a one-target smoke until logs show the
+  launch request reaches Mastra and the workflow returns a typed result.
+
+## Related Issues
+
+- PR #1319: `fix(admin): log Mastra transcript launch failures`
+- `docs/solutions/runtime-errors/useworkflow-nested-group-step-event-log-corruption.md`
+- `docs/solutions/architecture-patterns/provider-bound-content-embedding-backfill-gate-pattern.md`


### PR DESCRIPTION
## Summary
- normalize Mastra embedding launch timeouts so numeric env strings are accepted before `AbortSignal.timeout`
- apply the resolver to transcript, scene, and experience Admin -> Mastra launch clients
- add regression coverage for production-shaped timeout strings
- include ce-compound docs for the diagnostics hotfix and the env-string timeout root cause

## Root cause
Production had `MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS` as a numeric string. The launch client passed it through to `AbortSignal.timeout`, which throws synchronously when `delay` is not a number. That collapsed into a 1ms retryable `network_error` before any request reached Mastra or AI Gateway.

## Validation
- `pnpm --filter @forge/admin test -- mastra-launch-timeout.test.ts mastra-transcript-embedding-client.test.ts mastra-scene-embedding-client.test.ts mastra-experience-embedding-client.test.ts`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/runtime-errors/mastra-transcript-launch-network-error-diagnostics.md`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/runtime-errors/mastra-launch-timeout-env-string-network-error.md`
- `git diff --check`