### PR TITLE
fix(watch): prevent mobile language modal overflow

### DIFF
--- a/apps/web/src/components/watch/LanguagePickerModal.tsx
+++ b/apps/web/src/components/watch/LanguagePickerModal.tsx
@@ -676,7 +676,7 @@ export function LanguagePickerModal({
       />
       <DialogContent
         data-testid="watch-language-picker-modal"
-        className="w-full max-w-[min(90vw,608px)] border-0 bg-transparent p-0 text-stone-100 ring-0 sm:max-w-[608px]"
+        className="top-0 left-0 h-[100svh] w-screen max-w-none translate-x-0 translate-y-0 overflow-x-hidden overflow-y-auto border-0 bg-transparent px-3 py-24 text-stone-100 ring-0 sm:top-1/2 sm:left-1/2 sm:h-auto sm:max-h-[calc(100svh-6rem)] sm:w-full sm:max-w-[608px] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:p-0"
         overlayClassName="bg-black/85 supports-backdrop-filter:backdrop-blur-md"
         showCloseButton={false}
         portalContainer={portalContainer}
@@ -687,7 +687,7 @@ export function LanguagePickerModal({
             : t("dialogTitle")}
         </DialogTitle>
 
-        <div className="relative flex flex-col gap-10">
+        <div className="relative mx-auto flex min-h-full w-full max-w-[608px] flex-col justify-center gap-10 sm:min-h-0">
           <MultilingualTooltipPanel
             copy={activeTooltipCopy}
             excludedLanguage={excludedTooltipLanguage}
@@ -776,23 +776,23 @@ export function LanguagePickerModal({
           </div>
 
           <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between gap-3">
+            <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
               <MultilingualTooltip
                 copy={MULTILINGUAL_TOOLTIPS.subtitles}
                 testId="watch-language-picker-tooltip-subtitles"
-                className="min-w-0 flex-1"
+                className="w-full min-w-0 sm:flex-1"
                 onActivate={setActiveTooltipCopy}
                 onDeactivate={clearActiveTooltip}
               >
-                <div className="flex items-center gap-3">
-                  <div className="flex items-center gap-2.5">
+                <div className="flex min-w-0 flex-wrap items-center gap-3">
+                  <div className="flex min-w-0 items-center gap-2.5">
                     <span
                       data-testid="watch-language-picker-subtitles-icon"
                       className="flex size-8 shrink-0 items-center justify-center text-stone-200"
                     >
                       <Captions aria-hidden className="size-4" />
                     </span>
-                    <h2 className="text-xl font-semibold text-stone-100">
+                    <h2 className="min-w-0 text-xl font-semibold text-stone-100">
                       {t("subtitlesHeading")}
                     </h2>
                   </div>
@@ -806,7 +806,7 @@ export function LanguagePickerModal({
                   </span>
                 </div>
               </MultilingualTooltip>
-              <div className="flex items-center gap-4">
+              <div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-3 sm:w-auto sm:justify-end">
                 {sameLanguageSubtitleOptions.length === 0 ? (
                   <MultilingualTooltip
                     copy={MULTILINGUAL_TOOLTIPS.requestSubtitles}
@@ -820,7 +820,7 @@ export function LanguagePickerModal({
                       data-testid="watch-language-picker-request-ai-translation"
                       disabled={translationRequestSent}
                       onClick={() => setTranslationRequestSent(true)}
-                      className="gap-1.5 cursor-pointer rounded-full border border-stone-400/50 bg-transparent px-3 py-1.5 text-[11px] font-bold tracking-wider text-stone-300 uppercase transition-colors duration-200 hover:border-stone-200 hover:bg-transparent hover:text-white disabled:cursor-default disabled:border-stone-500/35 disabled:text-stone-500 disabled:opacity-100"
+                      className="min-w-0 max-w-full flex-1 shrink gap-1.5 cursor-pointer rounded-full border border-stone-400/50 bg-transparent px-3 py-1.5 text-center text-[11px] leading-4 font-bold tracking-wider whitespace-normal text-stone-300 uppercase transition-colors duration-200 hover:border-stone-200 hover:bg-transparent hover:text-white disabled:cursor-default disabled:border-stone-500/35 disabled:text-stone-500 disabled:opacity-100 sm:flex-none sm:whitespace-nowrap"
                     >
                       {translationRequestSent ? (
                         <Check
@@ -921,7 +921,7 @@ export function LanguagePickerModal({
             ) : null}
           </div>
 
-          <div className="flex items-center justify-end gap-6 pt-3">
+          <div className="flex flex-wrap items-center justify-end gap-x-6 gap-y-3 pt-3">
             <MultilingualTooltip
               copy={MULTILINGUAL_TOOLTIPS.close}
               testId="watch-language-picker-tooltip-close"

--- a/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
+++ b/apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx
@@ -561,6 +561,12 @@ describe("LanguagePickerModal — globe overlay", () => {
 
     const modal = $('[data-testid="watch-language-picker-modal"]')
     expect(modal?.className).toContain("bg-transparent")
+    expect(modal?.className).toContain("h-[100svh]")
+    expect(modal?.className).toContain("w-screen")
+    expect(modal?.className).toContain("max-w-none")
+    expect(modal?.className).toContain("overflow-x-hidden")
+    expect(modal?.className).toContain("overflow-y-auto")
+    expect(modal?.className).not.toContain("max-w-[min(90vw,608px)]")
     expect(modal?.className).toContain("sm:max-w-[608px]")
 
     expect(
@@ -618,6 +624,16 @@ describe("LanguagePickerModal — globe overlay", () => {
     expect(toggle.parentElement?.parentElement?.className).toContain(
       "items-center",
     )
+    expect(toggle.parentElement?.parentElement?.className).toContain(
+      "flex-wrap",
+    )
+    expect(toggle.parentElement?.parentElement?.className).toContain("min-w-0")
+    expect(
+      toggle.parentElement?.parentElement?.parentElement?.className,
+    ).toContain("flex-col")
+    expect(
+      toggle.parentElement?.parentElement?.parentElement?.className,
+    ).toContain("sm:flex-row")
     const thumb = toggle.querySelector('span[aria-hidden="true"]')
     expect(thumb?.className).toContain("size-7")
     expect(thumb?.className).toContain("translate-x-7")
@@ -824,6 +840,12 @@ describe("LanguagePickerModal — globe overlay", () => {
     expect(button.className).toContain("px-3")
     expect(button.className).toContain("py-1.5")
     expect(button.className).toContain("text-[11px]")
+    expect(button.className).toContain("min-w-0")
+    expect(button.className).toContain("max-w-full")
+    expect(button.className).toContain("flex-1")
+    expect(button.className).toContain("sm:flex-none")
+    expect(button.className).toContain("shrink")
+    expect(button.className).toContain("whitespace-normal")
     expect(
       $('[data-testid="watch-language-picker-request-icon"]'),
     ).not.toBeNull()
@@ -859,6 +881,10 @@ describe("LanguagePickerModal — globe overlay", () => {
       ["Subtitles unavailable"],
     )
     expect(button.parentElement?.parentElement?.contains(toggle)).toBe(true)
+    expect(button.parentElement?.parentElement?.className).toContain(
+      "flex-wrap",
+    )
+    expect(button.parentElement?.parentElement?.className).toContain("min-w-0")
     expect($$('[data-testid="language-combobox-trigger"]').length).toBe(1)
 
     act(() => {

--- a/docs/roadmap/platform/feat-196-watch-mobile-language-modal-layout.md
+++ b/docs/roadmap/platform/feat-196-watch-mobile-language-modal-layout.md
@@ -1,0 +1,64 @@
+---
+id: "feat-196"
+title: "Watch mobile language modal layout"
+owner: "vlad"
+priority: "P1"
+status: "complete"
+start_date: "2026-06-19"
+duration: 1
+depends_on: []
+blocks: []
+tags:
+  - "platform"
+  - "web"
+  - "watch-page"
+  - "mobile"
+  - "language-picker"
+---
+
+## Problem
+
+The Watch language picker modal is too narrow on mobile Safari and its
+localized subtitle controls can overflow the visible screen.
+
+## Entry Points - Read These First
+
+1. `apps/web/src/components/watch/LanguagePickerModal.tsx` - modal shell,
+   subtitle header, and action layout.
+2. `apps/web/src/components/watch/LanguageCombobox.tsx` - reusable language
+   selector used inside the modal.
+3. `apps/web/src/components/watch/__tests__/LanguagePickerModal.test.tsx` -
+   focused modal regression coverage.
+4. `docs/solutions/design-patterns/watch-language-player-chrome-layout-20260609.md`
+   - existing language picker layout and affordance decisions.
+
+## Grep These
+
+- `watch-language-picker-modal`
+- `watch-language-picker-request-ai-translation`
+- `watch-language-picker-subtitles-toggle`
+- `LanguagePickerModal`
+
+## What To Build
+
+1. Let the language picker use the full available mobile viewport width while
+   preserving the desktop max width.
+2. Prevent horizontal overflow from localized subtitle actions, counts, and
+   controls.
+3. Keep the language and subtitle combobox rows full width.
+4. Preserve the existing icon-first affordances and multilingual tooltips.
+
+## Constraints
+
+- Do not change language switching, subtitle state, public Watch URLs, or Admin
+  data fetching.
+- Do not change generated GraphQL or locale artifacts.
+- Keep the fix local to Watch modal layout unless tests expose a shared
+  combobox issue.
+
+## Verification
+
+- `pnpm --filter @forge/web test -- src/components/watch/__tests__/LanguagePickerModal.test.tsx`
+- Mobile browser smoke on `/watch/jesus.html/russian.html` with the language
+  modal open confirms the modal fills the available width and controls do not
+  overflow horizontally.

--- a/docs/solutions/ui-bugs/watch-mobile-language-modal-overflow-20260619.md
+++ b/docs/solutions/ui-bugs/watch-mobile-language-modal-overflow-20260619.md
@@ -1,0 +1,63 @@
+---
+title: Watch mobile language modal overflow
+date: 2026-06-19
+category: docs/solutions/ui-bugs
+module: apps/web
+problem_type: ui_bug
+component: watch-page
+severity: medium
+related_components:
+  - apps/web/src/components/watch/LanguagePickerModal.tsx
+  - apps/web/src/components/watch/LanguageCombobox.tsx
+  - apps/web/src/components/ui/button.tsx
+tags:
+  - watch-page
+  - language-picker
+  - mobile
+  - localization
+  - overflow
+applies_when:
+  - A Watch modal looks clipped or too narrow on a mobile viewport
+  - Localized pill buttons overlap adjacent controls
+  - A shared `Button` child is used in a constrained mobile flex row
+---
+
+# Watch mobile language modal overflow
+
+## Context
+
+The Watch language picker used a centered `max-w-[min(90vw,608px)]` dialog
+shell. On a phone viewport this left narrow gutters while localized controls
+inside the subtitles row still needed more horizontal space.
+
+The subtitle request action also used the shared `Button` base, which applies
+`whitespace-nowrap` and `shrink-0`. That is usually right for compact buttons,
+but it lets translated pill labels push or overlap nearby controls in a tight
+mobile row.
+
+## Pattern
+
+- Make mobile modal shells use the available viewport first, then restore the
+  desktop cap at `sm`.
+- Keep the modal content centered with an inner `max-w-*` container, not by
+  narrowing the fixed dialog surface on mobile.
+- Stack dense header/action rows on mobile and switch back to side-by-side from
+  `sm` up.
+- When a localized action pill sits in a mobile flex row, explicitly override
+  shared button defaults with `min-w-0`, `flex-1`, `shrink`, and
+  `whitespace-normal`; restore `sm:flex-none sm:whitespace-nowrap` if desktop
+  should stay compact.
+
+## Verification
+
+Use a mobile-width browser smoke with the language modal open and inspect both
+horizontal overflow and row overlap:
+
+```bash
+pnpm --filter @forge/web test -- src/components/watch/__tests__/LanguagePickerModal.test.tsx
+pnpm --filter @forge/web lint
+```
+
+For browser proof, open `/watch/jesus.html/russian.html` at 390px width, click
+the floating globe, and assert `document.documentElement.scrollWidth <=
+window.innerWidth` plus no modal descendants extend beyond the viewport.


### PR DESCRIPTION
## Summary

On mobile Safari, the Watch language picker now uses the available viewport instead of a narrow 90vw dialog, so localized subtitle controls stay inside the screen.

The subtitles header and actions stack on phones, then return to the existing side-by-side desktop layout at `sm`. The translated request button can now shrink and wrap instead of pushing the subtitle toggle offscreen, while the language and subtitle combobox rows keep their full-width treatment.

## Demo

Local iOS Simulator proof was captured at `output/playwright/watch-language-modal-ios-simulator.jpg` and is not embedded in the PR.

## Validation

- `pnpm --filter @forge/web test -- src/components/watch/__tests__/LanguagePickerModal.test.tsx`
- `pnpm --filter @forge/web lint`
- `pnpm --filter @forge/web typecheck`
- `git diff --check`
- Mobile Safari simulator check on iPhone 16 Pro / iOS 18.6 confirmed the modal fits the screen without horizontal overflow.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
