### PR TITLE
perf(tv,mobile): trim series-detail over-fetch + TV hero peek/fade

### DIFF
--- a/apps/mobile/src/lib/__tests__/normalizeVideo.test.ts
+++ b/apps/mobile/src/lib/__tests__/normalizeVideo.test.ts
@@ -693,6 +693,37 @@ describe("normalizeSeries", () => {
     expect(result.variants).toHaveLength(1)
   })
 
+  // Contract guard (mocked-shape vs real-contract): SeriesWatchVideo selects
+  // dubs WITHOUT the player-only duration/muxVideo, so the lean shape has those
+  // keys ABSENT (undefined), not null. The shared builder must still produce a
+  // playable trailer from hls alone; deleting the `?? null` coalescing in
+  // buildWatchVideoRecord should fail here.
+  it("tolerates the lean dub shape (duration/muxVideo absent): trailer from hls, duration & muxPlaybackId null", () => {
+    const result = normalizeSeries(
+      makeRawSeries({
+        variants: [
+          {
+            documentId: "dub-lean",
+            slug: "english",
+            published: true,
+            hls: "https://stream.mux.com/lean.m3u8",
+            language: {
+              coreId: "529",
+              bcp47: "en",
+              slug: "english",
+              name: { en: "English" },
+            },
+          },
+        ],
+      }),
+    )!
+    expect(result.streamingUrl).toBe("https://stream.mux.com/lean.m3u8")
+    expect(result.duration).toBeNull()
+    expect(result.muxPlaybackId).toBeNull()
+    expect(result.variants[0].duration).toBeNull()
+    expect(result.variants[0].muxPlaybackId).toBeNull()
+  })
+
   it("has no trailer streamingUrl when no dub is playable", () => {
     const result = normalizeSeries(
       makeRawSeries({

--- a/apps/mobile/src/lib/__tests__/queries.test.ts
+++ b/apps/mobile/src/lib/__tests__/queries.test.ts
@@ -1,0 +1,66 @@
+import { print } from "graphql"
+import type { DocumentNode } from "graphql"
+
+import { GET_SERIES_BY_SLUG, GET_VIDEO_BY_SLUG } from "../queries"
+
+// gql.tada documents are parsed DocumentNode ASTs (no raw source string is
+// retained), so we serialize them back with graphql's `print` to make
+// string/shape assertions on the selection set.
+function asSdl(doc: unknown): string {
+  return print(doc as DocumentNode)
+}
+
+const seriesSdl = asSdl(GET_SERIES_BY_SLUG)
+const bulkSdl = asSdl(GET_VIDEO_BY_SLUG)
+
+// The printed document is the operation followed by its fragment definitions.
+// Slicing off the fragments isolates an operation's OWN selections.
+function operationOnly(sdl: string): string {
+  const fragmentStart = sdl.indexOf("fragment ")
+  return fragmentStart === -1 ? sdl : sdl.slice(0, fragmentStart)
+}
+
+describe("GET_SERIES_BY_SLUG (lean series detail)", () => {
+  it("spreads the lean SeriesWatchVideo fragment, not the full WatchVideo", () => {
+    expect(operationOnly(seriesSdl)).toContain("...SeriesWatchVideo")
+    expect(operationOnly(seriesSdl)).not.toContain("...WatchVideo")
+  })
+
+  // Perf guard (series detail slow render): the screen renders its episode grid
+  // from its OWN children and never shows siblings, so the parents → parent →
+  // children chain (~208 nodes / ~190KB and ~1.6s of prod resolver time on a
+  // Jesus-sized series) must NOT be fetched here. It lives only on the watch
+  // screen's full WatchVideo fragment.
+  it("EXCLUDES the parents/siblings chain", () => {
+    expect(seriesSdl).not.toContain("parents")
+  })
+
+  // Perf guard: the series screen only needs a playable `hls` + `language` to
+  // pick/swap the trailer. Each dub's `duration` + `muxVideo.playbackId` are
+  // player-only — fetching them across ~2,270 dubs is dead weight (bytes + a
+  // per-dub muxVideo relation resolution server-side).
+  it("KEEPS variants: dubs with hls + language, but EXCLUDES per-dub duration + muxVideo", () => {
+    expect(seriesSdl).toContain("variants: dubs")
+    expect(seriesSdl).toContain("hls")
+    expect(seriesSdl).toMatch(/language\s*\{/)
+    expect(seriesSdl).not.toContain("duration")
+    expect(seriesSdl).not.toContain("muxVideo")
+    expect(seriesSdl).not.toContain("playbackId")
+  })
+
+  it("still selects the series-only children + childDubLanguages", () => {
+    expect(operationOnly(seriesSdl)).toMatch(/children\s*\{\s*order/)
+    expect(seriesSdl).toContain("childDubLanguages")
+    expect(seriesSdl).toContain("bcp47")
+  })
+})
+
+describe("GET_VIDEO_BY_SLUG (watch screen) keeps the full fragment", () => {
+  // The watch screen still needs siblings (Up Next) + player-only dub fields
+  // (duration, muxVideo.playbackId), so the trims above must NOT leak here.
+  it("KEEPS the parents/siblings chain and player-only dub fields", () => {
+    expect(bulkSdl).toContain("parents")
+    expect(bulkSdl).toContain("duration")
+    expect(bulkSdl).toContain("playbackId")
+  })
+})

--- a/apps/mobile/src/lib/__tests__/queries.test.ts
+++ b/apps/mobile/src/lib/__tests__/queries.test.ts
@@ -63,4 +63,13 @@ describe("GET_VIDEO_BY_SLUG (watch screen) keeps the full fragment", () => {
     expect(bulkSdl).toContain("duration")
     expect(bulkSdl).toContain("playbackId")
   })
+
+  // ...and does NOT carry the series-only selections (mirrors the TV
+  // "shared fragment stays lean" guard): the watch query must stay focused.
+  it("EXCLUDES series-only selections (childDubLanguages + top-level children)", () => {
+    expect(bulkSdl).not.toContain("childDubLanguages")
+    // `children` appears only inside the WatchVideo fragment's parents.parent
+    // sibling path — never as a top-level operation selection.
+    expect(operationOnly(bulkSdl)).not.toContain("children")
+  })
 })

--- a/apps/mobile/src/lib/normalizeVideo.ts
+++ b/apps/mobile/src/lib/normalizeVideo.ts
@@ -408,9 +408,11 @@ export function normalizeSeries(
   if (raw == null || !raw.documentId) return null
   const cached = normalizeSeriesCache.get(raw)
   if (cached !== undefined) return cached
-  // RawSeriesVideo is a structural superset of RawVideo (it spreads WatchVideo),
-  // so the shared builder maps the common fields; episodes + languages attach on
-  // top.
+  // RawSeriesVideo spreads the lean SeriesWatchVideo fragment — a SUBSET of
+  // WatchVideo (no parents chain; per-dub duration/muxVideo dropped). The shared
+  // builder accepts it via NormalizableVideo, mapping the common fields; the
+  // dropped fields resolve to siblings=[] / duration=null / muxPlaybackId=null
+  // on the series path (unused here). episodes + languages attach on top.
   const result: WatchVideoRecord = {
     ...buildWatchVideoRecord(raw),
     episodes: buildEpisodes(raw),

--- a/apps/mobile/src/lib/normalizeVideo.ts
+++ b/apps/mobile/src/lib/normalizeVideo.ts
@@ -154,9 +154,22 @@ function pickFirstLocale(
 
 type RawVariant = NonNullable<RawVideo["variants"]>[number]
 
+// The series query (GET_SERIES_BY_SLUG → SeriesWatchVideo) fetches a leaner
+// shape than the watch query: no `parents` chain, and each dub omits the
+// player-only `duration` + `muxVideo`. These permissive aliases let the shared
+// builder accept BOTH shapes — the full watch fragment and the lean series one
+// — without loosening either operation's own generated type.
+type NormalizableVariant = Omit<RawVariant, "duration" | "muxVideo"> &
+  Partial<Pick<RawVariant, "duration" | "muxVideo">>
+
+type NormalizableVideo = Omit<RawVideo, "parents" | "variants"> & {
+  parents?: RawVideo["parents"]
+  variants?: readonly NormalizableVariant[] | null
+}
+
 function pickFirstPlayableVariant(
-  variants: RawVideo["variants"] | undefined | null,
-): RawVariant | null {
+  variants: readonly NormalizableVariant[] | undefined | null,
+): NormalizableVariant | null {
   if (!variants) return null
   return (
     variants.find(
@@ -244,7 +257,7 @@ export function normalizeVideo(
   return result
 }
 
-function buildWatchVideoRecord(raw: RawVideo): WatchVideoRecord {
+function buildWatchVideoRecord(raw: NormalizableVideo): WatchVideoRecord {
   const locale = pickFirstLocale(raw.locales)
   const firstPlayable = pickFirstPlayableVariant(raw.variants)
 

--- a/apps/mobile/src/lib/queries.ts
+++ b/apps/mobile/src/lib/queries.ts
@@ -213,25 +213,99 @@ export const GET_VIDEO_BY_SLUG = adminGraphql(
 
 export type WatchVideoData = AdminResultOf<typeof GET_VIDEO_BY_SLUG>
 
+// ── Lean series-screen video fragment ──────────────────────────────
+//
+// SYNC: mirrors apps/tv/src/lib/videoQueries.ts `seriesWatchVideoFragment`.
+//
+// A leaner sibling of watchVideoFragment for the SERIES screen, which consumes
+// far less of the video than the watch screen. It DELIBERATELY OMITS two heavy
+// selections the watch screen needs but the series screen never reads:
+//   1. the `parents → parent → children` sibling chain — the series screen
+//      renders its episode grid from its OWN `children` (below) and never shows
+//      siblings (that's the watch screen's Up Next). On a Jesus-film-sized
+//      series the chain is ~208 nodes / ~190KB and ~1.6s of prod resolver time.
+//   2. each dub's `duration` + `muxVideo.playbackId` — player-only fields. The
+//      series screen needs only a playable `hls` + `language` to pick and swap
+//      the trailer; a series carries ~2,270 dubs, so every per-dub field
+//      multiplies (bytes + a per-dub muxVideo relation resolution server-side).
+// The bulk childDubLanguages aggregation (the largest remaining term) is a
+// known-slow admin resolver pending a composite index — see the hand-off note
+// in docs/.
+export const seriesWatchVideoFragment = adminGraphql(`
+  fragment SeriesWatchVideo on Video @_unmask {
+    documentId: id
+    slug
+    label
+    images {
+      documentId: id
+      url
+      thumbnail
+      mobileCinematicHigh
+      mobileCinematicLow
+    }
+    primaryLanguage {
+      coreId
+      bcp47
+    }
+    locales(locale: $locale) {
+      documentId: id
+      languageSlug
+      title
+      description
+      snippet
+      imageAlt
+    }
+    variants: dubs {
+      documentId: id
+      slug
+      published
+      hls
+      language {
+        coreId
+        bcp47
+        slug
+        name
+      }
+    }
+    studyQuestions {
+      documentId: id
+      languageSlug
+      value: text
+      order
+    }
+    bibleCitations {
+      documentId: id
+      chapterStart
+      chapterEnd
+      verseStart
+      verseEnd
+      order
+      osisId
+      bibleBook {
+        documentId: id
+        name
+      }
+    }
+  }
+`)
+
 // ── Series detail query ─────────────────────────────────────────────
 //
 // A series is a Video whose label is SERIES/COLLECTION (or which has children).
-// The series detail page needs three things the single-video query doesn't:
+// The series detail page needs two things the single-video query doesn't:
 //   1. the series' OWN `children` (the episode grid) — distinct from the
-//      `parents.parent.children` siblings the WatchVideo fragment carries;
+//      `parents.parent.children` siblings (which this query no longer fetches);
 //   2. `childDubLanguages` — the server-aggregated union of languages the
-//      episodes are available in, which drives the language sheet;
-//   3. (already in WatchVideo) the series' own `variants`/dubs — a playable one
-//      is the trailer.
-// These series-only selections live HERE, on a dedicated operation, NOT on the
-// shared `watchVideoFragment` — keeping the single-video query lean (see the
-// payload note above). gql.tada infers the types from admin's introspection;
-// no admin schema change is needed (the fields already exist).
+//      episodes are available in, which drives the language sheet.
+// The series' own `variants`/dubs (a playable one is the trailer) come from the
+// lean `seriesWatchVideoFragment` below — NOT the heavier `watchVideoFragment`.
+// These series-only selections live HERE, on the operation. gql.tada infers the
+// types from admin's introspection; no admin schema change is needed.
 export const GET_SERIES_BY_SLUG = adminGraphql(
   `
     query GetSeriesBySlug($locale: String!, $slug: String!) {
       videoBySlug(slug: $slug) {
-        ...WatchVideo
+        ...SeriesWatchVideo
         children {
           order
           child {
@@ -260,7 +334,7 @@ export const GET_SERIES_BY_SLUG = adminGraphql(
       }
     }
   `,
-  [watchVideoFragment],
+  [seriesWatchVideoFragment],
 )
 
 export type SeriesVideoData = AdminResultOf<typeof GET_SERIES_BY_SLUG>

--- a/apps/tv/app/series/[slug].tsx
+++ b/apps/tv/app/series/[slug].tsx
@@ -60,11 +60,20 @@ import { SeriesActionRow } from "../../src/components/series/SeriesActionRow"
 import { SeriesLanguagePanel } from "../../src/components/series/SeriesLanguagePanel"
 import { buildMetadataLine } from "../../src/components/watch/detailsHelpers"
 import { WATCH_THEME } from "../../src/components/watch/watchDetailTheme"
-import { COLORS } from "../../src/lib/colors"
+import { COLORS, hexToRgba } from "../../src/lib/colors"
 import { resolveImageUrl } from "../../src/lib/resolveImageUrl"
 import { scale } from "../../src/lib/scale"
 
 const { height: SCREEN_HEIGHT } = Dimensions.get("window")
+
+// The hero's LAYOUT slot stops short of full height so the top of the episode
+// rail peeks above the fold — the TV "next-row peek" affordance that tells the
+// viewer the screen scrolls (we deliberately don't ship a scroll-hint chevron).
+// Kept small/slight: just enough to reveal the rail heading + the card tops.
+// The backdrop image is NOT shortened by this — it renders at full SCREEN_HEIGHT
+// and the hero's overflow:hidden simply clips its bottom (where the rail sits),
+// so the thumbnail framing is identical to a full-height hero (top not trimmed).
+const HERO_PEEK = scale(170)
 
 // Stable fallback for the language panel while no record is resolved — a
 // fresh [] each render would re-run the panel's rows memo (the watch screen's
@@ -331,6 +340,25 @@ export default function SeriesScreen() {
             />
           </View>
 
+          {/* Soft fade at the hero's VISIBLE bottom edge → blends the artwork
+              into the episode rail's background (WATCH_THEME.below) instead of a
+              hard cut. Anchored to the hero (not the full-height backdrop) so it
+              sits exactly at the clipped bottom edge; rendered before heroContent
+              so the title/buttons stay crisp on top. */}
+          <LinearGradient
+            colors={[
+              hexToRgba(WATCH_THEME.below, 0),
+              hexToRgba(WATCH_THEME.below, 0.8),
+              WATCH_THEME.below,
+            ]}
+            locations={[0, 0.65, 1]}
+            start={{ x: 0.5, y: 0 }}
+            end={{ x: 0.5, y: 1 }}
+            style={styles.heroBottomFade}
+            pointerEvents="none"
+            collapsable={false}
+          />
+
           <View style={styles.heroContent}>
             <View style={styles.kicker}>
               <View style={styles.badge}>
@@ -423,22 +451,40 @@ const styles = StyleSheet.create({
 
   // ── Hero ──────────────────────────────────────────────────────────
   hero: {
-    height: SCREEN_HEIGHT,
+    height: SCREEN_HEIGHT - HERO_PEEK,
     justifyContent: "flex-end",
     backgroundColor: "#000000",
     overflow: "hidden",
   },
   backdrop: {
-    ...StyleSheet.absoluteFillObject,
+    // Full-screen height (NOT absoluteFill of the shortened hero) so the cover
+    // framing matches a full-height hero — the hero's overflow:hidden clips the
+    // bottom HERO_PEEK, which is where the episode rail peeks through.
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: SCREEN_HEIGHT,
     overflow: "hidden",
   },
   backdropFallback: {
     backgroundColor: COLORS.surfaceContainer,
   },
+  // Soft fade from the artwork into the rail's background at the hero's bottom
+  // edge (kills the hard line). Anchored to the hero bottom, behind heroContent.
+  heroBottomFade: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: scale(220),
+  },
   heroContent: {
     alignItems: "flex-start",
     paddingHorizontal: scale(80),
-    paddingBottom: scale(96),
+    // Tightened (was 96) to shrink the dead band between the action row and the
+    // episode rail below.
+    paddingBottom: scale(52),
   },
   kicker: {
     flexDirection: "row",
@@ -491,7 +537,8 @@ const styles = StyleSheet.create({
   // ── Below the fold (episode rail) ─────────────────────────────────
   below: {
     backgroundColor: WATCH_THEME.below,
-    paddingTop: scale(48),
+    // Tightened (was 48) so the rail sits closer under the hero action row.
+    paddingTop: scale(24),
   },
 
   // ── Error state ───────────────────────────────────────────────────

--- a/apps/tv/app/series/[slug].tsx
+++ b/apps/tv/app/series/[slug].tsx
@@ -59,21 +59,22 @@ import { RetryButton } from "../../src/components/RetryButton"
 import { SeriesActionRow } from "../../src/components/series/SeriesActionRow"
 import { SeriesLanguagePanel } from "../../src/components/series/SeriesLanguagePanel"
 import { buildMetadataLine } from "../../src/components/watch/detailsHelpers"
-import { WATCH_THEME } from "../../src/components/watch/watchDetailTheme"
+import {
+  WATCH_THEME,
+  HERO_PEEK,
+  HERO_BOTTOM_FADE_HEIGHT,
+} from "../../src/components/watch/watchDetailTheme"
 import { COLORS, hexToRgba } from "../../src/lib/colors"
 import { resolveImageUrl } from "../../src/lib/resolveImageUrl"
 import { scale } from "../../src/lib/scale"
 
 const { height: SCREEN_HEIGHT } = Dimensions.get("window")
 
-// The hero's LAYOUT slot stops short of full height so the top of the episode
-// rail peeks above the fold — the TV "next-row peek" affordance that tells the
-// viewer the screen scrolls (we deliberately don't ship a scroll-hint chevron).
-// Kept small/slight: just enough to reveal the rail heading + the card tops.
-// The backdrop image is NOT shortened by this — it renders at full SCREEN_HEIGHT
-// and the hero's overflow:hidden simply clips its bottom (where the rail sits),
-// so the thumbnail framing is identical to a full-height hero (top not trimmed).
-const HERO_PEEK = scale(170)
+// HERO_PEEK / HERO_BOTTOM_FADE_HEIGHT are shared with the watch screen (see
+// watchDetailTheme). The series backdrop is a static expo-image, so — unlike the
+// watch screen's VideoView — it renders at full SCREEN_HEIGHT and the hero's
+// overflow:hidden clips its bottom HERO_PEEK (thumbnail framing stays full, top
+// not trimmed); the rail peeks through there.
 
 // Stable fallback for the language panel while no record is resolved — a
 // fresh [] each render would re-run the panel's rows memo (the watch screen's
@@ -477,7 +478,7 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    height: scale(220),
+    height: HERO_BOTTOM_FADE_HEIGHT,
   },
   heroContent: {
     alignItems: "flex-start",

--- a/apps/tv/app/watch/[slug].tsx
+++ b/apps/tv/app/watch/[slug].tsx
@@ -41,7 +41,10 @@ import {
   buildRelatedQuestionsBlock,
 } from "../../src/components/watch/detailsAdapters"
 import { buildMetadataLine } from "../../src/components/watch/detailsHelpers"
-import { WATCH_THEME } from "../../src/components/watch/watchDetailTheme"
+import {
+  WATCH_THEME,
+  HERO_PEEK,
+} from "../../src/components/watch/watchDetailTheme"
 import { SECTION_HEADING } from "../../src/components/sections/sectionHeading"
 import { RelatedQuestionsRenderer } from "../../src/components/sections/RelatedQuestionsRenderer"
 import { BibleQuotesCarouselRenderer } from "../../src/components/sections/BibleQuotesCarouselRenderer"
@@ -220,12 +223,18 @@ export default function WatchVideoScreen() {
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
-        {/* Hero: full-screen cinematic backdrop with content anchored bottom-left. */}
+        {/* Hero: cinematic backdrop with content anchored bottom-left. The
+            backdrop fills the (HERO_PEEK-shortened) hero so the video clips by
+            construction on BOTH tvOS and Android — a full-height VideoView would
+            punch through the Up Next rail on Android (SurfaceView ignores
+            overflow:hidden). bottomFadeColor draws the hero→rail fade INSIDE the
+            backdrop so it composites over that SurfaceView. */}
         <View style={styles.hero}>
           <VideoBackdrop
             streamingUrl={backdropSource ?? null}
             posterUrl={displayPoster}
             overlayVisible={playerState.isVisible}
+            bottomFadeColor={WATCH_THEME.below}
           />
 
           <View style={styles.heroContent}>
@@ -327,7 +336,12 @@ const styles = StyleSheet.create({
 
   // ── Hero ──────────────────────────────────────────────────────────
   hero: {
-    height: SCREEN_HEIGHT,
+    // Shortened by HERO_PEEK so the Up Next rail peeks above the fold. The
+    // VideoBackdrop fills this (not full-screen) so its VideoView clips by
+    // construction on both tvOS and Android; the hero→rail fade is drawn inside
+    // the backdrop (bottomFadeColor) so it composites over the Android
+    // SurfaceView. overflow:hidden still guards the poster/scrim layers.
+    height: SCREEN_HEIGHT - HERO_PEEK,
     justifyContent: "flex-end",
     backgroundColor: "#000000",
     overflow: "hidden",
@@ -335,7 +349,9 @@ const styles = StyleSheet.create({
   heroContent: {
     alignItems: "flex-start",
     paddingHorizontal: scale(80),
-    paddingBottom: scale(96),
+    // Tightened (was 96) to shrink the dead band between the action row and the
+    // Up Next rail below.
+    paddingBottom: scale(52),
   },
   kicker: {
     flexDirection: "row",
@@ -388,7 +404,8 @@ const styles = StyleSheet.create({
   // ── Below the fold ────────────────────────────────────────────────
   below: {
     backgroundColor: WATCH_THEME.below,
-    paddingTop: scale(48),
+    // Tightened (was 48) so the rail sits closer under the hero action row.
+    paddingTop: scale(24),
   },
   aboutRow: {
     flexDirection: "row",

--- a/apps/tv/src/components/watch/VideoBackdrop.tsx
+++ b/apps/tv/src/components/watch/VideoBackdrop.tsx
@@ -18,9 +18,9 @@ import { Image } from "expo-image"
 import { LinearGradient } from "expo-linear-gradient"
 import { useVideoPlayer, VideoView } from "expo-video"
 
-import { COLORS } from "../../lib/colors"
+import { COLORS, hexToRgba } from "../../lib/colors"
 import { validateStreamingUrl } from "../../lib/validateUrl"
-import { WATCH_THEME } from "./watchDetailTheme"
+import { WATCH_THEME, HERO_BOTTOM_FADE_HEIGHT } from "./watchDetailTheme"
 
 // Hold the poster over the (invisible) video for this long after the stream is
 // ready, then crossfade the video in — gives the eye a stable still instead of
@@ -39,12 +39,22 @@ type VideoBackdropProps = {
    * be decoding at a time.
    */
   overlayVisible: boolean
+  /**
+   * When set, paints a bottom-edge fade to this color (e.g. WATCH_THEME.below)
+   * so the hero blends into the section below it. Rendered as the LAST layer
+   * with collapsable={false} so it composites OVER the Android VideoView
+   * SurfaceView (a regular sibling view in the parent would be punched through —
+   * see apps/tv/CLAUDE.md "Android TV VideoView z-order"). Anchored to the
+   * backdrop's own bottom, so the backdrop must be sized to the visible hero.
+   */
+  bottomFadeColor?: string | null
 }
 
 export function VideoBackdrop({
   streamingUrl,
   posterUrl,
   overlayVisible,
+  bottomFadeColor,
 }: VideoBackdropProps) {
   const [reduceMotion, setReduceMotion] = useState(false)
   useEffect(() => {
@@ -269,6 +279,28 @@ export function VideoBackdrop({
         pointerEvents="none"
         collapsable={false}
       />
+
+      {/* Bottom-edge fade into the section below the hero (opt-in via
+          bottomFadeColor). MUST live here, inside the backdrop, AFTER the
+          VideoView and with collapsable={false} — same reason the scrims above
+          do: on Android TV the VideoView is a SurfaceView that renders over
+          sibling RN views, so a fade placed in the parent hero would be punched
+          through. Anchored to this container's bottom = the visible hero edge. */}
+      {bottomFadeColor != null ? (
+        <LinearGradient
+          colors={[
+            hexToRgba(bottomFadeColor, 0),
+            hexToRgba(bottomFadeColor, 0.8),
+            bottomFadeColor,
+          ]}
+          locations={[0, 0.65, 1]}
+          start={{ x: 0.5, y: 0 }}
+          end={{ x: 0.5, y: 1 }}
+          style={styles.bottomFade}
+          pointerEvents="none"
+          collapsable={false}
+        />
+      ) : null}
     </View>
   )
 }
@@ -281,5 +313,12 @@ const styles = StyleSheet.create({
   },
   fallbackBg: {
     backgroundColor: COLORS.surfaceContainer,
+  },
+  bottomFade: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: HERO_BOTTOM_FADE_HEIGHT,
   },
 })

--- a/apps/tv/src/components/watch/watchDetailTheme.ts
+++ b/apps/tv/src/components/watch/watchDetailTheme.ts
@@ -10,6 +10,8 @@
 // No expo-blur dependency on TV, so the "frosted glass" pills are approximated
 // with a translucent white fill over the dark scrim — no actual backdrop blur.
 
+import { scale } from "../../lib/scale"
+
 /** Near-black surface/ink shared by WATCH_THEME (focusInk) and SEARCH_THEME. */
 export const NEAR_BLACK = "#0a0a0b"
 
@@ -41,6 +43,15 @@ export const WATCH_THEME = {
   /** Translucent chip behind the kicker badge ("SERIES"). */
   badgeBg: "rgba(255,255,255,0.16)",
 } as const
+
+// ── Hero layout (shared by the watch + series detail screens) ──────
+// The hero's LAYOUT slot stops short of full height by HERO_PEEK so the next
+// section (Up Next / Episodes rail) peeks above the fold — the TV next-row-peek
+// affordance (we deliberately don't ship a scroll-hint chevron).
+// HERO_BOTTOM_FADE_HEIGHT is the height of the gradient that fades the hero's
+// bottom edge into the rail background (WATCH_THEME.below), killing the hard seam.
+export const HERO_PEEK = scale(170)
+export const HERO_BOTTOM_FADE_HEIGHT = scale(220)
 
 // SECTION_HEADING moved to ../sections/sectionHeading (a generic SDUI section
 // renderer must not depend on this watch-only token file).

--- a/apps/tv/src/lib/normalizeVideo.test.ts
+++ b/apps/tv/src/lib/normalizeVideo.test.ts
@@ -477,6 +477,37 @@ describe("normalizeSeries — base record + trailer", () => {
     expect(result.streamingUrl).toBe("https://stream.mux.com/abc123.m3u8")
     expect(result.variants).toHaveLength(2)
   })
+
+  // Contract guard (mocked-shape vs real-contract): SeriesWatchVideo selects
+  // dubs WITHOUT the player-only duration/muxVideo, so the lean shape has those
+  // keys ABSENT (undefined), not null. The shared builder must still produce a
+  // playable trailer from hls alone; deleting the `?? null` coalescing in
+  // buildWatchVideoRecord should fail here.
+  it("tolerates the lean dub shape (duration/muxVideo absent): trailer from hls, duration & muxPlaybackId null", () => {
+    const result = normalizeSeries(
+      makeRawSeries({
+        variants: [
+          {
+            documentId: "dub-lean",
+            slug: "english",
+            published: true,
+            hls: "https://stream.mux.com/lean.m3u8",
+            language: {
+              coreId: "c-en",
+              bcp47: "en",
+              slug: "english",
+              name: { en: "English" },
+            },
+          },
+        ],
+      }),
+    )!
+    expect(result.streamingUrl).toBe("https://stream.mux.com/lean.m3u8")
+    expect(result.duration).toBeNull()
+    expect(result.muxPlaybackId).toBeNull()
+    expect(result.variants[0].duration).toBeNull()
+    expect(result.variants[0].muxPlaybackId).toBeNull()
+  })
 })
 
 describe("normalizeSeries — episodes (own children)", () => {

--- a/apps/tv/src/lib/normalizeVideo.ts
+++ b/apps/tv/src/lib/normalizeVideo.ts
@@ -186,9 +186,22 @@ function pickFirstLocale(
 
 type RawVariant = NonNullable<RawVideo["variants"]>[number]
 
+// The series query (GET_SERIES_BY_SLUG → SeriesWatchVideo) fetches a leaner
+// shape than the watch query: no `parents` chain, and each dub omits the
+// player-only `duration` + `muxVideo`. These permissive aliases let the shared
+// builder accept BOTH shapes — the full watch fragment and the lean series one
+// — without loosening either operation's own generated type.
+type NormalizableVariant = Omit<RawVariant, "duration" | "muxVideo"> &
+  Partial<Pick<RawVariant, "duration" | "muxVideo">>
+
+type NormalizableVideo = Omit<RawVideo, "parents" | "variants"> & {
+  parents?: RawVideo["parents"]
+  variants?: readonly NormalizableVariant[] | null
+}
+
 function pickFirstPlayableVariant(
-  variants: RawVideo["variants"] | undefined | null,
-): RawVariant | null {
+  variants: readonly NormalizableVariant[] | undefined | null,
+): NormalizableVariant | null {
   if (!variants) return null
   return (
     variants.find(
@@ -293,7 +306,7 @@ export function normalizeVideo(
   return result
 }
 
-function buildWatchVideoRecord(raw: RawVideo): WatchVideoRecord {
+function buildWatchVideoRecord(raw: NormalizableVideo): WatchVideoRecord {
   const locale = pickFirstLocale(raw.locales)
   const firstPlayable = pickFirstPlayableVariant(raw.variants)
 

--- a/apps/tv/src/lib/normalizeVideo.ts
+++ b/apps/tv/src/lib/normalizeVideo.ts
@@ -460,9 +460,11 @@ export function normalizeSeries(
   if (raw == null || !raw.documentId) return null
   const cached = normalizeSeriesCache.get(raw)
   if (cached !== undefined) return cached
-  // RawSeriesVideo is a structural superset of RawVideo (it spreads WatchVideo),
-  // so the shared builder maps the common fields; episodes + languages attach on
-  // top.
+  // RawSeriesVideo spreads the lean SeriesWatchVideo fragment — a SUBSET of
+  // WatchVideo (no parents chain; per-dub duration/muxVideo dropped). The shared
+  // builder accepts it via NormalizableVideo, mapping the common fields; the
+  // dropped fields resolve to siblings=[] / duration=null / muxPlaybackId=null
+  // on the series path (unused here). episodes + languages attach on top.
   const result: WatchSeriesRecord = {
     ...buildWatchVideoRecord(raw),
     episodes: buildEpisodes(raw),

--- a/apps/tv/src/lib/videoQueries.test.ts
+++ b/apps/tv/src/lib/videoQueries.test.ts
@@ -99,9 +99,34 @@ describe("GET_VIDEO_BY_SLUG (lean bulk video + dub list)", () => {
 })
 
 describe("GET_SERIES_BY_SLUG (series detail: own children + language union)", () => {
-  it("queries videoBySlug(slug:) and spreads the shared WatchVideo fragment", () => {
+  it("queries videoBySlug(slug:) and spreads the lean SeriesWatchVideo fragment", () => {
     expect(seriesOpSdl).toMatch(/videoBySlug\(slug:\s*\$slug\)/)
-    expect(seriesOpSdl).toContain("...WatchVideo")
+    expect(seriesOpSdl).toContain("...SeriesWatchVideo")
+    // The series screen does NOT use the full WatchVideo fragment — that one
+    // carries the watch screen's sibling chain + player-only per-dub fields.
+    expect(seriesOpSdl).not.toContain("...WatchVideo")
+  })
+
+  // Perf guard (TV series 10s render): the series screen renders the EpisodeRail
+  // from its OWN children and never renders siblings, so the parents → parent →
+  // children chain (~208 nodes / ~190KB on a Jesus-sized series, ~1.6s of prod
+  // resolver time) must NOT be fetched here. It lives only on the watch screen's
+  // full WatchVideo fragment.
+  it("EXCLUDES the parents/siblings chain", () => {
+    expect(seriesSdl).not.toContain("parents")
+  })
+
+  // Perf guard: the series screen only needs a playable `hls` + `language` to
+  // pick and swap the trailer. Each dub's `duration` + `muxVideo.playbackId`
+  // are player-only (watch screen) — fetching them across ~2,270 dubs is dead
+  // weight (bytes + a per-dub muxVideo relation resolution server-side).
+  it("KEEPS variants: dubs with hls + language, but EXCLUDES per-dub duration + muxVideo", () => {
+    expect(seriesSdl).toContain("variants: dubs")
+    expect(seriesSdl).toContain("hls")
+    expect(seriesSdl).toMatch(/language\s*\{/)
+    expect(seriesSdl).not.toContain("duration")
+    expect(seriesSdl).not.toContain("muxVideo")
+    expect(seriesSdl).not.toContain("playbackId")
   })
 
   it("selects the series' own children with the relation `order` field", () => {

--- a/apps/tv/src/lib/videoQueries.ts
+++ b/apps/tv/src/lib/videoQueries.ts
@@ -136,6 +136,83 @@ export const GET_VIDEO_BY_SLUG = graphql(
 
 export type WatchVideoData = ResultOf<typeof GET_VIDEO_BY_SLUG>
 
+// ── Lean series-screen video fragment ──────────────────────────────
+//
+// SYNC: mirrors apps/mobile/src/lib/queries.ts `seriesVideoFragment`.
+//
+// A leaner sibling of watchVideoFragment for the SERIES screen, which consumes
+// far less of the video than the watch screen. It DELIBERATELY OMITS two heavy
+// selections the watch screen needs but the series screen never reads:
+//   1. the `parents → parent → children` sibling chain — the series screen
+//      renders its EpisodeRail from its OWN `children` (below) and never shows
+//      siblings (that's the watch screen's Up Next rail). On a Jesus-film-sized
+//      series the chain is ~208 nodes / ~190KB and ~1.6s of prod resolver time.
+//   2. each dub's `duration` + `muxVideo.playbackId` — player-only fields. The
+//      series screen needs only a playable `hls` + `language` to pick and swap
+//      the trailer (pickDefaultTrailer / resolveTrailerSwap); a series carries
+//      ~2,270 dubs, so every per-dub field multiplies (bytes + a per-dub
+//      muxVideo relation resolution server-side).
+// The bulk childDubLanguages aggregation (the largest remaining term) is a
+// known-slow admin resolver pending a composite index — see the hand-off note
+// in docs/.
+export const seriesWatchVideoFragment = graphql(`
+  fragment SeriesWatchVideo on Video @_unmask {
+    documentId: id
+    slug
+    label
+    images {
+      documentId: id
+      url
+      thumbnail
+      mobileCinematicHigh
+      mobileCinematicLow
+    }
+    primaryLanguage {
+      coreId
+      bcp47
+    }
+    locales(locale: $locale) {
+      documentId: id
+      languageSlug
+      title
+      description
+      snippet
+      imageAlt
+    }
+    variants: dubs {
+      documentId: id
+      slug
+      published
+      hls
+      language {
+        coreId
+        bcp47
+        slug
+        name
+      }
+    }
+    studyQuestions {
+      documentId: id
+      languageSlug
+      value: text
+      order
+    }
+    bibleCitations {
+      documentId: id
+      chapterStart
+      chapterEnd
+      verseStart
+      verseEnd
+      order
+      osisId
+      bibleBook {
+        documentId: id
+        name
+      }
+    }
+  }
+`)
+
 // ── Series detail query ─────────────────────────────────────────────
 //
 // SYNC: mirrors apps/mobile/src/lib/queries.ts GET_SERIES_BY_SLUG.
@@ -143,19 +220,18 @@ export type WatchVideoData = ResultOf<typeof GET_VIDEO_BY_SLUG>
 // A series is a Video whose label is SERIES/COLLECTION (or which has children).
 // The series screen needs two things the single-video query doesn't:
 //   1. the series' OWN `children` (the episode rail) — distinct from the
-//      `parents.parent.children` siblings the WatchVideo fragment carries;
+//      `parents.parent.children` siblings (which this query no longer fetches);
 //   2. `childDubLanguages` — the server-aggregated union of languages the
 //      episodes are available in, which feeds the language panel.
-// These series-only selections live HERE, on a dedicated operation, NOT on the
-// shared `watchVideoFragment` — keeping the single-video query lean (see the
-// payload note above). Children select card fields only, never dubs/variants:
-// a Jesus-film-sized collection (61 chapters × ~2,200 dubs) is the 9.5MB
-// incident again.
+// These series-only selections live HERE, on the operation, atop the lean
+// `seriesWatchVideoFragment` (NOT the heavier `watchVideoFragment`). Children
+// select card fields only, never dubs/variants: a Jesus-film-sized collection
+// (61 chapters × ~2,200 dubs) is the 9.5MB incident again.
 export const GET_SERIES_BY_SLUG = graphql(
   `
     query GetSeriesBySlug($locale: String!, $slug: String!) {
       videoBySlug(slug: $slug) {
-        ...WatchVideo
+        ...SeriesWatchVideo
         children {
           order
           child {
@@ -186,7 +262,7 @@ export const GET_SERIES_BY_SLUG = graphql(
       }
     }
   `,
-  [watchVideoFragment],
+  [seriesWatchVideoFragment],
 )
 
 export type SeriesVideoData = ResultOf<typeof GET_SERIES_BY_SLUG>

--- a/apps/tv/src/lib/videoQueries.ts
+++ b/apps/tv/src/lib/videoQueries.ts
@@ -138,7 +138,7 @@ export type WatchVideoData = ResultOf<typeof GET_VIDEO_BY_SLUG>
 
 // ── Lean series-screen video fragment ──────────────────────────────
 //
-// SYNC: mirrors apps/mobile/src/lib/queries.ts `seriesVideoFragment`.
+// SYNC: mirrors apps/mobile/src/lib/queries.ts `seriesWatchVideoFragment`.
 //
 // A leaner sibling of watchVideoFragment for the SERIES screen, which consumes
 // far less of the video than the watch screen. It DELIBERATELY OMITS two heavy

--- a/docs/solutions/performance-issues/tv-mobile-series-detail-overfetch-and-childdublanguages-index-20260619.md
+++ b/docs/solutions/performance-issues/tv-mobile-series-detail-overfetch-and-childdublanguages-index-20260619.md
@@ -1,0 +1,126 @@
+---
+title: TV/mobile series-detail 10s render — shared-fragment over-fetch + an un-indexed childDubLanguages aggregation (local timing hides prod cost)
+date: 2026-06-19
+last_updated: 2026-06-19
+category: performance-issues
+module: apps/tv, apps/mobile, apps/admin
+problem_type: performance_issue
+component: graphql_query
+root_cause: over_fetch_plus_missing_db_index
+resolution_type: code_fix_plus_open_handoff
+severity: high
+symptoms:
+  - The series detail page (/series/[slug], e.g. the "jesus" film) takes up to ~10s to render on real TV / mobile devices.
+  - Local dev feels fine; the slowness only shows against the deployed admin.
+applies_when:
+  - A consumer screen reuses a shared GraphQL fragment that fetches more of an entity than the screen renders.
+  - A GraphQL field aggregates across a deep relation (children → dubs) without a supporting composite index.
+  - You benchmark a resolver against a small local DB and conclude it is fast.
+tags:
+  - graphql-overfetch
+  - shared-fragment
+  - postgres-index
+  - childDubLanguages
+  - admin-handoff
+  - local-vs-prod-latency
+---
+
+## Problem
+
+The TV (and mobile) **series detail** screen — `app/series/[slug].tsx`, e.g. the
+`jesus` film with 61 chapters — took **up to ~10s** to render its content on real
+devices. The question was: is the query fetching too much, or is the admin CMS
+slow to respond?
+
+**Answer: both, and they are the same cause.** The query asks the admin resolver
+to do far too much work at once. The dominant term is a server-side aggregation
+with no supporting index.
+
+## Diagnosis (measured)
+
+The TV/mobile clients get their endpoint from **EAS server-side env**
+(`EXPO_PUBLIC_GRAPHQL_URL=https://admin.jesusfilm.org/api/graphql`) — _not_ from
+`.env.local` (local `127.0.0.1:3003`) or `eas.json`. So any real-device build
+talks to **prod admin**. That is why local dev never reproduced it.
+
+`GET_SERIES_BY_SLUG` (slug `jesus`), same 1.25 MB payload both times:
+
+|                           | Local admin | Prod admin                 |
+| ------------------------- | ----------- | -------------------------- |
+| `{ __typename }` baseline | 0.047s      | 0.26–0.45s                 |
+| Full `GET_SERIES_BY_SLUG` | **0.45s**   | **7.5s warm / 11.4s cold** |
+
+Per-field prod attribution (≈, warm):
+
+| Field group           | Prod time    | Count | Notes                                                                                         |
+| --------------------- | ------------ | ----- | --------------------------------------------------------------------------------------------- |
+| `childDubLanguages`   | **2.5–4.9s** | 2,251 | DISTINCT-ON-language over ~137k dub rows (61 children × ~2,250 dubs). **No composite index.** |
+| `variants: dubs`      | ~2.4s        | 2,270 | Fetched only to pick **one** trailer dub; `muxVideo` relation resolved per dub.               |
+| `parents → siblings`  | ~1.6s        | 208   | **Never rendered on the series screen** — dead weight from the shared watch fragment.         |
+| `children` (episodes) | ~1.1s        | 61    | Legitimately needed (episode rail).                                                           |
+
+Only ~90 KB of the 1.25 MB is needed for first paint. The local 0.45s is
+unrepresentative: a tiny DB + OS page cache + loopback hid the real cost.
+
+## What was fixed (apps/tv + apps/mobile)
+
+A series-specific lean fragment `SeriesWatchVideo` (parallel to the watch
+screen's `WatchVideo`, which is unchanged), applied to both apps:
+
+- **Drops the `parents → parent → children` sibling chain** — the series screen
+  renders its `EpisodeRail`/grid from its OWN `children` and never shows siblings
+  (that's the watch screen's Up Next).
+- **Drops each dub's `duration` + `muxVideo.playbackId`** — player-only fields;
+  the series screen needs only a playable `hls` + `language` for the trailer.
+- Keeps `variants: dubs` (lean), `children`, and `childDubLanguages`.
+
+The normalizer's `buildWatchVideoRecord` input type was widened
+(`NormalizableVideo` / `NormalizableVariant`: `parents` + per-variant player
+fields optional) so the one shared builder accepts both the full watch shape and
+the lean series shape, with no loss of type safety. Over-fetch guard tests added:
+`apps/tv/src/lib/videoQueries.test.ts`, `apps/mobile/src/lib/__tests__/queries.test.ts`.
+
+**Measured impact (prod, slug `jesus`):**
+
+|                | Before    | After trim        |
+| -------------- | --------- | ----------------- |
+| Payload        | 1.25 MB   | **854 KB** (−32%) |
+| Latency (warm) | 7.5–11.4s | **5.3–5.7s**      |
+
+## Remaining root cause — HAND-OFF to admin owner (do NOT fix in the consumer apps)
+
+The residual ~5.3s is dominated by **`childDubLanguages`** (2.5–4.9s). The
+consumer apps cannot fix this; it is an admin DB/resolver issue.
+
+- Resolver: `apps/admin/src/services/video.service.ts` (`getChildDubLanguages`,
+  ~L1575–1618) exposed at `apps/admin/src/graphql/types/video.ts` (~L476–486).
+- It runs a `VideoDub` `findMany` filtered by `video.parents { some { parentId } }`
+  with `DISTINCT ON (languageId)` — scanning ~137k candidate rows then sorting.
+- Existing indexes (`VideoDub(videoId)`, `VideoDub(languageId)`,
+  `VideoRelation(childId)`, `VideoRelation(parentId, childId)`) do **not** support
+  this access path; on a large prod table the planner does a big scan + sort.
+
+**Recommended fix (admin migration):** add a composite index, e.g.
+
+```sql
+CREATE INDEX CONCURRENTLY video_dub_video_lang_idx
+  ON video_dub (video_id, deleted_at, published, language_id);
+```
+
+to enable an index-only path and drop the sort. This benefits **both** mobile and
+TV (first paint and the language panel). Optional follow-ups: a server-side
+`published` filter / pagination on `dubs`, and a cheap `childDubLanguagesCount`
+field so the hero "N languages" count doesn't require the full list.
+
+## The META lesson
+
+1. **A shared GraphQL fragment is over-fetch the moment a second screen reuses it
+   for less.** The series screen inherited the watch screen's sibling chain +
+   player-only dub fields. Split a lean fragment per consumer; guard it with a
+   `print()`-based jest test so it can't silently re-fatten.
+2. **Local resolver timing proves nothing about prod.** A small DB + page cache +
+   loopback hid a 12× aggregation cost. Benchmark suspect resolvers against a
+   prod-sized dataset, or read the query plan — don't trust the local stopwatch.
+3. **Know where the deployed app's endpoint actually comes from.** Here it's EAS
+   server-side env, not any file in the repo — so the only locally-configured
+   endpoint (`127.0.0.1:3003`) was never the one users hit.

--- a/docs/solutions/ui-bugs/android-tv-density-scaling-and-native-view-clipping-20260416.md
+++ b/docs/solutions/ui-bugs/android-tv-density-scaling-and-native-view-clipping-20260416.md
@@ -1,6 +1,7 @@
 ---
 title: "Android TV layout scaling and native view clipping fixes"
 date: "2026-04-16"
+last_updated: "2026-06-20"
 category: ui-bugs
 module: tv-app
 problem_type: ui_bug
@@ -10,6 +11,7 @@ symptoms:
   - "expo-image and LinearGradient native views completely invisible inside FocusableCard on Android TV"
   - "Touch targets and auto-scroll worked on invisible cards, confirming views existed but visual content was not painted"
   - "FocusableCard default backgroundColor rendered on top of native child views on Android"
+  - "A full-height expo-video VideoView inside an overflow:hidden hero punched through and rendered over the rail below it on Android TV (the inverse of the expo-image clip-to-invisible failure); correct on tvOS"
 root_cause: config_error
 resolution_type: code_fix
 severity: high
@@ -23,6 +25,8 @@ tags:
   - focusable-card
   - react-native-tvos
   - 10-foot-ui
+  - surfaceview
+  - video-backdrop
 ---
 
 # Android TV layout scaling and native view clipping fixes
@@ -135,6 +139,61 @@ Key changes:
 
 **Native view visibility:** On Android, `overflow: "hidden"` on a plain React Native `View` clips the _visual paint_ of native-backed children (expo-image, LinearGradient) without clipping their layout or touch areas. The views are "there" (interactive) but invisible. The `backgroundColor` on the container is composited on top of native children in Android's render order. Removing it and using `collapsable={false}` together allow native views to paint correctly. Hardware compositing props ensure the Animated overlay doesn't tear native child layers during focus transitions.
 
+## Update (2026-06-20): VideoView (SurfaceView) punch-through — the inverse failure mode (PR #1325)
+
+Prevention rule #2 below ("never `overflow:"hidden"` over native-backed views on Android") has a **second, opposite-looking failure mode** worth its own example, hit while adding a "next-row peek" to the TV watch-detail hero.
+
+`expo-image` and `LinearGradient` inside `overflow:"hidden"` get their paint **clipped → invisible** (the FocusableCard case above). But an **expo-video `VideoView` is backed by an Android `SurfaceView`**, which the OS composites at a separate hardware layer _after_ the RN layout pass. It is not clipped at all — it **punches through and renders OVER the content below the clip** (and over sibling RN views in the same ancestor), ignoring both `overflow:"hidden"` and JSX/`zIndex` draw order. Same root constraint, mirror-image symptom: expo-image disappears; `VideoView` over-paints.
+
+### Symptom
+
+The watch hero was shortened to `SCREEN_HEIGHT - HERO_PEEK` with `overflow:"hidden"` so the "Up Next" rail peeks above the fold, and `VideoBackdrop` rendered a full-`SCREEN_HEIGHT` `VideoView` inside it — the same full-height-clip trick the series screen uses for its static `expo-image` backdrop. On **tvOS** (`AVPlayerLayer` composites through UIKit and clips) it looked correct. On **Android TV** the bottom ~`HERO_PEEK` (170px) of the live trailer rendered on top of the Up Next rail, and a bottom-fade `LinearGradient` placed as a sibling of the backdrop _in the hero_ was drawn under the SurfaceView, so it masked nothing. The Apple-TV-simulator screenshot looked perfect — the bug is Android-TV-only.
+
+### Fix — two parts, both required
+
+**1. Size the surface to the visible region by construction.** You cannot clip a SurfaceView with an ancestor's `overflow:"hidden"`, so make the `VideoView` only as tall as the visible hero. `VideoBackdrop`'s container is `absoluteFillObject`, so rendering it inside the `SCREEN_HEIGHT - HERO_PEEK` hero (instead of a full-height layer) sizes the `VideoView` to the clipped height on both platforms — there is no overflow region to punch through.
+
+**2. Draw any overlay over the SurfaceView as a sibling AFTER the `VideoView`, inside the SAME parent, with `collapsable={false}`.** This is the exact mechanism `VideoBackdrop`'s ambient scrims already use. A fade placed in the parent hero (a sibling of the backdrop _component_) is punched through; the same fade moved _inside_ `VideoBackdrop`, after the `VideoView`, composites correctly. Exposed via an opt-in `bottomFadeColor` prop:
+
+```tsx
+// VideoBackdrop.tsx — inner bottom fade, LAST child, after <VideoView>, collapsable={false}
+{
+  bottomFadeColor != null ? (
+    <LinearGradient
+      colors={[
+        hexToRgba(bottomFadeColor, 0),
+        hexToRgba(bottomFadeColor, 0.8),
+        bottomFadeColor,
+      ]}
+      locations={[0, 0.65, 1]}
+      start={{ x: 0.5, y: 0 }}
+      end={{ x: 0.5, y: 1 }}
+      style={styles.bottomFade} // position:absolute, left/right:0, bottom:0, height: HERO_BOTTOM_FADE_HEIGHT
+      pointerEvents="none"
+      collapsable={false}
+    />
+  ) : null
+}
+
+// watch/[slug].tsx — VideoBackdrop fills the SHORTENED hero (no full-height wrapper) + passes the fade color
+;<VideoBackdrop
+  streamingUrl={backdropSource ?? null}
+  posterUrl={displayPoster}
+  overlayVisible={playerState.isVisible}
+  bottomFadeColor={WATCH_THEME.below}
+/>
+```
+
+### Why expo-image is safe but VideoView is not
+
+`expo-image`'s `Image` is a plain RN texture view the layout system clips normally, so the series screen's static backdrop CAN render at full `SCREEN_HEIGHT` inside the shortened hero and rely on `overflow:"hidden"` to clip it (full framing preserved, top not trimmed). A `VideoView` cannot — it must be sized to the visible region by construction.
+
+### Verification
+
+The tvOS simulator cannot reproduce this — `AVPlayerLayer` clips correctly, so a sim screenshot is a false "pass." Verify any change to z-ordering/clipping around a `VideoView` on a real **Android TV** emulator with the backdrop video **playing** — the poster `Image` clips fine, so the bug only appears once the SurfaceView's video fades in. Confirmed fixed on `Television_1080p_API_36` with a live-playing backdrop.
+
+(session history) `VideoBackdrop` already gives the `VideoView` Surface-specific handling elsewhere — its mount is gated on `!overlayVisible` to free the single tvOS decode slot for the fullscreen player, and the series hero is deliberately image-only for that same decoder reason. This punch-through fix extends the "the `VideoView` needs special treatment" posture from decoding to compositing/clipping.
+
 ## Prevention
 
 - **Always use `scale()` for TV dp values.** Never hardcode raw dp values for dimensions, fonts, padding, or border radii in TV UI code. All sizing flows through the scale utility so both platforms share a single reference canvas.
@@ -149,6 +208,12 @@ Key changes:
 
 - **Guard against `Dimensions.get("window")` returning 0 on Android cold start.** Use `(screenWidth || referenceWidth)` as a fallback to prevent division yielding 0.
 
+- **You cannot clip an Android `SurfaceView` (`expo-video VideoView`, `react-native-video`, Camera, Maps, GL) with an ancestor's `overflow:"hidden"` — size the surface itself to the visible region.** Unlike expo-image/LinearGradient (which get clipped to invisible), a SurfaceView ignores the clip and renders OVER the content below it. The full-height-inside-a-clipped-parent trick is safe for `Image` but not for `VideoView`.
+
+- **An overlay that must layer over an Android `SurfaceView` must be a sibling placed AFTER it, inside the SAME parent component, with `collapsable={false}`.** A scrim/fade/gradient in an ancestor or outer sibling — even a direct parent of the backdrop — is punched through on Android regardless of JSX order or `zIndex`.
+
+- **A change to z-ordering or clipping around a `VideoView` is not "done" until verified on a real Android TV emulator with the video playing.** tvOS (`AVPlayerLayer`) clips correctly, so the simulator hides SurfaceView bugs; and the poster `Image` clips fine, so the punch-through only appears once the video fades in.
+
 ## Related Issues
 
 - `docs/solutions/ui-bugs/tv-carousel-card-focus-animation-overflow-20260416.md` — The FocusableCard outer/inner layer split for focus glow clipping (predecessor to this fix)
@@ -156,3 +221,5 @@ Key changes:
 - `docs/solutions/best-practices/expo-tv-platform-setup-sdui-monorepo-20260410.md` — Section 6 documents the FocusableCard focus management pattern
 - `docs/solutions/mobile/responsive-typography-hook.md` — Documents `Math.round()` for scaled font sizes on Android (same principle applied here via `scale()`)
 - `docs/solutions/mobile/full-bleed-video-hero-with-scroll-over-content.md` — Android VideoView SurfaceView z-order issues (same native compositing constraint family)
+- `docs/solutions/ui-bugs/tv-backdrop-videoview-decoder-starvation-overlay-20260611.md` — the OTHER `VideoBackdrop` SurfaceView special-case (decode-slot starvation; `!overlayVisible` mount gate). Same component/file, different facet (decoding vs the 2026-06-20 clipping update above)
+- `docs/solutions/performance-issues/tv-mobile-series-detail-overfetch-and-childdublanguages-index-20260619.md` — shipped in the same PR (#1325); the series/watch detail-screen query trim that motivated the hero "next-row peek" layout


### PR DESCRIPTION
## What

Two related improvements to the TV/mobile **series & watch detail** screens.

### 1. Trim series-detail query over-fetch (perf)
`GET_SERIES_BY_SLUG` reused the watch screen's full `WatchVideo` fragment, fetching ~1.25 MB / ~4,800 entities for a Jesus-film-sized series — most never rendered there. Split a lean `SeriesWatchVideo` fragment (both apps) that drops:
- the `parents → parent → children` sibling chain (the series screen renders its own `children`, never siblings), and
- each dub's player-only `duration` + `muxVideo` (the trailer needs only `hls` + `language`).

The shared normalizer's `buildWatchVideoRecord` input is widened (`NormalizableVideo` / `NormalizableVariant`) to accept both the full watch shape and the lean series shape without loosening either operation's generated type. Over-fetch guard tests added.

**Measured (prod admin, slug `jesus`):** 1.25 MB → **854 KB** (−32%), ~7.5–11.4 s → **~5.3–5.7 s** warm.

> The residual ~5.3 s is an un-indexed `childDubLanguages` aggregation in admin — handed off (composite index) in `docs/solutions/performance-issues/tv-mobile-series-detail-overfetch-and-childdublanguages-index-20260619.md`. Not in this PR (no `apps/admin` changes).

### 2. TV detail-screen hero polish (series + watch)
- **Next-row peek** — the hero stops short of full height (`HERO_PEEK`) so the rail heading + card tops peek above the fold (no scroll-hint chevron).
- **Bottom-edge fade** into the rail background (kills the hard seam).
- **Tighter** hero → rail gap.
- **Android-safe backdrop:** the watch hero is a `VideoView` (a SurfaceView that ignores `overflow:hidden` on Android TV). It now fills the shortened hero so it clips by construction, and the fade lives **inside** `VideoBackdrop` (`collapsable={false}`) so it composites over the SurfaceView. Shared `HERO_PEEK` / `HERO_BOTTOM_FADE_HEIGHT` tokens in `watchDetailTheme`.

## Verification
- `tsc` clean; **462 TV + 283 mobile** unit tests pass.
- e2e on **Apple TV sim** (tvOS 26) and **Android TV emulator** (API 36) — Home/Series/Watch render correctly; the SurfaceView punch-through fix confirmed on Android TV with a **live-playing** backdrop video.
- Multi-agent `ce-code-review` + targeted adversarial verification on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)