### PR TITLE
feat(watch): add multilingual semantic search language control

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -107,6 +107,16 @@ a high-strength source attribution on their own.
 
 A request-side selector that chooses which retrieval pipeline Admin search should run for a caller. A Search Pipeline Mode changes how candidates are gathered and fused; it is not a health signal.
 
+### Search Language
+
+The language semantic search uses to interpret and match a query. Search Language is separate from UI locale, public Watch route language, and audio-language selection: changing it affects search results but does not change the viewer's website language, URL language segment, or selected Dub.
+
+Search Language identity should travel as the public language slug selected or confirmed by the viewer. Locale tags are useful for fallback negotiation and search execution, but they are not the exact identity of the viewer's chosen search language.
+
+### Query Language Suggestion
+
+A visible search-bar suggestion produced when the typed query appears to be in a supported language different from the current Search Language. The suggestion can be generous because it is confirm-gated: it does not change Search Language until the viewer accepts it, and unsupported or unrecognized queries leave the current Search Language in control.
+
 ### Keyword-First Search
 
 A Search Pipeline Mode that keeps semantic retrieval available while strengthening lexical and title-driven retrieval so exact or near-title matches are not diluted by broad semantic similarity.

--- a/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
@@ -1,23 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const rateLimitAuthRoute = vi.fn()
-const isValidSearchTraceSamplingBearer = vi.fn()
-const search = vi.fn()
-const recordSearchTraceSafely = vi.fn()
-
-vi.mock("@/auth/rate-limit", () => ({ rateLimitAuthRoute }))
-vi.mock("@/auth/search-trace-bearer", () => ({
-  isValidSearchTraceSamplingBearer,
+const routeMocks = vi.hoisted(() => ({
+  rateLimitAuthRoute: vi.fn(),
+  isValidSearchTraceSamplingBearer: vi.fn(),
+  search: vi.fn(),
+  recordSearchTraceSafely: vi.fn(),
+  languageFindFirst: vi.fn(),
 }))
-vi.mock("@/db/client", () => ({ prisma: {} }))
-vi.mock("@/services/search-trace.service", () => ({ recordSearchTraceSafely }))
-vi.mock("@/services/hybrid-search.service", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/services/hybrid-search.service")
-  >("@/services/hybrid-search.service")
+
+const {
+  rateLimitAuthRoute,
+  isValidSearchTraceSamplingBearer,
+  search,
+  recordSearchTraceSafely,
+  languageFindFirst,
+} = routeMocks
+
+vi.mock("@/auth/rate-limit", () => ({
+  rateLimitAuthRoute: routeMocks.rateLimitAuthRoute,
+}))
+vi.mock("@/auth/search-trace-bearer", () => ({
+  isValidSearchTraceSamplingBearer: routeMocks.isValidSearchTraceSamplingBearer,
+}))
+vi.mock("@/db/client", () => ({
+  prisma: {
+    language: {
+      findFirst: routeMocks.languageFindFirst,
+    },
+  },
+}))
+vi.mock("@/services/search-trace.service", () => ({
+  recordSearchTraceSafely: routeMocks.recordSearchTraceSafely,
+}))
+vi.mock("@/services/hybrid-search.service", () => {
+  const contentTypes = new Set(["video", "experience"])
   return {
-    ...actual,
-    HybridSearchService: vi.fn(() => ({ search })),
+    HybridSearchService: vi.fn(() => ({ search: routeMocks.search })),
+    isContentType: (value: string) => contentTypes.has(value),
   }
 })
 
@@ -40,6 +59,7 @@ describe("POST /api/internal/search-eval/search", () => {
     vi.clearAllMocks()
     rateLimitAuthRoute.mockResolvedValue({ allowed: true, source: "local" })
     isValidSearchTraceSamplingBearer.mockReturnValue(true)
+    languageFindFirst.mockResolvedValue(null)
     search.mockResolvedValue({
       results: [
         {
@@ -96,6 +116,53 @@ describe("POST /api/internal/search-eval/search", () => {
       contentTypes: ["video"],
     })
     expect(recordSearchTraceSafely).not.toHaveBeenCalled()
+  })
+
+  it("resolves a public language slug before running Admin search", async () => {
+    languageFindFirst.mockResolvedValueOnce({ bcp47: "es" })
+
+    const response = await POST(
+      request({
+        query: "Jesus",
+        locale: "en",
+        languageSlug: "spanish-castilian",
+        limit: 10,
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(languageFindFirst).toHaveBeenCalledWith({
+      where: { slug: "spanish-castilian", deletedAt: null },
+      select: { bcp47: true },
+    })
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "Jesus",
+        locale: "es",
+        limit: 10,
+      }),
+    )
+  })
+
+  it("rejects unsafe or unknown language slugs before search", async () => {
+    for (const body of [
+      { query: "Jesus", locale: "en", languageSlug: "../spanish" },
+      { query: "Jesus", locale: "en", languageSlug: "x".repeat(129) },
+    ]) {
+      const response = await POST(request(body))
+      expect(response.status).toBe(400)
+    }
+
+    languageFindFirst.mockResolvedValueOnce(null)
+    const response = await POST(
+      request({
+        query: "Jesus",
+        locale: "en",
+        languageSlug: "missing-language",
+      }),
+    )
+    expect(response.status).toBe(400)
+    expect(search).not.toHaveBeenCalled()
   })
 
   it("rejects missing bearer before parsing the body", async () => {

--- a/apps/admin/src/app/api/internal/search-eval/search/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.ts
@@ -12,7 +12,9 @@ const RATE_LIMIT_WINDOW_MS = 60_000
 const MAX_BODY_BYTES = 4096
 const MAX_QUERY_LENGTH = 1024
 const MAX_LOCALE_LENGTH = 32
+const MAX_LANGUAGE_SLUG_LENGTH = 128
 const BCP47_REGEX = /^[a-zA-Z]{2,3}(-[A-Za-z0-9]{2,8})*$/
+const LANGUAGE_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 function tooManyRequests(): Response {
   return Response.json(
@@ -120,6 +122,7 @@ function parseBody(body: unknown):
       limit?: number
       offset?: number
       mode?: string
+      languageSlug?: string
       contentTypes?: ContentType[]
     }
   | Response {
@@ -137,6 +140,16 @@ function parseBody(body: unknown):
   if (locale == null) return badRequest("locale is required")
   if (locale.length > MAX_LOCALE_LENGTH || !BCP47_REGEX.test(locale)) {
     return badRequest("locale must be a safe BCP-47 tag")
+  }
+
+  const languageSlug = parseString(record.languageSlug, "languageSlug")
+  if (languageSlug instanceof Response) return languageSlug
+  if (
+    languageSlug != null &&
+    (languageSlug.length > MAX_LANGUAGE_SLUG_LENGTH ||
+      !LANGUAGE_SLUG_REGEX.test(languageSlug))
+  ) {
+    return badRequest("languageSlug must be a safe public language slug")
   }
 
   const limit = parseInteger(record.limit, "limit")
@@ -165,8 +178,26 @@ function parseBody(body: unknown):
     limit,
     offset,
     mode,
+    languageSlug,
     contentTypes: contentType ? [contentType] : undefined,
   }
+}
+
+async function searchLocaleForParams(params: {
+  locale: string
+  languageSlug?: string
+}): Promise<string | Response> {
+  if (!params.languageSlug) return params.locale
+
+  const language = await prisma.language.findFirst({
+    where: { slug: params.languageSlug, deletedAt: null },
+    select: { bcp47: true },
+  })
+  const bcp47 = language?.bcp47?.trim()
+  if (!bcp47 || bcp47.length > MAX_LOCALE_LENGTH || !BCP47_REGEX.test(bcp47)) {
+    return badRequest("languageSlug must reference a searchable language")
+  }
+  return bcp47
 }
 
 function logValue(value: string | undefined): string {
@@ -197,10 +228,19 @@ export async function POST(request: Request): Promise<Response> {
   if (params instanceof Response) return params
 
   try {
+    const locale = await searchLocaleForParams(params)
+    if (locale instanceof Response) return locale
     const service = new HybridSearchService({ prisma })
-    const response = await service.search(params)
+    const response = await service.search({
+      query: params.query,
+      locale,
+      limit: params.limit,
+      offset: params.offset,
+      mode: params.mode,
+      contentTypes: params.contentTypes,
+    })
     console.info(
-      `[search] event=eval_search auth=bearer route=internal rl=${limit.source} locale=${logValue(params.locale)} mode=${logValue(params.mode)} result_count=${response.results.length}`,
+      `[search] event=eval_search auth=bearer route=internal rl=${limit.source} locale=${logValue(locale)} mode=${logValue(params.mode)} result_count=${response.results.length}`,
     )
     return Response.json(response, { status: 200 })
   } catch (error) {

--- a/apps/mastra/src/services/admin-search-eval-client.ts
+++ b/apps/mastra/src/services/admin-search-eval-client.ts
@@ -471,6 +471,7 @@ export async function callAdminEvalSearch(input: {
   payload: {
     query: string
     locale: string
+    languageSlug?: string
     limit?: number
     offset?: number
     mode?: string | null

--- a/apps/mastra/src/services/offline-search-eval/artifacts.ts
+++ b/apps/mastra/src/services/offline-search-eval/artifacts.ts
@@ -89,6 +89,8 @@ const BaselineCaseSchema = z
   .object({
     caseId: z.string().max(128),
     locale: z.string().max(32),
+    languageSlug: z.string().max(128).optional(),
+    websiteLocale: z.string().max(32).optional(),
     queryText: z.string().max(MAX_SAFE_TEXT),
     source: z.literal("seed"),
     tags: z.array(z.string().max(64)).max(MAX_TAGS),
@@ -207,6 +209,8 @@ const ComparisonOutcomeSchema = z
     kind: ReportOutcomeKindSchema,
     caseId: z.string().max(128),
     locale: z.string().max(32),
+    languageSlug: z.string().max(128).optional(),
+    websiteLocale: z.string().max(32).optional(),
     queryText: z.string().max(MAX_SAFE_TEXT),
     source: z.literal("seed"),
     baselineResults: z.array(SearchEvalResultSchema).max(MAX_RESULT_COUNT),

--- a/apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts
@@ -336,6 +336,40 @@ describe("native search eval projection", () => {
     expect(mastra.datasetsById.get("dataset-1")?.experiments).toHaveLength(2)
   })
 
+  it("preserves report outcome language context in native Dataset items", async () => {
+    const mastra = createFakeMastra()
+    const sample = createSampleSearchEvalReport({
+      runId: "sample-run-1",
+      now: new Date("2026-05-28T00:00:00.000Z"),
+    })
+    const report = {
+      ...sample,
+      outcomes: sample.outcomes.map((outcome) => ({
+        ...outcome,
+        languageSlug: "spanish-castilian",
+        websiteLocale: "en",
+      })),
+    }
+
+    await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report,
+      environmentLabel: "local",
+    })
+
+    const item = mastra.datasetsById.get("dataset-1")?.items[0]
+    expect(item?.input).toMatchObject({
+      languageSlug: "spanish-castilian",
+      websiteLocale: "en",
+    })
+    expect(item?.metadata).toMatchObject({
+      forgeSearchEval: {
+        languageSlug: "spanish-castilian",
+        websiteLocale: "en",
+      },
+    })
+  })
+
   it("keeps only sanitized promoted candidates in native datasets", async () => {
     const mastra = createFakeMastra()
     const candidates = [

--- a/apps/mastra/src/services/offline-search-eval/native-evaluation.ts
+++ b/apps/mastra/src/services/offline-search-eval/native-evaluation.ts
@@ -47,6 +47,8 @@ export const NativeSearchEvalInputSchema = z
   .object({
     query: z.string(),
     locale: z.string(),
+    languageSlug: z.string().nullable().optional(),
+    websiteLocale: z.string().nullable().optional(),
     source: z.enum([
       "seed",
       "generated_catalog",
@@ -86,6 +88,8 @@ export const NativeSearchEvalOutputSchema = z
     ]),
     caseId: z.string(),
     locale: z.string(),
+    languageSlug: z.string().nullable().optional(),
+    websiteLocale: z.string().nullable().optional(),
     query: z.string(),
     baselineTopResults: z.array(SearchEvalNativeResultSchema),
     currentTopResults: z.array(SearchEvalNativeResultSchema),
@@ -752,6 +756,8 @@ function nativeDatasetItemFromOutcome(input: {
     input: {
       query: input.outcome.queryText,
       locale: input.outcome.locale,
+      languageSlug: input.outcome.languageSlug ?? null,
+      websiteLocale: input.outcome.websiteLocale ?? null,
       source: input.outcome.source,
       searchOptions: {
         limit: input.report.metadata.search.limit,
@@ -780,6 +786,8 @@ function nativeDatasetItemFromOutcome(input: {
         promptSetVersion: input.report.metadata.promptSetVersion,
         caseId: input.outcome.caseId,
         locale: input.outcome.locale,
+        languageSlug: input.outcome.languageSlug ?? null,
+        websiteLocale: input.outcome.websiteLocale ?? null,
         promptSource: input.outcome.source,
         outcomeKind: input.outcome.kind,
         generatedCandidate: false,
@@ -797,6 +805,8 @@ function nativeOutputFromOutcome(
     outcomeKind: outcome.kind,
     caseId: outcome.caseId,
     locale: outcome.locale,
+    languageSlug: outcome.languageSlug ?? null,
+    websiteLocale: outcome.websiteLocale ?? null,
     query: outcome.queryText,
     baselineTopResults: outcome.baselineResults.slice(0, 5).map(nativeResult),
     currentTopResults: outcome.currentResults.slice(0, 5).map(nativeResult),

--- a/apps/mastra/src/services/offline-search-eval/runner.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/runner.test.ts
@@ -112,15 +112,17 @@ function memoryStore(baseline?: BaselineArtifact): SearchEvalArtifactStore & {
 describe("runOfflineSearchEval", () => {
   it("captures seed-only baselines while keeping generated candidates exploratory", async () => {
     const store = memoryStore()
-    const searchClient = vi.fn(async () => ({
-      ok: true as const,
-      result: {
-        results: [resultA],
-        hasMore: false,
-        query: "Jesus",
-        searchMode: "hybrid" as const,
-      },
-    }))
+    const searchClient = vi.fn(
+      async (_input: { payload: Record<string, unknown> }) => ({
+        ok: true as const,
+        result: {
+          results: [resultA],
+          hasMore: false,
+          query: "Jesus",
+          searchMode: "hybrid" as const,
+        },
+      }),
+    )
     const candidateListClient = vi.fn(async () => ({
       ok: true as const,
       result: {
@@ -175,6 +177,28 @@ describe("runOfflineSearchEval", () => {
         entry.queryText.includes("generated"),
       ),
     ).toBe(false)
+    expect(store.baselines[0]?.cases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          caseId: "seed-french-route-english-who-is-jesus",
+          locale: "en",
+          languageSlug: "english",
+          websiteLocale: "fr",
+        }),
+      ]),
+    )
+    expect(searchClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          query: "Bible Project",
+          locale: "en",
+          languageSlug: "english",
+        }),
+      }),
+    )
+    for (const call of searchClient.mock.calls) {
+      expect(call[0]?.payload).not.toHaveProperty("websiteLocale")
+    }
     expect(result.ok && result.report.generatedCandidateBehavior).toMatchObject(
       {
         included: 1,

--- a/apps/mastra/src/services/offline-search-eval/runner.ts
+++ b/apps/mastra/src/services/offline-search-eval/runner.ts
@@ -287,7 +287,7 @@ function generatedCaseFor(
 }
 
 async function searchAdmin(
-  prompt: { queryText: string; locale: string },
+  prompt: { queryText: string; locale: string; languageSlug?: string },
   input: OfflineSearchEvalInput,
   options: RunnerOptions,
   timing?: SearchTiming,
@@ -299,6 +299,7 @@ async function searchAdmin(
     payload: {
       query: prompt.queryText,
       locale: prompt.locale,
+      ...(prompt.languageSlug ? { languageSlug: prompt.languageSlug } : {}),
       limit: input.searchLimit ?? DEFAULT_SEARCH_LIMIT,
       mode: input.searchMode ?? null,
       contentType: input.contentType ?? null,
@@ -325,6 +326,8 @@ async function searchSeedCases(
     cases.push({
       caseId: prompt.id,
       locale: prompt.locale,
+      ...(prompt.languageSlug ? { languageSlug: prompt.languageSlug } : {}),
+      ...(prompt.websiteLocale ? { websiteLocale: prompt.websiteLocale } : {}),
       queryText: prompt.queryText,
       source: "seed",
       tags: prompt.tags,
@@ -343,6 +346,8 @@ function baselineReportOutcomes(
     kind: entry.searchFailure ? "search-failure" : "tie",
     caseId: entry.caseId,
     locale: entry.locale,
+    ...(entry.languageSlug ? { languageSlug: entry.languageSlug } : {}),
+    ...(entry.websiteLocale ? { websiteLocale: entry.websiteLocale } : {}),
     queryText: entry.queryText,
     source: "seed",
     baselineResults: entry.results,
@@ -425,7 +430,10 @@ async function exploratoryGeneratedOutcomes(
     }
 
     const result = await searchAdmin(
-      { queryText: entry.queryText, locale: entry.locale },
+      {
+        queryText: entry.queryText,
+        locale: entry.locale,
+      },
       input,
       options,
       timing,
@@ -502,7 +510,11 @@ async function compareBaselineCases({
 
   for (const entry of baselineCases) {
     const current = await searchAdmin(
-      { queryText: entry.queryText, locale: entry.locale },
+      {
+        queryText: entry.queryText,
+        locale: entry.locale,
+        languageSlug: entry.languageSlug,
+      },
       input,
       options,
       timing,
@@ -516,6 +528,8 @@ async function compareBaselineCases({
         kind: "search-failure",
         caseId: entry.caseId,
         locale: entry.locale,
+        ...(entry.languageSlug ? { languageSlug: entry.languageSlug } : {}),
+        ...(entry.websiteLocale ? { websiteLocale: entry.websiteLocale } : {}),
         queryText: entry.queryText,
         source: "seed",
         baselineResults: entry.results,
@@ -548,6 +562,8 @@ async function compareBaselineCases({
         kind: collapseSwapVerdicts(forward.verdict, swapped.verdict),
         caseId: entry.caseId,
         locale: entry.locale,
+        ...(entry.languageSlug ? { languageSlug: entry.languageSlug } : {}),
+        ...(entry.websiteLocale ? { websiteLocale: entry.websiteLocale } : {}),
         queryText: entry.queryText,
         source: "seed",
         baselineResults: entry.results,
@@ -569,6 +585,8 @@ async function compareBaselineCases({
         kind: "judge-failure",
         caseId: entry.caseId,
         locale: entry.locale,
+        ...(entry.languageSlug ? { languageSlug: entry.languageSlug } : {}),
+        ...(entry.websiteLocale ? { websiteLocale: entry.websiteLocale } : {}),
         queryText: entry.queryText,
         source: "seed",
         baselineResults: entry.results,

--- a/apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   SEARCH_EVAL_SEED_PROMPT_LOCALES,
+  SEARCH_EVAL_SEED_PROMPT_SET_VERSION,
   SEARCH_EVAL_SEED_PROMPTS,
   seedPromptsForLocales,
 } from "./seed-prompt-set"
@@ -18,6 +19,8 @@ describe("search eval seed prompt set", () => {
       "new believer",
       "small group Bible study",
       "church leader training",
+      "películas bíblicas para niños",
+      "यीशु कौन हैं?",
       "Jesus em português",
       "Wer ist Jesus?",
       "Кто такой Иисус?",
@@ -31,11 +34,15 @@ describe("search eval seed prompt set", () => {
   })
 
   it("keeps prompt metadata non-gating and locale-filterable", () => {
+    expect(SEARCH_EVAL_SEED_PROMPT_SET_VERSION).toBe(
+      "search-eval-seed-prompts/v4",
+    )
     expect(
       SEARCH_EVAL_SEED_PROMPTS.every(
         (prompt) =>
           prompt.source === "seed" &&
           /^[a-zA-Z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(prompt.locale) &&
+          /^[a-z0-9]+(-[a-z0-9]+)*$/.test(prompt.languageSlug ?? "") &&
           prompt.tags.length > 0,
       ),
     ).toBe(true)
@@ -47,11 +54,36 @@ describe("search eval seed prompt set", () => {
     expect(SEARCH_EVAL_SEED_PROMPT_LOCALES).toEqual([
       "en",
       "es",
+      "hi",
       "fr",
       "pt",
       "de",
       "ru",
       "ar",
     ])
+  })
+
+  it("includes website/watch locale mismatch cases", () => {
+    const mismatches = SEARCH_EVAL_SEED_PROMPTS.filter(
+      (prompt) =>
+        prompt.websiteLocale != null && prompt.websiteLocale !== prompt.locale,
+    )
+
+    expect(mismatches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "seed-spanish-castilian-children-bible-films",
+          locale: "es",
+          languageSlug: "spanish-castilian",
+          websiteLocale: "en",
+        }),
+        expect.objectContaining({
+          id: "seed-french-route-english-who-is-jesus",
+          locale: "en",
+          languageSlug: "english",
+          websiteLocale: "fr",
+        }),
+      ]),
+    )
   })
 })

--- a/apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts
+++ b/apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts
@@ -1,11 +1,12 @@
 import type { SeedPromptCase } from "./types"
 
-export const SEARCH_EVAL_SEED_PROMPT_SET_VERSION = "search-eval-seed-prompts/v2"
+export const SEARCH_EVAL_SEED_PROMPT_SET_VERSION = "search-eval-seed-prompts/v4"
 
 export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-bible-project",
     locale: "en",
+    languageSlug: "english",
     queryText: "Bible Project",
     source: "seed",
     tags: ["catalog", "brand-intent"],
@@ -14,6 +15,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-jesus",
     locale: "en",
+    languageSlug: "english",
     queryText: "Jesus",
     source: "seed",
     tags: ["core-title", "catalog"],
@@ -21,6 +23,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-who-is-jesus",
     locale: "en",
+    languageSlug: "english",
     queryText: "Who is Jesus?",
     source: "seed",
     tags: ["question", "new-believer"],
@@ -28,6 +31,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-videos-for-teens",
     locale: "en",
+    languageSlug: "english",
     queryText: "videos for teens",
     source: "seed",
     tags: ["audience", "teens"],
@@ -35,6 +39,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-resources-for-parents",
     locale: "en",
+    languageSlug: "english",
     queryText: "resources for parents",
     source: "seed",
     tags: ["audience", "parents"],
@@ -42,6 +47,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-new-believer",
     locale: "en",
+    languageSlug: "english",
     queryText: "new believer",
     source: "seed",
     tags: ["discipleship", "new-believer"],
@@ -49,6 +55,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-small-group-bible-study",
     locale: "en",
+    languageSlug: "english",
     queryText: "small group Bible study",
     source: "seed",
     tags: ["ministry", "small-group"],
@@ -56,6 +63,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-church-leader-training",
     locale: "en",
+    languageSlug: "english",
     queryText: "church leader training",
     source: "seed",
     tags: ["ministry", "leaders"],
@@ -63,13 +71,47 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-spanish-jesus",
     locale: "es",
+    languageSlug: "spanish-castilian",
     queryText: "Jesus en espanol",
     source: "seed",
     tags: ["locale", "core-title"],
   },
   {
+    id: "seed-spanish-castilian-children-bible-films",
+    locale: "es",
+    languageSlug: "spanish-castilian",
+    websiteLocale: "en",
+    queryText: "películas bíblicas para niños",
+    source: "seed",
+    tags: ["locale", "semantic-language", "children", "mismatch"],
+    operatorNotes:
+      "Exercises Spanish semantic search language selection from an English website/watch route.",
+  },
+  {
+    id: "seed-hindi-who-is-jesus",
+    locale: "hi",
+    languageSlug: "hindi",
+    queryText: "यीशु कौन हैं?",
+    source: "seed",
+    tags: ["locale", "semantic-language", "question", "new-believer"],
+    operatorNotes:
+      "Exercises non-Latin typed-query language detection and Hindi semantic search language selection.",
+  },
+  {
+    id: "seed-french-route-english-who-is-jesus",
+    locale: "en",
+    languageSlug: "english",
+    websiteLocale: "fr",
+    queryText: "Who is Jesus?",
+    source: "seed",
+    tags: ["question", "semantic-language", "mismatch"],
+    operatorNotes:
+      "Exercises English semantic search language selection from a French website/watch route.",
+  },
+  {
     id: "seed-french-hope-youth",
     locale: "fr",
+    languageSlug: "french",
     queryText: "videos d'espoir pour les jeunes",
     source: "seed",
     tags: ["locale", "audience", "youth"],
@@ -77,6 +119,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-portuguese-jesus",
     locale: "pt",
+    languageSlug: "portuguese-brazil",
     queryText: "Jesus em português",
     source: "seed",
     tags: ["locale", "core-title"],
@@ -84,6 +127,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-german-who-is-jesus",
     locale: "de",
+    languageSlug: "german-standard",
     queryText: "Wer ist Jesus?",
     source: "seed",
     tags: ["locale", "question", "new-believer"],
@@ -91,6 +135,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-russian-who-is-jesus",
     locale: "ru",
+    languageSlug: "russian",
     queryText: "Кто такой Иисус?",
     source: "seed",
     tags: ["locale", "question", "new-believer"],
@@ -98,6 +143,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   {
     id: "seed-arabic-who-is-jesus",
     locale: "ar",
+    languageSlug: "arabic-modern-standard",
     queryText: "من هو يسوع؟",
     source: "seed",
     tags: ["locale", "question", "new-believer"],

--- a/apps/mastra/src/services/offline-search-eval/types.ts
+++ b/apps/mastra/src/services/offline-search-eval/types.ts
@@ -18,6 +18,8 @@ export type SearchEvalResult = {
 export type SeedPromptCase = {
   id: string
   locale: string
+  languageSlug?: string
+  websiteLocale?: string
   queryText: string
   source: "seed"
   tags: string[]
@@ -40,6 +42,8 @@ export type SearchEvalCase = SeedPromptCase | GeneratedPromptCase
 export type BaselineCase = {
   caseId: string
   locale: string
+  languageSlug?: string
+  websiteLocale?: string
   queryText: string
   source: "seed"
   tags: string[]
@@ -108,6 +112,8 @@ export type ComparisonOutcome = {
   kind: ReportOutcomeKind
   caseId: string
   locale: string
+  languageSlug?: string
+  websiteLocale?: string
   queryText: string
   source: "seed"
   baselineResults: SearchEvalResult[]

--- a/apps/web/messages/ab.json
+++ b/apps/web/messages/ab.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ady.json
+++ b/apps/web/messages/ady.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/af.json
+++ b/apps/web/messages/af.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ak.json
+++ b/apps/web/messages/ak.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/am.json
+++ b/apps/web/messages/am.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "شاهد الآن",

--- a/apps/web/messages/as.json
+++ b/apps/web/messages/as.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ast.json
+++ b/apps/web/messages/ast.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/av.json
+++ b/apps/web/messages/av.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ay.json
+++ b/apps/web/messages/ay.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/az-Arab.json
+++ b/apps/web/messages/az-Arab.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/az-Cyrl.json
+++ b/apps/web/messages/az-Cyrl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/az.json
+++ b/apps/web/messages/az.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ba.json
+++ b/apps/web/messages/ba.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/be.json
+++ b/apps/web/messages/be.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bi.json
+++ b/apps/web/messages/bi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bjt.json
+++ b/apps/web/messages/bjt.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bn.json
+++ b/apps/web/messages/bn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "এখন দেখুন",

--- a/apps/web/messages/bo.json
+++ b/apps/web/messages/bo.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bs-Cyrl.json
+++ b/apps/web/messages/bs-Cyrl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bs.json
+++ b/apps/web/messages/bs.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bsc.json
+++ b/apps/web/messages/bsc.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/bua.json
+++ b/apps/web/messages/bua.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ca.json
+++ b/apps/web/messages/ca.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/caa.json
+++ b/apps/web/messages/caa.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/cak.json
+++ b/apps/web/messages/cak.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ce.json
+++ b/apps/web/messages/ce.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ceb.json
+++ b/apps/web/messages/ceb.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ch.json
+++ b/apps/web/messages/ch.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/chp.json
+++ b/apps/web/messages/chp.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ckb.json
+++ b/apps/web/messages/ckb.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/crk.json
+++ b/apps/web/messages/crk.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/cs.json
+++ b/apps/web/messages/cs.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/csb.json
+++ b/apps/web/messages/csb.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/cy.json
+++ b/apps/web/messages/cy.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "{suggestion} auf {language} suchen",
     "inLanguage": "auf {language}",
     "browseByRegion": "Nach Region stöbern",
-    "clearLanguages": "Zurücksetzen"
+    "clearLanguages": "Zurücksetzen",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Jetzt ansehen",

--- a/apps/web/messages/den.json
+++ b/apps/web/messages/den.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/dgr.json
+++ b/apps/web/messages/dgr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/dv.json
+++ b/apps/web/messages/dv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/dyo.json
+++ b/apps/web/messages/dyo.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/dz.json
+++ b/apps/web/messages/dz.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ee.json
+++ b/apps/web/messages/ee.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/el.json
+++ b/apps/web/messages/el.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Buscar {suggestion} en {language}",
     "inLanguage": "en {language}",
     "browseByRegion": "Explorar por región",
-    "clearLanguages": "Borrar"
+    "clearLanguages": "Borrar",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Ver ahora",

--- a/apps/web/messages/et.json
+++ b/apps/web/messages/et.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/eu.json
+++ b/apps/web/messages/eu.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/fa.json
+++ b/apps/web/messages/fa.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ff.json
+++ b/apps/web/messages/ff.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/fi.json
+++ b/apps/web/messages/fi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/fil.json
+++ b/apps/web/messages/fil.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/fj.json
+++ b/apps/web/messages/fj.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/fo.json
+++ b/apps/web/messages/fo.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Rechercher {suggestion} en {language}",
     "inLanguage": "en {language}",
     "browseByRegion": "Parcourir par région",
-    "clearLanguages": "Effacer"
+    "clearLanguages": "Effacer",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Regarder",

--- a/apps/web/messages/frr.json
+++ b/apps/web/messages/frr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/fy.json
+++ b/apps/web/messages/fy.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ga.json
+++ b/apps/web/messages/ga.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gaa.json
+++ b/apps/web/messages/gaa.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gd.json
+++ b/apps/web/messages/gd.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gil.json
+++ b/apps/web/messages/gil.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gl.json
+++ b/apps/web/messages/gl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gn.json
+++ b/apps/web/messages/gn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gsw.json
+++ b/apps/web/messages/gsw.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gu.json
+++ b/apps/web/messages/gu.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gv.json
+++ b/apps/web/messages/gv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/gwi.json
+++ b/apps/web/messages/gwi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/hak-Hant.json
+++ b/apps/web/messages/hak-Hant.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/haw.json
+++ b/apps/web/messages/haw.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/hif.json
+++ b/apps/web/messages/hif.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/hil.json
+++ b/apps/web/messages/hil.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ho.json
+++ b/apps/web/messages/ho.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/hr.json
+++ b/apps/web/messages/hr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ht.json
+++ b/apps/web/messages/ht.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/hu.json
+++ b/apps/web/messages/hu.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/hy.json
+++ b/apps/web/messages/hy.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Tonton sekarang",

--- a/apps/web/messages/ilo.json
+++ b/apps/web/messages/ilo.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/inh.json
+++ b/apps/web/messages/inh.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/is.json
+++ b/apps/web/messages/is.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Cerca {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Sfoglia per regione",
-    "clearLanguages": "Cancella"
+    "clearLanguages": "Cancella",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Guarda ora",

--- a/apps/web/messages/iu-Latn.json
+++ b/apps/web/messages/iu-Latn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/iu.json
+++ b/apps/web/messages/iu.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ixl.json
+++ b/apps/web/messages/ixl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "今すぐ見る",

--- a/apps/web/messages/ka.json
+++ b/apps/web/messages/ka.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kbd.json
+++ b/apps/web/messages/kbd.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kg.json
+++ b/apps/web/messages/kg.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kha.json
+++ b/apps/web/messages/kha.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kk.json
+++ b/apps/web/messages/kk.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kl.json
+++ b/apps/web/messages/kl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/km.json
+++ b/apps/web/messages/km.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kn.json
+++ b/apps/web/messages/kn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/knf.json
+++ b/apps/web/messages/knf.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "지금 보기",

--- a/apps/web/messages/koi.json
+++ b/apps/web/messages/koi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kok.json
+++ b/apps/web/messages/kok.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/krc.json
+++ b/apps/web/messages/krc.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ks.json
+++ b/apps/web/messages/ks.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kum.json
+++ b/apps/web/messages/kum.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/kv.json
+++ b/apps/web/messages/kv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ky.json
+++ b/apps/web/messages/ky.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/lb.json
+++ b/apps/web/messages/lb.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/lbe.json
+++ b/apps/web/messages/lbe.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/lez.json
+++ b/apps/web/messages/lez.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ln.json
+++ b/apps/web/messages/ln.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/lo.json
+++ b/apps/web/messages/lo.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/lt.json
+++ b/apps/web/messages/lt.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/lua.json
+++ b/apps/web/messages/lua.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/lv.json
+++ b/apps/web/messages/lv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mai.json
+++ b/apps/web/messages/mai.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mdf.json
+++ b/apps/web/messages/mdf.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mdh.json
+++ b/apps/web/messages/mdh.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mey-Latn.json
+++ b/apps/web/messages/mey-Latn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mfv.json
+++ b/apps/web/messages/mfv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mg.json
+++ b/apps/web/messages/mg.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mh.json
+++ b/apps/web/messages/mh.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mi.json
+++ b/apps/web/messages/mi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mk.json
+++ b/apps/web/messages/mk.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ml.json
+++ b/apps/web/messages/ml.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mn-Mong.json
+++ b/apps/web/messages/mn-Mong.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mn.json
+++ b/apps/web/messages/mn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/mr.json
+++ b/apps/web/messages/mr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ms-Arab.json
+++ b/apps/web/messages/ms-Arab.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ms.json
+++ b/apps/web/messages/ms.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Tonton sekarang",

--- a/apps/web/messages/mt.json
+++ b/apps/web/messages/mt.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/my.json
+++ b/apps/web/messages/my.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/myv.json
+++ b/apps/web/messages/myv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/na.json
+++ b/apps/web/messages/na.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/nan-Hant.json
+++ b/apps/web/messages/nan-Hant.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/nb.json
+++ b/apps/web/messages/nb.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/nd.json
+++ b/apps/web/messages/nd.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ne.json
+++ b/apps/web/messages/ne.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "अहिले हेर्नुहोस्",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Zoek {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Bladeren op regio",
-    "clearLanguages": "Wissen"
+    "clearLanguages": "Wissen",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Nu kijken",

--- a/apps/web/messages/nn.json
+++ b/apps/web/messages/nn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/no.json
+++ b/apps/web/messages/no.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/nr.json
+++ b/apps/web/messages/nr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/nso.json
+++ b/apps/web/messages/nso.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ny.json
+++ b/apps/web/messages/ny.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/oc.json
+++ b/apps/web/messages/oc.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/or.json
+++ b/apps/web/messages/or.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/os.json
+++ b/apps/web/messages/os.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/pa.json
+++ b/apps/web/messages/pa.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/pag.json
+++ b/apps/web/messages/pag.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/pap.json
+++ b/apps/web/messages/pap.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/pau.json
+++ b/apps/web/messages/pau.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Szukaj {suggestion} w języku {language}",
     "inLanguage": "w języku {language}",
     "browseByRegion": "Przeglądaj według regionu",
-    "clearLanguages": "Wyczyść"
+    "clearLanguages": "Wyczyść",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Obejrzyj teraz",

--- a/apps/web/messages/ps.json
+++ b/apps/web/messages/ps.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Buscar {suggestion} em {language}",
     "inLanguage": "em {language}",
     "browseByRegion": "Explorar por região",
-    "clearLanguages": "Limpar"
+    "clearLanguages": "Limpar",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Assistir agora",

--- a/apps/web/messages/qu.json
+++ b/apps/web/messages/qu.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/quc.json
+++ b/apps/web/messages/quc.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/quv.json
+++ b/apps/web/messages/quv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/rm.json
+++ b/apps/web/messages/rm.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/rn.json
+++ b/apps/web/messages/rn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ro.json
+++ b/apps/web/messages/ro.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Caută {suggestion} în {language}",
     "inLanguage": "în {language}",
     "browseByRegion": "Răsfoiește după regiune",
-    "clearLanguages": "Șterge"
+    "clearLanguages": "Șterge",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Urmărește acum",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Смотреть",

--- a/apps/web/messages/rw.json
+++ b/apps/web/messages/rw.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sa.json
+++ b/apps/web/messages/sa.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sah.json
+++ b/apps/web/messages/sah.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sat.json
+++ b/apps/web/messages/sat.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sav.json
+++ b/apps/web/messages/sav.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sd-Deva.json
+++ b/apps/web/messages/sd-Deva.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sd.json
+++ b/apps/web/messages/sd.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/se.json
+++ b/apps/web/messages/se.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sg.json
+++ b/apps/web/messages/sg.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/si.json
+++ b/apps/web/messages/si.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sk.json
+++ b/apps/web/messages/sk.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sl.json
+++ b/apps/web/messages/sl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sm.json
+++ b/apps/web/messages/sm.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sms.json
+++ b/apps/web/messages/sms.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sn.json
+++ b/apps/web/messages/sn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/snf.json
+++ b/apps/web/messages/snf.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/so.json
+++ b/apps/web/messages/so.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sq.json
+++ b/apps/web/messages/sq.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sr-Latn.json
+++ b/apps/web/messages/sr-Latn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sr.json
+++ b/apps/web/messages/sr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/srr.json
+++ b/apps/web/messages/srr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ss.json
+++ b/apps/web/messages/ss.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/st.json
+++ b/apps/web/messages/st.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sv.json
+++ b/apps/web/messages/sv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/sw.json
+++ b/apps/web/messages/sw.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ta.json
+++ b/apps/web/messages/ta.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/te.json
+++ b/apps/web/messages/te.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tet.json
+++ b/apps/web/messages/tet.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tg.json
+++ b/apps/web/messages/tg.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "ดูตอนนี้",

--- a/apps/web/messages/tk.json
+++ b/apps/web/messages/tk.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tl.json
+++ b/apps/web/messages/tl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Manood ngayon",

--- a/apps/web/messages/tn.json
+++ b/apps/web/messages/tn.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tnr.json
+++ b/apps/web/messages/tnr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/to.json
+++ b/apps/web/messages/to.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tpi.json
+++ b/apps/web/messages/tpi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Şimdi izle",

--- a/apps/web/messages/ts.json
+++ b/apps/web/messages/ts.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tsg.json
+++ b/apps/web/messages/tsg.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tt.json
+++ b/apps/web/messages/tt.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tvl.json
+++ b/apps/web/messages/tvl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ty.json
+++ b/apps/web/messages/ty.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tyv.json
+++ b/apps/web/messages/tyv.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/tzm.json
+++ b/apps/web/messages/tzm.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/udm.json
+++ b/apps/web/messages/udm.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ug.json
+++ b/apps/web/messages/ug.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ur.json
+++ b/apps/web/messages/ur.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/usp.json
+++ b/apps/web/messages/usp.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/uz-Arab.json
+++ b/apps/web/messages/uz-Arab.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/uz-Cyrl.json
+++ b/apps/web/messages/uz-Cyrl.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/uz.json
+++ b/apps/web/messages/uz.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/ve.json
+++ b/apps/web/messages/ve.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/vec.json
+++ b/apps/web/messages/vec.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Xem ngay",

--- a/apps/web/messages/war.json
+++ b/apps/web/messages/war.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/wo.json
+++ b/apps/web/messages/wo.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/xh.json
+++ b/apps/web/messages/xh.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/xin.json
+++ b/apps/web/messages/xin.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/yo.json
+++ b/apps/web/messages/yo.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/yue.json
+++ b/apps/web/messages/yue.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/za.json
+++ b/apps/web/messages/za.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "立即观看",

--- a/apps/web/messages/zh-Hant.json
+++ b/apps/web/messages/zh-Hant.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "立即觀看",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "立即观看",

--- a/apps/web/messages/zu.json
+++ b/apps/web/messages/zu.json
@@ -193,7 +193,10 @@
     "searchSuggestionWithLanguage": "Search {suggestion} in {language}",
     "inLanguage": "in {language}",
     "browseByRegion": "Browse by region",
-    "clearLanguages": "Clear"
+    "clearLanguages": "Clear",
+    "queryLanguageDetected": "{language} detected",
+    "searchInLanguage": "Search in {language}",
+    "tryDifferentKeywordsOrLanguage": "Try different keywords or choose another search language"
   },
   "HeroPlayer": {
     "playWithSound": "Watch now",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "rxjs": "^7.3.0",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
+    "tinyld": "1.3.4",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"
   },

--- a/apps/web/src/components/FloatingSearchContext.tsx
+++ b/apps/web/src/components/FloatingSearchContext.tsx
@@ -29,15 +29,18 @@ export type FloatingSearchContextValue = {
   languageGroups: SearchLanguageRegionGroup[]
   languageCountrySuggestion: SearchLanguageCountrySuggestion | null
   recommendedLanguage: SearchLanguageOption | null
+  languageOptionsLoaded: boolean
   languageOptionsLoading: boolean
   languageOptionsError: string | null
   selectedLanguageEnglishNames: string[]
   selectedLanguageRegionByName: Record<string, string>
+  selectedSearchLanguageOption: SearchLanguageOption | null
+  defaultSearchLanguageOption: SearchLanguageOption | null
   setOpen: (open: boolean) => void
   setQuery: (q: string) => void
   search: (
     q: string,
-    options?: { languageEnglishNames?: string[] },
+    options?: { languageEnglishNames?: string[]; languageSlug?: string | null },
   ) => Promise<void>
   loadMore: () => Promise<void>
   toggleSearchLanguage: (
@@ -48,6 +51,7 @@ export type FloatingSearchContextValue = {
     option: SearchLanguageOption,
     regionName?: string,
   ) => void
+  resetSearchLanguageToDefault: () => void
   clearSearchLanguages: () => void
   closeAndKeepQuery: () => void
 }

--- a/apps/web/src/components/FloatingSearchController.tsx
+++ b/apps/web/src/components/FloatingSearchController.tsx
@@ -17,13 +17,13 @@ import { getSearchLanguageOptions } from "@/lib/search-language-actions"
 import type { SearchActionResultSource, SearchResult } from "@/lib/search"
 import {
   MAX_SEARCH_LANGUAGE_FILTERS,
+  findSearchLanguageOptionByPublicSlug,
   groupSearchLanguagesByRegion,
   normalizeSearchLanguageEnglishNames,
   stripLanguageFromSearchQuery,
   type SearchLanguageCountrySuggestion,
   type SearchLanguageOption,
 } from "@/lib/search-language"
-import { writeSearchLanguagePreferenceSlug } from "@/lib/search-language-preference-client"
 import { buildSearchUrl } from "@/lib/search-url"
 import { parseWatchPath } from "@/lib/routes"
 import {
@@ -34,9 +34,12 @@ import {
 import { SearchOverlay } from "./SearchOverlay"
 
 const SEARCH_PAGE_SIZE = 10
+const SEARCH_LANGUAGE_OPTIONS_FALLBACK_MS = 1200
 
 type ActiveSearchSignature = {
   query: string
+  languageEnglishNames: string[]
+  languageSlug: string | null
   languageKey: string
   routeLanguageSlug: string | null
   resultSource: SearchActionResultSource
@@ -103,6 +106,7 @@ export function FloatingSearchController({
     useState<SearchLanguageCountrySuggestion | null>(null)
   const [recommendedLanguage, setRecommendedLanguage] =
     useState<SearchLanguageOption | null>(null)
+  const [languageOptionsLoaded, setLanguageOptionsLoaded] = useState(false)
   const [languageOptionsLoading, setLanguageOptionsLoading] = useState(false)
   const [languageOptionsError, setLanguageOptionsError] = useState<
     string | null
@@ -114,9 +118,12 @@ export function FloatingSearchController({
     useState<string[]>([])
   const [selectedLanguageRegionByName, setSelectedLanguageRegionByName] =
     useState<Record<string, string>>({})
+  const [selectedSearchLanguageOption, setSelectedSearchLanguageOption] =
+    useState<SearchLanguageOption | null>(null)
 
   const requestIdRef = useRef(0)
   const languageOptionsRequestIdRef = useRef(0)
+  const languageOptionsLoadedRef = useRef(false)
   const skeletonTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const loadingMoreRef = useRef(false)
   const loadMoreRunIdRef = useRef(0)
@@ -124,6 +131,10 @@ export function FloatingSearchController({
   const languageOptionsRef = useRef<SearchLanguageOption[]>([])
   const queryRef = useRef("")
   const selectedLanguageEnglishNamesRef = useRef<string[]>([])
+  const selectedSearchLanguageOptionRef = useRef<SearchLanguageOption | null>(
+    null,
+  )
+  const searchLanguageSelectionUserSetRef = useRef(false)
   const activeSearchSignatureRef = useRef<ActiveSearchSignature | null>(null)
   useEffect(() => {
     displayResultsRef.current = displayResults
@@ -134,6 +145,9 @@ export function FloatingSearchController({
   useEffect(() => {
     selectedLanguageEnglishNamesRef.current = selectedLanguageEnglishNames
   }, [selectedLanguageEnglishNames])
+  useEffect(() => {
+    selectedSearchLanguageOptionRef.current = selectedSearchLanguageOption
+  }, [selectedSearchLanguageOption])
 
   const setQuery = useCallback(
     (nextQuery: string) => {
@@ -170,12 +184,23 @@ export function FloatingSearchController({
     }
     return null
   }, [pathname])
+  const defaultSearchLanguage = useMemo(
+    () =>
+      defaultSearchLanguageOption({
+        options: languageOptions,
+        routeLanguageSlug,
+        recommendedLanguage,
+      }),
+    [languageOptions, recommendedLanguage, routeLanguageSlug],
+  )
 
   const refreshLanguageOptions = useCallback(
     async (
       availableLanguageFacets?: Record<string, number>,
     ): Promise<SearchLanguageOption[]> => {
       const thisRequest = ++languageOptionsRequestIdRef.current
+      languageOptionsLoadedRef.current = false
+      setLanguageOptionsLoaded(false)
       setLanguageOptionsLoading(true)
       setLanguageOptionsError(null)
 
@@ -192,12 +217,38 @@ export function FloatingSearchController({
           setLanguageOptions(response.options)
           setLanguageCountrySuggestion(response.countrySuggestion)
           setRecommendedLanguage(response.recommendedLanguage)
+          if (!searchLanguageSelectionUserSetRef.current) {
+            const defaultOption = defaultSearchLanguageOption({
+              options: response.options,
+              routeLanguageSlug,
+              recommendedLanguage: response.recommendedLanguage,
+            })
+            const nextLanguages = defaultOption
+              ? [defaultOption.englishName]
+              : []
+            selectedSearchLanguageOptionRef.current = defaultOption
+            selectedLanguageEnglishNamesRef.current = nextLanguages
+            setSelectedSearchLanguageOption(defaultOption)
+            setSelectedLanguageEnglishNames(nextLanguages)
+            setSelectedLanguageRegionByName(
+              defaultOption?.regionNames[0]
+                ? { [defaultOption.englishName]: defaultOption.regionNames[0] }
+                : {},
+            )
+          }
           return response.options
         }
 
         setLanguageOptions([])
         setLanguageCountrySuggestion(null)
         setRecommendedLanguage(null)
+        if (!searchLanguageSelectionUserSetRef.current) {
+          selectedSearchLanguageOptionRef.current = null
+          selectedLanguageEnglishNamesRef.current = []
+          setSelectedSearchLanguageOption(null)
+          setSelectedLanguageEnglishNames([])
+          setSelectedLanguageRegionByName({})
+        }
         setLanguageOptionsError(response.error.message)
         return []
       } catch {
@@ -205,16 +256,44 @@ export function FloatingSearchController({
         setLanguageOptions([])
         setLanguageCountrySuggestion(null)
         setRecommendedLanguage(null)
+        if (!searchLanguageSelectionUserSetRef.current) {
+          selectedSearchLanguageOptionRef.current = null
+          selectedLanguageEnglishNamesRef.current = []
+          setSelectedSearchLanguageOption(null)
+          setSelectedLanguageEnglishNames([])
+          setSelectedLanguageRegionByName({})
+        }
         setLanguageOptionsError("Language options are unavailable.")
         return []
       } finally {
         if (languageOptionsRequestIdRef.current === thisRequest) {
+          languageOptionsLoadedRef.current = true
+          setLanguageOptionsLoaded(true)
           setLanguageOptionsLoading(false)
         }
       }
     },
-    [],
+    [routeLanguageSlug],
   )
+
+  useEffect(() => {
+    if (searchLanguageSelectionUserSetRef.current) return
+    selectedSearchLanguageOptionRef.current = defaultSearchLanguage
+    setSelectedSearchLanguageOption(defaultSearchLanguage)
+    const nextLanguages = defaultSearchLanguage
+      ? [defaultSearchLanguage.englishName]
+      : []
+    selectedLanguageEnglishNamesRef.current = nextLanguages
+    setSelectedLanguageEnglishNames(nextLanguages)
+    setSelectedLanguageRegionByName(
+      defaultSearchLanguage?.regionNames[0]
+        ? {
+            [defaultSearchLanguage.englishName]:
+              defaultSearchLanguage.regionNames[0],
+          }
+        : {},
+    )
+  }, [defaultSearchLanguage])
 
   useEffect(() => {
     if (!open) return
@@ -247,13 +326,13 @@ export function FloatingSearchController({
   const search = useCallback(
     async (
       q: string,
-      options?: { languageEnglishNames?: string[] },
+      options?: {
+        languageEnglishNames?: string[]
+        languageSlug?: string | null
+      },
     ): Promise<void> => {
       const trimmed = q.trim()
       setQuery(q)
-      const activeLanguageEnglishNames =
-        options?.languageEnglishNames ?? selectedLanguageEnglishNamesRef.current
-      const activeLanguageKey = searchLanguageKey(activeLanguageEnglishNames)
 
       // Bump the request id immediately so any in-flight request (from a prior
       // call in any branch — exit-animation, Apollo, or clear) fails its
@@ -316,15 +395,27 @@ export function FloatingSearchController({
       }, skeletonThreshold)
 
       try {
-        const currentLanguageOptions =
-          languageOptionsRef.current.length > 0
-            ? languageOptionsRef.current
-            : await refreshLanguageOptions(
+        const currentLanguageOptions = languageOptionsLoadedRef.current
+          ? languageOptionsRef.current
+          : await withSearchLanguageOptionsFallback(
+              refreshLanguageOptions(
                 Object.keys(languageFacets).length > 0
                   ? languageFacets
                   : undefined,
-              )
+              ),
+              () => languageOptionsRef.current,
+            )
         if (requestIdRef.current !== thisRequest) return
+        const activeLanguageEnglishNames =
+          options?.languageEnglishNames ??
+          selectedLanguageEnglishNamesRef.current
+        const defaultLanguageSlug = algoliaSearchEnabled
+          ? null
+          : (selectedSearchLanguageOptionRef.current?.publicSlug ?? null)
+        const activeLanguageSlug =
+          options?.languageSlug !== undefined
+            ? options.languageSlug
+            : defaultLanguageSlug
 
         const data = await runSearch({
           query: trimmed.slice(0, 200),
@@ -332,6 +423,7 @@ export function FloatingSearchController({
           offset: 0,
           languageEnglishNames: activeLanguageEnglishNames,
           languageOptions: currentLanguageOptions,
+          languageSlug: activeLanguageSlug,
           routeLanguageSlug,
         })
 
@@ -360,9 +452,18 @@ export function FloatingSearchController({
         setResultsKey((k) => k + 1)
         setHasMore(data.hasMore)
         setResultSource(data.resultSource)
+        const signatureLanguageSlug =
+          data.resultSource === "semantic"
+            ? data.resolvedLanguage.publicSlug
+            : null
         activeSearchSignatureRef.current = {
           query: trimmed.slice(0, 200),
-          languageKey: activeLanguageKey,
+          languageEnglishNames: [...activeLanguageEnglishNames],
+          languageSlug: signatureLanguageSlug,
+          languageKey: searchLanguageKey(
+            activeLanguageEnglishNames,
+            signatureLanguageSlug,
+          ),
           routeLanguageSlug,
           resultSource: data.resultSource,
           nextOffset: data.nextOffset ?? newResults.length,
@@ -388,6 +489,7 @@ export function FloatingSearchController({
     [
       clearLoadingForRequest,
       languageFacets,
+      algoliaSearchEnabled,
       maybeSetLanguageFacets,
       pathname,
       refreshLanguageOptions,
@@ -401,8 +503,18 @@ export function FloatingSearchController({
     const expectedSignature = activeSearchSignatureRef.current
     if (!expectedSignature) return
     const currentQuery = queryRef.current.trim().slice(0, 200)
+    const currentLanguageSlug =
+      resultSource === "algolia"
+        ? null
+        : (selectedSearchLanguageOptionRef.current?.publicSlug ??
+          expectedSignature.languageSlug)
+    const currentLanguageEnglishNames =
+      selectedLanguageEnglishNamesRef.current.length > 0
+        ? selectedLanguageEnglishNamesRef.current
+        : expectedSignature.languageEnglishNames
     const currentLanguageKey = searchLanguageKey(
-      selectedLanguageEnglishNamesRef.current,
+      currentLanguageEnglishNames,
+      currentLanguageSlug,
     )
     if (
       expectedSignature.query !== currentQuery ||
@@ -427,8 +539,9 @@ export function FloatingSearchController({
         query: currentQuery,
         limit: SEARCH_PAGE_SIZE,
         offset: expectedSignature.nextOffset,
-        languageEnglishNames: selectedLanguageEnglishNamesRef.current,
+        languageEnglishNames: expectedSignature.languageEnglishNames,
         languageOptions: languageOptionsRef.current,
+        languageSlug: expectedSignature.languageSlug,
         routeLanguageSlug,
       })
       if (requestIdRef.current !== thisRequest) return
@@ -496,10 +609,6 @@ export function FloatingSearchController({
         return next
       })
 
-      if (!selected && option.publicSlug) {
-        writeSearchLanguagePreferenceSlug(option.publicSlug)
-      }
-
       const nextQuery = selected
         ? query
         : stripLanguageFromSearchQuery(option.englishName, query)
@@ -511,18 +620,40 @@ export function FloatingSearchController({
   const selectSearchLanguage = useCallback(
     (option: SearchLanguageOption, regionName?: string): void => {
       const nextLanguages = [option.englishName]
+      searchLanguageSelectionUserSetRef.current = true
       selectedLanguageEnglishNamesRef.current = nextLanguages
+      selectedSearchLanguageOptionRef.current = option.publicSlug
+        ? option
+        : null
       setSelectedLanguageEnglishNames(nextLanguages)
+      setSelectedSearchLanguageOption(option.publicSlug ? option : null)
       setSelectedLanguageRegionByName(
         regionName ? { [option.englishName]: regionName } : {},
       )
-
-      if (option.publicSlug) {
-        writeSearchLanguagePreferenceSlug(option.publicSlug)
-      }
     },
     [],
   )
+
+  const resetSearchLanguageToDefault = useCallback((): void => {
+    const defaultOption = defaultSearchLanguage
+    searchLanguageSelectionUserSetRef.current = false
+    selectedSearchLanguageOptionRef.current = defaultOption
+    const nextLanguages = defaultOption ? [defaultOption.englishName] : []
+    selectedLanguageEnglishNamesRef.current = nextLanguages
+    setSelectedSearchLanguageOption(defaultOption)
+    setSelectedLanguageEnglishNames(nextLanguages)
+    setSelectedLanguageRegionByName(
+      defaultOption?.regionNames[0]
+        ? { [defaultOption.englishName]: defaultOption.regionNames[0] }
+        : {},
+    )
+    if (query.trim().length > 0) {
+      void search(query, {
+        languageEnglishNames: nextLanguages,
+        languageSlug: defaultOption?.publicSlug ?? null,
+      })
+    }
+  }, [defaultSearchLanguage, query, search])
 
   const clearSearchLanguages = useCallback((): void => {
     selectedLanguageEnglishNamesRef.current = []
@@ -580,16 +711,20 @@ export function FloatingSearchController({
       languageGroups,
       languageCountrySuggestion,
       recommendedLanguage,
+      languageOptionsLoaded,
       languageOptionsLoading,
       languageOptionsError,
       selectedLanguageEnglishNames,
       selectedLanguageRegionByName,
+      selectedSearchLanguageOption,
+      defaultSearchLanguageOption: defaultSearchLanguage,
       setOpen,
       setQuery,
       search,
       loadMore,
       toggleSearchLanguage,
       selectSearchLanguage,
+      resetSearchLanguageToDefault,
       clearSearchLanguages,
       closeAndKeepQuery,
     }),
@@ -613,16 +748,20 @@ export function FloatingSearchController({
       languageGroups,
       languageCountrySuggestion,
       recommendedLanguage,
+      languageOptionsLoaded,
       languageOptionsLoading,
       languageOptionsError,
       selectedLanguageEnglishNames,
       selectedLanguageRegionByName,
+      selectedSearchLanguageOption,
+      defaultSearchLanguage,
       setOpen,
       setQuery,
       search,
       loadMore,
       toggleSearchLanguage,
       selectSearchLanguage,
+      resetSearchLanguageToDefault,
       clearSearchLanguages,
       closeAndKeepQuery,
     ],
@@ -640,8 +779,63 @@ export function FloatingSearchController({
   )
 }
 
-function searchLanguageKey(languageEnglishNames: readonly string[]): string {
-  return normalizeSearchLanguageEnglishNames(languageEnglishNames).join(
-    "\u0001",
-  )
+function searchLanguageKey(
+  languageEnglishNames: readonly string[],
+  languageSlug: string | null,
+): string {
+  return [
+    languageSlug ?? "",
+    normalizeSearchLanguageEnglishNames(languageEnglishNames).join("\u0001"),
+  ].join("\u0002")
+}
+
+function withSearchLanguageOptionsFallback(
+  promise: Promise<SearchLanguageOption[]>,
+  fallback: () => SearchLanguageOption[],
+): Promise<SearchLanguageOption[]> {
+  return new Promise((resolve) => {
+    let settled = false
+    const timeout = setTimeout(() => {
+      if (settled) return
+      settled = true
+      resolve(fallback())
+    }, SEARCH_LANGUAGE_OPTIONS_FALLBACK_MS)
+
+    promise.then(
+      (options) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        resolve(options)
+      },
+      () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        resolve(fallback())
+      },
+    )
+  })
+}
+
+function defaultSearchLanguageOption({
+  options,
+  routeLanguageSlug,
+  recommendedLanguage,
+}: {
+  options: readonly SearchLanguageOption[]
+  routeLanguageSlug: string | null
+  recommendedLanguage: SearchLanguageOption | null
+}): SearchLanguageOption | null {
+  if (routeLanguageSlug) {
+    const routeOption = findSearchLanguageOptionByPublicSlug(
+      routeLanguageSlug,
+      options,
+    )
+    if (routeOption) return routeOption
+  }
+
+  if (recommendedLanguage?.publicSlug) return recommendedLanguage
+
+  return findSearchLanguageOptionByPublicSlug("english", options)
 }

--- a/apps/web/src/components/SearchOverlay.tsx
+++ b/apps/web/src/components/SearchOverlay.tsx
@@ -1,6 +1,14 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react"
 import Image from "next/image"
 import Link from "next/link"
 import type { Route } from "next"
@@ -22,7 +30,11 @@ import { SpinnerIcon } from "@/components/ui/spinner"
 import { WatchModalViewportCloseButton } from "@/components/watch/WatchModalViewportCloseButton"
 import { CATEGORIES } from "@/lib/search-categories"
 import type { CategorySearchTerm } from "@/lib/search-categories"
-import { MAX_SEARCH_LANGUAGE_FILTERS } from "@/lib/search-language"
+import {
+  MAX_SEARCH_LANGUAGE_FILTERS,
+  type SearchLanguageOption,
+} from "@/lib/search-language"
+import { detectQueryLanguageSuggestion } from "@/lib/search-query-language"
 
 const CATEGORY_TITLE_KEYS: Record<
   CategorySearchTerm,
@@ -62,9 +74,12 @@ const ALGOLIA_REGION_ORDER = [
 ] as const
 
 type AlgoliaBrowseTab = "suggestions" | "languages"
+const MAX_LANGUAGE_AUTOCOMPLETE_OPTIONS = 50
+const SEARCH_LANGUAGE_METADATA_FALLBACK_MS = 1200
 
 export function SearchOverlay() {
   const t = useTranslations("SearchOverlay")
+  const tLanguage = useTranslations("LanguageCombobox")
   const {
     open,
     closing,
@@ -83,15 +98,19 @@ export function SearchOverlay() {
     languageGroups,
     languageCountrySuggestion,
     recommendedLanguage,
+    languageOptionsLoaded,
     languageOptionsLoading,
     languageOptionsError,
     selectedLanguageEnglishNames,
     selectedLanguageRegionByName,
+    selectedSearchLanguageOption,
+    defaultSearchLanguageOption,
     setQuery,
     search,
     loadMore,
     toggleSearchLanguage,
     selectSearchLanguage,
+    resetSearchLanguageToDefault,
     clearSearchLanguages,
     closeAndKeepQuery,
   } = useFloatingSearch()
@@ -101,12 +120,25 @@ export function SearchOverlay() {
     useState<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [languagePanelCollapsed, setLanguagePanelCollapsed] = useState(false)
+  const pendingSearchAfterLanguageLoadRef = useRef<string | null>(null)
+  const languageSearchInputRef = useRef<HTMLInputElement>(null)
+  const languageAutocompleteBlurTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const [languagePanelCollapsed, setLanguagePanelCollapsed] = useState(true)
   const [algoliaBrowseTab, setAlgoliaBrowseTab] =
     useState<AlgoliaBrowseTab>("languages")
   const [selectedRegionName, setSelectedRegionName] = useState<string | null>(
     null,
   )
+  const [languageSearchQuery, setLanguageSearchQuery] = useState("")
+  const [languageAutocompleteOpen, setLanguageAutocompleteOpen] =
+    useState(false)
+  const [languageAutocompleteDirty, setLanguageAutocompleteDirty] =
+    useState(false)
+  const [activeLanguageOptionIndex, setActiveLanguageOptionIndex] = useState(0)
+  const [languageMetadataFallbackReady, setLanguageMetadataFallbackReady] =
+    useState(false)
 
   const orderedLanguageGroups = useMemo(() => {
     const order = new Map<string, number>(
@@ -120,13 +152,11 @@ export function SearchOverlay() {
     })
   }, [languageGroups])
 
-  const activeRegionName =
-    algoliaSearchEnabled &&
-    orderedLanguageGroups.some(
-      (group) => group.regionName === selectedRegionName,
-    )
-      ? selectedRegionName
-      : (orderedLanguageGroups[0]?.regionName ?? null)
+  const activeRegionName = orderedLanguageGroups.some(
+    (group) => group.regionName === selectedRegionName,
+  )
+    ? selectedRegionName
+    : (orderedLanguageGroups[0]?.regionName ?? null)
 
   const setOverlayElement = useCallback((node: HTMLDivElement | null) => {
     overlayRef.current = node
@@ -189,24 +219,135 @@ export function SearchOverlay() {
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
+      if (languageAutocompleteBlurTimeoutRef.current) {
+        clearTimeout(languageAutocompleteBlurTimeoutRef.current)
+      }
     }
   }, [])
 
+  const semanticSearchEnabled = !algoliaSearchEnabled
+  const languageOptionsReadyForSearch =
+    !semanticSearchEnabled ||
+    languageOptionsLoaded ||
+    languageMetadataFallbackReady
+
+  useEffect(() => {
+    if (!open || !semanticSearchEnabled || languageOptionsLoaded) return
+    const fallbackTimer = setTimeout(() => {
+      setLanguageMetadataFallbackReady(true)
+    }, SEARCH_LANGUAGE_METADATA_FALLBACK_MS)
+    return () => {
+      clearTimeout(fallbackTimer)
+      setLanguageMetadataFallbackReady(false)
+    }
+  }, [languageOptionsLoaded, open, semanticSearchEnabled])
+
+  const maybeDetectQueryLanguageSuggestion = useCallback(
+    (value: string) => {
+      if (!semanticSearchEnabled) return null
+      return detectQueryLanguageSuggestion({
+        query: value,
+        currentLanguageSlug: selectedSearchLanguageOption?.publicSlug ?? null,
+        languageOptions,
+      })
+    },
+    [languageOptions, selectedSearchLanguageOption, semanticSearchEnabled],
+  )
+  const queryLanguageSuggestion = useMemo(
+    () => maybeDetectQueryLanguageSuggestion(query),
+    [maybeDetectQueryLanguageSuggestion, query],
+  )
+  const suggestedLanguageName =
+    queryLanguageSuggestion?.option.englishName.split(",")[0] ?? null
+
+  useEffect(() => {
+    if (!languageOptionsReadyForSearch) return
+    const pendingQuery = pendingSearchAfterLanguageLoadRef.current
+    if (pendingQuery == null || pendingQuery !== query) return
+    pendingSearchAfterLanguageLoadRef.current = null
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (pendingQuery.trim().length === 0) return
+    if (
+      semanticSearchEnabled &&
+      maybeDetectQueryLanguageSuggestion(pendingQuery)
+    ) {
+      return
+    }
+    debounceRef.current = setTimeout(() => {
+      void search(pendingQuery)
+    }, 300)
+  }, [
+    languageOptionsReadyForSearch,
+    maybeDetectQueryLanguageSuggestion,
+    query,
+    search,
+    semanticSearchEnabled,
+  ])
+
+  const handleQueryLanguageSuggestionConfirm = useCallback(() => {
+    const suggestion = queryLanguageSuggestion
+    if (!suggestion?.option.publicSlug) return
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    pendingSearchAfterLanguageLoadRef.current = null
+    selectSearchLanguage(suggestion.option, suggestion.option.regionNames[0])
+    void search(query, {
+      languageEnglishNames: [suggestion.option.englishName],
+      languageSlug: suggestion.option.publicSlug,
+    })
+  }, [query, queryLanguageSuggestion, search, selectSearchLanguage])
+
   const handleInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value
       setQuery(newValue)
       if (debounceRef.current) clearTimeout(debounceRef.current)
+      if (!languageOptionsReadyForSearch) {
+        pendingSearchAfterLanguageLoadRef.current = newValue
+        return
+      }
+      pendingSearchAfterLanguageLoadRef.current = null
+      if (maybeDetectQueryLanguageSuggestion(newValue)) return
       debounceRef.current = setTimeout(() => {
         void search(newValue)
       }, 300)
     },
-    [setQuery, search],
+    [
+      languageOptionsReadyForSearch,
+      maybeDetectQueryLanguageSuggestion,
+      setQuery,
+      search,
+    ],
+  )
+
+  const handleInputKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== "Enter") return
+      e.preventDefault()
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      if (!languageOptionsReadyForSearch) {
+        pendingSearchAfterLanguageLoadRef.current = query
+        return
+      }
+      pendingSearchAfterLanguageLoadRef.current = null
+      if (queryLanguageSuggestion) {
+        handleQueryLanguageSuggestionConfirm()
+        return
+      }
+      void search(query)
+    },
+    [
+      handleQueryLanguageSuggestionConfirm,
+      languageOptionsReadyForSearch,
+      query,
+      queryLanguageSuggestion,
+      search,
+    ],
   )
 
   const handleCategoryClick = useCallback(
     (searchTerm: string) => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
+      pendingSearchAfterLanguageLoadRef.current = null
       void search(searchTerm)
     },
     [search],
@@ -215,6 +356,7 @@ export function SearchOverlay() {
   const handleSuggestionClick = useCallback(
     (searchTerm: string) => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
+      pendingSearchAfterLanguageLoadRef.current = null
       if (recommendedLanguage) {
         selectSearchLanguage(
           recommendedLanguage,
@@ -232,6 +374,7 @@ export function SearchOverlay() {
 
   const handleRecommendedLanguageClick = useCallback(() => {
     if (!recommendedLanguage) return
+    pendingSearchAfterLanguageLoadRef.current = null
     selectSearchLanguage(
       recommendedLanguage,
       recommendedLanguage.regionNames[0],
@@ -243,33 +386,88 @@ export function SearchOverlay() {
     }
   }, [query, recommendedLanguage, search, selectSearchLanguage])
 
+  const handleSemanticLanguageClick = useCallback(
+    (language: SearchLanguageOption, regionName?: string) => {
+      if (!language.publicSlug) return
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      pendingSearchAfterLanguageLoadRef.current = null
+      setLanguageSearchQuery(language.englishName)
+      setLanguageAutocompleteOpen(false)
+      setLanguageAutocompleteDirty(false)
+      setActiveLanguageOptionIndex(0)
+      selectSearchLanguage(language, regionName)
+      if (query.trim().length > 0) {
+        void search(query, {
+          languageEnglishNames: [language.englishName],
+          languageSlug: language.publicSlug,
+        })
+      }
+    },
+    [query, search, selectSearchLanguage],
+  )
+
+  const handleResetSearchLanguage = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    pendingSearchAfterLanguageLoadRef.current = null
+    setLanguageSearchQuery(defaultSearchLanguageOption?.englishName ?? "")
+    setLanguageAutocompleteOpen(false)
+    setLanguageAutocompleteDirty(false)
+    setActiveLanguageOptionIndex(0)
+    resetSearchLanguageToDefault()
+  }, [defaultSearchLanguageOption, resetSearchLanguageToDefault])
+
   const handleClearInput = useCallback(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    pendingSearchAfterLanguageLoadRef.current = null
     void search("")
     inputRef.current?.focus()
   }, [search])
 
   const showCategoryGrid =
     !algoliaSearchEnabled && query.trim().length === 0 && !loading && !searched
+  const searchLanguageControlVisible =
+    algoliaSearchEnabled ||
+    languageOptionsLoading ||
+    languageOptions.length > 0 ||
+    languageOptionsError != null
   const languagePanelOpen =
-    open && algoliaSearchEnabled && !languagePanelCollapsed
-  const showAlgoliaBrowsePanel =
-    algoliaSearchEnabled && (languagePanelOpen || query.trim().length === 0)
+    open && searchLanguageControlVisible && !languagePanelCollapsed
+  const showLanguageBrowsePanel =
+    searchLanguageControlVisible &&
+    (languagePanelOpen || (algoliaSearchEnabled && query.trim().length === 0))
   const activeRegionGroup =
     orderedLanguageGroups.find(
       (group) => group.regionName === activeRegionName,
     ) ??
     orderedLanguageGroups[0] ??
     null
+  const searchOverlayScrollTopClass = queryLanguageSuggestion
+    ? "top-64 sm:top-56"
+    : searchLanguageControlVisible
+      ? "top-56 sm:top-44"
+      : "top-44 sm:top-32"
   const languageCountLabel =
     languageOptions.length >= 1000 ? "1000+" : String(languageOptions.length)
-  const selectedLanguageSummary =
+  const algoliaSelectedLanguageSummary =
     selectedLanguageEnglishNames.length === 0
       ? t("allLanguages")
       : selectedLanguageEnglishNames
           .slice(0, 2)
           .map((language) => language.split(",")[0])
           .join(", ")
+  const selectedSearchLanguageName =
+    selectedSearchLanguageOption?.englishName.split(",")[0] ??
+    defaultSearchLanguageOption?.englishName.split(",")[0] ??
+    recommendedLanguage?.englishName.split(",")[0] ??
+    null
+  const selectedSearchLanguageFullName =
+    selectedSearchLanguageOption?.englishName ??
+    defaultSearchLanguageOption?.englishName ??
+    recommendedLanguage?.englishName ??
+    ""
+  const selectedLanguageSummary = algoliaSearchEnabled
+    ? algoliaSelectedLanguageSummary
+    : (selectedSearchLanguageName ?? t("searchLanguageLabel"))
   const additionalLanguageCount = Math.max(
     0,
     selectedLanguageEnglishNames.length - 2,
@@ -278,6 +476,162 @@ export function SearchOverlay() {
     selectedLanguageEnglishNames.length >= MAX_SEARCH_LANGUAGE_FILTERS
   const recommendedLanguageName =
     recommendedLanguage?.englishName.split(",")[0] ?? null
+  const semanticLanguageOverrideActive =
+    semanticSearchEnabled &&
+    (selectedSearchLanguageOption?.publicSlug ?? null) !==
+      (defaultSearchLanguageOption?.publicSlug ?? null)
+  const searchableSemanticLanguageOptions = useMemo(
+    () =>
+      languageOptions.flatMap((language) => {
+        if (!language.publicSlug) return []
+        return [
+          {
+            language,
+            searchText: [
+              language.englishName,
+              language.nativeName ?? "",
+              language.bcp47 ?? "",
+              language.publicSlug,
+            ]
+              .join("\u0001")
+              .toLocaleLowerCase(),
+          },
+        ]
+      }),
+    [languageOptions],
+  )
+  const semanticLanguageAutocompleteOptions = useMemo(() => {
+    const term = languageAutocompleteDirty
+      ? languageSearchQuery.trim().toLocaleLowerCase()
+      : ""
+    const matches: SearchLanguageOption[] = []
+    for (const { language, searchText } of searchableSemanticLanguageOptions) {
+      if (term.length > 0 && !searchText.includes(term)) continue
+      matches.push(language)
+      if (matches.length >= MAX_LANGUAGE_AUTOCOMPLETE_OPTIONS) break
+    }
+    return matches
+  }, [
+    languageAutocompleteDirty,
+    languageSearchQuery,
+    searchableSemanticLanguageOptions,
+  ])
+  const showSemanticLanguageAutocomplete =
+    !algoliaSearchEnabled &&
+    languageAutocompleteOpen &&
+    languagePanelOpen &&
+    !languageOptionsLoading &&
+    !languageOptionsError
+  const resolvedActiveLanguageOptionIndex =
+    semanticLanguageAutocompleteOptions.length === 0
+      ? 0
+      : Math.min(
+          activeLanguageOptionIndex,
+          semanticLanguageAutocompleteOptions.length - 1,
+        )
+  const activeLanguageAutocompleteOption =
+    semanticLanguageAutocompleteOptions[resolvedActiveLanguageOptionIndex] ??
+    null
+  const activeLanguageAutocompleteOptionId =
+    activeLanguageAutocompleteOption?.publicSlug != null
+      ? `search-language-autocomplete-option-${activeLanguageAutocompleteOption.publicSlug}`
+      : undefined
+
+  useEffect(() => {
+    if (!languagePanelOpen || algoliaSearchEnabled) return
+    const focusTimer = setTimeout(() => {
+      const input = languageSearchInputRef.current
+      input?.focus()
+      input?.select()
+    }, 0)
+    return () => clearTimeout(focusTimer)
+  }, [algoliaSearchEnabled, languagePanelOpen])
+
+  const handleLanguagePanelToggle = useCallback(() => {
+    setLanguagePanelCollapsed((collapsed) => {
+      const nextCollapsed = !collapsed
+      setLanguageSearchQuery(selectedSearchLanguageFullName)
+      setLanguageAutocompleteDirty(false)
+      if (nextCollapsed) {
+        setLanguageAutocompleteOpen(false)
+        setActiveLanguageOptionIndex(0)
+      } else {
+        setLanguageAutocompleteOpen(true)
+      }
+      return nextCollapsed
+    })
+  }, [selectedSearchLanguageFullName])
+
+  const handleLanguageAutocompleteChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setLanguageSearchQuery(event.target.value)
+      setLanguageAutocompleteOpen(true)
+      setLanguageAutocompleteDirty(true)
+      setActiveLanguageOptionIndex(0)
+    },
+    [],
+  )
+
+  const handleLanguageAutocompleteFocus = useCallback(() => {
+    if (languageAutocompleteBlurTimeoutRef.current) {
+      clearTimeout(languageAutocompleteBlurTimeoutRef.current)
+      languageAutocompleteBlurTimeoutRef.current = null
+    }
+    setLanguageAutocompleteOpen(true)
+  }, [])
+
+  const handleLanguageAutocompleteBlur = useCallback(() => {
+    languageAutocompleteBlurTimeoutRef.current = setTimeout(() => {
+      setLanguageAutocompleteOpen(false)
+    }, 120)
+  }, [])
+
+  const handleLanguageAutocompleteKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Escape") {
+        if (languageAutocompleteOpen) {
+          event.stopPropagation()
+          setLanguageAutocompleteOpen(false)
+          setLanguageSearchQuery(selectedSearchLanguageFullName)
+          setLanguageAutocompleteDirty(false)
+        }
+        return
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault()
+        setLanguageAutocompleteOpen(true)
+        if (semanticLanguageAutocompleteOptions.length === 0) return
+        setActiveLanguageOptionIndex((index) =>
+          Math.min(index + 1, semanticLanguageAutocompleteOptions.length - 1),
+        )
+        return
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault()
+        setLanguageAutocompleteOpen(true)
+        if (semanticLanguageAutocompleteOptions.length === 0) return
+        setActiveLanguageOptionIndex((index) => Math.max(index - 1, 0))
+        return
+      }
+
+      if (event.key === "Enter" && activeLanguageAutocompleteOption) {
+        event.preventDefault()
+        handleSemanticLanguageClick(
+          activeLanguageAutocompleteOption,
+          activeLanguageAutocompleteOption.regionNames[0],
+        )
+      }
+    },
+    [
+      activeLanguageAutocompleteOption,
+      handleSemanticLanguageClick,
+      languageAutocompleteOpen,
+      semanticLanguageAutocompleteOptions.length,
+      selectedSearchLanguageFullName,
+    ],
+  )
 
   return (
     <div
@@ -338,62 +692,93 @@ export function SearchOverlay() {
             ref={inputRef}
             value={query}
             onChange={handleInputChange}
+            onKeyDown={handleInputKeyDown}
             onClear={handleClearInput}
             placeholder={t("placeholder")}
             aria-label={t("inputLabel")}
             iconTestId="search-overlay-input-icon"
             wrapperClassName="w-full"
           />
-          {algoliaSearchEnabled && (
-            <div className="mt-3 flex flex-wrap items-center gap-2">
+          {queryLanguageSuggestion && suggestedLanguageName && (
+            <div className="mt-3 inline-flex max-w-full flex-wrap items-center gap-2 rounded-full bg-stone-950/70 px-3 py-2 text-sm text-stone-200 ring-1 ring-white/12 backdrop-blur-md">
+              <span className="font-medium">
+                {t("queryLanguageDetected", {
+                  language: suggestedLanguageName,
+                })}
+              </span>
               <button
                 type="button"
-                aria-label={t("searchLanguageLabel")}
-                aria-controls="search-language-panel"
-                aria-expanded={showAlgoliaBrowsePanel}
-                onClick={() => setLanguagePanelCollapsed((value) => !value)}
-                className="inline-flex h-10 cursor-pointer items-center gap-2 rounded-full bg-white/12 px-4 text-sm font-medium text-stone-100 shadow-[0_8px_30px_rgba(0,0,0,0.22)] ring-1 ring-white/15 backdrop-blur-md transition hover:bg-white/18 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={handleQueryLanguageSuggestionConfirm}
+                className="inline-flex h-8 cursor-pointer items-center rounded-full bg-brand-red px-3 text-xs font-semibold text-white transition hover:bg-brand-red/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
               >
-                <Languages size={16} aria-hidden />
-                <span className="max-w-[12rem] truncate">
-                  {selectedLanguageSummary}
-                  {additionalLanguageCount > 0
-                    ? ` +${additionalLanguageCount}`
-                    : ""}
-                </span>
-                {languagePanelOpen ? (
-                  <ChevronUp size={16} aria-hidden />
-                ) : (
-                  <ChevronDown size={16} aria-hidden />
-                )}
+                {t("searchInLanguage", { language: suggestedLanguageName })}
               </button>
-              {selectedLanguageEnglishNames.map((language) => (
+            </div>
+          )}
+          {searchLanguageControlVisible && (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <div className="inline-flex items-center gap-1">
                 <button
-                  key={language}
                   type="button"
-                  aria-label={`Remove ${language}`}
-                  onClick={() => {
-                    const option = languageGroups
-                      .flatMap((group) => group.languages)
-                      .find((item) => item.englishName === language)
-                    toggleSearchLanguage(
-                      option ?? {
-                        englishName: language,
-                        nativeName: null,
-                        bcp47: null,
-                        publicSlug: null,
-                        regionNames: [],
-                      },
-                    )
-                  }}
-                  className="inline-flex h-9 cursor-pointer items-center gap-1 rounded-full bg-white/10 px-3 text-xs font-medium text-stone-100 ring-1 ring-white/15 transition hover:bg-white/16 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+                  aria-label={t("searchLanguageLabel")}
+                  aria-controls="search-language-panel"
+                  aria-expanded={showLanguageBrowsePanel}
+                  onClick={handleLanguagePanelToggle}
+                  className="inline-flex h-10 cursor-pointer items-center gap-2 rounded-full bg-white/12 px-4 text-sm font-medium text-stone-100 shadow-[0_8px_30px_rgba(0,0,0,0.22)] ring-1 ring-white/15 backdrop-blur-md transition hover:bg-white/18 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
                 >
-                  <span className="max-w-[9rem] truncate">
-                    {language.split(",")[0]}
+                  <Languages size={16} aria-hidden />
+                  <span className="max-w-[12rem] truncate">
+                    {selectedLanguageSummary}
+                    {additionalLanguageCount > 0
+                      ? ` +${additionalLanguageCount}`
+                      : ""}
                   </span>
-                  <X size={13} aria-hidden />
+                  {showLanguageBrowsePanel ? (
+                    <ChevronUp size={16} aria-hidden />
+                  ) : (
+                    <ChevronDown size={16} aria-hidden />
+                  )}
                 </button>
-              ))}
+                {semanticLanguageOverrideActive && (
+                  <button
+                    type="button"
+                    aria-label="Use website default search language"
+                    onClick={handleResetSearchLanguage}
+                    className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-white/10 text-stone-200 ring-1 ring-white/15 transition hover:bg-white/16 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+                  >
+                    <X size={16} aria-hidden />
+                  </button>
+                )}
+              </div>
+              {algoliaSearchEnabled &&
+                selectedLanguageEnglishNames.map((language) => (
+                  <button
+                    key={language}
+                    type="button"
+                    aria-label={`Remove ${language}`}
+                    onClick={() => {
+                      const option = languageGroups
+                        .flatMap((group) => group.languages)
+                        .find((item) => item.englishName === language)
+                      toggleSearchLanguage(
+                        option ?? {
+                          englishName: language,
+                          nativeName: null,
+                          bcp47: null,
+                          publicSlug: null,
+                          regionNames: [],
+                        },
+                      )
+                    }}
+                    className="inline-flex h-9 cursor-pointer items-center gap-1 rounded-full bg-white/10 px-3 text-xs font-medium text-stone-100 ring-1 ring-white/15 transition hover:bg-white/16 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+                  >
+                    <span className="max-w-[9rem] truncate">
+                      {language.split(",")[0]}
+                    </span>
+                    <X size={13} aria-hidden />
+                  </button>
+                ))}
             </div>
           )}
         </div>
@@ -412,64 +797,176 @@ export function SearchOverlay() {
         className="pointer-events-none absolute inset-x-0 bottom-[-14rem] z-0 h-[max(28rem,calc(env(safe-area-inset-bottom,0px)+24rem))] bg-black/85 backdrop-blur-[14px]"
       />
 
-      {/* Body: category grid when empty, results grid when queried.
-          Fills the entire dialog so the floating bar can sit ABOVE it
-          with backdrop-blur — `pt-24 sm:pt-32` clears the bar's height
-          (mobile logo + gap + input, or desktop input pt-12 + breathing room). */}
+      {/* Body: category grid when empty, results grid when queried. Its top
+          edge clears the floating search controls so cards cannot scroll under
+          the language chip or detected-language prompt. */}
       <div
-        className={`search-overlay-scroll absolute inset-0 z-1 overflow-y-auto px-4 pb-8 sm:px-6 ${
-          algoliaSearchEnabled ? "pt-56 sm:pt-44" : "pt-44 sm:pt-32"
-        }`}
+        className={`search-overlay-scroll absolute inset-x-0 bottom-0 z-1 overflow-y-auto px-4 pb-8 sm:px-6 ${searchOverlayScrollTopClass}`}
         aria-live="polite"
       >
         <div
           onClick={(e) => e.stopPropagation()}
           className="mx-auto max-w-[1400px]"
         >
-          {showAlgoliaBrowsePanel && (
+          {showLanguageBrowsePanel && (
             <div
               id="search-language-panel"
-              className="mb-6 border-y border-white/12 bg-stone-950/55 px-4 py-5 text-stone-100 shadow-2xl shadow-black/20 backdrop-blur-xl sm:px-6"
+              className="relative z-30 mb-6 overflow-visible border-y border-white/12 bg-stone-950/55 px-4 py-5 text-stone-100 shadow-2xl shadow-black/20 backdrop-blur-xl sm:px-6"
             >
-              <div
-                role="tablist"
-                aria-label="Search browse mode"
-                className="grid grid-cols-2 gap-0 border-b border-white/12 md:flex md:items-end md:justify-start md:gap-10"
-              >
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={algoliaBrowseTab === "suggestions"}
-                  onClick={() => setAlgoliaBrowseTab("suggestions")}
-                  className={`flex min-h-14 min-w-0 cursor-pointer items-center justify-center gap-3 border-b-3 px-2 text-xs font-bold tracking-[0.22em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 sm:text-sm md:min-w-72 ${
-                    algoliaBrowseTab === "suggestions"
-                      ? "border-brand-red text-stone-100"
-                      : "border-transparent text-stone-500 hover:text-stone-300"
-                  }`}
+              {algoliaSearchEnabled ? (
+                <div
+                  role="tablist"
+                  aria-label="Search browse mode"
+                  className="grid grid-cols-2 gap-0 border-b border-white/12 md:flex md:items-end md:justify-start md:gap-10"
                 >
-                  <SearchIcon className="h-5 w-5 shrink-0 sm:h-6 sm:w-6" />
-                  <span className="truncate">{t("searchSuggestions")}</span>
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={algoliaBrowseTab === "languages"}
-                  onClick={() => setAlgoliaBrowseTab("languages")}
-                  className={`flex min-h-14 min-w-0 cursor-pointer items-center justify-center gap-3 border-b-3 px-2 text-xs font-bold tracking-[0.22em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 sm:text-sm md:min-w-72 ${
-                    algoliaBrowseTab === "languages"
-                      ? "border-brand-red text-stone-100"
-                      : "border-transparent text-stone-500 hover:text-stone-300"
-                  }`}
-                >
-                  <Globe2 className="h-5 w-5 shrink-0 sm:h-6 sm:w-6" />
-                  <span className="truncate">{t("languages")}</span>
-                  <span className="rounded-full border border-white/18 px-2 py-0.5 text-[0.7rem] tracking-[0.16em] text-stone-300 sm:text-xs">
-                    {languageCountLabel}
-                  </span>
-                </button>
-              </div>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={algoliaBrowseTab === "suggestions"}
+                    onClick={() => setAlgoliaBrowseTab("suggestions")}
+                    className={`flex min-h-14 min-w-0 cursor-pointer items-center justify-center gap-3 border-b-3 px-2 text-xs font-bold tracking-[0.22em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 sm:text-sm md:min-w-72 ${
+                      algoliaBrowseTab === "suggestions"
+                        ? "border-brand-red text-stone-100"
+                        : "border-transparent text-stone-500 hover:text-stone-300"
+                    }`}
+                  >
+                    <SearchIcon className="h-5 w-5 shrink-0 sm:h-6 sm:w-6" />
+                    <span className="truncate">{t("searchSuggestions")}</span>
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={algoliaBrowseTab === "languages"}
+                    onClick={() => setAlgoliaBrowseTab("languages")}
+                    className={`flex min-h-14 min-w-0 cursor-pointer items-center justify-center gap-3 border-b-3 px-2 text-xs font-bold tracking-[0.22em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 sm:text-sm md:min-w-72 ${
+                      algoliaBrowseTab === "languages"
+                        ? "border-brand-red text-stone-100"
+                        : "border-transparent text-stone-500 hover:text-stone-300"
+                    }`}
+                  >
+                    <Globe2 className="h-5 w-5 shrink-0 sm:h-6 sm:w-6" />
+                    <span className="truncate">{t("languages")}</span>
+                    <span className="rounded-full border border-white/18 px-2 py-0.5 text-[0.7rem] tracking-[0.16em] text-stone-300 sm:text-xs">
+                      {languageCountLabel}
+                    </span>
+                  </button>
+                </div>
+              ) : (
+                <div className="border-b border-white/12 pb-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-xs font-semibold tracking-[0.18em] text-stone-500 uppercase">
+                        {t("searchLanguageLabel")}
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-white/18 px-2 py-0.5 text-[0.7rem] font-semibold tracking-[0.16em] text-stone-300 uppercase sm:text-xs">
+                      {languageCountLabel}
+                    </span>
+                  </div>
+                  <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <label
+                      htmlFor="search-language-autocomplete"
+                      className="sr-only"
+                    >
+                      {tLanguage("selectLanguage")}
+                    </label>
+                    <div className="relative w-full sm:max-w-md">
+                      <SearchIcon
+                        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-stone-500"
+                        aria-hidden
+                      />
+                      <input
+                        ref={languageSearchInputRef}
+                        id="search-language-autocomplete"
+                        type="search"
+                        role="combobox"
+                        aria-autocomplete="list"
+                        aria-expanded={showSemanticLanguageAutocomplete}
+                        aria-controls="search-language-autocomplete-listbox"
+                        aria-activedescendant={
+                          showSemanticLanguageAutocomplete
+                            ? activeLanguageAutocompleteOptionId
+                            : undefined
+                        }
+                        value={languageSearchQuery}
+                        onChange={handleLanguageAutocompleteChange}
+                        onFocus={handleLanguageAutocompleteFocus}
+                        onBlur={handleLanguageAutocompleteBlur}
+                        onKeyDown={handleLanguageAutocompleteKeyDown}
+                        placeholder={tLanguage("searchPlaceholder")}
+                        className="h-10 w-full rounded-full border border-white/12 bg-white/8 py-0 pl-10 pr-3 text-sm text-stone-100 outline-none transition placeholder:text-stone-500 focus:border-white/28 focus:bg-white/12 focus:ring-2 focus:ring-white/20"
+                      />
+                      {showSemanticLanguageAutocomplete && (
+                        <div
+                          id="search-language-autocomplete-listbox"
+                          role="listbox"
+                          aria-label={tLanguage("selectLanguage")}
+                          className="absolute left-0 right-0 top-[calc(100%+0.5rem)] z-50 max-h-72 overflow-y-auto rounded-xl border border-white/14 bg-stone-950/95 p-1 shadow-2xl shadow-black/35 backdrop-blur-xl"
+                        >
+                          {semanticLanguageAutocompleteOptions.length > 0 ? (
+                            semanticLanguageAutocompleteOptions.map(
+                              (language, index) => {
+                                const selected =
+                                  selectedSearchLanguageOption?.publicSlug ===
+                                  language.publicSlug
+                                const active =
+                                  index === resolvedActiveLanguageOptionIndex
+                                return (
+                                  <button
+                                    id={`search-language-autocomplete-option-${language.publicSlug}`}
+                                    key={
+                                      language.publicSlug ??
+                                      language.englishName
+                                    }
+                                    type="button"
+                                    role="option"
+                                    aria-label={language.englishName}
+                                    aria-selected={selected}
+                                    onMouseDown={(event) =>
+                                      event.preventDefault()
+                                    }
+                                    onMouseEnter={() =>
+                                      setActiveLanguageOptionIndex(index)
+                                    }
+                                    onClick={() =>
+                                      handleSemanticLanguageClick(
+                                        language,
+                                        language.regionNames[0],
+                                      )
+                                    }
+                                    className={`flex min-h-10 w-full cursor-pointer items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 ${
+                                      selected
+                                        ? "bg-brand-red text-white"
+                                        : active
+                                          ? "bg-white/12 text-white"
+                                          : "text-stone-200 hover:bg-white/10"
+                                    }`}
+                                  >
+                                    <span className="min-w-0 truncate font-medium">
+                                      {language.englishName}
+                                    </span>
+                                  </button>
+                                )
+                              },
+                            )
+                          ) : (
+                            <div
+                              role="option"
+                              aria-selected={false}
+                              aria-disabled="true"
+                              className="px-3 py-3 text-sm text-stone-400"
+                            >
+                              {tLanguage("noMatches")}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
 
-              {algoliaBrowseTab === "suggestions" && (
+              {algoliaSearchEnabled && algoliaBrowseTab === "suggestions" && (
                 <div className="pt-6">
                   {recommendedLanguage && (
                     <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-stone-300">
@@ -516,7 +1013,20 @@ export function SearchOverlay() {
                 </div>
               )}
 
-              {algoliaBrowseTab === "languages" && (
+              {!algoliaSearchEnabled && (
+                <div className="pt-5">
+                  {languageOptionsLoading && (
+                    <p className="text-sm text-stone-400">{t("loading")}</p>
+                  )}
+                  {languageOptionsError && !languageOptionsLoading && (
+                    <p className="text-sm text-brand-red">
+                      {languageOptionsError}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {algoliaSearchEnabled && algoliaBrowseTab === "languages" && (
                 <div className="pt-6">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="min-w-0">
@@ -755,8 +1265,19 @@ export function SearchOverlay() {
                 {t("noResults", { query: query.trim() })}
               </h2>
               <p className="mt-2 text-sm text-stone-500">
-                {t("tryDifferentKeywords")}
+                {semanticSearchEnabled
+                  ? t("tryDifferentKeywordsOrLanguage")
+                  : t("tryDifferentKeywords")}
               </p>
+              {queryLanguageSuggestion && suggestedLanguageName && (
+                <button
+                  type="button"
+                  onClick={handleQueryLanguageSuggestionConfirm}
+                  className="mt-4 inline-flex h-9 cursor-pointer items-center rounded-full bg-brand-red px-4 text-sm font-semibold text-white transition hover:bg-brand-red/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+                >
+                  {t("searchInLanguage", { language: suggestedLanguageName })}
+                </button>
+              )}
             </div>
           )}
 

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -28,11 +28,12 @@ import {
 } from "@/lib/watch-player-chrome-events"
 
 const navigationMocks = vi.hoisted(() => ({
+  pathname: "/",
   replace: vi.fn(),
 }))
 
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/",
+  usePathname: () => navigationMocks.pathname,
   useRouter: () => ({
     replace: navigationMocks.replace,
   }),
@@ -59,6 +60,7 @@ let root: Root
 
 beforeEach(() => {
   vi.clearAllMocks()
+  navigationMocks.pathname = "/"
   window.history.replaceState(null, "", "/")
   container = document.createElement("div")
   document.body.appendChild(container)
@@ -76,6 +78,23 @@ afterEach(() => {
 })
 
 const mockedRunSearch = vi.mocked(runSearch)
+const mockedGetSearchLanguageOptions = vi.mocked(getSearchLanguageOptions)
+
+const englishSearchLanguage = {
+  englishName: "English",
+  nativeName: "English",
+  bcp47: "en",
+  publicSlug: "english",
+  regionNames: ["Europe"],
+}
+
+const spanishSearchLanguage = {
+  englishName: "Spanish, Castilian",
+  nativeName: "Español",
+  bcp47: "es-ES",
+  publicSlug: "spanish-castilian",
+  regionNames: ["Europe"],
+}
 
 function dispatchChromeVisibility(visible: boolean, opacity?: number) {
   window.dispatchEvent(
@@ -405,7 +424,7 @@ describe("FloatingSearchProvider — header backdrop", () => {
 
 describe("FloatingSearchProvider — search mode", () => {
   it("uses the server language metadata response to enable Algolia UI on open", async () => {
-    vi.mocked(getSearchLanguageOptions).mockResolvedValueOnce({
+    mockedGetSearchLanguageOptions.mockResolvedValueOnce({
       ok: true,
       algoliaEnabled: true,
       options: [
@@ -532,6 +551,223 @@ describe("FloatingSearchProvider — search mode", () => {
     ).toBeNull()
   })
 
+  it("uses the manual semantic search language selection for the next search", async () => {
+    vi.useFakeTimers()
+    mockedGetSearchLanguageOptions.mockResolvedValueOnce({
+      ok: true,
+      algoliaEnabled: false,
+      options: [englishSearchLanguage, spanishSearchLanguage],
+      countrySuggestion: null,
+      recommendedLanguage: englishSearchLanguage,
+      countryCode: null,
+      countryName: null,
+    })
+    mockedRunSearch.mockResolvedValueOnce(searchResult("semantic"))
+
+    const input = await openSearchOverlay()
+    const languageToggle = document.querySelector(
+      '[aria-controls="search-language-panel"]',
+    ) as HTMLButtonElement | null
+
+    expect(languageToggle).not.toBeNull()
+    expect(languageToggle?.getAttribute("aria-expanded")).toBe("false")
+    expect(document.querySelector("#search-language-autocomplete")).toBeNull()
+    expect(document.body.textContent).not.toContain("Browse by region")
+    expect(document.body.textContent).not.toContain("Spanish, Castilian")
+
+    await act(async () => {
+      languageToggle?.click()
+      await Promise.resolve()
+    })
+
+    const languageSearchInput = document.querySelector(
+      "#search-language-autocomplete",
+    ) as HTMLInputElement | null
+
+    expect(languageSearchInput).not.toBeNull()
+    expect(languageSearchInput?.value).toBe("English")
+    expect(document.body.textContent).toContain("Search language")
+    expect(
+      document.querySelector("#search-language-autocomplete-listbox"),
+    ).not.toBeNull()
+    expect(document.body.textContent).toContain("Spanish, Castilian")
+
+    act(() => {
+      setInputValue(languageSearchInput as HTMLInputElement, "span")
+    })
+
+    const spanishButton = document.querySelector(
+      '[role="option"][aria-label="Spanish, Castilian"]',
+    ) as HTMLButtonElement | null
+
+    expect(spanishButton).not.toBeNull()
+
+    await act(async () => {
+      spanishButton?.click()
+      await Promise.resolve()
+    })
+    await submitDebouncedSearch(input, "jesus")
+
+    expect(mockedRunSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "jesus",
+        languageEnglishNames: ["Spanish, Castilian"],
+        languageSlug: "spanish-castilian",
+      }),
+    )
+
+    const clearLanguageButton = document.querySelector(
+      '[aria-label="Use website default search language"]',
+    ) as HTMLButtonElement | null
+    expect(clearLanguageButton).not.toBeNull()
+
+    await act(async () => {
+      clearLanguageButton?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockedRunSearch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: "jesus",
+        languageEnglishNames: ["English"],
+        languageSlug: "english",
+      }),
+    )
+  })
+
+  it("defaults semantic search language from the Watch route before browser recommendation", async () => {
+    vi.useFakeTimers()
+    navigationMocks.pathname = "/jesus.html/spanish-castilian.html"
+    mockedGetSearchLanguageOptions.mockResolvedValueOnce({
+      ok: true,
+      algoliaEnabled: false,
+      options: [englishSearchLanguage, spanishSearchLanguage],
+      countrySuggestion: null,
+      recommendedLanguage: englishSearchLanguage,
+      countryCode: null,
+      countryName: null,
+    })
+    mockedRunSearch.mockResolvedValueOnce(searchResult("semantic"))
+
+    const input = await openSearchOverlay()
+    await submitDebouncedSearch(input, "jesus")
+
+    expect(mockedRunSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "jesus",
+        languageSlug: "spanish-castilian",
+      }),
+    )
+  })
+
+  it("pauses semantic debounce for a detected query language until confirmed", async () => {
+    vi.useFakeTimers()
+    mockedGetSearchLanguageOptions.mockResolvedValueOnce({
+      ok: true,
+      algoliaEnabled: false,
+      options: [englishSearchLanguage, spanishSearchLanguage],
+      countrySuggestion: null,
+      recommendedLanguage: englishSearchLanguage,
+      countryCode: null,
+      countryName: null,
+    })
+    mockedRunSearch.mockResolvedValueOnce(searchResult("semantic"))
+
+    const input = await openSearchOverlay()
+
+    act(() => {
+      setInputValue(input, "la vida de Jesús en español para niños")
+      vi.advanceTimersByTime(400)
+    })
+
+    expect(mockedRunSearch).not.toHaveBeenCalled()
+    expect(document.body.textContent).toContain("Spanish detected")
+
+    const confirm = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Search in Spanish",
+    ) as HTMLButtonElement | undefined
+
+    await act(async () => {
+      confirm?.click()
+      await Promise.resolve()
+    })
+
+    expect(mockedRunSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "la vida de Jesús en español para niños",
+        languageEnglishNames: ["Spanish, Castilian"],
+        languageSlug: "spanish-castilian",
+      }),
+    )
+  })
+
+  it("waits for semantic language metadata before searching a detectable query", async () => {
+    vi.useFakeTimers()
+    type LanguageOptionsResponse = Awaited<
+      ReturnType<typeof getSearchLanguageOptions>
+    >
+    let resolveLanguageOptions: (
+      value: LanguageOptionsResponse,
+    ) => void = () => {}
+    const delayedLanguageOptions = new Promise<LanguageOptionsResponse>(
+      (resolve) => {
+        resolveLanguageOptions = resolve
+      },
+    )
+    mockedGetSearchLanguageOptions.mockReturnValueOnce(delayedLanguageOptions)
+    mockedRunSearch.mockResolvedValue(searchResult("semantic"))
+
+    const input = await openSearchOverlay()
+
+    act(() => {
+      setInputValue(input, "la vida de Jesús en español para niños")
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(400)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockedRunSearch).not.toHaveBeenCalled()
+    expect(document.body.textContent).not.toContain("Spanish detected")
+
+    await act(async () => {
+      resolveLanguageOptions({
+        ok: true,
+        algoliaEnabled: false,
+        options: [englishSearchLanguage, spanishSearchLanguage],
+        countrySuggestion: null,
+        recommendedLanguage: englishSearchLanguage,
+        countryCode: null,
+        countryName: null,
+      })
+      await delayedLanguageOptions
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockedRunSearch).not.toHaveBeenCalled()
+    expect(document.body.textContent).toContain("Spanish detected")
+
+    const confirm = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Search in Spanish",
+    ) as HTMLButtonElement | undefined
+
+    await act(async () => {
+      confirm?.click()
+      await Promise.resolve()
+    })
+
+    expect(mockedRunSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "la vida de Jesús en español para niños",
+        languageEnglishNames: ["Spanish, Castilian"],
+        languageSlug: "spanish-castilian",
+      }),
+    )
+  })
+
   it("uses the latest server search source to toggle Algolia-only UI state", async () => {
     vi.mocked(runSearch)
       .mockResolvedValueOnce(searchResult("algolia"))
@@ -624,6 +860,96 @@ describe("FloatingSearchProvider — search mode", () => {
       }),
     )
     expect(error?.textContent).toBe("Failed to load more results.")
+  })
+
+  it("keeps the resolved semantic language when loading more after metadata refresh", async () => {
+    navigationMocks.pathname = "/jesus.html/spanish-castilian.html"
+    mockedGetSearchLanguageOptions.mockResolvedValueOnce({
+      ok: true,
+      algoliaEnabled: false,
+      options: [englishSearchLanguage, spanishSearchLanguage],
+      countrySuggestion: null,
+      recommendedLanguage: englishSearchLanguage,
+      countryCode: null,
+      countryName: null,
+    })
+    mockedRunSearch
+      .mockResolvedValueOnce(
+        searchResult("semantic", {
+          results: [videoResult("semantic-1")],
+          hasMore: true,
+          nextOffset: 10,
+          resolvedLanguage: {
+            locale: "es",
+            publicSlug: "spanish-castilian",
+            englishName: "Spanish, Castilian",
+            source: "route",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        searchResult("semantic", {
+          results: [videoResult("semantic-2")],
+          hasMore: false,
+          resolvedLanguage: {
+            locale: "es",
+            publicSlug: "spanish-castilian",
+            englishName: "Spanish, Castilian",
+            source: "route",
+          },
+        }),
+      )
+
+    act(() => {
+      root.render(
+        <SearchControllerTestShell>
+          <SearchModeHarness />
+        </SearchControllerTestShell>,
+      )
+    })
+
+    const searchButton = document.querySelector(
+      '[data-testid="search-mode-harness-button"]',
+    ) as HTMLButtonElement
+    const loadMoreButton = document.querySelector(
+      '[data-testid="search-mode-harness-load-more-button"]',
+    ) as HTMLButtonElement
+    const resultCount = document.querySelector(
+      '[data-testid="search-result-count"]',
+    )
+
+    await act(async () => {
+      searchButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(resultCount?.textContent).toBe("1")
+    expect(mockedRunSearch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        query: "jesus",
+        languageEnglishNames: ["Spanish, Castilian"],
+        languageSlug: "spanish-castilian",
+      }),
+    )
+
+    await act(async () => {
+      loadMoreButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(resultCount?.textContent).toBe("2")
+    expect(mockedRunSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        query: "jesus",
+        offset: 10,
+        languageEnglishNames: ["Spanish, Castilian"],
+        languageSlug: "spanish-castilian",
+      }),
+    )
   })
 
   it("clears loading state when an in-flight search is reset before it resolves", async () => {
@@ -1219,8 +1545,9 @@ describe("FloatingSearchProvider — search overlay chrome", () => {
     expect(bottomBackdrop?.className).toContain("bg-black/85")
     expect(bottomBackdrop?.className).toContain("backdrop-blur-[14px]")
     expect(scrollBody?.className).toContain("z-1")
-    expect(scrollBody?.className).toContain("pt-44")
-    expect(scrollBody?.className).toContain("sm:pt-32")
+    expect(scrollBody?.className).toContain("top-44")
+    expect(scrollBody?.className).toContain("sm:top-32")
+    expect(scrollBody?.className).toContain("bottom-0")
     expect(overlayField).not.toBeNull()
     expect(overlayField?.className).toContain("rounded-[35px]")
     expect(overlayField?.className).toContain("bg-white")

--- a/apps/web/src/lib/search-actions.test.ts
+++ b/apps/web/src/lib/search-actions.test.ts
@@ -39,8 +39,10 @@ vi.mock("./algolia-video-transform", () => ({
 import { searchAlgoliaVideos } from "./algolia-search"
 import { transformAlgoliaVideoHits } from "./algolia-video-transform"
 import { isWatchAlgoliaSearchEnabled } from "./feature-flags"
+import { readPreferredLanguageSlug } from "./language-preference-server"
 import { runSearch } from "./search-actions"
 import { searchVideos } from "./search"
+import { readSearchLanguagePreferenceSlug } from "./search-language-preference-server"
 
 const spanishOption = {
   coreId: "21028",
@@ -98,12 +100,14 @@ describe("runSearch", () => {
       query: "jesus",
       limit: 5,
       offset: 10,
-      languageEnglishNames: ["Spanish Castilian"],
+      languageSlug: "spanish-castilian",
       languageOptions: [spanishOption],
     })
 
     expect(searchVideos).toHaveBeenCalledWith("jesus", 5, 10, undefined, "es")
     expect(searchAlgoliaVideos).not.toHaveBeenCalled()
+    expect(readSearchLanguagePreferenceSlug).not.toHaveBeenCalled()
+    expect(readPreferredLanguageSlug).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       ok: true,
       resultSource: "semantic",
@@ -255,6 +259,7 @@ describe("runSearch", () => {
       type: "experience",
       limit: 5,
       offset: 10,
+      routeLanguageSlug: "french",
     })
 
     expect(searchVideos).toHaveBeenCalledWith(
@@ -262,7 +267,7 @@ describe("runSearch", () => {
       5,
       10,
       "experience",
-      "pt",
+      "fr",
     )
     expect(searchAlgoliaVideos).not.toHaveBeenCalled()
   })

--- a/apps/web/src/lib/search-actions.ts
+++ b/apps/web/src/lib/search-actions.ts
@@ -3,7 +3,6 @@
 import { headers } from "next/headers"
 
 import { isWatchAlgoliaSearchEnabled } from "./feature-flags"
-import { readPreferredLanguageSlug } from "./language-preference-server"
 import { searchAlgoliaVideos } from "./algolia-search"
 import { transformAlgoliaVideoHits } from "./algolia-video-transform"
 import { isPublicWatchLanguageSlug } from "./locale"
@@ -14,7 +13,6 @@ import {
   type SearchError,
   type SearchResult,
 } from "./search"
-import { readSearchLanguagePreferenceSlug } from "./search-language-preference-server"
 import {
   findSearchLanguageOptionByEnglishName,
   normalizeSearchLanguageEnglishNames,
@@ -58,25 +56,16 @@ export async function runSearch(input: {
   const truncatedQuery = query.slice(0, 200)
   const selectedLanguageEnglishNames =
     normalizeSearchLanguageEnglishNames(languageEnglishNames)
-  const [
-    flagEnabled,
-    searchPreferenceSlug,
-    audioPreferenceSlug,
-    acceptLanguage,
-  ] = await Promise.all([
+  const [flagEnabled, acceptLanguage] = await Promise.all([
     isWatchAlgoliaSearchEnabled({
       custom: { surface: "floating-search-modal" },
     }),
-    readSearchLanguagePreferenceSlug(),
-    readPreferredLanguageSlug(),
     readAcceptLanguageHeader(),
   ])
 
   const resolvedLanguage = resolveSearchLanguage({
     selectedEnglishNames: selectedLanguageEnglishNames,
     explicitSlug: languageSlug,
-    searchPreferenceSlug,
-    audioPreferenceSlug,
     routeLanguageSlug,
     acceptLanguage,
     languageOptions,

--- a/apps/web/src/lib/search-language-actions.test.ts
+++ b/apps/web/src/lib/search-language-actions.test.ts
@@ -10,6 +10,10 @@ vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }))
 
+vi.mock("next/cache", () => ({
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+}))
+
 vi.mock("@/lib/admin-client", () => ({
   default: {
     query: vi.fn(),
@@ -62,19 +66,37 @@ describe("getSearchLanguageOptions", () => {
     consoleError.mockRestore()
   })
 
-  it("returns empty metadata without querying admin when the Algolia flag is off", async () => {
+  it("loads language metadata when the Algolia flag is off", async () => {
     flagMock.mockResolvedValueOnce(false)
+    queryMock.mockResolvedValueOnce({
+      data: {
+        languages: [englishLanguage, spanishLanguage],
+        countries: [],
+      },
+    })
 
     await expect(getSearchLanguageOptions()).resolves.toMatchObject({
       ok: true,
       algoliaEnabled: false,
-      options: [],
+      options: [
+        {
+          englishName: "English",
+          publicSlug: "english",
+        },
+        {
+          englishName: "Spanish, Castilian",
+          publicSlug: "spanish-castilian",
+        },
+      ],
       countrySuggestion: null,
-      recommendedLanguage: null,
+      recommendedLanguage: {
+        englishName: "Spanish, Castilian",
+        publicSlug: "spanish-castilian",
+      },
       countryCode: "US",
       countryName: "United States",
     })
-    expect(queryMock).not.toHaveBeenCalled()
+    expect(queryMock).toHaveBeenCalledTimes(1)
   })
 
   it("builds facet-limited options, country suggestions, and a recommended language", async () => {
@@ -143,8 +165,8 @@ describe("getSearchLanguageOptions", () => {
         ],
       },
       recommendedLanguage: {
-        englishName: "English",
-        publicSlug: "english",
+        englishName: "Spanish, Castilian",
+        publicSlug: "spanish-castilian",
       },
     })
   })

--- a/apps/web/src/lib/search-language-actions.ts
+++ b/apps/web/src/lib/search-language-actions.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { headers } from "next/headers"
+import { unstable_cache } from "next/cache"
 import { adminGraphql } from "@forge/admin-graphql"
 
 import client from "@/lib/admin-client"
@@ -66,6 +67,13 @@ type SearchLanguageMetadata = {
 
 const PAGE_SIZE = 500
 const MAX_LANGUAGE_PAGES = 10
+const SEARCH_LANGUAGE_METADATA_CACHE_TTL_SECONDS = 5 * 60
+
+const fetchCachedSearchLanguageMetadata = unstable_cache(
+  fetchSearchLanguageMetadataUncached,
+  ["watch-search-language-metadata"],
+  { revalidate: SEARCH_LANGUAGE_METADATA_CACHE_TTL_SECONDS },
+)
 
 export async function getSearchLanguageOptions(
   input: {
@@ -105,20 +113,8 @@ export async function getSearchLanguageOptions(
   const acceptLanguage = requestHeaders?.get("accept-language") ?? null
   const countryName = countryCode ? countryNameFromCode(countryCode) : null
 
-  if (!algoliaEnabled) {
-    return {
-      ok: true,
-      algoliaEnabled,
-      options: [],
-      countrySuggestion: null,
-      recommendedLanguage: null,
-      countryCode,
-      countryName,
-    }
-  }
-
   try {
-    const metadata = await fetchSearchLanguageMetadata()
+    const metadata = await fetchCachedSearchLanguageMetadata()
     const result = buildSearchLanguageOptions({
       languages: metadata.languages,
       countries: metadata.countries,
@@ -133,7 +129,6 @@ export async function getSearchLanguageOptions(
       options: result.options,
       countrySuggestion: result.countrySuggestion,
       recommendedLanguage: recommendedLanguageOption({
-        countrySuggestion: result.countrySuggestion,
         options: result.options,
         acceptLanguage,
       }),
@@ -160,7 +155,7 @@ export async function getSearchLanguageOptions(
   }
 }
 
-async function fetchSearchLanguageMetadata(): Promise<SearchLanguageMetadata> {
+async function fetchSearchLanguageMetadataUncached(): Promise<SearchLanguageMetadata> {
   const languages: SearchLanguageMetadataLanguage[] = []
   let countries: SearchLanguageMetadataCountry[] = []
 
@@ -221,17 +216,12 @@ function readCountryCode(requestHeaders: Headers | null): string | null {
 }
 
 function recommendedLanguageOption({
-  countrySuggestion,
   options,
   acceptLanguage,
 }: {
-  countrySuggestion: SearchLanguageCountrySuggestion | null
   options: readonly SearchLanguageOption[]
   acceptLanguage: string | null
 }): SearchLanguageOption | null {
-  const countryLanguage = countrySuggestion?.languages[0]
-  if (countryLanguage) return countryLanguage
-
   const locale = parseAcceptLanguage(acceptLanguage)
   const publicSlug = locale
     ? publicWatchAudioLanguageSlugForLocale(locale)

--- a/apps/web/src/lib/search-language.test.ts
+++ b/apps/web/src/lib/search-language.test.ts
@@ -56,12 +56,27 @@ describe("stripLanguageFromSearchQuery", () => {
 })
 
 describe("resolveSearchLanguage", () => {
-  it("uses selected Algolia language names before persisted preferences", () => {
+  it("uses explicit public slugs before legacy selected English names", () => {
     expect(
       resolveSearchLanguage({
         selectedEnglishNames: ["Spanish Castilian"],
-        searchPreferenceSlug: "french",
-        audioPreferenceSlug: "english",
+        explicitSlug: "french",
+        languageOptions,
+      }),
+    ).toEqual({
+      locale: "fr",
+      publicSlug: "french",
+      englishName: "French",
+      source: "explicit-selection",
+    })
+  })
+
+  it("uses selected language names before route and browser defaults", () => {
+    expect(
+      resolveSearchLanguage({
+        selectedEnglishNames: ["Spanish Castilian"],
+        routeLanguageSlug: "french",
+        acceptLanguage: "en-US,en;q=0.9",
         languageOptions,
       }),
     ).toEqual({
@@ -69,21 +84,6 @@ describe("resolveSearchLanguage", () => {
       publicSlug: "spanish-castilian",
       englishName: "Spanish, Castilian",
       source: "explicit-selection",
-    })
-  })
-
-  it("uses the search preference before the existing audio preference", () => {
-    expect(
-      resolveSearchLanguage({
-        searchPreferenceSlug: "french",
-        audioPreferenceSlug: "spanish-castilian",
-        languageOptions,
-      }),
-    ).toMatchObject({
-      locale: "fr",
-      publicSlug: "french",
-      englishName: "French",
-      source: "search-preference",
     })
   })
 

--- a/apps/web/src/lib/search-language.ts
+++ b/apps/web/src/lib/search-language.ts
@@ -9,8 +9,6 @@ import {
 
 export type SearchLanguageResolutionSource =
   | "explicit-selection"
-  | "search-preference"
-  | "audio-preference"
   | "route"
   | "accept-language"
   | "fallback"
@@ -84,8 +82,6 @@ export type SearchLanguageResolution = {
 export type ResolveSearchLanguageInput = {
   selectedEnglishNames?: readonly string[]
   explicitSlug?: string | null
-  searchPreferenceSlug?: string | null
-  audioPreferenceSlug?: string | null
   routeLanguageSlug?: string | null
   acceptLanguage?: string | null
   languageOptions?: readonly SearchLanguageOption[]
@@ -157,6 +153,13 @@ function optionForPublicSlug(
   return options.find((option) => option.publicSlug === publicSlug) ?? null
 }
 
+export function findSearchLanguageOptionByPublicSlug(
+  publicSlug: string,
+  options: readonly SearchLanguageOption[] = [],
+): SearchLanguageOption | null {
+  return optionForPublicSlug(publicSlug, options)
+}
+
 function resolutionFromSlug(
   slug: string | null | undefined,
   source: SearchLanguageResolutionSource,
@@ -208,26 +211,14 @@ function resolutionFromAcceptLanguage(
 export function resolveSearchLanguage({
   selectedEnglishNames = [],
   explicitSlug,
-  searchPreferenceSlug,
-  audioPreferenceSlug,
   routeLanguageSlug,
   acceptLanguage,
   languageOptions = [],
 }: ResolveSearchLanguageInput): SearchLanguageResolution {
   const explicitSelection = selectedEnglishNames[0]
   const candidates: Array<SearchLanguageResolution | null> = [
-    resolutionFromEnglishName(explicitSelection, languageOptions),
     resolutionFromSlug(explicitSlug, "explicit-selection", languageOptions),
-    resolutionFromSlug(
-      searchPreferenceSlug,
-      "search-preference",
-      languageOptions,
-    ),
-    resolutionFromSlug(
-      audioPreferenceSlug,
-      "audio-preference",
-      languageOptions,
-    ),
+    resolutionFromEnglishName(explicitSelection, languageOptions),
     resolutionFromSlug(routeLanguageSlug, "route", languageOptions),
     resolutionFromAcceptLanguage(acceptLanguage, languageOptions),
   ]

--- a/apps/web/src/lib/search-query-language.test.ts
+++ b/apps/web/src/lib/search-query-language.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { SearchLanguageOption } from "./search-language"
+
+const detectAllMock = vi.hoisted(() => vi.fn())
+
+vi.mock("tinyld", () => ({
+  detectAll: detectAllMock,
+}))
+
+import {
+  detectQueryLanguageSuggestion,
+  findSearchLanguageOptionForDetectorCode,
+} from "./search-query-language"
+
+const english = option("English", "english", "en")
+const spanish = option("Spanish, Castilian", "spanish-castilian", "es-ES")
+const french = option("French", "french", "fr")
+const arabic = option("Arabic, Modern Standard", "arabic-modern-standard", "ar")
+const hindi = option("Hindi", "hindi", "hi")
+const japanese = option("Japanese", "japanese", "ja")
+
+const languageOptions = [english, spanish, french, arabic, hindi, japanese]
+
+describe("detectQueryLanguageSuggestion", () => {
+  beforeEach(() => {
+    detectAllMock.mockReset()
+  })
+
+  it("suggests a supported language when TinyLD has enough confidence", () => {
+    detectAllMock.mockReturnValue([
+      { lang: "es", accuracy: 0.4 },
+      { lang: "pt", accuracy: 0.12 },
+    ])
+
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "peliculas biblicas para ninos cristianos",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toMatchObject({
+      option: spanish,
+      source: "tinyld",
+      confidence: 0.4,
+      margin: 0.28,
+    })
+  })
+
+  it("does not call the detector for one-character Latin queries", () => {
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "j",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toBeNull()
+    expect(detectAllMock).not.toHaveBeenCalled()
+  })
+
+  it("suggests a language for short Latin queries when the detector can identify one", () => {
+    detectAllMock.mockReturnValue([
+      { lang: "es", accuracy: 0.25 },
+      { lang: "pt", accuracy: 0.23 },
+    ])
+
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "vida",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toMatchObject({
+      option: spanish,
+      source: "tinyld",
+    })
+  })
+
+  it("suggests a language for short distinctive Latin queries", () => {
+    detectAllMock.mockReturnValue([{ lang: "es", accuracy: 1 }])
+
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "niños",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toMatchObject({
+      option: spanish,
+      source: "tinyld",
+    })
+  })
+
+  it("does not suggest the currently selected search language", () => {
+    detectAllMock.mockReturnValue([
+      { lang: "es", accuracy: 0.9 },
+      { lang: "fr", accuracy: 0.1 },
+    ])
+
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "peliculas biblicas para ninos cristianos",
+        currentLanguageSlug: "spanish-castilian",
+        languageOptions,
+      }),
+    ).toBeNull()
+  })
+
+  it("accepts close detector calls because suggestions require confirmation", () => {
+    detectAllMock.mockReturnValue([
+      { lang: "es", accuracy: 0.09 },
+      { lang: "pt", accuracy: 0.08 },
+    ])
+
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "videos de esperanza para jovenes cristianos",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toMatchObject({
+      option: spanish,
+      source: "tinyld",
+    })
+  })
+
+  it("rejects unsupported top language guesses", () => {
+    detectAllMock.mockReturnValue([
+      { lang: "ga", accuracy: 0.9 },
+      { lang: "en", accuracy: 0.1 },
+    ])
+
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "long enough query text with enough language tokens",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toBeNull()
+  })
+
+  it("uses script hints for unambiguous non-Latin scripts", () => {
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "يسوع",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toMatchObject({
+      option: arabic,
+      source: "script",
+    })
+    expect(detectAllMock).not.toHaveBeenCalled()
+  })
+
+  it("uses script hints for short Devanagari queries", () => {
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "य",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toMatchObject({
+      option: hindi,
+      source: "script",
+    })
+    expect(detectAllMock).not.toHaveBeenCalled()
+  })
+
+  it("uses script hints for a single Japanese kana character", () => {
+    expect(
+      detectQueryLanguageSuggestion({
+        query: "あ",
+        currentLanguageSlug: "english",
+        languageOptions,
+      }),
+    ).toMatchObject({
+      option: japanese,
+      source: "script",
+    })
+    expect(detectAllMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("findSearchLanguageOptionForDetectorCode", () => {
+  it("prefers the public Watch slug for codes with multiple variants", () => {
+    const latinAmericanSpanish = option(
+      "Spanish, Latin American",
+      "spanish-latin-american",
+      "es-419",
+    )
+
+    expect(
+      findSearchLanguageOptionForDetectorCode("es", [
+        latinAmericanSpanish,
+        spanish,
+      ]),
+    ).toBe(spanish)
+  })
+
+  it("does not guess when BCP-47 fallback has multiple matches", () => {
+    const first = option("First", "first", "zz-AA")
+    const second = option("Second", "second", "zz-BB")
+
+    expect(findSearchLanguageOptionForDetectorCode("zz", [first, second])).toBe(
+      null,
+    )
+  })
+})
+
+function option(
+  englishName: string,
+  publicSlug: string,
+  bcp47: string,
+): SearchLanguageOption {
+  return {
+    englishName,
+    nativeName: null,
+    bcp47,
+    publicSlug,
+    regionNames: [],
+  }
+}

--- a/apps/web/src/lib/search-query-language.ts
+++ b/apps/web/src/lib/search-query-language.ts
@@ -1,0 +1,237 @@
+import { detectAll } from "tinyld"
+
+import type { SearchLanguageOption } from "./search-language"
+
+export const MIN_QUERY_LANGUAGE_LETTERS = 3
+export const MIN_QUERY_LANGUAGE_TOKENS = 1
+export const MIN_DISTINCTIVE_QUERY_LANGUAGE_LETTERS = 1
+export const MIN_QUERY_LANGUAGE_SCORE = 0.001
+export const MIN_QUERY_LANGUAGE_MARGIN = 0
+export const MIN_QUERY_LANGUAGE_MARGIN_RATIO = 0
+
+export type SearchLanguageOptionWithPublicSlug = SearchLanguageOption & {
+  publicSlug: string
+}
+
+export type QueryLanguageSuggestion = {
+  option: SearchLanguageOptionWithPublicSlug
+  confidence: number
+  margin: number
+  source: "script" | "tinyld"
+}
+
+export type DetectQueryLanguageSuggestionInput = {
+  query: string
+  currentLanguageSlug: string | null
+  languageOptions: readonly SearchLanguageOption[]
+}
+
+type TinyLdCandidate = {
+  lang?: unknown
+  accuracy?: unknown
+}
+
+const PUBLIC_SLUG_BY_DETECTOR_CODE: Readonly<Record<string, string>> =
+  Object.freeze({
+    ar: "arabic-modern-standard",
+    bn: "bangla-2",
+    de: "german-standard",
+    en: "english",
+    es: "spanish-castilian",
+    fr: "french",
+    hi: "hindi",
+    id: "indonesian-isa",
+    it: "italian",
+    ja: "japanese",
+    ko: "korean",
+    ms: "malay",
+    ne: "nepali",
+    nl: "dutch",
+    pl: "polish",
+    pt: "portuguese-brazil",
+    ru: "russian",
+    sw: "swahili",
+    ta: "tamil",
+    te: "telugu",
+    th: "thai",
+    tl: "tagalog",
+    tr: "turkish",
+    uk: "ukrainian",
+    ur: "urdu",
+    vi: "vietnamese",
+    zh: "mandarin-china",
+  })
+
+const SCRIPT_HINTS: ReadonlyArray<{
+  code: string
+  pattern: RegExp
+  minimumCharacters: number
+}> = Object.freeze([
+  { code: "ar", pattern: /\p{Script=Arabic}/u, minimumCharacters: 1 },
+  { code: "zh", pattern: /\p{Script=Han}/u, minimumCharacters: 1 },
+  {
+    code: "ja",
+    pattern: /\p{Script=Hiragana}|\p{Script=Katakana}/u,
+    minimumCharacters: 1,
+  },
+  { code: "ko", pattern: /\p{Script=Hangul}/u, minimumCharacters: 1 },
+  { code: "hi", pattern: /\p{Script=Devanagari}/u, minimumCharacters: 1 },
+])
+
+const DISTINCTIVE_LATIN_MARK_PATTERN = /[À-ÖØ-öø-ÿĀ-žƀ-ɏ]/u
+
+export function detectQueryLanguageSuggestion({
+  query,
+  currentLanguageSlug,
+  languageOptions,
+}: DetectQueryLanguageSuggestionInput): QueryLanguageSuggestion | null {
+  const normalizedQuery = normalizeDetectableQuery(query)
+  if (!hasEnoughLanguageSignal(normalizedQuery)) return null
+
+  const scriptSuggestion = detectScriptSuggestion(
+    normalizedQuery,
+    currentLanguageSlug,
+    languageOptions,
+  )
+  if (scriptSuggestion) return scriptSuggestion
+
+  const candidates = safeDetectAll(normalizedQuery)
+  const [top, second] = candidates
+  if (!top) return null
+
+  const topOption = findSearchLanguageOptionForDetectorCode(
+    top.lang,
+    languageOptions,
+  )
+  const topOptionWithSlug = withPublicSlug(topOption)
+  if (!topOptionWithSlug) return null
+  if (topOptionWithSlug.publicSlug === currentLanguageSlug) return null
+
+  const confidence = top.accuracy
+  const secondScore = second?.accuracy ?? 0
+  const margin = confidence - secondScore
+  const marginRatio = margin / confidence
+
+  if (confidence < MIN_QUERY_LANGUAGE_SCORE) return null
+  if (margin < MIN_QUERY_LANGUAGE_MARGIN) return null
+  if (marginRatio < MIN_QUERY_LANGUAGE_MARGIN_RATIO) return null
+
+  return {
+    option: topOptionWithSlug,
+    confidence,
+    margin,
+    source: "tinyld",
+  }
+}
+
+export function findSearchLanguageOptionForDetectorCode(
+  detectorCode: string,
+  options: readonly SearchLanguageOption[],
+): SearchLanguageOption | null {
+  const code = detectorCode.trim().toLowerCase()
+  if (code.length === 0) return null
+
+  const preferredSlug = PUBLIC_SLUG_BY_DETECTOR_CODE[code]
+  if (preferredSlug) {
+    const preferred = options.find(
+      (option) => option.publicSlug === preferredSlug,
+    )
+    if (preferred) return preferred
+  }
+
+  const matches = options.filter((option) => {
+    const primary = option.bcp47?.split("-")[0]?.toLowerCase()
+    return primary === code
+  })
+  return matches.length === 1 ? (matches[0] ?? null) : null
+}
+
+function normalizeDetectableQuery(query: string): string {
+  return query.normalize("NFKC").replace(/\s+/g, " ").trim()
+}
+
+function hasEnoughLanguageSignal(query: string): boolean {
+  if (SCRIPT_HINTS.some((hint) => scriptCharacterCount(query, hint) > 0)) {
+    return true
+  }
+
+  const letterCount = query.match(/\p{Letter}/gu)?.length ?? 0
+  if (
+    letterCount >= MIN_DISTINCTIVE_QUERY_LANGUAGE_LETTERS &&
+    DISTINCTIVE_LATIN_MARK_PATTERN.test(query)
+  ) {
+    return true
+  }
+
+  if (letterCount < MIN_QUERY_LANGUAGE_LETTERS) return false
+
+  return languageTokens(query).length >= MIN_QUERY_LANGUAGE_TOKENS
+}
+
+function languageTokens(query: string): string[] {
+  return query.split(/[^\p{Letter}]+/u).filter((token) => token.length >= 2)
+}
+
+function detectScriptSuggestion(
+  query: string,
+  currentLanguageSlug: string | null,
+  languageOptions: readonly SearchLanguageOption[],
+): QueryLanguageSuggestion | null {
+  for (const hint of SCRIPT_HINTS) {
+    if (scriptCharacterCount(query, hint) < hint.minimumCharacters) continue
+    const option = findSearchLanguageOptionForDetectorCode(
+      hint.code,
+      languageOptions,
+    )
+    const optionWithSlug = withPublicSlug(option)
+    if (!optionWithSlug || optionWithSlug.publicSlug === currentLanguageSlug) {
+      return null
+    }
+    return {
+      option: optionWithSlug,
+      confidence: 1,
+      margin: 1,
+      source: "script",
+    }
+  }
+
+  return null
+}
+
+function scriptCharacterCount(
+  query: string,
+  hint: (typeof SCRIPT_HINTS)[number],
+): number {
+  return [...query].filter((character) => hint.pattern.test(character)).length
+}
+
+function withPublicSlug(
+  option: SearchLanguageOption | null,
+): SearchLanguageOptionWithPublicSlug | null {
+  return option?.publicSlug
+    ? { ...option, publicSlug: option.publicSlug }
+    : null
+}
+
+function safeDetectAll(
+  query: string,
+): Array<{ lang: string; accuracy: number }> {
+  try {
+    return (detectAll(query) as TinyLdCandidate[])
+      .map((candidate) => ({
+        lang:
+          typeof candidate.lang === "string"
+            ? candidate.lang.trim().toLowerCase()
+            : "",
+        accuracy:
+          typeof candidate.accuracy === "number" ? candidate.accuracy : 0,
+      }))
+      .filter(
+        (candidate) =>
+          candidate.lang.length > 0 && Number.isFinite(candidate.accuracy),
+      )
+      .sort((a, b) => b.accuracy - a.accuracy)
+  } catch {
+    return []
+  }
+}

--- a/docs/brainstorms/2026-06-19-watch-multilingual-semantic-search-requirements.md
+++ b/docs/brainstorms/2026-06-19-watch-multilingual-semantic-search-requirements.md
@@ -1,0 +1,168 @@
+---
+date: 2026-06-19
+topic: watch-multilingual-semantic-search
+---
+
+# Watch Multilingual Semantic Search
+
+## Summary
+
+Semantic search should make the search language visible and correct before a viewer commits a query. The search bar detects the likely language of the typed query, previews a confident "Search in <language>" suggestion, and runs semantic search in that language when the suggestion is confirmed.
+
+---
+
+## Problem Frame
+
+Watch serves a global audience trying to find videos in languages they can understand. Today, a viewer can type a query in one language while the search context remains another language, which can make valid multilingual searches feel like empty or wrong searches.
+
+The product already has a global modal search surface and language-aware search plumbing. This brainstorm narrows the next improvement to semantic search behavior: make query-language mismatch visible, let the viewer confirm the detected language, and keep a manual language selector available.
+
+---
+
+## Key Decisions
+
+- **Semantic search only.** This v1 improves the semantic search path and does not change Algolia search behavior.
+- **Visible detected-language suggestion.** A confident detected query language becomes a visible pending suggestion before search runs, instead of silently switching behind the viewer.
+- **Enter can confirm the visible suggestion.** When a confident suggestion is visible, pressing Enter searches in that detected language; otherwise Enter uses the visible manual language selection.
+- **Simple default language priority.** The default search language is website/watch language, then browser/device language, then English.
+- **Search language stays separate from watch language.** Choosing or confirming a search language does not change the site language, route language, or audio language.
+
+---
+
+## Actors
+
+- A1. Watch viewer: Searches for faith content from the global search modal.
+- A2. Multilingual viewer: Types a query in a language that may differ from the current website/watch language.
+- A3. Implementing engineer or agent: Plans the feature without changing Algolia search, route language, or audio language semantics.
+
+---
+
+## Key Flows
+
+- F1. Query language suggestion
+  - **Trigger:** A viewer types a query whose likely language differs from the current selected search language.
+  - **Actors:** A1, A2
+  - **Steps:** The search bar detects a likely supported query language, shows a visible "Search in <language>" suggestion, and makes that suggestion the pending search language while it remains visible.
+  - **Outcome:** The viewer can tell which language search will use before committing.
+  - **Covered by:** R1, R2, R3, R4
+
+- F2. Confirmed semantic search
+  - **Trigger:** A viewer presses Enter or selects the detected-language suggestion while it is visible.
+  - **Actors:** A1, A2
+  - **Steps:** The search runs through semantic search using the detected language, and results link to Watch pages without mutating the viewer's site or audio language.
+  - **Outcome:** A Spanish query on an English page can return Spanish semantic results when the suggestion is visible and confirmed.
+  - **Covered by:** R2, R3, R6, R7
+
+- F3. Manual language selection
+  - **Trigger:** A viewer opens the language selector or changes the selected search language.
+  - **Actors:** A1, A2
+  - **Steps:** The viewer chooses a search language manually; future searches in the current modal session use that visible selection unless a confident query-language suggestion is accepted.
+  - **Outcome:** The viewer keeps control when detection is wrong, low-confidence, or not desired.
+  - **Covered by:** R5, R6, R8
+
+- F4. No-result explanation
+  - **Trigger:** Semantic search returns no results in the selected language.
+  - **Actors:** A1, A2
+  - **Steps:** The empty state explains that results may exist in another language and exposes the language selector or a detected-language retry when available.
+  - **Outcome:** A no-result state becomes recoverable instead of feeling like final failure.
+  - **Covered by:** R9, R10
+
+---
+
+## Requirements
+
+**Semantic Search Language Behavior**
+
+- R1. The search bar must detect the likely language of the typed query when enough query text exists to make a useful guess.
+- R2. When detection is confident, supported, and different from the visible selected search language, the UI must show a visible suggestion to search in the detected language.
+- R3. When the detected-language suggestion is visible, pressing Enter must confirm that suggestion and run semantic search in the detected language.
+- R4. When detection is low-confidence, unsupported, or unavailable, pressing Enter must run semantic search using the visible selected search language.
+- R5. A manual language selector must be available so the viewer can choose the semantic search language directly.
+
+**Default Language Priority**
+
+- R6. The initial selected search language must default to the current website/watch language when available.
+- R7. If the website/watch language is unavailable, the selected search language must fall back to browser/device language when supported.
+- R8. If neither website/watch language nor browser/device language is usable, the selected search language must fall back to English.
+
+**Scope Safety**
+
+- R9. Search-language confirmation must not change the website language, route language, audio language, or persisted watch-language setting.
+- R10. No-result states must explain when results may exist in another language and offer a recovery path through language selection or a detected-language retry.
+- R11. Multilingual semantic behavior must be covered by the search eval suite with cases where query language differs from website/watch language.
+
+---
+
+## Acceptance Examples
+
+- AE1. Spanish query on English Watch page
+  - **Given:** The selected search language is English.
+  - **When:** The viewer types a Spanish query and the system confidently detects Spanish.
+  - **Then:** The search bar shows a "Search in Spanish" suggestion, and pressing Enter runs semantic search in Spanish.
+  - **Covers:** R1, R2, R3
+
+- AE2. Low-confidence query
+  - **Given:** The selected search language is English.
+  - **When:** The viewer types a short or ambiguous query whose language cannot be confidently detected.
+  - **Then:** No detected-language suggestion becomes active, and pressing Enter searches in English.
+  - **Covers:** R4
+
+- AE3. Manual language override
+  - **Given:** The viewer manually selects French as the search language.
+  - **When:** The viewer searches without accepting a different detected-language suggestion.
+  - **Then:** Semantic search uses French for that search.
+  - **Covers:** R5, R6, R9
+
+- AE4. No results in selected language
+  - **Given:** Semantic search returns no results in the selected language.
+  - **When:** Another supported language is plausible from the query or available through the selector.
+  - **Then:** The empty state explains that results may exist in another language and offers a language-based recovery path.
+  - **Covers:** R10
+
+- AE5. Eval coverage
+  - **Given:** The search eval suite includes multilingual cases.
+  - **When:** A query language differs from website/watch language.
+  - **Then:** The suite can verify that semantic search runs in the expected language after the suggestion is confirmed.
+  - **Covers:** R11
+
+---
+
+## Success Criteria
+
+- Viewers can see the semantic search language before search submission.
+- A confident query-language suggestion prevents obvious cross-language no-result failures.
+- The manual selector remains available for correction and control.
+- The v1 change does not alter Algolia behavior or any persisted watch-language setting.
+- Search evals protect the mismatch case: query language differs from website/watch language.
+
+---
+
+## Scope Boundaries
+
+- Algolia search behavior is out of scope.
+- Persisting a saved search-language preference is deferred.
+- Using the viewer's audio-language setting as a default input is out of scope.
+- Changing website/watch language, route language, or audio language as a side effect of search is out of scope.
+- Full search-ranking optimization is deferred; this feature focuses on selecting the right semantic search language.
+
+---
+
+## Dependencies / Assumptions
+
+- The current global search modal remains the canonical search surface.
+- Semantic search can accept a selected language or locale at search time.
+- Query-language detection can produce a confidence signal good enough to decide whether to show the suggestion.
+- Browser/device language is available only as a fallback signal, not as a persisted preference.
+
+---
+
+## Sources / Research
+
+- Product context: `PRODUCT.md`
+- Repo constraints: `AGENTS.md`, `apps/web/AGENTS.md`, `apps/web/CLAUDE.md`
+- Prior search modal requirements: `docs/brainstorms/2026-06-10-forge-algolia-search-modal-requirements.md`
+- Search modal pattern: `docs/solutions/architecture-patterns/forge-algolia-search-modal-20260610.md`
+- Search action boundary: `apps/web/src/lib/search-actions.ts`
+- Search language resolver: `apps/web/src/lib/search-language.ts`
+- Current no-result state: `apps/web/src/components/SearchOverlay.tsx`
+- UX grounding: [NN/g site search suggestions](https://www.nngroup.com/articles/site-search-suggestions/), [NN/g usability heuristics](https://www.nngroup.com/articles/ten-usability-heuristics/), [Baymard autocomplete UX](https://baymard.com/blog/autocomplete-design)

--- a/docs/plans/2026-06-19-001-feat-watch-multilingual-semantic-search-plan.md
+++ b/docs/plans/2026-06-19-001-feat-watch-multilingual-semantic-search-plan.md
@@ -1,0 +1,265 @@
+---
+title: "feat: Add multilingual semantic search language control"
+type: "feat"
+date: "2026-06-19"
+origin: "docs/brainstorms/2026-06-19-watch-multilingual-semantic-search-requirements.md"
+---
+
+# feat: Add Multilingual Semantic Search Language Control
+
+## Summary
+
+Implement semantic-search-only language control in the global Watch search modal. The modal will expose a single Search Language for semantic searches, detect confident query-language mismatches, show a visible "Search in <language>" suggestion, and run semantic search in the confirmed language without changing route language, website language, audio language, or saved language preferences.
+
+---
+
+## Problem Frame
+
+Watch viewers can type a query in one language while the current search context remains another language. That mismatch can make valid multilingual semantic searches look empty or wrong. The current code has language-aware search plumbing, but its language selector and metadata are tied to Algolia, and its resolver still considers saved search and audio-language preferences that this v1 explicitly excludes.
+
+This plan uses `docs/brainstorms/2026-06-19-watch-multilingual-semantic-search-requirements.md` as the origin document. It covers the full brainstorm scope for semantic search and keeps adjacent work out: no Algolia behavior change, no saved search-language preference, no audio-language default, and no route or website-language mutation.
+
+---
+
+## Requirements
+
+**Semantic Search Language Behavior**
+
+- R1. The search bar detects the likely language of a typed query only when enough text exists to make a useful guess.
+- R2. When detection is confident, supported, and different from the visible selected Search Language, the UI shows a visible suggestion to search in the detected language.
+- R3. When the detected-language suggestion is visible, pressing Enter or clicking the suggestion confirms it and runs semantic search in the detected language.
+- R4. When detection is low-confidence, unsupported, ambiguous, unavailable, or same-language, pressing Enter runs semantic search using the visible selected Search Language.
+- R5. A manual single-select Search Language control is available for semantic search.
+
+**Default Language Priority**
+
+- R6. The initial selected Search Language defaults to the current website/watch route language when available.
+- R7. If the website/watch route language is unavailable, the selected Search Language falls back to browser/device language when supported.
+- R8. If neither route nor browser/device language is usable, the selected Search Language falls back to English.
+
+**Scope Safety**
+
+- R9. Search-language confirmation does not change website language, route language, audio language, or persisted watch-language settings.
+- R10. Semantic no-result states explain that results may exist in another language and offer a language-based recovery path.
+- R11. Multilingual semantic behavior is covered by eval cases where query language differs from website/watch language.
+- R12. Plan-added scope constraint from the origin's Algolia boundary: Algolia search behavior remains unchanged; query-language suggestions and semantic single-select behavior are active only on semantic search paths.
+
+---
+
+## Key Technical Decisions
+
+- **Public slug is the semantic language identity:** Semantic search should pass a selected public language slug through the existing server-action boundary, then resolve it to the search locale. English names stay useful for display and Algolia filters, but they are not the canonical semantic selection identity.
+- **Semantic defaults ignore saved and audio preferences:** The resolver priority for semantic search is explicit in-session selection, route/watch language, browser/device language, then English. `forge_search_lang` and audio-language preference are not read or written for this v1.
+- **Semantic language selection is singular:** The semantic Search Language is a single visible choice. Algolia's current multi-select language filters remain separate and unchanged.
+- **Language metadata is not Algolia-owned:** The modal needs supported-language metadata even when the Algolia flag is off, so language option loading should be decoupled from Algolia facets while preserving the existing `algoliaEnabled` signal.
+- **Detection lives behind an adapter:** Add a small query-language detection helper around `tinyld`, with Unicode script prechecks where useful, named minimum length, top-score, and top-vs-second margin constants. The adapter returns no suggestion unless it maps to one unambiguous supported public slug, and tests are the authority for the initial thresholds.
+- **Visible suggestion pauses automatic search:** While a confident different-language suggestion is visible, the existing debounce should not fire a wrong-language search. Enter or click cancels pending debounce and runs exactly one semantic search in the detected language.
+- **Accepted suggestions are session-only:** Accepting "Search in Spanish" updates the visible Search Language for the open modal session and load-more continuity, but writes no cookie and does not mutate route or audio state.
+- **Algolia remains a separate mode:** When the modal is currently using Algolia for untyped video searches, keep its existing language/facet behavior. Do not add a semantic override that forces Algolia-enabled searches through semantic search.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  Q["Viewer types query"] --> D["Query-language detector"]
+  D --> C{"Confident, supported, different?"}
+  C -->|no| M["Visible selected Search Language"]
+  C -->|yes| S["Visible pending suggestion"]
+  S --> E{"Confirm via Enter or click?"}
+  E -->|yes| A["Accept suggestion for modal session"]
+  E -->|no| H["Hold auto-search while suggestion remains visible"]
+  A --> R["runSearch with selected public slug"]
+  M --> R
+  R --> V["Semantic search receives resolved locale"]
+  V --> N{"No results?"}
+  N -->|yes| X["Language recovery empty state"]
+  N -->|no| Y["Video results link with confirmed search-language slug"]
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> DefaultSelected
+  DefaultSelected --> PendingSuggestion: confident different query language
+  PendingSuggestion --> AcceptedSessionLanguage: Enter or click
+  PendingSuggestion --> DefaultSelected: input clears or detection drops
+  PendingSuggestion --> ManualSessionLanguage: manual language selection
+  DefaultSelected --> ManualSessionLanguage: manual language selection
+  ManualSessionLanguage --> PendingSuggestion: confident different query language
+  AcceptedSessionLanguage --> ManualSessionLanguage: manual language selection
+  AcceptedSessionLanguage --> [*]: modal closes
+  ManualSessionLanguage --> [*]: modal closes
+```
+
+---
+
+## Implementation Units
+
+### U1. Rework Semantic Search Language Resolution
+
+- **Goal:** Make semantic search resolve language from in-session slug, route/watch language, browser/device language, then English, without saved search or audio preference defaults.
+- **Requirements:** R6, R7, R8, R9, R12
+- **Dependencies:** None
+- **Files:**
+  - `apps/web/src/lib/search-language.ts`
+  - `apps/web/src/lib/search-actions.ts`
+  - `apps/web/src/lib/search-language.test.ts`
+  - `apps/web/src/lib/search-actions.test.ts`
+- **Approach:** Keep the resolver pure and reuse existing public Watch language helpers. Remove semantic dependency on search-language and audio-language preference readers. Prefer explicit semantic `languageSlug` over English-name selection for semantic calls, while leaving Algolia request shaping unchanged.
+- **Patterns to follow:** `apps/web/src/lib/locale.ts` for public slug resolution; `docs/solutions/best-practices/language-identity-on-slug-not-bcp47-20260605.md` for slug identity; `docs/solutions/architecture-patterns/forge-algolia-search-modal-20260610.md` for the server-action boundary.
+- **Test scenarios:**
+  - Explicit in-session public slug searches in that locale even when route and browser signals differ.
+  - Route/watch language beats browser/device language.
+  - Browser/device language beats English fallback when supported.
+  - Unsupported browser/device language falls back to English.
+  - Semantic `runSearch` does not consult saved search-language or audio-language preference readers.
+  - Algolia-enabled untyped video search still calls Algolia with the same language filter payload shape as before.
+- **Verification:** Resolver and server-action tests prove the priority chain and Algolia non-regression.
+
+### U2. Decouple Language Metadata and Semantic Manual Selection
+
+- **Goal:** Make supported language options and a manual single-select Search Language available in semantic mode.
+- **Requirements:** R5, R6, R7, R8, R9, R12
+- **Dependencies:** U1
+- **Files:**
+  - `apps/web/src/lib/search-language-actions.ts`
+  - `apps/web/src/lib/search-language-actions.test.ts`
+  - `apps/web/src/components/FloatingSearchContext.tsx`
+  - `apps/web/src/components/FloatingSearchController.tsx`
+  - `apps/web/src/components/SearchOverlay.tsx`
+  - `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`
+- **Approach:** Fetch language metadata regardless of the Algolia flag and keep returning the flag so the UI can branch cleanly. Store semantic selection as a selected option/public slug in controller context, pass `languageSlug` to `runSearch` for semantic searches and load-more, and key active semantic search signatures by slug. Seed semantic Search Language from route slug, then browser/device `Accept-Language`, then English; do not use geo-country suggestion for semantic defaults. Keep English-name arrays for Algolia filters/display and keep Algolia's existing multi-select UI isolated from the semantic single-select control. Remove client writes to the saved search-language preference for this semantic path.
+- **Patterns to follow:** Existing `getSearchLanguageOptions` metadata query and `buildSearchLanguageOptions` option shape; current request-id guards in `FloatingSearchController`.
+- **Test scenarios:**
+  - Language options are returned when Algolia is disabled.
+  - The semantic selector shows the route/watch language by default when available.
+  - Browser/device recommendation seeds the selector when no route language is available.
+  - Browser/device language beats geo-country suggestion when the two disagree.
+  - Manual French selection runs semantic search in French and writes no search-language cookie.
+  - Algolia-enabled mode still renders and behaves as the existing Algolia browse/filter UI.
+- **Verification:** Component tests cover default selection, manual selection, and Algolia non-regression.
+
+### U3. Add Query Language Detection Adapter
+
+- **Goal:** Detect likely query language for supported semantic Search Language suggestions without network calls while typing.
+- **Requirements:** R1, R2, R4, R9, R12
+- **Dependencies:** U2
+- **Files:**
+  - `apps/web/package.json`
+  - `pnpm-lock.yaml`
+  - `apps/web/src/lib/search-query-language.ts`
+  - `apps/web/src/lib/search-query-language.test.ts`
+- **Approach:** Add `tinyld` as the initial browser-safe detector. Wrap it in a local adapter that normalizes query text, applies named minimum length/token checks, uses script hints for obvious non-Latin cases, and requires named top-score and top-vs-second margin constants. Map detector output to supported public slugs through an explicit allowlist or an unambiguous option mapping; ambiguous BCP-47 collisions return no suggestion. Tests are the authority for the initial thresholds.
+- **Patterns to follow:** Pure helper style from `apps/web/src/lib/search-language.ts`; slug identity guidance from `CONCEPTS.md`.
+- **Test scenarios:**
+  - Confident supported Spanish query returns the Spanish Search Language option when English is selected.
+  - Short, numeric, brand-only, mixed-language, and ambiguous queries return no suggestion.
+  - Unsupported detector languages return no suggestion.
+  - Same-as-selected language returns no suggestion.
+  - BCP-47 collision or multiple possible public slugs returns no suggestion.
+  - Non-Latin script examples map only when a supported public slug is unambiguous.
+- **Verification:** Detector tests show conservative suggestion behavior before UI wiring depends on it.
+
+### U4. Wire Suggestion, Enter, Click, and Empty-State Recovery
+
+- **Goal:** Make the semantic query-language suggestion visible and confirmable, and make no-result states recoverable by language.
+- **Requirements:** R2, R3, R4, R5, R9, R10, R12
+- **Dependencies:** U2, U3
+- **Files:**
+  - `apps/web/src/components/FloatingSearchField.tsx`
+  - `apps/web/src/components/FloatingSearchContext.tsx`
+  - `apps/web/src/components/FloatingSearchController.tsx`
+  - `apps/web/src/components/SearchOverlay.tsx`
+  - `apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx`
+  - `apps/web/messages/en.json`
+  - `apps/web/messages/*.json`
+  - `apps/web/src/i18n/__tests__/messages-parity.test.ts`
+- **Approach:** Derive a pending suggestion from current query plus current semantic Search Language. Render it near the input as an action, not as hidden state. While visible, hold the typing debounce; Enter or click accepts the suggestion, updates session selected Search Language, and starts one semantic search. When no suggestion is visible, Enter uses the selected Search Language. Clear or recompute suggestions on input clear, manual language selection, modal close, stale detection, and route changes. Semantic no-result copy should mention language recovery and expose the selector or detected-language retry; error states keep existing retry copy.
+- **Patterns to follow:** Existing overlay focus trap, close behavior, debounce cleanup, URL sync guard, stale request guard, and load-more signature guard.
+- **Test scenarios:**
+  - Covers AE1. Spanish query on an English route shows "Search in Spanish" and Enter searches in Spanish once.
+  - Covers AE2. Low-confidence query shows no suggestion and Enter searches in the visible selected language.
+  - Covers AE3. Manual language selection searches with the manual language unless a different visible suggestion is confirmed.
+  - Clicking the suggestion cancels a pending debounce and runs one semantic search in the detected language.
+  - Load more after accepting a suggestion preserves query language and rejects stale language signatures.
+  - Covers AE4. Semantic no-results show language recovery copy and a recovery action; semantic errors keep connection/retry copy.
+  - Message parity passes after adding new SearchOverlay strings.
+- **Verification:** Component tests prove the user-visible flows and prevent duplicate/wrong-language searches.
+
+### U5. Add Multilingual Search Eval Mismatch Cases
+
+- **Goal:** Make the offline search eval seed set represent query-language and website/watch-language mismatch cases.
+- **Requirements:** R11
+- **Dependencies:** U1
+- **Files:**
+  - `apps/mastra/src/services/offline-search-eval/types.ts`
+  - `apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts`
+  - `apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts`
+- **Approach:** Extend seed prompt metadata with an optional website/watch locale context while keeping `locale` as the confirmed search locale used by the runner. Add at least two sanitized seed cases where the website/watch locale differs from the confirmed search locale, such as English route with Spanish query and French route with English query. Keep the eval runner offline and Admin-backed; do not move UI behavior into Mastra.
+- **Patterns to follow:** `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md` and existing `SEARCH_EVAL_SEED_PROMPT_SET_VERSION` versioning.
+- **Test scenarios:**
+  - Seed prompt IDs remain unique after adding mismatch cases.
+  - Mismatch cases carry different website/watch and confirmed search locales.
+  - Locale filtering still filters by confirmed search locale.
+  - Prompt-set version changes when the committed seed semantics change.
+- **Verification:** Seed prompt tests prove eval coverage exists without changing live search.
+
+---
+
+## Scope Boundaries
+
+- Algolia search behavior and Algolia language facets are out of scope.
+- Persisting a saved search-language preference is deferred.
+- User audio-language setting is not an input to v1 defaults.
+- Search confirmation does not mutate website/watch language, URL language, selected Dub, or persisted watch-language settings.
+- Search-ranking optimization is deferred; this feature selects the right semantic search language and validates the mismatch case.
+- Native browser `LanguageDetector`, MediaPipe, and heavier detector/model-download paths are deferred unless `tinyld` proves insufficient.
+
+---
+
+## System-Wide Impact
+
+This change crosses the Watch web modal, the web server-action search boundary, localized message catalogs, and Mastra's offline search eval seed set. It should not require Admin schema changes, generated GraphQL type edits, or public route changes.
+
+---
+
+## Risks & Dependencies
+
+- **Short-query false positives:** Detector scores are heuristics. Conservative thresholds, margin checks, and no-suggestion fallbacks protect users from surprise language switches.
+- **Language identity collisions:** Multiple public language slugs can share a BCP-47 primary code. Detector mapping must be explicit or unambiguous, and tests should cover collisions.
+- **Algolia flag confusion:** The modal already branches by feature flag. Semantic language behavior must stay hidden or inert when Algolia owns the active search path.
+- **Metadata availability:** Semantic mode now depends on language metadata that was previously skipped when Algolia was off. Failure should degrade to English fallback and a usable search box.
+- **Catalog copy churn:** SearchOverlay messages exist in many locale JSON files. Add keys through the repo's locale generation/check flow so parity stays green.
+
+---
+
+## Acceptance Examples
+
+- AE1. Spanish query on English Watch page: the search bar shows "Search in Spanish"; Enter runs semantic search in Spanish.
+- AE2. Low-confidence query: no detected-language suggestion becomes active; Enter searches in the visible selected language.
+- AE3. Manual language override: choosing French makes semantic search use French unless a different visible suggestion is accepted.
+- AE4. No results in selected language: the empty state explains that results may exist in another language and offers language recovery.
+- AE5. Eval coverage: the search eval seed set includes mismatch cases where website/watch language differs from confirmed search language.
+
+---
+
+## Verification Strategy
+
+Automated coverage should include focused unit tests for resolver priority, detector behavior, language metadata loading, search action request shape, overlay interaction, message parity, and Mastra seed prompt semantics.
+
+Manual validation should start the local web app, open the embedded browser, and exercise the semantic modal with Algolia disabled or otherwise forced onto the semantic path. The browser pass should confirm the selector is visible, a Spanish query on an English route shows and accepts the detected-language suggestion, low-confidence text searches in the selected language, manual language selection works without persistence, and semantic no-results show language recovery copy.
+
+---
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-06-19-watch-multilingual-semantic-search-requirements.md`
+- Product context: `PRODUCT.md`
+- Repo constraints: `AGENTS.md`, `apps/web/AGENTS.md`, `apps/web/CLAUDE.md`
+- Existing search pattern: `docs/solutions/architecture-patterns/forge-algolia-search-modal-20260610.md`
+- Language identity learning: `docs/solutions/best-practices/language-identity-on-slug-not-bcp47-20260605.md`
+- Search overlay fragility learnings: `docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md`, `docs/solutions/best-practices/nextjs-search-overlay-ui-patterns-20260415.md`
+- Offline eval boundary: `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`
+- UX grounding: NN/g site search suggestions (`https://www.nngroup.com/articles/site-search-suggestions/`), NN/g usability heuristics (`https://www.nngroup.com/articles/ten-usability-heuristics/`), Baymard autocomplete UX (`https://baymard.com/blog/autocomplete-design`)
+- Detector research: TinyLD (`https://github.com/komodojp/tinyld`), franc (`https://github.com/wooorm/franc`), MDN LanguageDetector (`https://developer.mozilla.org/en-US/docs/Web/API/LanguageDetector/detect`)

--- a/docs/roadmap/content-discovery/feat-196-watch-multilingual-search-behavior.md
+++ b/docs/roadmap/content-discovery/feat-196-watch-multilingual-search-behavior.md
@@ -3,7 +3,7 @@ id: "feat-196"
 title: "Watch multilingual search behavior"
 owner: "nisal"
 priority: "P1"
-status: "not-started"
+status: "complete"
 start_date: "2026-06-22"
 duration: 5
 depends_on: []

--- a/docs/solutions/ui-bugs/watch-semantic-search-language-metadata-confirmation-race.md
+++ b/docs/solutions/ui-bugs/watch-semantic-search-language-metadata-confirmation-race.md
@@ -1,0 +1,181 @@
+---
+title: "Watch semantic search must wait for language metadata before query-language confirmation"
+date: "2026-06-19"
+last_updated: "2026-06-19"
+category: "ui-bugs"
+module: "apps/web watch semantic search"
+problem_type: "ui_bug"
+component: "frontend_stimulus"
+symptoms:
+  - "A long non-English semantic query can search before the detected-language confirmation appears."
+  - "The first search can use the route, browser, or English fallback even though the typed query is in another supported language."
+  - "Tests with already-resolved language metadata pass while the delayed-metadata path remains unprotected."
+  - "Load more can fetch the next page with a different semantic language after metadata refresh changes the selected/default option."
+  - "A hung language-metadata request can strand semantic search if readiness has no bounded fallback."
+root_cause: "async_timing"
+resolution_type: "code_fix"
+severity: "medium"
+related_components:
+  - "apps/web/src/components/SearchOverlay.tsx"
+  - "apps/web/src/components/FloatingSearchController.tsx"
+  - "apps/web/src/components/FloatingSearchContext.tsx"
+  - "apps/web/src/lib/search-query-language.ts"
+tags: [watch, semantic-search, language, debounce, metadata, i18n, race]
+---
+
+# Watch semantic search must wait for language metadata before query-language confirmation
+
+## Problem
+
+The semantic Watch search overlay detects the language of a typed query and asks the viewer to confirm before searching in that detected language. Detection depends on the Admin language metadata list, so a query typed before that list loads can otherwise debounce into a search using the current default language.
+
+That violates the multilingual search rule: the app should only switch to the typed query's language after confirmation.
+
+The same state boundary also affects pagination. Once a semantic result set is created, "load more" must keep using the exact language slug that produced the first page, even if language metadata finishes loading or the default language ref changes afterward.
+
+## Symptoms
+
+- Typing a long Spanish query while language metadata is still pending can skip the "Spanish detected" confirmation.
+- The debounced search can call `runSearch` with the selected/default language instead of `languageSlug: "spanish-castilian"`.
+- The issue is invisible in tests that mock `getSearchLanguageOptions` as already resolved.
+- The server action's own metadata refresh is not enough, because the active semantic language slug is selected before that await.
+- The next-page request can drift from the initial request when pagination reads the latest selected language instead of the active result-set signature.
+- If metadata never reaches a terminal state, the overlay can keep holding the pending query instead of falling back to a searchable default.
+
+## What Didn't Work
+
+- **Only testing the loaded-metadata path.** A test where language options are present at first input proves the detector branch, but it does not prove the race where the input event happens first.
+- **Relying on `search()` to refresh language options.** `FloatingSearchController.search()` computes the active language slug before it awaits `refreshLanguageOptions()`, so the later metadata cannot retroactively make the original search Spanish.
+- **Treating an empty language list as "not ready."** A production response may legitimately be loaded-but-empty or error into fallback behavior. The overlay needs an explicit loaded flag, not an inference from `options.length`.
+- **Letting pagination re-read current language state.** The language chip/default can change after the first page, so load-more requests must use the original result-set language slug.
+- **Waiting indefinitely for metadata.** Metadata improves suggestions and manual selection, but search should still work if that request hangs or fails.
+
+## Solution
+
+Expose language metadata readiness from the controller and let the overlay hold a pending semantic search until metadata has reached a terminal state or a short fallback timer fires. The important distinction is loaded vs not loaded, not whether the option array has items.
+
+```tsx
+const [languageOptionsLoaded, setLanguageOptionsLoaded] = useState(false)
+
+// In refreshLanguageOptions()
+finally {
+  if (languageOptionsRequestIdRef.current === thisRequest) {
+    setLanguageOptionsLoaded(true)
+    setLanguageOptionsLoading(false)
+  }
+}
+```
+
+Then gate the overlay debounce on that readiness plus a bounded fallback:
+
+```tsx
+const pendingSearchAfterLanguageLoadRef = useRef<string | null>(null)
+const semanticSearchEnabled = !algoliaSearchEnabled
+const languageOptionsReadyForSearch =
+  !semanticSearchEnabled ||
+  languageOptionsLoaded ||
+  languageMetadataFallbackReady
+
+useEffect(() => {
+  if (!open || !semanticSearchEnabled || languageOptionsLoaded) return
+  const fallbackTimer = setTimeout(() => {
+    setLanguageMetadataFallbackReady(true)
+  }, SEARCH_LANGUAGE_METADATA_FALLBACK_MS)
+  return () => {
+    clearTimeout(fallbackTimer)
+    setLanguageMetadataFallbackReady(false)
+  }
+}, [languageOptionsLoaded, open, semanticSearchEnabled])
+
+useEffect(() => {
+  if (!languageOptionsReadyForSearch) return
+  const pendingQuery = pendingSearchAfterLanguageLoadRef.current
+  if (pendingQuery == null || pendingQuery !== query) return
+
+  pendingSearchAfterLanguageLoadRef.current = null
+  if (pendingQuery.trim().length === 0) return
+  if (
+    semanticSearchEnabled &&
+    maybeDetectQueryLanguageSuggestion(pendingQuery)
+  ) {
+    return
+  }
+
+  debounceRef.current = setTimeout(() => {
+    void search(pendingQuery)
+  }, 300)
+}, [
+  languageOptionsReadyForSearch,
+  maybeDetectQueryLanguageSuggestion,
+  query,
+  search,
+  semanticSearchEnabled,
+])
+```
+
+On input, store the pending query instead of searching while metadata is not ready:
+
+```tsx
+if (!languageOptionsReadyForSearch) {
+  pendingSearchAfterLanguageLoadRef.current = newValue
+  return
+}
+```
+
+When metadata arrives, the effect re-runs detection with the real language options. If the query language is detected, the confirmation CTA appears and no search fires. If no suggestion is available, the debounced search resumes with normal fallback behavior.
+
+Lock the race with a test that leaves `getSearchLanguageOptions` unresolved, types a detectable query, advances the debounce, and asserts that no search happened until metadata resolves and the confirmation is clicked.
+
+The controller still protects direct search calls by doing a bounded metadata refresh before `runSearch`:
+
+```tsx
+const currentLanguageOptions = languageOptionsLoadedRef.current
+  ? languageOptionsRef.current
+  : await withSearchLanguageOptionsFallback(
+      refreshLanguageOptions(facets),
+      () => languageOptionsRef.current,
+    )
+```
+
+When the result set is created, record the resolved language identity in the active search signature:
+
+```tsx
+activeSearchSignatureRef.current = {
+  query: data.query,
+  resultSource: data.resultSource,
+  languageEnglishNames: activeLanguageEnglishNames,
+  languageSlug: signatureLanguageSlug,
+  routeLanguageSlug,
+  nextOffset,
+}
+```
+
+Then load more must reuse `expectedSignature.languageSlug` and `expectedSignature.languageEnglishNames`, not whatever the language chip or default ref says later. Tests should cover a metadata refresh between the first page and "load more" and assert the second request keeps the original semantic language slug.
+
+## Why This Works
+
+Query-language detection is a client-side affordance that needs the same metadata as the manual language switcher. Without an explicit readiness flag, the overlay cannot tell "metadata has not loaded yet" apart from "metadata loaded with no options," and it may schedule search before it has enough information to decide whether confirmation is required.
+
+The pending-search ref keeps the user's latest query across the metadata boundary without dispatching stale searches. Clearing the ref on explicit actions such as category selection, manual language selection, confirmation, and clear input prevents a delayed metadata response from replaying an outdated intent.
+
+The fallback timer prevents metadata from becoming a hard availability dependency. If Admin language metadata is slow, semantic search can still run with route, browser, or English fallback; if metadata later arrives and the user continues typing, detection and manual selection can use the richer option set.
+
+The active search signature makes pagination deterministic. "Load more" is part of the same search, so it should inherit the first page's language slug, route language, result source, and offset instead of recomputing language from mutable UI state.
+
+## Prevention
+
+- Add delayed-metadata tests for UI paths where metadata controls whether an action is allowed, not only what label is shown.
+- Prefer explicit `loaded` state over inferring readiness from `loading` plus `options.length`; empty successful responses and fallback errors need to remain searchable.
+- Bound metadata waits so optional autocomplete/suggestion metadata cannot block search availability forever.
+- Include semantic language slug and route language in the active search signature for pagination and stale-response guards.
+- Keep semantic language identity on public language slugs, not BCP-47 tags. BCP-47 is for locale fallback and Admin query locale, not for exact language identity.
+- Verify Watch search races through the page-level overlay, not only by calling server actions directly. The failure can live in the debounce and client state even when the server action itself works.
+- Shape local browser mocks to the actual Admin GraphQL operation so smoke tests prove the production contract, not just a convenient branch.
+
+## Related Issues
+
+- [Key language identity on the unique slug, not BCP-47](../best-practices/language-identity-on-slug-not-bcp47-20260605.md)
+- [Forge Algolia Search Modal Pattern](../architecture-patterns/forge-algolia-search-modal-20260610.md)
+- [Watch search URL sync can strand the overlay in loading](watch-search-url-hydration-perpetual-loading.md)
+- [Mocked-shape-vs-real-contract testing discipline](../best-practices/mocked-shape-vs-real-contract-discipline-20260506.md)
+- [Mastra offline search eval orchestration boundary pattern](../architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,6 +963,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      tinyld:
+        specifier: 1.3.4
+        version: 1.3.4
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -12378,6 +12381,11 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyld@1.3.4:
+    resolution: {integrity: sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==}
+    engines: {node: '>= 12.10.0', npm: '>= 6.12.0', yarn: '>= 1.20.0'}
+    hasBin: true
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -21498,7 +21506,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
@@ -21555,7 +21563,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -21575,6 +21583,35 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -21586,7 +21623,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -27989,6 +28026,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyld@1.3.4: {}
 
   tinypool@1.1.1: {}
 


### PR DESCRIPTION
## Summary

Watch semantic search can now recover when the viewer types in a different language than the current page language. The overlay defaults Search Language from the Watch route, then browser/device language, then English; it also offers a confirm-gated detected-language suggestion and a manual searchable language selector for semantic mode.

This keeps Search Language separate from website language, audio language, and Algolia filters. Semantic search carries the selected public language slug through the web action and eval paths, then Admin resolves that slug to the BCP-47 locale used for execution.

| Area | What changed |
|---|---|
| Watch search UI | Added semantic Search Language chip, autocomplete selector, default reset, and inline detected-language suggestion |
| Search behavior | Pauses debounce while confirmation is visible and keeps load-more requests on the original semantic language slug |
| Language detection | Uses local script/tinyld heuristics with generous one-character script hints for obvious non-Latin queries |
| Admin eval search | Accepts a validated `languageSlug` and resolves it before running hybrid search |
| Mastra eval | Adds multilingual seed cases and separate `websiteLocale` mismatch context |
| Docs | Adds brainstorm, implementation plan, solution learning, concept vocabulary, and marks feat-196 complete |

## Design Notes

- Semantic Search Language is session-only for v1: no saved preference and no audio-language default.
- Query-language suggestions are intentionally generous because the user must confirm before the language changes.
- Language metadata loading is bounded: suggestions wait for metadata when it is available, but search can still proceed with route/browser/English fallback if metadata hangs.
- Algolia behavior remains isolated behind the existing mode checks.

## Validation

- `pnpm --filter @forge/web exec vitest run src/components/__tests__/FloatingSearchProvider.test.tsx src/lib/search-query-language.test.ts src/lib/search-language-actions.test.ts src/lib/search-language.test.ts src/lib/search-actions.test.ts`
- `pnpm --filter @forge/admin exec vitest run src/app/api/internal/search-eval/search/route.test.ts`
- `pnpm --filter @forge/mastra exec vitest run src/services/offline-search-eval/native-evaluation.test.ts src/services/offline-search-eval/runner.test.ts src/services/offline-search-eval/seed-prompt-set.test.ts`
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/admin db:generate && pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/mastra typecheck`
- package-relative eslint on touched web, admin, and mastra files
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/ui-bugs/watch-semantic-search-language-metadata-confirmation-race.md`
- `git diff --check`

## CE Review

CE code review verdict: Ready to merge. Actionable findings: none.

Artifacts: `/tmp/compound-engineering/ce-code-review/20260619-053311-756d7a2e/`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
